### PR TITLE
fix: stratum-lint autofix for components/decision (Wave 1)

### DIFF
--- a/components/decision/src/ai/miniforge/decision/core.clj
+++ b/components/decision/src/ai/miniforge/decision/core.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.decision.core
   "Pure constructors for canonical checkpoints and episodes.
    Layer 0: Small helper mappings
@@ -25,32 +24,32 @@
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Helper mappings
 
-(def ^:private decision-type->class
+;; Helper mappings
+(def ^{:stratum 0} ^:private decision-type->class
   {:approval :approval
    :choice :implementation-pattern-choice
    :input :request-for-input
    :confirmation :confirmation})
 
-(def ^:private priority->risk-tier
+(def ^{:stratum 0} ^:private priority->risk-tier
   {:critical :critical
    :high :high
    :medium :medium
    :low :low})
 
-(def ^:private decision-type->response-type
+(def ^{:stratum 0} ^:private decision-type->response-type
   {:approval :approve
    :choice :choose-option
    :input :approve-with-constraints
    :confirmation :approve})
 
-(defn- option->alternative
+(defn- ^{:stratum 0} option->alternative
   [idx option]
   {:id idx
    :summary (str option)})
 
-(defn- summarize-loop-errors
+(defn- ^{:stratum 0} summarize-loop-errors
   "Return a joined summary of the first two non-blank error messages, or nil
    when the error list yields nothing usable. Returning nil (rather than the
    empty string) lets callers fall back via `or` and keeps :uncertainty/:reason
@@ -65,41 +64,20 @@
     (when-not (str/blank? joined)
       joined)))
 
-(defn- control-plane-proposal
-  [summary options decision-type]
-  (cond-> {:action-type :request-human-decision
-           :decision-class (get decision-type->class decision-type
-                                :implementation-pattern-choice)
-           :summary summary}
-    (seq options) (assoc :alternatives
-                         (mapv option->alternative (range) options))))
-
-(defn- control-plane-uncertainty
+(defn- ^{:stratum 0} control-plane-uncertainty
   [agent-confidence]
   (cond-> {:class :agent-request
            :reason "External or delegated agent requested human judgment."}
     (some? agent-confidence) (assoc :agent-confidence agent-confidence)))
 
-(defn- control-plane-context
+(defn- ^{:stratum 0} control-plane-context
   [{:keys [context deadline tags]}]
   (cond-> {}
     context (assoc :context/text context)
     deadline (assoc :context/deadline deadline)
     (seq tags) (assoc :context/tags (set tags))))
 
-(defn- control-plane-checkpoint-input
-  [agent-id summary {:keys [type priority options agent-confidence]
-                     :as opts}]
-  {:source {:kind :control-plane-agent
-            :agent-id agent-id}
-   :task {:kind :control-plane-decision
-          :goal summary}
-   :proposal (control-plane-proposal summary options (or type :choice))
-   :uncertainty (control-plane-uncertainty agent-confidence)
-   :risk {:tier (get priority->risk-tier (or priority :medium) :medium)}
-   :context (control-plane-context opts)})
-
-(defn- loop-escalation-summary
+(defn- ^{:stratum 0} loop-escalation-summary
   [loop-state summary]
   (or summary
       (str "Loop escalation after "
@@ -107,13 +85,13 @@
            " attempt(s) for task "
            (name (or (get-in loop-state [:loop/task :task/type]) :unknown)))))
 
-(defn- loop-escalation-task
+(defn- ^{:stratum 0} loop-escalation-task
   [task summary]
   (cond-> {:kind :loop-escalation
            :goal summary}
     (:task/id task) (assoc :task-id (:task/id task))))
 
-(defn- loop-escalation-proposal
+(defn- ^{:stratum 0} loop-escalation-proposal
   [artifact summary]
   (let [content (some-> artifact :artifact/content str)
         diff-summary (when content
@@ -124,13 +102,7 @@
       (:artifact/path artifact) (assoc :files [(:artifact/path artifact)])
       diff-summary (assoc :diff-summary diff-summary))))
 
-(defn- loop-escalation-uncertainty
-  [errors]
-  {:class :validation-failure
-   :reason (or (summarize-loop-errors errors)
-               "Loop exhausted repair budget without convergence.")})
-
-(defn- loop-escalation-context
+(defn- ^{:stratum 0} loop-escalation-context
   [{:loop/keys [iteration state termination task errors]}]
   {:loop/iteration iteration
    :loop/state state
@@ -138,31 +110,8 @@
    :task/type (:task/type task)
    :error-count (count errors)})
 
-(defn- loop-escalation-checkpoint-input
-  [loop-state {:keys [summary risk-tier]}]
-  (let [summary (loop-escalation-summary loop-state summary)
-        task (:loop/task loop-state)
-        artifact (:loop/artifact loop-state)
-        errors (:loop/errors loop-state)]
-    {:source {:kind :loop-escalation
-              :loop-id (:loop/id loop-state)}
-     :task (loop-escalation-task task summary)
-     :proposal (loop-escalation-proposal artifact summary)
-     :uncertainty (loop-escalation-uncertainty errors)
-     :risk {:tier (or risk-tier :medium)}
-     :context (loop-escalation-context loop-state)}))
-
-(defn decision-response
-  [decision-type resolution & [rationale]]
-  (cond-> {:type (get decision-type->response-type decision-type :approve)
-           :value resolution
-           :authority-role :human}
-    rationale (assoc :rationale rationale)))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; Checkpoint constructors
-
-(defn create-checkpoint
+(defn ^{:stratum 0} create-checkpoint
   [{:keys [checkpoint-id status created-at resolved-at requested-authority
            source task proposal uncertainty risk context response]}]
   (cond-> {:checkpoint/id (or checkpoint-id (random-uuid))
@@ -178,27 +127,15 @@
     response (assoc :response response)
     resolved-at (assoc :checkpoint/resolved-at resolved-at)))
 
-(defn resolve-checkpoint
+(defn ^{:stratum 0} resolve-checkpoint
   [checkpoint response]
   (assoc checkpoint
          :checkpoint/status :resolved
          :checkpoint/resolved-at (java.util.Date.)
          :response response))
 
-(defn create-control-plane-checkpoint
-  [agent-id summary opts]
-  (-> (control-plane-checkpoint-input agent-id summary opts)
-      create-checkpoint))
-
-(defn create-loop-escalation-checkpoint
-  [loop-state opts]
-  (-> (loop-escalation-checkpoint-input loop-state opts)
-      create-checkpoint))
-
-;------------------------------------------------------------------------------ Layer 2
 ;; Episode constructors
-
-(defn create-episode
+(defn ^{:stratum 0} create-episode
   [checkpoint]
   (let [now (java.util.Date.)]
     (cond-> {:episode/id (random-uuid)
@@ -210,7 +147,7 @@
              :checkpoint checkpoint}
       (:response checkpoint) (assoc :supervision (:response checkpoint)))))
 
-(defn update-episode
+(defn ^{:stratum 0} update-episode
   [episode checkpoint & [opts]]
   (cond-> (assoc episode
                  :episode/status (cond
@@ -222,6 +159,70 @@
     (:response checkpoint) (assoc :supervision (:response checkpoint))
     (:execution-result opts) (assoc :execution-result (:execution-result opts))
     (:downstream-outcome opts) (assoc :downstream-outcome (:downstream-outcome opts))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} control-plane-proposal
+  [summary options decision-type]
+  (cond-> {:action-type :request-human-decision
+           :decision-class (get decision-type->class decision-type
+                                :implementation-pattern-choice)
+           :summary summary}
+    (seq options) (assoc :alternatives
+                         (mapv option->alternative (range) options))))
+
+(defn- ^{:stratum 1} loop-escalation-uncertainty
+  [errors]
+  {:class :validation-failure
+   :reason (or (summarize-loop-errors errors)
+               "Loop exhausted repair budget without convergence.")})
+
+(defn ^{:stratum 1} decision-response
+  [decision-type resolution & [rationale]]
+  (cond-> {:type (get decision-type->response-type decision-type :approve)
+           :value resolution
+           :authority-role :human}
+    rationale (assoc :rationale rationale)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- ^{:stratum 2} control-plane-checkpoint-input
+  [agent-id summary {:keys [type priority options agent-confidence]
+                     :as opts}]
+  {:source {:kind :control-plane-agent
+            :agent-id agent-id}
+   :task {:kind :control-plane-decision
+          :goal summary}
+   :proposal (control-plane-proposal summary options (or type :choice))
+   :uncertainty (control-plane-uncertainty agent-confidence)
+   :risk {:tier (get priority->risk-tier (or priority :medium) :medium)}
+   :context (control-plane-context opts)})
+
+(defn- ^{:stratum 2} loop-escalation-checkpoint-input
+  [loop-state {:keys [summary risk-tier]}]
+  (let [summary (loop-escalation-summary loop-state summary)
+        task (:loop/task loop-state)
+        artifact (:loop/artifact loop-state)
+        errors (:loop/errors loop-state)]
+    {:source {:kind :loop-escalation
+              :loop-id (:loop/id loop-state)}
+     :task (loop-escalation-task task summary)
+     :proposal (loop-escalation-proposal artifact summary)
+     :uncertainty (loop-escalation-uncertainty errors)
+     :risk {:tier (or risk-tier :medium)}
+     :context (loop-escalation-context loop-state)}))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} create-control-plane-checkpoint
+  [agent-id summary opts]
+  (-> (control-plane-checkpoint-input agent-id summary opts)
+      create-checkpoint))
+
+(defn ^{:stratum 3} create-loop-escalation-checkpoint
+  [loop-state opts]
+  (-> (loop-escalation-checkpoint-input loop-state opts)
+      create-checkpoint))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/decision/src/ai/miniforge/decision/interface.clj
+++ b/components/decision/src/ai/miniforge/decision/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.decision.interface
   "Public API for canonical decision checkpoints and episodes."
   (:require
@@ -23,81 +22,91 @@
    [ai.miniforge.decision.core :as core]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Schema re-exports
 
-(def DecisionCheckpoint
+;; Schema re-exports
+(def ^{:stratum 0} DecisionCheckpoint
   "Malli schema for a canonical normalized decision checkpoint."
   spec/DecisionCheckpoint)
-(def DecisionEpisode
+
+(def ^{:stratum 0} DecisionEpisode
   "Malli schema for a normalized decision episode (pending or resolved)."
   spec/DecisionEpisode)
 
-(def source-kinds
+(def ^{:stratum 0} source-kinds
   "Vector of known checkpoint producer categories."
   spec/source-kinds)
-(def authority-kinds
+
+(def ^{:stratum 0} authority-kinds
   "Vector of authorities that may answer a checkpoint."
   spec/authority-kinds)
-(def checkpoint-statuses
+
+(def ^{:stratum 0} checkpoint-statuses
   "Vector of checkpoint lifecycle states."
   spec/checkpoint-statuses)
-(def episode-statuses
+
+(def ^{:stratum 0} episode-statuses
   "Vector of episode lifecycle states."
   spec/episode-statuses)
-(def response-types
+
+(def ^{:stratum 0} response-types
   "Vector of structured supervision response actions."
   spec/response-types)
-(def risk-tiers
+
+(def ^{:stratum 0} risk-tiers
   "Vector of risk tiers used for decision routing."
   spec/risk-tiers)
-(def ControlPlaneContext
+
+(def ^{:stratum 0} ControlPlaneContext
   "Malli schema for control-plane decision checkpoint context."
   spec/ControlPlaneContext)
-(def LoopEscalationContext
+
+(def ^{:stratum 0} LoopEscalationContext
   "Malli schema for loop-escalation checkpoint context."
   spec/LoopEscalationContext)
-(def DecisionContext
+
+(def ^{:stratum 0} DecisionContext
   "Malli schema for the known decision-checkpoint context shapes."
   spec/DecisionContext)
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Validation helpers
-
-(def valid?
+(def ^{:stratum 0} valid?
   "True when `value` validates against `schema`. (schema value) -> boolean."
   spec/valid?)
-(def explain
+
+(def ^{:stratum 0} explain
   "Humanized explanation of why `value` fails `schema`. (schema value) -> map|nil."
   spec/explain)
-(def validate-result
+
+(def ^{:stratum 0} validate-result
   "Return `value` if it validates against `schema`, else return an anomaly."
   spec/validate-result)
-(def validate
+
+(def ^{:stratum 0} validate
   "Return `value` if it validates against `schema`, else throw. (schema value) -> value."
   spec/validate)
 
-;------------------------------------------------------------------------------ Layer 2
-;; Public constructors
+;------------------------------------------------------------------------------ Layer 1
 
-(defn create-checkpoint
+;; Public constructors
+(defn ^{:stratum 1} create-checkpoint
   "Create a canonical decision checkpoint."
   [opts]
   (validate DecisionCheckpoint
             (core/create-checkpoint opts)))
 
-(defn resolve-checkpoint
+(defn ^{:stratum 1} resolve-checkpoint
   "Resolve a checkpoint with structured supervision."
   [checkpoint response]
   (validate DecisionCheckpoint
             (core/resolve-checkpoint checkpoint response)))
 
-(defn create-episode
+(defn ^{:stratum 1} create-episode
   "Create a decision episode shell from a checkpoint."
   [checkpoint]
   (validate DecisionEpisode
             (core/create-episode checkpoint)))
 
-(defn update-episode
+(defn ^{:stratum 1} update-episode
   "Update a decision episode from checkpoint state."
   ([episode checkpoint]
    (update-episode episode checkpoint nil))
@@ -105,19 +114,19 @@
    (validate DecisionEpisode
              (core/update-episode episode checkpoint opts))))
 
-(defn create-control-plane-checkpoint
+(defn ^{:stratum 1} create-control-plane-checkpoint
   "Normalize a control-plane decision request."
   [agent-id summary opts]
   (validate DecisionCheckpoint
             (core/create-control-plane-checkpoint agent-id summary opts)))
 
-(defn create-loop-escalation-checkpoint
+(defn ^{:stratum 1} create-loop-escalation-checkpoint
   "Normalize an inner-loop escalation."
   [loop-state opts]
   (validate DecisionCheckpoint
             (core/create-loop-escalation-checkpoint loop-state opts)))
 
-(defn decision-response
+(defn ^{:stratum 1} decision-response
   "Create a structured supervision response."
   [decision-type resolution & [rationale]]
   (validate spec/DecisionResponse

--- a/components/decision/src/ai/miniforge/decision/spec.clj
+++ b/components/decision/src/ai/miniforge/decision/spec.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.decision.spec
   "Malli schemas for canonical decision checkpoints and episodes.
    Layer 0: Enums and registry
@@ -27,28 +26,39 @@
    [malli.error :as me]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Enums and registry
 
-(def source-kinds
+;; Enums and registry
+(def ^{:stratum 0} source-kinds
   [:control-plane-agent :loop-escalation :workflow-node :external-agent :policy-gate])
 
-(def authority-kinds
+(def ^{:stratum 0} authority-kinds
   [:human :system :model :rule :hybrid])
 
-(def checkpoint-statuses
+(def ^{:stratum 0} checkpoint-statuses
   [:pending :resolved :cancelled :expired])
 
-(def episode-statuses
+(def ^{:stratum 0} episode-statuses
   [:pending :resolved :completed])
 
-(def response-types
+(def ^{:stratum 0} response-types
   [:approve :approve-with-constraints :reject :choose-option
    :request-more-evidence :reroute :mark-delegable :always-escalate :defer])
 
-(def risk-tiers
+(def ^{:stratum 0} risk-tiers
   [:low :medium :high :critical])
 
-(def registry
+(defn ^{:stratum 0} valid?
+  [schema value]
+  (m/validate schema value))
+
+(defn ^{:stratum 0} explain
+  [schema value]
+  (some-> (m/explain schema value)
+          me/humanize))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} registry
   "Malli registry for decision types."
   {;; Common identifiers
    :id/uuid uuid?
@@ -63,16 +73,27 @@
    :response/type (into [:enum] response-types)
    :risk/tier (into [:enum] risk-tiers)})
 
-;------------------------------------------------------------------------------ Layer 1
-;; Canonical model
+(defn ^{:stratum 1} validate-result
+  "Return `value` when it validates against `schema`, else return an anomaly."
+  [schema value]
+  (if (valid? schema value)
+    value
+    (anomaly/anomaly :invalid-input
+                     "Decision schema validation failed"
+                     {:schema schema
+                      :value value
+                      :errors (explain schema value)})))
 
-(def Alternative
+;------------------------------------------------------------------------------ Layer 2
+
+;; Canonical model
+(def ^{:stratum 2} Alternative
   "Schema for one proposed alternative."
   [:map {:registry registry}
    [:id any?]
    [:summary :id/string]])
 
-(def DecisionSource
+(def ^{:stratum 2} DecisionSource
   "Schema for checkpoint source metadata."
   [:map {:registry registry}
    [:kind :source/kind]
@@ -81,14 +102,64 @@
    [:origin-run-id {:optional true} :id/string]
    [:loop-id {:optional true} :id/uuid]])
 
-(def DecisionTask
+(def ^{:stratum 2} DecisionTask
   "Schema for task metadata attached to a checkpoint."
   [:map {:registry registry}
    [:kind keyword?]
    [:goal {:optional true} :id/string]
    [:task-id {:optional true} :id/uuid]])
 
-(def DecisionProposal
+(def ^{:stratum 2} DecisionUncertainty
+  "Schema for uncertainty information."
+  [:map {:registry registry}
+   [:class keyword?]
+   [:reason :id/string]
+   [:agent-confidence {:optional true} [:double {:min 0.0 :max 1.0}]]])
+
+(def ^{:stratum 2} DecisionRisk
+  "Schema for risk data."
+  [:map {:registry registry}
+   [:tier :risk/tier]
+   [:critical-paths {:optional true} [:vector :id/string]]
+   [:requires-owner-review? {:optional true} boolean?]])
+
+(def ^{:stratum 2} ControlPlaneContext
+  [:map {:registry registry}
+   [:context/text {:optional true} :id/string]
+   [:context/deadline {:optional true} :common/timestamp]
+   [:context/tags {:optional true} [:set keyword?]]])
+
+(def ^{:stratum 2} LoopEscalationContext
+  [:map {:registry registry}
+   [:loop/iteration int?]
+   [:loop/state keyword?]
+   [:loop/termination [:map [:reason keyword?]]]
+   [:task/type {:optional true} keyword?]
+   [:error-count int?]])
+
+(def ^{:stratum 2} DecisionResponse
+  "Schema for the structured supervision response."
+  [:map {:registry registry}
+   [:type :response/type]
+   [:value {:optional true} any?]
+   [:constraints {:optional true} [:vector :id/string]]
+   [:rationale {:optional true} :id/string]
+   [:authority-role :authority/kind]])
+
+(defn ^{:stratum 2} validate
+  "Boundary wrapper around the canonical anomaly-returning
+   [[validate-result]]. Returns `value` on success and throws only for
+   legacy callers. Prefer `validate-result` in non-boundary code."
+  [schema value]
+  (let [result (validate-result schema value)]
+    (if (anomaly/anomaly? result)
+      (throw (ex-info (:anomaly/message result)
+                      (:anomaly/data result)))
+      result)))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(def ^{:stratum 3} DecisionProposal
   "Schema for the proposed action under judgment."
   [:map {:registry registry}
    [:action-type keyword?]
@@ -98,47 +169,12 @@
    [:files {:optional true} [:vector :id/string]]
    [:diff-summary {:optional true} :id/string]])
 
-(def DecisionUncertainty
-  "Schema for uncertainty information."
-  [:map {:registry registry}
-   [:class keyword?]
-   [:reason :id/string]
-   [:agent-confidence {:optional true} [:double {:min 0.0 :max 1.0}]]])
-
-(def DecisionRisk
-  "Schema for risk data."
-  [:map {:registry registry}
-   [:tier :risk/tier]
-   [:critical-paths {:optional true} [:vector :id/string]]
-   [:requires-owner-review? {:optional true} boolean?]])
-
-(def ControlPlaneContext
-  [:map {:registry registry}
-   [:context/text {:optional true} :id/string]
-   [:context/deadline {:optional true} :common/timestamp]
-   [:context/tags {:optional true} [:set keyword?]]])
-
-(def LoopEscalationContext
-  [:map {:registry registry}
-   [:loop/iteration int?]
-   [:loop/state keyword?]
-   [:loop/termination [:map [:reason keyword?]]]
-   [:task/type {:optional true} keyword?]
-   [:error-count int?]])
-
-(def DecisionContext
+(def ^{:stratum 3} DecisionContext
   [:or ControlPlaneContext LoopEscalationContext])
 
-(def DecisionResponse
-  "Schema for the structured supervision response."
-  [:map {:registry registry}
-   [:type :response/type]
-   [:value {:optional true} any?]
-   [:constraints {:optional true} [:vector :id/string]]
-   [:rationale {:optional true} :id/string]
-   [:authority-role :authority/kind]])
+;------------------------------------------------------------------------------ Layer 4
 
-(def DecisionCheckpoint
+(def ^{:stratum 4} DecisionCheckpoint
   [:map {:registry registry}
    [:checkpoint/id :id/uuid]
    [:checkpoint/status :checkpoint/status]
@@ -153,7 +189,9 @@
    [:context {:optional true} DecisionContext]
    [:response {:optional true} DecisionResponse]])
 
-(def DecisionEpisode
+;------------------------------------------------------------------------------ Layer 5
+
+(def ^{:stratum 5} DecisionEpisode
   "Normalized decision episode. The first implementation captures
    pending and resolved episodes before downstream outcome mining."
   [:map {:registry registry}
@@ -179,34 +217,3 @@
                           :summary "Choose one"}})
 
   :leave-this-here)
-
-(defn valid?
-  [schema value]
-  (m/validate schema value))
-
-(defn explain
-  [schema value]
-  (some-> (m/explain schema value)
-          me/humanize))
-
-(defn validate-result
-  "Return `value` when it validates against `schema`, else return an anomaly."
-  [schema value]
-  (if (valid? schema value)
-    value
-    (anomaly/anomaly :invalid-input
-                     "Decision schema validation failed"
-                     {:schema schema
-                      :value value
-                      :errors (explain schema value)})))
-
-(defn validate
-  "Boundary wrapper around the canonical anomaly-returning
-   [[validate-result]]. Returns `value` on success and throws only for
-   legacy callers. Prefer `validate-result` in non-boundary code."
-  [schema value]
-  (let [result (validate-result schema value)]
-    (if (anomaly/anomaly? result)
-      (throw (ex-info (:anomaly/message result)
-                      (:anomaly/data result)))
-      result)))

--- a/components/decision/test/ai/miniforge/decision/interface_test.clj
+++ b/components/decision/test/ai/miniforge/decision/interface_test.clj
@@ -221,8 +221,9 @@
     (is (thrown? clojure.lang.ExceptionInfo
                  (decision/create-checkpoint {}))))
   (testing "decision-response throws when authority-role somehow becomes invalid.
-            (Pure-fn path doesn't normally produce this; we exercise via spec/validate
-            directly to confirm the schema contract is enforced.)"
+            (Pure-fn path doesn't normally produce this; we exercise via
+            decision/validate, which delegates to spec/validate, to confirm
+            the schema contract is enforced.)"
     (is (thrown? clojure.lang.ExceptionInfo
                  (decision/validate spec/DecisionResponse
                                     {:type :approve :authority-role :alien})))))

--- a/components/decision/test/ai/miniforge/decision/interface_test.clj
+++ b/components/decision/test/ai/miniforge/decision/interface_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.decision.interface-test
   (:require
    [ai.miniforge.anomaly.interface :as anomaly]
@@ -24,9 +23,9 @@
    [ai.miniforge.decision.spec :as spec]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Test fixtures and factories
 
-(defn- valid-control-plane-checkpoint
+;; Test fixtures and factories
+(defn- ^{:stratum 0} valid-control-plane-checkpoint
   "Build a minimal valid control-plane checkpoint for use as a baseline."
   [& {:as overrides}]
   (decision/create-control-plane-checkpoint
@@ -37,14 +36,14 @@
            :options ["yes" "no"]}
           overrides)))
 
-(defn- valid-approve-response
+(defn- ^{:stratum 0} valid-approve-response
   [& {:as overrides}]
   (merge {:type :approve
           :value "yes"
           :authority-role :human}
          overrides))
 
-(defn- loop-state
+(defn- ^{:stratum 0} loop-state
   "Build a loop-state map for create-loop-escalation-checkpoint."
   [& {:as overrides}]
   (merge {:loop/id          (random-uuid)
@@ -56,10 +55,8 @@
           :loop/termination {:reason :max-iterations}}
          overrides))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Enum exposure and stability
-
-(deftest enum-lists-are-stable-and-complete-test
+(deftest ^{:stratum 0} enum-lists-are-stable-and-complete-test
   (testing "Each enum list contains the documented values"
     (is (= #{:control-plane-agent :loop-escalation :workflow-node
              :external-agent :policy-gate}
@@ -77,7 +74,7 @@
     (is (= #{:low :medium :high :critical}
            (set decision/risk-tiers)))))
 
-(deftest schema-vars-re-exported-test
+(deftest ^{:stratum 0} schema-vars-re-exported-test
   (testing "interface re-exports schemas point at the spec namespace"
     (is (= spec/DecisionCheckpoint     decision/DecisionCheckpoint))
     (is (= spec/DecisionEpisode        decision/DecisionEpisode))
@@ -85,44 +82,8 @@
     (is (= spec/LoopEscalationContext  decision/LoopEscalationContext))
     (is (= spec/DecisionContext        decision/DecisionContext))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Validation helpers (valid? / explain / validate)
-
-(deftest valid?-returns-bool-test
-  (testing "valid? returns true for conforming values"
-    (let [cp (valid-control-plane-checkpoint)]
-      (is (true? (decision/valid? decision/DecisionCheckpoint cp)))))
-  (testing "valid? returns false for non-conforming values"
-    (is (false? (decision/valid? decision/DecisionCheckpoint {})))
-    (is (false? (decision/valid? decision/DecisionCheckpoint {:checkpoint/id "not-a-uuid"})))))
-
-(deftest explain-humanizes-errors-test
-  (testing "explain returns nil when the value validates"
-    (is (nil? (decision/explain decision/DecisionCheckpoint
-                                (valid-control-plane-checkpoint)))))
-  (testing "explain returns a non-nil structure when the value fails"
-    (let [errs (decision/explain decision/DecisionCheckpoint {})]
-      (is (some? errs)))))
-
-(deftest validate-returns-value-or-throws-test
-  (testing "validate returns the value when it conforms"
-    (let [cp (valid-control-plane-checkpoint)]
-      (is (= cp (decision/validate decision/DecisionCheckpoint cp)))))
-  (testing "validate throws ex-info carrying :schema, :value, :errors"
-    (let [thrown (try
-                   (decision/validate decision/DecisionCheckpoint {:bogus 1})
-                   ::no-throw
-                   (catch clojure.lang.ExceptionInfo e e))]
-      (is (instance? clojure.lang.ExceptionInfo thrown))
-      (let [data (ex-data thrown)]
-        (is (contains? data :schema))
-        (is (contains? data :value))
-        (is (some? (:errors data)))))))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; create-checkpoint defaults
-
-(deftest create-checkpoint-fills-defaults-test
+(deftest ^{:stratum 0} create-checkpoint-fills-defaults-test
   (testing "Missing id/status/created-at/requested-authority get sensible defaults"
     (let [cp (decision/create-checkpoint
               {:source   {:kind :control-plane-agent}
@@ -134,27 +95,7 @@
       (is (inst?  (:checkpoint/created-at cp)))
       (is (= :human (:checkpoint/requested-authority cp))))))
 
-(deftest create-checkpoint-respects-explicit-fields-test
-  (testing "Explicit checkpoint-id, status, created-at, requested-authority are preserved"
-    (let [id  (random-uuid)
-          ts  (java.util.Date. 1700000000000)
-          cp  (decision/create-checkpoint
-               {:checkpoint-id          id
-                :status                 :resolved
-                :created-at             ts
-                :requested-authority    :rule
-                :source                 {:kind :policy-gate}
-                :proposal               {:action-type    :auto-approve
-                                         :decision-class :approval
-                                         :summary        "Auto approval"}
-                :response               (valid-approve-response :authority-role :rule)})]
-      (is (= id (:checkpoint/id cp)))
-      (is (= :resolved (:checkpoint/status cp)))
-      (is (= ts (:checkpoint/created-at cp)))
-      (is (= :rule (:checkpoint/requested-authority cp)))
-      (is (some? (:response cp))))))
-
-(deftest create-checkpoint-omits-optional-keys-when-absent-test
+(deftest ^{:stratum 0} create-checkpoint-omits-optional-keys-when-absent-test
   (testing "task/uncertainty/risk/context/response are omitted (not nil) when not supplied"
     (let [cp (decision/create-checkpoint
               {:source   {:kind :control-plane-agent}
@@ -167,68 +108,36 @@
       (is (not (contains? cp :context)))
       (is (not (contains? cp :response))))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; resolve-checkpoint
-
-(deftest resolve-checkpoint-marks-resolved-and-stamps-time-test
-  (testing "resolve-checkpoint sets :checkpoint/status :resolved and adds :resolved-at"
-    (let [cp        (valid-control-plane-checkpoint)
-          before-ms (System/currentTimeMillis)
-          resolved  (decision/resolve-checkpoint cp (valid-approve-response))]
-      (is (= :resolved (:checkpoint/status resolved)))
-      (is (inst? (:checkpoint/resolved-at resolved)))
-      (is (>= (.getTime ^java.util.Date (:checkpoint/resolved-at resolved))
-              before-ms)))))
-
-(deftest resolve-checkpoint-attaches-response-test
-  (testing "resolve-checkpoint stores the supervision response"
-    (let [cp       (valid-control-plane-checkpoint)
-          response (valid-approve-response :rationale "looks good")
-          resolved (decision/resolve-checkpoint cp response)]
-      (is (= response (:response resolved))))))
-
-(deftest resolve-checkpoint-preserves-other-fields-test
-  (testing "resolve-checkpoint does not mutate id, source, proposal"
-    (let [cp       (valid-control-plane-checkpoint)
-          resolved (decision/resolve-checkpoint cp (valid-approve-response))]
-      (is (= (:checkpoint/id cp) (:checkpoint/id resolved)))
-      (is (= (:source cp)        (:source resolved)))
-      (is (= (:proposal cp)      (:proposal resolved))))))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; decision-response
-
-(deftest decision-response-known-types-test
+(deftest ^{:stratum 0} decision-response-known-types-test
   (testing "decision-response maps each known decision type to a response type"
     (is (= :approve            (:type (decision/decision-response :approval     "ok"))))
     (is (= :choose-option      (:type (decision/decision-response :choice       "rebase"))))
     (is (= :approve-with-constraints (:type (decision/decision-response :input  "with-tests"))))
     (is (= :approve            (:type (decision/decision-response :confirmation "yes"))))))
 
-(deftest decision-response-unknown-type-defaults-to-approve-test
+(deftest ^{:stratum 0} decision-response-unknown-type-defaults-to-approve-test
   (testing "decision-response falls back to :approve for an unknown decision-type"
     (is (= :approve (:type (decision/decision-response :totally-unknown "yes"))))))
 
-(deftest decision-response-attaches-rationale-when-given-test
+(deftest ^{:stratum 0} decision-response-attaches-rationale-when-given-test
   (testing "decision-response includes :rationale only when supplied"
     (is (not (contains? (decision/decision-response :approval "yes") :rationale)))
     (let [r (decision/decision-response :approval "yes" "smoke tested")]
       (is (= "smoke tested" (:rationale r))))))
 
-(deftest decision-response-always-tags-authority-role-human-test
+(deftest ^{:stratum 0} decision-response-always-tags-authority-role-human-test
   (testing "decision-response defaults :authority-role to :human"
     (is (= :human (:authority-role (decision/decision-response :approval "yes"))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; create-control-plane-checkpoint — option matrix
-
-(deftest cp-checkpoint-omits-alternatives-when-no-options-test
+(deftest ^{:stratum 0} cp-checkpoint-omits-alternatives-when-no-options-test
   (testing "No :options ⇒ no :alternatives key in the proposal"
     (let [cp (decision/create-control-plane-checkpoint
               (random-uuid) "Just confirm" {:type :confirmation})]
       (is (not (contains? (:proposal cp) :alternatives))))))
 
-(deftest cp-checkpoint-builds-alternatives-from-options-test
+(deftest ^{:stratum 0} cp-checkpoint-builds-alternatives-from-options-test
   (testing "Options are normalized into indexed alternatives"
     (let [cp (decision/create-control-plane-checkpoint
               (random-uuid) "Pick one"
@@ -238,7 +147,7 @@
       (is (= [0 1 2] (mapv :id alts)))
       (is (= ["squash" "rebase" "merge-commit"] (mapv :summary alts))))))
 
-(deftest cp-checkpoint-priority-maps-to-risk-tier-test
+(deftest ^{:stratum 0} cp-checkpoint-priority-maps-to-risk-tier-test
   (testing "Each priority maps to its same-named risk tier; default is :medium"
     (is (= :critical (-> (decision/create-control-plane-checkpoint
                           (random-uuid) "x" {:type :approval :priority :critical})
@@ -256,7 +165,7 @@
                           (random-uuid) "x" {:type :approval})
                          :risk :tier)))))
 
-(deftest cp-checkpoint-decision-class-from-type-test
+(deftest ^{:stratum 0} cp-checkpoint-decision-class-from-type-test
   (testing "Each decision type maps to its decision-class; unknown defaults to :implementation-pattern-choice"
     (is (= :approval                    (-> (decision/create-control-plane-checkpoint
                                              (random-uuid) "x" {:type :approval})
@@ -276,7 +185,7 @@
                                              (random-uuid) "x" {:type :weird-type})
                                             :proposal :decision-class)))))
 
-(deftest cp-checkpoint-uncertainty-includes-confidence-when-given-test
+(deftest ^{:stratum 0} cp-checkpoint-uncertainty-includes-confidence-when-given-test
   (testing "agent-confidence is attached only when supplied"
     (let [without (decision/create-control-plane-checkpoint
                    (random-uuid) "x" {:type :approval})
@@ -287,7 +196,7 @@
       (is (not (contains? (:uncertainty without) :agent-confidence)))
       (is (= 0.42 (-> with :uncertainty :agent-confidence))))))
 
-(deftest cp-checkpoint-context-conditional-keys-test
+(deftest ^{:stratum 0} cp-checkpoint-context-conditional-keys-test
   (testing "Context omits unset keys but populates supplied ones"
     (let [empty-ctx (-> (decision/create-control-plane-checkpoint
                          (random-uuid) "x" {:type :approval})
@@ -305,175 +214,8 @@
       (is (= deadline             (:context/deadline full-ctx)))
       (is (= #{:urgent :prod}    (:context/tags    full-ctx))))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; create-loop-escalation-checkpoint
-
-(deftest loop-escalation-default-summary-test
-  (testing "Without :summary opt, the escalation summary is auto-generated from
-            the loop iteration count and task type"
-    (let [cp (decision/create-loop-escalation-checkpoint (loop-state) {})
-          summary (-> cp :proposal :summary)]
-      (is (re-find #"Loop escalation after 4 attempt"          summary))
-      (is (re-find #"implement"                                 summary)))))
-
-(deftest loop-escalation-explicit-summary-overrides-default-test
-  (testing "Explicit :summary opt is preserved verbatim"
-    (let [cp (decision/create-loop-escalation-checkpoint
-              (loop-state)
-              {:summary "Custom summary text"})]
-      (is (= "Custom summary text" (-> cp :proposal :summary))))))
-
-(deftest loop-escalation-task-includes-task-id-test
-  (testing "Task block carries kind :loop-escalation and the task-id"
-    (let [task-id (random-uuid)
-          cp (decision/create-loop-escalation-checkpoint
-              (loop-state :loop/task {:task/id task-id :task/type :review})
-              {})]
-      (is (= :loop-escalation (-> cp :task :kind)))
-      (is (= task-id          (-> cp :task :task-id))))))
-
-(deftest loop-escalation-task-without-id-omits-key-test
-  (testing "Loop with no task-id produces a task block without :task-id"
-    (let [cp (decision/create-loop-escalation-checkpoint
-              (loop-state :loop/task {:task/type :implement})
-              {})]
-      (is (= :loop-escalation (-> cp :task :kind)))
-      (is (not (contains? (:task cp) :task-id))))))
-
-(deftest loop-escalation-includes-artifact-files-and-diff-test
-  (testing "Artifact path becomes :files; content (truncated to 160 chars) becomes :diff-summary"
-    (let [content (apply str (repeat 200 \a))
-          cp (decision/create-loop-escalation-checkpoint
-              (loop-state :loop/artifact {:artifact/path    "src/foo.clj"
-                                          :artifact/content content})
-              {})
-          proposal (:proposal cp)]
-      (is (= ["src/foo.clj"] (:files proposal)))
-      (is (= 160 (count (:diff-summary proposal)))))))
-
-(deftest loop-escalation-no-artifact-omits-files-and-diff-test
-  (testing "Without an artifact, :files and :diff-summary are absent"
-    (let [cp (decision/create-loop-escalation-checkpoint (loop-state) {})
-          proposal (:proposal cp)]
-      (is (not (contains? proposal :files)))
-      (is (not (contains? proposal :diff-summary))))))
-
-(deftest loop-escalation-uncertainty-summarizes-errors-test
-  (testing "Uncertainty reason is the joined first two error messages, taken from
-            either :anomaly/message or :message"
-    (let [errors [{:message "first"}
-                  {:anomaly {:anomaly/message "second"}}
-                  {:message "third"}]
-          cp (decision/create-loop-escalation-checkpoint
-              (loop-state :loop/errors errors)
-              {})]
-      (is (= :validation-failure (-> cp :uncertainty :class)))
-      (is (= "first; second" (-> cp :uncertainty :reason))))))
-
-(deftest loop-escalation-uncertainty-empty-errors-fallback-test
-  (testing "With no parseable errors, the reason falls back to a default string"
-    (let [cp (decision/create-loop-escalation-checkpoint
-              (loop-state :loop/errors [])
-              {})]
-      (is (= "Loop exhausted repair budget without convergence."
-             (-> cp :uncertainty :reason))))))
-
-(deftest loop-escalation-risk-tier-default-and-override-test
-  (testing "Default risk tier is :medium; overridable via opts"
-    (is (= :medium   (-> (decision/create-loop-escalation-checkpoint (loop-state) {})
-                         :risk :tier)))
-    (is (= :critical (-> (decision/create-loop-escalation-checkpoint
-                          (loop-state) {:risk-tier :critical})
-                         :risk :tier)))))
-
-(deftest loop-escalation-context-projects-loop-fields-test
-  (testing "Context surfaces iteration, state, termination, task type, and error count"
-    (let [errors [{:message "a"} {:message "b"} {:message "c"}]
-          ls     (loop-state :loop/errors errors :loop/iteration 7)
-          cp     (decision/create-loop-escalation-checkpoint ls {})
-          ctx    (:context cp)]
-      (is (= 7              (:loop/iteration ctx)))
-      (is (= :escalated     (:loop/state     ctx)))
-      (is (= {:reason :max-iterations} (:loop/termination ctx)))
-      (is (= :implement     (:task/type      ctx)))
-      (is (= 3              (:error-count    ctx))))))
-
-;------------------------------------------------------------------------------ Layer 1
-;; create-episode / update-episode
-
-(deftest create-episode-status-mirrors-checkpoint-test
-  (testing "Pending checkpoint ⇒ :pending episode; resolved ⇒ :resolved"
-    (let [pending  (valid-control-plane-checkpoint)
-          resolved (decision/resolve-checkpoint pending (valid-approve-response))
-          ep1      (decision/create-episode pending)
-          ep2      (decision/create-episode resolved)]
-      (is (= :pending  (:episode/status ep1)))
-      (is (= :resolved (:episode/status ep2))))))
-
-(deftest create-episode-attaches-supervision-when-checkpoint-resolved-test
-  (testing "When the checkpoint already carries :response, episode :supervision is set"
-    (let [resolved (decision/resolve-checkpoint
-                    (valid-control-plane-checkpoint)
-                    (valid-approve-response :rationale "ok"))
-          ep       (decision/create-episode resolved)]
-      (is (some? (:supervision ep)))
-      (is (= "ok" (-> ep :supervision :rationale))))))
-
-(deftest create-episode-fresh-fields-test
-  (testing "create-episode fills :episode/id (UUID), :created-at = :updated-at (inst)"
-    (let [ep (decision/create-episode (valid-control-plane-checkpoint))]
-      (is (uuid? (:episode/id ep)))
-      (is (inst? (:episode/created-at ep)))
-      (is (inst? (:episode/updated-at ep)))
-      (is (= (:episode/created-at ep) (:episode/updated-at ep))))))
-
-(deftest update-episode-on-resolve-marks-resolved-test
-  (testing "Updating with a resolved checkpoint flips status to :resolved"
-    (let [cp       (valid-control-plane-checkpoint)
-          ep       (decision/create-episode cp)
-          resolved (decision/resolve-checkpoint cp (valid-approve-response))
-          updated  (decision/update-episode ep resolved)]
-      (is (= :resolved (:episode/status updated)))
-      (is (= :approve  (-> updated :supervision :type))))))
-
-(deftest update-episode-with-downstream-outcome-marks-completed-test
-  (testing "Supplying :downstream-outcome forces episode status :completed
-            even when the checkpoint is still :pending"
-    (let [cp      (valid-control-plane-checkpoint)
-          ep      (decision/create-episode cp)
-          updated (decision/update-episode ep cp
-                                           {:downstream-outcome
-                                            {:result :merged
-                                             :timestamp (java.util.Date.)}})]
-      (is (= :completed (:episode/status updated)))
-      (is (= :merged   (-> updated :downstream-outcome :result))))))
-
-(deftest update-episode-attaches-execution-result-when-given-test
-  (testing "execution-result opt is stored on the episode"
-    (let [cp      (valid-control-plane-checkpoint)
-          ep      (decision/create-episode cp)
-          updated (decision/update-episode ep cp
-                                           {:execution-result
-                                            {:exit-code 0 :duration-ms 1234}})]
-      (is (= 0    (-> updated :execution-result :exit-code)))
-      (is (= 1234 (-> updated :execution-result :duration-ms))))))
-
-(deftest update-episode-bumps-updated-at-test
-  (testing "update-episode advances :episode/updated-at past the original :created-at"
-    (let [cp       (valid-control-plane-checkpoint)
-          ep       (-> (decision/create-episode cp)
-                       (assoc :episode/created-at
-                              (java.util.Date. (- (System/currentTimeMillis) 1000))
-                              :episode/updated-at
-                              (java.util.Date. (- (System/currentTimeMillis) 1000))))
-          updated  (decision/update-episode ep cp)]
-      (is (.after ^java.util.Date (:episode/updated-at updated)
-                  ^java.util.Date (:episode/updated-at ep))))))
-
-;------------------------------------------------------------------------------ Layer 2
 ;; Schema validation through the public constructors
-
-(deftest constructors-throw-on-malformed-input-test
+(deftest ^{:stratum 0} constructors-throw-on-malformed-input-test
   (testing "create-checkpoint throws when the produced map fails schema validation"
     ;; Empty map produces a checkpoint missing :source / :proposal.
     (is (thrown? clojure.lang.ExceptionInfo
@@ -485,7 +227,7 @@
                  (decision/validate spec/DecisionResponse
                                     {:type :approve :authority-role :alien})))))
 
-(deftest validate-result-returns-anomaly-on-malformed-input-test
+(deftest ^{:stratum 0} validate-result-returns-anomaly-on-malformed-input-test
   (testing "validate-result returns a typed anomaly instead of throwing"
     (let [result (decision/validate-result
                   spec/DecisionResponse
@@ -495,19 +237,260 @@
       (is (contains? (get-in result [:anomaly/data :errors])
                      :authority-role)))))
 
-(deftest validate-result-returns-value-on-valid-input-test
+;------------------------------------------------------------------------------ Layer 1
+
+;; Validation helpers (valid? / explain / validate)
+(deftest ^{:stratum 1} valid?-returns-bool-test
+  (testing "valid? returns true for conforming values"
+    (let [cp (valid-control-plane-checkpoint)]
+      (is (true? (decision/valid? decision/DecisionCheckpoint cp)))))
+  (testing "valid? returns false for non-conforming values"
+    (is (false? (decision/valid? decision/DecisionCheckpoint {})))
+    (is (false? (decision/valid? decision/DecisionCheckpoint {:checkpoint/id "not-a-uuid"})))))
+
+(deftest ^{:stratum 1} explain-humanizes-errors-test
+  (testing "explain returns nil when the value validates"
+    (is (nil? (decision/explain decision/DecisionCheckpoint
+                                (valid-control-plane-checkpoint)))))
+  (testing "explain returns a non-nil structure when the value fails"
+    (let [errs (decision/explain decision/DecisionCheckpoint {})]
+      (is (some? errs)))))
+
+(deftest ^{:stratum 1} validate-returns-value-or-throws-test
+  (testing "validate returns the value when it conforms"
+    (let [cp (valid-control-plane-checkpoint)]
+      (is (= cp (decision/validate decision/DecisionCheckpoint cp)))))
+  (testing "validate throws ex-info carrying :schema, :value, :errors"
+    (let [thrown (try
+                   (decision/validate decision/DecisionCheckpoint {:bogus 1})
+                   ::no-throw
+                   (catch clojure.lang.ExceptionInfo e e))]
+      (is (instance? clojure.lang.ExceptionInfo thrown))
+      (let [data (ex-data thrown)]
+        (is (contains? data :schema))
+        (is (contains? data :value))
+        (is (some? (:errors data)))))))
+
+(deftest ^{:stratum 1} create-checkpoint-respects-explicit-fields-test
+  (testing "Explicit checkpoint-id, status, created-at, requested-authority are preserved"
+    (let [id  (random-uuid)
+          ts  (java.util.Date. 1700000000000)
+          cp  (decision/create-checkpoint
+               {:checkpoint-id          id
+                :status                 :resolved
+                :created-at             ts
+                :requested-authority    :rule
+                :source                 {:kind :policy-gate}
+                :proposal               {:action-type    :auto-approve
+                                         :decision-class :approval
+                                         :summary        "Auto approval"}
+                :response               (valid-approve-response :authority-role :rule)})]
+      (is (= id (:checkpoint/id cp)))
+      (is (= :resolved (:checkpoint/status cp)))
+      (is (= ts (:checkpoint/created-at cp)))
+      (is (= :rule (:checkpoint/requested-authority cp)))
+      (is (some? (:response cp))))))
+
+;; resolve-checkpoint
+(deftest ^{:stratum 1} resolve-checkpoint-marks-resolved-and-stamps-time-test
+  (testing "resolve-checkpoint sets :checkpoint/status :resolved and adds :resolved-at"
+    (let [cp        (valid-control-plane-checkpoint)
+          before-ms (System/currentTimeMillis)
+          resolved  (decision/resolve-checkpoint cp (valid-approve-response))]
+      (is (= :resolved (:checkpoint/status resolved)))
+      (is (inst? (:checkpoint/resolved-at resolved)))
+      (is (>= (.getTime ^java.util.Date (:checkpoint/resolved-at resolved))
+              before-ms)))))
+
+(deftest ^{:stratum 1} resolve-checkpoint-attaches-response-test
+  (testing "resolve-checkpoint stores the supervision response"
+    (let [cp       (valid-control-plane-checkpoint)
+          response (valid-approve-response :rationale "looks good")
+          resolved (decision/resolve-checkpoint cp response)]
+      (is (= response (:response resolved))))))
+
+(deftest ^{:stratum 1} resolve-checkpoint-preserves-other-fields-test
+  (testing "resolve-checkpoint does not mutate id, source, proposal"
+    (let [cp       (valid-control-plane-checkpoint)
+          resolved (decision/resolve-checkpoint cp (valid-approve-response))]
+      (is (= (:checkpoint/id cp) (:checkpoint/id resolved)))
+      (is (= (:source cp)        (:source resolved)))
+      (is (= (:proposal cp)      (:proposal resolved))))))
+
+;; create-loop-escalation-checkpoint
+(deftest ^{:stratum 1} loop-escalation-default-summary-test
+  (testing "Without :summary opt, the escalation summary is auto-generated from
+            the loop iteration count and task type"
+    (let [cp (decision/create-loop-escalation-checkpoint (loop-state) {})
+          summary (-> cp :proposal :summary)]
+      (is (re-find #"Loop escalation after 4 attempt"          summary))
+      (is (re-find #"implement"                                 summary)))))
+
+(deftest ^{:stratum 1} loop-escalation-explicit-summary-overrides-default-test
+  (testing "Explicit :summary opt is preserved verbatim"
+    (let [cp (decision/create-loop-escalation-checkpoint
+              (loop-state)
+              {:summary "Custom summary text"})]
+      (is (= "Custom summary text" (-> cp :proposal :summary))))))
+
+(deftest ^{:stratum 1} loop-escalation-task-includes-task-id-test
+  (testing "Task block carries kind :loop-escalation and the task-id"
+    (let [task-id (random-uuid)
+          cp (decision/create-loop-escalation-checkpoint
+              (loop-state :loop/task {:task/id task-id :task/type :review})
+              {})]
+      (is (= :loop-escalation (-> cp :task :kind)))
+      (is (= task-id          (-> cp :task :task-id))))))
+
+(deftest ^{:stratum 1} loop-escalation-task-without-id-omits-key-test
+  (testing "Loop with no task-id produces a task block without :task-id"
+    (let [cp (decision/create-loop-escalation-checkpoint
+              (loop-state :loop/task {:task/type :implement})
+              {})]
+      (is (= :loop-escalation (-> cp :task :kind)))
+      (is (not (contains? (:task cp) :task-id))))))
+
+(deftest ^{:stratum 1} loop-escalation-includes-artifact-files-and-diff-test
+  (testing "Artifact path becomes :files; content (truncated to 160 chars) becomes :diff-summary"
+    (let [content (apply str (repeat 200 \a))
+          cp (decision/create-loop-escalation-checkpoint
+              (loop-state :loop/artifact {:artifact/path    "src/foo.clj"
+                                          :artifact/content content})
+              {})
+          proposal (:proposal cp)]
+      (is (= ["src/foo.clj"] (:files proposal)))
+      (is (= 160 (count (:diff-summary proposal)))))))
+
+(deftest ^{:stratum 1} loop-escalation-no-artifact-omits-files-and-diff-test
+  (testing "Without an artifact, :files and :diff-summary are absent"
+    (let [cp (decision/create-loop-escalation-checkpoint (loop-state) {})
+          proposal (:proposal cp)]
+      (is (not (contains? proposal :files)))
+      (is (not (contains? proposal :diff-summary))))))
+
+(deftest ^{:stratum 1} loop-escalation-uncertainty-summarizes-errors-test
+  (testing "Uncertainty reason is the joined first two error messages, taken from
+            either :anomaly/message or :message"
+    (let [errors [{:message "first"}
+                  {:anomaly {:anomaly/message "second"}}
+                  {:message "third"}]
+          cp (decision/create-loop-escalation-checkpoint
+              (loop-state :loop/errors errors)
+              {})]
+      (is (= :validation-failure (-> cp :uncertainty :class)))
+      (is (= "first; second" (-> cp :uncertainty :reason))))))
+
+(deftest ^{:stratum 1} loop-escalation-uncertainty-empty-errors-fallback-test
+  (testing "With no parseable errors, the reason falls back to a default string"
+    (let [cp (decision/create-loop-escalation-checkpoint
+              (loop-state :loop/errors [])
+              {})]
+      (is (= "Loop exhausted repair budget without convergence."
+             (-> cp :uncertainty :reason))))))
+
+(deftest ^{:stratum 1} loop-escalation-risk-tier-default-and-override-test
+  (testing "Default risk tier is :medium; overridable via opts"
+    (is (= :medium   (-> (decision/create-loop-escalation-checkpoint (loop-state) {})
+                         :risk :tier)))
+    (is (= :critical (-> (decision/create-loop-escalation-checkpoint
+                          (loop-state) {:risk-tier :critical})
+                         :risk :tier)))))
+
+(deftest ^{:stratum 1} loop-escalation-context-projects-loop-fields-test
+  (testing "Context surfaces iteration, state, termination, task type, and error count"
+    (let [errors [{:message "a"} {:message "b"} {:message "c"}]
+          ls     (loop-state :loop/errors errors :loop/iteration 7)
+          cp     (decision/create-loop-escalation-checkpoint ls {})
+          ctx    (:context cp)]
+      (is (= 7              (:loop/iteration ctx)))
+      (is (= :escalated     (:loop/state     ctx)))
+      (is (= {:reason :max-iterations} (:loop/termination ctx)))
+      (is (= :implement     (:task/type      ctx)))
+      (is (= 3              (:error-count    ctx))))))
+
+;; create-episode / update-episode
+(deftest ^{:stratum 1} create-episode-status-mirrors-checkpoint-test
+  (testing "Pending checkpoint ⇒ :pending episode; resolved ⇒ :resolved"
+    (let [pending  (valid-control-plane-checkpoint)
+          resolved (decision/resolve-checkpoint pending (valid-approve-response))
+          ep1      (decision/create-episode pending)
+          ep2      (decision/create-episode resolved)]
+      (is (= :pending  (:episode/status ep1)))
+      (is (= :resolved (:episode/status ep2))))))
+
+(deftest ^{:stratum 1} create-episode-attaches-supervision-when-checkpoint-resolved-test
+  (testing "When the checkpoint already carries :response, episode :supervision is set"
+    (let [resolved (decision/resolve-checkpoint
+                    (valid-control-plane-checkpoint)
+                    (valid-approve-response :rationale "ok"))
+          ep       (decision/create-episode resolved)]
+      (is (some? (:supervision ep)))
+      (is (= "ok" (-> ep :supervision :rationale))))))
+
+(deftest ^{:stratum 1} create-episode-fresh-fields-test
+  (testing "create-episode fills :episode/id (UUID), :created-at = :updated-at (inst)"
+    (let [ep (decision/create-episode (valid-control-plane-checkpoint))]
+      (is (uuid? (:episode/id ep)))
+      (is (inst? (:episode/created-at ep)))
+      (is (inst? (:episode/updated-at ep)))
+      (is (= (:episode/created-at ep) (:episode/updated-at ep))))))
+
+(deftest ^{:stratum 1} update-episode-on-resolve-marks-resolved-test
+  (testing "Updating with a resolved checkpoint flips status to :resolved"
+    (let [cp       (valid-control-plane-checkpoint)
+          ep       (decision/create-episode cp)
+          resolved (decision/resolve-checkpoint cp (valid-approve-response))
+          updated  (decision/update-episode ep resolved)]
+      (is (= :resolved (:episode/status updated)))
+      (is (= :approve  (-> updated :supervision :type))))))
+
+(deftest ^{:stratum 1} update-episode-with-downstream-outcome-marks-completed-test
+  (testing "Supplying :downstream-outcome forces episode status :completed
+            even when the checkpoint is still :pending"
+    (let [cp      (valid-control-plane-checkpoint)
+          ep      (decision/create-episode cp)
+          updated (decision/update-episode ep cp
+                                           {:downstream-outcome
+                                            {:result :merged
+                                             :timestamp (java.util.Date.)}})]
+      (is (= :completed (:episode/status updated)))
+      (is (= :merged   (-> updated :downstream-outcome :result))))))
+
+(deftest ^{:stratum 1} update-episode-attaches-execution-result-when-given-test
+  (testing "execution-result opt is stored on the episode"
+    (let [cp      (valid-control-plane-checkpoint)
+          ep      (decision/create-episode cp)
+          updated (decision/update-episode ep cp
+                                           {:execution-result
+                                            {:exit-code 0 :duration-ms 1234}})]
+      (is (= 0    (-> updated :execution-result :exit-code)))
+      (is (= 1234 (-> updated :execution-result :duration-ms))))))
+
+(deftest ^{:stratum 1} update-episode-bumps-updated-at-test
+  (testing "update-episode advances :episode/updated-at past the original :created-at"
+    (let [cp       (valid-control-plane-checkpoint)
+          ep       (-> (decision/create-episode cp)
+                       (assoc :episode/created-at
+                              (java.util.Date. (- (System/currentTimeMillis) 1000))
+                              :episode/updated-at
+                              (java.util.Date. (- (System/currentTimeMillis) 1000))))
+          updated  (decision/update-episode ep cp)]
+      (is (.after ^java.util.Date (:episode/updated-at updated)
+                  ^java.util.Date (:episode/updated-at ep))))))
+
+(deftest ^{:stratum 1} validate-result-returns-value-on-valid-input-test
   (testing "validate-result returns the original valid value"
     (let [response (valid-approve-response)]
       (is (= response (decision/validate-result spec/DecisionResponse response))))))
 
-(deftest constructed-checkpoints-conform-to-schema-test
+(deftest ^{:stratum 1} constructed-checkpoints-conform-to-schema-test
   (testing "Each happy-path constructor produces a value that satisfies DecisionCheckpoint"
     (is (decision/valid? decision/DecisionCheckpoint
                          (valid-control-plane-checkpoint)))
     (is (decision/valid? decision/DecisionCheckpoint
                          (decision/create-loop-escalation-checkpoint (loop-state) {})))))
 
-(deftest constructed-episode-conforms-to-schema-test
+(deftest ^{:stratum 1} constructed-episode-conforms-to-schema-test
   (testing "create-episode produces a value satisfying DecisionEpisode"
     (let [ep (decision/create-episode (valid-control-plane-checkpoint))]
       (is (decision/valid? decision/DecisionEpisode ep)))))

--- a/docs/pull-requests/2026-07-24-fix-stratum-lint-wave1-decision.md
+++ b/docs/pull-requests/2026-07-24-fix-stratum-lint-wave1-decision.md
@@ -75,7 +75,8 @@ breaks across most of the tree rather than true strata boundaries.
   `(comment ...)` block is now genuinely the file's last form. Content of
   that block is byte-identical, only its relative position changed.
 
-No file outside `components/decision` touched.
+No component or test file outside `components/decision` touched (this
+PR doc itself is the only file outside that directory).
 
 ## Testing Plan
 

--- a/docs/pull-requests/2026-07-24-fix-stratum-lint-wave1-decision.md
+++ b/docs/pull-requests/2026-07-24-fix-stratum-lint-wave1-decision.md
@@ -31,11 +31,11 @@ breaks across most of the tree rather than true strata boundaries.
   validation helpers, `create-checkpoint`, `resolve-checkpoint`,
   loop-escalation, `create-episode`/`update-episode`, schema validation).
   `--fix` recomputed each `deftest`'s real stratum from the reference
-  graph — none of the test fns call each other except the three fixture
+  graph — none of the test fns call each other except three fixture
   helpers (`valid-control-plane-checkpoint`, `valid-approve-response`,
-  `loop-state`) that every `deftest` in the file depends on — and
-  collapsed the headings to two real layers: 0 (the fixtures) and 1 (every
-  `deftest`, all leaves relative to each other). Zero findings after.
+  `loop-state`) — and collapsed the headings to two real layers: Layer 0
+  (the fixtures, plus every `deftest` that doesn't call them — 16 tests),
+  Layer 1 (every `deftest` that does — 27 tests). Zero findings after.
 - `components/decision/src/ai/miniforge/decision/interface.clj` — zero
   pre-fix findings, but `--fix` still rewrote it: added `^{:stratum n}`
   metadata to all 24 defs, and folded a decorative `Layer 1`/`Layer 2`

--- a/docs/pull-requests/2026-07-24-fix-stratum-lint-wave1-decision.md
+++ b/docs/pull-requests/2026-07-24-fix-stratum-lint-wave1-decision.md
@@ -1,0 +1,147 @@
+# fix: stratum-lint autofix for components/decision (Wave 1)
+
+## Overview
+
+Runs the pinned `stratum-lint --fix` over all four `.clj` files in
+`components/decision` (3 src, 1 test) and commits the result. Regroups
+each file's top-level defs under `;---- Layer N` headings that match the
+tool's own same-file reference-graph inference, and adds `^{:stratum n}`
+metadata to every def. No logic changes.
+
+## Motivation
+
+Wave 1 of `work/stratum-lint-baseline-2026-07-24.md`: `decision` carried 7
+findings in the full-tree baseline, all SL002 (a `Layer 1` heading reused
+as a repeated section banner rather than one heading per real stratum) and
+zero SL001 (no upward-reference or reference-cycle risk to reason about
+first) — which is exactly why the baseline plan puts it in the first
+autofix batch, alongside `compliance-scanner`, `reliability`, `gate`, and
+`adapter-claude-code`, before the larger/riskier components. Rule 210
+(`standards/miniforge/languages/clojure.mdc`) requires headings that
+reflect a real one-way dependency DAG (Layer 0 = pure/lowest, higher
+layers may call lower/same layers only, max 3 layers/file); the baseline
+audit found this convention had been cargo-culted into decorative section
+breaks across most of the tree rather than true strata boundaries.
+
+## Changes in Detail
+
+- `components/decision/test/ai/miniforge/decision/interface_test.clj` —
+  the file carrying all 7 pre-fix findings: `Layer 1` was reused seven
+  times as a banner between unrelated `deftest` groups (enum exposure,
+  validation helpers, `create-checkpoint`, `resolve-checkpoint`,
+  loop-escalation, `create-episode`/`update-episode`, schema validation).
+  `--fix` recomputed each `deftest`'s real stratum from the reference
+  graph — none of the test fns call each other except the three fixture
+  helpers (`valid-control-plane-checkpoint`, `valid-approve-response`,
+  `loop-state`) that every `deftest` in the file depends on — and
+  collapsed the headings to two real layers: 0 (the fixtures) and 1 (every
+  `deftest`, all leaves relative to each other). Zero findings after.
+- `components/decision/src/ai/miniforge/decision/interface.clj` — zero
+  pre-fix findings, but `--fix` still rewrote it: added `^{:stratum n}`
+  metadata to all 24 defs, and folded a decorative `Layer 1`/`Layer 2`
+  split (labeled "Validation helpers" vs "Public constructors") into the
+  real 2-layer structure — Layer 0 is schema re-exports plus the
+  validation helpers (`valid?`/`explain`/`validate-result`/`validate`, all
+  pure delegation to `spec`), Layer 1 is the public constructors, which
+  call Layer 0's `validate`. Zero findings before and after.
+- `components/decision/src/ai/miniforge/decision/core.clj` — zero pre-fix
+  findings (the existing Layer 0/1/2 heading order was not itself wrong),
+  but the reference graph the tool infers is deeper than that 3-layer
+  labeling admitted: `decision-response` and two proposal/uncertainty
+  helpers, previously placed under Layer 0 next to pure value defs, are
+  called *by* the two checkpoint-constructor wrappers
+  (`create-control-plane-checkpoint`, `create-loop-escalation-checkpoint`)
+  by way of a Layer-2 input-builder — landing those wrappers at a genuine
+  Layer 3. Post-fix the file reports **SL003: 4 distinct layers (max 3)**.
+  This is a real over-budget finding, not a decorative one — needs an
+  actual namespace split, which is Wave 2 work and out of scope here.
+  Note: the `ns` docstring still says "Layer 0 / Layer 1 / Layer 2" —
+  `--fix` only rewrites headings and metadata, never prose — so that
+  docstring is now stale relative to the real 4-layer structure. Left
+  as-is rather than hand-edited, to keep this diff exactly what the
+  autofixer produced; worth folding into whichever Wave 2 PR splits this
+  namespace.
+- `components/decision/src/ai/miniforge/decision/spec.clj` — same shape,
+  worse: real reference graph resolves to **6** layers (0: enums plus
+  `valid?`/`explain`; 1: `registry` plus `validate-result`; 2: per-field
+  schemas plus `validate`; 3: `DecisionProposal`/`DecisionContext`; 4:
+  `DecisionCheckpoint`; 5: `DecisionEpisode`). Also **SL003: 6 distinct
+  layers (max 3)**, also Wave 2. Same stale-docstring note applies (still
+  says Layer 0/1/2). One structural side effect worth calling out
+  explicitly: `valid?`/`explain`/`validate-result`/`validate` previously
+  sat after the trailing `(comment ...)` block at the very end of the
+  file — an odd pre-existing placement, not something this PR introduced.
+  `--fix` moved them up into their correctly-inferred early layers, so the
+  `(comment ...)` block is now genuinely the file's last form. Content of
+  that block is byte-identical, only its relative position changed.
+
+No file outside `components/decision` touched.
+
+## Testing Plan
+
+1. Read every changed file's full diff (`git diff`, all four files, not
+   just `--stat`). Confirmed the changes are heading regrouping,
+   `^{:stratum n}` metadata, and — in `core.clj`/`spec.clj` — def
+   reordering to match the tool's inferred reference graph. No logic
+   edits found.
+2. Wrote a structural-equivalence check (babashka script): read every
+   top-level form from the pre-fix and post-fix version of each file,
+   strip metadata recursively (`clojure.walk`), and compare the four
+   before/after form sets as order-independent frequency multisets. All
+   four files: identical. (One apparent mismatch surfaced in
+   `interface_test.clj` — traced to a limitation of the comparison method
+   itself, not the fix: `java.util.regex.Pattern` has no value equality,
+   so two independently-read `#"..."` literals with identical source text
+   are never `=`. Direct textual diff of that one `deftest` confirmed it's
+   byte-identical apart from the added `^{:stratum n}` metadata.)
+3. Ran the actual test suite for the touched namespace (`bb test`,
+   stable-derived changed+affected bricks):
+   `ai.miniforge.decision.interface-test` — 43 tests, 116 assertions, 0
+   failures, 0 errors.
+4. Re-ran `stratum-lint` in plain (non-`--fix`) mode over
+   `components/decision` afterward. `interface.clj` and the test file:
+   zero findings. `core.clj` and `spec.clj`: one SL003 finding each (4 and
+   6 real layers, both over the 3-layer budget) — expected per the
+   baseline plan's Wave 2 (real namespace splits), not a failure of this
+   PR.
+
+Aside, not blocking: `bb test`'s affected-brick sweep also pulled in
+`ai.miniforge.pr-lifecycle.monitor-worklist-test`, which errors 5/11 tests
+with a `java.util.RegularEnumSet`/`HashSet` `ClassCastException` inside
+`babashka.fs`'s `delete-tree` (a JDK-version-sensitive bug in a
+third-party file-walk helper used for test cleanup). Confirmed
+pre-existing and unrelated: reproduced identically with this branch's
+changes stashed against the same base commit, and no `pr-lifecycle` file
+is touched by this PR. Also not part of the pre-commit smoke set
+(`resources/precommit-smoke-tests.edn` lists neither `pr-lifecycle` nor
+`decision` namespaces), so it doesn't gate this commit.
+
+## Deployment Plan
+
+Merges to `main`. Pure source-formatting normalization (headings +
+metadata) with no behavior change and no callers outside the four touched
+files — nothing to roll out or monitor.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+- Depends on: #1459 (stratum-lint pre-commit autofix wiring, already
+  merged) — reuses the same pinned sha
+- Enables: `work/stratum-lint-baseline-2026-07-24.md`'s Wave 2 (real
+  namespace splits) for `core.clj` (4 real layers) and `spec.clj` (6 real
+  layers), both now confirmed via SL003 rather than assumed
+
+## Checklist
+
+- [x] Full diff read for all 4 changed files; confirmed mechanical
+      (headings + `^{:stratum n}` metadata + reordering only, no logic
+      changes)
+- [x] Structural form-equivalence verified programmatically
+      (order-independent, metadata-stripped comparison)
+- [x] Component test suite green: `decision.interface-test` 43/43,
+      0 failures, 0 errors
+- [x] Post-fix plain lint: zero findings on `interface.clj` and the test
+      file; SL003 remainder on `core.clj`/`spec.clj` documented as
+      expected Wave 2 work, not a defect in this PR
+- [x] Unrelated pre-existing `pr-lifecycle` test flake investigated and
+      ruled out as caused by this change


### PR DESCRIPTION
## Summary

- Runs the pinned `stratum-lint --fix` over all four `.clj` files in `components/decision` (3 src, 1 test), regrouping top-level defs under `Layer N` headings that match the tool's inferred same-file reference graph and adding `^{:stratum n}` metadata. No logic changes.
- Wave 1 of `work/stratum-lint-baseline-2026-07-24.md`: `decision` had 7 pre-fix findings, all SL002 (decorative heading reuse), zero SL001 — matching the baseline plan's safe-to-autofix-first batch.
- `core.clj` and `spec.clj` now report SL003 (4 and 6 real layers, over the 3-layer budget) once the fix surfaces their true reference graph — expected, deferred to Wave 2 (real namespace splits). Full breakdown and per-file rationale in the PR doc: `docs/pull-requests/2026-07-24-fix-stratum-lint-wave1-decision.md`.

## Test plan

- [x] Full diff read for all 4 changed files — confirmed mechanical (headings + `^{:stratum n}` metadata + reordering only)
- [x] Structural form-equivalence verified programmatically (order-independent, metadata-stripped comparison of every top-level form, before vs. after)
- [x] `decision.interface-test`: 43 tests, 116 assertions, 0 failures, 0 errors
- [x] Post-fix plain lint: zero findings on `interface.clj` and the test file; SL003 remainder on `core.clj`/`spec.clj` documented as expected Wave 2 work
- [x] Pre-commit hook green: `poly:check`, `lint:clj`, `lint:stratum`, `fmt:md`, `test:precommit` (331 tests, 0 failures), `test:graalvm` (7 tests, 0 failures)
- [x] Investigated an unrelated `pr-lifecycle.monitor-worklist-test` flake (pre-existing `babashka.fs` JDK ClassCastException, reproduces identically on the base commit) — ruled out as caused by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)