### PR TITLE
fix: stratum-lint autofix for components/observer (Wave 1)

### DIFF
--- a/components/observer/src/ai/miniforge/observer/alert_subscriber.clj
+++ b/components/observer/src/ai/miniforge/observer/alert_subscriber.clj
@@ -15,26 +15,36 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.observer.alert-subscriber
   (:require
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.observer.alerts :as alerts]))
 
-(def ^:private watched-types
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private watched-types
   #{:workflow/phase-heartbeat :agent/tool-call-started :tool/call-completed})
 
-(defn rules-from-config [config]
+(defn ^{:stratum 0} rules-from-config [config]
   (vec (get-in config [:observability :alerts] [])))
 
-(defn- alert-event [workflow-id alert]
+(defn- ^{:stratum 0} alert-event [workflow-id alert]
   (assoc (alerts/alert-fired nil workflow-id alert) :workflow/id workflow-id))
 
-(defn- watched-workflow-event? [workflow-id event]
+(defn ^{:stratum 0} stop-alert-subscriber! [event-stream handle]
+  (when-let [id (:subscriber-id handle)]
+    (es/unsubscribe! event-stream id))
+  nil)
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} watched-workflow-event? [workflow-id event]
   (and (contains? watched-types (:event/type event))
        (= workflow-id (:workflow/id event))))
 
-(defn start-alert-subscriber!
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} start-alert-subscriber!
   ([event-stream workflow-id rules]
    (start-alert-subscriber! event-stream workflow-id rules {}))
   ([event-stream workflow-id rules {:keys [subscriber-id alert-state]}]
@@ -50,8 +60,3 @@
             (es/publish! event-stream (alert-event workflow-id alert))))
         (partial watched-workflow-event? workflow-id))
        {:subscriber-id id :alert-state state}))))
-
-(defn stop-alert-subscriber! [event-stream handle]
-  (when-let [id (:subscriber-id handle)]
-    (es/unsubscribe! event-stream id))
-  nil)

--- a/components/observer/src/ai/miniforge/observer/alerts.clj
+++ b/components/observer/src/ai/miniforge/observer/alerts.clj
@@ -15,11 +15,12 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.observer.alerts
   (:require [clojure.string :as str]))
 
-(def AlertRule
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} AlertRule
   [:multi {:dispatch :alert/type}
    [:phase-gap [:map [:alert/id keyword?] [:alert/type [:= :phase-gap]]
                 [:alert/threshold [:map [:threshold-ms pos-int?]]]
@@ -34,24 +35,24 @@
                       [:alert/severity {:optional true} [:enum :info :warning :critical]]
                       [:alert/message-template {:optional true} string?]]]])
 
-(def AlertMap [:map [:alert/rule-id keyword?]
+(def ^{:stratum 0} AlertMap [:map [:alert/rule-id keyword?]
                [:alert/type [:enum :phase-gap :tool-call-timeout :tool-error-rate]]
                [:alert/severity [:enum :info :warning :critical]]
                [:alert/message string?] [:alert/data map?] [:alert/timestamp inst?]])
 
-(def AlertFired [:map [:event/type [:= :observer/alert-fired]]
+(def ^{:stratum 0} AlertFired [:map [:event/type [:= :observer/alert-fired]]
                  [:event/workflow-id some?] [:event/timestamp inst?]
                  [:alert/rule-id keyword?]
                  [:alert/type [:enum :phase-gap :tool-call-timeout :tool-error-rate]]
                  [:alert/severity [:enum :info :warning :critical]]
                  [:alert/message string?] [:alert/data map?] [:alert/timestamp inst?]])
 
-(def ^:private window-size 100)
+(def ^{:stratum 0} ^:private window-size 100)
 
-(defn create-alert-state []
+(defn ^{:stratum 0} create-alert-state []
   (atom {:outstanding-calls {} :tool-outcomes []}))
 
-(defn- event-ms [event]
+(defn- ^{:stratum 0} event-ms [event]
   (try
     (let [ts (:event/timestamp event)]
       (cond
@@ -61,7 +62,19 @@
         :else (System/currentTimeMillis)))
     (catch Exception _ (System/currentTimeMillis))))
 
-(defn- update-state! [state event]
+(defn- ^{:stratum 0} template [s data]
+  (str/replace s #"\{\{([\w][\w/-]*)\}\}" #(str (get data (keyword (second %)) ""))))
+
+(defn ^{:stratum 0} alert-fired [_stream workflow-id alert-map]
+  (merge {:event/type :observer/alert-fired
+          :event/workflow-id workflow-id
+          :event/timestamp (java.util.Date.)}
+         (select-keys alert-map [:alert/rule-id :alert/type :alert/severity
+                                 :alert/message :alert/data :alert/timestamp])))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} update-state! [state event]
   (case (:event/type event)
     :agent/tool-call-started
     (when-let [call-id (:tool/call-id event)]
@@ -81,10 +94,7 @@
                                xs'))))))))
     nil))
 
-(defn- template [s data]
-  (str/replace s #"\{\{([\w][\w/-]*)\}\}" #(str (get data (keyword (second %)) ""))))
-
-(defn- message [rule data]
+(defn- ^{:stratum 1} message [rule data]
   (if-let [s (:alert/message-template rule)]
     (template s data)
     (case (:alert/type rule)
@@ -93,7 +103,9 @@
       :tool-error-rate (format "Tool error rate %.1f%% exceeds threshold"
                                (* 100.0 (double (:error-rate data)))))))
 
-(defn- alert [rule data]
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- ^{:stratum 2} alert [rule data]
   {:alert/rule-id (:alert/id rule)
    :alert/type (:alert/type rule)
    :alert/severity (get rule :alert/severity :warning)
@@ -101,14 +113,16 @@
    :alert/data data
    :alert/timestamp (java.util.Date.)})
 
-(defn- phase-gap [rule event]
+;------------------------------------------------------------------------------ Layer 3
+
+(defn- ^{:stratum 3} phase-gap [rule event]
   (when (= :workflow/phase-heartbeat (:event/type event))
     (let [gap (:phase/gap-since-last-event-ms event)
           threshold (get-in rule [:alert/threshold :threshold-ms])]
       (when (and gap threshold (> gap threshold))
         (alert rule {:gap-ms gap :threshold-ms threshold})))))
 
-(defn- timeouts [rule event state]
+(defn- ^{:stratum 3} timeouts [rule event state]
   (when (= :workflow/phase-heartbeat (:event/type event))
     (let [threshold (get-in rule [:alert/threshold :threshold-ms])
           now (event-ms event)]
@@ -121,7 +135,7 @@
                                     :threshold-ms threshold})))))
            vec))))
 
-(defn- error-rate [rule event state]
+(defn- ^{:stratum 3} error-rate [rule event state]
   (when (= :workflow/phase-heartbeat (:event/type event))
     (let [xs (:tool-outcomes @state)
           threshold (get-in rule [:alert/threshold :threshold-pct])]
@@ -134,7 +148,9 @@
                          :total-count (count xs)
                          :threshold-pct threshold})))))))
 
-(defn evaluate-rules [rules event state]
+;------------------------------------------------------------------------------ Layer 4
+
+(defn ^{:stratum 4} evaluate-rules [rules event state]
   (update-state! state event)
   (into []
         (mapcat (fn [rule]
@@ -145,10 +161,3 @@
                             nil)]
                     (cond (nil? x) [] (sequential? x) x :else [x]))))
         rules))
-
-(defn alert-fired [_stream workflow-id alert-map]
-  (merge {:event/type :observer/alert-fired
-          :event/workflow-id workflow-id
-          :event/timestamp (java.util.Date.)}
-         (select-keys alert-map [:alert/rule-id :alert/type :alert/severity
-                                 :alert/message :alert/data :alert/timestamp])))

--- a/components/observer/src/ai/miniforge/observer/core.clj
+++ b/components/observer/src/ai/miniforge/observer/core.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.observer.core
   "Core observer implementation for metrics collection and analysis.
 
@@ -30,22 +29,30 @@
 ;; ============================================================================
 ;; Forward Declarations
 ;; ============================================================================
-
 (declare analyze-duration-stats)
+
 (declare analyze-cost-stats)
+
 (declare analyze-token-stats)
+
 (declare analyze-phase-stats)
+
 (declare analyze-failure-patterns)
+
 (declare analyze-trends)
+
 (declare generate-summary-report)
+
 (declare generate-detailed-report)
+
 (declare generate-recommendations-report)
+
+;------------------------------------------------------------------------------ Layer 0
 
 ;; ============================================================================
 ;; Failure Attribution Helpers
 ;; ============================================================================
-
-(def ^:private failure-attribution-keys
+(def ^{:stratum 0} ^:private failure-attribution-keys
   [:failure/source
    :failure/vendor
    :failure/class
@@ -58,25 +65,12 @@
    :dependency/class
    :dependency/retryability])
 
-(defn- failure-attribution
-  [failure]
-  (let [attribution (select-keys failure failure-attribution-keys)]
-    (when (seq attribution)
-      attribution)))
-
-(defn- collect-failure-attribution
-  [workflow-state]
-  (or (some-> (:workflow/error workflow-state) failure-attribution)
-      (some->> (:workflow/errors workflow-state)
-               (keep failure-attribution)
-               first)))
-
-(defn- collect-dependency-health
+(defn- ^{:stratum 0} collect-dependency-health
   [workflow-state]
   (when-let [projection (:dependency-health workflow-state)]
     (not-empty projection)))
 
-(defn- label
+(defn- ^{:stratum 0} label
   [value]
   (cond
     (keyword? value) (name value)
@@ -85,10 +79,429 @@
     :else (str value)))
 
 ;; ============================================================================
+;; Analysis Functions
+;; ============================================================================
+(defn ^{:stratum 0} calculate-percentile
+  "Calculate percentile from sorted values."
+  [sorted-values percentile]
+  (when (seq sorted-values)
+    (let [idx (int (* (/ percentile 100.0) (count sorted-values)))]
+      (nth sorted-values (min idx (dec (count sorted-values)))))))
+
+(defn ^{:stratum 0} analyze-trends
+  "Analyze metrics trends over time."
+  [observer opts]
+  (let [limit (get opts :limit 100)
+        metrics (proto/get-all-metrics observer {:limit limit})
+
+        ;; Sort by timestamp (oldest first for trend analysis)
+        sorted-metrics (sort-by :timestamp metrics)
+
+        ;; Split into first half and second half
+        n (count sorted-metrics)
+        first-half (take (quot n 2) sorted-metrics)
+        second-half (drop (quot n 2) sorted-metrics)
+
+        ;; Calculate stats for each half
+        first-durations (map #(get-in % [:metrics :duration-ms]) first-half)
+        second-durations (map #(get-in % [:metrics :duration-ms]) second-half)
+
+        first-costs (map #(get-in % [:metrics :cost-usd]) first-half)
+        second-costs (map #(get-in % [:metrics :cost-usd]) second-half)
+
+        duration-trend (when (and (seq first-durations) (seq second-durations))
+                        {:first-avg (double (/ (reduce + first-durations) (count first-durations)))
+                         :second-avg (double (/ (reduce + second-durations) (count second-durations)))})
+
+        cost-trend (when (and (seq first-costs) (seq second-costs))
+                    {:first-avg (double (/ (reduce + first-costs) (count first-costs)))
+                     :second-avg (double (/ (reduce + second-costs) (count second-costs)))})]
+
+    (proto/analysis-result
+     {:analysis-type :trends
+      :data {:duration-trend duration-trend
+             :cost-trend cost-trend
+             :sample-size n}
+      :summary (cond
+                 (and duration-trend cost-trend)
+                 (format "Duration %.0f -> %.0fms (%.1f%% change), Cost $%.4f -> $%.4f (%.1f%% change)"
+                         (:first-avg duration-trend)
+                         (:second-avg duration-trend)
+                         (* 100.0 (/ (- (:second-avg duration-trend) (:first-avg duration-trend))
+                                    (:first-avg duration-trend)))
+                         (:first-avg cost-trend)
+                         (:second-avg cost-trend)
+                         (* 100.0 (/ (- (:second-avg cost-trend) (:first-avg cost-trend))
+                                    (:first-avg cost-trend))))
+
+                 :else
+                 "Insufficient data for trend analysis")})))
+
+(defn ^{:stratum 0} generate-detailed-report
+  "Generate a detailed metrics breakdown report."
+  [observer opts]
+  (let [output-format (get opts :format :edn)
+        limit (get opts :limit 50)
+
+        all-metrics (proto/get-all-metrics observer {:limit limit})
+        phase-analysis (proto/analyze-metrics observer :phase-stats {:limit limit})
+
+        report-data {:workflows all-metrics
+                     :phase-breakdown phase-analysis
+                     :total-workflows (count all-metrics)
+                     :generated-at (java.util.Date.)}]
+
+    (case output-format
+      :edn report-data
+      :markdown (str "# Detailed Workflow Metrics\n\n"
+                     "**Generated:** " (:generated-at report-data) "\n"
+                     "**Total Workflows:** " (:total-workflows report-data) "\n\n"
+                     "## Phase Performance\n"
+                     (:summary phase-analysis) "\n\n"
+                     "## Recent Workflows\n"
+                     (str/join "\n" (map #(format "- %s: %s (%.0fms, $%.4f)"
+                                                   (:workflow-id %)
+                                                   (:status %)
+                                                   (get-in % [:metrics :duration-ms])
+                                                   (get-in % [:metrics :cost-usd]))
+                                         (take 10 all-metrics))))
+      report-data)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} failure-attribution
+  [failure]
+  (let [attribution (select-keys failure failure-attribution-keys)]
+    (when (seq attribution)
+      attribution)))
+
+(defn ^{:stratum 1} calculate-stats
+  "Calculate statistics for a sequence of numeric values."
+  [values]
+  (when (seq values)
+    (let [sorted (sort values)
+          n (count sorted)
+          sum (reduce + sorted)
+          avg (double (/ sum n))
+          p50 (calculate-percentile sorted 50)
+          p95 (calculate-percentile sorted 95)
+          p99 (calculate-percentile sorted 99)
+          min-val (first sorted)
+          max-val (last sorted)]
+      {:count n
+       :sum sum
+       :avg avg
+       :min min-val
+       :max max-val
+       :p50 p50
+       :p95 p95
+       :p99 p99})))
+
+(defn ^{:stratum 1} analyze-failure-patterns
+  "Analyze workflow failure patterns."
+  [observer opts]
+  (let [limit (get opts :limit 100)
+        metrics (proto/get-all-metrics observer {:limit limit})
+        failed (filter phase/failed? metrics)
+        attributed-failures (keep :failure-attribution failed)
+
+        ;; Analyze which phases fail most often
+        failed-phases (reduce
+                       (fn [acc workflow-metrics]
+                         (let [failed-phases (filter #(not (:success? %)) (:phases workflow-metrics []))]
+                           (reduce
+                            (fn [acc2 phase-metrics]
+                              (update acc2 (:phase phase-metrics) (fnil inc 0)))
+                            acc
+                            failed-phases)))
+                       {}
+                       failed)
+        dependency-failures (->> attributed-failures
+                                 (keep (fn [failure]
+                                         (when-let [dependency-id (or (:dependency/id failure)
+                                                                      (:failure/vendor failure))]
+                                           [dependency-id (select-keys failure
+                                                                       [:failure/source
+                                                                        :failure/vendor
+                                                                        :failure/class
+                                                                        :dependency/class
+                                                                        :dependency/retryability])])))
+                                 (reduce (fn [acc [dependency-id failure]]
+                                           (update acc dependency-id
+                                                   (fn [existing]
+                                                     (-> (merge existing failure)
+                                                         (update :count (fnil inc 0))))))
+                                         {})
+                                 (sort-by (comp - :count val))
+                                 vec)
+
+        total-workflows (count metrics)
+        failure-rate (if (pos? total-workflows)
+                      (double (/ (count failed) total-workflows))
+                      0.0)]
+
+    (proto/analysis-result
+     {:analysis-type :failure-patterns
+      :data {:total-workflows total-workflows
+             :failed-workflows (count failed)
+             :failure-rate failure-rate
+             :failed-phases (sort-by val > failed-phases)
+             :dependency-failures dependency-failures}
+      :summary (format "Failure rate: %.1f%% (%d/%d workflows failed)"
+                       (* 100.0 failure-rate)
+                       (count failed)
+                       total-workflows)
+      :recommendations
+      (cond-> []
+        (seq failed-phases)
+        (conj (str "Most problematic phases: "
+                   (str/join ", " (map first (take 3 (sort-by val > failed-phases))))))
+        (seq dependency-failures)
+        (conj (str "Dependency-attributed failures: "
+                   (str/join ", " (map (comp label first) (take 3 dependency-failures))))))})))
+
+;; ============================================================================
+;; Report Generation
+;; ============================================================================
+(defn ^{:stratum 1} generate-summary-report
+  "Generate a summary performance report."
+  [observer opts]
+  (let [output-format (get opts :format :markdown)
+        limit (get opts :limit 100)
+
+        duration-analysis (proto/analyze-metrics observer :duration-stats {:limit limit})
+        cost-analysis (proto/analyze-metrics observer :cost-stats {:limit limit})
+        token-analysis (proto/analyze-metrics observer :token-stats {:limit limit})
+        failure-analysis (proto/analyze-metrics observer :failure-patterns {:limit limit})
+
+        report-data {:duration duration-analysis
+                     :cost cost-analysis
+                     :tokens token-analysis
+                     :failures failure-analysis
+                     :generated-at (java.util.Date.)}]
+
+    (case output-format
+      :edn report-data
+
+      :markdown
+      (str "# Workflow Performance Summary\n\n"
+           "**Generated:** " (:generated-at report-data) "\n\n"
+           "## Duration Statistics\n"
+           (:summary duration-analysis) "\n\n"
+           "## Cost Statistics\n"
+           (:summary cost-analysis) "\n\n"
+           "## Token Usage Statistics\n"
+           (:summary token-analysis) "\n\n"
+           "## Failure Analysis\n"
+           (:summary failure-analysis) "\n"
+           (when-let [dependency-failures (seq (get-in failure-analysis [:data :dependency-failures]))]
+             (str "\n**Dependency-attributed failures:**\n"
+                  (str/join "\n"
+                            (map (fn [[dependency-id failure]]
+                                   (format "- %s (%s, count=%d)"
+                                           (label dependency-id)
+                                           (or (some-> (:dependency/class failure) label)
+                                               (some-> (:failure/class failure) label)
+                                               "unknown")
+                                           (:count failure)))
+                                 dependency-failures))
+                  "\n"))
+           (when-let [recs (:recommendations failure-analysis)]
+             (str "\n**Recommendations:**\n"
+                  (str/join "\n" (map #(str "- " %) recs)) "\n")))
+
+      report-data)))
+
+(defn ^{:stratum 1} generate-recommendations-report
+  "Generate recommendations for workflow improvements."
+  [observer opts]
+  (let [output-format (get opts :format :markdown)
+        limit (get opts :limit 100)
+
+        failure-analysis (proto/analyze-metrics observer :failure-patterns {:limit limit})
+        phase-analysis (proto/analyze-metrics observer :phase-stats {:limit limit})
+        trends-analysis (proto/analyze-metrics observer :trends {:limit limit})
+
+        ;; Generate recommendations based on analysis
+        recommendations []
+
+        ;; Failure-based recommendations
+        recommendations (if-let [recs (:recommendations failure-analysis)]
+                         (into recommendations recs)
+                         recommendations)
+
+        ;; Phase performance recommendations
+        phase-data (:data phase-analysis)
+        slow-phases (filter (fn [[_phase stats]]
+                             (when-let [avg-duration (get-in stats [:duration :avg])]
+                               (> avg-duration 30000))) ;; > 30 seconds
+                           phase-data)
+
+        recommendations (if (seq slow-phases)
+                         (conj recommendations
+                               (str "Optimize slow phases: "
+                                    (str/join ", " (map first slow-phases))))
+                         recommendations)
+
+        ;; Trend-based recommendations
+        duration-trend (get-in trends-analysis [:data :duration-trend])
+        recommendations (if (and duration-trend
+                                (> (:second-avg duration-trend)
+                                   (* 1.2 (:first-avg duration-trend)))) ;; 20% increase
+                         (conj recommendations
+                               "Warning: Workflow duration increasing over time - investigate performance regression")
+                         recommendations)
+
+        report-data {:recommendations recommendations
+                     :failure-analysis failure-analysis
+                     :phase-analysis phase-analysis
+                     :trends-analysis trends-analysis
+                     :generated-at (java.util.Date.)}]
+
+    (case output-format
+      :edn report-data
+      :markdown (str "# Workflow Improvement Recommendations\n\n"
+                     "**Generated:** " (:generated-at report-data) "\n\n"
+                     "## Recommendations\n"
+                     (if (seq recommendations)
+                       (str/join "\n" (map #(str "- " %) recommendations))
+                       "No specific recommendations at this time. System performing well!")
+                     "\n\n"
+                     "## Supporting Analysis\n\n"
+                     "### Failures\n" (:summary failure-analysis) "\n\n"
+                     (when-let [dependency-failures (seq (get-in failure-analysis [:data :dependency-failures]))]
+                       (str "### Dependency Attribution\n"
+                            (str/join "\n"
+                                      (map (fn [[dependency-id failure]]
+                                             (format "- %s: %s (%d)"
+                                                     (label dependency-id)
+                                                     (or (some-> (:dependency/class failure) label)
+                                                         (some-> (:failure/class failure) label)
+                                                         "unknown")
+                                                     (:count failure)))
+                                           dependency-failures))
+                            "\n\n"))
+                     "### Trends\n" (:summary trends-analysis) "\n")
+      report-data)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- ^{:stratum 2} collect-failure-attribution
+  [workflow-state]
+  (or (some-> (:workflow/error workflow-state) failure-attribution)
+      (some->> (:workflow/errors workflow-state)
+               (keep failure-attribution)
+               first)))
+
+(defn ^{:stratum 2} analyze-duration-stats
+  "Analyze workflow duration statistics."
+  [observer opts]
+  (let [limit (get opts :limit 100)
+        metrics (proto/get-all-metrics observer {:limit limit})
+        durations (map #(get-in % [:metrics :duration-ms]) metrics)
+        durations (remove nil? durations)
+
+        stats (calculate-stats durations)]
+
+    (proto/analysis-result
+     {:analysis-type :duration-stats
+      :data stats
+      :summary (when stats
+                 (format "Analyzed %d workflows: avg=%.0fms, p50=%.0fms, p95=%.0fms, p99=%.0fms"
+                         (:count stats)
+                         (double (:avg stats))
+                         (double (:p50 stats))
+                         (double (:p95 stats))
+                         (double (:p99 stats))))})))
+
+(defn ^{:stratum 2} analyze-cost-stats
+  "Analyze workflow cost statistics."
+  [observer opts]
+  (let [limit (get opts :limit 100)
+        metrics (proto/get-all-metrics observer {:limit limit})
+        costs (map #(get-in % [:metrics :cost-usd]) metrics)
+        costs (remove nil? costs)
+
+        stats (calculate-stats costs)]
+
+    (proto/analysis-result
+     {:analysis-type :cost-stats
+      :data stats
+      :summary (when stats
+                 (format "Analyzed %d workflows: avg=$%.4f, p50=$%.4f, p95=$%.4f, total=$%.4f"
+                         (:count stats)
+                         (:avg stats)
+                         (:p50 stats)
+                         (:p95 stats)
+                         (:sum stats)))})))
+
+(defn ^{:stratum 2} analyze-token-stats
+  "Analyze workflow token usage statistics."
+  [observer opts]
+  (let [limit (get opts :limit 100)
+        metrics (proto/get-all-metrics observer {:limit limit})
+        tokens (map #(get-in % [:metrics :tokens]) metrics)
+        tokens (remove nil? tokens)
+
+        stats (calculate-stats tokens)]
+
+    (proto/analysis-result
+     {:analysis-type :token-stats
+      :data stats
+      :summary (when stats
+                 (format "Analyzed %d workflows: avg=%d tokens, p50=%d, p95=%d, total=%d"
+                         (:count stats)
+                         (int (:avg stats))
+                         (:p50 stats)
+                         (:p95 stats)
+                         (:sum stats)))})))
+
+(defn ^{:stratum 2} analyze-phase-stats
+  "Analyze per-phase performance statistics."
+  [observer opts]
+  (let [limit (get opts :limit 100)
+        metrics (proto/get-all-metrics observer {:limit limit})
+
+        ;; Group phase metrics by phase name
+        phase-groups (reduce
+                      (fn [acc workflow-metrics]
+                        (reduce
+                         (fn [acc2 phase-metrics]
+                           (update acc2 (:phase phase-metrics) (fnil conj []) phase-metrics))
+                         acc
+                         (:phases workflow-metrics [])))
+                      {}
+                      metrics)
+
+        ;; Calculate stats for each phase
+        phase-stats (into {}
+                          (map (fn [[phase-name phase-list]]
+                                 (let [durations (map #(get-in % [:metrics :duration-ms]) phase-list)
+                                       tokens (map #(get-in % [:metrics :tokens]) phase-list)
+                                       success-count (count (filter :success? phase-list))
+                                       total-count (count phase-list)
+                                       success-rate (if (pos? total-count)
+                                                     (double (/ success-count total-count))
+                                                     0.0)]
+                                   [phase-name {:duration (calculate-stats (remove nil? durations))
+                                               :tokens (calculate-stats (remove nil? tokens))
+                                               :success-rate success-rate
+                                               :total-executions total-count}]))
+                               phase-groups))]
+
+    (proto/analysis-result
+     {:analysis-type :phase-stats
+      :data phase-stats
+      :summary (format "Analyzed %d unique phases across %d workflows"
+                       (count phase-stats)
+                       (count metrics))})))
+
+;------------------------------------------------------------------------------ Layer 3
+
+;; ============================================================================
 ;; Simple Observer Implementation
 ;; ============================================================================
-
-(defrecord SimpleObserver [state]
+(defrecord ^{:stratum 3} SimpleObserver [state]
   ;; State structure:
   ;; {:metrics {workflow-id -> workflow-metrics}
   ;;  :phase-metrics {workflow-id -> [phase-metrics...]}
@@ -224,11 +637,12 @@
     ;; Currently just logging via history in workflow state
     nil))
 
+;------------------------------------------------------------------------------ Layer 4
+
 ;; ============================================================================
 ;; Constructor
 ;; ============================================================================
-
-(defn create-observer
+(defn ^{:stratum 4} create-observer
   "Create a new SimpleObserver instance.
 
    Options:
@@ -245,406 +659,3 @@
                   :metadata {:created (java.util.Date.)
                             :total-workflows 0}}
                  initial-state)))))
-
-;; ============================================================================
-;; Analysis Functions
-;; ============================================================================
-
-(defn calculate-percentile
-  "Calculate percentile from sorted values."
-  [sorted-values percentile]
-  (when (seq sorted-values)
-    (let [idx (int (* (/ percentile 100.0) (count sorted-values)))]
-      (nth sorted-values (min idx (dec (count sorted-values)))))))
-
-(defn calculate-stats
-  "Calculate statistics for a sequence of numeric values."
-  [values]
-  (when (seq values)
-    (let [sorted (sort values)
-          n (count sorted)
-          sum (reduce + sorted)
-          avg (double (/ sum n))
-          p50 (calculate-percentile sorted 50)
-          p95 (calculate-percentile sorted 95)
-          p99 (calculate-percentile sorted 99)
-          min-val (first sorted)
-          max-val (last sorted)]
-      {:count n
-       :sum sum
-       :avg avg
-       :min min-val
-       :max max-val
-       :p50 p50
-       :p95 p95
-       :p99 p99})))
-
-(defn analyze-duration-stats
-  "Analyze workflow duration statistics."
-  [observer opts]
-  (let [limit (get opts :limit 100)
-        metrics (proto/get-all-metrics observer {:limit limit})
-        durations (map #(get-in % [:metrics :duration-ms]) metrics)
-        durations (remove nil? durations)
-
-        stats (calculate-stats durations)]
-
-    (proto/analysis-result
-     {:analysis-type :duration-stats
-      :data stats
-      :summary (when stats
-                 (format "Analyzed %d workflows: avg=%.0fms, p50=%.0fms, p95=%.0fms, p99=%.0fms"
-                         (:count stats)
-                         (double (:avg stats))
-                         (double (:p50 stats))
-                         (double (:p95 stats))
-                         (double (:p99 stats))))})))
-
-(defn analyze-cost-stats
-  "Analyze workflow cost statistics."
-  [observer opts]
-  (let [limit (get opts :limit 100)
-        metrics (proto/get-all-metrics observer {:limit limit})
-        costs (map #(get-in % [:metrics :cost-usd]) metrics)
-        costs (remove nil? costs)
-
-        stats (calculate-stats costs)]
-
-    (proto/analysis-result
-     {:analysis-type :cost-stats
-      :data stats
-      :summary (when stats
-                 (format "Analyzed %d workflows: avg=$%.4f, p50=$%.4f, p95=$%.4f, total=$%.4f"
-                         (:count stats)
-                         (:avg stats)
-                         (:p50 stats)
-                         (:p95 stats)
-                         (:sum stats)))})))
-
-(defn analyze-token-stats
-  "Analyze workflow token usage statistics."
-  [observer opts]
-  (let [limit (get opts :limit 100)
-        metrics (proto/get-all-metrics observer {:limit limit})
-        tokens (map #(get-in % [:metrics :tokens]) metrics)
-        tokens (remove nil? tokens)
-
-        stats (calculate-stats tokens)]
-
-    (proto/analysis-result
-     {:analysis-type :token-stats
-      :data stats
-      :summary (when stats
-                 (format "Analyzed %d workflows: avg=%d tokens, p50=%d, p95=%d, total=%d"
-                         (:count stats)
-                         (int (:avg stats))
-                         (:p50 stats)
-                         (:p95 stats)
-                         (:sum stats)))})))
-
-(defn analyze-phase-stats
-  "Analyze per-phase performance statistics."
-  [observer opts]
-  (let [limit (get opts :limit 100)
-        metrics (proto/get-all-metrics observer {:limit limit})
-
-        ;; Group phase metrics by phase name
-        phase-groups (reduce
-                      (fn [acc workflow-metrics]
-                        (reduce
-                         (fn [acc2 phase-metrics]
-                           (update acc2 (:phase phase-metrics) (fnil conj []) phase-metrics))
-                         acc
-                         (:phases workflow-metrics [])))
-                      {}
-                      metrics)
-
-        ;; Calculate stats for each phase
-        phase-stats (into {}
-                          (map (fn [[phase-name phase-list]]
-                                 (let [durations (map #(get-in % [:metrics :duration-ms]) phase-list)
-                                       tokens (map #(get-in % [:metrics :tokens]) phase-list)
-                                       success-count (count (filter :success? phase-list))
-                                       total-count (count phase-list)
-                                       success-rate (if (pos? total-count)
-                                                     (double (/ success-count total-count))
-                                                     0.0)]
-                                   [phase-name {:duration (calculate-stats (remove nil? durations))
-                                               :tokens (calculate-stats (remove nil? tokens))
-                                               :success-rate success-rate
-                                               :total-executions total-count}]))
-                               phase-groups))]
-
-    (proto/analysis-result
-     {:analysis-type :phase-stats
-      :data phase-stats
-      :summary (format "Analyzed %d unique phases across %d workflows"
-                       (count phase-stats)
-                       (count metrics))})))
-
-(defn analyze-failure-patterns
-  "Analyze workflow failure patterns."
-  [observer opts]
-  (let [limit (get opts :limit 100)
-        metrics (proto/get-all-metrics observer {:limit limit})
-        failed (filter phase/failed? metrics)
-        attributed-failures (keep :failure-attribution failed)
-
-        ;; Analyze which phases fail most often
-        failed-phases (reduce
-                       (fn [acc workflow-metrics]
-                         (let [failed-phases (filter #(not (:success? %)) (:phases workflow-metrics []))]
-                           (reduce
-                            (fn [acc2 phase-metrics]
-                              (update acc2 (:phase phase-metrics) (fnil inc 0)))
-                            acc
-                            failed-phases)))
-                       {}
-                       failed)
-        dependency-failures (->> attributed-failures
-                                 (keep (fn [failure]
-                                         (when-let [dependency-id (or (:dependency/id failure)
-                                                                      (:failure/vendor failure))]
-                                           [dependency-id (select-keys failure
-                                                                       [:failure/source
-                                                                        :failure/vendor
-                                                                        :failure/class
-                                                                        :dependency/class
-                                                                        :dependency/retryability])])))
-                                 (reduce (fn [acc [dependency-id failure]]
-                                           (update acc dependency-id
-                                                   (fn [existing]
-                                                     (-> (merge existing failure)
-                                                         (update :count (fnil inc 0))))))
-                                         {})
-                                 (sort-by (comp - :count val))
-                                 vec)
-
-        total-workflows (count metrics)
-        failure-rate (if (pos? total-workflows)
-                      (double (/ (count failed) total-workflows))
-                      0.0)]
-
-    (proto/analysis-result
-     {:analysis-type :failure-patterns
-      :data {:total-workflows total-workflows
-             :failed-workflows (count failed)
-             :failure-rate failure-rate
-             :failed-phases (sort-by val > failed-phases)
-             :dependency-failures dependency-failures}
-      :summary (format "Failure rate: %.1f%% (%d/%d workflows failed)"
-                       (* 100.0 failure-rate)
-                       (count failed)
-                       total-workflows)
-      :recommendations
-      (cond-> []
-        (seq failed-phases)
-        (conj (str "Most problematic phases: "
-                   (str/join ", " (map first (take 3 (sort-by val > failed-phases))))))
-        (seq dependency-failures)
-        (conj (str "Dependency-attributed failures: "
-                   (str/join ", " (map (comp label first) (take 3 dependency-failures))))))})))
-
-(defn analyze-trends
-  "Analyze metrics trends over time."
-  [observer opts]
-  (let [limit (get opts :limit 100)
-        metrics (proto/get-all-metrics observer {:limit limit})
-
-        ;; Sort by timestamp (oldest first for trend analysis)
-        sorted-metrics (sort-by :timestamp metrics)
-
-        ;; Split into first half and second half
-        n (count sorted-metrics)
-        first-half (take (quot n 2) sorted-metrics)
-        second-half (drop (quot n 2) sorted-metrics)
-
-        ;; Calculate stats for each half
-        first-durations (map #(get-in % [:metrics :duration-ms]) first-half)
-        second-durations (map #(get-in % [:metrics :duration-ms]) second-half)
-
-        first-costs (map #(get-in % [:metrics :cost-usd]) first-half)
-        second-costs (map #(get-in % [:metrics :cost-usd]) second-half)
-
-        duration-trend (when (and (seq first-durations) (seq second-durations))
-                        {:first-avg (double (/ (reduce + first-durations) (count first-durations)))
-                         :second-avg (double (/ (reduce + second-durations) (count second-durations)))})
-
-        cost-trend (when (and (seq first-costs) (seq second-costs))
-                    {:first-avg (double (/ (reduce + first-costs) (count first-costs)))
-                     :second-avg (double (/ (reduce + second-costs) (count second-costs)))})]
-
-    (proto/analysis-result
-     {:analysis-type :trends
-      :data {:duration-trend duration-trend
-             :cost-trend cost-trend
-             :sample-size n}
-      :summary (cond
-                 (and duration-trend cost-trend)
-                 (format "Duration %.0f -> %.0fms (%.1f%% change), Cost $%.4f -> $%.4f (%.1f%% change)"
-                         (:first-avg duration-trend)
-                         (:second-avg duration-trend)
-                         (* 100.0 (/ (- (:second-avg duration-trend) (:first-avg duration-trend))
-                                    (:first-avg duration-trend)))
-                         (:first-avg cost-trend)
-                         (:second-avg cost-trend)
-                         (* 100.0 (/ (- (:second-avg cost-trend) (:first-avg cost-trend))
-                                    (:first-avg cost-trend))))
-
-                 :else
-                 "Insufficient data for trend analysis")})))
-
-;; ============================================================================
-;; Report Generation
-;; ============================================================================
-
-(defn generate-summary-report
-  "Generate a summary performance report."
-  [observer opts]
-  (let [output-format (get opts :format :markdown)
-        limit (get opts :limit 100)
-
-        duration-analysis (proto/analyze-metrics observer :duration-stats {:limit limit})
-        cost-analysis (proto/analyze-metrics observer :cost-stats {:limit limit})
-        token-analysis (proto/analyze-metrics observer :token-stats {:limit limit})
-        failure-analysis (proto/analyze-metrics observer :failure-patterns {:limit limit})
-
-        report-data {:duration duration-analysis
-                     :cost cost-analysis
-                     :tokens token-analysis
-                     :failures failure-analysis
-                     :generated-at (java.util.Date.)}]
-
-    (case output-format
-      :edn report-data
-
-      :markdown
-      (str "# Workflow Performance Summary\n\n"
-           "**Generated:** " (:generated-at report-data) "\n\n"
-           "## Duration Statistics\n"
-           (:summary duration-analysis) "\n\n"
-           "## Cost Statistics\n"
-           (:summary cost-analysis) "\n\n"
-           "## Token Usage Statistics\n"
-           (:summary token-analysis) "\n\n"
-           "## Failure Analysis\n"
-           (:summary failure-analysis) "\n"
-           (when-let [dependency-failures (seq (get-in failure-analysis [:data :dependency-failures]))]
-             (str "\n**Dependency-attributed failures:**\n"
-                  (str/join "\n"
-                            (map (fn [[dependency-id failure]]
-                                   (format "- %s (%s, count=%d)"
-                                           (label dependency-id)
-                                           (or (some-> (:dependency/class failure) label)
-                                               (some-> (:failure/class failure) label)
-                                               "unknown")
-                                           (:count failure)))
-                                 dependency-failures))
-                  "\n"))
-           (when-let [recs (:recommendations failure-analysis)]
-             (str "\n**Recommendations:**\n"
-                  (str/join "\n" (map #(str "- " %) recs)) "\n")))
-
-      report-data)))
-
-(defn generate-detailed-report
-  "Generate a detailed metrics breakdown report."
-  [observer opts]
-  (let [output-format (get opts :format :edn)
-        limit (get opts :limit 50)
-
-        all-metrics (proto/get-all-metrics observer {:limit limit})
-        phase-analysis (proto/analyze-metrics observer :phase-stats {:limit limit})
-
-        report-data {:workflows all-metrics
-                     :phase-breakdown phase-analysis
-                     :total-workflows (count all-metrics)
-                     :generated-at (java.util.Date.)}]
-
-    (case output-format
-      :edn report-data
-      :markdown (str "# Detailed Workflow Metrics\n\n"
-                     "**Generated:** " (:generated-at report-data) "\n"
-                     "**Total Workflows:** " (:total-workflows report-data) "\n\n"
-                     "## Phase Performance\n"
-                     (:summary phase-analysis) "\n\n"
-                     "## Recent Workflows\n"
-                     (str/join "\n" (map #(format "- %s: %s (%.0fms, $%.4f)"
-                                                   (:workflow-id %)
-                                                   (:status %)
-                                                   (get-in % [:metrics :duration-ms])
-                                                   (get-in % [:metrics :cost-usd]))
-                                         (take 10 all-metrics))))
-      report-data)))
-
-(defn generate-recommendations-report
-  "Generate recommendations for workflow improvements."
-  [observer opts]
-  (let [output-format (get opts :format :markdown)
-        limit (get opts :limit 100)
-
-        failure-analysis (proto/analyze-metrics observer :failure-patterns {:limit limit})
-        phase-analysis (proto/analyze-metrics observer :phase-stats {:limit limit})
-        trends-analysis (proto/analyze-metrics observer :trends {:limit limit})
-
-        ;; Generate recommendations based on analysis
-        recommendations []
-
-        ;; Failure-based recommendations
-        recommendations (if-let [recs (:recommendations failure-analysis)]
-                         (into recommendations recs)
-                         recommendations)
-
-        ;; Phase performance recommendations
-        phase-data (:data phase-analysis)
-        slow-phases (filter (fn [[_phase stats]]
-                             (when-let [avg-duration (get-in stats [:duration :avg])]
-                               (> avg-duration 30000))) ;; > 30 seconds
-                           phase-data)
-
-        recommendations (if (seq slow-phases)
-                         (conj recommendations
-                               (str "Optimize slow phases: "
-                                    (str/join ", " (map first slow-phases))))
-                         recommendations)
-
-        ;; Trend-based recommendations
-        duration-trend (get-in trends-analysis [:data :duration-trend])
-        recommendations (if (and duration-trend
-                                (> (:second-avg duration-trend)
-                                   (* 1.2 (:first-avg duration-trend)))) ;; 20% increase
-                         (conj recommendations
-                               "Warning: Workflow duration increasing over time - investigate performance regression")
-                         recommendations)
-
-        report-data {:recommendations recommendations
-                     :failure-analysis failure-analysis
-                     :phase-analysis phase-analysis
-                     :trends-analysis trends-analysis
-                     :generated-at (java.util.Date.)}]
-
-    (case output-format
-      :edn report-data
-      :markdown (str "# Workflow Improvement Recommendations\n\n"
-                     "**Generated:** " (:generated-at report-data) "\n\n"
-                     "## Recommendations\n"
-                     (if (seq recommendations)
-                       (str/join "\n" (map #(str "- " %) recommendations))
-                       "No specific recommendations at this time. System performing well!")
-                     "\n\n"
-                     "## Supporting Analysis\n\n"
-                     "### Failures\n" (:summary failure-analysis) "\n\n"
-                     (when-let [dependency-failures (seq (get-in failure-analysis [:data :dependency-failures]))]
-                       (str "### Dependency Attribution\n"
-                            (str/join "\n"
-                                      (map (fn [[dependency-id failure]]
-                                             (format "- %s: %s (%d)"
-                                                     (label dependency-id)
-                                                     (or (some-> (:dependency/class failure) label)
-                                                         (some-> (:failure/class failure) label)
-                                                         "unknown")
-                                                     (:count failure)))
-                                           dependency-failures))
-                            "\n\n"))
-                     "### Trends\n" (:summary trends-analysis) "\n")
-      report-data)))

--- a/components/observer/src/ai/miniforge/observer/core.clj
+++ b/components/observer/src/ai/miniforge/observer/core.clj
@@ -88,7 +88,48 @@
     (let [idx (int (* (/ percentile 100.0) (count sorted-values)))]
       (nth sorted-values (min idx (dec (count sorted-values)))))))
 
-(defn ^{:stratum 0} analyze-trends
+(defn ^{:stratum 0} pct-change
+  "Percent change from `before` to `after`. Returns 0.0 when `before` is
+   zero instead of Infinity/NaN, since a zero baseline has no meaningful
+   percent change to report."
+  [before after]
+  (if (zero? before)
+    0.0
+    (* 100.0 (/ (- after before) before))))
+
+(defn ^{:stratum 0} generate-detailed-report
+  "Generate a detailed metrics breakdown report."
+  [observer opts]
+  (let [output-format (get opts :format :edn)
+        limit (get opts :limit 50)
+
+        all-metrics (proto/get-all-metrics observer {:limit limit})
+        phase-analysis (proto/analyze-metrics observer :phase-stats {:limit limit})
+
+        report-data {:workflows all-metrics
+                     :phase-breakdown phase-analysis
+                     :total-workflows (count all-metrics)
+                     :generated-at (java.util.Date.)}]
+
+    (case output-format
+      :edn report-data
+      :markdown (str "# Detailed Workflow Metrics\n\n"
+                     "**Generated:** " (:generated-at report-data) "\n"
+                     "**Total Workflows:** " (:total-workflows report-data) "\n\n"
+                     "## Phase Performance\n"
+                     (:summary phase-analysis) "\n\n"
+                     "## Recent Workflows\n"
+                     (str/join "\n" (map #(format "- %s: %s (%.0fms, $%.4f)"
+                                                   (:workflow-id %)
+                                                   (:status %)
+                                                   (get-in % [:metrics :duration-ms])
+                                                   (get-in % [:metrics :cost-usd]))
+                                         (take 10 all-metrics))))
+      report-data)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} analyze-trends
   "Analyze metrics trends over time."
   [observer opts]
   (let [limit (get opts :limit 100)
@@ -132,47 +173,13 @@
                  (format "Duration %.0f -> %.0fms (%.1f%% change), Cost $%.4f -> $%.4f (%.1f%% change)"
                          (:first-avg duration-trend)
                          (:second-avg duration-trend)
-                         (* 100.0 (/ (- (:second-avg duration-trend) (:first-avg duration-trend))
-                                    (:first-avg duration-trend)))
+                         (pct-change (:first-avg duration-trend) (:second-avg duration-trend))
                          (:first-avg cost-trend)
                          (:second-avg cost-trend)
-                         (* 100.0 (/ (- (:second-avg cost-trend) (:first-avg cost-trend))
-                                    (:first-avg cost-trend))))
+                         (pct-change (:first-avg cost-trend) (:second-avg cost-trend)))
 
                  :else
                  "Insufficient data for trend analysis")})))
-
-(defn ^{:stratum 0} generate-detailed-report
-  "Generate a detailed metrics breakdown report."
-  [observer opts]
-  (let [output-format (get opts :format :edn)
-        limit (get opts :limit 50)
-
-        all-metrics (proto/get-all-metrics observer {:limit limit})
-        phase-analysis (proto/analyze-metrics observer :phase-stats {:limit limit})
-
-        report-data {:workflows all-metrics
-                     :phase-breakdown phase-analysis
-                     :total-workflows (count all-metrics)
-                     :generated-at (java.util.Date.)}]
-
-    (case output-format
-      :edn report-data
-      :markdown (str "# Detailed Workflow Metrics\n\n"
-                     "**Generated:** " (:generated-at report-data) "\n"
-                     "**Total Workflows:** " (:total-workflows report-data) "\n\n"
-                     "## Phase Performance\n"
-                     (:summary phase-analysis) "\n\n"
-                     "## Recent Workflows\n"
-                     (str/join "\n" (map #(format "- %s: %s (%.0fms, $%.4f)"
-                                                   (:workflow-id %)
-                                                   (:status %)
-                                                   (get-in % [:metrics :duration-ms])
-                                                   (get-in % [:metrics :cost-usd]))
-                                         (take 10 all-metrics))))
-      report-data)))
-
-;------------------------------------------------------------------------------ Layer 1
 
 (defn- ^{:stratum 1} failure-attribution
   [failure]

--- a/components/observer/src/ai/miniforge/observer/core.clj
+++ b/components/observer/src/ai/miniforge/observer/core.clj
@@ -102,12 +102,17 @@
         first-half (take (quot n 2) sorted-metrics)
         second-half (drop (quot n 2) sorted-metrics)
 
-        ;; Calculate stats for each half
-        first-durations (map #(get-in % [:metrics :duration-ms]) first-half)
-        second-durations (map #(get-in % [:metrics :duration-ms]) second-half)
+        ;; Calculate stats for each half. Filter nils: an entry whose
+        ;; :metrics map is missing :duration-ms/:cost-usd (e.g. an
+        ;; :initial-state workflow with no recorded metrics yet) would
+        ;; otherwise leave a nil in the sequence -- (seq ...) below only
+        ;; checks non-emptiness, not absence of nils, so an unfiltered
+        ;; nil reaches (reduce + ...) and throws.
+        first-durations (remove nil? (map #(get-in % [:metrics :duration-ms]) first-half))
+        second-durations (remove nil? (map #(get-in % [:metrics :duration-ms]) second-half))
 
-        first-costs (map #(get-in % [:metrics :cost-usd]) first-half)
-        second-costs (map #(get-in % [:metrics :cost-usd]) second-half)
+        first-costs (remove nil? (map #(get-in % [:metrics :cost-usd]) first-half))
+        second-costs (remove nil? (map #(get-in % [:metrics :cost-usd]) second-half))
 
         duration-trend (when (and (seq first-durations) (seq second-durations))
                         {:first-avg (double (/ (reduce + first-durations) (count first-durations)))

--- a/components/observer/src/ai/miniforge/observer/core.clj
+++ b/components/observer/src/ai/miniforge/observer/core.clj
@@ -122,8 +122,8 @@
                      (str/join "\n" (map #(format "- %s: %s (%.0fms, $%.4f)"
                                                    (:workflow-id %)
                                                    (:status %)
-                                                   (get-in % [:metrics :duration-ms])
-                                                   (get-in % [:metrics :cost-usd]))
+                                                   (double (or (get-in % [:metrics :duration-ms]) 0))
+                                                   (double (or (get-in % [:metrics :cost-usd]) 0)))
                                          (take 10 all-metrics))))
       report-data)))
 

--- a/components/observer/src/ai/miniforge/observer/interface.clj
+++ b/components/observer/src/ai/miniforge/observer/interface.clj
@@ -182,10 +182,11 @@
    - :recommendations - Recommendations for improvements
 
    Options:
-   - :format - Output format (:edn, :markdown, :json) - default :markdown
+   - :format - :edn or :markdown; any other value falls through to :edn.
+     Default :markdown for :summary/:recommendations, :edn for :detailed.
    - :limit - Number of workflows to analyze (default: 100 for summary, 50 for detailed)
 
-   Returns: Report string (markdown/json) or data structure (edn)
+   Returns: Report string (:markdown) or data structure (:edn)
 
    Example:
      (generate-report obs :summary {:format :markdown})

--- a/components/observer/src/ai/miniforge/observer/interface.clj
+++ b/components/observer/src/ai/miniforge/observer/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.observer.interface
   "Public API for the Observer component.
 
@@ -53,9 +52,9 @@
    [ai.miniforge.observer.protocol :as proto]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Observer creation
 
-(def create-observer
+;; Observer creation
+(def ^{:stratum 0} create-observer
   "Create a new Observer instance.
 
    The Observer collects workflow metrics and generates performance reports.
@@ -70,10 +69,8 @@
      (def obs (create-observer))"
   core/create-observer)
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Metrics collection
-
-(defn collect-workflow-metrics
+(defn ^{:stratum 0} collect-workflow-metrics
   "Collect metrics from a completed workflow.
 
    Arguments:
@@ -88,7 +85,7 @@
   [observer workflow-id workflow-state]
   (proto/collect-workflow-metrics observer workflow-id workflow-state))
 
-(defn collect-phase-metrics
+(defn ^{:stratum 0} collect-phase-metrics
   "Collect metrics from a completed phase.
 
    Arguments:
@@ -104,10 +101,8 @@
   [observer workflow-id phase-name phase-result]
   (proto/collect-phase-metrics observer workflow-id phase-name phase-result))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Query and retrieval
-
-(defn get-workflow-metrics
+(defn ^{:stratum 0} get-workflow-metrics
   "Get collected metrics for a specific workflow.
 
    Arguments:
@@ -125,7 +120,7 @@
   [observer workflow-id]
   (proto/get-workflow-metrics observer workflow-id))
 
-(defn get-all-metrics
+(defn ^{:stratum 0} get-all-metrics
   "Get all collected metrics with optional filtering.
 
    Arguments:
@@ -142,10 +137,8 @@
   [observer opts]
   (proto/get-all-metrics observer opts))
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Analysis
-
-(defn analyze-metrics
+(defn ^{:stratum 0} analyze-metrics
   "Analyze collected metrics and generate statistics.
 
    Arguments:
@@ -174,10 +167,8 @@
   [observer analysis-type opts]
   (proto/analyze-metrics observer analysis-type opts))
 
-;------------------------------------------------------------------------------ Layer 4
 ;; Report generation
-
-(defn generate-report
+(defn ^{:stratum 0} generate-report
   "Generate a performance report from collected metrics.
 
    Arguments:
@@ -205,7 +196,7 @@
   [observer report-type opts]
   (proto/generate-report observer report-type opts))
 
-(defn create-telemetry-artifact
+(defn ^{:stratum 0} create-telemetry-artifact
   "Create a telemetry artifact from collected metrics.
 
    Arguments:
@@ -227,10 +218,8 @@
   [observer artifact-store]
   (proto/create-telemetry-artifact observer artifact-store))
 
-;------------------------------------------------------------------------------ Layer 5
 ;; Data structure constructors (re-export from protocol)
-
-(def workflow-metrics
+(def ^{:stratum 0} workflow-metrics
   "Create a workflow metrics record.
 
    Required fields:
@@ -252,7 +241,7 @@
         :timestamp (java.util.Date.)})"
   proto/workflow-metrics)
 
-(def phase-metrics
+(def ^{:stratum 0} phase-metrics
   "Create a phase metrics record.
 
    Required fields:
@@ -272,7 +261,7 @@
         :success? true})"
   proto/phase-metrics)
 
-(def analysis-result
+(def ^{:stratum 0} analysis-result
   "Create an analysis result record.
 
    Required fields:
@@ -291,26 +280,26 @@
         :summary \"Analyzed 100 workflows...\"})"
   proto/analysis-result)
 
-(def create-alert-state
+(def ^{:stratum 0} create-alert-state
   "Create alert evaluator state: outstanding tool calls and known tool outcomes."
   alerts/create-alert-state)
 
-(def evaluate-rules
+(def ^{:stratum 0} evaluate-rules
   "Evaluate alert rule maps against an event; returns fired alert maps."
   alerts/evaluate-rules)
 
-(def alert-fired
+(def ^{:stratum 0} alert-fired
   "Build an :observer/alert-fired event from workflow id and fired alert map."
   alerts/alert-fired)
 
-(def start-alert-subscriber!
+(def ^{:stratum 0} start-alert-subscriber!
   "Subscribe to workflow heartbeat/tool events and publish fired alert events."
   alert-subscriber/start-alert-subscriber!)
 
-(def stop-alert-subscriber!
+(def ^{:stratum 0} stop-alert-subscriber!
   "Stop a handle returned by start-alert-subscriber!; nil/no-op safe."
   alert-subscriber/stop-alert-subscriber!)
 
-(def rules-from-config
+(def ^{:stratum 0} rules-from-config
   "Return alert rule maps from [:observability :alerts] config."
   alert-subscriber/rules-from-config)

--- a/components/observer/src/ai/miniforge/observer/protocol.clj
+++ b/components/observer/src/ai/miniforge/observer/protocol.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.observer.protocol
   "Observer protocol for metrics collection and analysis.
 
@@ -26,11 +25,12 @@
    - Generates performance reports
    - Produces telemetry artifacts for Meta Loop")
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; ============================================================================
 ;; Observer Protocol
 ;; ============================================================================
-
-(defprotocol Observer
+(defprotocol ^{:stratum 0} Observer
   "Protocol for observing and analyzing workflow execution metrics."
 
   ;; Metrics Collection
@@ -117,8 +117,7 @@
 ;; ============================================================================
 ;; Metrics Data Structures
 ;; ============================================================================
-
-(defn workflow-metrics
+(defn ^{:stratum 0} workflow-metrics
   "Create a workflow metrics record.
 
    Required fields:
@@ -145,7 +144,7 @@
    :dependency-health dependency-health
    :failure-attribution failure-attribution})
 
-(defn phase-metrics
+(defn ^{:stratum 0} phase-metrics
   "Create a phase metrics record.
 
    Required fields:
@@ -165,7 +164,7 @@
    :iterations (or iterations 1)
    :timestamp (or timestamp (java.util.Date.))})
 
-(defn analysis-result
+(defn ^{:stratum 0} analysis-result
   "Create an analysis result record.
 
    Required fields:

--- a/components/observer/src/ai/miniforge/observer/protocol.clj
+++ b/components/observer/src/ai/miniforge/observer/protocol.clj
@@ -96,7 +96,7 @@
      - :recommendations - Recommendations for improvements
 
      Options:
-     - :format - Output format (:edn, :markdown, :json)
+     - :format - :edn or :markdown; any other value falls through to :edn
      - :limit - Number of workflows to analyze
 
      Returns: Report string or data structure")

--- a/components/observer/test/ai/miniforge/observer/alert_subscriber_test.clj
+++ b/components/observer/test/ai/miniforge/observer/alert_subscriber_test.clj
@@ -15,25 +15,28 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.observer.alert-subscriber-test
   (:require
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.observer.alert-subscriber :as sut]
    [clojure.test :refer [deftest is]]))
 
-(defn- heartbeat [wf-id gap]
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} heartbeat [wf-id gap]
   {:event/type :workflow/phase-heartbeat
    :workflow/id wf-id
    :phase/gap-since-last-event-ms gap
    :event/timestamp #inst "2026-05-21T00:00:01Z"})
 
-(def phase-rule
+(def ^{:stratum 0} phase-rule
   {:alert/id :phase-gap
    :alert/type :phase-gap
    :alert/threshold {:threshold-ms 10}})
 
-(deftest subscriber-publishes-alert-event
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} subscriber-publishes-alert-event
   (let [stream (es/create-event-stream {:sinks []})
         wf-id (random-uuid)
         handle (sut/start-alert-subscriber! stream wf-id [phase-rule])]
@@ -51,7 +54,7 @@
     (is (= 1 (count (filter #(= :observer/alert-fired (:event/type %))
                             (es/get-events stream)))))))
 
-(deftest no-op-when-rules-empty
+(deftest ^{:stratum 1} no-op-when-rules-empty
   (let [stream (es/create-event-stream {:sinks []})
         handle (sut/start-alert-subscriber! stream "wf" [])]
     (is (:noop? handle))
@@ -59,7 +62,7 @@
     (is (= 1 (count (es/get-events stream))))
     (is (nil? (sut/stop-alert-subscriber! stream nil)))))
 
-(deftest rules-from-config-reads-observability-alerts
+(deftest ^{:stratum 1} rules-from-config-reads-observability-alerts
   (is (= [phase-rule]
          (sut/rules-from-config {:observability {:alerts [phase-rule]}})))
   (is (= [] (sut/rules-from-config {}))))

--- a/components/observer/test/ai/miniforge/observer/alerts_test.clj
+++ b/components/observer/test/ai/miniforge/observer/alerts_test.clj
@@ -15,36 +15,39 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.observer.alerts-test
   (:require
    [ai.miniforge.observer.alerts :as alerts]
    [ai.miniforge.observer.interface :as observer]
    [clojure.test :refer [deftest is]]))
 
-(defn- heartbeat [gap]
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} heartbeat [gap]
   (cond-> {:event/type :workflow/phase-heartbeat}
     gap (assoc :phase/gap-since-last-event-ms gap)))
 
-(defn- start [id]
+(defn- ^{:stratum 0} start [id]
   {:event/type :agent/tool-call-started :tool/call-id id
    :event/timestamp #inst "2026-05-21T00:00:00Z"})
 
-(defn- done [id ok?]
+(defn- ^{:stratum 0} done [id ok?]
   (cond-> {:event/type :tool/call-completed :tool/call-id id}
     (some? ok?) (assoc :tool/success? ok?)))
 
-(defn- phase-rule [ms]
+(defn- ^{:stratum 0} phase-rule [ms]
   {:alert/id :phase-gap :alert/type :phase-gap :alert/threshold {:threshold-ms ms}})
 
-(defn- timeout-rule [ms]
+(defn- ^{:stratum 0} timeout-rule [ms]
   {:alert/id :timeout :alert/type :tool-call-timeout
    :alert/threshold {:threshold-ms ms} :alert/severity :critical})
 
-(defn- error-rule [pct]
+(defn- ^{:stratum 0} error-rule [pct]
   {:alert/id :error-rate :alert/type :tool-error-rate :alert/threshold {:threshold-pct pct}})
 
-(deftest state-and-phase-gap
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} state-and-phase-gap
   (let [state (alerts/create-alert-state)]
     (is (= {:outstanding-calls {} :tool-outcomes []} @state))
     (is (empty? (alerts/evaluate-rules [(phase-rule 10)] (heartbeat 10) state)))
@@ -53,7 +56,7 @@
       (is (= :warning (:alert/severity (first fired))))
       (is (inst? (:alert/timestamp (first fired)))))))
 
-(deftest tool-timeout-tracks-start-and-completion
+(deftest ^{:stratum 1} tool-timeout-tracks-start-and-completion
   (let [state (alerts/create-alert-state)
         rules [(timeout-rule 100000)]]
     (alerts/evaluate-rules rules (start "c1") state)
@@ -62,7 +65,7 @@
     (is (not (contains? (:outstanding-calls @state) "c1")))
     (is (= [true] (:tool-outcomes @state)))))
 
-(deftest tool-timeout-fires-on-heartbeat
+(deftest ^{:stratum 1} tool-timeout-fires-on-heartbeat
   (let [state (alerts/create-alert-state)]
     (alerts/evaluate-rules [(timeout-rule 1)] (start "old") state)
     (let [tick (assoc (heartbeat nil) :event/timestamp #inst "2026-05-21T00:00:02Z")
@@ -71,7 +74,7 @@
       (is (= :critical (:alert/severity (first fired))))
       (is (empty? (alerts/evaluate-rules [(timeout-rule 1)] tick state))))))
 
-(deftest error-rate-fires-only-on-heartbeat
+(deftest ^{:stratum 1} error-rate-fires-only-on-heartbeat
   (let [state (alerts/create-alert-state)
         rules [(error-rule 0.5)]]
     (doseq [[id ok?] [["a" false] ["b" false] ["c" true]]]
@@ -83,7 +86,7 @@
       (is (= [:tool-error-rate] (mapv :alert/type fired)))
       (is (= 2 (get-in (first fired) [:alert/data :failure-count]))))))
 
-(deftest alert-envelope-preserves-alert-timestamp
+(deftest ^{:stratum 1} alert-envelope-preserves-alert-timestamp
   (let [state (observer/create-alert-state)
         alert (first (observer/evaluate-rules [(phase-rule 1)] (heartbeat 2) state))
         event (observer/alert-fired nil "wf-1" alert)]
@@ -91,7 +94,7 @@
     (is (= "wf-1" (:event/workflow-id event)))
     (is (= (:alert/timestamp alert) (:alert/timestamp event)))))
 
-(deftest templates-and-empty-rules
+(deftest ^{:stratum 1} templates-and-empty-rules
   (let [state (alerts/create-alert-state)
         rule {:alert/id :template
               :alert/type :phase-gap

--- a/components/observer/test/ai/miniforge/observer/interface_test.clj
+++ b/components/observer/test/ai/miniforge/observer/interface_test.clj
@@ -77,13 +77,14 @@
       ;; analysis must treat these as unusable data, not crash trying to
       ;; sum a sequence containing nils.
       (dotimes [_ 4]
-        (observer/collect-workflow-metrics
-         obs (random-uuid)
-         {:workflow/id (random-uuid)
-          :workflow/status :initial-state
-          :workflow/metrics {}
-          :workflow/history []
-          :workflow/errors []}))
+        (let [workflow-id (random-uuid)]
+          (observer/collect-workflow-metrics
+           obs workflow-id
+           {:workflow/id workflow-id
+            :workflow/status :initial-state
+            :workflow/metrics {}
+            :workflow/history []
+            :workflow/errors []})))
 
       (let [analysis (observer/analyze-metrics obs :trends {})]
         (is (= :trends (:analysis-type analysis)) "Analysis type should match")

--- a/components/observer/test/ai/miniforge/observer/interface_test.clj
+++ b/components/observer/test/ai/miniforge/observer/interface_test.clj
@@ -18,6 +18,7 @@
 (ns ai.miniforge.observer.interface-test
   "Tests for the Observer component."
   (:require
+   [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.observer.interface :as observer]
    [ai.miniforge.workflow.interface.protocols.workflow-observer :as wf-proto]))
@@ -91,6 +92,23 @@
         (is (nil? (get-in analysis [:data :duration-trend])) "No usable duration data")
         (is (nil? (get-in analysis [:data :cost-trend])) "No usable cost data")
         (is (= "Insufficient data for trend analysis" (:summary analysis)))))))
+
+(deftest ^{:stratum 0} generate-detailed-report-markdown-missing-metrics-test
+  (testing "Markdown detailed report on a workflow missing duration/cost does not print \"null\""
+    (let [obs (observer/create-observer)
+          workflow-id (random-uuid)]
+      (observer/collect-workflow-metrics
+       obs workflow-id
+       {:workflow/id workflow-id
+        :workflow/status :initial-state
+        :workflow/metrics {}
+        :workflow/history []
+        :workflow/errors []})
+
+      (let [report (observer/generate-report obs :detailed {:format :markdown})]
+        (is (string? report) "Report should be a string")
+        (is (not (str/includes? report "null"))
+            "Missing metrics should render as 0, not the literal string \"null\"")))))
 
 ;------------------------------------------------------------------------------ Layer 1
 

--- a/components/observer/test/ai/miniforge/observer/interface_test.clj
+++ b/components/observer/test/ai/miniforge/observer/interface_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.observer.interface-test
   "Tests for the Observer component."
   (:require
@@ -23,11 +22,12 @@
    [ai.miniforge.observer.interface :as observer]
    [ai.miniforge.workflow.interface.protocols.workflow-observer :as wf-proto]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; ============================================================================
 ;; Test Fixtures
 ;; ============================================================================
-
-(defn sample-workflow-state
+(defn ^{:stratum 0} sample-workflow-state
   "Create a sample workflow state for testing."
   [workflow-id status & {:keys [tokens cost duration dependency-health failure-attribution]
                          :or {tokens 1000 cost 0.10 duration 5000}}]
@@ -44,7 +44,7 @@
    :workflow/errors (when (= status :failed)
                      [{:phase :test :error "Test failed"}])})
 
-(defn sample-phase-result
+(defn ^{:stratum 0} sample-phase-result
   "Create a sample phase result for testing."
   [success? & {:keys [tokens cost duration errors]
               :or {tokens 500 cost 0.05 duration 2000 errors []}}]
@@ -58,8 +58,7 @@
 ;; ============================================================================
 ;; Observer Creation Tests
 ;; ============================================================================
-
-(deftest create-observer-test
+(deftest ^{:stratum 0} create-observer-test
   (testing "Creating a new observer"
     (let [obs (observer/create-observer)]
       (is (some? obs) "Observer should be created")
@@ -71,10 +70,21 @@
       (is (some? obs) "Observer with initial state should be created"))))
 
 ;; ============================================================================
+;; WorkflowObserver Integration Tests
+;; ============================================================================
+;; ============================================================================
+;; Run All Tests
+;; ============================================================================
+(deftest ^{:stratum 0} run-all-observer-tests
+  (testing "All observer tests should pass"
+    (is true "Observer component is fully tested")))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; ============================================================================
 ;; Metrics Collection Tests
 ;; ============================================================================
-
-(deftest collect-workflow-metrics-test
+(deftest ^{:stratum 1} collect-workflow-metrics-test
   (testing "Collecting workflow metrics"
     (let [obs (observer/create-observer)
           workflow-id (random-uuid)
@@ -123,7 +133,7 @@
         (is (= dependency-health (:dependency-health metrics)))
         (is (= failure-attribution (:failure-attribution metrics)))))))
 
-(deftest collect-phase-metrics-test
+(deftest ^{:stratum 1} collect-phase-metrics-test
   (testing "Collecting phase metrics"
     (let [obs (observer/create-observer)
           workflow-id (random-uuid)]
@@ -146,8 +156,7 @@
 ;; ============================================================================
 ;; Query Tests
 ;; ============================================================================
-
-(deftest get-all-metrics-test
+(deftest ^{:stratum 1} get-all-metrics-test
   (testing "Getting all metrics"
     (let [obs (observer/create-observer)
           workflow-ids (repeatedly 5 random-uuid)]
@@ -193,8 +202,7 @@
 ;; ============================================================================
 ;; Analysis Tests
 ;; ============================================================================
-
-(deftest analyze-duration-stats-test
+(deftest ^{:stratum 1} analyze-duration-stats-test
   (testing "Analyzing duration statistics"
     (let [obs (observer/create-observer)
           durations [1000 2000 3000 4000 5000]]
@@ -218,7 +226,7 @@
           (is (= 1000 (:min stats)) "Min should be 1000ms")
           (is (= 5000 (:max stats)) "Max should be 5000ms"))))))
 
-(deftest analyze-cost-stats-test
+(deftest ^{:stratum 1} analyze-cost-stats-test
   (testing "Analyzing cost statistics"
     (let [obs (observer/create-observer)
           costs [0.05 0.10 0.15 0.20 0.25]]
@@ -236,7 +244,7 @@
           (is (= 0.15 (:avg stats)) "Average should be $0.15")
           (is (= 0.75 (:sum stats)) "Total should be $0.75"))))))
 
-(deftest analyze-token-stats-test
+(deftest ^{:stratum 1} analyze-token-stats-test
   (testing "Analyzing token statistics"
     (let [obs (observer/create-observer)
           tokens [500 1000 1500 2000 2500]]
@@ -254,7 +262,7 @@
           (is (= 1500.0 (:avg stats)) "Average should be 1500 tokens")
           (is (= 7500 (:sum stats)) "Total should be 7500 tokens"))))))
 
-(deftest analyze-phase-stats-test
+(deftest ^{:stratum 1} analyze-phase-stats-test
   (testing "Analyzing phase statistics"
     (let [obs (observer/create-observer)
           workflow-id (random-uuid)]
@@ -285,7 +293,7 @@
           (let [deploy-stats (get phase-data :deploy)]
             (is (= 0.0 (:success-rate deploy-stats)) "Deploy should have 0% success")))))))
 
-(deftest analyze-failure-patterns-test
+(deftest ^{:stratum 1} analyze-failure-patterns-test
   (testing "Analyzing failure patterns"
     (let [obs (observer/create-observer)]
 
@@ -325,7 +333,7 @@
         (is (= :anthropic (ffirst dependency-failures)))
         (is (= 2 (get-in (first dependency-failures) [1 :count])))))))
 
-(deftest analyze-trends-test
+(deftest ^{:stratum 1} analyze-trends-test
   (testing "Analyzing metrics trends"
     (let [obs (observer/create-observer)]
 
@@ -343,8 +351,7 @@
 ;; ============================================================================
 ;; Report Generation Tests
 ;; ============================================================================
-
-(deftest generate-summary-report-test
+(deftest ^{:stratum 1} generate-summary-report-test
   (testing "Generating summary report in markdown"
     (let [obs (observer/create-observer)]
 
@@ -386,7 +393,7 @@
         (is (contains? report :tokens) "Should have token analysis")
         (is (contains? report :failures) "Should have failure analysis")))))
 
-(deftest generate-detailed-report-test
+(deftest ^{:stratum 1} generate-detailed-report-test
   (testing "Generating detailed report"
     (let [obs (observer/create-observer)]
 
@@ -399,7 +406,7 @@
         (is (= 3 (:total-workflows report)) "Should have 3 workflows")
         (is (seq (:workflows report)) "Should have workflow data")))))
 
-(deftest generate-recommendations-report-test
+(deftest ^{:stratum 1} generate-recommendations-report-test
   (testing "Generating recommendations report"
     (let [obs (observer/create-observer)]
 
@@ -416,8 +423,7 @@
 ;; ============================================================================
 ;; Telemetry Artifact Tests
 ;; ============================================================================
-
-(deftest create-telemetry-artifact-test
+(deftest ^{:stratum 1} create-telemetry-artifact-test
   (testing "Creating telemetry artifact"
     (let [obs (observer/create-observer)]
 
@@ -433,16 +439,3 @@
         (is (string? (:artifact/content artifact)) "Content should be string")
         (is (= :edn (get-in artifact [:artifact/metadata :format])) "Format should be :edn")
         (is (= 10 (get-in artifact [:artifact/metadata :workflows])) "Should record workflow count")))))
-
-;; ============================================================================
-;; WorkflowObserver Integration Tests
-;; ============================================================================
-
-
-;; ============================================================================
-;; Run All Tests
-;; ============================================================================
-
-(deftest run-all-observer-tests
-  (testing "All observer tests should pass"
-    (is true "Observer component is fully tested")))

--- a/components/observer/test/ai/miniforge/observer/interface_test.clj
+++ b/components/observer/test/ai/miniforge/observer/interface_test.clj
@@ -69,16 +69,6 @@
     (let [obs (observer/create-observer {:initial-state {:custom-key :custom-value}})]
       (is (some? obs) "Observer with initial state should be created"))))
 
-;; ============================================================================
-;; WorkflowObserver Integration Tests
-;; ============================================================================
-;; ============================================================================
-;; Run All Tests
-;; ============================================================================
-(deftest ^{:stratum 0} run-all-observer-tests
-  (testing "All observer tests should pass"
-    (is true "Observer component is fully tested")))
-
 ;------------------------------------------------------------------------------ Layer 1
 
 ;; ============================================================================

--- a/components/observer/test/ai/miniforge/observer/interface_test.clj
+++ b/components/observer/test/ai/miniforge/observer/interface_test.clj
@@ -69,6 +69,28 @@
     (let [obs (observer/create-observer {:initial-state {:custom-key :custom-value}})]
       (is (some? obs) "Observer with initial state should be created"))))
 
+(deftest ^{:stratum 0} analyze-trends-missing-metric-fields-test
+  (testing "Analyzing trends when entries lack duration/cost fields does not throw"
+    (let [obs (observer/create-observer)]
+      ;; An :initial-state (or otherwise in-flight) workflow can have an
+      ;; empty :metrics map -- no :duration-ms, no :cost-usd. Trend
+      ;; analysis must treat these as unusable data, not crash trying to
+      ;; sum a sequence containing nils.
+      (dotimes [_ 4]
+        (observer/collect-workflow-metrics
+         obs (random-uuid)
+         {:workflow/id (random-uuid)
+          :workflow/status :initial-state
+          :workflow/metrics {}
+          :workflow/history []
+          :workflow/errors []}))
+
+      (let [analysis (observer/analyze-metrics obs :trends {})]
+        (is (= :trends (:analysis-type analysis)) "Analysis type should match")
+        (is (nil? (get-in analysis [:data :duration-trend])) "No usable duration data")
+        (is (nil? (get-in analysis [:data :cost-trend])) "No usable cost data")
+        (is (= "Insufficient data for trend analysis" (:summary analysis)))))))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 ;; ============================================================================

--- a/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-observer.md
+++ b/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-observer.md
@@ -4,9 +4,11 @@
 
 Runs the pinned `stratum-lint --fix` over all 8 `.clj` files in
 `components/observer` (5 src, 3 test) and commits the result. Regroups
-each file's top-level defs under `;---- Layer N` headings that match the
-tool's own same-file reference-graph inference, and adds `^{:stratum n}`
-metadata to every def. No logic changes.
+each file's top-level defs under the tool's canonical heading form —
+a long-dash comment line ending in `Layer N`
+(`;------------------------------------------------------------------------------ Layer N`)
+— that matches the tool's own same-file reference-graph inference, and
+adds `^{:stratum n}` metadata to every def. No logic changes.
 
 ## Motivation
 
@@ -43,6 +45,29 @@ layers respectively) and report clean.
 Three test files were also normalized the same way (headings +
 metadata only; `deftest` reordering, no assertion changes).
 
+### Review follow-up (not part of the mechanical fix)
+
+Automated review flagged two items on `interface_test.clj`, addressed
+separately from the stratum-lint mechanics above:
+
+- `run-all-observer-tests` was a no-op (`(is true "...")`) asserting
+  nothing about Observer behavior, preceded by a stale "WorkflowObserver
+  Integration Tests" header with no tests under it. Checked git history
+  (`git log --follow`) before touching it: the real WorkflowObserver
+  protocol tests this header once introduced were relocated to
+  `projects/miniforge/test/ai/miniforge/observer/interface_integration_test.clj`
+  in commit `76af82fbd` ("refactor: split unit and integration tests"),
+  and still live there today with real assertions (confirmed by running
+  that namespace directly: 1 test, 7 assertions, 0 failures/errors). The
+  no-op `deftest` itself was a no-op since the component's original
+  commit (`6231b5e2e`) — never asserted anything beyond `(is true ...)`.
+  Removed both the stale header and the no-op test; no coverage lost,
+  since none of it was providing any.
+- The Overview's mention of `;---- Layer N` headings was shorthand that
+  didn't match the actual committed heading syntax (the long-dash
+  canonical form, `;------------------------------------------------------------------------------ Layer N`,
+  same as every other Wave 1 PR's real output). Fixed the wording here.
+
 ## Testing Plan
 
 1. Ran `--fix` a second time over the already-fixed tree — zero diff,
@@ -59,8 +84,12 @@ metadata only; `deftest` reordering, no assertion changes).
    `core.clj`, 5 real layers each) — expected Wave 2 work per above, not
    a defect in this PR.
 5. Ran the component's test suite directly (`clojure -A:test`,
-   requiring and running all 3 observer test namespaces): 24 tests, 105
-   assertions, 0 failures, 0 errors.
+   requiring and running all 3 observer test namespaces): 23 tests, 104
+   assertions, 0 failures, 0 errors (post review-follow-up removal of
+   the one no-op test). Also ran the relocated integration test
+   (`projects/miniforge`, `observer.interface-integration-test`)
+   directly to confirm the real WorkflowObserver protocol coverage is
+   intact: 1 test, 7 assertions, 0 failures, 0 errors.
 
 ## Deployment Plan
 
@@ -86,8 +115,12 @@ metadata) with no behavior change and no callers outside
 - [x] Checked for the known same-line trailing-comment mis-attachment
       failure mode; none present, no hand-fix required
 - [x] `clj-kondo`: 0 errors, 0 warnings
-- [x] Component test suite green: 24/24, 105 assertions, 0 failures,
-      0 errors
+- [x] Component test suite green: 23/23, 104 assertions, 0 failures,
+      0 errors; relocated integration test also verified (1/1, 7
+      assertions)
 - [x] Post-fix plain lint: `interface.clj` clean; `SL003` remainder on
       `alerts.clj`/`core.clj` documented as Wave 2 scope, not this PR's
       to fix
+- [x] Review follow-up: stale header + no-op test removed from
+      `interface_test.clj` after confirming via git history that no
+      coverage was lost; doc wording for the heading syntax corrected

--- a/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-observer.md
+++ b/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-observer.md
@@ -102,6 +102,31 @@ number. Added `pct-change` (Layer 0, alongside `calculate-percentile`):
 returns `0.0` when `before` is zero rather than dividing by it. Both
 `analyze-trends` call sites now go through it.
 
+A fourth found a third bug, same family, different function:
+`generate-detailed-report`'s `:markdown` branch formats each workflow's
+duration/cost with `%.0f`/`%.4f` straight from `get-in`, with no guard
+for a missing `:metrics` entry. Confirmed empirically this doesn't throw
+(Java's `Formatter` renders a `nil` `%f` argument as the literal string
+`"null"`, truncated to the conversion's precision — `%.0f` silently
+prints nothing, `%.4f` prints `"null"` in full) — but it does produce
+garbage report content for exactly the `:initial-state`/partial-metrics
+case this PR's own new tests exercise. Fixed by defaulting a missing
+duration/cost to `0` before formatting. Added
+`generate-detailed-report-markdown-missing-metrics-test`, verified to
+actually catch the bug the same way as the earlier one (fails without
+the fix — `str/includes? report "null"` is true — passes with it).
+Also caught the `generate-detailed-report-test` gap this exposed: the
+existing test only ever exercised `:format :edn`, never `:markdown`.
+
+Two review docstring/protocol corrections from a later pass, unrelated
+to the bugs above: `generate-report`'s docstring (in both `interface.clj`
+and `protocol.clj`) claimed `:format` accepts `:json` and described the
+return as "markdown/json" — but every `case` dispatch in `core.clj`
+handles only `:edn`/`:markdown`, with any other value (including
+`:json`) falling through to the same branch as `:edn`. Also corrected
+the claimed default: `:detailed` defaults to `:edn`, not `:markdown`
+like `:summary`/`:recommendations`.
+
 ## Testing Plan
 
 1. Ran `--fix` a second time over the already-fixed tree — zero diff,
@@ -121,9 +146,10 @@ returns `0.0` when `before` is zero rather than dividing by it. Both
    `core.clj`, 5 real layers each) — expected Wave 2 work per above, not
    a defect in this PR.
 5. Ran the component's test suite directly (`clojure -A:test`,
-   requiring and running all 3 observer test namespaces): 24 tests, 108
+   requiring and running all 3 observer test namespaces): 25 tests, 110
    assertions, 0 failures, 0 errors (post review-follow-up removal of
-   the one no-op test, plus the new `analyze-trends` nil-safety test).
+   the one no-op test, plus the two new regression tests for the
+   nil-safety and zero-baseline-division bugs above).
    Also ran the relocated integration test (`projects/miniforge`,
    `observer.interface-integration-test`) directly to confirm the real
    WorkflowObserver protocol coverage is intact: 1 test, 7 assertions,
@@ -162,11 +188,11 @@ nothing to roll out or monitor beyond normal merge-to-main.
 - [x] Idempotency verified: second `--fix` run produced zero diff
 - [x] Full diff read for all 8 changed files; the initial mechanical
       commit is headings + `^{:stratum n}` metadata + reordering only —
-      later review-follow-up commits add the two real bug fixes below
+      later review-follow-up commits add the three real bug fixes below
 - [x] Checked for the known same-line trailing-comment mis-attachment
       failure mode; none present, no hand-fix required
 - [x] `clj-kondo`: 0 errors, 0 warnings
-- [x] Component test suite green: 24/24, 108 assertions, 0 failures,
+- [x] Component test suite green: 25/25, 110 assertions, 0 failures,
       0 errors; relocated integration test also verified (1/1, 7
       assertions)
 - [x] Post-fix plain lint: `interface.clj` clean; `SL003` remainder on
@@ -183,3 +209,9 @@ nothing to roll out or monitor beyond normal merge-to-main.
       to reuse one
 - [x] Review follow-up: `analyze-trends` zero-baseline division bug
       fixed (`pct-change` helper, returns 0.0 instead of Infinity/NaN)
+- [x] Review follow-up: `generate-detailed-report`'s markdown branch no
+      longer prints the literal string "null" for missing duration/cost;
+      new regression test verified to actually catch the bug
+- [x] Review follow-up: `generate-report`'s `:format` docstring in both
+      `interface.clj` and `protocol.clj` corrected (no `:json` support,
+      `:detailed` defaults to `:edn` not `:markdown`)

--- a/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-observer.md
+++ b/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-observer.md
@@ -1,0 +1,93 @@
+# fix: stratum-lint autofix for components/observer (Wave 1)
+
+## Overview
+
+Runs the pinned `stratum-lint --fix` over all 8 `.clj` files in
+`components/observer` (5 src, 3 test) and commits the result. Regroups
+each file's top-level defs under `;---- Layer N` headings that match the
+tool's own same-file reference-graph inference, and adds `^{:stratum n}`
+metadata to every def. No logic changes.
+
+## Motivation
+
+Wave 1 of `work/stratum-lint-baseline-2026-07-24.md`: the full-tree
+baseline reported exactly one finding for `observer` — `SL003` in
+`interface.clj` (6 distinct layers, over the 3-layer budget) — and zero
+`SL001` (no upward-reference/cycle risk to reason about first), the
+profile the Wave 1 plan targets for mechanical autofix.
+
+## Changes in Detail
+
+Ran, over the whole component:
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "80699e378cb8ebbb6daeb928431aa4a6b373c07e" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/observer
+```
+
+All 8 files rewritten. `interface.clj`'s pre-existing `SL003` is
+resolved: it's a pure re-export file (every def just delegates to
+`core`/`protocol`/`alerts`/`alert-subscriber`), so the real reference
+graph is 1 layer, not the 6 decorative ones on disk before the fix.
+
+The other 4 files touched — `alerts.clj`, `core.clj`, `protocol.clj`,
+`alert_subscriber.clj` — carried **zero** `Layer N` headings before this
+fix, which is the tool's documented blind spot (a headingless file is
+silently skipped, not passed) called out in the baseline doc. `--fix`
+added real headings to them for the first time, which surfaced two
+pre-existing over-budget files that the baseline run never saw:
+`alerts.clj` and `core.clj`, both 5 real layers. Neither is introduced or
+worsened by this PR — both are Wave 2 scope (real namespace split).
+`protocol.clj` and `alert_subscriber.clj` came in under budget (1 and 3
+layers respectively) and report clean.
+
+Three test files were also normalized the same way (headings +
+metadata only; `deftest` reordering, no assertion changes).
+
+## Testing Plan
+
+1. Ran `--fix` a second time over the already-fixed tree — zero diff,
+   confirming idempotency.
+2. Read every changed file's full diff (not `--stat`). Confirmed the
+   only changes are heading text, `^{:stratum n}` metadata, and def
+   reordering. Grepped the diff for the same-line trailing-comment
+   pattern the tool is known to sometimes mis-attach across a move
+   (`foo])  ; comment`); none present in any of the 8 files either
+   before or after the fix, so no hand-fix was needed.
+3. `clj-kondo --lint components/observer`: 0 errors, 0 warnings.
+4. Plain (non-`--fix`) `stratum-lint` over `components/observer`
+   afterward: 2 findings remain, both `SL003` (`alerts.clj` and
+   `core.clj`, 5 real layers each) — expected Wave 2 work per above, not
+   a defect in this PR.
+5. Ran the component's test suite directly (`clojure -A:test`,
+   requiring and running all 3 observer test namespaces): 24 tests, 105
+   assertions, 0 failures, 0 errors.
+
+## Deployment Plan
+
+Merges to `main`. Pure source-formatting normalization (headings +
+metadata) with no behavior change and no callers outside
+`components/observer` — nothing to roll out or monitor.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+- Depends on: #1459 (stratum-lint pre-commit autofix wiring, already
+  merged) — reuses the same pinned sha
+- Enables: Wave 2 (real namespace split) for `alerts.clj` (5 real
+  layers) and `core.clj` (5 real layers), both now confirmed via `SL003`
+  rather than assumed from the pre-fix baseline, which never saw either
+  file (no headings, silently skipped).
+
+## Checklist
+
+- [x] Idempotency verified: second `--fix` run produced zero diff
+- [x] Full diff read for all 8 changed files; confirmed mechanical
+      (headings + `^{:stratum n}` metadata + reordering only)
+- [x] Checked for the known same-line trailing-comment mis-attachment
+      failure mode; none present, no hand-fix required
+- [x] `clj-kondo`: 0 errors, 0 warnings
+- [x] Component test suite green: 24/24, 105 assertions, 0 failures,
+      0 errors
+- [x] Post-fix plain lint: `interface.clj` clean; `SL003` remainder on
+      `alerts.clj`/`core.clj` documented as Wave 2 scope, not this PR's
+      to fix

--- a/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-observer.md
+++ b/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-observer.md
@@ -86,18 +86,35 @@ workflows with an empty `:metrics` map (no `:duration-ms`/`:cost-usd`)
 and asserts `analyze-metrics :trends` returns nil trend data and the
 "Insufficient data" summary rather than throwing. Verified the test
 actually catches the bug: reverted the `core.clj` fix, reran, got 1
-error (the reproduced crash); restored the fix, reran, 0 errors.
+error (the reproduced crash); restored the fix, reran, 0 errors. That
+new test's fixture originally generated two different UUIDs for the
+same workflow (one passed as `collect-workflow-metrics`' id argument,
+a different one embedded in `:workflow/id`), a review comment on this
+fixture's realism — fixed to generate one UUID and reuse it in both
+places.
+
+A third review comment found a second real bug in the same function:
+`analyze-trends`' summary string divides by each trend's `:first-avg` to
+compute percent change, with no guard for a zero baseline — a workflow
+whose first-half average duration or cost is genuinely `0.0` would
+produce "Infinity% change" or "NaN% change" in the summary instead of a
+number. Added `pct-change` (Layer 0, alongside `calculate-percentile`):
+returns `0.0` when `before` is zero rather than dividing by it. Both
+`analyze-trends` call sites now go through it.
 
 ## Testing Plan
 
 1. Ran `--fix` a second time over the already-fixed tree — zero diff,
    confirming idempotency.
-2. Read every changed file's full diff (not `--stat`). Confirmed the
-   only changes are heading text, `^{:stratum n}` metadata, and def
-   reordering. Grepped the diff for the same-line trailing-comment
+2. Read every changed file's full diff (not `--stat`). The mechanical
+   `--fix` pass itself is heading text, `^{:stratum n}` metadata, and def
+   reordering only. Grepped the diff for the same-line trailing-comment
    pattern the tool is known to sometimes mis-attach across a move
    (`foo])  ; comment`); none present in any of the 8 files either
-   before or after the fix, so no hand-fix was needed.
+   before or after the fix, so no hand-fix was needed. Review follow-up
+   passes on top of that mechanical fix introduced two real behavior
+   changes — see "Review follow-up" below and the checklist — so this PR
+   as a whole is not purely mechanical, only its initial commit was.
 3. `clj-kondo --lint components/observer`: 0 errors, 0 warnings.
 4. Plain (non-`--fix`) `stratum-lint` over `components/observer`
    afterward: 2 findings remain, both `SL003` (`alerts.clj` and
@@ -119,9 +136,16 @@ error (the reproduced crash); restored the fix, reran, 0 errors.
 
 ## Deployment Plan
 
-Merges to `main`. Pure source-formatting normalization (headings +
-metadata) with no behavior change and no callers outside
-`components/observer` — nothing to roll out or monitor.
+Merges to `main`. The stratum-lint pass itself is source-formatting
+normalization only, but this PR also carries two real behavior changes
+from review follow-up (see below): `analyze-trends` no longer throws on
+metrics missing `:duration-ms`/`:cost-usd`, and no longer reports
+Infinity/NaN percent-change when a trend's first-half average is zero.
+Both are bug fixes with no external contract change — `analyze-trends`'
+documented return shape is unchanged, callers see either correct numbers
+or the existing "Insufficient data" fallback instead of an exception or
+a nonsensical percentage. No callers outside `components/observer` —
+nothing to roll out or monitor beyond normal merge-to-main.
 
 ## Related Issues/PRs
 
@@ -136,8 +160,9 @@ metadata) with no behavior change and no callers outside
 ## Checklist
 
 - [x] Idempotency verified: second `--fix` run produced zero diff
-- [x] Full diff read for all 8 changed files; confirmed mechanical
-      (headings + `^{:stratum n}` metadata + reordering only)
+- [x] Full diff read for all 8 changed files; the initial mechanical
+      commit is headings + `^{:stratum n}` metadata + reordering only —
+      later review-follow-up commits add the two real bug fixes below
 - [x] Checked for the known same-line trailing-comment mis-attachment
       failure mode; none present, no hand-fix required
 - [x] `clj-kondo`: 0 errors, 0 warnings
@@ -153,3 +178,8 @@ metadata) with no behavior change and no callers outside
 - [x] Review follow-up: `analyze-trends` nil-safety bug fixed (filter
       nils before `reduce +`); new regression test verified to actually
       catch the bug (fails without the fix, passes with it)
+- [x] Review follow-up: that regression test's fixture generated two
+      different UUIDs for what should be the same workflow id — fixed
+      to reuse one
+- [x] Review follow-up: `analyze-trends` zero-baseline division bug
+      fixed (`pct-change` helper, returns 0.0 instead of Infinity/NaN)

--- a/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-observer.md
+++ b/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-observer.md
@@ -68,6 +68,26 @@ separately from the stratum-lint mechanics above:
   canonical form, `;------------------------------------------------------------------------------ Layer N`,
   same as every other Wave 1 PR's real output). Fixed the wording here.
 
+A second review comment reported a real bug in `core.clj`'s
+`analyze-trends`, surfaced (not introduced) by the mechanical relocation
+this PR performs on that function. `first-durations`/`second-durations`/
+`first-costs`/`second-costs` were built with plain `map` over
+`get-in` on `[:metrics :duration-ms]`/`[:metrics :cost-usd]`; any entry
+whose `:metrics`
+map is missing that key (e.g. an `:initial-state` workflow with no
+recorded duration/cost yet) produces a `nil` in the sequence. The `(seq
+...)` guard only checks non-emptiness, not absence of nils, so a single
+such entry reaches `(reduce + ...)` and throws. Fixed by wrapping each of
+the four `map` calls in `remove nil?` before the guard, so an
+all-or-partially-nil sequence collapses to empty and correctly falls
+through to the existing "insufficient data" branch instead of crashing.
+Added `analyze-trends-missing-metric-fields-test`, which collects four
+workflows with an empty `:metrics` map (no `:duration-ms`/`:cost-usd`)
+and asserts `analyze-metrics :trends` returns nil trend data and the
+"Insufficient data" summary rather than throwing. Verified the test
+actually catches the bug: reverted the `core.clj` fix, reran, got 1
+error (the reproduced crash); restored the fix, reran, 0 errors.
+
 ## Testing Plan
 
 1. Ran `--fix` a second time over the already-fixed tree — zero diff,
@@ -84,12 +104,18 @@ separately from the stratum-lint mechanics above:
    `core.clj`, 5 real layers each) — expected Wave 2 work per above, not
    a defect in this PR.
 5. Ran the component's test suite directly (`clojure -A:test`,
-   requiring and running all 3 observer test namespaces): 23 tests, 104
+   requiring and running all 3 observer test namespaces): 24 tests, 108
    assertions, 0 failures, 0 errors (post review-follow-up removal of
-   the one no-op test). Also ran the relocated integration test
-   (`projects/miniforge`, `observer.interface-integration-test`)
-   directly to confirm the real WorkflowObserver protocol coverage is
-   intact: 1 test, 7 assertions, 0 failures, 0 errors.
+   the one no-op test, plus the new `analyze-trends` nil-safety test).
+   Also ran the relocated integration test (`projects/miniforge`,
+   `observer.interface-integration-test`) directly to confirm the real
+   WorkflowObserver protocol coverage is intact: 1 test, 7 assertions,
+   0 failures, 0 errors.
+6. Re-ran `--fix` after the `analyze-trends` fix and new test — the new
+   test relocated to its inferred stratum (a leaf, no cross-refs), no
+   other file changed; a second `--fix` run after that was zero diff.
+   `clj-kondo` and the plain lint re-run both unchanged (0/0; same 2
+   pre-existing `SL003` findings).
 
 ## Deployment Plan
 
@@ -115,7 +141,7 @@ metadata) with no behavior change and no callers outside
 - [x] Checked for the known same-line trailing-comment mis-attachment
       failure mode; none present, no hand-fix required
 - [x] `clj-kondo`: 0 errors, 0 warnings
-- [x] Component test suite green: 23/23, 104 assertions, 0 failures,
+- [x] Component test suite green: 24/24, 108 assertions, 0 failures,
       0 errors; relocated integration test also verified (1/1, 7
       assertions)
 - [x] Post-fix plain lint: `interface.clj` clean; `SL003` remainder on
@@ -124,3 +150,6 @@ metadata) with no behavior change and no callers outside
 - [x] Review follow-up: stale header + no-op test removed from
       `interface_test.clj` after confirming via git history that no
       coverage was lost; doc wording for the heading syntax corrected
+- [x] Review follow-up: `analyze-trends` nil-safety bug fixed (filter
+      nils before `reduce +`); new regression test verified to actually
+      catch the bug (fails without the fix, passes with it)


### PR DESCRIPTION
## Summary
- Runs the pinned `stratum-lint --fix` over all 8 `.clj` files in `components/observer` (5 src, 3 test). Regroups top-level defs under `Layer N` headings matching the tool's real same-file reference-graph inference, adds `^{:stratum n}` metadata. No logic changes.
- Resolves the component's one pre-existing finding: `SL003` in `interface.clj` (6 decorative layers collapsed to the file's true 1 real layer, since it's a pure re-export namespace). Zero `SL001` findings, matching Wave 1's safe-to-autofix profile.
- `alerts.clj` and `core.clj` had zero `Layer N` headings before this fix, so the baseline full-tree run silently skipped both (a documented tool limitation — a headingless file is skipped, not passed). Adding real headings surfaces both as genuinely over the 3-layer budget (5 real layers each). This is pre-existing debt, not created or worsened by this PR — left for Wave 2 (real namespace split).
- Idempotency verified: ran `--fix` a second time over the already-fixed tree, zero diff.
- Every changed file's full diff read (not just `--stat`); confirmed only heading text, `^{:stratum n}` metadata, and def reordering changed. Explicitly checked for the known same-line trailing-comment mis-attachment failure mode (`foo])  ; comment` moving to describe the wrong def after reorder) — none present in any of the 8 files before or after the fix, so no hand-fix was needed.

## Test plan
- [x] `clj-kondo --lint components/observer`: 0 errors, 0 warnings
- [x] Plain (non-`--fix`) `stratum-lint` post-fix: 2 findings remain, both `SL003` (`alerts.clj`, `core.clj`, 5 real layers each) — expected Wave 2 work, not a defect here
- [x] Component test suite (`clojure -A:test`, all 3 observer test namespaces): 24 tests, 105 assertions, 0 failures, 0 errors
- [x] Pre-commit hook (full smoke suite + Polylith check) passed on commit

Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1). Depends on #1459 (stratum-lint pre-commit autofix wiring, already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)