### PR TITLE
fix(web-dashboard): gate state-mutating endpoints behind an operator session (#1460)

### DIFF
--- a/components/operator/src/ai/miniforge/operator/consumer.clj
+++ b/components/operator/src/ai/miniforge/operator/consumer.clj
@@ -87,8 +87,16 @@
    which routes the console's and the CLI's pause/resume/cancel
    controls through this channel — a click or a typed command is the
    same human gesture, and parking them at `:pending-human` with no
-   approver UI would make the control silently do nothing. Delegated
-   sources (`:meta-agent`, `:api`) are NOT here — they park at
+   approver UI would make the control silently do nothing.
+
+   Auto-approving these leans on each surface carrying operator
+   identity before it ever writes a request. `:tui` / `:native-app` /
+   `:cli` are local processes with no network listener. `:dashboard`
+   is HTTP-exposed, so it is only safe here because the dashboard's
+   control endpoints now require an authenticated operator session even
+   when browse-auth is disabled (issue #1460); an unauthenticated caller
+   is refused at the HTTP boundary and never reaches this table.
+   Delegated sources (`:meta-agent`, `:api`) are NOT here — they park at
    `:pending-human`."
   #{:cli :dashboard :native-app :tui})
 

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/server.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/server.clj
@@ -92,6 +92,16 @@
           (and (= uri "/logout") (= (:request-method req) :post))
           (auth/handle-logout auth-state req)
 
+          ;; Control gate: state-mutating requests require an authenticated
+          ;; operator session even when browse-auth is disabled (#1460).
+          ;; `current-session` is nil whenever auth is unconfigured, so a
+          ;; no-auth dashboard refuses every mutation while read-only views
+          ;; stay open. Intentional machine endpoints (event ingest, agent
+          ;; register/heartbeat) are `public-request?` and excluded.
+          (and (auth/mutating-request? req)
+               (nil? (auth/current-session auth-state req)))
+          (auth/control-unauthorized-response auth-state req)
+
           ;; Auth gate for browser-facing routes
           (and (auth/enabled? auth-state)
                (not (auth/public-request? req))
@@ -245,7 +255,7 @@
           (let [listener-id (subs uri 16)]
             (handlers/handle-api-listener-deregister state listener-id))
 
-          (= uri "/api/train/action")
+          (and (= uri "/api/train/action") (= (:request-method req) :post))
           (handlers/handle-api-train-action state params)
 
           (= uri "/api/filter-fields")

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/server/auth.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/server/auth.clj
@@ -176,6 +176,23 @@
       (.startsWith uri "/js/")
       (.startsWith uri "/img/")))
 
+(def ^:private mutating-methods
+  "HTTP methods that change server state. The dashboard's every write
+   route answers one of these; read-only views use GET/HEAD."
+  #{:post :put :patch :delete})
+
+(defn mutating-request?
+  "True for state-changing requests that must carry an authenticated
+   operator session regardless of the global browse-auth toggle
+   (issue #1460). A request mutates when it uses a non-idempotent HTTP
+   method and is not one of the intentionally public machine/login
+   endpoints (event ingest, agent register/heartbeat, login/logout).
+   Read-only GET/HEAD views are never mutating, so browsing a no-auth
+   dashboard stays open; only the controls need identity."
+  [{:keys [request-method] :as req}]
+  (and (contains? mutating-methods request-method)
+       (not (public-request? req))))
+
 (defn current-session
   "Return the current valid session map from the request cookie."
   [auth-state req]
@@ -273,3 +290,23 @@
                  "HX-Redirect" (str "/login?return-to="
                                     (java.net.URLEncoder/encode return-to "UTF-8"))}
        :body (json/generate-string {:error "authentication-required"})})))
+
+(defn control-unauthorized-response
+  "Auth challenge for a state-mutating request that arrived without a
+   session (issue #1460). When browse-auth is enabled this is the same
+   challenge browsing gets — a redirect / HX-Redirect to the login page,
+   so an operator can sign in. When browse-auth is disabled there is no
+   login page to send anyone to, so return a plain JSON 401 that names
+   the remedy: configure operator credentials. Read-only views stay
+   open in both modes; only mutations reach here."
+  [auth-state req]
+  (if (enabled? auth-state)
+    (unauthorized-response auth-state req)
+    {:status 401
+     :headers {"Content-Type" "application/json"}
+     :body (json/generate-string
+            {:error "authentication-required"
+             :message (str "Control actions require an authenticated operator "
+                           "session. Set MINIFORGE_WEB_USERNAME and "
+                           "MINIFORGE_WEB_PASSWORD (or configure a :users list) "
+                           "to enable operator login.")})}))

--- a/components/web-dashboard/test/ai/miniforge/web_dashboard/server/control_gate_test.clj
+++ b/components/web-dashboard/test/ai/miniforge/web_dashboard/server/control_gate_test.clj
@@ -1,0 +1,161 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.web-dashboard.server.control-gate-test
+  "The control gate (issue #1460): state-mutating requests require an
+   authenticated operator session even when browse-auth is disabled,
+   while read-only views and the intentional machine endpoints stay
+   open. These tests drive the assembled server handler so the gate is
+   exercised exactly as a live request would hit it."
+  (:require
+   [cheshire.core :as json]
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.event-stream.interface :as event-stream]
+   [ai.miniforge.web-dashboard.server :as server]
+   [ai.miniforge.web-dashboard.server.auth :as auth]
+   [ai.miniforge.web-dashboard.state.core :as state-core]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Test helpers
+(defn- ^{:stratum 0} no-auth-state
+  "A dashboard with no users configured — the default deployment. An
+   empty `:users` list keeps `build-auth-state` from reading the ambient
+   MINIFORGE_WEB_* env, so `enabled?` is deterministically false."
+  []
+  (state-core/create-state
+   {:auth (auth/build-auth-state {:users []})}))
+
+(defn- ^{:stratum 0} authed-state []
+  (state-core/create-state
+   {:auth (auth/build-auth-state
+           {:users [{:username "alice"
+                     :password "wonderland"
+                     :role :operator}]})}))
+
+(defn- ^{:stratum 0} body-stream [content]
+  (java.io.ByteArrayInputStream. (.getBytes (str content) "UTF-8")))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} login-cookie
+  "Drive the login flow against `handler` and return the session cookie."
+  [handler]
+  (-> (handler {:uri "/login"
+                :request-method :post
+                :headers {"content-type" "application/x-www-form-urlencoded"}
+                :body (body-stream "username=alice&password=wonderland&return-to=%2F")})
+      (get-in [:headers "Set-Cookie"])))
+
+(defn- ^{:stratum 1} command-req
+  [workflow-id & [cookie]]
+  {:uri (str "/api/workflow/" workflow-id "/command")
+   :request-method :post
+   :headers (cond-> {"content-type" "application/json"}
+              cookie (assoc "cookie" cookie))
+   :body (body-stream (json/generate-string {:command "pause"}))})
+
+(deftest ^{:stratum 1} no-auth-keeps-read-only-views-open
+  (testing "browsing stays open without a session"
+    (let [handler (server/create-handler (no-auth-state))]
+      (is (= 200 (:status (handler {:uri "/health" :request-method :get :headers {}})))
+          "health is reachable")
+      (is (not= 401 (:status (handler {:uri "/fleet" :request-method :get :headers {}})))
+          "a read-only view is not gated"))))
+
+(deftest ^{:stratum 1} no-auth-keeps-machine-endpoints-open
+  (testing "intentional machine ingest endpoints are not treated as operator control"
+    (let [handler (server/create-handler (no-auth-state))
+          response (handler {:uri "/api/events/ingest"
+                             :request-method :post
+                             :headers {"content-type" "application/json"}
+                             :body (body-stream "{}")})]
+      (is (not= 401 (:status response))
+          "event ingest stays public — it carries no operator authority to gate"))))
+
+(deftest ^{:stratum 1} no-auth-refuses-other-mutations
+  (testing "the gate covers every mutation, not just the workflow command endpoint"
+    (let [handler (server/create-handler (no-auth-state))]
+      (doseq [{:keys [uri query-string method]}
+              [{:uri "/api/train/action" :query-string "train-id=t1&action=pause" :method :post}
+               {:uri "/api/fleet/prs/sync" :method :post}
+               {:uri (str "/api/archive/" (random-uuid) "/delete") :method :post}
+               {:uri (str "/api/control-plane/agents/" (random-uuid) "/command") :method :post}]]
+        (let [response (handler {:uri uri
+                                 :query-string query-string
+                                 :request-method method
+                                 :headers {"content-type" "application/json"}
+                                 :body (body-stream "{}")})]
+          (is (= 401 (:status response)) (str uri " must require a session")))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; No-auth deployment: control is refused, browsing is open
+(deftest ^{:stratum 2} no-auth-refuses-control-mutation
+  (testing "an unauthenticated POST to the command endpoint is 401'd and no
+            intervention is ever written (#1460 acceptance)"
+    (let [written (atom [])]
+      (with-redefs [event-stream/request-intervention!
+                    (fn [request] (swap! written conj request) request)]
+        (let [handler (server/create-handler (no-auth-state))
+              response (handler (command-req (str (random-uuid))))]
+          (is (= 401 (:status response)))
+          (is (= "authentication-required"
+                 (:error (json/parse-string (:body response) true))))
+          (is (empty? @written)
+              "the gate blocks before any intervention reaches the operator channel"))))))
+
+;; Auth enabled: session passes, missing session is challenged
+(deftest ^{:stratum 2} authed-session-passes-the-gate
+  (testing "an authenticated operator reaches the control handler and the
+            intervention is written to the governed channel"
+    (let [written (atom [])]
+      (with-redefs [event-stream/request-intervention!
+                    (fn [request]
+                      (swap! written conj request)
+                      (assoc request :intervention/id (random-uuid)))]
+        (let [handler (server/create-handler (authed-state))
+              cookie (login-cookie handler)
+              response (handler (command-req (str (random-uuid)) cookie))
+              request (first @written)]
+          (is (= 200 (:status response)))
+          (is (= "requested" (:status (json/parse-string (:body response) true))))
+          (is (= :dashboard (:intervention/request-source request))
+              "the session-gated dashboard source reaches the operator channel"))))))
+
+(deftest ^{:stratum 2} enabled-without-session-is-challenged
+  (testing "auth enabled but no cookie: the mutation is refused"
+    (let [written (atom [])]
+      (with-redefs [event-stream/request-intervention!
+                    (fn [request] (swap! written conj request) request)]
+        (let [handler (server/create-handler (authed-state))
+              response (handler (command-req (str (random-uuid))))]
+          (is (= 401 (:status response)))
+          (is (empty? @written)))))))
+
+;; A mutation must not be reachable by GET
+(deftest ^{:stratum 2} train-action-is-post-only
+  (testing "the sole mutating endpoint that lacked a method guard no longer
+            answers GET, so the gate's method check cannot be bypassed"
+    (let [handler (server/create-handler (authed-state))
+          cookie (login-cookie handler)
+          response (handler {:uri "/api/train/action"
+                             :query-string "train-id=t1&action=pause"
+                             :request-method :get
+                             :headers {"cookie" cookie}})]
+      (is (= 404 (:status response))
+          "GET no longer routes to the train action handler"))))


### PR DESCRIPTION
Closes #1460. **Stacked on #1454 (D-4)** — the vulnerable code only exists on `feat/d4-replace-edn-poller`, so this PR targets that branch. Merge #1454's dependency chain first.

## The exposure

The dashboard's `POST /api/workflow/<id>/command` endpoint (and the other control mutations) stamp `:intervention/request-source :dashboard`, which `operator/consumer.clj` auto-approves — the intervention skips the `:pending-human` gate and is applied. The auth gate in `server.clj` only enforced when `auth/enabled?`, so on a no-auth deployment (the default; the server binds `0.0.0.0`) an unauthenticated HTTP caller could trigger auto-approved pause/resume/cancel.

## The fix — option (b), widened to all mutations

A **control gate** runs before routing, regardless of the browse-auth toggle:

- `auth/mutating-request?` — true for any non-idempotent method (`POST/PUT/PATCH/DELETE`) that isn't an intentional public machine/login endpoint (`public-request?`: event ingest, agent register/heartbeat, login/logout).
- The gate refuses a mutating request when `current-session` is nil. `current-session` is nil whenever auth is unconfigured, so a **no-auth dashboard refuses every mutation while read-only views stay open**. When auth is enabled the challenge is the usual login redirect / HX-Redirect; when disabled it is a JSON 401 that names the remedy (`control-unauthorized-response`).

Per the issue's acceptance criterion, a no-auth dashboard now cannot apply an intervention without an authenticated operator session.

Scope: the reporter chose to gate **all** state-mutating endpoints, not just the workflow command endpoint. So the same session requirement now covers fleet add/discover/sync, train actions, archive retention/delete, approval create/sign, listener register/deregister/annotate, and control-plane agent command/delete + decision resolve. The intentionally machine-facing endpoints (event ingest, agent register/heartbeat) stay public. This is consistent with browse-auth-enabled behaviour, where those same endpoints already required a session — the gate only extends that to the auth-disabled case.

Additional hardening: `/api/train/action` was the one mutating route without a method guard (it answered GET). It is now POST-only, so a GET can't slip past the method-based gate.

`:dashboard` and `:cli` stay in `auto-approve-request-sources` (option b, not option a). The policy docstring now records *why* auto-approving the HTTP-exposed `:dashboard` source is safe: the gate refuses an unauthenticated caller at the HTTP boundary, so a `:dashboard` request never reaches the auto-approve table without an operator session behind it.

## Broader auth/security posture (issue review items)

- **Approver UI for `:pending-human`** — still absent. It remains the load-bearing missing piece: any future narrowing of the auto-approve set (option a) would dead-button the controls without it. This PR takes option (b) specifically so the approver UI is *not* a prerequisite. Recommended as separate work before delegated sources (`:meta-agent`, `:api`) are ever surfaced through a console.
- **`auto-approve-request-sources` policy** — the four members (`:tui`, `:native-app`, `:cli`, `:dashboard`) are the surfaces where a human performed the originating gesture. `:tui`/`:native-app`/`:cli` are local processes with no network listener; `:dashboard` is now session-gated. Delegated sources (`:meta-agent`, `:api`) correctly park at `:pending-human`. Assessed as sound given the gate.
- **CLI `mf workflow cancel` (`:cli`)** — confirmed local-trust only. `bases/cli/.../workflow_commands.clj` writes the intervention straight into `{events-dir}/operator/` via a local CLI process; there is no HTTP listener, so it cannot be driven remotely. Auto-approving `:cli` is safe.
- **Should control always require identity?** — the gate answers "require an authenticated session to *act*." A recommended follow-up (deliberately **not** in this PR, to keep it focused and under the commit budget): thread the authenticated session principal into the intervention's `:requested-by` (and the structured path's RBAC requester), so the audit record names the real operator instead of the body-supplied/default `"dashboard"`. I have this change tested and ready as a stacked follow-up if wanted.

## Residual / not addressed here

- The dashboard still binds `0.0.0.0` by default. The gate closes unauthenticated *control*; binding to loopback by default would be defence-in-depth for the read-only surface too, but it is a behaviour change for legitimate remote-access deployments and is out of this issue's scope.
- A loopback-origin carve-out (allow control from `127.0.0.1` without a session) was considered and rejected: httpkit's `:remote-addr` becomes the proxy IP behind any co-located reverse proxy, which would auth-bypass all remote traffic in exactly the deployment where it matters — and it would violate the issue's acceptance criterion.

## Tests

- New `control_gate_test.clj` drives the assembled server handler: no-auth refuses the command endpoint (and no intervention is written), refuses the other mutations, keeps read-only views and machine endpoints open; auth-enabled passes a valid session and challenges a missing one; `/api/train/action` GET is 404.
- `web-dashboard` + `operator` brick tests: 0 failures.
- `bb test:graalvm`: 6 tests, 531 assertions, 0 failures (the web-dashboard + operator namespaces load and the gate code is Babashka-safe).
- `bb lint:clj` 0/0, `bb lint:stratum` clean (also cleared a pre-existing SL002 in `server.clj`), `bb commit-budget` 170/200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
