### PR TITLE
fix: stratum-lint autofix for components/pr-scoring (Wave 1)

### DIFF
--- a/components/pr-scoring/src/ai/miniforge/pr_scoring/core.clj
+++ b/components/pr-scoring/src/ai/miniforge/pr_scoring/core.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-scoring.core
   "PR scoring component — produces `:pr/scored` events per N5-delta-2 §3.
 
@@ -60,44 +59,24 @@
    [ai.miniforge.event-stream.interface.events :as events]))
 
 ;------------------------------------------------------------------------------ Layer 0
+
 ;; Subscription key
+(def ^{:stratum 0} ^:private subscriber-id ::pr-scoring)
 
-(def ^:private subscriber-id ::pr-scoring)
-
-;------------------------------------------------------------------------------ Layer 0
 ;; Trigger events — loaded from data
-
-(def trigger-config-resource
+(def ^{:stratum 0} trigger-config-resource
   "config/pr-scoring/triggers.edn")
 
-(defn load-default-triggers
-  "Read the default trigger-event-types set from the resource at
-   [[trigger-config-resource]]. Callers MAY override at component
-   construction time via the `:trigger-event-types` option to [[create]]
-   — the config is data, not compiled-in logic."
-  []
-  (if-let [r (io/resource trigger-config-resource)]
-    (edn/read-string (slurp r))
-    (throw (ex-info "pr-scoring: missing trigger-event-types config resource"
-                    {:resource trigger-config-resource}))))
-
-(def default-trigger-event-types
-  (delay (load-default-triggers)))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; Default scorer (no-op)
-
-(defn default-scorer-fn
+(defn ^{:stratum 0} default-scorer-fn
   "Placeholder scorer — returns `nil` so no `:pr/scored` events are
    emitted. Replace with a real scorer at `create` time once the
    `pr-train` + `policy-pack` integration lands."
   [_pr-event]
   nil)
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Event handling
-
-(defn- emit-scored!
+(defn- ^{:stratum 0} emit-scored!
   "Call `scorer-fn` on `event` and, if scores are returned, publish a
    `:pr/scored` event on `stream` carrying them."
   [stream scorer-fn event]
@@ -109,7 +88,20 @@
                                    scores
                                    (select-keys event [:workflow/id])))))
 
-(defn- handle-event!
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} load-default-triggers
+  "Read the default trigger-event-types set from the resource at
+   [[trigger-config-resource]]. Callers MAY override at component
+   construction time via the `:trigger-event-types` option to [[create]]
+   — the config is data, not compiled-in logic."
+  []
+  (if-let [r (io/resource trigger-config-resource)]
+    (edn/read-string (slurp r))
+    (throw (ex-info "pr-scoring: missing trigger-event-types config resource"
+                    {:resource trigger-config-resource}))))
+
+(defn- ^{:stratum 1} handle-event!
   "Entry point for every event the stream delivers. No-op unless the
    event type is in `triggers`. A scorer-fn that throws is suppressed
    silently (for the scaffold) — a follow-up PR wires proper structured
@@ -120,10 +112,34 @@
       (emit-scored! stream scorer-fn event)
       (catch Throwable _t nil))))
 
-;------------------------------------------------------------------------------ Layer 3
-;; Lifecycle
+(defn ^{:stratum 1} stop!
+  "Unsubscribe. Idempotent."
+  [component]
+  (let [{:keys [stream subscribed?]} @component]
+    (when subscribed?
+      (es/unsubscribe! stream subscriber-id)
+      (swap! component assoc :subscribed? false))
+    component))
 
-(defn create
+;------------------------------------------------------------------------------ Layer 2
+
+(def ^{:stratum 2} default-trigger-event-types
+  (delay (load-default-triggers)))
+
+(defn ^{:stratum 2} start!
+  "Subscribe to the stream. Idempotent — repeat calls are no-ops."
+  [component]
+  (let [{:keys [stream scorer-fn triggers subscribed?]} @component]
+    (when-not subscribed?
+      (es/subscribe! stream subscriber-id
+                     (fn [event] (handle-event! triggers scorer-fn stream event)))
+      (swap! component assoc :subscribed? true))
+    component))
+
+;------------------------------------------------------------------------------ Layer 3
+
+;; Lifecycle
+(defn ^{:stratum 3} create
   "Build a fresh pr-scoring component instance bound to `stream`. Does
    not subscribe yet — call `start!` to begin consuming events.
 
@@ -141,26 +157,9 @@
           :triggers (or trigger-event-types @default-trigger-event-types)
           :subscribed? false})))
 
-(defn start!
-  "Subscribe to the stream. Idempotent — repeat calls are no-ops."
-  [component]
-  (let [{:keys [stream scorer-fn triggers subscribed?]} @component]
-    (when-not subscribed?
-      (es/subscribe! stream subscriber-id
-                     (fn [event] (handle-event! triggers scorer-fn stream event)))
-      (swap! component assoc :subscribed? true))
-    component))
+;------------------------------------------------------------------------------ Layer 4
 
-(defn stop!
-  "Unsubscribe. Idempotent."
-  [component]
-  (let [{:keys [stream subscribed?]} @component]
-    (when subscribed?
-      (es/unsubscribe! stream subscriber-id)
-      (swap! component assoc :subscribed? false))
-    component))
-
-(defn attach!
+(defn ^{:stratum 4} attach!
   "Create + start in one step."
   ([stream] (attach! stream {}))
   ([stream opts] (start! (create stream opts))))

--- a/components/pr-scoring/src/ai/miniforge/pr_scoring/interface.clj
+++ b/components/pr-scoring/src/ai/miniforge/pr_scoring/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-scoring.interface
   "Public API for the pr-scoring component (N5-delta-2 §3).
 
@@ -36,10 +35,10 @@
   (:require
    [ai.miniforge.pr-scoring.core :as core]))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Lifecycle
+;------------------------------------------------------------------------------ Layer 0
 
-(def create
+;; Lifecycle
+(def ^{:stratum 0} create
   "Build a fresh pr-scoring component instance bound to event stream `stream`.
    Does not subscribe yet — call [[start!]] to begin consuming events.
 
@@ -53,45 +52,43 @@
    {:stream :scorer-fn :triggers :subscribed?}."
   core/create)
 
-(def start!
+(def ^{:stratum 0} start!
   "Subscribe the component to its stream so events begin flowing to the
    scorer-fn. Idempotent — repeat calls are no-ops.
    Args: `component` (the atom from [[create]]). Returns that same atom."
   core/start!)
 
-(def stop!
+(def ^{:stratum 0} stop!
   "Unsubscribe the component from its stream. Idempotent — no-op if not
    currently subscribed.
    Args: `component` (the atom). Returns that same atom."
   core/stop!)
 
-(def attach!
+(def ^{:stratum 0} attach!
   "Create + start in one step.
    Args: `stream`, and an optional opts map (see [[create]]).
    Returns the started component atom."
   core/attach!)
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Extension points
-
-(def default-scorer-fn
+(def ^{:stratum 0} default-scorer-fn
   "Placeholder scorer used when no `:scorer-fn` is supplied to [[create]].
    1-ary fn (pr-event → nil); always returns nil, so no `:pr/scored`
    events are emitted. Replace with a real scorer at create time."
   core/default-scorer-fn)
 
-(def load-default-triggers
+(def ^{:stratum 0} load-default-triggers
   "Read the default trigger-event-types set from the classpath resource at
    [[trigger-config-resource]]. Takes no args. Returns a set of event-type
    keywords. Throws ex-info if the resource is missing from the classpath."
   core/load-default-triggers)
 
-(def default-trigger-event-types
+(def ^{:stratum 0} default-trigger-event-types
   "A delay wrapping the default trigger set (see [[load-default-triggers]]);
    deref to obtain the set of event-type keywords. Delayed so the classpath
    scan runs on first use rather than at namespace load."
   core/default-trigger-event-types)
 
-(def trigger-config-resource
+(def ^{:stratum 0} trigger-config-resource
   "String: classpath location of the default trigger-event-types EDN set."
   core/trigger-config-resource)

--- a/components/pr-scoring/test/ai/miniforge/pr_scoring/core_test.clj
+++ b/components/pr-scoring/test/ai/miniforge/pr_scoring/core_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-scoring.core-test
   "Plumbing tests for the pr-scoring component. Real scoring logic is
    supplied via an injected scorer-fn — these tests use a stub scorer
@@ -26,24 +25,16 @@
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.pr-scoring.interface :as scoring]))
 
-;------------------------------------------------------------------------------ Helpers
+;------------------------------------------------------------------------------ Layer 0
 
-(defn- stream []
+;------------------------------------------------------------------------------ Helpers
+(defn- ^{:stratum 0} stream []
   (es/create-event-stream {:sinks []}))
 
-(defn- captured-stream
-  "Build a stream + attach a capture listener. Returns `[stream events-atom]`
-   where `events-atom` accrues every published event."
-  []
-  (let [s (stream)
-        captured (atom [])]
-    (es/subscribe! s ::capture (fn [ev] (swap! captured conj ev)))
-    [s captured]))
-
-(defn- scored-events [events]
+(defn- ^{:stratum 0} scored-events [events]
   (filter #(= :pr/scored (:event/type %)) events))
 
-(defn- pr-created-event [stream repo number]
+(defn- ^{:stratum 0} pr-created-event [stream repo number]
   ;; pr/created isn't an event-stream constructor yet, so hand-build a
   ;; minimal envelope matching the producer shape other components use.
   {:event/type            :pr/created
@@ -56,7 +47,7 @@
    :pr/number             number
    :pr/title              "test PR"})
 
-(def sample-scores
+(def ^{:stratum 0} sample-scores
   {:readiness {:readiness/score 0.9
                :readiness/threshold 0.8
                :readiness/ready? true
@@ -68,21 +59,40 @@
             :policy/violations []}
    :recommendation :merge})
 
-;------------------------------------------------------------------------------ Lifecycle
+(deftest ^{:stratum 0} default-trigger-set-is-loaded-from-edn
+  (testing "triggers come from the EDN resource, not a compiled-in literal"
+    (let [triggers @scoring/default-trigger-event-types]
+      (is (set? triggers))
+      (is (contains? triggers :pr/created))
+      (is (contains? triggers :pr/merged))
+      (is (not (contains? triggers :workflow/started))
+          "workflow events are not PR scoring triggers"))))
 
-(deftest create-does-not-subscribe
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} captured-stream
+  "Build a stream + attach a capture listener. Returns `[stream events-atom]`
+   where `events-atom` accrues every published event."
+  []
+  (let [s (stream)
+        captured (atom [])]
+    (es/subscribe! s ::capture (fn [ev] (swap! captured conj ev)))
+    [s captured]))
+
+;------------------------------------------------------------------------------ Lifecycle
+(deftest ^{:stratum 1} create-does-not-subscribe
   (let [s (stream)
         c (scoring/create s)]
     (is (false? (:subscribed? @c)))))
 
-(deftest start-then-stop-roundtrips-subscription-flag
+(deftest ^{:stratum 1} start-then-stop-roundtrips-subscription-flag
   (let [s (stream)
         c (scoring/attach! s)]
     (is (true? (:subscribed? @c)))
     (scoring/stop! c)
     (is (false? (:subscribed? @c)))))
 
-(deftest start-is-idempotent
+(deftest ^{:stratum 1} start-is-idempotent
   (let [s (stream)
         c (scoring/attach! s)]
     (is (true? (:subscribed? @c)))
@@ -90,16 +100,17 @@
     (is (true? (:subscribed? @c)) "repeat start! is a no-op")
     (scoring/stop! c)))
 
-;------------------------------------------------------------------------------ Emission
+;------------------------------------------------------------------------------ Layer 2
 
-(deftest default-scorer-emits-nothing
+;------------------------------------------------------------------------------ Emission
+(deftest ^{:stratum 2} default-scorer-emits-nothing
   (let [[s captured] (captured-stream)
         _ (scoring/attach! s)]
     (es/publish! s (pr-created-event s "acme/widget" 42))
     (is (empty? (scored-events @captured))
         "default scorer-fn returns nil; no :pr/scored event emitted")))
 
-(deftest scorer-returning-scores-emits-pr-scored
+(deftest ^{:stratum 2} scorer-returning-scores-emits-pr-scored
   (let [[s captured] (captured-stream)
         _ (scoring/attach! s {:scorer-fn (constantly sample-scores)})]
     (es/publish! s (pr-created-event s "acme/widget" 42))
@@ -111,14 +122,14 @@
         (is (= :low (get-in ev [:pr/risk :risk/level])))
         (is (= :merge (:pr/recommendation ev)))))))
 
-(deftest scorer-returning-nil-skips-emission
+(deftest ^{:stratum 2} scorer-returning-nil-skips-emission
   (let [[s captured] (captured-stream)
         _ (scoring/attach! s {:scorer-fn (fn [_] nil)})]
     (es/publish! s (pr-created-event s "acme/widget" 42))
     (is (empty? (scored-events @captured))
         "nil return from scorer-fn suppresses :pr/scored emission")))
 
-(deftest non-pr-events-do-not-trigger-scorer
+(deftest ^{:stratum 2} non-pr-events-do-not-trigger-scorer
   (let [calls (atom 0)
         [s captured] (captured-stream)
         _ (scoring/attach! s {:scorer-fn (fn [_] (swap! calls inc) sample-scores)})]
@@ -126,16 +137,7 @@
     (is (= 0 @calls) "workflow/started does not trigger scoring")
     (is (empty? (scored-events @captured)))))
 
-(deftest default-trigger-set-is-loaded-from-edn
-  (testing "triggers come from the EDN resource, not a compiled-in literal"
-    (let [triggers @scoring/default-trigger-event-types]
-      (is (set? triggers))
-      (is (contains? triggers :pr/created))
-      (is (contains? triggers :pr/merged))
-      (is (not (contains? triggers :workflow/started))
-          "workflow events are not PR scoring triggers"))))
-
-(deftest trigger-override-narrows-dispatch
+(deftest ^{:stratum 2} trigger-override-narrows-dispatch
   (testing "A caller-supplied :trigger-event-types restricts scoring to just those events"
     (let [calls (atom [])
           [s captured] (captured-stream)
@@ -148,14 +150,14 @@
           "only :pr/merged events invoked the scorer")
       (is (= 1 (count (scored-events @captured)))))))
 
-(deftest scorer-fn-exceptions-are-swallowed
+(deftest ^{:stratum 2} scorer-fn-exceptions-are-swallowed
   (let [[s captured] (captured-stream)
         _ (scoring/attach! s {:scorer-fn (fn [_] (throw (ex-info "boom" {})))})]
     (es/publish! s (pr-created-event s "acme/widget" 42))
     (is (empty? (scored-events @captured))
         "scorer throwing does not crash the component nor emit partial events")))
 
-(deftest partial-score-maps-pass-through
+(deftest ^{:stratum 2} partial-score-maps-pass-through
   (testing "Scorer returns only readiness; emitted event carries only that field"
     (let [[s captured] (captured-stream)
           _ (scoring/attach! s {:scorer-fn (fn [_]

--- a/components/pr-scoring/test/ai/miniforge/pr_scoring/core_test.clj
+++ b/components/pr-scoring/test/ai/miniforge/pr_scoring/core_test.clj
@@ -34,9 +34,11 @@
 (defn- ^{:stratum 0} scored-events [events]
   (filter #(= :pr/scored (:event/type %)) events))
 
-(defn- ^{:stratum 0} pr-created-event [stream repo number]
+(defn- ^{:stratum 0} pr-created-event [_stream repo number]
   ;; pr/created isn't an event-stream constructor yet, so hand-build a
   ;; minimal envelope matching the producer shape other components use.
+  ;; `_stream` kept unused for call-site symmetry with the real
+  ;; event-stream producer signature (every call site passes `s`).
   {:event/type            :pr/created
    :event/id              (random-uuid)
    :event/timestamp       (java.util.Date.)

--- a/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-pr-scoring.md
+++ b/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-pr-scoring.md
@@ -11,7 +11,7 @@ order only.
 
 ## Motivation
 
-`work/stratum-lint-baseline-2026-07-24.md` (Wave 0) found rule 210's
+`work/stratum-lint-baseline-2026-07-24.md`'s diagnosis found rule 210's
 stratified-design headings had been cargo-culted across most of the tree
 into decorative section banners that don't track a real dependency DAG.
 `components/pr-scoring` carried 2 reported findings, both in `core.clj` —

--- a/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-pr-scoring.md
+++ b/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-pr-scoring.md
@@ -1,0 +1,130 @@
+# fix: stratum-lint autofix for components/pr-scoring (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` (sha `80699e378cb8ebbb6daeb928431aa4a6b373c07e`)
+over all 3 Clojure files (2 `src`, 1 `test`) in `components/pr-scoring`,
+regrouping each file's defs under regenerated `;---- Layer N` headings and
+tagging every def with `^{:stratum n}` metadata inferred from the real
+same-file reference graph. No logic changes — headings, metadata, and def
+order only.
+
+## Motivation
+
+`work/stratum-lint-baseline-2026-07-24.md` (Wave 0) found rule 210's
+stratified-design headings had been cargo-culted across most of the tree
+into decorative section banners that don't track a real dependency DAG.
+`components/pr-scoring` carried 2 reported findings, both in `core.clj` —
+`SL002` (a `Layer 0` heading repeated instead of incrementing) and `SL003`
+(4 distinct decorative layers against the 3-layer budget) — and **zero
+`SL001`** upward-reference findings, which is what puts it in the Wave 1
+safe-to-autofix batch: no cycle/upward-call risk to reason about before
+running the mechanical fixer.
+
+## Changes in Detail
+
+Ran, over the whole component:
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "80699e378cb8ebbb6daeb928431aa4a6b373c07e" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/pr-scoring
+```
+
+All 3 files rewritten: `core.clj`, `interface.clj` (both `src`),
+`core_test.clj` (`test`). `--fix` normalizes every file in the component,
+not just the ones with findings — `interface.clj` and `core_test.clj` had
+none of their own; both are pure pass-through/test files where the real
+reference graph collapses to fewer layers than the old decorative banners
+implied.
+
+`core.clj` — the file the baseline flagged — resolves to **5 real layers**
+(`subscriber-id` / `trigger-config-resource` / `default-scorer-fn` /
+`emit-scored!` at 0; `load-default-triggers` / `handle-event!` / `stop!` at
+1; `default-trigger-event-types` / `start!` at 2; `create` at 3; `attach!`
+at 4), not the 4 distinct decorative headings the pre-fix banners showed.
+`--fix`'s honest reference-graph computation surfaced one more real layer
+than the old headings reported, not fewer — this file was under-counted,
+not over-counted, by the cargo-cult banners.
+
+`interface.clj` collapses to a single real layer (`0`): every def in it is
+a pass-through alias into `core`, so none references another same-file def.
+Its old banners (`Layer 1: Lifecycle`, `Layer 2: Extension points`) were
+themselves decorative overcounts of a file with no internal reference
+depth at all.
+
+`core_test.clj` had no `Layer N`-pattern heading before the fix at all
+(its old banners — `Helpers`, `Lifecycle`, `Emission` — are the same
+full-width dashed comment style but omit the word "Layer", so
+`stratum-lint`'s heading regex never matched them and the file was
+silently skipped by the plain-lint scan, per the baseline doc's documented
+limitation). `--fix` still processed it and assigned 3 real layers. Those
+three old banners survived untouched as ordinary comments, now sitting
+inside the corresponding real `Layer N` blocks (`Helpers` under `Layer 0`,
+`Lifecycle` under `Layer 1`, `Emission` under `Layer 2`). Checked each: all
+three still correctly describe the code immediately following them (no
+"Layer N" claim to contradict, and no relocation puts one next to the
+wrong group) — left in place rather than deleted or reworded.
+
+Checked every changed file for the other known tool limitation — a
+same-line trailing comment (`closing-form])  ; comment`) detached and
+reattached next to the wrong def during reordering. None present in this
+component; the one inline comment that exists (`pr-created-event`'s
+`;; pr/created isn't an event-stream constructor yet...`) is already its
+own indented line inside the function body, not a same-line trailing
+comment on a closing form, and moved as a unit with the function.
+
+## Testing Plan
+
+1. Ran plain (non-`--fix`) lint before fixing: 2 findings (`SL002` and
+   `SL003`, both on `core.clj`), 0 `SL001` — matches the baseline.
+2. Ran `--fix`, then ran the identical `--fix` command a second time: no
+   files reported as rewritten; diffed all 3 files byte-for-byte against
+   their post-first-fix state — zero diff, confirming idempotency.
+3. Read the full diff for all 3 changed files. Confirmed the only changes
+   are heading placement, def reordering, and `^{:stratum n}` metadata —
+   no executable code changed.
+4. `clj-kondo --lint components/pr-scoring`: 0 errors, 1 warning
+   (`unused binding stream` in `core_test.clj`'s `pr-created-event`).
+   Confirmed via `git stash` against the pre-fix file that this exact
+   warning (same message) already existed before this PR, just at a
+   different line number (46 → 37) because of reordering. Pre-existing,
+   unrelated to stratum-lint, out of scope for a mechanical single-purpose
+   PR — left untouched.
+5. Re-ran plain `stratum-lint` after the fix: `SL003` remains on
+   `core.clj`, now reporting **5** real layers instead of the 4 distinct
+   decorative ones originally flagged — surfaced by `--fix`'s honest
+   reference-graph analysis, not a regression. Wave 2 scope.
+6. Ran `ai.miniforge.pr-scoring.core-test` directly via `clojure -A:test
+   -e`: 11 tests, 26 assertions, 0 failures, 0 errors.
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+change — comment/metadata/order-only. Pre-commit's `lint:stratum`
+autofixer keeps this component clean going forward; `core.clj`'s `SL003`
+stays advisory (`MINIFORGE_STRATUM_BUDGET_MODE=warn` at commit time) until
+Wave 2 splits it.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+- Precedent: same Wave 1 mechanical-fix pattern as `bb-config`, `logging`,
+  `observer`, `patterns`, `dag-primitives`, and others already merged
+- Follow-on: Wave 2 namespace split for
+  `components/pr-scoring/src/ai/miniforge/pr_scoring/core.clj` (5 real
+  layers, over the 3-layer budget)
+
+## Checklist
+
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Second `--fix` pass confirms idempotency (zero diff)
+- [x] Diff read in full for all 3 changed files; mechanical-only
+- [x] Checked for same-line trailing-comment reattachment: none present
+- [x] Checked for stale `Layer N`-labeled decorative banners contradicting
+      the new real headings: none present (old non-"Layer" banners in
+      `core_test.clj` remain accurate where they sit; left as-is)
+- [x] `clj-kondo`: 0 errors, 1 pre-existing warning (unrelated to this
+      fix, verified via stash-diff against the pre-fix file)
+- [x] Component tests pass (11 tests, 26 assertions, 0 failures/errors)
+- [x] Plain lint re-run post-fix: `SL003` remains on `core.clj` (5 real
+      layers, up from 4 decorative — documented, Wave 2 scope)
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time

--- a/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-pr-scoring.md
+++ b/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-pr-scoring.md
@@ -82,13 +82,17 @@ comment on a closing form, and moved as a unit with the function.
 3. Read the full diff for all 3 changed files. Confirmed the only changes
    are heading placement, def reordering, and `^{:stratum n}` metadata —
    no executable code changed.
-4. `clj-kondo --lint components/pr-scoring`: 0 errors, 1 warning
-   (`unused binding stream` in `core_test.clj`'s `pr-created-event`).
-   Confirmed via `git stash` against the pre-fix file that this exact
-   warning (same message) already existed before this PR, just at a
-   different line number (46 → 37) because of reordering. Pre-existing,
-   unrelated to stratum-lint, out of scope for a mechanical single-purpose
-   PR — left untouched.
+4. `clj-kondo --lint components/pr-scoring`: found 1 pre-existing warning
+   (`unused binding stream` in `core_test.clj`'s `pr-created-event`),
+   confirmed via `git stash` against the pre-fix file to already exist
+   before this PR at a different line number (46 → 37, from reordering).
+   Unrelated to stratum-lint, but cheap and risk-free to fold in here
+   (Copilot review flagged it independently): renamed the unused param to
+   `_stream` to document the intent — kept for call-site symmetry with the
+   real event-stream producer signature, every call site passes `s`. No
+   behavior change. Re-ran `--fix` after the rename: zero diff (no
+   rewrite), confirming it didn't disturb the stratum computation.
+   `clj-kondo` now reports 0 errors, 0 warnings.
 5. Re-ran plain `stratum-lint` after the fix: `SL003` remains on
    `core.clj`, now reporting **5** real layers instead of the 4 distinct
    decorative ones originally flagged — surfaced by `--fix`'s honest
@@ -122,8 +126,8 @@ Wave 2 splits it.
 - [x] Checked for stale `Layer N`-labeled decorative banners contradicting
       the new real headings: none present (old non-"Layer" banners in
       `core_test.clj` remain accurate where they sit; left as-is)
-- [x] `clj-kondo`: 0 errors, 1 pre-existing warning (unrelated to this
-      fix, verified via stash-diff against the pre-fix file)
+- [x] `clj-kondo`: 0 errors, 0 warnings (one pre-existing unused-binding
+      warning fixed in passing — `_stream` rename, no behavior change)
 - [x] Component tests pass (11 tests, 26 assertions, 0 failures/errors)
 - [x] Plain lint re-run post-fix: `SL003` remains on `core.clj` (5 real
       layers, up from 4 decorative — documented, Wave 2 scope)


### PR DESCRIPTION
## Summary
- Mechanical rule-210 heading fix: `bb -Sdeps ... stratum-lint --fix` over `components/pr-scoring` resolves the pre-existing SL002 (non-monotonic heading) and SL003 (decorative over-count) findings by regenerating `Layer N` headings + `^{:stratum n}` metadata from the real same-file reference graph. No logic changes.
- Zero SL001 findings confirmed before starting (no upward-reference/cycle risk).
- `core.clj` resolves to 5 real layers (up from 4 decorative) — still over the 3-layer budget; deferred to Wave 2 (namespace split), not this PR's scope.

## Test plan
- [x] `--fix` run over the whole component; second `--fix` pass confirms idempotency (zero diff)
- [x] Full diff read for all 3 changed files; mechanical-only (headings/metadata/reorder)
- [x] Checked for known tool-limitation patterns (displaced trailing comments, stale contradictory `Layer N` banners) — none found
- [x] `clj-kondo --lint components/pr-scoring`: 0 errors, 1 pre-existing warning (verified via stash-diff, unrelated to this fix)
- [x] Component tests: 11 tests, 26 assertions, 0 failures/errors
- [x] Plain lint re-run post-fix: `SL003` remains on `core.clj` (5 real layers, documented, Wave 2 scope)

See `docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-pr-scoring.md` for full detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)