### PR TITLE
fix: stratum-lint autofix for components/bb-data-plane-http (Wave 1)

### DIFF
--- a/components/bb-data-plane-http/src/ai/miniforge/bb_data_plane_http/core.clj
+++ b/components/bb-data-plane-http/src/ai/miniforge/bb_data_plane_http/core.clj
@@ -15,13 +15,15 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.bb-data-plane-http.core
   "Implementation.
 
-   Layer 0: pure config resolution + URL/cmd builders.
-   Layer 1: lifecycle side effects (build, start, wait-ready, destroy).
-   Layer 2: HTTP helpers that take an injectable `:http-fn`."
+   Layer 0: pure resolution (`resolve-base-url`, `under-root`, cargo-cmd
+   building), `wait-ready!`/`destroy!`, and the injectable HTTP helpers —
+   no same-file dependencies.
+   Layer 1: `binary-path`/`manifest-path`, built on `under-root`.
+   Layer 2: `build!`/`start!` (process lifecycle), built on the Layer 1
+   path builders."
   (:require [ai.miniforge.anomaly.interface :as anomaly]
             [ai.miniforge.bb-paths.interface :as paths]
             [ai.miniforge.bb-proc.interface :as proc]
@@ -29,58 +31,32 @@
             [babashka.process :as p]
             [cheshire.core :as json]))
 
-(def ^:const default-base-url     "http://127.0.0.1:8787")
-(def ^:const default-base-url-env "THESIUM_DATA_PLANE_BASE_URL")
-
 ;------------------------------------------------------------------------------ Layer 0
-;; Pure resolution.
 
-(defn- under-root
+(def ^{:stratum 0} ^:const default-base-url     "http://127.0.0.1:8787")
+
+(def ^{:stratum 0} ^:const default-base-url-env "THESIUM_DATA_PLANE_BASE_URL")
+
+;; Pure resolution.
+(defn- ^{:stratum 0} under-root
   [root p]
   (cond
     (nil? p)                     nil
     (.startsWith ^String p "/")  p
     :else                        (str (or root (paths/repo-root)) "/" p)))
 
-(defn resolve-base-url
+(defn ^{:stratum 0} resolve-base-url
   [{:keys [base-url base-url-env]
     :or   {base-url     default-base-url
            base-url-env default-base-url-env}}]
   (or (System/getenv base-url-env) base-url))
 
-(defn binary-path
-  [{:keys [root binary]}]
-  (under-root root binary))
-
-(defn manifest-path
-  [{:keys [root manifest]}]
-  (under-root root manifest))
-
-(defn- build-cargo-cmd
+(defn- ^{:stratum 0} build-cargo-cmd
   [manifest quiet?]
   (cond-> ["cargo" "build" "--release" "--manifest-path" manifest]
     quiet? (conj "--quiet")))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Process lifecycle.
-
-(defn build!
-  [cfg {:keys [run-fn quiet?] :or {run-fn proc/run!}}]
-  (apply run-fn (build-cargo-cmd (manifest-path cfg) quiet?))
-  (binary-path cfg))
-
-(defn start!
-  [cfg {:keys [env state-dir state-dir-env log-path bg-fn]
-        :or   {bg-fn proc/run-bg!}}]
-  (let [env* (cond-> (or env {})
-               (and state-dir state-dir-env) (assoc state-dir-env state-dir))
-        opts (cond-> {}
-               (seq env*) (assoc :extra-env env*)
-               log-path   (assoc :out (java.io.File. ^String log-path)
-                                 :err (java.io.File. ^String log-path)))]
-    (bg-fn opts (binary-path cfg))))
-
-(defn wait-ready!
+(defn ^{:stratum 0} wait-ready!
   [health-url {:keys [max-attempts http-fn sleep-fn proc-handle]
                :or   {max-attempts 60
                       http-fn      #(http/get % {:throw false :timeout 1000})
@@ -102,21 +78,20 @@
                                                     :health-url health-url})
         :else                     (do (sleep-fn) (recur (inc attempt)))))))
 
-(defn destroy!
+(defn ^{:stratum 0} destroy!
   [proc]
   (proc/destroy! proc))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; HTTP helpers.
+(defn- ^{:stratum 0} default-http-get  [url]      (http/get  url {:throw false}))
 
-(defn- default-http-get  [url]      (http/get  url {:throw false}))
-(defn- default-http-post [url opts] (http/post url opts))
+(defn- ^{:stratum 0} default-http-post [url opts] (http/post url opts))
 
-(defn http-get-body
+(defn ^{:stratum 0} http-get-body
   [url {:keys [http-fn] :or {http-fn default-http-get}}]
   (:body (http-fn url)))
 
-(defn http-get-json
+(defn ^{:stratum 0} http-get-json
   [url {:keys [http-fn] :or {http-fn default-http-get}}]
   (try
     (let [resp (http-fn url)]
@@ -131,7 +106,7 @@
                                  {:url url}
                                  e))))
 
-(defn http-post-json
+(defn ^{:stratum 0} http-post-json
   [url body-map {:keys [http-fn] :or {http-fn default-http-post}}]
   (try
     (let [resp (http-fn url
@@ -148,6 +123,35 @@
                                  (str "POST " url " failed")
                                  {:url url}
                                  e))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} binary-path
+  [{:keys [root binary]}]
+  (under-root root binary))
+
+(defn ^{:stratum 1} manifest-path
+  [{:keys [root manifest]}]
+  (under-root root manifest))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Process lifecycle.
+(defn ^{:stratum 2} build!
+  [cfg {:keys [run-fn quiet?] :or {run-fn proc/run!}}]
+  (apply run-fn (build-cargo-cmd (manifest-path cfg) quiet?))
+  (binary-path cfg))
+
+(defn ^{:stratum 2} start!
+  [cfg {:keys [env state-dir state-dir-env log-path bg-fn]
+        :or   {bg-fn proc/run-bg!}}]
+  (let [env* (cond-> (or env {})
+               (and state-dir state-dir-env) (assoc state-dir-env state-dir))
+        opts (cond-> {}
+               (seq env*) (assoc :extra-env env*)
+               log-path   (assoc :out (java.io.File. ^String log-path)
+                                 :err (java.io.File. ^String log-path)))]
+    (bg-fn opts (binary-path cfg))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/bb-data-plane-http/src/ai/miniforge/bb_data_plane_http/interface.clj
+++ b/components/bb-data-plane-http/src/ai/miniforge/bb_data_plane_http/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.bb-data-plane-http.interface
   "Primitives for a Rust-backed Thesium-style data plane: cargo
    build/start/wait-ready/destroy lifecycle + generic HTTP helpers.
@@ -26,45 +25,43 @@
   (:require [ai.miniforge.bb-data-plane-http.core :as core]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Config resolution
 
-(defn resolve-base-url
+;; Config resolution
+(defn ^{:stratum 0} resolve-base-url
   "Return the base URL for the data plane. Honors the env var named in
    `:base-url-env` (default `THESIUM_DATA_PLANE_BASE_URL`), falling back
    to `:base-url` (default `http://127.0.0.1:8787`)."
   [cfg]
   (core/resolve-base-url cfg))
 
-(defn binary-path
+(defn ^{:stratum 0} binary-path
   "Return the absolute path of the data-plane binary for `cfg`.
    `cfg` = {:binary relative-path :root absolute-path-or-nil}."
   [cfg]
   (core/binary-path cfg))
 
-(defn manifest-path
+(defn ^{:stratum 0} manifest-path
   "Return the absolute path of the Cargo manifest for `cfg`.
    `cfg` = {:manifest relative-path :root absolute-path-or-nil}."
   [cfg]
   (core/manifest-path cfg))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Process lifecycle
-
-(defn build!
+(defn ^{:stratum 0} build!
   "Cargo-build the data plane in release mode. Returns the binary path.
    `cfg` per `binary-path`/`manifest-path`. `opts` may include
    `:run-fn`, `:quiet?`."
   ([cfg]      (core/build! cfg {}))
   ([cfg opts] (core/build! cfg opts)))
 
-(defn start!
+(defn ^{:stratum 0} start!
   "Spawn the data plane in the background. Returns the process handle.
    `opts`: `:env` (extra env map), `:state-dir`, `:state-dir-env`,
    `:log-path`, `:bg-fn`."
   ([cfg]      (core/start! cfg {}))
   ([cfg opts] (core/start! cfg opts)))
 
-(defn wait-ready!
+(defn ^{:stratum 0} wait-ready!
   "Poll `health-url` until it responds (< 500) or attempts exhausted.
    Returns `:ready` on success or an anomaly on exhaustion or early
    process death.
@@ -73,26 +70,24 @@
   ([health-url]      (core/wait-ready! health-url {}))
   ([health-url opts] (core/wait-ready! health-url opts)))
 
-(defn destroy!
+(defn ^{:stratum 0} destroy!
   "Tear down a running process handle (pass-through to bb-proc)."
   [proc]
   (core/destroy! proc))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Generic HTTP helpers
-
-(defn http-get-body
+(defn ^{:stratum 0} http-get-body
   "GET `url`; return raw body string (or nil on error). `opts`: `:http-fn`."
   ([url]      (core/http-get-body url {}))
   ([url opts] (core/http-get-body url opts)))
 
-(defn http-get-json
+(defn ^{:stratum 0} http-get-json
   "GET `url`; parse JSON body into keywordized map. Returns an anomaly
    on non-200. `opts`: `:http-fn`."
   ([url]      (core/http-get-json url {}))
   ([url opts] (core/http-get-json url opts)))
 
-(defn http-post-json
+(defn ^{:stratum 0} http-post-json
   "POST `url` with `body-map` as JSON. Parse response JSON.
    Returns an anomaly on non-200. `opts`: `:http-fn`."
   ([url body-map]      (core/http-post-json url body-map {}))

--- a/components/bb-data-plane-http/test/ai/miniforge/bb_data_plane_http/core_test.clj
+++ b/components/bb-data-plane-http/test/ai/miniforge/bb_data_plane_http/core_test.clj
@@ -15,23 +15,23 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.bb-data-plane-http.core-test
-  "Layer 0 + Layer 2 tested here. Layer 1 (process lifecycle) is exercised
-   by consumer repos running `bb test:signals:fixtures` or equivalent."
+  "Exercises core's resolution and HTTP-helper layers. Process lifecycle
+   (`build!`/`start!`) is exercised by consumer repos running
+   `bb test:signals:fixtures` or equivalent."
   (:require [ai.miniforge.anomaly.interface :as anomaly]
             [babashka.process :as p]
             [clojure.test :refer [deftest testing is]]
             [ai.miniforge.bb-data-plane-http.core :as sut]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Base-URL resolution.
 
-(deftest test-resolve-base-url-falls-back-to-default
+;; Base-URL resolution.
+(deftest ^{:stratum 0} test-resolve-base-url-falls-back-to-default
   (testing "given an empty cfg → default URL"
     (is (= "http://127.0.0.1:8787" (sut/resolve-base-url {})))))
 
-(deftest test-resolve-base-url-honors-explicit-cfg
+(deftest ^{:stratum 0} test-resolve-base-url-honors-explicit-cfg
   (testing "given :base-url in cfg → returned as-is when env unset"
     ;; We can't easily set/unset env in JVM tests; rely on a var that
     ;; we know is unset (long random name) for the env-var slot.
@@ -40,37 +40,35 @@
             {:base-url "http://other:9000"
              :base-url-env "UNLIKELY_TO_EXIST_ENV_VAR_NAME_12345"})))))
 
-(deftest test-binary-path-resolves-relative
+(deftest ^{:stratum 0} test-binary-path-resolves-relative
   (testing "given :root + :binary → joined path"
     (is (= "/tmp/root/bin/dp"
            (sut/binary-path {:root "/tmp/root" :binary "bin/dp"})))))
 
-(deftest test-binary-path-honors-absolute
+(deftest ^{:stratum 0} test-binary-path-honors-absolute
   (testing "given absolute :binary → returned as-is"
     (is (= "/abs/bin/dp"
            (sut/binary-path {:root "/tmp/root" :binary "/abs/bin/dp"})))))
 
-(deftest test-manifest-path-resolves-relative
+(deftest ^{:stratum 0} test-manifest-path-resolves-relative
   (testing "given :root + :manifest → joined path"
     (is (= "/tmp/root/Cargo.toml"
            (sut/manifest-path {:root "/tmp/root" :manifest "Cargo.toml"})))))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; HTTP helpers.
-
-(deftest test-http-get-body-returns-body
+(deftest ^{:stratum 0} test-http-get-body-returns-body
   (testing "given http-fn returning {:body 'x'} → 'x'"
     (is (= "raw-bytes"
            (sut/http-get-body "http://example"
                               {:http-fn (fn [_] {:status 200 :body "raw-bytes"})})))))
 
-(deftest test-http-get-json-parses-on-200
+(deftest ^{:stratum 0} test-http-get-json-parses-on-200
   (testing "given 200 response with JSON body → keywordized parsed map"
     (is (= {:a 1 :b "c"}
            (sut/http-get-json "http://example"
                               {:http-fn (fn [_] {:status 200 :body "{\"a\":1,\"b\":\"c\"}"})})))))
 
-(deftest test-http-get-json-returns-anomaly-on-non-200
+(deftest ^{:stratum 0} test-http-get-json-returns-anomaly-on-non-200
   (testing "given 500 response → anomaly"
     (let [result (sut/http-get-json "http://example"
                                     {:http-fn (fn [_] {:status 500 :body "err"})})]
@@ -78,7 +76,7 @@
       (is (= :fault (:anomaly/type result)))
       (is (= {:status 500 :body "err"} (:anomaly/data result))))))
 
-(deftest test-http-get-json-returns-anomaly-on-invalid-json
+(deftest ^{:stratum 0} test-http-get-json-returns-anomaly-on-invalid-json
   (testing "given 200 response with invalid JSON → anomaly"
     (let [result (sut/http-get-json "http://example"
                                     {:http-fn (fn [_] {:status 200 :body "{bad"})})]
@@ -88,7 +86,7 @@
       (is (= "com.fasterxml.jackson.core.JsonParseException"
              (get-in result [:anomaly/data :anomaly/ex-class]))))))
 
-(deftest test-http-get-json-returns-anomaly-on-transport-error
+(deftest ^{:stratum 0} test-http-get-json-returns-anomaly-on-transport-error
   (testing "given http-fn that throws → anomaly"
     (let [result (sut/http-get-json "http://example"
                                     {:http-fn (fn [_] (throw (Exception. "offline")))})]
@@ -96,7 +94,7 @@
       (is (= :fault (:anomaly/type result)))
       (is (= "offline" (get-in result [:anomaly/data :anomaly/ex-message]))))))
 
-(deftest test-http-post-json-sends-body-and-parses
+(deftest ^{:stratum 0} test-http-post-json-sends-body-and-parses
   (testing "given http-fn capturing args → body serialized, response parsed"
     (let [captured (atom nil)
           http    (fn [url opts]
@@ -111,7 +109,7 @@
       (is (= "{\"scenario\":\"live\"}"
              (get-in @captured [:opts :body]))))))
 
-(deftest test-http-post-json-returns-anomaly-on-non-200
+(deftest ^{:stratum 0} test-http-post-json-returns-anomaly-on-non-200
   (testing "given 400 response → anomaly"
     (let [result (sut/http-post-json "http://example" {}
                                      {:http-fn (fn [_ _] {:status 400 :body "bad"})})]
@@ -119,7 +117,7 @@
       (is (= :fault (:anomaly/type result)))
       (is (= {:status 400 :body "bad"} (:anomaly/data result))))))
 
-(deftest test-http-post-json-returns-anomaly-on-invalid-json
+(deftest ^{:stratum 0} test-http-post-json-returns-anomaly-on-invalid-json
   (testing "given 200 response with invalid JSON → anomaly"
     (let [result (sut/http-post-json "http://example" {:scenario "live"}
                                      {:http-fn (fn [_ _] {:status 200 :body "{bad"})})]
@@ -129,7 +127,7 @@
       (is (= "com.fasterxml.jackson.core.JsonParseException"
              (get-in result [:anomaly/data :anomaly/ex-class]))))))
 
-(deftest test-http-post-json-returns-anomaly-on-transport-error
+(deftest ^{:stratum 0} test-http-post-json-returns-anomaly-on-transport-error
   (testing "given http-fn that throws → anomaly"
     (let [result (sut/http-post-json "http://example" {:scenario "live"}
                                      {:http-fn (fn [_ _] (throw (Exception. "offline")))})]
@@ -139,8 +137,7 @@
 
 ;------------------------------------------------------------------------------ wait-ready!
 ;; Uses injected http + sleep so it's deterministic.
-
-(deftest test-wait-ready-returns-ready-on-first-success
+(deftest ^{:stratum 0} test-wait-ready-returns-ready-on-first-success
   (testing "given http-fn returning 200 on first call → :ready"
     (is (= :ready
            (sut/wait-ready! "http://example"
@@ -148,7 +145,7 @@
                              :sleep-fn (fn [] nil)
                              :max-attempts 1})))))
 
-(deftest test-wait-ready-exhausts-attempts
+(deftest ^{:stratum 0} test-wait-ready-exhausts-attempts
   (testing "given http-fn that always fails → anomaly with :attempts"
     (let [result (sut/wait-ready! "http://example"
                                   {:http-fn (fn [_] (throw (Exception. "nope")))
@@ -158,7 +155,7 @@
       (is (= :fault (:anomaly/type result)))
       (is (= 3 (get-in result [:anomaly/data :attempts]))))))
 
-(deftest test-wait-ready-reports-process-death
+(deftest ^{:stratum 0} test-wait-ready-reports-process-death
   (testing "given a dead process handle before readiness → anomaly"
     (with-redefs [p/alive? (constantly false)]
       (let [result (sut/wait-ready! "http://example"

--- a/components/bb-data-plane-http/test/ai/miniforge/bb_data_plane_http/core_test.clj
+++ b/components/bb-data-plane-http/test/ai/miniforge/bb_data_plane_http/core_test.clj
@@ -16,9 +16,9 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns ai.miniforge.bb-data-plane-http.core-test
-  "Exercises core's resolution and HTTP-helper layers. Process lifecycle
-   (`build!`/`start!`) is exercised by consumer repos running
-   `bb test:signals:fixtures` or equivalent."
+  "Exercises core's pure helpers: base-URL resolution, path builders, HTTP
+   helpers, and `wait-ready!`. Process lifecycle (`build!`/`start!`) is exercised
+   by consumer repos running `bb test:signals:fixtures` or equivalent."
   (:require [ai.miniforge.anomaly.interface :as anomaly]
             [babashka.process :as p]
             [clojure.test :refer [deftest testing is]]

--- a/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-bb-data-plane-http.md
+++ b/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-bb-data-plane-http.md
@@ -1,0 +1,103 @@
+# fix: stratum-lint autofix for components/bb-data-plane-http (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over `components/bb-data-plane-http` (`src` +
+`test`) to replace two pre-heading `def`s with real `Layer N` headings and
+`^{:stratum n}` metadata derived from the file's actual same-file
+reference graph. Mechanical, plus a hand-fix of two now-stale `Layer N`
+claims left in ns docstrings by the fixer (see below). One of the smaller
+per-component Wave 1 PRs from `work/stratum-lint-baseline-2026-07-24.md`.
+
+## Motivation
+
+`bb-data-plane-http` carried exactly two findings under the baseline's
+cargo-cult diagnosis, both `SL004` on `core.clj`: `default-base-url` and
+`default-base-url-env` sat above the file's first `Layer` heading. Zero
+`SL001` findings, so no upward-reference/cycle risk to reason about before
+running the mechanical fixer — matches the Wave 1 batch criteria exactly.
+
+## Changes in Detail
+
+Ran, over the whole component:
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "80699e378cb8ebbb6daeb928431aa4a6b373c07e" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/bb-data-plane-http
+```
+
+3 files rewritten: `core.clj`, `interface.clj` (both `src`), and
+`core_test.clj` (`test`) — `--fix` normalizes every file in the component,
+not just the two files with findings.
+
+`core.clj`'s real reference graph split into 3 layers, different from what
+its old (honest-looking, but wrong) headings claimed: Layer 0 is
+`resolve-base-url`/`under-root`/`build-cargo-cmd`/`wait-ready!`/`destroy!`/
+the HTTP helpers (no same-file deps); Layer 1 is `binary-path`/
+`manifest-path` (both call `under-root`); Layer 2 is `build!`/`start!` (the
+process lifecycle, calling the Layer 1 path builders and `build-cargo-cmd`).
+The old headings had labeled these groups Layer 0 (config + builders),
+Layer 1 (lifecycle), Layer 2 (HTTP) — same three buckets, wrong contents
+and wrong order relative to the real dependency direction.
+
+`interface.clj` collapsed to a single Layer 0: every def here is a
+thin pass-through to `core`, so none has a same-file dependency on another
+def in this file. `core_test.clj` likewise collapsed to Layer 0 throughout
+— `deftest` bodies call `sut/...` (a different namespace), not each other.
+No line of executable code changed in any of the three; diffs are heading
+text, metadata, and def/deftest reordering only.
+
+**Hand-fix beyond the tool's own patch:** both `core.clj`'s and
+`core_test.clj`'s namespace docstrings stated the old (wrong) per-layer
+breakdown in prose — not a comment banner, but the same root problem as
+the documented "stale decorative banner" tool limitation: `--fix`
+recomputes headings and metadata, but has no way to know a docstring is
+describing them too, so it left both untouched and now-false. Reworded
+both to match the real layering (see diffs) rather than deleting the
+content — it carries real information (which layer does what) that a
+bare `Layer N` heading doesn't. Re-ran `--fix` a third time afterward:
+zero diff, confirms the manual wording change didn't disturb anything the
+tool manages.
+
+## Testing Plan
+
+1. Ran plain (non-`--fix`) `stratum-lint` before the fix — reproduced the
+   baseline's two `SL004` findings exactly.
+2. Ran `--fix`, then a second `--fix` pass immediately after — zero diff,
+   confirms idempotency.
+3. Read the full diff for all 3 changed files. Confirmed no same-line
+   trailing comment was displaced onto the wrong def (this component has
+   none — all comments were already own-line). Found the stale-docstring
+   issue described above, hand-fixed it, then re-ran `--fix` a third time
+   to confirm the edit is stable (zero diff).
+4. `clj-kondo --lint components/bb-data-plane-http`: 0 errors, 0 warnings.
+5. Ran `ai.miniforge.bb-data-plane-http.core-test` directly via
+   `clojure -M:test -m cognitect.test-runner`: 17 tests, 38 assertions, 0
+   failures, 0 errors.
+6. Re-ran plain `stratum-lint` after the fix: zero findings across all
+   four rule checks. No `SL003` — the real layer counts for this
+   component (3 for `core.clj`, 1 for the other two files) are within the
+   3-layer budget, so nothing is deferred to Wave 2.
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+change — comments, metadata, docstring wording, and def order only.
+Pre-commit's `lint:stratum` autofixer keeps this component clean going
+forward.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+- No Wave 2 follow-on needed for this component — post-fix lint is clean.
+
+## Checklist
+
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Second `--fix` pass confirms idempotency (zero diff)
+- [x] Diff read in full for all 3 changed files
+- [x] Stale `Layer N` docstring claims (tool limitation, not this fix's
+      doing) hand-corrected; third `--fix` pass confirms stability
+- [x] `clj-kondo` clean (0 errors, 0 warnings)
+- [x] Component tests pass (17 tests, 38 assertions, 0 failures/errors)
+- [x] Plain lint re-run post-fix: zero findings, no `SL003` remaining
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
## Summary
- Runs `stratum-lint --fix` over `components/bb-data-plane-http` to replace 2 pre-heading `def`s (`SL004`) with real `Layer N` headings + `^{:stratum n}` metadata derived from the file's actual same-file reference graph.
- Zero `SL001` findings going in (no upward-reference/cycle risk), matching Wave 1 batch criteria — see `work/stratum-lint-baseline-2026-07-24.md`.
- Hand-corrected two ns docstrings (`core.clj`, `core_test.clj`) left with stale `Layer N` claims by the fixer — same root cause as the documented stale-banner tool limitation, just in prose. Re-ran `--fix` afterward to confirm stability (zero diff).
- No `SL003` remains post-fix — this component's real layer counts (3 for `core.clj`, 1 for the others) are within budget, no Wave 2 follow-on needed.

Full detail in `docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-bb-data-plane-http.md`.

## Test plan
- [x] `--fix` run twice in a row — zero diff on the second pass (idempotent)
- [x] Full diff read for all 3 changed files
- [x] `clj-kondo --lint components/bb-data-plane-http` — 0 errors, 0 warnings
- [x] `clojure -M:test -m cognitect.test-runner` in the component — 17 tests, 38 assertions, 0 failures/errors
- [x] Plain (non-`--fix`) lint re-run post-fix — zero findings across all four rule checks
- [x] Pre-commit hook ran the full smoke suite clean (331 + 8 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)