### PR TITLE
fix: stratum-lint autofix for components/self-healing (Wave 1)

### DIFF
--- a/components/self-healing/src/ai/miniforge/self_healing/backend_health.clj
+++ b/components/self-healing/src/ai/miniforge/self_healing/backend_health.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.self-healing.backend-health
   "Backend health tracking and automatic failover.
    Storage: ~/.miniforge/backend_health.edn"
@@ -24,9 +23,9 @@
    [clojure.edn :as edn]
    [clojure.java.io :as io]))
 
-;;------------------------------------------------------------------------------ Layer 0
-;; Tuning constants + file paths
+;------------------------------------------------------------------------------ Layer 0
 
+;; Tuning constants + file paths
 ;; Backend failover policy is operational config — the allow-list /
 ;; failover order and the health thresholds are operator policy, tuned
 ;; without a code release. Active values live in
@@ -34,41 +33,15 @@
 ;; below are the fallback when config is absent. `config` is public so the
 ;; sibling stream-recovery / integration namespaces resolve the same
 ;; defaults instead of re-hardcoding them.
-(def config
+(def ^{:stratum 0} config
   (cfg/load-config-resource "config/self-healing/backend-health.edn"
                             [:success-rate-threshold :switch-cooldown-ms
                              :failure-recency-window-ms
                              :health-decay-ms :default-backend
                              :fallback-order]))
 
-(def ^:private default-success-rate-threshold
-  "Minimum cumulative success rate (`:successful-calls / :total-calls`)
-   before a backend is considered degraded and a failover is triggered.
-   0.90 = at most 1 failure per 10 cumulative calls tolerated; below
-   that the backend is skipped in favor of a healthier one. Picked to
-   absorb transient single failures without flapping. (Note: the rate
-   is cumulative since last decay, not a sliding window — `maybe-decay-health`
-   resets the counters wholesale after 24h of stale data.)"
-  (:success-rate-threshold config))
-
-(def ^:private default-switch-cooldown-ms
-  "Minimum interval between automatic backend switches (30 min). After
-   a switch fires, the FROM backend is parked for this long even if its
-   success rate recovers — prevents two flaky backends from oscillating
-   between healthy and degraded."
-  (:switch-cooldown-ms config))
-
-(def ^:private default-failure-recency-window-ms
-  "Window during which a recent failure is considered fresh enough to
-   trigger a switch decision (5 min). The stored `:last-failure`
-   timestamp is compared against this window; older failures stay in
-   the cumulative counter for accounting but do not by themselves
-   cause a switch — stale failure data shouldn't trigger live failover."
-  (:failure-recency-window-ms config))
-
 ;; File paths and utilities
-
-(defn backend-health-path
+(defn ^{:stratum 0} backend-health-path
   "Get path to backend health tracking file.
 
    Returns: String path to ~/.miniforge/backend_health.edn"
@@ -77,7 +50,7 @@
         miniforge-dir (io/file home ".miniforge")]
     (.getPath (io/file miniforge-dir "backend_health.edn"))))
 
-(defn ensure-directory-exists
+(defn ^{:stratum 0} ensure-directory-exists
   "Ensure parent directory exists for a file path.
 
    Arguments:
@@ -89,7 +62,7 @@
     (when-not (.exists parent-dir)
       (.mkdirs parent-dir))))
 
-(defn safe-read-edn
+(defn ^{:stratum 0} safe-read-edn
   "Safely read EDN from file, returning default on error.
 
    Arguments:
@@ -104,7 +77,34 @@
     (catch Exception _
       default)))
 
-(defn atomic-write-edn
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} ^:private default-success-rate-threshold
+  "Minimum cumulative success rate (`:successful-calls / :total-calls`)
+   before a backend is considered degraded and a failover is triggered.
+   0.90 = at most 1 failure per 10 cumulative calls tolerated; below
+   that the backend is skipped in favor of a healthier one. Picked to
+   absorb transient single failures without flapping. (Note: the rate
+   is cumulative since last decay, not a sliding window — `maybe-decay-health`
+   resets the counters wholesale after 24h of stale data.)"
+  (:success-rate-threshold config))
+
+(def ^{:stratum 1} ^:private default-switch-cooldown-ms
+  "Minimum interval between automatic backend switches (30 min). After
+   a switch fires, the FROM backend is parked for this long even if its
+   success rate recovers — prevents two flaky backends from oscillating
+   between healthy and degraded."
+  (:switch-cooldown-ms config))
+
+(def ^{:stratum 1} ^:private default-failure-recency-window-ms
+  "Window during which a recent failure is considered fresh enough to
+   trigger a switch decision (5 min). The stored `:last-failure`
+   timestamp is compared against this window; older failures stay in
+   the cumulative counter for accounting but do not by themselves
+   cause a switch — stale failure data shouldn't trigger live failover."
+  (:failure-recency-window-ms config))
+
+(defn ^{:stratum 1} atomic-write-edn
   "Atomically write EDN to file using temp file + rename.
 
    Arguments:
@@ -118,10 +118,8 @@
     (spit temp-file (pr-str data))
     (.renameTo (io/file temp-file) (io/file file-path))))
 
-;;------------------------------------------------------------------------------ Layer 1
 ;; Default health data structure
-
-(defn default-health-data
+(defn ^{:stratum 1} default-health-data
   "Create default health data structure.
 
    Returns: Map with default backends, cooldowns, and fallback order"
@@ -131,14 +129,14 @@
    :default-backend (:default-backend config)
    :fallback-order (:fallback-order config)})
 
-;;------------------------------------------------------------------------------ Layer 2
 ;; Backend health operations
-
-(def ^:private decay-threshold-ms
+(def ^{:stratum 1} ^:private decay-threshold-ms
   "Maximum age of health data before counters are reset (24 hours)."
   (:health-decay-ms config))
 
-(defn- maybe-decay-health
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- ^{:stratum 2} maybe-decay-health
   "Reset backend counters if all recorded last-failure timestamps are older than
    24 hours. Prevents accumulation of stale metrics over weeks of use.
 
@@ -169,17 +167,7 @@
       (assoc health-data :backends {})
       health-data)))
 
-(defn load-health
-  "Load backend health data from persistent storage.
-   Applies decay: if all backend metrics are older than 24 hours, resets counters.
-
-   Returns: Map with :backends, :switch-cooldowns, :default-backend, :fallback-order"
-  []
-  (let [raw (or (safe-read-edn (backend-health-path) nil)
-                (default-health-data))]
-    (maybe-decay-health raw)))
-
-(defn save-health!
+(defn ^{:stratum 2} save-health!
   "Save backend health data to persistent storage.
 
    Arguments:
@@ -189,7 +177,19 @@
   [health-data]
   (atomic-write-edn (backend-health-path) health-data))
 
-(defn reset-backend-health!
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} load-health
+  "Load backend health data from persistent storage.
+   Applies decay: if all backend metrics are older than 24 hours, resets counters.
+
+   Returns: Map with :backends, :switch-cooldowns, :default-backend, :fallback-order"
+  []
+  (let [raw (or (safe-read-edn (backend-health-path) nil)
+                (default-health-data))]
+    (maybe-decay-health raw)))
+
+(defn ^{:stratum 3} reset-backend-health!
   "Reset all backend health data to defaults.
    Useful for clearing stale accumulated metrics.
 
@@ -199,7 +199,9 @@
     (save-health! defaults)
     defaults))
 
-(defn record-backend-call!
+;------------------------------------------------------------------------------ Layer 4
+
+(defn ^{:stratum 4} record-backend-call!
   "Record a backend API call and its result.
 
    Arguments:
@@ -232,7 +234,7 @@
     (save-health! new-health)
     updated-stats))
 
-(defn get-backend-success-rate
+(defn ^{:stratum 4} get-backend-success-rate
   "Get current success rate for a backend.
 
    Arguments:
@@ -245,7 +247,7 @@
         stats (get-in health [:backends backend-key])]
     (:success-rate stats)))
 
-(defn- recent-failure?
+(defn- ^{:stratum 4} recent-failure?
   "Check if the last failure for a backend is within the recency window.
 
    Arguments:
@@ -265,25 +267,7 @@
              age-ms (.until failure-instant now java.time.temporal.ChronoUnit/MILLIS)]
          (< age-ms recency-ms))))))
 
-(defn should-switch-backend?
-  "Check if backend should be switched due to low success rate.
-   Only triggers if the last failure is recent (within 5 minutes),
-   preventing false positives from stale accumulated health data.
-
-   Arguments:
-     backend - Keyword backend name
-     threshold - Double threshold (default `default-success-rate-threshold`)
-
-   Returns: Boolean true if should switch"
-  ([backend]
-   (should-switch-backend? backend default-success-rate-threshold))
-  ([backend threshold]
-   (if-let [success-rate (get-backend-success-rate backend)]
-     (and (recent-failure? backend)
-          (< success-rate threshold))
-     false)))
-
-(defn in-cooldown?
+(defn ^{:stratum 4} in-cooldown?
   "Check if backend is in cooldown period after a switch.
 
    Arguments:
@@ -305,7 +289,53 @@
              cooldown-end (.plusMillis instant cooldown-ms)]
          (.isBefore now cooldown-end))))))
 
-(defn select-best-backend
+(defn ^{:stratum 4} trigger-backend-switch!
+  "Trigger a backend switch and record cooldown.
+
+   Arguments:
+     from-backend - Keyword current backend
+     to-backend - Keyword new backend
+     cooldown-ms - Cooldown period in milliseconds (default `default-switch-cooldown-ms`)
+
+   Returns: Map with :from, :to, :cooldown-until"
+  ([from-backend to-backend]
+   (trigger-backend-switch! from-backend to-backend default-switch-cooldown-ms))
+  ([from-backend to-backend cooldown-ms]
+   (let [health (load-health)
+         now (java.time.Instant/now)
+         from-key (keyword from-backend)
+         to-key (keyword to-backend)
+         cooldown-until-str (str now)
+         updated-health (-> health
+                           (assoc-in [:switch-cooldowns from-key] cooldown-until-str)
+                           (assoc :default-backend to-key))]
+     (save-health! updated-health)
+     {:from from-key
+      :to to-key
+      :cooldown-until now
+      :cooldown-ms cooldown-ms})))
+
+;------------------------------------------------------------------------------ Layer 5
+
+(defn ^{:stratum 5} should-switch-backend?
+  "Check if backend should be switched due to low success rate.
+   Only triggers if the last failure is recent (within 5 minutes),
+   preventing false positives from stale accumulated health data.
+
+   Arguments:
+     backend - Keyword backend name
+     threshold - Double threshold (default `default-success-rate-threshold`)
+
+   Returns: Boolean true if should switch"
+  ([backend]
+   (should-switch-backend? backend default-success-rate-threshold))
+  ([backend threshold]
+   (if-let [success-rate (get-backend-success-rate backend)]
+     (and (recent-failure? backend)
+          (< success-rate threshold))
+     false)))
+
+(defn ^{:stratum 5} select-best-backend
   "Select the best available backend that is not unhealthy or in cooldown.
 
    Arguments:
@@ -349,36 +379,10 @@
                   true))) ;; No data = eligible
          candidates))))))
 
-(defn trigger-backend-switch!
-  "Trigger a backend switch and record cooldown.
+;------------------------------------------------------------------------------ Layer 6
 
-   Arguments:
-     from-backend - Keyword current backend
-     to-backend - Keyword new backend
-     cooldown-ms - Cooldown period in milliseconds (default `default-switch-cooldown-ms`)
-
-   Returns: Map with :from, :to, :cooldown-until"
-  ([from-backend to-backend]
-   (trigger-backend-switch! from-backend to-backend default-switch-cooldown-ms))
-  ([from-backend to-backend cooldown-ms]
-   (let [health (load-health)
-         now (java.time.Instant/now)
-         from-key (keyword from-backend)
-         to-key (keyword to-backend)
-         cooldown-until-str (str now)
-         updated-health (-> health
-                           (assoc-in [:switch-cooldowns from-key] cooldown-until-str)
-                           (assoc :default-backend to-key))]
-     (save-health! updated-health)
-     {:from from-key
-      :to to-key
-      :cooldown-until now
-      :cooldown-ms cooldown-ms})))
-
-;;------------------------------------------------------------------------------ Layer 3
 ;; High-level health check
-
-(defn check-and-switch-if-needed
+(defn ^{:stratum 6} check-and-switch-if-needed
   "Check current backend health and switch if necessary.
 
    Arguments:

--- a/components/self-healing/src/ai/miniforge/self_healing/integration.clj
+++ b/components/self-healing/src/ai/miniforge/self_healing/integration.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.self-healing.integration
   "Integration helpers for self-healing in workflow execution.
 
@@ -24,10 +23,10 @@
    [ai.miniforge.self-healing.backend-health :as health]
    [ai.miniforge.self-healing.workaround-detector :as detector]))
 
-;;------------------------------------------------------------------------------ Layer 0
-;; Configuration helpers
+;------------------------------------------------------------------------------ Layer 0
 
-(defn get-self-healing-config
+;; Configuration helpers
+(defn ^{:stratum 0} get-self-healing-config
   "Extract self-healing configuration from context or use defaults.
 
    Arguments:
@@ -44,7 +43,7 @@
      :cooldown-ms (get config :backend-switch-cooldown-ms
                        (:switch-cooldown-ms health/config))}))
 
-(defn get-current-backend
+(defn ^{:stratum 0} get-current-backend
   "Get current backend from context or config.
 
    Arguments:
@@ -56,10 +55,54 @@
       (get-in context [:config :llm :backend])
       :anthropic))
 
-;;------------------------------------------------------------------------------ Layer 1
-;; Backend health tracking
+;; Event emission helpers
+(defn ^{:stratum 0} emit-workaround-event
+  "Emit workaround-applied event to event stream.
 
-(defn execute-with-health-tracking
+   Arguments:
+     context - Execution context map
+     workaround-result - Result from workaround application
+
+   Returns: Event map"
+  [context workaround-result]
+  (let [pattern (:pattern workaround-result)]
+    {:event/type :self-healing/workaround-applied
+     :event/id (java.util.UUID/randomUUID)
+     :event/timestamp (java.time.Instant/now)
+     :event/version "1.0.0"
+     :event/sequence-number (or (get-in context [:execution/sequence-number]) 0)
+     :workflow/id (or (:workflow/id context) (java.util.UUID/randomUUID))
+     :pattern-id (:id pattern)
+     :success? (:success? workaround-result)
+     :message (format "Applied workaround: %s" (:description pattern))}))
+
+(defn ^{:stratum 0} emit-backend-switch-event
+  "Emit backend-switched event to event stream.
+
+   Arguments:
+     context - Execution context map
+     switch-result - Result from backend switch
+
+   Returns: Event map"
+  [context switch-result]
+  {:event/type :self-healing/backend-switched
+   :event/id (java.util.UUID/randomUUID)
+   :event/timestamp (java.time.Instant/now)
+   :event/version "1.0.0"
+   :event/sequence-number (or (get-in context [:execution/sequence-number]) 0)
+   :workflow/id (or (:workflow/id context) (java.util.UUID/randomUUID))
+   :from (:from switch-result)
+   :to (:to switch-result)
+   :reason "Backend health below threshold"
+   :cooldown-until (:cooldown-until switch-result)
+   :message (str "Switched backend from " (name (:from switch-result))
+                " to " (name (:to switch-result))
+                " due to low success rate")})
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Backend health tracking
+(defn ^{:stratum 1} execute-with-health-tracking
   "Execute operation with backend health tracking.
 
    Automatically records success/failure and checks for backend switches.
@@ -127,7 +170,7 @@
                :workaround-applied? false
                :workaround-found? (:workaround-found? workaround-result)})))))))
 
-(defn check-backend-health-and-switch
+(defn ^{:stratum 1} check-backend-health-and-switch
   "Check backend health and switch if necessary.
 
    Should be called at phase boundaries or after failures.
@@ -149,56 +192,10 @@
         (when switch-result
           (assoc switch-result :switched? true))))))
 
-;;------------------------------------------------------------------------------ Layer 2
-;; Event emission helpers
+;------------------------------------------------------------------------------ Layer 2
 
-(defn emit-workaround-event
-  "Emit workaround-applied event to event stream.
-
-   Arguments:
-     context - Execution context map
-     workaround-result - Result from workaround application
-
-   Returns: Event map"
-  [context workaround-result]
-  (let [pattern (:pattern workaround-result)]
-    {:event/type :self-healing/workaround-applied
-     :event/id (java.util.UUID/randomUUID)
-     :event/timestamp (java.time.Instant/now)
-     :event/version "1.0.0"
-     :event/sequence-number (or (get-in context [:execution/sequence-number]) 0)
-     :workflow/id (or (:workflow/id context) (java.util.UUID/randomUUID))
-     :pattern-id (:id pattern)
-     :success? (:success? workaround-result)
-     :message (format "Applied workaround: %s" (:description pattern))}))
-
-(defn emit-backend-switch-event
-  "Emit backend-switched event to event stream.
-
-   Arguments:
-     context - Execution context map
-     switch-result - Result from backend switch
-
-   Returns: Event map"
-  [context switch-result]
-  {:event/type :self-healing/backend-switched
-   :event/id (java.util.UUID/randomUUID)
-   :event/timestamp (java.time.Instant/now)
-   :event/version "1.0.0"
-   :event/sequence-number (or (get-in context [:execution/sequence-number]) 0)
-   :workflow/id (or (:workflow/id context) (java.util.UUID/randomUUID))
-   :from (:from switch-result)
-   :to (:to switch-result)
-   :reason "Backend health below threshold"
-   :cooldown-until (:cooldown-until switch-result)
-   :message (str "Switched backend from " (name (:from switch-result))
-                " to " (name (:to switch-result))
-                " due to low success rate")})
-
-;;------------------------------------------------------------------------------ Layer 3
 ;; High-level integration API
-
-(defn wrap-phase-execution
+(defn ^{:stratum 2} wrap-phase-execution
   "Wrap phase execution with self-healing capabilities.
 
    This is the main integration point for workflow execution.

--- a/components/self-healing/src/ai/miniforge/self_healing/interface.clj
+++ b/components/self-healing/src/ai/miniforge/self_healing/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.self-healing.interface
   "Public interface for self-healing system.
    Exports functions from workaround-registry, workaround-detector, backend-health,
@@ -27,99 +26,97 @@
    [ai.miniforge.self-healing.integration :as integration]
    [ai.miniforge.self-healing.stream-recovery :as stream-recovery]))
 
-;;------------------------------------------------------------------------------ Workaround Registry
+;------------------------------------------------------------------------------ Layer 0
 
-(def load-workarounds
+;;------------------------------------------------------------------------------ Workaround Registry
+(def ^{:stratum 0} load-workarounds
   "Load workarounds from persistent storage."
   registry/load-workarounds)
 
-(def save-workarounds!
+(def ^{:stratum 0} save-workarounds!
   "Save workarounds to persistent storage."
   registry/save-workarounds!)
 
-(def add-workaround!
+(def ^{:stratum 0} add-workaround!
   "Add a new workaround to the registry."
   registry/add-workaround!)
 
-(def update-workaround-stats!
+(def ^{:stratum 0} update-workaround-stats!
   "Update success/failure statistics for a workaround."
   registry/update-workaround-stats!)
 
-(def get-workaround-by-pattern
+(def ^{:stratum 0} get-workaround-by-pattern
   "Get workaround matching an error pattern ID."
   registry/get-workaround-by-pattern)
 
-(def get-high-confidence-workarounds
+(def ^{:stratum 0} get-high-confidence-workarounds
   "Get all workarounds with confidence >= 0.8."
   registry/get-high-confidence-workarounds)
 
-(def get-all-workarounds
+(def ^{:stratum 0} get-all-workarounds
   "Get all workarounds from registry."
   registry/get-all-workarounds)
 
-(def delete-workaround!
+(def ^{:stratum 0} delete-workaround!
   "Delete a workaround from the registry."
   registry/delete-workaround!)
 
 ;;------------------------------------------------------------------------------ Workaround Detector
-
-(def match-error-to-workaround
+(def ^{:stratum 0} match-error-to-workaround
   "Match error to a workaround pattern."
   detector/match-error-to-workaround)
 
-(def apply-workaround
+(def ^{:stratum 0} apply-workaround
   "Apply workaround based on type."
   detector/apply-workaround)
 
-(def detect-and-apply-workaround
+(def ^{:stratum 0} detect-and-apply-workaround
   "Detect workaround for error and apply it."
   detector/detect-and-apply-workaround)
 
 ;;------------------------------------------------------------------------------ Backend Health
-
-(def load-health
+(def ^{:stratum 0} load-health
   "Load backend health data from persistent storage."
   health/load-health)
 
-(def save-health!
+(def ^{:stratum 0} save-health!
   "Save backend health data to persistent storage."
   health/save-health!)
 
-(def record-backend-call!
+(def ^{:stratum 0} record-backend-call!
   "Record a backend API call and its result."
   health/record-backend-call!)
 
-(def get-backend-success-rate
+(def ^{:stratum 0} get-backend-success-rate
   "Get current success rate for a backend."
   health/get-backend-success-rate)
 
-(def should-switch-backend?
+(def ^{:stratum 0} should-switch-backend?
   "Check if backend should be switched due to low success rate."
   health/should-switch-backend?)
 
-(def in-cooldown?
+(def ^{:stratum 0} in-cooldown?
   "Check if backend is in cooldown period after a switch."
   health/in-cooldown?)
 
-(def select-best-backend
+(def ^{:stratum 0} select-best-backend
   "Select the best available backend that is not unhealthy or in cooldown."
   health/select-best-backend)
 
-(def trigger-backend-switch!
+(def ^{:stratum 0} trigger-backend-switch!
   "Trigger a backend switch and record cooldown."
   health/trigger-backend-switch!)
 
-(def check-and-switch-if-needed
+(def ^{:stratum 0} check-and-switch-if-needed
   "Check current backend health and switch if necessary."
   health/check-and-switch-if-needed)
 
-(def reset-backend-health!
+(def ^{:stratum 0} reset-backend-health!
   "Reset all backend health data to defaults, clearing stale metrics."
   health/reset-backend-health!)
 
 ;;------------------------------------------------------------------------------ Stream Recovery
-
-(def evaluate-stall-recovery
+(def ^{:stratum 0} evaluate-stall-recovery
   "Decide whether to resume, failover, or abort after a watchdog kill.
 
    Takes a context map with :phase-id, :backend, :session-id, :hang-count (atom),
@@ -138,7 +135,7 @@
    See ai.miniforge.self-healing.stream-recovery/evaluate-stall-recovery."
   stream-recovery/evaluate-stall-recovery)
 
-(def execute-resume!
+(def ^{:stratum 0} execute-resume!
   "Restart an agent subprocess using the backend-specific resume flag.
 
    Arguments: backend, session-id, optional extra-args.
@@ -153,23 +150,22 @@
   stream-recovery/execute-resume!)
 
 ;;------------------------------------------------------------------------------ Integration
-
-(def execute-with-health-tracking
+(def ^{:stratum 0} execute-with-health-tracking
   "Execute operation with backend health tracking."
   integration/execute-with-health-tracking)
 
-(def check-backend-health-and-switch
+(def ^{:stratum 0} check-backend-health-and-switch
   "Check backend health and switch if necessary."
   integration/check-backend-health-and-switch)
 
-(def emit-workaround-event
+(def ^{:stratum 0} emit-workaround-event
   "Emit workaround-applied event to event stream."
   integration/emit-workaround-event)
 
-(def emit-backend-switch-event
+(def ^{:stratum 0} emit-backend-switch-event
   "Emit backend-switched event to event stream."
   integration/emit-backend-switch-event)
 
-(def wrap-phase-execution
+(def ^{:stratum 0} wrap-phase-execution
   "Wrap phase execution with self-healing capabilities."
   integration/wrap-phase-execution)

--- a/components/self-healing/src/ai/miniforge/self_healing/stream_recovery.clj
+++ b/components/self-healing/src/ai/miniforge/self_healing/stream_recovery.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.self-healing.stream-recovery
   "Resume-on-kill logic: decide resume vs failover vs abort after a watchdog kill.
 
@@ -45,10 +44,10 @@
    [ai.miniforge.response.interface :as response]
    [ai.miniforge.self-healing.backend-health :as backend-health]))
 
-;;------------------------------------------------------------------------------ Layer 0
-;; Backend-specific CLI metadata
+;------------------------------------------------------------------------------ Layer 0
 
-(def ^:private backend-resume-flags
+;; Backend-specific CLI metadata
+(def ^{:stratum 0} ^:private backend-resume-flags
   "Map of backend keyword → CLI flag used to resume a prior session."
   {:anthropic   "--resume"
    :claude-code "--resume"
@@ -57,7 +56,7 @@
    :ollama      "--continue"
    :google      "--resume"})
 
-(def ^:private backend-binaries
+(def ^{:stratum 0} ^:private backend-binaries
   "Map of backend keyword → actual CLI binary name."
   {:anthropic   "claude"
    :claude-code "claude"
@@ -66,67 +65,8 @@
    :ollama      "ollama"
    :google      "gemini"})
 
-(defn resume-flag-for
-  "Return the backend-specific CLI resume flag.
-
-   Arguments:
-     backend - Keyword backend name
-
-   Returns: String CLI flag (defaults to \"--resume\")"
-  [backend]
-  (get backend-resume-flags (keyword backend) "--resume"))
-
-(defn- binary-for
-  "Return the CLI binary name for a backend.
-
-   Arguments:
-     backend - Keyword (or anything `clojure.lang.Named`) backend identifier.
-               Must be non-nil; nil/non-Named values return an anomaly rather
-               than producing a downstream NPE inside execute-resume!'s
-               ProcessBuilder.
-
-   Returns: String binary name (defaults to (name backend)) or anomaly map."
-  [backend]
-  (cond
-    (nil? backend)
-    (response/make-anomaly :anomalies/incorrect
-                           "binary-for: backend must not be nil"
-                           {:stream-recovery/backend backend})
-
-    (not (instance? clojure.lang.Named backend))
-    (response/make-anomaly :anomalies/incorrect
-                           "binary-for: backend must be a keyword or symbol"
-                           {:stream-recovery/backend backend
-                            :stream-recovery/type    (type backend)})
-
-    :else
-    (get backend-binaries (keyword backend) (name backend))))
-
-(defn build-resume-command
-  "Build the full CLI command vector to resume an agent session.
-
-   Arguments:
-     backend    - Keyword backend name (:anthropic, :openai, etc.)
-     session-id - String session identifier to resume
-     extra-args - Optional seq of additional CLI arguments
-
-   Returns: Vector of strings, e.g. [\"claude\" \"--resume\" \"<sid>\"],
-   or an anomaly map when backend input is invalid."
-  ([backend session-id]
-   (build-resume-command backend session-id []))
-  ([backend session-id extra-args]
-   (let [backend-key (if (string? backend) (keyword backend) backend)
-         binary      (binary-for backend-key)]
-     (if (response/anomaly-map? binary)
-       binary
-       (let [backend-kw (keyword backend-key)
-             flag       (resume-flag-for backend-kw)]
-         (into [binary flag (str session-id)] extra-args))))))
-
-;;------------------------------------------------------------------------------ Layer 1
 ;; Process management (isolated for testability)
-
-(defn- start-process!
+(defn- ^{:stratum 0} start-process!
   "Launch a subprocess from a command vector.
    Propagates java.io.IOException — caller is responsible for catching.
 
@@ -139,10 +79,8 @@
       (.inheritIO)
       (.start)))
 
-;;------------------------------------------------------------------------------ Layer 2
 ;; Shared failover helper
-
-(defn- perform-failover
+(defn- ^{:stratum 0} perform-failover
   "Record the current backend as unhealthy, select a candidate from
    allowed-failover-backends via backend-health/select-best-backend,
    trigger a switch, and return the decision map.
@@ -172,10 +110,46 @@
         {:action :abort
          :reason "no healthy backends"}))))
 
-;;------------------------------------------------------------------------------ Layer 3
-;; Core decision function
+;------------------------------------------------------------------------------ Layer 1
 
-(defn evaluate-stall-recovery
+(defn ^{:stratum 1} resume-flag-for
+  "Return the backend-specific CLI resume flag.
+
+   Arguments:
+     backend - Keyword backend name
+
+   Returns: String CLI flag (defaults to \"--resume\")"
+  [backend]
+  (get backend-resume-flags (keyword backend) "--resume"))
+
+(defn- ^{:stratum 1} binary-for
+  "Return the CLI binary name for a backend.
+
+   Arguments:
+     backend - Keyword (or anything `clojure.lang.Named`) backend identifier.
+               Must be non-nil; nil/non-Named values return an anomaly rather
+               than producing a downstream NPE inside execute-resume!'s
+               ProcessBuilder.
+
+   Returns: String binary name (defaults to (name backend)) or anomaly map."
+  [backend]
+  (cond
+    (nil? backend)
+    (response/make-anomaly :anomalies/incorrect
+                           "binary-for: backend must not be nil"
+                           {:stream-recovery/backend backend})
+
+    (not (instance? clojure.lang.Named backend))
+    (response/make-anomaly :anomalies/incorrect
+                           "binary-for: backend must be a keyword or symbol"
+                           {:stream-recovery/backend backend
+                            :stream-recovery/type    (type backend)})
+
+    :else
+    (get backend-binaries (keyword backend) (name backend))))
+
+;; Core decision function
+(defn ^{:stratum 1} evaluate-stall-recovery
   "Decide whether to resume, failover, or abort after a watchdog kill.
 
    Side effects on :failover path:
@@ -303,10 +277,33 @@
            :reason   "degenerate hang-count and no resumable session"
            :anomaly? true}))))))
 
-;;------------------------------------------------------------------------------ Layer 4
-;; Public subprocess restart
+;------------------------------------------------------------------------------ Layer 2
 
-(defn execute-resume!
+(defn ^{:stratum 2} build-resume-command
+  "Build the full CLI command vector to resume an agent session.
+
+   Arguments:
+     backend    - Keyword backend name (:anthropic, :openai, etc.)
+     session-id - String session identifier to resume
+     extra-args - Optional seq of additional CLI arguments
+
+   Returns: Vector of strings, e.g. [\"claude\" \"--resume\" \"<sid>\"],
+   or an anomaly map when backend input is invalid."
+  ([backend session-id]
+   (build-resume-command backend session-id []))
+  ([backend session-id extra-args]
+   (let [backend-key (if (string? backend) (keyword backend) backend)
+         binary      (binary-for backend-key)]
+     (if (response/anomaly-map? binary)
+       binary
+       (let [backend-kw (keyword backend-key)
+             flag       (resume-flag-for backend-kw)]
+         (into [binary flag (str session-id)] extra-args))))))
+
+;------------------------------------------------------------------------------ Layer 3
+
+;; Public subprocess restart
+(defn ^{:stratum 3} execute-resume!
   "Restart an agent subprocess using the backend-specific resume flag.
 
    Constructs a command of the form:
@@ -346,7 +343,6 @@
             :cmd              cmd}))))))
 
 ;;------------------------------------------------------------------------------ Rich comment
-
 (comment
   ;; First stall: resume (backend healthy)
   (let [hang (atom 1)]
@@ -373,4 +369,5 @@
 
   ;; Build command without launching a process
   (build-resume-command :anthropic "sess-xyz" ["--timeout" "120"]))
-  ;; => ["claude" "--resume" "sess-xyz" "--timeout" "120"]
+
+;; => ["claude" "--resume" "sess-xyz" "--timeout" "120"]

--- a/components/self-healing/src/ai/miniforge/self_healing/stream_recovery.clj
+++ b/components/self-healing/src/ai/miniforge/self_healing/stream_recovery.clj
@@ -368,6 +368,6 @@
   ;; => {:action :failover, :new-backend :openai}
 
   ;; Build command without launching a process
-  (build-resume-command :anthropic "sess-xyz" ["--timeout" "120"]))
-
-;; => ["claude" "--resume" "sess-xyz" "--timeout" "120"]
+  (build-resume-command :anthropic "sess-xyz" ["--timeout" "120"])
+  ;; => ["claude" "--resume" "sess-xyz" "--timeout" "120"]
+  )

--- a/components/self-healing/src/ai/miniforge/self_healing/workaround_detector.clj
+++ b/components/self-healing/src/ai/miniforge/self_healing/workaround_detector.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.self-healing.workaround-detector
   "Automatic detection and application of workarounds for known issues.
 
@@ -29,17 +28,16 @@
    [clojure.java.io :as io]
    [ai.miniforge.self-healing.workaround-registry :as registry]))
 
-;;------------------------------------------------------------------------------ Layer 0
-;; Result predicates
+;------------------------------------------------------------------------------ Layer 0
 
-(defn succeeded?
+;; Result predicates
+(defn ^{:stratum 0} succeeded?
   "Check if a result map indicates success."
   [result]
   (boolean (:success? result)))
 
 ;; Pattern loading with workaround metadata
-
-(defn load-workaround-patterns
+(defn ^{:stratum 0} load-workaround-patterns
   "Load workaround patterns from resources.
 
    Returns: Vector of pattern maps with :id, :regex, :workaround"
@@ -53,14 +51,8 @@
          (mapcat :patterns)
          (filter :workaround))))
 
-(def workaround-patterns
-  "Cached workaround patterns with auto-fix metadata"
-  (load-workaround-patterns))
-
-;;------------------------------------------------------------------------------ Layer 1
 ;; Pattern matching
-
-(defn matches-workaround-pattern?
+(defn ^{:stratum 0} matches-workaround-pattern?
   "Check if error message matches a workaround pattern.
 
    Arguments:
@@ -72,78 +64,16 @@
   (when (and error-msg (:regex pattern))
     (boolean (re-find (re-pattern (:regex pattern)) error-msg))))
 
-(defn match-error-to-workaround
-  "Match error to a workaround pattern.
-
-   Arguments:
-     error-result - Map with :message or exception
-
-   Returns: Pattern map with :workaround or nil"
-  [error-result]
-  (let [error-msg (if (string? error-result)
-                    error-result
-                    (or (:message error-result)
-                        (when (instance? Exception error-result)
-                          (ex-message error-result))
-                        (str error-result)))]
-    (first (filter #(matches-workaround-pattern? error-msg %) workaround-patterns))))
-
-;;------------------------------------------------------------------------------ Layer 2
 ;; User approval tracking
-
-(defn approval-file-path
+(defn ^{:stratum 0} approval-file-path
   "Get path to workaround approval tracking file.
 
    Returns: String path to ~/.miniforge/workaround_approvals.edn"
   []
   (str (config/miniforge-home) "/workaround_approvals.edn"))
 
-(defn load-approvals
-  "Load workaround approval history.
-
-   Returns: Map of pattern-id -> approval status"
-  []
-  (let [path (approval-file-path)]
-    (if (.exists (io/file path))
-      (try
-        (edn/read-string (slurp path))
-        (catch Exception _
-          {}))
-      {})))
-
-(defn save-approval!
-  "Save workaround approval.
-
-   Arguments:
-     pattern-id - Keyword pattern ID
-     approval - :always | :never | :once"
-  [pattern-id approval]
-  (let [path (approval-file-path)
-        approvals (assoc (load-approvals) pattern-id approval)]
-    (io/make-parents path)
-    (spit path (pr-str approvals))))
-
-(defn check-approval
-  "Check if workaround is approved.
-
-   Arguments:
-     pattern-id - Keyword pattern ID
-     requires-sudo? - Boolean if sudo required
-
-   Returns: :approved | :denied | :prompt"
-  [pattern-id requires-sudo?]
-  (let [approvals (load-approvals)
-        approval (get approvals pattern-id)]
-    (case approval
-      :always :approved
-      :never :denied
-      ;; No prior approval - prompt if sudo required
-      (if requires-sudo? :prompt :approved))))
-
-;;------------------------------------------------------------------------------ Layer 3
 ;; Workaround execution
-
-(defn execute-shell-command
+(defn ^{:stratum 0} execute-shell-command
   "Execute shell command and return result.
 
    Arguments:
@@ -164,7 +94,71 @@
       {:success? false
        :error (ex-message e)})))
 
-(defn apply-shell-workaround
+(defn ^{:stratum 0} apply-env-var-workaround
+  "Apply environment variable workaround.
+
+   Arguments:
+     workaround - Map with :env-var
+     _pattern-id - Keyword pattern ID (unused but kept for consistency)
+
+   Returns: Map with :success?, :message"
+  [workaround _pattern-id]
+  ;; Note: Can't set env vars for parent process, but can suggest
+  {:success? false
+   :message (str "Please set environment variable: " (:env-var workaround))
+   :suggestion (str "export " (:env-var workaround) "='your-value-here'")})
+
+(defn ^{:stratum 0} apply-backend-switch-workaround
+  "Apply backend switch workaround.
+
+   Arguments:
+     workaround - Map with :to-backend
+     _pattern-id - Keyword pattern ID (unused but kept for consistency)
+
+   Returns: Map with :success?, :message"
+  [workaround _pattern-id]
+  {:success? true
+   :message (str "Switching to backend: " (:to-backend workaround))
+   :to-backend (:to-backend workaround)})
+
+;; GitHub issue integration (for future enhancement)
+(defn ^{:stratum 0} fetch-workaround-from-github
+  "Fetch workaround suggestions from GitHub issues.
+
+   This is a placeholder for future GitHub API integration.
+
+   Arguments:
+     _error-message - String error message (unused - future implementation)
+     _repo - String repo (unused - future implementation)
+
+   Returns: Vector of suggested workarounds or nil"
+  [_error-message _repo]
+  ;; TODO: Implement GitHub API search for issues matching error message
+  ;; Search for closed issues with labels: 'workaround', 'resolved'
+  ;; Parse issue body for commands/fixes
+  ;; Return structured workaround suggestions
+  nil)
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} workaround-patterns
+  "Cached workaround patterns with auto-fix metadata"
+  (load-workaround-patterns))
+
+(defn ^{:stratum 1} load-approvals
+  "Load workaround approval history.
+
+   Returns: Map of pattern-id -> approval status"
+  []
+  (let [path (approval-file-path)]
+    (if (.exists (io/file path))
+      (try
+        (edn/read-string (slurp path))
+        (catch Exception _
+          {}))
+      {})))
+
+(defn ^{:stratum 1} apply-shell-workaround
   "Apply shell command workaround.
 
    Arguments:
@@ -183,34 +177,56 @@
        :message (str "Failed to execute: " command)
        :error (or (:error result) (:output result))})))
 
-(defn apply-env-var-workaround
-  "Apply environment variable workaround.
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} match-error-to-workaround
+  "Match error to a workaround pattern.
 
    Arguments:
-     workaround - Map with :env-var
-     _pattern-id - Keyword pattern ID (unused but kept for consistency)
+     error-result - Map with :message or exception
 
-   Returns: Map with :success?, :message"
-  [workaround _pattern-id]
-  ;; Note: Can't set env vars for parent process, but can suggest
-  {:success? false
-   :message (str "Please set environment variable: " (:env-var workaround))
-   :suggestion (str "export " (:env-var workaround) "='your-value-here'")})
+   Returns: Pattern map with :workaround or nil"
+  [error-result]
+  (let [error-msg (if (string? error-result)
+                    error-result
+                    (or (:message error-result)
+                        (when (instance? Exception error-result)
+                          (ex-message error-result))
+                        (str error-result)))]
+    (first (filter #(matches-workaround-pattern? error-msg %) workaround-patterns))))
 
-(defn apply-backend-switch-workaround
-  "Apply backend switch workaround.
+(defn ^{:stratum 2} save-approval!
+  "Save workaround approval.
 
    Arguments:
-     workaround - Map with :to-backend
-     _pattern-id - Keyword pattern ID (unused but kept for consistency)
+     pattern-id - Keyword pattern ID
+     approval - :always | :never | :once"
+  [pattern-id approval]
+  (let [path (approval-file-path)
+        approvals (assoc (load-approvals) pattern-id approval)]
+    (io/make-parents path)
+    (spit path (pr-str approvals))))
 
-   Returns: Map with :success?, :message"
-  [workaround _pattern-id]
-  {:success? true
-   :message (str "Switching to backend: " (:to-backend workaround))
-   :to-backend (:to-backend workaround)})
+(defn ^{:stratum 2} check-approval
+  "Check if workaround is approved.
 
-(defn apply-workaround
+   Arguments:
+     pattern-id - Keyword pattern ID
+     requires-sudo? - Boolean if sudo required
+
+   Returns: :approved | :denied | :prompt"
+  [pattern-id requires-sudo?]
+  (let [approvals (load-approvals)
+        approval (get approvals pattern-id)]
+    (case approval
+      :always :approved
+      :never :denied
+      ;; No prior approval - prompt if sudo required
+      (if requires-sudo? :prompt :approved))))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} apply-workaround
   "Apply workaround based on type.
 
    Arguments:
@@ -281,10 +297,10 @@
         :applied? false
         :message "Unknown approval state"}))))
 
-;;------------------------------------------------------------------------------ Layer 4
-;; High-level API
+;------------------------------------------------------------------------------ Layer 4
 
-(defn detect-and-apply-workaround
+;; High-level API
+(defn ^{:stratum 4} detect-and-apply-workaround
   "Detect workaround for error and apply it.
 
    Arguments:
@@ -323,23 +339,3 @@
       :applied? false
       :success? false
       :message "No workaround found for this error"})))
-
-;;------------------------------------------------------------------------------ Layer 5
-;; GitHub issue integration (for future enhancement)
-
-(defn fetch-workaround-from-github
-  "Fetch workaround suggestions from GitHub issues.
-
-   This is a placeholder for future GitHub API integration.
-
-   Arguments:
-     _error-message - String error message (unused - future implementation)
-     _repo - String repo (unused - future implementation)
-
-   Returns: Vector of suggested workarounds or nil"
-  [_error-message _repo]
-  ;; TODO: Implement GitHub API search for issues matching error message
-  ;; Search for closed issues with labels: 'workaround', 'resolved'
-  ;; Parse issue body for commands/fixes
-  ;; Return structured workaround suggestions
-  nil)

--- a/components/self-healing/src/ai/miniforge/self_healing/workaround_registry.clj
+++ b/components/self-healing/src/ai/miniforge/self_healing/workaround_registry.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.self-healing.workaround-registry
   "Persistent registry of known vendor bug workarounds.
    Storage: ~/.miniforge/known_workarounds.edn"
@@ -23,10 +22,10 @@
    [clojure.edn :as edn]
    [clojure.java.io :as io]))
 
-;;------------------------------------------------------------------------------ Layer 0
-;; File paths and utilities
+;------------------------------------------------------------------------------ Layer 0
 
-(defn workaround-registry-path
+;; File paths and utilities
+(defn ^{:stratum 0} workaround-registry-path
   "Get path to workaround registry file.
 
    Returns: String path to ~/.miniforge/known_workarounds.edn"
@@ -35,7 +34,7 @@
         miniforge-dir (io/file home ".miniforge")]
     (.getPath (io/file miniforge-dir "known_workarounds.edn"))))
 
-(defn ensure-directory-exists
+(defn ^{:stratum 0} ensure-directory-exists
   "Ensure parent directory exists for a file path.
 
    Arguments:
@@ -47,7 +46,7 @@
     (when-not (.exists parent-dir)
       (.mkdirs parent-dir))))
 
-(defn safe-read-edn
+(defn ^{:stratum 0} safe-read-edn
   "Safely read EDN from file, returning default on error.
 
    Arguments:
@@ -62,7 +61,9 @@
     (catch Exception _
       default)))
 
-(defn atomic-write-edn
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} atomic-write-edn
   "Atomically write EDN to file using temp file + rename.
 
    Arguments:
@@ -76,10 +77,8 @@
     (spit temp-file (pr-str data))
     (.renameTo (io/file temp-file) (io/file file-path))))
 
-;;------------------------------------------------------------------------------ Layer 1
 ;; Workaround registry operations
-
-(defn load-workarounds
+(defn ^{:stratum 1} load-workarounds
   "Load workarounds from persistent storage.
 
    Returns: Map with :workarounds vector"
@@ -87,7 +86,9 @@
   (or (safe-read-edn (workaround-registry-path) nil)
       {:workarounds []}))
 
-(defn save-workarounds!
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} save-workarounds!
   "Save workarounds to persistent storage.
 
    Arguments:
@@ -97,7 +98,37 @@
   [workarounds-data]
   (atomic-write-edn (workaround-registry-path) workarounds-data))
 
-(defn add-workaround!
+(defn ^{:stratum 2} get-workaround-by-pattern
+  "Get workaround matching an error pattern ID.
+
+   Arguments:
+     error-pattern-id - Keyword pattern ID
+
+   Returns: Workaround map or nil if not found"
+  [error-pattern-id]
+  (let [registry (load-workarounds)]
+    (first (filter #(= (:error-pattern-id %) error-pattern-id)
+                   (:workarounds registry)))))
+
+(defn ^{:stratum 2} get-high-confidence-workarounds
+  "Get all workarounds with confidence >= 0.8.
+
+   Returns: Vector of high-confidence workaround maps"
+  []
+  (let [registry (load-workarounds)]
+    (vec (filter #(>= (:confidence %) 0.8)
+                 (:workarounds registry)))))
+
+(defn ^{:stratum 2} get-all-workarounds
+  "Get all workarounds from registry.
+
+   Returns: Vector of all workaround maps"
+  []
+  (:workarounds (load-workarounds)))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} add-workaround!
   "Add a new workaround to the registry.
 
    Arguments:
@@ -125,7 +156,7 @@
      (update registry :workarounds conj new-workaround))
     new-workaround))
 
-(defn update-workaround-stats!
+(defn ^{:stratum 3} update-workaround-stats!
   "Update success/failure statistics for a workaround.
 
    Arguments:
@@ -154,35 +185,7 @@
         (save-workarounds! (assoc registry :workarounds new-workarounds))
         updated))))
 
-(defn get-workaround-by-pattern
-  "Get workaround matching an error pattern ID.
-
-   Arguments:
-     error-pattern-id - Keyword pattern ID
-
-   Returns: Workaround map or nil if not found"
-  [error-pattern-id]
-  (let [registry (load-workarounds)]
-    (first (filter #(= (:error-pattern-id %) error-pattern-id)
-                   (:workarounds registry)))))
-
-(defn get-high-confidence-workarounds
-  "Get all workarounds with confidence >= 0.8.
-
-   Returns: Vector of high-confidence workaround maps"
-  []
-  (let [registry (load-workarounds)]
-    (vec (filter #(>= (:confidence %) 0.8)
-                 (:workarounds registry)))))
-
-(defn get-all-workarounds
-  "Get all workarounds from registry.
-
-   Returns: Vector of all workaround maps"
-  []
-  (:workarounds (load-workarounds)))
-
-(defn delete-workaround!
+(defn ^{:stratum 3} delete-workaround!
   "Delete a workaround from the registry.
 
    Arguments:

--- a/components/self-healing/test/ai/miniforge/self_healing/anomaly/stream_recovery_anomaly_test.clj
+++ b/components/self-healing/test/ai/miniforge/self_healing/anomaly/stream_recovery_anomaly_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.self-healing.anomaly.stream-recovery-anomaly-test
   "Coverage for `stream-recovery/binary-for` and
    `stream-recovery/evaluate-stall-recovery` boundary escalation via
@@ -23,17 +22,19 @@
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.self-healing.stream-recovery :as recovery]))
 
-(deftest binary-for-nil-backend-returns-anomaly
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} binary-for-nil-backend-returns-anomaly
   (testing "nil backend returns :anomalies/incorrect"
     (let [result (#'recovery/binary-for nil)]
       (is (= :anomalies/incorrect (:anomaly/category result))))))
 
-(deftest binary-for-non-named-backend-returns-anomaly
+(deftest ^{:stratum 0} binary-for-non-named-backend-returns-anomaly
   (testing "non-keyword non-symbol backend returns :anomalies/incorrect"
     (let [result (#'recovery/binary-for "string-backend")]
       (is (= :anomalies/incorrect (:anomaly/category result))))))
 
-(deftest evaluate-stall-recovery-non-iatom-hang-count-returns-anomaly
+(deftest ^{:stratum 0} evaluate-stall-recovery-non-iatom-hang-count-returns-anomaly
   (testing "non-IAtom :hang-count returns :anomalies/incorrect"
     (let [result (recovery/evaluate-stall-recovery
                   {:phase-id :impl
@@ -44,7 +45,7 @@
                    :allowed-failover-backends []})]
       (is (= :anomalies/incorrect (:anomaly/category result))))))
 
-(deftest evaluate-stall-recovery-nil-backend-returns-anomaly
+(deftest ^{:stratum 0} evaluate-stall-recovery-nil-backend-returns-anomaly
   (testing "nil :backend returns :anomalies/incorrect"
     (let [result (recovery/evaluate-stall-recovery
                   {:phase-id :impl
@@ -55,7 +56,7 @@
                    :allowed-failover-backends []})]
       (is (= :anomalies/incorrect (:anomaly/category result))))))
 
-(deftest evaluate-stall-recovery-invalid-backend-returns-anomaly
+(deftest ^{:stratum 0} evaluate-stall-recovery-invalid-backend-returns-anomaly
   (testing "non-coercible :backend returns :anomalies/incorrect"
     (let [result (recovery/evaluate-stall-recovery
                   {:phase-id :impl
@@ -66,7 +67,7 @@
                    :allowed-failover-backends []})]
       (is (= :anomalies/incorrect (:anomaly/category result))))))
 
-(deftest execute-resume-invalid-backend-returns-anomaly
+(deftest ^{:stratum 0} execute-resume-invalid-backend-returns-anomaly
   (testing "invalid backend returns anomaly before ProcessBuilder startup"
     (let [result (recovery/execute-resume! 42 "sid")]
       (is (= :anomalies/incorrect (:anomaly/category result))))))

--- a/components/self-healing/test/ai/miniforge/self_healing/stream_recovery_test.clj
+++ b/components/self-healing/test/ai/miniforge/self_healing/stream_recovery_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.self-healing.stream-recovery-test
   "Tests for resume-on-kill / stall-recovery logic."
   (:require
@@ -23,25 +22,15 @@
    [ai.miniforge.self-healing.stream-recovery :as sut]
    [ai.miniforge.self-healing.backend-health :as health]))
 
-;;------------------------------------------------------------------------------ Helpers
+;------------------------------------------------------------------------------ Layer 0
 
-(def ^:private base-config
+;;------------------------------------------------------------------------------ Helpers
+(def ^{:stratum 0} ^:private base-config
   {:backend-switch-cooldown-ms 1800000
    :backend-health-threshold   0.90})
 
-(defn- make-ctx
-  "Build a minimal recovery context map."
-  [backend session-id hang-count-val allowed-failover]
-  {:phase-id                  :implement
-   :backend                   backend
-   :session-id                session-id
-   :hang-count                (atom hang-count-val)
-   :config                    base-config
-   :allowed-failover-backends allowed-failover})
-
 ;;------------------------------------------------------------------------------ resume-flag-for
-
-(deftest resume-flag-for-known-backends
+(deftest ^{:stratum 0} resume-flag-for-known-backends
   (testing "well-known backends return their documented flag"
     (is (= "--resume"   (sut/resume-flag-for :anthropic)))
     (is (= "--resume"   (sut/resume-flag-for :openai)))
@@ -49,45 +38,43 @@
     (is (= "--continue" (sut/resume-flag-for :ollama)))
     (is (= "--resume"   (sut/resume-flag-for :google)))))
 
-(deftest resume-flag-for-unknown-backend
+(deftest ^{:stratum 0} resume-flag-for-unknown-backend
   (testing "unknown backend defaults to --resume"
     (is (= "--resume" (sut/resume-flag-for :unknown-backend-xyz)))))
 
 ;;------------------------------------------------------------------------------ build-resume-command
-
-(deftest build-resume-command-anthropic-uses-claude-binary
+(deftest ^{:stratum 0} build-resume-command-anthropic-uses-claude-binary
   (testing ":anthropic backend maps to the 'claude' binary, not 'anthropic'"
     (is (= ["claude" "--resume" "sess-abc"]
            (sut/build-resume-command :anthropic "sess-abc")))))
 
-(deftest build-resume-command-claude-code-uses-claude-binary
+(deftest ^{:stratum 0} build-resume-command-claude-code-uses-claude-binary
   (testing ":claude-code backend also maps to the 'claude' binary"
     (is (= ["claude" "--resume" "s1"]
            (sut/build-resume-command :claude-code "s1")))))
 
-(deftest build-resume-command-google-uses-gemini-binary
+(deftest ^{:stratum 0} build-resume-command-google-uses-gemini-binary
   (testing ":google backend maps to the 'gemini' binary"
     (is (= ["gemini" "--resume" "s2"]
            (sut/build-resume-command :google "s2")))))
 
-(deftest build-resume-command-with-extra-args
+(deftest ^{:stratum 0} build-resume-command-with-extra-args
   (testing "appends extra args after session-id"
     (is (= ["openai" "--resume" "s123" "--timeout" "90"]
            (sut/build-resume-command :openai "s123" ["--timeout" "90"])))))
 
-(deftest build-resume-command-ollama-uses-continue
+(deftest ^{:stratum 0} build-resume-command-ollama-uses-continue
   (testing "ollama uses --continue flag and 'ollama' binary"
     (is (= ["ollama" "--continue" "s999"]
            (sut/build-resume-command :ollama "s999")))))
 
-(deftest build-resume-command-string-backend-coerced
+(deftest ^{:stratum 0} build-resume-command-string-backend-coerced
   (testing "string backend is coerced to keyword for lookup"
     (is (= ["codex" "--resume" "sid"]
            (sut/build-resume-command "codex" "sid")))))
 
 ;;------------------------------------------------------------------------------ evaluate-stall-recovery – guard clauses
-
-(deftest evaluate-stall-recovery-nil-backend-returns-anomaly
+(deftest ^{:stratum 0} evaluate-stall-recovery-nil-backend-returns-anomaly
   (testing "nil :backend returns :anomalies/incorrect"
     (let [result (sut/evaluate-stall-recovery
                   {:phase-id   :implement
@@ -99,7 +86,7 @@
       (is (= :anomalies/incorrect (:anomaly/category result)))
       (is (re-find #":backend is required" (:anomaly/message result))))))
 
-(deftest evaluate-stall-recovery-non-atom-hang-count-returns-anomaly
+(deftest ^{:stratum 0} evaluate-stall-recovery-non-atom-hang-count-returns-anomaly
   (testing "non-atom :hang-count returns :anomalies/incorrect"
     (let [result (sut/evaluate-stall-recovery
                   {:phase-id   :implement
@@ -111,143 +98,7 @@
       (is (= :anomalies/incorrect (:anomaly/category result)))
       (is (re-find #":hang-count must be an IAtom" (:anomaly/message result))))))
 
-;;------------------------------------------------------------------------------ evaluate-stall-recovery – :resume path
-
-(deftest evaluate-stall-recovery-first-hang-no-health-data-returns-resume
-  (testing "hang-count=1, backend has no health data (nil rate = eligible) → :resume"
-    (with-redefs [health/get-backend-success-rate (fn [_b] nil)
-                  health/record-backend-call!     (fn [_b _s] nil)
-                  health/select-best-backend      (fn [& _] nil)
-                  health/trigger-backend-switch!  (fn [& _] nil)]
-      (let [ctx    (make-ctx :anthropic "sess-111" 1 [:openai :codex])
-            result (sut/evaluate-stall-recovery ctx)]
-        (is (= :resume    (:action result)))
-        (is (= "sess-111" (:session-id result)))
-        (is (= :anthropic (:backend result)))))))
-
-(deftest evaluate-stall-recovery-first-hang-healthy-rate-returns-resume
-  (testing "hang-count=1, backend success-rate >= threshold → :resume, no side effects"
-    ;; Stubs all side-effect functions and asserts they were NOT called, proving
-    ;; the resume path is side-effect-free.
-    (let [record-calls (atom [])]
-      (with-redefs [health/get-backend-success-rate (fn [_b] 0.95) ; above threshold
-                    health/record-backend-call!     (fn [b s] (swap! record-calls conj [b s]))
-                    health/select-best-backend      (fn [& _] nil)
-                    health/trigger-backend-switch!  (fn [& _] nil)]
-        (let [ctx    (make-ctx :anthropic "sess-ok" 1 [:openai])
-              result (sut/evaluate-stall-recovery ctx)]
-          (is (= :resume (:action result)))
-          (is (empty? @record-calls)
-              "resume path must not record a backend failure"))))))
-
-;;------------------------------------------------------------------------------ evaluate-stall-recovery – health gate on count=1
-
-(deftest evaluate-stall-recovery-first-hang-unhealthy-backend-skips-resume
-  (testing "hang-count=1 but backend already below threshold → :failover, not :resume"
-    (with-redefs [health/get-backend-success-rate (fn [_b] 0.50)
-                  health/record-backend-call!     (fn [_b _s] nil)
-                  health/select-best-backend      (fn [& _] :openai)
-                  health/trigger-backend-switch!  (fn [& _] nil)]
-      (let [ctx    (make-ctx :anthropic "sess-sick" 1 [:openai :codex])
-            result (sut/evaluate-stall-recovery ctx)]
-        (is (= :failover (:action result)))
-        (is (= :openai   (:new-backend result)))))))
-
-(deftest evaluate-stall-recovery-first-hang-unhealthy-no-candidates-aborts
-  (testing "hang-count=1, backend unhealthy, no allowed failover candidates → :abort"
-    (with-redefs [health/get-backend-success-rate (fn [_b] 0.30)
-                  health/record-backend-call!     (fn [_b _s] nil)
-                  health/select-best-backend      (fn [& _] nil)
-                  health/trigger-backend-switch!  (fn [& _] nil)]
-      (let [ctx    (make-ctx :anthropic "sess-s" 1 [])
-            result (sut/evaluate-stall-recovery ctx)]
-        (is (= :abort  (:action result)))
-        (is (string? (:reason result)))))))
-
-(deftest evaluate-stall-recovery-first-hang-records-failure-before-early-failover
-  (testing "health-gate path calls record-backend-call! with false"
-    (let [recorded (atom nil)]
-      (with-redefs [health/get-backend-success-rate (fn [_b] 0.50)
-                    health/record-backend-call!     (fn [b s] (reset! recorded {:b b :s s}))
-                    health/select-best-backend      (fn [& _] :openai)
-                    health/trigger-backend-switch!  (fn [& _] nil)]
-        (sut/evaluate-stall-recovery (make-ctx :anthropic "sess-r" 1 [:openai]))
-        (is (= {:b :anthropic :s false} @recorded))))))
-
-;;------------------------------------------------------------------------------ evaluate-stall-recovery – degenerate count
-
-(deftest evaluate-stall-recovery-zero-hang-count-returns-resume-with-anomaly
-  (testing "hang-count=0 (degenerate) → :resume with :anomaly? true"
-    (with-redefs [health/get-backend-success-rate (fn [_b] nil)
-                  health/record-backend-call!     (fn [_b _s] nil)
-                  health/select-best-backend      (fn [& _] nil)
-                  health/trigger-backend-switch!  (fn [& _] nil)]
-      (let [ctx    (make-ctx :openai "sess-000" 0 [:anthropic])
-            result (sut/evaluate-stall-recovery ctx)]
-        (is (= :resume (:action result)))
-        (is (true? (:anomaly? result)))))))
-
-;;------------------------------------------------------------------------------ evaluate-stall-recovery – :failover path
-
-(deftest evaluate-stall-recovery-second-hang-returns-failover
-  (testing "hang-count=2 with healthy allowed failover backend → :failover"
-    (with-redefs [health/get-backend-success-rate (fn [_b] nil)
-                  health/record-backend-call!     (fn [_b _s] nil)
-                  health/select-best-backend      (fn [& _] :openai)
-                  health/trigger-backend-switch!  (fn [& _] nil)]
-      (let [ctx    (make-ctx :anthropic "sess-222" 2 [:openai :codex])
-            result (sut/evaluate-stall-recovery ctx)]
-        (is (= :failover (:action result)))
-        (is (= :openai   (:new-backend result)))))))
-
-(deftest evaluate-stall-recovery-third-hang-also-failover
-  (testing "hang-count=3 also triggers :failover"
-    (with-redefs [health/get-backend-success-rate (fn [_b] nil)
-                  health/record-backend-call!     (fn [_b _s] nil)
-                  health/select-best-backend      (fn [& _] :codex)
-                  health/trigger-backend-switch!  (fn [& _] nil)]
-      (let [ctx    (make-ctx :anthropic "sess-333" 3 [:codex])
-            result (sut/evaluate-stall-recovery ctx)]
-        (is (= :failover (:action result)))
-        (is (= :codex    (:new-backend result)))))))
-
-(deftest evaluate-stall-recovery-records-failure-on-second-hang
-  (testing "hang-count>=2 calls record-backend-call! with success?=false"
-    (let [recorded (atom nil)]
-      (with-redefs [health/get-backend-success-rate (fn [_b] nil)
-                    health/record-backend-call!     (fn [b s] (reset! recorded {:b b :s s}))
-                    health/select-best-backend      (fn [& _] :openai)
-                    health/trigger-backend-switch!  (fn [& _] nil)]
-        (sut/evaluate-stall-recovery (make-ctx :anthropic "sess-f" 2 [:openai]))
-        (is (= {:b :anthropic :s false} @recorded))))))
-
-(deftest evaluate-stall-recovery-calls-trigger-switch-on-failover
-  (testing "failover path calls trigger-backend-switch! with correct args"
-    (let [switch-calls (atom [])]
-      (with-redefs [health/get-backend-success-rate (fn [_b] nil)
-                    health/record-backend-call!     (fn [_b _s] nil)
-                    health/select-best-backend      (fn [& _] :openai)
-                    health/trigger-backend-switch!  (fn [f t ms]
-                                                      (swap! switch-calls conj {:from f :to t :ms ms}))]
-        (sut/evaluate-stall-recovery (make-ctx :anthropic "sess-sw" 2 [:openai]))
-        (is (= 1          (count @switch-calls)))
-        (is (= :anthropic (get-in @switch-calls [0 :from])))
-        (is (= :openai    (get-in @switch-calls [0 :to])))
-        (is (= 1800000    (get-in @switch-calls [0 :ms])))))))
-
-(deftest evaluate-stall-recovery-forwards-allowed-set-to-select-best-backend
-  (testing "allowed-failover-backends is forwarded to select-best-backend as a set"
-    (let [received-allowed (atom nil)]
-      (with-redefs [health/get-backend-success-rate (fn [_b] nil)
-                    health/record-backend-call!     (fn [_b _s] nil)
-                    health/select-best-backend      (fn [_cur _thr _cool allowed]
-                                                      (reset! received-allowed allowed)
-                                                      :codex)
-                    health/trigger-backend-switch!  (fn [& _] nil)]
-        (sut/evaluate-stall-recovery (make-ctx :anthropic "sess-a" 2 [:codex :ollama]))
-        (is (= #{:codex :ollama} @received-allowed))))))
-
-(deftest evaluate-stall-recovery-uses-cooldown-from-config
+(deftest ^{:stratum 0} evaluate-stall-recovery-uses-cooldown-from-config
   (testing "custom :backend-switch-cooldown-ms from :config is forwarded"
     (let [received-cooldown (atom nil)]
       (with-redefs [health/get-backend-success-rate (fn [_b] nil)
@@ -266,32 +117,8 @@
           :allowed-failover-backends [:openai]})
         (is (= 300000 @received-cooldown))))))
 
-;;------------------------------------------------------------------------------ evaluate-stall-recovery – :abort path
-
-(deftest evaluate-stall-recovery-no-allowed-backends-returns-abort
-  (testing "hang-count>=2 with empty allowed-failover-backends → :abort"
-    (with-redefs [health/get-backend-success-rate (fn [_b] nil)
-                  health/record-backend-call!     (fn [_b _s] nil)
-                  health/select-best-backend      (fn [& _] nil)
-                  health/trigger-backend-switch!  (fn [& _] nil)]
-      (let [ctx    (make-ctx :anthropic "sess-abort" 2 [])
-            result (sut/evaluate-stall-recovery ctx)]
-        (is (= :abort  (:action result)))
-        (is (string?   (:reason result)))))))
-
-(deftest evaluate-stall-recovery-select-best-nil-returns-abort
-  (testing "hang-count>=2 but select-best-backend returns nil → :abort"
-    (with-redefs [health/get-backend-success-rate (fn [_b] nil)
-                  health/record-backend-call!     (fn [_b _s] nil)
-                  health/select-best-backend      (fn [& _] nil)
-                  health/trigger-backend-switch!  (fn [& _] nil)]
-      (let [ctx    (make-ctx :anthropic "sess-cd" 2 [:openai :codex])
-            result (sut/evaluate-stall-recovery ctx)]
-        (is (= :abort (:action result)))))))
-
 ;;------------------------------------------------------------------------------ execute-resume!
-
-(deftest execute-resume-returns-expected-shape
+(deftest ^{:stratum 0} execute-resume-returns-expected-shape
   (testing "execute-resume! returns map with :process :backend :session-id :command"
     ;; Use a plain Object as sentinel — reify does not support abstract classes.
     (let [fake-proc (Object.)]
@@ -303,7 +130,7 @@
           (is (= "sess-xyz"           (:session-id result)))
           (is (= ["claude" "--resume" "sess-xyz"] (:command result))))))))
 
-(deftest execute-resume-with-extra-args
+(deftest ^{:stratum 0} execute-resume-with-extra-args
   (testing "extra-args are appended to the command"
     (let [launched (atom nil)]
       (with-redefs [ai.miniforge.self-healing.stream-recovery/start-process!
@@ -311,7 +138,7 @@
         (sut/execute-resume! :openai "s42" ["--timeout" "120"])
         (is (= ["openai" "--resume" "s42" "--timeout" "120"] @launched))))))
 
-(deftest execute-resume-ollama-uses-continue-flag-and-binary
+(deftest ^{:stratum 0} execute-resume-ollama-uses-continue-flag-and-binary
   (testing "ollama subprocess uses --continue and 'ollama' binary"
     (let [launched (atom nil)]
       (with-redefs [ai.miniforge.self-healing.stream-recovery/start-process!
@@ -320,7 +147,7 @@
         (is (= "ollama"     (first @launched)))
         (is (= "--continue" (second @launched)))))))
 
-(deftest execute-resume-google-uses-gemini-binary
+(deftest ^{:stratum 0} execute-resume-google-uses-gemini-binary
   (testing "google subprocess uses 'gemini' binary"
     (let [launched (atom nil)]
       (with-redefs [ai.miniforge.self-healing.stream-recovery/start-process!
@@ -328,21 +155,21 @@
         (sut/execute-resume! :google "sess-g")
         (is (= "gemini" (first @launched)))))))
 
-(deftest execute-resume-coerces-string-backend
+(deftest ^{:stratum 0} execute-resume-coerces-string-backend
   (testing "string backend is coerced to keyword in result map"
     (with-redefs [ai.miniforge.self-healing.stream-recovery/start-process!
                   (fn [_cmd] nil)]
       (let [result (sut/execute-resume! "codex" "sess-s")]
         (is (= :codex (:backend result)))))))
 
-(deftest execute-resume-session-id-coerced-to-string
+(deftest ^{:stratum 0} execute-resume-session-id-coerced-to-string
   (testing "non-string session-id is coerced to string"
     (with-redefs [ai.miniforge.self-healing.stream-recovery/start-process!
                   (fn [_cmd] nil)]
       (let [result (sut/execute-resume! :anthropic :some-keyword-session)]
         (is (= ":some-keyword-session" (:session-id result)))))))
 
-(deftest execute-resume-returns-anomaly-on-ioexception
+(deftest ^{:stratum 0} execute-resume-returns-anomaly-on-ioexception
   (testing "IOException from start-process! is returned as anomaly map, not thrown"
     (with-redefs [ai.miniforge.self-healing.stream-recovery/start-process!
                   (fn [_cmd] (throw (java.io.IOException. "No such file")))]
@@ -351,9 +178,177 @@
         (is (string? (:anomaly/message result)))
         (is (vector? (:cmd result)))))))
 
-(deftest execute-resume-anomaly-cmd-matches-attempted-command
+(deftest ^{:stratum 0} execute-resume-anomaly-cmd-matches-attempted-command
   (testing "anomaly :cmd is the exact command vector that was attempted"
     (with-redefs [ai.miniforge.self-healing.stream-recovery/start-process!
                   (fn [_cmd] (throw (java.io.IOException. "not found")))]
       (let [result (sut/execute-resume! :codex "sess-fail")]
         (is (= ["codex" "--resume" "sess-fail"] (:cmd result)))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} make-ctx
+  "Build a minimal recovery context map."
+  [backend session-id hang-count-val allowed-failover]
+  {:phase-id                  :implement
+   :backend                   backend
+   :session-id                session-id
+   :hang-count                (atom hang-count-val)
+   :config                    base-config
+   :allowed-failover-backends allowed-failover})
+
+;------------------------------------------------------------------------------ Layer 2
+
+;;------------------------------------------------------------------------------ evaluate-stall-recovery – :resume path
+(deftest ^{:stratum 2} evaluate-stall-recovery-first-hang-no-health-data-returns-resume
+  (testing "hang-count=1, backend has no health data (nil rate = eligible) → :resume"
+    (with-redefs [health/get-backend-success-rate (fn [_b] nil)
+                  health/record-backend-call!     (fn [_b _s] nil)
+                  health/select-best-backend      (fn [& _] nil)
+                  health/trigger-backend-switch!  (fn [& _] nil)]
+      (let [ctx    (make-ctx :anthropic "sess-111" 1 [:openai :codex])
+            result (sut/evaluate-stall-recovery ctx)]
+        (is (= :resume    (:action result)))
+        (is (= "sess-111" (:session-id result)))
+        (is (= :anthropic (:backend result)))))))
+
+(deftest ^{:stratum 2} evaluate-stall-recovery-first-hang-healthy-rate-returns-resume
+  (testing "hang-count=1, backend success-rate >= threshold → :resume, no side effects"
+    ;; Stubs all side-effect functions and asserts they were NOT called, proving
+    ;; the resume path is side-effect-free.
+    (let [record-calls (atom [])]
+      (with-redefs [health/get-backend-success-rate (fn [_b] 0.95) ; above threshold
+                    health/record-backend-call!     (fn [b s] (swap! record-calls conj [b s]))
+                    health/select-best-backend      (fn [& _] nil)
+                    health/trigger-backend-switch!  (fn [& _] nil)]
+        (let [ctx    (make-ctx :anthropic "sess-ok" 1 [:openai])
+              result (sut/evaluate-stall-recovery ctx)]
+          (is (= :resume (:action result)))
+          (is (empty? @record-calls)
+              "resume path must not record a backend failure"))))))
+
+;;------------------------------------------------------------------------------ evaluate-stall-recovery – health gate on count=1
+(deftest ^{:stratum 2} evaluate-stall-recovery-first-hang-unhealthy-backend-skips-resume
+  (testing "hang-count=1 but backend already below threshold → :failover, not :resume"
+    (with-redefs [health/get-backend-success-rate (fn [_b] 0.50)
+                  health/record-backend-call!     (fn [_b _s] nil)
+                  health/select-best-backend      (fn [& _] :openai)
+                  health/trigger-backend-switch!  (fn [& _] nil)]
+      (let [ctx    (make-ctx :anthropic "sess-sick" 1 [:openai :codex])
+            result (sut/evaluate-stall-recovery ctx)]
+        (is (= :failover (:action result)))
+        (is (= :openai   (:new-backend result)))))))
+
+(deftest ^{:stratum 2} evaluate-stall-recovery-first-hang-unhealthy-no-candidates-aborts
+  (testing "hang-count=1, backend unhealthy, no allowed failover candidates → :abort"
+    (with-redefs [health/get-backend-success-rate (fn [_b] 0.30)
+                  health/record-backend-call!     (fn [_b _s] nil)
+                  health/select-best-backend      (fn [& _] nil)
+                  health/trigger-backend-switch!  (fn [& _] nil)]
+      (let [ctx    (make-ctx :anthropic "sess-s" 1 [])
+            result (sut/evaluate-stall-recovery ctx)]
+        (is (= :abort  (:action result)))
+        (is (string? (:reason result)))))))
+
+(deftest ^{:stratum 2} evaluate-stall-recovery-first-hang-records-failure-before-early-failover
+  (testing "health-gate path calls record-backend-call! with false"
+    (let [recorded (atom nil)]
+      (with-redefs [health/get-backend-success-rate (fn [_b] 0.50)
+                    health/record-backend-call!     (fn [b s] (reset! recorded {:b b :s s}))
+                    health/select-best-backend      (fn [& _] :openai)
+                    health/trigger-backend-switch!  (fn [& _] nil)]
+        (sut/evaluate-stall-recovery (make-ctx :anthropic "sess-r" 1 [:openai]))
+        (is (= {:b :anthropic :s false} @recorded))))))
+
+;;------------------------------------------------------------------------------ evaluate-stall-recovery – degenerate count
+(deftest ^{:stratum 2} evaluate-stall-recovery-zero-hang-count-returns-resume-with-anomaly
+  (testing "hang-count=0 (degenerate) → :resume with :anomaly? true"
+    (with-redefs [health/get-backend-success-rate (fn [_b] nil)
+                  health/record-backend-call!     (fn [_b _s] nil)
+                  health/select-best-backend      (fn [& _] nil)
+                  health/trigger-backend-switch!  (fn [& _] nil)]
+      (let [ctx    (make-ctx :openai "sess-000" 0 [:anthropic])
+            result (sut/evaluate-stall-recovery ctx)]
+        (is (= :resume (:action result)))
+        (is (true? (:anomaly? result)))))))
+
+;;------------------------------------------------------------------------------ evaluate-stall-recovery – :failover path
+(deftest ^{:stratum 2} evaluate-stall-recovery-second-hang-returns-failover
+  (testing "hang-count=2 with healthy allowed failover backend → :failover"
+    (with-redefs [health/get-backend-success-rate (fn [_b] nil)
+                  health/record-backend-call!     (fn [_b _s] nil)
+                  health/select-best-backend      (fn [& _] :openai)
+                  health/trigger-backend-switch!  (fn [& _] nil)]
+      (let [ctx    (make-ctx :anthropic "sess-222" 2 [:openai :codex])
+            result (sut/evaluate-stall-recovery ctx)]
+        (is (= :failover (:action result)))
+        (is (= :openai   (:new-backend result)))))))
+
+(deftest ^{:stratum 2} evaluate-stall-recovery-third-hang-also-failover
+  (testing "hang-count=3 also triggers :failover"
+    (with-redefs [health/get-backend-success-rate (fn [_b] nil)
+                  health/record-backend-call!     (fn [_b _s] nil)
+                  health/select-best-backend      (fn [& _] :codex)
+                  health/trigger-backend-switch!  (fn [& _] nil)]
+      (let [ctx    (make-ctx :anthropic "sess-333" 3 [:codex])
+            result (sut/evaluate-stall-recovery ctx)]
+        (is (= :failover (:action result)))
+        (is (= :codex    (:new-backend result)))))))
+
+(deftest ^{:stratum 2} evaluate-stall-recovery-records-failure-on-second-hang
+  (testing "hang-count>=2 calls record-backend-call! with success?=false"
+    (let [recorded (atom nil)]
+      (with-redefs [health/get-backend-success-rate (fn [_b] nil)
+                    health/record-backend-call!     (fn [b s] (reset! recorded {:b b :s s}))
+                    health/select-best-backend      (fn [& _] :openai)
+                    health/trigger-backend-switch!  (fn [& _] nil)]
+        (sut/evaluate-stall-recovery (make-ctx :anthropic "sess-f" 2 [:openai]))
+        (is (= {:b :anthropic :s false} @recorded))))))
+
+(deftest ^{:stratum 2} evaluate-stall-recovery-calls-trigger-switch-on-failover
+  (testing "failover path calls trigger-backend-switch! with correct args"
+    (let [switch-calls (atom [])]
+      (with-redefs [health/get-backend-success-rate (fn [_b] nil)
+                    health/record-backend-call!     (fn [_b _s] nil)
+                    health/select-best-backend      (fn [& _] :openai)
+                    health/trigger-backend-switch!  (fn [f t ms]
+                                                      (swap! switch-calls conj {:from f :to t :ms ms}))]
+        (sut/evaluate-stall-recovery (make-ctx :anthropic "sess-sw" 2 [:openai]))
+        (is (= 1          (count @switch-calls)))
+        (is (= :anthropic (get-in @switch-calls [0 :from])))
+        (is (= :openai    (get-in @switch-calls [0 :to])))
+        (is (= 1800000    (get-in @switch-calls [0 :ms])))))))
+
+(deftest ^{:stratum 2} evaluate-stall-recovery-forwards-allowed-set-to-select-best-backend
+  (testing "allowed-failover-backends is forwarded to select-best-backend as a set"
+    (let [received-allowed (atom nil)]
+      (with-redefs [health/get-backend-success-rate (fn [_b] nil)
+                    health/record-backend-call!     (fn [_b _s] nil)
+                    health/select-best-backend      (fn [_cur _thr _cool allowed]
+                                                      (reset! received-allowed allowed)
+                                                      :codex)
+                    health/trigger-backend-switch!  (fn [& _] nil)]
+        (sut/evaluate-stall-recovery (make-ctx :anthropic "sess-a" 2 [:codex :ollama]))
+        (is (= #{:codex :ollama} @received-allowed))))))
+
+;;------------------------------------------------------------------------------ evaluate-stall-recovery – :abort path
+(deftest ^{:stratum 2} evaluate-stall-recovery-no-allowed-backends-returns-abort
+  (testing "hang-count>=2 with empty allowed-failover-backends → :abort"
+    (with-redefs [health/get-backend-success-rate (fn [_b] nil)
+                  health/record-backend-call!     (fn [_b _s] nil)
+                  health/select-best-backend      (fn [& _] nil)
+                  health/trigger-backend-switch!  (fn [& _] nil)]
+      (let [ctx    (make-ctx :anthropic "sess-abort" 2 [])
+            result (sut/evaluate-stall-recovery ctx)]
+        (is (= :abort  (:action result)))
+        (is (string?   (:reason result)))))))
+
+(deftest ^{:stratum 2} evaluate-stall-recovery-select-best-nil-returns-abort
+  (testing "hang-count>=2 but select-best-backend returns nil → :abort"
+    (with-redefs [health/get-backend-success-rate (fn [_b] nil)
+                  health/record-backend-call!     (fn [_b _s] nil)
+                  health/select-best-backend      (fn [& _] nil)
+                  health/trigger-backend-switch!  (fn [& _] nil)]
+      (let [ctx    (make-ctx :anthropic "sess-cd" 2 [:openai :codex])
+            result (sut/evaluate-stall-recovery ctx)]
+        (is (= :abort (:action result)))))))

--- a/components/self-healing/test/ai/miniforge/self_healing/workaround_detector_test.clj
+++ b/components/self-healing/test/ai/miniforge/self_healing/workaround_detector_test.clj
@@ -15,40 +15,21 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.self-healing.workaround-detector-test
   (:require
    [clojure.test :refer [deftest is testing use-fixtures]]
    [clojure.java.io :as io]
    [ai.miniforge.self-healing.workaround-detector :as detector]))
 
-;;------------------------------------------------------------------------------ Test fixtures
+;------------------------------------------------------------------------------ Layer 0
 
-(def test-approval-file
+;;------------------------------------------------------------------------------ Test fixtures
+(def ^{:stratum 0} test-approval-file
   "Test file path for approval tracking"
   (str (System/getProperty "java.io.tmpdir") "/test_workaround_approvals.edn"))
 
-(defn cleanup-test-files
-  "Delete test approval file"
-  []
-  (when (.exists (io/file test-approval-file))
-    (.delete (io/file test-approval-file))))
-
-(defn with-test-approval-file
-  "Fixture to use test approval file and clean up after"
-  [f]
-  (with-redefs [detector/approval-file-path (constantly test-approval-file)]
-    (cleanup-test-files)
-    (try
-      (f)
-      (finally
-        (cleanup-test-files)))))
-
-(use-fixtures :each with-test-approval-file)
-
 ;;------------------------------------------------------------------------------ Tests
-
-(deftest test-match-error-to-workaround
+(deftest ^{:stratum 0} test-match-error-to-workaround
   (testing "Match error message to workaround pattern"
     ;; This test depends on error patterns being loaded from resources
     ;; For now, test with a generic error that should match backend setup patterns
@@ -58,21 +39,21 @@
       ;; Just verify the function returns correctly
       (is (or (nil? pattern) (map? pattern))))))
 
-(deftest test-match-error-from-exception
+(deftest ^{:stratum 0} test-match-error-from-exception
   (testing "Match error from exception object"
     (let [ex (Exception. "Test error")
           result (detector/match-error-to-workaround ex)]
       ;; Should handle exception without crashing
       (is (or (nil? result) (map? result))))))
 
-(deftest test-match-error-from-map
+(deftest ^{:stratum 0} test-match-error-from-map
   (testing "Match error from map with :message key"
     (let [error-map {:message "Test error message"}
           result (detector/match-error-to-workaround error-map)]
       ;; Should handle map without crashing
       (is (or (nil? result) (map? result))))))
 
-(deftest test-detect-and-apply-no-match
+(deftest ^{:stratum 0} test-detect-and-apply-no-match
   (testing "Detect and apply when no pattern matches"
     (let [error "This is a completely unique error message that should not match anything at all"
           result (detector/detect-and-apply-workaround error)]
@@ -80,7 +61,7 @@
       (is (false? (:applied? result)))
       (is (false? (:success? result))))))
 
-(deftest test-apply-workaround-backend-switch
+(deftest ^{:stratum 0} test-apply-workaround-backend-switch
   (testing "Apply backend switch workaround"
     (let [pattern {:id :test-pattern
                    :description "Test backend switch"
@@ -92,7 +73,7 @@
       (is (true? (:success? result)))
       (is (= :openai (:to-backend result))))))
 
-(deftest test-apply-workaround-env-var
+(deftest ^{:stratum 0} test-apply-workaround-env-var
   (testing "Apply environment variable workaround"
     (let [pattern {:id :test-pattern
                    :description "Test env var"
@@ -105,7 +86,7 @@
       (is (string? (:message result)))
       (is (string? (:suggestion result))))))
 
-(deftest test-workaround-requires-prompt-no-fn
+(deftest ^{:stratum 0} test-workaround-requires-prompt-no-fn
   (testing "Workaround requiring prompt but no prompt function provided"
     (let [pattern {:id :test-pattern
                    :description "Test sudo operation"
@@ -118,7 +99,7 @@
       (is (false? (:success? result)))
       (is (true? (:requires-prompt result))))))
 
-(deftest test-workaround-with-prompt-approved
+(deftest ^{:stratum 0} test-workaround-with-prompt-approved
   (testing "Workaround with prompt function - user approves"
     (let [pattern {:id :test-pattern
                    :description "Test with approval"
@@ -131,7 +112,7 @@
       (is (true? (:applied? result)))
       (is (true? (:success? result))))))
 
-(deftest test-workaround-with-prompt-denied
+(deftest ^{:stratum 0} test-workaround-with-prompt-denied
   (testing "Workaround with prompt function - user denies"
     (let [pattern {:id :test-pattern
                    :description "Test with denial"
@@ -144,7 +125,7 @@
       (is (false? (:applied? result)))
       (is (false? (:success? result))))))
 
-(deftest test-workaround-auto-apply-no-sudo
+(deftest ^{:stratum 0} test-workaround-auto-apply-no-sudo
   (testing "Workaround with auto-apply and no sudo requirement"
     (let [pattern {:id :test-auto-apply
                    :description "Test auto apply"
@@ -156,7 +137,7 @@
       (is (true? (:applied? result)))
       (is (true? (:success? result))))))
 
-(deftest test-detect-and-apply-full-flow
+(deftest ^{:stratum 0} test-detect-and-apply-full-flow
   (testing "Full detect and apply flow"
     ;; Create a mock pattern that will match
     (with-redefs [detector/workaround-patterns
@@ -173,7 +154,7 @@
         (is (true? (:success? result)))
         (is (some? (:pattern result)))))))
 
-(deftest test-unknown-workaround-type
+(deftest ^{:stratum 0} test-unknown-workaround-type
   (testing "Unknown workaround type"
     (let [pattern {:id :test-unknown
                    :description "Test unknown type"
@@ -183,3 +164,25 @@
       (is (true? (:applied? result)))
       (is (false? (:success? result)))
       (is (re-find #"Unknown workaround type" (:message result))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} cleanup-test-files
+  "Delete test approval file"
+  []
+  (when (.exists (io/file test-approval-file))
+    (.delete (io/file test-approval-file))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} with-test-approval-file
+  "Fixture to use test approval file and clean up after"
+  [f]
+  (with-redefs [detector/approval-file-path (constantly test-approval-file)]
+    (cleanup-test-files)
+    (try
+      (f)
+      (finally
+        (cleanup-test-files)))))
+
+(use-fixtures :each with-test-approval-file)

--- a/components/self-healing/test/ai/miniforge/self_healing/workaround_registry_test.clj
+++ b/components/self-healing/test/ai/miniforge/self_healing/workaround_registry_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.self-healing.workaround-registry-test
   "Unit tests for workaround registry."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
@@ -23,35 +22,20 @@
             [ai.miniforge.config.interface :as config]
             [ai.miniforge.self-healing.workaround-registry :as registry]))
 
-;;------------------------------------------------------------------------------ Test fixtures
+;------------------------------------------------------------------------------ Layer 0
 
-(def test-registry-path
+;;------------------------------------------------------------------------------ Test fixtures
+(def ^{:stratum 0} test-registry-path
   (str (config/miniforge-home) "/test_workarounds.edn"))
 
-(defn cleanup-test-registry
-  [f]
-  (with-redefs [registry/workaround-registry-path (constantly test-registry-path)]
-    (try
-      ;; Clean before test to ensure isolation
-      (when (.exists (io/file test-registry-path))
-        (.delete (io/file test-registry-path)))
-      (f)
-      (finally
-        (when (.exists (io/file test-registry-path))
-          (.delete (io/file test-registry-path)))))))
-
-(use-fixtures :each cleanup-test-registry)
-
-;;------------------------------------------------------------------------------ Layer 0 Tests
 ;; Basic load/save operations
-
-(deftest test-load-workarounds-empty
+(deftest ^{:stratum 0} test-load-workarounds-empty
   (testing "Load workarounds from non-existent file returns empty registry"
     (let [result (registry/load-workarounds)]
       (is (map? result))
       (is (= [] (:workarounds result))))))
 
-(deftest test-save-and-load-roundtrip
+(deftest ^{:stratum 0} test-save-and-load-roundtrip
   (testing "Save and load workarounds roundtrip"
     (let [data {:workarounds [{:id (java.util.UUID/randomUUID)
                                :error-pattern-id :test-pattern
@@ -66,10 +50,8 @@
         (is (= 1 (count (:workarounds loaded))))
         (is (= :test-pattern (-> loaded :workarounds first :error-pattern-id)))))))
 
-;;------------------------------------------------------------------------------ Layer 1 Tests
 ;; Add workaround
-
-(deftest test-add-workaround
+(deftest ^{:stratum 0} test-add-workaround
   (testing "Add workaround generates ID and timestamps"
     (let [workaround {:error-pattern-id :anthropic-rate-limit
                       :description "Retry with exponential backoff"
@@ -85,7 +67,7 @@
       (is (some? (:discovered-at result)))
       (is (nil? (:last-used result))))))
 
-(deftest test-add-workaround-with-id
+(deftest ^{:stratum 0} test-add-workaround-with-id
   (testing "Add workaround preserves provided ID"
     (let [id (java.util.UUID/randomUUID)
           workaround {:id id
@@ -96,10 +78,8 @@
           result (registry/add-workaround! workaround)]
       (is (= id (:id result))))))
 
-;;------------------------------------------------------------------------------ Layer 2 Tests
 ;; Update statistics
-
-(deftest test-update-workaround-stats-success
+(deftest ^{:stratum 0} test-update-workaround-stats-success
   (testing "Update workaround stats on success"
     (let [workaround (registry/add-workaround!
                       {:error-pattern-id :test-pattern
@@ -113,7 +93,7 @@
       (is (= 1.0 (:confidence updated)))
       (is (some? (:last-used updated))))))
 
-(deftest test-update-workaround-stats-failure
+(deftest ^{:stratum 0} test-update-workaround-stats-failure
   (testing "Update workaround stats on failure"
     (let [workaround (registry/add-workaround!
                       {:error-pattern-id :test-pattern
@@ -126,7 +106,7 @@
       (is (= 1 (:failure-count updated)))
       (is (= 0.0 (:confidence updated))))))
 
-(deftest test-update-workaround-stats-confidence
+(deftest ^{:stratum 0} test-update-workaround-stats-confidence
   (testing "Update workaround stats calculates confidence correctly"
     (let [workaround (registry/add-workaround!
                       {:error-pattern-id :test-pattern
@@ -144,15 +124,13 @@
         (is (= 1 (:failure-count updated)))
         (is (= 0.75 (:confidence updated)))))))
 
-(deftest test-update-workaround-stats-not-found
+(deftest ^{:stratum 0} test-update-workaround-stats-not-found
   (testing "Update workaround stats returns nil for non-existent ID"
     (let [result (registry/update-workaround-stats! (java.util.UUID/randomUUID) true)]
       (is (nil? result)))))
 
-;;------------------------------------------------------------------------------ Layer 3 Tests
 ;; Query operations
-
-(deftest test-get-workaround-by-pattern
+(deftest ^{:stratum 0} test-get-workaround-by-pattern
   (testing "Get workaround by pattern ID"
     (registry/add-workaround!
      {:error-pattern-id :pattern-1
@@ -169,12 +147,12 @@
       (is (= :pattern-1 (:error-pattern-id result)))
       (is (= "Test 1" (:description result))))))
 
-(deftest test-get-workaround-by-pattern-not-found
+(deftest ^{:stratum 0} test-get-workaround-by-pattern-not-found
   (testing "Get workaround by pattern returns nil for non-existent pattern"
     (let [result (registry/get-workaround-by-pattern :non-existent)]
       (is (nil? result)))))
 
-(deftest test-get-high-confidence-workarounds
+(deftest ^{:stratum 0} test-get-high-confidence-workarounds
   (testing "Get high-confidence workarounds filters by confidence >= 0.8"
     (let [wa1 (registry/add-workaround!
                {:error-pattern-id :high-conf
@@ -200,7 +178,7 @@
         (is (= 1 (count high-conf)))
         (is (= :high-conf (-> high-conf first :error-pattern-id)))))))
 
-(deftest test-get-all-workarounds
+(deftest ^{:stratum 0} test-get-all-workarounds
   (testing "Get all workarounds returns complete list"
     (registry/add-workaround!
      {:error-pattern-id :pattern-1
@@ -215,7 +193,7 @@
     (let [all (registry/get-all-workarounds)]
       (is (= 2 (count all))))))
 
-(deftest test-delete-workaround
+(deftest ^{:stratum 0} test-delete-workaround
   (testing "Delete workaround removes it from registry"
     (let [workaround (registry/add-workaround!
                       {:error-pattern-id :to-delete
@@ -227,7 +205,23 @@
       (is (true? deleted?))
       (is (nil? (registry/get-workaround-by-pattern :to-delete))))))
 
-(deftest test-delete-workaround-not-found
+(deftest ^{:stratum 0} test-delete-workaround-not-found
   (testing "Delete non-existent workaround returns nil"
     (let [result (registry/delete-workaround! (java.util.UUID/randomUUID))]
       (is (nil? result)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} cleanup-test-registry
+  [f]
+  (with-redefs [registry/workaround-registry-path (constantly test-registry-path)]
+    (try
+      ;; Clean before test to ensure isolation
+      (when (.exists (io/file test-registry-path))
+        (.delete (io/file test-registry-path)))
+      (f)
+      (finally
+        (when (.exists (io/file test-registry-path))
+          (.delete (io/file test-registry-path)))))))
+
+(use-fixtures :each cleanup-test-registry)

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-self-healing.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-self-healing.md
@@ -1,0 +1,140 @@
+# fix: stratum-lint autofix for components/self-healing (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over `components/self-healing` (`src` + `test`)
+to replace decorative `Layer N` banners and missing headings with real
+`Layer N` headings and `^{:stratum n}` metadata derived from each file's
+actual same-file reference graph. Mechanical: no logic changes. Also
+hand-fixes four stale `;;---- Layer N Tests` banners that `--fix` left
+behind in one test file, still claiming layer numbers that no longer
+match the recomputed real stratum (see Changes in Detail) — a
+comment-only correction, not a behavior change. One of the Wave 1 batch 4
+per-component PRs from `work/stratum-lint-baseline-2026-07-24.md`.
+
+## Motivation
+
+Plain (non-`--fix`) `stratum-lint` on `components/self-healing` reported
+only `SL003` (over the 3-layer budget), zero `SL001`/`SL002`/`SL004`:
+
+```text
+backend_health.clj:378:1: SL003 file uses 4 distinct layers (max 3)
+integration.clj:198:1: SL003 file uses 4 distinct layers (max 3)
+stream_recovery.clj:306:1: SL003 file uses 5 distinct layers (max 3)
+workaround_detector.clj:327:1: SL003 file uses 6 distinct layers (max 3)
+```
+
+Zero `SL001`, confirming this component carries no upward-reference/cycle
+risk requiring human triage before running the mechanical fixer.
+`interface.clj` and `workaround_registry.clj` reported no findings at all
+pre-fix, but both used the cargo-cult pattern the baseline describes:
+`interface.clj` grouped its re-exports under double-semicolon named-section
+banners (`Workaround Registry`, `Backend Health`, etc.) with no real
+`Layer N` heading anywhere, and `workaround_registry.clj` had only two
+distinct heading values — both invisible to the checker under the
+documented "no heading = silently skipped" limitation, not a clean bill of
+health.
+
+## Changes in Detail
+
+Ran, over the whole component:
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "14965e1ee1a175bd00f637d9a9d5f7d27e62b73f" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/self-healing
+```
+
+All 10 `.clj` files in the component were rewritten (6 `src`, 4 `test`).
+Diffs are heading text, `^{:stratum n}` metadata, and def/deftest
+reordering only — no executable line changed. Two examples of the
+cargo-cult diagnosis confirmed here:
+
+- `workaround_detector.clj`'s `fetch-workaround-from-github` sat under an
+  old decorative "Layer 5" banner ("GitHub issue integration") purely
+  because it was written last. It has zero same-file references, so
+  `--fix` correctly placed it at real Layer 0, alongside the file's other
+  self-contained helpers.
+- `workaround_registry_test.clj` had old double-semicolon banners reading
+  "Layer 0 Tests" / "Layer 1 Tests" / "Layer 2 Tests" / "Layer 3 Tests"
+  before each `deftest` group. None of those tests reference each other or
+  any same-file helper beyond `test-registry-path` (real stratum 0), so
+  every one of them landed at real Layer 0 — the old banners' numbers
+  (1, 2, 3) no longer matched anything and sat confusingly between the
+  file's real Layer 0 and Layer 1 headings. Hand-fixed: dropped the
+  `Layer N Tests` claim from all four, keeping each still-accurate
+  description (`Basic load/save operations`, `Add workaround`, `Update
+  statistics`, `Query operations`) as a plain comment. Re-ran `--fix`
+  afterward — zero diff, confirms the manual edit didn't interact with
+  stratum computation (comments aren't part of the reference graph).
+
+No same-line trailing comment was displaced onto the wrong def — grepped
+the diff for the known `foo])  ; comment` migration pattern; no matches.
+One pre-existing oddity survives unchanged in `stream_recovery.clj`: a
+`;; => [...]` illustrative-output comment after the file's `(comment ...)`
+block was already outside that form before the fix (the form closes one
+line earlier); `--fix` only dedented it. Not a func­tional change and not
+attached to any def.
+
+## Testing Plan
+
+1. Ran plain `stratum-lint` before the fix — reproduced the four `SL003`
+   findings above exactly, zero `SL001`/`SL002`/`SL004`.
+2. Ran `--fix`, then a second `--fix` pass immediately after — zero diff,
+   confirms idempotency.
+3. Read the full diff for all 10 changed files. Confirmed only heading
+   text, `^{:stratum n}` metadata, and def/deftest reordering changed.
+   Found and hand-fixed the four stale `Layer N Tests` banners described
+   above; re-ran `--fix` a third time afterward — zero diff, confirming
+   stability.
+4. `clj-kondo --lint components/self-healing`: 0 errors, 0 warnings.
+5. Ran the full component test suite (`clojure -M:test -m
+   cognitect.test-runner` from `components/self-healing`): 64 tests, 123
+   assertions, 0 failures, 0 errors.
+6. Re-ran plain `stratum-lint` after the fix. `SL001`/`SL002`/`SL004`
+   clear. `SL003` remains on four files, with real layer counts now
+   precisely measured from the true reference graph instead of the old
+   decorative headings:
+   - `backend_health.clj`: 4 → **7** real layers (old headings
+     under-counted — several distinct strata had been merged under the
+     same heading number). Same underlying over-budget finding, count
+     increased because the old count was wrong.
+   - `stream_recovery.clj`: 5 → **4** real layers (old headings had one
+     extra, unneeded split). Same finding, count decreased.
+   - `workaround_detector.clj`: 6 → **5** real layers (same pattern, one
+     fewer than the old headings claimed).
+   - `workaround_registry.clj`: **new** finding — 0 pre-fix (the old
+     headings had only 2 distinct values, coincidentally under budget);
+     true depth is 4 real layers, surfaced only once `--fix` recomputed
+     from the actual reference graph.
+   - `integration.clj`: **resolved** — old headings claimed 4 layers, true
+     depth is 3, within budget. No longer reported.
+
+   All four remaining `SL003` findings are real over-budget files (Wave 2
+   scope: namespace split), not addressed here.
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+change — comment/metadata/order-only. Pre-commit's `lint:stratum`
+autofixer keeps this component clean going forward; the four `SL003`
+files stay advisory (`MINIFORGE_STRATUM_BUDGET_MODE=warn` at commit time)
+until Wave 2 splits them.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+- Follow-on: Wave 2 namespace splits for `backend_health.clj` (7 real
+  layers), `stream_recovery.clj` (4), `workaround_detector.clj` (5), and
+  `workaround_registry.clj` (4) — all over the 3-layer budget.
+
+## Checklist
+
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Second `--fix` pass confirms idempotency (zero diff)
+- [x] Diff read in full for all 10 changed files; mechanical-only
+- [x] Stale `Layer N Tests` banners in `workaround_registry_test.clj`
+      hand-fixed (comment-only); third `--fix` pass confirms stability
+- [x] `clj-kondo` clean (0 errors, 0 warnings)
+- [x] Component tests pass (64 tests, 123 assertions, 0 failures/errors)
+- [x] Plain lint re-run post-fix: `SL003` remains on 4 files, documented
+      above with precise before/after counts, tracked as Wave 2
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-self-healing.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-self-healing.md
@@ -68,11 +68,13 @@ cargo-cult diagnosis confirmed here:
 
 No same-line trailing comment was displaced onto the wrong def — grepped
 the diff for the known `foo])  ; comment` migration pattern; no matches.
-One pre-existing oddity survives unchanged in `stream_recovery.clj`: a
-`;; => [...]` illustrative-output comment after the file's `(comment ...)`
-block was already outside that form before the fix (the form closes one
-line earlier); `--fix` only dedented it. Not a functional change and not
-attached to any def.
+One pre-existing oddity caught by review in `stream_recovery.clj`: a
+`;; => [...]` illustrative-output comment sat after the file's
+`(comment ...)` block's closing paren instead of inside it (the form
+closed one line earlier than the comment); `--fix` only dedented it,
+didn't relocate it. Hand-fixed by moving the `=>` line inside the form,
+matching every other example in the same block. Not a functional
+change and not attached to any def.
 
 ## Testing Plan
 

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-self-healing.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-self-healing.md
@@ -71,7 +71,7 @@ the diff for the known `foo])  ; comment` migration pattern; no matches.
 One pre-existing oddity survives unchanged in `stream_recovery.clj`: a
 `;; => [...]` illustrative-output comment after the file's `(comment ...)`
 block was already outside that form before the fix (the form closes one
-line earlier); `--fix` only dedented it. Not a func­tional change and not
+line earlier); `--fix` only dedented it. Not a functional change and not
 attached to any def.
 
 ## Testing Plan


### PR DESCRIPTION
## Summary

- Runs `stratum-lint --fix` over `components/self-healing` (`src` + `test`) to replace decorative `Layer N` banners / missing headings with real headings and `^{:stratum n}` metadata derived from each file's actual same-file reference graph. Comment/metadata/reorder only — no logic changes.
- Hand-fixes four stale `;;---- Layer N Tests` banners in `workaround_registry_test.clj` whose claimed layer numbers no longer matched the recomputed real stratum (all four groups landed at real Layer 0).
- Four files remain over the 3-layer `SL003` budget post-fix (`backend_health`, `stream_recovery`, `workaround_detector`, `workaround_registry`) — real over-budget files needing a namespace split, deferred to Wave 2.

Full details, before/after layer counts, and diagnosis: `docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-self-healing.md`.

Batch 4 of Wave 1, per `work/stratum-lint-baseline-2026-07-24.md`.

## Test plan

- [x] Plain `stratum-lint` before fix reproduced the 4 baseline `SL003` findings, zero `SL001`/`SL002`/`SL004`
- [x] `--fix` run, then a second `--fix` pass immediately after: zero diff (idempotent)
- [x] Full diff read for all 10 changed files; hand-fixed 4 stale banner comments; third `--fix` pass after: zero diff
- [x] `clj-kondo --lint components/self-healing`: 0 errors, 0 warnings
- [x] `clojure -M:test -m cognitect.test-runner`: 64 tests, 123 assertions, 0 failures, 0 errors
- [x] Plain lint re-run post-fix: `SL003` remains on 4 files (documented, Wave 2 scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)