### PR TITLE
fix(dogfood): actionable semantic policy findings + resume crash robustness

### DIFF
--- a/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
@@ -684,6 +684,14 @@ depending on ambient namespace loading or raw var resolution."}
   (filter #(= :audit (get-in % [:rule :rule/enforcement :action]))
           violations))
 
+(defn- normalize-line
+  "A finding's line number, or nil when the judge omitted it. The
+   semantic-analyzer's raw->violation defaults a missing `:line` to 0,
+   which is not a valid editor line — carrying it forward would point the
+   agent/tooling at an impossible location."
+  [line]
+  (when (and (integer? line) (pos? line)) line))
+
 (defn- violation-location
   "Location for a gate finding, spanning both detector shapes. Content-scan
    / diff detectors carry top-level `:matches` + `:artifact-path`. The
@@ -696,7 +704,9 @@ depending on ambient namespace loading or raw var resolution."}
    finding names concrete sites like the mechanical detectors do."
   [violation]
   (if-let [hits (seq (:violations violation))]
-    {:matches (mapv #(select-keys % [:file :line :current :rationale]) hits)
+    {:matches (mapv #(-> (select-keys % [:file :line :current :rationale])
+                         (update :line normalize-line))
+                    hits)
      :path    (:file (first hits))}
     {:matches (:matches violation)
      :path    (:artifact-path violation)}))
@@ -718,7 +728,7 @@ depending on ambient namespace loading or raw var resolution."}
           "\n"
           (map (fn [{:keys [file line current rationale]}]
                  (str "  - " file
-                      (when line (str ":" line))
+                      (when-let [l (normalize-line line)] (str ":" l))
                       (when-not (str/blank? rationale) (str " — " rationale))
                       (when-not (str/blank? current) (str "  [" current "]"))))
                hits)))

--- a/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
@@ -684,13 +684,29 @@ depending on ambient namespace loading or raw var resolution."}
   (filter #(= :audit (get-in % [:rule :rule/enforcement :action]))
           violations))
 
+(defn- violation-location
+  "Location for a gate finding, spanning both detector shapes. Content-scan
+   / diff detectors carry top-level `:matches` + `:artifact-path`. The
+   semantic (LLM-judge) detector instead nests its per-file hits — each
+   `{:file :line :current}` from `semantic-analyzer` — under `:violations`,
+   with no top-level `:matches`/`:artifact-path`. Reading only the top-level
+   keys collapsed every semantic finding to `{:matches nil :path nil}`,
+   dropping the file/line/snippet the judge produced and leaving the
+   redirect agent nothing to act on. Surface the nested hits so a semantic
+   finding names concrete sites like the mechanical detectors do."
+  [violation]
+  (if-let [hits (seq (:violations violation))]
+    {:matches (mapv #(select-keys % [:file :line :current :rationale]) hits)
+     :path    (:file (first hits))}
+    {:matches (:matches violation)
+     :path    (:artifact-path violation)}))
+
 (defn violation->error
   [{:keys [rule violation]}]
   {:code (:rule/id rule)
    :message (:message violation)
    :severity (:rule/severity rule)
-   :location {:matches (:matches violation)
-              :path (:artifact-path violation)}
+   :location (violation-location violation)
    :remediation (get-in rule [:rule/enforcement :remediation])})
 
 (defn violation->warning

--- a/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
@@ -701,10 +701,33 @@ depending on ambient namespace loading or raw var resolution."}
     {:matches (:matches violation)
      :path    (:artifact-path violation)}))
 
+(defn- violation-message
+  "Finding message shown to the redirect/review agent. A semantic
+   violation's top-level `:message` is only the generic rule statement; the
+   judge's specific per-instance findings (what/where) live in `:violations`
+   (each `:rationale` is the judge's message for that site). Fold each hit
+   into the message as `path:line — rationale [snippet]` so the agent sees
+   the concrete instances to change, not just the rule — the other half of
+   why unlocalized semantic findings couldn't be acted on. Non-semantic
+   detectors keep their single `:message` unchanged."
+  [violation]
+  (if-let [hits (seq (:violations violation))]
+    (str (:message violation)
+         "\n"
+         (str/join
+          "\n"
+          (map (fn [{:keys [file line current rationale]}]
+                 (str "  - " file
+                      (when line (str ":" line))
+                      (when-not (str/blank? rationale) (str " — " rationale))
+                      (when-not (str/blank? current) (str "  [" current "]"))))
+               hits)))
+    (:message violation)))
+
 (defn violation->error
   [{:keys [rule violation]}]
   {:code (:rule/id rule)
-   :message (:message violation)
+   :message (violation-message violation)
    :severity (:rule/severity rule)
    :location (violation-location violation)
    :remediation (get-in rule [:rule/enforcement :remediation])})

--- a/components/policy-pack/test/ai/miniforge/policy_pack/detection_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/detection_test.clj
@@ -264,7 +264,31 @@
       (is (= :test-rule (:code error)))
       (is (= "Error!" (:message error)))
       (is (= :high (:severity error)))
-      (is (= "Fix it" (:remediation error)))))
+      (is (= "Fix it" (:remediation error)))
+      (is (= "main.py" (get-in error [:location :path]))
+          "content-scan path still surfaces from :artifact-path")))
+
+  (testing "Semantic violation surfaces the judge's nested file/line/snippet
+            (not {:matches nil :path nil}) so the finding is actionable"
+    (let [violation {:rule {:rule/id :std/named-constants
+                            :rule/severity :high
+                            :rule/enforcement {:action :hard-halt
+                                               :message "Magic number."}}
+                     :violation {:type :semantic
+                                 :rule-id :std/named-constants
+                                 :message "Magic number."
+                                 :violations [{:rule/id :std/named-constants
+                                               :file "components/x/src/x.clj"
+                                               :line 42
+                                               :current "(Thread/sleep 5000)"
+                                               :rationale "5000 is a magic number"}]}}
+          error (detection/violation->error violation)]
+      (is (= "components/x/src/x.clj" (get-in error [:location :path]))
+          "path comes from the judge's :file")
+      (is (= 42 (get-in error [:location :matches 0 :line]))
+          "line is preserved from the nested violation")
+      (is (= "(Thread/sleep 5000)" (get-in error [:location :matches 0 :current]))
+          "the offending snippet reaches the agent")))
 
   (testing "Converts violation to warning"
     (let [violation {:rule {:rule/id :test-rule

--- a/components/policy-pack/test/ai/miniforge/policy_pack/detection_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/detection_test.clj
@@ -288,7 +288,13 @@
       (is (= 42 (get-in error [:location :matches 0 :line]))
           "line is preserved from the nested violation")
       (is (= "(Thread/sleep 5000)" (get-in error [:location :matches 0 :current]))
-          "the offending snippet reaches the agent")))
+          "the offending snippet reaches the agent")
+      (is (clojure.string/includes? (:message error) "Magic number.")
+          "the generic rule statement is retained")
+      (is (clojure.string/includes? (:message error) "components/x/src/x.clj:42")
+          "the specific site is folded into the message")
+      (is (clojure.string/includes? (:message error) "5000 is a magic number")
+          "the judge's specific per-instance message reaches the agent")))
 
   (testing "Converts violation to warning"
     (let [violation {:rule {:rule/id :test-rule

--- a/components/policy-pack/test/ai/miniforge/policy_pack/detection_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/detection_test.clj
@@ -296,6 +296,27 @@
       (is (clojure.string/includes? (:message error) "5000 is a magic number")
           "the judge's specific per-instance message reaches the agent")))
 
+  (testing "A missing/0 judge line is normalized to nil, not a bogus :0 site"
+    (let [violation {:rule {:rule/id :std/localization
+                            :rule/severity :high
+                            :rule/enforcement {:action :hard-halt
+                                               :message "Raw string."}}
+                     :violation {:type :semantic
+                                 :rule-id :std/localization
+                                 :message "Raw string."
+                                 :violations [{:rule/id :std/localization
+                                               :file "a.clj"
+                                               :line 0
+                                               :current "\"hi\""
+                                               :rationale "raw literal"}]}}
+          error (detection/violation->error violation)]
+      (is (nil? (get-in error [:location :matches 0 :line]))
+          "line 0 becomes nil in the location")
+      (is (not (clojure.string/includes? (:message error) "a.clj:0"))
+          "no bogus :0 site in the message")
+      (is (clojure.string/includes? (:message error) "raw literal")
+          "the specific message still reaches the agent")))
+
   (testing "Converts violation to warning"
     (let [violation {:rule {:rule/id :test-rule
                             :rule/severity :low}

--- a/components/workflow/src/ai/miniforge/workflow/context.clj
+++ b/components/workflow/src/ai/miniforge/workflow/context.clj
@@ -367,10 +367,24 @@
   "Transition workflow to failed state using FSM. Same wall-clock
    duration semantics as transition-to-completed — duration is
    reported even on failure so the user can see how long the run
-   ran before failing."
+   ran before failing.
+
+   `:fail` is valid from `:running`, but a resumed run can be parked in a
+   phase state (e.g. `:phase-1-verify`) that defines no `:fail`
+   transition. Routing through the throwing `transition-execution` there
+   raises `:anomalies/fsm-unknown-event`, which SHADOWS the real error
+   that triggered this failure (the workflow-resume-fsm-advance defect:
+   the generic error path fed the machine an event no phase state
+   accepts, masking the original resume error). Use the non-throwing
+   result variant; when `:fail` is unknown at the current state, mark the
+   run failed directly so it still terminates and the original error
+   surfaces instead of a spurious FSM anomaly."
   [ctx]
   (-> (if (:execution/fsm-machine ctx)
-        (transition-execution ctx :fail)
+        (let [result (transition-execution-result ctx :fail)]
+          (if (anomaly/anomaly? result)
+            (assoc ctx :execution/status :failed)
+            result))
         (assoc ctx :execution/status :failed))
       (assoc :execution/ended-at (System/currentTimeMillis))
       stamp-wall-clock-duration))


### PR DESCRIPTION
## What

Three dogfood-surfaced infra fixes from the `release-opens-real-pr` run (workflow `b04b65e4`). All keep enforcement strict — they make findings **actionable** and resume **fail cleanly**, not the gates weaker.

### 1. Semantic policy findings carry file/line (was `{:matches nil :path nil}`)

`violation->error` read location from the top-level `:matches`/`:artifact-path` keys the content-scan/diff detectors use. The semantic (LLM-judge) detector nests its per-file hits (`:file :line :current`) under `:violations`, so every semantic finding collapsed to `{:matches nil :path nil}` — the redirect agent got no site to act on. `violation-location` now surfaces the nested hits.

### 2. Fold the judge's specific per-instance message into the finding message

The finding's `:message` was only the generic rule statement; the judge's *specific* message (what/where) sat unused in `:violations` `:rationale`. `violation-message` now appends each hit as `path:line — rationale [snippet]`.

**Why this, not "over-firing":** a reproduction of the batched judge on the run's `git.clj` returned **16 correctly-tagged, distinct violations** (localization×4, named-constants×4, result-handling×3, exceptions-as-data×2, …) — all real standards issues in the agent-written code. The gate was accurate; the run looped because findings were unlocalized and generically-messaged, not because they were false. With #1+#2 the agent gets rule + specific message + file:line:snippet and can comply.

### 3. Resume no longer crashes with a shadowing FSM error

Resuming a non-terminal-but-failed checkpoint restores the machine in a phase state (e.g. `:phase-1-verify`). `transition-to-failed` sent the workflow-level `:fail` through the *throwing* `transition-execution`; no phase state defines `:fail`, so it raised `:anomalies/fsm-unknown-event` and **shadowed the real resume error**. It now routes through the non-throwing result variant and, when `:fail` is unknown at the current state, marks the run `:failed` directly. (Defect #2 of `workflow-resume-fsm-advance`; defect #1 — resume not re-running remaining phases — is separate.)

## Verification

- `clojure -M:poly test brick:policy-pack`: detection-test 80 assertions, all pass; new assertions for location surfacing and message specificity.
- Workflow context change lints clean; existing suites unaffected.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)