### PR TITLE
fix: declare transitive deps.edn dependencies for standalone component testing

### DIFF
--- a/components/config/deps.edn
+++ b/components/config/deps.edn
@@ -2,6 +2,7 @@
  :deps {org.clojure/clojure {:mvn/version "1.12.0"}
         ai.miniforge/messages {:local/root "../messages"}
         babashka/fs {:mvn/version "0.5.22"}
+        babashka/process {:mvn/version "0.5.22"}
         aero/aero {:mvn/version "1.1.6"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/policy-pack/deps.edn
+++ b/components/policy-pack/deps.edn
@@ -3,6 +3,7 @@
         ai.miniforge/coerce {:local/root "../coerce"}
         ai.miniforge/algorithms {:local/root "../algorithms"}
         ai.miniforge/config {:local/root "../config"}
+        ai.miniforge/knowledge {:local/root "../knowledge"}
         ai.miniforge/response {:local/root "../response"}
         ai.miniforge/schema {:local/root "../schema"}
         metosin/malli {:mvn/version "0.16.4"}}


### PR DESCRIPTION
## Summary
- `components/policy-pack/deps.edn` used `ai.miniforge.knowledge/interface` (loader.clj, for `make-pack-ref`/`validate-transitive-trust`) without declaring a `local/root` dependency on it.
- `components/config/deps.edn` similarly required `babashka.process` (config/user.clj) without declaring `babashka/process`.
- Both gaps were masked because the repo-root `deps.edn`'s `:dev`/`:test` aliases flatten every component's `src`/`test` as extra-paths, bypassing per-component dependency resolution. Any component transitively depending on policy-pack or config could not be tested standalone via its own deps.edn + `clojure -A:test`.
- Discovered while verifying `components/connector-linter` tests for #1479 (a stratum-lint mechanical fix); the underlying gap is pre-existing on main and unrelated to that PR.

## Test plan
- [x] `clojure -A:test -e "(require 'ai.miniforge.connector-linter.etl-test) (clojure.test/run-tests 'ai.miniforge.connector-linter.etl-test)"` from `components/connector-linter` now passes standalone (11 tests, 33 assertions, 0 failures).
- [x] policy-pack's own test suite (266 tests, 2549 assertions) passes standalone from `components/policy-pack`, except one pre-existing test that asserts a repo-root-relative file path exists — confirmed passing (9 tests, 394 assertions) when run from repo root, so it's a cwd artifact, not a regression.
- [x] compliance-scanner: 106 tests, 337 assertions, 0 failures, standalone.
- [x] gate: 103 of its tests pass standalone (validation-pipeline-test excluded — it hits a separate, pre-existing, unrelated missing dependency on `ai.miniforge/loop` in `components/gate/deps.edn`, confirmed present on main before this change; not fixed here to keep this PR scoped).
- [x] Root pre-commit hooks (poly check, lint, stratum-lint, full smoke suite) pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)