### PR TITLE
fix: stratum-lint autofix for components/control-plane-adapter (Wave 1)

### DIFF
--- a/components/control-plane-adapter/src/ai/miniforge/control_plane_adapter/interface.clj
+++ b/components/control-plane-adapter/src/ai/miniforge/control_plane_adapter/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.control-plane-adapter.interface
   "Public API for the control plane adapter component.
 
@@ -29,9 +28,9 @@
    [ai.miniforge.control-plane-adapter.protocol :as proto]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Protocol re-exports + pure data + helpers with no in-namespace deps.
 
-(def ControlPlaneAdapter
+;; Protocol re-exports + pure data + helpers with no in-namespace deps.
+(def ^{:stratum 0} ControlPlaneAdapter
   "Protocol vendor-specific adapters must implement to bridge a
    vendor-native agent API to the control plane's normalized model.
 
@@ -39,20 +38,20 @@
    `deliver-decision`, `send-command`. Implement via defrecord/reify."
   proto/ControlPlaneAdapter)
 
-(def ControlPlaneAdapterLogs
+(def ^{:stratum 0} ControlPlaneAdapterLogs
   "Optional protocol for adapters that can retrieve agent logs.
 
    Single member `agent-logs`; adapters without log support omit it."
   proto/ControlPlaneAdapterLogs)
 
-(def adapter-id
+(def ^{:stratum 0} adapter-id
   "Protocol fn. Return the keyword identifying an adapter (e.g.
    :claude-code, :openai). Unique across all registered adapters.
 
    Args: [this]. Returns: keyword."
   proto/adapter-id)
 
-(def discover-agents
+(def ^{:stratum 0} discover-agents
   "Protocol fn. Discover running agents for the adapter's vendor.
 
    Args: [this config]. Returns: seq of agent-registration maps
@@ -61,7 +60,7 @@
    when none found or discovery unsupported (push-only adapters)."
   proto/discover-agents)
 
-(def poll-agent-status
+(def ^{:stratum 0} poll-agent-status
   "Protocol fn. Poll the current status of a single agent.
 
    Args: [this agent-record]. Returns: map
@@ -69,7 +68,7 @@
    when the agent is no longer reachable."
   proto/poll-agent-status)
 
-(def deliver-decision
+(def ^{:stratum 0} deliver-decision
   "Protocol fn. Deliver a resolved decision to an agent.
 
    Args: [this agent-record decision-resolution], where
@@ -78,7 +77,7 @@
    Returns: map {:delivered? boolean :error str-or-nil}."
   proto/deliver-decision)
 
-(def send-command
+(def ^{:stratum 0} send-command
   "Protocol fn. Send a control command to an agent.
 
    Args: [this agent-record command] where command is one of
@@ -86,7 +85,7 @@
    Returns: map {:success? boolean :error str-or-nil}."
   proto/send-command)
 
-(def agent-logs
+(def ^{:stratum 0} agent-logs
   "Protocol fn (ControlPlaneAdapterLogs). Retrieve recent agent logs.
 
    Args: [this agent-record opts] where opts is
@@ -95,14 +94,14 @@
    or nil when log retrieval is unsupported."
   proto/agent-logs)
 
-(def ^:private vendor-heartbeat-ms
+(def ^{:stratum 0} ^:private vendor-heartbeat-ms
   "Recommended heartbeat intervals per vendor (ms)."
   {:claude-code 15000    ;; local process, fast check
    :miniforge   10000    ;; native, fastest
    :openai      60000    ;; API rate limits
    :cursor      30000})
 
-(defn normalize-status
+(defn ^{:stratum 0} normalize-status
   "Normalize a vendor-specific status string to a control plane status keyword.
 
    Arguments:
@@ -117,7 +116,7 @@
   [vendor-status mapping]
   (get mapping (keyword vendor-status) :unknown))
 
-(defn ms-since
+(defn ^{:stratum 0} ms-since
   "Calculate milliseconds elapsed since a timestamp.
 
    Arguments:
@@ -129,9 +128,9 @@
     (- (System/currentTimeMillis) (.getTime timestamp))))
 
 ;------------------------------------------------------------------------------ Layer 1
-;; Composes Layer 0 (`vendor-heartbeat-ms`).
 
-(defn heartbeat-interval-for-vendor
+;; Composes Layer 0 (`vendor-heartbeat-ms`).
+(defn ^{:stratum 1} heartbeat-interval-for-vendor
   "Return the recommended heartbeat interval for a vendor.
 
    Arguments:

--- a/components/control-plane-adapter/src/ai/miniforge/control_plane_adapter/protocol.clj
+++ b/components/control-plane-adapter/src/ai/miniforge/control_plane_adapter/protocol.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.control-plane-adapter.protocol
   "Protocol definition for vendor-specific control plane adapters.
 
@@ -28,9 +27,9 @@
    plane API) or pull mode (adapter discovers and polls agents).")
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Core adapter protocol
 
-(defprotocol ControlPlaneAdapter
+;; Core adapter protocol
+(defprotocol ^{:stratum 0} ControlPlaneAdapter
   "Protocol for vendor-specific agent integration.
    Adapters bridge between vendor-native agent APIs and
    the control plane's normalized model."
@@ -89,10 +88,8 @@
 
      Returns {:success? bool :error string-or-nil}"))
 
-;------------------------------------------------------------------------------ Layer 0
 ;; Optional extended protocol
-
-(defprotocol ControlPlaneAdapterLogs
+(defprotocol ^{:stratum 0} ControlPlaneAdapterLogs
   "Optional protocol for adapters that support log retrieval."
 
   (agent-logs [this agent-record opts]

--- a/components/control-plane-adapter/test/ai/miniforge/control_plane_adapter/interface_test.clj
+++ b/components/control-plane-adapter/test/ai/miniforge/control_plane_adapter/interface_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.control-plane-adapter.interface-test
   (:require
    [clojure.test :refer [deftest is testing]]
@@ -23,15 +22,15 @@
    [ai.miniforge.control-plane-adapter.protocol :as proto]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Test fixtures and factories
 
-(def ^:private openai-status-map
+;; Test fixtures and factories
+(def ^{:stratum 0} ^:private openai-status-map
   {:requires_action :blocked
    :in_progress     :running
    :completed       :completed
    :failed          :failed})
 
-(defn- agent-record
+(defn- ^{:stratum 0} agent-record
   [& {:as overrides}]
   (merge {:agent/id          (random-uuid)
           :agent/external-id "ext-1"
@@ -40,7 +39,7 @@
           :agent/status      :running}
          overrides))
 
-(defn- mock-adapter
+(defn- ^{:stratum 0} mock-adapter
   "Build an adapter from a map of method overrides. Defaults are no-op."
   [{:keys [adapter-id discover-agents poll-agent-status
            deliver-decision send-command]
@@ -56,10 +55,8 @@
     (deliver-decision  [_ rec res]    (deliver-decision rec res))
     (send-command      [_ rec cmd]    (send-command rec cmd))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Protocol re-export tests
-
-(deftest interface-re-exports-protocol-test
+(deftest ^{:stratum 0} interface-re-exports-protocol-test
   (testing "interface namespace re-exports the ControlPlaneAdapter protocol"
     (is (= proto/ControlPlaneAdapter sut/ControlPlaneAdapter))
     (is (= proto/ControlPlaneAdapterLogs sut/ControlPlaneAdapterLogs)))
@@ -71,68 +68,62 @@
     (is (= proto/send-command      sut/send-command))
     (is (= proto/agent-logs        sut/agent-logs))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; normalize-status
-
-(deftest normalize-status-known-mapping-test
-  (testing "Known vendor status maps to control-plane keyword"
-    (is (= :blocked   (sut/normalize-status "requires_action" openai-status-map)))
-    (is (= :running   (sut/normalize-status "in_progress"     openai-status-map)))
-    (is (= :completed (sut/normalize-status "completed"       openai-status-map)))
-    (is (= :failed    (sut/normalize-status "failed"          openai-status-map)))))
-
-(deftest normalize-status-keyword-input-test
-  (testing "Keyword input is preserved (no double-keywording)"
-    (is (= :blocked (sut/normalize-status :requires_action openai-status-map)))))
-
-(deftest normalize-status-unknown-test
-  (testing "Unmapped status defaults to :unknown"
-    (is (= :unknown (sut/normalize-status "weird-state" openai-status-map)))
-    (is (= :unknown (sut/normalize-status :weird-state  openai-status-map)))))
-
-(deftest normalize-status-empty-mapping-test
+(deftest ^{:stratum 0} normalize-status-empty-mapping-test
   (testing "Empty mapping returns :unknown for any input"
     (is (= :unknown (sut/normalize-status "anything" {})))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; ms-since
-
-(deftest ms-since-past-timestamp-test
+(deftest ^{:stratum 0} ms-since-past-timestamp-test
   (testing "ms-since returns positive elapsed milliseconds for a past timestamp"
     (let [past (java.util.Date. (- (System/currentTimeMillis) 1000))
           elapsed (sut/ms-since past)]
       (is (number? elapsed))
       (is (>= elapsed 1000) "Should reflect at least the backdate amount"))))
 
-(deftest ms-since-nil-test
+(deftest ^{:stratum 0} ms-since-nil-test
   (testing "ms-since returns nil for a nil timestamp"
     (is (nil? (sut/ms-since nil)))))
 
-(deftest ms-since-recent-test
+(deftest ^{:stratum 0} ms-since-recent-test
   (testing "ms-since for ~now returns small non-negative ms"
     (let [now-ish (java.util.Date.)
           elapsed (sut/ms-since now-ish)]
       (is (>= elapsed 0)))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; heartbeat-interval-for-vendor
-
-(deftest heartbeat-interval-known-vendors-test
+(deftest ^{:stratum 0} heartbeat-interval-known-vendors-test
   (testing "Each known vendor returns its tuned interval"
     (is (= 15000 (sut/heartbeat-interval-for-vendor :claude-code)))
     (is (= 10000 (sut/heartbeat-interval-for-vendor :miniforge)))
     (is (= 60000 (sut/heartbeat-interval-for-vendor :openai)))
     (is (= 30000 (sut/heartbeat-interval-for-vendor :cursor)))))
 
-(deftest heartbeat-interval-unknown-vendor-test
+(deftest ^{:stratum 0} heartbeat-interval-unknown-vendor-test
   (testing "Unknown vendor falls back to 30s default"
     (is (= 30000 (sut/heartbeat-interval-for-vendor :acme-newcomer)))
     (is (= 30000 (sut/heartbeat-interval-for-vendor nil)))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Protocol shape — verify an adapter can be implemented and called via interface fns
+;------------------------------------------------------------------------------ Layer 1
 
-(deftest adapter-can-be-invoked-via-interface-test
+;; normalize-status
+(deftest ^{:stratum 1} normalize-status-known-mapping-test
+  (testing "Known vendor status maps to control-plane keyword"
+    (is (= :blocked   (sut/normalize-status "requires_action" openai-status-map)))
+    (is (= :running   (sut/normalize-status "in_progress"     openai-status-map)))
+    (is (= :completed (sut/normalize-status "completed"       openai-status-map)))
+    (is (= :failed    (sut/normalize-status "failed"          openai-status-map)))))
+
+(deftest ^{:stratum 1} normalize-status-keyword-input-test
+  (testing "Keyword input is preserved (no double-keywording)"
+    (is (= :blocked (sut/normalize-status :requires_action openai-status-map)))))
+
+(deftest ^{:stratum 1} normalize-status-unknown-test
+  (testing "Unmapped status defaults to :unknown"
+    (is (= :unknown (sut/normalize-status "weird-state" openai-status-map)))
+    (is (= :unknown (sut/normalize-status :weird-state  openai-status-map)))))
+
+;; Protocol shape — verify an adapter can be implemented and called via interface fns
+(deftest ^{:stratum 1} adapter-can-be-invoked-via-interface-test
   (testing "An adapter implementing ControlPlaneAdapter is callable via interface fns"
     (let [discovered (atom nil)
           delivered  (atom nil)
@@ -160,12 +151,12 @@
           (is (true? (:delivered? ret)))
           (is (= [rec res] @delivered)))))))
 
-(deftest adapter-defaults-to-unreachable-when-no-poll-result-test
+(deftest ^{:stratum 1} adapter-defaults-to-unreachable-when-no-poll-result-test
   (testing "poll-agent-status returning nil signals unreachable"
     (let [adapter (mock-adapter {:poll-agent-status (constantly nil)})]
       (is (nil? (sut/poll-agent-status adapter (agent-record)))))))
 
-(deftest send-command-failure-shape-test
+(deftest ^{:stratum 1} send-command-failure-shape-test
   (testing "send-command returns a failure shape with :error string"
     (let [adapter (mock-adapter
                    {:send-command (fn [_ _]

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-control-plane-adapter.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-control-plane-adapter.md
@@ -1,0 +1,90 @@
+# fix: stratum-lint autofix for components/control-plane-adapter (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over `components/control-plane-adapter` (`src` +
+`test`) to replace decorative, non-monotonic `Layer N` headings with real
+ones derived from the file's actual same-file reference graph, and to add
+`^{:stratum n}` metadata to every def. Mechanical: no logic changes. One
+of the Wave 1 per-component PRs from `work/stratum-lint-baseline-2026-07-24.md`.
+
+## Motivation
+
+The component carried 4 findings under the baseline's cargo-cult
+diagnosis, all `SL002` (a `Layer N` heading repeated instead of increasing):
+`protocol.clj` had two separate `Layer 0` headings for its two
+`defprotocol`s, and `interface_test.clj` had a `Layer 1` heading reused
+three times across unrelated `deftest` groups. Zero `SL001` findings, so
+no upward-reference/cycle risk to reason about before running the
+mechanical fixer — matches the baseline's Wave 1 batch criteria.
+
+## Changes in Detail
+
+Ran, over the whole component:
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "14965e1ee1a175bd00f637d9a9d5f7d27e62b73f" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/control-plane-adapter
+```
+
+3 files rewritten: `protocol.clj`, `interface.clj` (both `src`), and
+`interface_test.clj` (`test`) — `--fix` normalizes every file in the
+component, not just the ones with findings.
+
+- `protocol.clj`: both `defprotocol`s (`ControlPlaneAdapter`,
+  `ControlPlaneAdapterLogs`) are genuinely independent (no same-file
+  reference between them), so they collapse under one real `Layer 0`
+  heading instead of two. Each gained `^{:stratum 0}`.
+- `interface.clj` had no prior findings; `--fix` only added
+  `^{:stratum n}` metadata to its existing defs (all Layer 0, plus
+  `heartbeat-interval-for-vendor` at Layer 1 since it composes the
+  Layer-0 `vendor-heartbeat-ms` map) — no reordering, no heading changes.
+- `interface_test.clj`: three `deftest`s that reference the file-local
+  `openai-status-map` fixture (`normalize-status-known-mapping-test`,
+  `normalize-status-keyword-input-test`, `normalize-status-unknown-test`)
+  moved from their old position (labeled `Layer 1`, same as everything
+  else) down to after the vendor/heartbeat tests, now correctly at real
+  `Layer 1` (one above the `Layer 0` fixture they reference).
+  `normalize-status-empty-mapping-test`, which uses a literal `{}` instead
+  of the fixture, stayed at `Layer 0`. All other test groups collapsed
+  onto the same two real layers (0 and 1) instead of the old three
+  decorative ones (0, 1, 2).
+
+No same-line trailing comment was displaced onto the wrong def — checked
+each file for the known tool limitation and found none of that shape.
+
+## Testing Plan
+
+1. Ran plain (non-`--fix`) `stratum-lint` before the fix — reproduced the
+   baseline's 4 `SL002` findings exactly (same files, same lines).
+2. Ran `--fix`, then a second `--fix` pass immediately after on a saved
+   copy of the tree — zero diff, confirms idempotency.
+3. Read the full diff for all 3 changed files. Confirmed only heading
+   text, `^{:stratum n}` metadata, and def/deftest reordering changed; no
+   executable code touched.
+4. `clj-kondo --lint components/control-plane-adapter`: 0 errors, 0
+   warnings.
+5. Ran `ai.miniforge.control-plane-adapter.interface-test` directly via
+   `clojure -A:test`: 13 tests, 35 assertions, 0 failures, 0 errors.
+6. Re-ran plain `stratum-lint` after the fix: zero findings remain across
+   the whole component — no `SL003` surfaced (real depth stayed within
+   the 3-layer budget).
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+change — comment/metadata/order-only. Pre-commit's `lint:stratum`
+autofixer keeps this component clean going forward.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+
+## Checklist
+
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Second `--fix` pass confirms idempotency (zero diff)
+- [x] Diff read in full for all 3 changed files; mechanical-only
+- [x] `clj-kondo` clean (0 errors, 0 warnings)
+- [x] Component tests pass (13 tests, 35 assertions, 0 failures/errors)
+- [x] Plain lint re-run post-fix: zero findings remain, no `SL003`
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
## Summary

- Runs `stratum-lint --fix` over `components/control-plane-adapter` (`src` + `test`), replacing decorative, non-monotonic `Layer N` headings with real ones derived from the file's actual same-file reference graph, and stamping `^{:stratum n}` metadata on every def.
- Baseline: 4 `SL002` findings (`protocol.clj`, `interface_test.clj`), zero `SL001` — matches Wave 1 batch criteria (see `work/stratum-lint-baseline-2026-07-24.md`).
- Mechanical only: no logic changes. Full detail in `docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-control-plane-adapter.md`.

## Test plan

- [x] Plain lint before fix reproduced the baseline's 4 `SL002` findings exactly
- [x] `--fix` run, then a second `--fix` pass on a saved copy — zero diff (idempotent)
- [x] Full diff read for all 3 changed files — heading/metadata/reorder only
- [x] `clj-kondo --lint components/control-plane-adapter` — 0 errors, 0 warnings
- [x] `ai.miniforge.control-plane-adapter.interface-test` — 13 tests, 35 assertions, 0 failures/errors
- [x] Plain lint re-run post-fix — zero findings remain, no `SL003` surfaced

🤖 Generated with [Claude Code](https://claude.com/claude-code)