### PR TITLE
fix: stratum-lint autofix for components/pr-train (Wave 1)

### DIFF
--- a/components/pr-train/src/ai/miniforge/pr_train/core.clj
+++ b/components/pr-train/src/ai/miniforge/pr_train/core.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-train.core
   "Core implementation of PR Train management.
    Provides PRTrainManager protocol and in-memory implementation."
@@ -24,9 +23,9 @@
    [ai.miniforge.pr-train.state :as state]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Protocol definition
 
-(defprotocol PRTrainManager
+;; Protocol definition
+(defprotocol ^{:stratum 0} PRTrainManager
   "Protocol for managing PR trains.
 
    PR trains are coordinated sets of related PRs that must merge
@@ -133,10 +132,57 @@
     "Retrieve evidence bundle by ID.
      Returns bundle or nil if not found."))
 
-;------------------------------------------------------------------------------ Layer 1
-;; In-memory implementation
+;; ── Utility functions for working with trains ───────────────────────────────
+(defn ^{:stratum 0} list-trains
+  "List all trains in a manager.
 
-(defrecord InMemoryPRTrainManager [trains evidence-bundles event-stream]
+   Returns full train maps."
+  [manager]
+  (->> @(:trains manager)
+       vals
+       (sort-by :train/created-at)
+       vec))
+
+(defn ^{:stratum 0} find-trains-by-status
+  "Find trains with a given status.
+
+   Returns vector of train-ids."
+  [manager status]
+  (->> @(:trains manager)
+       (filter (fn [[_id train]] (= status (:train/status train))))
+       (map first)
+       vec))
+
+(defn ^{:stratum 0} find-trains-by-dag
+  "Find trains using a specific DAG.
+
+   Returns vector of train-ids."
+  [manager dag-id]
+  (->> @(:trains manager)
+       (filter (fn [[_id train]] (= dag-id (:train/dag-id train))))
+       (map first)
+       vec))
+
+(defn ^{:stratum 0} train-contains-pr?
+  "Check if a train contains a specific PR."
+  [manager train-id repo pr-number]
+  (when-let [train (get-train manager train-id)]
+    (some #(and (= repo (:pr/repo %))
+                (= pr-number (:pr/number %)))
+          (:train/prs train))))
+
+(defn ^{:stratum 0} get-pr-from-train
+  "Get a PR from a train.
+
+   Returns TrainPR or nil if not found."
+  [manager train-id pr-number]
+  (when-let [train (get-train manager train-id)]
+    (state/find-pr train pr-number)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; In-memory implementation
+(defrecord ^{:stratum 1} InMemoryPRTrainManager [trains evidence-bundles event-stream]
   PRTrainManager
 
   ;; Lifecycle
@@ -398,9 +444,9 @@
     (get @evidence-bundles bundle-id)))
 
 ;------------------------------------------------------------------------------ Layer 2
-;; Factory function
 
-(defn create-manager
+;; Factory function
+(defn ^{:stratum 2} create-manager
   "Create a new in-memory PR train manager.
    Options:
    - :event-stream - Optional event stream for publishing merge events
@@ -408,54 +454,6 @@
   ([] (create-manager nil))
   ([opts]
    (->InMemoryPRTrainManager (atom {}) (atom {}) (:event-stream opts))))
-
-;; ── Utility functions for working with trains ───────────────────────────────
-
-(defn list-trains
-  "List all trains in a manager.
-
-   Returns full train maps."
-  [manager]
-  (->> @(:trains manager)
-       vals
-       (sort-by :train/created-at)
-       vec))
-
-(defn find-trains-by-status
-  "Find trains with a given status.
-
-   Returns vector of train-ids."
-  [manager status]
-  (->> @(:trains manager)
-       (filter (fn [[_id train]] (= status (:train/status train))))
-       (map first)
-       vec))
-
-(defn find-trains-by-dag
-  "Find trains using a specific DAG.
-
-   Returns vector of train-ids."
-  [manager dag-id]
-  (->> @(:trains manager)
-       (filter (fn [[_id train]] (= dag-id (:train/dag-id train))))
-       (map first)
-       vec))
-
-(defn train-contains-pr?
-  "Check if a train contains a specific PR."
-  [manager train-id repo pr-number]
-  (when-let [train (get-train manager train-id)]
-    (some #(and (= repo (:pr/repo %))
-                (= pr-number (:pr/number %)))
-          (:train/prs train))))
-
-(defn get-pr-from-train
-  "Get a PR from a train.
-
-   Returns TrainPR or nil if not found."
-  [manager train-id pr-number]
-  (when-let [train (get-train manager train-id)]
-    (state/find-pr train pr-number)))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/pr-train/src/ai/miniforge/pr_train/interface.clj
+++ b/components/pr-train/src/ai/miniforge/pr_train/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-train.interface
   "Public API for the pr-train component.
    Manages linked PR trains with coordinated state and merge ordering."
@@ -28,116 +27,123 @@
    [ai.miniforge.pr-train.tiers :as tiers]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Protocol and schema re-exports
 
-(def PRTrainManager
+;; Protocol and schema re-exports
+(def ^{:stratum 0} PRTrainManager
   "Protocol governing PR train management: lifecycle, state sync, queries,
    merge actions, rollback, and evidence generation. Implemented by the
    in-memory manager returned from create-manager."
   core/PRTrainManager)
 
 ;; Schema re-exports
-(def TrainPR
+(def ^{:stratum 0} TrainPR
   "Malli :map schema for an individual PR within a train (repo, number, url,
    branch, title, status, merge-order, depends-on/blocks vectors, ci-status,
    optional gate-results, intent, and Tier 2 governance fields)."
   schema/TrainPR)
-(def PRTrain
+
+(def ^{:stratum 0} PRTrain
   "Malli :map schema for a complete PR train: identity, status, the :train/prs
    vector, computed aggregate state (blocking-prs, ready-to-merge, progress),
    optional rollback plan and evidence reference, and timestamps."
   schema/PRTrain)
-(def EvidenceBundle
+
+(def ^{:stratum 0} EvidenceBundle
   "Malli :map schema for a train's complete evidence bundle: id, train-id,
    created-at, per-PR evidence vector, summary, and miniforge-version."
   schema/EvidenceBundle)
-(def GateResult
+
+(def ^{:stratum 0} GateResult
   "Malli :map schema for a single gate check result: gate id, type, passed?
    boolean, and optional message, details, and timestamp."
   schema/GateResult)
-(def TaskIntent
+
+(def ^{:stratum 0} TaskIntent
   "Malli :map schema for semantic intent attached to a PR: intent type plus
    optional invariants, forbidden-actions, and required-evidence vectors."
   schema/TaskIntent)
-(def Progress
+
+(def ^{:stratum 0} Progress
   "Malli :map schema for a train progress summary: :total, :merged, :approved,
    :pending, and :failed counts."
   schema/Progress)
-(def RollbackPlan
+
+(def ^{:stratum 0} RollbackPlan
   "Malli :map schema for a train rollback plan: trigger, action, optional
    checkpoint PR number, and the prs-to-revert vector."
   schema/RollbackPlan)
 
 ;; Enum value sets
-(def pr-statuses
+(def ^{:stratum 0} pr-statuses
   "Vector of the possible PR status keywords, ordered :draft through :failed."
   schema/pr-statuses)
-(def train-statuses
+
+(def ^{:stratum 0} train-statuses
   "Vector of the possible train status keywords, ordered :drafting through
    :abandoned."
   schema/train-statuses)
-(def ci-statuses
+
+(def ^{:stratum 0} ci-statuses
   "Vector of the possible CI status keywords: :pending :running :passed
    :failed :skipped."
   schema/ci-statuses)
-(def rollback-triggers
+
+(def ^{:stratum 0} rollback-triggers
   "Vector of the keywords that can trigger a rollback: :ci-failure
    :gate-failure :manual :timeout."
   schema/rollback-triggers)
-(def evidence-types
+
+(def ^{:stratum 0} evidence-types
   "Vector of the evidence artifact type keywords (e.g. :terraform-plan,
    :ci-log, :gate-results, :approval-record)."
   schema/evidence-types)
 
 ;; State machine re-exports
-(def train-transitions
+(def ^{:stratum 0} train-transitions
   "Map of train status keyword to the set of statuses it may transition to."
   state/train-transitions)
-(def pr-transitions
+
+(def ^{:stratum 0} pr-transitions
   "Map of PR status keyword to the set of statuses it may transition to."
   state/pr-transitions)
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Manager creation
-
-(def create-manager
+(def ^{:stratum 0} create-manager
   "Create a new PR train manager.
 
    Returns an InMemoryPRTrainManager instance."
   core/create-manager)
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Train lifecycle
-
-(defn create-train
+(defn ^{:stratum 0} create-train
   "Create a new PR train linked to a repo DAG.
 
    Returns train-id (UUID)."
   [manager name dag-id description]
   (core/create-train manager name dag-id description))
 
-(defn add-pr
+(defn ^{:stratum 0} add-pr
   "Add a PR to the train.
 
    Returns updated train or nil if train not found."
   [manager train-id repo pr-number url branch title]
   (core/add-pr manager train-id repo pr-number url branch title))
 
-(defn remove-pr
+(defn ^{:stratum 0} remove-pr
   "Remove a PR from the train.
 
    Returns updated train or nil if train/PR not found."
   [manager train-id pr-number]
   (core/remove-pr manager train-id pr-number))
 
-(defn link-prs
+(defn ^{:stratum 0} link-prs
   "Auto-compute depends-on/blocks relationships.
 
    Returns updated train."
   [manager train-id]
   (core/link-prs manager train-id))
 
-(defn link-prs-from-dag
+(defn ^{:stratum 0} link-prs-from-dag
   "Link PR dependencies based on actual DAG topology.
 
    Arguments:
@@ -151,217 +157,199 @@
   [manager train-id dag-deps-map task-to-pr-map]
   (core/link-prs-from-dag manager train-id dag-deps-map task-to-pr-map))
 
-;------------------------------------------------------------------------------ Layer 3
 ;; State management
-
-(defn sync-pr-status
+(defn ^{:stratum 0} sync-pr-status
   "Update status for all PRs from external source.
 
    Returns updated train."
   [manager train-id status-map]
   (core/sync-pr-status manager train-id status-map))
 
-(defn update-pr-status
+(defn ^{:stratum 0} update-pr-status
   "Update status for a single PR.
 
    Returns updated train or nil if invalid transition."
   [manager train-id pr-number new-status]
   (core/update-pr-status manager train-id pr-number new-status))
 
-(defn update-pr-ci-status
+(defn ^{:stratum 0} update-pr-ci-status
   "Update CI status for a single PR.
 
    Returns updated train."
   [manager train-id pr-number ci-status]
   (core/update-pr-ci-status manager train-id pr-number ci-status))
 
-;------------------------------------------------------------------------------ Layer 4
 ;; Queries
-
-(defn get-train
+(defn ^{:stratum 0} get-train
   "Retrieve a train by ID.
 
    Returns full PRTrain map or nil if not found."
   [manager train-id]
   (core/get-train manager train-id))
 
-(defn get-blocking
+(defn ^{:stratum 0} get-blocking
   "Return PRs that are blocking train progress.
 
    Returns vector of PR numbers sorted by merge order."
   [manager train-id]
   (core/get-blocking manager train-id))
 
-(defn get-ready-to-merge
+(defn ^{:stratum 0} get-ready-to-merge
   "Return PRs that can merge now.
 
    Returns vector of PR numbers sorted by merge order."
   [manager train-id]
   (core/get-ready-to-merge manager train-id))
 
-(defn get-progress
+(defn ^{:stratum 0} get-progress
   "Return progress summary.
 
    Returns {:total :merged :approved :pending :failed}."
   [manager train-id]
   (core/get-progress manager train-id))
 
-;------------------------------------------------------------------------------ Layer 5
 ;; Merge actions
-
-(defn merge-next
+(defn ^{:stratum 0} merge-next
   "Mark the next ready PR as merging.
 
    Returns {:pr-number :train} or nil if none ready."
   [manager train-id]
   (core/merge-next manager train-id))
 
-(defn complete-merge
+(defn ^{:stratum 0} complete-merge
   "Mark a PR merge as complete.
 
    Returns updated train."
   [manager train-id pr-number]
   (core/complete-merge manager train-id pr-number))
 
-(defn fail-merge
+(defn ^{:stratum 0} fail-merge
   "Mark a PR merge as failed.
 
    Returns updated train."
   [manager train-id pr-number reason]
   (core/fail-merge manager train-id pr-number reason))
 
-(defn merge-all-ready
-  "Get all PRs ready to merge in order.
-
-   Returns vector of PR numbers."
-  [manager train-id]
-  (get-ready-to-merge manager train-id))
-
-;------------------------------------------------------------------------------ Layer 6
 ;; Train control
-
-(defn pause-train
+(defn ^{:stratum 0} pause-train
   "Pause all train activity.
 
    Returns updated train."
   [manager train-id reason]
   (core/pause-train manager train-id reason))
 
-(defn resume-train
+(defn ^{:stratum 0} resume-train
   "Resume paused train.
 
    Returns updated train."
   [manager train-id]
   (core/resume-train manager train-id))
 
-(defn rollback
+(defn ^{:stratum 0} rollback
   "Plan rollback: compute which PRs to revert.
 
    Returns updated train with :train/rollback-plan set."
   [manager train-id trigger reason]
   (core/rollback manager train-id trigger reason))
 
-(defn abandon-train
+(defn ^{:stratum 0} abandon-train
   "Mark train as abandoned.
 
    Returns updated train."
   [manager train-id reason]
   (core/abandon-train manager train-id reason))
 
-;------------------------------------------------------------------------------ Layer 7
 ;; Evidence
-
-(defn generate-evidence-bundle
+(defn ^{:stratum 0} generate-evidence-bundle
   "Collect and bundle all evidence artifacts.
 
    Returns EvidenceBundle."
   [manager train-id]
   (core/generate-evidence-bundle manager train-id))
 
-(defn get-evidence-bundle
+(defn ^{:stratum 0} get-evidence-bundle
   "Retrieve evidence bundle by ID.
 
    Returns EvidenceBundle or nil if not found."
   [manager bundle-id]
   (core/get-evidence-bundle manager bundle-id))
 
-;------------------------------------------------------------------------------ Layer 8
 ;; Utility functions
-
-(def list-trains
+(def ^{:stratum 0} list-trains
   "List all trains in a manager."
   core/list-trains)
 
-(def find-trains-by-status
+(def ^{:stratum 0} find-trains-by-status
   "Find trains with a given status."
   core/find-trains-by-status)
 
-(def find-trains-by-dag
+(def ^{:stratum 0} find-trains-by-dag
   "Find trains using a specific DAG."
   core/find-trains-by-dag)
 
-(def train-contains-pr?
+(def ^{:stratum 0} train-contains-pr?
   "Check if a train contains a specific PR."
   core/train-contains-pr?)
 
-(def get-pr-from-train
+(def ^{:stratum 0} get-pr-from-train
   "Get a PR from a train."
   core/get-pr-from-train)
 
-;------------------------------------------------------------------------------ Layer 9
 ;; State machine queries
-
-(defn valid-train-transition?
+(defn ^{:stratum 0} valid-train-transition?
   "Check if a train status transition is valid."
   [from-status to-status]
   (state/valid-train-transition? from-status to-status))
 
-(defn valid-pr-transition?
+(defn ^{:stratum 0} valid-pr-transition?
   "Check if a PR status transition is valid."
   [from-status to-status]
   (state/valid-pr-transition? from-status to-status))
 
-(defn ready-to-merge?
+(defn ^{:stratum 0} ready-to-merge?
   "Check if a PR is ready to merge within a train context."
   [train pr]
   (state/ready-to-merge? train pr))
 
-;------------------------------------------------------------------------------ Layer 10
 ;; Readiness scoring (N9)
-
-(def compute-readiness-score
+(def ^{:stratum 0} compute-readiness-score
   "Compute weighted readiness score for a PR in a train. Returns double in [0.0, 1.0]."
   readiness/compute-readiness-score)
 
-(def explain-readiness
+(def ^{:stratum 0} explain-readiness
   "Explain readiness score breakdown. Returns map with :readiness/score, :readiness/factors."
   readiness/explain-readiness)
 
-;------------------------------------------------------------------------------ Layer 11
 ;; Risk assessment (N9)
-
-(def assess-risk
+(def ^{:stratum 0} assess-risk
   "Assess overall risk for a PR. Returns {:risk/score :risk/level :risk/factors}."
   risk/assess-risk)
 
-;------------------------------------------------------------------------------ Layer 12
 ;; Automation tiers (N9)
-
-(def get-automation-tier
+(def ^{:stratum 0} get-automation-tier
   "Get effective automation tier for a repository."
   tiers/get-automation-tier)
 
-(def tier-allows?
+(def ^{:stratum 0} tier-allows?
   "Check if a tier allows a specific operation given readiness and risk."
   tiers/tier-allows?)
 
-(def can-auto-approve?
+(def ^{:stratum 0} can-auto-approve?
   "Check if a PR can be auto-approved."
   tiers/can-auto-approve?)
 
-(def can-auto-merge?
+(def ^{:stratum 0} can-auto-merge?
   "Check if a PR can be auto-merged."
   tiers/can-auto-merge?)
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} merge-all-ready
+  "Get all PRs ready to merge in order.
+
+   Returns vector of PR numbers."
+  [manager train-id]
+  (get-ready-to-merge manager train-id))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/pr-train/src/ai/miniforge/pr_train/readiness.clj
+++ b/components/pr-train/src/ai/miniforge/pr_train/readiness.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-train.readiness
   "Deterministic readiness scoring (0.0–1.0) for PR merge decisions.
 
@@ -23,31 +22,21 @@
    that accounts for dependency state, CI, approvals, gates, age, and staleness.
 
    All scoring parameters are loaded from resources/config/governance/readiness.edn
-   and can be overridden at call time by passing a custom config.
-
-   Layer 0: Configuration (data)
-   Layer 1: Factor scoring functions
-   Layer 2: Aggregation and explainability"
+   and can be overridden at call time by passing a custom config."
   (:require
    [ai.miniforge.config.interface :as config]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Configuration — all tunable data in one place
 
-(def default-config
+;; Configuration — all tunable data in one place
+(def ^{:stratum 0} default-config
   "Default readiness scoring configuration loaded from resources/config/governance/readiness.edn.
    All weights, thresholds, and score maps are pure data. Override by passing
    a custom config to `compute-readiness-score` and `explain-readiness`."
   (config/load-governance-config :readiness))
 
-;; Backward-compatible aliases
-(def readiness-weights (:weights default-config))
-(def ^:const default-merge-threshold (:merge-threshold default-config))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; Factor scoring functions — each returns 0.0 (bad) to 1.0 (good)
-
-(defn score-deps-factor
+(defn ^{:stratum 0} score-deps-factor
   "Score based on how many dependencies are already merged.
    1.0 = all deps merged or no deps, 0.0 = no deps merged."
   [train pr _cfg]
@@ -61,17 +50,17 @@
             merged-count (count (filter merged-prs deps))]
         (double (/ merged-count (count deps)))))))
 
-(defn score-ci-factor
+(defn ^{:stratum 0} score-ci-factor
   "Score based on CI status. Scores looked up from :ci-scores config."
   [_train pr cfg]
   (get (:ci-scores cfg) (:pr/ci-status pr) 0.0))
 
-(defn score-approved-factor
+(defn ^{:stratum 0} score-approved-factor
   "Score based on PR approval status. Scores looked up from :approval-scores config."
   [_train pr cfg]
   (get (:approval-scores cfg) (:pr/status pr) 0.0))
 
-(defn score-gates-factor
+(defn ^{:stratum 0} score-gates-factor
   "Score based on gate pass rate.
    1.0 = all gates passed (or no gates), 0.0 = all gates failed."
   [_train pr _cfg]
@@ -81,16 +70,21 @@
       (let [passed (count (filter :gate/passed? gates))]
         (double (/ passed (count gates)))))))
 
-(defn score-behind-main-factor
+(defn ^{:stratum 0} score-behind-main-factor
   "Score based on whether the PR branch is behind main.
    1.0 = not behind main (CLEAN), 0.0 = behind main (BEHIND/DIRTY)."
   [_train pr _cfg]
   (if (:pr/behind-main? pr) 0.0 1.0))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Aggregation and explainability
+;------------------------------------------------------------------------------ Layer 1
 
-(def factor-fns
+;; Backward-compatible aliases
+(def ^{:stratum 1} readiness-weights (:weights default-config))
+
+(def ^{:stratum 1} ^:const default-merge-threshold (:merge-threshold default-config))
+
+;; Aggregation and explainability
+(def ^{:stratum 1} factor-fns
   "Map from factor keyword to scoring function."
   {:deps-merged       score-deps-factor
    :ci-passed         score-ci-factor
@@ -98,7 +92,9 @@
    :gates-passed      score-gates-factor
    :behind-main       score-behind-main-factor})
 
-(defn score-factor
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} score-factor
   "Score a single factor, returning its contribution map."
   [train pr cfg [factor weight]]
   (let [score-fn (get factor-fns factor)
@@ -108,7 +104,9 @@
      :score score
      :contribution (* weight score)}))
 
-(defn compute-readiness-score
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} compute-readiness-score
   "Compute weighted readiness score for a PR in a train.
 
    Arguments:
@@ -124,7 +122,7 @@
           (map (partial score-factor train pr cfg))
           (transduce (map :contribution) + 0.0)))))
 
-(defn explain-readiness
+(defn ^{:stratum 3} explain-readiness
   "Explain readiness score breakdown for a PR.
 
    Arguments:

--- a/components/pr-train/src/ai/miniforge/pr_train/risk.clj
+++ b/components/pr-train/src/ai/miniforge/pr_train/risk.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-train.risk
   "Explainable risk assessment for PRs with concrete factors.
 
@@ -24,37 +23,21 @@
    critical file modifications.
 
    All thresholds are loaded from resources/config/governance/risk.edn and can
-   be overridden by passing a config to `assess-risk`.
-
-   Layer 0: Configuration and risk factor definitions
-   Layer 1: Factor assessment functions
-   Layer 2: Aggregation and risk level classification"
+   be overridden by passing a config to `assess-risk`."
   (:require
    [ai.miniforge.config.interface :as config]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Configuration
 
-(def default-config
+;; Configuration
+(def ^{:stratum 0} default-config
   "Default risk assessment configuration loaded from resources/config/governance/risk.edn.
    All thresholds and weights are tunable — pass overrides to `assess-risk`
    via the `:config` key."
   (config/load-governance-config :risk))
 
-;; Derived public vars for backward compatibility and external use
-(def risk-factors
-  "Risk factor definitions with weights."
-  (into {} (map (fn [[k v]] [k {:weight v :description (name k)}])
-                (:weights default-config))))
-
-(def risk-levels
-  "Risk level thresholds."
-  (:levels default-config))
-
-;------------------------------------------------------------------------------ Layer 0
 ;; Threshold scoring helper
-
-(defn score-by-thresholds
+(defn ^{:stratum 0} score-by-thresholds
   "Score a value against descending thresholds. Returns the score for the first
    threshold exceeded, or 0.0 if none match."
   [value thresholds scores compare-fn]
@@ -63,47 +46,7 @@
             (map vector thresholds scores))
       0.0))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Factor assessment functions — each returns {:value any :score 0.0-1.0 :explanation str}
-
-(defn assess-change-size
-  "Assess risk from change size. Larger changes = higher risk."
-  [pr-data cfg]
-  (let [{:keys [additions deletions]} (get pr-data :change-size {:additions 0 :deletions 0})
-        total (+ (or additions 0) (or deletions 0))
-        {:keys [thresholds scores]} (:change-size cfg)
-        score (score-by-thresholds total thresholds scores >)]
-    {:value {:additions additions :deletions deletions :total total}
-     :score score
-     :explanation (str total " lines changed"
-                       (when (> total 500) " (large change)"))}))
-
-(defn assess-dependency-fanout
-  "Assess risk from dependency fanout. More dependents = higher risk."
-  [_train pr cfg]
-  (let [blocks (:pr/blocks pr [])
-        fanout (count blocks)
-        {:keys [thresholds scores exact-one]} (:dependency-fanout cfg)
-        score (if (= fanout 1)
-                exact-one
-                (score-by-thresholds fanout thresholds scores >))]
-    {:value fanout
-     :score score
-     :explanation (str fanout " downstream PRs depend on this")}))
-
-(defn assess-test-coverage-delta
-  "Assess risk from test coverage changes. Decreased coverage = higher risk."
-  [pr-data cfg]
-  (let [delta (get pr-data :test-coverage-delta 0.0)
-        {:keys [thresholds scores]} (:test-coverage-delta cfg)
-        score (score-by-thresholds delta thresholds scores <)]
-    {:value delta
-     :score score
-     :explanation (if (neg? delta)
-                    (str "Coverage decreased by " (Math/abs delta) "%")
-                    (str "Coverage changed by " (if (pos? delta) "+" "") delta "%"))}))
-
-(defn assess-author-experience
+(defn ^{:stratum 0} assess-author-experience
   "Assess risk from author experience. Less experience = higher risk."
   [author-history cfg]
   (let [commits (get author-history :total-commits 0)
@@ -119,7 +62,57 @@
      :score score
      :explanation (str commits " total commits, " recent " recent")}))
 
-(defn assess-review-staleness
+;------------------------------------------------------------------------------ Layer 1
+
+;; Derived public vars for backward compatibility and external use
+(def ^{:stratum 1} risk-factors
+  "Risk factor definitions with weights."
+  (into {} (map (fn [[k v]] [k {:weight v :description (name k)}])
+                (:weights default-config))))
+
+(def ^{:stratum 1} risk-levels
+  "Risk level thresholds."
+  (:levels default-config))
+
+;; Factor assessment functions — each returns {:value any :score 0.0-1.0 :explanation str}
+(defn ^{:stratum 1} assess-change-size
+  "Assess risk from change size. Larger changes = higher risk."
+  [pr-data cfg]
+  (let [{:keys [additions deletions]} (get pr-data :change-size {:additions 0 :deletions 0})
+        total (+ (or additions 0) (or deletions 0))
+        {:keys [thresholds scores]} (:change-size cfg)
+        score (score-by-thresholds total thresholds scores >)]
+    {:value {:additions additions :deletions deletions :total total}
+     :score score
+     :explanation (str total " lines changed"
+                       (when (> total 500) " (large change)"))}))
+
+(defn ^{:stratum 1} assess-dependency-fanout
+  "Assess risk from dependency fanout. More dependents = higher risk."
+  [_train pr cfg]
+  (let [blocks (:pr/blocks pr [])
+        fanout (count blocks)
+        {:keys [thresholds scores exact-one]} (:dependency-fanout cfg)
+        score (if (= fanout 1)
+                exact-one
+                (score-by-thresholds fanout thresholds scores >))]
+    {:value fanout
+     :score score
+     :explanation (str fanout " downstream PRs depend on this")}))
+
+(defn ^{:stratum 1} assess-test-coverage-delta
+  "Assess risk from test coverage changes. Decreased coverage = higher risk."
+  [pr-data cfg]
+  (let [delta (get pr-data :test-coverage-delta 0.0)
+        {:keys [thresholds scores]} (:test-coverage-delta cfg)
+        score (score-by-thresholds delta thresholds scores <)]
+    {:value delta
+     :score score
+     :explanation (if (neg? delta)
+                    (str "Coverage decreased by " (Math/abs delta) "%")
+                    (str "Coverage changed by " (if (pos? delta) "+" "") delta "%"))}))
+
+(defn ^{:stratum 1} assess-review-staleness
   "Assess risk from review staleness. Stale reviews = higher risk."
   [pr-data cfg]
   (let [hours (get pr-data :hours-since-last-review 0)
@@ -129,7 +122,7 @@
      :score score
      :explanation (str hours " hours since last review")}))
 
-(defn assess-complexity-delta
+(defn ^{:stratum 1} assess-complexity-delta
   "Assess risk from complexity changes. Increased complexity = higher risk."
   [pr-data cfg]
   (let [delta (get pr-data :complexity-delta 0)
@@ -140,7 +133,7 @@
      :explanation (str "Complexity " (if (pos? delta) "increased" "changed")
                        " by " delta)}))
 
-(defn assess-critical-files
+(defn ^{:stratum 1} assess-critical-files
   "Assess risk from modifications to critical files."
   [pr-data cfg]
   (let [changed-files (get pr-data :changed-files [])
@@ -159,10 +152,8 @@
                     (str count-critical " critical file(s) modified")
                     "No critical files modified")}))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Aggregation and risk level classification
-
-(defn score->level
+(defn ^{:stratum 1} score->level
   "Convert risk score to risk level keyword."
   ([score] (score->level score (:levels default-config)))
   ([score levels]
@@ -172,7 +163,9 @@
      (>= score (:medium levels))   :medium
      :else                         :low)))
 
-(defn assess-risk
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} assess-risk
   "Assess overall risk for a PR.
 
    Arguments:

--- a/components/pr-train/src/ai/miniforge/pr_train/schema.clj
+++ b/components/pr-train/src/ai/miniforge/pr_train/schema.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-train.schema
   "Malli schemas for PR Train component.
    Defines TrainPR, PRTrain, EvidenceBundle, and related types."
@@ -23,38 +22,38 @@
    [malli.core :as m]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Enums and base types
 
-(def pr-statuses
+;; Enums and base types
+(def ^{:stratum 0} pr-statuses
   [:draft :open :reviewing :changes-requested
    :approved :merging :merged :closed :failed])
 
-(def train-statuses
+(def ^{:stratum 0} train-statuses
   [:drafting :open :reviewing :merging
    :merged :failed :rolled-back :abandoned])
 
-(def ci-statuses
+(def ^{:stratum 0} ci-statuses
   [:pending :running :passed :failed :skipped])
 
-(def rollback-triggers
+(def ^{:stratum 0} rollback-triggers
   [:ci-failure :gate-failure :manual :timeout])
 
-(def rollback-actions
+(def ^{:stratum 0} rollback-actions
   "Actions to take on rollback."
   [:revert-all :revert-to-checkpoint :pause])
 
-(def evidence-types
+(def ^{:stratum 0} evidence-types
   [:terraform-plan :atlantis-log :ci-log
    :gate-results :intent-validation :approval-record])
 
-(def intent-types
+(def ^{:stratum 0} intent-types
   "Types of semantic intent."
   [:create :import :modify :delete :migrate])
 
 ;------------------------------------------------------------------------------ Layer 1
-;; Registry
 
-(def registry
+;; Registry
+(def ^{:stratum 1} registry
   "Malli registry for PR train types."
   {;; Identifiers
    :id/uuid uuid?
@@ -86,9 +85,9 @@
    :common/pos-number [:double {:min 0.0}]})
 
 ;------------------------------------------------------------------------------ Layer 2
-;; Gate result schema
 
-(def GateResult
+;; Gate result schema
+(def ^{:stratum 2} GateResult
   [:map {:registry registry}
    [:gate/id keyword?]
    [:gate/type keyword?]
@@ -97,10 +96,8 @@
    [:gate/details {:optional true} [:map-of keyword? any?]]
    [:gate/timestamp {:optional true} :common/timestamp]])
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Task intent schema (for semantic validation)
-
-(def Invariant
+(def ^{:stratum 2} Invariant
   "Schema for an intent invariant."
   [:map {:registry registry}
    [:invariant/id keyword?]
@@ -110,17 +107,61 @@
      [:type [:enum :plan-output :diff-analysis :state-comparison]]
      [:condition any?]]]])
 
-(def TaskIntent
+;; Progress schema
+(def ^{:stratum 2} Progress
+  [:map {:registry registry}
+   [:total pos-int?]
+   [:merged :common/non-neg-int]
+   [:approved :common/non-neg-int]
+   [:pending :common/non-neg-int]
+   [:failed :common/non-neg-int]])
+
+;; Rollback plan schema
+(def ^{:stratum 2} RollbackPlan
+  [:map {:registry registry}
+   [:trigger (into [:enum] rollback-triggers)]
+   [:action (into [:enum] rollback-actions)]
+   [:checkpoint {:optional true} :pr/number]
+   [:prs-to-revert [:vector :pr/number]]])
+
+;; Evidence artifact schema
+(def ^{:stratum 2} EvidenceArtifact
+  "Schema for an individual evidence artifact."
+  [:map {:registry registry}
+   [:type :evidence/type]
+   [:content :id/string]
+   [:hash :id/string]
+   [:timestamp :common/timestamp]])
+
+(def ^{:stratum 2} EvidenceSummary
+  "Schema for evidence bundle summary."
+  [:map {:registry registry}
+   [:total-prs pos-int?]
+   [:gates-passed :common/non-neg-int]
+   [:gates-failed :common/non-neg-int]
+   [:human-approvals :common/non-neg-int]
+   [:semantic-violations :common/non-neg-int]])
+
+;------------------------------------------------------------------------------ Layer 3
+
+(def ^{:stratum 3} TaskIntent
   [:map {:registry registry}
    [:intent/type (into [:enum] intent-types)]
    [:intent/invariants {:optional true} [:vector Invariant]]
    [:intent/forbidden-actions {:optional true} [:vector keyword?]]
    [:intent/required-evidence {:optional true} [:vector keyword?]]])
 
-;------------------------------------------------------------------------------ Layer 4
-;; TrainPR schema
+(def ^{:stratum 3} PREvidence
+  "Schema for evidence associated with a single PR."
+  [:map {:registry registry}
+   [:pr/repo :pr/repo]
+   [:pr/number :pr/number]
+   [:evidence/artifacts [:vector EvidenceArtifact]]])
 
-(def TrainPR
+;------------------------------------------------------------------------------ Layer 4
+
+;; TrainPR schema
+(def ^{:stratum 4} TrainPR
   [:map {:registry registry}
    [:pr/repo :pr/repo]
    [:pr/number :pr/number]
@@ -152,31 +193,19 @@
        [:additions :common/non-neg-int]
        [:deletions :common/non-neg-int]]]]]])
 
+(def ^{:stratum 4} EvidenceBundle
+  [:map {:registry registry}
+   [:evidence/id :evidence/id]
+   [:evidence/train-id :train/id]
+   [:evidence/created-at :common/timestamp]
+   [:evidence/prs [:vector PREvidence]]
+   [:evidence/summary EvidenceSummary]
+   [:evidence/miniforge-version :id/string]])
+
 ;------------------------------------------------------------------------------ Layer 5
-;; Progress schema
 
-(def Progress
-  [:map {:registry registry}
-   [:total pos-int?]
-   [:merged :common/non-neg-int]
-   [:approved :common/non-neg-int]
-   [:pending :common/non-neg-int]
-   [:failed :common/non-neg-int]])
-
-;------------------------------------------------------------------------------ Layer 6
-;; Rollback plan schema
-
-(def RollbackPlan
-  [:map {:registry registry}
-   [:trigger (into [:enum] rollback-triggers)]
-   [:action (into [:enum] rollback-actions)]
-   [:checkpoint {:optional true} :pr/number]
-   [:prs-to-revert [:vector :pr/number]]])
-
-;------------------------------------------------------------------------------ Layer 7
 ;; PRTrain schema
-
-(def PRTrain
+(def ^{:stratum 5} PRTrain
   [:map {:registry registry}
    [:train/id :train/id]
    [:train/name :train/name]
@@ -200,42 +229,6 @@
    [:train/created-at :common/timestamp]
    [:train/updated-at :common/timestamp]
    [:train/merged-at {:optional true} :common/timestamp]])
-
-;------------------------------------------------------------------------------ Layer 8
-;; Evidence artifact schema
-
-(def EvidenceArtifact
-  "Schema for an individual evidence artifact."
-  [:map {:registry registry}
-   [:type :evidence/type]
-   [:content :id/string]
-   [:hash :id/string]
-   [:timestamp :common/timestamp]])
-
-(def PREvidence
-  "Schema for evidence associated with a single PR."
-  [:map {:registry registry}
-   [:pr/repo :pr/repo]
-   [:pr/number :pr/number]
-   [:evidence/artifacts [:vector EvidenceArtifact]]])
-
-(def EvidenceSummary
-  "Schema for evidence bundle summary."
-  [:map {:registry registry}
-   [:total-prs pos-int?]
-   [:gates-passed :common/non-neg-int]
-   [:gates-failed :common/non-neg-int]
-   [:human-approvals :common/non-neg-int]
-   [:semantic-violations :common/non-neg-int]])
-
-(def EvidenceBundle
-  [:map {:registry registry}
-   [:evidence/id :evidence/id]
-   [:evidence/train-id :train/id]
-   [:evidence/created-at :common/timestamp]
-   [:evidence/prs [:vector PREvidence]]
-   [:evidence/summary EvidenceSummary]
-   [:evidence/miniforge-version :id/string]])
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/pr-train/src/ai/miniforge/pr_train/state.clj
+++ b/components/pr-train/src/ai/miniforge/pr_train/state.clj
@@ -15,15 +15,14 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-train.state
   "State machine for PR trains and individual PRs.
    Manages valid transitions and state computations.")
 
 ;------------------------------------------------------------------------------ Layer 0
-;; State machine definitions
 
-(def train-transitions
+;; State machine definitions
+(def ^{:stratum 0} train-transitions
   "Valid train status transitions.
    DRAFTING -> OPEN -> REVIEWING -> MERGING -> MERGED
                                           |
@@ -39,7 +38,7 @@
    :rolled-back #{}
    :abandoned   #{}})
 
-(def pr-transitions
+(def ^{:stratum 0} pr-transitions
   {:draft             #{:open :closed}
    :open              #{:reviewing :closed}
    :reviewing         #{:changes-requested :approved :closed}
@@ -48,40 +47,15 @@
    :merging           #{:merged :failed}
    :merged            #{}
    :closed            #{:open}  ; Can reopen
-   :failed            #{:open}}) ; Can retry
+   :failed            #{:open}})  ; Can retry
 
-;------------------------------------------------------------------------------ Layer 1
-;; Transition validation
-
-(defn valid-train-transition?
-  "Check if a train status transition is valid."
-  [from-status to-status]
-  (contains? (get train-transitions from-status #{}) to-status))
-
-(defn valid-pr-transition?
-  "Check if a PR status transition is valid."
-  [from-status to-status]
-  (contains? (get pr-transitions from-status #{}) to-status))
-
-(defn terminal-train-status?
-  "Check if a train status is terminal (no further transitions)."
-  [status]
-  (empty? (get train-transitions status #{})))
-
-(defn terminal-pr-status?
-  "Check if a PR status is terminal."
-  [status]
-  (empty? (get pr-transitions status #{})))
-
-;------------------------------------------------------------------------------ Layer 2
 ;; Train state creation and updates
-
-(defn update-timestamp
+(defn ^{:stratum 0} update-timestamp
   "Update the updated-at timestamp."
   [train]
   (assoc train :train/updated-at (java.util.Date.)))
 
-(defn create-train-state
+(defn ^{:stratum 0} create-train-state
   "Create initial train state.
 
    Arguments:
@@ -107,23 +81,8 @@
      :train/updated-at now
      :train/merged-at nil}))
 
-(defn transition-train-status
-  "Transition train to a new status if valid.
-
-   Returns updated train or nil if transition is invalid."
-  [train new-status]
-  (let [current-status (:train/status train)]
-    (when (valid-train-transition? current-status new-status)
-      (-> train
-          (assoc :train/status new-status)
-          (cond-> (= new-status :merged)
-            (assoc :train/merged-at (java.util.Date.)))
-          update-timestamp))))
-
-;------------------------------------------------------------------------------ Layer 3
 ;; PR state management within train
-
-(defn create-pr-state
+(defn ^{:stratum 0} create-pr-state
   "Create a new PR state for addition to a train.
 
    Arguments:
@@ -149,12 +108,62 @@
    :pr/gate-results nil
    :pr/intent nil})
 
-(defn find-pr
+(defn ^{:stratum 0} find-pr
   "Find a PR in the train by number."
   [train pr-number]
   (first (filter #(= pr-number (:pr/number %)) (:train/prs train))))
 
-(defn update-pr
+(defn ^{:stratum 0} gates-passed?
+  "Check if all gates have passed for a PR."
+  [pr]
+  (let [gate-results (:pr/gate-results pr)]
+    (or (nil? gate-results)
+        (empty? gate-results)
+        (every? :gate/passed? gate-results))))
+
+;; Progress computation
+(defn ^{:stratum 0} compute-progress
+  "Compute progress summary for a train.
+
+   Returns a Progress map with counts of PRs in each state."
+  [train]
+  (let [prs (:train/prs train)
+        total (count prs)]
+    (when (pos? total)
+      (let [merged (count (filter #(= :merged (:pr/status %)) prs))
+            approved (count (filter #(= :approved (:pr/status %)) prs))
+            failed (count (filter #(= :failed (:pr/status %)) prs))
+            pending (- total merged approved failed)]
+        {:total total
+         :merged merged
+         :approved approved
+         :pending pending
+         :failed failed}))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Transition validation
+(defn ^{:stratum 1} valid-train-transition?
+  "Check if a train status transition is valid."
+  [from-status to-status]
+  (contains? (get train-transitions from-status #{}) to-status))
+
+(defn ^{:stratum 1} valid-pr-transition?
+  "Check if a PR status transition is valid."
+  [from-status to-status]
+  (contains? (get pr-transitions from-status #{}) to-status))
+
+(defn ^{:stratum 1} terminal-train-status?
+  "Check if a train status is terminal (no further transitions)."
+  [status]
+  (empty? (get train-transitions status #{})))
+
+(defn ^{:stratum 1} terminal-pr-status?
+  "Check if a PR status is terminal."
+  [status]
+  (empty? (get pr-transitions status #{})))
+
+(defn ^{:stratum 1} update-pr
   "Update a PR in the train by number.
 
    Arguments:
@@ -174,7 +183,54 @@
                       prs)))
       update-timestamp))
 
-(defn transition-pr-status
+;; Ready-to-merge computation
+(defn ^{:stratum 1} pr-merged?
+  "Check if a PR is merged."
+  [train pr-number]
+  (when-let [pr (find-pr train pr-number)]
+    (= :merged (:pr/status pr))))
+
+;; Rollback planning
+(defn ^{:stratum 1} compute-rollback-plan
+  "Compute a rollback plan for the train.
+
+   Arguments:
+   - train: The PRTrain
+   - trigger: What triggered the rollback
+   - action: What action to take
+
+   Returns updated train with rollback plan."
+  [train trigger action]
+  (let [merged-prs (->> (:train/prs train)
+                        (filter #(= :merged (:pr/status %)))
+                        (sort-by :pr/merge-order >)  ; Reverse order
+                        (mapv :pr/number))
+        checkpoint (when (seq merged-prs)
+                     (first (sort merged-prs)))]  ; First merged PR
+    (-> train
+        (assoc :train/rollback-plan
+               {:trigger trigger
+                :action action
+                :checkpoint checkpoint
+                :prs-to-revert merged-prs})
+        update-timestamp)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} transition-train-status
+  "Transition train to a new status if valid.
+
+   Returns updated train or nil if transition is invalid."
+  [train new-status]
+  (let [current-status (:train/status train)]
+    (when (valid-train-transition? current-status new-status)
+      (-> train
+          (assoc :train/status new-status)
+          (cond-> (= new-status :merged)
+            (assoc :train/merged-at (java.util.Date.)))
+          update-timestamp))))
+
+(defn ^{:stratum 2} transition-pr-status
   "Transition a PR to a new status if valid.
 
    Returns updated train or nil if transition is invalid."
@@ -184,29 +240,52 @@
       (when (valid-pr-transition? current-status new-status)
         (update-pr train pr-number #(assoc % :pr/status new-status))))))
 
-;------------------------------------------------------------------------------ Layer 4
-;; Ready-to-merge computation
-
-(defn pr-merged?
-  "Check if a PR is merged."
-  [train pr-number]
-  (when-let [pr (find-pr train pr-number)]
-    (= :merged (:pr/status pr))))
-
-(defn deps-merged?
+(defn ^{:stratum 2} deps-merged?
   "Check if all dependencies of a PR are merged."
   [train pr]
   (every? #(pr-merged? train %) (:pr/depends-on pr)))
 
-(defn gates-passed?
-  "Check if all gates have passed for a PR."
-  [pr]
-  (let [gate-results (:pr/gate-results pr)]
-    (or (nil? gate-results)
-        (empty? gate-results)
-        (every? :gate/passed? gate-results))))
+;; Auto-transition based on PR states
+(defn ^{:stratum 2} infer-train-status
+  "Infer what the train status should be based on PR states.
 
-(defn ready-to-merge?
+   Returns suggested new status or nil if no change needed."
+  [train]
+  (let [prs (:train/prs train)
+        current-status (:train/status train)]
+    (cond
+      ;; All PRs merged -> train is merged
+      (and (seq prs)
+           (every? #(= :merged (:pr/status %)) prs)
+           (not= :merged current-status))
+      :merged
+
+      ;; Any PR failed -> train failed
+      (and (some #(= :failed (:pr/status %)) prs)
+           (not= :failed current-status)
+           (not (terminal-train-status? current-status)))
+      :failed
+
+      ;; Any PR merging -> train is merging
+      (and (some #(= :merging (:pr/status %)) prs)
+           (= :reviewing current-status))
+      :merging
+
+      ;; Any PR reviewing/approved -> train is reviewing
+      (and (some #(#{:reviewing :approved} (:pr/status %)) prs)
+           (= :open current-status))
+      :reviewing
+
+      ;; Any PR open -> train is open
+      (and (some #(= :open (:pr/status %)) prs)
+           (= :drafting current-status))
+      :open
+
+      :else nil)))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} ready-to-merge?
   "Check if a PR is ready to merge.
 
    A PR is ready when:
@@ -220,7 +299,18 @@
        (= :passed (:pr/ci-status pr))
        (gates-passed? pr)))
 
-(defn compute-ready-to-merge
+(defn ^{:stratum 3} auto-transition-train
+  "Automatically transition train status based on PR states.
+
+   Returns updated train or original if no transition needed."
+  [train]
+  (if-let [new-status (infer-train-status train)]
+    (or (transition-train-status train new-status) train)
+    train))
+
+;------------------------------------------------------------------------------ Layer 4
+
+(defn ^{:stratum 4} compute-ready-to-merge
   "Compute list of PR numbers ready to merge.
 
    Returns vector of PR numbers sorted by merge order."
@@ -230,10 +320,8 @@
        (sort-by :pr/merge-order)
        (mapv :pr/number)))
 
-;------------------------------------------------------------------------------ Layer 5
 ;; Blocking PR computation
-
-(defn pr-blocking?
+(defn ^{:stratum 4} pr-blocking?
   "Check if a PR is blocking train progress.
 
    A PR is blocking when:
@@ -245,7 +333,9 @@
         not-ready? (not (ready-to-merge? train pr))]
     (and deps-ok? not-merged? not-ready?)))
 
-(defn compute-blocking-prs
+;------------------------------------------------------------------------------ Layer 5
+
+(defn ^{:stratum 5} compute-blocking-prs
   "Compute list of PR numbers that are blocking progress.
 
    Returns vector of PR numbers sorted by merge order."
@@ -256,30 +346,9 @@
        (mapv :pr/number)))
 
 ;------------------------------------------------------------------------------ Layer 6
-;; Progress computation
 
-(defn compute-progress
-  "Compute progress summary for a train.
-
-   Returns a Progress map with counts of PRs in each state."
-  [train]
-  (let [prs (:train/prs train)
-        total (count prs)]
-    (when (pos? total)
-      (let [merged (count (filter #(= :merged (:pr/status %)) prs))
-            approved (count (filter #(= :approved (:pr/status %)) prs))
-            failed (count (filter #(= :failed (:pr/status %)) prs))
-            pending (- total merged approved failed)]
-        {:total total
-         :merged merged
-         :approved approved
-         :pending pending
-         :failed failed}))))
-
-;------------------------------------------------------------------------------ Layer 7
 ;; Aggregate state recomputation
-
-(defn recompute-train-state
+(defn ^{:stratum 6} recompute-train-state
   "Recompute all derived state for a train.
 
    Updates:
@@ -295,10 +364,10 @@
       (assoc :train/progress (compute-progress train))
       update-timestamp))
 
-;------------------------------------------------------------------------------ Layer 8
-;; Dependency linking
+;------------------------------------------------------------------------------ Layer 7
 
-(defn link-pr-dependencies
+;; Dependency linking
+(defn ^{:stratum 7} link-pr-dependencies
   "Link PR dependencies based on merge order.
 
    PRs depend on all PRs with lower merge order.
@@ -326,10 +395,8 @@
         (assoc :train/prs linked-prs)
         recompute-train-state)))
 
-;------------------------------------------------------------------------------ Layer 8b
 ;; DAG-aware dependency linking
-
-(defn link-prs-from-dag
+(defn ^{:stratum 7} link-prs-from-dag
   "Link PR dependencies based on actual DAG topology rather than linear merge order.
 
    Arguments:
@@ -367,82 +434,6 @@
     (-> train
         (assoc :train/prs linked-prs)
         recompute-train-state)))
-
-;------------------------------------------------------------------------------ Layer 9
-;; Rollback planning
-
-(defn compute-rollback-plan
-  "Compute a rollback plan for the train.
-
-   Arguments:
-   - train: The PRTrain
-   - trigger: What triggered the rollback
-   - action: What action to take
-
-   Returns updated train with rollback plan."
-  [train trigger action]
-  (let [merged-prs (->> (:train/prs train)
-                        (filter #(= :merged (:pr/status %)))
-                        (sort-by :pr/merge-order >)  ; Reverse order
-                        (mapv :pr/number))
-        checkpoint (when (seq merged-prs)
-                     (first (sort merged-prs)))]  ; First merged PR
-    (-> train
-        (assoc :train/rollback-plan
-               {:trigger trigger
-                :action action
-                :checkpoint checkpoint
-                :prs-to-revert merged-prs})
-        update-timestamp)))
-
-;------------------------------------------------------------------------------ Layer 10
-;; Auto-transition based on PR states
-
-(defn infer-train-status
-  "Infer what the train status should be based on PR states.
-
-   Returns suggested new status or nil if no change needed."
-  [train]
-  (let [prs (:train/prs train)
-        current-status (:train/status train)]
-    (cond
-      ;; All PRs merged -> train is merged
-      (and (seq prs)
-           (every? #(= :merged (:pr/status %)) prs)
-           (not= :merged current-status))
-      :merged
-
-      ;; Any PR failed -> train failed
-      (and (some #(= :failed (:pr/status %)) prs)
-           (not= :failed current-status)
-           (not (terminal-train-status? current-status)))
-      :failed
-
-      ;; Any PR merging -> train is merging
-      (and (some #(= :merging (:pr/status %)) prs)
-           (= :reviewing current-status))
-      :merging
-
-      ;; Any PR reviewing/approved -> train is reviewing
-      (and (some #(#{:reviewing :approved} (:pr/status %)) prs)
-           (= :open current-status))
-      :reviewing
-
-      ;; Any PR open -> train is open
-      (and (some #(= :open (:pr/status %)) prs)
-           (= :drafting current-status))
-      :open
-
-      :else nil)))
-
-(defn auto-transition-train
-  "Automatically transition train status based on PR states.
-
-   Returns updated train or original if no transition needed."
-  [train]
-  (if-let [new-status (infer-train-status train)]
-    (or (transition-train-status train new-status) train)
-    train))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/pr-train/src/ai/miniforge/pr_train/tiers.clj
+++ b/components/pr-train/src/ai/miniforge/pr_train/tiers.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-train.tiers
   "Automation tier enforcement for PR trains.
 
@@ -31,40 +30,66 @@
 
    Tier definitions are loaded from resources/config/governance/tiers.edn
    and can be overridden by passing a custom definitions map to `tier-allows?`
-   and related functions.
-
-   Layer 0: Tier definitions (data)
-   Layer 1: Tier enforcement functions"
+   and related functions."
   (:require
    [ai.miniforge.config.interface :as config]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Tier definitions — pure data, no code
 
-(def default-tier-definitions
+;; Tier definitions — pure data, no code
+(def ^{:stratum 0} default-tier-definitions
   "Default automation tier constraint definitions loaded from
    resources/config/governance/tiers.edn."
   (config/load-governance-config :tiers))
 
-;; Backward-compatible alias
-(def tier-definitions
-  "Automation tier constraint definitions."
-  default-tier-definitions)
-
-(def risk-level-order
+(def ^{:stratum 0} risk-level-order
   "Risk levels ordered from lowest to highest."
   {:low 0 :medium 1 :high 2 :critical 3})
 
-;------------------------------------------------------------------------------ Layer 1
-;; Tier enforcement functions
+(defn ^{:stratum 0} get-repo-tier
+  "Look up the automation tier for a repository.
 
-(defn risk-within-limit?
+   Arguments:
+   - repo-config - Map of repo-id -> config with :automation-tier
+   - repo-id - Repository identifier string
+
+   Returns: Keyword :tier-0 through :tier-3 (default: :tier-1)"
+  [repo-config repo-id]
+  (get-in repo-config [repo-id :automation-tier] :tier-1))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Backward-compatible alias
+(def ^{:stratum 1} tier-definitions
+  "Automation tier constraint definitions."
+  default-tier-definitions)
+
+;; Tier enforcement functions
+(defn ^{:stratum 1} risk-within-limit?
   "Check if a risk level is within the tier's maximum allowed level."
   [actual-level max-level]
   (<= (get risk-level-order actual-level 99)
       (get risk-level-order max-level 99)))
 
-(defn check-operation
+(defn ^{:stratum 1} get-automation-tier
+  "Get the effective automation tier with full definition.
+
+   Arguments:
+   - repo-config - Repository configuration map
+   - repo-id - Repository identifier
+   - tiers - Optional tier definitions map
+
+   Returns: {:tier kw :definition map}"
+  ([repo-config repo-id]
+   (get-automation-tier repo-config repo-id default-tier-definitions))
+  ([repo-config repo-id tiers]
+   (let [tier (get-repo-tier repo-config repo-id)]
+     {:tier tier
+      :definition (get tiers tier)})))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} check-operation
   "Check if a tier definition allows an operation given readiness and risk."
   [tier-def operation-key readiness risk-level]
   (and (get tier-def operation-key)
@@ -74,7 +99,9 @@
               (or (nil? min-readiness)
                   (>= readiness min-readiness))))))
 
-(defn tier-allows?
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} tier-allows?
   "Check if a tier allows a specific operation given readiness and risk.
 
    Arguments:
@@ -96,46 +123,21 @@
          :auto-merge   (check-operation tier-def :auto-merge? readiness risk-level)
          false)))))
 
-(defn get-repo-tier
-  "Look up the automation tier for a repository.
+;------------------------------------------------------------------------------ Layer 4
 
-   Arguments:
-   - repo-config - Map of repo-id -> config with :automation-tier
-   - repo-id - Repository identifier string
-
-   Returns: Keyword :tier-0 through :tier-3 (default: :tier-1)"
-  [repo-config repo-id]
-  (get-in repo-config [repo-id :automation-tier] :tier-1))
-
-(defn can-auto-approve?
+(defn ^{:stratum 4} can-auto-approve?
   "Convenience: check if a PR can be auto-approved given its tier, readiness, and risk."
   ([tier readiness risk]
    (tier-allows? tier :auto-approve readiness risk))
   ([tier readiness risk tiers]
    (tier-allows? tier :auto-approve readiness risk tiers)))
 
-(defn can-auto-merge?
+(defn ^{:stratum 4} can-auto-merge?
   "Convenience: check if a PR can be auto-merged given its tier, readiness, and risk."
   ([tier readiness risk]
    (tier-allows? tier :auto-merge readiness risk))
   ([tier readiness risk tiers]
    (tier-allows? tier :auto-merge readiness risk tiers)))
-
-(defn get-automation-tier
-  "Get the effective automation tier with full definition.
-
-   Arguments:
-   - repo-config - Repository configuration map
-   - repo-id - Repository identifier
-   - tiers - Optional tier definitions map
-
-   Returns: {:tier kw :definition map}"
-  ([repo-config repo-id]
-   (get-automation-tier repo-config repo-id default-tier-definitions))
-  ([repo-config repo-id tiers]
-   (let [tier (get-repo-tier repo-config repo-id)]
-     {:tier tier
-      :definition (get tiers tier)})))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/pr-train/test/ai/miniforge/pr_train/event_stream_test.clj
+++ b/components/pr-train/test/ai/miniforge/pr_train/event_stream_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-train.event-stream-test
   "Tests for event-stream integration in PR train manager."
   (:require
@@ -23,7 +22,9 @@
    [ai.miniforge.pr-train.interface :as train]
    [ai.miniforge.event-stream.interface :as es]))
 
-(deftest complete-merge-emits-pr-merged-event
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} complete-merge-emits-pr-merged-event
   (testing "complete-merge publishes :pr/merged event to event-stream"
     ;; Real event-stream (no with-redefs — safe under pmap), sinkless:
     ;; the default file sink writes into the operator's REAL
@@ -71,7 +72,7 @@
             (is (uuid? (:event/id event)))
             (is (inst? (:event/timestamp event)))))))))
 
-(deftest add-pr-emits-pr-created-event
+(deftest ^{:stratum 0} add-pr-emits-pr-created-event
   (testing "add-pr announces the PR so an entity exists before merge"
     (let [stream (es/create-event-stream {:sinks []})
           captured (atom [])
@@ -90,7 +91,7 @@
           (is (= train-id (:train/id event)))
           (is (uuid? (:event/id event))))))))
 
-(deftest complete-merge-without-event-stream
+(deftest ^{:stratum 0} complete-merge-without-event-stream
   (testing "complete-merge works normally when no event-stream is configured"
     (let [mgr (train/create-manager)
           train-id (train/create-train mgr "No Stream" (random-uuid) nil)]

--- a/components/pr-train/test/ai/miniforge/pr_train/evidence_and_queries_test.clj
+++ b/components/pr-train/test/ai/miniforge/pr_train/evidence_and_queries_test.clj
@@ -15,18 +15,18 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-train.evidence-and-queries-test
   "Tests for evidence bundles, list, find, contains, and transitions."
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.pr-train.interface :as train]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; ============================================================================
 ;; Evidence tests
 ;; ============================================================================
-
-(deftest generate-evidence-bundle-test
+(deftest ^{:stratum 0} generate-evidence-bundle-test
   (testing "generate-evidence-bundle creates an evidence bundle"
     (let [mgr (train/create-manager)
           train-id (train/create-train mgr "Test" (random-uuid) nil)]
@@ -51,7 +51,7 @@
           (is (= 2 (:total-prs summary)))
           (is (= 1 (:human-approvals summary))))))))
 
-(deftest get-evidence-bundle-test
+(deftest ^{:stratum 0} get-evidence-bundle-test
   (testing "get-evidence-bundle retrieves stored bundle"
     (let [mgr (train/create-manager)
           train-id (train/create-train mgr "Test" (random-uuid) nil)]
@@ -65,8 +65,7 @@
 ;; ============================================================================
 ;; Utility function tests
 ;; ============================================================================
-
-(deftest list-trains-test
+(deftest ^{:stratum 0} list-trains-test
   (testing "list-trains returns all trains"
     (let [mgr (train/create-manager)]
       (train/create-train mgr "Train 1" (random-uuid) nil)
@@ -77,7 +76,7 @@
         (is (every? :train/id trains))
         (is (every? :train/name trains))))))
 
-(deftest find-trains-by-status-test
+(deftest ^{:stratum 0} find-trains-by-status-test
   (testing "find-trains-by-status filters by status"
     (let [mgr (train/create-manager)
           t1 (train/create-train mgr "Train 1" (random-uuid) nil)
@@ -89,7 +88,7 @@
       (is (= 1 (count (train/find-trains-by-status mgr :drafting))))
       (is (= 1 (count (train/find-trains-by-status mgr :abandoned)))))))
 
-(deftest train-contains-pr?-test
+(deftest ^{:stratum 0} train-contains-pr?-test
   (testing "train-contains-pr? checks PR membership"
     (let [mgr (train/create-manager)
           train-id (train/create-train mgr "Test" (random-uuid) nil)]
@@ -102,8 +101,7 @@
 ;; ============================================================================
 ;; State machine validation tests
 ;; ============================================================================
-
-(deftest valid-train-transition?-test
+(deftest ^{:stratum 0} valid-train-transition?-test
   (testing "valid-train-transition? validates transitions"
     (is (train/valid-train-transition? :drafting :open))
     (is (train/valid-train-transition? :open :reviewing))
@@ -111,7 +109,7 @@
     (is (not (train/valid-train-transition? :merged :drafting)))
     (is (not (train/valid-train-transition? :abandoned :open)))))
 
-(deftest valid-pr-transition?-test
+(deftest ^{:stratum 0} valid-pr-transition?-test
   (testing "valid-pr-transition? validates transitions"
     (is (train/valid-pr-transition? :draft :open))
     (is (train/valid-pr-transition? :reviewing :approved))

--- a/components/pr-train/test/ai/miniforge/pr_train/lifecycle_test.clj
+++ b/components/pr-train/test/ai/miniforge/pr_train/lifecycle_test.clj
@@ -15,18 +15,18 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-train.lifecycle-test
   "Tests for manager, train create, add/remove/link PR."
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.pr-train.interface :as train]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; ============================================================================
 ;; Manager creation tests
 ;; ============================================================================
-
-(deftest create-manager-test
+(deftest ^{:stratum 0} create-manager-test
   (testing "create-manager returns a manager"
     (let [mgr (train/create-manager)]
       (is (some? mgr))
@@ -35,8 +35,7 @@
 ;; ============================================================================
 ;; Train lifecycle tests
 ;; ============================================================================
-
-(deftest create-train-test
+(deftest ^{:stratum 0} create-train-test
   (testing "create-train returns a train-id"
     (let [mgr (train/create-manager)
           dag-id (random-uuid)
@@ -52,7 +51,7 @@
           (is (= :drafting (:train/status t)))
           (is (empty? (:train/prs t))))))))
 
-(deftest add-pr-test
+(deftest ^{:stratum 0} add-pr-test
   (testing "add-pr adds a PR to the train"
     (let [mgr (train/create-manager)
           train-id (train/create-train mgr "Test" (random-uuid) nil)
@@ -80,7 +79,7 @@
             orders (map :pr/merge-order (:train/prs t))]
         (is (= [1 2 3] orders))))))
 
-(deftest remove-pr-test
+(deftest ^{:stratum 0} remove-pr-test
   (testing "remove-pr removes a PR and reorders"
     (let [mgr (train/create-manager)
           train-id (train/create-train mgr "Test" (random-uuid) nil)]
@@ -94,7 +93,7 @@
         (is (= [1 3] remaining))
         (is (= [1 2] orders))))))
 
-(deftest link-prs-test
+(deftest ^{:stratum 0} link-prs-test
   (testing "link-prs computes dependencies"
     (let [mgr (train/create-manager)
           train-id (train/create-train mgr "Test" (random-uuid) nil)]

--- a/components/pr-train/test/ai/miniforge/pr_train/merge_operations_test.clj
+++ b/components/pr-train/test/ai/miniforge/pr_train/merge_operations_test.clj
@@ -15,18 +15,18 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-train.merge-operations-test
   "Tests for ready-to-merge, blocking, merge, and fail-merge operations."
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.pr-train.interface :as train]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; ============================================================================
 ;; State management tests
 ;; ============================================================================
-
-(deftest update-pr-status-test
+(deftest ^{:stratum 0} update-pr-status-test
   (testing "update-pr-status transitions PR state"
     (let [mgr (train/create-manager)
           train-id (train/create-train mgr "Test" (random-uuid) nil)]
@@ -51,7 +51,7 @@
       (is (nil? (train/update-pr-status mgr train-id 123 :approved)))
       (is (= :draft (:pr/status (train/get-pr-from-train mgr train-id 123)))))))
 
-(deftest update-pr-ci-status-test
+(deftest ^{:stratum 0} update-pr-ci-status-test
   (testing "update-pr-ci-status updates CI status"
     (let [mgr (train/create-manager)
           train-id (train/create-train mgr "Test" (random-uuid) nil)]
@@ -66,8 +66,7 @@
 ;; ============================================================================
 ;; Ready-to-merge tests
 ;; ============================================================================
-
-(deftest ready-to-merge-test
+(deftest ^{:stratum 0} ready-to-merge-test
   (testing "PR is ready when deps merged, approved, CI passed, gates passed"
     (let [mgr (train/create-manager)
           train-id (train/create-train mgr "Test" (random-uuid) nil)]
@@ -116,8 +115,7 @@
 ;; ============================================================================
 ;; Blocking PR tests
 ;; ============================================================================
-
-(deftest get-blocking-test
+(deftest ^{:stratum 0} get-blocking-test
   (testing "blocking PRs are those that could proceed but aren't ready"
     (let [mgr (train/create-manager)
           train-id (train/create-train mgr "Test" (random-uuid) nil)]
@@ -137,8 +135,7 @@
 ;; ============================================================================
 ;; Merge action tests
 ;; ============================================================================
-
-(deftest merge-next-test
+(deftest ^{:stratum 0} merge-next-test
   (testing "merge-next marks the next ready PR as merging"
     (let [mgr (train/create-manager)
           train-id (train/create-train mgr "Test" (random-uuid) nil)]
@@ -157,7 +154,7 @@
         (is (some? (:train result)))
         (is (= :merging (:pr/status (train/get-pr-from-train mgr train-id 100))))))))
 
-(deftest complete-merge-test
+(deftest ^{:stratum 0} complete-merge-test
   (testing "complete-merge marks PR as merged"
     (let [mgr (train/create-manager)
           train-id (train/create-train mgr "Test" (random-uuid) nil)]
@@ -173,7 +170,7 @@
       (train/complete-merge mgr train-id 100)
       (is (= :merged (:pr/status (train/get-pr-from-train mgr train-id 100)))))))
 
-(deftest fail-merge-test
+(deftest ^{:stratum 0} fail-merge-test
   (testing "fail-merge marks PR as failed and creates rollback plan"
     (let [mgr (train/create-manager)
           train-id (train/create-train mgr "Test" (random-uuid) nil)]

--- a/components/pr-train/test/ai/miniforge/pr_train/readiness_test.clj
+++ b/components/pr-train/test/ai/miniforge/pr_train/readiness_test.clj
@@ -15,17 +15,17 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-train.readiness-test
   (:require
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.pr-train.readiness :as readiness]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; ============================================================================
 ;; Factor scoring tests
 ;; ============================================================================
-
-(deftest score-deps-factor-test
+(deftest ^{:stratum 0} score-deps-factor-test
   (testing "no dependencies scores 1.0"
     (let [train {:train/prs []}
           pr {:pr/depends-on []}]
@@ -49,7 +49,7 @@
           pr {:pr/depends-on [1 2]}]
       (is (= 0.5 (readiness/score-deps-factor train pr readiness/default-config))))))
 
-(deftest score-ci-factor-test
+(deftest ^{:stratum 0} score-ci-factor-test
   (testing "passed CI scores 1.0"
     (is (= 1.0 (readiness/score-ci-factor nil {:pr/ci-status :passed} readiness/default-config))))
 
@@ -59,7 +59,7 @@
   (testing "failed CI scores 0.0"
     (is (= 0.0 (readiness/score-ci-factor nil {:pr/ci-status :failed} readiness/default-config)))))
 
-(deftest score-approved-factor-test
+(deftest ^{:stratum 0} score-approved-factor-test
   (testing "approved PR scores 1.0"
     (is (= 1.0 (readiness/score-approved-factor nil {:pr/status :approved} readiness/default-config))))
 
@@ -69,7 +69,7 @@
   (testing "draft PR scores 0.0"
     (is (= 0.0 (readiness/score-approved-factor nil {:pr/status :draft} readiness/default-config)))))
 
-(deftest score-gates-factor-test
+(deftest ^{:stratum 0} score-gates-factor-test
   (testing "no gates scores 1.0"
     (is (= 1.0 (readiness/score-gates-factor nil {:pr/gate-results []} readiness/default-config))))
 
@@ -83,7 +83,7 @@
                  {:pr/gate-results [{:gate/passed? true} {:gate/passed? false}]}
                  readiness/default-config)))))
 
-(deftest score-behind-main-factor-test
+(deftest ^{:stratum 0} score-behind-main-factor-test
   (testing "not behind main scores 1.0"
     (is (= 1.0 (readiness/score-behind-main-factor nil {:pr/behind-main? false} readiness/default-config))))
 
@@ -96,8 +96,7 @@
 ;; ============================================================================
 ;; Weighted aggregation tests
 ;; ============================================================================
-
-(deftest compute-readiness-score-test
+(deftest ^{:stratum 0} compute-readiness-score-test
   (testing "perfect PR scores near 1.0"
     (let [train {:train/prs [{:pr/number 1 :pr/status :merged}]}
           pr {:pr/number 2
@@ -124,8 +123,7 @@
 ;; ============================================================================
 ;; Explainability tests
 ;; ============================================================================
-
-(deftest explain-readiness-test
+(deftest ^{:stratum 0} explain-readiness-test
   (testing "explain returns all factors"
     (let [train {:train/prs []}
           pr {:pr/depends-on [] :pr/ci-status :passed :pr/status :approved
@@ -154,8 +152,7 @@
 ;; ============================================================================
 ;; Threshold tests
 ;; ============================================================================
-
-(deftest threshold-test
+(deftest ^{:stratum 0} threshold-test
   (testing "ready? reflects threshold comparison"
     (let [train {:train/prs []}
           good-pr {:pr/depends-on [] :pr/ci-status :passed :pr/status :approved

--- a/components/pr-train/test/ai/miniforge/pr_train/risk_test.clj
+++ b/components/pr-train/test/ai/miniforge/pr_train/risk_test.clj
@@ -15,17 +15,17 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-train.risk-test
   (:require
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.pr-train.risk :as risk]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; ============================================================================
 ;; Risk level classification tests
 ;; ============================================================================
-
-(deftest score->level-test
+(deftest ^{:stratum 0} score->level-test
   (testing "critical threshold"
     (is (= :critical (risk/score->level 0.75)))
     (is (= :critical (risk/score->level 1.0))))
@@ -45,8 +45,7 @@
 ;; ============================================================================
 ;; Risk assessment tests
 ;; ============================================================================
-
-(deftest assess-risk-test
+(deftest ^{:stratum 0} assess-risk-test
   (testing "low-risk PR"
     (let [result (risk/assess-risk
                   {:train/prs []}
@@ -107,8 +106,7 @@
 ;; ============================================================================
 ;; Factor detail tests
 ;; ============================================================================
-
-(deftest change-size-factor-test
+(deftest ^{:stratum 0} change-size-factor-test
   (testing "small change is low risk"
     (let [result (risk/assess-risk {:train/prs []} {:pr/number 1 :pr/blocks []}
                                    {:change-size {:additions 10 :deletions 5}} {})
@@ -121,7 +119,7 @@
           factor (first (filter #(= :change-size (:factor %)) (:risk/factors result)))]
       (is (= 1.0 (:score factor))))))
 
-(deftest critical-files-factor-test
+(deftest ^{:stratum 0} critical-files-factor-test
   (testing "no critical files is zero risk"
     (let [result (risk/assess-risk {:train/prs []} {:pr/number 1 :pr/blocks []}
                                    {:changed-files ["src/core.clj"]} {})

--- a/components/pr-train/test/ai/miniforge/pr_train/state_computation_test.clj
+++ b/components/pr-train/test/ai/miniforge/pr_train/state_computation_test.clj
@@ -15,18 +15,18 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-train.state-computation-test
   "Tests for ready-to-merge, blocking, progress, and dependency computations."
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.pr-train.state :as state]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; ============================================================================
 ;; Ready-to-merge computation tests
 ;; ============================================================================
-
-(deftest deps-merged?-test
+(deftest ^{:stratum 0} deps-merged?-test
   (testing "PR with no deps is always deps-merged"
     (let [pr (state/create-pr-state "acme/a" 100 "url" "branch" "PR" 1)
           train (-> (state/create-train-state (random-uuid) "Test" (random-uuid))
@@ -50,7 +50,7 @@
                     (assoc :train/prs [pr1 pr2]))]
       (is (state/deps-merged? train pr2)))))
 
-(deftest gates-passed?-test
+(deftest ^{:stratum 0} gates-passed?-test
   (testing "PR with no gates passes"
     (let [pr (state/create-pr-state "acme/a" 100 "url" "branch" "PR" 1)]
       (is (state/gates-passed? pr))))
@@ -69,7 +69,7 @@
                          {:gate/id :lint :gate/type :lint :gate/passed? false}]))]
       (is (not (state/gates-passed? pr))))))
 
-(deftest ready-to-merge?-test
+(deftest ^{:stratum 0} ready-to-merge?-test
   (testing "PR is ready when all conditions met"
     (let [pr (-> (state/create-pr-state "acme/a" 100 "url" "branch" "PR" 1)
                  (assoc :pr/status :approved)
@@ -104,7 +104,7 @@
                     (assoc :train/prs [pr1 pr2]))]
       (is (not (state/ready-to-merge? train pr2))))))
 
-(deftest compute-ready-to-merge-test
+(deftest ^{:stratum 0} compute-ready-to-merge-test
   (testing "returns ready PRs in merge order"
     (let [pr1 (-> (state/create-pr-state "acme/a" 100 "url" "branch" "PR 1" 1)
                   (assoc :pr/status :approved)
@@ -117,8 +117,7 @@
 ;; ============================================================================
 ;; Blocking PR computation tests
 ;; ============================================================================
-
-(deftest pr-blocking?-test
+(deftest ^{:stratum 0} pr-blocking?-test
   (testing "PR is blocking when deps merged but not ready"
     (let [pr (-> (state/create-pr-state "acme/a" 100 "url" "branch" "PR" 1)
                  (assoc :pr/status :open)
@@ -142,7 +141,7 @@
                     (assoc :train/prs [pr]))]
       (is (not (state/pr-blocking? train pr))))))
 
-(deftest compute-blocking-prs-test
+(deftest ^{:stratum 0} compute-blocking-prs-test
   (testing "returns blocking PRs"
     (let [pr1 (-> (state/create-pr-state "acme/a" 100 "url" "branch" "PR 1" 1)
                   (assoc :pr/status :open))
@@ -157,8 +156,7 @@
 ;; ============================================================================
 ;; Progress computation tests
 ;; ============================================================================
-
-(deftest compute-progress-test
+(deftest ^{:stratum 0} compute-progress-test
   (testing "computes correct progress"
     (let [pr1 (-> (state/create-pr-state "acme/a" 100 "url" "branch" "PR 1" 1)
                   (assoc :pr/status :merged))
@@ -181,8 +179,7 @@
 ;; ============================================================================
 ;; Dependency linking tests
 ;; ============================================================================
-
-(deftest link-pr-dependencies-test
+(deftest ^{:stratum 0} link-pr-dependencies-test
   (testing "links PRs in linear chain"
     (let [pr1 (state/create-pr-state "acme/a" 100 "url" "branch" "PR 1" 1)
           pr2 (state/create-pr-state "acme/b" 200 "url" "branch" "PR 2" 2)

--- a/components/pr-train/test/ai/miniforge/pr_train/state_creation_test.clj
+++ b/components/pr-train/test/ai/miniforge/pr_train/state_creation_test.clj
@@ -15,18 +15,18 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-train.state-creation-test
   "Tests for train and PR state creation and CRUD."
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.pr-train.state :as state]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; ============================================================================
 ;; Train state creation tests
 ;; ============================================================================
-
-(deftest create-train-state-test
+(deftest ^{:stratum 0} create-train-state-test
   (testing "creates valid initial state"
     (let [train-id (random-uuid)
           dag-id (random-uuid)
@@ -47,7 +47,7 @@
                                           :description "A description")]
       (is (= "A description" (:train/description train))))))
 
-(deftest transition-train-status-test
+(deftest ^{:stratum 0} transition-train-status-test
   (testing "valid transition updates status"
     (let [train (state/create-train-state (random-uuid) "Test" (random-uuid))
           updated (state/transition-train-status train :open)]
@@ -68,8 +68,7 @@
 ;; ============================================================================
 ;; PR state creation tests
 ;; ============================================================================
-
-(deftest create-pr-state-test
+(deftest ^{:stratum 0} create-pr-state-test
   (testing "creates valid PR state"
     (let [pr (state/create-pr-state "acme/repo" 123
                                     "https://github.com/acme/repo/pull/123"
@@ -85,7 +84,7 @@
       (is (empty? (:pr/depends-on pr)))
       (is (empty? (:pr/blocks pr))))))
 
-(deftest find-pr-test
+(deftest ^{:stratum 0} find-pr-test
   (testing "finds PR by number"
     (let [pr1 (state/create-pr-state "acme/a" 100 "url1" "branch" "PR 1" 1)
           pr2 (state/create-pr-state "acme/b" 200 "url2" "branch" "PR 2" 2)
@@ -95,7 +94,7 @@
       (is (= pr2 (state/find-pr train 200)))
       (is (nil? (state/find-pr train 300))))))
 
-(deftest update-pr-test
+(deftest ^{:stratum 0} update-pr-test
   (testing "updates PR in train"
     (let [pr1 (state/create-pr-state "acme/a" 100 "url1" "branch" "PR 1" 1)
           train (-> (state/create-train-state (random-uuid) "Test" (random-uuid))
@@ -103,7 +102,7 @@
           updated (state/update-pr train 100 #(assoc % :pr/status :open))]
       (is (= :open (:pr/status (state/find-pr updated 100)))))))
 
-(deftest transition-pr-status-test
+(deftest ^{:stratum 0} transition-pr-status-test
   (testing "valid PR transition updates status"
     (let [pr (state/create-pr-state "acme/a" 100 "url" "branch" "PR" 1)
           train (-> (state/create-train-state (random-uuid) "Test" (random-uuid))

--- a/components/pr-train/test/ai/miniforge/pr_train/state_machine_test.clj
+++ b/components/pr-train/test/ai/miniforge/pr_train/state_machine_test.clj
@@ -15,18 +15,18 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-train.state-machine-test
   "Tests for rollback, auto-transition, and recompute."
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.pr-train.state :as state]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; ============================================================================
 ;; Rollback planning tests
 ;; ============================================================================
-
-(deftest compute-rollback-plan-test
+(deftest ^{:stratum 0} compute-rollback-plan-test
   (testing "computes rollback plan with merged PRs"
     (let [pr1 (-> (state/create-pr-state "acme/a" 100 "url" "branch" "PR 1" 1)
                   (assoc :pr/status :merged))
@@ -46,8 +46,7 @@
 ;; ============================================================================
 ;; Auto-transition tests
 ;; ============================================================================
-
-(deftest infer-train-status-test
+(deftest ^{:stratum 0} infer-train-status-test
   (testing "infers :merged when all PRs merged"
     (let [pr1 (-> (state/create-pr-state "acme/a" 100 "url" "branch" "PR 1" 1)
                   (assoc :pr/status :merged))
@@ -82,7 +81,7 @@
                     (assoc :train/prs [pr]))]
       (is (nil? (state/infer-train-status train))))))
 
-(deftest auto-transition-train-test
+(deftest ^{:stratum 0} auto-transition-train-test
   (testing "auto-transitions train based on PR states"
     (let [pr1 (-> (state/create-pr-state "acme/a" 100 "url" "branch" "PR 1" 1)
                   (assoc :pr/status :merged))
@@ -102,8 +101,7 @@
 ;; ============================================================================
 ;; Recompute train state tests
 ;; ============================================================================
-
-(deftest recompute-train-state-test
+(deftest ^{:stratum 0} recompute-train-state-test
   (testing "recomputes all derived state"
     (let [pr1 (-> (state/create-pr-state "acme/a" 100 "url" "branch" "PR 1" 1)
                   (assoc :pr/status :approved)

--- a/components/pr-train/test/ai/miniforge/pr_train/state_transitions_test.clj
+++ b/components/pr-train/test/ai/miniforge/pr_train/state_transitions_test.clj
@@ -15,25 +15,25 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-train.state-transitions-test
   "Tests for state transition validation."
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.pr-train.state :as state]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; ============================================================================
 ;; State transition validation tests
 ;; ============================================================================
-
-(deftest train-transitions-test
+(deftest ^{:stratum 0} train-transitions-test
   (testing "train-transitions map is complete"
     (is (map? state/train-transitions))
     (is (contains? state/train-transitions :drafting))
     (is (contains? state/train-transitions :merged))
     (is (contains? state/train-transitions :abandoned))))
 
-(deftest valid-train-transition?-test
+(deftest ^{:stratum 0} valid-train-transition?-test
   (testing "valid forward transitions"
     (is (state/valid-train-transition? :drafting :open))
     (is (state/valid-train-transition? :drafting :abandoned))
@@ -50,7 +50,7 @@
     (is (not (state/valid-train-transition? :rolled-back :open)))
     (is (not (state/valid-train-transition? :drafting :merged)))))
 
-(deftest valid-pr-transition?-test
+(deftest ^{:stratum 0} valid-pr-transition?-test
   (testing "valid PR transitions"
     (is (state/valid-pr-transition? :draft :open))
     (is (state/valid-pr-transition? :draft :closed))
@@ -69,7 +69,7 @@
     (is (not (state/valid-pr-transition? :open :merged)))
     (is (not (state/valid-pr-transition? :reviewing :merged)))))
 
-(deftest terminal-status-tests
+(deftest ^{:stratum 0} terminal-status-tests
   (testing "terminal train statuses"
     (is (state/terminal-train-status? :merged))
     (is (state/terminal-train-status? :rolled-back))

--- a/components/pr-train/test/ai/miniforge/pr_train/tiers_test.clj
+++ b/components/pr-train/test/ai/miniforge/pr_train/tiers_test.clj
@@ -15,27 +15,27 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-train.tiers-test
   (:require
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.pr-train.tiers :as tiers]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; ============================================================================
 ;; Tier constraint tests
 ;; ============================================================================
-
-(deftest tier-0-test
+(deftest ^{:stratum 0} tier-0-test
   (testing "tier-0 disallows all automation"
     (is (false? (tiers/tier-allows? :tier-0 :auto-approve 1.0 {:risk/level :low})))
     (is (false? (tiers/tier-allows? :tier-0 :auto-merge 1.0 {:risk/level :low})))))
 
-(deftest tier-1-test
+(deftest ^{:stratum 0} tier-1-test
   (testing "tier-1 allows auto-merge but not auto-approve"
     (is (false? (tiers/tier-allows? :tier-1 :auto-approve 1.0 {:risk/level :low})))
     (is (true? (tiers/tier-allows? :tier-1 :auto-merge 0.5 {:risk/level :low})))))
 
-(deftest tier-2-test
+(deftest ^{:stratum 0} tier-2-test
   (testing "tier-2 allows both when constraints met"
     (is (true? (tiers/tier-allows? :tier-2 :auto-approve 0.95 {:risk/level :low})))
     (is (true? (tiers/tier-allows? :tier-2 :auto-merge 0.95 {:risk/level :medium}))))
@@ -47,7 +47,7 @@
     (is (false? (tiers/tier-allows? :tier-2 :auto-approve 0.95 {:risk/level :high})))
     (is (false? (tiers/tier-allows? :tier-2 :auto-merge 0.95 {:risk/level :critical})))))
 
-(deftest tier-3-test
+(deftest ^{:stratum 0} tier-3-test
   (testing "tier-3 allows with relaxed constraints"
     (is (true? (tiers/tier-allows? :tier-3 :auto-approve 0.80 {:risk/level :high})))
     (is (true? (tiers/tier-allows? :tier-3 :auto-merge 0.80 {:risk/level :medium}))))
@@ -61,15 +61,14 @@
 ;; ============================================================================
 ;; Operation gating tests
 ;; ============================================================================
-
-(deftest can-auto-approve-test
+(deftest ^{:stratum 0} can-auto-approve-test
   (testing "convenience function matches tier-allows?"
     (is (= (tiers/tier-allows? :tier-2 :auto-approve 0.95 {:risk/level :low})
            (tiers/can-auto-approve? :tier-2 0.95 {:risk/level :low})))
     (is (= (tiers/tier-allows? :tier-0 :auto-approve 1.0 {:risk/level :low})
            (tiers/can-auto-approve? :tier-0 1.0 {:risk/level :low})))))
 
-(deftest can-auto-merge-test
+(deftest ^{:stratum 0} can-auto-merge-test
   (testing "convenience function matches tier-allows?"
     (is (= (tiers/tier-allows? :tier-1 :auto-merge 0.5 {:risk/level :low})
            (tiers/can-auto-merge? :tier-1 0.5 {:risk/level :low})))
@@ -79,8 +78,7 @@
 ;; ============================================================================
 ;; Config lookup tests
 ;; ============================================================================
-
-(deftest get-repo-tier-test
+(deftest ^{:stratum 0} get-repo-tier-test
   (testing "returns configured tier"
     (is (= :tier-2
            (tiers/get-repo-tier {"acme/terraform" {:automation-tier :tier-2}} "acme/terraform"))))
@@ -88,7 +86,7 @@
   (testing "defaults to tier-1 for unknown repos"
     (is (= :tier-1 (tiers/get-repo-tier {} "unknown/repo")))))
 
-(deftest get-automation-tier-test
+(deftest ^{:stratum 0} get-automation-tier-test
   (testing "returns tier with definition"
     (let [result (tiers/get-automation-tier
                   {"acme/repo" {:automation-tier :tier-2}} "acme/repo")]
@@ -99,7 +97,6 @@
 ;; ============================================================================
 ;; Unknown operation test
 ;; ============================================================================
-
-(deftest unknown-operation-test
+(deftest ^{:stratum 0} unknown-operation-test
   (testing "unknown operations return false"
     (is (false? (tiers/tier-allows? :tier-3 :unknown-op 1.0 {:risk/level :low})))))

--- a/components/pr-train/test/ai/miniforge/pr_train/train_control_test.clj
+++ b/components/pr-train/test/ai/miniforge/pr_train/train_control_test.clj
@@ -15,18 +15,18 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-train.train-control-test
   "Tests for pause, resume, abandon, and progress."
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.pr-train.interface :as train]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; ============================================================================
 ;; Train control tests
 ;; ============================================================================
-
-(deftest pause-resume-test
+(deftest ^{:stratum 0} pause-resume-test
   (testing "pause-train and resume-train work"
     (let [mgr (train/create-manager)
           train-id (train/create-train mgr "Test" (random-uuid) nil)]
@@ -39,7 +39,7 @@
         (is (not (:train/paused? resumed)))
         (is (nil? (:train/pause-reason resumed)))))))
 
-(deftest abandon-train-test
+(deftest ^{:stratum 0} abandon-train-test
   (testing "abandon-train marks train as abandoned"
     (let [mgr (train/create-manager)
           train-id (train/create-train mgr "Test" (random-uuid) nil)
@@ -50,8 +50,7 @@
 ;; ============================================================================
 ;; Progress tests
 ;; ============================================================================
-
-(deftest get-progress-test
+(deftest ^{:stratum 0} get-progress-test
   (testing "progress tracks PR states"
     (let [mgr (train/create-manager)
           train-id (train/create-train mgr "Test" (random-uuid) nil)]

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-pr-train.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-pr-train.md
@@ -1,0 +1,139 @@
+# fix: stratum-lint autofix for components/pr-train (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over `components/pr-train` (src + test) and commits
+the result: regenerated `;---- Layer N` headings and `^{:stratum n}` metadata
+on every top-level def, computed from each file's real same-file reference
+graph. One component-scoped PR in the Wave 1 batch described in
+`work/stratum-lint-baseline-2026-07-24.md`.
+
+Beyond the mechanical `--fix` output, two hand-fixes were needed (both
+comment/docstring-only, no behavior change):
+
+1. `state.clj` carried a stale decorative `;---- Layer 8b` banner
+   immediately before `link-prs-from-dag` that `--fix` left untouched —
+   the known "leftover banner at a now-contradictory position" tool
+   limitation. `link-pr-dependencies` and `link-prs-from-dag` both landed
+   at the same real stratum (7), so the stale banner (which also used a
+   non-integer suffix that was never valid under rule 210 in the first
+   place) was simply redundant noise between two same-layer defs. Deleted
+   it, kept the plain `;; DAG-aware dependency linking` label comment
+   above the function, and confirmed the file is stable across a third
+   `--fix` pass.
+2. `risk.clj`, `readiness.clj`, and `tiers.clj` each had a namespace
+   docstring enumerating "Layer 0: ... Layer 1: ... Layer 2: ..." by hand.
+   `--fix` recomputed real depth from the reference graph and two of the
+   three no longer match: `readiness.clj` is now 4 real layers, not the
+   documented 3, and `tiers.clj` is now 5, not the documented 2 (both
+   previously under-counted by a heading structure that didn't track real
+   dependency depth). Removed the stale per-layer breakdowns from all
+   three docstrings rather than let them keep asserting counts that are
+   already wrong today and would drift again at the next real edit.
+
+## Motivation
+
+`pr-train` carried 4 findings in the baseline: `SL003` on `interface.clj`
+(13 distinct layers), `SL002` on `risk.clj` (a `Layer 0` heading reused
+after `Layer 0`, i.e. the decorative-banner pattern), and `SL003` on
+`schema.clj` (9 layers) and `state.clj` (11 layers). Zero `SL001`
+findings — confirmed by a plain lint run before starting, per this
+batch's instructions to stop and report rather than proceed if any
+turned up. Nothing in the component references a same-file def defined
+later at a lower layer, so this was safe to autofix mechanically with no
+cycle/upward-reference risk to reason about first.
+
+## Changes in Detail
+
+`stratum-lint --fix` (pinned sha `14965e1ee1a175bd00f637d9a9d5f7d27e62b73f`,
+read fresh from `tasks/stratum.clj` after resetting the branch onto
+current `main`) rewrote all 19 Clojure files in the component — every
+file, not just the 4 with findings, since `--fix` regenerates canonical
+headings and `^{:stratum n}` tags on every def regardless of prior state.
+
+- **src (7 files):** `core.clj`, `interface.clj`, `readiness.clj`,
+  `risk.clj`, `schema.clj`, `state.clj`, `tiers.clj`
+- **test (12 files):** `event_stream_test.clj`,
+  `evidence_and_queries_test.clj`, `lifecycle_test.clj`,
+  `merge_operations_test.clj`, `readiness_test.clj`, `risk_test.clj`,
+  `state_computation_test.clj`, `state_creation_test.clj`,
+  `state_machine_test.clj`, `state_transitions_test.clj`, `tiers_test.clj`,
+  `train_control_test.clj`
+
+`interface.clj` is the headline case: every one of its ~35 public defs is
+a thin re-export delegating to `core`/`schema`/`state`/`risk`/`readiness`/`tiers`
+— no same-file references at all — so the real reference graph puts
+almost all of them at Layer 0. The one exception, `merge-all-ready`, calls
+the same-file `get-ready-to-merge` and correctly lands at Layer 1. The
+old headings (`Layer 0` through `Layer 12`) were pure per-section
+decoration; the real structure is 2 layers, not 13.
+
+`schema.clj` (9 → 6 real layers) and `state.clj` (11 → 8 real layers)
+both remain over budget after the fix — see Testing Plan; these need an
+actual namespace split (Wave 2), not another mechanical pass.
+
+All test files only gained `^{:stratum n}` tags — every `deftest` in
+every file is independent of every other same-file `deftest`, so all
+land at Layer 0. No prior findings in test files (this component's
+baseline findings were all in `src`).
+
+## Testing Plan
+
+- `--fix` run twice in a row (plus a third pass over `state.clj` alone
+  after the hand-fix above); zero diff each time — idempotency confirmed
+  directly.
+- Read the full diff for all 19 changed files. Only heading text,
+  `^{:stratum n}` metadata, and def/deftest reordering changed, plus the
+  two hand-fixes described above. No same-line trailing comment was
+  displaced onto the wrong def.
+- `clj-kondo --lint components/pr-train`: 0 errors, 0 warnings.
+- Ran all 12 test namespaces directly via `clojure -M:test`: 68 tests,
+  337 assertions, 0 failures, 0 errors.
+- Plain (non-`--fix`) lint after fixing: 4 `SL003` findings remain.
+  - `schema.clj` (6 layers) and `state.clj` (8 layers): the **same**
+    findings as the baseline, just with a smaller (and now accurate)
+    layer count — both were already over budget before this PR under
+    their old, inflated heading counts.
+  - `readiness.clj` (4 layers) and `tiers.clj` (5 layers): **new**
+    findings this fix surfaces. Neither was in the baseline — both had
+    headings that under-counted real depth (`readiness.clj`'s 3 old
+    headings implied 3 layers; `tiers.clj`'s 2 old headings implied 2),
+    so the old, hand-written structure looked in-budget when the real
+    same-file call graph was already deeper. Not a regression from this
+    change — pre-existing depth the mechanical fix makes visible, same
+    situation prior Wave 1 PRs (`bb-config`, `gate`) hit. All four are
+    Wave 2 scope (real namespace split), not attempted here.
+  - `interface.clj` (was 13 layers) and `risk.clj` (was the `SL002`
+    banner-reuse finding) both fully resolved — 2 and 3 real layers
+    respectively, both in budget.
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+change — headings, metadata, comment positions, and two stale-docstring
+corrections only. Pre-commit's `lint:stratum` autofixer keeps this
+component clean going forward; the 4 `SL003` findings above stay
+advisory (`MINIFORGE_STRATUM_BUDGET_MODE=warn` at commit time) until
+Wave 2 splits those namespaces.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+- Follow-on: Wave 2 namespace splits for `schema.clj`, `state.clj`,
+  `readiness.clj`, and `tiers.clj` in `components/pr-train`
+
+## Checklist
+
+- [x] Branch reset onto `origin/main` before starting (stale-pin bug from
+      prior batches)
+- [x] Zero `SL001` findings confirmed before running `--fix`
+- [x] Idempotency verified directly (two full-component `--fix` passes,
+      plus a third targeted pass after the hand-fix), zero diff each time
+- [x] Full diff read for all 19 changed files; one stale-banner and three
+      stale-docstring hand-fixes documented above, no other anomalies
+- [x] `clj-kondo` clean across the whole component
+- [x] Component tests pass (68 tests, 337 assertions, 0 failures/errors)
+- [x] Plain lint re-run post-fix: 4 `SL003` findings remain, 2 same as
+      baseline (smaller count) and 2 newly surfaced — documented above as
+      Wave 2 scope
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
## Summary

- Runs `stratum-lint --fix` over `components/pr-train` (src + test): real `Layer N` headings and `^{:stratum n}` metadata computed from each file's actual same-file reference graph, replacing decorative headings (`interface.clj` collapses from 13 fake layers to 2 real ones; `risk.clj`'s reused `Layer 0` banner resolves).
- Two hand-fixes beyond the mechanical `--fix` output, both comment/docstring-only, no behavior change: deleted a stale `Layer 8b` banner in `state.clj` left behind between two defs the fix correctly placed at the same real stratum, and removed three now-inaccurate "Layer 0/1/2" docstring summaries (`risk.clj`, `readiness.clj`, `tiers.clj`) whose counts no longer match the real depth the fix surfaced.
- 4 `SL003` findings remain post-fix, all real over-budget files deferred to Wave 2 (namespace split): `schema.clj` and `state.clj` (same findings as baseline, smaller/accurate counts), `readiness.clj` and `tiers.clj` (newly surfaced — previously under-counted by decorative headings).

Full detail in `docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-pr-train.md`.

## Test plan

- [x] Confirmed zero SL001 findings before running `--fix`
- [x] `--fix` run twice (plus a third targeted pass after the hand-fix) — zero diff, idempotency confirmed
- [x] Full diff read for all 19 changed files
- [x] `clj-kondo --lint components/pr-train`: 0 errors, 0 warnings
- [x] All 12 test namespaces run directly: 68 tests, 337 assertions, 0 failures/errors
- [x] Full pre-commit gate green (poly check, lint:clj, lint:stratum advisory, fmt:md, 331-test smoke, 8-test GraalVM compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)