### PR TITLE
fix: gate/deps.edn missing local/root dep on ai.miniforge/loop

### DIFF
--- a/components/gate/deps.edn
+++ b/components/gate/deps.edn
@@ -2,6 +2,7 @@
  :deps {ai.miniforge/connector-linter {:local/root "../connector-linter"}
         ai.miniforge/event-stream {:local/root "../event-stream"}
         ai.miniforge/llm {:local/root "../llm"}
+        ai.miniforge/loop {:local/root "../loop"}
         ai.miniforge/messages {:local/root "../messages"}
         ai.miniforge/policy-pack {:local/root "../policy-pack"}
         ai.miniforge/repo-analyzer {:local/root "../repo-analyzer"}


### PR DESCRIPTION
## Summary
- `components/gate/test/ai/miniforge/gate/validation_pipeline_test.clj` requires `ai.miniforge.loop.{inner,gates,repair}`, but `components/gate/deps.edn` never declared a local/root dependency on `ai.miniforge/loop`.
- Masked by root-level `:dev`/`:test` classpath flattening; standalone `clojure -A:test` from `components/gate` failed with a `FileNotFoundException` for `ai/miniforge/loop/inner__init.class`.
- Same bug class as #1486 (missing local/root deps in `components/policy-pack/deps.edn` and `components/config/deps.edn`).

## Test plan
- [x] Reproduced the failure standalone from `components/gate` before the fix.
- [x] Added `ai.miniforge/loop {:local/root "../loop"}` to `components/gate/deps.edn`.
- [x] `validation_pipeline_test` passes standalone (9 tests, 25 assertions, 0 failures/errors).
- [x] Checked `components/loop/deps.edn` and its dependencies (`anomaly`, `clock`, `fsm`, `decision`, `logging`, `messages`, `response`) for a reference back to `ai.miniforge/gate` — none found, no circular dependency.
- [x] Root pre-commit smoke suite (331 tests) and GraalVM/Babashka compatibility suite still pass.
- [ ] Full `components/gate` test suite standalone — blocked by an unrelated, pre-existing gap: `components/policy-pack/deps.edn` is missing a local/root dep on `ai.miniforge/knowledge` (introduced in #1383), which breaks every gate test namespace that touches `ai.miniforge.gate.interface` (nearly all of them). Confirmed pre-existing on `main`, unrelated to this change. Flagged separately for its own fix/PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)