### PR TITLE
fix: stratum-lint autofix for components/connector-linter (Wave 1)

### DIFF
--- a/components/connector-linter/src/ai/miniforge/connector_linter/etl.clj
+++ b/components/connector-linter/src/ai/miniforge/connector_linter/etl.clj
@@ -8,9 +8,12 @@
    violation shape using declarative mapping specs loaded from EDN.
    No parser code per linter — all extraction is driven by data.
 
-   Layer 0: Field extraction and severity mapping
-   Layer 1: Format-specific record extraction
-   Layer 2: Apply mapping spec to produce violations"
+   Layer 0: Field extraction, severity mapping, JSON parsing, and the
+            mapping registry's resource name
+   Layer 1: Per-record transform, filter matching, format-specific
+            record extraction, and the mapping registry itself
+   Layer 2: Format dispatch and mapping lookup
+   Layer 3: Apply mapping spec to produce violations"
   (:require
    [ai.miniforge.compliance-scanner.interface :as factory]
    [cheshire.core :as json]
@@ -62,7 +65,6 @@
   [linter-id fields severity-map record file-override]
   (let [file     (or file-override (str (extract-field record (get fields :file))))
         line     (extract-field record (get fields :line))
-        column   (extract-field record (get fields :column))
         message  (extract-field record (get fields :message))
         code     (let [c (extract-field record (get fields :code))]
                    (if (keyword? c) (name c) (str c)))

--- a/components/connector-linter/src/ai/miniforge/connector_linter/etl.clj
+++ b/components/connector-linter/src/ai/miniforge/connector_linter/etl.clj
@@ -1,7 +1,6 @@
 ;; Title: Miniforge.ai
 ;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
 ;; Licensed under the Apache License, Version 2.0
-
 (ns ai.miniforge.connector-linter.etl
   "Data-driven field-mapping ETL engine for linter output.
 
@@ -20,9 +19,9 @@
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Field extraction
 
-(defn- extract-field
+;; Field extraction
+(defn- ^{:stratum 0} extract-field
   "Extract a value from a record using a path spec.
    Path can be a keyword (single key) or vector (get-in path).
    Numeric elements in vectors index into sequential collections."
@@ -38,14 +37,26 @@
                                  path-spec)
     :else                nil))
 
-(defn- map-severity
+(defn- ^{:stratum 0} map-severity
   "Map a raw severity value to a canonical severity keyword using the mapping's severity-map."
   [severity-map raw-value]
   (let [key (if (keyword? raw-value) (name raw-value) raw-value)]
     (get severity-map key
          (get severity-map raw-value :low))))
 
-(defn- record->violation
+;; Format-specific record extraction
+(defn- ^{:stratum 0} parse-json-safe
+  "Parse JSON string, returning nil on failure."
+  [s]
+  (when-not (str/blank? s)
+    (try (json/parse-string s true) (catch Exception _ nil))))
+
+;; Mapping registry
+(def ^{:stratum 0} ^:private mappings-resource "connector_linter/linter-mappings.edn")
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} record->violation
   "Transform a single parsed record into the canonical violation shape
    using the field mapping spec."
   [linter-id fields severity-map record file-override]
@@ -69,16 +80,7 @@
             (str (name linter-id) ": " (or message "")))
            :rule/severity severity)))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Format-specific record extraction
-
-(defn- parse-json-safe
-  "Parse JSON string, returning nil on failure."
-  [s]
-  (when-not (str/blank? s)
-    (try (json/parse-string s true) (catch Exception _ nil))))
-
-(defn- matches-filter?
+(defn- ^{:stratum 1} matches-filter?
   "Check if a record matches the mapping's filter predicate."
   [filter-spec record]
   (if filter-spec
@@ -86,7 +88,7 @@
        (extract-field record (get filter-spec :path)))
     true))
 
-(defn- extract-records-json
+(defn- ^{:stratum 1} extract-records-json
   "Extract records from a JSON array. Optionally unwrap via path."
   [output unwrap-path]
   (let [data (parse-json-safe output)]
@@ -94,12 +96,12 @@
       (extract-field data unwrap-path)
       (when (sequential? data) data))))
 
-(defn- extract-records-json-lines
+(defn- ^{:stratum 1} extract-records-json-lines
   "Extract records from newline-delimited JSON (one object per line)."
   [output]
   (keep parse-json-safe (str/split-lines output)))
 
-(defn- extract-records-json-nested
+(defn- ^{:stratum 1} extract-records-json-nested
   "Extract records from a JSON array of parent objects, each containing
    a nested array of child records. File path comes from the parent."
   [output parent-file-path unwrap-path]
@@ -111,7 +113,7 @@
                   (mapv #(assoc % ::parent-file file) children)))
               parents))))
 
-(defn- extract-records-edn
+(defn- ^{:stratum 1} extract-records-edn
   "Extract records from EDN output. Optionally unwrap via path."
   [output unwrap-path]
   (try
@@ -121,7 +123,16 @@
         (when (sequential? data) data)))
     (catch Exception _ nil)))
 
-(defn- extract-records
+(def ^{:stratum 1} mappings
+  (delay
+    (if-let [url (io/resource mappings-resource)]
+      (let [raw (edn/read-string (slurp url))]
+        (zipmap (map :mapping/id raw) raw))
+      {})))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- ^{:stratum 2} extract-records
   "Dispatch record extraction based on format."
   [output mapping]
   (let [fmt    (get mapping :mapping/format)
@@ -135,10 +146,14 @@
       :edn         (extract-records-edn output unwrap)
       nil)))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Apply mapping
+(defn ^{:stratum 2} get-mapping
+  [linter-id]
+  (get @mappings linter-id))
 
-(defn apply-mapping
+;------------------------------------------------------------------------------ Layer 3
+
+;; Apply mapping
+(defn ^{:stratum 3} apply-mapping
   [mapping output]
   (let [linter-id    (get mapping :mapping/id)
         fields       (get mapping :mapping/fields)
@@ -151,19 +166,3 @@
                  (record->violation linter-id fields severity-map record
                                    (get record ::parent-file))))
          (filterv #(seq (:current %))))))
-
-;------------------------------------------------------------------------------ Layer 2
-;; Mapping registry
-
-(def ^:private mappings-resource "connector_linter/linter-mappings.edn")
-
-(def mappings
-  (delay
-    (if-let [url (io/resource mappings-resource)]
-      (let [raw (edn/read-string (slurp url))]
-        (zipmap (map :mapping/id raw) raw))
-      {})))
-
-(defn get-mapping
-  [linter-id]
-  (get @mappings linter-id))

--- a/components/connector-linter/src/ai/miniforge/connector_linter/etl.clj
+++ b/components/connector-linter/src/ai/miniforge/connector_linter/etl.clj
@@ -47,7 +47,7 @@
     (get severity-map key
          (get severity-map raw-value :low))))
 
-;; Format-specific record extraction
+;; JSON parsing
 (defn- ^{:stratum 0} parse-json-safe
   "Parse JSON string, returning nil on failure."
   [s]

--- a/components/connector-linter/src/ai/miniforge/connector_linter/interface.clj
+++ b/components/connector-linter/src/ai/miniforge/connector_linter/interface.clj
@@ -1,46 +1,52 @@
 ;; Title: Miniforge.ai
 ;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
 ;; Licensed under the Apache License, Version 2.0
-
 (ns ai.miniforge.connector-linter.interface
   "Public API for data-driven linter integration."
   (:require
    [ai.miniforge.connector-linter.etl :as etl]
    [ai.miniforge.connector-linter.runner :as runner]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; ETL
-(def apply-mapping
+(def ^{:stratum 0} apply-mapping
   "Apply a mapping spec to raw linter output, producing canonical violations.
    Args: mapping (spec map from linter-mappings.edn), output (raw linter output
    string). Returns a vector of violation maps (empty when nothing matches);
    never nil."
   etl/apply-mapping)
-(def get-mapping
+
+(def ^{:stratum 0} get-mapping
   "Look up a mapping spec by linter ID. Args: linter-id (keyword). Returns the
    mapping map, or nil if no mapping is registered for that ID."
   etl/get-mapping)
-(def mappings
+
+(def ^{:stratum 0} mappings
   "All linter mappings loaded from classpath EDN, as a `delay`. Deref to obtain
    a map of {linter-id mapping-spec}; yields {} when the resource is absent."
   etl/mappings)
 
 ;; Runner
-(def linter-available?
+(def ^{:stratum 0} linter-available?
   "Check whether a linter CLI is available on PATH. Args: check-cmd (command
    vector). Returns boolean; false on any subprocess failure."
   runner/linter-available?)
-(def run-linter
+
+(def ^{:stratum 0} run-linter
   "Run a single linter and parse its output via the ETL mapping. Args:
    repo-path, tech-id (keyword), linter-config (map). Returns a map
    {:tech keyword :violations vector :available? boolean :duration-ms int}."
   runner/run-linter)
-(def run-all
+
+(def ^{:stratum 0} run-all
   "Run linters for all detected technologies. Args: repo-path, fingerprints
    (seq of tech fingerprint maps), detected-techs (set of tech-id keywords).
    Returns a map {:linter-results vector :violations vector
    :total-violations int :total-duration-ms int}."
   runner/run-all)
-(def run-fixes
+
+(def ^{:stratum 0} run-fixes
   "Run linter fix commands for detected technologies. Args: repo-path,
    fingerprints (seq of tech fingerprint maps), detected-techs (set of tech-id
    keywords). Returns a map {:fixed vector} of per-tech {:tech :exit} results."

--- a/components/connector-linter/src/ai/miniforge/connector_linter/runner.clj
+++ b/components/connector-linter/src/ai/miniforge/connector_linter/runner.clj
@@ -7,9 +7,8 @@
    Stratification (intra-namespace):
    Layer 0 — `linter-available?`, `run-subprocess`, `lintable-tech`
              (no in-ns deps).
-   Layer 1 — `run-linter` (composes Layer 0).
-   Layer 2 — `run-all`, `run-fixes` (public orchestration; compose
-             Layer 1)."
+   Layer 1 — `run-linter`, `run-fixes` (compose Layer 0).
+   Layer 2 — `run-all` (public orchestration; composes Layer 1)."
   (:require
    [ai.miniforge.clock.interface :as clock]
    [ai.miniforge.connector-linter.etl :as etl]

--- a/components/connector-linter/src/ai/miniforge/connector_linter/runner.clj
+++ b/components/connector-linter/src/ai/miniforge/connector_linter/runner.clj
@@ -1,7 +1,6 @@
 ;; Title: Miniforge.ai
 ;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
 ;; Licensed under the Apache License, Version 2.0
-
 (ns ai.miniforge.connector-linter.runner
   "Run linter subprocesses and parse output via ETL mappings.
 
@@ -17,16 +16,16 @@
    [babashka.process :as process]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; No in-namespace dependencies.
 
-(defn linter-available?
+;; No in-namespace dependencies.
+(defn ^{:stratum 0} linter-available?
   [check-cmd]
   (try
     (zero? (:exit (process/sh {:cmd check-cmd :continue true
                                :out :string :err :string})))
     (catch Exception _ false)))
 
-(defn- run-subprocess
+(defn- ^{:stratum 0} run-subprocess
   "Run a linter subprocess. Returns {:exit int :out string :err string}."
   [repo-path command args]
   (try
@@ -38,16 +37,16 @@
     (catch Exception e
       {:exit -1 :out "" :err (.getMessage e)})))
 
-(defn- lintable-tech
+(defn- ^{:stratum 0} lintable-tech
   "True when a fingerprint has a linter and is in the detected set."
   [detected-techs fingerprint]
   (and (:tech/linter fingerprint)
        (contains? detected-techs (:tech/id fingerprint))))
 
 ;------------------------------------------------------------------------------ Layer 1
-;; Composes Layer 0.
 
-(defn run-linter
+;; Composes Layer 0.
+(defn ^{:stratum 1} run-linter
   [repo-path tech-id linter-config]
   (let [{:keys [command args parser check-cmd]} linter-config
         available? (linter-available? (or check-cmd [command "--version"]))
@@ -65,23 +64,7 @@
          :available?  true
          :duration-ms (clock/elapsed-since start-ms)}))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Public orchestration — composes Layer 1 (`run-linter`) + Layer 0
-;; helpers (`lintable-tech`, `linter-available?`, `run-subprocess`).
-
-(defn run-all
-  [repo-path fingerprints detected-techs]
-  (let [lintable (filter #(lintable-tech detected-techs %) fingerprints)
-        results  (mapv (fn [fp]
-                         (run-linter repo-path (:tech/id fp) (:tech/linter fp)))
-                       lintable)
-        all-viols (vec (mapcat :violations results))]
-    {:linter-results    results
-     :violations        all-viols
-     :total-violations  (count all-viols)
-     :total-duration-ms (reduce + 0 (map :duration-ms results))}))
-
-(defn run-fixes
+(defn ^{:stratum 1} run-fixes
   [repo-path fingerprints detected-techs]
   (let [fixable (->> fingerprints
                      (filter #(lintable-tech detected-techs %))
@@ -93,3 +76,19 @@
                       {:tech (:tech/id fp)
                        :exit (:exit (run-subprocess repo-path command fix-args))})))
                 fixable))}))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Public orchestration — composes Layer 1 (`run-linter`) + Layer 0
+;; helpers (`lintable-tech`, `linter-available?`, `run-subprocess`).
+(defn ^{:stratum 2} run-all
+  [repo-path fingerprints detected-techs]
+  (let [lintable (filter #(lintable-tech detected-techs %) fingerprints)
+        results  (mapv (fn [fp]
+                         (run-linter repo-path (:tech/id fp) (:tech/linter fp)))
+                       lintable)
+        all-viols (vec (mapcat :violations results))]
+    {:linter-results    results
+     :violations        all-viols
+     :total-violations  (count all-viols)
+     :total-duration-ms (reduce + 0 (map :duration-ms results))}))

--- a/components/connector-linter/test/ai/miniforge/connector_linter/etl_test.clj
+++ b/components/connector-linter/test/ai/miniforge/connector_linter/etl_test.clj
@@ -1,71 +1,25 @@
 ;; Title: Miniforge.ai
 ;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
 ;; Licensed under the Apache License, Version 2.0
-
 (ns ai.miniforge.connector-linter.etl-test
   "Tests for the data-driven ETL engine — field extraction, format parsing, mapping application."
   (:require
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.connector-linter.etl :as sut]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; Access private functions
-(def extract-field (var-get #'sut/extract-field))
-(def map-severity (var-get #'sut/map-severity))
-(def matches-filter? (var-get #'sut/matches-filter?))
+(def ^{:stratum 0} extract-field (var-get #'sut/extract-field))
 
-;; ============================================================================
-;; Field extraction
-;; ============================================================================
+(def ^{:stratum 0} map-severity (var-get #'sut/map-severity))
 
-(deftest extract-field-keyword-test
-  (testing "extracts by keyword"
-    (is (= "foo.clj" (extract-field {:filename "foo.clj"} :filename)))))
-
-(deftest extract-field-vector-path-test
-  (testing "extracts by vector path"
-    (is (= 42 (extract-field {:pos {:line 42}} [:pos :line]))))
-
-  (testing "extracts through array index"
-    (is (= "bar.rs" (extract-field {:spans [{:file "bar.rs"}]} [:spans 0 :file]))))
-
-  (testing "returns nil for missing path"
-    (is (nil? (extract-field {:a 1} [:b :c])))))
-
-;; ============================================================================
-;; Severity mapping
-;; ============================================================================
-
-(deftest map-severity-test
-  (testing "maps string keys"
-    (is (= :critical (map-severity {"error" :critical} "error"))))
-
-  (testing "maps keyword values by name"
-    (is (= :high (map-severity {"warning" :high} :warning))))
-
-  (testing "defaults to :low for unknown"
-    (is (= :low (map-severity {"error" :critical} "unknown")))))
-
-;; ============================================================================
-;; Filter matching
-;; ============================================================================
-
-(deftest matches-filter-test
-  (testing "nil filter always matches"
-    (is (true? (matches-filter? nil {:anything true}))))
-
-  (testing "matches when path equals value"
-    (is (true? (matches-filter? {:path [:reason] :equals "compiler-message"}
-                                {:reason "compiler-message"}))))
-
-  (testing "rejects when path doesn't equal"
-    (is (false? (matches-filter? {:path [:reason] :equals "compiler-message"}
-                                 {:reason "build-script"})))))
+(def ^{:stratum 0} matches-filter? (var-get #'sut/matches-filter?))
 
 ;; ============================================================================
 ;; Mapping registry
 ;; ============================================================================
-
-(deftest mappings-load-test
+(deftest ^{:stratum 0} mappings-load-test
   (testing "mappings load from classpath"
     (is (map? @sut/mappings))
     (is (contains? @sut/mappings :clippy))
@@ -78,8 +32,7 @@
 ;; ============================================================================
 ;; Full mapping application — clj-kondo
 ;; ============================================================================
-
-(deftest apply-mapping-clj-kondo-test
+(deftest ^{:stratum 0} apply-mapping-clj-kondo-test
   (testing "parses EDN findings"
     (let [mapping (sut/get-mapping :clj-kondo)
           output  "{:findings [{:type :unresolved-symbol :filename \"src/core.clj\" :row 10 :col 5 :level :error :message \"Unresolved symbol: foo\"}]}"
@@ -92,8 +45,7 @@
 ;; ============================================================================
 ;; Full mapping application — ESLint (nested format)
 ;; ============================================================================
-
-(deftest apply-mapping-eslint-test
+(deftest ^{:stratum 0} apply-mapping-eslint-test
   (testing "parses nested JSON with parent file path"
     (let [mapping (sut/get-mapping :eslint)
           output  "[{\"filePath\":\"/src/app.js\",\"messages\":[{\"ruleId\":\"no-unused-vars\",\"severity\":2,\"message\":\"x is unused\",\"line\":5,\"column\":3}]}]"
@@ -105,8 +57,7 @@
 ;; ============================================================================
 ;; Full mapping application — Clippy (json-lines with filter)
 ;; ============================================================================
-
-(deftest apply-mapping-clippy-test
+(deftest ^{:stratum 0} apply-mapping-clippy-test
   (testing "filters for compiler-message and extracts nested fields"
     (let [mapping (sut/get-mapping :clippy)
           line1   "{\"reason\":\"compiler-artifact\"}"
@@ -120,8 +71,7 @@
 ;; ============================================================================
 ;; Full mapping application — ruff
 ;; ============================================================================
-
-(deftest apply-mapping-ruff-test
+(deftest ^{:stratum 0} apply-mapping-ruff-test
   (testing "parses flat JSON array"
     (let [mapping (sut/get-mapping :ruff)
           output  "[{\"code\":\"F401\",\"message\":\"unused import\",\"filename\":\"app.py\",\"location\":{\"row\":1,\"column\":1},\"type\":\"warning\"}]"
@@ -133,14 +83,60 @@
 ;; ============================================================================
 ;; Empty / error cases
 ;; ============================================================================
-
-(deftest apply-mapping-empty-test
+(deftest ^{:stratum 0} apply-mapping-empty-test
   (testing "empty output returns empty violations"
     (let [mapping (sut/get-mapping :eslint)]
       (is (= [] (sut/apply-mapping mapping "")))
       (is (= [] (sut/apply-mapping mapping "[]"))))))
 
-(deftest apply-mapping-malformed-test
+(deftest ^{:stratum 0} apply-mapping-malformed-test
   (testing "malformed output returns empty violations"
     (let [mapping (sut/get-mapping :eslint)]
       (is (= [] (sut/apply-mapping mapping "not json"))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; ============================================================================
+;; Field extraction
+;; ============================================================================
+(deftest ^{:stratum 1} extract-field-keyword-test
+  (testing "extracts by keyword"
+    (is (= "foo.clj" (extract-field {:filename "foo.clj"} :filename)))))
+
+(deftest ^{:stratum 1} extract-field-vector-path-test
+  (testing "extracts by vector path"
+    (is (= 42 (extract-field {:pos {:line 42}} [:pos :line]))))
+
+  (testing "extracts through array index"
+    (is (= "bar.rs" (extract-field {:spans [{:file "bar.rs"}]} [:spans 0 :file]))))
+
+  (testing "returns nil for missing path"
+    (is (nil? (extract-field {:a 1} [:b :c])))))
+
+;; ============================================================================
+;; Severity mapping
+;; ============================================================================
+(deftest ^{:stratum 1} map-severity-test
+  (testing "maps string keys"
+    (is (= :critical (map-severity {"error" :critical} "error"))))
+
+  (testing "maps keyword values by name"
+    (is (= :high (map-severity {"warning" :high} :warning))))
+
+  (testing "defaults to :low for unknown"
+    (is (= :low (map-severity {"error" :critical} "unknown")))))
+
+;; ============================================================================
+;; Filter matching
+;; ============================================================================
+(deftest ^{:stratum 1} matches-filter-test
+  (testing "nil filter always matches"
+    (is (true? (matches-filter? nil {:anything true}))))
+
+  (testing "matches when path equals value"
+    (is (true? (matches-filter? {:path [:reason] :equals "compiler-message"}
+                                {:reason "compiler-message"}))))
+
+  (testing "rejects when path doesn't equal"
+    (is (false? (matches-filter? {:path [:reason] :equals "compiler-message"}
+                                 {:reason "build-script"})))))

--- a/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-connector-linter.md
+++ b/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-connector-linter.md
@@ -52,12 +52,13 @@ attached to the same def/group it always described.
 3. Read the full diff for all 4 changed files. Confirmed the only changes
    are heading text, `^{:stratum n}` metadata, and def reordering — no
    logic changes, no comment misattachment.
-4. `clj-kondo --lint components/connector-linter`: 0 errors. 1 warning
-   (unused binding `column` in `etl.clj`'s `record->violation`, now at line
-   65 after reordering). Confirmed via `git stash` comparison against the
-   pre-fix file that this warning predates this PR (same warning, line 54
-   before reordering) — pre-existing and unrelated to the stratum-lint
-   change, not fixed here to keep this PR mechanical-only.
+4. `clj-kondo --lint components/connector-linter`: 0 errors, 0 warnings.
+   `record->violation` originally had an unused `column` binding (pre-
+   existing, confirmed via `git stash` comparison against the pre-fix
+   file — same warning present before this PR) — removed during review,
+   along with a stale section header and two stale docstring layer
+   summaries Copilot caught on later passes. See commit history for the
+   review-fix commits.
 5. Plain lint re-run post-fix: 1 `SL003` remains (`etl.clj`, 4 real layers
    against the 3-layer budget) — Wave 2 scope, documented above.
 6. Ran the component's test namespace directly:
@@ -86,8 +87,8 @@ order only.
 - [x] Idempotency verified directly (two `--fix` passes, zero diff)
 - [x] Full diff read for all 4 changed files; no comment misattachment
       (none existed pre-fix)
-- [x] `clj-kondo` clean except one pre-existing, unrelated warning
-      (confirmed via `git stash` comparison)
+- [x] `clj-kondo` clean (0 errors, 0 warnings) — one pre-existing unused
+      binding removed during review
 - [x] Plain lint re-run post-fix: `SL003` remains on `etl.clj`, documented
       as Wave 2 scope
 - [x] Tests pass: 11 tests / 33 assertions, 0 failures, 0 errors

--- a/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-connector-linter.md
+++ b/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-connector-linter.md
@@ -1,0 +1,95 @@
+# fix: stratum-lint autofix for components/connector-linter (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over `components/connector-linter` (`src` + `test`)
+to replace the one decorative `Layer N` heading with headings that reflect
+each file's real same-file reference graph, and tags every `def`/`defn` with
+`^{:stratum n}` metadata. Purely mechanical: no logic changes. One of the
+per-component Wave 1 PRs from `work/stratum-lint-baseline-2026-07-24.md`.
+
+## Motivation
+
+The baseline audit found `connector-linter` carrying exactly one finding —
+`SL002` in `etl.clj` (a `Layer 2` heading reused instead of strictly
+increasing) — and zero `SL001` (upward-reference) findings, which is
+precisely the Wave 1 selection criterion: no cycle/upward-call risk to
+reason about before running the mechanical fixer.
+
+## Changes in Detail
+
+Ran, over the whole component:
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "80699e378cb8ebbb6daeb928431aa4a6b373c07e" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/connector-linter
+```
+
+All 4 `.clj` files in the component were rewritten — `etl.clj`,
+`interface.clj`, `runner.clj`, `etl_test.clj` — including `interface.clj`,
+which had no `Layer N` heading at all before this fix (silently skipped by
+the plain lint check, not counted in the baseline's "1 finding"; `--fix`
+normalizes every file regardless).
+
+`etl.clj`'s real reference graph turned out to be 4 layers deep once
+inferred from actual same-file calls (`apply-mapping` → `extract-records` /
+`get-mapping` → `mappings` → `mappings-resource`), one over the 3-layer
+budget — a new `SL003` this fix surfaces but cannot resolve itself (needs an
+actual namespace split, Wave 2 scope, not attempted here).
+
+No same-line trailing comments existed in any of the 4 files before this
+fix (checked directly against the pre-fix content), so the comment-
+reattachment risk this wave's playbook warns about does not apply here —
+the only comments in these files are section-banner style, and each stayed
+attached to the same def/group it always described.
+
+## Testing Plan
+
+1. Plain (non-`--fix`) lint before the fix: reproduced the baseline's exact
+   single finding — `SL002` at `etl.clj:155`.
+2. Ran `--fix`, then ran the identical `--fix` command a second time and
+   diffed the component's files before/after that second pass: zero diff.
+   Idempotency verified directly, not assumed.
+3. Read the full diff for all 4 changed files. Confirmed the only changes
+   are heading text, `^{:stratum n}` metadata, and def reordering — no
+   logic changes, no comment misattachment.
+4. `clj-kondo --lint components/connector-linter`: 0 errors. 1 warning
+   (unused binding `column` in `etl.clj`'s `record->violation`, now at line
+   65 after reordering). Confirmed via `git stash` comparison against the
+   pre-fix file that this warning predates this PR (same warning, line 54
+   before reordering) — pre-existing and unrelated to the stratum-lint
+   change, not fixed here to keep this PR mechanical-only.
+5. Plain lint re-run post-fix: 1 `SL003` remains (`etl.clj`, 4 real layers
+   against the 3-layer budget) — Wave 2 scope, documented above.
+6. Ran the component's test namespace directly:
+   `clojure -A:dev:test -e "(require 'ai.miniforge.connector-linter.etl-test) (clojure.test/run-tests 'ai.miniforge.connector-linter.etl-test)"`
+   — 11 tests, 33 assertions, 0 failures, 0 errors. (The component-local
+   `deps.edn` alone can't resolve the classpath for this — it pulls in
+   `compliance-scanner` → `policy-pack`, whose `deps.edn` doesn't declare a
+   `knowledge` local/root that `policy-pack.loader` requires, a pre-existing
+   gap unrelated to this change; ran from the repo root against the
+   workspace `:dev:test` aliases instead, which resolve correctly.)
+
+## Deployment Plan
+
+Merges to `main`. No runtime behavior change — headings, metadata, and def
+order only.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+- Follow-on: Wave 2 namespace split for `etl.clj` (now `SL003`, 4 real
+  layers)
+
+## Checklist
+
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Idempotency verified directly (two `--fix` passes, zero diff)
+- [x] Full diff read for all 4 changed files; no comment misattachment
+      (none existed pre-fix)
+- [x] `clj-kondo` clean except one pre-existing, unrelated warning
+      (confirmed via `git stash` comparison)
+- [x] Plain lint re-run post-fix: `SL003` remains on `etl.clj`, documented
+      as Wave 2 scope
+- [x] Tests pass: 11 tests / 33 assertions, 0 failures, 0 errors
+- [x] No `--no-verify`; commit-budget / stratum-budget overrides used with
+      recorded rationale


### PR DESCRIPTION
## Summary

- Runs `stratum-lint --fix` (pin `80699e378cb8ebbb6daeb928431aa4a6b373c07e`) over `components/connector-linter` (src + test), fixing the component's single baseline finding — `SL002` in `etl.clj` (a `Layer 2` heading reused instead of strictly increasing) — and zero `SL001` upward-reference findings, per the Wave 1 selection criterion in `work/stratum-lint-baseline-2026-07-24.md`.
- Purely mechanical: heading text, `^{:stratum n}` metadata, and def reordering only. No logic changes.
- Idempotency verified directly: ran `--fix` twice, diffed the component before/after the second pass — zero diff.
- `etl.clj`'s real reference graph is 4 layers deep (`apply-mapping` → `extract-records`/`get-mapping` → `mappings` → `mappings-resource`), one over the 3-layer budget — a new `SL003` this fix surfaces but doesn't resolve. Wave 2 scope (namespace split), not attempted here; committed with `MINIFORGE_STRATUM_BUDGET_MODE=warn` per that decision.
- `clj-kondo --lint components/connector-linter`: 0 errors, 1 warning (`etl.clj:65` unused binding `column`) — confirmed via `git stash` comparison this predates this PR (pre-existing, unrelated), not fixed here to keep this PR mechanical-only.
- No same-line trailing comments existed in any of the 4 files pre-fix, so this wave's known comment-reattachment risk doesn't apply here.

## Test plan

- [x] Plain lint before fix reproduced the exact baseline finding (`SL002`, `etl.clj:155`)
- [x] `--fix` run twice, zero diff on the second pass
- [x] Full diff read for all 4 changed files
- [x] `clj-kondo --lint components/connector-linter`: 0 errors (1 pre-existing, unrelated warning)
- [x] Plain lint re-run post-fix: 1 `SL003` remains (`etl.clj`, Wave 2 scope)
- [x] `clojure -A:dev:test -e "(require 'ai.miniforge.connector-linter.etl-test) (clojure.test/run-tests 'ai.miniforge.connector-linter.etl-test)"`: 11 tests, 33 assertions, 0 failures, 0 errors
- [x] Full `bb pre-commit` gate green at commit time (commit-budget override, `poly:check`, `lint:clj`, `lint:stratum` warn-mode, `fmt:md`, `test:precommit` 331 tests, `test:graalvm` 8 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)