### PR TITLE
fix: bump babashka/fs to 0.5.34, stop poly test from masking bricks on a crash

### DIFF
--- a/bases/cli/deps.edn
+++ b/bases/cli/deps.edn
@@ -5,7 +5,7 @@
         ;; are all bundled with Babashka - no external deps needed for BB runtime
         ;; These are listed for JVM REPL/test compatibility
         org.babashka/cli {:mvn/version "0.8.60"}
-        babashka/fs      {:mvn/version "0.5.22"}
+        babashka/fs      {:mvn/version "0.5.34"}
         babashka/process {:mvn/version "0.5.22"}
         cheshire/cheshire {:mvn/version "5.13.0"}
 

--- a/components/bb-adapter-thesium-risk/deps.edn
+++ b/components/bb-adapter-thesium-risk/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources"]
- :deps  {babashka/fs                    {:mvn/version "0.5.22"}
+ :deps  {babashka/fs                    {:mvn/version "0.5.34"}
          cheshire/cheshire              {:mvn/version "5.13.0"}
          ai.miniforge/bb-out            {:local/root "../bb-out"}
          ai.miniforge/bb-paths          {:local/root "../bb-paths"}

--- a/components/bb-config/deps.edn
+++ b/components/bb-config/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources"]
- :deps  {babashka/fs           {:mvn/version "0.5.22"}
+ :deps  {babashka/fs           {:mvn/version "0.5.34"}
          ai.miniforge/bb-paths {:local/root "../bb-paths"}}
  :aliases
  {:test {:extra-paths ["test"]

--- a/components/bb-dev-tools/deps.edn
+++ b/components/bb-dev-tools/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src"]
- :deps  {babashka/fs                 {:mvn/version "0.5.22"}
+ :deps  {babashka/fs                 {:mvn/version "0.5.34"}
          ai.miniforge/bb-paths       {:local/root "../bb-paths"}
          ai.miniforge/bb-test-runner {:local/root "../bb-test-runner"}}
  :aliases

--- a/components/bb-etl-runner/deps.edn
+++ b/components/bb-etl-runner/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources"]
- :deps  {babashka/fs         {:mvn/version "0.5.22"}
+ :deps  {babashka/fs         {:mvn/version "0.5.34"}
          ai.miniforge/bb-out  {:local/root "../bb-out"}
          ai.miniforge/bb-proc {:local/root "../bb-proc"}}
  :aliases

--- a/components/bb-generate-icon/deps.edn
+++ b/components/bb-generate-icon/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources"]
- :deps  {babashka/fs           {:mvn/version "0.5.22"}
+ :deps  {babashka/fs           {:mvn/version "0.5.34"}
          ai.miniforge/anomaly  {:local/root "../anomaly"}
          ai.miniforge/bb-out   {:local/root "../bb-out"}
          ai.miniforge/bb-paths {:local/root "../bb-paths"}

--- a/components/bb-paths/deps.edn
+++ b/components/bb-paths/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src"]
- :deps  {babashka/fs {:mvn/version "0.5.22"}}
+ :deps  {babashka/fs {:mvn/version "0.5.34"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {io.github.cognitect-labs/test-runner

--- a/components/bb-platform/deps.edn
+++ b/components/bb-platform/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src"]
- :deps  {babashka/fs      {:mvn/version "0.5.22"}
+ :deps  {babashka/fs      {:mvn/version "0.5.34"}
          babashka/process {:mvn/version "0.5.22"}}
  :aliases
  {:test {:extra-paths ["test"]

--- a/components/bb-proc/deps.edn
+++ b/components/bb-proc/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src"]
- :deps  {babashka/fs      {:mvn/version "0.5.22"}
+ :deps  {babashka/fs      {:mvn/version "0.5.34"}
          babashka/process {:mvn/version "0.5.22"}}
  :aliases
  {:test {:extra-paths ["test"]

--- a/components/bb-test-runner/deps.edn
+++ b/components/bb-test-runner/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src"]
- :deps  {babashka/fs {:mvn/version "0.5.22"}}
+ :deps  {babashka/fs {:mvn/version "0.5.34"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {io.github.cognitect-labs/test-runner

--- a/components/config/deps.edn
+++ b/components/config/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["src" "resources"]
  :deps {org.clojure/clojure {:mvn/version "1.12.0"}
         ai.miniforge/messages {:local/root "../messages"}
-        babashka/fs {:mvn/version "0.5.22"}
+        babashka/fs {:mvn/version "0.5.34"}
         babashka/process {:mvn/version "0.5.22"}
         aero/aero {:mvn/version "1.1.6"}}
  :aliases {:test {:extra-paths ["test"]

--- a/components/pr-lifecycle/deps.edn
+++ b/components/pr-lifecycle/deps.edn
@@ -16,4 +16,4 @@
                   :extra-deps {io.github.cognitect-labs/test-runner
                                {:git/tag "v0.5.1" :git/sha "dfb30dd"}
                                babashka/fs
-                               {:mvn/version "0.5.22"}}}}}
+                               {:mvn/version "0.5.34"}}}}}

--- a/components/release-executor/deps.edn
+++ b/components/release-executor/deps.edn
@@ -5,5 +5,5 @@
         ai.miniforge/dag-executor {:local/root "../dag-executor"}
         ai.miniforge/logging {:local/root "../logging"}
         ai.miniforge/messages {:local/root "../messages"}
-        babashka/fs {:mvn/version "0.5.22"}
+        babashka/fs {:mvn/version "0.5.34"}
         babashka/process {:mvn/version "0.5.22"}}}

--- a/components/repo-analyzer/deps.edn
+++ b/components/repo-analyzer/deps.edn
@@ -1,4 +1,4 @@
 {:paths ["src" "resources"]
- :deps {babashka/fs      {:mvn/version "0.5.22"}
+ :deps {babashka/fs      {:mvn/version "0.5.34"}
         babashka/process {:mvn/version "0.5.22"}}
  :aliases {:test {:extra-paths ["test"]}}}

--- a/components/spec-parser/deps.edn
+++ b/components/spec-parser/deps.edn
@@ -2,7 +2,7 @@
  :deps {ai.miniforge/anomaly {:local/root "../anomaly"}    ; Canonical anomaly maps for exceptions-as-data
         ai.miniforge/knowledge {:local/root "../knowledge"} ; YAML frontmatter parsing
         metosin/malli {:mvn/version "0.16.4"}
-        babashka/fs   {:mvn/version "0.5.22"}
+        babashka/fs   {:mvn/version "0.5.34"}
         cheshire/cheshire {:mvn/version "5.13.0"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {io.github.cognitect-labs/test-runner

--- a/components/workflow/deps.edn
+++ b/components/workflow/deps.edn
@@ -23,7 +23,7 @@
         ai.miniforge/gate {:local/root "../gate"}          ; Gate interceptors
         ai.miniforge/dag-executor {:local/root "../dag-executor"}  ; Execution environment acquisition
         ai.miniforge/pr-lifecycle {:local/root "../pr-lifecycle"}  ; PR observe phase
-        babashka/fs {:mvn/version "0.5.22"}
+        babashka/fs {:mvn/version "0.5.34"}
         babashka/process {:mvn/version "0.5.22"}
         metosin/malli {:mvn/version "0.16.1"}              ; Schema validation
         http-kit/http-kit {:mvn/version "2.8.0"}           ; WebSocket client for dashboard connection

--- a/deps.edn
+++ b/deps.edn
@@ -634,9 +634,10 @@
                              ai.miniforge/tool-registry {:local/root "components/tool-registry"}}}
 
   :poly {:main-opts  ["-m" "polylith.clj.core.poly-cli.core"]
+         :extra-paths ["tools/poly-test-runner/src"]
          :extra-deps {polylith/clj-poly {:mvn/version "0.2.21"}}}
 
   :build {:deps       {io.github.clojure/tools.build {:mvn/version "0.10.6"}
-                       babashka/fs                   {:mvn/version "0.5.22"}
+                       babashka/fs                   {:mvn/version "0.5.34"}
                        babashka/process              {:mvn/version "0.5.22"}}
           :ns-default build}}}

--- a/tools/poly-test-runner/src/ai/miniforge/poly_test_runner/core.clj
+++ b/tools/poly-test-runner/src/ai/miniforge/poly_test_runner/core.clj
@@ -1,0 +1,107 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.poly-test-runner.core
+  "Custom Polylith test runner, wired in via workspace.edn's :test
+   :create-test-runner. Registered on the clj-poly classpath through the
+   :poly alias's :extra-paths (deps.edn), so it is only ever loaded by the
+   `poly` CLI process itself, never by application code.
+
+   Polylith's built-in clojure-test-test-runner
+   (polylith.clj.core.clojure-test-test-runner.core/run-test-statements)
+   throws immediately as soon as ONE test namespace reports any error or
+   failure, from inside a `doseq` over every test namespace in the project.
+   That throw is uncaught at every level above it (the per-project doseq in
+   run-test-statements, and the per-project doseq in
+   test-runner-orchestrator.core/run), so a single red namespace silently
+   aborts every remaining brick in that project AND every remaining project
+   in the same `poly test` invocation — with no message indicating anything
+   was skipped. Confirmed against clj-poly 0.2.21-0.3.32 (current latest);
+   not fixed upstream as of this writing.
+
+   This reuses the built-in runner's namespace-discovery and statement-
+   building helpers verbatim, swapping in a statement runner that always
+   finishes the full doseq, then throws once at the end if anything failed
+   — satisfying the TestRunner contract (`run-tests` must throw on failure)
+   without masking untested bricks."
+  (:require
+   [polylith.clj.core.clojure-test-test-runner.core :as builtin]
+   [polylith.clj.core.test-runner-contract.interface :as test-runner-contract]
+   [polylith.clj.core.util.interface.color :as color]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} run-test-statements-without-early-abort
+  "Same body as polylith.clj.core.clojure-test-test-runner.core/run-test-statements,
+   except the throw-on-failure moves from inside the doseq (aborting the
+   remaining statements) to after it (every statement still runs)."
+  [project-name eval-in-project test-statements run-message is-verbose color-mode]
+  (println (str run-message))
+  (when is-verbose (println (str "# test-statements:\n" test-statements) "\n"))
+  (let [any-failed? (atom false)]
+    (doseq [statement test-statements]
+      (let [{:keys [error fail pass]}
+            (try
+              (eval-in-project statement)
+              (catch Exception e
+                (.printStackTrace e)
+                (println (str (color/error color-mode "Couldn't run test statement")
+                               " for the " (color/project project-name color-mode)
+                               " project: " statement " " (color/error color-mode e)))))
+            result-str (str "Test results: " pass " passes, " fail " failures, " error " errors.")]
+        (if (or (nil? error) (< 0 error) (< 0 fail))
+          (do (reset! any-failed? true)
+              (println (str "\n" (color/error color-mode result-str))))
+          (println (str "\n" (color/ok color-mode result-str))))))
+    (when @any-failed?
+      (throw (Exception.
+              (str "\n" (color/error
+                         color-mode
+                         (str "One or more test statements failed in the " project-name
+                              " project (see full output above). Every namespace in this "
+                              "project was executed — none were skipped due to an earlier "
+                              "failure."))))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} create
+  "Drop-in replacement for polylith.clj.core.clojure-test-test-runner.interface/create."
+  [{:keys [workspace project]}]
+  (let [{:keys [bases components]} workspace
+        {:keys [name bricks-to-test projects-to-test namespaces paths]} project
+        test-sources-present* (delay (-> paths :test seq))
+        bricks-to-test* (delay bricks-to-test)
+        projects-to-test* (delay projects-to-test)
+        test-statements* (->> [(builtin/brick-test-namespaces (into components bases) @bricks-to-test*)
+                                (builtin/project-test-namespaces name @projects-to-test* namespaces)]
+                               (into [] (comp cat (map builtin/->test-statement)))
+                               (delay))]
+    (reify test-runner-contract/TestRunner
+      (test-runner-name [_] "Resilient clojure.test runner (completes every brick even if an earlier one errors)")
+
+      (test-sources-present? [_] @test-sources-present*)
+
+      (tests-present? [this {_eval-in-project :eval-in-project :as _opts}]
+        (and (test-runner-contract/test-sources-present? this)
+             (seq @test-statements*)))
+
+      (run-tests [this {:keys [color-mode eval-in-project is-verbose] :as opts}]
+        (when (test-runner-contract/tests-present? this opts)
+          (let [run-message (builtin/run-message name components bases @bricks-to-test*
+                                                  @projects-to-test* color-mode)]
+            (run-test-statements-without-early-abort
+             name eval-in-project @test-statements* run-message is-verbose color-mode)))))))

--- a/tools/poly-test-runner/src/ai/miniforge/poly_test_runner/core.clj
+++ b/tools/poly-test-runner/src/ai/miniforge/poly_test_runner/core.clj
@@ -61,9 +61,10 @@
                 (.printStackTrace e)
                 (println (str (color/error color-mode "Couldn't run test statement")
                                " for the " (color/project project-name color-mode)
-                               " project: " statement " " (color/error color-mode e)))))
+                               " project: " statement " " (color/error color-mode e)))
+                {:pass 0 :fail 0 :error 1}))
             result-str (str "Test results: " pass " passes, " fail " failures, " error " errors.")]
-        (if (or (nil? error) (< 0 error) (< 0 fail))
+        (if (or (pos? error) (pos? fail))
           (do (reset! any-failed? true)
               (println (str "\n" (color/error color-mode result-str))))
           (println (str "\n" (color/ok color-mode result-str))))))

--- a/tools/poly-test-runner/src/ai/miniforge/poly_test_runner/core.clj
+++ b/tools/poly-test-runner/src/ai/miniforge/poly_test_runner/core.clj
@@ -37,7 +37,10 @@
    building helpers verbatim, swapping in a statement runner that always
    finishes the full doseq, then throws once at the end if anything failed
    — satisfying the TestRunner contract (`run-tests` must throw on failure)
-   without masking untested bricks."
+   without masking untested bricks WITHIN A PROJECT. It does not reach the
+   outer per-project doseq in test-runner-orchestrator.core/run, which can
+   still abort remaining projects; that gap is unfixed and tracked
+   separately."
   (:require
    [polylith.clj.core.clojure-test-test-runner.core :as builtin]
    [polylith.clj.core.test-runner-contract.interface :as test-runner-contract]
@@ -57,7 +60,15 @@
       (let [{:keys [error fail pass]}
             (try
               (eval-in-project statement)
-              (catch Exception e
+              (catch VirtualMachineError e
+                ;; OutOfMemoryError, StackOverflowError, etc. — not safe to
+                ;; treat as a single failed statement and keep looping.
+                (throw e))
+              (catch Throwable e
+                ;; Throwable, not Exception: an Error (e.g. a namespace's
+                ;; :require throwing NoClassDefFoundError) must also be
+                ;; converted to a result here, or it would defeat the whole
+                ;; point of this runner by escaping the doseq uncaught.
                 (.printStackTrace e)
                 (println (str (color/error color-mode "Couldn't run test statement")
                                " for the " (color/project project-name color-mode)
@@ -92,7 +103,7 @@
                                (into [] (comp cat (map builtin/->test-statement)))
                                (delay))]
     (reify test-runner-contract/TestRunner
-      (test-runner-name [_] "Resilient clojure.test runner (completes every brick even if an earlier one errors)")
+      (test-runner-name [_] "Resilient clojure.test runner (completes every brick within a project even if an earlier one errors)")
 
       (test-sources-present? [_] @test-sources-present*)
 

--- a/workspace.edn
+++ b/workspace.edn
@@ -6,6 +6,12 @@
        :auto-add false}
  :tag-patterns {:stable "stable/*"
                 :release "v[0-9]*"}
+ ;; Polylith's built-in clojure.test runner aborts the ENTIRE `poly test`
+ ;; invocation (every remaining brick, every remaining project) as soon as
+ ;; one test namespace reports an error or failure. This runner behaves
+ ;; identically but runs every namespace to completion first. See
+ ;; tools/poly-test-runner/src/ai/miniforge/poly_test_runner/core.clj.
+ :test {:create-test-runner ai.miniforge.poly-test-runner.core/create}
  :projects {"development"    {:alias "dev"}
             "data-foundry"   {:alias "df"}
             "miniforge-core" {:alias "core"

--- a/workspace.edn
+++ b/workspace.edn
@@ -6,11 +6,14 @@
        :auto-add false}
  :tag-patterns {:stable "stable/*"
                 :release "v[0-9]*"}
- ;; Polylith's built-in clojure.test runner aborts the ENTIRE `poly test`
- ;; invocation (every remaining brick, every remaining project) as soon as
- ;; one test namespace reports an error or failure. This runner behaves
- ;; identically but runs every namespace to completion first. See
- ;; tools/poly-test-runner/src/ai/miniforge/poly_test_runner/core.clj.
+ ;; Polylith's built-in clojure.test runner aborts a project's entire brick
+ ;; list as soon as one test namespace reports an error or failure. This
+ ;; runner behaves identically but runs every namespace in the project to
+ ;; completion first. Scope: per-project only — it does not protect against
+ ;; the outer per-project loop in Polylith's own orchestrator, which can
+ ;; still abort remaining PROJECTS (miniforge-core, miniforge-tui, ...) in
+ ;; the same `poly test` invocation; that's a separate, not-yet-fixed gap.
+ ;; See tools/poly-test-runner/src/ai/miniforge/poly_test_runner/core.clj.
  :test {:create-test-runner ai.miniforge.poly-test-runner.core/create}
  :projects {"development"    {:alias "dev"}
             "data-foundry"   {:alias "df"}


### PR DESCRIPTION
## Summary
- `babashka/fs` 0.5.22's `u+wx` type-hints `Files/getPosixFilePermissions`'s return as `^HashSet`. On this JDK/filesystem, `Files/createTempDirectory` returns a `RegularEnumSet`-backed `Set` instead, so the checkcast throws inside `delete-tree`'s `:force` cleanup path — hit by every `fs/with-temp-dir` test on teardown. Confirmed against `main` (unrelated to any other in-flight branch), root-caused down to the exact type hint, and confirmed fixed upstream in 0.5.31+. Bumped to the current 0.5.34 across all 17 `deps.edn` files that pinned 0.5.22.
- Separately: Polylith's built-in `clojure.test` runner throws the instant one test namespace errors, from inside the `doseq` over every namespace in a project. Uncaught above it, so one red brick (`pr-lifecycle`, via the bug above) silently aborted every remaining brick in the same `poly test` invocation — including `workflow` — with no message indicating anything was skipped. Confirmed unchanged through the latest published `clj-poly` (0.3.32). Confirmed intentional upstream design for setup failures (polyfy/polylith#234), so not something to report as a bug.
- Added a custom `TestRunner` (`tools/poly-test-runner`) via Polylith's documented extension point that runs every namespace in a project to completion before throwing, so a crash no longer masks untested bricks. Wired globally through `workspace.edn`'s `:create-test-runner` and the `:poly` alias's `:extra-paths` in `deps.edn`.

## Known residual gap
The custom runner only stops the abort *within* a project's brick list. Polylith's outer per-project loop (`test-runner-orchestrator.core/run`) still has no catch, so a red project can still skip subsequent projects (`miniforge-core`, `miniforge-tui`) in the same invocation. No per-project hook exists upstream to fix this from `workspace.edn`; follow-up.

## Test plan
- [x] `pr-lifecycle`'s `monitor-worklist-test` runs clean (11 tests, 0 errors) after the version bump — previously 5 `ClassCastException`s.
- [x] `poly check` passes.
- [x] Reintroduced the babashka.fs bug in `pr-lifecycle` only, ran `poly test brick:pr-lifecycle:workflow`: `pr-lifecycle` still errored 5x as before, but all ~90 `workflow` namespaces still ran afterward, exit code correctly nonzero.
- [x] Reverted the reintroduced bug, re-ran the same scope: 297 namespaces tested, exit 0.
- [x] Pre-commit smoke suite (331 tests) and GraalVM/babashka compatibility checks passed on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)