### PR TITLE
fix: stratum-lint autofix for components/reliability (Wave 1)

### DIFF
--- a/components/reliability/src/ai/miniforge/reliability/budget.clj
+++ b/components/reliability/src/ai/miniforge/reliability/budget.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.reliability.budget
   "Error budget computation per N1 §5.5.4.
 
@@ -29,19 +28,13 @@
    [clojure.java.io :as io]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Constants
 
-(def ^:private defaults
+;; Constants
+(def ^{:stratum 0} ^:private defaults
   (-> (io/resource "config/reliability/defaults.edn") slurp edn/read-string))
 
-(def ^:const default-critical-threshold
-  "Budget fraction below which the budget is considered critical."
-  (:budget-critical-threshold defaults))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; Factory
-
-(defn error-budget
+(defn ^{:stratum 0} error-budget
   ([remaining burn-rate]
    {:error-budget/remaining remaining
     :error-budget/burn-rate burn-rate})
@@ -53,10 +46,19 @@
     :error-budget/window      window
     :error-budget/computed-at (java.util.Date.)}))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Budget computation
+;; Predicates
+(defn ^{:stratum 0} budget-exhausted?
+  [budget]
+  (<= (:error-budget/remaining budget) 0.0))
 
-(defn compute-error-budget
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} ^:const default-critical-threshold
+  "Budget fraction below which the budget is considered critical."
+  (:budget-critical-threshold defaults))
+
+;; Budget computation
+(defn ^{:stratum 1} compute-error-budget
   [sli-value slo-target inverted?]
   (let [[remaining burn-rate]
         (if inverted?
@@ -80,19 +82,7 @@
                0.0)]))]
     (error-budget remaining burn-rate)))
 
-;------------------------------------------------------------------------------ Layer 0
-;; Predicates
-
-(defn budget-exhausted?
-  [budget]
-  (<= (:error-budget/remaining budget) 0.0))
-
-(defn budget-critical?
-  ([budget] (budget-critical? budget default-critical-threshold))
-  ([budget threshold]
-   (< (:error-budget/remaining budget) threshold)))
-
-(defn critical-budget-exhausted?
+(defn ^{:stratum 1} critical-budget-exhausted?
   "Returns true if any critical-tier budget in the budget map is exhausted.
    budget-state is a map of {[sli tier window] -> budget-map}."
   [budget-state]
@@ -101,7 +91,16 @@
                (budget-exhausted? b)))
         budget-state))
 
-(defn critical-budget-low?
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} budget-critical?
+  ([budget] (budget-critical? budget default-critical-threshold))
+  ([budget threshold]
+   (< (:error-budget/remaining budget) threshold)))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} critical-budget-low?
   "Returns true if any critical-tier budget in the budget map is below threshold.
    budget-state is a map of {[sli tier window] -> budget-map}."
   [budget-state]

--- a/components/reliability/src/ai/miniforge/reliability/degradation.clj
+++ b/components/reliability/src/ai/miniforge/reliability/degradation.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.reliability.degradation
   "Degradation mode FSM per N1 §5.5.5 and N8 §3.4.
 
@@ -37,19 +36,13 @@
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Config
 
-(def ^:private defaults
+;; Config
+(def ^{:stratum 0} ^:private defaults
   (-> (io/resource "config/reliability/defaults.edn") slurp edn/read-string))
 
-(def default-config
-  "Default degradation policy config."
-  (:degradation-policy defaults))
-
-;------------------------------------------------------------------------------ Layer 0
 ;; FSM definition
-
-(def degradation-machine
+(def ^{:stratum 0} degradation-machine
   "Degradation mode state machine.
 
    Transitions:
@@ -83,110 +76,73 @@
                       :budget-recovered :nominal}}
      :safe-mode {:on {:operator-exit :nominal}}}}))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; DegradationManager
-
-(defrecord DegradationManager
+(defrecord ^{:stratum 0} DegradationManager
   [fsm-state      ; atom wrapping FSM state
    event-stream   ; event stream atom for emitting events
-   config])       ; data-driven degradation policy
+   config])
 
-(def ^:private mode-rank
+; data-driven degradation policy
+(def ^{:stratum 0} ^:private mode-rank
   {:nominal 0
    :degraded 1
    :safe-mode 2})
 
-(defn- merge-manager-config
-  [config]
-  (merge default-config config))
-
-(defn create-manager
-  [event-stream & [config]]
-  (->DegradationManager
-   (atom (fsm/initialize degradation-machine))
-   event-stream
-   (merge-manager-config config)))
-
-(defn current-mode
+(defn ^{:stratum 0} current-mode
   [manager]
   (fsm/current-state @(:fsm-state manager)))
 
-(defn- transition-signal
+(defn- ^{:stratum 0} transition-signal
   [mode event message & [opts]]
   (cond-> {:mode mode
            :event event
            :message message}
     opts (merge opts)))
 
-(defn- dependency-id-label
+(defn- ^{:stratum 0} dependency-id-label
   [dependency]
   (some-> dependency :dependency/id name))
 
-(defn- dependency-labels
-  [dependencies]
-  (->> dependencies
-       (keep dependency-id-label)
-       sort
-       vec))
-
-(defn- dependency-list
-  [dependencies]
-  (str/join ", " (dependency-labels dependencies)))
-
-(defn- active-dependencies
+(defn- ^{:stratum 0} active-dependencies
   [dependency-health]
   (->> dependency-health
        vals
        (remove #(= :healthy (:dependency/status %)))
        vec))
 
-(defn- dependencies-with-status
+(defn- ^{:stratum 0} dependencies-with-status
   [dependencies status]
   (filterv #(= status (:dependency/status %)) dependencies))
 
-(defn- prioritized-status
+(defn- ^{:stratum 0} dependency-mode
+  [status {:keys [dependency-status->mode]}]
+  (get dependency-status->mode status))
+
+(defn- ^{:stratum 0} dependency-event
+  [status {:keys [dependency-status->event]}]
+  (get dependency-status->event status))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} default-config
+  "Default degradation policy config."
+  (:degradation-policy defaults))
+
+(defn- ^{:stratum 1} dependency-labels
+  [dependencies]
+  (->> dependencies
+       (keep dependency-id-label)
+       sort
+       vec))
+
+(defn- ^{:stratum 1} prioritized-status
   [dependencies {:keys [dependency-status-precedence]}]
   (some (fn [status]
           (when (seq (dependencies-with-status dependencies status))
             status))
         dependency-status-precedence))
 
-(defn- dependency-mode
-  [status {:keys [dependency-status->mode]}]
-  (get dependency-status->mode status))
-
-(defn- dependency-event
-  [status {:keys [dependency-status->event]}]
-  (get dependency-status->event status))
-
-(defn- dependency-message
-  [status dependencies]
-  (let [dependency-listing (dependency-list dependencies)
-        params {:dependencies dependency-listing}]
-    (case status
-      :operator-action-required (messages/t :degradation/dependency-operator-action params)
-      :misconfigured (messages/t :degradation/dependency-operator-action params)
-      :unavailable (messages/t :degradation/dependency-unavailable params)
-      :degraded (messages/t :degradation/dependency-degraded params)
-      (messages/t :degradation/dependency-degraded params))))
-
-(defn- dependency-signal
-  [dependency-health config]
-  (let [dependencies (active-dependencies dependency-health)
-        status (prioritized-status dependencies config)
-        mode (dependency-mode status config)
-        event (dependency-event status config)]
-    (when (and status mode event)
-      (transition-signal mode
-                         event
-                         (dependency-message status dependencies)
-                         {:dependency/status status
-                          :dependency/ids (dependency-labels dependencies)
-                          :safe-mode-trigger (when (= mode :safe-mode) event)
-                          :safe-mode-details (when (= mode :safe-mode)
-                                               (dependency-message status dependencies))}))))
-
-(defn- budget-signal
+(defn- ^{:stratum 1} budget-signal
   [budget-state]
   (let [any-critical-exhausted? (budget/critical-budget-exhausted? budget-state)
         any-critical-low? (budget/critical-budget-low? budget-state)]
@@ -203,7 +159,7 @@
                          :budget-critical
                          (messages/t :degradation/critical-budget-low)))))
 
-(defn- stronger-signal
+(defn- ^{:stratum 1} stronger-signal
   [left right]
   (cond
     (nil? left) right
@@ -214,24 +170,7 @@
        (mode-rank (:mode left))) right
     :else left))
 
-(defn recommendation
-  "Pure degradation recommendation from budgets and dependency health.
-
-   Returns a signal map with:
-   - :mode    target mode
-   - :event   FSM transition event
-   - :message localized degradation trigger description"
-  ([budget-state]
-   (recommendation budget-state {} default-config))
-  ([budget-state dependency-health]
-   (recommendation budget-state dependency-health default-config))
-  ([budget-state dependency-health config]
-   (let [budget-derived-signal (budget-signal budget-state)
-         dependency-derived-signal (dependency-signal dependency-health config)]
-     (or (stronger-signal budget-derived-signal dependency-derived-signal)
-         (transition-signal :nominal nil (messages/t :degradation/dependency-recovered))))))
-
-(defn- transition!
+(defn- ^{:stratum 1} transition!
   "Attempt a state transition, emit events if it succeeds.
    Returns the new mode, or the unchanged mode if transition was invalid."
   [manager {:keys [event message safe-mode-trigger safe-mode-details]}]
@@ -252,7 +191,117 @@
                                                      safe-mode-details)))))
     new-mode))
 
-(defn evaluate-and-transition!
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- ^{:stratum 2} merge-manager-config
+  [config]
+  (merge default-config config))
+
+(defn- ^{:stratum 2} dependency-list
+  [dependencies]
+  (str/join ", " (dependency-labels dependencies)))
+
+(defn ^{:stratum 2} enter-safe-mode!
+  [manager trigger details]
+  (let [current (current-mode manager)]
+    (when (not= current :safe-mode)
+      (let [event-kw (case trigger
+                       :emergency-stop :emergency-stop
+                       :unknown-failures :unknown-failures
+                       :dependency-unavailable :dependency-unavailable
+                       :dependency-operator-action :dependency-operator-action
+                       :manual :manual
+                       :emergency-stop)]
+        (transition! manager
+                     (transition-signal :safe-mode
+                                        event-kw
+                                        (or details (name trigger))
+                                        {:safe-mode-trigger trigger
+                                         :safe-mode-details details})))))
+  (current-mode manager))
+
+(defn ^{:stratum 2} exit-safe-mode!
+  "Exit safe-mode. Requires explicit justification per N8 §3.4.3.
+
+   Arguments:
+     manager       - DegradationManager
+     justification - string explaining why safe-mode is being exited
+     principal     - string identifying who is exiting safe-mode
+
+   Returns: new mode (should be :nominal) or :safe-mode if not in safe-mode."
+  [manager justification principal]
+  (let [current (current-mode manager)]
+    (when (= current :safe-mode)
+      (let [new-mode (transition! manager
+                                  (transition-signal :nominal
+                                                     :operator-exit
+                                                     (messages/t :degradation/operator-exit-reason
+                                                                 {:principal principal :justification justification})))]
+        (when-let [stream (:event-stream manager)]
+          (stream/publish! stream
+                           (events/safe-mode-exited stream principal justification 0 0)))
+        new-mode))))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} create-manager
+  [event-stream & [config]]
+  (->DegradationManager
+   (atom (fsm/initialize degradation-machine))
+   event-stream
+   (merge-manager-config config)))
+
+(defn- ^{:stratum 3} dependency-message
+  [status dependencies]
+  (let [dependency-listing (dependency-list dependencies)
+        params {:dependencies dependency-listing}]
+    (case status
+      :operator-action-required (messages/t :degradation/dependency-operator-action params)
+      :misconfigured (messages/t :degradation/dependency-operator-action params)
+      :unavailable (messages/t :degradation/dependency-unavailable params)
+      :degraded (messages/t :degradation/dependency-degraded params)
+      (messages/t :degradation/dependency-degraded params))))
+
+;------------------------------------------------------------------------------ Layer 4
+
+(defn- ^{:stratum 4} dependency-signal
+  [dependency-health config]
+  (let [dependencies (active-dependencies dependency-health)
+        status (prioritized-status dependencies config)
+        mode (dependency-mode status config)
+        event (dependency-event status config)]
+    (when (and status mode event)
+      (transition-signal mode
+                         event
+                         (dependency-message status dependencies)
+                         {:dependency/status status
+                          :dependency/ids (dependency-labels dependencies)
+                          :safe-mode-trigger (when (= mode :safe-mode) event)
+                          :safe-mode-details (when (= mode :safe-mode)
+                                               (dependency-message status dependencies))}))))
+
+;------------------------------------------------------------------------------ Layer 5
+
+(defn ^{:stratum 5} recommendation
+  "Pure degradation recommendation from budgets and dependency health.
+
+   Returns a signal map with:
+   - :mode    target mode
+   - :event   FSM transition event
+   - :message localized degradation trigger description"
+  ([budget-state]
+   (recommendation budget-state {} default-config))
+  ([budget-state dependency-health]
+   (recommendation budget-state dependency-health default-config))
+  ([budget-state dependency-health config]
+   (let [budget-derived-signal (budget-signal budget-state)
+         dependency-derived-signal (dependency-signal dependency-health config)]
+     (or (stronger-signal budget-derived-signal dependency-derived-signal)
+         (transition-signal :nominal nil (messages/t :degradation/dependency-recovered))))))
+
+;------------------------------------------------------------------------------ Layer 6
+
+(defn ^{:stratum 6} evaluate-and-transition!
   "Evaluate budget state and trigger mode transition if warranted.
 
    Arguments:
@@ -312,47 +361,6 @@
 
       :safe-mode
       current))))
-
-(defn enter-safe-mode!
-  [manager trigger details]
-  (let [current (current-mode manager)]
-    (when (not= current :safe-mode)
-      (let [event-kw (case trigger
-                       :emergency-stop :emergency-stop
-                       :unknown-failures :unknown-failures
-                       :dependency-unavailable :dependency-unavailable
-                       :dependency-operator-action :dependency-operator-action
-                       :manual :manual
-                       :emergency-stop)]
-        (transition! manager
-                     (transition-signal :safe-mode
-                                        event-kw
-                                        (or details (name trigger))
-                                        {:safe-mode-trigger trigger
-                                         :safe-mode-details details})))))
-  (current-mode manager))
-
-(defn exit-safe-mode!
-  "Exit safe-mode. Requires explicit justification per N8 §3.4.3.
-
-   Arguments:
-     manager       - DegradationManager
-     justification - string explaining why safe-mode is being exited
-     principal     - string identifying who is exiting safe-mode
-
-   Returns: new mode (should be :nominal) or :safe-mode if not in safe-mode."
-  [manager justification principal]
-  (let [current (current-mode manager)]
-    (when (= current :safe-mode)
-      (let [new-mode (transition! manager
-                                  (transition-signal :nominal
-                                                     :operator-exit
-                                                     (messages/t :degradation/operator-exit-reason
-                                                                 {:principal principal :justification justification})))]
-        (when-let [stream (:event-stream manager)]
-          (stream/publish! stream
-                           (events/safe-mode-exited stream principal justification 0 0)))
-        new-mode))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/reliability/src/ai/miniforge/reliability/dependency_health.clj
+++ b/components/reliability/src/ai/miniforge/reliability/dependency_health.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.reliability.dependency-health
   "Pure dependency-health projection from classified dependency incidents.
 
@@ -28,32 +27,22 @@
    [clojure.java.io :as io]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Config and constants
 
-(def ^:private defaults
+;; Config and constants
+(def ^{:stratum 0} ^:private defaults
   (-> (io/resource "config/reliability/defaults.edn") slurp edn/read-string))
 
-(def default-config
-  "Default dependency-health projection config."
-  (:dependency-health defaults))
-
-(def ^:private dependency-kind-by-source
+(def ^{:stratum 0} ^:private dependency-kind-by-source
   {:external-provider :provider
    :external-platform :platform
    :user-env :environment})
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Helpers
-
-(defn- dependency-id
+(defn- ^{:stratum 0} dependency-id
   [{vendor :failure/vendor source :failure/source}]
   (or vendor source))
 
-(defn- dependency-kind
-  [source]
-  (get dependency-kind-by-source source :environment))
-
-(defn- incident-status
+(defn- ^{:stratum 0} incident-status
   [incident config]
   (let [retryability (:dependency/retryability incident)
         dependency-class (:dependency/class incident)
@@ -62,23 +51,23 @@
       :operator-action-required
       class-status)))
 
-(defn- incident-observed-at
+(defn- ^{:stratum 0} incident-observed-at
   [incident default-instant]
   (or (:dependency/observed-at incident)
       (:event/timestamp incident)
       default-instant))
 
-(defn- recovery-observed-at
+(defn- ^{:stratum 0} recovery-observed-at
   [recovery default-instant]
   (or (:dependency/recovered-at recovery)
       (:event/timestamp recovery)
       default-instant))
 
-(defn- status-counts
+(defn- ^{:stratum 0} status-counts
   [observations]
   (frequencies (map :dependency/status observations)))
 
-(defn- satisfied-threshold-status
+(defn- ^{:stratum 0} satisfied-threshold-status
   [counts {:keys [status-precedence status-thresholds]}]
   (some (fn [status]
           (let [threshold (get status-thresholds status Long/MAX_VALUE)
@@ -87,27 +76,38 @@
               status)))
         status-precedence))
 
-(defn- projected-status
-  [observations config]
-  (or (some-> observations status-counts (satisfied-threshold-status config))
-      :healthy))
-
-(defn- trim-observations
+(defn- ^{:stratum 0} trim-observations
   [observations window-size]
   (->> observations
        (take-last window-size)
        vec))
 
-(defn- base-entry
+(defn ^{:stratum 0} dependency-incident?
   [incident]
-  (let [source (:failure/source incident)
-        vendor (:failure/vendor incident)]
-    (cond-> {:dependency/id (dependency-id incident)
-             :dependency/source source
-             :dependency/kind (dependency-kind source)}
-      vendor (assoc :dependency/vendor vendor))))
+  (failure-classifier/dependency-failure? incident))
 
-(defn- observation
+(defn- ^{:stratum 0} recovery-id
+  [recovery]
+  (or (:dependency/id recovery)
+      (:failure/vendor recovery)
+      (:failure/source recovery)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} default-config
+  "Default dependency-health projection config."
+  (:dependency-health defaults))
+
+(defn- ^{:stratum 1} dependency-kind
+  [source]
+  (get dependency-kind-by-source source :environment))
+
+(defn- ^{:stratum 1} projected-status
+  [observations config]
+  (or (some-> observations status-counts (satisfied-threshold-status config))
+      :healthy))
+
+(defn- ^{:stratum 1} observation
   [incident observed-at config]
   (let [status (incident-status incident config)]
     {:dependency/status status
@@ -116,38 +116,18 @@
      :failure/class (:failure/class incident)
      :dependency/observed-at observed-at}))
 
-(defn- normalize-entry
-  [entry incident]
-  (merge (base-entry incident) entry))
+;------------------------------------------------------------------------------ Layer 2
 
-(defn dependency-incident?
+(defn- ^{:stratum 2} base-entry
   [incident]
-  (failure-classifier/dependency-failure? incident))
+  (let [source (:failure/source incident)
+        vendor (:failure/vendor incident)]
+    (cond-> {:dependency/id (dependency-id incident)
+             :dependency/source source
+             :dependency/kind (dependency-kind source)}
+      vendor (assoc :dependency/vendor vendor))))
 
-(defn- register-incident
-  [state incident config default-instant]
-  (let [entry-id (dependency-id incident)
-        observed-at (incident-observed-at incident default-instant)
-        new-observation (observation incident observed-at config)
-        window-size (:window-size config)]
-    (update state entry-id
-            (fn [entry]
-              (let [existing-observations (:dependency/observations entry)
-                    observations (-> existing-observations
-                                     (conj new-observation)
-                                     (trim-observations window-size))]
-                (-> entry
-                    (normalize-entry incident)
-                    (assoc :dependency/observations observations
-                           :dependency/last-observed-at observed-at)))))))
-
-(defn- recovery-id
-  [recovery]
-  (or (:dependency/id recovery)
-      (:failure/vendor recovery)
-      (:failure/source recovery)))
-
-(defn- recovery-entry
+(defn- ^{:stratum 2} recovery-entry
   [entry recovery recovered-at]
   (let [source (or (:dependency/source entry) (:failure/source recovery))
         vendor (or (:dependency/vendor entry) (:failure/vendor recovery))
@@ -162,19 +142,7 @@
         (:dependency/last-observed-at entry)
         (assoc :dependency/last-observed-at (:dependency/last-observed-at entry))))))
 
-(defn- register-recovery
-  [state recovery default-instant]
-  (let [entry-id (recovery-id recovery)
-        recovered-at (recovery-observed-at recovery default-instant)]
-    (if entry-id
-      (let [entry (get state entry-id)
-            updated-entry (recovery-entry entry recovery recovered-at)]
-        (if updated-entry
-          (assoc state entry-id updated-entry)
-          state))
-      state)))
-
-(defn- project-entry
+(defn- ^{:stratum 2} project-entry
   [entry config]
   (let [observations (:dependency/observations entry)
         counts (status-counts observations)
@@ -201,10 +169,57 @@
       last-observed-at (assoc :dependency/last-observed-at last-observed-at)
       last-recovered-at (assoc :dependency/last-recovered-at last-recovered-at))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Public pipeline
+;------------------------------------------------------------------------------ Layer 3
 
-(defn apply-signals
+(defn- ^{:stratum 3} normalize-entry
+  [entry incident]
+  (merge (base-entry incident) entry))
+
+(defn- ^{:stratum 3} register-recovery
+  [state recovery default-instant]
+  (let [entry-id (recovery-id recovery)
+        recovered-at (recovery-observed-at recovery default-instant)]
+    (if entry-id
+      (let [entry (get state entry-id)
+            updated-entry (recovery-entry entry recovery recovered-at)]
+        (if updated-entry
+          (assoc state entry-id updated-entry)
+          state))
+      state)))
+
+(defn ^{:stratum 3} project-health
+  ([dependency-state]
+   (project-health dependency-state default-config))
+  ([dependency-state config]
+   (let [effective-config (merge default-config config)]
+     (into {}
+           (map (fn [[entry-id entry]]
+                  [entry-id (project-entry entry effective-config)]))
+           dependency-state))))
+
+;------------------------------------------------------------------------------ Layer 4
+
+(defn- ^{:stratum 4} register-incident
+  [state incident config default-instant]
+  (let [entry-id (dependency-id incident)
+        observed-at (incident-observed-at incident default-instant)
+        new-observation (observation incident observed-at config)
+        window-size (:window-size config)]
+    (update state entry-id
+            (fn [entry]
+              (let [existing-observations (:dependency/observations entry)
+                    observations (-> existing-observations
+                                     (conj new-observation)
+                                     (trim-observations window-size))]
+                (-> entry
+                    (normalize-entry incident)
+                    (assoc :dependency/observations observations
+                           :dependency/last-observed-at observed-at)))))))
+
+;------------------------------------------------------------------------------ Layer 5
+
+;; Public pipeline
+(defn ^{:stratum 5} apply-signals
   "Apply dependency incidents and recovery signals to rolling state.
 
    Arguments:
@@ -224,13 +239,3 @@
      (reduce #(register-recovery %1 %2 observed-at)
              state-with-incidents
              recoveries))))
-
-(defn project-health
-  ([dependency-state]
-   (project-health dependency-state default-config))
-  ([dependency-state config]
-   (let [effective-config (merge default-config config)]
-     (into {}
-           (map (fn [[entry-id entry]]
-                  [entry-id (project-entry entry effective-config)]))
-           dependency-state))))

--- a/components/reliability/src/ai/miniforge/reliability/engine.clj
+++ b/components/reliability/src/ai/miniforge/reliability/engine.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.reliability.engine
   "ReliabilityEngine — periodic SLI computation, SLO checking, and budget tracking.
 
@@ -33,12 +32,71 @@
    [clojure.java.io :as io]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Config loading
 
-(def ^:private defaults
+;; Config loading
+(def ^{:stratum 0} ^:private defaults
   (-> (io/resource "config/reliability/defaults.edn") slurp edn/read-string))
 
-(defn- merge-engine-config
+;; Engine record
+(defrecord ^{:stratum 0} ReliabilityEngine
+  [event-stream   ; event stream atom for emitting events
+   state          ; atom: {:slis [...] :slo-checks [...] :budgets {...} :mode :nominal}
+   config])
+
+;; Pipeline stages
+(defn- ^{:stratum 0} check-all-slos-across-tiers
+  "Check SLOs for all SLI results across all tier/window combinations."
+  [all-slis tiers windows slo-targets]
+  (vec
+   (for [tier tiers
+         window windows
+         :let [window-slis (filter #(= window (:sli/window %)) all-slis)
+               checks (slo/check-all-slos window-slis tier slo-targets)]
+         check checks]
+     (assoc check :slo/tier tier))))
+
+(defn- ^{:stratum 0} compute-budgets
+  "Compute error budgets for all enforced SLO checks."
+  [all-slo-checks]
+  (into {}
+        (for [{:keys [sli/name slo/actual slo/target slo/tier slo/window]}
+              all-slo-checks
+              :let [{:keys [error-budget/remaining error-budget/burn-rate]}
+                    (budget/compute-error-budget actual target
+                                                (contains? slo/inverted-slis name))]]
+          [[name tier window]
+           (budget/error-budget remaining burn-rate tier name window)])))
+
+(defn- ^{:stratum 0} dependency-health-delta
+  [prior-projection current-projection]
+  (keep (fn [[dependency-id projection]]
+          (let [prior (get prior-projection dependency-id)]
+            (when (not= prior projection)
+              {:dependency/id dependency-id
+               :previous prior
+               :current projection})))
+        current-projection))
+
+(defn- ^{:stratum 0} recovered-from-unhealthy?
+  "True when `previous-status` was a non-nil non-healthy state and
+   `current-status` is `:healthy`. The first observation of a
+   dependency (no prior status) is not a recovery."
+  [previous-status current-status]
+  (and previous-status
+       (not= :healthy previous-status)
+       (= :healthy current-status)))
+
+(defn ^{:stratum 0} current-state
+  [engine]
+  @(:state engine))
+
+(defn ^{:stratum 0} current-mode
+  [engine]
+  (:mode @(:state engine)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} merge-engine-config
   [config]
   (let [base-config {:windows (:default-windows defaults)
                      :tiers (:default-tiers defaults)
@@ -54,15 +112,17 @@
            (merge (:dependency-health base-config)
                   (:dependency-health config)))))
 
-;------------------------------------------------------------------------------ Layer 0
-;; Engine record
+(defn- ^{:stratum 1} dependency-health-event
+  "Pick the right event constructor for a transition."
+  [event-stream current previous-status]
+  (if (recovered-from-unhealthy? previous-status (:dependency/status current))
+    (events/dependency-recovered event-stream current previous-status)
+    (events/dependency-health-updated event-stream current previous-status)))
 
-(defrecord ReliabilityEngine
-  [event-stream   ; event stream atom for emitting events
-   state          ; atom: {:slis [...] :slo-checks [...] :budgets {...} :mode :nominal}
-   config])       ; {:windows [:7d] :tiers [:standard :critical] :dependency-health {...}}
+;------------------------------------------------------------------------------ Layer 2
 
-(defn create-engine
+; {:windows [:7d] :tiers [:standard :critical] :dependency-health {...}}
+(defn ^{:stratum 2} create-engine
   "Create a ReliabilityEngine.
 
    Arguments:
@@ -83,69 +143,17 @@
           :last-computed-at nil})
    (merge-engine-config config)))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Pipeline stages
-
-(defn- check-all-slos-across-tiers
-  "Check SLOs for all SLI results across all tier/window combinations."
-  [all-slis tiers windows slo-targets]
-  (vec
-   (for [tier tiers
-         window windows
-         :let [window-slis (filter #(= window (:sli/window %)) all-slis)
-               checks (slo/check-all-slos window-slis tier slo-targets)]
-         check checks]
-     (assoc check :slo/tier tier))))
-
-(defn- compute-budgets
-  "Compute error budgets for all enforced SLO checks."
-  [all-slo-checks]
-  (into {}
-        (for [{:keys [sli/name slo/actual slo/target slo/tier slo/window]}
-              all-slo-checks
-              :let [{:keys [error-budget/remaining error-budget/burn-rate]}
-                    (budget/compute-error-budget actual target
-                                                (contains? slo/inverted-slis name))]]
-          [[name tier window]
-           (budget/error-budget remaining burn-rate tier name window)])))
-
-(defn- dependency-health-delta
-  [prior-projection current-projection]
-  (keep (fn [[dependency-id projection]]
-          (let [prior (get prior-projection dependency-id)]
-            (when (not= prior projection)
-              {:dependency/id dependency-id
-               :previous prior
-               :current projection})))
-        current-projection))
-
-(defn- recovered-from-unhealthy?
-  "True when `previous-status` was a non-nil non-healthy state and
-   `current-status` is `:healthy`. The first observation of a
-   dependency (no prior status) is not a recovery."
-  [previous-status current-status]
-  (and previous-status
-       (not= :healthy previous-status)
-       (= :healthy current-status)))
-
-(defn- dependency-health-event
-  "Pick the right event constructor for a transition."
-  [event-stream current previous-status]
-  (if (recovered-from-unhealthy? previous-status (:dependency/status current))
-    (events/dependency-recovered event-stream current previous-status)
-    (events/dependency-health-updated event-stream current previous-status)))
-
-(defn- emit-dependency-health-events!
+(defn- ^{:stratum 2} emit-dependency-health-events!
   [event-stream prior-projection current-projection]
   (doseq [{:keys [previous current]} (dependency-health-delta prior-projection current-projection)]
     (let [previous-status (:dependency/status previous)]
       (stream/publish! event-stream
                        (dependency-health-event event-stream current previous-status)))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Compute cycle
+;------------------------------------------------------------------------------ Layer 3
 
-(defn compute-cycle!
+;; Compute cycle
+(defn ^{:stratum 3} compute-cycle!
   "Execute one reliability computation cycle.
 
    1. Compute all SLIs for each configured window
@@ -224,14 +232,6 @@
      :dependency-health dependency-health-projection
      :breaches breaches
      :recommendation recommendation}))
-
-(defn current-state
-  [engine]
-  @(:state engine))
-
-(defn current-mode
-  [engine]
-  (:mode @(:state engine)))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/reliability/src/ai/miniforge/reliability/interface.clj
+++ b/components/reliability/src/ai/miniforge/reliability/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.reliability.interface
   "Public API for the reliability component per N1 §5.5.
 
@@ -37,57 +36,57 @@
    [ai.miniforge.reliability.degradation :as degradation]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Schemas
 
-(def WorkflowTier
+;; Schemas
+(def ^{:stratum 0} WorkflowTier
   "Malli `[:enum ...]` schema of workflow tiers (:best-effort :standard
    :critical). Tier determines SLO targets and degradation behavior."
   schema/WorkflowTier)
 
-(def SliName
+(def ^{:stratum 0} SliName
   "Malli `[:enum ...]` schema of the seven SLI identifiers (:SLI-1 through
    :SLI-7)."
   schema/SliName)
 
-(def Window
+(def ^{:stratum 0} Window
   "Malli `[:enum ...]` schema of rolling measurement windows (:1h :7d :30d)."
   schema/Window)
 
-(def DegradationMode
+(def ^{:stratum 0} DegradationMode
   "Malli `[:enum ...]` schema of degradation modes (:nominal :degraded
    :safe-mode)."
   schema/DegradationMode)
 
-(def SliResult
+(def ^{:stratum 0} SliResult
   "Malli `[:map ...]` schema for a single computed SLI result. Required keys:
    :sli/name (SliName), :sli/value (double), :sli/window (Window). Optional:
    :sli/tier (WorkflowTier), :sli/dimensions (map)."
   schema/SliResult)
 
-(def SloCheck
+(def ^{:stratum 0} SloCheck
   "Malli `[:map ...]` schema for an SLO check outcome. Keys: :breached?
    (boolean), :sli/name (SliName), :slo/target (double), :slo/actual (double),
    :slo/tier (WorkflowTier), :slo/window (Window)."
   schema/SloCheck)
 
-(def ErrorBudget
+(def ^{:stratum 0} ErrorBudget
   "Malli `[:map ...]` schema for a computed error budget. Keys:
    :error-budget/tier (WorkflowTier), :error-budget/sli (SliName),
    :error-budget/window (Window), :error-budget/remaining (double),
    :error-budget/burn-rate (double), :error-budget/computed-at (inst)."
   schema/ErrorBudget)
 
-(def DependencyKind
+(def ^{:stratum 0} DependencyKind
   "Malli `[:enum ...]` schema of dependency kinds (:provider :platform
    :environment)."
   schema/DependencyKind)
 
-(def DependencyHealthStatus
+(def ^{:stratum 0} DependencyHealthStatus
   "Malli `[:enum ...]` schema of dependency health statuses (:healthy
    :degraded :unavailable :misconfigured :operator-action-required)."
   schema/DependencyHealthStatus)
 
-(def DependencyHealth
+(def ^{:stratum 0} DependencyHealth
   "Malli `[:map ...]` schema for a projected dependency-health entity.
    Required keys include :dependency/id, :dependency/source, :dependency/kind
    (DependencyKind), :dependency/status (DependencyHealthStatus),
@@ -96,40 +95,38 @@
    optional keys carry vendor/class/retryability and observation timestamps."
   schema/DependencyHealth)
 
-;------------------------------------------------------------------------------ Layer 1
 ;; SLI computation (pure)
-
-(def compute-workflow-success-rate
+(def ^{:stratum 0} compute-workflow-success-rate
   "SLI-1. (workflow-metrics window) -> double in [0.0, 1.0]: fraction of
    terminal workflows that completed or escalated. Returns 0.0 when no
    terminal workflows fall in the window. Pure."
   sli/compute-workflow-success-rate)
 
-(def compute-phase-latency
+(def ^{:stratum 0} compute-phase-latency
   "SLI-2. (phase-metrics window) -> map {:p50 :p95 :p99} of phase duration-ms
    percentiles (doubles). Percentiles are 0.0 when no durations fall in the
    window. Pure."
   sli/compute-phase-latency)
 
-(def compute-inner-loop-convergence
+(def ^{:stratum 0} compute-inner-loop-convergence
   "SLI-3. (phase-metrics window) -> double in [0.0, 1.0]: fraction of inner
    loops (entries carrying :iterations) that converged (:success?). Returns
    0.0 when no loops fall in the window. Pure."
   sli/compute-inner-loop-convergence)
 
-(def compute-gate-pass-rate
+(def ^{:stratum 0} compute-gate-pass-rate
   "SLI-4. (gate-metrics window) -> double in [0.0, 1.0]: fraction of gate
    evaluations that :passed?. Returns 0.0 when no gate events fall in the
    window. Pure."
   sli/compute-gate-pass-rate)
 
-(def compute-tool-success-rate
+(def ^{:stratum 0} compute-tool-success-rate
   "SLI-5. (tool-metrics window) -> double in [0.0, 1.0]: fraction of tool
    invocations that report :success?. Returns 0.0 when no invocations fall in
    the window. Pure."
   sli/compute-tool-success-rate)
 
-(def compute-failure-distribution
+(def ^{:stratum 0} compute-failure-distribution
   "SLI-6 (full). (failure-events window) -> map keyed by each distinct
    :failure/class VALUE found in the windowed events (e.g.
    :failure.class/unknown), with that class's fraction (double) of all
@@ -138,61 +135,57 @@
    Pure."
   sli/compute-failure-distribution)
 
-(def compute-unknown-failure-rate
+(def ^{:stratum 0} compute-unknown-failure-rate
   "SLI-6 (scalar). (failure-events window) -> double in [0.0, 1.0]: the
    :failure.class/unknown fraction from the distribution, or 0.0 if absent. A
    high rate signals insufficient failure instrumentation. Pure."
   sli/compute-unknown-failure-rate)
 
-(def compute-context-staleness-rate
+(def ^{:stratum 0} compute-context-staleness-rate
   "SLI-7. (context-metrics window) -> double in [0.0, 1.0]: fraction of
    context packs flagged :stale?. Returns 0.0 when no records fall in the
    window. Pure."
   sli/compute-context-staleness-rate)
 
-(def compute-all-slis
+(def ^{:stratum 0} compute-all-slis
   "(metrics window) -> vector of seven SliResult maps (one per SLI), each
    {:sli/name :sli/value :sli/window}. metrics is a map of per-source metric
    vectors (:workflow-metrics :phase-metrics :gate-metrics :tool-metrics
    :failure-events :context-metrics); missing sources default to empty. Pure."
   sli/compute-all-slis)
 
-;------------------------------------------------------------------------------ Layer 2
 ;; SLO checking (pure)
-
-(def default-slo-targets
+(def ^{:stratum 0} default-slo-targets
   "Nested map of SLO targets {SliName -> {WorkflowTier -> target-double}},
    loaded from config/reliability/slo-targets.edn. A nil entry means
    advisory-only (no enforcement for that SLI/tier)."
   slo/default-targets)
 
-(def check-slo
+(def ^{:stratum 0} check-slo
   "(sli-result tier [targets]) -> SloCheck map, or nil if the SLI is
    advisory-only for the tier. :breached? is true when the actual value
    crosses the target (below a floor, or above the ceiling for inverted SLIs
    such as SLI-6). Pure."
   slo/check-slo)
 
-(def check-all-slos
+(def ^{:stratum 0} check-all-slos
   "(sli-results tier [targets]) -> vector of SloCheck maps. Excludes
    advisory-only SLIs (those with no target for the tier). Pure."
   slo/check-all-slos)
 
-(def breached-slos
+(def ^{:stratum 0} breached-slos
   "(slo-checks) -> lazy seq of the SloCheck maps whose :breached? is true.
    Pure."
   slo/breached-slos)
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Error budgets (pure)
-
-(def error-budget
+(def ^{:stratum 0} error-budget
   "Factory: create an error budget map.
    (error-budget remaining burn-rate) or
    (error-budget remaining burn-rate tier sli window)"
   budget/error-budget)
 
-(def compute-error-budget
+(def ^{:stratum 0} compute-error-budget
   "(sli-value slo-target inverted?) -> ErrorBudget map with
    :error-budget/remaining (double 0.0-1.0 fraction left) and
    :error-budget/burn-rate (double; 1.0 = nominal, >1.0 = over-consuming).
@@ -200,36 +193,33 @@
    Pure."
   budget/compute-error-budget)
 
-(def budget-exhausted?
+(def ^{:stratum 0} budget-exhausted?
   "(budget) -> boolean: true when :error-budget/remaining is at or below 0.0."
   budget/budget-exhausted?)
 
-(def budget-critical?
+(def ^{:stratum 0} budget-critical?
   "(budget [threshold]) -> boolean: true when :error-budget/remaining is below
    threshold (default 0.25, i.e. under 25% remaining)."
   budget/budget-critical?)
 
 ;------------------------------------------------------------------------------ Layer 3b
 ;; Dependency health projection (pure)
-
-(def dependency-incident?
+(def ^{:stratum 0} dependency-incident?
   "Returns true when the classified failure contributes to dependency-health
    projection."
   dependency-health/dependency-incident?)
 
-(def apply-dependency-signals
+(def ^{:stratum 0} apply-dependency-signals
   "Apply classified dependency incidents and recovery signals to rolling
    dependency-health state."
   dependency-health/apply-signals)
 
-(def project-dependency-health
+(def ^{:stratum 0} project-dependency-health
   "Project rolling dependency-health state into canonical dependency entities."
   dependency-health/project-health)
 
-;------------------------------------------------------------------------------ Layer 4
 ;; Engine (stateful)
-
-(def create-engine
+(def ^{:stratum 0} create-engine
   "Create a ReliabilityEngine.
 
    Arguments:
@@ -240,7 +230,7 @@
                               :degradation-policy {...}}"
   engine/create-engine)
 
-(def compute-cycle!
+(def ^{:stratum 0} compute-cycle!
   "Execute one reliability computation cycle.
    Computes SLIs, checks SLOs, updates budgets, emits events.
 
@@ -253,18 +243,16 @@
     :recommendation}"
   engine/compute-cycle!)
 
-(def current-state
+(def ^{:stratum 0} current-state
   "Get the current reliability state."
   engine/current-state)
 
-(def current-mode
+(def ^{:stratum 0} current-mode
   "Get the current degradation mode recommendation."
   engine/current-mode)
 
-;------------------------------------------------------------------------------ Layer 5
 ;; Degradation mode manager (stateful, N1 §5.5.5, N8 §3.4)
-
-(def create-degradation-manager
+(def ^{:stratum 0} create-degradation-manager
   "Create a DegradationManager with FSM for :nominal → :degraded → :safe-mode.
 
    Arguments:
@@ -272,11 +260,11 @@
      config       - optional {:unknown-failure-threshold 3}"
   degradation/create-manager)
 
-(def degradation-mode
+(def ^{:stratum 0} degradation-mode
   "Get the current degradation mode (:nominal, :degraded, or :safe-mode)."
   degradation/current-mode)
 
-(def evaluate-degradation!
+(def ^{:stratum 0} evaluate-degradation!
   "Evaluate budget state and trigger mode transition if warranted.
 
    Arguments:
@@ -287,7 +275,7 @@
    Returns: current degradation mode."
   degradation/evaluate-and-transition!)
 
-(def enter-safe-mode!
+(def ^{:stratum 0} enter-safe-mode!
   "Force entry to safe-mode from any state.
 
    Arguments:
@@ -296,7 +284,7 @@
      details - string"
   degradation/enter-safe-mode!)
 
-(def exit-safe-mode!
+(def ^{:stratum 0} exit-safe-mode!
   "Exit safe-mode (requires justification per N8 §3.4.3).
 
    Arguments:

--- a/components/reliability/src/ai/miniforge/reliability/messages.clj
+++ b/components/reliability/src/ai/miniforge/reliability/messages.clj
@@ -15,13 +15,14 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.reliability.messages
   "Component-level message catalog for reliability.
    Delegates to the shared messages component."
   (:require [ai.miniforge.messages.interface :as messages]))
 
-(def t
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} t
   "Look up a reliability message by key, with optional param substitution."
   (messages/create-translator "config/reliability/messages/en-US.edn"
                               :reliability/messages))

--- a/components/reliability/src/ai/miniforge/reliability/schema.clj
+++ b/components/reliability/src/ai/miniforge/reliability/schema.clj
@@ -15,35 +15,34 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.reliability.schema
   "Malli schemas for reliability data structures per N1 §5.5.")
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Enums
 
-(def WorkflowTier
+;; Enums
+(def ^{:stratum 0} WorkflowTier
   [:enum :best-effort :standard :critical])
 
-(def SliName
+(def ^{:stratum 0} SliName
   [:enum :SLI-1 :SLI-2 :SLI-3 :SLI-4 :SLI-5 :SLI-6 :SLI-7])
 
-(def Window
+(def ^{:stratum 0} Window
   [:enum :1h :7d :30d])
 
-(def DegradationMode
+(def ^{:stratum 0} DegradationMode
   [:enum :nominal :degraded :safe-mode])
 
-(def DependencyKind
+(def ^{:stratum 0} DependencyKind
   [:enum :provider :platform :environment])
 
-(def DependencyHealthStatus
+(def ^{:stratum 0} DependencyHealthStatus
   [:enum :healthy :degraded :unavailable :misconfigured :operator-action-required])
 
-;------------------------------------------------------------------------------ Layer 0
-;; Records
+;------------------------------------------------------------------------------ Layer 1
 
-(def SliResult
+;; Records
+(def ^{:stratum 1} SliResult
   [:map
    [:sli/name SliName]
    [:sli/value :double]
@@ -51,7 +50,7 @@
    [:sli/tier {:optional true} WorkflowTier]
    [:sli/dimensions {:optional true} :map]])
 
-(def SloCheck
+(def ^{:stratum 1} SloCheck
   [:map
    [:breached? :boolean]
    [:sli/name SliName]
@@ -60,7 +59,7 @@
    [:slo/tier WorkflowTier]
    [:slo/window Window]])
 
-(def ErrorBudget
+(def ^{:stratum 1} ErrorBudget
   [:map
    [:error-budget/tier WorkflowTier]
    [:error-budget/sli SliName]
@@ -69,7 +68,7 @@
    [:error-budget/burn-rate :double]
    [:error-budget/computed-at inst?]])
 
-(def DependencyHealth
+(def ^{:stratum 1} DependencyHealth
   [:map
    [:dependency/id keyword?]
    [:dependency/source keyword?]

--- a/components/reliability/src/ai/miniforge/reliability/sli.clj
+++ b/components/reliability/src/ai/miniforge/reliability/sli.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.reliability.sli
   "Pure SLI computation functions per N1 §5.5.2.
 
@@ -26,14 +25,14 @@
    Layer 1: Aggregate computation")
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Helpers
 
-(defn- safe-ratio
+;; Helpers
+(defn- ^{:stratum 0} safe-ratio
   "Compute numerator/denominator, returning 0.0 when denominator is zero."
   [numerator denominator]
   (if (zero? denominator) 0.0 (double (/ numerator denominator))))
 
-(defn- filter-by-window
+(defn- ^{:stratum 0} filter-by-window
   "Filter metrics to those within the time window from now."
   [metrics window]
   (let [window-ms (case window
@@ -46,7 +45,7 @@
                 (.after ^java.util.Date ts cutoff)))
             metrics)))
 
-(defn- percentile
+(defn- ^{:stratum 0} percentile
   "Compute percentile from sorted values."
   [sorted-vals p]
   (if (empty? sorted-vals)
@@ -55,20 +54,26 @@
           idx (min (dec n) (int (Math/floor (* p (dec n)))))]
       (double (nth sorted-vals idx)))))
 
-(defn- terminal-workflow?
+(defn- ^{:stratum 0} terminal-workflow?
   "Returns true if the workflow has reached a terminal status."
   [workflow]
   (#{:completed :failed :escalated} (:status workflow)))
 
-(defn- successful-workflow?
+(defn- ^{:stratum 0} successful-workflow?
   "Returns true if the workflow completed successfully or escalated."
   [workflow]
   (#{:completed :escalated} (:status workflow)))
 
-;------------------------------------------------------------------------------ Layer 0
-;; SLI-1: Workflow Success Rate
+;; SLI-2: Phase Completion Latency
+(defn- ^{:stratum 0} has-duration?
+  "Returns the duration-ms metric if present, nil otherwise."
+  [metric]
+  (get-in metric [:metrics :duration-ms]))
 
-(defn compute-workflow-success-rate
+;------------------------------------------------------------------------------ Layer 1
+
+;; SLI-1: Workflow Success Rate
+(defn ^{:stratum 1} compute-workflow-success-rate
   [workflow-metrics window]
   (let [windowed (filter-by-window workflow-metrics window)
         terminal (filter terminal-workflow? windowed)
@@ -76,15 +81,7 @@
         successful (count (filter successful-workflow? terminal))]
     (safe-ratio successful total)))
 
-;------------------------------------------------------------------------------ Layer 0
-;; SLI-2: Phase Completion Latency
-
-(defn- has-duration?
-  "Returns the duration-ms metric if present, nil otherwise."
-  [metric]
-  (get-in metric [:metrics :duration-ms]))
-
-(defn compute-phase-latency
+(defn ^{:stratum 1} compute-phase-latency
   [phase-metrics window]
   (let [windowed (filter-by-window phase-metrics window)
         durations (->> windowed
@@ -96,10 +93,8 @@
      :p95 (percentile durations 0.95)
      :p99 (percentile durations 0.99)}))
 
-;------------------------------------------------------------------------------ Layer 0
 ;; SLI-3: Inner Loop Convergence Rate
-
-(defn compute-inner-loop-convergence
+(defn ^{:stratum 1} compute-inner-loop-convergence
   [phase-metrics window]
   (let [windowed (filter-by-window phase-metrics window)
         with-loops (filter :iterations windowed)
@@ -107,30 +102,24 @@
         converged (count (filter :success? with-loops))]
     (safe-ratio converged total)))
 
-;------------------------------------------------------------------------------ Layer 0
 ;; SLI-4: Gate Pass Rate
-
-(defn compute-gate-pass-rate
+(defn ^{:stratum 1} compute-gate-pass-rate
   [gate-metrics window]
   (let [windowed (filter-by-window gate-metrics window)
         total (count windowed)
         passed (count (filter :passed? windowed))]
     (safe-ratio passed total)))
 
-;------------------------------------------------------------------------------ Layer 0
 ;; SLI-5: Tool Invocation Success Rate
-
-(defn compute-tool-success-rate
+(defn ^{:stratum 1} compute-tool-success-rate
   [tool-metrics window]
   (let [windowed (filter-by-window tool-metrics window)
         total (count windowed)
         successful (count (filter :success? windowed))]
     (safe-ratio successful total)))
 
-;------------------------------------------------------------------------------ Layer 0
 ;; SLI-6: Failure Class Distribution
-
-(defn compute-failure-distribution
+(defn ^{:stratum 1} compute-failure-distribution
   [failure-events window]
   (let [windowed (filter-by-window failure-events window)
         total (count windowed)]
@@ -143,26 +132,26 @@
              (map class-fraction)
              (into {}))))))
 
-(defn compute-unknown-failure-rate
-  [failure-events window]
-  (get (compute-failure-distribution failure-events window)
-       :failure.class/unknown
-       0.0))
-
-;------------------------------------------------------------------------------ Layer 0
 ;; SLI-7: Context Staleness Rate
-
-(defn compute-context-staleness-rate
+(defn ^{:stratum 1} compute-context-staleness-rate
   [context-metrics window]
   (let [windowed (filter-by-window context-metrics window)
         total (count windowed)
         stale (count (filter :stale? windowed))]
     (safe-ratio stale total)))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Aggregate SLI computation
+;------------------------------------------------------------------------------ Layer 2
 
-(defn compute-all-slis
+(defn ^{:stratum 2} compute-unknown-failure-rate
+  [failure-events window]
+  (get (compute-failure-distribution failure-events window)
+       :failure.class/unknown
+       0.0))
+
+;------------------------------------------------------------------------------ Layer 3
+
+;; Aggregate SLI computation
+(defn ^{:stratum 3} compute-all-slis
   [metrics window]
   (let [{:keys [workflow-metrics phase-metrics gate-metrics
                 tool-metrics failure-events context-metrics]} metrics]

--- a/components/reliability/src/ai/miniforge/reliability/slo.clj
+++ b/components/reliability/src/ai/miniforge/reliability/slo.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.reliability.slo
   "SLO target checking per workflow tier per N1 §5.5.3.
 
@@ -26,32 +25,43 @@
    [clojure.java.io :as io]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Configuration
 
-(def default-targets
+;; Configuration
+(def ^{:stratum 0} default-targets
   (-> (io/resource "config/reliability/slo-targets.edn")
       slurp
       edn/read-string))
 
-(def ^:private defaults
+(def ^{:stratum 0} ^:private defaults
   (-> (io/resource "config/reliability/defaults.edn")
       slurp
       edn/read-string))
 
-(def inverted-slis
+(defn ^{:stratum 0} breached?
+  "Returns true if an SLO check result indicates a breach."
+  [slo-check]
+  (:breached? slo-check))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} inverted-slis
   "SLIs where lower is better (the target is a ceiling, not a floor)."
   (:inverted-slis defaults))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; SLO checking (pure)
-
-(defn get-target
+(defn ^{:stratum 1} get-target
   "Get the SLO target for an SLI at a given tier. Returns nil if advisory-only."
   ([sli-name tier] (get-target sli-name tier default-targets))
   ([sli-name tier targets]
    (get-in targets [sli-name tier])))
 
-(defn check-slo
+(defn ^{:stratum 1} breached-slos
+  [slo-checks]
+  (filter breached? slo-checks))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} check-slo
   ([sli-result tier] (check-slo sli-result tier default-targets))
   ([sli-result tier targets]
    (let [{:keys [sli/name sli/value sli/window]} sli-result
@@ -67,22 +77,15 @@
           :slo/tier tier
           :slo/window window})))))
 
-(defn check-all-slos
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} check-all-slos
   ([sli-results tier] (check-all-slos sli-results tier default-targets))
   ([sli-results tier targets]
    (->> sli-results
         (map #(check-slo % tier targets))
         (filter some?)
         vec)))
-
-(defn breached?
-  "Returns true if an SLO check result indicates a breach."
-  [slo-check]
-  (:breached? slo-check))
-
-(defn breached-slos
-  [slo-checks]
-  (filter breached? slo-checks))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/reliability/test/ai/miniforge/reliability/degradation_test.clj
+++ b/components/reliability/test/ai/miniforge/reliability/degradation_test.clj
@@ -15,19 +15,19 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 ;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-
 (ns ai.miniforge.reliability.degradation-test
   (:require
    [clojure.test :refer [deftest is]]
    [ai.miniforge.reliability.interface :as rel]
    [ai.miniforge.event-stream.interface.stream :as stream]))
 
-(defn- make-stream []
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} make-stream []
   (stream/create-event-stream {:sinks []}))
 
-(defn- dependency-health-entry
+(defn- ^{:stratum 0} dependency-health-entry
   [status]
   {:anthropic {:dependency/id :anthropic
                :dependency/source :external-provider
@@ -39,15 +39,15 @@
                                             {}
                                             {status 1})}})
 
-;; ---------------------------------------------------------------------------- Basic lifecycle
+;------------------------------------------------------------------------------ Layer 1
 
-(deftest initial-mode-is-nominal-test
+;; ---------------------------------------------------------------------------- Basic lifecycle
+(deftest ^{:stratum 1} initial-mode-is-nominal-test
   (let [mgr (rel/create-degradation-manager (make-stream))]
     (is (= :nominal (rel/degradation-mode mgr)))))
 
 ;; ---------------------------------------------------------------------------- Budget-driven transitions
-
-(deftest nominal-to-degraded-on-critical-low-test
+(deftest ^{:stratum 1} nominal-to-degraded-on-critical-low-test
   (let [mgr (rel/create-degradation-manager (make-stream))
         budgets {[:SLI-1 :critical :7d]
                  {:error-budget/tier :critical
@@ -56,7 +56,7 @@
     (rel/evaluate-degradation! mgr budgets)
     (is (= :degraded (rel/degradation-mode mgr)))))
 
-(deftest nominal-to-safe-mode-on-exhausted-test
+(deftest ^{:stratum 1} nominal-to-safe-mode-on-exhausted-test
   (let [mgr (rel/create-degradation-manager (make-stream))
         budgets {[:SLI-1 :critical :7d]
                  {:error-budget/tier :critical
@@ -65,7 +65,7 @@
     (rel/evaluate-degradation! mgr budgets)
     (is (= :safe-mode (rel/degradation-mode mgr)))))
 
-(deftest degraded-to-nominal-on-recovery-test
+(deftest ^{:stratum 1} degraded-to-nominal-on-recovery-test
   (let [mgr (rel/create-degradation-manager (make-stream))
         ;; First go to degraded
         low-budgets {[:SLI-1 :critical :7d]
@@ -82,7 +82,7 @@
     (rel/evaluate-degradation! mgr good-budgets)
     (is (= :nominal (rel/degradation-mode mgr)))))
 
-(deftest degraded-to-safe-mode-on-exhaustion-test
+(deftest ^{:stratum 1} degraded-to-safe-mode-on-exhaustion-test
   (let [mgr (rel/create-degradation-manager (make-stream))
         low-budgets {[:SLI-1 :critical :7d]
                      {:error-budget/tier :critical
@@ -97,17 +97,17 @@
     (rel/evaluate-degradation! mgr exhausted)
     (is (= :safe-mode (rel/degradation-mode mgr)))))
 
-(deftest nominal-to-degraded-on-dependency-health-test
+(deftest ^{:stratum 1} nominal-to-degraded-on-dependency-health-test
   (let [mgr (rel/create-degradation-manager (make-stream))]
     (rel/evaluate-degradation! mgr {} (dependency-health-entry :degraded))
     (is (= :degraded (rel/degradation-mode mgr)))))
 
-(deftest nominal-to-safe-mode-on-operator-action-dependency-test
+(deftest ^{:stratum 1} nominal-to-safe-mode-on-operator-action-dependency-test
   (let [mgr (rel/create-degradation-manager (make-stream))]
     (rel/evaluate-degradation! mgr {} (dependency-health-entry :operator-action-required))
     (is (= :safe-mode (rel/degradation-mode mgr)))))
 
-(deftest degraded-to-nominal-on-dependency-recovery-test
+(deftest ^{:stratum 1} degraded-to-nominal-on-dependency-recovery-test
   (let [mgr (rel/create-degradation-manager (make-stream))]
     (rel/evaluate-degradation! mgr {} (dependency-health-entry :degraded))
     (is (= :degraded (rel/degradation-mode mgr)))
@@ -115,13 +115,12 @@
     (is (= :nominal (rel/degradation-mode mgr)))))
 
 ;; ---------------------------------------------------------------------------- Emergency stop
-
-(deftest emergency-stop-from-nominal-test
+(deftest ^{:stratum 1} emergency-stop-from-nominal-test
   (let [mgr (rel/create-degradation-manager (make-stream))]
     (rel/enter-safe-mode! mgr :emergency-stop "Production incident")
     (is (= :safe-mode (rel/degradation-mode mgr)))))
 
-(deftest emergency-stop-from-degraded-test
+(deftest ^{:stratum 1} emergency-stop-from-degraded-test
   (let [mgr (rel/create-degradation-manager (make-stream))
         low-budgets {[:SLI-1 :critical :7d]
                      {:error-budget/tier :critical
@@ -131,7 +130,7 @@
     (rel/enter-safe-mode! mgr :emergency-stop "Manual halt")
     (is (= :safe-mode (rel/degradation-mode mgr)))))
 
-(deftest manual-entry-preserves-manual-trigger-test
+(deftest ^{:stratum 1} manual-entry-preserves-manual-trigger-test
   (let [stream (make-stream)
         mgr (rel/create-degradation-manager stream)]
     (rel/enter-safe-mode! mgr :manual "Operator requested safe mode")
@@ -142,23 +141,21 @@
       (is (= :manual (:safe-mode/trigger entered))))))
 
 ;; ---------------------------------------------------------------------------- Safe-mode exit
-
-(deftest safe-mode-exit-requires-justification-test
+(deftest ^{:stratum 1} safe-mode-exit-requires-justification-test
   (let [mgr (rel/create-degradation-manager (make-stream))]
     (rel/enter-safe-mode! mgr :emergency-stop "Test")
     (is (= :safe-mode (rel/degradation-mode mgr)))
     (rel/exit-safe-mode! mgr "Incident resolved" "chris@miniforge.ai")
     (is (= :nominal (rel/degradation-mode mgr)))))
 
-(deftest exit-from-non-safe-mode-is-noop-test
+(deftest ^{:stratum 1} exit-from-non-safe-mode-is-noop-test
   (let [mgr (rel/create-degradation-manager (make-stream))]
     (is (= :nominal (rel/degradation-mode mgr)))
     (rel/exit-safe-mode! mgr "No reason" "someone")
     (is (= :nominal (rel/degradation-mode mgr)))))
 
 ;; ---------------------------------------------------------------------------- Event emission
-
-(deftest transitions-emit-events-test
+(deftest ^{:stratum 1} transitions-emit-events-test
   (let [stream (make-stream)
         mgr (rel/create-degradation-manager stream)
         budgets {[:SLI-1 :critical :7d]
@@ -172,7 +169,7 @@
       (is (= :nominal (:degradation/from (first mode-events))))
       (is (= :degraded (:degradation/to (first mode-events)))))))
 
-(deftest dependency-safe-mode-transition-emits-safe-mode-entered-test
+(deftest ^{:stratum 1} dependency-safe-mode-transition-emits-safe-mode-entered-test
   (let [stream (make-stream)
         mgr (rel/create-degradation-manager stream)]
     (rel/evaluate-degradation! mgr {} (dependency-health-entry :operator-action-required))
@@ -183,8 +180,7 @@
              (:safe-mode/trigger (first entered-events)))))))
 
 ;; ---------------------------------------------------------------------------- Standard tier budgets don't trigger degradation
-
-(deftest standard-tier-does-not-trigger-degradation-test
+(deftest ^{:stratum 1} standard-tier-does-not-trigger-degradation-test
   (let [mgr (rel/create-degradation-manager (make-stream))
         budgets {[:SLI-1 :standard :7d]
                  {:error-budget/tier :standard

--- a/components/reliability/test/ai/miniforge/reliability/dependency_health_test.clj
+++ b/components/reliability/test/ai/miniforge/reliability/dependency_health_test.clj
@@ -15,13 +15,14 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.reliability.dependency-health-test
   (:require
    [clojure.test :refer [deftest is]]
    [ai.miniforge.reliability.interface :as rel]))
 
-(defn- dependency-failure
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} dependency-failure
   [overrides]
   (merge {:failure/class :failure.class/external
           :failure/source :external-provider
@@ -31,7 +32,9 @@
           :failure/message "rate limit"}
          overrides))
 
-(deftest provider-rate-limits-project-degraded-health
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} provider-rate-limits-project-degraded-health
   (let [rolling-state (rel/apply-dependency-signals {}
                                              [(dependency-failure {})]
                                              [])
@@ -41,7 +44,7 @@
     (is (= :provider (:dependency/kind anthropic-health)))
     (is (= 1 (:dependency/failure-count anthropic-health)))))
 
-(deftest repeated-outages-cross-unavailable-threshold
+(deftest ^{:stratum 1} repeated-outages-cross-unavailable-threshold
   (let [incidents (repeat 3 (dependency-failure {:dependency/class :outage
                                                  :failure/message "provider outage"}))
         rolling-state (rel/apply-dependency-signals {} incidents [])
@@ -50,7 +53,7 @@
     (is (= :unavailable (:dependency/status anthropic-health)))
     (is (= 3 (:dependency/failure-count anthropic-health)))))
 
-(deftest environment-misconfiguration-is-tracked-separately
+(deftest ^{:stratum 1} environment-misconfiguration-is-tracked-separately
   (let [rolling-state (rel/apply-dependency-signals
                        {}
                        [(dependency-failure {:failure/source :user-env
@@ -64,7 +67,7 @@
     (is (= :operator-action-required (:dependency/status env-health)))
     (is (= :environment (:dependency/kind env-health)))))
 
-(deftest recovery-resets-health-to-healthy
+(deftest ^{:stratum 1} recovery-resets-health-to-healthy
   (let [rolling-state (rel/apply-dependency-signals
                        {}
                        [(dependency-failure {:dependency/class :outage})]

--- a/components/reliability/test/ai/miniforge/reliability/engine_test.clj
+++ b/components/reliability/test/ai/miniforge/reliability/engine_test.clj
@@ -15,14 +15,15 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.reliability.engine-test
   (:require
    [ai.miniforge.event-stream.interface.stream :as stream]
    [ai.miniforge.reliability.interface :as rel]
    [clojure.test :refer [deftest is]]))
 
-(defn- dependency-failure
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} dependency-failure
   [overrides]
   (merge {:failure/class :failure.class/external
           :failure/source :external-provider
@@ -32,7 +33,9 @@
           :failure/message "rate limit"}
          overrides))
 
-(deftest compute-cycle-emits-dependency-health-updated-events
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} compute-cycle-emits-dependency-health-updated-events
   (let [event-stream (stream/create-event-stream {:sinks []})
         engine (rel/create-engine event-stream {:tiers []})
         result (rel/compute-cycle! engine {:dependency/incidents [(dependency-failure {})]})
@@ -45,7 +48,7 @@
     (is (= :anthropic (:dependency/id dependency-event)))
     (is (= :degraded (:dependency/status dependency-event)))))
 
-(deftest compute-cycle-emits-dependency-recovered-events
+(deftest ^{:stratum 1} compute-cycle-emits-dependency-recovered-events
   (let [event-stream (stream/create-event-stream {:sinks []})
         engine (rel/create-engine event-stream {:tiers []})]
     (rel/compute-cycle! engine {:dependency/incidents (repeat 3 (dependency-failure {:dependency/class :outage}))})
@@ -57,4 +60,4 @@
           recovered-event (last recovered-events)]
       (is (= 1 (count recovered-events)))
       (is (= :healthy (:dependency/status recovered-event)))
-      (is (= :unavailable (:dependency/previous-status recovered-event)))))) 
+      (is (= :unavailable (:dependency/previous-status recovered-event))))))

--- a/components/reliability/test/ai/miniforge/reliability/sli_test.clj
+++ b/components/reliability/test/ai/miniforge/reliability/sli_test.clj
@@ -15,20 +15,75 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 ;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-
 (ns ai.miniforge.reliability.sli-test
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.reliability.interface :as rel]
    [ai.miniforge.event-stream.interface.stream :as stream]))
 
-(def now (java.util.Date.))
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} now (java.util.Date.))
+
+;; ---------------------------------------------------------------------------- SLO checking
+(deftest ^{:stratum 0} slo-check-test
+  (testing "SLI-1 below standard target is breach"
+    (let [result (rel/check-slo {:sli/name :SLI-1 :sli/value 0.80 :sli/window :7d}
+                                :standard)]
+      (is (:breached? result))
+      (is (= 0.85 (:slo/target result)))))
+
+  (testing "SLI-1 above standard target is not breach"
+    (let [result (rel/check-slo {:sli/name :SLI-1 :sli/value 0.90 :sli/window :7d}
+                                :standard)]
+      (is (not (:breached? result)))))
+
+  (testing "SLI-6 inverted: above target is breach"
+    (let [result (rel/check-slo {:sli/name :SLI-6 :sli/value 0.15 :sli/window :7d}
+                                :standard)]
+      (is (:breached? result))
+      (is (= 0.10 (:slo/target result)))))
+
+  (testing "advisory-only returns nil"
+    (is (nil? (rel/check-slo {:sli/name :SLI-1 :sli/value 0.50 :sli/window :7d}
+                             :best-effort)))))
+
+;; ---------------------------------------------------------------------------- Error budgets
+(deftest ^{:stratum 0} error-budget-test
+  (testing "healthy budget"
+    (let [b (rel/compute-error-budget 0.90 0.85 false)]
+      (is (> (:error-budget/remaining b) 0.0))
+      (is (not (rel/budget-exhausted? b)))
+      (is (not (rel/budget-critical? b)))))
+
+  (testing "exhausted budget"
+    (let [b (rel/compute-error-budget 0.80 0.85 false)]
+      (is (rel/budget-exhausted? b))))
+
+  (testing "critical but not exhausted"
+    (let [b (rel/compute-error-budget 0.855 0.85 false)]
+      (is (not (rel/budget-exhausted? b)))
+      ;; remaining ~0.033, which is < 0.25 threshold
+      (is (rel/budget-critical? b))))
+
+  (testing "inverted SLI budget"
+    (let [b (rel/compute-error-budget 0.05 0.10 true)]
+      (is (= 0.5 (:error-budget/remaining b)))
+      (is (not (rel/budget-exhausted? b))))))
+
+;; ---------------------------------------------------------------------------- compute-all-slis
+(deftest ^{:stratum 0} compute-all-slis-test
+  (testing "returns 7 SLI results"
+    (let [results (rel/compute-all-slis {} :7d)]
+      (is (= 7 (count results)))
+      (is (every? #(contains? % :sli/name) results))
+      (is (every? #(= :7d (:sli/window %)) results)))))
+
+;------------------------------------------------------------------------------ Layer 1
 
 ;; ---------------------------------------------------------------------------- SLI-1: Workflow Success Rate
-
-(deftest workflow-success-rate-test
+(deftest ^{:stratum 1} workflow-success-rate-test
   (testing "basic success rate"
     (is (= 1.0 (rel/compute-workflow-success-rate
                  [{:status :completed :timestamp now}
@@ -55,8 +110,7 @@
                  :7d)))))
 
 ;; ---------------------------------------------------------------------------- SLI-3: Inner Loop Convergence
-
-(deftest inner-loop-convergence-test
+(deftest ^{:stratum 1} inner-loop-convergence-test
   (testing "all converge"
     (is (= 1.0 (rel/compute-inner-loop-convergence
                  [{:iterations 2 :success? true :timestamp now}
@@ -76,8 +130,7 @@
                  :7d)))))
 
 ;; ---------------------------------------------------------------------------- SLI-4: Gate Pass Rate
-
-(deftest gate-pass-rate-test
+(deftest ^{:stratum 1} gate-pass-rate-test
   (is (= 0.75 (rel/compute-gate-pass-rate
                 [{:passed? true :timestamp now}
                  {:passed? true :timestamp now}
@@ -86,8 +139,7 @@
                 :7d))))
 
 ;; ---------------------------------------------------------------------------- SLI-6: Failure Distribution
-
-(deftest failure-distribution-test
+(deftest ^{:stratum 1} failure-distribution-test
   (testing "correct distribution"
     (let [events [{:failure/class :failure.class/timeout :timestamp now}
                   {:failure/class :failure.class/timeout :timestamp now}
@@ -106,66 +158,8 @@
                    {:failure/class :failure.class/external :timestamp now}]
                   :7d)))))
 
-;; ---------------------------------------------------------------------------- SLO checking
-
-(deftest slo-check-test
-  (testing "SLI-1 below standard target is breach"
-    (let [result (rel/check-slo {:sli/name :SLI-1 :sli/value 0.80 :sli/window :7d}
-                                :standard)]
-      (is (:breached? result))
-      (is (= 0.85 (:slo/target result)))))
-
-  (testing "SLI-1 above standard target is not breach"
-    (let [result (rel/check-slo {:sli/name :SLI-1 :sli/value 0.90 :sli/window :7d}
-                                :standard)]
-      (is (not (:breached? result)))))
-
-  (testing "SLI-6 inverted: above target is breach"
-    (let [result (rel/check-slo {:sli/name :SLI-6 :sli/value 0.15 :sli/window :7d}
-                                :standard)]
-      (is (:breached? result))
-      (is (= 0.10 (:slo/target result)))))
-
-  (testing "advisory-only returns nil"
-    (is (nil? (rel/check-slo {:sli/name :SLI-1 :sli/value 0.50 :sli/window :7d}
-                             :best-effort)))))
-
-;; ---------------------------------------------------------------------------- Error budgets
-
-(deftest error-budget-test
-  (testing "healthy budget"
-    (let [b (rel/compute-error-budget 0.90 0.85 false)]
-      (is (> (:error-budget/remaining b) 0.0))
-      (is (not (rel/budget-exhausted? b)))
-      (is (not (rel/budget-critical? b)))))
-
-  (testing "exhausted budget"
-    (let [b (rel/compute-error-budget 0.80 0.85 false)]
-      (is (rel/budget-exhausted? b))))
-
-  (testing "critical but not exhausted"
-    (let [b (rel/compute-error-budget 0.855 0.85 false)]
-      (is (not (rel/budget-exhausted? b)))
-      ;; remaining ~0.033, which is < 0.25 threshold
-      (is (rel/budget-critical? b))))
-
-  (testing "inverted SLI budget"
-    (let [b (rel/compute-error-budget 0.05 0.10 true)]
-      (is (= 0.5 (:error-budget/remaining b)))
-      (is (not (rel/budget-exhausted? b))))))
-
-;; ---------------------------------------------------------------------------- compute-all-slis
-
-(deftest compute-all-slis-test
-  (testing "returns 7 SLI results"
-    (let [results (rel/compute-all-slis {} :7d)]
-      (is (= 7 (count results)))
-      (is (every? #(contains? % :sli/name) results))
-      (is (every? #(= :7d (:sli/window %)) results)))))
-
 ;; ---------------------------------------------------------------------------- Engine
-
-(deftest engine-test
+(deftest ^{:stratum 1} engine-test
   (testing "compute-cycle! returns expected structure"
     (let [stream (stream/create-event-stream {:sinks []})
           eng (rel/create-engine stream {:windows [:7d] :tiers [:standard]})

--- a/docs/pull-requests/2026-07-24-fix-stratum-lint-wave1-reliability.md
+++ b/docs/pull-requests/2026-07-24-fix-stratum-lint-wave1-reliability.md
@@ -1,0 +1,150 @@
+# fix: stratum-lint autofix for components/reliability (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` (sha `acd82a2f`) over all 13 Clojure files (9
+`src`, 4 `test`) in `components/reliability`, regrouping each file's defs
+under regenerated `;---- Layer N` headings and tagging every def with
+`^{:stratum n}` metadata inferred from the real same-file reference graph.
+No logic changes — headings and metadata only.
+
+## Motivation
+
+`work/stratum-lint-baseline-2026-07-24.md` (Wave 0) found rule 210's
+stratified-design headings had been cargo-culted across most of the tree
+into decorative section banners that didn't track a real dependency DAG.
+`reliability` carried 12 findings (11 SL002 heading-order, 1 SL003
+over-budget, **zero SL001** upward-references) — the zero-SL001 profile is
+what puts it in the first safe-to-autofix batch (autofix cannot be trusted
+to resolve a genuine upward reference; it can always resolve mis-ordered or
+decorative headings). This PR is that Wave 1 pass for `reliability`.
+
+## Changes in Detail
+
+Ran:
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "acd82a2f5c0155cb03d92ce1f4465cc064125895" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/reliability
+```
+
+All 13 files rewritten:
+
+- `src/.../budget.clj`, `degradation.clj`, `dependency_health.clj`,
+  `engine.clj`, `interface.clj`, `messages.clj`, `schema.clj`, `sli.clj`,
+  `slo.clj`
+- `test/.../degradation_test.clj`, `dependency_health_test.clj`,
+  `engine_test.clj`, `sli_test.clj`
+
+Every named top-level form (`def`/`defn`/`defn-`/`defrecord`/`deftest`/`ns`)
+was verified byte-identical before and after, ignoring the added
+`^{:stratum n}` metadata — confirmed with a form-level comparison script
+reading both versions with the Clojure reader (see Testing Plan). No
+function body, test assertion, or `ns` form changed; only heading
+placement, def order, and metadata did.
+
+**`interface.clj` (the file the baseline flagged as the one SL003
+over-budget finding) is now fully resolved to a single Layer 0.** It's a
+pure pass-through file — every def just aliases a var in another
+namespace — so the real same-file reference graph has no internal edges,
+and the previously decorative 6-heading structure collapses to what it
+actually is: flat. Zero re-splitting needed here.
+
+**Two cosmetic comment misplacements**, both the same tool quirk: a
+trailing inline comment on a `defrecord`'s last field (e.g.
+`config])       ; data-driven degradation policy`) gets detached during
+reordering and reattached as a leading comment on an unrelated def that
+happened to land at that position afterward (`degradation.clj`'s
+`DegradationManager` comment ends up above `mode-rank`; `engine.clj`'s
+`ReliabilityEngine` comment ends up above `create-engine`). Left as the
+autofixer produced them rather than hand-patched, so this PR's diff is
+exactly and only what `--fix` emits — verifiable and reproducible. Harmless
+(comments, not code; the affected line is still valid, still describes the
+same field's shape in prose nearby), but worth an upstream issue against
+`stratum-lint`'s comment-reattachment heuristic for `defrecord` trailing
+field comments — flagged separately, out of scope for this PR.
+
+Also noticed: a handful of `ns` docstrings state a smaller layer count in
+prose than the file now really has (e.g. `budget.clj`'s docstring says
+"Layer 0: Constants / Layer 1: Pure computation functions" but the file is
+now 4 real layers). `--fix` only rewrites structural headings/metadata, not
+free-text docstrings, so these are stale by construction until someone
+updates the prose by hand. Cosmetic, not blocking.
+
+## Testing Plan
+
+1. Ran plain (non-`--fix`) lint before fixing: 12 findings, exactly matching
+   the baseline (11 SL002, 1 SL003 in `interface.clj`, 0 SL001).
+2. Ran `--fix`; reviewed `git diff --stat` and read every one of the 13
+   changed files in full.
+3. Wrote and ran a babashka script
+   (`/tmp` scratch, not committed) that reads the pre-fix (`git show HEAD:`)
+   and post-fix version of each file with the Clojure reader, strips the
+   `:stratum` key from metadata, and diffs every named top-level form's body
+   between versions by name. Result: zero missing forms, zero added forms,
+   **zero body differences** across all 13 files (188 total named forms
+   compared, including `ns` and `deftest` forms).
+4. Ran plain lint again after `--fix`. **Not clean** — 6 of 9 `src` files
+   still report SL003:
+
+   ```text
+   budget.clj:            4 distinct layers (max 3)
+   degradation.clj:       7 distinct layers (max 3)
+   dependency_health.clj: 6 distinct layers (max 3)
+   engine.clj:            4 distinct layers (max 3)
+   sli.clj:               4 distinct layers (max 3)
+   slo.clj:               4 distinct layers (max 3)
+   ```
+
+   This is larger than the baseline's "1 over-budget file" prediction — but
+   that number came from the *pre-fix* decorative headings, which cycled
+   through 0/1/2 repeatedly without exceeding 3 distinct labels even when
+   badly misordered (that's what SL002 was catching). Once `--fix` computes
+   the *real* per-file stratification from the actual call graph, several
+   files turn out to have genuine DAG depth greater than 3 — the decorative
+   headings were masking this, not just misordering it. This is exactly the
+   SL003-remainder case flagged as expected/out-of-scope in the task
+   instructions and in the baseline's Wave 2 section (real namespace
+   splits) — noted here, not fixed in this PR.
+5. Ran the component's test suite directly
+   (`cd components/reliability && clojure -M:test -m cognitect.test-runner`):
+   30 tests, 80 assertions, 0 failures, 0 errors.
+6. Ran `bb poly:check`: passes (one pre-existing warning in an unrelated
+   component, `config`, not touched by this PR).
+7. Ran `clj-kondo --lint components/reliability/src components/reliability/test`
+   directly: 0 errors, 0 warnings.
+
+## Deployment Plan
+
+Merges to `main`. No runtime behavior change — pure source reformatting.
+No migration, no config change, no rollout sequencing needed.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 0) —
+  `reliability` is one of the smaller-reference-graph components
+  recommended for an early Wave 1 batch (`compliance-scanner`,
+  `reliability`, `gate`, `decision`, `adapter-claude-code`).
+- Depends on: #1459 (`fix: stratum-lint pre-commit autofixes instead of just
+  failing`), which bumped the pinned sha to `acd82a2f` and wired `--fix`
+  into pre-commit.
+- Follow-on: Wave 2 namespace splits for the 6 files above (`budget.clj`,
+  `degradation.clj`, `dependency_health.clj`, `engine.clj`, `sli.clj`,
+  `slo.clj`), each genuinely over the 3-layer budget once decorative
+  headings are replaced with real ones.
+- Worth filing upstream against `miniforge-ai/stratum-lint`: the
+  `defrecord`-trailing-field-comment reattachment quirk noted above.
+
+## Checklist
+
+- [x] Ran `--fix` over the whole component (src + test)
+- [x] Reviewed full diff for all 13 changed files; confirmed mechanical
+      (headings + `^{:stratum n}` metadata only)
+- [x] Form-level equivalence verified programmatically (188 named forms,
+      zero body differences)
+- [x] Re-ran plain lint post-fix; 6 SL003 remainders documented above as
+      expected Wave 2 work, not a regression or failure
+- [x] Component test suite green (30 tests, 80 assertions)
+- [x] `poly:check` and `clj-kondo` clean
+- [x] Two cosmetic comment-placement quirks identified, explained, and left
+      unmodified (exact `--fix` output preserved) rather than silently
+      hand-patched


### PR DESCRIPTION
## Summary

- Runs `stratum-lint --fix` (sha `acd82a2f`) over all 13 Clojure files in `components/reliability` (9 src + 4 test), regrouping defs under regenerated `Layer N` headings with `^{:stratum n}` metadata inferred from the real same-file reference graph.
- Purely mechanical: headings + metadata only, no logic changes. Verified by comparing every named top-level form's body between pre- and post-fix versions via the Clojure reader — zero differences across 188 forms.
- Wave 1 of `work/stratum-lint-baseline-2026-07-24.md`: `reliability` had 12 pre-fix findings (11 SL002 heading-order, 1 SL003, **zero SL001**), which is why it's in the first safe-to-autofix batch.

## Notable findings (see PR doc for full detail)

- `interface.clj` — the baseline's one SL003 finding — fully resolves: it's a pure pass-through file with no internal reference edges, so its real stratification collapses to a single Layer 0.
- Post-fix plain lint still reports **SL003 on 6 of 9 src files** (`budget`, `degradation`, `dependency_health`, `engine`, `sli`, `slo`) — more than the baseline predicted, because that number came from pre-fix decorative headings that never exceeded 3 distinct labels even when misordered. The real reference-graph stratification exposes genuine DAG depth > 3 in these files. This is expected/out-of-scope per the task framing (Wave 2 = real namespace splits) — documented, not fixed, here.
- Two cosmetic comment-placement quirks in the autofixer itself: a trailing inline comment on a `defrecord`'s last field gets reattached to an unrelated following def after reordering (`degradation.clj`, `engine.clj`). Harmless (comments only), left as the tool produced it so this PR's diff is exactly `--fix`'s output — worth an upstream issue against `stratum-lint`, out of scope here.

## Test plan

- [x] Pre-fix plain lint: 12 findings, matches baseline exactly (11 SL002, 1 SL003, 0 SL001)
- [x] `--fix` run; full diff read for all 13 files
- [x] Form-level equivalence script (Clojure reader, strips `:stratum` metadata): 0 missing/added/differing forms across 188 named top-level forms
- [x] Post-fix plain lint: 6 SL003 remainders, documented as Wave 2 work
- [x] Component test suite: 30 tests, 80 assertions, 0 failures
- [x] `poly:check` clean (one pre-existing unrelated warning in `config`)
- [x] `clj-kondo` clean (0 errors, 0 warnings)
- [x] Full `bb pre-commit`: commit-budget (overridden — mechanical full-file reorder), `poly:check`, `lint:clj`, `lint:stratum` (advisory SL003 only), `fmt:md`, `test:precommit` (331 tests / 1241 assertions), `test:graalvm` (7 tests / 539 assertions) — all green

## Related

- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 0)
- Depends on: #1459 (autofix wired into pre-commit, sha bump to `acd82a2f`)
- Follow-on: Wave 2 namespace splits for the 6 SL003 files above
- Full detail: `docs/pull-requests/2026-07-24-fix-stratum-lint-wave1-reliability.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)