### PR TITLE
fix: stratum-lint autofix for components/workflow-compliance-scanner (Wave 1)

### DIFF
--- a/components/workflow-compliance-scanner/src/ai/miniforge/workflow_compliance_scanner/phases.clj
+++ b/components/workflow-compliance-scanner/src/ai/miniforge/workflow_compliance_scanner/phases.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.workflow-compliance-scanner.phases
   "Phase interceptors for the compliance scan and execute workflows.
 
@@ -35,9 +34,9 @@
    [ai.miniforge.phase.interface              :as phase]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Helpers
 
-(defn- resolve-repo-path
+;; Helpers
+(defn- ^{:stratum 0} resolve-repo-path
   "Resolve the repository path from context.
    Prefers explicit [:execution/input :repo-path] when provided (cross-repo scan),
    then :execution/worktree-path (isolation), then '.'."
@@ -46,65 +45,41 @@
       (get ctx :execution/worktree-path)
       "."))
 
-(defn- resolve-standards-path
+(defn- ^{:stratum 0} resolve-standards-path
   "Resolve the standards path from context.
    Prefers [:execution/input :standards-path], then '.standards'."
   [ctx]
   (or (get-in ctx [:execution/input :standards-path])
       ".standards"))
 
-(defn- resolve-rules
+(defn- ^{:stratum 0} resolve-rules
   "Resolve which rules to apply from context input.
    Defaults to :always-apply."
   [ctx]
   (get-in ctx [:execution/input :rules] :always-apply))
 
-;------------------------------------------------------------------------------ Layer 0
 ;; Default configs
-
-(def default-scan-config
+(def ^{:stratum 0} default-scan-config
   {:agent nil
    :gates []
    :budget {:tokens 5000 :iterations 1 :time-seconds 300}})
 
-(def default-classify-config
+(def ^{:stratum 0} default-classify-config
   {:agent nil
    :gates []
    :budget {:tokens 1000 :iterations 1 :time-seconds 60}})
 
-(def default-plan-config
+(def ^{:stratum 0} default-plan-config
   {:agent nil
    :gates []
    :budget {:tokens 5000 :iterations 1 :time-seconds 120}})
 
-(def default-execute-config
+(def ^{:stratum 0} default-execute-config
   {:agent nil
    :gates []
    :budget {:tokens 5000 :iterations 1 :time-seconds 1800}})
 
-;; Register defaults on load
-(phase/register-phase-defaults! :compliance-scan     default-scan-config)
-(phase/register-phase-defaults! :compliance-classify default-classify-config)
-(phase/register-phase-defaults! :compliance-plan     default-plan-config)
-(phase/register-phase-defaults! :compliance-execute  default-execute-config)
-
-;------------------------------------------------------------------------------ Layer 1
-;; :compliance-scan interceptor
-
-(defn enter-compliance-scan
-  "Execute compliance scan phase.
-
-   Calls compliance-scanner/scan and stores ScanResult in context."
-  [ctx]
-  (let [start-time     (System/currentTimeMillis)
-        repo-path      (resolve-repo-path ctx)
-        standards-path (resolve-standards-path ctx)
-        rules          (resolve-rules ctx)
-        scan-result    (compliance-scanner/scan repo-path standards-path {:rules rules})]
-    (phase/enter-context ctx :compliance-scan nil [] default-scan-config start-time
-                                {:status :success :output scan-result})))
-
-(defn leave-compliance-scan
+(defn ^{:stratum 0} leave-compliance-scan
   "Post-processing for compliance scan phase.
 
    Records violation count in metrics."
@@ -125,28 +100,14 @@
         (update-in [:execution :phases-completed] (fnil conj []) :compliance-scan)
         (update-in [:execution/metrics :duration-ms] (fnil + 0) duration-ms))))
 
-(defn error-compliance-scan
+(defn ^{:stratum 0} error-compliance-scan
   "Handle compliance scan phase errors."
   [ctx ex]
   (-> ctx
       (assoc-in [:phase :status] :failed)
       (assoc-in [:phase :error] (phase/exception-error ex))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; :compliance-classify interceptor
-
-(defn enter-compliance-classify
-  "Execute compliance classify phase.
-
-   Reads violations from scan phase results, classifies them, stores output."
-  [ctx]
-  (let [start-time  (System/currentTimeMillis)
-        violations  (get-in ctx [:execution/phase-results :compliance-scan :result :output :violations] [])
-        classified  (compliance-scanner/classify violations)]
-    (phase/enter-context ctx :compliance-classify nil [] default-classify-config start-time
-                                {:status :success :output {:classified-violations classified}})))
-
-(defn leave-compliance-classify
+(defn ^{:stratum 0} leave-compliance-classify
   "Post-processing for compliance classify phase.
 
    Records auto-fixable and needs-review counts in metrics."
@@ -169,35 +130,14 @@
         (update-in [:execution :phases-completed] (fnil conj []) :compliance-classify)
         (update-in [:execution/metrics :duration-ms] (fnil + 0) duration-ms))))
 
-(defn error-compliance-classify
+(defn ^{:stratum 0} error-compliance-classify
   "Handle compliance classify phase errors."
   [ctx ex]
   (-> ctx
       (assoc-in [:phase :status] :failed)
       (assoc-in [:phase :error] (phase/exception-error ex))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; :compliance-plan interceptor
-
-(defn enter-compliance-plan
-  "Execute compliance plan phase.
-
-   Reads classified violations, generates plan, writes work spec and delta
-   report to disk, stores plan output in context."
-  [ctx]
-  (let [start-time     (System/currentTimeMillis)
-        repo-path      (resolve-repo-path ctx)
-        standards-path (resolve-standards-path ctx)
-        classified     (get-in ctx [:execution/phase-results :compliance-classify :result :output :classified-violations] [])
-        the-plan       (compliance-scanner/plan classified repo-path)]
-    (compliance-scanner/write-work-spec! (:work-spec the-plan) repo-path)
-    (compliance-scanner/write-delta-report! repo-path standards-path classified the-plan)
-    (phase/enter-context ctx :compliance-plan nil [] default-plan-config start-time
-                                {:status :success
-                                 :output {:plan       the-plan
-                                          :task-count (count (:dag-tasks the-plan))}})))
-
-(defn leave-compliance-plan
+(defn ^{:stratum 0} leave-compliance-plan
   "Post-processing for compliance plan phase.
 
    Records task count in metrics."
@@ -217,29 +157,14 @@
         (update-in [:execution :phases-completed] (fnil conj []) :compliance-plan)
         (update-in [:execution/metrics :duration-ms] (fnil + 0) duration-ms))))
 
-(defn error-compliance-plan
+(defn ^{:stratum 0} error-compliance-plan
   "Handle compliance plan phase errors."
   [ctx ex]
   (-> ctx
       (assoc-in [:phase :status] :failed)
       (assoc-in [:phase :error] (phase/exception-error ex))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; :compliance-execute interceptor
-
-(defn enter-compliance-execute
-  "Execute compliance execute phase.
-   Reads the plan from phase results, applies auto-fixable violations to files
-   in the worktree, commits per rule, and opens one GitHub PR per rule."
-  [ctx]
-  (let [start-time (System/currentTimeMillis)
-        repo-path  (resolve-repo-path ctx)
-        plan       (get-in ctx [:execution/phase-results :compliance-plan :result :output :plan])
-        result     (compliance-scanner/execute! plan repo-path)]
-    (phase/enter-context ctx :compliance-execute nil [] default-execute-config start-time
-                                {:status :success :output result})))
-
-(defn leave-compliance-execute
+(defn ^{:stratum 0} leave-compliance-execute
   "Post-processing for compliance execute phase.
    Records PR count and violations-fixed in metrics."
   [ctx]
@@ -263,17 +188,77 @@
         (update-in [:execution :phases-completed] (fnil conj []) :compliance-execute)
         (update-in [:execution/metrics :duration-ms] (fnil + 0) duration-ms))))
 
-(defn error-compliance-execute
+(defn ^{:stratum 0} error-compliance-execute
   "Handle compliance execute phase errors."
   [ctx ex]
   (-> ctx
       (assoc-in [:phase :status] :failed)
       (assoc-in [:phase :error] (phase/exception-error ex))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Registry methods
+;------------------------------------------------------------------------------ Layer 1
 
-(defmethod phase/get-phase-interceptor-method :compliance-scan
+;; :compliance-scan interceptor
+(defn ^{:stratum 1} enter-compliance-scan
+  "Execute compliance scan phase.
+
+   Calls compliance-scanner/scan and stores ScanResult in context."
+  [ctx]
+  (let [start-time     (System/currentTimeMillis)
+        repo-path      (resolve-repo-path ctx)
+        standards-path (resolve-standards-path ctx)
+        rules          (resolve-rules ctx)
+        scan-result    (compliance-scanner/scan repo-path standards-path {:rules rules})]
+    (phase/enter-context ctx :compliance-scan nil [] default-scan-config start-time
+                                {:status :success :output scan-result})))
+
+;; :compliance-classify interceptor
+(defn ^{:stratum 1} enter-compliance-classify
+  "Execute compliance classify phase.
+
+   Reads violations from scan phase results, classifies them, stores output."
+  [ctx]
+  (let [start-time  (System/currentTimeMillis)
+        violations  (get-in ctx [:execution/phase-results :compliance-scan :result :output :violations] [])
+        classified  (compliance-scanner/classify violations)]
+    (phase/enter-context ctx :compliance-classify nil [] default-classify-config start-time
+                                {:status :success :output {:classified-violations classified}})))
+
+;; :compliance-plan interceptor
+(defn ^{:stratum 1} enter-compliance-plan
+  "Execute compliance plan phase.
+
+   Reads classified violations, generates plan, writes work spec and delta
+   report to disk, stores plan output in context."
+  [ctx]
+  (let [start-time     (System/currentTimeMillis)
+        repo-path      (resolve-repo-path ctx)
+        standards-path (resolve-standards-path ctx)
+        classified     (get-in ctx [:execution/phase-results :compliance-classify :result :output :classified-violations] [])
+        the-plan       (compliance-scanner/plan classified repo-path)]
+    (compliance-scanner/write-work-spec! (:work-spec the-plan) repo-path)
+    (compliance-scanner/write-delta-report! repo-path standards-path classified the-plan)
+    (phase/enter-context ctx :compliance-plan nil [] default-plan-config start-time
+                                {:status :success
+                                 :output {:plan       the-plan
+                                          :task-count (count (:dag-tasks the-plan))}})))
+
+;; :compliance-execute interceptor
+(defn ^{:stratum 1} enter-compliance-execute
+  "Execute compliance execute phase.
+   Reads the plan from phase results, applies auto-fixable violations to files
+   in the worktree, commits per rule, and opens one GitHub PR per rule."
+  [ctx]
+  (let [start-time (System/currentTimeMillis)
+        repo-path  (resolve-repo-path ctx)
+        plan       (get-in ctx [:execution/phase-results :compliance-plan :result :output :plan])
+        result     (compliance-scanner/execute! plan repo-path)]
+    (phase/enter-context ctx :compliance-execute nil [] default-execute-config start-time
+                                {:status :success :output result})))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Registry methods
+(defmethod ^{:stratum 2} phase/get-phase-interceptor-method :compliance-scan
   [config]
   (let [merged (phase/merge-with-defaults config)]
     {:name   ::compliance-scan
@@ -282,7 +267,7 @@
      :leave  leave-compliance-scan
      :error  error-compliance-scan}))
 
-(defmethod phase/get-phase-interceptor-method :compliance-classify
+(defmethod ^{:stratum 2} phase/get-phase-interceptor-method :compliance-classify
   [config]
   (let [merged (phase/merge-with-defaults config)]
     {:name   ::compliance-classify
@@ -291,7 +276,7 @@
      :leave  leave-compliance-classify
      :error  error-compliance-classify}))
 
-(defmethod phase/get-phase-interceptor-method :compliance-plan
+(defmethod ^{:stratum 2} phase/get-phase-interceptor-method :compliance-plan
   [config]
   (let [merged (phase/merge-with-defaults config)]
     {:name   ::compliance-plan
@@ -300,7 +285,7 @@
      :leave  leave-compliance-plan
      :error  error-compliance-plan}))
 
-(defmethod phase/get-phase-interceptor-method :compliance-execute
+(defmethod ^{:stratum 2} phase/get-phase-interceptor-method :compliance-execute
   [config]
   (let [merged (phase/merge-with-defaults config)]
     {:name   ::compliance-execute
@@ -308,6 +293,15 @@
      :enter  (fn [ctx] (enter-compliance-execute (assoc ctx :phase-config merged)))
      :leave  leave-compliance-execute
      :error  error-compliance-execute}))
+
+;; Register defaults on load
+(phase/register-phase-defaults! :compliance-scan     default-scan-config)
+
+(phase/register-phase-defaults! :compliance-classify default-classify-config)
+
+(phase/register-phase-defaults! :compliance-plan     default-plan-config)
+
+(phase/register-phase-defaults! :compliance-execute  default-execute-config)
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/workflow-compliance-scanner/test/ai/miniforge/workflow_compliance_scanner/phases_test.clj
+++ b/components/workflow-compliance-scanner/test/ai/miniforge/workflow_compliance_scanner/phases_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.workflow-compliance-scanner.phases-test
   "Unit tests for the compliance scan workflow phase interceptors.
 
@@ -30,9 +29,10 @@
    [ai.miniforge.workflow-compliance-scanner.phases     :as phases]
    [ai.miniforge.workflow-compliance-scanner.interface]))
 
-;------------------------------------------------------------------------------ Test Fixtures
+;------------------------------------------------------------------------------ Layer 0
 
-(def stub-violation
+;------------------------------------------------------------------------------ Test Fixtures
+(def ^{:stratum 0} stub-violation
   {:rule/id       :std/clojure
    :rule/category "210"
    :rule/title    "Clojure Map Access"
@@ -41,23 +41,7 @@
    :current       "(or (:k m) nil)"
    :suggested     "(get m :k nil)"})
 
-(def stub-classified-violation
-  (assoc stub-violation :auto-fixable? true :rationale "Literal default"))
-
-(def stub-scan-result
-  {:violations    [stub-violation]
-   :rules-scanned [:std/clojure]
-   :files-scanned 1
-   :duration-ms   42})
-
-(def stub-plan
-  {:dag-tasks [{:task/id (random-uuid) :task/deps #{} :task/file "components/foo/src/core.clj"
-                :task/rule-id :std/clojure :task/violations [stub-classified-violation]}]
-   :work-spec  "# Compliance Work Spec\n"
-   :summary    {:total-violations 1 :auto-fixable 1 :needs-review 0
-                :files-affected 1 :rules-violated 1}})
-
-(defn base-ctx
+(defn ^{:stratum 0} base-ctx
   "Minimal execution context for testing."
   []
   {:execution/id            (random-uuid)
@@ -69,8 +53,7 @@
    :execution/phase-results {}})
 
 ;------------------------------------------------------------------------------ Registry Tests
-
-(deftest phases-registered-in-registry-test
+(deftest ^{:stratum 0} phases-registered-in-registry-test
   (testing "all three compliance phases are registered in the registry after namespace load"
     (is (some? (registry/phase-defaults :compliance-scan))
         ":compliance-scan defaults should be registered")
@@ -79,7 +62,7 @@
     (is (some? (registry/phase-defaults :compliance-plan))
         ":compliance-plan defaults should be registered")))
 
-(deftest phase-default-budgets-test
+(deftest ^{:stratum 0} phase-default-budgets-test
   (testing ":compliance-scan has correct default budget"
     (let [defaults (registry/phase-defaults :compliance-scan)]
       (is (= 5000 (get-in defaults [:budget :tokens])))
@@ -96,9 +79,89 @@
       (is (= 1 (get-in defaults [:budget :iterations])))
       (is (= 120 (get-in defaults [:budget :time-seconds]))))))
 
-;------------------------------------------------------------------------------ :compliance-scan Tests
+;------------------------------------------------------------------------------ :compliance-execute Tests
+(deftest ^{:stratum 0} phases-execute-registered-in-registry-test
+  (testing ":compliance-execute defaults are registered"
+    (is (some? (registry/phase-defaults :compliance-execute)))))
 
-(deftest enter-compliance-scan-stores-scan-result-test
+(deftest ^{:stratum 0} phase-execute-default-budget-test
+  (testing ":compliance-execute has correct default budget"
+    (let [defaults (registry/phase-defaults :compliance-execute)]
+      (is (= 5000 (get-in defaults [:budget :tokens])))
+      (is (= 1 (get-in defaults [:budget :iterations])))
+      (is (= 1800 (get-in defaults [:budget :time-seconds]))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} stub-classified-violation
+  (assoc stub-violation :auto-fixable? true :rationale "Literal default"))
+
+(def ^{:stratum 1} stub-scan-result
+  {:violations    [stub-violation]
+   :rules-scanned [:std/clojure]
+   :files-scanned 1
+   :duration-ms   42})
+
+(deftest ^{:stratum 1} enter-compliance-classify-handles-missing-scan-results-test
+  (testing "enter-compliance-classify uses empty violations when scan results missing"
+    (let [classify-input (atom nil)]
+      (with-redefs [compliance-scanner/classify (fn [violations]
+                                                  (reset! classify-input violations)
+                                                  [])]
+        (phases/enter-compliance-classify (base-ctx))
+        (is (= [] @classify-input)
+            "Should call classify with empty vector when no scan results present")))))
+
+(deftest ^{:stratum 1} error-compliance-execute-sets-failed-status-test
+  (testing "error-compliance-execute sets :failed status"
+    (let [ctx (base-ctx)
+          ex (ex-info "Execute failed" {:reason :git-error})
+          result (phases/error-compliance-execute ctx ex)]
+      (is (= :failed (get-in result [:phase :status])))
+      (is (= "Execute failed" (get-in result [:phase :error :message]))))))
+
+;------------------------------------------------------------------------------ Error Handler Tests
+(deftest ^{:stratum 1} error-compliance-scan-sets-failed-status-test
+  (testing "error-compliance-scan sets :failed status with exception error"
+    (let [ctx (base-ctx)
+          ex  (ex-info "Scan failed" {:reason :io-error})
+          result (phases/error-compliance-scan ctx ex)]
+      (is (= :failed (get-in result [:phase :status]))
+          "Phase status should be :failed")
+      (is (= "Scan failed" (get-in result [:phase :error :message]))
+          "Error message should be captured"))))
+
+(deftest ^{:stratum 1} error-compliance-classify-sets-failed-status-test
+  (testing "error-compliance-classify sets :failed status"
+    (let [ctx (base-ctx)
+          ex  (ex-info "Classify failed" {:reason :unexpected})
+          result (phases/error-compliance-classify ctx ex)]
+      (is (= :failed (get-in result [:phase :status]))
+          "Phase status should be :failed")
+      (is (some? (get-in result [:phase :error]))
+          "Error map should be present"))))
+
+(deftest ^{:stratum 1} error-compliance-plan-sets-failed-status-test
+  (testing "error-compliance-plan sets :failed status"
+    (let [ctx (base-ctx)
+          ex  (ex-info "Plan failed" {:reason :write-error})
+          result (phases/error-compliance-plan ctx ex)]
+      (is (= :failed (get-in result [:phase :status]))
+          "Phase status should be :failed")
+      (is (= "Plan failed" (get-in result [:phase :error :message]))
+          "Error message should be captured"))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(def ^{:stratum 2} stub-plan
+  {:dag-tasks [{:task/id (random-uuid) :task/deps #{} :task/file "components/foo/src/core.clj"
+                :task/rule-id :std/clojure :task/violations [stub-classified-violation]}]
+   :work-spec  "# Compliance Work Spec\n"
+   :summary    {:total-violations 1 :auto-fixable 1 :needs-review 0
+                :files-affected 1 :rules-violated 1}})
+
+;------------------------------------------------------------------------------ :compliance-scan Tests
+(deftest ^{:stratum 2} enter-compliance-scan-stores-scan-result-test
   (testing "enter-compliance-scan stores scan result under [:phase :result :output]"
     (with-redefs [compliance-scanner/scan (fn [_repo _standards _opts] stub-scan-result)]
       (let [ctx    (base-ctx)
@@ -112,7 +175,7 @@
         (is (= :success (get-in result [:phase :result :status]))
             "Result status should be :success")))))
 
-(deftest enter-compliance-scan-uses-worktree-path-test
+(deftest ^{:stratum 2} enter-compliance-scan-uses-worktree-path-test
   (testing "enter-compliance-scan prefers :execution/worktree-path for repo-path"
     (let [captured-repo (atom nil)]
       (with-redefs [compliance-scanner/scan (fn [repo _standards _opts]
@@ -122,7 +185,7 @@
         (is (= "/tmp/test-repo" @captured-repo)
             "Should use :execution/worktree-path as repo-path")))))
 
-(deftest leave-compliance-scan-records-violation-count-test
+(deftest ^{:stratum 2} leave-compliance-scan-records-violation-count-test
   (testing "leave-compliance-scan adds violation-count to metrics and stores phase results"
     (with-redefs [compliance-scanner/scan (fn [_repo _standards _opts] stub-scan-result)]
       (let [ctx         (base-ctx)
@@ -141,8 +204,7 @@
             ":compliance-scan should be added to phases-completed")))))
 
 ;------------------------------------------------------------------------------ :compliance-classify Tests
-
-(deftest enter-compliance-classify-reads-violations-and-stores-classified-test
+(deftest ^{:stratum 2} enter-compliance-classify-reads-violations-and-stores-classified-test
   (testing "enter-compliance-classify reads violations from phase-results and stores classified"
     (with-redefs [compliance-scanner/classify (fn [_violations] [stub-classified-violation])]
       (let [ctx    (-> (base-ctx)
@@ -157,17 +219,7 @@
                (get-in result [:phase :result :output :classified-violations]))
             "Classified violations should be stored in output")))))
 
-(deftest enter-compliance-classify-handles-missing-scan-results-test
-  (testing "enter-compliance-classify uses empty violations when scan results missing"
-    (let [classify-input (atom nil)]
-      (with-redefs [compliance-scanner/classify (fn [violations]
-                                                  (reset! classify-input violations)
-                                                  [])]
-        (phases/enter-compliance-classify (base-ctx))
-        (is (= [] @classify-input)
-            "Should call classify with empty vector when no scan results present")))))
-
-(deftest leave-compliance-classify-records-auto-fixable-needs-review-test
+(deftest ^{:stratum 2} leave-compliance-classify-records-auto-fixable-needs-review-test
   (testing "leave-compliance-classify records auto-fixable and needs-review counts"
     (with-redefs [compliance-scanner/classify (fn [_violations] [stub-classified-violation])]
       (let [ctx        (-> (base-ctx)
@@ -184,9 +236,10 @@
         (is (= [:compliance-classify] (get-in left-ctx [:execution :phases-completed]))
             ":compliance-classify should be added to phases-completed")))))
 
-;------------------------------------------------------------------------------ :compliance-plan Tests
+;------------------------------------------------------------------------------ Layer 3
 
-(deftest enter-compliance-plan-reads-classified-and-stores-plan-test
+;------------------------------------------------------------------------------ :compliance-plan Tests
+(deftest ^{:stratum 3} enter-compliance-plan-reads-classified-and-stores-plan-test
   (testing "enter-compliance-plan reads classified violations and stores plan output"
     (with-redefs [compliance-scanner/plan              (fn [_classified _repo] stub-plan)
                   compliance-scanner/write-work-spec!  (fn [_spec _repo] "/tmp/test-repo/docs/compliance/spec.md")
@@ -204,7 +257,7 @@
         (is (= 1 (get-in result [:phase :result :output :task-count]))
             "Task count should reflect dag-tasks count")))))
 
-(deftest enter-compliance-plan-calls-write-work-spec-test
+(deftest ^{:stratum 3} enter-compliance-plan-calls-write-work-spec-test
   (testing "enter-compliance-plan calls write-work-spec! with the work-spec string"
     (let [write-spec-calls (atom [])]
       (with-redefs [compliance-scanner/plan              (fn [_classified _repo] stub-plan)
@@ -218,7 +271,7 @@
         (is (= "# Compliance Work Spec\n" (:spec (first @write-spec-calls)))
             "Work spec string should be passed to write-work-spec!")))))
 
-(deftest enter-compliance-plan-calls-write-delta-report-test
+(deftest ^{:stratum 3} enter-compliance-plan-calls-write-delta-report-test
   (testing "enter-compliance-plan calls write-delta-report! with correct args"
     (let [write-report-calls (atom [])]
       (with-redefs [compliance-scanner/plan              (fn [_classified _repo] stub-plan)
@@ -239,7 +292,7 @@
           (is (= [stub-classified-violation] (:classified (first @write-report-calls)))
               "Classified violations should be passed to write-delta-report!"))))))
 
-(deftest leave-compliance-plan-records-task-count-test
+(deftest ^{:stratum 3} leave-compliance-plan-records-task-count-test
   (testing "leave-compliance-plan records task count in metrics"
     (with-redefs [compliance-scanner/plan              (fn [_classified _repo] stub-plan)
                   compliance-scanner/write-work-spec!  (fn [_spec _repo] "/written/spec")
@@ -256,20 +309,7 @@
         (is (= [:compliance-plan] (get-in left-ctx [:execution :phases-completed]))
             ":compliance-plan should be added to phases-completed")))))
 
-;------------------------------------------------------------------------------ :compliance-execute Tests
-
-(deftest phases-execute-registered-in-registry-test
-  (testing ":compliance-execute defaults are registered"
-    (is (some? (registry/phase-defaults :compliance-execute)))))
-
-(deftest phase-execute-default-budget-test
-  (testing ":compliance-execute has correct default budget"
-    (let [defaults (registry/phase-defaults :compliance-execute)]
-      (is (= 5000 (get-in defaults [:budget :tokens])))
-      (is (= 1 (get-in defaults [:budget :iterations])))
-      (is (= 1800 (get-in defaults [:budget :time-seconds]))))))
-
-(deftest enter-compliance-execute-stores-execute-result-test
+(deftest ^{:stratum 3} enter-compliance-execute-stores-execute-result-test
   (testing "enter-compliance-execute calls execute! and stores output"
     (let [stub-exec-result {:prs [{:rule/id :std/clojure :branch "fix/compliance-210" :pr-url "https://github.com/org/repo/pull/1" :violations-fixed 5 :files-changed 3}] :violations-fixed 5 :files-changed 3}]
       (with-redefs [compliance-scanner/execute! (fn [_plan _repo] stub-exec-result)]
@@ -280,7 +320,7 @@
           (is (= :running (get-in result [:phase :status])))
           (is (= stub-exec-result (get-in result [:phase :result :output]))))))))
 
-(deftest leave-compliance-execute-records-metrics-test
+(deftest ^{:stratum 3} leave-compliance-execute-records-metrics-test
   (testing "leave-compliance-execute records metrics"
     (let [stub-exec-result {:prs [{:violations-fixed 5 :files-changed 3} {:violations-fixed 1 :files-changed 1}] :violations-fixed 6 :files-changed 4}]
       (with-redefs [compliance-scanner/execute! (fn [_plan _repo] stub-exec-result)]
@@ -292,46 +332,6 @@
           (is (= 2 (get-in left-ctx [:phase :metrics :pr-count])))
           (is (= 6 (get-in left-ctx [:phase :metrics :violations-fixed])))
           (is (= 4 (get-in left-ctx [:phase :metrics :files-changed]))))))))
-
-(deftest error-compliance-execute-sets-failed-status-test
-  (testing "error-compliance-execute sets :failed status"
-    (let [ctx (base-ctx)
-          ex (ex-info "Execute failed" {:reason :git-error})
-          result (phases/error-compliance-execute ctx ex)]
-      (is (= :failed (get-in result [:phase :status])))
-      (is (= "Execute failed" (get-in result [:phase :error :message]))))))
-
-;------------------------------------------------------------------------------ Error Handler Tests
-
-(deftest error-compliance-scan-sets-failed-status-test
-  (testing "error-compliance-scan sets :failed status with exception error"
-    (let [ctx (base-ctx)
-          ex  (ex-info "Scan failed" {:reason :io-error})
-          result (phases/error-compliance-scan ctx ex)]
-      (is (= :failed (get-in result [:phase :status]))
-          "Phase status should be :failed")
-      (is (= "Scan failed" (get-in result [:phase :error :message]))
-          "Error message should be captured"))))
-
-(deftest error-compliance-classify-sets-failed-status-test
-  (testing "error-compliance-classify sets :failed status"
-    (let [ctx (base-ctx)
-          ex  (ex-info "Classify failed" {:reason :unexpected})
-          result (phases/error-compliance-classify ctx ex)]
-      (is (= :failed (get-in result [:phase :status]))
-          "Phase status should be :failed")
-      (is (some? (get-in result [:phase :error]))
-          "Error map should be present"))))
-
-(deftest error-compliance-plan-sets-failed-status-test
-  (testing "error-compliance-plan sets :failed status"
-    (let [ctx (base-ctx)
-          ex  (ex-info "Plan failed" {:reason :write-error})
-          result (phases/error-compliance-plan ctx ex)]
-      (is (= :failed (get-in result [:phase :status]))
-          "Phase status should be :failed")
-      (is (= "Plan failed" (get-in result [:phase :error :message]))
-          "Error message should be captured"))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-workflow-compliance-scanner.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-workflow-compliance-scanner.md
@@ -1,0 +1,106 @@
+# fix: stratum-lint autofix for components/workflow-compliance-scanner (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over `components/workflow-compliance-scanner`
+(`src` + `test`) to replace decorative `Layer N` heading reuse with real
+headings and `^{:stratum n}` metadata derived from each file's actual
+same-file reference graph. Purely mechanical: no logic changes. One of
+the smaller per-component Wave 1 PRs from
+`work/stratum-lint-baseline-2026-07-24.md`.
+
+## Motivation
+
+Baseline for this component: 4 `SL002` findings, all in
+`phases.clj` — the same `Layer 0`/`Layer 1` headings reused as repeated
+section banners (`Helpers` / `Default configs` under one `Layer 0`, four
+separate interceptor sections each stamped `Layer 1`) instead of one
+heading per real stratum. Zero `SL001` findings, so no
+upward-reference/cycle risk to reason about before running the mechanical
+fixer — matches the Wave 1 batch criteria exactly. `interface.clj` had no
+findings and is untouched by the fix.
+
+## Changes in Detail
+
+Ran, over the whole component:
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "14965e1ee1a175bd00f637d9a9d5f7d27e62b73f" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/workflow-compliance-scanner
+```
+
+2 files rewritten: `phases.clj` (`src`) and `phases_test.clj` (`test`).
+
+`phases.clj`: the helper fns (`resolve-repo-path`, `resolve-standards-path`,
+`resolve-rules`), the four `default-*-config` defs, and the four
+`leave-`/`error-` fns all collapse to real `Layer 0` (nothing else in the
+file depends on them). The four `enter-` fns move to `Layer 1` (each calls
+a `resolve-*` helper and/or a `default-*-config`). The four
+`defmethod phase/get-phase-interceptor-method` implementations land
+together at `Layer 2` (each references both an `enter-` and a `leave-`/
+`error-` fn) — verified they're all consistently at the same stratum, per
+this program's known defmethod-placement bug class. The four
+`register-phase-defaults!` calls (side-effecting, not `def`/`defn`/
+`defmethod`) sort to the end of the file after the last `defmethod`; this
+doesn't change behavior since Clojure evaluates top-level forms in file
+order regardless, both registries are independent, and every `def` each
+form touches is already bound earlier in the file.
+
+`phases_test.clj` had **no** `Layer N` headings at all before this fix —
+only named section banners (`Test Fixtures`, `Registry Tests`, etc.) with
+no number, so the baseline's plain lint run silently skipped it (a
+documented tool limitation, not a pass). `--fix` added real headings
+across 4 strata (`Layer 0`–`3`) tracking the actual `deftest`/stub
+dependency chain (e.g. `stub-plan` at `Layer 2` because `Layer 3`'s
+`:compliance-plan`/`:compliance-execute` tests depend on it).
+
+No line of executable code changed in either file; diffs are heading
+text, metadata, and def/deftest reordering only.
+
+## Testing Plan
+
+1. Ran plain (non-`--fix`) `stratum-lint` before the fix — reproduced the
+   baseline's 4 `SL002` findings exactly, confirmed zero `SL001`.
+2. Ran `--fix`, then a second `--fix` pass immediately after — zero diff,
+   confirms idempotency.
+3. Read the full diff for both changed files. No same-line trailing
+   comment was displaced onto the wrong def, and no stale decorative
+   `;;---- Layer N: ...` banner survived the fix (checked both files for
+   the double-semicolon pattern — none found).
+4. `clj-kondo --lint components/workflow-compliance-scanner`: 0 errors,
+   0 warnings.
+5. Ran `ai.miniforge.workflow-compliance-scanner.phases-test` directly via
+   `clojure -A:test`: 20 tests, 61 assertions, 0 failures, 0 errors.
+6. Re-ran plain `stratum-lint` after the fix: `SL001`/`SL002`/`SL004`
+   clear on both files, and `phases.clj` is fully clean. One new finding:
+   `SL003` on `phases_test.clj` — 4 real layers against the 3-layer
+   budget. This is **newly surfaced**, not a re-labeled pre-existing
+   finding: the file had zero `Layer N` headings before this fix (invisible
+   to the baseline scan), so the baseline's per-component finding count
+   for this component (4, all `SL002`) never included it. Deferred to
+   Wave 2 (real namespace split / test file decomposition).
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+change — comment/metadata/order-only. Pre-commit's `lint:stratum`
+autofixer keeps this component clean going forward; `phases_test.clj`'s
+`SL003` stays advisory (`MINIFORGE_STRATUM_BUDGET_MODE=warn` at commit
+time) until Wave 2 splits it.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+- Follow-on: Wave 2 split for
+  `components/workflow-compliance-scanner/test/ai/miniforge/workflow_compliance_scanner/phases_test.clj`
+  (4 real layers, over budget, newly surfaced by this fix)
+
+## Checklist
+
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Second `--fix` pass confirms idempotency (zero diff)
+- [x] Diff read in full for both changed files; mechanical-only
+- [x] `clj-kondo` clean before/after (0 errors, 0 warnings)
+- [x] Component tests pass (20 tests, 61 assertions, 0 failures/errors)
+- [x] Plain lint re-run post-fix: zero findings except the newly-surfaced
+      `SL003` on `phases_test.clj` (documented above, tracked as Wave 2)
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
## Summary
- Runs `stratum-lint --fix` over `components/workflow-compliance-scanner` (`src` + `test`) to replace decorative `Layer N` heading reuse with real headings and `^{:stratum n}` metadata derived from each file's actual same-file reference graph.
- Zero `SL001` findings confirmed before fixing (no upward-reference/cycle risk). Mechanical only: no logic changes.
- `phases_test.clj` had no `Layer N` headings at all before this fix (silently skipped by the baseline scan, per its documented limitation); `--fix` surfaces a new `SL003` (4 real layers, over the 3-layer budget), deferred to Wave 2 (namespace split).

Full detail in `docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-workflow-compliance-scanner.md`.

## Test plan
- [x] Baseline plain lint: 4 `SL002` findings (all `phases.clj`), zero `SL001` — confirmed before fixing
- [x] `--fix` run, then a second `--fix` pass: zero diff (idempotent)
- [x] Full diff read for both changed files: no misplaced trailing comments, no stale decorative Layer banners
- [x] `clj-kondo --lint components/workflow-compliance-scanner`: 0 errors, 0 warnings
- [x] `ai.miniforge.workflow-compliance-scanner.phases-test`: 20 tests, 61 assertions, 0 failures/errors
- [x] Plain lint re-run post-fix: clean except newly-surfaced `SL003` on `phases_test.clj` (documented, tracked as Wave 2)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>