### PR TITLE
fix: stratum-lint autofix for components/pipeline-pack (Wave 1)

### DIFF
--- a/components/pipeline-pack/src/ai/miniforge/pipeline_pack/interface.clj
+++ b/components/pipeline-pack/src/ai/miniforge/pipeline_pack/interface.clj
@@ -7,16 +7,20 @@
    [ai.miniforge.pipeline-pack.loader :as loader]
    [ai.miniforge.pipeline-pack.registry :as registry]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; -- Schema re-exports --
-(def TrustLevel
+(def ^{:stratum 0} TrustLevel
   "Malli enum schema for a pack's trust level: [:enum :tainted :untrusted :trusted].
    Use to validate or coerce :pack/trust-level."
   pack-schema/TrustLevel)
-(def AuthorityChannel
+
+(def ^{:stratum 0} AuthorityChannel
   "Malli enum schema for a pack's authority channel: [:enum :authority/data :authority/instruction].
    :authority/data = data-only; :authority/instruction = code-bearing (requires :trusted)."
   pack-schema/AuthorityChannel)
-(def PipelinePackManifest
+
+(def ^{:stratum 0} PipelinePackManifest
   "Malli :map schema for a pipeline pack manifest (pack.edn contents).
    Required keys: :pack/id, :pack/name, :pack/version, :pack/description,
    :pack/author, :pack/trust-level, :pack/authority, :pack/pipelines (vector),
@@ -24,83 +28,86 @@
    :pack/metric-registry (string), :pack/connector-types (set of keywords),
    :pack/extends (vector of {:pack-id string})."
   pack-schema/PipelinePackManifest)
-(def trust-levels
+
+(def ^{:stratum 0} trust-levels
   "Vector of the legal trust-level keywords, in ascending trust order:
    [:tainted :untrusted :trusted]."
   pack-schema/trust-levels)
-(def authority-channels
+
+(def ^{:stratum 0} authority-channels
   "Vector of the legal authority-channel keywords:
    [:authority/data :authority/instruction]."
   pack-schema/authority-channels)
 
 ;; -- Validation --
-(def valid-manifest?
+(def ^{:stratum 0} valid-manifest?
   "Predicate. Returns true if the given value conforms to PipelinePackManifest,
    else false. Takes a manifest map."
   pack-schema/valid-manifest?)
-(def validate-manifest
+
+(def ^{:stratum 0} validate-manifest
   "Validate a manifest map against PipelinePackManifest.
    Returns {:valid? true :errors nil} on success, or
    {:valid? false :errors <humanized-error-map>} on failure."
   pack-schema/validate-manifest)
 
 ;; -- Loading --
-(defn load-pack
+(defn ^{:stratum 0} load-pack
   "Load a pipeline pack from a directory path.
    Returns {:success? true :pack ...} or {:success? false :error ...}"
   [dir-path]
   (loader/load-pack-from-directory dir-path))
 
-(defn discover-packs
+(defn ^{:stratum 0} discover-packs
   "Discover all pipeline packs in a directory.
    Returns vector of {:path string :pack-id string}."
   [packs-dir]
   (loader/discover-packs packs-dir))
 
-(defn load-all-packs
+(defn ^{:stratum 0} load-all-packs
   "Load all packs from a packs directory.
    Returns {:loaded [...] :failed [...]}."
   [packs-dir]
   (loader/load-all-packs packs-dir))
 
 ;; -- Registry --
-(defn create-registry
+(defn ^{:stratum 0} create-registry
   "Create a new empty pack registry (atom-backed)."
   []
   (registry/create-registry))
 
-(defn register-pack!
+(defn ^{:stratum 0} register-pack!
   "Register a loaded pack in the registry."
   [reg pack]
   (registry/register-pack! reg pack))
 
-(defn unregister-pack!
+(defn ^{:stratum 0} unregister-pack!
   "Remove a pack from the registry by id."
   [reg pack-id]
   (registry/unregister-pack! reg pack-id))
 
-(defn get-pack
+(defn ^{:stratum 0} get-pack
   "Get a pack by id from registry."
   [reg pack-id]
   (registry/get-pack reg pack-id))
 
-(defn list-packs
+(defn ^{:stratum 0} list-packs
   "List all registered packs."
   [reg]
   (registry/list-packs reg))
 
-(defn list-pack-ids
+(defn ^{:stratum 0} list-pack-ids
   "List all registered pack ids."
   [reg]
   (registry/list-pack-ids reg))
 
-(defn pack-count
+(defn ^{:stratum 0} pack-count
   "Return number of registered packs."
   [reg]
   (registry/pack-count reg))
 
 ;; -- Trust --
-(defn validate-pack-trust
+(defn ^{:stratum 0} validate-pack-trust
   "Validate that a pack's trust/authority combination is legal."
   [pack]
   (registry/validate-pack-trust pack))

--- a/components/pipeline-pack/src/ai/miniforge/pipeline_pack/loader.clj
+++ b/components/pipeline-pack/src/ai/miniforge/pipeline_pack/loader.clj
@@ -1,9 +1,13 @@
 (ns ai.miniforge.pipeline-pack.loader
   "Load pipeline packs from disk.
 
-   Layer 0: EDN parsing, normalization
-   Layer 1: Directory loader (reads manifest, resolves relative paths)
-   Layer 2: Discovery and batch loading"
+   Layer 0: EDN parsing, path/registry primitives, discovery predicates
+   Layer 1: normalize-manifest, path resolution, discover-packs
+   Layer 2: build-pack-from-manifest
+   Layer 3: read-and-validate-manifest
+   Layer 4: load-pack-from-directory
+   Layer 5: load-discovered-pack
+   Layer 6: load-all-packs"
   (:require
    [ai.miniforge.schema.interface :as schema]
    [ai.miniforge.pipeline-pack.schema :as pack-schema]
@@ -13,9 +17,9 @@
    [clojure.edn :as edn]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; EDN parsing and normalization
 
-(defn safe-read-edn
+;; EDN parsing and normalization
+(defn ^{:stratum 0} safe-read-edn
   "Safely read EDN from a file. Returns {:success? bool :data any :error string}."
   [file]
   (try
@@ -25,7 +29,7 @@
     (catch Exception e
       {:success? false :data nil :error (.getMessage e)})))
 
-(defn ensure-instant
+(defn ^{:stratum 0} ensure-instant
   "Convert timestamp representations to Instant."
   [value]
   (cond
@@ -36,7 +40,46 @@
                         (java.time.Instant/now)))
     :else (java.time.Instant/now)))
 
-(defn normalize-manifest
+;; Path helpers
+(defn- ^{:stratum 0} resolve-relative-path
+  "Resolve a relative path against a base directory."
+  [dir relative]
+  (.getPath (io/file dir relative)))
+
+(defn- ^{:stratum 0} load-metric-registry-file
+  "Load a metric registry relative to a pack directory."
+  [dir registry-path]
+  (let [reg-file (io/file dir registry-path)]
+    (if (.exists reg-file)
+      (metric-registry/load-registry (.getPath reg-file))
+      (schema/failure :registry (msg/t :pack/registry-not-found {:path registry-path})))))
+
+(defn- ^{:stratum 0} attach-registry
+  "Attach metric registry result to a pack map."
+  [pack registry-result]
+  (cond
+    (nil? registry-result)          pack
+    (:success? registry-result)     (assoc pack :pack/registry (:registry registry-result))
+    :else                           (assoc pack :pack/registry-error (:error registry-result))))
+
+;; Discovery
+(defn- ^{:stratum 0} directory? [f] (.isDirectory f))
+
+(defn- ^{:stratum 0} has-manifest? [dir] (.exists (io/file dir "pack.edn")))
+
+(defn- ^{:stratum 0} dir->pack-entry
+  "Convert a directory File to a discovery entry."
+  [d]
+  {:path (.getPath d) :pack-id (.getName d)})
+
+(defn- ^{:stratum 0} failed-pack-summary
+  "Extract summary fields from a failed pack load result."
+  [result]
+  (select-keys result [:pack-id :path :error]))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} normalize-manifest
   "Normalize a pack manifest, applying defaults."
   [manifest]
   (-> manifest
@@ -52,44 +95,34 @@
              (not (set? (:pack/connector-types manifest))))
         (update :pack/connector-types set))))
 
-;------------------------------------------------------------------------------ Layer 0
-;; Path helpers
-
-(defn- resolve-relative-path
-  "Resolve a relative path against a base directory."
-  [dir relative]
-  (.getPath (io/file dir relative)))
-
-(defn- load-metric-registry-file
-  "Load a metric registry relative to a pack directory."
-  [dir registry-path]
-  (let [reg-file (io/file dir registry-path)]
-    (if (.exists reg-file)
-      (metric-registry/load-registry (.getPath reg-file))
-      (schema/failure :registry (msg/t :pack/registry-not-found {:path registry-path})))))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; Directory loader — helpers
-
-(defn- resolve-pipelines
+(defn- ^{:stratum 1} resolve-pipelines
   "Resolve pipeline paths relative to pack directory."
   [dir manifest]
   (mapv (partial resolve-relative-path dir) (:pack/pipelines manifest)))
 
-(defn- resolve-envs
+(defn- ^{:stratum 1} resolve-envs
   "Resolve env paths relative to pack directory."
   [dir manifest]
   (mapv (partial resolve-relative-path dir) (:pack/envs manifest)))
 
-(defn- attach-registry
-  "Attach metric registry result to a pack map."
-  [pack registry-result]
-  (cond
-    (nil? registry-result)          pack
-    (:success? registry-result)     (assoc pack :pack/registry (:registry registry-result))
-    :else                           (assoc pack :pack/registry-error (:error registry-result))))
+(defn ^{:stratum 1} discover-packs
+  "Discover all pipeline packs in a directory.
 
-(defn- build-pack-from-manifest
+   Looks for subdirectories containing pack.edn.
+
+   Returns vector of {:path string :pack-id string}."
+  [packs-dir]
+  (let [dir (io/file packs-dir)]
+    (when (.exists dir)
+      (->> (.listFiles dir)
+           (filter directory?)
+           (filter has-manifest?)
+           (mapv dir->pack-entry)))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- ^{:stratum 2} build-pack-from-manifest
   "Given a validated manifest and its directory, resolve paths, load registry,
    and assemble the pack map."
   [dir manifest]
@@ -103,7 +136,9 @@
                  (attach-registry registry-result))]
     (schema/success :pack pack)))
 
-(defn- read-and-validate-manifest
+;------------------------------------------------------------------------------ Layer 3
+
+(defn- ^{:stratum 3} read-and-validate-manifest
   "Read pack.edn, normalize, validate, and build the pack if valid."
   [dir manifest-file]
   (let [{:keys [success? data error]} (safe-read-edn manifest-file)]
@@ -115,9 +150,10 @@
           (schema/failure :pack (msg/t :pack/manifest-invalid {:errors (pr-str errors)}))
           (build-pack-from-manifest dir manifest))))))
 
-;; Directory loader — public
+;------------------------------------------------------------------------------ Layer 4
 
-(defn load-pack-from-directory
+;; Directory loader — public
+(defn ^{:stratum 4} load-pack-from-directory
   "Load a pipeline pack from a directory.
 
    Expected structure:
@@ -142,45 +178,18 @@
       :else
       (read-and-validate-manifest dir manifest-file))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Discovery
+;------------------------------------------------------------------------------ Layer 5
 
-(defn- directory? [f] (.isDirectory f))
-
-(defn- has-manifest? [dir] (.exists (io/file dir "pack.edn")))
-
-(defn- dir->pack-entry
-  "Convert a directory File to a discovery entry."
-  [d]
-  {:path (.getPath d) :pack-id (.getName d)})
-
-(defn discover-packs
-  "Discover all pipeline packs in a directory.
-
-   Looks for subdirectories containing pack.edn.
-
-   Returns vector of {:path string :pack-id string}."
-  [packs-dir]
-  (let [dir (io/file packs-dir)]
-    (when (.exists dir)
-      (->> (.listFiles dir)
-           (filter directory?)
-           (filter has-manifest?)
-           (mapv dir->pack-entry)))))
-
-(defn- load-discovered-pack
+(defn- ^{:stratum 5} load-discovered-pack
   "Load a single discovered pack entry, tagging with pack-id and path."
   [{:keys [path pack-id]}]
   (assoc (load-pack-from-directory path)
          :pack-id pack-id
          :path path))
 
-(defn- failed-pack-summary
-  "Extract summary fields from a failed pack load result."
-  [result]
-  (select-keys result [:pack-id :path :error]))
+;------------------------------------------------------------------------------ Layer 6
 
-(defn load-all-packs
+(defn ^{:stratum 6} load-all-packs
   [packs-dir]
   (let [discovered (discover-packs packs-dir)
         results (mapv load-discovered-pack discovered)

--- a/components/pipeline-pack/src/ai/miniforge/pipeline_pack/messages.clj
+++ b/components/pipeline-pack/src/ai/miniforge/pipeline_pack/messages.clj
@@ -2,6 +2,8 @@
   "Message catalog — delegates to ai.miniforge.messages."
   (:require [ai.miniforge.messages.interface :as messages]))
 
-(def t
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} t
   "Look up a message by key, with optional param substitution."
   (messages/create-translator "config/pipeline-pack/messages/en-US.edn" :pipeline-pack/messages))

--- a/components/pipeline-pack/src/ai/miniforge/pipeline_pack/registry.clj
+++ b/components/pipeline-pack/src/ai/miniforge/pipeline_pack/registry.clj
@@ -6,16 +6,14 @@
   (:require [ai.miniforge.pipeline-pack.messages :as msg]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Registry creation
 
-(defn create-registry
+;; Registry creation
+(defn ^{:stratum 0} create-registry
   []
   (atom {}))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Mutations
-
-(defn register-pack!
+(defn ^{:stratum 0} register-pack!
   "Register a loaded pack in the registry. Returns the registry.
    Pack must have :pack/manifest with :pack/id."
   [registry pack]
@@ -23,36 +21,32 @@
     (swap! registry assoc pack-id pack)
     registry))
 
-(defn unregister-pack!
+(defn ^{:stratum 0} unregister-pack!
   [registry pack-id]
   (swap! registry dissoc pack-id)
   registry)
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Queries
-
-(defn get-pack
+(defn ^{:stratum 0} get-pack
   "Get a pack by id. Returns nil if not found."
   [registry pack-id]
   (get @registry pack-id))
 
-(defn list-packs
+(defn ^{:stratum 0} list-packs
   "List all registered packs. Returns vector of pack maps."
   [registry]
   (vec (vals @registry)))
 
-(defn list-pack-ids
+(defn ^{:stratum 0} list-pack-ids
   [registry]
   (vec (keys @registry)))
 
-(defn pack-count
+(defn ^{:stratum 0} pack-count
   [registry]
   (count @registry))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Trust validation
-
-(defn validate-pack-trust
+(defn ^{:stratum 0} validate-pack-trust
   "Validate that a pack's trust level is compatible with its authority.
    Data-only packs (:authority/data) work at any trust level.
    Instruction packs (:authority/instruction) require :trusted."

--- a/components/pipeline-pack/src/ai/miniforge/pipeline_pack/schema.clj
+++ b/components/pipeline-pack/src/ai/miniforge/pipeline_pack/schema.clj
@@ -1,32 +1,52 @@
 (ns ai.miniforge.pipeline-pack.schema
   "Malli schemas for pipeline pack manifests.
 
-   Layer 0: Enums (TrustLevel, AuthorityChannel)
-   Layer 1: PackManifest schema
-   Layer 2: Validation helpers"
+   Layer 0: enum value vectors, plus schema-generic validation helpers
+   Layer 1: TrustLevel/AuthorityChannel enum schemas (built from Layer 0's vectors)
+   Layer 2: PipelinePackManifest
+   Layer 3: valid-manifest?/validate-manifest (compose Layer 0's helpers with Layer 2's schema)"
   (:require
    [malli.core :as m]
    [malli.error :as me]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Enums
 
-(def trust-levels
+;; Enums
+(def ^{:stratum 0} trust-levels
   [:tainted :untrusted :trusted])
 
-(def TrustLevel
-  (into [:enum] trust-levels))
-
-(def authority-channels
+(def ^{:stratum 0} authority-channels
   [:authority/data :authority/instruction])
 
-(def AuthorityChannel
-  (into [:enum] authority-channels))
+;; Validation helpers
+(defn ^{:stratum 0} valid?
+  [schema value]
+  (m/validate schema value))
+
+(defn ^{:stratum 0} validate
+  [schema value]
+  (if (m/validate schema value)
+    {:valid? true :errors nil}
+    {:valid? false
+     :errors (me/humanize (m/explain schema value))}))
+
+(defn ^{:stratum 0} explain
+  [schema value]
+  (when-let [explanation (m/explain schema value)]
+    (me/humanize explanation)))
 
 ;------------------------------------------------------------------------------ Layer 1
-;; Pack manifest schema
 
-(def PipelinePackManifest
+(def ^{:stratum 1} TrustLevel
+  (into [:enum] trust-levels))
+
+(def ^{:stratum 1} AuthorityChannel
+  (into [:enum] authority-channels))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Pack manifest schema
+(def ^{:stratum 2} PipelinePackManifest
   "Schema for a pipeline pack manifest.
 
    Trust model mirrors policy-pack:
@@ -49,29 +69,12 @@
    [:pack/created-at inst?]
    [:pack/updated-at inst?]])
 
-;------------------------------------------------------------------------------ Layer 2
-;; Validation helpers
+;------------------------------------------------------------------------------ Layer 3
 
-(defn valid?
-  [schema value]
-  (m/validate schema value))
-
-(defn validate
-  [schema value]
-  (if (m/validate schema value)
-    {:valid? true :errors nil}
-    {:valid? false
-     :errors (me/humanize (m/explain schema value))}))
-
-(defn explain
-  [schema value]
-  (when-let [explanation (m/explain schema value)]
-    (me/humanize explanation)))
-
-(defn valid-manifest?
+(defn ^{:stratum 3} valid-manifest?
   [value]
   (valid? PipelinePackManifest value))
 
-(defn validate-manifest
+(defn ^{:stratum 3} validate-manifest
   [value]
   (validate PipelinePackManifest value))

--- a/components/pipeline-pack/test/ai/miniforge/pipeline_pack/interface_test.clj
+++ b/components/pipeline-pack/test/ai/miniforge/pipeline_pack/interface_test.clj
@@ -15,23 +15,26 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pipeline-pack.interface-test
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.pipeline-pack.interface :as pp]
             [clojure.java.io :as io]))
 
-(def ^:private simple-pack-dir
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private simple-pack-dir
   (-> (io/resource "test-packs/simple-pack/pack.edn")
       io/file .getParentFile .getPath))
 
-(deftest interface-load-test
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} interface-load-test
   (testing "Load pack via interface"
     (let [result (pp/load-pack simple-pack-dir)]
       (is (:success? result))
       (is (= "simple-pack" (get-in result [:pack :pack/manifest :pack/id]))))))
 
-(deftest interface-registry-test
+(deftest ^{:stratum 1} interface-registry-test
   (testing "Full registry workflow via interface"
     (let [result (pp/load-pack simple-pack-dir)
           pack (:pack result)
@@ -44,7 +47,7 @@
       (pp/unregister-pack! reg "simple-pack")
       (is (= 0 (pp/pack-count reg))))))
 
-(deftest interface-trust-test
+(deftest ^{:stratum 1} interface-trust-test
   (testing "Trust validation via interface"
     (let [result (pp/load-pack simple-pack-dir)
           pack (:pack result)]

--- a/components/pipeline-pack/test/ai/miniforge/pipeline_pack/loader_test.clj
+++ b/components/pipeline-pack/test/ai/miniforge/pipeline_pack/loader_test.clj
@@ -15,24 +15,24 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pipeline-pack.loader-test
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.pipeline-pack.loader :as loader]
             [ai.miniforge.pipeline-pack.schema :as pack-schema]
             [clojure.java.io :as io]))
 
-(def ^:private simple-pack-dir
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private simple-pack-dir
   (-> (io/resource "test-packs/simple-pack/pack.edn")
       io/file .getParentFile .getPath))
 
-(def ^:private test-packs-dir
+(def ^{:stratum 0} ^:private test-packs-dir
   (-> (io/resource "test-packs/simple-pack/pack.edn")
       io/file .getParentFile .getParentFile .getPath))
 
 ;; -- Schema validation --
-
-(deftest validate-manifest-test
+(deftest ^{:stratum 0} validate-manifest-test
   (testing "Valid manifest passes"
     (let [manifest {:pack/id "test" :pack/name "Test" :pack/version "1.0"
                     :pack/description "Test pack" :pack/author "test"
@@ -55,9 +55,23 @@
                   :pack/created-at (java.time.Instant/now)
                   :pack/updated-at (java.time.Instant/now)})))))
 
-;; -- Loader --
+;; -- Normalization --
+(deftest ^{:stratum 0} normalize-defaults-test
+  (testing "Defaults applied to minimal manifest"
+    (let [minimal {:pack/id "x" :pack/name "X" :pack/version "1"
+                   :pack/description "d" :pack/author "a"
+                   :pack/created-at #inst "2026-03-17"
+                   :pack/updated-at #inst "2026-03-17"}
+          normalized (loader/normalize-manifest minimal)]
+      (is (= :untrusted (:pack/trust-level normalized)))
+      (is (= :authority/data (:pack/authority normalized)))
+      (is (= [] (:pack/pipelines normalized)))
+      (is (= [] (:pack/envs normalized))))))
 
-(deftest load-pack-from-directory-test
+;------------------------------------------------------------------------------ Layer 1
+
+;; -- Loader --
+(deftest ^{:stratum 1} load-pack-from-directory-test
   (testing "Load valid pack from test fixtures"
     (let [result (loader/load-pack-from-directory simple-pack-dir)]
       (is (:success? result))
@@ -83,23 +97,8 @@
     (let [result (loader/load-pack-from-directory test-packs-dir)]
       (is (not (:success? result))))))
 
-;; -- Normalization --
-
-(deftest normalize-defaults-test
-  (testing "Defaults applied to minimal manifest"
-    (let [minimal {:pack/id "x" :pack/name "X" :pack/version "1"
-                   :pack/description "d" :pack/author "a"
-                   :pack/created-at #inst "2026-03-17"
-                   :pack/updated-at #inst "2026-03-17"}
-          normalized (loader/normalize-manifest minimal)]
-      (is (= :untrusted (:pack/trust-level normalized)))
-      (is (= :authority/data (:pack/authority normalized)))
-      (is (= [] (:pack/pipelines normalized)))
-      (is (= [] (:pack/envs normalized))))))
-
 ;; -- Discovery --
-
-(deftest discover-packs-test
+(deftest ^{:stratum 1} discover-packs-test
   (testing "Discovers packs in test directory"
     (let [packs (loader/discover-packs test-packs-dir)]
       (is (= 1 (count packs)))
@@ -108,7 +107,7 @@
   (testing "Returns nil for nonexistent directory"
     (is (nil? (loader/discover-packs "/nonexistent")))))
 
-(deftest load-all-packs-test
+(deftest ^{:stratum 1} load-all-packs-test
   (testing "Loads all discovered packs"
     (let [result (loader/load-all-packs test-packs-dir)]
       (is (= 1 (count (:loaded result))))

--- a/components/pipeline-pack/test/ai/miniforge/pipeline_pack/registry_test.clj
+++ b/components/pipeline-pack/test/ai/miniforge/pipeline_pack/registry_test.clj
@@ -15,12 +15,13 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pipeline-pack.registry-test
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.pipeline-pack.registry :as registry]))
 
-(def ^:private sample-pack
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private sample-pack
   {:pack/manifest {:pack/id "test-pack"
                    :pack/name "Test Pack"
                    :pack/trust-level :untrusted
@@ -29,7 +30,7 @@
    :pack/pipelines ["/tmp/test/p.edn"]
    :pack/envs ["/tmp/test/e.edn"]})
 
-(def ^:private trusted-instruction-pack
+(def ^{:stratum 0} ^:private trusted-instruction-pack
   {:pack/manifest {:pack/id "trusted-instr"
                    :pack/name "Trusted Instruction Pack"
                    :pack/trust-level :trusted
@@ -38,7 +39,7 @@
    :pack/pipelines []
    :pack/envs []})
 
-(def ^:private untrusted-instruction-pack
+(def ^{:stratum 0} ^:private untrusted-instruction-pack
   {:pack/manifest {:pack/id "bad-pack"
                    :pack/name "Bad Pack"
                    :pack/trust-level :untrusted
@@ -47,9 +48,10 @@
    :pack/pipelines []
    :pack/envs []})
 
-;; -- Registry CRUD --
+;------------------------------------------------------------------------------ Layer 1
 
-(deftest registry-lifecycle-test
+;; -- Registry CRUD --
+(deftest ^{:stratum 1} registry-lifecycle-test
   (testing "Create empty registry"
     (let [reg (registry/create-registry)]
       (is (= 0 (registry/pack-count reg)))))
@@ -82,8 +84,7 @@
       (is (nil? (registry/get-pack reg "nope"))))))
 
 ;; -- Trust validation --
-
-(deftest trust-validation-test
+(deftest ^{:stratum 1} trust-validation-test
   (testing "Data-only + untrusted is valid"
     (let [result (registry/validate-pack-trust sample-pack)]
       (is (:valid? result))))

--- a/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-pipeline-pack.md
+++ b/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-pipeline-pack.md
@@ -1,0 +1,135 @@
+# fix: stratum-lint autofix for components/pipeline-pack (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over `components/pipeline-pack` (`src` + `test`) to
+replace decorative, repeated `Layer N` headings with real ones derived from
+the file's actual same-file reference graph, plus `^{:stratum n}` metadata on
+every top-level def. Purely mechanical, plus two hand-fixes to ns docstrings
+whose "Layer N" summaries went stale once `--fix` revealed the true depth
+(see Changes in Detail). One of the smaller per-component Wave 1 PRs from
+`work/stratum-lint-baseline-2026-07-24.md`.
+
+## Motivation
+
+`pipeline-pack` carried exactly two findings under the baseline's cargo-cult
+diagnosis, both `SL002`: `loader.clj` and `registry.clj` each reused a
+`Layer N` heading as a repeated section banner instead of one heading per
+real stratum. Zero `SL001` findings, so no upward-reference/cycle risk to
+reason about before running the mechanical fixer — matches the baseline's
+Wave 1 batch criteria exactly.
+
+## Changes in Detail
+
+Ran, over the whole component:
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "80699e378cb8ebbb6daeb928431aa4a6b373c07e" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/pipeline-pack
+```
+
+All 8 files rewritten (5 `src`, 3 `test`) — `--fix` normalizes every file in
+the component, not just the two with findings.
+
+- `registry.clj`: the old headings claimed 3 layers (0/1/2) for what is
+  actually one — every function here (`create-registry`,
+  `register-pack!`, `unregister-pack!`, `get-pack`, `list-packs`,
+  `list-pack-ids`, `pack-count`, `validate-pack-trust`) is independent, no
+  same-file def calls another. Collapsed to a single real `Layer 0`.
+- `loader.clj`: the old headings claimed 3 layers (0/0/1/2); the real
+  reference chain is 7 deep: `Layer 0` (EDN/path/registry primitives,
+  discovery predicates) → `Layer 1` (`normalize-manifest`, path resolution,
+  `discover-packs`) → `Layer 2` (`build-pack-from-manifest`) → `Layer 3`
+  (`read-and-validate-manifest`) → `Layer 4` (`load-pack-from-directory`)
+  → `Layer 5` (`load-discovered-pack`) → `Layer 6` (`load-all-packs`).
+- `interface.clj`, `messages.clj`, `schema.clj`, and the 3 test files only
+  gained `^{:stratum n}` tags (and, where headings were already correct,
+  no reordering) — no prior findings of their own. `schema.clj`'s real
+  depth also came out higher than its old headings claimed: 4 layers
+  (0–3) against 3 previously.
+
+No line of executable code changed; diffs are heading text, metadata, and
+def/deftest reordering only, with one exception: `schema.clj` and
+`loader.clj` each had an `ns` docstring summarizing the (previously
+decorative) layer structure by name — e.g. `loader.clj`'s said "Layer 0:
+EDN parsing, normalization / Layer 1: Directory loader.../ Layer 2:
+Discovery and batch loading". `--fix` only rewrites headings and metadata,
+never prose, so both docstrings would otherwise have been left stating a
+3-layer structure that no longer matches the real 4- and 7-layer ones
+`--fix` just computed — a wrong architectural claim is worse than none
+(same principle rule 210 applies to headings). Hand-rewrote both docstrings
+to list the real layers by content, matching what a later batch
+(`adapter-claude-code`) did after automated review flagged the identical
+staleness there. Re-ran `--fix` after the docstring edits: zero diff,
+confirming it doesn't touch prose either way.
+
+Neither file shows the other known tool-limitation pattern (a same-line
+trailing comment displaced onto a different def) — grepped for `;;----`
+double-semicolon decorative banners across the whole component: none
+found, so that hand-fix path didn't apply here.
+
+`loader.clj` and `schema.clj` now report `SL003` — 7 and 4 real layers
+respectively, against the 3-layer budget. Both are **newly surfaced by this
+fix**, not pre-existing: confirmed via `git show origin/main:...` that the
+old headings on both files topped out at `Layer 2` (three or fewer labels),
+so no `SL003` was reported at baseline — the decorative headings were
+under-counting the real depth, not just mislabeling it. The true depth was
+invisible until `--fix`'s reference-graph analysis exposed it. Namespace
+split is Wave 2 work, consistent with how prior Wave 1 PRs (`bb-config`,
+`decision`, `compliance-scanner`) handled the same situation.
+
+## Testing Plan
+
+1. Ran plain (non-`--fix`) `stratum-lint` before the fix — reproduced the
+   baseline's exact 2 `SL002` findings (`loader.clj`, `registry.clj`).
+2. Ran `--fix`, then a second `--fix` pass immediately after — zero diff,
+   confirms idempotency. Hand-edited the two stale docstrings, then ran
+   `--fix` a third time — zero diff again, confirming the tool never
+   touches prose.
+3. Read the full diff for all 8 changed files (not just `--stat`).
+   Confirmed changes are heading text, `^{:stratum n}` metadata, and
+   def/deftest reordering, plus the two docstring hand-edits described
+   above. Grepped the whole component for `;;----` decorative banners:
+   none survived (there were none to begin with), so the second known
+   tool-limitation pattern doesn't apply here either.
+4. `clj-kondo --lint components/pipeline-pack`: 0 errors, 0 warnings.
+5. Ran all 3 test namespaces directly via `clojure -A:test`:
+   `ai.miniforge.pipeline-pack.interface-test`,
+   `ai.miniforge.pipeline-pack.loader-test`,
+   `ai.miniforge.pipeline-pack.registry-test` — 10 tests, 45 assertions,
+   0 failures, 0 errors.
+6. Re-ran plain `stratum-lint` after the fix: `SL001`/`SL002`/`SL004`
+   clear. `SL003` remains on `loader.clj` (7 layers) and `schema.clj`
+   (4 layers) — expected, newly surfaced (see above), tracked as Wave 2,
+   not a defect in this PR.
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+change — comment/metadata/order/docstring-only. Pre-commit's
+`lint:stratum` autofixer keeps this component clean going forward;
+`loader.clj`'s and `schema.clj`'s `SL003` stay advisory
+(`MINIFORGE_STRATUM_BUDGET_MODE=warn` at commit time) until Wave 2 splits
+them.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+- Follow-on: Wave 2 namespace splits for
+  `components/pipeline-pack/src/ai/miniforge/pipeline_pack/loader.clj`
+  (7 real layers) and
+  `components/pipeline-pack/src/ai/miniforge/pipeline_pack/schema.clj`
+  (4 real layers), both over the 3-layer budget.
+
+## Checklist
+
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Second `--fix` pass confirms idempotency (zero diff); third pass
+      after hand-editing two stale docstrings also zero diff
+- [x] Diff read in full for all 8 changed files; mechanical plus two
+      documented, verified docstring hand-fixes
+- [x] `clj-kondo` clean (0 errors, 0 warnings)
+- [x] Component tests pass (10 tests, 45 assertions, 0 failures/errors)
+- [x] Plain lint re-run post-fix: zero findings except `SL003`
+      (`loader.clj`, `schema.clj`, documented above, newly surfaced,
+      tracked as Wave 2)
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
## Summary
- Runs `stratum-lint --fix` over `components/pipeline-pack` to replace decorative, repeated `Layer N` headings (2 baseline `SL002` findings: `loader.clj`, `registry.clj`) with real ones from the file's actual same-file reference graph, plus `^{:stratum n}` metadata on every def. Zero `SL001` findings (no upward-reference/cycle risk).
- Hand-corrects two `ns` docstrings (`schema.clj`, `loader.clj`) whose "Layer N: ..." prose summaries went stale once `--fix` revealed the real depth (4 and 7 layers, vs 3 claimed) — `--fix` only rewrites headings/metadata, never prose.
- `loader.clj` (7 layers) and `schema.clj` (4 layers) now report `SL003`, newly surfaced by this fix (old headings topped out at `Layer 2`, so no `SL003` at baseline) — real over-budget files, deferred to Wave 2 namespace splits.

Full details in `docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-pipeline-pack.md`.

## Test plan
- [x] `--fix` run over the whole component (`src` + `test`); second `--fix` pass confirms idempotency (zero diff); third pass after docstring hand-edits also zero diff
- [x] Full diff read for all 8 changed files — mechanical plus two documented, verified docstring fixes; no displaced trailing comments, no stale `;;----` banners
- [x] `clj-kondo --lint components/pipeline-pack`: 0 errors, 0 warnings
- [x] Component tests: 10 tests, 45 assertions, 0 failures/errors
- [x] Plain lint re-run post-fix: zero findings except the two newly-surfaced `SL003` (documented, tracked as Wave 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)