### PR TITLE
fix: stratum-lint autofix for components/connector-edgar (Wave 1)

### DIFF
--- a/components/connector-edgar/src/ai/miniforge/connector_edgar/core.clj
+++ b/components/connector-edgar/src/ai/miniforge/connector_edgar/core.clj
@@ -15,13 +15,14 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-edgar.core
   "EdgarConnector defrecord — thin protocol wrapper delegating to impl."
   (:require [ai.miniforge.connector.interface :as connector]
             [ai.miniforge.connector-edgar.impl :as impl]))
 
-(defrecord EdgarConnector []
+;------------------------------------------------------------------------------ Layer 0
+
+(defrecord ^{:stratum 0} EdgarConnector []
   connector/Connector
   (connect    [_ config auth]                      (impl/do-connect config auth))
   (close      [_ handle]                           (impl/do-close handle))

--- a/components/connector-edgar/src/ai/miniforge/connector_edgar/impl.clj
+++ b/components/connector-edgar/src/ai/miniforge/connector_edgar/impl.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-edgar.impl
   "Implementation functions for the EDGAR connector.
    Queries SEC EDGAR EFTS for filings, fetches filing documents,
@@ -35,53 +34,23 @@
            [java.time.temporal TemporalAdjusters]
            [java.util UUID]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; -- Handle state --
-
-(def ^:private handles (connector/create-handle-registry))
-
-(defn get-handle [handle] (connector/get-handle handles handle))
-(defn store-handle! [handle state] (connector/store-handle! handles handle state))
-(defn remove-handle! [handle] (connector/remove-handle! handles handle))
+(def ^{:stratum 0} ^:private handles (connector/create-handle-registry))
 
 ;; -- Rate limiting --
-
-(def ^:private last-request-at (atom 0))
-
-(defn- rate-limit!
-  "Sleep to enforce requests-per-second."
-  [rps]
-  (reset! last-request-at (http/time-based-acquire! rps @last-request-at)))
-
-;; -- HTTP helpers --
-
-(defn- fetch-url
-  "Fetch a URL with the SEC-required User-Agent header."
-  [url user-agent]
-  (rate-limit! 8)
-  (let [resp (bb-http/get url {:headers {"User-Agent" user-agent}
-                               :as      :bytes
-                               :throw   false
-                               :timeout 30000})
-        status (:status resp)]
-    (when (<= 200 status 299)
-      (:body resp))))
-
-(defn- fetch-json
-  "Fetch a URL and parse response as JSON."
-  [url user-agent]
-  (when-let [body (fetch-url url user-agent)]
-    (cheshire/parse-string (String. ^bytes body "UTF-8") keyword)))
+(def ^{:stratum 0} ^:private last-request-at (atom 0))
 
 ;; -- XML parsing --
-
-(defn- parse-xml
+(defn- ^{:stratum 0} parse-xml
   "Parse a byte-array as XML, return the root element. `clojure.data.xml`
    elements are records shaped `{:tag :attrs :content}` with content
    being a seq of child elements and text strings."
   [^bytes xml-bytes]
   (xml/parse (ByteArrayInputStream. xml-bytes)))
 
-(defn- elements-by-tag
+(defn- ^{:stratum 0} elements-by-tag
   "Return every descendant element whose `:tag` matches `tag-kw`.
    Depth-first, excluding `el` itself — matches the javax.xml
    `getElementsByTagName` it replaces. `(rest (tree-seq …))` drops the
@@ -90,63 +59,8 @@
   (filter (fn [n] (and (map? n) (= tag-kw (:tag n))))
           (rest (tree-seq :content :content el))))
 
-(defn- text-content
-  "Concatenated text content of the first descendant element with
-   `tag-kw`, or nil when empty. Matches the javax.xml
-   `getTextContent` behaviour the caller expects."
-  [el tag-kw]
-  (when-let [match (first (elements-by-tag el tag-kw))]
-    (let [text (->> (tree-seq :content :content match)
-                    (filter string?)
-                    (apply str))]
-      (when-not (empty? text) text))))
-
-;; -- EDGAR EFTS API --
-
-(defn- search-filings
-  "Search EDGAR EFTS for filings of a given form type in a date range."
-  [efts-base form-type start-date end-date sample-size user-agent]
-  (let [url (str efts-base
-                 "?q=%22" form-type "%22"
-                 "&forms=" form-type
-                 "&dateRange=custom"
-                 "&startdt=" start-date
-                 "&enddt=" end-date
-                 "&_source=adsh,ciks,file_date"
-                 "&from=0&size=" sample-size)]
-    (when-let [data (fetch-json url user-agent)]
-      (get-in data [:hits :hits]))))
-
-(defn- fetch-filing-xml
-  "Fetch a filing's XML document. Tries common filenames."
-  [archives-base adsh cik user-agent filenames]
-  (let [adsh-path (str/replace adsh "-" "")
-        cik-num   (str (parse-long cik))]
-    (some (fn [fname]
-            (fetch-url (str archives-base "/" cik-num "/" adsh-path "/" fname)
-                       user-agent))
-          filenames)))
-
-;; -- Form 4 transaction extraction --
-
-(defn- extract-form4-transactions
-  "Extract open-market P/S transactions from Form 4 XML bytes."
-  [^bytes xml-bytes transaction-codes]
-  (try
-    (let [root (parse-xml xml-bytes)]
-      (for [txn (elements-by-tag root :nonDerivativeTransaction)
-            :let [code   (text-content txn :transactionCode)
-                  shares (text-content txn :transactionShares)
-                  price  (text-content txn :transactionPricePerShare)]
-            :when (and code (contains? transaction-codes code))]
-        {:code   code
-         :shares (when shares (parse-double shares))
-         :price  (when price (parse-double price))}))
-    (catch Exception _ [])))
-
 ;; -- Aggregation --
-
-(defn- monthly-windows
+(defn- ^{:stratum 0} monthly-windows
   "Generate [start end] date string pairs for each month from start to today."
   [^String start-date-str]
   (let [start  (LocalDate/parse start-date-str)
@@ -161,7 +75,154 @@
           (recur (.plusMonths d 1)
                  (conj windows [(.format d fmt) (.format end fmt)])))))))
 
-(defn- fetch-filing-transactions
+(defn- ^{:stratum 0} count-by-code
+  "Count transactions matching a given code."
+  [txns code]
+  (count (filter #(= code (:code %)) txns)))
+
+(defn- ^{:stratum 0} handle-anomaly->response
+  "Convert connector handle validation anomalies to the response anomaly shape
+   expected by current connector protocol consumers."
+  [handle-anomaly]
+  (response/make-anomaly :anomalies/not-found
+                         (:anomaly/message handle-anomaly)
+                         (:anomaly/data handle-anomaly)))
+
+(defn ^{:stratum 0} do-checkpoint [cursor-state]
+  (connector/checkpoint-result cursor-state))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} get-handle [handle] (connector/get-handle handles handle))
+
+(defn ^{:stratum 1} store-handle! [handle state] (connector/store-handle! handles handle state))
+
+(defn ^{:stratum 1} remove-handle! [handle] (connector/remove-handle! handles handle))
+
+(defn- ^{:stratum 1} rate-limit!
+  "Sleep to enforce requests-per-second."
+  [rps]
+  (reset! last-request-at (http/time-based-acquire! rps @last-request-at)))
+
+(defn- ^{:stratum 1} text-content
+  "Concatenated text content of the first descendant element with
+   `tag-kw`, or nil when empty. Matches the javax.xml
+   `getTextContent` behaviour the caller expects."
+  [el tag-kw]
+  (when-let [match (first (elements-by-tag el tag-kw))]
+    (let [text (->> (tree-seq :content :content match)
+                    (filter string?)
+                    (apply str))]
+      (when-not (empty? text) text))))
+
+;; -- Source --
+(defn- ^{:stratum 1} require-handle
+  "Retrieve handle state or return an anomaly."
+  [handle]
+  (connector/require-handle handles handle
+                            {:message (msg/t :edgar/handle-not-found {:handle handle})}))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; -- HTTP helpers --
+(defn- ^{:stratum 2} fetch-url
+  "Fetch a URL with the SEC-required User-Agent header."
+  [url user-agent]
+  (rate-limit! 8)
+  (let [resp (bb-http/get url {:headers {"User-Agent" user-agent}
+                               :as      :bytes
+                               :throw   false
+                               :timeout 30000})
+        status (:status resp)]
+    (when (<= 200 status 299)
+      (:body resp))))
+
+;; -- Form 4 transaction extraction --
+(defn- ^{:stratum 2} extract-form4-transactions
+  "Extract open-market P/S transactions from Form 4 XML bytes."
+  [^bytes xml-bytes transaction-codes]
+  (try
+    (let [root (parse-xml xml-bytes)]
+      (for [txn (elements-by-tag root :nonDerivativeTransaction)
+            :let [code   (text-content txn :transactionCode)
+                  shares (text-content txn :transactionShares)
+                  price  (text-content txn :transactionPricePerShare)]
+            :when (and code (contains? transaction-codes code))]
+        {:code   code
+         :shares (when shares (parse-double shares))
+         :price  (when price (parse-double price))}))
+    (catch Exception _ [])))
+
+;; -- Lifecycle --
+(defn ^{:stratum 2} do-connect
+  "Validate config, register handle."
+  [config _auth]
+  (let [form-type  (:edgar/form-type config)
+        user-agent (:edgar/user-agent config)
+        aggregation (:edgar/aggregation config)]
+    (cond
+      (nil? form-type)   (response/throw-anomaly! :anomalies/incorrect
+                                                  (msg/t :edgar/form-type-required)
+                                                  {:config config})
+      (nil? user-agent)  (response/throw-anomaly! :anomalies/incorrect
+                                                  (msg/t :edgar/user-agent-required)
+                                                  {:config config})
+      (nil? aggregation) (response/throw-anomaly! :anomalies/incorrect
+                                                  (msg/t :edgar/aggregation-required)
+                                                  {:config config})
+      :else
+      (let [handle (str (UUID/randomUUID))]
+        (store-handle! handle {:config config})
+        (connector/connect-result handle)))))
+
+(defn ^{:stratum 2} do-close [handle]
+  (remove-handle! handle)
+  (connector/close-result))
+
+(defn ^{:stratum 2} do-discover [handle]
+  (let [handle-state (require-handle handle)]
+    (if (anomaly/anomaly? handle-state)
+      (handle-anomaly->response handle-state)
+      (let [{:keys [config]} handle-state]
+        (connector/discover-result [{:schema/name        (:edgar/form-type config)
+                                     :schema/aggregation (:edgar/aggregation config)}])))))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn- ^{:stratum 3} fetch-json
+  "Fetch a URL and parse response as JSON."
+  [url user-agent]
+  (when-let [body (fetch-url url user-agent)]
+    (cheshire/parse-string (String. ^bytes body "UTF-8") keyword)))
+
+(defn- ^{:stratum 3} fetch-filing-xml
+  "Fetch a filing's XML document. Tries common filenames."
+  [archives-base adsh cik user-agent filenames]
+  (let [adsh-path (str/replace adsh "-" "")
+        cik-num   (str (parse-long cik))]
+    (some (fn [fname]
+            (fetch-url (str archives-base "/" cik-num "/" adsh-path "/" fname)
+                       user-agent))
+          filenames)))
+
+;------------------------------------------------------------------------------ Layer 4
+
+;; -- EDGAR EFTS API --
+(defn- ^{:stratum 4} search-filings
+  "Search EDGAR EFTS for filings of a given form type in a date range."
+  [efts-base form-type start-date end-date sample-size user-agent]
+  (let [url (str efts-base
+                 "?q=%22" form-type "%22"
+                 "&forms=" form-type
+                 "&dateRange=custom"
+                 "&startdt=" start-date
+                 "&enddt=" end-date
+                 "&_source=adsh,ciks,file_date"
+                 "&from=0&size=" sample-size)]
+    (when-let [data (fetch-json url user-agent)]
+      (get-in data [:hits :hits]))))
+
+(defn- ^{:stratum 4} fetch-filing-transactions
   "Fetch and extract transactions from a single EFTS hit."
   [archives-base hit user-agent filenames transaction-codes]
   (let [src  (:_source hit)
@@ -171,12 +232,9 @@
       (when-let [xml (fetch-filing-xml archives-base adsh cik user-agent filenames)]
         (extract-form4-transactions xml transaction-codes)))))
 
-(defn- count-by-code
-  "Count transactions matching a given code."
-  [txns code]
-  (count (filter #(= code (:code %)) txns)))
+;------------------------------------------------------------------------------ Layer 5
 
-(defn- aggregate-buy-sell-ratio
+(defn- ^{:stratum 5} aggregate-buy-sell-ratio
   "Aggregate Form 4 transactions into monthly buy:sell ratio records."
   [config user-agent]
   (let [{:edgar/keys [start-date sample-size transaction-codes
@@ -203,58 +261,9 @@
         :series_id (or series-id "INSIDER_BUY_SELL_RATIO")
         :value     (format "%.4f" ratio)}))))
 
-;; -- Lifecycle --
+;------------------------------------------------------------------------------ Layer 6
 
-(defn do-connect
-  "Validate config, register handle."
-  [config _auth]
-  (let [form-type  (:edgar/form-type config)
-        user-agent (:edgar/user-agent config)
-        aggregation (:edgar/aggregation config)]
-    (cond
-      (nil? form-type)   (response/throw-anomaly! :anomalies/incorrect
-                                                  (msg/t :edgar/form-type-required)
-                                                  {:config config})
-      (nil? user-agent)  (response/throw-anomaly! :anomalies/incorrect
-                                                  (msg/t :edgar/user-agent-required)
-                                                  {:config config})
-      (nil? aggregation) (response/throw-anomaly! :anomalies/incorrect
-                                                  (msg/t :edgar/aggregation-required)
-                                                  {:config config})
-      :else
-      (let [handle (str (UUID/randomUUID))]
-        (store-handle! handle {:config config})
-        (connector/connect-result handle)))))
-
-(defn do-close [handle]
-  (remove-handle! handle)
-  (connector/close-result))
-
-;; -- Source --
-
-(defn- require-handle
-  "Retrieve handle state or return an anomaly."
-  [handle]
-  (connector/require-handle handles handle
-                            {:message (msg/t :edgar/handle-not-found {:handle handle})}))
-
-(defn- handle-anomaly->response
-  "Convert connector handle validation anomalies to the response anomaly shape
-   expected by current connector protocol consumers."
-  [handle-anomaly]
-  (response/make-anomaly :anomalies/not-found
-                         (:anomaly/message handle-anomaly)
-                         (:anomaly/data handle-anomaly)))
-
-(defn do-discover [handle]
-  (let [handle-state (require-handle handle)]
-    (if (anomaly/anomaly? handle-state)
-      (handle-anomaly->response handle-state)
-      (let [{:keys [config]} handle-state]
-        (connector/discover-result [{:schema/name        (:edgar/form-type config)
-                                     :schema/aggregation (:edgar/aggregation config)}])))))
-
-(defn do-extract
+(defn ^{:stratum 6} do-extract
   "Extract aggregated records from EDGAR filings."
   [handle _opts]
   (let [handle-state (require-handle handle)]
@@ -270,6 +279,3 @@
                                                   (msg/t :edgar/aggregation-unknown {:agg (:edgar/aggregation config)})
                                                   {:aggregation (:edgar/aggregation config)}))]
         (connector/extract-result records nil false)))))
-
-(defn do-checkpoint [cursor-state]
-  (connector/checkpoint-result cursor-state))

--- a/components/connector-edgar/src/ai/miniforge/connector_edgar/interface.clj
+++ b/components/connector-edgar/src/ai/miniforge/connector_edgar/interface.clj
@@ -15,17 +15,18 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-edgar.interface
   "Public API for the EDGAR connector component."
   (:require [ai.miniforge.connector-edgar.core :as core]))
 
-(defn create-edgar-connector
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} create-edgar-connector
   "Create a new EdgarConnector instance."
   []
   (core/->EdgarConnector))
 
-(def connector-metadata
+(def ^{:stratum 0} connector-metadata
   "Registration metadata for the EDGAR connector."
   {:connector/name         "SEC EDGAR Connector"
    :connector/type         :source

--- a/components/connector-edgar/src/ai/miniforge/connector_edgar/messages.clj
+++ b/components/connector-edgar/src/ai/miniforge/connector_edgar/messages.clj
@@ -15,11 +15,12 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-edgar.messages
   "Message catalog — delegates to ai.miniforge.messages."
   (:require [ai.miniforge.messages.interface :as messages]))
 
-(def t
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} t
   "Look up a message by key, with optional param substitution."
   (messages/create-translator "config/connector-edgar/messages/en-US.edn" :connector-edgar/messages))

--- a/components/connector-edgar/test/ai/miniforge/connector_edgar/anomaly/edgar_anomaly_test.clj
+++ b/components/connector-edgar/test/ai/miniforge/connector_edgar/anomaly/edgar_anomaly_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-edgar.anomaly.edgar-anomaly-test
   "Coverage for `impl/do-connect` and `impl/do-extract` boundary
    escalation via `response/throw-anomaly!`.
@@ -26,7 +25,9 @@
             [ai.miniforge.connector-edgar.impl :as impl])
   (:import (clojure.lang ExceptionInfo)))
 
-(deftest do-connect-missing-form-type-throws-anomaly
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} do-connect-missing-form-type-throws-anomaly
   (testing "missing :edgar/form-type raises :anomalies/incorrect"
     (try
       (impl/do-connect {:edgar/user-agent "ua" :edgar/aggregation :monthly-buy-sell-ratio} nil)
@@ -35,7 +36,7 @@
         (is (= :anomalies/incorrect (:anomaly/category (ex-data e))))
         (is (some? (:config (ex-data e))))))))
 
-(deftest do-connect-missing-user-agent-throws-anomaly
+(deftest ^{:stratum 0} do-connect-missing-user-agent-throws-anomaly
   (testing "missing :edgar/user-agent raises :anomalies/incorrect"
     (try
       (impl/do-connect {:edgar/form-type "10-K" :edgar/aggregation :monthly-buy-sell-ratio} nil)
@@ -43,7 +44,7 @@
       (catch ExceptionInfo e
         (is (= :anomalies/incorrect (:anomaly/category (ex-data e))))))))
 
-(deftest do-connect-missing-aggregation-throws-anomaly
+(deftest ^{:stratum 0} do-connect-missing-aggregation-throws-anomaly
   (testing "missing :edgar/aggregation raises :anomalies/incorrect"
     (try
       (impl/do-connect {:edgar/form-type "10-K" :edgar/user-agent "ua"} nil)
@@ -51,7 +52,7 @@
       (catch ExceptionInfo e
         (is (= :anomalies/incorrect (:anomaly/category (ex-data e))))))))
 
-(deftest do-extract-unknown-aggregation-throws-anomaly
+(deftest ^{:stratum 0} do-extract-unknown-aggregation-throws-anomaly
   (testing "do-extract with unknown :edgar/aggregation raises :anomalies/unsupported"
     (let [connect-result (impl/do-connect
                           {:edgar/form-type "10-K"

--- a/components/connector-edgar/test/ai/miniforge/connector_edgar/interface_test.clj
+++ b/components/connector-edgar/test/ai/miniforge/connector_edgar/interface_test.clj
@@ -15,13 +15,14 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-edgar.interface-test
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.connector-edgar.impl :as impl]
             [ai.miniforge.response.interface :as response]))
 
-(deftest connect-validates-config-test
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} connect-validates-config-test
   (testing "do-connect requires form-type, user-agent, aggregation"
     (is (thrown? Exception (impl/do-connect {} nil)))
     (is (thrown? Exception (impl/do-connect {:edgar/form-type "4"} nil)))
@@ -29,7 +30,7 @@
                 (impl/do-connect {:edgar/form-type "4"
                                   :edgar/user-agent "Test/1.0"} nil)))))
 
-(deftest connect-close-lifecycle-test
+(deftest ^{:stratum 0} connect-close-lifecycle-test
   (testing "connect and close work"
     (let [config {:edgar/form-type   "4"
                   :edgar/user-agent  "Test/1.0 test@test.com"
@@ -40,7 +41,7 @@
       (let [close-result (impl/do-close (:connection/handle result))]
         (is (= :closed (:connector/status close-result)))))))
 
-(deftest extract-form4-transactions-test
+(deftest ^{:stratum 0} extract-form4-transactions-test
   (testing "extracts P and S transactions from Form 4 XML"
     (let [xml-str "<?xml version=\"1.0\"?>
 <ownershipDocument>
@@ -83,12 +84,12 @@
       (is (= "S" (:code (second txns))))
       (is (= 500.0 (:shares (second txns)))))))
 
-(deftest extract-form4-transactions-invalid-xml-test
+(deftest ^{:stratum 0} extract-form4-transactions-invalid-xml-test
   (testing "invalid XML returns empty"
     (let [txns (#'impl/extract-form4-transactions (.getBytes "not xml" "UTF-8") #{"P" "S"})]
       (is (empty? txns)))))
 
-(deftest monthly-windows-test
+(deftest ^{:stratum 0} monthly-windows-test
   (testing "generates monthly windows from start date"
     (let [windows (#'impl/monthly-windows "2026-01-01")]
       (is (pos? (count windows)))
@@ -98,7 +99,7 @@
         (is (string? s))
         (is (string? e))))))
 
-(deftest discover-test
+(deftest ^{:stratum 0} discover-test
   (testing "discover returns form type info"
     (let [config {:edgar/form-type   "4"
                   :edgar/user-agent  "Test/1.0"
@@ -109,17 +110,15 @@
       (is (= "4" (:schema/name (first (:schemas result)))))
       (impl/do-close handle))))
 
-;;------------------------------------------------------------------------------ Layer 2
 ;; Migrated handle-lookup helper — connector boundaries return anomalies.
-
-(deftest discover-returns-anomaly-on-unknown-handle-test
+(deftest ^{:stratum 0} discover-returns-anomaly-on-unknown-handle-test
   (testing "do-discover returns an anomaly with :handle when handle is missing"
     (let [result (impl/do-discover "no-such-handle")]
       (is (response/anomaly-map? result))
       (is (= :anomalies/not-found (:anomaly/category result)))
       (is (= "no-such-handle" (:handle result))))))
 
-(deftest extract-returns-anomaly-on-unknown-handle-test
+(deftest ^{:stratum 0} extract-returns-anomaly-on-unknown-handle-test
   (testing "do-extract returns an anomaly with :handle when handle is missing"
     (let [result (impl/do-extract "no-such-handle" {})]
       (is (response/anomaly-map? result))

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-connector-edgar.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-connector-edgar.md
@@ -1,0 +1,124 @@
+<!--
+  Title: stratum-lint autofix for components/connector-edgar (Wave 1)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix: stratum-lint autofix for components/connector-edgar (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over `components/connector-edgar` (`src` +
+`test`) to replace decorative `Layer N` headings with real ones derived
+from each file's actual same-file reference graph, and tag every
+top-level `def`/`defn`/`deftest` with `^{:stratum n}`. Batch 5 of Wave 1
+from `work/stratum-lint-baseline-2026-07-24.md`. Purely mechanical — no
+executable logic changed anywhere.
+
+## Motivation
+
+A fresh plain-lint run before touching anything confirmed zero `SL001`
+(no upward-reference/cycle risk), matching the Wave 1 batch criteria.
+All 6 pre-existing findings were `SL004` (a `deftest` appearing before
+any `Layer` heading), concentrated entirely in
+`interface_test.clj`, which had no headings at all.
+
+## Changes in Detail
+
+Ran, over the whole component:
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "bef8657a2efd3b1ba9e1a4f510693c9fbca45abd" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/connector-edgar
+```
+
+All 6 `.clj` files in the component were rewritten (`--fix` normalizes
+every file, not just the ones with findings): `core.clj`, `impl.clj`,
+`interface.clj`, `messages.clj`, and both test files. Diffs are heading
+text, `^{:stratum n}` metadata, and def/deftest reordering only.
+
+`core.clj`, `interface.clj`, and `messages.clj` each collapsed to a
+single real `Layer 0` — every def in those files was already at the
+base stratum, just missing the heading and metadata.
+
+`impl.clj` is the substantial diff: `--fix` recomputed **7 real layers**
+(0 through 6) from the file's actual call graph — handle-registry
+plumbing and pure helpers (`parse-xml`, `monthly-windows`,
+`count-by-code`, etc.) at Layer 0, up through `search-filings` →
+`fetch-filing-transactions` → `aggregate-buy-sell-ratio` → `do-extract`
+at Layer 6, the deepest chain being the EFTS-search → fetch-transactions
+→ aggregate → extract pipeline. This produces a new `SL003` (over the
+3-layer budget) that did not show up in the pre-fix baseline, because
+the file previously had no headings at all to measure against — see
+Testing Plan and Deployment Plan.
+
+`interface_test.clj` had one old decorative double-semicolon banner
+(`;;------------------------------------------------------------------------------ Layer 2`)
+sitting above a `;; Migrated handle-lookup helper...` comment. Unlike
+the contradictory-banner class seen in earlier batches, `--fix` removed
+this one cleanly on its own — every `deftest` in the file resolved to
+the same real Layer 0, so there was nothing left for the old banner to
+contradict. Verified by reading the full post-fix file: the descriptive
+comment survives intact above its `deftest`, no orphaned heading
+remains. No hand edit was needed.
+
+No `defmethod` in this component, so the upstream `defmethod`-refs-union
+bug class doesn't apply here. No reader-conditional-wrapped defs, so the
+SL008 restructuring pattern (`components/artifact`) wasn't needed either.
+
+## Testing Plan
+
+1. Ran plain (non-`--fix`) `stratum-lint` before any change — reproduced
+   the 6 `SL004` findings exactly, confirmed 0 `SL001`.
+2. Ran `--fix`, then a second `--fix` pass immediately after — zero
+   diff, confirms idempotency.
+3. Read the full diff for all 6 changed files. No same-line
+   trailing-comment displacement found in any file; the one decorative
+   banner found (`interface_test.clj`) was resolved cleanly by the tool
+   itself, not left contradictory — confirmed by inspection, no hand
+   edit required.
+4. `clj-kondo --lint components/connector-edgar`: 0 errors, 0 warnings,
+   both before and after.
+5. Ran both test namespaces directly via `clojure -M:dev:test`:
+   `ai.miniforge.connector-edgar.interface-test` and
+   `ai.miniforge.connector-edgar.anomaly.edgar-anomaly-test` — 12 tests,
+   42 assertions, 0 failures, 0 errors.
+6. Re-ran plain `stratum-lint` after the fix: `SL001`/`SL002`/`SL004`
+   clear across the component. One `SL003` remains, newly surfaced (not
+   present in the pre-fix baseline, since the file had no headings to
+   measure against before): `impl.clj` at 7 real layers against the
+   3-layer budget — a genuine Wave 2 (namespace split) candidate, not a
+   defect in this fix.
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+change — comment/metadata/order-only. Committed with
+`MINIFORGE_STRATUM_BUDGET_MODE=warn` alongside
+`MINIFORGE_COMMIT_BUDGET_OVERRIDE=1` so the pre-commit gate's post-fix
+lint pass doesn't hard-block on the newly surfaced `impl.clj` `SL003`.
+Pre-commit's `lint:stratum` autofixer keeps this component clean going
+forward for everything except that one over-budget file, which stays
+advisory until Wave 2 splits it.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+- Follow-on: Wave 2 namespace split for
+  `components/connector-edgar/src/ai/miniforge/connector_edgar/impl.clj`
+  (7 real layers, over the 3-layer budget)
+
+## Checklist
+
+- [x] Confirmed zero `SL001` findings before making any change
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Second `--fix` pass confirms idempotency (zero diff)
+- [x] Diff read in full for all 6 changed files
+- [x] One decorative banner found in `interface_test.clj`; verified the
+      tool resolved it cleanly with no orphaned contradiction — no hand
+      edit needed
+- [x] `clj-kondo` clean (0 errors, 0 warnings, before and after)
+- [x] Component tests pass (12 tests, 42 assertions, 0 failures/errors)
+- [x] Plain lint re-run post-fix: zero `SL001`/`SL002`/`SL004`; `SL003`
+      remains on `impl.clj` — newly surfaced by the fix, tracked as
+      Wave 2 above
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
<!--
  Title: stratum-lint autofix for components/connector-edgar (Wave 1)
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# fix: stratum-lint autofix for components/connector-edgar (Wave 1)

## Overview

Runs `stratum-lint --fix` over `components/connector-edgar` (`src` +
`test`) to replace decorative `Layer N` headings with real ones derived
from each file's actual same-file reference graph, and tag every
top-level `def`/`defn`/`deftest` with `^{:stratum n}`. Batch 5 of Wave 1
from `work/stratum-lint-baseline-2026-07-24.md`. Purely mechanical — no
executable logic changed anywhere.

## Motivation

A fresh plain-lint run before touching anything confirmed zero `SL001`
(no upward-reference/cycle risk), matching the Wave 1 batch criteria.
All 6 pre-existing findings were `SL004` (a `deftest` appearing before
any `Layer` heading), concentrated entirely in
`interface_test.clj`, which had no headings at all.

## Changes in Detail

Ran, over the whole component:

```bash
bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "bef8657a2efd3b1ba9e1a4f510693c9fbca45abd" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/connector-edgar
```

All 6 `.clj` files in the component were rewritten (`--fix` normalizes
every file, not just the ones with findings): `core.clj`, `impl.clj`,
`interface.clj`, `messages.clj`, and both test files. Diffs are heading
text, `^{:stratum n}` metadata, and def/deftest reordering only.

`core.clj`, `interface.clj`, and `messages.clj` each collapsed to a
single real `Layer 0` — every def in those files was already at the
base stratum, just missing the heading and metadata.

`impl.clj` is the substantial diff: `--fix` recomputed **7 real layers**
(0 through 6) from the file's actual call graph — handle-registry
plumbing and pure helpers (`parse-xml`, `monthly-windows`,
`count-by-code`, etc.) at Layer 0, up through `search-filings` →
`fetch-filing-transactions` → `aggregate-buy-sell-ratio` → `do-extract`
at Layer 6, the deepest chain being the EFTS-search → fetch-transactions
→ aggregate → extract pipeline. This produces a new `SL003` (over the
3-layer budget) that did not show up in the pre-fix baseline, because
the file previously had no headings at all to measure against — see
Testing Plan and Deployment Plan.

`interface_test.clj` had one old decorative double-semicolon banner
(`;;------------------------------------------------------------------------------ Layer 2`)
sitting above a `;; Migrated handle-lookup helper...` comment. Unlike
the contradictory-banner class seen in earlier batches, `--fix` removed
this one cleanly on its own — every `deftest` in the file resolved to
the same real Layer 0, so there was nothing left for the old banner to
contradict. Verified by reading the full post-fix file: the descriptive
comment survives intact above its `deftest`, no orphaned heading
remains. No hand edit was needed.

No `defmethod` in this component, so the upstream `defmethod`-refs-union
bug class doesn't apply here. No reader-conditional-wrapped defs, so the
SL008 restructuring pattern (`components/artifact`) wasn't needed either.

## Testing Plan

1. Ran plain (non-`--fix`) `stratum-lint` before any change — reproduced
   the 6 `SL004` findings exactly, confirmed 0 `SL001`.
2. Ran `--fix`, then a second `--fix` pass immediately after — zero
   diff, confirms idempotency.
3. Read the full diff for all 6 changed files. No same-line
   trailing-comment displacement found in any file; the one decorative
   banner found (`interface_test.clj`) was resolved cleanly by the tool
   itself, not left contradictory — confirmed by inspection, no hand
   edit required.
4. `clj-kondo --lint components/connector-edgar`: 0 errors, 0 warnings,
   both before and after.
5. Ran both test namespaces directly via `clojure -M:dev:test`:
   `ai.miniforge.connector-edgar.interface-test` and
   `ai.miniforge.connector-edgar.anomaly.edgar-anomaly-test` — 12 tests,
   42 assertions, 0 failures, 0 errors.
6. Re-ran plain `stratum-lint` after the fix: `SL001`/`SL002`/`SL004`
   clear across the component. One `SL003` remains, newly surfaced (not
   present in the pre-fix baseline, since the file had no headings to
   measure against before): `impl.clj` at 7 real layers against the
   3-layer budget — a genuine Wave 2 (namespace split) candidate, not a
   defect in this fix.

## Deployment Plan

Merges to `main` like any other component change. No runtime behavior
change — comment/metadata/order-only. Committed with
`MINIFORGE_STRATUM_BUDGET_MODE=warn` alongside
`MINIFORGE_COMMIT_BUDGET_OVERRIDE=1` so the pre-commit gate's post-fix
lint pass doesn't hard-block on the newly surfaced `impl.clj` `SL003`.
Pre-commit's `lint:stratum` autofixer keeps this component clean going
forward for everything except that one over-budget file, which stays
advisory until Wave 2 splits it.

## Related Issues/PRs

- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
- Follow-on: Wave 2 namespace split for
  `components/connector-edgar/src/ai/miniforge/connector_edgar/impl.clj`
  (7 real layers, over the 3-layer budget)

## Checklist

- [x] Confirmed zero `SL001` findings before making any change
- [x] `--fix` run over the whole component (`src` + `test`)
- [x] Second `--fix` pass confirms idempotency (zero diff)
- [x] Diff read in full for all 6 changed files
- [x] One decorative banner found in `interface_test.clj`; verified the
      tool resolved it cleanly with no orphaned contradiction — no hand
      edit needed
- [x] `clj-kondo` clean (0 errors, 0 warnings, before and after)
- [x] Component tests pass (12 tests, 42 assertions, 0 failures/errors)
- [x] Plain lint re-run post-fix: zero `SL001`/`SL002`/`SL004`; `SL003`
      remains on `impl.clj` — newly surfaced by the fix, tracked as
      Wave 2 above
- [x] No `--no-verify`; pre-commit hook runs normally at commit time
