### PR TITLE
fix: stratum-lint autofix for components/tool (Wave 1)

### DIFF
--- a/components/tool/src/ai/miniforge/tool/core.clj
+++ b/components/tool/src/ai/miniforge/tool/core.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.tool.core
   "Tool protocol and registry implementation.
    Layer 0: Pure functions for tool definitions and validation
@@ -30,9 +29,9 @@
    [ai.miniforge.tool.tracking :as tracking]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Tool schema and validation
 
-(def tool-schema
+;; Tool schema and validation
+(def ^{:stratum 0} tool-schema
   "Schema for tool definitions (Phase 0 - minimal implementation).
 
    Phase 0 provides core tool protocol for agent use.
@@ -54,15 +53,15 @@
    :tool/description :string
    :tool/parameters  :map       ; parameter spec {:param {:type :string :required true}}
    :tool/handler     :fn        ; (fn [params context] -> result)
-   :tool/metadata    :map})     ; optional metadata (can include future MCP fields)
+   :tool/metadata    :map})  ; optional metadata (can include future MCP fields)
 
-(defn valid-tool-id?
+(defn ^{:stratum 0} valid-tool-id?
   "Check if tool ID is valid (namespaced keyword)."
   [id]
   (and (keyword? id)
        (namespace id)))
 
-(defn validate-params
+(defn ^{:stratum 0} validate-params
   "Validate parameters against a parameter spec.
    Returns {:valid? true} or {:valid? false :errors [...]}."
   [param-spec params]
@@ -74,7 +73,7 @@
       {:valid? false
        :errors (mapv #(messages/t :tool/missing-parameter {:param (name %)}) missing)})))
 
-(defn build-tool-definition
+(defn ^{:stratum 0} build-tool-definition
   "Build a tool definition map from parts."
   [{:keys [id name description parameters handler metadata]
     :or {parameters {} metadata {}}}]
@@ -85,20 +84,18 @@
    :tool/handler handler
    :tool/metadata metadata})
 
-(defn tool-summary
+(defn ^{:stratum 0} tool-summary
   "Create a brief summary of a tool for display."
   [tool]
   (messages/t :tool/summary {:name (:tool/name tool) :description (:tool/description tool)}))
 
-(defn- searchable-text
+(defn- ^{:stratum 0} searchable-text
   "Return string metadata as searchable text; ignore absent or malformed values."
   [value]
   (if (string? value) value ""))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Tool protocol and registry
-
-(defprotocol Tool
+(defprotocol ^{:stratum 0} Tool
   "Protocol for executable tools."
   (tool-id [this] "Return the tool's identifier.")
   (tool-info [this] "Return tool metadata and description.")
@@ -106,7 +103,7 @@
   (validate-args [this args] "Validate arguments against tool schema. Returns {:valid? bool :errors [...]}")
   (get-schema [this] "Return tool parameter schema."))
 
-(defprotocol ToolRegistry
+(defprotocol ^{:stratum 0} ToolRegistry
   "Protocol for tool registration and lookup."
   (register-tool [this tool] "Register a tool in the registry.")
   (unregister-tool [this tool-id] "Remove a tool from the registry.")
@@ -114,7 +111,7 @@
   (list-tools [this] "List all registered tools.")
   (find-tools [this query] "Find tools matching query."))
 
-(defn emit-tool-event!
+(defn ^{:stratum 0} emit-tool-event!
   "Emit a tool lifecycle event when the context carries an event stream."
   [context tool-id event-type & [extra]]
   (try
@@ -127,7 +124,21 @@
         (events/publish! stream (constructor stream wf-id agent-id tool-id extra))))
     (catch Exception _ nil)))
 
-(defrecord FunctionTool [id name description parameters handler metadata]
+(defn ^{:stratum 0} execute-tool
+  "Execute a tool from a registry by ID.
+   Returns execution result or error if tool not found."
+  [registry tool-id params context]
+  (if-let [tool (get-tool registry tool-id)]
+    (execute tool params context)
+    (let [not-found-msg (messages/t :tool/not-found {:tool-id tool-id})]
+      {:success false
+       :error {:type :not-found
+               :message not-found-msg}
+       :anomaly (anomaly/anomaly :not-found not-found-msg {})})))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defrecord ^{:stratum 1} FunctionTool [id name description parameters handler metadata]
   Tool
   (tool-id [_this] id)
   (tool-info [_this]
@@ -171,7 +182,7 @@
   (get-schema [_this]
     parameters))
 
-(defrecord AtomRegistry [tools-atom logger]
+(defrecord ^{:stratum 1} AtomRegistry [tools-atom logger]
   ToolRegistry
   (register-tool [_this tool]
     (let [id (tool-id tool)]
@@ -203,7 +214,9 @@
                        (or (str/includes? (str/lower-case (searchable-text (:name info))) q)
                            (str/includes? (str/lower-case (searchable-text (:description info))) q)))))))))
 
-(defn create-function-tool
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} create-function-tool
   "Create a function-based tool.
 
    Options:
@@ -229,7 +242,7 @@
                     handler
                     metadata)))
 
-(defn create-registry
+(defn ^{:stratum 2} create-registry
   "Create a new tool registry.
 
    Options:
@@ -237,18 +250,6 @@
   ([] (create-registry {}))
   ([{:keys [logger]}]
    (->AtomRegistry (atom {}) logger)))
-
-(defn execute-tool
-  "Execute a tool from a registry by ID.
-   Returns execution result or error if tool not found."
-  [registry tool-id params context]
-  (if-let [tool (get-tool registry tool-id)]
-    (execute tool params context)
-    (let [not-found-msg (messages/t :tool/not-found {:tool-id tool-id})]
-      {:success false
-       :error {:type :not-found
-               :message not-found-msg}
-       :anomaly (anomaly/anomaly :not-found not-found-msg {})})))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/tool/src/ai/miniforge/tool/interface.clj
+++ b/components/tool/src/ai/miniforge/tool/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.tool.interface
   "Public API for the tool component.
    Provides tool definition, registration, and execution.
@@ -29,20 +28,18 @@
    [ai.miniforge.tool.tracking :as tracking]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Re-export protocols for extension
 
-(def Tool
+;; Re-export protocols for extension
+(def ^{:stratum 0} Tool
   "Tool protocol for implementing custom tools."
   core/Tool)
 
-(def ToolRegistry
+(def ^{:stratum 0} ToolRegistry
   "ToolRegistry protocol for implementing custom registries."
   core/ToolRegistry)
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Tool creation
-
-(defn create-tool
+(defn ^{:stratum 0} create-tool
   "Create a function-based tool.
 
    Options:
@@ -66,8 +63,7 @@
   (core/create-function-tool opts))
 
 ;; Registry creation and management
-
-(defn create-registry
+(defn ^{:stratum 0} create-registry
   "Create a new tool registry.
 
    Options:
@@ -79,37 +75,35 @@
   ([] (core/create-registry))
   ([opts] (core/create-registry opts)))
 
-(defn register!
+(defn ^{:stratum 0} register!
   "Register a tool in a registry. Returns the tool ID."
   [registry tool]
   (core/register-tool registry tool))
 
-(defn unregister!
+(defn ^{:stratum 0} unregister!
   "Remove a tool from a registry. Returns the tool ID."
   [registry tool-id]
   (core/unregister-tool registry tool-id))
 
-(defn get-tool
+(defn ^{:stratum 0} get-tool
   "Retrieve a tool by ID from a registry.
    Returns nil if not found."
   [registry tool-id]
   (core/get-tool registry tool-id))
 
-(defn list-tools
+(defn ^{:stratum 0} list-tools
   "List all registered tools in a registry."
   [registry]
   (core/list-tools registry))
 
-(defn find-tools
+(defn ^{:stratum 0} find-tools
   "Find tools matching a query string.
    Searches tool names and descriptions."
   [registry query]
   (core/find-tools registry query))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Tool execution
-
-(defn execute
+(defn ^{:stratum 0} execute
   "Execute a tool directly.
 
    Arguments:
@@ -123,7 +117,7 @@
   [tool params context]
   (core/execute tool params context))
 
-(defn execute-by-id
+(defn ^{:stratum 0} execute-by-id
   "Execute a tool from a registry by ID.
 
    Arguments:
@@ -139,19 +133,18 @@
   (core/execute-tool registry tool-id params context))
 
 ;; Tool introspection
-
-(defn tool-id
+(defn ^{:stratum 0} tool-id
   "Get the ID of a tool."
   [tool]
   (core/tool-id tool))
 
-(defn tool-info
+(defn ^{:stratum 0} tool-info
   "Get information about a tool.
    Returns map with :id, :name, :description, :parameters, :metadata."
   [tool]
   (core/tool-info tool))
 
-(defn validate-args
+(defn ^{:stratum 0} validate-args
   "Validate arguments against tool schema.
    Returns {:valid? boolean :errors [...]}
    
@@ -160,7 +153,7 @@
   [tool args]
   (core/validate-args tool args))
 
-(defn get-schema
+(defn ^{:stratum 0} get-schema
   "Get the parameter schema for a tool.
    Returns the tool's parameter specification map.
    
@@ -171,31 +164,28 @@
   (core/get-schema tool))
 
 ;; Response helpers
-
-(defn success?
+(defn ^{:stratum 0} success?
   "Check if an execution result was successful."
   [result]
   (:success result))
 
-(defn get-result
+(defn ^{:stratum 0} get-result
   "Extract the result from a successful execution."
   [result]
   (:result result))
 
-(defn get-error
+(defn ^{:stratum 0} get-error
   "Extract error details from a failed execution."
   [result]
   (:error result))
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Invocation tracking
-
-(defn attach-invocation-tracking
+(defn ^{:stratum 0} attach-invocation-tracking
   "Attach tool invocation tracking to a context map."
   [context]
   (tracking/attach-invocation-tracking context))
 
-(defn tool-invocations
+(defn ^{:stratum 0} tool-invocations
   "Get tool invocation records from a context map."
   [context]
   (tracking/tool-invocations context))

--- a/components/tool/src/ai/miniforge/tool/messages.clj
+++ b/components/tool/src/ai/miniforge/tool/messages.clj
@@ -15,13 +15,14 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.tool.messages
   "Component-level message catalog for tool.
    Delegates to the shared messages component."
   (:require [ai.miniforge.messages.interface :as messages]))
 
-(def t
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} t
   "Look up a tool message by key, with optional param substitution."
   (messages/create-translator "config/tool/messages/en-US.edn"
                               :tool/messages))

--- a/components/tool/src/ai/miniforge/tool/tracking.clj
+++ b/components/tool/src/ai/miniforge/tool/tracking.clj
@@ -15,39 +15,19 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.tool.tracking
   "Tool invocation tracking helpers.")
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Invocation records
 
-(defn instant-from-ms
+;; Invocation records
+(defn ^{:stratum 0} instant-from-ms
   "Create an Instant from epoch millis."
   [millis]
   (java.time.Instant/ofEpochMilli millis))
 
-(defn build-invocation
-  "Build a tool invocation record from execution inputs and result."
-  [tool-id params start-ms end-ms result]
-  (let [duration (- end-ms start-ms)]
-    (cond-> {:tool/id tool-id
-             :tool/invoked-at (instant-from-ms start-ms)
-             :tool/duration-ms (max 0 duration)
-             :tool/args (or params {})}
-      (contains? result :result)
-      (assoc :tool/result (:result result))
-
-      (contains? result :exit-code)
-      (assoc :tool/exit-code (:exit-code result))
-
-      (contains? result :error)
-      (assoc :tool/error (:error result)))))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; Context helpers
-
-(defn attach-invocation-tracking
+(defn ^{:stratum 0} attach-invocation-tracking
   "Attach invocation tracking to a context map.
    Adds :tool/invocations (atom) and :tool/record-invocation when missing."
   [context]
@@ -63,7 +43,7 @@
                :tool/invocations store
                :tool/record-invocation record-fn)))))
 
-(defn tool-invocations
+(defn ^{:stratum 0} tool-invocations
   "Return tool invocations from a context map."
   [context]
   (let [store (:tool/invocations context)]
@@ -72,7 +52,7 @@
       (sequential? store) (vec store)
       :else [])))
 
-(defn record-invocation
+(defn ^{:stratum 0} record-invocation
   "Record a tool invocation using context if tracking is configured."
   [context invocation]
   (let [record-fn (:tool/record-invocation context)
@@ -86,6 +66,25 @@
 
       :else nil))
   invocation)
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} build-invocation
+  "Build a tool invocation record from execution inputs and result."
+  [tool-id params start-ms end-ms result]
+  (let [duration (- end-ms start-ms)]
+    (cond-> {:tool/id tool-id
+             :tool/invoked-at (instant-from-ms start-ms)
+             :tool/duration-ms (max 0 duration)
+             :tool/args (or params {})}
+      (contains? result :result)
+      (assoc :tool/result (:result result))
+
+      (contains? result :exit-code)
+      (assoc :tool/exit-code (:exit-code result))
+
+      (contains? result :error)
+      (assoc :tool/error (:error result)))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/tool/test/ai/miniforge/tool/anomaly_shape_test.clj
+++ b/components/tool/test/ai/miniforge/tool/anomaly_shape_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.tool.anomaly-shape-test
   "Lock the canonical anomaly shape produced by the tool component
    after the W2 anomaly convergence flip.
@@ -37,13 +36,15 @@
    [ai.miniforge.tool.interface :as tool]))
 
 ;------------------------------------------------------------------------------ Layer 0
+
 ;; Test factories + handler fixtures.
+(defn- ^{:stratum 0} echo-handler [params _ctx] (:message params))
 
-(defn- echo-handler [params _ctx] (:message params))
-(defn- throwing-handler [_params _ctx] (throw (ex-info "boom" {:why :test})))
-(defn- nil-message-throwing-handler [_params _ctx] (throw (Exception.)))
+(defn- ^{:stratum 0} throwing-handler [_params _ctx] (throw (ex-info "boom" {:why :test})))
 
-(defn- make-tool
+(defn- ^{:stratum 0} nil-message-throwing-handler [_params _ctx] (throw (Exception.)))
+
+(defn- ^{:stratum 0} make-tool
   "Factory for a `tool/create-tool` invocation. Always supplies the
    four-field map shape so each test only varies what it cares about."
   [{:keys [id description parameters handler]
@@ -54,10 +55,20 @@
                      :parameters  parameters
                      :handler     handler}))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Anomaly-shape tests, one per failure path.
+(deftest ^{:stratum 0} execute-tool-not-found-emits-not-found-anomaly
+  (testing "execute-tool on a missing tool yields :not-found anomaly"
+    (let [reg    (tool/create-registry)
+          result (tool/execute-by-id reg :tools/missing {} {})
+          a      (:anomaly result)]
+      (is (false? (:success result)))
+      (is (anomaly/anomaly? a))
+      (is (= :not-found (:anomaly/type a)))
+      (is (nil? (:anomaly/subtype a))))))
 
-(deftest execute-validation-error-emits-invalid-input-anomaly
+;------------------------------------------------------------------------------ Layer 1
+
+;; Anomaly-shape tests, one per failure path.
+(deftest ^{:stratum 1} execute-validation-error-emits-invalid-input-anomaly
   (testing "missing required parameter yields :invalid-input anomaly"
     (let [t      (make-tool {:id         :tools/echo
                              :parameters {:message {:type :string :required true}}
@@ -70,7 +81,7 @@
       (is (nil? (:anomaly/subtype a))
           "generic-standard incorrect has no domain subtype"))))
 
-(deftest execute-handler-exception-emits-fault-anomaly
+(deftest ^{:stratum 1} execute-handler-exception-emits-fault-anomaly
   (testing "handler exception yields :fault anomaly with provenance"
     (let [t      (make-tool {:id      :tools/throws
                              :handler throwing-handler})
@@ -82,7 +93,7 @@
       (is (nil? (:anomaly/subtype a)))
       (is (= "boom" (:anomaly/ex-message (:anomaly/data a)))))))
 
-(deftest execute-handler-nil-message-exception-falls-back-to-class-name
+(deftest ^{:stratum 1} execute-handler-nil-message-exception-falls-back-to-class-name
   (testing "handler throwing an exception with no message still yields a schema-valid anomaly"
     (let [t      (make-tool {:id      :tools/throws-blank
                              :handler nil-message-throwing-handler})
@@ -97,13 +108,3 @@
           "fallback is the exception class name")
       (is (= "java.lang.Exception" (get-in result [:error :message]))
           ":error :message stays consistent with the anomaly fallback"))))
-
-(deftest execute-tool-not-found-emits-not-found-anomaly
-  (testing "execute-tool on a missing tool yields :not-found anomaly"
-    (let [reg    (tool/create-registry)
-          result (tool/execute-by-id reg :tools/missing {} {})
-          a      (:anomaly result)]
-      (is (false? (:success result)))
-      (is (anomaly/anomaly? a))
-      (is (= :not-found (:anomaly/type a)))
-      (is (nil? (:anomaly/subtype a))))))

--- a/components/tool/test/ai/miniforge/tool/interface_test.clj
+++ b/components/tool/test/ai/miniforge/tool/interface_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.tool.interface-test
   (:require [clojure.test :as test :refer [deftest testing is]]
             [ai.miniforge.anomaly.interface :as anomaly]
@@ -23,47 +22,18 @@
             [ai.miniforge.event-stream.interface :as es]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Test fixtures
 
-(defn echo-handler [params _ctx]
+;; Test fixtures
+(defn ^{:stratum 0} echo-handler [params _ctx]
   (:message params))
 
-(defn add-handler [params _ctx]
+(defn ^{:stratum 0} add-handler [params _ctx]
   (+ (:a params) (:b params)))
 
-(defn throwing-handler [_params _ctx]
+(defn ^{:stratum 0} throwing-handler [_params _ctx]
   (throw (Exception. "Intentional error")))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Tool creation tests
-
-(deftest create-tool-test
-  (testing "creates tool with all options"
-    (let [tool (tool/create-tool
-                {:id :test/echo
-                 :name "Echo Tool"
-                 :description "Echoes the message"
-                 :parameters {:message {:type :string :required true}}
-                 :handler echo-handler
-                 :metadata {:version "1.0"}})]
-      (is (some? tool))
-      (is (= :test/echo (tool/tool-id tool)))))
-
-  (testing "creates tool with minimal options"
-    (let [tool (tool/create-tool
-                {:id :test/simple
-                 :handler (constantly :ok)})]
-      (is (some? tool))
-      (is (= :test/simple (tool/tool-id tool)))))
-
-  (testing "returns anomaly on non-namespaced id"
-    (let [result (tool/create-tool {:id :no-namespace
-                                    :handler (constantly :ok)})]
-      (is (anomaly/anomaly? result))
-      (is (= :invalid-input (:anomaly/type result)))
-      (is (= :no-namespace (get-in result [:anomaly/data :id]))))))
-
-(deftest tool-info-test
+(deftest ^{:stratum 0} tool-info-test
   (testing "returns tool information"
     (let [tool (tool/create-tool
                 {:id :test/info
@@ -80,8 +50,7 @@
       (is (= {:author "test"} (:metadata info))))))
 
 ;; Registry tests
-
-(deftest create-registry-test
+(deftest ^{:stratum 0} create-registry-test
   (testing "creates empty registry"
     (let [registry (tool/create-registry)]
       (is (some? registry))
@@ -91,7 +60,7 @@
     (let [registry (tool/create-registry {:logger nil})]
       (is (some? registry)))))
 
-(deftest register-tool-test
+(deftest ^{:stratum 0} register-tool-test
   (testing "registers a tool"
     (let [registry (tool/create-registry)
           my-tool (tool/create-tool {:id :test/registered
@@ -109,7 +78,7 @@
       (is (some? found))
       (is (= :test/retrieve (tool/tool-id found))))))
 
-(deftest unregister-tool-test
+(deftest ^{:stratum 0} unregister-tool-test
   (testing "unregisters a tool"
     (let [registry (tool/create-registry)
           my-tool (tool/create-tool {:id :test/remove
@@ -119,7 +88,7 @@
       (is (nil? (tool/get-tool registry :test/remove)))
       (is (empty? (tool/list-tools registry))))))
 
-(deftest find-tools-test
+(deftest ^{:stratum 0} find-tools-test
   (testing "finds tools by name"
     (let [registry (tool/create-registry)
           _ (tool/register! registry
@@ -167,9 +136,110 @@
       (is (empty? (tool/find-tools registry "malformed-metadata-token"))
           "malformed metadata is not stringified into searchable text"))))
 
-;; Execution tests
+(deftest ^{:stratum 0} execute-by-id-test
+  (testing "executes tool by id from registry"
+    (let [registry (tool/create-registry)
+          _ (tool/register! registry
+                            (tool/create-tool
+                             {:id :test/by-id
+                              :handler (fn [params _ctx] (* (:n params) 2))}))
+          result (tool/execute-by-id registry :test/by-id {:n 21} {})]
+      (is (tool/success? result))
+      (is (= 42 (tool/get-result result)))))
 
-(deftest execute-test
+  (testing "returns error for unknown tool"
+    (let [registry (tool/create-registry)
+          result (tool/execute-by-id registry :test/unknown {} {})]
+      (is (not (tool/success? result)))
+      (is (= :not-found (get-in (tool/get-error result) [:type]))))))
+
+;; Protocol method tests (N1 conformance)
+(deftest ^{:stratum 0} validate-args-test
+  (testing "validate-args protocol method works"
+    (let [my-tool (tool/create-tool
+                   {:id :test/validate
+                    :parameters {:x {:required true}
+                                 :y {:required false}}
+                    :handler (constantly nil)})
+          valid-result (tool/validate-args my-tool {:x 10 :y 20})
+          invalid-result (tool/validate-args my-tool {:y 20})]
+      (is (:valid? valid-result))
+      (is (not (:valid? invalid-result)))
+      (is (seq (:errors invalid-result)))))
+
+  (testing "validate-args with all required params"
+    (let [my-tool (tool/create-tool
+                   {:id :test/all-required
+                    :parameters {:a {:required true}
+                                 :b {:required true}}
+                    :handler (constantly nil)})
+          result (tool/validate-args my-tool {:a 1 :b 2})]
+      (is (:valid? result))
+      (is (empty? (:errors result))))))
+
+(deftest ^{:stratum 0} get-schema-test
+  (testing "get-schema protocol method returns parameters"
+    (let [params {:message {:type :string :required true}
+                  :count {:type :number :required false}}
+          my-tool (tool/create-tool
+                   {:id :test/schema
+                    :parameters params
+                    :handler (constantly nil)})
+          schema (tool/get-schema my-tool)]
+      (is (= params schema))))
+
+  (testing "get-schema returns empty map for parameterless tool"
+    (let [my-tool (tool/create-tool
+                   {:id :test/no-params
+                    :handler (constantly :ok)})
+          schema (tool/get-schema my-tool)]
+      (is (map? schema)))))
+
+;; Response helper tests
+(deftest ^{:stratum 0} response-helpers-test
+  (testing "success? returns true for successful result"
+    (is (tool/success? {:success true :result "ok"})))
+
+  (testing "success? returns false for failed result"
+    (is (not (tool/success? {:success false :error {:type "error"}}))))
+
+  (testing "get-result extracts result"
+    (is (= "value" (tool/get-result {:success true :result "value"}))))
+
+  (testing "get-error extracts error"
+    (is (= {:type "err"} (tool/get-error {:success false :error {:type "err"}})))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Tool creation tests
+(deftest ^{:stratum 1} create-tool-test
+  (testing "creates tool with all options"
+    (let [tool (tool/create-tool
+                {:id :test/echo
+                 :name "Echo Tool"
+                 :description "Echoes the message"
+                 :parameters {:message {:type :string :required true}}
+                 :handler echo-handler
+                 :metadata {:version "1.0"}})]
+      (is (some? tool))
+      (is (= :test/echo (tool/tool-id tool)))))
+
+  (testing "creates tool with minimal options"
+    (let [tool (tool/create-tool
+                {:id :test/simple
+                 :handler (constantly :ok)})]
+      (is (some? tool))
+      (is (= :test/simple (tool/tool-id tool)))))
+
+  (testing "returns anomaly on non-namespaced id"
+    (let [result (tool/create-tool {:id :no-namespace
+                                    :handler (constantly :ok)})]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (= :no-namespace (get-in result [:anomaly/data :id]))))))
+
+;; Execution tests
+(deftest ^{:stratum 1} execute-test
   (testing "executes tool successfully"
     (let [my-tool (tool/create-tool
                    {:id :test/exec
@@ -206,26 +276,8 @@
       (is (not (tool/success? result)))
       (is (= :execution-error (get-in (tool/get-error result) [:type]))))))
 
-(deftest execute-by-id-test
-  (testing "executes tool by id from registry"
-    (let [registry (tool/create-registry)
-          _ (tool/register! registry
-                            (tool/create-tool
-                             {:id :test/by-id
-                              :handler (fn [params _ctx] (* (:n params) 2))}))
-          result (tool/execute-by-id registry :test/by-id {:n 21} {})]
-      (is (tool/success? result))
-      (is (= 42 (tool/get-result result)))))
-
-  (testing "returns error for unknown tool"
-    (let [registry (tool/create-registry)
-          result (tool/execute-by-id registry :test/unknown {} {})]
-      (is (not (tool/success? result)))
-      (is (= :not-found (get-in (tool/get-error result) [:type]))))))
-
 ;; Invocation tracking tests
-
-(deftest invocation-tracking-test
+(deftest ^{:stratum 1} invocation-tracking-test
   (testing "records successful invocation"
     (let [context (tool/attach-invocation-tracking {})
           my-tool (tool/create-tool
@@ -254,67 +306,8 @@
       (is (= :test/track-error (:tool/id invocation)))
       (is (= :validation-error (get-in invocation [:tool/error :type]))))))
 
-;; Protocol method tests (N1 conformance)
-
-(deftest validate-args-test
-  (testing "validate-args protocol method works"
-    (let [my-tool (tool/create-tool
-                   {:id :test/validate
-                    :parameters {:x {:required true}
-                                 :y {:required false}}
-                    :handler (constantly nil)})
-          valid-result (tool/validate-args my-tool {:x 10 :y 20})
-          invalid-result (tool/validate-args my-tool {:y 20})]
-      (is (:valid? valid-result))
-      (is (not (:valid? invalid-result)))
-      (is (seq (:errors invalid-result)))))
-
-  (testing "validate-args with all required params"
-    (let [my-tool (tool/create-tool
-                   {:id :test/all-required
-                    :parameters {:a {:required true}
-                                 :b {:required true}}
-                    :handler (constantly nil)})
-          result (tool/validate-args my-tool {:a 1 :b 2})]
-      (is (:valid? result))
-      (is (empty? (:errors result))))))
-
-(deftest get-schema-test
-  (testing "get-schema protocol method returns parameters"
-    (let [params {:message {:type :string :required true}
-                  :count {:type :number :required false}}
-          my-tool (tool/create-tool
-                   {:id :test/schema
-                    :parameters params
-                    :handler (constantly nil)})
-          schema (tool/get-schema my-tool)]
-      (is (= params schema))))
-
-  (testing "get-schema returns empty map for parameterless tool"
-    (let [my-tool (tool/create-tool
-                   {:id :test/no-params
-                    :handler (constantly :ok)})
-          schema (tool/get-schema my-tool)]
-      (is (map? schema)))))
-
-;; Response helper tests
-
-(deftest response-helpers-test
-  (testing "success? returns true for successful result"
-    (is (tool/success? {:success true :result "ok"})))
-
-  (testing "success? returns false for failed result"
-    (is (not (tool/success? {:success false :error {:type "error"}}))))
-
-  (testing "get-result extracts result"
-    (is (= "value" (tool/get-result {:success true :result "value"}))))
-
-  (testing "get-error extracts error"
-    (is (= {:type "err"} (tool/get-error {:success false :error {:type "err"}})))))
-
 ;; Event emission wiring tests
-
-(deftest tool-emits-events-on-execution-test
+(deftest ^{:stratum 1} tool-emits-events-on-execution-test
   (testing "tool emits tool/invoked and tool/completed events when event-stream is in context"
     (let [stream (es/create-event-stream {:sinks []})
           wf-id (random-uuid)
@@ -331,7 +324,7 @@
       (is (some #(= :tool/invoked (:event/type %)) events))
       (is (some #(= :tool/completed (:event/type %)) events)))))
 
-(deftest tool-works-without-event-stream-test
+(deftest ^{:stratum 1} tool-works-without-event-stream-test
   (testing "tool executes normally without event-stream in context"
     (let [my-tool (tool/create-tool
                    {:id :test/no-stream

--- a/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-tool.md
+++ b/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-tool.md
@@ -1,0 +1,81 @@
+# fix: stratum-lint autofix for components/tool (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over `components/tool` (src + test) and commits
+the result: regenerated `;---- Layer N` headings and `^{:stratum n}`
+metadata on every top-level def, computed from each file's real same-file
+reference graph. No logic changed. One PR in the Wave 1 batch described in
+`work/stratum-lint-baseline-2026-07-24.md`.
+
+## Motivation
+
+The baseline audit found rule 210 (`standards/miniforge/languages/clojure.mdc`)
+had been cargo-culted into decorative section banners across most of the
+tree. `components/tool` carried exactly one finding — `SL003` in
+`interface.clj` (4 distinct layers against the budget of 3, from headings
+that didn't track real dependency depth) — and zero `SL001`
+upward-reference findings, meeting the baseline's criterion for safe
+mechanical autofix with no cycle/reasoning risk to check first.
+
+## Changes in Detail
+
+`stratum-lint --fix` (pinned sha `80699e378cb8ebbb6daeb928431aa4a6b373c07e`,
+read from `tasks/stratum.clj`) rewrote all 6 Clojure files in the
+component:
+
+- **src (4 files):** `core.clj`, `interface.clj`, `messages.clj`,
+  `tracking.clj`
+- **test (2 files):** `anomaly_shape_test.clj`, `interface_test.clj`
+
+`interface.clj`'s functions are thin wrappers delegating straight to
+`core`/`tracking` with no same-file references between them, so their real
+stratum collapsed to a single Layer 0 — the old 4-layer split was
+decorative. `core.clj` and `tracking.clj` picked up a genuine second
+(and, for `core.clj`, third) layer from real same-file calls (e.g.
+`tracking/build-invocation` depending on `instant-from-ms`), and both test
+files' `deftest` forms were regrouped by which helpers they actually call.
+
+## Testing Plan
+
+- `--fix` run twice in a row; second pass produced no rewrites (no
+  "rewrote" output) and a direct diff of all 6 files against the
+  first pass's output was empty — idempotency confirmed directly.
+- Read the full diff for every changed file. All changes are heading
+  regrouping, `^{:stratum n}` metadata, and def/deftest reordering. One
+  same-line trailing comment existed pre-fix (`core.clj`'s `tool-schema`);
+  checked it explicitly — it stayed attached to the same def, only
+  whitespace before it changed. No comment moved to a different def.
+- `clj-kondo --lint components/tool`: 0 errors, 0 warnings.
+- Plain (non-fix) lint after fixing: exit 0, no findings remain — the
+  original `SL003` resolved because the real dependency graph fits within
+  the 3-layer budget once headings track it honestly. No Wave 2 follow-up
+  needed for this component.
+- Ran the component's tests directly from the repo root classpath
+  (`clojure -M:test`, requiring `ai.miniforge.tool.interface-test` and
+  `ai.miniforge.tool.anomaly-shape-test`): 18 tests, 85 assertions, 0
+  failures, 0 errors.
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+changes — headings, metadata, and def order only. The pre-commit hook's
+`lint:stratum` autofixer keeps this component clean going forward.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+- No follow-on: post-fix lint reports zero remaining findings for this
+  component (no Wave 2 namespace split needed)
+
+## Checklist
+
+- [x] `--fix` run over the whole component (src + test)
+- [x] Idempotency verified directly (two `--fix` passes, zero diff)
+- [x] Diff reviewed file-by-file; mechanical-only (headings + metadata +
+      reorder); one pre-existing same-line comment checked, confirmed
+      correctly attached
+- [x] `clj-kondo` clean (0 errors, 0 warnings)
+- [x] Plain lint re-run post-fix: zero findings remain
+- [x] Tests pass: 18 tests, 85 assertions, 0 failures/errors
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
## Summary

- Runs `stratum-lint --fix` (pin `80699e378cb8ebbb6daeb928431aa4a6b373c07e`) over `components/tool` (src + test), fixing the component's one pre-existing finding: `SL003` in `interface.clj` (4 distinct layers against the 3-layer budget, from decorative headings that didn't track real dependency depth).
- Zero `SL001` (upward-reference/cycle) findings going in, per the baseline audit — no design risk to reason about before running the mechanical fixer.
- Mechanical only: heading regrouping, `^{:stratum n}` metadata, and def/deftest reordering. No logic changes.
- Idempotency verified directly: ran `--fix` twice, second pass produced zero rewrites and a byte-for-byte diff of all 6 files came back empty.
- Full diff read file-by-file. One same-line trailing comment existed pre-fix (`core.clj`'s `tool-schema`); confirmed it stayed attached to the correct def (only whitespace changed) — no comment misattachment to hand-fix.
- Post-fix plain lint: exit 0, zero findings remain. No Wave 2 namespace split needed for this component.
- `clj-kondo --lint components/tool`: 0 errors, 0 warnings.
- Tests: 18 tests, 85 assertions, 0 failures/errors (`ai.miniforge.tool.interface-test`, `ai.miniforge.tool.anomaly-shape-test`).
- Pre-commit hook's own autofix pass re-ran `--fix` at commit time with no further rewrites, and the full pre-commit smoke suite (331 tests / 1241 assertions) + GraalVM compat suite (8 tests / 545 assertions) passed.

PR doc: `docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-tool.md`. Part of the Wave 1 batch tracked in `work/stratum-lint-baseline-2026-07-24.md`.

## Test plan

- [x] `--fix` run over the whole component, idempotency verified (two passes, zero diff)
- [x] Full diff reviewed per file; mechanical-only, comment attachment checked
- [x] `clj-kondo` clean (0/0)
- [x] Plain lint post-fix: zero findings remain
- [x] Component tests pass (18 tests, 85 assertions)
- [x] Pre-commit hook ran clean, no `--no-verify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)