### PR TITLE
fix: stratum-lint autofix for components/control-plane (Wave 1)

### DIFF
--- a/components/control-plane/src/ai/miniforge/control_plane/decision_queue.clj
+++ b/components/control-plane/src/ai/miniforge/control_plane/decision_queue.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.control-plane.decision-queue
   "Priority-ranked decision queue for the control plane.
 
@@ -24,27 +23,18 @@
    then by age (oldest first), with agents in :blocked state
    receiving a boost.
 
-   Built on the approval.clj pattern: atom-backed store with CRUD.
-
-   Layer 0: Decision creation
-   Layer 1: Decision resolution and status
-   Layer 2: Queue manager (atom-backed store)
-   Layer 3: Priority sorting and queries"
+   Built on the approval.clj pattern: atom-backed store with CRUD."
   (:require
    [ai.miniforge.decision.interface :as decision]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Decision creation
 
-(def ^:const priority-order
+;; Decision creation
+(def ^{:stratum 0} ^:const priority-order
   "Priority ranking — lower index = higher priority."
   [:critical :high :medium :low])
 
-(def ^:private priority-rank
-  "Map of priority keyword to numeric rank."
-  (zipmap priority-order (range)))
-
-(defn create-decision
+(defn ^{:stratum 0} create-decision
   "Create a new decision request.
 
    Arguments:
@@ -87,20 +77,18 @@
       (:deadline opts) (assoc :decision/deadline (:deadline opts))
       (:tags opts)     (assoc :decision/tags (set (:tags opts))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Decision resolution and status
-
-(defn pending?
+(defn ^{:stratum 0} pending?
   "Check if a decision is still pending."
   [decision]
   (= :pending (:decision/status decision)))
 
-(defn resolved?
+(defn ^{:stratum 0} resolved?
   "Check if a decision has been resolved."
   [decision]
   (= :resolved (:decision/status decision)))
 
-(defn- resolved-decision-record
+(defn- ^{:stratum 0} resolved-decision-record
   [decision resolution comment checkpoint episode]
   (cond-> (assoc decision
                  :decision/status :resolved
@@ -110,7 +98,74 @@
                  :decision/episode episode)
     (some? comment) (assoc :decision/comment comment)))
 
-(defn expired?
+(defn ^{:stratum 0} expire-decision
+  "Mark a decision as expired."
+  [decision]
+  (assoc decision :decision/status :expired))
+
+;; Queue manager (atom-backed store)
+(defn ^{:stratum 0} create-decision-manager
+  "Create a new decision manager.
+
+   Returns: Atom containing {:decisions {}}.
+
+   Example:
+     (def mgr (create-decision-manager))"
+  []
+  (atom {:decisions {}}))
+
+(defn ^{:stratum 0} submit-decision!
+  "Submit a new decision to the queue.
+
+   Arguments:
+   - manager  - Decision manager atom
+   - decision - Decision record (from create-decision)
+
+   Returns: The submitted decision."
+  [manager decision]
+  (swap! manager assoc-in [:decisions (:decision/id decision)] decision)
+  decision)
+
+(defn ^{:stratum 0} cancel-decision!
+  "Cancel a pending decision.
+
+   Returns: Updated decision, or nil if not found."
+  [manager decision-id]
+  (let [result (atom nil)]
+    (swap! manager
+           (fn [state]
+             (if-let [decision (get-in state [:decisions decision-id])]
+               (let [cancelled (assoc decision :decision/status :cancelled)]
+                 (reset! result cancelled)
+                 (assoc-in state [:decisions decision-id] cancelled))
+               (do (reset! result nil) state))))
+    @result))
+
+(defn ^{:stratum 0} get-decision
+  "Get a decision by ID."
+  [manager decision-id]
+  (get-in @manager [:decisions decision-id]))
+
+(defn ^{:stratum 0} decisions-for-agent
+  "Get all decisions for a specific agent.
+
+   Options:
+   - :status - Filter by decision status (:pending, :resolved, :expired)
+
+   Returns: Seq of decision records."
+  [manager agent-id & [opts]]
+  (let [decisions (vals (:decisions @manager))]
+    (cond->> decisions
+      true           (filter #(= agent-id (:decision/agent-id %)))
+      (:status opts) (filter #(= (:status opts) (:decision/status %))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} ^:private priority-rank
+  "Map of priority keyword to numeric rank."
+  (zipmap priority-order (range)))
+
+(defn ^{:stratum 1} expired?
   "Check if a decision has expired past its deadline."
   [decision]
   (or (= :expired (:decision/status decision))
@@ -118,7 +173,7 @@
         (and (pending? decision)
              (.after (java.util.Date.) deadline)))))
 
-(defn resolve-decision
+(defn ^{:stratum 1} resolve-decision
   "Resolve a decision with the human's choice.
 
    Arguments:
@@ -135,37 +190,35 @@
         episode (decision/update-episode (:decision/episode decision) checkpoint)]
     (resolved-decision-record decision resolution comment checkpoint episode)))
 
-(defn expire-decision
-  "Mark a decision as expired."
-  [decision]
-  (assoc decision :decision/status :expired))
+(defn ^{:stratum 1} expire-stale-decisions!
+  "Expire all decisions past their deadline.
+
+   Returns: Seq of expired decision IDs."
+  [manager]
+  (let [now (java.util.Date.)
+        expired-ids (atom [])]
+    (swap! manager
+           (fn [state]
+             (reduce-kv
+              (fn [s id decision]
+                (if (and (pending? decision)
+                         (:decision/deadline decision)
+                         (.after now (:decision/deadline decision)))
+                  (do (swap! expired-ids conj id)
+                      (assoc-in s [:decisions id] (expire-decision decision)))
+                  s))
+              state
+              (:decisions state))))
+    @expired-ids))
+
+(defn ^{:stratum 1} count-pending
+  "Count the number of pending decisions."
+  [manager]
+  (count (filter pending? (vals (:decisions @manager)))))
 
 ;------------------------------------------------------------------------------ Layer 2
-;; Queue manager (atom-backed store)
 
-(defn create-decision-manager
-  "Create a new decision manager.
-
-   Returns: Atom containing {:decisions {}}.
-
-   Example:
-     (def mgr (create-decision-manager))"
-  []
-  (atom {:decisions {}}))
-
-(defn submit-decision!
-  "Submit a new decision to the queue.
-
-   Arguments:
-   - manager  - Decision manager atom
-   - decision - Decision record (from create-decision)
-
-   Returns: The submitted decision."
-  [manager decision]
-  (swap! manager assoc-in [:decisions (:decision/id decision)] decision)
-  decision)
-
-(defn resolve-decision!
+(defn ^{:stratum 2} resolve-decision!
   "Resolve a pending decision in the queue.
 
    Arguments:
@@ -188,51 +241,8 @@
                (do (reset! result nil) state))))
     @result))
 
-(defn cancel-decision!
-  "Cancel a pending decision.
-
-   Returns: Updated decision, or nil if not found."
-  [manager decision-id]
-  (let [result (atom nil)]
-    (swap! manager
-           (fn [state]
-             (if-let [decision (get-in state [:decisions decision-id])]
-               (let [cancelled (assoc decision :decision/status :cancelled)]
-                 (reset! result cancelled)
-                 (assoc-in state [:decisions decision-id] cancelled))
-               (do (reset! result nil) state))))
-    @result))
-
-(defn get-decision
-  "Get a decision by ID."
-  [manager decision-id]
-  (get-in @manager [:decisions decision-id]))
-
-(defn expire-stale-decisions!
-  "Expire all decisions past their deadline.
-
-   Returns: Seq of expired decision IDs."
-  [manager]
-  (let [now (java.util.Date.)
-        expired-ids (atom [])]
-    (swap! manager
-           (fn [state]
-             (reduce-kv
-              (fn [s id decision]
-                (if (and (pending? decision)
-                         (:decision/deadline decision)
-                         (.after now (:decision/deadline decision)))
-                  (do (swap! expired-ids conj id)
-                      (assoc-in s [:decisions id] (expire-decision decision)))
-                  s))
-              state
-              (:decisions state))))
-    @expired-ids))
-
-;------------------------------------------------------------------------------ Layer 3
 ;; Priority sorting and queries
-
-(defn- decision-sort-key
+(defn- ^{:stratum 2} decision-sort-key
   "Compute sort key for priority ordering.
    Lower values = higher priority."
   [decision blocked-agent-ids]
@@ -243,7 +253,9 @@
         effective-priority (+ base-priority blocked-boost)]
     [effective-priority (.getTime (:decision/created-at decision))]))
 
-(defn pending-decisions
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} pending-decisions
   "Get all pending decisions, sorted by priority.
 
    Arguments:
@@ -256,24 +268,6 @@
     (->> (vals (:decisions @manager))
          (filter pending?)
          (sort-by #(decision-sort-key % blocked)))))
-
-(defn decisions-for-agent
-  "Get all decisions for a specific agent.
-
-   Options:
-   - :status - Filter by decision status (:pending, :resolved, :expired)
-
-   Returns: Seq of decision records."
-  [manager agent-id & [opts]]
-  (let [decisions (vals (:decisions @manager))]
-    (cond->> decisions
-      true           (filter #(= agent-id (:decision/agent-id %)))
-      (:status opts) (filter #(= (:status opts) (:decision/status %))))))
-
-(defn count-pending
-  "Count the number of pending decisions."
-  [manager]
-  (count (filter pending? (vals (:decisions @manager)))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/control-plane/src/ai/miniforge/control_plane/heartbeat.clj
+++ b/components/control-plane/src/ai/miniforge/control_plane/heartbeat.clj
@@ -15,32 +15,39 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.control-plane.heartbeat
   "Heartbeat watchdog for the control plane.
 
    Runs a background thread that periodically checks all registered
    agents for missed heartbeats. When an agent misses 3 consecutive
-   heartbeat intervals, it transitions to :unreachable.
-
-   Layer 0: Timeout detection
-   Layer 1: Watchdog thread lifecycle"
+   heartbeat intervals, it transitions to :unreachable."
   (:require
    [ai.miniforge.control-plane.registry :as registry]
    [ai.miniforge.control-plane.state-machine :as sm]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Timeout detection
 
-(def ^:const missed-heartbeat-multiplier
+;; Timeout detection
+(def ^{:stratum 0} ^:const missed-heartbeat-multiplier
   "Number of missed intervals before marking unreachable."
   3)
 
-(def ^:const default-check-interval-ms
+(def ^{:stratum 0} ^:const default-check-interval-ms
   "How often the watchdog checks for stale agents."
   10000)
 
-(defn heartbeat-stale?
+(defn ^{:stratum 0} stop-watchdog
+  "Stop a running heartbeat watchdog.
+
+   Arguments:
+   - watchdog - Map returned by start-watchdog."
+  [watchdog]
+  (when-let [stop (:stop-fn watchdog)]
+    (stop)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} heartbeat-stale?
   "Check if an agent's heartbeat is stale (missed too many intervals).
 
    Arguments:
@@ -55,7 +62,9 @@
     (when last-hb
       (> (- (.getTime now) (.getTime last-hb)) threshold))))
 
-(defn check-stale-agents
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} check-stale-agents
   "Check all agents for missed heartbeats and transition stale ones.
 
    Arguments:
@@ -80,10 +89,10 @@
      []
      non-terminal)))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Watchdog thread lifecycle
+;------------------------------------------------------------------------------ Layer 3
 
-(defn start-watchdog
+;; Watchdog thread lifecycle
+(defn ^{:stratum 3} start-watchdog
   "Start the heartbeat watchdog background thread.
 
    Arguments:
@@ -114,15 +123,6 @@
      :stop-fn (fn []
                 (reset! running false)
                 (future-cancel fut))}))
-
-(defn stop-watchdog
-  "Stop a running heartbeat watchdog.
-
-   Arguments:
-   - watchdog - Map returned by start-watchdog."
-  [watchdog]
-  (when-let [stop (:stop-fn watchdog)]
-    (stop)))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/control-plane/src/ai/miniforge/control_plane/interface.clj
+++ b/components/control-plane/src/ai/miniforge/control_plane/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.control-plane.interface
   "Public API for the control plane component.
 
@@ -24,11 +23,10 @@
    requests as a priority queue, and delivers human decisions back
    to agents.
 
-   Layer 0: State machine (profile loading, transition validation)
-   Layer 1: Agent registry (CRUD, heartbeat, state transitions)
-   Layer 2: Decision queue (submit, resolve, priority sorting)
-   Layer 3: Heartbeat watchdog (background liveness monitoring)
-   Layer 4: Orchestrator (adapter coordination, full lifecycle)"
+   A flat re-export facade over state machine, agent registry,
+   decision queue, heartbeat watchdog, and orchestrator — each def
+   just aliases a var from its own component namespace, so there
+   are no same-file dependencies among them."
   (:require
    [ai.miniforge.control-plane.messages :as messages]
    [ai.miniforge.control-plane.state-machine :as sm]
@@ -38,177 +36,167 @@
    [ai.miniforge.control-plane.orchestrator :as orch]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Messages
 
-(def t
+;; Messages
+(def ^{:stratum 0} t
   "Look up a control-plane message by key, with optional param substitution."
   messages/t)
 
-;------------------------------------------------------------------------------ Layer 0
 ;; State machine
-
-(def load-profile
+(def ^{:stratum 0} load-profile
   "Load the control-plane state profile from classpath.
    Returns: State profile map."
   sm/load-profile)
 
-(def get-profile
+(def ^{:stratum 0} get-profile
   "Get the cached control-plane state profile."
   sm/get-profile)
 
-(def valid-transition?
+(def ^{:stratum 0} valid-transition?
   "Check if a state transition is valid.
    (valid-transition? profile :running :blocked) ;=> true"
   sm/valid-transition?)
 
-(def validate-transition-result
+(def ^{:stratum 0} validate-transition-result
   "Validate a state transition. Returns nil on success or an anomaly on invalid."
   sm/validate-transition-result)
 
-(def terminal?
+(def ^{:stratum 0} terminal?
   "Check if a status is terminal.
    (terminal? profile :completed) ;=> true"
   sm/terminal?)
 
-(def event->transition
+(def ^{:stratum 0} event->transition
   "Map an event type to its configured transition."
   sm/event->transition)
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Agent registry
-
-(def create-registry
+(def ^{:stratum 0} create-registry
   "Create a new agent registry.
    Returns: Atom containing agent store."
   registry/create-registry)
 
-(def register-agent!
+(def ^{:stratum 0} register-agent!
   "Register a new agent with the control plane.
    Returns: Complete agent record with :agent/id assigned."
   registry/register-agent!)
 
-(def deregister-agent!
+(def ^{:stratum 0} deregister-agent!
   "Remove an agent from the registry.
    Returns: The removed agent record."
   registry/deregister-agent!)
 
-(def update-agent!
+(def ^{:stratum 0} update-agent!
   "Update fields on an existing agent record.
    Returns: Updated agent record."
   registry/update-agent!)
 
-(def get-agent
+(def ^{:stratum 0} get-agent
   "Get an agent record by UUID."
   registry/get-agent)
 
-(def get-agent-by-external-id
+(def ^{:stratum 0} get-agent-by-external-id
   "Get an agent by vendor-specific external ID."
   registry/get-agent-by-external-id)
 
-(def list-agents
+(def ^{:stratum 0} list-agents
   "List agents, optionally filtered by :vendor, :status, or :tag."
   registry/list-agents)
 
-(def count-agents
+(def ^{:stratum 0} count-agents
   "Count agents, optionally filtered by status."
   registry/count-agents)
 
-(def agents-by-status
+(def ^{:stratum 0} agents-by-status
   "Group agents by their current status."
   registry/agents-by-status)
 
-(def record-heartbeat!
+(def ^{:stratum 0} record-heartbeat!
   "Record a heartbeat, updating timestamp and optional fields."
   registry/record-heartbeat!)
 
-(def transition-agent!
+(def ^{:stratum 0} transition-agent!
   "Transition an agent to a new status with validation.
    Returns an updated agent record, or an anomaly map with
    `:anomaly/type :not-found` when the agent ID is absent."
   registry/transition-agent!)
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Decision queue
-
-(def create-decision
+(def ^{:stratum 0} create-decision
   "Create a new decision request.
    (create-decision agent-id \"Merge PR?\" {:priority :high})"
   dq/create-decision)
 
-(def create-decision-manager
+(def ^{:stratum 0} create-decision-manager
   "Create a new decision manager (atom-backed store)."
   dq/create-decision-manager)
 
-(def submit-decision!
+(def ^{:stratum 0} submit-decision!
   "Submit a new decision to the queue."
   dq/submit-decision!)
 
-(def resolve-decision!
+(def ^{:stratum 0} resolve-decision!
   "Resolve a pending decision with the human's choice."
   dq/resolve-decision!)
 
-(def cancel-decision!
+(def ^{:stratum 0} cancel-decision!
   "Cancel a pending decision."
   dq/cancel-decision!)
 
-(def get-decision
+(def ^{:stratum 0} get-decision
   "Get a decision by ID."
   dq/get-decision)
 
-(def pending-decisions
+(def ^{:stratum 0} pending-decisions
   "Get all pending decisions, sorted by priority."
   dq/pending-decisions)
 
-(def decisions-for-agent
+(def ^{:stratum 0} decisions-for-agent
   "Get all decisions for a specific agent."
   dq/decisions-for-agent)
 
-(def count-pending
+(def ^{:stratum 0} count-pending
   "Count pending decisions."
   dq/count-pending)
 
-(def expire-stale-decisions!
+(def ^{:stratum 0} expire-stale-decisions!
   "Expire all decisions past their deadline."
   dq/expire-stale-decisions!)
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Heartbeat watchdog
-
-(def start-watchdog
+(def ^{:stratum 0} start-watchdog
   "Start the heartbeat watchdog background thread.
    Returns: Map with :future and :stop-fn."
   heartbeat/start-watchdog)
 
-(def stop-watchdog
+(def ^{:stratum 0} stop-watchdog
   "Stop a running heartbeat watchdog."
   heartbeat/stop-watchdog)
 
-(def check-stale-agents
+(def ^{:stratum 0} check-stale-agents
   "Check all agents for missed heartbeats (single pass)."
   heartbeat/check-stale-agents)
 
-;------------------------------------------------------------------------------ Layer 4
 ;; Orchestrator
-
-(def create-orchestrator
+(def ^{:stratum 0} create-orchestrator
   "Create a control plane orchestrator.
    Coordinates adapters, registry, decisions, and heartbeat monitoring.
    (create-orchestrator {:adapters [claude-adapter]})"
   orch/create-orchestrator)
 
-(def start!
+(def ^{:stratum 0} start!
   "Start the orchestrator discovery and polling loops."
   orch/start!)
 
-(def stop!
+(def ^{:stratum 0} stop!
   "Stop the orchestrator and all background loops."
   orch/stop!)
 
-(def submit-decision-from-agent!
+(def ^{:stratum 0} submit-decision-from-agent!
   "Submit a decision from an agent and transition it to :blocked."
   orch/submit-decision-from-agent!)
 
-(def resolve-and-deliver!
+(def ^{:stratum 0} resolve-and-deliver!
   "Resolve a decision and deliver the result back to the agent."
   orch/resolve-and-deliver!)
 

--- a/components/control-plane/src/ai/miniforge/control_plane/messages.clj
+++ b/components/control-plane/src/ai/miniforge/control_plane/messages.clj
@@ -15,13 +15,14 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.control-plane.messages
   "Component-level message catalog for control-plane.
    Delegates to the shared messages component."
   (:require [ai.miniforge.messages.interface :as messages]))
 
-(def t
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} t
   "Look up a control-plane message by key, with optional param substitution."
   (messages/create-translator "config/control-plane/messages/en-US.edn"
                               :control-plane/messages))

--- a/components/control-plane/src/ai/miniforge/control_plane/orchestrator.clj
+++ b/components/control-plane/src/ai/miniforge/control_plane/orchestrator.clj
@@ -15,17 +15,12 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.control-plane.orchestrator
   "Orchestrator loop for the control plane.
 
    Coordinates adapters, the agent registry, decision queue,
    and heartbeat watchdog into a unified runtime. Periodically
-   runs adapter discovery and status polling.
-
-   Layer 0: Orchestrator creation
-   Layer 1: Discovery and polling loop
-   Layer 2: Full lifecycle management"
+   runs adapter discovery and status polling."
   (:require
    [ai.miniforge.control-plane.registry :as registry]
    [ai.miniforge.control-plane.decision-queue :as dq]
@@ -35,22 +30,38 @@
    [ai.miniforge.event-stream.interface.stream :as stream]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Orchestrator state
 
-(def ^:const default-discovery-interval-ms
+;; Orchestrator state
+(def ^{:stratum 0} ^:const default-discovery-interval-ms
   "How often to run adapter discovery."
   30000)
 
-(def ^:const default-poll-interval-ms
+(def ^{:stratum 0} ^:const default-poll-interval-ms
   "How often to poll agent status."
   10000)
 
-(defn- publish-event!
+(defn- ^{:stratum 0} publish-event!
   [event-stream event]
   (when (and event-stream event)
     (stream/publish! event-stream event)))
 
-(defn create-orchestrator
+(defn ^{:stratum 0} stop!
+  "Stop the orchestrator and all background loops.
+
+   Arguments:
+   - orchestrator - Running orchestrator."
+  [orchestrator]
+  (reset! (:running orchestrator) false)
+  (doseq [f @(:futures orchestrator)]
+    (future-cancel f))
+  (when-let [wd (:watchdog orchestrator)]
+    (heartbeat/stop-watchdog wd))
+  (reset! (:futures orchestrator) [])
+  orchestrator)
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} create-orchestrator
   "Create a control plane orchestrator.
 
    Arguments:
@@ -82,10 +93,8 @@
    :running (atom false)
    :futures (atom [])})
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Discovery and polling
-
-(defn- run-discovery-pass
+(defn- ^{:stratum 1} run-discovery-pass
   "Run one discovery pass across all adapters.
    Registers any newly discovered agents."
   [{:keys [registry adapters on-agent-discovered event-stream workflow-id]}]
@@ -115,7 +124,7 @@
                                                             registered)}))))))))
       (catch Exception _e nil))))
 
-(defn- run-poll-pass
+(defn- ^{:stratum 1} run-poll-pass
   "Run one status poll pass for all non-terminal agents."
   [{:keys [registry adapters event-stream workflow-id]}]
   (let [agents (registry/list-agents registry)
@@ -163,61 +172,7 @@
                                      new-status)))))
               (catch Exception _e nil))))))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Full lifecycle
-
-(defn start!
-  "Start the orchestrator discovery and polling loops.
-
-   Arguments:
-   - orchestrator - Orchestrator map from create-orchestrator
-
-   Returns: Updated orchestrator with running futures."
-  [orchestrator]
-  (let [{:keys [running futures discovery-interval-ms poll-interval-ms
-                registry on-agent-unreachable]} orchestrator]
-    (reset! running true)
-
-    ;; Discovery loop
-    (swap! futures conj
-           (future
-             (while @running
-               (try
-                 (run-discovery-pass orchestrator)
-                 (catch Exception _e nil))
-               (Thread/sleep discovery-interval-ms))))
-
-    ;; Poll loop
-    (swap! futures conj
-           (future
-             (while @running
-               (try
-                 (run-poll-pass orchestrator)
-                 (catch Exception _e nil))
-               (Thread/sleep poll-interval-ms))))
-
-    ;; Heartbeat watchdog
-    (let [wd (heartbeat/start-watchdog registry
-               {:check-interval-ms poll-interval-ms
-                :on-unreachable on-agent-unreachable})]
-      (swap! futures conj (:future wd))
-      (assoc orchestrator :watchdog wd))))
-
-(defn stop!
-  "Stop the orchestrator and all background loops.
-
-   Arguments:
-   - orchestrator - Running orchestrator."
-  [orchestrator]
-  (reset! (:running orchestrator) false)
-  (doseq [f @(:futures orchestrator)]
-    (future-cancel f))
-  (when-let [wd (:watchdog orchestrator)]
-    (heartbeat/stop-watchdog wd))
-  (reset! (:futures orchestrator) [])
-  orchestrator)
-
-(defn submit-decision-from-agent!
+(defn ^{:stratum 1} submit-decision-from-agent!
   "Submit a decision from an agent to the queue.
    Transitions the agent to :blocked.
 
@@ -253,7 +208,7 @@
                         :deadline (:decision/deadline decision)})))
     decision))
 
-(defn resolve-and-deliver!
+(defn ^{:stratum 1} resolve-and-deliver!
   "Resolve a decision and deliver the result back to the agent.
 
    Arguments:
@@ -290,6 +245,46 @@
                            comment)))
         {:resolved resolved
          :delivered? (get delivery :delivered? false)}))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Full lifecycle
+(defn ^{:stratum 2} start!
+  "Start the orchestrator discovery and polling loops.
+
+   Arguments:
+   - orchestrator - Orchestrator map from create-orchestrator
+
+   Returns: Updated orchestrator with running futures."
+  [orchestrator]
+  (let [{:keys [running futures discovery-interval-ms poll-interval-ms
+                registry on-agent-unreachable]} orchestrator]
+    (reset! running true)
+
+    ;; Discovery loop
+    (swap! futures conj
+           (future
+             (while @running
+               (try
+                 (run-discovery-pass orchestrator)
+                 (catch Exception _e nil))
+               (Thread/sleep discovery-interval-ms))))
+
+    ;; Poll loop
+    (swap! futures conj
+           (future
+             (while @running
+               (try
+                 (run-poll-pass orchestrator)
+                 (catch Exception _e nil))
+               (Thread/sleep poll-interval-ms))))
+
+    ;; Heartbeat watchdog
+    (let [wd (heartbeat/start-watchdog registry
+               {:check-interval-ms poll-interval-ms
+                :on-unreachable on-agent-unreachable})]
+      (swap! futures conj (:future wd))
+      (assoc orchestrator :watchdog wd))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/control-plane/src/ai/miniforge/control_plane/registry.clj
+++ b/components/control-plane/src/ai/miniforge/control_plane/registry.clj
@@ -15,27 +15,21 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.control-plane.registry
   "Atom-backed agent registry for the control plane.
 
    Manages the lifecycle of registered agents from any vendor.
    Each agent gets a control-plane-assigned UUID and is tracked
-   with normalized state, heartbeat timestamps, and metadata.
-
-   Layer 0: Registry creation
-   Layer 1: Agent CRUD
-   Layer 2: Query operations
-   Layer 3: Heartbeat updates"
+   with normalized state, heartbeat timestamps, and metadata."
   (:require
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.control-plane.messages :as messages]
    [ai.miniforge.control-plane.state-machine :as sm]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Registry creation
 
-(defn create-registry
+;; Registry creation
+(defn ^{:stratum 0} create-registry
   "Create a new agent registry.
 
    Returns: Atom containing {:agents {} :by-vendor {} :by-external-id {}}.
@@ -47,10 +41,8 @@
          :by-vendor {}
          :by-external-id {}}))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Agent CRUD
-
-(defn register-agent!
+(defn ^{:stratum 0} register-agent!
   "Register a new agent with the control plane.
 
    Arguments:
@@ -96,7 +88,7 @@
                  (cond-> ext-id (assoc-in [:by-external-id ext-id] agent-id)))))
     agent-record))
 
-(defn deregister-agent!
+(defn ^{:stratum 0} deregister-agent!
   "Remove an agent from the registry.
 
    Arguments:
@@ -117,7 +109,7 @@
                      (cond-> ext-id (update :by-external-id dissoc ext-id))))))
       agent-record)))
 
-(defn update-agent!
+(defn ^{:stratum 0} update-agent!
   "Update fields on an existing agent record.
 
    Arguments:
@@ -138,17 +130,15 @@
                    state))))
     @result))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Query operations
-
-(defn get-agent
+(defn ^{:stratum 0} get-agent
   "Get an agent record by its control-plane UUID.
 
    Returns: Agent record map, or nil if not found."
   [registry agent-id]
   (get-in @registry [:agents agent-id]))
 
-(defn get-agent-by-external-id
+(defn ^{:stratum 0} get-agent-by-external-id
   "Get an agent record by its vendor-specific external ID.
 
    Returns: Agent record map, or nil if not found."
@@ -156,7 +146,7 @@
   (when-let [agent-id (get-in @registry [:by-external-id external-id])]
     (get-in @registry [:agents agent-id])))
 
-(defn list-agents
+(defn ^{:stratum 0} list-agents
   "List all registered agents.
 
    Options:
@@ -173,7 +163,23 @@
       status (filter #(= status (:agent/status %)))
       tag    (filter #(contains? (:agent/tags %) tag)))))
 
-(defn count-agents
+(defn ^{:stratum 0} agents-by-status
+  "Group agents by their current status.
+
+   Returns: Map of status keyword → seq of agent records."
+  [registry]
+  (group-by :agent/status (vals (:agents @registry))))
+
+;; Heartbeat updates
+(defn- ^{:stratum 0} agent-not-found-anomaly
+  [agent-id]
+  (anomaly/anomaly :not-found
+                   (messages/t :registry/agent-not-found)
+                   {:agent/id agent-id}))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} count-agents
   "Count agents, optionally filtered by status.
 
    Returns: Integer count."
@@ -182,23 +188,7 @@
     (count (list-agents registry {:status status}))
     (count (:agents @registry))))
 
-(defn agents-by-status
-  "Group agents by their current status.
-
-   Returns: Map of status keyword → seq of agent records."
-  [registry]
-  (group-by :agent/status (vals (:agents @registry))))
-
-;------------------------------------------------------------------------------ Layer 3
-;; Heartbeat updates
-
-(defn- agent-not-found-anomaly
-  [agent-id]
-  (anomaly/anomaly :not-found
-                   (messages/t :registry/agent-not-found)
-                   {:agent/id agent-id}))
-
-(defn record-heartbeat!
+(defn ^{:stratum 1} record-heartbeat!
   "Record a heartbeat from an agent, updating timestamp and optional fields.
 
    Arguments:
@@ -226,7 +216,7 @@
                   updates)]
     (update-agent! registry agent-id updates)))
 
-(defn transition-agent!
+(defn ^{:stratum 1} transition-agent!
   "Transition an agent to a new status with validation.
 
    Arguments:

--- a/components/control-plane/src/ai/miniforge/control_plane/state_machine.clj
+++ b/components/control-plane/src/ai/miniforge/control_plane/state_machine.clj
@@ -15,18 +15,13 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.control-plane.state-machine
   "Normalized agent lifecycle state machine for the control plane.
 
    Loads state profiles from EDN and validates transitions.
    Agents from any vendor are mapped to a common set of states:
    unknown, initializing, running, idle, blocked, paused,
-   completed, failed, unreachable, terminated.
-
-   Layer 0: Profile loading
-  Layer 1: Transition validation
-  Layer 2: Event mapping"
+   completed, failed, unreachable, terminated."
   (:require
    [clojure.edn :as edn]
    [clojure.java.io :as io]
@@ -34,13 +29,56 @@
    [ai.miniforge.control-plane.messages :as messages]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Profile loading
 
-(def ^:const default-profile-path
+;; Profile loading
+(def ^{:stratum 0} ^:const default-profile-path
   "Classpath location of the control-plane state profile."
   "control-plane/state-profiles/control-plane.edn")
 
-(defn load-profile
+;; Transition validation
+(defn ^{:stratum 0} valid-statuses
+  "Return the set of all valid agent statuses.
+
+   Example:
+     (valid-statuses (get-profile))
+     ;=> #{:unknown :initializing :running ...}"
+  [profile]
+  (set (:task-statuses profile)))
+
+(defn ^{:stratum 0} terminal?
+  "Check if a status is terminal (no further transitions).
+
+   Example:
+     (terminal? (get-profile) :completed) ;=> true
+     (terminal? (get-profile) :running)   ;=> false"
+  [profile status]
+  (contains? (set (:terminal-statuses profile)) status))
+
+(defn ^{:stratum 0} valid-transition?
+  "Check if a transition from `from-status` to `to-status` is valid.
+
+   Example:
+     (valid-transition? (get-profile) :running :blocked)   ;=> true
+     (valid-transition? (get-profile) :completed :running)  ;=> false"
+  [profile from-status to-status]
+  (let [transitions (:valid-transitions profile)]
+    (contains? (get transitions from-status #{}) to-status)))
+
+;; Event mapping
+(defn ^{:stratum 0} event->transition
+  "Map an event type to its configured transition.
+
+   Returns: Transition map or nil if event has no mapping.
+
+   Example:
+     (event->transition (get-profile) :agent/decision-needed)
+     ;=> {:type :transition :to :blocked}"
+  [profile event-type]
+  (get (:event-mappings profile) event-type))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} load-profile
   "Load the control-plane state profile from classpath.
 
    Returns: State profile map with :task-statuses, :valid-transitions, etc.
@@ -57,47 +95,7 @@
                      {:path path
                       :config/error :invalid-config})))))
 
-(def ^:private profile-cache
-  "Cached profile instance."
-  (delay (load-profile)))
-
-(defn get-profile
-  "Get the cached control-plane state profile."
-  []
-  @profile-cache)
-
-;------------------------------------------------------------------------------ Layer 1
-;; Transition validation
-
-(defn valid-statuses
-  "Return the set of all valid agent statuses.
-
-   Example:
-     (valid-statuses (get-profile))
-     ;=> #{:unknown :initializing :running ...}"
-  [profile]
-  (set (:task-statuses profile)))
-
-(defn terminal?
-  "Check if a status is terminal (no further transitions).
-
-   Example:
-     (terminal? (get-profile) :completed) ;=> true
-     (terminal? (get-profile) :running)   ;=> false"
-  [profile status]
-  (contains? (set (:terminal-statuses profile)) status))
-
-(defn valid-transition?
-  "Check if a transition from `from-status` to `to-status` is valid.
-
-   Example:
-     (valid-transition? (get-profile) :running :blocked)   ;=> true
-     (valid-transition? (get-profile) :completed :running)  ;=> false"
-  [profile from-status to-status]
-  (let [transitions (:valid-transitions profile)]
-    (contains? (get transitions from-status #{}) to-status)))
-
-(defn validate-transition-result
+(defn ^{:stratum 1} validate-transition-result
   "Validate a state transition. Returns nil on success or an anomaly on invalid.
 
    Arguments:
@@ -113,7 +111,13 @@
                       :valid-targets (get (:valid-transitions profile)
                                          from-status #{})})))
 
-(defn validate-transition
+;------------------------------------------------------------------------------ Layer 2
+
+(def ^{:stratum 2} ^:private profile-cache
+  "Cached profile instance."
+  (delay (load-profile)))
+
+(defn ^{:stratum 2} validate-transition
   "Boundary wrapper around the canonical anomaly-returning
    [[validate-transition-result]]. Returns nil on success and throws only for
    legacy callers. Prefer `validate-transition-result` in non-boundary code."
@@ -123,19 +127,12 @@
       (throw (ex-info (:anomaly/message result)
                       (:anomaly/data result))))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Event mapping
+;------------------------------------------------------------------------------ Layer 3
 
-(defn event->transition
-  "Map an event type to its configured transition.
-
-   Returns: Transition map or nil if event has no mapping.
-
-   Example:
-     (event->transition (get-profile) :agent/decision-needed)
-     ;=> {:type :transition :to :blocked}"
-  [profile event-type]
-  (get (:event-mappings profile) event-type))
+(defn ^{:stratum 3} get-profile
+  "Get the cached control-plane state profile."
+  []
+  @profile-cache)
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/control-plane/test/ai/miniforge/control_plane/interface_test.clj
+++ b/components/control-plane/test/ai/miniforge/control_plane/interface_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.control-plane.interface-test
   (:require
    [ai.miniforge.anomaly.interface :as anomaly]
@@ -25,9 +24,10 @@
    [ai.miniforge.control-plane.registry :as registry]
    [ai.miniforge.control-plane.interface :as cp]))
 
-;------------------------------------------------------------------------------ State Machine Tests
+;------------------------------------------------------------------------------ Layer 0
 
-(deftest load-profile-test
+;------------------------------------------------------------------------------ State Machine Tests
+(deftest ^{:stratum 0} load-profile-test
   (testing "Profile loads from classpath"
     (let [profile (cp/load-profile)]
       (is (= :control-plane (:profile/id profile)))
@@ -36,7 +36,7 @@
       (is (contains? (set (:task-statuses profile)) :blocked))
       (is (map? (:valid-transitions profile))))))
 
-(deftest load-profile-missing-resource-carries-invalid-config-marker
+(deftest ^{:stratum 0} load-profile-missing-resource-carries-invalid-config-marker
   (testing "Missing classpath state profile is an invalid configuration fault"
     (let [missing-path "control-plane/state-profiles/missing.edn"
           resource io/resource]
@@ -51,7 +51,7 @@
           (is (= missing-path (:path (ex-data thrown))))
           (is (= :invalid-config (:config/error (ex-data thrown)))))))))
 
-(deftest valid-transition-test
+(deftest ^{:stratum 0} valid-transition-test
   (let [profile (cp/get-profile)]
     (testing "Valid transitions"
       (are [from to] (cp/valid-transition? profile from to)
@@ -71,7 +71,7 @@
         :terminated :running
         :blocked   :completed))))
 
-(deftest validate-transition-result-test
+(deftest ^{:stratum 0} validate-transition-result-test
   (let [profile (cp/get-profile)]
     (testing "valid transitions return nil"
       (is (nil? (cp/validate-transition-result profile :running :blocked))))
@@ -87,7 +87,7 @@
       (is (thrown? clojure.lang.ExceptionInfo
                    (sm/validate-transition profile :completed :running))))))
 
-(deftest terminal-test
+(deftest ^{:stratum 0} terminal-test
   (let [profile (cp/get-profile)]
     (testing "Terminal states"
       (is (cp/terminal? profile :completed))
@@ -98,7 +98,7 @@
       (is (not (cp/terminal? profile :blocked)))
       (is (not (cp/terminal? profile :idle))))))
 
-(deftest event-mapping-test
+(deftest ^{:stratum 0} event-mapping-test
   (let [profile (cp/get-profile)]
     (testing "Event maps to transition"
       (is (= :blocked (:to (cp/event->transition profile :agent/decision-needed))))
@@ -107,8 +107,7 @@
       (is (nil? (cp/event->transition profile :bogus/event))))))
 
 ;------------------------------------------------------------------------------ Registry Tests
-
-(deftest registry-crud-test
+(deftest ^{:stratum 0} registry-crud-test
   (let [reg (cp/create-registry)]
     (testing "Register an agent"
       (let [agent (cp/register-agent! reg {:agent/vendor :claude-code
@@ -147,7 +146,7 @@
             (is (nil? (cp/get-agent reg (:agent/id agent))))
             (is (= 0 (cp/count-agents reg)))))))))
 
-(deftest heartbeat-test
+(deftest ^{:stratum 0} heartbeat-test
   (let [reg (cp/create-registry)
         agent (cp/register-agent! reg {:agent/vendor :claude-code
                                         :agent/name "Test"})
@@ -163,7 +162,7 @@
       (let [updated (cp/record-heartbeat! reg agent-id {:status :unknown})]
         (is (= :running (:agent/status updated)))))))
 
-(deftest transition-agent-test
+(deftest ^{:stratum 0} transition-agent-test
   (testing "Valid transition"
     (let [reg (cp/create-registry)
           agent (cp/register-agent! reg {:agent/vendor :test :agent/name "T"})
@@ -198,7 +197,7 @@
           (is (= {:agent/id agent-id}
                  (:anomaly/data result))))))))
 
-(deftest agents-by-status-test
+(deftest ^{:stratum 0} agents-by-status-test
   (let [reg (cp/create-registry)]
     (cp/register-agent! reg {:agent/vendor :a :agent/name "A"})
     (let [b (cp/register-agent! reg {:agent/vendor :b :agent/name "B"})]
@@ -208,8 +207,7 @@
         (is (= 1 (count (:running grouped))))))))
 
 ;------------------------------------------------------------------------------ Decision Queue Tests
-
-(deftest decision-crud-test
+(deftest ^{:stratum 0} decision-crud-test
   (let [mgr (cp/create-decision-manager)
         agent-id (random-uuid)]
     (testing "Create and submit decision"
@@ -249,7 +247,7 @@
         (testing "Pending count after resolve"
           (is (= 0 (cp/count-pending mgr))))))))
 
-(deftest decision-priority-ordering-test
+(deftest ^{:stratum 0} decision-priority-ordering-test
   (let [mgr (cp/create-decision-manager)
         agent-id (random-uuid)
         d-low (cp/create-decision agent-id "Low priority" {:priority :low})
@@ -266,7 +264,7 @@
         (is (= [:critical :high :medium :low]
                (mapv :decision/priority pending)))))))
 
-(deftest decision-blocked-boost-test
+(deftest ^{:stratum 0} decision-blocked-boost-test
   (let [mgr (cp/create-decision-manager)
         blocked-agent (random-uuid)
         normal-agent (random-uuid)
@@ -284,7 +282,7 @@
       (let [pending (cp/pending-decisions mgr #{blocked-agent})]
         (is (= blocked-agent (:decision/agent-id (first pending))))))))
 
-(deftest decisions-for-agent-test
+(deftest ^{:stratum 0} decisions-for-agent-test
   (let [mgr (cp/create-decision-manager)
         a1 (random-uuid)
         a2 (random-uuid)]
@@ -296,7 +294,7 @@
       (is (= 2 (count (cp/decisions-for-agent mgr a1))))
       (is (= 1 (count (cp/decisions-for-agent mgr a2)))))))
 
-(deftest cancel-decision-test
+(deftest ^{:stratum 0} cancel-decision-test
   (let [mgr (cp/create-decision-manager)
         d (cp/create-decision (random-uuid) "Cancel me")]
     (cp/submit-decision! mgr d)
@@ -306,8 +304,7 @@
     (is (= :cancelled (:decision/status (cp/get-decision mgr (:decision/id d)))))))
 
 ;------------------------------------------------------------------------------ Heartbeat Watchdog Tests
-
-(deftest stale-agent-detection-test
+(deftest ^{:stratum 0} stale-agent-detection-test
   (let [reg (cp/create-registry)
         agent (cp/register-agent! reg {:agent/vendor :test
                                         :agent/name "Stale"

--- a/components/control-plane/test/ai/miniforge/control_plane/orchestrator_edge_test.clj
+++ b/components/control-plane/test/ai/miniforge/control_plane/orchestrator_edge_test.clj
@@ -1,7 +1,6 @@
 ;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
 ;;
 ;; Licensed under the Apache License, Version 2.0
-
 (ns ai.miniforge.control-plane.orchestrator-edge-test
   "Edge-case and gap-coverage tests for the orchestrator.
    Complements orchestrator-test and orchestrator-supplemental-test
@@ -14,30 +13,14 @@
    [ai.miniforge.control-plane-adapter.protocol :as adapter]
    [ai.miniforge.event-stream.interface.stream :as stream]))
 
-(def ^:private default-wait-timeout-ms 2000)
+;------------------------------------------------------------------------------ Layer 0
 
-(defn- wait-until-count
-  "Block until `(count @items-atom) >= n` or `timeout-ms` elapses.
-   Uses add-watch + promise — no fixed sleep. Returns true if reached, false on timeout."
-  ([items-atom n] (wait-until-count items-atom n default-wait-timeout-ms))
-  ([items-atom n timeout-ms]
-   (let [done (promise)
-         k    (gensym "wait-count-")]
-     (when (>= (count @items-atom) n)
-       (deliver done :immediate))
-     (add-watch items-atom k
-                (fn [_ _ _ new-val]
-                  (when (>= (count new-val) n)
-                    (deliver done :reached))))
-     (let [result (deref done timeout-ms ::timeout)]
-       (remove-watch items-atom k)
-       (not= result ::timeout)))))
+(def ^{:stratum 0} ^:private default-wait-timeout-ms 2000)
 
 ;; ---------------------------------------------------------------------------
 ;; Test helpers
 ;; ---------------------------------------------------------------------------
-
-(defn make-mock-adapter
+(defn ^{:stratum 0} make-mock-adapter
   "Create a mock adapter implementing ControlPlaneAdapter."
   [overrides]
   (let [id (get overrides :adapter-id :test-adapter)]
@@ -60,14 +43,14 @@
           (f agent-record command)
           {:success? true})))))
 
-(defn base-opts
+(defn ^{:stratum 0} base-opts
   [& [overrides]]
   (merge {:adapters []
           :discovery-interval-ms 50
           :poll-interval-ms 50}
          overrides))
 
-(defn register-running-agent!
+(defn ^{:stratum 0} register-running-agent!
   "Helper: register an agent and transition to :running."
   [reg agent-info]
   (let [rec (registry/register-agent! reg agent-info)]
@@ -75,10 +58,45 @@
     (registry/get-agent reg (:agent/id rec))))
 
 ;; ---------------------------------------------------------------------------
+;; create-orchestrator: nil adapters normalizes to empty vector
+;; ---------------------------------------------------------------------------
+(deftest ^{:stratum 0} create-orchestrator-nil-adapters-test
+  (testing "nil adapters is normalized to empty vector"
+    (let [orch (sut/create-orchestrator {:adapters nil})]
+      (is (vector? (:adapters orch)))
+      (is (empty? (:adapters orch))))))
+
+;; ---------------------------------------------------------------------------
+;; create-orchestrator: preserves event-stream reference
+;; ---------------------------------------------------------------------------
+(deftest ^{:stratum 0} create-orchestrator-event-stream-nil-by-default-test
+  (testing "event-stream is nil when not provided"
+    (let [orch (sut/create-orchestrator {})]
+      (is (nil? (:event-stream orch))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} wait-until-count
+  "Block until `(count @items-atom) >= n` or `timeout-ms` elapses.
+   Uses add-watch + promise — no fixed sleep. Returns true if reached, false on timeout."
+  ([items-atom n] (wait-until-count items-atom n default-wait-timeout-ms))
+  ([items-atom n timeout-ms]
+   (let [done (promise)
+         k    (gensym "wait-count-")]
+     (when (>= (count @items-atom) n)
+       (deliver done :immediate))
+     (add-watch items-atom k
+                (fn [_ _ _ new-val]
+                  (when (>= (count new-val) n)
+                    (deliver done :reached))))
+     (let [result (deref done timeout-ms ::timeout)]
+       (remove-watch items-atom k)
+       (not= result ::timeout)))))
+
+;; ---------------------------------------------------------------------------
 ;; resolve-and-deliver!: no matching adapter for agent's vendor
 ;; ---------------------------------------------------------------------------
-
-(deftest resolve-and-deliver-no-matching-adapter-test
+(deftest ^{:stratum 1} resolve-and-deliver-no-matching-adapter-test
   (testing "resolve-and-deliver! returns delivered?=false when no adapter matches vendor"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -106,8 +124,7 @@
 ;; ---------------------------------------------------------------------------
 ;; resolve-and-deliver!: no adapters at all
 ;; ---------------------------------------------------------------------------
-
-(deftest resolve-and-deliver-no-adapters-test
+(deftest ^{:stratum 1} resolve-and-deliver-no-adapters-test
   (testing "resolve-and-deliver! works with zero adapters (delivered?=false)"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -127,42 +144,9 @@
       (is (false? (:delivered? result))))))
 
 ;; ---------------------------------------------------------------------------
-;; resolve-and-deliver!: emits decision-resolved event
-;; ---------------------------------------------------------------------------
-
-(deftest resolve-and-deliver-emits-decision-resolved-event-test
-  (testing "resolve-and-deliver! emits :control-plane/decision-resolved event"
-    (let [reg (registry/create-registry)
-          dm (dq/create-decision-manager)
-          es (stream/create-event-stream {:sinks []})
-          published (atom [])
-          _ (stream/subscribe! es :test-sub #(swap! published conj %))
-          adapter (make-mock-adapter
-                   {:deliver-decision (fn [_ _] {:delivered? true})})
-          agent-rec (register-running-agent! reg
-                     {:agent/external-id "ext-ev-resolve"
-                      :agent/name "Resolve Ev Agent"
-                      :agent/vendor :test-adapter})
-          orch (sut/create-orchestrator
-                (base-opts {:registry reg
-                            :decision-manager dm
-                            :adapters [adapter]
-                            :event-stream es}))
-          decision (sut/submit-decision-from-agent!
-                    orch (:agent/id agent-rec) "Resolve event test")
-          ;; Wait for submit-emitted events, then clear before resolve.
-          _ (wait-until-count published 1)
-          _ (reset! published [])
-          _ (sut/resolve-and-deliver!
-             orch (:decision/id decision) "approved")]
-      (is (wait-until-count published 1)
-          "should have published decision-resolved event"))))
-
-;; ---------------------------------------------------------------------------
 ;; resolve-and-deliver!: nonexistent decision-id
 ;; ---------------------------------------------------------------------------
-
-(deftest resolve-and-deliver-nonexistent-decision-test
+(deftest ^{:stratum 1} resolve-and-deliver-nonexistent-decision-test
   (testing "resolve-and-deliver! returns nil for a nonexistent decision-id"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -176,8 +160,7 @@
 ;; ---------------------------------------------------------------------------
 ;; resolve-and-deliver!: with a string comment
 ;; ---------------------------------------------------------------------------
-
-(deftest resolve-and-deliver-with-comment-test
+(deftest ^{:stratum 1} resolve-and-deliver-with-comment-test
   (testing "resolve-and-deliver! passes comment through to resolved decision"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -202,8 +185,7 @@
 ;; ---------------------------------------------------------------------------
 ;; resolve-and-deliver!: adapter returns delivered?=false
 ;; ---------------------------------------------------------------------------
-
-(deftest resolve-and-deliver-adapter-returns-not-delivered-test
+(deftest ^{:stratum 1} resolve-and-deliver-adapter-returns-not-delivered-test
   (testing "resolve-and-deliver! surfaces delivered?=false from adapter"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -229,8 +211,7 @@
 ;; ---------------------------------------------------------------------------
 ;; submit-decision-from-agent!: without event-stream (nil)
 ;; ---------------------------------------------------------------------------
-
-(deftest submit-decision-no-event-stream-test
+(deftest ^{:stratum 1} submit-decision-no-event-stream-test
   (testing "submit-decision-from-agent! works fine without event-stream"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -252,8 +233,7 @@
 ;; ---------------------------------------------------------------------------
 ;; resolve-and-deliver!: without event-stream (nil)
 ;; ---------------------------------------------------------------------------
-
-(deftest resolve-and-deliver-no-event-stream-test
+(deftest ^{:stratum 1} resolve-and-deliver-no-event-stream-test
   (testing "resolve-and-deliver! works fine without event-stream"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -277,8 +257,7 @@
 ;; ---------------------------------------------------------------------------
 ;; Discovery pass: no adapters configured
 ;; ---------------------------------------------------------------------------
-
-(deftest run-discovery-pass-no-adapters-test
+(deftest ^{:stratum 1} run-discovery-pass-no-adapters-test
   (testing "discovery pass with no adapters is a no-op"
     (let [reg (registry/create-registry)
           orch (sut/create-orchestrator
@@ -289,8 +268,7 @@
 ;; ---------------------------------------------------------------------------
 ;; Poll pass: no agents registered
 ;; ---------------------------------------------------------------------------
-
-(deftest run-poll-pass-no-agents-test
+(deftest ^{:stratum 1} run-poll-pass-no-agents-test
   (testing "poll pass with no agents registered is a no-op"
     (let [reg (registry/create-registry)
           adapter (make-mock-adapter {})
@@ -299,58 +277,9 @@
       (is (nil? (#'sut/run-poll-pass orch))))))
 
 ;; ---------------------------------------------------------------------------
-;; Poll pass: uses :status key from status-update (not :agent/status)
-;; ---------------------------------------------------------------------------
-
-(deftest run-poll-pass-uses-status-key-test
-  (testing "poll pass extracts new-status from :status key in status-update"
-    (let [reg (registry/create-registry)
-          es (stream/create-event-stream {:sinks []})
-          published (atom [])
-          _ (stream/subscribe! es :test-sub #(swap! published conj %))
-          _agent-rec (registry/register-agent! reg
-                      {:agent/external-id "ext-status-key"
-                       :agent/name "Status Key Agent"
-                       :agent/vendor :test-adapter})
-          ;; Return :status (not :agent/status) matching the code's (:status status-update)
-          adapter (make-mock-adapter
-                   {:poll-agent-status
-                    (fn [_] {:status :running
-                             :task "coding"})})
-          orch (sut/create-orchestrator
-                (base-opts {:registry reg
-                            :adapters [adapter]
-                            :event-stream es}))]
-      (#'sut/run-poll-pass orch)
-      ;; Agent was :initializing, poll returned :status :running
-      ;; This should trigger a state-changed event
-      (is (wait-until-count published 1)
-          "should emit state-changed when :status key differs from current"))))
-
-;; ---------------------------------------------------------------------------
-;; create-orchestrator: nil adapters normalizes to empty vector
-;; ---------------------------------------------------------------------------
-
-(deftest create-orchestrator-nil-adapters-test
-  (testing "nil adapters is normalized to empty vector"
-    (let [orch (sut/create-orchestrator {:adapters nil})]
-      (is (vector? (:adapters orch)))
-      (is (empty? (:adapters orch))))))
-
-;; ---------------------------------------------------------------------------
-;; create-orchestrator: preserves event-stream reference
-;; ---------------------------------------------------------------------------
-
-(deftest create-orchestrator-event-stream-nil-by-default-test
-  (testing "event-stream is nil when not provided"
-    (let [orch (sut/create-orchestrator {})]
-      (is (nil? (:event-stream orch))))))
-
-;; ---------------------------------------------------------------------------
 ;; submit then resolve full round-trip with callbacks
 ;; ---------------------------------------------------------------------------
-
-(deftest full-decision-round-trip-callbacks-test
+(deftest ^{:stratum 1} full-decision-round-trip-callbacks-test
   (testing "decision round-trip fires on-decision-created callback"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -382,8 +311,7 @@
 ;; ---------------------------------------------------------------------------
 ;; Poll pass: adapter returns map without :delivered? key
 ;; ---------------------------------------------------------------------------
-
-(deftest resolve-and-deliver-adapter-missing-delivered-key-test
+(deftest ^{:stratum 1} resolve-and-deliver-adapter-missing-delivered-key-test
   (testing "resolve-and-deliver! defaults to delivered?=false when key is missing"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -407,8 +335,7 @@
 ;; ---------------------------------------------------------------------------
 ;; start!/stop!: watchdog key is present after start
 ;; ---------------------------------------------------------------------------
-
-(deftest start-returns-orchestrator-map-with-all-keys-test
+(deftest ^{:stratum 1} start-returns-orchestrator-map-with-all-keys-test
   (testing "start! returns orchestrator with all expected keys including :watchdog"
     (let [orch (sut/create-orchestrator (base-opts))
           started (sut/start! orch)]
@@ -422,8 +349,7 @@
 ;; ---------------------------------------------------------------------------
 ;; submit-decision-from-agent!: decision has correct priority default
 ;; ---------------------------------------------------------------------------
-
-(deftest submit-decision-default-priority-test
+(deftest ^{:stratum 1} submit-decision-default-priority-test
   (testing "submit-decision-from-agent! without priority opts uses default"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -441,8 +367,7 @@
 ;; ---------------------------------------------------------------------------
 ;; Multiple decisions from same agent
 ;; ---------------------------------------------------------------------------
-
-(deftest multiple-decisions-same-agent-test
+(deftest ^{:stratum 1} multiple-decisions-same-agent-test
   (testing "an agent can submit multiple decisions (second while already blocked)"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -468,8 +393,7 @@
 ;; ---------------------------------------------------------------------------
 ;; Poll pass: adapter returns nil for some agents, status for others
 ;; ---------------------------------------------------------------------------
-
-(deftest run-poll-pass-mixed-nil-and-status-test
+(deftest ^{:stratum 1} run-poll-pass-mixed-nil-and-status-test
   (testing "poll handles mix of nil and valid status from adapter"
     (let [reg (registry/create-registry)
           _ (registry/register-agent! reg
@@ -494,8 +418,7 @@
 ;; ---------------------------------------------------------------------------
 ;; stop!: returns the orchestrator
 ;; ---------------------------------------------------------------------------
-
-(deftest stop-returns-orchestrator-test
+(deftest ^{:stratum 1} stop-returns-orchestrator-test
   (testing "stop! returns the orchestrator map"
     (let [orch (sut/create-orchestrator (base-opts))
           started (sut/start! orch)
@@ -503,3 +426,64 @@
       (is (map? stopped))
       (is (contains? stopped :registry))
       (is (false? @(:running stopped))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; ---------------------------------------------------------------------------
+;; resolve-and-deliver!: emits decision-resolved event
+;; ---------------------------------------------------------------------------
+(deftest ^{:stratum 2} resolve-and-deliver-emits-decision-resolved-event-test
+  (testing "resolve-and-deliver! emits :control-plane/decision-resolved event"
+    (let [reg (registry/create-registry)
+          dm (dq/create-decision-manager)
+          es (stream/create-event-stream {:sinks []})
+          published (atom [])
+          _ (stream/subscribe! es :test-sub #(swap! published conj %))
+          adapter (make-mock-adapter
+                   {:deliver-decision (fn [_ _] {:delivered? true})})
+          agent-rec (register-running-agent! reg
+                     {:agent/external-id "ext-ev-resolve"
+                      :agent/name "Resolve Ev Agent"
+                      :agent/vendor :test-adapter})
+          orch (sut/create-orchestrator
+                (base-opts {:registry reg
+                            :decision-manager dm
+                            :adapters [adapter]
+                            :event-stream es}))
+          decision (sut/submit-decision-from-agent!
+                    orch (:agent/id agent-rec) "Resolve event test")
+          ;; Wait for submit-emitted events, then clear before resolve.
+          _ (wait-until-count published 1)
+          _ (reset! published [])
+          _ (sut/resolve-and-deliver!
+             orch (:decision/id decision) "approved")]
+      (is (wait-until-count published 1)
+          "should have published decision-resolved event"))))
+
+;; ---------------------------------------------------------------------------
+;; Poll pass: uses :status key from status-update (not :agent/status)
+;; ---------------------------------------------------------------------------
+(deftest ^{:stratum 2} run-poll-pass-uses-status-key-test
+  (testing "poll pass extracts new-status from :status key in status-update"
+    (let [reg (registry/create-registry)
+          es (stream/create-event-stream {:sinks []})
+          published (atom [])
+          _ (stream/subscribe! es :test-sub #(swap! published conj %))
+          _agent-rec (registry/register-agent! reg
+                      {:agent/external-id "ext-status-key"
+                       :agent/name "Status Key Agent"
+                       :agent/vendor :test-adapter})
+          ;; Return :status (not :agent/status) matching the code's (:status status-update)
+          adapter (make-mock-adapter
+                   {:poll-agent-status
+                    (fn [_] {:status :running
+                             :task "coding"})})
+          orch (sut/create-orchestrator
+                (base-opts {:registry reg
+                            :adapters [adapter]
+                            :event-stream es}))]
+      (#'sut/run-poll-pass orch)
+      ;; Agent was :initializing, poll returned :status :running
+      ;; This should trigger a state-changed event
+      (is (wait-until-count published 1)
+          "should emit state-changed when :status key differs from current"))))

--- a/components/control-plane/test/ai/miniforge/control_plane/orchestrator_supplemental_test.clj
+++ b/components/control-plane/test/ai/miniforge/control_plane/orchestrator_supplemental_test.clj
@@ -1,7 +1,6 @@
 ;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
 ;;
 ;; Licensed under the Apache License, Version 2.0
-
 (ns ai.miniforge.control-plane.orchestrator-supplemental-test
   "Supplemental tests for the orchestrator.
    Covers property-based tests, concurrency edge cases,
@@ -14,30 +13,14 @@
    [ai.miniforge.control-plane-adapter.protocol :as adapter]
    [ai.miniforge.event-stream.interface.stream :as stream]))
 
-(def ^:private default-wait-timeout-ms 2000)
+;------------------------------------------------------------------------------ Layer 0
 
-(defn- wait-until-count
-  "Block until `(count @items-atom) >= n` or `timeout-ms` elapses.
-   Uses add-watch + promise — no fixed sleep. Returns true if reached, false on timeout."
-  ([items-atom n] (wait-until-count items-atom n default-wait-timeout-ms))
-  ([items-atom n timeout-ms]
-   (let [done (promise)
-         k    (gensym "wait-count-")]
-     (when (>= (count @items-atom) n)
-       (deliver done :immediate))
-     (add-watch items-atom k
-                (fn [_ _ _ new-val]
-                  (when (>= (count new-val) n)
-                    (deliver done :reached))))
-     (let [result (deref done timeout-ms ::timeout)]
-       (remove-watch items-atom k)
-       (not= result ::timeout)))))
+(def ^{:stratum 0} ^:private default-wait-timeout-ms 2000)
 
 ;; ---------------------------------------------------------------------------
 ;; Test helpers
 ;; ---------------------------------------------------------------------------
-
-(defn make-mock-adapter
+(defn ^{:stratum 0} make-mock-adapter
   "Create a mock adapter implementing ControlPlaneAdapter."
   [overrides]
   (let [id (get overrides :adapter-id :test-adapter)]
@@ -60,14 +43,14 @@
           (f agent-record command)
           {:success? true})))))
 
-(defn base-opts
+(defn ^{:stratum 0} base-opts
   [& [overrides]]
   (merge {:adapters []
           :discovery-interval-ms 50
           :poll-interval-ms 50}
          overrides))
 
-(defn register-running-agent!
+(defn ^{:stratum 0} register-running-agent!
   "Helper: register an agent and transition to :running."
   [reg agent-info]
   (let [rec (registry/register-agent! reg agent-info)]
@@ -75,10 +58,47 @@
     (registry/get-agent reg (:agent/id rec))))
 
 ;; ---------------------------------------------------------------------------
+;; create-orchestrator: interval values
+;; ---------------------------------------------------------------------------
+(deftest ^{:stratum 0} create-orchestrator-custom-intervals-test
+  (testing "custom interval values are stored correctly"
+    (let [orch (sut/create-orchestrator
+                {:discovery-interval-ms 60000
+                 :poll-interval-ms 5000})]
+      (is (= 60000 (:discovery-interval-ms orch)))
+      (is (= 5000 (:poll-interval-ms orch))))))
+
+(deftest ^{:stratum 0} create-orchestrator-zero-intervals-test
+  (testing "zero intervals are accepted (caller's responsibility)"
+    (let [orch (sut/create-orchestrator
+                {:discovery-interval-ms 0
+                 :poll-interval-ms 0})]
+      (is (= 0 (:discovery-interval-ms orch)))
+      (is (= 0 (:poll-interval-ms orch))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} wait-until-count
+  "Block until `(count @items-atom) >= n` or `timeout-ms` elapses.
+   Uses add-watch + promise — no fixed sleep. Returns true if reached, false on timeout."
+  ([items-atom n] (wait-until-count items-atom n default-wait-timeout-ms))
+  ([items-atom n timeout-ms]
+   (let [done (promise)
+         k    (gensym "wait-count-")]
+     (when (>= (count @items-atom) n)
+       (deliver done :immediate))
+     (add-watch items-atom k
+                (fn [_ _ _ new-val]
+                  (when (>= (count new-val) n)
+                    (deliver done :reached))))
+     (let [result (deref done timeout-ms ::timeout)]
+       (remove-watch items-atom k)
+       (not= result ::timeout)))))
+
+;; ---------------------------------------------------------------------------
 ;; Discovery: adapter returns nil instead of empty seq
 ;; ---------------------------------------------------------------------------
-
-(deftest run-discovery-pass-adapter-returns-nil-test
+(deftest ^{:stratum 1} run-discovery-pass-adapter-returns-nil-test
   (testing "discovery pass handles adapter returning nil (not empty seq)"
     (let [reg (registry/create-registry)
           adapter (make-mock-adapter
@@ -92,8 +112,7 @@
 ;; ---------------------------------------------------------------------------
 ;; Discovery: duplicate external-ids across adapters
 ;; ---------------------------------------------------------------------------
-
-(deftest run-discovery-pass-duplicate-ext-id-across-adapters-test
+(deftest ^{:stratum 1} run-discovery-pass-duplicate-ext-id-across-adapters-test
   (testing "same external-id from two adapters only registers once"
     (let [reg (registry/create-registry)
           discovered (atom [])
@@ -120,8 +139,7 @@
 ;; ---------------------------------------------------------------------------
 ;; Poll: adapter returns status-update without :agent/status key
 ;; ---------------------------------------------------------------------------
-
-(deftest run-poll-pass-status-update-missing-status-key-test
+(deftest ^{:stratum 1} run-poll-pass-status-update-missing-status-key-test
   (testing "poll pass handles status update map without :agent/status"
     (let [reg (registry/create-registry)
           _ (registry/register-agent! reg
@@ -139,37 +157,9 @@
           "should not throw when status key is missing"))))
 
 ;; ---------------------------------------------------------------------------
-;; Poll: status changes emit correct old/new values
-;; ---------------------------------------------------------------------------
-
-(deftest run-poll-pass-status-change-event-values-test
-  (testing "poll emits state-changed with correct old and new status values"
-    (let [reg (registry/create-registry)
-          es (stream/create-event-stream {:sinks []})
-          published (atom [])
-          _ (stream/subscribe! es :test-sub #(swap! published conj %))
-          _agent-rec (registry/register-agent! reg
-                      {:agent/external-id "ext-change"
-                       :agent/name "Change Agent"
-                       :agent/vendor :test-adapter})
-          ;; Agent starts as :unknown (default), poll returns :running
-          adapter (make-mock-adapter
-                   {:poll-agent-status
-                    (fn [_] {:status :running})})
-          orch (sut/create-orchestrator
-                (base-opts {:registry reg
-                            :adapters [adapter]
-                            :event-stream es}))]
-      (#'sut/run-poll-pass orch)
-      ;; Verify at least one event was published with state change
-      (is (wait-until-count published 1)
-          "should emit event for status change"))))
-
-;; ---------------------------------------------------------------------------
 ;; resolve-and-deliver!: adapter throws during delivery
 ;; ---------------------------------------------------------------------------
-
-(deftest resolve-and-deliver-adapter-throws-test
+(deftest ^{:stratum 1} resolve-and-deliver-adapter-throws-test
   (testing "resolve-and-deliver! handles adapter throwing during delivery"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -196,8 +186,7 @@
 ;; ---------------------------------------------------------------------------
 ;; resolve-and-deliver!: already-resolved decision
 ;; ---------------------------------------------------------------------------
-
-(deftest resolve-and-deliver-already-resolved-test
+(deftest ^{:stratum 1} resolve-and-deliver-already-resolved-test
   (testing "resolve-and-deliver! on already-resolved decision returns nil"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -226,8 +215,7 @@
 ;; ---------------------------------------------------------------------------
 ;; submit-decision-from-agent!: no opts provided (varargs edge case)
 ;; ---------------------------------------------------------------------------
-
-(deftest submit-decision-no-opts-test
+(deftest ^{:stratum 1} submit-decision-no-opts-test
   (testing "submit-decision-from-agent! works with only required args (no opts)"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -244,36 +232,9 @@
       (is (= "Simple question" (:decision/summary decision))))))
 
 ;; ---------------------------------------------------------------------------
-;; submit-decision-from-agent!: with event stream, event has correct fields
-;; ---------------------------------------------------------------------------
-
-(deftest submit-decision-event-fields-test
-  (testing "decision-created event contains agent-id and summary"
-    (let [reg (registry/create-registry)
-          dm (dq/create-decision-manager)
-          es (stream/create-event-stream {:sinks []})
-          published (atom [])
-          _ (stream/subscribe! es :test-sub #(swap! published conj %))
-          agent-rec (register-running-agent! reg
-                     {:agent/external-id "ext-evfield"
-                      :agent/name "EvField Agent"
-                      :agent/vendor :test-adapter})
-          orch (sut/create-orchestrator
-                (base-opts {:registry reg
-                            :decision-manager dm
-                            :event-stream es}))
-          decision (sut/submit-decision-from-agent!
-                    orch (:agent/id agent-rec) "Event field test")]
-      (is (wait-until-count published 1)
-          "should have published decision-created event")
-      ;; Verify the returned decision is well-formed
-      (is (= (:agent/id agent-rec) (:decision/agent-id decision))))))
-
-;; ---------------------------------------------------------------------------
 ;; Concurrent discovery passes don't duplicate registrations
 ;; ---------------------------------------------------------------------------
-
-(deftest concurrent-discovery-no-duplicates-test
+(deftest ^{:stratum 1} concurrent-discovery-no-duplicates-test
   (testing "concurrent discovery passes don't create duplicate agent registrations"
     (let [reg (registry/create-registry)
           call-count (atom 0)
@@ -301,8 +262,7 @@
 ;; ---------------------------------------------------------------------------
 ;; start!/stop! with active discovery finding agents
 ;; ---------------------------------------------------------------------------
-
-(deftest start-stop-rapid-cycling-test
+(deftest ^{:stratum 1} start-stop-rapid-cycling-test
   (testing "rapid start/stop cycling doesn't leave orphaned threads"
     (let [adapter (make-mock-adapter {})
           orch (sut/create-orchestrator
@@ -321,8 +281,7 @@
 ;; ---------------------------------------------------------------------------
 ;; start! sets up watchdog correctly
 ;; ---------------------------------------------------------------------------
-
-(deftest start-watchdog-uses-poll-interval-test
+(deftest ^{:stratum 1} start-watchdog-uses-poll-interval-test
   (testing "start! creates watchdog that uses poll-interval-ms"
     (let [orch (sut/create-orchestrator
                 (base-opts {:poll-interval-ms 100}))
@@ -336,8 +295,7 @@
 ;; ---------------------------------------------------------------------------
 ;; stop! cancels all futures
 ;; ---------------------------------------------------------------------------
-
-(deftest stop-cancels-futures-test
+(deftest ^{:stratum 1} stop-cancels-futures-test
   (testing "stop! cancels futures and clears them"
     (let [adapter (make-mock-adapter {})
           orch (sut/create-orchestrator
@@ -360,8 +318,7 @@
 ;; ---------------------------------------------------------------------------
 ;; resolve-and-deliver! transitions agent back to running
 ;; ---------------------------------------------------------------------------
-
-(deftest resolve-and-deliver-agent-transitions-blocked-to-running-test
+(deftest ^{:stratum 1} resolve-and-deliver-agent-transitions-blocked-to-running-test
   (testing "agent goes :running -> :blocked (submit) -> :running (resolve)"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -388,8 +345,7 @@
 ;; ---------------------------------------------------------------------------
 ;; resolve-and-deliver! with comment=nil
 ;; ---------------------------------------------------------------------------
-
-(deftest resolve-and-deliver-nil-comment-test
+(deftest ^{:stratum 1} resolve-and-deliver-nil-comment-test
   (testing "resolve-and-deliver! with explicit nil comment"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -414,8 +370,7 @@
 ;; ---------------------------------------------------------------------------
 ;; Discovery: agent-info with extra metadata fields
 ;; ---------------------------------------------------------------------------
-
-(deftest run-discovery-pass-agent-with-capabilities-and-metadata-test
+(deftest ^{:stratum 1} run-discovery-pass-agent-with-capabilities-and-metadata-test
   (testing "discovery pass handles agents with rich metadata"
     (let [reg (registry/create-registry)
           discovered (atom [])
@@ -439,8 +394,7 @@
 ;; ---------------------------------------------------------------------------
 ;; Poll pass: adapter returns status for already-transitioning agent
 ;; ---------------------------------------------------------------------------
-
-(deftest run-poll-pass-polls-blocked-agents-test
+(deftest ^{:stratum 1} run-poll-pass-polls-blocked-agents-test
   (testing "poll pass does poll agents with :blocked status (not terminal)"
     (let [reg (registry/create-registry)
           poll-count (atom 0)
@@ -460,7 +414,7 @@
       (is (= 1 @poll-count)
           "should poll :blocked agents since they are not terminal"))))
 
-(deftest run-poll-pass-polls-idle-agents-test
+(deftest ^{:stratum 1} run-poll-pass-polls-idle-agents-test
   (testing "poll pass polls agents with :idle status"
     (let [reg (registry/create-registry)
           poll-count (atom 0)
@@ -483,8 +437,7 @@
 ;; ---------------------------------------------------------------------------
 ;; submit-decision-from-agent!: returns decision with correct agent-id
 ;; ---------------------------------------------------------------------------
-
-(deftest submit-decision-decision-stored-in-manager-test
+(deftest ^{:stratum 1} submit-decision-decision-stored-in-manager-test
   (testing "submitted decision is retrievable from the decision manager"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -504,8 +457,7 @@
 ;; ---------------------------------------------------------------------------
 ;; resolve-and-deliver!: decision resolved data matches
 ;; ---------------------------------------------------------------------------
-
-(deftest resolve-and-deliver-passes-resolved-decision-to-adapter-test
+(deftest ^{:stratum 1} resolve-and-deliver-passes-resolved-decision-to-adapter-test
   (testing "adapter receives the resolved decision with resolution"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -532,30 +484,9 @@
       (is (= "Ship it" (:decision/comment @delivered-data))))))
 
 ;; ---------------------------------------------------------------------------
-;; create-orchestrator: interval values
-;; ---------------------------------------------------------------------------
-
-(deftest create-orchestrator-custom-intervals-test
-  (testing "custom interval values are stored correctly"
-    (let [orch (sut/create-orchestrator
-                {:discovery-interval-ms 60000
-                 :poll-interval-ms 5000})]
-      (is (= 60000 (:discovery-interval-ms orch)))
-      (is (= 5000 (:poll-interval-ms orch))))))
-
-(deftest create-orchestrator-zero-intervals-test
-  (testing "zero intervals are accepted (caller's responsibility)"
-    (let [orch (sut/create-orchestrator
-                {:discovery-interval-ms 0
-                 :poll-interval-ms 0})]
-      (is (= 0 (:discovery-interval-ms orch)))
-      (is (= 0 (:poll-interval-ms orch))))))
-
-;; ---------------------------------------------------------------------------
 ;; Integration: multiple agents, mixed statuses
 ;; ---------------------------------------------------------------------------
-
-(deftest poll-pass-mixed-statuses-test
+(deftest ^{:stratum 1} poll-pass-mixed-statuses-test
   (testing "poll correctly handles mix of terminal and non-terminal agents"
     (let [reg (registry/create-registry)
           poll-log (atom [])
@@ -595,8 +526,7 @@
 ;; ---------------------------------------------------------------------------
 ;; Integration: decision lifecycle with multiple agents
 ;; ---------------------------------------------------------------------------
-
-(deftest multiple-agents-independent-decisions-test
+(deftest ^{:stratum 1} multiple-agents-independent-decisions-test
   (testing "decisions for different agents are independent"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -629,3 +559,56 @@
       ;; Resolve d2
       (sut/resolve-and-deliver! orch (:decision/id d2) "no")
       (is (= :running (:agent/status (registry/get-agent reg (:agent/id a2))))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; ---------------------------------------------------------------------------
+;; Poll: status changes emit correct old/new values
+;; ---------------------------------------------------------------------------
+(deftest ^{:stratum 2} run-poll-pass-status-change-event-values-test
+  (testing "poll emits state-changed with correct old and new status values"
+    (let [reg (registry/create-registry)
+          es (stream/create-event-stream {:sinks []})
+          published (atom [])
+          _ (stream/subscribe! es :test-sub #(swap! published conj %))
+          _agent-rec (registry/register-agent! reg
+                      {:agent/external-id "ext-change"
+                       :agent/name "Change Agent"
+                       :agent/vendor :test-adapter})
+          ;; Agent starts as :unknown (default), poll returns :running
+          adapter (make-mock-adapter
+                   {:poll-agent-status
+                    (fn [_] {:status :running})})
+          orch (sut/create-orchestrator
+                (base-opts {:registry reg
+                            :adapters [adapter]
+                            :event-stream es}))]
+      (#'sut/run-poll-pass orch)
+      ;; Verify at least one event was published with state change
+      (is (wait-until-count published 1)
+          "should emit event for status change"))))
+
+;; ---------------------------------------------------------------------------
+;; submit-decision-from-agent!: with event stream, event has correct fields
+;; ---------------------------------------------------------------------------
+(deftest ^{:stratum 2} submit-decision-event-fields-test
+  (testing "decision-created event contains agent-id and summary"
+    (let [reg (registry/create-registry)
+          dm (dq/create-decision-manager)
+          es (stream/create-event-stream {:sinks []})
+          published (atom [])
+          _ (stream/subscribe! es :test-sub #(swap! published conj %))
+          agent-rec (register-running-agent! reg
+                     {:agent/external-id "ext-evfield"
+                      :agent/name "EvField Agent"
+                      :agent/vendor :test-adapter})
+          orch (sut/create-orchestrator
+                (base-opts {:registry reg
+                            :decision-manager dm
+                            :event-stream es}))
+          decision (sut/submit-decision-from-agent!
+                    orch (:agent/id agent-rec) "Event field test")]
+      (is (wait-until-count published 1)
+          "should have published decision-created event")
+      ;; Verify the returned decision is well-formed
+      (is (= (:agent/id agent-rec) (:decision/agent-id decision))))))

--- a/components/control-plane/test/ai/miniforge/control_plane/orchestrator_test.clj
+++ b/components/control-plane/test/ai/miniforge/control_plane/orchestrator_test.clj
@@ -1,7 +1,6 @@
 ;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
 ;;
 ;; Licensed under the Apache License, Version 2.0
-
 (ns ai.miniforge.control-plane.orchestrator-test
   (:require
    [clojure.test :refer [deftest testing is]]
@@ -11,11 +10,12 @@
    [ai.miniforge.control-plane-adapter.protocol :as adapter]
    [ai.miniforge.event-stream.interface.stream :as stream]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; ---------------------------------------------------------------------------
 ;; Test helpers
 ;; ---------------------------------------------------------------------------
-
-(defn make-mock-adapter
+(defn ^{:stratum 0} make-mock-adapter
   "Create a mock adapter implementing ControlPlaneAdapter.
    `overrides` is a map of {:discover-agents fn, :poll-agent-status fn,
                              :deliver-decision fn, :send-command fn, :adapter-id kw}."
@@ -40,61 +40,21 @@
           (f agent-record command)
           {:success? true})))))
 
-(defn make-test-event-stream
+(defn ^{:stratum 0} make-test-event-stream
   "Create a minimal event stream that captures published events."
   []
   (let [events-atom (atom [])]
     {:stream (stream/create-event-stream {:sinks []})
      :published events-atom}))
 
-(def ^:private default-wait-timeout-ms 2000)
+(def ^{:stratum 0} ^:private default-wait-timeout-ms 2000)
 
-(defn- wait-until-count
-  "Block until `(count @items-atom) >= n` or `timeout-ms` elapses.
-   Uses add-watch + promise — no fixed sleep. Returns true if reached, false on timeout."
-  ([items-atom n] (wait-until-count items-atom n default-wait-timeout-ms))
-  ([items-atom n timeout-ms]
-   (let [done (promise)
-         k    (gensym "wait-count-")]
-     (when (>= (count @items-atom) n)
-       (deliver done :immediate))
-     (add-watch items-atom k
-                (fn [_ _ _ new-val]
-                  (when (>= (count new-val) n)
-                    (deliver done :reached))))
-     (let [result (deref done timeout-ms ::timeout)]
-       (remove-watch items-atom k)
-       (not= result ::timeout)))))
-
-(defn- wait-until
-  "Block until `(pred)` returns truthy or `timeout-ms` elapses.
-   Returns true if pred satisfied, false on timeout."
-  ([pred] (wait-until pred default-wait-timeout-ms))
-  ([pred timeout-ms]
-   (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
-     (loop []
-       (cond
-         (pred) true
-         (> (System/currentTimeMillis) deadline) false
-         :else (do (java.util.concurrent.locks.LockSupport/parkNanos 1000000)
-                   (recur)))))))
-
-(def test-workflow-id (java.util.UUID/fromString "00000000-0000-0000-0000-000000000001"))
-
-(defn base-orchestrator-opts
-  "Minimal valid opts for creating an orchestrator."
-  [& [overrides]]
-  (merge {:adapters []
-          :workflow-id test-workflow-id
-          :discovery-interval-ms 50
-          :poll-interval-ms 50}
-         overrides))
+(def ^{:stratum 0} test-workflow-id (java.util.UUID/fromString "00000000-0000-0000-0000-000000000001"))
 
 ;; ---------------------------------------------------------------------------
-;; Layer 0: create-orchestrator
+;; create-orchestrator
 ;; ---------------------------------------------------------------------------
-
-(deftest create-orchestrator-defaults-test
+(deftest ^{:stratum 0} create-orchestrator-defaults-test
   (testing "creates orchestrator with default values when minimal opts given"
     (let [orch (sut/create-orchestrator {})]
       (is (some? (:registry orch))
@@ -122,7 +82,92 @@
       (is (empty? @(:futures orch))
           "should have no futures initially"))))
 
-(deftest create-orchestrator-custom-opts-test
+(deftest ^{:stratum 0} create-orchestrator-default-callbacks-are-safe-test
+  (testing "default callbacks can be called without error"
+    (let [orch (sut/create-orchestrator {})]
+      (is (nil? ((:on-agent-discovered orch) {:agent/id (random-uuid)})))
+      (is (nil? ((:on-agent-unreachable orch) (random-uuid))))
+      (is (nil? ((:on-decision-created orch) {:decision/id (random-uuid)}))))))
+
+(deftest ^{:stratum 0} create-orchestrator-running-and-futures-are-atoms-test
+  (testing "running and futures are independent atoms per orchestrator"
+    (let [orch1 (sut/create-orchestrator {})
+          orch2 (sut/create-orchestrator {})]
+      (reset! (:running orch1) true)
+      (is (true? @(:running orch1)))
+      (is (false? @(:running orch2))
+          "orch2 running should be independent of orch1"))))
+
+;; ---------------------------------------------------------------------------
+;; Constants
+;; ---------------------------------------------------------------------------
+(deftest ^{:stratum 0} default-constants-test
+  (testing "default interval constants are positive integers"
+    (is (pos-int? sut/default-discovery-interval-ms))
+    (is (pos-int? sut/default-poll-interval-ms))
+    (is (= 30000 sut/default-discovery-interval-ms))
+    (is (= 10000 sut/default-poll-interval-ms))))
+
+;; ---------------------------------------------------------------------------
+;; Edge cases
+;; ---------------------------------------------------------------------------
+(deftest ^{:stratum 0} create-orchestrator-nil-adapters-test
+  (testing "nil adapters defaults to empty vector"
+    (let [orch (sut/create-orchestrator {:adapters nil})]
+      (is (= [] (:adapters orch))))))
+
+(deftest ^{:stratum 0} create-orchestrator-empty-opts-test
+  (testing "create-orchestrator works with completely empty opts map"
+    (let [orch (sut/create-orchestrator {})]
+      (is (some? orch))
+      (is (some? (:registry orch)))
+      (is (some? (:decision-manager orch)))
+      (is (= [] (:adapters orch)))
+      (is (instance? clojure.lang.Atom (:running orch)))
+      (is (instance? clojure.lang.Atom (:futures orch))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} wait-until-count
+  "Block until `(count @items-atom) >= n` or `timeout-ms` elapses.
+   Uses add-watch + promise — no fixed sleep. Returns true if reached, false on timeout."
+  ([items-atom n] (wait-until-count items-atom n default-wait-timeout-ms))
+  ([items-atom n timeout-ms]
+   (let [done (promise)
+         k    (gensym "wait-count-")]
+     (when (>= (count @items-atom) n)
+       (deliver done :immediate))
+     (add-watch items-atom k
+                (fn [_ _ _ new-val]
+                  (when (>= (count new-val) n)
+                    (deliver done :reached))))
+     (let [result (deref done timeout-ms ::timeout)]
+       (remove-watch items-atom k)
+       (not= result ::timeout)))))
+
+(defn- ^{:stratum 1} wait-until
+  "Block until `(pred)` returns truthy or `timeout-ms` elapses.
+   Returns true if pred satisfied, false on timeout."
+  ([pred] (wait-until pred default-wait-timeout-ms))
+  ([pred timeout-ms]
+   (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
+     (loop []
+       (cond
+         (pred) true
+         (> (System/currentTimeMillis) deadline) false
+         :else (do (java.util.concurrent.locks.LockSupport/parkNanos 1000000)
+                   (recur)))))))
+
+(defn ^{:stratum 1} base-orchestrator-opts
+  "Minimal valid opts for creating an orchestrator."
+  [& [overrides]]
+  (merge {:adapters []
+          :workflow-id test-workflow-id
+          :discovery-interval-ms 50
+          :poll-interval-ms 50}
+         overrides))
+
+(deftest ^{:stratum 1} create-orchestrator-custom-opts-test
   (testing "respects all provided options"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -159,7 +204,7 @@
       ((:on-agent-discovered orch) :test-agent)
       (is (= :test-agent @discovered-atom)))))
 
-(deftest create-orchestrator-multiple-adapters-test
+(deftest ^{:stratum 1} create-orchestrator-multiple-adapters-test
   (testing "supports multiple adapters as a vector"
     (let [a1 (make-mock-adapter {:adapter-id :adapter-1})
           a2 (make-mock-adapter {:adapter-id :adapter-2})
@@ -168,38 +213,12 @@
       (is (= :adapter-1 (adapter/adapter-id (first (:adapters orch)))))
       (is (= :adapter-2 (adapter/adapter-id (second (:adapters orch))))))))
 
-(deftest create-orchestrator-default-callbacks-are-safe-test
-  (testing "default callbacks can be called without error"
-    (let [orch (sut/create-orchestrator {})]
-      (is (nil? ((:on-agent-discovered orch) {:agent/id (random-uuid)})))
-      (is (nil? ((:on-agent-unreachable orch) (random-uuid))))
-      (is (nil? ((:on-decision-created orch) {:decision/id (random-uuid)}))))))
-
-(deftest create-orchestrator-running-and-futures-are-atoms-test
-  (testing "running and futures are independent atoms per orchestrator"
-    (let [orch1 (sut/create-orchestrator {})
-          orch2 (sut/create-orchestrator {})]
-      (reset! (:running orch1) true)
-      (is (true? @(:running orch1)))
-      (is (false? @(:running orch2))
-          "orch2 running should be independent of orch1"))))
+;------------------------------------------------------------------------------ Layer 2
 
 ;; ---------------------------------------------------------------------------
-;; Constants
+;; Discovery pass (unit-level, calling private fn via #')
 ;; ---------------------------------------------------------------------------
-
-(deftest default-constants-test
-  (testing "default interval constants are positive integers"
-    (is (pos-int? sut/default-discovery-interval-ms))
-    (is (pos-int? sut/default-poll-interval-ms))
-    (is (= 30000 sut/default-discovery-interval-ms))
-    (is (= 10000 sut/default-poll-interval-ms))))
-
-;; ---------------------------------------------------------------------------
-;; Layer 1: Discovery pass (unit-level, calling private fn via #')
-;; ---------------------------------------------------------------------------
-
-(deftest run-discovery-pass-registers-new-agents-test
+(deftest ^{:stratum 2} run-discovery-pass-registers-new-agents-test
   (testing "discovery pass registers newly discovered agents"
     (let [reg (registry/create-registry)
           discovered (atom [])
@@ -221,7 +240,7 @@
           "on-agent-discovered callback should have been called")
       (is (= "Test Agent" (:agent/name (first @discovered)))))))
 
-(deftest run-discovery-pass-skips-known-agents-test
+(deftest ^{:stratum 2} run-discovery-pass-skips-known-agents-test
   (testing "discovery pass does not re-register known agents"
     (let [reg (registry/create-registry)
           discovered (atom [])
@@ -244,7 +263,7 @@
       (is (= 1 (count @discovered))
           "callback should only fire once"))))
 
-(deftest run-discovery-pass-handles-adapter-exception-test
+(deftest ^{:stratum 2} run-discovery-pass-handles-adapter-exception-test
   (testing "discovery pass catches exceptions from adapter"
     (let [reg (registry/create-registry)
           adapter (make-mock-adapter
@@ -255,7 +274,7 @@
       ;; Should not throw
       (is (nil? (#'sut/run-discovery-pass orch))))))
 
-(deftest run-discovery-pass-multiple-adapters-test
+(deftest ^{:stratum 2} run-discovery-pass-multiple-adapters-test
   (testing "discovery across multiple adapters"
     (let [reg (registry/create-registry)
           a1 (make-mock-adapter
@@ -273,7 +292,7 @@
       (#'sut/run-discovery-pass orch)
       (is (= 2 (registry/count-agents reg))))))
 
-(deftest run-discovery-pass-with-event-stream-test
+(deftest ^{:stratum 2} run-discovery-pass-with-event-stream-test
   (testing "discovery emits agent-registered events when stream is present"
     (let [reg (registry/create-registry)
           es (stream/create-event-stream {:sinks []})
@@ -293,7 +312,7 @@
       (is (wait-until-count published 1)
           "should have published at least one event"))))
 
-(deftest run-discovery-pass-empty-results-test
+(deftest ^{:stratum 2} run-discovery-pass-empty-results-test
   (testing "discovery pass handles adapter returning empty list"
     (let [reg (registry/create-registry)
           adapter (make-mock-adapter
@@ -305,7 +324,7 @@
       (is (zero? (registry/count-agents reg))
           "no agents should be registered when none discovered"))))
 
-(deftest run-discovery-pass-multiple-agents-one-adapter-test
+(deftest ^{:stratum 2} run-discovery-pass-multiple-agents-one-adapter-test
   (testing "discovery pass registers multiple agents from a single adapter"
     (let [reg (registry/create-registry)
           discovered (atom [])
@@ -325,7 +344,7 @@
       (is (= 3 (count @discovered))
           "callback should fire for each new agent"))))
 
-(deftest run-discovery-pass-partial-failure-test
+(deftest ^{:stratum 2} run-discovery-pass-partial-failure-test
   (testing "discovery continues with second adapter when first throws"
     (let [reg (registry/create-registry)
           failing-adapter (make-mock-adapter
@@ -344,10 +363,9 @@
           "should still register agents from non-failing adapter"))))
 
 ;; ---------------------------------------------------------------------------
-;; Layer 1: Poll pass
+;; Poll pass
 ;; ---------------------------------------------------------------------------
-
-(deftest run-poll-pass-updates-agent-status-test
+(deftest ^{:stratum 2} run-poll-pass-updates-agent-status-test
   (testing "poll pass records heartbeat and detects status changes"
     (let [reg (registry/create-registry)
           agent-rec (registry/register-agent! reg
@@ -368,7 +386,7 @@
         (is (some? (:agent/last-heartbeat updated))
             "heartbeat should be recorded")))))
 
-(deftest run-poll-pass-skips-terminal-agents-test
+(deftest ^{:stratum 2} run-poll-pass-skips-terminal-agents-test
   (testing "poll pass skips agents with terminal status"
     (let [reg (registry/create-registry)
           poll-count (atom 0)
@@ -388,7 +406,7 @@
       (is (zero? @poll-count)
           "should not poll terminal agents"))))
 
-(deftest run-poll-pass-skips-failed-agents-test
+(deftest ^{:stratum 2} run-poll-pass-skips-failed-agents-test
   (testing "poll pass skips agents with :failed status"
     (let [reg (registry/create-registry)
           poll-count (atom 0)
@@ -408,7 +426,7 @@
       (is (zero? @poll-count)
           "should not poll failed agents"))))
 
-(deftest run-poll-pass-skips-terminated-agents-test
+(deftest ^{:stratum 2} run-poll-pass-skips-terminated-agents-test
   (testing "poll pass skips agents with :terminated status"
     (let [reg (registry/create-registry)
           poll-count (atom 0)
@@ -428,7 +446,7 @@
       (is (zero? @poll-count)
           "should not poll terminated agents"))))
 
-(deftest run-poll-pass-handles-poll-exception-test
+(deftest ^{:stratum 2} run-poll-pass-handles-poll-exception-test
   (testing "poll pass catches exceptions from adapter poll"
     (let [reg (registry/create-registry)
           _ (registry/register-agent! reg
@@ -444,7 +462,7 @@
       ;; Should not throw
       (is (nil? (#'sut/run-poll-pass orch))))))
 
-(deftest run-poll-pass-nil-status-update-test
+(deftest ^{:stratum 2} run-poll-pass-nil-status-update-test
   (testing "poll pass handles nil status update gracefully"
     (let [reg (registry/create-registry)
           _ (registry/register-agent! reg
@@ -459,7 +477,7 @@
       ;; Should not throw when poll returns nil
       (is (nil? (#'sut/run-poll-pass orch))))))
 
-(deftest run-poll-pass-with-event-stream-emits-on-status-change-test
+(deftest ^{:stratum 2} run-poll-pass-with-event-stream-emits-on-status-change-test
   (testing "poll pass emits agent-state-changed event when status changes"
     (let [reg (registry/create-registry)
           es (stream/create-event-stream {:sinks []})
@@ -483,7 +501,7 @@
       (is (wait-until-count published 1)
           "should have published at least one state-changed event"))))
 
-(deftest run-poll-pass-no-event-when-status-unchanged-test
+(deftest ^{:stratum 2} run-poll-pass-no-event-when-status-unchanged-test
   (testing "poll pass keeps heartbeats but skips state-changed when status remains the same"
     (let [reg (registry/create-registry)
           es (stream/create-event-stream {:sinks []})
@@ -508,7 +526,7 @@
         (is (= [:control-plane/agent-heartbeat] event-types)
             "stable polls should publish heartbeat context but not a state change")))))
 
-(deftest run-poll-pass-multiple-vendors-test
+(deftest ^{:stratum 2} run-poll-pass-multiple-vendors-test
   (testing "poll pass routes agents to correct adapters by vendor"
     (let [reg (registry/create-registry)
           poll-log (atom [])
@@ -535,7 +553,7 @@
       (is (some #(= [:vendor-1 "V1 Agent"] %) @poll-log))
       (is (some #(= [:vendor-2 "V2 Agent"] %) @poll-log)))))
 
-(deftest run-poll-pass-unmatched-vendor-test
+(deftest ^{:stratum 2} run-poll-pass-unmatched-vendor-test
   (testing "poll pass skips agents whose vendor has no matching adapter"
     (let [reg (registry/create-registry)
           poll-count (atom 0)
@@ -552,10 +570,9 @@
           "should not poll agents with unmatched vendor"))))
 
 ;; ---------------------------------------------------------------------------
-;; Layer 2: start! and stop!
+;; start! and stop!
 ;; ---------------------------------------------------------------------------
-
-(deftest start-stop-lifecycle-test
+(deftest ^{:stratum 2} start-stop-lifecycle-test
   (testing "start! sets running to true and stop! cleans up"
     (let [adapter (make-mock-adapter {})
           orch (sut/create-orchestrator
@@ -572,7 +589,7 @@
         (is (empty? @(:futures stopped))
             "futures should be cleared after stop")))))
 
-(deftest start-runs-discovery-test
+(deftest ^{:stratum 2} start-runs-discovery-test
   (testing "start! triggers discovery loop that finds agents"
     (let [reg (registry/create-registry)
           discovered (atom [])
@@ -603,7 +620,7 @@
       (is (pos? (count @discovered))
           "on-agent-discovered should have been called"))))
 
-(deftest stop-idempotent-test
+(deftest ^{:stratum 2} stop-idempotent-test
   (testing "stop! can be called multiple times safely"
     (let [orch (sut/create-orchestrator (base-orchestrator-opts))]
       (sut/start! orch)
@@ -611,7 +628,7 @@
       ;; Second stop should not throw
       (is (some? (sut/stop! orch))))))
 
-(deftest start-returns-orchestrator-with-watchdog-test
+(deftest ^{:stratum 2} start-returns-orchestrator-with-watchdog-test
   (testing "start! returns orchestrator with :watchdog key"
     (let [orch (sut/create-orchestrator (base-orchestrator-opts))
           started (sut/start! orch)]
@@ -619,7 +636,7 @@
           "should have a watchdog after start")
       (sut/stop! started))))
 
-(deftest stop-clears-running-flag-immediately-test
+(deftest ^{:stratum 2} stop-clears-running-flag-immediately-test
   (testing "stop! sets running to false immediately"
     (let [orch (sut/create-orchestrator (base-orchestrator-opts))]
       (sut/start! orch)
@@ -627,7 +644,7 @@
       (sut/stop! orch)
       (is (false? @(:running orch))))))
 
-(deftest stop-on-never-started-orchestrator-test
+(deftest ^{:stratum 2} stop-on-never-started-orchestrator-test
   (testing "stop! on a never-started orchestrator is safe"
     (let [orch (sut/create-orchestrator (base-orchestrator-opts))]
       (is (some? (sut/stop! orch))
@@ -635,10 +652,9 @@
       (is (false? @(:running orch))))))
 
 ;; ---------------------------------------------------------------------------
-;; Layer 2: submit-decision-from-agent!
+;; submit-decision-from-agent!
 ;; ---------------------------------------------------------------------------
-
-(deftest submit-decision-from-agent-test
+(deftest ^{:stratum 2} submit-decision-from-agent-test
   (testing "submits a decision, transitions agent to :blocked, fires callback"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -672,7 +688,7 @@
       ;; Decision should be in the manager
       (is (some? (dq/get-decision dm (:decision/id decision)))))))
 
-(deftest submit-decision-with-opts-test
+(deftest ^{:stratum 2} submit-decision-with-opts-test
   (testing "submit-decision-from-agent! passes opts to create-decision"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -692,7 +708,7 @@
       (is (= :high (:decision/priority decision)))
       (is (= :choice (:decision/type decision))))))
 
-(deftest submit-decision-terminal-agent-test
+(deftest ^{:stratum 2} submit-decision-terminal-agent-test
   (testing "submit-decision-from-agent! handles already-terminal agent gracefully"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -711,7 +727,7 @@
       (is (some? decision)
           "decision should still be created even if transition fails"))))
 
-(deftest submit-decision-with-event-stream-test
+(deftest ^{:stratum 2} submit-decision-with-event-stream-test
   (testing "submit-decision-from-agent! emits decision-created event"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -733,7 +749,7 @@
       (is (wait-until-count published 1)
           "should have published a decision-created event"))))
 
-(deftest submit-multiple-decisions-same-agent-test
+(deftest ^{:stratum 2} submit-multiple-decisions-same-agent-test
   (testing "can submit multiple decisions for the same agent"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -757,10 +773,9 @@
           "both decisions should be in the manager"))))
 
 ;; ---------------------------------------------------------------------------
-;; Layer 2: resolve-and-deliver!
+;; resolve-and-deliver!
 ;; ---------------------------------------------------------------------------
-
-(deftest resolve-and-deliver-test
+(deftest ^{:stratum 2} resolve-and-deliver-test
   (testing "resolves decision, delivers to agent, transitions back to :running"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -795,7 +810,7 @@
         (is (= :running (:agent/status agent))
             "agent should be transitioned back to :running")))))
 
-(deftest resolve-and-deliver-unknown-decision-test
+(deftest ^{:stratum 2} resolve-and-deliver-unknown-decision-test
   (testing "resolve-and-deliver! returns nil for unknown decision ID"
     (let [orch (sut/create-orchestrator (base-orchestrator-opts))
           result (sut/resolve-and-deliver!
@@ -803,7 +818,7 @@
       (is (nil? result)
           "should return nil when decision not found"))))
 
-(deftest resolve-and-deliver-no-adapter-test
+(deftest ^{:stratum 2} resolve-and-deliver-no-adapter-test
   (testing "resolve-and-deliver! handles missing adapter (delivery fails)"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -826,7 +841,7 @@
       (is (false? (:delivered? result))
           "delivery should be false when no adapter matches"))))
 
-(deftest resolve-and-deliver-with-event-stream-test
+(deftest ^{:stratum 2} resolve-and-deliver-with-event-stream-test
   (testing "resolve-and-deliver! emits decision-resolved event"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -854,7 +869,7 @@
       (is (wait-until-count published 2)
           "should have published decision-created and decision-resolved events"))))
 
-(deftest resolve-and-deliver-without-comment-test
+(deftest ^{:stratum 2} resolve-and-deliver-without-comment-test
   (testing "resolve-and-deliver! works without optional comment"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -875,7 +890,7 @@
       (is (some? (:resolved result)))
       (is (true? (:delivered? result))))))
 
-(deftest resolve-and-deliver-adapter-delivery-failure-test
+(deftest ^{:stratum 2} resolve-and-deliver-adapter-delivery-failure-test
   (testing "resolve-and-deliver! reports delivered? false when adapter returns failure"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -898,7 +913,7 @@
       (is (false? (:delivered? result))
           "delivered? should be false when adapter reports failure"))))
 
-(deftest resolve-and-deliver-resolved-data-contains-resolution-test
+(deftest ^{:stratum 2} resolve-and-deliver-resolved-data-contains-resolution-test
   (testing "the resolved decision contains the resolution value"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -922,8 +937,7 @@
 ;; ---------------------------------------------------------------------------
 ;; Integration: full lifecycle
 ;; ---------------------------------------------------------------------------
-
-(deftest full-lifecycle-integration-test
+(deftest ^{:stratum 2} full-lifecycle-integration-test
   (testing "end-to-end: create -> start -> discover -> decide -> resolve -> stop"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -968,7 +982,7 @@
       (sut/stop! orch)
       (is (false? @(:running orch))))))
 
-(deftest full-lifecycle-with-event-stream-integration-test
+(deftest ^{:stratum 2} full-lifecycle-with-event-stream-integration-test
   (testing "end-to-end with event stream captures all events"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -1007,16 +1021,7 @@
 
       (sut/stop! orch))))
 
-;; ---------------------------------------------------------------------------
-;; Edge cases
-;; ---------------------------------------------------------------------------
-
-(deftest create-orchestrator-nil-adapters-test
-  (testing "nil adapters defaults to empty vector"
-    (let [orch (sut/create-orchestrator {:adapters nil})]
-      (is (= [] (:adapters orch))))))
-
-(deftest discovery-with-no-adapters-test
+(deftest ^{:stratum 2} discovery-with-no-adapters-test
   (testing "discovery pass with no adapters is a no-op"
     (let [reg (registry/create-registry)
           orch (sut/create-orchestrator
@@ -1024,7 +1029,7 @@
       (#'sut/run-discovery-pass orch)
       (is (zero? (registry/count-agents reg))))))
 
-(deftest poll-pass-with-no-agents-test
+(deftest ^{:stratum 2} poll-pass-with-no-agents-test
   (testing "poll pass with empty registry is a no-op"
     (let [reg (registry/create-registry)
           poll-count (atom 0)
@@ -1037,7 +1042,7 @@
       (is (zero? @poll-count)
           "should not call poll when registry is empty"))))
 
-(deftest poll-pass-with-no-adapters-test
+(deftest ^{:stratum 2} poll-pass-with-no-adapters-test
   (testing "poll pass with no adapters is safe"
     (let [reg (registry/create-registry)
           _ (registry/register-agent! reg
@@ -1046,13 +1051,3 @@
                 (base-orchestrator-opts {:registry reg :adapters []}))]
       ;; Should not throw
       (is (nil? (#'sut/run-poll-pass orch))))))
-
-(deftest create-orchestrator-empty-opts-test
-  (testing "create-orchestrator works with completely empty opts map"
-    (let [orch (sut/create-orchestrator {})]
-      (is (some? orch))
-      (is (some? (:registry orch)))
-      (is (some? (:decision-manager orch)))
-      (is (= [] (:adapters orch)))
-      (is (instance? clojure.lang.Atom (:running orch)))
-      (is (instance? clojure.lang.Atom (:futures orch))))))

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-control-plane.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-control-plane.md
@@ -1,0 +1,155 @@
+# fix: stratum-lint autofix for components/control-plane (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over `components/control-plane` (`src` + `test`)
+to replace decorative/miscounted `Layer N` headings with real ones derived
+from each file's actual same-file reference graph, plus `^{:stratum n}`
+metadata on every def. One of the per-component Wave 1 PRs from
+`work/stratum-lint-baseline-2026-07-24.md`.
+
+Not purely mechanical: the autofix left behind stale prose in six ns
+docstrings and one test file's leftover banner comments that, after the
+real headings moved, either made a false claim about which layer held
+which concept or (in two spots) directly contradicted the real heading
+sitting right above them. Those are hand-fixed here — text-only, no
+logic or behavior change, but not something `--fix` itself did. Described
+plainly rather than left for review to catch.
+
+## Motivation
+
+Baseline (plain `stratum-lint`, no `--fix`) on this component:
+
+```text
+components/control-plane/src/ai/miniforge/control_plane/decision_queue.clj:232:1: SL003 file uses 4 distinct layers (max 3)
+components/control-plane/src/ai/miniforge/control_plane/interface.clj:47:1: SL002 Layer 0 heading appears after Layer 0
+components/control-plane/src/ai/miniforge/control_plane/interface.clj:190:1: SL003 file uses 5 distinct layers (max 3)
+components/control-plane/src/ai/miniforge/control_plane/registry.clj:192:1: SL003 file uses 4 distinct layers (max 3)
+```
+
+4 findings, 3 files, zero `SL001` — matches the Wave 1 batch criteria
+(no upward-reference/cycle risk to reason about before running the
+mechanical fixer).
+
+## Changes in Detail
+
+Ran, over the whole component:
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "14965e1ee1a175bd00f637d9a9d5f7d27e62b73f" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/control-plane
+```
+
+11 files rewritten — `--fix` normalizes every file in the component, not
+just the ones with findings:
+
+- `src`: `decision_queue.clj`, `heartbeat.clj`, `interface.clj`,
+  `messages.clj`, `orchestrator.clj`, `registry.clj`, `state_machine.clj`
+- `test`: `interface_test.clj`, `orchestrator_edge_test.clj`,
+  `orchestrator_supplemental_test.clj`, `orchestrator_test.clj`
+
+Notable recomputations:
+
+- `interface.clj` is a flat re-export facade (every def just aliases a
+  var from another component's namespace) — all 25 defs collapsed to a
+  single real Layer 0. Both prior findings (`SL002`, `SL003`) disappear.
+- `registry.clj`'s real structure is 2 layers, not the 4 its old headings
+  implied — its `SL003` finding disappears too.
+- `heartbeat.clj` and `state_machine.clj` weren't in the baseline findings
+  at all (their old headings were monotonic and within the 3-layer
+  budget), but the real reference graph puts each at 4 distinct layers —
+  `--fix` surfaces a `SL003` that didn't previously show, because the old
+  headings under-counted the real depth rather than over-counting it.
+- `decision_queue.clj` stays at 4 real layers — same finding as baseline,
+  just re-derived from the graph instead of hand-counted.
+
+No multimethods in this component, so the `defmethod`-stratum-placement
+bug class from the pinned fix doesn't apply here. No same-line trailing
+comment was displaced onto the wrong def (checked every diff by hand).
+
+### Hand-fixed: stale `Layer N` prose the autofix left behind
+
+Six ns docstrings (`decision_queue.clj`, `interface.clj`, `registry.clj`,
+`heartbeat.clj`, `orchestrator.clj`, `state_machine.clj`) carried a
+`Layer 0: <concept>` / `Layer 1: <concept>` ... breakdown that predates
+this fix. Once the real strata were recomputed, none of these lists still
+matched: concepts that used to map one-to-one to a layer number now split
+across layers, merged into one, or (for `interface.clj`) collapsed
+entirely to a single layer. Reworking the numbers to match would just
+re-drift on the next real edit, and the same information is already
+carried by the inline single-semicolon section comments (`;; Decision
+creation`, `;; Agent CRUD`, etc.) that the fix preserves right above each
+group of defs — so the `Layer N` breakdown was deleted from each
+docstring rather than relabeled.
+
+`orchestrator_test.clj` separately carried five older-style decorative
+banners of the form `;; Layer N: <description>` (a different artifact
+than the ns docstring lists above — these predate this file ever having
+real `Layer N` headings). Two of them were left flatly wrong by the fix:
+`;; Layer 1: Discovery pass ...` and `;; Layer 1: Poll pass` now sit
+immediately inside the real `Layer 2` block, contradicting it. The other
+three (`Layer 2: start! and stop!`, `Layer 2:
+submit-decision-from-agent!`, `Layer 2: resolve-and-deliver!`) still
+happened to agree with the real heading beside them, but carry the exact
+same staleness risk that just broke the first two. Reworded all five to
+drop the layer number and keep the description (e.g. `;; Poll pass`).
+
+## Testing Plan
+
+1. Ran plain `stratum-lint` before the fix — reproduced the baseline's 4
+   findings across 3 files exactly, confirmed 0 `SL001`.
+2. Ran `--fix`, then ran the identical `--fix` command a second time —
+   zero further changes (`git diff` before/after the second pass is
+   identical).
+3. Read the full diff of all 11 changed files. Found and hand-fixed the
+   stale `Layer N` prose described above; found no trailing-comment
+   reflow onto the wrong def.
+4. Re-ran `--fix` a third time after the hand edits — still zero diff,
+   confirming the manual changes didn't disturb the fixed structure.
+5. `clj-kondo --lint components/control-plane`: 0 errors, 0 warnings,
+   both before and after.
+6. Ran all 4 test namespaces directly:
+   `clojure -M:dev:test -e "(require ...) (clojure.test/run-tests ...)"`
+   — 108 tests, 294 assertions, 0 failures, 0 errors.
+7. Re-ran plain `stratum-lint` after the fix:
+
+   ```text
+   components/control-plane/src/ai/miniforge/control_plane/decision_queue.clj:256:1: SL003 file uses 4 distinct layers (max 3)
+   components/control-plane/src/ai/miniforge/control_plane/heartbeat.clj:92:1: SL003 file uses 4 distinct layers (max 3)
+   components/control-plane/src/ai/miniforge/control_plane/state_machine.clj:130:1: SL003 file uses 4 distinct layers (max 3)
+   ```
+
+   `decision_queue.clj` is the same pre-existing finding as baseline
+   (unchanged layer count, just re-derived). `heartbeat.clj` and
+   `state_machine.clj` are newly surfaced by the fix — their old headings
+   undercounted the real depth. All three are real over-budget files,
+   Wave 2 scope (namespace split), not fixed here.
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+change — headings, `^{:stratum n}` metadata, def/deftest order, and the
+hand-fixed docstring/comment prose only. Pre-commit's `lint:stratum`
+autofixer keeps this component clean going forward; the three `SL003`
+findings stay advisory (`MINIFORGE_STRATUM_BUDGET_MODE=warn` at commit
+time) until Wave 2 splits those namespaces.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+- Follow-on: Wave 2 namespace splits for `decision_queue.clj`,
+  `heartbeat.clj`, and `state_machine.clj` (each 4 real layers, over the
+  3-layer budget)
+
+## Checklist
+
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Second `--fix` pass confirms idempotency (zero diff)
+- [x] Diff read in full for all 11 changed files
+- [x] Stale `Layer N` docstring/comment prose left by the fix hand-corrected
+      (6 ns docstrings + 5 banner comments in `orchestrator_test.clj`)
+- [x] Third `--fix` pass after hand edits still zero diff
+- [x] `clj-kondo` clean before/after (0 errors, 0 warnings)
+- [x] Component tests pass (108 tests, 294 assertions, 0 failures/errors)
+- [x] Plain lint re-run post-fix: 3 pre-existing/newly-surfaced `SL003`
+      findings documented above, tracked as Wave 2
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
## Summary

- Runs `stratum-lint --fix` over `components/control-plane` to replace decorative/miscounted `Layer N` headings with real ones derived from each file's actual same-file reference graph, plus `^{:stratum n}` metadata on every def.
- Hand-corrects stale `Layer N: <concept>` prose the autofix left behind (6 ns docstrings + 5 banner comments in `orchestrator_test.clj`) that no longer matched the recomputed real strata — one pair had gone flatly wrong (claimed `Layer 1`, sat inside the real `Layer 2` block).
- 3 `SL003` findings remain (`decision_queue.clj`, `heartbeat.clj`, `state_machine.clj` — each 4 real layers, over the 3-layer budget); deferred to Wave 2 (namespace split) per `work/stratum-lint-baseline-2026-07-24.md`.

Full detail in `docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-control-plane.md`.

## Test plan

- [x] Plain `stratum-lint` before fix reproduced baseline's 4 findings / 3 files, 0 `SL001`
- [x] `--fix` run, second `--fix` pass confirms idempotency (zero diff)
- [x] Full diff read for all 11 changed files; hand-fixed stale heading prose; third `--fix` pass after hand edits still zero diff
- [x] `clj-kondo --lint components/control-plane`: 0 errors, 0 warnings (before and after)
- [x] All 4 test namespaces: 108 tests, 294 assertions, 0 failures, 0 errors
- [x] Plain lint re-run post-fix: 3 `SL003` findings documented, tracked as Wave 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)