### PR TITLE
fix: stratum-lint autofix for components/context-pack (Wave 1)

### DIFF
--- a/components/context-pack/src/ai/miniforge/context_pack/budget.clj
+++ b/components/context-pack/src/ai/miniforge/context_pack/budget.clj
@@ -1,7 +1,6 @@
 ;; Title: Miniforge.ai
 ;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
 ;; Licensed under the Apache License, Version 2.0
-
 (ns ai.miniforge.context-pack.budget
   "Token budget enforcement for context packs.
 
@@ -10,24 +9,34 @@
             [ai.miniforge.context-pack.factory :as factory]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Token estimation
 
-(defn estimate-tokens
+;; Token estimation
+(defn ^{:stratum 0} estimate-tokens
   "Estimate token count for a string (~4 chars per token)."
   [s]
   (if (string? s)
     (int (Math/ceil (/ (count s) 4)))
     0))
 
-(defn would-exceed?
+(defn ^{:stratum 0} would-exceed?
   "Check if adding tokens would exceed the pack's budget."
   [pack additional-tokens]
   (> (+ (:tokens-used pack) additional-tokens) (:budget pack)))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Budget tracking
+(defn ^{:stratum 0} tokens-remaining
+  "Get remaining token budget for a pack."
+  [pack]
+  (max 0 (- (:budget pack) (:tokens-used pack))))
 
-(defn add-source
+(defn ^{:stratum 0} exhausted?
+  "Check if a pack's budget is exhausted."
+  [pack]
+  (:exhausted? pack))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Budget tracking
+(defn ^{:stratum 1} add-source
   "Add a source to the pack, tracking its token cost.
    Returns updated pack, or pack with :exhausted? true if over budget."
   [pack kind path content]
@@ -44,7 +53,9 @@
             (and over-budget? (= policy :warn))
             (assoc :exhausted? true))))))
 
-(defn try-add-item
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} try-add-item
   "Try to add an item to the pack within budget.
    Returns updated pack if it fits, or pack with :exhausted? true if not."
   [pack kind path content update-fn]
@@ -54,13 +65,3 @@
       (-> pack
           update-fn
           (add-source kind path content)))))
-
-(defn tokens-remaining
-  "Get remaining token budget for a pack."
-  [pack]
-  (max 0 (- (:budget pack) (:tokens-used pack))))
-
-(defn exhausted?
-  "Check if a pack's budget is exhausted."
-  [pack]
-  (:exhausted? pack))

--- a/components/context-pack/src/ai/miniforge/context_pack/builder.clj
+++ b/components/context-pack/src/ai/miniforge/context_pack/builder.clj
@@ -1,7 +1,6 @@
 ;; Title: Miniforge.ai
 ;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
 ;; Licensed under the Apache License, Version 2.0
-
 (ns ai.miniforge.context-pack.builder
   "Assemble context packs from repo-index data.
 
@@ -13,14 +12,14 @@
             [ai.miniforge.repo-index.interface :as repo-index]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Helpers
 
-(defn- snippet-text
+;; Helpers
+(defn- ^{:stratum 0} snippet-text
   "Extract concatenated text from a search hit's snippets."
   [hit]
   (apply str (map :text (:snippets hit))))
 
-(defn- reduce-within-budget
+(defn- ^{:stratum 0} reduce-within-budget
   "Reduce items into a pack, stopping when budget is exhausted.
    item-fn takes (pack, item) and returns updated pack."
   [pack items item-fn]
@@ -32,10 +31,8 @@
     pack
     items))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Pack assembly steps
-
-(defn- add-repo-map
+(defn- ^{:stratum 0} add-repo-map
   "Add the repo map to the pack, consuming budget."
   [pack repo-index]
   (if (or (nil? repo-index) (budget/exhausted? pack))
@@ -46,19 +43,13 @@
           (assoc :repo-map rmap)
           (budget/add-source :repo-map nil rmap)))))
 
-(defn- try-add-file
+(defn- ^{:stratum 0} try-add-file
   "Try to add a single file to the pack within budget."
   [pack file]
   (budget/try-add-item pack :file (:path file) (:content file)
     #(update % :files conj file)))
 
-(defn- try-add-search-hit
-  "Try to add a single search hit to the pack within budget."
-  [pack hit]
-  (budget/try-add-item pack :search (:path hit) (snippet-text hit)
-    #(update % :search-results conj hit)))
-
-(defn- load-files
+(defn- ^{:stratum 0} load-files
   "Load and deduplicate files from the repo index."
   [repo-index files-in-scope]
   (let [max-f (config/max-files)
@@ -67,7 +58,7 @@
                                {:max-lines max-l})
          dedup/dedup-files)))
 
-(defn- load-search-results
+(defn- ^{:stratum 0} load-search-results
   "Load, deduplicate, and filter search results against already-included files."
   [search-index query included-files]
   (let [max-r (config/max-search-results)]
@@ -75,14 +66,34 @@
          dedup/dedup-search-results
          (dedup/remove-already-included included-files))))
 
-(defn- add-files
+(defn ^{:stratum 0} audit
+  "Create a budget audit snapshot for a context pack."
+  [pack]
+  (factory/->budget-audit
+    (:phase pack)
+    (:budget pack)
+    (:tokens-used pack)
+    (:exhausted? pack)
+    (count (:sources pack))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} try-add-search-hit
+  "Try to add a single search hit to the pack within budget."
+  [pack hit]
+  (budget/try-add-item pack :search (:path hit) (snippet-text hit)
+    #(update % :search-results conj hit)))
+
+(defn- ^{:stratum 1} add-files
   "Add file contents to the pack within budget."
   [pack repo-index files-in-scope]
   (if (or (not (seq files-in-scope)) (budget/exhausted? pack))
     pack
     (reduce-within-budget pack (load-files repo-index files-in-scope) try-add-file)))
 
-(defn- add-search-results
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- ^{:stratum 2} add-search-results
   "Add search results to the pack within budget."
   [pack search-index query]
   (if (or (nil? search-index) (nil? query) (budget/exhausted? pack))
@@ -90,10 +101,10 @@
     (let [filtered (load-search-results search-index query (:files pack))]
       (reduce-within-budget pack filtered try-add-search-hit))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Public API
+;------------------------------------------------------------------------------ Layer 3
 
-(defn build-pack
+;; Public API
+(defn ^{:stratum 3} build-pack
   "Assemble a context pack for a given phase.
 
    Arguments:
@@ -115,19 +126,9 @@
         (add-files repo-index (:files-in-scope opts))
         (add-search-results (:search-index opts) (:search-query opts)))))
 
-(defn extend-pack
+(defn ^{:stratum 3} extend-pack
   "Extend an existing context pack with additional files or search results."
   [pack repo-index opts]
   (-> pack
       (add-files repo-index (:files-in-scope opts))
       (add-search-results (:search-index opts) (:search-query opts))))
-
-(defn audit
-  "Create a budget audit snapshot for a context pack."
-  [pack]
-  (factory/->budget-audit
-    (:phase pack)
-    (:budget pack)
-    (:tokens-used pack)
-    (:exhausted? pack)
-    (count (:sources pack))))

--- a/components/context-pack/src/ai/miniforge/context_pack/config.clj
+++ b/components/context-pack/src/ai/miniforge/context_pack/config.clj
@@ -4,7 +4,11 @@
 (ns ai.miniforge.context-pack.config
   "Budget configuration loaded from EDN resources.
 
-   Layer 0 — pure config loading, no domain logic."
+   No dependencies on other context-pack namespaces, but a real 4-deep
+   same-file chain (config-path, then load-budget-config, then
+   budget-config, then the public getters) — over the 3-layer budget
+   (SL003), deferred to Wave 2. See the per-def :stratum metadata for
+   the real breakdown."
   (:require [clojure.edn :as edn]
             [clojure.java.io :as io]))
 

--- a/components/context-pack/src/ai/miniforge/context_pack/config.clj
+++ b/components/context-pack/src/ai/miniforge/context_pack/config.clj
@@ -1,7 +1,6 @@
 ;; Title: Miniforge.ai
 ;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
 ;; Licensed under the Apache License, Version 2.0
-
 (ns ai.miniforge.context-pack.config
   "Budget configuration loaded from EDN resources.
 
@@ -9,42 +8,50 @@
   (:require [clojure.edn :as edn]
             [clojure.java.io :as io]))
 
-(def ^:private config-path "config/context-pack/budgets.edn")
+;------------------------------------------------------------------------------ Layer 0
 
-(defn- load-budget-config []
+(def ^{:stratum 0} ^:private config-path "config/context-pack/budgets.edn")
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} load-budget-config []
   (if-let [res (io/resource config-path)]
     (get (edn/read-string (slurp res)) :context-pack/budgets {})
     {}))
 
-(def ^:private budget-config (delay (load-budget-config)))
+;------------------------------------------------------------------------------ Layer 2
 
-(defn phase-budget
+(def ^{:stratum 2} ^:private budget-config (delay (load-budget-config)))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} phase-budget
   "Get the token budget for a given phase keyword."
   [phase]
   (get-in @budget-config [:phase-budgets phase]
           (get @budget-config :default-budget 2000)))
 
-(defn repo-map-budget
+(defn ^{:stratum 3} repo-map-budget
   "Get the token budget allocated for the repo map."
   []
   (get @budget-config :repo-map-budget 500))
 
-(defn max-files
+(defn ^{:stratum 3} max-files
   "Get the maximum number of files to include."
   []
   (get @budget-config :max-files 25))
 
-(defn max-lines-per-file
+(defn ^{:stratum 3} max-lines-per-file
   "Get the maximum lines per file."
   []
   (get @budget-config :max-lines-per-file 500))
 
-(defn max-search-results
+(defn ^{:stratum 3} max-search-results
   "Get the maximum number of search results."
   []
   (get @budget-config :max-search-results 5))
 
-(defn exhaustion-policy
+(defn ^{:stratum 3} exhaustion-policy
   "Get the budget exhaustion policy (:fail-closed or :warn)."
   []
   (get @budget-config :exhaustion-policy :fail-closed))

--- a/components/context-pack/src/ai/miniforge/context_pack/dedup.clj
+++ b/components/context-pack/src/ai/miniforge/context_pack/dedup.clj
@@ -4,7 +4,9 @@
 (ns ai.miniforge.context-pack.dedup
   "Deduplicate context items by identity.
 
-   Layer 0 — pure functions, no dependencies.")
+   No dependencies on other context-pack namespaces. dedup-files calls
+   path-not-seen? in this file, so the two sit at different same-file
+   layers — see the per-def :stratum metadata for the real breakdown.")
 
 ;------------------------------------------------------------------------------ Layer 0
 

--- a/components/context-pack/src/ai/miniforge/context_pack/dedup.clj
+++ b/components/context-pack/src/ai/miniforge/context_pack/dedup.clj
@@ -1,13 +1,14 @@
 ;; Title: Miniforge.ai
 ;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
 ;; Licensed under the Apache License, Version 2.0
-
 (ns ai.miniforge.context-pack.dedup
   "Deduplicate context items by identity.
 
    Layer 0 — pure functions, no dependencies.")
 
-(defn- path-not-seen?
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} path-not-seen?
   "Returns true if the file's path has not been seen, marking it as seen."
   [seen f]
   (let [path (:path f)]
@@ -15,13 +16,7 @@
       false
       (do (vswap! seen conj path) true))))
 
-(defn dedup-files
-  "Deduplicate file entries by path, keeping the first occurrence."
-  [files]
-  (let [seen (volatile! #{})]
-    (filterv (partial path-not-seen? seen) files)))
-
-(defn dedup-search-results
+(defn ^{:stratum 0} dedup-search-results
   "Deduplicate search results by path, keeping the highest-scoring entry."
   [results]
   (->> (group-by :path results)
@@ -30,8 +25,16 @@
        (sort-by :score >)
        vec))
 
-(defn remove-already-included
+(defn ^{:stratum 0} remove-already-included
   "Remove search results whose paths are already in the included files."
   [included-files search-results]
   (let [included-paths (set (map :path included-files))]
     (filterv #(not (contains? included-paths (:path %))) search-results)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} dedup-files
+  "Deduplicate file entries by path, keeping the first occurrence."
+  [files]
+  (let [seen (volatile! #{})]
+    (filterv (partial path-not-seen? seen) files)))

--- a/components/context-pack/src/ai/miniforge/context_pack/factory.clj
+++ b/components/context-pack/src/ai/miniforge/context_pack/factory.clj
@@ -1,16 +1,15 @@
 ;; Title: Miniforge.ai
 ;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
 ;; Licensed under the Apache License, Version 2.0
-
 (ns ai.miniforge.context-pack.factory
   "Factory functions for context-pack domain maps.
 
    Layer 0 — pure data construction.")
 
 ;------------------------------------------------------------------------------ Layer 0
-;; ContextPack
 
-(defn ->context-pack
+;; ContextPack
+(defn ^{:stratum 0} ->context-pack
   [phase budget repo-map-text files search-results]
   {:phase phase
    :budget budget
@@ -21,10 +20,8 @@
    :exhausted? false
    :sources []})
 
-;------------------------------------------------------------------------------ Layer 0
 ;; Budget audit
-
-(defn ->budget-audit
+(defn ^{:stratum 0} ->budget-audit
   [phase budget tokens-used exhausted? source-count]
   {:phase phase
    :budget budget
@@ -36,19 +33,15 @@
                   (double (/ tokens-used budget))
                   0.0)})
 
-;------------------------------------------------------------------------------ Layer 0
 ;; Source tracking
-
-(defn ->source
+(defn ^{:stratum 0} ->source
   [kind path tokens]
   {:kind kind
    :path path
    :tokens tokens})
 
-;------------------------------------------------------------------------------ Layer 0
 ;; Pack context (used by implement phase to cache context-pack results)
-
-(defn ->pack-context
+(defn ^{:stratum 0} ->pack-context
   [repo-index context-pack]
   {:repo-index repo-index
    :context-pack context-pack

--- a/components/context-pack/src/ai/miniforge/context_pack/interface.clj
+++ b/components/context-pack/src/ai/miniforge/context_pack/interface.clj
@@ -1,16 +1,16 @@
 ;; Title: Miniforge.ai
 ;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
 ;; Licensed under the Apache License, Version 2.0
-
 (ns ai.miniforge.context-pack.interface
   "Public API for the context-pack component.
 
    Assembles bounded, auditable context documents from repo-index data
    with per-phase token budgets.
 
-   Layer 0: Schema re-exports
-   Layer 1: Budget queries
-   Layer 2: Pack building and auditing"
+   Sections: schema re-exports, factory re-exports, budget queries,
+   pack building and auditing. All delegate to other namespaces, so
+   there's no same-file reference depth between them — every def here
+   sits at Layer 0."
   (:require [ai.miniforge.context-pack.schema :as schema]
             [ai.miniforge.context-pack.factory :as factory]
             [ai.miniforge.context-pack.builder :as builder]
@@ -18,9 +18,9 @@
             [ai.miniforge.context-pack.config :as config]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Schema re-exports
 
-(def ContextPack
+;; Schema re-exports
+(def ^{:stratum 0} ContextPack
   "Malli schema (a [:map ...] vector) for a bounded context pack.
 
    Keys: :phase (keyword), :budget (int), :tokens-used (int),
@@ -29,7 +29,7 @@
    :sources (vector of Source)."
   schema/ContextPack)
 
-(def BudgetAudit
+(def ^{:stratum 0} BudgetAudit
   "Malli schema (a [:map ...] vector) for a budget audit snapshot.
 
    Keys: :phase (keyword), :budget (int), :tokens-used (int),
@@ -37,17 +37,15 @@
    :utilization (double)."
   schema/BudgetAudit)
 
-(def Source
+(def ^{:stratum 0} Source
   "Malli schema (a [:map ...] vector) for a single source-tracking entry.
 
    Keys: :kind (enum :repo-map | :file | :search), :path (non-empty
    string or nil), :tokens (int)."
   schema/Source)
 
-;------------------------------------------------------------------------------ Layer 0
 ;; Factory re-exports
-
-(def ->context-pack
+(def ^{:stratum 0} ->context-pack
   "Construct a ContextPack map with an empty audit trail.
 
    Args: phase (keyword), budget (int), repo-map-text (string or nil),
@@ -56,7 +54,7 @@
    :sources []. Total function, never throws."
   factory/->context-pack)
 
-(def ->budget-audit
+(def ^{:stratum 0} ->budget-audit
   "Construct a BudgetAudit snapshot map.
 
    Args: phase (keyword), budget (int), tokens-used (int),
@@ -68,7 +66,7 @@
    is non-positive)."
   factory/->budget-audit)
 
-(def ->source
+(def ^{:stratum 0} ->source
   "Construct a Source-tracking entry for a pack's audit trail.
 
    Args: kind (keyword :repo-map | :file | :search), path (string or
@@ -76,7 +74,7 @@
    throws."
   factory/->source)
 
-(def ->pack-context
+(def ^{:stratum 0} ->pack-context
   "Construct a pack-context map for caching context-pack results in an
    execution context.
 
@@ -86,28 +84,24 @@
    function, never throws."
   factory/->pack-context)
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Budget queries
-
-(defn phase-budget
+(defn ^{:stratum 0} phase-budget
   "Get the configured token budget for a phase."
   [phase]
   (config/phase-budget phase))
 
-(defn tokens-remaining
+(defn ^{:stratum 0} tokens-remaining
   "Get remaining token budget for a context pack."
   [pack]
   (budget/tokens-remaining pack))
 
-(defn exhausted?
+(defn ^{:stratum 0} exhausted?
   "Check if a pack's budget is exhausted."
   [pack]
   (budget/exhausted? pack))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Pack building
-
-(defn build-pack
+(defn ^{:stratum 0} build-pack
   "Assemble a context pack for a given phase.
 
    Wraps repo-map + files + search results into a bounded context
@@ -127,7 +121,7 @@
   [phase repo-index opts]
   (builder/build-pack phase repo-index opts))
 
-(defn extend-pack
+(defn ^{:stratum 0} extend-pack
   "Extend an existing context pack with additional content.
 
    Arguments:
@@ -140,7 +134,7 @@
   [pack repo-index opts]
   (builder/extend-pack pack repo-index opts))
 
-(defn audit
+(defn ^{:stratum 0} audit
   "Create a budget audit snapshot for a context pack.
 
    Returns:

--- a/components/context-pack/src/ai/miniforge/context_pack/schema.clj
+++ b/components/context-pack/src/ai/miniforge/context_pack/schema.clj
@@ -1,7 +1,6 @@
 ;; Title: Miniforge.ai
 ;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
 ;; Licensed under the Apache License, Version 2.0
-
 (ns ai.miniforge.context-pack.schema
   "Malli schemas for context-pack domain types.
 
@@ -9,13 +8,25 @@
 
 ;------------------------------------------------------------------------------ Layer 0
 
-(def Source
+(def ^{:stratum 0} Source
   [:map
    [:kind [:enum :repo-map :file :search]]
    [:path [:maybe [:string {:min 1}]]]
    [:tokens :int]])
 
-(def ContextPack
+(def ^{:stratum 0} BudgetAudit
+  [:map
+   [:phase :keyword]
+   [:budget :int]
+   [:tokens-used :int]
+   [:tokens-remaining :int]
+   [:exhausted? :boolean]
+   [:source-count :int]
+   [:utilization :double]])
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} ContextPack
   [:map
    [:phase :keyword]
    [:budget :int]
@@ -25,13 +36,3 @@
    [:search-results [:vector :map]]
    [:exhausted? :boolean]
    [:sources [:vector Source]]])
-
-(def BudgetAudit
-  [:map
-   [:phase :keyword]
-   [:budget :int]
-   [:tokens-used :int]
-   [:tokens-remaining :int]
-   [:exhausted? :boolean]
-   [:source-count :int]
-   [:utilization :double]])

--- a/components/context-pack/src/ai/miniforge/context_pack/schema.clj
+++ b/components/context-pack/src/ai/miniforge/context_pack/schema.clj
@@ -4,7 +4,10 @@
 (ns ai.miniforge.context-pack.schema
   "Malli schemas for context-pack domain types.
 
-   Layer 0 — pure data definitions.")
+   No dependencies on other context-pack namespaces. ContextPack
+   references Source in this file, so it sits one same-file layer above
+   Source and BudgetAudit — see the per-def :stratum metadata for the
+   real breakdown.")
 
 ;------------------------------------------------------------------------------ Layer 0
 

--- a/components/context-pack/test/ai/miniforge/context_pack/interface_test.clj
+++ b/components/context-pack/test/ai/miniforge/context_pack/interface_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.context-pack.interface-test
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.context-pack.interface :as ctx]
@@ -23,7 +22,9 @@
             [ai.miniforge.repo-index.interface :as repo-index]
             [malli.core :as m]))
 
-(deftest phase-budget-test
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} phase-budget-test
   (testing "returns configured budgets for known phases"
     (is (= 100000 (ctx/phase-budget :implement)))
     (is (= 20000 (ctx/phase-budget :plan)))
@@ -33,7 +34,7 @@
   (testing "returns default budget for unknown phases"
     (is (= 40000 (ctx/phase-budget :unknown)))))
 
-(deftest build-pack-basic-test
+(deftest ^{:stratum 0} build-pack-basic-test
   (testing "builds a context pack with repo map and files"
     (let [idx (repo-index/build-index ".")
           ;; Use small files that fit within budget
@@ -47,7 +48,7 @@
       (is (pos? (count (:files pack))))
       (is (not (:exhausted? pack))))))
 
-(deftest build-pack-schema-test
+(deftest ^{:stratum 0} build-pack-schema-test
   (testing "pack conforms to ContextPack schema"
     (let [idx (repo-index/build-index ".")
           pack (ctx/build-pack :implement idx
@@ -56,7 +57,7 @@
           (str "ContextPack schema mismatch: "
                (m/explain schema/ContextPack pack))))))
 
-(deftest build-pack-with-search-test
+(deftest ^{:stratum 0} build-pack-with-search-test
   (testing "builds a pack including search results"
     (let [idx (repo-index/build-index ".")
           si (repo-index/build-search-index idx)
@@ -67,7 +68,7 @@
       (is (pos? (count (:search-results pack))))
       (is (pos? (:tokens-used pack))))))
 
-(deftest budget-enforcement-test
+(deftest ^{:stratum 0} budget-enforcement-test
   (testing "pack respects budget limits"
     (let [idx (repo-index/build-index ".")
           ;; Very small budget should truncate
@@ -78,7 +79,7 @@
       (is (<= (:tokens-used pack) 200)
           "should stay near budget (with one item overshoot possible)"))))
 
-(deftest budget-exhaustion-test
+(deftest ^{:stratum 0} budget-exhaustion-test
   (testing "pack marks exhausted when budget exceeded"
     (let [idx (repo-index/build-index ".")
           pack (ctx/build-pack :implement idx
@@ -88,7 +89,7 @@
       ;; 50 tokens is too small for repo-map + files
       (is (:exhausted? pack)))))
 
-(deftest audit-test
+(deftest ^{:stratum 0} audit-test
   (testing "audit returns budget snapshot"
     (let [idx (repo-index/build-index ".")
           pack (ctx/build-pack :implement idx
@@ -102,7 +103,7 @@
       (is (double? (:utilization a)))
       (is (not (:exhausted? a))))))
 
-(deftest audit-schema-test
+(deftest ^{:stratum 0} audit-schema-test
   (testing "audit conforms to BudgetAudit schema"
     (let [idx (repo-index/build-index ".")
           pack (ctx/build-pack :implement idx {:files-in-scope ["workspace.edn"]})
@@ -111,7 +112,7 @@
           (str "BudgetAudit schema mismatch: "
                (m/explain schema/BudgetAudit a))))))
 
-(deftest extend-pack-test
+(deftest ^{:stratum 0} extend-pack-test
   (testing "extend-pack adds more content within budget"
     (let [idx (repo-index/build-index ".")
           pack (ctx/build-pack :implement idx {:files-in-scope ["workspace.edn"]})
@@ -121,14 +122,14 @@
       (is (> (:tokens-used extended) initial-tokens))
       (is (> (count (:files extended)) (count (:files pack)))))))
 
-(deftest tokens-remaining-test
+(deftest ^{:stratum 0} tokens-remaining-test
   (testing "tokens-remaining reports correct value"
     (let [idx (repo-index/build-index ".")
           pack (ctx/build-pack :implement idx {:files-in-scope ["workspace.edn"]})]
       (is (= (- (:budget pack) (:tokens-used pack))
              (ctx/tokens-remaining pack))))))
 
-(deftest dedup-test
+(deftest ^{:stratum 0} dedup-test
   (testing "duplicate files are not double-counted"
     (let [idx (repo-index/build-index ".")
           pack (ctx/build-pack :implement idx

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-context-pack.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-context-pack.md
@@ -1,0 +1,129 @@
+# fix: stratum-lint autofix for components/context-pack (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over `components/context-pack` (`src` + `test`)
+to replace decorative `Layer N` headings with ones derived from each
+file's actual same-file reference graph, and to tag every `def`/`defn`/
+`deftest` with real `^{:stratum n}` metadata. One of the smaller
+per-component Wave 1 PRs from `work/stratum-lint-baseline-2026-07-24.md`.
+
+No logic changes. One manual documentation correction beyond the raw
+`--fix` output: `interface.clj`'s namespace docstring claimed an internal
+`Layer 0 / Layer 1 / Layer 2` breakdown left over from the old decorative
+headings; the fix collapsed every def in that file to Layer 0 (each just
+delegates to another namespace, so there's no same-file reference depth
+between them), leaving the docstring's layer claims false. Reworded to
+drop the numbered-layer claim while keeping the section list.
+
+## Motivation
+
+Baseline findings for this component: 4 `SL002` (`factory.clj` x3,
+`interface.clj` x1) — a `Layer 0` heading repeated as a section banner
+instead of appearing once. Zero `SL001` findings, so no upward-reference
+or cycle risk to reason about before running the mechanical fixer —
+matches the Wave 1 batch criteria.
+
+## Changes in Detail
+
+Ran, over the whole component:
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "14965e1ee1a175bd00f637d9a9d5f7d27e62b73f" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/context-pack
+```
+
+All 8 files rewrote (`--fix` normalizes every file in the component, not
+just the ones with findings): `budget.clj`, `builder.clj`, `config.clj`,
+`dedup.clj`, `factory.clj`, `interface.clj`, `schema.clj`, and
+`interface_test.clj`.
+
+- `factory.clj` — 4 defs, all pure data constructors with no same-file
+  calls between them. The 4 repeated `Layer 0` banners collapsed to one;
+  each `defn` now carries `^{:stratum 0}`.
+- `interface.clj` — every def re-exports another namespace's schema or
+  delegates to another namespace's function; none reference each other
+  in-file, so every def landed at `^{:stratum 0}`, replacing the old
+  `Layer 0/1/2` grouping.
+- `schema.clj` — `Source` and `BudgetAudit` are independent
+  (`^{:stratum 0}`); `ContextPack` references `Source` in its `:sources`
+  key, so it moved to `^{:stratum 1}`.
+- `dedup.clj` — `dedup-files` calls `path-not-seen?`, so it moved from
+  its old position to `^{:stratum 1}`; the other three functions are leaf
+  and stayed at `^{:stratum 0}`.
+- `budget.clj` — real 3-layer chain confirmed correct:
+  `estimate-tokens`/`would-exceed?`/`tokens-remaining`/`exhausted?`
+  (`^{:stratum 0}`) → `add-source` (`^{:stratum 1}`) → `try-add-item`
+  (`^{:stratum 2}`).
+- `builder.clj` and `config.clj` — see below; both now report `SL003`.
+- `interface_test.clj` — all 11 `deftest` forms are independent (no
+  same-file calls between tests), so all collapsed to `^{:stratum 0}`;
+  reordering here has no behavioral effect.
+
+`builder.clj` and `config.clj` each surfaced a **new** `SL003` (4 real
+layers, over the 3-layer budget) that the baseline scan did not report:
+
+- `config.clj` had no `Layer` heading at all before the fix — the tool
+  silently skips headingless files (a documented limitation), so its true
+  4-layer chain (`config-path` → `load-budget-config` → `budget-config` →
+  the five public getters) was invisible to the baseline count.
+- `builder.clj` already had 3 headings (`Layer 0/1/2`) in strictly
+  increasing order, so it never tripped `SL002`/`SL003` — but the
+  grouping under those headings was wrong: `try-add-search-hit` was
+  filed under the same heading as `add-repo-map`/`add-files`/etc. even
+  though it calls `snippet-text`, and `add-search-results` was filed one
+  heading below `build-pack`/`extend-pack` even though it calls
+  `try-add-search-hit`. The corrected reference graph needs a real 4th
+  layer (`build-pack`/`extend-pack` → `add-search-results` →
+  `try-add-search-hit` → `snippet-text`).
+
+Both are Wave 2 scope (real namespace split), not fixed here.
+
+## Testing Plan
+
+1. Ran plain (non-`--fix`) `stratum-lint` before the fix — reproduced the
+   baseline's 4 `SL002` findings exactly, zero `SL001`.
+2. Ran `--fix`, then a second and third `--fix` pass immediately after —
+   zero diff on both repeats, confirms idempotency.
+3. Read the full diff for all 8 changed files. No same-line trailing
+   comment was displaced onto the wrong def, and no `defmethod` exists in
+   this component (the two known tool-limitation patterns from the Wave 1
+   playbook don't apply here). Found and hand-fixed one stale docstring
+   (`interface.clj`, see Overview); re-ran `--fix` afterward to confirm
+   the manual edit is stable (no further rewrite).
+4. `clj-kondo --lint components/context-pack`: 0 errors, 0 warnings.
+5. Ran `ai.miniforge.context-pack.interface-test` directly via
+   `clojure -A:dev:test`: 11 tests, 29 assertions, 0 failures, 0 errors.
+6. Re-ran plain `stratum-lint` after the fix: `SL001`/`SL002`/`SL004`
+   clear. `SL003` now reports on `builder.clj` and `config.clj` (4 real
+   layers each) — both newly surfaced by the corrected grouping, not
+   pre-existing findings; documented above and deferred to Wave 2.
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+change — comment/metadata/order/docstring-only. Pre-commit's
+`lint:stratum` autofixer keeps this component clean going forward;
+`builder.clj` and `config.clj`'s `SL003` stay advisory
+(`MINIFORGE_STRATUM_BUDGET_MODE=warn` at commit time) until Wave 2 splits
+them.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+- Follow-on: Wave 2 namespace split for
+  `components/context-pack/src/ai/miniforge/context_pack/builder.clj` and
+  `components/context-pack/src/ai/miniforge/context_pack/config.clj`
+  (4 real layers each, over the 3-layer budget)
+
+## Checklist
+
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Second and third `--fix` passes confirm idempotency (zero diff)
+- [x] Diff read in full for all 8 changed files; one stale docstring
+      hand-corrected (documented above), no logic changes
+- [x] `clj-kondo` clean before/after (0 errors, 0 warnings)
+- [x] Component tests pass (11 tests, 29 assertions, 0 failures/errors)
+- [x] Plain lint re-run post-fix: zero findings except `SL003`
+      (`builder.clj`, `config.clj` — newly surfaced, documented above,
+      tracked as Wave 2)
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-context-pack.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-context-pack.md
@@ -8,13 +8,29 @@ file's actual same-file reference graph, and to tag every `def`/`defn`/
 `deftest` with real `^{:stratum n}` metadata. One of the smaller
 per-component Wave 1 PRs from `work/stratum-lint-baseline-2026-07-24.md`.
 
-No logic changes. One manual documentation correction beyond the raw
-`--fix` output: `interface.clj`'s namespace docstring claimed an internal
-`Layer 0 / Layer 1 / Layer 2` breakdown left over from the old decorative
-headings; the fix collapsed every def in that file to Layer 0 (each just
-delegates to another namespace, so there's no same-file reference depth
-between them), leaving the docstring's layer claims false. Reworded to
-drop the numbered-layer claim while keeping the section list.
+No logic changes. Four manual documentation corrections beyond the raw
+`--fix` output, all the same shape: a namespace docstring asserting a
+single `Layer N` (or an explicit `Layer 0/1/2` breakdown) that the fix
+falsified once the real same-file reference graph was computed.
+
+- `interface.clj` claimed an internal `Layer 0 / Layer 1 / Layer 2`
+  breakdown left over from the old decorative headings; every def in
+  that file collapsed to Layer 0 (each just delegates to another
+  namespace, so there's no same-file reference depth between them).
+  Reworded to drop the numbered-layer claim while keeping the section
+  list.
+- `dedup.clj`, `schema.clj`, and `config.clj` each claimed "Layer 0" (or
+  "no dependencies" / "no domain logic") for the whole file, which is
+  true of their *inter-file* dependencies (none of these three require
+  another context-pack namespace) but no longer true of their *intra-file*
+  structure once `--fix` exposed real same-file chains: `dedup.clj` and
+  `schema.clj` each have 2 real layers, `config.clj` has 4 (see below).
+  Caught during automated PR review (Copilot flagged `dedup.clj`
+  specifically); checking the other files with the same "Layer 0 — pure
+  X" phrasing turned up the same problem in `schema.clj` and
+  `config.clj`, so all three got the same treatment: drop the blanket
+  single-layer claim, state the real intra-file dependency instead,
+  point at the per-def `:stratum` metadata for the full breakdown.
 
 ## Motivation
 
@@ -97,6 +113,13 @@ Both are Wave 2 scope (real namespace split), not fixed here.
    clear. `SL003` now reports on `builder.clj` and `config.clj` (4 real
    layers each) — both newly surfaced by the corrected grouping, not
    pre-existing findings; documented above and deferred to Wave 2.
+7. Automated PR review flagged the same stale-docstring shape in
+   `dedup.clj`; checking the other files carrying the same "Layer 0 —
+   pure X" phrasing (`schema.clj`, `config.clj`) turned up the identical
+   problem in both. Hand-corrected all three (see Overview), then re-ran
+   `--fix` (no further rewrite — stable), `clj-kondo` (still 0/0), the
+   plain lint (same two `SL003` findings, nothing new), and the test
+   namespace (still 11 tests, 29 assertions, 0 failures/errors).
 
 ## Deployment Plan
 
@@ -119,8 +142,9 @@ them.
 
 - [x] `--fix` run over the whole component (`src` + `test`)
 - [x] Second and third `--fix` passes confirm idempotency (zero diff)
-- [x] Diff read in full for all 8 changed files; one stale docstring
-      hand-corrected (documented above), no logic changes
+- [x] Diff read in full for all 8 changed files; four stale docstrings
+      hand-corrected across two review passes (documented above), no
+      logic changes
 - [x] `clj-kondo` clean before/after (0 errors, 0 warnings)
 - [x] Component tests pass (11 tests, 29 assertions, 0 failures/errors)
 - [x] Plain lint re-run post-fix: zero findings except `SL003`


### PR DESCRIPTION
## Summary

- Runs `stratum-lint --fix` over `components/context-pack` (src + test), replacing decorative `Layer N` section banners with headings and `^{:stratum n}` metadata derived from each file's real same-file reference graph.
- Zero `SL001` (upward-reference/cycle) findings confirmed before running `--fix`, per Wave 1 batch criteria.
- Surfaces two new `SL003` findings (`builder.clj`, `config.clj` — 4 real layers each, over the 3-layer budget) that the baseline scan missed. Both deferred to Wave 2 (real namespace split).
- One manual documentation correction: `interface.clj`'s namespace docstring claimed a stale `Layer 0/1/2` breakdown; every def in that file collapsed to Layer 0 since none reference each other in-file.

Full details in `docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-context-pack.md`.

## Test plan

- [x] Plain lint before fix reproduced baseline's 4 `SL002` findings exactly, zero `SL001`
- [x] `--fix` run, then two more `--fix` passes — zero diff, confirms idempotency
- [x] Full diff read for all 8 changed files; no trailing-comment displacement, no `defmethod` in this component
- [x] `clj-kondo --lint components/context-pack`: 0 errors, 0 warnings
- [x] `ai.miniforge.context-pack.interface-test`: 11 tests, 29 assertions, 0 failures, 0 errors
- [x] Plain lint re-run post-fix: `SL001`/`SL002`/`SL004` clear; `SL003` remains on `builder.clj`/`config.clj` (newly surfaced, tracked as Wave 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)