### PR TITLE
fix: stratum-lint autofix for components/connector-jira (Wave 1)

### DIFF
--- a/components/connector-jira/src/ai/miniforge/connector_jira/core.clj
+++ b/components/connector-jira/src/ai/miniforge/connector_jira/core.clj
@@ -15,13 +15,14 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-jira.core
   "JiraConnector defrecord — thin protocol wrapper delegating to impl."
   (:require [ai.miniforge.connector.interface :as connector]
             [ai.miniforge.connector-jira.impl :as impl]))
 
-(defrecord JiraConnector []
+;------------------------------------------------------------------------------ Layer 0
+
+(defrecord ^{:stratum 0} JiraConnector []
   connector/Connector
   (connect    [_ config auth]                      (impl/do-connect config auth))
   (close      [_ handle]                           (impl/do-close handle))

--- a/components/connector-jira/src/ai/miniforge/connector_jira/impl.clj
+++ b/components/connector-jira/src/ai/miniforge/connector_jira/impl.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-jira.impl
   "Implementation functions for the Jira Cloud REST API connector.
    Small composable functions organized in a stratified DAG."
@@ -28,24 +27,13 @@
             [ai.miniforge.response.interface :as response])
   (:import [java.util Base64 UUID]))
 
-;;------------------------------------------------------------------------------ Layer 0
+;------------------------------------------------------------------------------ Layer 0
+
 ;; Handle state
-
-(def ^:private handles (connector/create-handle-registry))
-
-(defn- store-handle! [handle state] (connector/store-handle! handles handle state))
-(defn- remove-handle! [handle] (connector/remove-handle! handles handle))
-(defn- touch-handle! [handle] (connector/touch-handle! handles handle))
-
-(defn- require-handle
-  "Retrieve handle state or return an anomaly."
-  [handle]
-  (connector/require-handle handles handle
-                            {:message (msg/t :jira/handle-not-found {:handle handle})}))
+(def ^{:stratum 0} ^:private handles (connector/create-handle-registry))
 
 ;; Auth — Jira Cloud uses Basic auth (email:api-token)
-
-(defn- build-auth-headers
+(defn- ^{:stratum 0} build-auth-headers
   "Build authorization headers for Jira Cloud.
    Basic auth: Base64(email:api-token)."
   [config {:auth/keys [credential-id]}]
@@ -56,14 +44,7 @@
      "Accept"        "application/json"
      "Content-Type"  "application/json"}))
 
-(defn- resolve-auth-headers
-  "Build auth headers from config + auth, defaulting to empty map."
-  [config auth]
-  (if (:auth/credential-id auth)
-    (build-auth-headers config auth)
-    {}))
-
-(defn- validate-auth
+(defn- ^{:stratum 0} validate-auth
   "Validate auth credential reference, returning a localized response anomaly on failure."
   [auth]
   (when-let [auth-anomaly (connector/validate-auth auth)]
@@ -72,7 +53,7 @@
                              (msg/t :jira/auth-invalid {:errors errors})
                              (:anomaly/data auth-anomaly)))))
 
-(defn- handle-anomaly->response
+(defn- ^{:stratum 0} handle-anomaly->response
   "Convert connector handle validation anomalies to the response anomaly shape
    expected by current connector protocol consumers."
   [handle-anomaly]
@@ -80,20 +61,14 @@
                          (:anomaly/message handle-anomaly)
                          (:anomaly/data handle-anomaly)))
 
-;;------------------------------------------------------------------------------ Layer 1
 ;; HTTP — Jira uses offset pagination (startAt + maxResults), not Link headers.
-
-(defn- error-response
+(defn- ^{:stratum 0} error-response
   [status resp]
   (http/error-response status resp
     {:rate-limited   (msg/t :jira/rate-limited)
      :request-failed (fn [s e] (msg/t :jira/request-failed {:status s :error e}))}))
 
-(defn- do-request
-  [url headers query-params]
-  (http/do-request url headers query-params error-response))
-
-(defn- require-resource!
+(defn- ^{:stratum 0} require-resource!
   "Look up resource def or throw."
   [schema-name]
   (or (resources/get-resource (keyword schema-name))
@@ -101,13 +76,43 @@
                                (msg/t :jira/resource-unknown {:resource schema-name})
                                {:resource schema-name})))
 
-(defn- timestamp-value
+(defn- ^{:stratum 0} timestamp-value
   [record]
   (or (:updated record)
       (get-in record [:fields :updated])
       (get-in record [:fields :created])))
 
-(defn- fetch-all-pages
+(defn ^{:stratum 0} do-checkpoint [cursor-state]
+  (connector/checkpoint-result cursor-state))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} store-handle! [handle state] (connector/store-handle! handles handle state))
+
+(defn- ^{:stratum 1} remove-handle! [handle] (connector/remove-handle! handles handle))
+
+(defn- ^{:stratum 1} touch-handle! [handle] (connector/touch-handle! handles handle))
+
+(defn- ^{:stratum 1} require-handle
+  "Retrieve handle state or return an anomaly."
+  [handle]
+  (connector/require-handle handles handle
+                            {:message (msg/t :jira/handle-not-found {:handle handle})}))
+
+(defn- ^{:stratum 1} resolve-auth-headers
+  "Build auth headers from config + auth, defaulting to empty map."
+  [config auth]
+  (if (:auth/credential-id auth)
+    (build-auth-headers config auth)
+    {}))
+
+(defn- ^{:stratum 1} do-request
+  [url headers query-params]
+  (http/do-request url headers query-params error-response))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- ^{:stratum 2} fetch-all-pages
   "Fetch all pages from a Jira endpoint using offset pagination.
    response-key is the JSON key containing the records array (e.g. :issues, :values)."
   [handle url headers query-params response-key]
@@ -124,10 +129,8 @@
         all-records
         (recur (count all-records) all-records)))))
 
-;;------------------------------------------------------------------------------ Layer 2
 ;; Lifecycle and source operations
-
-(defn do-connect
+(defn ^{:stratum 2} do-connect
   "Validate config at boundary, register handle."
   [config auth]
   (if-not (:jira/site config)
@@ -145,17 +148,19 @@
                                  :last-request-at nil})
           (connector/connect-result handle))))))
 
-(defn do-close [handle]
+(defn ^{:stratum 2} do-close [handle]
   (remove-handle! handle)
   (connector/close-result))
 
-(defn do-discover [handle]
+(defn ^{:stratum 2} do-discover [handle]
   (let [handle-state (require-handle handle)]
     (if (anomaly/anomaly? handle-state)
       (handle-anomaly->response handle-state)
       (connector/discover-result (resources/resource-schemas)))))
 
-(defn do-extract
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} do-extract
   "Extract records from a Jira Cloud API resource.
    Validates records at the API boundary — malformed records from
    the Jira API are filtered out before entering the pipeline."
@@ -174,6 +179,3 @@
             cursor       (when (= :timestamp-watermark (:cursor-type resource-def))
                            (http/max-timestamp-cursor timestamp-value records))]
         (connector/extract-result records cursor false)))))
-
-(defn do-checkpoint [cursor-state]
-  (connector/checkpoint-result cursor-state))

--- a/components/connector-jira/src/ai/miniforge/connector_jira/interface.clj
+++ b/components/connector-jira/src/ai/miniforge/connector_jira/interface.clj
@@ -15,29 +15,26 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-jira.interface
   "Public API for the Jira Cloud REST API connector component."
   (:require [ai.miniforge.connector-jira.core :as core]
             [ai.miniforge.connector-jira.schema :as schema]
             [ai.miniforge.connector.interface :as conn]))
 
-;;------------------------------------------------------------------------------ Layer 0
-;; Schemas (exported for consumers)
+;------------------------------------------------------------------------------ Layer 0
 
-(def JiraConfig
+;; Schemas (exported for consumers)
+(def ^{:stratum 0} JiraConfig
   "Malli schema for Jira connector configuration."
   schema/JiraConfig)
 
-;;------------------------------------------------------------------------------ Layer 1
 ;; Factory and metadata
-
-(defn create-jira-connector
+(defn ^{:stratum 0} create-jira-connector
   "Create a new JiraConnector instance."
   []
   (core/->JiraConnector))
 
-(def connector-metadata
+(def ^{:stratum 0} connector-metadata
   "Registration metadata for the Jira Cloud REST API connector."
   {:connector/name         "Jira Cloud REST API Connector"
    :connector/type         :source

--- a/components/connector-jira/src/ai/miniforge/connector_jira/messages.clj
+++ b/components/connector-jira/src/ai/miniforge/connector_jira/messages.clj
@@ -15,12 +15,13 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-jira.messages
   "Message catalog — delegates to ai.miniforge.messages."
   (:require [ai.miniforge.messages.interface :as messages]))
 
-(def t
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} t
   "Look up a message by key, with optional param substitution."
   (messages/create-translator "config/connector-jira/messages/en-US.edn"
                               :connector-jira/messages))

--- a/components/connector-jira/src/ai/miniforge/connector_jira/resources.clj
+++ b/components/connector-jira/src/ai/miniforge/connector_jira/resources.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-jira.resources
   "Jira Cloud REST API resource type registry and URL/param builders.
    Resource definitions are loaded from an EDN resource file at startup."
@@ -24,12 +23,43 @@
             [clojure.java.io :as io]
             [clojure.string :as str]))
 
-;;------------------------------------------------------------------------------ Layer 0
+;------------------------------------------------------------------------------ Layer 0
+
 ;; Resource loading
+(def ^{:stratum 0} ^:private resource-path "config/connector-jira/resources.edn")
 
-(def ^:private resource-path "config/connector-jira/resources.edn")
+;; URL and param builders
+(defn ^{:stratum 0} build-base-url
+  "Build the Jira Cloud base URL from config.
+   When :jira/cloud-id is present, uses the Atlassian API gateway — required for
+   scoped API tokens (tokens with explicit permission scopes).
+   Falls back to the classic site URL for classic (unscoped) API tokens."
+  [config]
+  (if-let [cloud-id (:jira/cloud-id config)]
+    (str "https://api.atlassian.com/ex/jira/" cloud-id)
+    (str "https://" (:jira/site config) ".atlassian.net")))
 
-(defn- load-resources []
+(defn ^{:stratum 0} build-url
+  "Build a Jira API URL by substituting path parameters."
+  [base-url resource-def config]
+  (str base-url
+       (-> (:endpoint resource-def)
+           (str/replace "{board_id}" (str (get config :jira/board-id "")))
+           (str/replace "{issue_key}" (str (get config :jira/issue-key ""))))))
+
+(defn- ^{:stratum 0} resolved-project-key
+  "Return :jira/project-key from config only if it is a real resolved value.
+   Treats nil, blank, and unresolved placeholders (${...}) as absent."
+  [config]
+  (let [pk (:jira/project-key config)]
+    (when (and (string? pk)
+               (not (str/blank? pk))
+               (not (str/starts-with? pk "${")))
+      pk)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} load-resources []
   (if-let [res (io/resource resource-path)]
     (edn/read-string (slurp res))
     (response/throw-anomaly! :anomalies/not-found
@@ -40,47 +70,7 @@
                               :classpath/resource resource-path
                               :config/resource resource-path})))
 
-(def jira-resources
-  "Registry of Jira Cloud REST API resource types, loaded from EDN."
-  (delay (load-resources)))
-
-(defn get-resource
-  "Look up a resource definition by key."
-  [resource-key]
-  (get @jira-resources resource-key))
-
-;;------------------------------------------------------------------------------ Layer 1
-;; URL and param builders
-
-(defn build-base-url
-  "Build the Jira Cloud base URL from config.
-   When :jira/cloud-id is present, uses the Atlassian API gateway — required for
-   scoped API tokens (tokens with explicit permission scopes).
-   Falls back to the classic site URL for classic (unscoped) API tokens."
-  [config]
-  (if-let [cloud-id (:jira/cloud-id config)]
-    (str "https://api.atlassian.com/ex/jira/" cloud-id)
-    (str "https://" (:jira/site config) ".atlassian.net")))
-
-(defn build-url
-  "Build a Jira API URL by substituting path parameters."
-  [base-url resource-def config]
-  (str base-url
-       (-> (:endpoint resource-def)
-           (str/replace "{board_id}" (str (get config :jira/board-id "")))
-           (str/replace "{issue_key}" (str (get config :jira/issue-key ""))))))
-
-(defn- resolved-project-key
-  "Return :jira/project-key from config only if it is a real resolved value.
-   Treats nil, blank, and unresolved placeholders (${...}) as absent."
-  [config]
-  (let [pk (:jira/project-key config)]
-    (when (and (string? pk)
-               (not (str/blank? pk))
-               (not (str/starts-with? pk "${")))
-      pk)))
-
-(defn build-query-params
+(defn ^{:stratum 1} build-query-params
   "Build query params for a Jira API request.
    For the issues resource, constructs JQL with optional project and cursor filters.
 
@@ -104,7 +94,20 @@
       ;; Other resources: no JQL
       params)))
 
-(defn resource-schemas
+;------------------------------------------------------------------------------ Layer 2
+
+(def ^{:stratum 2} jira-resources
+  "Registry of Jira Cloud REST API resource types, loaded from EDN."
+  (delay (load-resources)))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} get-resource
+  "Look up a resource definition by key."
+  [resource-key]
+  (get @jira-resources resource-key))
+
+(defn ^{:stratum 3} resource-schemas
   "Return discover-compatible schema list for all known Jira resources."
   []
   (mapv (fn [[k v]]

--- a/components/connector-jira/src/ai/miniforge/connector_jira/schema.clj
+++ b/components/connector-jira/src/ai/miniforge/connector_jira/schema.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-jira.schema
   "Malli schemas for the Jira connector.
 
@@ -26,10 +25,10 @@
             [malli.core :as m]
             [malli.error :as me]))
 
-;;------------------------------------------------------------------------------ Layer 0
-;; Config schemas (user → connector boundary)
+;------------------------------------------------------------------------------ Layer 0
 
-(def JiraConfig
+;; Config schemas (user → connector boundary)
+(def ^{:stratum 0} JiraConfig
   "Schema for Jira connector configuration.
    Requires :jira/site (the Atlassian subdomain, e.g. \"mycompany\")."
   [:map
@@ -40,10 +39,8 @@
    [:jira/email {:optional true} [:maybe string?]]
    [:jira/cloud-id {:optional true} [:maybe string?]]])
 
-;;------------------------------------------------------------------------------ Layer 1
 ;; API response schemas (Jira API → connector boundary)
-
-(def JiraIssue
+(def ^{:stratum 0} JiraIssue
   "Schema for a Jira issue record from /rest/api/3/search."
   [:map
    [:id string?]
@@ -54,27 +51,27 @@
              [:updated {:optional true} [:maybe string?]]
              [:created {:optional true} [:maybe string?]]]]])
 
-(def JiraProject
+(def ^{:stratum 0} JiraProject
   "Schema for a Jira project record from /rest/api/3/project/search."
   [:map
    [:id string?]
    [:key string?]
    [:name string?]])
 
-(def JiraBoard
+(def ^{:stratum 0} JiraBoard
   "Schema for a Jira board record from /rest/agile/1.0/board."
   [:map
    [:id int?]
    [:name string?]])
 
-(def JiraSprint
+(def ^{:stratum 0} JiraSprint
   "Schema for a Jira sprint record from the sprints endpoint."
   [:map
    [:id int?]
    [:name string?]
    [:state string?]])
 
-(def JiraComment
+(def ^{:stratum 0} JiraComment
   "Schema for a Jira comment record from issue comments endpoint."
   [:map
    [:id string?]
@@ -82,24 +79,15 @@
    [:created {:optional true} [:maybe string?]]
    [:updated {:optional true} [:maybe string?]]])
 
-(def JiraPaginatedResponse
+(def ^{:stratum 0} JiraPaginatedResponse
   "Schema for the offset-paginated response envelope."
   [:map
    [:startAt int?]
    [:maxResults int?]
    [:total int?]])
 
-(def ^:private resource->schema
-  {:issues   JiraIssue
-   :projects JiraProject
-   :boards   JiraBoard
-   :sprints  JiraSprint
-   :comments JiraComment})
-
-;;------------------------------------------------------------------------------ Layer 2
 ;; Validation
-
-(defn validate
+(defn ^{:stratum 0} validate
   "Validate value against schema."
   [schema value]
   (if (m/validate schema value)
@@ -107,7 +95,7 @@
     {:valid? false
      :errors (me/humanize (m/explain schema value))}))
 
-(defn validate!
+(defn ^{:stratum 0} validate!
   "Validate and throw on failure."
   [schema value]
   (when-not (m/validate schema value)
@@ -118,17 +106,30 @@
                               :value value}))
   value)
 
-(defn validate-response
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} ^:private resource->schema
+  {:issues   JiraIssue
+   :projects JiraProject
+   :boards   JiraBoard
+   :sprints  JiraSprint
+   :comments JiraComment})
+
+(defn ^{:stratum 1} validate-response
   "Validate a paginated response envelope. Returns {:valid? bool :errors ...}."
   [body]
   (validate JiraPaginatedResponse body))
 
-(defn record-schema
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} record-schema
   "Look up the record schema for a resource keyword, or nil."
   [resource-key]
   (get resource->schema resource-key))
 
-(defn validate-records
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} validate-records
   "Validate a batch of records against the schema for the given resource.
    Returns records unchanged if valid; logs and filters invalid records."
   [resource-key records]

--- a/components/connector-jira/test/ai/miniforge/connector_jira/anomaly/jira_anomaly_test.clj
+++ b/components/connector-jira/test/ai/miniforge/connector_jira/anomaly/jira_anomaly_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-jira.anomaly.jira-anomaly-test
   "Coverage for `impl/do-connect`, `impl/require-resource!`, and
    `schema/validate!` boundary escalation via `response/throw-anomaly!`."
@@ -26,12 +25,14 @@
             [ai.miniforge.connector-jira.schema :as schema])
   (:import (clojure.lang ExceptionInfo)))
 
-(deftest do-connect-missing-site-returns-anomaly
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} do-connect-missing-site-returns-anomaly
   (testing "config without :jira/site returns :anomalies/incorrect"
     (let [result (impl/do-connect {} nil)]
       (is (= :anomalies/incorrect (:anomaly/category result))))))
 
-(deftest require-resource-unknown-throws-anomaly
+(deftest ^{:stratum 0} require-resource-unknown-throws-anomaly
   (testing "looking up an unknown resource raises :anomalies/not-found"
     (try
       (@#'impl/require-resource! "totally-bogus-resource")
@@ -39,7 +40,7 @@
       (catch ExceptionInfo e
         (is (= :anomalies/not-found (:anomaly/category (ex-data e))))))))
 
-(deftest schema-validate-bang-failure-throws-anomaly
+(deftest ^{:stratum 0} schema-validate-bang-failure-throws-anomaly
   (testing "schema validation failure raises :anomalies/incorrect"
     (try
       (schema/validate! schema/JiraConfig {:jira/site 42})
@@ -49,7 +50,7 @@
         (is (= :invalid-config (:config/error (ex-data e))))
         (is (some? (:errors (ex-data e))))))))
 
-(deftest load-resources-missing-edn-throws-anomaly
+(deftest ^{:stratum 0} load-resources-missing-edn-throws-anomaly
   (testing "missing resource EDN raises :anomalies/not-found"
     (with-redefs [io/resource (constantly nil)]
       (try

--- a/components/connector-jira/test/ai/miniforge/connector_jira/impl_test.clj
+++ b/components/connector-jira/test/ai/miniforge/connector_jira/impl_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-jira.impl-test
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
@@ -25,10 +24,10 @@
             [ai.miniforge.response.interface :as response]
             [ai.miniforge.schema.interface :as schema]))
 
-;;------------------------------------------------------------------------------ Layer 0
-;; Resource registry tests
+;------------------------------------------------------------------------------ Layer 0
 
-(deftest resource-schemas-test
+;; Resource registry tests
+(deftest ^{:stratum 0} resource-schemas-test
   (testing "resource-schemas returns all known resources"
     (let [schemas (resources/resource-schemas)]
       (is (= 5 (count schemas)))
@@ -39,10 +38,8 @@
       (is (some #(= "sprints" (:schema/name %)) schemas))
       (is (some #(= "comments" (:schema/name %)) schemas)))))
 
-;;------------------------------------------------------------------------------ Layer 1
 ;; URL building tests
-
-(deftest build-base-url-test
+(deftest ^{:stratum 0} build-base-url-test
   (testing "builds classic site URL from :jira/site"
     (is (= "https://mycompany.atlassian.net"
            (resources/build-base-url {:jira/site "mycompany"}))))
@@ -51,7 +48,7 @@
     (is (= "https://api.atlassian.com/ex/jira/abc-123"
            (resources/build-base-url {:jira/site "mycompany" :jira/cloud-id "abc-123"})))))
 
-(deftest build-url-test
+(deftest ^{:stratum 0} build-url-test
   (testing "builds issues search URL"
     (let [resource-def (resources/get-resource :issues)
           url (resources/build-url "https://myco.atlassian.net" resource-def {})]
@@ -79,10 +76,8 @@
           url (resources/build-url "https://myco.atlassian.net" resource-def config)]
       (is (= "https://myco.atlassian.net/rest/api/3/issue/PROJ-123/comment" url)))))
 
-;;------------------------------------------------------------------------------ Layer 2
 ;; Query param building
-
-(deftest build-query-params-test
+(deftest ^{:stratum 0} build-query-params-test
   (testing "issues: includes JQL with project key and default fields"
     (let [resource-def (resources/get-resource :issues)
           params (resources/build-query-params resource-def nil {} {:jira/project-key "PROJ"})]
@@ -118,15 +113,13 @@
       (is (= 50 (get params "maxResults")))
       (is (nil? (get params "jql"))))))
 
-;;------------------------------------------------------------------------------ Layer 3
 ;; Connect / close lifecycle
-
-(deftest connect-validates-config-test
+(deftest ^{:stratum 0} connect-validates-config-test
   (testing "do-connect requires :jira/site"
     (let [result (impl/do-connect {} nil)]
       (is (= :anomalies/incorrect (:anomaly/category result))))))
 
-(deftest connect-close-lifecycle-test
+(deftest ^{:stratum 0} connect-close-lifecycle-test
   (testing "connect and close with valid config"
     (let [result (impl/do-connect {:jira/site "mycompany"} nil)]
       (is (= :connected (:connector/status result)))
@@ -134,17 +127,15 @@
       (let [close-result (impl/do-close (:connection/handle result))]
         (is (= :closed (:connector/status close-result)))))))
 
-(deftest discover-test
+(deftest ^{:stratum 0} discover-test
   (testing "discover returns all resources"
     (let [handle (:connection/handle (impl/do-connect {:jira/site "mycompany"} nil))
           result (impl/do-discover handle)]
       (is (= 5 (:discover/total-count result)))
       (impl/do-close handle))))
 
-;;------------------------------------------------------------------------------ Layer 4
 ;; Extract with mocked HTTP
-
-(deftest extract-issues-offset-pagination-test
+(deftest ^{:stratum 0} extract-issues-offset-pagination-test
   (testing "do-extract drains offset-paginated Jira responses"
     (let [handle (:connection/handle (impl/do-connect {:jira/site "test"
                                                        :jira/project-key "PROJ"} nil))
@@ -176,7 +167,7 @@
         (finally
           (impl/do-close handle))))))
 
-(deftest extract-projects-test
+(deftest ^{:stratum 0} extract-projects-test
   (testing "do-extract for projects uses :values response key"
     (let [handle (:connection/handle (impl/do-connect {:jira/site "test"} nil))]
       (try
@@ -193,7 +184,7 @@
         (finally
           (impl/do-close handle))))))
 
-(deftest extract-unknown-resource-test
+(deftest ^{:stratum 0} extract-unknown-resource-test
   (testing "do-extract throws for unknown resource"
     (let [handle (:connection/handle (impl/do-connect {:jira/site "test"} nil))]
       (try
@@ -201,16 +192,14 @@
         (finally
           (impl/do-close handle))))))
 
-(deftest checkpoint-test
+(deftest ^{:stratum 0} checkpoint-test
   (testing "checkpoint returns committed"
     (let [cursor {:cursor/type :timestamp-watermark :cursor/value "2026-01-01 00:00"}
           result (impl/do-checkpoint cursor)]
       (is (= :committed (:checkpoint/status result))))))
 
-;;------------------------------------------------------------------------------ Layer 5
 ;; Boundary schema validation
-
-(deftest config-schema-validation-test
+(deftest ^{:stratum 0} config-schema-validation-test
   (testing "valid config passes"
     (is (:valid? (jira-schema/validate jira-schema/JiraConfig
                                        {:jira/site "mycompany"
@@ -225,7 +214,7 @@
                                        {:jira/site "mycompany"
                                         :auth/method :basic})))))
 
-(deftest response-schema-validation-test
+(deftest ^{:stratum 0} response-schema-validation-test
   (testing "valid paginated response passes"
     (is (:valid? (jira-schema/validate-response
                   {:startAt 0 :maxResults 50 :total 100}))))
@@ -234,7 +223,7 @@
     (is (not (:valid? (jira-schema/validate-response
                        {:startAt 0 :maxResults 50}))))))
 
-(deftest issue-schema-validation-test
+(deftest ^{:stratum 0} issue-schema-validation-test
   (testing "valid issue passes"
     (is (:valid? (jira-schema/validate jira-schema/JiraIssue
                                        {:id "10001" :key "PROJ-1"
@@ -251,7 +240,7 @@
                                             {:key "PROJ-1"
                                              :fields {:summary "A bug"}}))))))
 
-(deftest validate-records-filters-invalid-test
+(deftest ^{:stratum 0} validate-records-filters-invalid-test
   (testing "valid records pass through"
     (let [records [{:id "1" :key "PROJ-1" :fields {:summary "ok"}}
                    {:id "2" :key "PROJ-2" :fields {:summary "also ok"}}]]
@@ -267,7 +256,7 @@
     (let [records [{:anything "goes"}]]
       (is (= 1 (count (jira-schema/validate-records :unknown records)))))))
 
-(deftest extract-filters-malformed-api-records-test
+(deftest ^{:stratum 0} extract-filters-malformed-api-records-test
   (testing "extract drops records that fail schema validation"
     (let [handle (:connection/handle (impl/do-connect {:jira/site "test"
                                                        :jira/project-key "PROJ"} nil))]
@@ -293,24 +282,22 @@
         (finally
           (impl/do-close handle))))))
 
-;;------------------------------------------------------------------------------ Layer 6
 ;; Migrated validation helpers — connector boundaries return anomalies.
-
-(deftest discover-returns-anomaly-on-unknown-handle-test
+(deftest ^{:stratum 0} discover-returns-anomaly-on-unknown-handle-test
   (testing "do-discover returns an anomaly with :handle when handle is missing"
     (let [result (impl/do-discover "no-such-handle")]
       (is (response/anomaly-map? result))
       (is (= :anomalies/not-found (:anomaly/category result)))
       (is (= "no-such-handle" (:handle result))))))
 
-(deftest extract-returns-anomaly-on-unknown-handle-test
+(deftest ^{:stratum 0} extract-returns-anomaly-on-unknown-handle-test
   (testing "do-extract returns an anomaly with :handle when handle is missing"
     (let [result (impl/do-extract "no-such-handle" "issues" {})]
       (is (response/anomaly-map? result))
       (is (= :anomalies/not-found (:anomaly/category result)))
       (is (= "no-such-handle" (:handle result))))))
 
-(deftest connect-rejects-malformed-auth-test
+(deftest ^{:stratum 0} connect-rejects-malformed-auth-test
   (testing "do-connect returns an anomaly when auth credential-ref is malformed"
     (let [result (impl/do-connect {:jira/site "mycompany"}
                                   {:auth/method :api-key
@@ -320,7 +307,7 @@
       (is (= :anomalies/incorrect (:anomaly/category result)))
       (is (some? (:errors result))))))
 
-(deftest connect-accepts-valid-auth-test
+(deftest ^{:stratum 0} connect-accepts-valid-auth-test
   (testing "do-connect succeeds when auth credential-ref validates"
     (let [result (impl/do-connect {:jira/site "mycompany"}
                                   {:auth/method        :api-key

--- a/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-connector-jira.md
+++ b/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-connector-jira.md
@@ -1,0 +1,119 @@
+# fix: stratum-lint autofix for components/connector-jira (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over the whole `connector-jira` component
+(`src` and `test`) to replace decorative `Layer N` section headings with
+headings that reflect each file's real same-file reference graph, and
+tags every `def`/`defn`/`defrecord`/`deftest` with `^{:stratum n}`
+metadata. Purely mechanical — no logic changes. One of the per-component
+Wave 1 PRs from `work/stratum-lint-baseline-2026-07-24.md`.
+
+## Motivation
+
+`work/stratum-lint-baseline-2026-07-24.md` found rule 210's `Layer N`
+heading convention (`standards/miniforge/languages/clojure.mdc`) cargo-culted
+across most of the codebase — headings repeated as visual section breaks
+instead of one heading per real abstraction stratum. `connector-jira`
+carried exactly 1 finding: `SL003` in `test/.../impl_test.clj` (7 nominal
+`Layer` headings, one per `deftest` group, versus a budget of 3) — and
+zero `SL001` (upward-reference) findings, which is why the baseline named
+it a Wave 1 target: no cycle/upward-call risk to reason about before
+running the mechanical fixer.
+
+## Changes in Detail
+
+Ran, after resetting the branch onto current `main` (pin `80699e378c` in
+`tasks/stratum.clj`):
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "80699e378cb8ebbb6daeb928431aa4a6b373c07e" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/connector-jira
+```
+
+All 8 `.clj` files rewritten (6 `src`, 2 `test`) — including files with
+zero prior findings; `--fix` normalizes those too. Diff stat: 8 files
+changed, 146 insertions(+), 153 deletions(-).
+
+- `core.clj`, `messages.clj` — single-def files, no reordering, just a
+  `Layer 0` heading and `^{:stratum 0}` metadata added.
+- `interface.clj` — 2 decorative headings (`Layer 0`/`Layer 1`) collapsed
+  to 1 real layer; the schema re-export and the factory/metadata defs
+  don't actually reference each other.
+- `schema.clj` — decorative 3-heading structure regrouped into the real
+  4-layer chain: schemas → `validate`/`validate!` (Layer 0) → `resource->schema`
+  registry + `validate-response` (Layer 1) → `record-schema` (Layer 2) →
+  `validate-records` (Layer 3).
+- `resources.clj` — regrouped into a real 4-layer chain:
+  `resource-path`/URL builders (Layer 0) → `load-resources`/`build-query-params`
+  (Layer 1) → `jira-resources` delay (Layer 2) → `get-resource`/`resource-schemas`
+  (Layer 3).
+- `impl.clj` — regrouped into a real 4-layer chain: boundary/auth
+  helpers + `do-checkpoint` (Layer 0) → handle-registry wrappers +
+  `do-request` (Layer 1) → `fetch-all-pages`/`do-connect`/`do-close`/`do-discover`
+  (Layer 2) → `do-extract` (Layer 3).
+- `test/anomaly/jira_anomaly_test.clj` — single decorative heading
+  collapsed to `Layer 0`, no reordering.
+- `test/impl_test.clj` — the file with the original finding: 7 decorative
+  per-`deftest`-group headings (`Layer 0`–`Layer 6`) collapsed to 1 real
+  layer (`deftest` forms don't reference each other); `deftest` order in
+  the file is unchanged.
+
+No same-line trailing comments existed in any of these 8 files before the
+fix (checked pre-fix content for `) ;` / `] ;` patterns), so the known
+same-line-trailing-comment reattachment issue does not apply here — no
+hand fix-up was needed.
+
+## Testing Plan
+
+1. **Idempotency**: ran `--fix` a second time over the whole component;
+   `diff -r` against a copy taken after the first pass showed zero diff.
+2. **Diff review**: read every changed file's full diff (not just
+   `--stat`). Confirmed the only changes are heading text, `^{:stratum n}`
+   metadata, and def/deftest reordering — no logic or assertion changes.
+3. **`clj-kondo --lint components/connector-jira`**: 0 errors, 0 warnings.
+4. **Plain (non-`--fix`) re-lint** after the fix:
+
+   ```bash
+   bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "80699e378cb8ebbb6daeb928431aa4a6b373c07e" :deps/root "clojure"}}}' -m stratum-lint.interface components/connector-jira
+   ```
+
+   3 `SL003` findings remain — **expected, out of scope for this PR**:
+   `impl.clj` (4 real layers), `resources.clj` (4 real layers), `schema.clj`
+   (4 real layers), all over the 3-layer budget. None of these 3 files
+   had any finding before this fix — their old, partially-honest 2-heading
+   structure under-reported real depth. `--fix`'s reference-graph inference
+   surfaced the true depth; the code's actual structure did not change.
+   All 3 need a real namespace split, tracked as Wave 2 work
+   (`work/stratum-lint-baseline-2026-07-24.md`). Zero `SL001`/`SL002`/`SL004`
+   remain.
+5. **Component tests**: `ai.miniforge.connector-jira.impl-test` and
+   `ai.miniforge.connector-jira.anomaly.jira-anomaly-test`, run via
+   `clojure -A:dev:test`. 24 tests, 71 assertions, 0 failures, 0 errors.
+
+## Deployment Plan
+
+Merges to `main` like any other component change. Comment/metadata/reorder
+only — no runtime behavior change, no migration. Committed with
+`MINIFORGE_STRATUM_BUDGET_MODE=warn` for the 3 pre-existing over-budget
+files this PR surfaces but doesn't create or worsen.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+- Follow-on: Wave 2 namespace splits for `impl.clj`, `resources.clj`,
+  `schema.clj` (all now `SL003`, 4 real layers each)
+- Same shape as other Wave 1 component PRs (e.g. #1461, #1462, #1463,
+  #1464, #1467)
+
+## Checklist
+
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Idempotency verified directly (two `--fix` passes, zero diff)
+- [x] Diff read in full for every changed file, not just `--stat`
+- [x] No same-line trailing comments existed pre-fix; no hand fix-up
+      needed
+- [x] `clj-kondo --lint` clean (0 errors, 0 warnings)
+- [x] Plain lint re-run post-fix: 3 expected `SL003` findings remain
+      (documented above, tracked as Wave 2); zero `SL001`/`SL002`/`SL004`
+- [x] Component test suite run: 24 tests / 71 assertions, 0 failures/errors
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
## Summary

Runs `stratum-lint --fix` over `components/connector-jira` (src + test) to replace decorative `Layer N` section headings with headings that reflect each file's real same-file reference graph, and tags every def/deftest with `^{:stratum n}` metadata. Mechanical only — no logic changes. One of the per-component Wave 1 PRs from `work/stratum-lint-baseline-2026-07-24.md`.

- Fixes the component's single pre-existing finding: `SL003` in `test/.../impl_test.clj` (7 decorative per-`deftest`-group `Layer` headings collapsed to 1 real layer). Zero `SL001` findings meant no cycle/upward-reference risk to reason about first.
- All 8 `.clj` files rewritten (6 src, 2 test) — `--fix` normalizes files with zero prior findings too.
- `resources.clj`, `schema.clj`, and `impl.clj` had zero prior findings under their old, under-reporting 2-heading structure, but `--fix`'s reference-graph inference revealed each is genuinely 4 real layers deep (over the 3-layer budget). This is real, pre-existing architectural depth surfaced by the fix, not created by it — tracked as Wave 2 (namespace split) work, not fixed here.
- No same-line trailing comments existed in any of these 8 files pre-fix, so the known same-line-trailing-comment reattachment issue did not apply — no hand fix-up was needed.

## Test plan

- [x] Idempotency verified directly: ran `--fix` a second time over the whole component, `diff -r` against a copy from the first pass showed zero diff.
- [x] Read every changed file's full diff (not `--stat`) — confirmed only heading text, `^{:stratum n}` metadata, and def/deftest reordering changed.
- [x] `clj-kondo --lint components/connector-jira`: 0 errors, 0 warnings.
- [x] Plain (non-`--fix`) re-lint after the fix: 3 `SL003` findings remain (`impl.clj`, `resources.clj`, `schema.clj`, each 4 real layers vs budget 3) — expected, Wave 2 scope. Zero `SL001`/`SL002`/`SL004`.
- [x] Component tests: `ai.miniforge.connector-jira.impl-test` + `ai.miniforge.connector-jira.anomaly.jira-anomaly-test` via `clojure -A:dev:test` — 24 tests, 71 assertions, 0 failures, 0 errors.
- [x] Committed with `MINIFORGE_STRATUM_BUDGET_MODE=warn` for the 3 pre-existing over-budget files this PR surfaces but doesn't create or worsen.

PR doc: `docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-connector-jira.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)