### PR TITLE
fix: stratum-lint autofix for components/llm (Wave 1)

### DIFF
--- a/components/llm/src/ai/miniforge/llm/core.clj
+++ b/components/llm/src/ai/miniforge/llm/core.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.llm.core
   "LLM client implementation using CLI backends.
 
@@ -30,20 +29,28 @@
    [ai.miniforge.llm.protocols.impl.llm-client :as impl]
    [ai.miniforge.llm.protocols.records.llm-client :as records]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; Re-export protocol for backward compatibility
-(def LLMClient p/LLMClient)
+(def ^{:stratum 0} LLMClient p/LLMClient)
 
 ;; Re-export protocol methods
-(def complete* p/complete*)
-(def get-config p/get-config)
+(def ^{:stratum 0} complete* p/complete*)
+
+(def ^{:stratum 0} get-config p/get-config)
 
 ;; Re-export implementation functions
-(def backends impl/backends)
-(def build-messages-prompt impl/build-messages-prompt)
-(def parse-cli-output impl/parse-cli-output)
-(def default-exec-fn impl/default-exec-fn)
-(def mock-exec-fn impl/mock-exec-fn)
-(def mock-exec-fn-multi impl/mock-exec-fn-multi)
+(def ^{:stratum 0} backends impl/backends)
+
+(def ^{:stratum 0} build-messages-prompt impl/build-messages-prompt)
+
+(def ^{:stratum 0} parse-cli-output impl/parse-cli-output)
+
+(def ^{:stratum 0} default-exec-fn impl/default-exec-fn)
+
+(def ^{:stratum 0} mock-exec-fn impl/mock-exec-fn)
+
+(def ^{:stratum 0} mock-exec-fn-multi impl/mock-exec-fn-multi)
 
 ;; Re-export factory functions
-(def create-client records/create-client)
+(def ^{:stratum 0} create-client records/create-client)

--- a/components/llm/src/ai/miniforge/llm/cost.clj
+++ b/components/llm/src/ai/miniforge/llm/cost.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.llm.cost
   "Fallback USD cost estimation from token usage when the upstream
    CLI doesn't surface `total_cost_usd` in its streaming result.
@@ -34,21 +33,31 @@
    [clojure.edn :as edn]
    [clojure.java.io :as io]))
 
-;; Constants
+;------------------------------------------------------------------------------ Layer 0
 
-(def ^:private cost-table-resource-path
+;; Constants
+(def ^{:stratum 0} ^:private cost-table-resource-path
   "Classpath path to the EDN pricing table. Single source of truth
    so callers can't drift on which file is canonical."
   "llm/cost-table.edn")
 
-(def ^:private tokens-per-million
+(def ^{:stratum 0} ^:private tokens-per-million
   "Per-1M-token denominator for the EDN pricing table. Defined as
    a named constant so the unit-of-pricing is readable inline at
    estimate-cost rather than appearing as a bare 1000000 in the
    arithmetic."
   1000000)
 
-(def ^:private cost-table
+(defn- ^{:stratum 0} usage-token-count
+  "Return a numeric usage token count, treating missing or malformed values
+   as zero so cost estimation remains numeric for upstream payloads."
+  [usage token-key]
+  (let [tokens (get usage token-key)]
+    (if (number? tokens) tokens 0)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} ^:private cost-table
   "Delay-loaded pricing table. Loaded once at namespace init via
    the resource path; defaults to an empty pricing map when the
    resource is missing so callers see $0.00 rather than throwing.
@@ -63,16 +72,10 @@
           {})
       (catch Exception _ {}))))
 
-(defn- usage-token-count
-  "Return a numeric usage token count, treating missing or malformed values
-   as zero so cost estimation remains numeric for upstream payloads."
-  [usage token-key]
-  (let [tokens (get usage token-key)]
-    (if (number? tokens) tokens 0)))
+;------------------------------------------------------------------------------ Layer 2
 
 ;; Public API
-
-(defn pricing-for-model
+(defn ^{:stratum 2} pricing-for-model
   "Return `{:input-per-1m N :output-per-1m N}` for the given
    model-id string, or nil when the model isn't in the table.
    Callers fold the nil to a zero-cost estimate rather than
@@ -81,7 +84,9 @@
   (when (string? model-id)
     (get @cost-table model-id)))
 
-(defn estimate-cost
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} estimate-cost
   "Compute USD cost from a token-usage map and model-id.
 
    Inputs:

--- a/components/llm/src/ai/miniforge/llm/interface.clj
+++ b/components/llm/src/ai/miniforge/llm/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.llm.interface
   "Public API for LLM client using CLI backends.
    Supports claude CLI, cursor CLI, and mock backends."
@@ -29,14 +28,14 @@
    [ai.miniforge.llm.model-selector :as selector]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Backend information
 
-(def backends
+;; Backend information
+(def ^{:stratum 0} backends
   "Available CLI backends."
   impl/backends)
 
 ;; Re-export protocol for public API
-(def LLMClient
+(def ^{:stratum 0} LLMClient
   "Protocol clients implement for LLM interaction; the public extensibility
    point for custom backends. Methods: complete* [this request] -> result
    map ({:success true :content :usage} or {:success false :error :anomaly});
@@ -46,10 +45,8 @@
    -> the client's config map."
   p/LLMClient)
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Client creation
-
-(defn create-client
+(defn ^{:stratum 0} create-client
   "Create a new LLM client.
 
    Options:
@@ -71,7 +68,7 @@
   ([] (records/create-client))
   ([opts] (records/create-client opts)))
 
-(defn backend-for-model
+(defn ^{:stratum 0} backend-for-model
   "Look up the backend keyword for a model-id string.
    Returns :claude, :codex, :gemini, :ollama, etc. based on the model catalog.
    Falls back to :codex for unknown models."
@@ -83,7 +80,7 @@
            :backend)
       :codex))
 
-(defn client-backend
+(defn ^{:stratum 0} client-backend
   "Return the backend keyword configured for an LLM client."
   [client]
   (when client
@@ -91,13 +88,7 @@
         p/get-config
         :backend)))
 
-(defn create-client-for-model
-  "Create a new LLM client using the appropriate backend for a model-id.
-   Looks up the model in the catalog to determine backend."
-  [model-id]
-  (create-client {:backend (backend-for-model model-id)}))
-
-(defn mock-client
+(defn ^{:stratum 0} mock-client
   "Create a mock client for testing.
 
    Options:
@@ -114,10 +105,8 @@
                   (impl/mock-exec-fn (or output "Mock response") :exit exit))]
     (records/create-client {:backend :claude :exec-fn exec-fn})))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Completion API
-
-(defn complete
+(defn ^{:stratum 0} complete
   "Send a completion request to the LLM.
 
    Arguments:
@@ -141,23 +130,7 @@
   [client request]
   (p/complete* client request))
 
-(defn chat
-  "Convenience function for simple single-turn chat.
-
-   Arguments:
-   - client  - Client created by create-client
-   - prompt  - User message string
-   - opts    - Optional map with :system, :max-tokens
-
-   Example:
-     (chat client \"What is 2+2?\")
-     (chat client \"Explain monads\" {:system \"Be concise.\"})"
-  ([client prompt]
-   (chat client prompt {}))
-  ([client prompt opts]
-   (complete client (assoc opts :prompt prompt))))
-
-(defn complete-stream
+(defn ^{:stratum 0} complete-stream
   "Send a streaming completion request to the LLM.
 
    Arguments:
@@ -181,50 +154,29 @@
   [client request on-chunk]
   (p/complete-stream* client request on-chunk))
 
-(defn chat-stream
-  "Convenience function for streaming single-turn chat.
-
-   Arguments:
-   - client   - Client created by create-client
-   - prompt   - User message string
-   - on-chunk - Callback for streaming chunks
-   - opts     - Optional map with :system, :max-tokens
-
-   Example:
-     (chat-stream client
-                  \"Tell me a story\"
-                  (fn [{:keys [delta]}] (print delta)))"
-  ([client prompt on-chunk]
-   (chat-stream client prompt on-chunk {}))
-  ([client prompt on-chunk opts]
-   (complete-stream client (assoc opts :prompt prompt) on-chunk)))
-
 ;; Response helpers
-
-(defn success?
+(defn ^{:stratum 0} success?
   "Check if a response was successful."
   [response]
   (:success response))
 
-(defn get-content
+(defn ^{:stratum 0} get-content
   "Extract content from a successful response."
   [response]
   (:content response))
 
-(defn get-error
+(defn ^{:stratum 0} get-error
   "Extract error details from a failed response."
   [response]
   (:error response))
 
-(defn rate-limited?
+(defn ^{:stratum 0} rate-limited?
   "Check if a response indicates the provider rate-limited the request."
   [response]
   (= :anomalies.agent/rate-limited (:anomaly response)))
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Progress Monitoring
-
-(defn create-progress-monitor
+(defn ^{:stratum 0} create-progress-monitor
   "Create a progress monitor for tracking workflow activity.
 
    Options:
@@ -240,7 +192,7 @@
   [opts]
   (pm/create-progress-monitor opts))
 
-(defn record-chunk!
+(defn ^{:stratum 0} record-chunk!
   "Record a streaming chunk as activity.
 
    Arguments:
@@ -254,7 +206,7 @@
   [monitor chunk-content]
   (pm/record-chunk! monitor chunk-content))
 
-(defn record-file-write!
+(defn ^{:stratum 0} record-file-write!
   "Record a file write as activity.
 
    Arguments:
@@ -266,7 +218,7 @@
   [monitor file-path]
   (pm/record-file-write! monitor file-path))
 
-(defn check-timeout
+(defn ^{:stratum 0} check-timeout
   "Check if monitor has timed out.
 
    Arguments:
@@ -285,7 +237,7 @@
   [monitor]
   (pm/check-timeout monitor))
 
-(defn get-stats
+(defn ^{:stratum 0} get-stats
   "Get current progress monitor statistics.
 
    Arguments:
@@ -305,10 +257,8 @@
   [monitor]
   (pm/get-stats monitor))
 
-;------------------------------------------------------------------------------ Layer 4
 ;; Model Selection API
-
-(defn get-model
+(defn ^{:stratum 0} get-model
   "Get a model's full profile by keyword.
 
    Example:
@@ -317,20 +267,20 @@
   [model-key]
   (registry/get-model model-key))
 
-(defn context-window-for-model-id
+(defn ^{:stratum 0} context-window-for-model-id
   "Context window (max input tokens) for a backend model-id string
    (e.g. \"claude-opus-4-6\"), or nil when uncatalogued. See N12 §2."
   [model-id]
   (registry/context-window-for-model-id model-id))
 
-(defn prompt-size-telemetry
+(defn ^{:stratum 0} prompt-size-telemetry
   "Pre-flight size gauge over the assembled system + user prompt:
    {:system-chars :user-chars :total-chars :estimated-input-tokens}.
    See N12 §3."
   [system prompt]
   (impl/prompt-size-telemetry system prompt))
 
-(defn get-models-by-capability
+(defn ^{:stratum 0} get-models-by-capability
   "Get models meeting or exceeding a capability level.
 
    Example:
@@ -338,7 +288,7 @@
   [capability min-level]
   (registry/get-models-by-capability capability min-level))
 
-(defn get-models-by-use-case
+(defn ^{:stratum 0} get-models-by-use-case
   "Get models that support a specific use-case.
 
    Example:
@@ -346,7 +296,7 @@
   [use-case]
   (registry/get-models-by-use-case use-case))
 
-(defn recommend-models-for-task-type
+(defn ^{:stratum 0} recommend-models-for-task-type
   "Get recommended models for a task type.
 
    Example:
@@ -354,7 +304,7 @@
   [task-type]
   (registry/recommend-models-for-task-type task-type))
 
-(defn select-model
+(defn ^{:stratum 0} select-model
   "Select optimal model based on task classification.
 
    Arguments:
@@ -373,7 +323,7 @@
   ([task-classification config constraints]
    (selector/select-model task-classification config constraints)))
 
-(defn select-model-for-phase
+(defn ^{:stratum 0} select-model-for-phase
   "Select model for a workflow phase.
 
    Example:
@@ -382,7 +332,7 @@
   [phase & {:keys [config constraints]}]
   (selector/select-model-for-phase phase :config config :constraints constraints))
 
-(defn explain-selection
+(defn ^{:stratum 0} explain-selection
   "Generate user-facing explanation of model selection.
 
    Example:
@@ -390,29 +340,67 @@
   [selection]
   (selector/explain-selection selection))
 
-;------------------------------------------------------------------------------ Layer 5
 ;; Capsule integration
-
-(def capsule-exec-fn
+(def ^{:stratum 0} capsule-exec-fn
   "Build a capsule-aware exec function for LLM clients running inside executors."
   impl/capsule-exec-fn)
 
-;------------------------------------------------------------------------------ Layer 6
 ;; Cost estimation — single source of truth for token → USD pricing.
 ;; See ai.miniforge.llm.cost for the table and the arithmetic; this
 ;; re-export lets agent / workflow callers reach pricing without
 ;; depending on the impl namespace directly.
-
-(def estimate-cost
+(def ^{:stratum 0} estimate-cost
   "Estimate USD from {:input-tokens N :output-tokens N} usage and a
    model-id string. Returns 0.0 for unknown / unpriced models.
    See ai.miniforge.llm.cost/estimate-cost."
   cost/estimate-cost)
 
-(def pricing-for-model
+(def ^{:stratum 0} pricing-for-model
   "Look up {:input-per-1m :output-per-1m} pricing for a model-id.
    Returns nil when the model isn't in the cost table."
   cost/pricing-for-model)
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} create-client-for-model
+  "Create a new LLM client using the appropriate backend for a model-id.
+   Looks up the model in the catalog to determine backend."
+  [model-id]
+  (create-client {:backend (backend-for-model model-id)}))
+
+(defn ^{:stratum 1} chat
+  "Convenience function for simple single-turn chat.
+
+   Arguments:
+   - client  - Client created by create-client
+   - prompt  - User message string
+   - opts    - Optional map with :system, :max-tokens
+
+   Example:
+     (chat client \"What is 2+2?\")
+     (chat client \"Explain monads\" {:system \"Be concise.\"})"
+  ([client prompt]
+   (chat client prompt {}))
+  ([client prompt opts]
+   (complete client (assoc opts :prompt prompt))))
+
+(defn ^{:stratum 1} chat-stream
+  "Convenience function for streaming single-turn chat.
+
+   Arguments:
+   - client   - Client created by create-client
+   - prompt   - User message string
+   - on-chunk - Callback for streaming chunks
+   - opts     - Optional map with :system, :max-tokens
+
+   Example:
+     (chat-stream client
+                  \"Tell me a story\"
+                  (fn [{:keys [delta]}] (print delta)))"
+  ([client prompt on-chunk]
+   (chat-stream client prompt on-chunk {}))
+  ([client prompt on-chunk opts]
+   (complete-stream client (assoc opts :prompt prompt) on-chunk)))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/llm/src/ai/miniforge/llm/interface/protocols/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/interface/protocols/llm_client.clj
@@ -15,14 +15,15 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.llm.interface.protocols.llm-client
   "Public protocol for LLM client interaction.
 
    This is an extensibility point - users can implement custom LLM clients
    by implementing this protocol.")
 
-(defprotocol LLMClient
+;------------------------------------------------------------------------------ Layer 0
+
+(defprotocol ^{:stratum 0} LLMClient
   "Protocol for LLM interaction."
   (complete* [this request]
     "Send a completion request, returns result map.")

--- a/components/llm/src/ai/miniforge/llm/messages.clj
+++ b/components/llm/src/ai/miniforge/llm/messages.clj
@@ -15,11 +15,12 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.llm.messages
   "Message catalog for the LLM component."
   (:require [ai.miniforge.messages.interface :as messages]))
 
-(def t
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} t
   "Look up an LLM message by key, with optional param substitution."
   (messages/create-translator "config/llm/messages/en-US.edn" :llm/messages))

--- a/components/llm/src/ai/miniforge/llm/model_registry.clj
+++ b/components/llm/src/ai/miniforge/llm/model_registry.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.llm.model-registry
   "Model registry with capability profiles for intelligent model selection.
    Layer 0: Model capability definitions (resource-backed data)
@@ -27,17 +26,17 @@
    [clojure.java.io :as io]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Model capability definitions
 
-(def capability-levels
+;; Model capability definitions
+(def ^{:stratum 0} capability-levels
   "Capability levels from lowest to highest"
   [:poor :fair :good :excellent :exceptional])
 
-(def speed-levels
+(def ^{:stratum 0} speed-levels
   "Speed capability levels from slowest to fastest"
   [:slow :moderate :balanced :fast :very-fast])
 
-(defn- load-model-catalog
+(defn- ^{:stratum 0} load-model-catalog
   "Load the model catalog from EDN resources."
   []
   (if-let [resource (io/resource "llm/model-catalog.edn")]
@@ -45,23 +44,32 @@
     (response/throw-anomaly! :anomalies/not-found
                             "Missing llm/model-catalog.edn resource")))
 
-(def ^:private model-catalog
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} ^:private model-catalog
   "Resource-backed model catalog and task-type recommendations."
   (delay (load-model-catalog)))
 
-(def model-registry
+;------------------------------------------------------------------------------ Layer 2
+
+(def ^{:stratum 2} model-registry
   "Comprehensive registry of all supported models with their capabilities."
   (:models @model-catalog))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Query functions
+;; Recommendation logic
+(def ^{:stratum 2} task-type-recommendations
+  "Recommended models for each task type, organized by tier."
+  (:task-type-recommendations @model-catalog))
 
-(defn get-model
+;------------------------------------------------------------------------------ Layer 3
+
+;; Query functions
+(defn ^{:stratum 3} get-model
   "Get a model's full profile by keyword."
   [model-key]
   (get model-registry model-key))
 
-(defn context-window-for-model-id
+(defn ^{:stratum 3} context-window-for-model-id
   "Context window (max input tokens) for a backend model-id string
    (e.g. \"claude-opus-4-6\"), or nil when the model-id is not in the
    catalog. Looks up by the entry's :model-id rather than the catalog key,
@@ -73,7 +81,7 @@
             (get-in v [:capabilities :context-window])))
         model-registry))
 
-(defn get-models-by-capability
+(defn ^{:stratum 3} get-models-by-capability
   "Get models meeting or exceeding a capability level.
    Example: (get-models-by-capability :reasoning :excellent)
    Returns: [:opus-4.6 :sonnet-4.6 :gpt-5.3-codex ...]"
@@ -89,7 +97,7 @@
            (map first)
            (into [])))))
 
-(defn get-models-by-speed
+(defn ^{:stratum 3} get-models-by-speed
   "Get models meeting or exceeding a speed level.
    Example: (get-models-by-speed :fast)
    Returns: [:haiku-4.5 :gemini-2.5-flash-lite ...]"
@@ -105,7 +113,7 @@
            (map first)
            (into [])))))
 
-(defn get-models-by-use-case
+(defn ^{:stratum 3} get-models-by-use-case
   "Get models that support a specific use-case.
    Example: (get-models-by-use-case :code-implementation)
    Returns: [:sonnet-4.6 :gpt-5.2-codex ...]"
@@ -116,7 +124,7 @@
        (map first)
        (into [])))
 
-(defn get-models-by-provider
+(defn ^{:stratum 3} get-models-by-provider
   "Get all models from a specific provider."
   [provider]
   (->> model-registry
@@ -124,7 +132,7 @@
        (map first)
        (into [])))
 
-(defn get-local-models
+(defn ^{:stratum 3} get-local-models
   "Get all local models (for privacy-sensitive tasks)."
   []
   (->> model-registry
@@ -132,28 +140,23 @@
        (map first)
        (into [])))
 
-(defn supports-large-context?
-  "Check if model supports contexts larger than threshold (default 200k)."
-  ([model-key] (supports-large-context? model-key 200000))
-  ([model-key threshold]
-   (when-let [model (get-model model-key)]
-     (>= (get-in model [:capabilities :context-window]) threshold))))
-
-;------------------------------------------------------------------------------ Layer 2
-;; Recommendation logic
-
-(def task-type-recommendations
-  "Recommended models for each task type, organized by tier."
-  (:task-type-recommendations @model-catalog))
-
-(defn recommend-models-for-task-type
+(defn ^{:stratum 3} recommend-models-for-task-type
   "Get recommended models for a task type.
    Returns map with :tier-1, :tier-2, :tier-3-local, and :rationale."
   [task-type]
   (get task-type-recommendations task-type))
 
-(defn get-primary-recommendation
+(defn ^{:stratum 3} get-primary-recommendation
   "Get the primary recommended model for a task type.
    Returns the first model from tier-1."
   [task-type]
   (first (get-in task-type-recommendations [task-type :tier-1])))
+
+;------------------------------------------------------------------------------ Layer 4
+
+(defn ^{:stratum 4} supports-large-context?
+  "Check if model supports contexts larger than threshold (default 200k)."
+  ([model-key] (supports-large-context? model-key 200000))
+  ([model-key threshold]
+   (when-let [model (get-model model-key)]
+     (>= (get-in model [:capabilities :context-window]) threshold))))

--- a/components/llm/src/ai/miniforge/llm/model_selector.clj
+++ b/components/llm/src/ai/miniforge/llm/model_selector.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.llm.model-selector
   "Intelligent model selection based on task classification.
    Layer 0: Selection constraints and availability checking
@@ -34,16 +33,98 @@
    [clojure.java.io :as io]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Constraints and availability
 
-(def ^:private default-cost-limit-usd
+;; Constraints and availability
+(def ^{:stratum 0} ^:private default-cost-limit-usd
   "Fallback per-task cost limit ($) when neither config nor caller specifies
    one. Used by `default-config-fallback` and by the selection fns'
    `(or cost-limit ...)` guards so the unspecified-budget default has a single
    name. 0.10 comfortably covers a routine Sonnet/Haiku task."
   0.10)
 
-(def default-config-fallback
+(def ^{:stratum 0} ^:private economical-cost-threshold-usd
+  "Minimum per-task budget ($) at which an :economical model is
+   affordable in meets-cost-constraint?."
+  0.01)
+
+(def ^{:stratum 0} ^:private moderate-cost-threshold-usd
+  "Minimum per-task budget ($) at which a :moderate model is affordable."
+  0.05)
+
+(def ^{:stratum 0} ^:private cost-optimized-default-limit-usd
+  "Fallback per-task budget ($) for the cost-optimized selection strategy when
+   the caller gives none. Tighter than the general default so cost-optimized
+   selection actually prefers cheaper tiers."
+  0.05)
+
+(def ^{:stratum 0} ^:private phase-classification-confidence
+  "Confidence assigned to a task classification derived from the SDLC phase
+   (rather than LLM-inferred). 0.9 — the phase→type mapping is deterministic
+   and near-certain, but a phase can occasionally host atypical work, so not
+   1.0."
+  0.9)
+
+(def ^{:stratum 0} ^:private fallback-provider-env-vars
+  "Hard-coded fallback when `llm/model-selector.edn :provider-env-vars` is
+   absent. Operators override by editing the EDN file, not this constant."
+  {:anthropic "ANTHROPIC_API_KEY"
+   :openai    "OPENAI_API_KEY"
+   :google    "GOOGLE_API_KEY"
+   :groq      "GROQ_API_KEY"})
+
+(defn- ^{:stratum 0} load-model-selector-config
+  []
+  (if-let [resource (io/resource "llm/model-selector.edn")]
+    (edn/read-string (slurp resource))
+    {}))
+
+(def ^{:stratum 0} get-env-var
+  "Wraps System/getenv; rebind in tests to inject env state without mutating
+   the real process environment."
+  #(System/getenv %))
+
+(defn ^{:stratum 0} meets-context-requirement?
+  "Check if model can handle the required context size."
+  [model-key required-context]
+  (if-let [model (registry/get-model model-key)]
+    (>= (get-in model [:capabilities :context-window]) required-context)
+    false))
+
+;; Selection orchestration
+(defn ^{:stratum 0} build-selection-rationale
+  "Build human-readable explanation of model selection."
+  [model-key task-classification strategy constraints]
+  (let [model (registry/get-model model-key)
+        task-type (:type task-classification)
+        confidence (:confidence task-classification)
+        recommendations (registry/recommend-models-for-task-type task-type)]
+
+    (str
+     (format "Task: %s (confidence: %.0f%%)\n" (name task-type) (* confidence 100))
+     (format "Selected Model: %s (%s)\n" (:model-id model) (name (:provider model)))
+     (format "Strategy: %s\n" (name strategy))
+     (when-let [rationale (:rationale recommendations)]
+       (format "Rationale: %s\n" rationale))
+     (when (:require-local constraints)
+       "Constraint: Local inference required\n")
+     (when (:context-size constraints)
+       (format "Context: %d tokens\n" (:context-size constraints)))
+     (format "Best For: %s" (first (:best-for model))))))
+
+(defn ^{:stratum 0} explain-selection
+  "Generate user-facing explanation of model selection."
+  [selection]
+  (str "Model Auto-Selected: " (name (:model selection)) "\n"
+       "\n"
+       (:rationale selection)
+       "\n"
+       (when (:fallback-used selection)
+         "\nNote: Primary model unavailable, using fallback")
+       "\nOverride: Set :spec/model-override to force a specific model"))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} default-config-fallback
   "Hard-coded fallback when `llm/model-selector.edn :default-config` is
    absent. The active value comes from that EDN file per rule 007."
   {:enabled true
@@ -53,52 +134,18 @@
    :allow-downgrade true
    :require-local false})
 
-(def ^:private economical-cost-threshold-usd
-  "Minimum per-task budget ($) at which an :economical model is
-   affordable in meets-cost-constraint?."
-  0.01)
-
-(def ^:private moderate-cost-threshold-usd
-  "Minimum per-task budget ($) at which a :moderate model is affordable."
-  0.05)
-
-(def ^:private expensive-cost-threshold-usd
+(def ^{:stratum 1} ^:private expensive-cost-threshold-usd
   "Minimum per-task budget ($) at which an :expensive model is
    affordable. Equal to the default budget — the default is set to just afford
    an expensive model when the caller is silent."
   default-cost-limit-usd)
 
-(def ^:private cost-optimized-default-limit-usd
-  "Fallback per-task budget ($) for the cost-optimized selection strategy when
-   the caller gives none. Tighter than the general default so cost-optimized
-   selection actually prefers cheaper tiers."
-  0.05)
-
-(def ^:private phase-classification-confidence
-  "Confidence assigned to a task classification derived from the SDLC phase
-   (rather than LLM-inferred). 0.9 — the phase→type mapping is deterministic
-   and near-certain, but a phase can occasionally host atypical work, so not
-   1.0."
-  0.9)
-
-(def ^:private fallback-provider-env-vars
-  "Hard-coded fallback when `llm/model-selector.edn :provider-env-vars` is
-   absent. Operators override by editing the EDN file, not this constant."
-  {:anthropic "ANTHROPIC_API_KEY"
-   :openai    "OPENAI_API_KEY"
-   :google    "GOOGLE_API_KEY"
-   :groq      "GROQ_API_KEY"})
-
-(defn- load-model-selector-config
-  []
-  (if-let [resource (io/resource "llm/model-selector.edn")]
-    (edn/read-string (slurp resource))
-    {}))
-
-(def ^:private model-selector-config
+(def ^{:stratum 1} ^:private model-selector-config
   (delay (load-model-selector-config)))
 
-(def default-config
+;------------------------------------------------------------------------------ Layer 2
+
+(def ^{:stratum 2} default-config
   "Active default configuration for model selection. EDN-loaded value
    from `llm/model-selector.edn :default-config` if present, else the
    code-side `default-config-fallback`. Realized via `delay` so the
@@ -106,35 +153,11 @@
   (delay (or (:default-config @model-selector-config)
              default-config-fallback)))
 
-(def ^:private provider-env-vars
+(def ^{:stratum 2} ^:private provider-env-vars
   (delay (or (:provider-env-vars @model-selector-config)
              fallback-provider-env-vars)))
 
-(def get-env-var
-  "Wraps System/getenv; rebind in tests to inject env state without mutating
-   the real process environment."
-  #(System/getenv %))
-
-(defn model-available?
-  "Returns true when the model key is registered in the model catalog and
-   its provider's API key env var is present (non-blank) in the process
-   environment. Local-runner models with no entry in provider-env-vars are
-   always considered available. Unregistered keys return false."
-  [model-key]
-  (when-let [model (registry/get-model model-key)]
-    (let [env-var (get @provider-env-vars (:provider model))]
-      (or (nil? env-var)
-          (boolean (when-let [v (get-env-var env-var)]
-                     (not (.isBlank ^String v))))))))
-
-(defn meets-context-requirement?
-  "Check if model can handle the required context size."
-  [model-key required-context]
-  (if-let [model (registry/get-model model-key)]
-    (>= (get-in model [:capabilities :context-window]) required-context)
-    false))
-
-(defn meets-cost-constraint?
+(defn ^{:stratum 2} meets-cost-constraint?
   "Check if model meets cost constraint (simplified)."
   [model-key cost-limit]
   (when-let [model (registry/get-model model-key)]
@@ -146,10 +169,24 @@
         :expensive (>= cost-limit expensive-cost-threshold-usd)
         true))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Selection strategies
+;------------------------------------------------------------------------------ Layer 3
 
-(defn select-by-automatic
+(defn ^{:stratum 3} model-available?
+  "Returns true when the model key is registered in the model catalog and
+   its provider's API key env var is present (non-blank) in the process
+   environment. Local-runner models with no entry in provider-env-vars are
+   always considered available. Unregistered keys return false."
+  [model-key]
+  (when-let [model (registry/get-model model-key)]
+    (let [env-var (get @provider-env-vars (:provider model))]
+      (or (nil? env-var)
+          (boolean (when-let [v (get-env-var env-var)]
+                     (not (.isBlank ^String v))))))))
+
+;------------------------------------------------------------------------------ Layer 4
+
+;; Selection strategies
+(defn ^{:stratum 4} select-by-automatic
   "Automatic selection based on task type.
    Picks the best model for the task, considering availability."
   [task-type {:keys [context-size cost-limit require-local]}]
@@ -173,7 +210,7 @@
         ;; Fallback to first available if no match
         (first (filter model-available? all-tiers)))))
 
-(defn select-by-cost-optimized
+(defn ^{:stratum 4} select-by-cost-optimized
   "Cost-optimized selection - prefer cheapest sufficient model."
   [task-type {:keys [context-size cost-limit]}]
   (let [recommendations (registry/recommend-models-for-task-type task-type)
@@ -189,7 +226,7 @@
                           (meets-cost-constraint? model-key (or cost-limit cost-optimized-default-limit-usd))))
                    tiers))))
 
-(defn select-by-speed
+(defn ^{:stratum 4} select-by-speed
   "Speed-optimized selection - prefer fastest models."
   [task-type {:keys [context-size cost-limit]}]
   (let [recommendations (registry/recommend-models-for-task-type task-type)
@@ -215,30 +252,9 @@
                           (meets-cost-constraint? model-key (or cost-limit default-cost-limit-usd))))
                    sorted-by-speed))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Selection orchestration
+;------------------------------------------------------------------------------ Layer 5
 
-(defn build-selection-rationale
-  "Build human-readable explanation of model selection."
-  [model-key task-classification strategy constraints]
-  (let [model (registry/get-model model-key)
-        task-type (:type task-classification)
-        confidence (:confidence task-classification)
-        recommendations (registry/recommend-models-for-task-type task-type)]
-
-    (str
-     (format "Task: %s (confidence: %.0f%%)\n" (name task-type) (* confidence 100))
-     (format "Selected Model: %s (%s)\n" (:model-id model) (name (:provider model)))
-     (format "Strategy: %s\n" (name strategy))
-     (when-let [rationale (:rationale recommendations)]
-       (format "Rationale: %s\n" rationale))
-     (when (:require-local constraints)
-       "Constraint: Local inference required\n")
-     (when (:context-size constraints)
-       (format "Context: %d tokens\n" (:context-size constraints)))
-     (format "Best For: %s" (first (:best-for model))))))
-
-(defn select-model
+(defn ^{:stratum 5} select-model
   "Main entry point for intelligent model selection.
 
    Input:
@@ -295,7 +311,9 @@
       :rationale (build-selection-rationale model-key task-classification strategy constraints)
       :fallback-used fallback-used})))
 
-(defn select-model-for-phase
+;------------------------------------------------------------------------------ Layer 6
+
+(defn ^{:stratum 6} select-model-for-phase
   "Select model specifically for a workflow phase.
    Convenience function that creates task classification from phase."
   [phase & {:keys [config constraints]}]
@@ -306,14 +324,3 @@
                              :confidence phase-classification-confidence
                              :reason (format "Phase-based classification for '%s'" phase)}]
     (select-model task-classification config constraints)))
-
-(defn explain-selection
-  "Generate user-facing explanation of model selection."
-  [selection]
-  (str "Model Auto-Selected: " (name (:model selection)) "\n"
-       "\n"
-       (:rationale selection)
-       "\n"
-       (when (:fallback-used selection)
-         "\nNote: Primary model unavailable, using fallback")
-       "\nOverride: Set :spec/model-override to force a specific model"))

--- a/components/llm/src/ai/miniforge/llm/network_health.clj
+++ b/components/llm/src/ai/miniforge/llm/network_health.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.llm.network-health
   "URL-driven network connectivity probe.
 
@@ -37,19 +36,17 @@
   (:require [org.httpkit.client :as http]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Constants
 
-(def ^:const default-probe-timeout-ms
+;; Constants
+(def ^{:stratum 0} ^:const default-probe-timeout-ms
   "Maximum time a single probe is allowed to wait for an HTTP response
    before being considered failed. 3s is a generous ceiling — a healthy
    provider responds in <500ms; a 3s ceiling tolerates a slow CDN edge
    without making the probe itself a stagnation source."
   3000)
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Probe primitive
-
-(defn- response-proves-connectivity?
+(defn- ^{:stratum 0} response-proves-connectivity?
   "True when an http-kit response map shows the request reached an HTTP
    peer and got a response back — regardless of status code. A 4xx or
    even a 5xx means the network is up; only an exception (`:error`) or
@@ -59,7 +56,9 @@
                 (nil? (:error response))
                 (pos-int? (:status response)))))
 
-(defn network-healthy?
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} network-healthy?
   "Probe `probe-url` for a live HTTP response and return true/false.
 
    Returns true when the probe receives an HTTP response within

--- a/components/llm/src/ai/miniforge/llm/network_monitor.clj
+++ b/components/llm/src/ai/miniforge/llm/network_monitor.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.llm.network-monitor
   "Network-drop scheduler for the per-LLM-call lifecycle.
 
@@ -36,36 +35,34 @@
   (:require [ai.miniforge.llm.network-health :as nh]))
 
 ;------------------------------------------------------------------------------ Layer 0
+
 ;; Defaults
 ;;
 ;; Operationally tuned constants — kept as named `def`s here (vs an EDN
 ;; file) per standards rule 007: callers override via the
 ;; `start-network-monitor!` options map and the values change very
 ;; rarely.
-
-(def ^:const default-probe-interval-ms
+(def ^{:stratum 0} ^:const default-probe-interval-ms
   "Time between probe attempts. 10s — fast enough to detect a drop
    within ~30s (probe interval × failure threshold), slow enough that
    the probe traffic itself does not contribute meaningful load."
   10000)
 
-(def ^:const default-failure-threshold
+(def ^{:stratum 0} ^:const default-failure-threshold
   "Number of CONSECUTIVE probe failures required to declare a
    confirmed network drop. 3 strikes (= ~30s of dead network at the
    default 10s interval) absorbs transient blips — a single failed
    probe never costs a phase restart."
   3)
 
-(def ^:const monitor-stop-join-ms
+(def ^{:stratum 0} ^:const monitor-stop-join-ms
   "How long stop! waits for the worker thread to exit after
    interrupting it. The worker only needs to wake from Thread/sleep,
    see the running? flag, and exit."
   200)
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Scheduler
-
-(defn- run-monitor-loop!
+(defn- ^{:stratum 0} run-monitor-loop!
   "Inner worker loop. Polls `probe-fn` every `probe-interval-ms`;
    tracks consecutive failures. On `failure-threshold` consecutive
    failures, atomically claims the firing slot via `compare-and-set!`
@@ -100,7 +97,9 @@
             :else
             (recur next-failures)))))))
 
-(defn start-network-monitor!
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} start-network-monitor!
   "Spawn a daemon thread that probes `:probe-url` every
    `:probe-interval-ms` ms and fires `:on-drop` after
    `:failure-threshold` consecutive failures (single-fire).

--- a/components/llm/src/ai/miniforge/llm/progress_monitor.clj
+++ b/components/llm/src/ai/miniforge/llm/progress_monitor.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.llm.progress-monitor
   "Adaptive timeout monitoring based on actual progress detection.
 
@@ -23,39 +22,39 @@
    changes to detect when an agent is stuck vs actively working.")
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Timeout thresholds and monitor state
 
-(def ^:private default-stagnation-threshold-ms
+;; Timeout thresholds and monitor state
+(def ^{:stratum 0} ^:private default-stagnation-threshold-ms
   "Time without any progress signal before an agent is considered stuck —
    the adaptive-timeout trip point. 2 minutes: long enough to ride out a slow
    model turn or a quiet tool call, short enough that a genuinely hung agent
    is caught before it burns a phase budget."
   120000)
 
-(def ^:private default-max-total-ms
+(def ^{:stratum 0} ^:private default-max-total-ms
   "Hard ceiling on a single monitored run regardless of progress. 10 minutes —
    a backstop for an agent that keeps emitting just enough to look active but
    never actually finishes."
   600000)
 
-(def ^:private default-min-activity-interval-ms
+(def ^{:stratum 0} ^:private default-min-activity-interval-ms
   "Minimum spacing between counted progress signals; debounces a burst of
    chunks into one activity tick so rapid streaming doesn't reset the
    stagnation clock on every token. 5 seconds."
   5000)
 
-(def ^:private min-substantive-chunk-length
+(def ^{:stratum 0} ^:private min-substantive-chunk-length
   "A streamed chunk with this length or fewer characters is treated as
    non-substantive — a spinner/keepalive blip, not real output — so it does
    not count as progress."
   10)
 
-(def ^:private active-window-ms
+(def ^{:stratum 0} ^:private active-window-ms
   "Recency window for the :is-active? status flag: activity newer than this
    marks the monitor active. 30 seconds."
   30000)
 
-(defn create-progress-monitor
+(defn ^{:stratum 0} create-progress-monitor
    "Create a progress monitor for adaptive timeout.
 
    Options:
@@ -79,47 +78,7 @@
           :min-activity-interval-ms min-activity-interval-ms
           :stagnant-cycles 0}))
 
-(defn record-chunk!
-   "Record a streaming chunk as activity.
-
-   Returns true if this represents meaningful progress, false if stagnant."
-   [monitor chunk-content]
-   (let [now (System/currentTimeMillis)
-         state @monitor
-         last-content (:last-chunk-content state)
-         last-activity (:last-activity-at state)
-         min-interval (:min-activity-interval-ms state)
-         is-different? (not= chunk-content last-content)
-         is-not-just-thinking? (and chunk-content
-                                    (not (re-find #"(?i)^(thinking|analyzing|considering)" chunk-content)))
-         is-substantive? (and chunk-content (> (count chunk-content) min-substantive-chunk-length))
-         time-since-activity (- now last-activity)
-         ;; First chunk always counts as progress (last-content will be nil)
-         is-first-chunk? (nil? last-content)
-         sufficient-interval? (or is-first-chunk?
-                                  (> time-since-activity min-interval))
-
-         meaningful-progress? (and is-different?
-                                   is-not-just-thinking?
-                                   is-substantive?
-                                   sufficient-interval?)]
-
-     (swap! monitor
-            (fn [state]
-              (cond-> (assoc state
-                             :last-chunk-content chunk-content
-                             :chunk-count (inc (:chunk-count state)))
-                meaningful-progress?
-                (assoc :last-activity-at now
-                       :stagnant-cycles 0
-                       :unique-chunks (conj (:unique-chunks state) chunk-content))
-
-                (not meaningful-progress?)
-                (update :stagnant-cycles inc))))
-
-     meaningful-progress?))
-
-(defn record-file-write!
+(defn ^{:stratum 0} record-file-write!
   "Record a file write as significant progress."
   [monitor file-path]
   (let [now (System/currentTimeMillis)]
@@ -130,7 +89,7 @@
                     :stagnant-cycles 0
                     :file-writes (conj (:file-writes state) file-path))))))
 
-(defn record-activity!
+(defn ^{:stratum 0} record-activity!
   "Record semantic activity that should keep the monitor alive even when
    repeated events do not produce new substantive text.
 
@@ -148,7 +107,7 @@
                  (update :unique-chunks conj activity-key)))))
   true)
 
-(defn check-timeout
+(defn ^{:stratum 0} check-timeout
   "Check if the monitor has timed out.
 
    Returns:
@@ -188,16 +147,56 @@
       ;; Still making progress
       :else nil)))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Keepalive — decouples stagnation from CLI emission cadence
-
-(def ^:private keepalive-stop-join-ms
+(def ^{:stratum 0} ^:private keepalive-stop-join-ms
   "How long stop! waits for the keepalive thread to exit after
    interrupting it. 100ms is generous — the worker only needs to
    wake from Thread/sleep, see the running? flag, and exit."
   100)
 
-(defn start-keepalive!
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} record-chunk!
+   "Record a streaming chunk as activity.
+
+   Returns true if this represents meaningful progress, false if stagnant."
+   [monitor chunk-content]
+   (let [now (System/currentTimeMillis)
+         state @monitor
+         last-content (:last-chunk-content state)
+         last-activity (:last-activity-at state)
+         min-interval (:min-activity-interval-ms state)
+         is-different? (not= chunk-content last-content)
+         is-not-just-thinking? (and chunk-content
+                                    (not (re-find #"(?i)^(thinking|analyzing|considering)" chunk-content)))
+         is-substantive? (and chunk-content (> (count chunk-content) min-substantive-chunk-length))
+         time-since-activity (- now last-activity)
+         ;; First chunk always counts as progress (last-content will be nil)
+         is-first-chunk? (nil? last-content)
+         sufficient-interval? (or is-first-chunk?
+                                  (> time-since-activity min-interval))
+
+         meaningful-progress? (and is-different?
+                                   is-not-just-thinking?
+                                   is-substantive?
+                                   sufficient-interval?)]
+
+     (swap! monitor
+            (fn [state]
+              (cond-> (assoc state
+                             :last-chunk-content chunk-content
+                             :chunk-count (inc (:chunk-count state)))
+                meaningful-progress?
+                (assoc :last-activity-at now
+                       :stagnant-cycles 0
+                       :unique-chunks (conj (:unique-chunks state) chunk-content))
+
+                (not meaningful-progress?)
+                (update :stagnant-cycles inc))))
+
+     meaningful-progress?))
+
+(defn ^{:stratum 1} start-keepalive!
   "Spawn a daemon thread that calls record-activity! on `monitor` every
    `interval-ms` until the returned 0-arity stop-fn is invoked.
 
@@ -255,7 +254,7 @@
       (.interrupt thread)
       (.join thread keepalive-stop-join-ms))))
 
-(defn get-stats
+(defn ^{:stratum 1} get-stats
   "Get current statistics from the monitor."
   [monitor]
   (let [now (System/currentTimeMillis)

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.llm.protocols.impl.llm-client
   "Implementation functions for LLMClient protocol."
   (:require
@@ -39,6 +38,7 @@
    [java.util.concurrent LinkedBlockingQueue TimeUnit]))
 
 ;------------------------------------------------------------------------------ Layer 0
+
 ;; LLM response builders
 ;;
 ;; All LLM responses follow the contract:
@@ -47,69 +47,14 @@
 ;;
 ;; These builders ensure consistent construction across all backends
 ;; (CLI, HTTP/Ollama, streaming, non-streaming).
-
-(defn- load-client-defaults
+(defn- ^{:stratum 0} load-client-defaults
   []
   (if-let [resource (io/resource "llm/client-defaults.edn")]
     (edn/read-string (slurp resource))
     (response/throw-anomaly! :anomalies/not-found
                              "Missing llm/client-defaults.edn resource")))
 
-(def ^:private client-defaults
-  (delay (load-client-defaults)))
-
-(defn- client-default
-  [path]
-  (get-in @client-defaults path))
-
-(defn- default-claude-cli-budget-usd
-  []
-  (client-default [:claude-cli :default-budget-usd]))
-
-(defn- anthropic-api-version
-  []
-  (client-default [:http :anthropic :api-version]))
-
-(defn- default-anthropic-max-tokens
-  []
-  (client-default [:http :anthropic :default-max-tokens]))
-
-;; ---------------------------------------------------------------------------
-;; Stream-timing constants
-;;
-;; Names spell out intent so the surrounding code reads as the why,
-;; not the what. Tuning history lives in inline doc-comments next to
-;; each constant.
-
-(defn- default-stagnation-threshold-ms
-  []
-  (client-default [:stream :default-stagnation-threshold-ms]))
-
-(defn- default-max-total-ms
-  []
-  (client-default [:stream :default-max-total-ms]))
-
-(defn- default-min-activity-interval-ms
-  []
-  (client-default [:stream :default-min-activity-interval-ms]))
-
-(defn- stream-line-timeout-ms
-  []
-  (client-default [:stream :line-timeout-ms]))
-
-(defn- process-join-timeout-ms
-  []
-  (client-default [:stream :process-join-timeout-ms]))
-
-(defn- post-kill-join-timeout-ms
-  []
-  (client-default [:stream :post-kill-join-timeout-ms]))
-
-(defn- stream-poll-interval-ms
-  []
-  (client-default [:stream :poll-interval-ms]))
-
-(defn llm-success
+(defn ^{:stratum 0} llm-success
   "Build a successful LLM response."
   ([content]
    (llm-success content nil))
@@ -121,7 +66,7 @@
               :tokens (+ (get usage :input-tokens 0) (get usage :output-tokens 0))}
        (some? exit-code) (assoc :exit-code exit-code)))))
 
-(def ^:private category->type
+(def ^{:stratum 0} ^:private category->type
   "W2 convergence map (subset). Maps every legacy `:anomalies/*` and
    `:anomalies.*/*` category this brick actually produces (per
    `(grep '(llm-error ' …)`) to the canonical `:anomaly/type` from the
@@ -144,7 +89,7 @@
    :anomalies.agent/llm-error    :fault
    :anomalies.agent/rate-limited :unavailable})
 
-(def ^:private generic-standard-categories
+(def ^{:stratum 0} ^:private generic-standard-categories
   "Subset of the cognitect-standard categories (per the runbook
    `Generic standard (no subtype)` table) that this brick emits — these
    seven map 1:1 to a type and carry no `:anomaly/subtype`. The runbook's
@@ -158,7 +103,566 @@
     :anomalies/forbidden
     :anomalies/not-found})
 
-(defn- ->canonical-anomaly
+;; Stream parser functions
+(defn- ^{:stratum 0} parsed-usage
+  [usage]
+  ;; Capture cache fields: a large prompt lands mostly under cache-creation.
+  ;; Assoc only numeric fields — a present-but-nil key defeats downstream
+  ;; `(get usage :input-tokens 0)` defaulting (NPEs llm-success's :tokens sum).
+  (let [input-tokens (:input_tokens usage)
+        output-tokens (:output_tokens usage)
+        cache-creation (:cache_creation_input_tokens usage)
+        cache-read (:cache_read_input_tokens usage)]
+    (when (some number? [input-tokens output-tokens cache-creation cache-read])
+      (cond-> {}
+        (number? input-tokens)   (assoc :input-tokens input-tokens)
+        (number? output-tokens)  (assoc :output-tokens output-tokens)
+        (number? cache-creation) (assoc :cache-creation-input-tokens cache-creation)
+        (number? cache-read)     (assoc :cache-read-input-tokens cache-read)))))
+
+(defn- ^{:stratum 0} normalize-codex-finish-reason
+  "Normalize a Codex finish_reason string to the canonical stop-reason strings
+   used across all backends.
+
+   Codex → canonical mapping:
+   - \"stop\"      → \"end_turn\"     (normal completion)
+   - \"max_turns\" → \"max_turns\"    (turn budget exhausted)
+   - \"length\"    → \"max_tokens\"   (token budget exhausted)
+   - anything else → passed through unchanged"
+  [finish-reason]
+  (when finish-reason
+    (case finish-reason
+      "stop"      "end_turn"
+      "max_turns" "max_turns"
+      "length"    "max_tokens"
+      finish-reason)))
+
+;------------------------------------------------------------------------------ Backend configurations
+;; Named argument builders — extracted from the backends config map for clarity.
+(defn ^{:stratum 0} claude-mcp-allowlist-string
+  "Claude CLI's --allowedTools wire format.
+
+   Accepts two entry shapes:
+   - `{:mcp/server :mcp/tool}` keyword map → `mcp__<server>__<tool>`
+     (MCP tool; server name comes from the mcp-config.json key)
+   - Keyword by itself → `(name kw)` (native Claude Code tool,
+     e.g. `:Write`)
+
+   Entries are joined with commas. A malformed entry throws via
+   `(name nil)` at the call site."
+  [mcp-allowed-tools]
+  (->> mcp-allowed-tools
+       (mapv (fn [t]
+               (if (keyword? t)
+                 (name t)
+                 (let [{:mcp/keys [server tool]} t]
+                   (str "mcp__" (name server) "__" (name tool))))))
+       (str/join ",")))
+
+(def ^{:stratum 0} ^:private claude-input-format-flag
+  "Claude CLI flag that selects how the user prompt is delivered. Paired
+   with `claude-input-format-stdin` (the only value we use today), this
+   tells the CLI to read the prompt from stdin instead of argv."
+  "--input-format")
+
+(def ^{:stratum 0} ^:private claude-input-format-stdin
+  "Argument value for `claude-input-format-flag` that switches the CLI
+   to text-on-stdin input mode."
+  "text")
+
+(defn- ^{:stratum 0} codex-args
+  "Build CLI arguments for the Codex backend."
+  [{:keys [prompt model system prompt-via]
+    :or {prompt-via :stdin}}]
+  (let [stdin? (= prompt-via :stdin)]
+    (cond-> ["exec"
+             "--json"
+             "--ignore-user-config"
+             "--sandbox=workspace-write"
+             "--skip-git-repo-check"]
+      true   (into ["-c" "approval_policy=never"])
+      model  (into ["-m" model])
+      system (into ["-c" (str "system_prompt=" (json/generate-string system))])
+      stdin? (conj "-")
+      (not stdin?) (conj prompt))))
+
+(defn- ^{:stratum 0} cursor-args
+  "Build CLI arguments for the Cursor backend (binary `agent`).
+
+   Flags follow https://cursor.com/docs/cli/reference/parameters:
+
+     -p / --print  non-interactive run with tool access
+     --force       required for the agent to write files in print mode;
+                   this is the autonomous-execution switch (analogous to
+                   codex `approval_policy=never`)
+
+   Tool restriction is enforced out-of-band via the default-deny
+   .cursor/cli.json permissions allowlist written by the agent session
+   (see artifact-session/write-cursor-permissions!), not via CLI flags —
+   so we do not pass --approve-mcps (which would blanket-approve every MCP
+   server). Cursor exposes no system-prompt flag, so `system` is prepended
+   to the user prompt."
+  [{:keys [prompt system model]}]
+  (let [prompt (if system (str system "\n\n" prompt) prompt)]
+    (cond-> ["-p" "--force"]
+      model (into ["--model" model])
+      true  (conj prompt))))
+
+(defn- ^{:stratum 0} opencode-args
+  "Build CLI arguments for the OpenCode backend.
+
+   OpenCode owns provider credentials, model aliases, project config,
+   agent profiles, MCP config, and permissions. Miniforge passes the
+   selected model/profile knobs through and treats OpenCode as the
+   common provider wrapper instead of handling API keys directly."
+  [{:keys [prompt model agent attach command session continue? fork? files format]}]
+  (cond-> ["run"]
+    attach    (into ["--attach" attach])
+    command   (into ["--command" command])
+    continue? (conj "--continue")
+    session   (into ["--session" session])
+    fork?     (conj "--fork")
+    model     (into ["--model" model])
+    agent     (into ["--agent" agent])
+    (seq files) (into (mapcat (fn [file] ["--file" file]) files))
+    format    (into ["--format" format])
+    true      (conj prompt)))
+
+(defn- ^{:stratum 0} echo-args
+  "Build CLI arguments for the echo (test) backend."
+  [{:keys [prompt]}]
+  [prompt])
+
+;; `:probe-endpoint` on each backend entry is the stable provider edge
+;; URL that the network-monitor (PR-B) probes via
+;; `network-health/network-healthy?`. We only care that the connection
+;; completed, not the response status — a 4xx is the typical case (HEAD
+;; against api.anthropic.com unauthenticated returns 405). Backends
+;; without a provider-controlled endpoint (`:echo`) get the generic
+;; Cloudflare DNS connectivity URL so the monitor still has something
+;; to probe.
+(def ^{:stratum 0} ^:private generic-connectivity-probe-url
+  "https://1.1.1.1/")
+
+;; Pure-data backend fields (`:cmd`, endpoints, `:default-model`,
+;; `:models`, etc.) live in `llm/backends.edn`; the function-valued
+;; fields (`:stream-parser`, `:args-fn`) stay here because they
+;; reference parser/arg-builder fns defined in this namespace. The two
+;; are merged per backend below to form `backends`.
+(defn- ^{:stratum 0} load-backend-data
+  []
+  (if-let [resource (io/resource "llm/backends.edn")]
+    (edn/read-string (slurp resource))
+    (response/throw-anomaly! :anomalies/not-found
+                             "Missing llm/backends.edn resource")))
+
+(defn ^{:stratum 0} build-messages-prompt [messages]
+  (->> messages
+       (map (fn [{:keys [role content]}]
+              (case role
+                "user" content
+                "assistant" (str "[Assistant]: " content)
+                "system" (str "[System]: " content)
+                content)))
+       (str/join "\n\n")))
+
+(defn- ^{:stratum 0} http-failure-anomaly
+  "Build the canonical `:unavailable` anomaly that this brick emits for
+   any HTTP-layer failure on an LLM call (thrown exception or http-kit
+   `{:error <Throwable>}` deref). Centralizes the shape so the throwing
+   and non-throwing failure modes converge."
+  [^Throwable cause url]
+  (anomaly/anomaly
+   :unavailable
+   (str "HTTP request failed: " (.getMessage cause))
+   {:operation :http-request
+    :url url}))
+
+(defn- ^{:stratum 0} token-usage
+  "Build the canonical usage map, keeping only numeric fields — a
+   present-but-nil key defeats downstream `(get usage :input-tokens 0)`
+   defaulting (same trap `parsed-usage` guards against)."
+  [input-tokens output-tokens]
+  (cond-> {}
+    (number? input-tokens)  (assoc :input-tokens input-tokens)
+    (number? output-tokens) (assoc :output-tokens output-tokens)))
+
+(def ^{:stratum 0} ^:private http-too-many-requests
+  "HTTP 429. `java.net.HttpURLConnection` predates RFC 6585 and has no
+   constant for it; the other status literals in this namespace come
+   from that class."
+  429)
+
+(defn- ^{:stratum 0} parse-response-body
+  "Parse a response body as JSON, returning a canonical fault anomaly when
+   the JSON library throws. Callers retain the HTTP status alongside this
+   value so a non-OK response remains a status failure, not a parse failure."
+  [{:keys [status body]}]
+  (try+
+    (json/parse-string body true)
+    (catch Exception e
+      (anomaly/exception-anomaly
+       :fault
+       (msg/t :http-provider.system/parse-failed
+              {:reason (ex-message e)})
+       {:operation :parse-provider-response
+        :status status}
+       e))))
+
+;------------------------------------------------------------------------------ Direct provider requests
+;; Request/response shaping for the API-key HTTP backends
+;; (:anthropic-api / :openai-api / :gemini-api) used where CLI-agent
+;; backends cannot run — a sandboxed (Mac App Store) child process
+;; inherits the sandbox, so the user's claude/codex CLI wakes up
+;; without its config or keychain. Each provider is a body builder +
+;; response extractor pair; transport and error shaping are shared
+;; (`http-post-request`, `parse-provider-response`).
+(defn- ^{:stratum 0} chat-messages
+  "Normalize a request to the wire-shape message vector shared by the
+   chat-style provider APIs: a `:prompt` string becomes a single user
+   message; an explicit `:messages` vector passes through with only
+   the wire-relevant keys."
+  [{:keys [prompt messages]}]
+  (if prompt
+    [{:role "user" :content prompt}]
+    (mapv (fn [m] (select-keys m [:role :content])) messages)))
+
+(defn ^{:stratum 0} getenv-value
+  "Indirection over `System/getenv` so env-dependent backend resolution
+   (api-key, base-url) is testable via `with-redefs` (kept public like
+   `http-post-request` for exactly that reason)."
+  [k]
+  (System/getenv k))
+
+(defn ^{:stratum 0} rate-limited?
+  "Detect Claude CLI rate limit messages in content.
+   Claude CLI returns exit 0 but emits a rate limit message as content."
+  [content]
+  (and (string? content)
+       (re-find #"(?i)you've hit your limit|too many requests|\b429\b|rate limit(?:ed| exceeded)?\b|resets \d+[ap]m"
+                content)))
+
+(defn ^{:stratum 0} format-timeout-error [{:keys [message type elapsed-ms]}]
+  (format "Adaptive timeout: %s (type: %s, elapsed: %dms)"
+          message (name type) elapsed-ms))
+
+(defn ^{:stratum 0} success-result [out-lines process-result]
+  {:out (str/join "\n" out-lines)
+   :err (:err process-result)
+   :exit (:exit process-result)})
+
+(defn ^{:stratum 0} stream-anomaly-result [out-lines stream-anomaly]
+  {:out (str/join "\n" out-lines)
+   :err (:anomaly/message stream-anomaly)
+   :exit -1
+   :anomaly stream-anomaly})
+
+(def ^{:stratum 0} ^:private eof-sentinel
+  (Object.))
+
+(defn- ^{:stratum 0} open-stream-dump-writer
+  []
+  (when-let [dump-path (System/getenv "MF_STREAM_DUMP")]
+    (java.io.PrintWriter.
+     (java.io.FileWriter. dump-path true))))
+
+(defn- ^{:stratum 0} stream-read-failure
+  [ex]
+  (anomaly/exception-anomaly :fault (or (ex-message ex) (str (type ex))) ex))
+
+(defn- ^{:stratum 0} enqueue-stream-line!
+  [line-queue line]
+  (.put line-queue line))
+
+(def ^{:stratum 0} ^:private stream-reader-join-timeout-ms
+  "How long process-stream-lines waits for its daemon reader thread to
+   exit after the stream reader is closed."
+  100)
+
+(defn- ^{:stratum 0} daemon-thread!
+  [thread-name f]
+  (let [thread (Thread. ^Runnable f thread-name)]
+    (.setDaemon thread true)
+    (.start thread)
+    thread))
+
+(defn- ^{:stratum 0} record-stream-line!
+  [out-lines dump-writer on-line last-line-at now line]
+  (reset! last-line-at now)
+  (swap! out-lines conj line)
+  (when dump-writer
+    (.println dump-writer line)
+    (.flush dump-writer))
+  (on-line line))
+
+(defn- ^{:stratum 0} stream-idle-timeout
+  [last-line-at line-timeout-ms out-lines now]
+  (when (>= (- now @last-line-at) line-timeout-ms)
+    {:type :stream-idle
+     :message (str "No stream output for " line-timeout-ms "ms")
+     :elapsed-ms (- now @last-line-at)
+     :stats {:lines-read (count @out-lines)}}))
+
+(defn- ^{:stratum 0} anomaly-signal?
+  [line-or-signal]
+  (anomaly/anomaly? line-or-signal))
+
+(defn ^{:stratum 0} clean-env
+  "Build environment map without CLAUDECODE to allow nested Claude CLI sessions.
+   Returns nil if CLAUDECODE is not set (use default env)."
+  []
+  (when (System/getenv "CLAUDECODE")
+    (into {} (remove (fn [[k _]] (= k "CLAUDECODE"))) (System/getenv))))
+
+(defn- ^{:stratum 0} ->stdin-stream
+  "Build the InputStream passed as the subprocess's stdin. A non-blank
+   :stdin string becomes a ByteArrayInputStream over its UTF-8 bytes;
+   absent or blank stdin maps to a zero-length stream so the
+   subprocess sees EOF immediately (legacy behavior for argv backends)."
+  [stdin-str]
+  (if (and (string? stdin-str) (not (.isEmpty ^String stdin-str)))
+    (ByteArrayInputStream. (.getBytes ^String stdin-str "UTF-8"))
+    (ByteArrayInputStream. (byte-array 0))))
+
+(defn- ^{:stratum 0} apply-process-env!
+  [^ProcessBuilder builder env]
+  (when env
+    (let [target-env (.environment builder)]
+      (.clear target-env)
+      (doseq [[k v] env]
+        (.put target-env k v)))))
+
+(defn- ^{:stratum 0} wait-for-stream-process
+  [^Process process timeout-ms]
+  (if (.waitFor process (long timeout-ms) TimeUnit/MILLISECONDS)
+    {:exit (.exitValue process)}
+    {:exit -1 :err "Process timed out"}))
+
+(def ^{:stratum 0} ^:private keepalive-min-interval-ms
+  "Floor on the keepalive interval so the worker doesn't burn cycles
+   pinging the monitor in a tight loop on production-sized thresholds.
+   1s is plenty fine-grained for a 180+ second stagnation window."
+  1000)
+
+(defn- ^{:stratum 0} network-drop-timeout
+  "Shape the network-monitor's `:on-drop` diagnostic into the same
+   `{:type :message :elapsed-ms ...}` envelope `pm/check-timeout`
+   returns, so the existing `timeout-result` path handles it
+   identically. The PR-C auto-resumer keys on `:type :network-drop` to
+   know it should resume from the last persisted checkpoint."
+  [{:keys [backend-key consecutive-failures probe-interval-ms]
+    :as   diag}]
+  {:type           :network-drop
+   :backend-key    backend-key
+   :elapsed-ms     (* consecutive-failures probe-interval-ms)
+   :message        (format "Network drop: %d consecutive probes failed for %s"
+                           consecutive-failures (name backend-key))
+   :stats          (select-keys diag
+                                [:consecutive-failures :failure-threshold
+                                 :probe-interval-ms])})
+
+(defn- ^{:stratum 0} resolve-prompt-via
+  "Read the backend's declared prompt-delivery mode. Defaults to :argv
+   so backends that pre-date the :prompt-via knob keep their legacy
+   behavior."
+  [backend-config]
+  (get backend-config :prompt-via :argv))
+
+(defn- ^{:stratum 0} exec-opts-for-prompt-via
+  "Build the exec-layer opts map for a given prompt-via + prompt.
+
+   :stdin → {:stdin prompt} so the exec layer pipes the prompt to the
+            subprocess's stdin.
+   :argv  → {} (prompt rides in argv via the args-fn).
+
+   Returning an empty map for :argv lets call sites use `(seq opts)`
+   to decide between the 1-arity and 2-arity exec-fn calls — preserves
+   back-compat with caller-supplied 1-arity exec-fns documented as a
+   public test hook on CLIClient."
+  [prompt-via prompt]
+  (cond-> {} (= prompt-via :stdin) (assoc :stdin prompt)))
+
+(defn- ^{:stratum 0} run-cli-exec
+  "Invoke a CLI exec-fn with cmd plus optional opts. The 1-arity
+   branch keeps caller-supplied exec-fns from the days before opts
+   existed working unchanged; the 2-arity branch threads opts in
+   when they carry signal (e.g. :stdin)."
+  [exec-fn cmd opts]
+  (if (seq opts)
+    (exec-fn cmd opts)
+    (exec-fn cmd)))
+
+(defn ^{:stratum 0} normalize-exec-fn
+  "Wrap an exec-fn so it accepts both 1-arity (cmd) and 2-arity
+   (cmd opts) call patterns.
+
+   `:exec-fn` on `create-client` is a documented public test hook.
+   Pre-:prompt-via callers supplied 1-arity functions; once the
+   :stdin path landed the impl started invoking exec-fn 2-arity for
+   the :claude backend. Without this wrapper a 1-arity user fn
+   would throw ArityException the first time the new code path
+   ran.
+
+   The wrapper probes 2-arity on first 2-arity call and caches the
+   decision in an atom so subsequent calls dispatch directly. The
+   probe only happens when the caller actually passes opts; pure
+   1-arity invocations stay one indirection.
+
+   Returns a fn equivalent to `f` for callers that already accept
+   both arities."
+  [f]
+  (let [arity (atom :unknown)]
+    (fn
+      ([cmd] (f cmd))
+      ([cmd opts]
+       (case @arity
+         :one (f cmd)
+         :two (f cmd opts)
+         (try
+           (let [r (f cmd opts)]
+             (reset! arity :two)
+             r)
+           (catch clojure.lang.ArityException _
+             (reset! arity :one)
+             (f cmd))))))))
+
+(defn ^{:stratum 0} log-prompt-sent [logger backend prompt]
+  (when logger
+    (log/debug logger :system :agent/prompt-sent
+               {:data {:backend backend
+                       :prompt-length (count prompt)}})))
+
+(defn ^{:stratum 0} log-response [logger response]
+  (when logger
+    (if (:success response)
+      (log/debug logger :system :agent/response-received
+                 {:data {:response-length (count (:content response))}})
+      (log/error logger :system :agent/task-failed
+                 {:message (msg/t :backend.system/request-failed)
+                  :data (:error response)}))))
+
+(defn- ^{:stratum 0} record-parsed-progress!
+  [progress-monitor parsed accumulated-content]
+  (cond
+    (:tool-use parsed)
+    (pm/record-activity!
+     progress-monitor
+     (str "tool-use:"
+          (or (:tool-name parsed)
+              (some->> (:tool-names parsed) seq sort (str/join ","))
+              "unknown")))
+
+    ;; Tool-result events are liveness signals — use a stable activity
+    ;; key (not the call-id) so :unique-chunks stays bounded across long
+    ;; tool-heavy runs.
+    (:tool-result parsed)
+    (pm/record-activity! progress-monitor :tool-result)
+
+    (:heartbeat parsed)
+    (pm/record-activity! progress-monitor :stream-heartbeat)
+
+    (contains? parsed :done?)
+    (pm/record-activity! progress-monitor :stream-result)
+
+    :else
+    (pm/record-chunk! progress-monitor @accumulated-content)))
+
+(defn ^{:stratum 0} log-streaming-result [logger timeout-info content-length]
+  (when logger
+    (if timeout-info
+      (log/warn logger :system :agent/streaming-timeout
+                {:message (:message timeout-info)
+                 :data {:type (:type timeout-info)
+                        :elapsed-ms (:elapsed-ms timeout-info)
+                        :stats (:stats timeout-info)}})
+      (log/debug logger :system :agent/streaming-complete
+                 {:data {:response-length content-length}}))))
+
+(defn- ^{:stratum 0} message-preview
+  "Return the last up-to-500 characters of content for post-mortem diagnostics.
+   Returns nil when content is blank."
+  [content]
+  (when (seq content)
+    (subs content (max 0 (- (count content) 500)))))
+
+(defn- ^{:stratum 0} blank-streaming-success?
+  "True when the streaming transport exited 0 but produced no useful parsed output.
+
+   This is the Claude failure mode observed in dogfood on 2026-05-02:
+   the process exited successfully, emitted no parsed stdout blocks, no tool calls,
+   and left the planner with an empty assistant turn. In that case we retry once
+   through the non-streaming path before classifying the invocation as failed."
+  [exit-code final-content tool-call-count usage]
+  (and (zero? exit-code)
+       (str/blank? final-content)
+       (zero? tool-call-count)
+       (nil? usage)))
+
+(def ^{:stratum 0} context-overflow-error-type
+  "Error :type for a prompt that exceeded the model's context window.
+   Terminal: excluded from submission-recovery (the turn has no artifact to
+   recover and a retry just re-sends the over-budget prompt). See N12 §4."
+  "context_overflow")
+
+(defn- ^{:stratum 0} usage-token-count
+  "Return a numeric usage token count, treating missing or malformed values
+   as zero so context accounting remains numeric for upstream payloads."
+  [usage token-key]
+  (let [tokens (get usage token-key)]
+    (if (number? tokens) tokens 0)))
+
+(def ^{:stratum 0} ^:private chars-per-token-estimate
+  "Rough characters-per-token divisor for a pre-flight input-size estimate.
+   ~4 chars/token is the usual English heuristic; this is a coarse gauge of
+   headroom against the model's context window, not a billing figure."
+  4)
+
+(defn ^{:stratum 0} get-config-impl [client]
+  (:config client))
+
+(defn ^{:stratum 0} capsule-exec-fn
+  "Returns an exec-fn that routes CLI commands through a task capsule executor.
+   Used in governed mode so the agent CLI runs inside the Docker/K8s container
+   instead of on the host (N11 §6.2).
+
+   Arguments:
+   - execute-fn  - function [executor env-id command opts] -> result map
+   - executor    - TaskExecutor instance
+   - env-id      - environment/container ID
+   - workdir     - workspace directory inside capsule"
+  [execute-fn executor env-id workdir]
+  (fn [cmd]
+    (let [result (execute-fn executor env-id cmd {:workdir workdir})]
+      (if (and (map? result) (:data result))
+        {:out (get-in result [:data :stdout] "")
+         :err (get-in result [:data :stderr] "")
+         :exit (get-in result [:data :exit-code] 0)}
+        {:out ""
+         :err (str "Capsule exec error: " result)
+         :exit 1}))))
+
+(defn ^{:stratum 0} mock-exec-fn [output & {:keys [exit] :or {exit 0}}]
+  (fn
+    ([_cmd]      {:out output :err "" :exit exit})
+    ([_cmd _opts] {:out output :err "" :exit exit})))
+
+(defn ^{:stratum 0} mock-exec-fn-multi [outputs]
+  (let [call-count (atom 0)
+        respond    (fn []
+                     (let [idx @call-count
+                           output (get outputs idx (last outputs))]
+                       (swap! call-count inc)
+                       {:out output :err "" :exit 0}))]
+    (fn
+      ([_cmd]       (respond))
+      ([_cmd _opts] (respond)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} ^:private client-defaults
+  (delay (load-client-defaults)))
+
+(defn- ^{:stratum 1} ->canonical-anomaly
   "Build a canonical anomaly map from the brick's legacy category
    keyword + message + extra data. Generic-standard categories produce
    `(anomaly/anomaly type msg data)`; domain categories produce
@@ -178,49 +682,7 @@
       (anomaly/anomaly a-type message data)
       (anomaly/sub-anomaly a-type category message data))))
 
-(defn llm-error
-  "Build a failed LLM response with anomaly.
-
-   The `:anomaly` map is canonical (W2 convergence): `:anomaly/type` from
-   the runbook, `:anomaly/subtype` set to the original category for
-   domain categories (so failure-classifier / response/translate dispatch
-   identically). The original `:operation` lives under `:anomaly/data`."
-  ([category error-type message]
-   (llm-error category error-type message nil))
-  ([category error-type message
-    {:keys [exit-code stderr stdout raw-stdout timeout failure-anomaly]}]
-   (cond-> {:success false
-            :error (cond-> {:type error-type :message message}
-                     stderr  (assoc :stderr stderr)
-                     stdout  (assoc :stdout stdout)
-                     raw-stdout (assoc :raw-stdout raw-stdout)
-                     timeout (assoc :timeout timeout))
-            :anomaly (or failure-anomaly
-                         (->canonical-anomaly
-                          category message
-                          {:operation :llm-complete}))}
-     (some? exit-code) (assoc :exit-code exit-code))))
-
-;------------------------------------------------------------------------------ Layer 0
-;; Stream parser functions
-
-(defn- parsed-usage
-  [usage]
-  ;; Capture cache fields: a large prompt lands mostly under cache-creation.
-  ;; Assoc only numeric fields — a present-but-nil key defeats downstream
-  ;; `(get usage :input-tokens 0)` defaulting (NPEs llm-success's :tokens sum).
-  (let [input-tokens (:input_tokens usage)
-        output-tokens (:output_tokens usage)
-        cache-creation (:cache_creation_input_tokens usage)
-        cache-read (:cache_read_input_tokens usage)]
-    (when (some number? [input-tokens output-tokens cache-creation cache-read])
-      (cond-> {}
-        (number? input-tokens)   (assoc :input-tokens input-tokens)
-        (number? output-tokens)  (assoc :output-tokens output-tokens)
-        (number? cache-creation) (assoc :cache-creation-input-tokens cache-creation)
-        (number? cache-read)     (assoc :cache-read-input-tokens cache-read)))))
-
-(defn parse-claude-stream-line
+(defn ^{:stratum 1} parse-claude-stream-line
   "Parse a line from Claude CLI streaming output.
 
    Claude CLI stream-json emits:
@@ -370,24 +832,7 @@
     (catch Exception _e
       nil)))
 
-(defn- normalize-codex-finish-reason
-  "Normalize a Codex finish_reason string to the canonical stop-reason strings
-   used across all backends.
-
-   Codex → canonical mapping:
-   - \"stop\"      → \"end_turn\"     (normal completion)
-   - \"max_turns\" → \"max_turns\"    (turn budget exhausted)
-   - \"length\"    → \"max_tokens\"   (token budget exhausted)
-   - anything else → passed through unchanged"
-  [finish-reason]
-  (when finish-reason
-    (case finish-reason
-      "stop"      "end_turn"
-      "max_turns" "max_turns"
-      "length"    "max_tokens"
-      finish-reason)))
-
-(defn parse-codex-stream-line
+(defn ^{:stratum 1} parse-codex-stream-line
   "Parse a line from Codex CLI streaming output.
 
    Codex emits JSONL events:
@@ -483,41 +928,592 @@
     (catch Exception _e
       nil)))
 
-;------------------------------------------------------------------------------ Backend configurations
-;; Named argument builders — extracted from the backends config map for clarity.
+(def ^{:stratum 1} ^:private backend-data
+  (load-backend-data))
 
-(defn claude-mcp-allowlist-string
-  "Claude CLI's --allowedTools wire format.
+;------------------------------------------------------------------------------ HTTP Backend Support
+(defn ^{:stratum 1} ollama-request-body
+  "Build Ollama API request body. `:num-ctx` sets Ollama's context-window
+   option — without it Ollama applies its own small default and silently
+   truncates long prompts."
+  [{:keys [prompt messages model streaming? num-ctx]}]
+  (let [model (or model "codellama")
+        msg-content (or prompt
+                        (build-messages-prompt messages))]
+    (cond-> {:model model
+             :messages [{:role "user" :content msg-content}]
+             :stream (boolean streaming?)}
+      num-ctx (assoc :options {:num_ctx (long num-ctx)}))))
 
-   Accepts two entry shapes:
-   - `{:mcp/server :mcp/tool}` keyword map → `mcp__<server>__<tool>`
-     (MCP tool; server name comes from the mcp-config.json key)
-   - Keyword by itself → `(name kw)` (native Claude Code tool,
-     e.g. `:Write`)
+(defn ^{:stratum 1} http-post-request
+  "Make HTTP POST request to LLM API.
 
-   Entries are joined with commas. A malformed entry throws via
-   `(name nil)` at the call site."
-  [mcp-allowed-tools]
-  (->> mcp-allowed-tools
-       (mapv (fn [t]
-               (if (keyword? t)
-                 (name t)
-                 (let [{:mcp/keys [server tool]} t]
-                   (str "mcp__" (name server) "__" (name tool))))))
-       (str/join ",")))
+   Returns HTTP response map or canonical anomaly map on failure
+   (W2 convergence: `:anomaly/type :unavailable`, no subtype since
+   `:anomalies/unavailable` is a generic-standard category).
 
-(def ^:private claude-input-format-flag
-  "Claude CLI flag that selects how the user prompt is delivered. Paired
-   with `claude-input-format-stdin` (the only value we use today), this
-   tells the CLI to read the prompt from stdin instead of argv."
-  "--input-format")
+   http-kit signals connection failures via either a thrown exception
+   or a `{:error <Throwable>}` response map (depending on whether the
+   error surfaces before or after the future resolves); both modes
+   collapse to the same canonical anomaly."
+  [url headers body]
+  (try
+    (let [response @(http/post url
+                               {:headers headers
+                                :body (json/generate-string body)})]
+      (if-let [cause (:error response)]
+        (http-failure-anomaly cause url)
+        response))
+    (catch Exception e
+      (http-failure-anomaly e url))))
 
-(def ^:private claude-input-format-stdin
-  "Argument value for `claude-input-format-flag` that switches the CLI
-   to text-on-stdin input mode."
-  "text")
+(defn- ^{:stratum 1} extraction
+  "The `{:content :usage}` shape `parse-provider-response` expects from
+   every extractor — built in one place so the extractors stay pure
+   field mappings."
+  [content input-tokens output-tokens]
+  {:content content
+   :usage (token-usage input-tokens output-tokens)})
 
-(defn- claude-args
+(defn- ^{:stratum 1} http-status->category
+  "Map a non-OK provider HTTP status to the brick's legacy anomaly
+   category, so a 403 classifies as forbidden and a 429 as rate-limited
+   instead of everything collapsing into a generic api_error."
+  [status]
+  (cond
+    (not (integer? status))                              :anomalies/unavailable
+    (or (= status HttpURLConnection/HTTP_UNAUTHORIZED)
+        (= status HttpURLConnection/HTTP_FORBIDDEN))  :anomalies/forbidden
+    (= status HttpURLConnection/HTTP_NOT_FOUND)       :anomalies/not-found
+    (= status http-too-many-requests)                 :anomalies.agent/rate-limited
+    (< status HttpURLConnection/HTTP_INTERNAL_ERROR)  :anomalies/incorrect
+    :else                                             :anomalies/unavailable))
+
+(defn ^{:stratum 1} openai-request-body
+  "Build an OpenAI Chat Completions request body. The system prompt is
+   a leading `system`-role message on this API."
+  [{:keys [system model max-tokens] :as request}]
+  (cond-> {:model model
+           :messages (into (if system [{:role "system" :content system}] [])
+                           (chat-messages request))}
+    max-tokens (assoc :max_completion_tokens max-tokens)))
+
+(defn ^{:stratum 1} gemini-request-body
+  "Build a Gemini generateContent request body. Gemini has no
+   assistant role — prior assistant turns map to `model` — and the
+   system prompt rides in `systemInstruction`."
+  [{:keys [system max-tokens] :as request}]
+  (cond-> {:contents (mapv (fn [{:keys [role content]}]
+                             {:role (if (= role "assistant") "model" "user")
+                              :parts [{:text content}]})
+                           (chat-messages request))}
+    system     (assoc :systemInstruction {:parts [{:text system}]})
+    max-tokens (assoc :generationConfig {:maxOutputTokens max-tokens})))
+
+(defn- ^{:stratum 1} resolve-api-key
+  "Resolve the API key for a direct provider backend: a non-blank
+   `:api-key` in the client config wins; otherwise the backend's
+   `:api-key-env` environment variable. Blank/whitespace values count
+   as absent on BOTH paths — a config map carrying :api-key \"\" (BYOK
+   setups where the key field exists but is empty) must still fall
+   through to the env var. The env path is how the sandboxed app
+   delivers a keychain-held key to the workflow process without it
+   ever touching disk."
+  [backend-config config]
+  (or (some-> (:api-key config) str str/trim not-empty)
+      (some-> (:api-key-env backend-config) getenv-value str str/trim not-empty)))
+
+(defn- ^{:stratum 1} resolve-base-url
+  "The endpoint for the request. Only a backend that declares
+   `:base-url-env` supports overrides — there a non-blank client-config
+   `:base-url` wins, then the env variable. Every other backend always
+   uses its static `:api-endpoint`, so a stray client `:base-url` can
+   never redirect a fixed-endpoint provider."
+  [backend-config config]
+  (or (when (:base-url-env backend-config)
+        (or (some-> (:base-url config) str str/trim not-empty)
+            (some-> (:base-url-env backend-config) getenv-value str str/trim
+                    not-empty)))
+      (:api-endpoint backend-config)))
+
+(defn ^{:stratum 1} timeout-result [out-lines timeout-reason]
+  {:out (str/join "\n" out-lines)
+   :err (format-timeout-error timeout-reason)
+   :exit -1
+   :timeout timeout-reason})
+
+(defn- ^{:stratum 1} read-stream-loop!
+  [out-reader line-queue]
+  (loop []
+    (if-some [line (.readLine out-reader)]
+      (do (enqueue-stream-line! line-queue line)
+          (recur))
+      (enqueue-stream-line! line-queue eof-sentinel))))
+
+(defn- ^{:stratum 1} stop-stream-reader!
+  [^Thread reader-thread out-reader]
+  (try (.close out-reader) (catch Exception _))
+  (.interrupt reader-thread)
+  (.join reader-thread stream-reader-join-timeout-ms))
+
+(defn- ^{:stratum 1} eof-signal?
+  [line-or-signal]
+  (identical? line-or-signal eof-sentinel))
+
+(defn- ^{:stratum 1} timeout-signal
+  [last-line-at line-timeout-ms out-lines]
+  {:done? false
+   :timeout (stream-idle-timeout last-line-at
+                                 line-timeout-ms
+                                 out-lines
+                                 (System/currentTimeMillis))})
+
+(defn- ^{:stratum 1} write-process-stdin!
+  [^Process process stdin-str]
+  (daemon-thread!
+   "llm-stream-stdin-writer"
+   (fn []
+     (try
+       (with-open [out (.getOutputStream process)
+                   in (->stdin-stream stdin-str)]
+         (io/copy in out))
+       (catch Exception _
+         nil)))))
+
+(defn- ^{:stratum 1} read-process-stream!
+  [thread-name input-stream output]
+  (daemon-thread!
+   thread-name
+   (fn []
+     (try
+       (reset! output (slurp input-stream))
+       (catch Exception e
+         (reset! output (or (ex-message e) (str e))))))))
+
+(defn- ^{:stratum 1} stop-stream-process!
+  [{:keys [^Process process stdin-thread stderr-thread stderr]} timeout? join-timeout]
+  (when timeout?
+    (try (.destroyForcibly process) (catch Exception _ nil)))
+  (let [result (wait-for-stream-process process join-timeout)]
+    (when stdin-thread
+      (.join ^Thread stdin-thread stream-reader-join-timeout-ms))
+    (when stderr-thread
+      (.join ^Thread stderr-thread stream-reader-join-timeout-ms))
+    (assoc result :err @stderr)))
+
+(defn ^{:stratum 1} build-request-prompt [request]
+  (or (:prompt request)
+      (build-messages-prompt (:messages request))))
+
+(defn ^{:stratum 1} stream-with-parser
+  [stream-parser on-chunk progress-monitor accumulated-content accumulated-usage accumulated-cost accumulated-tools accumulated-session-id accumulated-stop-reason accumulated-turns]
+  (fn [line]
+    (when-let [parsed (stream-parser line)]
+      (when-let [usage (:usage parsed)]
+        (swap! accumulated-usage (fn [prev] (merge prev usage))))
+      (when-let [cost (:cost-usd parsed)]
+        (reset! accumulated-cost cost))
+      (when-let [session-id (:session-id parsed)]
+        (reset! accumulated-session-id session-id))
+      (when-let [sr (:stop-reason parsed)]
+        (reset! accumulated-stop-reason sr))
+      ;; Claude surfaces num_turns as an absolute count on the result event.
+      (when-let [nt (:num-turns parsed)]
+        (reset! accumulated-turns nt))
+      ;; Claude may surface the final assistant text only on the terminal
+      ;; result event. Preserve previously streamed content when present,
+      ;; but recover result-only output when no assistant delta arrived.
+      (when-let [final-content (:final-content parsed)]
+        (when (and (string? final-content)
+                   (str/blank? @accumulated-content)
+                   (not (str/blank? final-content)))
+          (reset! accumulated-content final-content)))
+      ;; Codex signals each completed turn via :increment-turns rather than
+      ;; emitting an absolute count — bump the accumulator on each one.
+      (when (:increment-turns parsed)
+        (swap! accumulated-turns (fnil inc 0)))
+      (if (or (:tool-use parsed) (:tool-result parsed) (:heartbeat parsed))
+        ;; Tool-use, tool-result, and heartbeat events: track tool names and
+        ;; fire on-chunk without appending anything to accumulated-content.
+        (do
+          (when-let [tool-name (:tool-name parsed)]
+            (swap! accumulated-tools conj tool-name))
+          (when-let [tool-names (:tool-names parsed)]
+            (swap! accumulated-tools into tool-names))
+          (record-parsed-progress! progress-monitor parsed accumulated-content)
+          (on-chunk (assoc parsed :content @accumulated-content)))
+        ;; Normal text deltas
+        (when-let [delta (:delta parsed)]
+          (swap! accumulated-content str delta)
+          (record-parsed-progress! progress-monitor parsed accumulated-content)
+          (on-chunk (assoc parsed :content @accumulated-content)))))))
+
+(defn ^{:stratum 1} total-input-tokens
+  "prompt + cache-creation + cache-read tokens. Summed because a large
+   prompt lands mostly under cache-creation, not :input-tokens. See N12 §2."
+  [usage]
+  (+ (usage-token-count usage :input-tokens)
+     (usage-token-count usage :cache-creation-input-tokens)
+     (usage-token-count usage :cache-read-input-tokens)))
+
+(defn ^{:stratum 1} prompt-size-telemetry
+  "Pre-flight size gauge over the assembled system + user prompt, computed
+   BEFORE dispatch so it survives a context-overflow rejection (where
+   `:usage` never arrives). `:estimated-input-tokens` is a coarse chars/4
+   estimate, rounded UP so a near-boundary prompt isn't under-reported.
+   See N12 §3."
+  [system prompt]
+  (let [system-chars (count (or system ""))
+        user-chars   (count (or prompt ""))
+        total-chars  (+ system-chars user-chars)]
+    {:system-chars system-chars
+     :user-chars user-chars
+     :total-chars total-chars
+     ;; ceil division (stay conservative for a headroom gauge)
+     :estimated-input-tokens (quot (+ total-chars (dec chars-per-token-estimate))
+                                   chars-per-token-estimate)}))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- ^{:stratum 2} client-default
+  [path]
+  (get-in @client-defaults path))
+
+(defn ^{:stratum 2} llm-error
+  "Build a failed LLM response with anomaly.
+
+   The `:anomaly` map is canonical (W2 convergence): `:anomaly/type` from
+   the runbook, `:anomaly/subtype` set to the original category for
+   domain categories (so failure-classifier / response/translate dispatch
+   identically). The original `:operation` lives under `:anomaly/data`."
+  ([category error-type message]
+   (llm-error category error-type message nil))
+  ([category error-type message
+    {:keys [exit-code stderr stdout raw-stdout timeout failure-anomaly]}]
+   (cond-> {:success false
+            :error (cond-> {:type error-type :message message}
+                     stderr  (assoc :stderr stderr)
+                     stdout  (assoc :stdout stdout)
+                     raw-stdout (assoc :raw-stdout raw-stdout)
+                     timeout (assoc :timeout timeout))
+            :anomaly (or failure-anomaly
+                         (->canonical-anomaly
+                          category message
+                          {:operation :llm-complete}))}
+     (some? exit-code) (assoc :exit-code exit-code))))
+
+(defn- ^{:stratum 2} request-endpoint
+  "Resolve the request URL. Gemini embeds the model in the URL path
+   (`:model-in-url?`); the other providers take it in the body."
+  [backend-config request config]
+  (let [endpoint (resolve-base-url backend-config config)]
+    (if (:model-in-url? backend-config)
+      (format endpoint (:model request))
+      endpoint)))
+
+(defn- ^{:stratum 2} extract-anthropic
+  "Text + usage from an Anthropic Messages response: join the `text`
+   content blocks (tool-use and thinking blocks carry no answer text)."
+  [body]
+  (extraction (->> (:content body)
+                   (keep (fn [block] (when (= "text" (:type block)) (:text block))))
+                   (str/join))
+              (get-in body [:usage :input_tokens])
+              (get-in body [:usage :output_tokens])))
+
+(defn- ^{:stratum 2} extract-openai
+  "Text + usage from an OpenAI Chat Completions response."
+  [body]
+  (extraction (get-in body [:choices 0 :message :content])
+              (get-in body [:usage :prompt_tokens])
+              (get-in body [:usage :completion_tokens])))
+
+(defn- ^{:stratum 2} extract-gemini
+  "Text + usage from a Gemini generateContent response: join the text
+   parts of the first candidate."
+  [body]
+  (extraction (->> (get-in body [:candidates 0 :content :parts])
+                   (keep :text)
+                   (str/join))
+              (get-in body [:usageMetadata :promptTokenCount])
+              (get-in body [:usageMetadata :candidatesTokenCount])))
+
+(defn- ^{:stratum 2} start-stream-reader!
+  "Start the daemon that drains `out-reader` into `line-queue`.
+
+   Three exit shapes:
+   1. EOF — `read-stream-loop!` enqueues the eof sentinel and returns; thread
+      exits cleanly.
+   2. Clean shutdown via `stop-stream-reader!` — the consumer
+      (`process-stream-lines`) has stopped polling, so `stop-stream-reader!`
+      closes the reader and calls `.interrupt`. `BufferedReader.readLine`
+      is NOT interruptible, so a reader blocked there unblocks via the
+      `.close` (the read returns nil or throws `IOException`). A reader
+      blocked in `.put` on a full queue unblocks via the `.interrupt` and
+      raises `InterruptedException`. Both cases land in the same silent
+      catch: the consumer already left the queue; no anomaly to publish.
+   3. Real read error — surface as a `stream-read-failure` anomaly so the
+      consumer sees it. The inner try/catch around the anomaly enqueue
+      guards against a sticky-interrupt race during cleanup (the thread's
+      interrupt flag is still set from case 2, so `.put` here can throw IE
+      too — swallow it; the consumer is already gone).
+
+   Pre-fix, case 2 was caught by the generic `(catch Exception e ...)` which
+   then called `enqueue-stream-line!` → `.put` → a second IE that bubbled out
+   of the runnable to the JVM default exception handler and printed an ugly
+   stack trace to stderr. The 2026-06-04 eliminate-requiring-resolve dogfood
+   surfaced 18 of these IEs across 20 sub-tasks — pure log noise, zero
+   workflow impact, but enough to look like a real bug in post-run triage."
+  [out-reader line-queue]
+  (daemon-thread!
+   "llm-stream-reader"
+   (fn []
+     (try
+       (read-stream-loop! out-reader line-queue)
+       (catch InterruptedException _
+         ;; clean shutdown — consumer already exited; nothing to report
+         nil)
+       (catch Exception e
+         (try
+           (enqueue-stream-line! line-queue (stream-read-failure e))
+           (catch InterruptedException _
+             ;; the stop-stream-reader! interrupt raced this catch
+             nil)))))))
+
+(defn- ^{:stratum 2} process-stream-signal
+  [line-or-signal out-lines dump-writer on-line last-line-at line-timeout-ms]
+  (cond
+    (anomaly-signal? line-or-signal)
+    {:done? true
+     :anomaly line-or-signal}
+
+    (eof-signal? line-or-signal)
+    {:done? true}
+
+    (some? line-or-signal)
+    (do (record-stream-line! out-lines
+                             dump-writer
+                             on-line
+                             last-line-at
+                             (System/currentTimeMillis)
+                             line-or-signal)
+        {:done? false})
+
+    :else
+    (timeout-signal last-line-at line-timeout-ms out-lines)))
+
+(defn- ^{:stratum 2} read-process-stderr!
+  [^Process process stderr]
+  (read-process-stream! "llm-stream-stderr-reader"
+                        (.getErrorStream process)
+                        stderr))
+
+(defn- ^{:stratum 2} start-capture-process!
+  [cmd {:keys [workdir stdin]}]
+  (let [builder (ProcessBuilder. ^java.util.List cmd)]
+    (when-let [env (clean-env)]
+      (apply-process-env! builder env))
+    (when workdir
+      (.directory builder (io/file workdir)))
+    (let [process (.start builder)
+          stdout (atom "")
+          stderr (atom "")
+          stdin-thread (write-process-stdin! process stdin)
+          stdout-thread (read-process-stream! "llm-stdout-reader"
+                                             (.getInputStream process)
+                                             stdout)
+          stderr-thread (read-process-stream! "llm-stderr-reader"
+                                             (.getErrorStream process)
+                                             stderr)]
+      {:process process
+       :stdout stdout
+       :stderr stderr
+       :stdin-thread stdin-thread
+       :stdout-thread stdout-thread
+       :stderr-thread stderr-thread})))
+
+(defn ^{:stratum 2} context-overflow-by-usage?
+  "True when total input tokens >= the model's context window — the
+   structured, locale/backend-independent overflow signal (N12 §4).
+   `context-window` is nil for uncatalogued models → no assertion."
+  [usage context-window]
+  (boolean (and context-window
+                (pos? (total-input-tokens usage))
+                (>= (total-input-tokens usage) context-window))))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn- ^{:stratum 3} default-claude-cli-budget-usd
+  []
+  (client-default [:claude-cli :default-budget-usd]))
+
+(defn- ^{:stratum 3} anthropic-api-version
+  []
+  (client-default [:http :anthropic :api-version]))
+
+(defn- ^{:stratum 3} default-anthropic-max-tokens
+  []
+  (client-default [:http :anthropic :default-max-tokens]))
+
+;; ---------------------------------------------------------------------------
+;; Stream-timing constants
+;;
+;; Names spell out intent so the surrounding code reads as the why,
+;; not the what. Tuning history lives in inline doc-comments next to
+;; each constant.
+(defn- ^{:stratum 3} default-stagnation-threshold-ms
+  []
+  (client-default [:stream :default-stagnation-threshold-ms]))
+
+(defn- ^{:stratum 3} default-max-total-ms
+  []
+  (client-default [:stream :default-max-total-ms]))
+
+(defn- ^{:stratum 3} default-min-activity-interval-ms
+  []
+  (client-default [:stream :default-min-activity-interval-ms]))
+
+(defn- ^{:stratum 3} stream-line-timeout-ms
+  []
+  (client-default [:stream :line-timeout-ms]))
+
+(defn- ^{:stratum 3} process-join-timeout-ms
+  []
+  (client-default [:stream :process-join-timeout-ms]))
+
+(defn- ^{:stratum 3} post-kill-join-timeout-ms
+  []
+  (client-default [:stream :post-kill-join-timeout-ms]))
+
+(defn- ^{:stratum 3} stream-poll-interval-ms
+  []
+  (client-default [:stream :poll-interval-ms]))
+
+(defn- ^{:stratum 3} provider-http-error->llm-error
+  "Build the canonical failure for a non-OK provider response: the
+   category classifies by status class, and the message preserves the
+   status alongside the provider's own error text."
+  [{:keys [status message]}]
+  (llm-error (http-status->category status)
+             "api_error"
+             (msg/t :http-provider.system/api-error
+                    {:status status
+                     :message (or message
+                                  (msg/t :http-provider.system/unknown-api-error))})))
+
+(defn- ^{:stratum 3} response-parse-error
+  "Wrap a canonical JSON-parse anomaly in the LLM failure shape without
+   discarding its operation, HTTP status, or exception provenance."
+  [parse-anomaly]
+  (llm-error :anomalies/fault
+             "parse_error"
+             (:anomaly/message parse-anomaly)
+             {:failure-anomaly parse-anomaly}))
+
+(defn ^{:stratum 3} success-response
+  ([output exit-code]
+   (success-response output exit-code nil))
+  ([output exit-code stderr]
+  (let [trimmed (str/trim output)]
+    (cond
+      (str/blank? trimmed)
+      (llm-error :anomalies.agent/llm-error "empty_success_output"
+                 "CLI backend exited successfully but produced no output"
+                 {:exit-code exit-code :stderr stderr :stdout output})
+
+      (rate-limited? trimmed)
+      (llm-error :anomalies.agent/rate-limited "rate_limit"
+                 (str "Claude CLI rate limited: " trimmed)
+                 {:exit-code exit-code :stdout output})
+
+      :else
+      (cond-> (llm-success trimmed {:exit-code exit-code})
+        (seq stderr) (assoc :stderr stderr))))))
+
+(defn ^{:stratum 3} error-response [output exit-code stderr]
+  (let [error-message (if (and stderr (str/blank? output)) stderr output)]
+    (llm-error :anomalies.agent/llm-error "cli_error" (str/trim error-message)
+               {:exit-code exit-code :stderr stderr :stdout output})))
+
+(defn- ^{:stratum 3} start-stream-process!
+  [cmd {:keys [workdir stdin]}]
+  (let [builder (ProcessBuilder. ^java.util.List cmd)]
+    (when-let [env (clean-env)]
+      (apply-process-env! builder env))
+    (when workdir
+      (.directory builder (io/file workdir)))
+    (let [process (.start builder)
+          stderr (atom "")
+          stdin-thread (write-process-stdin! process stdin)
+          stderr-thread (read-process-stderr! process stderr)]
+      {:process process
+       :stderr stderr
+       :stdin-thread stdin-thread
+       :stderr-thread stderr-thread})))
+
+(defn ^{:stratum 3} streaming-success-response
+  "Build a streaming success response with diagnostic metadata.
+
+   Diagnostic fields added to the response map:
+   - :stop-reason          — why the model stopped (\"end_turn\", \"max_turns\", etc.)
+   - :num-turns            — number of conversation turns consumed
+   - :tool-call-count      — total number of tool invocations during the run
+   - :final-message-preview — last 500 chars of accumulated content (post-mortem aid)"
+  [content exit-code usage cost-usd stop-reason num-turns tool-call-count final-message-preview stderr]
+  (if (rate-limited? content)
+    (llm-error :anomalies.agent/rate-limited "rate_limit"
+               (str "Claude CLI rate limited: " (str/trim content))
+               {:exit-code exit-code :stdout content
+                :stop-reason stop-reason :num-turns num-turns})
+    (cond-> (llm-success content {:exit-code exit-code :usage usage})
+      cost-usd                    (assoc :cost-usd cost-usd)
+      stop-reason                 (assoc :stop-reason stop-reason)
+      num-turns                   (assoc :num-turns num-turns)
+      (some? tool-call-count)     (assoc :tool-call-count tool-call-count)
+      (seq final-message-preview) (assoc :final-message-preview final-message-preview)
+      (seq stderr)                (assoc :stderr stderr))))
+
+(defn ^{:stratum 3} streaming-error-response
+  "Build a streaming error response with diagnostic metadata.
+
+   Diagnostic fields added to the response map (alongside :success/:error/:anomaly):
+   - :stop-reason          — last observed stop reason before failure
+   - :num-turns            — number of conversation turns consumed
+   - :tool-call-count      — total number of tool invocations during the run
+   - :final-message-preview — last 500 chars of accumulated content (post-mortem aid)
+
+   `usage` + `context-window` drive context-overflow classification (N12 §4);
+   optional — the 9-arity form skips it (for callers without them)."
+  ([content exit-code err-result raw-stdout timeout-info stop-reason num-turns
+    tool-call-count final-message-preview]
+   (streaming-error-response content exit-code err-result raw-stdout timeout-info
+                             stop-reason num-turns tool-call-count
+                             final-message-preview nil nil))
+  ([content exit-code err-result raw-stdout timeout-info stop-reason num-turns
+    tool-call-count final-message-preview usage context-window]
+   (let [error-message (or (not-empty (str/trim (or err-result "")))
+                           (when-not (str/blank? content) content)
+                           (not-empty (str/trim (or raw-stdout "")))
+                           (msg/t :streaming-error.system/no-output))
+         category (if timeout-info :anomalies/timeout :anomalies.agent/llm-error)
+         error-type (cond
+                      timeout-info "adaptive_timeout"
+                      (context-overflow-by-usage? usage context-window) context-overflow-error-type
+                      :else "cli_error")]
+     (cond-> (llm-error category error-type (str/trim error-message)
+                        {:exit-code exit-code
+                         :stderr err-result
+                         :stdout content
+                         :raw-stdout raw-stdout
+                         :timeout timeout-info})
+       stop-reason                 (assoc :stop-reason stop-reason)
+       num-turns                   (assoc :num-turns num-turns)
+       (some? tool-call-count)     (assoc :tool-call-count tool-call-count)
+       (seq final-message-preview) (assoc :final-message-preview final-message-preview)))))
+
+;------------------------------------------------------------------------------ Layer 4
+
+(defn- ^{:stratum 4} claude-args
   "Build CLI arguments for the Claude backend.
 
    Prompt delivery is controlled by `:prompt-via` on the request map:
@@ -574,259 +1570,7 @@
       resume                       (into ["--resume" resume])
       (not stdin?)                 (conj prompt))))
 
-(defn- codex-args
-  "Build CLI arguments for the Codex backend."
-  [{:keys [prompt model system prompt-via]
-    :or {prompt-via :stdin}}]
-  (let [stdin? (= prompt-via :stdin)]
-    (cond-> ["exec"
-             "--json"
-             "--ignore-user-config"
-             "--sandbox=workspace-write"
-             "--skip-git-repo-check"]
-      true   (into ["-c" "approval_policy=never"])
-      model  (into ["-m" model])
-      system (into ["-c" (str "system_prompt=" (json/generate-string system))])
-      stdin? (conj "-")
-      (not stdin?) (conj prompt))))
-
-(defn- cursor-args
-  "Build CLI arguments for the Cursor backend (binary `agent`).
-
-   Flags follow https://cursor.com/docs/cli/reference/parameters:
-
-     -p / --print  non-interactive run with tool access
-     --force       required for the agent to write files in print mode;
-                   this is the autonomous-execution switch (analogous to
-                   codex `approval_policy=never`)
-
-   Tool restriction is enforced out-of-band via the default-deny
-   .cursor/cli.json permissions allowlist written by the agent session
-   (see artifact-session/write-cursor-permissions!), not via CLI flags —
-   so we do not pass --approve-mcps (which would blanket-approve every MCP
-   server). Cursor exposes no system-prompt flag, so `system` is prepended
-   to the user prompt."
-  [{:keys [prompt system model]}]
-  (let [prompt (if system (str system "\n\n" prompt) prompt)]
-    (cond-> ["-p" "--force"]
-      model (into ["--model" model])
-      true  (conj prompt))))
-
-(defn- opencode-args
-  "Build CLI arguments for the OpenCode backend.
-
-   OpenCode owns provider credentials, model aliases, project config,
-   agent profiles, MCP config, and permissions. Miniforge passes the
-   selected model/profile knobs through and treats OpenCode as the
-   common provider wrapper instead of handling API keys directly."
-  [{:keys [prompt model agent attach command session continue? fork? files format]}]
-  (cond-> ["run"]
-    attach    (into ["--attach" attach])
-    command   (into ["--command" command])
-    continue? (conj "--continue")
-    session   (into ["--session" session])
-    fork?     (conj "--fork")
-    model     (into ["--model" model])
-    agent     (into ["--agent" agent])
-    (seq files) (into (mapcat (fn [file] ["--file" file]) files))
-    format    (into ["--format" format])
-    true      (conj prompt)))
-
-(defn- echo-args
-  "Build CLI arguments for the echo (test) backend."
-  [{:keys [prompt]}]
-  [prompt])
-
-;; `:probe-endpoint` on each backend entry is the stable provider edge
-;; URL that the network-monitor (PR-B) probes via
-;; `network-health/network-healthy?`. We only care that the connection
-;; completed, not the response status — a 4xx is the typical case (HEAD
-;; against api.anthropic.com unauthenticated returns 405). Backends
-;; without a provider-controlled endpoint (`:echo`) get the generic
-;; Cloudflare DNS connectivity URL so the monitor still has something
-;; to probe.
-(def ^:private generic-connectivity-probe-url
-  "https://1.1.1.1/")
-
-;; Pure-data backend fields (`:cmd`, endpoints, `:default-model`,
-;; `:models`, etc.) live in `llm/backends.edn`; the function-valued
-;; fields (`:stream-parser`, `:args-fn`) stay here because they
-;; reference parser/arg-builder fns defined in this namespace. The two
-;; are merged per backend below to form `backends`.
-(defn- load-backend-data
-  []
-  (if-let [resource (io/resource "llm/backends.edn")]
-    (edn/read-string (slurp resource))
-    (response/throw-anomaly! :anomalies/not-found
-                             "Missing llm/backends.edn resource")))
-
-(def ^:private backend-data
-  (load-backend-data))
-
-;; Function-valued backend fields. The :ollama entry is intentionally
-;; absent (it has none); OpenCode loads credentials from its auth
-;; store, environment, or project .env/config, so Miniforge should not
-;; read provider-specific keys on that path.
-(def ^:private backend-fns
-  {:claude {:stream-parser parse-claude-stream-line
-            :args-fn claude-args}
-   :codex {:stream-parser parse-codex-stream-line
-           :args-fn codex-args}
-   :cursor {:args-fn cursor-args}
-   :opencode {:args-fn opencode-args}
-   :echo {:args-fn echo-args}})
-
-(def backends
-  (merge-with merge backend-data backend-fns))
-
-(defn probe-endpoint-for
-  "Resolve the network-health probe URL for `backend-key`. Returns the
-   backend entry's `:probe-endpoint` when set, the generic Cloudflare
-   DNS connectivity URL otherwise (covers unknown backends and any
-   future entry added without an explicit endpoint).
-
-   The caller (e.g. `stream-exec-fn` in PR-B) resolves the URL here and
-   passes it to `network-health/network-healthy?` directly, keeping
-   that namespace endpoint-agnostic and free of backend-config
-   dependencies."
-  [backend-key]
-  (or (get-in backends [backend-key :probe-endpoint])
-      generic-connectivity-probe-url))
-
-(defn build-messages-prompt [messages]
-  (->> messages
-       (map (fn [{:keys [role content]}]
-              (case role
-                "user" content
-                "assistant" (str "[Assistant]: " content)
-                "system" (str "[System]: " content)
-                content)))
-       (str/join "\n\n")))
-
-;------------------------------------------------------------------------------ HTTP Backend Support
-
-(defn ollama-request-body
-  "Build Ollama API request body. `:num-ctx` sets Ollama's context-window
-   option — without it Ollama applies its own small default and silently
-   truncates long prompts."
-  [{:keys [prompt messages model streaming? num-ctx]}]
-  (let [model (or model "codellama")
-        msg-content (or prompt
-                        (build-messages-prompt messages))]
-    (cond-> {:model model
-             :messages [{:role "user" :content msg-content}]
-             :stream (boolean streaming?)}
-      num-ctx (assoc :options {:num_ctx (long num-ctx)}))))
-
-(defn- http-failure-anomaly
-  "Build the canonical `:unavailable` anomaly that this brick emits for
-   any HTTP-layer failure on an LLM call (thrown exception or http-kit
-   `{:error <Throwable>}` deref). Centralizes the shape so the throwing
-   and non-throwing failure modes converge."
-  [^Throwable cause url]
-  (anomaly/anomaly
-   :unavailable
-   (str "HTTP request failed: " (.getMessage cause))
-   {:operation :http-request
-    :url url}))
-
-(defn http-post-request
-  "Make HTTP POST request to LLM API.
-
-   Returns HTTP response map or canonical anomaly map on failure
-   (W2 convergence: `:anomaly/type :unavailable`, no subtype since
-   `:anomalies/unavailable` is a generic-standard category).
-
-   http-kit signals connection failures via either a thrown exception
-   or a `{:error <Throwable>}` response map (depending on whether the
-   error surfaces before or after the future resolves); both modes
-   collapse to the same canonical anomaly."
-  [url headers body]
-  (try
-    (let [response @(http/post url
-                               {:headers headers
-                                :body (json/generate-string body)})]
-      (if-let [cause (:error response)]
-        (http-failure-anomaly cause url)
-        response))
-    (catch Exception e
-      (http-failure-anomaly e url))))
-
-(defn- token-usage
-  "Build the canonical usage map, keeping only numeric fields — a
-   present-but-nil key defeats downstream `(get usage :input-tokens 0)`
-   defaulting (same trap `parsed-usage` guards against)."
-  [input-tokens output-tokens]
-  (cond-> {}
-    (number? input-tokens)  (assoc :input-tokens input-tokens)
-    (number? output-tokens) (assoc :output-tokens output-tokens)))
-
-(defn- extraction
-  "The `{:content :usage}` shape `parse-provider-response` expects from
-   every extractor — built in one place so the extractors stay pure
-   field mappings."
-  [content input-tokens output-tokens]
-  {:content content
-   :usage (token-usage input-tokens output-tokens)})
-
-(def ^:private http-too-many-requests
-  "HTTP 429. `java.net.HttpURLConnection` predates RFC 6585 and has no
-   constant for it; the other status literals in this namespace come
-   from that class."
-  429)
-
-(defn- http-status->category
-  "Map a non-OK provider HTTP status to the brick's legacy anomaly
-   category, so a 403 classifies as forbidden and a 429 as rate-limited
-   instead of everything collapsing into a generic api_error."
-  [status]
-  (cond
-    (not (integer? status))                              :anomalies/unavailable
-    (or (= status HttpURLConnection/HTTP_UNAUTHORIZED)
-        (= status HttpURLConnection/HTTP_FORBIDDEN))  :anomalies/forbidden
-    (= status HttpURLConnection/HTTP_NOT_FOUND)       :anomalies/not-found
-    (= status http-too-many-requests)                 :anomalies.agent/rate-limited
-    (< status HttpURLConnection/HTTP_INTERNAL_ERROR)  :anomalies/incorrect
-    :else                                             :anomalies/unavailable))
-
-(defn- parse-response-body
-  "Parse a response body as JSON, returning a canonical fault anomaly when
-   the JSON library throws. Callers retain the HTTP status alongside this
-   value so a non-OK response remains a status failure, not a parse failure."
-  [{:keys [status body]}]
-  (try+
-    (json/parse-string body true)
-    (catch Exception e
-      (anomaly/exception-anomaly
-       :fault
-       (msg/t :http-provider.system/parse-failed
-              {:reason (ex-message e)})
-       {:operation :parse-provider-response
-        :status status}
-       e))))
-
-(defn- provider-http-error->llm-error
-  "Build the canonical failure for a non-OK provider response: the
-   category classifies by status class, and the message preserves the
-   status alongside the provider's own error text."
-  [{:keys [status message]}]
-  (llm-error (http-status->category status)
-             "api_error"
-             (msg/t :http-provider.system/api-error
-                    {:status status
-                     :message (or message
-                                  (msg/t :http-provider.system/unknown-api-error))})))
-
-(defn- response-parse-error
-  "Wrap a canonical JSON-parse anomaly in the LLM failure shape without
-   discarding its operation, HTTP status, or exception provenance."
-  [parse-anomaly]
-  (llm-error :anomalies/fault
-             "parse_error"
-             (:anomaly/message parse-anomaly)
-             {:failure-anomaly parse-anomaly}))
-
-(defn parse-ollama-response
+(defn ^{:stratum 4} parse-ollama-response
   "Parse Ollama API response.
 
    Handles canonical anomaly maps from http-post-request or HTTP
@@ -854,26 +1598,7 @@
                      {:usage (token-usage (:prompt_eval_count body)
                                           (:eval_count body))})))))
 
-;------------------------------------------------------------------------------ Direct provider requests
-;; Request/response shaping for the API-key HTTP backends
-;; (:anthropic-api / :openai-api / :gemini-api) used where CLI-agent
-;; backends cannot run — a sandboxed (Mac App Store) child process
-;; inherits the sandbox, so the user's claude/codex CLI wakes up
-;; without its config or keychain. Each provider is a body builder +
-;; response extractor pair; transport and error shaping are shared
-;; (`http-post-request`, `parse-provider-response`).
-
-(defn- chat-messages
-  "Normalize a request to the wire-shape message vector shared by the
-   chat-style provider APIs: a `:prompt` string becomes a single user
-   message; an explicit `:messages` vector passes through with only
-   the wire-relevant keys."
-  [{:keys [prompt messages]}]
-  (if prompt
-    [{:role "user" :content prompt}]
-    (mapv (fn [m] (select-keys m [:role :content])) messages)))
-
-(defn anthropic-request-body
+(defn ^{:stratum 4} anthropic-request-body
   "Build an Anthropic Messages API request body. `max_tokens` is
    mandatory on this API, so an absent or nil `:max-tokens` falls back
    to the configured default — callers pass {:max-tokens nil} through
@@ -885,28 +1610,7 @@
            :messages (chat-messages request)}
     system (assoc :system system)))
 
-(defn openai-request-body
-  "Build an OpenAI Chat Completions request body. The system prompt is
-   a leading `system`-role message on this API."
-  [{:keys [system model max-tokens] :as request}]
-  (cond-> {:model model
-           :messages (into (if system [{:role "system" :content system}] [])
-                           (chat-messages request))}
-    max-tokens (assoc :max_completion_tokens max-tokens)))
-
-(defn gemini-request-body
-  "Build a Gemini generateContent request body. Gemini has no
-   assistant role — prior assistant turns map to `model` — and the
-   system prompt rides in `systemInstruction`."
-  [{:keys [system max-tokens] :as request}]
-  (cond-> {:contents (mapv (fn [{:keys [role content]}]
-                             {:role (if (= role "assistant") "model" "user")
-                              :parts [{:text content}]})
-                           (chat-messages request))}
-    system     (assoc :systemInstruction {:parts [{:text system}]})
-    max-tokens (assoc :generationConfig {:maxOutputTokens max-tokens})))
-
-(defn- provider-headers
+(defn- ^{:stratum 4} provider-headers
   "Auth + protocol headers for a direct provider request. Each provider
    spells the API-key header differently; only Anthropic versions its
    wire protocol via a header. The default arm covers Ollama, which is
@@ -927,49 +1631,7 @@
                  "x-goog-api-key" api-key}
     {"Content-Type" "application/json"}))
 
-(defn getenv-value
-  "Indirection over `System/getenv` so env-dependent backend resolution
-   (api-key, base-url) is testable via `with-redefs` (kept public like
-   `http-post-request` for exactly that reason)."
-  [k]
-  (System/getenv k))
-
-(defn- resolve-api-key
-  "Resolve the API key for a direct provider backend: a non-blank
-   `:api-key` in the client config wins; otherwise the backend's
-   `:api-key-env` environment variable. Blank/whitespace values count
-   as absent on BOTH paths — a config map carrying :api-key \"\" (BYOK
-   setups where the key field exists but is empty) must still fall
-   through to the env var. The env path is how the sandboxed app
-   delivers a keychain-held key to the workflow process without it
-   ever touching disk."
-  [backend-config config]
-  (or (some-> (:api-key config) str str/trim not-empty)
-      (some-> (:api-key-env backend-config) getenv-value str str/trim not-empty)))
-
-(defn- resolve-base-url
-  "The endpoint for the request. Only a backend that declares
-   `:base-url-env` supports overrides — there a non-blank client-config
-   `:base-url` wins, then the env variable. Every other backend always
-   uses its static `:api-endpoint`, so a stray client `:base-url` can
-   never redirect a fixed-endpoint provider."
-  [backend-config config]
-  (or (when (:base-url-env backend-config)
-        (or (some-> (:base-url config) str str/trim not-empty)
-            (some-> (:base-url-env backend-config) getenv-value str str/trim
-                    not-empty)))
-      (:api-endpoint backend-config)))
-
-(defn- request-endpoint
-  "Resolve the request URL. Gemini embeds the model in the URL path
-   (`:model-in-url?`); the other providers take it in the body."
-  [backend-config request config]
-  (let [endpoint (resolve-base-url backend-config config)]
-    (if (:model-in-url? backend-config)
-      (format endpoint (:model request))
-      endpoint)))
-
-(defn- parse-provider-response
+(defn- ^{:stratum 4} parse-provider-response
   "Shared response handling for the direct provider backends: a
    transport-layer anomaly converts to the canonical http_error
    failure; otherwise JSON parse, HTTP status check, then
@@ -1002,34 +1664,82 @@
                        (msg/t :http-provider.system/no-generated-text))
             (llm-success content {:usage usage})))))))
 
-(defn- extract-anthropic
-  "Text + usage from an Anthropic Messages response: join the `text`
-   content blocks (tool-use and thinking blocks carry no answer text)."
-  [body]
-  (extraction (->> (:content body)
-                   (keep (fn [block] (when (= "text" (:type block)) (:text block))))
-                   (str/join))
-              (get-in body [:usage :input_tokens])
-              (get-in body [:usage :output_tokens])))
+(defn ^{:stratum 4} parse-cli-output
+  ([output exit-code]
+   (parse-cli-output output exit-code nil))
+  ([output exit-code stderr]
+   (if (zero? exit-code)
+     (success-response output exit-code stderr)
+     (error-response output exit-code stderr))))
 
-(defn- extract-openai
-  "Text + usage from an OpenAI Chat Completions response."
-  [body]
-  (extraction (get-in body [:choices 0 :message :content])
-              (get-in body [:usage :prompt_tokens])
-              (get-in body [:usage :completion_tokens])))
+(defn ^{:stratum 4} default-progress-monitor []
+  (pm/create-progress-monitor
+   {:stagnation-threshold-ms  (default-stagnation-threshold-ms)
+    :max-total-ms             (default-max-total-ms)
+    :min-activity-interval-ms (default-min-activity-interval-ms)}))
 
-(defn- extract-gemini
-  "Text + usage from a Gemini generateContent response: join the text
-   parts of the first candidate."
-  [body]
-  (extraction (->> (get-in body [:candidates 0 :content :parts])
-                   (keep :text)
-                   (str/join))
-              (get-in body [:usageMetadata :promptTokenCount])
-              (get-in body [:usageMetadata :candidatesTokenCount])))
+(defn- ^{:stratum 4} stream-poll-signal
+  [line-queue]
+  (.poll line-queue
+         (stream-poll-interval-ms)
+         TimeUnit/MILLISECONDS))
 
-(def ^:private http-providers
+(defn- ^{:stratum 4} stop-capture-process!
+  [{:keys [^Process process stdin-thread stdout-thread stderr-thread stdout stderr]}
+   timeout-ms]
+  (let [initial-result (wait-for-stream-process process timeout-ms)
+        timed-out? (= -1 (:exit initial-result))
+        result (if timed-out?
+                 (do
+                   (try (.destroyForcibly process) (catch Exception _ nil))
+                   (wait-for-stream-process process (post-kill-join-timeout-ms)))
+                 initial-result)]
+    (doseq [thread [stdin-thread stdout-thread stderr-thread]
+            :when thread]
+      (.join ^Thread thread stream-reader-join-timeout-ms))
+    {:out (or @stdout "")
+     :err (or (not-empty (:err result)) @stderr "")
+     :exit (:exit result)}))
+
+(defn- ^{:stratum 4} keepalive-interval-ms
+  "Refresh interval for the stream-side keepalive thread.
+
+   Tied to the configured stagnation threshold so the keepalive fires
+   well within the window — at one-third of the threshold we get
+   three refreshes per stagnation-window, so a brief reader stall
+   never races the timer.
+
+   Two clamps:
+   - lower: `keepalive-min-interval-ms` to avoid a hot-loop on
+     production stagnation values.
+   - upper: strictly less than the stagnation threshold so the
+     keepalive always fires before stagnation can. The min wins
+     when the configured threshold is small (e.g. tests using
+     80ms) so the lower-bound floor doesn't push the interval
+     past the threshold."
+  [monitor]
+  (let [stagnation (get @monitor :stagnation-threshold-ms
+                        (default-stagnation-threshold-ms))
+        target     (long (/ stagnation 3))
+        ceiling    (max 1 (dec stagnation))]
+    (min ceiling (max keepalive-min-interval-ms target))))
+
+;------------------------------------------------------------------------------ Layer 5
+
+;; Function-valued backend fields. The :ollama entry is intentionally
+;; absent (it has none); OpenCode loads credentials from its auth
+;; store, environment, or project .env/config, so Miniforge should not
+;; read provider-specific keys on that path.
+(def ^{:stratum 5} ^:private backend-fns
+  {:claude {:stream-parser parse-claude-stream-line
+            :args-fn claude-args}
+   :codex {:stream-parser parse-codex-stream-line
+           :args-fn codex-args}
+   :cursor {:args-fn cursor-args}
+   :opencode {:args-fn opencode-args}
+   :echo {:args-fn echo-args}})
+
+(def ^{:stratum 5} ^:private http-providers
   "Wire-shape registry for the HTTP backends: request-body builder +
    response parser per provider string, plus `:requires-model?` for
    the APIs that embed the model in the body or URL and have no
@@ -1051,7 +1761,57 @@
                 :parse-fn (partial parse-provider-response extract-gemini)
                 :requires-model? true}})
 
-(defn http-complete
+(defn ^{:stratum 5} process-stream-lines [out-reader monitor on-line]
+  (let [out-lines (atom [])
+        timeout-reason (atom nil)
+        stream-anomaly (atom nil)
+        line-timeout-ms (stream-line-timeout-ms)
+        last-line-at (atom (System/currentTimeMillis))
+        dump-writer (open-stream-dump-writer)
+        line-queue (LinkedBlockingQueue.)
+        reader-thread (start-stream-reader! out-reader line-queue)]
+    (try+
+      (loop []
+        (if-let [t (pm/check-timeout monitor)]
+          (reset! timeout-reason t)
+          (let [{:keys [done? timeout anomaly]}
+                (process-stream-signal (stream-poll-signal line-queue)
+                                       out-lines
+                                       dump-writer
+                                       on-line
+                                       last-line-at
+                                       line-timeout-ms)]
+            (cond
+              anomaly (reset! stream-anomaly anomaly)
+              done? nil
+              timeout (reset! timeout-reason timeout)
+              :else (recur)))))
+      (finally
+        (stop-stream-reader! reader-thread out-reader)
+        (when dump-writer (.close dump-writer))))
+    {:lines @out-lines
+     :timeout @timeout-reason
+     :anomaly @stream-anomaly}))
+
+(defn ^{:stratum 5} default-exec-fn
+  "Run `cmd` with ProcessBuilder, capturing :out / :err / :exit.
+
+   2-arity opts map supports:
+   - `:stdin`  — string piped to the subprocess's stdin
+   - `:workdir` — directory where the subprocess runs"
+  ([cmd] (default-exec-fn cmd {}))
+  ([cmd {:keys [stdin workdir]}]
+   (let [timeout-ms 600000
+         process (start-capture-process! cmd {:stdin stdin
+                                              :workdir workdir})]
+     (stop-capture-process! process timeout-ms))))
+
+;------------------------------------------------------------------------------ Layer 6
+
+(def ^{:stratum 6} backends
+  (merge-with merge backend-data backend-fns))
+
+(defn ^{:stratum 6} http-complete
   "Complete request using an HTTP backend.
 
    Two families share this path: the local, credential-free Ollama
@@ -1092,7 +1852,23 @@
                                    (provider-headers provider api-key)
                                    (body-fn request))))))
 
-(defn http-stream-complete
+;------------------------------------------------------------------------------ Layer 7
+
+(defn ^{:stratum 7} probe-endpoint-for
+  "Resolve the network-health probe URL for `backend-key`. Returns the
+   backend entry's `:probe-endpoint` when set, the generic Cloudflare
+   DNS connectivity URL otherwise (covers unknown backends and any
+   future entry added without an explicit endpoint).
+
+   The caller (e.g. `stream-exec-fn` in PR-B) resolves the URL here and
+   passes it to `network-health/network-healthy?` directly, keeping
+   that namespace endpoint-agnostic and free of backend-config
+   dependencies."
+  [backend-key]
+  (or (get-in backends [backend-key :probe-endpoint])
+      generic-connectivity-probe-url))
+
+(defn ^{:stratum 7} http-stream-complete
   "Complete request using HTTP API with streaming.
 
    Note: Currently falls back to non-streaming — the HTTP backends
@@ -1114,428 +1890,39 @@
                    (msg/t :http-provider.system/stream-failed
                           {:reason (.getMessage e)}))))))
 
-(defn rate-limited?
-  "Detect Claude CLI rate limit messages in content.
-   Claude CLI returns exit 0 but emits a rate limit message as content."
-  [content]
-  (and (string? content)
-       (re-find #"(?i)you've hit your limit|too many requests|\b429\b|rate limit(?:ed| exceeded)?\b|resets \d+[ap]m"
-                content)))
+(defn ^{:stratum 7} complete-impl [client request]
+  (let [{:keys [config logger exec-fn]} client
+        {:keys [backend model num-ctx]} config
+        backend-config (get backends backend)
+        {:keys [cmd args-fn]} backend-config
+        request-with-model (cond-> request
+                             model (assoc :model model)
+                             num-ctx (assoc :num-ctx num-ctx))]
+    (log-prompt-sent logger backend (build-request-prompt request))
 
-(defn success-response
-  ([output exit-code]
-   (success-response output exit-code nil))
-  ([output exit-code stderr]
-  (let [trimmed (str/trim output)]
-    (cond
-      (str/blank? trimmed)
-      (llm-error :anomalies.agent/llm-error "empty_success_output"
-                 "CLI backend exited successfully but produced no output"
-                 {:exit-code exit-code :stderr stderr :stdout output})
+    ;; Handle HTTP backends differently from CLI backends
+    (if (= cmd "http")
+      (let [response (http-complete backend-config request-with-model config)]
+        (log-response logger response)
+        response)
 
-      (rate-limited? trimmed)
-      (llm-error :anomalies.agent/rate-limited "rate_limit"
-                 (str "Claude CLI rate limited: " trimmed)
-                 {:exit-code exit-code :stdout output})
+      ;; CLI backend
+      (let [prompt     (build-request-prompt request)
+            prompt-via (resolve-prompt-via backend-config)
+            args     (args-fn (assoc request-with-model
+                                     :prompt prompt
+                                     :prompt-via prompt-via))
+            full-cmd (into [cmd] args)
+            opts     (cond-> (exec-opts-for-prompt-via prompt-via prompt)
+                       (:workdir request) (assoc :workdir (:workdir request)))
+            result   (run-cli-exec exec-fn full-cmd opts)
+            response (parse-cli-output (:out result) (:exit result) (:err result))]
+        (log-response logger response)
+        response))))
 
-      :else
-      (cond-> (llm-success trimmed {:exit-code exit-code})
-        (seq stderr) (assoc :stderr stderr))))))
+;------------------------------------------------------------------------------ Layer 8
 
-(defn error-response [output exit-code stderr]
-  (let [error-message (if (and stderr (str/blank? output)) stderr output)]
-    (llm-error :anomalies.agent/llm-error "cli_error" (str/trim error-message)
-               {:exit-code exit-code :stderr stderr :stdout output})))
-
-(defn parse-cli-output
-  ([output exit-code]
-   (parse-cli-output output exit-code nil))
-  ([output exit-code stderr]
-   (if (zero? exit-code)
-     (success-response output exit-code stderr)
-     (error-response output exit-code stderr))))
-
-(defn default-progress-monitor []
-  (pm/create-progress-monitor
-   {:stagnation-threshold-ms  (default-stagnation-threshold-ms)
-    :max-total-ms             (default-max-total-ms)
-    :min-activity-interval-ms (default-min-activity-interval-ms)}))
-
-(defn format-timeout-error [{:keys [message type elapsed-ms]}]
-  (format "Adaptive timeout: %s (type: %s, elapsed: %dms)"
-          message (name type) elapsed-ms))
-
-(defn timeout-result [out-lines timeout-reason]
-  {:out (str/join "\n" out-lines)
-   :err (format-timeout-error timeout-reason)
-   :exit -1
-   :timeout timeout-reason})
-
-(defn success-result [out-lines process-result]
-  {:out (str/join "\n" out-lines)
-   :err (:err process-result)
-   :exit (:exit process-result)})
-
-(defn stream-anomaly-result [out-lines stream-anomaly]
-  {:out (str/join "\n" out-lines)
-   :err (:anomaly/message stream-anomaly)
-   :exit -1
-   :anomaly stream-anomaly})
-
-;------------------------------------------------------------------------------ Layer 1
-
-(def ^:private eof-sentinel
-  (Object.))
-
-(defn- open-stream-dump-writer
-  []
-  (when-let [dump-path (System/getenv "MF_STREAM_DUMP")]
-    (java.io.PrintWriter.
-     (java.io.FileWriter. dump-path true))))
-
-(defn- stream-read-failure
-  [ex]
-  (anomaly/exception-anomaly :fault (or (ex-message ex) (str (type ex))) ex))
-
-(defn- enqueue-stream-line!
-  [line-queue line]
-  (.put line-queue line))
-
-(defn- read-stream-loop!
-  [out-reader line-queue]
-  (loop []
-    (if-some [line (.readLine out-reader)]
-      (do (enqueue-stream-line! line-queue line)
-          (recur))
-      (enqueue-stream-line! line-queue eof-sentinel))))
-
-(def ^:private stream-reader-join-timeout-ms
-  "How long process-stream-lines waits for its daemon reader thread to
-   exit after the stream reader is closed."
-  100)
-
-(defn- daemon-thread!
-  [thread-name f]
-  (let [thread (Thread. ^Runnable f thread-name)]
-    (.setDaemon thread true)
-    (.start thread)
-    thread))
-
-(defn- start-stream-reader!
-  "Start the daemon that drains `out-reader` into `line-queue`.
-
-   Three exit shapes:
-   1. EOF — `read-stream-loop!` enqueues the eof sentinel and returns; thread
-      exits cleanly.
-   2. Clean shutdown via `stop-stream-reader!` — the consumer
-      (`process-stream-lines`) has stopped polling, so `stop-stream-reader!`
-      closes the reader and calls `.interrupt`. `BufferedReader.readLine`
-      is NOT interruptible, so a reader blocked there unblocks via the
-      `.close` (the read returns nil or throws `IOException`). A reader
-      blocked in `.put` on a full queue unblocks via the `.interrupt` and
-      raises `InterruptedException`. Both cases land in the same silent
-      catch: the consumer already left the queue; no anomaly to publish.
-   3. Real read error — surface as a `stream-read-failure` anomaly so the
-      consumer sees it. The inner try/catch around the anomaly enqueue
-      guards against a sticky-interrupt race during cleanup (the thread's
-      interrupt flag is still set from case 2, so `.put` here can throw IE
-      too — swallow it; the consumer is already gone).
-
-   Pre-fix, case 2 was caught by the generic `(catch Exception e ...)` which
-   then called `enqueue-stream-line!` → `.put` → a second IE that bubbled out
-   of the runnable to the JVM default exception handler and printed an ugly
-   stack trace to stderr. The 2026-06-04 eliminate-requiring-resolve dogfood
-   surfaced 18 of these IEs across 20 sub-tasks — pure log noise, zero
-   workflow impact, but enough to look like a real bug in post-run triage."
-  [out-reader line-queue]
-  (daemon-thread!
-   "llm-stream-reader"
-   (fn []
-     (try
-       (read-stream-loop! out-reader line-queue)
-       (catch InterruptedException _
-         ;; clean shutdown — consumer already exited; nothing to report
-         nil)
-       (catch Exception e
-         (try
-           (enqueue-stream-line! line-queue (stream-read-failure e))
-           (catch InterruptedException _
-             ;; the stop-stream-reader! interrupt raced this catch
-             nil)))))))
-
-(defn- stop-stream-reader!
-  [^Thread reader-thread out-reader]
-  (try (.close out-reader) (catch Exception _))
-  (.interrupt reader-thread)
-  (.join reader-thread stream-reader-join-timeout-ms))
-
-(defn- record-stream-line!
-  [out-lines dump-writer on-line last-line-at now line]
-  (reset! last-line-at now)
-  (swap! out-lines conj line)
-  (when dump-writer
-    (.println dump-writer line)
-    (.flush dump-writer))
-  (on-line line))
-
-(defn- stream-idle-timeout
-  [last-line-at line-timeout-ms out-lines now]
-  (when (>= (- now @last-line-at) line-timeout-ms)
-    {:type :stream-idle
-     :message (str "No stream output for " line-timeout-ms "ms")
-     :elapsed-ms (- now @last-line-at)
-     :stats {:lines-read (count @out-lines)}}))
-
-(defn- stream-poll-signal
-  [line-queue]
-  (.poll line-queue
-         (stream-poll-interval-ms)
-         TimeUnit/MILLISECONDS))
-
-(defn- anomaly-signal?
-  [line-or-signal]
-  (anomaly/anomaly? line-or-signal))
-
-(defn- eof-signal?
-  [line-or-signal]
-  (identical? line-or-signal eof-sentinel))
-
-(defn- timeout-signal
-  [last-line-at line-timeout-ms out-lines]
-  {:done? false
-   :timeout (stream-idle-timeout last-line-at
-                                 line-timeout-ms
-                                 out-lines
-                                 (System/currentTimeMillis))})
-
-(defn- process-stream-signal
-  [line-or-signal out-lines dump-writer on-line last-line-at line-timeout-ms]
-  (cond
-    (anomaly-signal? line-or-signal)
-    {:done? true
-     :anomaly line-or-signal}
-
-    (eof-signal? line-or-signal)
-    {:done? true}
-
-    (some? line-or-signal)
-    (do (record-stream-line! out-lines
-                             dump-writer
-                             on-line
-                             last-line-at
-                             (System/currentTimeMillis)
-                             line-or-signal)
-        {:done? false})
-
-    :else
-    (timeout-signal last-line-at line-timeout-ms out-lines)))
-
-(defn process-stream-lines [out-reader monitor on-line]
-  (let [out-lines (atom [])
-        timeout-reason (atom nil)
-        stream-anomaly (atom nil)
-        line-timeout-ms (stream-line-timeout-ms)
-        last-line-at (atom (System/currentTimeMillis))
-        dump-writer (open-stream-dump-writer)
-        line-queue (LinkedBlockingQueue.)
-        reader-thread (start-stream-reader! out-reader line-queue)]
-    (try+
-      (loop []
-        (if-let [t (pm/check-timeout monitor)]
-          (reset! timeout-reason t)
-          (let [{:keys [done? timeout anomaly]}
-                (process-stream-signal (stream-poll-signal line-queue)
-                                       out-lines
-                                       dump-writer
-                                       on-line
-                                       last-line-at
-                                       line-timeout-ms)]
-            (cond
-              anomaly (reset! stream-anomaly anomaly)
-              done? nil
-              timeout (reset! timeout-reason timeout)
-              :else (recur)))))
-      (finally
-        (stop-stream-reader! reader-thread out-reader)
-        (when dump-writer (.close dump-writer))))
-    {:lines @out-lines
-     :timeout @timeout-reason
-     :anomaly @stream-anomaly}))
-
-(defn clean-env
-  "Build environment map without CLAUDECODE to allow nested Claude CLI sessions.
-   Returns nil if CLAUDECODE is not set (use default env)."
-  []
-  (when (System/getenv "CLAUDECODE")
-    (into {} (remove (fn [[k _]] (= k "CLAUDECODE"))) (System/getenv))))
-
-(defn- ->stdin-stream
-  "Build the InputStream passed as the subprocess's stdin. A non-blank
-   :stdin string becomes a ByteArrayInputStream over its UTF-8 bytes;
-   absent or blank stdin maps to a zero-length stream so the
-   subprocess sees EOF immediately (legacy behavior for argv backends)."
-  [stdin-str]
-  (if (and (string? stdin-str) (not (.isEmpty ^String stdin-str)))
-    (ByteArrayInputStream. (.getBytes ^String stdin-str "UTF-8"))
-    (ByteArrayInputStream. (byte-array 0))))
-
-(defn- apply-process-env!
-  [^ProcessBuilder builder env]
-  (when env
-    (let [target-env (.environment builder)]
-      (.clear target-env)
-      (doseq [[k v] env]
-        (.put target-env k v)))))
-
-(defn- write-process-stdin!
-  [^Process process stdin-str]
-  (daemon-thread!
-   "llm-stream-stdin-writer"
-   (fn []
-     (try
-       (with-open [out (.getOutputStream process)
-                   in (->stdin-stream stdin-str)]
-         (io/copy in out))
-       (catch Exception _
-         nil)))))
-
-(defn- read-process-stream!
-  [thread-name input-stream output]
-  (daemon-thread!
-   thread-name
-   (fn []
-     (try
-       (reset! output (slurp input-stream))
-       (catch Exception e
-         (reset! output (or (ex-message e) (str e))))))))
-
-(defn- read-process-stderr!
-  [^Process process stderr]
-  (read-process-stream! "llm-stream-stderr-reader"
-                        (.getErrorStream process)
-                        stderr))
-
-(defn- start-stream-process!
-  [cmd {:keys [workdir stdin]}]
-  (let [builder (ProcessBuilder. ^java.util.List cmd)]
-    (when-let [env (clean-env)]
-      (apply-process-env! builder env))
-    (when workdir
-      (.directory builder (io/file workdir)))
-    (let [process (.start builder)
-          stderr (atom "")
-          stdin-thread (write-process-stdin! process stdin)
-          stderr-thread (read-process-stderr! process stderr)]
-      {:process process
-       :stderr stderr
-       :stdin-thread stdin-thread
-       :stderr-thread stderr-thread})))
-
-(defn- start-capture-process!
-  [cmd {:keys [workdir stdin]}]
-  (let [builder (ProcessBuilder. ^java.util.List cmd)]
-    (when-let [env (clean-env)]
-      (apply-process-env! builder env))
-    (when workdir
-      (.directory builder (io/file workdir)))
-    (let [process (.start builder)
-          stdout (atom "")
-          stderr (atom "")
-          stdin-thread (write-process-stdin! process stdin)
-          stdout-thread (read-process-stream! "llm-stdout-reader"
-                                             (.getInputStream process)
-                                             stdout)
-          stderr-thread (read-process-stream! "llm-stderr-reader"
-                                             (.getErrorStream process)
-                                             stderr)]
-      {:process process
-       :stdout stdout
-       :stderr stderr
-       :stdin-thread stdin-thread
-       :stdout-thread stdout-thread
-       :stderr-thread stderr-thread})))
-
-(defn- wait-for-stream-process
-  [^Process process timeout-ms]
-  (if (.waitFor process (long timeout-ms) TimeUnit/MILLISECONDS)
-    {:exit (.exitValue process)}
-    {:exit -1 :err "Process timed out"}))
-
-(defn- stop-stream-process!
-  [{:keys [^Process process stdin-thread stderr-thread stderr]} timeout? join-timeout]
-  (when timeout?
-    (try (.destroyForcibly process) (catch Exception _ nil)))
-  (let [result (wait-for-stream-process process join-timeout)]
-    (when stdin-thread
-      (.join ^Thread stdin-thread stream-reader-join-timeout-ms))
-    (when stderr-thread
-      (.join ^Thread stderr-thread stream-reader-join-timeout-ms))
-    (assoc result :err @stderr)))
-
-(defn- stop-capture-process!
-  [{:keys [^Process process stdin-thread stdout-thread stderr-thread stdout stderr]}
-   timeout-ms]
-  (let [initial-result (wait-for-stream-process process timeout-ms)
-        timed-out? (= -1 (:exit initial-result))
-        result (if timed-out?
-                 (do
-                   (try (.destroyForcibly process) (catch Exception _ nil))
-                   (wait-for-stream-process process (post-kill-join-timeout-ms)))
-                 initial-result)]
-    (doseq [thread [stdin-thread stdout-thread stderr-thread]
-            :when thread]
-      (.join ^Thread thread stream-reader-join-timeout-ms))
-    {:out (or @stdout "")
-     :err (or (not-empty (:err result)) @stderr "")
-     :exit (:exit result)}))
-
-(def ^:private keepalive-min-interval-ms
-  "Floor on the keepalive interval so the worker doesn't burn cycles
-   pinging the monitor in a tight loop on production-sized thresholds.
-   1s is plenty fine-grained for a 180+ second stagnation window."
-  1000)
-
-(defn- keepalive-interval-ms
-  "Refresh interval for the stream-side keepalive thread.
-
-   Tied to the configured stagnation threshold so the keepalive fires
-   well within the window — at one-third of the threshold we get
-   three refreshes per stagnation-window, so a brief reader stall
-   never races the timer.
-
-   Two clamps:
-   - lower: `keepalive-min-interval-ms` to avoid a hot-loop on
-     production stagnation values.
-   - upper: strictly less than the stagnation threshold so the
-     keepalive always fires before stagnation can. The min wins
-     when the configured threshold is small (e.g. tests using
-     80ms) so the lower-bound floor doesn't push the interval
-     past the threshold."
-  [monitor]
-  (let [stagnation (get @monitor :stagnation-threshold-ms
-                        (default-stagnation-threshold-ms))
-        target     (long (/ stagnation 3))
-        ceiling    (max 1 (dec stagnation))]
-    (min ceiling (max keepalive-min-interval-ms target))))
-
-(defn- network-drop-timeout
-  "Shape the network-monitor's `:on-drop` diagnostic into the same
-   `{:type :message :elapsed-ms ...}` envelope `pm/check-timeout`
-   returns, so the existing `timeout-result` path handles it
-   identically. The PR-C auto-resumer keys on `:type :network-drop` to
-   know it should resume from the last persisted checkpoint."
-  [{:keys [backend-key consecutive-failures probe-interval-ms]
-    :as   diag}]
-  {:type           :network-drop
-   :backend-key    backend-key
-   :elapsed-ms     (* consecutive-failures probe-interval-ms)
-   :message        (format "Network drop: %d consecutive probes failed for %s"
-                           consecutive-failures (name backend-key))
-   :stats          (select-keys diag
-                                [:consecutive-failures :failure-threshold
-                                 :probe-interval-ms])})
-
-(defn stream-exec-fn
+(defn ^{:stratum 8} stream-exec-fn
   "Run `cmd` as a streaming subprocess, dispatching each output line to
    `on-line`.
 
@@ -1642,123 +2029,7 @@
        :else
        (success-result lines result)))))
 
-;------------------------------------------------------------------------------ Layer 2
-
-(defn build-request-prompt [request]
-  (or (:prompt request)
-      (build-messages-prompt (:messages request))))
-
-(defn- resolve-prompt-via
-  "Read the backend's declared prompt-delivery mode. Defaults to :argv
-   so backends that pre-date the :prompt-via knob keep their legacy
-   behavior."
-  [backend-config]
-  (get backend-config :prompt-via :argv))
-
-(defn- exec-opts-for-prompt-via
-  "Build the exec-layer opts map for a given prompt-via + prompt.
-
-   :stdin → {:stdin prompt} so the exec layer pipes the prompt to the
-            subprocess's stdin.
-   :argv  → {} (prompt rides in argv via the args-fn).
-
-   Returning an empty map for :argv lets call sites use `(seq opts)`
-   to decide between the 1-arity and 2-arity exec-fn calls — preserves
-   back-compat with caller-supplied 1-arity exec-fns documented as a
-   public test hook on CLIClient."
-  [prompt-via prompt]
-  (cond-> {} (= prompt-via :stdin) (assoc :stdin prompt)))
-
-(defn- run-cli-exec
-  "Invoke a CLI exec-fn with cmd plus optional opts. The 1-arity
-   branch keeps caller-supplied exec-fns from the days before opts
-   existed working unchanged; the 2-arity branch threads opts in
-   when they carry signal (e.g. :stdin)."
-  [exec-fn cmd opts]
-  (if (seq opts)
-    (exec-fn cmd opts)
-    (exec-fn cmd)))
-
-(defn normalize-exec-fn
-  "Wrap an exec-fn so it accepts both 1-arity (cmd) and 2-arity
-   (cmd opts) call patterns.
-
-   `:exec-fn` on `create-client` is a documented public test hook.
-   Pre-:prompt-via callers supplied 1-arity functions; once the
-   :stdin path landed the impl started invoking exec-fn 2-arity for
-   the :claude backend. Without this wrapper a 1-arity user fn
-   would throw ArityException the first time the new code path
-   ran.
-
-   The wrapper probes 2-arity on first 2-arity call and caches the
-   decision in an atom so subsequent calls dispatch directly. The
-   probe only happens when the caller actually passes opts; pure
-   1-arity invocations stay one indirection.
-
-   Returns a fn equivalent to `f` for callers that already accept
-   both arities."
-  [f]
-  (let [arity (atom :unknown)]
-    (fn
-      ([cmd] (f cmd))
-      ([cmd opts]
-       (case @arity
-         :one (f cmd)
-         :two (f cmd opts)
-         (try
-           (let [r (f cmd opts)]
-             (reset! arity :two)
-             r)
-           (catch clojure.lang.ArityException _
-             (reset! arity :one)
-             (f cmd))))))))
-
-(defn log-prompt-sent [logger backend prompt]
-  (when logger
-    (log/debug logger :system :agent/prompt-sent
-               {:data {:backend backend
-                       :prompt-length (count prompt)}})))
-
-(defn log-response [logger response]
-  (when logger
-    (if (:success response)
-      (log/debug logger :system :agent/response-received
-                 {:data {:response-length (count (:content response))}})
-      (log/error logger :system :agent/task-failed
-                 {:message (msg/t :backend.system/request-failed)
-                  :data (:error response)}))))
-
-(defn complete-impl [client request]
-  (let [{:keys [config logger exec-fn]} client
-        {:keys [backend model num-ctx]} config
-        backend-config (get backends backend)
-        {:keys [cmd args-fn]} backend-config
-        request-with-model (cond-> request
-                             model (assoc :model model)
-                             num-ctx (assoc :num-ctx num-ctx))]
-    (log-prompt-sent logger backend (build-request-prompt request))
-
-    ;; Handle HTTP backends differently from CLI backends
-    (if (= cmd "http")
-      (let [response (http-complete backend-config request-with-model config)]
-        (log-response logger response)
-        response)
-
-      ;; CLI backend
-      (let [prompt     (build-request-prompt request)
-            prompt-via (resolve-prompt-via backend-config)
-            args     (args-fn (assoc request-with-model
-                                     :prompt prompt
-                                     :prompt-via prompt-via))
-            full-cmd (into [cmd] args)
-            opts     (cond-> (exec-opts-for-prompt-via prompt-via prompt)
-                       (:workdir request) (assoc :workdir (:workdir request)))
-            result   (run-cli-exec exec-fn full-cmd opts)
-            response (parse-cli-output (:out result) (:exit result) (:err result))]
-        (log-response logger response)
-        response))))
-
-(defn handle-non-streaming-fallback [client request on-chunk]
+(defn ^{:stratum 8} handle-non-streaming-fallback [client request on-chunk]
   (let [result (complete-impl client request)]
     (when (:success result)
       (on-chunk {:delta (:content result)
@@ -1766,220 +2037,9 @@
                  :content (:content result)}))
     result))
 
-(defn- record-parsed-progress!
-  [progress-monitor parsed accumulated-content]
-  (cond
-    (:tool-use parsed)
-    (pm/record-activity!
-     progress-monitor
-     (str "tool-use:"
-          (or (:tool-name parsed)
-              (some->> (:tool-names parsed) seq sort (str/join ","))
-              "unknown")))
+;------------------------------------------------------------------------------ Layer 9
 
-    ;; Tool-result events are liveness signals — use a stable activity
-    ;; key (not the call-id) so :unique-chunks stays bounded across long
-    ;; tool-heavy runs.
-    (:tool-result parsed)
-    (pm/record-activity! progress-monitor :tool-result)
-
-    (:heartbeat parsed)
-    (pm/record-activity! progress-monitor :stream-heartbeat)
-
-    (contains? parsed :done?)
-    (pm/record-activity! progress-monitor :stream-result)
-
-    :else
-    (pm/record-chunk! progress-monitor @accumulated-content)))
-
-(defn stream-with-parser
-  [stream-parser on-chunk progress-monitor accumulated-content accumulated-usage accumulated-cost accumulated-tools accumulated-session-id accumulated-stop-reason accumulated-turns]
-  (fn [line]
-    (when-let [parsed (stream-parser line)]
-      (when-let [usage (:usage parsed)]
-        (swap! accumulated-usage (fn [prev] (merge prev usage))))
-      (when-let [cost (:cost-usd parsed)]
-        (reset! accumulated-cost cost))
-      (when-let [session-id (:session-id parsed)]
-        (reset! accumulated-session-id session-id))
-      (when-let [sr (:stop-reason parsed)]
-        (reset! accumulated-stop-reason sr))
-      ;; Claude surfaces num_turns as an absolute count on the result event.
-      (when-let [nt (:num-turns parsed)]
-        (reset! accumulated-turns nt))
-      ;; Claude may surface the final assistant text only on the terminal
-      ;; result event. Preserve previously streamed content when present,
-      ;; but recover result-only output when no assistant delta arrived.
-      (when-let [final-content (:final-content parsed)]
-        (when (and (string? final-content)
-                   (str/blank? @accumulated-content)
-                   (not (str/blank? final-content)))
-          (reset! accumulated-content final-content)))
-      ;; Codex signals each completed turn via :increment-turns rather than
-      ;; emitting an absolute count — bump the accumulator on each one.
-      (when (:increment-turns parsed)
-        (swap! accumulated-turns (fnil inc 0)))
-      (if (or (:tool-use parsed) (:tool-result parsed) (:heartbeat parsed))
-        ;; Tool-use, tool-result, and heartbeat events: track tool names and
-        ;; fire on-chunk without appending anything to accumulated-content.
-        (do
-          (when-let [tool-name (:tool-name parsed)]
-            (swap! accumulated-tools conj tool-name))
-          (when-let [tool-names (:tool-names parsed)]
-            (swap! accumulated-tools into tool-names))
-          (record-parsed-progress! progress-monitor parsed accumulated-content)
-          (on-chunk (assoc parsed :content @accumulated-content)))
-        ;; Normal text deltas
-        (when-let [delta (:delta parsed)]
-          (swap! accumulated-content str delta)
-          (record-parsed-progress! progress-monitor parsed accumulated-content)
-          (on-chunk (assoc parsed :content @accumulated-content)))))))
-
-(defn log-streaming-result [logger timeout-info content-length]
-  (when logger
-    (if timeout-info
-      (log/warn logger :system :agent/streaming-timeout
-                {:message (:message timeout-info)
-                 :data {:type (:type timeout-info)
-                        :elapsed-ms (:elapsed-ms timeout-info)
-                        :stats (:stats timeout-info)}})
-      (log/debug logger :system :agent/streaming-complete
-                 {:data {:response-length content-length}}))))
-
-(defn- message-preview
-  "Return the last up-to-500 characters of content for post-mortem diagnostics.
-   Returns nil when content is blank."
-  [content]
-  (when (seq content)
-    (subs content (max 0 (- (count content) 500)))))
-
-(defn streaming-success-response
-  "Build a streaming success response with diagnostic metadata.
-
-   Diagnostic fields added to the response map:
-   - :stop-reason          — why the model stopped (\"end_turn\", \"max_turns\", etc.)
-   - :num-turns            — number of conversation turns consumed
-   - :tool-call-count      — total number of tool invocations during the run
-   - :final-message-preview — last 500 chars of accumulated content (post-mortem aid)"
-  [content exit-code usage cost-usd stop-reason num-turns tool-call-count final-message-preview stderr]
-  (if (rate-limited? content)
-    (llm-error :anomalies.agent/rate-limited "rate_limit"
-               (str "Claude CLI rate limited: " (str/trim content))
-               {:exit-code exit-code :stdout content
-                :stop-reason stop-reason :num-turns num-turns})
-    (cond-> (llm-success content {:exit-code exit-code :usage usage})
-      cost-usd                    (assoc :cost-usd cost-usd)
-      stop-reason                 (assoc :stop-reason stop-reason)
-      num-turns                   (assoc :num-turns num-turns)
-      (some? tool-call-count)     (assoc :tool-call-count tool-call-count)
-      (seq final-message-preview) (assoc :final-message-preview final-message-preview)
-      (seq stderr)                (assoc :stderr stderr))))
-
-(defn- blank-streaming-success?
-  "True when the streaming transport exited 0 but produced no useful parsed output.
-
-   This is the Claude failure mode observed in dogfood on 2026-05-02:
-   the process exited successfully, emitted no parsed stdout blocks, no tool calls,
-   and left the planner with an empty assistant turn. In that case we retry once
-   through the non-streaming path before classifying the invocation as failed."
-  [exit-code final-content tool-call-count usage]
-  (and (zero? exit-code)
-       (str/blank? final-content)
-       (zero? tool-call-count)
-       (nil? usage)))
-
-(def context-overflow-error-type
-  "Error :type for a prompt that exceeded the model's context window.
-   Terminal: excluded from submission-recovery (the turn has no artifact to
-   recover and a retry just re-sends the over-budget prompt). See N12 §4."
-  "context_overflow")
-
-(defn- usage-token-count
-  "Return a numeric usage token count, treating missing or malformed values
-   as zero so context accounting remains numeric for upstream payloads."
-  [usage token-key]
-  (let [tokens (get usage token-key)]
-    (if (number? tokens) tokens 0)))
-
-(defn total-input-tokens
-  "prompt + cache-creation + cache-read tokens. Summed because a large
-   prompt lands mostly under cache-creation, not :input-tokens. See N12 §2."
-  [usage]
-  (+ (usage-token-count usage :input-tokens)
-     (usage-token-count usage :cache-creation-input-tokens)
-     (usage-token-count usage :cache-read-input-tokens)))
-
-(defn context-overflow-by-usage?
-  "True when total input tokens >= the model's context window — the
-   structured, locale/backend-independent overflow signal (N12 §4).
-   `context-window` is nil for uncatalogued models → no assertion."
-  [usage context-window]
-  (boolean (and context-window
-                (pos? (total-input-tokens usage))
-                (>= (total-input-tokens usage) context-window))))
-
-(defn streaming-error-response
-  "Build a streaming error response with diagnostic metadata.
-
-   Diagnostic fields added to the response map (alongside :success/:error/:anomaly):
-   - :stop-reason          — last observed stop reason before failure
-   - :num-turns            — number of conversation turns consumed
-   - :tool-call-count      — total number of tool invocations during the run
-   - :final-message-preview — last 500 chars of accumulated content (post-mortem aid)
-
-   `usage` + `context-window` drive context-overflow classification (N12 §4);
-   optional — the 9-arity form skips it (for callers without them)."
-  ([content exit-code err-result raw-stdout timeout-info stop-reason num-turns
-    tool-call-count final-message-preview]
-   (streaming-error-response content exit-code err-result raw-stdout timeout-info
-                             stop-reason num-turns tool-call-count
-                             final-message-preview nil nil))
-  ([content exit-code err-result raw-stdout timeout-info stop-reason num-turns
-    tool-call-count final-message-preview usage context-window]
-   (let [error-message (or (not-empty (str/trim (or err-result "")))
-                           (when-not (str/blank? content) content)
-                           (not-empty (str/trim (or raw-stdout "")))
-                           (msg/t :streaming-error.system/no-output))
-         category (if timeout-info :anomalies/timeout :anomalies.agent/llm-error)
-         error-type (cond
-                      timeout-info "adaptive_timeout"
-                      (context-overflow-by-usage? usage context-window) context-overflow-error-type
-                      :else "cli_error")]
-     (cond-> (llm-error category error-type (str/trim error-message)
-                        {:exit-code exit-code
-                         :stderr err-result
-                         :stdout content
-                         :raw-stdout raw-stdout
-                         :timeout timeout-info})
-       stop-reason                 (assoc :stop-reason stop-reason)
-       num-turns                   (assoc :num-turns num-turns)
-       (some? tool-call-count)     (assoc :tool-call-count tool-call-count)
-       (seq final-message-preview) (assoc :final-message-preview final-message-preview)))))
-
-(def ^:private chars-per-token-estimate
-  "Rough characters-per-token divisor for a pre-flight input-size estimate.
-   ~4 chars/token is the usual English heuristic; this is a coarse gauge of
-   headroom against the model's context window, not a billing figure."
-  4)
-
-(defn prompt-size-telemetry
-  "Pre-flight size gauge over the assembled system + user prompt, computed
-   BEFORE dispatch so it survives a context-overflow rejection (where
-   `:usage` never arrives). `:estimated-input-tokens` is a coarse chars/4
-   estimate, rounded UP so a near-boundary prompt isn't under-reported.
-   See N12 §3."
-  [system prompt]
-  (let [system-chars (count (or system ""))
-        user-chars   (count (or prompt ""))
-        total-chars  (+ system-chars user-chars)]
-    {:system-chars system-chars
-     :user-chars user-chars
-     :total-chars total-chars
-     ;; ceil division (stay conservative for a headroom gauge)
-     :estimated-input-tokens (quot (+ total-chars (dec chars-per-token-estimate))
-                                   chars-per-token-estimate)}))
-
-(defn handle-streaming [client request on-chunk backend-config progress-monitor]
+(defn ^{:stratum 9} handle-streaming [client request on-chunk backend-config progress-monitor]
   (let [{:keys [logger config]} client
         stream-fn (or (:stream-exec-fn client) stream-exec-fn)
         {:keys [backend model num-ctx]} config
@@ -2093,7 +2153,9 @@
                                                (:model request-with-model)))
               session-id (assoc :session-id session-id))))))))
 
-(defn complete-stream-impl [client request on-chunk]
+;------------------------------------------------------------------------------ Layer 10
+
+(defn ^{:stratum 10} complete-stream-impl [client request on-chunk]
   (let [{:keys [config]} client
         {:keys [backend model num-ctx]} config
         backend-config (get backends backend)
@@ -2116,58 +2178,3 @@
       (if-not streaming?
         (handle-non-streaming-fallback client request on-chunk)
         (handle-streaming client request on-chunk backend-config progress-monitor)))))
-
-(defn get-config-impl [client]
-  (:config client))
-
-;------------------------------------------------------------------------------ Layer 3
-
-(defn default-exec-fn
-  "Run `cmd` with ProcessBuilder, capturing :out / :err / :exit.
-
-   2-arity opts map supports:
-   - `:stdin`  — string piped to the subprocess's stdin
-   - `:workdir` — directory where the subprocess runs"
-  ([cmd] (default-exec-fn cmd {}))
-  ([cmd {:keys [stdin workdir]}]
-   (let [timeout-ms 600000
-         process (start-capture-process! cmd {:stdin stdin
-                                              :workdir workdir})]
-     (stop-capture-process! process timeout-ms))))
-
-(defn capsule-exec-fn
-  "Returns an exec-fn that routes CLI commands through a task capsule executor.
-   Used in governed mode so the agent CLI runs inside the Docker/K8s container
-   instead of on the host (N11 §6.2).
-
-   Arguments:
-   - execute-fn  - function [executor env-id command opts] -> result map
-   - executor    - TaskExecutor instance
-   - env-id      - environment/container ID
-   - workdir     - workspace directory inside capsule"
-  [execute-fn executor env-id workdir]
-  (fn [cmd]
-    (let [result (execute-fn executor env-id cmd {:workdir workdir})]
-      (if (and (map? result) (:data result))
-        {:out (get-in result [:data :stdout] "")
-         :err (get-in result [:data :stderr] "")
-         :exit (get-in result [:data :exit-code] 0)}
-        {:out ""
-         :err (str "Capsule exec error: " result)
-         :exit 1}))))
-
-(defn mock-exec-fn [output & {:keys [exit] :or {exit 0}}]
-  (fn
-    ([_cmd]      {:out output :err "" :exit exit})
-    ([_cmd _opts] {:out output :err "" :exit exit})))
-
-(defn mock-exec-fn-multi [outputs]
-  (let [call-count (atom 0)
-        respond    (fn []
-                     (let [idx @call-count
-                           output (get outputs idx (last outputs))]
-                       (swap! call-count inc)
-                       {:out output :err "" :exit 0}))]
-    (fn
-      ([_cmd]       (respond))
-      ([_cmd _opts] (respond)))))

--- a/components/llm/src/ai/miniforge/llm/protocols/records/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/records/llm_client.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.llm.protocols.records.llm-client
   "Record that implements LLMClient protocol.
 
@@ -25,7 +24,9 @@
    [ai.miniforge.llm.protocols.impl.llm-client :as impl]
    [ai.miniforge.response.interface :as response]))
 
-(defrecord CLIClient [config logger exec-fn stream-exec-fn]
+;------------------------------------------------------------------------------ Layer 0
+
+(defrecord ^{:stratum 0} CLIClient [config logger exec-fn stream-exec-fn]
   p/LLMClient
   (complete* [this request]
     (impl/complete-impl this request))
@@ -37,9 +38,9 @@
     (impl/get-config-impl this)))
 
 ;------------------------------------------------------------------------------ Layer 1
-;; Factory functions
 
-(defn create-client
+;; Factory functions
+(defn ^{:stratum 1} create-client
   "Create a new LLM client.
 
    Options:

--- a/components/llm/test/ai/miniforge/llm/args_fn_test.clj
+++ b/components/llm/test/ai/miniforge/llm/args_fn_test.clj
@@ -71,7 +71,7 @@
     (is (= "opencode" (get-in impl/backends [:opencode :cmd])))
     (is (= "OpenCode" (get-in impl/backends [:opencode :provider])))
     (is (false? (get-in impl/backends [:opencode :streaming?])))
-    (is (not (contains? (get impl/backends :opencode) :api-key-var)))
+    (is (not (contains? (get impl/backends :opencode) :api-key-env)))
     (is (= :argv (get-in impl/backends [:opencode :prompt-via])))))
 
 ;------------------------------------------------------------------------------ Layer 1

--- a/components/llm/test/ai/miniforge/llm/args_fn_test.clj
+++ b/components/llm/test/ai/miniforge/llm/args_fn_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.llm.args-fn-test
   "Tests for named backend argument builder functions.
    Verifies that extracted defn- functions produce the same args
@@ -25,71 +24,13 @@
    [clojure.string :as str]
    [ai.miniforge.llm.protocols.impl.llm-client :as impl]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; Private fn accessor
-(defn- private-fn [sym]
+(defn- ^{:stratum 0} private-fn [sym]
   (var-get (ns-resolve 'ai.miniforge.llm.protocols.impl.llm-client sym)))
 
-;; ============================================================================
-;; claude-args
-;; ============================================================================
-
-(deftest claude-args-minimal-test
-  (testing "minimal prompt produces [-p <prompt>]"
-    (let [args ((private-fn 'claude-args) {:prompt "hello"})]
-      (is (= ["-p" "hello"] args)))))
-
-(deftest claude-args-streaming-test
-  (testing "streaming adds output-format and verbose flags"
-    (let [args ((private-fn 'claude-args) {:prompt "hi" :streaming? true})]
-      (is (some #(= "--output-format" %) args))
-      (is (some #(= "stream-json" %) args))
-      (is (some #(= "--verbose" %) args))
-      (is (= "hi" (last args))))))
-
-(deftest claude-args-mcp-config-test
-  (testing "mcp-config adds --mcp-config flag"
-    (let [args ((private-fn 'claude-args) {:prompt "p" :mcp-config "/tmp/mcp.json"})]
-      (is (some #(= "--mcp-config" %) args))
-      (is (some #(= "/tmp/mcp.json" %) args))))
-
-  (testing "mcp-config also adds --strict-mcp-config so host MCP config does not leak"
-    (let [args ((private-fn 'claude-args) {:prompt "p" :mcp-config "/tmp/mcp.json"})]
-      (is (some #(= "--strict-mcp-config" %) args))
-      (is (= ["--mcp-config" "/tmp/mcp.json" "--strict-mcp-config"]
-             (->> args
-                  (drop-while #(not= "--mcp-config" %))
-                  (take 3)))
-          "--strict-mcp-config immediately follows the --mcp-config path")))
-
-  (testing "no mcp-config means no --strict-mcp-config"
-    (let [args ((private-fn 'claude-args) {:prompt "p"})]
-      (is (not (some #(= "--strict-mcp-config" %) args))))))
-
-(deftest claude-args-allowed-tools-test
-  (testing "mcp maps format as mcp__<server>__<tool>, joined with commas"
-    (let [args ((private-fn 'claude-args)
-                {:prompt "p"
-                 :mcp-allowed-tools
-                 [{:mcp/server :context :mcp/tool :context_read}
-                  {:mcp/server :context :mcp/tool :context_grep}]})]
-      (is (some #(= "--allowedTools" %) args))
-      (is (some #(= "mcp__context__context_read,mcp__context__context_grep" %) args))))
-
-  (testing "bare keywords format as the native tool name"
-    (let [args ((private-fn 'claude-args)
-                {:prompt "p"
-                 :mcp-allowed-tools [:Write :Edit]})]
-      (is (some #(= "Write,Edit" %) args))))
-
-  (testing "mixed maps + keywords format correctly"
-    (let [args ((private-fn 'claude-args)
-                {:prompt "p"
-                 :mcp-allowed-tools
-                 [{:mcp/server :context :mcp/tool :context_read}
-                  :Write]})]
-      (is (some #(= "mcp__context__context_read,Write" %) args)))))
-
-(deftest claude-mcp-allowlist-string-test
+(deftest ^{:stratum 0} claude-mcp-allowlist-string-test
   (testing "keyword server + tool → mcp__<server>__<tool>"
     (is (= "mcp__context__context_read"
            (impl/claude-mcp-allowlist-string
@@ -115,50 +56,129 @@
   (testing "empty vector produces empty string"
     (is (= "" (impl/claude-mcp-allowlist-string [])))))
 
-(deftest claude-args-disallowed-tools-test
+;; ============================================================================
+;; backends map wiring
+;; ============================================================================
+(deftest ^{:stratum 0} backends-args-fn-wired-test
+  (testing "all backends with :args-fn reference named functions, not lambdas"
+    (doseq [[k backend] impl/backends
+            :when (:args-fn backend)]
+      (is (fn? (:args-fn backend))
+          (str "Backend " k " should have a function :args-fn")))))
+
+(deftest ^{:stratum 0} opencode-backend-wiring-test
+  (testing "OpenCode backend delegates auth/provider handling to OpenCode"
+    (is (= "opencode" (get-in impl/backends [:opencode :cmd])))
+    (is (= "OpenCode" (get-in impl/backends [:opencode :provider])))
+    (is (false? (get-in impl/backends [:opencode :streaming?])))
+    (is (not (contains? (get impl/backends :opencode) :api-key-var)))
+    (is (= :argv (get-in impl/backends [:opencode :prompt-via])))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; ============================================================================
+;; claude-args
+;; ============================================================================
+(deftest ^{:stratum 1} claude-args-minimal-test
+  (testing "minimal prompt produces [-p <prompt>]"
+    (let [args ((private-fn 'claude-args) {:prompt "hello"})]
+      (is (= ["-p" "hello"] args)))))
+
+(deftest ^{:stratum 1} claude-args-streaming-test
+  (testing "streaming adds output-format and verbose flags"
+    (let [args ((private-fn 'claude-args) {:prompt "hi" :streaming? true})]
+      (is (some #(= "--output-format" %) args))
+      (is (some #(= "stream-json" %) args))
+      (is (some #(= "--verbose" %) args))
+      (is (= "hi" (last args))))))
+
+(deftest ^{:stratum 1} claude-args-mcp-config-test
+  (testing "mcp-config adds --mcp-config flag"
+    (let [args ((private-fn 'claude-args) {:prompt "p" :mcp-config "/tmp/mcp.json"})]
+      (is (some #(= "--mcp-config" %) args))
+      (is (some #(= "/tmp/mcp.json" %) args))))
+
+  (testing "mcp-config also adds --strict-mcp-config so host MCP config does not leak"
+    (let [args ((private-fn 'claude-args) {:prompt "p" :mcp-config "/tmp/mcp.json"})]
+      (is (some #(= "--strict-mcp-config" %) args))
+      (is (= ["--mcp-config" "/tmp/mcp.json" "--strict-mcp-config"]
+             (->> args
+                  (drop-while #(not= "--mcp-config" %))
+                  (take 3)))
+          "--strict-mcp-config immediately follows the --mcp-config path")))
+
+  (testing "no mcp-config means no --strict-mcp-config"
+    (let [args ((private-fn 'claude-args) {:prompt "p"})]
+      (is (not (some #(= "--strict-mcp-config" %) args))))))
+
+(deftest ^{:stratum 1} claude-args-allowed-tools-test
+  (testing "mcp maps format as mcp__<server>__<tool>, joined with commas"
+    (let [args ((private-fn 'claude-args)
+                {:prompt "p"
+                 :mcp-allowed-tools
+                 [{:mcp/server :context :mcp/tool :context_read}
+                  {:mcp/server :context :mcp/tool :context_grep}]})]
+      (is (some #(= "--allowedTools" %) args))
+      (is (some #(= "mcp__context__context_read,mcp__context__context_grep" %) args))))
+
+  (testing "bare keywords format as the native tool name"
+    (let [args ((private-fn 'claude-args)
+                {:prompt "p"
+                 :mcp-allowed-tools [:Write :Edit]})]
+      (is (some #(= "Write,Edit" %) args))))
+
+  (testing "mixed maps + keywords format correctly"
+    (let [args ((private-fn 'claude-args)
+                {:prompt "p"
+                 :mcp-allowed-tools
+                 [{:mcp/server :context :mcp/tool :context_read}
+                  :Write]})]
+      (is (some #(= "mcp__context__context_read,Write" %) args)))))
+
+(deftest ^{:stratum 1} claude-args-disallowed-tools-test
   (testing "disallowed-tools adds --disallowedTools"
     (let [args ((private-fn 'claude-args) {:prompt "p" :disallowed-tools ["bad"]})]
       (is (some #(= "--disallowedTools" %) args))
       (is (some #(= "bad" %) args)))))
 
-(deftest claude-args-system-prompt-test
+(deftest ^{:stratum 1} claude-args-system-prompt-test
   (testing "system prompt adds --system-prompt flag"
     (let [args ((private-fn 'claude-args) {:prompt "p" :system "You are helpful"})]
       (is (some #(= "--system-prompt" %) args))
       (is (some #(= "You are helpful" %) args)))))
 
-(deftest claude-args-budget-test
+(deftest ^{:stratum 1} claude-args-budget-test
   (testing "explicit budget-usd sets --max-budget-usd"
     (let [args ((private-fn 'claude-args) {:prompt "p" :budget-usd 5.0})]
       (is (some #(= "--max-budget-usd" %) args))
       (is (some #(= "5.0" %) args)))))
 
-(deftest claude-args-max-turns-test
+(deftest ^{:stratum 1} claude-args-max-turns-test
   (testing "max-turns adds --max-turns flag"
     (let [args ((private-fn 'claude-args) {:prompt "p" :max-turns 10})]
       (is (some #(= "--max-turns" %) args))
       (is (some #(= "10" %) args)))))
 
-(deftest claude-args-supervision-settings-test
+(deftest ^{:stratum 1} claude-args-supervision-settings-test
   (testing "supervision settings path adds --settings flag"
     (let [args ((private-fn 'claude-args)
                 {:prompt "p" :supervision {:settings-path "/tmp/s.json"}})]
       (is (some #(= "--settings" %) args))
       (is (some #(= "/tmp/s.json" %) args)))))
 
-(deftest claude-args-model-test
+(deftest ^{:stratum 1} claude-args-model-test
   (testing "model adds --model flag"
     (let [args ((private-fn 'claude-args) {:prompt "p" :model "claude-sonnet-4-6"})]
       (is (some #(= "--model" %) args))
       (is (some #(= "claude-sonnet-4-6" %) args)))))
 
-(deftest claude-args-resume-test
+(deftest ^{:stratum 1} claude-args-resume-test
   (testing "resume adds --resume flag"
     (let [args ((private-fn 'claude-args) {:prompt "p" :resume "session-abc"})]
       (is (some #(= "--resume" %) args))
       (is (some #(= "session-abc" %) args)))))
 
-(deftest claude-args-prompt-always-last-test
+(deftest ^{:stratum 1} claude-args-prompt-always-last-test
   (testing "prompt is always the last argument"
     (let [args ((private-fn 'claude-args)
                 {:prompt "the-prompt" :streaming? true :system "sys"
@@ -168,8 +188,7 @@
 ;; ============================================================================
 ;; codex-args
 ;; ============================================================================
-
-(deftest codex-args-minimal-test
+(deftest ^{:stratum 1} codex-args-minimal-test
   (testing "minimal prompt produces exec with explicit sandbox + approval flags"
     (let [args ((private-fn 'codex-args) {:prompt "fix bug"
                                           :prompt-via :argv})]
@@ -183,20 +202,20 @@
       (is (some #(= "--skip-git-repo-check" %) args))
       (is (= "fix bug" (last args))))))
 
-(deftest codex-args-defaults-to-stdin-test
+(deftest ^{:stratum 1} codex-args-defaults-to-stdin-test
   (testing "default prompt delivery follows the backend stdin shape"
     (let [args ((private-fn 'codex-args) {:prompt "fix bug"})]
       (is (not (some #{"fix bug"} args)))
       (is (= "-" (last args))))))
 
-(deftest codex-args-stdin-test
+(deftest ^{:stratum 1} codex-args-stdin-test
   (testing "stdin prompt delivery keeps prompt content out of argv"
     (let [args ((private-fn 'codex-args)
                 {:prompt "fix bug" :prompt-via :stdin})]
       (is (not (some #{"fix bug"} args)))
       (is (= "-" (last args))))))
 
-(deftest codex-args-preflight-safe-config-test
+(deftest ^{:stratum 1} codex-args-preflight-safe-config-test
   (testing "config overrides are safe before artifact MCP config exists"
     (let [args ((private-fn 'codex-args) {:prompt "p"})]
       ;; The artifact MCP config writer marks the server required. Passing
@@ -207,13 +226,13 @@
       ;; cannot relax it.
       (is (some #(re-matches #"approval_policy=\"?never\"?" %) args)))))
 
-(deftest codex-args-model-test
+(deftest ^{:stratum 1} codex-args-model-test
   (testing "model adds -m flag"
     (let [args ((private-fn 'codex-args) {:prompt "p" :model "gpt-4o"})]
       (is (some #(= "-m" %) args))
       (is (some #(= "gpt-4o" %) args)))))
 
-(deftest codex-args-system-test
+(deftest ^{:stratum 1} codex-args-system-test
   (testing "system prompt adds -c flag with JSON-encoded value"
     (let [args ((private-fn 'codex-args) {:prompt "p" :system "be helpful"})]
       (is (some #(str/starts-with? % "system_prompt=") args)))))
@@ -221,24 +240,23 @@
 ;; ============================================================================
 ;; cursor-args
 ;; ============================================================================
-
-(deftest cursor-args-minimal-test
+(deftest ^{:stratum 1} cursor-args-minimal-test
   (testing "minimal prompt produces [-p --force <prompt>] (autonomous writes)"
     (let [args ((private-fn 'cursor-args) {:prompt "fix it"})]
       (is (= ["-p" "--force" "fix it"] args)))))
 
-(deftest cursor-args-no-approve-mcps-test
+(deftest ^{:stratum 1} cursor-args-no-approve-mcps-test
   (testing "MCP scoping is via the permissions allowlist, not --approve-mcps"
     (let [args ((private-fn 'cursor-args) {:prompt "p" :mcp-allowed-tools ["t1"]})]
       (is (not (some #(= "--approve-mcps" %) args)))
       (is (= "p" (last args))))))
 
-(deftest cursor-args-model-test
+(deftest ^{:stratum 1} cursor-args-model-test
   (testing "model adds --model <model> before the prompt"
     (let [args ((private-fn 'cursor-args) {:prompt "p" :model "gpt-5.2"})]
       (is (= ["-p" "--force" "--model" "gpt-5.2" "p"] args)))))
 
-(deftest cursor-args-system-test
+(deftest ^{:stratum 1} cursor-args-system-test
   (testing "system is prepended to the prompt (no system-prompt flag on cursor)"
     (let [args ((private-fn 'cursor-args) {:prompt "do it" :system "be terse"})]
       (is (= ["-p" "--force" "be terse\n\ndo it"] args)))))
@@ -246,13 +264,12 @@
 ;; ============================================================================
 ;; opencode-args
 ;; ============================================================================
-
-(deftest opencode-args-minimal-test
+(deftest ^{:stratum 1} opencode-args-minimal-test
   (testing "minimal prompt invokes non-interactive run"
     (let [args ((private-fn 'opencode-args) {:prompt "explain"})]
       (is (= ["run" "explain"] args)))))
 
-(deftest opencode-args-model-and-agent-test
+(deftest ^{:stratum 1} opencode-args-model-and-agent-test
   (testing "model and agent pass through to OpenCode"
     (let [args ((private-fn 'opencode-args)
                 {:prompt "fix it"
@@ -265,7 +282,7 @@
       (is (some #(= "miniforge-implementer" %) args))
       (is (= "fix it" (last args))))))
 
-(deftest opencode-args-session-and-attach-test
+(deftest ^{:stratum 1} opencode-args-session-and-attach-test
   (testing "session reuse and serve attachment flags are preserved"
     (let [args ((private-fn 'opencode-args)
                 {:prompt "continue"
@@ -279,7 +296,7 @@
               "continue"]
              args)))))
 
-(deftest opencode-args-files-test
+(deftest ^{:stratum 1} opencode-args-files-test
   (testing "attached files expand into repeated --file flags"
     (let [args ((private-fn 'opencode-args)
                 {:prompt "review"
@@ -293,27 +310,7 @@
 ;; ============================================================================
 ;; echo-args
 ;; ============================================================================
-
-(deftest echo-args-test
+(deftest ^{:stratum 1} echo-args-test
   (testing "echo backend returns prompt in a vector"
     (let [args ((private-fn 'echo-args) {:prompt "test-echo"})]
       (is (= ["test-echo"] args)))))
-
-;; ============================================================================
-;; backends map wiring
-;; ============================================================================
-
-(deftest backends-args-fn-wired-test
-  (testing "all backends with :args-fn reference named functions, not lambdas"
-    (doseq [[k backend] impl/backends
-            :when (:args-fn backend)]
-      (is (fn? (:args-fn backend))
-          (str "Backend " k " should have a function :args-fn")))))
-
-(deftest opencode-backend-wiring-test
-  (testing "OpenCode backend delegates auth/provider handling to OpenCode"
-    (is (= "opencode" (get-in impl/backends [:opencode :cmd])))
-    (is (= "OpenCode" (get-in impl/backends [:opencode :provider])))
-    (is (false? (get-in impl/backends [:opencode :streaming?])))
-    (is (not (contains? (get impl/backends :opencode) :api-key-var)))
-    (is (= :argv (get-in impl/backends [:opencode :prompt-via])))))

--- a/components/llm/test/ai/miniforge/llm/context_overflow_test.clj
+++ b/components/llm/test/ai/miniforge/llm/context_overflow_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.llm.context-overflow-test
   "Context-overflow is classified as a distinct terminal error type from the
    structured usage token counts (locale- and backend-independent), NOT from
@@ -25,10 +24,12 @@
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.llm.protocols.impl.llm-client :as impl]))
 
-(defn- private-fn [sym]
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} private-fn [sym]
   (var-get (ns-resolve 'ai.miniforge.llm.protocols.impl.llm-client sym)))
 
-(deftest total-input-tokens-test
+(deftest ^{:stratum 0} total-input-tokens-test
   (testing "sums prompt + cache-creation + cache-read; the real prompt size
             lives mostly in cache-creation, not :input-tokens"
     (is (= 204282 (impl/total-input-tokens
@@ -50,7 +51,7 @@
                :cache-creation-input-tokens :unknown
                :cache-read-input-tokens []})))))
 
-(deftest context-overflow-by-usage?-test
+(deftest ^{:stratum 0} context-overflow-by-usage?-test
   (testing "true once total input tokens reach the model's context window"
     ;; the actual adhoc-2135293220 shape: 204,282 input vs a 200k window
     (is (impl/context-overflow-by-usage?
@@ -63,7 +64,7 @@
     (is (not (impl/context-overflow-by-usage? {} 200000)))
     (is (not (impl/context-overflow-by-usage? nil 200000)))))
 
-(deftest streaming-error-response-classifies-overflow-test
+(deftest ^{:stratum 0} streaming-error-response-classifies-overflow-test
   (testing "input tokens >= window => terminal context_overflow type, not cli_error"
     (let [resp (impl/streaming-error-response
                 "Prompt is too long" 0 nil "Prompt is too long"
@@ -92,7 +93,9 @@
                 "" -1 "process died" "" nil nil nil 5 nil)]
       (is (= "cli_error" (get-in resp [:error :type]))))))
 
-(deftest parsed-usage-omits-absent-fields-test
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} parsed-usage-omits-absent-fields-test
   (testing "a cache-only usage frame produces NO nil :input-tokens key, so
             downstream `(get usage :input-tokens 0)` defaulting still works
             (would otherwise NPE in llm-success's :tokens sum)"

--- a/components/llm/test/ai/miniforge/llm/cost_test.clj
+++ b/components/llm/test/ai/miniforge/llm/cost_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.llm.cost-test
   "Pins the contract for the cost-estimate fallback used when the
    upstream CLI doesn't surface total_cost_usd in its streaming
@@ -25,6 +24,8 @@
    [ai.miniforge.llm.cost :as sut]
    [clojure.test :refer [deftest is testing]]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; Cost tolerance — pricing literals in the EDN table (`3.00`,
 ;; `0.25`, …) read as BigDecimal, so the intermediate arithmetic
 ;; mixes BigDecimal with int tokens and produces BigDecimal; the
@@ -32,15 +33,10 @@
 ;; primitive double, but a tight epsilon keeps the assertions
 ;; stable across any cast-order surprises (and matches the
 ;; tolerance pattern used in dag-orchestrator-test).
-(def ^:private cost-usd-epsilon 1.0e-9)
-
-(defn- approx=
-  [expected actual]
-  (< (Math/abs (double (- expected actual))) cost-usd-epsilon))
+(def ^{:stratum 0} ^:private cost-usd-epsilon 1.0e-9)
 
 ;------------------------------------------------------------------------------ pricing-for-model
-
-(deftest pricing-for-model-returns-entry-for-known-model-test
+(deftest ^{:stratum 0} pricing-for-model-returns-entry-for-known-model-test
   (testing "Models in the cost table return their {:input-per-1m
             :output-per-1m} pair so the estimate-cost arithmetic
             can multiply through."
@@ -48,7 +44,7 @@
       (is (= 3.0  (:input-per-1m p)))
       (is (= 15.0 (:output-per-1m p))))))
 
-(deftest pricing-for-model-nil-for-unknown-model-test
+(deftest ^{:stratum 0} pricing-for-model-nil-for-unknown-model-test
   (testing "Unknown / unpriced models return nil so estimate-cost
             can fold to a $0.00 estimate rather than throwing."
     (is (nil? (sut/pricing-for-model "not-a-real-model")))
@@ -56,7 +52,7 @@
         "free / local models simply aren't in the table — caller
          interprets nil as 'no pricing, no estimate'")))
 
-(deftest pricing-for-model-nil-input-safe-test
+(deftest ^{:stratum 0} pricing-for-model-nil-input-safe-test
   (testing "nil / non-string input returns nil rather than NPE-ing
             on the get lookup — callers may pass through a config
             map's :model value without coercion."
@@ -64,19 +60,7 @@
     (is (nil? (sut/pricing-for-model :keyword-not-string)))
     (is (nil? (sut/pricing-for-model 42)))))
 
-;------------------------------------------------------------------------------ estimate-cost
-
-(deftest estimate-cost-priced-model-test
-  (testing "Known model + usage → USD computed via
-            (in-tokens × in-per-1M + out-tokens × out-per-1M)
-            / 1,000,000. sonnet-4-6 at 3.0/15.0 with 10k input +
-            2k output = (10000 * 3 + 2000 * 15) / 1M = 60000/1M = 0.06"
-    (is (approx= 0.06
-                 (sut/estimate-cost {:input-tokens 10000
-                                     :output-tokens 2000}
-                                    "claude-sonnet-4-6")))))
-
-(deftest estimate-cost-unpriced-model-returns-zero-test
+(deftest ^{:stratum 0} estimate-cost-unpriced-model-returns-zero-test
   (testing "Unpriced model → 0.0 rather than nil or throw. Lets the
             caller assoc the value into the streaming response
             unconditionally without a nil-guard."
@@ -84,7 +68,7 @@
                                    :output-tokens 50000}
                                   "free-local-model")))))
 
-(deftest estimate-cost-missing-or-nonnumeric-token-counts-return-zero-test
+(deftest ^{:stratum 0} estimate-cost-missing-or-nonnumeric-token-counts-return-zero-test
   (testing "Missing usage or non-numeric token counts with a priced model
             return 0.0 — absent tokens mean zero cost, no surprises."
     (is (= 0.0 (sut/estimate-cost nil "claude-sonnet-4-6")))
@@ -99,31 +83,8 @@
                                    :output-tokens :unknown}
                                   "claude-sonnet-4-6")))))
 
-(deftest estimate-cost-missing-input-or-output-tokens-test
-  (testing "Partial usage maps (only :input-tokens, only
-            :output-tokens) default the missing side to 0."
-    (is (approx= 0.03
-                 (sut/estimate-cost {:input-tokens 10000}
-                                    "claude-sonnet-4-6"))
-        "10000 * 3/1M = 0.03 — :output-tokens default 0 contributes 0")
-    (is (approx= 0.03
-                 (sut/estimate-cost {:output-tokens 2000}
-                                    "claude-sonnet-4-6"))
-        "2000 * 15/1M = 0.03 — :input-tokens default 0 contributes 0")))
-
-(deftest estimate-cost-haiku-cheap-pricing-test
-  (testing "Haiku's much cheaper pricing demonstrates the table
-            is per-model (not a constant rate). 10k+2k tokens at
-            $0.25/$1.25 per 1M = (10000*0.25 + 2000*1.25)/1M =
-            (2500 + 2500)/1M = 0.005"
-    (is (approx= 0.005
-                 (sut/estimate-cost {:input-tokens 10000
-                                     :output-tokens 2000}
-                                    "claude-haiku-4-5-20251001")))))
-
 ;------------------------------------------------------------------------------ Exceptions-as-data: cost-table load failure
-
-(deftest cost-table-load-failure-yields-empty-map-test
+(deftest ^{:stratum 0} cost-table-load-failure-yields-empty-map-test
   (testing "Slurp / edn-parse failure on the EDN resource must NOT
             cause estimate-cost / pricing-for-model to throw — both
             are documented as exceptions-as-data (never throw). The
@@ -159,6 +120,47 @@
               "resource failure caught at delay boundary, defaults to {}")
           (is (pos? @load-attempts)
               "the boundary guard actually exercised the failing path"))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} approx=
+  [expected actual]
+  (< (Math/abs (double (- expected actual))) cost-usd-epsilon))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;------------------------------------------------------------------------------ estimate-cost
+(deftest ^{:stratum 2} estimate-cost-priced-model-test
+  (testing "Known model + usage → USD computed via
+            (in-tokens × in-per-1M + out-tokens × out-per-1M)
+            / 1,000,000. sonnet-4-6 at 3.0/15.0 with 10k input +
+            2k output = (10000 * 3 + 2000 * 15) / 1M = 60000/1M = 0.06"
+    (is (approx= 0.06
+                 (sut/estimate-cost {:input-tokens 10000
+                                     :output-tokens 2000}
+                                    "claude-sonnet-4-6")))))
+
+(deftest ^{:stratum 2} estimate-cost-missing-input-or-output-tokens-test
+  (testing "Partial usage maps (only :input-tokens, only
+            :output-tokens) default the missing side to 0."
+    (is (approx= 0.03
+                 (sut/estimate-cost {:input-tokens 10000}
+                                    "claude-sonnet-4-6"))
+        "10000 * 3/1M = 0.03 — :output-tokens default 0 contributes 0")
+    (is (approx= 0.03
+                 (sut/estimate-cost {:output-tokens 2000}
+                                    "claude-sonnet-4-6"))
+        "2000 * 15/1M = 0.03 — :input-tokens default 0 contributes 0")))
+
+(deftest ^{:stratum 2} estimate-cost-haiku-cheap-pricing-test
+  (testing "Haiku's much cheaper pricing demonstrates the table
+            is per-model (not a constant rate). 10k+2k tokens at
+            $0.25/$1.25 per 1M = (10000*0.25 + 2000*1.25)/1M =
+            (2500 + 2500)/1M = 0.005"
+    (is (approx= 0.005
+                 (sut/estimate-cost {:input-tokens 10000
+                                     :output-tokens 2000}
+                                    "claude-haiku-4-5-20251001")))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/llm/test/ai/miniforge/llm/http_providers_test.clj
+++ b/components/llm/test/ai/miniforge/llm/http_providers_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.llm.http-providers-test
   "Direct API-key HTTP provider backends (:anthropic-api / :openai-api /
    :gemini-api): request-body shaping, auth headers, endpoint
@@ -29,41 +28,26 @@
    [ai.miniforge.llm.protocols.impl.llm-client :as impl]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Fixtures
 
-(def ^:private test-api-key
+;; Fixtures
+(def ^{:stratum 0} ^:private test-api-key
   "Opaque key value asserted against captured request headers. Passed
    as explicit `:api-key` config so a developer's real provider env
    vars can never leak into (or satisfy) these tests."
   "mf-test-api-key")
 
-(def ^:private missing-key-env
+(def ^{:stratum 0} ^:private missing-key-env
   "Env-var name driving the missing-API-key error path. Unique per test
    run (nanotime suffix), so the test never depends on a hard-coded name
    happening to be unset in the host environment."
   (str "MF_TEST_NONEXISTENT_API_KEY_" (System/nanoTime)))
 
-(defn- http-200
+(defn- ^{:stratum 0} http-200
   "HTTP response fixture with the given body map JSON-encoded."
   [body]
   {:status 200 :body (json/generate-string body)})
 
-(defn- anthropic-200
-  [text]
-  (http-200 {:content [{:type "text" :text text}]
-             :usage {:input_tokens 11 :output_tokens 7}}))
-
-(defn- openai-200
-  [text]
-  (http-200 {:choices [{:message {:role "assistant" :content text}}]
-             :usage {:prompt_tokens 11 :completion_tokens 7}}))
-
-(defn- gemini-200
-  [text]
-  (http-200 {:candidates [{:content {:parts [{:text text}]}}]
-             :usageMetadata {:promptTokenCount 11 :candidatesTokenCount 7}}))
-
-(defn- capture-http
+(defn- ^{:stratum 0} capture-http
   "Run `f` with `http-post-request` stubbed to record its arguments
    and return `response`. Returns {:result <f's value> :captured
    {:url :headers :body}}."
@@ -75,14 +59,12 @@
                     response)]
       {:result (f) :captured @captured})))
 
-(defn- backend-config
+(defn- ^{:stratum 0} backend-config
   [backend]
   (get impl/backends backend))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Request-body builders
-
-(deftest anthropic-request-body-test
+(deftest ^{:stratum 0} anthropic-request-body-test
   (testing "prompt becomes a single user message; max_tokens defaults from config"
     (let [body (impl/anthropic-request-body {:prompt "hi" :model "claude-opus-4-8"})]
       (is (= "claude-opus-4-8" (:model body)))
@@ -111,7 +93,7 @@
               {:role "assistant" :content "b"}]
              (:messages body))))))
 
-(deftest ollama-request-body-num-ctx-test
+(deftest ^{:stratum 0} ollama-request-body-num-ctx-test
   (testing ":num-ctx becomes Ollama's options.num_ctx; absent means no options
             key at all (Ollama then applies its own default)"
     (let [body (impl/ollama-request-body {:prompt "hi" :model "m" :num-ctx 32768})]
@@ -119,20 +101,7 @@
     (let [body (impl/ollama-request-body {:prompt "hi" :model "m"})]
       (is (not (contains? body :options))))))
 
-(deftest ollama-num-ctx-threads-from-client-config-test
-  (testing "a client created with :num-ctx sends it on every Ollama request —
-            the silent-truncation guard for long prompts"
-    (let [{:keys [captured]}
-          (capture-http (http-200 {:message {:content "ok"}
-                                   :prompt_eval_count 1 :eval_count 1})
-                        (fn []
-                          (llm/complete (llm/create-client {:backend :ollama
-                                                            :model "m"
-                                                            :num-ctx 65536})
-                                        {:prompt "long surface"})))]
-      (is (= {:num_ctx 65536} (:options (:body captured)))))))
-
-(deftest openai-request-body-test
+(deftest ^{:stratum 0} openai-request-body-test
   (testing "system becomes the leading system-role message"
     (let [body (impl/openai-request-body {:prompt "hi" :model "gpt-x" :system "s"})]
       (is (= [{:role "system" :content "s"}
@@ -144,7 +113,7 @@
     (is (not (contains? (impl/openai-request-body {:prompt "p" :model "m"})
                         :max_completion_tokens)))))
 
-(deftest gemini-request-body-test
+(deftest ^{:stratum 0} gemini-request-body-test
   (testing "assistant role maps to model; system rides in systemInstruction"
     (let [body (impl/gemini-request-body
                 {:messages [{:role "user" :content "q"}
@@ -159,57 +128,50 @@
     (is (= {:maxOutputTokens 5}
            (:generationConfig (impl/gemini-request-body {:prompt "p" :max-tokens 5}))))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; http-complete: headers, endpoints, parsing, key resolution
+(deftest ^{:stratum 0} ollama-response-failures-are-data-test
+  (testing "a non-OK response is classified by status without throwing"
+    (let [result (impl/parse-ollama-response
+                  {:status 503 :body (json/generate-string {:error "overloaded"})})]
+      (is (= "api_error" (get-in result [:error :type])))
+      (is (= :unavailable (get-in result [:anomaly :anomaly/type])))))
+  (testing "malformed JSON on a 200 becomes a parse failure with provenance"
+    (let [result (impl/parse-ollama-response {:status 200 :body "not-json"})]
+      (is (= "parse_error" (get-in result [:error :type])))
+      (is (= :fault (get-in result [:anomaly :anomaly/type])))
+      (is (= :parse-provider-response
+             (get-in result [:anomaly :anomaly/data :operation]))))))
 
-(deftest anthropic-api-round-trip-test
-  (let [{:keys [result captured]}
-        (capture-http (anthropic-200 "answer")
-                      #(impl/http-complete (backend-config :anthropic-api)
-                                           {:prompt "q" :model "claude-opus-4-8"}
-                                           {:api-key test-api-key}))]
-    (testing "request goes to the Messages API with key + version headers"
-      (is (= "https://api.anthropic.com/v1/messages" (:url captured)))
-      (is (= test-api-key (get-in captured [:headers "x-api-key"])))
-      (is (string? (get-in captured [:headers "anthropic-version"])))
-      (is (= "claude-opus-4-8" (get-in captured [:body :model]))))
-    (testing "response parses to canonical success"
-      (is (:success result))
-      (is (= "answer" (:content result)))
-      (is (= {:input-tokens 11 :output-tokens 7} (:usage result)))
-      (is (= 18 (:tokens result))))))
+;------------------------------------------------------------------------------ Layer 1
 
-(deftest openai-api-round-trip-test
-  (let [{:keys [result captured]}
-        (capture-http (openai-200 "answer")
-                      #(impl/http-complete (backend-config :openai-api)
-                                           {:prompt "q" :model "gpt-x"}
-                                           {:api-key test-api-key}))]
-    (testing "request carries a Bearer authorization header"
-      (is (= "https://api.openai.com/v1/chat/completions" (:url captured)))
-      (is (= (str "Bearer " test-api-key)
-             (get-in captured [:headers "Authorization"]))))
-    (testing "response parses choices + prompt/completion usage"
-      (is (:success result))
-      (is (= "answer" (:content result)))
-      (is (= {:input-tokens 11 :output-tokens 7} (:usage result))))))
+(defn- ^{:stratum 1} anthropic-200
+  [text]
+  (http-200 {:content [{:type "text" :text text}]
+             :usage {:input_tokens 11 :output_tokens 7}}))
 
-(deftest gemini-api-round-trip-test
-  (let [{:keys [result captured]}
-        (capture-http (gemini-200 "answer")
-                      #(impl/http-complete (backend-config :gemini-api)
-                                           {:prompt "q" :model "gemini-x"}
-                                           {:api-key test-api-key}))]
-    (testing "model is embedded in the URL path, key in x-goog-api-key"
-      (is (= "https://generativelanguage.googleapis.com/v1beta/models/gemini-x:generateContent"
-             (:url captured)))
-      (is (= test-api-key (get-in captured [:headers "x-goog-api-key"]))))
-    (testing "response parses candidates + usageMetadata"
-      (is (:success result))
-      (is (= "answer" (:content result)))
-      (is (= {:input-tokens 11 :output-tokens 7} (:usage result))))))
+(defn- ^{:stratum 1} openai-200
+  [text]
+  (http-200 {:choices [{:message {:role "assistant" :content text}}]
+             :usage {:prompt_tokens 11 :completion_tokens 7}}))
 
-(deftest openai-compat-wiring-test
+(defn- ^{:stratum 1} gemini-200
+  [text]
+  (http-200 {:candidates [{:content {:parts [{:text text}]}}]
+             :usageMetadata {:promptTokenCount 11 :candidatesTokenCount 7}}))
+
+(deftest ^{:stratum 1} ollama-num-ctx-threads-from-client-config-test
+  (testing "a client created with :num-ctx sends it on every Ollama request —
+            the silent-truncation guard for long prompts"
+    (let [{:keys [captured]}
+          (capture-http (http-200 {:message {:content "ok"}
+                                   :prompt_eval_count 1 :eval_count 1})
+                        (fn []
+                          (llm/complete (llm/create-client {:backend :ollama
+                                                            :model "m"
+                                                            :num-ctx 65536})
+                                        {:prompt "long surface"})))]
+      (is (= {:num_ctx 65536} (:options (:body captured)))))))
+
+(deftest ^{:stratum 1} openai-compat-wiring-test
   (testing "the generic backend rides the OpenAI wire shape, carries an
             OPTIONAL api key (so a key is sent when present but never
             required — keyless local servers still work), and defaults to
@@ -224,94 +186,7 @@
       (is (= "MINIFORGE_OPENAI_COMPAT_BASE_URL" (:base-url-env entry)))
       (is (false? (:requires-cli? entry))))))
 
-(deftest openai-compat-keyless-round-trip-test
-  (testing "a keyless local server gets no Authorization header; the OpenAI
-            body/parse shapes are reused"
-    (let [{:keys [result captured]}
-          (capture-http (openai-200 "local answer")
-                        (fn []
-                          (with-redefs [impl/getenv-value (constantly nil)]
-                            (llm/complete (llm/create-client {:backend :openai-compat
-                                                              :model "qwen3-30b-a3b"})
-                                          {:prompt "hi"}))))]
-      (is (true? (:success result)))
-      (is (= "local answer" (:content result)))
-      (is (= "http://localhost:1234/v1/chat/completions" (:url captured)))
-      (is (not (contains? (:headers captured) "Authorization")))
-      (is (= "qwen3-30b-a3b" (:model (:body captured)))))))
-
-(deftest openai-compat-key-and-base-url-override-test
-  (testing "a supplied :api-key becomes a bearer header and :base-url wins
-            over the default endpoint"
-    (let [{:keys [captured]}
-          (capture-http (openai-200 "ok")
-                        (fn []
-                          (llm/complete (llm/create-client
-                                         {:backend :openai-compat
-                                          :model "m"
-                                          :api-key test-api-key
-                                          :base-url "http://localhost:8000/v1/chat/completions"})
-                                        {:prompt "hi"})))]
-      (is (= (str "Bearer " test-api-key)
-             (get (:headers captured) "Authorization")))
-      (is (= "http://localhost:8000/v1/chat/completions" (:url captured))))))
-
-(deftest base-url-override-is-scoped-to-declaring-backends-test
-  (testing "a stray :base-url on a fixed-endpoint provider is ignored —
-            only backends declaring :base-url-env support the override"
-    (let [{:keys [captured]}
-          (capture-http (openai-200 "ok")
-                        (fn []
-                          (llm/complete (llm/create-client
-                                         {:backend :openai-api
-                                          :model "m"
-                                          :api-key test-api-key
-                                          :base-url "http://localhost:9999/hijack"})
-                                        {:prompt "hi"})))]
-      (is (= "https://api.openai.com/v1/chat/completions" (:url captured))))))
-
-(deftest openai-compat-requires-model-test
-  (testing "no model on client or request fails closed before any request"
-    (let [{:keys [result captured]}
-          (capture-http (openai-200 "never")
-                        (fn []
-                          (llm/complete (llm/create-client {:backend :openai-compat})
-                                        {:prompt "hi"})))]
-      (is (false? (:success result)))
-      (is (= "missing_model" (get-in result [:error :type])))
-      (is (nil? captured) "failed closed before the transport"))))
-
-(deftest openai-compat-api-key-is-optional-not-fail-closed-test
-  (testing "openai-compat declares :api-key-env but :optional-api-key? true, so
-            a missing key does NOT fail closed (a local keyless server works) —
-            unlike the cloud providers which do fail closed"
-    (let [{:keys [result captured]}
-          (capture-http (openai-200 "keyless ok")
-                        (fn []
-                          (with-redefs [impl/getenv-value (constantly nil)]
-                            (llm/complete (llm/create-client {:backend :openai-compat
-                                                              :model "m"})
-                                          {:prompt "hi"}))))]
-      (is (true? (:success result)) "no key -> still succeeds (keyless)")
-      (is (not (contains? (:headers captured) "Authorization"))
-          "no Authorization header when no key is resolved"))))
-
-(deftest openai-compat-resolves-api-key-from-env-test
-  (testing "with no client :api-key, the key resolves from the backend's
-            :api-key-env (the OpenRouter path) and becomes a bearer header"
-    (let [env-var (get (backend-config :openai-compat) :api-key-env)
-          {:keys [captured]}
-          (capture-http (openai-200 "keyed ok")
-                        (fn []
-                          (with-redefs [impl/getenv-value
-                                        (fn [k] (when (= k env-var) test-api-key))]
-                            (llm/complete (llm/create-client {:backend :openai-compat
-                                                              :model "m"})
-                                          {:prompt "hi"}))))]
-      (is (= (str "Bearer " test-api-key)
-             (get (:headers captured) "Authorization"))))))
-
-(deftest missing-api-key-test
+(deftest ^{:stratum 1} missing-api-key-test
   (let [result (impl/http-complete {:provider "Anthropic"
                                     :api-key-env missing-key-env
                                     :api-endpoint "http://llm-test.invalid/"}
@@ -332,7 +207,7 @@
         (is (not (:success result)) (pr-str blank))
         (is (= "missing_api_key" (get-in result [:error :type])))))))
 
-(defn- provider-error
+(defn- ^{:stratum 1} provider-error
   "Run an anthropic-api request against a canned non-200 response and
    return the parsed result."
   [status body]
@@ -341,7 +216,169 @@
                                               {:prompt "q" :model "m"}
                                               {:api-key test-api-key}))))
 
-(deftest provider-error-responses-test
+(deftest ^{:stratum 1} missing-model-test
+  (testing "an API provider without a model fails closed before any request"
+    (let [result (impl/http-complete (backend-config :anthropic-api)
+                                     {:prompt "q"}
+                                     {:api-key test-api-key})]
+      (is (not (:success result)))
+      (is (= "missing_model" (get-in result [:error :type])))
+      (is (= :invalid-input (get-in result [:anomaly :anomaly/type])))))
+  (testing "ollama without a model still runs (body builder defaults it)"
+    (let [{:keys [result captured]}
+          (capture-http (http-200 {:message {:content "hi"}})
+                        #(impl/http-complete (backend-config :ollama)
+                                             {:prompt "q"}
+                                             {}))]
+      (is (:success result))
+      (is (string? (get-in captured [:body :model]))))))
+
+(deftest ^{:stratum 1} ollama-usage-nil-guard-test
+  (testing "missing eval counts produce an empty usage map, not a nil-keyed one"
+    (let [result (impl/parse-ollama-response
+                  (http-200 {:message {:content "hi"}}))]
+      (is (:success result))
+      (is (= {} (:usage result)))
+      (is (= 0 (:tokens result))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; http-complete: headers, endpoints, parsing, key resolution
+(deftest ^{:stratum 2} anthropic-api-round-trip-test
+  (let [{:keys [result captured]}
+        (capture-http (anthropic-200 "answer")
+                      #(impl/http-complete (backend-config :anthropic-api)
+                                           {:prompt "q" :model "claude-opus-4-8"}
+                                           {:api-key test-api-key}))]
+    (testing "request goes to the Messages API with key + version headers"
+      (is (= "https://api.anthropic.com/v1/messages" (:url captured)))
+      (is (= test-api-key (get-in captured [:headers "x-api-key"])))
+      (is (string? (get-in captured [:headers "anthropic-version"])))
+      (is (= "claude-opus-4-8" (get-in captured [:body :model]))))
+    (testing "response parses to canonical success"
+      (is (:success result))
+      (is (= "answer" (:content result)))
+      (is (= {:input-tokens 11 :output-tokens 7} (:usage result)))
+      (is (= 18 (:tokens result))))))
+
+(deftest ^{:stratum 2} openai-api-round-trip-test
+  (let [{:keys [result captured]}
+        (capture-http (openai-200 "answer")
+                      #(impl/http-complete (backend-config :openai-api)
+                                           {:prompt "q" :model "gpt-x"}
+                                           {:api-key test-api-key}))]
+    (testing "request carries a Bearer authorization header"
+      (is (= "https://api.openai.com/v1/chat/completions" (:url captured)))
+      (is (= (str "Bearer " test-api-key)
+             (get-in captured [:headers "Authorization"]))))
+    (testing "response parses choices + prompt/completion usage"
+      (is (:success result))
+      (is (= "answer" (:content result)))
+      (is (= {:input-tokens 11 :output-tokens 7} (:usage result))))))
+
+(deftest ^{:stratum 2} gemini-api-round-trip-test
+  (let [{:keys [result captured]}
+        (capture-http (gemini-200 "answer")
+                      #(impl/http-complete (backend-config :gemini-api)
+                                           {:prompt "q" :model "gemini-x"}
+                                           {:api-key test-api-key}))]
+    (testing "model is embedded in the URL path, key in x-goog-api-key"
+      (is (= "https://generativelanguage.googleapis.com/v1beta/models/gemini-x:generateContent"
+             (:url captured)))
+      (is (= test-api-key (get-in captured [:headers "x-goog-api-key"]))))
+    (testing "response parses candidates + usageMetadata"
+      (is (:success result))
+      (is (= "answer" (:content result)))
+      (is (= {:input-tokens 11 :output-tokens 7} (:usage result))))))
+
+(deftest ^{:stratum 2} openai-compat-keyless-round-trip-test
+  (testing "a keyless local server gets no Authorization header; the OpenAI
+            body/parse shapes are reused"
+    (let [{:keys [result captured]}
+          (capture-http (openai-200 "local answer")
+                        (fn []
+                          (with-redefs [impl/getenv-value (constantly nil)]
+                            (llm/complete (llm/create-client {:backend :openai-compat
+                                                              :model "qwen3-30b-a3b"})
+                                          {:prompt "hi"}))))]
+      (is (true? (:success result)))
+      (is (= "local answer" (:content result)))
+      (is (= "http://localhost:1234/v1/chat/completions" (:url captured)))
+      (is (not (contains? (:headers captured) "Authorization")))
+      (is (= "qwen3-30b-a3b" (:model (:body captured)))))))
+
+(deftest ^{:stratum 2} openai-compat-key-and-base-url-override-test
+  (testing "a supplied :api-key becomes a bearer header and :base-url wins
+            over the default endpoint"
+    (let [{:keys [captured]}
+          (capture-http (openai-200 "ok")
+                        (fn []
+                          (llm/complete (llm/create-client
+                                         {:backend :openai-compat
+                                          :model "m"
+                                          :api-key test-api-key
+                                          :base-url "http://localhost:8000/v1/chat/completions"})
+                                        {:prompt "hi"})))]
+      (is (= (str "Bearer " test-api-key)
+             (get (:headers captured) "Authorization")))
+      (is (= "http://localhost:8000/v1/chat/completions" (:url captured))))))
+
+(deftest ^{:stratum 2} base-url-override-is-scoped-to-declaring-backends-test
+  (testing "a stray :base-url on a fixed-endpoint provider is ignored —
+            only backends declaring :base-url-env support the override"
+    (let [{:keys [captured]}
+          (capture-http (openai-200 "ok")
+                        (fn []
+                          (llm/complete (llm/create-client
+                                         {:backend :openai-api
+                                          :model "m"
+                                          :api-key test-api-key
+                                          :base-url "http://localhost:9999/hijack"})
+                                        {:prompt "hi"})))]
+      (is (= "https://api.openai.com/v1/chat/completions" (:url captured))))))
+
+(deftest ^{:stratum 2} openai-compat-requires-model-test
+  (testing "no model on client or request fails closed before any request"
+    (let [{:keys [result captured]}
+          (capture-http (openai-200 "never")
+                        (fn []
+                          (llm/complete (llm/create-client {:backend :openai-compat})
+                                        {:prompt "hi"})))]
+      (is (false? (:success result)))
+      (is (= "missing_model" (get-in result [:error :type])))
+      (is (nil? captured) "failed closed before the transport"))))
+
+(deftest ^{:stratum 2} openai-compat-api-key-is-optional-not-fail-closed-test
+  (testing "openai-compat declares :api-key-env but :optional-api-key? true, so
+            a missing key does NOT fail closed (a local keyless server works) —
+            unlike the cloud providers which do fail closed"
+    (let [{:keys [result captured]}
+          (capture-http (openai-200 "keyless ok")
+                        (fn []
+                          (with-redefs [impl/getenv-value (constantly nil)]
+                            (llm/complete (llm/create-client {:backend :openai-compat
+                                                              :model "m"})
+                                          {:prompt "hi"}))))]
+      (is (true? (:success result)) "no key -> still succeeds (keyless)")
+      (is (not (contains? (:headers captured) "Authorization"))
+          "no Authorization header when no key is resolved"))))
+
+(deftest ^{:stratum 2} openai-compat-resolves-api-key-from-env-test
+  (testing "with no client :api-key, the key resolves from the backend's
+            :api-key-env (the OpenRouter path) and becomes a bearer header"
+    (let [env-var (get (backend-config :openai-compat) :api-key-env)
+          {:keys [captured]}
+          (capture-http (openai-200 "keyed ok")
+                        (fn []
+                          (with-redefs [impl/getenv-value
+                                        (fn [k] (when (= k env-var) test-api-key))]
+                            (llm/complete (llm/create-client {:backend :openai-compat
+                                                              :model "m"})
+                                          {:prompt "hi"}))))]
+      (is (= (str "Bearer " test-api-key)
+             (get (:headers captured) "Authorization"))))))
+
+(deftest ^{:stratum 2} provider-error-responses-test
   (testing "429 classifies as rate-limited, preserving status + provider message"
     (let [result (provider-error 429 {:error {:type "rate_limit_error"
                                               :message "slow down"}})]
@@ -391,48 +428,8 @@
                                      {})]
       (is (= "unsupported_backend" (get-in result [:error :type]))))))
 
-(deftest missing-model-test
-  (testing "an API provider without a model fails closed before any request"
-    (let [result (impl/http-complete (backend-config :anthropic-api)
-                                     {:prompt "q"}
-                                     {:api-key test-api-key})]
-      (is (not (:success result)))
-      (is (= "missing_model" (get-in result [:error :type])))
-      (is (= :invalid-input (get-in result [:anomaly :anomaly/type])))))
-  (testing "ollama without a model still runs (body builder defaults it)"
-    (let [{:keys [result captured]}
-          (capture-http (http-200 {:message {:content "hi"}})
-                        #(impl/http-complete (backend-config :ollama)
-                                             {:prompt "q"}
-                                             {}))]
-      (is (:success result))
-      (is (string? (get-in captured [:body :model]))))))
-
-(deftest ollama-usage-nil-guard-test
-  (testing "missing eval counts produce an empty usage map, not a nil-keyed one"
-    (let [result (impl/parse-ollama-response
-                  (http-200 {:message {:content "hi"}}))]
-      (is (:success result))
-      (is (= {} (:usage result)))
-      (is (= 0 (:tokens result))))))
-
-(deftest ollama-response-failures-are-data-test
-  (testing "a non-OK response is classified by status without throwing"
-    (let [result (impl/parse-ollama-response
-                  {:status 503 :body (json/generate-string {:error "overloaded"})})]
-      (is (= "api_error" (get-in result [:error :type])))
-      (is (= :unavailable (get-in result [:anomaly :anomaly/type])))))
-  (testing "malformed JSON on a 200 becomes a parse failure with provenance"
-    (let [result (impl/parse-ollama-response {:status 200 :body "not-json"})]
-      (is (= "parse_error" (get-in result [:error :type])))
-      (is (= :fault (get-in result [:anomaly :anomaly/type])))
-      (is (= :parse-provider-response
-             (get-in result [:anomaly :anomaly/data :operation]))))))
-
-;------------------------------------------------------------------------------ Layer 3
 ;; Client integration: config threading through complete / complete-stream
-
-(deftest client-round-trip-test
+(deftest ^{:stratum 2} client-round-trip-test
   (testing "client :model and :api-key flow through complete"
     (let [{:keys [result captured]}
           (capture-http (anthropic-200 "done")

--- a/components/llm/test/ai/miniforge/llm/interface_test.clj
+++ b/components/llm/test/ai/miniforge/llm/interface_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.llm.interface-test
   (:require [clojure.test :as test :refer [deftest testing is]]
             [clojure.string :as str]
@@ -28,14 +27,12 @@
             [cheshire.core :as json]))
 
 ;------------------------------------------------------------------------------ Layer 0
+
 ;; Test fixtures
+(def ^{:stratum 0} mock-response "This is a mock response")
 
-(def mock-response "This is a mock response")
-
-;------------------------------------------------------------------------------ Layer 1
 ;; Client creation tests
-
-(deftest create-client-test
+(deftest ^{:stratum 0} create-client-test
   (testing "creates client with default backend"
     (let [client (llm/create-client)]
       (is (some? client))))
@@ -48,7 +45,7 @@
     (is (thrown? clojure.lang.ExceptionInfo
                  (llm/create-client {:backend :unknown})))))
 
-(deftest mock-client-test
+(deftest ^{:stratum 0} mock-client-test
   (testing "creates mock client with output"
     (let [client (llm/mock-client {:output "Hello"})]
       (is (some? client))))
@@ -58,8 +55,7 @@
       (is (some? client)))))
 
 ;; Completion tests with mock client
-
-(deftest complete-test
+(deftest ^{:stratum 0} complete-test
   (testing "returns success for mock client"
     (let [client (llm/mock-client {:output "42"})
           resp (llm/complete client {:prompt "What is 6*7?"})]
@@ -84,7 +80,7 @@
       (is (not (llm/success? resp)))
       (is (some? (llm/get-error resp))))))
 
-(deftest chat-test
+(deftest ^{:stratum 0} chat-test
   (testing "simple chat returns response"
     (let [client (llm/mock-client {:output "4"})
           resp (llm/chat client "2+2?")]
@@ -96,7 +92,7 @@
           resp (llm/chat client "explain" {:system "Be brief"})]
       (is (llm/success? resp)))))
 
-(deftest multi-response-test
+(deftest ^{:stratum 0} multi-response-test
   (testing "mock client returns sequential responses"
     (let [client (llm/mock-client {:outputs ["First" "Second" "Third"]})
           r1 (llm/chat client "1")
@@ -114,8 +110,7 @@
       (is (= "B" (llm/get-content r3))))))
 
 ;; Response helper tests
-
-(deftest response-helpers-test
+(deftest ^{:stratum 0} response-helpers-test
   (testing "success? returns true for successful response"
     (is (llm/success? {:success true :content "ok"})))
 
@@ -130,21 +125,16 @@
 
 ;; Echo backend test moved to integration tests
 ;; (actual CLI calls belong in projects/miniforge/test)
-
 ;; Backends registry test
-
-(deftest backends-test
+(deftest ^{:stratum 0} backends-test
   (testing "backends contains expected keys"
     (is (contains? llm/backends :claude))
     (is (contains? llm/backends :echo))))
 
 ;; Streaming tests removed - they call actual CLIs via p/process and can't be
 ;; properly mocked in brick tests. Move to integration tests.
-
-;------------------------------------------------------------------------------ Layer 2
 ;; Metrics tracking tests (PR #248)
-
-(deftest parse-claude-stream-result-event-test
+(deftest ^{:stratum 0} parse-claude-stream-result-event-test
   (testing "result event extracts usage tokens"
     (let [line (json/generate-string
                  {:type "result"
@@ -183,7 +173,7 @@
       (is (= 42 (:num-turns parsed)))
       (is (= "max_turns" (:stop-reason parsed))))))
 
-(deftest parse-claude-stream-liveness-event-test
+(deftest ^{:stratum 0} parse-claude-stream-liveness-event-test
   (testing "rate_limit_event parses as a heartbeat — keeps stream supervision alive"
     ;; 2026-05-04 dogfood regression: parse-claude-stream-line returned nil
     ;; for rate_limit_event, so 60s of 'allowed' rate-limit notifications
@@ -207,7 +197,7 @@
           "system init refreshes liveness once at the start of the stream")
       (is (false? (:done? parsed))))))
 
-(deftest record-parsed-progress-heartbeat-liveness-test
+(deftest ^{:stratum 0} record-parsed-progress-heartbeat-liveness-test
   (testing "heartbeat-only Claude stream events are recorded as activity"
     ;; This guards the production regression path more directly than the
     ;; parser-shape test above: if parsing still succeeds but progress
@@ -239,7 +229,7 @@
         (is (nil? (pm/check-timeout monitor))
             (str label " heartbeat must keep monitor below stagnation threshold"))))))
 
-(deftest parse-claude-stream-assistant-stop-reason-test
+(deftest ^{:stratum 0} parse-claude-stream-assistant-stop-reason-test
   (testing "assistant message with text carries stop_reason"
     (let [line (json/generate-string
                  {:type "assistant"
@@ -275,7 +265,7 @@
       (is (= "partial" (:delta parsed)))
       (is (nil? (:stop-reason parsed))))))
 
-(deftest parse-codex-stream-line-test
+(deftest ^{:stratum 0} parse-codex-stream-line-test
   (testing "agent_message item extracts text delta"
     (let [line (json/generate-string
                  {:type "item.completed"
@@ -327,7 +317,7 @@
           parsed (impl/parse-codex-stream-line line)]
       (is (nil? parsed)))))
 
-(deftest parse-codex-stream-line-finish-reason-test
+(deftest ^{:stratum 0} parse-codex-stream-line-finish-reason-test
   (testing "turn.completed always sets :increment-turns true"
     (let [line (json/generate-string {:type "turn.completed"
                                       :usage {:input_tokens 10 :output_tokens 5}})
@@ -368,7 +358,7 @@
           parsed (impl/parse-codex-stream-line line)]
       (is (nil? (:stop-reason parsed))))))
 
-(deftest parse-cli-output-includes-metrics-test
+(deftest ^{:stratum 0} parse-cli-output-includes-metrics-test
   (testing "success response includes :tokens and :usage keys"
     (let [resp (impl/parse-cli-output "hello world" 0)]
       (is (:success resp))
@@ -389,7 +379,7 @@
       (is (= "empty_success_output" (get-in resp [:error :type])))
       (is (some? (:anomaly resp))))))
 
-(deftest mock-client-response-includes-metrics-test
+(deftest ^{:stratum 0} mock-client-response-includes-metrics-test
   (testing "mock client success response has :tokens and :usage"
     (let [client (llm/mock-client {:output "ok"})
           resp (llm/complete client {:prompt "test"})]
@@ -402,7 +392,7 @@
           resp (llm/complete client {:prompt "test"})]
       (is (some? (:anomaly resp))))))
 
-(deftest stream-parser-accumulates-usage-test
+(deftest ^{:stratum 0} stream-parser-accumulates-usage-test
   (testing "stream-with-parser stores usage from parsed events"
     (let [monitor (pm/create-progress-monitor {:min-activity-interval-ms 1})
           content (atom "")
@@ -440,7 +430,7 @@
       (is (= {:input-tokens 100 :output-tokens 50} @usage))
       (is (= 0.0045 @cost)))))
 
-(deftest stream-parser-recovers-result-only-content-test
+(deftest ^{:stratum 0} stream-parser-recovers-result-only-content-test
   (testing "result-only content is recovered when no assistant delta arrived"
     (let [monitor (pm/create-progress-monitor {:min-activity-interval-ms 1})
           content (atom "")
@@ -466,7 +456,7 @@
       (is (= "end_turn" @stop-reason))
       (is (= "{\"ok\":true}" (:content (last @chunks)))))))
 
-(deftest stream-parser-accumulates-stop-reason-and-turns-test
+(deftest ^{:stratum 0} stream-parser-accumulates-stop-reason-and-turns-test
   (testing "latest stop_reason wins, num_turns captured from result event"
     (let [monitor (pm/create-progress-monitor {:min-activity-interval-ms 1})
           content (atom "")
@@ -503,7 +493,7 @@
       (is (= "end_turn" @stop-reason))
       (is (= 7 @turns)))))
 
-(deftest stream-parser-codex-increment-turns-test
+(deftest ^{:stratum 0} stream-parser-codex-increment-turns-test
   (testing "turn.completed events increment the turns accumulator"
     (let [monitor (pm/create-progress-monitor {:min-activity-interval-ms 1})
           content (atom "")
@@ -552,10 +542,8 @@
       (is (= "end_turn" @stop-reason))
       (is (= 1 @turns)))))
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Rate limit detection tests
-
-(deftest rate-limited?-test
+(deftest ^{:stratum 0} rate-limited?-test
   (testing "detects Claude CLI rate limit message"
     (is (impl/rate-limited? (msg/t :rate-limit-test.system/claude-limit-la)))
     (is (impl/rate-limited? (msg/t :rate-limit-test.system/claude-limit-utc))))
@@ -578,7 +566,7 @@
                                  (msg/t :rate-limit-test.system/risk-tag)]}]}))))
     (is (not (impl/rate-limited? nil)))))
 
-(deftest rate-limited-success-response-test
+(deftest ^{:stratum 0} rate-limited-success-response-test
   (testing "rate limit content in success-response returns error"
     (let [resp (impl/success-response
                  "You've hit your limit · resets 7pm (America/Los_Angeles)" 0)]
@@ -600,7 +588,7 @@
       (is (:success resp))
       (is (= "warning on stderr" (:stderr resp))))))
 
-(deftest rate-limited-streaming-success-response-test
+(deftest ^{:stratum 0} rate-limited-streaming-success-response-test
   (testing "rate limit content in streaming-success-response returns error"
     (let [resp (impl/streaming-success-response
                  "You've hit your limit · resets 7pm (America/Los_Angeles)" 0 nil nil nil nil nil nil nil)]
@@ -618,10 +606,8 @@
       (is (= "max_turns" (:stop-reason resp)))
       (is (= 80 (:num-turns resp))))))
 
-;------------------------------------------------------------------------------ Layer 4
 ;; Diagnostic metadata tests — tool-call-count and final-message-preview
-
-(deftest streaming-success-response-diagnostic-test
+(deftest ^{:stratum 0} streaming-success-response-diagnostic-test
   (testing "tool-call-count is included when provided"
     (let [resp (impl/streaming-success-response "hello" 0 nil nil nil nil 3 nil nil)]
       (is (:success resp))
@@ -655,7 +641,7 @@
       (is (= "diagnostic stderr" (:stderr resp)))
       (is (= 0.002 (:cost-usd resp))))))
 
-(deftest streaming-error-response-diagnostic-test
+(deftest ^{:stratum 0} streaming-error-response-diagnostic-test
   (testing "tool-call-count is surfaced on error responses"
     (let [resp (impl/streaming-error-response "" -1 "process died" "" nil nil nil 5 nil)]
       (is (not (:success resp)))
@@ -692,7 +678,7 @@
       (is (= raw (get-in resp [:error :message])))
       (is (= raw (get-in resp [:error :raw-stdout]))))))
 
-(deftest process-stream-lines-eof-is-not-timeout-test
+(deftest ^{:stratum 0} process-stream-lines-eof-is-not-timeout-test
   (testing "clean EOF with no lines does not synthesize a stream-idle timeout"
     (let [reader (java.io.BufferedReader. (java.io.StringReader. ""))
           monitor (pm/create-progress-monitor
@@ -703,7 +689,7 @@
       (is (= [] (:lines result)))
       (is (nil? (:timeout result))))))
 
-(deftest process-stream-lines-read-failure-is-anomaly-data-test
+(deftest ^{:stratum 0} process-stream-lines-read-failure-is-anomaly-data-test
   (testing "reader failures return canonical anomaly data instead of throwing"
     (let [reader (java.io.BufferedReader.
                   (proxy [java.io.Reader] []
@@ -722,10 +708,11 @@
       (is (= :fault (:anomaly/type stream-anomaly)))
       (is (= "stream read failed" (:anomaly/message stream-anomaly))))))
 
-(def ^:private start-stream-reader! #'impl/start-stream-reader!)
-(def ^:private stop-stream-reader!  #'impl/stop-stream-reader!)
+(def ^{:stratum 0} ^:private start-stream-reader! #'impl/start-stream-reader!)
 
-(defn- wait-until-blocked
+(def ^{:stratum 0} ^:private stop-stream-reader!  #'impl/stop-stream-reader!)
+
+(defn- ^{:stratum 0} wait-until-blocked
   "Spin-wait until `^Thread t` reaches a parked/blocked thread state
    (WAITING/TIMED_WAITING/BLOCKED). Used by the clean-shutdown regression
    test to confirm the reader is actually blocked on `.put` BEFORE we
@@ -742,60 +729,7 @@
         (>= (System/currentTimeMillis) deadline) false
         :else (do (Thread/sleep 5) (recur))))))
 
-(deftest start-stream-reader!-clean-shutdown-prints-no-stderr-test
-  ;; Regression: pre-fix the daemon's `(catch Exception e ...)` caught
-  ;; the InterruptedException raised by `stop-stream-reader!`'s
-  ;; interrupt, then tried to enqueue a `stream-read-failure` anomaly
-  ;; via `.put` — which itself raised IE because the thread's interrupt
-  ;; flag was still set, bubbling the second IE to the JVM default
-  ;; handler and printing an ugly stack trace to stderr. The 2026-06-04
-  ;; dogfood surfaced 18 of these across 20 sub-tasks (pure noise, zero
-  ;; workflow impact).
-  ;;
-  ;; The fix: dedicated `(catch InterruptedException _)` for the clean
-  ;; shutdown + inner try/catch around the anomaly enqueue.
-  ;;
-  ;; The test exercises `start-stream-reader!` / `stop-stream-reader!`
-  ;; directly with a CAPACITY-1 queue so the reader's second `.put`
-  ;; blocks deterministically (no `Thread/sleep`-based race). With the
-  ;; queue full, the reader is guaranteed to be parked on `.put` when
-  ;; `stop-stream-reader!` interrupts it.
-  (testing "interrupting a reader blocked on a full queue does not print to stderr"
-    (let [;; Bounded queue, capacity 1. Pre-filled so the reader's first
-          ;; put blocks immediately.
-          line-queue (java.util.concurrent.LinkedBlockingQueue. 1)
-          _          (.put line-queue "filler")
-          ;; PipedWriter/Reader with one line of content so the reader
-          ;; has something to read and try to enqueue.
-          writer (java.io.PipedWriter.)
-          reader (java.io.BufferedReader. (java.io.PipedReader. writer))
-          _ (.write writer "first-line\n")
-          _ (.flush writer)
-          stderr-capture (java.io.ByteArrayOutputStream.)
-          original-err System/err
-          captured-print-stream (java.io.PrintStream. stderr-capture true "UTF-8")]
-      (try
-        (System/setErr captured-print-stream)
-        (let [reader-thread (start-stream-reader! reader line-queue)]
-          (try
-            (is (wait-until-blocked reader-thread 1000)
-                "reader must reach a blocked state on .put before the interrupt fires")
-            (stop-stream-reader! reader-thread reader)
-            (finally
-              (.join reader-thread 1000))))
-        ;; Read with the same charset the PrintStream wrote.
-        (let [captured (.toString stderr-capture "UTF-8")]
-          (is (not (re-find #"InterruptedException" captured))
-              "clean shutdown must not leak an IE stack trace to stderr"))
-        (finally
-          (System/setErr original-err)
-          ;; Close the redirected stream — flushes any buffered bytes and
-          ;; releases the underlying ByteArrayOutputStream from the
-          ;; PrintStream's writer lock.
-          (.close captured-print-stream)
-          (.close writer))))))
-
-(deftest process-stream-lines-honors-progress-monitor-while-waiting-for-output-test
+(deftest ^{:stratum 0} process-stream-lines-honors-progress-monitor-while-waiting-for-output-test
   (testing "progress-monitor timeout can fire while stdout is idle and still open"
     (let [writer (java.io.PipedWriter.)
           reader (java.io.BufferedReader. (java.io.PipedReader. writer))
@@ -817,7 +751,7 @@
         (finally
           (.close writer))))))
 
-(deftest stream-with-parser-records-tool-progress-test
+(deftest ^{:stratum 0} stream-with-parser-records-tool-progress-test
   (testing "tool-use events reset semantic progress even without text deltas"
     (let [monitor (pm/create-progress-monitor
                    {:stagnation-threshold-ms 1000
@@ -851,7 +785,7 @@
       (is (= "" @accumulated-content))
       (is (= 1 (count @chunks))))))
 
-(deftest stream-with-parser-records-liveness-progress-test
+(deftest ^{:stratum 0} stream-with-parser-records-liveness-progress-test
   ;; 2026-05-04 dogfood regression — Claude emits rate_limit_event
   ;; while the model is mid-think (no assistant chunks yet). PR #774
   ;; mapped these to nil, so they did not advance the activity
@@ -895,7 +829,7 @@
         (is (< before (:last-activity-at @monitor))
             "system init must refresh liveness once at stream start")))))
 
-(deftest message-preview-via-streaming-success-test
+(deftest ^{:stratum 0} message-preview-via-streaming-success-test
   (testing "short content is returned in full as preview"
     (let [short-content "short response"
           resp (impl/streaming-success-response short-content 0 nil nil nil nil 0 short-content nil)]
@@ -907,7 +841,7 @@
           resp (impl/streaming-success-response long-content 0 nil nil nil nil 0 preview nil)]
       (is (= 500 (count (:final-message-preview resp)))))))
 
-(deftest complete-stream-impl-empty-stream-fallback-test
+(deftest ^{:stratum 0} complete-stream-impl-empty-stream-fallback-test
   (testing "streaming success with no parsed output falls back to non-streaming completion"
     (let [chunks (atom [])
           client (ai.miniforge.llm.protocols.records.llm-client/create-client
@@ -925,10 +859,8 @@
                :content "fallback answer"}]
              @chunks)))))
 
-;------------------------------------------------------------------------------ Layer 5
 ;; Claude backend args-fn budget tests (PR #288)
-
-(deftest claude-args-fn-budget-usd-test
+(deftest ^{:stratum 0} claude-args-fn-budget-usd-test
   (let [args-fn (:args-fn (get impl/backends :claude))]
 
     (testing "budget-usd from request is used as --max-budget-usd value"
@@ -965,7 +897,6 @@
       (let [args (args-fn {:prompt "test" :budget-usd 1.0})]
         (is (not (some #{"--max-turns"} args)))))))
 
-;------------------------------------------------------------------------------ Layer 5
 ;; Claude backend prompt delivery (argv vs stdin) — argv-overflow guard
 ;;
 ;; The Stage 3 dogfood (2026-05-07) hit "Argument list too long" because
@@ -973,74 +904,43 @@
 ;; pushed the argv past POSIX ARG_MAX. The :claude backend now declares
 ;; :prompt-via :stdin and the args-fn omits the positional prompt while
 ;; adding --input-format text. These tests lock that contract.
-
-(def ^:private sample-prompt
+(def ^{:stratum 0} ^:private sample-prompt
   "Synthetic prompt used to assert the prompt content's *placement*
    (argv vs not-argv). Same shape (string) as a real planner prompt;
    size is small because the assertions hinge on identity-of-content,
    not length."
   "this should arrive on stdin not in argv")
 
-(deftest claude-args-fn-prompt-via-argv-default-test
-  (testing "prompt-via defaults to :argv — prompt is the last argv element"
-    (let [args-fn (:args-fn (get impl/backends :claude))
-          args (args-fn {:prompt sample-prompt})]
-      (is (= sample-prompt (last args))
-          "prompt is conjoined as positional argv arg")
-      (is (not (some #{"--input-format"} args))
-          "no --input-format flag in argv mode"))))
-
-(deftest claude-args-fn-prompt-via-argv-explicit-test
-  (testing "prompt-via :argv (explicit) keeps current argv shape"
-    (let [args-fn (:args-fn (get impl/backends :claude))
-          args (args-fn {:prompt sample-prompt :prompt-via :argv})]
-      (is (= sample-prompt (last args))
-          "prompt is conjoined as positional argv arg")
-      (is (not (some #{"--input-format"} args))))))
-
-(deftest claude-args-fn-prompt-via-stdin-omits-argv-test
-  (testing "prompt-via :stdin drops the positional prompt"
-    (let [args-fn (:args-fn (get impl/backends :claude))
-          args (args-fn {:prompt sample-prompt :prompt-via :stdin})]
-      (is (not (some #{sample-prompt} args))
-          "prompt content must NOT appear in argv when :prompt-via :stdin")
-      (is (some #{"--input-format"} args)
-          "--input-format text flag must be present so claude reads stdin")
-      (is (= "text" (nth args (inc (.indexOf args "--input-format"))))
-          "--input-format value is 'text'"))))
-
-(deftest claude-backend-declares-prompt-via-stdin-test
+(deftest ^{:stratum 0} claude-backend-declares-prompt-via-stdin-test
   (testing ":claude backend config declares :prompt-via :stdin"
     (is (= :stdin (:prompt-via (get impl/backends :claude)))
         "claude must default to stdin to avoid POSIX ARG_MAX overflow")))
 
-(deftest cli-backends-declare-safe-prompt-delivery-test
+(deftest ^{:stratum 0} cli-backends-declare-safe-prompt-delivery-test
   (testing "codex uses stdin; other non-Claude CLI backends remain argv"
     (is (= :stdin (:prompt-via (get impl/backends :codex))))
     (is (= :argv (:prompt-via (get impl/backends :cursor))))
     (is (= :argv (:prompt-via (get impl/backends :opencode))))
     (is (= :argv (:prompt-via (get impl/backends :echo))))))
 
-;------------------------------------------------------------------------------ Layer 5
 ;; default-exec-fn / stream-exec-fn — :stdin opt is piped to the subprocess
 ;;
 ;; Use `cat` as the subprocess: stdin is echoed verbatim to stdout, so we
 ;; can assert the bytes the exec layer wrote without depending on a
 ;; real LLM CLI.
-
-(deftest default-exec-fn-pipes-stdin-test
+(deftest ^{:stratum 0} default-exec-fn-pipes-stdin-test
   (testing ":stdin opt is written to subprocess stdin"
     (let [{:keys [out exit]} (impl/default-exec-fn ["cat"] {:stdin "hello stdin"})]
       (is (zero? exit))
       (is (= "hello stdin" out)))))
 
-(deftest default-exec-fn-no-stdin-default-test
+(deftest ^{:stratum 0} default-exec-fn-no-stdin-default-test
   (testing "no :stdin opt → empty stdin (legacy behavior)"
     (let [{:keys [out exit]} (impl/default-exec-fn ["cat"])]
       (is (zero? exit))
       (is (= "" out)))))
 
-(deftest default-exec-fn-honors-workdir-test
+(deftest ^{:stratum 0} default-exec-fn-honors-workdir-test
   (testing ":workdir opt becomes the subprocess working directory"
     (let [workdir (.getCanonicalPath (java.io.File. (System/getProperty "java.io.tmpdir")))
           {:keys [out exit]} (impl/default-exec-fn ["pwd"] {:workdir workdir})
@@ -1048,7 +948,7 @@
       (is (zero? exit))
       (is (= workdir actual)))))
 
-(deftest read-process-stream-error-is-string-test
+(deftest ^{:stratum 0} read-process-stream-error-is-string-test
   (testing "reader exceptions never publish nil output"
     (let [stream (proxy [java.io.InputStream] []
                    (read
@@ -1064,7 +964,7 @@
       (is (string? @output))
       (is (seq @output)))))
 
-(deftest stop-capture-process-waits-after-destroy-test
+(deftest ^{:stratum 0} stop-capture-process-waits-after-destroy-test
   (testing "capture timeout waits again after forcible destroy before returning"
     (let [destroyed? (atom false)
           wait-calls (atom [])
@@ -1100,7 +1000,7 @@
             (is (= "" (:out result)))
             (is (= "" (:err result)))))))))
 
-(deftest complete-impl-passes-workdir-to-exec-fn-test
+(deftest ^{:stratum 0} complete-impl-passes-workdir-to-exec-fn-test
   (testing "non-streaming CLI completion runs in the requested workdir"
     (let [seen-opts (atom nil)
           exec-fn   (fn
@@ -1115,7 +1015,7 @@
       (is (= "/tmp/task-worktree" (:workdir @seen-opts))
           "fallback/non-streaming calls must not run in the host checkout"))))
 
-(deftest legacy-1-arity-exec-fn-survives-stdin-path-test
+(deftest ^{:stratum 0} legacy-1-arity-exec-fn-survives-stdin-path-test
   (testing "1-arity user-supplied :exec-fn keeps working when impl invokes 2-arity"
     ;; Backward-compat guard: PR #798 review pointed out that callers
     ;; predating :prompt-via supplied 1-arity exec-fns. The :claude
@@ -1134,7 +1034,7 @@
       (is (some? @seen)
           "legacy 1-arity fn was eventually invoked"))))
 
-(deftest normalize-exec-fn-passes-opts-to-2-arity-fn-test
+(deftest ^{:stratum 0} normalize-exec-fn-passes-opts-to-2-arity-fn-test
   (testing "2-arity user-supplied exec-fn receives opts unchanged"
     (let [seen-opts (atom nil)
           two-arity (fn
@@ -1147,7 +1047,6 @@
       (is (= {:stdin "the-prompt"} @seen-opts)
           "opts must reach a 2-arity-capable fn unchanged"))))
 
-;------------------------------------------------------------------------------ Layer 5
 ;; Keepalive — decouples stagnation from the CLI's emission cadence
 ;;
 ;; Stage-3 dogfood (2026-05-07) failed at the planner with
@@ -1160,8 +1059,7 @@
 ;; the JVM-side reader is alive. These tests lock both halves of the
 ;; contract — the bug pattern (silence => stagnation) and the fix
 ;; (keepalive masks silence).
-
-(deftest stagnation-fires-on-silence-without-keepalive-test
+(deftest ^{:stratum 0} stagnation-fires-on-silence-without-keepalive-test
   (testing "without keepalive, a silent monitor stagnates after the threshold"
     ;; Bug demonstration: this is the dogfood failure mode in unit form.
     ;; record-activity! once at start, then silence — the timer expires.
@@ -1175,7 +1073,7 @@
         (is (= :stagnation (:type timeout))
             "silence beyond stagnation-threshold-ms ⇒ stagnation fires")))))
 
-(deftest keepalive-prevents-stagnation-during-silence-test
+(deftest ^{:stratum 0} keepalive-prevents-stagnation-during-silence-test
   (testing "keepalive thread refreshes the monitor across silent periods"
     (let [monitor (pm/create-progress-monitor
                    {:stagnation-threshold-ms 80
@@ -1190,7 +1088,7 @@
         (finally
           (stop!))))))
 
-(deftest keepalive-stop-fn-halts-the-thread-test
+(deftest ^{:stratum 0} keepalive-stop-fn-halts-the-thread-test
   (testing "stop! returned by start-keepalive! halts further refreshes"
     (let [monitor (pm/create-progress-monitor
                    {:stagnation-threshold-ms 80
@@ -1205,7 +1103,7 @@
       (is (= :stagnation (:type (pm/check-timeout monitor)))
           "after stop!, silence stagnates as expected"))))
 
-(deftest keepalive-rejects-non-positive-interval-test
+(deftest ^{:stratum 0} keepalive-rejects-non-positive-interval-test
   (testing "start-keepalive! refuses non-positive interval-ms"
     ;; Without validation Thread/sleep would throw IllegalArgumentException
     ;; deep in the worker thread; assert + AssertionError fails fast at the
@@ -1218,7 +1116,7 @@
       (is (thrown? AssertionError (pm/start-keepalive! monitor 1.5))
           "non-integer interval rejected"))))
 
-(deftest keepalive-stop-is-definitive-test
+(deftest ^{:stratum 0} keepalive-stop-is-definitive-test
   (testing "after stop!, no further activity ticks land"
     ;; Race-window guard: stop! interrupts the thread + joins so the
     ;; worker has exited (or is about to exit on the running? check)
@@ -1241,7 +1139,7 @@
               (str "at most one in-flight tick may land after stop!, got "
                    extra-ticks)))))))
 
-(deftest keepalive-does-not-mask-hard-limit-test
+(deftest ^{:stratum 0} keepalive-does-not-mask-hard-limit-test
   (testing "keepalive only refreshes stagnation; max-total-ms still fires"
     ;; Wedge backstop: the keepalive is a per-tick refresh of
     ;; last-activity-at, but :max-total-ms tracks elapsed-since-start
@@ -1261,7 +1159,7 @@
         (finally
           (stop!))))))
 
-(deftest stream-exec-fn-pipes-stdin-test
+(deftest ^{:stratum 0} stream-exec-fn-pipes-stdin-test
   (testing ":stdin opt is written to subprocess stdin in streaming path"
     (let [seen (atom [])
           handler (fn [line] (swap! seen conj line))
@@ -1273,7 +1171,7 @@
       (is (= ["line1" "line2"] @seen)
           "subprocess saw stdin content split by line"))))
 
-(defn- fake-stream-process
+(defn- ^{:stratum 0} fake-stream-process
   "Stub for `#'impl/start-stream-process!`. Returns a map matching the
    shape `stream-exec-fn` consumes, with a `Process` proxy whose
    stdout is `input-stream`. `.destroyForcibly` closes the supplied
@@ -1306,91 +1204,9 @@
      :stdin-thread  nil
      :stderr-thread nil}))
 
-(defn- fake-blocking-stream-process
-  "Variant of `fake-stream-process` whose stdout never produces a line
-   (PipedInputStream connected to a never-written PipedOutputStream).
-   `.destroyForcibly` closes the pipe so the reader unblocks with EOF."
-  []
-  (let [piped-out (java.io.PipedOutputStream.)
-        piped-in  (java.io.PipedInputStream. piped-out)]
-    (fake-stream-process piped-in
-                         (fn [] (try (.close piped-out) (catch Exception _))))))
-
-(defn- fake-eof-stream-process
-  "Variant of `fake-stream-process` whose stdout is immediately empty,
-   so `process-stream-lines` returns cleanly. Used by the no-monitor
-   test."
-  []
-  (fake-stream-process (java.io.ByteArrayInputStream. (byte-array 0))
-                       (fn [])))
-
-(deftest stream-exec-fn-network-drop-returns-network-drop-timeout-test
-  ;; PR-B integration test: when the network-monitor's probe-fn reports
-  ;; sustained failure, `stream-exec-fn` must (a) kill the subprocess
-  ;; so the consumer loop unblocks and (b) surface the network-drop
-  ;; reason as the result's `:timeout` envelope. PR-C will key off the
-  ;; `:type :network-drop` to schedule the auto-resume.
-  (testing "sustained probe failure surfaces a :network-drop timeout result"
-    ;; Stubbed subprocess (see `fake-blocking-stream-process`) — never
-    ;; produces output until the network monitor's `.destroyForcibly`
-    ;; closes the pipe. With a stub probe-fn returning false, the
-    ;; monitor fires within ~30ms (10ms interval × 3 strikes) and
-    ;; forces stream-exec-fn to return. No real subprocess; portable.
-    (with-redefs [impl/start-stream-process! (fn [_cmd _opts]
-                                               (fake-blocking-stream-process))]
-      (let [handler (fn [_line] nil)
-            monitor (pm/create-progress-monitor {:min-activity-interval-ms 1
-                                                 :stagnation-threshold-ms  120000
-                                                 :max-total-ms             120000})
-            result  (impl/stream-exec-fn
-                      ["unused-because-stubbed"]
-                      handler
-                      {:progress-monitor monitor
-                       :backend-key      :claude
-                       :network-monitor-opts
-                       {:probe-interval-ms 10
-                        :failure-threshold 3
-                        :probe-fn          (constantly false)}})
-            timeout (:timeout result)]
-        (is (some? timeout)
-            "result must carry a :timeout envelope when the monitor fires")
-        (is (= :network-drop (:type timeout)))
-        (is (= :claude (:backend-key timeout)))
-        (is (re-find #"Network drop" (:message timeout))
-            ":message identifies the drop class for downstream log readers")))))
-
-(deftest stream-exec-fn-omits-network-monitor-when-no-backend-key-test
-  ;; Backwards compat: legacy callers (synthetic-stream tests, the
-  ;; `:echo` test backend) supply no `:backend-key`. The network
-  ;; monitor must stay dormant so they keep working unchanged.
-  (testing "without :backend-key, no probe traffic is generated"
-    (with-redefs [impl/start-stream-process! (fn [_cmd _opts]
-                                               (fake-eof-stream-process))]
-      (let [probe-calls (atom 0)
-            handler (fn [_line] nil)
-            monitor (pm/create-progress-monitor {:min-activity-interval-ms 1})
-            result  (impl/stream-exec-fn
-                      ["unused-because-stubbed"]
-                      handler
-                      {:progress-monitor monitor
-                       ;; No :backend-key. Even if the test caller
-                       ;; mistakenly supplies network-monitor-opts (e.g.
-                       ;; via a stale fixture), the monitor must not
-                       ;; start.
-                       :network-monitor-opts
-                       {:probe-fn (fn [_probe-url]
-                                    (swap! probe-calls inc)
-                                    false)}})]
-        (is (zero? @probe-calls)
-            "probe-fn must not be called when :backend-key is absent")
-        (is (nil? (:timeout result))
-            "process completed without timeout")))))
-
-;------------------------------------------------------------------------------ Layer 6
 ;; Rich tool-event chunks — :tool-call-id/:tool-input on tool_use,
 ;; :tool-result chunks from tool_result content blocks
-
-(deftest parse-claude-stream-tool-use-enriched-test
+(deftest ^{:stratum 0} parse-claude-stream-tool-use-enriched-test
   (testing "tool_use block with id and input yields :tool-call-id and :tool-input"
     (let [line   (json/generate-string
                    {:type "assistant"
@@ -1436,7 +1252,7 @@
       (is (= "t1" (:tool-call-id parsed)))
       (is (= {:pattern "foo"} (:tool-input parsed))))))
 
-(deftest parse-claude-stream-tool-result-test
+(deftest ^{:stratum 0} parse-claude-stream-tool-result-test
   (testing "user message with tool_result block emits :tool-result chunk"
     (let [line   (json/generate-string
                    {:type "user"
@@ -1492,7 +1308,7 @@
       (is (true? (:heartbeat parsed)))
       (is (nil? (:tool-result parsed))))))
 
-(deftest parse-codex-stream-tool-result-test
+(deftest ^{:stratum 0} parse-codex-stream-tool-result-test
   (testing "mcp_tool_result item emits :tool-result chunk"
     (let [line   (json/generate-string
                    {:type "item.completed"
@@ -1541,7 +1357,7 @@
       (is (= "native_call" (:tool-call-id parsed)))
       (is (= "native output" (:tool-output parsed))))))
 
-(deftest stream-with-parser-tool-result-test
+(deftest ^{:stratum 0} stream-with-parser-tool-result-test
   (testing ":tool-result chunks forwarded via on-chunk without accumulating content"
     (let [monitor (pm/create-progress-monitor {:min-activity-interval-ms 1})
           chunks  (atom [])
@@ -1597,6 +1413,171 @@
                                        :is_error    false}]}}))
       (is (< before (:last-activity-at @monitor))
           ":tool-result must advance :last-activity-at to keep monitor alive"))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} start-stream-reader!-clean-shutdown-prints-no-stderr-test
+  ;; Regression: pre-fix the daemon's `(catch Exception e ...)` caught
+  ;; the InterruptedException raised by `stop-stream-reader!`'s
+  ;; interrupt, then tried to enqueue a `stream-read-failure` anomaly
+  ;; via `.put` — which itself raised IE because the thread's interrupt
+  ;; flag was still set, bubbling the second IE to the JVM default
+  ;; handler and printing an ugly stack trace to stderr. The 2026-06-04
+  ;; dogfood surfaced 18 of these across 20 sub-tasks (pure noise, zero
+  ;; workflow impact).
+  ;;
+  ;; The fix: dedicated `(catch InterruptedException _)` for the clean
+  ;; shutdown + inner try/catch around the anomaly enqueue.
+  ;;
+  ;; The test exercises `start-stream-reader!` / `stop-stream-reader!`
+  ;; directly with a CAPACITY-1 queue so the reader's second `.put`
+  ;; blocks deterministically (no `Thread/sleep`-based race). With the
+  ;; queue full, the reader is guaranteed to be parked on `.put` when
+  ;; `stop-stream-reader!` interrupts it.
+  (testing "interrupting a reader blocked on a full queue does not print to stderr"
+    (let [;; Bounded queue, capacity 1. Pre-filled so the reader's first
+          ;; put blocks immediately.
+          line-queue (java.util.concurrent.LinkedBlockingQueue. 1)
+          _          (.put line-queue "filler")
+          ;; PipedWriter/Reader with one line of content so the reader
+          ;; has something to read and try to enqueue.
+          writer (java.io.PipedWriter.)
+          reader (java.io.BufferedReader. (java.io.PipedReader. writer))
+          _ (.write writer "first-line\n")
+          _ (.flush writer)
+          stderr-capture (java.io.ByteArrayOutputStream.)
+          original-err System/err
+          captured-print-stream (java.io.PrintStream. stderr-capture true "UTF-8")]
+      (try
+        (System/setErr captured-print-stream)
+        (let [reader-thread (start-stream-reader! reader line-queue)]
+          (try
+            (is (wait-until-blocked reader-thread 1000)
+                "reader must reach a blocked state on .put before the interrupt fires")
+            (stop-stream-reader! reader-thread reader)
+            (finally
+              (.join reader-thread 1000))))
+        ;; Read with the same charset the PrintStream wrote.
+        (let [captured (.toString stderr-capture "UTF-8")]
+          (is (not (re-find #"InterruptedException" captured))
+              "clean shutdown must not leak an IE stack trace to stderr"))
+        (finally
+          (System/setErr original-err)
+          ;; Close the redirected stream — flushes any buffered bytes and
+          ;; releases the underlying ByteArrayOutputStream from the
+          ;; PrintStream's writer lock.
+          (.close captured-print-stream)
+          (.close writer))))))
+
+(deftest ^{:stratum 1} claude-args-fn-prompt-via-argv-default-test
+  (testing "prompt-via defaults to :argv — prompt is the last argv element"
+    (let [args-fn (:args-fn (get impl/backends :claude))
+          args (args-fn {:prompt sample-prompt})]
+      (is (= sample-prompt (last args))
+          "prompt is conjoined as positional argv arg")
+      (is (not (some #{"--input-format"} args))
+          "no --input-format flag in argv mode"))))
+
+(deftest ^{:stratum 1} claude-args-fn-prompt-via-argv-explicit-test
+  (testing "prompt-via :argv (explicit) keeps current argv shape"
+    (let [args-fn (:args-fn (get impl/backends :claude))
+          args (args-fn {:prompt sample-prompt :prompt-via :argv})]
+      (is (= sample-prompt (last args))
+          "prompt is conjoined as positional argv arg")
+      (is (not (some #{"--input-format"} args))))))
+
+(deftest ^{:stratum 1} claude-args-fn-prompt-via-stdin-omits-argv-test
+  (testing "prompt-via :stdin drops the positional prompt"
+    (let [args-fn (:args-fn (get impl/backends :claude))
+          args (args-fn {:prompt sample-prompt :prompt-via :stdin})]
+      (is (not (some #{sample-prompt} args))
+          "prompt content must NOT appear in argv when :prompt-via :stdin")
+      (is (some #{"--input-format"} args)
+          "--input-format text flag must be present so claude reads stdin")
+      (is (= "text" (nth args (inc (.indexOf args "--input-format"))))
+          "--input-format value is 'text'"))))
+
+(defn- ^{:stratum 1} fake-blocking-stream-process
+  "Variant of `fake-stream-process` whose stdout never produces a line
+   (PipedInputStream connected to a never-written PipedOutputStream).
+   `.destroyForcibly` closes the pipe so the reader unblocks with EOF."
+  []
+  (let [piped-out (java.io.PipedOutputStream.)
+        piped-in  (java.io.PipedInputStream. piped-out)]
+    (fake-stream-process piped-in
+                         (fn [] (try (.close piped-out) (catch Exception _))))))
+
+(defn- ^{:stratum 1} fake-eof-stream-process
+  "Variant of `fake-stream-process` whose stdout is immediately empty,
+   so `process-stream-lines` returns cleanly. Used by the no-monitor
+   test."
+  []
+  (fake-stream-process (java.io.ByteArrayInputStream. (byte-array 0))
+                       (fn [])))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} stream-exec-fn-network-drop-returns-network-drop-timeout-test
+  ;; PR-B integration test: when the network-monitor's probe-fn reports
+  ;; sustained failure, `stream-exec-fn` must (a) kill the subprocess
+  ;; so the consumer loop unblocks and (b) surface the network-drop
+  ;; reason as the result's `:timeout` envelope. PR-C will key off the
+  ;; `:type :network-drop` to schedule the auto-resume.
+  (testing "sustained probe failure surfaces a :network-drop timeout result"
+    ;; Stubbed subprocess (see `fake-blocking-stream-process`) — never
+    ;; produces output until the network monitor's `.destroyForcibly`
+    ;; closes the pipe. With a stub probe-fn returning false, the
+    ;; monitor fires within ~30ms (10ms interval × 3 strikes) and
+    ;; forces stream-exec-fn to return. No real subprocess; portable.
+    (with-redefs [impl/start-stream-process! (fn [_cmd _opts]
+                                               (fake-blocking-stream-process))]
+      (let [handler (fn [_line] nil)
+            monitor (pm/create-progress-monitor {:min-activity-interval-ms 1
+                                                 :stagnation-threshold-ms  120000
+                                                 :max-total-ms             120000})
+            result  (impl/stream-exec-fn
+                      ["unused-because-stubbed"]
+                      handler
+                      {:progress-monitor monitor
+                       :backend-key      :claude
+                       :network-monitor-opts
+                       {:probe-interval-ms 10
+                        :failure-threshold 3
+                        :probe-fn          (constantly false)}})
+            timeout (:timeout result)]
+        (is (some? timeout)
+            "result must carry a :timeout envelope when the monitor fires")
+        (is (= :network-drop (:type timeout)))
+        (is (= :claude (:backend-key timeout)))
+        (is (re-find #"Network drop" (:message timeout))
+            ":message identifies the drop class for downstream log readers")))))
+
+(deftest ^{:stratum 2} stream-exec-fn-omits-network-monitor-when-no-backend-key-test
+  ;; Backwards compat: legacy callers (synthetic-stream tests, the
+  ;; `:echo` test backend) supply no `:backend-key`. The network
+  ;; monitor must stay dormant so they keep working unchanged.
+  (testing "without :backend-key, no probe traffic is generated"
+    (with-redefs [impl/start-stream-process! (fn [_cmd _opts]
+                                               (fake-eof-stream-process))]
+      (let [probe-calls (atom 0)
+            handler (fn [_line] nil)
+            monitor (pm/create-progress-monitor {:min-activity-interval-ms 1})
+            result  (impl/stream-exec-fn
+                      ["unused-because-stubbed"]
+                      handler
+                      {:progress-monitor monitor
+                       ;; No :backend-key. Even if the test caller
+                       ;; mistakenly supplies network-monitor-opts (e.g.
+                       ;; via a stale fixture), the monitor must not
+                       ;; start.
+                       :network-monitor-opts
+                       {:probe-fn (fn [_probe-url]
+                                    (swap! probe-calls inc)
+                                    false)}})]
+        (is (zero? @probe-calls)
+            "probe-fn must not be called when :backend-key is absent")
+        (is (nil? (:timeout result))
+            "process completed without timeout")))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/llm/test/ai/miniforge/llm/llm_anomaly_shape_test.clj
+++ b/components/llm/test/ai/miniforge/llm/llm_anomaly_shape_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.llm.llm-anomaly-shape-test
   "Lock the canonical anomaly shape produced by `llm-client/llm-error`
    and `llm-client/http-post-request` after the W2 anomaly convergence
@@ -42,32 +41,24 @@
    [ai.miniforge.llm.protocols.impl.llm-client :as client]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Factories and fixtures
 
-(def ^:private test-url
+;; Factories and fixtures
+(def ^{:stratum 0} ^:private test-url
   "Static target URL used by `http-post-request` failure tests. Never
    actually dereferenced — `http/post` is stubbed via `with-redefs`."
   "http://llm-anomaly-shape-test.invalid/llm")
 
-(def ^:private test-headers
+(def ^{:stratum 0} ^:private test-headers
   {"Content-Type" "application/json"})
 
-(defn- error-type-placeholder
+(defn- ^{:stratum 0} error-type-placeholder
   "Opaque error-type label used by `llm-error` tests. The shape-of-anomaly
    tests don't assert against the error-type field — they only need a
    stable, non-blank token to pass the builder's contract."
   []
   "shape_test_error_type")
 
-(defn- anomaly-of
-  "Build a canonical anomaly map for the given legacy category by driving
-   the public `llm-error` builder and extracting `:anomaly` from the
-   response. The 2nd/3rd args are opaque placeholders — shape tests
-   only assert on the anomaly map itself."
-  [category]
-  (:anomaly (client/llm-error category (error-type-placeholder) "boom")))
-
-(defn- delivered-future
+(defn- ^{:stratum 0} delivered-future
   "Wrap a value in an already-resolved future so `@(http/post ...)`
    returns it synchronously under `with-redefs`."
   [v]
@@ -75,7 +66,7 @@
     (deliver p v)
     p))
 
-(defn- stub-http-post-throwing
+(defn- ^{:stratum 0} stub-http-post-throwing
   "`http/post` stub whose deref throws the given exception — mirrors
    http-kit's throwing failure mode (e.g. body serialization or an
    `IllegalArgumentException` on a malformed URL)."
@@ -84,7 +75,17 @@
     (reify clojure.lang.IDeref
       (deref [_] (throw ex)))))
 
-(defn- stub-http-post-error-map
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} anomaly-of
+  "Build a canonical anomaly map for the given legacy category by driving
+   the public `llm-error` builder and extracting `:anomaly` from the
+   response. The 2nd/3rd args are opaque placeholders — shape tests
+   only assert on the anomaly map itself."
+  [category]
+  (:anomaly (client/llm-error category (error-type-placeholder) "boom")))
+
+(defn- ^{:stratum 1} stub-http-post-error-map
   "`http/post` stub whose deref returns `{:error <Throwable>}` — mirrors
    http-kit's non-throwing failure mode (the common case for connection
    refused / DNS failure)."
@@ -92,10 +93,26 @@
   (fn [_url _opts]
     (delivered-future {:error cause :opts {}})))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Unit tests
+(deftest ^{:stratum 1} http-post-request-throwing-failure-emits-canonical-unavailable
+  (testing "thrown exception on deref → canonical :unavailable anomaly"
+    (let [cause (java.net.ConnectException. "Connection refused")]
+      (with-redefs [http/post (stub-http-post-throwing cause)]
+        (let [a (client/http-post-request test-url test-headers {})]
+          (is (anomaly/anomaly? a)
+              "throwing path must produce a canonical anomaly")
+          (is (= :unavailable (:anomaly/type a)))
+          (is (nil? (:anomaly/subtype a))
+              ":anomalies/unavailable is generic-standard — no subtype")
+          (is (= :http-request (get-in a [:anomaly/data :operation])))
+          (is (= test-url (get-in a [:anomaly/data :url]))
+              ":url lives under :anomaly/data, not at the top level")
+          (is (nil? (:anomaly.llm/url a))
+              "legacy :anomaly.llm/url no longer set at the top level"))))))
 
-(deftest llm-error-generic-standard-category-emits-typed-anomaly-no-subtype
+;------------------------------------------------------------------------------ Layer 2
+
+;; Unit tests
+(deftest ^{:stratum 2} llm-error-generic-standard-category-emits-typed-anomaly-no-subtype
   (testing ":anomalies/unavailable maps to :unavailable with no subtype"
     (let [a (anomaly-of :anomalies/unavailable)]
       (is (anomaly/anomaly? a))
@@ -118,7 +135,7 @@
       (is (= :timeout (:anomaly/type a)))
       (is (nil? (:anomaly/subtype a))))))
 
-(deftest llm-error-domain-category-emits-subtype
+(deftest ^{:stratum 2} llm-error-domain-category-emits-subtype
   (testing ":anomalies.agent/llm-error → :fault + subtype verbatim"
     (let [a (anomaly-of :anomalies.agent/llm-error)]
       (is (anomaly/anomaly? a))
@@ -131,7 +148,7 @@
       (is (= :unavailable (:anomaly/type a)))
       (is (= :anomalies.agent/rate-limited (:anomaly/subtype a))))))
 
-(deftest llm-error-domain-payload-lives-under-anomaly-data
+(deftest ^{:stratum 2} llm-error-domain-payload-lives-under-anomaly-data
   (testing "the :operation domain field is carried under :anomaly/data"
     (let [a    (anomaly-of :anomalies/fault)
           data (:anomaly/data a)]
@@ -142,23 +159,7 @@
       (is (nil? (:operation a))
           ":operation also not at the anomaly's top level"))))
 
-(deftest http-post-request-throwing-failure-emits-canonical-unavailable
-  (testing "thrown exception on deref → canonical :unavailable anomaly"
-    (let [cause (java.net.ConnectException. "Connection refused")]
-      (with-redefs [http/post (stub-http-post-throwing cause)]
-        (let [a (client/http-post-request test-url test-headers {})]
-          (is (anomaly/anomaly? a)
-              "throwing path must produce a canonical anomaly")
-          (is (= :unavailable (:anomaly/type a)))
-          (is (nil? (:anomaly/subtype a))
-              ":anomalies/unavailable is generic-standard — no subtype")
-          (is (= :http-request (get-in a [:anomaly/data :operation])))
-          (is (= test-url (get-in a [:anomaly/data :url]))
-              ":url lives under :anomaly/data, not at the top level")
-          (is (nil? (:anomaly.llm/url a))
-              "legacy :anomaly.llm/url no longer set at the top level"))))))
-
-(deftest http-post-request-error-map-failure-emits-canonical-unavailable
+(deftest ^{:stratum 2} http-post-request-error-map-failure-emits-canonical-unavailable
   (testing "{:error <Throwable>} deref response → canonical :unavailable anomaly"
     ;; http-kit's common non-throwing failure mode: the future resolves
     ;; to a map with `:error` set. Pre-fix this would have flowed through

--- a/components/llm/test/ai/miniforge/llm/model_registry_test.clj
+++ b/components/llm/test/ai/miniforge/llm/model_registry_test.clj
@@ -15,13 +15,14 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.llm.model-registry-test
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.llm.model-registry :as registry]))
 
-(deftest test-get-model
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} test-get-model
   (testing "Get model by keyword"
     (let [opus (registry/get-model :opus-4.6)]
       (is (= "claude-opus-4-6" (:model-id opus)))
@@ -41,7 +42,7 @@
       (is (= :openai (:provider gpt-5-4-model)))
       (is (= 1050000 (get-in gpt-5-4-model [:capabilities :context-window]))))))
 
-(deftest test-get-models-by-capability
+(deftest ^{:stratum 0} test-get-models-by-capability
   (testing "Query by reasoning capability"
     (let [exceptional (registry/get-models-by-capability :reasoning :exceptional)]
       (is (seq exceptional))
@@ -71,7 +72,7 @@
       (is (seq very-fast))
       (is (some #{:gemini-2.5-flash-lite} very-fast)))))
 
-(deftest test-get-models-by-use-case
+(deftest ^{:stratum 0} test-get-models-by-use-case
   (testing "Query by code-implementation use-case"
     (let [models (registry/get-models-by-use-case :code-implementation)]
       (is (seq models))
@@ -88,7 +89,7 @@
       (is (seq models))
       (is (some #{:haiku-4.5} models)))))
 
-(deftest test-get-models-by-provider
+(deftest ^{:stratum 0} test-get-models-by-provider
   (testing "Get Anthropic models"
     (let [models (registry/get-models-by-provider :anthropic)]
       (is (seq models))
@@ -111,7 +112,7 @@
       (is (some #{:gpt-5.3-codex} models))
       (is (some #{:gpt-5.2-codex} models)))))
 
-(deftest test-context-window-for-model-id
+(deftest ^{:stratum 0} test-context-window-for-model-id
   (testing "resolves the context window by provider model-id string"
     (is (= 200000 (registry/context-window-for-model-id "claude-opus-4-6")))
     (is (= 1000000 (registry/context-window-for-model-id "claude-opus-4-7"))))
@@ -120,7 +121,7 @@
     (is (nil? (registry/context-window-for-model-id "no-such-model")))
     (is (nil? (registry/context-window-for-model-id nil)))))
 
-(deftest test-get-local-models
+(deftest ^{:stratum 0} test-get-local-models
   (testing "Get all local models"
     (let [models (registry/get-local-models)]
       (is (seq models))
@@ -132,7 +133,7 @@
       (is (not (some #{:opus-4.6} models)))
       (is (not (some #{:sonnet-4.6} models))))))
 
-(deftest test-supports-large-context
+(deftest ^{:stratum 0} test-supports-large-context
   (testing "Check large context support"
     (is (registry/supports-large-context? :opus-4.6))
     (is (registry/supports-large-context? :sonnet-4.6))
@@ -147,7 +148,7 @@
     (is (not (registry/supports-large-context? :opus-4.6 1000000)))
     (is (not (registry/supports-large-context? :haiku-4.5 300000)))))
 
-(deftest test-recommend-models-for-task-type
+(deftest ^{:stratum 0} test-recommend-models-for-task-type
   (testing "Recommend models for thinking-heavy tasks"
     (let [rec (registry/recommend-models-for-task-type :thinking-heavy)]
       (is (seq (:tier-1 rec)))
@@ -174,14 +175,14 @@
       (is (some #{:llama-3.3-70b} (:tier-1-local rec)))
       (is (:rationale rec)))))
 
-(deftest test-get-primary-recommendation
+(deftest ^{:stratum 0} test-get-primary-recommendation
   (testing "Get primary recommendation"
     (is (= :opus-4.7 (registry/get-primary-recommendation :thinking-heavy)))
     (is (= :sonnet-4.6 (registry/get-primary-recommendation :execution-focused)))
     (is (= :haiku-4.5 (registry/get-primary-recommendation :simple-validation)))
     (is (= :opus-4.7 (registry/get-primary-recommendation :large-context)))))
 
-(deftest test-model-registry-completeness
+(deftest ^{:stratum 0} test-model-registry-completeness
   (testing "All 19 models are present"
     (is (= 19 (count registry/model-registry))))
 

--- a/components/llm/test/ai/miniforge/llm/model_selection_integration_test.clj
+++ b/components/llm/test/ai/miniforge/llm/model_selection_integration_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.llm.model-selection-integration-test
   "Integration tests for the complete intelligent model selection system.
    Tests the full flow: task -> classification -> model selection -> execution."
@@ -31,7 +30,9 @@
                       (with-redefs [selector/get-env-var (constantly "test-key")]
                         (f))))
 
-(deftest test-end-to-end-planning-task
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} test-end-to-end-planning-task
   (testing "End-to-end: Planning task selects Opus"
     (let [;; Step 1: Create task description
           task {:phase :plan
@@ -60,7 +61,7 @@
       (let [model (registry/get-model (:model selection))]
         (is (#{:exceptional :excellent} (get-in model [:capabilities :reasoning])))))))
 
-(deftest test-end-to-end-implementation-task
+(deftest ^{:stratum 0} test-end-to-end-implementation-task
   (testing "End-to-end: Implementation task selects Sonnet"
     (let [task {:phase :implement
                 :agent-type :implementer-agent
@@ -80,7 +81,7 @@
       (let [model (registry/get-model (:model selection))]
         (is (#{:exceptional :excellent} (get-in model [:capabilities :code-generation])))))))
 
-(deftest test-end-to-end-validation-task
+(deftest ^{:stratum 0} test-end-to-end-validation-task
   (testing "End-to-end: Validation task selects Haiku or fast model"
     (let [task {:phase :validate
                 :agent-type :validator-agent
@@ -100,7 +101,7 @@
       (let [model (registry/get-model (:model selection))]
         (is (#{:fast :very-fast :economical} (get-in model [:capabilities :speed])))))))
 
-(deftest test-privacy-constraint
+(deftest ^{:stratum 0} test-privacy-constraint
   (testing "Privacy constraint forces local model"
     (let [task {:phase :implement
                 :agent-type :implementer-agent
@@ -120,7 +121,7 @@
         (is (get-in model [:capabilities :local]))
         (is (= :free (get-in model [:capabilities :cost])))))))
 
-(deftest test-large-context-task
+(deftest ^{:stratum 0} test-large-context-task
   (testing "Large context task selects a large-context provider"
     (let [task {:phase :implement
                 :context-tokens 500000
@@ -140,7 +141,7 @@
         ;; Current large-context tier includes Anthropic (Opus 4.7 1M), Google and OpenAI 1M+ models.
         (is (some #{(:provider model)} [:anthropic :google :openai]))))))
 
-(deftest test-cost-optimized-strategy
+(deftest ^{:stratum 0} test-cost-optimized-strategy
   (testing "Cost-optimized strategy prefers cheaper models"
     (let [task {:phase :implement
                 :agent-type :implementer-agent
@@ -164,7 +165,7 @@
       (is (:model selection-auto))
       (is (:model selection-cost)))))
 
-(deftest test-selection-transparency
+(deftest ^{:stratum 0} test-selection-transparency
   (testing "Selection provides clear rationale"
     (let [task {:phase :plan
                 :description "Architecture planning"}
@@ -184,7 +185,7 @@
       (is (re-find #"Model Auto-Selected:" explanation))
       (is (re-find #"Override:" explanation)))))
 
-(deftest test-multiple-task-types
+(deftest ^{:stratum 0} test-multiple-task-types
   (testing "Different task types get appropriate models"
     (let [;; Create various task types
           tasks [{:phase :plan :title "Plan"}
@@ -222,7 +223,7 @@
       (let [validate-selection (-> selections (nth 2) :selection)]
         (is (= :simple-validation (:task-type validate-selection)))))))
 
-(deftest test-fallback-behavior
+(deftest ^{:stratum 0} test-fallback-behavior
   (testing "System has safe fallback when selection fails"
     (let [;; Minimal task with no clear signals
           task {:description "Generic task"}
@@ -238,7 +239,7 @@
       (is (:model selection))
       (is (:model-id selection)))))
 
-(deftest test-cross-provider-selection
+(deftest ^{:stratum 0} test-cross-provider-selection
   (testing "System can select from multiple providers"
     (let [;; Create tasks that might favor different providers
           tasks [{:phase :plan :title "Complex reasoning"}
@@ -268,7 +269,7 @@
       (let [privacy (nth selections 2)]
         (is (#{:meta :alibaba :deepseek :zhipu} (:provider privacy)))))))
 
-(deftest test-model-override
+(deftest ^{:stratum 0} test-model-override
   (testing "Explicit model override bypasses automatic selection"
     ;; Note: This test documents expected behavior
     ;; In actual agent creation, passing :model explicitly
@@ -287,7 +288,7 @@
       ;; This is tested at the agent layer, not here
       )))
 
-(deftest test-selection-confidence
+(deftest ^{:stratum 0} test-selection-confidence
   (testing "Selection includes confidence from classification"
     (let [;; High-confidence task (clear phase signal)
           high-conf-task {:phase :plan
@@ -313,7 +314,7 @@
       (is (:model high-selection))
       (is (:model low-selection)))))
 
-(deftest test-all-19-models-accessible
+(deftest ^{:stratum 0} test-all-19-models-accessible
   (testing "All 19 models in registry can be selected"
     (let [;; Get all model keys
           all-models (keys registry/model-registry)]
@@ -329,7 +330,7 @@
           (is (:provider model))
           (is (:capabilities model)))))))
 
-(deftest test-selection-rationale-completeness
+(deftest ^{:stratum 0} test-selection-rationale-completeness
   (testing "Selection rationale includes all key information"
     (let [task {:phase :implement
                 :description "Code implementation"

--- a/components/llm/test/ai/miniforge/llm/model_selector_test.clj
+++ b/components/llm/test/ai/miniforge/llm/model_selector_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.llm.model-selector-test
   (:require
    [clojure.test :refer [deftest is testing use-fixtures]]
@@ -28,7 +27,9 @@
                       (with-redefs [selector/get-env-var (constantly "test-key")]
                         (f))))
 
-(deftest test-model-available
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} test-model-available
   (testing "cloud model available when API key env var is set"
     ;; fixture already sets get-env-var -> "test-key" for the outer cases
     (is (selector/model-available? :sonnet-4.6))
@@ -46,20 +47,20 @@
   (testing "unregistered model key returns falsy"
     (is (not (selector/model-available? :nonexistent-model-xyz)))))
 
-(deftest test-meets-context-requirement
+(deftest ^{:stratum 0} test-meets-context-requirement
   (testing "Context requirement checks"
     (is (selector/meets-context-requirement? :opus-4.6 100000))
     (is (selector/meets-context-requirement? :gemini-2.5-pro 500000))
     (is (not (selector/meets-context-requirement? :qwen-2.5-coder-32b 100000)))))
 
-(deftest test-meets-cost-constraint
+(deftest ^{:stratum 0} test-meets-cost-constraint
   (testing "Cost constraint checks"
     (is (selector/meets-cost-constraint? :haiku-4.5 0.01))
     (is (selector/meets-cost-constraint? :sonnet-4.6 0.05))
     (is (selector/meets-cost-constraint? :opus-4.6 0.10))
     (is (selector/meets-cost-constraint? :codellama-34b 0.01))))
 
-(deftest test-select-by-automatic
+(deftest ^{:stratum 0} test-select-by-automatic
   (testing "Automatic selection for thinking-heavy"
     (let [selected (selector/select-by-automatic :thinking-heavy {})]
       (is (some #{selected} [:opus-4.7 :opus-4.6 :gpt-5.4-pro :gpt-5.4]))))
@@ -76,18 +77,18 @@
     (let [selected (selector/select-by-automatic :execution-focused {:require-local true})]
       (is (some #{selected} [:qwen-2.5-coder-32b :deepseek-coder-33b :codellama-34b])))))
 
-(deftest test-select-by-cost-optimized
+(deftest ^{:stratum 0} test-select-by-cost-optimized
   (testing "Cost-optimized selection prefers free models"
     (let [selected (selector/select-by-cost-optimized :execution-focused {})]
       ;; Should prefer local/free models or cheap cloud models
       (is (keyword? selected)))))
 
-(deftest test-select-by-speed
+(deftest ^{:stratum 0} test-select-by-speed
   (testing "Speed-optimized selection prefers fast models"
     (let [selected (selector/select-by-speed :execution-focused {})]
       (is (keyword? selected)))))
 
-(deftest test-select-model
+(deftest ^{:stratum 0} test-select-model
   (testing "Select model for thinking-heavy task"
     (let [classification {:type :thinking-heavy
                           :confidence 0.9
@@ -147,7 +148,7 @@
           model (registry/get-model (:model selection))]
       (is (>= (get-in model [:capabilities :context-window]) 500000)))))
 
-(deftest test-select-model-for-phase
+(deftest ^{:stratum 0} test-select-model-for-phase
   (testing "Plan phase selects thinking model"
     (let [selection (selector/select-model-for-phase :plan)]
       (is (= :thinking-heavy (:task-type selection)))
@@ -163,7 +164,7 @@
       (is (= :simple-validation (:task-type selection)))
       (is (:model selection)))))
 
-(deftest test-build-selection-rationale
+(deftest ^{:stratum 0} test-build-selection-rationale
   (testing "Rationale is human-readable"
     (let [classification {:type :thinking-heavy
                           :confidence 0.9
@@ -175,7 +176,7 @@
       (is (re-find #"Task:" rationale))
       (is (re-find #"Selected Model:" rationale)))))
 
-(deftest test-explain-selection
+(deftest ^{:stratum 0} test-explain-selection
   (testing "Explanation is user-friendly"
     (let [classification {:type :execution-focused
                           :confidence 0.85
@@ -187,7 +188,7 @@
       (is (re-find #"Model Auto-Selected:" explanation))
       (is (re-find #"Override:" explanation)))))
 
-(deftest test-selection-strategies
+(deftest ^{:stratum 0} test-selection-strategies
   (testing "Automatic strategy"
     (let [classification {:type :execution-focused
                           :confidence 0.8
@@ -212,7 +213,7 @@
                                            {:strategy :speed})]
       (is (= :speed (:strategy selection))))))
 
-(deftest test-fallback-behavior
+(deftest ^{:stratum 0} test-fallback-behavior
   (testing "Fallback to safe default when no model matches"
     ;; Test with valid task type - even with unknown types, system should return a model
     ;; Using execution-focused as a safe default case

--- a/components/llm/test/ai/miniforge/llm/network_health_test.clj
+++ b/components/llm/test/ai/miniforge/llm/network_health_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.llm.network-health-test
   "Tests for `ai.miniforge.llm.network-health` — the URL-driven
    connectivity probe primitive that PR-B will schedule alongside the
@@ -25,9 +24,10 @@
    [ai.miniforge.llm.network-health :as nh]
    [ai.miniforge.llm.protocols.impl.llm-client :as impl]))
 
-;------------------------------------------------------------------------------ Factories
+;------------------------------------------------------------------------------ Layer 0
 
-(defn- stub-http-client
+;------------------------------------------------------------------------------ Factories
+(defn- ^{:stratum 0} stub-http-client
   "Build an http-client stub matching `org.httpkit.client/request`'s
    shape (called with a request-map, returns a deref-able). The stub
    `response` is what the caller's `@(http-client ...)` returns.
@@ -40,7 +40,7 @@
       (swap! capture assoc :last-request request-map))
     (delay response)))
 
-(defn- throwing-http-client
+(defn- ^{:stratum 0} throwing-http-client
   "Build an http-client stub that throws `ex` synchronously (mirroring
    http-kit's documented dual-mode behavior where connection failures
    can surface as a *thrown* exception rather than an `:error` map)."
@@ -48,7 +48,7 @@
   (fn [_request-map]
     (throw ex)))
 
-(defn- throwing-on-deref-http-client
+(defn- ^{:stratum 0} throwing-on-deref-http-client
   "Build an http-client stub that returns a deref-able whose `@` throws.
    http-kit can also surface failures this way for callers that drop
    into Java-thread land."
@@ -58,8 +58,7 @@
       (deref [_] (throw ex)))))
 
 ;------------------------------------------------------------------------------ Probe-endpoint resolution (lives in llm-client/backends)
-
-(deftest probe-endpoint-for-test
+(deftest ^{:stratum 0} probe-endpoint-for-test
   ;; Co-located with the rest of each backend's config in
   ;; `llm-client/backends` — comment review on PR #1051 moved the
   ;; lookup out of network-health so the probe primitive stays
@@ -80,9 +79,10 @@
     (is (= "https://1.1.1.1/" (impl/probe-endpoint-for nil))
         "nil backend key still resolves to the generic fallback")))
 
-;------------------------------------------------------------------------------ network-healthy? (URL-driven)
+;------------------------------------------------------------------------------ Layer 1
 
-(deftest network-healthy?-treats-any-http-response-as-up-test
+;------------------------------------------------------------------------------ network-healthy? (URL-driven)
+(deftest ^{:stratum 1} network-healthy?-treats-any-http-response-as-up-test
   ;; Connectivity is about TCP/TLS reach + an HTTP exchange; any status
   ;; code proves the network completed a round trip. 4xx is the common
   ;; case for an unauthenticated HEAD on api.anthropic.com (returns 405
@@ -112,7 +112,7 @@
             {:http-client (stub-http-client {:status 301 :body ""
                                              :headers {"Location" "https://elsewhere"}})})))))
 
-(deftest network-healthy?-treats-connection-failure-as-down-test
+(deftest ^{:stratum 1} network-healthy?-treats-connection-failure-as-down-test
   (let [test-url "https://api.example.com/"]
     (testing ":error key (connection refused, DNS failure, etc.) → false"
       (is (false? (nh/network-healthy?
@@ -145,7 +145,7 @@
                     test-url
                     {:http-client (stub-http-client "not-a-map")}))))))
 
-(deftest network-healthy?-treats-thrown-exception-as-down-test
+(deftest ^{:stratum 1} network-healthy?-treats-thrown-exception-as-down-test
   ;; Regression for PR #1051 comment review: http-kit can surface
   ;; connection failures as a *thrown* exception rather than an
   ;; `:error` map. The probe must catch both shapes — otherwise it
@@ -176,8 +176,7 @@
                                     (RuntimeException. "wat"))}))))))
 
 ;------------------------------------------------------------------------------ Request shape
-
-(deftest network-healthy?-sends-head-request-test
+(deftest ^{:stratum 1} network-healthy?-sends-head-request-test
   (testing "probe uses HEAD method against the URL it was given"
     (let [capture (atom {})]
       (nh/network-healthy?
@@ -188,7 +187,7 @@
              (get-in @capture [:last-request :url]))
           "URL is the one the caller passed in — no internal mapping"))))
 
-(deftest network-healthy?-default-timeout-test
+(deftest ^{:stratum 1} network-healthy?-default-timeout-test
   (testing "default-probe-timeout-ms is propagated to the http-client"
     (let [capture (atom {})]
       (nh/network-healthy?
@@ -197,7 +196,7 @@
       (is (= nh/default-probe-timeout-ms
              (get-in @capture [:last-request :timeout]))))))
 
-(deftest network-healthy?-custom-timeout-test
+(deftest ^{:stratum 1} network-healthy?-custom-timeout-test
   (testing ":timeout-ms in opts overrides the default"
     (let [capture (atom {})]
       (nh/network-healthy?

--- a/components/llm/test/ai/miniforge/llm/network_monitor_test.clj
+++ b/components/llm/test/ai/miniforge/llm/network_monitor_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.llm.network-monitor-test
   "Tests for `ai.miniforge.llm.network-monitor` — the consecutive-
    failure scheduler that turns the probe primitive into a single-fire
@@ -24,9 +23,10 @@
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.llm.network-monitor :as nm]))
 
-;------------------------------------------------------------------------------ Factories + helpers
+;------------------------------------------------------------------------------ Layer 0
 
-(defn- scripted-probe
+;------------------------------------------------------------------------------ Factories + helpers
+(defn- ^{:stratum 0} scripted-probe
   "Build a probe-fn that returns the next value from `script` on each
    call. `script` is a vector of `:up` / `:down` keywords (or true /
    false). Once the script runs out, further calls return the last
@@ -41,7 +41,7 @@
         (swap! idx inc)
         (get coerce v v)))))
 
-(defn- record-call
+(defn- ^{:stratum 0} record-call
   "Build an on-drop callback that swap!'s its diagnostic-map into
    `record-atom` under :calls (vec) and signals the latch."
   [record-atom latch]
@@ -52,19 +52,46 @@
 ;; Short interval / low threshold so the suite stays fast — the
 ;; production defaults are 10s/3 strikes (~30s to fire); tests use ms-
 ;; level intervals for the same logical exercise.
-(def ^:private fast-probe-interval-ms 10)
-(def ^:private fast-failure-threshold 3)
+(def ^{:stratum 0} ^:private fast-probe-interval-ms 10)
 
-(defn- wait-for-fire-or-timeout
+(def ^{:stratum 0} ^:private fast-failure-threshold 3)
+
+(defn- ^{:stratum 0} wait-for-fire-or-timeout
   "Block up to `timeout-ms` for the on-drop callback to fire (the
    `latch` promise to be delivered). Returns the delivered value, or
    `::timeout` if the latch never fires."
   [latch timeout-ms]
   (deref latch timeout-ms ::timeout))
 
-;------------------------------------------------------------------------------ Healthy path
+;------------------------------------------------------------------------------ stream-exec-fn opts merge protection
+;; This test lives here (rather than in interface_test) because it
+;; pins the contract from the monitor's perspective: when callers pass
+;; through `:network-monitor-opts`, the integration must enforce its
+;; own `:probe-url`, `:backend-key`, and `:on-drop`. The integration
+;; site in `stream-exec-fn` (Copilot review on PR #1053) merges caller
+;; opts FIRST, so its protected keys always win.
+(deftest ^{:stratum 0} probe-url-and-on-drop-take-priority-over-caller-opts-test
+  (testing "caller opts merged FIRST → integration owns the protected keys"
+    ;; Mimic the merge order that stream-exec-fn now uses:
+    ;;   (merge caller-opts {:probe-url ... :backend-key ... :on-drop ...})
+    (let [caller-opts {:probe-url   "https://malicious.example.com/"
+                       :on-drop     (fn [_] (throw (Exception. "caller's on-drop")))
+                       :backend-key :spoofed}
+          integration {:probe-url   "https://real.example.com/"
+                       :backend-key :claude
+                       :on-drop     (fn [diag]
+                                      (is (= "https://real.example.com/" (:probe-url diag)))
+                                      (is (= :claude (:backend-key diag))))}
+          effective   (merge caller-opts integration)]
+      (is (= "https://real.example.com/" (:probe-url effective)))
+      (is (= :claude (:backend-key effective)))
+      (is (not= (:on-drop caller-opts) (:on-drop effective))
+          "integration's on-drop wins; caller's on-drop is discarded"))))
 
-(deftest steady-healthy-stream-never-fires-test
+;------------------------------------------------------------------------------ Layer 1
+
+;------------------------------------------------------------------------------ Healthy path
+(deftest ^{:stratum 1} steady-healthy-stream-never-fires-test
   (testing "every probe returns :up → on-drop never called"
     (let [record (atom {:calls []})
           stop!  (nm/start-network-monitor!
@@ -83,8 +110,7 @@
           (stop!))))))
 
 ;------------------------------------------------------------------------------ Transient blip
-
-(deftest transient-blip-resets-counter-test
+(deftest ^{:stratum 1} transient-blip-resets-counter-test
   (testing "an isolated failure followed by a recovery does not fire on-drop"
     (let [record (atom {:calls []})
           ;; failure-threshold 3; sequence is down, up, down, down, up, up...
@@ -106,8 +132,7 @@
           (stop!))))))
 
 ;------------------------------------------------------------------------------ Confirmed drop
-
-(deftest three-consecutive-failures-fire-on-drop-once-test
+(deftest ^{:stratum 1} three-consecutive-failures-fire-on-drop-once-test
   (testing "exactly threshold consecutive failures fires on-drop once"
     (let [record (atom {:calls []})
           latch  (promise)
@@ -133,7 +158,7 @@
         (finally
           (stop!))))))
 
-(deftest on-drop-diagnostic-shape-test
+(deftest ^{:stratum 1} on-drop-diagnostic-shape-test
   (testing "on-drop receives a diagnostic map with the canonical keys"
     (let [record (atom {:calls []})
           latch  (promise)
@@ -159,8 +184,7 @@
           (stop!))))))
 
 ;------------------------------------------------------------------------------ Probe-fn exception is treated as failure
-
-(deftest probe-fn-exception-counts-as-failure-test
+(deftest ^{:stratum 1} probe-fn-exception-counts-as-failure-test
   ;; A probe that throws (DNS resolution failure that bubbles out,
   ;; some other unexpected exception) should be treated as a failed
   ;; probe rather than crashing the monitor thread.
@@ -185,8 +209,7 @@
           (stop!))))))
 
 ;------------------------------------------------------------------------------ stop! semantics
-
-(deftest stop!-prevents-further-on-drop-calls-test
+(deftest ^{:stratum 1} stop!-prevents-further-on-drop-calls-test
   (testing "stop! invoked before the threshold is reached → on-drop never fires"
     (let [record (atom {:calls []})
           stop!  (nm/start-network-monitor!
@@ -203,7 +226,7 @@
       (is (empty? (:calls @record))
           "stop! interrupts the worker before on-drop can fire"))))
 
-(deftest stop!-is-idempotent-test
+(deftest ^{:stratum 1} stop!-is-idempotent-test
   (testing "calling stop! twice is a no-op the second time"
     (let [stop! (nm/start-network-monitor!
                   {:probe-url         "https://test.example.com/"
@@ -217,8 +240,7 @@
           "second stop! returns nil — does not throw"))))
 
 ;------------------------------------------------------------------------------ Argument validation
-
-(deftest start-monitor-rejects-missing-probe-url-test
+(deftest ^{:stratum 1} start-monitor-rejects-missing-probe-url-test
   (is (thrown? AssertionError
                (nm/start-network-monitor!
                  {:backend-key       :claude
@@ -237,7 +259,7 @@
                   :on-drop           (fn [_] nil)}))
       "empty :probe-url is not a usable URL"))
 
-(deftest start-monitor-rejects-non-positive-interval-test
+(deftest ^{:stratum 1} start-monitor-rejects-non-positive-interval-test
   (is (thrown? AssertionError
                (nm/start-network-monitor!
                  {:probe-url         "https://test.example.com/"
@@ -255,7 +277,7 @@
                   :probe-fn          (scripted-probe [:up])
                   :on-drop           (fn [_] nil)}))))
 
-(deftest start-monitor-rejects-non-positive-threshold-test
+(deftest ^{:stratum 1} start-monitor-rejects-non-positive-threshold-test
   (is (thrown? AssertionError
                (nm/start-network-monitor!
                  {:probe-url         "https://test.example.com/"
@@ -273,7 +295,7 @@
                   :probe-fn          (scripted-probe [:up])
                   :on-drop           (fn [_] nil)}))))
 
-(deftest start-monitor-rejects-non-fn-on-drop-test
+(deftest ^{:stratum 1} start-monitor-rejects-non-fn-on-drop-test
   (is (thrown? AssertionError
                (nm/start-network-monitor!
                  {:probe-url         "https://test.example.com/"
@@ -290,8 +312,7 @@
 ;; after stop! had already returned. The fix uses `compare-and-set!`
 ;; on the running? atom to atomically claim the firing slot — stop!
 ;; and the worker race for the same true→false transition.
-
-(deftest stop!-racing-the-fire-cas-suppresses-on-drop-test
+(deftest ^{:stratum 1} stop!-racing-the-fire-cas-suppresses-on-drop-test
   ;; Drive many short trials. The slow `:on-drop` callback amplifies
   ;; the window in which a stop! after the threshold check could race
   ;; the fire. With the CAS in place, a stop! that wins the
@@ -320,7 +341,7 @@
         (is (<= (count (:calls @record)) 1)
             "CAS guarantees at most one on-drop call, regardless of race outcome")))))
 
-(deftest stop!-then-already-passed-threshold-fires-at-most-once-test
+(deftest ^{:stratum 1} stop!-then-already-passed-threshold-fires-at-most-once-test
   ;; The classic single-fire guarantee under heavy concurrent stop! /
   ;; probe pressure. After firing, the worker exits; extra :down
   ;; probes do NOT produce additional calls.
@@ -340,30 +361,3 @@
         (is (= 1 (count (:calls @record))))
         (finally
           (stop!))))))
-
-;------------------------------------------------------------------------------ stream-exec-fn opts merge protection
-
-;; This test lives here (rather than in interface_test) because it
-;; pins the contract from the monitor's perspective: when callers pass
-;; through `:network-monitor-opts`, the integration must enforce its
-;; own `:probe-url`, `:backend-key`, and `:on-drop`. The integration
-;; site in `stream-exec-fn` (Copilot review on PR #1053) merges caller
-;; opts FIRST, so its protected keys always win.
-
-(deftest probe-url-and-on-drop-take-priority-over-caller-opts-test
-  (testing "caller opts merged FIRST → integration owns the protected keys"
-    ;; Mimic the merge order that stream-exec-fn now uses:
-    ;;   (merge caller-opts {:probe-url ... :backend-key ... :on-drop ...})
-    (let [caller-opts {:probe-url   "https://malicious.example.com/"
-                       :on-drop     (fn [_] (throw (Exception. "caller's on-drop")))
-                       :backend-key :spoofed}
-          integration {:probe-url   "https://real.example.com/"
-                       :backend-key :claude
-                       :on-drop     (fn [diag]
-                                      (is (= "https://real.example.com/" (:probe-url diag)))
-                                      (is (= :claude (:backend-key diag))))}
-          effective   (merge caller-opts integration)]
-      (is (= "https://real.example.com/" (:probe-url effective)))
-      (is (= :claude (:backend-key effective)))
-      (is (not= (:on-drop caller-opts) (:on-drop effective))
-          "integration's on-drop wins; caller's on-drop is discarded"))))

--- a/components/llm/test/ai/miniforge/llm/prompt_size_telemetry_test.clj
+++ b/components/llm/test/ai/miniforge/llm/prompt_size_telemetry_test.clj
@@ -15,14 +15,15 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.llm.prompt-size-telemetry-test
   "Pre-flight input-size gauge for the assembled agent prompt."
   (:require
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.llm.protocols.impl.llm-client :as impl]))
 
-(deftest prompt-size-telemetry-test
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} prompt-size-telemetry-test
   (testing "counts system + user chars and estimates input tokens (chars/4)"
     (is (= {:system-chars 8
             :user-chars 12

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-llm.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-llm.md
@@ -1,0 +1,162 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+# fix: stratum-lint autofix for components/llm (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over `components/llm` (`src` + `test`) to replace
+decorative `Layer N` headings with real ones derived from each file's actual
+same-file reference graph, and tag every top-level `def`/`defn`/`deftest`
+with `^{:stratum n}`. One batch (batch 5) of the Wave 1 program tracked in
+`work/stratum-lint-baseline-2026-07-24.md`. Purely mechanical: no hand edits
+were needed beyond what `--fix` produced, and no executable logic changed
+anywhere.
+
+## Motivation
+
+Baseline findings for this component, confirmed via a fresh plain-lint run
+before touching anything (zero `SL001` — no upward-reference/cycle risk,
+matching the Wave 1 batch criteria):
+
+- `interface.clj`: `SL003`, 7 distinct (decorative) layers against the
+  3-layer budget.
+- `protocols/impl/llm_client.clj`: `SL002` (a `Layer 0` heading reappearing
+  after `Layer 0`) and `SL003` (4 distinct decorative layers).
+- `protocols/records/llm_client.clj`: `SL004`, the `CLIClient` `defrecord`
+  appears before the file's first `Layer` heading.
+- `test/http_providers_test.clj`: `SL003`, 4 distinct decorative layers.
+- `test/interface_test.clj`: `SL002` (three separate `Layer 5` headings
+  each reappearing after `Layer 5`) and `SL003` (7 distinct decorative
+  layers).
+
+## Changes in Detail
+
+Ran, over the whole component:
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "bef8657a2efd3b1ba9e1a4f510693c9fbca45abd" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/llm
+```
+
+All 24 `.clj` files in the component were rewritten (`--fix` normalizes
+every file, not just the ones with findings): 12 `src` files and 12 `test`
+files. Diffs are heading text, `^{:stratum n}` metadata, and def/deftest
+reordering only — verified with an automated structural check (read every
+top-level form from the pre-fix and post-fix version of each file with the
+Clojure reader, strip metadata, compare as a multiset) confirming an
+identical set of forms before and after in all 24 files; the only
+differences are position and the added `^{:stratum n}` annotations.
+
+Two reorderings worth calling out because they look large in the raw diff:
+
+- `interface.clj` collapsed from 7 decorative layers to 2 real ones
+  (`0` and `1`): almost every re-exported function is a direct pass-through
+  to another namespace (real stratum 0); only `chat`, `chat-stream`, and
+  `create-client-for-model` call another same-file def (`complete`,
+  `complete-stream`, `create-client`, `backend-for-model`) and land at
+  stratum 1.
+- `protocols/impl/llm_client.clj` (2180 lines) is the largest diff by far —
+  its real reference graph is 11 layers deep, all correctly monotonic
+  (`Layer 0` through `Layer 10`) in the rewritten file. No trailing
+  same-line comment was found displaced onto the wrong def anywhere in this
+  file or any other file in the component (checked with a targeted grep for
+  `)  ; comment` patterns across every changed file).
+
+No decorative `;;----` (double-semicolon) banners were left orphaned next
+to a contradicting real heading anywhere in the component. Two ns
+docstrings (`model_registry.clj` and `model_selector.clj`) contain a prose
+summary of their own layer structure (e.g. `"Layer 0: Model capability
+definitions ... Layer 1: Query functions ... Layer 2: Recommendation
+logic"`) that is now stale relative to the real layer count `--fix`
+computed. Left these untouched, consistent with how the `artifact`
+component (an earlier Wave 1 batch) handled the identical situation — these
+are docstring prose, not the heading-comment convention stratum-lint
+parses, and are out of scope for a mechanical autofix pass.
+
+No `defmethod` in this component, so the upstream `defmethod`-refs-union bug
+class (already fixed at this pin) doesn't apply here. No reader-conditional
+(`#?(...)`) wrapped `defn` in this component, so `SL008` never came up.
+
+## Testing Plan
+
+1. Ran plain (non-`--fix`) `stratum-lint` before any change — reproduced
+   the findings above exactly, confirmed 0 `SL001`.
+2. Ran `--fix`, then a second `--fix` pass immediately after — zero diff,
+   confirms idempotency.
+3. Read the full diff for all 24 changed files, plus an automated
+   structural-equality check (Clojure reader, metadata stripped, multiset
+   compare) across all 24 files confirming no code body changed. Checked
+   for same-line trailing-comment displacement and orphaned decorative
+   banners — none found.
+4. `clj-kondo --lint components/llm`: 0 errors, 2 warnings both before and
+   after (`cost_test.clj` unresolved `clojure.java.io`/`clojure.edn`
+   namespace warnings — pre-existing, confirmed via `git stash` + re-lint;
+   unchanged in content and count, only line numbers shifted).
+5. Ran all 12 test namespaces directly via `clojure -M:dev:test`: 186
+   tests, 1051 assertions, 0 failures, 0 errors.
+6. Re-ran plain `stratum-lint` after the fix: `SL001`/`SL002`/`SL004` clear
+   across the component. `SL003` remains on 4 files, all newly surfaced by
+   the fix (not present as `SL003` in the pre-fix baseline in this form —
+   the pre-fix `SL003`s were on different files with different decorative
+   counts):
+   - `cost.clj`: 4 real layers (was clean pre-fix; `--fix` surfaced a
+     genuine chain through `usage-token-count`/`cost-table`/
+     `pricing-for-model`/`estimate-cost`).
+   - `model_registry.clj`: 5 real layers (was clean pre-fix; true chain is
+     `load-model-catalog` → `model-catalog`/`model-registry` →
+     `task-type-recommendations` → query fns → `supports-large-context?`).
+   - `model_selector.clj`: 7 real layers (was clean pre-fix; true chain
+     runs constants → `default-config-fallback`/`model-selector-config` →
+     `default-config`/`provider-env-vars`/`meets-cost-constraint?` →
+     `model-available?` → the three `select-by-*` strategies →
+     `select-model` → `select-model-for-phase`).
+   - `protocols/impl/llm_client.clj`: 11 real layers (was 4 decorative,
+     already over budget pre-fix).
+
+   All four are genuinely over the 3-layer budget the old decorative
+   headings hid (either by undercounting or by not existing at all) — not
+   a regression this PR introduces. Deferred to Wave 2 (real namespace
+   split), consistent with how prior Wave 1 PRs handled the same situation.
+   `interface.clj`'s, `protocols/records/llm_client.clj`'s,
+   `http_providers_test.clj`'s, and `interface_test.clj`'s original findings
+   are all fully resolved (collapsed to 2–3 real layers each, under
+   budget).
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+change — comment/metadata/order-only. Pre-commit's `lint:stratum` autofixer
+keeps this component clean going forward; the 4 over-budget files stay
+advisory (`MINIFORGE_STRATUM_BUDGET_MODE=warn` at commit time) until Wave 2
+splits them.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1, batch 5)
+- Follow-on: Wave 2 namespace split for
+  `components/llm/src/ai/miniforge/llm/cost.clj` (4 real layers),
+  `components/llm/src/ai/miniforge/llm/model_registry.clj` (5 real
+  layers), `components/llm/src/ai/miniforge/llm/model_selector.clj` (7 real
+  layers), and
+  `components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj` (11
+  real layers, 2180 lines — the clearest Wave 2 split candidate in this
+  component)
+
+## Checklist
+
+- [x] Confirmed zero `SL001` before making any change
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Second `--fix` pass confirms idempotency (zero diff)
+- [x] Diff read in full for all 24 changed files, plus an automated
+      structural-equality check confirming no code body changed
+- [x] No same-line trailing-comment displacement found in any file
+- [x] No orphaned decorative `;;----` banners found in any file
+- [x] `clj-kondo` clean of new issues (0 errors before/after; 2
+      pre-existing warnings unchanged in content/count)
+- [x] Component tests pass (186 tests, 1051 assertions, 0 failures/errors)
+- [x] Plain lint re-run post-fix: zero `SL001`/`SL002`/`SL004`; `SL003`
+      remains on 4 files — newly surfaced by the fix, tracked as Wave 2
+      above
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->
# fix: stratum-lint autofix for components/llm (Wave 1)

## Overview

Runs `stratum-lint --fix` over `components/llm` (`src` + `test`) to replace
decorative `Layer N` headings with real ones derived from each file's actual
same-file reference graph, and tag every top-level `def`/`defn`/`deftest`
with `^{:stratum n}`. One batch (batch 5) of the Wave 1 program tracked in
`work/stratum-lint-baseline-2026-07-24.md`. Purely mechanical: no hand edits
were needed beyond what `--fix` produced, and no executable logic changed
anywhere.

## Motivation

Baseline findings for this component, confirmed via a fresh plain-lint run
before touching anything (zero `SL001` — no upward-reference/cycle risk,
matching the Wave 1 batch criteria):

- `interface.clj`: `SL003`, 7 distinct (decorative) layers against the
  3-layer budget.
- `protocols/impl/llm_client.clj`: `SL002` (a `Layer 0` heading reappearing
  after `Layer 0`) and `SL003` (4 distinct decorative layers).
- `protocols/records/llm_client.clj`: `SL004`, the `CLIClient` `defrecord`
  appears before the file's first `Layer` heading.
- `test/http_providers_test.clj`: `SL003`, 4 distinct decorative layers.
- `test/interface_test.clj`: `SL002` (three separate `Layer 5` headings
  each reappearing after `Layer 5`) and `SL003` (7 distinct decorative
  layers).

## Changes in Detail

Ran, over the whole component:

```bash
bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "bef8657a2efd3b1ba9e1a4f510693c9fbca45abd" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/llm
```

All 24 `.clj` files in the component were rewritten (`--fix` normalizes
every file, not just the ones with findings): 12 `src` files and 12 `test`
files. Diffs are heading text, `^{:stratum n}` metadata, and def/deftest
reordering only — verified with an automated structural check (read every
top-level form from the pre-fix and post-fix version of each file with the
Clojure reader, strip metadata, compare as a multiset) confirming an
identical set of forms before and after in all 24 files; the only
differences are position and the added `^{:stratum n}` annotations.

Two reorderings worth calling out because they look large in the raw diff:

- `interface.clj` collapsed from 7 decorative layers to 2 real ones
  (`0` and `1`): almost every re-exported function is a direct pass-through
  to another namespace (real stratum 0); only `chat`, `chat-stream`, and
  `create-client-for-model` call another same-file def (`complete`,
  `complete-stream`, `create-client`, `backend-for-model`) and land at
  stratum 1.
- `protocols/impl/llm_client.clj` (2180 lines) is the largest diff by far —
  its real reference graph is 11 layers deep, all correctly monotonic
  (`Layer 0` through `Layer 10`) in the rewritten file. No trailing
  same-line comment was found displaced onto the wrong def anywhere in this
  file or any other file in the component (checked with a targeted grep for
  `)  ; comment` patterns across every changed file).

No decorative `;;----` (double-semicolon) banners were left orphaned next
to a contradicting real heading anywhere in the component. Two ns
docstrings (`model_registry.clj` and `model_selector.clj`) contain a prose
summary of their own layer structure (e.g. `"Layer 0: Model capability
definitions ... Layer 1: Query functions ... Layer 2: Recommendation
logic"`) that is now stale relative to the real layer count `--fix`
computed. Left these untouched, consistent with how the `artifact`
component (an earlier Wave 1 batch) handled the identical situation — these
are docstring prose, not the heading-comment convention stratum-lint
parses, and are out of scope for a mechanical autofix pass.

No `defmethod` in this component, so the upstream `defmethod`-refs-union bug
class (already fixed at this pin) doesn't apply here. No reader-conditional
(`#?(...)`) wrapped `defn` in this component, so `SL008` never came up.

## Testing Plan

1. Ran plain (non-`--fix`) `stratum-lint` before any change — reproduced
   the findings above exactly, confirmed 0 `SL001`.
2. Ran `--fix`, then a second `--fix` pass immediately after — zero diff,
   confirms idempotency.
3. Read the full diff for all 24 changed files, plus an automated
   structural-equality check (Clojure reader, metadata stripped, multiset
   compare) across all 24 files confirming no code body changed. Checked
   for same-line trailing-comment displacement and orphaned decorative
   banners — none found.
4. `clj-kondo --lint components/llm`: 0 errors, 2 warnings both before and
   after (`cost_test.clj` unresolved `clojure.java.io`/`clojure.edn`
   namespace warnings — pre-existing, confirmed via `git stash` + re-lint;
   unchanged in content and count, only line numbers shifted).
5. Ran all 12 test namespaces directly via `clojure -M:dev:test`: 186
   tests, 1051 assertions, 0 failures, 0 errors.
6. Re-ran plain `stratum-lint` after the fix: `SL001`/`SL002`/`SL004` clear
   across the component. `SL003` remains on 4 files, all newly surfaced by
   the fix (not present as `SL003` in the pre-fix baseline in this form —
   the pre-fix `SL003`s were on different files with different decorative
   counts):
   - `cost.clj`: 4 real layers (was clean pre-fix; `--fix` surfaced a
     genuine chain through `usage-token-count`/`cost-table`/
     `pricing-for-model`/`estimate-cost`).
   - `model_registry.clj`: 5 real layers (was clean pre-fix; true chain is
     `load-model-catalog` → `model-catalog`/`model-registry` →
     `task-type-recommendations` → query fns → `supports-large-context?`).
   - `model_selector.clj`: 7 real layers (was clean pre-fix; true chain
     runs constants → `default-config-fallback`/`model-selector-config` →
     `default-config`/`provider-env-vars`/`meets-cost-constraint?` →
     `model-available?` → the three `select-by-*` strategies →
     `select-model` → `select-model-for-phase`).
   - `protocols/impl/llm_client.clj`: 11 real layers (was 4 decorative,
     already over budget pre-fix).

   All four are genuinely over the 3-layer budget the old decorative
   headings hid (either by undercounting or by not existing at all) — not
   a regression this PR introduces. Deferred to Wave 2 (real namespace
   split), consistent with how prior Wave 1 PRs handled the same situation.
   `interface.clj`'s, `protocols/records/llm_client.clj`'s,
   `http_providers_test.clj`'s, and `interface_test.clj`'s original findings
   are all fully resolved (collapsed to 2–3 real layers each, under
   budget).

## Deployment Plan

Merges to `main` like any other component change. No runtime behavior
change — comment/metadata/order-only. Pre-commit's `lint:stratum` autofixer
keeps this component clean going forward; the 4 over-budget files stay
advisory (`MINIFORGE_STRATUM_BUDGET_MODE=warn` at commit time) until Wave 2
splits them.

## Related Issues/PRs

- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1, batch 5)
- Follow-on: Wave 2 namespace split for
  `components/llm/src/ai/miniforge/llm/cost.clj` (4 real layers),
  `components/llm/src/ai/miniforge/llm/model_registry.clj` (5 real
  layers), `components/llm/src/ai/miniforge/llm/model_selector.clj` (7 real
  layers), and
  `components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj` (11
  real layers, 2180 lines — the clearest Wave 2 split candidate in this
  component)

## Checklist

- [x] Confirmed zero `SL001` before making any change
- [x] `--fix` run over the whole component (`src` + `test`)
- [x] Second `--fix` pass confirms idempotency (zero diff)
- [x] Diff read in full for all 24 changed files, plus an automated
      structural-equality check confirming no code body changed
- [x] No same-line trailing-comment displacement found in any file
- [x] No orphaned decorative `;;----` banners found in any file
- [x] `clj-kondo` clean of new issues (0 errors before/after; 2
      pre-existing warnings unchanged in content/count)
- [x] Component tests pass (186 tests, 1051 assertions, 0 failures/errors)
- [x] Plain lint re-run post-fix: zero `SL001`/`SL002`/`SL004`; `SL003`
      remains on 4 files — newly surfaced by the fix, tracked as Wave 2
      above
- [x] No `--no-verify`; pre-commit hook runs normally at commit time
