### PR TITLE
fix: stratum-lint autofix for components/connector-sarif (Wave 1)

### DIFF
--- a/components/connector-sarif/src/ai/miniforge/connector_sarif/core.clj
+++ b/components/connector-sarif/src/ai/miniforge/connector_sarif/core.clj
@@ -15,13 +15,14 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-sarif.core
   "SarifConnector defrecord — thin protocol wrapper delegating to impl."
   (:require [ai.miniforge.connector.interface :as connector]
             [ai.miniforge.connector-sarif.impl :as impl]))
 
-(defrecord SarifConnector []
+;------------------------------------------------------------------------------ Layer 0
+
+(defrecord ^{:stratum 0} SarifConnector []
   connector/Connector
   (connect [_ config _auth] (impl/do-connect config))
   (close   [_ handle]       (impl/do-close handle))

--- a/components/connector-sarif/src/ai/miniforge/connector_sarif/format.clj
+++ b/components/connector-sarif/src/ai/miniforge/connector_sarif/format.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-sarif.format
   "SARIF JSON and CSV parsing helpers.
    Handles SARIF v2.1.0 structure (tool -> runs[] -> results[] -> locations[]).
@@ -27,10 +26,11 @@
             [clojure.string :as str]
             [clojure.data.csv :as csv]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; --------------------------------------------------------------------------
 ;; SARIF v2.1.0 Parsing
-
-(defn- normalize-severity
+(defn- ^{:stratum 0} normalize-severity
   "Normalize SARIF level string to keyword."
   [level]
   (case (str/lower-case (or level "warning"))
@@ -40,7 +40,7 @@
     "none"    :none
     :warning))
 
-(defn- extract-location
+(defn- ^{:stratum 0} extract-location
   "Extract physical location from a SARIF location object."
   [loc]
   (let [phys (get loc "physicalLocation")
@@ -50,7 +50,39 @@
      :line   (get region "startLine")
      :column (get region "startColumn")}))
 
-(defn- parse-sarif-result
+;; --------------------------------------------------------------------------
+;; CSV Parsing
+(def ^{:stratum 0} default-csv-columns
+  "Default column mapping for CSV scan output."
+  {:rule-id  "Rule ID"
+   :message  "Message"
+   :severity "Severity"
+   :file     "File"
+   :line     "Line"
+   :column   "Column"})
+
+(defn- ^{:stratum 0} find-column-index
+  "Find column index by header name (case-insensitive)."
+  [headers col-name]
+  (let [target (str/lower-case col-name)]
+    (first (keep-indexed
+            (fn [idx h] (when (= (str/lower-case (str/trim h)) target) idx))
+            headers))))
+
+;; --------------------------------------------------------------------------
+;; File discovery and format detection
+(defn ^{:stratum 0} detect-format
+  "Detect file format from extension."
+  [path]
+  (cond
+    (str/ends-with? (str/lower-case path) ".sarif")     :sarif
+    (str/ends-with? (str/lower-case path) ".sarif.json") :sarif
+    (str/ends-with? (str/lower-case path) ".csv")        :csv
+    :else :unknown))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} parse-sarif-result
   "Parse a single SARIF result into a unified violation record."
   [result tool-name run-idx result-idx]
   (let [rule-id  (get result "ruleId" "unknown")
@@ -66,44 +98,7 @@
      :violation/source-tool tool-name
      :violation/raw         result}))
 
-(defn parse-sarif
-  "Parse a SARIF v2.1.0 JSON file into violation records.
-   Returns a vector of unified SarifViolation maps."
-  [path]
-  (let [content (json/parse-string (slurp path))
-        runs    (get content "runs" [])]
-    (into []
-          (mapcat
-           (fn [[run-idx run]]
-             (let [tool-name (get-in run ["tool" "driver" "name"] "unknown")
-                   results   (get run "results" [])]
-               (map-indexed
-                (fn [res-idx result]
-                  (parse-sarif-result result tool-name run-idx res-idx))
-                results)))
-           (map-indexed vector runs)))))
-
-;; --------------------------------------------------------------------------
-;; CSV Parsing
-
-(def default-csv-columns
-  "Default column mapping for CSV scan output."
-  {:rule-id  "Rule ID"
-   :message  "Message"
-   :severity "Severity"
-   :file     "File"
-   :line     "Line"
-   :column   "Column"})
-
-(defn- find-column-index
-  "Find column index by header name (case-insensitive)."
-  [headers col-name]
-  (let [target (str/lower-case col-name)]
-    (first (keep-indexed
-            (fn [idx h] (when (= (str/lower-case (str/trim h)) target) idx))
-            headers))))
-
-(defn- csv-row->violation
+(defn- ^{:stratum 1} csv-row->violation
   "Convert a CSV row to a unified violation record."
   [row headers col-map idx]
   (let [get-col (fn [k]
@@ -121,7 +116,38 @@
      :violation/source-tool "csv-import"
      :violation/raw         (zipmap headers row)}))
 
-(defn parse-csv
+(defn ^{:stratum 1} list-scan-files
+  "List scannable files in a path (file or directory)."
+  [source-path]
+  (let [f (io/file source-path)]
+    (cond
+      (not (.exists f)) []
+      (.isFile f)       [(.getAbsolutePath f)]
+      (.isDirectory f)  (->> (.listFiles f)
+                             (filter #(#{:sarif :csv} (detect-format (.getName %))))
+                             (mapv #(.getAbsolutePath %)))
+      :else [])))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} parse-sarif
+  "Parse a SARIF v2.1.0 JSON file into violation records.
+   Returns a vector of unified SarifViolation maps."
+  [path]
+  (let [content (json/parse-string (slurp path))
+        runs    (get content "runs" [])]
+    (into []
+          (mapcat
+           (fn [[run-idx run]]
+             (let [tool-name (get-in run ["tool" "driver" "name"] "unknown")
+                   results   (get run "results" [])]
+               (map-indexed
+                (fn [res-idx result]
+                  (parse-sarif-result result tool-name run-idx res-idx))
+                results)))
+           (map-indexed vector runs)))))
+
+(defn ^{:stratum 2} parse-csv
   "Parse a CSV scan output file into violation records.
    Accepts optional column mapping override."
   ([path] (parse-csv path nil))
@@ -135,31 +161,9 @@
                (fn [idx row] (csv-row->violation row headers col-map idx))
                data)))))))
 
-;; --------------------------------------------------------------------------
-;; File discovery and format detection
+;------------------------------------------------------------------------------ Layer 3
 
-(defn detect-format
-  "Detect file format from extension."
-  [path]
-  (cond
-    (str/ends-with? (str/lower-case path) ".sarif")     :sarif
-    (str/ends-with? (str/lower-case path) ".sarif.json") :sarif
-    (str/ends-with? (str/lower-case path) ".csv")        :csv
-    :else :unknown))
-
-(defn list-scan-files
-  "List scannable files in a path (file or directory)."
-  [source-path]
-  (let [f (io/file source-path)]
-    (cond
-      (not (.exists f)) []
-      (.isFile f)       [(.getAbsolutePath f)]
-      (.isDirectory f)  (->> (.listFiles f)
-                             (filter #(#{:sarif :csv} (detect-format (.getName %))))
-                             (mapv #(.getAbsolutePath %)))
-      :else [])))
-
-(defn parse-file
+(defn ^{:stratum 3} parse-file
   "Parse a single file based on format. Returns violation records."
   [path fmt csv-columns]
   (let [actual-fmt (if (= fmt :auto) (detect-format path) (or fmt (detect-format path)))]

--- a/components/connector-sarif/src/ai/miniforge/connector_sarif/impl.clj
+++ b/components/connector-sarif/src/ai/miniforge/connector_sarif/impl.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-sarif.impl
   "SARIF connector implementation — connect, discover, extract, checkpoint."
   (:require [ai.miniforge.anomaly.interface :as anomaly]
@@ -25,28 +24,36 @@
             [ai.miniforge.response.interface :as response]
             [clojure.string :as str]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; --------------------------------------------------------------------------
 ;; Handle state
+(def ^{:stratum 0} ^:private handles (connector/create-handle-registry))
 
-(def ^:private handles (connector/create-handle-registry))
+(defn- ^{:stratum 0} generate-handle [] (str "sarif-" (java.util.UUID/randomUUID)))
 
-(defn- generate-handle [] (str "sarif-" (java.util.UUID/randomUUID)))
-
-(defn- require-handle
-  "Look up handle state or return an anomaly."
-  [handle]
-  (connector/require-handle handles handle
-                            {:message (str "Unknown handle: " handle)}))
-
-(defn- handle-anomaly->response [handle-anomaly]
+(defn- ^{:stratum 0} handle-anomaly->response [handle-anomaly]
   (response/make-anomaly :anomalies/not-found
                          (:anomaly/message handle-anomaly)
                          (:anomaly/data handle-anomaly)))
 
 ;; --------------------------------------------------------------------------
-;; Connect / Close
+;; Discover
+(defn- ^{:stratum 0} build-schema-descriptor [schema-type count]
+  {:schema/name schema-type
+   :schema/record-count count})
 
-(defn do-connect
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} require-handle
+  "Look up handle state or return an anomaly."
+  [handle]
+  (connector/require-handle handles handle
+                            {:message (str "Unknown handle: " handle)}))
+
+;; --------------------------------------------------------------------------
+;; Connect / Close
+(defn ^{:stratum 1} do-connect
   "Validate config and establish a connection handle."
   [config]
   (let [{:keys [valid? errors]} (schema/validate-config config)]
@@ -62,20 +69,15 @@
         {:connection/handle handle
          :connector/status  :connected}))))
 
-(defn do-close
+(defn ^{:stratum 1} do-close
   "Release a connection handle."
   [handle]
   (connector/remove-handle! handles handle)
   {:connector/status :closed})
 
-;; --------------------------------------------------------------------------
-;; Discover
+;------------------------------------------------------------------------------ Layer 2
 
-(defn- build-schema-descriptor [schema-type count]
-  {:schema/name schema-type
-   :schema/record-count count})
-
-(defn do-discover
+(defn ^{:stratum 2} do-discover
   "Discover available schemas in the connected source."
   [handle _opts]
   (let [state (require-handle handle)]
@@ -106,8 +108,7 @@
 
 ;; --------------------------------------------------------------------------
 ;; Extract
-
-(defn do-extract
+(defn ^{:stratum 2} do-extract
   "Extract records for a given schema."
   [handle _schema-name opts]
   (let [state (require-handle handle)]
@@ -133,8 +134,7 @@
 
 ;; --------------------------------------------------------------------------
 ;; Checkpoint
-
-(defn do-checkpoint
+(defn ^{:stratum 2} do-checkpoint
   "Persist cursor state for resumable extraction."
   [handle _connector-id _cursor-state]
   (let [state (require-handle handle)]

--- a/components/connector-sarif/src/ai/miniforge/connector_sarif/interface.clj
+++ b/components/connector-sarif/src/ai/miniforge/connector_sarif/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-sarif.interface
   "Public API for the SARIF/CSV connector.
    A SourceConnector that extracts violations from SARIF v2.1.0 JSON
@@ -24,12 +23,14 @@
             [ai.miniforge.connector-sarif.schema :as schema]
             [ai.miniforge.connector.interface :as conn]))
 
-(defn create-sarif-connector
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} create-sarif-connector
   "Create a new SarifConnector instance."
   []
   (core/->SarifConnector))
 
-(def connector-metadata
+(def ^{:stratum 0} connector-metadata
   "Registration metadata for the SARIF connector."
   {:connector/name         "SARIF/CSV Scanner Connector"
    :connector/type         :source
@@ -40,7 +41,7 @@
    :connector/maintainer   "data-foundry"})
 
 ;; Schema exports
-(def SarifViolation
+(def ^{:stratum 0} SarifViolation
   "Malli schema (a `[:map ...]` vector) for a unified violation record,
    normalized from both SARIF and CSV sources. Required keys:
    :violation/id, :violation/rule-id, :violation/message (strings),
@@ -49,28 +50,28 @@
    :violation/source-tool (string), :violation/raw (map)."
   schema/SarifViolation)
 
-(def SarifConfig
+(def ^{:stratum 0} SarifConfig
   "Malli schema (a `[:map ...]` vector) for the SARIF connector config.
    Required key :sarif/source-path (string); optional :sarif/format
    (:sarif/:csv/:auto) and :sarif/csv-columns (keyword->string map)."
   schema/SarifConfig)
 
-(defn validate-config
+(defn ^{:stratum 0} validate-config
   "Validate a SARIF connector config map against SarifConfig.
    Returns a map {:valid? boolean :errors map-or-nil}; :errors holds the
    humanized Malli error map when invalid, nil when valid."
   [config] (schema/validate-config config))
 
-(defn validate-violation
+(defn ^{:stratum 0} validate-violation
   "Validate a single violation record against SarifViolation.
    Returns a map {:valid? boolean :errors map-or-nil}; :errors holds the
    humanized Malli error map when invalid, nil when valid."
   [v] (schema/validate-violation v))
 
-(defn violation-json-schema
+(defn ^{:stratum 0} violation-json-schema
   "Return the SarifViolation schema transformed to a JSON Schema map."
   [] (schema/violation-json-schema))
 
-(defn config-json-schema
+(defn ^{:stratum 0} config-json-schema
   "Return the SarifConfig schema transformed to a JSON Schema map."
   [] (schema/config-json-schema))

--- a/components/connector-sarif/src/ai/miniforge/connector_sarif/schema.clj
+++ b/components/connector-sarif/src/ai/miniforge/connector_sarif/schema.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-sarif.schema
   "Malli schemas, validation, and JSON Schema export for the SARIF
    connector contract."
@@ -23,32 +22,41 @@
             [malli.error :as me]
             [malli.json-schema :as json-schema]))
 
-;; -------------------------------------------------------------------------- Layer 0
-;; Enums
+;------------------------------------------------------------------------------ Layer 0
 
-(def SeverityLevel
+;; Enums
+(def ^{:stratum 0} SeverityLevel
   "Normalized severity levels."
   [:enum :error :warning :note :none])
 
-(def SchemaType
+(def ^{:stratum 0} SchemaType
   "Available extraction schemas."
   [:enum :sarif-result :sarif-run :csv-violation])
 
-(def SourceFormat
+(def ^{:stratum 0} SourceFormat
   "Supported input file formats."
   [:enum :sarif :csv :auto])
 
-;; -------------------------------------------------------------------------- Layer 1
 ;; Core schemas
-
-(def Location
+(def ^{:stratum 0} Location
   "Physical location of a violation."
   [:map
    [:file {:optional true} [:maybe :string]]
    [:line {:optional true} [:maybe :int]]
    [:column {:optional true} [:maybe :int]]])
 
-(def SarifViolation
+;; Validation
+(defn ^{:stratum 0} validate
+  "Validate value against schema. Returns {:valid? bool :errors map-or-nil}."
+  [schema value]
+  (if (m/validate schema value)
+    {:valid? true :errors nil}
+    {:valid? false
+     :errors (me/humanize (m/explain schema value))}))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} SarifViolation
   [:map
    [:violation/id :string]
    [:violation/rule-id :string]
@@ -58,38 +66,27 @@
    [:violation/source-tool :string]
    [:violation/raw :map]])
 
-(def SarifConfig
+(def ^{:stratum 1} SarifConfig
   [:map
    [:sarif/source-path :string]
    [:sarif/format {:optional true} SourceFormat]
    [:sarif/csv-columns {:optional true} [:map-of :keyword :string]]])
 
-;; -------------------------------------------------------------------------- Layer 2
-;; Validation
+;------------------------------------------------------------------------------ Layer 2
 
-(defn validate
-  "Validate value against schema. Returns {:valid? bool :errors map-or-nil}."
-  [schema value]
-  (if (m/validate schema value)
-    {:valid? true :errors nil}
-    {:valid? false
-     :errors (me/humanize (m/explain schema value))}))
-
-(defn validate-config
+(defn ^{:stratum 2} validate-config
   [value]
   (validate SarifConfig value))
 
-(defn validate-violation
+(defn ^{:stratum 2} validate-violation
   [value]
   (validate SarifViolation value))
 
-;; -------------------------------------------------------------------------- Layer 3
 ;; JSON Schema export
-
-(defn violation-json-schema
+(defn ^{:stratum 2} violation-json-schema
   []
   (json-schema/transform SarifViolation))
 
-(defn config-json-schema
+(defn ^{:stratum 2} config-json-schema
   []
   (json-schema/transform SarifConfig))

--- a/components/connector-sarif/test/ai/miniforge/connector_sarif/anomaly/sarif_anomaly_test.clj
+++ b/components/connector-sarif/test/ai/miniforge/connector_sarif/anomaly/sarif_anomaly_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-sarif.anomaly.sarif-anomaly-test
   "Coverage for sarif `format/parse-file` and `impl/do-connect`
    boundary escalation via `response/throw-anomaly!`.
@@ -28,7 +27,9 @@
             [ai.miniforge.response.interface :as response])
   (:import (clojure.lang ExceptionInfo)))
 
-(deftest parse-file-unsupported-format-throws-anomaly
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} parse-file-unsupported-format-throws-anomaly
   (testing "unrecognised format raises :anomalies/unsupported"
     (try
       (fmt/parse-file "/nope/no.weird" :weird nil)
@@ -39,7 +40,7 @@
         (is (= "/nope/no.weird" (:path (ex-data e))))
         (is (= :weird (:format (ex-data e))))))))
 
-(deftest do-connect-invalid-config-returns-anomaly
+(deftest ^{:stratum 0} do-connect-invalid-config-returns-anomaly
   (testing "invalid SARIF config returns :anomalies/incorrect"
     (let [result (impl/do-connect {})]
       (is (response/anomaly-map? result))

--- a/components/connector-sarif/test/ai/miniforge/connector_sarif/format_test.clj
+++ b/components/connector-sarif/test/ai/miniforge/connector_sarif/format_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-sarif.format-test
   (:require [clojure.test :refer [deftest testing is]]
             [cheshire.core :as json]
@@ -23,9 +22,9 @@
             [ai.miniforge.connector-sarif.format :as sut]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Test fixtures and factories
 
-(defn- temp-file!
+;; Test fixtures and factories
+(defn- ^{:stratum 0} temp-file!
   "Create a temp file with given content and `extension`. Returns absolute path."
   [extension content]
   (let [f (java.io.File/createTempFile "sarif-test" extension)]
@@ -33,7 +32,7 @@
     (spit f content)
     (.getAbsolutePath f)))
 
-(defn- delete-recursively!
+(defn- ^{:stratum 0} delete-recursively!
   "Recursively delete `f`. JVM File/deleteOnExit cannot remove non-empty
    directories, so register an explicit shutdown hook for each temp dir."
   [^java.io.File f]
@@ -43,18 +42,7 @@
         (delete-recursively! child)))
     (.delete f)))
 
-(defn- temp-dir!
-  "Create a temp directory and register a shutdown hook to delete it
-   recursively on JVM exit. Returns the File."
-  [prefix]
-  (let [dir (.toFile (java.nio.file.Files/createTempDirectory
-                      prefix
-                      (make-array java.nio.file.attribute.FileAttribute 0)))]
-    (.addShutdownHook (Runtime/getRuntime)
-                      (Thread. ^Runnable #(delete-recursively! dir)))
-    dir))
-
-(defn- sarif-result
+(defn- ^{:stratum 0} sarif-result
   "Build a SARIF result object for tests."
   [rule-id message & {:keys [level file line column]
                       :or {level "warning" file "src/x.cpp" line 10 column 5}}]
@@ -65,7 +53,7 @@
                  {"artifactLocation" {"uri" file}
                   "region" {"startLine" line "startColumn" column}}}]})
 
-(defn- sarif-doc
+(defn- ^{:stratum 0} sarif-doc
   "Build a complete SARIF JSON document with one or more runs."
   ([results] (sarif-doc "TestScanner" results))
   ([tool-name results]
@@ -74,7 +62,7 @@
     "runs"    [{"tool" {"driver" {"name" tool-name "version" "1.0"}}
                 "results" results}]}))
 
-(defn- sarif-multi-run-doc
+(defn- ^{:stratum 0} sarif-multi-run-doc
   "Build a SARIF document with multiple runs."
   [run-specs]
   {"version" "2.1.0"
@@ -83,26 +71,8 @@
                    "results" results})
                 run-specs)})
 
-(defn- temp-sarif!
-  ([results] (temp-sarif! "TestScanner" results))
-  ([tool-name results]
-   (temp-file! ".sarif" (json/generate-string (sarif-doc tool-name results)))))
-
-(defn- temp-csv!
-  "Build a CSV temp file from a vector of header strings and a vector of row vectors."
-  [headers rows]
-  (let [header-line (clojure.string/join "," headers)
-        body (when (seq rows)
-               (str "\n"
-                    (clojure.string/join "\n"
-                                         (map #(clojure.string/join "," %) rows))))
-        content (str header-line body "\n")]
-    (temp-file! ".csv" content)))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; detect-format
-
-(deftest detect-format-known-extensions-test
+(deftest ^{:stratum 0} detect-format-known-extensions-test
   (testing ".sarif and .sarif.json detect as :sarif"
     (is (= :sarif (sut/detect-format "scan.sarif")))
     (is (= :sarif (sut/detect-format "scan.sarif.json")))
@@ -115,19 +85,113 @@
     (is (= :unknown (sut/detect-format "no-extension")))
     (is (= :unknown (sut/detect-format "")))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; parse-sarif — happy paths and edge cases
+;; list-scan-files
+(deftest ^{:stratum 0} list-scan-files-nonexistent-path-test
+  (testing "Path that doesn't exist yields an empty vector"
+    (is (= [] (sut/list-scan-files "/totally/not/here.sarif")))))
 
-(deftest parse-sarif-empty-runs-test
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} temp-dir!
+  "Create a temp directory and register a shutdown hook to delete it
+   recursively on JVM exit. Returns the File."
+  [prefix]
+  (let [dir (.toFile (java.nio.file.Files/createTempDirectory
+                      prefix
+                      (make-array java.nio.file.attribute.FileAttribute 0)))]
+    (.addShutdownHook (Runtime/getRuntime)
+                      (Thread. ^Runnable #(delete-recursively! dir)))
+    dir))
+
+(defn- ^{:stratum 1} temp-sarif!
+  ([results] (temp-sarif! "TestScanner" results))
+  ([tool-name results]
+   (temp-file! ".sarif" (json/generate-string (sarif-doc tool-name results)))))
+
+(defn- ^{:stratum 1} temp-csv!
+  "Build a CSV temp file from a vector of header strings and a vector of row vectors."
+  [headers rows]
+  (let [header-line (clojure.string/join "," headers)
+        body (when (seq rows)
+               (str "\n"
+                    (clojure.string/join "\n"
+                                         (map #(clojure.string/join "," %) rows))))
+        content (str header-line body "\n")]
+    (temp-file! ".csv" content)))
+
+;; parse-sarif — happy paths and edge cases
+(deftest ^{:stratum 1} parse-sarif-empty-runs-test
   (testing "SARIF document with no runs yields an empty vector"
     (let [path (temp-file! ".sarif" (json/generate-string {"version" "2.1.0" "runs" []}))]
       (is (= [] (sut/parse-sarif path))))))
 
-(deftest parse-sarif-empty-results-test
+(deftest ^{:stratum 1} parse-sarif-missing-message-or-location-test
+  (testing "Missing message text defaults to empty string; missing locations
+            yield an empty location map"
+    (let [path (temp-file!
+                ".sarif"
+                (json/generate-string
+                 {"version" "2.1.0"
+                  "runs" [{"tool" {"driver" {"name" "T"}}
+                           "results" [{"ruleId" "R"}]}]}))
+          [v] (sut/parse-sarif path)]
+      (is (= ""  (:violation/message v)))
+      (is (= {} (:violation/location v))))))
+
+(deftest ^{:stratum 1} parse-sarif-missing-tool-name-test
+  (testing "Missing tool driver name falls back to 'unknown'"
+    (let [path (temp-file!
+                ".sarif"
+                (json/generate-string
+                 {"version" "2.1.0"
+                  "runs" [{"tool" {} "results" [{"ruleId" "R"}]}]}))
+          [v] (sut/parse-sarif path)]
+      (is (= "unknown:0:0" (:violation/id v)))
+      (is (= "unknown"     (:violation/source-tool v))))))
+
+(deftest ^{:stratum 1} parse-sarif-multi-run-id-format-test
+  (testing "IDs encode tool-name:run-idx:result-idx across multiple runs"
+    (let [path (temp-file!
+                ".sarif"
+                (json/generate-string
+                 (sarif-multi-run-doc
+                  [{:tool "ToolA"
+                    :results [(sarif-result "A1" "m1") (sarif-result "A2" "m2")]}
+                   {:tool "ToolB"
+                    :results [(sarif-result "B1" "m1")]}])))
+          ids (mapv :violation/id (sut/parse-sarif path))]
+      (is (= ["ToolA:0:0" "ToolA:0:1" "ToolB:1:0"] ids)))))
+
+(deftest ^{:stratum 1} parse-sarif-missing-rule-id-defaults-to-unknown-test
+  (testing "Result without ruleId gets :violation/rule-id 'unknown'"
+    (let [path (temp-file!
+                ".sarif"
+                (json/generate-string
+                 {"version" "2.1.0"
+                  "runs" [{"tool" {"driver" {"name" "T"}}
+                           "results" [{"message" {"text" "no rule"}}]}]}))
+          [v] (sut/parse-sarif path)]
+      (is (= "unknown" (:violation/rule-id v))))))
+
+(deftest ^{:stratum 1} parse-file-unsupported-format-throws-test
+  (testing "Unknown format throws ex-info with :path and :format keys"
+    (let [unknown-path (temp-file! ".xml" "<x/>")
+          thrown (try
+                   (sut/parse-file unknown-path nil nil)
+                   ::no-throw
+                   (catch clojure.lang.ExceptionInfo e e))]
+      (is (instance? clojure.lang.ExceptionInfo thrown))
+      (let [data (ex-data thrown)]
+        (is (= unknown-path (:path data)))
+        (is (= :unknown     (:format data)))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} parse-sarif-empty-results-test
   (testing "Run with no results yields an empty vector"
     (is (= [] (sut/parse-sarif (temp-sarif! []))))))
 
-(deftest parse-sarif-single-result-shape-test
+(deftest ^{:stratum 2} parse-sarif-single-result-shape-test
   (testing "Single result is parsed into a fully-populated violation map"
     (let [path (temp-sarif!
                 "ToolX"
@@ -143,7 +207,7 @@
              (:violation/location v)))
       (is (map? (:violation/raw v))))))
 
-(deftest parse-sarif-severity-normalization-test
+(deftest ^{:stratum 2} parse-sarif-severity-normalization-test
   (testing "All SARIF level strings normalize to expected severity keywords"
     (let [path (temp-sarif!
                 [(sarif-result "R" "m" :level "error")
@@ -156,58 +220,8 @@
           severities (mapv :violation/severity (sut/parse-sarif path))]
       (is (= [:error :warning :note :none :warning :warning :warning] severities)))))
 
-(deftest parse-sarif-missing-message-or-location-test
-  (testing "Missing message text defaults to empty string; missing locations
-            yield an empty location map"
-    (let [path (temp-file!
-                ".sarif"
-                (json/generate-string
-                 {"version" "2.1.0"
-                  "runs" [{"tool" {"driver" {"name" "T"}}
-                           "results" [{"ruleId" "R"}]}]}))
-          [v] (sut/parse-sarif path)]
-      (is (= ""  (:violation/message v)))
-      (is (= {} (:violation/location v))))))
-
-(deftest parse-sarif-missing-tool-name-test
-  (testing "Missing tool driver name falls back to 'unknown'"
-    (let [path (temp-file!
-                ".sarif"
-                (json/generate-string
-                 {"version" "2.1.0"
-                  "runs" [{"tool" {} "results" [{"ruleId" "R"}]}]}))
-          [v] (sut/parse-sarif path)]
-      (is (= "unknown:0:0" (:violation/id v)))
-      (is (= "unknown"     (:violation/source-tool v))))))
-
-(deftest parse-sarif-multi-run-id-format-test
-  (testing "IDs encode tool-name:run-idx:result-idx across multiple runs"
-    (let [path (temp-file!
-                ".sarif"
-                (json/generate-string
-                 (sarif-multi-run-doc
-                  [{:tool "ToolA"
-                    :results [(sarif-result "A1" "m1") (sarif-result "A2" "m2")]}
-                   {:tool "ToolB"
-                    :results [(sarif-result "B1" "m1")]}])))
-          ids (mapv :violation/id (sut/parse-sarif path))]
-      (is (= ["ToolA:0:0" "ToolA:0:1" "ToolB:1:0"] ids)))))
-
-(deftest parse-sarif-missing-rule-id-defaults-to-unknown-test
-  (testing "Result without ruleId gets :violation/rule-id 'unknown'"
-    (let [path (temp-file!
-                ".sarif"
-                (json/generate-string
-                 {"version" "2.1.0"
-                  "runs" [{"tool" {"driver" {"name" "T"}}
-                           "results" [{"message" {"text" "no rule"}}]}]}))
-          [v] (sut/parse-sarif path)]
-      (is (= "unknown" (:violation/rule-id v))))))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; parse-csv — default columns + custom mapping
-
-(deftest parse-csv-default-columns-test
+(deftest ^{:stratum 2} parse-csv-default-columns-test
   (testing "CSV with default column headers maps to violation records"
     (let [path (temp-csv! ["Rule ID" "Message" "Severity" "File" "Line" "Column"]
                           [["R-1" "Issue one" "error"   "src/a.clj" "1" "5"]
@@ -224,7 +238,7 @@
       (is (= "csv:1"             (:violation/id v2)))
       (is (= :warning            (:violation/severity v2))))))
 
-(deftest parse-csv-case-insensitive-headers-test
+(deftest ^{:stratum 2} parse-csv-case-insensitive-headers-test
   (testing "Header lookup is case-insensitive and trims whitespace"
     (let [path (temp-csv! ["RULE ID" " message " "severity" "FILE" "line" "column"]
                           [["X" "msg" "note" "f.clj" "9" "1"]])
@@ -234,7 +248,7 @@
       (is (= :note   (:violation/severity v)))
       (is (= "f.clj" (-> v :violation/location :file))))))
 
-(deftest parse-csv-non-numeric-line-column-test
+(deftest ^{:stratum 2} parse-csv-non-numeric-line-column-test
   (testing "Non-numeric line/column values become nil rather than throwing"
     (let [path (temp-csv! ["Rule ID" "Message" "Severity" "File" "Line" "Column"]
                           [["R" "m" "error" "f.clj" "n/a" "x"]])
@@ -242,7 +256,7 @@
       (is (nil? (-> v :violation/location :line)))
       (is (nil? (-> v :violation/location :column))))))
 
-(deftest parse-csv-custom-column-mapping-test
+(deftest ^{:stratum 2} parse-csv-custom-column-mapping-test
   (testing "Custom column mapping is merged on top of defaults"
     (let [path (temp-csv! ["TheRule" "TheMessage" "TheSeverity" "ThePath" "TheLine" "TheCol"]
                           [["R" "m" "error" "f.clj" "1" "1"]])
@@ -258,31 +272,24 @@
       (is (= :error  (:violation/severity v)))
       (is (= "f.clj" (-> v :violation/location :file))))))
 
-(deftest parse-csv-empty-file-test
+(deftest ^{:stratum 2} parse-csv-empty-file-test
   (testing "CSV with only a header row yields no violations"
     (let [path (temp-csv! ["Rule ID" "Message" "Severity" "File" "Line" "Column"] [])]
       (is (= [] (sut/parse-csv path))))))
 
-(deftest parse-csv-missing-columns-defaults-test
+(deftest ^{:stratum 2} parse-csv-missing-columns-defaults-test
   (testing "Missing/unmappable columns yield 'unknown' rule-id and empty message"
     (let [path (temp-csv! ["Other"] [["just-a-value"]])
           [v] (sut/parse-csv path)]
       (is (= "unknown" (:violation/rule-id v)))
       (is (= ""        (:violation/message v))))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; list-scan-files
-
-(deftest list-scan-files-nonexistent-path-test
-  (testing "Path that doesn't exist yields an empty vector"
-    (is (= [] (sut/list-scan-files "/totally/not/here.sarif")))))
-
-(deftest list-scan-files-single-file-test
+(deftest ^{:stratum 2} list-scan-files-single-file-test
   (testing "A single existing file is returned in a vector with its absolute path"
     (let [path (temp-sarif! [])]
       (is (= [path] (sut/list-scan-files path))))))
 
-(deftest list-scan-files-directory-filters-by-extension-test
+(deftest ^{:stratum 2} list-scan-files-directory-filters-by-extension-test
   (testing "A directory yields only .sarif and .csv files; other extensions skipped"
     (let [tmp (temp-dir! "sarif-list-test")
           sarif-f (io/file tmp "scan.sarif")
@@ -297,15 +304,13 @@
         (is (some #(.endsWith ^String % "results.csv") files))
         (is (not (some #(.endsWith ^String % "data.xml") files)))))))
 
-(deftest list-scan-files-empty-directory-test
+(deftest ^{:stratum 2} list-scan-files-empty-directory-test
   (testing "Empty directory yields an empty vector"
     (let [tmp (temp-dir! "sarif-list-empty")]
       (is (= [] (sut/list-scan-files (.getAbsolutePath tmp)))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; parse-file dispatch
-
-(deftest parse-file-dispatches-by-format-test
+(deftest ^{:stratum 2} parse-file-dispatches-by-format-test
   (testing "Explicit :sarif format parses via parse-sarif"
     (let [path (temp-sarif! [(sarif-result "R" "m")])]
       (is (= 1 (count (sut/parse-file path :sarif nil))))))
@@ -314,22 +319,10 @@
                           [["R" "m" "error" "f" "1" "1"]])]
       (is (= 1 (count (sut/parse-file path :csv nil)))))))
 
-(deftest parse-file-auto-detects-format-test
+(deftest ^{:stratum 2} parse-file-auto-detects-format-test
   (testing ":auto and nil format both detect by extension"
     (let [sarif-path (temp-sarif! [(sarif-result "R" "m")])
           csv-path   (temp-csv! ["Rule ID" "Message" "Severity" "File" "Line" "Column"]
                                 [["R" "m" "error" "f" "1" "1"]])]
       (is (= 1 (count (sut/parse-file sarif-path :auto nil))))
       (is (= 1 (count (sut/parse-file csv-path nil nil)))))))
-
-(deftest parse-file-unsupported-format-throws-test
-  (testing "Unknown format throws ex-info with :path and :format keys"
-    (let [unknown-path (temp-file! ".xml" "<x/>")
-          thrown (try
-                   (sut/parse-file unknown-path nil nil)
-                   ::no-throw
-                   (catch clojure.lang.ExceptionInfo e e))]
-      (is (instance? clojure.lang.ExceptionInfo thrown))
-      (let [data (ex-data thrown)]
-        (is (= unknown-path (:path data)))
-        (is (= :unknown     (:format data)))))))

--- a/components/connector-sarif/test/ai/miniforge/connector_sarif/format_test.clj
+++ b/components/connector-sarif/test/ai/miniforge/connector_sarif/format_test.clj
@@ -19,6 +19,7 @@
   (:require [clojure.test :refer [deftest testing is]]
             [cheshire.core :as json]
             [clojure.java.io :as io]
+            [clojure.string :as str]
             [ai.miniforge.connector-sarif.format :as sut]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -111,11 +112,11 @@
 (defn- ^{:stratum 1} temp-csv!
   "Build a CSV temp file from a vector of header strings and a vector of row vectors."
   [headers rows]
-  (let [header-line (clojure.string/join "," headers)
+  (let [header-line (str/join "," headers)
         body (when (seq rows)
                (str "\n"
-                    (clojure.string/join "\n"
-                                         (map #(clojure.string/join "," %) rows))))
+                    (str/join "\n"
+                              (map #(str/join "," %) rows))))
         content (str header-line body "\n")]
     (temp-file! ".csv" content)))
 

--- a/components/connector-sarif/test/ai/miniforge/connector_sarif/impl_test.clj
+++ b/components/connector-sarif/test/ai/miniforge/connector_sarif/impl_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-sarif.impl-test
   (:require [clojure.test :refer [deftest testing is]]
             [cheshire.core :as json]
@@ -23,10 +22,11 @@
             [ai.miniforge.response.interface :as response]
             [ai.miniforge.connector-sarif.format :as fmt]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; --------------------------------------------------------------------------
 ;; Test helpers
-
-(defn- create-temp-sarif-file
+(defn- ^{:stratum 0} create-temp-sarif-file
   "Create a temporary SARIF file with given results."
   [results]
   (let [f (java.io.File/createTempFile "test-scan" ".sarif")
@@ -38,7 +38,7 @@
     (spit f (json/generate-string content))
     (.getAbsolutePath f)))
 
-(defn- create-sarif-violation
+(defn- ^{:stratum 0} create-sarif-violation
   "Create a SARIF result object for testing."
   [rule-id message & {:keys [level file line]
                       :or {level "warning" file "src/test.cpp" line 1}}]
@@ -49,10 +49,42 @@
                  {"artifactLocation" {"uri" file}
                   "region" {"startLine" line "startColumn" 1}}}]})
 
+(deftest ^{:stratum 0} test-format-detection
+  (testing "Format auto-detection"
+    (is (= :sarif (fmt/detect-format "scan.sarif")))
+    (is (= :sarif (fmt/detect-format "scan.sarif.json")))
+    (is (= :csv (fmt/detect-format "results.csv")))
+    (is (= :unknown (fmt/detect-format "data.xml")))))
+
+;; --------------------------------------------------------------------------
+;; Migrated handle-lookup helper — connector boundaries return response
+;; anomalies.
+(deftest ^{:stratum 0} discover-returns-anomaly-on-unknown-handle-test
+  (testing "do-discover returns an anomaly with :handle when handle is missing"
+    (let [result (impl/do-discover "no-such-handle" {})]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/not-found (:anomaly/category result)))
+      (is (= "no-such-handle" (:handle result))))))
+
+(deftest ^{:stratum 0} extract-returns-anomaly-on-unknown-handle-test
+  (testing "do-extract returns an anomaly with :handle when handle is missing"
+    (let [result (impl/do-extract "no-such-handle" :sarif-result {})]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/not-found (:anomaly/category result)))
+      (is (= "no-such-handle" (:handle result))))))
+
+(deftest ^{:stratum 0} checkpoint-returns-anomaly-on-unknown-handle-test
+  (testing "do-checkpoint returns an anomaly with :handle when handle is missing"
+    (let [result (impl/do-checkpoint "no-such-handle" "sarif-conn-1" {})]
+      (is (response/anomaly-map? result))
+      (is (= :anomalies/not-found (:anomaly/category result)))
+      (is (= "no-such-handle" (:handle result))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
 ;; --------------------------------------------------------------------------
 ;; Tests
-
-(deftest test-connect-and-close
+(deftest ^{:stratum 1} test-connect-and-close
   (testing "Connect with valid config"
     (let [temp-file (create-temp-sarif-file [])
           result    (impl/do-connect {:sarif/source-path temp-file})]
@@ -66,7 +98,7 @@
       (is (= :anomalies/incorrect (:anomaly/category result)))
       (is (seq (:sarif/errors result))))))
 
-(deftest test-discover
+(deftest ^{:stratum 1} test-discover
   (testing "Discover schemas from SARIF file"
     (let [temp-file (create-temp-sarif-file [(create-sarif-violation "API-001" "Test")])
           {:keys [connection/handle]} (impl/do-connect {:sarif/source-path temp-file})
@@ -74,7 +106,7 @@
       (is (seq (:schemas result)))
       (impl/do-close handle))))
 
-(deftest test-extract
+(deftest ^{:stratum 1} test-extract
   (testing "Extract violations from SARIF"
     (let [temp-file (create-temp-sarif-file [(create-sarif-violation "API-001" "Undocumented call" :level "error")
                                              (create-sarif-violation "API-002" "Dynamic load" :level "warning")])
@@ -88,42 +120,10 @@
         (is (string? (:violation/message v))))
       (impl/do-close handle))))
 
-(deftest test-format-detection
-  (testing "Format auto-detection"
-    (is (= :sarif (fmt/detect-format "scan.sarif")))
-    (is (= :sarif (fmt/detect-format "scan.sarif.json")))
-    (is (= :csv (fmt/detect-format "results.csv")))
-    (is (= :unknown (fmt/detect-format "data.xml")))))
-
-(deftest test-empty-file
+(deftest ^{:stratum 1} test-empty-file
   (testing "Empty SARIF file returns no violations"
     (let [temp-file (create-temp-sarif-file [])
           {:keys [connection/handle]} (impl/do-connect {:sarif/source-path temp-file})
           result (impl/do-extract handle :sarif-result {})]
       (is (empty? (:records result)))
       (impl/do-close handle))))
-
-;; --------------------------------------------------------------------------
-;; Migrated handle-lookup helper — connector boundaries return response
-;; anomalies.
-
-(deftest discover-returns-anomaly-on-unknown-handle-test
-  (testing "do-discover returns an anomaly with :handle when handle is missing"
-    (let [result (impl/do-discover "no-such-handle" {})]
-      (is (response/anomaly-map? result))
-      (is (= :anomalies/not-found (:anomaly/category result)))
-      (is (= "no-such-handle" (:handle result))))))
-
-(deftest extract-returns-anomaly-on-unknown-handle-test
-  (testing "do-extract returns an anomaly with :handle when handle is missing"
-    (let [result (impl/do-extract "no-such-handle" :sarif-result {})]
-      (is (response/anomaly-map? result))
-      (is (= :anomalies/not-found (:anomaly/category result)))
-      (is (= "no-such-handle" (:handle result))))))
-
-(deftest checkpoint-returns-anomaly-on-unknown-handle-test
-  (testing "do-checkpoint returns an anomaly with :handle when handle is missing"
-    (let [result (impl/do-checkpoint "no-such-handle" "sarif-conn-1" {})]
-      (is (response/anomaly-map? result))
-      (is (= :anomalies/not-found (:anomaly/category result)))
-      (is (= "no-such-handle" (:handle result))))))

--- a/components/connector-sarif/test/ai/miniforge/connector_sarif/interface_test.clj
+++ b/components/connector-sarif/test/ai/miniforge/connector_sarif/interface_test.clj
@@ -15,26 +15,23 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-sarif.interface-test
   (:require [clojure.test :refer [deftest testing is]]
             [ai.miniforge.connector-sarif.interface :as sut]
             [ai.miniforge.connector-sarif.schema :as schema]))
 
-;------------------------------------------------------------------------------ Layer 1
-;; create-sarif-connector
+;------------------------------------------------------------------------------ Layer 0
 
-(deftest create-sarif-connector-returns-record-test
+;; create-sarif-connector
+(deftest ^{:stratum 0} create-sarif-connector-returns-record-test
   (testing "Factory returns a SarifConnector defrecord instance"
     (let [c (sut/create-sarif-connector)]
       (is (some? c))
       ;; defrecord generates a class with an underscore in its name.
       (is (instance? ai.miniforge.connector_sarif.core.SarifConnector c)))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; connector-metadata shape
-
-(deftest connector-metadata-shape-test
+(deftest ^{:stratum 0} connector-metadata-shape-test
   (testing "Metadata declares name/type/version/capabilities/auth/maintainer"
     (let [m sut/connector-metadata]
       (is (string? (:connector/name m)))
@@ -45,15 +42,13 @@
       (is (some? (:connector/retry-policy m)))
       (is (= "data-foundry" (:connector/maintainer m))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Schema and validation re-exports
-
-(deftest schema-reexports-point-to-spec-test
+(deftest ^{:stratum 0} schema-reexports-point-to-spec-test
   (testing "interface re-exports SarifViolation and SarifConfig from spec"
     (is (= schema/SarifViolation sut/SarifViolation))
     (is (= schema/SarifConfig    sut/SarifConfig))))
 
-(deftest validate-config-passthrough-test
+(deftest ^{:stratum 0} validate-config-passthrough-test
   (testing "validate-config delegates to schema"
     ;; Schema validates only that :sarif/source-path is a string —
     ;; use a platform-neutral source rather than a hard-coded Unix path.
@@ -61,7 +56,7 @@
                           {:sarif/source-path (System/getProperty "java.io.tmpdir")}))))
     (is (false? (:valid? (sut/validate-config {}))))))
 
-(deftest validate-violation-passthrough-test
+(deftest ^{:stratum 0} validate-violation-passthrough-test
   (testing "validate-violation delegates to schema"
     (is (true?  (:valid? (sut/validate-violation
                           {:violation/id          "v"
@@ -73,14 +68,14 @@
                            :violation/raw         {}}))))
     (is (false? (:valid? (sut/validate-violation {}))))))
 
-(deftest violation-json-schema-shape-test
+(deftest ^{:stratum 0} violation-json-schema-shape-test
   (testing "violation-json-schema returns the JSON Schema for the violation map"
     (let [s (sut/violation-json-schema)]
       (is (map? s))
       (is (= "object" (:type s)))
       (is (contains? (:properties s) :violation/id)))))
 
-(deftest config-json-schema-shape-test
+(deftest ^{:stratum 0} config-json-schema-shape-test
   (testing "config-json-schema returns the JSON Schema for the config map"
     (let [s (sut/config-json-schema)]
       (is (map? s))

--- a/components/connector-sarif/test/ai/miniforge/connector_sarif/schema_test.clj
+++ b/components/connector-sarif/test/ai/miniforge/connector_sarif/schema_test.clj
@@ -15,15 +15,14 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.connector-sarif.schema-test
   (:require [clojure.test :refer [deftest testing is]]
             [ai.miniforge.connector-sarif.schema :as sut]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Test fixtures and factories
 
-(defn- valid-violation
+;; Test fixtures and factories
+(defn- ^{:stratum 0} valid-violation
   [& {:as overrides}]
   (merge {:violation/id          "v-1"
           :violation/rule-id     "R-1"
@@ -34,82 +33,28 @@
           :violation/raw         {}}
          overrides))
 
-(defn- valid-config
+(defn- ^{:stratum 0} valid-config
   [& {:as overrides}]
   ;; The schema validates only that :sarif/source-path is a string. Use the
   ;; platform-neutral java.io.tmpdir rather than a hard-coded Unix path so
   ;; the test isn't a Unix-only fixture by accident.
   (merge {:sarif/source-path (System/getProperty "java.io.tmpdir")} overrides))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Enum exposure
-
-(deftest enums-are-stable-test
+(deftest ^{:stratum 0} enums-are-stable-test
   (testing "Each enum schema declares the documented closed set"
     (is (= [:enum :error :warning :note :none] sut/SeverityLevel))
     (is (= [:enum :sarif-result :sarif-run :csv-violation] sut/SchemaType))
     (is (= [:enum :sarif :csv :auto] sut/SourceFormat))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; validate / validate-violation
-
-(deftest validate-violation-valid-test
-  (testing "A fully-populated violation validates"
-    (let [{:keys [valid? errors]} (sut/validate-violation (valid-violation))]
-      (is (true? valid?))
-      (is (nil? errors)))))
-
-(deftest validate-violation-rejects-unknown-severity-test
-  (testing "Severity outside the enum fails validation"
-    (let [{:keys [valid? errors]} (sut/validate-violation
-                                   (valid-violation :violation/severity :critical))]
-      (is (false? valid?))
-      (is (some? errors)))))
-
-(deftest validate-violation-rejects-missing-required-test
-  (testing "Missing :violation/rule-id fails validation"
-    (let [{:keys [valid?]} (sut/validate-violation
-                            (dissoc (valid-violation) :violation/rule-id))]
-      (is (false? valid?)))))
-
-(deftest validate-violation-allows-empty-location-test
-  (testing "All location fields are optional and may be missing or nil"
-    (is (true? (:valid? (sut/validate-violation
-                         (valid-violation :violation/location {})))))
-    (is (true? (:valid? (sut/validate-violation
-                         (valid-violation :violation/location {:file "f"})))))))
-
-;------------------------------------------------------------------------------ Layer 1
-;; validate / validate-config
-
-(deftest validate-config-minimal-test
-  (testing "Only :sarif/source-path is required"
-    (is (true? (:valid? (sut/validate-config (valid-config)))))))
-
-(deftest validate-config-rejects-empty-test
+(deftest ^{:stratum 0} validate-config-rejects-empty-test
   (testing "Empty config (no :sarif/source-path) fails validation"
     (is (false? (:valid? (sut/validate-config {})))))
   (testing "Non-string source-path fails validation"
     (is (false? (:valid? (sut/validate-config {:sarif/source-path 42}))))))
 
-(deftest validate-config-format-enum-test
-  (testing ":sarif/format must be :sarif, :csv, or :auto when supplied"
-    (is (true?  (:valid? (sut/validate-config (valid-config :sarif/format :sarif)))))
-    (is (true?  (:valid? (sut/validate-config (valid-config :sarif/format :csv)))))
-    (is (true?  (:valid? (sut/validate-config (valid-config :sarif/format :auto)))))
-    (is (false? (:valid? (sut/validate-config (valid-config :sarif/format :json)))))))
-
-(deftest validate-config-csv-columns-shape-test
-  (testing ":sarif/csv-columns must be keyword → string when supplied"
-    (is (true?  (:valid? (sut/validate-config
-                          (valid-config :sarif/csv-columns {:rule-id "Rule" :file "Path"})))))
-    (is (false? (:valid? (sut/validate-config
-                          (valid-config :sarif/csv-columns {"rule-id" "Rule"})))))))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; JSON Schema export
-
-(deftest json-schema-export-shape-test
+(deftest ^{:stratum 0} json-schema-export-shape-test
   (testing "violation-json-schema returns a JSON Schema map declaring the violation type"
     (let [s (sut/violation-json-schema)]
       (is (map? s))
@@ -118,9 +63,57 @@
       (is (contains? (:properties s) :violation/id))
       (is (contains? (:properties s) :violation/severity)))))
 
-(deftest config-json-schema-export-shape-test
+(deftest ^{:stratum 0} config-json-schema-export-shape-test
   (testing "config-json-schema returns a JSON Schema map for the connector config"
     (let [s (sut/config-json-schema)]
       (is (map? s))
       (is (= "object" (:type s)))
       (is (contains? (:properties s) :sarif/source-path)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; validate / validate-violation
+(deftest ^{:stratum 1} validate-violation-valid-test
+  (testing "A fully-populated violation validates"
+    (let [{:keys [valid? errors]} (sut/validate-violation (valid-violation))]
+      (is (true? valid?))
+      (is (nil? errors)))))
+
+(deftest ^{:stratum 1} validate-violation-rejects-unknown-severity-test
+  (testing "Severity outside the enum fails validation"
+    (let [{:keys [valid? errors]} (sut/validate-violation
+                                   (valid-violation :violation/severity :critical))]
+      (is (false? valid?))
+      (is (some? errors)))))
+
+(deftest ^{:stratum 1} validate-violation-rejects-missing-required-test
+  (testing "Missing :violation/rule-id fails validation"
+    (let [{:keys [valid?]} (sut/validate-violation
+                            (dissoc (valid-violation) :violation/rule-id))]
+      (is (false? valid?)))))
+
+(deftest ^{:stratum 1} validate-violation-allows-empty-location-test
+  (testing "All location fields are optional and may be missing or nil"
+    (is (true? (:valid? (sut/validate-violation
+                         (valid-violation :violation/location {})))))
+    (is (true? (:valid? (sut/validate-violation
+                         (valid-violation :violation/location {:file "f"})))))))
+
+;; validate / validate-config
+(deftest ^{:stratum 1} validate-config-minimal-test
+  (testing "Only :sarif/source-path is required"
+    (is (true? (:valid? (sut/validate-config (valid-config)))))))
+
+(deftest ^{:stratum 1} validate-config-format-enum-test
+  (testing ":sarif/format must be :sarif, :csv, or :auto when supplied"
+    (is (true?  (:valid? (sut/validate-config (valid-config :sarif/format :sarif)))))
+    (is (true?  (:valid? (sut/validate-config (valid-config :sarif/format :csv)))))
+    (is (true?  (:valid? (sut/validate-config (valid-config :sarif/format :auto)))))
+    (is (false? (:valid? (sut/validate-config (valid-config :sarif/format :json)))))))
+
+(deftest ^{:stratum 1} validate-config-csv-columns-shape-test
+  (testing ":sarif/csv-columns must be keyword → string when supplied"
+    (is (true?  (:valid? (sut/validate-config
+                          (valid-config :sarif/csv-columns {:rule-id "Rule" :file "Path"})))))
+    (is (false? (:valid? (sut/validate-config
+                          (valid-config :sarif/csv-columns {"rule-id" "Rule"})))))))

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-connector-sarif.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-connector-sarif.md
@@ -66,13 +66,12 @@ than deferring it.
    double-semicolon `;;---- Layer N` banners left behind, and no
    same-line trailing comment displaced onto the wrong def — checked
    visually file by file.
-4. `clj-kondo --lint components/connector-sarif`: 0 errors. 1 pre-existing
-   warning (`format_test.clj`, unresolved `clojure.string` namespace —
-   the file uses fully-qualified `clojure.string/join` without a
-   `:require`) present before this change too (confirmed via `git stash`
-   - re-lint); only its reported line number shifted, from 94 to 114, as
-   a direct result of `--fix` reordering `temp-csv!` further down the
-   file. Not introduced by this change, not touched.
+4. `clj-kondo --lint components/connector-sarif`: 0 errors, 0 warnings.
+   `format_test.clj` previously used fully-qualified `clojure.string/join`
+   without a `:require` (a pre-existing warning, confirmed via `git
+   stash` + re-lint); added `[clojure.string :as str]` and switched
+   `temp-csv!` to the aliased `str/join` while touching the file for
+   the heading fix, clearing it.
 5. Ran all 5 test namespaces directly (`clojure -M:dev:test`, since
    `:poly test` can sweep in an unrelated pre-existing environment flake
    on this machine): `format-test`, `impl-test`, `interface-test`,

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-connector-sarif.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-connector-sarif.md
@@ -111,9 +111,9 @@ time) until Wave 2 splits it.
 - [x] Second `--fix` pass confirms idempotency (zero diff)
 - [x] Diff read in full for all 10 changed files — no orphaned decorative
       banners, no displaced trailing comments
-- [x] `clj-kondo` clean of new issues (0 errors before/after; 1
-      pre-existing warning unchanged in content, only its line number
-      shifted from reordering)
+- [x] `clj-kondo` clean: 0 errors, 0 warnings. A pre-existing warning in
+      `format_test.clj` (unrequired `clojure.string`) was cleared by
+      adding the require and switching to `str/join` (review feedback)
 - [x] Component tests pass (50 tests, 141 assertions, 0 failures/errors)
 - [x] Plain lint re-run post-fix: zero `SL001`/`SL002`/`SL004`; `SL003`
       remains on `format.clj` only — newly surfaced by the fix (not

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-connector-sarif.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-connector-sarif.md
@@ -1,0 +1,122 @@
+<!--
+  Title: Stratum-lint autofix for components/connector-sarif (Wave 1)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix: stratum-lint autofix for components/connector-sarif (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over `components/connector-sarif` (`src` + `test`)
+to replace decorative `Layer N` headings with real ones derived from each
+file's actual same-file reference graph, and tag every top-level `def`/
+`defn`/`defrecord`/`deftest` with `^{:stratum n}`. One of the Wave 1 batches
+from `work/stratum-lint-baseline-2026-07-24.md` (batch 5). Purely mechanical
+— comment/metadata/def-order only, no executable logic changed.
+
+## Motivation
+
+Baseline plain (non-`--fix`) lint run for this component, before touching
+anything, confirmed zero `SL001` (no upward-reference/cycle risk — this
+component was not on the pre-vetted SL001-free list, so this was checked
+directly rather than assumed):
+
+- `src/.../schema.clj`: `SL003` — 4 distinct (decorative) layers against
+  the 3-layer budget.
+- `test/.../format_test.clj`: `SL002` ×4 — a `Layer 1` heading repeated
+  three more times as a per-test-group section banner.
+- `test/.../interface_test.clj`: `SL002` ×2 — same pattern.
+- `test/.../schema_test.clj`: `SL002` ×3 — same pattern.
+
+10 findings total, 0 `SL001`.
+
+## Changes in Detail
+
+Ran, over the whole component:
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "bef8657a2efd3b1ba9e1a4f510693c9fbca45abd" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/connector-sarif
+```
+
+All 10 `.clj` files in the component were rewritten (`--fix` normalizes
+every file, not just the ones with findings): `core.clj`, `format.clj`,
+`impl.clj`, `interface.clj`, `schema.clj`, and all 5 test files. No `SL008`
+refusal — no reader-conditional-wrapped def in this component. Diffs are
+heading text, `^{:stratum n}` metadata, and def/deftest reordering only.
+
+One thing worth calling out because it looks alarming in a raw diff:
+`schema.clj`'s original `SL003` (4 *decorative* layers: `Layer 0` "Enums",
+`Layer 1` "Core schemas", `Layer 2` "Validation", `Layer 3` "JSON Schema
+export") collapsed to 3 *real* layers once `--fix` recomputed the actual
+reference graph — `validate` (the shared helper) turned out to belong at
+Layer 0 alongside the enums and `Location`, not at the old Layer 2, since
+nothing in the file calls it except `validate-config`/`validate-violation`
+which now sit at Layer 1 uses. This resolves the original finding rather
+than deferring it.
+
+## Testing Plan
+
+1. Ran plain `stratum-lint` before any change — reproduced the 10 findings
+   above exactly, confirmed 0 `SL001`.
+2. Ran `--fix`, then a second `--fix` pass immediately after — no files
+   listed as rewritten on the second pass, `git status` unchanged: zero
+   diff, confirms idempotency.
+3. Read the full diff for all 10 changed files. No decorative
+   double-semicolon `;;---- Layer N` banners left behind, and no
+   same-line trailing comment displaced onto the wrong def — checked
+   visually file by file.
+4. `clj-kondo --lint components/connector-sarif`: 0 errors. 1 pre-existing
+   warning (`format_test.clj`, unresolved `clojure.string` namespace —
+   the file uses fully-qualified `clojure.string/join` without a
+   `:require`) present before this change too (confirmed via `git stash`
+   - re-lint); only its reported line number shifted, from 94 to 114, as
+   a direct result of `--fix` reordering `temp-csv!` further down the
+   file. Not introduced by this change, not touched.
+5. Ran all 5 test namespaces directly (`clojure -M:dev:test`, since
+   `:poly test` can sweep in an unrelated pre-existing environment flake
+   on this machine): `format-test`, `impl-test`, `interface-test`,
+   `schema-test`, `anomaly.sarif-anomaly-test` — 50 tests, 141 assertions,
+   0 failures, 0 errors.
+6. Re-ran plain `stratum-lint` after the fix: `SL001`/`SL002`/`SL004`
+   clear across the component. One new `SL003` surfaced — not present in
+   the pre-fix baseline — on `format.clj`: 4 real layers (`normalize-severity`
+   /`extract-location`/`default-csv-columns`/`find-column-index`/
+   `detect-format` → `parse-sarif-result`/`csv-row->violation`/
+   `list-scan-files` → `parse-sarif`/`parse-csv` → `parse-file`). This
+   file previously carried only 2 decorative headings, undercounting its
+   true depth; genuinely over the 3-layer budget, not a regression this
+   PR introduces. Deferred to Wave 2 (real namespace split), consistent
+   with how prior Wave 1 PRs (e.g. `schema`, `self-healing`) handled the
+   same situation. `schema.clj`'s original `SL003` is fully resolved
+   (collapsed to 3 real layers, under budget).
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+change — comment/metadata/order-only. Pre-commit's `lint:stratum`
+autofixer keeps this component clean going forward; `format.clj`'s
+`SL003` stays advisory (`MINIFORGE_STRATUM_BUDGET_MODE=warn` at commit
+time) until Wave 2 splits it.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+- Follow-on: Wave 2 namespace split for
+  `components/connector-sarif/src/ai/miniforge/connector_sarif/format.clj`
+  (4 real layers, over the 3-layer budget)
+
+## Checklist
+
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Second `--fix` pass confirms idempotency (zero diff)
+- [x] Diff read in full for all 10 changed files — no orphaned decorative
+      banners, no displaced trailing comments
+- [x] `clj-kondo` clean of new issues (0 errors before/after; 1
+      pre-existing warning unchanged in content, only its line number
+      shifted from reordering)
+- [x] Component tests pass (50 tests, 141 assertions, 0 failures/errors)
+- [x] Plain lint re-run post-fix: zero `SL001`/`SL002`/`SL004`; `SL003`
+      remains on `format.clj` only — newly surfaced by the fix (not
+      pre-existing), tracked as Wave 2 above
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
<!--
  Title: Stratum-lint autofix for components/connector-sarif (Wave 1)
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# fix: stratum-lint autofix for components/connector-sarif (Wave 1)

## Overview

Runs `stratum-lint --fix` over `components/connector-sarif` (`src` + `test`)
to replace decorative `Layer N` headings with real ones derived from each
file's actual same-file reference graph, and tag every top-level `def`/
`defn`/`defrecord`/`deftest` with `^{:stratum n}`. One of the Wave 1 batches
from `work/stratum-lint-baseline-2026-07-24.md` (batch 5). Purely mechanical
— comment/metadata/def-order only, no executable logic changed.

## Motivation

Baseline plain (non-`--fix`) lint run for this component, before touching
anything, confirmed zero `SL001` (no upward-reference/cycle risk — this
component was not on the pre-vetted SL001-free list, so this was checked
directly rather than assumed):

- `src/.../schema.clj`: `SL003` — 4 distinct (decorative) layers against
  the 3-layer budget.
- `test/.../format_test.clj`: `SL002` ×4 — a `Layer 1` heading repeated
  three more times as a per-test-group section banner.
- `test/.../interface_test.clj`: `SL002` ×2 — same pattern.
- `test/.../schema_test.clj`: `SL002` ×3 — same pattern.

10 findings total, 0 `SL001`.

## Changes in Detail

Ran, over the whole component:

```bash
bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "bef8657a2efd3b1ba9e1a4f510693c9fbca45abd" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/connector-sarif
```

All 10 `.clj` files in the component were rewritten (`--fix` normalizes
every file, not just the ones with findings): `core.clj`, `format.clj`,
`impl.clj`, `interface.clj`, `schema.clj`, and all 5 test files. No `SL008`
refusal — no reader-conditional-wrapped def in this component. Diffs are
heading text, `^{:stratum n}` metadata, and def/deftest reordering only.

One thing worth calling out because it looks alarming in a raw diff:
`schema.clj`'s original `SL003` (4 *decorative* layers: `Layer 0` "Enums",
`Layer 1` "Core schemas", `Layer 2` "Validation", `Layer 3` "JSON Schema
export") collapsed to 3 *real* layers once `--fix` recomputed the actual
reference graph — `validate` (the shared helper) turned out to belong at
Layer 0 alongside the enums and `Location`, not at the old Layer 2, since
nothing in the file calls it except `validate-config`/`validate-violation`
which now sit at Layer 1 uses. This resolves the original finding rather
than deferring it.

## Testing Plan

1. Ran plain `stratum-lint` before any change — reproduced the 10 findings
   above exactly, confirmed 0 `SL001`.
2. Ran `--fix`, then a second `--fix` pass immediately after — no files
   listed as rewritten on the second pass, `git status` unchanged: zero
   diff, confirms idempotency.
3. Read the full diff for all 10 changed files. No decorative
   double-semicolon `;;---- Layer N` banners left behind, and no
   same-line trailing comment displaced onto the wrong def — checked
   visually file by file.
4. `clj-kondo --lint components/connector-sarif`: 0 errors. 1 pre-existing
   warning (`format_test.clj`, unresolved `clojure.string` namespace —
   the file uses fully-qualified `clojure.string/join` without a
   `:require`) present before this change too (confirmed via `git stash`
   - re-lint); only its reported line number shifted, from 94 to 114, as
   a direct result of `--fix` reordering `temp-csv!` further down the
   file. Not introduced by this change, not touched.
5. Ran all 5 test namespaces directly (`clojure -M:dev:test`, since
   `:poly test` can sweep in an unrelated pre-existing environment flake
   on this machine): `format-test`, `impl-test`, `interface-test`,
   `schema-test`, `anomaly.sarif-anomaly-test` — 50 tests, 141 assertions,
   0 failures, 0 errors.
6. Re-ran plain `stratum-lint` after the fix: `SL001`/`SL002`/`SL004`
   clear across the component. One new `SL003` surfaced — not present in
   the pre-fix baseline — on `format.clj`: 4 real layers (`normalize-severity`
   /`extract-location`/`default-csv-columns`/`find-column-index`/
   `detect-format` → `parse-sarif-result`/`csv-row->violation`/
   `list-scan-files` → `parse-sarif`/`parse-csv` → `parse-file`). This
   file previously carried only 2 decorative headings, undercounting its
   true depth; genuinely over the 3-layer budget, not a regression this
   PR introduces. Deferred to Wave 2 (real namespace split), consistent
   with how prior Wave 1 PRs (e.g. `schema`, `self-healing`) handled the
   same situation. `schema.clj`'s original `SL003` is fully resolved
   (collapsed to 3 real layers, under budget).

## Deployment Plan

Merges to `main` like any other component change. No runtime behavior
change — comment/metadata/order-only. Pre-commit's `lint:stratum`
autofixer keeps this component clean going forward; `format.clj`'s
`SL003` stays advisory (`MINIFORGE_STRATUM_BUDGET_MODE=warn` at commit
time) until Wave 2 splits it.

## Related Issues/PRs

- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
- Follow-on: Wave 2 namespace split for
  `components/connector-sarif/src/ai/miniforge/connector_sarif/format.clj`
  (4 real layers, over the 3-layer budget)

## Checklist

- [x] `--fix` run over the whole component (`src` + `test`)
- [x] Second `--fix` pass confirms idempotency (zero diff)
- [x] Diff read in full for all 10 changed files — no orphaned decorative
      banners, no displaced trailing comments
- [x] `clj-kondo` clean of new issues (0 errors before/after; 1
      pre-existing warning unchanged in content, only its line number
      shifted from reordering)
- [x] Component tests pass (50 tests, 141 assertions, 0 failures/errors)
- [x] Plain lint re-run post-fix: zero `SL001`/`SL002`/`SL004`; `SL003`
      remains on `format.clj` only — newly surfaced by the fix (not
      pre-existing), tracked as Wave 2 above
- [x] No `--no-verify`; pre-commit hook runs normally at commit time
