### PR TITLE
fix(release-executor): retarget path-traversal test to path-traversal-anomaly

### DIFF
--- a/components/release-executor/test/ai/miniforge/release_executor/file_writing_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/file_writing_test.clj
@@ -25,6 +25,7 @@
    [clojure.test :refer [deftest testing is]]
    [clojure.java.io :as io]
    [clojure.string :as str]
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.release-executor.files :as files]
    [babashka.fs :as fs]))
 
@@ -285,32 +286,28 @@
           (cleanup-temp-dir temp-dir))))))
 
 (deftest invalid-path-handling-test
-  (testing "assert-within-worktree! rejects path traversal (../)"
+  (testing "path-traversal-anomaly returns an anomaly for path traversal (../)"
     (let [temp-dir (create-temp-dir)]
       (try
-        (let [worktree   (fs/path temp-dir)
-              escape-path (fs/path temp-dir "../outside/repo.clj")]
-          (is (thrown-with-msg?
-               clojure.lang.ExceptionInfo
-               #"Path traversal rejected"
-               (files/assert-within-worktree! worktree escape-path))
-              "assert-within-worktree! should throw for ../outside/repo.clj")
-          (is (= :path-traversal
-                 (:type (ex-data (try
-                                   (files/assert-within-worktree! worktree escape-path)
-                                   nil
-                                   (catch clojure.lang.ExceptionInfo e e)))))
-              "ex-data :type should be :path-traversal"))
+        (let [worktree    (fs/path temp-dir)
+              escape-path (fs/path temp-dir "../outside/repo.clj")
+              result      (files/path-traversal-anomaly worktree escape-path)]
+          (is (anomaly/anomaly? result)
+              "path-traversal-anomaly should return an anomaly for ../outside/repo.clj")
+          (is (= :invalid-input (:anomaly/type result))
+              ":anomaly/type should be :invalid-input")
+          (is (re-find #"Path traversal rejected" (:anomaly/message result))
+              ":anomaly/message should mention path traversal"))
         (finally
           (cleanup-temp-dir temp-dir)))))
 
-  (testing "assert-within-worktree! accepts paths inside the worktree"
+  (testing "path-traversal-anomaly returns nil for paths inside the worktree"
     (let [temp-dir (create-temp-dir)]
       (try
         (let [worktree    (fs/path temp-dir)
               inside-path (fs/path temp-dir "src/feature.clj")]
-          (is (nil? (files/assert-within-worktree! worktree inside-path))
-              "assert-within-worktree! should return nil for valid path"))
+          (is (nil? (files/path-traversal-anomaly worktree inside-path))
+              "path-traversal-anomaly should return nil for valid path"))
         (finally
           (cleanup-temp-dir temp-dir)))))
 


### PR DESCRIPTION
## Problem

`invalid-path-handling-test` in `components/release-executor/test/ai/miniforge/release_executor/file_writing_test.clj` still called `files/assert-within-worktree!`, which no longer exists. `files.clj` now exposes `path-traversal-anomaly`, which **returns** a canonical `:invalid-input` anomaly map for `../` escapes and `nil` for in-bounds paths instead of **throwing** an `ExceptionInfo` with `:type :path-traversal`.

Result: `ai.miniforge.release-executor.file-writing-test` failed to compile (`No such var: files/assert-within-worktree!`), so `clojure -M:poly test :all` / any full-brick run was red on that namespace. Pre-existing since e7575691 (#993); unnoticed because change-scoped test runs skip it. Unrelated to #1456/#1457.

## Fix

Rewrote the two affected `testing` blocks to the current non-throwing contract:
- escape (`../outside/repo.clj`) → assert `path-traversal-anomaly` returns an anomaly (`anomaly/anomaly?`), `:anomaly/type` = `:invalid-input`, `:anomaly/message` matches `Path traversal rejected`.
- inside path → assert it returns `nil`.

Added the `ai.miniforge.anomaly.interface` require (already a declared dependency of the brick). The `process-file-action` failure-result block is unchanged. Only this one file referenced the removed var (7 hits); no src caller or other test namespace does.

## Verification

- Release-executor brick set (all 9 namespaces): 241 tests, 592 assertions, 0 failures, 0 errors.
- `clj-kondo`: 0 errors, 0 warnings on the file.
- `clojure -M:poly check`: exit 0 (only a pre-existing unrelated `config` fixture warning).
- `bb lint:stratum`: exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)