### PR TITLE
fix: bump stratum-lint pin to pick up three correctness fixes

### DIFF
--- a/docs/pull-requests/2026-07-24-fix-bump-stratum-lint-pin-latest.md
+++ b/docs/pull-requests/2026-07-24-fix-bump-stratum-lint-pin-latest.md
@@ -1,0 +1,63 @@
+# fix: bump stratum-lint pin to pick up two correctness fixes
+
+## Overview
+
+Bumps `tasks/stratum.clj`'s pinned `stratum-lint` sha from `acd82a2f`
+(current on `main`, includes the SL001 scoping and comment-block fixes
+from #1459) to `8a40bdea`, which additionally includes:
+
+- [stratum-lint#8](https://github.com/miniforge-ai/stratum-lint/pull/8):
+  `--fix` keeps a `#_{...}` reader-discard (e.g.
+  `#_{:clj-kondo/ignore [...]}`) attached to its def instead of
+  detaching it.
+- [stratum-lint#10](https://github.com/miniforge-ai/stratum-lint/pull/10):
+  `--fix` orders a `defrecord`/`deftype` before any def calling its
+  auto-generated constructor (`->Name`/`map->Name`) — the old pin could
+  produce code that fails to compile.
+
+## Motivation
+
+Found mid-Wave-1: the pre-commit gate (`bb lint:stratum`, via
+`tasks/stratum.clj`) runs `--fix` on every commit touching a staged
+`.clj`/`.cljc` file, using its *own* pinned sha — independent of whatever
+sha someone ran by hand beforehand. Against `components/adapter-claude-code`
+(which has both a `#_{:clj-kondo/ignore [...]}` directive and a
+`defrecord`), the pre-commit hook's stale pin silently re-introduced both
+bugs into already-hand-verified, correctly-fixed staged files at commit
+time — confirmed live via a failing `test:graalvm` step (`Unable to
+resolve symbol: ->ClaudeCodeAdapter`) after a commit that had, moments
+earlier, verified clean.
+
+Every other Wave 1 PR so far (`compliance-scanner`, `reliability`,
+`decision`, `gate`) happened not to hit this — none combine a reader-
+discard with a problematic constructor-before-definition ordering — but
+any future component that does would silently corrupt on commit without
+this bump. This is now the priority blocker for continuing Wave 1.
+
+## Changes in Detail
+
+- `tasks/stratum.clj`: `stratum-lint-deps`'s pinned sha,
+  `acd82a2f` → `8a40bdea`.
+
+## Testing Plan
+
+Confirmed the sha resolves via `bb -Sdeps`. This change lints itself via
+the pre-commit hook it wires into — a clean pre-commit run against this
+one-line change is the relevant end-to-end confirmation.
+
+## Deployment Plan
+
+Merges to `main` immediately — every commit touching a `.clj`/`.cljc`
+file goes through this pin until it's bumped.
+
+## Related Issues/PRs
+
+- Fixes consumed: [stratum-lint#8](https://github.com/miniforge-ai/stratum-lint/pull/8), [#10](https://github.com/miniforge-ai/stratum-lint/pull/10)
+- Blocks: `fix/stratum-lint-wave1-adapter-claude-code` (currently stuck on
+  this exact staleness)
+- Part of: `work/stratum-lint-baseline-2026-07-24.md`, Wave 1
+
+## Checklist
+
+- [x] Sha resolves via `bb -Sdeps`
+- [x] Pre-commit hook (which this file itself wires into) passes clean

--- a/docs/pull-requests/2026-07-24-fix-bump-stratum-lint-pin-latest.md
+++ b/docs/pull-requests/2026-07-24-fix-bump-stratum-lint-pin-latest.md
@@ -1,10 +1,10 @@
-# fix: bump stratum-lint pin to pick up two correctness fixes
+# fix: bump stratum-lint pin to pick up three correctness fixes
 
 ## Overview
 
 Bumps `tasks/stratum.clj`'s pinned `stratum-lint` sha from `acd82a2f`
 (current on `main`, includes the SL001 scoping and comment-block fixes
-from #1459) to `8a40bdea`, which additionally includes:
+from #1459) to `59b4b9a3`, which additionally includes:
 
 - [stratum-lint#8](https://github.com/miniforge-ai/stratum-lint/pull/8):
   `--fix` keeps a `#_{...}` reader-discard (e.g.
@@ -14,6 +14,11 @@ from #1459) to `8a40bdea`, which additionally includes:
   `--fix` orders a `defrecord`/`deftype` before any def calling its
   auto-generated constructor (`->Name`/`map->Name`) — the old pin could
   produce code that fails to compile.
+- [stratum-lint#12](https://github.com/miniforge-ai/stratum-lint/pull/12):
+  `--fix` keeps a same-line trailing comment (documenting the last field
+  of a multi-line `defrecord`, or the last entry of a vector literal)
+  attached to the def it trails, instead of relocating it above the next
+  def.
 
 ## Motivation
 
@@ -28,16 +33,18 @@ time — confirmed live via a failing `test:graalvm` step (`Unable to
 resolve symbol: ->ClaudeCodeAdapter`) after a commit that had, moments
 earlier, verified clean.
 
-Every other Wave 1 PR so far (`compliance-scanner`, `reliability`,
-`decision`, `gate`) happened not to hit this — none combine a reader-
-discard with a problematic constructor-before-definition ordering — but
-any future component that does would silently corrupt on commit without
-this bump. This is now the priority blocker for continuing Wave 1.
+`compliance-scanner` and `decision` didn't hit any of these three.
+`reliability` and `gate` both hit the same-line-trailing-comment bug
+independently (a real, recurring pattern — 2 of the first 5 components),
+flagged in automated review on `gate`'s PR before this pin bump landed.
+Any future component combining these patterns would silently corrupt on
+commit without this bump — this is the priority blocker for continuing
+Wave 1.
 
 ## Changes in Detail
 
 - `tasks/stratum.clj`: `stratum-lint-deps`'s pinned sha,
-  `acd82a2f` → `8a40bdea`.
+  `acd82a2f` → `59b4b9a3`.
 
 ## Testing Plan
 
@@ -48,11 +55,16 @@ one-line change is the relevant end-to-end confirmation.
 ## Deployment Plan
 
 Merges to `main` immediately — every commit touching a `.clj`/`.cljc`
-file goes through this pin until it's bumped.
+file goes through this pin until it's bumped. Follow-on: re-run `gate`'s
+autofix fresh against this sha (addresses the pending review comment plus
+any other undetected same-line-trailing-comment instances in that
+component), and a small fix-up PR for the already-merged `reliability`
+component's `degradation.clj` to restore its misplaced comment.
 
 ## Related Issues/PRs
 
-- Fixes consumed: [stratum-lint#8](https://github.com/miniforge-ai/stratum-lint/pull/8), [#10](https://github.com/miniforge-ai/stratum-lint/pull/10)
+- Fixes consumed: [stratum-lint#8](https://github.com/miniforge-ai/stratum-lint/pull/8),
+  [#10](https://github.com/miniforge-ai/stratum-lint/pull/10), [#12](https://github.com/miniforge-ai/stratum-lint/pull/12)
 - Blocks: `fix/stratum-lint-wave1-adapter-claude-code` (currently stuck on
   this exact staleness)
 - Part of: `work/stratum-lint-baseline-2026-07-24.md`, Wave 1

--- a/tasks/stratum.clj
+++ b/tasks/stratum.clj
@@ -37,7 +37,7 @@
    included — never fetch the sibling repo; only the pre-commit gate
    pays the one-time clone."
   (pr-str {:deps {'io.github.miniforge-ai/stratum-lint
-                  {:git/sha "8a40bdeaf2897e2cc13f61e056a1882af7d811ab"
+                  {:git/sha "59b4b9a3eefa06c87eaa75ffcfa7f106501ea0c2"
                    :deps/root "clojure"}}}))
 
 (defn ^{:stratum 0} restage!

--- a/tasks/stratum.clj
+++ b/tasks/stratum.clj
@@ -37,7 +37,7 @@
    included — never fetch the sibling repo; only the pre-commit gate
    pays the one-time clone."
   (pr-str {:deps {'io.github.miniforge-ai/stratum-lint
-                  {:git/sha "acd82a2f5c0155cb03d92ce1f4465cc064125895"
+                  {:git/sha "8a40bdeaf2897e2cc13f61e056a1882af7d811ab"
                    :deps/root "clojure"}}}))
 
 (defn ^{:stratum 0} restage!


### PR DESCRIPTION
## Summary
- `tasks/stratum.clj`'s pinned sha still predated stratum-lint#8 (reader-discard attachment), #10 (defrecord/deftype ordered before its constructor callers), and #12 (same-line trailing comment attachment).
- The pre-commit gate runs `--fix` using this file's own pin on **every** commit, regardless of what sha someone ran by hand first — so a file combining any of these patterns would get silently re-corrupted at commit time.
- Confirmed live against `components/adapter-claude-code` (has a reader-discard and a problematic defrecord ordering): a hand-verified, correctly-fixed commit got its files silently re-broken by this exact mechanism. `reliability` and `gate` independently hit the same-line-trailing-comment bug (#12), found while this PR was open — bumped straight to the sha that includes it rather than landing this PR and immediately needing a follow-up bump.

Priority fix — blocks correct completion of the in-flight `adapter-claude-code` Wave 1 PR, unblocks re-running `gate`'s autofix cleanly, and would silently corrupt any future component combining these patterns.

See `docs/pull-requests/2026-07-24-fix-bump-stratum-lint-pin-latest.md` for full detail.

## Test plan
- [x] Sha resolves via `bb -Sdeps`
- [x] Pre-commit checks pass clean on this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)