### PR TITLE
fix: stratum-lint autofix for components/schema (Wave 1)

### DIFF
--- a/components/schema/src/ai/miniforge/schema/core.clj
+++ b/components/schema/src/ai/miniforge/schema/core.clj
@@ -15,40 +15,43 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.schema.core
   "Core domain schemas for miniforge.
-   Layer 0: Base types and registries
-   Layer 1: Composite schemas (Agent, Task, Artifact, Workflow)"
+   Layer 0: Base enum vocabularies, severities, and normalize-severity
+   Layer 1: severity-order and the shared malli registry
+   Layer 2: compare-severity/Severity and standalone composite schemas
+            (Agent, TaskConstraints, TaskResult, Metrics, MetaAgentConfig, ...)
+   Layer 3: more-severe and top-level composites depending on Layer 2
+            (Task, Artifact, Workflow, MetaCoordinatorState)"
   (:require
    [malli.core :as m]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Base types and registries
 
-(def agent-roles
+;; Base types and registries
+(def ^{:stratum 0} agent-roles
   [:planner :architect :implementer :tester :reviewer :sre :security :release :historian :operator])
 
-(def meta-agent-roles
+(def ^{:stratum 0} meta-agent-roles
   "Meta-agent roles for workflow monitoring and control."
   [:progress-monitor :test-quality :conflict-detector :resource-manager :evidence-collector])
 
-(def task-types
+(def ^{:stratum 0} task-types
   [:plan :design :implement :test :review :deploy])
 
-(def task-statuses
+(def ^{:stratum 0} task-statuses
   [:pending :running :completed :failed :blocked])
 
-(def artifact-types
+(def ^{:stratum 0} artifact-types
   [:spec :plan :adr :code :test :review :manifest :image :telemetry :incident])
 
-(def workflow-phases
+(def ^{:stratum 0} workflow-phases
   [:plan :design :implement :verify :review :release :observe])
 
-(def workflow-statuses
+(def ^{:stratum 0} workflow-statuses
   [:pending :running :paused :completed :failed :cancelled])
 
-(def severities
+(def ^{:stratum 0} severities
   "Canonical severity levels, most to least severe. The single source of truth
    for how-bad-is-it across the codebase: rule severity (policy-pack), runtime
    violation/attention severity (supervisory, evidence-bundle), and any display
@@ -57,12 +60,7 @@
    `:high`/`:low` via `normalize-severity`."
   [:critical :high :medium :low :info])
 
-(def severity-order
-  "Rank per severity, 0 = most severe. Derived from `severities` so the order
-   table cannot drift from the enum."
-  (zipmap severities (range)))
-
-(defn normalize-severity
+(defn ^{:stratum 0} normalize-severity
   "Coerce a legacy severity keyword to the canonical enum: `:major` → `:high`,
    `:minor` → `:low`; every canonical value (and anything else) is returned
    unchanged. Lets a producer or reader tolerate a pre-migration value."
@@ -72,19 +70,14 @@
     :minor :low
     severity))
 
-(defn compare-severity
-  "Compare two severities. Negative when `a` is more severe than `b`, positive
-   when less, 0 when equal. Unknown severities sort last."
-  [a b]
-  (- (get severity-order a 99)
-     (get severity-order b 99)))
+;------------------------------------------------------------------------------ Layer 1
 
-(defn more-severe
-  "Return the more severe of two severities."
-  [a b]
-  (if (neg? (compare-severity a b)) a b))
+(def ^{:stratum 1} severity-order
+  "Rank per severity, 0 = most severe. Derived from `severities` so the order
+   table cannot drift from the enum."
+  (zipmap severities (range)))
 
-(def registry
+(def ^{:stratum 1} registry
   "Malli registry for base schema types."
   {;; Identifiers
    :id/uuid        uuid?
@@ -124,15 +117,22 @@
    :common/non-neg-int [:int {:min 0}]
    :common/pos-number [:double {:min 0.0}]})
 
-(def Severity
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} compare-severity
+  "Compare two severities. Negative when `a` is more severe than `b`, positive
+   when less, 0 when equal. Unknown severities sort last."
+  [a b]
+  (- (get severity-order a 99)
+     (get severity-order b 99)))
+
+(def ^{:stratum 2} Severity
   "Malli enum for a canonical severity level (see `severities`). Reuses the
    `:severity` registry entry so there is one constructed enum, not two copies."
   (:severity registry))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Composite schemas
-
-(def Agent
+(def ^{:stratum 2} Agent
   "Schema for an AI agent.
    Agents are pure functions: (context, task) -> (artifacts, decisions, signals)"
   [:map {:registry registry}
@@ -150,7 +150,7 @@
        [:tokens {:optional true} :common/non-neg-int]
        [:cost-usd {:optional true} :common/pos-number]]]]]])
 
-(def TaskConstraints
+(def ^{:stratum 2} TaskConstraints
   "Schema for task execution constraints."
   [:map {:registry registry}
    [:budget {:optional true}
@@ -162,7 +162,7 @@
    [:policies {:optional true} [:vector keyword?]]
    [:max-iterations {:optional true} :common/non-neg-int]])
 
-(def TaskResult
+(def ^{:stratum 2} TaskResult
   "Schema for task execution result."
   [:map {:registry registry}
    [:outcome [:enum :success :failure :escalated]]
@@ -175,7 +175,59 @@
      [:cost-usd {:optional true} :common/pos-number]
      [:iterations {:optional true} :common/non-neg-int]]]])
 
-(def Task
+(def ^{:stratum 2} ArtifactOrigin
+  "Schema for artifact provenance origin."
+  [:map {:registry registry}
+   [:intent-id {:optional true} :id/uuid]
+   [:agent-id {:optional true} :agent/id]
+   [:task-id {:optional true} :task/id]])
+
+(def ^{:stratum 2} WorkflowBudget
+  "Schema for workflow budget allocation."
+  [:map {:registry registry}
+   [:tokens {:optional true} :common/non-neg-int]
+   [:cost-usd {:optional true} :common/pos-number]
+   [:duration-ms {:optional true} :common/non-neg-int]])
+
+(def ^{:stratum 2} Metrics
+  "Schema for an agent/phase result's `:metrics` map. `:tokens` and
+   `:duration-ms` are REQUIRED and non-nil — they are consumed by cost and
+   accumulation arithmetic, so a missing or nil value is a boundary violation
+   (it throws a message-less NPE downstream). `:non-neg-int` already rejects a
+   present nil; making the keys required also rejects an absent one."
+  [:map {:registry registry}
+   [:tokens :common/non-neg-int]
+   [:duration-ms :common/non-neg-int]
+   [:cost-usd {:optional true} :common/pos-number]
+   [:iterations {:optional true} :common/non-neg-int]])
+
+(def ^{:stratum 2} MetaAgentConfig
+  "Schema for meta-agent configuration."
+  [:map {:registry registry}
+   [:id :meta-agent/id]
+   [:name :id/string]
+   [:can-halt? boolean?]
+   [:check-interval-ms :common/non-neg-int]
+   [:priority :meta-agent/priority]
+   [:enabled? boolean?]])
+
+(def ^{:stratum 2} MetaAgentHealthCheck
+  "Schema for meta-agent health check result."
+  [:map {:registry registry}
+   [:status :meta-agent/status]
+   [:agent/id :meta-agent/id]
+   [:message :id/string]
+   [:data {:optional true} [:map-of keyword? any?]]
+   [:checked-at :common/timestamp]])
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} more-severe
+  "Return the more severe of two severities."
+  [a b]
+  (if (neg? (compare-severity a b)) a b))
+
+(def ^{:stratum 3} Task
   "Schema for a unit of work assigned to an agent."
   [:map {:registry registry}
    [:task/id :task/id]
@@ -189,14 +241,7 @@
    [:task/constraints {:optional true} TaskConstraints]
    [:task/result {:optional true} TaskResult]])
 
-(def ArtifactOrigin
-  "Schema for artifact provenance origin."
-  [:map {:registry registry}
-   [:intent-id {:optional true} :id/uuid]
-   [:agent-id {:optional true} :agent/id]
-   [:task-id {:optional true} :task/id]])
-
-(def Artifact
+(def ^{:stratum 3} Artifact
   "Schema for a versioned work product with provenance."
   [:map {:registry registry}
    [:artifact/id :artifact/id]
@@ -209,26 +254,7 @@
    [:artifact/metadata {:optional true} [:map-of keyword? any?]]
    [:artifact/created-at {:optional true} :common/timestamp]])
 
-(def WorkflowBudget
-  "Schema for workflow budget allocation."
-  [:map {:registry registry}
-   [:tokens {:optional true} :common/non-neg-int]
-   [:cost-usd {:optional true} :common/pos-number]
-   [:duration-ms {:optional true} :common/non-neg-int]])
-
-(def Metrics
-  "Schema for an agent/phase result's `:metrics` map. `:tokens` and
-   `:duration-ms` are REQUIRED and non-nil — they are consumed by cost and
-   accumulation arithmetic, so a missing or nil value is a boundary violation
-   (it throws a message-less NPE downstream). `:non-neg-int` already rejects a
-   present nil; making the keys required also rejects an absent one."
-  [:map {:registry registry}
-   [:tokens :common/non-neg-int]
-   [:duration-ms :common/non-neg-int]
-   [:cost-usd {:optional true} :common/pos-number]
-   [:iterations {:optional true} :common/non-neg-int]])
-
-(def Workflow
+(def ^{:stratum 3} Workflow
   "Schema for an outer loop SDLC delivery instance."
   [:map {:registry registry}
    [:workflow/id :workflow/id]
@@ -252,26 +278,7 @@
       [:enabled? {:optional true} boolean?]
       [:config {:optional true} [:map-of keyword? any?]]]]]])
 
-(def MetaAgentConfig
-  "Schema for meta-agent configuration."
-  [:map {:registry registry}
-   [:id :meta-agent/id]
-   [:name :id/string]
-   [:can-halt? boolean?]
-   [:check-interval-ms :common/non-neg-int]
-   [:priority :meta-agent/priority]
-   [:enabled? boolean?]])
-
-(def MetaAgentHealthCheck
-  "Schema for meta-agent health check result."
-  [:map {:registry registry}
-   [:status :meta-agent/status]
-   [:agent/id :meta-agent/id]
-   [:message :id/string]
-   [:data {:optional true} [:map-of keyword? any?]]
-   [:checked-at :common/timestamp]])
-
-(def MetaCoordinatorState
+(def ^{:stratum 3} MetaCoordinatorState
   "Schema for meta-agent coordinator state."
   [:map {:registry registry}
    [:status :meta-agent/status]

--- a/components/schema/src/ai/miniforge/schema/core.clj
+++ b/components/schema/src/ai/miniforge/schema/core.clj
@@ -28,7 +28,7 @@
 
 ;------------------------------------------------------------------------------ Layer 0
 
-;; Base types and registries
+;; Base enum vocabularies and severity helpers
 (def ^{:stratum 0} agent-roles
   [:planner :architect :implementer :tester :reviewer :sre :security :release :historian :operator])
 

--- a/components/schema/src/ai/miniforge/schema/interface.clj
+++ b/components/schema/src/ai/miniforge/schema/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.schema.interface
   "Public API for the schema component.
    Provides validation functions and schema access for domain types."
@@ -28,222 +27,220 @@
    [ai.miniforge.schema.supervisory :as supervisory]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Schema re-exports (allow other components to reference schemas)
 
-(def Agent
+;; Schema re-exports (allow other components to reference schemas)
+(def ^{:stratum 0} Agent
   "Malli schema (open `:map` — no `{:closed true}`, so extra keys are accepted)
    for an AI agent: `:agent/id` (uuid) and `:agent/role` (enum) required;
    optional capabilities, memory, config.
    Pass to [[valid?]]/[[validate]]/[[validate-anomaly]] to check agent maps."
   core/Agent)
 
-(def Task
+(def ^{:stratum 0} Task
   "Malli `:map` schema for a unit of work: `:task/id`, `:task/type`,
    `:task/status` required; optional agent, io artifacts, parent/children,
    constraints, result. Use with the validation fns."
   core/Task)
 
-(def Artifact
+(def ^{:stratum 0} Artifact
   "Malli `:map` schema for a versioned work product with provenance:
    `:artifact/id`, `:artifact/type`, `:artifact/version` required; optional
    content, origin, lineage, metadata, created-at."
   core/Artifact)
 
-(def Workflow
+(def ^{:stratum 0} Workflow
   "Malli `:map` schema for an outer-loop SDLC delivery instance:
    `:workflow/id` and `:workflow/status` required; optional name, phase,
    priority, checkpoint, budget/consumed, spec-id, meta-agents."
   core/Workflow)
 
-(def TaskConstraints
+(def ^{:stratum 0} TaskConstraints
   "Malli `:map` schema for task execution constraints: optional budget
    (tokens/cost-usd/duration-ms), deadline, policies, max-iterations.
    Embedded under `:task/constraints` in [[Task]]."
   core/TaskConstraints)
 
-(def TaskResult
+(def ^{:stratum 0} TaskResult
   "Malli `:map` schema for task execution result: required `:outcome`
    (`:success`/`:failure`/`:escalated`); optional error, signals, metrics.
    Embedded under `:task/result` in [[Task]]."
   core/TaskResult)
 
-(def ArtifactOrigin
+(def ^{:stratum 0} ArtifactOrigin
   "Malli `:map` schema for artifact provenance: optional `:intent-id`,
    `:agent-id`, `:task-id`. Embedded under `:artifact/origin` in [[Artifact]]."
   core/ArtifactOrigin)
 
-(def WorkflowBudget
+(def ^{:stratum 0} WorkflowBudget
   "Malli `:map` schema for a workflow budget allocation: optional `:tokens`,
    `:cost-usd`, `:duration-ms`. Used for both `:workflow/budget` and
    `:workflow/consumed` in [[Workflow]]."
   core/WorkflowBudget)
 
-(def Metrics
+(def ^{:stratum 0} Metrics
   "Malli `:map` schema for an agent/phase result's `:metrics`: REQUIRED non-nil
    `:tokens` and `:duration-ms` (consumed by cost/accumulation arithmetic),
    optional `:cost-usd`, `:iterations`. Validate agent-result metrics against
    this at the phase-input boundary so a nil fails loud instead of NPE-ing."
   core/Metrics)
 
-(def LogEntry
+(def ^{:stratum 0} LogEntry
   "Malli `:map` schema for a structured EDN log entry. Required: `:log/id`,
    `:log/timestamp`, `:log/level`, `:log/category`, `:log/event`. Optional:
    message, context (`:ctx/*`), scenario, data, tracing, perf metrics."
   logging/LogEntry)
 
-(def Scenario
+(def ^{:stratum 0} Scenario
   "Malli `:map` schema for a test scenario definition: `:scenario/id`,
    `:scenario/name`, `:scenario/created-at`, `:scenario/status` required;
    optional tags, created-by, config, expected."
   logging/Scenario)
 
 ;; Supervisory entity schemas
-(def WorkflowRun
+(def ^{:stratum 0} WorkflowRun
   "Malli open `:map` schema for a supervisory workflow run: `:workflow/id`,
    `:workflow/key`, `:workflow/status`, `:workflow/phase`,
    `:workflow/started-at` required. Extra keys pass through."
   supervisory/WorkflowRun)
 
-(def PolicyEvaluation
+(def ^{:stratum 0} PolicyEvaluation
   "Malli open `:map` schema for a policy evaluation result: `:eval/id`,
    `:eval/pr-id`, `:eval/result`, `:eval/rules-applied`, `:eval/evaluated-at`
    required. Extra keys pass through."
   supervisory/PolicyEvaluation)
 
-(def PolicyViolation
+(def ^{:stratum 0} PolicyViolation
   "Malli open `:map` schema for a single policy violation: `:violation/id`,
    `:violation/eval-id`, `:violation/rule`, `:violation/category`,
    `:violation/severity` required. Extra keys pass through."
   supervisory/PolicyViolation)
 
-(def AttentionItem
+(def ^{:stratum 0} AttentionItem
   "Malli open `:map` schema for an item needing human oversight:
    `:attention/id`, `:attention/severity`, `:attention/summary`,
    `:attention/source-type`, `:attention/source-id` required. Extra keys pass."
   supervisory/AttentionItem)
 
-(def Waiver
+(def ^{:stratum 0} Waiver
   "Malli open `:map` schema for a human waiver of a violation: `:waiver/id`,
    `:waiver/eval-id`, `:waiver/actor`, `:waiver/reason`, `:waiver/created-at`
    required. Extra keys pass through."
   supervisory/Waiver)
 
-(def EvidenceBundle
+(def ^{:stratum 0} EvidenceBundle
   "Malli open `:map` schema for evidence collected during a workflow:
    `:evidence/id`, `:evidence/workflow-id`, `:evidence/entries` required.
    Extra keys pass through."
   supervisory/EvidenceBundle)
 
 ;; Enum value sets for programmatic access
-(def agent-roles
+(def ^{:stratum 0} agent-roles
   "Vector of canonical agent role keywords, ordered by implementation priority
    (`:planner`, `:architect`, `:implementer`, ...)."
   core/agent-roles)
 
-(def task-types
+(def ^{:stratum 0} task-types
   "Vector of task-type keywords (`:plan`, `:design`, `:implement`, `:test`,
    `:review`, `:deploy`)."
   core/task-types)
 
-(def task-statuses
+(def ^{:stratum 0} task-statuses
   "Vector of task-status keywords (`:pending`, `:running`, `:completed`,
    `:failed`, `:blocked`)."
   core/task-statuses)
 
-(def artifact-types
+(def ^{:stratum 0} artifact-types
   "Vector of artifact-type keywords (`:spec`, `:plan`, `:adr`, `:code`,
    `:test`, `:review`, `:manifest`, `:image`, `:telemetry`, `:incident`)."
   core/artifact-types)
 
-(def workflow-phases
+(def ^{:stratum 0} workflow-phases
   "Vector of outer-loop SDLC phase keywords (`:plan`, `:design`, `:implement`,
    `:verify`, `:review`, `:release`, `:observe`)."
   core/workflow-phases)
 
-(def workflow-statuses
+(def ^{:stratum 0} workflow-statuses
   "Vector of workflow-status keywords (`:pending`, `:running`, `:paused`,
    `:completed`, `:failed`, `:cancelled`)."
   core/workflow-statuses)
 
-(def severities
+(def ^{:stratum 0} severities
   "Canonical severity levels, most to least severe
    (`:critical :high :medium :low :info`). One source of truth for rule,
    violation, attention, and display severity."
   core/severities)
 
-(def Severity
+(def ^{:stratum 0} Severity
   "Malli enum schema for a canonical severity level."
   core/Severity)
 
-(def severity-order
+(def ^{:stratum 0} severity-order
   "Map from severity keyword to rank (0 = most severe), derived from
    `severities`."
   core/severity-order)
 
-(def normalize-severity
+(def ^{:stratum 0} normalize-severity
   "Coerce a legacy severity (`:major` → `:high`, `:minor` → `:low`) to the
    canonical enum; canonical/other values pass through unchanged."
   core/normalize-severity)
 
-(def compare-severity
+(def ^{:stratum 0} compare-severity
   "Compare two severities: negative when the first is more severe, positive when
    less, 0 when equal."
   core/compare-severity)
 
-(def more-severe
+(def ^{:stratum 0} more-severe
   "Return the more severe of two severities."
   core/more-severe)
 
-(def log-levels
+(def ^{:stratum 0} log-levels
   "Vector of log severity keywords, most to least verbose (`:trace`, `:debug`,
    `:info`, `:warn`, `:error`, `:fatal`)."
   logging/log-levels)
 
-(def log-categories
+(def ^{:stratum 0} log-categories
   "Vector of log category keywords (`:agent`, `:loop`, `:policy`, `:artifact`,
    `:system`)."
   logging/log-categories)
 
-(def all-events
+(def ^{:stratum 0} all-events
   "Vector of all known log-event keywords across the agent, loop, policy,
    artifact, and system taxonomies."
   logging/all-events)
 
-(def scenario-tags
+(def ^{:stratum 0} scenario-tags
   "Vector of standard scenario-test tag keywords (`:canary`, `:shadow`,
    `:regression`, ...)."
   logging/scenario-tags)
 
 ;; Supervisory enum value sets
-(def eval-results
+(def ^{:stratum 0} eval-results
   "Vector of policy-evaluation outcome keywords (`:pass`, `:fail`, `:warn`,
    `:skip`)."
   supervisory/eval-results)
 
-(def violation-categories
+(def ^{:stratum 0} violation-categories
   "Vector of policy-violation category keywords (`:style`, `:security`,
    `:testing`, `:documentation`, `:architecture`, `:process`, `:budget`)."
   supervisory/violation-categories)
 
-(def violation-severities
+(def ^{:stratum 0} violation-severities
   "Vector of severity keywords for violations and attention items (`:info`,
    `:low`, `:medium`, `:high`, `:critical`)."
   supervisory/violation-severities)
 
-(def attention-source-types
+(def ^{:stratum 0} attention-source-types
   "Vector of source-type keywords that can raise attention items (`:workflow`,
    `:policy`, `:agent`, `:system`, `:human`)."
   supervisory/attention-source-types)
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Validation functions
-
-(defn valid?
+(defn ^{:stratum 0} valid?
   "Returns true if value validates against schema."
   [schema value]
   (m/validate schema value))
 
-(defn validate-anomaly
+(defn ^{:stratum 0} validate-anomaly
   "Validate `value` against `schema`. Return `value` on success, or an
    `:invalid-input` anomaly map describing the validation failure.
 
@@ -262,95 +259,14 @@
                      {:errors (me/humanize (m/explain schema value))
                       :value  value})))
 
-(defn validate
-  "Returns value if valid, throws ex-info with explanation if invalid.
-
-   DEPRECATED: prefer [[validate-anomaly]], which returns an anomaly map
-   rather than throwing. This thrower is retained for backward compatibility
-   with existing callsites; new code should consume `validate-anomaly` and
-   fold its result into a response chain."
-  {:deprecated "exceptions-as-data — prefer validate-anomaly"}
-  [schema value]
-  (let [result (validate-anomaly schema value)]
-    (if (anomaly/anomaly? result)
-      (throw (ex-info "Schema validation failed"
-                      {:schema schema
-                       :value  value
-                       :errors (get-in result [:anomaly/data :errors])}))
-      result)))
-
-(defn explain
+(defn ^{:stratum 0} explain
   "Returns human-readable explanation of validation errors, or nil if valid."
   [schema value]
   (when-let [explanation (m/explain schema value)]
     (me/humanize explanation)))
 
-(defn valid-agent?
-  "Returns true if value is a valid Agent."
-  [value]
-  (valid? Agent value))
-
-(defn valid-task?
-  "Returns true if value is a valid Task."
-  [value]
-  (valid? Task value))
-
-(defn valid-artifact?
-  "Returns true if value is a valid Artifact."
-  [value]
-  (valid? Artifact value))
-
-(defn valid-workflow?
-  "Returns true if value is a valid Workflow."
-  [value]
-  (valid? Workflow value))
-
-(defn valid-log-entry?
-  "Returns true if value is a valid LogEntry."
-  [value]
-  (valid? LogEntry value))
-
-(defn valid-scenario?
-  "Returns true if value is a valid Scenario."
-  [value]
-  (valid? Scenario value))
-
-;; Supervisory entity validators
-
-(defn valid-workflow-run?
-  "Returns true if value is a valid WorkflowRun."
-  [value]
-  (valid? WorkflowRun value))
-
-(defn valid-policy-evaluation?
-  "Returns true if value is a valid PolicyEvaluation."
-  [value]
-  (valid? PolicyEvaluation value))
-
-(defn valid-policy-violation?
-  "Returns true if value is a valid PolicyViolation."
-  [value]
-  (valid? PolicyViolation value))
-
-(defn valid-attention-item?
-  "Returns true if value is a valid AttentionItem."
-  [value]
-  (valid? AttentionItem value))
-
-(defn valid-waiver?
-  "Returns true if value is a valid Waiver."
-  [value]
-  (valid? Waiver value))
-
-(defn valid-evidence-bundle?
-  "Returns true if value is a valid EvidenceBundle."
-  [value]
-  (valid? EvidenceBundle value))
-
-;------------------------------------------------------------------------------ Layer 2
 ;; Response helpers
-
-(defn success
+(defn ^{:stratum 0} success
   "Create a success response.
 
    Arguments:
@@ -372,7 +288,7 @@
   ([data-key data opts]
    (merge {:success? true data-key data} opts)))
 
-(defn failure
+(defn ^{:stratum 0} failure
   "Create a failure response with a single error.
 
    Arguments:
@@ -397,7 +313,7 @@
              :anomaly (anomaly/anomaly :fault msg {})}
             opts))))
 
-(defn failure-with-errors
+(defn ^{:stratum 0} failure-with-errors
   "Create a failure response with multiple errors.
 
    Arguments:
@@ -416,7 +332,7 @@
   ([data-key errors opts]
    (merge {:success? false data-key nil :errors errors} opts)))
 
-(defn exception-failure
+(defn ^{:stratum 0} exception-failure
   "Create a failure response from an exception.
 
    Arguments:
@@ -442,22 +358,20 @@
              :anomaly (anomaly/exception-anomaly :fault (ex-message ex) ex)}
             opts))))
 
-(defn succeeded?
+(defn ^{:stratum 0} succeeded?
   "Returns true if result represents a successful operation.
    Prefer over direct :success? key access."
   [result]
   (true? (:success? result)))
 
-(defn failed?
+(defn ^{:stratum 0} failed?
   "Returns true if result represents a failed operation.
    Prefer over direct :success? key access."
   [result]
   (not (true? (:success? result))))
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Validation response helpers
-
-(defn valid
+(defn ^{:stratum 0} valid
   "Create a valid validation response.
 
    Arguments:
@@ -477,7 +391,7 @@
   ([opts]
    (merge {:valid? true} opts)))
 
-(defn invalid
+(defn ^{:stratum 0} invalid
   "Create an invalid validation response with error.
 
    Arguments:
@@ -498,7 +412,7 @@
   ([error opts]
    (merge {:valid? false :error error} opts)))
 
-(defn invalid-with-errors
+(defn ^{:stratum 0} invalid-with-errors
   "Create an invalid validation response with multiple errors.
 
    Arguments:
@@ -515,6 +429,86 @@
    (invalid-with-errors errors nil))
   ([errors opts]
    (merge {:valid? false :errors errors} opts)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} validate
+  "Returns value if valid, throws ex-info with explanation if invalid.
+
+   DEPRECATED: prefer [[validate-anomaly]], which returns an anomaly map
+   rather than throwing. This thrower is retained for backward compatibility
+   with existing callsites; new code should consume `validate-anomaly` and
+   fold its result into a response chain."
+  {:deprecated "exceptions-as-data — prefer validate-anomaly"}
+  [schema value]
+  (let [result (validate-anomaly schema value)]
+    (if (anomaly/anomaly? result)
+      (throw (ex-info "Schema validation failed"
+                      {:schema schema
+                       :value  value
+                       :errors (get-in result [:anomaly/data :errors])}))
+      result)))
+
+(defn ^{:stratum 1} valid-agent?
+  "Returns true if value is a valid Agent."
+  [value]
+  (valid? Agent value))
+
+(defn ^{:stratum 1} valid-task?
+  "Returns true if value is a valid Task."
+  [value]
+  (valid? Task value))
+
+(defn ^{:stratum 1} valid-artifact?
+  "Returns true if value is a valid Artifact."
+  [value]
+  (valid? Artifact value))
+
+(defn ^{:stratum 1} valid-workflow?
+  "Returns true if value is a valid Workflow."
+  [value]
+  (valid? Workflow value))
+
+(defn ^{:stratum 1} valid-log-entry?
+  "Returns true if value is a valid LogEntry."
+  [value]
+  (valid? LogEntry value))
+
+(defn ^{:stratum 1} valid-scenario?
+  "Returns true if value is a valid Scenario."
+  [value]
+  (valid? Scenario value))
+
+;; Supervisory entity validators
+(defn ^{:stratum 1} valid-workflow-run?
+  "Returns true if value is a valid WorkflowRun."
+  [value]
+  (valid? WorkflowRun value))
+
+(defn ^{:stratum 1} valid-policy-evaluation?
+  "Returns true if value is a valid PolicyEvaluation."
+  [value]
+  (valid? PolicyEvaluation value))
+
+(defn ^{:stratum 1} valid-policy-violation?
+  "Returns true if value is a valid PolicyViolation."
+  [value]
+  (valid? PolicyViolation value))
+
+(defn ^{:stratum 1} valid-attention-item?
+  "Returns true if value is a valid AttentionItem."
+  [value]
+  (valid? AttentionItem value))
+
+(defn ^{:stratum 1} valid-waiver?
+  "Returns true if value is a valid Waiver."
+  [value]
+  (valid? Waiver value))
+
+(defn ^{:stratum 1} valid-evidence-bundle?
+  "Returns true if value is a valid EvidenceBundle."
+  [value]
+  (valid? EvidenceBundle value))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/schema/src/ai/miniforge/schema/logging.clj
+++ b/components/schema/src/ai/miniforge/schema/logging.clj
@@ -15,29 +15,31 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.schema.logging
   "Logging schemas for miniforge structured EDN logging.
-   Layer 0: Base types and event taxonomy
-   Layer 1: Composite schemas (LogEntry, Scenario)"
+   Layer 0: Base event/level/category vocabularies
+   Layer 1: all-events (aggregates the Layer 0 event vocabularies)
+   Layer 2: logging-registry (the malli registry)
+   Layer 3: Composite schemas (LogContext, ScenarioContext, TraceContext,
+            PerfMetrics, LogEntry, Scenario)"
   (:require
    [malli.core :as m]
    [ai.miniforge.schema.core :as core]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Base types and event taxonomy
 
-(def log-levels
+;; Base types and event taxonomy
+(def ^{:stratum 0} log-levels
   [:trace :debug :info :warn :error :fatal])
 
-(def log-categories
+(def ^{:stratum 0} log-categories
   [:agent :loop :policy :artifact :system])
 
-(def loop-types
+(def ^{:stratum 0} loop-types
   "Types of control loops in the system."
   [:inner :outer :meta])
 
-(def agent-events
+(def ^{:stratum 0} agent-events
   "Events emitted by agent operations."
   [:agent/task-started
    :agent/task-completed
@@ -46,7 +48,7 @@
    :agent/response-received
    :agent/memory-updated])
 
-(def loop-events
+(def ^{:stratum 0} loop-events
   "Events emitted by control loops."
   [:inner/iteration-started
    :inner/validation-passed
@@ -61,7 +63,7 @@
    :meta/improvement-proposed
    :meta/improvement-applied])
 
-(def policy-events
+(def ^{:stratum 0} policy-events
   "Events emitted by policy evaluation."
   [:policy/gate-evaluated
    :policy/budget-checked
@@ -70,14 +72,14 @@
    :policy/human-required
    :policy/human-approved])
 
-(def artifact-events
+(def ^{:stratum 0} artifact-events
   "Events emitted by artifact operations."
   [:artifact/created
    :artifact/versioned
    :artifact/linked
    :artifact/validation])
 
-(def system-events
+(def ^{:stratum 0} system-events
   "Events emitted by system operations."
   [:system/startup
    :system/shutdown
@@ -85,13 +87,17 @@
    :system/plugin-loaded
    :system/health-check])
 
-(def all-events
-  (vec (concat agent-events loop-events policy-events artifact-events system-events)))
-
-(def scenario-tags
+(def ^{:stratum 0} scenario-tags
   [:canary :shadow :regression :smoke :stress :chaos :golden-path :error-recovery :rollback])
 
-(def logging-registry
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} all-events
+  (vec (concat agent-events loop-events policy-events artifact-events system-events)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(def ^{:stratum 2} logging-registry
   "Malli registry for logging schema types."
   (merge
    core/registry
@@ -102,10 +108,10 @@
     :log/loop-type (into [:enum] loop-types)
     :scenario/tag  (into [:enum] scenario-tags)}))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Composite schemas
+;------------------------------------------------------------------------------ Layer 3
 
-(def LogContext
+;; Composite schemas
+(def ^{:stratum 3} LogContext
   "Schema for log entry context fields."
   [:map {:registry logging-registry}
    [:ctx/workflow-id {:optional true} :workflow/id]
@@ -114,27 +120,27 @@
    [:ctx/phase {:optional true} :workflow/phase]
    [:ctx/loop {:optional true} :log/loop-type]])
 
-(def ScenarioContext
+(def ^{:stratum 3} ScenarioContext
   "Schema for scenario tracking in logs."
   [:map {:registry logging-registry}
    [:scenario/id {:optional true} :id/uuid]
    [:scenario/tags {:optional true} [:set :scenario/tag]]])
 
-(def TraceContext
+(def ^{:stratum 3} TraceContext
   "Schema for distributed tracing correlation."
   [:map {:registry logging-registry}
    [:trace/id {:optional true} :id/uuid]
    [:span/id {:optional true} :id/uuid]
    [:parent-span/id {:optional true} :id/uuid]])
 
-(def PerfMetrics
+(def ^{:stratum 3} PerfMetrics
   "Schema for performance metrics in log entries."
   [:map {:registry logging-registry}
    [:perf/duration-ms {:optional true} :common/non-neg-int]
    [:perf/tokens-used {:optional true} :common/non-neg-int]
    [:perf/cost-usd {:optional true} :common/pos-number]])
 
-(def LogEntry
+(def ^{:stratum 3} LogEntry
   "Schema for a structured log entry.
    Core data substrate for debugging, tracing, and meta loop signals."
   [:map {:registry logging-registry}
@@ -172,7 +178,7 @@
    [:perf/tokens-used {:optional true} :common/non-neg-int]
    [:perf/cost-usd {:optional true} :common/pos-number]])
 
-(def Scenario
+(def ^{:stratum 3} Scenario
   "Schema for a test scenario definition."
   [:map {:registry logging-registry}
    [:scenario/id :id/uuid]

--- a/components/schema/src/ai/miniforge/schema/supervisory.clj
+++ b/components/schema/src/ai/miniforge/schema/supervisory.clj
@@ -10,30 +10,31 @@
    producers to annotate entities with ad-hoc metadata without
    breaking validation.
 
-   Layer 0: Enums and registry extensions
-   Layer 1: Composite schemas"
+   Layer 0: Enums for supervisory entities
+   Layer 1: supervisory-registry (registry extensions)
+   Layer 2: Composite schemas (WorkflowRun, PolicyEvaluation, PolicyViolation,
+            AttentionItem, Waiver, EvidenceBundle)"
   (:require
    [ai.miniforge.schema.core :as core]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Enums for supervisory entities
 
-(def eval-results
+;; Enums for supervisory entities
+(def ^{:stratum 0} eval-results
   [:pass :fail :warn :skip])
 
-(def violation-categories
+(def ^{:stratum 0} violation-categories
   [:style :security :testing :documentation :architecture :process :budget])
 
-(def violation-severities
+(def ^{:stratum 0} violation-severities
   [:info :low :medium :high :critical])
 
-(def attention-source-types
+(def ^{:stratum 0} attention-source-types
   [:workflow :policy :agent :system :human])
 
-;------------------------------------------------------------------------------ Layer 0a
-;; Registry extensions for supervisory types
+;------------------------------------------------------------------------------ Layer 1
 
-(def supervisory-registry
+(def ^{:stratum 1} supervisory-registry
   "Malli registry extending core registry with supervisory types."
   (merge
    core/registry
@@ -57,10 +58,10 @@
     ;; Evidence types
     :evidence/id       :id/uuid}))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Composite schemas — all open maps (no {:closed true})
+;------------------------------------------------------------------------------ Layer 2
 
-(def WorkflowRun
+;; Composite schemas — all open maps (no {:closed true})
+(def ^{:stratum 2} WorkflowRun
   "Schema for a supervisory workflow run.
    Tracks the lifecycle of a single workflow execution.
    Open map — extra keys pass through."
@@ -71,7 +72,7 @@
    [:workflow/phase :workflow/phase]
    [:workflow/started-at :common/timestamp]])
 
-(def PolicyEvaluation
+(def ^{:stratum 2} PolicyEvaluation
   "Schema for a policy evaluation result.
    Records the outcome of evaluating policies against a PR.
    Open map — extra keys pass through."
@@ -82,7 +83,7 @@
    [:eval/rules-applied [:vector keyword?]]
    [:eval/evaluated-at :common/timestamp]])
 
-(def PolicyViolation
+(def ^{:stratum 2} PolicyViolation
   "Schema for a policy violation.
    Identifies a specific rule violation within an evaluation.
    Open map — extra keys pass through."
@@ -93,7 +94,7 @@
    [:violation/category :violation/category]
    [:violation/severity :violation/severity]])
 
-(def AttentionItem
+(def ^{:stratum 2} AttentionItem
   "Schema for an attention item requiring human review.
    Surfaces items needing oversight from any source in the system.
    Open map — extra keys pass through."
@@ -104,7 +105,7 @@
    [:attention/source-type :attention/source-type]
    [:attention/source-id [:string {:min 1}]]])
 
-(def Waiver
+(def ^{:stratum 2} Waiver
   "Schema for a policy waiver.
    Records a human decision to waive a policy violation.
    Open map — extra keys pass through."
@@ -115,7 +116,7 @@
    [:waiver/reason [:string {:min 1}]]
    [:waiver/created-at :common/timestamp]])
 
-(def EvidenceBundle
+(def ^{:stratum 2} EvidenceBundle
   "Schema for an evidence bundle.
    Collects evidence entries produced during a workflow.
    Open map — extra keys pass through."

--- a/components/schema/test/ai/miniforge/schema/interface/failure_anomaly_shape_test.clj
+++ b/components/schema/test/ai/miniforge/schema/interface/failure_anomaly_shape_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.schema.interface.failure-anomaly-shape-test
   "Lock the canonical anomaly shape produced by `schema/failure` and
    `schema/exception-failure` after the W2 anomaly convergence flip.
@@ -31,44 +30,44 @@
    [ai.miniforge.schema.interface :as schema]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Fixtures and factories — the canonical-shape post-flip contract.
 
-(def ^:private data-key
+;; Fixtures and factories — the canonical-shape post-flip contract.
+(def ^{:stratum 0} ^:private data-key
   "Arbitrary domain data-key used by `schema/failure` and
    `schema/exception-failure`; the shape contract is independent of
    which data-key the caller passes."
   :pack)
 
-(def ^:private fault-message
+(def ^{:stratum 0} ^:private fault-message
   "Plain string message exercised by the `failure/2` path."
   "File not found")
 
-(def ^:private exception-message
+(def ^{:stratum 0} ^:private exception-message
   "Message attached to the test `ex-info` instance; exercised on the
    `exception-failure` path and asserted on `:anomaly/ex-message`."
   "kaboom")
 
-(def ^:private exception-ex-data
+(def ^{:stratum 0} ^:private exception-ex-data
   "ex-data carried by the test exception; locked on
    `:anomaly/ex-data` to prove exception provenance is preserved."
   {:phase :extraction})
 
-(def ^:private exception-info-class-name
+(def ^{:stratum 0} ^:private exception-info-class-name
   "Fully-qualified class name of `clojure.lang.ExceptionInfo`,
    locked on `:anomaly/ex-class` to prove the class is carried
    through to the anomaly's data."
   "clojure.lang.ExceptionInfo")
 
-(defn- make-ex
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} make-ex
   "Build the canonical `ex-info` fixture used by every
    `exception-failure` assertion in this file."
   []
   (ex-info exception-message exception-ex-data))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Shape locks — `:anomaly/type :fault` with no `:anomaly/subtype`.
-
-(deftest failure-emits-canonical-fault-anomaly
+(deftest ^{:stratum 1} failure-emits-canonical-fault-anomaly
   (testing "failure/2 attaches an anomaly with :anomaly/type :fault"
     (let [resp (schema/failure data-key fault-message)
           a    (:anomaly resp)]
@@ -81,7 +80,9 @@
     (let [resp (schema/failure data-key fault-message)]
       (is (= fault-message (:anomaly/message (:anomaly resp)))))))
 
-(deftest exception-failure-emits-canonical-fault-anomaly
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} exception-failure-emits-canonical-fault-anomaly
   (testing "exception-failure wraps the exception as a :fault anomaly"
     (let [resp (schema/exception-failure data-key (make-ex))
           a    (:anomaly resp)]

--- a/components/schema/test/ai/miniforge/schema/interface/validate_anomaly_failure_test.clj
+++ b/components/schema/test/ai/miniforge/schema/interface/validate_anomaly_failure_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.schema.interface.validate-anomaly-failure-test
   "Failure-path coverage for `schema/validate-anomaly`: invalid values
    become canonical anomalies carrying useful diagnostic data."
@@ -23,34 +22,38 @@
             [ai.miniforge.anomaly.interface :as anomaly]
             [ai.miniforge.schema.interface :as schema]))
 
-(def invalid-agent
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} invalid-agent
   {:agent/id "not-a-uuid"
    :agent/role :invalid-role})
 
-(deftest validate-anomaly-returns-anomaly-on-failure
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} validate-anomaly-returns-anomaly-on-failure
   (testing "invalid value returns an anomaly map, not the value"
     (let [result (schema/validate-anomaly schema/Agent invalid-agent)]
       (is (anomaly/anomaly? result)))))
 
-(deftest validate-anomaly-uses-invalid-input-type
+(deftest ^{:stratum 1} validate-anomaly-uses-invalid-input-type
   (testing "anomaly type is :invalid-input — it's a validation failure"
     (let [result (schema/validate-anomaly schema/Agent invalid-agent)]
       (is (= :invalid-input (:anomaly/type result))))))
 
-(deftest validate-anomaly-message-is-human-readable
+(deftest ^{:stratum 1} validate-anomaly-message-is-human-readable
   (testing "anomaly carries a human-readable message"
     (let [result (schema/validate-anomaly schema/Agent invalid-agent)]
       (is (string? (:anomaly/message result)))
       (is (seq (:anomaly/message result))))))
 
-(deftest validate-anomaly-data-carries-errors
+(deftest ^{:stratum 1} validate-anomaly-data-carries-errors
   (testing "anomaly data includes humanized malli errors"
     (let [result (schema/validate-anomaly schema/Agent invalid-agent)
           errors (get-in result [:anomaly/data :errors])]
       (is (some? errors))
       (is (map? errors)))))
 
-(deftest validate-anomaly-data-carries-offending-value
+(deftest ^{:stratum 1} validate-anomaly-data-carries-offending-value
   (testing "anomaly data includes the offending value for diagnostics"
     (let [result (schema/validate-anomaly schema/Agent invalid-agent)]
       (is (= invalid-agent (get-in result [:anomaly/data :value]))))))

--- a/components/schema/test/ai/miniforge/schema/interface/validate_anomaly_happy_path_test.clj
+++ b/components/schema/test/ai/miniforge/schema/interface/validate_anomaly_happy_path_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.schema.interface.validate-anomaly-happy-path-test
   "Happy-path coverage for `schema/validate-anomaly`: valid values pass
    straight through unchanged."
@@ -23,20 +22,24 @@
             [ai.miniforge.anomaly.interface :as anomaly]
             [ai.miniforge.schema.interface :as schema]))
 
-(def valid-agent
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} valid-agent
   {:agent/id (random-uuid)
    :agent/role :implementer
    :agent/capabilities #{:code :test}
    :agent/config {:model "claude-sonnet-4"
                   :temperature 0.3}})
 
-(deftest validate-anomaly-returns-value-on-success
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} validate-anomaly-returns-value-on-success
   (testing "valid agent returns the value, not an anomaly"
     (let [result (schema/validate-anomaly schema/Agent valid-agent)]
       (is (= valid-agent result))
       (is (not (anomaly/anomaly? result))))))
 
-(deftest validate-anomaly-preserves-identity
+(deftest ^{:stratum 1} validate-anomaly-preserves-identity
   (testing "result is the input value (identity, not a copy)"
     (is (identical? valid-agent
                     (schema/validate-anomaly schema/Agent valid-agent)))))

--- a/components/schema/test/ai/miniforge/schema/interface/validate_throwing_compat_test.clj
+++ b/components/schema/test/ai/miniforge/schema/interface/validate_throwing_compat_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.schema.interface.validate-throwing-compat-test
   "Backward-compat coverage for the deprecated throwing `schema/validate`.
 
@@ -26,27 +25,31 @@
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.schema.interface :as schema]))
 
-(def valid-agent
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} valid-agent
   {:agent/id (random-uuid)
    :agent/role :implementer
    :agent/capabilities #{:code :test}
    :agent/config {:model "claude-sonnet-4"
                   :temperature 0.3}})
 
-(def invalid-agent
+(def ^{:stratum 0} invalid-agent
   {:agent/id "not-a-uuid"
    :agent/role :invalid-role})
 
-(deftest validate-still-returns-value-on-success
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} validate-still-returns-value-on-success
   (testing "deprecated throwing variant returns input unchanged on success"
     (is (= valid-agent (schema/validate schema/Agent valid-agent)))))
 
-(deftest validate-still-throws-ex-info-on-failure
+(deftest ^{:stratum 1} validate-still-throws-ex-info-on-failure
   (testing "deprecated throwing variant still throws ExceptionInfo on bad input"
     (is (thrown? clojure.lang.ExceptionInfo
                  (schema/validate schema/Agent invalid-agent)))))
 
-(deftest validate-thrown-ex-data-carries-errors
+(deftest ^{:stratum 1} validate-thrown-ex-data-carries-errors
   (testing "thrown ex-info carries :errors map for legacy callers"
     (try
       (schema/validate schema/Agent invalid-agent)

--- a/components/schema/test/ai/miniforge/schema/interface_test.clj
+++ b/components/schema/test/ai/miniforge/schema/interface_test.clj
@@ -15,41 +15,40 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.schema.interface-test
   (:require [clojure.test :as test :refer [deftest testing is]]
             [ai.miniforge.schema.interface :as schema]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Test fixtures
 
-(def valid-agent
+;; Test fixtures
+(def ^{:stratum 0} valid-agent
   {:agent/id (random-uuid)
    :agent/role :implementer
    :agent/capabilities #{:code :test}
    :agent/config {:model "claude-sonnet-4"
                   :max-tokens 8000}})
 
-(def valid-task
+(def ^{:stratum 0} valid-task
   {:task/id (random-uuid)
    :task/type :implement
    :task/status :pending
    :task/constraints {:budget {:tokens 50000}}})
 
-(def valid-artifact
+(def ^{:stratum 0} valid-artifact
   {:artifact/id (random-uuid)
    :artifact/type :code
    :artifact/version "1.0.0"
    :artifact/content "(defn hello [] \"world\")"})
 
-(def valid-workflow
+(def ^{:stratum 0} valid-workflow
   {:workflow/id (random-uuid)
    :workflow/name "feature-auth"
    :workflow/status :running
    :workflow/phase :implement
    :workflow/priority 5})
 
-(def valid-log-entry
+(def ^{:stratum 0} valid-log-entry
   {:log/id (random-uuid)
    :log/timestamp (java.util.Date.)
    :log/level :info
@@ -58,17 +57,79 @@
    :ctx/workflow-id (random-uuid)
    :data {:agent-role :implementer}})
 
-(def valid-scenario
+(def ^{:stratum 0} valid-scenario
   {:scenario/id (random-uuid)
    :scenario/name "happy-path"
    :scenario/tags #{:golden-path}
    :scenario/created-at (java.util.Date.)
    :scenario/status :running})
 
-;------------------------------------------------------------------------------ Layer 1
-;; Agent tests
+(deftest ^{:stratum 0} metrics-schema-test
+  (testing "valid metrics pass"
+    (is (schema/valid? schema/Metrics {:tokens 0 :duration-ms 0}))
+    (is (schema/valid? schema/Metrics {:tokens 1500 :duration-ms 3000 :cost-usd 0.02})))
+  (testing "explicit nil :tokens is rejected (the NPE class)"
+    (is (not (schema/valid? schema/Metrics {:tokens nil :duration-ms 0}))))
+  (testing "missing required key is rejected"
+    (is (not (schema/valid? schema/Metrics {:duration-ms 0})))
+    (is (not (schema/valid? schema/Metrics {:tokens 0}))))
+  (testing "negative tokens rejected"
+    (is (not (schema/valid? schema/Metrics {:tokens -1 :duration-ms 0})))))
 
-(deftest valid-agent?-test
+;; Enum access tests
+(deftest ^{:stratum 0} enum-values-test
+  (testing "agent-roles contains expected values"
+    (is (= 10 (count schema/agent-roles)))
+    (is (some #{:planner} schema/agent-roles))
+    (is (some #{:implementer} schema/agent-roles)))
+
+  (testing "task-types contains expected values"
+    (is (some #{:implement} schema/task-types))
+    (is (some #{:test} schema/task-types)))
+
+  (testing "artifact-types contains expected values"
+    (is (some #{:code} schema/artifact-types))
+    (is (some #{:spec} schema/artifact-types)))
+
+  (testing "log-levels contains expected values"
+    (is (= [:trace :debug :info :warn :error :fatal] schema/log-levels)))
+
+  (testing "all-events contains events from all categories"
+    (is (some #{:agent/task-started} schema/all-events))
+    (is (some #{:system/startup} schema/all-events))
+    (is (some #{:policy/gate-evaluated} schema/all-events))))
+
+;; Canonical severity
+(deftest ^{:stratum 0} severities-are-canonical-five-level
+  (testing "the shared severity enum is the 5-level scale, most to least severe"
+    (is (= [:critical :high :medium :low :info] schema/severities))
+    (is (= {:critical 0 :high 1 :medium 2 :low 3 :info 4} schema/severity-order))))
+
+(deftest ^{:stratum 0} severity-schema-rejects-legacy-values
+  (testing "Severity accepts canonical values and rejects legacy :major/:minor"
+    (is (schema/valid? schema/Severity :high))
+    (is (schema/valid? schema/Severity :info))
+    (is (not (schema/valid? schema/Severity :major)))
+    (is (not (schema/valid? schema/Severity :minor)))))
+
+(deftest ^{:stratum 0} normalize-severity-maps-legacy-to-canonical
+  (testing ":major->:high, :minor->:low, canonical/other unchanged"
+    (is (= :high (schema/normalize-severity :major)))
+    (is (= :low (schema/normalize-severity :minor)))
+    (is (= :critical (schema/normalize-severity :critical)))
+    (is (= :medium (schema/normalize-severity :medium)))))
+
+(deftest ^{:stratum 0} severity-comparison
+  (testing "compare-severity / more-severe order by rank"
+    (is (neg? (schema/compare-severity :critical :low)))
+    (is (pos? (schema/compare-severity :info :high)))
+    (is (zero? (schema/compare-severity :medium :medium)))
+    (is (= :critical (schema/more-severe :low :critical)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Agent tests
+(deftest ^{:stratum 1} valid-agent?-test
   (testing "valid agent returns true"
     (is (true? (schema/valid-agent? valid-agent))))
 
@@ -88,8 +149,7 @@
                   :agent/role :implementer})))))
 
 ;; Task tests
-
-(deftest valid-task?-test
+(deftest ^{:stratum 1} valid-task?-test
   (testing "valid task returns true"
     (is (true? (schema/valid-task? valid-task))))
 
@@ -112,8 +172,7 @@
                   :task/status :invalid})))))
 
 ;; Artifact tests
-
-(deftest valid-artifact?-test
+(deftest ^{:stratum 1} valid-artifact?-test
   (testing "valid artifact returns true"
     (is (true? (schema/valid-artifact? valid-artifact))))
 
@@ -130,8 +189,7 @@
                   :artifact/version "1.0.0"})))))
 
 ;; Workflow tests
-
-(deftest valid-workflow?-test
+(deftest ^{:stratum 1} valid-workflow?-test
   (testing "valid workflow returns true"
     (is (true? (schema/valid-workflow? valid-workflow))))
 
@@ -146,8 +204,7 @@
                   :workflow/status :invalid})))))
 
 ;; LogEntry tests
-
-(deftest valid-log-entry?-test
+(deftest ^{:stratum 1} valid-log-entry?-test
   (testing "valid log entry returns true"
     (is (true? (schema/valid-log-entry? valid-log-entry))))
 
@@ -168,8 +225,7 @@
                   :log/event :agent/task-started})))))
 
 ;; Scenario tests
-
-(deftest valid-scenario?-test
+(deftest ^{:stratum 1} valid-scenario?-test
   (testing "valid scenario returns true"
     (is (true? (schema/valid-scenario? valid-scenario))))
 
@@ -181,8 +237,7 @@
                   :scenario/status :invalid})))))
 
 ;; General validation tests
-
-(deftest explain-test
+(deftest ^{:stratum 1} explain-test
   (testing "valid data returns nil"
     (is (nil? (schema/explain schema/Agent valid-agent))))
 
@@ -193,7 +248,7 @@
       (is (contains? errors :agent/id))
       (is (contains? errors :agent/role)))))
 
-(deftest validate-test
+(deftest ^{:stratum 1} validate-test
   (testing "valid data returns the data"
     (is (= valid-agent (schema/validate schema/Agent valid-agent))))
 
@@ -202,73 +257,8 @@
                           #"Schema validation failed"
                           (schema/validate schema/Agent {:agent/id "bad"})))))
 
-(deftest metrics-schema-test
-  (testing "valid metrics pass"
-    (is (schema/valid? schema/Metrics {:tokens 0 :duration-ms 0}))
-    (is (schema/valid? schema/Metrics {:tokens 1500 :duration-ms 3000 :cost-usd 0.02})))
-  (testing "explicit nil :tokens is rejected (the NPE class)"
-    (is (not (schema/valid? schema/Metrics {:tokens nil :duration-ms 0}))))
-  (testing "missing required key is rejected"
-    (is (not (schema/valid? schema/Metrics {:duration-ms 0})))
-    (is (not (schema/valid? schema/Metrics {:tokens 0}))))
-  (testing "negative tokens rejected"
-    (is (not (schema/valid? schema/Metrics {:tokens -1 :duration-ms 0})))))
-
-;; Enum access tests
-
-(deftest enum-values-test
-  (testing "agent-roles contains expected values"
-    (is (= 10 (count schema/agent-roles)))
-    (is (some #{:planner} schema/agent-roles))
-    (is (some #{:implementer} schema/agent-roles)))
-
-  (testing "task-types contains expected values"
-    (is (some #{:implement} schema/task-types))
-    (is (some #{:test} schema/task-types)))
-
-  (testing "artifact-types contains expected values"
-    (is (some #{:code} schema/artifact-types))
-    (is (some #{:spec} schema/artifact-types)))
-
-  (testing "log-levels contains expected values"
-    (is (= [:trace :debug :info :warn :error :fatal] schema/log-levels)))
-
-  (testing "all-events contains events from all categories"
-    (is (some #{:agent/task-started} schema/all-events))
-    (is (some #{:system/startup} schema/all-events))
-    (is (some #{:policy/gate-evaluated} schema/all-events))))
-
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   (test/run-tests 'ai.miniforge.schema.interface-test)
 
   :leave-this-here)
-
-;------------------------------------------------------------------------------ Layer 1
-;; Canonical severity
-
-(deftest severities-are-canonical-five-level
-  (testing "the shared severity enum is the 5-level scale, most to least severe"
-    (is (= [:critical :high :medium :low :info] schema/severities))
-    (is (= {:critical 0 :high 1 :medium 2 :low 3 :info 4} schema/severity-order))))
-
-(deftest severity-schema-rejects-legacy-values
-  (testing "Severity accepts canonical values and rejects legacy :major/:minor"
-    (is (schema/valid? schema/Severity :high))
-    (is (schema/valid? schema/Severity :info))
-    (is (not (schema/valid? schema/Severity :major)))
-    (is (not (schema/valid? schema/Severity :minor)))))
-
-(deftest normalize-severity-maps-legacy-to-canonical
-  (testing ":major->:high, :minor->:low, canonical/other unchanged"
-    (is (= :high (schema/normalize-severity :major)))
-    (is (= :low (schema/normalize-severity :minor)))
-    (is (= :critical (schema/normalize-severity :critical)))
-    (is (= :medium (schema/normalize-severity :medium)))))
-
-(deftest severity-comparison
-  (testing "compare-severity / more-severe order by rank"
-    (is (neg? (schema/compare-severity :critical :low)))
-    (is (pos? (schema/compare-severity :info :high)))
-    (is (zero? (schema/compare-severity :medium :medium)))
-    (is (= :critical (schema/more-severe :low :critical)))))

--- a/components/schema/test/ai/miniforge/schema/supervisory_test.clj
+++ b/components/schema/test/ai/miniforge/schema/supervisory_test.clj
@@ -15,60 +15,85 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.schema.supervisory-test
   (:require [clojure.test :as test :refer [deftest testing is]]
             [ai.miniforge.schema.interface :as schema]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Test fixtures
 
-(def valid-workflow-run
+;; Test fixtures
+(def ^{:stratum 0} valid-workflow-run
   {:workflow/id (random-uuid)
    :workflow/key "feature-auth"
    :workflow/status :running
    :workflow/phase :implement
    :workflow/started-at (java.util.Date.)})
 
-(def valid-policy-evaluation
+(def ^{:stratum 0} valid-policy-evaluation
   {:eval/id (random-uuid)
    :eval/pr-id "miniforge/core#42"
    :eval/result :pass
    :eval/rules-applied [:no-force-push :require-tests :require-review]
    :eval/evaluated-at (java.util.Date.)})
 
-(def valid-policy-violation
+(def ^{:stratum 0} valid-policy-violation
   {:violation/id (random-uuid)
    :violation/eval-id (random-uuid)
    :violation/rule "require-tests"
    :violation/category :testing
    :violation/severity :high})
 
-(def valid-attention-item
+(def ^{:stratum 0} valid-attention-item
   {:attention/id (random-uuid)
    :attention/severity :medium
    :attention/summary "PR #42 has no test coverage for auth module"
    :attention/source-type :policy
    :attention/source-id "eval-abc-123"})
 
-(def valid-waiver
+(def ^{:stratum 0} valid-waiver
   {:waiver/id (random-uuid)
    :waiver/eval-id (random-uuid)
    :waiver/actor "chris@miniforge.ai"
    :waiver/reason "Legacy code migration — tests will be added in follow-up PR"
    :waiver/created-at (java.util.Date.)})
 
-(def valid-evidence-bundle
+(def ^{:stratum 0} valid-evidence-bundle
   {:evidence/id (random-uuid)
    :evidence/workflow-id (random-uuid)
    :evidence/entries [{:type :test-result :passed? true :suite "unit"}
                       {:type :coverage :value 0.85 :threshold 0.80}
                       {:type :review :approved? true :reviewer "reviewer-agent"}]})
 
-;------------------------------------------------------------------------------ Layer 1
-;; WorkflowRun tests
+(deftest ^{:stratum 0} enum-values-test
+  (testing "eval-results contains expected values"
+    (is (= [:pass :fail :warn :skip] schema/eval-results)))
 
-(deftest valid-workflow-run?-test
+  (testing "violation-categories contains expected values"
+    (is (some #{:security} schema/violation-categories))
+    (is (some #{:testing} schema/violation-categories))
+    (is (some #{:architecture} schema/violation-categories)))
+
+  (testing "violation-severities contains expected values"
+    (is (= [:info :low :medium :high :critical] schema/violation-severities)))
+
+  (testing "attention-source-types contains expected values"
+    (is (some #{:workflow} schema/attention-source-types))
+    (is (some #{:human} schema/attention-source-types))))
+
+;; All-required-keys-missing tests (comprehensive)
+(deftest ^{:stratum 0} empty-map-fails-all-schemas-test
+  (testing "empty map fails all supervisory schemas"
+    (is (false? (schema/valid-workflow-run? {})))
+    (is (false? (schema/valid-policy-evaluation? {})))
+    (is (false? (schema/valid-policy-violation? {})))
+    (is (false? (schema/valid-attention-item? {})))
+    (is (false? (schema/valid-waiver? {})))
+    (is (false? (schema/valid-evidence-bundle? {})))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; WorkflowRun tests
+(deftest ^{:stratum 1} valid-workflow-run?-test
   (testing "valid workflow run returns true"
     (is (true? (schema/valid-workflow-run? valid-workflow-run))))
 
@@ -95,10 +120,8 @@
                        :workflow/duration-ms 12345
                        :meta {:foo :bar}))))))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; PolicyEvaluation tests
-
-(deftest valid-policy-evaluation?-test
+(deftest ^{:stratum 1} valid-policy-evaluation?-test
   (testing "valid policy evaluation returns true"
     (is (true? (schema/valid-policy-evaluation? valid-policy-evaluation))))
 
@@ -124,10 +147,8 @@
                        :eval/notes "Manual override approved"
                        :eval/duration-ms 450))))))
 
-;------------------------------------------------------------------------------ Layer 3
 ;; PolicyViolation tests
-
-(deftest valid-policy-violation?-test
+(deftest ^{:stratum 1} valid-policy-violation?-test
   (testing "valid policy violation returns true"
     (is (true? (schema/valid-policy-violation? valid-policy-violation))))
 
@@ -153,10 +174,8 @@
                        :violation/message "No tests found for changed files"
                        :violation/line-number 42))))))
 
-;------------------------------------------------------------------------------ Layer 4
 ;; AttentionItem tests
-
-(deftest valid-attention-item?-test
+(deftest ^{:stratum 1} valid-attention-item?-test
   (testing "valid attention item returns true"
     (is (true? (schema/valid-attention-item? valid-attention-item))))
 
@@ -186,10 +205,8 @@
                        :attention/created-at (java.util.Date.)
                        :attention/acknowledged? false))))))
 
-;------------------------------------------------------------------------------ Layer 5
 ;; Waiver tests
-
-(deftest valid-waiver?-test
+(deftest ^{:stratum 1} valid-waiver?-test
   (testing "valid waiver returns true"
     (is (true? (schema/valid-waiver? valid-waiver))))
 
@@ -215,10 +232,8 @@
                        :waiver/expires-at (java.util.Date.)
                        :waiver/scope :pr))))))
 
-;------------------------------------------------------------------------------ Layer 6
 ;; EvidenceBundle tests
-
-(deftest valid-evidence-bundle?-test
+(deftest ^{:stratum 1} valid-evidence-bundle?-test
   (testing "valid evidence bundle returns true"
     (is (true? (schema/valid-evidence-bundle? valid-evidence-bundle))))
 
@@ -240,10 +255,8 @@
                        :evidence/created-at (java.util.Date.)
                        :evidence/summary "All checks passed"))))))
 
-;------------------------------------------------------------------------------ Layer 7
 ;; Cross-cutting validation tests
-
-(deftest explain-supervisory-test
+(deftest ^{:stratum 1} explain-supervisory-test
   (testing "explain returns nil for valid data"
     (is (nil? (schema/explain schema/WorkflowRun valid-workflow-run)))
     (is (nil? (schema/explain schema/PolicyEvaluation valid-policy-evaluation)))
@@ -257,7 +270,7 @@
       (is (map? errors))
       (is (contains? errors :workflow/id)))))
 
-(deftest validate-supervisory-test
+(deftest ^{:stratum 1} validate-supervisory-test
   (testing "validate returns data for valid input"
     (is (= valid-workflow-run
            (schema/validate schema/WorkflowRun valid-workflow-run))))
@@ -266,34 +279,6 @@
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
                           #"Schema validation failed"
                           (schema/validate schema/WorkflowRun {})))))
-
-(deftest enum-values-test
-  (testing "eval-results contains expected values"
-    (is (= [:pass :fail :warn :skip] schema/eval-results)))
-
-  (testing "violation-categories contains expected values"
-    (is (some #{:security} schema/violation-categories))
-    (is (some #{:testing} schema/violation-categories))
-    (is (some #{:architecture} schema/violation-categories)))
-
-  (testing "violation-severities contains expected values"
-    (is (= [:info :low :medium :high :critical] schema/violation-severities)))
-
-  (testing "attention-source-types contains expected values"
-    (is (some #{:workflow} schema/attention-source-types))
-    (is (some #{:human} schema/attention-source-types))))
-
-;------------------------------------------------------------------------------ Layer 8
-;; All-required-keys-missing tests (comprehensive)
-
-(deftest empty-map-fails-all-schemas-test
-  (testing "empty map fails all supervisory schemas"
-    (is (false? (schema/valid-workflow-run? {})))
-    (is (false? (schema/valid-policy-evaluation? {})))
-    (is (false? (schema/valid-policy-violation? {})))
-    (is (false? (schema/valid-attention-item? {})))
-    (is (false? (schema/valid-waiver? {})))
-    (is (false? (schema/valid-evidence-bundle? {})))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-schema.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-schema.md
@@ -1,0 +1,147 @@
+# fix: stratum-lint autofix for components/schema (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over `components/schema` (`src` + `test`) to
+replace decorative `Layer N` headings with real ones derived from each
+file's actual same-file reference graph, and tag every top-level `def`/
+`defn`/`deftest` with `^{:stratum n}`. One of the Wave 1 batches from
+`work/stratum-lint-baseline-2026-07-24.md`. Mostly mechanical, but one
+manual fix was needed beyond the autofix output: a stale decorative
+`;---- Layer 0a` banner in `supervisory.clj` survived the tool untouched
+and was deleted (see Changes in Detail), and three namespace docstrings
+that hardcoded a now-wrong layer count were rewritten to match the real
+structure the fix produced. No executable logic changed anywhere.
+
+## Motivation
+
+Baseline findings for this component, confirmed via a fresh plain-lint
+run before touching anything (zero `SL001` — no upward-reference/cycle
+risk, matching the Wave 1 batch criteria):
+
+- `interface.clj`: `SL003`, 4 distinct (decorative) layers against the
+  3-layer budget.
+- `interface_test.clj`: `SL002`, a `Layer 1` heading reappearing after
+  `Layer 1` — a duplicate section banner sitting after the file's
+  trailing `(comment ...)` block, not a real second stratum.
+- `supervisory_test.clj`: `SL003`, 9 distinct layers — one decorative
+  `Layer N` banner per `deftest` group.
+
+## Changes in Detail
+
+Ran, over the whole component:
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "14965e1ee1a175bd00f637d9a9d5f7d27e62b73f" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/schema
+```
+
+All 10 `.clj` files in the component were rewritten (`--fix` normalizes
+every file, not just the ones with findings): `core.clj`, `interface.clj`,
+`logging.clj`, `supervisory.clj`, and all 6 test files. Diffs are heading
+text, `^{:stratum n}` metadata, and def/deftest reordering only.
+
+Two things the autofix itself resolved correctly and are worth calling
+out because they look alarming in a raw diff:
+
+- `interface_test.clj`'s duplicate `Layer 1` heading (4 severity-related
+  `deftest`s stranded after the file's `(comment ...)` block) was
+  collapsed: those tests, plus two more that were already correctly at
+  the real Layer 0, all moved up next to the fixtures. No test was
+  dropped — `36 tests / 139 assertions` before and after.
+- `supervisory_test.clj`'s 9 decorative per-`deftest`-group banners
+  collapsed to 2 real layers (fixtures, then everything that uses them —
+  none of the 8 `deftest` groups actually depend on each other).
+
+One thing the autofix did **not** resolve, found during the mandated
+full-diff read (`work/stratum-lint-baseline-2026-07-24.md`'s known
+tool-limitation class (b) — a stale decorative banner surviving next to
+a new real heading): `supervisory.clj` had an old `;---- Layer 0a`
+sub-banner (with its own "Registry extensions for supervisory types"
+comment) sitting directly below the fix's new, correct `;---- Layer 1`
+heading — a leftover from the pre-fix file's `Layer 0 / Layer 0a / Layer
+1` decorative scheme. Deleted both lines by hand: the `supervisory-registry`
+def already carries an equivalent docstring, so the banner added nothing
+and directly contradicted the heading above it. Re-ran `--fix` a third
+time afterward — zero diff, confirms the hand edit is stable.
+
+Also updated by hand: `core.clj`, `logging.clj`, and `supervisory.clj`
+each carry a namespace-docstring summary of their own layer structure
+(e.g. `"Layer 0: Base types and registries \n Layer 1: Composite
+schemas"`). The fix changed the real layer count in all three (2→4, 2→4,
+2→3 respectively) without touching the docstrings, leaving them
+describing a structure the file no longer has. Rewrote each to list its
+actual layers/contents.
+
+No `defmethod` in this component, so the upstream `defmethod`-refs-union
+bug class (already fixed at this pin) doesn't apply here.
+
+## Testing Plan
+
+1. Ran plain (non-`--fix`) `stratum-lint` before any change — reproduced
+   the 3 findings above exactly, confirmed 0 `SL001`.
+2. Ran `--fix`, then a second `--fix` pass immediately after — zero diff,
+   confirms idempotency.
+3. Read the full diff for all 10 changed files. Found and hand-fixed the
+   stale `Layer 0a` banner in `supervisory.clj` (above); no same-line
+   trailing-comment displacement found in any file.
+4. Ran `--fix` a third time after the hand edits — zero diff, confirms
+   the manual fix is stable under the tool.
+5. `clj-kondo --lint components/schema`: 0 errors both before and after.
+   8 pre-existing warnings (deprecated `schema/validate` used by its own
+   backward-compat test coverage) are unchanged in content and count
+   before and after — only line numbers shifted from reordering. Not
+   introduced by this change.
+6. Ran all 6 test namespaces directly via `clojure -M:test`: 36 tests,
+   139 assertions, 0 failures, 0 errors.
+7. Re-ran plain `stratum-lint` after the fix: `SL001`/`SL002`/`SL004`
+   clear across the component. `SL003` remains, newly surfaced (not
+   present in the pre-fix baseline run) on two files:
+   - `core.clj`: 4 real layers (was 2 decorative, under budget) —
+     `--fix` inferred the true chain `severities`/`normalize-severity` →
+     `severity-order`/`registry` → `compare-severity`/`Severity`/most
+     composite schemas → `more-severe`/`Task`/`Artifact`/`Workflow`.
+   - `logging.clj`: 4 real layers (was 2 decorative, under budget) —
+     true chain is the base vocabularies → `all-events` → `logging-registry`
+     → the composite schemas.
+
+   Both are genuinely over the 3-layer budget the old decorative headings
+   hid by undercounting, not a regression this PR introduces — deferred
+   to Wave 2 (real namespace split), consistent with how prior Wave 1
+   PRs (e.g. `bb-config`) handled the same situation. `interface.clj`'s
+   original `SL003` and `supervisory_test.clj`'s original `SL003` are
+   both fully resolved (collapsed to 2 real layers each, under budget).
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+change — comment/metadata/order/docstring-only. Pre-commit's
+`lint:stratum` autofixer keeps this component clean going forward;
+`core.clj` and `logging.clj`'s `SL003` stay advisory
+(`MINIFORGE_STRATUM_BUDGET_MODE=warn` at commit time) until Wave 2 splits
+them.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+- Follow-on: Wave 2 namespace split for
+  `components/schema/src/ai/miniforge/schema/core.clj` and
+  `components/schema/src/ai/miniforge/schema/logging.clj` (4 real layers
+  each, over the 3-layer budget)
+
+## Checklist
+
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Second `--fix` pass confirms idempotency (zero diff)
+- [x] Diff read in full for all 10 changed files
+- [x] Stale decorative `Layer 0a` banner (`supervisory.clj`) found and
+      removed by hand; third `--fix` pass confirms it's stable
+- [x] Three namespace docstrings (`core.clj`, `logging.clj`,
+      `supervisory.clj`) updated to match the real post-fix layer
+      structure
+- [x] `clj-kondo` clean of new issues (0 errors before/after; 8
+      pre-existing warnings unchanged in content/count)
+- [x] Component tests pass (36 tests, 139 assertions, 0 failures/errors)
+- [x] Plain lint re-run post-fix: zero `SL001`/`SL002`/`SL004`; `SL003`
+      remains on `core.clj` and `logging.clj` — newly surfaced by the
+      fix (not pre-existing), tracked as Wave 2 above
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
## Summary

- Runs `stratum-lint --fix` over `components/schema` (rule 210 / `work/stratum-lint-baseline-2026-07-24.md` Wave 1). Zero SL001 findings confirmed before starting.
- One manual fix beyond the tool's own output: deleted a stale `;---- Layer 0a` decorative banner in `supervisory.clj` that survived the fix untouched and contradicted the new real `Layer 1` heading next to it. Also updated three namespace docstrings (`core.clj`, `logging.clj`, `supervisory.clj`) that hardcoded a now-stale layer count.
- `core.clj` and `logging.clj` now report `SL003` (4 real layers vs the 3-layer budget) — newly surfaced by the fix (old decorative headings undercounted), not pre-existing. Deferred to Wave 2. `interface.clj`'s and `supervisory_test.clj`'s original `SL003`, and `interface_test.clj`'s `SL002`, are fully resolved.
- No executable logic changed anywhere.

Full detail in `docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-schema.md`.

## Test plan

- [x] `--fix` run over the whole component; second `--fix` pass confirms idempotency (zero diff)
- [x] Full diff read for all 10 changed files; hand-fixed the stale banner, then a third `--fix` pass confirmed it's stable (zero diff)
- [x] `clj-kondo --lint components/schema`: 0 errors before/after; 8 pre-existing warnings unchanged in content/count
- [x] All 6 test namespaces run directly: 36 tests, 139 assertions, 0 failures/errors
- [x] Plain lint re-run post-fix: zero SL001/SL002/SL004; SL003 remains on `core.clj`/`logging.clj`, tracked as Wave 2

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>