### PR TITLE
fix: bump stratum-lint pin for the defmethod refs-union fix

### DIFF
--- a/docs/pull-requests/2026-07-25-fix-bump-stratum-lint-pin-defmethod-refs.md
+++ b/docs/pull-requests/2026-07-25-fix-bump-stratum-lint-pin-defmethod-refs.md
@@ -1,0 +1,49 @@
+# fix: bump stratum-lint pin for the defmethod refs-union fix
+
+## Overview
+
+Bumps `tasks/stratum.clj`'s pinned `stratum-lint` sha from `80699e37`
+(current on `main`) to `14965e1`, which includes
+[stratum-lint#14](https://github.com/miniforge-ai/stratum-lint/pull/14):
+`infer-levels` built its dependency graph with `into {}` keyed by def
+name — a repeated key (every `defmethod` on one multimethod shares the
+multimethod's own name) kept only the *last* entry's refs, silently
+discarding every earlier `defmethod`'s references.
+
+## Motivation
+
+Found during Wave 1 batch 3's `release-executor` component PR:
+`process-file-action`'s `:default` method (last in file, calls nothing)
+overwrote `:create`/`:modify`/`:delete`'s refs (which call several
+layers deep into `path-traversal-anomaly`) in the graph. `--fix`
+computed the multimethod as a leaf and placed it *before* the function
+it actually calls — a forward reference breaking both `clj-kondo` and
+Clojure compilation. `release-executor`'s Wave 1 PR excluded
+`components/release-executor/.../files.clj` from its `--fix` pass
+pending this fix, rather than committing broken output.
+
+## Changes in Detail
+
+- `tasks/stratum.clj`: `stratum-lint-deps`'s pinned sha,
+  `80699e37` → `14965e1`.
+
+## Testing Plan
+
+Confirmed the sha resolves via `bb -Sdeps`. Pre-commit hook (which this
+file wires into) passes clean on this change.
+
+## Deployment Plan
+
+Merges to `main` immediately. Follow-on: `release-executor`'s Wave 1 PR
+can now run `--fix` over `files.clj` too, once this pin lands.
+
+## Related Issues/PRs
+
+- Fix consumed: [stratum-lint#14](https://github.com/miniforge-ai/stratum-lint/pull/14)
+- Unblocks: `files.clj` in `release-executor`'s Wave 1 PR
+- Part of: `work/stratum-lint-baseline-2026-07-24.md`, Wave 1 batch 3
+
+## Checklist
+
+- [x] Sha resolves via `bb -Sdeps`
+- [x] Pre-commit hook passes clean

--- a/tasks/stratum.clj
+++ b/tasks/stratum.clj
@@ -37,7 +37,7 @@
    included — never fetch the sibling repo; only the pre-commit gate
    pays the one-time clone."
   (pr-str {:deps {'io.github.miniforge-ai/stratum-lint
-                  {:git/sha "80699e378cb8ebbb6daeb928431aa4a6b373c07e"
+                  {:git/sha "14965e1ee1a175bd00f637d9a9d5f7d27e62b73f"
                    :deps/root "clojure"}}}))
 
 (defn ^{:stratum 0} restage!


### PR DESCRIPTION
## Summary

Bumps `tasks/stratum.clj`'s pinned `stratum-lint` sha from `80699e37` to `14965e1`, which includes [stratum-lint#14](https://github.com/miniforge-ai/stratum-lint/pull/14): `infer-levels`'s dependency graph was keyed by def name via `into {}` — a repeated key (every `defmethod` on one multimethod shares the multimethod's own name) kept only the *last* entry's refs, discarding earlier `defmethod`s' references.

Found via `release-executor`'s Wave 1 stratum-lint PR: `process-file-action`'s `:default` method (last in file, refs nothing) overwrote `:create`/`:modify`/`:delete`'s refs (which call several layers into `path-traversal-anomaly`), computing the multimethod as a leaf and placing it before the function it actually calls — a forward reference breaking both `clj-kondo` and Clojure compilation. `release-executor`'s PR excluded `files.clj` from its `--fix` pass pending this.

Full detail in `docs/pull-requests/2026-07-25-fix-bump-stratum-lint-pin-defmethod-refs.md`.

## Test plan

- [x] Sha resolves via `bb -Sdeps`
- [x] `bb pre-commit` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)