### PR TITLE
fix: stratum-lint autofix for components/dag-primitives (Wave 1)

### DIFF
--- a/components/dag-primitives/src/ai/miniforge/dag_primitives/graph.clj
+++ b/components/dag-primitives/src/ai/miniforge/dag_primitives/graph.clj
@@ -15,15 +15,14 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.dag-primitives.graph
   "Utility functions for directed graphs represented as dependency maps.
    dep-map convention: {node-id #{predecessor-id ...}}")
 
-;;------------------------------------------------------------------------------ Layer 0
-;; Graph construction
+;------------------------------------------------------------------------------ Layer 0
 
-(defn successors-of
+;; Graph construction
+(defn ^{:stratum 0} successors-of
   "Build a forward adjacency map from a dependency map.
    For each node, returns the set of nodes that directly follow it.
    Every node in dep-map gets an entry, even if it has no successors."
@@ -36,7 +35,7 @@
           (zipmap (keys dep-map) (repeat #{}))
           dep-map))
 
-(defn predecessor-counts
+(defn ^{:stratum 0} predecessor-counts
   "Return a map of {node-id count} counting unsatisfied predecessors per node."
   [dep-map]
   (reduce-kv (fn [counts node predecessors]

--- a/components/dag-primitives/src/ai/miniforge/dag_primitives/interface.clj
+++ b/components/dag-primitives/src/ai/miniforge/dag_primitives/interface.clj
@@ -15,16 +15,15 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.dag-primitives.interface
   "Public API for dag-primitives — generic topological sort and Result monad."
   (:require [ai.miniforge.dag-primitives.kahn   :as kahn]
             [ai.miniforge.dag-primitives.result :as result]))
 
-;;------------------------------------------------------------------------------ Layer 0
-;; Topological sort
+;------------------------------------------------------------------------------ Layer 0
 
-(defn topological-sort
+;; Topological sort
+(defn ^{:stratum 0} topological-sort
   "Kahn's algorithm on a generic dependency map.
 
    dep-map: {node-id #{predecessor-node-id ...}}
@@ -40,20 +39,29 @@
   ([dep-map ordered-nodes]
    (kahn/topological-sort dep-map ordered-nodes)))
 
-;;------------------------------------------------------------------------------ Layer 1
 ;; Result monad
+(defn ^{:stratum 0} ok        [data]              (result/ok data))
 
-(defn ok        [data]              (result/ok data))
-(defn err
+(defn ^{:stratum 0} err
   ([code message]      (result/err code message))
   ([code message data] (result/err code message data)))
-(defn ok?       [r]                 (result/ok? r))
-(defn err?      [r]                 (result/err? r))
-(defn unwrap    [r]                 (result/unwrap r))
-(defn unwrap-anomaly [r]            (result/unwrap-anomaly r))
-(defn unwrap-or [r default]         (result/unwrap-or r default))
-(defn map-ok    [r f]               (result/map-ok r f))
-(defn map-err   [r f]               (result/map-err r f))
-(defn and-then  [r f]               (result/and-then r f))
-(defn or-else   [r f]               (result/or-else r f))
-(defn collect   [results]           (result/collect results))
+
+(defn ^{:stratum 0} ok?       [r]                 (result/ok? r))
+
+(defn ^{:stratum 0} err?      [r]                 (result/err? r))
+
+(defn ^{:stratum 0} unwrap    [r]                 (result/unwrap r))
+
+(defn ^{:stratum 0} unwrap-anomaly [r]            (result/unwrap-anomaly r))
+
+(defn ^{:stratum 0} unwrap-or [r default]         (result/unwrap-or r default))
+
+(defn ^{:stratum 0} map-ok    [r f]               (result/map-ok r f))
+
+(defn ^{:stratum 0} map-err   [r f]               (result/map-err r f))
+
+(defn ^{:stratum 0} and-then  [r f]               (result/and-then r f))
+
+(defn ^{:stratum 0} or-else   [r f]               (result/or-else r f))
+
+(defn ^{:stratum 0} collect   [results]           (result/collect results))

--- a/components/dag-primitives/src/ai/miniforge/dag_primitives/interface.clj
+++ b/components/dag-primitives/src/ai/miniforge/dag_primitives/interface.clj
@@ -33,7 +33,7 @@
 
    Returns:
      {:ok? true  :data [node-ids in topological order]}
-     {:ok? false :error {:code :cycle-detected :cycle-nodes #{...}}}"
+     {:ok? false :error {:code :cycle-detected :message \"...\" :data {:cycle-nodes #{...}}}}"
   ([dep-map]
    (kahn/topological-sort dep-map))
   ([dep-map ordered-nodes]

--- a/components/dag-primitives/src/ai/miniforge/dag_primitives/kahn.clj
+++ b/components/dag-primitives/src/ai/miniforge/dag_primitives/kahn.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.dag-primitives.kahn
   "Generic Kahn's algorithm for topological sort.
    Operates on a plain dependency map — no domain types."
@@ -23,20 +22,18 @@
             [ai.miniforge.dag-primitives.graph  :as graph]
             [ai.miniforge.dag-primitives.result :as result]))
 
-;;------------------------------------------------------------------------------ Layer 0
-;; Queue construction
+;------------------------------------------------------------------------------ Layer 0
 
-(defn- initial-queue
+;; Queue construction
+(defn- ^{:stratum 0} initial-queue
   "Seed the ready queue with all nodes that have no predecessors,
    preserving the caller-supplied tie-breaking order."
   [in-degree ordered-nodes]
   (into clojure.lang.PersistentQueue/EMPTY
         (filter #(zero? (get in-degree %)) ordered-nodes)))
 
-;;------------------------------------------------------------------------------ Layer 1
 ;; Kahn step
-
-(defn- process-node
+(defn- ^{:stratum 0} process-node
   "Remove node from the queue, decrement in-degrees for its successors,
    and enqueue any successor whose in-degree just reached zero."
   [adj in-degree queue result node]
@@ -45,10 +42,10 @@
         ready   (filter #(zero? (get new-deg %)) succs)]
     [(into (pop queue) ready) new-deg (conj result node)]))
 
-;;------------------------------------------------------------------------------ Layer 2
-;; Topological sort
+;------------------------------------------------------------------------------ Layer 1
 
-(defn topological-sort
+;; Topological sort
+(defn ^{:stratum 1} topological-sort
   "Kahn's algorithm on a generic dependency map.
 
    dep-map: {node-id #{predecessor-node-id ...}}

--- a/components/dag-primitives/src/ai/miniforge/dag_primitives/result.clj
+++ b/components/dag-primitives/src/ai/miniforge/dag_primitives/result.clj
@@ -15,39 +15,39 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.dag-primitives.result
   "Result monad — consistent ok/err patterns for pipeline and DAG operations."
   (:require [ai.miniforge.anomaly.interface :as anomaly]))
 
-;;------------------------------------------------------------------------------ Layer 0
-;; Constructors
+;------------------------------------------------------------------------------ Layer 0
 
-(defn ok
+;; Constructors
+(defn ^{:stratum 0} ok
   "Success result.  Returns {:ok? true :data data}"
   [data]
   {:ok? true :data data})
 
-(defn err
+(defn ^{:stratum 0} err
   "Error result.  Returns {:ok? false :error {:code kw :message str [:data map]}}"
   ([code message]
    {:ok? false :error {:code code :message message}})
   ([code message data]
    {:ok? false :error {:code code :message message :data data}}))
 
-(defn ok?  [result] (:ok? result false))
-(defn err? [result] (not (:ok? result true)))
+(defn ^{:stratum 0} ok?  [result] (:ok? result false))
 
-;;------------------------------------------------------------------------------ Layer 1
+(defn ^{:stratum 0} err? [result] (not (:ok? result true)))
+
 ;; Extraction
-
-(defn- unwrap-error-message
+(defn- ^{:stratum 0} unwrap-error-message
   "Return an error message when it is a string; otherwise return the canonical fallback."
   [error]
   (let [message (get error :message)]
     (if (string? message) message "Unwrap called on error result")))
 
-(defn unwrap-anomaly
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} unwrap-anomaly
   "Extract data from a result. On ok, return the wrapped data; on err,
    return a canonical `:fault` anomaly carrying the error code, message,
    and any error data the result carried.
@@ -65,7 +65,7 @@
                          (:code error) (assoc :code (:code error))
                          (:data error) (assoc :error-data (:data error)))))))
 
-(defn unwrap
+(defn ^{:stratum 1} unwrap
   "Extract data from an ok result; throw on error.
 
    DEPRECATED: prefer [[unwrap-anomaly]], which returns an anomaly map
@@ -78,38 +78,34 @@
     (:data result)
     (throw (ex-info "Unwrap called on error result" {:error (:error result)}))))
 
-(defn unwrap-or
+(defn ^{:stratum 1} unwrap-or
   "Extract data from an ok result, or return default on error."
   [result default]
   (if (ok? result) (:data result) default))
 
-;;------------------------------------------------------------------------------ Layer 2
 ;; Transforms
-
-(defn map-ok
+(defn ^{:stratum 1} map-ok
   "Apply f to the data inside an ok result; pass errors through."
   [result f]
   (if (ok? result) (ok (f (:data result))) result))
 
-(defn map-err
+(defn ^{:stratum 1} map-err
   "Apply f to the error inside an err result; pass oks through."
   [result f]
   (if (err? result) {:ok? false :error (f (:error result))} result))
 
-;;------------------------------------------------------------------------------ Layer 3
 ;; Combinators
-
-(defn and-then
+(defn ^{:stratum 1} and-then
   "Chain f (returns a result) onto an ok result; pass errors through."
   [result f]
   (if (ok? result) (f (:data result)) result))
 
-(defn or-else
+(defn ^{:stratum 1} or-else
   "Chain f (returns a result) onto an err result; pass oks through."
   [result f]
   (if (err? result) (f (:error result)) result))
 
-(defn collect
+(defn ^{:stratum 1} collect
   "Collect a seq of results into a result of seq.
    Returns the first error encountered, or ok of all data values."
   [results]

--- a/components/dag-primitives/test/ai/miniforge/dag_primitives/interface_test.clj
+++ b/components/dag-primitives/test/ai/miniforge/dag_primitives/interface_test.clj
@@ -15,20 +15,20 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.dag-primitives.interface-test
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.dag-primitives.interface :as dp]))
 
-;;------------------------------------------------------------------------------ Topological sort
+;------------------------------------------------------------------------------ Layer 0
 
-(deftest topological-sort-linear-chain
+;;------------------------------------------------------------------------------ Topological sort
+(deftest ^{:stratum 0} topological-sort-linear-chain
   (testing "A → B → C returns [A B C]"
     (let [result (dp/topological-sort {:a #{} :b #{:a} :c #{:b}})]
       (is (dp/ok? result))
       (is (= [:a :b :c] (:data result))))))
 
-(deftest topological-sort-parallel-roots
+(deftest ^{:stratum 0} topological-sort-parallel-roots
   (testing "Two independent roots both precede their shared dependent"
     (let [result (dp/topological-sort {:a #{} :b #{} :c #{:a :b}})]
       (is (dp/ok? result))
@@ -37,7 +37,7 @@
         (is (< (.indexOf order :a) (.indexOf order :c)))
         (is (< (.indexOf order :b) (.indexOf order :c)))))))
 
-(deftest topological-sort-diamond
+(deftest ^{:stratum 0} topological-sort-diamond
   (testing "Diamond: A → B, A → C, B → D, C → D"
     (let [result (dp/topological-sort {:a #{} :b #{:a} :c #{:a} :d #{:b :c}})]
       (is (dp/ok? result))
@@ -46,26 +46,26 @@
         (is (= :a (first order)))
         (is (= :d (last order)))))))
 
-(deftest topological-sort-single-node
+(deftest ^{:stratum 0} topological-sort-single-node
   (testing "Single node with no deps"
     (let [result (dp/topological-sort {:a #{}})]
       (is (dp/ok? result))
       (is (= [:a] (:data result))))))
 
-(deftest topological-sort-empty
+(deftest ^{:stratum 0} topological-sort-empty
   (testing "Empty graph"
     (let [result (dp/topological-sort {})]
       (is (dp/ok? result))
       (is (= [] (:data result))))))
 
-(deftest topological-sort-cycle-detected
+(deftest ^{:stratum 0} topological-sort-cycle-detected
   (testing "Cycle returns err with :cycle-detected"
     (let [result (dp/topological-sort {:a #{:c} :b #{:a} :c #{:b}})]
       (is (dp/err? result))
       (is (= :cycle-detected (get-in result [:error :code])))
       (is (= #{:a :b :c} (get-in result [:error :data :cycle-nodes]))))))
 
-(deftest topological-sort-partial-cycle
+(deftest ^{:stratum 0} topological-sort-partial-cycle
   (testing "Cycle in part of graph; acyclic nodes still processed"
     (let [result (dp/topological-sort {:root #{} :a #{:b} :b #{:a}})]
       (is (dp/err? result))
@@ -73,50 +73,49 @@
       (is (= #{:a :b} (get-in result [:error :data :cycle-nodes]))))))
 
 ;;------------------------------------------------------------------------------ Result monad
-
-(deftest ok-construction
+(deftest ^{:stratum 0} ok-construction
   (is (dp/ok? (dp/ok {:x 1})))
   (is (= {:x 1} (:data (dp/ok {:x 1})))))
 
-(deftest err-construction
+(deftest ^{:stratum 0} err-construction
   (is (dp/err? (dp/err :bad "oops")))
   (is (= :bad (get-in (dp/err :bad "oops") [:error :code])))
   (is (= {:detail "x"} (get-in (dp/err :bad "oops" {:detail "x"}) [:error :data]))))
 
-(deftest unwrap-ok
+(deftest ^{:stratum 0} unwrap-ok
   (is (= 42 (dp/unwrap (dp/ok 42)))))
 
-(deftest unwrap-err-throws
+(deftest ^{:stratum 0} unwrap-err-throws
   (is (thrown? Exception (dp/unwrap (dp/err :e "e")))))
 
-(deftest unwrap-or-default
+(deftest ^{:stratum 0} unwrap-or-default
   (is (= :fallback (dp/unwrap-or (dp/err :e "e") :fallback))))
 
-(deftest map-ok-transforms-data
+(deftest ^{:stratum 0} map-ok-transforms-data
   (let [result (dp/map-ok (dp/ok 5) inc)]
     (is (dp/ok? result))
     (is (= 6 (:data result)))))
 
-(deftest map-ok-passes-through-err
+(deftest ^{:stratum 0} map-ok-passes-through-err
   (let [e (dp/err :e "e")]
     (is (= e (dp/map-ok e inc)))))
 
-(deftest and-then-chains
+(deftest ^{:stratum 0} and-then-chains
   (let [result (dp/and-then (dp/ok 5) #(dp/ok (* % 2)))]
     (is (dp/ok? result))
     (is (= 10 (:data result)))))
 
-(deftest and-then-short-circuits-on-err
+(deftest ^{:stratum 0} and-then-short-circuits-on-err
   (let [e      (dp/err :e "e")
         result (dp/and-then e #(dp/ok (inc %)))]
     (is (= e result))))
 
-(deftest collect-all-ok
+(deftest ^{:stratum 0} collect-all-ok
   (let [result (dp/collect [(dp/ok 1) (dp/ok 2) (dp/ok 3)])]
     (is (dp/ok? result))
     (is (= [1 2 3] (:data result)))))
 
-(deftest collect-first-err-short-circuits
+(deftest ^{:stratum 0} collect-first-err-short-circuits
   (let [e      (dp/err :bad "bad")
         result (dp/collect [(dp/ok 1) e (dp/ok 3)])]
     (is (= e result))))

--- a/components/dag-primitives/test/ai/miniforge/dag_primitives/unwrap_anomaly_failure_test.clj
+++ b/components/dag-primitives/test/ai/miniforge/dag_primitives/unwrap_anomaly_failure_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.dag-primitives.unwrap-anomaly-failure-test
   "Failure-path coverage for `dag-primitives/unwrap-anomaly`: err results
    become canonical anomalies that preserve the original error context."
@@ -23,27 +22,29 @@
             [ai.miniforge.anomaly.interface :as anomaly]
             [ai.miniforge.dag-primitives.interface :as dp]))
 
-(deftest unwrap-anomaly-returns-anomaly-on-err
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} unwrap-anomaly-returns-anomaly-on-err
   (testing "err result becomes a canonical anomaly map"
     (let [result (dp/unwrap-anomaly (dp/err :cycle-detected "graph has a cycle"))]
       (is (anomaly/anomaly? result)))))
 
-(deftest unwrap-anomaly-uses-fault-type
+(deftest ^{:stratum 0} unwrap-anomaly-uses-fault-type
   (testing "anomaly type is :fault — err results signal an internal failure"
     (let [result (dp/unwrap-anomaly (dp/err :cycle-detected "graph has a cycle"))]
       (is (= :fault (:anomaly/type result))))))
 
-(deftest unwrap-anomaly-preserves-message
+(deftest ^{:stratum 0} unwrap-anomaly-preserves-message
   (testing "err message becomes the anomaly message"
     (let [result (dp/unwrap-anomaly (dp/err :cycle-detected "graph has a cycle"))]
       (is (= "graph has a cycle" (:anomaly/message result))))))
 
-(deftest unwrap-anomaly-preserves-error-code
+(deftest ^{:stratum 0} unwrap-anomaly-preserves-error-code
   (testing "err code is exposed in :anomaly/data :code"
     (let [result (dp/unwrap-anomaly (dp/err :cycle-detected "graph has a cycle"))]
       (is (= :cycle-detected (get-in result [:anomaly/data :code]))))))
 
-(deftest unwrap-anomaly-preserves-error-data
+(deftest ^{:stratum 0} unwrap-anomaly-preserves-error-data
   (testing "err data is exposed in :anomaly/data :error-data"
     (let [result (dp/unwrap-anomaly (dp/err :cycle-detected
                                             "graph has a cycle"
@@ -51,7 +52,7 @@
       (is (= {:nodes #{:a :b}}
              (get-in result [:anomaly/data :error-data]))))))
 
-(deftest unwrap-anomaly-handles-missing-message
+(deftest ^{:stratum 0} unwrap-anomaly-handles-missing-message
   (testing "err with no message still produces a valid anomaly"
     (let [bare-err {:ok? false :error {:code :unknown}}
           result   (dp/unwrap-anomaly bare-err)]
@@ -59,7 +60,7 @@
       (is (string? (:anomaly/message result)))
       (is (seq (:anomaly/message result))))))
 
-(deftest unwrap-anomaly-normalizes-malformed-messages
+(deftest ^{:stratum 0} unwrap-anomaly-normalizes-malformed-messages
   (testing "nil, false, and non-string messages use the canonical fallback"
     (doseq [message [nil false :not-text 42 []]
             :let [result (dp/unwrap-anomaly

--- a/components/dag-primitives/test/ai/miniforge/dag_primitives/unwrap_anomaly_happy_path_test.clj
+++ b/components/dag-primitives/test/ai/miniforge/dag_primitives/unwrap_anomaly_happy_path_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.dag-primitives.unwrap-anomaly-happy-path-test
   "Happy-path coverage for `dag-primitives/unwrap-anomaly`: ok results
    surface their wrapped data unchanged."
@@ -23,15 +22,17 @@
             [ai.miniforge.anomaly.interface :as anomaly]
             [ai.miniforge.dag-primitives.interface :as dp]))
 
-(deftest unwrap-anomaly-returns-data-on-ok
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} unwrap-anomaly-returns-data-on-ok
   (testing "ok result surfaces its data"
     (is (= 42 (dp/unwrap-anomaly (dp/ok 42))))))
 
-(deftest unwrap-anomaly-preserves-nested-data
+(deftest ^{:stratum 0} unwrap-anomaly-preserves-nested-data
   (testing "complex data structures pass through unchanged"
     (let [payload {:nodes [:a :b :c] :edges #{[:a :b]}}]
       (is (= payload (dp/unwrap-anomaly (dp/ok payload)))))))
 
-(deftest unwrap-anomaly-ok-result-not-an-anomaly
+(deftest ^{:stratum 0} unwrap-anomaly-ok-result-not-an-anomaly
   (testing "ok unwrap result is not flagged as anomaly"
     (is (not (anomaly/anomaly? (dp/unwrap-anomaly (dp/ok :anything)))))))

--- a/components/dag-primitives/test/ai/miniforge/dag_primitives/unwrap_throwing_compat_test.clj
+++ b/components/dag-primitives/test/ai/miniforge/dag_primitives/unwrap_throwing_compat_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.dag-primitives.unwrap-throwing-compat-test
   "Backward-compat coverage for the deprecated throwing `unwrap`.
 
@@ -25,11 +24,13 @@
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.dag-primitives.interface :as dp]))
 
-(deftest unwrap-still-returns-data-on-ok
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} unwrap-still-returns-data-on-ok
   (testing "deprecated thrower returns ok data unchanged"
     (is (= 42 (dp/unwrap (dp/ok 42))))))
 
-(deftest unwrap-still-throws-on-err
+(deftest ^{:stratum 0} unwrap-still-throws-on-err
   (testing "deprecated thrower throws ExceptionInfo on err input"
     (is (thrown? clojure.lang.ExceptionInfo
                  (dp/unwrap (dp/err :cycle "boom"))))))

--- a/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-dag-primitives.md
+++ b/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-dag-primitives.md
@@ -3,8 +3,7 @@
 ## Overview
 
 Runs `stratum-lint --fix` over the whole `dag-primitives` component (`src`
-
-+ `test`) to replace decorative `Layer N` headings with headings that
+and `test`) to replace decorative `Layer N` headings with headings that
 reflect each file's real same-file reference graph, tagging every
 `def`/`defn`/`deftest` with `^{:stratum n}` metadata. Purely mechanical: no
 logic changes. Part of the per-component Wave 1 series from
@@ -13,8 +12,9 @@ logic changes. Part of the per-component Wave 1 series from
 ## Motivation
 
 `dag-primitives` carried exactly one finding in the baseline —
-`components/dag_primitives/result.clj:99:1: SL003 file uses 4 distinct
-layers (max 3)` — and zero `SL001` (upward-reference) findings, so no
+`components/dag-primitives/src/ai/miniforge/dag_primitives/result.clj:99:1:
+SL003 file uses 4 distinct layers (max 3)` — and zero `SL001`
+(upward-reference) findings, so no
 cycle/upward-call risk to reason about before running the mechanical
 fixer.
 
@@ -70,12 +70,16 @@ autofixer keeps this component clean going forward.
 
 + Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1 —
   mechanical relabeling via `--fix`, decorative-heading files only)
-+ Sibling Wave 1 PRs: `2026-07-24-fix-stratum-lint-wave1-compliance-scanner.md`,
-  `-reliability.md`, `-gate.md`, `-decision.md`, `-adapter-claude-code.md`
++ Sibling Wave 1 PR docs:
+  `docs/pull-requests/2026-07-24-fix-stratum-lint-wave1-compliance-scanner.md`,
+  `docs/pull-requests/2026-07-24-fix-stratum-lint-wave1-reliability.md`,
+  `docs/pull-requests/2026-07-24-fix-stratum-lint-wave1-gate.md`,
+  `docs/pull-requests/2026-07-24-fix-stratum-lint-wave1-decision.md`,
+  `docs/pull-requests/2026-07-24-fix-stratum-lint-wave1-adapter-claude-code.md`
 
 ## Checklist
 
-+ [x] `--fix` run over the whole component (`src` + `test`)
++ [x] `--fix` run over the whole component (`src` and `test`)
 + [x] Idempotency verified (second `--fix` pass: zero diff)
 + [x] Diff reviewed file-by-file; mechanical-only (heading + metadata +
       reorder); no comment-attachment issue found (none existed to break)

--- a/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-dag-primitives.md
+++ b/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-dag-primitives.md
@@ -1,0 +1,86 @@
+# fix: stratum-lint autofix for components/dag-primitives (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over the whole `dag-primitives` component (`src`
+
++ `test`) to replace decorative `Layer N` headings with headings that
+reflect each file's real same-file reference graph, tagging every
+`def`/`defn`/`deftest` with `^{:stratum n}` metadata. Purely mechanical: no
+logic changes. Part of the per-component Wave 1 series from
+`work/stratum-lint-baseline-2026-07-24.md`.
+
+## Motivation
+
+`dag-primitives` carried exactly one finding in the baseline —
+`components/dag_primitives/result.clj:99:1: SL003 file uses 4 distinct
+layers (max 3)` — and zero `SL001` (upward-reference) findings, so no
+cycle/upward-call risk to reason about before running the mechanical
+fixer.
+
+## Changes in Detail
+
+Ran, over the whole component:
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "80699e378cb8ebbb6daeb928431aa4a6b373c07e" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/dag-primitives
+```
+
+All 8 files in the component rewritten (4 `src`, 4 `test`) — `--fix`
+normalizes files with zero prior findings too, adding `^{:stratum n}`
+metadata as a one-time pass. Diff stat: 8 files changed, 92
+insertions(+), 90 deletions(-).
+
+`result.clj`'s real reference graph collapses to 2 strata (`ok`/`err`/etc.
+at 0, everything downstream at 1) — well under budget. The old headings
+(`Layer 0` through `Layer 3`) were decorative section banners
+(Constructors/Extraction/Transforms/Combinators), not real dependency
+depth. No other file changed layer count in a way that introduced a new
+finding.
+
+## Testing Plan
+
+1. Confirmed idempotency: ran `--fix` a second time — zero diff, zero
+   "rewrote" output.
+2. Read every changed file's full diff (all 8; small component). Changes
+   are heading text, `^{:stratum n}` metadata, and def
+   reordering/re-grouping only. No same-line trailing comments existed in
+   any of these files before the fix (checked via `grep` against the
+   pre-fix `origin/main` content), so the comment-reattachment risk this
+   wave watches for does not apply here — nothing to hand-fix.
+3. `clj-kondo --lint components/dag-primitives`: 0 errors. 1 warning
+   (deprecated-fn usage notice on `unwrap`, referenced from
+   `interface.clj`) — confirmed pre-existing on `origin/main` before this
+   fix and unrelated to stratum-lint; the project's own `clj-kondo` gate
+   (`tasks/lint.clj`) already allows warnings and fails only on errors.
+4. Re-ran plain (non-`--fix`) `stratum-lint` over the component after the
+   fix: exit 0, zero findings remain. The SL003 finding is fully resolved
+   — no Wave 2 namespace split needed for this component.
+5. Ran the component's test suite directly (`clojure -M:test -m
+   cognitect.test-runner` from `components/dag-primitives`): 30 tests, 55
+   assertions, 0 failures, 0 errors.
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+change — comment/metadata-only reorder. Pre-commit's `lint:stratum`
+autofixer keeps this component clean going forward.
+
+## Related Issues/PRs
+
++ Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1 —
+  mechanical relabeling via `--fix`, decorative-heading files only)
++ Sibling Wave 1 PRs: `2026-07-24-fix-stratum-lint-wave1-compliance-scanner.md`,
+  `-reliability.md`, `-gate.md`, `-decision.md`, `-adapter-claude-code.md`
+
+## Checklist
+
++ [x] `--fix` run over the whole component (`src` + `test`)
++ [x] Idempotency verified (second `--fix` pass: zero diff)
++ [x] Diff reviewed file-by-file; mechanical-only (heading + metadata +
+      reorder); no comment-attachment issue found (none existed to break)
++ [x] `clj-kondo` clean (0 errors; 1 pre-existing, unrelated warning)
++ [x] Plain lint re-run post-fix: zero findings (SL003 fully resolved, no
+      Wave 2 follow-up needed for this component)
++ [x] Component test suite: 30 tests, 55 assertions, 0 failures, 0 errors
++ [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
## Summary

- Runs `stratum-lint --fix` over `components/dag-primitives` (`src` + `test`, 8 files) to replace the decorative `Layer N` headings with headings that reflect each file's real same-file reference graph, tagging every def/deftest with `^{:stratum n}` metadata.
- Fixes the component's single baseline finding: `result.clj:99:1: SL003 file uses 4 distinct layers (max 3)`. The real reference graph collapses to 2 strata (constructors/accessors at 0, everything downstream at 1) — the old 4-layer split was a decorative section-banner artifact, not real depth. Zero `SL001` findings in this component (no upward-reference/cycle risk).
- Purely mechanical: no logic changes. No comment-attachment issue found or fixed — no same-line trailing comments existed in any of these 8 files before the fix, so that known tool limitation doesn't apply here.

## Testing

- Idempotency: ran `--fix` a second time — zero diff.
- Read every changed file's full diff (small component, all 8 read). Confirmed heading + `^{:stratum n}` metadata + def reordering only.
- `clj-kondo --lint components/dag-primitives`: 0 errors, 1 warning (pre-existing deprecated-fn notice on `unwrap`, confirmed present on `main` before this PR, unrelated to stratum-lint; the project's own gate already allows warnings and fails only on errors).
- Plain (non-`--fix`) `stratum-lint` re-run post-fix: exit 0, zero findings remain. **SL003 is fully resolved — no Wave 2 namespace split needed for this component.**
- Component test suite (`clojure -M:test -m cognitect.test-runner`): 30 tests, 55 assertions, 0 failures, 0 errors.
- Full pre-commit hook passed clean (Polylith check, clj-kondo, stratum-lint, markdown format, smoke tests, GraalVM/bb compat) — no override flags needed.

## Related

Part of the Wave 1 series from `work/stratum-lint-baseline-2026-07-24.md`. Doc: `docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-dag-primitives.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)