### PR TITLE
fix: stratum-lint autofix for components/compliance-scanner (Wave 1)

### DIFF
--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/classify.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/classify.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.compliance-scanner.classify
   "Classify violations: add :auto-fixable? and :rationale to each violation.
 
@@ -28,15 +27,15 @@
             [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Context exclusion matching
 
-(defn- has-path-exclusion?
+;; Context exclusion matching
+(defn- ^{:stratum 0} has-path-exclusion?
   "Return true if the violation's file path matches a :path-contains exclusion."
   [violation ctx-rule]
   (when-let [p (get ctx-rule :path-contains)]
     (str/includes? (get violation :file "") p)))
 
-(defn- has-content-exclusion?
+(defn- ^{:stratum 0} has-content-exclusion?
   "Return true if the violation's :current text matches a :current-contains exclusion."
   [violation ctx-rule]
   (when-let [cs (get ctx-rule :current-contains)]
@@ -45,20 +44,24 @@
         (boolean (some #(str/includes? current %) cs))
         (str/includes? current cs)))))
 
-(defn- matches-exclude-context?
+(defn- ^{:stratum 0} semantic-strategy?
+  "Return true if the violation has a :semantic remediation strategy."
+  [violation]
+  (= :semantic (get-in violation [:remediation :strategy]
+                       (get violation :remediation-strategy))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} matches-exclude-context?
   "Return true if a violation matches an exclusion context rule.
    Exclusion contexts are declared in MDC remediation config."
   [violation ctx-rule]
   (or (has-path-exclusion? violation ctx-rule)
       (has-content-exclusion? violation ctx-rule)))
 
-(defn- semantic-strategy?
-  "Return true if the violation has a :semantic remediation strategy."
-  [violation]
-  (= :semantic (get-in violation [:remediation :strategy]
-                       (get violation :remediation-strategy))))
+;------------------------------------------------------------------------------ Layer 2
 
-(defn- classify-one
+(defn- ^{:stratum 2} classify-one
   "Classify a single violation using pack-enriched metadata.
    Uses :auto-fixable-default and :exclude-contexts from the pack rule.
    Violations with :semantic remediation strategy are always not auto-fixable."
@@ -76,10 +79,10 @@
                             :else        (str (get violation :rule/title "Manual review")
                                               " — manual review required")))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Top-level entry point
+;------------------------------------------------------------------------------ Layer 3
 
-(defn classify-violations
+;; Top-level entry point
+(defn ^{:stratum 3} classify-violations
   "Add :auto-fixable? and :rationale to each violation.
    Returns updated violation list."
   [violations]

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/comments.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/comments.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.compliance-scanner.comments
   "Render classified Violations into PR review comment payloads per
    N13 §2.3 (Closed-Loop PR Pipeline — Violation Comment Renderer).
@@ -31,9 +30,9 @@
             [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Severity inference
 
-(defn- infer-severity
+;; Severity inference
+(defn- ^{:stratum 0} infer-severity
   "Map a classified Violation to a :violation/severity keyword.
 
    Heuristic: violations whose `:rule/category` matches
@@ -49,16 +48,57 @@
                                    (str/includes? category "critical")))]
         (if critical-cat? :error :warning))))
 
-;------------------------------------------------------------------------------ Layer 0
 ;; Payload construction
-
-(defn- rationale-text
+(defn- ^{:stratum 0} rationale-text
   "Return a violation rationale when it is a string; otherwise return empty text."
   [violation]
   (let [rationale (get violation :rationale)]
     (if (string? rationale) rationale "")))
 
-(defn violation->payload
+;; Body rendering
+(defn- ^{:stratum 0} pr-edn
+  "Pretty-print an EDN value for embedding in a comment body. Stable
+   key ordering keeps comment diffs minimal across re-renders."
+  [v]
+  (if (map? v)
+    (let [ordered-keys [:violation/rule-id
+                        :violation/severity
+                        :violation/auto-fixable?
+                        :violation/suggested-fix
+                        :violation/rationale
+                        :violation/pack-id
+                        :violation/pack-version]
+          present      (filter #(contains? v %) ordered-keys)
+          extras       (sort (remove (set ordered-keys) (keys v)))
+          all-keys     (concat present extras)
+          lines        (for [k all-keys]
+                         (str " " (pr-str k) " " (pr-str (get v k))))]
+      (str "{" (str/triml (str/join "\n" lines)) "}"))
+    (pr-str v)))
+
+;; Parser (round-trip helper)
+(defn ^{:stratum 0} extract-payload
+  "Extract a `:comment/payload` map from a comment body produced by
+   `render-body`. Returns nil if no payload block is found.
+
+   Used by the Comment Response Agent's bot-comment-table parser
+   (per `pr-monitoring-workflow.md` Bot Comment Handling) to recover
+   the structured payload from a posted comment."
+  [body]
+  (when (string? body)
+    (let [block-re #"(?s)```edn\s*:comment/payload\s*(\{.*?\})\s*```"]
+      (when-let [[_ edn-str] (re-find block-re body)]
+        (try
+          ;; clojure.edn/read-string is strictly EDN — no reader macros,
+          ;; no #=, no eval. Comment bodies are untrusted input once
+          ;; posted/retrieved from a PR. {:default identity} swallows
+          ;; unknown tagged literals safely.
+          (edn/read-string {:default (fn [_tag value] value)} edn-str)
+          (catch Exception _ nil))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} violation->payload
   "Build the :comment/payload map for a single classified Violation.
 
    Arguments:
@@ -83,30 +123,7 @@
    :violation/pack-id        (:pack/id pack-info)
    :violation/pack-version   (:pack/version pack-info)})
 
-;------------------------------------------------------------------------------ Layer 0
-;; Body rendering
-
-(defn- pr-edn
-  "Pretty-print an EDN value for embedding in a comment body. Stable
-   key ordering keeps comment diffs minimal across re-renders."
-  [v]
-  (if (map? v)
-    (let [ordered-keys [:violation/rule-id
-                        :violation/severity
-                        :violation/auto-fixable?
-                        :violation/suggested-fix
-                        :violation/rationale
-                        :violation/pack-id
-                        :violation/pack-version]
-          present      (filter #(contains? v %) ordered-keys)
-          extras       (sort (remove (set ordered-keys) (keys v)))
-          all-keys     (concat present extras)
-          lines        (for [k all-keys]
-                         (str " " (pr-str k) " " (pr-str (get v k))))]
-      (str "{" (str/triml (str/join "\n" lines)) "}"))
-    (pr-str v)))
-
-(defn- render-body
+(defn- ^{:stratum 1} render-body
   "Build the human-readable comment body with the embedded EDN payload
    block."
   [violation payload]
@@ -122,10 +139,10 @@
        "```\n"
        "<sub>Posted by `miniforge-policy-evaluator[bot]` — see N13 §2.3</sub>"))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Single-comment builder
+;------------------------------------------------------------------------------ Layer 2
 
-(defn violation->comment
+;; Single-comment builder
+(defn ^{:stratum 2} violation->comment
   "Render a single classified Violation to the comment record per
    N13 §2.3.
 
@@ -149,10 +166,10 @@
      :comment/body    body
      :comment/payload payload}))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Bulk renderer
+;------------------------------------------------------------------------------ Layer 3
 
-(defn violations->comments
+;; Bulk renderer
+(defn ^{:stratum 3} violations->comments
   "Render a vector of classified Violations to a vector of comment
    records.
 
@@ -167,28 +184,6 @@
        (sort-by (juxt :comment/path :comment/line
                       (comp str :violation/rule-id :comment/payload)))
        vec))
-
-;------------------------------------------------------------------------------ Layer 2
-;; Parser (round-trip helper)
-
-(defn extract-payload
-  "Extract a `:comment/payload` map from a comment body produced by
-   `render-body`. Returns nil if no payload block is found.
-
-   Used by the Comment Response Agent's bot-comment-table parser
-   (per `pr-monitoring-workflow.md` Bot Comment Handling) to recover
-   the structured payload from a posted comment."
-  [body]
-  (when (string? body)
-    (let [block-re #"(?s)```edn\s*:comment/payload\s*(\{.*?\})\s*```"]
-      (when-let [[_ edn-str] (re-find block-re body)]
-        (try
-          ;; clojure.edn/read-string is strictly EDN — no reader macros,
-          ;; no #=, no eval. Comment bodies are untrusted input once
-          ;; posted/retrieved from a PR. {:default identity} swallows
-          ;; unknown tagged literals safely.
-          (edn/read-string {:default (fn [_tag value] value)} edn-str)
-          (catch Exception _ nil))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.compliance-scanner.exceptions-as-data
   "Exceptions-as-data linter (Dewey 005).
 
@@ -43,20 +42,20 @@
    [clojure.tools.reader.reader-types        :as rt]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Rule identity
 
-(def rule-id
+;; Rule identity
+(def ^{:stratum 0} rule-id
   :std/exceptions-as-data)
 
-(def rule-category
+(def ^{:stratum 0} rule-category
   "Dewey category for foundations/exceptions-as-data."
   "005")
 
-(def rule-title
+(def ^{:stratum 0} rule-title
   "Human-readable title surfaced in scan output."
   "Exceptions as Data")
 
-(def suggestion
+(def ^{:stratum 0} suggestion
   "One-sentence pointer to the suggested rewrite. Linter is informational
    only — actual rewrites belong to the cleanup workstream and are guided
    by the canonical `ai.miniforge.anomaly.interface/anomaly` constructor."
@@ -64,19 +63,17 @@
        "instead of throwing; reserve throws for boundary namespaces and "
        "programmer-error guards."))
 
-;------------------------------------------------------------------------------ Layer 0
 ;; Boundary-namespace detection
 ;;
 ;; Boundary namespaces are exempt from the rule because they sit at the
 ;; system edge where exception conversion is appropriate. Spec lives in
 ;; .standards/foundations/exceptions-as-data.mdc — this list mirrors it.
-
-(def ^:private boundary-segment-patterns
+(def ^{:stratum 0} ^:private boundary-segment-patterns
   "Namespace segments that mark a boundary file. A file is a boundary
    if any of its dotted segments matches one of these."
   #{"cli" "boundary" "http" "web" "mcp" "consumer" "listener" "listeners"})
 
-(def ^:private boundary-prefix-patterns
+(def ^{:stratum 0} ^:private boundary-prefix-patterns
   "Whole namespace prefixes that mark boundary bases whose Polylith name
    cannot be represented as a standalone dotted segment. Keep this list
    narrow so component names that merely contain boundary words, such as
@@ -88,11 +85,11 @@
   #{"ai.miniforge.mcp-context-server"
     "ai.miniforge.response.anomaly"})
 
-(def ^:private boundary-suffix-patterns
+(def ^{:stratum 0} ^:private boundary-suffix-patterns
   "Whole-namespace suffixes that mark boundary files."
   #{"main"})
 
-(defn- ns-segments
+(defn- ^{:stratum 0} ns-segments
   "Split a fully-qualified ns symbol or string into its dotted segments.
    Returns [] when the value is not a usable ns value."
   [ns-sym]
@@ -100,69 +97,20 @@
     (str/split (str ns-sym) #"\.")
     []))
 
-(defn- boundary-prefix?
-  [ns-sym]
-  (let [ns-str (when (and ns-sym (or (symbol? ns-sym) (string? ns-sym)))
-                 (str ns-sym))]
-    (boolean
-     (when ns-str
-       (some (fn [prefix]
-               (or (= ns-str prefix)
-                   (str/starts-with? ns-str (str prefix "."))))
-             boundary-prefix-patterns)))))
-
-(defn boundary-namespace?
-  "Return true when the given namespace symbol denotes a boundary file
-   per the rule's exemption list. Pure — depends only on the name.
-
-   Boundary segments must appear as standalone dotted segments of the
-   namespace (e.g. `ai.miniforge.foo.http.handlers`). Component names
-   that merely contain `http` (e.g. `bb-data-plane-http`) are NOT
-   boundaries — those components are still required to return anomalies
-   internally and only convert at their CLI / handler edge."
-  [ns-sym]
-  (let [segs     (ns-segments ns-sym)
-        last-seg (last segs)]
-    (boolean
-     (or (some boundary-segment-patterns segs)
-         (boundary-prefix? ns-sym)
-         (when last-seg
-           (or (contains? boundary-suffix-patterns last-seg)
-               (str/ends-with? last-seg "-main")))))))
-
-;------------------------------------------------------------------------------ Layer 0
 ;; Throw-shape recognition
-
-(def ^:private throw-call-symbols
+(def ^{:stratum 0} ^:private throw-call-symbols
   "Bare or namespaced symbols whose call position is a throw boundary.
    `throw-anomaly!` is canonical anomaly-as-thrown-data; flagging it
    leaves the per-site judgment to the human reviewer."
   #{'throw 'throw+ 'throw-anomaly! 'response/throw-anomaly!})
 
-(def ^:private throw-class-suffixes
+(def ^{:stratum 0} ^:private throw-class-suffixes
   "Constructor-form class-name suffixes that count as exception
    instantiation regardless of qualifier (e.g. `IllegalArgumentException.`,
    `java.lang.RuntimeException.`)."
   ["Exception." "Error." "Throwable."])
 
-(defn- throw-call?
-  "True when `head` is a symbol calling out a throw-shaped operator."
-  [head]
-  (and (symbol? head)
-       (or (contains? throw-call-symbols head)
-           (let [bare (symbol (name head))]
-             (contains? throw-call-symbols bare)))))
-
-(defn- throw-class?
-  "True when `head` is a Class. constructor symbol whose name ends in
-   one of the configured exception suffixes."
-  [head]
-  (and (symbol? head)
-       (let [s (name head)]
-         (and (str/ends-with? s ".")
-              (boolean (some #(str/ends-with? s %) throw-class-suffixes))))))
-
-(defn- ex-info-call?
+(defn- ^{:stratum 0} ex-info-call?
   "True when `head` is a symbol whose unqualified `name` is `ex-info`.
 
    This matches:
@@ -178,20 +126,8 @@
   (and (symbol? head)
        (= "ex-info" (name head))))
 
-(defn- throw-shaped-form?
-  "Classify a list-form's head as a throw-shaped operator. Returns
-   the operator kind keyword or nil."
-  [head]
-  (cond
-    (throw-call? head)   :throw
-    (throw-class? head)  :ctor
-    (ex-info-call? head) :ex-info
-    :else                nil))
-
-;------------------------------------------------------------------------------ Layer 0
 ;; Programmer-error-guard classification
-
-(def ^:private programmer-error-markers
+(def ^{:stratum 0} ^:private programmer-error-markers
   "Lowercase substrings within the throw message (or in any keyword /
    symbol name appearing inside the throw expression) that signal a
    programmer error / boot-time guard. Markers come straight from the
@@ -220,7 +156,7 @@
    "unmapped"
    "no matching"])
 
-(defn- collect-text
+(defn- ^{:stratum 0} collect-text
   "Collect every string-shaped piece of evidence — string literals plus
    the names of keywords and symbols — that appears anywhere within
    `form`, walking recursively. The keyword/symbol names are included
@@ -245,7 +181,170 @@
                                   form)
      :else                [])))
 
-(defn- programmer-error-guard?
+;; Local boundary-wrapper classification
+(defn- ^{:stratum 0} defn-form?
+  [form]
+  (and (seq? form)
+       (symbol? (first form))
+       (contains? #{"defn" "defn-"} (name (first form)))))
+
+(defn- ^{:stratum 0} bang-symbol?
+  [sym]
+  (and (symbol? sym)
+       (str/ends-with? (name sym) "!")))
+
+;; Reader integration
+(defn- ^{:stratum 0} indexing-pushback
+  "Build an indexing pushback reader from a string. We use the indexing
+   reader so each form carries `:line` / `:column` reader-meta, which
+   we propagate into the violation map."
+  [^String content]
+  (rt/indexing-push-back-reader (java.io.PushbackReader.
+                                 (java.io.StringReader. content))))
+
+(defn- ^{:stratum 0} form-line
+  "Extract `:line` from form metadata, defaulting to 0."
+  [form]
+  (or (when (instance? clojure.lang.IObj form)
+        (:line (meta form)))
+      0))
+
+(defn- ^{:stratum 0} form-column
+  "Extract `:column` from form metadata, defaulting to 0."
+  [form]
+  (or (when (instance? clojure.lang.IObj form)
+        (:column (meta form)))
+      0))
+
+(defn- ^{:stratum 0} ns-form?
+  "True when `form` is a `(ns ...)` declaration."
+  [form]
+  (and (seq? form)
+       (= 'ns (first form))))
+
+;; Walk + classify
+(defn- ^{:stratum 0} form-snippet
+  "Render a short single-line snippet of the form for the violation's
+   `:current` field. Truncated to keep CLI output readable."
+  [form]
+  (let [s (try (pr-str form)
+               (catch Exception _ "<unprintable>"))
+        one-line (-> s
+                     (str/replace #"\s+" " ")
+                     str/trim)
+        max-len 120]
+    (if (> (count one-line) max-len)
+      (str (subs one-line 0 max-len) " …")
+      one-line)))
+
+(defn- ^{:stratum 0} simple-rethrow?
+  [form]
+  (and (seq? form)
+       (= 'throw (first form))
+       (= 2 (count form))
+       (symbol? (second form))))
+
+(defn- ^{:stratum 0} throw-anomaly-form?
+  [form]
+  (and (seq? form)
+       (symbol? (first form))
+       (= "throw-anomaly!" (name (first form)))))
+
+(def ^{:stratum 0} ^:private cleanup-rethrow-markers
+  "Cleanup operations that make a same-catch rethrow informational.
+
+   This is deliberately narrow: a log-and-rethrow remains actionable, while
+   scheduler shutdown and future cancellation preserve resources before
+   propagating the original failure."
+  #{"shutdownNow" ".shutdownNow" "future-cancel"})
+
+(def ^{:stratum 0} ^:private skip-walk-heads
+  "Forms whose contents are not analyzed. `comment` is a Rich Comment
+   block and its body is dev-only. The inventory excludes these."
+  #{'comment 'clojure.core/comment})
+
+(defn- ^{:stratum 0} interrupted-exception-catch?
+  [form]
+  (and (seq? form)
+       (= 'catch (first form))
+       (let [class-sym (second form)]
+         (and (symbol? class-sym)
+              (= "InterruptedException" (name class-sym))))))
+
+;; File enumeration and scan entry point
+(defn- ^{:stratum 0} target-file?
+  "True when the path matches `components/*/src/**/*.clj` or
+   `bases/*/src/**/*.clj`. Repo-relative path expected."
+  [^String relative-path]
+  (and (or (str/starts-with? relative-path "components/")
+           (str/starts-with? relative-path "bases/"))
+       (or (str/ends-with? relative-path ".clj")
+           (str/ends-with? relative-path ".cljc"))
+       (str/includes? relative-path "/src/")))
+
+(defn- ^{:stratum 0} normalize-separators
+  "Convert platform path separators to forward slash. `target-file?`
+   matches against forward-slash-delimited segments (`components/`,
+   `/src/`), which is the canonical Polylith convention. On Windows,
+   `getAbsolutePath` returns backslashes; without normalization the
+   linter would scan zero files. On Linux/macOS this is a no-op."
+  [^String path]
+  (if (= "\\" java.io.File/separator)
+    (str/replace path "\\" "/")
+    path))
+
+(defn- ^{:stratum 0} within-root?
+  "Return true iff the canonical path of `candidate` starts with the
+   canonical path of `root` followed by the system file separator.
+   Uses canonical paths to resolve symlinks and `..` segments before
+   the comparison, preventing path-traversal via relative-path inputs.
+
+   Returns false (safe default) when .getCanonicalPath throws
+   IOException or SecurityException so the caller's exceptions-as-data
+   contract is preserved."
+  [^java.io.File root ^java.io.File candidate]
+  (try
+    (let [canonical-root      (.getCanonicalPath root)
+          canonical-candidate (.getCanonicalPath candidate)
+          sep                 java.io.File/separator
+          prefix              (if (str/ends-with? canonical-root sep)
+                                canonical-root
+                                (str canonical-root sep))]
+      (str/starts-with? canonical-candidate prefix))
+    (catch Exception _
+      false)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} boundary-prefix?
+  [ns-sym]
+  (let [ns-str (when (and ns-sym (or (symbol? ns-sym) (string? ns-sym)))
+                 (str ns-sym))]
+    (boolean
+     (when ns-str
+       (some (fn [prefix]
+               (or (= ns-str prefix)
+                   (str/starts-with? ns-str (str prefix "."))))
+             boundary-prefix-patterns)))))
+
+(defn- ^{:stratum 1} throw-call?
+  "True when `head` is a symbol calling out a throw-shaped operator."
+  [head]
+  (and (symbol? head)
+       (or (contains? throw-call-symbols head)
+           (let [bare (symbol (name head))]
+             (contains? throw-call-symbols bare)))))
+
+(defn- ^{:stratum 1} throw-class?
+  "True when `head` is a Class. constructor symbol whose name ends in
+   one of the configured exception suffixes."
+  [head]
+  (and (symbol? head)
+       (let [s (name head)]
+         (and (str/ends-with? s ".")
+              (boolean (some #(str/ends-with? s %) throw-class-suffixes))))))
+
+(defn- ^{:stratum 1} programmer-error-guard?
   "True when the throw-shaped form looks like a programmer-error guard.
    Signal: any string, keyword, or symbol name inside the throw
    expression matches one of `programmer-error-markers`. The .standards
@@ -255,21 +354,7 @@
         joined (str/lower-case (str/join " " tokens))]
     (boolean (some #(str/includes? joined %) programmer-error-markers))))
 
-;------------------------------------------------------------------------------ Layer 0
-;; Local boundary-wrapper classification
-
-(defn- defn-form?
-  [form]
-  (and (seq? form)
-       (symbol? (first form))
-       (contains? #{"defn" "defn-"} (name (first form)))))
-
-(defn- bang-symbol?
-  [sym]
-  (and (symbol? sym)
-       (str/ends-with? (name sym) "!")))
-
-(defn- defn-context
+(defn- ^{:stratum 1} defn-context
   "Extract the local function name, docstring, and metadata from a defn form.
    This is intentionally small: enough for classifier context, not a full
    defn parser."
@@ -286,7 +371,7 @@
        :defn-doc  doc
        :defn-meta metadata})))
 
-(defn- local-boundary-wrapper?
+(defn- ^{:stratum 1} local-boundary-wrapper?
   "True when the enclosing defn is a documented local compatibility boundary.
 
   Whole boundary namespaces are exempt earlier. This narrower classifier
@@ -314,18 +399,7 @@
                (str/includes? doc-text "compat")
                (str/includes? doc-text "prefer")))))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Reader integration
-
-(defn- indexing-pushback
-  "Build an indexing pushback reader from a string. We use the indexing
-   reader so each form carries `:line` / `:column` reader-meta, which
-   we propagate into the violation map."
-  [^String content]
-  (rt/indexing-push-back-reader (java.io.PushbackReader.
-                                 (java.io.StringReader. content))))
-
-(defn- read-all-forms
+(defn- ^{:stratum 1} read-all-forms
   "Read every top-level form from the file content.
 
    Returns a vector of forms. The indexing reader attaches `:line` and
@@ -345,27 +419,7 @@
           (persistent! acc)
           (recur (conj! acc form)))))))
 
-(defn- form-line
-  "Extract `:line` from form metadata, defaulting to 0."
-  [form]
-  (or (when (instance? clojure.lang.IObj form)
-        (:line (meta form)))
-      0))
-
-(defn- form-column
-  "Extract `:column` from form metadata, defaulting to 0."
-  [form]
-  (or (when (instance? clojure.lang.IObj form)
-        (:column (meta form)))
-      0))
-
-(defn- ns-form?
-  "True when `form` is a `(ns ...)` declaration."
-  [form]
-  (and (seq? form)
-       (= 'ns (first form))))
-
-(defn- extract-ns-symbol
+(defn- ^{:stratum 1} extract-ns-symbol
   "Return the namespace symbol from a vector of top-level forms,
    or nil if none present."
   [forms]
@@ -375,51 +429,123 @@
               (when (symbol? n) n))))
         forms))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Walk + classify
-
-(defn- form-snippet
-  "Render a short single-line snippet of the form for the violation's
-   `:current` field. Truncated to keep CLI output readable."
-  [form]
-  (let [s (try (pr-str form)
-               (catch Exception _ "<unprintable>"))
-        one-line (-> s
-                     (str/replace #"\s+" " ")
-                     str/trim)
-        max-len 120]
-    (if (> (count one-line) max-len)
-      (str (subs one-line 0 max-len) " …")
-      one-line)))
-
-(defn- simple-rethrow?
-  [form]
-  (and (seq? form)
-       (= 'throw (first form))
-       (= 2 (count form))
-       (symbol? (second form))))
-
-(defn- throw-anomaly-form?
-  [form]
-  (and (seq? form)
-       (symbol? (first form))
-       (= "throw-anomaly!" (name (first form)))))
-
-(def ^:private cleanup-rethrow-markers
-  "Cleanup operations that make a same-catch rethrow informational.
-
-   This is deliberately narrow: a log-and-rethrow remains actionable, while
-   scheduler shutdown and future cancellation preserve resources before
-   propagating the original failure."
-  #{"shutdownNow" ".shutdownNow" "future-cancel"})
-
-(defn- cleanup-call?
+(defn- ^{:stratum 1} cleanup-call?
   [form]
   (boolean
    (some cleanup-rethrow-markers
          (map name (filter symbol? (tree-seq coll? seq form))))))
 
-(defn- cleanup-before-rethrow?
+(defn- ^{:stratum 1} ->violation-record
+  "Construct an internal violation record. Severity is always informational
+   — exceptions-as-data is `:warning`, never `:error`, until cleanup
+   completes."
+  [file-path form classification kind]
+  {:file       file-path
+   :line       (form-line form)
+   :column     (form-column form)
+   :kind       kind
+   :classification classification
+   :snippet    (form-snippet form)})
+
+(defn- ^{:stratum 1} interrupted-catch-binding
+  [form]
+  (when (interrupted-exception-catch? form)
+    (let [binding-sym (nth form 2 nil)]
+      (when (symbol? binding-sym)
+        binding-sym))))
+
+(defn- ^{:stratum 1} list-target-files
+  "Walk the repo root and return repo-relative paths for every Clojure
+   source file under components/*/src or bases/*/src. Test files are
+   intentionally excluded — the rule is about production source.
+
+   Paths are normalized to forward-slash separators so `target-file?`
+   matches consistently on Windows and POSIX hosts."
+  [repo-root]
+  (let [root     (io/file repo-root)
+        root-len (inc (count (.getAbsolutePath root)))]
+    (->> (file-seq root)
+         (filter #(.isFile ^java.io.File %))
+         (map (fn [^java.io.File f]
+                (let [abs (.getAbsolutePath f)
+                      rel (if (>= (count abs) root-len)
+                            (subs abs root-len)
+                            abs)]
+                  (normalize-separators rel))))
+         (filter target-file?)
+         vec)))
+
+(defn- ^{:stratum 1} format-violation
+  "Build a public Violation map (per compliance-scanner schema) from an
+   internal record. Severity policy: every emit defaults to `:warning`,
+   even `:fatal-only` rows — the latter just carry that classification
+   in their rationale so consumers can filter."
+  [{:keys [file line column kind classification snippet]}]
+  (let [kind-name (case kind
+                    :throw   "throw"
+                    :ctor    "exception ctor"
+                    :ex-info "ex-info"
+                    "throw-shaped")
+        rationale (case classification
+                    :fatal-only
+                    (str kind-name " classified :fatal-only "
+                         "(programmer-error guard); informational only")
+                    :local-boundary
+                    (str kind-name " inside documented local boundary wrapper; "
+                         "informational only")
+                    (str kind-name " outside boundary namespace; "
+                         "consider returning an anomaly map"))]
+    (-> (factory/->violation
+         rule-id rule-category rule-title
+         file
+         ;; Clamp line to a positive integer. `(or line 1)` does not
+         ;; suffice — a literal 0 from `form-line`'s default is truthy
+         ;; and would propagate through, producing invalid `file:0:col`
+         ;; locations in output.
+         (max 1 (long (or line 1)))
+         snippet
+         suggestion
+         false             ; never auto-fixable; cleanup is a human pass
+         rationale)
+        (assoc :severity             :warning
+               :column               (or column 0)
+               :classification       classification
+               ;; Tell the classify phase to leave :auto-fixable? false:
+               ;; the linter is a human-review gate, not a mechanical fix.
+               :auto-fixable-default false))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} boundary-namespace?
+  "Return true when the given namespace symbol denotes a boundary file
+   per the rule's exemption list. Pure — depends only on the name.
+
+   Boundary segments must appear as standalone dotted segments of the
+   namespace (e.g. `ai.miniforge.foo.http.handlers`). Component names
+   that merely contain `http` (e.g. `bb-data-plane-http`) are NOT
+   boundaries — those components are still required to return anomalies
+   internally and only convert at their CLI / handler edge."
+  [ns-sym]
+  (let [segs     (ns-segments ns-sym)
+        last-seg (last segs)]
+    (boolean
+     (or (some boundary-segment-patterns segs)
+         (boundary-prefix? ns-sym)
+         (when last-seg
+           (or (contains? boundary-suffix-patterns last-seg)
+               (str/ends-with? last-seg "-main")))))))
+
+(defn- ^{:stratum 2} throw-shaped-form?
+  "Classify a list-form's head as a throw-shaped operator. Returns
+   the operator kind keyword or nil."
+  [head]
+  (cond
+    (throw-call? head)   :throw
+    (throw-class? head)  :ctor
+    (ex-info-call? head) :ex-info
+    :else                nil))
+
+(defn- ^{:stratum 2} cleanup-before-rethrow?
   [catch-form binding-sym]
   (let [body (drop 3 catch-form)]
     (loop [forms body
@@ -437,7 +563,7 @@
           (recur (next forms) saw-cleanup?))
         false))))
 
-(defn- classify-throw-site
+(defn- ^{:stratum 2} classify-throw-site
   "Return the severity classification for a throw-shaped form found in
    a non-boundary namespace. Documented local boundary wrappers are
    `:local-boundary`; programmer-error guards, exact `InterruptedException`
@@ -465,39 +591,9 @@
     :else
     :cleanup-needed))
 
-(defn- ->violation-record
-  "Construct an internal violation record. Severity is always informational
-   — exceptions-as-data is `:warning`, never `:error`, until cleanup
-   completes."
-  [file-path form classification kind]
-  {:file       file-path
-   :line       (form-line form)
-   :column     (form-column form)
-   :kind       kind
-   :classification classification
-   :snippet    (form-snippet form)})
+;------------------------------------------------------------------------------ Layer 3
 
-(def ^:private skip-walk-heads
-  "Forms whose contents are not analyzed. `comment` is a Rich Comment
-   block and its body is dev-only. The inventory excludes these."
-  #{'comment 'clojure.core/comment})
-
-(defn- interrupted-exception-catch?
-  [form]
-  (and (seq? form)
-       (= 'catch (first form))
-       (let [class-sym (second form)]
-         (and (symbol? class-sym)
-              (= "InterruptedException" (name class-sym))))))
-
-(defn- interrupted-catch-binding
-  [form]
-  (when (interrupted-exception-catch? form)
-    (let [binding-sym (nth form 2 nil)]
-      (when (symbol? binding-sym)
-        binding-sym))))
-
-(defn- form-context
+(defn- ^{:stratum 3} form-context
   "Enrich traversal context once for a parent form before walking children."
   [context form]
   (let [defn-data   (defn-context form)
@@ -516,7 +612,9 @@
            (cleanup-before-rethrow? form catch-binding))
       (assoc :cleanup-rethrow-binding catch-binding))))
 
-(defn- visit-form
+;------------------------------------------------------------------------------ Layer 4
+
+(defn- ^{:stratum 4} visit-form
   "Walk a single form and conj violation records onto `acc!` (a transient
    vector). Recurses into seqable children, including vectors and maps.
 
@@ -569,7 +667,9 @@
     :else
     acc!)))
 
-(defn analyze-content
+;------------------------------------------------------------------------------ Layer 5
+
+(defn ^{:stratum 5} analyze-content
   "Analyze a single Clojure source file's content. Returns a map with:
 
      :ns           — the resolved namespace symbol (or nil)
@@ -590,112 +690,9 @@
      :boundary?  boundary?
      :violations violations}))
 
-;------------------------------------------------------------------------------ Layer 2
-;; File enumeration and scan entry point
+;------------------------------------------------------------------------------ Layer 6
 
-(defn- target-file?
-  "True when the path matches `components/*/src/**/*.clj` or
-   `bases/*/src/**/*.clj`. Repo-relative path expected."
-  [^String relative-path]
-  (and (or (str/starts-with? relative-path "components/")
-           (str/starts-with? relative-path "bases/"))
-       (or (str/ends-with? relative-path ".clj")
-           (str/ends-with? relative-path ".cljc"))
-       (str/includes? relative-path "/src/")))
-
-(defn- normalize-separators
-  "Convert platform path separators to forward slash. `target-file?`
-   matches against forward-slash-delimited segments (`components/`,
-   `/src/`), which is the canonical Polylith convention. On Windows,
-   `getAbsolutePath` returns backslashes; without normalization the
-   linter would scan zero files. On Linux/macOS this is a no-op."
-  [^String path]
-  (if (= "\\" java.io.File/separator)
-    (str/replace path "\\" "/")
-    path))
-
-(defn- list-target-files
-  "Walk the repo root and return repo-relative paths for every Clojure
-   source file under components/*/src or bases/*/src. Test files are
-   intentionally excluded — the rule is about production source.
-
-   Paths are normalized to forward-slash separators so `target-file?`
-   matches consistently on Windows and POSIX hosts."
-  [repo-root]
-  (let [root     (io/file repo-root)
-        root-len (inc (count (.getAbsolutePath root)))]
-    (->> (file-seq root)
-         (filter #(.isFile ^java.io.File %))
-         (map (fn [^java.io.File f]
-                (let [abs (.getAbsolutePath f)
-                      rel (if (>= (count abs) root-len)
-                            (subs abs root-len)
-                            abs)]
-                  (normalize-separators rel))))
-         (filter target-file?)
-         vec)))
-
-(defn- format-violation
-  "Build a public Violation map (per compliance-scanner schema) from an
-   internal record. Severity policy: every emit defaults to `:warning`,
-   even `:fatal-only` rows — the latter just carry that classification
-   in their rationale so consumers can filter."
-  [{:keys [file line column kind classification snippet]}]
-  (let [kind-name (case kind
-                    :throw   "throw"
-                    :ctor    "exception ctor"
-                    :ex-info "ex-info"
-                    "throw-shaped")
-        rationale (case classification
-                    :fatal-only
-                    (str kind-name " classified :fatal-only "
-                         "(programmer-error guard); informational only")
-                    :local-boundary
-                    (str kind-name " inside documented local boundary wrapper; "
-                         "informational only")
-                    (str kind-name " outside boundary namespace; "
-                         "consider returning an anomaly map"))]
-    (-> (factory/->violation
-         rule-id rule-category rule-title
-         file
-         ;; Clamp line to a positive integer. `(or line 1)` does not
-         ;; suffice — a literal 0 from `form-line`'s default is truthy
-         ;; and would propagate through, producing invalid `file:0:col`
-         ;; locations in output.
-         (max 1 (long (or line 1)))
-         snippet
-         suggestion
-         false             ; never auto-fixable; cleanup is a human pass
-         rationale)
-        (assoc :severity             :warning
-               :column               (or column 0)
-               :classification       classification
-               ;; Tell the classify phase to leave :auto-fixable? false:
-               ;; the linter is a human-review gate, not a mechanical fix.
-               :auto-fixable-default false))))
-
-(defn- within-root?
-  "Return true iff the canonical path of `candidate` starts with the
-   canonical path of `root` followed by the system file separator.
-   Uses canonical paths to resolve symlinks and `..` segments before
-   the comparison, preventing path-traversal via relative-path inputs.
-
-   Returns false (safe default) when .getCanonicalPath throws
-   IOException or SecurityException so the caller's exceptions-as-data
-   contract is preserved."
-  [^java.io.File root ^java.io.File candidate]
-  (try
-    (let [canonical-root      (.getCanonicalPath root)
-          canonical-candidate (.getCanonicalPath candidate)
-          sep                 java.io.File/separator
-          prefix              (if (str/ends-with? canonical-root sep)
-                                canonical-root
-                                (str canonical-root sep))]
-      (str/starts-with? canonical-candidate prefix))
-    (catch Exception _
-      false)))
-
-(defn analyze-file
+(defn ^{:stratum 6} analyze-file
   "Analyze a single file by absolute or relative path. Returns a vector
    of public Violation maps.
 
@@ -722,7 +719,9 @@
             []))
         []))))
 
-(defn scan-repo
+;------------------------------------------------------------------------------ Layer 7
+
+(defn ^{:stratum 7} scan-repo
   "Scan a repository for exceptions-as-data violations.
 
    Arguments:
@@ -759,7 +758,6 @@
                       :local-boundary local-boundary}})))
 
 ;------------------------------------------------------------------------------ Rich Comment
-
 (comment
   ;; Run the linter against the current repo.
   (def result (scan-repo "."))

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/execute.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/execute.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.compliance-scanner.execute
   "Apply auto-fixable violations to files and create one PR per rule.
 
@@ -29,9 +28,9 @@
             [clojure.string     :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; File patch helpers
 
-(defn- apply-line-replacement
+;; File patch helpers
+(defn- ^{:stratum 0} apply-line-replacement
   "Replace the first occurrence of :current with :suggested on the violation's line.
    lines is a vector of strings (0-indexed). line numbers in violations are 1-indexed."
   [lines violation]
@@ -42,18 +41,18 @@
       (update lines idx str/replace-first current suggested)
       lines)))
 
-(defn- prepend-violation?
+(defn- ^{:stratum 0} prepend-violation?
   "Return true if a violation is a prepend-type remediation."
   [violation]
   (or (= :prepend (get violation :remediation-type))
       (= :std/header-copyright (get violation :rule/id))))
 
-(defn- append-violation?
+(defn- ^{:stratum 0} append-violation?
   "Return true if a violation is an append-type remediation."
   [violation]
   (= :append (get violation :remediation-type)))
 
-(defn- apply-prepend
+(defn- ^{:stratum 0} apply-prepend
   "Prepend content from the violation's remediation template."
   [content violation]
   (let [template (get violation :remediation-template)]
@@ -61,7 +60,7 @@
       (str template "\n" content)
       content)))
 
-(defn- apply-append
+(defn- ^{:stratum 0} apply-append
   "Append content from the violation's remediation template."
   [content violation]
   (let [template (get violation :remediation-template)]
@@ -71,7 +70,66 @@
         (str content "\n" template "\n"))
       content)))
 
-(defn patch-file-content
+(def ^{:stratum 0} ^:private semantic-repair-template
+  "Template for LLM semantic repair prompts.
+   Pack-bundled templates (PR #463) will supersede this when wired."
+  (str "Fix the following code violation.\n\n"
+       "**Rule:** %s\n"
+       "**File:** %s:%s\n"
+       "**Current code:** `%s`\n"
+       "**Issue:** %s\n"
+       "%s\n"
+       "\nProvide the corrected code only, no explanation."))
+
+;; Git shell helpers
+(defn- ^{:stratum 0} git!
+  "Run a git command in repo-path directory. Returns the sh result map.
+   Logs non-zero exit codes for debugging (branch -D failures are expected)."
+  [repo-path & args]
+  (let [result (apply shell/sh "git" (concat args [:dir repo-path]))]
+    (when (and (not (zero? (:exit result)))
+               (not (str/includes? (str args) "branch")))  ;; branch -D may fail safely
+      (println (str "  git " (str/join " " args) " → exit " (:exit result)))
+      (when-not (str/blank? (:err result))
+        (println (str "  stderr: " (str/trim (:err result))))))
+    result))
+
+(defn- ^{:stratum 0} branch-slug
+  "Convert a rule category and title to a valid git branch segment."
+  [category title]
+  (-> (str/lower-case title)
+      (str/replace #"[^a-z0-9]+" "-")
+      (str/replace #"-+$" "")
+      (->> (str "fix/compliance-" category "-"))))
+
+;------------------------------------------------------------------------------ Layer 1.5
+;; PR documentation (pure)
+(defn- ^{:stratum 0} today-str
+  "Return today's date as YYYY-MM-DD."
+  []
+  (str (java.time.LocalDate/now)))
+
+(defn- ^{:stratum 0} format-violation-line
+  "Format a single violation as a markdown table row."
+  [v]
+  (str "| `" (get v :file "") "` | " (get v :line 0)
+       " | `" (get v :current "") "`"
+       (when-let [s (get v :suggested)]
+         (str " | `" s "`"))
+       " |"))
+
+(defn- ^{:stratum 0} write-pr-doc!
+  "Write the PR documentation file. Creates parent directories if needed.
+   Returns the relative path written."
+  [repo-path relative-path content]
+  (let [f (io/file repo-path relative-path)]
+    (io/make-parents f)
+    (spit f content)
+    relative-path))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} patch-file-content
   "Apply all violations for one file to its string content. Pure — no I/O.
 
    Line-replacement violations are applied bottom-up (descending line number) so
@@ -95,18 +153,7 @@
                         patched)]
     patched))
 
-(def ^:private semantic-repair-template
-  "Template for LLM semantic repair prompts.
-   Pack-bundled templates (PR #463) will supersede this when wired."
-  (str "Fix the following code violation.\n\n"
-       "**Rule:** %s\n"
-       "**File:** %s:%s\n"
-       "**Current code:** `%s`\n"
-       "**Issue:** %s\n"
-       "%s\n"
-       "\nProvide the corrected code only, no explanation."))
-
-(defn build-semantic-repair-prompt
+(defn ^{:stratum 1} build-semantic-repair-prompt
   "Build a structured prompt for LLM-based semantic repair of a violation.
 
    This is the dispatch path for :semantic remediation strategy violations.
@@ -130,61 +177,19 @@
                       (get violation :rationale "")
                       (or reference ""))}))
 
-(defn- patch-file!
-  "Apply auto-fixable violations to a file on disk. No-op if content is unchanged.
-   Returns the absolute file path."
-  [repo-path file violations]
-  (let [path    (str repo-path "/" file)
-        content (slurp path)
-        patched (patch-file-content content violations)]
-    (when-not (= content patched)
-      (spit path patched))
-    path))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Git shell helpers
-
-(defn- git!
-  "Run a git command in repo-path directory. Returns the sh result map.
-   Logs non-zero exit codes for debugging (branch -D failures are expected)."
-  [repo-path & args]
-  (let [result (apply shell/sh "git" (concat args [:dir repo-path]))]
-    (when (and (not (zero? (:exit result)))
-               (not (str/includes? (str args) "branch")))  ;; branch -D may fail safely
-      (println (str "  git " (str/join " " args) " → exit " (:exit result)))
-      (when-not (str/blank? (:err result))
-        (println (str "  stderr: " (str/trim (:err result))))))
-    result))
-
-(defn- branch-slug
-  "Convert a rule category and title to a valid git branch segment."
-  [category title]
-  (-> (str/lower-case title)
-      (str/replace #"[^a-z0-9]+" "-")
-      (str/replace #"-+$" "")
-      (->> (str "fix/compliance-" category "-"))))
-
-(defn- reset-to-origin-main!
+(defn- ^{:stratum 1} reset-to-origin-main!
   "Detach HEAD at origin/main, giving a clean base for the next rule branch."
   [repo-path]
   (git! repo-path "fetch" "origin" "main" "--quiet")
   (git! repo-path "checkout" "--detach" "origin/main"))
 
-(defn- create-rule-branch!
+(defn- ^{:stratum 1} create-rule-branch!
   "Create and checkout a new branch from origin/main. Deletes if already exists."
   [repo-path branch]
   (git! repo-path "branch" "-D" branch)  ;; safe to fail if absent
   (git! repo-path "checkout" "-b" branch "origin/main"))
 
-;------------------------------------------------------------------------------ Layer 1.5
-;; PR documentation (pure)
-
-(defn- today-str
-  "Return today's date as YYYY-MM-DD."
-  []
-  (str (java.time.LocalDate/now)))
-
-(defn- pr-doc-filename
+(defn- ^{:stratum 1} pr-doc-filename
   "Generate the docs/pull-requests/ filename for a compliance PR."
   [category title]
   (let [slug (-> (str/lower-case title)
@@ -192,16 +197,7 @@
                  (str/replace #"-+$" ""))]
     (str "docs/pull-requests/" (today-str) "-fix-" category "-" slug ".md")))
 
-(defn- format-violation-line
-  "Format a single violation as a markdown table row."
-  [v]
-  (str "| `" (get v :file "") "` | " (get v :line 0)
-       " | `" (get v :current "") "`"
-       (when-let [s (get v :suggested)]
-         (str " | `" s "`"))
-       " |"))
-
-(defn- build-pr-doc
+(defn- ^{:stratum 1} build-pr-doc
   "Generate the PR documentation markdown for a compliance fix.
    Pure function — returns the markdown string."
   [branch category title patched-files violations-fixed auto-violations]
@@ -244,7 +240,7 @@
          "---\n"
          "*Auto-generated by the Miniforge compliance scanner.*\n")))
 
-(defn- build-pr-body
+(defn- ^{:stratum 1} build-pr-body
   "Generate the GitHub PR body with YAML attribution frontmatter."
   [category title violations-fixed file-count pr-doc-path]
   (str "```yaml\n"
@@ -265,19 +261,23 @@
        "\n"
        "\uD83E\uDD16 Generated with [Miniforge](https://miniforge.ai)"))
 
-(defn- write-pr-doc!
-  "Write the PR documentation file. Creates parent directories if needed.
-   Returns the relative path written."
-  [repo-path relative-path content]
-  (let [f (io/file repo-path relative-path)]
-    (io/make-parents f)
-    (spit f content)
-    relative-path))
-
 ;------------------------------------------------------------------------------ Layer 2
-;; Per-rule fix, commit, and PR
 
-(defn- fix-and-pr-for-rule!
+(defn- ^{:stratum 2} patch-file!
+  "Apply auto-fixable violations to a file on disk. No-op if content is unchanged.
+   Returns the absolute file path."
+  [repo-path file violations]
+  (let [path    (str repo-path "/" file)
+        content (slurp path)
+        patched (patch-file-content content violations)]
+    (when-not (= content patched)
+      (spit path patched))
+    path))
+
+;------------------------------------------------------------------------------ Layer 3
+
+;; Per-rule fix, commit, and PR
+(defn- ^{:stratum 3} fix-and-pr-for-rule!
   "Create a branch, apply auto-fixable fixes, write PR doc, commit, push, and open a PR.
    Returns a result map with :branch, :pr-url, :violations-fixed, :files-changed, :pr-doc."
   [repo-path rule-id category title tasks]
@@ -330,10 +330,10 @@
          :violations-fixed violations-fixed
          :files-changed    (count patched-files)}))))
 
-;------------------------------------------------------------------------------ Layer 3
-;; Top-level entry point
+;------------------------------------------------------------------------------ Layer 4
 
-(defn execute!
+;; Top-level entry point
+(defn ^{:stratum 4} execute!
   "Apply all auto-fixable violations and create one PR per rule.
 
    Reads DAG tasks from plan, groups by :task/rule-id, and for each rule

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/factory.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/factory.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.compliance-scanner.factory
   "Factory functions for compliance-scanner domain maps.
 
@@ -25,9 +24,9 @@
    Layer 0 — pure data construction, no I/O or side effects.")
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Violation
 
-(defn ->violation
+;; Violation
+(defn ^{:stratum 0} ->violation
   [rule-id rule-category title file line current suggested auto-fixable? rationale]
   {:rule/id       rule-id
    :rule/category rule-category
@@ -39,20 +38,16 @@
    :auto-fixable? auto-fixable?
    :rationale     rationale})
 
-;------------------------------------------------------------------------------ Layer 0
 ;; ScanResult
-
-(defn ->scan-result
+(defn ^{:stratum 0} ->scan-result
   [violations rules-scanned files-scanned scan-duration-ms]
   {:violations       violations
    :rules-scanned    rules-scanned
    :files-scanned    files-scanned
    :scan-duration-ms scan-duration-ms})
 
-;------------------------------------------------------------------------------ Layer 0
 ;; PlanSummary
-
-(defn ->plan-summary
+(defn ^{:stratum 0} ->plan-summary
   [violations]
   (let [auto-fixable (filter :auto-fixable? violations)
         needs-review (remove :auto-fixable? violations)
@@ -64,10 +59,8 @@
      :files-affected   files
      :rules-violated   rules}))
 
-;------------------------------------------------------------------------------ Layer 0
 ;; PlanTask
-
-(defn ->plan-task
+(defn ^{:stratum 0} ->plan-task
   [id deps file rule-id violations]
   {:task/id         id
    :task/deps       deps
@@ -75,19 +68,15 @@
    :task/rule-id    rule-id
    :task/violations violations})
 
-;------------------------------------------------------------------------------ Layer 0
 ;; Plan
-
-(defn ->plan
+(defn ^{:stratum 0} ->plan
   [dag-tasks work-spec summary]
   {:dag-tasks dag-tasks
    :work-spec work-spec
    :summary   summary})
 
-;------------------------------------------------------------------------------ Layer 0
 ;; DeltaReport
-
-(defn ->delta-report
+(defn ^{:stratum 0} ->delta-report
   [repo-path standards-path scan-timestamp summary violations]
   {:repo-path      repo-path
    :standards-path standards-path

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/interface.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.compliance-scanner.interface
   "Public API for the compliance-scanner component.
 
@@ -36,94 +35,100 @@
             [ai.miniforge.compliance-scanner.named-constants    :as named-const]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Schema re-exports
 
-(def Violation
+;; Schema re-exports
+(def ^{:stratum 0} Violation
   "Malli schema (a `[:map ...]` vector) for a single detected rule breach.
    Keys: :rule/id (keyword), :rule/category (non-empty string),
    :rule/title (string), :file (string), :line (int), :current (string),
    :suggested (string or nil), :auto-fixable? (boolean), :rationale (string)."
   schema/Violation)
-(def ScanResult
+
+(def ^{:stratum 0} ScanResult
   "Malli schema (a `[:map ...]` vector) for the output of the scan phase.
    Keys: :violations (vector of Violation), :rules-scanned (vector of
    keywords), :files-scanned (int), :scan-duration-ms (int)."
   schema/ScanResult)
-(def PlanTask
+
+(def ^{:stratum 0} PlanTask
   "Malli schema (a `[:map ...]` vector) for one DAG task node in a Plan.
    Keys: :task/id (uuid), :task/deps (set of uuids), :task/file (string),
    :task/rule-id (keyword), :task/violations (vector of Violation)."
   schema/PlanTask)
-(def Plan
+
+(def ^{:stratum 0} Plan
   "Malli schema (a `[:map ...]` vector) for the full remediation plan.
    Keys: :dag-tasks (vector of PlanTask), :work-spec (string),
    :summary (PlanSummary)."
   schema/Plan)
-(def PlanSummary
+
+(def ^{:stratum 0} PlanSummary
   "Malli schema (a `[:map ...]` vector) of aggregate plan counts.
    Keys: :total-violations, :auto-fixable, :needs-review, :files-affected,
    :rules-violated (all ints)."
   schema/PlanSummary)
 
-;------------------------------------------------------------------------------ Layer 0
 ;; Factory re-exports
-
-(def ->violation
+(def ^{:stratum 0} ->violation
   "Construct a Violation map from positional args:
    [rule-id rule-category title file line current suggested auto-fixable?
    rationale]. Pure; returns the map."
   factory/->violation)
-(def ->scan-result
+
+(def ^{:stratum 0} ->scan-result
   "Construct a ScanResult map from positional args:
    [violations rules-scanned files-scanned scan-duration-ms]. Pure;
    returns the map."
   factory/->scan-result)
-(def ->plan-summary
+
+(def ^{:stratum 0} ->plan-summary
   "Derive a PlanSummary map from a collection of violations by counting
    totals, auto-fixable, needs-review, distinct files, and distinct rules.
    Pure; returns the map."
   factory/->plan-summary)
-(def ->plan-task
+
+(def ^{:stratum 0} ->plan-task
   "Construct a PlanTask map from positional args:
    [id deps file rule-id violations]. Pure; returns the map."
   factory/->plan-task)
-(def ->plan
+
+(def ^{:stratum 0} ->plan
   "Construct a Plan map from positional args:
    [dag-tasks work-spec summary]. Pure; returns the map."
   factory/->plan)
-(def ->delta-report
+
+(def ^{:stratum 0} ->delta-report
   "Construct a DeltaReport map from positional args:
    [repo-path standards-path scan-timestamp summary violations]. Pure;
    returns the map."
   factory/->delta-report)
-(def DeltaReport
+
+(def ^{:stratum 0} DeltaReport
   "Malli schema (a `[:map ...]` vector) for the delta report written to
    disk. Keys: :repo-path (string), :standards-path (string),
    :scan-timestamp (string), :summary (PlanSummary), :violations (vector
    of Violation)."
   schema/DeltaReport)
 
-;------------------------------------------------------------------------------ Layer 0
 ;; Built-in linter re-exports
 ;;
 ;; Standalone Clojure-AST linters that the compliance scanner runs in
 ;; addition to the regex-driven pack rules.
-
-(def exceptions-as-data-rule-id
+(def ^{:stratum 0} exceptions-as-data-rule-id
   "Stable rule id for the exceptions-as-data linter."
   exc-data/rule-id)
 
-(defn scan-exceptions-as-data
+(defn ^{:stratum 0} scan-exceptions-as-data
   "Run the exceptions-as-data linter against `repo-root`. Returns a map
    with `:violations`, `:files-scanned`, `:counts`, and `:rule/id`."
   [repo-root]
   (exc-data/scan-repo repo-root))
 
-(def named-constants-rule-id
+(def ^{:stratum 0} named-constants-rule-id
   "Stable rule id for the named-constants locator."
   named-const/rule-id)
 
-(defn scan-named-constants
+(defn ^{:stratum 0} scan-named-constants
   "Locate magic NUMERIC literals against `repo-root` (Dewey 006). Deterministic,
    LLM-free MEASUREMENT: returns `:violations` (each with `:file`, `:line`,
    `:column`, `:current` (the literal token), `:kind` `:magic-numeric`, and
@@ -135,10 +140,8 @@
   [repo-root]
   (named-const/scan-repo repo-root))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Phase entry points
-
-(defn scan
+(defn ^{:stratum 0} scan
   "Scan a repo for violations across all configured rules.
 
    Arguments:
@@ -150,7 +153,7 @@
   [repo-path standards-path opts]
   (scan/scan-repo repo-path standards-path opts))
 
-(defn classify
+(defn ^{:stratum 0} classify
   "Add :auto-fixable? and :rationale to each violation.
 
    Arguments:
@@ -160,7 +163,7 @@
   [violations]
   (classify/classify-violations violations))
 
-(defn plan
+(defn ^{:stratum 0} plan
   "Generate DAG task defs and markdown work spec from classified violations.
 
    Arguments:
@@ -171,7 +174,7 @@
   [violations repo-path]
   (plan/plan violations repo-path))
 
-(defn write-report!
+(defn ^{:stratum 0} write-report!
   "Write EDN delta report to .miniforge/compliance-report.edn.
 
    Arguments:
@@ -182,7 +185,7 @@
   [delta-report repo-path]
   (report/write-report! delta-report repo-path))
 
-(defn write-work-spec!
+(defn ^{:stratum 0} write-work-spec!
   "Write markdown work spec to docs/compliance/YYYY-MM-DD-compliance-delta.md.
 
    Arguments:
@@ -193,7 +196,37 @@
   [work-spec repo-path]
   (report/write-work-spec! work-spec repo-path))
 
-(defn write-delta-report!
+(defn ^{:stratum 0} execute!
+  "Apply all auto-fixable violations and create one PR per rule.
+
+   Arguments:
+   - plan      - Plan map with :dag-tasks (from the plan phase)
+   - repo-path - string path to the repo/worktree root
+
+   Returns map with :prs (vector of per-rule results), :violations-fixed, :files-changed."
+  [plan repo-path]
+  (execute/execute! plan repo-path))
+
+;; PR-scoped review entry point (N13 §2.2)
+(def ^{:stratum 0} violation->comment
+  "Render a single classified Violation to a PR review comment per
+   N13 §2.3."
+  comments/violation->comment)
+
+(def ^{:stratum 0} violations->comments
+  "Render a vector of classified Violations to a vector of PR review
+   comment records per N13 §2.3."
+  comments/violations->comments)
+
+(def ^{:stratum 0} extract-comment-payload
+  "Recover the embedded `:comment/payload` map from a comment body.
+   Used by the Comment Response Agent to parse posted policy
+   violations."
+  comments/extract-payload)
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} write-delta-report!
   "Build and write EDN delta report from classified violations and plan.
 
    Arguments:
@@ -209,37 +242,7 @@
                                              (:summary plan) classified)]
     (write-report! delta-report repo-path)))
 
-(defn execute!
-  "Apply all auto-fixable violations and create one PR per rule.
-
-   Arguments:
-   - plan      - Plan map with :dag-tasks (from the plan phase)
-   - repo-path - string path to the repo/worktree root
-
-   Returns map with :prs (vector of per-rule results), :violations-fixed, :files-changed."
-  [plan repo-path]
-  (execute/execute! plan repo-path))
-
-;------------------------------------------------------------------------------ Layer 1
-;; PR-scoped review entry point (N13 §2.2)
-
-(def violation->comment
-  "Render a single classified Violation to a PR review comment per
-   N13 §2.3."
-  comments/violation->comment)
-
-(def violations->comments
-  "Render a vector of classified Violations to a vector of PR review
-   comment records per N13 §2.3."
-  comments/violations->comments)
-
-(def extract-comment-payload
-  "Recover the embedded `:comment/payload` map from a comment body.
-   Used by the Comment Response Agent to parse posted policy
-   violations."
-  comments/extract-payload)
-
-(defn pr-review
+(defn ^{:stratum 1} pr-review
   "PR-scoped read-only standards review per N13 §2.2.
 
    Runs scan with `:since base-ref` (incremental + diff-analysis modes),
@@ -301,10 +304,8 @@
                              :files-affected (count (distinct (mapv :file classified)))
                              :rules-violated (count (distinct (mapv :rule/id classified)))}}))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Convenience orchestrator
-
-(defn compliance-run!
+(defn ^{:stratum 1} compliance-run!
   "Convenience: scan → classify → plan → write-report! → write-work-spec!
 
    Arguments:

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/messages.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/messages.clj
@@ -15,12 +15,13 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.compliance-scanner.messages
   "Component-scoped message translator for compliance-scanner."
   (:require [ai.miniforge.messages.interface :as messages]))
 
-(def t
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} t
   (messages/create-translator
    "config/compliance-scanner/messages/en-US.edn"
    :compliance-scanner/messages))

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/named_constants.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/named_constants.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.compliance-scanner.named-constants
   "Named-constants locator (Dewey 006) — deterministic MEASUREMENT tool.
 
@@ -38,43 +37,30 @@
    [clojure.java.io :as io]
    [clojure.string :as str]))
 
-(def rule-id :std/named-constants)
-(def rule-category "006")
+;------------------------------------------------------------------------------ Layer 0
 
-(def ^:private exempt-values
+(def ^{:stratum 0} rule-id :std/named-constants)
+
+(def ^{:stratum 0} rule-category "006")
+
+(def ^{:stratum 0} ^:private exempt-values
   "Numeric values that are structural sentinels, never magic: loop / index
    bounds (-1, 0, 1) and the doubling identity (2). Mirrors the rule's
    \"larger than 2 or smaller than -1\" threshold."
   #{-1.0 0.0 1.0 2.0})
 
-;------------------------------------------------------------------------------ Layer 0
 ;; Numeric classification
-
-(def ^:private numeric-token-pattern
+(def ^{:stratum 0} ^:private numeric-token-pattern
   "A token that is a Clojure numeric literal: integers, decimals (with optional
    exponent and M/N suffix), leading-dot decimals, hex, radix, and ratios."
   #"[-+]?(?:\d+\.?\d*(?:[eE][-+]?\d+)?[MN]?|\.\d+(?:[eE][-+]?\d+)?M?|0[xX][0-9a-fA-F]+|\d+r[0-9a-zA-Z]+|\d+/\d+)")
 
-(defn- numeric-token? [tok]
-  (boolean (re-matches numeric-token-pattern tok)))
-
-(defn- magic-numeric?
-  "True when `tok` is a numeric literal whose value is not a structural
-   sentinel. Hex / radix / ratio literals (which Double/parseDouble cannot
-   read) are treated as magic — they carry meaning worth naming."
-  [tok]
-  (and (numeric-token? tok)
-       (let [t (str/replace tok #"[MN]$" "")]
-         (try
-           (not (contains? exempt-values (Double/parseDouble t)))
-           (catch Exception _ true)))))
-
-(def ^:private token-char?
+(def ^{:stratum 0} ^:private token-char?
   "Characters that may appear inside a symbol / number token. A token ends at
    whitespace or a structural delimiter."
   (complement #{\space \tab \newline \return \, \( \) \[ \] \{ \} \" \; \' \` \~ \@ \^}))
 
-(defn- skip-string
+(defn- ^{:stratum 0} skip-string
   "Given `content` and the index just AFTER an opening quote, return
    `[end-index end-line end-col]` positioned just after the closing quote,
    counting newlines so later line numbers stay correct."
@@ -88,7 +74,51 @@
         (= (.charAt content j) \") [(inc j) l (inc cl)]
         :else (recur (inc j) l (inc cl))))))
 
-(defn scan-numeric-tokens
+(defn- ^{:stratum 0} normalize-separators [^String p] (str/replace p "\\" "/"))
+
+(defn- ^{:stratum 0} target-file? [rel]
+  (and (str/ends-with? rel ".clj")
+       (or (re-find #"^components/[^/]+/src/" rel)
+           (re-find #"^bases/[^/]+/src/" rel))))
+
+(defn- ^{:stratum 0} safe-slurp
+  "Read a file, returning its content or nil on any I/O error (permissions,
+   encoding, transient failure). The locator is best-effort — a single
+   unreadable file must not abort the whole scan."
+  [f]
+  (try (slurp f) (catch Exception _ nil)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} numeric-token? [tok]
+  (boolean (re-matches numeric-token-pattern tok)))
+
+(defn- ^{:stratum 1} list-target-files [repo-root]
+  (let [root (io/file repo-root)
+        root-len (inc (count (.getAbsolutePath root)))]
+    (->> (file-seq root)
+         (filter #(.isFile ^java.io.File %))
+         (map (fn [^java.io.File f]
+                (normalize-separators (subs (.getAbsolutePath f) root-len))))
+         (filter target-file?)
+         vec)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- ^{:stratum 2} magic-numeric?
+  "True when `tok` is a numeric literal whose value is not a structural
+   sentinel. Hex / radix / ratio literals (which Double/parseDouble cannot
+   read) are treated as magic — they carry meaning worth naming."
+  [tok]
+  (and (numeric-token? tok)
+       (let [t (str/replace tok #"[MN]$" "")]
+         (try
+           (not (contains? exempt-values (Double/parseDouble t)))
+           (catch Exception _ true)))))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} scan-numeric-tokens
   "Char-lex `content`, returning `[{:line :col :token}]` for every numeric
    literal token in a CODE position (outside strings, comments, char-literals)."
   [^String content]
@@ -133,10 +163,10 @@
                        (conj! acc {:line line :col col :token tok})
                        acc)))))))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; File + repo scan
+;------------------------------------------------------------------------------ Layer 4
 
-(defn analyze-content
+;; File + repo scan
+(defn ^{:stratum 4} analyze-content
   "Return violation maps for magic numeric literals in `content`.
    `rel` is the repo-relative path used in the record."
   [rel ^String content]
@@ -150,31 +180,9 @@
            :kind     :magic-numeric})
         (scan-numeric-tokens content)))
 
-(defn- normalize-separators [^String p] (str/replace p "\\" "/"))
+;------------------------------------------------------------------------------ Layer 5
 
-(defn- target-file? [rel]
-  (and (str/ends-with? rel ".clj")
-       (or (re-find #"^components/[^/]+/src/" rel)
-           (re-find #"^bases/[^/]+/src/" rel))))
-
-(defn- list-target-files [repo-root]
-  (let [root (io/file repo-root)
-        root-len (inc (count (.getAbsolutePath root)))]
-    (->> (file-seq root)
-         (filter #(.isFile ^java.io.File %))
-         (map (fn [^java.io.File f]
-                (normalize-separators (subs (.getAbsolutePath f) root-len))))
-         (filter target-file?)
-         vec)))
-
-(defn- safe-slurp
-  "Read a file, returning its content or nil on any I/O error (permissions,
-   encoding, transient failure). The locator is best-effort — a single
-   unreadable file must not abort the whole scan."
-  [f]
-  (try (slurp f) (catch Exception _ nil)))
-
-(defn scan-repo
+(defn ^{:stratum 5} scan-repo
   "Scan `repo-root` for magic numeric literals. Returns
    {:violations [...] :files-scanned N :rule/id :std/named-constants
     :counts {:magic-numeric N}}. Pure locator: no writes, no throw, no exit —

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/plan.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/plan.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.compliance-scanner.plan
   "Plan phase: generate DAG task defs and markdown work spec from violations.
 
@@ -28,30 +27,42 @@
             [clojure.string                            :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; DAG topology helpers
 
-(defn- group-by-file-rule
+;; DAG topology helpers
+(defn- ^{:stratum 0} group-by-file-rule
   "Group violations by [file rule-id].
    Returns map of [file rule-id] -> [violation ...]."
   [violations]
   (group-by (fn [v] [(get v :file) (get v :rule/id)]) violations))
 
-(defn- dewey-order
+(defn- ^{:stratum 0} dewey-order
   "Numeric sort key for a Dewey code string."
   [dewey-str]
   (coerce/safe-parse-int dewey-str 0))
 
-(defn- key->uuid-entry
+(defn- ^{:stratum 0} key->uuid-entry
   "Return [k (random-uuid)] for use in building a key->id map."
   [k]
   [k (random-uuid)])
 
-(defn- key->category-entry
+(defn- ^{:stratum 0} key->category-entry
   "Return [k category-string] for a [file rule-id] key and its violations."
   [[k vs]]
   [k (get (first vs) :rule/category "0")])
 
-(defn- file->ordered-rule-ids-entry
+;; Markdown work-spec builder
+(defn- ^{:stratum 0} violation->md-row
+  "Render a single violation as a markdown list item."
+  [v]
+  (let [tag (if (get v :auto-fixable?) (msg/t :plan/tag-auto) (msg/t :plan/tag-review))]
+    (str "- **L" (get v :line) "** `" (get v :current) "`"
+         (when-let [s (get v :suggested)]
+           (str " → `" s "`"))
+         " [" tag "]")))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} file->ordered-rule-ids-entry
   "Return [file ordered-rule-ids] sorted by Dewey category ascending.
    ks is a seq of [file rule-id] keys; the result extracts just the rule-ids."
   [key->cat [file ks]]
@@ -59,7 +70,7 @@
              (sort-by #(dewey-order (get key->cat %)))
              (mapv second))])
 
-(defn- build-task
+(defn- ^{:stratum 1} build-task
   "Build a PlanTask for a [file rule-id] group, resolving intra-file deps."
   [key->id key->cat file->rule-ids [[file rule-id] viols]]
   (let [id        (get key->id [file rule-id])
@@ -70,7 +81,17 @@
         deps      (into #{} (map #(get key->id [file %]) prior-ids))]
     (factory/->plan-task id deps file rule-id viols)))
 
-(defn- build-dag-tasks
+(defn- ^{:stratum 1} render-violation-group
+  "Render a labeled group of violations as markdown lines, or nil if empty."
+  [label viols]
+  (when (seq viols)
+    (concat [label ""]
+            (map violation->md-row viols)
+            [""])))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- ^{:stratum 2} build-dag-tasks
   "Build PlanTask records with intra-file ordering deps.
 
    Within a file, a task for a rule with a higher Dewey category depends on all
@@ -83,27 +104,7 @@
                                      (group-by first (keys groups))))]
     (mapv (partial build-task key->id key->cat file->rule-ids) groups)))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Markdown work-spec builder
-
-(defn- violation->md-row
-  "Render a single violation as a markdown list item."
-  [v]
-  (let [tag (if (get v :auto-fixable?) (msg/t :plan/tag-auto) (msg/t :plan/tag-review))]
-    (str "- **L" (get v :line) "** `" (get v :current) "`"
-         (when-let [s (get v :suggested)]
-           (str " → `" s "`"))
-         " [" tag "]")))
-
-(defn- render-violation-group
-  "Render a labeled group of violations as markdown lines, or nil if empty."
-  [label viols]
-  (when (seq viols)
-    (concat [label ""]
-            (map violation->md-row viols)
-            [""])))
-
-(defn- section-for-rule
+(defn- ^{:stratum 2} section-for-rule
   "Render a markdown section for all violations of one rule."
   [_rule-id viols]
   (let [rule-title (get (first viols) :rule/title (str _rule-id))
@@ -117,7 +118,9 @@
        (render-violation-group (msg/t :plan/auto-fixable-label) auto)
        (render-violation-group (msg/t :plan/needs-review-label) needs)))))
 
-(defn- build-work-spec
+;------------------------------------------------------------------------------ Layer 3
+
+(defn- ^{:stratum 3} build-work-spec
   "Build the full markdown work spec string from classified violations."
   [violations summary]
   (let [by-rule      (group-by :rule/id violations)
@@ -168,10 +171,10 @@
        (msg/t :plan/instr-3)
        ""])))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Top-level entry point
+;------------------------------------------------------------------------------ Layer 4
 
-(defn plan
+;; Top-level entry point
+(defn ^{:stratum 4} plan
   "Generate DAG task defs and markdown work spec from violations.
 
    Arguments:

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/report.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/report.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.compliance-scanner.report
   "EDN delta report and markdown work-spec writers.
 
@@ -25,14 +24,14 @@
             [clojure.pprint  :as pprint]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Path helpers
 
-(defn- report-path
+;; Path helpers
+(defn- ^{:stratum 0} report-path
   "Return the absolute path for the EDN compliance report."
   [repo-path]
   (str repo-path "/.miniforge/compliance-report.edn"))
 
-(defn- work-spec-path
+(defn- ^{:stratum 0} work-spec-path
   "Return the absolute path for the dated markdown work spec."
   [repo-path]
   (let [date-str (.format
@@ -40,15 +39,15 @@
                   (java.time.LocalDate/now))]
     (str repo-path "/docs/compliance/" date-str "-compliance-delta.md")))
 
-(defn- ensure-parent!
+(defn- ^{:stratum 0} ensure-parent!
   "Create parent directories for a file path if they don't exist."
   [file-path]
   (-> (io/file file-path) .getParentFile .mkdirs))
 
 ;------------------------------------------------------------------------------ Layer 1
-;; Report writers
 
-(defn write-report!
+;; Report writers
+(defn ^{:stratum 1} write-report!
   "Write EDN delta report to .miniforge/compliance-report.edn.
 
    Arguments:
@@ -62,7 +61,7 @@
     (spit path (with-out-str (pprint/pprint delta-report)))
     path))
 
-(defn write-work-spec!
+(defn ^{:stratum 1} write-work-spec!
   "Write markdown work spec to docs/compliance/YYYY-MM-DD-compliance-delta.md.
 
    Arguments:

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/scan.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/scan.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.compliance-scanner.scan
   "Scan phase: load files, run detection, return violations.
 
@@ -34,9 +33,9 @@
   (:import [java.nio.file FileSystems Paths]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Per-file detection helpers
 
-(defn- header-present?
+;; Per-file detection helpers
+(defn- ^{:stratum 0} header-present?
   "Return true if the first 10 lines of content contain both
    the name pattern and the email pattern."
   [content name-pattern email-pattern]
@@ -46,13 +45,13 @@
     (and (re-find name-pattern first-10)
          (re-find email-pattern first-10))))
 
-(defn- pattern-present?
+(defn- ^{:stratum 0} pattern-present?
   "Return true if pattern appears anywhere in content.
    Generic negative-mode check (not header-specific)."
   [content pattern]
   (boolean (re-find pattern content)))
 
-(defn- positive-matches
+(defn- ^{:stratum 0} positive-matches
   "Find all lines in content matching pattern.
    Returns seq of {:line int :text string :match string}."
   [pattern content]
@@ -64,72 +63,9 @@
                          :match (if (string? m) m (first m))})))
        (filter :match)))
 
-(defn- violations-for-positive-rule
-  "Scan a single file with a positive-match rule (pattern = violation).
-   Returns vector of Violation maps (without :auto-fixable? / :rationale —
-   those are added by classify)."
-  [rule-cfg file-path content]
-  (let [rule-id  (get rule-cfg :rule/id)
-        rule-cat (get rule-cfg :rule/category)
-        title    (get rule-cfg :title)
-        pattern  (get rule-cfg :pattern)
-        suggest  (get rule-cfg :suggest-fn)
-        matches  (positive-matches pattern content)]
-    (mapv (fn [{:keys [line match]}]
-            (factory/->violation
-             rule-id
-             rule-cat
-             title
-             file-path
-             line
-             match
-             (suggest match)
-             false          ; classify phase fills this in
-             ""))           ; classify phase fills this in
-          matches)))
-
-(defn- violations-for-negative-rule
-  "Scan a single file with a negative-match rule (absence of pattern = violation).
-   Returns a vector of 0 or 1 Violation maps."
-  [rule-cfg file-path content]
-  (let [rule-id  (get rule-cfg :rule/id)
-        rule-cat (get rule-cfg :rule/category)
-        title    (get rule-cfg :title)
-        pattern  (get rule-cfg :pattern)
-        suggest  (get rule-cfg :suggest-fn)
-        ep       (get rule-cfg :email-pattern)
-        present? (if ep
-                   (header-present? content pattern ep)
-                   (pattern-present? content pattern))
-        absence-msg (if ep
-                      (msg/t :scan/missing-header)
-                      (str "(missing: " title ")"))]
-    (if present?
-      []
-      [(factory/->violation
-        rule-id
-        rule-cat
-        title
-        file-path
-        1
-        absence-msg
-        (suggest nil)
-        false
-        "")])))
-
-(defn- scan-file
-  "Dispatch to the appropriate scanner for a rule config.
-   Returns vector of raw (pre-classify) Violation maps."
-  [rule-cfg file-path content]
-  (case (get rule-cfg :detect-mode :positive)
-    :positive (violations-for-positive-rule rule-cfg file-path content)
-    :negative (violations-for-negative-rule rule-cfg file-path content)
-    []))
-
 ;------------------------------------------------------------------------------ Layer 0.5
 ;; Pack-driven detection config
-
-(defn- globs->file-pred
+(defn- ^{:stratum 0} globs->file-pred
   "Convert a vector of glob patterns into a file-path predicate function.
    Uses java.nio.file.PathMatcher for standard glob matching."
   [globs]
@@ -139,7 +75,7 @@
       (let [p (Paths/get path (into-array String []))]
         (boolean (some #(.matches ^java.nio.file.PathMatcher % p) matchers))))))
 
-(defn- build-suggest-fn
+(defn- ^{:stratum 0} build-suggest-fn
   "Build a suggest function from pack detection and remediation config.
    Uses str/replace-first with $1/$2/$3 group references for mechanical fixes."
   [detection remediation]
@@ -158,34 +94,11 @@
       :else
       (constantly nil))))
 
-(defn- pack-rule->detection-config
-  "Convert a compiled pack rule into the detection config format used by scan-file.
-   Returns nil for rules without :content-scan detection."
-  [rule]
-  (let [detection   (get rule :rule/detection)
-        remediation (get rule :rule/remediation)
-        globs       (get-in rule [:rule/applies-to :file-globs])]
-    (when (= :content-scan (get detection :type))
-      (cond->
-        {:rule/id       (get rule :rule/id)
-         :rule/category (get rule :rule/category)
-         :title         (get rule :rule/title)
-         :pattern       (re-pattern (get detection :pattern))
-         :file-pred     (globs->file-pred (or globs ["**/*"]))
-         :suggest-fn    (build-suggest-fn detection remediation)
-         :detect-mode   (get detection :mode :positive)}
-
-        (get detection :email-pattern)
-        (assoc :email-pattern (re-pattern (get detection :email-pattern)))
-
-        remediation
-        (assoc :remediation remediation)))))
-
-(def ^:private scannable-types
+(def ^{:stratum 0} ^:private scannable-types
   "Detection types the compliance scanner can process."
   #{:content-scan :diff-analysis :plan-output})
 
-(def ^:private category-dewey-ranges
+(def ^{:stratum 0} ^:private category-dewey-ranges
   "Category keyword name to Dewey code range [lo hi].
    Static data — no runtime dependency on taxonomy component."
   {"foundations"   [0 99]
@@ -199,65 +112,7 @@
    "project"       [800 899]
    "meta"          [900 999]})
 
-(defn- category-matches?
-  "Check if a rule's Dewey category falls in a category selector's range.
-   Uses static range lookup — no cross-layer dependency."
-  [rule cat-kw]
-  (let [cat-name (name cat-kw)
-        rule-cat (:rule/category rule)]
-    (or (= cat-name rule-cat)
-        (when-let [[lo hi] (get category-dewey-ranges cat-name)]
-          (try
-            (let [code (Integer/parseInt (str rule-cat))]
-              (and (<= lo code) (<= code hi)))
-            (catch Exception _ false))))))
-
-(defn- rule-matches-selector?
-  "Check if a rule matches a selector element (keyword — rule ID or category ID)."
-  [rule selector-kw]
-  (or (= selector-kw (:rule/id rule))
-      (category-matches? rule selector-kw)))
-
-(defn- filter-pack-rules
-  "Filter compiled pack rules by the :rules option.
-
-   Supported selectors:
-   - :all / :always-apply — all rules with scannable detection types
-   - keyword — single rule ID match
-   - set of keywords — matches rule IDs OR category IDs
-     e.g. #{:std/clojure :mf.cat/workflows}
-
-   Only rules with scannable detection types (content-scan, diff-analysis,
-   plan-output) pass through."
-  [pack-rules opts]
-  (let [raw       (get opts :rules :always-apply)
-        requested (if (string? raw) (keyword (subs raw 1)) raw)
-        scannable (filter #(contains? scannable-types
-                                      (get-in % [:rule/detection :type]))
-                          pack-rules)]
-    (cond
-      (contains? #{:all :always-apply} requested) scannable
-      (keyword? requested)  (filter #(= requested (:rule/id %)) scannable)
-      (set? requested)      (filter (fn [rule]
-                                      (some #(rule-matches-selector? rule %) requested))
-                                    scannable)
-      :else                 scannable)))
-
-(defn- load-pack-detection-configs
-  "Load compiled pack from standards-path and convert rules to detection configs.
-   Returns vector of detection config maps, or nil if pack unavailable."
-  [standards-path opts]
-  (try
-    (let [result (policy-pack/compile-standards-pack standards-path)]
-      (when (:success? result)
-        (let [rules     (get-in result [:pack :pack/rules])
-              filtered  (filter-pack-rules rules opts)
-              configs   (keep pack-rule->detection-config filtered)]
-          (when (seq configs)
-            (vec configs)))))
-    (catch Exception _ nil)))
-
-(defn- enrich-violation
+(defn- ^{:stratum 0} enrich-violation
   "Attach remediation metadata from the pack rule to a violation map.
    Downstream classify and execute phases use these fields."
   [violation remediation]
@@ -276,8 +131,7 @@
 
 ;------------------------------------------------------------------------------ Layer 0.6
 ;; Diff/plan detection and incremental mode helpers
-
-(defn- safe-git-ref?
+(defn- ^{:stratum 0} safe-git-ref?
   "Return true iff ref contains only characters valid in a git ref argument.
    Rejects empty strings, nil, and any value starting with '-' (which git
    could interpret as an option flag)."
@@ -287,54 +141,7 @@
                 (not (str/starts-with? ref "-"))
                 (re-matches #"[a-zA-Z0-9/_.\-~^@{}]+" ref))))
 
-(defn- git-diff
-  "Run git diff and return the output string."
-  [repo-path since-ref]
-  (when (safe-git-ref? since-ref)
-    (try
-      (let [pb (ProcessBuilder. ^java.util.List
-                ["git" "diff" (str since-ref "..HEAD")])
-            _  (.directory pb (io/file repo-path))
-            proc (.start pb)
-            out  (slurp (.getInputStream proc))]
-        (.waitFor proc)
-        (when-not (str/blank? out) out))
-      (catch Exception _ nil))))
-
-(defn- git-diff-name-only
-  "Run git diff --name-only and return set of changed file paths."
-  [repo-path since-ref]
-  (when (safe-git-ref? since-ref)
-    (try
-      (let [pb (ProcessBuilder. ^java.util.List
-                ["git" "diff" "--name-only" (str since-ref "..HEAD")])
-            _  (.directory pb (io/file repo-path))
-            proc (.start pb)
-            out  (slurp (.getInputStream proc))]
-        (.waitFor proc)
-        (when-not (str/blank? out)
-          (set (str/split-lines (str/trim out)))))
-      (catch Exception _ nil))))
-
-(defn- scan-diff-rule
-  "Scan a git diff for violations using a diff-analysis rule.
-   Returns vector of Violation maps."
-  [rule-cfg diff-content]
-  (let [rule-id  (:rule/id rule-cfg)
-        rule-cat (:rule/category rule-cfg)
-        title    (:rule/title rule-cfg)
-        pattern  (re-pattern (get-in rule-cfg [:rule/detection :pattern]))
-        matches  (positive-matches pattern diff-content)]
-    (mapv (fn [{:keys [line match]}]
-            (factory/->violation
-             rule-id rule-cat title
-             "<diff>"     ; file is the entire diff
-             line match
-             nil          ; no suggestion for diff violations
-             false ""))
-          matches)))
-
-(defn- scan-plan-rule
+(defn- ^{:stratum 0} scan-plan-rule
   "Scan plan output for violations using a plan-output rule.
    Uses the policy-pack detect-violation dispatcher for resource-level analysis.
    Returns vector of Violation maps."
@@ -368,50 +175,13 @@
             nil false "")]))
       [])))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Per-rule scanning
-
-(defn- scan-file-record
-  "Load and scan a single file record against a rule config.
-   Returns vector of raw Violation maps, or [] if the file cannot be read."
-  [rule-cfg index file-record]
-  (let [path    (:path file-record)
-        content (try
-                  (slurp (str (:repo-root index) "/" path))
-                  (catch Exception _ nil))]
-    (if content
-      (scan-file rule-cfg path content)
-      [])))
-
-(defn- scan-rule
-  "Scan the entire repo for a single rule.
-   Returns vector of raw Violation maps."
-  [rule-cfg index]
-  (let [file-pred      (get rule-cfg :file-pred (constantly false))
-        matching-files (repo-index/find-files index #(file-pred (:path %)))]
-    (->> matching-files
-         (mapcat (partial scan-file-record rule-cfg index))
-         vec)))
-
-(defn- get-rule-configs
-  "Resolve detection configs from opts :pack or by compiling from standards-path.
-   Returns vector of detection config maps, or nil if none found."
-  [opts standards-path]
-  (or (when-let [pack (get opts :pack)]
-        (let [rules    (get pack :pack/rules)
-              filtered (filter-pack-rules rules opts)]
-          (when (seq filtered)
-            (vec (keep pack-rule->detection-config filtered)))))
-      (load-pack-detection-configs standards-path opts)))
-
 ;------------------------------------------------------------------------------ Layer 1.5
 ;; Built-in Clojure-AST linters
 ;;
 ;; These linters do not flow through pack-rule detection configs because
 ;; their analysis is structural, not regex-driven. They are first-class
 ;; rules of the scanner and run alongside content/diff/plan rules.
-
-(defn- exceptions-as-data-selected?
+(defn- ^{:stratum 0} exceptions-as-data-selected?
   "True when the rules selector resolves the exceptions-as-data linter on.
    Defaults on for `:all` / `:always-apply`; opts in for explicit selectors."
   [opts]
@@ -424,7 +194,145 @@
            (contains? requested exc-data/rule-id)) true
       :else false)))
 
-(defn- run-exceptions-as-data
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} violations-for-positive-rule
+  "Scan a single file with a positive-match rule (pattern = violation).
+   Returns vector of Violation maps (without :auto-fixable? / :rationale —
+   those are added by classify)."
+  [rule-cfg file-path content]
+  (let [rule-id  (get rule-cfg :rule/id)
+        rule-cat (get rule-cfg :rule/category)
+        title    (get rule-cfg :title)
+        pattern  (get rule-cfg :pattern)
+        suggest  (get rule-cfg :suggest-fn)
+        matches  (positive-matches pattern content)]
+    (mapv (fn [{:keys [line match]}]
+            (factory/->violation
+             rule-id
+             rule-cat
+             title
+             file-path
+             line
+             match
+             (suggest match)
+             false          ; classify phase fills this in
+             ""))           ; classify phase fills this in
+          matches)))
+
+(defn- ^{:stratum 1} violations-for-negative-rule
+  "Scan a single file with a negative-match rule (absence of pattern = violation).
+   Returns a vector of 0 or 1 Violation maps."
+  [rule-cfg file-path content]
+  (let [rule-id  (get rule-cfg :rule/id)
+        rule-cat (get rule-cfg :rule/category)
+        title    (get rule-cfg :title)
+        pattern  (get rule-cfg :pattern)
+        suggest  (get rule-cfg :suggest-fn)
+        ep       (get rule-cfg :email-pattern)
+        present? (if ep
+                   (header-present? content pattern ep)
+                   (pattern-present? content pattern))
+        absence-msg (if ep
+                      (msg/t :scan/missing-header)
+                      (str "(missing: " title ")"))]
+    (if present?
+      []
+      [(factory/->violation
+        rule-id
+        rule-cat
+        title
+        file-path
+        1
+        absence-msg
+        (suggest nil)
+        false
+        "")])))
+
+(defn- ^{:stratum 1} pack-rule->detection-config
+  "Convert a compiled pack rule into the detection config format used by scan-file.
+   Returns nil for rules without :content-scan detection."
+  [rule]
+  (let [detection   (get rule :rule/detection)
+        remediation (get rule :rule/remediation)
+        globs       (get-in rule [:rule/applies-to :file-globs])]
+    (when (= :content-scan (get detection :type))
+      (cond->
+        {:rule/id       (get rule :rule/id)
+         :rule/category (get rule :rule/category)
+         :title         (get rule :rule/title)
+         :pattern       (re-pattern (get detection :pattern))
+         :file-pred     (globs->file-pred (or globs ["**/*"]))
+         :suggest-fn    (build-suggest-fn detection remediation)
+         :detect-mode   (get detection :mode :positive)}
+
+        (get detection :email-pattern)
+        (assoc :email-pattern (re-pattern (get detection :email-pattern)))
+
+        remediation
+        (assoc :remediation remediation)))))
+
+(defn- ^{:stratum 1} category-matches?
+  "Check if a rule's Dewey category falls in a category selector's range.
+   Uses static range lookup — no cross-layer dependency."
+  [rule cat-kw]
+  (let [cat-name (name cat-kw)
+        rule-cat (:rule/category rule)]
+    (or (= cat-name rule-cat)
+        (when-let [[lo hi] (get category-dewey-ranges cat-name)]
+          (try
+            (let [code (Integer/parseInt (str rule-cat))]
+              (and (<= lo code) (<= code hi)))
+            (catch Exception _ false))))))
+
+(defn- ^{:stratum 1} git-diff
+  "Run git diff and return the output string."
+  [repo-path since-ref]
+  (when (safe-git-ref? since-ref)
+    (try
+      (let [pb (ProcessBuilder. ^java.util.List
+                ["git" "diff" (str since-ref "..HEAD")])
+            _  (.directory pb (io/file repo-path))
+            proc (.start pb)
+            out  (slurp (.getInputStream proc))]
+        (.waitFor proc)
+        (when-not (str/blank? out) out))
+      (catch Exception _ nil))))
+
+(defn- ^{:stratum 1} git-diff-name-only
+  "Run git diff --name-only and return set of changed file paths."
+  [repo-path since-ref]
+  (when (safe-git-ref? since-ref)
+    (try
+      (let [pb (ProcessBuilder. ^java.util.List
+                ["git" "diff" "--name-only" (str since-ref "..HEAD")])
+            _  (.directory pb (io/file repo-path))
+            proc (.start pb)
+            out  (slurp (.getInputStream proc))]
+        (.waitFor proc)
+        (when-not (str/blank? out)
+          (set (str/split-lines (str/trim out)))))
+      (catch Exception _ nil))))
+
+(defn- ^{:stratum 1} scan-diff-rule
+  "Scan a git diff for violations using a diff-analysis rule.
+   Returns vector of Violation maps."
+  [rule-cfg diff-content]
+  (let [rule-id  (:rule/id rule-cfg)
+        rule-cat (:rule/category rule-cfg)
+        title    (:rule/title rule-cfg)
+        pattern  (re-pattern (get-in rule-cfg [:rule/detection :pattern]))
+        matches  (positive-matches pattern diff-content)]
+    (mapv (fn [{:keys [line match]}]
+            (factory/->violation
+             rule-id rule-cat title
+             "<diff>"     ; file is the entire diff
+             line match
+             nil          ; no suggestion for diff violations
+             false ""))
+          matches)))
+
+(defn- ^{:stratum 1} run-exceptions-as-data
   "Run the AST-based exceptions-as-data linter against the repo. Returns
    a vector of actionable Violation maps when selected, or nil when the
    rule selector leaves the linter off. Returned rows are already in the
@@ -444,10 +352,107 @@
     (filterv #(= :cleanup-needed (:classification %))
              (:violations (exc-data/scan-repo repo-path changed-files)))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Top-level entry point
+(defn- ^{:stratum 1} scan-plan-rules
+  "Scan plan-output rules against terraform plan output."
+  [plan-rules plan-output]
+  (when plan-output
+    (->> plan-rules
+         (mapcat #(scan-plan-rule % plan-output))
+         vec)))
 
-(defn- scan-changed-files
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- ^{:stratum 2} scan-file
+  "Dispatch to the appropriate scanner for a rule config.
+   Returns vector of raw (pre-classify) Violation maps."
+  [rule-cfg file-path content]
+  (case (get rule-cfg :detect-mode :positive)
+    :positive (violations-for-positive-rule rule-cfg file-path content)
+    :negative (violations-for-negative-rule rule-cfg file-path content)
+    []))
+
+(defn- ^{:stratum 2} rule-matches-selector?
+  "Check if a rule matches a selector element (keyword — rule ID or category ID)."
+  [rule selector-kw]
+  (or (= selector-kw (:rule/id rule))
+      (category-matches? rule selector-kw)))
+
+(defn- ^{:stratum 2} scan-diff-rules
+  "Scan diff-analysis rules against a git diff."
+  [diff-rules diff-content]
+  (when diff-content
+    (->> diff-rules
+         (mapcat #(scan-diff-rule % diff-content))
+         vec)))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn- ^{:stratum 3} filter-pack-rules
+  "Filter compiled pack rules by the :rules option.
+
+   Supported selectors:
+   - :all / :always-apply — all rules with scannable detection types
+   - keyword — single rule ID match
+   - set of keywords — matches rule IDs OR category IDs
+     e.g. #{:std/clojure :mf.cat/workflows}
+
+   Only rules with scannable detection types (content-scan, diff-analysis,
+   plan-output) pass through."
+  [pack-rules opts]
+  (let [raw       (get opts :rules :always-apply)
+        requested (if (string? raw) (keyword (subs raw 1)) raw)
+        scannable (filter #(contains? scannable-types
+                                      (get-in % [:rule/detection :type]))
+                          pack-rules)]
+    (cond
+      (contains? #{:all :always-apply} requested) scannable
+      (keyword? requested)  (filter #(= requested (:rule/id %)) scannable)
+      (set? requested)      (filter (fn [rule]
+                                      (some #(rule-matches-selector? rule %) requested))
+                                    scannable)
+      :else                 scannable)))
+
+;; Per-rule scanning
+(defn- ^{:stratum 3} scan-file-record
+  "Load and scan a single file record against a rule config.
+   Returns vector of raw Violation maps, or [] if the file cannot be read."
+  [rule-cfg index file-record]
+  (let [path    (:path file-record)
+        content (try
+                  (slurp (str (:repo-root index) "/" path))
+                  (catch Exception _ nil))]
+    (if content
+      (scan-file rule-cfg path content)
+      [])))
+
+;------------------------------------------------------------------------------ Layer 4
+
+(defn- ^{:stratum 4} load-pack-detection-configs
+  "Load compiled pack from standards-path and convert rules to detection configs.
+   Returns vector of detection config maps, or nil if pack unavailable."
+  [standards-path opts]
+  (try
+    (let [result (policy-pack/compile-standards-pack standards-path)]
+      (when (:success? result)
+        (let [rules     (get-in result [:pack :pack/rules])
+              filtered  (filter-pack-rules rules opts)
+              configs   (keep pack-rule->detection-config filtered)]
+          (when (seq configs)
+            (vec configs)))))
+    (catch Exception _ nil)))
+
+(defn- ^{:stratum 4} scan-rule
+  "Scan the entire repo for a single rule.
+   Returns vector of raw Violation maps."
+  [rule-cfg index]
+  (let [file-pred      (get rule-cfg :file-pred (constantly false))
+        matching-files (repo-index/find-files index #(file-pred (:path %)))]
+    (->> matching-files
+         (mapcat (partial scan-file-record rule-cfg index))
+         vec)))
+
+;; Top-level entry point
+(defn- ^{:stratum 4} scan-changed-files
   "Scan only files present in the changed-files set for a single rule config."
   [cfg index changed-files]
   (let [file-pred (get cfg :file-pred (constantly false))
@@ -457,7 +462,20 @@
                                       (file-pred (:path f))))))]
     (mapcat #(scan-file-record cfg index %) matching)))
 
-(defn- scan-and-enrich
+;------------------------------------------------------------------------------ Layer 5
+
+(defn- ^{:stratum 5} get-rule-configs
+  "Resolve detection configs from opts :pack or by compiling from standards-path.
+   Returns vector of detection config maps, or nil if none found."
+  [opts standards-path]
+  (or (when-let [pack (get opts :pack)]
+        (let [rules    (get pack :pack/rules)
+              filtered (filter-pack-rules rules opts)]
+          (when (seq filtered)
+            (vec (keep pack-rule->detection-config filtered)))))
+      (load-pack-detection-configs standards-path opts)))
+
+(defn- ^{:stratum 5} scan-and-enrich
   "Scan a single rule config (full or incremental) and enrich violations."
   [cfg index changed-files]
   (let [viols (if changed-files
@@ -468,7 +486,9 @@
       (mapv #(enrich-violation % rem) viols)
       viols)))
 
-(defn- scan-content-rules
+;------------------------------------------------------------------------------ Layer 6
+
+(defn- ^{:stratum 6} scan-content-rules
   "Scan content-scan rules across the repo index.
    When changed-files is non-nil, limits scanning to those files only."
   [content-cfgs index changed-files]
@@ -476,23 +496,9 @@
        (mapcat #(scan-and-enrich % index changed-files))
        vec))
 
-(defn- scan-diff-rules
-  "Scan diff-analysis rules against a git diff."
-  [diff-rules diff-content]
-  (when diff-content
-    (->> diff-rules
-         (mapcat #(scan-diff-rule % diff-content))
-         vec)))
+;------------------------------------------------------------------------------ Layer 7
 
-(defn- scan-plan-rules
-  "Scan plan-output rules against terraform plan output."
-  [plan-rules plan-output]
-  (when plan-output
-    (->> plan-rules
-         (mapcat #(scan-plan-rule % plan-output))
-         vec)))
-
-(defn scan-repo
+(defn ^{:stratum 7} scan-repo
   "Scan a repo for violations across all configured rules.
 
    Supports multiple detection types:

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/schema.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/schema.clj
@@ -15,16 +15,15 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.compliance-scanner.schema
   "Malli schemas for compliance-scanner domain types.
 
    Layer 0 — pure data definitions, no dependencies.")
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Violation — one detected instance of a rule breach
 
-(def Violation
+;; Violation — one detected instance of a rule breach
+(def ^{:stratum 0} Violation
   [:map
    [:rule/id       :keyword]
    [:rule/category [:string {:min 1}]]
@@ -36,31 +35,8 @@
    [:auto-fixable? :boolean]
    [:rationale     :string]])
 
-;------------------------------------------------------------------------------ Layer 0
-;; ScanResult — output of the scan phase
-
-(def ScanResult
-  [:map
-   [:violations       [:vector Violation]]
-   [:rules-scanned    [:vector :keyword]]
-   [:files-scanned    :int]
-   [:scan-duration-ms :int]])
-
-;------------------------------------------------------------------------------ Layer 0
-;; PlanTask — one DAG task node
-
-(def PlanTask
-  [:map
-   [:task/id         uuid?]
-   [:task/deps       [:set uuid?]]
-   [:task/file       :string]
-   [:task/rule-id    :keyword]
-   [:task/violations [:vector Violation]]])
-
-;------------------------------------------------------------------------------ Layer 0
 ;; PlanSummary — aggregate counts
-
-(def PlanSummary
+(def ^{:stratum 0} PlanSummary
   [:map
    [:total-violations :int]
    [:auto-fixable     :int]
@@ -68,25 +44,42 @@
    [:files-affected   :int]
    [:rules-violated   :int]])
 
-;------------------------------------------------------------------------------ Layer 0
-;; Plan — output of the plan phase
+;------------------------------------------------------------------------------ Layer 1
 
-(def Plan
+;; ScanResult — output of the scan phase
+(def ^{:stratum 1} ScanResult
   [:map
-   [:dag-tasks [:vector PlanTask]]
-   [:work-spec :string]
-   [:summary   PlanSummary]])
+   [:violations       [:vector Violation]]
+   [:rules-scanned    [:vector :keyword]]
+   [:files-scanned    :int]
+   [:scan-duration-ms :int]])
 
-;------------------------------------------------------------------------------ Layer 0
+;; PlanTask — one DAG task node
+(def ^{:stratum 1} PlanTask
+  [:map
+   [:task/id         uuid?]
+   [:task/deps       [:set uuid?]]
+   [:task/file       :string]
+   [:task/rule-id    :keyword]
+   [:task/violations [:vector Violation]]])
+
 ;; DeltaReport — final serialisable output
-
-(def DeltaReport
+(def ^{:stratum 1} DeltaReport
   [:map
    [:repo-path       :string]
    [:standards-path  :string]
    [:scan-timestamp  :string]
    [:summary         PlanSummary]
    [:violations      [:vector Violation]]])
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Plan — output of the plan phase
+(def ^{:stratum 2} Plan
+  [:map
+   [:dag-tasks [:vector PlanTask]]
+   [:work-spec :string]
+   [:summary   PlanSummary]])
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/classify_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/classify_test.clj
@@ -15,16 +15,16 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.compliance-scanner.classify-test
   "Tests for the classify phase — pack-driven classification."
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.compliance-scanner.classify :as classify]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; ---------------------------------------------------------------------------
 ;; Test fixtures — pack-enriched violations
-
-(def ^:private base-210
+(def ^{:stratum 0} ^:private base-210
   {:rule/id       :std/clojure
    :rule/category "210"
    :rule/title    "Clojure Map Access"
@@ -36,7 +36,7 @@
    :exclude-contexts [{:path-contains "server/"}
                        {:current-contains [":type" ":priority" ":status" ";; JSON"]}]})
 
-(def ^:private base-730
+(def ^{:stratum 0} ^:private base-730
   {:rule/id       :std/datever
    :rule/category "730"
    :rule/title    "Version Format (SemVer vs DateVer)"
@@ -46,7 +46,7 @@
    ;; Pack enrichment
    :auto-fixable-default false})
 
-(def ^:private base-810
+(def ^{:stratum 0} ^:private base-810
   {:rule/id       :std/header-copyright
    :rule/category "810"
    :rule/title    "Copyright Header (Markdown)"
@@ -59,53 +59,8 @@
    :remediation-template "<!--\n  Copyright header\n-->"})
 
 ;; ---------------------------------------------------------------------------
-;; Dewey 210 classification
-
-(deftest classify-210-standard-is-auto-fixable
-  (testing "ordinary 210 violation in a component src file is auto-fixable"
-    (let [v    (assoc base-210 :file "components/foo/src/ai/miniforge/foo/core.clj")
-          [r]  (classify/classify-violations [v])]
-      (is (true? (:auto-fixable? r)))
-      (is (re-find #"Literal default" (:rationale r))))))
-
-(deftest classify-210-server-file-is-needs-review
-  (testing "210 violation in a server/ file is excluded by context rule"
-    (let [v   (assoc base-210 :file "server/handler.clj")
-          [r] (classify/classify-violations [v])]
-      (is (false? (:auto-fixable? r)))
-      (is (re-find #"JSON" (:rationale r))))))
-
-(deftest classify-210-json-signal-key-is-needs-review
-  (testing "210 violation with a JSON-signal key (:status) is excluded"
-    (let [v   (-> base-210
-                  (assoc :file "components/foo/src/ai/miniforge/foo/core.clj")
-                  (assoc :current "(or (:status m) :active)"))
-          [r] (classify/classify-violations [v])]
-      (is (false? (:auto-fixable? r))))))
-
-;; ---------------------------------------------------------------------------
-;; Dewey 730 classification
-
-(deftest classify-730-always-needs-review
-  (testing "Dewey 730 violations always need review — declared not auto-fixable"
-    (let [v   (assoc base-730 :file "build.clj")
-          [r] (classify/classify-violations [v])]
-      (is (false? (:auto-fixable? r)))
-      (is (string? (:rationale r))))))
-
-;; ---------------------------------------------------------------------------
-;; Dewey 810 classification
-
-(deftest classify-810-missing-header-is-auto-fixable
-  (testing "810 violation for absent header is auto-fixable"
-    (let [v   (assoc base-810 :file "docs/guide.md")
-          [r] (classify/classify-violations [v])]
-      (is (true? (:auto-fixable? r))))))
-
-;; ---------------------------------------------------------------------------
 ;; Manual-review rules (auto-fixable-default false)
-
-(deftest classify-manual-review-uses-rule-title
+(deftest ^{:stratum 0} classify-manual-review-uses-rule-title
   (testing "rules with auto-fixable-default false use rule title in rationale"
     (let [v   {:rule/id :foundations/no-unsafe-rust
                :rule/category "001"
@@ -119,10 +74,52 @@
       (is (clojure.string/includes? (:rationale r) "No Unsafe Rust"))
       (is (not (clojure.string/includes? (:rationale r) "SemVer"))))))
 
+;------------------------------------------------------------------------------ Layer 1
+
+;; ---------------------------------------------------------------------------
+;; Dewey 210 classification
+(deftest ^{:stratum 1} classify-210-standard-is-auto-fixable
+  (testing "ordinary 210 violation in a component src file is auto-fixable"
+    (let [v    (assoc base-210 :file "components/foo/src/ai/miniforge/foo/core.clj")
+          [r]  (classify/classify-violations [v])]
+      (is (true? (:auto-fixable? r)))
+      (is (re-find #"Literal default" (:rationale r))))))
+
+(deftest ^{:stratum 1} classify-210-server-file-is-needs-review
+  (testing "210 violation in a server/ file is excluded by context rule"
+    (let [v   (assoc base-210 :file "server/handler.clj")
+          [r] (classify/classify-violations [v])]
+      (is (false? (:auto-fixable? r)))
+      (is (re-find #"JSON" (:rationale r))))))
+
+(deftest ^{:stratum 1} classify-210-json-signal-key-is-needs-review
+  (testing "210 violation with a JSON-signal key (:status) is excluded"
+    (let [v   (-> base-210
+                  (assoc :file "components/foo/src/ai/miniforge/foo/core.clj")
+                  (assoc :current "(or (:status m) :active)"))
+          [r] (classify/classify-violations [v])]
+      (is (false? (:auto-fixable? r))))))
+
+;; ---------------------------------------------------------------------------
+;; Dewey 730 classification
+(deftest ^{:stratum 1} classify-730-always-needs-review
+  (testing "Dewey 730 violations always need review — declared not auto-fixable"
+    (let [v   (assoc base-730 :file "build.clj")
+          [r] (classify/classify-violations [v])]
+      (is (false? (:auto-fixable? r)))
+      (is (string? (:rationale r))))))
+
+;; ---------------------------------------------------------------------------
+;; Dewey 810 classification
+(deftest ^{:stratum 1} classify-810-missing-header-is-auto-fixable
+  (testing "810 violation for absent header is auto-fixable"
+    (let [v   (assoc base-810 :file "docs/guide.md")
+          [r] (classify/classify-violations [v])]
+      (is (true? (:auto-fixable? r))))))
+
 ;; ---------------------------------------------------------------------------
 ;; Batch classification
-
-(deftest classify-batch-returns-all-violations
+(deftest ^{:stratum 1} classify-batch-returns-all-violations
   (testing "classify-violations returns same count as input"
     (let [viols [base-210 base-730 base-810]
           result (classify/classify-violations

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/comments_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/comments_test.clj
@@ -15,17 +15,18 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.compliance-scanner.comments-test
   "Tests for the violation comment renderer (N13 §2.3)."
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.string :as str]
             [ai.miniforge.compliance-scanner.comments :as comments]))
 
-(def ^:private base-pack-info
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private base-pack-info
   {:pack/id "miniforge-standards" :pack/version "1.4.0"})
 
-(def ^:private auto-fixable-violation
+(def ^{:stratum 0} ^:private auto-fixable-violation
   {:rule/id        :ai.miniforge.standards/exceptions-as-data
    :rule/category  "code-quality"
    :rule/title     "Exceptions must be data, not exceptions"
@@ -36,7 +37,7 @@
    :auto-fixable?  true
    :rationale      "Throwing exceptions breaks effect-as-data."})
 
-(def ^:private non-fixable-violation
+(def ^{:stratum 0} ^:private non-fixable-violation
   {:rule/id        :ai.miniforge.standards/no-credentials-in-source
    :rule/category  "security"
    :rule/title     "Hardcoded credentials"
@@ -47,7 +48,14 @@
    :auto-fixable?  false
    :rationale      "Manual review required for credential rotation."})
 
-(deftest payload-shape-required-keys
+(deftest ^{:stratum 0} extract-payload-missing-returns-nil
+  (testing "no payload block → nil"
+    (is (nil? (comments/extract-payload "no payload here")))
+    (is (nil? (comments/extract-payload nil)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} payload-shape-required-keys
   (testing "payload contains all N13 §2.3 keys"
     (let [p (comments/violation->payload auto-fixable-violation base-pack-info)]
       (is (= :ai.miniforge.standards/exceptions-as-data (:violation/rule-id p)))
@@ -58,7 +66,7 @@
       (is (= "1.4.0" (:violation/pack-version p)))
       (is (#{:error :warning :info} (:violation/severity p))))))
 
-(deftest payload-rationale-is-always-text
+(deftest ^{:stratum 1} payload-rationale-is-always-text
   (testing "absent and malformed rationales become empty strings"
     (doseq [violation [(dissoc auto-fixable-violation :rationale)
                        (assoc auto-fixable-violation :rationale nil)
@@ -68,7 +76,7 @@
       (is (= "" (:violation/rationale
                  (comments/violation->payload violation base-pack-info)))))))
 
-(deftest comment-body-uses-normalized-rationale
+(deftest ^{:stratum 1} comment-body-uses-normalized-rationale
   (testing "absent and malformed rationales are omitted from the human-readable body"
     (doseq [rationale [nil false :not-text 987654321]
             :let [violation (assoc auto-fixable-violation :rationale rationale)
@@ -78,7 +86,7 @@
       (is (not (str/includes? body (pr-str rationale)))
           (str "did not render " (pr-str rationale))))))
 
-(deftest payload-severity-inference
+(deftest ^{:stratum 1} payload-severity-inference
   (testing "auto-fixable + non-critical → :warning"
     (is (= :warning
            (:violation/severity
@@ -105,7 +113,7 @@
              (assoc auto-fixable-violation :severity-override :info)
              base-pack-info))))))
 
-(deftest comment-record-shape
+(deftest ^{:stratum 1} comment-record-shape
   (testing "comment record has the four required keys + payload"
     (let [c (comments/violation->comment auto-fixable-violation base-pack-info)]
       (is (= "miniforge-policy-evaluator[bot]" (:comment/author c)))
@@ -114,7 +122,7 @@
       (is (string? (:comment/body c)))
       (is (map? (:comment/payload c))))))
 
-(deftest comment-body-embeds-edn-payload
+(deftest ^{:stratum 1} comment-body-embeds-edn-payload
   (testing "comment body contains a parseable :comment/payload EDN block"
     (let [c (comments/violation->comment auto-fixable-violation base-pack-info)
           body (:comment/body c)]
@@ -123,18 +131,13 @@
       (is (str/includes? body ":violation/rule-id"))
       (is (str/includes? body "miniforge-policy-evaluator[bot]")))))
 
-(deftest extract-payload-roundtrips
+(deftest ^{:stratum 1} extract-payload-roundtrips
   (testing "rendered → extracted yields the same payload"
     (let [c   (comments/violation->comment auto-fixable-violation base-pack-info)
           got (comments/extract-payload (:comment/body c))]
       (is (= (:comment/payload c) got)))))
 
-(deftest extract-payload-missing-returns-nil
-  (testing "no payload block → nil"
-    (is (nil? (comments/extract-payload "no payload here")))
-    (is (nil? (comments/extract-payload nil)))))
-
-(deftest bulk-render-stable-order
+(deftest ^{:stratum 1} bulk-render-stable-order
   (testing "violations are sorted by (path, line, rule-id) ascending"
     (let [vs [(assoc auto-fixable-violation :line 50)
               non-fixable-violation
@@ -147,7 +150,7 @@
             lines               (mapv :comment/line components-comments)]
         (is (= [42 50] lines))))))
 
-(deftest auto-fixable-flag-preserved
+(deftest ^{:stratum 1} auto-fixable-flag-preserved
   (testing "auto-fixable? boolean flows through to payload"
     (is (true?  (-> auto-fixable-violation
                     (comments/violation->comment base-pack-info)
@@ -158,7 +161,7 @@
                     :comment/payload
                     :violation/auto-fixable?)))))
 
-(deftest pack-info-injected
+(deftest ^{:stratum 1} pack-info-injected
   (testing "pack-id and pack-version are passed through"
     (let [p (comments/violation->payload auto-fixable-violation
                                           {:pack/id "custom-pack"

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/boundary_exemption_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/boundary_exemption_test.clj
@@ -15,20 +15,21 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.compliance-scanner.exceptions-as-data.boundary-exemption-test
   "Boundary-namespace exemption: throws in cli/web/http/mcp/etc. are skipped."
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.compliance-scanner.exceptions-as-data :as exc]))
 
-(deftest cli-namespace-is-boundary
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} cli-namespace-is-boundary
   (testing "*.cli.* and *-main namespaces are boundaries"
     (is (true?  (exc/boundary-namespace? 'ai.miniforge.cli.main)))
     (is (true?  (exc/boundary-namespace? 'ai.miniforge.cli.commands.scan)))
     (is (true?  (exc/boundary-namespace? 'ai.miniforge.foo.bar-main)))))
 
-(deftest http-and-web-namespaces-are-boundaries
+(deftest ^{:stratum 0} http-and-web-namespaces-are-boundaries
   (testing "explicit `http` and `web` segments are boundaries"
     (is (true? (exc/boundary-namespace? 'ai.miniforge.foo.http.handlers)))
     (is (true? (exc/boundary-namespace? 'ai.miniforge.web.handlers))))
@@ -38,7 +39,7 @@
     ;; — its core/impl namespaces still need to return anomalies internally.
     (is (false? (exc/boundary-namespace? 'ai.miniforge.bb-data-plane-http.core)))))
 
-(deftest mcp-listener-consumer-and-boundary-namespaces
+(deftest ^{:stratum 0} mcp-listener-consumer-and-boundary-namespaces
   (testing "the explicit boundary segments are detected"
     (is (true? (exc/boundary-namespace? 'ai.miniforge.mcp.bridge)))
     (is (true? (exc/boundary-namespace? 'ai.miniforge.kafka.consumer)))
@@ -46,24 +47,24 @@
     (is (true? (exc/boundary-namespace? 'ai.miniforge.events.listeners)))
     (is (true? (exc/boundary-namespace? 'ai.miniforge.foo.boundary.in)))))
 
-(deftest dashed-mcp-base-is-boundary
+(deftest ^{:stratum 0} dashed-mcp-base-is-boundary
   (testing "the MCP context-server base is an external protocol boundary"
     (is (true? (exc/boundary-namespace? 'ai.miniforge.mcp-context-server.tools)))
     (is (true? (exc/boundary-namespace? 'ai.miniforge.mcp-context-server.server)))))
 
-(deftest response-anomaly-bridge-is-boundary
+(deftest ^{:stratum 0} response-anomaly-bridge-is-boundary
   (testing "the canonical thrown-anomaly bridge is an explicit boundary"
     (is (true? (exc/boundary-namespace? 'ai.miniforge.response.anomaly)))
     (is (false? (exc/boundary-namespace? 'ai.miniforge.response.translate)))))
 
-(deftest core-namespaces-are-not-boundaries
+(deftest ^{:stratum 0} core-namespaces-are-not-boundaries
   (testing "ordinary component core namespaces are not boundaries"
     (is (false? (exc/boundary-namespace? 'ai.miniforge.agent.planner)))
     (is (false? (exc/boundary-namespace? 'ai.miniforge.workflow.runner)))
     (is (false? (exc/boundary-namespace? 'ai.miniforge.config.user)))
     (is (false? (exc/boundary-namespace? 'ai.miniforge.some-mcp-ish.core)))))
 
-(deftest boundary-files-yield-zero-violations
+(deftest ^{:stratum 0} boundary-files-yield-zero-violations
   (testing "throws inside a CLI namespace produce no violations"
     (let [src "(ns ai.miniforge.cli.main)
               (defn -main [& _]
@@ -80,7 +81,7 @@
       (is (true? boundary?))
       (is (zero? (count violations))))))
 
-(deftest response-anomaly-bridge-yields-zero-violations
+(deftest ^{:stratum 0} response-anomaly-bridge-yields-zero-violations
   (testing "throw+ inside response.anomaly is the canonical escalation bridge"
     (let [src "(ns ai.miniforge.response.anomaly)
               (defn throw-anomaly! [a]

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/end_to_end_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/end_to_end_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.compliance-scanner.exceptions-as-data.end-to-end-test
   "End-to-end: run the linter against a small synthetic fixture tree and
    assert the expected hit count and category split."
@@ -24,13 +23,15 @@
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.compliance-scanner.exceptions-as-data :as exc]))
 
-(defn- write!
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} write!
   [^java.io.File root rel content]
   (let [f (io/file root rel)]
     (io/make-parents f)
     (spit f content)))
 
-(defn- with-fixture
+(defn- ^{:stratum 0} with-fixture
   [f]
   (let [root (doto (io/file (System/getProperty "java.io.tmpdir")
                             (str "exc-e2e-" (random-uuid)))
@@ -39,7 +40,9 @@
          (finally (doseq [^java.io.File ff (reverse (file-seq root))]
                     (.delete ff))))))
 
-(deftest synthetic-tree-yields-expected-counts
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} synthetic-tree-yields-expected-counts
   (with-fixture
    (fn [root]
      ;; 1) Non-boundary cleanup-needed site

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/fatal_only_classification_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/fatal_only_classification_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.compliance-scanner.exceptions-as-data.fatal-only-classification-test
   "Programmer-error guards (`unknown` / `unsupported` / `required`)
    are classified as :fatal-only — informational, not actionable."
@@ -23,7 +22,9 @@
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.compliance-scanner.exceptions-as-data :as exc]))
 
-(deftest unknown-message-classified-fatal-only
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} unknown-message-classified-fatal-only
   (testing "throw whose message contains 'Unknown' is :fatal-only"
     (let [src "(ns ai.miniforge.foo.core)
               (defn lookup [m k]
@@ -33,7 +34,7 @@
       (is (= 1 (count violations)))
       (is (= :fatal-only (:classification (first violations)))))))
 
-(deftest unsupported-is-fatal-only
+(deftest ^{:stratum 0} unsupported-is-fatal-only
   (testing "'Unsupported X' messages are :fatal-only"
     (let [src "(ns ai.miniforge.foo.core)
               (defn dispatch [k]
@@ -44,7 +45,7 @@
       (is (= 1 (count violations)))
       (is (= :fatal-only (:classification (first violations)))))))
 
-(deftest required-config-is-fatal-only
+(deftest ^{:stratum 0} required-config-is-fatal-only
   (testing "'X is required' programmer-error messages are :fatal-only"
     (let [src "(ns ai.miniforge.foo.core)
               (defn check [opts]
@@ -54,7 +55,7 @@
       (is (= 1 (count violations)))
       (is (= :fatal-only (:classification (first violations)))))))
 
-(deftest registry-contract-message-key-is-fatal-only
+(deftest ^{:stratum 0} registry-contract-message-key-is-fatal-only
   (testing "localized registry contract keys are programmer-error guards"
     (let [src "(ns ai.miniforge.foo.registry)
               (defn register-widget! [widget-key f]
@@ -70,7 +71,7 @@
       (is (= 2 (count violations)))
       (is (every? #(= :fatal-only (:classification %)) violations)))))
 
-(deftest registry-resolution-invariant-is-fatal-only
+(deftest ^{:stratum 0} registry-resolution-invariant-is-fatal-only
   (testing "validated-but-missing registry resolution keys are fatal-only"
     (let [src "(ns ai.miniforge.foo.registry)
               (defn resolve-widget [k]
@@ -82,7 +83,7 @@
       (is (= 1 (count violations)))
       (is (= :fatal-only (:classification (first violations)))))))
 
-(deftest no-matching-reflection-helper-is-fatal-only
+(deftest ^{:stratum 0} no-matching-reflection-helper-is-fatal-only
   (testing "reflection helper arity misses are programmer errors"
     (let [src "(ns ai.miniforge.foo.reflect)
               (defn construct [ctor]
@@ -92,7 +93,7 @@
       (is (= 1 (count violations)))
       (is (= :fatal-only (:classification (first violations)))))))
 
-(deftest unmapped-dispatch-table-category-is-fatal-only
+(deftest ^{:stratum 0} unmapped-dispatch-table-category-is-fatal-only
   (testing "unmapped category guards protect closed dispatch tables"
     (let [src "(ns ai.miniforge.foo.dispatch)
               (defn category-type [category]
@@ -103,7 +104,7 @@
       (is (= 1 (count violations)))
       (is (= :fatal-only (:classification (first violations)))))))
 
-(deftest nested-invalid-config-marker-is-fatal-only
+(deftest ^{:stratum 0} nested-invalid-config-marker-is-fatal-only
   (testing "nested invalid-config ex-data marks fail-fast config guards"
     (let [src "(ns ai.miniforge.foo.config)
               (defn read-config [path]
@@ -114,7 +115,7 @@
       (is (= 1 (count violations)))
       (is (= :fatal-only (:classification (first violations)))))))
 
-(deftest localized-not-function-message-key-is-fatal-only
+(deftest ^{:stratum 0} localized-not-function-message-key-is-fatal-only
   (testing "localized non-callable function guards are programmer errors"
     (let [src "(ns ai.miniforge.foo.gate)
               (defn check [provided]
@@ -126,7 +127,7 @@
       (is (= 1 (count violations)))
       (is (= :fatal-only (:classification (first violations)))))))
 
-(deftest interrupted-exception-rethrow-is-fatal-only
+(deftest ^{:stratum 0} interrupted-exception-rethrow-is-fatal-only
   (testing "InterruptedException rethrows preserve cancellation"
     (let [src "(ns ai.miniforge.foo.loop)
               (defn poll []
@@ -139,7 +140,7 @@
       (is (= 1 (count violations)))
       (is (= :fatal-only (:classification (first violations)))))))
 
-(deftest cleanup-preserving-rethrow-is-fatal-only
+(deftest ^{:stratum 0} cleanup-preserving-rethrow-is-fatal-only
   (testing "resource cleanup followed by same-binding rethrow is informational"
     (let [src "(ns ai.miniforge.foo.scheduler)
               (defn schedule [executor task]
@@ -152,7 +153,7 @@
       (is (= 1 (count violations)))
       (is (= :fatal-only (:classification (first violations)))))))
 
-(deftest future-cancel-rethrow-is-fatal-only
+(deftest ^{:stratum 0} future-cancel-rethrow-is-fatal-only
   (testing "future cancellation before rethrow preserves task cleanup"
     (let [src "(ns ai.miniforge.foo.batch)
               (defn await-all [futures]
@@ -166,7 +167,7 @@
       (is (= 1 (count violations)))
       (is (= :fatal-only (:classification (first violations)))))))
 
-(deftest log-only-rethrow-remains-cleanup-needed
+(deftest ^{:stratum 0} log-only-rethrow-remains-cleanup-needed
   (testing "logging before rethrow does not make the site informational"
     (let [src "(ns ai.miniforge.foo.runner)
               (defn run []
@@ -179,7 +180,7 @@
       (is (= 1 (count violations)))
       (is (= :cleanup-needed (:classification (first violations)))))))
 
-(deftest plain-failure-is-cleanup-needed
+(deftest ^{:stratum 0} plain-failure-is-cleanup-needed
   (testing "messages without programmer-error markers are :cleanup-needed"
     (let [src "(ns ai.miniforge.foo.core)
               (defn fetch! [url]

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/local_boundary_classification_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/local_boundary_classification_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.compliance-scanner.exceptions-as-data.local-boundary-classification-test
   "Local boundary throwers retained for compatibility are informational, while
    ordinary throwers in component code remain actionable."
@@ -23,7 +22,9 @@
    [ai.miniforge.compliance-scanner.exceptions-as-data :as exc]
    [clojure.test :refer [deftest is testing]]))
 
-(deftest documented-boundary-wrapper-is-local-boundary
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} documented-boundary-wrapper-is-local-boundary
   (testing "defn docstrings can mark retained component-local boundary throwers"
     (let [src "(ns ai.miniforge.foo.core)
               (defn make-widget [request]
@@ -45,7 +46,7 @@
       (is (= 1 (count violations)))
       (is (= :local-boundary (:classification (first violations)))))))
 
-(deftest malformed-documentation-is-not-boundary-evidence
+(deftest ^{:stratum 0} malformed-documentation-is-not-boundary-evidence
   (testing "absent and malformed function documentation is treated as empty text"
     (doseq [context [{}
                      {:defn-doc nil}
@@ -55,7 +56,7 @@
       (is (false? (#'exc/local-boundary-wrapper? context))
           (str "ignored " (pr-str (:defn-doc context)))))))
 
-(deftest throwing-boundary-with-data-equivalent-is-local-boundary
+(deftest ^{:stratum 0} throwing-boundary-with-data-equivalent-is-local-boundary
   (testing "response/throw-anomaly! bridges with anomaly-returning equivalents are local boundaries"
     (let [src "(ns ai.miniforge.foo.core
                 (:require [ai.miniforge.response.interface :as response]))
@@ -77,7 +78,7 @@
       (is (= 1 (count violations)))
       (is (= :local-boundary (:classification (first violations)))))))
 
-(deftest deprecated-exceptions-as-data-wrapper-is-local-boundary
+(deftest ^{:stratum 0} deprecated-exceptions-as-data-wrapper-is-local-boundary
   (testing "deprecated throwers with exceptions-as-data metadata are local boundaries"
     (let [src "(ns ai.miniforge.foo.core)
               (defn unwrap-anomaly [result]
@@ -96,7 +97,7 @@
       (is (= 1 (count violations)))
       (is (= :local-boundary (:classification (first violations)))))))
 
-(deftest response-chain-execute-with-handling-throw-anomaly-is-local-boundary
+(deftest ^{:stratum 0} response-chain-execute-with-handling-throw-anomaly-is-local-boundary
   (testing "throw-anomaly inside response-chain handling is captured into returned data"
     (let [src "(ns ai.miniforge.foo.core
                 (:require [ai.miniforge.response.interface :as response]))
@@ -115,7 +116,7 @@
       (is (= 1 (count violations)))
       (is (= :local-boundary (:classification (first violations)))))))
 
-(deftest undocumented-bang-thrower-remains-cleanup-needed
+(deftest ^{:stratum 0} undocumented-bang-thrower-remains-cleanup-needed
   (testing "a bang name alone is not enough to exempt a throw"
     (let [src "(ns ai.miniforge.foo.core)
               (defn fetch!

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/output_format_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/output_format_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.compliance-scanner.exceptions-as-data.output-format-test
   "Output shape: violations carry the canonical scanner Violation keys plus
    the linter-specific fields (`:severity`, `:column`, `:classification`)."
@@ -24,7 +23,9 @@
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.compliance-scanner.exceptions-as-data :as exc]))
 
-(defn- make-fixture-file!
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} make-fixture-file!
   "Create a small synthetic file under a temp directory and return its
    relative path."
   [^java.io.File root rel content]
@@ -33,7 +34,7 @@
     (spit f content)
     rel))
 
-(defn- with-temp-repo
+(defn- ^{:stratum 0} with-temp-repo
   "Run `f` against a fresh temp directory; cleans up afterward.
    Uses random-uuid to keep parallel test runs from colliding."
   [f]
@@ -44,7 +45,9 @@
          (finally (doseq [^java.io.File ff (reverse (file-seq root))]
                     (.delete ff))))))
 
-(deftest violation-shape-matches-scanner-canonical-keys
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} violation-shape-matches-scanner-canonical-keys
   (with-temp-repo
    (fn [root]
      (let [rel (make-fixture-file!
@@ -70,7 +73,7 @@
          (is (contains? #{:cleanup-needed :fatal-only :local-boundary}
                         (:classification v))))))))
 
-(deftest empty-repo-yields-zero-violations
+(deftest ^{:stratum 1} empty-repo-yields-zero-violations
   (with-temp-repo
    (fn [root]
      (let [result (exc/scan-repo (.getAbsolutePath root))]
@@ -79,7 +82,7 @@
        (is (= {:cleanup-needed 0 :fatal-only 0 :local-boundary 0}
               (:counts result)))))))
 
-(deftest summary-counts-match-classifications
+(deftest ^{:stratum 1} summary-counts-match-classifications
   (with-temp-repo
    (fn [root]
      (make-fixture-file!

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/path_traversal_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/path_traversal_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.compliance-scanner.exceptions-as-data.path-traversal-test
   "Security: analyze-file must reject relative-path values that escape repo-root.
    A caller supplying \"../../../etc/passwd\" must receive [] — not file contents."
@@ -24,7 +23,9 @@
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.compliance-scanner.exceptions-as-data :as exc]))
 
-(defn- with-temp-root
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} with-temp-root
   "Create a temp directory, call (f root-path), then delete the tree."
   [f]
   (let [root (doto (io/file (System/getProperty "java.io.tmpdir")
@@ -34,7 +35,9 @@
          (finally (doseq [^java.io.File ff (reverse (file-seq root))]
                     (.delete ff))))))
 
-(deftest path-traversal-via-dotdot-is-rejected
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} path-traversal-via-dotdot-is-rejected
   (testing "relative-path with .. segments that escape repo-root returns []"
     (with-temp-root
      (fn [root]
@@ -44,7 +47,7 @@
          (is (= [] result)
              "analyze-file must return [] when relative-path escapes repo-root"))))))
 
-(deftest path-traversal-via-absolute-path-is-rejected
+(deftest ^{:stratum 1} path-traversal-via-absolute-path-is-rejected
   (testing "absolute path that is outside repo-root returns []"
     (with-temp-root
      (fn [root]
@@ -60,7 +63,7 @@
          (is (= [] result)
              "analyze-file must return [] when path resolves outside repo-root"))))))
 
-(deftest legitimate-path-inside-root-is-allowed
+(deftest ^{:stratum 1} legitimate-path-inside-root-is-allowed
   (testing "a path that stays inside repo-root is analyzed normally"
     (with-temp-root
      (fn [root]

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/positive_detection_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/positive_detection_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.compliance-scanner.exceptions-as-data.positive-detection-test
   "Positive detection: throws inside non-boundary namespaces are flagged."
   (:require
@@ -23,7 +22,9 @@
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.compliance-scanner.exceptions-as-data :as exc]))
 
-(deftest detects-bare-throw-in-non-boundary-namespace
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} detects-bare-throw-in-non-boundary-namespace
   (testing "(throw ex-info ...) inside a defn yields one violation"
     (let [src "(ns ai.miniforge.foo.core)
               (defn boom []
@@ -37,7 +38,7 @@
         (is (= :cleanup-needed (:classification v)))
         (is (pos-int? (:line v)))))))
 
-(deftest detects-ex-info-without-throw
+(deftest ^{:stratum 0} detects-ex-info-without-throw
   (testing "bare (ex-info ...) is flagged even without an enclosing throw"
     (let [src "(ns ai.miniforge.foo.core)
               (defn make-err [] (ex-info \"oops\" {}))"
@@ -45,7 +46,7 @@
       (is (= 1 (count violations)))
       (is (= :ex-info (:kind (first violations)))))))
 
-(deftest detects-throw-anomaly!-bang
+(deftest ^{:stratum 0} detects-throw-anomaly!-bang
   (testing "namespaced response/throw-anomaly! is flagged as throw"
     (let [src "(ns ai.miniforge.foo.core
                 (:require [ai.miniforge.response.interface :as response]))
@@ -57,7 +58,7 @@
       (is (= 1 (count violations)))
       (is (= :throw (:kind (first violations)))))))
 
-(deftest detects-exception-class-instantiation
+(deftest ^{:stratum 0} detects-exception-class-instantiation
   (testing "(IllegalArgumentException. ...) is flagged"
     (let [src "(ns ai.miniforge.foo.core)
               (defn boom []
@@ -67,7 +68,7 @@
       (is (pos? (count violations)))
       (is (some #{:throw :ctor} (map :kind violations))))))
 
-(deftest ordinary-rethrow-remains-cleanup-needed
+(deftest ^{:stratum 0} ordinary-rethrow-remains-cleanup-needed
   (testing "simple rethrow outside InterruptedException catch is still actionable"
     (let [src "(ns ai.miniforge.foo.core)
               (defn run []
@@ -80,7 +81,7 @@
       (is (= 1 (count violations)))
       (is (= :cleanup-needed (:classification (first violations)))))))
 
-(deftest interrupted-catch-different-symbol-remains-cleanup-needed
+(deftest ^{:stratum 0} interrupted-catch-different-symbol-remains-cleanup-needed
   (testing "InterruptedException catches only exempt the caught binding rethrow"
     (let [src "(ns ai.miniforge.foo.core)
               (defn run []
@@ -93,14 +94,14 @@
       (is (= 2 (count violations)))
       (is (every? #(= :cleanup-needed (:classification %)) violations)))))
 
-(deftest reports-line-and-column
+(deftest ^{:stratum 0} reports-line-and-column
   (testing "every violation carries a usable line:col location"
     (let [src "(ns ai.miniforge.foo.core)\n\n(defn b []\n  (throw (ex-info \"m\" {})))"
           {:keys [violations]} (exc/analyze-content "foo.clj" src)]
       (is (every? #(pos-int? (:line %)) violations))
       (is (every? #(some? (:column %)) violations)))))
 
-(deftest ignores-throws-in-docstrings
+(deftest ^{:stratum 0} ignores-throws-in-docstrings
   (testing "the word `throw` inside a string literal does not trigger"
     (let [src "(ns ai.miniforge.foo.core)
               (defn ok
@@ -110,7 +111,7 @@
           {:keys [violations]} (exc/analyze-content "foo.clj" src)]
       (is (= 0 (count violations))))))
 
-(deftest snippet-is-single-line-and-truncated
+(deftest ^{:stratum 0} snippet-is-single-line-and-truncated
   (testing "snippet output collapses whitespace and limits length"
     (let [src "(ns ai.miniforge.foo.core)
               (defn b [] (throw (ex-info \"x\" {:a 1 :b 2})))"

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/execute_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/execute_test.clj
@@ -15,16 +15,16 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.compliance-scanner.execute-test
   "Unit tests for execute/patch-file-content — the pure file-patching logic."
   (:require [clojure.test   :refer [deftest testing is]]
             [clojure.string :as str]
             [ai.miniforge.compliance-scanner.execute :as execute]))
 
-;------------------------------------------------------------------------------ Fixtures
+;------------------------------------------------------------------------------ Layer 0
 
-(def clojure-violation
+;------------------------------------------------------------------------------ Fixtures
+(def ^{:stratum 0} clojure-violation
   {:rule/id       :std/clojure
    :rule/category "210"
    :line          3
@@ -32,7 +32,7 @@
    :suggested     "(get m :timeout 5000)"
    :auto-fixable? true})
 
-(def datever-violation
+(def ^{:stratum 0} datever-violation
   {:rule/id       :std/datever
    :rule/category "730"
    :line          2
@@ -40,7 +40,7 @@
    :suggested     "1.2.3.0"
    :auto-fixable? true})
 
-(def copyright-violation
+(def ^{:stratum 0} copyright-violation
   {:rule/id              :std/header-copyright
    :rule/category        "810"
    :line                 1
@@ -50,71 +50,7 @@
    :remediation-type     :prepend
    :remediation-template "<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->"})
 
-;------------------------------------------------------------------------------ patch-file-content tests
-
-(deftest line-replacement-applies-on-correct-line-test
-  (testing "patch-file-content replaces :current with :suggested on the correct line"
-    (let [content  "line1\nline2\n(or (:timeout m) 5000)\nline4\n"
-          patched  (execute/patch-file-content content [clojure-violation])]
-      (is (str/includes? patched "(get m :timeout 5000)")
-          "Should contain the suggested replacement")
-      (is (not (str/includes? patched "(or (:timeout m) 5000)"))
-          "Should not contain the original text"))))
-
-(deftest line-replacement-only-modifies-target-line-test
-  (testing "patch-file-content leaves other lines untouched"
-    (let [content  "line1\nline2\n(or (:timeout m) 5000)\nline4\n"
-          patched  (execute/patch-file-content content [clojure-violation])
-          lines    (str/split-lines patched)]
-      (is (= "line1" (get lines 0)) "Line 1 unchanged")
-      (is (= "line2" (get lines 1)) "Line 2 unchanged")
-      (is (= "line4" (get lines 3)) "Line 4 unchanged"))))
-
-(deftest trailing-newline-preserved-test
-  (testing "patch-file-content preserves trailing newline"
-    (let [content "(or (:timeout m) 5000)\n"
-          v       (assoc clojure-violation :line 1)
-          patched (execute/patch-file-content content [v])]
-      (is (str/ends-with? patched "\n")
-          "Trailing newline should be preserved"))))
-
-(deftest no-trailing-newline-preserved-test
-  (testing "patch-file-content preserves absence of trailing newline"
-    (let [content "(or (:timeout m) 5000)"
-          v       (assoc clojure-violation :line 1)
-          patched (execute/patch-file-content content [v])]
-      (is (not (str/ends-with? patched "\n"))
-          "No trailing newline should not be added"))))
-
-(deftest multiple-violations-same-file-applied-test
-  (testing "patch-file-content applies multiple violations to the same file"
-    (let [content  "line1\n1.2.3\n(or (:timeout m) 5000)\nline4\n"
-          patched  (execute/patch-file-content content [clojure-violation datever-violation])]
-      (is (str/includes? patched "1.2.3.0")    "DateVer fix applied")
-      (is (str/includes? patched "(get m :timeout 5000)") "Clojure map access fix applied"))))
-
-(deftest copyright-header-prepended-test
-  (testing "patch-file-content prepends copyright header for missing-header violations"
-    (let [content "# My Doc\n\nSome content.\n"
-          patched (execute/patch-file-content content [copyright-violation])]
-      (is (str/starts-with? patched "<!--")
-          "Patched content should start with HTML comment")
-      (is (str/includes? patched "Christopher Lester")
-          "Copyright header should contain author name")
-      (is (str/includes? patched "# My Doc")
-          "Original content should be preserved after the header"))))
-
-(deftest copyright-header-before-line-edits-test
-  (testing "copyright prepend does not shift line indices for line-replacement violations"
-    (let [content  "(or (:timeout m) 5000)\nline2\n"
-          v-clj    (assoc clojure-violation :line 1)
-          patched  (execute/patch-file-content content [v-clj copyright-violation])]
-      (is (str/includes? patched "(get m :timeout 5000)")
-          "Clojure fix should still be applied")
-      (is (str/starts-with? patched "<!--")
-          "Copyright header should be at the top"))))
-
-(deftest no-change-when-suggested-nil-and-not-copyright-test
+(deftest ^{:stratum 0} no-change-when-suggested-nil-and-not-copyright-test
   (testing "patch-file-content skips violations with nil suggested that aren't copyright"
     (let [content "original content\n"
           v       {:rule/id :std/clojure :line 1 :current "original content"
@@ -123,7 +59,7 @@
       (is (= content patched)
           "Content should be unchanged when suggested is nil and not copyright"))))
 
-(deftest embedded-pattern-replaces-only-match-test
+(deftest ^{:stratum 0} embedded-pattern-replaces-only-match-test
   (testing "patch-file-content replaces only the matched substring, not the whole line"
     (let [content  "  (let [state (keyword (str/lower-case (or (:state check) \"\")))]\n"
           v        {:rule/id       :std/clojure
@@ -136,14 +72,13 @@
       (is (= "  (let [state (keyword (str/lower-case (get check :state \"\")))]\n" patched)
           "Only the matched (or ...) form should be replaced, preserving surrounding code"))))
 
-(deftest empty-violations-returns-content-unchanged-test
+(deftest ^{:stratum 0} empty-violations-returns-content-unchanged-test
   (testing "patch-file-content with empty violations returns content unchanged"
     (let [content "some content\n"]
       (is (= content (execute/patch-file-content content []))))))
 
 ;------------------------------------------------------------------------------ PR doc generation
-
-(deftest build-pr-doc-contains-attribution-yaml
+(deftest ^{:stratum 0} build-pr-doc-contains-attribution-yaml
   (testing "PR doc includes YAML attribution block with rule metadata"
     (let [build-pr-doc #'execute/build-pr-doc
           doc (build-pr-doc "fix/compliance-210-clojure-map-access" "210"
@@ -163,7 +98,7 @@
       (is (str/includes? doc "**Branch:** `fix/compliance-210-clojure-map-access`"))
       (is (str/includes? doc "| `components/foo/src/core.clj` | 10")))))
 
-(deftest build-pr-body-contains-attribution-yaml
+(deftest ^{:stratum 0} build-pr-body-contains-attribution-yaml
   (testing "PR body includes YAML attribution block"
     (let [build-pr-body #'execute/build-pr-body
           body (build-pr-body "210" "Clojure Map Access" 5 3
@@ -173,6 +108,71 @@
       (is (str/includes? body "violations-fixed: 5"))
       (is (str/includes? body "files-changed: 3"))
       (is (str/includes? body "docs/pull-requests/2026-04-07-fix-210-clojure-map-access.md")))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;------------------------------------------------------------------------------ patch-file-content tests
+(deftest ^{:stratum 1} line-replacement-applies-on-correct-line-test
+  (testing "patch-file-content replaces :current with :suggested on the correct line"
+    (let [content  "line1\nline2\n(or (:timeout m) 5000)\nline4\n"
+          patched  (execute/patch-file-content content [clojure-violation])]
+      (is (str/includes? patched "(get m :timeout 5000)")
+          "Should contain the suggested replacement")
+      (is (not (str/includes? patched "(or (:timeout m) 5000)"))
+          "Should not contain the original text"))))
+
+(deftest ^{:stratum 1} line-replacement-only-modifies-target-line-test
+  (testing "patch-file-content leaves other lines untouched"
+    (let [content  "line1\nline2\n(or (:timeout m) 5000)\nline4\n"
+          patched  (execute/patch-file-content content [clojure-violation])
+          lines    (str/split-lines patched)]
+      (is (= "line1" (get lines 0)) "Line 1 unchanged")
+      (is (= "line2" (get lines 1)) "Line 2 unchanged")
+      (is (= "line4" (get lines 3)) "Line 4 unchanged"))))
+
+(deftest ^{:stratum 1} trailing-newline-preserved-test
+  (testing "patch-file-content preserves trailing newline"
+    (let [content "(or (:timeout m) 5000)\n"
+          v       (assoc clojure-violation :line 1)
+          patched (execute/patch-file-content content [v])]
+      (is (str/ends-with? patched "\n")
+          "Trailing newline should be preserved"))))
+
+(deftest ^{:stratum 1} no-trailing-newline-preserved-test
+  (testing "patch-file-content preserves absence of trailing newline"
+    (let [content "(or (:timeout m) 5000)"
+          v       (assoc clojure-violation :line 1)
+          patched (execute/patch-file-content content [v])]
+      (is (not (str/ends-with? patched "\n"))
+          "No trailing newline should not be added"))))
+
+(deftest ^{:stratum 1} multiple-violations-same-file-applied-test
+  (testing "patch-file-content applies multiple violations to the same file"
+    (let [content  "line1\n1.2.3\n(or (:timeout m) 5000)\nline4\n"
+          patched  (execute/patch-file-content content [clojure-violation datever-violation])]
+      (is (str/includes? patched "1.2.3.0")    "DateVer fix applied")
+      (is (str/includes? patched "(get m :timeout 5000)") "Clojure map access fix applied"))))
+
+(deftest ^{:stratum 1} copyright-header-prepended-test
+  (testing "patch-file-content prepends copyright header for missing-header violations"
+    (let [content "# My Doc\n\nSome content.\n"
+          patched (execute/patch-file-content content [copyright-violation])]
+      (is (str/starts-with? patched "<!--")
+          "Patched content should start with HTML comment")
+      (is (str/includes? patched "Christopher Lester")
+          "Copyright header should contain author name")
+      (is (str/includes? patched "# My Doc")
+          "Original content should be preserved after the header"))))
+
+(deftest ^{:stratum 1} copyright-header-before-line-edits-test
+  (testing "copyright prepend does not shift line indices for line-replacement violations"
+    (let [content  "(or (:timeout m) 5000)\nline2\n"
+          v-clj    (assoc clojure-violation :line 1)
+          patched  (execute/patch-file-content content [v-clj copyright-violation])]
+      (is (str/includes? patched "(get m :timeout 5000)")
+          "Clojure fix should still be applied")
+      (is (str/starts-with? patched "<!--")
+          "Copyright header should be at the top"))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/multi_detection_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/multi_detection_test.clj
@@ -15,28 +15,36 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.compliance-scanner.multi-detection-test
   "Tests for multi-detection scanning, category selectors, and incremental mode."
   (:require
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.compliance-scanner.scan]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; Access private functions via var for unit testing
-(def ^:private category-matches?
+(def ^{:stratum 0} ^:private category-matches?
   (var-get #'ai.miniforge.compliance-scanner.scan/category-matches?))
 
-(def ^:private rule-matches-selector?
+(def ^{:stratum 0} ^:private rule-matches-selector?
   (var-get #'ai.miniforge.compliance-scanner.scan/rule-matches-selector?))
 
-(def ^:private category-dewey-ranges
+(def ^{:stratum 0} ^:private category-dewey-ranges
   (var-get #'ai.miniforge.compliance-scanner.scan/category-dewey-ranges))
+
+;; ============================================================================
+;; Diff rule scanning
+;; ============================================================================
+(def ^{:stratum 0} ^:private scan-diff-rule
+  (var-get #'ai.miniforge.compliance-scanner.scan/scan-diff-rule))
+
+;------------------------------------------------------------------------------ Layer 1
 
 ;; ============================================================================
 ;; Category Dewey ranges data
 ;; ============================================================================
-
-(deftest category-dewey-ranges-test
+(deftest ^{:stratum 1} category-dewey-ranges-test
   (testing "has all 10 categories"
     (is (= 10 (count category-dewey-ranges))))
 
@@ -48,8 +56,7 @@
 ;; ============================================================================
 ;; Category matching
 ;; ============================================================================
-
-(deftest category-matches-exact-test
+(deftest ^{:stratum 1} category-matches-exact-test
   (testing "exact name match"
     (let [rule {:rule/category "foundations"}]
       (is (true? (category-matches? rule :mf.cat/foundations)))))
@@ -58,7 +65,7 @@
     (let [rule {:rule/category "foundations"}]
       (is (not (category-matches? rule :mf.cat/languages))))))
 
-(deftest category-matches-dewey-range-test
+(deftest ^{:stratum 1} category-matches-dewey-range-test
   (testing "Dewey code 210 matches :mf.cat/languages (200-299)"
     (let [rule {:rule/category "210"}]
       (is (true? (category-matches? rule :mf.cat/languages)))))
@@ -78,8 +85,7 @@
 ;; ============================================================================
 ;; Rule selector matching
 ;; ============================================================================
-
-(deftest rule-matches-selector-rule-id-test
+(deftest ^{:stratum 1} rule-matches-selector-rule-id-test
   (testing "matches by rule ID"
     (let [rule {:rule/id :std/clojure :rule/category "210"}]
       (is (true? (rule-matches-selector? rule :std/clojure)))))
@@ -88,19 +94,12 @@
     (let [rule {:rule/id :std/clojure :rule/category "210"}]
       (is (not (rule-matches-selector? rule :std/python))))))
 
-(deftest rule-matches-selector-category-test
+(deftest ^{:stratum 1} rule-matches-selector-category-test
   (testing "matches by category keyword"
     (let [rule {:rule/id :std/clojure :rule/category "210"}]
       (is (true? (rule-matches-selector? rule :mf.cat/languages))))))
 
-;; ============================================================================
-;; Diff rule scanning
-;; ============================================================================
-
-(def ^:private scan-diff-rule
-  (var-get #'ai.miniforge.compliance-scanner.scan/scan-diff-rule))
-
-(deftest scan-diff-rule-test
+(deftest ^{:stratum 1} scan-diff-rule-test
   (testing "detects pattern in diff content"
     (let [rule-cfg {:rule/id       :test/removed-import
                     :rule/category "300"

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/named_constants_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/named_constants_test.clj
@@ -15,50 +15,22 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.compliance-scanner.named-constants-test
   (:require
    [ai.miniforge.compliance-scanner.named-constants :as sut]
    [clojure.test :refer [deftest is testing]]))
 
-(defn- tokens [s] (mapv :token (sut/scan-numeric-tokens s)))
+;------------------------------------------------------------------------------ Layer 0
 
-(deftest flags-magic-numeric-literals-test
-  (testing "numbers outside the sentinel set are magic"
-    (is (= ["300000"] (tokens "(def x {:t 300000})")))
-    (is (= ["130"] (tokens "(recur 130 acc)")))
-    (is (= ["10" "60"] (tokens "(max 10 (- cols 60))")))
-    (is (= ["0xFF"] (tokens "(bit-and x 0xFF)")) "hex is magic")
-    (is (= ["7200"] (tokens "\"sleep\" 7200")) "int after a string still flagged")))
+(defn- ^{:stratum 0} tokens [s] (mapv :token (sut/scan-numeric-tokens s)))
 
-(deftest exempts-structural-sentinels-test
-  (testing "-1, 0, 1, 2 are structural and never flagged"
-    (is (= [] (tokens "(if (< n 2) 0 1)")))
-    (is (= [] (tokens "(dec 1) (inc 0) (nth xs -1)")))
-    (is (= [] (tokens "(* x 2)")) "the doubling identity is exempt")))
-
-(deftest ignores-strings-comments-symbols-test
-  (testing "numbers inside strings, comments, or symbols are not code literals"
-    (is (= [] (tokens "(def p \"config/foo/messages/64.edn\")")) "in a string")
-    (is (= [] (tokens ";; timeout is 300000 ms")) "in a comment")
-    (is (= [] (tokens "(def h sha256-hex)")) "digits inside a symbol")
-    (is (= [] (tokens "(str \"ver 300\")")) "number in a string arg")))
-
-(deftest char-literals-not-retokenized-test
-  (testing "unicode/octal/named char literals don't leak digits as numbers"
-    (is (= [] (tokens "(def c \\u0030)")) "\\u0030 digits not a number")
-    (is (= [] (tokens "(def c \\o101)")) "\\o101 digits not a number")
-    (is (= [] (tokens "(when (= ch \\newline) x)")) "named char literal")
-    (is (= [] (tokens "(def c \\1)")) "digit char literal is not a magic number")
-    (is (= ["42"] (tokens "(def c \\a) (def n 42)")) "a real number after a char literal still flags")))
-
-(deftest string-with-newline-keeps-line-numbers-test
+(deftest ^{:stratum 0} string-with-newline-keeps-line-numbers-test
   (testing "a multi-line string does not desync line tracking"
     (let [r (sut/scan-numeric-tokens "(def s \"a\nb\")\n(def n 42)")]
       (is (= [{:token "42"}] (mapv #(select-keys % [:token]) r)))
       (is (= 3 (:line (first r))) "42 is on line 3, after the 2-line string"))))
 
-(deftest analyze-content-shape-test
+(deftest ^{:stratum 0} analyze-content-shape-test
   (testing "violation records carry rule id, file, line, and the token"
     (let [[v] (sut/analyze-content "x.clj" "(def t 5000)")]
       (is (= :std/named-constants (:rule/id v)))
@@ -66,3 +38,34 @@
       (is (= "5000" (:current v)))
       (is (= :magic-numeric (:kind v)))
       (is (pos-int? (:line v))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} flags-magic-numeric-literals-test
+  (testing "numbers outside the sentinel set are magic"
+    (is (= ["300000"] (tokens "(def x {:t 300000})")))
+    (is (= ["130"] (tokens "(recur 130 acc)")))
+    (is (= ["10" "60"] (tokens "(max 10 (- cols 60))")))
+    (is (= ["0xFF"] (tokens "(bit-and x 0xFF)")) "hex is magic")
+    (is (= ["7200"] (tokens "\"sleep\" 7200")) "int after a string still flagged")))
+
+(deftest ^{:stratum 1} exempts-structural-sentinels-test
+  (testing "-1, 0, 1, 2 are structural and never flagged"
+    (is (= [] (tokens "(if (< n 2) 0 1)")))
+    (is (= [] (tokens "(dec 1) (inc 0) (nth xs -1)")))
+    (is (= [] (tokens "(* x 2)")) "the doubling identity is exempt")))
+
+(deftest ^{:stratum 1} ignores-strings-comments-symbols-test
+  (testing "numbers inside strings, comments, or symbols are not code literals"
+    (is (= [] (tokens "(def p \"config/foo/messages/64.edn\")")) "in a string")
+    (is (= [] (tokens ";; timeout is 300000 ms")) "in a comment")
+    (is (= [] (tokens "(def h sha256-hex)")) "digits inside a symbol")
+    (is (= [] (tokens "(str \"ver 300\")")) "number in a string arg")))
+
+(deftest ^{:stratum 1} char-literals-not-retokenized-test
+  (testing "unicode/octal/named char literals don't leak digits as numbers"
+    (is (= [] (tokens "(def c \\u0030)")) "\\u0030 digits not a number")
+    (is (= [] (tokens "(def c \\o101)")) "\\o101 digits not a number")
+    (is (= [] (tokens "(when (= ch \\newline) x)")) "named char literal")
+    (is (= [] (tokens "(def c \\1)")) "digit char literal is not a magic number")
+    (is (= ["42"] (tokens "(def c \\a) (def n 42)")) "a real number after a char literal still flags")))

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/plan_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/plan_test.clj
@@ -15,17 +15,17 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.compliance-scanner.plan-test
   "Tests for the plan phase."
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.string :as str]
             [ai.miniforge.compliance-scanner.plan :as plan]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; ---------------------------------------------------------------------------
 ;; Test fixtures
-
-(defn- make-violation
+(defn- ^{:stratum 0} make-violation
   [rule-id rule-category file line auto-fixable?]
   {:rule/id       rule-id
    :rule/category rule-category
@@ -37,13 +37,15 @@
    :auto-fixable? auto-fixable?
    :rationale     "test"})
 
-(def ^:private file-a "components/foo/src/core.clj")
-(def ^:private file-b "components/bar/src/core.clj")
+(def ^{:stratum 0} ^:private file-a "components/foo/src/core.clj")
+
+(def ^{:stratum 0} ^:private file-b "components/bar/src/core.clj")
+
+;------------------------------------------------------------------------------ Layer 1
 
 ;; ---------------------------------------------------------------------------
 ;; DAG topology
-
-(deftest same-file-different-rules-creates-deps
+(deftest ^{:stratum 1} same-file-different-rules-creates-deps
   (testing "two rules on the same file produce an intra-file dep edge"
     (let [viols [(make-violation :std/clojure          "210" file-a 10 true)
                  (make-violation :std/header-copyright "810" file-a 1  true)]
@@ -60,7 +62,7 @@
         ;; 810 depends on 210
         (is (contains? (:task/deps task-810) (:task/id task-210)))))))
 
-(deftest different-files-have-no-deps
+(deftest ^{:stratum 1} different-files-have-no-deps
   (testing "violations on different files produce tasks with no cross-file deps"
     (let [viols [(make-violation :std/clojure "210" file-a 10 true)
                  (make-violation :std/clojure "210" file-b 5  true)]
@@ -69,7 +71,7 @@
       ;; Each task has no deps (separate files)
       (is (every? #(empty? (:task/deps %)) dag-tasks)))))
 
-(deftest single-violation-has-no-deps
+(deftest ^{:stratum 1} single-violation-has-no-deps
   (testing "a plan with one violation produces a task with an empty dep set"
     (let [viols [(make-violation :std/datever "730" file-a 3 true)]
           {:keys [dag-tasks]} (plan/plan viols ".")]
@@ -78,8 +80,7 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Summary statistics
-
-(deftest summary-stats-are-correct
+(deftest ^{:stratum 1} summary-stats-are-correct
   (testing "plan summary counts match the violation list"
     (let [viols [(make-violation :std/clojure          "210" file-a 10 true)
                  (make-violation :std/header-copyright "810" file-a 1  true)
@@ -94,8 +95,7 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Markdown work spec
-
-(deftest work-spec-contains-expected-sections
+(deftest ^{:stratum 1} work-spec-contains-expected-sections
   (testing "work spec markdown includes all required section headers"
     (let [viols [(make-violation :std/clojure          "210" file-a 10 true)
                  (make-violation :std/header-copyright "810" file-b 1  false)]
@@ -106,7 +106,7 @@
       (is (str/includes? work-spec "## Needs-Review Summary"))
       (is (str/includes? work-spec "## Execution Instructions")))))
 
-(deftest work-spec-lists-rule-categories
+(deftest ^{:stratum 1} work-spec-lists-rule-categories
   (testing "work spec includes each rule category in section headers"
     (let [viols [(make-violation :std/clojure  "210" file-a 10 true)
                  (make-violation :std/datever  "730" file-b 3  true)]
@@ -114,7 +114,7 @@
       (is (str/includes? work-spec "210 —"))
       (is (str/includes? work-spec "730 —")))))
 
-(deftest work-spec-no-violations-shows-no-review-message
+(deftest ^{:stratum 1} work-spec-no-violations-shows-no-review-message
   (testing "work spec says no violations need review when all are auto-fixable"
     (let [viols [(make-violation :std/clojure "210" file-a 10 true)]
           {:keys [work-spec]} (plan/plan viols ".")]
@@ -122,8 +122,7 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Task structure
-
-(deftest tasks-have-required-keys
+(deftest ^{:stratum 1} tasks-have-required-keys
   (testing "every PlanTask has all required keys"
     (let [viols [(make-violation :std/clojure          "210" file-a 10 true)
                  (make-violation :std/header-copyright "810" file-b 1  false)]

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/pr_review_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/pr_review_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.compliance-scanner.pr-review-test
   "Tests for the `pr-review` Layer 1 entry point (N13 §2.2).
 
@@ -30,7 +29,9 @@
             [ai.miniforge.compliance-scanner.scan      :as scan-impl]
             [ai.miniforge.compliance-scanner.execute   :as execute-impl]))
 
-(def ^:private one-violation
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private one-violation
   {:rule/id        :ai.miniforge.standards/example-rule
    :rule/category  "code-quality"
    :rule/title     "Example rule"
@@ -41,13 +42,7 @@
    :auto-fixable?  true
    :rationale      "test fixture"})
 
-(def ^:private fake-scan-result
-  {:violations       [one-violation]
-   :rules-scanned    [:ai.miniforge.standards/example-rule]
-   :files-scanned    1
-   :scan-duration-ms 1})
-
-(deftest base-ref-required
+(deftest ^{:stratum 0} base-ref-required
   (testing "missing :base-ref throws with anomaly tag"
     (let [thrown (try
                    (scanner/pr-review "/nonexistent" ".standards" {})
@@ -61,7 +56,50 @@
                  (scanner/pr-review "/nonexistent" ".standards"
                                     {:base-ref ""})))))
 
-(deftest scan-invoked-with-since
+(deftest ^{:stratum 0} empty-scan-returns-empty-comments
+  (testing "no violations → empty comments vector + zeroed summary"
+    (with-redefs [scan-impl/scan-repo (fn [_ _ _] {:violations       []
+                                                   :rules-scanned    []
+                                                   :files-scanned    0
+                                                   :scan-duration-ms 1})
+                  execute-impl/execute! (fn [& _] (throw (ex-info "should not be called" {})))]
+      (let [{:pr-review/keys [comments summary]}
+            (scanner/pr-review "/some/repo" ".standards"
+                               {:base-ref "origin/main"})]
+        (is (= [] comments))
+        (is (zero? (:total summary)))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} ^:private fake-scan-result
+  {:violations       [one-violation]
+   :rules-scanned    [:ai.miniforge.standards/example-rule]
+   :files-scanned    1
+   :scan-duration-ms 1})
+
+(deftest ^{:stratum 1} summary-counts
+  (testing "summary aggregates total / auto-fixable / needs-review / files / rules"
+    (let [v1 (assoc one-violation :file "a.clj" :rule/id :rule/a :auto-fixable? true)
+          v2 (assoc one-violation :file "b.clj" :rule/id :rule/b :auto-fixable? false)
+          v3 (assoc one-violation :file "a.clj" :rule/id :rule/a :auto-fixable? true)]
+      (with-redefs [scan-impl/scan-repo (fn [_ _ _] {:violations       [v1 v2 v3]
+                                                     :rules-scanned    [:rule/a :rule/b]
+                                                     :files-scanned    2
+                                                     :scan-duration-ms 1})
+                    classify-impl/classify-violations identity
+                    execute-impl/execute! (fn [& _] (throw (ex-info "should not be called" {})))]
+        (let [{:pr-review/keys [summary]}
+              (scanner/pr-review "/some/repo" ".standards"
+                                 {:base-ref "origin/main"})]
+          (is (= 3 (:total summary)))
+          (is (= 2 (:auto-fixable summary)))
+          (is (= 1 (:needs-review summary)))
+          (is (= 2 (:files-affected summary)))
+          (is (= 2 (:rules-violated summary))))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} scan-invoked-with-since
   (testing "pr-review forwards :base-ref to scan as :since and never to execute!"
     (let [scan-calls    (atom [])
           execute-calls (atom 0)]
@@ -93,7 +131,7 @@
                                  :comment/payload :violation/pack-id])))
           (is (= 1 (get-in result [:pr-review/summary :total]))))))))
 
-(deftest pack-info-default
+(deftest ^{:stratum 2} pack-info-default
   (testing "no :pack-info supplied → default pack-id/version filled in"
     (with-redefs [scan-impl/scan-repo (fn [_ _ _] fake-scan-result)
                   execute-impl/execute! (fn [& _] (throw (ex-info "should not be called" {})))]
@@ -104,36 +142,3 @@
                                          :comment/payload :violation/pack-id])))
         (is (= "0.0.0"   (get-in result [:pr-review/comments 0
                                          :comment/payload :violation/pack-version])))))))
-
-(deftest summary-counts
-  (testing "summary aggregates total / auto-fixable / needs-review / files / rules"
-    (let [v1 (assoc one-violation :file "a.clj" :rule/id :rule/a :auto-fixable? true)
-          v2 (assoc one-violation :file "b.clj" :rule/id :rule/b :auto-fixable? false)
-          v3 (assoc one-violation :file "a.clj" :rule/id :rule/a :auto-fixable? true)]
-      (with-redefs [scan-impl/scan-repo (fn [_ _ _] {:violations       [v1 v2 v3]
-                                                     :rules-scanned    [:rule/a :rule/b]
-                                                     :files-scanned    2
-                                                     :scan-duration-ms 1})
-                    classify-impl/classify-violations identity
-                    execute-impl/execute! (fn [& _] (throw (ex-info "should not be called" {})))]
-        (let [{:pr-review/keys [summary]}
-              (scanner/pr-review "/some/repo" ".standards"
-                                 {:base-ref "origin/main"})]
-          (is (= 3 (:total summary)))
-          (is (= 2 (:auto-fixable summary)))
-          (is (= 1 (:needs-review summary)))
-          (is (= 2 (:files-affected summary)))
-          (is (= 2 (:rules-violated summary))))))))
-
-(deftest empty-scan-returns-empty-comments
-  (testing "no violations → empty comments vector + zeroed summary"
-    (with-redefs [scan-impl/scan-repo (fn [_ _ _] {:violations       []
-                                                   :rules-scanned    []
-                                                   :files-scanned    0
-                                                   :scan-duration-ms 1})
-                  execute-impl/execute! (fn [& _] (throw (ex-info "should not be called" {})))]
-      (let [{:pr-review/keys [comments summary]}
-            (scanner/pr-review "/some/repo" ".standards"
-                               {:base-ref "origin/main"})]
-        (is (= [] comments))
-        (is (zero? (:total summary)))))))

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/scan_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/scan_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.compliance-scanner.scan-test
   "Tests for the scan phase.
 
@@ -25,24 +24,70 @@
             [clojure.java.io :as io]
             [ai.miniforge.compliance-scanner.scan :as scan]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; ---------------------------------------------------------------------------
 ;; Helpers
-
-(def ^:private d210-pattern
+(def ^{:stratum 0} ^:private d210-pattern
   "Canonical Dewey 210 detection pattern from .standards/languages/clojure.mdc."
   (re-pattern "\\(or \\((:[a-zA-Z][a-zA-Z0-9?!_*+<>-]*)\\s+([a-zA-Z][a-zA-Z0-9_-]*)\\)\\s+((?:nil|true|false|\"[^\"]*\"|-?\\d+(?:\\.\\d+)?|\\[\\]|\\{\\}|:[a-zA-Z][a-zA-Z0-9_-]*))\\)"))
 
-(defn- matches? [pattern s]
+(defn- ^{:stratum 0} matches? [pattern s]
   (boolean (re-find pattern s)))
 
-(def ^:private test-pack
+(def ^{:stratum 0} ^:private test-pack
   "Pre-compiled pack fixture for integration tests."
   (edn/read-string (slurp (io/resource "test-fixtures/clojure-210-pack.edn"))))
 
 ;; ---------------------------------------------------------------------------
-;; Dewey 210 regex tests
+;; Integration: scan a temp directory
+(defn- ^{:stratum 0} write-temp-file!
+  "Write content to a temporary file and return its java.io.File."
+  [dir relative-path content]
+  (let [f (io/file dir relative-path)]
+    (io/make-parents f)
+    (spit f content)
+    f))
 
-(deftest dewey-210-matches-simple-literal-defaults
+(defn- ^{:stratum 0} run-in-dir!
+  "Run a subprocess in `dir`, clearing inherited Git hook env vars."
+  [dir & cmd]
+  (let [pb       (doto (ProcessBuilder. ^java.util.List (vec cmd))
+                   (.directory dir)
+                   (.inheritIO))
+        env      (.environment pb)
+        git-keys (filterv #(re-find #"^GIT_" %) (keys env))]
+    (doseq [k git-keys] (.remove env k))
+    (let [exit (.waitFor (.start pb))]
+      (when-not (zero? exit)
+        (throw (ex-info "Test subprocess failed"
+                        {:cmd cmd :dir (.getAbsolutePath dir) :exit exit})))
+      exit)))
+
+;; ---------------------------------------------------------------------------
+;; safe-git-ref? validation
+(deftest ^{:stratum 0} safe-git-ref-allows-well-formed-refs
+  (testing "common git ref forms are accepted"
+    (is (#'scan/safe-git-ref? "origin/main"))
+    (is (#'scan/safe-git-ref? "HEAD~1"))
+    (is (#'scan/safe-git-ref? "abc123def456"))
+    (is (#'scan/safe-git-ref? "v1.0.0-rc1"))
+    (is (#'scan/safe-git-ref? "refs/heads/feature-branch"))))
+
+(deftest ^{:stratum 0} safe-git-ref-rejects-unsafe-values
+  (testing "values that could inject git options or shell constructs are rejected"
+    (is (not (#'scan/safe-git-ref? "; rm -rf /")))
+    (is (not (#'scan/safe-git-ref? "--exec=cmd")))
+    (is (not (#'scan/safe-git-ref? "-C /malicious/path")))
+    (is (not (#'scan/safe-git-ref? "ref with spaces")))
+    (is (not (#'scan/safe-git-ref? "")))
+    (is (not (#'scan/safe-git-ref? nil)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; ---------------------------------------------------------------------------
+;; Dewey 210 regex tests
+(deftest ^{:stratum 1} dewey-210-matches-simple-literal-defaults
   (testing "integer default"
     (is (matches? d210-pattern "(or (:timeout m) 5000)")))
   (testing "nil default"
@@ -58,12 +103,12 @@
   (testing "empty map default"
     (is (matches? d210-pattern "(or (:opts m) {})"))))
 
-(deftest dewey-210-does-not-match-dual-key-coalesce
+(deftest ^{:stratum 1} dewey-210-does-not-match-dual-key-coalesce
   (testing "two-key coalesce (dual-key pattern — must be left alone)"
     ;; (or (:k1 m) (:k2 m) default) should NOT match
     (is (not (matches? d210-pattern "(or (:k1 m) (:k2 m) :fallback)")))))
 
-(deftest dewey-210-does-not-match-computed-default
+(deftest ^{:stratum 1} dewey-210-does-not-match-computed-default
   (testing "computed default via function call"
     ;; (or (:k m) (some-fn)) — default is not a literal
     (is (not (matches? d210-pattern "(or (:k m) (some-fn))"))))
@@ -72,33 +117,7 @@
     ;; Note: our pattern requires a literal, so symbol defaults won't match.
     (is (not (matches? d210-pattern "(or (:k m) my-var)")))))
 
-;; ---------------------------------------------------------------------------
-;; Integration: scan a temp directory
-
-(defn- write-temp-file!
-  "Write content to a temporary file and return its java.io.File."
-  [dir relative-path content]
-  (let [f (io/file dir relative-path)]
-    (io/make-parents f)
-    (spit f content)
-    f))
-
-(defn- run-in-dir!
-  "Run a subprocess in `dir`, clearing inherited Git hook env vars."
-  [dir & cmd]
-  (let [pb       (doto (ProcessBuilder. ^java.util.List (vec cmd))
-                   (.directory dir)
-                   (.inheritIO))
-        env      (.environment pb)
-        git-keys (filterv #(re-find #"^GIT_" %) (keys env))]
-    (doseq [k git-keys] (.remove env k))
-    (let [exit (.waitFor (.start pb))]
-      (when-not (zero? exit)
-        (throw (ex-info "Test subprocess failed"
-                        {:cmd cmd :dir (.getAbsolutePath dir) :exit exit})))
-      exit)))
-
-(deftest scan-repo-detects-210-in-temp-dir
+(deftest ^{:stratum 1} scan-repo-detects-210-in-temp-dir
   (testing "scan-repo finds Dewey 210 violations in a synthetic repo"
     (let [tmp-dir (doto (io/file (System/getProperty "java.io.tmpdir")
                                  (str "cs-scan-test-" (System/currentTimeMillis)))
@@ -151,7 +170,7 @@
           (doseq [f (reverse (file-seq tmp-dir))]
             (.delete f)))))))
 
-(deftest scan-repo-excludes-fatal-only-exceptions-as-data-rows
+(deftest ^{:stratum 1} scan-repo-excludes-fatal-only-exceptions-as-data-rows
   (testing "top-level review output keeps cleanup-needed rows actionable"
     (let [tmp-dir (doto (io/file (System/getProperty "java.io.tmpdir")
                                  (str "cs-exc-filter-test-" (System/currentTimeMillis)))
@@ -188,26 +207,6 @@
         (finally
           (doseq [f (reverse (file-seq tmp-dir))]
             (.delete f)))))))
-
-;; ---------------------------------------------------------------------------
-;; safe-git-ref? validation
-
-(deftest safe-git-ref-allows-well-formed-refs
-  (testing "common git ref forms are accepted"
-    (is (#'scan/safe-git-ref? "origin/main"))
-    (is (#'scan/safe-git-ref? "HEAD~1"))
-    (is (#'scan/safe-git-ref? "abc123def456"))
-    (is (#'scan/safe-git-ref? "v1.0.0-rc1"))
-    (is (#'scan/safe-git-ref? "refs/heads/feature-branch"))))
-
-(deftest safe-git-ref-rejects-unsafe-values
-  (testing "values that could inject git options or shell constructs are rejected"
-    (is (not (#'scan/safe-git-ref? "; rm -rf /")))
-    (is (not (#'scan/safe-git-ref? "--exec=cmd")))
-    (is (not (#'scan/safe-git-ref? "-C /malicious/path")))
-    (is (not (#'scan/safe-git-ref? "ref with spaces")))
-    (is (not (#'scan/safe-git-ref? "")))
-    (is (not (#'scan/safe-git-ref? nil)))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/docs/pull-requests/2026-07-24-fix-stratum-lint-wave1-compliance-scanner.md
+++ b/docs/pull-requests/2026-07-24-fix-stratum-lint-wave1-compliance-scanner.md
@@ -1,0 +1,127 @@
+# fix: stratum-lint autofix for components/compliance-scanner (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over the whole `compliance-scanner` component
+(`src` + `test`) to replace decorative/misordered `Layer N` headings with
+headings that reflect the file's real same-file reference graph, and tags
+each `def`/`defn` with `^{:stratum n}` metadata. Purely mechanical: no
+logic changes. This is the first of the per-component Wave 1 PRs from
+`work/stratum-lint-baseline-2026-07-24.md`.
+
+## Motivation
+
+`work/stratum-lint-baseline-2026-07-24.md` found rule 210's per-file
+`Layer N` heading convention (`standards/miniforge/languages/clojure.mdc`)
+had been cargo-culted across most of the codebase: headings repeated as
+visual section breaks rather than one heading per real abstraction
+stratum. `compliance-scanner` carried 25 findings under that diagnosis —
+21 `SL002` (heading reused instead of strictly increasing), 3 `SL004`
+(`def` before the first heading), 1 `SL003` (over the 3-layer budget) —
+and zero `SL001` (upward-reference) findings, which is exactly why the
+baseline's Wave 1 plan named it a first-batch target: no cycle/upward-call
+risk to reason about before running the mechanical fixer.
+
+## Changes in Detail
+
+Ran, over the whole component:
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "acd82a2f5c0155cb03d92ce1f4465cc064125895" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/compliance-scanner
+```
+
+27 files rewritten (12 `src`, 15 `test`) — every `.clj` file in the
+component, including files that had zero prior findings (`--fix`
+normalizes those too, adding `^{:stratum n}` metadata as a one-time pass;
+matches the tool's documented idempotency behavior). Diff stat:
+27 files changed, 1277 insertions(+), 1263 deletions(-).
+
+No line of executable code changed. Verified by stripping `;---- Layer N`
+headings, `Rich Comment` headings, and `^{:stratum n}` metadata from both
+the pre-fix and post-fix content of every changed file, sorting each set
+of lines, and diffing — all 27 files came back byte-identical under that
+normalization. The diff itself is def reordering (regrouped under
+regenerated headings) plus metadata addition.
+
+A notable finding from running the fixer: only `execute.clj` reported
+`SL003` before this fix (4 distinct layers under its old, partially-honest
+headings). Once `--fix` inferred each file's *real* stratum count from the
+reference graph, 6 more files that looked clean under the old decorative
+headings turned out to already be over the 3-layer budget:
+
+| File | Real layers (post-fix) |
+|------|------------------------:|
+| `classify.clj` | 4 |
+| `comments.clj` | 4 |
+| `execute.clj` | 5 |
+| `named_constants.clj` | 6 |
+| `plan.clj` | 5 |
+| `scan.clj` | 8 |
+| `exceptions_as_data.clj` | 8 |
+
+This confirms the baseline doc's diagnosis for this component specifically:
+the decorative headings weren't just mis-ordered, they were actively
+under-reporting real structural depth. All 7 need an actual namespace
+split (Wave 2), out of scope for this PR.
+
+## Testing Plan
+
+1. Ran plain (non-`--fix`) `stratum-lint` over `components/compliance-scanner`
+   before the fix — reproduced the baseline's 25 findings exactly (21
+   `SL002`, 1 `SL003`, 3 `SL004`, 0 `SL001`).
+2. Ran `--fix`, then reviewed `git diff --stat` and read the full diff for
+   every changed file (`named_constants.clj`, `execute.clj`,
+   `exceptions_as_data.clj`, `comments.clj`, `messages.clj` read in full;
+   all others diffed and spot-checked). Confirmed heading regrouping and
+   `^{:stratum n}` metadata only — no mangled comment blocks, no altered
+   Apache license headers (checked the header's last line is byte-identical
+   across all 27 files at the same position), no logic changes.
+3. Ran the sort-and-diff content-preservation check described above across
+   all 27 changed files programmatically — all reported identical content
+   modulo headings/metadata/order.
+4. Ran `clj-kondo` over `components/compliance-scanner/src` and `test`
+   before and after the fix: 0 errors both times, same single pre-existing
+   warning (unresolved `clojure.string` require in `classify_test.clj`, at
+   a different line number post-reorder) — confirms no parse/structural
+   damage from the rewrite.
+5. Re-ran plain `stratum-lint` (no `--fix`) over
+   `components/compliance-scanner` after the fix: `SL001`, `SL002`,
+   `SL004`, `SL005`, `SL006` all clear. `SL003` remains on 7 files (table
+   above) — expected per the baseline's Wave 1/Wave 2 split; each needs a
+   real namespace split, tracked as Wave 2 work, not a defect in this PR.
+6. Did not run the full `bb pre-commit` / `test:poly` suite manually in
+   this exploration — left to the pre-commit hook (`test:precommit`,
+   `test:graalvm`) at commit time, which is the real validation gate per
+   the baseline plan's Wave 0 decision.
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+changes — this is a comment/metadata-only reorder, so there is nothing to
+roll out beyond the merge itself. The pre-commit hook's own
+`lint:stratum` autofixer (landed in
+`2026-07-24-fix-stratum-lint-autofix-precommit.md`) will keep this
+component clean going forward for any file it touches; the remaining
+`SL003` files stay flagged as advisory (non-blocking) until Wave 2 splits
+them.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1 —
+  mechanical relabeling via `--fix`, decorative-heading files only)
+- Depends on: `2026-07-24-fix-stratum-lint-autofix-precommit.md` (upstream
+  sha bump + autofix wiring)
+- Follow-on: Wave 2 namespace splits for `classify.clj`, `comments.clj`,
+  `execute.clj`, `named_constants.clj`, `plan.clj`, `scan.clj`,
+  `exceptions_as_data.clj` (all now `SL003`, 4–8 real layers each)
+
+## Checklist
+
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Diff reviewed file-by-file; confirmed mechanical-only (heading +
+      metadata) via full reads plus a sorted-content-diff check across all
+      27 files
+- [x] `clj-kondo` clean before/after (0 errors, same pre-existing warning)
+- [x] Plain lint re-run post-fix: zero findings except `SL003` (7 files,
+      documented above, tracked as Wave 2)
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
## Summary

- Runs `stratum-lint --fix` over the whole `compliance-scanner` component (src + test) — 27 files rewritten, purely mechanical (heading regrouping + `^{:stratum n}` metadata, no logic changes, verified via a sorted-content-diff across every changed file).
- Wave 1 of `work/stratum-lint-baseline-2026-07-24.md`: this component had 25 findings (21 `SL002`, 1 `SL003`, 3 `SL004`, **zero** `SL001`), which is why the baseline plan named it a first-batch target — no upward-reference/cycle risk to reason about before running the mechanical fixer.
- Notable finding: only `execute.clj` reported `SL003` before the fix. Once `--fix` inferred each file's real stratum count from the reference graph, 6 more files that looked clean under the old decorative headings turned out to already be 4–8 real layers deep (`classify.clj`, `comments.clj`, `named_constants.clj`, `plan.clj`, `scan.clj`, `exceptions_as_data.clj`). All 7 now report `SL003` (over the 3-layer budget) — expected, tracked as Wave 2 namespace-split work, **out of scope for this PR**.

Full detail in `docs/pull-requests/2026-07-24-fix-stratum-lint-wave1-compliance-scanner.md`.

## Test plan

- [x] Reproduced the baseline's 25 pre-fix findings exactly before running `--fix`
- [x] Read the full diff for every changed file (5 in full: `named_constants.clj`, `execute.clj`, `exceptions_as_data.clj`, `comments.clj`, `messages.clj`; all 27 diffed/spot-checked)
- [x] Programmatic sorted-content-diff across all 27 changed files (strip headings/metadata, sort, diff) — confirmed byte-identical content, order-only changes
- [x] `clj-kondo` before/after: 0 errors both times, same single pre-existing warning (line-shifted only)
- [x] Post-fix plain lint: `SL001`/`SL002`/`SL004`/`SL005`/`SL006` all clear; `SL003` remains on 7 files, documented above and in the PR doc as Wave 2
- [x] Pre-commit hook ran normally (no `--no-verify`): `poly:check`, `lint:clj`, `lint:stratum` (advisory SL003 printed, non-blocking), `fmt:md`, `test:precommit` (331 tests / 1241 assertions, 0 failures), `test:graalvm` (7 tests / 539 assertions, 0 failures) — all passed
- [x] Commit budget gate overridden via `MINIFORGE_COMMIT_BUDGET_OVERRIDE` (full-file mechanical reorder, expected per the baseline plan)

Related: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1), depends on the autofix wiring landed in the stratum-lint pre-commit PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)