### PR TITLE
fix: stratum-lint pre-commit autofixes instead of just failing

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -56,7 +56,7 @@
    :task (lint/clj-all)}
 
   lint:stratum
-  {:doc  "Stratified-design lint (stratum-lint) over staged Clojure files"
+  {:doc  "Stratified-design autofix (stratum-lint --fix) over staged Clojure files"
    :requires ([lint])
    :task (lint/stratum-staged)}
 

--- a/docs/pull-requests/2026-07-24-fix-stratum-lint-autofix-precommit.md
+++ b/docs/pull-requests/2026-07-24-fix-stratum-lint-autofix-precommit.md
@@ -1,0 +1,89 @@
+# fix: stratum-lint pre-commit autofixes instead of just failing
+
+## Overview
+
+Bumps the pinned `stratum-lint` sha to pick up the SL001 lexical-scoping
+fix ([miniforge-ai/stratum-lint#6](https://github.com/miniforge-ai/stratum-lint/pull/6)),
+and changes `bb lint:stratum` (the pre-commit gate) from "lint staged
+files, fail on any finding" to "autofix staged files, re-stage the result,
+fail only when autofix genuinely can't resolve it" — the same shape
+`fmt:md-staged` already uses for Markdown.
+
+## Motivation
+
+Wave 0 of `work/stratum-lint-baseline-2026-07-24.md`: enforcement was
+staged-files-only and fail-only, which is how 876 findings accumulated
+across the tree without anyone noticing — a developer touching one line
+of an already-messy file got a wall of pre-existing findings unrelated to
+their change, with no automated way to clear them. Autofix removes that
+friction for the mechanical categories (decorative/misordered headings,
+pre-heading defs) so a touched file gets normalized as a side effect of
+normal development, not just in dedicated cleanup PRs.
+
+## Changes in Detail
+
+- `tasks/lint.clj`:
+  - Bumped `stratum-lint-deps` sha to `d83e92d5` (the merged lexical-
+    scoping fix).
+  - `stratum-staged` now invokes `--fix` instead of plain lint, re-`git
+    add`s every staged file after a successful fix (mirrors
+    `fmt/md-staged`'s re-stage step), and only fails the commit when
+    `--fix`'s own exit code says it couldn't resolve the file (a parse
+    failure, or a genuine same-file reference cycle — SL000/SL007).
+  - After a successful autofix, runs one more plain (non-fix) lint pass
+    over the same files and prints any remaining findings as a
+    non-blocking advisory. In practice this is only ever SL003 (over the
+    3-layer budget) — `--fix` regroups defs correctly but can't split a
+    file into multiple namespaces, so that stays a manual `rule 210`
+    namespace-split, surfaced but not enforced here.
+- `bb.edn` — updated `lint:stratum`'s doc string to say "autofix" instead
+  of "lint".
+
+## Testing Plan
+
+Functional, in an isolated scratch git repo (not the real tree) exercising
+all four paths the new logic can take:
+
+1. A file with decorative/misordered headings — autofixed, re-staged.
+2. An already-clean file — still rewritten once, to add `^{:stratum n}`
+   metadata (confirmed via the tool's own idempotency guarantee: a second
+   fix pass is a byte-for-byte no-op, so this is a one-time normalization
+   per file, not a recurring diff).
+3. A genuine same-file reference cycle (SL007) — commit correctly blocked,
+   file left untouched, exit 1.
+4. A file whose real stratum count exceeds the budget after fixing —
+   autofixed and re-staged, plus the non-blocking SL003 advisory printed.
+
+Also verified the sha bump itself resolves via `bb -Sdeps` and that
+running the pinned linter against the six specific miniforge files from
+the baseline (the 5 confirmed false positives + the 1 real violation)
+reproduces the fix's effect end-to-end through this repo's own dependency
+declaration, not just in the stratum-lint repo's own test suite.
+
+Did not run the full `bb pre-commit` against a real staged production file
+in this PR — that's deliberately deferred to the Wave 1-4 per-component
+fix PRs, where each component's autofix diff gets reviewed on its own.
+
+## Deployment Plan
+
+Merges to `main`. Takes effect on the next commit that stages a `.clj`/
+`.cljc` file. Transitional note: for any of the ~378 files with existing
+stratum-lint findings, the *first* commit that touches it after this
+merges will carry a full-file reorder/metadata diff as a side effect —
+this can be large enough to trip `commit-budget` (200 lines) on an
+otherwise-small change. That's an accepted tradeoff for now (override or
+land the file's cleanup as its own commit first); Wave 1-4 will have
+cleared most of the tree's debt before most developers hit it organically.
+
+## Related Issues/PRs
+
+- Upstream fix: [miniforge-ai/stratum-lint#6](https://github.com/miniforge-ai/stratum-lint/pull/6)
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 0)
+- Follow-on: Waves 1-4, per-component fix PRs
+
+## Checklist
+
+- [x] Upstream fix merged before this PR (sequencing per the baseline plan)
+- [x] All four autofix code paths exercised functionally
+- [x] Transitional commit-budget interaction documented, not silently left
+      as a surprise

--- a/docs/pull-requests/2026-07-24-fix-stratum-lint-autofix-precommit.md
+++ b/docs/pull-requests/2026-07-24-fix-stratum-lint-autofix-precommit.md
@@ -22,14 +22,26 @@ normal development, not just in dedicated cleanup PRs.
 
 ## Changes in Detail
 
+- `tasks/stratum.clj` (new): the autofix mechanics — `stratum-lint-deps`,
+  `restage!`, `lint-only-and-fail!`, `advisory-lint!`,
+  `autofix-and-restage!`. Split out of `tasks/lint.clj` because this PR's
+  own dogfooding caught it tripping the very rule it enforces: the real
+  call chain (`stratum-lint-deps`/`restage!` → `lint-only-and-fail!`/
+  `advisory-lint!` → `autofix-and-restage!` → the dispatcher) is 4 real
+  layers deep, one over budget (rule 210's "a file wanting a fourth band
+  is the signal to split the namespace"). `tasks/lint.clj`'s dispatcher
+  calls into it via a qualified `stratum/...` reference, which the
+  per-file check doesn't count — each file is back to 3 layers, verified
+  with the linter itself against both files (zero findings).
+  `stratum-lint-deps`'s sha (now in `tasks/stratum.clj`) is bumped to
+  `acd82a2f` — the merged lexical-scoping fix,
+  [#6](https://github.com/miniforge-ai/stratum-lint/pull/6), plus a
+  second fix found while validating this PR end-to-end,
+  [#7](https://github.com/miniforge-ai/stratum-lint/pull/7): `--fix` was
+  exploding a leading/trailing comment block — e.g. this repo's Apache
+  header, on every Clojure file per rule 810 — into one double-spaced
+  line per comment instead of one tight block.
 - `tasks/lint.clj`:
-  - Bumped `stratum-lint-deps` sha to `acd82a2f` (the merged lexical-
-    scoping fix, [#6](https://github.com/miniforge-ai/stratum-lint/pull/6),
-    plus a second fix found while validating this PR end-to-end,
-    [#7](https://github.com/miniforge-ai/stratum-lint/pull/7): `--fix` was
-    exploding a leading/trailing comment block — e.g. this repo's Apache
-    header, on every Clojure file per rule 810 — into one double-spaced
-    line per comment instead of one tight block).
   - `stratum-staged` now splits staged files by whether they carry
     unstaged changes beyond what's staged (`unstaged-files`, mirroring
     `staged-files`). A partially-staged file (e.g. after `git add -p`) is

--- a/docs/pull-requests/2026-07-24-fix-stratum-lint-autofix-precommit.md
+++ b/docs/pull-requests/2026-07-24-fix-stratum-lint-autofix-precommit.md
@@ -23,8 +23,13 @@ normal development, not just in dedicated cleanup PRs.
 ## Changes in Detail
 
 - `tasks/lint.clj`:
-  - Bumped `stratum-lint-deps` sha to `d83e92d5` (the merged lexical-
-    scoping fix).
+  - Bumped `stratum-lint-deps` sha to `acd82a2f` (the merged lexical-
+    scoping fix, [#6](https://github.com/miniforge-ai/stratum-lint/pull/6),
+    plus a second fix found while validating this PR end-to-end,
+    [#7](https://github.com/miniforge-ai/stratum-lint/pull/7): `--fix` was
+    exploding a leading/trailing comment block — e.g. this repo's Apache
+    header, on every Clojure file per rule 810 — into one double-spaced
+    line per comment instead of one tight block).
   - `stratum-staged` now invokes `--fix` instead of plain lint, re-`git
     add`s every staged file after a successful fix (mirrors
     `fmt/md-staged`'s re-stage step), and only fails the commit when
@@ -64,6 +69,15 @@ Did not run the full `bb pre-commit` against a real staged production file
 in this PR — that's deliberately deferred to the Wave 1-4 per-component
 fix PRs, where each component's autofix diff gets reviewed on its own.
 
+Caught the comment-block bug (#7) exactly this way: this PR's own
+pre-commit run autofixed `tasks/lint.clj` itself, and its Apache header —
+present in this file and, per rule 810, in every other Clojure source in
+the repo — came back double-spaced. Filed and merged the fix upstream,
+bumped the pin again, and confirmed re-running the corrected `--fix`
+against the already-mangled file self-heals it (verified byte-for-byte:
+only the header's blank lines are removed, the already-correct Layer
+structure is untouched).
+
 ## Deployment Plan
 
 Merges to `main`. Takes effect on the next commit that stages a `.clj`/
@@ -77,13 +91,18 @@ cleared most of the tree's debt before most developers hit it organically.
 
 ## Related Issues/PRs
 
-- Upstream fix: [miniforge-ai/stratum-lint#6](https://github.com/miniforge-ai/stratum-lint/pull/6)
+- Upstream fixes: [miniforge-ai/stratum-lint#6](https://github.com/miniforge-ai/stratum-lint/pull/6)
+  (SL001 scoping), [#7](https://github.com/miniforge-ai/stratum-lint/pull/7)
+  (comment-block preservation, found while validating this PR)
 - Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 0)
 - Follow-on: Waves 1-4, per-component fix PRs
 
 ## Checklist
 
-- [x] Upstream fix merged before this PR (sequencing per the baseline plan)
+- [x] Both upstream fixes merged before this PR (sequencing per the
+      baseline plan)
 - [x] All four autofix code paths exercised functionally
 - [x] Transitional commit-budget interaction documented, not silently left
       as a surprise
+- [x] Comment-block bug found during end-to-end validation, fixed
+      upstream, and confirmed self-healing on the already-mangled file

--- a/docs/pull-requests/2026-07-24-fix-stratum-lint-autofix-precommit.md
+++ b/docs/pull-requests/2026-07-24-fix-stratum-lint-autofix-precommit.md
@@ -7,7 +7,7 @@ fix ([miniforge-ai/stratum-lint#6](https://github.com/miniforge-ai/stratum-lint/
 and changes `bb lint:stratum` (the pre-commit gate) from "lint staged
 files, fail on any finding" to "autofix staged files, re-stage the result,
 fail only when autofix genuinely can't resolve it" — the same shape
-`fmt:md-staged` already uses for Markdown.
+`bb fmt:md` already uses for Markdown.
 
 ## Motivation
 

--- a/docs/pull-requests/2026-07-24-fix-stratum-lint-autofix-precommit.md
+++ b/docs/pull-requests/2026-07-24-fix-stratum-lint-autofix-precommit.md
@@ -30,17 +30,27 @@ normal development, not just in dedicated cleanup PRs.
     exploding a leading/trailing comment block — e.g. this repo's Apache
     header, on every Clojure file per rule 810 — into one double-spaced
     line per comment instead of one tight block).
-  - `stratum-staged` now invokes `--fix` instead of plain lint, re-`git
-    add`s every staged file after a successful fix (mirrors
-    `fmt/md-staged`'s re-stage step), and only fails the commit when
-    `--fix`'s own exit code says it couldn't resolve the file (a parse
-    failure, or a genuine same-file reference cycle — SL000/SL007).
-  - After a successful autofix, runs one more plain (non-fix) lint pass
-    over the same files and prints any remaining findings as a
-    non-blocking advisory. In practice this is only ever SL003 (over the
-    3-layer budget) — `--fix` regroups defs correctly but can't split a
-    file into multiple namespaces, so that stays a manual `rule 210`
-    namespace-split, surfaced but not enforced here.
+  - `stratum-staged` now splits staged files by whether they carry
+    unstaged changes beyond what's staged (`unstaged-files`, mirroring
+    `staged-files`). A partially-staged file (e.g. after `git add -p`) is
+    lint-checked with the *old* fail-only behavior instead of autofixed —
+    `--fix` reads the working-tree file, so autofixing and re-staging it
+    whole would silently include work-in-progress the developer left out
+    on purpose (`lint-only-and-fail!`).
+  - A fully-staged file goes through `autofix-and-restage!`: run `--fix`,
+    then `restage!` (re-`git add`, mirrors `fmt/md-staged`'s re-stage
+    step, but checks `git add`'s own exit code — no longer possible for
+    the fixed content to fail to stage silently), then `advisory-lint!`.
+    `autofix-and-restage!` only fails the commit when `--fix`'s own exit
+    code says it couldn't resolve the file (a parse failure, or a genuine
+    same-file reference cycle — SL000/SL007).
+  - `advisory-lint!` runs one more plain (non-fix) lint pass over the
+    fixed files and prints any remaining findings — in practice always
+    SL003 (over the 3-layer budget), since `--fix` resolves everything
+    else, but the message doesn't presume that's the only possibility —
+    as a non-blocking advisory. Prints stderr too and fails the commit on
+    any exit code other than 0 (clean) or 1 (findings present), so a
+    broken tool invocation can't pass silently.
 - `bb.edn` — updated `lint:stratum`'s doc string to say "autofix" instead
   of "lint".
 
@@ -68,6 +78,15 @@ declaration, not just in the stratum-lint repo's own test suite.
 Did not run the full `bb pre-commit` against a real staged production file
 in this PR — that's deliberately deferred to the Wave 1-4 per-component
 fix PRs, where each component's autofix diff gets reviewed on its own.
+
+Added a fifth path after automated review flagged the working-tree/index
+gap: staged one edit to a scratch file (`git add`), then made a second,
+unstaged edit to the same file (simulating `git add -p`). Confirmed the
+unstaged marker never reached the git index (`git show :file` before and
+after `stratum-staged` runs) — the file was lint-checked and the commit
+correctly blocked on its pre-existing findings, with zero mutation to the
+staged content. Re-ran the plain fully-staged case afterward to confirm
+it still autofixes and re-stages normally.
 
 Caught the comment-block bug (#7) exactly this way: this PR's own
 pre-commit run autofixed `tasks/lint.clj` itself, and its Apache header —

--- a/tasks/lint.clj
+++ b/tasks/lint.clj
@@ -1,37 +1,20 @@
 ;; Title: Miniforge.ai
-
 ;; Subtitle: An agentic SDLC / fleet-control platform
-
 ;; Author: Christopher Lester
-
 ;; Line: Founder, Miniforge.ai (project)
-
 ;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
-
 ;;
-
 ;; Licensed under the Apache License, Version 2.0 (the "License");
-
 ;; you may not use this file except in compliance with the License.
-
 ;; You may obtain a copy of the License at
-
 ;;
-
 ;;     http://www.apache.org/licenses/LICENSE-2.0
-
 ;;
-
 ;; Unless required by applicable law or agreed to in writing, software
-
 ;; distributed under the License is distributed on an "AS IS" BASIS,
-
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-
 ;; See the License for the specific language governing permissions and
-
 ;; limitations under the License.
-
 (ns lint
   (:require
    [babashka.process :as p]
@@ -64,7 +47,7 @@
    included — never fetch the sibling repo; only the pre-commit gate
    pays the one-time clone."
   (pr-str {:deps {'io.github.miniforge-ai/stratum-lint
-                  {:git/sha "d83e92d501898a272f753cf64943c5b00c4002d1"
+                  {:git/sha "acd82a2f5c0155cb03d92ce1f4465cc064125895"
                    :deps/root "clojure"}}}))
 
 ;------------------------------------------------------------------------------ Layer 1

--- a/tasks/lint.clj
+++ b/tasks/lint.clj
@@ -88,7 +88,8 @@
     (if (seq files)
       (do
         (println "🔍 Stratum-linting" (count files) "Clojure file(s)...")
-        ;; Autofix, the same shape as fmt:md-staged's `lint --fix`:
+        ;; Autofix, the same shape `bb fmt:md` already uses (fmt/md-staged
+        ;; runs markdownlint --fix and re-stages):
         ;; stratum-lint infers each def's real stratum from the same-file
         ;; reference graph and regroups under regenerated headings, so a
         ;; decorative/misordered heading never reaches a commit. Exit

--- a/tasks/lint.clj
+++ b/tasks/lint.clj
@@ -28,6 +28,16 @@
       str/split-lines
       (->> (remove str/blank?))))
 
+(defn ^{:stratum 0} unstaged-files
+  "Files with working-tree changes beyond what's staged — a partially
+   staged file (e.g. after `git add -p`) shows up here too."
+  []
+  (-> (p/sh "git" "diff" "--name-only")
+      :out
+      str/split-lines
+      (->> (remove str/blank?))
+      set))
+
 (defn ^{:stratum 0} clj-all []
   (println "🔍 Linting all Clojure files...")
   (println "Directories: bases components development/src")
@@ -50,11 +60,60 @@
                   {:git/sha "acd82a2f5c0155cb03d92ce1f4465cc064125895"
                    :deps/root "clojure"}}}))
 
+(defn ^{:stratum 0} restage!
+  "Re-stage `files` after autofix; fails the commit if `git add` itself
+   fails, rather than silently leaving the fixed content unstaged."
+  [files]
+  (doseq [f files]
+    (let [{:keys [exit err]} (p/sh "git" "add" f)]
+      (when-not (zero? exit)
+        (println "❌ Failed to re-stage" f "after autofix:" err)
+        (System/exit exit)))))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn ^{:stratum 1} staged-by-ext [ext]
   (->> (staged-files)
        (filter (fn [f] (str/ends-with? f ext)))))
+
+(defn ^{:stratum 1} lint-only-and-fail!
+  "Plain (non-fix) lint over `files`; fails the commit on any finding.
+   Used for files with unstaged changes beyond what's staged, where
+   autofixing would risk silently staging work-in-progress the developer
+   left out on purpose."
+  [files]
+  (println "⚠️  Skipping autofix for partially-staged file(s) — checking only:"
+           (str/join ", " files))
+  (let [{:keys [exit out err]} (apply p/sh {:out :string :err :string}
+                                      "bb" "-Sdeps" stratum-lint-deps
+                                      "-m" "stratum-lint.interface"
+                                      files)]
+    (when-not (str/blank? out) (println out))
+    (when-not (str/blank? err) (binding [*out* *err*] (println err)))
+    (when-not (zero? exit)
+      (println "❌ Stratified-design lint failed — stage the file fully to"
+               "allow autofix, or fix headings by hand. Exit code:" exit)
+      (System/exit exit))))
+
+(defn ^{:stratum 1} advisory-lint!
+  "Plain (non-fix) lint pass over already-fixed `files`; prints any
+   remaining findings (in practice always SL003 — over the layer budget,
+   needs a namespace split — since --fix resolves everything else) as a
+   non-blocking advisory. Only a genuinely unexpected exit (neither clean
+   nor findings-present) fails the commit — a broken tool invocation
+   should never pass silently."
+  [files]
+  (let [{:keys [exit out err]} (apply p/sh {:out :string :err :string}
+                                      "bb" "-Sdeps" stratum-lint-deps
+                                      "-m" "stratum-lint.interface"
+                                      files)]
+    (when-not (str/blank? out)
+      (println "⚠️  Stratified-design findings remain after autofix (often a namespace split needed for an over-budget file):")
+      (println out))
+    (when-not (str/blank? err) (binding [*out* *err*] (println err)))
+    (when-not (contains? #{0 1} exit)
+      (println "❌ Post-fix advisory lint pass could not run — exit code:" exit)
+      (System/exit exit))))
 
 ;------------------------------------------------------------------------------ Layer 2
 
@@ -81,46 +140,51 @@
           (System/exit 3)))
       (println "✓ No Clojure files to lint"))))
 
-(defn ^{:stratum 2} stratum-staged []
+(defn ^{:stratum 2} autofix-and-restage!
+  "Run --fix over fully-staged `files`, re-stage on success. Exit
+   contract in --fix mode: 0 covers \"already clean\" and \"successfully
+   fixed\"; 1 is reserved for what --fix genuinely cannot resolve on its
+   own (a parse failure, or a same-file reference cycle) and still fails
+   the commit for a human to look at."
+  [files]
+  (let [{:keys [exit out err]} (apply p/sh {:out :string :err :string}
+                                      "bb" "-Sdeps" stratum-lint-deps
+                                      "-m" "stratum-lint.interface" "--fix"
+                                      files)]
+    (when-not (str/blank? out) (println out))
+    (when-not (str/blank? err) (binding [*out* *err*] (println err)))
+    (if-not (zero? exit)
+      (do
+        (println "❌ Stratified-design lint could not auto-fix — exit code:" exit)
+        (System/exit exit))
+      (do
+        (restage! files)
+        (advisory-lint! files)))))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} stratum-staged
+  "Autofix, the same shape `bb fmt:md` already uses (fmt/md-staged runs
+   markdownlint --fix and re-stages): stratum-lint infers each def's real
+   stratum from the same-file reference graph and regroups under
+   regenerated headings, so a decorative/misordered heading never reaches
+   a commit. Files without Layer headings are ignored by the linter, so
+   unannotated legacy namespaces pass untouched — enforcement tightens
+   file-by-file as headings appear.
+
+   A file with unstaged changes beyond what's staged (e.g. after `git add
+   -p`) is lint-checked instead of autofixed — --fix operates on the
+   working-tree file, and re-staging it whole would silently include
+   work-in-progress the developer deliberately left unstaged."
+  []
   (let [files (->> (concat (staged-by-ext ".clj")
                            (staged-by-ext ".cljc"))
                    (remove (fn [f] (str/starts-with? f ".clj-kondo/"))))]
     (if (seq files)
-      (do
+      (let [dirty (unstaged-files)
+            unsafe (filter dirty files)
+            safe (remove dirty files)]
         (println "🔍 Stratum-linting" (count files) "Clojure file(s)...")
-        ;; Autofix, the same shape `bb fmt:md` already uses (fmt/md-staged
-        ;; runs markdownlint --fix and re-stages):
-        ;; stratum-lint infers each def's real stratum from the same-file
-        ;; reference graph and regroups under regenerated headings, so a
-        ;; decorative/misordered heading never reaches a commit. Exit
-        ;; contract in --fix mode: 0 covers "already clean" and
-        ;; "successfully fixed"; 1 is reserved for what --fix genuinely
-        ;; cannot resolve on its own (a parse failure, or a same-file
-        ;; reference cycle) and still fails the commit for a human to
-        ;; look at. Files without Layer headings are ignored by the
-        ;; linter, so unannotated legacy namespaces pass untouched —
-        ;; enforcement tightens file-by-file as headings appear.
-        (let [{:keys [exit out err]} (apply p/sh {:out :string :err :string}
-                                            "bb" "-Sdeps" stratum-lint-deps
-                                            "-m" "stratum-lint.interface" "--fix"
-                                            files)]
-          (when-not (str/blank? out) (println out))
-          (when-not (str/blank? err) (binding [*out* *err*] (println err)))
-          (if-not (zero? exit)
-            (do
-              (println "❌ Stratified-design lint could not auto-fix — exit code:" exit)
-              (System/exit exit))
-            (do
-              (doseq [f files] (p/sh "git" "add" f))
-              ;; Autofix regroups defs; it can't split a file that still
-              ;; has more real strata than the budget (3) — that needs an
-              ;; actual namespace split (rule 210). Surface it as advisory
-              ;; output rather than blocking the commit.
-              (let [{:keys [out]} (apply p/sh {:out :string :err :string}
-                                        "bb" "-Sdeps" stratum-lint-deps
-                                        "-m" "stratum-lint.interface"
-                                        files)]
-                (when-not (str/blank? out)
-                  (println "⚠️  Still needs a namespace split after autofix (over the 3-layer budget):")
-                  (println out)))))))
+        (when (seq unsafe) (lint-only-and-fail! unsafe))
+        (when (seq safe) (autofix-and-restage! safe)))
       (println "✓ No Clojure files to stratum-lint"))))

--- a/tasks/lint.clj
+++ b/tasks/lint.clj
@@ -1,19 +1,35 @@
 ;; Title: Miniforge.ai
+
 ;; Subtitle: An agentic SDLC / fleet-control platform
+
 ;; Author: Christopher Lester
+
 ;; Line: Founder, Miniforge.ai (project)
+
 ;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+
 ;;
+
 ;; Licensed under the Apache License, Version 2.0 (the "License");
+
 ;; you may not use this file except in compliance with the License.
+
 ;; You may obtain a copy of the License at
+
 ;;
+
 ;;     http://www.apache.org/licenses/LICENSE-2.0
+
 ;;
+
 ;; Unless required by applicable law or agreed to in writing, software
+
 ;; distributed under the License is distributed on an "AS IS" BASIS,
+
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
 ;; See the License for the specific language governing permissions and
+
 ;; limitations under the License.
 
 (ns lint
@@ -21,17 +37,45 @@
    [babashka.process :as p]
    [clojure.string :as str]))
 
-(defn staged-files []
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} staged-files []
   (-> (p/sh "git" "diff" "--cached" "--name-only" "--diff-filter=ACM")
       :out
       str/split-lines
       (->> (remove str/blank?))))
 
-(defn staged-by-ext [ext]
+(defn ^{:stratum 0} clj-all []
+  (println "🔍 Linting all Clojure files...")
+  (println "Directories: bases components development/src")
+  (let [{:keys [exit out err]} (p/sh {:out :string :err :string}
+                                     "clj-kondo" "--lint" "bases" "components" "development/src")]
+    (when-not (str/blank? out) (println out))
+    (when-not (str/blank? err) (binding [*out* *err*] (println err)))
+    (when-not (zero? exit)
+      (println "❌ Linting failed with exit code:" exit)
+      (System/exit exit))))
+
+(def ^{:stratum 0} ^:private stratum-lint-deps
+  "Sha-pinned git coordinate for the stratum-lint Clojure component
+   (bb-native; the linter for stratified-design separator comments whose
+   heading ends in `Layer N`, miniforge-standards rule 210). Resolved lazily in a
+   subprocess via `bb -Sdeps` so plain `bb <task>` invocations — CI
+   included — never fetch the sibling repo; only the pre-commit gate
+   pays the one-time clone."
+  (pr-str {:deps {'io.github.miniforge-ai/stratum-lint
+                  {:git/sha "d83e92d501898a272f753cf64943c5b00c4002d1"
+                   :deps/root "clojure"}}}))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} staged-by-ext [ext]
   (->> (staged-files)
        (filter (fn [f] (str/ends-with? f ext)))))
 
-(defn clj-staged []
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} clj-staged []
   (let [clj-files (->> (concat (staged-by-ext ".clj")
                                (staged-by-ext ".cljs")
                                (staged-by-ext ".cljc")
@@ -54,46 +98,45 @@
           (System/exit 3)))
       (println "✓ No Clojure files to lint"))))
 
-(defn clj-all []
-  (println "🔍 Linting all Clojure files...")
-  (println "Directories: bases components development/src")
-  (let [{:keys [exit out err]} (p/sh {:out :string :err :string}
-                                     "clj-kondo" "--lint" "bases" "components" "development/src")]
-    (when-not (str/blank? out) (println out))
-    (when-not (str/blank? err) (binding [*out* *err*] (println err)))
-    (when-not (zero? exit)
-      (println "❌ Linting failed with exit code:" exit)
-      (System/exit exit))))
-
-(def ^:private stratum-lint-deps
-  "Sha-pinned git coordinate for the stratum-lint Clojure component
-   (bb-native; the linter for stratified-design separator comments whose
-   heading ends in `Layer N`, miniforge-standards rule 210). Resolved lazily in a
-   subprocess via `bb -Sdeps` so plain `bb <task>` invocations — CI
-   included — never fetch the sibling repo; only the pre-commit gate
-   pays the one-time clone."
-  (pr-str {:deps {'io.github.miniforge-ai/stratum-lint
-                  {:git/sha "7ca43db35c7547fe919069e9d69ef8c5d2810042"
-                   :deps/root "clojure"}}}))
-
-(defn stratum-staged []
+(defn ^{:stratum 2} stratum-staged []
   (let [files (->> (concat (staged-by-ext ".clj")
                            (staged-by-ext ".cljc"))
                    (remove (fn [f] (str/starts-with? f ".clj-kondo/"))))]
     (if (seq files)
       (do
         (println "🔍 Stratum-linting" (count files) "Clojure file(s)...")
-        ;; Exit contract per stratum-lint: 0 clean, 1 findings, 2 usage
-        ;; error. Files without Layer headings are ignored by the
+        ;; Autofix, the same shape as fmt:md-staged's `lint --fix`:
+        ;; stratum-lint infers each def's real stratum from the same-file
+        ;; reference graph and regroups under regenerated headings, so a
+        ;; decorative/misordered heading never reaches a commit. Exit
+        ;; contract in --fix mode: 0 covers "already clean" and
+        ;; "successfully fixed"; 1 is reserved for what --fix genuinely
+        ;; cannot resolve on its own (a parse failure, or a same-file
+        ;; reference cycle) and still fails the commit for a human to
+        ;; look at. Files without Layer headings are ignored by the
         ;; linter, so unannotated legacy namespaces pass untouched —
         ;; enforcement tightens file-by-file as headings appear.
         (let [{:keys [exit out err]} (apply p/sh {:out :string :err :string}
                                             "bb" "-Sdeps" stratum-lint-deps
-                                            "-m" "stratum-lint.interface"
+                                            "-m" "stratum-lint.interface" "--fix"
                                             files)]
           (when-not (str/blank? out) (println out))
           (when-not (str/blank? err) (binding [*out* *err*] (println err)))
-          (when-not (zero? exit)
-            (println "❌ Stratified-design lint failed with exit code:" exit)
-            (System/exit exit))))
+          (if-not (zero? exit)
+            (do
+              (println "❌ Stratified-design lint could not auto-fix — exit code:" exit)
+              (System/exit exit))
+            (do
+              (doseq [f files] (p/sh "git" "add" f))
+              ;; Autofix regroups defs; it can't split a file that still
+              ;; has more real strata than the budget (3) — that needs an
+              ;; actual namespace split (rule 210). Surface it as advisory
+              ;; output rather than blocking the commit.
+              (let [{:keys [out]} (apply p/sh {:out :string :err :string}
+                                        "bb" "-Sdeps" stratum-lint-deps
+                                        "-m" "stratum-lint.interface"
+                                        files)]
+                (when-not (str/blank? out)
+                  (println "⚠️  Still needs a namespace split after autofix (over the 3-layer budget):")
+                  (println out)))))))
       (println "✓ No Clojure files to stratum-lint"))))

--- a/tasks/lint.clj
+++ b/tasks/lint.clj
@@ -18,7 +18,8 @@
 (ns lint
   (:require
    [babashka.process :as p]
-   [clojure.string :as str]))
+   [clojure.string :as str]
+   [stratum]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -49,71 +50,11 @@
       (println "❌ Linting failed with exit code:" exit)
       (System/exit exit))))
 
-(def ^{:stratum 0} ^:private stratum-lint-deps
-  "Sha-pinned git coordinate for the stratum-lint Clojure component
-   (bb-native; the linter for stratified-design separator comments whose
-   heading ends in `Layer N`, miniforge-standards rule 210). Resolved lazily in a
-   subprocess via `bb -Sdeps` so plain `bb <task>` invocations — CI
-   included — never fetch the sibling repo; only the pre-commit gate
-   pays the one-time clone."
-  (pr-str {:deps {'io.github.miniforge-ai/stratum-lint
-                  {:git/sha "acd82a2f5c0155cb03d92ce1f4465cc064125895"
-                   :deps/root "clojure"}}}))
-
-(defn ^{:stratum 0} restage!
-  "Re-stage `files` after autofix; fails the commit if `git add` itself
-   fails, rather than silently leaving the fixed content unstaged."
-  [files]
-  (doseq [f files]
-    (let [{:keys [exit err]} (p/sh "git" "add" f)]
-      (when-not (zero? exit)
-        (println "❌ Failed to re-stage" f "after autofix:" err)
-        (System/exit exit)))))
-
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn ^{:stratum 1} staged-by-ext [ext]
   (->> (staged-files)
        (filter (fn [f] (str/ends-with? f ext)))))
-
-(defn ^{:stratum 1} lint-only-and-fail!
-  "Plain (non-fix) lint over `files`; fails the commit on any finding.
-   Used for files with unstaged changes beyond what's staged, where
-   autofixing would risk silently staging work-in-progress the developer
-   left out on purpose."
-  [files]
-  (println "⚠️  Skipping autofix for partially-staged file(s) — checking only:"
-           (str/join ", " files))
-  (let [{:keys [exit out err]} (apply p/sh {:out :string :err :string}
-                                      "bb" "-Sdeps" stratum-lint-deps
-                                      "-m" "stratum-lint.interface"
-                                      files)]
-    (when-not (str/blank? out) (println out))
-    (when-not (str/blank? err) (binding [*out* *err*] (println err)))
-    (when-not (zero? exit)
-      (println "❌ Stratified-design lint failed — stage the file fully to"
-               "allow autofix, or fix headings by hand. Exit code:" exit)
-      (System/exit exit))))
-
-(defn ^{:stratum 1} advisory-lint!
-  "Plain (non-fix) lint pass over already-fixed `files`; prints any
-   remaining findings (in practice always SL003 — over the layer budget,
-   needs a namespace split — since --fix resolves everything else) as a
-   non-blocking advisory. Only a genuinely unexpected exit (neither clean
-   nor findings-present) fails the commit — a broken tool invocation
-   should never pass silently."
-  [files]
-  (let [{:keys [exit out err]} (apply p/sh {:out :string :err :string}
-                                      "bb" "-Sdeps" stratum-lint-deps
-                                      "-m" "stratum-lint.interface"
-                                      files)]
-    (when-not (str/blank? out)
-      (println "⚠️  Stratified-design findings remain after autofix (often a namespace split needed for an over-budget file):")
-      (println out))
-    (when-not (str/blank? err) (binding [*out* *err*] (println err)))
-    (when-not (contains? #{0 1} exit)
-      (println "❌ Post-fix advisory lint pass could not run — exit code:" exit)
-      (System/exit exit))))
 
 ;------------------------------------------------------------------------------ Layer 2
 
@@ -140,30 +81,7 @@
           (System/exit 3)))
       (println "✓ No Clojure files to lint"))))
 
-(defn ^{:stratum 2} autofix-and-restage!
-  "Run --fix over fully-staged `files`, re-stage on success. Exit
-   contract in --fix mode: 0 covers \"already clean\" and \"successfully
-   fixed\"; 1 is reserved for what --fix genuinely cannot resolve on its
-   own (a parse failure, or a same-file reference cycle) and still fails
-   the commit for a human to look at."
-  [files]
-  (let [{:keys [exit out err]} (apply p/sh {:out :string :err :string}
-                                      "bb" "-Sdeps" stratum-lint-deps
-                                      "-m" "stratum-lint.interface" "--fix"
-                                      files)]
-    (when-not (str/blank? out) (println out))
-    (when-not (str/blank? err) (binding [*out* *err*] (println err)))
-    (if-not (zero? exit)
-      (do
-        (println "❌ Stratified-design lint could not auto-fix — exit code:" exit)
-        (System/exit exit))
-      (do
-        (restage! files)
-        (advisory-lint! files)))))
-
-;------------------------------------------------------------------------------ Layer 3
-
-(defn ^{:stratum 3} stratum-staged
+(defn ^{:stratum 2} stratum-staged
   "Autofix, the same shape `bb fmt:md` already uses (fmt/md-staged runs
    markdownlint --fix and re-stages): stratum-lint infers each def's real
    stratum from the same-file reference graph and regroups under
@@ -175,7 +93,9 @@
    A file with unstaged changes beyond what's staged (e.g. after `git add
    -p`) is lint-checked instead of autofixed — --fix operates on the
    working-tree file, and re-staging it whole would silently include
-   work-in-progress the developer deliberately left unstaged."
+   work-in-progress the developer deliberately left unstaged. Mechanics
+   live in the `stratum` namespace (rule 210: this dispatcher plus that
+   namespace's own chain would be 4 real layers in one file)."
   []
   (let [files (->> (concat (staged-by-ext ".clj")
                            (staged-by-ext ".cljc"))
@@ -185,6 +105,6 @@
             unsafe (filter dirty files)
             safe (remove dirty files)]
         (println "🔍 Stratum-linting" (count files) "Clojure file(s)...")
-        (when (seq unsafe) (lint-only-and-fail! unsafe))
-        (when (seq safe) (autofix-and-restage! safe)))
+        (when (seq unsafe) (stratum/lint-only-and-fail! unsafe))
+        (when (seq safe) (stratum/autofix-and-restage! safe)))
       (println "✓ No Clojure files to stratum-lint"))))

--- a/tasks/stratum.clj
+++ b/tasks/stratum.clj
@@ -17,11 +17,12 @@
 ;; limitations under the License.
 (ns stratum
   "Stratum-lint autofix mechanics, split out of `lint` (rule 210: a
-   namespace wanting a fourth real layer is the signal to split it — this
-   chain runs stratum-lint-deps/restage! -> lint-only-and-fail!/
-   advisory-lint! -> autofix-and-restage!, a genuine 3-deep call graph).
-   `lint/stratum-staged` is the dispatcher; everything here is its
-   mechanics."
+   namespace wanting a fourth real layer is the signal to split it).
+   `lint/stratum-staged` is the dispatcher; it calls `autofix-and-restage!`
+   for fully-staged files or `lint-only-and-fail!` for partially-staged
+   ones. `autofix-and-restage!` composes `restage!` and `advisory-lint!`,
+   which both read `stratum-lint-deps` — the genuine 3-deep layer chain
+   that no longer fits alongside the dispatcher in one file."
   (:require
    [babashka.process :as p]
    [clojure.string :as str]))
@@ -44,7 +45,7 @@
    fails, rather than silently leaving the fixed content unstaged."
   [files]
   (doseq [f files]
-    (let [{:keys [exit err]} (p/sh "git" "add" f)]
+    (let [{:keys [exit err]} (p/sh "git" "add" "--" f)]
       (when-not (zero? exit)
         (println "❌ Failed to re-stage" f "after autofix:" err)
         (System/exit exit)))))

--- a/tasks/stratum.clj
+++ b/tasks/stratum.clj
@@ -1,0 +1,114 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns stratum
+  "Stratum-lint autofix mechanics, split out of `lint` (rule 210: a
+   namespace wanting a fourth real layer is the signal to split it — this
+   chain runs stratum-lint-deps/restage! -> lint-only-and-fail!/
+   advisory-lint! -> autofix-and-restage!, a genuine 3-deep call graph).
+   `lint/stratum-staged` is the dispatcher; everything here is its
+   mechanics."
+  (:require
+   [babashka.process :as p]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private stratum-lint-deps
+  "Sha-pinned git coordinate for the stratum-lint Clojure component
+   (bb-native; the linter for stratified-design separator comments whose
+   heading ends in `Layer N`, miniforge-standards rule 210). Resolved lazily in a
+   subprocess via `bb -Sdeps` so plain `bb <task>` invocations — CI
+   included — never fetch the sibling repo; only the pre-commit gate
+   pays the one-time clone."
+  (pr-str {:deps {'io.github.miniforge-ai/stratum-lint
+                  {:git/sha "acd82a2f5c0155cb03d92ce1f4465cc064125895"
+                   :deps/root "clojure"}}}))
+
+(defn ^{:stratum 0} restage!
+  "Re-stage `files` after autofix; fails the commit if `git add` itself
+   fails, rather than silently leaving the fixed content unstaged."
+  [files]
+  (doseq [f files]
+    (let [{:keys [exit err]} (p/sh "git" "add" f)]
+      (when-not (zero? exit)
+        (println "❌ Failed to re-stage" f "after autofix:" err)
+        (System/exit exit)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} lint-only-and-fail!
+  "Plain (non-fix) lint over `files`; fails the commit on any finding.
+   Used for files with unstaged changes beyond what's staged, where
+   autofixing would risk silently staging work-in-progress the developer
+   left out on purpose."
+  [files]
+  (println "⚠️  Skipping autofix for partially-staged file(s) — checking only:"
+           (str/join ", " files))
+  (let [{:keys [exit out err]} (apply p/sh {:out :string :err :string}
+                                      "bb" "-Sdeps" stratum-lint-deps
+                                      "-m" "stratum-lint.interface"
+                                      files)]
+    (when-not (str/blank? out) (println out))
+    (when-not (str/blank? err) (binding [*out* *err*] (println err)))
+    (when-not (zero? exit)
+      (println "❌ Stratified-design lint failed — stage the file fully to"
+               "allow autofix, or fix headings by hand. Exit code:" exit)
+      (System/exit exit))))
+
+(defn ^{:stratum 1} advisory-lint!
+  "Plain (non-fix) lint pass over already-fixed `files`; prints any
+   remaining findings (in practice always SL003 — over the layer budget,
+   needs a namespace split — since --fix resolves everything else) as a
+   non-blocking advisory. Only a genuinely unexpected exit (neither clean
+   nor findings-present) fails the commit — a broken tool invocation
+   should never pass silently."
+  [files]
+  (let [{:keys [exit out err]} (apply p/sh {:out :string :err :string}
+                                      "bb" "-Sdeps" stratum-lint-deps
+                                      "-m" "stratum-lint.interface"
+                                      files)]
+    (when-not (str/blank? out)
+      (println "⚠️  Stratified-design findings remain after autofix (often a namespace split needed for an over-budget file):")
+      (println out))
+    (when-not (str/blank? err) (binding [*out* *err*] (println err)))
+    (when-not (contains? #{0 1} exit)
+      (println "❌ Post-fix advisory lint pass could not run — exit code:" exit)
+      (System/exit exit))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} autofix-and-restage!
+  "Run --fix over fully-staged `files`, re-stage on success. Exit
+   contract in --fix mode: 0 covers \"already clean\" and \"successfully
+   fixed\"; 1 is reserved for what --fix genuinely cannot resolve on its
+   own (a parse failure, or a same-file reference cycle) and still fails
+   the commit for a human to look at."
+  [files]
+  (let [{:keys [exit out err]} (apply p/sh {:out :string :err :string}
+                                      "bb" "-Sdeps" stratum-lint-deps
+                                      "-m" "stratum-lint.interface" "--fix"
+                                      files)]
+    (when-not (str/blank? out) (println out))
+    (when-not (str/blank? err) (binding [*out* *err*] (println err)))
+    (if-not (zero? exit)
+      (do
+        (println "❌ Stratified-design lint could not auto-fix — exit code:" exit)
+        (System/exit exit))
+      (do
+        (restage! files)
+        (advisory-lint! files)))))


### PR DESCRIPTION
## Summary
- Wave 0 of `work/stratum-lint-baseline-2026-07-24.md` (#1458): bumps the pinned `stratum-lint` sha to the merged SL001 lexical-scoping fix ([stratum-lint#6](https://github.com/miniforge-ai/stratum-lint/pull/6)).
- Changes `bb lint:stratum` (the pre-commit gate) from "lint staged files, fail on any finding" to "autofix staged files, re-stage the result" — the same shape `fmt:md-staged` already uses for Markdown. Only fails the commit when `--fix` itself can't resolve the file (parse failure or a genuine same-file reference cycle).
- A non-blocking advisory prints when a file still exceeds the 3-layer budget after fixing — that needs an actual namespace split, which autofix can't do.

Transitional note (documented in the PR doc): the first commit touching any of the ~378 currently-messy files will carry a full-file reorder/metadata diff as a side effect, which can trip the 200-line commit-budget gate on an otherwise-small change. Accepted tradeoff — Waves 1-4 clear most of this before it's hit organically.

See `docs/pull-requests/2026-07-24-fix-stratum-lint-autofix-precommit.md` for full detail.

## Test plan
- [x] Sha bump resolves via `bb -Sdeps`
- [x] All four autofix code paths verified in an isolated scratch repo: decorative-heading file (fixed), already-clean file (one-time metadata normalization, confirmed idempotent on a second pass), genuine reference cycle (commit blocked, exit 1), over-budget file (fixed + non-blocking advisory)
- [x] Dogfooded for real: this PR's own pre-commit run autofixed `tasks/lint.clj` itself (added real Layer 0/1/2 headings), and `bb tasks`/pre-commit still pass afterward
- [x] Full `bb pre-commit` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)