### PR TITLE
fix(release): open a real PR in local (no-executor) mode via a host-mode backend

### DIFF
--- a/components/release-executor/src/ai/miniforge/release_executor/core.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/core.clj
@@ -109,13 +109,16 @@
     ;; Host-mode path: local-dogfood context supplies a worktree but no
     ;; sandbox executor.  Accepting this as valid (with :host-mode? true) is
     ;; the root fix for the dogfood PR failure described in the ns docstring.
-    (and (:worktree-path state)
+    ;; A blank :worktree-path is NOT present — babashka.process treats
+    ;; :dir "" as the current working directory, which would run host git/gh
+    ;; against whatever repo the process happens to sit in.
+    (and (not (str/blank? (:worktree-path state)))
          (nil? (:executor state))
          (nil? (:environment-id state)))
     (assoc state :host-mode? true)
 
     ;; Sandbox-mode guards — same order/messages as before
-    (not (:worktree-path state))
+    (str/blank? (:worktree-path state))
     (fail state :missing-worktree-path (msg/t :exec/missing-worktree-path))
 
     (not (:executor state))

--- a/components/release-executor/src/ai/miniforge/release_executor/core.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/core.clj
@@ -135,7 +135,7 @@
     (not (:create-pr? state)) state
     :else
     (let [gh-auth (if (:host-mode? state)
-                    (git/check-gh-auth!)
+                    (git/check-gh-auth! (:github-token state))
                     (sandbox/check-gh-auth! (:executor state) (:environment-id state)
                                             (gh-exec-opts state)))]
       (if (:authenticated? gh-auth)
@@ -324,7 +324,7 @@
     :else
     (let [{:keys [branch host-mode? worktree-path executor environment-id]} state
           result (if host-mode?
-                   (git/push-branch! worktree-path branch)
+                   (git/push-branch! worktree-path branch (:github-token state))
                    (sandbox/push-branch! executor environment-id branch
                                          (gh-exec-opts state)))]
       (if (result/succeeded? result)
@@ -372,7 +372,7 @@
                    :body        (with-provenance (:release/pr-body release-meta) state)
                    :base-branch base-branch}
           result (if host-mode?
-                   (git/create-pr! worktree-path pr-opts)
+                   (git/create-pr! worktree-path pr-opts (:github-token state))
                    (sandbox/create-pr! executor environment-id pr-opts
                                        (gh-exec-opts state)))]
       (if (result/succeeded? result)
@@ -587,7 +587,7 @@
                 state)]
       (try
         (if host-mode?
-          (git/edit-pr-body! worktree-path pr-number body)
+          (git/edit-pr-body! worktree-path pr-number body (:github-token state))
           (sandbox/edit-pr-body! executor environment-id pr-number body
                                  (gh-exec-opts state)))
         (when logger

--- a/components/release-executor/src/ai/miniforge/release_executor/core.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/core.clj
@@ -1,16 +1,42 @@
 (ns ai.miniforge.release-executor.core
-  "Release phase executor - orchestrates the release pipeline.
+  "Release phase executor — orchestrates the release pipeline.
 
    In the environment model, code changes live in the executor's git worktree.
    The release phase stages dirty files, commits, pushes, and creates a PR.
    No file writes from code artifacts — the implement agent already wrote files
    to the worktree during the implement phase.
 
-   All git/gh operations route through the DAG executor (sandbox module) so
-   that governed-mode capsules never shell out to the host."
+   ## Backends
+
+   Two git backends are supported in a single pipeline:
+
+   - **Sandbox mode** (`:host-mode?` absent / false): all git/gh operations route
+     through the DAG executor (`sandbox` module) so that governed-mode capsules
+     never shell out to the host.  Requires `:executor` + `:environment-id`.
+
+   - **Host mode** (`:host-mode?` true): git/gh operations run directly on the
+     host working tree via `git.clj` (babashka.process).  Active when
+     `:worktree-path` is present but `:executor` and `:environment-id` are both
+     nil — i.e. the local-dogfood path.
+
+   ### Diagnosis — why local-dogfood PR creation failed
+
+   `step-validate-inputs` checked `:worktree-path` (present), then immediately
+   failed on `(not (:executor state))` with `:missing-executor`.  Every
+   downstream step calls `sandbox/*` functions that require a live DAG executor.
+   The dogfood/host path (local worktree, no Docker capsule) supplied neither
+   `:executor` nor `:environment-id`, so the pipeline was dead on entry — no
+   branch was created, no commit staged, no PR opened.
+
+   Fix: when `:worktree-path` IS present and `:executor` / `:environment-id`
+   are BOTH nil, `step-validate-inputs` now sets `:host-mode? true` and accepts
+   the state. Every step that previously called `sandbox/*` unconditionally now
+   dispatches: host-mode → `git/*` using `:worktree-path`; sandbox-mode → same
+   `sandbox/*` path as before."
   (:require
    [ai.miniforge.artifact.interface :as artifact]
    [ai.miniforge.logging.interface :as log]
+   [ai.miniforge.release-executor.git :as git]
    [ai.miniforge.release-executor.messages :as msg]
    [ai.miniforge.release-executor.metadata :as metadata]
    [ai.miniforge.release-executor.result :as result]
@@ -65,21 +91,53 @@
 ;------------------------------------------------------------------------------ Layer 1
 ;; Pipeline steps
 
-(defn step-validate-inputs [state]
-  (cond
-    (failed? state)              state
-    (not (:worktree-path state)) (fail state :missing-worktree-path (msg/t :exec/missing-worktree-path))
-    (not (:executor state))      (fail state :missing-executor (msg/t :exec/missing-executor))
-    (not (:environment-id state)) (fail state :missing-environment-id (msg/t :exec/missing-environment-id))
-    :else                        state))
+(defn step-validate-inputs
+  "Validate that the pipeline state carries enough context to execute.
 
-(defn step-check-gh-auth [state]
+   Host mode: when :worktree-path IS present and :executor / :environment-id
+   are BOTH nil, the state is accepted with :host-mode? true.  Git/gh ops will
+   route through git.clj (babashka.process) instead of the DAG executor.
+
+   Sandbox mode: requires :worktree-path, :executor, and :environment-id.
+
+   The previous implementation rejected any context that lacked :executor,
+   which made every local-dogfood release fail before any git work could run."
+  [state]
   (cond
     (failed? state) state
+
+    ;; Host-mode path: local-dogfood context supplies a worktree but no
+    ;; sandbox executor.  Accepting this as valid (with :host-mode? true) is
+    ;; the root fix for the dogfood PR failure described in the ns docstring.
+    (and (:worktree-path state)
+         (nil? (:executor state))
+         (nil? (:environment-id state)))
+    (assoc state :host-mode? true)
+
+    ;; Sandbox-mode guards — same order/messages as before
+    (not (:worktree-path state))
+    (fail state :missing-worktree-path (msg/t :exec/missing-worktree-path))
+
+    (not (:executor state))
+    (fail state :missing-executor (msg/t :exec/missing-executor))
+
+    (not (:environment-id state))
+    (fail state :missing-environment-id (msg/t :exec/missing-environment-id))
+
+    :else state))
+
+(defn step-check-gh-auth
+  "Check gh CLI auth.  Dispatches to git/check-gh-auth! (host) or
+   sandbox/check-gh-auth! (sandbox)."
+  [state]
+  (cond
+    (failed? state)           state
     (not (:create-pr? state)) state
     :else
-    (let [gh-auth (sandbox/check-gh-auth! (:executor state) (:environment-id state)
-                                           (gh-exec-opts state))]
+    (let [gh-auth (if (:host-mode? state)
+                    (git/check-gh-auth!)
+                    (sandbox/check-gh-auth! (:executor state) (:environment-id state)
+                                            (gh-exec-opts state)))]
       (if (:authenticated? gh-auth)
         state
         (fail state :gh-auth-failed (:error gh-auth)
@@ -101,28 +159,30 @@
           (assoc state :release-meta release-meta)
           (fail state :metadata-generation-failed (msg/t :step/metadata-generation-failed)))))))
 
-(defn step-create-branch [state]
+(defn step-create-branch
+  "Create the release branch.  Dispatches git backend based on :host-mode?."
+  [state]
   (if (failed? state)
     state
-    (let [{:keys [release-meta executor environment-id base-branch-override]} state
+    (let [{:keys [release-meta host-mode? worktree-path executor environment-id
+                  base-branch-override logger]} state
           branch-name (:release/branch-name release-meta)
-          result (sandbox/create-branch! executor environment-id branch-name)]
+          result (if host-mode?
+                   (git/create-branch! worktree-path branch-name)
+                   (sandbox/create-branch! executor environment-id branch-name))]
       (if-not (result/succeeded? result)
         (fail state :branch-create-failed (:error result))
         (let [detected  (:base-branch result)
-              logger    (:logger state)
               ;; A chained DAG task's parent branch (override) becomes the PR
-              ;; base so the PR stacks on the parent. create-branch! fetched
-              ;; only origin/<detected>; fetch the override too so later
-              ;; origin/<base> range diffs / commits-ahead and the PR
-              ;; merge-base resolve.
+              ;; base so the PR stacks on the parent.  Fetch the override branch
+              ;; so later origin/<base> range diffs and commits-ahead resolve.
               override? (and base-branch-override (not= base-branch-override detected))
               fetch-r   (when override?
-                          (sandbox/fetch-branch! executor environment-id base-branch-override))
+                          (if host-mode?
+                            (git/fetch-branch! worktree-path base-branch-override)
+                            (sandbox/fetch-branch! executor environment-id base-branch-override)))
               ;; Degrade gracefully: if the parent branch can't be fetched
-              ;; (e.g. not yet on the remote), fall back to the detected
-              ;; default rather than failing the release — the PR opens
-              ;; against the default instead of stacking. Degraded, not fatal.
+              ;; (e.g. not yet on the remote), fall back to detected default.
               fetch-ok? (or (not override?) (result/succeeded? fetch-r))
               base      (if (and override? fetch-ok?) base-branch-override detected)]
           (when (and override? (not fetch-ok?) logger)
@@ -132,25 +192,24 @@
           (assoc state :branch (:branch result) :base-branch base))))))
 
 (defn step-stage-dirty-files
-  "Stage all dirty files in the executor environment.
-
-   In the environment model, files are already in the worktree (written by
-   the implement agent); this step stages them for commit.
+  "Stage all dirty files.  Dispatches git backend based on :host-mode?.
 
    Empty-stage handling: when nothing is dirty, the implementer's writes
-   may already be committed on the branch as phase-boundary commits (the
-   workflow runtime persists each phase boundary as a commit on the task
-   branch since 2026-04-30). In that case `git rev-list --count
-   origin/<base>..HEAD` reports the carry-forward commits and we treat
-   that as success — step-commit will skip cleanly and step-push will
+   may already be committed on the branch as phase-boundary commits.
+   `git rev-list --count origin/<base>..HEAD` detects this carry-forward case
+   and treats it as success — step-commit will skip cleanly and step-push will
    ship the existing commits."
   [state]
   (if (failed? state)
     state
-    (let [{:keys [executor environment-id base-branch]} state
-          stage-r (sandbox/stage-files! executor environment-id :all)
+    (let [{:keys [host-mode? worktree-path executor environment-id base-branch]} state
+          stage-r (if host-mode?
+                    (git/stage-files! worktree-path :all)
+                    (sandbox/stage-files! executor environment-id :all))
           staged-r (when (result/succeeded? stage-r)
-                     (sandbox/exec! executor environment-id "git diff --cached --name-only"))
+                     (if host-mode?
+                       (git/exec! worktree-path "git diff --cached --name-only")
+                       (sandbox/exec! executor environment-id "git diff --cached --name-only")))
           staged-output (get staged-r :output "")
           staged-count (count (remove str/blank? (str/split-lines staged-output)))]
       (cond
@@ -161,9 +220,11 @@
         (assoc state :write-metrics {:total-operations staged-count
                                      :files-written staged-count})
 
-        ;; Nothing dirty in the worktree, but the branch may already
-        ;; carry the work as boundary commits — accept that as success.
-        (let [ahead (sandbox/commits-ahead-of-base executor environment-id base-branch)]
+        ;; Nothing dirty in the worktree, but the branch may already carry
+        ;; the work as boundary commits — accept that as success.
+        (let [ahead (if host-mode?
+                      (git/commits-ahead-of-base worktree-path base-branch)
+                      (sandbox/commits-ahead-of-base executor environment-id base-branch))]
           (and ahead (pos? ahead)))
         (assoc state :write-metrics {:total-operations 0 :files-written 0
                                      :preexisting-commits true})
@@ -184,27 +245,30 @@
        (> deletions (* 3 (max 1 additions)))))
 
 (defn step-validate-diff
-  "Validate diff is not destructive before committing. Rejects changes
-   that delete more tests than they add or that empty files. Routes
-   through the executor (sandbox) so governed-mode capsules never
-   shell out to the host.
+  "Validate diff is not destructive before committing.  Dispatches git backend
+   based on :host-mode?.
 
-   In the boundary-commits case (`:preexisting-commits true`), the
-   staged index is empty — the work is in commits on the branch, not
-   in the index — so validation reads the range diff
-   `origin/<base>..HEAD` instead. Without this branch the destructive-
-   diff gate would silently no-op on every boundary-commit release."
+   In the boundary-commits case (:preexisting-commits true) the staged index is
+   empty — validation reads the range diff `origin/<base>...HEAD` instead."
   [state]
   (if (failed? state)
     state
-    (let [{:keys [executor environment-id logger base-branch]} state
+    (let [{:keys [host-mode? worktree-path executor environment-id logger base-branch]} state
           preexisting? (get-in state [:write-metrics :preexisting-commits])
           diff-stats  (if preexisting?
-                        (sandbox/diff-stats-range executor environment-id base-branch)
-                        (sandbox/diff-stats executor environment-id))
+                        (if host-mode?
+                          (git/diff-stats-range worktree-path base-branch)
+                          (sandbox/diff-stats-range executor environment-id base-branch))
+                        (if host-mode?
+                          (git/diff-stats worktree-path)
+                          (sandbox/diff-stats executor environment-id)))
           test-counts (if preexisting?
-                        (sandbox/count-test-defs-range executor environment-id base-branch)
-                        (sandbox/count-test-defs executor environment-id))]
+                        (if host-mode?
+                          (git/count-test-defs-range worktree-path base-branch)
+                          (sandbox/count-test-defs-range executor environment-id base-branch))
+                        (if host-mode?
+                          (git/count-test-defs worktree-path)
+                          (sandbox/count-test-defs executor environment-id)))]
       (cond
         (net-negative-tests? test-counts)
         (let [data {:added (:added test-counts) :removed (:removed test-counts)}]
@@ -223,41 +287,46 @@
             state)))))
 
 (defn step-commit
-  "Commit the staged changes with the release-meta message.
+  "Commit staged changes.  Dispatches git backend based on :host-mode?.
 
-   Skipped when step-stage-dirty-files found no dirty files and the
-   branch already carries the work as phase-boundary commits — the
-   existing HEAD becomes the release commit and the boundary-commit
-   messages are what end up in the PR. (This matches the worktree-as-
-   artifact handoff model: the work is in the branch already; release
-   is publishing it, not re-recording it.)"
+   Skipped when step-stage-dirty-files found no dirty files and the branch
+   already carries the work as phase-boundary commits — the existing HEAD
+   becomes the release commit."
   [state]
   (cond
     (failed? state) state
 
     (get-in state [:write-metrics :preexisting-commits])
-    (let [sha-r (sandbox/exec! (:executor state) (:environment-id state)
-                               "git rev-parse HEAD")]
+    (let [{:keys [host-mode? worktree-path executor environment-id]} state
+          sha-r (if host-mode?
+                  (git/exec! worktree-path "git rev-parse HEAD")
+                  (sandbox/exec! executor environment-id "git rev-parse HEAD"))]
       (cond-> state
         (result/succeeded? sha-r)
-        (assoc :commit-sha (str/trim (:output sha-r "")))))
+        (assoc :commit-sha (str/trim (get sha-r :output "")))))
 
     :else
-    (let [{:keys [release-meta executor environment-id]} state
-          result (sandbox/commit-changes! executor environment-id
-                                          (:release/commit-message release-meta))]
+    (let [{:keys [release-meta host-mode? worktree-path executor environment-id]} state
+          result (if host-mode?
+                   (git/commit-changes! worktree-path (:release/commit-message release-meta))
+                   (sandbox/commit-changes! executor environment-id
+                                            (:release/commit-message release-meta)))]
       (if (result/succeeded? result)
         (assoc state :commit-sha (:commit-sha result))
         (fail state :commit-failed (:error result))))))
 
-(defn step-push [state]
+(defn step-push
+  "Push branch to origin.  Dispatches git backend based on :host-mode?."
+  [state]
   (cond
-    (failed? state) state
+    (failed? state)           state
     (not (:create-pr? state)) state
     :else
-    (let [{:keys [branch executor environment-id]} state
-          result (sandbox/push-branch! executor environment-id branch
-                                       (gh-exec-opts state))]
+    (let [{:keys [branch host-mode? worktree-path executor environment-id]} state
+          result (if host-mode?
+                   (git/push-branch! worktree-path branch)
+                   (sandbox/push-branch! executor environment-id branch
+                                         (gh-exec-opts state)))]
       (if (result/succeeded? result)
         state
         (fail state :push-failed (:error result))))))
@@ -287,21 +356,29 @@
       body
       (str (provenance-frontmatter state) body))))
 
-(defn step-create-pr [state]
+(defn step-create-pr
+  "Create the pull request.  Dispatches git backend based on :host-mode?.
+
+   git/create-pr! carries the same duplicate-PR reuse logic as
+   sandbox/create-pr! — retry-safe on both backends."
+  [state]
   (cond
-    (failed? state) state
+    (failed? state)           state
     (not (:create-pr? state)) state
     :else
-    (let [{:keys [release-meta base-branch executor environment-id]} state
-          result (sandbox/create-pr! executor environment-id
-                                     {:title (:release/pr-title release-meta)
-                                      :body (with-provenance (:release/pr-body release-meta) state)
-                                      :base-branch base-branch}
-                                     (gh-exec-opts state))]
+    (let [{:keys [release-meta base-branch host-mode? worktree-path
+                  executor environment-id]} state
+          pr-opts {:title       (:release/pr-title release-meta)
+                   :body        (with-provenance (:release/pr-body release-meta) state)
+                   :base-branch base-branch}
+          result (if host-mode?
+                   (git/create-pr! worktree-path pr-opts)
+                   (sandbox/create-pr! executor environment-id pr-opts
+                                       (gh-exec-opts state)))]
       (if (result/succeeded? result)
         (assoc state
                :pr-number (:pr-number result)
-               :pr-url (:pr-url result))
+               :pr-url    (:pr-url result))
         (fail state :pr-create-failed (:error result))))))
 
 (defn- pr-doc-filename
@@ -340,16 +417,15 @@
       "_No file changes recorded._")))
 
 (defn- format-test-results
-  "Format test results from test artifacts as markdown.
-   Extracts result status, pass/fail counts, and summary text."
+  "Format test results from test artifacts as markdown."
   [test-artifacts]
   (if (seq test-artifacts)
     (let [latest (last test-artifacts)
           results (:test/results latest)
           summary (:test/summary latest)
-          total (:test/total latest)
-          passed (:test/passed latest)
-          failed (:test/failed latest)]
+          total   (:test/total latest)
+          passed  (:test/passed latest)
+          failed  (:test/failed latest)]
       (str (when results
              (str "**Result**: " (name results) "\n"))
            (when (and total passed)
@@ -366,9 +442,9 @@
    from review artifacts as markdown."
   [review-artifacts]
   (if (seq review-artifacts)
-    (let [latest (last review-artifacts)
-          decision (:review/decision latest)
-          summary (:review/summary latest)
+    (let [latest       (last review-artifacts)
+          decision     (:review/decision latest)
+          summary      (:review/summary latest)
           known-issues (metadata/format-known-issues (:review/warnings latest))]
       (str (when decision
              (str (msg/t :pr/decision {:decision (name decision)}) "\n"))
@@ -385,9 +461,9 @@
   (let [{:keys [release/pr-title release/pr-description release/commit-message]} release-meta
         {:keys [pr-number pr-url branch]} state-info
         review-artifacts (:review-artifacts workflow-data)
-        test-artifacts (:test-artifacts workflow-data)
-        files-md (format-files-changed code-artifacts)
-        tests-md (format-test-results test-artifacts)
+        test-artifacts   (:test-artifacts workflow-data)
+        files-md  (format-files-changed code-artifacts)
+        tests-md  (format-test-results test-artifacts)
         review-md (format-review-decision review-artifacts)]
     (str "<!--\n"
          "  Title: Miniforge.ai\n"
@@ -411,89 +487,67 @@
   "Write a docs/pull-requests/ markdown file, stage it, and amend the commit.
    Runs after step-create-pr so PR number/URL are available.
    Skipped when :create-pr? is false (no PR → no PR doc needed).
-   All I/O routes through the executor so governed-mode capsules never
-   touch the host filesystem."
+
+   NOTE: This step is retained for compatibility but is NOT in the active
+   pipeline — step-generate-pr-doc (below) supersedes it.  The sandbox/*
+   calls here are intentionally left without host-mode dispatch to signal
+   that this path should not be re-added to the pipeline; remove when safe."
   [state]
   (cond
-    (failed? state) state
+    (failed? state)           state
     (not (:create-pr? state)) state
     :else
     (let [{:keys [release-meta pr-number pr-url branch
                   executor environment-id logger]} state
           filename (pr-doc-filename (:release/pr-title release-meta))
           rel-path (str "docs/pull-requests/" filename)
-          content (render-pr-doc release-meta
-                                 {:pr-number pr-number
-                                  :pr-url pr-url
-                                  :branch branch})]
+          content  (render-pr-doc release-meta
+                                  {:pr-number pr-number
+                                   :pr-url    pr-url
+                                   :branch    branch})]
       (try
-        ;; Write via executor (governed) — never touch host filesystem
         (let [write-r (sandbox/write-file! executor environment-id rel-path content)]
           (if (result/succeeded? write-r)
             (do
               (when logger
                 (log/info logger :release-executor :pr-doc-written
                           {:data {:path rel-path}}))
-              ;; Stage the doc and amend the commit to include it
-              (sandbox/exec! executor environment-id
-                             (str "git add " rel-path))
-              (sandbox/exec! executor environment-id
-                             "git commit --amend --no-edit --no-verify")
-              ;; Force-push since we amended — route through executor with token
-              (sandbox/exec! executor environment-id
-                             "git push --force-with-lease"
+              (sandbox/exec! executor environment-id (str "git add " rel-path))
+              (sandbox/exec! executor environment-id "git commit --amend --no-edit --no-verify")
+              (sandbox/exec! executor environment-id "git push --force-with-lease"
                              (gh-exec-opts state)))
             (when logger
               (log/warn logger :release-executor :pr-doc-write-failed
                         {:message (:error write-r)}))))
         state
-      (catch Exception e
-        (when logger
-          (log/warn logger :release-executor :pr-doc-write-failed
-                    {:message (.getMessage e)}))
-        ;; Non-fatal: continue pipeline even if doc write fails
-        state)))))
+        (catch Exception e
+          (when logger
+            (log/warn logger :release-executor :pr-doc-write-failed
+                      {:message (.getMessage e)}))
+          state)))))
 
 (defn- looks-like-structured-pr-body?
   "True when a string already starts with the canonical PR-body shape
-   (a `## Summary` header at top, possibly after a blank line). When
-   the releaser agent obeyed the updated prompt it produces this shape
-   directly; in that case the fallback must NOT wrap it under another
-   `## Summary` (which would double-nest the headings)."
+   (a `## Summary` header at top, possibly after a blank line)."
   [s]
   (and (string? s)
        (boolean (re-find #"(?m)\A\s*##\s+Summary\b" s))))
 
 (defn- non-blank-section
-  "Render `(str header body \"\\n\\n\")` only when `body` is a non-blank
-   string. Guards the section against rendering an empty `## Header`
-   when the formatter returned `\"\"` for an artifact with no data."
+  "Render `(str header body \"\\n\\n\")` only when `body` is a non-blank string."
   [header body]
   (when (and body (not (str/blank? body)))
     (str header body "\n\n")))
 
 (defn- render-pr-body-fallback
-  "Render a structured GitHub PR body when the releaser agent didn't
-   produce one. Distinct from `render-pr-doc-full` (which targets the
-   committed docs/pull-requests/*.md file): no HTML copyright header,
-   no `_No X available._` placeholder strings — those belong in the
-   docs file for repo browsers, not in the PR description GitHub
-   reviewers see first.
-
-   When `:release/pr-description` already looks like a full PR body
-   (starts with `## Summary`), use it as the body verbatim and append
-   only the structured sections (Files Changed / Test Results /
-   Review) — wrapping a structured pr-description under another
-   `## Summary` would double-nest the heading."
+  "Render a structured GitHub PR body when the releaser agent didn't produce one.
+   Distinct from `render-pr-doc-full` (which targets the committed
+   docs/pull-requests/*.md file): no HTML copyright header, no placeholder strings."
   [release-meta code-artifacts workflow-data]
   (let [{:keys [release/pr-title release/pr-description]} release-meta
         review-artifacts (:review-artifacts workflow-data)
         test-artifacts   (:test-artifacts workflow-data)
         files-md         (format-files-changed code-artifacts)
-        ;; Sections are omitted entirely when their formatted markdown is
-        ;; blank — `format-test-results` etc. can return "" when artifacts
-        ;; exist but lack the expected fields, so `(seq artifacts)` alone
-        ;; isn't enough to gate the section.
         review-md        (when (seq review-artifacts) (format-review-decision review-artifacts))
         tests-md         (when (seq test-artifacts)   (format-test-results test-artifacts))
         structured?      (looks-like-structured-pr-body? pr-description)
@@ -508,100 +562,89 @@
          "🤖 Generated autonomously by [miniforge](https://github.com/miniforge-ai/miniforge).\n")))
 
 (defn- pr-body-needs-update?
-  "True when the post-create PR body should be overwritten. Only fires
-   when the agent failed to produce a useful body — never clobbers a
-   real :release/pr-body from the releaser agent."
+  "True when the post-create PR body should be overwritten."
   [release-meta]
   (let [body (:release/pr-body release-meta)]
     (or (nil? body)
         (str/blank? body)
-        ;; Treat a body that's just the title as a degraded agent
-        ;; output worth replacing with the structured fallback.
         (= (str/trim body) (str/trim (str (:release/pr-title release-meta)))))))
 
 (defn step-update-pr-body
-  "Update the GitHub PR body ONLY when the initial body was missing or
-   degraded (just the title, blank). When the releaser agent produced
-   a real :release/pr-body, step-create-pr already posted it — do not
-   overwrite. Crucially, the GitHub PR body is NOT the same surface as
-   the committed docs/pull-requests/*.md file; use a body-specific
-   renderer (`render-pr-body-fallback`), not the docs-file renderer."
+  "Update the GitHub PR body when the initial body was missing or degraded.
+   Dispatches git backend based on :host-mode?."
   [state]
   (cond
-    (failed? state) state
-    (not (:create-pr? state)) state
-    (not (:pr-number state)) state
+    (failed? state)                               state
+    (not (:create-pr? state))                     state
+    (not (:pr-number state))                      state
     (not (pr-body-needs-update? (:release-meta state))) state
     :else
-    (let [{:keys [release-meta pr-number executor environment-id logger
+    (let [{:keys [release-meta pr-number host-mode? worktree-path
+                  executor environment-id logger
                   code-artifacts workflow-data]} state
           body (with-provenance
                 (render-pr-body-fallback release-meta code-artifacts workflow-data)
                 state)]
       (try
-        (sandbox/edit-pr-body! executor environment-id
-                               pr-number body
-                               (gh-exec-opts state))
+        (if host-mode?
+          (git/edit-pr-body! worktree-path pr-number body)
+          (sandbox/edit-pr-body! executor environment-id pr-number body
+                                 (gh-exec-opts state)))
         (when logger
           (log/info logger :release-executor :pr-body-updated
                     {:data {:pr-number pr-number
-                            :reason :degraded-agent-body
-                            :source :fallback-renderer}}))
+                            :reason    :degraded-agent-body
+                            :source    :fallback-renderer}}))
         state
         (catch Exception e
           (when logger
             (log/warn logger :release-executor :pr-body-update-failed
                       {:message (.getMessage e)}))
-          ;; Non-fatal: PR exists, just has the original (degraded) body.
           state)))))
 
 (defn step-generate-pr-doc
   "Generate a comprehensive PR doc at docs/pull-requests/YYYY-MM-DD-<slug>.md.
-   Includes title, summary, files changed, test results, and review decision.
-   Stages the doc and amends the release commit to include it, then
-   force-pushes so the PR branch reflects the amended commit.
+   Stages the doc and amends the release commit to include it, then force-pushes.
+   Dispatches git backend based on :host-mode?.
 
    Runs after step-create-pr so PR number/URL are available.
-   Skipped when :create-pr? is false (no PR → no PR doc needed).
-   All I/O routes through the executor so governed-mode capsules never
-   touch the host filesystem."
+   Skipped when :create-pr? is false."
   [state]
   (cond
-    (failed? state) state
+    (failed? state)           state
     (not (:create-pr? state)) state
     :else
     (let [{:keys [release-meta pr-number pr-url branch
-                  executor environment-id logger code-artifacts workflow-data]} state
+                  host-mode? worktree-path executor environment-id
+                  logger code-artifacts workflow-data]} state
           filename (pr-doc-filename (:release/pr-title release-meta))
-          ;; Relative to the container workdir (the worktree root). The sandbox
-          ;; rejects absolute paths, so this must
-          ;; NOT be prefixed with worktree-path — the executor resolves it
-          ;; against the workdir. The git add below already uses rel-path.
           rel-path (str "docs/pull-requests/" filename)
-          content (render-pr-doc-full
-                   release-meta
-                   {:pr-number pr-number :pr-url pr-url :branch branch}
-                   code-artifacts
-                   workflow-data)]
+          content  (render-pr-doc-full
+                    release-meta
+                    {:pr-number pr-number :pr-url pr-url :branch branch}
+                    code-artifacts
+                    workflow-data)]
       (try
-        ;; Write via executor (governed) — never touch host filesystem
-        (let [write-r (sandbox/write-file! executor environment-id rel-path content)]
+        (let [write-r (if host-mode?
+                        (git/write-file! worktree-path rel-path content)
+                        (sandbox/write-file! executor environment-id rel-path content))]
           (if (result/succeeded? write-r)
             (do
               (when logger
                 (log/info logger :release-executor :pr-doc-generated
                           {:data {:path rel-path}}))
-              ;; Stage the doc and amend the commit to include it
-              (sandbox/exec! executor environment-id
-                             (str "git add " rel-path))
-              (sandbox/exec! executor environment-id
-                             "git commit --amend --no-edit --no-verify")
-              ;; Force-push since we amended — route through executor with token
-              (sandbox/exec! executor environment-id
-                             "git push --force-with-lease"
-                             (gh-exec-opts state))
+              (if host-mode?
+                (do
+                  (git/exec! worktree-path (str "git add " rel-path))
+                  (git/exec! worktree-path "git commit --amend --no-edit --no-verify")
+                  (git/exec! worktree-path "git push --force-with-lease"))
+                (do
+                  (sandbox/exec! executor environment-id (str "git add " rel-path))
+                  (sandbox/exec! executor environment-id "git commit --amend --no-edit --no-verify")
+                  (sandbox/exec! executor environment-id "git push --force-with-lease"
+                                 (gh-exec-opts state))))
               (assoc state
-                     :pr-doc-path rel-path
+                     :pr-doc-path    rel-path
                      :pr-doc-content content))
             (do
               (when logger
@@ -612,7 +655,6 @@
           (when logger
             (log/warn logger :release-executor :pr-doc-generation-failed
                       {:message (.getMessage e)}))
-          ;; Non-fatal: continue pipeline even if doc generation fails
           state)))))
 
 (defn step-build-artifact [state]
@@ -621,22 +663,22 @@
     (let [{:keys [worktree-path branch base-branch commit-sha create-pr?
                   pr-number pr-url release-meta write-metrics code-artifacts]} state
           release-content (merge write-metrics
-                                 {:git-staged? true
+                                 {:git-staged?   true
                                   :worktree-path (str worktree-path)
-                                  :branch branch
-                                  :base-branch base-branch
-                                  :commit-sha commit-sha
-                                  :pr-created? (boolean create-pr?)
-                                  :pr-number pr-number
-                                  :pr-url pr-url
+                                  :branch        branch
+                                  :base-branch   base-branch
+                                  :commit-sha    commit-sha
+                                  :pr-created?   (boolean create-pr?)
+                                  :pr-number     pr-number
+                                  :pr-url        pr-url
                                   :release-metadata release-meta})
           release-artifact (artifact/build-artifact
-                            {:id (random-uuid)
-                             :type :release
-                             :version "1.0.0"
-                             :content release-content
-                             :metadata {:phase :release
-                                        :code-artifacts-count (count code-artifacts)}})]
+                            {:id       (random-uuid)
+                             :type     :release
+                             :version  "1.0.0"
+                             :content  release-content
+                             :metadata {:phase                 :release
+                                        :code-artifacts-count  (count code-artifacts)}})]
       (assoc state :release-artifact release-artifact))))
 
 (defn step-save-artifact [state]
@@ -656,22 +698,22 @@
                 branch commit-sha pr-number pr-url]} state]
     (if failure
       (result/phase-failure (:type failure) (:message failure)
-                            {:hint (:hint failure)
+                            {:hint    (:hint failure)
                              :metrics (or write-metrics {})})
       (do
         (when logger
           (log/info logger :release-executor :phase-completed
-                    {:data {:branch branch
-                            :commit commit-sha
-                            :pr-url pr-url
+                    {:data {:branch        branch
+                            :commit        commit-sha
+                            :pr-url        pr-url
                             :files-written (:files-written write-metrics)}}))
         (result/phase-success
          [release-artifact]
          (merge write-metrics
-                {:pr-number pr-number
-                 :pr-url pr-url
+                {:pr-number  pr-number
+                 :pr-url     pr-url
                  :commit-sha commit-sha
-                 :branch branch}))))))
+                 :branch     branch}))))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Main execute function
@@ -679,13 +721,13 @@
 (defn execute-release-phase
   "Execute the release phase.
 
-   Requires an executor environment (worktree) acquired before this phase.
-   Stages dirty files in the worktree, commits, pushes, and creates a PR.
+   Accepts two backends transparently:
 
-   All git/gh operations route through the sandbox module (DAG executor)
-   so that governed-mode capsules never shell out to the host. The GitHub
-   token (when provided via :github-token in context) is injected as the
-   GH_TOKEN env var for gh CLI commands inside the capsule.
+   - **Sandbox mode**: `:executor` + `:environment-id` in context; all git/gh
+     ops route through the DAG executor (governed-mode capsule).
+
+   - **Host mode**: `:worktree-path` in context, no `:executor` / `:environment-id`;
+     git/gh ops run directly on the host (local-dogfood path).
 
    Arguments:
    - workflow-state - Workflow state with :workflow/artifacts
@@ -699,37 +741,36 @@
     :errors []
     :metrics {...}}"
   [workflow-state context opts]
-  (let [logger (:logger context)
-        executor (:executor context)
+  (let [logger         (:logger context)
+        executor       (:executor context)
         environment-id (:environment-id context)
         workflow-artifacts (:workflow/artifacts workflow-state)
-        initial-state (cond-> {:logger logger
-                               :worktree-path (:worktree-path context)
-                               :artifact-store (:artifact-store context)
-                               :context context
-                               :create-pr? (get context :create-pr? true)
-                               ;; Explicit PR base override (a dependency-chained
-                               ;; DAG task's parent branch). When present it wins
-                               ;; over the branch-creation default so the PR
-                               ;; stacks on the parent; diff/commits-ahead ranges
-                               ;; key off it too, yielding this task's own layer.
-                               :base-branch-override (:base-branch context)
-                               ;; PR provenance ({:workflow :spec :task}) →
-                               ;; rendered as YAML frontmatter on the PR body.
-                               :provenance (:provenance context)
-                               :releaser (:releaser opts)
-                               :task-description (get-in workflow-state [:workflow/spec :spec/description])
-                               :code-artifacts (extract-code-artifacts workflow-artifacts)
-                               :workflow-data (extract-workflow-data workflow-artifacts)
-                               :executor executor
-                               :environment-id environment-id
-                               :github-token (:github-token context)}
-                        (:release-meta opts) (assoc :release-meta (:release-meta opts)))]
+        initial-state  (cond-> {:logger         logger
+                                :worktree-path  (:worktree-path context)
+                                :artifact-store (:artifact-store context)
+                                :context        context
+                                :create-pr?     (get context :create-pr? true)
+                                ;; Explicit PR base override (a dependency-chained
+                                ;; DAG task's parent branch).  When present it wins
+                                ;; over the branch-creation default so the PR
+                                ;; stacks on the parent.
+                                :base-branch-override (:base-branch context)
+                                ;; PR provenance ({:workflow :spec :task}) rendered
+                                ;; as YAML frontmatter on the PR body.
+                                :provenance     (:provenance context)
+                                :releaser       (:releaser opts)
+                                :task-description (get-in workflow-state [:workflow/spec :spec/description])
+                                :code-artifacts (extract-code-artifacts workflow-artifacts)
+                                :workflow-data  (extract-workflow-data workflow-artifacts)
+                                :executor       executor
+                                :environment-id environment-id
+                                :github-token   (:github-token context)}
+                       (:release-meta opts) (assoc :release-meta (:release-meta opts)))]
 
     (when logger
       (log/info logger :release-executor :phase-started
                 {:data {:worktree-path (:worktree-path initial-state)
-                        :create-pr? (:create-pr? initial-state)}}))
+                        :create-pr?    (:create-pr? initial-state)}}))
 
     (-> initial-state
         step-validate-inputs

--- a/components/release-executor/src/ai/miniforge/release_executor/core.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/core.clj
@@ -208,7 +208,7 @@
                     (sandbox/stage-files! executor environment-id :all))
           staged-r (when (result/succeeded? stage-r)
                      (if host-mode?
-                       (git/exec! worktree-path "git diff --cached --name-only")
+                       (git/exec! worktree-path ["git" "diff" "--cached" "--name-only"])
                        (sandbox/exec! executor environment-id "git diff --cached --name-only")))
           staged-output (get staged-r :output "")
           staged-count (count (remove str/blank? (str/split-lines staged-output)))]
@@ -299,7 +299,7 @@
     (get-in state [:write-metrics :preexisting-commits])
     (let [{:keys [host-mode? worktree-path executor environment-id]} state
           sha-r (if host-mode?
-                  (git/exec! worktree-path "git rev-parse HEAD")
+                  (git/exec! worktree-path ["git" "rev-parse" "HEAD"])
                   (sandbox/exec! executor environment-id "git rev-parse HEAD"))]
       (cond-> state
         (result/succeeded? sha-r)
@@ -635,9 +635,9 @@
                           {:data {:path rel-path}}))
               (if host-mode?
                 (do
-                  (git/exec! worktree-path (str "git add " rel-path))
-                  (git/exec! worktree-path "git commit --amend --no-edit --no-verify")
-                  (git/exec! worktree-path "git push --force-with-lease"))
+                  (git/exec! worktree-path ["git" "add" rel-path])
+                  (git/exec! worktree-path ["git" "commit" "--amend" "--no-edit" "--no-verify"])
+                  (git/force-push! worktree-path (:github-token state)))
                 (do
                   (sandbox/exec! executor environment-id (str "git add " rel-path))
                   (sandbox/exec! executor environment-id "git commit --amend --no-edit --no-verify")

--- a/components/release-executor/src/ai/miniforge/release_executor/core.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/core.clj
@@ -196,9 +196,10 @@
 
    Empty-stage handling: when nothing is dirty, the implementer's writes
    may already be committed on the branch as phase-boundary commits.
-   `git rev-list --count origin/<base>..HEAD` detects this carry-forward case
-   and treats it as success — step-commit will skip cleanly and step-push will
-   ship the existing commits."
+   commits-ahead-of-base (git rev-list --count --right-only
+   origin/<base>...HEAD — the three-dot merge-base form) detects this
+   carry-forward case and treats it as success — step-commit will skip
+   cleanly and step-push will ship the existing commits."
   [state]
   (if (failed? state)
     state

--- a/components/release-executor/src/ai/miniforge/release_executor/core.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/core.clj
@@ -217,6 +217,13 @@
         (not (result/succeeded? stage-r))
         (fail state :stage-failed (:error stage-r))
 
+        ;; The listing command itself failed — don't misread an errored
+        ;; `git diff --cached --name-only` as an empty staged set (which
+        ;; would fall through to the boundary-commit path or a spurious
+        ;; :no-files-to-stage). Fail fast with the real error.
+        (and staged-r (not (result/succeeded? staged-r)))
+        (fail state :stage-list-failed (:error staged-r))
+
         (pos? staged-count)
         (assoc state :write-metrics {:total-operations staged-count
                                      :files-written staged-count})
@@ -634,19 +641,39 @@
               (when logger
                 (log/info logger :release-executor :pr-doc-generated
                           {:data {:path rel-path}}))
-              (if host-mode?
-                (do
-                  (git/exec! worktree-path ["git" "add" rel-path])
-                  (git/exec! worktree-path ["git" "commit" "--amend" "--no-edit" "--no-verify"])
-                  (git/force-push! worktree-path (:github-token state)))
-                (do
-                  (sandbox/exec! executor environment-id (str "git add " rel-path))
-                  (sandbox/exec! executor environment-id "git commit --amend --no-edit --no-verify")
-                  (sandbox/exec! executor environment-id "git push --force-with-lease"
-                                 (gh-exec-opts state))))
-              (assoc state
-                     :pr-doc-path    rel-path
-                     :pr-doc-content content))
+              ;; Amend the doc onto the branch tip and re-push. Thread each
+              ;; step's result so a failed add/amend/push does not let us
+              ;; claim :pr-doc-path — the doc would be in the worktree but
+              ;; not on the pushed branch. Publish is best-effort: on
+              ;; failure we warn and continue (the PR + doc file still exist
+              ;; locally) rather than fail the whole release for a doc-only
+              ;; step.
+              (let [publish-r
+                    (if host-mode?
+                      (let [add-r    (git/exec! worktree-path ["git" "add" rel-path])
+                            commit-r (when (result/succeeded? add-r)
+                                       (git/exec! worktree-path
+                                                  ["git" "commit" "--amend" "--no-edit" "--no-verify"]))]
+                        (if (and commit-r (result/succeeded? commit-r))
+                          (git/force-push! worktree-path (:github-token state))
+                          (or commit-r add-r)))
+                      (let [add-r    (sandbox/exec! executor environment-id (str "git add " rel-path))
+                            commit-r (when (result/succeeded? add-r)
+                                       (sandbox/exec! executor environment-id
+                                                      "git commit --amend --no-edit --no-verify"))]
+                        (if (and commit-r (result/succeeded? commit-r))
+                          (sandbox/exec! executor environment-id "git push --force-with-lease"
+                                         (gh-exec-opts state))
+                          (or commit-r add-r))))]
+                (if (result/succeeded? publish-r)
+                  (assoc state :pr-doc-path rel-path :pr-doc-content content)
+                  (do
+                    (when logger
+                      (log/warn logger :release-executor :pr-doc-publish-failed
+                                {:message (str "PR doc amend/push did not complete; "
+                                               "not claiming it was published: "
+                                               (:error publish-r))}))
+                    state))))
             (do
               (when logger
                 (log/warn logger :release-executor :pr-doc-generation-failed

--- a/components/release-executor/src/ai/miniforge/release_executor/git.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/git.clj
@@ -88,14 +88,17 @@
 ;; Generic command runner
 
 (defn exec!
-  "Run a shell command string in the worktree directory.
-   Returns {:success? bool :output string :error string}.
-   Used for ad-hoc git commands (git rev-parse, git add, git commit --amend, etc.)."
-  [worktree-path cmd]
+  "Run a git command in the worktree directory. `args` is an argv vector
+   (e.g. [\"git\" \"rev-parse\" \"HEAD\"]) passed straight to the process — NOT
+   through `sh -c` — so shell metacharacters in any argument are inert and
+   there is no command-injection surface even if an argument carries
+   untrusted data. Returns {:success? bool :output string :error string}.
+   For ad-hoc git commands (rev-parse, diff --name-only, add, amend)."
+  [worktree-path args]
   (try
-    (let [r (process/shell
-             {:dir (str worktree-path) :out :string :err :string :continue true}
-             "sh" "-c" cmd)]
+    (let [r (apply process/shell
+                   {:dir (str worktree-path) :out :string :err :string :continue true}
+                   args)]
       (if (zero? (:exit r))
         (result/shell-success {:output (str/trim (get r :out ""))})
         (result/shell-failure (str/trim (get r :err ""))
@@ -335,6 +338,22 @@
          (result/shell-failure (get r :err ""))))
      (catch Exception e
        (result/shell-failure (.getMessage e))))))
+
+(defn force-push!
+  "Force-push the current branch with --force-with-lease, injecting
+   `github-token` as GH_TOKEN so gh's git credential helper authenticates
+   with the pipeline credential (the PR-doc amend path uses this). Returns a
+   shell-result."
+  [worktree-path github-token]
+  (try
+    (let [r (process/shell
+             (gh-shell-opts worktree-path github-token)
+             "git" "push" "--force-with-lease")]
+      (if (zero? (:exit r))
+        (result/shell-success {:output (get r :out "")})
+        (result/shell-failure (get r :err ""))))
+    (catch Exception e
+      (result/shell-failure (.getMessage e)))))
 
 (defn write-file!
   "Write content to a relative path inside the worktree.

--- a/components/release-executor/src/ai/miniforge/release_executor/git.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/git.clj
@@ -217,16 +217,17 @@
    Uses the three-dot merge-base form so concurrent movement of origin/<base>
    does not shrink the count to zero. Returns nil on git failure."
   [worktree-path base-branch]
-  (try
-    (let [r (process/shell
-             {:dir (str worktree-path) :out :string :err :string :continue true}
-             "git" "rev-list" "--count" "--right-only"
-             (str "origin/" base-branch "...HEAD"))]
-      (when (zero? (:exit r))
-        (try
-          (Long/parseLong (str/trim (get r :out "0")))
-          (catch NumberFormatException _ nil))))
-    (catch Exception _ nil)))
+  (when-not (validate-safe-branch-name base-branch)
+    (try
+      (let [r (process/shell
+               {:dir (str worktree-path) :out :string :err :string :continue true}
+               "git" "rev-list" "--count" "--right-only"
+               (str "origin/" base-branch "...HEAD"))]
+        (when (zero? (:exit r))
+          (try
+            (Long/parseLong (str/trim (get r :out "0")))
+            (catch NumberFormatException _ nil))))
+      (catch Exception _ nil))))
 
 (defn diff-stats
   "Get line-level diff stats for staged changes.
@@ -254,21 +255,22 @@
    origin/<base> — `git diff origin/<base>...HEAD --numstat` with the
    three-dot form (merge-base diff). Mirrors sandbox/diff-stats-range."
   [worktree-path base-branch]
-  (try
-    (let [r (process/shell
-             {:dir (str worktree-path) :out :string :err :string :continue true}
-             "git" "diff" (str "origin/" base-branch "...HEAD") "--numstat")]
-      (when (zero? (:exit r))
-        (let [lines (str/split-lines (str/trim (get r :out "")))
-              parsed (keep (fn [line]
-                             (when-let [[_ adds dels] (re-matches #"(\d+)\t(\d+)\t.*" line)]
-                               {:additions (parse-long adds)
-                                :deletions (parse-long dels)}))
-                           lines)]
-          {:additions (reduce + 0 (map :additions parsed))
-           :deletions (reduce + 0 (map :deletions parsed))
-           :files (count parsed)})))
-    (catch Exception _ nil)))
+  (when-not (validate-safe-branch-name base-branch)
+    (try
+      (let [r (process/shell
+               {:dir (str worktree-path) :out :string :err :string :continue true}
+               "git" "diff" (str "origin/" base-branch "...HEAD") "--numstat")]
+        (when (zero? (:exit r))
+          (let [lines (str/split-lines (str/trim (get r :out "")))
+                parsed (keep (fn [line]
+                               (when-let [[_ adds dels] (re-matches #"(\d+)\t(\d+)\t.*" line)]
+                                 {:additions (parse-long adds)
+                                  :deletions (parse-long dels)}))
+                             lines)]
+            {:additions (reduce + 0 (map :additions parsed))
+             :deletions (reduce + 0 (map :deletions parsed))
+             :files (count parsed)})))
+      (catch Exception _ nil))))
 
 (defn count-test-defs
   "Count deftest forms in staged changes.
@@ -290,16 +292,17 @@
   "Count deftest forms added/removed in origin/<base>...HEAD (merge-base diff).
    Mirrors sandbox/count-test-defs-range."
   [worktree-path base-branch]
-  (try
-    (let [r (process/shell
-             {:dir (str worktree-path) :out :string :err :string :continue true}
-             "git" "diff" (str "origin/" base-branch "...HEAD") "-U0")]
-      (when (zero? (:exit r))
-        (let [diff-text (get r :out "")
-              added   (count (re-seq #"(?m)^\+.*\(deftest " diff-text))
-              removed (count (re-seq #"(?m)^-.*\(deftest " diff-text))]
-          {:added added :removed removed})))
-    (catch Exception _ nil)))
+  (when-not (validate-safe-branch-name base-branch)
+    (try
+      (let [r (process/shell
+               {:dir (str worktree-path) :out :string :err :string :continue true}
+               "git" "diff" (str "origin/" base-branch "...HEAD") "-U0")]
+        (when (zero? (:exit r))
+          (let [diff-text (get r :out "")
+                added   (count (re-seq #"(?m)^\+.*\(deftest " diff-text))
+                removed (count (re-seq #"(?m)^-.*\(deftest " diff-text))]
+            {:added added :removed removed})))
+      (catch Exception _ nil))))
 
 (defn commit-changes!
   "Commit staged changes with the given message.
@@ -355,19 +358,35 @@
     (catch Exception e
       (result/shell-failure (.getMessage e)))))
 
+(defn- inside-worktree?
+  "True when `file` resolves inside `worktree-path` after canonicalization
+   (collapses `..`, symlinks, and redundant separators). Kept self-contained
+   rather than reusing files/path-traversal-anomaly, which depends on this
+   namespace (a git→files require would cycle)."
+  [worktree-path ^java.io.File file]
+  (let [root   (.getCanonicalPath (java.io.File. (str worktree-path)))
+        target (.getCanonicalPath file)]
+    (or (= target root)
+        (str/starts-with? target (str root java.io.File/separator)))))
+
 (defn write-file!
-  "Write content to a relative path inside the worktree.
-   Creates parent directories as needed.
-   Returns {:success? bool :output string :error string}."
+  "Write content to a path inside the worktree, creating parent dirs.
+   Rejects a `rel-path` that escapes the worktree root (absolute path, `..`
+   segments, or symlinked parents) via a canonical-path check — parity with
+   the sandbox backend's guard. Returns {:success? bool :output string
+   :error string}."
   [worktree-path rel-path content]
-  (try
-    (let [file   (java.io.File. (str worktree-path) (str rel-path))
-          parent (.getParentFile file)]
-      (when parent (.mkdirs parent))
-      (spit file content)
-      (result/shell-success {:output (str rel-path)}))
-    (catch Exception e
-      (result/shell-failure (.getMessage e)))))
+  (let [file (java.io.File. (str worktree-path) (str rel-path))]
+    (if-not (inside-worktree? worktree-path file)
+      (result/shell-failure (str "Path traversal rejected: " rel-path
+                                 " escapes worktree root"))
+      (try
+        (let [parent (.getParentFile file)]
+          (when parent (.mkdirs parent))
+          (spit file content)
+          (result/shell-success {:output (str rel-path)}))
+        (catch Exception e
+          (result/shell-failure (.getMessage e)))))))
 
 (defn edit-pr-body!
   "Update the body of an existing PR using gh CLI on the host. Injects

--- a/components/release-executor/src/ai/miniforge/release_executor/git.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/git.clj
@@ -130,13 +130,16 @@
       (result/shell-failure (.getMessage e)))))
 
 (defn check-gh-auth!
-  "Check if gh CLI is available and authenticated on the host. Injects
-   `github-token` as GH_TOKEN so the check reflects the credential the
-   pipeline will use to open the PR (not just ambient host auth).
+  "Check if gh CLI is available and authenticated on the host. The optional
+   `github-token` is injected as GH_TOKEN so the check reflects the
+   credential the pipeline will use to open the PR (not just ambient host
+   auth); the 0-arity keeps the historical public-interface signature and
+   inherits the ambient environment.
 
    Returns {:available? bool :authenticated? bool :user string :error string}"
-  [github-token]
-  (try
+  ([] (check-gh-auth! nil))
+  ([github-token]
+   (try
     (let [which-r (process/shell
                    {:out :string :err :string :continue true}
                    "which" "gh")]
@@ -152,7 +155,7 @@
             (gh-available-unauthenticated
              (str "gh not authenticated. Run: gh auth login\n" (get auth-r :err "")))))))
     (catch Exception e
-      (gh-unavailable (.getMessage e)))))
+      (gh-unavailable (.getMessage e))))))
 
 (defn create-branch!
   "Create a new git branch for the release, branching from HEAD so that
@@ -356,37 +359,42 @@
    whose `origin` is an SSH remote can still push, matching
    sandbox/push-branch!.
 
+   The optional `github-token` drives GH_TOKEN injection and the HTTPS
+   fallback; the 2-arity keeps the historical public-interface signature
+   (ambient credentials, no fallback).
+
    Returns {:success? bool :error string}"
-  [worktree-path branch-name github-token]
-  (or
-   (validate-safe-branch-name branch-name)
-   (let [result (raw-push! worktree-path branch-name github-token)]
-     (if (or (result/succeeded? result) (not github-token))
-       result
-       (let [url-r      (exec! worktree-path ["git" "remote" "get-url" "origin"])
-             remote-url (when (result/succeeded? url-r) (str/trim (get url-r :output "")))
-             https-url  (ssh->https-with-token remote-url github-token)]
-         (if https-url
-           (do
-             (exec! worktree-path ["git" "remote" "set-url" "origin" https-url])
-             (let [retry     (raw-push! worktree-path branch-name github-token)
-                   ;; Restore the original remote URL so the token never
-                   ;; persists in the worktree's git config.
-                   restore-r (exec! worktree-path
-                                    ["git" "remote" "set-url" "origin" remote-url])]
-               (if (result/succeeded? restore-r)
-                 retry
-                 ;; The restore failed — origin may still embed the token.
-                 ;; Fail loud (even if the push itself succeeded) with the
-                 ;; scrub command, rather than report a clean success while a
-                 ;; credential is persisted in git config.
-                 (result/shell-failure
-                  (str "Pushed via HTTPS token fallback but could not restore the "
-                       "origin remote URL; it may still embed the GitHub token. "
-                       "Scrub it: git remote set-url origin " remote-url ". "
-                       "Restore error: " (:error restore-r))
-                  {:push-succeeded? (result/succeeded? retry)}))))
-           result))))))
+  ([worktree-path branch-name] (push-branch! worktree-path branch-name nil))
+  ([worktree-path branch-name github-token]
+   (or
+    (validate-safe-branch-name branch-name)
+    (let [result (raw-push! worktree-path branch-name github-token)]
+      (if (or (result/succeeded? result) (not github-token))
+        result
+        (let [url-r      (exec! worktree-path ["git" "remote" "get-url" "origin"])
+              remote-url (when (result/succeeded? url-r) (str/trim (get url-r :output "")))
+              https-url  (ssh->https-with-token remote-url github-token)]
+          (if https-url
+            (do
+              (exec! worktree-path ["git" "remote" "set-url" "origin" https-url])
+              (let [retry     (raw-push! worktree-path branch-name github-token)
+                    ;; Restore the original remote URL so the token never
+                    ;; persists in the worktree's git config.
+                    restore-r (exec! worktree-path
+                                     ["git" "remote" "set-url" "origin" remote-url])]
+                (if (result/succeeded? restore-r)
+                  retry
+                  ;; The restore failed — origin may still embed the token.
+                  ;; Fail loud (even if the push itself succeeded) with the
+                  ;; scrub command, rather than report a clean success while a
+                  ;; credential is persisted in git config.
+                  (result/shell-failure
+                   (str "Pushed via HTTPS token fallback but could not restore the "
+                        "origin remote URL; it may still embed the GitHub token. "
+                        "Scrub it: git remote set-url origin " remote-url ". "
+                        "Restore error: " (:error restore-r))
+                   {:push-succeeded? (result/succeeded? retry)}))))
+            result)))))))
 
 (defn force-push!
   "Force-push the current branch with --force-with-lease, injecting
@@ -500,30 +508,35 @@
    - A branch that already has an open PR (retry/resume) reuses that PR via
      `gh pr view` rather than opening a duplicate.
 
+   The optional `github-token` (injected as GH_TOKEN) is the new host-mode
+   credential path; the 2-arity keeps the historical public-interface
+   signature and inherits the ambient environment.
+
    Returns {:success? bool :pr-number int :pr-url string :error string}"
-  [worktree-path {:keys [title body base-branch]} github-token]
-  (let [base (or base-branch "main")]
-    (or
-     (validate-safe-branch-name base)
-     (try
-       (let [result (process/shell
-                     (gh-shell-opts worktree-path github-token)
-                     "gh" "pr" "create"
-                     "--title" title
-                     "--body"  (or body "")
-                     "--base"  base)]
-         (cond
-           (zero? (:exit result))
-           (if-let [pr (parse-pr-ref (get result :out ""))]
-             (result/shell-success pr)
-             (result/shell-failure (msg/t :pr/create-unconfirmed
-                                          {:output (str/trim (get result :out ""))})
-                                   {:pr-url nil :pr-number nil}))
+  ([worktree-path pr-opts] (create-pr! worktree-path pr-opts nil))
+  ([worktree-path {:keys [title body base-branch]} github-token]
+   (let [base (or base-branch "main")]
+     (or
+      (validate-safe-branch-name base)
+      (try
+        (let [result (process/shell
+                      (gh-shell-opts worktree-path github-token)
+                      "gh" "pr" "create"
+                      "--title" title
+                      "--body"  (or body "")
+                      "--base"  base)]
+          (cond
+            (zero? (:exit result))
+            (if-let [pr (parse-pr-ref (get result :out ""))]
+              (result/shell-success pr)
+              (result/shell-failure (msg/t :pr/create-unconfirmed
+                                           {:output (str/trim (get result :out ""))})
+                                    {:pr-url nil :pr-number nil}))
 
-           (pr-already-exists? (get result :err ""))
-           (reuse-existing-pr! worktree-path github-token)
+            (pr-already-exists? (get result :err ""))
+            (reuse-existing-pr! worktree-path github-token)
 
-           :else
-           (result/shell-failure (get result :err "") {:pr-url nil :pr-number nil})))
-       (catch Exception e
-         (result/shell-failure (.getMessage e) {:pr-url nil :pr-number nil}))))))
+            :else
+            (result/shell-failure (get result :err "") {:pr-url nil :pr-number nil})))
+        (catch Exception e
+          (result/shell-failure (.getMessage e) {:pr-url nil :pr-number nil})))))))

--- a/components/release-executor/src/ai/miniforge/release_executor/git.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/git.clj
@@ -63,13 +63,14 @@
   (let [s (str branch)]
     (cond
       (str/blank? s)
-      (result/shell-failure "Unsafe branch name: must not be blank" {:branch nil})
+      (result/shell-failure "Unsafe branch name: must not be blank" {:branch s})
 
       (str/starts-with? s "-")
-      (result/shell-failure "Unsafe branch name: must not start with '-'" {:branch nil})
+      (result/shell-failure (str "Unsafe branch name: must not start with '-': " (pr-str s))
+                            {:branch s})
 
       (not (re-matches #"[A-Za-z0-9._/-]+" s))
-      (result/shell-failure (str "Unsafe branch name: " s) {:branch nil})
+      (result/shell-failure (str "Unsafe branch name: " (pr-str s)) {:branch s})
 
       :else nil)))
 

--- a/components/release-executor/src/ai/miniforge/release_executor/git.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/git.clj
@@ -48,6 +48,42 @@
   [user]
   {:available? true :authenticated? true :user user})
 
+;------------------------------------------------------------------------------ Layer 0
+;; Safety + credential helpers (host-mode parity with sandbox.clj)
+
+(defn validate-safe-branch-name
+  "Return nil when `branch` is safe to pass as a git/gh argument, else a
+   shell-failure result. Mirrors sandbox/validate-safe-branch-name: allows
+   only [A-Za-z0-9._/-] (the set git permits) and rejects blank names or
+   names starting with '-', which git would read as an option flag (option
+   injection). Host-mode passes branch names as argv (not through `sh -c`),
+   so shell metacharacters are already inert, but a leading-'-' name is still
+   an argument-injection vector — hence the guard."
+  [branch]
+  (let [s (str branch)]
+    (cond
+      (str/blank? s)
+      (result/shell-failure "Unsafe branch name: must not be blank" {:branch nil})
+
+      (str/starts-with? s "-")
+      (result/shell-failure "Unsafe branch name: must not start with '-'" {:branch nil})
+
+      (not (re-matches #"[A-Za-z0-9._/-]+" s))
+      (result/shell-failure (str "Unsafe branch name: " s) {:branch nil})
+
+      :else nil)))
+
+(defn- gh-shell-opts
+  "process/shell option map for a gh call, injecting the caller's
+   `github-token` as GH_TOKEN so host-mode uses the same credential the
+   pipeline resolved — parity with sandbox's gh-exec-opts :env injection.
+   `worktree-path` may be nil (e.g. `gh auth status` needs no cwd). When no
+   token is supplied the call inherits the ambient environment."
+  [worktree-path github-token]
+  (cond-> {:out :string :err :string :continue true}
+    worktree-path (assoc :dir (str worktree-path))
+    github-token  (assoc :extra-env {"GH_TOKEN" github-token})))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Generic command runner
 
@@ -90,10 +126,12 @@
       (result/shell-failure (.getMessage e)))))
 
 (defn check-gh-auth!
-  "Check if gh CLI is available and authenticated on the host.
+  "Check if gh CLI is available and authenticated on the host. Injects
+   `github-token` as GH_TOKEN so the check reflects the credential the
+   pipeline will use to open the PR (not just ambient host auth).
 
    Returns {:available? bool :authenticated? bool :user string :error string}"
-  []
+  [github-token]
   (try
     (let [which-r (process/shell
                    {:out :string :err :string :continue true}
@@ -101,7 +139,7 @@
       (if-not (zero? (:exit which-r))
         (gh-unavailable "gh CLI not found. Install with: brew install gh")
         (let [auth-r (process/shell
-                      {:out :string :err :string :continue true}
+                      (gh-shell-opts nil github-token)
                       "gh" "auth" "status")]
           (if (zero? (:exit auth-r))
             (let [output (get auth-r :out "")
@@ -122,7 +160,9 @@
 
    Returns {:success? bool :branch string :base-branch string :error string}"
   [worktree-path branch-name]
-  (try
+  (or
+   (validate-safe-branch-name branch-name)
+   (try
     (let [dir-opts {:dir (str worktree-path) :out :string :err :string :continue true}
           default-branch-r (process/shell dir-opts
                                           "git" "symbolic-ref" "refs/remotes/origin/HEAD")
@@ -131,6 +171,12 @@
                                str/trim
                                (str/replace #"refs/remotes/origin/" ""))
                            "main")
+          ;; Refresh origin/<default> before branching so later
+          ;; origin/<base>...HEAD range diffs / commits-ahead resolve
+          ;; against current tips (sandbox/create-branch! fetches too).
+          ;; Best-effort: a fetch failure (offline worktree) degrades to a
+          ;; possibly-stale base rather than aborting the release.
+          _ (process/shell dir-opts "git" "fetch" "origin" default-branch)
           checkout-r (process/shell dir-opts
                                     "git" "checkout" "-b" branch-name)]
       (if (zero? (:exit checkout-r))
@@ -142,7 +188,7 @@
             (result/shell-failure (str "Failed to create branch: " (get retry-r :err ""))
                                   {:branch nil})))))
     (catch Exception e
-      (result/shell-failure (.getMessage e) {:branch nil}))))
+      (result/shell-failure (.getMessage e) {:branch nil})))))
 
 (defn fetch-branch!
   "Fetch origin/<branch> into the local worktree.
@@ -151,15 +197,17 @@
    `origin/<base>` range diffs and commits-ahead resolve on the host.
    Returns a shell-result."
   [worktree-path branch]
-  (try
-    (let [r (process/shell
-             {:dir (str worktree-path) :out :string :err :string :continue true}
-             "git" "fetch" "origin" (str branch))]
-      (if (zero? (:exit r))
-        (result/shell-success {:output (get r :out "")})
-        (result/shell-failure (get r :err ""))))
-    (catch Exception e
-      (result/shell-failure (.getMessage e)))))
+  (or
+   (validate-safe-branch-name branch)
+   (try
+     (let [r (process/shell
+              {:dir (str worktree-path) :out :string :err :string :continue true}
+              "git" "fetch" "origin" (str branch))]
+       (if (zero? (:exit r))
+         (result/shell-success {:output (get r :out "")})
+         (result/shell-failure (get r :err ""))))
+     (catch Exception e
+       (result/shell-failure (.getMessage e))))))
 
 (defn commits-ahead-of-base
   "Count commits HEAD has added since branching from origin/<base>.
@@ -270,19 +318,23 @@
       (result/shell-failure (.getMessage e) {:commit-sha nil}))))
 
 (defn push-branch!
-  "Push the current branch to origin.
+  "Push the current branch to origin. Injects `github-token` as GH_TOKEN so
+   gh's git credential helper authenticates the push with the pipeline's
+   credential.
 
    Returns {:success? bool :error string}"
-  [worktree-path branch-name]
-  (try
-    (let [r (process/shell
-             {:dir (str worktree-path) :out :string :err :string :continue true}
-             "git" "push" "-u" "origin" branch-name)]
-      (if (zero? (:exit r))
-        (result/shell-success {:output (get r :out "")})
-        (result/shell-failure (get r :err ""))))
-    (catch Exception e
-      (result/shell-failure (.getMessage e)))))
+  [worktree-path branch-name github-token]
+  (or
+   (validate-safe-branch-name branch-name)
+   (try
+     (let [r (process/shell
+              (gh-shell-opts worktree-path github-token)
+              "git" "push" "-u" "origin" branch-name)]
+       (if (zero? (:exit r))
+         (result/shell-success {:output (get r :out "")})
+         (result/shell-failure (get r :err ""))))
+     (catch Exception e
+       (result/shell-failure (.getMessage e))))))
 
 (defn write-file!
   "Write content to a relative path inside the worktree.
@@ -299,12 +351,13 @@
       (result/shell-failure (.getMessage e)))))
 
 (defn edit-pr-body!
-  "Update the body of an existing PR using gh CLI on the host.
+  "Update the body of an existing PR using gh CLI on the host. Injects
+   `github-token` as GH_TOKEN.
    Returns {:success? bool :output string :error string}."
-  [worktree-path pr-number body]
+  [worktree-path pr-number body github-token]
   (try
     (let [r (process/shell
-             {:dir (str worktree-path) :out :string :err :string :continue true}
+             (gh-shell-opts worktree-path github-token)
              "gh" "pr" "edit" (str pr-number) "--body" (or body ""))]
       (if (zero? (:exit r))
         (result/shell-success {:output (get r :out "")})
@@ -333,10 +386,10 @@
    release retry reuses it instead of opening a duplicate.
    Falls back to a failure carrying the original create error when the PR
    cannot be resolved via gh pr view."
-  [worktree-path]
+  [worktree-path github-token]
   (try
     (let [r (process/shell
-             {:dir (str worktree-path) :out :string :err :string :continue true}
+             (gh-shell-opts worktree-path github-token)
              "gh" "pr" "view" "--json" "url" "--jq" ".url")]
       (if-let [pr (and (zero? (:exit r))
                        (parse-pr-ref (get r :out "")))]
@@ -359,27 +412,29 @@
      `gh pr view` rather than opening a duplicate.
 
    Returns {:success? bool :pr-number int :pr-url string :error string}"
-  [worktree-path {:keys [title body base-branch]}]
-  (try
-    (let [base   (or base-branch "main")
-          result (process/shell
-                  {:dir (str worktree-path) :out :string :err :string :continue true}
-                  "gh" "pr" "create"
-                  "--title" title
-                  "--body"  (or body "")
-                  "--base"  base)]
-      (cond
-        (zero? (:exit result))
-        (if-let [pr (parse-pr-ref (get result :out ""))]
-          (result/shell-success pr)
-          (result/shell-failure (msg/t :pr/create-unconfirmed
-                                       {:output (str/trim (get result :out ""))})
-                                {:pr-url nil :pr-number nil}))
+  [worktree-path {:keys [title body base-branch]} github-token]
+  (let [base (or base-branch "main")]
+    (or
+     (validate-safe-branch-name base)
+     (try
+       (let [result (process/shell
+                     (gh-shell-opts worktree-path github-token)
+                     "gh" "pr" "create"
+                     "--title" title
+                     "--body"  (or body "")
+                     "--base"  base)]
+         (cond
+           (zero? (:exit result))
+           (if-let [pr (parse-pr-ref (get result :out ""))]
+             (result/shell-success pr)
+             (result/shell-failure (msg/t :pr/create-unconfirmed
+                                          {:output (str/trim (get result :out ""))})
+                                   {:pr-url nil :pr-number nil}))
 
-        (pr-already-exists? (get result :err ""))
-        (reuse-existing-pr! worktree-path)
+           (pr-already-exists? (get result :err ""))
+           (reuse-existing-pr! worktree-path github-token)
 
-        :else
-        (result/shell-failure (get result :err "") {:pr-url nil :pr-number nil})))
-    (catch Exception e
-      (result/shell-failure (.getMessage e) {:pr-url nil :pr-number nil}))))
+           :else
+           (result/shell-failure (get result :err "") {:pr-url nil :pr-number nil})))
+       (catch Exception e
+         (result/shell-failure (.getMessage e) {:pr-url nil :pr-number nil}))))))

--- a/components/release-executor/src/ai/miniforge/release_executor/git.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/git.clj
@@ -369,11 +369,23 @@
          (if https-url
            (do
              (exec! worktree-path ["git" "remote" "set-url" "origin" https-url])
-             (let [retry (raw-push! worktree-path branch-name github-token)]
-               ;; Restore the original remote URL so the token never persists
-               ;; in the worktree's git config.
-               (exec! worktree-path ["git" "remote" "set-url" "origin" remote-url])
-               retry))
+             (let [retry     (raw-push! worktree-path branch-name github-token)
+                   ;; Restore the original remote URL so the token never
+                   ;; persists in the worktree's git config.
+                   restore-r (exec! worktree-path
+                                    ["git" "remote" "set-url" "origin" remote-url])]
+               (if (result/succeeded? restore-r)
+                 retry
+                 ;; The restore failed — origin may still embed the token.
+                 ;; Fail loud (even if the push itself succeeded) with the
+                 ;; scrub command, rather than report a clean success while a
+                 ;; credential is persisted in git config.
+                 (result/shell-failure
+                  (str "Pushed via HTTPS token fallback but could not restore the "
+                       "origin remote URL; it may still embed the GitHub token. "
+                       "Scrub it: git remote set-url origin " remote-url ". "
+                       "Restore error: " (:error restore-r))
+                  {:push-succeeded? (result/succeeded? retry)}))))
            result))))))
 
 (defn force-push!

--- a/components/release-executor/src/ai/miniforge/release_executor/git.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/git.clj
@@ -17,9 +17,15 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.release-executor.git
-  "Git operations for the release executor.
-   Provides shell-based git and gh CLI operations."
+  "Git operations for the release executor — host-mode backend.
+
+   Provides shell-based git and gh CLI operations that run directly against
+   the host working tree (babashka.process). This is the counterpart to
+   sandbox.clj which routes operations through the DAG executor container.
+
+   Used when :host-mode? is true (local-dogfood / no executor supplied)."
   (:require
+   [ai.miniforge.release-executor.messages :as msg]
    [ai.miniforge.release-executor.result :as result]
    [babashka.process :as process]
    [clojure.string :as str]))
@@ -43,6 +49,25 @@
   {:available? true :authenticated? true :user user})
 
 ;------------------------------------------------------------------------------ Layer 1
+;; Generic command runner
+
+(defn exec!
+  "Run a shell command string in the worktree directory.
+   Returns {:success? bool :output string :error string}.
+   Used for ad-hoc git commands (git rev-parse, git add, git commit --amend, etc.)."
+  [worktree-path cmd]
+  (try
+    (let [r (process/shell
+             {:dir (str worktree-path) :out :string :err :string :continue true}
+             "sh" "-c" cmd)]
+      (if (zero? (:exit r))
+        (result/shell-success {:output (str/trim (get r :out ""))})
+        (result/shell-failure (str/trim (get r :err ""))
+                              {:output (str/trim (get r :out ""))})))
+    (catch Exception e
+      (result/shell-failure (.getMessage e)))))
+
+;------------------------------------------------------------------------------ Layer 1
 ;; Git operations
 
 (defn stage-files!
@@ -52,46 +77,44 @@
     (let [git-args (if (= file-paths :all)
                      ["git" "add" "."]
                      (into ["git" "add"] (map str file-paths)))
-          result (apply process/shell
-                        {:dir (str worktree-path)
-                         :out :string
-                         :err :string
-                         :continue true}
-                        git-args)]
-      (if (zero? (:exit result))
-        (result/shell-success {:output (:out result "")})
-        (result/shell-failure (:err result "") {:output (:out result "")})))
+          r (apply process/shell
+                   {:dir (str worktree-path)
+                    :out :string
+                    :err :string
+                    :continue true}
+                   git-args)]
+      (if (zero? (:exit r))
+        (result/shell-success {:output (get r :out "")})
+        (result/shell-failure (get r :err "") {:output (get r :out "")})))
     (catch Exception e
       (result/shell-failure (.getMessage e)))))
 
 (defn check-gh-auth!
-  "Check if gh CLI is available and authenticated.
+  "Check if gh CLI is available and authenticated on the host.
 
    Returns {:available? bool :authenticated? bool :user string :error string}"
   []
   (try
-    (let [which-result (process/shell
-                        {:out :string :err :string :continue true}
-                        "which" "gh")]
-      (if-not (zero? (:exit which-result))
+    (let [which-r (process/shell
+                   {:out :string :err :string :continue true}
+                   "which" "gh")]
+      (if-not (zero? (:exit which-r))
         (gh-unavailable "gh CLI not found. Install with: brew install gh")
-        (let [auth-result (process/shell
-                           {:out :string :err :string :continue true}
-                           "gh" "auth" "status")]
-          (if (zero? (:exit auth-result))
-            (let [output (:out auth-result "")
+        (let [auth-r (process/shell
+                      {:out :string :err :string :continue true}
+                      "gh" "auth" "status")]
+          (if (zero? (:exit auth-r))
+            (let [output (get auth-r :out "")
                   user-match (re-find #"Logged in to [^\s]+ account (\S+)" output)]
               (gh-authenticated (or (second user-match) "unknown")))
             (gh-available-unauthenticated
-             (str "gh not authenticated. Run: gh auth login\n" (:err auth-result)))))))
+             (str "gh not authenticated. Run: gh auth login\n" (get auth-r :err "")))))))
     (catch Exception e
       (gh-unavailable (.getMessage e)))))
 
 (defn create-branch!
-  "Create a new git branch for the release.
-
-   Branches from HEAD (not origin/main) so MCP-written files in the working
-   tree are preserved. The PR will target the default branch.
+  "Create a new git branch for the release, branching from HEAD so that
+   phase-boundary commits already on the task branch carry forward.
 
    Arguments:
    - worktree-path - Path to git worktree root
@@ -101,28 +124,58 @@
   [worktree-path branch-name]
   (try
     (let [dir-opts {:dir (str worktree-path) :out :string :err :string :continue true}
-          default-branch-result (process/shell dir-opts
-                                               "git" "symbolic-ref" "refs/remotes/origin/HEAD")
-          default-branch (if (zero? (:exit default-branch-result))
-                           (-> (:out default-branch-result)
+          default-branch-r (process/shell dir-opts
+                                          "git" "symbolic-ref" "refs/remotes/origin/HEAD")
+          default-branch (if (zero? (:exit default-branch-r))
+                           (-> (get default-branch-r :out "")
                                str/trim
                                (str/replace #"refs/remotes/origin/" ""))
                            "main")
-          ;; Branch from HEAD to preserve MCP-written files in the working tree
-          checkout-result (process/shell dir-opts
-                                         "git" "checkout" "-b" branch-name)]
-      (if (zero? (:exit checkout-result))
+          checkout-r (process/shell dir-opts
+                                    "git" "checkout" "-b" branch-name)]
+      (if (zero? (:exit checkout-r))
         (result/shell-success {:branch branch-name :base-branch default-branch})
-        ;; Retry with timestamp suffix if branch name already exists
-        (let [timestamped-name (str branch-name "-" (System/currentTimeMillis))
-              retry-result (process/shell dir-opts
-                                          "git" "checkout" "-b" timestamped-name)]
-          (if (zero? (:exit retry-result))
-            (result/shell-success {:branch timestamped-name :base-branch default-branch})
-            (result/shell-failure (str "Failed to create branch: " (:err retry-result))
+        (let [ts-name (str branch-name "-" (System/currentTimeMillis))
+              retry-r (process/shell dir-opts "git" "checkout" "-b" ts-name)]
+          (if (zero? (:exit retry-r))
+            (result/shell-success {:branch ts-name :base-branch default-branch})
+            (result/shell-failure (str "Failed to create branch: " (get retry-r :err ""))
                                   {:branch nil})))))
     (catch Exception e
       (result/shell-failure (.getMessage e) {:branch nil}))))
+
+(defn fetch-branch!
+  "Fetch origin/<branch> into the local worktree.
+
+   Used when a stacked-PR base is a parent task's branch: pulls it so later
+   `origin/<base>` range diffs and commits-ahead resolve on the host.
+   Returns a shell-result."
+  [worktree-path branch]
+  (try
+    (let [r (process/shell
+             {:dir (str worktree-path) :out :string :err :string :continue true}
+             "git" "fetch" "origin" (str branch))]
+      (if (zero? (:exit r))
+        (result/shell-success {:output (get r :out "")})
+        (result/shell-failure (get r :err ""))))
+    (catch Exception e
+      (result/shell-failure (.getMessage e)))))
+
+(defn commits-ahead-of-base
+  "Count commits HEAD has added since branching from origin/<base>.
+   Uses the three-dot merge-base form so concurrent movement of origin/<base>
+   does not shrink the count to zero. Returns nil on git failure."
+  [worktree-path base-branch]
+  (try
+    (let [r (process/shell
+             {:dir (str worktree-path) :out :string :err :string :continue true}
+             "git" "rev-list" "--count" "--right-only"
+             (str "origin/" base-branch "...HEAD"))]
+      (when (zero? (:exit r))
+        (try
+          (Long/parseLong (str/trim (get r :out "0")))
+          (catch NumberFormatException _ nil))))
+    (catch Exception _ nil)))
 
 (defn diff-stats
   "Get line-level diff stats for staged changes.
@@ -130,11 +183,32 @@
    Returns {:additions N :deletions N :files N} or nil on error."
   [worktree-path]
   (try
-    (let [result (process/shell
-                  {:dir (str worktree-path) :out :string :err :string :continue true}
-                  "git" "diff" "--cached" "--numstat")]
-      (when (zero? (:exit result))
-        (let [lines (str/split-lines (str/trim (:out result "")))
+    (let [r (process/shell
+             {:dir (str worktree-path) :out :string :err :string :continue true}
+             "git" "diff" "--cached" "--numstat")]
+      (when (zero? (:exit r))
+        (let [lines (str/split-lines (str/trim (get r :out "")))
+              parsed (keep (fn [line]
+                             (when-let [[_ adds dels] (re-matches #"(\d+)\t(\d+)\t.*" line)]
+                               {:additions (parse-long adds)
+                                :deletions (parse-long dels)}))
+                           lines)]
+          {:additions (reduce + 0 (map :additions parsed))
+           :deletions (reduce + 0 (map :deletions parsed))
+           :files (count parsed)})))
+    (catch Exception _ nil)))
+
+(defn diff-stats-range
+  "Get diff stats for the changes this branch introduced since branching from
+   origin/<base> — `git diff origin/<base>...HEAD --numstat` with the
+   three-dot form (merge-base diff). Mirrors sandbox/diff-stats-range."
+  [worktree-path base-branch]
+  (try
+    (let [r (process/shell
+             {:dir (str worktree-path) :out :string :err :string :continue true}
+             "git" "diff" (str "origin/" base-branch "...HEAD") "--numstat")]
+      (when (zero? (:exit r))
+        (let [lines (str/split-lines (str/trim (get r :out "")))
               parsed (keep (fn [line]
                              (when-let [[_ adds dels] (re-matches #"(\d+)\t(\d+)\t.*" line)]
                                {:additions (parse-long adds)
@@ -151,12 +225,27 @@
    Returns {:added N :removed N} or nil on error."
   [worktree-path]
   (try
-    (let [result (process/shell
-                  {:dir (str worktree-path) :out :string :err :string :continue true}
-                  "git" "diff" "--cached" "-U0")]
-      (when (zero? (:exit result))
-        (let [diff-text (:out result "")
-              added (count (re-seq #"(?m)^\+.*\(deftest " diff-text))
+    (let [r (process/shell
+             {:dir (str worktree-path) :out :string :err :string :continue true}
+             "git" "diff" "--cached" "-U0")]
+      (when (zero? (:exit r))
+        (let [diff-text (get r :out "")
+              added   (count (re-seq #"(?m)^\+.*\(deftest " diff-text))
+              removed (count (re-seq #"(?m)^-.*\(deftest " diff-text))]
+          {:added added :removed removed})))
+    (catch Exception _ nil)))
+
+(defn count-test-defs-range
+  "Count deftest forms added/removed in origin/<base>...HEAD (merge-base diff).
+   Mirrors sandbox/count-test-defs-range."
+  [worktree-path base-branch]
+  (try
+    (let [r (process/shell
+             {:dir (str worktree-path) :out :string :err :string :continue true}
+             "git" "diff" (str "origin/" base-branch "...HEAD") "-U0")]
+      (when (zero? (:exit r))
+        (let [diff-text (get r :out "")
+              added   (count (re-seq #"(?m)^\+.*\(deftest " diff-text))
               removed (count (re-seq #"(?m)^-.*\(deftest " diff-text))]
           {:added added :removed removed})))
     (catch Exception _ nil)))
@@ -167,16 +256,16 @@
    Returns {:success? bool :commit-sha string :error string}"
   [worktree-path commit-message]
   (try
-    (let [result (process/shell
-                  {:dir (str worktree-path) :out :string :err :string :continue true}
-                  "git" "commit" "-m" commit-message)]
-      (if (zero? (:exit result))
-        (let [sha-result (process/shell
-                          {:dir (str worktree-path) :out :string :err :string :continue true}
-                          "git" "rev-parse" "HEAD")]
-          (result/shell-success {:commit-sha (str/trim (:out sha-result ""))
-                                 :output (:out result)}))
-        (result/shell-failure (:err result) {:commit-sha nil})))
+    (let [commit-r (process/shell
+                    {:dir (str worktree-path) :out :string :err :string :continue true}
+                    "git" "commit" "-m" commit-message)]
+      (if (zero? (:exit commit-r))
+        (let [sha-r (process/shell
+                     {:dir (str worktree-path) :out :string :err :string :continue true}
+                     "git" "rev-parse" "HEAD")]
+          (result/shell-success {:commit-sha (str/trim (get sha-r :out ""))
+                                 :output (get commit-r :out "")}))
+        (result/shell-failure (get commit-r :err "") {:commit-sha nil})))
     (catch Exception e
       (result/shell-failure (.getMessage e) {:commit-sha nil}))))
 
@@ -186,34 +275,111 @@
    Returns {:success? bool :error string}"
   [worktree-path branch-name]
   (try
-    (let [result (process/shell
-                  {:dir (str worktree-path) :out :string :err :string :continue true}
-                  "git" "push" "-u" "origin" branch-name)]
-      (if (zero? (:exit result))
-        (result/shell-success {:output (:out result)})
-        (result/shell-failure (:err result))))
+    (let [r (process/shell
+             {:dir (str worktree-path) :out :string :err :string :continue true}
+             "git" "push" "-u" "origin" branch-name)]
+      (if (zero? (:exit r))
+        (result/shell-success {:output (get r :out "")})
+        (result/shell-failure (get r :err ""))))
     (catch Exception e
       (result/shell-failure (.getMessage e)))))
 
+(defn write-file!
+  "Write content to a relative path inside the worktree.
+   Creates parent directories as needed.
+   Returns {:success? bool :output string :error string}."
+  [worktree-path rel-path content]
+  (try
+    (let [file   (java.io.File. (str worktree-path) (str rel-path))
+          parent (.getParentFile file)]
+      (when parent (.mkdirs parent))
+      (spit file content)
+      (result/shell-success {:output (str rel-path)}))
+    (catch Exception e
+      (result/shell-failure (.getMessage e)))))
+
+(defn edit-pr-body!
+  "Update the body of an existing PR using gh CLI on the host.
+   Returns {:success? bool :output string :error string}."
+  [worktree-path pr-number body]
+  (try
+    (let [r (process/shell
+             {:dir (str worktree-path) :out :string :err :string :continue true}
+             "gh" "pr" "edit" (str pr-number) "--body" (or body ""))]
+      (if (zero? (:exit r))
+        (result/shell-success {:output (get r :out "")})
+        (result/shell-failure (get r :err ""))))
+    (catch Exception e
+      (result/shell-failure (.getMessage e)))))
+
+;------------------------------------------------------------------------------ Layer 1.5
+;; PR creation helpers (mirrors sandbox.clj equivalents)
+
+(defn- parse-pr-ref
+  "Parse a gh PR URL output into {:pr-url :pr-number}, or nil when the output
+   carries no /pull/<n> reference."
+  [output]
+  (let [url (str/trim (or output ""))]
+    (when-let [match (re-find #"/pull/(\d+)" url)]
+      {:pr-url url :pr-number (parse-long (second match))})))
+
+(defn- pr-already-exists?
+  "True when a gh error indicates a PR already exists for the current branch."
+  [error]
+  (boolean (some-> error str/lower-case (str/includes? "already exists"))))
+
+(defn- reuse-existing-pr!
+  "Resolve the PR already open for the current branch via gh pr view, so a
+   release retry reuses it instead of opening a duplicate.
+   Falls back to a failure carrying the original create error when the PR
+   cannot be resolved via gh pr view."
+  [worktree-path]
+  (try
+    (let [r (process/shell
+             {:dir (str worktree-path) :out :string :err :string :continue true}
+             "gh" "pr" "view" "--json" "url" "--jq" ".url")]
+      (if-let [pr (and (zero? (:exit r))
+                       (parse-pr-ref (get r :out "")))]
+        (result/shell-success pr)
+        (result/shell-failure (msg/t :pr/reuse-unresolved
+                                     {:error (or (not-empty (str/trim (get r :err "")))
+                                                 (not-empty (str/trim (get r :out "")))
+                                                 (msg/t :pr/reuse-no-url))})
+                              {:pr-url nil :pr-number nil})))
+    (catch Exception e
+      (result/shell-failure (.getMessage e) {:pr-url nil :pr-number nil}))))
+
 (defn create-pr!
-  "Create a pull request using gh CLI.
+  "Create a pull request using gh CLI on the host.
+
+   Two robustness guarantees matching sandbox/create-pr!:
+   - A `gh pr create` that exits 0 but prints no PR URL is a FAILURE — release
+     must never claim a PR it never opened.
+   - A branch that already has an open PR (retry/resume) reuses that PR via
+     `gh pr view` rather than opening a duplicate.
 
    Returns {:success? bool :pr-number int :pr-url string :error string}"
   [worktree-path {:keys [title body base-branch]}]
   (try
-    (let [base (or base-branch "main")
-          args ["gh" "pr" "create"
-                "--title" title
-                "--body" body
-                "--base" base]
-          result (apply process/shell
-                        {:dir (str worktree-path) :out :string :err :string :continue true}
-                        args)]
-      (if (zero? (:exit result))
-        (let [pr-url (str/trim (:out result ""))
-              pr-num (when-let [match (re-find #"/pull/(\d+)" pr-url)]
-                       (parse-long (second match)))]
-          (result/shell-success {:pr-url pr-url :pr-number pr-num}))
-        (result/shell-failure (:err result) {:pr-url nil :pr-number nil})))
+    (let [base   (or base-branch "main")
+          result (process/shell
+                  {:dir (str worktree-path) :out :string :err :string :continue true}
+                  "gh" "pr" "create"
+                  "--title" title
+                  "--body"  (or body "")
+                  "--base"  base)]
+      (cond
+        (zero? (:exit result))
+        (if-let [pr (parse-pr-ref (get result :out ""))]
+          (result/shell-success pr)
+          (result/shell-failure (msg/t :pr/create-unconfirmed
+                                       {:output (str/trim (get result :out ""))})
+                                {:pr-url nil :pr-number nil}))
+
+        (pr-already-exists? (get result :err ""))
+        (reuse-existing-pr! worktree-path)
+
+        :else
+        (result/shell-failure (get result :err "") {:pr-url nil :pr-number nil})))
     (catch Exception e
       (result/shell-failure (.getMessage e) {:pr-url nil :pr-number nil}))))

--- a/components/release-executor/src/ai/miniforge/release_executor/git.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/git.clj
@@ -410,10 +410,15 @@
    rather than reusing files/path-traversal-anomaly, which depends on this
    namespace (a git→files require would cycle)."
   [worktree-path ^java.io.File file]
-  (let [root   (.getCanonicalPath (java.io.File. (str worktree-path)))
-        target (.getCanonicalPath file)]
-    (or (= target root)
-        (str/starts-with? target (str root java.io.File/separator)))))
+  (try
+    (let [root   (.getCanonicalPath (java.io.File. (str worktree-path)))
+          target (.getCanonicalPath file)]
+      (or (= target root)
+          (str/starts-with? target (str root java.io.File/separator))))
+    ;; getCanonicalPath can throw on invalid paths / IO errors. The check
+    ;; runs before write-file!'s own try, so fail closed here (treat as
+    ;; escaping) — write-file! then returns a shell-failure, never throws.
+    (catch Exception _ false)))
 
 (defn write-file!
   "Write content to a path inside the worktree, creating parent dirs.

--- a/components/release-executor/src/ai/miniforge/release_executor/git.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/git.clj
@@ -323,24 +323,57 @@
     (catch Exception e
       (result/shell-failure (.getMessage e) {:commit-sha nil}))))
 
+(defn- ssh->https-with-token
+  "Convert an SSH or HTTPS git remote URL to HTTPS with token auth embedded,
+   or nil when conversion is not possible. Mirrors sandbox/ssh->https-with-token."
+  [remote-url token]
+  (when remote-url
+    (if-let [[_ host path] (re-matches #"git@([^:]+):(.+)" remote-url)]
+      (str "https://x-access-token:" token "@" host "/" path)
+      (when (str/starts-with? (str remote-url) "https://")
+        (str/replace remote-url #"https://" (str "https://x-access-token:" token "@"))))))
+
+(defn- raw-push!
+  "One `git push -u origin <branch>` with GH_TOKEN injected. Returns a
+   shell-result."
+  [worktree-path branch-name github-token]
+  (try
+    (let [r (process/shell
+             (gh-shell-opts worktree-path github-token)
+             "git" "push" "-u" "origin" branch-name)]
+      (if (zero? (:exit r))
+        (result/shell-success {:output (get r :out "")})
+        (result/shell-failure (get r :err ""))))
+    (catch Exception e
+      (result/shell-failure (.getMessage e)))))
+
 (defn push-branch!
-  "Push the current branch to origin. Injects `github-token` as GH_TOKEN so
-   gh's git credential helper authenticates the push with the pipeline's
-   credential.
+  "Push the current branch to origin. Injects `github-token` as GH_TOKEN for
+   gh's git credential helper. If the initial push fails and a token is
+   present, retries over HTTPS with the token embedded in a temporary origin
+   URL (restoring the original afterwards) — so a token-only environment
+   whose `origin` is an SSH remote can still push, matching
+   sandbox/push-branch!.
 
    Returns {:success? bool :error string}"
   [worktree-path branch-name github-token]
   (or
    (validate-safe-branch-name branch-name)
-   (try
-     (let [r (process/shell
-              (gh-shell-opts worktree-path github-token)
-              "git" "push" "-u" "origin" branch-name)]
-       (if (zero? (:exit r))
-         (result/shell-success {:output (get r :out "")})
-         (result/shell-failure (get r :err ""))))
-     (catch Exception e
-       (result/shell-failure (.getMessage e))))))
+   (let [result (raw-push! worktree-path branch-name github-token)]
+     (if (or (result/succeeded? result) (not github-token))
+       result
+       (let [url-r      (exec! worktree-path ["git" "remote" "get-url" "origin"])
+             remote-url (when (result/succeeded? url-r) (str/trim (get url-r :output "")))
+             https-url  (ssh->https-with-token remote-url github-token)]
+         (if https-url
+           (do
+             (exec! worktree-path ["git" "remote" "set-url" "origin" https-url])
+             (let [retry (raw-push! worktree-path branch-name github-token)]
+               ;; Restore the original remote URL so the token never persists
+               ;; in the worktree's git config.
+               (exec! worktree-path ["git" "remote" "set-url" "origin" remote-url])
+               retry))
+           result))))))
 
 (defn force-push!
   "Force-push the current branch with --force-with-lease, injecting

--- a/components/release-executor/test/ai/miniforge/release_executor/git_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/git_test.clj
@@ -137,6 +137,29 @@
         (git/force-push! "/tmp/wt" "push-tok"))
       (is (= "push-tok" (get-in @seen [:extra-env "GH_TOKEN"]))))))
 
+;;-------------------------------------------- path traversal + base safety
+(deftest write-file-path-traversal-test
+  (let [dir (fs/create-temp-dir {:prefix "git-host-mode-wf-"})]
+    (try
+      (testing "write-file! writes a normal relative path"
+        (is (:success? (git/write-file! dir "docs/pull-requests/p.md" "hi\n")))
+        (is (= "hi\n" (slurp (str (fs/path dir "docs/pull-requests/p.md"))))))
+      (testing "write-file! rejects a ../ escape and writes nothing outside root"
+        (let [r (git/write-file! dir "../escape.md" "nope")]
+          (is (not (:success? r)))
+          (is (not (fs/exists? (fs/path (fs/parent dir) "escape.md"))))))
+      (finally (fs/delete-tree dir)))))
+
+(deftest range-fns-reject-unsafe-base-test
+  (let [dir (fs/create-temp-dir {:prefix "git-host-mode-range-"})]
+    (try
+      (init-repo! dir)
+      (testing "range/ahead functions return nil for an unsafe base (no git call)"
+        (is (nil? (git/diff-stats-range dir "-x")))
+        (is (nil? (git/count-test-defs-range dir "--upload-pack=evil")))
+        (is (nil? (git/commits-ahead-of-base dir "a;rm -rf /"))))
+      (finally (fs/delete-tree dir)))))
+
 ;;------------------------------------------- core host-mode dispatch
 (deftest step-validate-inputs-host-mode-test
   (testing "no executor + no environment-id + worktree present → :host-mode? true"

--- a/components/release-executor/test/ai/miniforge/release_executor/git_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/git_test.clj
@@ -226,4 +226,8 @@
       (is (not (:host-mode? r)))
       (is (not (core/failed? r)))))
   (testing ":create-pr? true with neither executor nor worktree still fails"
-    (is (core/failed? (core/step-validate-inputs {:create-pr? true})))))
+    (is (core/failed? (core/step-validate-inputs {:create-pr? true}))))
+  (testing "a blank :worktree-path is not host-mode (babashka :dir \"\" = cwd)"
+    (let [r (core/step-validate-inputs {:worktree-path "  " :create-pr? true})]
+      (is (not (:host-mode? r)))
+      (is (core/failed? r)))))

--- a/components/release-executor/test/ai/miniforge/release_executor/git_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/git_test.clj
@@ -35,8 +35,9 @@
          args))
 
 (defn- init-repo!
-  "Initialise a throwaway git repo with one seed commit and a fake origin
-   remote so origin-relative commands have something to resolve."
+  "Initialise a throwaway git repo with one seed commit. No `origin` remote
+   is added, so origin-relative host-mode calls (create-branch!'s best-effort
+   fetch) degrade gracefully — which is itself part of what these tests cover."
   [dir]
   (sh! dir "git" "init" "-q")
   (sh! dir "git" "config" "user.email" "test@example.com")

--- a/components/release-executor/test/ai/miniforge/release_executor/git_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/git_test.clj
@@ -64,7 +64,7 @@
     (try
       (init-repo! dir)
       (testing "exec! runs a command in the worktree"
-        (is (:success? (git/exec! dir "git rev-parse --is-inside-work-tree"))))
+        (is (:success? (git/exec! dir ["git" "rev-parse" "--is-inside-work-tree"]))))
       (testing "write-file! + stage-files! + commit-changes! round-trip"
         (is (:success? (git/write-file! dir "src/a.clj" "(ns a)\n")))
         (is (:success? (git/stage-files! dir :all)))
@@ -88,7 +88,7 @@
           (is (:success? r))
           (is (= "release/x" (:branch r)))
           (is (= "release/x"
-                 (:output (git/exec! dir "git rev-parse --abbrev-ref HEAD"))))))
+                 (:output (git/exec! dir ["git" "rev-parse" "--abbrev-ref" "HEAD"]))))))
       (testing "create-branch! rejects an option-injection name before any git call"
         (let [r (git/create-branch! dir "-rf")]
           (is (not (:success? r)))))
@@ -126,6 +126,15 @@
         (git/check-gh-auth! "tok-123"))
       (let [auth (first (filter #(= "gh" (first (:args %))) @calls))]
         (is (= "tok-123" (get-in auth [:opts :extra-env "GH_TOKEN"])))))))
+
+(deftest force-push-injects-token-test
+  (testing "force-push! passes GH_TOKEN via :extra-env"
+    (let [seen (atom nil)]
+      (with-redefs [process/shell (fn [opts & _]
+                                    (reset! seen opts)
+                                    {:exit 0 :out "" :err ""})]
+        (git/force-push! "/tmp/wt" "push-tok"))
+      (is (= "push-tok" (get-in @seen [:extra-env "GH_TOKEN"]))))))
 
 ;;------------------------------------------- core host-mode dispatch
 (deftest step-validate-inputs-host-mode-test

--- a/components/release-executor/test/ai/miniforge/release_executor/git_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/git_test.clj
@@ -160,6 +160,33 @@
         (is (nil? (git/commits-ahead-of-base dir "a;rm -rf /"))))
       (finally (fs/delete-tree dir)))))
 
+;;-------------------------------------------- push SSH→HTTPS fallback
+(deftest push-branch-https-fallback-test
+  (testing "push fails with a token → rewrite SSH origin to https-with-token, retry, restore"
+    (let [calls   (atom [])
+          push-n  (atom 0)]
+      (with-redefs [process/shell
+                    (fn [_opts & args]
+                      (let [a (vec args)]
+                        (swap! calls conj a)
+                        (cond
+                          (= "push" (second a))
+                          (do (swap! push-n inc)
+                              (if (= 1 @push-n)
+                                {:exit 1 :out "" :err "ssh: permission denied (publickey)"}
+                                {:exit 0 :out "pushed" :err ""}))
+                          (= ["git" "remote" "get-url" "origin"] a)
+                          {:exit 0 :out "git@github.com:o/r.git" :err ""}
+                          :else {:exit 0 :out "" :err ""})))]
+        (let [r        (git/push-branch! "/tmp/wt" "b" "tok")
+              set-urls (filter #(= ["git" "remote" "set-url"] (vec (take 3 %))) @calls)]
+          (is (:success? r) "second push over https succeeds")
+          (is (= 2 (count set-urls)) "origin is set to https-with-token then restored")
+          (is (re-find #"x-access-token:tok@github\.com/o/r\.git" (str (last (first set-urls))))
+              "temporary origin embeds the token over https")
+          (is (= "git@github.com:o/r.git" (last (second set-urls)))
+              "original ssh origin is restored"))))))
+
 ;;------------------------------------------- core host-mode dispatch
 (deftest step-validate-inputs-host-mode-test
   (testing "no executor + no environment-id + worktree present → :host-mode? true"

--- a/components/release-executor/test/ai/miniforge/release_executor/git_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/git_test.clj
@@ -187,6 +187,31 @@
           (is (= "git@github.com:o/r.git" (last (second set-urls)))
               "original ssh origin is restored"))))))
 
+(deftest push-branch-restore-failure-fails-loud-test
+  (testing "restore of origin failing after the https fallback fails loud with a scrub hint"
+    (let [push-n (atom 0) seturl-n (atom 0)]
+      (with-redefs [process/shell
+                    (fn [_opts & args]
+                      (let [a (vec args)]
+                        (cond
+                          (= "push" (second a))
+                          (do (swap! push-n inc)
+                              (if (= 1 @push-n)
+                                {:exit 1 :out "" :err "ssh: denied"}
+                                {:exit 0 :out "ok" :err ""}))
+                          (= ["git" "remote" "get-url" "origin"] a)
+                          {:exit 0 :out "git@github.com:o/r.git" :err ""}
+                          (= ["git" "remote" "set-url"] (vec (take 3 a)))
+                          (do (swap! seturl-n inc)
+                              (if (= 1 @seturl-n)
+                                {:exit 0 :out "" :err ""}          ; set to https ok
+                                {:exit 1 :out "" :err "config locked"})) ; restore fails
+                          :else {:exit 0 :out "" :err ""})))]
+        (let [r (git/push-branch! "/tmp/wt" "b" "tok")]
+          (is (not (:success? r)) "restore failure makes the overall result a failure")
+          (is (re-find #"Scrub it" (:error r)) "surfaces the scrub command")
+          (is (true? (:push-succeeded? r)) "records that the push itself succeeded"))))))
+
 ;;------------------------------------------- core host-mode dispatch
 (deftest step-validate-inputs-host-mode-test
   (testing "no executor + no environment-id + worktree present → :host-mode? true"

--- a/components/release-executor/test/ai/miniforge/release_executor/git_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/git_test.clj
@@ -1,0 +1,144 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.release-executor.git-test
+  "Tests for the host-mode (no-executor) git/gh backend used when a local
+   `bb dogfood` run has no DAG executor. Covers branch-name safety, the
+   real-git stage/commit/branch/diff round-trip, GH_TOKEN injection, and the
+   core step-validate-inputs host-mode dispatch."
+  (:require
+   [babashka.fs :as fs]
+   [babashka.process :as process]
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.release-executor.core :as core]
+   [ai.miniforge.release-executor.git :as git]))
+
+;;------------------------------------------------------------------- helpers
+(defn- sh! [dir & args]
+  (apply process/shell
+         {:dir (str dir) :out :string :err :string :continue true}
+         args))
+
+(defn- init-repo!
+  "Initialise a throwaway git repo with one seed commit and a fake origin
+   remote so origin-relative commands have something to resolve."
+  [dir]
+  (sh! dir "git" "init" "-q")
+  (sh! dir "git" "config" "user.email" "test@example.com")
+  (sh! dir "git" "config" "user.name" "Test")
+  (sh! dir "git" "config" "commit.gpgsign" "false")
+  (spit (str (fs/path dir "README.md")) "seed\n")
+  (sh! dir "git" "add" ".")
+  (sh! dir "git" "commit" "-q" "-m" "seed"))
+
+;;------------------------------------------------------ branch-name safety
+(deftest validate-safe-branch-name-test
+  (testing "git-legal names are accepted (nil result)"
+    (is (nil? (git/validate-safe-branch-name "main")))
+    (is (nil? (git/validate-safe-branch-name "release/task-99c14ec5")))
+    (is (nil? (git/validate-safe-branch-name "feature_1.2.3"))))
+  (testing "blank / option-flag / metacharacter names are rejected"
+    (doseq [bad ["" "-rf" "--force" "a b" "a;rm -rf /" "$(whoami)" "a`b`"]]
+      (let [r (git/validate-safe-branch-name bad)]
+        (is (and (map? r) (not (:success? r)))
+            (str "expected failure for branch name: " (pr-str bad)))))))
+
+;;-------------------------------------------------- real-git round-trip
+(deftest stage-commit-diff-roundtrip-test
+  (let [dir (fs/create-temp-dir {:prefix "git-host-mode-"})]
+    (try
+      (init-repo! dir)
+      (testing "exec! runs a command in the worktree"
+        (is (:success? (git/exec! dir "git rev-parse --is-inside-work-tree"))))
+      (testing "write-file! + stage-files! + commit-changes! round-trip"
+        (is (:success? (git/write-file! dir "src/a.clj" "(ns a)\n")))
+        (is (:success? (git/stage-files! dir :all)))
+        (let [c (git/commit-changes! dir "add a")]
+          (is (:success? c))
+          (is (re-matches #"[0-9a-f]{7,40}" (:commit-sha c)))))
+      (testing "diff-stats counts staged additions"
+        (is (:success? (git/write-file! dir "src/b.clj" "(ns b)\n(def x 1)\n")))
+        (is (:success? (git/stage-files! dir :all)))
+        (let [s (git/diff-stats dir)]
+          (is (= 1 (:files s)))
+          (is (pos? (:additions s)))))
+      (finally (fs/delete-tree dir)))))
+
+(deftest create-branch-test
+  (let [dir (fs/create-temp-dir {:prefix "git-host-mode-branch-"})]
+    (try
+      (init-repo! dir)
+      (testing "create-branch! creates and checks out the branch"
+        (let [r (git/create-branch! dir "release/x")]
+          (is (:success? r))
+          (is (= "release/x" (:branch r)))
+          (is (= "release/x"
+                 (:output (git/exec! dir "git rev-parse --abbrev-ref HEAD"))))))
+      (testing "create-branch! rejects an option-injection name before any git call"
+        (let [r (git/create-branch! dir "-rf")]
+          (is (not (:success? r)))))
+      (finally (fs/delete-tree dir)))))
+
+;;-------------------------------------------- GH_TOKEN injection (parity)
+(deftest gh-token-injection-test
+  (testing "create-pr! injects GH_TOKEN via :extra-env when a token is present"
+    (let [seen (atom nil)]
+      (with-redefs [process/shell (fn [opts & _]
+                                    (reset! seen opts)
+                                    {:exit 0 :out "https://github.com/o/r/pull/7" :err ""})]
+        (git/create-pr! "/tmp/wt" {:title "t" :body "b" :base-branch "main"} "sekret"))
+      (is (= "sekret" (get-in @seen [:extra-env "GH_TOKEN"])))))
+  (testing "create-pr! omits :extra-env when no token (inherits ambient env)"
+    (let [seen (atom :unset)]
+      (with-redefs [process/shell (fn [opts & _]
+                                    (reset! seen opts)
+                                    {:exit 0 :out "https://github.com/o/r/pull/7" :err ""})]
+        (git/create-pr! "/tmp/wt" {:title "t" :body "b" :base-branch "main"} nil))
+      (is (nil? (:extra-env @seen)))))
+  (testing "create-pr! rejects an unsafe base branch without shelling out"
+    (let [called (atom false)]
+      (with-redefs [process/shell (fn [& _] (reset! called true) {:exit 0 :out "" :err ""})]
+        (let [r (git/create-pr! "/tmp/wt" {:title "t" :body "b" :base-branch "-x"} "tok")]
+          (is (not (:success? r)))
+          (is (false? @called) "no gh process is spawned for an unsafe base")))))
+  (testing "check-gh-auth! injects GH_TOKEN on the auth-status call"
+    (let [calls (atom [])]
+      (with-redefs [process/shell (fn [opts & args]
+                                    (swap! calls conj {:opts opts :args (vec args)})
+                                    (if (= "which" (first args))
+                                      {:exit 0 :out "/usr/bin/gh" :err ""}
+                                      {:exit 0 :out "Logged in to github.com account me (X)" :err ""}))]
+        (git/check-gh-auth! "tok-123"))
+      (let [auth (first (filter #(= "gh" (first (:args %))) @calls))]
+        (is (= "tok-123" (get-in auth [:opts :extra-env "GH_TOKEN"])))))))
+
+;;------------------------------------------- core host-mode dispatch
+(deftest step-validate-inputs-host-mode-test
+  (testing "no executor + no environment-id + worktree present → :host-mode? true"
+    (let [r (core/step-validate-inputs {:worktree-path "/tmp/wt" :create-pr? true})]
+      (is (:host-mode? r))
+      (is (not (core/failed? r)))))
+  (testing "sandbox inputs (executor + env-id) do not set :host-mode?"
+    (let [r (core/step-validate-inputs {:worktree-path "/tmp/wt"
+                                        :executor :some-executor
+                                        :environment-id "env-1"
+                                        :create-pr? true})]
+      (is (not (:host-mode? r)))
+      (is (not (core/failed? r)))))
+  (testing ":create-pr? true with neither executor nor worktree still fails"
+    (is (core/failed? (core/step-validate-inputs {:create-pr? true})))))


### PR DESCRIPTION
## What

Spec: **release-opens-real-pr** (dogfood-resilience blocker). A fully successful local `bb dogfood` run reached `:release` and produced only a `docs/pull-requests/*.md` file plus a checkpoint bundle — no GitHub PR — so the dogfood loop dead-ended at a doc.

## Root cause

The release-executor pipeline routed every git/gh operation through `sandbox/*` → `dag/executor-execute!`, which requires a live DAG executor (the Docker/sandbox path). A local dogfood run supplies **no executor**, so `step-create-pr` could never reach `gh`.

## Fix — one pipeline, two backends

- `step-validate-inputs` accepts a state with no `:executor`/`:environment-id` but a `:worktree-path` as `:host-mode? true` (and still fails when `:create-pr?` is true with neither an executor nor a worktree).
- Every step that called `sandbox/*` now dispatches on `:host-mode?` — `git/*` (babashka.process against the host worktree) when true, `sandbox/*` otherwise. Steps covered: `step-check-gh-auth`, `step-create-branch`, `step-stage-dirty-files`, `step-validate-diff`, `step-commit`, `step-push`, `step-create-pr`, `step-generate-pr-doc`, `step-update-pr-body`.
- `git.clj` gains the host-mode backend: `exec!`, `check-gh-auth!`, `create-branch!`, `fetch-branch!`, `commits-ahead-of-base`, `diff-stats`/`-range`, `count-test-defs-range`, stage/commit/push, `create-pr!` (with the ported `parse-pr-ref` / `pr-already-exists?` / `reuse-existing-pr!` duplicate-PR guard), and `edit-pr-body!`.

Not a second PR path — the same steps, same state threading, same fail-loud propagation. Honors `:create-pr?` (doc-only when false).

## Provenance

Implemented by the dogfood run on this spec (workflow `b04b65e4`, worktree `task-99c14ec5`); explore/plan/implement and the syntax/lint/tests/coverage gates passed. Extracted to this branch for review.

## Follow-up in this PR

Host-mode unit tests for `git.clj` mirroring `sandbox_test.clj` (the dogfood run's own verify phase was blocked by an unrelated policy-verify infra bug before it could add them; adding here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)