### PR TITLE
fix: SL003 blocks the commit by default, configurable to warn

### DIFF
--- a/docs/pull-requests/2026-07-24-fix-sl003-blocking-by-default.md
+++ b/docs/pull-requests/2026-07-24-fix-sl003-blocking-by-default.md
@@ -38,13 +38,18 @@ actually split (Wave 2) — or the commit sets
 ## Changes in Detail
 
 - `tasks/stratum.clj`:
-  - `budget-mode-env`/`warn-only?` (new, Layer 0): reads
+  - `budget-mode-env` (new, Layer 0): the env var name,
     `MINIFORGE_STRATUM_BUDGET_MODE`; `"warn"` opts into non-blocking,
-    anything else (including unset) blocks.
+    anything else (including unset) blocks. The check itself
+    (`(= "warn" (System/getenv budget-mode-env))`) is inlined directly
+    in `post-fix-lint!` rather than its own named fn — pulling it out
+    would have pushed this file to 4 real layers, tripping the very
+    check this PR adds (caught live while writing it).
   - `advisory-lint!` renamed to `post-fix-lint!` and now fails the
-    commit (`System/exit 1`) on any remaining finding unless
-    `warn-only?` — an unexpected exit code (neither 0 nor 1) still
-    always fails the commit regardless of mode, unchanged from before.
+    commit (`System/exit 1`) on any remaining finding unless the warn
+    check above is true — an unexpected exit code (neither 0 nor 1)
+    still always fails the commit regardless of mode, unchanged from
+    before.
   - `autofix-and-restage!`'s call site updated to the new name.
 
 ## Testing Plan

--- a/docs/pull-requests/2026-07-24-fix-sl003-blocking-by-default.md
+++ b/docs/pull-requests/2026-07-24-fix-sl003-blocking-by-default.md
@@ -1,0 +1,84 @@
+# fix: SL003 blocks the commit by default, configurable to warn
+
+## Overview
+
+`bb lint:stratum`'s post-fix check (any stratum-lint finding remaining
+after `--fix` — in practice always SL003, over the 3-layer budget)
+printed a non-blocking advisory and let the commit through regardless.
+It now fails the commit by default, same as every other rule 210
+violation. `MINIFORGE_STRATUM_BUDGET_MODE=warn` opts back into the old
+print-and-continue behavior.
+
+## Motivation
+
+Flagged directly: PR #1464 (`gate`'s Wave 1 autofix) has 5 files over the
+layer budget, and CI was green regardless — because CI never runs
+stratum-lint at all (only `bb lint:clj:all`/clj-kondo), and the one place
+that does, the pre-commit gate, treated this specific violation as
+advisory-only. That's the same "rule exists but doesn't actually enforce
+anything" pattern this entire cleanup effort (`work/stratum-lint-baseline-2026-07-24.md`)
+was started to eliminate — an over-budget file is a genuine, acknowledged
+rule 210 violation, not a lesser one `--fix` happens not to resolve
+mechanically.
+
+Chosen scope: blocking everywhere, immediately, not just for `gate`'s PR
+or gated behind finishing Wave 2 first. Configurable via env var rather
+than hardcoded, so a team mid-way through clearing a large pre-existing
+backlog (which is exactly this repo's situation right now — Wave 2 hasn't
+started) has an explicit, visible opt-out rather than the check being
+silently toothless for everyone.
+
+**Immediate consequence:** any commit touching one of the ~23 files
+already flagged with SL003 (across merged Wave 1 PRs for
+`compliance-scanner`, `reliability`, `decision`, plus the still-open
+`gate` and `adapter-claude-code`) is now blocked until that file is
+actually split (Wave 2) — or the commit sets
+`MINIFORGE_STRATUM_BUDGET_MODE=warn` explicitly.
+
+## Changes in Detail
+
+- `tasks/stratum.clj`:
+  - `budget-mode-env`/`warn-only?` (new, Layer 0): reads
+    `MINIFORGE_STRATUM_BUDGET_MODE`; `"warn"` opts into non-blocking,
+    anything else (including unset) blocks.
+  - `advisory-lint!` renamed to `post-fix-lint!` and now fails the
+    commit (`System/exit 1`) on any remaining finding unless
+    `warn-only?` — an unexpected exit code (neither 0 nor 1) still
+    always fails the commit regardless of mode, unchanged from before.
+  - `autofix-and-restage!`'s call site updated to the new name.
+
+## Testing Plan
+
+Functional, in an isolated scratch repo: a file with 4 real layers
+(1 over budget) staged and touched.
+
+- Default (no env var): `bb lint:stratum` exits 1, prints `❌`.
+- `MINIFORGE_STRATUM_BUDGET_MODE=warn`: same file, same finding, prints
+  `⚠️`, exits 0, file still gets re-staged with the mechanical fix
+  applied.
+- Verified `tasks/stratum.clj`/`tasks/lint.clj` themselves still lint
+  clean (self-referential — this file is exactly the kind this check
+  covers).
+
+## Deployment Plan
+
+Merges to `main`. Takes effect on the next commit touching a `.clj`/
+`.cljc` file with a remaining stratum-lint finding. Follow-on: `gate`'s
+open PR (#1464) needs an actual Wave 2 namespace split for its 5
+over-budget files before it can be committed further under the new
+default — flagged separately, not attempted here.
+
+## Related Issues/PRs
+
+- Directly requested in response to `work/stratum-lint-baseline-2026-07-24.md`
+  Wave 1 review of PR #1464.
+- Affects: `fix/stratum-lint-wave1-gate` (#1464) — blocked pending Wave 2
+  for that component.
+
+## Checklist
+
+- [x] Both modes (default-block, opt-in-warn) verified functionally
+- [x] Unexpected-exit-code case still always fails regardless of mode
+      (unchanged behavior, re-verified)
+- [x] This file and `tasks/lint.clj` lint clean under the tool this
+      change governs

--- a/docs/pull-requests/2026-07-24-fix-stratum-lint-autofix-precommit.md
+++ b/docs/pull-requests/2026-07-24-fix-stratum-lint-autofix-precommit.md
@@ -23,11 +23,11 @@ normal development, not just in dedicated cleanup PRs.
 ## Changes in Detail
 
 - `tasks/stratum.clj` (new): the autofix mechanics — `stratum-lint-deps`,
-  `restage!`, `lint-only-and-fail!`, `advisory-lint!`,
+  `restage!`, `lint-only-and-fail!`, `post-fix-lint!`,
   `autofix-and-restage!`. Split out of `tasks/lint.clj` because this PR's
   own dogfooding caught it tripping the very rule it enforces: the real
   call chain (`stratum-lint-deps`/`restage!` → `lint-only-and-fail!`/
-  `advisory-lint!` → `autofix-and-restage!` → the dispatcher) is 4 real
+  `post-fix-lint!` → `autofix-and-restage!` → the dispatcher) is 4 real
   layers deep, one over budget (rule 210's "a file wanting a fourth band
   is the signal to split the namespace"). `tasks/lint.clj`'s dispatcher
   calls into it via a qualified `stratum/...` reference, which the
@@ -52,11 +52,11 @@ normal development, not just in dedicated cleanup PRs.
   - A fully-staged file goes through `autofix-and-restage!`: run `--fix`,
     then `restage!` (re-`git add`, mirrors `fmt/md-staged`'s re-stage
     step, but checks `git add`'s own exit code — no longer possible for
-    the fixed content to fail to stage silently), then `advisory-lint!`.
+    the fixed content to fail to stage silently), then `post-fix-lint!`.
     `autofix-and-restage!` only fails the commit when `--fix`'s own exit
     code says it couldn't resolve the file (a parse failure, or a genuine
     same-file reference cycle — SL000/SL007).
-  - `advisory-lint!` runs one more plain (non-fix) lint pass over the
+  - `post-fix-lint!` runs one more plain (non-fix) lint pass over the
     fixed files and prints any remaining findings — in practice always
     SL003 (over the 3-layer budget), since `--fix` resolves everything
     else, but the message doesn't presume that's the only possibility —
@@ -127,6 +127,15 @@ cleared most of the tree's debt before most developers hit it organically.
   (comment-block preservation, found while validating this PR)
 - Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 0)
 - Follow-on: Waves 1-4, per-component fix PRs
+
+**Update (#1471):** the "non-blocking advisory" described above for a
+remaining post-fix finding (in practice always SL003) is no longer
+current — it now fails the commit by default, same as any other rule 210
+violation, with `MINIFORGE_STRATUM_BUDGET_MODE=warn` as an explicit
+opt-out. Renamed `post-fix-lint!` accordingly; this doc's function-name
+references above have been updated to match, but the "non-blocking"
+framing in the surrounding prose reflects this PR's original design, not
+current behavior.
 
 ## Checklist
 

--- a/docs/pull-requests/2026-07-24-fix-stratum-lint-autofix-precommit.md
+++ b/docs/pull-requests/2026-07-24-fix-stratum-lint-autofix-precommit.md
@@ -132,10 +132,10 @@ cleared most of the tree's debt before most developers hit it organically.
 remaining post-fix finding (in practice always SL003) is no longer
 current — it now fails the commit by default, same as any other rule 210
 violation, with `MINIFORGE_STRATUM_BUDGET_MODE=warn` as an explicit
-opt-out. Renamed `post-fix-lint!` accordingly; this doc's function-name
-references above have been updated to match, but the "non-blocking"
-framing in the surrounding prose reflects this PR's original design, not
-current behavior.
+opt-out. `advisory-lint!` was renamed to `post-fix-lint!` accordingly;
+this doc's function-name references above have been updated to match,
+but the "non-blocking" framing in the surrounding prose reflects this
+PR's original design, not current behavior.
 
 ## Checklist
 

--- a/tasks/stratum.clj
+++ b/tasks/stratum.clj
@@ -99,8 +99,8 @@
                                       files)
         warn? (= "warn" (System/getenv budget-mode-env))]
     (when-not (str/blank? out)
-      (println (if warn? "⚠️ " "❌")
-               "Stratified-design findings remain after autofix (needs a namespace split for an over-budget file):")
+      (println (if warn? "⚠️" "❌")
+               "Stratified-design findings remain after autofix (often a namespace split needed for an over-budget file):")
       (println out))
     (when-not (str/blank? err) (binding [*out* *err*] (println err)))
     (cond

--- a/tasks/stratum.clj
+++ b/tasks/stratum.clj
@@ -50,7 +50,7 @@
         (println "❌ Failed to re-stage" f "after autofix:" err)
         (System/exit exit)))))
 
-(def ^{:stratum 0} budget-mode-env
+(def ^{:stratum 0} ^:private budget-mode-env
   "Env var toggling how a remaining stratum-lint finding after autofix
    (in practice always SL003 — over the layer budget, needs a namespace
    split, since --fix resolves everything else) is treated: unset or any

--- a/tasks/stratum.clj
+++ b/tasks/stratum.clj
@@ -20,7 +20,7 @@
    namespace wanting a fourth real layer is the signal to split it).
    `lint/stratum-staged` is the dispatcher; it calls `autofix-and-restage!`
    for fully-staged files or `lint-only-and-fail!` for partially-staged
-   ones. `autofix-and-restage!` composes `restage!` and `advisory-lint!`,
+   ones. `autofix-and-restage!` composes `restage!` and `post-fix-lint!`,
    which both read `stratum-lint-deps` — the genuine 3-deep layer chain
    that no longer fits alongside the dispatcher in one file."
   (:require
@@ -50,6 +50,17 @@
         (println "❌ Failed to re-stage" f "after autofix:" err)
         (System/exit exit)))))
 
+(def ^{:stratum 0} budget-mode-env
+  "Env var toggling how a remaining stratum-lint finding after autofix
+   (in practice always SL003 — over the layer budget, needs a namespace
+   split, since --fix resolves everything else) is treated: unset or any
+   value other than \"warn\" blocks the commit; \"warn\" prints and
+   continues. Blocking is the default — every rule 210 violation gets
+   real enforcement, not a decorative print — with an explicit opt-out
+   for a team mid-way through clearing a backlog of pre-existing
+   over-budget files."
+  "MINIFORGE_STRATUM_BUDGET_MODE")
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn ^{:stratum 1} lint-only-and-fail!
@@ -71,24 +82,34 @@
                "allow autofix, or fix headings by hand. Exit code:" exit)
       (System/exit exit))))
 
-(defn ^{:stratum 1} advisory-lint!
-  "Plain (non-fix) lint pass over already-fixed `files`; prints any
-   remaining findings (in practice always SL003 — over the layer budget,
-   needs a namespace split — since --fix resolves everything else) as a
-   non-blocking advisory. Only a genuinely unexpected exit (neither clean
-   nor findings-present) fails the commit — a broken tool invocation
-   should never pass silently."
+(defn ^{:stratum 1} post-fix-lint!
+  "Plain (non-fix) lint pass over already-fixed `files`; any remaining
+   finding (in practice always SL003 — over the layer budget, needs a
+   namespace split — since --fix resolves everything else) fails the
+   commit by default, same as any other rule 210 violation — set
+   `MINIFORGE_STRATUM_BUDGET_MODE=warn` to print and continue instead,
+   e.g. while working through a backlog of pre-existing over-budget
+   files. A genuinely unexpected exit (neither clean nor
+   findings-present) always fails the commit regardless of mode — a
+   broken tool invocation should never pass silently."
   [files]
   (let [{:keys [exit out err]} (apply p/sh {:out :string :err :string}
                                       "bb" "-Sdeps" stratum-lint-deps
                                       "-m" "stratum-lint.interface"
-                                      files)]
+                                      files)
+        warn? (= "warn" (System/getenv budget-mode-env))]
     (when-not (str/blank? out)
-      (println "⚠️  Stratified-design findings remain after autofix (often a namespace split needed for an over-budget file):")
+      (println (if warn? "⚠️ " "❌")
+               "Stratified-design findings remain after autofix (needs a namespace split for an over-budget file):")
       (println out))
     (when-not (str/blank? err) (binding [*out* *err*] (println err)))
-    (when-not (contains? #{0 1} exit)
-      (println "❌ Post-fix advisory lint pass could not run — exit code:" exit)
+    (cond
+      (not (contains? #{0 1} exit))
+      (do
+        (println "❌ Post-fix lint pass could not run — exit code:" exit)
+        (System/exit exit))
+
+      (and (= 1 exit) (not warn?))
       (System/exit exit))))
 
 ;------------------------------------------------------------------------------ Layer 2
@@ -112,4 +133,4 @@
         (System/exit exit))
       (do
         (restage! files)
-        (advisory-lint! files)))))
+        (post-fix-lint! files)))))


### PR DESCRIPTION
## Summary
- `bb lint:stratum`'s post-fix check (any finding remaining after `--fix` — in practice always SL003, over the 3-layer budget) printed a non-blocking advisory and let the commit through regardless. Now fails the commit by default, same as every other rule 210 violation. `MINIFORGE_STRATUM_BUDGET_MODE=warn` opts back into print-and-continue.
- Flagged directly against PR #1464 (`gate`'s Wave 1 autofix, 5 files over budget, CI green regardless): the advisory-only design was the same "rule exists but doesn't enforce anything" pattern this whole cleanup effort was started to eliminate.
- **Immediate consequence:** any commit touching one of the ~23 files already flagged with SL003 (across merged `compliance-scanner`/`reliability`/`decision` and open `gate`/`adapter-claude-code`) is now blocked until that file is actually split (Wave 2), or the commit sets the warn override explicitly.

See `docs/pull-requests/2026-07-24-fix-sl003-blocking-by-default.md` for full detail.

## Test plan
- [x] Default (no env var) blocks: verified in an isolated scratch repo
- [x] `MINIFORGE_STRATUM_BUDGET_MODE=warn` prints and continues: verified
- [x] Unexpected-exit-code case still always fails regardless of mode
- [x] Caught live: this file itself briefly went over budget while writing this change and the new gate correctly blocked its own first commit attempt — resolved by inlining rather than adding a needless extra layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)