### PR TITLE
fix: stratum-lint autofix for components/pr-label-watcher (Wave 1)

### DIFF
--- a/components/pr-label-watcher/src/ai/miniforge/pr_label_watcher/core.clj
+++ b/components/pr-label-watcher/src/ai/miniforge/pr_label_watcher/core.clj
@@ -103,7 +103,7 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
-;; Pure registry helpers
+;; Registry loading
 (defn ^{:stratum 1} load-registry
   "Read the label-actions registry from the M1 resource. Returns the
    string-keyed map under `:pr-label-actions/registry`.
@@ -124,6 +124,7 @@
         edn/read-string
         :pr-label-actions/registry)))
 
+;; Ancestor predicate factory
 (defn ^{:stratum 1} make-ancestor?-fn
   "Build the ancestor predicate `(fn [base-sha merge-sha] -> bool)`.
 
@@ -144,6 +145,7 @@
       (or (nil? base-sha) (nil? merge-sha)) false
       :else (ancestor-via-shell shell-fn base-sha merge-sha))))
 
+;; Payload assembly
 (defn ^{:stratum 1} build-match-payload
   "Build the structured payload that the meta-agent consumes on hit.
 

--- a/components/pr-label-watcher/src/ai/miniforge/pr_label_watcher/core.clj
+++ b/components/pr-label-watcher/src/ai/miniforge/pr_label_watcher/core.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-label-watcher.core
   "Mechanical (zero-token) label → action matcher (M2 of the labeled-PR-
    actions plan — see `docs/design/labeled-pr-actions-plan.md`).
@@ -40,47 +39,22 @@
    [clojure.set :as set]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Tuning constants + resource paths
 
-(def ^:private registry-resource-path
+;; Tuning constants + resource paths
+(def ^{:stratum 0} ^:private registry-resource-path
   "Classpath location of the M1 label-actions registry. Owned by
    pr-lifecycle; consumed read-only here."
   "config/pr-lifecycle/label-actions.edn")
 
-;------------------------------------------------------------------------------ Layer 0
-;; Pure registry helpers
-
-(defn load-registry
-  "Read the label-actions registry from the M1 resource. Returns the
-   string-keyed map under `:pr-label-actions/registry`.
-
-   Throws an `ex-info` (not an opaque NPE) when the resource is missing
-   on the classpath — that's a deploy bug, not a runtime condition,
-   and the explicit error message carries the lookup path so an
-   operator can see exactly what's missing without reading a stack
-   trace."
-  []
-  (let [resource (io/resource registry-resource-path)]
-    (when-not resource
-      (throw (ex-info "pr-label-watcher: label-actions registry resource not found on classpath"
-                      {:resource-path registry-resource-path
-                       :hint "the pr-lifecycle brick owns this resource (M1, PR #906); confirm components/pr-lifecycle/resources is on the classpath"})))
-    (-> resource
-        slurp
-        edn/read-string
-        :pr-label-actions/registry)))
-
-(defn matching-labels
+(defn ^{:stratum 0} matching-labels
   "Set of registry-keys (label strings) that are present on the merged
    PR. Pure intersection — no normalization, GitHub labels are
    case-sensitive at the project boundary."
   [pr-labels registry]
   (set/intersection (set pr-labels) (set (keys registry))))
 
-;------------------------------------------------------------------------------ Layer 0
 ;; Ancestry predicate
-
-(defn- ancestor-via-shell
+(defn- ^{:stratum 0} ancestor-via-shell
   "Default implementation of the ancestor predicate. Calls
    `git merge-base --is-ancestor <base> <merge>` via the supplied
    shell-fn (so tests don't shell out). Exit 0 → ancestor, exit 1 →
@@ -94,27 +68,7 @@
                                  base-sha merge-sha)]
     (= 0 exit)))
 
-(defn make-ancestor?-fn
-  "Build the ancestor predicate `(fn [base-sha merge-sha] -> bool)`.
-
-   `:shell-fn` is REQUIRED and injectable — production passes
-   `(partial babashka.process/shell {:out :string :err :string :continue true})`
-   or equivalent; tests pass a stub that maps SHA pairs to exit codes.
-
-   Throws an `ex-info` immediately when `:shell-fn` is missing or
-   non-fn, so misconfiguration surfaces at predicate-build time
-   instead of as an opaque NPE on first call."
-  [{:keys [shell-fn] :as opts}]
-  (when-not (fn? shell-fn)
-    (throw (ex-info "pr-label-watcher: make-ancestor?-fn requires :shell-fn"
-                    {:provided (set (keys opts))
-                     :hint "pass `:shell-fn (partial babashka.process/shell {:out :string :err :string :continue true})` or an equivalent stub in tests"})))
-  (fn [base-sha merge-sha]
-    (cond
-      (or (nil? base-sha) (nil? merge-sha)) false
-      :else (ancestor-via-shell shell-fn base-sha merge-sha))))
-
-(defn workflow-applies?
+(defn ^{:stratum 0} workflow-applies?
   "Apply the action's `:applies-when` clause to a candidate workflow.
 
    Currently the only supported predicate is
@@ -138,10 +92,8 @@
 
       :else false)))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Match payload assembly
-
-(defn- workflow-summary
+(defn- ^{:stratum 0} workflow-summary
   "Lift the keys that matter for downstream consumers off a workflow
    record. The meta-agent (M2b) and the rebase actuator (M3) need
    `:workflow/id` and `:workflow/base-sha`; everything else lives in
@@ -149,7 +101,50 @@
   [workflow]
   (select-keys workflow [:workflow/id :workflow/base-sha]))
 
-(defn build-match-payload
+;------------------------------------------------------------------------------ Layer 1
+
+;; Pure registry helpers
+(defn ^{:stratum 1} load-registry
+  "Read the label-actions registry from the M1 resource. Returns the
+   string-keyed map under `:pr-label-actions/registry`.
+
+   Throws an `ex-info` (not an opaque NPE) when the resource is missing
+   on the classpath — that's a deploy bug, not a runtime condition,
+   and the explicit error message carries the lookup path so an
+   operator can see exactly what's missing without reading a stack
+   trace."
+  []
+  (let [resource (io/resource registry-resource-path)]
+    (when-not resource
+      (throw (ex-info "pr-label-watcher: label-actions registry resource not found on classpath"
+                      {:resource-path registry-resource-path
+                       :hint "the pr-lifecycle brick owns this resource (M1, PR #906); confirm components/pr-lifecycle/resources is on the classpath"})))
+    (-> resource
+        slurp
+        edn/read-string
+        :pr-label-actions/registry)))
+
+(defn ^{:stratum 1} make-ancestor?-fn
+  "Build the ancestor predicate `(fn [base-sha merge-sha] -> bool)`.
+
+   `:shell-fn` is REQUIRED and injectable — production passes
+   `(partial babashka.process/shell {:out :string :err :string :continue true})`
+   or equivalent; tests pass a stub that maps SHA pairs to exit codes.
+
+   Throws an `ex-info` immediately when `:shell-fn` is missing or
+   non-fn, so misconfiguration surfaces at predicate-build time
+   instead of as an opaque NPE on first call."
+  [{:keys [shell-fn] :as opts}]
+  (when-not (fn? shell-fn)
+    (throw (ex-info "pr-label-watcher: make-ancestor?-fn requires :shell-fn"
+                    {:provided (set (keys opts))
+                     :hint "pass `:shell-fn (partial babashka.process/shell {:out :string :err :string :continue true})` or an equivalent stub in tests"})))
+  (fn [base-sha merge-sha]
+    (cond
+      (or (nil? base-sha) (nil? merge-sha)) false
+      :else (ancestor-via-shell shell-fn base-sha merge-sha))))
+
+(defn ^{:stratum 1} build-match-payload
   "Build the structured payload that the meta-agent consumes on hit.
 
    Empty `matched-workflows` means the label matched the registry but
@@ -166,7 +161,9 @@
    :pr-label/config    action
    :matched-workflows  (mapv workflow-summary matched-workflows)})
 
-(defn match
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} match
   "Pure top-level matcher.
 
    Inputs:
@@ -198,7 +195,6 @@
        (sort labels)))))
 
 ;------------------------------------------------------------------------------ Rich Comment
-
 (comment
   (def reg (load-registry))
   reg

--- a/components/pr-label-watcher/src/ai/miniforge/pr_label_watcher/interface.clj
+++ b/components/pr-label-watcher/src/ai/miniforge/pr_label_watcher/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-label-watcher.interface
   "Public surface for the mechanical PR-label watcher.
 
@@ -27,17 +26,21 @@
   (:require
    [ai.miniforge.pr-label-watcher.core :as core]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; Registry loading
-(def load-registry        core/load-registry)
-(def matching-labels      core/matching-labels)
+(def ^{:stratum 0} load-registry        core/load-registry)
+
+(def ^{:stratum 0} matching-labels      core/matching-labels)
 
 ;; Ancestry + applicability
-(def make-ancestor?-fn    core/make-ancestor?-fn)
-(def workflow-applies?    core/workflow-applies?)
+(def ^{:stratum 0} make-ancestor?-fn    core/make-ancestor?-fn)
+
+(def ^{:stratum 0} workflow-applies?    core/workflow-applies?)
 
 ;; Top-level match — pure, all inputs explicit, no side effects.
-(def match                core/match)
+(def ^{:stratum 0} match                core/match)
 
 ;; Payload construction (exposed so downstream consumers can synthesize
 ;; payloads in tests without going through the full match pipeline).
-(def build-match-payload  core/build-match-payload)
+(def ^{:stratum 0} build-match-payload  core/build-match-payload)

--- a/components/pr-label-watcher/test/ai/miniforge/pr_label_watcher/core_test.clj
+++ b/components/pr-label-watcher/test/ai/miniforge/pr_label_watcher/core_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-label-watcher.core-test
   "Pure-logic tests for the M2 label-action matcher.
 
@@ -26,37 +25,35 @@
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.pr-label-watcher.core :as sut]))
 
-;------------------------------------------------------------------------------ Fixtures
+;------------------------------------------------------------------------------ Layer 0
 
-(def ^:private dogfood-fix-action
+;------------------------------------------------------------------------------ Fixtures
+(def ^{:stratum 0} ^:private dogfood-fix-action
   {:action       :rebase-and-resume
    :description  "Pause, rebase the task worktree onto post-merge main, resume from the next phase boundary"
    :on-conflict  :attention-required
    :applies-when {:workflow.base-sha/not-ancestor-of-merge true}})
 
-(def ^:private test-registry
-  {"dogfood-fix" dogfood-fix-action})
-
-(def ^:private wf-old
+(def ^{:stratum 0} ^:private wf-old
   {:workflow/id #uuid "11111111-1111-1111-1111-111111111111"
    :workflow/base-sha "old-sha"})
 
-(def ^:private wf-recent
+(def ^{:stratum 0} ^:private wf-recent
   {:workflow/id #uuid "22222222-2222-2222-2222-222222222222"
    :workflow/base-sha "recent-sha"})
 
-(def ^:private wf-no-base-sha
+(def ^{:stratum 0} ^:private wf-no-base-sha
   ;; A pre-M1 workflow whose checkpoint never recorded a base SHA.
   ;; Must never match — ancestry can't be evaluated.
   {:workflow/id #uuid "33333333-3333-3333-3333-333333333333"})
 
-(defn- merge-event
+(defn- ^{:stratum 0} merge-event
   ([labels]            (merge-event labels "merge-sha-abc"))
   ([labels merge-sha]  {:pr/number    42
                          :pr/labels    (set labels)
                          :pr/merge-sha merge-sha}))
 
-(defn- ancestry-table-fn
+(defn- ^{:stratum 0} ancestry-table-fn
   "Stub ancestry predicate driven by a `{[base merge] bool}` table —
    `true` means base IS an ancestor of merge (workflow already has the
    fix → skip)."
@@ -64,74 +61,127 @@
   (fn [base-sha merge-sha]
     (boolean (get table [base-sha merge-sha]))))
 
-;------------------------------------------------------------------------------ Layer 0: load-registry
-
-(deftest load-registry-reads-m1-resource-test
+;; load-registry
+(deftest ^{:stratum 0} load-registry-reads-m1-resource-test
   (testing "the registry resource ships under config/pr-lifecycle and parses"
     (let [r (sut/load-registry)]
       (is (map? r))
       (is (contains? r "dogfood-fix")
           "M1 seeded the dogfood-fix entry; this test fails if the resource is moved or renamed"))))
 
-(deftest load-registry-action-shape-test
+(deftest ^{:stratum 0} load-registry-action-shape-test
   (testing "the dogfood-fix entry has the keys the watcher reads"
     (let [action (get (sut/load-registry) "dogfood-fix")]
       (is (= :rebase-and-resume (:action action)))
       (is (true? (get-in action [:applies-when :workflow.base-sha/not-ancestor-of-merge]))
           ":applies-when predicate must be true so workflow-applies? fires when ancestry says NO"))))
 
-;------------------------------------------------------------------------------ Layer 0: matching-labels
+;; ancestor predicate factory
+(deftest ^{:stratum 0} make-ancestor?-fn-returns-false-on-nil-shas-test
+  (testing "nil base-sha or merge-sha never claims ancestry — protects against pre-M1 workflows"
+    (let [pred (sut/make-ancestor?-fn
+                {:shell-fn (fn [& _] (throw (ex-info "should not shell out" {})))})]
+      (is (false? (pred nil "merge-sha")))
+      (is (false? (pred "base-sha" nil)))
+      (is (false? (pred nil nil))))))
 
-(deftest matching-labels-returns-intersection-test
-  (testing "string set intersection between PR labels and registry keys"
-    (is (= #{"dogfood-fix"}
-           (sut/matching-labels #{"dogfood-fix" "other"} test-registry)))))
+(deftest ^{:stratum 0} make-ancestor?-fn-treats-exit-0-as-ancestor-test
+  (testing "shell exit 0 → ancestor; anything else → not ancestor"
+    (let [pred-yes (sut/make-ancestor?-fn {:shell-fn (fn [& _] {:exit 0})})
+          pred-no  (sut/make-ancestor?-fn {:shell-fn (fn [& _] {:exit 1})})]
+      (is (true?  (pred-yes "a" "b")))
+      (is (false? (pred-no  "a" "b"))))))
 
-(deftest matching-labels-empty-when-no-overlap-test
-  (is (= #{} (sut/matching-labels #{"other" "unrelated"} test-registry))))
+(deftest ^{:stratum 0} make-ancestor?-fn-treats-unknown-exit-as-not-ancestor-test
+  (testing "non-{0,1} exits (e.g. 128 unknown SHA) treated as not-ancestor — conservative: surface the action"
+    ;; Better to fire a redundant intervention than silently swallow a real
+    ;; one because git couldn't resolve the SHA pair.
+    (let [pred (sut/make-ancestor?-fn {:shell-fn (fn [& _] {:exit 128})})]
+      (is (false? (pred "unknown-base" "unknown-merge"))))))
 
-(deftest matching-labels-case-sensitive-test
-  (testing "GitHub labels are case-sensitive — no normalization"
-    (is (= #{} (sut/matching-labels #{"Dogfood-Fix"} test-registry))
-        "uppercase variant must NOT match — labels are normalized at GitHub-project boundary, not here")))
+(deftest ^{:stratum 0} make-ancestor?-fn-throws-when-shell-fn-missing-test
+  (testing "misconfigured opts (no :shell-fn) fail loudly at build time, not opaquely on first call"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #":shell-fn"
+                          (sut/make-ancestor?-fn {})))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #":shell-fn"
+                          (sut/make-ancestor?-fn {:shell-fn nil}))
+        "explicit nil is rejected — caller probably forgot to wire the dep")
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #":shell-fn"
+                          (sut/make-ancestor?-fn {:shell-fn "not-a-fn"}))
+        "non-fn value rejected — fail fast at predicate-build time")))
 
-;------------------------------------------------------------------------------ Layer 0: workflow-applies?
+;------------------------------------------------------------------------------ Layer 1
 
-(deftest workflow-applies?-true-when-base-not-ancestor-test
+(def ^{:stratum 1} ^:private test-registry
+  {"dogfood-fix" dogfood-fix-action})
+
+;; workflow-applies?
+(deftest ^{:stratum 1} workflow-applies?-true-when-base-not-ancestor-test
   (testing "workflow whose base SHA is NOT an ancestor of merge SHA matches"
     (let [ancestor?-fn (ancestry-table-fn {})] ; nothing ancestor of anything
       (is (true? (sut/workflow-applies? wf-old dogfood-fix-action
                                         ancestor?-fn "merge-sha"))))))
 
-(deftest workflow-applies?-false-when-base-is-ancestor-test
+(deftest ^{:stratum 1} workflow-applies?-false-when-base-is-ancestor-test
   (testing "workflow whose base SHA IS an ancestor of merge SHA does NOT match (already has fix)"
     (let [ancestor?-fn (ancestry-table-fn {["recent-sha" "merge-sha"] true})]
       (is (false? (sut/workflow-applies? wf-recent dogfood-fix-action
                                          ancestor?-fn "merge-sha"))))))
 
-(deftest workflow-applies?-false-when-no-base-sha-test
+(deftest ^{:stratum 1} workflow-applies?-false-when-no-base-sha-test
   (testing "workflow with no recorded base SHA is never matched (pre-M1 checkpoint, handled manually)"
     (let [ancestor?-fn (ancestry-table-fn {})]
       (is (false? (sut/workflow-applies? wf-no-base-sha dogfood-fix-action
                                          ancestor?-fn "merge-sha"))))))
 
-(deftest workflow-applies?-false-when-applies-when-unset-test
+(deftest ^{:stratum 1} workflow-applies?-false-when-applies-when-unset-test
   (testing "action without :applies-when never matches — opt-in semantics"
     (let [action {:action :rebase-and-resume :applies-when {}}
           ancestor?-fn (ancestry-table-fn {})]
       (is (false? (sut/workflow-applies? wf-old action
                                          ancestor?-fn "merge-sha"))))))
 
-;------------------------------------------------------------------------------ Layer 1: match (top-level)
+(deftest ^{:stratum 1} match-handles-multiple-labels-test
+  (testing "two matching labels produce two payloads, deterministically sorted"
+    (let [registry {"a-fix"   (assoc dogfood-fix-action :action :rebase-and-resume)
+                    "b-fix"   (assoc dogfood-fix-action :action :rebase-and-resume)}
+          payloads (sut/match (merge-event #{"a-fix" "b-fix"})
+                              registry
+                              [wf-old]
+                              (ancestry-table-fn {}))]
+      (is (= 2 (count payloads)))
+      (is (= ["a-fix" "b-fix"]
+             (map :pr-label/label payloads))
+          "labels are sorted for deterministic ordering across runs"))))
 
-(deftest match-empty-vector-when-no-labels-match-test
+;------------------------------------------------------------------------------ Layer 2
+
+;; matching-labels
+(deftest ^{:stratum 2} matching-labels-returns-intersection-test
+  (testing "string set intersection between PR labels and registry keys"
+    (is (= #{"dogfood-fix"}
+           (sut/matching-labels #{"dogfood-fix" "other"} test-registry)))))
+
+(deftest ^{:stratum 2} matching-labels-empty-when-no-overlap-test
+  (is (= #{} (sut/matching-labels #{"other" "unrelated"} test-registry))))
+
+(deftest ^{:stratum 2} matching-labels-case-sensitive-test
+  (testing "GitHub labels are case-sensitive — no normalization"
+    (is (= #{} (sut/matching-labels #{"Dogfood-Fix"} test-registry))
+        "uppercase variant must NOT match — labels are normalized at GitHub-project boundary, not here")))
+
+;; match (top-level)
+(deftest ^{:stratum 2} match-empty-vector-when-no-labels-match-test
   (testing "PR with no registry-labels produces no payloads"
     (is (= [] (sut/match (merge-event #{"unrelated"})
                          test-registry
                          [wf-old]
                          (ancestry-table-fn {}))))))
 
-(deftest match-payload-shape-test
+(deftest ^{:stratum 2} match-payload-shape-test
   (testing "match payload contains all the keys the meta-agent needs"
     (let [[payload :as payloads]
           (sut/match (merge-event #{"dogfood-fix"})
@@ -149,7 +199,7 @@
       (is (vector? (:matched-workflows payload)))
       (is (= 1 (count (:matched-workflows payload)))))))
 
-(deftest match-includes-only-applicable-workflows-test
+(deftest ^{:stratum 2} match-includes-only-applicable-workflows-test
   (testing "match filters out workflows that already have the fix (base IS ancestor)"
     (let [[payload] (sut/match (merge-event #{"dogfood-fix"})
                                test-registry
@@ -160,7 +210,7 @@
       (is (= (:workflow/id wf-old)
              (-> payload :matched-workflows first :workflow/id))))))
 
-(deftest match-emits-empty-matched-workflows-when-all-skip-test
+(deftest ^{:stratum 2} match-emits-empty-matched-workflows-when-all-skip-test
   (testing "label matched but every workflow already has the fix → empty matched-workflows, payload still emitted"
     ;; Observability: operator sees \"label fired but nothing to do\".
     (let [[payload] (sut/match (merge-event #{"dogfood-fix"})
@@ -171,59 +221,7 @@
           "payload IS emitted on label-match-but-no-applicable-workflows")
       (is (= [] (:matched-workflows payload))))))
 
-(deftest match-handles-multiple-labels-test
-  (testing "two matching labels produce two payloads, deterministically sorted"
-    (let [registry {"a-fix"   (assoc dogfood-fix-action :action :rebase-and-resume)
-                    "b-fix"   (assoc dogfood-fix-action :action :rebase-and-resume)}
-          payloads (sut/match (merge-event #{"a-fix" "b-fix"})
-                              registry
-                              [wf-old]
-                              (ancestry-table-fn {}))]
-      (is (= 2 (count payloads)))
-      (is (= ["a-fix" "b-fix"]
-             (map :pr-label/label payloads))
-          "labels are sorted for deterministic ordering across runs"))))
-
-;------------------------------------------------------------------------------ Layer 1: ancestor predicate factory
-
-(deftest make-ancestor?-fn-returns-false-on-nil-shas-test
-  (testing "nil base-sha or merge-sha never claims ancestry — protects against pre-M1 workflows"
-    (let [pred (sut/make-ancestor?-fn
-                {:shell-fn (fn [& _] (throw (ex-info "should not shell out" {})))})]
-      (is (false? (pred nil "merge-sha")))
-      (is (false? (pred "base-sha" nil)))
-      (is (false? (pred nil nil))))))
-
-(deftest make-ancestor?-fn-treats-exit-0-as-ancestor-test
-  (testing "shell exit 0 → ancestor; anything else → not ancestor"
-    (let [pred-yes (sut/make-ancestor?-fn {:shell-fn (fn [& _] {:exit 0})})
-          pred-no  (sut/make-ancestor?-fn {:shell-fn (fn [& _] {:exit 1})})]
-      (is (true?  (pred-yes "a" "b")))
-      (is (false? (pred-no  "a" "b"))))))
-
-(deftest make-ancestor?-fn-treats-unknown-exit-as-not-ancestor-test
-  (testing "non-{0,1} exits (e.g. 128 unknown SHA) treated as not-ancestor — conservative: surface the action"
-    ;; Better to fire a redundant intervention than silently swallow a real
-    ;; one because git couldn't resolve the SHA pair.
-    (let [pred (sut/make-ancestor?-fn {:shell-fn (fn [& _] {:exit 128})})]
-      (is (false? (pred "unknown-base" "unknown-merge"))))))
-
-(deftest make-ancestor?-fn-throws-when-shell-fn-missing-test
-  (testing "misconfigured opts (no :shell-fn) fail loudly at build time, not opaquely on first call"
-    (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                          #":shell-fn"
-                          (sut/make-ancestor?-fn {})))
-    (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                          #":shell-fn"
-                          (sut/make-ancestor?-fn {:shell-fn nil}))
-        "explicit nil is rejected — caller probably forgot to wire the dep")
-    (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                          #":shell-fn"
-                          (sut/make-ancestor?-fn {:shell-fn "not-a-fn"}))
-        "non-fn value rejected — fail fast at predicate-build time")))
-
 ;------------------------------------------------------------------------------ Rich Comment
-
 (comment
   (clojure.test/run-tests 'ai.miniforge.pr-label-watcher.core-test)
   :leave-this-here)

--- a/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-pr-label-watcher.md
+++ b/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-pr-label-watcher.md
@@ -1,0 +1,109 @@
+# fix: stratum-lint autofix for components/pr-label-watcher (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over `components/pr-label-watcher` (`src` +
+`test`) to replace decorative `Layer N` section banners with headings
+and `^{:stratum n}` metadata derived from the file's actual same-file
+reference graph. Purely mechanical: no logic changes. One of the
+smaller per-component Wave 1 PRs from
+`work/stratum-lint-baseline-2026-07-24.md` (batch 3).
+
+## Motivation
+
+`pr-label-watcher` carried exactly two findings under the baseline's
+cargo-cult diagnosis, both `SL002` in `core.clj` (a repeated `Layer 0`
+banner used three times as a visual section break instead of once per
+real stratum). Zero `SL001` findings, so no upward-reference/cycle risk
+to reason about before running the mechanical fixer — matches the
+baseline's Wave 1 batch criteria.
+
+## Changes in Detail
+
+Ran, over the whole component, at the pin declared in `tasks/stratum.clj`
+(`80699e378cb8ebbb6daeb928431aa4a6b373c07e`):
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "80699e378cb8ebbb6daeb928431aa4a6b373c07e" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/pr-label-watcher
+```
+
+3 files rewritten: `core.clj`, `interface.clj` (both `src`), and
+`core_test.clj` (`test`) — `--fix` normalizes every file in the
+component, not just the one with a finding. `interface.clj` had no
+`Layer` heading at all before this (the tool silently skips headerless
+files on a plain lint pass); it now carries `Layer 0` and per-`def`
+`^{:stratum 0}` metadata, since every re-export in that file is a bare
+alias with no same-file dependency on another def in the file.
+`core.clj`'s three real layers (0–2) now match the file's actual call
+chain: `matching-labels`/`workflow-applies?`/`ancestor-via-shell`/
+`workflow-summary` at Layer 0, `load-registry`/`make-ancestor?-fn`/
+`build-match-payload` at Layer 1 (each composes a Layer-0 def), and
+`match` at Layer 2 (composes both). `core_test.clj`'s `deftest` forms
+were regrouped by which layer of `core.clj` they exercise. No line of
+executable code changed; diffs are heading text, metadata, and
+def/deftest reordering only.
+
+One hand-fix beyond the mechanical run, in `core_test.clj`: five
+old single-semicolon `;---- Layer N: <description>` banners (grouping
+tests by which `core.clj` function they cover, e.g. `Layer 1: ancestor
+predicate factory`) survived the `--fix` pass untouched — a documented
+tool limitation, since the tool only recognizes bare `Layer N` headings
+as real, not the colon-plus-description variant. After reordering, four
+of the five now sat under a *different* real `Layer N` heading than the
+number they claimed (e.g. `;---- Layer 1: ancestor predicate factory`
+ended up positioned under tests the fixer placed at real `Layer 0`) —
+actively misleading, not merely stale. Reworded each of the five to drop
+the now-wrong `Layer N:` prefix, keeping the descriptive fragment
+(`;; ancestor predicate factory`, `;; workflow-applies?`, `;;
+matching-labels`, `;; match (top-level)`, `;; load-registry`) since it
+still names a real, useful test grouping — matching the plain
+double-semicolon description style `--fix` itself used for `core.clj`'s
+surviving comments (e.g. `;; Ancestry predicate`). Re-ran `--fix` after
+the edit: zero diff, confirming the hand-fix didn't destabilize the
+tool's own output.
+
+No `SL003` (over-budget) risk here: `core.clj` tops out at 3 real
+layers, exactly at budget.
+
+## Testing Plan
+
+1. Ran plain (non-`--fix`) `stratum-lint` before the fix — reproduced
+   the baseline's two `SL002` findings exactly (`core.clj:50`,
+   `core.clj:80`).
+2. Ran `--fix`, then a second `--fix` pass immediately after — zero
+   diff, confirms idempotency.
+3. Read the full diff for all 3 changed files. Found the stale-banner
+   contradiction described above in `core_test.clj`; hand-fixed it, then
+   ran `--fix` a third time — zero diff, confirms the hand-fix is stable
+   too. No same-line trailing comment was displaced onto the wrong def
+   (this component has none of that shape).
+4. `clj-kondo --lint components/pr-label-watcher`: 0 errors, 0 warnings.
+5. Re-ran plain `stratum-lint` after the fix: zero findings of any kind
+   (`SL001`–`SL004` all clear, including `SL003` — no over-budget file
+   surfaced).
+6. Ran `ai.miniforge.pr-label-watcher.core-test` directly via
+   `clojure -A:test -e`: 18 tests, 36 assertions, 0 failures, 0 errors.
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+change — comment/metadata/order-only. Pre-commit's `lint:stratum`
+autofixer keeps this component clean going forward.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1, batch 3)
+- No Wave 2 follow-on needed — no `SL003` finding remains.
+
+## Checklist
+
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Second and third `--fix` passes confirm idempotency (zero diff),
+      the second after this PR's one hand-fix
+- [x] Diff read in full for all 3 changed files; mechanical except one
+      hand-fix (stale, now-contradictory `Layer N:` banner text in
+      `core_test.clj`, reworded — no code or test-assertion changes)
+- [x] `clj-kondo` clean before/after (0 errors, 0 warnings)
+- [x] Component tests pass (18 tests, 36 assertions, 0 failures/errors)
+- [x] Plain lint re-run post-fix: zero findings, no `SL003` remains
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time

--- a/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-pr-label-watcher.md
+++ b/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-pr-label-watcher.md
@@ -38,10 +38,26 @@ alias with no same-file dependency on another def in the file.
 chain: `matching-labels`/`workflow-applies?`/`ancestor-via-shell`/
 `workflow-summary` at Layer 0, `load-registry`/`make-ancestor?-fn`/
 `build-match-payload` at Layer 1 (each composes a Layer-0 def), and
-`match` at Layer 2 (composes both). `core_test.clj`'s `deftest` forms
-were regrouped by which layer of `core.clj` they exercise. No line of
-executable code changed; diffs are heading text, metadata, and
-def/deftest reordering only.
+`match` at Layer 2 (composes both).
+
+`core_test.clj`'s layers are **not** a mirror of `core.clj`'s — each
+file's strata come from its own same-file reference graph only, computed
+independently. In the test file: the fixtures (`dogfood-fix-action`,
+`wf-old`, `wf-recent`, `wf-no-base-sha`, `merge-event`,
+`ancestry-table-fn`) sit at Layer 0; `test-registry`, which references
+`dogfood-fix-action`, sits at Layer 1; each `deftest` then lands one
+layer above the highest-layer same-file fixture/helper it references (or
+at Layer 0 if it references none — most tests call `sut/...` functions,
+which are cross-namespace and don't count). This is why the layers don't
+line up with `core.clj` at all: `load-registry` is Layer 1 in `core.clj`
+but its tests are Layer 0 in `core_test.clj` (they call no same-file
+fixture); `matching-labels` is Layer 0 in `core.clj` but its tests are
+Layer 2 (they reference `test-registry`, which is Layer 1). The one
+place layer numbers happen to coincide — `match` at Layer 2 in both
+files — is coincidental: both files' own dependency chains happen to run
+3 deep, not a deliberate correspondence. No line of executable code
+changed; diffs are heading text, metadata, and def/deftest reordering
+only.
 
 One hand-fix beyond the mechanical run, in `core_test.clj`: five
 old single-semicolon `;---- Layer N: <description>` banners (grouping

--- a/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-pr-label-watcher.md
+++ b/docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-pr-label-watcher.md
@@ -78,6 +78,18 @@ surviving comments (e.g. `;; Ancestry predicate`). Re-ran `--fix` after
 the edit: zero diff, confirming the hand-fix didn't destabilize the
 tool's own output.
 
+A second hand-fix, in `core.clj`: `--fix` left a single Layer-1 group
+comment, `;; Pure registry helpers`, ahead of all three Layer-1 defs
+(`load-registry`, `make-ancestor?-fn`, `build-match-payload`) — accurate
+for the first, wrong for the other two (`make-ancestor?-fn` builds a
+git-ancestry/shell predicate; `build-match-payload` assembles the output
+payload, neither is registry-related). Split it into three group
+comments, one per def, matching this same file's own Layer-0 convention
+(which already carries one short comment per def-group: `;; Tuning
+constants + resource paths`, `;; Ancestry predicate`, `;; Match payload
+assembly`): `;; Registry loading`, `;; Ancestor predicate factory`, `;;
+Payload assembly`. Re-ran `--fix` after the edit: zero diff.
+
 No `SL003` (over-budget) risk here: `core.clj` tops out at 3 real
 layers, exactly at budget.
 
@@ -99,6 +111,10 @@ layers, exactly at budget.
    surfaced).
 6. Ran `ai.miniforge.pr-label-watcher.core-test` directly via
    `clojure -A:test -e`: 18 tests, 36 assertions, 0 failures, 0 errors.
+7. After review flagged the `core.clj` Layer-1 header and the
+   `core_test.clj` regrouping claim (below), re-ran `--fix` again post
+   hand-fix: zero diff. Re-ran `clj-kondo`, plain `stratum-lint`, and the
+   test suite: unchanged — 0/0, zero findings, 18 tests/36 assertions.
 
 ## Deployment Plan
 
@@ -114,11 +130,12 @@ autofixer keeps this component clean going forward.
 ## Checklist
 
 - [x] `--fix` run over the whole component (`src` + `test`)
-- [x] Second and third `--fix` passes confirm idempotency (zero diff),
-      the second after this PR's one hand-fix
-- [x] Diff read in full for all 3 changed files; mechanical except one
-      hand-fix (stale, now-contradictory `Layer N:` banner text in
-      `core_test.clj`, reworded — no code or test-assertion changes)
+- [x] Repeated `--fix` passes confirm idempotency (zero diff) after each
+      of this PR's two hand-fixes and one doc correction
+- [x] Diff read in full for all 3 changed files; mechanical except two
+      hand-fixes (stale, now-contradictory `Layer N:` banner text in
+      `core_test.clj`; an inaccurate multi-def group comment in
+      `core.clj`) — no code or test-assertion changes
 - [x] `clj-kondo` clean before/after (0 errors, 0 warnings)
 - [x] Component tests pass (18 tests, 36 assertions, 0 failures/errors)
 - [x] Plain lint re-run post-fix: zero findings, no `SL003` remains


### PR DESCRIPTION
## Summary
- Runs `stratum-lint --fix` over `components/pr-label-watcher` (src + test); clears the 2 pre-existing SL002 findings in `core.clj` (decorative repeated `Layer 0` banner).
- Hand-fixed 5 stale, now-contradictory `Layer N: <description>` test-grouping banners in `core_test.clj` that survived the fix untouched (documented tool limitation) — reworded to drop the wrong layer claim, kept the descriptive grouping.
- No logic changes. 18 tests / 36 assertions pass. clj-kondo clean. Zero findings remain post-fix (no SL003).

Wave 1 batch 3 of `work/stratum-lint-baseline-2026-07-24.md`. Full detail in `docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-pr-label-watcher.md`.

## Test plan
- [x] `--fix` run over whole component; second and third passes confirm idempotency (zero diff)
- [x] Full diff read for all 3 changed files
- [x] `clj-kondo --lint components/pr-label-watcher`: 0 errors, 0 warnings
- [x] Plain lint re-run post-fix: zero findings
- [x] `clojure -A:test` on `core-test`: 18 tests, 36 assertions, 0 failures/errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)