### PR TITLE
fix: stratum-lint autofix for components/connector-http (Wave 1)

### DIFF
--- a/components/connector-http/src/ai/miniforge/connector_http/core.clj
+++ b/components/connector-http/src/ai/miniforge/connector_http/core.clj
@@ -15,13 +15,14 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-http.core
   "HttpConnector defrecord — thin protocol wrapper delegating to impl."
   (:require [ai.miniforge.connector.interface :as connector]
             [ai.miniforge.connector-http.impl :as impl]))
 
-(defrecord HttpConnector []
+;------------------------------------------------------------------------------ Layer 0
+
+(defrecord ^{:stratum 0} HttpConnector []
   connector/Connector
   (connect    [_ config auth]                      (impl/do-connect config auth))
   (close      [_ handle]                           (impl/do-close handle))

--- a/components/connector-http/src/ai/miniforge/connector_http/cursors.clj
+++ b/components/connector-http/src/ai/miniforge/connector_http/cursors.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-http.cursors
   "Shared timestamp-watermark cursor utilities for REST API connectors.
 
@@ -25,26 +24,15 @@
   (:require [clojure.string :as str])
   (:import [java.time Instant]))
 
-;;------------------------------------------------------------------------------ Layer 0
-;; Timestamp parsing
+;------------------------------------------------------------------------------ Layer 0
 
-(defn parse-timestamp
+;; Timestamp parsing
+(defn ^{:stratum 0} parse-timestamp
   [value]
   (when (and (string? value) (not (str/blank? value)))
     (Instant/parse value)))
 
-;;------------------------------------------------------------------------------ Layer 1
-;; Per-record cursor predicates and builders
-
-(defn after-cursor?
-  [timestamp-fn cursor record]
-  (if-let [cursor-ts (some-> cursor :cursor/value parse-timestamp)]
-    (some-> (timestamp-fn record)
-            parse-timestamp
-            (.isAfter cursor-ts))
-    true))
-
-(defn last-record-cursor
+(defn ^{:stratum 0} last-record-cursor
   [resource-def records]
   (when-let [last-record (last records)]
     (when (= :timestamp-watermark (:cursor-type resource-def))
@@ -52,15 +40,24 @@
        :cursor/value (or (:updated_at last-record)
                          (:created_at last-record))})))
 
-;;------------------------------------------------------------------------------ Layer 2
 ;; Collection-level cursor operations
-
-(defn sort-by-timestamp
+(defn ^{:stratum 0} sort-by-timestamp
   [timestamp-fn records]
   (sort-by #(or (timestamp-fn %) "") records))
 
-(defn max-timestamp-cursor
+(defn ^{:stratum 0} max-timestamp-cursor
   [timestamp-fn records]
   (when-let [latest-ts (some->> records (keep timestamp-fn) sort last)]
     {:cursor/type  :timestamp-watermark
      :cursor/value latest-ts}))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Per-record cursor predicates and builders
+(defn ^{:stratum 1} after-cursor?
+  [timestamp-fn cursor record]
+  (if-let [cursor-ts (some-> cursor :cursor/value parse-timestamp)]
+    (some-> (timestamp-fn record)
+            parse-timestamp
+            (.isAfter cursor-ts))
+    true))

--- a/components/connector-http/src/ai/miniforge/connector_http/etag.clj
+++ b/components/connector-http/src/ai/miniforge/connector_http/etag.clj
@@ -15,52 +15,53 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-http.etag
   "Shared ETag caching for conditional HTTP requests.
    Stores ETags per URL, adds If-None-Match headers to subsequent requests.
    304 Not Modified responses don't count against rate limits.")
 
-;;------------------------------------------------------------------------------ Layer 0
+;------------------------------------------------------------------------------ Layer 0
+
 ;; Cache
+(defonce ^{:stratum 0} ^:private cache (atom {}))
 
-(defonce ^:private cache (atom {}))
+(defn ^{:stratum 0} extract-etag
+  "Extract the ETag header from response headers."
+  [response-headers]
+  (get response-headers "etag"))
 
-(defn get-etag
+(defn ^{:stratum 0} not-modified?
+  "Check if an HTTP status indicates Not Modified."
+  [status]
+  (= 304 status))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} get-etag
   "Retrieve cached ETag for a URL."
   [url]
   (get @cache url))
 
-(defn store-etag!
+(defn ^{:stratum 1} store-etag!
   "Cache an ETag for a URL."
   [url etag]
   (when etag
     (swap! cache assoc url etag)))
 
-(defn clear-cache!
+(defn ^{:stratum 1} clear-cache!
   "Clear the entire ETag cache. Useful for testing."
   []
   (reset! cache {}))
 
-;;------------------------------------------------------------------------------ Layer 1
-;; Header helpers
+;------------------------------------------------------------------------------ Layer 2
 
-(defn add-etag-header
+;; Header helpers
+(defn ^{:stratum 2} add-etag-header
   "Add If-None-Match header if we have a cached ETag for this URL."
   [headers url]
   (if-let [etag (get-etag url)]
     (assoc headers "If-None-Match" etag)
     headers))
-
-(defn extract-etag
-  "Extract the ETag header from response headers."
-  [response-headers]
-  (get response-headers "etag"))
-
-(defn not-modified?
-  "Check if an HTTP status indicates Not Modified."
-  [status]
-  (= 304 status))
 
 (comment
   ;; (store-etag! "https://api.github.com/repos/org/repo/pulls" "W/\"abc123\"")

--- a/components/connector-http/src/ai/miniforge/connector_http/impl.clj
+++ b/components/connector-http/src/ai/miniforge/connector_http/impl.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-http.impl
   "Implementation functions for the HTTP connector.
    Pure logic separated from protocol wiring."
@@ -28,18 +27,13 @@
             [cheshire.core :as json])
   (:import [java.util UUID]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; -- Handle state --
-
-(def ^:private handles (connector/create-handle-registry))
-
-(defn get-handle [handle] (connector/get-handle handles handle))
-(defn store-handle! [handle state] (connector/store-handle! handles handle state))
-(defn remove-handle! [handle] (connector/remove-handle! handles handle))
-(defn touch-handle! [handle] (connector/touch-handle! handles handle))
+(def ^{:stratum 0} ^:private handles (connector/create-handle-registry))
 
 ;; -- Auth --
-
-(defn build-auth-headers
+(defn ^{:stratum 0} build-auth-headers
   "Build auth headers from auth config."
   [{:auth/keys [method credential-id]}]
   (case method
@@ -48,8 +42,7 @@
     {}))
 
 ;; -- Rate limiting --
-
-(defn enforce-rate-limit!
+(defn ^{:stratum 0} enforce-rate-limit!
   "Sleep if needed to enforce requests-per-second."
   [handle-state]
   (when-let [rps (get-in handle-state [:config :http/rate-limit :requests-per-second])]
@@ -60,8 +53,7 @@
           (Thread/sleep (long (- min-interval-ms elapsed))))))))
 
 ;; -- HTTP --
-
-(defn do-request
+(defn ^{:stratum 0} do-request
   "Execute an HTTP GET request. Returns schema/success or schema/failure."
   [url headers query-params]
   (let [resp (http/get url {:headers      headers
@@ -85,7 +77,7 @@
       (schema/failure :body (msg/t :http/request-failed {:status status :error (:body resp)})
                       {:error-type :permanent}))))
 
-(defn extract-records
+(defn ^{:stratum 0} extract-records
   "Extract records from response body using configured response-path."
   [body response-path]
   (let [data (if response-path (get-in body response-path) body)]
@@ -95,8 +87,7 @@
       :else              [])))
 
 ;; -- Pagination helpers --
-
-(defn build-page-params
+(defn ^{:stratum 0} build-page-params
   "Build query-params map for the current page."
   [pagination offset cursor-value batch-size]
   (case (:type pagination)
@@ -104,7 +95,7 @@
     :cursor (page/cursor-params pagination cursor-value batch-size)
     {}))
 
-(defn page-has-more?
+(defn ^{:stratum 0} page-has-more?
   "Determine if more pages exist after this batch."
   [pagination body offset record-count]
   (case (:type pagination)
@@ -112,7 +103,7 @@
     :cursor (some? (page/extract-cursor-value body pagination))
     false))
 
-(defn next-cursor-value
+(defn ^{:stratum 0} next-cursor-value
   "Compute the cursor value for the next page."
   [pagination body offset record-count]
   (case (:type pagination)
@@ -120,46 +111,20 @@
     :cursor (page/extract-cursor-value body pagination)
     nil))
 
-;; -- Lifecycle --
+(defn ^{:stratum 0} do-checkpoint [cursor-state]
+  (connector/checkpoint-result cursor-state))
 
-(defn do-connect
-  "Validate config, register handle. Returns connect-result."
-  [config auth]
-  (let [base-url (:http/base-url config)
-        endpoint (:http/endpoint config)]
-    (cond
-      (nil? base-url) (response/make-anomaly :anomalies/incorrect
-                                             (msg/t :http/base-url-required)
-                                             {:config config})
-      (nil? endpoint) (response/make-anomaly :anomalies/incorrect
-                                             (msg/t :http/endpoint-required)
-                                             {:config config})
+;------------------------------------------------------------------------------ Layer 1
 
-      :else
-      (let [handle       (str (UUID/randomUUID))
-            auth-headers (if (and auth (:auth/method auth))
-                           (build-auth-headers auth)
-                           {})]
-        (store-handle! handle {:config       config
-                               :auth-headers auth-headers
-                               :last-request-at nil})
-        (connector/connect-result handle)))))
+(defn ^{:stratum 1} get-handle [handle] (connector/get-handle handles handle))
 
-(defn do-close [handle]
-  (remove-handle! handle)
-  (connector/close-result))
+(defn ^{:stratum 1} store-handle! [handle state] (connector/store-handle! handles handle state))
 
-;; -- Source --
+(defn ^{:stratum 1} remove-handle! [handle] (connector/remove-handle! handles handle))
 
-(defn do-discover [handle]
-  (if-let [{:keys [config]} (get-handle handle)]
-    (connector/discover-result [{:schema/name    (:http/endpoint config)
-                              :schema/base-url (:http/base-url config)}])
-    (response/make-anomaly :anomalies/not-found
-                           (msg/t :http/handle-not-found {:handle handle})
-                           {:handle handle})))
+(defn ^{:stratum 1} touch-handle! [handle] (connector/touch-handle! handles handle))
 
-(defn- fetch-single
+(defn- ^{:stratum 1} fetch-single
   "Fetch one page of records for a single query-params set.
    Returns the records vector."
   [url headers base-query-params response-path pagination opts]
@@ -182,7 +147,46 @@
                         :cursor/value next-val})]
         {:records records :cursor cursor :has-more has-more}))))
 
-(defn do-extract
+;------------------------------------------------------------------------------ Layer 2
+
+;; -- Lifecycle --
+(defn ^{:stratum 2} do-connect
+  "Validate config, register handle. Returns connect-result."
+  [config auth]
+  (let [base-url (:http/base-url config)
+        endpoint (:http/endpoint config)]
+    (cond
+      (nil? base-url) (response/make-anomaly :anomalies/incorrect
+                                             (msg/t :http/base-url-required)
+                                             {:config config})
+      (nil? endpoint) (response/make-anomaly :anomalies/incorrect
+                                             (msg/t :http/endpoint-required)
+                                             {:config config})
+
+      :else
+      (let [handle       (str (UUID/randomUUID))
+            auth-headers (if (and auth (:auth/method auth))
+                           (build-auth-headers auth)
+                           {})]
+        (store-handle! handle {:config       config
+                               :auth-headers auth-headers
+                               :last-request-at nil})
+        (connector/connect-result handle)))))
+
+(defn ^{:stratum 2} do-close [handle]
+  (remove-handle! handle)
+  (connector/close-result))
+
+;; -- Source --
+(defn ^{:stratum 2} do-discover [handle]
+  (if-let [{:keys [config]} (get-handle handle)]
+    (connector/discover-result [{:schema/name    (:http/endpoint config)
+                              :schema/base-url (:http/base-url config)}])
+    (response/make-anomaly :anomalies/not-found
+                           (msg/t :http/handle-not-found {:handle handle})
+                           {:handle handle})))
+
+(defn ^{:stratum 2} do-extract
   "Fetch records from the HTTP API.
    If the handle's config contains :batch/param-sets, fetches all param sets
    in parallel via pmap, enriching each record with its param-set keys.
@@ -226,6 +230,3 @@
     (response/make-anomaly :anomalies/not-found
                            (msg/t :http/handle-not-found {:handle handle})
                            {:handle handle})))
-
-(defn do-checkpoint [cursor-state]
-  (connector/checkpoint-result cursor-state))

--- a/components/connector-http/src/ai/miniforge/connector_http/interface.clj
+++ b/components/connector-http/src/ai/miniforge/connector_http/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-http.interface
   "Public API for the HTTP connector component."
   (:require [ai.miniforge.connector-http.core :as core]
@@ -24,12 +23,14 @@
             [ai.miniforge.connector-http.request :as request]
             [ai.miniforge.connector.interface :as conn]))
 
-(defn create-http-connector
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} create-http-connector
   "Create a new HttpConnector instance."
   []
   (core/->HttpConnector))
 
-(def connector-metadata
+(def ^{:stratum 0} connector-metadata
   "Registration metadata for the HTTP connector."
   {:connector/name         "HTTP REST Connector"
    :connector/type         :source
@@ -40,87 +41,98 @@
    :connector/maintainer   "data-foundry"})
 
 ;; -- Cursor utilities (shared by HTTP-based source connectors) --
-(def after-cursor?
+(def ^{:stratum 0} after-cursor?
   "Predicate (fn [timestamp-fn cursor record] boolean): true if the record's
    timestamp is strictly after the cursor's :cursor/value watermark. timestamp-fn
    extracts an ISO-8601 string (or nil) from a record. Returns true whenever the
    cursor carries no parseable :cursor/value timestamp — i.e. a nil cursor, a
    missing :cursor/value, or a blank/malformed one (no prior watermark)."
   cursors/after-cursor?)
-(def last-record-cursor
+
+(def ^{:stratum 0} last-record-cursor
   "(fn [resource-def records] cursor-map-or-nil): build a :timestamp-watermark
    cursor map {:cursor/type :timestamp-watermark :cursor/value iso-string} from the
    last record's :updated_at or :created_at. :cursor/value may be nil when the last
    record carries neither :updated_at nor :created_at. Returns nil when records is
    empty or the resource-def :cursor-type is not :timestamp-watermark."
   cursors/last-record-cursor)
-(def max-timestamp-cursor
+
+(def ^{:stratum 0} max-timestamp-cursor
   "(fn [timestamp-fn records] cursor-map-or-nil): build a :timestamp-watermark
    cursor map {:cursor/type :timestamp-watermark :cursor/value iso-string} from the
    maximum timestamp across records. timestamp-fn extracts an ISO-8601 string (or
    nil) per record. Returns nil when records is empty or none carry a timestamp."
   cursors/max-timestamp-cursor)
-(def sort-by-timestamp
+
+(def ^{:stratum 0} sort-by-timestamp
   "(fn [timestamp-fn records] sorted-seq): sort records ascending by timestamp.
    timestamp-fn extracts an ISO-8601 string (or nil) per record; records with nil
    timestamps sort first."
   cursors/sort-by-timestamp)
-(def parse-timestamp
+
+(def ^{:stratum 0} parse-timestamp
   "(fn [value] Instant-or-nil): parse an ISO-8601 timestamp string to a
    java.time.Instant. Returns nil when value is nil, non-string, or blank; throws
    on a malformed non-blank string."
   cursors/parse-timestamp)
 
 ;; -- Request utilities (shared by HTTP-based source connectors) --
-(def coerce-records
+(def ^{:stratum 0} coerce-records
   "(fn [body] vector): coerce a parsed response body to a vector of records. A
    sequential body is returned as a vector; any other value is wrapped in a
    single-element vector."
   request/coerce-records)
-(def do-request
+
+(def ^{:stratum 0} do-request
   "(fn [url headers query-params error-fn] result): execute an HTTP GET, applying
    ETag conditional-request handling (If-None-Match). Returns a schema/success
    (2xx or 304 Not Modified) or schema/failure. error-fn (fn [status resp] failure)
    supplies connector-specific error messages for non-success, non-304 responses."
   request/do-request)
-(def error-response
+
+(def ^{:stratum 0} error-response
   "(fn [status resp msgs] failure): build a schema/failure from a non-success,
    non-304 response. msgs map: {:rate-limited string :server-error string
    :request-failed (fn [status err-str] string)} — callers supply their own
    localized labels. The :error-type in failure metadata is :rate-limited (429),
    :transient (5xx), or :permanent (other 4xx)."
   request/error-response)
-(def next-url
+
+(def ^{:stratum 0} next-url
   "(fn [resp] string-or-nil): extract the 'next' page URL from the response's Link
    header. Returns nil when no Link header or no next relation is present."
   request/next-url)
-(def throw-on-failure!
+
+(def ^{:stratum 0} throw-on-failure!
   "(fn [result] result): return result unchanged on success; on failure throw an
    ExceptionInfo carrying :anomaly/category :anomalies/unavailable and the legacy
    :error-type key in ex-data."
   request/throw-on-failure!)
 
 ;; -- Rate-limit utilities --
-(def acquire-permit!
+(def ^{:stratum 0} acquire-permit!
   "(fn [handles-atom handle opts] nil): side-effecting. Inspect the handle's stored
    rate-limit state and, when remaining requests fall below the threshold, block the
    calling thread until the rate limit resets (capped at 60s) by deref-ing a promise
    that a task scheduled on a ScheduledExecutorService delivers. opts: {:threshold
    long} overrides the default (10). Returns nil."
   rate-limit/acquire-permit!)
-(def parse-rate-headers
+
+(def ^{:stratum 0} parse-rate-headers
   "(fn [headers mapping] info-map-or-nil): extract rate-limit info from response
    headers. mapping: {:remaining header :reset header :limit header}. Returns
    {:remaining long :reset-epoch long :limit long-or-nil}, or nil when the
    remaining/reset headers are absent or unparseable."
   rate-limit/parse-rate-headers)
-(def time-based-acquire!
+
+(def ^{:stratum 0} time-based-acquire!
   "(fn [rps last-request-ms] epoch-ms): side-effecting. Sleep if needed to honor an
    rps (requests-per-second) limit given the prior request's epoch-millis (0 or nil
    means no prior request). Returns the current epoch-millis for use as the next
    last-request-at."
   rate-limit/time-based-acquire!)
-(def update-rate-state!
+
+(def ^{:stratum 0} update-rate-state!
   "(fn [handles-atom handle rate-info] state-or-nil): side-effecting. Store
    rate-info under [handle :rate-limit] in the handles atom via swap!. No-op
    returning nil when rate-info is nil."

--- a/components/connector-http/src/ai/miniforge/connector_http/messages.clj
+++ b/components/connector-http/src/ai/miniforge/connector_http/messages.clj
@@ -15,11 +15,12 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-http.messages
   "Message catalog — delegates to ai.miniforge.messages."
   (:require [ai.miniforge.messages.interface :as messages]))
 
-(def t
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} t
   "Look up a message by key, with optional param substitution."
   (messages/create-translator "config/connector-http/messages/en-US.edn" :connector-http/messages))

--- a/components/connector-http/src/ai/miniforge/connector_http/pagination.clj
+++ b/components/connector-http/src/ai/miniforge/connector_http/pagination.clj
@@ -15,29 +15,30 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-http.pagination
   "Pagination strategies for HTTP extraction."
   (:require [clojure.string :as str]))
 
-(defn offset-params
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} offset-params
   "Build query params for offset-based pagination."
   [{:keys [param page-size-param]} offset page-size]
   {(or param "offset") offset
    (or page-size-param "limit") page-size})
 
-(defn cursor-params
+(defn ^{:stratum 0} cursor-params
   "Build query params for cursor-based pagination."
   [{:keys [param page-size-param]} cursor-value page-size]
   (cond-> {(or page-size-param "limit") page-size}
     cursor-value (assoc (or param "cursor") cursor-value)))
 
-(defn next-offset
+(defn ^{:stratum 0} next-offset
   "Calculate next offset for offset-based pagination."
   [current-offset records-count]
   (+ current-offset records-count))
 
-(defn has-more-offset?
+(defn ^{:stratum 0} has-more-offset?
   "Determine if more pages exist for offset pagination."
   [response-body {:keys [total-path]} current-offset records-count]
   (if total-path
@@ -45,7 +46,7 @@
       (and (number? total) (< (+ current-offset records-count) total)))
     (pos? records-count)))
 
-(defn extract-cursor-value
+(defn ^{:stratum 0} extract-cursor-value
   "Extract next cursor value from response for cursor-based pagination."
   [response-body {:keys [next-cursor-path]}]
   (when next-cursor-path
@@ -54,8 +55,7 @@
 ;; --------------------------------------------------------------------------
 ;; Link-header pagination (RFC 5988)
 ;; --------------------------------------------------------------------------
-
-(defn parse-link-header
+(defn ^{:stratum 0} parse-link-header
   "Parse an HTTP Link header into a map of {rel url}.
    Example: '<https://api.github.com/repos?page=2>; rel=\"next\"'
    → {\"next\" \"https://api.github.com/repos?page=2\"}"
@@ -68,12 +68,14 @@
                 :when (and url rel)]
             [rel url]))))
 
-(defn link-header-next-url
+(defn ^{:stratum 0} link-header-next-url
   "Extract the 'next' URL from a parsed Link header map."
   [links]
   (get links "next"))
 
-(defn link-header-has-more?
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} link-header-has-more?
   "Check if a Link header indicates more pages."
   [links]
   (boolean (link-header-next-url links)))

--- a/components/connector-http/src/ai/miniforge/connector_http/rate_limit.clj
+++ b/components/connector-http/src/ai/miniforge/connector_http/rate_limit.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-http.rate-limit
   "Shared response-header-driven rate limiting for API connectors.
    Reads rate limit headers from HTTP responses and backs off when
@@ -23,16 +22,46 @@
    that returns standard rate limit headers."
   (:import [java.util.concurrent Executors ScheduledExecutorService TimeUnit]))
 
-;;------------------------------------------------------------------------------ Layer 0
-;; Header parsing
+;------------------------------------------------------------------------------ Layer 0
 
-(defn- parse-long-header
+;; Header parsing
+(defn- ^{:stratum 0} parse-long-header
   "Parse a header value as a long, returning nil on failure."
   [headers header-name]
   (when-let [v (get headers header-name)]
     (try (Long/parseLong (str v)) (catch NumberFormatException _ nil))))
 
-(defn parse-rate-headers
+;; State management
+(defn ^{:stratum 0} update-rate-state!
+  [handles-atom handle rate-info]
+  (when rate-info
+    (swap! handles-atom assoc-in [handle :rate-limit] rate-info)))
+
+(defn- ^{:stratum 0} ms-until-reset
+  "Milliseconds until the rate limit resets. Returns 0 if already past."
+  [reset-epoch]
+  (max 0 (- (* reset-epoch 1000) (System/currentTimeMillis))))
+
+;; Permit acquisition
+(defonce ^{:stratum 0} ^:private ^ScheduledExecutorService executor
+  (Executors/newSingleThreadScheduledExecutor))
+
+(def ^{:stratum 0} ^:private default-threshold
+  "Back off when remaining requests drops below this threshold."
+  10)
+
+;; Time-based (interval) rate limiting
+(defn ^{:stratum 0} time-based-acquire!
+  [rps last-request-ms]
+  (let [min-interval-ms (/ 1000.0 rps)
+        elapsed         (- (System/currentTimeMillis) (or last-request-ms 0))]
+    (when (< elapsed min-interval-ms)
+      (Thread/sleep (long (- min-interval-ms elapsed)))))
+  (System/currentTimeMillis))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} parse-rate-headers
   [headers mapping]
   (let [remaining (parse-long-header headers (:remaining mapping))
         reset-at  (parse-long-header headers (:reset mapping))
@@ -42,30 +71,7 @@
        :reset-epoch reset-at
        :limit       limit})))
 
-;;------------------------------------------------------------------------------ Layer 1
-;; State management
-
-(defn update-rate-state!
-  [handles-atom handle rate-info]
-  (when rate-info
-    (swap! handles-atom assoc-in [handle :rate-limit] rate-info)))
-
-(defn- ms-until-reset
-  "Milliseconds until the rate limit resets. Returns 0 if already past."
-  [reset-epoch]
-  (max 0 (- (* reset-epoch 1000) (System/currentTimeMillis))))
-
-;;------------------------------------------------------------------------------ Layer 2
-;; Permit acquisition
-
-(defonce ^:private ^ScheduledExecutorService executor
-  (Executors/newSingleThreadScheduledExecutor))
-
-(def ^:private default-threshold
-  "Back off when remaining requests drops below this threshold."
-  10)
-
-(defn acquire-permit!
+(defn ^{:stratum 1} acquire-permit!
   [handles-atom handle opts]
   (when-let [rate-info (get-in @handles-atom [handle :rate-limit])]
     (let [remaining (:remaining rate-info)
@@ -79,17 +85,6 @@
                          (long (min wait-ms 60000)) ;; cap at 60s
                          TimeUnit/MILLISECONDS)
               @p)))))))
-
-;;------------------------------------------------------------------------------ Layer 3
-;; Time-based (interval) rate limiting
-
-(defn time-based-acquire!
-  [rps last-request-ms]
-  (let [min-interval-ms (/ 1000.0 rps)
-        elapsed         (- (System/currentTimeMillis) (or last-request-ms 0))]
-    (when (< elapsed min-interval-ms)
-      (Thread/sleep (long (- min-interval-ms elapsed)))))
-  (System/currentTimeMillis))
 
 (comment
   ;; Provider header mappings:

--- a/components/connector-http/src/ai/miniforge/connector_http/request.clj
+++ b/components/connector-http/src/ai/miniforge/connector_http/request.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-http.request
   "Shared HTTP GET request pattern for REST API connectors.
    Handles ETag conditional requests, response classification, and
@@ -32,15 +31,15 @@
             [babashka.http-client :as http]
             [cheshire.core :as json]))
 
-;;------------------------------------------------------------------------------ Layer 0
-;; Predicates and classifiers
+;------------------------------------------------------------------------------ Layer 0
 
-(defn ok?
+;; Predicates and classifiers
+(defn ^{:stratum 0} ok?
   "Predicate: is the HTTP status a success (2xx)?"
   [status]
   (<= 200 status 299))
 
-(defn classify-error
+(defn ^{:stratum 0} classify-error
   "Classify a non-success HTTP status into an error category keyword."
   [status]
   (cond
@@ -48,45 +47,20 @@
     (<= 500 status 599) :server-error
     :else               :client-error))
 
-;;------------------------------------------------------------------------------ Layer 1
 ;; Response builders
-
-(defn success-response
+(defn ^{:stratum 0} success-response
   "Build a schema/success from a 2xx response. Caches the ETag for the URL."
   [url resp]
   (etag/store-etag! url (etag/extract-etag (:headers resp)))
   (schema/success :body (json/parse-string (:body resp) keyword)
                   {:headers (:headers resp)}))
 
-(defn not-modified-response
+(defn ^{:stratum 0} not-modified-response
   "Build a schema/success for a 304 Not Modified response."
   [resp]
   (schema/success :body nil {:headers (:headers resp) :not-modified true}))
 
-(defn error-response
-  [status resp msgs]
-  (let [request-failed (:request-failed msgs)]
-    (case (classify-error status)
-      :rate-limited (schema/failure :body (:rate-limited msgs)                      {:error-type :rate-limited})
-      :server-error (schema/failure :body (request-failed status (:server-error msgs)) {:error-type :transient})
-      :client-error (schema/failure :body (request-failed status (:body resp))      {:error-type :permanent}))))
-
-;;------------------------------------------------------------------------------ Layer 2
-;; Request execution and post-request helpers
-
-(defn do-request
-  [url headers query-params error-fn]
-  (let [resp   (http/get url {:headers      (etag/add-etag-header headers url)
-                              :query-params query-params
-                              :as           :string
-                              :throw        false})
-        status (:status resp)]
-    (cond
-      (etag/not-modified? status) (not-modified-response resp)
-      (ok? status)                (success-response url resp)
-      :else                       (error-fn status resp))))
-
-(defn throw-on-failure!
+(defn ^{:stratum 0} throw-on-failure!
   "Throw an anomaly if result is a failure. Returns result unchanged on success.
 
    The thrown ExceptionInfo carries `:anomaly/category :anomalies/unavailable`
@@ -100,13 +74,36 @@
                              {:error-type (:error-type result)}))
   result)
 
-(defn next-url
+(defn ^{:stratum 0} next-url
   [resp]
   (some-> (:headers resp)
           (get "link")
           page/parse-link-header
           page/link-header-next-url))
 
-(defn coerce-records
+(defn ^{:stratum 0} coerce-records
   [body]
   (if (sequential? body) (vec body) [body]))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} error-response
+  [status resp msgs]
+  (let [request-failed (:request-failed msgs)]
+    (case (classify-error status)
+      :rate-limited (schema/failure :body (:rate-limited msgs)                      {:error-type :rate-limited})
+      :server-error (schema/failure :body (request-failed status (:server-error msgs)) {:error-type :transient})
+      :client-error (schema/failure :body (request-failed status (:body resp))      {:error-type :permanent}))))
+
+;; Request execution and post-request helpers
+(defn ^{:stratum 1} do-request
+  [url headers query-params error-fn]
+  (let [resp   (http/get url {:headers      (etag/add-etag-header headers url)
+                              :query-params query-params
+                              :as           :string
+                              :throw        false})
+        status (:status resp)]
+    (cond
+      (etag/not-modified? status) (not-modified-response resp)
+      (ok? status)                (success-response url resp)
+      :else                       (error-fn status resp))))

--- a/components/connector-http/test/ai/miniforge/connector_http/anomaly/http_anomaly_test.clj
+++ b/components/connector-http/test/ai/miniforge/connector_http/anomaly/http_anomaly_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-http.anomaly.http-anomaly-test
   "Coverage for `impl/do-connect`, `impl/do-discover`, `impl/do-extract`,
    and `request/throw-on-failure!` anomaly behavior.
@@ -28,29 +27,31 @@
             [ai.miniforge.response.interface :as response])
   (:import (clojure.lang ExceptionInfo)))
 
-(deftest do-connect-missing-base-url-returns-anomaly
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} do-connect-missing-base-url-returns-anomaly
   (testing "missing :http/base-url returns :anomalies/incorrect"
     (let [result (impl/do-connect {:http/endpoint "/items"} nil)]
       (is (= :anomalies/incorrect (:anomaly/category result))))))
 
-(deftest do-connect-missing-endpoint-returns-anomaly
+(deftest ^{:stratum 0} do-connect-missing-endpoint-returns-anomaly
   (testing "missing :http/endpoint returns :anomalies/incorrect"
     (let [result (impl/do-connect {:http/base-url "https://x"} nil)]
       (is (= :anomalies/incorrect (:anomaly/category result))))))
 
-(deftest do-discover-missing-handle-returns-anomaly
+(deftest ^{:stratum 0} do-discover-missing-handle-returns-anomaly
   (testing "discover with bogus handle returns :anomalies/not-found"
     (let [result (impl/do-discover "no-such-handle")]
       (is (response/anomaly-map? result))
       (is (= :anomalies/not-found (:anomaly/category result)))
       (is (= "no-such-handle" (:handle result))))))
 
-(deftest do-extract-missing-handle-returns-anomaly
+(deftest ^{:stratum 0} do-extract-missing-handle-returns-anomaly
   (testing "extract with bogus handle returns :anomalies/not-found"
     (let [result (impl/do-extract "no-such-handle" {})]
       (is (= :anomalies/not-found (:anomaly/category result))))))
 
-(deftest throw-on-failure-unavailable-anomaly
+(deftest ^{:stratum 0} throw-on-failure-unavailable-anomaly
   (testing "request failure raises :anomalies/unavailable"
     (try
       (request/throw-on-failure! {:success? false
@@ -61,12 +62,12 @@
         (is (= :anomalies/unavailable (:anomaly/category (ex-data e))))
         (is (= :transient (:error-type (ex-data e))))))))
 
-(deftest throw-on-failure-passes-through-success
+(deftest ^{:stratum 0} throw-on-failure-passes-through-success
   (testing "successful result passes through unchanged"
     (let [success {:success? true :body :data}]
       (is (= success (request/throw-on-failure! success))))))
 
-(deftest fetch-single-request-failure-returns-anomaly
+(deftest ^{:stratum 0} fetch-single-request-failure-returns-anomaly
   (testing "do-extract returns fetch-single request failure as :anomalies/unavailable"
     (let [{:keys [connection/handle]} (impl/do-connect {:http/base-url "https://example.test"
                                                         :http/endpoint "/items"}

--- a/components/connector-http/test/ai/miniforge/connector_http/cursors_test.clj
+++ b/components/connector-http/test/ai/miniforge/connector_http/cursors_test.clj
@@ -15,25 +15,22 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-http.cursors-test
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.connector-http.cursors :as cursors]))
 
-;;------------------------------------------------------------------------------ Layer 0
-;; Fixtures
+;------------------------------------------------------------------------------ Layer 0
 
-(def ^:private ts-fn
+;; Fixtures
+(def ^{:stratum 0} ^:private ts-fn
   "Standard timestamp extractor for test records."
   #(or (:updated_at %) (:created_at %)))
 
-(def ^:private resource-def
+(def ^{:stratum 0} ^:private resource-def
   {:cursor-type :timestamp-watermark})
 
-;;------------------------------------------------------------------------------ Layer 1
 ;; Tests
-
-(deftest parse-timestamp-test
+(deftest ^{:stratum 0} parse-timestamp-test
   (testing "parses valid ISO-8601 timestamp to Instant"
     (is (some? (cursors/parse-timestamp "2024-01-15T10:00:00Z"))))
 
@@ -46,7 +43,9 @@
   (testing "returns nil for blank string"
     (is (nil? (cursors/parse-timestamp "   ")))))
 
-(deftest after-cursor?-test
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} after-cursor?-test
   (testing "returns true when cursor is nil (no prior watermark)"
     (is (true? (cursors/after-cursor? ts-fn nil {:updated_at "2024-01-15T10:00:00Z"}))))
 
@@ -74,7 +73,7 @@
                                        :cursor/value "2024-01-14T00:00:00Z"}
                                       {:created_at "2024-01-15T10:00:00Z"})))))
 
-(deftest last-record-cursor-test
+(deftest ^{:stratum 1} last-record-cursor-test
   (testing "returns nil for empty records"
     (is (nil? (cursors/last-record-cursor resource-def []))))
 
@@ -98,7 +97,7 @@
                                              [{:created_at "2024-01-15T10:00:00Z"}])]
       (is (= "2024-01-15T10:00:00Z" (:cursor/value cursor))))))
 
-(deftest sort-by-timestamp-test
+(deftest ^{:stratum 1} sort-by-timestamp-test
   (testing "sorts records ascending by timestamp"
     (let [records [{:updated_at "2024-01-15T10:00:00Z"}
                    {:updated_at "2024-01-13T08:00:00Z"}
@@ -117,7 +116,7 @@
   (testing "empty collection returns empty"
     (is (empty? (cursors/sort-by-timestamp ts-fn [])))))
 
-(deftest max-timestamp-cursor-test
+(deftest ^{:stratum 1} max-timestamp-cursor-test
   (testing "returns nil for empty records"
     (is (nil? (cursors/max-timestamp-cursor ts-fn []))))
 

--- a/components/connector-http/test/ai/miniforge/connector_http/etag_test.clj
+++ b/components/connector-http/test/ai/miniforge/connector_http/etag_test.clj
@@ -15,20 +15,17 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-http.etag-test
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [ai.miniforge.connector-http.etag :as etag]))
 
-;;------------------------------------------------------------------------------ Layer 0
 ;; Fixtures
-
 (use-fixtures :each (fn [f] (etag/clear-cache!) (f)))
 
-;;------------------------------------------------------------------------------ Layer 1
-;; Tests
+;------------------------------------------------------------------------------ Layer 0
 
-(deftest store-and-retrieve-etag-test
+;; Tests
+(deftest ^{:stratum 0} store-and-retrieve-etag-test
   (testing "stores and retrieves ETag for URL"
     (etag/store-etag! "https://api.github.com/repos/org/repo/pulls" "W/\"abc123\"")
     (is (= "W/\"abc123\"" (etag/get-etag "https://api.github.com/repos/org/repo/pulls"))))
@@ -40,7 +37,7 @@
     (etag/store-etag! "https://example.com" nil)
     (is (nil? (etag/get-etag "https://example.com")))))
 
-(deftest add-etag-header-test
+(deftest ^{:stratum 0} add-etag-header-test
   (testing "adds If-None-Match when ETag cached"
     (etag/store-etag! "https://example.com" "W/\"xyz\"")
     (let [headers (etag/add-etag-header {"Accept" "application/json"} "https://example.com")]
@@ -52,21 +49,21 @@
       (is (nil? (get headers "If-None-Match")))
       (is (= "text/html" (get headers "Accept"))))))
 
-(deftest extract-etag-test
+(deftest ^{:stratum 0} extract-etag-test
   (testing "extracts etag from response headers"
     (is (= "W/\"abc\"" (etag/extract-etag {"etag" "W/\"abc\""}))))
 
   (testing "returns nil when no etag header"
     (is (nil? (etag/extract-etag {"content-type" "application/json"})))))
 
-(deftest not-modified-test
+(deftest ^{:stratum 0} not-modified-test
   (testing "304 is not-modified"
     (is (true? (etag/not-modified? 304))))
 
   (testing "200 is not not-modified"
     (is (false? (etag/not-modified? 200)))))
 
-(deftest clear-cache-test
+(deftest ^{:stratum 0} clear-cache-test
   (testing "clear-cache! removes all entries"
     (etag/store-etag! "https://a.com" "e1")
     (etag/store-etag! "https://b.com" "e2")

--- a/components/connector-http/test/ai/miniforge/connector_http/interface_test.clj
+++ b/components/connector-http/test/ai/miniforge/connector_http/interface_test.clj
@@ -15,18 +15,18 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-http.interface-test
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.connector-http.interface :as http-conn]
             [ai.miniforge.connector-http.impl :as impl]
             [ai.miniforge.connector.interface :as conn]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; ---------------------------------------------------------------------------
 ;; Connector metadata
 ;; ---------------------------------------------------------------------------
-
-(deftest connector-metadata-test
+(deftest ^{:stratum 0} connector-metadata-test
   (testing "HTTP connector metadata"
     (let [meta http-conn/connector-metadata]
       (is (= :source (:connector/type meta)))
@@ -36,8 +36,7 @@
 ;; ---------------------------------------------------------------------------
 ;; Connect / close lifecycle
 ;; ---------------------------------------------------------------------------
-
-(deftest connect-close-lifecycle-test
+(deftest ^{:stratum 0} connect-close-lifecycle-test
   (testing "Connect and close lifecycle"
     (let [hc (http-conn/create-http-connector)
           result (conn/connect hc {:http/base-url "https://api.example.com"
@@ -47,13 +46,13 @@
       (let [close-result (conn/close hc (:connection/handle result))]
         (is (= :closed (:connector/status close-result)))))))
 
-(deftest connect-missing-base-url-test
+(deftest ^{:stratum 0} connect-missing-base-url-test
   (testing "Connect returns anomaly without :http/base-url"
     (let [hc (http-conn/create-http-connector)
           result (conn/connect hc {:http/endpoint "/data"} {})]
       (is (= :anomalies/incorrect (:anomaly/category result))))))
 
-(deftest connect-missing-endpoint-test
+(deftest ^{:stratum 0} connect-missing-endpoint-test
   (testing "Connect returns anomaly without :http/endpoint"
     (let [hc (http-conn/create-http-connector)
           result (conn/connect hc {:http/base-url "https://api.example.com"} {})]
@@ -62,8 +61,7 @@
 ;; ---------------------------------------------------------------------------
 ;; Extract with stubbed HTTP (override do-request)
 ;; ---------------------------------------------------------------------------
-
-(deftest extract-simple-test
+(deftest ^{:stratum 0} extract-simple-test
   (testing "Extract with simple JSON array response"
     (with-redefs [impl/do-request
                   (fn [_url _headers _params]
@@ -78,7 +76,7 @@
         (is (= [{:id 1 :name "alpha"} {:id 2 :name "beta"}] (:records result)))
         (conn/close hc handle)))))
 
-(deftest extract-nested-response-path-test
+(deftest ^{:stratum 0} extract-nested-response-path-test
   (testing "Extract with nested response path"
     (with-redefs [impl/do-request
                   (fn [_url _headers _params]
@@ -95,7 +93,7 @@
         (is (= [{:id 1} {:id 2} {:id 3}] (:records result)))
         (conn/close hc handle)))))
 
-(deftest extract-offset-pagination-test
+(deftest ^{:stratum 0} extract-offset-pagination-test
   (testing "Extract with offset-based pagination"
     (let [call-count (atom 0)]
       (with-redefs [impl/do-request
@@ -130,7 +128,7 @@
             (is (false? (:extract/has-more r2))))
           (conn/close hc handle))))))
 
-(deftest extract-cursor-pagination-test
+(deftest ^{:stratum 0} extract-cursor-pagination-test
   (testing "Extract with cursor-based pagination"
     (with-redefs [impl/do-request
                   (fn [_url _headers params]
@@ -161,7 +159,7 @@
           (is (false? (:extract/has-more r2))))
         (conn/close hc handle)))))
 
-(deftest extract-http-error-test
+(deftest ^{:stratum 0} extract-http-error-test
   (testing "Extract returns anomaly on HTTP 500"
     (with-redefs [impl/do-request
                   (fn [_url _headers _params]
@@ -176,7 +174,7 @@
           (is (= :transient (:error-type result))))
         (conn/close hc handle)))))
 
-(deftest extract-rate-limited-test
+(deftest ^{:stratum 0} extract-rate-limited-test
   (testing "Extract returns anomaly on HTTP 429"
     (with-redefs [impl/do-request
                   (fn [_url _headers _params]
@@ -195,8 +193,7 @@
 ;; ---------------------------------------------------------------------------
 ;; Batch extract
 ;; ---------------------------------------------------------------------------
-
-(deftest batch-extract-parallel-test
+(deftest ^{:stratum 0} batch-extract-parallel-test
   (testing "Extract with :batch/param-sets fetches all param sets in parallel"
     (let [calls (atom [])]
       (with-redefs [impl/do-request
@@ -225,7 +222,7 @@
           (is (false? (:extract/has-more result)))
           (conn/close hc handle))))))
 
-(deftest batch-extract-enriches-records-test
+(deftest ^{:stratum 0} batch-extract-enriches-records-test
   (testing "Batch extract merges param-set keys into each record"
     (with-redefs [impl/do-request
                   (fn [_url _headers _params]
@@ -247,7 +244,7 @@
         (is (= "2026-01-01" (:date (first records))))
         (conn/close hc handle)))))
 
-(deftest batch-extract-error-propagates-test
+(deftest ^{:stratum 0} batch-extract-error-propagates-test
   (testing "Batch extract returns anomaly from individual fetches"
     (with-redefs [impl/do-request
                   (fn [_url _headers params]
@@ -269,8 +266,7 @@
 ;; ---------------------------------------------------------------------------
 ;; Auth header construction
 ;; ---------------------------------------------------------------------------
-
-(deftest auth-header-api-key-test
+(deftest ^{:stratum 0} auth-header-api-key-test
   (testing "API key auth sets Bearer header"
     (with-redefs [impl/do-request
                   (fn [_url headers _params]
@@ -285,7 +281,7 @@
         (conn/extract hc handle "data" {})
         (conn/close hc handle)))))
 
-(deftest auth-header-basic-test
+(deftest ^{:stratum 0} auth-header-basic-test
   (testing "Basic auth sets Basic header"
     (with-redefs [impl/do-request
                   (fn [_url headers _params]
@@ -303,8 +299,7 @@
 ;; ---------------------------------------------------------------------------
 ;; Discover
 ;; ---------------------------------------------------------------------------
-
-(deftest discover-test
+(deftest ^{:stratum 0} discover-test
   (testing "Discover returns endpoint info"
     (let [hc (http-conn/create-http-connector)
           handle (:connection/handle
@@ -318,8 +313,7 @@
 ;; ---------------------------------------------------------------------------
 ;; Checkpoint
 ;; ---------------------------------------------------------------------------
-
-(deftest checkpoint-test
+(deftest ^{:stratum 0} checkpoint-test
   (testing "Checkpoint returns committed status"
     (let [hc (http-conn/create-http-connector)
           handle (:connection/handle

--- a/components/connector-http/test/ai/miniforge/connector_http/rate_limit_test.clj
+++ b/components/connector-http/test/ai/miniforge/connector_http/rate_limit_test.clj
@@ -15,24 +15,40 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-http.rate-limit-test
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.connector-http.rate-limit :as rate]))
 
-;;------------------------------------------------------------------------------ Layer 0
-;; Fixtures
+;------------------------------------------------------------------------------ Layer 0
 
-(def github-mapping
+;; Fixtures
+(def ^{:stratum 0} github-mapping
   {:remaining "x-ratelimit-remaining" :reset "x-ratelimit-reset" :limit "x-ratelimit-limit"})
 
-(def gitlab-mapping
+(def ^{:stratum 0} gitlab-mapping
   {:remaining "ratelimit-remaining" :reset "ratelimit-reset" :limit "ratelimit-limit"})
 
-;;------------------------------------------------------------------------------ Layer 1
-;; Tests
+(deftest ^{:stratum 0} update-rate-state-test
+  (testing "stores rate info in handle atom"
+    (let [handles (atom {"h1" {:config {}}})]
+      (rate/update-rate-state! handles "h1" {:remaining 100 :reset-epoch 99999})
+      (is (= 100 (get-in @handles ["h1" :rate-limit :remaining])))))
 
-(deftest parse-rate-headers-test
+  (testing "no-op when rate-info is nil"
+    (let [handles (atom {"h1" {:config {}}})]
+      (rate/update-rate-state! handles "h1" nil)
+      (is (nil? (get-in @handles ["h1" :rate-limit]))))))
+
+(deftest ^{:stratum 0} acquire-permit-no-block-test
+  (testing "does not block when remaining is above threshold"
+    (let [handles (atom {"h1" {:rate-limit {:remaining 4990 :reset-epoch 9999999999}}})]
+      ;; Should return immediately (nil = no wait needed)
+      (is (nil? (rate/acquire-permit! handles "h1" {}))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Tests
+(deftest ^{:stratum 1} parse-rate-headers-test
   (testing "parses GitHub rate limit headers"
     (let [headers {"x-ratelimit-remaining" "4990"
                    "x-ratelimit-reset" "1711468800"
@@ -57,23 +73,6 @@
     (is (nil? (rate/parse-rate-headers {"x-ratelimit-remaining" "bogus"
                                         "x-ratelimit-reset" "also-bogus"}
                                        github-mapping)))))
-
-(deftest update-rate-state-test
-  (testing "stores rate info in handle atom"
-    (let [handles (atom {"h1" {:config {}}})]
-      (rate/update-rate-state! handles "h1" {:remaining 100 :reset-epoch 99999})
-      (is (= 100 (get-in @handles ["h1" :rate-limit :remaining])))))
-
-  (testing "no-op when rate-info is nil"
-    (let [handles (atom {"h1" {:config {}}})]
-      (rate/update-rate-state! handles "h1" nil)
-      (is (nil? (get-in @handles ["h1" :rate-limit]))))))
-
-(deftest acquire-permit-no-block-test
-  (testing "does not block when remaining is above threshold"
-    (let [handles (atom {"h1" {:rate-limit {:remaining 4990 :reset-epoch 9999999999}}})]
-      ;; Should return immediately (nil = no wait needed)
-      (is (nil? (rate/acquire-permit! handles "h1" {}))))))
 
 (comment
   ;; Run: clj -M:dev:test -n ai.miniforge.connector-http.rate-limit-test

--- a/components/connector-http/test/ai/miniforge/connector_http/request_test.clj
+++ b/components/connector-http/test/ai/miniforge/connector_http/request_test.clj
@@ -15,41 +15,38 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-http.request-test
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [ai.miniforge.connector-http.etag :as etag]
             [ai.miniforge.connector-http.request :as request]
             [babashka.http-client :as http]))
 
-;;------------------------------------------------------------------------------ Layer 0
 ;; Fixtures
-
 (use-fixtures :each (fn [f] (etag/clear-cache!) (f)))
 
-(def ^:private error-msgs
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private error-msgs
   {:rate-limited   "Rate limited"
    :server-error   "server error"
    :request-failed (fn [s e] (str "Failed " s ": " e))})
 
-;;------------------------------------------------------------------------------ Layer 1
 ;; Tests
-
-(deftest ok?-test
+(deftest ^{:stratum 0} ok?-test
   (testing "200 is ok"  (is (true?  (request/ok? 200))))
   (testing "299 is ok"  (is (true?  (request/ok? 299))))
   (testing "404 is not" (is (false? (request/ok? 404))))
   (testing "500 is not" (is (false? (request/ok? 500))))
   (testing "304 is not" (is (false? (request/ok? 304)))))
 
-(deftest classify-error-test
+(deftest ^{:stratum 0} classify-error-test
   (testing "429 is :rate-limited"  (is (= :rate-limited  (request/classify-error 429))))
   (testing "500 is :server-error"  (is (= :server-error  (request/classify-error 500))))
   (testing "503 is :server-error"  (is (= :server-error  (request/classify-error 503))))
   (testing "404 is :client-error"  (is (= :client-error  (request/classify-error 404))))
   (testing "401 is :client-error"  (is (= :client-error  (request/classify-error 401)))))
 
-(deftest success-response-test
+(deftest ^{:stratum 0} success-response-test
   (testing "parses JSON body and carries headers"
     (let [url    "https://api.example.com/repos"
           resp   {:status 200 :body "[{\"id\":1}]" :headers {"content-type" "application/json"}}
@@ -69,14 +66,89 @@
           resp {:status 200 :body "[]" :headers {}}]
       (is (some? (request/success-response url resp))))))
 
-(deftest not-modified-response-test
+(deftest ^{:stratum 0} not-modified-response-test
   (testing "returns success with nil body and :not-modified true"
     (let [result (request/not-modified-response {:status 304 :headers {"etag" "W/\"abc\""}})]
       (is (true? (:success? result)))
       (is (nil? (:body result)))
       (is (true? (:not-modified result))))))
 
-(deftest error-response-test
+(deftest ^{:stratum 0} do-request-test
+  (testing "returns success for 2xx"
+    (with-redefs [http/get (fn [_ _] {:status 200 :body "[{\"id\":1}]" :headers {}})]
+      (let [result (request/do-request "https://example.com" {} {} (fn [_ _] nil))]
+        (is (true? (:success? result)))
+        (is (= [{:id 1}] (:body result))))))
+
+  (testing "returns not-modified for 304"
+    (with-redefs [http/get (fn [_ _] {:status 304 :body "" :headers {}})]
+      (let [result (request/do-request "https://example.com" {} {} (fn [_ _] nil))]
+        (is (true? (:success? result)))
+        (is (nil? (:body result)))
+        (is (true? (:not-modified result))))))
+
+  (testing "delegates non-2xx non-304 to error-fn"
+    (with-redefs [http/get (fn [_ _] {:status 429 :body "" :headers {}})]
+      (let [called (atom nil)]
+        (request/do-request "https://example.com" {} {}
+                            (fn [s r] (reset! called s) {:success? false :error-type :rate-limited}))
+        (is (= 429 @called)))))
+
+  (testing "adds If-None-Match when ETag is cached"
+    (etag/store-etag! "https://example.com/cached" "W/\"xyz\"")
+    (let [received-headers (atom nil)]
+      (with-redefs [http/get (fn [_ opts] (reset! received-headers (:headers opts))
+                              {:status 200 :body "[]" :headers {}})]
+        (request/do-request "https://example.com/cached" {} {} (fn [_ _] nil))
+        (is (= "W/\"xyz\"" (get @received-headers "If-None-Match")))))))
+
+(deftest ^{:stratum 0} throw-on-failure!-test
+  (testing "returns result unchanged on success"
+    (let [result {:success? true :body [{:id 1}]}]
+      (is (= result (request/throw-on-failure! result)))))
+
+  (testing "throws ex-info on failure"
+    (is (thrown? clojure.lang.ExceptionInfo
+          (request/throw-on-failure! {:success? false :error "failed" :error-type :permanent}))))
+
+  (testing "thrown exception carries error-type in ex-data"
+    (try
+      (request/throw-on-failure! {:success? false :error "transient" :error-type :transient})
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :transient (:error-type (ex-data e))))))))
+
+(deftest ^{:stratum 0} next-url-test
+  (testing "returns next URL from Link header"
+    (let [link "<https://api.example.com?page=2>; rel=\"next\", <https://api.example.com?page=5>; rel=\"last\""
+          resp {:headers {"link" link}}]
+      (is (= "https://api.example.com?page=2" (request/next-url resp)))))
+
+  (testing "returns nil when no next rel in Link header"
+    (let [resp {:headers {"link" "<https://api.example.com?page=5>; rel=\"last\""}}]
+      (is (nil? (request/next-url resp)))))
+
+  (testing "returns nil when no Link header"
+    (is (nil? (request/next-url {:headers {}}))))
+
+  (testing "returns nil when headers are absent"
+    (is (nil? (request/next-url {})))))
+
+(deftest ^{:stratum 0} coerce-records-test
+  (testing "vector body returned as vec"
+    (is (= [{:a 1} {:b 2}] (request/coerce-records [{:a 1} {:b 2}]))))
+
+  (testing "map body wrapped in vector"
+    (is (= [{:id 1}] (request/coerce-records {:id 1}))))
+
+  (testing "list body coerced to vector"
+    (is (= [{:a 1}] (request/coerce-records (list {:a 1})))))
+
+  (testing "empty vector stays empty"
+    (is (= [] (request/coerce-records [])))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} error-response-test
   (testing "rate-limited response has :rate-limited error-type"
     (let [result (request/error-response 429 {:body ""} error-msgs)]
       (is (false? (:success? result)))
@@ -107,79 +179,6 @@
                  :request-failed (fn [s e] (swap! calls conj {:status s :error e}) "")}]
       (request/error-response 403 {:body "forbidden"} msgs)
       (is (= "forbidden" (:error (first @calls)))))))
-
-(deftest do-request-test
-  (testing "returns success for 2xx"
-    (with-redefs [http/get (fn [_ _] {:status 200 :body "[{\"id\":1}]" :headers {}})]
-      (let [result (request/do-request "https://example.com" {} {} (fn [_ _] nil))]
-        (is (true? (:success? result)))
-        (is (= [{:id 1}] (:body result))))))
-
-  (testing "returns not-modified for 304"
-    (with-redefs [http/get (fn [_ _] {:status 304 :body "" :headers {}})]
-      (let [result (request/do-request "https://example.com" {} {} (fn [_ _] nil))]
-        (is (true? (:success? result)))
-        (is (nil? (:body result)))
-        (is (true? (:not-modified result))))))
-
-  (testing "delegates non-2xx non-304 to error-fn"
-    (with-redefs [http/get (fn [_ _] {:status 429 :body "" :headers {}})]
-      (let [called (atom nil)]
-        (request/do-request "https://example.com" {} {}
-                            (fn [s r] (reset! called s) {:success? false :error-type :rate-limited}))
-        (is (= 429 @called)))))
-
-  (testing "adds If-None-Match when ETag is cached"
-    (etag/store-etag! "https://example.com/cached" "W/\"xyz\"")
-    (let [received-headers (atom nil)]
-      (with-redefs [http/get (fn [_ opts] (reset! received-headers (:headers opts))
-                              {:status 200 :body "[]" :headers {}})]
-        (request/do-request "https://example.com/cached" {} {} (fn [_ _] nil))
-        (is (= "W/\"xyz\"" (get @received-headers "If-None-Match")))))))
-
-(deftest throw-on-failure!-test
-  (testing "returns result unchanged on success"
-    (let [result {:success? true :body [{:id 1}]}]
-      (is (= result (request/throw-on-failure! result)))))
-
-  (testing "throws ex-info on failure"
-    (is (thrown? clojure.lang.ExceptionInfo
-          (request/throw-on-failure! {:success? false :error "failed" :error-type :permanent}))))
-
-  (testing "thrown exception carries error-type in ex-data"
-    (try
-      (request/throw-on-failure! {:success? false :error "transient" :error-type :transient})
-      (catch clojure.lang.ExceptionInfo e
-        (is (= :transient (:error-type (ex-data e))))))))
-
-(deftest next-url-test
-  (testing "returns next URL from Link header"
-    (let [link "<https://api.example.com?page=2>; rel=\"next\", <https://api.example.com?page=5>; rel=\"last\""
-          resp {:headers {"link" link}}]
-      (is (= "https://api.example.com?page=2" (request/next-url resp)))))
-
-  (testing "returns nil when no next rel in Link header"
-    (let [resp {:headers {"link" "<https://api.example.com?page=5>; rel=\"last\""}}]
-      (is (nil? (request/next-url resp)))))
-
-  (testing "returns nil when no Link header"
-    (is (nil? (request/next-url {:headers {}}))))
-
-  (testing "returns nil when headers are absent"
-    (is (nil? (request/next-url {})))))
-
-(deftest coerce-records-test
-  (testing "vector body returned as vec"
-    (is (= [{:a 1} {:b 2}] (request/coerce-records [{:a 1} {:b 2}]))))
-
-  (testing "map body wrapped in vector"
-    (is (= [{:id 1}] (request/coerce-records {:id 1}))))
-
-  (testing "list body coerced to vector"
-    (is (= [{:a 1}] (request/coerce-records (list {:a 1})))))
-
-  (testing "empty vector stays empty"
-    (is (= [] (request/coerce-records [])))))
 
 (comment
   ;; Run: clj -M:dev:test -n ai.miniforge.connector-http.request-test

--- a/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-connector-http.md
+++ b/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-connector-http.md
@@ -1,0 +1,97 @@
+# fix: stratum-lint autofix for components/connector-http (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over the whole `connector-http` component
+(`src` + `test`) to replace the file's `Layer N` headings with headings
+regenerated from its real same-file reference graph, and tags each
+`def`/`defn`/`deftest` with `^{:stratum n}` metadata. Purely mechanical:
+no logic changes. Part of the per-component Wave 1 sweep from
+`work/stratum-lint-baseline-2026-07-24.md`.
+
+## Motivation
+
+`components/connector-http` carried exactly one baseline finding: `SL003`
+on `rate_limit.clj` (file reporting 4 distinct layers against the 3-layer
+budget), with zero `SL001` (upward-reference) findings — the reason
+this component was Wave 1 scope rather than needing the SL001 human
+triage from Wave 3.
+
+## Changes in Detail
+
+Reset onto current `origin/main` first (the pinned-sha staleness bug that
+hit three earlier Wave 1 PRs), confirmed the `tasks/stratum.clj` pin
+(`80699e378cb8ebbb6daeb928431aa4a6b373c07e`), then ran:
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "80699e378cb8ebbb6daeb928431aa4a6b373c07e" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/connector-http
+```
+
+15 files rewritten (9 `src`, 6 `test`) — every `.clj` file in the
+component, including files with no prior findings (`--fix` normalizes
+those too). Diff stat: 15 files changed, 312 insertions(+), 316
+deletions(-).
+
+`rate_limit.clj`'s own real reference graph turned out shallower than its
+old headings claimed: `time-based-acquire!` and `update-rate-state!`
+don't call anything else in the file (real Layer 0, alongside
+`parse-long-header`, `ms-until-reset`, `executor`, `default-threshold`),
+and `parse-rate-headers`/`acquire-permit!` each call one Layer-0 def (real
+Layer 1). Two real layers, not four — the old headings were
+over-reporting depth, not under-reporting it as seen in other Wave 1
+components. No SL003 remains after the fix.
+
+## Testing Plan
+
+1. Ran plain (non-`--fix`) `stratum-lint` on `components/connector-http`
+   before the fix — reproduced the single baseline `SL003` finding on
+   `rate_limit.clj`.
+2. Ran `--fix`, then ran it a second time to verify idempotency — zero
+   diff between the two passes (`diff -rq` on the full component tree).
+3. Read the full diff for every one of the 15 changed files. Confirmed
+   heading regrouping, `^{:stratum n}` metadata, and def reordering only.
+   Checked specifically for the known tool limitation where a same-line
+   trailing comment can get reattached to the wrong def after reordering
+   — no same-line trailing comments existed in this component before or
+   after the fix (only leading `;;`/`;` block comments, which moved
+   correctly with their following def), so no hand-fix was needed.
+4. Ran `clj-kondo --lint components/connector-http`: 0 errors, 1 warning
+   (unused binding `r` in `request_test.clj`), confirmed pre-existing on
+   `origin/main` at the same content (line number only shifted from 129
+   to 94 due to reordering) — not introduced by this change.
+5. Re-ran plain `stratum-lint` on `components/connector-http` after the
+   fix: exit 0, zero findings remain. No `SL003` (or any other check)
+   left over — nothing deferred to Wave 2 for this component.
+6. Ran the component's full test suite via
+   `clojure -M:poly test brick:connector-http`: 6 namespaces, 46 tests,
+   146 assertions, 0 failures, 0 errors.
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+changes — comment/metadata/reorder only. The pre-commit hook's
+`lint:stratum` autofixer keeps this component clean going forward.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1 —
+  mechanical relabeling via `--fix`, decorative-heading files only)
+- Depends on: `2026-07-24-fix-stratum-lint-autofix-precommit.md` (upstream
+  sha bump + autofix wiring)
+- Precedent PRs from the same wave: `2026-07-24-fix-stratum-lint-wave1-compliance-scanner.md`,
+  `-reliability.md`, `-gate.md`, `-decision.md`, `-adapter-claude-code.md`
+
+## Checklist
+
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Idempotency verified: second `--fix` pass produced zero diff
+- [x] Diff read in full for every changed file; confirmed mechanical-only
+      (heading + metadata + reorder); no trailing-comment misattachment
+      found or needed hand-fixing
+- [x] `clj-kondo` clean (0 errors; 1 pre-existing warning, unaffected by
+      this change)
+- [x] Plain lint re-run post-fix: zero findings (no `SL003` remains — no
+      Wave 2 follow-on needed for this component)
+- [x] Full component test suite passing (46 tests, 146 assertions, 0
+      failures/errors)
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
## Summary

- Runs `stratum-lint --fix` over the whole `connector-http` component (`src` + `test`, 15 files) to replace the single `SL003` finding (`rate_limit.clj` reporting 4 layers against the 3-layer budget) with headings and `^{:stratum n}` metadata regenerated from the file's real same-file reference graph.
- `rate_limit.clj`'s real reference graph is only 2 layers deep, not 4 — the old headings were over-reporting depth. Zero findings remain after the fix; no Wave 2 (namespace split) follow-on needed for this component.
- Purely mechanical: heading regrouping, `^{:stratum n}` metadata, def reordering. No logic changes.

Part of the Wave 1 sweep tracked in `work/stratum-lint-baseline-2026-07-24.md`.

## Test plan

- [x] Reproduced the baseline: plain (non-`--fix`) lint on `components/connector-http` before the fix showed exactly one `SL003` finding, zero `SL001`.
- [x] Idempotency: ran `--fix` twice; second pass produced zero diff (`diff -rq` on the full component tree).
- [x] Read the full diff for every one of the 15 changed files — heading/metadata/reorder only. Checked specifically for the known trailing-same-line-comment reattachment issue; none existed in this component before or after the fix, so no hand-fix was needed.
- [x] `clj-kondo --lint components/connector-http`: 0 errors, 1 warning (unused binding `r` in `request_test.clj`) — confirmed pre-existing on `origin/main` at identical content, only the line number shifted due to reordering.
- [x] Re-ran plain lint post-fix: exit 0, zero findings remain.
- [x] Full component test suite (`clojure -M:poly test brick:connector-http`): 6 namespaces, 46 tests, 146 assertions, 0 failures, 0 errors.
- [x] Pre-commit hook (stratum-lint autofix re-run, clj-kondo, smoke tests, GraalVM compat) passed clean at commit time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)