### PR TITLE
fix: stratum-lint autofix for components/knowledge-pack (Wave 1)

### DIFF
--- a/components/knowledge-pack/src/ai/miniforge/knowledge_pack/interface.clj
+++ b/components/knowledge-pack/src/ai/miniforge/knowledge_pack/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.knowledge-pack.interface
   "Public API for the knowledge-pack component (Zettelkasten
    distribution layer).
@@ -44,18 +43,18 @@
      `verify-pack` — verify a pack against a zettel store. Returns
                      `{:valid? :pack/discrepancy :ref/discrepancies}`.
 
-   Two strata:
-     Layer 0 — schema re-exports.
-     Layer 1 — operation re-exports."
+   One stratum: every export here is a re-export of a var from
+   `pack`/`schema`/`verify` (schema re-exports, then operation
+   re-exports); none reference each other within this file."
   (:require
    [ai.miniforge.knowledge-pack.pack   :as pack-impl]
    [ai.miniforge.knowledge-pack.schema :as schema-impl]
    [ai.miniforge.knowledge-pack.verify :as verify-impl]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Schema re-exports.
 
-(def ZettelRef
+;; Schema re-exports.
+(def ^{:stratum 0} ZettelRef
   "Malli schema (`[:map {:closed false}]`) for the canonical
    Decision-6 content-addressed reference to a zettel revision: the
    `(:zettel/id, :zettel/revision-id, :zettel/digest)` triple. `id`
@@ -65,7 +64,7 @@
    logical id."
   schema-impl/ZettelRef)
 
-(def KnowledgePack
+(def ^{:stratum 0} KnowledgePack
   "Malli schema (`[:map {:closed false}]`) for a knowledge-pack
    manifest: a curated, content-addressed collection of zettel
    revisions. Required keys: `:pack/id` (uuid), `:pack/uid`,
@@ -79,10 +78,8 @@
    are optional; the constructors stamp the derived identity fields."
   schema-impl/KnowledgePack)
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Operation re-exports.
-
-(def build-pack
+(def ^{:stratum 0} build-pack
   "Construct a fresh content-addressed pack manifest.
    `(build-pack uid title version zettels & opts)`. `uid` / `title` /
    `version` are strings; `zettels` is a sequence of zettel MAPS (not
@@ -94,7 +91,7 @@
    `zettel->ref`) if any zettel lacks the required reference fields."
   pack-impl/build-pack)
 
-(def update-pack
+(def ^{:stratum 0} update-pack
   "Apply `changes` to a pack and re-stamp its revision identity.
    `(update-pack pack changes)` -> updated pack map. Caller-supplied
    `:pack/digest` / `:pack/revision-id` in `changes` are dropped;
@@ -105,7 +102,7 @@
    `:pack/description` / `:pack/zettels` / `:pack/dependencies`)."
   pack-impl/update-pack)
 
-(def add-zettel
+(def ^{:stratum 0} add-zettel
   "Append a zettel reference to a pack's manifest.
    `(add-zettel pack zettel)` -> updated pack map. `zettel` is a
    zettel MAP (projected via `zettel->ref`); the pack revision
@@ -113,13 +110,13 @@
    reference fields."
   pack-impl/add-zettel)
 
-(def remove-zettel
+(def ^{:stratum 0} remove-zettel
   "Remove every reference to `zettel-id` from a pack's manifest.
    `(remove-zettel pack zettel-id)` -> updated pack map. The revision
    rotates only if a reference was actually removed."
   pack-impl/remove-zettel)
 
-(def zettel->ref
+(def ^{:stratum 0} zettel->ref
   "Pure projection from a zettel map to its content-addressed
    reference triple. `(zettel->ref zettel)` -> `{:zettel/id
    :zettel/revision-id :zettel/digest}`. Throws `ex-info` if any of
@@ -127,20 +124,20 @@
    `knowledge.zettel/update-zettel` first)."
   pack-impl/zettel->ref)
 
-(def compute-digest
+(def ^{:stratum 0} compute-digest
   "Pure: SHA-256 hex string of the pack's canonical-EDN content
    projection. `(compute-digest pack)` -> 64-char hex string. Stable
    across map-key reorderings and non-content metadata changes;
    rotates when a content-bearing field changes."
   pack-impl/compute-digest)
 
-(def revision-id-from-digest
+(def ^{:stratum 0} revision-id-from-digest
   "Pure: derive a stable UUID from a digest hex string.
    `(revision-id-from-digest digest)` -> `java.util.UUID`. Two packs
    with identical content projections land on the same revision-id."
   pack-impl/revision-id-from-digest)
 
-(def verify-pack
+(def ^{:stratum 0} verify-pack
   "Verify a pack against a zettel store.
    `(verify-pack pack lookup-fn)` where `lookup-fn` is
    `(fn [zettel-id revision-id] -> zettel-map | nil)`. Returns a map

--- a/components/knowledge-pack/src/ai/miniforge/knowledge_pack/pack.clj
+++ b/components/knowledge-pack/src/ai/miniforge/knowledge_pack/pack.clj
@@ -62,7 +62,7 @@
    zettel-side spoof guard."
   #{:pack/digest :pack/revision-id})
 
-;; Public constructors + projection.
+;; Zettel-to-reference projection.
 (defn ^{:stratum 0} zettel->ref
   "Pure: project a zettel map down to the `(zettel/id,
    zettel/revision-id, zettel/digest)` triple a pack manifest holds.

--- a/components/knowledge-pack/src/ai/miniforge/knowledge_pack/pack.clj
+++ b/components/knowledge-pack/src/ai/miniforge/knowledge_pack/pack.clj
@@ -15,28 +15,26 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.knowledge-pack.pack
   "Knowledge pack operations: build, update, project to a content-
    addressed reference triple, derive the manifest digest +
    revision-id.
 
-   Two strata mirror the zettel module:
-     Layer 0 — content-bearing subset + digest / revision-id
-               derivation. Pure; no I/O.
-     Layer 1 — public constructors: `build-pack`, `update-pack`,
-               plus the `zettel->ref` projection callers use to
-               build the `:pack/zettels` triples from existing
-               zettel maps."
+   Six strata (over the rule-210 budget of 3 — a namespace-split
+   candidate, not resolved here): field lists and pure derivations
+   at Layer 0, rising through the projection/digest/stamp chain to
+   the public constructors (`build-pack`, `update-pack`) at Layer 4
+   and the manifest mutators (`add-zettel`, `remove-zettel`) at
+   Layer 5, which call back into `update-pack`."
   (:require
    [ai.miniforge.content-hash.interface :as content-hash])
   (:import
    [java.util UUID]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Content-bearing subset + revision identity.
 
-(def ^:private content-bearing-fields
+;; Content-bearing subset + revision identity.
+(def ^{:stratum 0} ^:private content-bearing-fields
   "Fields whose value affects a pack's revision identity. Operational
    metadata (`:pack/id`, `:pack/created`, `:pack/modified`,
    `:pack/author`, `:fleet/*`, `:privacy/*`) is excluded — same
@@ -50,47 +48,22 @@
    :pack/zettels
    :pack/dependencies])
 
-(defn- content-projection
-  "Pure: project a pack down to the content-bearing subset that feeds
-   the digest. Stable across additions of operational metadata."
-  [pack]
-  (select-keys pack content-bearing-fields))
-
-(defn compute-digest
-  "Pure: SHA-256 hex of the pack's canonical-EDN content-projection.
-   Stable across map-key reorderings and across non-content metadata
-   changes; rotates whenever a content-bearing field changes."
-  [pack]
-  (content-hash/content-hash (content-projection pack)))
-
-(defn revision-id-from-digest
+(defn ^{:stratum 0} revision-id-from-digest
   "Pure: derive a stable UUID from a digest hex string. Two packs
    with identical content-projections land on the same
    `:pack/revision-id`."
   ^UUID [^String digest]
   (UUID/nameUUIDFromBytes (.getBytes digest "UTF-8")))
 
-(defn- stamp-revision
-  "Pure: stamp a pack with `:pack/digest` + `:pack/revision-id`
-   derived from its current content projection. Idempotent for an
-   already-stamped pack whose content has not changed."
-  [pack]
-  (let [d (compute-digest pack)]
-    (assoc pack
-           :pack/digest      d
-           :pack/revision-id (revision-id-from-digest d))))
-
-(def ^:private derived-fields
+(def ^{:stratum 0} ^:private derived-fields
   "Fields the constructor / updater own — callers cannot override
    them via `update-pack`. Ensures the relationship between content
    and revision identity stays tamper-evident, mirroring the
    zettel-side spoof guard."
   #{:pack/digest :pack/revision-id})
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Public constructors + projection.
-
-(defn zettel->ref
+(defn ^{:stratum 0} zettel->ref
   "Pure: project a zettel map down to the `(zettel/id,
    zettel/revision-id, zettel/digest)` triple a pack manifest holds.
 
@@ -111,7 +84,38 @@
      :zettel/revision-id revision-id
      :zettel/digest      digest}))
 
-(defn build-pack
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} content-projection
+  "Pure: project a pack down to the content-bearing subset that feeds
+   the digest. Stable across additions of operational metadata."
+  [pack]
+  (select-keys pack content-bearing-fields))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} compute-digest
+  "Pure: SHA-256 hex of the pack's canonical-EDN content-projection.
+   Stable across map-key reorderings and across non-content metadata
+   changes; rotates whenever a content-bearing field changes."
+  [pack]
+  (content-hash/content-hash (content-projection pack)))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn- ^{:stratum 3} stamp-revision
+  "Pure: stamp a pack with `:pack/digest` + `:pack/revision-id`
+   derived from its current content projection. Idempotent for an
+   already-stamped pack whose content has not changed."
+  [pack]
+  (let [d (compute-digest pack)]
+    (assoc pack
+           :pack/digest      d
+           :pack/revision-id (revision-id-from-digest d))))
+
+;------------------------------------------------------------------------------ Layer 4
+
+(defn ^{:stratum 4} build-pack
   "Construct a fresh content-addressed pack manifest.
 
    Required arguments:
@@ -165,7 +169,7 @@
                oss-version            (assoc :fleet/oss-version oss-version))]
     (stamp-revision pack)))
 
-(defn update-pack
+(defn ^{:stratum 4} update-pack
   "Update a pack with new values, setting the modified timestamp.
 
    `:pack/digest` and `:pack/revision-id` are DERIVED — any value
@@ -192,7 +196,9 @@
                       (assoc :pack/modified (java.util.Date.)))]
     (stamp-revision merged)))
 
-(defn add-zettel
+;------------------------------------------------------------------------------ Layer 5
+
+(defn ^{:stratum 5} add-zettel
   "Add a zettel reference to a pack's manifest. The zettel is
    projected via `zettel->ref` (so callers can pass the zettel map
    directly) and the pack revision rotates via `update-pack`."
@@ -201,7 +207,7 @@
         existing (vec (:pack/zettels pack))]
     (update-pack pack {:pack/zettels (conj existing ref)})))
 
-(defn remove-zettel
+(defn ^{:stratum 5} remove-zettel
   "Remove every reference to `zettel-id` from the pack's manifest.
    Pack revision rotates if any reference was actually removed."
   [pack zettel-id]

--- a/components/knowledge-pack/src/ai/miniforge/knowledge_pack/schema.clj
+++ b/components/knowledge-pack/src/ai/miniforge/knowledge_pack/schema.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.knowledge-pack.schema
   "Malli schemas for Zettelkasten knowledge packs.
 
@@ -46,9 +45,9 @@
    [ai.miniforge.knowledge.interface :as knowledge]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Content-addressed reference triple.
 
-(def ZettelRef
+;; Content-addressed reference triple.
+(def ^{:stratum 0} ZettelRef
   "The canonical Decision-6 reference to a zettel revision. Pack
    manifests + future content-addressed surfaces reference zettels
    only via this triple; no surface is permitted to substitute the
@@ -60,9 +59,9 @@
    [:zettel/digest      [:re #"^[0-9a-f]{64}$"]]])
 
 ;------------------------------------------------------------------------------ Layer 1
-;; Pack manifest.
 
-(def KnowledgePack
+;; Pack manifest.
+(def ^{:stratum 1} KnowledgePack
   "A curated collection of zettel revisions distributed as a
    content-addressed manifest.
 

--- a/components/knowledge-pack/src/ai/miniforge/knowledge_pack/verify.clj
+++ b/components/knowledge-pack/src/ai/miniforge/knowledge_pack/verify.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.knowledge-pack.verify
   "Pack manifest verification — the boundary that turns a stored
    pack back into a trusted citation.
@@ -49,9 +48,9 @@
    [ai.miniforge.knowledge-pack.pack :as pack]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Discrepancy factory + per-ref verification.
 
-(defn- discrepancy
+;; Discrepancy factory + per-ref verification.
+(defn- ^{:stratum 0} discrepancy
   "Pure factory: build a discrepancy map. `extras` is an optional
    map merged onto the `{:reason :detail}` base; per-ref callers
    pass `{:ref ref :stored-digest ...}` and manifest-level callers
@@ -61,7 +60,9 @@
   ([reason detail extras]
    (merge {:reason reason :detail detail} extras)))
 
-(defn- verify-ref
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} verify-ref
   "Pure: compare a single `:pack/zettels` entry against what the
    store currently holds. Returns nil on success or a structured
    discrepancy map on failure."
@@ -88,10 +89,8 @@
                    "lookup returned a zettel with a different :zettel/revision-id (lookup-fn invariant violation)"
                    {:ref ref}))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Manifest-level verification.
-
-(defn- verify-manifest-digest
+(defn- ^{:stratum 1} verify-manifest-digest
   "Pure: recompute the pack's digest from the current content
    projection, compare against the stamped digest, AND verify the
    stamped `:pack/revision-id` is the UUID derived from that
@@ -131,7 +130,9 @@
                    {:stamped-revision-id stamped-rev
                     :derived-revision-id derived-rev}))))
 
-(defn verify-pack
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} verify-pack
   "Verify a pack against a zettel store.
 
    Arguments:

--- a/components/knowledge-pack/src/ai/miniforge/knowledge_pack/verify.clj
+++ b/components/knowledge-pack/src/ai/miniforge/knowledge_pack/verify.clj
@@ -49,7 +49,7 @@
 
 ;------------------------------------------------------------------------------ Layer 0
 
-;; Discrepancy factory + per-ref verification.
+;; Discrepancy factory.
 (defn- ^{:stratum 0} discrepancy
   "Pure factory: build a discrepancy map. `extras` is an optional
    map merged onto the `{:reason :detail}` base; per-ref callers

--- a/components/knowledge-pack/test/ai/miniforge/knowledge_pack/pack_test.clj
+++ b/components/knowledge-pack/test/ai/miniforge/knowledge_pack/pack_test.clj
@@ -9,7 +9,6 @@
 ;; You may obtain a copy of the License at
 ;;
 ;;     http://www.apache.org/licenses/LICENSE-2.0
-
 (ns ai.miniforge.knowledge-pack.pack-test
   "Tests for `knowledge-pack/build-pack` + `update-pack` + projection
    helpers. Covers the same revision-keyed identity invariants the
@@ -26,9 +25,9 @@
    [java.util UUID]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Helpers.
 
-(defn- z
+;; Helpers.
+(defn- ^{:stratum 0} z
   "Build a fresh stamped zettel via the OSS knowledge constructor.
    Each call produces a different :zettel/id but the same
    :zettel/revision-id when the content is identical."
@@ -38,24 +37,59 @@
            content "# Body of the test zettel."}}]
   (knowledge/create-zettel uid title content :rule))
 
-(defn- pack-of
+(defn- ^{:stratum 0} pack-of
   "Build a pack with sensible defaults around the supplied zettels."
   [zettels & overrides]
   (apply kp/build-pack
          "test-pack" "Test Pack" "1.0.0" zettels
          overrides))
 
-;------------------------------------------------------------------------------ Layer 1
-;; build-pack stamps revision + digest deterministically.
+(deftest ^{:stratum 0} test-update-backfills-derived-fields-on-legacy-pack
+  (testing "a legacy pack without derived fields gets them stamped on first update"
+    (let [legacy {:pack/id      (UUID/randomUUID)
+                  :pack/uid     "legacy-pack"
+                  :pack/title   "Legacy"
+                  :pack/version "0.0.1"
+                  :pack/zettels []
+                  :pack/created (java.util.Date.)
+                  :pack/author  "user"}
+          updated (kp/update-pack legacy {:fleet/oss-version "1.0.0"})]
+      (is (string? (:pack/digest updated)))
+      (is (= 64 (count (:pack/digest updated))))
+      (is (instance? UUID (:pack/revision-id updated))))))
 
-(deftest test-build-pack-stamps-revision-and-digest
+(deftest ^{:stratum 0} test-zettel-ref-throws-on-missing-fields
+  (testing "a zettel missing revision-id / digest cannot be projected to a pack triple"
+    ;; The constructor refuses to silently emit a malformed triple —
+    ;; per Decision 6, packs reference content-addressable zettels
+    ;; only.
+    (let [legacy {:zettel/id (UUID/randomUUID)
+                  :zettel/uid "legacy"
+                  :zettel/title "Legacy"
+                  :zettel/content "Body."
+                  :zettel/type :rule
+                  :zettel/created (java.util.Date.)
+                  :zettel/author "user"}]
+      (is (thrown? clojure.lang.ExceptionInfo (kp/zettel->ref legacy))))))
+
+(deftest ^{:stratum 0} test-zettelref-schema-rejects-uppercase-digest
+  (testing ":zettel/digest must be lowercase hex per the shared regex"
+    (let [bad {:zettel/id          (UUID/randomUUID)
+               :zettel/revision-id (UUID/randomUUID)
+               :zettel/digest      "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF"}]
+      (is (false? (m/validate kp-schema/ZettelRef bad))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; build-pack stamps revision + digest deterministically.
+(deftest ^{:stratum 1} test-build-pack-stamps-revision-and-digest
   (testing "every fresh pack carries a 64-char hex digest + a UUID revision-id"
     (let [p (pack-of [(z) (z :uid "second" :content "different content")])]
       (is (string? (:pack/digest p)))
       (is (re-matches #"^[0-9a-f]{64}$" (:pack/digest p)))
       (is (instance? UUID (:pack/revision-id p))))))
 
-(deftest test-pack-revision-id-is-deterministic-over-content
+(deftest ^{:stratum 1} test-pack-revision-id-is-deterministic-over-content
   (testing "two packs that reference the same zettel triples land on the same revision-id and digest"
     ;; The pack's content-projection includes :pack/zettels (the
     ;; vector of (zettel-id, revision-id, digest) triples), so
@@ -73,7 +107,7 @@
       (is (= (:pack/digest p1)      (:pack/digest p2)))
       (is (= (:pack/revision-id p1) (:pack/revision-id p2))))))
 
-(deftest test-distinct-content-produces-distinct-revision
+(deftest ^{:stratum 1} test-distinct-content-produces-distinct-revision
   (testing "any change to a content-bearing field produces a different revision-id"
     (let [shared (z)
           p1 (pack-of [shared])
@@ -81,16 +115,14 @@
       (is (not= (:pack/digest p1)      (:pack/digest p2)))
       (is (not= (:pack/revision-id p1) (:pack/revision-id p2))))))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; update-pack semantics.
-
-(deftest test-update-content-rotates-revision
+(deftest ^{:stratum 1} test-update-content-rotates-revision
   (testing "changing :pack/title rotates the revision"
     (let [p1 (pack-of [(z)])
           p2 (kp/update-pack p1 {:pack/title "Renamed"})]
       (is (not= (:pack/revision-id p1) (:pack/revision-id p2))))))
 
-(deftest test-update-zettels-rotates-revision
+(deftest ^{:stratum 1} test-update-zettels-rotates-revision
   (testing "adding a zettel ref rotates the revision"
     (let [p1 (pack-of [(z)])
           p2 (kp/add-zettel p1 (z :uid "second" :content "different content"))]
@@ -98,7 +130,7 @@
       (is (= 1 (count (:pack/zettels p1))))
       (is (= 2 (count (:pack/zettels p2)))))))
 
-(deftest test-remove-zettel-rotates-revision
+(deftest ^{:stratum 1} test-remove-zettel-rotates-revision
   (testing "removing a zettel ref rotates the revision"
     (let [zettel (z)
           p1 (pack-of [zettel])
@@ -106,7 +138,7 @@
       (is (not= (:pack/revision-id p1) (:pack/revision-id p2)))
       (is (empty? (:pack/zettels p2))))))
 
-(deftest test-update-operational-metadata-leaves-revision-intact
+(deftest ^{:stratum 1} test-update-operational-metadata-leaves-revision-intact
   (testing "operational-only changes (privacy, share scope, oss-version) preserve revision"
     (let [p1 (pack-of [(z)] :privacy/classification :internal :fleet/oss-version "1.0.0")
           p2 (kp/update-pack p1 {:privacy/classification :restricted})
@@ -117,7 +149,7 @@
       (is (= (:pack/revision-id p3) (:pack/revision-id p4)))
       (is (= (:pack/digest p1) (:pack/digest p4))))))
 
-(deftest test-update-ignores-caller-supplied-derived-fields
+(deftest ^{:stratum 1} test-update-ignores-caller-supplied-derived-fields
   (testing "callers cannot spoof :pack/digest or :pack/revision-id via update-pack"
     (let [p1 (pack-of [(z)])
           forged-digest "0000000000000000000000000000000000000000000000000000000000000000"
@@ -129,24 +161,8 @@
       (is (= (:pack/digest p1) (:pack/digest p2))
           "digest stays equal to p1's because content didn't change"))))
 
-(deftest test-update-backfills-derived-fields-on-legacy-pack
-  (testing "a legacy pack without derived fields gets them stamped on first update"
-    (let [legacy {:pack/id      (UUID/randomUUID)
-                  :pack/uid     "legacy-pack"
-                  :pack/title   "Legacy"
-                  :pack/version "0.0.1"
-                  :pack/zettels []
-                  :pack/created (java.util.Date.)
-                  :pack/author  "user"}
-          updated (kp/update-pack legacy {:fleet/oss-version "1.0.0"})]
-      (is (string? (:pack/digest updated)))
-      (is (= 64 (count (:pack/digest updated))))
-      (is (instance? UUID (:pack/revision-id updated))))))
-
-;------------------------------------------------------------------------------ Layer 3
 ;; zettel->ref projection.
-
-(deftest test-zettel-ref-projects-canonical-triple
+(deftest ^{:stratum 1} test-zettel-ref-projects-canonical-triple
   (testing "zettel->ref returns a closed (id, revision-id, digest) map"
     (let [zettel (z)
           ref    (kp/zettel->ref zettel)]
@@ -156,24 +172,8 @@
       (is (= (:zettel/revision-id zettel) (:zettel/revision-id ref)))
       (is (= (:zettel/digest zettel)      (:zettel/digest ref))))))
 
-(deftest test-zettel-ref-throws-on-missing-fields
-  (testing "a zettel missing revision-id / digest cannot be projected to a pack triple"
-    ;; The constructor refuses to silently emit a malformed triple —
-    ;; per Decision 6, packs reference content-addressable zettels
-    ;; only.
-    (let [legacy {:zettel/id (UUID/randomUUID)
-                  :zettel/uid "legacy"
-                  :zettel/title "Legacy"
-                  :zettel/content "Body."
-                  :zettel/type :rule
-                  :zettel/created (java.util.Date.)
-                  :zettel/author "user"}]
-      (is (thrown? clojure.lang.ExceptionInfo (kp/zettel->ref legacy))))))
-
-;------------------------------------------------------------------------------ Layer 4
 ;; Schema acceptance.
-
-(deftest test-built-pack-validates-against-schema
+(deftest ^{:stratum 1} test-built-pack-validates-against-schema
   (testing "the constructor stamps a pack that round-trips through Malli"
     (let [p (pack-of [(z)] :description "A test pack."
                      :fleet/shareable true
@@ -181,10 +181,3 @@
                      :privacy/classification :internal
                      :fleet/oss-version "1.0.0")]
       (is (m/validate kp/KnowledgePack p)))))
-
-(deftest test-zettelref-schema-rejects-uppercase-digest
-  (testing ":zettel/digest must be lowercase hex per the shared regex"
-    (let [bad {:zettel/id          (UUID/randomUUID)
-               :zettel/revision-id (UUID/randomUUID)
-               :zettel/digest      "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF"}]
-      (is (false? (m/validate kp-schema/ZettelRef bad))))))

--- a/components/knowledge-pack/test/ai/miniforge/knowledge_pack/verify_test.clj
+++ b/components/knowledge-pack/test/ai/miniforge/knowledge_pack/verify_test.clj
@@ -9,7 +9,6 @@
 ;; You may obtain a copy of the License at
 ;;
 ;;     http://www.apache.org/licenses/LICENSE-2.0
-
 (ns ai.miniforge.knowledge-pack.verify-test
   "Tests for `verify-pack` — the boundary that turns a stored pack
    manifest back into a trusted citation. Covers each named outcome:
@@ -27,9 +26,9 @@
    [java.util UUID]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Helpers — build a tiny in-memory zettel store + a lookup-fn.
 
-(defn- store-of
+;; Helpers — build a tiny in-memory zettel store + a lookup-fn.
+(defn- ^{:stratum 0} store-of
   "Build a `(zettel-id, revision-id) → zettel` map from a sequence
    of zettels. The lookup-fn closes over this map."
   [zettels]
@@ -37,16 +36,16 @@
         (map (fn [z] [[(:zettel/id z) (:zettel/revision-id z)] z]))
         zettels))
 
-(defn- lookup-from
+(defn- ^{:stratum 0} lookup-from
   "Build a lookup-fn over an in-memory store map."
   [store]
   (fn [id revision-id]
     (get store [id revision-id])))
 
 ;------------------------------------------------------------------------------ Layer 1
-;; Happy path.
 
-(deftest test-verify-pack-happy-path
+;; Happy path.
+(deftest ^{:stratum 1} test-verify-pack-happy-path
   (testing "every triple resolves + digests match → :valid? true"
     (let [z1 (knowledge/create-zettel "z-1" "Z1" "Body 1." :rule)
           z2 (knowledge/create-zettel "z-2" "Z2" "Body 2." :rule)
@@ -56,10 +55,8 @@
       (is (nil? (:pack/discrepancy result)))
       (is (empty? (:ref/discrepancies result))))))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Per-ref discrepancies.
-
-(deftest test-verify-pack-missing-zettel
+(deftest ^{:stratum 1} test-verify-pack-missing-zettel
   (testing "a triple that doesn't resolve in the store surfaces :zettel-not-found"
     (let [z1   (knowledge/create-zettel "z-1" "Z1" "Body 1." :rule)
           pack (kp/build-pack "p" "Pack" "1.0.0" [z1])
@@ -70,7 +67,7 @@
       (is (= :zettel-not-found
              (-> result :ref/discrepancies first :reason))))))
 
-(deftest test-verify-pack-digest-drift
+(deftest ^{:stratum 1} test-verify-pack-digest-drift
   (testing "a stored zettel's digest differing from the pack triple surfaces :digest-mismatch"
     ;; The pack references z1 with its original digest; the store
     ;; has the SAME id+revision but a tampered digest. Real-world
@@ -86,7 +83,7 @@
       (is (= :digest-mismatch
              (-> result :ref/discrepancies first :reason))))))
 
-(deftest test-verify-pack-lookup-fn-invariant-violation
+(deftest ^{:stratum 1} test-verify-pack-lookup-fn-invariant-violation
   (testing "lookup-fn returning a zettel with mismatched :zettel/id surfaces :id-mismatch"
     (let [z1     (knowledge/create-zettel "z-1" "Z1" "Body 1." :rule)
           pack   (kp/build-pack "p" "Pack" "1.0.0" [z1])
@@ -99,7 +96,7 @@
       (is (= :id-mismatch
              (-> result :ref/discrepancies first :reason))))))
 
-(deftest test-verify-pack-multiple-discrepancies
+(deftest ^{:stratum 1} test-verify-pack-multiple-discrepancies
   (testing "verify accumulates every per-ref problem, not just the first"
     (let [z1   (knowledge/create-zettel "z-1" "Z1" "Body 1." :rule)
           z2   (knowledge/create-zettel "z-2" "Z2" "Body 2." :rule)
@@ -113,10 +110,8 @@
       (is (= #{:zettel-not-found :digest-mismatch}
              (set (map :reason (:ref/discrepancies result))))))))
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Manifest-level discrepancies.
-
-(deftest test-verify-pack-detects-tampered-manifest
+(deftest ^{:stratum 1} test-verify-pack-detects-tampered-manifest
   (testing "a pack whose body was edited without going through update-pack surfaces :pack/digest-mismatch"
     ;; Forge a pack: build, then mutate :pack/title directly without
     ;; update-pack — :pack/digest stays at the old content's digest.
@@ -128,7 +123,7 @@
       (is (= :pack/digest-mismatch
              (-> result :pack/discrepancy :reason))))))
 
-(deftest test-verify-pack-detects-missing-manifest-digest
+(deftest ^{:stratum 1} test-verify-pack-detects-missing-manifest-digest
   (testing "a legacy pack without :pack/digest fails verification with :pack/digest-missing"
     (let [legacy {:pack/id      (UUID/randomUUID)
                   :pack/uid     "legacy"
@@ -142,7 +137,7 @@
       (is (= :pack/digest-missing
              (-> result :pack/discrepancy :reason))))))
 
-(deftest test-verify-pack-detects-missing-revision-id
+(deftest ^{:stratum 1} test-verify-pack-detects-missing-revision-id
   (testing "a pack with :pack/digest but no :pack/revision-id surfaces :pack/revision-id-missing"
     ;; Partial stamping should never happen via the constructors
     ;; (build-pack / update-pack always stamp both), but a forged
@@ -155,7 +150,7 @@
       (is (= :pack/revision-id-missing
              (-> result :pack/discrepancy :reason))))))
 
-(deftest test-verify-pack-detects-forged-revision-id
+(deftest ^{:stratum 1} test-verify-pack-detects-forged-revision-id
   (testing ":pack/revision-id forged independent of :pack/digest fails with :pack/revision-id-mismatch"
     ;; An attacker-rotated `:pack/revision-id` (e.g. attempting to
     ;; ride existing trust onto new content by stamping a forged

--- a/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-knowledge-pack.md
+++ b/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-knowledge-pack.md
@@ -1,0 +1,114 @@
+# fix: stratum-lint autofix for components/knowledge-pack (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over `components/knowledge-pack` (`src` + `test`)
+to replace decorative `Layer N` headings with real ones + `^{:stratum n}`
+metadata derived from each file's actual same-file reference graph.
+Mechanically driven; two follow-up docstring corrections were needed where
+the fix changed a file's real layer count and left the ns docstring's own
+"how many strata" claim stale. One of the smaller per-component Wave 1 PRs
+from `work/stratum-lint-baseline-2026-07-24.md`.
+
+## Motivation
+
+`knowledge-pack` carried 2 findings under the baseline's cargo-cult
+diagnosis, both `SL003` (over-budget heading count) on the two test files:
+`pack_test.clj` (5 distinct layers) and `verify_test.clj` (4 distinct
+layers). Zero `SL001` findings, so no upward-reference/cycle risk to
+reason about before running the mechanical fixer — matches the baseline's
+Wave 1 batch criteria exactly.
+
+## Changes in Detail
+
+Ran, over the whole component:
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "80699e378cb8ebbb6daeb928431aa4a6b373c07e" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/knowledge-pack
+```
+
+All 6 files rewritten: `interface.clj`, `pack.clj`, `schema.clj`,
+`verify.clj` (`src`), and `pack_test.clj`, `verify_test.clj` (`test`).
+
+- `interface.clj`: every export collapsed to a single real `Layer 0` — all
+  ten defs are pure re-exports of vars from `pack`/`schema`/`verify`, none
+  referencing each other in this file. The ns docstring previously claimed
+  "Two strata: Layer 0 — schema re-exports. Layer 1 — operation
+  re-exports." — now false, since the fix found only one real layer.
+  Reworded to state the actual (one-layer) structure.
+- `pack.clj`: real depth is 6 layers (0–5) — `content-bearing-fields` /
+  `revision-id-from-digest` / `zettel->ref` at Layer 0, rising through
+  `content-projection` → `compute-digest` → `stamp-revision` to the public
+  constructors (`build-pack`, `update-pack`) at Layer 4 and the manifest
+  mutators (`add-zettel`, `remove-zettel`) at Layer 5. The ns docstring
+  previously claimed "Two strata mirror the zettel module" — also now
+  false; reworded to state the real 6-layer chain and flag it as a
+  namespace-split candidate.
+- `schema.clj`: 2 real layers (`ZettelRef` at Layer 0, `KnowledgePack` at
+  Layer 1) — matched its existing docstring claim exactly, no wording
+  change needed.
+- `verify.clj`: 3 real layers (0–2), within budget — heading text and
+  metadata only.
+- `pack_test.clj` / `verify_test.clj`: real depth collapsed from 5→2 and
+  4→2 respectively (most `deftest` forms don't reference each other, so
+  they land on the same real layer as the helpers or the first consumer).
+
+No line of executable code changed; diffs are heading text,
+`^{:stratum n}` metadata, def/deftest reordering, and (in `interface.clj`
+and `pack.clj` only) the two docstring corrections above.
+
+## Testing Plan
+
+1. Ran plain (non-`--fix`) `stratum-lint` before the fix — reproduced the
+   baseline's exact 2 findings (`SL003` on both test files).
+2. Ran `--fix`, then a second `--fix` pass immediately after — zero diff,
+   confirms idempotency. Re-ran a third time after the two manual
+   docstring edits — still zero diff.
+3. Read the full diff for all 6 changed files. No same-line trailing
+   comment was displaced onto the wrong def — all comments in this
+   component were already own-line banners, so that known tool limitation
+   doesn't apply here. Found the other known pattern instead (stale
+   layer-count claim in a docstring, not a section banner) in
+   `interface.clj` and `pack.clj`; both corrected by hand per-occurrence,
+   as above.
+4. `clj-kondo --lint components/knowledge-pack`: 0 errors, 0 warnings,
+   before and after.
+5. Ran both test namespaces directly via `clojure -M:test`: 22 tests, 53
+   assertions, 0 failures, 0 errors.
+6. Re-ran plain `stratum-lint` after the fix: `SL001`/`SL002`/`SL004` clear
+   everywhere. `SL003` newly appears on `pack.clj` — **not** the same
+   finding as before the fix (which reported zero findings for this file);
+   the old 2-layer heading under-counted the real reference chain, and
+   `--fix` surfaced the true 6-layer depth. Deferred to Wave 2 (real
+   namespace split), consistent with how prior Wave 1 PRs (`bb-config`,
+   `decision`, `compliance-scanner`) handled the same situation. The two
+   pre-existing `SL003` findings on the test files are resolved (both
+   collapsed to 2 real layers, within budget).
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+change — comment/metadata/order/docstring-only. Pre-commit's
+`lint:stratum` autofixer keeps this component clean going forward;
+`pack.clj`'s `SL003` stays advisory (`MINIFORGE_STRATUM_BUDGET_MODE=warn`
+at commit time) until Wave 2 splits it.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+- Follow-on: Wave 2 namespace split for
+  `components/knowledge-pack/src/ai/miniforge/knowledge_pack/pack.clj`
+  (6 real layers, over the 3-layer budget)
+
+## Checklist
+
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Second (and third, post-manual-edit) `--fix` pass confirms
+      idempotency (zero diff)
+- [x] Diff read in full for all 6 changed files; mechanical, plus two
+      hand-corrected stale docstring claims
+- [x] `clj-kondo` clean before/after (0 errors, 0 warnings)
+- [x] Component tests pass (22 tests, 53 assertions, 0 failures/errors)
+- [x] Plain lint re-run post-fix: zero findings except `SL003`
+      (`pack.clj`, newly surfaced, documented above, tracked as Wave 2)
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time

--- a/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-knowledge-pack.md
+++ b/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-knowledge-pack.md
@@ -53,8 +53,8 @@ All 6 files rewritten: `interface.clj`, `pack.clj`, `schema.clj`,
   4→2 respectively (most `deftest` forms don't reference each other, so
   they land on the same real layer as the helpers or the first consumer).
 
-No line of executable code changed; diffs are heading text,
-`^{:stratum n}` metadata, def/deftest reordering, and (in `interface.clj`
+No change in runtime behavior — diffs are heading text,
+`^{:stratum n}` metadata, and def/deftest reordering, and (in `interface.clj`
 and `pack.clj` only) the two docstring corrections above.
 
 ## Testing Plan


### PR DESCRIPTION
## Summary

- Mechanical `stratum-lint --fix` pass over `components/knowledge-pack` (`src` + `test`), replacing decorative `Layer N` headings with real ones + `^{:stratum n}` metadata derived from each file's actual same-file reference graph (rule 210).
- Resolves the 2 baseline `SL003` findings (both test files, over-counted at 5 and 4 layers, now 2 real layers each). Zero `SL001` findings — no upward-reference/cycle risk.
- Hand-corrected two ns docstrings (`interface.clj`, `pack.clj`) whose "how many strata" claims went stale once the fix recomputed the real layer count.
- `pack.clj` now reports a **new** `SL003`: 6 real layers (0–5), previously hidden by an under-counted 2-layer heading. Deferred to Wave 2 (namespace split) per `work/stratum-lint-baseline-2026-07-24.md`.

Full detail: `docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-knowledge-pack.md`.

## Test plan

- [x] `--fix` run twice (idempotent, zero diff on second pass), and a third time after manual docstring edits (still zero diff)
- [x] Full diff read for all 6 changed files — mechanical, plus 2 hand-corrected stale docstring claims
- [x] `clj-kondo --lint components/knowledge-pack`: 0 errors, 0 warnings
- [x] Component tests: 22 tests, 53 assertions, 0 failures/errors (`clojure -M:test`)
- [x] Plain lint re-run post-fix: clean except the newly-surfaced `SL003` on `pack.clj` (documented, tracked as Wave 2)
- [x] Pre-commit hook ran clean (331 tests / 1241 assertions smoke suite + 8 GraalVM compat tests / 546 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)