### PR TITLE
fix(release): fail loud when the HTTPS token-fallback set-url itself fails (stacked on #1457)

### DIFF
--- a/components/release-executor/resources/config/release-executor/messages/en-US.edn
+++ b/components/release-executor/resources/config/release-executor/messages/en-US.edn
@@ -23,6 +23,8 @@
   :pr/reuse-no-url "gh pr view returned no PR URL"
 
   ;; push HTTPS+token fallback
+  :push/https-fallback-setup-failed
+  "Push failed and the HTTPS token fallback could not be applied: repointing origin to the token URL failed, so origin is unchanged (no token persisted). Push error: {push-error}. Set-url error: {set-url-error}"
   :push/https-fallback-restore-failed
   "Pushed via HTTPS token fallback but could not restore the origin remote URL; it may still embed the GitHub token. Scrub it: git remote set-url origin {remote-url}. Restore error: {restore-error}"
   :push/https-fallback-push-and-restore-failed

--- a/components/release-executor/src/ai/miniforge/release_executor/git.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/git.clj
@@ -369,32 +369,42 @@
             remote-url (when (result/succeeded? url-r) (str/trim (get url-r :output "")))
             https-url  (ssh->https-with-token remote-url github-token)]
         (if https-url
-          (do
-            (exec! worktree-path ["git" "remote" "set-url" "origin" https-url])
-            (let [retry     (push!)
-                  ;; Restore the original remote URL so the token never
-                  ;; persists in the worktree's git config.
-                  restore-r (exec! worktree-path
-                                   ["git" "remote" "set-url" "origin" remote-url])]
-              (if (result/succeeded? restore-r)
-                retry
-                ;; The restore failed — origin may still embed the token.
-                ;; Fail loud (even when the push itself succeeded) with the
-                ;; scrub command, rather than report a clean success while a
-                ;; credential is persisted in git config. When the retry push
-                ;; also failed, carry its error too so the root cause isn't
-                ;; lost.
-                (let [pushed? (result/succeeded? retry)]
-                  (result/shell-failure
-                   (if pushed?
-                     (msg/t :push/https-fallback-restore-failed
-                            {:remote-url    remote-url
-                             :restore-error (:error restore-r)})
-                     (msg/t :push/https-fallback-push-and-restore-failed
-                            {:remote-url    remote-url
-                             :push-error    (:error retry)
-                             :restore-error (:error restore-r)}))
-                   {:push-succeeded? pushed?})))))
+          (let [set-r (exec! worktree-path ["git" "remote" "set-url" "origin" https-url])]
+            (if-not (result/succeeded? set-r)
+              ;; Could not repoint origin at the token URL, so the fallback
+              ;; never applied — origin is unchanged (still the original URL,
+              ;; no token persisted, nothing to scrub). Report both the
+              ;; original push failure and the set-url error rather than
+              ;; pushing over the unchanged remote and masking the reason.
+              (result/shell-failure
+               (msg/t :push/https-fallback-setup-failed
+                      {:push-error    (:error result)
+                       :set-url-error (:error set-r)})
+               {:push-succeeded? false})
+              (let [retry     (push!)
+                    ;; Restore the original remote URL so the token never
+                    ;; persists in the worktree's git config.
+                    restore-r (exec! worktree-path
+                                     ["git" "remote" "set-url" "origin" remote-url])]
+                (if (result/succeeded? restore-r)
+                  retry
+                  ;; The restore failed — origin may still embed the token.
+                  ;; Fail loud (even when the push itself succeeded) with the
+                  ;; scrub command, rather than report a clean success while a
+                  ;; credential is persisted in git config. When the retry push
+                  ;; also failed, carry its error too so the root cause isn't
+                  ;; lost.
+                  (let [pushed? (result/succeeded? retry)]
+                    (result/shell-failure
+                     (if pushed?
+                       (msg/t :push/https-fallback-restore-failed
+                              {:remote-url    remote-url
+                               :restore-error (:error restore-r)})
+                       (msg/t :push/https-fallback-push-and-restore-failed
+                              {:remote-url    remote-url
+                               :push-error    (:error retry)
+                               :restore-error (:error restore-r)}))
+                     {:push-succeeded? pushed?}))))))
           result)))))
 
 (defn- raw-force-push!

--- a/components/release-executor/test/ai/miniforge/release_executor/git_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/git_test.clj
@@ -292,6 +292,31 @@
           (is (re-find #"config locked" (:error r)) "includes the restore error")
           (is (re-find #"Scrub it" (:error r)) "still surfaces the scrub command"))))))
 
+(deftest force-push-https-setup-failure-test
+  (testing "repointing origin to the token URL fails → report it, skip the retry push, no restore"
+    (let [push-n (atom 0) seturl-n (atom 0)]
+      (with-redefs [process/shell
+                    (fn [_opts & args]
+                      (let [a (vec args)]
+                        (cond
+                          (= "push" (second a))
+                          (do (swap! push-n inc)
+                              {:exit 1 :out "" :err "ssh: denied"})
+                          (= ["git" "remote" "get-url" "origin"] a)
+                          {:exit 0 :out "git@github.com:o/r.git" :err ""}
+                          (= ["git" "remote" "set-url"] (vec (take 3 a)))
+                          (do (swap! seturl-n inc)
+                              {:exit 1 :out "" :err "config locked"})
+                          :else {:exit 0 :out "" :err ""})))]
+        (let [r (git/force-push! "/tmp/wt" "tok")]
+          (is (not (:success? r)))
+          (is (= 1 @push-n) "the retry push is not attempted when the token-URL set-url fails")
+          (is (= 1 @seturl-n) "only the token-URL set-url runs; no restore (origin unchanged)")
+          (is (false? (:push-succeeded? r)))
+          (is (re-find #"could not be applied" (:error r)) "reports the fallback could not be set up")
+          (is (re-find #"ssh: denied" (:error r)) "includes the original push error")
+          (is (re-find #"config locked" (:error r)) "surfaces the set-url error"))))))
+
 ;;------------------------------------------- core host-mode dispatch
 (deftest step-validate-inputs-host-mode-test
   (testing "no executor + no environment-id + worktree present → :host-mode? true"


### PR DESCRIPTION
Stacked on #1457 (base is that PR's branch; GitHub repoints this to `main` once #1457 merges).

## What

Addresses the open Copilot comment on #1457 (`git.clj` `with-https-token-fallback!`): the result of `git remote set-url origin <https-url>` was ignored. If that set-url failed (e.g. a config lock), the code still ran the retry push — over the **unchanged SSH origin** — and then reported only the retry/restore errors, masking the real reason the fallback never applied.

## Fix

Capture the set-url result. On failure, return immediately with a message naming the set-url error. Origin is unchanged (still the original URL, no token persisted), so there is nothing to scrub and no restore is attempted. The message is a system-locale catalog string (`:push/https-fallback-setup-failed`).

## Tests

`force-push-https-setup-failure-test` — asserts the retry push is **not** attempted, no restore runs, and the set-url error surfaces. Existing fallback tests (success / restore-failure / both-failed) still pass. Full release-executor brick green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)