### PR TITLE
fix: stratum-lint autofix for components/response-chain (Wave 1)

### DIFF
--- a/components/response-chain/src/ai/miniforge/response_chain/contract.clj
+++ b/components/response-chain/src/ai/miniforge/response_chain/contract.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.response-chain.contract
   "Malli contracts for the response-chain shape.
 
@@ -33,9 +32,9 @@
    [malli.error :as me]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Step
 
-(def Step
+;; Step
+(def ^{:stratum 0} Step
   "Malli schema for a single response-chain step.
 
    Every step carries:
@@ -60,9 +59,9 @@
    [:request    {:optional true} :any]])
 
 ;------------------------------------------------------------------------------ Layer 1
-;; Chain
 
-(def Chain
+;; Chain
+(def ^{:stratum 1} Chain
   "Malli schema for a response-chain envelope.
 
    Every chain carries:
@@ -75,27 +74,27 @@
    [:succeeded?     :boolean]
    [:response-chain [:vector Step]]])
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Validation helpers
-
-(defn valid-step?
+(defn ^{:stratum 1} valid-step?
   "Return true when `value` matches the `Step` schema."
   [value]
   (m/validate Step value))
 
-(defn valid-chain?
-  "Return true when `value` matches the `Chain` schema."
-  [value]
-  (m/validate Chain value))
-
-(defn explain-step
+(defn ^{:stratum 1} explain-step
   "Return a humanized explanation for an invalid step, or nil
    when `value` is valid."
   [value]
   (some-> (m/explain Step value)
           me/humanize))
 
-(defn explain-chain
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} valid-chain?
+  "Return true when `value` matches the `Chain` schema."
+  [value]
+  (m/validate Chain value))
+
+(defn ^{:stratum 2} explain-chain
   "Return a humanized explanation for an invalid chain, or nil
    when `value` is valid."
   [value]

--- a/components/response-chain/src/ai/miniforge/response_chain/core.clj
+++ b/components/response-chain/src/ai/miniforge/response_chain/core.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.response-chain.core
   "Implementation of the response-chain primitive.
 
@@ -30,9 +29,9 @@
    [ai.miniforge.response-chain.contract :as contract]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Step construction
 
-(defn- build-step
+;; Step construction
+(defn- ^{:stratum 0} build-step
   "Build a canonical step map. `an` may be nil. The step's
    `:succeeded?` is true iff `an` is nil. When `request` is non-nil it
    is attached as an optional `:request` key; when nil the key is
@@ -47,21 +46,55 @@
             :response   response}
      (some? request) (assoc :request request))))
 
-;------------------------------------------------------------------------------ Layer 0
 ;; Operation-key coercion
 ;;
 ;; The Chain and Step schemas require `:operation` to be a keyword. The
 ;; component is a non-throwing boundary helper, so we coerce non-keyword
 ;; operations to a sentinel and surface the bad input as an anomaly
 ;; rather than producing a chain that fails its own schema.
-
-(def ^:private invalid-operation-sentinel
+(def ^{:stratum 0} ^:private invalid-operation-sentinel
   "Sentinel operation key used when caller supplies a non-keyword
    operation. Keeps the chain/step schema invariant intact even when
    input is malformed."
   :response-chain/invalid)
 
-(defn- coerce-operation
+;; Append
+(defn- ^{:stratum 0} recompute-succeeded?
+  "Return true iff every step in `steps` has `:succeeded?` true."
+  [steps]
+  (every? :succeeded? steps))
+
+;; Predicate
+(defn ^{:stratum 0} succeeded?
+  "True when `step-or-chain` is recorded as successful.
+
+   - A step succeeds iff `:succeeded?` is true.
+   - A chain succeeds iff every appended step succeeded (an empty chain
+     is vacuously successful)."
+  [step-or-chain]
+  (boolean (:succeeded? step-or-chain)))
+
+;; Accessors
+(defn ^{:stratum 0} steps
+  "Return the vector of step maps from `chain`."
+  [chain]
+  (get chain :response-chain []))
+
+(defn ^{:stratum 0} last-response
+  "Return the `:response` of the most recently appended step, or nil
+   when the chain has no steps."
+  [chain]
+  (some-> chain :response-chain peek :response))
+
+(defn ^{:stratum 0} last-anomaly
+  "Return the `:anomaly` of the most recently appended step, or nil
+   when the chain has no steps or the last step succeeded."
+  [chain]
+  (some-> chain :response-chain peek :anomaly))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} coerce-operation
   "Return `operation` when it is already a keyword; otherwise return
    the canonical sentinel. Callers use this to ensure the chain/step
    schema is preserved even when input is malformed."
@@ -70,10 +103,30 @@
     operation
     invalid-operation-sentinel))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Chain construction
+(defn- ^{:stratum 1} conj-step
+  "Append `step` to `chain` and recompute the chain's `:succeeded?`
+   invariant from the resulting step vector."
+  [chain step]
+  (let [steps (conj (:response-chain chain) step)]
+    (assoc chain
+           :response-chain steps
+           :succeeded? (recompute-succeeded? steps))))
 
-(defn create-chain
+(defn ^{:stratum 1} last-successful-or
+  "Return the `:response` of the most recently appended *successful*
+   step, or `default` when the chain has no successful steps."
+  [chain default]
+  (let [step (->> (steps chain)
+                  (filter :succeeded?)
+                  last)]
+    (if step
+      (:response step)
+      default)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Chain construction
+(defn ^{:stratum 2} create-chain
   "Return a fresh chain for the named `operation`.
 
    When `operation` is a keyword, the chain is empty and vacuously
@@ -98,24 +151,9 @@
          :succeeded?     false
          :response-chain [step]}))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Append
+;------------------------------------------------------------------------------ Layer 3
 
-(defn- recompute-succeeded?
-  "Return true iff every step in `steps` has `:succeeded?` true."
-  [steps]
-  (every? :succeeded? steps))
-
-(defn- conj-step
-  "Append `step` to `chain` and recompute the chain's `:succeeded?`
-   invariant from the resulting step vector."
-  [chain step]
-  (let [steps (conj (:response-chain chain) step)]
-    (assoc chain
-           :response-chain steps
-           :succeeded? (recompute-succeeded? steps))))
-
-(defn- guarded-append
+(defn- ^{:stratum 3} guarded-append
   "Append `step` to `chain` after validating both inputs against the
    schema. If validation fails we still produce a step — but it carries
    an `:invalid-input` anomaly and flips the chain's `:succeeded?` false.
@@ -141,7 +179,9 @@
     :else
     (conj-step chain step)))
 
-(defn append-step
+;------------------------------------------------------------------------------ Layer 4
+
+(defn ^{:stratum 4} append-step
   "Append a step to `chain` for `operation`.
 
    - 3-arity: a successful step carrying `response`.
@@ -172,46 +212,3 @@
                         {:operation         operation
                          :original-anomaly  an}))]
      (guarded-append chain op (build-step op eff-anomaly response request)))))
-
-;------------------------------------------------------------------------------ Layer 3
-;; Predicate
-
-(defn succeeded?
-  "True when `step-or-chain` is recorded as successful.
-
-   - A step succeeds iff `:succeeded?` is true.
-   - A chain succeeds iff every appended step succeeded (an empty chain
-     is vacuously successful)."
-  [step-or-chain]
-  (boolean (:succeeded? step-or-chain)))
-
-;------------------------------------------------------------------------------ Layer 4
-;; Accessors
-
-(defn steps
-  "Return the vector of step maps from `chain`."
-  [chain]
-  (get chain :response-chain []))
-
-(defn last-response
-  "Return the `:response` of the most recently appended step, or nil
-   when the chain has no steps."
-  [chain]
-  (some-> chain :response-chain peek :response))
-
-(defn last-anomaly
-  "Return the `:anomaly` of the most recently appended step, or nil
-   when the chain has no steps or the last step succeeded."
-  [chain]
-  (some-> chain :response-chain peek :anomaly))
-
-(defn last-successful-or
-  "Return the `:response` of the most recently appended *successful*
-   step, or `default` when the chain has no successful steps."
-  [chain default]
-  (let [step (->> (steps chain)
-                  (filter :succeeded?)
-                  last)]
-    (if step
-      (:response step)
-      default)))

--- a/components/response-chain/src/ai/miniforge/response_chain/interface.clj
+++ b/components/response-chain/src/ai/miniforge/response_chain/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.response-chain.interface
   "Public API for the response-chain component.
 
@@ -52,22 +51,20 @@
    [ai.miniforge.response-chain.core :as core]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Schema re-exports
 
-(def Chain
+;; Schema re-exports
+(def ^{:stratum 0} Chain
   "Malli schema for the canonical chain map. See
    `ai.miniforge.response-chain.contract/Chain`."
   contract/Chain)
 
-(def Step
+(def ^{:stratum 0} Step
   "Malli schema for a single chain step. See
    `ai.miniforge.response-chain.contract/Step`."
   contract/Step)
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Construction
-
-(defn create-chain
+(defn ^{:stratum 0} create-chain
   "Start a new response-chain for the named `operation-key`.
 
    Returns a chain map with no steps and `:succeeded?` true (vacuous
@@ -75,10 +72,8 @@
   [operation-key]
   (core/create-chain operation-key))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Append
-
-(defn append-step
+(defn ^{:stratum 0} append-step
   "Append a step to `chain` for `operation-key`.
 
    - 3-arity `(append-step chain operation-key response)`
@@ -110,10 +105,8 @@
   ([chain operation-key anomaly response request]
    (core/append-step chain operation-key anomaly response request)))
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Predicate
-
-(defn succeeded?
+(defn ^{:stratum 0} succeeded?
   "True when `step-or-chain` is recorded as successful.
 
    - For a step: returns the step's `:succeeded?` flag.
@@ -122,34 +115,31 @@
   [step-or-chain]
   (core/succeeded? step-or-chain))
 
-;------------------------------------------------------------------------------ Layer 4
 ;; Accessors
-
-(defn steps
+(defn ^{:stratum 0} steps
   "Return the vector of step maps from `chain` in append order."
   [chain]
   (core/steps chain))
 
-(defn last-response
+(defn ^{:stratum 0} last-response
   "Return the `:response` of the most recently appended step, or nil
    when the chain has no steps."
   [chain]
   (core/last-response chain))
 
-(defn last-anomaly
+(defn ^{:stratum 0} last-anomaly
   "Return the `:anomaly` of the most recently appended step, or nil
    when the chain has no steps or the last step succeeded."
   [chain]
   (core/last-anomaly chain))
 
-(defn last-successful-or
+(defn ^{:stratum 0} last-successful-or
   "Return the `:response` of the most recently appended *successful*
    step, or `default` when no successful step has been appended."
   [chain default]
   (core/last-successful-or chain default))
 
 ;------------------------------------------------------------------------------ Rich Comment
-
 (comment
   (require '[ai.miniforge.anomaly.interface :as anomaly])
 

--- a/components/response-chain/test/ai/miniforge/response_chain/interface/append_step_anomaly_test.clj
+++ b/components/response-chain/test/ai/miniforge/response_chain/interface/append_step_anomaly_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.response-chain.interface.append-step-anomaly-test
   "Anomaly-step append. The 4-arity overload with a non-nil anomaly
    must record a failed step and flip the chain's `:succeeded?` to false
@@ -25,7 +24,9 @@
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.response-chain.interface :as chain]))
 
-(deftest anomaly-step-marks-itself-failed
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} anomaly-step-marks-itself-failed
   (testing "step with non-nil anomaly has succeeded? false"
     (let [a (anomaly/anomaly :not-found "missing" {:id 1})
           c (-> (chain/create-chain :flow)
@@ -35,7 +36,7 @@
       (is (= a (:anomaly s)))
       (is (nil? (:response s))))))
 
-(deftest anomaly-step-flips-chain-succeeded-false
+(deftest ^{:stratum 0} anomaly-step-flips-chain-succeeded-false
   (testing "chain :succeeded? becomes false once any step fails"
     (let [a (anomaly/anomaly :fault "boom" {})
           c (-> (chain/create-chain :flow)
@@ -43,7 +44,7 @@
                 (chain/append-step :b a nil))]
       (is (false? (chain/succeeded? c))))))
 
-(deftest later-success-does-not-recover-failed-chain
+(deftest ^{:stratum 0} later-success-does-not-recover-failed-chain
   (testing "once any step has failed, the chain stays failed"
     (let [a (anomaly/anomaly :fault "boom" {})
           c (-> (chain/create-chain :flow)
@@ -53,7 +54,7 @@
       (is (false? (chain/succeeded? c)))
       (is (= 3 (count (chain/steps c)))))))
 
-(deftest four-arity-with-nil-anomaly-is-success
+(deftest ^{:stratum 0} four-arity-with-nil-anomaly-is-success
   (testing "4-arity with explicit nil anomaly behaves like the 3-arity"
     (let [c (-> (chain/create-chain :flow)
                 (chain/append-step :a nil 42))

--- a/components/response-chain/test/ai/miniforge/response_chain/interface/append_step_request_test.clj
+++ b/components/response-chain/test/ai/miniforge/response_chain/interface/append_step_request_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.response-chain.interface.append-step-request-test
   "5-arity append-step that carries the original request as :request
    metadata on the step. Used by downstream consumers (e.g. an
@@ -27,7 +26,9 @@
    [clojure.test :refer [deftest is testing]]
    [malli.core :as m]))
 
-(deftest five-arity-success-attaches-request-to-step
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} five-arity-success-attaches-request-to-step
   (testing "5-arity success path records :request on the step"
     (let [request {:lookup [:person/id "chris"]}
           c0     (chain/create-chain :flow)
@@ -41,7 +42,7 @@
       (is (= request (:request step)))
       (is (= {:id "chris" :name "Christopher Lester"} (:response step))))))
 
-(deftest five-arity-anomaly-attaches-request-to-step
+(deftest ^{:stratum 0} five-arity-anomaly-attaches-request-to-step
   (testing "5-arity anomaly path also records :request on the step"
     (let [request  {:lookup []}
           response {:error :lookup-empty}
@@ -58,21 +59,21 @@
       (is (= response (:response step)))
       (is (= an (:anomaly step))))))
 
-(deftest three-arity-omits-request-key
+(deftest ^{:stratum 0} three-arity-omits-request-key
   (testing "3-arity success path produces a step WITHOUT :request key"
     (let [c0   (chain/create-chain :flow)
           c1   (chain/append-step c0 :op {:result 1})
           step (last (chain/steps c1))]
       (is (not (contains? step :request))))))
 
-(deftest four-arity-omits-request-key
+(deftest ^{:stratum 0} four-arity-omits-request-key
   (testing "4-arity (existing API) produces a step WITHOUT :request key"
     (let [c0   (chain/create-chain :flow)
           c1   (chain/append-step c0 :op nil {:result 1})
           step (last (chain/steps c1))]
       (is (not (contains? step :request))))))
 
-(deftest five-arity-with-nil-request-omits-key
+(deftest ^{:stratum 0} five-arity-with-nil-request-omits-key
   (testing "5-arity with explicit nil request omits :request key"
     (let [c0   (chain/create-chain :flow)
           c1   (chain/append-step c0 :op nil {:result 1} nil)
@@ -80,7 +81,7 @@
       (is (not (contains? step :request)))
       (is (chain/succeeded? c1)))))
 
-(deftest schema-validates-step-with-request
+(deftest ^{:stratum 0} schema-validates-step-with-request
   (testing "Step schema accepts steps that carry :request"
     (let [c0   (chain/create-chain :flow)
           c1   (chain/append-step c0 :op nil "ok" {:original "request"})
@@ -88,7 +89,7 @@
       (is (m/validate chain/Step step))
       (is (= {:original "request"} (:request step))))))
 
-(deftest schema-validates-step-without-request
+(deftest ^{:stratum 0} schema-validates-step-without-request
   (testing "Step schema still accepts steps that omit :request (back-compat)"
     (let [c0   (chain/create-chain :flow)
           c1   (chain/append-step c0 :op {:result 1})
@@ -96,7 +97,7 @@
       (is (m/validate chain/Step step))
       (is (not (contains? step :request))))))
 
-(deftest schema-validates-chain-with-mixed-steps
+(deftest ^{:stratum 0} schema-validates-chain-with-mixed-steps
   (testing "Chain schema accepts a mix of steps with and without :request"
     (let [c (-> (chain/create-chain :flow)
                 (chain/append-step :step-1 {:result 1})
@@ -108,7 +109,7 @@
       (is (contains?     (nth (chain/steps c) 1) :request))
       (is (not (contains? (nth (chain/steps c) 2) :request))))))
 
-(deftest non-keyword-operation-still-records-request
+(deftest ^{:stratum 0} non-keyword-operation-still-records-request
   (testing "non-keyword operation in 5-arity still surfaces :invalid-input AND records the request"
     (let [request {:lookup [:person/id "chris"]}
           c0      (chain/create-chain :flow)
@@ -119,7 +120,7 @@
       (is (= :invalid-input (-> step :anomaly :anomaly/type)))
       (is (= request (:request step))))))
 
-(deftest request-can-be-arbitrary-edn
+(deftest ^{:stratum 0} request-can-be-arbitrary-edn
   (testing ":request accepts any EDN-shape value"
     (doseq [req [{:map "value"}
                  [:vector :of :keywords]

--- a/components/response-chain/test/ai/miniforge/response_chain/interface/append_step_success_test.clj
+++ b/components/response-chain/test/ai/miniforge/response_chain/interface/append_step_success_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.response-chain.interface.append-step-success-test
   "Successful-step append. The 3-arity overload must record a step
    with `:succeeded? true`, no anomaly, and the carried response, while
@@ -24,7 +23,9 @@
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.response-chain.interface :as chain]))
 
-(deftest append-step-3-arity-marks-step-successful
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} append-step-3-arity-marks-step-successful
   (testing "appended step has succeeded? true and nil anomaly"
     (let [c (-> (chain/create-chain :flow)
                 (chain/append-step :db/lookup {:id 1}))
@@ -34,14 +35,14 @@
       (is (= :db/lookup (:operation s)))
       (is (= {:id 1} (:response s))))))
 
-(deftest append-step-3-arity-keeps-chain-successful
+(deftest ^{:stratum 0} append-step-3-arity-keeps-chain-successful
   (testing "chain :succeeded? remains true after an all-success run"
     (let [c (-> (chain/create-chain :flow)
                 (chain/append-step :a 1)
                 (chain/append-step :b 2))]
       (is (chain/succeeded? c)))))
 
-(deftest append-step-preserves-operation-and-grows-step-vector
+(deftest ^{:stratum 0} append-step-preserves-operation-and-grows-step-vector
   (testing "the chain's :operation is preserved and steps grow by one"
     (let [c0 (chain/create-chain :flow)
           c1 (chain/append-step c0 :a 1)
@@ -51,7 +52,7 @@
       (is (= 1 (count (chain/steps c1))))
       (is (= 2 (count (chain/steps c2)))))))
 
-(deftest append-step-accepts-nil-response
+(deftest ^{:stratum 0} append-step-accepts-nil-response
   (testing "nil is a valid response value"
     (let [c (-> (chain/create-chain :flow)
                 (chain/append-step :a nil))

--- a/components/response-chain/test/ai/miniforge/response_chain/interface/create_chain_test.clj
+++ b/components/response-chain/test/ai/miniforge/response_chain/interface/create_chain_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.response-chain.interface.create-chain-test
   "Initial-state happy path. A fresh chain must have the right
    operation, an empty step vector, and a vacuously-true `:succeeded?`."
@@ -24,26 +23,28 @@
    [malli.core :as m]
    [ai.miniforge.response-chain.interface :as chain]))
 
-(deftest create-chain-returns-canonical-shape
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} create-chain-returns-canonical-shape
   (testing "fresh chain has the three canonical keys"
     (let [c (chain/create-chain :auth/login)]
       (is (= :auth/login (:operation c)))
       (is (true? (:succeeded? c)))
       (is (= [] (:response-chain c))))))
 
-(deftest fresh-chain-validates-against-the-schema
+(deftest ^{:stratum 0} fresh-chain-validates-against-the-schema
   (testing "an empty chain matches the malli Chain schema"
     (is (m/validate chain/Chain (chain/create-chain :anything)))))
 
-(deftest fresh-chain-is-vacuously-successful
+(deftest ^{:stratum 0} fresh-chain-is-vacuously-successful
   (testing "succeeded? returns true for a chain with no steps"
     (is (true? (chain/succeeded? (chain/create-chain :x))))))
 
-(deftest fresh-chain-has-empty-step-vector
+(deftest ^{:stratum 0} fresh-chain-has-empty-step-vector
   (testing "steps returns an empty vector for a fresh chain"
     (is (= [] (chain/steps (chain/create-chain :x))))))
 
-(deftest fresh-chain-has-no-last-response-or-anomaly
+(deftest ^{:stratum 0} fresh-chain-has-no-last-response-or-anomaly
   (testing "last-response and last-anomaly are nil on an empty chain"
     (let [c (chain/create-chain :x)]
       (is (nil? (chain/last-response c)))

--- a/components/response-chain/test/ai/miniforge/response_chain/interface/last_anomaly_test.clj
+++ b/components/response-chain/test/ai/miniforge/response_chain/interface/last_anomaly_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.response-chain.interface.last-anomaly-test
   "`last-anomaly` returns the most recent step's `:anomaly` (or nil
    when the chain is empty / the last step succeeded)."
@@ -24,24 +23,26 @@
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.response-chain.interface :as chain]))
 
-(deftest last-anomaly-nil-for-empty-chain
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} last-anomaly-nil-for-empty-chain
   (testing "no steps yet means no anomaly"
     (is (nil? (chain/last-anomaly (chain/create-chain :x))))))
 
-(deftest last-anomaly-nil-when-last-step-succeeded
+(deftest ^{:stratum 0} last-anomaly-nil-when-last-step-succeeded
   (testing "last successful step reports nil anomaly"
     (let [c (-> (chain/create-chain :x)
                 (chain/append-step :a 1))]
       (is (nil? (chain/last-anomaly c))))))
 
-(deftest last-anomaly-returns-anomaly-for-failed-step
+(deftest ^{:stratum 0} last-anomaly-returns-anomaly-for-failed-step
   (testing "non-nil anomaly is returned when the last step failed"
     (let [a (anomaly/anomaly :not-found "missing" {:id 7})
           c (-> (chain/create-chain :x)
                 (chain/append-step :a a nil))]
       (is (= a (chain/last-anomaly c))))))
 
-(deftest last-anomaly-tracks-the-last-step-not-the-first-failure
+(deftest ^{:stratum 0} last-anomaly-tracks-the-last-step-not-the-first-failure
   (testing "if the failure is followed by a success, last-anomaly is nil"
     (let [a (anomaly/anomaly :fault "boom" {})
           c (-> (chain/create-chain :x)

--- a/components/response-chain/test/ai/miniforge/response_chain/interface/last_response_test.clj
+++ b/components/response-chain/test/ai/miniforge/response_chain/interface/last_response_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.response-chain.interface.last-response-test
   "`last-response` returns the most recent step's `:response` value,
    regardless of success status, and nil for empty chains."
@@ -24,11 +23,13 @@
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.response-chain.interface :as chain]))
 
-(deftest last-response-nil-for-empty-chain
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} last-response-nil-for-empty-chain
   (testing "empty chain has no last response"
     (is (nil? (chain/last-response (chain/create-chain :x))))))
 
-(deftest last-response-returns-most-recent-success
+(deftest ^{:stratum 0} last-response-returns-most-recent-success
   (testing "happy path: last response is the last appended response"
     (let [c (-> (chain/create-chain :x)
                 (chain/append-step :a 1)
@@ -36,7 +37,7 @@
                 (chain/append-step :c 3))]
       (is (= 3 (chain/last-response c))))))
 
-(deftest last-response-of-failed-step-is-its-response
+(deftest ^{:stratum 0} last-response-of-failed-step-is-its-response
   (testing "even when the last step failed, last-response returns its :response"
     (let [a (anomaly/anomaly :fault "boom" {})
           c (-> (chain/create-chain :x)
@@ -44,7 +45,7 @@
                 (chain/append-step :b a {:partial true}))]
       (is (= {:partial true} (chain/last-response c))))))
 
-(deftest last-response-handles-nil-payload
+(deftest ^{:stratum 0} last-response-handles-nil-payload
   (testing "nil response on the last step is returned as nil"
     (let [c (-> (chain/create-chain :x)
                 (chain/append-step :a 1)

--- a/components/response-chain/test/ai/miniforge/response_chain/interface/last_successful_or_test.clj
+++ b/components/response-chain/test/ai/miniforge/response_chain/interface/last_successful_or_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.response-chain.interface.last-successful-or-test
   "`last-successful-or` returns the most recent successful step's
    `:response`, falling back to a caller-supplied default when none has
@@ -25,11 +24,13 @@
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.response-chain.interface :as chain]))
 
-(deftest fallback-default-on-empty-chain
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} fallback-default-on-empty-chain
   (testing "no steps yet => default is returned"
     (is (= ::none (chain/last-successful-or (chain/create-chain :x) ::none)))))
 
-(deftest fallback-default-when-no-step-succeeded
+(deftest ^{:stratum 0} fallback-default-when-no-step-succeeded
   (testing "every step failed => default is returned"
     (let [a (anomaly/anomaly :fault "boom" {})
           c (-> (chain/create-chain :x)
@@ -37,7 +38,7 @@
                 (chain/append-step :b a nil))]
       (is (= ::fallback (chain/last-successful-or c ::fallback))))))
 
-(deftest returns-most-recent-successful-response
+(deftest ^{:stratum 0} returns-most-recent-successful-response
   (testing "with mixed failures, returns the most recent successful step's response"
     (let [a (anomaly/anomaly :fault "boom" {})
           c (-> (chain/create-chain :x)
@@ -46,7 +47,7 @@
                 (chain/append-step :c a nil))]
       (is (= 2 (chain/last-successful-or c ::none))))))
 
-(deftest returns-most-recent-success-after-recovery
+(deftest ^{:stratum 0} returns-most-recent-success-after-recovery
   (testing "if a later step succeeds, that is the most recent success"
     (let [a (anomaly/anomaly :fault "boom" {})
           c (-> (chain/create-chain :x)
@@ -55,7 +56,7 @@
                 (chain/append-step :c 3))]
       (is (= 3 (chain/last-successful-or c ::none))))))
 
-(deftest default-can-be-any-value
+(deftest ^{:stratum 0} default-can-be-any-value
   (testing "default may be nil, a map, or any value"
     (let [c (chain/create-chain :x)]
       (is (nil? (chain/last-successful-or c nil)))

--- a/components/response-chain/test/ai/miniforge/response_chain/interface/malli_validation_test.clj
+++ b/components/response-chain/test/ai/miniforge/response_chain/interface/malli_validation_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.response-chain.interface.malli-validation-test
   "Boundary validation. Malformed input must be rejected — but as data,
    not as a thrown exception. The component records an `:invalid-input`
@@ -26,23 +25,25 @@
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.response-chain.interface :as chain]))
 
-(deftest fresh-chain-validates
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} fresh-chain-validates
   (testing "the canonical fresh chain validates against the Chain schema"
     (is (m/validate chain/Chain (chain/create-chain :x)))))
 
-(deftest valid-step-validates
+(deftest ^{:stratum 0} valid-step-validates
   (testing "a step produced by append-step matches the Step schema"
     (let [c (-> (chain/create-chain :x)
                 (chain/append-step :a {:ok true}))]
       (is (every? #(m/validate chain/Step %) (chain/steps c))))))
 
-(deftest append-on-malformed-chain-does-not-throw
+(deftest ^{:stratum 0} append-on-malformed-chain-does-not-throw
   (testing "passing a non-chain to append-step returns a chain, not an exception"
     (let [result (chain/append-step {:not "a chain"} :op "value")]
       (is (map? result))
       (is (m/validate chain/Chain result)))))
 
-(deftest append-on-malformed-chain-records-invalid-input-anomaly
+(deftest ^{:stratum 0} append-on-malformed-chain-records-invalid-input-anomaly
   (testing "the recovery chain carries an :invalid-input anomaly step"
     (let [result (chain/append-step {:not "a chain"} :op "value")
           last-step (last (chain/steps result))]
@@ -50,7 +51,7 @@
       (is (= :invalid-input (some-> last-step :anomaly :anomaly/type)))
       (is (anomaly/anomaly? (:anomaly last-step))))))
 
-(deftest four-arity-with-non-anomaly-second-arg-is-rejected
+(deftest ^{:stratum 0} four-arity-with-non-anomaly-second-arg-is-rejected
   (testing "a non-Anomaly value in the anomaly slot is treated as malformed input"
     (let [c0 (chain/create-chain :x)
           result (chain/append-step c0 :op "not-an-anomaly" "value")
@@ -59,7 +60,7 @@
       (is (false? (chain/succeeded? result)))
       (is (= :invalid-input (some-> last-step :anomaly :anomaly/type))))))
 
-(deftest invalid-input-recovery-keeps-chain-well-formed
+(deftest ^{:stratum 0} invalid-input-recovery-keeps-chain-well-formed
   (testing "even after recovery the resulting chain validates"
     (let [result (-> (chain/create-chain :x)
                      (chain/append-step :a 1)
@@ -67,7 +68,7 @@
       (is (m/validate chain/Chain result))
       (is (false? (chain/succeeded? result))))))
 
-(deftest non-keyword-operation-on-append-step-records-invalid-input
+(deftest ^{:stratum 0} non-keyword-operation-on-append-step-records-invalid-input
   (testing "append-step coerces non-keyword operation to the sentinel"
     (let [result    (chain/append-step (chain/create-chain :x) "op" {:any "thing"})
           last-step (last (chain/steps result))]
@@ -77,7 +78,7 @@
       (is (= :invalid-input (some-> last-step :anomaly :anomaly/type)))
       (is (= "op" (some-> last-step :anomaly :anomaly/data :operation))))))
 
-(deftest non-keyword-operation-on-create-chain-records-invalid-input
+(deftest ^{:stratum 0} non-keyword-operation-on-create-chain-records-invalid-input
   (testing "create-chain coerces non-keyword operation to the sentinel and seeds an :invalid-input step"
     (let [result    (chain/create-chain "not-a-keyword")
           first-step (first (chain/steps result))]

--- a/components/response-chain/test/ai/miniforge/response_chain/interface/multi_step_composition_test.clj
+++ b/components/response-chain/test/ai/miniforge/response_chain/interface/multi_step_composition_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.response-chain.interface.multi-step-composition-test
   "Threading semantics. The chain is a linear accumulator: order is
    preserved, the chain stays well-formed across many appends, and the
@@ -26,7 +25,9 @@
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.response-chain.interface :as chain]))
 
-(deftest steps-preserve-append-order
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} steps-preserve-append-order
   (testing "operations come back in the order they were appended"
     (let [c (-> (chain/create-chain :flow)
                 (chain/append-step :a 1)
@@ -36,7 +37,7 @@
       (is (= [:a :b :c :d]
              (mapv :operation (chain/steps c)))))))
 
-(deftest responses-are-paired-with-their-operations
+(deftest ^{:stratum 0} responses-are-paired-with-their-operations
   (testing "each step's :response is the value passed at append time"
     (let [c (-> (chain/create-chain :flow)
                 (chain/append-step :a "first")
@@ -47,7 +48,7 @@
               ["third"  :c]]
              (mapv (juxt :response :operation) (chain/steps c)))))))
 
-(deftest chain-shape-stays-valid-through-many-appends
+(deftest ^{:stratum 0} chain-shape-stays-valid-through-many-appends
   (testing "after each append the chain still validates against the schema"
     (let [a (anomaly/anomaly :fault "boom" {})
           c (-> (chain/create-chain :flow)
@@ -57,7 +58,7 @@
       (is (m/validate chain/Chain c))
       (is (every? #(m/validate chain/Step %) (chain/steps c))))))
 
-(deftest succeeded-invariant-recomputed-each-append
+(deftest ^{:stratum 0} succeeded-invariant-recomputed-each-append
   (testing "chain :succeeded? equals the AND of all step :succeeded? after each append"
     (let [a (anomaly/anomaly :fault "boom" {})
           c0 (chain/create-chain :flow)
@@ -69,7 +70,7 @@
       (is (false? (:succeeded? c2)))
       (is (false? (:succeeded? c3))))))
 
-(deftest threading-is-pure-and-non-mutating
+(deftest ^{:stratum 0} threading-is-pure-and-non-mutating
   (testing "each append returns a new chain; the original is unchanged"
     (let [c0 (chain/create-chain :flow)
           c1 (chain/append-step c0 :a 1)]

--- a/components/response-chain/test/ai/miniforge/response_chain/interface/succeeded_predicate_test.clj
+++ b/components/response-chain/test/ai/miniforge/response_chain/interface/succeeded_predicate_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.response-chain.interface.succeeded-predicate-test
   "Predicate semantics. `succeeded?` must work uniformly for steps and
    for chains, and must always return a boolean."
@@ -24,11 +23,13 @@
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.response-chain.interface :as chain]))
 
-(deftest succeeded?-for-empty-chain-is-true
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} succeeded?-for-empty-chain-is-true
   (testing "empty chain is vacuously successful"
     (is (true? (chain/succeeded? (chain/create-chain :x))))))
 
-(deftest succeeded?-for-all-success-chain-is-true
+(deftest ^{:stratum 0} succeeded?-for-all-success-chain-is-true
   (testing "chain with only successful steps reports true"
     (let [c (-> (chain/create-chain :x)
                 (chain/append-step :a 1)
@@ -36,7 +37,7 @@
                 (chain/append-step :c 3))]
       (is (true? (chain/succeeded? c))))))
 
-(deftest succeeded?-for-any-failed-chain-is-false
+(deftest ^{:stratum 0} succeeded?-for-any-failed-chain-is-false
   (testing "any failed step makes the chain unsuccessful"
     (let [a (anomaly/anomaly :fault "boom" {})
           c (-> (chain/create-chain :x)
@@ -44,7 +45,7 @@
                 (chain/append-step :b a nil))]
       (is (false? (chain/succeeded? c))))))
 
-(deftest succeeded?-of-individual-steps
+(deftest ^{:stratum 0} succeeded?-of-individual-steps
   (testing "succeeded? reads :succeeded? off a single step"
     (let [a (anomaly/anomaly :timeout "slow" {})
           c (-> (chain/create-chain :x)
@@ -54,7 +55,7 @@
       (is (true?  (chain/succeeded? ok-step)))
       (is (false? (chain/succeeded? nope-step))))))
 
-(deftest succeeded?-always-returns-a-boolean
+(deftest ^{:stratum 0} succeeded?-always-returns-a-boolean
   (testing "result is true or false, never nil or a truthy non-boolean"
     (is (boolean? (chain/succeeded? (chain/create-chain :x))))
     (is (boolean? (chain/succeeded? {:succeeded? nil})))

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-response-chain.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-response-chain.md
@@ -1,0 +1,115 @@
+# fix: stratum-lint autofix for components/response-chain (Wave 1)
+
+## Overview
+
+Mechanical `stratum-lint --fix` pass over `components/response-chain`
+(`src` + `test`) — one component from
+`work/stratum-lint-baseline-2026-07-24.md`'s Wave 1 batch 4 — to replace
+decorative `Layer N` headings with real ones derived from each file's
+actual same-file reference graph. No logic changes: every diff is
+heading text, `^{:stratum n}` metadata, and def/deftest reordering.
+
+## Motivation
+
+`response-chain` carried 3 findings under the baseline's cargo-cult
+diagnosis: one `SL002` in `core.clj` (a repeated `Layer 0` heading —
+`build-step` and the operation-coercion sentinel both banner'd as
+"Layer 0" even though the file's later defs genuinely build on them),
+and `SL003` in both `core.clj` and `interface.clj` (5 distinct layers
+against the 3-layer budget). Zero `SL001` findings for the component —
+matches Wave 1's selection criteria: no upward-reference/cycle risk to
+reason about before running the mechanical fixer.
+
+## Changes in Detail
+
+Ran, over the whole component, at the current stratum-lint pin
+(`14965e1ee1a175bd00f637d9a9d5f7d27e62b73f`, already current — no bump
+needed this batch):
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "14965e1ee1a175bd00f637d9a9d5f7d27e62b73f" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/response-chain
+```
+
+13 files rewritten (`--fix` normalizes every already-annotated file in
+the component, not just the 2 with findings): `contract.clj`, `core.clj`,
+`interface.clj` (`src`), and all 10 test files.
+
+- **`core.clj`**: the real reference graph collapses `succeeded?`,
+  `steps`, `last-response`, and `last-anomaly` (previously banner'd as
+  Layer 3/Layer 4 "Predicate"/"Accessors" sections placed after
+  `append-step`) down to `Layer 0` — none of them actually reference
+  anything else in the file, they only read keys off the chain map
+  directly. `recompute-succeeded?` and `invalid-operation-sentinel` join
+  them at `Layer 0`, resolving the `SL002` duplicate-heading finding.
+  `coerce-operation`, `conj-step`, and `last-successful-or` land at
+  `Layer 1` (each references a `Layer 0` def); `create-chain` at `Layer 2`;
+  `guarded-append` at `Layer 3`; `append-step` at `Layer 4`. Still 5 real
+  layers total — `SL003` remains, see below.
+- **`interface.clj`**: every function is a pure pass-through to `core/*`
+  with no same-file references between them, so the real depth is a
+  single layer. All 8 defs (the two schema re-exports plus 6 functions)
+  land at `Layer 0`. The old headings claimed 5 layers (`Layer 0`–`Layer 4`,
+  one per function) that never existed in the same-file graph — `SL003`
+  here is fully resolved, not just relabeled.
+- **`contract.clj`** (no prior findings): `Step` at `Layer 0`;
+  `valid-step?`/`explain-step` at `Layer 1` (reference `Step` only);
+  `valid-chain?`/`explain-chain` moved from the old "Layer 2 Validation
+  helpers" grouping to `Layer 2` proper, now correctly separated from
+  `valid-step?`/`explain-step` since they reference `Chain` (`Layer 1`),
+  one level deeper. Stays within budget (3 layers), still 0 findings.
+- **Test files** (all 10): each file's `deftest` forms have no same-file
+  references to each other, so every one collapses to a single
+  `Layer 0` heading — mechanical, no reordering of assertions within a
+  test.
+
+No stale double-semicolon `;;---- Layer N` banners or same-line trailing
+comments were present in this component to begin with, so neither of the
+two known tool-limitation patterns applied — confirmed by reading every
+changed file's full diff. No `defmethod`s in this component either.
+
+## Testing Plan
+
+1. Ran plain (non-`--fix`) `stratum-lint` before the fix — reproduced the
+   baseline's 3 findings exactly (1 `SL002` + 2 `SL003`), 0 `SL001`.
+2. Ran `--fix`, then a second `--fix` pass immediately after — zero diff,
+   confirms idempotency.
+3. Read the full diff for all 13 changed files. No misplaced trailing
+   comment, no stale non-standard heading banner, no `defmethod` stratum
+   issue.
+4. `clj-kondo --lint components/response-chain`: 0 errors, 0 warnings.
+5. Ran all 10 test namespaces via `clojure -M:test -m cognitect.test-runner`:
+   54 tests, 121 assertions, 0 failures, 0 errors.
+6. Re-ran plain `stratum-lint` after the fix: `SL001`/`SL002`/`SL004`
+   clear. `interface.clj`'s `SL003` is fully resolved (real depth is 1
+   layer, not 5 — the old heading over-counted it). `core.clj`'s `SL003`
+   remains: still 5 real layers against the 3-layer budget — the same
+   finding as before, not newly surfaced, since `core.clj`'s old headings
+   already reflected the real depth (aside from the duplicate `Layer 0`
+   this fix resolved). Deferred to Wave 2 (real namespace split).
+
+## Deployment Plan
+
+Merges to `main` like any other component change. Comment/metadata/order
+only — no runtime behavior change. Pre-commit's `lint:stratum` autofixer
+keeps this component clean going forward; `core.clj`'s `SL003` stays
+advisory (`MINIFORGE_STRATUM_BUDGET_MODE=warn` at commit time) until
+Wave 2 splits it.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+- Follow-on: Wave 2 namespace split for
+  `components/response-chain/src/ai/miniforge/response_chain/core.clj`
+  (5 real layers, over the 3-layer budget)
+
+## Checklist
+
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Second `--fix` pass confirms idempotency (zero diff)
+- [x] Diff read in full for all 13 changed files; mechanical-only
+- [x] `clj-kondo` clean (0 errors, 0 warnings)
+- [x] Component tests pass (54 tests, 121 assertions, 0 failures/errors)
+- [x] Plain lint re-run post-fix: `SL003` remains only on `core.clj`
+      (pre-existing, tracked as Wave 2); `interface.clj`'s `SL003` fully
+      resolved
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
## Summary

- Mechanical `stratum-lint --fix` pass over `components/response-chain` (Wave 1 batch 4 of `work/stratum-lint-baseline-2026-07-24.md`) — replaces decorative `Layer N` headings with real ones derived from each file's actual same-file reference graph. No logic changes.
- Resolves the component's `SL002` (duplicate `Layer 0` in `core.clj`) and `SL003` in `interface.clj` (real depth is 1 layer, not the 5 the old headings claimed).
- `core.clj`'s `SL003` remains (5 real layers vs. the 3-layer budget) — pre-existing, deferred to Wave 2 (namespace split).
- Zero `SL001` findings for this component, confirmed before running the fixer.

Full detail in `docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-response-chain.md`.

## Test plan

- [x] Plain lint before fix reproduced the baseline's 3 findings exactly (1 SL002 + 2 SL003), 0 SL001
- [x] `--fix` run, then a second `--fix` pass — zero diff (idempotent)
- [x] Full diff read for all 13 changed files — no misplaced trailing comments, no stale banners, no defmethod issues
- [x] `clj-kondo --lint components/response-chain` — 0 errors, 0 warnings
- [x] All 10 test namespaces via `clojure -M:test -m cognitect.test-runner` — 54 tests, 121 assertions, 0 failures/errors
- [x] Plain lint re-run post-fix — `SL003` remains only on `core.clj` (pre-existing, Wave 2), `interface.clj`'s fully resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)