### PR TITLE
fix: stratum-lint autofix for components/config (Wave 1)

### DIFF
--- a/components/config/src/ai/miniforge/config/digest.clj
+++ b/components/config/src/ai/miniforge/config/digest.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.config.digest
   "Content integrity verification for governance config files.
 
@@ -34,9 +33,9 @@
    [java.security MessageDigest]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; No in-namespace dependencies.
 
-(defn bytes->hex
+;; No in-namespace dependencies.
+(defn ^{:stratum 0} bytes->hex
   "Convert byte array to lowercase hex string. Babashka/GraalVM compatible."
   [^bytes ba]
   (let [sb (StringBuilder. (* 2 (alength ba)))]
@@ -44,7 +43,7 @@
       (.append sb (format "%02x" (aget ba i))))
     (.toString sb)))
 
-(defn load-digest-manifest
+(defn ^{:stratum 0} load-digest-manifest
   "Load governance/digests.edn from classpath.
    Returns a map of config-key -> digest-string, or nil if not found."
   []
@@ -55,9 +54,9 @@
         nil))))
 
 ;------------------------------------------------------------------------------ Layer 1
-;; Composes Layer 0.
 
-(defn sha256-hex
+;; Composes Layer 0.
+(defn ^{:stratum 1} sha256-hex
   "Compute SHA-256 hex digest of a string.
    Returns a prefixed string like \"sha256:a1b2c3d4...\"."
   [^String content]
@@ -66,9 +65,9 @@
     (str "sha256:" (bytes->hex hash-bytes))))
 
 ;------------------------------------------------------------------------------ Layer 2
-;; Composes Layer 0 (`load-digest-manifest`) + Layer 1 (`sha256-hex`).
 
-(defn verify-governance-file
+;; Composes Layer 0 (`load-digest-manifest`) + Layer 1 (`sha256-hex`).
+(defn ^{:stratum 2} verify-governance-file
   "Verify content against the digest manifest.
 
    Arguments:

--- a/components/config/src/ai/miniforge/config/governance.clj
+++ b/components/config/src/ai/miniforge/config/governance.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.config.governance
   "Governance config loading with aero profiles, regex compilation,
    digest verification, and merge chain.
@@ -41,20 +40,20 @@
    [ai.miniforge.config.user :as user]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Constants and helpers
 
-(def config-key->filename
+;; Constants and helpers
+(def ^{:stratum 0} config-key->filename
   "Map from config key to EDN filename."
   {:readiness        "readiness.edn"
    :risk             "risk.edn"
    :tiers            "tiers.edn"
    :knowledge-safety "knowledge-safety.edn"})
 
-(def user-config-path
+(def ^{:stratum 0} user-config-path
   "Default path to user config file."
   (str (user/miniforge-home) "/config.edn"))
 
-(defn resolve-profile
+(defn ^{:stratum 0} resolve-profile
   "Resolve governance profile from env var or opts.
    Defaults to :default."
   [opts]
@@ -62,7 +61,7 @@
       (some-> (System/getenv "MINIFORGE_GOVERNANCE_PROFILE") keyword)
       :default))
 
-(defn deep-merge
+(defn ^{:stratum 0} deep-merge
   "Recursively merge maps. Later values win for non-map keys."
   [& maps]
   (reduce (fn [acc m]
@@ -73,10 +72,8 @@
                        acc m))
           {} maps))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Regex compilation
-
-(defn compile-risk-patterns
+(defn ^{:stratum 0} compile-risk-patterns
   "Compile regex pattern strings in risk config under :critical-files :patterns.
    Returns config with compiled patterns."
   [config]
@@ -85,7 +82,7 @@
               (mapv re-pattern patterns))
     config))
 
-(defn compile-injection-patterns
+(defn ^{:stratum 0} compile-injection-patterns
   "Compile all regex pattern string vectors under :injection-patterns.
    Returns config with compiled patterns."
   [config]
@@ -96,29 +93,7 @@
                       {} categories))
     config))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Config loading and merge chain
-
-(defn load-resource-config
-  "Load a governance EDN file from classpath using aero for profile resolution."
-  [config-key profile]
-  (when-let [filename (get config-key->filename config-key)]
-    (when-let [resource (io/resource (str "config/governance/" filename))]
-      (aero/read-config resource {:profile profile}))))
-
-(defn load-user-overrides
-  "Load governance overrides from user config file.
-   Returns the map at [:governance <config-key>] or nil."
-  [config-key]
-  (try
-    (let [path user-config-path]
-      (when (fs/exists? path)
-        (let [user-cfg (edn/read-string (slurp path))]
-          (get-in user-cfg [:governance config-key]))))
-    (catch Exception _e
-      nil)))
-
-(defn verify-and-warn
+(defn ^{:stratum 0} verify-and-warn
   "Verify governance file content against digest manifest.
    For :knowledge-safety, mismatch throws. For others, logs a warning."
   [config-key content]
@@ -138,12 +113,34 @@
                                    (name config-key)
                                    ". File may have been modified.")))))))
 
-(defn needs-regex-compilation?
+(defn ^{:stratum 0} needs-regex-compilation?
   "Return true if this config key has regex strings that need compilation."
   [config-key]
   (contains? #{:risk :knowledge-safety} config-key))
 
-(defn compile-patterns
+;------------------------------------------------------------------------------ Layer 1
+
+;; Config loading and merge chain
+(defn ^{:stratum 1} load-resource-config
+  "Load a governance EDN file from classpath using aero for profile resolution."
+  [config-key profile]
+  (when-let [filename (get config-key->filename config-key)]
+    (when-let [resource (io/resource (str "config/governance/" filename))]
+      (aero/read-config resource {:profile profile}))))
+
+(defn ^{:stratum 1} load-user-overrides
+  "Load governance overrides from user config file.
+   Returns the map at [:governance <config-key>] or nil."
+  [config-key]
+  (try
+    (let [path user-config-path]
+      (when (fs/exists? path)
+        (let [user-cfg (edn/read-string (slurp path))]
+          (get-in user-cfg [:governance config-key]))))
+    (catch Exception _e
+      nil)))
+
+(defn ^{:stratum 1} compile-patterns
   "Compile regex patterns for configs that need it."
   [config-key config]
   (case config-key
@@ -151,7 +148,7 @@
     :knowledge-safety (compile-injection-patterns config)
     config))
 
-(defn apply-pack-overrides
+(defn ^{:stratum 1} apply-pack-overrides
   "Apply pack config overrides with safety checks.
 
    Safety rules:
@@ -201,7 +198,9 @@
           ;; Non-safety configs: merge freely
           (deep-merge base-config overrides))))))
 
-(defn load-governance-config
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} load-governance-config
   "Load governance config with full merge chain.
 
    Merge chain (precedence lowest -> highest):

--- a/components/config/src/ai/miniforge/config/interface.clj
+++ b/components/config/src/ai/miniforge/config/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.config.interface
   "Public interface for configuration management."
   (:require
@@ -25,138 +24,144 @@
    [ai.miniforge.config.profile :as profile]
    [ai.miniforge.config.resource :as resource]))
 
-;; Re-export public functions
+;------------------------------------------------------------------------------ Layer 0
 
+;; Re-export public functions
 ;; Generic classpath EDN config-resource loaders — the one home for the
 ;; load-a-component's-config-resource pattern. `load-config-resource`
 ;; fails fast (ex-info) on a missing/malformed/non-map resource or a
 ;; missing required key; `read-config-resource-or` is fail-open and
 ;; returns the supplied fallback on any error.
-(def load-config-resource
+(def ^{:stratum 0} load-config-resource
   "Read an EDN config resource from the classpath, failing fast with a
    clear ex-info on a missing/malformed/non-map resource or a missing
    required key. Arities: [path], [path required-keys], and
    [path required-keys extra-ex-data]."
   resource/load-config-resource)
-(def read-config-resource-or
+
+(def ^{:stratum 0} read-config-resource-or
   "Read an EDN config resource, returning `fallback` if the resource is
    absent, unreadable, malformed, or not a map (fail-open). Args:
    [path fallback]."
   resource/read-config-resource-or)
-(def default-user-config-path
+
+(def ^{:stratum 0} default-user-config-path
   "Default filesystem path string for the user config file
    (`<miniforge-home>/config.edn`). Computed once at load time."
   user/default-user-config-path)
-(def default-config
+
+(def ^{:stratum 0} default-config
   "Default configuration value: a map loaded at load time from the shipped
    classpath resource config/default-user-config.edn (with a fallback
    resource). Empty map {} if neither resource can be read."
   user/default-config)
-(def miniforge-home
+
+(def ^{:stratum 0} miniforge-home
   "Function returning the miniforge home directory as a string.
    Args: none. Returns: MINIFORGE_HOME env var if set, else
    `<user.home>/.miniforge`. Never nil."
   user/miniforge-home)
-(def repo-config-dir-name
+
+(def ^{:stratum 0} repo-config-dir-name
   "String naming the repo-level config directory: \".miniforge\"."
   user/repo-config-dir-name)
 
-(defn repo-config-path
+(defn ^{:stratum 0} repo-config-path
   "Return the path to .miniforge/config.edn in the given working directory."
   ([] (user/repo-config-path))
   ([working-dir] (user/repo-config-path working-dir)))
 
-(defn load-user-config
+(defn ^{:stratum 0} load-user-config
   "Load user configuration from file."
   ([] (user/load-user-config))
   ([path] (user/load-user-config path)))
 
-(defn load-repo-config
+(defn ^{:stratum 0} load-repo-config
   "Load repo-level configuration from .miniforge/config.edn.
    Returns nil if the file does not exist or cannot be parsed."
   ([] (user/load-repo-config))
   ([path] (user/load-repo-config path)))
 
-(defn load-merged-config
+(defn ^{:stratum 0} load-merged-config
   "Load and merge all configuration sources (user > env > defaults)."
   ([] (user/load-merged-config))
   ([path] (user/load-merged-config path)))
 
-(defn load-merged-config-with-repo
+(defn ^{:stratum 0} load-merged-config-with-repo
   "Load and merge all configuration sources including repo-level config.
    Precedence: repo > user > env > defaults."
   ([] (user/load-merged-config-with-repo))
   ([user-path repo-path] (user/load-merged-config-with-repo user-path repo-path)))
 
-(defn save-user-config
+(defn ^{:stratum 0} save-user-config
   "Save user configuration to file."
   ([config] (user/save-user-config config))
   ([config path] (user/save-user-config config path)))
 
-(defn init-user-config
+(defn ^{:stratum 0} init-user-config
   "Initialize user config file with defaults."
   ([] (user/init-user-config))
   ([path] (user/init-user-config path)))
 
-(defn update-user-config
+(defn ^{:stratum 0} update-user-config
   "Update a specific key in user config."
   ([key-path value] (user/update-user-config key-path value))
   ([key-path value path] (user/update-user-config key-path value path)))
 
-(defn reset-user-config
+(defn ^{:stratum 0} reset-user-config
   "Reset user config to defaults."
   ([] (user/reset-user-config))
   ([path] (user/reset-user-config path)))
 
-(defn edit-user-config
+(defn ^{:stratum 0} edit-user-config
   "Open user config in $EDITOR."
   ([] (user/edit-user-config))
   ([path] (user/edit-user-config path)))
 
-(defn merge-configs
+(defn ^{:stratum 0} merge-configs
   "Merge configurations with precedence."
   [& configs]
   (apply user/merge-configs configs))
 
 ;; Governance config functions
-(defn load-governance-config
+(defn ^{:stratum 0} load-governance-config
   "Load governance config with full merge chain (resource -> profile -> user -> pack -> compile)."
   ([config-key] (governance/load-governance-config config-key))
   ([config-key opts] (governance/load-governance-config config-key opts)))
 
-(defn apply-pack-overrides
+(defn ^{:stratum 0} apply-pack-overrides
   "Apply pack config overrides with safety checks."
   [config-key base-config pack]
   (governance/apply-pack-overrides config-key base-config pack))
 
 ;; Digest functions
-(defn sha256-hex
+(defn ^{:stratum 0} sha256-hex
   "Compute SHA-256 hex digest of a string."
   [content]
   (digest/sha256-hex content))
 
-(defn verify-governance-file
+(defn ^{:stratum 0} verify-governance-file
   "Verify governance file content against digest manifest."
   [config-key content]
   (digest/verify-governance-file config-key content))
 
 ;; Profile functions
-(def profile-path
+(def ^{:stratum 0} profile-path
   "Default filesystem path string for the user profile file
    (`<miniforge-home>/profile.edn`). Computed once at load time."
   profile/profile-path)
 
-(defn load-profile
+(defn ^{:stratum 0} load-profile
   "Load user profile from ~/.miniforge/profile.edn."
   ([] (profile/load-profile))
   ([path] (profile/load-profile path)))
 
-(defn validate-profile
+(defn ^{:stratum 0} validate-profile
   "Validate a profile map. Returns {:valid? bool :errors [...]}."
   [p]
   (profile/validate-profile p))
 
-(defn resolve-token
+(defn ^{:stratum 0} resolve-token
   "Resolve git token for a host kind using profile + env var chain."
   [host-kind & [opts]]
   (profile/resolve-token host-kind opts))

--- a/components/config/src/ai/miniforge/config/profile.clj
+++ b/components/config/src/ai/miniforge/config/profile.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.config.profile
   "User profile management (~/.miniforge/profile.edn).
 
@@ -40,28 +39,12 @@
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Schema and path
 
-(def profile-path
+;; Schema and path
+(def ^{:stratum 0} profile-path
   (str (user/miniforge-home) "/profile.edn"))
 
-
-;------------------------------------------------------------------------------ Layer 1
-;; Load and validate
-
-(defn load-profile
-  "Load user profile from ~/.miniforge/profile.edn using Aero.
-   Returns the profile map, or nil if file does not exist."
-  ([] (load-profile profile-path))
-  ([path]
-   (let [f (io/file path)]
-     (when (.exists f)
-       (try
-         (aero/read-config f)
-         (catch Exception _
-           nil))))))
-
-(defn validate-profile
+(defn ^{:stratum 0} validate-profile
   "Validate a profile map. Returns {:valid? bool :errors [...]}.
    Checks that :tokens is a map with keyword keys and string values,
    and that :identity has :name and :email when present."
@@ -85,10 +68,8 @@
     {:valid? (empty? errors)
      :errors errors}))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Token resolution
-
-(defn- gh-cli-token
+(defn- ^{:stratum 0} gh-cli-token
   "Attempt to get a GitHub token from the gh CLI.
    Returns the token string or nil."
   []
@@ -99,7 +80,24 @@
           (when (seq token) token))))
     (catch Exception _ nil)))
 
-(defn resolve-token
+;------------------------------------------------------------------------------ Layer 1
+
+;; Load and validate
+(defn ^{:stratum 1} load-profile
+  "Load user profile from ~/.miniforge/profile.edn using Aero.
+   Returns the profile map, or nil if file does not exist."
+  ([] (load-profile profile-path))
+  ([path]
+   (let [f (io/file path)]
+     (when (.exists f)
+       (try
+         (aero/read-config f)
+         (catch Exception _
+           nil))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} resolve-token
   "Resolve a git authentication token for a given host kind.
 
    Resolution order:

--- a/components/config/src/ai/miniforge/config/resource.clj
+++ b/components/config/src/ai/miniforge/config/resource.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.config.resource
   "Generic classpath EDN config-resource loading. One home for the
    load-this-component's-config-resource pattern so components stop
@@ -35,14 +34,16 @@
    [clojure.edn :as edn]
    [clojure.java.io :as io]))
 
-(def ^:private t
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private t
   "System-locale translator for this component. The loader's fail-fast
    diagnostics are operator-facing (system-locale, not user UI), but routed
    through the catalog so the one place to audit or override them is data."
   (messages/create-translator "config/config/messages/system.edn"
                               :config/system))
 
-(defn- extra-ex-data-map
+(defn- ^{:stratum 0} extra-ex-data-map
   [path extra-ex-data]
   (cond
     (nil? extra-ex-data) {}
@@ -51,7 +52,23 @@
                           {:config/resource path
                            :config/extra-ex-data extra-ex-data}))))
 
-(defn load-config-resource
+(defn ^{:stratum 0} read-config-resource-or
+  "Read an EDN config resource, returning `fallback` if the resource is
+   absent, unreadable, malformed, or not a map (fail-open). Cancellation
+   (`InterruptedException`) is propagated, not swallowed."
+  [path fallback]
+  (try
+    (let [url    (io/resource path)
+          parsed (when url (edn/read-string (slurp url :encoding "UTF-8")))]
+      (if (map? parsed) parsed fallback))
+    (catch InterruptedException e
+      (.interrupt (Thread/currentThread))
+      (throw e))
+    (catch Exception _ fallback)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} load-config-resource
   "Read an EDN config resource from the classpath, failing fast with a
    clear ex-info when the resource is absent, malformed, not a map, or
    missing a required key. Returns the parsed map.
@@ -98,17 +115,3 @@
            (throw (ex-info (t :resource/missing-keys {:path path :keys missing})
                            (assoc ex-data :config/missing-keys missing))))
          parsed)))))
-
-(defn read-config-resource-or
-  "Read an EDN config resource, returning `fallback` if the resource is
-   absent, unreadable, malformed, or not a map (fail-open). Cancellation
-   (`InterruptedException`) is propagated, not swallowed."
-  [path fallback]
-  (try
-    (let [url    (io/resource path)
-          parsed (when url (edn/read-string (slurp url :encoding "UTF-8")))]
-      (if (map? parsed) parsed fallback))
-    (catch InterruptedException e
-      (.interrupt (Thread/currentThread))
-      (throw e))
-    (catch Exception _ fallback)))

--- a/components/config/src/ai/miniforge/config/user.clj
+++ b/components/config/src/ai/miniforge/config/user.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.config.user
   "User configuration management for Miniforge.
 
@@ -31,53 +30,29 @@
    [babashka.process]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Constants and utilities
 
-(defn miniforge-home
+;; Constants and utilities
+(defn ^{:stratum 0} miniforge-home
   []
   (or (System/getenv "MINIFORGE_HOME")
       (str (System/getProperty "user.home") "/.miniforge")))
 
-(def default-user-config-path
-  (str (miniforge-home) "/config.edn"))
-
-(def ^:private default-config-resource-path
+(def ^{:stratum 0} ^:private default-config-resource-path
   "Primary resource path for shipped user config defaults."
   "config/default-user-config.edn")
 
-(def ^:private fallback-config-resource-path
+(def ^{:stratum 0} ^:private fallback-config-resource-path
   "Fallback resource path when the primary config cannot be loaded."
   "config/default-user-config-fallback.edn")
 
-(defn find-resource
+(defn ^{:stratum 0} find-resource
   "Resource lookup seam. Public so tests can rebind it via `with-redefs`
    when validating the fallback resource path; not part of the external
    API."
   [resource-path]
   (io/resource resource-path))
 
-(defn- read-config-resource
-  "Read an EDN config resource, returning nil on missing resource or parse failure."
-  [resource-path]
-  (when-let [resource (find-resource resource-path)]
-    (try
-      (edn/read-string (slurp resource))
-      (catch Exception _e
-        nil))))
-
-(defn load-default-config
-  "Load default configuration from resources.
-
-   Returns: Default config map or resource-backed fallback."
-  []
-  (or (some-> (read-config-resource default-config-resource-path) :config)
-      (some-> (read-config-resource fallback-config-resource-path) :config)
-      {}))
-
-(def default-config
-  (load-default-config))
-
-(defn read-edn-file
+(defn ^{:stratum 0} read-edn-file
   "Safely read an EDN file, returning nil on error."
   [path]
   (try
@@ -86,19 +61,46 @@
     (catch Exception _e
       nil)))
 
-(defn write-edn-file
+(defn ^{:stratum 0} write-edn-file
   "Write EDN data to a file, creating parent directories if needed."
   [path data]
   (fs/create-dirs (fs/parent path))
   (spit path (with-out-str (clojure.pprint/pprint data))))
 
-;------------------------------------------------------------------------------ Layer 0
 ;; Repo-level configuration
-
-(def repo-config-dir-name
+(def ^{:stratum 0} repo-config-dir-name
   ".miniforge")
 
-(defn repo-config-path
+;; Environment variable overrides
+(defn ^{:stratum 0} get-env-var
+  "Get environment variable value."
+  [var-name]
+  (System/getenv var-name))
+
+(defn ^{:stratum 0} parse-env-value
+  "Parse environment variable value (string -> EDN)."
+  [value]
+  (when value
+    (try
+      (edn/read-string value)
+      (catch Exception _
+        value))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} default-user-config-path
+  (str (miniforge-home) "/config.edn"))
+
+(defn- ^{:stratum 1} read-config-resource
+  "Read an EDN config resource, returning nil on missing resource or parse failure."
+  [resource-path]
+  (when-let [resource (find-resource resource-path)]
+    (try
+      (edn/read-string (slurp resource))
+      (catch Exception _e
+        nil))))
+
+(defn ^{:stratum 1} repo-config-path
   "Return the path to .miniforge/config.edn in the given working directory.
 
    Uses the JVM's current working directory by default. Pass an explicit
@@ -114,40 +116,7 @@
         repo-config-dir-name java.io.File/separator
         "config.edn")))
 
-(defn load-repo-config
-  "Load repo-level configuration from .miniforge/config.edn.
-
-   Reads from the current working directory by default. Returns nil when
-   the file does not exist or cannot be parsed — never throws.
-
-   This layer lets individual repositories declare :policy-packs settings,
-   governance overrides, or other project-specific config without touching
-   the user's global ~/.miniforge/config.edn.
-
-   Arguments:
-   - path - Optional explicit path (defaults to (repo-config-path))"
-  ([] (load-repo-config (repo-config-path)))
-  ([path]
-   (read-edn-file path)))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Environment variable overrides
-
-(defn get-env-var
-  "Get environment variable value."
-  [var-name]
-  (System/getenv var-name))
-
-(defn parse-env-value
-  "Parse environment variable value (string -> EDN)."
-  [value]
-  (when value
-    (try
-      (edn/read-string value)
-      (catch Exception _
-        value))))
-
-(defn apply-env-overrides
+(defn ^{:stratum 1} apply-env-overrides
   "Apply environment variable overrides to config.
 
    Supports these env vars:
@@ -236,16 +205,41 @@
     (assoc-in [:self-healing :backend-health-threshold] (parse-env-value (get-env-var "MINIFORGE_BACKEND_HEALTH_THRESHOLD")))))
 
 ;------------------------------------------------------------------------------ Layer 2
-;; Config loading and merging
 
-(defn load-user-config
+(defn ^{:stratum 2} load-default-config
+  "Load default configuration from resources.
+
+   Returns: Default config map or resource-backed fallback."
+  []
+  (or (some-> (read-config-resource default-config-resource-path) :config)
+      (some-> (read-config-resource fallback-config-resource-path) :config)
+      {}))
+
+(defn ^{:stratum 2} load-repo-config
+  "Load repo-level configuration from .miniforge/config.edn.
+
+   Reads from the current working directory by default. Returns nil when
+   the file does not exist or cannot be parsed — never throws.
+
+   This layer lets individual repositories declare :policy-packs settings,
+   governance overrides, or other project-specific config without touching
+   the user's global ~/.miniforge/config.edn.
+
+   Arguments:
+   - path - Optional explicit path (defaults to (repo-config-path))"
+  ([] (load-repo-config (repo-config-path)))
+  ([path]
+   (read-edn-file path)))
+
+;; Config loading and merging
+(defn ^{:stratum 2} load-user-config
   "Load user configuration from file.
    Returns nil if file doesn't exist."
   ([] (load-user-config default-user-config-path))
   ([path]
    (read-edn-file path)))
 
-(defn merge-configs
+(defn ^{:stratum 2} merge-configs
   "Merge configurations with precedence: user > env > defaults.
 
    Returns fully merged configuration map."
@@ -258,7 +252,21 @@
                     configs)]
     (apply-env-overrides base)))
 
-(defn load-merged-config
+;; Config saving and initialization
+(defn ^{:stratum 2} save-user-config
+  ([config] (save-user-config config default-user-config-path))
+  ([config path]
+   (write-edn-file path config)
+   config))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(def ^{:stratum 3} default-config
+  (load-default-config))
+
+;------------------------------------------------------------------------------ Layer 4
+
+(defn ^{:stratum 4} load-merged-config
   "Load and merge all configuration sources.
 
    Precedence: user config > env vars > defaults."
@@ -269,7 +277,7 @@
        (merge-configs default-config user-config)
        (merge-configs default-config)))))
 
-(defn load-merged-config-with-repo
+(defn ^{:stratum 4} load-merged-config-with-repo
   "Load and merge all configuration sources, including repo-level config.
 
    Precedence (lowest to highest):
@@ -291,16 +299,7 @@
                   (load-user-config user-path)
                   (load-repo-config repo-path))))
 
-;------------------------------------------------------------------------------ Layer 3
-;; Config saving and initialization
-
-(defn save-user-config
-  ([config] (save-user-config config default-user-config-path))
-  ([config path]
-   (write-edn-file path config)
-   config))
-
-(defn init-user-config
+(defn ^{:stratum 4} init-user-config
   "Initialize user config file with defaults if it doesn't exist.
    Returns path to config file."
   ([] (init-user-config default-user-config-path))
@@ -309,7 +308,7 @@
      (save-user-config default-config path))
    path))
 
-(defn update-user-config
+(defn ^{:stratum 4} update-user-config
   "Update a specific key in user config.
    Loads existing config, updates key, and saves.
 
@@ -322,12 +321,14 @@
          updated-config (assoc-in current-config key-path value)]
      (save-user-config updated-config path))))
 
-(defn reset-user-config
+(defn ^{:stratum 4} reset-user-config
   ([] (reset-user-config default-user-config-path))
   ([path]
    (save-user-config default-config path)))
 
-(defn edit-user-config
+;------------------------------------------------------------------------------ Layer 5
+
+(defn ^{:stratum 5} edit-user-config
   "Open user config in $EDITOR.
    Creates config file if it doesn't exist.
    Returns path to config file."

--- a/components/config/test/ai/miniforge/config/digest_test.clj
+++ b/components/config/test/ai/miniforge/config/digest_test.clj
@@ -15,14 +15,15 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.config.digest-test
   (:require
    [clojure.java.io :as io]
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.config.digest :as digest]))
 
-(deftest sha256-hex-test
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} sha256-hex-test
   (testing "produces consistent hex digest with sha256: prefix"
     (let [result (digest/sha256-hex "hello")]
       (is (string? result))
@@ -44,7 +45,7 @@
     (let [result (digest/sha256-hex "")]
       (is (.startsWith result "sha256:")))))
 
-(deftest load-digest-manifest-test
+(deftest ^{:stratum 0} load-digest-manifest-test
   (testing "loads digest manifest from classpath"
     (let [manifest (digest/load-digest-manifest)]
       (is (map? manifest))
@@ -54,7 +55,7 @@
       (is (contains? manifest :knowledge-safety))
       (is (every? #(.startsWith % "sha256:") (vals manifest))))))
 
-(deftest verify-governance-file-test
+(deftest ^{:stratum 0} verify-governance-file-test
   (testing "returns :ok for matching content"
     (let [manifest (digest/load-digest-manifest)
           content (slurp (io/resource "config/governance/readiness.edn"))]

--- a/components/config/test/ai/miniforge/config/governance_test.clj
+++ b/components/config/test/ai/miniforge/config/governance_test.clj
@@ -15,15 +15,14 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.config.governance-test
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.config.governance :as gov]))
 
-;------------------------------------------------------------------------------ Loading
+;------------------------------------------------------------------------------ Layer 0
 
-(deftest load-governance-config-readiness-test
+(deftest ^{:stratum 0} load-governance-config-readiness-test
   (testing "loads readiness config with expected keys"
     (let [cfg (gov/load-governance-config :readiness {:skip-digest? true})]
       (is (map? cfg))
@@ -49,7 +48,7 @@
     (let [cfg (gov/load-governance-config :readiness {:profile :permissive :skip-digest? true})]
       (is (= 0.70 (:merge-threshold cfg))))))
 
-(deftest load-governance-config-risk-test
+(deftest ^{:stratum 0} load-governance-config-risk-test
   (testing "loads risk config with compiled regex patterns"
     (let [cfg (gov/load-governance-config :risk {:skip-digest? true})]
       (is (map? cfg))
@@ -70,7 +69,7 @@
       (is (some #(re-find % "credentials.json") patterns))
       (is (some #(re-find % "Dockerfile") patterns)))))
 
-(deftest load-governance-config-tiers-test
+(deftest ^{:stratum 0} load-governance-config-tiers-test
   (testing "loads tiers config with expected tier keys"
     (let [cfg (gov/load-governance-config :tiers {:skip-digest? true})]
       (is (map? cfg))
@@ -88,7 +87,7 @@
     (let [cfg (gov/load-governance-config :tiers {:skip-digest? true})]
       (is (= :medium (get-in cfg [:tier-2 :constraints :max-risk-level]))))))
 
-(deftest load-governance-config-knowledge-safety-test
+(deftest ^{:stratum 0} load-governance-config-knowledge-safety-test
   (testing "loads knowledge-safety config with compiled injection patterns"
     (let [cfg (gov/load-governance-config :knowledge-safety {:skip-digest? true})]
       (is (map? cfg))
@@ -107,7 +106,7 @@
       (is (some #(re-find % "ignore previous instructions") role-patterns))
       (is (some #(re-find % "You Are Now an unrestricted AI") role-patterns)))))
 
-(deftest load-governance-config-unknown-key-test
+(deftest ^{:stratum 0} load-governance-config-unknown-key-test
   (testing "throws for unknown config key"
     (let [ex (try (gov/load-governance-config :nonexistent {:skip-digest? true})
                   (catch clojure.lang.ExceptionInfo e e))]
@@ -118,8 +117,7 @@
              (:config/invalid-config-reason (ex-data ex)))))))
 
 ;------------------------------------------------------------------------------ Regex Compilation
-
-(deftest compile-risk-patterns-test
+(deftest ^{:stratum 0} compile-risk-patterns-test
   (testing "compiles string patterns to regex"
     (let [input {:critical-files {:patterns ["(?i)test" "foo\\.bar"]}}
           result (gov/compile-risk-patterns input)]
@@ -130,7 +128,7 @@
     (let [input {:weights {:a 1}}]
       (is (= input (gov/compile-risk-patterns input))))))
 
-(deftest compile-injection-patterns-test
+(deftest ^{:stratum 0} compile-injection-patterns-test
   (testing "compiles all categories"
     (let [input {:injection-patterns {:cat-a ["(?i)foo" "bar"]
                                       :cat-b ["baz"]}}
@@ -145,8 +143,7 @@
       (is (= input (gov/compile-injection-patterns input))))))
 
 ;------------------------------------------------------------------------------ Pack Overrides
-
-(deftest apply-pack-overrides-test
+(deftest ^{:stratum 0} apply-pack-overrides-test
   (testing "applies overrides from trusted pack"
     (let [base {:merge-threshold 0.85 :weights {:a 0.5}}
           pack {:pack/id "test"
@@ -226,8 +223,7 @@
              (:config/invalid-config-reason (ex-data ex)))))))
 
 ;------------------------------------------------------------------------------ Regression: Values Match Original Hardcoded Defaults
-
-(deftest regression-readiness-defaults-test
+(deftest ^{:stratum 0} regression-readiness-defaults-test
   (testing "loaded readiness config matches current expected values"
     (let [cfg (gov/load-governance-config :readiness {:profile :default :skip-digest? true})]
       (is (= {:deps-merged 0.25 :ci-passed 0.25 :approved 0.20
@@ -240,7 +236,7 @@
               :reviewing 0.5 :changes-requested 0.25}
              (:approval-scores cfg))))))
 
-(deftest regression-risk-defaults-test
+(deftest ^{:stratum 0} regression-risk-defaults-test
   (testing "loaded risk config matches original hardcoded values (pre-compilation)"
     (let [cfg (gov/load-governance-config :risk {:profile :default :skip-digest? true})]
       (is (= {:change-size 0.25 :dependency-fanout 0.20
@@ -254,7 +250,7 @@
       (is (instance? java.util.regex.Pattern
                      (first (get-in cfg [:critical-files :patterns])))))))
 
-(deftest regression-tiers-defaults-test
+(deftest ^{:stratum 0} regression-tiers-defaults-test
   (testing "loaded tiers config matches original hardcoded values"
     (let [cfg (gov/load-governance-config :tiers {:profile :default :skip-digest? true})]
       (is (false? (get-in cfg [:tier-0 :auto-approve?])))
@@ -268,7 +264,7 @@
       (is (= :high (get-in cfg [:tier-3 :constraints :max-risk-level])))
       (is (= 0.75 (get-in cfg [:tier-3 :constraints :min-readiness]))))))
 
-(deftest regression-knowledge-safety-defaults-test
+(deftest ^{:stratum 0} regression-knowledge-safety-defaults-test
   (testing "loaded knowledge-safety config matches original hardcoded values"
     (let [cfg (gov/load-governance-config :knowledge-safety {:profile :default :skip-digest? true})]
       (is (= "ai.miniforge/knowledge-safety" (:pack-id cfg)))

--- a/components/config/test/ai/miniforge/config/profile_test.clj
+++ b/components/config/test/ai/miniforge/config/profile_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.config.profile-test
   "Tests for user profile loading and token resolution."
   (:require
@@ -23,9 +22,9 @@
    [ai.miniforge.config.profile :as profile]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; validate-profile tests
 
-(deftest validate-profile-valid-test
+;; validate-profile tests
+(deftest ^{:stratum 0} validate-profile-valid-test
   (testing "Valid profile passes validation"
     (let [p {:tokens {:github "tok-123" :gitlab "tok-456"}
              :identity {:name "Test User" :email "test@example.com"}
@@ -34,35 +33,33 @@
       (is (:valid? result))
       (is (empty? (:errors result))))))
 
-(deftest validate-profile-empty-test
+(deftest ^{:stratum 0} validate-profile-empty-test
   (testing "Empty profile is valid (all fields optional)"
     (let [result (profile/validate-profile {})]
       (is (:valid? result)))))
 
-(deftest validate-profile-bad-tokens-test
+(deftest ^{:stratum 0} validate-profile-bad-tokens-test
   (testing "Non-map :tokens fails"
     (let [result (profile/validate-profile {:tokens "not-a-map"})]
       (is (not (:valid? result)))
       (is (some #(re-find #":tokens" %) (:errors result))))))
 
-(deftest validate-profile-bad-identity-test
+(deftest ^{:stratum 0} validate-profile-bad-identity-test
   (testing "Non-map :identity fails"
     (let [result (profile/validate-profile {:identity "not-a-map"})]
       (is (not (:valid? result))))))
 
-(deftest validate-profile-bad-email-test
+(deftest ^{:stratum 0} validate-profile-bad-email-test
   (testing "Non-string email fails"
     (let [result (profile/validate-profile {:identity {:email 123}})]
       (is (not (:valid? result))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; load-profile tests
-
-(deftest load-profile-missing-file-test
+(deftest ^{:stratum 0} load-profile-missing-file-test
   (testing "Missing file returns nil"
     (is (nil? (profile/load-profile "/tmp/nonexistent-miniforge-profile.edn")))))
 
-(deftest load-profile-roundtrip-test
+(deftest ^{:stratum 0} load-profile-roundtrip-test
   (testing "Aero reads profile with #env tags"
     (let [tmp (java.io.File/createTempFile "profile-test" ".edn")]
       (try
@@ -73,10 +70,8 @@
         (finally
           (.delete tmp))))))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; resolve-token tests
-
-(deftest resolve-token-from-profile-test
+(deftest ^{:stratum 0} resolve-token-from-profile-test
   (testing "Token resolved from profile when no env override"
     (let [profile {:tokens {:github "profile-gh-token"
                             :gitlab "profile-gl-token"}}]
@@ -87,12 +82,12 @@
       (is (= "profile-gl-token"
              (profile/resolve-token :gitlab {:profile profile}))))))
 
-(deftest resolve-token-nil-for-unknown-host-test
+(deftest ^{:stratum 0} resolve-token-nil-for-unknown-host-test
   (testing "Unknown host kind with no profile returns nil"
     (let [profile {:tokens {}}]
       (is (nil? (profile/resolve-token :custom {:profile profile}))))))
 
-(deftest resolve-token-profile-nil-test
+(deftest ^{:stratum 0} resolve-token-profile-nil-test
   (testing "Nil profile with no env vars falls through"
     ;; With empty profile and no matching env var, should return nil for :custom
     (is (nil? (profile/resolve-token :custom {:profile {}})))))

--- a/components/config/test/ai/miniforge/config/resource_test.clj
+++ b/components/config/test/ai/miniforge/config/resource_test.clj
@@ -15,30 +15,36 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.config.resource-test
   (:require
    [ai.miniforge.config.resource :as resource]
    [clojure.java.io :as io]
    [clojure.test :refer [deftest is testing]]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; A real map resource shipped by this component, used for the happy path.
-(def ^:private a-real-resource "config/default-user-config-fallback.edn")
-(def ^:private a-missing-resource "config/does-not-exist-xyz.edn")
+(def ^{:stratum 0} ^:private a-real-resource "config/default-user-config-fallback.edn")
+
+(def ^{:stratum 0} ^:private a-missing-resource "config/does-not-exist-xyz.edn")
+
 ;; Test fixtures (under test/resource_test_fixtures/, on the test classpath).
 ;; The malformed fixture uses a .txt extension so the EDN linter does not
 ;; reject its deliberately invalid content; the loader reads by path, not
 ;; extension.
-(def ^:private a-malformed-resource "resource_test_fixtures/malformed-edn.txt")
-(def ^:private a-non-map-resource "resource_test_fixtures/non-map.edn")
+(def ^{:stratum 0} ^:private a-malformed-resource "resource_test_fixtures/malformed-edn.txt")
 
-(deftest load-config-resource-happy-path
+(def ^{:stratum 0} ^:private a-non-map-resource "resource_test_fixtures/non-map.edn")
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} load-config-resource-happy-path
   (testing "returns the parsed map for a resource on the classpath"
     (is (map? (resource/load-config-resource a-real-resource))))
   (testing "an empty required-keys set is a no-op"
     (is (map? (resource/load-config-resource a-real-resource [])))))
 
-(deftest load-config-resource-missing-resource
+(deftest ^{:stratum 1} load-config-resource-missing-resource
   (testing "throws a clear ex-info naming the missing resource"
     (let [ex (try (resource/load-config-resource a-missing-resource)
                   (catch clojure.lang.ExceptionInfo e e))]
@@ -55,7 +61,7 @@
       (is (= "add the component resources to the classpath"
              (:hint (ex-data ex)))))))
 
-(deftest load-config-resource-extra-ex-data-contract
+(deftest ^{:stratum 1} load-config-resource-extra-ex-data-contract
   (testing "throws a clear ex-info when caller-supplied diagnostic ex-data is not a map"
     (let [ex (try (resource/load-config-resource a-real-resource nil [:hint "bad"])
                   (catch clojure.lang.ExceptionInfo e e))]
@@ -63,14 +69,14 @@
       (is (= a-real-resource (:config/resource (ex-data ex))))
       (is (= [:hint "bad"] (:config/extra-ex-data (ex-data ex)))))))
 
-(deftest load-config-resource-missing-key
+(deftest ^{:stratum 1} load-config-resource-missing-key
   (testing "throws when a required key is absent, naming the key"
     (let [ex (try (resource/load-config-resource a-real-resource [:definitely-not-a-key])
                   (catch clojure.lang.ExceptionInfo e e))]
       (is (instance? clojure.lang.ExceptionInfo ex))
       (is (= [:definitely-not-a-key] (:config/missing-keys (ex-data ex)))))))
 
-(deftest load-config-resource-malformed
+(deftest ^{:stratum 1} load-config-resource-malformed
   (testing "throws a clear ex-info for malformed EDN"
     (let [ex (try (resource/load-config-resource a-malformed-resource)
                   (catch clojure.lang.ExceptionInfo e e))]
@@ -79,7 +85,7 @@
       (is (= :invalid-config (:config/error (ex-data ex))))
       (is (= :malformed-edn (:config/invalid-config-reason (ex-data ex)))))))
 
-(deftest load-config-resource-unreadable-resource
+(deftest ^{:stratum 1} load-config-resource-unreadable-resource
   (testing "distinguishes resource read failures from malformed EDN"
     (let [missing-file-url (java.net.URL.
                             (str "file:/tmp/miniforge-missing-"
@@ -94,7 +100,7 @@
       (is (= :unreadable-resource
              (:config/invalid-config-reason (ex-data ex)))))))
 
-(deftest load-config-resource-non-map
+(deftest ^{:stratum 1} load-config-resource-non-map
   (testing "throws when the EDN parses to a non-map value"
     (let [ex (try (resource/load-config-resource a-non-map-resource)
                   (catch clojure.lang.ExceptionInfo e e))]
@@ -103,7 +109,7 @@
       (is (= :invalid-config (:config/error (ex-data ex))))
       (is (= :not-a-map (:config/invalid-config-reason (ex-data ex)))))))
 
-(deftest read-config-resource-or-fail-open
+(deftest ^{:stratum 1} read-config-resource-or-fail-open
   (testing "returns the fallback for a missing resource"
     (is (= {:fallback true}
            (resource/read-config-resource-or a-missing-resource {:fallback true}))))

--- a/components/config/test/ai/miniforge/config/user_defaults_test.clj
+++ b/components/config/test/ai/miniforge/config/user_defaults_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.config.user-defaults-test
   (:require
    [clojure.test :refer [deftest testing is]]
@@ -24,9 +23,9 @@
    [ai.miniforge.config.user :as user]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Default config policy
 
-(deftest default-config-prefers-opencode-test
+;; Default config policy
+(deftest ^{:stratum 0} default-config-prefers-opencode-test
   (let [cfg config/default-config]
     (testing "default llm backend routes provider auth through OpenCode"
       (is (= :opencode (get-in cfg [:llm :backend])))
@@ -49,7 +48,7 @@
           ":workflow/worktree-root must be present in the default config so
            create-worktree-executor picks it up without a disk read"))))
 
-(deftest load-default-config-falls-back-to-edn-resource-test
+(deftest ^{:stratum 0} load-default-config-falls-back-to-edn-resource-test
   (let [orig-resource io/resource]
     (with-redefs [user/find-resource (fn [path]
                                        (case path
@@ -67,7 +66,7 @@
             "fallback EDN must carry :workflow/worktree-root so the dag-executor
              can locate worktrees even when the primary resource is missing")))))
 
-(deftest repo-config-support-test
+(deftest ^{:stratum 0} repo-config-support-test
   (testing "repo-config-path appends .miniforge/config.edn to the provided root"
     (is (= (str "/tmp/repo" java.io.File/separator
                 ".miniforge" java.io.File/separator

--- a/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-config.md
+++ b/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-config.md
@@ -1,0 +1,124 @@
+# fix: stratum-lint autofix for components/config (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over `components/config` (`src` + `test`) to
+replace decorative/mislabeled `Layer N` headings with real ones derived
+from the file's actual same-file reference graph, and adds `^{:stratum n}`
+metadata to every top-level def. Purely mechanical: no logic changes.
+One component-scoped PR from `work/stratum-lint-baseline-2026-07-24.md`
+(Wave 1, batch 3).
+
+## Motivation
+
+`components/config` carried exactly 2 findings under the baseline's
+cargo-cult diagnosis, both in `user.clj`: `SL002` (a `Layer 0` heading
+reused after `Layer 0`, i.e. a heading not strictly increasing) and
+`SL003` (file reported 4 distinct layers against the 3-layer budget).
+Zero `SL001` findings — no upward-reference/cycle risk to reason about
+before running the mechanical fixer — matching the baseline's Wave 1
+batch criteria exactly.
+
+## Changes in Detail
+
+Ran, over the whole component:
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "80699e378cb8ebbb6daeb928431aa4a6b373c07e" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/config
+```
+
+All 11 files in the component were rewritten (6 `src`, 5 `test`) —
+`--fix` normalizes every file passed to it, not just the ones with
+findings. `resource.clj` had no prior findings at all (its file predates
+any `Layer` heading, so rule 210's checker silently skipped it — a
+documented tool limitation) but still gained real headings and
+`^{:stratum n}` metadata for the first time. Everywhere else, existing
+headings/metadata were recomputed against the real reference graph; a
+few functions moved between layers or changed position within a layer
+where the old heading undercounted or overcounted the file's actual
+dependency depth (e.g. `profile.clj`'s `load-profile` moved from a
+stale "Layer 1" position to the reference-graph-correct Layer 1 slot
+after `gh-cli-token`; `governance.clj`'s config-loading functions moved
+down a layer once their real dependency on `deep-merge`/pattern
+compilation was accounted for). No line of executable code changed;
+diffs are heading text, `^{:stratum n}` metadata, comment repositioning,
+and def/deftest reordering only.
+
+**Hand-fix:** `governance_test.clj` had a pre-existing, non-`Layer`
+descriptive divider (`;----... Loading`) directly above its first
+`deftest`. `--fix` doesn't recognize dividers without the literal
+`Layer N` text as headings, so it left this one untouched but inserted
+the new real `Layer 0` heading immediately above it — leaving two
+stacked banner-style comments in a row that say nothing beyond what the
+`Layer 0` heading (this file collapses to a single real layer) and the
+test names (`load-governance-config-*-test`) already convey. Deleted
+the now-redundant `Loading` line; re-ran `--fix` twice more afterward
+and got zero rewrites both times, confirming the deletion didn't
+destabilize anything. Three sibling dividers in the same file (`Regex
+Compilation`, `Pack Overrides`, `Regression: Values Match Original
+Hardcoded Defaults`) were left alone — each still groups several tests
+under one label that isn't otherwise obvious at a glance, and none of
+them make a `Layer N` claim to be wrong about, so removing them would
+lose information for no correctness gain. Grepped the whole component
+for the double-semicolon `;;---- Layer N: <description>` stale-banner
+shape seen in earlier Wave 1 batches (e.g. `logging`'s `sinks.clj`) —
+zero matches; that specific failure mode doesn't occur here. Also
+checked every diff for a same-line trailing comment relocated onto the
+wrong def (the other known tool limitation) — none found; every
+existing comment in this component was already its own line.
+
+`user.clj` now reports `SL003`: 6 real layers (0-5) against the 3-layer
+budget — worse than the 4 layers the old (wrong) heading had claimed.
+`--fix` inferring the true reference chain surfaced more depth than the
+pre-fix heading admitted to, not something this PR introduces. Deferred
+to Wave 2 (real namespace split), consistent with how prior Wave 1 PRs
+(`bb-config`, `decision`, `compliance-scanner`) handled the same
+situation.
+
+## Testing Plan
+
+1. Ran plain (non-`--fix`) `stratum-lint` before the fix — reproduced
+   the baseline's exact 2 findings (`SL002` + `SL003`, both `user.clj`).
+2. Ran `--fix`, then a second `--fix` pass immediately after — zero
+   files rewritten, confirming idempotency.
+3. Read the full diff for all 11 changed files. Found one hand-fix-worthy
+   case (the stacked divider in `governance_test.clj`, above); applied
+   it, then ran `--fix` a third time — zero rewrites, confirming the
+   hand-edit is stable.
+4. `clj-kondo --lint components/config`: 0 errors, 0 warnings, both
+   before (verified via `git stash`) and after the fix.
+5. Ran all 5 test namespaces directly via `clojure -A:test`: 36 tests,
+   168 assertions, 0 failures, 0 errors.
+6. Re-ran plain `stratum-lint` after the fix: `SL001`/`SL002`/`SL004`
+   clear. `SL003` remains on `user.clj`, now reporting 6 real layers
+   (up from the pre-fix heading's claimed 4) — expected, tracked as
+   Wave 2, not a defect in this PR.
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+change — comment/metadata/order-only. Pre-commit's `lint:stratum`
+autofixer keeps this component clean going forward; `user.clj`'s
+`SL003` stays advisory (`MINIFORGE_STRATUM_BUDGET_MODE=warn` at commit
+time) until Wave 2 splits it.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+- Follow-on: Wave 2 namespace split for
+  `components/config/src/ai/miniforge/config/user.clj` (6 real layers,
+  over the 3-layer budget)
+
+## Checklist
+
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Second `--fix` pass confirms idempotency (zero diff)
+- [x] Diff read in full for all 11 changed files; mechanical-only aside
+      from one hand-fixed redundant comment divider
+- [x] Hand-fix (`governance_test.clj` stacked divider) re-verified
+      stable via a third `--fix` pass (zero rewrites)
+- [x] `clj-kondo` clean before/after (0 errors, 0 warnings)
+- [x] Component tests pass (36 tests, 168 assertions, 0 failures/errors)
+- [x] Plain lint re-run post-fix: zero findings except `SL003`
+      (`user.clj`, documented above, tracked as Wave 2)
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
## Summary

- Runs `stratum-lint --fix` over `components/config` (`src` + `test`), replacing decorative/mislabeled `Layer N` headings with real ones derived from the file's actual same-file reference graph, and adding `^{:stratum n}` metadata to every top-level def. Purely mechanical, no logic changes.
- Fixes the component's 2 baseline findings (`SL002` + `SL003`, both in `user.clj`); zero `SL001` (no upward-reference/cycle risk).
- One hand-fix: removed a redundant stacked comment divider in `governance_test.clj` left adjacent to a newly-inserted `Layer 0` heading (see PR doc for detail).
- `user.clj` still reports `SL003` post-fix (6 real layers vs. the 3-layer budget, up from the pre-fix heading's claimed 4) — deferred to Wave 2 (namespace split), not this PR's scope.

Full detail in `docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-config.md`.

## Test plan

- [x] Plain lint before fix reproduced the baseline's exact 2 findings
- [x] `--fix` run, then a second (and after a hand-edit, third) `--fix` pass — zero rewrites each time, confirming idempotency
- [x] Full diff read for all 11 changed files
- [x] `clj-kondo --lint components/config`: 0 errors/warnings before and after
- [x] All 5 test namespaces run directly: 36 tests, 168 assertions, 0 failures/errors
- [x] Plain lint re-run post-fix: only the pre-existing (now-recharacterized) `SL003` on `user.clj` remains
- [x] Pre-commit hook ran the same autofix at its pinned sha during `git commit` and made no further changes; full smoke suite passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)