### PR TITLE
fix: stratum-lint autofix for components/agent-runtime (Wave 1)

### DIFF
--- a/components/agent-runtime/src/ai/miniforge/agent_runtime/error_classifier/core.clj
+++ b/components/agent-runtime/src/ai/miniforge/agent_runtime/error_classifier/core.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.agent-runtime.error-classifier.core
   "Core error classification logic.
 
@@ -25,7 +24,9 @@
    [ai.miniforge.agent-runtime.error-classifier.reporting :as reporting]
    [ai.miniforge.failure-classifier.interface :as failure-classifier]))
 
-(def ^:private retry-type->failure-class
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private retry-type->failure-class
   "Map the narrow retry-classification `:type` to the ONE canonical failure
    class. The failure taxonomy (N1 §5.3.3) is owned by `failure-classifier`
    (its single source of truth) — referenced here, never redefined. `:type`
@@ -35,17 +36,8 @@
    :task-code     :failure.class/task-code
    :external      :failure.class/external})
 
-(defn- ->failure-class
-  "Derive the canonical failure class for a retry `:type`, validated against
-   failure-classifier's set so we can never emit a non-canonical class."
-  [retry-type]
-  (let [c (get retry-type->failure-class retry-type :failure.class/unknown)]
-    (if (failure-classifier/valid-failure-class? c) c :failure.class/unknown)))
-
-;;------------------------------------------------------------------------------ Layer 0
 ;; Error message extraction
-
-(defn extract-error-context
+(defn ^{:stratum 0} extract-error-context
   "Extract relevant context from error for classification.
 
    Arguments:
@@ -58,10 +50,8 @@
     (string? error) error
     :else (str error)))
 
-;;------------------------------------------------------------------------------ Layer 1
 ;; Completed work extraction
-
-(defn extract-completed-work
+(defn ^{:stratum 0} extract-completed-work
   "Extract completed work items from task state.
 
    Arguments:
@@ -106,10 +96,8 @@
       @items)
     []))
 
-;;------------------------------------------------------------------------------ Layer 2
 ;; Retry logic
-
-(defn determine-confidence
+(defn ^{:stratum 0} determine-confidence
   "Calculate confidence score for classification.
 
    Arguments:
@@ -123,7 +111,7 @@
     0.95
     0.5))
 
-(defn should-retry?
+(defn ^{:stratum 0} should-retry?
   "Determine if user should retry based on error type.
 
    Arguments:
@@ -138,10 +126,19 @@
     :external true
     true))
 
-;;------------------------------------------------------------------------------ Layer 3
-;; Main classification function
+;------------------------------------------------------------------------------ Layer 1
 
-(defn classify-error
+(defn- ^{:stratum 1} ->failure-class
+  "Derive the canonical failure class for a retry `:type`, validated against
+   failure-classifier's set so we can never emit a non-canonical class."
+  [retry-type]
+  (let [c (get retry-type->failure-class retry-type :failure.class/unknown)]
+    (if (failure-classifier/valid-failure-class? c) c :failure.class/unknown)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Main classification function
+(defn ^{:stratum 2} classify-error
   "Classify an error by matching against known patterns.
 
    Arguments:

--- a/components/agent-runtime/src/ai/miniforge/agent_runtime/error_classifier/messages.clj
+++ b/components/agent-runtime/src/ai/miniforge/agent_runtime/error_classifier/messages.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.agent-runtime.error-classifier.messages
   "User-facing error message generation.
 
@@ -24,10 +23,10 @@
   (:require
    [clojure.string :as str]))
 
-;;------------------------------------------------------------------------------ Layer 0
-;; Completed work formatting
+;------------------------------------------------------------------------------ Layer 0
 
-(defn format-completed-work-section
+;; Completed work formatting
+(defn ^{:stratum 0} format-completed-work-section
   "Format completed work items for display.
 
    Arguments:
@@ -40,10 +39,26 @@
     (str "\n\nPartial work completed:\n"
          (str/join "\n" (map #(str icon-prefix " " %) completed-work)))))
 
-;;------------------------------------------------------------------------------ Layer 1
-;; Error type specific formatting
+(defn ^{:stratum 0} add-suggestions
+  "Add troubleshooting suggestions to error message.
 
-(defn format-agent-backend-error
+   Arguments:
+     message - Base error message
+     error-type - Classification keyword
+
+   Returns: Message with added suggestions"
+  [message error-type]
+  (let [suggestions (case error-type
+                      :agent-backend "\n\nTroubleshooting:\n- This is a bug in the agent system\n- Your code is fine\n- Report the issue and retry later"
+                      :task-code "\n\nTroubleshooting:\n- Check the error details above\n- Fix the code issue\n- Run tests locally before retrying"
+                      :external "\n\nTroubleshooting:\n- Wait a few minutes\n- Check service status\n- Retry with exponential backoff"
+                      "")]
+    (str message suggestions)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Error type specific formatting
+(defn ^{:stratum 1} format-agent-backend-error
   "Format agent backend error message.
 
    Arguments:
@@ -64,7 +79,7 @@
        (when report-url
          (str "\n\nReport this issue:\n" report-url))))
 
-(defn format-task-code-error
+(defn ^{:stratum 1} format-task-code-error
   "Format task code error message.
 
    Arguments:
@@ -77,7 +92,7 @@
        (format-completed-work-section completed-work "⏸️ ")
        "\n\nFix the issue and retry your task."))
 
-(defn format-external-error
+(defn ^{:stratum 1} format-external-error
   "Format external service error message.
 
    Arguments:
@@ -90,10 +105,10 @@
        (format-completed-work-section completed-work "✅")
        "\n\nWait a few minutes and retry. This is usually transient."))
 
-;;------------------------------------------------------------------------------ Layer 2
-;; Main formatting function
+;------------------------------------------------------------------------------ Layer 2
 
-(defn format-error-message
+;; Main formatting function
+(defn ^{:stratum 2} format-error-message
   "Generate user-friendly error message with context.
 
    Arguments:
@@ -106,19 +121,3 @@
     :task-code (format-task-code-error classified-error)
     :external (format-external-error classified-error)
     (str "❌ Error: " (:message classified-error))))
-
-(defn add-suggestions
-  "Add troubleshooting suggestions to error message.
-
-   Arguments:
-     message - Base error message
-     error-type - Classification keyword
-
-   Returns: Message with added suggestions"
-  [message error-type]
-  (let [suggestions (case error-type
-                      :agent-backend "\n\nTroubleshooting:\n- This is a bug in the agent system\n- Your code is fine\n- Report the issue and retry later"
-                      :task-code "\n\nTroubleshooting:\n- Check the error details above\n- Fix the code issue\n- Run tests locally before retrying"
-                      :external "\n\nTroubleshooting:\n- Wait a few minutes\n- Check service status\n- Retry with exponential backoff"
-                      "")]
-    (str message suggestions)))

--- a/components/agent-runtime/src/ai/miniforge/agent_runtime/error_classifier/patterns.clj
+++ b/components/agent-runtime/src/ai/miniforge/agent_runtime/error_classifier/patterns.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.agent-runtime.error-classifier.patterns
   "Error pattern definitions and matching logic.
 
@@ -29,10 +28,10 @@
    [clojure.edn :as edn]
    [clojure.java.io :as io]))
 
-;;------------------------------------------------------------------------------ Layer 0
-;; Pattern loading from configuration
+;------------------------------------------------------------------------------ Layer 0
 
-(defn load-pattern-config
+;; Pattern loading from configuration
+(defn ^{:stratum 0} load-pattern-config
   "Load error pattern configuration from resource file.
 
    Arguments:
@@ -46,7 +45,7 @@
       (catch Exception _e
         nil))))
 
-(defn compile-pattern
+(defn ^{:stratum 0} compile-pattern
   "Compile a pattern map with regex string to a case-insensitive regex.
 
    Arguments:
@@ -67,7 +66,22 @@
                :rate-limit? rate-limit?)
         (update :regex #(re-pattern (str "(?i)" %))))))
 
-(defn load-patterns
+;; Pattern matching
+(defn ^{:stratum 0} matches-pattern?
+  "Check if error message matches a pattern.
+
+   Arguments:
+     error - Error message string
+     pattern - Pattern map with :regex key
+
+   Returns: Boolean indicating if pattern matches"
+  [error pattern]
+  (when error
+    (boolean (re-find (:regex pattern) error))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} load-patterns
   "Load and compile patterns from a config file.
 
    Arguments:
@@ -81,45 +95,32 @@
       (mapv #(compile-pattern % type vendor) (:patterns config)))
     []))
 
-;;------------------------------------------------------------------------------ Layer 1
-;; Pattern definitions (loaded from config)
+;------------------------------------------------------------------------------ Layer 2
 
-(def agent-backend-patterns
+;; Pattern definitions (loaded from config)
+(def ^{:stratum 2} agent-backend-patterns
   "Patterns that indicate agent system bugs (Claude Code internal errors).
    Loaded from resources/error-patterns/agent-backend.edn"
   (load-patterns "agent-backend"))
 
-(def task-code-patterns
+(def ^{:stratum 2} task-code-patterns
   "Patterns that indicate user code errors.
    Loaded from resources/error-patterns/task-code.edn"
   (load-patterns "task-code"))
 
-(def external-patterns
+(def ^{:stratum 2} external-patterns
   "Patterns that indicate external service errors.
    Loaded from resources/error-patterns/external.edn"
   (load-patterns "external"))
 
-(def backend-setup-patterns
+(def ^{:stratum 2} backend-setup-patterns
   "Patterns that indicate backend setup/configuration errors.
    Loaded from resources/error-patterns/backend-setup.edn"
   (load-patterns "backend-setup"))
 
-;;------------------------------------------------------------------------------ Layer 2
-;; Pattern matching
+;------------------------------------------------------------------------------ Layer 3
 
-(defn matches-pattern?
-  "Check if error message matches a pattern.
-
-   Arguments:
-     error - Error message string
-     pattern - Pattern map with :regex key
-
-   Returns: Boolean indicating if pattern matches"
-  [error pattern]
-  (when error
-    (boolean (re-find (:regex pattern) error))))
-
-(defn classify-by-patterns
+(defn ^{:stratum 3} classify-by-patterns
   "Classify error by matching against pattern lists.
 
    Arguments:

--- a/components/agent-runtime/src/ai/miniforge/agent_runtime/error_classifier/reporting.clj
+++ b/components/agent-runtime/src/ai/miniforge/agent_runtime/error_classifier/reporting.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.agent-runtime.error-classifier.reporting
   "Vendor reporting and issue tracking for error classification.
 
@@ -23,10 +22,10 @@
   (:require
    [clojure.string :as str]))
 
-;;------------------------------------------------------------------------------ Layer 0
-;; Vendor information
+;------------------------------------------------------------------------------ Layer 0
 
-(def vendor-info
+;; Vendor information
+(def ^{:stratum 0} vendor-info
   "Vendor information for issue reporting"
   {"Claude Code" {:name "Claude Code"
                   :repo-url "https://github.com/anthropics/claude-code"
@@ -38,10 +37,8 @@
                        :repo-url nil
                        :issue-template nil}})
 
-;;------------------------------------------------------------------------------ Layer 1
 ;; URL generation
-
-(defn build-issue-title
+(defn ^{:stratum 0} build-issue-title
   "Build issue title based on error type."
   [error-type]
   (case error-type
@@ -50,7 +47,7 @@
     :external "External Service Error"
     "Error"))
 
-(defn build-issue-body
+(defn ^{:stratum 0} build-issue-body
   "Build issue body with error context."
   [error-context]
   (let [{:keys [message task-id timestamp]} error-context]
@@ -60,7 +57,9 @@
          (when timestamp
            (str "\nTimestamp: " timestamp)))))
 
-(defn get-vendor-report-url
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} get-vendor-report-url
   "Generate vendor-specific issue reporting URL with pre-filled context.
 
    Arguments:
@@ -80,5 +79,7 @@
              "?title=" title-param
              "&body=" (java.net.URLEncoder/encode body "UTF-8"))))))
 
+;------------------------------------------------------------------------------ Layer 2
+
 ;; Alias for backward compatibility
-(def generate-report-url get-vendor-report-url)
+(def ^{:stratum 2} generate-report-url get-vendor-report-url)

--- a/components/agent-runtime/src/ai/miniforge/agent_runtime/interface.clj
+++ b/components/agent-runtime/src/ai/miniforge/agent_runtime/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.agent-runtime.interface
   "Agent runtime public interface.
 
@@ -39,9 +38,9 @@
    [ai.miniforge.agent-runtime.error-classifier.reporting :as reporting]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Error classification
 
-(def classify-error
+;; Error classification
+(def ^{:stratum 0} classify-error
   "Classify an error by matching against known patterns.
 
    Arguments:
@@ -68,16 +67,14 @@
          :should-retry false}"
   core/classify-error)
 
-(def external-patterns
+(def ^{:stratum 0} external-patterns
   "Compiled external-service error patterns used for shared recovery decisions.
    Each entry is a pattern map from the error classifier with keys such as
    :regex, :type, :vendor, and :rate-limit?."
   patterns/external-patterns)
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Message formatting
-
-(def format-error-message
+(def ^{:stratum 0} format-error-message
   "Generate user-friendly error message with context.
 
    Arguments:
@@ -94,7 +91,7 @@
      => \"⚠️  Agent System Error (Not Your Fault!)...\""
   messages/format-error-message)
 
-(def extract-completed-work
+(def ^{:stratum 0} extract-completed-work
   "Extract completed work items from task state.
 
    Arguments:
@@ -112,10 +109,8 @@
          \"PR created at https://...\"]"
   core/extract-completed-work)
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Reporting and retry logic
-
-(def generate-report-url
+(def ^{:stratum 0} generate-report-url
   "Generate vendor-specific issue reporting URL with pre-filled context.
 
    Arguments:
@@ -132,7 +127,7 @@
      => \"https://github.com/anthropics/claude-code/issues/new?title=...\""
   reporting/get-vendor-report-url)
 
-(defn should-retry?
+(defn ^{:stratum 0} should-retry?
   "Determine if user should retry based on error type.
 
    Arguments:

--- a/components/agent-runtime/test/ai/miniforge/agent_runtime/error_classifier_test.clj
+++ b/components/agent-runtime/test/ai/miniforge/agent_runtime/error_classifier_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.agent-runtime.error-classifier-test
   "Unit tests for error classification and message generation."
   (:require [clojure.test :refer [deftest is testing are]]
@@ -23,7 +22,9 @@
             [ai.miniforge.agent-runtime.interface :as classifier]
             [ai.miniforge.failure-classifier.interface :as failure-classifier]))
 
-(deftest classify-error-emits-canonical-failure-class
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} classify-error-emits-canonical-failure-class
   (testing "classification carries a :failure/class from failure-classifier's
             canonical set — one taxonomy, referenced not redefined"
     (doseq [err ["connection refused" "Simple error string" "anything at all"]]
@@ -36,10 +37,8 @@
     (is (= :failure.class/task-code
            (:failure/class (classifier/classify-error "Simple error string" nil))))))
 
-;------------------------------------------------------------------------------ Layer 0 Tests
 ;; Pattern matching and classification
-
-(deftest test-agent-backend-classification
+(deftest ^{:stratum 0} test-agent-backend-classification
   (testing "Agent backend error patterns"
     (are [error-msg] (= :agent-backend
                        (:type (classifier/classify-error error-msg nil)))
@@ -51,7 +50,7 @@
       "agent is undefined"
       "handoff failed for agent")))
 
-(deftest test-task-code-classification
+(deftest ^{:stratum 0} test-task-code-classification
   (testing "Task code error patterns"
     (are [error-msg] (= :task-code
                        (:type (classifier/classify-error error-msg nil)))
@@ -64,7 +63,7 @@
       "Unexpected token at line 42"
       "Parse error: missing closing parenthesis")))
 
-(deftest test-external-classification
+(deftest ^{:stratum 0} test-external-classification
   (testing "External service error patterns"
     (are [error-msg] (= :external
                        (:type (classifier/classify-error error-msg nil)))
@@ -78,12 +77,12 @@
       "Connection refused to api.github.com"
       "DNS lookup failed for github.com")))
 
-(deftest test-default-classification
+(deftest ^{:stratum 0} test-default-classification
   (testing "Unknown errors default to task-code (conservative)"
     (is (= :task-code
            (:type (classifier/classify-error "Some unknown error" nil))))))
 
-(deftest test-vendor-attribution
+(deftest ^{:stratum 0} test-vendor-attribution
   (testing "Correct vendor attribution for each error type"
     (is (= "Claude Code"
            (:vendor (classifier/classify-error "classifyHandoffIfNeeded is not defined" nil))))
@@ -92,7 +91,7 @@
     (is (= "External Service"
            (:vendor (classifier/classify-error "ECONNREFUSED" nil))))))
 
-(deftest test-extract-completed-work
+(deftest ^{:stratum 0} test-extract-completed-work
   (testing "Extract work items from task state"
     (is (= []
            (classifier/extract-completed-work nil)))
@@ -126,10 +125,8 @@
     (is (= ["5 commits made"]
            (classifier/extract-completed-work {:commits-made 5})))))
 
-;------------------------------------------------------------------------------ Layer 1 Tests
 ;; Message formatting
-
-(deftest test-format-error-message
+(deftest ^{:stratum 0} test-format-error-message
   (testing "Agent backend error message formatting"
     (let [classified (classifier/classify-error
                       "classifyHandoffIfNeeded is not defined"
@@ -177,10 +174,8 @@
       (is (str/includes? message "Partial work completed"))
       (is (str/includes? message "✅ Created branch: feat/new-feature")))))
 
-;------------------------------------------------------------------------------ Layer 2 Tests
 ;; URL generation and retry logic
-
-(deftest test-generate-report-url
+(deftest ^{:stratum 0} test-generate-report-url
   (testing "Claude Code report URL generation"
     (let [url (classifier/generate-report-url
                :agent-backend
@@ -205,7 +200,7 @@
     (let [classified (classifier/classify-error "ECONNREFUSED" nil)]
       (is (nil? (:report-url classified))))))
 
-(deftest test-should-retry
+(deftest ^{:stratum 0} test-should-retry
   (testing "Agent backend errors with completed work - don't retry"
     (let [classified (classifier/classify-error
                       "classifyHandoffIfNeeded is not defined"
@@ -230,10 +225,8 @@
                       nil)]
       (is (true? (:should-retry classified))))))
 
-;------------------------------------------------------------------------------ Integration Tests
 ;; Full classification flow
-
-(deftest test-classify-error-full
+(deftest ^{:stratum 0} test-classify-error-full
   (testing "Full classification of agent backend error"
     (let [result (classifier/classify-error
                   (ex-info "classifyHandoffIfNeeded is not defined" {})
@@ -269,7 +262,7 @@
       (is (nil? (:report-url result)))
       (is (true? (:should-retry result))))))
 
-(deftest test-exception-handling
+(deftest ^{:stratum 0} test-exception-handling
   (testing "Classify Exception objects"
     (let [ex (ex-info "Test error" {:some :data})
           result (classifier/classify-error ex nil)]

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-agent-runtime.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-agent-runtime.md
@@ -1,0 +1,136 @@
+# fix: stratum-lint autofix for components/agent-runtime (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over `components/agent-runtime` (`src` + `test`)
+to replace cargo-culted `Layer N` headings with real ones derived from
+each file's actual same-file reference graph, plus `^{:stratum n}`
+metadata on every def. One of the smaller per-component Wave 1 PRs from
+`work/stratum-lint-baseline-2026-07-24.md`.
+
+Mostly mechanical, with one manual cleanup: `error_classifier_test.clj`
+carried four decorative section banners (`Layer 0 Tests`, `Layer 1
+Tests`, `Layer 2 Tests`, `Integration Tests`) that `--fix` left in place
+because they don't match the tool's own generated heading shape. Left
+untouched, they'd contradict the real headings the fix just added — every
+`deftest` in this file is genuinely stratum 0 (each only calls the public
+interface, none call each other), so banners implying a Layer 0→1→2
+progression across the file are false. Hand-removed the four banner
+lines, keeping the plain descriptive comment under each (e.g. `;; Message
+formatting`) since those still carry real grouping information. No test
+code changed — comment text only.
+
+## Motivation
+
+`components/agent-runtime` carried 3 findings under the baseline's
+cargo-cult diagnosis, all in one file:
+`error_classifier/core.clj` — 2× `SL004` (`retry-type->failure-class` and
+`->failure-class` sat above the file's first `Layer` heading) and 1×
+`SL003` (4 distinct layers against the 3-layer budget). Zero `SL001`
+findings component-wide, confirmed by a plain lint run before touching
+anything — no upward-reference/cycle risk to reason about first, matching
+the Wave 1 batch criteria exactly.
+
+## Changes in Detail
+
+Ran, over the whole component:
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "14965e1ee1a175bd00f637d9a9d5f7d27e62b73f" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/agent-runtime
+```
+
+6 files rewritten — `--fix` normalizes every file in the component, not
+just the ones with findings:
+
+- `error_classifier/core.clj` — `retry-type->failure-class` (Layer 0),
+  `->failure-class` (Layer 1, calls the map above), `classify-error`
+  (Layer 2, calls `->failure-class` plus four Layer-0 helpers). Real
+  depth 3, within budget; the old headings had claimed 4 (0–3) by
+  counting per-function-group instead of per real dependency level.
+- `error_classifier/messages.clj` — `add-suggestions` moved from an
+  unheaded trailing position to Layer 0 (it's a leaf, no same-file
+  calls); the three `format-*-error` functions landed at Layer 1
+  (they call `format-completed-work-section`); `format-error-message`
+  at Layer 2.
+- `error_classifier/patterns.clj` — real depth is 4 (`load-pattern-config`
+  / `compile-pattern` / `matches-pattern?` at Layer 0 → `load-patterns` at
+  Layer 1 → the four pattern `def`s at Layer 2 → `classify-by-patterns` at
+  Layer 3), one deeper than the old 3-heading version, which happened to
+  look compliant (monotonic, ≤3) while under-counting the true chain.
+  This surfaces a **new** `SL003` — see below.
+- `error_classifier/reporting.clj` — real depth 3 (0–2), matches the old
+  heading count; only metadata and reordering changed.
+- `interface.clj` — pure re-export file; every `def` is a bare alias to
+  another namespace's var, so all collapse to Layer 0. The old headings
+  (0/1/2) had grouped aliases by topic, not by real depth.
+- `error_classifier_test.clj` — all 12 `deftest`s are real Layer 0 (no
+  test calls another test); one bare `Layer 0` heading added before the
+  first `deftest`, which previously sat above any heading at all. See
+  Overview for the hand-fix to the four stale banners this exposed.
+
+No line of executable/test logic changed anywhere; diffs are heading
+text, `^{:stratum n}` metadata, def/deftest reordering, and (in the test
+file) the four hand-removed stale banner lines.
+
+`patterns.clj` now reports `SL003`: 4 real layers (0–3) against the
+3-layer budget. This is a **newly surfaced** finding, not the same one
+masked before — the pre-fix headings only claimed 3 layers and were
+monotonic, so the plain lint baseline reported zero findings for this
+file at all. `--fix` inferring the true reference chain reveals a real
+depth of 4. Deferred to Wave 2 (real namespace split), consistent with
+how prior Wave 1 PRs handled the same situation.
+
+## Testing Plan
+
+1. Ran plain (non-`--fix`) `stratum-lint` before the fix — reproduced the
+   baseline's 3 findings exactly (2× `SL004`, 1× `SL003`, all in
+   `core.clj`), and confirmed 0 `SL001` findings component-wide before
+   proceeding.
+2. Ran `--fix`, then a second `--fix` pass immediately after — zero diff,
+   confirms idempotency.
+3. Read the full diff for all 6 changed files. Found the stale-banner
+   pattern in `error_classifier_test.clj` (see Overview); hand-fixed it,
+   then ran `--fix` a third time — zero diff, confirms the hand-fix is
+   stable. No same-line trailing comment was displaced onto the wrong def
+   in any file.
+4. Confirmed no `defmethod`s in this component — the multimethod-stratum
+   bug class doesn't apply here.
+5. `clj-kondo --lint components/agent-runtime`: 0 errors, 0 warnings.
+6. Ran `ai.miniforge.agent-runtime.error-classifier-test` directly via
+   `clojure -A:test -e`: 12 tests, 91 assertions, 0 failures, 0 errors.
+7. Re-ran plain `stratum-lint` after the fix: `SL001`/`SL002`/`SL004`
+   clear. `SL003` remains, newly surfaced on `patterns.clj` (4 real
+   layers) — expected, tracked as Wave 2, not a defect in this PR.
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+change — comment/metadata/order-only in source and tests. Pre-commit's
+`lint:stratum` autofixer keeps this component clean going forward;
+`patterns.clj`'s `SL003` stays advisory
+(`MINIFORGE_STRATUM_BUDGET_MODE=warn` at commit time) until Wave 2 splits
+it.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+- Follow-on: Wave 2 namespace split for
+  `components/agent-runtime/src/ai/miniforge/agent_runtime/error_classifier/patterns.clj`
+  (4 real layers, over the 3-layer budget — newly surfaced by this fix,
+  not present in the original baseline)
+
+## Checklist
+
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Second `--fix` pass confirms idempotency (zero diff)
+- [x] Diff read in full for all 6 changed files
+- [x] Stale decorative banners in the test file hand-fixed; third `--fix`
+      pass confirms the hand-fix is stable (zero diff)
+- [x] No `defmethod`s in this component (multimethod-stratum bug class
+      not applicable)
+- [x] `clj-kondo` clean before/after (0 errors, 0 warnings)
+- [x] Component tests pass (12 tests, 91 assertions, 0 failures/errors)
+- [x] Plain lint re-run post-fix: zero findings except `SL003`
+      (`patterns.clj`, newly surfaced, documented above, tracked as
+      Wave 2)
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
## Summary
- Runs `stratum-lint --fix` over `components/agent-runtime` (src + test) to replace cargo-culted `Layer N` headings with real ones derived from each file's actual same-file reference graph, per rule 210.
- Zero SL001 findings confirmed before fixing (no upward-reference/cycle risk).
- Hand-fixed four stale decorative test-file banners (`Layer 0 Tests`, `Layer 1 Tests`, `Layer 2 Tests`, `Integration Tests`) left behind by `--fix` — they contradicted the real all-Layer-0 depth the fix computed for every `deftest` in that file.
- `patterns.clj` now surfaces a **new** SL003 (4 real layers, over the 3-layer budget) that the old (monotonic-looking but under-counting) headings masked. Deferred to Wave 2, not fixed here.

Full detail in `docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-agent-runtime.md`.

## Test plan
- [x] Plain lint before fix: reproduced baseline exactly (2x SL004, 1x SL003, 0x SL001)
- [x] `--fix` run; second `--fix` pass: zero diff (idempotent)
- [x] Full diff read for all 6 changed files
- [x] Hand-fixed stale test banners; third `--fix` pass: zero diff (stable)
- [x] `clj-kondo --lint components/agent-runtime`: 0 errors, 0 warnings
- [x] `ai.miniforge.agent-runtime.error-classifier-test`: 12 tests, 91 assertions, 0 failures/errors
- [x] Plain lint after fix: only SL003 remains (patterns.clj, newly surfaced, Wave 2 scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)