### PR TITLE
fix: stratum-lint autofix for components/orchestrator (Wave 1)

### DIFF
--- a/components/orchestrator/src/ai/miniforge/orchestrator/core.clj
+++ b/components/orchestrator/src/ai/miniforge/orchestrator/core.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.orchestrator.core
   "Core orchestrator (Control Plane) implementation.
 
@@ -36,9 +35,9 @@
    [ai.miniforge.logging.interface :as log]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Configuration
 
-(defn build-repair-learning
+;; Configuration
+(defn ^{:stratum 0} build-repair-learning
   "Build a learning capture map from a repair history entry."
   [agent-role task repair-history]
   (let [last-repair (last repair-history)]
@@ -53,12 +52,12 @@
      :tags [:repair :inner-loop (keyword (name agent-role))]
      :confidence 0.7}))
 
-(def default-config
+(def ^{:stratum 0} default-config
   "Default control plane configuration."
   (config/load-config-resource "config/orchestrator/defaults.edn"
                                [:default-budget :escalation-threshold]))
 
-(def task-type->agent-role
+(def ^{:stratum 0} task-type->agent-role
   "Mapping of task types to agent roles."
   {:plan       :planner
    :design     :planner
@@ -66,66 +65,8 @@
    :test       :tester
    :review     :reviewer})
 
-;------------------------------------------------------------------------------ Layer 1
-;; Task Router implementation
-
-(defrecord SimpleTaskRouter [config]
-  proto/TaskRouter
-
-  (route-task [_this task _context]
-    (let [task-type (:task/type task)
-          agent-role (get task-type->agent-role task-type :implementer)]
-      {:agent-role agent-role
-       :reason (messages/t :route/reason {:task-type task-type :agent-role agent-role})}))
-
-  (can-handle? [_this task agent-role]
-    (let [task-type (:task/type task)
-          expected-role (get task-type->agent-role task-type)]
-      (= expected-role agent-role))))
-
-(defn create-router
-  "Create a task router."
-  ([] (create-router {}))
-  ([config] (->SimpleTaskRouter config)))
-
-;------------------------------------------------------------------------------ Layer 2
-;; Budget Manager implementation
-
-(defrecord SimpleBudgetManager [budgets usage]
-  proto/BudgetManager
-
-  (track-usage [_this workflow-id new-usage]
-    (swap! usage update workflow-id
-           (fn [current]
-             (let [curr (or current {:tokens 0 :cost-usd 0.0 :duration-ms 0})]
-               {:tokens (+ (:tokens curr) (get new-usage :tokens 0))
-                :cost-usd (+ (:cost-usd curr) (get new-usage :cost-usd 0.0))
-                :duration-ms (+ (:duration-ms curr) (get new-usage :duration-ms 0))}))))
-
-  (check-budget [_this workflow-id]
-    (let [budget (get @budgets workflow-id (:default-budget default-config))
-          used (get @usage workflow-id {:tokens 0 :cost-usd 0.0 :duration-ms 0})]
-      {:within-budget? (and (<= (:tokens used) (:max-tokens budget))
-                            (<= (:cost-usd used) (:max-cost-usd budget))
-                            (<= (:duration-ms used) (:timeout-ms budget)))
-       :remaining {:tokens (- (:max-tokens budget) (:tokens used))
-                   :cost-usd (- (:max-cost-usd budget) (:cost-usd used))
-                   :time-ms (- (:timeout-ms budget) (:duration-ms used))}
-       :used used
-       :budget budget}))
-
-  (set-budget [_this workflow-id budget]
-    (swap! budgets assoc workflow-id budget)))
-
-(defn create-budget-manager
-  "Create a budget manager."
-  []
-  (->SimpleBudgetManager (atom {}) (atom {})))
-
-;------------------------------------------------------------------------------ Layer 3
 ;; Knowledge Coordinator implementation
-
-(defn format-zettel-for-context
+(defn ^{:stratum 0} format-zettel-for-context
   "Format a zettel for inclusion in agent context."
   [zettel]
   (str (messages/t :knowledge/zettel-heading {:title (:zettel/title zettel)})
@@ -135,70 +76,8 @@
        (:zettel/content zettel)
        "\n"))
 
-(defn format-knowledge-block
-  "Format injected knowledge as a context block."
-  [zettels agent-role]
-  (when (seq zettels)
-    (str (messages/t :knowledge/header {:role (name agent-role)})
-         (messages/t :knowledge/preamble)
-         (apply str (map format-zettel-for-context zettels))
-         (messages/t :knowledge/separator))))
-
-(defrecord SimpleKnowledgeCoordinator [knowledge-store config]
-  proto/KnowledgeCoordinator
-
-  (inject-for-agent [_this agent-role task context]
-    (when (:knowledge-injection? config)
-      (let [task-tags (get task :task/tags [])
-            context-tags (get context :tags [])
-            query-context {:tags (distinct (concat task-tags context-tags))}
-            zettels (knowledge/inject-knowledge knowledge-store agent-role query-context)]
-        {:formatted (format-knowledge-block zettels agent-role)
-         :zettels zettels
-         :count (count zettels)})))
-
-  (capture-execution-learning [this execution-result]
-    (when (and (:learning-capture? config)
-               (:repaired? execution-result))
-      (let [{:keys [agent-role task repair-history]} execution-result]
-        (when (seq repair-history)
-          (let [learning (knowledge/capture-inner-loop-learning
-                          knowledge-store
-                          (build-repair-learning agent-role task repair-history))]
-            ;; Check if learning should be promoted to a rule
-            (when learning
-              (let [learning-id (or (:zettel/id learning) (:id learning))
-                    promotion-check (proto/should-promote-learning? this learning)]
-                (when (and (:promote? promotion-check) learning-id)
-                  (try
-                    (knowledge/promote-learning knowledge-store learning-id {})
-                    (catch Exception e
-                      (log/warn (:logger knowledge-store)
-                                :orchestrator
-                                :orchestrator/promote-learning-failed
-                                {:error (ex-message e) :learning-id learning-id})
-                      nil)))))
-            learning)))))
-
-  (should-promote-learning? [_this learning]
-    (let [confidence (get-in learning [:zettel/source :source/confidence] 0)
-          promotable? (>= confidence 0.85)]
-      {:promote? promotable?
-       :confidence confidence
-       :reason (if promotable?
-                 (messages/t :promote/ready)
-                 (messages/t :promote/below-threshold {:threshold 0.85}))})))
-
-(defn create-knowledge-coordinator
-  "Create a knowledge coordinator."
-  ([knowledge-store] (create-knowledge-coordinator knowledge-store default-config))
-  ([knowledge-store config]
-   (->SimpleKnowledgeCoordinator knowledge-store config)))
-
-;------------------------------------------------------------------------------ Layer 4
 ;; Control Plane implementation
-
-(defrecord ControlPlane [config router budget-mgr knowledge-coord
+(defrecord ^{:stratum 0} ControlPlane [config router budget-mgr knowledge-coord
                           workflow-mgr operator llm-backend artifact-store
                           active-workflows logger]
   proto/Orchestrator
@@ -286,7 +165,127 @@
                   {:data {:workflow-id workflow-id}})
         true))))
 
-(defn create-control-plane
+;------------------------------------------------------------------------------ Layer 1
+
+;; Task Router implementation
+(defrecord ^{:stratum 1} SimpleTaskRouter [config]
+  proto/TaskRouter
+
+  (route-task [_this task _context]
+    (let [task-type (:task/type task)
+          agent-role (get task-type->agent-role task-type :implementer)]
+      {:agent-role agent-role
+       :reason (messages/t :route/reason {:task-type task-type :agent-role agent-role})}))
+
+  (can-handle? [_this task agent-role]
+    (let [task-type (:task/type task)
+          expected-role (get task-type->agent-role task-type)]
+      (= expected-role agent-role))))
+
+;; Budget Manager implementation
+(defrecord ^{:stratum 1} SimpleBudgetManager [budgets usage]
+  proto/BudgetManager
+
+  (track-usage [_this workflow-id new-usage]
+    (swap! usage update workflow-id
+           (fn [current]
+             (let [curr (or current {:tokens 0 :cost-usd 0.0 :duration-ms 0})]
+               {:tokens (+ (:tokens curr) (get new-usage :tokens 0))
+                :cost-usd (+ (:cost-usd curr) (get new-usage :cost-usd 0.0))
+                :duration-ms (+ (:duration-ms curr) (get new-usage :duration-ms 0))}))))
+
+  (check-budget [_this workflow-id]
+    (let [budget (get @budgets workflow-id (:default-budget default-config))
+          used (get @usage workflow-id {:tokens 0 :cost-usd 0.0 :duration-ms 0})]
+      {:within-budget? (and (<= (:tokens used) (:max-tokens budget))
+                            (<= (:cost-usd used) (:max-cost-usd budget))
+                            (<= (:duration-ms used) (:timeout-ms budget)))
+       :remaining {:tokens (- (:max-tokens budget) (:tokens used))
+                   :cost-usd (- (:max-cost-usd budget) (:cost-usd used))
+                   :time-ms (- (:timeout-ms budget) (:duration-ms used))}
+       :used used
+       :budget budget}))
+
+  (set-budget [_this workflow-id budget]
+    (swap! budgets assoc workflow-id budget)))
+
+(defn ^{:stratum 1} format-knowledge-block
+  "Format injected knowledge as a context block."
+  [zettels agent-role]
+  (when (seq zettels)
+    (str (messages/t :knowledge/header {:role (name agent-role)})
+         (messages/t :knowledge/preamble)
+         (apply str (map format-zettel-for-context zettels))
+         (messages/t :knowledge/separator))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} create-router
+  "Create a task router."
+  ([] (create-router {}))
+  ([config] (->SimpleTaskRouter config)))
+
+(defn ^{:stratum 2} create-budget-manager
+  "Create a budget manager."
+  []
+  (->SimpleBudgetManager (atom {}) (atom {})))
+
+(defrecord ^{:stratum 2} SimpleKnowledgeCoordinator [knowledge-store config]
+  proto/KnowledgeCoordinator
+
+  (inject-for-agent [_this agent-role task context]
+    (when (:knowledge-injection? config)
+      (let [task-tags (get task :task/tags [])
+            context-tags (get context :tags [])
+            query-context {:tags (distinct (concat task-tags context-tags))}
+            zettels (knowledge/inject-knowledge knowledge-store agent-role query-context)]
+        {:formatted (format-knowledge-block zettels agent-role)
+         :zettels zettels
+         :count (count zettels)})))
+
+  (capture-execution-learning [this execution-result]
+    (when (and (:learning-capture? config)
+               (:repaired? execution-result))
+      (let [{:keys [agent-role task repair-history]} execution-result]
+        (when (seq repair-history)
+          (let [learning (knowledge/capture-inner-loop-learning
+                          knowledge-store
+                          (build-repair-learning agent-role task repair-history))]
+            ;; Check if learning should be promoted to a rule
+            (when learning
+              (let [learning-id (or (:zettel/id learning) (:id learning))
+                    promotion-check (proto/should-promote-learning? this learning)]
+                (when (and (:promote? promotion-check) learning-id)
+                  (try
+                    (knowledge/promote-learning knowledge-store learning-id {})
+                    (catch Exception e
+                      (log/warn (:logger knowledge-store)
+                                :orchestrator
+                                :orchestrator/promote-learning-failed
+                                {:error (ex-message e) :learning-id learning-id})
+                      nil)))))
+            learning)))))
+
+  (should-promote-learning? [_this learning]
+    (let [confidence (get-in learning [:zettel/source :source/confidence] 0)
+          promotable? (>= confidence 0.85)]
+      {:promote? promotable?
+       :confidence confidence
+       :reason (if promotable?
+                 (messages/t :promote/ready)
+                 (messages/t :promote/below-threshold {:threshold 0.85}))})))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} create-knowledge-coordinator
+  "Create a knowledge coordinator."
+  ([knowledge-store] (create-knowledge-coordinator knowledge-store default-config))
+  ([knowledge-store config]
+   (->SimpleKnowledgeCoordinator knowledge-store config)))
+
+;------------------------------------------------------------------------------ Layer 4
+
+(defn ^{:stratum 4} create-control-plane
   "Create a control plane (orchestrator) with all components.
    See ai.miniforge.orchestrator.interface for the full argument/option contract."
   [llm-backend knowledge-store artifact-store & [{:keys [config logger operator]}]]
@@ -313,8 +312,10 @@
      (atom {})
      log)))
 
+;------------------------------------------------------------------------------ Layer 5
+
 ;; Alias for backward compatibility
-(def create-orchestrator create-control-plane)
+(def ^{:stratum 5} create-orchestrator create-control-plane)
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/orchestrator/src/ai/miniforge/orchestrator/interface.clj
+++ b/components/orchestrator/src/ai/miniforge/orchestrator/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.orchestrator.interface
   "Public API for the orchestrator component.
    Provides workflow execution, task routing, and knowledge coordination."
@@ -24,9 +23,9 @@
    [ai.miniforge.orchestrator.protocol :as proto]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Protocol re-exports
 
-(def Orchestrator
+;; Protocol re-exports
+(def ^{:stratum 0} Orchestrator
   "Protocol satisfied by control-plane instances.
 
    Defines the workflow lifecycle contract: execute-workflow,
@@ -35,14 +34,14 @@
    extend or check satisfies? against the published contract."
   proto/Orchestrator)
 
-(def TaskRouter
+(def ^{:stratum 0} TaskRouter
   "Protocol satisfied by task-router instances.
 
    Defines route-task and can-handle?, mapping task types to agent
    roles. Re-exported for extension and satisfies? checks."
   proto/TaskRouter)
 
-(def BudgetManager
+(def ^{:stratum 0} BudgetManager
   "Protocol satisfied by budget-manager instances.
 
    Defines track-usage, check-budget, and set-budget for tracking
@@ -50,7 +49,7 @@
    extension and satisfies? checks."
   proto/BudgetManager)
 
-(def KnowledgeCoordinator
+(def ^{:stratum 0} KnowledgeCoordinator
   "Protocol satisfied by knowledge-coordinator instances.
 
    Defines inject-for-agent, capture-execution-learning, and
@@ -58,10 +57,8 @@
    capture. Re-exported for extension and satisfies? checks."
   proto/KnowledgeCoordinator)
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Orchestrator creation
-
-(def create-control-plane
+(def ^{:stratum 0} create-control-plane
   "Create a control plane (orchestrator) with all components.
 
    The control plane is the central coordination layer:
@@ -86,18 +83,16 @@
   core/create-control-plane)
 
 ;; Backward compatibility alias
-(def create-orchestrator
+(def ^{:stratum 0} create-orchestrator
   "Alias for create-control-plane (backward compatibility)."
   core/create-orchestrator)
 
-(def default-config
+(def ^{:stratum 0} default-config
   "Default orchestrator configuration."
   core/default-config)
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Workflow execution
-
-(defn execute-workflow
+(defn ^{:stratum 0} execute-workflow
   "Execute a complete workflow from specification to results.
 
    Arguments:
@@ -119,7 +114,7 @@
   [orchestrator spec context]
   (proto/execute-workflow orchestrator spec context))
 
-(defn get-workflow-status
+(defn ^{:stratum 0} get-workflow-status
   "Get the current status of a workflow execution.
 
    Returns:
@@ -133,12 +128,12 @@
   [orchestrator workflow-id]
   (proto/get-workflow-status orchestrator workflow-id))
 
-(defn cancel-workflow
+(defn ^{:stratum 0} cancel-workflow
   "Cancel a running workflow."
   [orchestrator workflow-id]
   (proto/cancel-workflow orchestrator workflow-id))
 
-(defn get-workflow-results
+(defn ^{:stratum 0} get-workflow-results
   "Get the results of a completed workflow.
 
    Returns:
@@ -148,20 +143,18 @@
   [orchestrator workflow-id]
   (proto/get-workflow-results orchestrator workflow-id))
 
-(defn pause-workflow
+(defn ^{:stratum 0} pause-workflow
   "Pause a running workflow for human review."
   [orchestrator workflow-id]
   (proto/pause-workflow orchestrator workflow-id))
 
-(defn resume-workflow
+(defn ^{:stratum 0} resume-workflow
   "Resume a paused workflow."
   [orchestrator workflow-id]
   (proto/resume-workflow orchestrator workflow-id))
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Task routing
-
-(def create-router
+(def ^{:stratum 0} create-router
   "Create a task router.
 
    Example:
@@ -169,7 +162,7 @@
      (create-router {:custom-routes {...}})"
   core/create-router)
 
-(defn route-task
+(defn ^{:stratum 0} route-task
   "Determine which agent should handle a task.
 
    Returns:
@@ -178,26 +171,24 @@
   [router task context]
   (proto/route-task router task context))
 
-(defn can-handle?
+(defn ^{:stratum 0} can-handle?
   "Check if an agent role can handle a task type."
   [router task agent-role]
   (proto/can-handle? router task agent-role))
 
-;------------------------------------------------------------------------------ Layer 4
 ;; Budget management
-
-(def create-budget-manager
+(def ^{:stratum 0} create-budget-manager
   "Create a budget manager for tracking resource usage."
   core/create-budget-manager)
 
-(defn track-usage
+(defn ^{:stratum 0} track-usage
   "Record resource usage for a workflow.
 
    usage: {:tokens int :cost-usd double :duration-ms int}"
   [budget-mgr workflow-id usage]
   (proto/track-usage budget-mgr workflow-id usage))
 
-(defn check-budget
+(defn ^{:stratum 0} check-budget
   "Check if workflow is within budget.
 
    Returns:
@@ -208,15 +199,13 @@
   [budget-mgr workflow-id]
   (proto/check-budget budget-mgr workflow-id))
 
-(defn set-budget
+(defn ^{:stratum 0} set-budget
   "Set budget limits for a workflow."
   [budget-mgr workflow-id budget]
   (proto/set-budget budget-mgr workflow-id budget))
 
-;------------------------------------------------------------------------------ Layer 5
 ;; Knowledge coordination
-
-(def create-knowledge-coordinator
+(def ^{:stratum 0} create-knowledge-coordinator
   "Create a knowledge coordinator.
 
    Arguments:
@@ -230,7 +219,7 @@
      (create-knowledge-coordinator k-store {:knowledge-injection? true})"
   core/create-knowledge-coordinator)
 
-(defn inject-for-agent
+(defn ^{:stratum 0} inject-for-agent
   "Get knowledge to inject for an agent working on a task.
 
    Returns:
@@ -240,7 +229,7 @@
   [coordinator agent-role task context]
   (proto/inject-for-agent coordinator agent-role task context))
 
-(defn capture-execution-learning
+(defn ^{:stratum 0} capture-execution-learning
   "Capture learnings from an agent execution.
 
    execution-result should include:
@@ -253,7 +242,7 @@
   [coordinator execution-result]
   (proto/capture-execution-learning coordinator execution-result))
 
-(defn should-promote-learning?
+(defn ^{:stratum 0} should-promote-learning?
   "Check if a learning should be promoted to rule.
 
    Returns:

--- a/components/orchestrator/src/ai/miniforge/orchestrator/messages.clj
+++ b/components/orchestrator/src/ai/miniforge/orchestrator/messages.clj
@@ -15,13 +15,14 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.orchestrator.messages
   "Component-level message catalog for orchestrator.
    Delegates to the shared messages component."
   (:require [ai.miniforge.messages.interface :as messages]))
 
-(def t
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} t
   "Look up an orchestrator message by key, with optional param substitution."
   (messages/create-translator "config/orchestrator/messages/en-US.edn"
                               :orchestrator/messages))

--- a/components/orchestrator/src/ai/miniforge/orchestrator/protocol.clj
+++ b/components/orchestrator/src/ai/miniforge/orchestrator/protocol.clj
@@ -15,14 +15,13 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.orchestrator.protocol
   "Orchestrator protocols for pipeline execution.")
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Core orchestrator protocol
 
-(defprotocol Orchestrator
+;; Core orchestrator protocol
+(defprotocol ^{:stratum 0} Orchestrator
   "Protocol for workflow orchestration.
    Coordinates agents, tasks, and knowledge through the pipeline."
 
@@ -47,10 +46,8 @@
   (resume-workflow [this workflow-id]
     "Resume a paused workflow. Returns true if resumed."))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Task router protocol
-
-(defprotocol TaskRouter
+(defprotocol ^{:stratum 0} TaskRouter
   "Routes tasks to appropriate agents based on type and context."
 
   (route-task [this task context]
@@ -60,10 +57,8 @@
   (can-handle? [this task agent-role]
     "Check if an agent role can handle a task type."))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Budget manager protocol
-
-(defprotocol BudgetManager
+(defprotocol ^{:stratum 0} BudgetManager
   "Tracks and enforces resource budgets."
 
   (track-usage [this workflow-id usage]
@@ -77,10 +72,8 @@
     "Set budget limits for a workflow.
      budget: {:max-tokens int :max-cost-usd double :timeout-ms int}"))
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Knowledge coordinator protocol
-
-(defprotocol KnowledgeCoordinator
+(defprotocol ^{:stratum 0} KnowledgeCoordinator
   "Coordinates knowledge injection and learning capture."
 
   (inject-for-agent [this agent-role task context]

--- a/components/orchestrator/test/ai/miniforge/orchestrator/interface_test.clj
+++ b/components/orchestrator/test/ai/miniforge/orchestrator/interface_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.orchestrator.interface-test
   (:require
    [clojure.test :refer [deftest is testing]]
@@ -25,9 +24,9 @@
    [ai.miniforge.orchestrator.protocol :as proto]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Test fixtures and factories
 
-(defn- task
+;; Test fixtures and factories
+(defn- ^{:stratum 0} task
   "Build a task map with an optional :task/type and other overrides."
   [task-type & {:as overrides}]
   (merge {:task/id    (random-uuid)
@@ -35,25 +34,25 @@
           :task/title (str (name task-type) " task")}
          overrides))
 
-(defn- repair-entry
+(defn- ^{:stratum 0} repair-entry
   [error-type fix-description]
   {:error-type      error-type
    :fix-description fix-description})
 
-(defn- zettel
+(defn- ^{:stratum 0} zettel
   [& {:as overrides}]
   (merge {:zettel/id      (random-uuid)
           :zettel/title   "Z"
           :zettel/content "body"}
          overrides))
 
-(defn- learning-with-confidence
+(defn- ^{:stratum 0} learning-with-confidence
   [confidence]
   {:zettel/source {:source/confidence confidence}})
 
 ;; Capture/no-op knowledge-store stub used to keep the knowledge coordinator
 ;; tests honest without dragging in the real knowledge component.
-(defn- capture-knowledge-store
+(defn- ^{:stratum 0} capture-knowledge-store
   "Return [stub captured-atom]. Calls to inject-knowledge/capture-inner-loop-learning
    are recorded, and inject-knowledge returns whatever vector is configured."
   [{:keys [inject-result capture-fn promote-fn]
@@ -69,10 +68,8 @@
       :stub/captured      captured}
      captured]))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Re-exports — interface forwards to core/protocol
-
-(deftest interface-re-exports-test
+(deftest ^{:stratum 0} interface-re-exports-test
   (testing "interface namespace re-exports the four protocols"
     (is (= proto/Orchestrator         sut/Orchestrator))
     (is (= proto/TaskRouter           sut/TaskRouter))
@@ -86,10 +83,8 @@
     (is (= core/create-knowledge-coordinator sut/create-knowledge-coordinator))
     (is (= core/default-config               sut/default-config))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; default-config
-
-(deftest default-config-shape-test
+(deftest ^{:stratum 0} default-config-shape-test
   (testing "default-config carries the documented keys"
     (let [cfg core/default-config]
       (is (contains? cfg :default-budget))
@@ -101,42 +96,8 @@
         (is (pos? (:max-cost-usd b)))
         (is (pos? (:timeout-ms b)))))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; SimpleTaskRouter / route-task / can-handle?
-
-(deftest route-task-uses-task-type-mapping-test
-  (testing "Each known task type routes to its expected agent role"
-    (let [router (sut/create-router)]
-      (is (= :planner     (-> (sut/route-task router (task :plan)      {}) :agent-role)))
-      (is (= :planner     (-> (sut/route-task router (task :design)    {}) :agent-role)))
-      (is (= :implementer (-> (sut/route-task router (task :implement) {}) :agent-role)))
-      (is (= :tester      (-> (sut/route-task router (task :test)      {}) :agent-role)))
-      (is (= :reviewer    (-> (sut/route-task router (task :review)    {}) :agent-role))))))
-
-(deftest route-task-unknown-defaults-to-implementer-test
-  (testing "Unknown task type falls back to :implementer"
-    (let [router (sut/create-router)]
-      (is (= :implementer (-> (sut/route-task router (task :unknown) {}) :agent-role))))))
-
-(deftest route-task-includes-reason-string-test
-  (testing "Routing decision carries a non-blank :reason"
-    (let [router (sut/create-router)
-          {:keys [reason]} (sut/route-task router (task :implement) {})]
-      (is (string? reason))
-      (is (not (str/blank? reason))))))
-
-(deftest can-handle?-test
-  (testing "can-handle? matches the mapping"
-    (let [router (sut/create-router)]
-      (is (true?  (sut/can-handle? router (task :plan)      :planner)))
-      (is (false? (sut/can-handle? router (task :plan)      :implementer)))
-      (is (true?  (sut/can-handle? router (task :implement) :implementer)))
-      (is (false? (sut/can-handle? router (task :review)    :tester))))))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; SimpleBudgetManager
-
-(deftest budget-set-and-check-test
+(deftest ^{:stratum 0} budget-set-and-check-test
   (testing "set-budget stores per-workflow limits, check-budget reports them"
     (let [bm (sut/create-budget-manager)
           wf-id (random-uuid)
@@ -150,7 +111,7 @@
         (is (= 60000  (:time-ms remaining)))
         (is (= 1000   (:max-tokens budget)))))))
 
-(deftest budget-track-accumulates-test
+(deftest ^{:stratum 0} budget-track-accumulates-test
   (testing "Repeated track-usage calls accumulate across all three counters"
     (let [bm (sut/create-budget-manager)
           wf-id (random-uuid)]
@@ -164,7 +125,7 @@
         (is (= 700  (:tokens remaining)))
         (is (true? within-budget?))))))
 
-(deftest budget-exceeded-reports-not-within-budget-test
+(deftest ^{:stratum 0} budget-exceeded-reports-not-within-budget-test
   (testing "Spending past the cap flips :within-budget? to false"
     (let [bm (sut/create-budget-manager)
           wf-id (random-uuid)]
@@ -172,7 +133,7 @@
       (sut/track-usage bm wf-id {:tokens 200 :cost-usd 0.10 :duration-ms 0})
       (is (false? (:within-budget? (sut/check-budget bm wf-id)))))))
 
-(deftest budget-default-applies-when-not-set-test
+(deftest ^{:stratum 0} budget-default-applies-when-not-set-test
   (testing "An unset workflow falls back to the default budget"
     (let [bm (sut/create-budget-manager)
           wf-id (random-uuid)
@@ -181,10 +142,44 @@
       (is (= (-> core/default-config :default-budget :max-tokens)
              (:max-tokens budget))))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; build-repair-learning
+(deftest ^{:stratum 0} format-knowledge-block-empty-test
+  (testing "Empty zettel list produces no block"
+    (is (nil? (core/format-knowledge-block [] :implementer)))))
 
-(deftest build-repair-learning-shape-test
+;------------------------------------------------------------------------------ Layer 1
+
+;; SimpleTaskRouter / route-task / can-handle?
+(deftest ^{:stratum 1} route-task-uses-task-type-mapping-test
+  (testing "Each known task type routes to its expected agent role"
+    (let [router (sut/create-router)]
+      (is (= :planner     (-> (sut/route-task router (task :plan)      {}) :agent-role)))
+      (is (= :planner     (-> (sut/route-task router (task :design)    {}) :agent-role)))
+      (is (= :implementer (-> (sut/route-task router (task :implement) {}) :agent-role)))
+      (is (= :tester      (-> (sut/route-task router (task :test)      {}) :agent-role)))
+      (is (= :reviewer    (-> (sut/route-task router (task :review)    {}) :agent-role))))))
+
+(deftest ^{:stratum 1} route-task-unknown-defaults-to-implementer-test
+  (testing "Unknown task type falls back to :implementer"
+    (let [router (sut/create-router)]
+      (is (= :implementer (-> (sut/route-task router (task :unknown) {}) :agent-role))))))
+
+(deftest ^{:stratum 1} route-task-includes-reason-string-test
+  (testing "Routing decision carries a non-blank :reason"
+    (let [router (sut/create-router)
+          {:keys [reason]} (sut/route-task router (task :implement) {})]
+      (is (string? reason))
+      (is (not (str/blank? reason))))))
+
+(deftest ^{:stratum 1} can-handle?-test
+  (testing "can-handle? matches the mapping"
+    (let [router (sut/create-router)]
+      (is (true?  (sut/can-handle? router (task :plan)      :planner)))
+      (is (false? (sut/can-handle? router (task :plan)      :implementer)))
+      (is (true?  (sut/can-handle? router (task :implement) :implementer)))
+      (is (false? (sut/can-handle? router (task :review)    :tester))))))
+
+;; build-repair-learning
+(deftest ^{:stratum 1} build-repair-learning-shape-test
   (testing "build-repair-learning returns the documented learning capture shape"
     (let [tk (task :implement :task/title "Add greet fn")
           history [(repair-entry :compile-error "added missing import")
@@ -197,10 +192,8 @@
       (is (= [:repair :inner-loop :implementer] (:tags learning)))
       (is (= 0.7 (:confidence learning))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; format-zettel-for-context / format-knowledge-block
-
-(deftest format-zettel-includes-title-and-content-test
+(deftest ^{:stratum 1} format-zettel-includes-title-and-content-test
   (testing "Each zettel renders title + content; dewey is bracketed when present"
     (let [with-dewey (zettel :zettel/title "T" :zettel/content "C" :zettel/dewey "210")
           without    (zettel :zettel/title "T" :zettel/content "C")]
@@ -209,11 +202,7 @@
       (is (str/includes? (core/format-zettel-for-context with-dewey) "C"))
       (is (not (str/includes? (core/format-zettel-for-context without) "["))))))
 
-(deftest format-knowledge-block-empty-test
-  (testing "Empty zettel list produces no block"
-    (is (nil? (core/format-knowledge-block [] :implementer)))))
-
-(deftest format-knowledge-block-renders-test
+(deftest ^{:stratum 1} format-knowledge-block-renders-test
   (testing "Non-empty zettel list produces a block containing each title"
     (let [block (core/format-knowledge-block
                  [(zettel :zettel/title "Alpha")
@@ -223,10 +212,8 @@
       (is (str/includes? block "Alpha"))
       (is (str/includes? block "Beta")))))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; SimpleKnowledgeCoordinator — uses with-redefs to stub knowledge calls.
-
-(deftest knowledge-coord-injection-disabled-returns-nil-test
+(deftest ^{:stratum 1} knowledge-coord-injection-disabled-returns-nil-test
   (testing "When :knowledge-injection? is false, inject-for-agent returns nil"
     (let [[store _] (capture-knowledge-store {})
           coord (sut/create-knowledge-coordinator store
@@ -234,7 +221,7 @@
                                                          :knowledge-injection? false))]
       (is (nil? (sut/inject-for-agent coord :implementer (task :implement) {}))))))
 
-(deftest knowledge-coord-injection-enabled-returns-block-test
+(deftest ^{:stratum 1} knowledge-coord-injection-enabled-returns-block-test
   (testing "When enabled, inject-for-agent merges task and context tags into the query
             and packages the result into a {:formatted :zettels :count} map"
     (let [seen-args (atom nil)
@@ -256,7 +243,7 @@
             (is (= :implementer role))
             (is (= #{:clj :io} (set (:tags context))))))))))
 
-(deftest should-promote-learning?-confidence-threshold-test
+(deftest ^{:stratum 1} should-promote-learning?-confidence-threshold-test
   (testing "Confidence ≥ 0.85 ⇒ :promote? true; below ⇒ false"
     (let [coord (sut/create-knowledge-coordinator ::store core/default-config)]
       (is (true?  (:promote? (sut/should-promote-learning? coord (learning-with-confidence 0.90)))))
@@ -265,7 +252,7 @@
       (is (false? (:promote? (sut/should-promote-learning? coord (learning-with-confidence 0.0)))))
       (is (false? (:promote? (sut/should-promote-learning? coord {})))))))
 
-(deftest should-promote-learning?-includes-confidence-and-reason-test
+(deftest ^{:stratum 1} should-promote-learning?-includes-confidence-and-reason-test
   (testing "should-promote-learning? returns the confidence and a non-blank reason"
     (let [coord (sut/create-knowledge-coordinator ::store core/default-config)
           decision (sut/should-promote-learning? coord (learning-with-confidence 0.90))]
@@ -273,14 +260,14 @@
       (is (string? (:reason decision)))
       (is (not (str/blank? (:reason decision)))))))
 
-(deftest capture-execution-learning-no-op-when-not-repaired-test
+(deftest ^{:stratum 1} capture-execution-learning-no-op-when-not-repaired-test
   (testing "execution-result without :repaired? skips capture"
     (let [coord (sut/create-knowledge-coordinator ::store core/default-config)]
       (is (nil? (sut/capture-execution-learning
                  coord {:repaired? false :agent-role :implementer
                         :task (task :implement) :repair-history []}))))))
 
-(deftest capture-execution-learning-disabled-test
+(deftest ^{:stratum 1} capture-execution-learning-disabled-test
   (testing "When :learning-capture? false, capture is skipped even on a repair"
     (let [coord (sut/create-knowledge-coordinator
                  ::store
@@ -291,7 +278,7 @@
                         :task (task :implement)
                         :repair-history history}))))))
 
-(deftest capture-execution-learning-calls-knowledge-store-test
+(deftest ^{:stratum 1} capture-execution-learning-calls-knowledge-store-test
   (testing "On a repaired execution, capture-inner-loop-learning is called and the
             result is returned"
     (let [seen   (atom nil)

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-orchestrator.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-orchestrator.md
@@ -1,0 +1,155 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix: stratum-lint autofix for components/orchestrator (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over `components/orchestrator` (`src` + `test`)
+to replace decorative `Layer N` banners with real `Layer N` headings and
+`^{:stratum n}` metadata derived from each file's actual same-file
+reference graph. Mechanical: no logic changes, no execution-order changes.
+One of the Wave 1 batch 5 per-component PRs from
+`work/stratum-lint-baseline-2026-07-24.md`.
+
+## Motivation
+
+Plain (non-`--fix`) `stratum-lint` on `components/orchestrator` reported
+zero `SL001` (upward-reference/cycle risk) — confirmed before touching
+anything, since this component wasn't among the six already spot-checked
+in the baseline triage. Findings were `SL003` (over the 3-layer budget)
+and `SL002` (non-monotonic heading reuse):
+
+```text
+core.clj:198:1: SL003 file uses 5 distinct layers (max 3)
+interface.clj:216:1: SL003 file uses 6 distinct layers (max 3)
+protocol.clj:80:1: SL003 file uses 4 distinct layers (max 3)
+interface_test.clj:89,104,136,184,200: SL002 Layer 1 heading repeated non-monotonically (x5)
+```
+
+`messages.clj` reported nothing at all pre-fix, but carried no `Layer N`
+heading anywhere — the documented "no heading = silently skipped"
+limitation, not a clean bill of health.
+
+## Changes in Detail
+
+Ran, over the whole component:
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "bef8657a2efd3b1ba9e1a4f510693c9fbca45abd" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/orchestrator
+```
+
+All 5 `.clj` files were rewritten (4 `src`, 1 `test`). Diffs are heading
+text, `^{:stratum n}` metadata, and def/deftest reordering only — no
+executable line changed. Notable findings from the recomputed real
+dependency graph:
+
+- `protocol.clj` declares four independent protocols
+  (`Orchestrator`, `TaskRouter`, `BudgetManager`, `KnowledgeCoordinator`)
+  with no same-file reference between them. The old headings numbered
+  them 0-3 sequentially by writing order; real stratum for all four is 0.
+  The pre-fix `SL003` (4 layers) was an artifact of that sequential
+  numbering, not real complexity — fully resolved, not deferred.
+- `interface.clj` is a pure re-export/delegation layer: every `def`/`defn`
+  calls straight into `core/*` or `proto/*` (required namespaces, not
+  same-file defs). Real stratum for every def is 0. The pre-fix `SL003`
+  (6 layers) was the same sequential-numbering artifact — fully resolved.
+- `core.clj` has genuine same-file structure. `--fix` moved the
+  `ControlPlane` defrecord (previously written last, under a "Layer 4"
+  banner) up to real Layer 0: its protocol method bodies call `wf/`,
+  `proto/`, and `log/` functions from required namespaces only, no
+  same-file def. Real Layer 0 also holds `format-zettel-for-context`,
+  `build-repair-learning`, `default-config`, and `task-type->agent-role`.
+  `SimpleTaskRouter`/`SimpleBudgetManager`/`format-knowledge-block` sit at
+  real Layer 1 (reference Layer 0 defs); `create-router`/
+  `create-budget-manager`/`SimpleKnowledgeCoordinator` at Layer 2;
+  `create-knowledge-coordinator` at Layer 3; `create-control-plane`
+  (constructs a `ControlPlane` via `->ControlPlane`, so must follow its
+  Layer-0 defrecord in file order) at Layer 4; the `create-orchestrator`
+  backward-compat alias at Layer 5. Six real layers, confirmed against
+  the compile-order constraint (defrecord must precede any
+  `->RecordName` call) by reading the full rewritten file top to bottom.
+- `interface_test.clj`: the five test fixture helpers (`task`,
+  `repair-entry`, `zettel`, `learning-with-confidence`,
+  `capture-knowledge-store`) and every `deftest` that calls none of them
+  landed at real Layer 0; every `deftest` that calls one of those
+  fixtures landed at real Layer 1. The old headings repeated "Layer 1"
+  five times non-monotonically (the `SL002` findings) instead of
+  separating these two real strata.
+- `messages.clj` gained its first real heading (`Layer 0` on the sole
+  `def t`) plus a stray blank line removed between the license header and
+  the `ns` form (`--fix` normalizes this on every file it touches,
+  matching prior batches).
+
+No same-line trailing comment was displaced onto the wrong def and no
+stale decorative double-semicolon banner was left contradicting a real
+heading — checked by reading the full diff and the full resulting file
+for all 5 changed files, not just the diff hunks.
+
+## Testing Plan
+
+1. Ran plain `stratum-lint` before the fix — reproduced the findings
+   above exactly. Confirmed zero `SL001` before proceeding, per this
+   component's stated risk (not pre-vetted as SL001-free).
+2. Ran `--fix`, then a second `--fix` pass immediately after — no output,
+   zero diff, confirms idempotency.
+3. Read the full diff and the full resulting content for all 5 changed
+   files. Confirmed only heading text, `^{:stratum n}` metadata, and
+   def/deftest reordering changed; independently re-derived the expected
+   real stratum for every def from its same-file reference graph and
+   matched it against what `--fix` produced.
+4. `clj-kondo --lint components/orchestrator`: 0 errors, 1 warning
+   (`Unresolved namespace ai.miniforge.knowledge.interface` in a
+   `with-redefs` form in `interface_test.clj`). Confirmed pre-existing via
+   `git stash` + re-lint — same warning at the pre-fix line number,
+   unrelated to this diff.
+5. Ran the component's sole test namespace directly:
+   `clojure -M:dev:test -e "(require 'ai.miniforge.orchestrator.interface-test)
+   (require 'clojure.test) (clojure.test/run-tests
+   'ai.miniforge.orchestrator.interface-test)"` — 21 tests, 79 assertions,
+   0 failures, 0 errors.
+6. Re-ran plain `stratum-lint` after the fix:
+   - `protocol.clj`: **resolved**. Old headings claimed 4 layers; true
+     depth is 1 (real Layer 0 only). No longer reported.
+   - `interface.clj`: **resolved**. Old headings claimed 6 layers; true
+     depth is 1 (real Layer 0 only). No longer reported.
+   - `core.clj`: still `SL003`, now precisely measured — 5 → **6** real
+     layers (old decorative count had merged two distinct strata under
+     one heading). Genuine over-budget file, Wave 2 scope (namespace
+     split), not addressed here.
+   - `interface_test.clj`: `SL002` resolved — real 2-layer structure, well
+     under budget.
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+change — comment/metadata/order-only. Pre-commit's `lint:stratum`
+autofixer keeps this component clean going forward; `core.clj` stays
+advisory (`MINIFORGE_STRATUM_BUDGET_MODE=warn` at commit time) until
+Wave 2 splits it.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+- Follow-on: Wave 2 namespace split for `core.clj` (6 real layers, over
+  the 3-layer budget).
+
+## Checklist
+
+- [x] Plain lint run first; confirmed zero `SL001` before proceeding
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Second `--fix` pass confirms idempotency (zero diff)
+- [x] Diff and full file content read for all 5 changed files;
+      mechanical-only, compile order independently re-derived and checked
+- [x] `clj-kondo` clean (0 errors; 1 pre-existing warning confirmed via
+      `git stash`)
+- [x] Component test namespace passes (21 tests, 79 assertions, 0
+      failures/errors)
+- [x] Plain lint re-run post-fix: `protocol.clj`/`interface.clj` `SL003`
+      resolved (were decorative-numbering artifacts, not real
+      complexity); `core.clj` `SL003` remains, documented above with
+      precise before/after counts, tracked as Wave 2
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# fix: stratum-lint autofix for components/orchestrator (Wave 1)

## Overview

Runs `stratum-lint --fix` over `components/orchestrator` (`src` + `test`)
to replace decorative `Layer N` banners with real `Layer N` headings and
`^{:stratum n}` metadata derived from each file's actual same-file
reference graph. Mechanical: no logic changes, no execution-order changes.
One of the Wave 1 batch 5 per-component PRs from
`work/stratum-lint-baseline-2026-07-24.md`.

## Motivation

Plain (non-`--fix`) `stratum-lint` on `components/orchestrator` reported
zero `SL001` (upward-reference/cycle risk) — confirmed before touching
anything, since this component wasn't among the six already spot-checked
in the baseline triage. Findings were `SL003` (over the 3-layer budget)
and `SL002` (non-monotonic heading reuse):

```text
core.clj:198:1: SL003 file uses 5 distinct layers (max 3)
interface.clj:216:1: SL003 file uses 6 distinct layers (max 3)
protocol.clj:80:1: SL003 file uses 4 distinct layers (max 3)
interface_test.clj:89,104,136,184,200: SL002 Layer 1 heading repeated non-monotonically (x5)
```

`messages.clj` reported nothing at all pre-fix, but carried no `Layer N`
heading anywhere — the documented "no heading = silently skipped"
limitation, not a clean bill of health.

## Changes in Detail

Ran, over the whole component:

```bash
bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "bef8657a2efd3b1ba9e1a4f510693c9fbca45abd" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/orchestrator
```

All 5 `.clj` files were rewritten (4 `src`, 1 `test`). Diffs are heading
text, `^{:stratum n}` metadata, and def/deftest reordering only — no
executable line changed. Notable findings from the recomputed real
dependency graph:

- `protocol.clj` declares four independent protocols
  (`Orchestrator`, `TaskRouter`, `BudgetManager`, `KnowledgeCoordinator`)
  with no same-file reference between them. The old headings numbered
  them 0-3 sequentially by writing order; real stratum for all four is 0.
  The pre-fix `SL003` (4 layers) was an artifact of that sequential
  numbering, not real complexity — fully resolved, not deferred.
- `interface.clj` is a pure re-export/delegation layer: every `def`/`defn`
  calls straight into `core/*` or `proto/*` (required namespaces, not
  same-file defs). Real stratum for every def is 0. The pre-fix `SL003`
  (6 layers) was the same sequential-numbering artifact — fully resolved.
- `core.clj` has genuine same-file structure. `--fix` moved the
  `ControlPlane` defrecord (previously written last, under a "Layer 4"
  banner) up to real Layer 0: its protocol method bodies call `wf/`,
  `proto/`, and `log/` functions from required namespaces only, no
  same-file def. Real Layer 0 also holds `format-zettel-for-context`,
  `build-repair-learning`, `default-config`, and `task-type->agent-role`.
  `SimpleTaskRouter`/`SimpleBudgetManager`/`format-knowledge-block` sit at
  real Layer 1 (reference Layer 0 defs); `create-router`/
  `create-budget-manager`/`SimpleKnowledgeCoordinator` at Layer 2;
  `create-knowledge-coordinator` at Layer 3; `create-control-plane`
  (constructs a `ControlPlane` via `->ControlPlane`, so must follow its
  Layer-0 defrecord in file order) at Layer 4; the `create-orchestrator`
  backward-compat alias at Layer 5. Six real layers, confirmed against
  the compile-order constraint (defrecord must precede any
  `->RecordName` call) by reading the full rewritten file top to bottom.
- `interface_test.clj`: the five test fixture helpers (`task`,
  `repair-entry`, `zettel`, `learning-with-confidence`,
  `capture-knowledge-store`) and every `deftest` that calls none of them
  landed at real Layer 0; every `deftest` that calls one of those
  fixtures landed at real Layer 1. The old headings repeated "Layer 1"
  five times non-monotonically (the `SL002` findings) instead of
  separating these two real strata.
- `messages.clj` gained its first real heading (`Layer 0` on the sole
  `def t`) plus a stray blank line removed between the license header and
  the `ns` form (`--fix` normalizes this on every file it touches,
  matching prior batches).

No same-line trailing comment was displaced onto the wrong def and no
stale decorative double-semicolon banner was left contradicting a real
heading — checked by reading the full diff and the full resulting file
for all 5 changed files, not just the diff hunks.

## Testing Plan

1. Ran plain `stratum-lint` before the fix — reproduced the findings
   above exactly. Confirmed zero `SL001` before proceeding, per this
   component's stated risk (not pre-vetted as SL001-free).
2. Ran `--fix`, then a second `--fix` pass immediately after — no output,
   zero diff, confirms idempotency.
3. Read the full diff and the full resulting content for all 5 changed
   files. Confirmed only heading text, `^{:stratum n}` metadata, and
   def/deftest reordering changed; independently re-derived the expected
   real stratum for every def from its same-file reference graph and
   matched it against what `--fix` produced.
4. `clj-kondo --lint components/orchestrator`: 0 errors, 1 warning
   (`Unresolved namespace ai.miniforge.knowledge.interface` in a
   `with-redefs` form in `interface_test.clj`). Confirmed pre-existing via
   `git stash` + re-lint — same warning at the pre-fix line number,
   unrelated to this diff.
5. Ran the component's sole test namespace directly:
   `clojure -M:dev:test -e "(require 'ai.miniforge.orchestrator.interface-test)
   (require 'clojure.test) (clojure.test/run-tests
   'ai.miniforge.orchestrator.interface-test)"` — 21 tests, 79 assertions,
   0 failures, 0 errors.
6. Re-ran plain `stratum-lint` after the fix:
   - `protocol.clj`: **resolved**. Old headings claimed 4 layers; true
     depth is 1 (real Layer 0 only). No longer reported.
   - `interface.clj`: **resolved**. Old headings claimed 6 layers; true
     depth is 1 (real Layer 0 only). No longer reported.
   - `core.clj`: still `SL003`, now precisely measured — 5 → **6** real
     layers (old decorative count had merged two distinct strata under
     one heading). Genuine over-budget file, Wave 2 scope (namespace
     split), not addressed here.
   - `interface_test.clj`: `SL002` resolved — real 2-layer structure, well
     under budget.

## Deployment Plan

Merges to `main` like any other component change. No runtime behavior
change — comment/metadata/order-only. Pre-commit's `lint:stratum`
autofixer keeps this component clean going forward; `core.clj` stays
advisory (`MINIFORGE_STRATUM_BUDGET_MODE=warn` at commit time) until
Wave 2 splits it.

## Related Issues/PRs

- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
- Follow-on: Wave 2 namespace split for `core.clj` (6 real layers, over
  the 3-layer budget).

## Checklist

- [x] Plain lint run first; confirmed zero `SL001` before proceeding
- [x] `--fix` run over the whole component (`src` + `test`)
- [x] Second `--fix` pass confirms idempotency (zero diff)
- [x] Diff and full file content read for all 5 changed files;
      mechanical-only, compile order independently re-derived and checked
- [x] `clj-kondo` clean (0 errors; 1 pre-existing warning confirmed via
      `git stash`)
- [x] Component test namespace passes (21 tests, 79 assertions, 0
      failures/errors)
- [x] Plain lint re-run post-fix: `protocol.clj`/`interface.clj` `SL003`
      resolved (were decorative-numbering artifacts, not real
      complexity); `core.clj` `SL003` remains, documented above with
      precise before/after counts, tracked as Wave 2
- [x] No `--no-verify`; pre-commit hook runs normally at commit time
