### PR TITLE
fix: stratum-lint autofix for components/artifact (Wave 1)

### DIFF
--- a/components/artifact/src/ai/miniforge/artifact/core.clj
+++ b/components/artifact/src/ai/miniforge/artifact/core.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.artifact.core
   "Artifact storage and provenance tracking.
    Layer 0: Pure functions for artifact operations
@@ -28,9 +27,9 @@
    - ai.miniforge.artifact.datalevin-store (JVM only)")
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Pure functions
 
-(defn build-artifact
+;; Pure functions
+(defn ^{:stratum 0} build-artifact
   "Build an artifact map from components."
   [{:keys [id type version content origin parents metadata]
     :or {parents [] metadata {}}}]
@@ -42,12 +41,12 @@
            :artifact/metadata metadata}
     origin (assoc :artifact/origin origin)))
 
-(defn add-parent
+(defn ^{:stratum 0} add-parent
   "Add a parent artifact ID to an artifact's parents list."
   [artifact parent-id]
   (update artifact :artifact/parents (fnil conj []) parent-id))
 
-(defn add-child
+(defn ^{:stratum 0} add-child
   "Add a child artifact ID to an artifact's children list."
   [artifact child-id]
   (update artifact :artifact/children (fnil conj []) child-id))

--- a/components/artifact/src/ai/miniforge/artifact/datalevin_store.clj
+++ b/components/artifact/src/ai/miniforge/artifact/datalevin_store.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.artifact.datalevin-store
   "Datalevin-based artifact store implementation (JVM only).
 
@@ -28,9 +27,9 @@
    [ai.miniforge.logging.interface :as log]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Datalevin schema
 
-(def datalevin-schema
+;; Datalevin schema
+(def ^{:stratum 0} datalevin-schema
   "Datalevin schema for artifact storage."
   {:artifact/id       {:db/unique :db.unique/identity}
    :artifact/type     {}
@@ -38,10 +37,8 @@
    :artifact/parents  {:db/cardinality :db.cardinality/many}
    :artifact/children {:db/cardinality :db.cardinality/many}})
 
-;------------------------------------------------------------------------------ Layer 1
 ;; DatalevinStore implementation
-
-(defrecord DatalevinStore [conn logger]
+(defrecord ^{:stratum 0} DatalevinStore [conn logger]
   p/ArtifactStore
   (save [_this artifact]
     (let [id (:artifact/id artifact)]
@@ -93,10 +90,10 @@
   (close [_this]
     (d/close conn)))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Public API
+;------------------------------------------------------------------------------ Layer 1
 
-(defn create-datalevin-store
+;; Public API
+(defn ^{:stratum 1} create-datalevin-store
   "Create a new Datalevin-based artifact store (JVM only).
 
    Options:

--- a/components/artifact/src/ai/miniforge/artifact/interface.cljc
+++ b/components/artifact/src/ai/miniforge/artifact/interface.cljc
@@ -15,18 +15,19 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.artifact.interface
   "Public API for the artifact component."
   (:require
    #?@(:bb []
-       :clj [[ai.miniforge.artifact.datalevin-store :as datalevin-store]])
+       :default [[ai.miniforge.artifact.datalevin-store :as datalevin-store]])
    [ai.miniforge.artifact.core :as core]
    [ai.miniforge.artifact.interface.protocols.artifact-store :as p]
    [ai.miniforge.artifact.protocols.records.transit-store :as transit-store]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; Re-export protocol for public API
-(def ArtifactStore
+(def ^{:stratum 0} ArtifactStore
   "Protocol contract for pluggable artifact stores (extensibility point).
 
    Re-exported from ai.miniforge.artifact.interface.protocols.artifact-store.
@@ -39,35 +40,15 @@
    currently document argument contracts or failure modes)."
   p/ArtifactStore)
 
-#?(:bb
-   (defn- create-datalevin-store
-     [opts]
-     (throw (ex-info "Datalevin artifact store is JVM-only; use create-transit-store under Babashka"
-                     {:store :datalevin
-                      :runtime :bb
-                      :opts opts})))
+(defn- ^{:stratum 0} create-datalevin-store
+  [opts]
+  #?(:bb (throw (ex-info "Datalevin artifact store is JVM-only; use create-transit-store under Babashka"
+                        {:store :datalevin
+                         :runtime :bb
+                         :opts opts}))
+     :default (datalevin-store/create-datalevin-store opts)))
 
-   :clj
-   (defn- create-datalevin-store
-     [opts]
-     (datalevin-store/create-datalevin-store opts)))
-
-(defn create-store
-  "Create a Datalevin-based artifact store (JVM only).
-   For Babashka compatibility, use create-transit-store instead.
-
-   Options:
-   - :dir      - Directory for storage (nil for in-memory)
-   - :logger   - Optional logger
-   - :schema   - Optional custom Datalevin schema
-
-   Examples:
-     (create-store)                          ; in-memory
-     (create-store {:dir \"data/artifacts\"})  ; persistent"
-  ([] (create-store {}))
-  ([opts] (create-datalevin-store opts)))
-
-(defn create-transit-store
+(defn ^{:stratum 0} create-transit-store
   "Create a Transit-based artifact store (Babashka compatible).
 
    Options:
@@ -90,25 +71,48 @@
   ([] (transit-store/create-transit-store))
   ([opts] (transit-store/create-transit-store opts)))
 
-(defn close-store [store] (p/close store))
-(defn save! [store artifact] (p/save store artifact))
-(defn load-artifact [store id] (p/load-artifact store id))
-(defn query [store criteria] (p/query store criteria))
-(defn link! [store parent-id child-id] (p/link store parent-id child-id))
+(defn ^{:stratum 0} close-store [store] (p/close store))
 
-(defn build-artifact [opts] (core/build-artifact opts))
-(defn add-parent [artifact parent-id] (core/add-parent artifact parent-id))
-(defn add-child [artifact child-id] (core/add-child artifact child-id))
+(defn ^{:stratum 0} save! [store artifact] (p/save store artifact))
 
-(defn get-provenance [store artifact-id]
+(defn ^{:stratum 0} load-artifact [store id] (p/load-artifact store id))
+
+(defn ^{:stratum 0} query [store criteria] (p/query store criteria))
+
+(defn ^{:stratum 0} link! [store parent-id child-id] (p/link store parent-id child-id))
+
+(defn ^{:stratum 0} build-artifact [opts] (core/build-artifact opts))
+
+(defn ^{:stratum 0} add-parent [artifact parent-id] (core/add-parent artifact parent-id))
+
+(defn ^{:stratum 0} add-child [artifact child-id] (core/add-child artifact child-id))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} create-store
+  "Create a Datalevin-based artifact store (JVM only).
+   For Babashka compatibility, use create-transit-store instead.
+
+   Options:
+   - :dir      - Directory for storage (nil for in-memory)
+   - :logger   - Optional logger
+   - :schema   - Optional custom Datalevin schema
+
+   Examples:
+     (create-store)                          ; in-memory
+     (create-store {:dir \"data/artifacts\"})  ; persistent"
+  ([] (create-store {}))
+  ([opts] (create-datalevin-store opts)))
+
+(defn ^{:stratum 1} get-provenance [store artifact-id]
   (when-let [artifact (load-artifact store artifact-id)]
     {:ancestors (:artifact/parents artifact [])
      :descendants (:artifact/children artifact [])}))
 
-(defn query-by-type [store artifact-type]
+(defn ^{:stratum 1} query-by-type [store artifact-type]
   (query store {:artifact/type artifact-type}))
 
-(defn query-by-origin [store origin-criteria]
+(defn ^{:stratum 1} query-by-origin [store origin-criteria]
   (let [all-artifacts (query store {})
         {task-id :task-id agent-id :agent-id} origin-criteria]
     (filter (fn [art]

--- a/components/artifact/src/ai/miniforge/artifact/interface/protocols/artifact_store.clj
+++ b/components/artifact/src/ai/miniforge/artifact/interface/protocols/artifact_store.clj
@@ -15,14 +15,15 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.artifact.interface.protocols.artifact-store
   "Public protocol for artifact persistence and retrieval.
 
    This is an extensibility point - users can implement custom artifact stores
    to persist artifacts to different backends (databases, file systems, cloud storage, etc.).")
 
-(defprotocol ArtifactStore
+;------------------------------------------------------------------------------ Layer 0
+
+(defprotocol ^{:stratum 0} ArtifactStore
   "Protocol for artifact persistence and retrieval."
 
   (save [this artifact]

--- a/components/artifact/src/ai/miniforge/artifact/messages.clj
+++ b/components/artifact/src/ai/miniforge/artifact/messages.clj
@@ -15,10 +15,11 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.artifact.messages
   (:require [ai.miniforge.messages.interface :as messages]))
 
-(def t
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} t
   (messages/create-translator "config/artifact/messages/en-US.edn"
                               :artifact/messages))

--- a/components/artifact/src/ai/miniforge/artifact/protocols/impl/transit_store.clj
+++ b/components/artifact/src/ai/miniforge/artifact/protocols/impl/transit_store.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.artifact.protocols.impl.transit-store
   "Implementation functions for TransitArtifactStore protocol.
 
@@ -32,9 +31,9 @@
    [ai.miniforge.logging.interface :as log]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Pure functions for path handling
 
-(defn artifacts-dir
+;; Pure functions for path handling
+(defn ^{:stratum 0} artifacts-dir
   "Get the artifacts directory path.
    Defaults to ~/.miniforge/artifacts"
   ([] (artifacts-dir nil))
@@ -43,33 +42,31 @@
      (str base-dir "/artifacts")
      (str (config/miniforge-home) "/artifacts"))))
 
-(defn artifact-file-path
+(defn ^{:stratum 0} artifact-file-path
   "Get the file path for an artifact by ID."
   [artifacts-dir artifact-id]
   (str artifacts-dir "/" artifact-id ".transit.json"))
 
-(defn index-file-path
+(defn ^{:stratum 0} index-file-path
   "Get the path to the metadata index file."
   [artifacts-dir]
   (str artifacts-dir "/index.transit.json"))
 
-(defn ensure-artifacts-dir!
+(defn ^{:stratum 0} ensure-artifacts-dir!
   "Ensure the artifacts directory exists."
   [dir]
   (.mkdirs (io/file dir))
   dir)
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Transit serialization
-
-(defn write-transit
+(defn ^{:stratum 0} write-transit
   "Write data to a file in Transit JSON format."
   [file-path data]
   (with-open [out (io/output-stream file-path)]
     (let [writer (transit/writer out :json)]
       (transit/write writer data))))
 
-(defn read-transit
+(defn ^{:stratum 0} read-transit
   "Read data from a Transit JSON file.
    Returns nil if file doesn't exist."
   [file-path]
@@ -78,22 +75,7 @@
       (let [reader (transit/reader in :json)]
         (transit/read reader)))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Index management
-
-(defn load-index
-  "Load the artifact metadata index.
-   Returns empty map if index doesn't exist."
-  [artifacts-dir]
-  (or (read-transit (index-file-path artifacts-dir))
-      {}))
-
-(defn save-index!
-  "Save the artifact metadata index."
-  [artifacts-dir index]
-  (write-transit (index-file-path artifacts-dir) index))
-
-(defn add-to-index
+(defn ^{:stratum 0} add-to-index
   "Add artifact metadata to the index."
   [index artifact]
   (let [id (:artifact/id artifact)
@@ -104,35 +86,15 @@
                   :artifact/children (:artifact/children artifact)}]
     (assoc index id metadata)))
 
-(defn update-index-links
+(defn ^{:stratum 0} update-index-links
   "Update parent-child links in the index."
   [index parent-id child-id]
   (-> index
       (update-in [parent-id :artifact/children] (fnil conj []) child-id)
       (update-in [child-id :artifact/parents] (fnil conj []) parent-id)))
 
-;------------------------------------------------------------------------------ Layer 3
-;; Artifact persistence
-
-(defn persist-artifact!
-  "Persist an artifact to disk in Transit format."
-  [artifacts-dir artifact]
-  (let [id (:artifact/id artifact)
-        file-path (artifact-file-path artifacts-dir id)]
-    (write-transit file-path artifact)
-    id))
-
-(defn load-artifact-from-disk
-  "Load an artifact from disk.
-   Returns nil if not found."
-  [artifacts-dir artifact-id]
-  (let [file-path (artifact-file-path artifacts-dir artifact-id)]
-    (read-transit file-path)))
-
-;------------------------------------------------------------------------------ Layer 4
 ;; Protocol implementations
-
-(defn log-artifact-saved
+(defn ^{:stratum 0} log-artifact-saved
   "Log artifact save operation."
   [logger artifact-id artifact]
   (when logger
@@ -141,7 +103,7 @@
                        :artifact-type (:artifact/type artifact)
                        :storage :transit}})))
 
-(defn log-artifact-save-failed
+(defn ^{:stratum 0} log-artifact-save-failed
   "Log artifact save failure."
   [logger artifact-id e]
   (when logger
@@ -149,7 +111,92 @@
                {:message (.getMessage e)
                 :data {:artifact-id artifact-id}})))
 
-(defn save-artifact
+(defn- ^{:stratum 0} criterion-match?
+  [metadata [k v]]
+  (= (get metadata k) v))
+
+(defn- ^{:stratum 0} load-indexed-artifact
+  [record id]
+  (p/load-artifact record id))
+
+(defn ^{:stratum 0} update-cache-links
+  "Update cached artifacts with new links."
+  [cache parent-id child-id]
+  (when-let [parent (get @cache parent-id)]
+    (swap! cache assoc parent-id (core/add-child parent child-id)))
+  (when-let [child (get @cache child-id)]
+    (swap! cache assoc child-id (core/add-parent child parent-id))))
+
+;; Anomaly-returning helpers
+(defn- ^{:stratum 0} anomaly?
+  [x]
+  (anomaly/anomaly? x))
+
+(defn- ^{:stratum 0} link-target-message
+  [role]
+  (case role
+    :parent (messages/t :link/parent-not-found)
+    :child  (messages/t :link/child-not-found)
+    (messages/t :link/artifact-not-found)))
+
+(defn- ^{:stratum 0} link-target-role
+  [result]
+  (get-in result [:anomaly/data :artifact/role]))
+
+(defn ^{:stratum 0} close-store
+  "Close store implementation."
+  [{:keys [cache logger]}]
+  ;; Ensure all pending writes complete
+  (Thread/sleep 100) ; Give futures time to complete
+  (when logger
+    (log/info logger :system :artifact/store-closed
+              {:data {:artifact-count (count @cache)}})))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Index management
+(defn ^{:stratum 1} load-index
+  "Load the artifact metadata index.
+   Returns empty map if index doesn't exist."
+  [artifacts-dir]
+  (or (read-transit (index-file-path artifacts-dir))
+      {}))
+
+(defn ^{:stratum 1} save-index!
+  "Save the artifact metadata index."
+  [artifacts-dir index]
+  (write-transit (index-file-path artifacts-dir) index))
+
+;; Artifact persistence
+(defn ^{:stratum 1} persist-artifact!
+  "Persist an artifact to disk in Transit format."
+  [artifacts-dir artifact]
+  (let [id (:artifact/id artifact)
+        file-path (artifact-file-path artifacts-dir id)]
+    (write-transit file-path artifact)
+    id))
+
+(defn ^{:stratum 1} load-artifact-from-disk
+  "Load an artifact from disk.
+   Returns nil if not found."
+  [artifacts-dir artifact-id]
+  (let [file-path (artifact-file-path artifacts-dir artifact-id)]
+    (read-transit file-path)))
+
+(defn- ^{:stratum 1} metadata-match?
+  [criteria metadata]
+  (every? (partial criterion-match? metadata) criteria))
+
+(defn- ^{:stratum 1} link-target-anomaly
+  [artifact-id role]
+  (anomaly/anomaly :not-found
+                   (link-target-message role)
+                   {:artifact/id artifact-id
+                    :artifact/role role}))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} save-artifact
   "Save artifact implementation."
   [{:keys [artifacts-dir cache index logger]} artifact]
   (let [id (:artifact/id artifact)]
@@ -170,7 +217,7 @@
           (log-artifact-save-failed logger id e))))
     id))
 
-(defn load-artifact-impl
+(defn ^{:stratum 2} load-artifact-impl
   "Load artifact implementation."
   [{:keys [artifacts-dir cache logger]} id]
   ;; Try memory cache first
@@ -185,49 +232,12 @@
                              :source :disk}}))
         artifact)))
 
-(defn- criterion-match?
-  [metadata [k v]]
-  (= (get metadata k) v))
-
-(defn- metadata-match?
-  [criteria metadata]
-  (every? (partial criterion-match? metadata) criteria))
-
-(defn- matching-index-id
+(defn- ^{:stratum 2} matching-index-id
   [criteria [id metadata]]
   (when (metadata-match? criteria metadata)
     id))
 
-(defn filter-by-criteria
-  "Filter artifacts by criteria."
-  [index criteria]
-  (keep (partial matching-index-id criteria) index))
-
-(defn- load-indexed-artifact
-  [record id]
-  (p/load-artifact record id))
-
-(defn query-artifacts
-  "Query artifacts implementation."
-  [{:keys [index] :as record} criteria]
-  (if (empty? criteria)
-    ;; Return all artifacts
-    (let [all-ids (keys @index)]
-      (keep (partial load-indexed-artifact record) all-ids))
-    ;; Filter by criteria using index first for efficiency
-    (let [matching-ids (filter-by-criteria @index criteria)
-          artifacts (keep (partial load-indexed-artifact record) matching-ids)]
-      (vec artifacts))))
-
-(defn update-cache-links
-  "Update cached artifacts with new links."
-  [cache parent-id child-id]
-  (when-let [parent (get @cache parent-id)]
-    (swap! cache assoc parent-id (core/add-child parent child-id)))
-  (when-let [child (get @cache child-id)]
-    (swap! cache assoc child-id (core/add-parent child parent-id))))
-
-(defn persist-linked-artifacts
+(defn ^{:stratum 2} persist-linked-artifacts
   "Persist both linked artifacts to disk."
   [record artifacts-dir parent-id child-id logger]
   (future
@@ -243,39 +253,35 @@
                       :data {:parent-id parent-id
                              :child-id child-id}}))))))
 
-;------------------------------------------------------------------------------ Layer 5
-;; Anomaly-returning helpers
+;------------------------------------------------------------------------------ Layer 3
 
-(defn- anomaly?
-  [x]
-  (anomaly/anomaly? x))
+(defn ^{:stratum 3} filter-by-criteria
+  "Filter artifacts by criteria."
+  [index criteria]
+  (keep (partial matching-index-id criteria) index))
 
-(defn- link-target-message
-  [role]
-  (case role
-    :parent (messages/t :link/parent-not-found)
-    :child  (messages/t :link/child-not-found)
-    (messages/t :link/artifact-not-found)))
-
-(defn- link-target-anomaly
-  [artifact-id role]
-  (anomaly/anomaly :not-found
-                   (link-target-message role)
-                   {:artifact/id artifact-id
-                    :artifact/role role}))
-
-(defn- link-target-role
-  [result]
-  (get-in result [:anomaly/data :artifact/role]))
-
-(defn find-link-target
+(defn ^{:stratum 3} find-link-target
   "Load an artifact for linking, or return a typed not-found anomaly."
   [record artifact-id role]
   (if-let [artifact (load-artifact-impl record artifact-id)]
     artifact
     (link-target-anomaly artifact-id role)))
 
-(defn link-artifacts
+;------------------------------------------------------------------------------ Layer 4
+
+(defn ^{:stratum 4} query-artifacts
+  "Query artifacts implementation."
+  [{:keys [index] :as record} criteria]
+  (if (empty? criteria)
+    ;; Return all artifacts
+    (let [all-ids (keys @index)]
+      (keep (partial load-indexed-artifact record) all-ids))
+    ;; Filter by criteria using index first for efficiency
+    (let [matching-ids (filter-by-criteria @index criteria)
+          artifacts (keep (partial load-indexed-artifact record) matching-ids)]
+      (vec artifacts))))
+
+(defn ^{:stratum 4} link-artifacts
   "Link artifacts, preserving the ArtifactStore boolean facade.
    Missing link targets are represented as anomalies internally and logged."
   [{:keys [artifacts-dir cache index logger] :as record} parent-id child-id]
@@ -309,12 +315,3 @@
                      {:data {:parent-id parent-id
                              :child-id  child-id}}))
         true))))
-
-(defn close-store
-  "Close store implementation."
-  [{:keys [cache logger]}]
-  ;; Ensure all pending writes complete
-  (Thread/sleep 100) ; Give futures time to complete
-  (when logger
-    (log/info logger :system :artifact/store-closed
-              {:data {:artifact-count (count @cache)}})))

--- a/components/artifact/src/ai/miniforge/artifact/protocols/records/transit_store.clj
+++ b/components/artifact/src/ai/miniforge/artifact/protocols/records/transit_store.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.artifact.protocols.records.transit-store
   "TransitArtifactStore record that implements the ArtifactStore protocol.
 
@@ -43,7 +42,9 @@
    [ai.miniforge.artifact.interface.protocols.artifact-store :as p]
    [ai.miniforge.artifact.protocols.impl.transit-store :as impl]))
 
-(defrecord TransitArtifactStore [artifacts-dir cache index logger]
+;------------------------------------------------------------------------------ Layer 0
+
+(defrecord ^{:stratum 0} TransitArtifactStore [artifacts-dir cache index logger]
   p/ArtifactStore
 
   (save [this artifact]
@@ -61,7 +62,9 @@
   (close [this]
     (impl/close-store this)))
 
-(defn create-transit-store
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} create-transit-store
   ([] (create-transit-store {}))
   ([{:keys [dir logger]}]
    (let [artifacts-dir (impl/artifacts-dir dir)]

--- a/components/artifact/test/ai/miniforge/artifact/core_test.clj
+++ b/components/artifact/test/ai/miniforge/artifact/core_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.artifact.core-test
   "Unit tests for artifact core pure functions."
   (:require
@@ -23,9 +22,9 @@
    [ai.miniforge.artifact.core :as core]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; build-artifact
 
-(deftest build-artifact-minimal-test
+;; build-artifact
+(deftest ^{:stratum 0} build-artifact-minimal-test
   (testing "builds artifact with required fields only"
     (let [id (random-uuid)
           art (core/build-artifact {:id id
@@ -40,7 +39,7 @@
       (is (= {} (:artifact/metadata art)))
       (is (nil? (:artifact/origin art))))))
 
-(deftest build-artifact-with-origin-test
+(deftest ^{:stratum 0} build-artifact-with-origin-test
   (testing "includes origin when provided"
     (let [art (core/build-artifact {:id (random-uuid)
                                     :type :code
@@ -49,7 +48,7 @@
                                     :origin :implementer})]
       (is (= :implementer (:artifact/origin art))))))
 
-(deftest build-artifact-with-parents-test
+(deftest ^{:stratum 0} build-artifact-with-parents-test
   (testing "preserves provided parents"
     (let [p1 (random-uuid)
           p2 (random-uuid)
@@ -60,7 +59,7 @@
                                     :parents [p1 p2]})]
       (is (= [p1 p2] (:artifact/parents art))))))
 
-(deftest build-artifact-with-metadata-test
+(deftest ^{:stratum 0} build-artifact-with-metadata-test
   (testing "preserves provided metadata"
     (let [meta-map {:language :clojure :lines 42}
           art (core/build-artifact {:id (random-uuid)
@@ -70,7 +69,7 @@
                                     :metadata meta-map})]
       (is (= meta-map (:artifact/metadata art))))))
 
-(deftest build-artifact-nil-content-test
+(deftest ^{:stratum 0} build-artifact-nil-content-test
   (testing "nil content is preserved"
     (let [art (core/build-artifact {:id (random-uuid)
                                     :type :plan
@@ -78,10 +77,8 @@
                                     :content nil})]
       (is (nil? (:artifact/content art))))))
 
-;------------------------------------------------------------------------------ Layer 0
 ;; add-parent
-
-(deftest add-parent-test
+(deftest ^{:stratum 0} add-parent-test
   (testing "appends parent ID to parents list"
     (let [base (core/build-artifact {:id (random-uuid)
                                      :type :code
@@ -99,10 +96,8 @@
           result (core/add-parent bare (random-uuid))]
       (is (= 1 (count (:artifact/parents result)))))))
 
-;------------------------------------------------------------------------------ Layer 0
 ;; add-child
-
-(deftest add-child-test
+(deftest ^{:stratum 0} add-child-test
   (testing "appends child ID to children list"
     (let [base (core/build-artifact {:id (random-uuid)
                                      :type :code
@@ -120,17 +115,15 @@
           result (core/add-child bare (random-uuid))]
       (is (= 1 (count (:artifact/children result)))))))
 
-;------------------------------------------------------------------------------ Layer 0
 ;; Immutability
-
-(deftest build-artifact-immutability-test
+(deftest ^{:stratum 0} build-artifact-immutability-test
   (testing "build-artifact does not mutate input map"
     (let [input {:id (random-uuid) :type :plan :version "1.0.0" :content {}}
           input-copy (into {} input)
           _ (core/build-artifact input)]
       (is (= input-copy input)))))
 
-(deftest add-parent-immutability-test
+(deftest ^{:stratum 0} add-parent-immutability-test
   (testing "add-parent returns new map, original unchanged"
     (let [base (core/build-artifact {:id (random-uuid)
                                      :type :code

--- a/components/artifact/test/ai/miniforge/artifact/interface_test.clj
+++ b/components/artifact/test/ai/miniforge/artifact/interface_test.clj
@@ -15,14 +15,15 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.artifact.interface-test
   "Unit tests for artifact core helpers."
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.artifact.interface :as artifact]))
 
-(deftest build-artifact-test
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} build-artifact-test
   (testing "build-artifact assembles required fields"
     (let [id (random-uuid)
           artifact-map (artifact/build-artifact
@@ -35,7 +36,7 @@
       (is (= [] (:artifact/parents artifact-map)))
       (is (= {} (:artifact/metadata artifact-map))))))
 
-(deftest parent-child-helpers-test
+(deftest ^{:stratum 0} parent-child-helpers-test
   (testing "add-parent and add-child append identifiers"
     (let [base (artifact/build-artifact
                 {:id (random-uuid)

--- a/components/artifact/test/ai/miniforge/artifact/protocols/impl/transit_store_test.clj
+++ b/components/artifact/test/ai/miniforge/artifact/protocols/impl/transit_store_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.artifact.protocols.impl.transit-store-test
   (:require [ai.miniforge.anomaly.interface :as anomaly]
             [ai.miniforge.artifact.interface.protocols.artifact-store :as p]
@@ -25,12 +24,17 @@
             [clojure.test :refer [deftest is testing]])
   (:import [java.nio.file Files]))
 
-(def ^:private parent-id "parent-id")
-(def ^:private child-id "child-id")
-(def ^:private missing-parent-id "missing-parent")
-(def ^:private missing-child-id "missing-child")
+;------------------------------------------------------------------------------ Layer 0
 
-(defn- artifact
+(def ^{:stratum 0} ^:private parent-id "parent-id")
+
+(def ^{:stratum 0} ^:private child-id "child-id")
+
+(def ^{:stratum 0} ^:private missing-parent-id "missing-parent")
+
+(def ^{:stratum 0} ^:private missing-child-id "missing-child")
+
+(defn- ^{:stratum 0} artifact
   [id type]
   {:artifact/id id
    :artifact/type type
@@ -38,28 +42,32 @@
    :artifact/parents []
    :artifact/children []})
 
-(defn- parent-artifact []
-  (artifact parent-id :plan))
-
-(defn- child-artifact []
-  (artifact child-id :code))
-
-(defn- delete-dir! [file]
+(defn- ^{:stratum 0} delete-dir! [file]
   (when (.exists (io/file file))
     (doseq [f (reverse (file-seq (io/file file)))]
       (io/delete-file f true))))
 
-(defn- temp-store []
+(defn- ^{:stratum 0} temp-store []
   (let [dir (.toFile (Files/createTempDirectory
                       "transit-store-test"
                       (make-array java.nio.file.attribute.FileAttribute 0)))]
     [(store/create-transit-store {:dir (.getPath dir)}) dir]))
 
-(defn- save! [store artifact]
+(defn- ^{:stratum 0} save! [store artifact]
   (p/save store artifact)
   artifact)
 
-(deftest test-find-link-target
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} parent-artifact []
+  (artifact parent-id :plan))
+
+(defn- ^{:stratum 1} child-artifact []
+  (artifact child-id :code))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} test-find-link-target
   (let [[artifact-store dir] (temp-store)]
     (try
       (testing "given existing target -> returns artifact"
@@ -79,7 +87,7 @@
       (finally
         (delete-dir! dir)))))
 
-(deftest test-link-artifacts-success
+(deftest ^{:stratum 2} test-link-artifacts-success
   (let [[artifact-store dir] (temp-store)]
     (try
       (save! artifact-store (parent-artifact))
@@ -93,12 +101,14 @@
       (finally
         (delete-dir! dir)))))
 
-(defn- missing-target-cases []
+(defn- ^{:stratum 2} missing-target-cases []
   [["missing parent" [(child-artifact)] missing-parent-id child-id]
    ["missing child" [(parent-artifact)] parent-id missing-child-id]
    ["missing both" [] missing-parent-id missing-child-id]])
 
-(deftest test-link-artifacts-missing-targets
+;------------------------------------------------------------------------------ Layer 3
+
+(deftest ^{:stratum 3} test-link-artifacts-missing-targets
   (doseq [[label artifacts parent-id child-id]
           (missing-target-cases)]
     (let [[artifact-store dir] (temp-store)]

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-artifact.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-artifact.md
@@ -1,0 +1,188 @@
+# fix: stratum-lint autofix for components/artifact (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over `components/artifact` (`src` + `test`) to
+replace decorative/repeated `Layer N` headings with real ones and
+`^{:stratum n}` metadata derived from each file's actual same-file
+reference graph. One of the Wave 1 per-component PRs from
+`work/stratum-lint-baseline-2026-07-24.md`.
+
+**Not purely mechanical**: `--fix` on `interface.cljc` moved a private
+`#?(:bb ... :clj ...)`-wrapped helper (`create-datalevin-store`) from
+before its only caller (`create-store`) to the very end of the file,
+after all headed layers. The tool does not parse `defn-` forms nested
+inside a reader-conditional splice (the whole top-level form is `#?()`,
+not the `defn-` itself) as recognized defs, so it never saw the
+same-file call from `create-store` and placed the untracked form after
+everything else instead of leaving it where a human would need it. That
+broke compilation outright (`Unable to resolve symbol:
+create-datalevin-store in this context`) — confirmed by loading the
+namespace before and after.
+
+First attempt was to hand-restore the original position, but re-running
+`--fix` moved it right back to the end (confirmed empirically, not a
+one-off) — a hand-fix alone doesn't survive pre-commit's autofixer
+re-running on any future edit to this file. Resolved instead by
+restructuring the code so the tool can parse it: moved the `#?(:bb ...
+:default ...)` split from wrapping the whole top-level `defn-` to living
+inside the function body (`(defn- create-datalevin-store [opts] #?(:bb
+... :default ...))`), matching the convention `components/datalevin`
+already uses for the same bb/JVM split
+(`components/datalevin/src/ai/miniforge/datalevin/interface.cljc`, which
+uses `:default` rather than `:clj` for the same reason — confirmed by
+grepping for other `#?(:bb` uses in the tree). `create-datalevin-store`
+is now a normal, always-present `defn-` that `--fix` correctly recognizes
+and stratifies at Layer 0; `create-store`, which calls it, correctly
+moved to Layer 1. Verified: compiles, `--fix` run a second time against
+this file makes no further change (stable), and `clj-kondo` is clean
+(switching the body's bb/else split to `:default` also required changing
+the file's `:require` reader-conditional from `:clj` to `:default` for
+the same alias to resolve under clj-kondo's analysis — the require and
+the body must agree on which key selects the JVM branch). Behavior is
+unchanged: same throw on `:bb`, same delegation to
+`datalevin-store/create-datalevin-store` otherwise. Everything else in
+this PR is heading/metadata/reorder only, with no other logic change.
+
+## Motivation
+
+Baseline findings for this component: one `SL003` (`transit_store.clj`,
+reported as "6 distinct layers", over the 3-layer budget) and three
+`SL002` (`core_test.clj`, a repeated "Layer 0" banner reused across four
+different function groups instead of one heading per real stratum). Zero
+`SL001` findings, confirmed via a plain (non-`--fix`) lint run before
+touching anything — no upward-reference/cycle risk to reason about first,
+matching this wave's batch criteria.
+
+## Changes in Detail
+
+Ran, over the whole component:
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "14965e1ee1a175bd00f637d9a9d5f7d27e62b73f" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/artifact
+```
+
+10 files rewritten across `src` and `test`:
+`core.clj`, `datalevin_store.clj`, `interface.cljc`,
+`interface/protocols/artifact_store.clj`, `messages.clj`,
+`protocols/impl/transit_store.clj`, `protocols/records/transit_store.clj`,
+`test/core_test.clj`, `test/interface_test.clj`,
+`test/protocols/impl/transit_store_test.clj`.
+
+Most files only gained `^{:stratum 0}` tags on their (already
+single-layer) defs — no reordering, no prior findings. The two files with
+actual findings:
+
+- `transit_store.clj` collapsed from 6 nominal layers to 5 real ones
+  (`Layer 0` through `Layer 4`), regrouping helpers like
+  `criterion-match?`, `load-indexed-artifact`, and `update-cache-links`
+  (previously scattered under stale section comments) to their true
+  stratum-0 depth, and moving `close-store` up from its old, wrong
+  position at the bottom.
+- `core_test.clj` collapsed four repeated "Layer 0" banners (one per
+  `deftest` group: `build-artifact`, `add-parent`, `add-child`,
+  immutability) into a single real Layer 0 — all these tests genuinely
+  have no same-file dependency depth.
+- `transit_store_test.clj` had **zero** `Layer` headings before this fix
+  (silently skipped by the plain linter — a documented tool limitation:
+  files with no heading at all aren't flagged, so this file reported no
+  findings pre-fix despite having real structure). `--fix` added
+  headings and revealed a genuine 4-layer dependency chain
+  (`parent-id`/`artifact`/`temp-store` → `parent-artifact`/`child-artifact`
+  → `test-find-link-target`/`test-link-artifacts-success` →
+  `test-link-artifacts-missing-targets`).
+
+The `interface.cljc` forward-reference break and its fix are described
+above under Overview.
+
+## Testing Plan
+
+1. Ran plain (non-`--fix`) `stratum-lint` before the fix — reproduced the
+   baseline's exactly 4 findings (1 `SL003`, 3 `SL002`), zero `SL001`.
+2. Ran `--fix`, then a second `--fix` pass immediately after — zero diff,
+   confirms idempotency of the tool's own output.
+3. Read the full diff for all 10 changed files. Found the
+   `interface.cljc` forward-reference break (see Overview), confirmed by
+   loading the namespace (`clojure -M -e "(require
+   'ai.miniforge.artifact.interface)"`) before and after each attempted
+   fix — failed with `Unable to resolve symbol` on the tool's raw output;
+   still failed after a naive hand-restore once `--fix` was re-run
+   (confirmed the relocation is deterministic, not a one-off); succeeded
+   once the code was restructured so the reader-conditional split lives
+   inside the function body instead of around the whole top-level form.
+   Re-ran `--fix` over the whole component again after the restructure —
+   zero diff, confirms the final state is a stable fixed point the tool
+   itself agrees with, not just a hand-edit sitting untouched. No other
+   file showed the trailing same-line-comment displacement or stale
+   double-semicolon `Layer N` banner patterns from prior batches.
+4. `clj-kondo --lint components/artifact`: 0 errors, 0 warnings (the
+   restructure briefly introduced a false "unused binding opts" warning
+   under a `:clj`-keyed body branch — resolved by switching to `:default`
+   for both the body split and the file's `:require` reader-conditional,
+   matching the `components/datalevin` convention).
+5. Ran `ai.miniforge.artifact.core-test`,
+   `ai.miniforge.artifact.interface-test`, and
+   `ai.miniforge.artifact.protocols.impl.transit-store-test` directly via
+   `clojure -A:test`: 14 tests, 37 assertions, 0 failures, 0 errors.
+6. Re-ran plain `stratum-lint` after the fix: `SL001`/`SL002`/`SL004`
+   clear. Two `SL003` findings remain:
+   - `transit_store.clj` (5 real layers) — **same underlying finding as
+     baseline**, now correctly counted (was reported as "6" against the
+     old decorative headings; the tool's real reference-graph count is
+     5). Not new, deferred to Wave 2.
+   - `transit_store_test.clj` (4 real layers) — **newly surfaced**. This
+     file had zero findings pre-fix only because it had no `Layer`
+     heading at all (see above); the fix's added structure revealed the
+     real over-budget depth for the first time. Deferred to Wave 2.
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+change: `create-datalevin-store`'s restructure only moves where the
+`:bb`/`:default` split sits syntactically, not what either branch does.
+Pre-commit's `lint:stratum` autofixer will re-run `--fix` against this
+component on any future commit touching these files — confirmed stable
+(zero diff) against the final state, so this is safe going forward.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+- Follow-on (Wave 2): namespace split for
+  `components/artifact/src/ai/miniforge/artifact/protocols/impl/transit_store.clj`
+  (5 real layers) and
+  `components/artifact/test/ai/miniforge/artifact/protocols/impl/transit_store_test.clj`
+  (4 real layers), both over the 3-layer budget.
+- **New upstream bug to file against `miniforge-ai/stratum-lint`**:
+  `--fix` does not parse `defn`/`defn-` forms nested inside a
+  `#?(:bb ... :clj ...)` reader-conditional splice as recognized defs. It
+  silently relocates the entire unrecognized top-level form to the end
+  of the file, past all `Layer` headings, regardless of same-file
+  callers referencing it earlier in the file — this can (and here did)
+  break compilation. Worked around in this PR by restructuring the one
+  file that hit it (moving the split inside the function body instead of
+  around the whole form), but the underlying tool defect is unfixed:
+  any other file in the tree with a `#?(:bb ...)`/`#?(:clj ...)`-wrapped
+  top-level `defn`/`defn-` that has a same-file caller is at risk of the
+  same silent breakage the next time it's touched under `--fix`. Worth a
+  codebase-wide grep for that shape (`resume.cljc` in `components/workflow`
+  has the wrapping pattern too, but its wrapped def has no same-file
+  caller, so it wasn't exposed here) before this recurs elsewhere.
+
+## Checklist
+
+- [x] Zero `SL001` findings confirmed before running `--fix`
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Second `--fix` pass confirms idempotency of the tool's raw output
+      (zero diff)
+- [x] Diff read in full for all 10 changed files
+- [x] Found and fixed a real compile-breaking tool defect
+      (`interface.cljc` forward reference) by restructuring the affected
+      reader conditional rather than hand-ordering around it; verified
+      by loading the namespace before/after and confirming a subsequent
+      `--fix` pass makes no further change
+- [x] `clj-kondo` clean (0 errors, 0 warnings)
+- [x] Component tests pass (14 tests, 37 assertions, 0 failures/errors)
+- [x] Plain lint re-run post-fix: zero findings except 2 `SL003` (one
+      pre-existing/same, one newly surfaced — both documented above,
+      tracked as Wave 2)
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
## Summary

- Runs `stratum-lint --fix` over `components/artifact` (`src` + `test`) — Wave 1 of `work/stratum-lint-baseline-2026-07-24.md`. Zero `SL001` findings confirmed before starting.
- Found and fixed a real compile-breaking tool defect along the way: `--fix` does not recognize a `defn-` nested inside a `#?(:bb ... :clj ...)` reader-conditional splice, and silently relocated a private helper (`create-datalevin-store` in `interface.cljc`) past its only caller, breaking compilation. Fixed by restructuring the conditional to live inside the function body (matching the convention `components/datalevin` already uses), not just a hand-restore — a hand-restore alone doesn't survive the next `--fix` pass.
- Everything else is heading/metadata/reorder only.

Full detail in `docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-artifact.md`.

## Test plan

- [x] Plain lint before fix reproduced baseline exactly (1 SL003, 3 SL002, 0 SL001)
- [x] `--fix` run, second `--fix` pass confirms idempotency (zero diff)
- [x] Full diff read for all 10 changed files
- [x] `interface.cljc` namespace loads (`clojure -M -e "(require 'ai.miniforge.artifact.interface)"`) before/after
- [x] `clj-kondo --lint components/artifact`: 0 errors, 0 warnings
- [x] Component tests: 14 tests, 37 assertions, 0 failures/errors
- [x] Plain lint re-run post-fix: 2 SL003 remain (1 pre-existing/same, 1 newly surfaced), documented, deferred to Wave 2
- [x] Pre-commit hook ran clean (no `--no-verify`), including full smoke-test suite and GraalVM compatibility tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)