### PR TITLE
fix: stratum-lint autofix for components/knowledge (Wave 1)

### DIFF
--- a/components/knowledge/src/ai/miniforge/knowledge/interface.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.knowledge.interface
   "Public API for the knowledge component (Zettelkasten).
 
@@ -44,9 +43,9 @@
    [malli.core :as m]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Schema re-exports
 
-(def Zettel
+;; Schema re-exports
+(def ^{:stratum 0} Zettel
   "Malli schema (a `[:map ...]`) for an atomic unit of knowledge.
    Required keys: :zettel/id (uuid), :zettel/uid, :zettel/title,
    :zettel/content, :zettel/type, :zettel/created (inst), :zettel/author.
@@ -55,90 +54,102 @@
    share intent (:fleet/*, :privacy/classification, :zettel/trust-level).
    Use with `malli.core/validate` to check a zettel map."
   schema/Zettel)
-(def ZettelSummary
+
+(def ^{:stratum 0} ZettelSummary
   "Malli schema (a `[:map ...]`) for a lightweight zettel reference used
    in listings. Required keys: :zettel/id (uuid), :zettel/uid (string),
    :zettel/title (string), :zettel/type. Optional: :zettel/dewey,
    :zettel/tags."
   schema/ZettelSummary)
-(def Link
+
+(def ^{:stratum 0} Link
   "Malli schema (a `[:map ...]`) for a connection between zettels with
    explicit rationale. Required keys: :link/target-id (uuid), :link/type
    (a LinkType), :link/rationale (string, min 10 chars — must explain WHY).
    Optional: :link/strength (double 0.0-1.0), :link/bidirectional? (bool)."
   schema/Link)
-(def LinkType
+
+(def ^{:stratum 0} LinkType
   "Malli schema — an `[:enum ...]` of link kinds between zettels:
    :supports, :contradicts, :extends, :applies-to, :example-of,
    :questions, :answers, :supersedes, :related."
   schema/LinkType)
-(def ZettelType
+
+(def ^{:stratum 0} ZettelType
   "Malli schema — an `[:enum ...]` of knowledge-unit categories:
    :rule, :concept, :learning, :example, :hub, :question, :decision."
   schema/ZettelType)
-(def Source
+
+(def ^{:stratum 0} Source
   "Malli schema (a `[:map ...]`) for zettel provenance. Required key:
    :source/type (a SourceType). Optional: :source/agent (keyword),
    :source/task-id (uuid), :source/context (string),
    :source/confidence (double 0.0-1.0)."
   schema/Source)
-(def SourceType
+
+(def ^{:stratum 0} SourceType
   "Malli schema — an `[:enum ...]` of how knowledge was created:
    :manual, :inner-loop, :meta-loop, :import, :migration."
   schema/SourceType)
-(def KnowledgeQuery
+
+(def ^{:stratum 0} KnowledgeQuery
   "Malli schema (a `[:map ...]`) for a knowledge-retrieval query. All keys
    optional: :agent-role, :task-type, :tags, :dewey-range (tuple),
    :dewey-prefixes, :include-types, :exclude-types, :min-strength,
    :related-to, :traverse-links?, :max-hops (1-5), :limit, :text-search."
   schema/KnowledgeQuery)
-(def AgentManifest
+
+(def ^{:stratum 0} AgentManifest
   "Malli schema (a `[:map ...]`) for an agent role's knowledge-injection
    config. Required key: :agent-role (keyword). Optional: :dewey-prefixes,
    :tags, :types, :hubs (hub UIDs), :always-include (UIDs), :max-zettels."
   schema/AgentManifest)
-(def LearningCapture
+
+(def ^{:stratum 0} LearningCapture
   "Malli schema (a `[:map ...]`) for input when capturing a new learning.
    Required keys: :type (a SourceType), :title (string), :content (string).
    Optional: :agent, :task-id, :tags, :dewey, :links, :confidence (0.0-1.0)."
   schema/LearningCapture)
+
 ;; Fleet-share enums (added in #807). Surfaced through the interface
 ;; so downstream components reference them without reaching into
 ;; `knowledge.schema` directly (Polylith dependency rule).
-(def ShareScope
+(def ^{:stratum 0} ShareScope
   "Malli schema — an `[:enum ...]` of audience scopes a zettel is intended
    for when shared via Fleet: :org, :team, :repo, :workflow."
   schema/ShareScope)
-(def Classification
+
+(def ^{:stratum 0} Classification
   "Malli schema — an `[:enum ...]` of privacy classifications (Fleet
    Decision 8): :public-org, :internal, :restricted, :secret. Governs how
    far a shared zettel may travel and the scanner's veto bar."
   schema/Classification)
+
 ;; Per-revision trust enum (closes #836). Surfaced here so fleet's
 ;; producer-side share-learning gate can reference it without
 ;; reaching into `knowledge.schema` directly.
-(def TrustLevel
+(def ^{:stratum 0} TrustLevel
   "Malli schema — an `[:enum ...]` of per-revision trust values:
    :untrusted (default) and :trusted (set only by promote-learning, reset
    on any content rotation). Fleet's share-learning gate keys off this."
   schema/TrustLevel)
+
 ;; Policy-pack rule lookup schemas. Callers may validate their own
 ;; inputs against PolicyQuery before passing to lookup-policy-rules.
-(def PolicyQuery
+(def ^{:stratum 0} PolicyQuery
   "Malli schema (a `[:map ...]`) for policy-pack rule lookup input. All
    keys optional (omitting all returns every loaded :rule zettel); multiple
    criteria are ANDed: :query (case-insensitive substring on title + body),
    :tags (vector keyword; at-least-one match), :dewey-prefix (prefix string)."
   schema/PolicyQuery)
-(def PolicyResult
+
+(def ^{:stratum 0} PolicyResult
   "Malli schema (a `[:map ...]`) for a compact rule result from
    lookup-policy-rules. Keys: :rule/title (string), :rule/content (string)."
   schema/PolicyResult)
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Store creation
-
-(def create-store
+(def ^{:stratum 0} create-store
   "Create an in-memory knowledge store.
 
    Options:
@@ -149,7 +160,7 @@
      (create-store {:logger my-logger})"
   store/create-store)
 
-(def create-file-backed-store
+(def ^{:stratum 0} create-file-backed-store
   "Create a file-backed persistent knowledge store.
 
    On startup, scans the directory and loads all .edn files into
@@ -164,10 +175,8 @@
      (create-file-backed-store {:path \"/repo/.miniforge/knowledge\"})"
   store/create-file-backed-store)
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Zettel CRUD
-
-(def create-zettel
+(def ^{:stratum 0} create-zettel
   "Create a new zettel with required fields.
 
    Arguments:
@@ -189,45 +198,43 @@
                     :dewey '210' :tags [:clojure :namespace])"
   zettel/create-zettel)
 
-(defn put-zettel
+(defn ^{:stratum 0} put-zettel
   "Store a zettel in the knowledge store. Returns the stored zettel."
   [knowledge-store zettel-data]
   (store/put-zettel knowledge-store zettel-data))
 
-(defn get-zettel
+(defn ^{:stratum 0} get-zettel
   "Retrieve a zettel by ID (UUID) or UID (string)."
   [knowledge-store id-or-uid]
   (if (uuid? id-or-uid)
     (store/get-zettel-by-id knowledge-store id-or-uid)
     (store/get-zettel-by-uid knowledge-store id-or-uid)))
 
-(defn delete-zettel
+(defn ^{:stratum 0} delete-zettel
   "Remove a zettel from the store by ID."
   [knowledge-store id]
   (store/delete-zettel knowledge-store id))
 
-(defn list-zettels
+(defn ^{:stratum 0} list-zettels
   "List all zettels as lightweight summaries."
   [knowledge-store]
   (store/list-zettels knowledge-store))
 
-(def update-zettel
+(def ^{:stratum 0} update-zettel
   "Update a zettel with new values, setting modified timestamp."
   zettel/update-zettel)
 
-(def validate-zettel
+(def ^{:stratum 0} validate-zettel
   "Validate a zettel against the schema.
    Returns {:valid? bool :errors ...}"
   zettel/validate-zettel)
 
-(def zettel-summary
+(def ^{:stratum 0} zettel-summary
   "Extract a lightweight summary from a zettel."
   zettel/zettel-summary)
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Link management
-
-(def create-link
+(def ^{:stratum 0} create-link
   "Create a link to another zettel.
 
    Arguments:
@@ -244,28 +251,26 @@
                   'Adds namespace details to the base Clojure rule')"
   zettel/create-link)
 
-(def add-link
+(def ^{:stratum 0} add-link
   "Add a link to a zettel. Returns updated zettel."
   zettel/add-link)
 
-(def remove-link
+(def ^{:stratum 0} remove-link
   "Remove a link from a zettel by target ID. Returns updated zettel."
   zettel/remove-link)
 
-(def get-links
+(def ^{:stratum 0} get-links
   "Get links from a zettel.
    Direction: :outgoing, :incoming, or :both"
   zettel/get-links)
 
-(def compute-backlinks
+(def ^{:stratum 0} compute-backlinks
   "Given a collection of zettels, compute backlinks for each.
    Returns map of zettel-id -> [source-ids...]"
   zettel/compute-backlinks)
 
-;------------------------------------------------------------------------------ Layer 4
 ;; Query and search
-
-(defn query-knowledge
+(defn ^{:stratum 0} query-knowledge
   "Query zettels matching criteria.
 
    Query options:
@@ -280,7 +285,7 @@
   [knowledge-store query-map]
   (store/query knowledge-store query-map))
 
-(def find-related
+(def ^{:stratum 0} find-related
   "Find zettels related through links.
 
    Options:
@@ -290,12 +295,12 @@
    Returns vector of related zettels sorted by hop distance."
   store/find-related)
 
-(def search
+(def ^{:stratum 0} search
   "Full-text search across zettel titles and content.
    Returns matching zettels sorted by relevance."
   store/search)
 
-(defn lookup-policy-rules
+(defn ^{:stratum 0} lookup-policy-rules
   "Search loaded policy-pack rules by keyword, dewey code, or tag.
 
    Only :rule-type zettels are searched — those loaded from .mdc rule files
@@ -321,15 +326,13 @@
       (policy-lookup/lookup-policy-rules knowledge-store q)
       [])))
 
-;------------------------------------------------------------------------------ Layer 5
 ;; Agent injection
-
-(def get-agent-manifest
+(def ^{:stratum 0} get-agent-manifest
   "Get the knowledge injection manifest for an agent role.
    Returns configuration specifying which knowledge to inject."
   store/get-agent-manifest)
 
-(def inject-knowledge
+(def ^{:stratum 0} inject-knowledge
   "Retrieve relevant knowledge for an agent based on role and context.
 
    Arguments:
@@ -342,7 +345,7 @@
    See also: inject-knowledge-with-manifest for zettels + selection manifest."
   store/inject-knowledge)
 
-(def inject-knowledge-with-manifest
+(def ^{:stratum 0} inject-knowledge-with-manifest
   "Retrieve relevant knowledge for an agent with a selection manifest.
 
    Like inject-knowledge, but returns a map containing both the matched
@@ -360,7 +363,7 @@
                 :tags-matched [keyword...], :score number}]}"
   store/inject-knowledge-with-manifest)
 
-(def format-for-prompt
+(def ^{:stratum 0} format-for-prompt
   "Format a collection of zettels as a markdown knowledge block for LLM context.
 
    Arguments:
@@ -370,7 +373,7 @@
    Returns markdown string, or nil if no zettels."
   store/format-for-prompt)
 
-(defn inject-and-format
+(defn ^{:stratum 0} inject-and-format
   "Inject knowledge for an agent role and format for prompt inclusion.
    Combines inject-knowledge + format-for-prompt into a single safe call.
 
@@ -388,10 +391,8 @@
           (store/format-for-prompt zettels role)))
       (catch Exception _e nil))))
 
-;------------------------------------------------------------------------------ Layer 6
 ;; Learning capture
-
-(def capture-learning
+(def ^{:stratum 0} capture-learning
   "Capture a new learning from agent execution.
 
    Arguments:
@@ -408,11 +409,11 @@
    Returns the created learning zettel."
   learning/capture-learning)
 
-(def capture-inner-loop-learning
+(def ^{:stratum 0} capture-inner-loop-learning
   "Convenience function to capture learning from repair cycle."
   learning/capture-inner-loop-learning)
 
-(defn capture-repair-learning!
+(defn ^{:stratum 0} capture-repair-learning!
   "Capture a learning when a repair cycle succeeds.
    Safe to call unconditionally — no-ops when store is nil or iterations <= 1.
 
@@ -436,7 +437,7 @@
           :tags [:repair :inner-loop (keyword (name agent-role))]})
         (catch Exception _e nil)))))
 
-(defn capture-feedback-learning!
+(defn ^{:stratum 0} capture-feedback-learning!
   "Capture review feedback as a learning.
    Safe to call unconditionally — no-ops when store is nil or feedback is empty.
 
@@ -459,11 +460,11 @@
         :confidence 0.6})
       (catch Exception _e nil))))
 
-(def capture-meta-loop-learning
+(def ^{:stratum 0} capture-meta-loop-learning
   "Convenience function to capture learning from observed patterns."
   learning/capture-meta-loop-learning)
 
-(def detect-recurring-patterns
+(def ^{:stratum 0} detect-recurring-patterns
   "Detect recurring patterns among learnings by grouping on tags.
 
    Scans all learnings and flags tags with 3+ occurrences.
@@ -475,7 +476,7 @@
    Returns vector of {:tag :count :learnings}."
   learning/detect-recurring-patterns)
 
-(def synthesize-recurring-patterns!
+(def ^{:stratum 0} synthesize-recurring-patterns!
   "Detect recurring patterns and capture them as meta-loop learnings.
 
    Scans learnings for recurring tags, creates a meta-loop learning for each
@@ -484,7 +485,7 @@
    Returns count of new patterns synthesized."
   learning/synthesize-recurring-patterns!)
 
-(def promote-learning
+(def ^{:stratum 0} promote-learning
   "Promote a validated learning to a rule.
 
    Options:
@@ -493,7 +494,7 @@
    - :reviewed-by - Who reviewed/approved this"
   learning/promote-learning)
 
-(def list-learnings
+(def ^{:stratum 0} list-learnings
   "List all learnings, optionally filtered.
 
    Options:
@@ -502,32 +503,28 @@
    - :promotable?    - Only return high-confidence learnings"
   learning/list-learnings)
 
-;------------------------------------------------------------------------------ Layer 7
 ;; Serialization
-
-(def zettel->markdown
+(def ^{:stratum 0} zettel->markdown
   "Serialize a zettel to Markdown with YAML frontmatter."
   zettel/zettel->markdown)
 
-(def markdown->zettel
+(def ^{:stratum 0} markdown->zettel
   "Parse Markdown content (a string) with YAML frontmatter into a zettel.
    Returns nil if parsing fails."
   zettel/markdown->zettel)
 
-(def split-frontmatter
+(def ^{:stratum 0} split-frontmatter
   "Split markdown content into frontmatter and body.
    Returns {:frontmatter string :body string} or nil if no frontmatter."
   yaml/split-frontmatter)
 
-(def parse-yaml-frontmatter
+(def ^{:stratum 0} parse-yaml-frontmatter
   "Parse YAML frontmatter into EDN map.
    Handles basic YAML: key: value, arrays, lists."
   yaml/parse-yaml-frontmatter)
 
-;------------------------------------------------------------------------------ Layer 8
 ;; Rule and documentation loading
-
-(def load-rules-from-directory
+(def ^{:stratum 0} load-rules-from-directory
   "Load all .mdc rule files from a directory into the knowledge store.
 
    Arguments:
@@ -541,7 +538,7 @@
      (load-rules-from-directory store \".cursor/rules\")"
   loader/load-rules-from-directory)
 
-(def load-project-docs
+(def ^{:stratum 0} load-project-docs
   "Load project documentation files (agents.md, claude.md, etc.) into knowledge store.
 
    Arguments:
@@ -555,7 +552,7 @@
      (load-project-docs store \".\")"
   loader/load-project-docs)
 
-(def initialize-knowledge-store!
+(def ^{:stratum 0} initialize-knowledge-store!
   "Initialize a knowledge store with rules and documentation.
 
    This is the main entry point for loading knowledge at system startup.
@@ -578,10 +575,8 @@
      (initialize-knowledge-store! store {:rules-dir \"custom/rules\"})"
   loader/initialize-knowledge-store!)
 
-;------------------------------------------------------------------------------ Layer 9
 ;; Trust validation (N1 §2.10.2)
-
-(defn make-pack-ref
+(defn ^{:stratum 0} make-pack-ref
   "Create a pack reference with trust information.
 
    Arguments:
@@ -601,7 +596,7 @@
   (ai.miniforge.knowledge.trust/make-pack-ref
    pack-id trust-level authority :dependencies dependencies))
 
-(def validate-transitive-trust
+(def ^{:stratum 0} validate-transitive-trust
   "Validate all transitive trust rules for a pack graph.
 
    Checks:
@@ -621,7 +616,7 @@
      (validate-transitive-trust {\"pack-a\" pack-ref-a \"pack-b\" pack-ref-b})"
   ai.miniforge.knowledge.trust/validate-transitive-trust)
 
-(def compute-inherited-trust-level
+(def ^{:stratum 0} compute-inherited-trust-level
   "Compute the inherited trust level from a collection of packs.
 
    Rule 2: When pack A includes content from pack B, the combined content

--- a/components/knowledge/src/ai/miniforge/knowledge/learning.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/learning.clj
@@ -15,12 +15,13 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.knowledge.learning
   "Learning capture from agent execution.
-   Layer 0: Learning capture
-   Layer 1: Learning promotion (learning -> rule)
-   Layer 2: Pattern detection"
+   Layer 0: capture-learning, promote-learning, detect-recurring-patterns,
+     list-learnings — no same-file dependents among them
+   Layer 1: capture-inner-loop-learning / capture-meta-loop-learning
+     (both call capture-learning)
+   Layer 2: synthesize-recurring-patterns! (calls detect-recurring-patterns)"
   (:require
    [ai.miniforge.knowledge.schema :as schema]
    [ai.miniforge.knowledge.zettel :as zettel]
@@ -30,9 +31,9 @@
    [malli.core :as m]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Learning capture
 
-(defn capture-learning
+;; Learning capture
+(defn ^{:stratum 0} capture-learning
   "Capture a new learning from agent execution.
 
    Arguments:
@@ -104,43 +105,8 @@
 
     (store/put-zettel knowledge-store z)))
 
-(defn capture-inner-loop-learning
-  "Convenience function to capture learning from inner loop execution.
-
-   This is typically called when a repair cycle discovers something useful."
-  [knowledge-store {:keys [agent task-id title content tags related-to]}]
-  (capture-learning knowledge-store
-                    {:type :inner-loop
-                     :agent agent
-                     :task-id task-id
-                     :title title
-                     :content content
-                     :tags tags
-                     :links (when related-to
-                              [{:target related-to
-                                :type :extends
-                                :rationale (messages/t :learning/implementation-rationale)}])
-                     :confidence 0.7}))
-
-(defn capture-meta-loop-learning
-  "Convenience function to capture learning from meta loop (patterns across executions).
-
-   This is typically called when the system observes recurring patterns."
-  [knowledge-store {:keys [title content tags confidence related-tasks]}]
-  (capture-learning knowledge-store
-                    {:type :meta-loop
-                     :title title
-                     :content content
-                     :tags tags
-                     :confidence (or confidence 0.85)
-                     :context (when (seq related-tasks)
-                                (messages/t :learning/observed-across
-                                            {:tasks (str/join ", " (map str related-tasks))}))}))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; Learning promotion
-
-(defn promote-learning
+(defn ^{:stratum 0} promote-learning
   "Promote a learning to a rule after validation.
 
    This upgrades the zettel type from `:learning` to `:rule` AND
@@ -211,10 +177,8 @@
         (store/delete-zettel knowledge-store learning-id)
         (store/put-zettel knowledge-store rule)))))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Pattern detection
-
-(defn detect-recurring-patterns
+(defn ^{:stratum 0} detect-recurring-patterns
   "Detect recurring patterns among learnings by grouping on tags.
 
    Scans all learnings in the store and groups them by their tags.
@@ -258,7 +222,59 @@
                       vec)]
     patterns))
 
-(defn synthesize-recurring-patterns!
+(defn ^{:stratum 0} list-learnings
+  [knowledge-store & [{:keys [min-confidence agent promotable?]}]]
+  (let [all-learnings (store/query knowledge-store {:include-types [:learning]})
+        filtered (cond->> all-learnings
+                   min-confidence
+                   (filter #(>= (get-in % [:zettel/source :source/confidence] 0)
+                                min-confidence))
+
+                   agent
+                   (filter #(= agent (get-in % [:zettel/source :source/agent])))
+
+                   promotable?
+                   (filter #(>= (get-in % [:zettel/source :source/confidence] 0) 0.8)))]
+    (vec filtered)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} capture-inner-loop-learning
+  "Convenience function to capture learning from inner loop execution.
+
+   This is typically called when a repair cycle discovers something useful."
+  [knowledge-store {:keys [agent task-id title content tags related-to]}]
+  (capture-learning knowledge-store
+                    {:type :inner-loop
+                     :agent agent
+                     :task-id task-id
+                     :title title
+                     :content content
+                     :tags tags
+                     :links (when related-to
+                              [{:target related-to
+                                :type :extends
+                                :rationale (messages/t :learning/implementation-rationale)}])
+                     :confidence 0.7}))
+
+(defn ^{:stratum 1} capture-meta-loop-learning
+  "Convenience function to capture learning from meta loop (patterns across executions).
+
+   This is typically called when the system observes recurring patterns."
+  [knowledge-store {:keys [title content tags confidence related-tasks]}]
+  (capture-learning knowledge-store
+                    {:type :meta-loop
+                     :title title
+                     :content content
+                     :tags tags
+                     :confidence (or confidence 0.85)
+                     :context (when (seq related-tasks)
+                                (messages/t :learning/observed-across
+                                            {:tasks (str/join ", " (map str related-tasks))}))}))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} synthesize-recurring-patterns!
   [knowledge-store]
   (let [patterns (detect-recurring-patterns knowledge-store)
         new-count (atom 0)]
@@ -283,21 +299,6 @@
               :related-tasks (mapv :id learnings)})
             (swap! new-count inc)))))
     @new-count))
-
-(defn list-learnings
-  [knowledge-store & [{:keys [min-confidence agent promotable?]}]]
-  (let [all-learnings (store/query knowledge-store {:include-types [:learning]})
-        filtered (cond->> all-learnings
-                   min-confidence
-                   (filter #(>= (get-in % [:zettel/source :source/confidence] 0)
-                                min-confidence))
-
-                   agent
-                   (filter #(= agent (get-in % [:zettel/source :source/agent])))
-
-                   promotable?
-                   (filter #(>= (get-in % [:zettel/source :source/confidence] 0) 0.8)))]
-    (vec filtered)))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/knowledge/src/ai/miniforge/knowledge/loader.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/loader.clj
@@ -15,17 +15,20 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.knowledge.loader
   "Load rules and knowledge from .cursor/rules/ and project documentation.
 
    Converts .mdc rule files and markdown documentation into zettels
    and populates the knowledge store for agent access.
 
-   This component is organized into 3 layers:
-   - Layer 0: Pure path/file utilities
-   - Layer 1: File loading operations
-   - Layer 2: Orchestration (initialize function)"
+   - Layer 0: pure path/file utilities + directory-loading driver
+   - Layer 1: load-mdc-file / load-project-docs (over Layer 0)
+   - Layer 2: load-rules-from-directory / load-docs (over Layer 1)
+   - Layer 3: load-rules (over Layer 2)
+   - Layer 4: initialize-knowledge-store! (over Layer 3)
+
+   5 real strata — over the rule 210 budget of 3; a genuine namespace
+   split (Wave 2), not a labeling problem."
   (:require
    [ai.miniforge.knowledge.messages :as messages]
    [ai.miniforge.knowledge.store :as store]
@@ -34,9 +37,9 @@
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Pure path and file utilities
 
-(defn find-mdc-files
+;; Pure path and file utilities
+(defn ^{:stratum 0} find-mdc-files
   "Recursively find all .mdc files in a directory.
    Returns sequence of java.io.File objects."
   [dir]
@@ -45,7 +48,7 @@
          (filter #(.isFile %))
          (filter #(str/ends-with? (.getName %) ".mdc")))))
 
-(defn extract-tags-from-path
+(defn ^{:stratum 0} extract-tags-from-path
   "Extract tags from file path relative to rules root.
    Uses slug-only path segments — no numeric prefix required.
    Examples:
@@ -58,7 +61,7 @@
        (map keyword)
        vec))
 
-(defn generate-title-from-filename
+(defn ^{:stratum 0} generate-title-from-filename
   "Generate a human-readable title from a slug filename.
    Examples:
      'clojure.mdc'          -> 'Clojure'
@@ -69,10 +72,62 @@
       (str/replace #"-" " ")
       str/capitalize))
 
-;------------------------------------------------------------------------------ Layer 1
-;; File loading operations
+(defn ^{:stratum 0} load-markdown-file
+  "Load a markdown file and convert to zettel.
+   For files like agents.md, claude.md, etc."
+  [file zettel-type]
+  (try
+    (let [content (slurp file)
+          filename (.getName file)
+          uid (str/replace filename #"\.md$" "")
 
-(defn load-mdc-file
+          ;; Extract title from first # heading or use filename
+          title (if-let [match (re-find #"^#\s+(.+)$" (first (str/split-lines content)))]
+                  (second match)
+                  (-> filename
+                      (str/replace #"\.md$" "")
+                      (str/replace #"-" " ")
+                      str/capitalize))]
+
+      {:zettel/id (random-uuid)
+       :zettel/uid uid
+       :zettel/title title
+       :zettel/content content
+       :zettel/type zettel-type
+       :zettel/dewey "000"  ;; Foundational documentation
+       :zettel/tags [:documentation :project]
+       :zettel/links []
+       :zettel/source {:type :migration
+                      :origin filename
+                      :confidence 1.0}
+       :zettel/author "system"
+       :zettel/created (java.util.Date.)
+       :zettel/metadata {}})
+
+    (catch Exception e
+      (println (messages/t :loader/error-loading {:file (.getName file) :error (.getMessage e)}))
+      nil)))
+
+(defn ^{:stratum 0} load-files-from-directory
+  "Load files from directory using provided loader function.
+   Returns {:loaded int :failed int :items [items...]}."
+  [knowledge-store files loader-fn]
+  (reduce
+   (fn [acc file]
+     (if-let [item (loader-fn file)]
+       (do
+         (store/put-zettel knowledge-store item)
+         (-> acc
+             (update :loaded inc)
+             (update :items conj item)))
+       (update acc :failed inc)))
+   {:loaded 0 :failed 0 :items []}
+   files))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; File loading operations
+(defn ^{:stratum 1} load-mdc-file
   "Load a single .mdc file and convert to zettel data.
    Returns zettel map or nil if parsing fails."
   [file rules-root]
@@ -116,69 +171,7 @@
       (println (messages/t :loader/error-loading {:file (.getName file) :error (.getMessage e)}))
       nil)))
 
-(defn load-markdown-file
-  "Load a markdown file and convert to zettel.
-   For files like agents.md, claude.md, etc."
-  [file zettel-type]
-  (try
-    (let [content (slurp file)
-          filename (.getName file)
-          uid (str/replace filename #"\.md$" "")
-
-          ;; Extract title from first # heading or use filename
-          title (if-let [match (re-find #"^#\s+(.+)$" (first (str/split-lines content)))]
-                  (second match)
-                  (-> filename
-                      (str/replace #"\.md$" "")
-                      (str/replace #"-" " ")
-                      str/capitalize))]
-
-      {:zettel/id (random-uuid)
-       :zettel/uid uid
-       :zettel/title title
-       :zettel/content content
-       :zettel/type zettel-type
-       :zettel/dewey "000"  ;; Foundational documentation
-       :zettel/tags [:documentation :project]
-       :zettel/links []
-       :zettel/source {:type :migration
-                      :origin filename
-                      :confidence 1.0}
-       :zettel/author "system"
-       :zettel/created (java.util.Date.)
-       :zettel/metadata {}})
-
-    (catch Exception e
-      (println (messages/t :loader/error-loading {:file (.getName file) :error (.getMessage e)}))
-      nil)))
-
-(defn load-files-from-directory
-  "Load files from directory using provided loader function.
-   Returns {:loaded int :failed int :items [items...]}."
-  [knowledge-store files loader-fn]
-  (reduce
-   (fn [acc file]
-     (if-let [item (loader-fn file)]
-       (do
-         (store/put-zettel knowledge-store item)
-         (-> acc
-             (update :loaded inc)
-             (update :items conj item)))
-       (update acc :failed inc)))
-   {:loaded 0 :failed 0 :items []}
-   files))
-
-(defn load-rules-from-directory
-  [knowledge-store rules-dir]
-  (let [rules-root (io/file rules-dir)
-        mdc-files (find-mdc-files rules-root)
-        loader (fn [file] (load-mdc-file file (.getPath rules-root)))
-        result (load-files-from-directory knowledge-store mdc-files loader)]
-    (-> result
-        (dissoc :items)
-        (assoc :zettels (:items result)))))
-
-(defn load-project-docs
+(defn ^{:stratum 1} load-project-docs
   [knowledge-store project-root]
   (let [root (io/file project-root)
         doc-files ["agents.md" "claude.md" ".clauderc" "claude_instructions.md"]
@@ -190,23 +183,37 @@
         (dissoc :items))))
 
 ;------------------------------------------------------------------------------ Layer 2
-;; Orchestration
 
-(defn load-rules
-  "Load rules and return result with stats.
-   Pure orchestration - delegates I/O to loader function."
+(defn ^{:stratum 2} load-rules-from-directory
   [knowledge-store rules-dir]
-  (let [result (load-rules-from-directory knowledge-store rules-dir)]
-    (select-keys result [:loaded :failed])))
+  (let [rules-root (io/file rules-dir)
+        mdc-files (find-mdc-files rules-root)
+        loader (fn [file] (load-mdc-file file (.getPath rules-root)))
+        result (load-files-from-directory knowledge-store mdc-files loader)]
+    (-> result
+        (dissoc :items)
+        (assoc :zettels (:items result)))))
 
-(defn load-docs
+(defn ^{:stratum 2} load-docs
   "Load documentation and return result with stats and file list.
    Pure orchestration - delegates I/O to loader function."
   [knowledge-store project-root]
   (let [result (load-project-docs knowledge-store project-root)]
     result))
 
-(defn initialize-knowledge-store!
+;------------------------------------------------------------------------------ Layer 3
+
+;; Orchestration
+(defn ^{:stratum 3} load-rules
+  "Load rules and return result with stats.
+   Pure orchestration - delegates I/O to loader function."
+  [knowledge-store rules-dir]
+  (let [result (load-rules-from-directory knowledge-store rules-dir)]
+    (select-keys result [:loaded :failed])))
+
+;------------------------------------------------------------------------------ Layer 4
+
+(defn ^{:stratum 4} initialize-knowledge-store!
   "Initialize a knowledge store with rules and documentation.
 
    This is the main entry point for loading knowledge at system startup.

--- a/components/knowledge/src/ai/miniforge/knowledge/messages.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/messages.clj
@@ -15,13 +15,14 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.knowledge.messages
   "Component-level message catalog for knowledge.
    Delegates to the shared messages component."
   (:require [ai.miniforge.messages.interface :as messages]))
 
-(def t
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} t
   "Look up a knowledge message by key, with optional param substitution."
   (messages/create-translator "config/knowledge/messages/en-US.edn"
                               :knowledge/messages))

--- a/components/knowledge/src/ai/miniforge/knowledge/policy_lookup.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/policy_lookup.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.knowledge.policy-lookup
   "Pure query functions for searching loaded policy-pack rules.
 
@@ -23,16 +22,18 @@
    or policy packs). All criteria are optional; omitting all returns all rules.
    Multiple criteria are ANDed.
 
-   Layer 0: query translation + result projection
-   Layer 1: lookup orchestration"
+   Layer 0: pure predicates + result projection (dewey-prefixes,
+     normalise-query-string, zettel->policy-result)
+   Layer 1: query-map translation (build-store-query, over Layer 0)
+   Layer 2: lookup orchestration (lookup-policy-rules, over Layer 1)"
   (:require
    [ai.miniforge.knowledge.store :as store]
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Query translation and result projection
 
-(defn- dewey-prefixes
+;; Query translation and result projection
+(defn- ^{:stratum 0} dewey-prefixes
   "Coerce a scalar dewey-prefix string into the list form the store expects.
    Returns nil when the prefix is nil, blank, or whitespace-only."
   [dewey-prefix]
@@ -40,14 +41,22 @@
     (when (seq trimmed)
       [trimmed])))
 
-(defn- normalise-query-string
+(defn- ^{:stratum 0} normalise-query-string
   "Return nil for nil/blank query, otherwise the trimmed string.
    Ensures the store text-search filter is skipped when no keyword was given."
   [q]
   (let [trimmed (str/trim (or q ""))]
     (when (seq trimmed) trimmed)))
 
-(defn- build-store-query
+(defn- ^{:stratum 0} zettel->policy-result
+  "Project a zettel into the compact {:rule/title :rule/content} shape."
+  [zettel]
+  {:rule/title   (:zettel/title zettel)
+   :rule/content (:zettel/content zettel)})
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} build-store-query
   "Translate a PolicyQuery map to the KnowledgeStore query map.
    Always restricts to :rule type so only policy-pack rules are searched."
   [{:keys [query tags dewey-prefix]}]
@@ -58,16 +67,10 @@
       (seq tags)  (assoc :tags (vec tags))
       prefixes    (assoc :dewey-prefixes prefixes))))
 
-(defn- zettel->policy-result
-  "Project a zettel into the compact {:rule/title :rule/content} shape."
-  [zettel]
-  {:rule/title   (:zettel/title zettel)
-   :rule/content (:zettel/content zettel)})
+;------------------------------------------------------------------------------ Layer 2
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Lookup orchestration
-
-(defn lookup-policy-rules
+(defn ^{:stratum 2} lookup-policy-rules
   [knowledge-store policy-query]
   (if (nil? knowledge-store)
     []

--- a/components/knowledge/src/ai/miniforge/knowledge/promotion.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/promotion.clj
@@ -15,16 +15,15 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.knowledge.promotion
   "Pack promotion with trust level elevation and justification tracking.
    Implements N6 §2.1 pack promotion evidence requirements."
   (:require [ai.miniforge.knowledge.messages :as messages]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Promotion Justification Examples
 
-(def justification-template-keys
+;; Promotion Justification Examples
+(def ^{:stratum 0} justification-template-keys
   "Standard justification template keys for pack promotions. The display text
    for each lives in the message catalog under :promotion/<key>."
   #{:safety-scan-passed
@@ -33,33 +32,8 @@
     :policy-compliance
     :automated-validation})
 
-(defn format-justification
-  "Format a promotion justification with optional details.
-
-   Arguments:
-   - template-key - Keyword in justification-template-keys (text from the catalog)
-   - details      - (optional) Additional context string
-
-   Returns formatted justification string.
-
-   Example:
-     (format-justification :safety-scan-passed)
-     => \"passed knowledge-safety scans with no violations\"
-
-     (format-justification :safety-scan-passed \"3 scans completed\")
-     => \"passed knowledge-safety scans with no violations (3 scans completed)\""
-  [template-key & [details]]
-  (let [base (if (contains? justification-template-keys template-key)
-               (messages/t (keyword "promotion" (name template-key)))
-               (messages/t :promotion/generic {:template (name template-key)}))]
-    (if details
-      (messages/t :promotion/with-details {:base base :details details})
-      base)))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; Pack Promotion Record
-
-(defn create-promotion-record
+(defn ^{:stratum 0} create-promotion-record
   "Create a pack promotion record for evidence bundle.
 
    Arguments:
@@ -106,14 +80,12 @@
    :pack-hash (or pack-hash "")
    :pack-signature (or pack-signature "")})
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Trust Level Validation
-
-(def valid-trust-levels
+(def ^{:stratum 0} valid-trust-levels
   "Valid trust levels per N6 spec."
   #{:untrusted :tainted :trusted})
 
-(def valid-promotions
+(def ^{:stratum 0} valid-promotions
   "Valid trust level promotion paths.
    Prevents invalid promotions like :tainted -> :trusted without intermediate step."
   #{[:untrusted :trusted]   ; Most common: untrusted pack passes validation
@@ -121,7 +93,48 @@
     [:tainted :untrusted]    ; Clean up tainted content
     [:trusted :untrusted]})  ; Demote if compromised
 
-(defn valid-promotion?
+(defn ^{:stratum 0} record-promotion-in-workflow
+  "Record a pack promotion in workflow state for evidence collection.
+
+   This adds the promotion record to the workflow state so it will be
+   included in the evidence bundle at workflow completion.
+
+   Arguments:
+   - workflow-state   - Current workflow state map
+   - promotion-record - Promotion record from promote-pack
+
+   Returns updated workflow state."
+  [workflow-state promotion-record]
+  (update workflow-state :workflow/pack-promotions
+          (fnil conj [])
+          promotion-record))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} format-justification
+  "Format a promotion justification with optional details.
+
+   Arguments:
+   - template-key - Keyword in justification-template-keys (text from the catalog)
+   - details      - (optional) Additional context string
+
+   Returns formatted justification string.
+
+   Example:
+     (format-justification :safety-scan-passed)
+     => \"passed knowledge-safety scans with no violations\"
+
+     (format-justification :safety-scan-passed \"3 scans completed\")
+     => \"passed knowledge-safety scans with no violations (3 scans completed)\""
+  [template-key & [details]]
+  (let [base (if (contains? justification-template-keys template-key)
+               (messages/t (keyword "promotion" (name template-key)))
+               (messages/t :promotion/generic {:template (name template-key)}))]
+    (if details
+      (messages/t :promotion/with-details {:base base :details details})
+      base)))
+
+(defn ^{:stratum 1} valid-promotion?
   "Check if a trust level promotion is valid.
 
    Arguments:
@@ -134,7 +147,9 @@
        (contains? valid-trust-levels to-trust)
        (contains? valid-promotions [from-trust to-trust])))
 
-(defn validate-promotion
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} validate-promotion
   "Validate a promotion record before recording.
 
    Returns {:valid? bool :errors [string...]}"
@@ -155,9 +170,9 @@
      :errors errors}))
 
 ;------------------------------------------------------------------------------ Layer 3
-;; Promotion Execution
 
-(defn promote-pack
+;; Promotion Execution
+(defn ^{:stratum 3} promote-pack
   "Promote a pack to a new trust level with justification.
 
    This creates a promotion record and optionally adds it to workflow state
@@ -187,22 +202,6 @@
         validation (validate-promotion promotion-record)]
     (merge validation
            {:promotion-record promotion-record})))
-
-(defn record-promotion-in-workflow
-  "Record a pack promotion in workflow state for evidence collection.
-
-   This adds the promotion record to the workflow state so it will be
-   included in the evidence bundle at workflow completion.
-
-   Arguments:
-   - workflow-state   - Current workflow state map
-   - promotion-record - Promotion record from promote-pack
-
-   Returns updated workflow state."
-  [workflow-state promotion-record]
-  (update workflow-state :workflow/pack-promotions
-          (fnil conj [])
-          promotion-record))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/knowledge/src/ai/miniforge/knowledge/schema.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/schema.clj
@@ -15,20 +15,22 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.knowledge.schema
   "Malli schemas for the knowledge component (Zettelkasten).
-   Layer 0: Link schemas
-   Layer 1: Source/provenance schemas
-   Layer 2: Zettel schemas
-   Layer 3: Query schemas"
+   Layer 0: enum schemas + the query/result schemas built only from
+     enums and primitives (LinkType, SourceType, ZettelType, ShareScope,
+     Classification, TrustLevel, PolicyQuery, PolicyResult)
+   Layer 1: compound schemas referencing Layer 0 enums (Link, Source,
+     ZettelSummary, KnowledgeQuery, AgentManifest, LearningCapture)
+   Layer 2: Zettel — references Link + Source + ShareScope +
+     Classification + TrustLevel, all from Layers 0-1"
   (:require
    [malli.core :as m]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Link schemas
 
-(def LinkType
+;; Link schemas
+(def ^{:stratum 0} LinkType
   "Types of connections between zettels."
   [:enum
    :supports      ; Evidence or argument supporting the target
@@ -39,42 +41,20 @@
    :questions     ; Raises a question about the target
    :answers       ; Responds to a question
    :supersedes    ; Replaces/updates the target
-   :related])     ; General association
+   :related])  ; General association
 
-(def Link
-  "A connection between zettels with explicit rationale."
-  [:map
-   [:link/target-id uuid?]
-   [:link/type LinkType]
-   [:link/rationale [:string {:min 10}]]  ; Must explain WHY
-   [:link/strength {:optional true} [:double {:min 0.0 :max 1.0}]]
-   [:link/bidirectional? {:optional true} boolean?]])
-
-;------------------------------------------------------------------------------ Layer 1
 ;; Source/provenance schemas
-
-(def SourceType
+(def ^{:stratum 0} SourceType
   "How this knowledge was created."
   [:enum
    :manual        ; Human-authored
    :inner-loop    ; Generated during repair cycle
    :meta-loop     ; Observed pattern across executions
    :import        ; Imported from external source
-   :migration])   ; Migrated from existing rules
+   :migration])  ; Migrated from existing rules
 
-(def Source
-  "Provenance information for a zettel."
-  [:map
-   [:source/type SourceType]
-   [:source/agent {:optional true} keyword?]     ; Which agent role
-   [:source/task-id {:optional true} uuid?]      ; Task that generated this
-   [:source/context {:optional true} string?]    ; Additional context
-   [:source/confidence {:optional true} [:double {:min 0.0 :max 1.0}]]])
-
-;------------------------------------------------------------------------------ Layer 2
 ;; Zettel schemas
-
-(def ZettelType
+(def ^{:stratum 0} ZettelType
   "Categories of knowledge units."
   [:enum
    :rule         ; Constraint/convention (from .mdc files)
@@ -83,22 +63,21 @@
    :example      ; Concrete code/pattern
    :hub          ; Structure note organizing others
    :question     ; Open question to resolve
-   :decision])   ; ADR-style decision record
+   :decision])  ; ADR-style decision record
 
 ;; ----------------------------------------------------------------------------
 ;; Fleet-share fields (Decision 6 + 8 + 13 of the miniforge-fleet Phase E
 ;; planning doc). All optional — local Zettelkasten use does not require any
 ;; of them; they're populated when the zettel becomes a candidate for
 ;; cross-instance share via miniforge-fleet's event log.
-
-(def ShareScope
+(def ^{:stratum 0} ShareScope
   "Audience scope a zettel is intended for when shared via Fleet.
    Decision 14 — every event carries an audience scope, even on
    single-org deployments (multi-tenant retrofit otherwise becomes
    unbounded work)."
   [:enum :org :team :repo :workflow])
 
-(def Classification
+(def ^{:stratum 0} Classification
   "Privacy classification from Decision 8.
      :public-org  — distributable across the org-wide fleet.
      :internal    — org-only, not pushed beyond org boundaries.
@@ -108,7 +87,7 @@
                     (`:fleet/shareable true` is a hard reject upstream)."
   [:enum :public-org :internal :restricted :secret])
 
-(def TrustLevel
+(def ^{:stratum 0} TrustLevel
   "Trust attached to a specific zettel revision (Decision 6 + 8 of
    miniforge-fleet's Phase E plan; closes the gap filed at
    miniforge-ai/miniforge#836).
@@ -129,9 +108,108 @@
    than the looser `:zettel/type :rule` proxy."
   [:enum :untrusted :trusted])
 
-;; ----------------------------------------------------------------------------
+;; Query schemas
+(def ^{:stratum 0} PolicyQuery
+  "Input schema for policy-pack rule lookup.
+   All fields are optional; omitting all returns every loaded :rule zettel.
+   Multiple criteria are ANDed.
 
-(def Zettel
+   :query        Case-insensitive substring matched against rule title + body.
+   :tags         Vector of keywords; a rule matches if it carries at least one.
+   :dewey-prefix Prefix string matched at the start of the rule's Dewey code
+                 (e.g. \"21\" matches \"210\" and \"211\"; \"210\" matches
+                 \"210\" but not \"211\")."
+  [:map
+   [:query        {:optional true} [:string {:min 1}]]
+   [:tags         {:optional true} [:vector keyword?]]
+   [:dewey-prefix {:optional true} [:string {:min 1}]]])
+
+(def ^{:stratum 0} PolicyResult
+  "Compact rule result returned by lookup-policy-rules.
+   Contains only the title and full markdown content of the matched rule."
+  [:map
+   [:rule/title   string?]
+   [:rule/content string?]])
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} Link
+  "A connection between zettels with explicit rationale."
+  [:map
+   [:link/target-id uuid?]
+   [:link/type LinkType]
+   [:link/rationale [:string {:min 10}]]  ; Must explain WHY
+   [:link/strength {:optional true} [:double {:min 0.0 :max 1.0}]]
+   [:link/bidirectional? {:optional true} boolean?]])
+
+(def ^{:stratum 1} Source
+  "Provenance information for a zettel."
+  [:map
+   [:source/type SourceType]
+   [:source/agent {:optional true} keyword?]     ; Which agent role
+   [:source/task-id {:optional true} uuid?]      ; Task that generated this
+   [:source/context {:optional true} string?]    ; Additional context
+   [:source/confidence {:optional true} [:double {:min 0.0 :max 1.0}]]])
+
+(def ^{:stratum 1} ZettelSummary
+  "Lightweight zettel reference for listings."
+  [:map
+   [:zettel/id uuid?]
+   [:zettel/uid string?]
+   [:zettel/title string?]
+   [:zettel/type ZettelType]
+   [:zettel/dewey {:optional true} string?]
+   [:zettel/tags {:optional true} [:vector keyword?]]])
+
+(def ^{:stratum 1} KnowledgeQuery
+  "Query specification for retrieving relevant knowledge."
+  [:map
+   [:agent-role {:optional true} keyword?]
+   [:task-type {:optional true} keyword?]
+   [:tags {:optional true} [:vector keyword?]]
+   [:dewey-range {:optional true} [:tuple string? string?]]  ; ["200" "299"]
+   [:dewey-prefixes {:optional true} [:vector string?]]      ; ["210" "220"]
+   [:include-types {:optional true} [:vector ZettelType]]
+   [:exclude-types {:optional true} [:vector ZettelType]]
+   [:min-strength {:optional true} [:double {:min 0.0 :max 1.0}]]
+   [:related-to {:optional true} [:or uuid? string?]]
+   [:traverse-links? {:optional true} boolean?]
+   [:max-hops {:optional true} [:int {:min 1 :max 5}]]
+   [:limit {:optional true} [:int {:min 1}]]
+   [:text-search {:optional true} string?]])
+
+(def ^{:stratum 1} AgentManifest
+  "Knowledge injection configuration for an agent role."
+  [:map
+   [:agent-role keyword?]
+   [:dewey-prefixes {:optional true} [:vector string?]]
+   [:tags {:optional true} [:vector keyword?]]
+   [:types {:optional true} [:vector ZettelType]]
+   [:hubs {:optional true} [:vector string?]]        ; Hub UIDs to include
+   [:always-include {:optional true} [:vector string?]]  ; UIDs always injected
+   [:max-zettels {:optional true} [:int {:min 1}]]])
+
+(def ^{:stratum 1} LearningCapture
+  "Input for capturing new learning from agent execution."
+  [:map
+   [:type SourceType]
+   [:agent {:optional true} keyword?]
+   [:task-id {:optional true} uuid?]
+   [:title [:string {:min 1}]]
+   [:content [:string {:min 1}]]
+   [:tags {:optional true} [:vector keyword?]]
+   [:dewey {:optional true} string?]
+   [:links {:optional true} [:vector
+                             [:map
+                              [:target [:or uuid? string?]]  ; ID or UID
+                              [:type LinkType]
+                              [:rationale string?]]]]
+   [:confidence {:optional true} [:double {:min 0.0 :max 1.0}]]])
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; ----------------------------------------------------------------------------
+(def ^{:stratum 2} Zettel
   "An atomic unit of knowledge.
 
    Decision 6 of miniforge-fleet's Phase E planning doc requires every
@@ -185,86 +263,6 @@
    ;; produced the zettel; Fleet's E.4 quarantine gate + E.9 migration
    ;; registry both key off this.
    [:fleet/oss-version {:optional true} [:string {:min 1}]]])
-
-(def ZettelSummary
-  "Lightweight zettel reference for listings."
-  [:map
-   [:zettel/id uuid?]
-   [:zettel/uid string?]
-   [:zettel/title string?]
-   [:zettel/type ZettelType]
-   [:zettel/dewey {:optional true} string?]
-   [:zettel/tags {:optional true} [:vector keyword?]]])
-
-;------------------------------------------------------------------------------ Layer 3
-;; Query schemas
-
-(def PolicyQuery
-  "Input schema for policy-pack rule lookup.
-   All fields are optional; omitting all returns every loaded :rule zettel.
-   Multiple criteria are ANDed.
-
-   :query        Case-insensitive substring matched against rule title + body.
-   :tags         Vector of keywords; a rule matches if it carries at least one.
-   :dewey-prefix Prefix string matched at the start of the rule's Dewey code
-                 (e.g. \"21\" matches \"210\" and \"211\"; \"210\" matches
-                 \"210\" but not \"211\")."
-  [:map
-   [:query        {:optional true} [:string {:min 1}]]
-   [:tags         {:optional true} [:vector keyword?]]
-   [:dewey-prefix {:optional true} [:string {:min 1}]]])
-
-(def PolicyResult
-  "Compact rule result returned by lookup-policy-rules.
-   Contains only the title and full markdown content of the matched rule."
-  [:map
-   [:rule/title   string?]
-   [:rule/content string?]])
-
-(def KnowledgeQuery
-  "Query specification for retrieving relevant knowledge."
-  [:map
-   [:agent-role {:optional true} keyword?]
-   [:task-type {:optional true} keyword?]
-   [:tags {:optional true} [:vector keyword?]]
-   [:dewey-range {:optional true} [:tuple string? string?]]  ; ["200" "299"]
-   [:dewey-prefixes {:optional true} [:vector string?]]      ; ["210" "220"]
-   [:include-types {:optional true} [:vector ZettelType]]
-   [:exclude-types {:optional true} [:vector ZettelType]]
-   [:min-strength {:optional true} [:double {:min 0.0 :max 1.0}]]
-   [:related-to {:optional true} [:or uuid? string?]]
-   [:traverse-links? {:optional true} boolean?]
-   [:max-hops {:optional true} [:int {:min 1 :max 5}]]
-   [:limit {:optional true} [:int {:min 1}]]
-   [:text-search {:optional true} string?]])
-
-(def AgentManifest
-  "Knowledge injection configuration for an agent role."
-  [:map
-   [:agent-role keyword?]
-   [:dewey-prefixes {:optional true} [:vector string?]]
-   [:tags {:optional true} [:vector keyword?]]
-   [:types {:optional true} [:vector ZettelType]]
-   [:hubs {:optional true} [:vector string?]]        ; Hub UIDs to include
-   [:always-include {:optional true} [:vector string?]]  ; UIDs always injected
-   [:max-zettels {:optional true} [:int {:min 1}]]])
-
-(def LearningCapture
-  "Input for capturing new learning from agent execution."
-  [:map
-   [:type SourceType]
-   [:agent {:optional true} keyword?]
-   [:task-id {:optional true} uuid?]
-   [:title [:string {:min 1}]]
-   [:content [:string {:min 1}]]
-   [:tags {:optional true} [:vector keyword?]]
-   [:dewey {:optional true} string?]
-   [:links {:optional true} [:vector
-                             [:map
-                              [:target [:or uuid? string?]]  ; ID or UID
-                              [:type LinkType]
-                              [:rationale string?]]]]
-   [:confidence {:optional true} [:double {:min 0.0 :max 1.0}]]])
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/knowledge/src/ai/miniforge/knowledge/store.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/store.clj
@@ -15,13 +15,20 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.knowledge.store
   "Knowledge store for zettels.
-   Layer 0: In-memory store protocol and implementation
-   Layer 0.5: File-backed persistent store
-   Layer 1: Query operations
-   Layer 2: Agent injection"
+   Layer 0: KnowledgeStore protocol, matches-query?, file-backed I/O
+     helpers, find-related, search, agent-manifest data, prompt-format
+     helper — all pure or protocol-shape, no same-file dependents yet
+   Layer 1: InMemoryStore / FileBackedStore (implement the Layer 0
+     protocol), get-agent-manifest, compute-manifest-entry,
+     format-for-prompt
+   Layer 2: create-store / create-file-backed-store (construct the
+     Layer 1 records), inject-knowledge-with-manifest
+   Layer 3: inject-knowledge (over inject-knowledge-with-manifest)
+
+   4 real strata — over the rule 210 budget of 3; a genuine namespace
+   split (Wave 2), not a labeling problem."
   (:require
    [ai.miniforge.config.interface :as config]
    [ai.miniforge.knowledge.messages :as messages]
@@ -34,9 +41,9 @@
    [java.nio.file Files StandardCopyOption]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Store protocol and in-memory implementation
 
-(defprotocol KnowledgeStore
+;; Store protocol and in-memory implementation
+(defprotocol ^{:stratum 0} KnowledgeStore
   "Protocol for zettel storage and retrieval."
 
   (put-zettel [this zettel]
@@ -57,7 +64,7 @@
   (query [this query-map]
     "Query zettels matching criteria. Returns vector of zettels."))
 
-(defn matches-query?
+(defn ^{:stratum 0} matches-query?
   "Check if a zettel matches query criteria."
   [zettel {:keys [tags dewey-prefixes include-types exclude-types
                   text-search]}]
@@ -88,7 +95,160 @@
          (str/includes? (str/lower-case zettel-content)
                         (str/lower-case text-search))))))
 
-(defrecord InMemoryStore [zettels-by-id zettels-by-uid logger]
+;; File-backed persistent store
+(defn- ^{:stratum 0} expand-path
+  "Expand ~ in file paths to home directory."
+  [path]
+  (if (str/starts-with? path "~")
+    (str (System/getProperty "user.home") (subs path 1))
+    path))
+
+(defn- ^{:stratum 0} ensure-directory
+  "Ensure a directory exists, creating it if necessary."
+  [path]
+  (let [dir (io/file path)]
+    (when-not (.exists dir)
+      (.mkdirs dir))
+    dir))
+
+(defn- ^{:stratum 0} uid->filename
+  "Convert a zettel UID to a safe filename."
+  [uid]
+  (-> uid
+      (str/replace #"[^a-zA-Z0-9_-]" "_")
+      (str ".edn")))
+
+(defn- ^{:stratum 0} atomic-write!
+  "Write content to file via temp + move, preferring atomic replacement."
+  [file content]
+  (let [parent (.getParentFile file)
+        tmp (java.io.File/createTempFile "zettel-" ".edn.tmp" parent)]
+    (try
+      (spit tmp content)
+      (try
+        (Files/move (.toPath tmp)
+                    (.toPath file)
+                    (into-array StandardCopyOption
+                                [StandardCopyOption/ATOMIC_MOVE
+                                 StandardCopyOption/REPLACE_EXISTING]))
+        (catch Exception _e
+          (Files/move (.toPath tmp)
+                      (.toPath file)
+                      (into-array StandardCopyOption
+                                  [StandardCopyOption/REPLACE_EXISTING]))))
+      (finally
+        (when (.exists tmp)
+          (.delete tmp))))))
+
+(defn- ^{:stratum 0} load-zettel-file
+  "Load a single .edn zettel file. Returns zettel map or nil."
+  [file]
+  (try
+    (edn/read-string (slurp file))
+    (catch Exception _e nil)))
+
+;; Query operations
+(defn ^{:stratum 0} find-related
+  [store zettel-or-id & {:keys [max-hops direction] :or {max-hops 1 direction :both}}]
+  (let [start-zettel (if (map? zettel-or-id)
+                       zettel-or-id
+                       (get-zettel-by-id store zettel-or-id))]
+    (when start-zettel
+      (loop [hop 1
+             visited #{(:zettel/id start-zettel)}
+             frontier [start-zettel]
+             results []]
+        (if (or (> hop max-hops) (empty? frontier))
+          results
+          (let [new-ids (for [z frontier
+                              link (zettel/get-links z direction)
+                              :let [target-id (:link/target-id link)]
+                              :when (and target-id (not (visited target-id)))]
+                          target-id)
+                new-zettels (->> new-ids
+                                 distinct
+                                 (map #(get-zettel-by-id store %))
+                                 (remove nil?)
+                                 vec)]
+            (recur (inc hop)
+                   (into visited (map :zettel/id new-zettels))
+                   new-zettels
+                   (into results new-zettels))))))))
+
+(defn ^{:stratum 0} search
+  [store text]
+  (let [terms (str/split (str/lower-case text) #"\s+")
+        score-fn (fn [zettel]
+                   (let [content (str/lower-case
+                                  (str (:zettel/title zettel) " "
+                                       (:zettel/content zettel)))]
+                     (reduce + (map (fn [term]
+                                      (count (re-seq (re-pattern term) content)))
+                                    terms))))]
+    (->> (query store {:text-search text})
+         (map (fn [z] (assoc z :search-score (score-fn z))))
+         (sort-by :search-score >)
+         (mapv #(dissoc % :search-score)))))
+
+;; Agent injection
+(def ^{:stratum 0} default-agent-manifests
+  "Default knowledge injection configuration per agent role.
+
+   Dewey prefix filtering has been removed from this map. Phase-scoped rule
+   injection (including always-inject standards rules) is now handled by
+   `ai.miniforge.phase.agent-behavior/load-and-filter-behaviors`, which reads
+   from compiled policy packs (miniforge-standards.pack.edn and built-ins).
+
+   This manifest drives dynamic Zettelkasten knowledge retrieval only —
+   user-created zettels that may not follow any Dewey classification."
+  {:planner
+   {:agent-role :planner
+    :tags [:architecture :planning :workflow]
+    :types [:rule :decision :hub]
+    :max-zettels 20}
+
+   :implementer
+   {:agent-role :implementer
+    :tags [:coding :clojure :testing]
+    :types [:rule :learning :example]
+    :max-zettels 15}
+
+   :tester
+   {:agent-role :tester
+    :tags [:testing :coverage :assertions]
+    :types [:rule :example :learning]
+    :max-zettels 10}
+
+   :reviewer
+   {:agent-role :reviewer
+    :tags [:code-review :quality]
+    :types [:rule :learning]
+    :max-zettels 15}})
+
+(def ^{:stratum 0} ^:private manifest-score-weights
+  "Weights for computing manifest entry relevance scores.
+   Each weight controls how much a particular match type contributes
+   to the total score used for ranking and observability."
+  {:tag-match   1.0   ; per matching tag
+   :dewey-match 1.0   ; dewey classification prefix match
+   :type-match  0.5})  ; zettel type match
+
+;; Prompt formatting
+(defn ^{:stratum 0} format-zettel-for-prompt
+  "Format a single zettel as a compact markdown block for LLM context."
+  [zettel]
+  (str (messages/t :store/zettel-heading {:title (:zettel/title zettel)})
+       (when-let [dewey (:zettel/dewey zettel)]
+         (messages/t :store/zettel-dewey-tag {:dewey dewey}))
+       (when (= :learning (:zettel/type zettel))
+         (messages/t :store/learning-suffix))
+       "\n"
+       (:zettel/content zettel)
+       "\n"))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defrecord ^{:stratum 1} InMemoryStore [zettels-by-id zettels-by-uid logger]
   KnowledgeStore
   (put-zettel [_this zettel]
     (let [id (:zettel/id zettel)
@@ -124,69 +284,7 @@
                     matching)]
       (vec limited))))
 
-(defn create-store
-  [& [{:keys [logger]}]]
-  (->InMemoryStore
-   (atom {})
-   (atom {})
-   (or logger (log/create-logger {:min-level :info :output (fn [_])}))))
-
-;------------------------------------------------------------------------------ Layer 0.5
-;; File-backed persistent store
-
-(defn- expand-path
-  "Expand ~ in file paths to home directory."
-  [path]
-  (if (str/starts-with? path "~")
-    (str (System/getProperty "user.home") (subs path 1))
-    path))
-
-(defn- ensure-directory
-  "Ensure a directory exists, creating it if necessary."
-  [path]
-  (let [dir (io/file path)]
-    (when-not (.exists dir)
-      (.mkdirs dir))
-    dir))
-
-(defn- uid->filename
-  "Convert a zettel UID to a safe filename."
-  [uid]
-  (-> uid
-      (str/replace #"[^a-zA-Z0-9_-]" "_")
-      (str ".edn")))
-
-
-(defn- atomic-write!
-  "Write content to file via temp + move, preferring atomic replacement."
-  [file content]
-  (let [parent (.getParentFile file)
-        tmp (java.io.File/createTempFile "zettel-" ".edn.tmp" parent)]
-    (try
-      (spit tmp content)
-      (try
-        (Files/move (.toPath tmp)
-                    (.toPath file)
-                    (into-array StandardCopyOption
-                                [StandardCopyOption/ATOMIC_MOVE
-                                 StandardCopyOption/REPLACE_EXISTING]))
-        (catch Exception _e
-          (Files/move (.toPath tmp)
-                      (.toPath file)
-                      (into-array StandardCopyOption
-                                  [StandardCopyOption/REPLACE_EXISTING]))))
-      (finally
-        (when (.exists tmp)
-          (.delete tmp))))))
-
-(defn- load-zettel-file
-  "Load a single .edn zettel file. Returns zettel map or nil."
-  [file]
-  (try
-    (edn/read-string (slurp file))
-    (catch Exception _e nil)))
-
-(defn- scan-directory
+(defn- ^{:stratum 1} scan-directory
   "Scan a directory for .edn zettel files and load them all.
    Returns {:by-id {uuid zettel} :by-uid {uid zettel}}."
   [dir]
@@ -204,7 +302,7 @@
             (filter #(str/ends-with? (.getName %) ".edn"))))
       {:by-id {} :by-uid {}})))
 
-(defrecord FileBackedStore [base-path zettels-by-id zettels-by-uid logger]
+(defrecord ^{:stratum 1} FileBackedStore [base-path zettels-by-id zettels-by-uid logger]
   KnowledgeStore
   (put-zettel [_this zettel]
     (let [id (:zettel/id zettel)
@@ -246,117 +344,12 @@
                     matching)]
       (vec limited))))
 
-(defn create-file-backed-store
-  [& [{:keys [path logger]}]]
-  (let [base-path (expand-path (or path (str (config/miniforge-home) "/knowledge")))
-        _ (ensure-directory base-path)
-        log (or logger (log/create-logger {:min-level :info :output (fn [_])}))
-        initial (scan-directory base-path)]
-    (log/debug log :knowledge :knowledge/store-initialized
-               {:data {:path base-path
-                       :zettel-count (count (:by-id initial))}})
-    (->FileBackedStore
-     base-path
-     (atom (:by-id initial))
-     (atom (:by-uid initial))
-     log)))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Query operations
-
-(defn find-related
-  [store zettel-or-id & {:keys [max-hops direction] :or {max-hops 1 direction :both}}]
-  (let [start-zettel (if (map? zettel-or-id)
-                       zettel-or-id
-                       (get-zettel-by-id store zettel-or-id))]
-    (when start-zettel
-      (loop [hop 1
-             visited #{(:zettel/id start-zettel)}
-             frontier [start-zettel]
-             results []]
-        (if (or (> hop max-hops) (empty? frontier))
-          results
-          (let [new-ids (for [z frontier
-                              link (zettel/get-links z direction)
-                              :let [target-id (:link/target-id link)]
-                              :when (and target-id (not (visited target-id)))]
-                          target-id)
-                new-zettels (->> new-ids
-                                 distinct
-                                 (map #(get-zettel-by-id store %))
-                                 (remove nil?)
-                                 vec)]
-            (recur (inc hop)
-                   (into visited (map :zettel/id new-zettels))
-                   new-zettels
-                   (into results new-zettels))))))))
-
-(defn search
-  [store text]
-  (let [terms (str/split (str/lower-case text) #"\s+")
-        score-fn (fn [zettel]
-                   (let [content (str/lower-case
-                                  (str (:zettel/title zettel) " "
-                                       (:zettel/content zettel)))]
-                     (reduce + (map (fn [term]
-                                      (count (re-seq (re-pattern term) content)))
-                                    terms))))]
-    (->> (query store {:text-search text})
-         (map (fn [z] (assoc z :search-score (score-fn z))))
-         (sort-by :search-score >)
-         (mapv #(dissoc % :search-score)))))
-
-;------------------------------------------------------------------------------ Layer 2
-;; Agent injection
-
-(def default-agent-manifests
-  "Default knowledge injection configuration per agent role.
-
-   Dewey prefix filtering has been removed from this map. Phase-scoped rule
-   injection (including always-inject standards rules) is now handled by
-   `ai.miniforge.phase.agent-behavior/load-and-filter-behaviors`, which reads
-   from compiled policy packs (miniforge-standards.pack.edn and built-ins).
-
-   This manifest drives dynamic Zettelkasten knowledge retrieval only —
-   user-created zettels that may not follow any Dewey classification."
-  {:planner
-   {:agent-role :planner
-    :tags [:architecture :planning :workflow]
-    :types [:rule :decision :hub]
-    :max-zettels 20}
-
-   :implementer
-   {:agent-role :implementer
-    :tags [:coding :clojure :testing]
-    :types [:rule :learning :example]
-    :max-zettels 15}
-
-   :tester
-   {:agent-role :tester
-    :tags [:testing :coverage :assertions]
-    :types [:rule :example :learning]
-    :max-zettels 10}
-
-   :reviewer
-   {:agent-role :reviewer
-    :tags [:code-review :quality]
-    :types [:rule :learning]
-    :max-zettels 15}})
-
-(defn get-agent-manifest
+(defn ^{:stratum 1} get-agent-manifest
   [role]
   (get default-agent-manifests role
        {:agent-role role :types [:rule] :max-zettels 10}))
 
-(def ^:private manifest-score-weights
-  "Weights for computing manifest entry relevance scores.
-   Each weight controls how much a particular match type contributes
-   to the total score used for ranking and observability."
-  {:tag-match   1.0   ; per matching tag
-   :dewey-match 1.0   ; dewey classification prefix match
-   :type-match  0.5}) ; zettel type match
-
-(defn- compute-manifest-entry
+(defn- ^{:stratum 1} compute-manifest-entry
   "Compute a manifest entry for a zettel matched during knowledge injection.
 
    Scores each zettel based on how well it matches the query criteria
@@ -386,7 +379,39 @@
      :tags-matched tags-matched
      :score        total-score}))
 
-(defn inject-knowledge-with-manifest
+(defn ^{:stratum 1} format-for-prompt
+  [zettels role]
+  (when (seq zettels)
+    (str (messages/t :prompt/header {:role (name role)})
+         (messages/t :prompt/preamble)
+         (apply str (map format-zettel-for-prompt zettels))
+         (messages/t :prompt/separator))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} create-store
+  [& [{:keys [logger]}]]
+  (->InMemoryStore
+   (atom {})
+   (atom {})
+   (or logger (log/create-logger {:min-level :info :output (fn [_])}))))
+
+(defn ^{:stratum 2} create-file-backed-store
+  [& [{:keys [path logger]}]]
+  (let [base-path (expand-path (or path (str (config/miniforge-home) "/knowledge")))
+        _ (ensure-directory base-path)
+        log (or logger (log/create-logger {:min-level :info :output (fn [_])}))
+        initial (scan-directory base-path)]
+    (log/debug log :knowledge :knowledge/store-initialized
+               {:data {:path base-path
+                       :zettel-count (count (:by-id initial))}})
+    (->FileBackedStore
+     base-path
+     (atom (:by-id initial))
+     (atom (:by-uid initial))
+     log)))
+
+(defn ^{:stratum 2} inject-knowledge-with-manifest
   "Retrieve relevant knowledge for an agent with a selection manifest.
 
    Like inject-knowledge, but returns a map containing both the matched
@@ -447,32 +472,11 @@
     {:zettels  zettels
      :manifest manifest-entries}))
 
-(defn inject-knowledge
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} inject-knowledge
   [store agent-role & [context]]
   (:zettels (inject-knowledge-with-manifest store agent-role context)))
-
-;------------------------------------------------------------------------------ Layer 3
-;; Prompt formatting
-
-(defn format-zettel-for-prompt
-  "Format a single zettel as a compact markdown block for LLM context."
-  [zettel]
-  (str (messages/t :store/zettel-heading {:title (:zettel/title zettel)})
-       (when-let [dewey (:zettel/dewey zettel)]
-         (messages/t :store/zettel-dewey-tag {:dewey dewey}))
-       (when (= :learning (:zettel/type zettel))
-         (messages/t :store/learning-suffix))
-       "\n"
-       (:zettel/content zettel)
-       "\n"))
-
-(defn format-for-prompt
-  [zettels role]
-  (when (seq zettels)
-    (str (messages/t :prompt/header {:role (name role)})
-         (messages/t :prompt/preamble)
-         (apply str (map format-zettel-for-prompt zettels))
-         (messages/t :prompt/separator))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/knowledge/src/ai/miniforge/knowledge/trust.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/trust.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.knowledge.trust
   "Transitive trust rules for knowledge packs.
 
@@ -40,54 +39,22 @@
    [clojure.string]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Trust level ordering
 
-(def trust-levels
+;; Trust level ordering
+(def ^{:stratum 0} trust-levels
   "Trust levels in ascending order (lower index = less trusted)."
   [:tainted :untrusted :trusted])
 
-(defn trust-level-order
-  "Return numeric order of trust level (lower = less trusted).
-   Returns nil for invalid trust levels."
-  [level]
-  (let [idx (.indexOf trust-levels level)]
-    (when (>= idx 0) idx)))
-
-(defn lowest-trust-level
-  "Return the lowest (least trusted) level from a collection.
-   Returns :tainted if any level is :tainted.
-   Returns :untrusted if any is :untrusted and none are :tainted.
-   Returns :trusted only if all are :trusted."
-  [levels]
-  (when (seq levels)
-    (let [valid-levels (filter #(contains? (set trust-levels) %) levels)]
-      (if (empty? valid-levels)
-        :untrusted  ; Default to untrusted if no valid levels
-        (apply min-key trust-level-order valid-levels)))))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; Pack trust schema
-
-(defn make-pack-ref
+(defn ^{:stratum 0} make-pack-ref
   [pack-id trust-level authority & {:keys [dependencies]}]
   {:pack-id pack-id
    :trust-level trust-level
    :authority authority
    :dependencies (or dependencies [])})
 
-(defn valid-pack-ref?
-  "Validate that a pack reference has required fields and valid values."
-  [pack-ref]
-  (and (map? pack-ref)
-       (:pack-id pack-ref)
-       (contains? (set trust-levels) (:trust-level pack-ref))
-       (contains? #{:authority/instruction :authority/data} (:authority pack-ref))
-       (vector? (:dependencies pack-ref))))
-
-;------------------------------------------------------------------------------ Layer 2
 ;; Transitive trust rule validation
-
-(defn validate-instruction-authority-not-transitive
+(defn ^{:stratum 0} validate-instruction-authority-not-transitive
   "Rule 1: Instruction authority is not transitive.
 
    If pack A (:trusted, :authority/instruction) references pack B (:untrusted),
@@ -111,12 +78,7 @@
                :trust-level (:trust-level target-pack)}))
       (schema/valid))))
 
-(defn compute-inherited-trust-level
-  [pack-refs]
-  (let [levels (map :trust-level pack-refs)]
-    (lowest-trust-level levels)))
-
-(defn validate-cross-trust-references
+(defn ^{:stratum 0} validate-cross-trust-references
   "Rule 3: Cross-trust references.
 
    Packs MAY reference other packs of any trust level, but must
@@ -146,7 +108,7 @@
 
        :else nil))))
 
-(defn validate-tainted-isolation
+(defn ^{:stratum 0} validate-tainted-isolation
   "Rule 4: Tainted isolation.
 
    Content marked :tainted MUST NOT be included in any pack used for
@@ -175,35 +137,72 @@
          {:tainted-path (:path found)})
         (schema/valid)))))
 
-;------------------------------------------------------------------------------ Layer 4
 ;; Combined validation helpers
-
-(defn valid?
+(defn ^{:stratum 0} valid?
   "Check if a validation result is valid."
   [result]
   (:valid? result))
 
-(defn error-from
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} trust-level-order
+  "Return numeric order of trust level (lower = less trusted).
+   Returns nil for invalid trust levels."
+  [level]
+  (let [idx (.indexOf trust-levels level)]
+    (when (>= idx 0) idx)))
+
+(defn ^{:stratum 1} valid-pack-ref?
+  "Validate that a pack reference has required fields and valid values."
+  [pack-ref]
+  (and (map? pack-ref)
+       (:pack-id pack-ref)
+       (contains? (set trust-levels) (:trust-level pack-ref))
+       (contains? #{:authority/instruction :authority/data} (:authority pack-ref))
+       (vector? (:dependencies pack-ref))))
+
+(defn ^{:stratum 1} error-from
   "Extract error from validation result if invalid, otherwise nil."
   [result]
   (when-not (valid? result)
     (:error result)))
 
-(defn check-dependency-authority
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} lowest-trust-level
+  "Return the lowest (least trusted) level from a collection.
+   Returns :tainted if any level is :tainted.
+   Returns :untrusted if any is :untrusted and none are :tainted.
+   Returns :trusted only if all are :trusted."
+  [levels]
+  (when (seq levels)
+    (let [valid-levels (filter #(contains? (set trust-levels) %) levels)]
+      (if (empty? valid-levels)
+        :untrusted  ; Default to untrusted if no valid levels
+        (apply min-key trust-level-order valid-levels)))))
+
+(defn ^{:stratum 2} check-dependency-authority
   "Check if a dependency violates authority transitivity rules.
    Returns error string or nil."
   [pack-ref dep-id pack-graph]
   (when-let [dep-ref (get pack-graph dep-id)]
     (error-from (validate-instruction-authority-not-transitive pack-ref dep-ref))))
 
-(defn check-pack-tainted-isolation
+(defn ^{:stratum 2} check-pack-tainted-isolation
   "Check if an instruction pack transitively includes tainted content.
    Returns error string or nil."
   [pack-id pack-ref pack-graph]
   (when (= :authority/instruction (:authority pack-ref))
     (error-from (validate-tainted-isolation pack-id pack-graph))))
 
-(defn collect-authority-errors
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} compute-inherited-trust-level
+  [pack-refs]
+  (let [levels (map :trust-level pack-refs)]
+    (lowest-trust-level levels)))
+
+(defn ^{:stratum 3} collect-authority-errors
   "Check Rule 1: Instruction authority is not transitive.
 
    Validates that no pack with instruction authority transitively
@@ -221,7 +220,7 @@
         :when error]
     error))
 
-(defn collect-tainted-errors
+(defn ^{:stratum 3} collect-tainted-errors
   "Check Rule 4: Tainted isolation from instruction authority.
 
    Validates that no pack with instruction authority transitively
@@ -238,7 +237,9 @@
         :when error]
     error))
 
-(defn validate-transitive-trust
+;------------------------------------------------------------------------------ Layer 4
+
+(defn ^{:stratum 4} validate-transitive-trust
   [pack-graph]
   ;; Rule 3: Validate cross-trust references first (graph structure)
   (let [graph-validation (validate-cross-trust-references pack-graph)]

--- a/components/knowledge/src/ai/miniforge/knowledge/yaml.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/yaml.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.knowledge.yaml
   "YAML frontmatter parsing for markdown files.
 
@@ -26,9 +25,9 @@
    [clojure.edn :as edn]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Pure parsing helpers
 
-(defn parse-array-value
+;; Pure parsing helpers
+(defn ^{:stratum 0} parse-array-value
   "Parse array-style value [item1, item2] into vector.
    Returns parsed vector or original string on failure."
   [v]
@@ -38,7 +37,7 @@
       ;; If EDN parsing fails, split by comma
       (vec (map str/trim (str/split (str/replace v #"[\[\]]" "") #","))))))
 
-(defn parse-scalar-value
+(defn ^{:stratum 0} parse-scalar-value
   "Parse a scalar YAML value into appropriate Clojure type.
    Handles: booleans, numbers, and strings (with quote removal)."
   [v]
@@ -55,30 +54,14 @@
     :else
     (str/replace v #"^[\"']|[\"']$" "")))
 
-(defn parse-value
-  "Parse a YAML value, handling arrays and scalars."
-  [v]
-  (if (str/starts-with? v "[")
-    (parse-array-value v)
-    (parse-scalar-value v)))
-
-(defn parse-key-value-line
-  "Parse a key: value line into [key value] pair.
-   Returns [key nil] for key with no value, or nil if line doesn't match pattern."
-  [line]
-  (when-let [[_ k v] (re-find #"^(\w+):\s*(.*)$" line)]
-    (if (str/blank? v)
-      [(keyword k) nil]
-      [(keyword k) (parse-value v)])))
-
-(defn parse-list-item
+(defn ^{:stratum 0} parse-list-item
   "Parse a list item line (e.g., '  - item').
    Returns the item value or nil if not a list item."
   [line]
   (when (str/starts-with? line "  - ")
     (str/trim (subs line 4))))
 
-(defn add-to-collection
+(defn ^{:stratum 0} add-to-collection
   "Add a value to an existing collection field.
    Creates vector if field doesn't exist, appends to existing vector."
   [existing value]
@@ -87,10 +70,45 @@
     (nil? existing) [value]
     :else [existing value]))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Stateful accumulation (using reduce instead of atom)
+(defn ^{:stratum 0} split-frontmatter
+  "Split markdown content into frontmatter and body.
+   Returns {:frontmatter string :body string} or nil if no frontmatter."
+  [content]
+  (let [lines (str/split-lines content)]
+    (when (and (seq lines) (= "---" (first lines)))
+      (let [end-idx (->> (rest lines)
+                         (map-indexed vector)
+                         (filter (fn [[_ line]] (= "---" line)))
+                         first
+                         first)]
+        (when end-idx
+          {:frontmatter (str/join "\n" (take end-idx (rest lines)))
+           :body (str/join "\n" (drop (+ end-idx 2) lines))})))))
 
-(defn process-yaml-line
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} parse-value
+  "Parse a YAML value, handling arrays and scalars."
+  [v]
+  (if (str/starts-with? v "[")
+    (parse-array-value v)
+    (parse-scalar-value v)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} parse-key-value-line
+  "Parse a key: value line into [key value] pair.
+   Returns [key nil] for key with no value, or nil if line doesn't match pattern."
+  [line]
+  (when-let [[_ k v] (re-find #"^(\w+):\s*(.*)$" line)]
+    (if (str/blank? v)
+      [(keyword k) nil]
+      [(keyword k) (parse-value v)])))
+
+;------------------------------------------------------------------------------ Layer 3
+
+;; Stateful accumulation (using reduce instead of atom)
+(defn ^{:stratum 3} process-yaml-line
   "Process a single YAML line and update accumulator.
    Returns updated accumulator map."
   [acc line]
@@ -115,7 +133,9 @@
     :else
     acc))
 
-(defn parse-yaml-frontmatter
+;------------------------------------------------------------------------------ Layer 4
+
+(defn ^{:stratum 4} parse-yaml-frontmatter
   "Parse YAML frontmatter into EDN map.
    Simple parser for basic YAML - handles:
    - key: value
@@ -127,18 +147,3 @@
   [yaml-str]
   (let [lines (str/split-lines yaml-str)]
     (reduce process-yaml-line {} lines)))
-
-(defn split-frontmatter
-  "Split markdown content into frontmatter and body.
-   Returns {:frontmatter string :body string} or nil if no frontmatter."
-  [content]
-  (let [lines (str/split-lines content)]
-    (when (and (seq lines) (= "---" (first lines)))
-      (let [end-idx (->> (rest lines)
-                         (map-indexed vector)
-                         (filter (fn [[_ line]] (= "---" line)))
-                         first
-                         first)]
-        (when end-idx
-          {:frontmatter (str/join "\n" (take end-idx (rest lines)))
-           :body (str/join "\n" (drop (+ end-idx 2) lines))})))))

--- a/components/knowledge/src/ai/miniforge/knowledge/zettel.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/zettel.clj
@@ -15,12 +15,17 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.knowledge.zettel
   "Zettel (atomic note) operations.
-   Layer 0: Zettel creation and manipulation
-   Layer 1: Link management
-   Layer 2: Serialization (Markdown with YAML frontmatter)"
+   Layer 0: pure helpers — link/backlink management, summary/validation,
+     frontmatter formatting/parsing, id/inst coercion
+   Layer 1: markdown <-> zettel serialization + content-projection (over Layer 0)
+   Layer 2: compute-digest (over the Layer 1 content-projection)
+   Layer 3: stamp-revision (over the Layer 2 digest)
+   Layer 4: create-zettel / update-zettel (over stamp-revision)
+
+   5 real strata — over the rule 210 budget of 3; a genuine namespace
+   split (Wave 2), not a labeling problem."
   (:require
    [ai.miniforge.content-hash.interface :as content-hash]
    [ai.miniforge.knowledge.schema :as schema]
@@ -31,6 +36,7 @@
    [java.util UUID]))
 
 ;------------------------------------------------------------------------------ Layer 0
+
 ;; Content-bearing subset + revision-id derivation.
 ;;
 ;; miniforge-fleet's Phase E Decision 6: trust attaches to the IMMUTABLE
@@ -39,8 +45,7 @@
 ;; content" — anything that affects WHAT the zettel says — and (b)
 ;; derive `:zettel/revision-id` deterministically from the digest so two
 ;; agents producing the same content land on the same revision id.
-
-(def ^:private content-bearing-fields
+(def ^{:stratum 0} ^:private content-bearing-fields
   "Fields whose value affects the zettel's revision identity. Operational
    metadata (`:zettel/id`, `:zettel/created`, `:zettel/modified`,
    `:zettel/author`, `:zettel/backlinks`, `:fleet/*`, `:privacy/*`,
@@ -55,39 +60,14 @@
    :zettel/links
    :zettel/source])
 
-(defn- content-projection
-  "Pure: project `zettel` down to the content-bearing subset that feeds
-   the digest. Stable across additions of operational metadata."
-  [zettel]
-  (select-keys zettel content-bearing-fields))
-
-(defn compute-digest
-  "Pure: SHA-256 hex digest of the zettel's canonical-EDN
-   content-projection. Stable across map-key reorderings and across
-   non-content metadata changes; rotates whenever a content-bearing
-   field changes. Used to seed `:zettel/digest` and (deterministically)
-   `:zettel/revision-id`."
-  [zettel]
-  (content-hash/content-hash (content-projection zettel)))
-
-(defn revision-id-from-digest
+(defn ^{:stratum 0} revision-id-from-digest
   "Pure: derive a stable UUID from a digest hex string. Two zettels with
    identical content land on the same `:zettel/revision-id` — the
    property miniforge-fleet's E.1 idempotent-retry path needs."
   ^UUID [^String digest]
   (UUID/nameUUIDFromBytes (.getBytes digest "UTF-8")))
 
-(defn- stamp-revision
-  "Pure: stamp a zettel with `:zettel/digest` + `:zettel/revision-id`
-   derived from its current content projection. Idempotent for an
-   already-stamped zettel whose content has not changed."
-  [zettel]
-  (let [d (compute-digest zettel)]
-    (assoc zettel
-           :zettel/digest d
-           :zettel/revision-id (revision-id-from-digest d))))
-
-(def ^:private derived-fields
+(def ^{:stratum 0} ^:private derived-fields
   "Fields the constructor / updater own — callers cannot override them
    directly via `update-zettel`'s `changes` map; they're recomputed
    from `content-projection` so the relationship between content
@@ -111,10 +91,195 @@
    consumer enforces its meaning."
   #{:zettel/digest :zettel/revision-id :zettel/trust-level})
 
-;------------------------------------------------------------------------------ Layer 1
-;; Zettel creation and manipulation
+(defn ^{:stratum 0} zettel-summary
+  [zettel]
+  (select-keys zettel [:zettel/id :zettel/uid :zettel/title
+                       :zettel/type :zettel/dewey :zettel/tags]))
 
-(defn create-zettel
+(defn ^{:stratum 0} validate-zettel
+  [zettel]
+  (if (m/validate schema/Zettel zettel)
+    {:valid? true :errors nil}
+    {:valid? false :errors (m/explain schema/Zettel zettel)}))
+
+;; Link management
+(defn ^{:stratum 0} create-link
+  [target-id type rationale & {:keys [strength bidirectional?]}]
+  (cond-> {:link/target-id target-id
+           :link/type type
+           :link/rationale rationale}
+    strength (assoc :link/strength strength)
+    (some? bidirectional?) (assoc :link/bidirectional? bidirectional?)))
+
+(defn ^{:stratum 0} add-link
+  [zettel link]
+  (let [links (get zettel :zettel/links [])]
+    (-> zettel
+        (assoc :zettel/links (conj links link))
+        (assoc :zettel/modified (java.util.Date.)))))
+
+(defn ^{:stratum 0} remove-link
+  [zettel target-id]
+  (let [links (get zettel :zettel/links [])]
+    (-> zettel
+        (assoc :zettel/links (vec (remove #(= target-id (:link/target-id %)) links)))
+        (assoc :zettel/modified (java.util.Date.)))))
+
+(defn ^{:stratum 0} get-links
+  "Get links from a zettel.
+
+   Direction:
+   - :outgoing  - Links from this zettel
+   - :incoming  - Backlinks to this zettel
+   - :both      - All connections"
+  [zettel direction]
+  (case direction
+    :outgoing (get zettel :zettel/links [])
+    :incoming (mapv (fn [id] {:link/target-id id :link/type :backlink})
+                    (get zettel :zettel/backlinks []))
+    :both (concat (get-links zettel :outgoing)
+                  (get-links zettel :incoming))))
+
+(defn ^{:stratum 0} compute-backlinks
+  [zettels]
+  (reduce
+   (fn [acc zettel]
+     (let [source-id (:zettel/id zettel)]
+       (reduce
+        (fn [acc2 link]
+          (let [target-id (:link/target-id link)]
+            (update acc2 target-id (fnil conj []) source-id)))
+        acc
+        (get zettel :zettel/links []))))
+   {}
+   zettels))
+
+;; Serialization (Markdown with YAML frontmatter)
+(defn ^{:stratum 0} format-frontmatter
+  "Convert zettel metadata to YAML frontmatter."
+  [zettel]
+  (let [meta (cond-> {:id (str (:zettel/id zettel))
+                      :uid (:zettel/uid zettel)
+                      :type (name (:zettel/type zettel))
+                      :created (str (:zettel/created zettel))
+                      :author (:zettel/author zettel)}
+               (:zettel/dewey zettel) (assoc :dewey (:zettel/dewey zettel))
+               (seq (:zettel/tags zettel)) (assoc :tags (mapv name (:zettel/tags zettel)))
+               (:zettel/modified zettel) (assoc :modified (str (:zettel/modified zettel)))
+               (seq (:zettel/links zettel))
+               (assoc :links (mapv (fn [link]
+                                     {:target (str (:link/target-id link))
+                                      :type (name (:link/type link))
+                                      :rationale (:link/rationale link)})
+                                   (:zettel/links zettel))))]
+    (yaml/generate-string meta :dumper-options {:flow-style :block})))
+
+(defn ^{:stratum 0} parse-frontmatter
+  "Parse YAML frontmatter from a string."
+  [frontmatter-str]
+  (try
+    (yaml/parse-string frontmatter-str)
+    (catch Exception _e
+      nil)))
+
+(defn ^{:stratum 0} extract-title-from-content
+  "Extract title from first H1 heading in content."
+  [content]
+  (when-let [match (re-find #"^#\s+(.+)$" (first (str/split-lines content)))]
+    (second match)))
+
+(defn ^{:stratum 0} str->uuid
+  "Parse a string as UUID, or return nil."
+  [s]
+  (try
+    (java.util.UUID/fromString s)
+    (catch Exception _e nil)))
+
+(defn ^{:stratum 0} parse-inst
+  "Parse a string as inst, or return nil."
+  [s]
+  (try
+    (java.util.Date/from (java.time.Instant/parse s))
+    (catch Exception _e
+      ;; Try alternate format
+      (try
+        (let [fmt (java.text.SimpleDateFormat. "EEE MMM dd HH:mm:ss zzz yyyy")]
+          (.parse fmt s))
+        (catch Exception _e2 nil)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} content-projection
+  "Pure: project `zettel` down to the content-bearing subset that feeds
+   the digest. Stable across additions of operational metadata."
+  [zettel]
+  (select-keys zettel content-bearing-fields))
+
+(defn ^{:stratum 1} zettel->markdown
+  [zettel]
+  (str "---\n"
+       (format-frontmatter zettel)
+       "---\n\n"
+       "# " (:zettel/title zettel) "\n\n"
+       (:zettel/content zettel)))
+
+(defn ^{:stratum 1} markdown->zettel
+  [markdown-str]
+  (when-let [matches (re-find #"(?s)^---\n(.+?)\n---\n\n?(.*)$" markdown-str)]
+    (let [[_ frontmatter-str content] matches
+          frontmatter (parse-frontmatter frontmatter-str)]
+      (when frontmatter
+        (let [title (or (extract-title-from-content content)
+                        (:title frontmatter)
+                        "Untitled")
+              ;; Remove title line from content if present
+              body (str/replace content #"^#\s+.+\n\n?" "")]
+          (cond-> {:zettel/id (or (str->uuid (:id frontmatter)) (random-uuid))
+                   :zettel/uid (:uid frontmatter)
+                   :zettel/title title
+                   :zettel/content body
+                   :zettel/type (keyword (:type frontmatter))
+                   :zettel/created (or (parse-inst (:created frontmatter))
+                                       (java.util.Date.))
+                   :zettel/author (get frontmatter :author "unknown")}
+            (:dewey frontmatter) (assoc :zettel/dewey (:dewey frontmatter))
+            (seq (:tags frontmatter)) (assoc :zettel/tags (mapv keyword (:tags frontmatter)))
+            (:modified frontmatter) (assoc :zettel/modified (parse-inst (:modified frontmatter)))
+            (seq (:links frontmatter))
+            (assoc :zettel/links
+                   (mapv (fn [link]
+                           {:link/target-id (str->uuid (:target link))
+                            :link/type (keyword (:type link))
+                            :link/rationale (:rationale link)})
+                         (:links frontmatter)))))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} compute-digest
+  "Pure: SHA-256 hex digest of the zettel's canonical-EDN
+   content-projection. Stable across map-key reorderings and across
+   non-content metadata changes; rotates whenever a content-bearing
+   field changes. Used to seed `:zettel/digest` and (deterministically)
+   `:zettel/revision-id`."
+  [zettel]
+  (content-hash/content-hash (content-projection zettel)))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn- ^{:stratum 3} stamp-revision
+  "Pure: stamp a zettel with `:zettel/digest` + `:zettel/revision-id`
+   derived from its current content projection. Idempotent for an
+   already-stamped zettel whose content has not changed."
+  [zettel]
+  (let [d (compute-digest zettel)]
+    (assoc zettel
+           :zettel/digest d
+           :zettel/revision-id (revision-id-from-digest d))))
+
+;------------------------------------------------------------------------------ Layer 4
+
+;; Zettel creation and manipulation
+(defn ^{:stratum 4} create-zettel
   "Create a new zettel with required fields.
 
    Arguments:
@@ -186,7 +351,7 @@
                  oss-version            (assoc :fleet/oss-version oss-version))]
     (stamp-revision zettel)))
 
-(defn update-zettel
+(defn ^{:stratum 4} update-zettel
   "Update a zettel with new values, setting modified timestamp.
 
    `:zettel/digest`, `:zettel/revision-id`, and `:zettel/trust-level`
@@ -239,164 +404,6 @@
                      (some? old-trust)                            old-trust
                      :else                                        :untrusted)]
     (assoc stamped :zettel/trust-level next-trust)))
-
-(defn zettel-summary
-  [zettel]
-  (select-keys zettel [:zettel/id :zettel/uid :zettel/title
-                       :zettel/type :zettel/dewey :zettel/tags]))
-
-(defn validate-zettel
-  [zettel]
-  (if (m/validate schema/Zettel zettel)
-    {:valid? true :errors nil}
-    {:valid? false :errors (m/explain schema/Zettel zettel)}))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Link management
-
-(defn create-link
-  [target-id type rationale & {:keys [strength bidirectional?]}]
-  (cond-> {:link/target-id target-id
-           :link/type type
-           :link/rationale rationale}
-    strength (assoc :link/strength strength)
-    (some? bidirectional?) (assoc :link/bidirectional? bidirectional?)))
-
-(defn add-link
-  [zettel link]
-  (let [links (get zettel :zettel/links [])]
-    (-> zettel
-        (assoc :zettel/links (conj links link))
-        (assoc :zettel/modified (java.util.Date.)))))
-
-(defn remove-link
-  [zettel target-id]
-  (let [links (get zettel :zettel/links [])]
-    (-> zettel
-        (assoc :zettel/links (vec (remove #(= target-id (:link/target-id %)) links)))
-        (assoc :zettel/modified (java.util.Date.)))))
-
-(defn get-links
-  "Get links from a zettel.
-
-   Direction:
-   - :outgoing  - Links from this zettel
-   - :incoming  - Backlinks to this zettel
-   - :both      - All connections"
-  [zettel direction]
-  (case direction
-    :outgoing (get zettel :zettel/links [])
-    :incoming (mapv (fn [id] {:link/target-id id :link/type :backlink})
-                    (get zettel :zettel/backlinks []))
-    :both (concat (get-links zettel :outgoing)
-                  (get-links zettel :incoming))))
-
-(defn compute-backlinks
-  [zettels]
-  (reduce
-   (fn [acc zettel]
-     (let [source-id (:zettel/id zettel)]
-       (reduce
-        (fn [acc2 link]
-          (let [target-id (:link/target-id link)]
-            (update acc2 target-id (fnil conj []) source-id)))
-        acc
-        (get zettel :zettel/links []))))
-   {}
-   zettels))
-
-;------------------------------------------------------------------------------ Layer 2
-;; Serialization (Markdown with YAML frontmatter)
-
-(defn format-frontmatter
-  "Convert zettel metadata to YAML frontmatter."
-  [zettel]
-  (let [meta (cond-> {:id (str (:zettel/id zettel))
-                      :uid (:zettel/uid zettel)
-                      :type (name (:zettel/type zettel))
-                      :created (str (:zettel/created zettel))
-                      :author (:zettel/author zettel)}
-               (:zettel/dewey zettel) (assoc :dewey (:zettel/dewey zettel))
-               (seq (:zettel/tags zettel)) (assoc :tags (mapv name (:zettel/tags zettel)))
-               (:zettel/modified zettel) (assoc :modified (str (:zettel/modified zettel)))
-               (seq (:zettel/links zettel))
-               (assoc :links (mapv (fn [link]
-                                     {:target (str (:link/target-id link))
-                                      :type (name (:link/type link))
-                                      :rationale (:link/rationale link)})
-                                   (:zettel/links zettel))))]
-    (yaml/generate-string meta :dumper-options {:flow-style :block})))
-
-(defn zettel->markdown
-  [zettel]
-  (str "---\n"
-       (format-frontmatter zettel)
-       "---\n\n"
-       "# " (:zettel/title zettel) "\n\n"
-       (:zettel/content zettel)))
-
-(defn parse-frontmatter
-  "Parse YAML frontmatter from a string."
-  [frontmatter-str]
-  (try
-    (yaml/parse-string frontmatter-str)
-    (catch Exception _e
-      nil)))
-
-(defn extract-title-from-content
-  "Extract title from first H1 heading in content."
-  [content]
-  (when-let [match (re-find #"^#\s+(.+)$" (first (str/split-lines content)))]
-    (second match)))
-
-(defn str->uuid
-  "Parse a string as UUID, or return nil."
-  [s]
-  (try
-    (java.util.UUID/fromString s)
-    (catch Exception _e nil)))
-
-(defn parse-inst
-  "Parse a string as inst, or return nil."
-  [s]
-  (try
-    (java.util.Date/from (java.time.Instant/parse s))
-    (catch Exception _e
-      ;; Try alternate format
-      (try
-        (let [fmt (java.text.SimpleDateFormat. "EEE MMM dd HH:mm:ss zzz yyyy")]
-          (.parse fmt s))
-        (catch Exception _e2 nil)))))
-
-(defn markdown->zettel
-  [markdown-str]
-  (when-let [matches (re-find #"(?s)^---\n(.+?)\n---\n\n?(.*)$" markdown-str)]
-    (let [[_ frontmatter-str content] matches
-          frontmatter (parse-frontmatter frontmatter-str)]
-      (when frontmatter
-        (let [title (or (extract-title-from-content content)
-                        (:title frontmatter)
-                        "Untitled")
-              ;; Remove title line from content if present
-              body (str/replace content #"^#\s+.+\n\n?" "")]
-          (cond-> {:zettel/id (or (str->uuid (:id frontmatter)) (random-uuid))
-                   :zettel/uid (:uid frontmatter)
-                   :zettel/title title
-                   :zettel/content body
-                   :zettel/type (keyword (:type frontmatter))
-                   :zettel/created (or (parse-inst (:created frontmatter))
-                                       (java.util.Date.))
-                   :zettel/author (get frontmatter :author "unknown")}
-            (:dewey frontmatter) (assoc :zettel/dewey (:dewey frontmatter))
-            (seq (:tags frontmatter)) (assoc :zettel/tags (mapv keyword (:tags frontmatter)))
-            (:modified frontmatter) (assoc :zettel/modified (parse-inst (:modified frontmatter)))
-            (seq (:links frontmatter))
-            (assoc :zettel/links
-                   (mapv (fn [link]
-                           {:link/target-id (str->uuid (:target link))
-                            :link/type (keyword (:type link))
-                            :link/rationale (:rationale link)})
-                         (:links frontmatter)))))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/knowledge/test/ai/miniforge/knowledge/file_backed_store_test.clj
+++ b/components/knowledge/test/ai/miniforge/knowledge/file_backed_store_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.knowledge.file-backed-store-test
   "Tests for FileBackedStore: persistence, round-trip, query."
   (:require
@@ -24,9 +23,11 @@
    [ai.miniforge.knowledge.zettel :as zettel]
    [clojure.java.io :as io]))
 
-(def ^:dynamic *test-dir* nil)
+;------------------------------------------------------------------------------ Layer 0
 
-(defn temp-dir-fixture [f]
+(def ^{:stratum 0} ^:dynamic *test-dir* nil)
+
+(defn ^{:stratum 0} temp-dir-fixture [f]
   (let [dir (str (System/getProperty "java.io.tmpdir")
                  "/miniforge-kb-test-" (System/currentTimeMillis))]
     (binding [*test-dir* dir]
@@ -40,9 +41,24 @@
                 (.delete file))
               (.delete d))))))))
 
-(use-fixtures :each temp-dir-fixture)
+(deftest ^{:stratum 0} format-for-prompt-test
+  (testing "format-for-prompt renders markdown block"
+    (let [z1 (zettel/create-zettel "r1" "Rule One" "Content one" :rule :dewey "210")
+          z2 (zettel/create-zettel "l1" "Learning One" "Content two" :learning)
+          result (store/format-for-prompt [z1 z2] :implementer)]
+      (is (string? result))
+      (is (.contains result "Rule One"))
+      (is (.contains result "Learning One"))
+      (is (.contains result "(learning)"))
+      (is (.contains result "implementer"))))
 
-(deftest file-backed-store-round-trip
+  (testing "format-for-prompt returns nil for empty zettels"
+    (is (nil? (store/format-for-prompt [] :planner)))
+    (is (nil? (store/format-for-prompt nil :planner)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} file-backed-store-round-trip
   (testing "Write → restart → read round-trip"
     (let [store1 (store/create-file-backed-store {:path *test-dir*})
           z (zettel/create-zettel "test-uid" "Test Title"
@@ -62,7 +78,7 @@
           (is (= :rule (:zettel/type loaded)))
           (is (= "210" (:zettel/dewey loaded))))))))
 
-(deftest file-backed-store-delete
+(deftest ^{:stratum 1} file-backed-store-delete
   (testing "Delete removes file and index entry"
     (let [store1 (store/create-file-backed-store {:path *test-dir*})
           z (zettel/create-zettel "del-test" "Delete Me"
@@ -77,7 +93,7 @@
       (let [store2 (store/create-file-backed-store {:path *test-dir*})]
         (is (= 0 (count (store/list-zettels store2))))))))
 
-(deftest file-backed-store-query
+(deftest ^{:stratum 1} file-backed-store-query
   (testing "Query works on file-backed store"
     (let [s (store/create-file-backed-store {:path *test-dir*})
           z1 (zettel/create-zettel "rule-1" "Clojure Rule"
@@ -93,7 +109,7 @@
       (is (= 1 (count (store/query s {:include-types [:learning]}))))
       (is (= 2 (count (store/query s {})))))))
 
-(deftest file-backed-store-search
+(deftest ^{:stratum 1} file-backed-store-search
   (testing "Text search works on file-backed store"
     (let [s (store/create-file-backed-store {:path *test-dir*})
           z (zettel/create-zettel "search-test" "Threading Macros"
@@ -103,17 +119,4 @@
       (is (= 1 (count (store/search s "threading"))))
       (is (= 0 (count (store/search s "nonexistent")))))))
 
-(deftest format-for-prompt-test
-  (testing "format-for-prompt renders markdown block"
-    (let [z1 (zettel/create-zettel "r1" "Rule One" "Content one" :rule :dewey "210")
-          z2 (zettel/create-zettel "l1" "Learning One" "Content two" :learning)
-          result (store/format-for-prompt [z1 z2] :implementer)]
-      (is (string? result))
-      (is (.contains result "Rule One"))
-      (is (.contains result "Learning One"))
-      (is (.contains result "(learning)"))
-      (is (.contains result "implementer"))))
-
-  (testing "format-for-prompt returns nil for empty zettels"
-    (is (nil? (store/format-for-prompt [] :planner)))
-    (is (nil? (store/format-for-prompt nil :planner)))))
+(use-fixtures :each temp-dir-fixture)

--- a/components/knowledge/test/ai/miniforge/knowledge/learning_test.clj
+++ b/components/knowledge/test/ai/miniforge/knowledge/learning_test.clj
@@ -9,7 +9,6 @@
 ;; You may obtain a copy of the License at
 ;;
 ;;     http://www.apache.org/licenses/LICENSE-2.0
-
 (ns ai.miniforge.knowledge.learning-test
   "Tests for the learning lifecycle — capture and promotion.
 
@@ -32,17 +31,17 @@
    [clojure.test :refer [deftest is testing use-fixtures]]))
 
 ;------------------------------------------------------------------------------ Layer 0
+
 ;; Fixtures.
+(def ^{:stratum 0} ^:dynamic *store* nil)
 
-(def ^:dynamic *store* nil)
-
-(defn- with-store [f]
+(defn- ^{:stratum 0} with-store [f]
   (binding [*store* (knowledge/create-store)]
     (f)))
 
-(use-fixtures :each with-store)
+;------------------------------------------------------------------------------ Layer 1
 
-(defn- new-learning
+(defn- ^{:stratum 1} new-learning
   "Build + persist a fresh `:learning` zettel; return the persisted
    value so callers can drive `promote-learning` against its id."
   []
@@ -54,16 +53,24 @@
     (knowledge/put-zettel *store* z)
     (knowledge/get-zettel *store* (:zettel/id z))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; promote-learning trust stamp.
+(deftest ^{:stratum 1} test-promote-learning-on-non-learning-returns-nil
+  (testing "promote-learning is a no-op on a non-:learning zettel — existing contract"
+    (let [rule (knowledge/create-zettel "200-already-a-rule" "Already a Rule"
+                                        "Body." :rule)
+          _    (knowledge/put-zettel *store* rule)
+          r    (knowledge/promote-learning *store* (:zettel/id rule))]
+      (is (nil? r)))))
 
-(deftest test-fresh-learning-defaults-to-untrusted
+;------------------------------------------------------------------------------ Layer 2
+
+;; promote-learning trust stamp.
+(deftest ^{:stratum 2} test-fresh-learning-defaults-to-untrusted
   (testing "create-zettel + put → the persisted :learning carries :zettel/trust-level :untrusted"
     (let [l (new-learning)]
       (is (= :learning  (:zettel/type l)))
       (is (= :untrusted (:zettel/trust-level l))))))
 
-(deftest test-promote-learning-stamps-trusted-on-promoted-revision
+(deftest ^{:stratum 2} test-promote-learning-stamps-trusted-on-promoted-revision
   (testing "promote-learning flips type to :rule AND stamps :zettel/trust-level :trusted"
     (let [l        (new-learning)
           promoted (knowledge/promote-learning *store* (:zettel/id l)
@@ -73,18 +80,8 @@
       (is (= :trusted (:zettel/trust-level promoted))
           "promotion is the only path that grants :trusted"))))
 
-(deftest test-promote-learning-on-non-learning-returns-nil
-  (testing "promote-learning is a no-op on a non-:learning zettel — existing contract"
-    (let [rule (knowledge/create-zettel "200-already-a-rule" "Already a Rule"
-                                        "Body." :rule)
-          _    (knowledge/put-zettel *store* rule)
-          r    (knowledge/promote-learning *store* (:zettel/id rule))]
-      (is (nil? r)))))
-
-;------------------------------------------------------------------------------ Layer 2
 ;; Trust drops on a content edit AFTER promotion (the closure of #836).
-
-(deftest test-content-edit-on-promoted-rule-drops-trust
+(deftest ^{:stratum 2} test-content-edit-on-promoted-rule-drops-trust
   (testing "update-zettel on a content-bearing field of a :trusted rule resets to :untrusted"
     ;; The gap #836 closes: a promoted-and-trusted rule must NOT
     ;; carry trust onto a new revision when its content rotates.
@@ -100,7 +97,7 @@
       (is (= :untrusted (:zettel/trust-level edited))
           "rotation reset trust on the new revision"))))
 
-(deftest test-operational-edit-on-promoted-rule-preserves-trust
+(deftest ^{:stratum 2} test-operational-edit-on-promoted-rule-preserves-trust
   (testing "update-zettel on operational metadata only preserves the :trusted stamp"
     (let [l        (new-learning)
           promoted (knowledge/promote-learning *store* (:zettel/id l))
@@ -110,3 +107,5 @@
           "operational edit did not rotate revision-id")
       (is (= :trusted (:zettel/trust-level edited))
           "trust preserved across operational-only edit"))))
+
+(use-fixtures :each with-store)

--- a/components/knowledge/test/ai/miniforge/knowledge/loader_test.clj
+++ b/components/knowledge/test/ai/miniforge/knowledge/loader_test.clj
@@ -15,13 +15,14 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.knowledge.loader-test
   (:require
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.knowledge.loader :as sut]))
 
-(deftest initialize-knowledge-store-default-rules-dir-test
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} initialize-knowledge-store-default-rules-dir-test
   (testing "defaults rules loading to .cursor/rules"
     (let [captured-rules-dir (atom nil)]
       (with-redefs [sut/load-rules (fn [_store rules-dir]
@@ -32,7 +33,7 @@
         (is (= 0 (:total (sut/initialize-knowledge-store! ::store {}))))
         (is (= ".cursor/rules" @captured-rules-dir))))))
 
-(deftest initialize-knowledge-store-explicit-rules-dir-test
+(deftest ^{:stratum 0} initialize-knowledge-store-explicit-rules-dir-test
   (testing "respects an explicit rules-dir override"
     (let [captured-rules-dir (atom nil)]
       (with-redefs [sut/load-rules (fn [_store rules-dir]

--- a/components/knowledge/test/ai/miniforge/knowledge/pattern_detection_test.clj
+++ b/components/knowledge/test/ai/miniforge/knowledge/pattern_detection_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.knowledge.pattern-detection-test
   "Tests for recurring pattern detection and cross-execution synthesis."
   (:require
@@ -24,14 +23,15 @@
    [ai.miniforge.knowledge.learning :as learning]
    [ai.miniforge.knowledge.store :as store]))
 
-;------------------------------------------------------------------------------ Helpers
+;------------------------------------------------------------------------------ Layer 0
 
-(defn- fresh-store
+;------------------------------------------------------------------------------ Helpers
+(defn- ^{:stratum 0} fresh-store
   "Create a fresh in-memory knowledge store."
   []
   (store/create-store))
 
-(defn- seed-learnings!
+(defn- ^{:stratum 0} seed-learnings!
   "Seed a store with n learnings sharing the given tags.
    Returns the store."
   [store n tags & {:keys [agent confidence]
@@ -47,21 +47,21 @@
       :confidence confidence}))
   store)
 
-;------------------------------------------------------------------------------ Layer 0
-;; detect-recurring-patterns
+;------------------------------------------------------------------------------ Layer 1
 
-(deftest detect-recurring-patterns-empty-store
+;; detect-recurring-patterns
+(deftest ^{:stratum 1} detect-recurring-patterns-empty-store
   (testing "Empty store returns no patterns"
     (let [store (fresh-store)]
       (is (empty? (knowledge/detect-recurring-patterns store))))))
 
-(deftest detect-recurring-patterns-below-threshold
+(deftest ^{:stratum 1} detect-recurring-patterns-below-threshold
   (testing "Fewer than 3 learnings sharing a tag returns no patterns"
     (let [store (fresh-store)]
       (seed-learnings! store 2 [:clojure :protocol])
       (is (empty? (knowledge/detect-recurring-patterns store))))))
 
-(deftest detect-recurring-patterns-at-threshold
+(deftest ^{:stratum 1} detect-recurring-patterns-at-threshold
   (testing "Exactly 3 learnings sharing a tag returns a pattern"
     (let [store (fresh-store)]
       (seed-learnings! store 3 [:clojure :protocol])
@@ -71,7 +71,7 @@
         (is (every? #(= 3 (:count %)) patterns))
         (is (every? #(= 3 (count (:learnings %))) patterns))))))
 
-(deftest detect-recurring-patterns-above-threshold
+(deftest ^{:stratum 1} detect-recurring-patterns-above-threshold
   (testing "5 learnings sharing a tag returns pattern with count 5"
     (let [store (fresh-store)]
       (seed-learnings! store 5 [:namespace])
@@ -80,14 +80,14 @@
         (is (= :namespace (:tag (first patterns))))
         (is (= 5 (:count (first patterns))))))))
 
-(deftest detect-recurring-patterns-excludes-noise-tags
+(deftest ^{:stratum 1} detect-recurring-patterns-excludes-noise-tags
   (testing "Default exclude-tags filters :inner-loop and :repair"
     (let [store (fresh-store)]
       ;; These learnings only have excluded tags
       (seed-learnings! store 5 [:inner-loop :repair])
       (is (empty? (knowledge/detect-recurring-patterns store))))))
 
-(deftest detect-recurring-patterns-custom-threshold
+(deftest ^{:stratum 1} detect-recurring-patterns-custom-threshold
   (testing "Custom min-occurrences is respected"
     (let [store (fresh-store)]
       (seed-learnings! store 2 [:rare-pattern])
@@ -97,7 +97,7 @@
         (is (= 1 (count patterns)))
         (is (= :rare-pattern (:tag (first patterns))))))))
 
-(deftest detect-recurring-patterns-custom-exclude-tags
+(deftest ^{:stratum 1} detect-recurring-patterns-custom-exclude-tags
   (testing "Custom exclude-tags overrides defaults"
     (let [store (fresh-store)]
       (seed-learnings! store 4 [:inner-loop :real-tag])
@@ -110,7 +110,7 @@
                           store {:exclude-tags #{}})]
         (is (= 2 (count all-patterns)))))))
 
-(deftest detect-recurring-patterns-sorted-by-frequency
+(deftest ^{:stratum 1} detect-recurring-patterns-sorted-by-frequency
   (testing "Patterns are sorted by count descending"
     (let [store (fresh-store)]
       (seed-learnings! store 5 [:frequent])
@@ -119,7 +119,7 @@
         (is (= [:frequent :moderate]
                (mapv :tag patterns)))))))
 
-(deftest detect-recurring-patterns-learning-summaries
+(deftest ^{:stratum 1} detect-recurring-patterns-learning-summaries
   (testing "Each pattern includes learning summaries with expected keys"
     (let [store (fresh-store)]
       (seed-learnings! store 3 [:protocol])
@@ -132,16 +132,14 @@
           (is (contains? summary :title))
           (is (contains? summary :confidence)))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; synthesize-recurring-patterns!
-
-(deftest synthesize-patterns-no-patterns
+(deftest ^{:stratum 1} synthesize-patterns-no-patterns
   (testing "No patterns means 0 synthesized"
     (let [store (fresh-store)]
       (seed-learnings! store 2 [:not-enough])
       (is (= 0 (knowledge/synthesize-recurring-patterns! store))))))
 
-(deftest synthesize-patterns-creates-meta-loop-learnings
+(deftest ^{:stratum 1} synthesize-patterns-creates-meta-loop-learnings
   (testing "Patterns above threshold produce meta-loop learnings"
     (let [store (fresh-store)]
       (seed-learnings! store 4 [:protocol])
@@ -158,14 +156,14 @@
           (is (some #{:meta-loop} (:zettel/tags pattern-learning)))
           (is (some #{:protocol} (:zettel/tags pattern-learning))))))))
 
-(deftest synthesize-patterns-idempotent
+(deftest ^{:stratum 1} synthesize-patterns-idempotent
   (testing "Second call produces 0 new patterns"
     (let [store (fresh-store)]
       (seed-learnings! store 4 [:protocol])
       (is (= 1 (knowledge/synthesize-recurring-patterns! store)))
       (is (= 0 (knowledge/synthesize-recurring-patterns! store))))))
 
-(deftest synthesize-patterns-multiple-tags
+(deftest ^{:stratum 1} synthesize-patterns-multiple-tags
   (testing "Multiple distinct patterns each produce a learning"
     (let [store (fresh-store)]
       (seed-learnings! store 3 [:alpha])
@@ -173,7 +171,7 @@
       (let [synthesized (knowledge/synthesize-recurring-patterns! store)]
         (is (= 2 synthesized))))))
 
-(deftest synthesize-patterns-content-includes-learning-titles
+(deftest ^{:stratum 1} synthesize-patterns-content-includes-learning-titles
   (testing "Synthesized learning content includes titles of related learnings"
     (let [store (fresh-store)]
       (seed-learnings! store 3 [:namespace])
@@ -185,7 +183,7 @@
         (is (re-find #"Learning 1" (:zettel/content pattern-learning)))
         (is (re-find #"Learning 2" (:zettel/content pattern-learning)))))))
 
-(deftest synthesize-patterns-high-confidence
+(deftest ^{:stratum 1} synthesize-patterns-high-confidence
   (testing "Synthesized meta-loop learnings have 0.85 confidence"
     (let [store (fresh-store)]
       (seed-learnings! store 3 [:quality])

--- a/components/knowledge/test/ai/miniforge/knowledge/policy_lookup_test.clj
+++ b/components/knowledge/test/ai/miniforge/knowledge/policy_lookup_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.knowledge.policy-lookup-test
   (:require
    [ai.miniforge.knowledge.interface :as knowledge]
@@ -24,14 +23,14 @@
    [clojure.test :refer [deftest is testing]]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Test fixtures and factories
 
-(defn- make-store
+;; Test fixtures and factories
+(defn- ^{:stratum 0} make-store
   "Create an empty in-memory store with no logger noise."
   []
   (store/create-store))
 
-(defn- rule-zettel
+(defn- ^{:stratum 0} rule-zettel
   "Build a minimal :rule zettel for testing. All keys required by the store."
   [uid title content & {:as overrides}]
   (merge {:zettel/id      (random-uuid)
@@ -45,7 +44,7 @@
           :zettel/created (java.util.Date.)}
          overrides))
 
-(defn- non-rule-zettel
+(defn- ^{:stratum 0} non-rule-zettel
   "Build a :learning zettel (should be excluded from policy lookup)."
   [uid title]
   {:zettel/id      (random-uuid)
@@ -58,7 +57,32 @@
    :zettel/author  "test"
    :zettel/created (java.util.Date.)})
 
-(defn- store-with-rules
+(defn- ^{:stratum 0} titles
+  "Extract rule titles from lookup results for easy assertion."
+  [results]
+  (mapv :rule/title results))
+
+;; Unit tests — policy-lookup/lookup-policy-rules (pure function)
+(deftest ^{:stratum 0} test-nil-store-returns-empty-vector
+  (testing "nil knowledge-store → safe, returns []"
+    (is (= [] (sut/lookup-policy-rules nil {})))))
+
+;; Interface-level tests — knowledge/lookup-policy-rules (boundary + validation)
+(deftest ^{:stratum 0} test-interface-nil-store-safe
+  (testing "interface: nil store → []"
+    (is (= [] (knowledge/lookup-policy-rules nil {})))))
+
+(deftest ^{:stratum 0} test-policy-query-schema-exported
+  (testing "PolicyQuery schema is exported from the interface namespace"
+    (is (some? knowledge/PolicyQuery))))
+
+(deftest ^{:stratum 0} test-policy-result-schema-exported
+  (testing "PolicyResult schema is exported from the interface namespace"
+    (is (some? knowledge/PolicyResult))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} store-with-rules
   "Create a store pre-populated with several rules."
   []
   (doto (make-store)
@@ -79,30 +103,20 @@
                                   :zettel/tags [:clojure :exceptions]))
     (store/put-zettel (non-rule-zettel "learning-42" "A captured learning"))))
 
-(defn- titles
-  "Extract rule titles from lookup results for easy assertion."
-  [results]
-  (mapv :rule/title results))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Unit tests — policy-lookup/lookup-policy-rules (pure function)
-
-(deftest test-nil-store-returns-empty-vector
-  (testing "nil knowledge-store → safe, returns []"
-    (is (= [] (sut/lookup-policy-rules nil {})))))
-
-(deftest test-empty-store-returns-empty-vector
+(deftest ^{:stratum 1} test-empty-store-returns-empty-vector
   (testing "empty store with any query → []"
     (is (= [] (sut/lookup-policy-rules (make-store) {})))))
 
-(deftest test-empty-query-returns-all-rules
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} test-empty-query-returns-all-rules
   (testing "empty query map → all :rule zettels, no learnings"
     (let [results (sut/lookup-policy-rules (store-with-rules) {})]
       (is (= 3 (count results)))
       (is (every? #(contains? % :rule/title) results))
       (is (every? #(contains? % :rule/content) results)))))
 
-(deftest test-result-shape
+(deftest ^{:stratum 2} test-result-shape
   (testing "each result has only :rule/title and :rule/content"
     (let [[first-result] (sut/lookup-policy-rules (store-with-rules) {})]
       (is (string? (:rule/title first-result)))
@@ -111,78 +125,78 @@
       (is (nil? (:zettel/id first-result)))
       (is (nil? (:zettel/type first-result))))))
 
-(deftest test-non-rule-zettels-excluded
+(deftest ^{:stratum 2} test-non-rule-zettels-excluded
   (testing "learnings and other types are not returned"
     (let [results (sut/lookup-policy-rules (store-with-rules) {})
           result-titles (titles results)]
       (is (not (some #{"A captured learning"} result-titles))))))
 
-(deftest test-keyword-query-matches-title
+(deftest ^{:stratum 2} test-keyword-query-matches-title
   (testing ":query matches title substring (case-insensitive)"
     (let [results (sut/lookup-policy-rules (store-with-rules) {:query "Namespace"})]
       (is (= 1 (count results)))
       (is (= "Clojure Namespace Conventions" (:rule/title (first results)))))))
 
-(deftest test-keyword-query-matches-content
+(deftest ^{:stratum 2} test-keyword-query-matches-content
   (testing ":query matches body content (case-insensitive)"
     (let [results (sut/lookup-policy-rules (store-with-rules) {:query "slingshot"})]
       (is (= 1 (count results)))
       (is (= "Clojure Exception Handling" (:rule/title (first results)))))))
 
-(deftest test-keyword-query-case-insensitive
+(deftest ^{:stratum 2} test-keyword-query-case-insensitive
   (testing ":query match is case-insensitive"
     (let [upper (sut/lookup-policy-rules (store-with-rules) {:query "POLYLITH"})
           lower (sut/lookup-policy-rules (store-with-rules) {:query "polylith"})]
       (is (= (count upper) (count lower)))
       (is (= 1 (count lower))))))
 
-(deftest test-keyword-query-no-match-returns-empty
+(deftest ^{:stratum 2} test-keyword-query-no-match-returns-empty
   (testing ":query with no matches → []"
     (is (= [] (sut/lookup-policy-rules (store-with-rules) {:query "xyzzy-nonexistent"})))))
 
-(deftest test-tags-filter-single-tag
+(deftest ^{:stratum 2} test-tags-filter-single-tag
   (testing ":tags with one tag returns matching rules"
     (let [results (sut/lookup-policy-rules (store-with-rules) {:tags [:clojure]})]
       (is (= 2 (count results)))
       (is (= #{"Clojure Namespace Conventions" "Clojure Exception Handling"}
              (set (titles results)))))))
 
-(deftest test-tags-filter-no-match
+(deftest ^{:stratum 2} test-tags-filter-no-match
   (testing ":tags with no matching zettel → []"
     (is (= [] (sut/lookup-policy-rules (store-with-rules) {:tags [:python]})))))
 
-(deftest test-dewey-prefix-exact-match
+(deftest ^{:stratum 2} test-dewey-prefix-exact-match
   (testing ":dewey-prefix exact match returns the matching rule"
     (let [results (sut/lookup-policy-rules (store-with-rules) {:dewey-prefix "001"})]
       (is (= 1 (count results)))
       (is (= "Stratified Design" (:rule/title (first results)))))))
 
-(deftest test-dewey-prefix-matches-children
+(deftest ^{:stratum 2} test-dewey-prefix-matches-children
   (testing ":dewey-prefix \"21\" matches dewey \"210\" and \"211\""
     (let [results (sut/lookup-policy-rules (store-with-rules) {:dewey-prefix "21"})]
       (is (= 2 (count results)))
       (is (= #{"Clojure Namespace Conventions" "Clojure Exception Handling"}
              (set (titles results)))))))
 
-(deftest test-dewey-prefix-no-match
+(deftest ^{:stratum 2} test-dewey-prefix-no-match
   (testing ":dewey-prefix with no matching rules → []"
     (is (= [] (sut/lookup-policy-rules (store-with-rules) {:dewey-prefix "999"})))))
 
-(deftest test-combined-query-and-tags
+(deftest ^{:stratum 2} test-combined-query-and-tags
   (testing "combined :query + :tags → intersection"
     (let [results (sut/lookup-policy-rules (store-with-rules)
                                            {:query "slingshot" :tags [:clojure]})]
       (is (= 1 (count results)))
       (is (= "Clojure Exception Handling" (:rule/title (first results)))))))
 
-(deftest test-combined-tags-and-dewey
+(deftest ^{:stratum 2} test-combined-tags-and-dewey
   (testing "combined :tags + :dewey-prefix → intersection"
     (let [results (sut/lookup-policy-rules (store-with-rules)
                                            {:tags [:clojure] :dewey-prefix "210"})]
       (is (= 1 (count results)))
       (is (= "Clojure Namespace Conventions" (:rule/title (first results)))))))
 
-(deftest test-all-criteria-combined
+(deftest ^{:stratum 2} test-all-criteria-combined
   (testing "all three criteria combined → most specific match"
     (let [results (sut/lookup-policy-rules (store-with-rules)
                                            {:query "slingshot"
@@ -191,38 +205,23 @@
       (is (= 1 (count results)))
       (is (= "Clojure Exception Handling" (:rule/title (first results)))))))
 
-(deftest test-all-criteria-combined-no-match
+(deftest ^{:stratum 2} test-all-criteria-combined-no-match
   (testing "conflicting criteria → []"
     (is (= [] (sut/lookup-policy-rules (store-with-rules)
                                        {:query "slingshot"
                                         :tags [:architecture]})))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Interface-level tests — knowledge/lookup-policy-rules (boundary + validation)
-
-(deftest test-interface-nil-store-safe
-  (testing "interface: nil store → []"
-    (is (= [] (knowledge/lookup-policy-rules nil {})))))
-
-(deftest test-interface-nil-query-treated-as-empty
+(deftest ^{:stratum 2} test-interface-nil-query-treated-as-empty
   (testing "interface: nil query → treated as empty, returns all rules"
     (let [results (knowledge/lookup-policy-rules (store-with-rules) nil)]
       (is (= 3 (count results))))))
 
-(deftest test-interface-invalid-query-returns-empty
+(deftest ^{:stratum 2} test-interface-invalid-query-returns-empty
   (testing "interface: query failing PolicyQuery schema → []"
     ;; :tags must be a vector of keywords, not a string
     (is (= [] (knowledge/lookup-policy-rules (store-with-rules) {:tags "clojure"})))))
 
-(deftest test-interface-valid-query-delegates
+(deftest ^{:stratum 2} test-interface-valid-query-delegates
   (testing "interface: valid query delegates to lookup-policy-rules"
     (let [results (knowledge/lookup-policy-rules (store-with-rules) {:tags [:clojure]})]
       (is (= 2 (count results))))))
-
-(deftest test-policy-query-schema-exported
-  (testing "PolicyQuery schema is exported from the interface namespace"
-    (is (some? knowledge/PolicyQuery))))
-
-(deftest test-policy-result-schema-exported
-  (testing "PolicyResult schema is exported from the interface namespace"
-    (is (some? knowledge/PolicyResult))))

--- a/components/knowledge/test/ai/miniforge/knowledge/promotion_test.clj
+++ b/components/knowledge/test/ai/miniforge/knowledge/promotion_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.knowledge.promotion-test
   "Tests for pack promotion with justification tracking."
   (:require
@@ -23,9 +22,9 @@
    [ai.miniforge.knowledge.promotion :as promotion]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Justification Formatting Tests
 
-(deftest test-format-justification-basic
+;; Justification Formatting Tests
+(deftest ^{:stratum 0} test-format-justification-basic
   (testing "Format justification from template"
     (is (= "passed knowledge-safety scans with no violations"
            (promotion/format-justification :safety-scan-passed)))
@@ -36,7 +35,7 @@
     (is (= "verified signature from trusted key"
            (promotion/format-justification :signature-verified)))))
 
-(deftest test-format-justification-with-details
+(deftest ^{:stratum 0} test-format-justification-with-details
   (testing "Format justification with additional details"
     (is (= "passed knowledge-safety scans with no violations (3 scans completed)"
            (promotion/format-justification :safety-scan-passed "3 scans completed")))
@@ -45,16 +44,14 @@
            (promotion/format-justification :manual-review-approved
                                            "reviewed by 3 engineers")))))
 
-(deftest test-format-justification-unknown-template
+(deftest ^{:stratum 0} test-format-justification-unknown-template
   (testing "Unknown template keys generate fallback justification"
     (let [result (promotion/format-justification :custom-reason)]
       (is (string? result))
       (is (re-find #"custom-reason" result)))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Promotion Record Creation Tests
-
-(deftest test-create-promotion-record-minimal
+(deftest ^{:stratum 0} test-create-promotion-record-minimal
   (testing "Create promotion record with minimal required fields"
     (let [record (promotion/create-promotion-record
                   "test-pack-001"
@@ -71,7 +68,7 @@
       (is (= "knowledge-safety" (:promotion-policy record)))
       (is (inst? (:promoted-at record))))))
 
-(deftest test-create-promotion-record-full
+(deftest ^{:stratum 0} test-create-promotion-record-full
   (testing "Create promotion record with all fields"
     (let [record (promotion/create-promotion-record
                   "security-pack-v1"
@@ -94,7 +91,7 @@
       (is (= "sha256:abc123def456" (:pack-hash record)))
       (is (= "sig789" (:pack-signature record))))))
 
-(deftest test-create-promotion-record-requires-justification
+(deftest ^{:stratum 0} test-create-promotion-record-requires-justification
   (testing "Promotion record requires non-empty justification"
     (is (thrown? AssertionError
                  (promotion/create-promotion-record
@@ -110,10 +107,8 @@
                   :trusted
                   nil)))))  ;; Nil justification should fail precondition
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Trust Level Validation Tests
-
-(deftest test-valid-promotion-paths
+(deftest ^{:stratum 0} test-valid-promotion-paths
   (testing "Valid promotion paths are accepted"
     (is (true? (promotion/valid-promotion? :untrusted :trusted))
         "untrusted -> trusted is most common promotion")
@@ -127,7 +122,7 @@
     (is (true? (promotion/valid-promotion? :trusted :untrusted))
         "trusted -> untrusted demotes compromised content")))
 
-(deftest test-invalid-promotion-paths
+(deftest ^{:stratum 0} test-invalid-promotion-paths
   (testing "Invalid promotion paths are rejected"
     (is (false? (promotion/valid-promotion? :tainted :trusted))
         "Cannot promote directly from tainted to trusted")
@@ -138,7 +133,7 @@
     (is (false? (promotion/valid-promotion? :untrusted :invalid))
         "Invalid trust levels are rejected")))
 
-(deftest test-validate-promotion-success
+(deftest ^{:stratum 0} test-validate-promotion-success
   (testing "Valid promotion record passes validation"
     (let [record (promotion/create-promotion-record
                   "test-pack"
@@ -150,7 +145,7 @@
       (is (:valid? result))
       (is (empty? (:errors result))))))
 
-(deftest test-validate-promotion-invalid-path
+(deftest ^{:stratum 0} test-validate-promotion-invalid-path
   (testing "Invalid promotion path fails validation"
     (let [record (promotion/create-promotion-record
                   "test-pack"
@@ -162,10 +157,8 @@
       (is (not (:valid? result)))
       (is (some #(re-find #"Invalid promotion path" %) (:errors result))))))
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Promotion Execution Tests
-
-(deftest test-promote-pack-success
+(deftest ^{:stratum 0} test-promote-pack-success
   (testing "Successful pack promotion returns valid record"
     (let [result (promotion/promote-pack
                   "my-pack-v1"
@@ -182,7 +175,7 @@
       (is (= "passed knowledge-safety scans with no violations"
              (-> result :promotion-record :promotion-justification))))))
 
-(deftest test-promote-pack-invalid-path
+(deftest ^{:stratum 0} test-promote-pack-invalid-path
   (testing "Invalid promotion path returns errors"
     (let [result (promotion/promote-pack
                   "bad-pack"
@@ -195,10 +188,8 @@
       (is (map? (:promotion-record result))
           "Should still return promotion record for inspection"))))
 
-;------------------------------------------------------------------------------ Layer 4
 ;; Workflow Integration Tests
-
-(deftest test-record-promotion-in-workflow-empty
+(deftest ^{:stratum 0} test-record-promotion-in-workflow-empty
   (testing "Record promotion in empty workflow state"
     (let [workflow-state {}
           promotion-record (promotion/create-promotion-record
@@ -218,7 +209,7 @@
                  first
                  :pack/id))))))
 
-(deftest test-record-promotion-in-workflow-multiple
+(deftest ^{:stratum 0} test-record-promotion-in-workflow-multiple
   (testing "Record multiple promotions in workflow state"
     (let [workflow-state {}
           promotion1 (promotion/create-promotion-record
@@ -236,7 +227,7 @@
       (is (= ["pack-001" "pack-002" "pack-003"]
              (map :pack/id (:workflow/pack-promotions state3)))))))
 
-(deftest test-record-promotion-preserves-other-fields
+(deftest ^{:stratum 0} test-record-promotion-preserves-other-fields
   (testing "Recording promotion preserves other workflow state fields"
     (let [workflow-state {:workflow/status :in-progress
                           :workflow/id (random-uuid)

--- a/components/knowledge/test/ai/miniforge/knowledge/store_test.clj
+++ b/components/knowledge/test/ai/miniforge/knowledge/store_test.clj
@@ -15,13 +15,14 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.knowledge.store-test
   (:require
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.knowledge.store :as sut]))
 
-(deftest default-agent-manifests-no-dewey-prefixes-test
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} default-agent-manifests-no-dewey-prefixes-test
   (testing "default agent manifests no longer constrain retrieval by dewey prefixes"
     (doseq [[role manifest] sut/default-agent-manifests]
       (is (not (contains? manifest :dewey-prefixes))

--- a/components/knowledge/test/ai/miniforge/knowledge/trust_test.clj
+++ b/components/knowledge/test/ai/miniforge/knowledge/trust_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.knowledge.trust-test
   "Tests for transitive trust rules (N1 §2.10.2).
 
@@ -30,9 +29,9 @@
    [ai.miniforge.knowledge.trust :as trust]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Trust level ordering tests
 
-(deftest trust-level-order-test
+;; Trust level ordering tests
+(deftest ^{:stratum 0} trust-level-order-test
   (testing "Trust levels have correct ordering"
     (is (= 0 (trust/trust-level-order :tainted)))
     (is (= 1 (trust/trust-level-order :untrusted)))
@@ -41,7 +40,7 @@
   (testing "Invalid trust level returns nil"
     (is (nil? (trust/trust-level-order :invalid)))))
 
-(deftest lowest-trust-level-test
+(deftest ^{:stratum 0} lowest-trust-level-test
   (testing "Returns lowest trust level from collection"
     (is (= :tainted (trust/lowest-trust-level [:tainted :untrusted :trusted])))
     (is (= :untrusted (trust/lowest-trust-level [:untrusted :trusted])))
@@ -60,10 +59,8 @@
   (testing "All invalid levels defaults to :untrusted"
     (is (= :untrusted (trust/lowest-trust-level [:invalid :bad])))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Pack reference creation and validation tests
-
-(deftest make-pack-ref-test
+(deftest ^{:stratum 0} make-pack-ref-test
   (testing "Creates pack reference with required fields"
     (let [pack-ref (trust/make-pack-ref "pack-a" :trusted :authority/instruction)]
       (is (= "pack-a" (:pack-id pack-ref)))
@@ -76,7 +73,7 @@
                                        :dependencies ["pack-b" "pack-c"])]
       (is (= ["pack-b" "pack-c"] (:dependencies pack-ref))))))
 
-(deftest valid-pack-ref-test
+(deftest ^{:stratum 0} valid-pack-ref-test
   (testing "Valid pack reference passes validation"
     (let [pack-ref (trust/make-pack-ref "pack-a" :trusted :authority/instruction)]
       (is (trust/valid-pack-ref? pack-ref))))
@@ -86,10 +83,8 @@
     (is (not (trust/valid-pack-ref? {:pack-id "a"})))
     (is (not (trust/valid-pack-ref? {:pack-id "a" :trust-level :invalid})))))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Rule 1: Instruction authority is not transitive
-
-(deftest instruction-authority-not-transitive-test
+(deftest ^{:stratum 0} instruction-authority-not-transitive-test
   (testing "Trusted pack can reference untrusted data pack"
     (let [trusted-pack (trust/make-pack-ref "pack-a" :trusted :authority/instruction)
           untrusted-pack (trust/make-pack-ref "pack-b" :untrusted :authority/data)
@@ -121,10 +116,8 @@
                   data-pack-a data-pack-b)]
       (is (:valid? result)))))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Rule 2: Trust level inheritance
-
-(deftest trust-level-inheritance-test
+(deftest ^{:stratum 0} trust-level-inheritance-test
   (testing "Combines trusted packs as trusted"
     (let [pack-a (trust/make-pack-ref "pack-a" :trusted :authority/instruction)
           pack-b (trust/make-pack-ref "pack-b" :trusted :authority/data)
@@ -150,10 +143,8 @@
           result (trust/compute-inherited-trust-level [pack-a pack-b])]
       (is (= :untrusted result)))))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Rule 3: Cross-trust references
-
-(deftest cross-trust-references-valid-test
+(deftest ^{:stratum 0} cross-trust-references-valid-test
   (testing "Linear dependency chain is valid"
     (let [graph {"pack-a" (trust/make-pack-ref "pack-a" :trusted :authority/instruction
                                                :dependencies ["pack-b"])
@@ -180,7 +171,7 @@
           result (trust/validate-cross-trust-references graph)]
       (is (:valid? result)))))
 
-(deftest cross-trust-references-circular-test
+(deftest ^{:stratum 0} cross-trust-references-circular-test
   (testing "INVALID: Direct circular dependency"
     (let [graph {"pack-a" (trust/make-pack-ref "pack-a" :trusted :authority/data
                                                :dependencies ["pack-b"])
@@ -202,7 +193,7 @@
       (is (not (:valid? result)))
       (is (re-find #"circular" (clojure.string/lower-case (:error result)))))))
 
-(deftest cross-trust-references-missing-dep-test
+(deftest ^{:stratum 0} cross-trust-references-missing-dep-test
   (testing "INVALID: Missing dependency"
     (let [graph {"pack-a" (trust/make-pack-ref "pack-a" :trusted :authority/instruction
                                                :dependencies ["pack-missing"])}
@@ -210,10 +201,8 @@
       (is (not (:valid? result)))
       (is (re-find #"missing" (clojure.string/lower-case (:error result)))))))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Rule 4: Tainted isolation
-
-(deftest tainted-isolation-test
+(deftest ^{:stratum 0} tainted-isolation-test
   (testing "Data pack with tainted dependency is OK"
     (let [graph {"pack-a" (trust/make-pack-ref "pack-a" :trusted :authority/data
                                                :dependencies ["pack-b"])
@@ -251,10 +240,8 @@
           result (trust/validate-tainted-isolation "pack-a" graph)]
       (is (:valid? result)))))
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Combined validation
-
-(deftest validate-transitive-trust-complete-test
+(deftest ^{:stratum 0} validate-transitive-trust-complete-test
   (testing "Valid pack graph passes all rules"
     (let [graph {"pack-a" (trust/make-pack-ref "pack-a" :trusted :authority/instruction
                                                :dependencies ["pack-b"])

--- a/components/knowledge/test/ai/miniforge/knowledge/zettel_revision_test.clj
+++ b/components/knowledge/test/ai/miniforge/knowledge/zettel_revision_test.clj
@@ -9,7 +9,6 @@
 ;; You may obtain a copy of the License at
 ;;
 ;;     http://www.apache.org/licenses/LICENSE-2.0
-
 (ns ai.miniforge.knowledge.zettel-revision-test
   "Tests for the revision-keyed identity + Fleet-share schema additions
    landed for miniforge-fleet's Phase E (Decisions 6 + 8 + 13).
@@ -30,9 +29,9 @@
    [malli.core :as m]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Helpers.
 
-(defn- new-z
+;; Helpers.
+(defn- ^{:stratum 0} new-z
   "A zettel built via the public constructor, with optional kwargs."
   [& kvs]
   (apply zettel/create-zettel
@@ -40,17 +39,67 @@
          :rule
          kvs))
 
-;------------------------------------------------------------------------------ Layer 1
-;; create-zettel stamps revision-id + digest.
+(deftest ^{:stratum 0} test-update-backfills-derived-fields-on-legacy-zettel
+  (testing "a legacy zettel without :zettel/digest / :zettel/revision-id gets them stamped on first update"
+    ;; Decision 6 wants the system to converge on a fully-stamped state
+    ;; without an explicit migration. update-zettel handles that
+    ;; convergence implicitly by always re-stamping after merge.
+    (let [legacy {:zettel/id      (java.util.UUID/randomUUID)
+                  :zettel/uid     "legacy-z"
+                  :zettel/title   "Legacy Zettel"
+                  :zettel/content "Body."
+                  :zettel/type    :rule
+                  :zettel/created (java.util.Date.)
+                  :zettel/author  "user"}
+          updated (zettel/update-zettel legacy {:fleet/oss-version "1.0.0"})]
+      (is (string? (:zettel/digest updated))
+          ":zettel/digest backfilled by update")
+      (is (= 64 (count (:zettel/digest updated))))
+      (is (instance? java.util.UUID (:zettel/revision-id updated))
+          ":zettel/revision-id backfilled by update")
+      (is (= "1.0.0" (:fleet/oss-version updated))
+          "the operational change still landed"))))
 
-(deftest test-create-zettel-stamps-revision-and-digest
+;; Schema regression — pre-Decision-6 zettels still validate.
+(deftest ^{:stratum 0} test-legacy-zettel-without-fleet-fields-still-validates
+  (testing "a zettel built without any of the new fields still passes the schema"
+    ;; Round-trip a manually-shaped zettel (no Fleet fields, no
+    ;; revision-id) so legacy file-backed stores keep working until
+    ;; a future migration backfills the new fields.
+    (let [legacy {:zettel/id      (random-uuid)
+                  :zettel/uid     "legacy-1"
+                  :zettel/title   "Legacy Zettel"
+                  :zettel/content "Body."
+                  :zettel/type    :rule
+                  :zettel/created (java.util.Date.)
+                  :zettel/author  "user"}]
+      (is (m/validate schema/Zettel legacy)))))
+
+(deftest ^{:stratum 0} test-update-zettel-backfills-trust-level-on-legacy-zettel
+  (testing "a legacy zettel (no :zettel/trust-level) gets :untrusted on first update"
+    ;; Same convergence pattern the digest/revision-id backfill uses
+    ;; — no explicit migration needed.
+    (let [legacy  {:zettel/id      (java.util.UUID/randomUUID)
+                   :zettel/uid     "legacy-trust"
+                   :zettel/title   "Legacy"
+                   :zettel/content "Body."
+                   :zettel/type    :rule
+                   :zettel/created (java.util.Date.)
+                   :zettel/author  "user"}
+          updated (zettel/update-zettel legacy {:fleet/oss-version "1.0.0"})]
+      (is (= :untrusted (:zettel/trust-level updated))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; create-zettel stamps revision-id + digest.
+(deftest ^{:stratum 1} test-create-zettel-stamps-revision-and-digest
   (testing "every fresh zettel carries a 64-char hex digest + a UUID revision-id"
     (let [z (new-z)]
       (is (string? (:zettel/digest z)))
       (is (= 64 (count (:zettel/digest z))) "SHA-256 hex = 64 chars")
       (is (instance? java.util.UUID (:zettel/revision-id z))))))
 
-(deftest test-revision-id-is-deterministic-over-content
+(deftest ^{:stratum 1} test-revision-id-is-deterministic-over-content
   (testing "two zettels with identical content land on the same revision-id and digest"
     ;; The :zettel/id (logical identity) differs because the constructor mints
     ;; a fresh random UUID; the revision-id is derived from content and so
@@ -63,30 +112,28 @@
       (is (= (:zettel/digest z1)      (:zettel/digest z2)))
       (is (= (:zettel/revision-id z1) (:zettel/revision-id z2))))))
 
-(deftest test-distinct-content-produces-distinct-revision
+(deftest ^{:stratum 1} test-distinct-content-produces-distinct-revision
   (testing "any change to a content-bearing field produces a different revision-id"
     (let [z1 (new-z :tags [:a])
           z2 (new-z :tags [:b])]
       (is (not= (:zettel/digest z1) (:zettel/digest z2)))
       (is (not= (:zettel/revision-id z1) (:zettel/revision-id z2))))))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; update-zettel rotates revision on content change, leaves it alone otherwise.
-
-(deftest test-update-content-field-rotates-revision
+(deftest ^{:stratum 1} test-update-content-field-rotates-revision
   (testing "changing :zettel/content rotates :zettel/revision-id + :zettel/digest"
     (let [z1 (new-z)
           z2 (zettel/update-zettel z1 {:zettel/content "# Brand new content"})]
       (is (not= (:zettel/digest z1)      (:zettel/digest z2)))
       (is (not= (:zettel/revision-id z1) (:zettel/revision-id z2))))))
 
-(deftest test-update-tags-rotates-revision
+(deftest ^{:stratum 1} test-update-tags-rotates-revision
   (testing "changing :zettel/tags rotates the revision (tags are content-bearing)"
     (let [z1 (new-z :tags [:a])
           z2 (zettel/update-zettel z1 {:zettel/tags [:a :b]})]
       (is (not= (:zettel/revision-id z1) (:zettel/revision-id z2))))))
 
-(deftest test-update-operational-metadata-leaves-revision-intact
+(deftest ^{:stratum 1} test-update-operational-metadata-leaves-revision-intact
   (testing "operational-only changes (privacy classification, share scope, oss-version) preserve revision-id"
     ;; Decision 6: trust attaches to the immutable revision. Changing a
     ;; share-policy must NOT silently migrate trust onto a new revision —
@@ -101,7 +148,7 @@
       (is (= (:zettel/digest z1) (:zettel/digest z4))
           "digest unchanged across operational-metadata updates"))))
 
-(deftest test-update-ignores-caller-supplied-derived-fields
+(deftest ^{:stratum 1} test-update-ignores-caller-supplied-derived-fields
   (testing "callers cannot spoof :zettel/digest or :zettel/revision-id via update-zettel"
     ;; A producer trying to stamp a forged digest/revision-id (e.g. to
     ;; ride existing trust onto new content) gets neither — the updater
@@ -131,122 +178,79 @@
                 (:zettel/digest z2))
           "rotated digest comes from content, not from the spoof attempt"))))
 
-(deftest test-update-backfills-derived-fields-on-legacy-zettel
-  (testing "a legacy zettel without :zettel/digest / :zettel/revision-id gets them stamped on first update"
-    ;; Decision 6 wants the system to converge on a fully-stamped state
-    ;; without an explicit migration. update-zettel handles that
-    ;; convergence implicitly by always re-stamping after merge.
-    (let [legacy {:zettel/id      (java.util.UUID/randomUUID)
-                  :zettel/uid     "legacy-z"
-                  :zettel/title   "Legacy Zettel"
-                  :zettel/content "Body."
-                  :zettel/type    :rule
-                  :zettel/created (java.util.Date.)
-                  :zettel/author  "user"}
-          updated (zettel/update-zettel legacy {:fleet/oss-version "1.0.0"})]
-      (is (string? (:zettel/digest updated))
-          ":zettel/digest backfilled by update")
-      (is (= 64 (count (:zettel/digest updated))))
-      (is (instance? java.util.UUID (:zettel/revision-id updated))
-          ":zettel/revision-id backfilled by update")
-      (is (= "1.0.0" (:fleet/oss-version updated))
-          "the operational change still landed"))))
-
 ;------------------------------------------------------------------------------ Layer 2.5
 ;; Schema digest validation — accepts canonical lowercase hex; rejects
 ;; uppercase / non-hex / wrong-length.
-
-(deftest test-digest-schema-accepts-canonical-hex
+(deftest ^{:stratum 1} test-digest-schema-accepts-canonical-hex
   (testing "the digest the constructor stamps is lowercase SHA-256 hex and validates"
     (let [z (new-z)]
       (is (m/validate schema/Zettel z))
       (is (re-matches #"^[0-9a-f]{64}$" (:zettel/digest z))))))
 
-(deftest test-digest-schema-rejects-uppercase-hex
+(deftest ^{:stratum 1} test-digest-schema-rejects-uppercase-hex
   (testing "uppercase hex fails — content-hash always returns lowercase, so uppercase = forged or corrupted"
     (let [z (assoc (new-z) :zettel/digest
                    "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF")]
       (is (false? (m/validate schema/Zettel z))))))
 
-(deftest test-digest-schema-rejects-non-hex
+(deftest ^{:stratum 1} test-digest-schema-rejects-non-hex
   (testing "64-char string with non-hex characters fails"
     (let [z (assoc (new-z) :zettel/digest
                    (apply str (repeat 64 \z)))]
       (is (false? (m/validate schema/Zettel z))))))
 
-(deftest test-digest-schema-rejects-wrong-length
+(deftest ^{:stratum 1} test-digest-schema-rejects-wrong-length
   (testing "wrong-length hex fails"
     (let [too-short (apply str (repeat 63 \a))
           too-long  (apply str (repeat 65 \a))]
       (is (false? (m/validate schema/Zettel (assoc (new-z) :zettel/digest too-short))))
       (is (false? (m/validate schema/Zettel (assoc (new-z) :zettel/digest too-long)))))))
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Fleet-share schema fields accept their documented values.
-
-(deftest test-shareable-field-accepts-boolean
+(deftest ^{:stratum 1} test-shareable-field-accepts-boolean
   (testing ":fleet/shareable true / false both validate; the constructor stamps it"
     (doseq [b [true false]]
       (let [z (new-z :fleet/shareable b)]
         (is (= b (:fleet/shareable z)))
         (is (m/validate schema/Zettel z))))))
 
-(deftest test-share-scope-accepts-enum
+(deftest ^{:stratum 1} test-share-scope-accepts-enum
   (testing ":fleet/share-scope accepts the closed enum :org / :team / :repo / :workflow"
     (doseq [s [:org :team :repo :workflow]]
       (let [z (new-z :fleet/share-scope s)]
         (is (= s (:fleet/share-scope z)))
         (is (m/validate schema/Zettel z))))))
 
-(deftest test-share-scope-rejects-bad-value
+(deftest ^{:stratum 1} test-share-scope-rejects-bad-value
   (testing ":fleet/share-scope outside the enum fails schema validation"
     (let [z (assoc (new-z) :fleet/share-scope :galaxy)]
       (is (false? (m/validate schema/Zettel z))))))
 
-(deftest test-classification-accepts-enum
+(deftest ^{:stratum 1} test-classification-accepts-enum
   (testing ":privacy/classification accepts :public-org / :internal / :restricted / :secret"
     (doseq [c [:public-org :internal :restricted :secret]]
       (let [z (new-z :privacy/classification c)]
         (is (= c (:privacy/classification z)))
         (is (m/validate schema/Zettel z))))))
 
-(deftest test-classification-rejects-bad-value
+(deftest ^{:stratum 1} test-classification-rejects-bad-value
   (testing ":privacy/classification outside the enum fails validation"
     (let [z (assoc (new-z) :privacy/classification :other)]
       (is (false? (m/validate schema/Zettel z))))))
 
-(deftest test-oss-version-accepts-string
+(deftest ^{:stratum 1} test-oss-version-accepts-string
   (testing ":fleet/oss-version accepts a non-empty string"
     (let [z (new-z :fleet/oss-version "2026.05.07.42")]
       (is (= "2026.05.07.42" (:fleet/oss-version z)))
       (is (m/validate schema/Zettel z)))))
 
-(deftest test-oss-version-rejects-empty-string
+(deftest ^{:stratum 1} test-oss-version-rejects-empty-string
   (testing ":fleet/oss-version cannot be the empty string (would defeat the provenance)"
     (let [z (assoc (new-z) :fleet/oss-version "")]
       (is (false? (m/validate schema/Zettel z))))))
 
-;------------------------------------------------------------------------------ Layer 4
-;; Schema regression — pre-Decision-6 zettels still validate.
-
-(deftest test-legacy-zettel-without-fleet-fields-still-validates
-  (testing "a zettel built without any of the new fields still passes the schema"
-    ;; Round-trip a manually-shaped zettel (no Fleet fields, no
-    ;; revision-id) so legacy file-backed stores keep working until
-    ;; a future migration backfills the new fields.
-    (let [legacy {:zettel/id      (random-uuid)
-                  :zettel/uid     "legacy-1"
-                  :zettel/title   "Legacy Zettel"
-                  :zettel/content "Body."
-                  :zettel/type    :rule
-                  :zettel/created (java.util.Date.)
-                  :zettel/author  "user"}]
-      (is (m/validate schema/Zettel legacy)))))
-
-;------------------------------------------------------------------------------ Layer 5
 ;; :zettel/trust-level — per-revision trust (Decision 6 + 8; closes #836).
-
-(deftest test-create-zettel-defaults-trust-level-untrusted
+(deftest ^{:stratum 1} test-create-zettel-defaults-trust-level-untrusted
   (testing "every fresh zettel starts with :zettel/trust-level :untrusted"
     ;; Constructor default. learning/promote-learning is the only
     ;; path that post-asserts :trusted; it routes through
@@ -257,7 +261,7 @@
     (let [z (new-z)]
       (is (= :untrusted (:zettel/trust-level z))))))
 
-(deftest test-trust-level-resets-on-content-rotation
+(deftest ^{:stratum 1} test-trust-level-resets-on-content-rotation
   (testing "editing :zettel/content rotates revision-id AND resets trust to :untrusted"
     ;; The gap #836 closes: a producer who has already promoted a
     ;; zettel to :trusted and then edits its content must NOT
@@ -271,14 +275,14 @@
       (is (= :untrusted (:zettel/trust-level z2))
           "trust reset on content rotation"))))
 
-(deftest test-trust-level-resets-on-tag-rotation
+(deftest ^{:stratum 1} test-trust-level-resets-on-tag-rotation
   (testing "any content-bearing rotation resets trust — not just :zettel/content"
     (let [z1 (-> (new-z :tags [:a]) (assoc :zettel/trust-level :trusted))
           z2 (zettel/update-zettel z1 {:zettel/tags [:a :b]})]
       (is (not= (:zettel/revision-id z1) (:zettel/revision-id z2)))
       (is (= :untrusted (:zettel/trust-level z2))))))
 
-(deftest test-trust-level-preserved-on-operational-only-update
+(deftest ^{:stratum 1} test-trust-level-preserved-on-operational-only-update
   (testing "operational-metadata-only updates preserve trust (no revision rotation)"
     ;; Decision 6: changing operational policy must NOT silently
     ;; downgrade trust either. The current revision is still the
@@ -293,7 +297,7 @@
       (is (= :trusted (:zettel/trust-level z3)))
       (is (= :trusted (:zettel/trust-level z4))))))
 
-(deftest test-update-zettel-ignores-caller-supplied-trust-level
+(deftest ^{:stratum 1} test-update-zettel-ignores-caller-supplied-trust-level
   (testing "callers cannot stamp :zettel/trust-level via update-zettel changes"
     ;; The full closure: even if a producer attempts to override
     ;; trust through the edit path, update-zettel drops it from
@@ -313,26 +317,12 @@
         (is (= :untrusted (:zettel/trust-level z2))
             "content edit forces :untrusted; spoof attempt at :trusted ignored")))))
 
-(deftest test-update-zettel-backfills-trust-level-on-legacy-zettel
-  (testing "a legacy zettel (no :zettel/trust-level) gets :untrusted on first update"
-    ;; Same convergence pattern the digest/revision-id backfill uses
-    ;; — no explicit migration needed.
-    (let [legacy  {:zettel/id      (java.util.UUID/randomUUID)
-                   :zettel/uid     "legacy-trust"
-                   :zettel/title   "Legacy"
-                   :zettel/content "Body."
-                   :zettel/type    :rule
-                   :zettel/created (java.util.Date.)
-                   :zettel/author  "user"}
-          updated (zettel/update-zettel legacy {:fleet/oss-version "1.0.0"})]
-      (is (= :untrusted (:zettel/trust-level updated))))))
-
-(deftest test-trust-level-schema-rejects-bad-value
+(deftest ^{:stratum 1} test-trust-level-schema-rejects-bad-value
   (testing ":zettel/trust-level outside the closed enum fails schema validation"
     (let [z (assoc (new-z) :zettel/trust-level :very-trusted)]
       (is (false? (m/validate schema/Zettel z))))))
 
-(deftest test-trust-level-schema-accepts-both-values
+(deftest ^{:stratum 1} test-trust-level-schema-accepts-both-values
   (testing ":zettel/trust-level :trusted and :untrusted both validate"
     (doseq [t [:trusted :untrusted]]
       (let [z (assoc (new-z) :zettel/trust-level t)]

--- a/components/knowledge/test/ai/miniforge/knowledge/zettel_revision_test.clj
+++ b/components/knowledge/test/ai/miniforge/knowledge/zettel_revision_test.clj
@@ -178,7 +178,6 @@
                 (:zettel/digest z2))
           "rotated digest comes from content, not from the spoof attempt"))))
 
-;------------------------------------------------------------------------------ Layer 2.5
 ;; Schema digest validation — accepts canonical lowercase hex; rejects
 ;; uppercase / non-hex / wrong-length.
 (deftest ^{:stratum 1} test-digest-schema-accepts-canonical-hex

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-knowledge.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-knowledge.md
@@ -1,0 +1,157 @@
+<!--
+  Title: Fix stratum-lint autofix for components/knowledge (Wave 1)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix: stratum-lint autofix for components/knowledge (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over `components/knowledge` (`src` + `test`) to
+replace decorative `Layer N` headings with real ones + `^{:stratum n}`
+metadata derived from each file's actual same-file reference graph, per
+rule 210 (`standards/miniforge/languages/clojure.mdc`). One of the
+per-component Wave 1 batches from `work/stratum-lint-baseline-2026-07-24.md`
+(batch 5). Not to be confused with `components/knowledge-pack`, a separate
+component already fixed in batch 3 (#1494).
+
+## Motivation
+
+`components/knowledge` carried 14 baseline findings — 4 `SL002`, 8 `SL003`,
+2 `SL004`, **zero `SL001`** — so no upward-reference/cycle risk needed
+triage before running the mechanical fixer; matches the Wave 1 batch
+criteria exactly. A plain (non-`--fix`) lint run before touching anything
+reproduced the baseline's 14 findings exactly, confirming the count hadn't
+drifted since the baseline was taken.
+
+## Changes in Detail
+
+Ran, over the whole component:
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "bef8657a2efd3b1ba9e1a4f510693c9fbca45abd" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/knowledge
+```
+
+All 11 `src` files and all 9 `test` files rewrote (20 files total). No
+`SL008` refusal — no reader-conditional-wrapped defn hit that class of
+issue in this component.
+
+- `interface.clj` (1 real layer), `messages.clj` (1): all defs collapsed to
+  a single real `Layer 0` — `interface.clj` is a pure re-export facade over
+  `schema`/`zettel`/`store`/`learning`/`loader`/`trust`/`yaml`, none
+  referencing each other in this file. `interface.clj` previously carried
+  10 decorative `Layer N` (0-9) headings. Neither ns docstring made a
+  "how many layers" claim, so nothing to correct.
+- `promotion.clj` (4, over budget — unchanged from baseline), `trust.clj`
+  (5, over budget — up from the baseline's mislabeled 4): headings +
+  metadata only; neither ns docstring made a layer-count claim to correct.
+- `learning.clj` (3, within budget), `policy_lookup.clj` (3, within
+  budget): both ns docstrings previously described a different-content,
+  differently-numbered breakdown (e.g. `learning.clj` claimed "Layer 0:
+  Learning capture / Layer 1: Learning promotion / Layer 2: Pattern
+  detection", but the real Layer 0 groups `capture-learning`,
+  `promote-learning`, `detect-recurring-patterns`, AND `list-learnings`
+  together); corrected to describe the real grouping.
+- `schema.clj`: real depth is 3 layers (enums + primitive-only schemas at
+  Layer 0, compound schemas referencing those enums at Layer 1, `Zettel`
+  itself at Layer 2) — **down** from the baseline's 4-layer `SL003`
+  finding, now within budget. Ns docstring corrected to match.
+- `store.clj` (4, over budget), `loader.clj` (5, over budget), `zettel.clj`
+  (5, over budget): genuinely new information the baseline's plain-lint
+  pass couldn't see, since each of these files' pre-fix headings happened
+  to already be monotonic and within-budget by coincidence while
+  *mislabeling* the real reference depth. `--fix`'s reference-graph
+  computation is the only way to discover this; documented as a Wave 2
+  namespace-split candidate for each, below. All three ns docstrings
+  previously claimed a lower, differently-mapped layer count; corrected by
+  hand to describe the real per-layer grouping (see diffs for exact
+  wording).
+- `yaml.clj`: also over budget (5 layers, newly surfaced — baseline
+  reported zero findings for this file), but its ns docstring made no
+  layer-count claim to begin with — headings + metadata only.
+- `store.clj` also had one decorative `;---- Layer 0.5` banner (a
+  non-integer heading stratum-lint's regex doesn't recognize, so it wasn't
+  touched by `--fix`) sitting between two defs both later computed as real
+  `Layer 0` — a false sub-boundary. Dropped the heading line by hand,
+  keeping its descriptive text ("File-backed persistent store") as a plain
+  comment. Same class of fix as prior Wave 1 batches (e.g.
+  `components/event-stream`).
+- Test files: mechanical only. `pattern_detection_test.clj` had two
+  `SL004` findings (`fresh-store`, `seed-learnings!` before the first real
+  heading, previously under a decorative `;---- Helpers` banner) — both
+  now correctly grouped under a real `Layer 0`. `trust_test.clj` had a
+  `Layer 2` heading repeated four times (`SL002`) — all four `deftest`
+  groups collapsed to a single real `Layer 0`, since none of the tests
+  reference each other in-file. `use-fixtures` calls in
+  `file_backed_store_test.clj` and `learning_test.clj` got swept to the
+  file's appendix (after all `deftest` forms) — `--fix`'s known behavior
+  for any non-def top-level form. Verified this is safe: `use-fixtures`
+  only needs to execute once during namespace load, which completes in
+  full before `clojure.test/run-tests` ever runs a test, so its position
+  relative to the `deftest` forms in the file has no effect on behavior.
+
+No change in runtime behavior anywhere in this diff — heading text,
+`^{:stratum n}` metadata, def/deftest reordering, and (six files: `zettel`,
+`loader`, `schema`, `store`, `learning`, `policy_lookup`) ns docstring
+corrections to match the real, now-computed layer structure.
+
+## Testing Plan
+
+1. Ran plain (non-`--fix`) `stratum-lint` before touching anything —
+   reproduced the baseline's exact 14 findings, 0 `SL001`.
+2. Ran `--fix`, then a second `--fix` pass immediately after — zero diff,
+   confirms idempotency.
+3. Read the full diff for all 20 changed files. No same-line trailing
+   comment was displaced onto the wrong def. Found one decorative
+   non-integer heading (`store.clj`'s `Layer 0.5`, described above) and six
+   stale ns-docstring layer-count claims (`zettel.clj`, `loader.clj`,
+   `schema.clj`, `store.clj`, `learning.clj`, `policy_lookup.clj`);
+   hand-corrected all six.
+4. Re-ran `--fix` a third time after the manual edits — zero diff, still
+   idempotent.
+5. `clj-kondo --lint components/knowledge`: 0 errors, 0 warnings.
+6. Ran all 9 test namespaces directly via `clojure -M:dev:test`
+   (`file-backed-store-test`, `learning-test`, `loader-test`,
+   `pattern-detection-test`, `policy-lookup-test`, `promotion-test`,
+   `store-test`, `trust-test`, `zettel-revision-test`): **106 tests, 311
+   assertions, 0 failures, 0 errors.**
+7. Re-ran plain `stratum-lint` after the fix: `SL001`/`SL002`/`SL004` clear
+   everywhere. `SL003` remains on 6 files — `loader.clj` (5 layers),
+   `promotion.clj` (4), `store.clj` (4), `trust.clj` (5), `yaml.clj` (5),
+   `zettel.clj` (5). `promotion.clj` was already `SL003` in the baseline
+   (4 layers, unchanged). The other five are newly surfaced by `--fix`'s
+   accurate reference-graph computation — the baseline's plain-lint pass
+   under-counted them because their pre-fix headings were coincidentally
+   monotonic and in-budget while describing the wrong grouping. All six
+   deferred to Wave 2 (real namespace split), consistent with how prior
+   Wave 1 batches handled the same situation.
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+change — comment/metadata/order/docstring-only. Pre-commit's
+`lint:stratum` autofixer keeps this component clean going forward; the six
+files above stay advisory (`MINIFORGE_STRATUM_BUDGET_MODE=warn` at commit
+time) until Wave 2 splits them.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1, batch 5)
+- Distinct component from `components/knowledge-pack` (already fixed, #1494)
+- Follow-on: Wave 2 namespace split for `components/knowledge/src/ai/miniforge/knowledge/{loader,promotion,store,trust,yaml,zettel}.clj`
+  (4-5 real layers each, over the 3-layer budget)
+
+## Checklist
+
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Second (and third, post-manual-edit) `--fix` pass confirms
+      idempotency (zero diff)
+- [x] Diff read in full for all 20 changed files; mechanical, plus one
+      decorative-heading removal and six hand-corrected stale docstring
+      claims
+- [x] `clj-kondo` clean (0 errors, 0 warnings)
+- [x] Component tests pass (106 tests, 311 assertions, 0 failures/errors)
+- [x] Plain lint re-run post-fix: zero findings except `SL003` on 6 files
+      (documented above, tracked as Wave 2)
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
<!--
  Title: Fix stratum-lint autofix for components/knowledge (Wave 1)
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# fix: stratum-lint autofix for components/knowledge (Wave 1)

## Overview

Runs `stratum-lint --fix` over `components/knowledge` (`src` + `test`) to
replace decorative `Layer N` headings with real ones + `^{:stratum n}`
metadata derived from each file's actual same-file reference graph, per
rule 210 (`standards/miniforge/languages/clojure.mdc`). One of the
per-component Wave 1 batches from `work/stratum-lint-baseline-2026-07-24.md`
(batch 5). Not to be confused with `components/knowledge-pack`, a separate
component already fixed in batch 3 (#1494).

## Motivation

`components/knowledge` carried 14 baseline findings — 4 `SL002`, 8 `SL003`,
2 `SL004`, **zero `SL001`** — so no upward-reference/cycle risk needed
triage before running the mechanical fixer; matches the Wave 1 batch
criteria exactly. A plain (non-`--fix`) lint run before touching anything
reproduced the baseline's 14 findings exactly, confirming the count hadn't
drifted since the baseline was taken.

## Changes in Detail

Ran, over the whole component:

```bash
bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "bef8657a2efd3b1ba9e1a4f510693c9fbca45abd" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/knowledge
```

All 11 `src` files and all 9 `test` files rewrote (20 files total). No
`SL008` refusal — no reader-conditional-wrapped defn hit that class of
issue in this component.

- `interface.clj` (1 real layer), `messages.clj` (1): all defs collapsed to
  a single real `Layer 0` — `interface.clj` is a pure re-export facade over
  `schema`/`zettel`/`store`/`learning`/`loader`/`trust`/`yaml`, none
  referencing each other in this file. `interface.clj` previously carried
  10 decorative `Layer N` (0-9) headings. Neither ns docstring made a
  "how many layers" claim, so nothing to correct.
- `promotion.clj` (4, over budget — unchanged from baseline), `trust.clj`
  (5, over budget — up from the baseline's mislabeled 4): headings +
  metadata only; neither ns docstring made a layer-count claim to correct.
- `learning.clj` (3, within budget), `policy_lookup.clj` (3, within
  budget): both ns docstrings previously described a different-content,
  differently-numbered breakdown (e.g. `learning.clj` claimed "Layer 0:
  Learning capture / Layer 1: Learning promotion / Layer 2: Pattern
  detection", but the real Layer 0 groups `capture-learning`,
  `promote-learning`, `detect-recurring-patterns`, AND `list-learnings`
  together); corrected to describe the real grouping.
- `schema.clj`: real depth is 3 layers (enums + primitive-only schemas at
  Layer 0, compound schemas referencing those enums at Layer 1, `Zettel`
  itself at Layer 2) — **down** from the baseline's 4-layer `SL003`
  finding, now within budget. Ns docstring corrected to match.
- `store.clj` (4, over budget), `loader.clj` (5, over budget), `zettel.clj`
  (5, over budget): genuinely new information the baseline's plain-lint
  pass couldn't see, since each of these files' pre-fix headings happened
  to already be monotonic and within-budget by coincidence while
  *mislabeling* the real reference depth. `--fix`'s reference-graph
  computation is the only way to discover this; documented as a Wave 2
  namespace-split candidate for each, below. All three ns docstrings
  previously claimed a lower, differently-mapped layer count; corrected by
  hand to describe the real per-layer grouping (see diffs for exact
  wording).
- `yaml.clj`: also over budget (5 layers, newly surfaced — baseline
  reported zero findings for this file), but its ns docstring made no
  layer-count claim to begin with — headings + metadata only.
- `store.clj` also had one decorative `;---- Layer 0.5` banner (a
  non-integer heading stratum-lint's regex doesn't recognize, so it wasn't
  touched by `--fix`) sitting between two defs both later computed as real
  `Layer 0` — a false sub-boundary. Dropped the heading line by hand,
  keeping its descriptive text ("File-backed persistent store") as a plain
  comment. Same class of fix as prior Wave 1 batches (e.g.
  `components/event-stream`).
- Test files: mechanical only. `pattern_detection_test.clj` had two
  `SL004` findings (`fresh-store`, `seed-learnings!` before the first real
  heading, previously under a decorative `;---- Helpers` banner) — both
  now correctly grouped under a real `Layer 0`. `trust_test.clj` had a
  `Layer 2` heading repeated four times (`SL002`) — all four `deftest`
  groups collapsed to a single real `Layer 0`, since none of the tests
  reference each other in-file. `use-fixtures` calls in
  `file_backed_store_test.clj` and `learning_test.clj` got swept to the
  file's appendix (after all `deftest` forms) — `--fix`'s known behavior
  for any non-def top-level form. Verified this is safe: `use-fixtures`
  only needs to execute once during namespace load, which completes in
  full before `clojure.test/run-tests` ever runs a test, so its position
  relative to the `deftest` forms in the file has no effect on behavior.

No change in runtime behavior anywhere in this diff — heading text,
`^{:stratum n}` metadata, def/deftest reordering, and (six files: `zettel`,
`loader`, `schema`, `store`, `learning`, `policy_lookup`) ns docstring
corrections to match the real, now-computed layer structure.

## Testing Plan

1. Ran plain (non-`--fix`) `stratum-lint` before touching anything —
   reproduced the baseline's exact 14 findings, 0 `SL001`.
2. Ran `--fix`, then a second `--fix` pass immediately after — zero diff,
   confirms idempotency.
3. Read the full diff for all 20 changed files. No same-line trailing
   comment was displaced onto the wrong def. Found one decorative
   non-integer heading (`store.clj`'s `Layer 0.5`, described above) and six
   stale ns-docstring layer-count claims (`zettel.clj`, `loader.clj`,
   `schema.clj`, `store.clj`, `learning.clj`, `policy_lookup.clj`);
   hand-corrected all six.
4. Re-ran `--fix` a third time after the manual edits — zero diff, still
   idempotent.
5. `clj-kondo --lint components/knowledge`: 0 errors, 0 warnings.
6. Ran all 9 test namespaces directly via `clojure -M:dev:test`
   (`file-backed-store-test`, `learning-test`, `loader-test`,
   `pattern-detection-test`, `policy-lookup-test`, `promotion-test`,
   `store-test`, `trust-test`, `zettel-revision-test`): **106 tests, 311
   assertions, 0 failures, 0 errors.**
7. Re-ran plain `stratum-lint` after the fix: `SL001`/`SL002`/`SL004` clear
   everywhere. `SL003` remains on 6 files — `loader.clj` (5 layers),
   `promotion.clj` (4), `store.clj` (4), `trust.clj` (5), `yaml.clj` (5),
   `zettel.clj` (5). `promotion.clj` was already `SL003` in the baseline
   (4 layers, unchanged). The other five are newly surfaced by `--fix`'s
   accurate reference-graph computation — the baseline's plain-lint pass
   under-counted them because their pre-fix headings were coincidentally
   monotonic and in-budget while describing the wrong grouping. All six
   deferred to Wave 2 (real namespace split), consistent with how prior
   Wave 1 batches handled the same situation.

## Deployment Plan

Merges to `main` like any other component change. No runtime behavior
change — comment/metadata/order/docstring-only. Pre-commit's
`lint:stratum` autofixer keeps this component clean going forward; the six
files above stay advisory (`MINIFORGE_STRATUM_BUDGET_MODE=warn` at commit
time) until Wave 2 splits them.

## Related Issues/PRs

- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1, batch 5)
- Distinct component from `components/knowledge-pack` (already fixed, #1494)
- Follow-on: Wave 2 namespace split for `components/knowledge/src/ai/miniforge/knowledge/{loader,promotion,store,trust,yaml,zettel}.clj`
  (4-5 real layers each, over the 3-layer budget)

## Checklist

- [x] `--fix` run over the whole component (`src` + `test`)
- [x] Second (and third, post-manual-edit) `--fix` pass confirms
      idempotency (zero diff)
- [x] Diff read in full for all 20 changed files; mechanical, plus one
      decorative-heading removal and six hand-corrected stale docstring
      claims
- [x] `clj-kondo` clean (0 errors, 0 warnings)
- [x] Component tests pass (106 tests, 311 assertions, 0 failures/errors)
- [x] Plain lint re-run post-fix: zero findings except `SL003` on 6 files
      (documented above, tracked as Wave 2)
- [x] No `--no-verify`; pre-commit hook runs normally at commit time
