### PR TITLE
fix(release): host-mode force-push! SSH→HTTPS token fallback (follow-up to #1456)

### DIFF
--- a/components/release-executor/resources/config/release-executor/messages/en-US.edn
+++ b/components/release-executor/resources/config/release-executor/messages/en-US.edn
@@ -22,6 +22,12 @@
   :pr/reuse-unresolved "A PR already exists for this branch but could not be resolved via gh pr view: {error}"
   :pr/reuse-no-url "gh pr view returned no PR URL"
 
+  ;; push HTTPS+token fallback
+  :push/https-fallback-restore-failed
+  "Pushed via HTTPS token fallback but could not restore the origin remote URL; it may still embed the GitHub token. Scrub it: git remote set-url origin {remote-url}. Restore error: {restore-error}"
+  :push/https-fallback-push-and-restore-failed
+  "HTTPS token-fallback push failed and the origin remote URL could not be restored; it may still embed the GitHub token. Scrub it: git remote set-url origin {remote-url}. Push error: {push-error}. Restore error: {restore-error}"
+
   ;; pipeline steps
   :step/metadata-generation-failed "Releaser agent failed to generate release metadata"
   :step/no-files-to-stage "No modified files in executor environment to stage for release"

--- a/components/release-executor/src/ai/miniforge/release_executor/git.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/git.clj
@@ -379,15 +379,22 @@
               (if (result/succeeded? restore-r)
                 retry
                 ;; The restore failed — origin may still embed the token.
-                ;; Fail loud (even if the push itself succeeded) with the
+                ;; Fail loud (even when the push itself succeeded) with the
                 ;; scrub command, rather than report a clean success while a
-                ;; credential is persisted in git config.
-                (result/shell-failure
-                 (str "Pushed via HTTPS token fallback but could not restore the "
-                      "origin remote URL; it may still embed the GitHub token. "
-                      "Scrub it: git remote set-url origin " remote-url ". "
-                      "Restore error: " (:error restore-r))
-                 {:push-succeeded? (result/succeeded? retry)}))))
+                ;; credential is persisted in git config. When the retry push
+                ;; also failed, carry its error too so the root cause isn't
+                ;; lost.
+                (let [pushed? (result/succeeded? retry)]
+                  (result/shell-failure
+                   (if pushed?
+                     (msg/t :push/https-fallback-restore-failed
+                            {:remote-url    remote-url
+                             :restore-error (:error restore-r)})
+                     (msg/t :push/https-fallback-push-and-restore-failed
+                            {:remote-url    remote-url
+                             :push-error    (:error retry)
+                             :restore-error (:error restore-r)}))
+                   {:push-succeeded? pushed?})))))
           result)))))
 
 (defn- raw-force-push!

--- a/components/release-executor/src/ai/miniforge/release_executor/git.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/git.clj
@@ -351,6 +351,59 @@
     (catch Exception e
       (result/shell-failure (.getMessage e)))))
 
+(defn- with-https-token-fallback!
+  "Run `push!` (a 0-arg thunk returning a shell-result). On failure with a
+   token present, retry once over HTTPS+token auth: rewrite origin to an https
+   URL embedding the token, re-run `push!`, then restore the original URL so
+   the token never persists in git config. If the restore itself fails, fail
+   loud — even when the push succeeded — with the scrub command and
+   :push-succeeded?, rather than report a clean success while a credential
+   lingers in git config. Covers an SSH `origin` that GH_TOKEN alone can't
+   authenticate. Shared by push-branch! and force-push!; mirrors
+   sandbox/push-branch!."
+  [worktree-path github-token push!]
+  (let [result (push!)]
+    (if (or (result/succeeded? result) (not github-token))
+      result
+      (let [url-r      (exec! worktree-path ["git" "remote" "get-url" "origin"])
+            remote-url (when (result/succeeded? url-r) (str/trim (get url-r :output "")))
+            https-url  (ssh->https-with-token remote-url github-token)]
+        (if https-url
+          (do
+            (exec! worktree-path ["git" "remote" "set-url" "origin" https-url])
+            (let [retry     (push!)
+                  ;; Restore the original remote URL so the token never
+                  ;; persists in the worktree's git config.
+                  restore-r (exec! worktree-path
+                                   ["git" "remote" "set-url" "origin" remote-url])]
+              (if (result/succeeded? restore-r)
+                retry
+                ;; The restore failed — origin may still embed the token.
+                ;; Fail loud (even if the push itself succeeded) with the
+                ;; scrub command, rather than report a clean success while a
+                ;; credential is persisted in git config.
+                (result/shell-failure
+                 (str "Pushed via HTTPS token fallback but could not restore the "
+                      "origin remote URL; it may still embed the GitHub token. "
+                      "Scrub it: git remote set-url origin " remote-url ". "
+                      "Restore error: " (:error restore-r))
+                 {:push-succeeded? (result/succeeded? retry)}))))
+          result)))))
+
+(defn- raw-force-push!
+  "One `git push --force-with-lease` with GH_TOKEN injected. Returns a
+   shell-result."
+  [worktree-path github-token]
+  (try
+    (let [r (process/shell
+             (gh-shell-opts worktree-path github-token)
+             "git" "push" "--force-with-lease")]
+      (if (zero? (:exit r))
+        (result/shell-success {:output (get r :out "")})
+        (result/shell-failure (get r :err ""))))
+    (catch Exception e
+      (result/shell-failure (.getMessage e)))))
+
 (defn push-branch!
   "Push the current branch to origin. Injects `github-token` as GH_TOKEN for
    gh's git credential helper. If the initial push fails and a token is
@@ -368,49 +421,22 @@
   ([worktree-path branch-name github-token]
    (or
     (validate-safe-branch-name branch-name)
-    (let [result (raw-push! worktree-path branch-name github-token)]
-      (if (or (result/succeeded? result) (not github-token))
-        result
-        (let [url-r      (exec! worktree-path ["git" "remote" "get-url" "origin"])
-              remote-url (when (result/succeeded? url-r) (str/trim (get url-r :output "")))
-              https-url  (ssh->https-with-token remote-url github-token)]
-          (if https-url
-            (do
-              (exec! worktree-path ["git" "remote" "set-url" "origin" https-url])
-              (let [retry     (raw-push! worktree-path branch-name github-token)
-                    ;; Restore the original remote URL so the token never
-                    ;; persists in the worktree's git config.
-                    restore-r (exec! worktree-path
-                                     ["git" "remote" "set-url" "origin" remote-url])]
-                (if (result/succeeded? restore-r)
-                  retry
-                  ;; The restore failed — origin may still embed the token.
-                  ;; Fail loud (even if the push itself succeeded) with the
-                  ;; scrub command, rather than report a clean success while a
-                  ;; credential is persisted in git config.
-                  (result/shell-failure
-                   (str "Pushed via HTTPS token fallback but could not restore the "
-                        "origin remote URL; it may still embed the GitHub token. "
-                        "Scrub it: git remote set-url origin " remote-url ". "
-                        "Restore error: " (:error restore-r))
-                   {:push-succeeded? (result/succeeded? retry)}))))
-            result)))))))
+    (with-https-token-fallback!
+     worktree-path github-token
+     #(raw-push! worktree-path branch-name github-token)))))
 
 (defn force-push!
   "Force-push the current branch with --force-with-lease, injecting
    `github-token` as GH_TOKEN so gh's git credential helper authenticates
-   with the pipeline credential (the PR-doc amend path uses this). Returns a
-   shell-result."
+   with the pipeline credential (the PR-doc amend path uses this). If the push
+   fails and a token is present, retries over HTTPS + token auth via the same
+   with-https-token-fallback! that push-branch! uses — an SSH `origin` can't be
+   authenticated by GH_TOKEN alone, so without this the PR-doc amend push would
+   fail in a token-only local run. Returns a shell-result."
   [worktree-path github-token]
-  (try
-    (let [r (process/shell
-             (gh-shell-opts worktree-path github-token)
-             "git" "push" "--force-with-lease")]
-      (if (zero? (:exit r))
-        (result/shell-success {:output (get r :out "")})
-        (result/shell-failure (get r :err ""))))
-    (catch Exception e
-      (result/shell-failure (.getMessage e)))))
+  (with-https-token-fallback!
+   worktree-path github-token
+   #(raw-force-push! worktree-path github-token)))
 
 (defn- inside-worktree?
   "True when `file` resolves inside `worktree-path` after canonicalization

--- a/components/release-executor/test/ai/miniforge/release_executor/git_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/git_test.clj
@@ -212,6 +212,59 @@
           (is (re-find #"Scrub it" (:error r)) "surfaces the scrub command")
           (is (true? (:push-succeeded? r)) "records that the push itself succeeded"))))))
 
+;;-------------------------------------------- force-push shares the fallback
+(deftest force-push-https-fallback-test
+  (testing "force-push over SSH fails with a token → rewrite to https-with-token, retry, restore"
+    (let [calls  (atom [])
+          push-n (atom 0)]
+      (with-redefs [process/shell
+                    (fn [_opts & args]
+                      (let [a (vec args)]
+                        (swap! calls conj a)
+                        (cond
+                          (= "push" (second a))
+                          (do (swap! push-n inc)
+                              (if (= 1 @push-n)
+                                {:exit 1 :out "" :err "ssh: permission denied (publickey)"}
+                                {:exit 0 :out "pushed" :err ""}))
+                          (= ["git" "remote" "get-url" "origin"] a)
+                          {:exit 0 :out "git@github.com:o/r.git" :err ""}
+                          :else {:exit 0 :out "" :err ""})))]
+        (let [r        (git/force-push! "/tmp/wt" "tok")
+              set-urls (filter #(= ["git" "remote" "set-url"] (vec (take 3 %))) @calls)]
+          (is (:success? r) "second force-push over https succeeds")
+          (is (= 2 @push-n) "force-push retried once after the SSH failure")
+          (is (= 2 (count set-urls)) "origin is set to https-with-token then restored")
+          (is (re-find #"x-access-token:tok@github\.com/o/r\.git" (str (last (first set-urls))))
+              "temporary origin embeds the token over https")
+          (is (= "git@github.com:o/r.git" (last (second set-urls)))
+              "original ssh origin is restored"))))))
+
+(deftest force-push-restore-failure-fails-loud-test
+  (testing "force-push restore failure after the https fallback fails loud with a scrub hint"
+    (let [push-n (atom 0) seturl-n (atom 0)]
+      (with-redefs [process/shell
+                    (fn [_opts & args]
+                      (let [a (vec args)]
+                        (cond
+                          (= "push" (second a))
+                          (do (swap! push-n inc)
+                              (if (= 1 @push-n)
+                                {:exit 1 :out "" :err "ssh: denied"}
+                                {:exit 0 :out "ok" :err ""}))
+                          (= ["git" "remote" "get-url" "origin"] a)
+                          {:exit 0 :out "git@github.com:o/r.git" :err ""}
+                          (= ["git" "remote" "set-url"] (vec (take 3 a)))
+                          (do (swap! seturl-n inc)
+                              (if (= 1 @seturl-n)
+                                {:exit 0 :out "" :err ""}
+                                {:exit 1 :out "" :err "config locked"}))
+                          :else {:exit 0 :out "" :err ""})))]
+        (let [r (git/force-push! "/tmp/wt" "tok")]
+          (is (not (:success? r)) "restore failure makes the overall result a failure")
+          (is (re-find #"Scrub it" (:error r)) "surfaces the scrub command")
+          (is (true? (:push-succeeded? r)) "records that the push itself succeeded"))))))
+
 ;;------------------------------------------- core host-mode dispatch
 (deftest step-validate-inputs-host-mode-test
   (testing "no executor + no environment-id + worktree present → :host-mode? true"

--- a/components/release-executor/test/ai/miniforge/release_executor/git_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/git_test.clj
@@ -265,6 +265,33 @@
           (is (re-find #"Scrub it" (:error r)) "surfaces the scrub command")
           (is (true? (:push-succeeded? r)) "records that the push itself succeeded"))))))
 
+(deftest force-push-push-and-restore-both-fail-test
+  (testing "https retry push AND restore both fail → error carries both, push-succeeded? false"
+    (let [push-n (atom 0) seturl-n (atom 0)]
+      (with-redefs [process/shell
+                    (fn [_opts & args]
+                      (let [a (vec args)]
+                        (cond
+                          (= "push" (second a))
+                          (do (swap! push-n inc)
+                              (if (= 1 @push-n)
+                                {:exit 1 :out "" :err "ssh: denied"}
+                                {:exit 128 :out "" :err "remote rejected https"}))
+                          (= ["git" "remote" "get-url" "origin"] a)
+                          {:exit 0 :out "git@github.com:o/r.git" :err ""}
+                          (= ["git" "remote" "set-url"] (vec (take 3 a)))
+                          (do (swap! seturl-n inc)
+                              (if (= 1 @seturl-n)
+                                {:exit 0 :out "" :err ""}
+                                {:exit 1 :out "" :err "config locked"}))
+                          :else {:exit 0 :out "" :err ""})))]
+        (let [r (git/force-push! "/tmp/wt" "tok")]
+          (is (not (:success? r)))
+          (is (false? (:push-succeeded? r)) "records that the retry push also failed")
+          (is (re-find #"remote rejected https" (:error r)) "includes the retry push error")
+          (is (re-find #"config locked" (:error r)) "includes the restore error")
+          (is (re-find #"Scrub it" (:error r)) "still surfaces the scrub command"))))))
+
 ;;------------------------------------------- core host-mode dispatch
 (deftest step-validate-inputs-host-mode-test
   (testing "no executor + no environment-id + worktree present → :host-mode? true"


### PR DESCRIPTION
## What

Follow-up to #1456 (merged). That PR gave host-mode `push-branch!` an SSH→HTTPS+token push fallback and a fail-loud-on-restore-failure guard, but `force-push!` — the PR-doc amend path in `step-generate-pr-doc` — kept the plain body and still has the identical gap.

## Why it matters

`GH_TOKEN` injection alone can't authenticate an SSH `origin` (`git@github.com:…`) — `git push` still uses SSH keys. In a token-only local (no-executor) run whose origin is an SSH remote:

- `push-branch!` succeeds via the fallback (and restores origin to SSH), so the PR opens.
- The subsequent PR-doc amend `force-push!` then hits SSH with no fallback and fails. The graceful-degradation path (from #1456) prevents a crash, but the PR-doc silently isn't published — the release output the feature exists to produce.

## Fix

Extract the fallback (including the restore-failure fail-loud path) into one private `with-https-token-fallback!` helper taking a push thunk, and route **both** `push-branch!` and `force-push!` through it — removing the divergence rather than adding a third copy.

- `push-branch!`'s public optional-token arities are unchanged; its existing tests (`push-branch-https-fallback-test`, `push-branch-restore-failure-fails-loud-test`) still pass through the shared helper.
- `force-push!` now retries over HTTPS+token and fails loud with the scrub hint (and `:push-succeeded?`) if origin can't be restored.

## Tests

`force-push-https-fallback-test` (SSH fail → https retry → restore) and `force-push-restore-failure-fails-loud-test`, mirroring the `push-branch!` pair. Full release-executor brick green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)