### PR TITLE
fix: stratum-lint autofix for components/connector-github (Wave 1)

### DIFF
--- a/components/connector-github/src/ai/miniforge/connector_github/core.clj
+++ b/components/connector-github/src/ai/miniforge/connector_github/core.clj
@@ -15,13 +15,14 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-github.core
   "GitHubConnector defrecord — thin protocol wrapper delegating to impl."
   (:require [ai.miniforge.connector.interface :as connector]
             [ai.miniforge.connector-github.impl :as impl]))
 
-(defrecord GitHubConnector []
+;------------------------------------------------------------------------------ Layer 0
+
+(defrecord ^{:stratum 0} GitHubConnector []
   connector/Connector
   (connect    [_ config auth]                      (impl/do-connect config auth))
   (close      [_ handle]                           (impl/do-close handle))

--- a/components/connector-github/src/ai/miniforge/connector_github/impl.clj
+++ b/components/connector-github/src/ai/miniforge/connector_github/impl.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-github.impl
   "Implementation functions for the GitHub REST API connector."
   (:require [ai.miniforge.anomaly.interface :as anomaly]
@@ -27,18 +26,13 @@
             [ai.miniforge.response.interface :as response])
   (:import [java.util UUID]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; -- Handle state --
-
-(def ^:private handles (connector/create-handle-registry))
-
-(defn get-handle [handle] (connector/get-handle handles handle))
-(defn store-handle! [handle state] (connector/store-handle! handles handle state))
-(defn remove-handle! [handle] (connector/remove-handle! handles handle))
-(defn touch-handle! [handle] (connector/touch-handle! handles handle))
+(def ^{:stratum 0} ^:private handles (connector/create-handle-registry))
 
 ;; -- Auth --
-
-(defn- build-auth-headers
+(defn- ^{:stratum 0} build-auth-headers
   "Build authorization headers from auth config.
    Supports :api-key (Bearer token) and :oauth2 (Bearer token)."
   [{:auth/keys [method credential-id]}]
@@ -50,66 +44,42 @@
 ;; -- Rate limiting --
 ;; Uses response-header-driven rate limiting via connector-http/rate-limit.
 ;; GitHub returns x-ratelimit-remaining and x-ratelimit-reset on every response.
-
-(def ^:private github-rate-headers
+(def ^{:stratum 0} ^:private github-rate-headers
   {:remaining "x-ratelimit-remaining"
    :reset     "x-ratelimit-reset"
    :limit     "x-ratelimit-limit"})
 
-(defn- update-rate-limits!
-  "Parse rate limit headers from a response and store in handle state."
-  [handle response-headers]
-  (when-let [info (http/parse-rate-headers response-headers github-rate-headers)]
-    (http/update-rate-state! handles handle info)))
-
 ;; -- Record filters --
-
-(defn- issue-not-pr?
+(defn- ^{:stratum 0} issue-not-pr?
   "Predicate: true if a GitHub issue record is NOT a pull request.
    GitHub's /issues endpoint returns PRs mixed in — they have a :pull_request key."
   [record]
   (nil? (:pull_request record)))
 
-(defn- filter-issues
-  "Filter PRs from issues endpoint results. Only applied to :issues resource."
-  [resource-key records]
-  (if (= :issues resource-key)
-    (filterv issue-not-pr? records)
-    records))
-
 ;; -- HTTP helpers --
-
-(defn- github-headers
+(defn- ^{:stratum 0} github-headers
   "Merge auth headers with GitHub-required headers."
   [auth-headers]
   (merge auth-headers
          {"Accept"               "application/vnd.github+json"
           "X-GitHub-Api-Version" "2022-11-28"}))
 
-(defn- error-response
+(defn- ^{:stratum 0} error-response
   [status resp]
   (http/error-response status resp
     {:rate-limited   (msg/t :github/rate-limited)
      :request-failed (fn [s e] (msg/t :github/request-failed {:status s :error e}))}))
 
-(defn- do-request
-  [url headers query-params]
-  (http/do-request url headers query-params error-response))
-
-(defn- response-records
-  [resource-key resp]
-  (filter-issues resource-key (http/coerce-records (:body resp))))
-
-(defn- final-cursor
+(defn- ^{:stratum 0} final-cursor
   [resource-def records]
   (http/last-record-cursor resource-def records))
 
-(defn- page-fetch-result
+(defn- ^{:stratum 0} page-fetch-result
   [records cursor]
   {:records records
    :cursor  cursor})
 
-(defn- timestamp-value
+(defn- ^{:stratum 0} timestamp-value
   "Extract the most recent timestamp from a record.
    Reviews use :submitted_at; other resources use :updated_at/:created_at."
   [record]
@@ -117,32 +87,7 @@
       (:created_at record)
       (:submitted_at record)))
 
-(defn- fetch-all-pages
-  [handle resource-key resource-def headers url query-params]
-  (loop [next-request-url url
-         next-query-params query-params
-         accumulated []]
-    (http/acquire-permit! handles handle {})
-    (let [resp (http/throw-on-failure! (do-request next-request-url headers next-query-params))]
-      (update-rate-limits! handle (:headers resp))
-      (touch-handle! handle)
-      (if (:not-modified resp)
-        (page-fetch-result [] nil)
-        (let [page-records (response-records resource-key resp)
-              all-records  (into accumulated page-records)]
-          (if-let [next-link (http/next-url resp)]
-            (recur next-link nil all-records)
-            (page-fetch-result all-records
-                               (final-cursor resource-def all-records))))))))
-
-
-(defn- resource-records
-  [handle resource-key resource-def config headers cursor opts]
-  (let [url          (resources/build-url (:github/base-url config) resource-def config)
-        query-params (resources/build-query-params resource-def cursor opts)]
-    (:records (fetch-all-pages handle resource-key resource-def headers url query-params))))
-
-(defn- enrich-review
+(defn- ^{:stratum 0} enrich-review
   [pull review]
   (assoc review
          :pull_number (:number pull)
@@ -151,39 +96,7 @@
          :pull_html_url (:html_url pull)
          :pull_state (:state pull)))
 
-(defn- pull-review-records
-  [handle reviews-resource config headers cursor opts pull]
-  (let [review-config (assoc config :github/pull-number (:number pull))
-        records       (resource-records handle :reviews reviews-resource review-config headers nil opts)]
-    (->> records
-         (map #(enrich-review pull %))
-         (filter #(http/after-cursor? timestamp-value cursor %)))))
-
-(defn- extract-reviews
-  [handle config headers cursor opts]
-  (let [pulls-resource (resources/get-resource :pulls)
-        pulls          (resource-records handle :pulls pulls-resource config headers cursor opts)
-        reviews        (->> pulls
-                            (mapcat #(pull-review-records handle
-                                                          (resources/get-resource :reviews)
-                                                          config
-                                                          headers
-                                                          cursor
-                                                          opts
-                                                          %))
-                            (http/sort-by-timestamp timestamp-value)
-                            vec)]
-    (connector/extract-result reviews (http/max-timestamp-cursor timestamp-value reviews) false)))
-
-;; -- Helpers --
-
-(defn- require-handle
-  "Retrieve handle state or return an anomaly."
-  [handle]
-  (connector/require-handle handles handle
-                            {:message (msg/t :github/handle-not-found {:handle handle})}))
-
-(defn- require-resource!
+(defn- ^{:stratum 0} require-resource!
   "Look up resource def or throw."
   [schema-name]
   (or (resources/get-resource (keyword schema-name))
@@ -191,18 +104,57 @@
                                (msg/t :github/resource-unknown {:resource schema-name})
                                {:resource schema-name})))
 
-(defn- validation-errors
+(defn- ^{:stratum 0} validation-errors
   "Extract errors from a validation result, centralizing knowledge of the :errors key."
   [result]
   (:errors result))
 
-(defn- connector-anomaly->response
+(defn- ^{:stratum 0} connector-anomaly->response
   "Convert connector validation anomalies to the response anomaly shape
    expected by current connector protocol consumers."
   [category message anomaly]
   (response/make-anomaly category message (:anomaly/data anomaly)))
 
-(defn- validate-connect
+(defn ^{:stratum 0} do-checkpoint
+  "Persist cursor state. Returns checkpoint-result."
+  [cursor-state]
+  (connector/checkpoint-result cursor-state))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} get-handle [handle] (connector/get-handle handles handle))
+
+(defn ^{:stratum 1} store-handle! [handle state] (connector/store-handle! handles handle state))
+
+(defn ^{:stratum 1} remove-handle! [handle] (connector/remove-handle! handles handle))
+
+(defn ^{:stratum 1} touch-handle! [handle] (connector/touch-handle! handles handle))
+
+(defn- ^{:stratum 1} update-rate-limits!
+  "Parse rate limit headers from a response and store in handle state."
+  [handle response-headers]
+  (when-let [info (http/parse-rate-headers response-headers github-rate-headers)]
+    (http/update-rate-state! handles handle info)))
+
+(defn- ^{:stratum 1} filter-issues
+  "Filter PRs from issues endpoint results. Only applied to :issues resource."
+  [resource-key records]
+  (if (= :issues resource-key)
+    (filterv issue-not-pr? records)
+    records))
+
+(defn- ^{:stratum 1} do-request
+  [url headers query-params]
+  (http/do-request url headers query-params error-response))
+
+;; -- Helpers --
+(defn- ^{:stratum 1} require-handle
+  "Retrieve handle state or return an anomaly."
+  [handle]
+  (connector/require-handle handles handle
+                            {:message (msg/t :github/handle-not-found {:handle handle})}))
+
+(defn- ^{:stratum 1} validate-connect
   "Validate config and auth sequentially.
 
    Returns nil on success. Returns a response anomaly map for config
@@ -228,8 +180,14 @@
                                        (msg/t :github/auth-invalid {:errors errors})
                                        auth-anomaly))))))
 
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- ^{:stratum 2} response-records
+  [resource-key resp]
+  (filter-issues resource-key (http/coerce-records (:body resp))))
+
 ;; -- Lifecycle --
-(defn do-connect
+(defn ^{:stratum 2} do-connect
   "Validate config and auth, register handle.
 
    Returns a connect-result map on success or a response anomaly map when
@@ -245,15 +203,14 @@
                              :last-request-at nil})
       (connector/connect-result handle))))
 
-(defn do-close
+(defn ^{:stratum 2} do-close
   "Remove handle state. Returns close-result."
   [handle]
   (remove-handle! handle)
   (connector/close-result))
 
 ;; -- Source --
-
-(defn do-discover
+(defn ^{:stratum 2} do-discover
   "Return available resource schemas based on config."
   [handle]
   (let [handle-state (require-handle handle)]
@@ -263,7 +220,65 @@
                                    handle-state)
       (connector/discover-result (resources/resource-schemas)))))
 
-(defn do-extract
+;------------------------------------------------------------------------------ Layer 3
+
+(defn- ^{:stratum 3} fetch-all-pages
+  [handle resource-key resource-def headers url query-params]
+  (loop [next-request-url url
+         next-query-params query-params
+         accumulated []]
+    (http/acquire-permit! handles handle {})
+    (let [resp (http/throw-on-failure! (do-request next-request-url headers next-query-params))]
+      (update-rate-limits! handle (:headers resp))
+      (touch-handle! handle)
+      (if (:not-modified resp)
+        (page-fetch-result [] nil)
+        (let [page-records (response-records resource-key resp)
+              all-records  (into accumulated page-records)]
+          (if-let [next-link (http/next-url resp)]
+            (recur next-link nil all-records)
+            (page-fetch-result all-records
+                               (final-cursor resource-def all-records))))))))
+
+;------------------------------------------------------------------------------ Layer 4
+
+(defn- ^{:stratum 4} resource-records
+  [handle resource-key resource-def config headers cursor opts]
+  (let [url          (resources/build-url (:github/base-url config) resource-def config)
+        query-params (resources/build-query-params resource-def cursor opts)]
+    (:records (fetch-all-pages handle resource-key resource-def headers url query-params))))
+
+;------------------------------------------------------------------------------ Layer 5
+
+(defn- ^{:stratum 5} pull-review-records
+  [handle reviews-resource config headers cursor opts pull]
+  (let [review-config (assoc config :github/pull-number (:number pull))
+        records       (resource-records handle :reviews reviews-resource review-config headers nil opts)]
+    (->> records
+         (map #(enrich-review pull %))
+         (filter #(http/after-cursor? timestamp-value cursor %)))))
+
+;------------------------------------------------------------------------------ Layer 6
+
+(defn- ^{:stratum 6} extract-reviews
+  [handle config headers cursor opts]
+  (let [pulls-resource (resources/get-resource :pulls)
+        pulls          (resource-records handle :pulls pulls-resource config headers cursor opts)
+        reviews        (->> pulls
+                            (mapcat #(pull-review-records handle
+                                                          (resources/get-resource :reviews)
+                                                          config
+                                                          headers
+                                                          cursor
+                                                          opts
+                                                          %))
+                            (http/sort-by-timestamp timestamp-value)
+                            vec)]
+    (connector/extract-result reviews (http/max-timestamp-cursor timestamp-value reviews) false)))
+
+;------------------------------------------------------------------------------ Layer 7
+
+(defn ^{:stratum 7} do-extract
   "Extract records from a GitHub API resource."
   [handle schema-name opts]
   (let [handle-state (require-handle handle)]
@@ -282,8 +297,3 @@
                 query-params (resources/build-query-params resource-def cursor opts)
                 {:keys [records cursor]} (fetch-all-pages handle resource-key resource-def headers url query-params)]
             (connector/extract-result records cursor false)))))))
-
-(defn do-checkpoint
-  "Persist cursor state. Returns checkpoint-result."
-  [cursor-state]
-  (connector/checkpoint-result cursor-state))

--- a/components/connector-github/src/ai/miniforge/connector_github/interface.clj
+++ b/components/connector-github/src/ai/miniforge/connector_github/interface.clj
@@ -15,18 +15,19 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-github.interface
   "Public API for the GitHub REST API connector component."
   (:require [ai.miniforge.connector-github.core :as core]
             [ai.miniforge.connector.interface :as conn]))
 
-(defn create-github-connector
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} create-github-connector
   "Create a new GitHubConnector instance."
   []
   (core/->GitHubConnector))
 
-(def connector-metadata
+(def ^{:stratum 0} connector-metadata
   "Registration metadata for the GitHub REST API connector."
   {:connector/name         "GitHub REST API Connector"
    :connector/type         :source

--- a/components/connector-github/src/ai/miniforge/connector_github/messages.clj
+++ b/components/connector-github/src/ai/miniforge/connector_github/messages.clj
@@ -15,11 +15,12 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-github.messages
   "Message catalog — delegates to ai.miniforge.messages."
   (:require [ai.miniforge.messages.interface :as messages]))
 
-(def t
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} t
   "Look up a message by key, with optional param substitution."
   (messages/create-translator "config/connector-github/messages/en-US.edn" :connector-github/messages))

--- a/components/connector-github/src/ai/miniforge/connector_github/resources.clj
+++ b/components/connector-github/src/ai/miniforge/connector_github/resources.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-github.resources
   "GitHub resource type registry and URL/param builders.
    Resource definitions are loaded from an EDN resource file at startup."
@@ -25,27 +24,11 @@
             [clojure.java.io :as io]
             [clojure.string :as str]))
 
-(def ^:private resource-path "config/connector-github/resources.edn")
+;------------------------------------------------------------------------------ Layer 0
 
-(defn- load-resources []
-  (if-let [res (io/resource resource-path)]
-    (edn/read-string (slurp res))
-    (response/throw-anomaly! :anomalies/not-found
-                             (msg/t :github/resources-not-found {:path resource-path})
-                             {:path resource-path
-                              :classpath/resource resource-path
-                              :config/resource resource-path})))
+(def ^{:stratum 0} ^:private resource-path "config/connector-github/resources.edn")
 
-(def github-resources
-  "Registry of GitHub REST API v3 resource types, loaded from EDN."
-  (delay (load-resources)))
-
-(defn get-resource
-  "Look up a resource definition by key."
-  [resource-key]
-  (get @github-resources resource-key))
-
-(defn build-url
+(defn ^{:stratum 0} build-url
   "Build a GitHub API URL by substituting {org}, {owner}, {repo}, {pull_number}
    from config into the resource endpoint template."
   [base-url resource-def config]
@@ -61,7 +44,7 @@
              (str/replace "{repo}" (or (:github/repo config) ""))
              (str/replace "{pull_number}" (str (or (:github/pull-number config) "")))))))
 
-(defn build-query-params
+(defn ^{:stratum 0} build-query-params
   "Build query params for a GitHub API request, merging resource defaults,
    sort/direction, per_page, and incremental cursor value."
   [resource-def cursor opts]
@@ -77,7 +60,31 @@
       (and incr-param cursor-value)
       (assoc incr-param cursor-value))))
 
-(defn resource-schemas
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} load-resources []
+  (if-let [res (io/resource resource-path)]
+    (edn/read-string (slurp res))
+    (response/throw-anomaly! :anomalies/not-found
+                             (msg/t :github/resources-not-found {:path resource-path})
+                             {:path resource-path
+                              :classpath/resource resource-path
+                              :config/resource resource-path})))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(def ^{:stratum 2} github-resources
+  "Registry of GitHub REST API v3 resource types, loaded from EDN."
+  (delay (load-resources)))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} get-resource
+  "Look up a resource definition by key."
+  [resource-key]
+  (get @github-resources resource-key))
+
+(defn ^{:stratum 3} resource-schemas
   "Return discover-compatible schema list for all known GitHub resources."
   []
   (mapv (fn [[resource-key resource-def]]

--- a/components/connector-github/src/ai/miniforge/connector_github/schema.clj
+++ b/components/connector-github/src/ai/miniforge/connector_github/schema.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-github.schema
   "Malli schemas for the GitHub connector.
 
@@ -27,30 +26,19 @@
    [malli.error :as me]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Enums and base types
 
-(def auth-methods
+;; Enums and base types
+(def ^{:stratum 0} auth-methods
   [:api-key :oauth2])
 
-(def AuthMethod
-  (into [:enum] auth-methods))
-
-(def capabilities
+(def ^{:stratum 0} capabilities
   [:cap/discovery :cap/incremental :cap/pagination :cap/rate-limiting])
 
-(def Capability
-  (into [:enum] capabilities))
-
-(def connector-types
+(def ^{:stratum 0} connector-types
   [:source :sink])
 
-(def ConnectorType
-  (into [:enum] connector-types))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; Config and metadata schemas
-
-(def GitHubConfig
+(def ^{:stratum 0} GitHubConfig
   "Schema for GitHub connector configuration.
    Requires either :github/org or :github/owner (or both)."
   [:map
@@ -60,7 +48,50 @@
    [:github/repo {:optional true} string?]
    [:github/pull-number {:optional true} int?]])
 
-(def ConnectorMetadata
+;; Validation helpers
+(defn ^{:stratum 0} valid?
+  "1-arity: predicate on a validation result map — true iff :valid? is true.
+   2-arity: validate value against a Malli schema."
+  ([result] (true? (:valid? result)))
+  ([schema value] (m/validate schema value)))
+
+(defn ^{:stratum 0} validate
+  "Validate value against schema. Returns {:valid? bool :errors map-or-nil}."
+  [schema value]
+  (if (m/validate schema value)
+    {:valid? true :errors nil}
+    {:valid? false
+     :errors (me/humanize (m/explain schema value))}))
+
+(defn ^{:stratum 0} explain
+  [schema value]
+  (when-let [explanation (m/explain schema value)]
+    (me/humanize explanation)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} AuthMethod
+  (into [:enum] auth-methods))
+
+(def ^{:stratum 1} Capability
+  (into [:enum] capabilities))
+
+(def ^{:stratum 1} ConnectorType
+  (into [:enum] connector-types))
+
+(defn ^{:stratum 1} invalid?
+  "Predicate: did this validation result fail? Complement of valid?/1."
+  [result]
+  (not (valid? result)))
+
+(defn ^{:stratum 1} validate-config
+  "Validate a GitHub connector config map."
+  [value]
+  (validate GitHubConfig value))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(def ^{:stratum 2} ConnectorMetadata
   "Schema for connector registration metadata."
   [:map
    [:connector/name string?]
@@ -75,39 +106,9 @@
      [:retry/base-delay-ms int?]]]
    [:connector/maintainer string?]])
 
-;------------------------------------------------------------------------------ Layer 2
-;; Validation helpers
+;------------------------------------------------------------------------------ Layer 3
 
-(defn valid?
-  "1-arity: predicate on a validation result map — true iff :valid? is true.
-   2-arity: validate value against a Malli schema."
-  ([result] (true? (:valid? result)))
-  ([schema value] (m/validate schema value)))
-
-(defn invalid?
-  "Predicate: did this validation result fail? Complement of valid?/1."
-  [result]
-  (not (valid? result)))
-
-(defn validate
-  "Validate value against schema. Returns {:valid? bool :errors map-or-nil}."
-  [schema value]
-  (if (m/validate schema value)
-    {:valid? true :errors nil}
-    {:valid? false
-     :errors (me/humanize (m/explain schema value))}))
-
-(defn explain
-  [schema value]
-  (when-let [explanation (m/explain schema value)]
-    (me/humanize explanation)))
-
-(defn validate-config
-  "Validate a GitHub connector config map."
-  [value]
-  (validate GitHubConfig value))
-
-(defn validate-metadata
+(defn ^{:stratum 3} validate-metadata
   "Validate connector metadata."
   [value]
   (validate ConnectorMetadata value))

--- a/components/connector-github/test/ai/miniforge/connector_github/anomaly/github_anomaly_test.clj
+++ b/components/connector-github/test/ai/miniforge/connector_github/anomaly/github_anomaly_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-github.anomaly.github-anomaly-test
   "Coverage for `impl/do-connect` config anomalies and
    `impl/require-resource!` boundary escalation via `response/throw-anomaly!`."
@@ -26,13 +25,15 @@
             [ai.miniforge.response.interface :as response])
   (:import (clojure.lang ExceptionInfo)))
 
-(deftest do-connect-missing-owner-and-org-returns-anomaly
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} do-connect-missing-owner-and-org-returns-anomaly
   (testing "config without :github/owner or :github/org returns :anomalies/incorrect"
     (let [result (impl/do-connect {} nil)]
       (is (response/anomaly-map? result))
       (is (= :anomalies/incorrect (:anomaly/category result))))))
 
-(deftest require-resource-unknown-throws-anomaly
+(deftest ^{:stratum 0} require-resource-unknown-throws-anomaly
   (testing "looking up an unknown resource raises :anomalies/not-found"
     (try
       (@#'impl/require-resource! "totally-bogus-resource")
@@ -41,14 +42,14 @@
         (is (= :anomalies/not-found (:anomaly/category (ex-data e))))
         (is (= "totally-bogus-resource" (:resource (ex-data e))))))))
 
-(deftest do-connect-invalid-schema-returns-anomaly
+(deftest ^{:stratum 0} do-connect-invalid-schema-returns-anomaly
   (testing "malformed config returns :anomalies/incorrect"
     (let [result (impl/do-connect {:github/owner 42} nil)]
       (is (response/anomaly-map? result))
       (is (= :anomalies/incorrect (:anomaly/category result)))
       (is (some? (:errors result))))))
 
-(deftest load-resources-missing-edn-throws-anomaly
+(deftest ^{:stratum 0} load-resources-missing-edn-throws-anomaly
   (testing "missing resource EDN raises :anomalies/not-found"
     (with-redefs [io/resource (constantly nil)]
       (try

--- a/components/connector-github/test/ai/miniforge/connector_github/impl_test.clj
+++ b/components/connector-github/test/ai/miniforge/connector_github/impl_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-github.impl-test
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.connector-github.impl :as impl]
@@ -24,7 +23,9 @@
             [ai.miniforge.response.interface :as response]
             [ai.miniforge.schema.interface :as schema]))
 
-(deftest resource-schemas-test
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} resource-schemas-test
   (testing "resource-schemas returns all known resources"
     (let [schemas (resources/resource-schemas)]
       (is (= 6 (count schemas)))
@@ -38,7 +39,7 @@
       (is (some #(= "comments" (:schema/name %)) schemas))
       (is (some #(= "reviews" (:schema/name %)) schemas)))))
 
-(deftest build-url-test
+(deftest ^{:stratum 0} build-url-test
   (testing "builds org repos URL"
     (let [resource-def (resources/get-resource :repos)
           config       {:github/org "myorg"}
@@ -69,7 +70,7 @@
           url          (resources/build-url "https://api.github.com" resource-def config)]
       (is (= "https://api.github.com/repos/myuser/myrepo/pulls/42/reviews" url)))))
 
-(deftest build-query-params-test
+(deftest ^{:stratum 0} build-query-params-test
   (testing "includes default params and per_page"
     (let [resource-def (resources/get-resource :issues)
           params       (resources/build-query-params resource-def nil {})]
@@ -94,13 +95,13 @@
           params       (resources/build-query-params resource-def nil {})]
       (is (nil? (get params "since"))))))
 
-(deftest connect-validates-config-test
+(deftest ^{:stratum 0} connect-validates-config-test
   (testing "do-connect requires org or owner"
     (let [result (impl/do-connect {} nil)]
       (is (response/anomaly-map? result))
       (is (= :anomalies/incorrect (:anomaly/category result))))))
 
-(deftest connect-close-lifecycle-test
+(deftest ^{:stratum 0} connect-close-lifecycle-test
   (testing "connect and close work with org"
     (let [config {:github/org "test-org"}
           result (impl/do-connect config nil)]
@@ -116,7 +117,7 @@
       (is (= :connected (:connector/status result)))
       (impl/do-close (:connection/handle result)))))
 
-(deftest discover-test
+(deftest ^{:stratum 0} discover-test
   (testing "discover returns all resource schemas"
     (let [config {:github/org "test-org"}
           handle (:connection/handle (impl/do-connect config nil))
@@ -125,7 +126,7 @@
       (is (= 6 (count (:schemas result))))
       (impl/do-close handle))))
 
-(deftest extract-follows-link-pagination-test
+(deftest ^{:stratum 0} extract-follows-link-pagination-test
   (testing "do-extract drains paginated GitHub responses before returning"
     (let [config {:github/owner "test-user" :github/repo "test-repo"}
           handle (:connection/handle (impl/do-connect config nil))
@@ -149,7 +150,7 @@
         (finally
           (impl/do-close handle))))))
 
-(deftest extract-reviews-fans-out-across-pulls-test
+(deftest ^{:stratum 0} extract-reviews-fans-out-across-pulls-test
   (testing "review extraction enumerates pull reviews and preserves parent linkage"
     (let [handle (:connection/handle (impl/do-connect {:github/owner "test-user"
                                                        :github/repo "test-repo"} nil))
@@ -203,7 +204,7 @@
         (finally
           (impl/do-close handle))))))
 
-(deftest extract-reviews-filters-by-cursor-test
+(deftest ^{:stratum 0} extract-reviews-filters-by-cursor-test
   (testing "review extraction filters out reviews at or before the prior cursor"
     (let [handle (:connection/handle (impl/do-connect {:github/owner "test-user"
                                                        :github/repo "test-repo"} nil))
@@ -246,17 +247,15 @@
         (finally
           (impl/do-close handle))))))
 
-(deftest checkpoint-test
+(deftest ^{:stratum 0} checkpoint-test
   (testing "checkpoint returns committed result"
     (let [cursor {:cursor/type :timestamp-watermark :cursor/value "2026-01-01T00:00:00Z"}
           result (impl/do-checkpoint cursor)]
       (is (= :committed (:checkpoint/status result)))
       (is (= cursor (:checkpoint/cursor result))))))
 
-;;------------------------------------------------------------------------------ Layer 1
 ;; Issue filtering tests
-
-(deftest issue-filtering-test
+(deftest ^{:stratum 0} issue-filtering-test
   (testing "issue-not-pr? returns true for plain issues"
     (is (true? (#'impl/issue-not-pr? {:number 1 :title "Bug"}))))
 
@@ -277,10 +276,8 @@
           result (#'impl/filter-issues :pulls records)]
       (is (= 2 (count result))))))
 
-;;------------------------------------------------------------------------------ Layer 1
 ;; Rate limit header integration tests
-
-(deftest rate-limit-header-capture-test
+(deftest ^{:stratum 0} rate-limit-header-capture-test
   (testing "update-rate-limits! stores parsed rate info in handle"
     (let [handle "test-handle"
           ;; Manually store a handle
@@ -294,10 +291,8 @@
         (is (= 1711468800 (get-in state [:rate-limit :reset-epoch]))))
       (impl/remove-handle! handle))))
 
-;;------------------------------------------------------------------------------ Layer 1
 ;; ETag integration tests
-
-(deftest etag-integration-test
+(deftest ^{:stratum 0} etag-integration-test
   (testing "ETag cache starts empty for unknown URLs"
     (etag/clear-cache!)
     (is (nil? (etag/get-etag "https://api.github.com/repos/test/test/issues"))))
@@ -313,24 +308,22 @@
     (let [headers (etag/add-etag-header {} "https://example.com")]
       (is (= "W/\"test-etag\"" (get headers "If-None-Match"))))))
 
-;;------------------------------------------------------------------------------ Layer 2
 ;; Migrated validation helpers — connector boundaries return anomalies.
-
-(deftest discover-returns-anomaly-on-unknown-handle-test
+(deftest ^{:stratum 0} discover-returns-anomaly-on-unknown-handle-test
   (testing "do-discover returns an anomaly with :handle when handle is missing"
     (let [result (impl/do-discover "no-such-handle")]
       (is (response/anomaly-map? result))
       (is (= :anomalies/not-found (:anomaly/category result)))
       (is (= "no-such-handle" (:handle result))))))
 
-(deftest extract-returns-anomaly-on-unknown-handle-test
+(deftest ^{:stratum 0} extract-returns-anomaly-on-unknown-handle-test
   (testing "do-extract returns an anomaly with :handle when handle is missing"
     (let [result (impl/do-extract "no-such-handle" "issues" {})]
       (is (response/anomaly-map? result))
       (is (= :anomalies/not-found (:anomaly/category result)))
       (is (= "no-such-handle" (:handle result))))))
 
-(deftest connect-rejects-malformed-auth-test
+(deftest ^{:stratum 0} connect-rejects-malformed-auth-test
   (testing "do-connect returns an anomaly when auth credential-ref is malformed"
     (let [result (impl/do-connect {:github/owner "owner" :github/repo "repo"}
                                   {:auth/method :api-key
@@ -340,7 +333,7 @@
       (is (= :anomalies/incorrect (:anomaly/category result)))
       (is (some? (:errors result))))))
 
-(deftest connect-accepts-valid-auth-test
+(deftest ^{:stratum 0} connect-accepts-valid-auth-test
   (testing "do-connect succeeds when auth credential-ref validates"
     (let [result (impl/do-connect {:github/owner "owner" :github/repo "repo"}
                                   {:auth/method        :api-key

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-connector-github.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-connector-github.md
@@ -1,0 +1,130 @@
+<!--
+  Title: fix: stratum-lint autofix for components/connector-github (Wave 1)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix: stratum-lint autofix for components/connector-github (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over `components/connector-github` (`src` +
+`test`) to replace decorative `Layer N` headings with real ones derived
+from each file's actual same-file reference graph, and tag every
+top-level `def`/`defn`/`deftest` with `^{:stratum n}`. One of the Wave 1
+batches from `work/stratum-lint-baseline-2026-07-24.md`. Fully mechanical
+— no hand edits were needed beyond the autofix output. No executable
+logic changed anywhere.
+
+## Motivation
+
+Baseline findings for this component, confirmed via a fresh plain-lint
+run before touching anything (zero `SL001` — no upward-reference/cycle
+risk, matching the Wave 1 batch criteria):
+
+- `test/ai/miniforge/connector_github/impl_test.clj`: 10 `SL004` findings
+  (every `deftest` in the file appeared before the first `Layer` heading
+  — the file had no heading at all) plus 2 `SL002` findings (a `Layer 1`
+  heading reused three times, and a `Layer 2` heading reused once, as
+  decorative per-group section banners rather than one heading per real
+  stratum).
+
+12 findings total, matching the baseline doc's per-component table
+exactly (`SL001` 0, `SL002` 2, `SL003` 0, `SL004` 10).
+
+## Changes in Detail
+
+Ran, over the whole component:
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "bef8657a2efd3b1ba9e1a4f510693c9fbca45abd" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/connector-github
+```
+
+All 8 `.clj` files in the component were rewritten (`--fix` normalizes
+every file, not just the ones with findings): `core.clj`, `impl.clj`,
+`interface.clj`, `messages.clj`, `resources.clj`, `schema.clj`, and both
+test files. Diffs are heading text, `^{:stratum n}` metadata, and
+def/deftest reordering only.
+
+Two files had their defs reordered onto a real, deeper dependency chain
+than their prior (single, flat) heading implied:
+
+- `resources.clj` collapsed from one flat section into 4 real layers:
+  `resource-path`/`build-url`/`build-query-params` (Layer 0) →
+  `load-resources` (Layer 1, uses `resource-path`) → `github-resources`
+  (Layer 2, delays `load-resources`) → `get-resource`/`resource-schemas`
+  (Layer 3, dereference `github-resources`).
+- `impl.clj` collapsed into 8 real layers, reflecting a genuine deep
+  call chain in the pagination/review-extraction path: `do-extract`
+  (Layer 7) → `extract-reviews` (Layer 6) → `pull-review-records` (Layer
+  5) → `resource-records` (Layer 4) → `fetch-all-pages` (Layer 3) →
+  `response-records` (Layer 2) → `filter-issues` (Layer 1) →
+  `issue-not-pr?` (Layer 0). `schema.clj` similarly collapsed into 4 real
+  layers (enum vectors → enum schemas → composite `ConnectorMetadata` →
+  `validate-metadata`).
+
+`impl_test.clj`'s 3 decorative double-semicolon `;;---- Layer N` banners
+(with no trailing label after the number — the plain-text label lived on
+a separate following comment line, e.g. `;; Issue filtering tests`) were
+removed cleanly by the fix itself along with the rest of the old heading
+structure; the descriptive comment lines were left in place untouched.
+Read the full diff for all 8 files and found no orphaned/contradictory
+banner and no same-line trailing-comment displacement.
+
+## Testing Plan
+
+1. Ran plain (non-`--fix`) `stratum-lint` before any change — reproduced
+   the 12 findings above exactly (10 `SL004` + 2 `SL002`), confirmed 0
+   `SL001`.
+2. Ran `--fix`, then a second `--fix` pass immediately after — zero
+   diff, confirms idempotency.
+3. Read the full diff for all 8 changed files. No stale decorative
+   banners, no trailing-comment displacement, no forward-reference
+   ordering issues found — each def is used only after its own
+   definition in the rewritten file.
+4. `clj-kondo --lint components/connector-github`: 0 errors, 0 warnings,
+   both before and after (confirmed via `git stash`).
+5. Ran both test namespaces directly via `clojure -M:dev:test`: 21
+   tests, 74 assertions, 0 failures, 0 errors.
+6. Re-ran plain `stratum-lint` after the fix: `SL001`/`SL002`/`SL004`
+   clear across the component. `SL003` newly surfaces (not present in
+   the pre-fix baseline, which only tracks decorative headings) on 3
+   files, each genuinely over the 3-layer budget once the real
+   dependency depth is counted:
+   - `impl.clj`: 8 real layers (the pagination/review-extraction chain
+     above).
+   - `resources.clj`: 4 real layers.
+   - `schema.clj`: 4 real layers.
+
+   All three are real Wave 2 (namespace split) candidates per the
+   baseline doc's Wave 4 section — not something to fix in this batch.
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+change — comment/metadata/order only. Pre-commit's `lint:stratum`
+autofixer keeps this component clean going forward; `impl.clj`,
+`resources.clj`, and `schema.clj`'s `SL003` stay advisory
+(`MINIFORGE_STRATUM_BUDGET_MODE=warn` at commit time) until Wave 2 splits
+them.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+- Follow-on: Wave 2 namespace split for
+  `components/connector-github/src/ai/miniforge/connector_github/impl.clj`
+  (8 real layers), `resources.clj` (4 real layers), and `schema.clj` (4
+  real layers) — all over the 3-layer budget.
+
+## Checklist
+
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Second `--fix` pass confirms idempotency (zero diff)
+- [x] Diff read in full for all 8 changed files
+- [x] No stale decorative banners or trailing-comment displacement found
+- [x] `clj-kondo` clean (0 errors, 0 warnings before/after)
+- [x] Component tests pass (21 tests, 74 assertions, 0 failures/errors)
+- [x] Plain lint re-run post-fix: zero `SL001`/`SL002`/`SL004`; `SL003`
+      newly surfaces on `impl.clj`, `resources.clj`, and `schema.clj` —
+      tracked as Wave 2 above
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
<!--
  Title: fix: stratum-lint autofix for components/connector-github (Wave 1)
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# fix: stratum-lint autofix for components/connector-github (Wave 1)

## Overview

Runs `stratum-lint --fix` over `components/connector-github` (`src` +
`test`) to replace decorative `Layer N` headings with real ones derived
from each file's actual same-file reference graph, and tag every
top-level `def`/`defn`/`deftest` with `^{:stratum n}`. One of the Wave 1
batches from `work/stratum-lint-baseline-2026-07-24.md`. Fully mechanical
— no hand edits were needed beyond the autofix output. No executable
logic changed anywhere.

## Motivation

Baseline findings for this component, confirmed via a fresh plain-lint
run before touching anything (zero `SL001` — no upward-reference/cycle
risk, matching the Wave 1 batch criteria):

- `test/ai/miniforge/connector_github/impl_test.clj`: 10 `SL004` findings
  (every `deftest` in the file appeared before the first `Layer` heading
  — the file had no heading at all) plus 2 `SL002` findings (a `Layer 1`
  heading reused three times, and a `Layer 2` heading reused once, as
  decorative per-group section banners rather than one heading per real
  stratum).

12 findings total, matching the baseline doc's per-component table
exactly (`SL001` 0, `SL002` 2, `SL003` 0, `SL004` 10).

## Changes in Detail

Ran, over the whole component:

```bash
bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "bef8657a2efd3b1ba9e1a4f510693c9fbca45abd" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/connector-github
```

All 8 `.clj` files in the component were rewritten (`--fix` normalizes
every file, not just the ones with findings): `core.clj`, `impl.clj`,
`interface.clj`, `messages.clj`, `resources.clj`, `schema.clj`, and both
test files. Diffs are heading text, `^{:stratum n}` metadata, and
def/deftest reordering only.

Two files had their defs reordered onto a real, deeper dependency chain
than their prior (single, flat) heading implied:

- `resources.clj` collapsed from one flat section into 4 real layers:
  `resource-path`/`build-url`/`build-query-params` (Layer 0) →
  `load-resources` (Layer 1, uses `resource-path`) → `github-resources`
  (Layer 2, delays `load-resources`) → `get-resource`/`resource-schemas`
  (Layer 3, dereference `github-resources`).
- `impl.clj` collapsed into 8 real layers, reflecting a genuine deep
  call chain in the pagination/review-extraction path: `do-extract`
  (Layer 7) → `extract-reviews` (Layer 6) → `pull-review-records` (Layer
  5) → `resource-records` (Layer 4) → `fetch-all-pages` (Layer 3) →
  `response-records` (Layer 2) → `filter-issues` (Layer 1) →
  `issue-not-pr?` (Layer 0). `schema.clj` similarly collapsed into 4 real
  layers (enum vectors → enum schemas → composite `ConnectorMetadata` →
  `validate-metadata`).

`impl_test.clj`'s 3 decorative double-semicolon `;;---- Layer N` banners
(with no trailing label after the number — the plain-text label lived on
a separate following comment line, e.g. `;; Issue filtering tests`) were
removed cleanly by the fix itself along with the rest of the old heading
structure; the descriptive comment lines were left in place untouched.
Read the full diff for all 8 files and found no orphaned/contradictory
banner and no same-line trailing-comment displacement.

## Testing Plan

1. Ran plain (non-`--fix`) `stratum-lint` before any change — reproduced
   the 12 findings above exactly (10 `SL004` + 2 `SL002`), confirmed 0
   `SL001`.
2. Ran `--fix`, then a second `--fix` pass immediately after — zero
   diff, confirms idempotency.
3. Read the full diff for all 8 changed files. No stale decorative
   banners, no trailing-comment displacement, no forward-reference
   ordering issues found — each def is used only after its own
   definition in the rewritten file.
4. `clj-kondo --lint components/connector-github`: 0 errors, 0 warnings,
   both before and after (confirmed via `git stash`).
5. Ran both test namespaces directly via `clojure -M:dev:test`: 21
   tests, 74 assertions, 0 failures, 0 errors.
6. Re-ran plain `stratum-lint` after the fix: `SL001`/`SL002`/`SL004`
   clear across the component. `SL003` newly surfaces (not present in
   the pre-fix baseline, which only tracks decorative headings) on 3
   files, each genuinely over the 3-layer budget once the real
   dependency depth is counted:
   - `impl.clj`: 8 real layers (the pagination/review-extraction chain
     above).
   - `resources.clj`: 4 real layers.
   - `schema.clj`: 4 real layers.

   All three are real Wave 2 (namespace split) candidates per the
   baseline doc's Wave 4 section — not something to fix in this batch.

## Deployment Plan

Merges to `main` like any other component change. No runtime behavior
change — comment/metadata/order only. Pre-commit's `lint:stratum`
autofixer keeps this component clean going forward; `impl.clj`,
`resources.clj`, and `schema.clj`'s `SL003` stay advisory
(`MINIFORGE_STRATUM_BUDGET_MODE=warn` at commit time) until Wave 2 splits
them.

## Related Issues/PRs

- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
- Follow-on: Wave 2 namespace split for
  `components/connector-github/src/ai/miniforge/connector_github/impl.clj`
  (8 real layers), `resources.clj` (4 real layers), and `schema.clj` (4
  real layers) — all over the 3-layer budget.

## Checklist

- [x] `--fix` run over the whole component (`src` + `test`)
- [x] Second `--fix` pass confirms idempotency (zero diff)
- [x] Diff read in full for all 8 changed files
- [x] No stale decorative banners or trailing-comment displacement found
- [x] `clj-kondo` clean (0 errors, 0 warnings before/after)
- [x] Component tests pass (21 tests, 74 assertions, 0 failures/errors)
- [x] Plain lint re-run post-fix: zero `SL001`/`SL002`/`SL004`; `SL003`
      newly surfaces on `impl.clj`, `resources.clj`, and `schema.clj` —
      tracked as Wave 2 above
- [x] No `--no-verify`; pre-commit hook runs normally at commit time
