### PR TITLE
fix: stratum-lint autofix for components/logging (Wave 1)

### DIFF
--- a/components/logging/src/ai/miniforge/logging/core.clj
+++ b/components/logging/src/ai/miniforge/logging/core.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.logging.core
   "Structured EDN logging implementation.
    Layer 0: Pure functions for log entry creation
@@ -27,9 +26,9 @@
    [clojure.java.io :as io]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Pure functions for log entry creation
 
-(defn make-entry
+;; Pure functions for log entry creation
+(defn ^{:stratum 0} make-entry
   "Create a log entry map with required fields.
    Additional context can be merged in."
   [level category event & {:keys [message data]}]
@@ -42,30 +41,28 @@
       message (assoc :log/message message)
       data (assoc :data data))))
 
-(defn merge-context
+(defn ^{:stratum 0} merge-context
   "Merge context map into a log entry, preserving entry values on conflict."
   [entry context]
   (merge context entry))
 
-(defn level-enabled?
+(defn ^{:stratum 0} level-enabled?
   "Check if a log level should be emitted given the configured minimum level."
   [configured-level entry-level]
   (log-format/level-enabled? configured-level entry-level))
 
-(defn format-edn
+(defn ^{:stratum 0} format-edn
   "Format a log entry as an EDN string for output."
   [entry]
   (log-format/format-edn entry))
 
-(defn format-human
+(defn ^{:stratum 0} format-human
   "Format a log entry as a human-readable string."
   [entry]
   (log-format/format-human entry))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Logger protocol and implementations
-
-(defprotocol Logger
+(defprotocol ^{:stratum 0} Logger
   "Protocol for structured logging."
   (log* [this level category event opts]
     "Emit a structured log entry. opts may include :message, :data, and context keys.")
@@ -76,42 +73,14 @@
   (get-config [this]
     "Return the logger configuration."))
 
-(defrecord EDNLogger [config context output-fn]
-  Logger
-  (log* [_this level category event opts]
-    (when (level-enabled? (:min-level config :trace) level)
-      (let [entry (-> (apply make-entry level category event (mapcat identity opts))
-                      (merge-context context))]
-        (output-fn entry)
-        entry)))
-
-  (with-context* [_this context-map]
-    (->EDNLogger config (merge context context-map) output-fn))
-
-  (get-context [_this]
-    context)
-
-  (get-config [_this]
-    config))
-
-(defn default-output-fn
-  "Default output function that prints EDN to *out*."
-  [entry]
-  (println (format-edn entry)))
-
-(defn human-output-fn
-  "Human-readable output function."
-  [entry]
-  (println (format-human entry)))
-
-(defn collecting-output-fn
+(defn ^{:stratum 0} collecting-output-fn
   "Returns [output-fn, entries-atom] for collecting entries in tests."
   []
   (let [entries (atom [])]
     [(fn [entry] (swap! entries conj entry))
      entries]))
 
-(defn log-file-path
+(defn ^{:stratum 0} log-file-path
   "Get path to log file for a workflow.
 
    Arguments:
@@ -124,7 +93,7 @@
     (.mkdirs logs-dir)
     (.getPath (io/file logs-dir log-file))))
 
-(defn file-size-mb
+(defn ^{:stratum 0} file-size-mb
   "Get file size in megabytes.
 
    Arguments:
@@ -137,22 +106,7 @@
       (/ (.length file) 1024.0 1024.0)
       0.0)))
 
-(defn rotate-log-if-needed
-  "Rotate log file if it exceeds size threshold.
-
-   Arguments:
-     file-path - String path to log file
-     max-size-mb - Maximum size in MB (default 10MB)
-
-   Returns: nil"
-  [file-path max-size-mb]
-  (when (> (file-size-mb file-path) max-size-mb)
-    (let [timestamp (.format (java.time.LocalDateTime/now)
-                             (java.time.format.DateTimeFormatter/ofPattern "yyyyMMdd-HHmmss"))
-          rotated-path (str file-path "." timestamp)]
-      (.renameTo (io/file file-path) (io/file rotated-path)))))
-
-(defn cleanup-old-rotated-logs
+(defn ^{:stratum 0} cleanup-old-rotated-logs
   "Delete rotated log files in `logs-dir` older than `retention-days`.
 
    Rotated files are named like `<workflow-id>.log.yyyyMMdd-HHmmss`.
@@ -171,7 +125,83 @@
            (filter #(.delete ^java.io.File %))
            count))))
 
-(defn file-output-fn
+(defn ^{:stratum 0} combined-output-fn
+  "Combine multiple output functions.
+
+   Arguments:
+     output-fns - Vector of output functions
+
+   Returns: Combined output function"
+  [output-fns]
+  (fn [entry]
+    (doseq [output-fn output-fns]
+      (try
+        (output-fn entry)
+        (catch Exception _e
+          ;; Continue with other outputs even if one fails
+          nil)))))
+
+(defn ^{:stratum 0} timed*
+  "Execute f, logging start and completion with duration.
+   Returns [result duration-ms]."
+  [logger level category event f]
+  (log* logger level category event {:message "started"})
+  (let [start (System/currentTimeMillis)
+        result (f)
+        duration (- (System/currentTimeMillis) start)]
+    (log* logger level category event
+          {:message "completed"
+           :data {:duration-ms duration}})
+    [result duration]))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defrecord ^{:stratum 1} EDNLogger [config context output-fn]
+  Logger
+  (log* [_this level category event opts]
+    (when (level-enabled? (:min-level config :trace) level)
+      (let [entry (-> (apply make-entry level category event (mapcat identity opts))
+                      (merge-context context))]
+        (output-fn entry)
+        entry)))
+
+  (with-context* [_this context-map]
+    (->EDNLogger config (merge context context-map) output-fn))
+
+  (get-context [_this]
+    context)
+
+  (get-config [_this]
+    config))
+
+(defn ^{:stratum 1} default-output-fn
+  "Default output function that prints EDN to *out*."
+  [entry]
+  (println (format-edn entry)))
+
+(defn ^{:stratum 1} human-output-fn
+  "Human-readable output function."
+  [entry]
+  (println (format-human entry)))
+
+(defn ^{:stratum 1} rotate-log-if-needed
+  "Rotate log file if it exceeds size threshold.
+
+   Arguments:
+     file-path - String path to log file
+     max-size-mb - Maximum size in MB (default 10MB)
+
+   Returns: nil"
+  [file-path max-size-mb]
+  (when (> (file-size-mb file-path) max-size-mb)
+    (let [timestamp (.format (java.time.LocalDateTime/now)
+                             (java.time.format.DateTimeFormatter/ofPattern "yyyyMMdd-HHmmss"))
+          rotated-path (str file-path "." timestamp)]
+      (.renameTo (io/file file-path) (io/file rotated-path)))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} file-output-fn
   "Output function that writes logs to per-workflow files.
 
    DEPRECATED: Use ai.miniforge.logging.sinks/file-sink instead.
@@ -204,23 +234,7 @@
             ;; Silently fail - don't break logging if file write fails
             nil))))))
 
-(defn combined-output-fn
-  "Combine multiple output functions.
-
-   Arguments:
-     output-fns - Vector of output functions
-
-   Returns: Combined output function"
-  [output-fns]
-  (fn [entry]
-    (doseq [output-fn output-fns]
-      (try
-        (output-fn entry)
-        (catch Exception _e
-          ;; Continue with other outputs even if one fails
-          nil)))))
-
-(defn create-logger
+(defn ^{:stratum 2} create-logger
   "Create a new EDN logger with the given configuration.
 
    Options:
@@ -260,19 +274,6 @@
                        :human human-output-fn
                        output))]
      (->EDNLogger {:min-level min-level} (or context {}) output-fn))))
-
-(defn timed*
-  "Execute f, logging start and completion with duration.
-   Returns [result duration-ms]."
-  [logger level category event f]
-  (log* logger level category event {:message "started"})
-  (let [start (System/currentTimeMillis)
-        result (f)
-        duration (- (System/currentTimeMillis) start)]
-    (log* logger level category event
-          {:message "completed"
-           :data {:duration-ms duration}})
-    [result duration]))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/logging/src/ai/miniforge/logging/format.clj
+++ b/components/logging/src/ai/miniforge/logging/format.clj
@@ -15,26 +15,20 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.logging.format
   "Pure log level and formatting helpers shared by logger core and sinks.")
 
-(def ^:private level-order
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private level-order
   {:trace 0 :debug 1 :info 2 :warn 3 :error 4 :fatal 5})
 
-(defn level-enabled?
-  "Check if a log level should be emitted given the configured minimum level."
-  [configured-level entry-level]
-  (let [configured-ord (get level-order configured-level 0)
-        entry-ord (get level-order entry-level 0)]
-    (>= entry-ord configured-ord)))
-
-(defn format-edn
+(defn ^{:stratum 0} format-edn
   "Format a log entry as an EDN string for output."
   [entry]
   (pr-str entry))
 
-(defn format-human
+(defn ^{:stratum 0} format-human
   "Format a log entry as a human-readable string."
   [entry]
   (let [{:log/keys [timestamp level category event message]} entry]
@@ -42,3 +36,12 @@
          " [" (name level) "] "
          (name category) "/" (name event)
          (when message (str " - " message)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} level-enabled?
+  "Check if a log level should be emitted given the configured minimum level."
+  [configured-level entry-level]
+  (let [configured-ord (get level-order configured-level 0)
+        entry-ord (get level-order entry-level 0)]
+    (>= entry-ord configured-ord)))

--- a/components/logging/src/ai/miniforge/logging/http.clj
+++ b/components/logging/src/ai/miniforge/logging/http.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.logging.http
   "JDK `java.net.http` request-builder helper shared by the fleet sinks.
 
@@ -25,7 +24,9 @@
    dedicated `http-utils` brick if a third consumer outside the
    sink-layer arrives.")
 
-(defn- invoke-static
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} invoke-static
   [class-name method-name param-types args]
   (.invoke (.getMethod (Class/forName class-name)
                        method-name
@@ -33,7 +34,9 @@
            nil
            (object-array args)))
 
-(defn build-json-post
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} build-json-post
   "Build an HTTP POST request with a JSON string `body` and a Bearer
    `api-key` header. `timeout-ms` sets the request-level timeout via
    `HttpRequest.Builder.timeout`."

--- a/components/logging/src/ai/miniforge/logging/interface.clj
+++ b/components/logging/src/ai/miniforge/logging/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.logging.interface
   "Public API for structured EDN logging.
    Provides logger creation, context management, and level-specific log
@@ -28,9 +27,9 @@
    [ai.miniforge.logging.http :as http]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Logger creation and configuration
 
-(defn create-logger
+;; Logger creation and configuration
+(defn ^{:stratum 0} create-logger
   "Create a new EDN logger.
 
    Options:
@@ -43,7 +42,7 @@
   ([] (core/create-logger))
   ([opts] (core/create-logger opts)))
 
-(defn with-context
+(defn ^{:stratum 0} with-context
   "Return a new logger with additional context merged into all entries.
    Context keys are typically namespaced like :ctx/workflow-id,
    :ctx/agent-id. Nil logger passes through (the result is still nil)
@@ -57,12 +56,12 @@
   (when logger
     (core/with-context* logger context-map)))
 
-(defn get-context
+(defn ^{:stratum 0} get-context
   "Return the current context map from a logger."
   [logger]
   (core/get-context logger))
 
-(defn collecting-logger
+(defn ^{:stratum 0} collecting-logger
   "Create a logger that collects entries into an atom for testing.
    Returns [logger entries-atom].
 
@@ -76,10 +75,8 @@
      [(core/create-logger (assoc opts :output output-fn))
       entries])))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Core logging function
-
-(defn log
+(defn ^{:stratum 0} log
   "Emit a structured log entry.
 
    Arguments:
@@ -103,47 +100,44 @@
 ;; Level-specific convenience functions. Each wrapper is nil-safe so
 ;; callers don't have to repeat `(when logger …)` at every call site
 ;; — passing a nil logger drops the entry on the floor.
-
-(defn trace
+(defn ^{:stratum 0} trace
   "Log at :trace level (detailed internal state). Nil logger = no-op."
   ([logger category event] (trace logger category event {}))
   ([logger category event opts]
    (when logger (core/log* logger :trace category event opts))))
 
-(defn debug
+(defn ^{:stratum 0} debug
   "Log at :debug level (operational detail). Nil logger = no-op."
   ([logger category event] (debug logger category event {}))
   ([logger category event opts]
    (when logger (core/log* logger :debug category event opts))))
 
-(defn info
+(defn ^{:stratum 0} info
   "Log at :info level (business events). Nil logger = no-op."
   ([logger category event] (info logger category event {}))
   ([logger category event opts]
    (when logger (core/log* logger :info category event opts))))
 
-(defn warn
+(defn ^{:stratum 0} warn
   "Log at :warn level (recoverable issues). Nil logger = no-op."
   ([logger category event] (warn logger category event {}))
   ([logger category event opts]
    (when logger (core/log* logger :warn category event opts))))
 
-(defn error
+(defn ^{:stratum 0} error
   "Log at :error level (failed operations). Nil logger = no-op."
   ([logger category event] (error logger category event {}))
   ([logger category event opts]
    (when logger (core/log* logger :error category event opts))))
 
-(defn fatal
+(defn ^{:stratum 0} fatal
   "Log at :fatal level (system-level failures). Nil logger = no-op."
   ([logger category event] (fatal logger category event {}))
   ([logger category event opts]
    (when logger (core/log* logger :fatal category event opts))))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Timed execution
-
-(defn timed
+(defn ^{:stratum 0} timed
   "Execute f and log start/completion with duration.
    Returns the result of f. Nil logger skips both log entries and just
    returns `(f)`.
@@ -156,7 +150,24 @@
     (first (core/timed* logger level category event f))
     (f)))
 
-(defmacro with-timing
+(defn ^{:stratum 0} cleanup-old-rotated-logs
+  "Delete rotated log files in `logs-dir` older than `retention-days`.
+   Returns the number of files deleted."
+  [logs-dir retention-days]
+  (core/cleanup-old-rotated-logs logs-dir retention-days))
+
+;; HTTP request builder — used by both the in-brick fleet sink and the
+;; event-stream fleet sink. Pass-through to `ai.miniforge.logging.http`.
+(defn ^{:stratum 0} build-json-post
+  "Build a `java.net.http.HttpRequest` POST with a JSON-string `body`
+   and a Bearer `api-key` header. `timeout-ms` sets the request-level
+   timeout. Used by every fleet-style HTTP sink (logging + event-stream)."
+  [uri body api-key timeout-ms]
+  (http/build-json-post uri body api-key timeout-ms))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defmacro ^{:stratum 1} with-timing
   "Execute body and log start/completion with duration.
    Returns the result of body.
 
@@ -165,23 +176,6 @@
        (do-expensive-work))"
   [logger level category event & body]
   `(timed ~logger ~level ~category ~event (fn [] ~@body)))
-
-(defn cleanup-old-rotated-logs
-  "Delete rotated log files in `logs-dir` older than `retention-days`.
-   Returns the number of files deleted."
-  [logs-dir retention-days]
-  (core/cleanup-old-rotated-logs logs-dir retention-days))
-
-;------------------------------------------------------------------------------ Layer 3
-;; HTTP request builder — used by both the in-brick fleet sink and the
-;; event-stream fleet sink. Pass-through to `ai.miniforge.logging.http`.
-
-(defn build-json-post
-  "Build a `java.net.http.HttpRequest` POST with a JSON-string `body`
-   and a Bearer `api-key` header. `timeout-ms` sets the request-level
-   timeout. Used by every fleet-style HTTP sink (logging + event-stream)."
-  [uri body api-key timeout-ms]
-  (http/build-json-post uri body api-key timeout-ms))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/logging/src/ai/miniforge/logging/messages.clj
+++ b/components/logging/src/ai/miniforge/logging/messages.clj
@@ -15,13 +15,14 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.logging.messages
   "Component-level message catalog for logging.
    Delegates to the shared messages component."
   (:require [ai.miniforge.messages.interface :as messages]))
 
-(def t
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} t
   "Look up a logging message by key, with optional param substitution."
   (messages/create-translator "config/logging/messages/en-US.edn"
                               :logging/messages))

--- a/components/logging/src/ai/miniforge/logging/sinks.clj
+++ b/components/logging/src/ai/miniforge/logging/sinks.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.logging.sinks
   "Configurable log sinks for different deployment scenarios.
 
@@ -37,9 +36,10 @@
   (:import
    [java.net.http HttpClient HttpResponse$BodyHandlers]))
 
-;;------------------------------------------------------------------------------ Layer 0: File Sink
+;------------------------------------------------------------------------------ Layer 0
 
-(defn log-file-path
+;;------------------------------------------------------------------------------ Layer 0: File Sink
+(defn ^{:stratum 0} log-file-path
   "Get path to log file for a workflow.
 
    Arguments:
@@ -52,49 +52,14 @@
     (.mkdirs logs-dir)
     (.getPath (io/file logs-dir log-file))))
 
-(defn file-size-mb [file-path]
+(defn ^{:stratum 0} file-size-mb [file-path]
   (let [file (io/file file-path)]
     (if (.exists file)
       (/ (.length file) 1024.0 1024.0)
       0.0)))
 
-(defn rotate-log-if-needed [file-path max-size-mb]
-  (when (> (file-size-mb file-path) max-size-mb)
-    (let [timestamp (.format (java.time.LocalDateTime/now)
-                             (java.time.format.DateTimeFormatter/ofPattern "yyyyMMdd-HHmmss"))
-          rotated-path (str file-path "." timestamp)]
-      (.renameTo (io/file file-path) (io/file rotated-path)))))
-
-(defn file-sink
-  "Create a file sink that writes logs to per-workflow files.
-
-   Arguments:
-     opts - Map with optional:
-       :base-dir - Base directory (default: ~/.miniforge/logs)
-       :max-size-mb - Max file size before rotation (default 10)
-       :format - :edn or :human (default :human)
-
-   Returns: Sink function (fn [log-entry] -> nil)"
-  [& [opts]]
-  (let [max-size-mb (:max-size-mb opts 10)
-        format-fn (case (:format opts :human)
-                    :edn log-format/format-edn
-                    :human log-format/format-human
-                    log-format/format-human)]
-    (fn [entry]
-      (when-let [workflow-id (:workflow/id entry)]
-        (try
-          (let [file-path (log-file-path workflow-id)]
-            (rotate-log-if-needed file-path max-size-mb)
-            (with-open [writer (io/writer file-path :append true)]
-              (.write writer (format-fn entry))
-              (.write writer "\n")))
-          (catch Exception _e
-            nil))))))
-
 ;;------------------------------------------------------------------------------ Layer 1: Stream Sinks
-
-(defn stdout-sink
+(defn ^{:stratum 0} stdout-sink
   "Create a stdout sink that prints logs to standard output.
 
    Arguments:
@@ -116,7 +81,7 @@
           (catch Exception _e
             nil))))))
 
-(defn stderr-sink
+(defn ^{:stratum 0} stderr-sink
   "Create a stderr sink that prints logs to standard error.
 
    Arguments:
@@ -140,8 +105,7 @@
             nil))))))
 
 ;;------------------------------------------------------------------------------ Layer 2: Fleet Sink
-
-(defn fleet-sink
+(defn ^{:stratum 0} fleet-sink
   "Create a fleet sink that sends logs to fleet command via HTTP.
 
    Arguments:
@@ -218,8 +182,7 @@
             (flush-batch!)))))))
 
 ;;------------------------------------------------------------------------------ Layer 3: Multi-Sink
-
-(defn multi-sink
+(defn ^{:stratum 0} multi-sink
   "Create a multi-sink that writes to multiple sinks simultaneously.
 
    Arguments:
@@ -234,9 +197,48 @@
         (catch Exception _e
           nil)))))
 
-;;------------------------------------------------------------------------------ Layer 4: Sink Factory
+;------------------------------------------------------------------------------ Layer 1
 
-(defn create-sink
+(defn ^{:stratum 1} rotate-log-if-needed [file-path max-size-mb]
+  (when (> (file-size-mb file-path) max-size-mb)
+    (let [timestamp (.format (java.time.LocalDateTime/now)
+                             (java.time.format.DateTimeFormatter/ofPattern "yyyyMMdd-HHmmss"))
+          rotated-path (str file-path "." timestamp)]
+      (.renameTo (io/file file-path) (io/file rotated-path)))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} file-sink
+  "Create a file sink that writes logs to per-workflow files.
+
+   Arguments:
+     opts - Map with optional:
+       :base-dir - Base directory (default: ~/.miniforge/logs)
+       :max-size-mb - Max file size before rotation (default 10)
+       :format - :edn or :human (default :human)
+
+   Returns: Sink function (fn [log-entry] -> nil)"
+  [& [opts]]
+  (let [max-size-mb (:max-size-mb opts 10)
+        format-fn (case (:format opts :human)
+                    :edn log-format/format-edn
+                    :human log-format/format-human
+                    log-format/format-human)]
+    (fn [entry]
+      (when-let [workflow-id (:workflow/id entry)]
+        (try
+          (let [file-path (log-file-path workflow-id)]
+            (rotate-log-if-needed file-path max-size-mb)
+            (with-open [writer (io/writer file-path :append true)]
+              (.write writer (format-fn entry))
+              (.write writer "\n")))
+          (catch Exception _e
+            nil))))))
+
+;------------------------------------------------------------------------------ Layer 3
+
+;;------------------------------------------------------------------------------ Layer 4: Sink Factory
+(defn ^{:stratum 3} create-sink
   "Create a log sink from configuration.
 
    Arguments:
@@ -274,7 +276,9 @@
                     {:config sink-config
                      :config/error :invalid-config}))))
 
-(defn create-sinks-from-config
+;------------------------------------------------------------------------------ Layer 4
+
+(defn ^{:stratum 4} create-sinks-from-config
   "Create log sinks from user configuration.
 
    Arguments:

--- a/components/logging/src/ai/miniforge/logging/sinks.clj
+++ b/components/logging/src/ai/miniforge/logging/sinks.clj
@@ -38,7 +38,6 @@
 
 ;------------------------------------------------------------------------------ Layer 0
 
-;;------------------------------------------------------------------------------ Layer 0: File Sink
 (defn ^{:stratum 0} log-file-path
   "Get path to log file for a workflow.
 
@@ -58,7 +57,6 @@
       (/ (.length file) 1024.0 1024.0)
       0.0)))
 
-;;------------------------------------------------------------------------------ Layer 1: Stream Sinks
 (defn ^{:stratum 0} stdout-sink
   "Create a stdout sink that prints logs to standard output.
 
@@ -104,7 +102,6 @@
           (catch Exception _e
             nil))))))
 
-;;------------------------------------------------------------------------------ Layer 2: Fleet Sink
 (defn ^{:stratum 0} fleet-sink
   "Create a fleet sink that sends logs to fleet command via HTTP.
 
@@ -181,7 +178,6 @@
           (when (or batch-full? time-exceeded?)
             (flush-batch!)))))))
 
-;;------------------------------------------------------------------------------ Layer 3: Multi-Sink
 (defn ^{:stratum 0} multi-sink
   "Create a multi-sink that writes to multiple sinks simultaneously.
 
@@ -237,7 +233,6 @@
 
 ;------------------------------------------------------------------------------ Layer 3
 
-;;------------------------------------------------------------------------------ Layer 4: Sink Factory
 (defn ^{:stratum 3} create-sink
   "Create a log sink from configuration.
 

--- a/components/logging/test/ai/miniforge/logging/interface_test.clj
+++ b/components/logging/test/ai/miniforge/logging/interface_test.clj
@@ -15,25 +15,22 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.logging.interface-test
   (:require [clojure.test :as test :refer [deftest testing is]]
             [ai.miniforge.logging.interface :as log]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Test helpers
 
-(defn get-entries
+;; Test helpers
+(defn ^{:stratum 0} get-entries
   "Helper to create a collecting logger, run f with it, and return entries."
   [f]
   (let [[logger entries] (log/collecting-logger {:min-level :trace})]
     (f logger)
     @entries))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Logger creation tests
-
-(deftest create-logger-test
+(deftest ^{:stratum 0} create-logger-test
   (testing "creates logger with default options"
     (let [logger (log/create-logger)]
       (is (some? logger))
@@ -44,16 +41,104 @@
           logger (log/create-logger {:context ctx})]
       (is (= ctx (log/get-context logger))))))
 
-(deftest collecting-logger-test
+(deftest ^{:stratum 0} collecting-logger-test
   (testing "collecting-logger captures entries"
     (let [[logger entries] (log/collecting-logger)]
       (log/info logger :agent :agent/task-started {})
       (is (= 1 (count @entries)))
       (is (= :info (:log/level (first @entries)))))))
 
-;; Context tests
+;; Min-level filtering tests
+(deftest ^{:stratum 0} min-level-test
+  (testing "filters entries below min-level"
+    (let [[logger entries] (log/collecting-logger {:min-level :info})]
+      (log/trace logger :agent :agent/memory-updated {})
+      (log/debug logger :loop :inner/iteration-started {})
+      (log/info logger :agent :agent/task-started {})
+      (log/warn logger :policy :policy/budget-exceeded {})
+      (is (= 2 (count @entries)))
+      (is (every? #{:info :warn} (map :log/level @entries)))))
 
-(deftest with-context-test
+  (testing "emits all levels when min-level is :trace"
+    (let [[logger entries] (log/collecting-logger {:min-level :trace})]
+      (log/trace logger :agent :agent/memory-updated {})
+      (log/debug logger :loop :inner/iteration-started {})
+      (log/info logger :agent :agent/task-started {})
+      (is (= 3 (count @entries))))))
+
+;; Timed execution tests
+(deftest ^{:stratum 0} timed-test
+  (testing "timed returns result of function"
+    (let [[logger _] (log/collecting-logger)
+          result (log/timed logger :info :system :system/health-check
+                            #(+ 1 2))]
+      (is (= 3 result))))
+
+  (testing "timed logs start and completion"
+    (let [[logger entries] (log/collecting-logger)]
+      (log/timed logger :info :system :system/health-check (constantly :ok))
+      (is (= 2 (count @entries)))
+      (is (= "started" (:log/message (first @entries))))
+      (is (= "completed" (:log/message (second @entries))))))
+
+  (testing "timed includes duration in completion entry"
+    (let [[logger entries] (log/collecting-logger)]
+      (log/timed logger :info :system :system/health-check
+                 #(Thread/sleep 10))
+      (let [completion (second @entries)]
+        (is (number? (get-in completion [:data :duration-ms])))
+        (is (>= (get-in completion [:data :duration-ms]) 10))))))
+
+(deftest ^{:stratum 0} nil-logger-is-no-op-test
+  (testing "every level wrapper is nil-safe"
+    (is (nil? (log/trace nil :system :event)))
+    (is (nil? (log/debug nil :system :event)))
+    (is (nil? (log/info  nil :system :event)))
+    (is (nil? (log/warn  nil :system :event)))
+    (is (nil? (log/error nil :system :event)))
+    (is (nil? (log/fatal nil :system :event)))
+    (is (nil? (log/log   nil :info :system :event {}))))
+
+  (testing "with-context passes nil through"
+    (is (nil? (log/with-context nil {:ctx/workflow-id "x"}))))
+
+  (testing "timed with nil logger executes f and returns its result"
+    (let [calls (atom 0)
+          result (log/timed nil :info :system :event
+                            (fn [] (swap! calls inc) :done))]
+      (is (= :done result))
+      (is (= 1 @calls)))))
+
+(deftest ^{:stratum 0} cleanup-old-rotated-logs-test
+  (testing "deletes only rotated logs older than the retention window"
+    (let [dir (java.nio.file.Files/createTempDirectory "miniforge-logs-test" (make-array java.nio.file.attribute.FileAttribute 0))
+          old-rotated (.toFile (.resolve dir "workflow.log.20250101-000000"))
+          new-rotated (.toFile (.resolve dir "workflow.log.20260101-000000"))
+          active-log (.toFile (.resolve dir "workflow.log"))
+          old-plain (.toFile (.resolve dir "plain.txt"))]
+      (try
+        (doseq [f [old-rotated new-rotated active-log old-plain]]
+          (spit f "x"))
+        (let [old-time (- (System/currentTimeMillis) (* 10 24 60 60 1000))
+              new-time (System/currentTimeMillis)]
+          (.setLastModified old-rotated old-time)
+          (.setLastModified old-plain old-time)
+          (.setLastModified new-rotated new-time)
+          (.setLastModified active-log old-time))
+        (is (= 1 (log/cleanup-old-rotated-logs (.toString dir) 7)))
+        (is (not (.exists old-rotated)))
+        (is (.exists new-rotated))
+        (is (.exists active-log))
+        (is (.exists old-plain))
+        (finally
+          (doseq [f [old-rotated new-rotated active-log old-plain]]
+            (when (.exists f) (.delete f)))
+          (.delete (.toFile dir)))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Context tests
+(deftest ^{:stratum 1} with-context-test
   (testing "adds context to logger"
     (let [entries (get-entries
                    (fn [logger]
@@ -80,8 +165,7 @@
       (is (= {:from-entry true} (:data (first entries)))))))
 
 ;; Level-specific function tests
-
-(deftest log-levels-test
+(deftest ^{:stratum 1} log-levels-test
   (testing "trace level"
     (let [entries (get-entries #(log/trace % :agent :agent/memory-updated {}))]
       (is (= :trace (:log/level (first entries))))))
@@ -107,8 +191,7 @@
       (is (= :fatal (:log/level (first entries)))))))
 
 ;; Log entry structure tests
-
-(deftest log-entry-structure-test
+(deftest ^{:stratum 1} log-entry-structure-test
   (testing "entry has required fields"
     (let [entries (get-entries #(log/info % :agent :agent/task-started {}))
           entry (first entries)]
@@ -128,52 +211,8 @@
                                           {:data {:agent-role :implementer}}))]
       (is (= {:agent-role :implementer} (:data (first entries)))))))
 
-;; Min-level filtering tests
-
-(deftest min-level-test
-  (testing "filters entries below min-level"
-    (let [[logger entries] (log/collecting-logger {:min-level :info})]
-      (log/trace logger :agent :agent/memory-updated {})
-      (log/debug logger :loop :inner/iteration-started {})
-      (log/info logger :agent :agent/task-started {})
-      (log/warn logger :policy :policy/budget-exceeded {})
-      (is (= 2 (count @entries)))
-      (is (every? #{:info :warn} (map :log/level @entries)))))
-
-  (testing "emits all levels when min-level is :trace"
-    (let [[logger entries] (log/collecting-logger {:min-level :trace})]
-      (log/trace logger :agent :agent/memory-updated {})
-      (log/debug logger :loop :inner/iteration-started {})
-      (log/info logger :agent :agent/task-started {})
-      (is (= 3 (count @entries))))))
-
-;; Timed execution tests
-
-(deftest timed-test
-  (testing "timed returns result of function"
-    (let [[logger _] (log/collecting-logger)
-          result (log/timed logger :info :system :system/health-check
-                            #(+ 1 2))]
-      (is (= 3 result))))
-
-  (testing "timed logs start and completion"
-    (let [[logger entries] (log/collecting-logger)]
-      (log/timed logger :info :system :system/health-check (constantly :ok))
-      (is (= 2 (count @entries)))
-      (is (= "started" (:log/message (first @entries))))
-      (is (= "completed" (:log/message (second @entries))))))
-
-  (testing "timed includes duration in completion entry"
-    (let [[logger entries] (log/collecting-logger)]
-      (log/timed logger :info :system :system/health-check
-                 #(Thread/sleep 10))
-      (let [completion (second @entries)]
-        (is (number? (get-in completion [:data :duration-ms])))
-        (is (>= (get-in completion [:data :duration-ms]) 10))))))
-
 ;; Generic log function test
-
-(deftest log-function-test
+(deftest ^{:stratum 1} log-function-test
   (testing "log function works with explicit level"
     (let [entries (get-entries
                    #(log/log % :warn :policy :policy/escalation
@@ -185,52 +224,6 @@
       (is (= :policy/escalation (:log/event entry)))
       (is (= "Escalating to human" (:log/message entry)))
       (is (= {:reason "budget exceeded"} (:data entry))))))
-
-(deftest nil-logger-is-no-op-test
-  (testing "every level wrapper is nil-safe"
-    (is (nil? (log/trace nil :system :event)))
-    (is (nil? (log/debug nil :system :event)))
-    (is (nil? (log/info  nil :system :event)))
-    (is (nil? (log/warn  nil :system :event)))
-    (is (nil? (log/error nil :system :event)))
-    (is (nil? (log/fatal nil :system :event)))
-    (is (nil? (log/log   nil :info :system :event {}))))
-
-  (testing "with-context passes nil through"
-    (is (nil? (log/with-context nil {:ctx/workflow-id "x"}))))
-
-  (testing "timed with nil logger executes f and returns its result"
-    (let [calls (atom 0)
-          result (log/timed nil :info :system :event
-                            (fn [] (swap! calls inc) :done))]
-      (is (= :done result))
-      (is (= 1 @calls)))))
-
-(deftest cleanup-old-rotated-logs-test
-  (testing "deletes only rotated logs older than the retention window"
-    (let [dir (java.nio.file.Files/createTempDirectory "miniforge-logs-test" (make-array java.nio.file.attribute.FileAttribute 0))
-          old-rotated (.toFile (.resolve dir "workflow.log.20250101-000000"))
-          new-rotated (.toFile (.resolve dir "workflow.log.20260101-000000"))
-          active-log (.toFile (.resolve dir "workflow.log"))
-          old-plain (.toFile (.resolve dir "plain.txt"))]
-      (try
-        (doseq [f [old-rotated new-rotated active-log old-plain]]
-          (spit f "x"))
-        (let [old-time (- (System/currentTimeMillis) (* 10 24 60 60 1000))
-              new-time (System/currentTimeMillis)]
-          (.setLastModified old-rotated old-time)
-          (.setLastModified old-plain old-time)
-          (.setLastModified new-rotated new-time)
-          (.setLastModified active-log old-time))
-        (is (= 1 (log/cleanup-old-rotated-logs (.toString dir) 7)))
-        (is (not (.exists old-rotated)))
-        (is (.exists new-rotated))
-        (is (.exists active-log))
-        (is (.exists old-plain))
-        (finally
-          (doseq [f [old-rotated new-rotated active-log old-plain]]
-            (when (.exists f) (.delete f)))
-          (.delete (.toFile dir)))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/logging/test/ai/miniforge/logging/sinks_test.clj
+++ b/components/logging/test/ai/miniforge/logging/sinks_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.logging.sinks-test
   (:require
    [ai.miniforge.logging.sinks :as sinks]
@@ -23,7 +22,9 @@
   (:import
    (clojure.lang ExceptionInfo)))
 
-(deftest create-sink-invalid-config-carries-invalid-config-data
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} create-sink-invalid-config-carries-invalid-config-data
   (testing "non-map non-vector sink config is an invalid config setup failure"
     (let [thrown (try
                    (sinks/create-sink "not-a-sink")

--- a/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-logging.md
+++ b/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-logging.md
@@ -37,15 +37,20 @@ content loss.
 `interface.clj` — the file the baseline flagged — is now resolved to 2 real
 layers (was mislabeled as 4). `--fix` also processed `sinks.clj`, which the
 original baseline scan reported zero findings for; it turns out its
-decorative headings used a double-semicolon `;;---- Layer N: <label>`
-format that the linter's heading parser doesn't recognize, so the file was
-silently skipped by the original scan rather than passing — exactly the
-"documented limitation" the baseline doc warned about (files with no
-recognized heading under-report the true debt). Once `--fix` computed
-`sinks.clj`'s real reference graph, it came out to **5 distinct layers**,
-over the 3-layer budget. This is pre-existing structural debt this PR did
-not create — it's the same code, now correctly labeled — and is out of
-scope here; tracked as Wave 2 (needs an actual namespace split).
+decorative headings (`;;------ Layer N: <label>`, e.g. `Layer 2: Fleet
+Sink`) carry trailing descriptive text after the layer number, which
+`stratum-lint`'s heading regex (`^;+\s*-*\s*Layer\s+(\d+)\s*-*\s*$`)
+doesn't match — it requires nothing but optional dashes/whitespace after
+`Layer N`, not a colon and a label. So these were never recognized as
+headings at all (semicolon count is irrelevant to the regex; the trailing
+text is what breaks the match), and the file was silently skipped by the
+original scan rather than passing — exactly the "documented limitation"
+the baseline doc warned about (files with no recognized heading
+under-report the true debt). Once `--fix` computed `sinks.clj`'s real
+reference graph, it came out to **5 distinct layers**, over the 3-layer
+budget. This is pre-existing structural debt this PR did not create — it's
+the same code, now correctly labeled — and is out of scope here; tracked as
+Wave 2 (needs an actual namespace split).
 
 Checked every changed file for the known tool limitation where a same-line
 trailing comment (`closing-form])  ; comment`) can get detached and
@@ -53,6 +58,29 @@ reattached next to the wrong def during reordering: one such comment
 exists in `sinks.clj` (`[:file]) ;; Default to file sink`, inside a `let`
 binding in `create-sinks-from-config`), and it stayed correctly attached
 to the same binding after the fix — no hand-correction needed.
+
+**Follow-up (post-review):** because the old double-semicolon banners in
+`sinks.clj` were never recognized as real headings, `--fix` left them in
+place as ordinary comments — dragged along with whichever def ended up
+nearest them after the reorder. The result: 5 stale banners
+(`Layer 0: File Sink`, `Layer 1: Stream Sinks`, `Layer 2: Fleet Sink`,
+`Layer 3: Multi-Sink`, `Layer 4: Sink Factory`) ended up sitting at layer
+numbers that contradict the real, adjacent single-semicolon heading and
+the def's own `^{:stratum n}` metadata — e.g. `Layer 2: Fleet Sink` sitting
+directly above `fleet-sink`, which is tagged `^{:stratum 0}`. Flagged by
+Copilot review on this PR. Not a `stratum-lint` bug (the regex is working
+exactly as documented) — a per-file cleanup call. Removed all 5: each
+one's descriptive fragment (`File Sink`, `Stream Sinks`, `Fleet Sink`,
+`Multi-Sink`, `Sink Factory`) is redundant with either the function name
+or its own docstring's opening line, so deleting loses no information
+that isn't already stated nearby; keeping a labeled-but-wrong-numbered
+banner next to a correct one would only re-create the exact confusion
+being fixed. Re-ran `--fix` twice after the deletion: no output either
+time (nothing left to rewrite), confirming the removal didn't touch the
+real heading structure — same single `SL003` finding on `sinks.clj`, same
+5-layer count, only the line number shifted. Checked every other changed
+file in the component for the same pattern (`grep` for `;;.*Layer\s+\d+.*:`)
+— none found; `sinks.clj` was the only offender.
 
 ## Testing Plan
 
@@ -109,3 +137,7 @@ the namespace.
 - [x] Component test suite passes (11 tests, 54 assertions, 0
       failures/errors)
 - [x] No `--no-verify`; pre-commit hook runs normally at commit time
+- [x] Post-review: stale double-semicolon banners with wrong `Layer N:`
+      labels removed from `sinks.clj` (5); confirmed absent elsewhere in
+      the component; re-verified idempotency and unchanged finding after
+      removal

--- a/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-logging.md
+++ b/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-logging.md
@@ -1,0 +1,111 @@
+# fix: stratum-lint autofix for components/logging (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` (sha `80699e378cb8ebbb6daeb928431aa4a6b373c07e`)
+over all 8 Clojure files (6 `src`, 2 `test`) in `components/logging`,
+regrouping each file's defs under regenerated `;---- Layer N` headings and
+tagging every def with `^{:stratum n}` metadata inferred from the real
+same-file reference graph. No logic changes — headings, metadata, and def
+order only.
+
+## Motivation
+
+`work/stratum-lint-baseline-2026-07-24.md` (Wave 0) found rule 210's
+stratified-design headings had been cargo-culted across most of the tree
+into decorative section banners that don't track a real dependency DAG.
+`components/logging` carried exactly 1 reported finding — `SL003` on
+`interface.clj` (4 distinct layers against the 3-layer budget) — and
+**zero `SL001`** upward-reference findings, which is what puts it in the
+Wave 1 safe-to-autofix batch: no cycle/upward-call risk to reason about
+before running the mechanical fixer.
+
+## Changes in Detail
+
+Ran, over the whole component:
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "80699e378cb8ebbb6daeb928431aa4a6b373c07e" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/logging
+```
+
+All 8 files rewritten: `core.clj`, `format.clj`, `http.clj`, `interface.clj`,
+`messages.clj`, `sinks.clj`, `interface_test.clj`, `sinks_test.clj`. Diff
+stat: 8 files changed, 291 insertions(+), 291 deletions(-) — perfectly
+balanced, consistent with pure reordering plus metadata addition and no
+content loss.
+
+`interface.clj` — the file the baseline flagged — is now resolved to 2 real
+layers (was mislabeled as 4). `--fix` also processed `sinks.clj`, which the
+original baseline scan reported zero findings for; it turns out its
+decorative headings used a double-semicolon `;;---- Layer N: <label>`
+format that the linter's heading parser doesn't recognize, so the file was
+silently skipped by the original scan rather than passing — exactly the
+"documented limitation" the baseline doc warned about (files with no
+recognized heading under-report the true debt). Once `--fix` computed
+`sinks.clj`'s real reference graph, it came out to **5 distinct layers**,
+over the 3-layer budget. This is pre-existing structural debt this PR did
+not create — it's the same code, now correctly labeled — and is out of
+scope here; tracked as Wave 2 (needs an actual namespace split).
+
+Checked every changed file for the known tool limitation where a same-line
+trailing comment (`closing-form])  ; comment`) can get detached and
+reattached next to the wrong def during reordering: one such comment
+exists in `sinks.clj` (`[:file]) ;; Default to file sink`, inside a `let`
+binding in `create-sinks-from-config`), and it stayed correctly attached
+to the same binding after the fix — no hand-correction needed.
+
+## Testing Plan
+
+1. Ran plain (non-`--fix`) lint before fixing: 1 finding (`SL003` on
+   `interface.clj`), 0 `SL001` — matches the baseline.
+2. Ran `--fix`, then ran the identical `--fix` command a second time:
+   zero-diff, confirming idempotency.
+3. Read the full diff for all 8 changed files. Confirmed the only changes
+   are heading placement, def reordering, and `^{:stratum n}` metadata;
+   insertions and deletions are equal (291/291) across the whole diff.
+4. `clj-kondo --lint components/logging`: 0 errors, 0 warnings.
+5. Re-ran plain `stratum-lint` after the fix: `SL003` remains, now on
+   `sinks.clj` (5 real layers) instead of `interface.clj` — a
+   previously-invisible over-budget file surfaced by `--fix`'s
+   heading-format-independent reference-graph analysis, not a regression.
+   Wave 2 scope.
+6. Ran the component's test suite (`interface-test` + `sinks-test`, via
+   babashka with the component's resolved classpath, since
+   `ai.miniforge.config.user` — a transitive dep — requires
+   `babashka.process`, which isn't declared as a Maven dep and is only
+   available under `bb`): 11 tests, 54 assertions, 0 failures, 0 errors.
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+changes — comment/metadata/order-only. The pre-commit hook's `lint:stratum`
+autofixer keeps this component clean going forward for any file it
+touches; the remaining `SL003` on `sinks.clj` stays flagged (build config
+is `MINIFORGE_STRATUM_BUDGET_MODE=warn` on this commit, since the finding
+is pre-existing and not created or worsened by this PR) until Wave 2 splits
+the namespace.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1 —
+  mechanical relabeling via `--fix`, decorative-heading files only)
+- Precedent: #1461 (`compliance-scanner`), #1462 (`reliability`), #1463
+  (`decision`), #1464 (`gate`), #1467 (`adapter-claude-code`) — same Wave 1
+  pattern
+- Follow-on: Wave 2 namespace split for `sinks.clj` (now `SL003`, 5 real
+  layers)
+
+## Checklist
+
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Idempotency verified (second `--fix` run, zero diff)
+- [x] Diff reviewed file-by-file; confirmed mechanical-only (heading +
+      metadata + reorder)
+- [x] Checked for same-line trailing-comment reattachment; one found,
+      confirmed correctly attached, no hand-fix needed
+- [x] `clj-kondo` clean (0 errors, 0 warnings)
+- [x] Plain lint re-run post-fix: `SL003` remains on `sinks.clj`
+      (pre-existing, documented, Wave 2 scope)
+- [x] Component test suite passes (11 tests, 54 assertions, 0
+      failures/errors)
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
## Summary

- Runs `stratum-lint --fix` (sha `80699e378cb8ebbb6daeb928431aa4a6b373c07e`) over `components/logging` (6 `src` + 2 `test` files), regrouping defs under regenerated `;---- Layer N` headings and tagging every def with `^{:stratum n}` metadata from the real same-file reference graph. Mechanical only — no logic changes (291 insertions / 291 deletions, exactly balanced).
- Fixes the 1 reported finding: `SL003` on `interface.clj` (4 layers, over the 3-layer budget); component had 0 `SL001` findings, the profile that puts it in the Wave 1 safe-to-autofix batch.
- `--fix` also surfaced a previously-invisible `SL003` on `sinks.clj` (5 real layers) — its old `;;----`-style headings weren't in the format the linter's parser recognizes, so the original baseline scan silently skipped it rather than passing it. Pre-existing debt, not created by this PR; left for Wave 2 (needs an actual namespace split).

## Test plan

- [x] Idempotency: ran `--fix` a second time, zero diff.
- [x] Read every changed file's full diff — confirmed heading/order/metadata only, no comment misattachment (one same-line trailing comment in `sinks.clj` checked and confirmed correctly attached post-fix).
- [x] `clj-kondo --lint components/logging`: 0 errors, 0 warnings.
- [x] Plain `stratum-lint` re-run post-fix: `SL003` remains on `sinks.clj` only (documented above, Wave 2 scope).
- [x] Component test suite: 11 tests, 54 assertions, 0 failures/errors.
- [x] Pre-commit hook (full smoke + GraalVM compat suites) passed at commit time: 331 tests/1241 assertions and 8 tests/545 assertions, 0 failures.

See `docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-logging.md` for full detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)