### PR TITLE
fix: stratum-lint autofix for components/reporting (Wave 1)

### DIFF
--- a/components/reporting/src/ai/miniforge/reporting/core.clj
+++ b/components/reporting/src/ai/miniforge/reporting/core.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.reporting.core
   "Core reporting implementation."
   (:require
@@ -26,9 +25,9 @@
    [ai.miniforge.logging.interface :as log]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Helper functions
 
-(defn safe-get
+;; Helper functions
+(defn ^{:stratum 0} safe-get
   "Returns nil on error; logs at WARN when a logger is supplied.
   Call as (safe-get f arg…) or (safe-get logger f arg…)."
   [maybe-logger-or-fn & rest]
@@ -45,7 +44,7 @@
                      :data {:fn (str f)}})
           nil)))))
 
-(defn count-by-status
+(defn ^{:stratum 0} count-by-status
   "Count workflows by status."
   [workflows status]
   (count (filter #(= status (:workflow/status %)) workflows)))
@@ -55,11 +54,8 @@
     "Count workflows by phase."
     [workflows phase]
     (count (filter #(= phase (:workflow/phase %)) workflows)))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; Subscription management (polling-based for BB compatibility)
-
-(defn create-subscription
+(defn ^{:stratum 0} create-subscription
   "Create a new subscription record."
   [topics callback]
   {:subscription/id (random-uuid)
@@ -69,6 +65,29 @@
    :subscription/last-poll 0
    :subscription/event-queue (atom [])})
 
+;; Workflow detail aggregation
+(defn ^{:stratum 0} build-workflow-timeline
+  "Build timeline of phase transitions."
+  [workflow-state]
+  (let [history (:workflow/history workflow-state [])]
+    (mapv (fn [entry]
+            {:phase (:phase entry)
+             :status (:status entry)
+             :started-at (:started-at entry)
+             :completed-at (:completed-at entry)})
+          history)))
+
+(defn ^{:stratum 0} get-workflow-logs
+  "Get logs for a workflow."
+  [logger _workflow-id]
+  (if logger
+    ;; In real implementation, would query logger with context filter
+    ;; For now, return empty as logger doesn't expose query API
+    []
+    []))
+
+;------------------------------------------------------------------------------ Layer 1
+
 ;; Note: Keep for future event broadcasting support
 #_(defn add-event-to-subscriptions
     "Add event to relevant subscriptions."
@@ -76,11 +95,8 @@
     (doseq [[_id sub] @subscriptions]
       (when (contains? (:subscription/topics sub) (:event/topic event))
         (swap! (:subscription/event-queue sub) conj event))))
-
-;------------------------------------------------------------------------------ Layer 2
 ;; System status aggregation
-
-(defn aggregate-workflow-stats
+(defn ^{:stratum 1} aggregate-workflow-stats
   "Aggregate workflow statistics."
   [workflow-component logger]
   (if-let [all-workflows (safe-get logger wf/get-state workflow-component :all)]
@@ -90,7 +106,7 @@
      :failed (count-by-status all-workflows :failed)}
     {:active 0 :pending 0 :completed 0 :failed 0}))
 
-(defn aggregate-resource-metrics
+(defn ^{:stratum 1} aggregate-resource-metrics
   "Aggregate resource usage metrics."
   [workflow-component logger]
   (if-let [all-workflows (safe-get logger wf/get-state workflow-component :all)]
@@ -103,7 +119,7 @@
      all-workflows)
     {:tokens-used 0 :cost-usd 0.0}))
 
-(defn aggregate-meta-loop-status
+(defn ^{:stratum 1} aggregate-meta-loop-status
   "Aggregate meta-loop status."
   [operator-component logger]
   (if operator-component
@@ -114,7 +130,7 @@
     {:status :not-configured
      :pending-improvements 0}))
 
-(defn collect-alerts
+(defn ^{:stratum 1} collect-alerts
   "Collect system alerts."
   [workflow-stats operator-component logger]
   (let [alerts []]
@@ -130,21 +146,7 @@
              :severity :warning
              :message "Multiple pending improvements awaiting review"}))))
 
-;------------------------------------------------------------------------------ Layer 3
-;; Workflow detail aggregation
-
-(defn build-workflow-timeline
-  "Build timeline of phase transitions."
-  [workflow-state]
-  (let [history (:workflow/history workflow-state [])]
-    (mapv (fn [entry]
-            {:phase (:phase entry)
-             :status (:status entry)
-             :started-at (:started-at entry)
-             :completed-at (:completed-at entry)})
-          history)))
-
-(defn get-workflow-artifacts
+(defn ^{:stratum 1} get-workflow-artifacts
   "Get artifacts for a workflow."
   [artifact-store workflow-id logger]
   (if artifact-store
@@ -156,19 +158,10 @@
             (or artifacts [])))
     []))
 
-(defn get-workflow-logs
-  "Get logs for a workflow."
-  [logger _workflow-id]
-  (if logger
-    ;; In real implementation, would query logger with context filter
-    ;; For now, return empty as logger doesn't expose query API
-    []
-    []))
+;------------------------------------------------------------------------------ Layer 2
 
-;------------------------------------------------------------------------------ Layer 4
 ;; ReportingService implementation
-
-(defrecord ReportingServiceImpl [workflow-component
+(defrecord ^{:stratum 2} ReportingServiceImpl [workflow-component
                                   orchestrator-component
                                   operator-component
                                   artifact-store
@@ -271,10 +264,10 @@
         events)
       [])))
 
-;------------------------------------------------------------------------------ Layer 5
-;; Constructor
+;------------------------------------------------------------------------------ Layer 3
 
-(defn create-reporting-service
+;; Constructor
+(defn ^{:stratum 3} create-reporting-service
   ([] (create-reporting-service {}))
   ([{:keys [workflow-component
             orchestrator-component

--- a/components/reporting/src/ai/miniforge/reporting/interface.clj
+++ b/components/reporting/src/ai/miniforge/reporting/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.reporting.interface
   "Public API for the reporting component.
    Provides system status monitoring and workflow reporting."
@@ -28,9 +27,9 @@
    [ai.miniforge.reporting.views.edn :as view-edn]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Protocol re-exports
 
-(def ReportingService
+;; Protocol re-exports
+(def ^{:stratum 0} ReportingService
   "Protocol satisfied by reporting service instances.
 
    Defines the monitoring/aggregation contract: get-system-status,
@@ -40,10 +39,8 @@
    are produced by create-reporting-service."
   proto/ReportingService)
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Service creation
-
-(def create-reporting-service
+(def ^{:stratum 0} create-reporting-service
   "Create a reporting service.
 
    The reporting service aggregates data from multiple components
@@ -63,10 +60,8 @@
                       :logger logger}))"
   core/create-reporting-service)
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Status queries
-
-(defn get-system-status
+(defn ^{:stratum 0} get-system-status
   "Get overall system status.
 
    Returns:
@@ -80,7 +75,7 @@
   [reporting-service]
   (proto/get-system-status reporting-service))
 
-(defn get-workflow-list
+(defn ^{:stratum 0} get-workflow-list
   "Get list of workflows with optional filtering.
 
    criteria:
@@ -97,7 +92,7 @@
   ([reporting-service criteria]
    (proto/get-workflow-list reporting-service criteria)))
 
-(defn get-workflow-detail
+(defn ^{:stratum 0} get-workflow-detail
   "Get detailed information about a specific workflow.
 
    Returns:
@@ -114,7 +109,7 @@
   [reporting-service workflow-id]
   (proto/get-workflow-detail reporting-service workflow-id))
 
-(defn get-meta-loop-status
+(defn ^{:stratum 0} get-meta-loop-status
   "Get meta-loop (operator) status.
 
    Returns:
@@ -127,10 +122,8 @@
   [reporting-service]
   (proto/get-meta-loop-status reporting-service))
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Event subscriptions (polling-based for BB compatibility)
-
-(defn subscribe
+(defn ^{:stratum 0} subscribe
   "Subscribe to events for polling-based updates.
 
    topics: Set of topic keywords
@@ -153,7 +146,7 @@
   [reporting-service topics callback]
   (proto/subscribe reporting-service topics callback))
 
-(defn unsubscribe
+(defn ^{:stratum 0} unsubscribe
   "Unsubscribe from events.
 
    Returns true if subscription was removed.
@@ -163,7 +156,7 @@
   [reporting-service subscription-id]
   (proto/unsubscribe reporting-service subscription-id))
 
-(defn poll-events
+(defn ^{:stratum 0} poll-events
   "Poll for events on a subscription.
 
    Returns sequence of events since last poll.
@@ -174,10 +167,8 @@
   [reporting-service subscription-id]
   (proto/poll-events reporting-service subscription-id))
 
-;------------------------------------------------------------------------------ Layer 4
 ;; Rendering functions
-
-(defn render-system-overview
+(defn ^{:stratum 0} render-system-overview
   "Render system overview with status information.
 
    See ai.miniforge.reporting.views.system for full documentation.
@@ -187,7 +178,7 @@
   [system-data]
   (view-system/render-system-overview system-data))
 
-(defn render-workflow-list
+(defn ^{:stratum 0} render-workflow-list
   "Render a list of workflows as a table.
 
    See ai.miniforge.reporting.views.workflow for full documentation.
@@ -197,7 +188,7 @@
   [workflows]
   (view-workflow/render-workflow-list workflows))
 
-(defn render-workflow-detail
+(defn ^{:stratum 0} render-workflow-detail
   "Render detailed workflow information.
 
    See ai.miniforge.reporting.views.workflow for full documentation.
@@ -207,7 +198,7 @@
   [workflow]
   (view-workflow/render-workflow-detail workflow))
 
-(defn render-meta-loop
+(defn ^{:stratum 0} render-meta-loop
   "Render meta-loop status and optimization information.
 
    See ai.miniforge.reporting.views.meta for full documentation.
@@ -217,7 +208,7 @@
   [meta-data]
   (view-meta/render-meta-loop meta-data))
 
-(defn render-edn
+(defn ^{:stratum 0} render-edn
   "Render arbitrary data as pretty-printed EDN.
 
    See ai.miniforge.reporting.views.edn for full documentation.

--- a/components/reporting/src/ai/miniforge/reporting/protocol.clj
+++ b/components/reporting/src/ai/miniforge/reporting/protocol.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.reporting.protocol
   "Reporting protocols for system status and monitoring.
 
@@ -23,9 +22,9 @@
    and operator components to provide unified views of system state.")
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Core reporting protocol
 
-(defprotocol ReportingService
+;; Core reporting protocol
+(defprotocol ^{:stratum 0} ReportingService
   "Protocol for reporting and monitoring service.
    Aggregates data from multiple components for unified status views."
 

--- a/components/reporting/src/ai/miniforge/reporting/views/edn.clj
+++ b/components/reporting/src/ai/miniforge/reporting/views/edn.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.reporting.views.edn
   "EDN data rendering.
 
@@ -23,9 +22,9 @@
   (:require [clojure.pprint]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; EDN rendering
 
-(defn render-edn
+;; EDN rendering
+(defn ^{:stratum 0} render-edn
   "Render arbitrary data as pretty-printed EDN.
 
    Args:

--- a/components/reporting/src/ai/miniforge/reporting/views/formatting.clj
+++ b/components/reporting/src/ai/miniforge/reporting/views/formatting.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.reporting.views.formatting
   "Low-level formatting utilities for terminal output.
 
@@ -23,9 +22,9 @@
   (:require [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; ANSI color codes and basic colorization
 
-(def ansi-codes
+;; ANSI color codes and basic colorization
+(def ^{:stratum 0} ansi-codes
   "ANSI escape codes for terminal colors and styles."
   {:reset "\033[0m"
    :bold "\033[1m"
@@ -43,12 +42,7 @@
    :bg-yellow "\033[43m"
    :bg-blue "\033[44m"})
 
-(defn ansi
-  "Apply ANSI color/formatting to text."
-  [code text]
-  (str (get ansi-codes code "") text (:reset ansi-codes)))
-
-(defn status-color
+(defn ^{:stratum 0} status-color
   "Get color for a status keyword."
   [status]
   (case status
@@ -57,10 +51,8 @@
     (:failed :error) :red
     :white))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Box drawing and separators
-
-(def box-chars
+(def ^{:stratum 0} box-chars
   "Unicode box drawing characters."
   {:horizontal "─"
    :vertical "│"
@@ -74,7 +66,41 @@
    :t-right "├"
    :t-left "┤"})
 
-(defn draw-box
+;; Table formatting
+(defn ^{:stratum 0} format-table
+  "Format data as a table."
+  [headers rows]
+  (let [col-count (count headers)
+        col-widths (map (fn [idx]
+                          (apply max
+                                 (count (nth headers idx))
+                                 (map #(count (str (nth % idx ""))) rows)))
+                        (range col-count))
+        format-row (fn [row]
+                     (str/join " │ "
+                               (map-indexed
+                                (fn [idx val]
+                                  (let [width (nth col-widths idx)
+                                        val-str (str val)]
+                                    (str val-str
+                                         (apply str (repeat (- width (count val-str)) " ")))))
+                                row)))
+        header-line (format-row headers)
+        separator (str/join "─┼─"
+                            (map #(apply str (repeat % "─")) col-widths))]
+    (str/join "\n"
+              (concat
+               [header-line separator]
+               (map format-row rows)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} ansi
+  "Apply ANSI color/formatting to text."
+  [code text]
+  (str (get ansi-codes code "") text (:reset ansi-codes)))
+
+(defn ^{:stratum 1} draw-box
   "Draw a box around content."
   [title content width]
   (let [title-str (str " " title " ")
@@ -101,39 +127,10 @@
                     content-lines)
                [bottom-line]))))
 
-(defn draw-separator
+(defn ^{:stratum 1} draw-separator
   "Draw a horizontal separator."
   [width]
   (apply str (repeat width (:horizontal box-chars))))
-
-;------------------------------------------------------------------------------ Layer 2
-;; Table formatting
-
-(defn format-table
-  "Format data as a table."
-  [headers rows]
-  (let [col-count (count headers)
-        col-widths (map (fn [idx]
-                          (apply max
-                                 (count (nth headers idx))
-                                 (map #(count (str (nth % idx ""))) rows)))
-                        (range col-count))
-        format-row (fn [row]
-                     (str/join " │ "
-                               (map-indexed
-                                (fn [idx val]
-                                  (let [width (nth col-widths idx)
-                                        val-str (str val)]
-                                    (str val-str
-                                         (apply str (repeat (- width (count val-str)) " ")))))
-                                row)))
-        header-line (format-row headers)
-        separator (str/join "─┼─"
-                            (map #(apply str (repeat % "─")) col-widths))]
-    (str/join "\n"
-              (concat
-               [header-line separator]
-               (map format-row rows)))))
 
 (comment
   ;; Test ANSI colors

--- a/components/reporting/src/ai/miniforge/reporting/views/meta.clj
+++ b/components/reporting/src/ai/miniforge/reporting/views/meta.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.reporting.views.meta
   "Meta-loop status rendering.
 
@@ -24,9 +23,9 @@
             [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Meta-loop status rendering
 
-(defn render-meta-loop
+;; Meta-loop status rendering
+(defn ^{:stratum 0} render-meta-loop
   "Render meta-loop dashboard.
 
    Args:

--- a/components/reporting/src/ai/miniforge/reporting/views/system.clj
+++ b/components/reporting/src/ai/miniforge/reporting/views/system.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.reporting.views.system
   "System overview rendering.
 
@@ -24,9 +23,9 @@
             [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; System overview rendering
 
-(defn render-system-overview
+;; System overview rendering
+(defn ^{:stratum 0} render-system-overview
   "Render system overview with boxed display.
 
    Args:

--- a/components/reporting/src/ai/miniforge/reporting/views/workflow.clj
+++ b/components/reporting/src/ai/miniforge/reporting/views/workflow.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.reporting.views.workflow
   "Workflow rendering - list and detail views.
 
@@ -24,9 +23,9 @@
             [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Workflow list rendering
 
-(defn render-workflow-list
+;; Workflow list rendering
+(defn ^{:stratum 0} render-workflow-list
   "Render workflow list as table.
 
    Args:
@@ -53,10 +52,8 @@
                     workflows)]
       (fmt/format-table headers rows))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Workflow detail rendering
-
-(defn render-workflow-detail
+(defn ^{:stratum 0} render-workflow-detail
   "Render detailed workflow view.
 
    Args:

--- a/components/reporting/test/ai/miniforge/reporting/core_test.clj
+++ b/components/reporting/test/ai/miniforge/reporting/core_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.reporting.core-test
   "Unit tests for reporting core helpers."
   (:require
@@ -23,21 +22,23 @@
    [ai.miniforge.reporting.core :as core]
    [ai.miniforge.logging.interface :as log]))
 
-(deftest test-safe-get-returns-value-on-success
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} test-safe-get-returns-value-on-success
   (testing "safe-get returns the fn result when no exception is thrown"
     (is (= 42 (core/safe-get (fn [] 42))))
     (is (= :ok (core/safe-get (constantly :ok))))))
 
-(deftest test-safe-get-returns-nil-on-exception
+(deftest ^{:stratum 0} test-safe-get-returns-nil-on-exception
   (testing "safe-get without logger returns nil when fn throws"
     (is (nil? (core/safe-get (fn [] (throw (Exception. "boom"))))))))
 
-(deftest test-safe-get-with-logger-returns-nil-on-exception
+(deftest ^{:stratum 0} test-safe-get-with-logger-returns-nil-on-exception
   (testing "safe-get with logger returns nil when fn throws"
     (let [[logger _] (log/collecting-logger)]
       (is (nil? (core/safe-get logger (fn [] (throw (Exception. "boom")))))))))
 
-(deftest test-safe-get-with-logger-emits-warn-on-exception
+(deftest ^{:stratum 0} test-safe-get-with-logger-emits-warn-on-exception
   (testing "safe-get emits :reporting/safe-get-error at WARN when logger is provided"
     (let [[logger entries] (log/collecting-logger)]
       (core/safe-get logger (fn [] (throw (Exception. "boom"))))
@@ -45,13 +46,13 @@
                       (= :warn (:log/level %)))
                 @entries)))))
 
-(deftest test-safe-get-with-logger-returns-value-on-success
+(deftest ^{:stratum 0} test-safe-get-with-logger-returns-value-on-success
   (testing "safe-get with logger returns value and does not log when fn succeeds"
     (let [[logger entries] (log/collecting-logger)]
       (is (= 42 (core/safe-get logger (fn [] 42))))
       (is (empty? @entries)))))
 
-(deftest test-safe-get-nil-logger-is-safe
+(deftest ^{:stratum 0} test-safe-get-nil-logger-is-safe
   (testing "safe-get with nil logger behaves like no-logger variant"
     (is (nil? (core/safe-get nil (fn [] (throw (Exception. "boom"))))))
     (is (= 42 (core/safe-get nil (fn [] 42))))))

--- a/components/reporting/test/ai/miniforge/reporting/interface_test.clj
+++ b/components/reporting/test/ai/miniforge/reporting/interface_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.reporting.interface-test
   "Tests for reporting component interface."
   (:require
@@ -25,9 +24,9 @@
    [ai.miniforge.workflow.interface :as workflow]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Test fixtures
 
-(defn create-mock-workflow-component
+;; Test fixtures
+(defn ^{:stratum 0} create-mock-workflow-component
   "Create a mock workflow component for testing."
   []
   (let [workflows (atom [{:workflow/id (random-uuid)
@@ -52,7 +51,7 @@
           @workflows
           (first (filter #(= workflow-id (:workflow/id %)) @workflows)))))))
 
-(defn create-mock-operator-component
+(defn ^{:stratum 0} create-mock-operator-component
   "Create a mock operator component for testing."
   []
   (let [signals (atom [{:signal/id (random-uuid)
@@ -70,10 +69,65 @@
       (get-proposals [_this query]
         (filter #(= (:status query) (:improvement/status %)) @proposals)))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; System status tests
+(deftest ^{:stratum 0} test-get-system-status-without-components
+  (testing "get-system-status handles missing components gracefully"
+    (let [reporting (reporting/create-reporting-service {})
+          status (reporting/get-system-status reporting)]
+      
+      (is (map? status))
+      (is (= 0 (get-in status [:workflows :active])))
+      (is (= 0 (get-in status [:resources :tokens-used])))
+      (is (= :not-configured (get-in status [:meta-loop :status]))))))
 
-(deftest test-get-system-status
+(deftest ^{:stratum 0} test-get-meta-loop-status-without-operator
+  (testing "get-meta-loop-status handles missing operator"
+    (let [reporting (reporting/create-reporting-service {})
+          status (reporting/get-meta-loop-status reporting)]
+      
+      (is (map? status))
+      (is (empty? (:signals status)))
+      (is (empty? (:pending-improvements status))))))
+
+;; Subscription tests
+(deftest ^{:stratum 0} test-subscribe-and-unsubscribe
+  (testing "subscribe creates subscription and unsubscribe removes it"
+    (let [[logger entries] (log/collecting-logger)
+          reporting (reporting/create-reporting-service {:logger logger})
+          events (atom [])
+          callback (fn [event] (swap! events conj event))
+          sub-id (reporting/subscribe reporting #{:workflow-events} callback)]
+      
+      (is (uuid? sub-id))
+      
+      ;; Check subscription logged
+      (is (some #(= :reporting/subscription-created (:log/event %)) @entries))
+      
+      ;; Unsubscribe
+      (is (true? (reporting/unsubscribe reporting sub-id)))
+      
+      ;; Check unsubscribe logged
+      (is (some #(= :reporting/subscription-removed (:log/event %)) @entries)))))
+
+(deftest ^{:stratum 0} test-poll-events
+  (testing "poll-events returns empty for new subscription"
+    (let [reporting (reporting/create-reporting-service {})
+          callback (fn [_event] nil)
+          sub-id (reporting/subscribe reporting #{:workflow-events} callback)
+          events (reporting/poll-events reporting sub-id)]
+      
+      (is (empty? events)))))
+
+(deftest ^{:stratum 0} test-poll-events-nonexistent-subscription
+  (testing "poll-events returns empty for nonexistent subscription"
+    (let [reporting (reporting/create-reporting-service {})
+          events (reporting/poll-events reporting (random-uuid))]
+      
+      (is (empty? events)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; System status tests
+(deftest ^{:stratum 1} test-get-system-status
   (testing "get-system-status returns aggregated status"
     (let [[logger _entries] (log/collecting-logger)
           wf-component (create-mock-workflow-component)
@@ -102,20 +156,8 @@
       ;; Check meta-loop status
       (is (= 1 (get-in status [:meta-loop :pending-improvements]))))))
 
-(deftest test-get-system-status-without-components
-  (testing "get-system-status handles missing components gracefully"
-    (let [reporting (reporting/create-reporting-service {})
-          status (reporting/get-system-status reporting)]
-      
-      (is (map? status))
-      (is (= 0 (get-in status [:workflows :active])))
-      (is (= 0 (get-in status [:resources :tokens-used])))
-      (is (= :not-configured (get-in status [:meta-loop :status]))))))
-
-;------------------------------------------------------------------------------ Layer 2
 ;; Workflow list tests
-
-(deftest test-get-workflow-list
+(deftest ^{:stratum 1} test-get-workflow-list
   (testing "get-workflow-list returns all workflows"
     (let [wf-component (create-mock-workflow-component)
           reporting (reporting/create-reporting-service
@@ -127,7 +169,7 @@
       (is (every? #(contains? % :workflow/status) workflows))
       (is (every? #(contains? % :workflow/phase) workflows)))))
 
-(deftest test-get-workflow-list-with-filtering
+(deftest ^{:stratum 1} test-get-workflow-list-with-filtering
   (testing "get-workflow-list filters by status"
     (let [wf-component (create-mock-workflow-component)
           reporting (reporting/create-reporting-service
@@ -146,7 +188,7 @@
       (is (= 1 (count impl-workflows)))
       (is (= :implement (:workflow/phase (first impl-workflows)))))))
 
-(deftest test-get-workflow-list-with-limit
+(deftest ^{:stratum 1} test-get-workflow-list-with-limit
   (testing "get-workflow-list respects limit"
     (let [wf-component (create-mock-workflow-component)
           reporting (reporting/create-reporting-service
@@ -155,10 +197,8 @@
       
       (is (= 2 (count workflows))))))
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Workflow detail tests
-
-(deftest test-get-workflow-detail
+(deftest ^{:stratum 1} test-get-workflow-detail
   (testing "get-workflow-detail returns workflow details"
     (let [wf-component (create-mock-workflow-component)
           reporting (reporting/create-reporting-service
@@ -174,7 +214,7 @@
       (is (contains? detail :artifacts))
       (is (contains? detail :logs)))))
 
-(deftest test-get-workflow-detail-not-found
+(deftest ^{:stratum 1} test-get-workflow-detail-not-found
   (testing "get-workflow-detail returns nil for non-existent workflow"
     (let [wf-component (create-mock-workflow-component)
           reporting (reporting/create-reporting-service
@@ -183,10 +223,8 @@
       
       (is (nil? detail)))))
 
-;------------------------------------------------------------------------------ Layer 4
 ;; Meta-loop status tests
-
-(deftest test-get-meta-loop-status
+(deftest ^{:stratum 1} test-get-meta-loop-status
   (testing "get-meta-loop-status returns operator data"
     (let [op-component (create-mock-operator-component)
           reporting (reporting/create-reporting-service
@@ -200,50 +238,3 @@
       
       (is (= 1 (count (:signals status))))
       (is (= 1 (count (:pending-improvements status)))))))
-
-(deftest test-get-meta-loop-status-without-operator
-  (testing "get-meta-loop-status handles missing operator"
-    (let [reporting (reporting/create-reporting-service {})
-          status (reporting/get-meta-loop-status reporting)]
-      
-      (is (map? status))
-      (is (empty? (:signals status)))
-      (is (empty? (:pending-improvements status))))))
-
-;------------------------------------------------------------------------------ Layer 5
-;; Subscription tests
-
-(deftest test-subscribe-and-unsubscribe
-  (testing "subscribe creates subscription and unsubscribe removes it"
-    (let [[logger entries] (log/collecting-logger)
-          reporting (reporting/create-reporting-service {:logger logger})
-          events (atom [])
-          callback (fn [event] (swap! events conj event))
-          sub-id (reporting/subscribe reporting #{:workflow-events} callback)]
-      
-      (is (uuid? sub-id))
-      
-      ;; Check subscription logged
-      (is (some #(= :reporting/subscription-created (:log/event %)) @entries))
-      
-      ;; Unsubscribe
-      (is (true? (reporting/unsubscribe reporting sub-id)))
-      
-      ;; Check unsubscribe logged
-      (is (some #(= :reporting/subscription-removed (:log/event %)) @entries)))))
-
-(deftest test-poll-events
-  (testing "poll-events returns empty for new subscription"
-    (let [reporting (reporting/create-reporting-service {})
-          callback (fn [_event] nil)
-          sub-id (reporting/subscribe reporting #{:workflow-events} callback)
-          events (reporting/poll-events reporting sub-id)]
-      
-      (is (empty? events)))))
-
-(deftest test-poll-events-nonexistent-subscription
-  (testing "poll-events returns empty for nonexistent subscription"
-    (let [reporting (reporting/create-reporting-service {})
-          events (reporting/poll-events reporting (random-uuid))]
-      
-      (is (empty? events)))))

--- a/components/reporting/test/ai/miniforge/reporting/interface_test.clj
+++ b/components/reporting/test/ai/miniforge/reporting/interface_test.clj
@@ -73,7 +73,7 @@
   (testing "get-system-status handles missing components gracefully"
     (let [reporting (reporting/create-reporting-service {})
           status (reporting/get-system-status reporting)]
-      
+
       (is (map? status))
       (is (= 0 (get-in status [:workflows :active])))
       (is (= 0 (get-in status [:resources :tokens-used])))
@@ -83,7 +83,7 @@
   (testing "get-meta-loop-status handles missing operator"
     (let [reporting (reporting/create-reporting-service {})
           status (reporting/get-meta-loop-status reporting)]
-      
+
       (is (map? status))
       (is (empty? (:signals status)))
       (is (empty? (:pending-improvements status))))))
@@ -96,15 +96,15 @@
           events (atom [])
           callback (fn [event] (swap! events conj event))
           sub-id (reporting/subscribe reporting #{:workflow-events} callback)]
-      
+
       (is (uuid? sub-id))
-      
+
       ;; Check subscription logged
       (is (some #(= :reporting/subscription-created (:log/event %)) @entries))
-      
+
       ;; Unsubscribe
       (is (true? (reporting/unsubscribe reporting sub-id)))
-      
+
       ;; Check unsubscribe logged
       (is (some #(= :reporting/subscription-removed (:log/event %)) @entries)))))
 
@@ -114,14 +114,14 @@
           callback (fn [_event] nil)
           sub-id (reporting/subscribe reporting #{:workflow-events} callback)
           events (reporting/poll-events reporting sub-id)]
-      
+
       (is (empty? events)))))
 
 (deftest ^{:stratum 0} test-poll-events-nonexistent-subscription
   (testing "poll-events returns empty for nonexistent subscription"
     (let [reporting (reporting/create-reporting-service {})
           events (reporting/poll-events reporting (random-uuid))]
-      
+
       (is (empty? events)))))
 
 ;------------------------------------------------------------------------------ Layer 1
@@ -137,22 +137,22 @@
                       :operator-component op-component
                       :logger logger})
           status (reporting/get-system-status reporting)]
-      
+
       (is (map? status))
       (is (contains? status :workflows))
       (is (contains? status :resources))
       (is (contains? status :meta-loop))
       (is (contains? status :alerts))
-      
+
       ;; Check workflow counts
       (is (= 1 (get-in status [:workflows :active])))
       (is (= 1 (get-in status [:workflows :completed])))
       (is (= 1 (get-in status [:workflows :failed])))
-      
+
       ;; Check resource metrics
       (is (= 1700 (get-in status [:resources :tokens-used])))
       (is (= 0.085 (get-in status [:resources :cost-usd])))
-      
+
       ;; Check meta-loop status
       (is (= 1 (get-in status [:meta-loop :pending-improvements]))))))
 
@@ -163,7 +163,7 @@
           reporting (reporting/create-reporting-service
                      {:workflow-component wf-component})
           workflows (reporting/get-workflow-list reporting)]
-      
+
       (is (= 3 (count workflows)))
       (is (every? #(contains? % :workflow/id) workflows))
       (is (every? #(contains? % :workflow/status) workflows))
@@ -175,16 +175,16 @@
           reporting (reporting/create-reporting-service
                      {:workflow-component wf-component})
           running-workflows (reporting/get-workflow-list reporting {:status :running})]
-      
+
       (is (= 1 (count running-workflows)))
       (is (= :running (:workflow/status (first running-workflows))))))
-  
+
   (testing "get-workflow-list filters by phase"
     (let [wf-component (create-mock-workflow-component)
           reporting (reporting/create-reporting-service
                      {:workflow-component wf-component})
           impl-workflows (reporting/get-workflow-list reporting {:phase :implement})]
-      
+
       (is (= 1 (count impl-workflows)))
       (is (= :implement (:workflow/phase (first impl-workflows)))))))
 
@@ -194,7 +194,7 @@
           reporting (reporting/create-reporting-service
                      {:workflow-component wf-component})
           workflows (reporting/get-workflow-list reporting {:limit 2})]
-      
+
       (is (= 2 (count workflows))))))
 
 ;; Workflow detail tests
@@ -206,7 +206,7 @@
           workflows (reporting/get-workflow-list reporting)
           workflow-id (:workflow/id (first workflows))
           detail (reporting/get-workflow-detail reporting workflow-id)]
-      
+
       (is (map? detail))
       (is (contains? detail :header))
       (is (contains? detail :timeline))
@@ -220,7 +220,7 @@
           reporting (reporting/create-reporting-service
                      {:workflow-component wf-component})
           detail (reporting/get-workflow-detail reporting (random-uuid))]
-      
+
       (is (nil? detail)))))
 
 ;; Meta-loop status tests
@@ -230,11 +230,11 @@
           reporting (reporting/create-reporting-service
                      {:operator-component op-component})
           status (reporting/get-meta-loop-status reporting)]
-      
+
       (is (map? status))
       (is (contains? status :signals))
       (is (contains? status :pending-improvements))
       (is (contains? status :recent-improvements))
-      
+
       (is (= 1 (count (:signals status))))
       (is (= 1 (count (:pending-improvements status)))))))

--- a/components/reporting/test/ai/miniforge/reporting/views_test.clj
+++ b/components/reporting/test/ai/miniforge/reporting/views_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.reporting.views-test
   "Tests for reporting view renderers."
   (:require
@@ -28,9 +27,9 @@
    [ai.miniforge.reporting.views.edn :as edn]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Test data
 
-(def sample-system-status
+;; Test data
+(def ^{:stratum 0} sample-system-status
   {:workflows {:active 2 :pending 1 :completed 10 :failed 1}
    :resources {:tokens-used 5000 :cost-usd 0.25}
    :meta-loop {:status :active :pending-improvements 3}
@@ -38,7 +37,7 @@
              :severity :error
              :message "1 failed workflow(s)"}]})
 
-(def sample-workflows
+(def ^{:stratum 0} sample-workflows
   [{:workflow/id #uuid "12345678-1234-1234-1234-123456789012"
     :workflow/status :running
     :workflow/phase :implement
@@ -48,7 +47,7 @@
     :workflow/phase :done
     :workflow/created-at 1234567890000}])
 
-(def sample-workflow-detail
+(def ^{:stratum 0} sample-workflow-detail
   {:header {:id #uuid "12345678-1234-1234-1234-123456789012"
             :status :running
             :phase :implement
@@ -65,7 +64,7 @@
                 :created-at 1234567890000}]
    :logs []})
 
-(def sample-meta-loop
+(def ^{:stratum 0} sample-meta-loop
   {:signals [{:signal/id #uuid "11111111-1111-1111-1111-111111111111"
               :signal/type :workflow-failed
               :signal/timestamp 1234567890000}]
@@ -75,10 +74,8 @@
                            :improvement/rationale "Add validation rule"}]
    :recent-improvements []})
 
-;------------------------------------------------------------------------------ Layer 1
 ;; ANSI helper tests
-
-(deftest test-ansi
+(deftest ^{:stratum 0} test-ansi
   (testing "ansi wraps text with color codes"
     (let [colored (fmt/ansi :green "test")]
       (is (str/includes? colored "test"))
@@ -89,10 +86,8 @@
     (is (= :yellow (fmt/status-color :pending)))
     (is (= :red (fmt/status-color :failed)))))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Box drawing tests
-
-(deftest test-draw-box
+(deftest ^{:stratum 0} test-draw-box
   (testing "draw-box creates box around content"
     (let [box (fmt/draw-box "Title" "Content line 1\nContent line 2" 40)]
       (is (str/includes? box "Title"))
@@ -102,16 +97,14 @@
       (is (str/includes? box "└"))
       (is (str/includes? box "│")))))
 
-(deftest test-draw-separator
+(deftest ^{:stratum 0} test-draw-separator
   (testing "draw-separator creates horizontal line"
     (let [sep (fmt/draw-separator 20)]
       (is (= 20 (count sep)))
       (is (every? #(= % \─) sep)))))
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Table formatting tests
-
-(deftest test-format-table
+(deftest ^{:stratum 0} test-format-table
   (testing "format-table creates aligned table"
     (let [headers ["Col1" "Col2" "Col3"]
           rows [["A" "B" "C"]
@@ -125,10 +118,47 @@
       (is (str/includes? table "Longest"))
       (is (str/includes? table "─")))))
 
-;------------------------------------------------------------------------------ Layer 4
-;; System overview renderer tests
+(deftest ^{:stratum 0} test-render-workflow-list-empty
+  (testing "render-workflow-list handles empty list"
+    (let [output (wf/render-workflow-list [])]
+      
+      (is (str/includes? output "No workflows found")))))
 
-(deftest test-render-system-overview
+(deftest ^{:stratum 0} test-render-workflow-detail-not-found
+  (testing "render-workflow-detail handles nil"
+    (let [output (wf/render-workflow-detail nil)]
+      
+      (is (str/includes? output "Workflow not found")))))
+
+(deftest ^{:stratum 0} test-render-meta-loop-empty
+  (testing "render-meta-loop handles empty data"
+    (let [status {:signals []
+                  :pending-improvements []
+                  :recent-improvements []}
+          output (meta/render-meta-loop status)]
+      
+      (is (str/includes? output "No recent signals"))
+      (is (str/includes? output "No pending improvements"))
+      (is (str/includes? output "No recent improvements")))))
+
+;; EDN renderer tests
+(deftest ^{:stratum 0} test-render-edn
+  (testing "render-edn outputs valid EDN"
+    (let [data {:foo "bar" :baz 42}
+          output (edn/render-edn data)]
+      
+      (is (str/includes? output ":foo"))
+      (is (str/includes? output "bar"))
+      (is (str/includes? output ":baz"))
+      (is (str/includes? output "42"))
+      
+      ;; Verify it's parseable EDN
+      (is (map? (read-string output))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; System overview renderer tests
+(deftest ^{:stratum 1} test-render-system-overview
   (testing "render-system-overview creates formatted output"
     (let [output (sys/render-system-overview sample-system-status)]
       
@@ -143,17 +173,15 @@
       (is (str/includes? output "5000"))
       (is (str/includes? output "$0.2500")))))
 
-(deftest test-render-system-overview-no-alerts
+(deftest ^{:stratum 1} test-render-system-overview-no-alerts
   (testing "render-system-overview handles empty alerts"
     (let [status (assoc sample-system-status :alerts [])
           output (sys/render-system-overview status)]
       
       (is (str/includes? output "No alerts")))))
 
-;------------------------------------------------------------------------------ Layer 5
 ;; Workflow list renderer tests
-
-(deftest test-render-workflow-list
+(deftest ^{:stratum 1} test-render-workflow-list
   (testing "render-workflow-list creates table"
     (let [output (wf/render-workflow-list sample-workflows)]
       
@@ -166,16 +194,8 @@
       (is (str/includes? output "running"))
       (is (str/includes? output "implement")))))
 
-(deftest test-render-workflow-list-empty
-  (testing "render-workflow-list handles empty list"
-    (let [output (wf/render-workflow-list [])]
-      
-      (is (str/includes? output "No workflows found")))))
-
-;------------------------------------------------------------------------------ Layer 6
 ;; Workflow detail renderer tests
-
-(deftest test-render-workflow-detail
+(deftest ^{:stratum 1} test-render-workflow-detail
   (testing "render-workflow-detail creates detailed view"
     (let [output (wf/render-workflow-detail sample-workflow-detail)]
       
@@ -189,16 +209,8 @@
       (is (str/includes? output "implement"))
       (is (str/includes? output "Implement feature")))))
 
-(deftest test-render-workflow-detail-not-found
-  (testing "render-workflow-detail handles nil"
-    (let [output (wf/render-workflow-detail nil)]
-      
-      (is (str/includes? output "Workflow not found")))))
-
-;------------------------------------------------------------------------------ Layer 7
 ;; Meta-loop renderer tests
-
-(deftest test-render-meta-loop
+(deftest ^{:stratum 1} test-render-meta-loop
   (testing "render-meta-loop creates dashboard"
     (let [output (meta/render-meta-loop sample-meta-loop)]
       
@@ -209,30 +221,3 @@
       (is (str/includes? output "workflow-failed"))
       (is (str/includes? output "rule-addition"))
       (is (str/includes? output "0.85")))))
-
-(deftest test-render-meta-loop-empty
-  (testing "render-meta-loop handles empty data"
-    (let [status {:signals []
-                  :pending-improvements []
-                  :recent-improvements []}
-          output (meta/render-meta-loop status)]
-      
-      (is (str/includes? output "No recent signals"))
-      (is (str/includes? output "No pending improvements"))
-      (is (str/includes? output "No recent improvements")))))
-
-;------------------------------------------------------------------------------ Layer 8
-;; EDN renderer tests
-
-(deftest test-render-edn
-  (testing "render-edn outputs valid EDN"
-    (let [data {:foo "bar" :baz 42}
-          output (edn/render-edn data)]
-      
-      (is (str/includes? output ":foo"))
-      (is (str/includes? output "bar"))
-      (is (str/includes? output ":baz"))
-      (is (str/includes? output "42"))
-      
-      ;; Verify it's parseable EDN
-      (is (map? (read-string output))))))

--- a/components/reporting/test/ai/miniforge/reporting/views_test.clj
+++ b/components/reporting/test/ai/miniforge/reporting/views_test.clj
@@ -80,7 +80,7 @@
     (let [colored (fmt/ansi :green "test")]
       (is (str/includes? colored "test"))
       (is (str/includes? colored "\033["))))
-  
+
   (testing "status-color returns appropriate color"
     (is (= :green (fmt/status-color :completed)))
     (is (= :yellow (fmt/status-color :pending)))
@@ -110,7 +110,7 @@
           rows [["A" "B" "C"]
                 ["Long" "Longer" "Longest"]]
           table (fmt/format-table headers rows)]
-      
+
       (is (str/includes? table "Col1"))
       (is (str/includes? table "Col2"))
       (is (str/includes? table "Col3"))
@@ -121,13 +121,13 @@
 (deftest ^{:stratum 0} test-render-workflow-list-empty
   (testing "render-workflow-list handles empty list"
     (let [output (wf/render-workflow-list [])]
-      
+
       (is (str/includes? output "No workflows found")))))
 
 (deftest ^{:stratum 0} test-render-workflow-detail-not-found
   (testing "render-workflow-detail handles nil"
     (let [output (wf/render-workflow-detail nil)]
-      
+
       (is (str/includes? output "Workflow not found")))))
 
 (deftest ^{:stratum 0} test-render-meta-loop-empty
@@ -136,7 +136,7 @@
                   :pending-improvements []
                   :recent-improvements []}
           output (meta/render-meta-loop status)]
-      
+
       (is (str/includes? output "No recent signals"))
       (is (str/includes? output "No pending improvements"))
       (is (str/includes? output "No recent improvements")))))
@@ -146,12 +146,12 @@
   (testing "render-edn outputs valid EDN"
     (let [data {:foo "bar" :baz 42}
           output (edn/render-edn data)]
-      
+
       (is (str/includes? output ":foo"))
       (is (str/includes? output "bar"))
       (is (str/includes? output ":baz"))
       (is (str/includes? output "42"))
-      
+
       ;; Verify it's parseable EDN
       (is (map? (read-string output))))))
 
@@ -161,12 +161,12 @@
 (deftest ^{:stratum 1} test-render-system-overview
   (testing "render-system-overview creates formatted output"
     (let [output (sys/render-system-overview sample-system-status)]
-      
+
       (is (str/includes? output "WORKFLOWS"))
       (is (str/includes? output "RESOURCES"))
       (is (str/includes? output "META-LOOP"))
       (is (str/includes? output "ALERTS"))
-      
+
       (is (str/includes? output "Active:"))
       (is (str/includes? output "2"))
       (is (str/includes? output "Tokens Used:"))
@@ -177,19 +177,19 @@
   (testing "render-system-overview handles empty alerts"
     (let [status (assoc sample-system-status :alerts [])
           output (sys/render-system-overview status)]
-      
+
       (is (str/includes? output "No alerts")))))
 
 ;; Workflow list renderer tests
 (deftest ^{:stratum 1} test-render-workflow-list
   (testing "render-workflow-list creates table"
     (let [output (wf/render-workflow-list sample-workflows)]
-      
+
       (is (str/includes? output "ID"))
       (is (str/includes? output "Status"))
       (is (str/includes? output "Phase"))
       (is (str/includes? output "Created"))
-      
+
       (is (str/includes? output "12345678"))
       (is (str/includes? output "running"))
       (is (str/includes? output "implement")))))
@@ -198,12 +198,12 @@
 (deftest ^{:stratum 1} test-render-workflow-detail
   (testing "render-workflow-detail creates detailed view"
     (let [output (wf/render-workflow-detail sample-workflow-detail)]
-      
+
       (is (str/includes? output "WORKFLOW HEADER"))
       (is (str/includes? output "TIMELINE"))
       (is (str/includes? output "CURRENT TASK"))
       (is (str/includes? output "ARTIFACTS"))
-      
+
       (is (str/includes? output "12345678-1234-1234-1234-123456789012"))
       (is (str/includes? output "running"))
       (is (str/includes? output "implement"))
@@ -213,11 +213,11 @@
 (deftest ^{:stratum 1} test-render-meta-loop
   (testing "render-meta-loop creates dashboard"
     (let [output (meta/render-meta-loop sample-meta-loop)]
-      
+
       (is (str/includes? output "RECENT SIGNALS"))
       (is (str/includes? output "PENDING IMPROVEMENTS"))
       (is (str/includes? output "RECENT IMPROVEMENTS"))
-      
+
       (is (str/includes? output "workflow-failed"))
       (is (str/includes? output "rule-addition"))
       (is (str/includes? output "0.85")))))

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-reporting.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-reporting.md
@@ -1,0 +1,113 @@
+# fix: stratum-lint autofix for components/reporting (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over `components/reporting` (`src` + `test`) to
+replace decorative `Layer N` headings with ones derived from the file's
+actual same-file reference graph, and tags every top-level def/deftest with
+`^{:stratum n}` metadata. Mechanical: no logic changes. One of the
+per-component Wave 1 PRs from `work/stratum-lint-baseline-2026-07-24.md`.
+
+## Motivation
+
+`components/reporting` carried 4 findings under the baseline's cargo-cult
+diagnosis, all `SL003` (heading claims more distinct layers than the
+3-layer budget): `core.clj` (claimed 6), `interface.clj` (claimed 5),
+`interface_test.clj` (claimed 6), `views_test.clj` (claimed 9). Zero
+`SL001` findings, so no upward-reference/cycle risk to reason about before
+running the mechanical fixer.
+
+## Changes in Detail
+
+Ran, over the whole component:
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "14965e1ee1a175bd00f637d9a9d5f7d27e62b73f" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/reporting
+```
+
+All 11 files rewritten (`--fix` normalizes every file in the component,
+not just the ones with findings): `core.clj`, `interface.clj`,
+`protocol.clj`, `views/edn.clj`, `views/formatting.clj`, `views/meta.clj`,
+`views/system.clj`, `views/workflow.clj`, `core_test.clj`,
+`interface_test.clj`, `views_test.clj`.
+
+Notable collapses, all matching the real reference graph:
+
+- `interface.clj`'s defs each delegate to another namespace
+  (`proto/`, `core/`, `view-*`) and never call each other in-file, so all
+  6 defs (previously spread across 5 decorative layers) land at real
+  Layer 0.
+- `views/formatting.clj`'s `format-table` doesn't call any of `ansi`,
+  `draw-box`, `draw-separator`, or the color/box-char tables, so it moves
+  from the old Layer 2 down to real Layer 0 alongside the other
+  no-same-file-dependency defs; `ansi`/`draw-box`/`draw-separator` (which
+  do reference the data tables) land at Layer 1.
+- `core.clj` collapses from 6 decorative layers to 4 real ones
+  (`safe-get`/`count-by-status`/`create-subscription`/`build-workflow-timeline`/`get-workflow-logs`
+  at 0; the `aggregate-*`/`collect-alerts`/`get-workflow-artifacts` helpers
+  that call them at 1; `ReportingServiceImpl` at 2; the
+  `create-reporting-service` constructor at 3).
+- `interface_test.clj` and `views_test.clj` reorder `deftest` forms by
+  whether they call same-file fixtures/sample data (Layer 1) or not
+  (Layer 0), collapsing 6 and 9 decorative layers to 2 real ones each.
+
+No line of executable code changed; diffs are heading text, `^{:stratum
+n}` metadata, and def/deftest reordering only. The one same-line trailing
+comment in the component (`(atom {})  ; subscriptions` in
+`create-reporting-service`) stayed attached to its own def; no stale
+double-semicolon banner text survived; the component has no
+`defmethod`/`defmulti`, so the multimethod-stratum bug this pin already
+fixes doesn't apply here.
+
+`core.clj` now reports `SL003`: 4 real layers (0–3) against the 3-layer
+budget. This is the same finding as before the fix (it already reported
+`SL003` pre-fix, at a decorative count of 6) — `--fix` corrected the count
+to the real depth, it didn't introduce a new violation. Deferred to Wave 2
+(real namespace split), consistent with how prior Wave 1 PRs (`bb-config`,
+`decision`, `compliance-scanner`) handled the same situation.
+
+## Testing Plan
+
+1. Ran plain (non-`--fix`) `stratum-lint` before the fix — reproduced the
+   baseline's 4 `SL003` findings exactly; confirmed zero `SL001` findings
+   before proceeding.
+2. Ran `--fix`, then a second `--fix` pass immediately after — zero diff,
+   confirms idempotency.
+3. Read the full diff for all 11 changed files. Confirmed only heading
+   text, `^{:stratum n}` metadata, and def/deftest reordering changed; no
+   same-line trailing comment was displaced onto the wrong def; no stale
+   `;;----`-style banner survived.
+4. `clj-kondo --lint components/reporting`: 0 errors, 0 warnings.
+5. Ran `ai.miniforge.reporting.core-test`, `ai.miniforge.reporting.interface-test`,
+   and `ai.miniforge.reporting.views-test` directly via `clojure -A:test`:
+   31 tests, 115 assertions, 0 failures, 0 errors.
+6. Re-ran plain `stratum-lint` after the fix: `SL001`/`SL002`/`SL004`
+   clear across the component. `SL003` remains on `core.clj` (4 real
+   layers) — expected, tracked as Wave 2, not a defect in this PR.
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+change — comment/metadata/order-only. Pre-commit's `lint:stratum`
+autofixer keeps this component clean going forward; `core.clj`'s `SL003`
+stays advisory (`MINIFORGE_STRATUM_BUDGET_MODE=warn` at commit time) until
+Wave 2 splits it.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+- Follow-on: Wave 2 namespace split for
+  `components/reporting/src/ai/miniforge/reporting/core.clj` (4 real
+  layers, over the 3-layer budget)
+
+## Checklist
+
+- [x] Confirmed zero `SL001` findings before running `--fix`
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Second `--fix` pass confirms idempotency (zero diff)
+- [x] Diff read in full for all 11 changed files; mechanical-only
+- [x] `clj-kondo` clean (0 errors, 0 warnings)
+- [x] Component tests pass (31 tests, 115 assertions, 0 failures/errors)
+- [x] Plain lint re-run post-fix: zero findings except `SL003` (`core.clj`,
+      documented above, tracked as Wave 2)
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
## Summary

- Runs `stratum-lint --fix` over `components/reporting` (`src` + `test`), replacing decorative `Layer N` headings (4 pre-existing `SL003` findings, zero `SL001`) with ones derived from the file's real same-file reference graph, and tagging every top-level def/deftest with `^{:stratum n}` metadata.
- Mechanical only: no logic changes, only heading text / metadata / def-deftest reordering.
- `core.clj` still reports `SL003` post-fix (4 real layers vs the 3-layer budget, down from a decorative claim of 6) — deferred to Wave 2 as a namespace split, not fixed here.

Full details in `docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-reporting.md`.

## Test plan

- [x] Confirmed zero `SL001` findings before running `--fix`
- [x] `--fix` run over the whole component; second `--fix` pass confirms idempotency (zero diff)
- [x] Full diff read for all 11 changed files — mechanical only, no comment/logic corruption
- [x] `clj-kondo --lint components/reporting`: 0 errors, 0 warnings
- [x] `ai.miniforge.reporting.{core,interface,views}-test` via `clojure -A:test`: 31 tests, 115 assertions, 0 failures/errors
- [x] Plain lint re-run post-fix: zero findings except the pre-existing `SL003` on `core.clj` (tracked as Wave 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)