### PR TITLE
fix: stratum-lint autofix for components/patterns (Wave 1)

### DIFF
--- a/components/patterns/src/ai/miniforge/patterns/core.clj
+++ b/components/patterns/src/ai/miniforge/patterns/core.clj
@@ -15,45 +15,38 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.patterns.core
   "Centralized regex pattern registry.
 
    Named patterns for reuse across components. Each pattern has a
    descriptive name so its purpose is clear at the call site.")
 
-;;------------------------------------------------------------------------------ Layer 0
-;; Markdown / file-path extraction patterns
+;------------------------------------------------------------------------------ Layer 0
 
-(def md-heading-file-path
+;; Markdown / file-path extraction patterns
+(def ^{:stratum 0} md-heading-file-path
   #"#{1,4}\s+[`*]*([^\s`*]+\.\w{1,6})[`*]*")
 
-(def md-delimited-file-path
+(def ^{:stratum 0} md-delimited-file-path
   #"[`*]+([^\s`*]+\.\w{1,6})[`*]+")
 
-(def md-label-file-path
+(def ^{:stratum 0} md-label-file-path
   #"(?i)(?:file|path):\s*`?([^\s`]+\.\w{1,6})`?")
 
-(def md-code-block
+(def ^{:stratum 0} md-code-block
   #"```(?:(\w+)\n)?([^`]+)```")
 
-;;------------------------------------------------------------------------------ Layer 1
 ;; File extension patterns
-
-(def file-extension
+(def ^{:stratum 0} file-extension
   #"\.(\w+)$")
 
-;;------------------------------------------------------------------------------ Layer 2
 ;; EDN / structured content patterns
-
-(def edn-code-block
+(def ^{:stratum 0} edn-code-block
   #"```(?:clojure|edn)?\s*\n([\s\S]*?)\n```")
 
-(def inline-already-implemented
+(def ^{:stratum 0} inline-already-implemented
   #"\{:status\s+:already-implemented[^}]*\}")
 
-;;------------------------------------------------------------------------------ Layer 3
 ;; Rate-limit detection (canonical pattern — use this everywhere)
-
-(def rate-limit
+(def ^{:stratum 0} rate-limit
   #"(?i)you've hit your limit|rate.?limit|429|quota.?exceeded|resets \d+[ap]m")

--- a/components/patterns/src/ai/miniforge/patterns/interface.clj
+++ b/components/patterns/src/ai/miniforge/patterns/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.patterns.interface
   "Centralized, named regex patterns for reuse across components.
 
@@ -26,26 +25,31 @@
      (re-find patterns/rate-limit response-text)"
   (:require [ai.miniforge.patterns.core :as core]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; Markdown / file-path extraction
-(def md-heading-file-path
+(def ^{:stratum 0} md-heading-file-path
   "java.util.regex.Pattern matching a file path inside a markdown heading,
    e.g. `### path/to/file.clj` (1-4 leading #, optional ` or * wrapping).
    Capture group 1 holds the bare path. Use with re-find: returns
    [whole-match path] vector on a hit, nil on no match."
   core/md-heading-file-path)
-(def md-delimited-file-path
+
+(def ^{:stratum 0} md-delimited-file-path
   "java.util.regex.Pattern matching a file path wrapped in backticks or
    bold/italic asterisks, e.g. `` `path/to/file.clj` `` or `**path/to/file.clj**`.
    Capture group 1 holds the bare path. Use with re-find: returns
    [whole-match path] vector on a hit, nil on no match."
   core/md-delimited-file-path)
-(def md-label-file-path
+
+(def ^{:stratum 0} md-label-file-path
   "java.util.regex.Pattern (case-insensitive) matching a labelled file path,
    e.g. `File: path/to/file.clj` or `Path: path/to/file.clj` (optional
    backticks). Capture group 1 holds the bare path. Use with re-find:
    returns [whole-match path] vector on a hit, nil on no match."
   core/md-label-file-path)
-(def md-code-block
+
+(def ^{:stratum 0} md-code-block
   "java.util.regex.Pattern matching a fenced markdown code block:
    ```lang\\ncontent```. Capture group 1 holds the optional language tag
    (nil if absent), group 2 the block body. Use with re-find/re-seq:
@@ -53,20 +57,21 @@
   core/md-code-block)
 
 ;; File extensions
-(def file-extension
+(def ^{:stratum 0} file-extension
   "java.util.regex.Pattern matching a trailing file extension, e.g. `.clj`.
    Capture group 1 holds the extension without the dot. Use with re-find:
    returns [whole-match ext] vector on a hit, nil on no match."
   core/file-extension)
 
 ;; EDN / structured content
-(def edn-code-block
+(def ^{:stratum 0} edn-code-block
   "java.util.regex.Pattern matching a clojure/edn fenced code block
    (lang tag clojure, edn, or absent). Capture group 1 holds the block
    body. Use with re-find/re-seq: returns [whole-match body] vectors,
    nil/empty on no match."
   core/edn-code-block)
-(def inline-already-implemented
+
+(def ^{:stratum 0} inline-already-implemented
   "java.util.regex.Pattern matching an inline
    `{:status :already-implemented ...}` EDN map within free text. No capture
    groups. Use with re-find: returns the matched substring on a hit, nil on
@@ -74,7 +79,7 @@
   core/inline-already-implemented)
 
 ;; Rate-limit detection
-(def rate-limit
+(def ^{:stratum 0} rate-limit
   "Canonical java.util.regex.Pattern (case-insensitive) detecting
    rate-limit / quota messages in LLM or API responses (e.g. \"rate limit\",
    \"429\", \"quota exceeded\", \"resets 3pm\"). Use everywhere instead of

--- a/components/patterns/test/ai/miniforge/patterns/interface_test.clj
+++ b/components/patterns/test/ai/miniforge/patterns/interface_test.clj
@@ -15,33 +15,34 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.patterns.interface-test
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.patterns.interface :as patterns]))
 
-(deftest md-heading-file-path-test
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} md-heading-file-path-test
   (testing "matches file paths in markdown headings"
     (is (= "src/core.clj"
            (second (re-find patterns/md-heading-file-path "### src/core.clj"))))
     (is (= "path/to/file.js"
            (second (re-find patterns/md-heading-file-path "## `path/to/file.js`"))))))
 
-(deftest md-delimited-file-path-test
+(deftest ^{:stratum 0} md-delimited-file-path-test
   (testing "matches file paths in backticks or bold"
     (is (= "src/core.clj"
            (second (re-find patterns/md-delimited-file-path "`src/core.clj`"))))
     (is (= "path/to/file.js"
            (second (re-find patterns/md-delimited-file-path "**path/to/file.js**"))))))
 
-(deftest md-label-file-path-test
+(deftest ^{:stratum 0} md-label-file-path-test
   (testing "matches File: or Path: labels"
     (is (= "src/core.clj"
            (second (re-find patterns/md-label-file-path "File: src/core.clj"))))
     (is (= "path/to/file.js"
            (second (re-find patterns/md-label-file-path "Path: `path/to/file.js`"))))))
 
-(deftest rate-limit-test
+(deftest ^{:stratum 0} rate-limit-test
   (testing "detects rate-limit messages"
     (is (re-find patterns/rate-limit "Error 429: Too many requests"))
     (is (re-find patterns/rate-limit "You've hit your limit"))

--- a/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-patterns.md
+++ b/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-patterns.md
@@ -1,0 +1,80 @@
+# fix: stratum-lint autofix for components/patterns (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over `components/patterns` (src + test) and
+commits the result: regenerated `;---- Layer N` headings and
+`^{:stratum n}` metadata on every top-level def, computed from each
+file's real same-file reference graph. No logic changed. One component
+in the Wave 1 batch from `work/stratum-lint-baseline-2026-07-24.md`.
+
+## Motivation
+
+The baseline audit found `components/patterns/src/.../core.clj` tripping
+`SL003` (4 distinct layers under its old, decorative headings — over the
+3-layer budget from rule 210, `standards/miniforge/languages/clojure.mdc`)
+and zero `SL001` upward-reference findings — the criterion the baseline
+plan uses to mark a file safe for a mechanical autofix pass with no
+cycle/reasoning risk.
+
+## Changes in Detail
+
+Ran, pinned to the sha in `tasks/stratum.clj`
+(`80699e378cb8ebbb6daeb928431aa4a6b373c07e`):
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "80699e378cb8ebbb6daeb928431aa4a6b373c07e" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/patterns
+```
+
+All 3 files in the component were rewritten: `core.clj`, `interface.clj`,
+`test/.../interface_test.clj`. `core.clj`'s defs are a set of standalone
+regex literals with no same-file cross-references, so the real reference
+graph collapses its old 4 decorative headings (`Layer 0`-`3`, one per
+loose "section") to a single real `Layer 0` — the SL003 over-budget
+reading was itself decorative, not a genuine depth problem. No defs were
+reordered; only headings were merged and `^{:stratum 0}` metadata added
+throughout all three files.
+
+## Testing Plan
+
+1. Ran plain (non-`--fix`) `stratum-lint` before the fix — reproduced the
+   baseline's single finding exactly: `SL003` on `core.clj` ("file uses 4
+   distinct layers (max 3)"), zero `SL001`.
+2. Ran `--fix`, then read the full diff for all 3 changed files. Confirmed
+   heading merge and `^{:stratum n}` metadata only — no def reordering, no
+   comment relocation, license headers unchanged.
+3. Ran `--fix` a second time: zero output, zero diff against the first
+   pass — confirmed idempotent.
+4. Ran `clj-kondo` over `components/patterns`: 0 errors, 0 warnings.
+5. Re-ran plain `stratum-lint` after the fix: exit 0, no findings remain.
+   The prior `SL003` does not persist — the file's real stratum count is
+   1, not 4 — so there is no Wave 2 follow-on for this component.
+6. Ran `components/patterns/test/.../interface_test.clj` directly
+   (`clojure -M -e` requiring the namespace and invoking
+   `clojure.test/run-tests`): 4 tests, 9 assertions, 0 failures, 0 errors.
+
+## Deployment Plan
+
+Merges to `main` like any other component change. Comment/metadata/
+heading-only diff — no runtime behavior change, nothing to roll out
+beyond the merge. The pre-commit hook's `lint:stratum` autofixer keeps
+this component clean going forward.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1 —
+  mechanical relabeling via `--fix`, decorative-heading files only)
+- No Wave 2 follow-on: this component's `SL003` fully resolved by the
+  fix, no real over-budget file remains.
+
+## Checklist
+
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Full diff read for all 3 changed files; heading + metadata only, no
+      reordering, no comment relocation
+- [x] Idempotency verified: second `--fix` pass produced zero diff
+- [x] `clj-kondo` clean (0 errors, 0 warnings)
+- [x] Plain lint re-run post-fix: zero findings remain (no residual
+      `SL003`)
+- [x] Component test namespace run directly: 0 failures, 0 errors
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
## Summary

- Runs `stratum-lint --fix` over `components/patterns` (src + test), one component in the Wave 1 batch from `work/stratum-lint-baseline-2026-07-24.md`.
- Fixes the component's single pre-existing finding: `SL003` on `core.clj` ("file uses 4 distinct layers (max 3)"). Zero `SL001` findings going in, matching the baseline's Wave 1 safe-to-autofix criteria.
- `core.clj`'s defs are standalone regex literals with no same-file cross-references, so the real reference graph collapses the old 4 decorative headings to a single real `Layer 0` — the SL003 reading was itself decorative, not a genuine depth problem. No defs reordered; only headings merged and `^{:stratum n}` metadata added across all 3 changed files (`core.clj`, `interface.clj`, `test/.../interface_test.clj`).

## Testing Plan

- [x] Plain (non-`--fix`) lint before the fix reproduced the baseline's single finding exactly (`SL003`, 0 `SL001`).
- [x] `--fix` run, full diff read for all 3 changed files: heading + `^{:stratum n}` metadata only, no reordering, no comment relocation.
- [x] Idempotency verified: second `--fix` pass produced zero output and zero diff.
- [x] `clj-kondo --lint components/patterns`: 0 errors, 0 warnings.
- [x] Plain lint re-run post-fix: exit 0, no findings remain — no residual `SL003`, no Wave 2 follow-on needed for this component.
- [x] `interface_test.clj` run directly: 4 tests, 9 assertions, 0 failures, 0 errors.
- [x] Pre-commit hook (Polylith check, clj-kondo, stratum-lint, markdown format, full smoke-test suite, GraalVM/Babashka compat) ran clean at commit time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)