### PR TITLE
fix: stratum-lint autofix for components/metric-registry (Wave 1)

### DIFF
--- a/components/metric-registry/src/ai/miniforge/metric_registry/interface.clj
+++ b/components/metric-registry/src/ai/miniforge/metric_registry/interface.clj
@@ -11,71 +11,89 @@
    [clojure.edn :as edn]
    [clojure.java.io :as io]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; -- Schema re-exports --
-(def AcquisitionClass
+(def ^{:stratum 0} AcquisitionClass
   "Malli `[:enum ...]` schema for a metric's acquisition class (sourcing tier)."
   reg-schema/AcquisitionClass)
-(def ImplementationMode
+
+(def ^{:stratum 0} ImplementationMode
   "Malli `[:enum ...]` schema for how a metric is implemented (pull/derive/vendor/deprecated)."
   reg-schema/ImplementationMode)
-(def RefreshCadence
+
+(def ^{:stratum 0} RefreshCadence
   "Malli `[:enum ...]` schema for a metric's refresh cadence (realtime through annual)."
   reg-schema/RefreshCadence)
-(def RedistributionRisk
+
+(def ^{:stratum 0} RedistributionRisk
   "Malli `[:enum ...]` schema for a metric's redistribution-risk level (none/low/medium/high)."
   reg-schema/RedistributionRisk)
-(def MetricDirection
+
+(def ^{:stratum 0} MetricDirection
   "Malli `[:enum ...]` schema for a metric's directional polarity (normal/inverse)."
   reg-schema/MetricDirection)
-(def MetricUnit
+
+(def ^{:stratum 0} MetricUnit
   "Malli `[:enum ...]` schema for a metric's unit (percent/ratio/index/basis-points/count/usd/level)."
   reg-schema/MetricUnit)
-(def MetricEntry
+
+(def ^{:stratum 0} MetricEntry
   "Malli `[:map ...]` schema for one metric definition (id, name, sourcing, cadence, unit, etc.)."
   reg-schema/MetricEntry)
-(def MetricFamily
+
+(def ^{:stratum 0} MetricFamily
   "Malli `[:map ...]` schema for a named group of related metrics."
   reg-schema/MetricFamily)
-(def MetricRegistry
+
+(def ^{:stratum 0} MetricRegistry
   "Malli `[:map ...]` schema for the complete registry (id, version, families, pipeline map)."
   reg-schema/MetricRegistry)
 
 ;; -- Enum value sets --
-(def acquisition-classes
+(def ^{:stratum 0} acquisition-classes
   "Vector of the four acquisition-class keywords, in taxonomy order."
   reg-schema/acquisition-classes)
-(def implementation-modes
+
+(def ^{:stratum 0} implementation-modes
   "Vector of the implementation-mode keywords."
   reg-schema/implementation-modes)
-(def refresh-cadences
+
+(def ^{:stratum 0} refresh-cadences
   "Vector of the refresh-cadence keywords, ordered fastest to slowest."
   reg-schema/refresh-cadences)
-(def redistribution-risks
+
+(def ^{:stratum 0} redistribution-risks
   "Vector of the redistribution-risk keywords ([:none :low :medium :high]), in ascending order of risk."
   reg-schema/redistribution-risks)
-(def metric-directions
+
+(def ^{:stratum 0} metric-directions
   "Vector of the metric-direction keywords."
   reg-schema/metric-directions)
-(def metric-units
+
+(def ^{:stratum 0} metric-units
   "Vector of the metric-unit keywords."
   reg-schema/metric-units)
 
 ;; -- Validation --
-(def valid-metric?
+(def ^{:stratum 0} valid-metric?
   "Predicate: true if value conforms to the MetricEntry schema, false otherwise. Takes one metric value."
   reg-schema/valid-metric?)
-(def valid-family?
+
+(def ^{:stratum 0} valid-family?
   "Predicate: true if value conforms to the MetricFamily schema, false otherwise. Takes one family value."
   reg-schema/valid-family?)
-(def valid-registry?
+
+(def ^{:stratum 0} valid-registry?
   "Predicate: true if value conforms to the MetricRegistry schema, false otherwise. Takes one registry value."
   reg-schema/valid-registry?)
-(def validate-registry
+
+(def ^{:stratum 0} validate-registry
   "Validate a registry value against MetricRegistry. Returns {:valid? bool :errors map-or-nil}; never throws on invalid input."
   reg-schema/validate-registry)
 
 ;; -- Loading --
-(defn load-registry
+(defn ^{:stratum 0} load-registry
   "Load a metric registry from an EDN file path.
    Returns {:success? true :registry ...} or {:success? false :error ...}"
   [path]
@@ -93,37 +111,37 @@
       (schema/exception-failure :registry e))))
 
 ;; -- Lookups --
-(defn all-metrics
+(defn ^{:stratum 0} all-metrics
   "Return flat sequence of all metrics across all families."
   [registry]
   (lookup/all-metrics registry))
 
-(defn find-metric
+(defn ^{:stratum 0} find-metric
   "Find a single metric by id. Returns nil if not found."
   [registry metric-id]
   (lookup/find-metric registry metric-id))
 
-(defn find-metrics-by-family
+(defn ^{:stratum 0} find-metrics-by-family
   "Return all metrics in a given family."
   [registry family-id]
   (lookup/find-metrics-by-family registry family-id))
 
-(defn find-metrics-by-source-type
+(defn ^{:stratum 0} find-metrics-by-source-type
   "Return all metrics matching a given acquisition class."
   [registry source-type]
   (lookup/find-metrics-by-source-type registry source-type))
 
-(defn find-metrics-by-pipeline
+(defn ^{:stratum 0} find-metrics-by-pipeline
   "Return metric ids mapped to a given pipeline name."
   [registry pipeline-name]
   (lookup/find-metrics-by-pipeline registry pipeline-name))
 
-(defn family-ids
+(defn ^{:stratum 0} family-ids
   "Return all family ids in the registry."
   [registry]
   (lookup/family-ids registry))
 
-(defn metric-count
+(defn ^{:stratum 0} metric-count
   "Return total number of metrics across all families."
   [registry]
   (lookup/metric-count registry))

--- a/components/metric-registry/src/ai/miniforge/metric_registry/interface.clj
+++ b/components/metric-registry/src/ai/miniforge/metric_registry/interface.clj
@@ -1,3 +1,20 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 (ns ai.miniforge.metric-registry.interface
   "Public API for the metric-registry component.
 

--- a/components/metric-registry/src/ai/miniforge/metric_registry/lookup.clj
+++ b/components/metric-registry/src/ai/miniforge/metric_registry/lookup.clj
@@ -1,33 +1,37 @@
 (ns ai.miniforge.metric-registry.lookup
   "Pure query functions over metric registry data.")
 
-(defn all-metrics
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} all-metrics
   [registry]
   (mapcat :family/metrics (:registry/families registry)))
 
-(defn find-metric
-  [registry metric-id]
-  (some (fn [m] (when (= metric-id (:metric/id m)) m))
-        (all-metrics registry)))
-
-(defn find-metrics-by-family
+(defn ^{:stratum 0} find-metrics-by-family
   [registry family-id]
   (some (fn [f] (when (= family-id (:family/id f)) (:family/metrics f)))
         (:registry/families registry)))
 
-(defn find-metrics-by-source-type
+(defn ^{:stratum 0} find-metrics-by-pipeline
+  [registry pipeline-name]
+  (get-in registry [:registry/pipeline-metric-map pipeline-name]))
+
+(defn ^{:stratum 0} family-ids
+  [registry]
+  (mapv :family/id (:registry/families registry)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} find-metric
+  [registry metric-id]
+  (some (fn [m] (when (= metric-id (:metric/id m)) m))
+        (all-metrics registry)))
+
+(defn ^{:stratum 1} find-metrics-by-source-type
   [registry source-type]
   (filter #(= source-type (:metric/source-type %))
           (all-metrics registry)))
 
-(defn find-metrics-by-pipeline
-  [registry pipeline-name]
-  (get-in registry [:registry/pipeline-metric-map pipeline-name]))
-
-(defn family-ids
-  [registry]
-  (mapv :family/id (:registry/families registry)))
-
-(defn metric-count
+(defn ^{:stratum 1} metric-count
   [registry]
   (count (all-metrics registry)))

--- a/components/metric-registry/src/ai/miniforge/metric_registry/lookup.clj
+++ b/components/metric-registry/src/ai/miniforge/metric_registry/lookup.clj
@@ -1,3 +1,20 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 (ns ai.miniforge.metric-registry.lookup
   "Pure query functions over metric registry data.")
 

--- a/components/metric-registry/src/ai/miniforge/metric_registry/messages.clj
+++ b/components/metric-registry/src/ai/miniforge/metric_registry/messages.clj
@@ -2,6 +2,8 @@
   "Message catalog — delegates to ai.miniforge.messages."
   (:require [ai.miniforge.messages.interface :as messages]))
 
-(def t
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} t
   "Look up a message by key, with optional param substitution."
   (messages/create-translator "config/metric-registry/messages/en-US.edn" :metric-registry/messages))

--- a/components/metric-registry/src/ai/miniforge/metric_registry/messages.clj
+++ b/components/metric-registry/src/ai/miniforge/metric_registry/messages.clj
@@ -1,3 +1,20 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 (ns ai.miniforge.metric-registry.messages
   "Message catalog — delegates to ai.miniforge.messages."
   (:require [ai.miniforge.messages.interface :as messages]))

--- a/components/metric-registry/src/ai/miniforge/metric_registry/schema.clj
+++ b/components/metric-registry/src/ai/miniforge/metric_registry/schema.clj
@@ -9,49 +9,69 @@
    [malli.error :as me]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Enums and base types
 
-(def acquisition-classes
+;; Enums and base types
+(def ^{:stratum 0} acquisition-classes
   "Four-layer acquisition taxonomy for metric sourcing."
   [:public_canonical :official_market :premium_benchmark :house_factor])
 
-(def AcquisitionClass
-  (into [:enum] acquisition-classes))
-
-(def implementation-modes
+(def ^{:stratum 0} implementation-modes
   [:pull :derive :vendor :deprecated])
 
-(def ImplementationMode
-  (into [:enum] implementation-modes))
-
-(def refresh-cadences
+(def ^{:stratum 0} refresh-cadences
   [:realtime :daily :weekly :monthly :quarterly :annual])
 
-(def RefreshCadence
-  (into [:enum] refresh-cadences))
-
-(def redistribution-risks
+(def ^{:stratum 0} redistribution-risks
   [:none :low :medium :high])
 
-(def RedistributionRisk
-  (into [:enum] redistribution-risks))
-
-(def metric-directions
+(def ^{:stratum 0} metric-directions
   [:normal :inverse])
 
-(def MetricDirection
-  (into [:enum] metric-directions))
-
-(def metric-units
+(def ^{:stratum 0} metric-units
   [:percent :ratio :index :basis-points :count :usd :level])
 
-(def MetricUnit
-  (into [:enum] metric-units))
+;; Validation helpers
+(defn ^{:stratum 0} valid?
+  [schema value]
+  (m/validate schema value))
+
+(defn ^{:stratum 0} validate
+  "Validate value against schema. Returns {:valid? bool :errors map-or-nil}."
+  [schema value]
+  (if (m/validate schema value)
+    {:valid? true :errors nil}
+    {:valid? false
+     :errors (me/humanize (m/explain schema value))}))
+
+(defn ^{:stratum 0} explain
+  [schema value]
+  (when-let [explanation (m/explain schema value)]
+    (me/humanize explanation)))
 
 ;------------------------------------------------------------------------------ Layer 1
-;; Metric entry and family schemas
 
-(def MetricEntry
+(def ^{:stratum 1} AcquisitionClass
+  (into [:enum] acquisition-classes))
+
+(def ^{:stratum 1} ImplementationMode
+  (into [:enum] implementation-modes))
+
+(def ^{:stratum 1} RefreshCadence
+  (into [:enum] refresh-cadences))
+
+(def ^{:stratum 1} RedistributionRisk
+  (into [:enum] redistribution-risks))
+
+(def ^{:stratum 1} MetricDirection
+  (into [:enum] metric-directions))
+
+(def ^{:stratum 1} MetricUnit
+  (into [:enum] metric-units))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Metric entry and family schemas
+(def ^{:stratum 2} MetricEntry
   [:map
    [:metric/id string?]
    [:metric/name string?]
@@ -66,54 +86,38 @@
    [:metric/description {:optional true} string?]
    [:metric/series-id {:optional true} string?]])
 
-(def MetricFamily
+;------------------------------------------------------------------------------ Layer 3
+
+(def ^{:stratum 3} MetricFamily
   [:map
    [:family/id keyword?]
    [:family/name string?]
    [:family/metrics [:vector MetricEntry]]])
 
-;------------------------------------------------------------------------------ Layer 2
-;; Registry schema
+(defn ^{:stratum 3} valid-metric?
+  [value]
+  (valid? MetricEntry value))
 
-(def MetricRegistry
+;------------------------------------------------------------------------------ Layer 4
+
+;; Registry schema
+(def ^{:stratum 4} MetricRegistry
   [:map
    [:registry/id string?]
    [:registry/version string?]
    [:registry/families [:vector MetricFamily]]
    [:registry/pipeline-metric-map {:optional true} [:map-of string? [:vector string?]]]])
 
-;------------------------------------------------------------------------------ Layer 2
-;; Validation helpers
-
-(defn valid?
-  [schema value]
-  (m/validate schema value))
-
-(defn validate
-  "Validate value against schema. Returns {:valid? bool :errors map-or-nil}."
-  [schema value]
-  (if (m/validate schema value)
-    {:valid? true :errors nil}
-    {:valid? false
-     :errors (me/humanize (m/explain schema value))}))
-
-(defn explain
-  [schema value]
-  (when-let [explanation (m/explain schema value)]
-    (me/humanize explanation)))
-
-(defn valid-metric?
-  [value]
-  (valid? MetricEntry value))
-
-(defn valid-family?
+(defn ^{:stratum 4} valid-family?
   [value]
   (valid? MetricFamily value))
 
-(defn valid-registry?
+;------------------------------------------------------------------------------ Layer 5
+
+(defn ^{:stratum 5} valid-registry?
   [value]
   (valid? MetricRegistry value))
 
-(defn validate-registry
+(defn ^{:stratum 5} validate-registry
   [value]
   (validate MetricRegistry value))

--- a/components/metric-registry/src/ai/miniforge/metric_registry/schema.clj
+++ b/components/metric-registry/src/ai/miniforge/metric_registry/schema.clj
@@ -1,3 +1,20 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 (ns ai.miniforge.metric-registry.schema
   "Malli schemas for metric registry.
 

--- a/components/metric-registry/test/ai/miniforge/metric_registry/interface_test.clj
+++ b/components/metric-registry/test/ai/miniforge/metric_registry/interface_test.clj
@@ -15,12 +15,13 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.metric-registry.interface-test
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.metric-registry.interface :as mr]))
 
-(def ^:private sample-metric
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private sample-metric
   {:metric/id              "T10Y2Y"
    :metric/name            "10Y-2Y Treasury Spread"
    :metric/source-type     :public_canonical
@@ -32,7 +33,7 @@
    :metric/direction       :normal
    :metric/unit            :percent})
 
-(def ^:private sample-house-metric
+(def ^{:stratum 0} ^:private sample-house-metric
   {:metric/id              "BUFFETT_INDICATOR"
    :metric/name            "Buffett Indicator (Market Cap / GDP)"
    :metric/source-type     :house_factor
@@ -44,7 +45,23 @@
    :metric/direction       :inverse
    :metric/unit            :ratio})
 
-(def ^:private sample-registry
+;; -- Enum value sets --
+(deftest ^{:stratum 0} enum-sets-test
+  (testing "Acquisition classes"
+    (is (= [:public_canonical :official_market :premium_benchmark :house_factor]
+           mr/acquisition-classes)))
+
+  (testing "Implementation modes"
+    (is (= [:pull :derive :vendor :deprecated]
+           mr/implementation-modes)))
+
+  (testing "Refresh cadences"
+    (is (= [:realtime :daily :weekly :monthly :quarterly :annual]
+           mr/refresh-cadences))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} ^:private sample-registry
   {:registry/id      "risk-metrics"
    :registry/version "2026.03.17"
    :registry/families
@@ -58,8 +75,7 @@
    {"fred-risk-data" ["T10Y2Y" "BUFFETT_INDICATOR"]}})
 
 ;; -- Schema validation --
-
-(deftest valid-metric-test
+(deftest ^{:stratum 1} valid-metric-test
   (testing "Valid public canonical metric passes"
     (is (true? (mr/valid-metric? sample-metric))))
 
@@ -72,7 +88,7 @@
   (testing "Invalid enum value fails"
     (is (false? (mr/valid-metric? (assoc sample-metric :metric/source-type :invalid))))))
 
-(deftest valid-family-test
+(deftest ^{:stratum 1} valid-family-test
   (testing "Valid family passes"
     (is (true? (mr/valid-family?
                 {:family/id :yield-curve
@@ -85,7 +101,9 @@
                  :family/name "Empty"
                  :family/metrics []})))))
 
-(deftest validate-registry-test
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} validate-registry-test
   (testing "Valid registry passes"
     (let [result (mr/validate-registry sample-registry)]
       (is (true? (:valid? result)))
@@ -103,28 +121,12 @@
           result (mr/validate-registry bad)]
       (is (false? (:valid? result))))))
 
-;; -- Enum value sets --
-
-(deftest enum-sets-test
-  (testing "Acquisition classes"
-    (is (= [:public_canonical :official_market :premium_benchmark :house_factor]
-           mr/acquisition-classes)))
-
-  (testing "Implementation modes"
-    (is (= [:pull :derive :vendor :deprecated]
-           mr/implementation-modes)))
-
-  (testing "Refresh cadences"
-    (is (= [:realtime :daily :weekly :monthly :quarterly :annual]
-           mr/refresh-cadences))))
-
 ;; -- Lookup functions --
-
-(deftest all-metrics-test
+(deftest ^{:stratum 2} all-metrics-test
   (testing "Returns all metrics across families"
     (is (= 2 (count (mr/all-metrics sample-registry))))))
 
-(deftest find-metric-test
+(deftest ^{:stratum 2} find-metric-test
   (testing "Find existing metric by id"
     (let [m (mr/find-metric sample-registry "T10Y2Y")]
       (is (some? m))
@@ -133,7 +135,7 @@
   (testing "Returns nil for missing metric"
     (is (nil? (mr/find-metric sample-registry "NONEXISTENT")))))
 
-(deftest find-metrics-by-family-test
+(deftest ^{:stratum 2} find-metrics-by-family-test
   (testing "Find metrics in yield-curve family"
     (let [ms (mr/find-metrics-by-family sample-registry :yield-curve)]
       (is (= 1 (count ms)))
@@ -142,7 +144,7 @@
   (testing "Returns nil for missing family"
     (is (nil? (mr/find-metrics-by-family sample-registry :nonexistent)))))
 
-(deftest find-metrics-by-source-type-test
+(deftest ^{:stratum 2} find-metrics-by-source-type-test
   (testing "Find public canonical metrics"
     (let [ms (mr/find-metrics-by-source-type sample-registry :public_canonical)]
       (is (= 1 (count ms)))
@@ -156,7 +158,7 @@
   (testing "Returns empty for unmatched source type"
     (is (empty? (mr/find-metrics-by-source-type sample-registry :premium_benchmark)))))
 
-(deftest find-metrics-by-pipeline-test
+(deftest ^{:stratum 2} find-metrics-by-pipeline-test
   (testing "Find metrics for known pipeline"
     (is (= ["T10Y2Y" "BUFFETT_INDICATOR"]
            (mr/find-metrics-by-pipeline sample-registry "fred-risk-data"))))
@@ -164,11 +166,11 @@
   (testing "Returns nil for unknown pipeline"
     (is (nil? (mr/find-metrics-by-pipeline sample-registry "unknown")))))
 
-(deftest family-ids-test
+(deftest ^{:stratum 2} family-ids-test
   (testing "Returns all family ids"
     (is (= [:yield-curve :house-factors]
            (mr/family-ids sample-registry)))))
 
-(deftest metric-count-test
+(deftest ^{:stratum 2} metric-count-test
   (testing "Counts all metrics"
     (is (= 2 (mr/metric-count sample-registry)))))

--- a/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-metric-registry.md
+++ b/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-metric-registry.md
@@ -1,0 +1,80 @@
+# fix: stratum-lint autofix for components/metric-registry (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over `components/metric-registry` (src + test) and
+commits the result: regenerated `;---- Layer N` headings and `^{:stratum n}`
+metadata on every top-level def, computed from each file's real same-file
+reference graph. No logic changed. One PR in the Wave 1 batch described in
+`work/stratum-lint-baseline-2026-07-24.md`.
+
+## Motivation
+
+The baseline audit found rule 210 (`standards/miniforge/languages/clojure.mdc`)
+had been cargo-culted into decorative section banners across most of the
+tree. `metric-registry` carried exactly one finding — `SL002` in
+`schema.clj` (a `Layer 2` heading repeated instead of strictly increasing) —
+and zero `SL001` upward-reference findings, meeting the baseline's criterion
+for safe mechanical autofix with no cycle/reasoning risk to check first.
+
+## Changes in Detail
+
+`stratum-lint --fix` (pinned sha `80699e378cb8ebbb6daeb928431aa4a6b373c07e`)
+rewrote all 5 Clojure files in the component — every file, not just
+`schema.clj`, because `--fix` always regenerates canonical headings and
+tags every def with `^{:stratum n}`, even in files that had no prior
+findings:
+
+- **src (4 files):** `interface.clj`, `lookup.clj`, `messages.clj`,
+  `schema.clj`
+- **test (1 file):** `interface_test.clj`
+
+`schema.clj`'s real reference graph turned out deeper than its old,
+partially-honest 3-heading layout suggested: `--fix` computed 6 distinct
+strata (0–5) from actual same-file dependencies, not the 3 the old
+headings implied.
+
+## Testing Plan
+
+- `--fix` run twice in a row before committing; second pass produced no
+  rewrites and the working tree was byte-identical to the first pass —
+  idempotency confirmed directly.
+- Read the full diff for every changed file. All changes are heading
+  regrouping, `^{:stratum n}` metadata, and def reordering. No comments in
+  this component's files were same-line trailing comments to begin with
+  (checked pre-fix content directly), so none were at risk of
+  misattachment; none moved incorrectly.
+- `clj-kondo --lint components/metric-registry`: 0 errors, 0 warnings.
+- Plain (non-fix) lint after fixing: one `SL003` remains —
+  `schema.clj` genuinely uses 6 distinct layers against the budget of 3.
+  Pre-existing real depth, not decorative; needs an actual namespace split
+  (Wave 2 scope), not attempted here.
+- Ran the component's tests directly (`clojure -M:dev:test`, requiring
+  `ai.miniforge.metric-registry.interface-test`): 11 tests, 30 assertions,
+  0 failures, 0 errors.
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+changes — headings, metadata, and def order only. The pre-commit hook's
+`lint:stratum` autofixer keeps this component clean going forward; the
+remaining `SL003` finding on `schema.clj` stays advisory
+(`MINIFORGE_STRATUM_BUDGET_MODE=warn`) until Wave 2 splits it.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+- Follow-on: Wave 2 namespace split for `schema.clj` (`SL003`, 6 real
+  layers)
+
+## Checklist
+
+- [x] `--fix` run over the whole component (src + test)
+- [x] Idempotency verified directly (two `--fix` passes, zero diff)
+- [x] Diff reviewed file-by-file; mechanical-only (headings + metadata +
+      reorder)
+- [x] `clj-kondo` clean (0 errors, 0 warnings)
+- [x] Plain lint re-run post-fix: only `SL003` remains, documented as
+      Wave 2 scope
+- [x] Tests pass: 11 tests, 30 assertions, 0 failures/errors
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
## Summary

- Runs `stratum-lint --fix` (pin `80699e378cb8ebbb6daeb928431aa4a6b373c07e`) over `components/metric-registry` (src + test), regenerating `;---- Layer N` headings and `^{:stratum n}` metadata from each file's real same-file reference graph. Mechanical only — no logic changes.
- Fixes the component's one pre-existing finding: `SL002` in `schema.clj` (a `Layer 2` heading reused instead of strictly increasing). Zero `SL001` findings meant no upward-reference/cycle risk to check first — this component qualified for Wave 1's mechanical-fix batch per `work/stratum-lint-baseline-2026-07-24.md`.
- One `SL003` remains post-fix: `schema.clj`'s real reference graph is 6 layers deep against the 3-layer budget. Genuine pre-existing depth (the old headings under-tracked it), not something this PR creates or worsens — Wave 2 scope (namespace split), not attempted here. Committed with `MINIFORGE_STRATUM_BUDGET_MODE=warn` for that reason.

## Test plan

- [x] `--fix` run twice in a row; second pass produced zero diff (idempotency verified directly)
- [x] Full diff read for every changed file; confirmed heading regrouping + metadata + def reorder only, no comment misattachment (no same-line trailing comments existed pre-fix to begin with)
- [x] `clj-kondo --lint components/metric-registry`: 0 errors, 0 warnings
- [x] Plain (non-fix) lint post-fix: only `SL003` remains, documented above as Wave 2 scope
- [x] Component tests pass directly (`clojure -M:dev:test`): 11 tests, 30 assertions, 0 failures, 0 errors
- [x] Full pre-commit gate green at commit time: poly check, lint:clj, lint:stratum, fmt:md, 331-test smoke suite, GraalVM compatibility (8 tests) — all passed with 0 failures/errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)