### PR TITLE
fix: stratum-lint autofix for components/connector-excel (Wave 1)

### DIFF
--- a/components/connector-excel/src/ai/miniforge/connector_excel/core.clj
+++ b/components/connector-excel/src/ai/miniforge/connector_excel/core.clj
@@ -15,13 +15,14 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-excel.core
   "ExcelConnector defrecord — thin protocol wrapper delegating to impl."
   (:require [ai.miniforge.connector.interface :as connector]
             [ai.miniforge.connector-excel.impl :as impl]))
 
-(defrecord ExcelConnector []
+;------------------------------------------------------------------------------ Layer 0
+
+(defrecord ^{:stratum 0} ExcelConnector []
   connector/Connector
   (connect    [_ config auth]                      (impl/do-connect config auth))
   (close      [_ handle]                           (impl/do-close handle))

--- a/components/connector-excel/src/ai/miniforge/connector_excel/impl.clj
+++ b/components/connector-excel/src/ai/miniforge/connector_excel/impl.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-excel.impl
   "Implementation functions for the Excel connector.
    Downloads a remote Excel file and extracts records using column mappings."
@@ -28,17 +27,13 @@
            [java.util UUID]
            [org.apache.poi.ss.usermodel WorkbookFactory Cell DateUtil]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; -- Handle state --
-
-(def ^:private handles (connector/create-handle-registry))
-
-(defn get-handle [handle] (connector/get-handle handles handle))
-(defn store-handle! [handle state] (connector/store-handle! handles handle state))
-(defn remove-handle! [handle] (connector/remove-handle! handles handle))
+(def ^{:stratum 0} ^:private handles (connector/create-handle-registry))
 
 ;; -- Excel parsing --
-
-(defn- cell-value
+(defn- ^{:stratum 0} cell-value
   "Extract a typed value from a POI Cell."
   [^Cell cell]
   (when cell
@@ -53,7 +48,58 @@
                      (catch Exception _ (.getStringCellValue cell)))
       nil)))
 
-(defn- row-to-record
+;; -- Filtering --
+(defn- ^{:stratum 0} min-value-filter
+  "Create a filter that keeps records where :date >= min-val."
+  [min-val]
+  (fn [record]
+    (let [v (:date record)]
+      (and (number? v) (>= v min-val)))))
+
+;; -- Record normalization --
+(defn- ^{:stratum 0} decimal-year-to-iso
+  "Convert a decimal year (e.g. 2026.03) to ISO date string (2026-03-01)."
+  [d]
+  (let [year  (int d)
+        month (Math/round (* (- d year) 100.0))]
+    (format "%d-%02d-01" year (max 1 month))))
+
+;; -- Download --
+(defn- ^{:stratum 0} download-to-temp-result
+  "Download a URL to a temporary file. Returns the File or a legacy response
+   anomaly map when the HTTP response is not successful."
+  [url]
+  (let [resp (http/get url {:as      :bytes
+                            :headers {"User-Agent" "Mozilla/5.0"}
+                            :throw   false})
+        status (:status resp)]
+    (if-not (<= 200 status 299)
+      (response/make-anomaly :anomalies/unavailable
+                             (msg/t :excel/download-failed {:error (str "HTTP " status)})
+                             {:status status})
+      (let [tmp (File/createTempFile "connector-excel-" ".xls")]
+        (.deleteOnExit tmp)
+        (with-open [out (FileOutputStream. tmp)]
+          (.write out ^bytes (:body resp)))
+        tmp))))
+
+(defn- ^{:stratum 0} handle-anomaly->response [handle-anomaly]
+  (response/make-anomaly :anomalies/not-found
+                         (:anomaly/message handle-anomaly)
+                         (:anomaly/data handle-anomaly)))
+
+(defn ^{:stratum 0} do-checkpoint [cursor-state]
+  (connector/checkpoint-result cursor-state))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} get-handle [handle] (connector/get-handle handles handle))
+
+(defn ^{:stratum 1} store-handle! [handle state] (connector/store-handle! handles handle state))
+
+(defn ^{:stratum 1} remove-handle! [handle] (connector/remove-handle! handles handle))
+
+(defn- ^{:stratum 1} row-to-record
   "Extract a record map from a POI Row using column index→keyword mapping."
   [row columns]
   (when row
@@ -67,7 +113,40 @@
      {}
      columns)))
 
-(defn parse-sheet
+(defn- ^{:stratum 1} normalize-record
+  "Normalize a record: convert decimal-year dates, enrich with series-id."
+  [date-fmt series-id record]
+  (cond-> record
+    (and (= date-fmt :decimal-year) (number? (:date record)))
+    (assoc :date (decimal-year-to-iso (:date record)))
+    series-id
+    (assoc :series_id series-id)))
+
+(defn- ^{:stratum 1} download-to-temp
+  "Boundary wrapper around the anomaly-returning `download-to-temp-result`.
+   Preserves the connector's historical throwing download contract."
+  [url]
+  (let [result (download-to-temp-result url)]
+    (if (response/anomaly-map? result)
+      (response/throw-anomaly! (:anomaly/category result)
+                               (:anomaly/message result)
+                               (dissoc result
+                                       :anomaly/category
+                                       :anomaly/message
+                                       :anomaly/id
+                                       :anomaly/timestamp))
+      result)))
+
+;; -- Source --
+(defn- ^{:stratum 1} require-handle
+  "Retrieve handle state or return an anomaly."
+  [handle]
+  (connector/require-handle handles handle
+                            {:message (msg/t :excel/handle-not-found {:handle handle})}))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} parse-sheet
   "Parse an Excel sheet into records using column mapping.
    columns: map of column-index (int) to keyword field name.
    data-start-row: 0-indexed row to start reading data from.
@@ -92,71 +171,8 @@
                               :config/error :invalid-config
                               :config/invalid-config-reason :missing-excel-sheet})))
 
-;; -- Filtering --
-
-(defn- min-value-filter
-  "Create a filter that keeps records where :date >= min-val."
-  [min-val]
-  (fn [record]
-    (let [v (:date record)]
-      (and (number? v) (>= v min-val)))))
-
-;; -- Record normalization --
-
-(defn- decimal-year-to-iso
-  "Convert a decimal year (e.g. 2026.03) to ISO date string (2026-03-01)."
-  [d]
-  (let [year  (int d)
-        month (Math/round (* (- d year) 100.0))]
-    (format "%d-%02d-01" year (max 1 month))))
-
-(defn- normalize-record
-  "Normalize a record: convert decimal-year dates, enrich with series-id."
-  [date-fmt series-id record]
-  (cond-> record
-    (and (= date-fmt :decimal-year) (number? (:date record)))
-    (assoc :date (decimal-year-to-iso (:date record)))
-    series-id
-    (assoc :series_id series-id)))
-
-;; -- Download --
-
-(defn- download-to-temp-result
-  "Download a URL to a temporary file. Returns the File or a legacy response
-   anomaly map when the HTTP response is not successful."
-  [url]
-  (let [resp (http/get url {:as      :bytes
-                            :headers {"User-Agent" "Mozilla/5.0"}
-                            :throw   false})
-        status (:status resp)]
-    (if-not (<= 200 status 299)
-      (response/make-anomaly :anomalies/unavailable
-                             (msg/t :excel/download-failed {:error (str "HTTP " status)})
-                             {:status status})
-      (let [tmp (File/createTempFile "connector-excel-" ".xls")]
-        (.deleteOnExit tmp)
-        (with-open [out (FileOutputStream. tmp)]
-          (.write out ^bytes (:body resp)))
-        tmp))))
-
-(defn- download-to-temp
-  "Boundary wrapper around the anomaly-returning `download-to-temp-result`.
-   Preserves the connector's historical throwing download contract."
-  [url]
-  (let [result (download-to-temp-result url)]
-    (if (response/anomaly-map? result)
-      (response/throw-anomaly! (:anomaly/category result)
-                               (:anomaly/message result)
-                               (dissoc result
-                                       :anomaly/category
-                                       :anomaly/message
-                                       :anomaly/id
-                                       :anomaly/timestamp))
-      result)))
-
 ;; -- Lifecycle --
-
-(defn do-connect
+(defn ^{:stratum 2} do-connect
   "Validate config, download file, register handle."
   [config _auth]
   (let [url        (:excel/url config)
@@ -187,27 +203,14 @@
                                :tmp-file tmp-file})
         (connector/connect-result handle)))))
 
-(defn do-close [handle]
+(defn ^{:stratum 2} do-close [handle]
   (when-let [{:keys [workbook tmp-file]} (get-handle handle)]
     (try (.close workbook) (catch Exception _))
     (try (.delete ^File tmp-file) (catch Exception _)))
   (remove-handle! handle)
   (connector/close-result))
 
-;; -- Source --
-
-(defn- require-handle
-  "Retrieve handle state or return an anomaly."
-  [handle]
-  (connector/require-handle handles handle
-                            {:message (msg/t :excel/handle-not-found {:handle handle})}))
-
-(defn- handle-anomaly->response [handle-anomaly]
-  (response/make-anomaly :anomalies/not-found
-                         (:anomaly/message handle-anomaly)
-                         (:anomaly/data handle-anomaly)))
-
-(defn do-discover [handle]
+(defn ^{:stratum 2} do-discover [handle]
   (let [handle-state (require-handle handle)]
     (if (anomaly/anomaly? handle-state)
       (handle-anomaly->response handle-state)
@@ -215,7 +218,9 @@
         (connector/discover-result [{:schema/name (:excel/sheet-name config)
                                      :schema/url  (:excel/url config)}])))))
 
-(defn do-extract
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} do-extract
   "Parse the Excel sheet and return records."
   [handle _opts]
   (let [handle-state (require-handle handle)]
@@ -230,6 +235,3 @@
             date-fmt  (:excel/date-format config)
             enriched  (mapv (partial normalize-record date-fmt series-id) records)]
         (connector/extract-result enriched nil false)))))
-
-(defn do-checkpoint [cursor-state]
-  (connector/checkpoint-result cursor-state))

--- a/components/connector-excel/src/ai/miniforge/connector_excel/interface.clj
+++ b/components/connector-excel/src/ai/miniforge/connector_excel/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-excel.interface
   "Public API for the Excel connector component.
 
@@ -24,12 +23,14 @@
   {:miniforge/runtime :jvm-only}
   (:require [ai.miniforge.connector-excel.core :as core]))
 
-(defn create-excel-connector
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} create-excel-connector
   "Create a new ExcelConnector instance."
   []
   (core/->ExcelConnector))
 
-(def connector-metadata
+(def ^{:stratum 0} connector-metadata
   "Registration metadata for the Excel connector."
   {:connector/name         "Excel File Connector"
    :connector/type         :source

--- a/components/connector-excel/src/ai/miniforge/connector_excel/messages.clj
+++ b/components/connector-excel/src/ai/miniforge/connector_excel/messages.clj
@@ -15,11 +15,12 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-excel.messages
   "Message catalog — delegates to ai.miniforge.messages."
   (:require [ai.miniforge.messages.interface :as messages]))
 
-(def t
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} t
   "Look up a message by key, with optional param substitution."
   (messages/create-translator "config/connector-excel/messages/en-US.edn" :connector-excel/messages))

--- a/components/connector-excel/test/ai/miniforge/connector_excel/anomaly/excel_anomaly_test.clj
+++ b/components/connector-excel/test/ai/miniforge/connector_excel/anomaly/excel_anomaly_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-excel.anomaly.excel-anomaly-test
   "Coverage for `impl/do-connect` config-validation paths,
    `impl/parse-sheet` sheet-not-found, and the non-2xx download path
@@ -28,7 +27,9 @@
   (:import (clojure.lang ExceptionInfo)
            (org.apache.poi.xssf.usermodel XSSFWorkbook)))
 
-(deftest do-connect-missing-url-throws-anomaly
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} do-connect-missing-url-throws-anomaly
   (testing "missing :excel/url raises :anomalies/incorrect"
     (try
       (impl/do-connect {:excel/sheet-name "Sheet1" :excel/columns {0 :a}} nil)
@@ -39,7 +40,7 @@
         (is (= :missing-excel-url
                (:config/invalid-config-reason (ex-data e))))))))
 
-(deftest do-connect-missing-sheet-throws-anomaly
+(deftest ^{:stratum 0} do-connect-missing-sheet-throws-anomaly
   (testing "missing :excel/sheet-name raises :anomalies/incorrect"
     (try
       (impl/do-connect {:excel/url "http://x/y.xls" :excel/columns {0 :a}} nil)
@@ -50,7 +51,7 @@
         (is (= :missing-excel-sheet-name
                (:config/invalid-config-reason (ex-data e))))))))
 
-(deftest do-connect-missing-columns-throws-anomaly
+(deftest ^{:stratum 0} do-connect-missing-columns-throws-anomaly
   (testing "missing :excel/columns raises :anomalies/incorrect"
     (try
       (impl/do-connect {:excel/url "http://x/y.xls" :excel/sheet-name "Sheet1"} nil)
@@ -61,7 +62,7 @@
         (is (= :missing-excel-columns
                (:config/invalid-config-reason (ex-data e))))))))
 
-(deftest parse-sheet-missing-sheet-throws-anomaly
+(deftest ^{:stratum 0} parse-sheet-missing-sheet-throws-anomaly
   (testing "requesting a sheet absent from the workbook raises :anomalies/not-found"
     (let [wb (XSSFWorkbook.)]
       (try
@@ -78,7 +79,7 @@
         (finally
           (.close wb))))))
 
-(deftest do-connect-non-2xx-download-throws-anomaly
+(deftest ^{:stratum 0} do-connect-non-2xx-download-throws-anomaly
   (testing "non-2xx HTTP response while downloading raises :anomalies/unavailable"
     (with-redefs [http/get (fn [_url _opts] {:status 503 :body (byte-array 0)})]
       (try
@@ -91,7 +92,7 @@
           (is (= :anomalies/unavailable (:anomaly/category (ex-data e))))
           (is (= 503 (:status (ex-data e)))))))))
 
-(deftest download-to-temp-result-non-2xx-returns-anomaly
+(deftest ^{:stratum 0} download-to-temp-result-non-2xx-returns-anomaly
   (testing "non-2xx HTTP response can be represented without throwing"
     (with-redefs [http/get (fn [_url _opts] {:status 503 :body (byte-array 0)})]
       (let [result (@#'impl/download-to-temp-result "http://x/y.xls")]

--- a/components/connector-excel/test/ai/miniforge/connector_excel/interface_test.clj
+++ b/components/connector-excel/test/ai/miniforge/connector_excel/interface_test.clj
@@ -15,17 +15,18 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-excel.interface-test
   (:require [ai.miniforge.response.interface :as response]
             [clojure.test :refer [deftest is testing]]
             [ai.miniforge.connector-excel.impl :as impl]))
 
-(deftest cell-value-nil-test
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} cell-value-nil-test
   (testing "nil cell returns nil"
     (is (nil? (#'impl/cell-value nil)))))
 
-(deftest parse-sheet-column-mapping-test
+(deftest ^{:stratum 0} parse-sheet-column-mapping-test
   (testing "parse-sheet extracts records with column mapping"
     ;; Create an in-memory workbook to test against
     (let [wb   (org.apache.poi.xssf.usermodel.XSSFWorkbook.)
@@ -49,7 +50,7 @@
         (is (= 36.1 (:value (second records)))))
       (.close wb))))
 
-(deftest parse-sheet-with-filter-test
+(deftest ^{:stratum 0} parse-sheet-with-filter-test
   (testing "parse-sheet applies row filter"
     (let [wb    (org.apache.poi.xssf.usermodel.XSSFWorkbook.)
           sheet (.createSheet wb "Filtered")]
@@ -69,14 +70,14 @@
         (is (= 2020.01 (:date (first records)))))
       (.close wb))))
 
-(deftest parse-sheet-missing-sheet-test
+(deftest ^{:stratum 0} parse-sheet-missing-sheet-test
   (testing "parse-sheet throws on missing sheet"
     (let [wb (org.apache.poi.xssf.usermodel.XSSFWorkbook.)]
       (.createSheet wb "Other")
       (is (thrown? Exception (impl/parse-sheet wb "Missing" {0 :x} 0 nil)))
       (.close wb))))
 
-(deftest extract-enriches-series-id-test
+(deftest ^{:stratum 0} extract-enriches-series-id-test
   (testing "do-extract enriches records with series-id"
     (let [wb    (org.apache.poi.xssf.usermodel.XSSFWorkbook.)
           sheet (.createSheet wb "Data")]
@@ -97,7 +98,7 @@
         (impl/remove-handle! handle))
       (.close wb))))
 
-(deftest extract-decimal-year-date-format-test
+(deftest ^{:stratum 0} extract-decimal-year-date-format-test
   (testing "do-extract normalizes decimal-year dates to ISO"
     (let [wb    (org.apache.poi.xssf.usermodel.XSSFWorkbook.)
           sheet (.createSheet wb "Data")]
@@ -120,24 +121,22 @@
         (impl/remove-handle! handle))
       (.close wb))))
 
-(deftest connect-validates-config-test
+(deftest ^{:stratum 0} connect-validates-config-test
   (testing "do-connect requires url, sheet-name, columns"
     (is (thrown? Exception (impl/do-connect {} nil)))
     (is (thrown? Exception (impl/do-connect {:excel/url "x"} nil)))
     (is (thrown? Exception (impl/do-connect {:excel/url "x" :excel/sheet-name "S"} nil)))))
 
-;;------------------------------------------------------------------------------ Layer 2
 ;; Migrated handle-lookup helper — connector boundaries return response
 ;; anomalies.
-
-(deftest discover-returns-anomaly-on-unknown-handle-test
+(deftest ^{:stratum 0} discover-returns-anomaly-on-unknown-handle-test
   (testing "do-discover returns an anomaly with :handle when handle is missing"
     (let [result (impl/do-discover "no-such-handle")]
       (is (response/anomaly-map? result))
       (is (= :anomalies/not-found (:anomaly/category result)))
       (is (= "no-such-handle" (:handle result))))))
 
-(deftest extract-returns-anomaly-on-unknown-handle-test
+(deftest ^{:stratum 0} extract-returns-anomaly-on-unknown-handle-test
   (testing "do-extract returns an anomaly with :handle when handle is missing"
     (let [result (impl/do-extract "no-such-handle" {})]
       (is (response/anomaly-map? result))

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-connector-excel.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-connector-excel.md
@@ -1,0 +1,132 @@
+<!--
+  Title: fix: stratum-lint autofix for components/connector-excel (Wave 1)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix: stratum-lint autofix for components/connector-excel (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over `components/connector-excel` (`src` + `test`)
+to replace missing `Layer N` headings with real headings and
+`^{:stratum n}` metadata derived from each file's actual same-file
+reference graph. Mechanical: no logic changes. One of the Wave 1 batch 5
+per-component PRs from `work/stratum-lint-baseline-2026-07-24.md`.
+
+## Motivation
+
+Plain (non-`--fix`) `stratum-lint` on `components/connector-excel` reported
+only `SL004` (defs before the first `Layer` heading), all seven in the same
+test file, zero `SL001`/`SL002`/`SL003`:
+
+```text
+components/connector-excel/test/ai/miniforge/connector_excel/interface_test.clj:24:1: SL004 'cell-value-nil-test' appears before the first Layer heading
+components/connector-excel/test/ai/miniforge/connector_excel/interface_test.clj:28:1: SL004 'parse-sheet-column-mapping-test' appears before the first Layer heading
+components/connector-excel/test/ai/miniforge/connector_excel/interface_test.clj:52:1: SL004 'parse-sheet-with-filter-test' appears before the first Layer heading
+components/connector-excel/test/ai/miniforge/connector_excel/interface_test.clj:72:1: SL004 'parse-sheet-missing-sheet-test' appears before the first Layer heading
+components/connector-excel/test/ai/miniforge/connector_excel/interface_test.clj:79:1: SL004 'extract-enriches-series-id-test' appears before the first Layer heading
+components/connector-excel/test/ai/miniforge/connector_excel/interface_test.clj:100:1: SL004 'extract-decimal-year-date-format-test' appears before the first Layer heading
+components/connector-excel/test/ai/miniforge/connector_excel/interface_test.clj:123:1: SL004 'connect-validates-config-test' appears before the first Layer heading
+```
+
+Zero `SL001`, confirming this component carries no upward-reference/cycle
+risk requiring human triage before running the mechanical fixer. The other
+five files (`core.clj`, `impl.clj`, `interface.clj`, `messages.clj`,
+`anomaly/excel_anomaly_test.clj`) reported no findings at all pre-fix, but
+had no `Layer N` heading anywhere either — invisible to the checker under
+the documented "no heading = silently skipped" limitation, not a clean bill
+of health.
+
+## Changes in Detail
+
+Ran, over the whole component:
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "bef8657a2efd3b1ba9e1a4f510693c9fbca45abd" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/connector-excel
+```
+
+All 6 `.clj` files in the component were rewritten (4 `src`, 2 `test`).
+Diffs are heading insertion, `^{:stratum n}` metadata, and def/deftest
+reordering only — no executable line changed.
+
+- `impl.clj` had the most reordering: `--fix` regrouped its defs into 4
+  real layers by actual same-file reference depth (handle-registry
+  accessors and pure helpers at Layer 0/1, `parse-sheet`/`do-connect`/
+  `do-close`/`do-discover` at Layer 2, `do-extract` at Layer 3, since it
+  calls into `parse-sheet` and `normalize-record`). This exceeds the
+  3-layer budget — see Testing Plan.
+- `interface_test.clj` carried one stale double-semicolon `Layer 2` banner
+  (`;;---- Layer 2` above `discover-returns-anomaly-on-unknown-handle-test`)
+  that predated any real heading in the file and was never recognized by
+  the tool's heading regex. `--fix` dropped it entirely as part of
+  regrouping all seven tests to real Layer 0 (none of the tests reference
+  each other or any same-file helper beyond `impl` functions), leaving the
+  still-accurate "Migrated handle-lookup helper" comment in place with no
+  contradiction. No hand-fix needed — verified by reading the resulting
+  file in full.
+- `core.clj`, `messages.clj`, `interface.clj`, and
+  `anomaly/excel_anomaly_test.clj` each got a single Layer 0 heading
+  inserted plus `^{:stratum 0}` metadata on their (in each case, one-layer)
+  defs — no reordering, since each file's defs are already independent of
+  each other.
+
+No same-line trailing comment was displaced onto the wrong def — grepped
+the diff for the known `foo])  ; comment` migration pattern; no matches.
+
+## Testing Plan
+
+1. Ran plain `stratum-lint` before the fix — reproduced the seven `SL004`
+   findings above exactly, zero `SL001`/`SL002`/`SL003`.
+2. Ran `--fix`, then a second `--fix` pass immediately after — zero diff,
+   confirms idempotency.
+3. Read the full diff for all 6 changed files. Confirmed only heading
+   insertion, `^{:stratum n}` metadata, and def/deftest reordering
+   changed. Confirmed no orphaned/contradictory decorative headings
+   remained (grepped for `;;----`/`;----` across the component; only the
+   regenerated single-semicolon real headings are present).
+4. `clj-kondo --lint components/connector-excel`: 0 errors, 0 warnings.
+5. Ran the component's test namespaces directly (`clojure -M:dev:test -e
+   "..."` requiring and running `ai.miniforge.connector-excel.interface-test`
+   and `ai.miniforge.connector-excel.anomaly.excel-anomaly-test`): 15
+   tests, 39 assertions, 0 failures, 0 errors.
+6. Re-ran plain `stratum-lint` after the fix. `SL001`/`SL002`/`SL004`
+   clear. One new `SL003` finding:
+
+   ```text
+   components/connector-excel/src/ai/miniforge/connector_excel/impl.clj:221:1: SL003 file uses 4 distinct layers (max 3); split the namespace or extract a component
+   ```
+
+   `impl.clj`'s true reference-graph depth is 4 real layers (over the
+   3-layer budget) — this file had no headings at all pre-fix, so the
+   over-budget condition was invisible to the checker before this PR, not
+   newly introduced by it. Real namespace-split scope for Wave 2, not
+   addressed here. Committed with `MINIFORGE_STRATUM_BUDGET_MODE=warn`.
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+change — comment/metadata/order-only. Pre-commit's `lint:stratum`
+autofixer keeps this component clean going forward; `impl.clj` stays
+advisory (`MINIFORGE_STRATUM_BUDGET_MODE=warn` at commit time) until
+Wave 2 splits it.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+- Follow-on: Wave 2 namespace split for `impl.clj` (4 real layers, over
+  the 3-layer budget).
+
+## Checklist
+
+- [x] Zero `SL001` confirmed before running `--fix` (no upward-reference/
+      cycle risk requiring human triage)
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Second `--fix` pass confirms idempotency (zero diff)
+- [x] Diff read in full for all 6 changed files; mechanical-only
+- [x] No orphaned/contradictory decorative headings found
+- [x] `clj-kondo` clean (0 errors, 0 warnings)
+- [x] Component tests pass (15 tests, 39 assertions, 0 failures/errors)
+- [x] Plain lint re-run post-fix: `SL003` newly surfaced on `impl.clj`
+      (4 real layers), documented above, tracked as Wave 2
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
<!--
  Title: fix: stratum-lint autofix for components/connector-excel (Wave 1)
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# fix: stratum-lint autofix for components/connector-excel (Wave 1)

## Overview

Runs `stratum-lint --fix` over `components/connector-excel` (`src` + `test`)
to replace missing `Layer N` headings with real headings and
`^{:stratum n}` metadata derived from each file's actual same-file
reference graph. Mechanical: no logic changes. One of the Wave 1 batch 5
per-component PRs from `work/stratum-lint-baseline-2026-07-24.md`.

## Motivation

Plain (non-`--fix`) `stratum-lint` on `components/connector-excel` reported
only `SL004` (defs before the first `Layer` heading), all seven in the same
test file, zero `SL001`/`SL002`/`SL003`:

```text
components/connector-excel/test/ai/miniforge/connector_excel/interface_test.clj:24:1: SL004 'cell-value-nil-test' appears before the first Layer heading
components/connector-excel/test/ai/miniforge/connector_excel/interface_test.clj:28:1: SL004 'parse-sheet-column-mapping-test' appears before the first Layer heading
components/connector-excel/test/ai/miniforge/connector_excel/interface_test.clj:52:1: SL004 'parse-sheet-with-filter-test' appears before the first Layer heading
components/connector-excel/test/ai/miniforge/connector_excel/interface_test.clj:72:1: SL004 'parse-sheet-missing-sheet-test' appears before the first Layer heading
components/connector-excel/test/ai/miniforge/connector_excel/interface_test.clj:79:1: SL004 'extract-enriches-series-id-test' appears before the first Layer heading
components/connector-excel/test/ai/miniforge/connector_excel/interface_test.clj:100:1: SL004 'extract-decimal-year-date-format-test' appears before the first Layer heading
components/connector-excel/test/ai/miniforge/connector_excel/interface_test.clj:123:1: SL004 'connect-validates-config-test' appears before the first Layer heading
```

Zero `SL001`, confirming this component carries no upward-reference/cycle
risk requiring human triage before running the mechanical fixer. The other
five files (`core.clj`, `impl.clj`, `interface.clj`, `messages.clj`,
`anomaly/excel_anomaly_test.clj`) reported no findings at all pre-fix, but
had no `Layer N` heading anywhere either — invisible to the checker under
the documented "no heading = silently skipped" limitation, not a clean bill
of health.

## Changes in Detail

Ran, over the whole component:

```bash
bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "bef8657a2efd3b1ba9e1a4f510693c9fbca45abd" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/connector-excel
```

All 6 `.clj` files in the component were rewritten (4 `src`, 2 `test`).
Diffs are heading insertion, `^{:stratum n}` metadata, and def/deftest
reordering only — no executable line changed.

- `impl.clj` had the most reordering: `--fix` regrouped its defs into 4
  real layers by actual same-file reference depth (handle-registry
  accessors and pure helpers at Layer 0/1, `parse-sheet`/`do-connect`/
  `do-close`/`do-discover` at Layer 2, `do-extract` at Layer 3, since it
  calls into `parse-sheet` and `normalize-record`). This exceeds the
  3-layer budget — see Testing Plan.
- `interface_test.clj` carried one stale double-semicolon `Layer 2` banner
  (`;;---- Layer 2` above `discover-returns-anomaly-on-unknown-handle-test`)
  that predated any real heading in the file and was never recognized by
  the tool's heading regex. `--fix` dropped it entirely as part of
  regrouping all seven tests to real Layer 0 (none of the tests reference
  each other or any same-file helper beyond `impl` functions), leaving the
  still-accurate "Migrated handle-lookup helper" comment in place with no
  contradiction. No hand-fix needed — verified by reading the resulting
  file in full.
- `core.clj`, `messages.clj`, `interface.clj`, and
  `anomaly/excel_anomaly_test.clj` each got a single Layer 0 heading
  inserted plus `^{:stratum 0}` metadata on their (in each case, one-layer)
  defs — no reordering, since each file's defs are already independent of
  each other.

No same-line trailing comment was displaced onto the wrong def — grepped
the diff for the known `foo])  ; comment` migration pattern; no matches.

## Testing Plan

1. Ran plain `stratum-lint` before the fix — reproduced the seven `SL004`
   findings above exactly, zero `SL001`/`SL002`/`SL003`.
2. Ran `--fix`, then a second `--fix` pass immediately after — zero diff,
   confirms idempotency.
3. Read the full diff for all 6 changed files. Confirmed only heading
   insertion, `^{:stratum n}` metadata, and def/deftest reordering
   changed. Confirmed no orphaned/contradictory decorative headings
   remained (grepped for `;;----`/`;----` across the component; only the
   regenerated single-semicolon real headings are present).
4. `clj-kondo --lint components/connector-excel`: 0 errors, 0 warnings.
5. Ran the component's test namespaces directly (`clojure -M:dev:test -e
   "..."` requiring and running `ai.miniforge.connector-excel.interface-test`
   and `ai.miniforge.connector-excel.anomaly.excel-anomaly-test`): 15
   tests, 39 assertions, 0 failures, 0 errors.
6. Re-ran plain `stratum-lint` after the fix. `SL001`/`SL002`/`SL004`
   clear. One new `SL003` finding:

   ```text
   components/connector-excel/src/ai/miniforge/connector_excel/impl.clj:221:1: SL003 file uses 4 distinct layers (max 3); split the namespace or extract a component
   ```

   `impl.clj`'s true reference-graph depth is 4 real layers (over the
   3-layer budget) — this file had no headings at all pre-fix, so the
   over-budget condition was invisible to the checker before this PR, not
   newly introduced by it. Real namespace-split scope for Wave 2, not
   addressed here. Committed with `MINIFORGE_STRATUM_BUDGET_MODE=warn`.

## Deployment Plan

Merges to `main` like any other component change. No runtime behavior
change — comment/metadata/order-only. Pre-commit's `lint:stratum`
autofixer keeps this component clean going forward; `impl.clj` stays
advisory (`MINIFORGE_STRATUM_BUDGET_MODE=warn` at commit time) until
Wave 2 splits it.

## Related Issues/PRs

- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
- Follow-on: Wave 2 namespace split for `impl.clj` (4 real layers, over
  the 3-layer budget).

## Checklist

- [x] Zero `SL001` confirmed before running `--fix` (no upward-reference/
      cycle risk requiring human triage)
- [x] `--fix` run over the whole component (`src` + `test`)
- [x] Second `--fix` pass confirms idempotency (zero diff)
- [x] Diff read in full for all 6 changed files; mechanical-only
- [x] No orphaned/contradictory decorative headings found
- [x] `clj-kondo` clean (0 errors, 0 warnings)
- [x] Component tests pass (15 tests, 39 assertions, 0 failures/errors)
- [x] Plain lint re-run post-fix: `SL003` newly surfaced on `impl.clj`
      (4 real layers), documented above, tracked as Wave 2
- [x] No `--no-verify`; pre-commit hook runs normally at commit time
