### PR TITLE
fix: stratum-lint autofix for components/fsm (Wave 1)

### DIFF
--- a/components/fsm/src/ai/miniforge/fsm/core.clj
+++ b/components/fsm/src/ai/miniforge/fsm/core.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.fsm.core
   "Core FSM implementation wrapping clj-statecharts.
 
@@ -39,9 +38,9 @@
    [statecharts.core :as sc]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Internal helpers
 
-(defn compile-transitions
+;; Internal helpers
+(defn ^{:stratum 0} compile-transitions
   "Compile transition definitions.
 
    Supports shorthand and full forms:
@@ -58,7 +57,93 @@
    {}
    transitions))
 
-(defn compile-state
+;; Machine definition
+(defn ^{:stratum 0} extract-final-states
+  "Extract the set of states marked as :type :final."
+  [states]
+  (into #{}
+        (comp (filter (fn [[_ v]] (= :final (:type v))))
+              (map first))
+        states))
+
+;; State operations
+(defn ^{:stratum 0} initialize
+  "Initialize a state machine, returning the initial state.
+
+   Arguments:
+     machine - Compiled machine definition
+
+   Returns:
+     Initial state map with :_state and context."
+  [machine]
+  (sc/initialize machine))
+
+(defn- ^{:stratum 0} event-map
+  [event]
+  (if (keyword? event)
+    {:type event}
+    event))
+
+(defn- ^{:stratum 0} unknown-event-message
+  [state event-map]
+  (str "FSM unknown event " (pr-str (:type event-map))
+       " at state " (pr-str (get state :_state state))))
+
+(defn- ^{:stratum 0} unknown-event-data
+  [state event-map]
+  {:anomaly/category :anomalies/fsm-unknown-event
+   :fsm/state state
+   :fsm/event event-map})
+
+(defn ^{:stratum 0} current-state
+  "Get the current state value from a state map.
+
+   Arguments:
+     state - State map from initialize or transition
+
+   Returns:
+     Current state keyword."
+  [state]
+  (:_state state))
+
+(defn ^{:stratum 0} context
+  "Get the context from a state map.
+
+   Arguments:
+     state - State map
+
+   Returns:
+     Context map (everything except internal state keys)."
+  [state]
+  (dissoc state :_state))
+
+(defn ^{:stratum 0} all-guards
+  "Combine multiple guards with AND logic.
+
+   Arguments:
+     guards - Sequence of guard functions
+
+   Returns:
+     Combined guard that passes only if all pass."
+  [& guards]
+  (fn [state event]
+    (every? #(% state event) guards)))
+
+(defn ^{:stratum 0} any-guard
+  "Combine multiple guards with OR logic.
+
+   Arguments:
+     guards - Sequence of guard functions
+
+   Returns:
+     Combined guard that passes if any pass."
+  [& guards]
+  (fn [state event]
+    (some #(% state event) guards)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} compile-state
   "Compile a state definition to clj-statecharts format.
 
    Supports:
@@ -74,18 +159,100 @@
       entry (assoc :entry entry)
       exit  (assoc :exit exit))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Machine definition
+(defn- ^{:stratum 1} statechart-transition-result
+  "Boundary wrapper around clj-statecharts transition, returning a canonical
+   unknown-event anomaly while preserving unexpected statechart failures as
+   exceptions."
+  [machine state event-map]
+  (try
+    (sc/transition machine state event-map)
+    (catch clojure.lang.ExceptionInfo e
+      (if (re-find #"got unknown event" (ex-message e))
+        (with-meta
+          (anomaly/sub-anomaly :invalid-input
+                               :anomalies/fsm-unknown-event
+                               (unknown-event-message state event-map)
+                               (unknown-event-data state event-map))
+          {:cause e})
+        (throw e)))))
 
-(defn extract-final-states
-  "Extract the set of states marked as :type :final."
-  [states]
-  (into #{}
-        (comp (filter (fn [[_ v]] (= :final (:type v))))
-              (map first))
-        states))
+(defn ^{:stratum 1} in-state?
+  "Check if the machine is in a specific state.
 
-(defn define-machine
+   Arguments:
+     state    - State map
+     state-id - State keyword to check
+
+   Returns:
+     Boolean."
+  [state state-id]
+  (= state-id (current-state state)))
+
+(defn ^{:stratum 1} final?
+  "Check if the current state is a final state.
+
+   Arguments:
+     machine - Compiled machine definition
+     state   - Current state map
+
+   Returns:
+     Boolean."
+  [machine state]
+  (let [current (current-state state)
+        final-states (:miniforge/final-states machine #{})]
+    (contains? final-states current)))
+
+;; Context manipulation
+(defn ^{:stratum 1} assign
+  "Create an action that assigns values to context.
+
+   Arguments:
+     assignments - Map of context keys to values or functions
+                   Functions receive (context, event) and return new value
+
+   Returns:
+     Action function for use in :entry/:exit/:actions."
+  [assignments]
+  (fn [state event]
+    (reduce-kv
+     (fn [s k v]
+       (assoc s k (if (fn? v)
+                    (v (context s) event)
+                    v)))
+     state
+     assignments)))
+
+(defn ^{:stratum 1} update-context
+  "Update context in a state map.
+
+   Arguments:
+     state - Current state map
+     f     - Function to apply to context
+     args  - Additional args to f
+
+   Returns:
+     Updated state map."
+  [state f & args]
+  (let [ctx (context state)
+        new-ctx (apply f ctx args)]
+    (merge state new-ctx)))
+
+;; Guard helpers
+(defn ^{:stratum 1} guard
+  "Create a guard function from a predicate.
+
+   Arguments:
+     pred - Predicate fn (context, event) -> boolean
+
+   Returns:
+     Guard function for use in transitions."
+  [pred]
+  (fn [state event]
+    (pred (context state) event)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} define-machine
   "Create a state machine definition from miniforge config.
 
    Arguments:
@@ -111,55 +278,7 @@
     ;; Attach final states as metadata
     (assoc machine :miniforge/final-states final-states)))
 
-;------------------------------------------------------------------------------ Layer 2
-;; State operations
-
-(defn initialize
-  "Initialize a state machine, returning the initial state.
-
-   Arguments:
-     machine - Compiled machine definition
-
-   Returns:
-     Initial state map with :_state and context."
-  [machine]
-  (sc/initialize machine))
-
-(defn- event-map
-  [event]
-  (if (keyword? event)
-    {:type event}
-    event))
-
-(defn- unknown-event-message
-  [state event-map]
-  (str "FSM unknown event " (pr-str (:type event-map))
-       " at state " (pr-str (get state :_state state))))
-
-(defn- unknown-event-data
-  [state event-map]
-  {:anomaly/category :anomalies/fsm-unknown-event
-   :fsm/state state
-   :fsm/event event-map})
-
-(defn- statechart-transition-result
-  "Boundary wrapper around clj-statecharts transition, returning a canonical
-   unknown-event anomaly while preserving unexpected statechart failures as
-   exceptions."
-  [machine state event-map]
-  (try
-    (sc/transition machine state event-map)
-    (catch clojure.lang.ExceptionInfo e
-      (if (re-find #"got unknown event" (ex-message e))
-        (with-meta
-          (anomaly/sub-anomaly :invalid-input
-                               :anomalies/fsm-unknown-event
-                               (unknown-event-message state event-map)
-                               (unknown-event-data state event-map))
-          {:cause e})
-        (throw e)))))
-
-(defn transition-result
+(defn ^{:stratum 2} transition-result
   "Transition the machine given an event, returning the new state or a
    canonical anomaly for a state-local unknown event.
 
@@ -168,7 +287,9 @@
   [machine state event]
   (statechart-transition-result machine state (event-map event)))
 
-(defn transition
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} transition
   "Boundary wrapper around the anomaly-returning `transition-result`.
 
    Transition the machine given an event.
@@ -194,130 +315,6 @@
                       (:anomaly/data result)
                       (:cause (meta result))))
       result)))
-
-(defn current-state
-  "Get the current state value from a state map.
-
-   Arguments:
-     state - State map from initialize or transition
-
-   Returns:
-     Current state keyword."
-  [state]
-  (:_state state))
-
-(defn context
-  "Get the context from a state map.
-
-   Arguments:
-     state - State map
-
-   Returns:
-     Context map (everything except internal state keys)."
-  [state]
-  (dissoc state :_state))
-
-(defn in-state?
-  "Check if the machine is in a specific state.
-
-   Arguments:
-     state    - State map
-     state-id - State keyword to check
-
-   Returns:
-     Boolean."
-  [state state-id]
-  (= state-id (current-state state)))
-
-(defn final?
-  "Check if the current state is a final state.
-
-   Arguments:
-     machine - Compiled machine definition
-     state   - Current state map
-
-   Returns:
-     Boolean."
-  [machine state]
-  (let [current (current-state state)
-        final-states (:miniforge/final-states machine #{})]
-    (contains? final-states current)))
-
-;------------------------------------------------------------------------------ Layer 3
-;; Context manipulation
-
-(defn assign
-  "Create an action that assigns values to context.
-
-   Arguments:
-     assignments - Map of context keys to values or functions
-                   Functions receive (context, event) and return new value
-
-   Returns:
-     Action function for use in :entry/:exit/:actions."
-  [assignments]
-  (fn [state event]
-    (reduce-kv
-     (fn [s k v]
-       (assoc s k (if (fn? v)
-                    (v (context s) event)
-                    v)))
-     state
-     assignments)))
-
-(defn update-context
-  "Update context in a state map.
-
-   Arguments:
-     state - Current state map
-     f     - Function to apply to context
-     args  - Additional args to f
-
-   Returns:
-     Updated state map."
-  [state f & args]
-  (let [ctx (context state)
-        new-ctx (apply f ctx args)]
-    (merge state new-ctx)))
-
-;------------------------------------------------------------------------------ Layer 4
-;; Guard helpers
-
-(defn guard
-  "Create a guard function from a predicate.
-
-   Arguments:
-     pred - Predicate fn (context, event) -> boolean
-
-   Returns:
-     Guard function for use in transitions."
-  [pred]
-  (fn [state event]
-    (pred (context state) event)))
-
-(defn all-guards
-  "Combine multiple guards with AND logic.
-
-   Arguments:
-     guards - Sequence of guard functions
-
-   Returns:
-     Combined guard that passes only if all pass."
-  [& guards]
-  (fn [state event]
-    (every? #(% state event) guards)))
-
-(defn any-guard
-  "Combine multiple guards with OR logic.
-
-   Arguments:
-     guards - Sequence of guard functions
-
-   Returns:
-     Combined guard that passes if any pass."
-  [& guards]
-  (fn [state event]
-    (some #(% state event) guards)))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/fsm/src/ai/miniforge/fsm/interface.clj
+++ b/components/fsm/src/ai/miniforge/fsm/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.fsm.interface
   "Finite State Machine public interface.
 
@@ -31,9 +30,9 @@
    [ai.miniforge.fsm.core :as core]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Machine definition
 
-(def define-machine
+;; Machine definition
+(def ^{:stratum 0} define-machine
   "Create a state machine definition from config.
 
    Config format:
@@ -53,17 +52,15 @@
    Returns compiled machine definition."
   core/define-machine)
 
-;------------------------------------------------------------------------------ Layer 1
 ;; State operations
-
-(def initialize
+(def ^{:stratum 0} initialize
   "Initialize a machine, returning the initial state.
 
    Example:
      (def state (initialize machine))"
   core/initialize)
 
-(def transition
+(def ^{:stratum 0} transition
   "Transition given an event.
 
    Arguments:
@@ -76,44 +73,42 @@
      (transition machine state {:type :fail :data {:error \"timeout\"}})"
   core/transition)
 
-(def transition-result
+(def ^{:stratum 0} transition-result
   "Transition given an event, returning a state or a canonical anomaly for a
    state-local unknown event. Non-unknown statechart failures are thrown
    unchanged."
   core/transition-result)
 
-(def current-state
+(def ^{:stratum 0} current-state
   "Get current state keyword from state map.
 
    Example:
      (current-state state) ;; => :running"
   core/current-state)
 
-(def context
+(def ^{:stratum 0} context
   "Get context data from state map.
 
    Example:
      (context state) ;; => {:phase-index 2}"
   core/context)
 
-(def in-state?
+(def ^{:stratum 0} in-state?
   "Check if machine is in a specific state.
 
    Example:
      (in-state? state :running) ;; => true"
   core/in-state?)
 
-(def final?
+(def ^{:stratum 0} final?
   "Check if current state is a final state.
 
    Example:
      (final? machine state) ;; => false"
   core/final?)
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Context manipulation
-
-(def assign
+(def ^{:stratum 0} assign
   "Create action that assigns values to context.
 
    Values can be constants or functions (context, event) -> value.
@@ -123,31 +118,29 @@
               :last-event (fn [ctx event] (:type event))})"
   core/assign)
 
-(def update-context
+(def ^{:stratum 0} update-context
   "Update context with a function.
 
    Example:
      (update-context state assoc :key value)"
   core/update-context)
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Guard helpers
-
-(def guard
+(def ^{:stratum 0} guard
   "Create a guard from predicate (context, event) -> boolean.
 
    Example:
      (guard (fn [ctx event] (< (:attempts ctx) 3)))"
   core/guard)
 
-(def all-guards
+(def ^{:stratum 0} all-guards
   "Combine guards with AND logic.
 
    Example:
      (all-guards has-budget? has-permission?)"
   core/all-guards)
 
-(def any-guard
+(def ^{:stratum 0} any-guard
   "Combine guards with OR logic.
 
    Example:

--- a/components/fsm/test/ai/miniforge/fsm/interface_test.clj
+++ b/components/fsm/test/ai/miniforge/fsm/interface_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.fsm.interface-test
   "Tests for the FSM component."
   (:require
@@ -23,11 +22,12 @@
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.fsm.interface :as fsm]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; ============================================================================
 ;; Machine definition tests
 ;; ============================================================================
-
-(deftest define-machine-basic-test
+(deftest ^{:stratum 0} define-machine-basic-test
   (testing "define-machine creates a machine from config"
     (let [machine (fsm/define-machine
                    {:fsm/id :test
@@ -38,7 +38,7 @@
       (is (some? machine))
       (is (= :test (:id machine))))))
 
-(deftest define-machine-with-context-test
+(deftest ^{:stratum 0} define-machine-with-context-test
   (testing "define-machine includes initial context"
     (let [machine (fsm/define-machine
                    {:fsm/id :test
@@ -52,8 +52,7 @@
 ;; ============================================================================
 ;; Initialize tests
 ;; ============================================================================
-
-(deftest initialize-test
+(deftest ^{:stratum 0} initialize-test
   (testing "initialize returns initial state"
     (let [machine (fsm/define-machine
                    {:fsm/id :test
@@ -68,8 +67,7 @@
 ;; ============================================================================
 ;; Transition tests
 ;; ============================================================================
-
-(deftest transition-basic-test
+(deftest ^{:stratum 0} transition-basic-test
   (testing "transition moves to target state"
     (let [machine (fsm/define-machine
                    {:fsm/id :test
@@ -84,7 +82,7 @@
       (is (= :b (fsm/current-state s1)))
       (is (= :c (fsm/current-state s2))))))
 
-(deftest transition-unknown-event-throws-test
+(deftest ^{:stratum 0} transition-unknown-event-throws-test
   (testing "an event the state doesn't handle throws a typed anomaly — never a
             silent no-op (Fable review §2.2)"
     (let [machine (fsm/define-machine
@@ -101,7 +99,7 @@
       (is (= {:type :unknown-event} (:fsm/event (ex-data ex)))
           "ex-data names the offending event for diagnosis"))))
 
-(deftest transition-result-unknown-event-returns-anomaly-test
+(deftest ^{:stratum 0} transition-result-unknown-event-returns-anomaly-test
   (testing "transition-result returns a canonical anomaly for unknown events"
     (let [machine (fsm/define-machine
                    {:fsm/id :test
@@ -120,7 +118,7 @@
       (is (some? (:cause (meta result)))
           "preserves the clj-statecharts cause for the boundary wrapper"))))
 
-(deftest transition-with-event-data-test
+(deftest ^{:stratum 0} transition-with-event-data-test
   (testing "transition accepts event with data"
     (let [machine (fsm/define-machine
                    {:fsm/id :test
@@ -134,8 +132,7 @@
 ;; ============================================================================
 ;; State query tests
 ;; ============================================================================
-
-(deftest in-state?-test
+(deftest ^{:stratum 0} in-state?-test
   (testing "in-state? checks current state"
     (let [machine (fsm/define-machine
                    {:fsm/id :test
@@ -146,7 +143,7 @@
       (is (fsm/in-state? state :idle))
       (is (not (fsm/in-state? state :running))))))
 
-(deftest final?-test
+(deftest ^{:stratum 0} final?-test
   (testing "final? detects final states"
     (let [machine (fsm/define-machine
                    {:fsm/id :test
@@ -161,8 +158,7 @@
 ;; ============================================================================
 ;; Context tests
 ;; ============================================================================
-
-(deftest context-test
+(deftest ^{:stratum 0} context-test
   (testing "context returns context without internal state"
     (let [machine (fsm/define-machine
                    {:fsm/id :test
@@ -175,7 +171,7 @@
       (is (= 2 (:b ctx)))
       (is (not (contains? ctx :_state))))))
 
-(deftest update-context-test
+(deftest ^{:stratum 0} update-context-test
   (testing "update-context applies function to context"
     (let [machine (fsm/define-machine
                    {:fsm/id :test
@@ -190,15 +186,14 @@
 ;; ============================================================================
 ;; Guard tests
 ;; ============================================================================
-
-(deftest guard-test
+(deftest ^{:stratum 0} guard-test
   (testing "guard creates predicate function"
     (let [g (fsm/guard (fn [ctx _event] (< (:attempts ctx) 3)))]
       (is (g {:attempts 0 :_state :x} {}))
       (is (g {:attempts 2 :_state :x} {}))
       (is (not (g {:attempts 3 :_state :x} {}))))))
 
-(deftest all-guards-test
+(deftest ^{:stratum 0} all-guards-test
   (testing "all-guards combines with AND"
     (let [g1 (fsm/guard (fn [ctx _] (:a ctx)))
           g2 (fsm/guard (fn [ctx _] (:b ctx)))
@@ -207,7 +202,7 @@
       (is (not (combined {:a true :b false :_state :x} {})))
       (is (not (combined {:a false :b true :_state :x} {}))))))
 
-(deftest any-guard-test
+(deftest ^{:stratum 0} any-guard-test
   (testing "any-guard combines with OR"
     (let [g1 (fsm/guard (fn [ctx _] (:a ctx)))
           g2 (fsm/guard (fn [ctx _] (:b ctx)))
@@ -220,8 +215,7 @@
 ;; ============================================================================
 ;; Workflow FSM example test
 ;; ============================================================================
-
-(deftest workflow-fsm-test
+(deftest ^{:stratum 0} workflow-fsm-test
   (testing "workflow FSM handles typical workflow transitions"
     (let [machine (fsm/define-machine
                    {:fsm/id :workflow

--- a/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-fsm.md
+++ b/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-fsm.md
@@ -1,0 +1,100 @@
+# fix: stratum-lint autofix for components/fsm (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over `components/fsm` (`src` + `test`) to replace
+decorative `Layer N` headings with real ones derived from the file's actual
+same-file reference graph, and tags every `def`/`deftest` with
+`^{:stratum n}`. Purely mechanical: no logic changes. One of the
+per-component Wave 1 PRs from `work/stratum-lint-baseline-2026-07-24.md`
+(batch 3).
+
+## Motivation
+
+`components/fsm` carried 2 findings under the baseline's cargo-cult
+diagnosis, both `SL003` (over the 3-layer budget): `core.clj` (reported 5
+distinct layers) and `interface.clj` (reported 4). Zero `SL001` findings —
+no upward-reference/cycle risk to reason about before running the mechanical
+fixer, matching the Wave 1 batch criteria exactly. (An earlier baseline pass
+had flagged one `SL001` on `core.clj:88` — a `context` parameter shadowing
+the later `context` def — but that was already confirmed a checker false
+positive and cleared once Wave 0's upstream scoping fix landed in the
+pinned `stratum-lint` sha; the current pin reports zero `SL001` here.)
+
+## Changes in Detail
+
+Ran, over the whole component:
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "80699e378cb8ebbb6daeb928431aa4a6b373c07e" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/fsm
+```
+
+3 files rewritten: `core.clj`, `interface.clj` (both `src`), and
+`interface_test.clj` (`test`).
+
+- `interface.clj` collapses from 4 decorative layers to a single real one:
+  every `def` here is an independent re-export of a `core` function with no
+  same-file references between them, so the whole file lands at
+  `^{:stratum 0}`.
+- `core.clj` regroups around the real reference chain: guard/context/state
+  helpers land at Layer 0, `compile-state`/`statechart-transition-result`/
+  `in-state?`/`final?`/`assign`/`update-context`/`guard` at Layer 1 (they
+  compose Layer 0), `define-machine`/`transition-result` at Layer 2, and
+  `transition` at Layer 3 (it composes `transition-result`).
+- `interface_test.clj`'s `deftest` forms all land at Layer 0 — each is
+  self-contained, no test calls another test.
+
+No line of executable code changed; diffs are heading text, `^{:stratum n}`
+metadata, and def/deftest reordering only.
+
+## Testing Plan
+
+1. Ran plain (non-`--fix`) `stratum-lint` before the fix — reproduced the
+   baseline's 2 `SL003` findings exactly (`core.clj` at 5 layers,
+   `interface.clj` at 4).
+2. Ran `--fix`, then a second `--fix` pass immediately after — zero diff on
+   all 3 files, confirms idempotency.
+3. Read the full diff for all 3 changed files. The pre-existing plain
+   double-semicolon section comments (`;; Machine definition`, `;; State
+   operations`, `;; Context manipulation`, `;; Guard helpers`) don't assert
+   a layer number themselves, and each stayed correctly paired with the def
+   it labeled after reordering — no stale/contradictory banner. No
+   same-line trailing comment was displaced onto the wrong def either
+   (none of the three files had one).
+4. `clj-kondo --lint components/fsm`: 0 errors, 0 warnings, before and
+   after.
+5. Ran `ai.miniforge.fsm.interface-test` directly via `clojure -A:test`: 15
+   tests, 41 assertions, 0 failures, 0 errors.
+6. Re-ran plain `stratum-lint` after the fix: `interface.clj`'s `SL003`
+   clears entirely — its old 4-layer count was purely decorative. `core.clj`
+   still reports `SL003`, but now at 4 real layers (down from the
+   pre-fix-reported 5) — the same underlying over-budget file, not a new
+   finding; the old headings had over-counted the depth, `--fix` corrected
+   the count while confirming it's genuinely still over budget. Deferred to
+   Wave 2.
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+change — comment/metadata/order-only. Pre-commit's `lint:stratum` autofixer
+keeps this component clean going forward; `core.clj`'s `SL003` stays
+advisory (`MINIFORGE_STRATUM_BUDGET_MODE=warn` at commit time) until Wave 2
+splits it.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+- Follow-on: Wave 2 namespace split for
+  `components/fsm/src/ai/miniforge/fsm/core.clj` (4 real layers, over the
+  3-layer budget)
+
+## Checklist
+
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Second `--fix` pass confirms idempotency (zero diff)
+- [x] Diff read in full for all 3 changed files; mechanical-only
+- [x] `clj-kondo` clean before/after (0 errors, 0 warnings)
+- [x] Component tests pass (15 tests, 41 assertions, 0 failures/errors)
+- [x] Plain lint re-run post-fix: `interface.clj` clears entirely;
+      `core.clj`'s `SL003` remains (documented above, tracked as Wave 2)
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
## Summary
- Runs `stratum-lint --fix` over `components/fsm` (`src` + `test`) to replace decorative `Layer N` headings with real ones derived from the file's actual same-file reference graph, plus `^{:stratum n}` metadata. Mechanical only, no logic changes.
- Wave 1 (batch 3) of `work/stratum-lint-baseline-2026-07-24.md`. Baseline: 2 findings, both `SL003`, zero `SL001` — matches the batch's safe-fix criteria.
- `interface.clj`'s `SL003` clears entirely (was decorative — all defs are independent re-exports). `core.clj`'s `SL003` remains, but at 4 real layers (corrected down from the pre-fix-reported 5) — same over-budget file, not a new finding, deferred to Wave 2.

## Test plan
- [x] `--fix` run over the whole component; second `--fix` pass confirms idempotency (zero diff)
- [x] Full diff read for all 3 changed files — no displaced trailing comment, no stale decorative banner
- [x] `clj-kondo --lint components/fsm`: 0 errors, 0 warnings
- [x] `ai.miniforge.fsm.interface-test`: 15 tests, 41 assertions, 0 failures/errors
- [x] Plain lint re-run post-fix: `interface.clj` clean; `core.clj`'s `SL003` remains (documented, Wave 2)

See `docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-fsm.md` for full detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)