### PR TITLE
fix: stratum-lint autofix for components/workflow-resume (Wave 1)

### DIFF
--- a/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
+++ b/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.workflow-resume.core
   "Pure reconstruction of execution context from recorded event streams.
 
@@ -45,35 +44,35 @@
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Pure extractors over an event sequence
 
-(defn completed?
+;; Pure extractors over an event sequence
+(defn ^{:stratum 0} completed?
   [reconstructed]
   (true? (:completed? reconstructed)))
 
-(defn failed?
+(defn ^{:stratum 0} failed?
   [reconstructed]
   (true? (:failed? reconstructed)))
 
-(defn paused?
+(defn ^{:stratum 0} paused?
   [reconstructed]
   (true? (:dag-paused? reconstructed)))
 
-(defn extract-completed-dag-tasks
+(defn ^{:stratum 0} extract-completed-dag-tasks
   [events]
   (->> events
        (filter #(= :dag/task-completed (:event/type %)))
        (map :dag/task-id)
        set))
 
-(defn extract-completed-dag-artifacts
+(defn ^{:stratum 0} extract-completed-dag-artifacts
   [events]
   (->> events
        (filter #(= :dag/task-completed (:event/type %)))
        (mapcat #(get-in % [:dag/result :data :artifacts] []))
        vec))
 
-(defn extract-workspace-checkpoints
+(defn ^{:stratum 0} extract-workspace-checkpoints
   "Workspace persistence records emitted at phase boundaries.
 
    These are the container/worktree provenance records that survive when
@@ -98,7 +97,7 @@
                    checkpoint))))
        vec))
 
-(defn extract-dag-pause-info
+(defn ^{:stratum 0} extract-dag-pause-info
   [events]
   (when-let [pause-event (->> events
                               (filter #(= :dag/paused (:event/type %)))
@@ -106,7 +105,7 @@
     {:completed-task-ids (set (:dag/completed-task-ids pause-event))
      :pause-reason (:dag/pause-reason pause-event)}))
 
-(def completed-outcomes
+(def ^{:stratum 0} completed-outcomes
   "Phase outcomes that count as completed for resume — the phase finished its
    work, so resume trims it from the pipeline rather than re-running it.
    :success did the work; :skipped short-circuited because the work was already
@@ -114,14 +113,7 @@
    producer yet, so they too fall outside this set and would re-run."
   #{:success :skipped})
 
-(defn extract-completed-phases
-  [events]
-  (->> events
-       (filter #(= :workflow/phase-completed (:event/type %)))
-       (filter #(contains? completed-outcomes (:phase/outcome %)))
-       (mapv :workflow/phase)))
-
-(defn extract-phase-results
+(defn ^{:stratum 0} extract-phase-results
   [events]
   (->> events
        (filter #(= :workflow/phase-completed (:event/type %)))
@@ -139,14 +131,14 @@
                                     (:phase/review-decision evt)))))
                {})))
 
-(defn find-workflow-spec
+(defn ^{:stratum 0} find-workflow-spec
   [events]
   (->> events
        (filter #(= :workflow/started (:event/type %)))
        first
        :workflow/spec))
 
-(defn- ensure-reconstruction-source
+(defn- ^{:stratum 0} ensure-reconstruction-source
   [checkpoint-data events-dir workflow-id events raw-events]
   (when-not (or checkpoint-data (seq events))
     (anomaly/anomaly :not-found
@@ -155,56 +147,18 @@
                       :events-dir (str events-dir)
                       :raw-event-count (count raw-events)})))
 
-(defn- checkpoint-status
+(defn- ^{:stratum 0} checkpoint-status
   [checkpoint-data]
   (get-in checkpoint-data [:machine-snapshot :execution/status]))
 
-(defn- checkpoint-dag-result
+(defn- ^{:stratum 0} checkpoint-dag-result
   [checkpoint-data]
   (get-in checkpoint-data [:machine-snapshot :execution/dag-result]))
 
-(defn- reconstructed-completed?
-  [by-type checkpoint-data]
-  (let [status (checkpoint-status checkpoint-data)]
-    (if (some? status)
-      (contains? #{:completed :completed-with-warnings} status)
-      (boolean (seq (get by-type :workflow/completed))))))
-
-(defn- reconstructed-failed?
-  [by-type checkpoint-data]
-  (let [status (checkpoint-status checkpoint-data)]
-    (if (some? status)
-      (= :failed status)
-      (boolean (seq (get by-type :workflow/failed))))))
-
-(def ^:private resume-config-resource
+(def ^{:stratum 0} ^:private resume-config-resource
   "config/workflow-resume/resume.edn")
 
-(defn- read-resume-config
-  []
-  (if-let [resource (io/resource resume-config-resource)]
-    (:workflow-resume/resume (edn/read-string (slurp resource)))
-    (anomaly/anomaly :not-found
-                     "Workflow resume config resource not found"
-                     {:resource resume-config-resource
-                      :config/error :invalid-config})))
-
-(def ^:private resume-config
-  (delay (read-resume-config)))
-
-(defn- config-set
-  [k]
-  (set (get @resume-config k)))
-
-(def completed-phase-statuses
-  "Phase result statuses that are safe to skip on resume."
-  (config-set :completed-phase-statuses))
-
-(def blocking-review-decisions
-  "Review decisions that must resume the repair path."
-  (config-set :blocking-review-decisions))
-
-(defn- phase-result-status
+(defn- ^{:stratum 0} phase-result-status
   [phase-result]
   (or (:status phase-result)
       (:phase/status phase-result)
@@ -213,26 +167,13 @@
       (get-in phase-result [:result :status])
       (get-in phase-result [:phase/result :status])))
 
-(defn- review-blocked?
-  [phase-id phase-result]
-  (and (= :review phase-id)
-       (contains? blocking-review-decisions
-                  (response/review-decision (response/phase-output phase-result)))))
-
-(defn- completed-phase-result?
-  [phase-id phase-result]
-  (and phase-result
-       (not (review-blocked? phase-id phase-result))
-       (contains? completed-phase-statuses
-                  (phase-result-status phase-result))))
-
-(defn- checkpoint-phase-order
+(defn- ^{:stratum 0} checkpoint-phase-order
   [checkpoint-data phase-results]
   (let [manifest-order (get-in checkpoint-data [:manifest :workflow/phases-completed])]
     (vec (concat manifest-order
                  (remove (set manifest-order) (keys phase-results))))))
 
-(defn- event-phase-order
+(defn- ^{:stratum 0} event-phase-order
   [events]
   (->> events
        (filter #(= :workflow/phase-completed (:event/type %)))
@@ -240,31 +181,80 @@
        distinct
        vec))
 
-(defn- completed-checkpoint-phases
-  [checkpoint-data phase-results]
-  (->> (checkpoint-phase-order checkpoint-data phase-results)
-       (filter #(completed-phase-result? % (get phase-results %)))))
+;; Pipeline trimming
+(defn ^{:stratum 0} trim-pipeline
+  "Drop the already-completed prefix from a workflow's pipeline.
 
-(defn- completed-event-phases
+   Pure: takes a workflow map with `:workflow/pipeline` and a
+   collection of completed phase keywords; returns the workflow with only
+   leading completed phases removed. Completed phases after the first
+   incomplete phase are preserved."
+  [workflow completed-phases]
+  (anomaly/let-ok [_valid (schema/validate schema/TrimPipelineInput
+                                           {:workflow workflow
+                                            :completed-phases completed-phases}
+                                           {:message "Invalid trim-pipeline input"
+                                            :schema-name :workflow-resume/trim-pipeline})]
+    (let [completed-set (set completed-phases)
+          remaining (vec (drop-while #(completed-set (:phase %))
+                                     (get workflow :workflow/pipeline [])))]
+      (assoc workflow :workflow/pipeline remaining))))
+
+;; Identity resolution
+(defn- ^{:stratum 0} synthetic-dag-task-workflow-id?
+  "True when the recorded workflow id is an internal DAG task workflow key,
+   not a loadable top-level workflow type from the registry."
+  [workflow-id]
+  (and (keyword? workflow-id)
+       (str/starts-with? (name workflow-id) "dag-task-")))
+
+(def ^{:stratum 0} ^:private workflow-type-identifier-re
+  "Regex for an unqualified workflow-type keyword name. Workflow types are loader keys
+   like :canonical-sdlc / :quick-fix — strict identifier characters only.
+   This rejects values like \"In-flight PR / branch / task-claim registry\"
+   (a human title that the producer side accidentally records under
+   `:name`) before they get keywordized into an unloadable lookup key."
+  #"^[A-Za-z][A-Za-z0-9._+!?*<>=-]*$")
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} extract-completed-phases
   [events]
-  (let [event-results (extract-phase-results events)]
-    (->> (event-phase-order events)
-         (filter #(completed-phase-result? % (get event-results %))))))
+  (->> events
+       (filter #(= :workflow/phase-completed (:event/type %)))
+       (filter #(contains? completed-outcomes (:phase/outcome %)))
+       (mapv :workflow/phase)))
 
-(defn- restored-completed-phases
-  [checkpoint-data events phase-results]
-  (->> (concat (completed-event-phases events)
-               (completed-checkpoint-phases checkpoint-data phase-results))
-       distinct
-       vec))
+(defn- ^{:stratum 1} reconstructed-completed?
+  [by-type checkpoint-data]
+  (let [status (checkpoint-status checkpoint-data)]
+    (if (some? status)
+      (contains? #{:completed :completed-with-warnings} status)
+      (boolean (seq (get by-type :workflow/completed))))))
 
-(defn- restored-phase-results
+(defn- ^{:stratum 1} reconstructed-failed?
+  [by-type checkpoint-data]
+  (let [status (checkpoint-status checkpoint-data)]
+    (if (some? status)
+      (= :failed status)
+      (boolean (seq (get by-type :workflow/failed))))))
+
+(defn- ^{:stratum 1} read-resume-config
+  []
+  (if-let [resource (io/resource resume-config-resource)]
+    (:workflow-resume/resume (edn/read-string (slurp resource)))
+    (anomaly/anomaly :not-found
+                     "Workflow resume config resource not found"
+                     {:resource resume-config-resource
+                      :config/error :invalid-config})))
+
+(defn- ^{:stratum 1} restored-phase-results
   [checkpoint-data events]
   (if checkpoint-data
     (:phase-results checkpoint-data)
     (extract-phase-results events)))
 
-(defn- restored-dag-pause-info
+(defn- ^{:stratum 1} restored-dag-pause-info
   [checkpoint-data events]
   (let [dag-result (checkpoint-dag-result checkpoint-data)]
     (or (when (:paused? dag-result)
@@ -272,7 +262,32 @@
            :pause-reason (:pause-reason dag-result)})
         (extract-dag-pause-info events))))
 
-(defn- restored-completed-dag-tasks
+(defn- ^{:stratum 1} restored-completed-dag-artifacts
+  [checkpoint-data events]
+  (let [dag-result (checkpoint-dag-result checkpoint-data)
+        checkpoint-artifacts (vec (get dag-result :artifacts []))
+        event-artifacts (extract-completed-dag-artifacts events)]
+    (if (seq checkpoint-artifacts)
+      checkpoint-artifacts
+      event-artifacts)))
+
+(defn- ^{:stratum 1} restored-workspace-checkpoint
+  [events]
+  (last (extract-workspace-checkpoints events)))
+
+(defn- ^{:stratum 1} valid-workflow-type-keyword?
+  "True when `v` is an unqualified workflow-type keyword name."
+  [v]
+  (and (keyword? v)
+       (nil? (namespace v))
+       (re-matches workflow-type-identifier-re (name v))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(def ^{:stratum 2} ^:private resume-config
+  (delay (read-resume-config)))
+
+(defn- ^{:stratum 2} restored-completed-dag-tasks
   [checkpoint-data events]
   (let [dag-result (checkpoint-dag-result checkpoint-data)
         checkpoint-task-ids (set (:completed-task-ids dag-result))
@@ -283,23 +298,140 @@
         pause-task-ids
         #{})))
 
-(defn- restored-completed-dag-artifacts
-  [checkpoint-data events]
-  (let [dag-result (checkpoint-dag-result checkpoint-data)
-        checkpoint-artifacts (vec (get dag-result :artifacts []))
-        event-artifacts (extract-completed-dag-artifacts events)]
-    (if (seq checkpoint-artifacts)
-      checkpoint-artifacts
-      event-artifacts)))
+(defn- ^{:stratum 2} candidate-workflow-type
+  "Pull a candidate workflow-type keyword out of the recorded workflow
+   spec. Preference order:
 
-(defn- restored-workspace-checkpoint
+   1. `:workflow-type` — canonical key when callers thread it through
+   2. `:workflow/id`    — same shape as a workflow-config map
+   3. `:name`           — legacy / TUI shape; ONLY accepted when the
+      value is an unqualified workflow-type keyword/name matching a
+      strict keyword-name regex, because some producers
+      (notably the cli + TUI persistence path) record the human spec
+      title under `:name` and a title with spaces / slashes would
+      keywordize into an unloadable key.
+
+   Returns a keyword or nil."
+  [workflow-spec]
+  (let [keyword-if-valid (fn [v]
+                           (cond
+                             (valid-workflow-type-keyword? v) v
+                             (and (string? v)
+                                  (re-matches workflow-type-identifier-re v))
+                             (keyword v)
+                             :else nil))]
+    (or (keyword-if-valid (get workflow-spec :workflow-type))
+        (keyword-if-valid (get workflow-spec :workflow/id))
+        (keyword-if-valid (get workflow-spec :name)))))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn- ^{:stratum 3} config-set
+  [k]
+  (set (get @resume-config k)))
+
+(defn ^{:stratum 3} resolve-workflow-identity
+  "Resolve `{:workflow-type :workflow-version}` for a resume run.
+
+   Preference order for `:workflow-type`:
+
+   1. A keyword-valid identifier extracted from the recorded
+      `:workflow/spec` via `candidate-workflow-type` (tries
+      `:workflow-type`, `:workflow/id`, then `:name`).
+   2. The `:execution/workflow-id` from the machine snapshot, unless
+      it's a synthetic DAG-task key.
+   3. The caller-supplied `fallback-fn` (typically a selection profile).
+
+   Returns a `:not-found` anomaly if no source yields a loadable type.
+
+   Arguments:
+   - `reconstructed` — context map from `reconstruct-context`
+   - `fallback-fn`   — 0-arity; returns a type keyword or nil
+
+   Pre-2026-05-23: this fn did `(some-> workflow-spec :name keyword)`
+   unconditionally, which produced unloadable keywords like
+   `:In-flight PR / branch / task-claim registry` whenever a producer
+   recorded the spec title under `:name` (observed dogfooding
+   work/in-flight-pr-registry.spec.edn, workflow a92b2c97). The
+   identifier-regex gate above keeps the legacy path working for
+   well-formed names while rejecting human-title strings."
+  [reconstructed fallback-fn]
+  (anomaly/let-ok [_valid (schema/validate schema/ResolveWorkflowIdentityInput
+                                           {:reconstructed reconstructed
+                                            :fallback-fn fallback-fn}
+                                           {:message "Invalid resolve-workflow-identity input"
+                                            :schema-name :workflow-resume/resolve-workflow-identity})]
+    (let [workflow-spec (:workflow-spec reconstructed)
+          machine-snapshot (:machine-snapshot reconstructed)
+          workflow-id-from-snapshot (:execution/workflow-id machine-snapshot)
+          workflow-type (or (candidate-workflow-type workflow-spec)
+                            (when-not (synthetic-dag-task-workflow-id? workflow-id-from-snapshot)
+                              workflow-id-from-snapshot)
+                            (fallback-fn))
+          workflow-version (or (get workflow-spec :version)
+                               (:execution/workflow-version machine-snapshot)
+                               "latest")]
+      (if workflow-type
+        {:workflow-type workflow-type
+         :workflow-version workflow-version}
+        (anomaly/anomaly :not-found
+                         "Could not resolve a workflow type for resume"
+                         {:operation :resume-workflow
+                          :workflow-spec workflow-spec})))))
+
+;------------------------------------------------------------------------------ Layer 4
+
+(def ^{:stratum 4} completed-phase-statuses
+  "Phase result statuses that are safe to skip on resume."
+  (config-set :completed-phase-statuses))
+
+(def ^{:stratum 4} blocking-review-decisions
+  "Review decisions that must resume the repair path."
+  (config-set :blocking-review-decisions))
+
+;------------------------------------------------------------------------------ Layer 5
+
+(defn- ^{:stratum 5} review-blocked?
+  [phase-id phase-result]
+  (and (= :review phase-id)
+       (contains? blocking-review-decisions
+                  (response/review-decision (response/phase-output phase-result)))))
+
+;------------------------------------------------------------------------------ Layer 6
+
+(defn- ^{:stratum 6} completed-phase-result?
+  [phase-id phase-result]
+  (and phase-result
+       (not (review-blocked? phase-id phase-result))
+       (contains? completed-phase-statuses
+                  (phase-result-status phase-result))))
+
+;------------------------------------------------------------------------------ Layer 7
+
+(defn- ^{:stratum 7} completed-checkpoint-phases
+  [checkpoint-data phase-results]
+  (->> (checkpoint-phase-order checkpoint-data phase-results)
+       (filter #(completed-phase-result? % (get phase-results %)))))
+
+(defn- ^{:stratum 7} completed-event-phases
   [events]
-  (last (extract-workspace-checkpoints events)))
+  (let [event-results (extract-phase-results events)]
+    (->> (event-phase-order events)
+         (filter #(completed-phase-result? % (get event-results %))))))
 
-;------------------------------------------------------------------------------ Layer 1
+;------------------------------------------------------------------------------ Layer 8
+
+(defn- ^{:stratum 8} restored-completed-phases
+  [checkpoint-data events phase-results]
+  (->> (concat (completed-event-phases events)
+               (completed-checkpoint-phases checkpoint-data phase-results))
+       distinct
+       vec))
+
+;------------------------------------------------------------------------------ Layer 9
+
 ;; Context reconstruction
-
-(defn reconstruct-context
+(defn ^{:stratum 9} reconstruct-context
   "Build a complete resume-context map from a workflow id's events.
 
    Arguments:
@@ -365,124 +497,3 @@
            :dag-pause-reason (:pause-reason dag-pause-info)
            :machine-snapshot machine-snapshot
            :checkpoint-manifest (:manifest checkpoint-data)})))))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Pipeline trimming
-
-(defn trim-pipeline
-  "Drop the already-completed prefix from a workflow's pipeline.
-
-   Pure: takes a workflow map with `:workflow/pipeline` and a
-   collection of completed phase keywords; returns the workflow with only
-   leading completed phases removed. Completed phases after the first
-   incomplete phase are preserved."
-  [workflow completed-phases]
-  (anomaly/let-ok [_valid (schema/validate schema/TrimPipelineInput
-                                           {:workflow workflow
-                                            :completed-phases completed-phases}
-                                           {:message "Invalid trim-pipeline input"
-                                            :schema-name :workflow-resume/trim-pipeline})]
-    (let [completed-set (set completed-phases)
-          remaining (vec (drop-while #(completed-set (:phase %))
-                                     (get workflow :workflow/pipeline [])))]
-      (assoc workflow :workflow/pipeline remaining))))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Identity resolution
-
-(defn- synthetic-dag-task-workflow-id?
-  "True when the recorded workflow id is an internal DAG task workflow key,
-   not a loadable top-level workflow type from the registry."
-  [workflow-id]
-  (and (keyword? workflow-id)
-       (str/starts-with? (name workflow-id) "dag-task-")))
-
-(def ^:private workflow-type-identifier-re
-  "Regex for an unqualified workflow-type keyword name. Workflow types are loader keys
-   like :canonical-sdlc / :quick-fix — strict identifier characters only.
-   This rejects values like \"In-flight PR / branch / task-claim registry\"
-   (a human title that the producer side accidentally records under
-   `:name`) before they get keywordized into an unloadable lookup key."
-  #"^[A-Za-z][A-Za-z0-9._+!?*<>=-]*$")
-
-(defn- valid-workflow-type-keyword?
-  "True when `v` is an unqualified workflow-type keyword name."
-  [v]
-  (and (keyword? v)
-       (nil? (namespace v))
-       (re-matches workflow-type-identifier-re (name v))))
-
-(defn- candidate-workflow-type
-  "Pull a candidate workflow-type keyword out of the recorded workflow
-   spec. Preference order:
-
-   1. `:workflow-type` — canonical key when callers thread it through
-   2. `:workflow/id`    — same shape as a workflow-config map
-   3. `:name`           — legacy / TUI shape; ONLY accepted when the
-      value is an unqualified workflow-type keyword/name matching a
-      strict keyword-name regex, because some producers
-      (notably the cli + TUI persistence path) record the human spec
-      title under `:name` and a title with spaces / slashes would
-      keywordize into an unloadable key.
-
-   Returns a keyword or nil."
-  [workflow-spec]
-  (let [keyword-if-valid (fn [v]
-                           (cond
-                             (valid-workflow-type-keyword? v) v
-                             (and (string? v)
-                                  (re-matches workflow-type-identifier-re v))
-                             (keyword v)
-                             :else nil))]
-    (or (keyword-if-valid (get workflow-spec :workflow-type))
-        (keyword-if-valid (get workflow-spec :workflow/id))
-        (keyword-if-valid (get workflow-spec :name)))))
-
-(defn resolve-workflow-identity
-  "Resolve `{:workflow-type :workflow-version}` for a resume run.
-
-   Preference order for `:workflow-type`:
-
-   1. A keyword-valid identifier extracted from the recorded
-      `:workflow/spec` via `candidate-workflow-type` (tries
-      `:workflow-type`, `:workflow/id`, then `:name`).
-   2. The `:execution/workflow-id` from the machine snapshot, unless
-      it's a synthetic DAG-task key.
-   3. The caller-supplied `fallback-fn` (typically a selection profile).
-
-   Returns a `:not-found` anomaly if no source yields a loadable type.
-
-   Arguments:
-   - `reconstructed` — context map from `reconstruct-context`
-   - `fallback-fn`   — 0-arity; returns a type keyword or nil
-
-   Pre-2026-05-23: this fn did `(some-> workflow-spec :name keyword)`
-   unconditionally, which produced unloadable keywords like
-   `:In-flight PR / branch / task-claim registry` whenever a producer
-   recorded the spec title under `:name` (observed dogfooding
-   work/in-flight-pr-registry.spec.edn, workflow a92b2c97). The
-   identifier-regex gate above keeps the legacy path working for
-   well-formed names while rejecting human-title strings."
-  [reconstructed fallback-fn]
-  (anomaly/let-ok [_valid (schema/validate schema/ResolveWorkflowIdentityInput
-                                           {:reconstructed reconstructed
-                                            :fallback-fn fallback-fn}
-                                           {:message "Invalid resolve-workflow-identity input"
-                                            :schema-name :workflow-resume/resolve-workflow-identity})]
-    (let [workflow-spec (:workflow-spec reconstructed)
-          machine-snapshot (:machine-snapshot reconstructed)
-          workflow-id-from-snapshot (:execution/workflow-id machine-snapshot)
-          workflow-type (or (candidate-workflow-type workflow-spec)
-                            (when-not (synthetic-dag-task-workflow-id? workflow-id-from-snapshot)
-                              workflow-id-from-snapshot)
-                            (fallback-fn))
-          workflow-version (or (get workflow-spec :version)
-                               (:execution/workflow-version machine-snapshot)
-                               "latest")]
-      (if workflow-type
-        {:workflow-type workflow-type
-         :workflow-version workflow-version}
-        (anomaly/anomaly :not-found
-                         "Could not resolve a workflow type for resume"
-                         {:operation :resume-workflow
-                          :workflow-spec workflow-spec})))))

--- a/components/workflow-resume/src/ai/miniforge/workflow_resume/interface.clj
+++ b/components/workflow-resume/src/ai/miniforge/workflow_resume/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.workflow-resume.interface
   "Public API for workflow resume — reconstructing execution context
    from recorded events and preparing a trimmed workflow for re-run.
@@ -39,35 +38,35 @@
    [ai.miniforge.workflow-resume.core :as core]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Pure extractors
 
-(def completed?
+;; Pure extractors
+(def ^{:stratum 0} completed?
   "True when a reconstructed workflow context completed successfully.
    Arg: the context map from `reconstruct-context`. Returns boolean."
   core/completed?)
 
-(def failed?
+(def ^{:stratum 0} failed?
   "True when a reconstructed workflow context has failed.
    Arg: the context map from `reconstruct-context`. Returns boolean."
   core/failed?)
 
-(def paused?
+(def ^{:stratum 0} paused?
   "True when a reconstructed workflow context reflects a paused DAG.
    Arg: the context map from `reconstruct-context`. Returns boolean."
   core/paused?)
 
-(def extract-completed-dag-tasks
+(def ^{:stratum 0} extract-completed-dag-tasks
   "Task IDs that finished successfully as `:dag/task-completed` events.
    Arg: a sequence of events. Returns a set of task-id values."
   core/extract-completed-dag-tasks)
 
-(def extract-completed-dag-artifacts
+(def ^{:stratum 0} extract-completed-dag-artifacts
   "Artifacts recorded on successful `:dag/task-completed` events.
    Arg: a sequence of events. Returns a vector of artifact maps
    (empty when none)."
   core/extract-completed-dag-artifacts)
 
-(def extract-workspace-checkpoints
+(def ^{:stratum 0} extract-workspace-checkpoints
   "Workspace persistence records emitted at phase boundaries, used so a
    failed repair loop can resume from the last persisted branch/bundle
    rather than the spec base. Arg: a sequence of events. Returns a vector
@@ -76,34 +75,32 @@
    one of :bundle-path/:commit-sha are kept (empty when none)."
   core/extract-workspace-checkpoints)
 
-(def extract-dag-pause-info
+(def ^{:stratum 0} extract-dag-pause-info
   "Completed task IDs + pause reason from the last `:dag/paused` event.
    Arg: a sequence of events. Returns {:completed-task-ids set
    :pause-reason keyword-or-nil}, or nil when no pause event exists."
   core/extract-dag-pause-info)
 
-(def extract-completed-phases
+(def ^{:stratum 0} extract-completed-phases
   "Phase names (keywords) that completed — `:success` or `:skipped` outcome
    (see `core/completed-outcomes`). Arg: a sequence of events. Returns a vector
    of phase keywords in event order."
   core/extract-completed-phases)
 
-(def extract-phase-results
+(def ^{:stratum 0} extract-phase-results
   "Per-phase outcome/duration/timestamp from `:workflow/phase-completed`
    events. Arg: a sequence of events. Returns a map from phase keyword to
    {:outcome :duration-ms :timestamp} (empty when none)."
   core/extract-phase-results)
 
-(def find-workflow-spec
+(def ^{:stratum 0} find-workflow-spec
   "The workflow spec recorded on the first `:workflow/started` event.
    Arg: a sequence of events. Returns the spec value, or nil if the run
    never emitted one."
   core/find-workflow-spec)
 
-;------------------------------------------------------------------------------ Layer 1
 ;; High-level APIs
-
-(def reconstruct-context
+(def ^{:stratum 0} reconstruct-context
   "Build a complete resume-context map from a workflow id's events.
 
    Args:
@@ -121,7 +118,7 @@
    (missing/non-keyword `:event/type`) are dropped silently."
   core/reconstruct-context)
 
-(def trim-pipeline
+(def ^{:stratum 0} trim-pipeline
   "Drop the already-completed leading phases from a workflow's pipeline.
 
    Args: a workflow map with `:workflow/pipeline` and a collection of
@@ -130,7 +127,7 @@
    incomplete phase are preserved), or an anomaly on invalid input."
   core/trim-pipeline)
 
-(def resolve-workflow-identity
+(def ^{:stratum 0} resolve-workflow-identity
   "Resolve `{:workflow-type keyword :workflow-version string}` for a
    resume run.
 

--- a/components/workflow-resume/src/ai/miniforge/workflow_resume/schema.clj
+++ b/components/workflow-resume/src/ai/miniforge/workflow_resume/schema.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.workflow-resume.schema
   "Malli schemas for workflow-resume inputs + event shape.
 
@@ -34,23 +33,21 @@
    [malli.error :as me]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Event shape — minimum fields the component actually reads
 
-(def EventBase
+;; Event shape — minimum fields the component actually reads
+(def ^{:stratum 0} EventBase
   "Every event we care about has `:event/type` as the discriminator.
    Extractors filter on it; without it, an event has no meaning here."
   [:map {:closed false}
    [:event/type keyword?]])
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Inputs to the public API
-
-(def ReconstructContextInput
+(def ^{:stratum 0} ReconstructContextInput
   [:map {:closed false}
    [:events-dir some?]
    [:workflow-id [:or string? uuid?]]])
 
-(def TrimPipelineInput
+(def ^{:stratum 0} TrimPipelineInput
   [:map {:closed false}
    [:workflow [:map {:closed false}
                [:workflow/pipeline [:vector
@@ -58,24 +55,14 @@
                                      [:phase keyword?]]]]]]
    [:completed-phases [:sequential keyword?]]])
 
-(def ResolveWorkflowIdentityInput
+(def ^{:stratum 0} ResolveWorkflowIdentityInput
   [:map {:closed false}
    [:reconstructed [:map {:closed false}
                     [:workflow-spec {:optional true}
                      [:maybe [:map {:closed false}]]]]]
    [:fallback-fn fn?]])
 
-;------------------------------------------------------------------------------ Layer 1
-;; Validation helpers
-
-(defn valid-event?
-  "True when `ev` is a map with a keyword `:event/type`. Used by the
-   reader to filter events that were parseable-as-JSON but shaped
-   wrong (e.g. from an older miniforge with a different event format)."
-  [ev]
-  (m/validate EventBase ev))
-
-(defn validate
+(defn ^{:stratum 0} validate
   "Return `value` if it matches `schema`, otherwise return a canonical
    `:invalid-input` anomaly."
   [schema value opts]
@@ -88,3 +75,13 @@
      (merge {:schema (m/form schema)
              :errors (me/humanize (m/explain schema value))}
             (dissoc opts :message :schema-name)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Validation helpers
+(defn ^{:stratum 1} valid-event?
+  "True when `ev` is a map with a keyword `:event/type`. Used by the
+   reader to filter events that were parseable-as-JSON but shaped
+   wrong (e.g. from an older miniforge with a different event format)."
+  [ev]
+  (m/validate EventBase ev))

--- a/components/workflow-resume/test/ai/miniforge/workflow_resume/core_test.clj
+++ b/components/workflow-resume/test/ai/miniforge/workflow_resume/core_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.workflow-resume.core-test
   (:require
    [ai.miniforge.anomaly.interface :as anomaly]
@@ -28,9 +27,9 @@
    [clojure.test :refer [deftest testing is]]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Pure extractors
 
-(deftest missing-resume-config-resource-carries-invalid-config-marker
+;; Pure extractors
+(deftest ^{:stratum 0} missing-resume-config-resource-carries-invalid-config-marker
   (testing "Missing classpath resume config is an invalid configuration fault"
     (with-redefs [io/resource (constantly nil)]
       (let [result (@#'core/read-resume-config)]
@@ -41,7 +40,7 @@
         (is (= :invalid-config
                (get-in result [:anomaly/data :config/error])))))))
 
-(deftest reconstruct-context-propagates-resume-config-anomaly-test
+(deftest ^{:stratum 0} reconstruct-context-propagates-resume-config-anomaly-test
   (testing "configuration faults short-circuit before disk reads"
     (let [config-anomaly (anomaly/anomaly
                           :not-found
@@ -57,7 +56,7 @@
         (is (= config-anomaly
                (core/reconstruct-context "/tmp/unused-events" (str (random-uuid)))))))))
 
-(deftest reconstructed-status-predicates-test
+(deftest ^{:stratum 0} reconstructed-status-predicates-test
   (testing "predicates read the reconstructed status flags"
     (let [completed {:completed? true}
           failed {:failed? true}
@@ -70,7 +69,7 @@
       (is (true? (core/paused? paused)))
       (is (false? (core/paused? running))))))
 
-(deftest extract-completed-phases-test
+(deftest ^{:stratum 0} extract-completed-phases-test
   (testing ":success and :skipped count as completed; :failure does not"
     (let [events [{:event/type :workflow/started}
                   {:event/type :workflow/phase-completed
@@ -84,7 +83,7 @@
       (is (= [:explore :plan :release] (core/extract-completed-phases events))
           "a :skipped phase is completed (not re-run); a :failure is omitted"))))
 
-(deftest extract-phase-results-test
+(deftest ^{:stratum 0} extract-phase-results-test
   (testing "builds {phase → {:outcome :duration-ms :timestamp}}"
     (let [events [{:event/type :workflow/phase-completed
                    :workflow/phase :plan
@@ -114,14 +113,14 @@
           result (core/extract-phase-results events)]
       (is (not (contains? (get-in result [:plan :result] {}) :output))))))
 
-(deftest extract-completed-dag-tasks-test
+(deftest ^{:stratum 0} extract-completed-dag-tasks-test
   (testing "collects :dag/task-id values from :dag/task-completed events"
     (let [events [{:event/type :dag/task-completed :dag/task-id "t1"}
                   {:event/type :dag/task-completed :dag/task-id "t2"}
                   {:event/type :dag/task-failed    :dag/task-id "t3"}]]
       (is (= #{"t1" "t2"} (core/extract-completed-dag-tasks events))))))
 
-(deftest extract-completed-dag-artifacts-test
+(deftest ^{:stratum 0} extract-completed-dag-artifacts-test
   (testing "collects artifacts from :dag/task-completed events"
     (let [events [{:event/type :dag/task-completed
                    :dag/result {:data {:artifacts [{:artifact/id "a"}]}}}
@@ -133,7 +132,7 @@
       (is (= [{:artifact/id "a"} {:artifact/id "b"} {:artifact/id "c"}]
              (core/extract-completed-dag-artifacts events))))))
 
-(deftest extract-workspace-checkpoints-test
+(deftest ^{:stratum 0} extract-workspace-checkpoints-test
   (testing "collects persisted workspace provenance for failed-task resume"
     (let [events [{:event/type :workspace/persisted
                    :workspace/branch "task-a"
@@ -154,7 +153,7 @@
       (is (= "task-a" (:branch (first checkpoints))))
       (is (= "/tmp/task-b.bundle" (:bundle-path (second checkpoints)))))))
 
-(deftest extract-dag-pause-info-last-pause-wins-test
+(deftest ^{:stratum 0} extract-dag-pause-info-last-pause-wins-test
   (testing "multiple pause events — latest one wins"
     (let [events [{:event/type :dag/paused
                    :dag/completed-task-ids ["a"]
@@ -170,7 +169,7 @@
     (is (nil? (core/extract-dag-pause-info
                 [{:event/type :workflow/started}])))))
 
-(deftest find-workflow-spec-test
+(deftest ^{:stratum 0} find-workflow-spec-test
   (testing "returns :workflow/spec from the first :workflow/started event"
     (let [events [{:event/type :workflow/started
                    :workflow/spec {:name "planner-convergence" :version "1.0"}}
@@ -181,10 +180,8 @@
   (testing "nil when no :workflow/started event"
     (is (nil? (core/find-workflow-spec [{:event/type :workflow/phase-started}])))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; trim-pipeline
-
-(deftest trim-pipeline-test
+(deftest ^{:stratum 0} trim-pipeline-test
   (testing "already-completed phases are removed; remaining order preserved"
     (let [workflow {:workflow/pipeline [{:phase :explore}
                                         {:phase :plan}
@@ -218,10 +215,8 @@
               {:phase :release}]
              (:workflow/pipeline trimmed))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; resolve-workflow-identity
-
-(deftest resolve-workflow-identity-from-spec-test
+(deftest ^{:stratum 0} resolve-workflow-identity-from-spec-test
   (testing "recorded workflow spec wins — fallback-fn not called"
     (is (= {:workflow-type :financial-etl :workflow-version "1.2.3"}
            (core/resolve-workflow-identity
@@ -234,7 +229,7 @@
              {:workflow-spec {:name "lean-sdlc"}}
              (constantly nil))))))
 
-(deftest resolve-workflow-identity-from-machine-snapshot-test
+(deftest ^{:stratum 0} resolve-workflow-identity-from-machine-snapshot-test
   (testing "machine snapshot identity wins when no workflow spec is present"
     (is (= {:workflow-type :canonical-sdlc :workflow-version "2.0.0"}
            (core/resolve-workflow-identity
@@ -242,7 +237,7 @@
                                 :execution/workflow-version "2.0.0"}}
             (constantly nil))))))
 
-(deftest resolve-workflow-identity-ignores-synthetic-dag-task-workflow-id-test
+(deftest ^{:stratum 0} resolve-workflow-identity-ignores-synthetic-dag-task-workflow-id-test
   (testing "synthetic DAG task workflow ids fall back to a loadable top-level workflow type"
     (is (= {:workflow-type :default-sdlc :workflow-version "2.0.0"}
            (core/resolve-workflow-identity
@@ -250,7 +245,7 @@
                                 :execution/workflow-version "2.0.0"}}
             (constantly :default-sdlc))))))
 
-(deftest resolve-workflow-identity-fallback-test
+(deftest ^{:stratum 0} resolve-workflow-identity-fallback-test
   (testing "no spec → fallback-fn result used as :workflow-type"
     (is (= {:workflow-type :default-sdlc :workflow-version "latest"}
            (core/resolve-workflow-identity
@@ -264,7 +259,7 @@
       (is (= :resume-workflow
              (get-in result [:anomaly/data :operation]))))))
 
-(deftest resolve-workflow-identity-prefers-workflow-type-key-test
+(deftest ^{:stratum 0} resolve-workflow-identity-prefers-workflow-type-key-test
   (testing ":workflow-type wins over :name when both are present"
     (is (= {:workflow-type :canonical-sdlc :workflow-version "latest"}
            (core/resolve-workflow-identity
@@ -279,7 +274,7 @@
              {:workflow-spec {:workflow/id :canonical-sdlc :version "2.0.0"}}
              (constantly nil))))))
 
-(deftest resolve-workflow-identity-rejects-non-identifier-name-test
+(deftest ^{:stratum 0} resolve-workflow-identity-rejects-non-identifier-name-test
   ;; Regression for the 2026-05-22 dogfood of
   ;; work/in-flight-pr-registry.spec.edn (workflow a92b2c97), where the
   ;; recorded spec was {:name "In-flight PR / branch / task-claim
@@ -308,7 +303,7 @@
                              :version "latest"}}
             (fn [] :canonical-sdlc))))))
 
-(deftest resolve-workflow-identity-rejects-qualified-workflow-types-test
+(deftest ^{:stratum 0} resolve-workflow-identity-rejects-qualified-workflow-types-test
   (testing "slash-containing string identifiers are rejected before keywordization"
     (is (= {:workflow-type :canonical-sdlc :workflow-version "latest"}
            (core/resolve-workflow-identity
@@ -331,10 +326,8 @@
             {:workflow-spec {:name :foo/bar}}
             (fn [] :fallback-sdlc))))))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; reconstruct-context — integration with the event-stream reader
-
-(defn- with-temp-events-dir [body-fn]
+(defn- ^{:stratum 0} with-temp-events-dir [body-fn]
   (let [base (doto (io/file (System/getProperty "java.io.tmpdir")
                             (str "mf-wr-test-" (random-uuid)))
                .mkdirs)]
@@ -344,10 +337,10 @@
         (doseq [^java.io.File f (reverse (file-seq base))]
           (.delete f))))))
 
-(defn- write-event! [^java.io.File dir filename event-map]
+(defn- ^{:stratum 0} write-event! [^java.io.File dir filename event-map]
   (spit (io/file dir filename) (json/generate-string event-map)))
 
-(def resume-checkpoint-config
+(def ^{:stratum 0} resume-checkpoint-config
   {:base-machine-snapshot {:execution/workflow-id :canonical-sdlc
                            :execution/workflow-version "1.0.0"
                            :execution/status :failed}
@@ -366,14 +359,92 @@
                       :phase-results {:release {:status :retrying}
                                       :plan {:status :completed}}}})
 
-(defn- configured-checkpoint-data
+(deftest ^{:stratum 0} reconstruct-context-prefers-machine-snapshot-test
+  (testing "checkpoint data restores workflow and DAG resume state without requiring event files"
+    (let [workflow-id (str (random-uuid))
+          checkpoint-data {:machine-snapshot {:execution/id workflow-id
+                                             :execution/workflow-id :canonical-sdlc
+                                             :execution/workflow-version "1.0.0"
+                                             :execution/status :running
+                                             :execution/dag-result {:paused? true
+                                                                    :completed-task-ids ["task-1" "task-2"]
+                                                                    :artifacts [{:artifact/id "art-1"}]
+                                                                    :pause-reason :rate-limit}}
+                           :manifest {:workflow/phases-completed [:plan]}
+                           :phase-results {:plan {:status :completed}}}]
+      (with-redefs [workflow-checkpoints/load-checkpoint-data (fn [_workflow-run-id] checkpoint-data)
+                    es/read-workflow-events-by-id (fn [_events-dir _workflow-run-id] nil)]
+        (let [ctx (core/reconstruct-context "/tmp/unused-events" workflow-id)]
+          (is (= workflow-id (:workflow-id ctx)))
+          (is (= (:machine-snapshot checkpoint-data) (:machine-snapshot ctx)))
+          (is (= [:plan] (:completed-phases ctx)))
+          (is (= {:status :completed}
+                 (get-in ctx [:phase-results :plan])))
+          (is (= #{"task-1" "task-2"} (:completed-dag-tasks ctx)))
+          (is (= [{:artifact/id "art-1"}] (:completed-dag-artifacts ctx)))
+          (is (true? (:dag-paused? ctx)))
+          (is (= :rate-limit (:dag-pause-reason ctx)))
+          (is (= 0 (:event-count ctx))))))))
+
+(deftest ^{:stratum 0} reconstruct-context-uses-checkpoint-status-over-stale-terminal-events-test
+  (testing "a resumed running checkpoint overrides older failed events"
+    (let [workflow-id (str (random-uuid))
+          checkpoint-data {:machine-snapshot {:execution/id workflow-id
+                                             :execution/workflow-id :canonical-sdlc
+                                             :execution/workflow-version "1.0.0"
+                                             :execution/status :running}
+                           :manifest {:workflow/phases-completed [:plan]}
+                           :phase-results {:plan {:status :completed}}}
+          events [{:event/type :workflow/failed}]]
+      (with-redefs [workflow-checkpoints/load-checkpoint-data (fn [_workflow-run-id] checkpoint-data)
+                    es/read-workflow-events-by-id (fn [_events-dir _workflow-run-id] events)]
+        (let [ctx (core/reconstruct-context "/tmp/unused-events" workflow-id)]
+          (is (false? (:failed? ctx)))
+          (is (false? (:completed? ctx))))))))
+
+;; Interface re-exports
+(deftest ^{:stratum 0} interface-reexports-test
+  (testing "interface exposes the domain API"
+    (is (= core/completed? wr/completed?))
+    (is (= core/failed? wr/failed?))
+    (is (= core/paused? wr/paused?))
+    (is (= core/extract-completed-dag-tasks wr/extract-completed-dag-tasks))
+    (is (= core/extract-completed-dag-artifacts wr/extract-completed-dag-artifacts))
+    (is (= core/extract-workspace-checkpoints wr/extract-workspace-checkpoints))
+    (is (= core/extract-completed-phases wr/extract-completed-phases))
+    (is (= core/reconstruct-context wr/reconstruct-context))
+    (is (= core/trim-pipeline wr/trim-pipeline))
+    (is (= core/resolve-workflow-identity wr/resolve-workflow-identity))))
+
+(deftest ^{:stratum 0} trim-pipeline-validates-workflow-shape-test
+  (testing "workflow without :workflow/pipeline is rejected"
+    (let [result (core/trim-pipeline {:wrong-shape true} [])]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))))
+
+  (testing "pipeline entries without :phase keyword are rejected"
+    (let [result (core/trim-pipeline {:workflow/pipeline [{:no-phase "here"}]} [])]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result))))))
+
+(deftest ^{:stratum 0} resolve-workflow-identity-validates-fallback-fn-test
+  (testing "non-function fallback is rejected"
+    (let [result (core/resolve-workflow-identity
+                  {:workflow-spec {:name "x"}}
+                  "not a function")]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} configured-checkpoint-data
   [config-key workflow-id]
   (let [checkpoint (get resume-checkpoint-config config-key)]
     (assoc checkpoint :machine-snapshot
            (assoc (:base-machine-snapshot resume-checkpoint-config)
                   :execution/id workflow-id))))
 
-(deftest reconstruct-context-integration-test
+(deftest ^{:stratum 1} reconstruct-context-integration-test
   (with-temp-events-dir
     (fn [base-dir]
       (let [wf-id (str (random-uuid))
@@ -434,7 +505,7 @@
                     :timestamp nil}
                    (:workspace-checkpoint ctx)))))))))
 
-(deftest reconstruct-context-missing-workflow-test
+(deftest ^{:stratum 1} reconstruct-context-missing-workflow-test
   (with-temp-events-dir
     (fn [base-dir]
       (testing "missing workflow dir → :not-found anomaly"
@@ -442,98 +513,8 @@
           (is (anomaly/anomaly? result))
           (is (= :not-found (:anomaly/type result))))))))
 
-(deftest reconstruct-context-prefers-machine-snapshot-test
-  (testing "checkpoint data restores workflow and DAG resume state without requiring event files"
-    (let [workflow-id (str (random-uuid))
-          checkpoint-data {:machine-snapshot {:execution/id workflow-id
-                                             :execution/workflow-id :canonical-sdlc
-                                             :execution/workflow-version "1.0.0"
-                                             :execution/status :running
-                                             :execution/dag-result {:paused? true
-                                                                    :completed-task-ids ["task-1" "task-2"]
-                                                                    :artifacts [{:artifact/id "art-1"}]
-                                                                    :pause-reason :rate-limit}}
-                           :manifest {:workflow/phases-completed [:plan]}
-                           :phase-results {:plan {:status :completed}}}]
-      (with-redefs [workflow-checkpoints/load-checkpoint-data (fn [_workflow-run-id] checkpoint-data)
-                    es/read-workflow-events-by-id (fn [_events-dir _workflow-run-id] nil)]
-        (let [ctx (core/reconstruct-context "/tmp/unused-events" workflow-id)]
-          (is (= workflow-id (:workflow-id ctx)))
-          (is (= (:machine-snapshot checkpoint-data) (:machine-snapshot ctx)))
-          (is (= [:plan] (:completed-phases ctx)))
-          (is (= {:status :completed}
-                 (get-in ctx [:phase-results :plan])))
-          (is (= #{"task-1" "task-2"} (:completed-dag-tasks ctx)))
-          (is (= [{:artifact/id "art-1"}] (:completed-dag-artifacts ctx)))
-          (is (true? (:dag-paused? ctx)))
-          (is (= :rate-limit (:dag-pause-reason ctx)))
-          (is (= 0 (:event-count ctx))))))))
-
-(deftest reconstruct-context-uses-checkpoint-status-over-stale-terminal-events-test
-  (testing "a resumed running checkpoint overrides older failed events"
-    (let [workflow-id (str (random-uuid))
-          checkpoint-data {:machine-snapshot {:execution/id workflow-id
-                                             :execution/workflow-id :canonical-sdlc
-                                             :execution/workflow-version "1.0.0"
-                                             :execution/status :running}
-                           :manifest {:workflow/phases-completed [:plan]}
-                           :phase-results {:plan {:status :completed}}}
-          events [{:event/type :workflow/failed}]]
-      (with-redefs [workflow-checkpoints/load-checkpoint-data (fn [_workflow-run-id] checkpoint-data)
-                    es/read-workflow-events-by-id (fn [_events-dir _workflow-run-id] events)]
-        (let [ctx (core/reconstruct-context "/tmp/unused-events" workflow-id)]
-          (is (false? (:failed? ctx)))
-          (is (false? (:completed? ctx))))))))
-
-(deftest reconstruct-context-trims-only-completed-checkpoint-phases-test
-  (testing "checkpoint manifests may list failed/retrying phases; resume skips only completed results"
-    (let [workflow-id (str (random-uuid))
-          checkpoint-data (configured-checkpoint-data :blocked-review
-                                                      workflow-id)]
-      (with-redefs [workflow-checkpoints/load-checkpoint-data (fn [_workflow-run-id] checkpoint-data)
-                    es/read-workflow-events-by-id (fn [_events-dir _workflow-run-id] nil)]
-        (let [ctx (core/reconstruct-context "/tmp/unused-events" workflow-id)]
-          (is (= [:explore :plan :implement] (:completed-phases ctx))))))))
-
-(deftest reconstruct-context-merges-latest-successful-events-with-checkpoint-test
-  (testing "a damaged manifest can still resume from successful event history"
-    (let [workflow-id (str (random-uuid))
-          checkpoint-data (configured-checkpoint-data :damaged-manifest
-                                                      workflow-id)
-          events [{:event/type :workflow/phase-completed
-                   :workflow/phase :explore
-                   :phase/outcome :success}
-                  {:event/type :workflow/phase-completed
-                   :workflow/phase :implement
-                   :phase/outcome :failure}
-                  {:event/type :workflow/phase-completed
-                   :workflow/phase :verify
-                   :phase/outcome :success}]]
-      (with-redefs [workflow-checkpoints/load-checkpoint-data (fn [_workflow-run-id] checkpoint-data)
-                    es/read-workflow-events-by-id (fn [_events-dir _workflow-run-id] events)]
-        (let [ctx (core/reconstruct-context "/tmp/unused-events" workflow-id)]
-          (is (= [:explore :verify :plan] (:completed-phases ctx))))))))
-
-;------------------------------------------------------------------------------ Layer 3
-;; Interface re-exports
-
-(deftest interface-reexports-test
-  (testing "interface exposes the domain API"
-    (is (= core/completed? wr/completed?))
-    (is (= core/failed? wr/failed?))
-    (is (= core/paused? wr/paused?))
-    (is (= core/extract-completed-dag-tasks wr/extract-completed-dag-tasks))
-    (is (= core/extract-completed-dag-artifacts wr/extract-completed-dag-artifacts))
-    (is (= core/extract-workspace-checkpoints wr/extract-workspace-checkpoints))
-    (is (= core/extract-completed-phases wr/extract-completed-phases))
-    (is (= core/reconstruct-context wr/reconstruct-context))
-    (is (= core/trim-pipeline wr/trim-pipeline))
-    (is (= core/resolve-workflow-identity wr/resolve-workflow-identity))))
-
-;------------------------------------------------------------------------------ Layer 4
 ;; Validation — schemas enforce data shape at the component boundary
-
-(deftest reconstruct-context-validates-workflow-id-test
+(deftest ^{:stratum 1} reconstruct-context-validates-workflow-id-test
   (with-temp-events-dir
     (fn [base-dir]
       (testing "nil workflow-id is rejected before disk access"
@@ -546,7 +527,7 @@
           (is (anomaly/anomaly? result))
           (is (= :invalid-input (:anomaly/type result))))))))
 
-(deftest reconstruct-context-filters-malformed-events-test
+(deftest ^{:stratum 1} reconstruct-context-filters-malformed-events-test
   (with-temp-events-dir
     (fn [base-dir]
       (let [wf-id (str (random-uuid))
@@ -567,7 +548,7 @@
             (is (= 1 (:event-count ctx)))
             (is (= [:plan] (:completed-phases ctx)))))))))
 
-(deftest reconstruct-context-rejects-malformed-only-events-test
+(deftest ^{:stratum 1} reconstruct-context-rejects-malformed-only-events-test
   (with-temp-events-dir
     (fn [base-dir]
       (let [wf-id (str (random-uuid))
@@ -582,21 +563,33 @@
             (is (= :not-found (:anomaly/type result)))
             (is (= 2 (get-in result [:anomaly/data :raw-event-count])))))))))
 
-(deftest trim-pipeline-validates-workflow-shape-test
-  (testing "workflow without :workflow/pipeline is rejected"
-    (let [result (core/trim-pipeline {:wrong-shape true} [])]
-      (is (anomaly/anomaly? result))
-      (is (= :invalid-input (:anomaly/type result)))))
+;------------------------------------------------------------------------------ Layer 2
 
-  (testing "pipeline entries without :phase keyword are rejected"
-    (let [result (core/trim-pipeline {:workflow/pipeline [{:no-phase "here"}]} [])]
-      (is (anomaly/anomaly? result))
-      (is (= :invalid-input (:anomaly/type result))))))
+(deftest ^{:stratum 2} reconstruct-context-trims-only-completed-checkpoint-phases-test
+  (testing "checkpoint manifests may list failed/retrying phases; resume skips only completed results"
+    (let [workflow-id (str (random-uuid))
+          checkpoint-data (configured-checkpoint-data :blocked-review
+                                                      workflow-id)]
+      (with-redefs [workflow-checkpoints/load-checkpoint-data (fn [_workflow-run-id] checkpoint-data)
+                    es/read-workflow-events-by-id (fn [_events-dir _workflow-run-id] nil)]
+        (let [ctx (core/reconstruct-context "/tmp/unused-events" workflow-id)]
+          (is (= [:explore :plan :implement] (:completed-phases ctx))))))))
 
-(deftest resolve-workflow-identity-validates-fallback-fn-test
-  (testing "non-function fallback is rejected"
-    (let [result (core/resolve-workflow-identity
-                  {:workflow-spec {:name "x"}}
-                  "not a function")]
-      (is (anomaly/anomaly? result))
-      (is (= :invalid-input (:anomaly/type result))))))
+(deftest ^{:stratum 2} reconstruct-context-merges-latest-successful-events-with-checkpoint-test
+  (testing "a damaged manifest can still resume from successful event history"
+    (let [workflow-id (str (random-uuid))
+          checkpoint-data (configured-checkpoint-data :damaged-manifest
+                                                      workflow-id)
+          events [{:event/type :workflow/phase-completed
+                   :workflow/phase :explore
+                   :phase/outcome :success}
+                  {:event/type :workflow/phase-completed
+                   :workflow/phase :implement
+                   :phase/outcome :failure}
+                  {:event/type :workflow/phase-completed
+                   :workflow/phase :verify
+                   :phase/outcome :success}]]
+      (with-redefs [workflow-checkpoints/load-checkpoint-data (fn [_workflow-run-id] checkpoint-data)
+                    es/read-workflow-events-by-id (fn [_events-dir _workflow-run-id] events)]
+        (let [ctx (core/reconstruct-context "/tmp/unused-events" workflow-id)]
+          (is (= [:explore :verify :plan] (:completed-phases ctx))))))))

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-workflow-resume.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-workflow-resume.md
@@ -1,0 +1,138 @@
+<!--
+  Title: fix: stratum-lint autofix for components/workflow-resume (Wave 1)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+# fix: stratum-lint autofix for components/workflow-resume (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over `components/workflow-resume` (`src` + `test`)
+to replace non-monotonic `Layer N` headings with real `Layer N` headings and
+`^{:stratum n}` metadata derived from each file's actual same-file reference
+graph. Mechanical: no logic changes. One of the Wave 1 batch 5 per-component
+PRs from `work/stratum-lint-baseline-2026-07-24.md`.
+
+## Motivation
+
+Plain (non-`--fix`) `stratum-lint` on `components/workflow-resume` reported:
+
+```text
+core.clj:369:1: SL002 Layer 1 heading appears after Layer 1; headings must strictly increase
+core.clj:390:1: SL002 Layer 1 heading appears after Layer 1; headings must strictly increase
+schema.clj:68:1: SL002 Layer 1 heading appears after Layer 1; headings must strictly increase
+core_test.clj:221:1: SL002 Layer 1 heading appears after Layer 1; headings must strictly increase
+core_test.clj:533:1: SL003 file uses 5 distinct layers (max 3); split the namespace or extract a component
+```
+
+Zero `SL001`, confirming this component carries no upward-reference/cycle
+risk requiring human triage before running the mechanical fixer.
+`interface.clj` reported no findings at all pre-fix, but was still cargo-cult:
+its two headings (`Layer 0`, `Layer 1`) were monotonic so the checker passed
+it, yet every def under `Layer 1` ("High-level APIs") turned out to have zero
+same-file references — a decorative split, not a real one.
+
+## Changes in Detail
+
+Ran, over the whole component (pin from `tasks/stratum.clj`):
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "bef8657a2efd3b1ba9e1a4f510693c9fbca45abd" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/workflow-resume
+```
+
+All 4 `.clj` files in the component were rewritten (3 `src`, 1 `test`).
+Diffs are heading text, `^{:stratum n}` metadata, and def/deftest reordering
+only — no executable line changed:
+
+- `schema.clj`: `valid-event?` and `validate` were both mislabeled under
+  `Layer 1`/no metadata; `--fix` correctly placed both at real `Layer 0`
+  (neither has a same-file reference to anything past `EventBase`), leaving
+  a single real heading in the file.
+- `interface.clj`: the "High-level APIs" comment banner and its three
+  re-exports (`reconstruct-context`, `trim-pipeline`,
+  `resolve-workflow-identity`) sat under a `Layer 1` heading despite being
+  pure `core/...` var re-exports with zero same-file references — real
+  stratum for all of them is `Layer 0`. The file collapsed to one real
+  layer; the "High-level APIs" comment was kept as plain text since it no
+  longer contradicts any heading.
+- `core.clj`: the deepest file in the component. `reconstruct-context`'s
+  real call chain (`restored-completed-phases` → `completed-checkpoint-phases`
+  / `completed-event-phases` → `completed-phase-result?` → `review-blocked?`
+  → `blocking-review-decisions`/`completed-phase-statuses` → `resume-config`
+  → `read-resume-config`) recomputed to **10** real layers (0–9), previously
+  hidden under 2 non-monotonic `Layer 1` banners.
+- `core_test.clj`: deftest groups were scattered under repeated `Layer 1`/
+  `Layer 2`/`Layer 3` banners with no relationship to which helpers each test
+  actually exercised. Recomputed to 3 real layers (0–2) — the file's tests
+  mostly call the public API directly (`Layer 0`); `reconstruct-context-integration-test`
+  and the two checkpoint-manifest tests that depend on the private
+  `configured-checkpoint-data` helper landed at `Layer 1`/`Layer 2`.
+
+No same-line trailing comment was displaced onto the wrong def — grepped the
+diff for the known `foo])  ; comment` migration pattern; no matches. No
+decorative double-semicolon `;;---- Layer N: <label>` banners were left
+behind either — grepped all four files post-fix for `Layer`; every remaining
+occurrence is a real, single-semicolon, tool-generated heading.
+
+## Testing Plan
+
+1. Ran plain `stratum-lint` before the fix — reproduced the five findings
+   above exactly, zero `SL001`.
+2. Ran `--fix`, then a second `--fix` pass immediately after — zero diff
+   (empty output, exit 0), confirms idempotency.
+3. Read the full diff for all 4 changed files. Confirmed only heading text,
+   `^{:stratum n}` metadata, and def/deftest reordering changed; no
+   executable line touched.
+4. `clj-kondo --lint components/workflow-resume`: 0 errors, 0 warnings.
+   Confirmed identical result (`git stash` + re-lint) on the pre-fix tree —
+   not a pre-existing warning being masked.
+5. Ran the component's only test namespace directly (`clojure -M:dev:test -e
+   "(require 'ai.miniforge.workflow-resume.core-test) (clojure.test/run-tests
+   'ai.miniforge.workflow-resume.core-test)"`): 30 tests, 97 assertions, 0
+   failures, 0 errors.
+6. Re-ran plain `stratum-lint` after the fix. `SL001`/`SL002`/`SL004` clear.
+   `SL003` remains on one file, with the real layer count now precisely
+   measured from the true reference graph:
+   - `core.clj`: **new** finding — 0 pre-fix (the old headings only ever
+     used the values 0 and 1, so the checker never saw the file as
+     over-budget); true depth is **10** real layers, surfaced only once
+     `--fix` recomputed from the actual reference graph.
+   - `core_test.clj`: 5 → **3** real layers (old headings had two extra,
+     unneeded splits). Finding resolved — now within budget.
+
+   The `core.clj` `SL003` finding is a real over-budget file (Wave 2 scope:
+   namespace split), not addressed here. Committed with
+   `MINIFORGE_STRATUM_BUDGET_MODE=warn` alongside
+   `MINIFORGE_COMMIT_BUDGET_OVERRIDE=1` per the Wave 1 convention for
+   pre-existing over-budget files.
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+change — comment/metadata/order-only. Pre-commit's `lint:stratum` autofixer
+keeps this component clean going forward; `core.clj` stays advisory
+(`MINIFORGE_STRATUM_BUDGET_MODE=warn` at commit time) until Wave 2 splits it.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+- Follow-on: Wave 2 namespace split for `core.clj` (10 real layers, over the
+  3-layer budget) — likely split along the `reconstruct-context` restoration
+  chain (checkpoint/event merging) vs. `resolve-workflow-identity` vs. the
+  phase-completion predicate chain (`review-blocked?` /
+  `completed-phase-result?` / `completed-checkpoint-phases` /
+  `completed-event-phases` / `restored-completed-phases`).
+
+## Checklist
+
+- [x] Confirmed zero `SL001` findings before running `--fix`
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Second `--fix` pass confirms idempotency (zero diff)
+- [x] Diff read in full for all 4 changed files; mechanical-only
+- [x] No decorative `;;---- Layer N: <label>` banners left behind
+- [x] `clj-kondo` clean (0 errors, 0 warnings), confirmed not pre-existing
+- [x] Component's test namespace passes (30 tests, 97 assertions, 0
+      failures/errors)
+- [x] Plain lint re-run post-fix: `SL003` remains on `core.clj` (10 real
+      layers), documented above, tracked as Wave 2
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
<!--
  Title: fix: stratum-lint autofix for components/workflow-resume (Wave 1)
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->
# fix: stratum-lint autofix for components/workflow-resume (Wave 1)

## Overview

Runs `stratum-lint --fix` over `components/workflow-resume` (`src` + `test`)
to replace non-monotonic `Layer N` headings with real `Layer N` headings and
`^{:stratum n}` metadata derived from each file's actual same-file reference
graph. Mechanical: no logic changes. One of the Wave 1 batch 5 per-component
PRs from `work/stratum-lint-baseline-2026-07-24.md`.

## Motivation

Plain (non-`--fix`) `stratum-lint` on `components/workflow-resume` reported:

```text
core.clj:369:1: SL002 Layer 1 heading appears after Layer 1; headings must strictly increase
core.clj:390:1: SL002 Layer 1 heading appears after Layer 1; headings must strictly increase
schema.clj:68:1: SL002 Layer 1 heading appears after Layer 1; headings must strictly increase
core_test.clj:221:1: SL002 Layer 1 heading appears after Layer 1; headings must strictly increase
core_test.clj:533:1: SL003 file uses 5 distinct layers (max 3); split the namespace or extract a component
```

Zero `SL001`, confirming this component carries no upward-reference/cycle
risk requiring human triage before running the mechanical fixer.
`interface.clj` reported no findings at all pre-fix, but was still cargo-cult:
its two headings (`Layer 0`, `Layer 1`) were monotonic so the checker passed
it, yet every def under `Layer 1` ("High-level APIs") turned out to have zero
same-file references — a decorative split, not a real one.

## Changes in Detail

Ran, over the whole component (pin from `tasks/stratum.clj`):

```bash
bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "bef8657a2efd3b1ba9e1a4f510693c9fbca45abd" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/workflow-resume
```

All 4 `.clj` files in the component were rewritten (3 `src`, 1 `test`).
Diffs are heading text, `^{:stratum n}` metadata, and def/deftest reordering
only — no executable line changed:

- `schema.clj`: `valid-event?` and `validate` were both mislabeled under
  `Layer 1`/no metadata; `--fix` correctly placed both at real `Layer 0`
  (neither has a same-file reference to anything past `EventBase`), leaving
  a single real heading in the file.
- `interface.clj`: the "High-level APIs" comment banner and its three
  re-exports (`reconstruct-context`, `trim-pipeline`,
  `resolve-workflow-identity`) sat under a `Layer 1` heading despite being
  pure `core/...` var re-exports with zero same-file references — real
  stratum for all of them is `Layer 0`. The file collapsed to one real
  layer; the "High-level APIs" comment was kept as plain text since it no
  longer contradicts any heading.
- `core.clj`: the deepest file in the component. `reconstruct-context`'s
  real call chain (`restored-completed-phases` → `completed-checkpoint-phases`
  / `completed-event-phases` → `completed-phase-result?` → `review-blocked?`
  → `blocking-review-decisions`/`completed-phase-statuses` → `resume-config`
  → `read-resume-config`) recomputed to **10** real layers (0–9), previously
  hidden under 2 non-monotonic `Layer 1` banners.
- `core_test.clj`: deftest groups were scattered under repeated `Layer 1`/
  `Layer 2`/`Layer 3` banners with no relationship to which helpers each test
  actually exercised. Recomputed to 3 real layers (0–2) — the file's tests
  mostly call the public API directly (`Layer 0`); `reconstruct-context-integration-test`
  and the two checkpoint-manifest tests that depend on the private
  `configured-checkpoint-data` helper landed at `Layer 1`/`Layer 2`.

No same-line trailing comment was displaced onto the wrong def — grepped the
diff for the known `foo])  ; comment` migration pattern; no matches. No
decorative double-semicolon `;;---- Layer N: <label>` banners were left
behind either — grepped all four files post-fix for `Layer`; every remaining
occurrence is a real, single-semicolon, tool-generated heading.

## Testing Plan

1. Ran plain `stratum-lint` before the fix — reproduced the five findings
   above exactly, zero `SL001`.
2. Ran `--fix`, then a second `--fix` pass immediately after — zero diff
   (empty output, exit 0), confirms idempotency.
3. Read the full diff for all 4 changed files. Confirmed only heading text,
   `^{:stratum n}` metadata, and def/deftest reordering changed; no
   executable line touched.
4. `clj-kondo --lint components/workflow-resume`: 0 errors, 0 warnings.
   Confirmed identical result (`git stash` + re-lint) on the pre-fix tree —
   not a pre-existing warning being masked.
5. Ran the component's only test namespace directly (`clojure -M:dev:test -e
   "(require 'ai.miniforge.workflow-resume.core-test) (clojure.test/run-tests
   'ai.miniforge.workflow-resume.core-test)"`): 30 tests, 97 assertions, 0
   failures, 0 errors.
6. Re-ran plain `stratum-lint` after the fix. `SL001`/`SL002`/`SL004` clear.
   `SL003` remains on one file, with the real layer count now precisely
   measured from the true reference graph:
   - `core.clj`: **new** finding — 0 pre-fix (the old headings only ever
     used the values 0 and 1, so the checker never saw the file as
     over-budget); true depth is **10** real layers, surfaced only once
     `--fix` recomputed from the actual reference graph.
   - `core_test.clj`: 5 → **3** real layers (old headings had two extra,
     unneeded splits). Finding resolved — now within budget.

   The `core.clj` `SL003` finding is a real over-budget file (Wave 2 scope:
   namespace split), not addressed here. Committed with
   `MINIFORGE_STRATUM_BUDGET_MODE=warn` alongside
   `MINIFORGE_COMMIT_BUDGET_OVERRIDE=1` per the Wave 1 convention for
   pre-existing over-budget files.

## Deployment Plan

Merges to `main` like any other component change. No runtime behavior
change — comment/metadata/order-only. Pre-commit's `lint:stratum` autofixer
keeps this component clean going forward; `core.clj` stays advisory
(`MINIFORGE_STRATUM_BUDGET_MODE=warn` at commit time) until Wave 2 splits it.

## Related Issues/PRs

- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
- Follow-on: Wave 2 namespace split for `core.clj` (10 real layers, over the
  3-layer budget) — likely split along the `reconstruct-context` restoration
  chain (checkpoint/event merging) vs. `resolve-workflow-identity` vs. the
  phase-completion predicate chain (`review-blocked?` /
  `completed-phase-result?` / `completed-checkpoint-phases` /
  `completed-event-phases` / `restored-completed-phases`).

## Checklist

- [x] Confirmed zero `SL001` findings before running `--fix`
- [x] `--fix` run over the whole component (`src` + `test`)
- [x] Second `--fix` pass confirms idempotency (zero diff)
- [x] Diff read in full for all 4 changed files; mechanical-only
- [x] No decorative `;;---- Layer N: <label>` banners left behind
- [x] `clj-kondo` clean (0 errors, 0 warnings), confirmed not pre-existing
- [x] Component's test namespace passes (30 tests, 97 assertions, 0
      failures/errors)
- [x] Plain lint re-run post-fix: `SL003` remains on `core.clj` (10 real
      layers), documented above, tracked as Wave 2
- [x] No `--no-verify`; pre-commit hook runs normally at commit time
