### PR TITLE
fix: stratum-lint autofix for components/repo-dag (Wave 1)

### DIFF
--- a/components/repo-dag/src/ai/miniforge/repo_dag/core.clj
+++ b/components/repo-dag/src/ai/miniforge/repo_dag/core.clj
@@ -15,12 +15,13 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.repo-dag.core
   "Implementation of the repo-dag component.
-   Layer 0: Pure functions for DAG operations
-   Layer 1: Protocol definition
-   Layer 2: In-memory implementation"
+   Layer 0: Pure DAG primitives, protocol definition, and store helpers
+   Layer 1: Schema-validating siblings, traversal, and validation logic
+   Layer 2: Schema-aware constructors and anomaly-returning CRUD impls
+   Layer 3: In-memory manager implementation
+   Layer 4: Factory function"
   (:require
    [clojure.set :as set]
    [clojure.string :as str]
@@ -31,9 +32,9 @@
    [ai.miniforge.repo-dag.schema :as schema]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Pure functions for DAG operations
 
-(defn validate-schema-anomaly
+;; Pure functions for DAG operations
+(defn ^{:stratum 0} validate-schema-anomaly
   "Validate a value against a schema. Return the value on success, or an
    `:invalid-input` anomaly map describing the validation failure.
 
@@ -52,14 +53,7 @@
                       :value value
                       :errors (me/humanize (m/explain schema-def value))})))
 
-(defn validate-schema
-  "Validate a value against a schema, returning the value or an anomaly map.
-
-   Kept as a stable alias for [[validate-schema-anomaly]]."
-  [schema-def value]
-  (validate-schema-anomaly schema-def value))
-
-(defn- build-repo-node
+(defn- ^{:stratum 0} build-repo-node
   "Internal: assemble the repo-node map (no validation). Shared by
    repo-node constructors so their behavior never drifts."
   [{:keys [repo/url repo/name repo/org repo/type repo/layer repo/default-branch repo/watch-config]
@@ -73,23 +67,7 @@
       org (assoc :repo/org org)
       watch-config (assoc :repo/watch-config watch-config))))
 
-(defn make-repo-node-anomaly
-  "Build a repo node from `repo-config`, returning the validated node or
-   an `:invalid-input` anomaly when schema validation rejects it (e.g.
-   missing `:repo/type`, malformed `:repo/url`, …).
-
-   Prefer this over [[make-repo-node]] in non-boundary code."
-  [repo-config]
-  (validate-schema-anomaly schema/RepoNode (build-repo-node repo-config)))
-
-(defn make-repo-node
-  "Create a repo node with layer inference if not specified.
-
-   Returns an anomaly map when schema validation fails."
-  [repo-config]
-  (validate-schema schema/RepoNode (build-repo-node repo-config)))
-
-(defn- build-repo-edge
+(defn- ^{:stratum 0} build-repo-edge
   "Internal: assemble the edge map (no validation). Shared by
    repo-edge constructors."
   [{:keys [edge/from edge/to edge/constraint edge/merge-ordering edge/validation]
@@ -100,38 +78,12 @@
            :edge/merge-ordering merge-ordering}
     validation (assoc :edge/validation validation)))
 
-(defn make-repo-edge-anomaly
-  "Build a repo edge from `edge-config`, returning the validated edge or
-   an `:invalid-input` anomaly when schema validation rejects it (unknown
-   `:edge/constraint`, unknown `:edge/merge-ordering`, missing endpoints, …).
-
-   Prefer this over [[make-repo-edge]] in non-boundary code."
-  [edge-config]
-  (validate-schema-anomaly schema/RepoEdge (build-repo-edge edge-config)))
-
-(defn make-repo-edge
-  "Create a repo edge with default merge ordering.
-
-   Returns an anomaly map when schema validation fails."
-  [edge-config]
-  (validate-schema schema/RepoEdge (build-repo-edge edge-config)))
-
-(defn make-dag
-  "Create a new empty DAG, or return an anomaly map if validation fails."
-  [id dag-name description]
-  (let [dag (cond-> {:dag/id id
-                     :dag/name dag-name
-                     :dag/repos []
-                     :dag/edges []}
-              description (assoc :dag/description description))]
-    (validate-schema schema/RepoDag dag)))
-
-(defn find-repo-by-name
+(defn ^{:stratum 0} find-repo-by-name
   "Find a repo node by name in the DAG."
   [dag repo-name]
   (some #(when (= repo-name (:repo/name %)) %) (:dag/repos dag)))
 
-(defn find-edge
+(defn ^{:stratum 0} find-edge
   "Find an edge by from/to pair."
   [dag from-repo to-repo]
   (some #(when (and (= from-repo (:edge/from %))
@@ -139,15 +91,14 @@
            %)
         (:dag/edges dag)))
 
-(defn repo-names
+(defn ^{:stratum 0} repo-names
   "Get set of all repo names in the DAG."
   [dag]
   (set (map :repo/name (:dag/repos dag))))
 
 ;------------------------------------------------------------------------------ Layer 0.5
 ;; Kahn's algorithm for topological sort
-
-(defn topo-sort
+(defn ^{:stratum 0} topo-sort
   "Perform topological sort using Kahn's algorithm.
    Returns {:success true :order [...]} or {:success false :error :cycle-detected :cycle-nodes #{...}}"
   [dag]
@@ -165,17 +116,9 @@
        :error       :cycle-detected
        :cycle-nodes (get-in result [:error :data :cycle-nodes])})))
 
-(defn find-cycle-nodes
-  "Find nodes involved in a cycle. Returns nil if no cycle."
-  [dag]
-  (let [result (topo-sort dag)]
-    (when-not (:success result)
-      (:cycle-nodes result))))
-
 ;------------------------------------------------------------------------------ Layer 0.6
 ;; Graph traversal functions
-
-(defn build-adjacency
+(defn ^{:stratum 0} build-adjacency
   "Build adjacency list from DAG edges."
   [dag]
   (reduce (fn [acc edge]
@@ -183,7 +126,7 @@
           {}
           (:dag/edges dag)))
 
-(defn build-reverse-adjacency
+(defn ^{:stratum 0} build-reverse-adjacency
   "Build reverse adjacency list (for finding upstream repos)."
   [dag]
   (reduce (fn [acc edge]
@@ -191,52 +134,7 @@
           {}
           (:dag/edges dag)))
 
-(defn downstream-repos
-  "Get all repos that depend on the given repo (transitive closure)."
-  [dag repo-name]
-  (let [adj (build-adjacency dag)]
-    (loop [to-visit #{repo-name}
-           visited #{}]
-      (if (empty? to-visit)
-        (disj visited repo-name) ; Don't include the starting repo
-        (let [current (first to-visit)
-              neighbors (get adj current #{})]
-          (recur (into (disj to-visit current)
-                       (set/difference neighbors visited))
-                 (conj visited current)))))))
-
-(defn upstream-repos-impl
-  "Get all repos that this repo depends on (transitive closure)."
-  [dag repo-name]
-  (let [rev-adj (build-reverse-adjacency dag)]
-    (loop [to-visit #{repo-name}
-           visited #{}]
-      (if (empty? to-visit)
-        (disj visited repo-name) ; Don't include the starting repo
-        (let [current (first to-visit)
-              neighbors (get rev-adj current #{})]
-          (recur (into (disj to-visit current)
-                       (set/difference neighbors visited))
-                 (conj visited current)))))))
-
-(defn compute-merge-order
-  "Given a set of repo names, compute valid merge order based on DAG topology.
-   Only considers repos in the pr-set."
-  [dag pr-set]
-  (let [pr-names (set pr-set)
-        ;; Filter edges to only those between repos in pr-set
-        relevant-edges (filterv (fn [edge]
-                                  (and (contains? pr-names (:edge/from edge))
-                                       (contains? pr-names (:edge/to edge))))
-                                (:dag/edges dag))
-        ;; Create sub-DAG
-        sub-dag (assoc dag
-                       :dag/repos (filterv #(contains? pr-names (:repo/name %))
-                                           (:dag/repos dag))
-                       :dag/edges relevant-edges)]
-    (topo-sort sub-dag)))
-
-(defn compute-layers
+(defn ^{:stratum 0} compute-layers
   "Group repos by their layer."
   [dag]
   (reduce (fn [acc repo]
@@ -246,181 +144,21 @@
           {}
           (:dag/repos dag)))
 
-;------------------------------------------------------------------------------ Layer 0.7
-;; Validation functions
-
-(defn validate-dag-impl
-  "Validate DAG structure. Returns {:valid? bool :errors [...]}"
-  [dag]
-  (let [repo-name-set (repo-names dag)
-        errors (atom [])]
-    ;; Check for duplicate repo names
-    (let [names (map :repo/name (:dag/repos dag))
-          freqs (frequencies names)
-          dups (filterv #(> (val %) 1) freqs)]
-      (doseq [[dup-name dup-count] dups]
-        (swap! errors conj {:type :duplicate-repo
-                            :message (str "Duplicate repo name: " dup-name " (appears " dup-count " times)")
-                            :data {:repo-name dup-name :count dup-count}})))
-
-    ;; Check for edges referencing missing repos
-    (doseq [edge (:dag/edges dag)]
-      (let [from-repo (:edge/from edge)
-            to-repo (:edge/to edge)]
-        (when-not (contains? repo-name-set from-repo)
-          (swap! errors conj {:type :missing-repo
-                              :message (str "Edge references missing repo: " from-repo)
-                              :data {:edge-from from-repo :edge-to to-repo}}))
-        (when-not (contains? repo-name-set to-repo)
-          (swap! errors conj {:type :missing-repo
-                              :message (str "Edge references missing repo: " to-repo)
-                              :data {:edge-from from-repo :edge-to to-repo}}))))
-
-    ;; Check for self-loops
-    (doseq [edge (:dag/edges dag)]
-      (let [from-repo (:edge/from edge)
-            to-repo (:edge/to edge)]
-        (when (= from-repo to-repo)
-          (swap! errors conj {:type :self-loop
-                              :message (str "Self-loop detected: " from-repo " -> " to-repo)
-                              :data {:repo from-repo}}))))
-
-    ;; Check for cycles
-    (let [result (topo-sort dag)]
-      (when-not (:success result)
-        (swap! errors conj {:type :cycle
-                            :message (str "Cycle detected involving repos: "
-                                          (str/join ", " (:cycle-nodes result)))
-                            :data {:cycle-nodes (:cycle-nodes result)}})))
-
-    {:valid? (empty? @errors)
-     :errors @errors}))
-
 ;------------------------------------------------------------------------------ Layer 0.8
 ;; Anomaly-returning shape helpers
 ;;
 ;; These are private store-shaped helpers; they consume the manager's
 ;; mutable atom directly so the protocol method bodies stay thin and
 ;; the anomaly-returning siblings have a single, shared implementation.
-
-(defn- dag-not-found-anomaly
+(defn- ^{:stratum 0} dag-not-found-anomaly
   "Construct the canonical `:not-found` anomaly for a missing DAG."
   [dag-id]
   (anomaly/anomaly :not-found
                    "DAG not found"
                    {:dag-id dag-id}))
 
-(defn- add-repo-impl
-  "Anomaly-returning add-repo. `store` is the manager's atom. Returns the
-   updated DAG on success, or an anomaly on missing DAG (`:not-found`),
-   schema-invalid `repo-config` (`:invalid-input`), or duplicate repo name
-   (`:conflict`)."
-  [store dag-id repo-config]
-  (if-let [dag (get @store dag-id)]
-    (let [node-or-anomaly (make-repo-node-anomaly repo-config)]
-      (if (anomaly/anomaly? node-or-anomaly)
-        node-or-anomaly
-        (let [rname (:repo/name node-or-anomaly)]
-          (if (find-repo-by-name dag rname)
-            (anomaly/anomaly :conflict
-                             "Repo already exists"
-                             {:dag-id dag-id :repo-name rname})
-            (let [updated (update dag :dag/repos conj node-or-anomaly)]
-              (swap! store assoc dag-id updated)
-              updated)))))
-    (dag-not-found-anomaly dag-id)))
-
-(defn- remove-repo-impl
-  "Anomaly-returning remove-repo. Returns the updated DAG on success, or a
-   `:not-found` anomaly if the DAG does not exist."
-  [store dag-id repo-name]
-  (if-let [dag (get @store dag-id)]
-    (let [updated-repos (filterv #(not= repo-name (:repo/name %)) (:dag/repos dag))
-          updated-edges (filterv #(and (not= repo-name (:edge/from %))
-                                       (not= repo-name (:edge/to %)))
-                                 (:dag/edges dag))
-          updated (assoc dag
-                         :dag/repos updated-repos
-                         :dag/edges updated-edges)]
-      (swap! store assoc dag-id updated)
-      updated)
-    (dag-not-found-anomaly dag-id)))
-
-(defn- add-edge-impl
-  "Anomaly-returning add-edge. Returns the updated DAG on success, or an
-   anomaly classifying the failure (:not-found, :invalid-input, or :conflict)."
-  [store dag-id from-repo to-repo constraint merge-ordering]
-  (if-let [dag (get @store dag-id)]
-    (let [repo-name-set (repo-names dag)]
-      (cond
-        (not (contains? repo-name-set from-repo))
-        (anomaly/anomaly :not-found
-                         "From repo not found in DAG"
-                         {:dag-id dag-id :repo-name from-repo})
-
-        (not (contains? repo-name-set to-repo))
-        (anomaly/anomaly :not-found
-                         "To repo not found in DAG"
-                         {:dag-id dag-id :repo-name to-repo})
-
-        (= from-repo to-repo)
-        (anomaly/anomaly :invalid-input
-                         "Self-loop not allowed"
-                         {:dag-id dag-id :repo-name from-repo})
-
-        (find-edge dag from-repo to-repo)
-        (anomaly/anomaly :conflict
-                         "Edge already exists"
-                         {:dag-id dag-id :from from-repo :to to-repo})
-
-        :else
-        (let [edge-or-anomaly (make-repo-edge-anomaly
-                               {:edge/from from-repo
-                                :edge/to to-repo
-                                :edge/constraint constraint
-                                :edge/merge-ordering merge-ordering})]
-          (if (anomaly/anomaly? edge-or-anomaly)
-            edge-or-anomaly
-            (let [updated (update dag :dag/edges conj edge-or-anomaly)
-                  result (topo-sort updated)]
-              (if (:success result)
-                (do
-                  (swap! store assoc dag-id updated)
-                  updated)
-                (anomaly/anomaly :conflict
-                                 "Adding edge would create cycle"
-                                 {:dag-id dag-id
-                                  :from from-repo
-                                  :to to-repo
-                                  :cycle-nodes (:cycle-nodes result)})))))))
-    (dag-not-found-anomaly dag-id)))
-
-(defn- remove-edge-impl
-  "Anomaly-returning remove-edge. Returns the updated DAG on success, or a
-   `:not-found` anomaly if the DAG does not exist."
-  [store dag-id from-repo to-repo]
-  (if-let [dag (get @store dag-id)]
-    (let [updated-edges (filterv #(not (and (= from-repo (:edge/from %))
-                                            (= to-repo (:edge/to %))))
-                                 (:dag/edges dag))
-          updated (assoc dag :dag/edges updated-edges)]
-      (swap! store assoc dag-id updated)
-      updated)
-    (dag-not-found-anomaly dag-id)))
-
-(defn- with-dag-or-anomaly
-  "Look up `dag-id` in `store`; on hit, apply `f` to the DAG and return its
-   result. On miss, return a `:not-found` anomaly. Shared helper for the
-   read-only protocol methods."
-  [store dag-id f]
-  (if-let [dag (get @store dag-id)]
-    (f dag)
-    (dag-not-found-anomaly dag-id)))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; Protocol definition
-
-(defprotocol RepoDagManager
+(defprotocol ^{:stratum 0} RepoDagManager
   "Protocol for managing repository dependency graphs."
 
   ;; CRUD operations
@@ -491,10 +229,280 @@
   (validate-dag-anomaly [this dag-id]
     "Explicit implementation name used by `validate-dag`."))
 
-;------------------------------------------------------------------------------ Layer 2
-;; In-memory implementation
+(defn ^{:stratum 0} get-all-dags
+  "Get all DAGs from the manager's store."
+  [manager]
+  (vals @(:store manager)))
 
-(defrecord InMemoryDagManager [store]
+(defn ^{:stratum 0} reset-manager!
+  "Reset the manager's store. Useful for testing."
+  [manager]
+  (reset! (:store manager) {}))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} validate-schema
+  "Validate a value against a schema, returning the value or an anomaly map.
+
+   Kept as a stable alias for [[validate-schema-anomaly]]."
+  [schema-def value]
+  (validate-schema-anomaly schema-def value))
+
+(defn ^{:stratum 1} make-repo-node-anomaly
+  "Build a repo node from `repo-config`, returning the validated node or
+   an `:invalid-input` anomaly when schema validation rejects it (e.g.
+   missing `:repo/type`, malformed `:repo/url`, …).
+
+   Prefer this over [[make-repo-node]] in non-boundary code."
+  [repo-config]
+  (validate-schema-anomaly schema/RepoNode (build-repo-node repo-config)))
+
+(defn ^{:stratum 1} make-repo-edge-anomaly
+  "Build a repo edge from `edge-config`, returning the validated edge or
+   an `:invalid-input` anomaly when schema validation rejects it (unknown
+   `:edge/constraint`, unknown `:edge/merge-ordering`, missing endpoints, …).
+
+   Prefer this over [[make-repo-edge]] in non-boundary code."
+  [edge-config]
+  (validate-schema-anomaly schema/RepoEdge (build-repo-edge edge-config)))
+
+(defn ^{:stratum 1} find-cycle-nodes
+  "Find nodes involved in a cycle. Returns nil if no cycle."
+  [dag]
+  (let [result (topo-sort dag)]
+    (when-not (:success result)
+      (:cycle-nodes result))))
+
+(defn ^{:stratum 1} downstream-repos
+  "Get all repos that depend on the given repo (transitive closure)."
+  [dag repo-name]
+  (let [adj (build-adjacency dag)]
+    (loop [to-visit #{repo-name}
+           visited #{}]
+      (if (empty? to-visit)
+        (disj visited repo-name) ; Don't include the starting repo
+        (let [current (first to-visit)
+              neighbors (get adj current #{})]
+          (recur (into (disj to-visit current)
+                       (set/difference neighbors visited))
+                 (conj visited current)))))))
+
+(defn ^{:stratum 1} upstream-repos-impl
+  "Get all repos that this repo depends on (transitive closure)."
+  [dag repo-name]
+  (let [rev-adj (build-reverse-adjacency dag)]
+    (loop [to-visit #{repo-name}
+           visited #{}]
+      (if (empty? to-visit)
+        (disj visited repo-name) ; Don't include the starting repo
+        (let [current (first to-visit)
+              neighbors (get rev-adj current #{})]
+          (recur (into (disj to-visit current)
+                       (set/difference neighbors visited))
+                 (conj visited current)))))))
+
+(defn ^{:stratum 1} compute-merge-order
+  "Given a set of repo names, compute valid merge order based on DAG topology.
+   Only considers repos in the pr-set."
+  [dag pr-set]
+  (let [pr-names (set pr-set)
+        ;; Filter edges to only those between repos in pr-set
+        relevant-edges (filterv (fn [edge]
+                                  (and (contains? pr-names (:edge/from edge))
+                                       (contains? pr-names (:edge/to edge))))
+                                (:dag/edges dag))
+        ;; Create sub-DAG
+        sub-dag (assoc dag
+                       :dag/repos (filterv #(contains? pr-names (:repo/name %))
+                                           (:dag/repos dag))
+                       :dag/edges relevant-edges)]
+    (topo-sort sub-dag)))
+
+;; Validation functions
+(defn ^{:stratum 1} validate-dag-impl
+  "Validate DAG structure. Returns {:valid? bool :errors [...]}"
+  [dag]
+  (let [repo-name-set (repo-names dag)
+        errors (atom [])]
+    ;; Check for duplicate repo names
+    (let [names (map :repo/name (:dag/repos dag))
+          freqs (frequencies names)
+          dups (filterv #(> (val %) 1) freqs)]
+      (doseq [[dup-name dup-count] dups]
+        (swap! errors conj {:type :duplicate-repo
+                            :message (str "Duplicate repo name: " dup-name " (appears " dup-count " times)")
+                            :data {:repo-name dup-name :count dup-count}})))
+
+    ;; Check for edges referencing missing repos
+    (doseq [edge (:dag/edges dag)]
+      (let [from-repo (:edge/from edge)
+            to-repo (:edge/to edge)]
+        (when-not (contains? repo-name-set from-repo)
+          (swap! errors conj {:type :missing-repo
+                              :message (str "Edge references missing repo: " from-repo)
+                              :data {:edge-from from-repo :edge-to to-repo}}))
+        (when-not (contains? repo-name-set to-repo)
+          (swap! errors conj {:type :missing-repo
+                              :message (str "Edge references missing repo: " to-repo)
+                              :data {:edge-from from-repo :edge-to to-repo}}))))
+
+    ;; Check for self-loops
+    (doseq [edge (:dag/edges dag)]
+      (let [from-repo (:edge/from edge)
+            to-repo (:edge/to edge)]
+        (when (= from-repo to-repo)
+          (swap! errors conj {:type :self-loop
+                              :message (str "Self-loop detected: " from-repo " -> " to-repo)
+                              :data {:repo from-repo}}))))
+
+    ;; Check for cycles
+    (let [result (topo-sort dag)]
+      (when-not (:success result)
+        (swap! errors conj {:type :cycle
+                            :message (str "Cycle detected involving repos: "
+                                          (str/join ", " (:cycle-nodes result)))
+                            :data {:cycle-nodes (:cycle-nodes result)}})))
+
+    {:valid? (empty? @errors)
+     :errors @errors}))
+
+(defn- ^{:stratum 1} remove-repo-impl
+  "Anomaly-returning remove-repo. Returns the updated DAG on success, or a
+   `:not-found` anomaly if the DAG does not exist."
+  [store dag-id repo-name]
+  (if-let [dag (get @store dag-id)]
+    (let [updated-repos (filterv #(not= repo-name (:repo/name %)) (:dag/repos dag))
+          updated-edges (filterv #(and (not= repo-name (:edge/from %))
+                                       (not= repo-name (:edge/to %)))
+                                 (:dag/edges dag))
+          updated (assoc dag
+                         :dag/repos updated-repos
+                         :dag/edges updated-edges)]
+      (swap! store assoc dag-id updated)
+      updated)
+    (dag-not-found-anomaly dag-id)))
+
+(defn- ^{:stratum 1} remove-edge-impl
+  "Anomaly-returning remove-edge. Returns the updated DAG on success, or a
+   `:not-found` anomaly if the DAG does not exist."
+  [store dag-id from-repo to-repo]
+  (if-let [dag (get @store dag-id)]
+    (let [updated-edges (filterv #(not (and (= from-repo (:edge/from %))
+                                            (= to-repo (:edge/to %))))
+                                 (:dag/edges dag))
+          updated (assoc dag :dag/edges updated-edges)]
+      (swap! store assoc dag-id updated)
+      updated)
+    (dag-not-found-anomaly dag-id)))
+
+(defn- ^{:stratum 1} with-dag-or-anomaly
+  "Look up `dag-id` in `store`; on hit, apply `f` to the DAG and return its
+   result. On miss, return a `:not-found` anomaly. Shared helper for the
+   read-only protocol methods."
+  [store dag-id f]
+  (if-let [dag (get @store dag-id)]
+    (f dag)
+    (dag-not-found-anomaly dag-id)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} make-repo-node
+  "Create a repo node with layer inference if not specified.
+
+   Returns an anomaly map when schema validation fails."
+  [repo-config]
+  (validate-schema schema/RepoNode (build-repo-node repo-config)))
+
+(defn ^{:stratum 2} make-repo-edge
+  "Create a repo edge with default merge ordering.
+
+   Returns an anomaly map when schema validation fails."
+  [edge-config]
+  (validate-schema schema/RepoEdge (build-repo-edge edge-config)))
+
+(defn ^{:stratum 2} make-dag
+  "Create a new empty DAG, or return an anomaly map if validation fails."
+  [id dag-name description]
+  (let [dag (cond-> {:dag/id id
+                     :dag/name dag-name
+                     :dag/repos []
+                     :dag/edges []}
+              description (assoc :dag/description description))]
+    (validate-schema schema/RepoDag dag)))
+
+(defn- ^{:stratum 2} add-repo-impl
+  "Anomaly-returning add-repo. `store` is the manager's atom. Returns the
+   updated DAG on success, or an anomaly on missing DAG (`:not-found`),
+   schema-invalid `repo-config` (`:invalid-input`), or duplicate repo name
+   (`:conflict`)."
+  [store dag-id repo-config]
+  (if-let [dag (get @store dag-id)]
+    (let [node-or-anomaly (make-repo-node-anomaly repo-config)]
+      (if (anomaly/anomaly? node-or-anomaly)
+        node-or-anomaly
+        (let [rname (:repo/name node-or-anomaly)]
+          (if (find-repo-by-name dag rname)
+            (anomaly/anomaly :conflict
+                             "Repo already exists"
+                             {:dag-id dag-id :repo-name rname})
+            (let [updated (update dag :dag/repos conj node-or-anomaly)]
+              (swap! store assoc dag-id updated)
+              updated)))))
+    (dag-not-found-anomaly dag-id)))
+
+(defn- ^{:stratum 2} add-edge-impl
+  "Anomaly-returning add-edge. Returns the updated DAG on success, or an
+   anomaly classifying the failure (:not-found, :invalid-input, or :conflict)."
+  [store dag-id from-repo to-repo constraint merge-ordering]
+  (if-let [dag (get @store dag-id)]
+    (let [repo-name-set (repo-names dag)]
+      (cond
+        (not (contains? repo-name-set from-repo))
+        (anomaly/anomaly :not-found
+                         "From repo not found in DAG"
+                         {:dag-id dag-id :repo-name from-repo})
+
+        (not (contains? repo-name-set to-repo))
+        (anomaly/anomaly :not-found
+                         "To repo not found in DAG"
+                         {:dag-id dag-id :repo-name to-repo})
+
+        (= from-repo to-repo)
+        (anomaly/anomaly :invalid-input
+                         "Self-loop not allowed"
+                         {:dag-id dag-id :repo-name from-repo})
+
+        (find-edge dag from-repo to-repo)
+        (anomaly/anomaly :conflict
+                         "Edge already exists"
+                         {:dag-id dag-id :from from-repo :to to-repo})
+
+        :else
+        (let [edge-or-anomaly (make-repo-edge-anomaly
+                               {:edge/from from-repo
+                                :edge/to to-repo
+                                :edge/constraint constraint
+                                :edge/merge-ordering merge-ordering})]
+          (if (anomaly/anomaly? edge-or-anomaly)
+            edge-or-anomaly
+            (let [updated (update dag :dag/edges conj edge-or-anomaly)
+                  result (topo-sort updated)]
+              (if (:success result)
+                (do
+                  (swap! store assoc dag-id updated)
+                  updated)
+                (anomaly/anomaly :conflict
+                                 "Adding edge would create cycle"
+                                 {:dag-id dag-id
+                                  :from from-repo
+                                  :to to-repo
+                                  :cycle-nodes (:cycle-nodes result)})))))))
+    (dag-not-found-anomaly dag-id)))
+
+;------------------------------------------------------------------------------ Layer 3
+
+;; In-memory implementation
+(defrecord ^{:stratum 3} InMemoryDagManager [store]
   RepoDagManager
 
   (create-dag [_this dag-name description]
@@ -560,23 +568,13 @@
   (validate-dag [this dag-id]
     (validate-dag-anomaly this dag-id)))
 
-;------------------------------------------------------------------------------ Layer 3
-;; Factory functions
+;------------------------------------------------------------------------------ Layer 4
 
-(defn create-manager
+;; Factory functions
+(defn ^{:stratum 4} create-manager
   "Create a new in-memory DAG manager."
   []
   (->InMemoryDagManager (atom {})))
-
-(defn get-all-dags
-  "Get all DAGs from the manager's store."
-  [manager]
-  (vals @(:store manager)))
-
-(defn reset-manager!
-  "Reset the manager's store. Useful for testing."
-  [manager]
-  (reset! (:store manager) {}))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/repo-dag/src/ai/miniforge/repo_dag/interface.clj
+++ b/components/repo-dag/src/ai/miniforge/repo_dag/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.repo-dag.interface
   "Public API for the repo-dag component.
    Provides DAG CRUD, topological sorting, and dependency graph queries."
@@ -24,75 +23,84 @@
    [ai.miniforge.repo-dag.schema :as schema]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Schema re-exports
 
-(def RepoNode
+;; Schema re-exports
+(def ^{:stratum 0} RepoNode
   "Malli `[:map ...]` schema for a repository node: its URL, name, type,
    layer, default branch, and optional org and watch-config."
   schema/RepoNode)
-(def RepoEdge
+
+(def ^{:stratum 0} RepoEdge
   "Malli `[:map ...]` schema for a directed dependency edge between two repos
    (`:edge/from` -> `:edge/to`) carrying a constraint, merge-ordering, and
    optional validation config."
   schema/RepoEdge)
-(def RepoDag
+
+(def ^{:stratum 0} RepoDag
   "Malli `[:map ...]` schema for a complete repository dependency graph:
    id, name, optional description, vectors of repos and edges, and optional
    computed topo-order and layers."
   schema/RepoDag)
-(def WatchConfig
+
+(def ^{:stratum 0} WatchConfig
   "Malli `[:map ...]` schema for change-watch configuration: optional
    `:labels-include`/`:labels-exclude` and `:paths-include`/`:paths-exclude`
    vectors of strings."
   schema/WatchConfig)
-(def EdgeValidation
+
+(def ^{:stratum 0} EdgeValidation
   "Malli `[:map ...]` schema for per-edge validation gates: require-ci-pass?,
    require-plan-clean?, and an optional custom-gate keyword."
   schema/EdgeValidation)
 
 ;; Enum value sets for programmatic access
-(def repo-types
+(def ^{:stratum 0} repo-types
   "Vector of the repository type keywords valid in the DAG
    (e.g. :terraform-module, :kubernetes, :library)."
   schema/repo-types)
-(def repo-layers
+
+(def ^{:stratum 0} repo-layers
   "Vector of the logical layer keywords for repositories
    (:foundations :infrastructure :platform :application :adapters)."
   schema/repo-layers)
-(def edge-constraints
+
+(def ^{:stratum 0} edge-constraints
   "Vector of the dependency-edge constraint keywords
    (e.g. :module-before-live, :schema-before-impl)."
   schema/edge-constraints)
-(def merge-orderings
+
+(def ^{:stratum 0} merge-orderings
   "Vector of the merge-ordering strategy keywords
    (:sequential :parallel-ok :same-pr-train)."
   schema/merge-orderings)
-(def type->layer
+
+(def ^{:stratum 0} type->layer
   "Map of repository type keyword to its default layer keyword."
   schema/type->layer)
 
 ;; Validation helpers
-(def valid-repo-node?
+(def ^{:stratum 0} valid-repo-node?
   "Predicate: returns true if the value conforms to the RepoNode schema,
    false otherwise."
   schema/valid-repo-node?)
-(def valid-repo-edge?
+
+(def ^{:stratum 0} valid-repo-edge?
   "Predicate: returns true if the value conforms to the RepoEdge schema,
    false otherwise."
   schema/valid-repo-edge?)
-(def valid-repo-dag?
+
+(def ^{:stratum 0} valid-repo-dag?
   "Predicate: returns true if the value conforms to the RepoDag schema,
    false otherwise."
   schema/valid-repo-dag?)
-(def infer-layer
+
+(def ^{:stratum 0} infer-layer
   "Given a repository type keyword, returns its default layer keyword,
    falling back to :application for unknown types."
   schema/infer-layer)
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Manager lifecycle
-
-(defn create-manager
+(defn ^{:stratum 0} create-manager
   "Create a new in-memory DAG manager.
 
    Returns a manager instance that can be used with all other functions.
@@ -102,7 +110,7 @@
   []
   (core/create-manager))
 
-(defn reset-manager!
+(defn ^{:stratum 0} reset-manager!
   "Reset the manager's store to empty. Useful for testing.
 
    Arguments:
@@ -110,7 +118,7 @@
   [manager]
   (core/reset-manager! manager))
 
-(defn get-all-dags
+(defn ^{:stratum 0} get-all-dags
   "Get all DAGs from the manager's store.
 
    Arguments:
@@ -120,10 +128,8 @@
   [manager]
   (core/get-all-dags manager))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; DAG CRUD operations
-
-(defn create-dag
+(defn ^{:stratum 0} create-dag
   "Create a new empty DAG.
 
    Arguments:
@@ -138,7 +144,7 @@
   ([manager dag-name] (core/create-dag manager dag-name nil))
   ([manager dag-name description] (core/create-dag manager dag-name description)))
 
-(defn get-dag
+(defn ^{:stratum 0} get-dag
   "Retrieve a DAG by ID.
 
    Arguments:
@@ -149,7 +155,7 @@
   [manager dag-id]
   (core/get-dag manager dag-id))
 
-(defn add-repo
+(defn ^{:stratum 0} add-repo
   "Add a repository node to the DAG.
 
    Arguments:
@@ -168,7 +174,7 @@
   [manager dag-id repo-config]
   (core/add-repo manager dag-id repo-config))
 
-(defn add-repo-anomaly
+(defn ^{:stratum 0} add-repo-anomaly
   "Anomaly-returning variant of [[add-repo]].
 
    Returns the updated DAG on success, or an anomaly map on failure:
@@ -182,7 +188,7 @@
   [manager dag-id repo-config]
   (core/add-repo-anomaly manager dag-id repo-config))
 
-(defn remove-repo
+(defn ^{:stratum 0} remove-repo
   "Remove a repository from the DAG.
 
    Arguments:
@@ -195,7 +201,7 @@
   [manager dag-id repo-name]
   (core/remove-repo manager dag-id repo-name))
 
-(defn remove-repo-anomaly
+(defn ^{:stratum 0} remove-repo-anomaly
   "Anomaly-returning variant of [[remove-repo]].
 
    Returns the updated DAG on success, or a `:not-found` anomaly when the
@@ -203,7 +209,7 @@
   [manager dag-id repo-name]
   (core/remove-repo-anomaly manager dag-id repo-name))
 
-(defn add-edge
+(defn ^{:stratum 0} add-edge
   "Add a dependency edge between repos.
 
    Arguments:
@@ -225,7 +231,7 @@
   [manager dag-id from-repo to-repo constraint merge-ordering]
   (core/add-edge manager dag-id from-repo to-repo constraint merge-ordering))
 
-(defn add-edge-anomaly
+(defn ^{:stratum 0} add-edge-anomaly
   "Anomaly-returning variant of [[add-edge]].
 
    Returns the updated DAG on success, or an anomaly map on failure:
@@ -241,7 +247,7 @@
   [manager dag-id from-repo to-repo constraint merge-ordering]
   (core/add-edge-anomaly manager dag-id from-repo to-repo constraint merge-ordering))
 
-(defn remove-edge
+(defn ^{:stratum 0} remove-edge
   "Remove a dependency edge.
 
    Arguments:
@@ -254,7 +260,7 @@
   [manager dag-id from-repo to-repo]
   (core/remove-edge manager dag-id from-repo to-repo))
 
-(defn remove-edge-anomaly
+(defn ^{:stratum 0} remove-edge-anomaly
   "Anomaly-returning variant of [[remove-edge]].
 
    Returns the updated DAG on success, or a `:not-found` anomaly when the
@@ -262,10 +268,8 @@
   [manager dag-id from-repo to-repo]
   (core/remove-edge-anomaly manager dag-id from-repo to-repo))
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Query operations
-
-(defn compute-topo-order
+(defn ^{:stratum 0} compute-topo-order
   "Compute topological sort of repos in the DAG.
 
    Arguments:
@@ -283,7 +287,7 @@
   [manager dag-id]
   (core/compute-topo-order manager dag-id))
 
-(defn compute-topo-order-anomaly
+(defn ^{:stratum 0} compute-topo-order-anomaly
   "Explicit implementation name for [[compute-topo-order]].
 
    Returns the topo-sort result map on success, or a `:not-found` anomaly
@@ -291,7 +295,7 @@
   [manager dag-id]
   (core/compute-topo-order-anomaly manager dag-id))
 
-(defn affected-repos
+(defn ^{:stratum 0} affected-repos
   "Given a changed repo, return all downstream repos that may be affected.
 
    Arguments:
@@ -308,7 +312,7 @@
   [manager dag-id changed-repo]
   (core/affected-repos manager dag-id changed-repo))
 
-(defn affected-repos-anomaly
+(defn ^{:stratum 0} affected-repos-anomaly
   "Explicit implementation name for [[affected-repos]].
 
    Returns the set of downstream repo names on success, or a `:not-found`
@@ -316,7 +320,7 @@
   [manager dag-id changed-repo]
   (core/affected-repos-anomaly manager dag-id changed-repo))
 
-(defn upstream-repos
+(defn ^{:stratum 0} upstream-repos
   "Return all repos that the given repo depends on.
 
    Arguments:
@@ -333,7 +337,7 @@
   [manager dag-id repo-name]
   (core/upstream-repos manager dag-id repo-name))
 
-(defn upstream-repos-anomaly
+(defn ^{:stratum 0} upstream-repos-anomaly
   "Explicit implementation name for [[upstream-repos]].
 
    Returns the set of upstream repo names on success, or a `:not-found`
@@ -341,7 +345,7 @@
   [manager dag-id repo-name]
   (core/upstream-repos-anomaly manager dag-id repo-name))
 
-(defn merge-order
+(defn ^{:stratum 0} merge-order
   "Given a set of repos with PRs, compute valid merge order.
 
    Arguments:
@@ -363,7 +367,7 @@
   [manager dag-id pr-set]
   (core/merge-order manager dag-id pr-set))
 
-(defn merge-order-anomaly
+(defn ^{:stratum 0} merge-order-anomaly
   "Explicit implementation name for [[merge-order]].
 
    Returns the merge-order result map on success, or a `:not-found`
@@ -371,10 +375,8 @@
   [manager dag-id pr-set]
   (core/merge-order-anomaly manager dag-id pr-set))
 
-;------------------------------------------------------------------------------ Layer 4
 ;; Validation
-
-(defn validate-dag
+(defn ^{:stratum 0} validate-dag
   "Check DAG for structural validity.
 
    Arguments:
@@ -399,7 +401,7 @@
   [manager dag-id]
   (core/validate-dag manager dag-id))
 
-(defn validate-dag-anomaly
+(defn ^{:stratum 0} validate-dag-anomaly
   "Explicit implementation name for [[validate-dag]].
 
    Returns the validation result map on success, or a `:not-found` anomaly
@@ -407,10 +409,8 @@
   [manager dag-id]
   (core/validate-dag-anomaly manager dag-id))
 
-;------------------------------------------------------------------------------ Layer 5
 ;; Pure functions (no manager required)
-
-(defn topo-sort
+(defn ^{:stratum 0} topo-sort
   "Perform topological sort on a DAG directly.
 
    Arguments:
@@ -424,7 +424,7 @@
   [dag]
   (core/topo-sort dag))
 
-(defn find-cycle-nodes
+(defn ^{:stratum 0} find-cycle-nodes
   "Find nodes involved in a cycle.
 
    Arguments:
@@ -434,7 +434,7 @@
   [dag]
   (core/find-cycle-nodes dag))
 
-(defn compute-layers
+(defn ^{:stratum 0} compute-layers
   "Group repos by their layer.
 
    Arguments:

--- a/components/repo-dag/src/ai/miniforge/repo_dag/schema.clj
+++ b/components/repo-dag/src/ai/miniforge/repo_dag/schema.clj
@@ -15,38 +15,39 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.repo-dag.schema
   "Malli schemas for the repo-dag component.
-   Layer 0: Enums and base types
-   Layer 1: RepoNode and RepoEdge schemas
-   Layer 2: RepoDag composite schema"
+   Layer 0: Enums, base types, and standalone map schemas
+   Layer 1: Registry and infer-layer (depend on the Layer 0 enums)
+   Layer 2: RepoNode and RepoEdge schemas (depend on the registry)
+   Layer 3: RepoDag composite schema and node/edge validators
+   Layer 4: valid-repo-dag? (depends on RepoDag)"
   (:require
    [malli.core :as m]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Enums and base types
 
-(def repo-types
+;; Enums and base types
+(def ^{:stratum 0} repo-types
   [:terraform-module :terraform-live :kubernetes
    :argocd :application :library :documentation])
 
-(def repo-layers
+(def ^{:stratum 0} repo-layers
   [:foundations :infrastructure :platform :application :adapters])
 
-(def edge-constraints
+(def ^{:stratum 0} edge-constraints
   [:module-before-live      ; TF modules before live infra
    :infra-before-k8s        ; Infrastructure before K8s manifests
    :k8s-before-argocd       ; Manifests before ArgoCD apps
    :library-before-consumer ; Libraries before consumers
-   :schema-before-impl])    ; Schema changes before implementations
+   :schema-before-impl])  ; Schema changes before implementations
 
-(def merge-orderings
+(def ^{:stratum 0} merge-orderings
   [:sequential    ; Must merge in order
    :parallel-ok   ; Can merge in parallel if both ready
-   :same-pr-train]) ; Must be in same PR train
+   :same-pr-train])  ; Must be in same PR train
 
-(def type->layer
+(def ^{:stratum 0} type->layer
   {:terraform-module :foundations
    :terraform-live   :infrastructure
    :kubernetes       :platform
@@ -55,7 +56,41 @@
    :library          :foundations
    :documentation    :adapters})
 
-(def registry
+;; RepoNode and RepoEdge schemas
+(def ^{:stratum 0} WatchConfig
+  [:map
+   [:labels-include {:optional true} [:vector string?]]
+   [:labels-exclude {:optional true} [:vector string?]]
+   [:paths-include {:optional true} [:vector string?]]
+   [:paths-exclude {:optional true} [:vector string?]]])
+
+(def ^{:stratum 0} EdgeValidation
+  [:map
+   [:require-ci-pass? {:default true} boolean?]
+   [:require-plan-clean? {:default false} boolean?]
+   [:custom-gate {:optional true} keyword?]])
+
+(def ^{:stratum 0} TopoSortResult
+  "Result of a topological sort operation."
+  [:map
+   [:success boolean?]
+   [:order {:optional true} [:vector string?]]
+   [:error {:optional true} [:enum :cycle-detected :invalid-dag]]
+   [:cycle-nodes {:optional true} [:set string?]]])
+
+(def ^{:stratum 0} ValidationResult
+  "Result of DAG validation."
+  [:map
+   [:valid? boolean?]
+   [:errors [:vector
+             [:map
+              [:type [:enum :cycle :orphan-edge :missing-repo :duplicate-repo :self-loop]]
+              [:message string?]
+              [:data {:optional true} any?]]]]])
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} registry
   "Malli registry for repo-dag schema types."
   {;; Identifiers
    :dag/id          uuid?
@@ -70,17 +105,13 @@
    :edge/constraint (into [:enum] edge-constraints)
    :edge/merge-ordering (into [:enum] merge-orderings)})
 
-;------------------------------------------------------------------------------ Layer 1
-;; RepoNode and RepoEdge schemas
+(defn ^{:stratum 1} infer-layer
+  [repo-type]
+  (get type->layer repo-type :application))
 
-(def WatchConfig
-  [:map
-   [:labels-include {:optional true} [:vector string?]]
-   [:labels-exclude {:optional true} [:vector string?]]
-   [:paths-include {:optional true} [:vector string?]]
-   [:paths-exclude {:optional true} [:vector string?]]])
+;------------------------------------------------------------------------------ Layer 2
 
-(def RepoNode
+(def ^{:stratum 2} RepoNode
   "Repository node in the DAG.
    Represents a single repository with its metadata and configuration."
   [:map {:registry registry}
@@ -92,13 +123,7 @@
    [:repo/default-branch {:default "main"} string?]
    [:repo/watch-config {:optional true} WatchConfig]])
 
-(def EdgeValidation
-  [:map
-   [:require-ci-pass? {:default true} boolean?]
-   [:require-plan-clean? {:default false} boolean?]
-   [:custom-gate {:optional true} keyword?]])
-
-(def RepoEdge
+(def ^{:stratum 2} RepoEdge
   "Dependency edge between repositories.
    Represents a directed relationship from one repo to another."
   [:map {:registry registry}
@@ -108,10 +133,10 @@
    [:edge/merge-ordering :edge/merge-ordering]
    [:edge/validation {:optional true} EdgeValidation]])
 
-;------------------------------------------------------------------------------ Layer 2
-;; RepoDag composite schema
+;------------------------------------------------------------------------------ Layer 3
 
-(def RepoDag
+;; RepoDag composite schema
+(def ^{:stratum 3} RepoDag
   "Complete repository dependency graph.
    Contains all nodes, edges, and computed ordering information."
   [:map {:registry registry}
@@ -124,42 +149,20 @@
    [:dag/topo-order {:optional true} [:vector :repo/name]]
    [:dag/layers {:optional true} [:map-of keyword? [:vector :repo/name]]]])
 
-(def TopoSortResult
-  "Result of a topological sort operation."
-  [:map
-   [:success boolean?]
-   [:order {:optional true} [:vector string?]]
-   [:error {:optional true} [:enum :cycle-detected :invalid-dag]]
-   [:cycle-nodes {:optional true} [:set string?]]])
-
-(def ValidationResult
-  "Result of DAG validation."
-  [:map
-   [:valid? boolean?]
-   [:errors [:vector
-             [:map
-              [:type [:enum :cycle :orphan-edge :missing-repo :duplicate-repo :self-loop]]
-              [:message string?]
-              [:data {:optional true} any?]]]]])
-
-;------------------------------------------------------------------------------ Layer 3
 ;; Validation helpers
-
-(defn valid-repo-node?
+(defn ^{:stratum 3} valid-repo-node?
   [value]
   (m/validate RepoNode value))
 
-(defn valid-repo-edge?
+(defn ^{:stratum 3} valid-repo-edge?
   [value]
   (m/validate RepoEdge value))
 
-(defn valid-repo-dag?
+;------------------------------------------------------------------------------ Layer 4
+
+(defn ^{:stratum 4} valid-repo-dag?
   [value]
   (m/validate RepoDag value))
-
-(defn infer-layer
-  [repo-type]
-  (get type->layer repo-type :application))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/repo-dag/src/ai/miniforge/repo_dag/schema.clj
+++ b/components/repo-dag/src/ai/miniforge/repo_dag/schema.clj
@@ -56,7 +56,7 @@
    :library          :foundations
    :documentation    :adapters})
 
-;; RepoNode and RepoEdge schemas
+;; Standalone map schemas (no dependency on the registry or each other)
 (def ^{:stratum 0} WatchConfig
   [:map
    [:labels-include {:optional true} [:vector string?]]

--- a/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/add_edge_test.clj
+++ b/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/add_edge_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.repo-dag.anomaly.add-edge-test
   "Coverage for `dag/add-edge-anomaly` and its stable alias
    `dag/add-edge`. Seven failure modes:
@@ -32,10 +31,13 @@
             [ai.miniforge.repo-dag.interface :as dag]
             [ai.miniforge.repo-dag.schema :as schema]))
 
-(def ^:dynamic *manager* nil)
-(def ^:dynamic *dag-id* nil)
+;------------------------------------------------------------------------------ Layer 0
 
-(defn manager-and-dag-fixture [f]
+(def ^{:stratum 0} ^:dynamic *manager* nil)
+
+(def ^{:stratum 0} ^:dynamic *dag-id* nil)
+
+(defn ^{:stratum 0} manager-and-dag-fixture [f]
   (binding [*manager* (dag/create-manager)]
     (let [d (dag/create-dag *manager* "test-dag")]
       (dag/add-repo-anomaly *manager* (:dag/id d)
@@ -49,11 +51,10 @@
       (binding [*dag-id* (:dag/id d)]
         (f)))))
 
-(use-fixtures :each manager-and-dag-fixture)
+;------------------------------------------------------------------------------ Layer 1
 
 ;------------------------------------------------------------------------------ Happy path
-
-(deftest add-edge-anomaly-returns-updated-dag
+(deftest ^{:stratum 1} add-edge-anomaly-returns-updated-dag
   (testing "successful add returns the updated DAG, not an anomaly"
     (let [result (dag/add-edge-anomaly *manager* *dag-id*
                                        "repo-a" "repo-b"
@@ -62,8 +63,7 @@
       (is (= 1 (count (:dag/edges result)))))))
 
 ;------------------------------------------------------------------------------ Failure: DAG not found
-
-(deftest add-edge-anomaly-not-found-when-dag-missing
+(deftest ^{:stratum 1} add-edge-anomaly-not-found-when-dag-missing
   (testing "missing DAG yields :not-found anomaly"
     (let [missing-id (random-uuid)
           result (dag/add-edge-anomaly *manager* missing-id
@@ -74,8 +74,7 @@
       (is (= missing-id (get-in result [:anomaly/data :dag-id]))))))
 
 ;------------------------------------------------------------------------------ Failure: from-repo not found
-
-(deftest add-edge-anomaly-not-found-when-from-repo-missing
+(deftest ^{:stratum 1} add-edge-anomaly-not-found-when-from-repo-missing
   (testing "missing from-repo yields :not-found anomaly"
     (let [result (dag/add-edge-anomaly *manager* *dag-id*
                                        "ghost" "repo-b"
@@ -85,8 +84,7 @@
       (is (= "ghost" (get-in result [:anomaly/data :repo-name]))))))
 
 ;------------------------------------------------------------------------------ Failure: to-repo not found
-
-(deftest add-edge-anomaly-not-found-when-to-repo-missing
+(deftest ^{:stratum 1} add-edge-anomaly-not-found-when-to-repo-missing
   (testing "missing to-repo yields :not-found anomaly"
     (let [result (dag/add-edge-anomaly *manager* *dag-id*
                                        "repo-a" "ghost"
@@ -96,8 +94,7 @@
       (is (= "ghost" (get-in result [:anomaly/data :repo-name]))))))
 
 ;------------------------------------------------------------------------------ Failure: self-loop
-
-(deftest add-edge-anomaly-invalid-input-on-self-loop
+(deftest ^{:stratum 1} add-edge-anomaly-invalid-input-on-self-loop
   (testing "self-loop yields :invalid-input anomaly — input shape rejected"
     (let [result (dag/add-edge-anomaly *manager* *dag-id*
                                        "repo-a" "repo-a"
@@ -107,8 +104,7 @@
       (is (= "repo-a" (get-in result [:anomaly/data :repo-name]))))))
 
 ;------------------------------------------------------------------------------ Failure: schema-invalid edge payload
-
-(deftest add-edge-anomaly-invalid-input-on-unknown-constraint
+(deftest ^{:stratum 1} add-edge-anomaly-invalid-input-on-unknown-constraint
   (testing "unknown :edge/constraint yields :invalid-input anomaly — schema rejection
             short-circuits via make-repo-edge-anomaly before the edge is appended."
     (let [result (dag/add-edge-anomaly *manager* *dag-id*
@@ -119,7 +115,7 @@
       (is (some? (get-in result [:anomaly/data :errors])))
       (is (= schema/RepoEdge (get-in result [:anomaly/data :schema]))))))
 
-(deftest add-edge-anomaly-invalid-input-on-unknown-merge-ordering
+(deftest ^{:stratum 1} add-edge-anomaly-invalid-input-on-unknown-merge-ordering
   (testing "unknown :edge/merge-ordering yields :invalid-input anomaly"
     (let [result (dag/add-edge-anomaly *manager* *dag-id*
                                        "repo-a" "repo-b"
@@ -128,8 +124,7 @@
       (is (= :invalid-input (:anomaly/type result))))))
 
 ;------------------------------------------------------------------------------ Failure: duplicate edge
-
-(deftest add-edge-anomaly-conflict-on-duplicate
+(deftest ^{:stratum 1} add-edge-anomaly-conflict-on-duplicate
   (testing "duplicate edge yields :conflict anomaly"
     (dag/add-edge-anomaly *manager* *dag-id*
                           "repo-a" "repo-b"
@@ -143,8 +138,7 @@
       (is (= "repo-b" (get-in result [:anomaly/data :to]))))))
 
 ;------------------------------------------------------------------------------ Failure: cycle
-
-(deftest add-edge-anomaly-conflict-on-cycle
+(deftest ^{:stratum 1} add-edge-anomaly-conflict-on-cycle
   (testing "cycle-introducing edge yields :conflict anomaly carrying cycle-nodes"
     (dag/add-edge-anomaly *manager* *dag-id*
                           "repo-a" "repo-b"
@@ -157,8 +151,7 @@
       (is (set? (get-in result [:anomaly/data :cycle-nodes]))))))
 
 ;------------------------------------------------------------------------------ Alias compatibility
-
-(deftest add-edge-returns-anomaly-on-missing-from-repo
+(deftest ^{:stratum 1} add-edge-returns-anomaly-on-missing-from-repo
   (testing "stable alias returns anomaly data on missing from-repo"
     (let [result (dag/add-edge *manager* *dag-id* "ghost" "repo-b"
                                :library-before-consumer :sequential)]
@@ -166,7 +159,7 @@
       (is (= :not-found (:anomaly/type result)))
       (is (= "ghost" (get-in result [:anomaly/data :repo-name]))))))
 
-(deftest add-edge-returns-anomaly-on-self-loop
+(deftest ^{:stratum 1} add-edge-returns-anomaly-on-self-loop
   (testing "stable alias returns anomaly data on self-loop"
     (let [result (dag/add-edge *manager* *dag-id* "repo-a" "repo-a"
                                :library-before-consumer :sequential)]
@@ -174,7 +167,7 @@
       (is (= :invalid-input (:anomaly/type result)))
       (is (= "repo-a" (get-in result [:anomaly/data :repo-name]))))))
 
-(deftest add-edge-returns-anomaly-on-cycle
+(deftest ^{:stratum 1} add-edge-returns-anomaly-on-cycle
   (testing "stable alias returns anomaly data on cycle introduction"
     (dag/add-edge *manager* *dag-id* "repo-a" "repo-b"
                   :library-before-consumer :sequential)
@@ -183,3 +176,5 @@
       (is (anomaly/anomaly? result))
       (is (= :conflict (:anomaly/type result)))
       (is (set? (get-in result [:anomaly/data :cycle-nodes]))))))
+
+(use-fixtures :each manager-and-dag-fixture)

--- a/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/add_repo_test.clj
+++ b/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/add_repo_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.repo-dag.anomaly.add-repo-test
   "Coverage for `dag/add-repo-anomaly` and its stable alias
    `dag/add-repo`. Three anomaly classes:
@@ -28,22 +27,23 @@
             [ai.miniforge.repo-dag.interface :as dag]
             [ai.miniforge.repo-dag.schema :as schema]))
 
-(def ^:dynamic *manager* nil)
+;------------------------------------------------------------------------------ Layer 0
 
-(defn manager-fixture [f]
+(def ^{:stratum 0} ^:dynamic *manager* nil)
+
+(defn ^{:stratum 0} manager-fixture [f]
   (binding [*manager* (dag/create-manager)]
     (f)))
 
-(use-fixtures :each manager-fixture)
-
-(def repo-config
+(def ^{:stratum 0} repo-config
   {:repo/url "https://github.com/acme/tf"
    :repo/name "tf"
    :repo/type :terraform-module})
 
-;------------------------------------------------------------------------------ Happy path
+;------------------------------------------------------------------------------ Layer 1
 
-(deftest add-repo-anomaly-returns-updated-dag
+;------------------------------------------------------------------------------ Happy path
+(deftest ^{:stratum 1} add-repo-anomaly-returns-updated-dag
   (testing "successful add returns the updated DAG, not an anomaly"
     (let [d (dag/create-dag *manager* "test-dag")
           result (dag/add-repo-anomaly *manager* (:dag/id d) repo-config)]
@@ -52,8 +52,7 @@
       (is (= "tf" (-> result :dag/repos first :repo/name))))))
 
 ;------------------------------------------------------------------------------ Failure path: DAG not found
-
-(deftest add-repo-anomaly-not-found-when-dag-missing
+(deftest ^{:stratum 1} add-repo-anomaly-not-found-when-dag-missing
   (testing "missing DAG yields :not-found anomaly"
     (let [missing-id (random-uuid)
           result (dag/add-repo-anomaly *manager* missing-id repo-config)]
@@ -62,8 +61,7 @@
       (is (= missing-id (get-in result [:anomaly/data :dag-id]))))))
 
 ;------------------------------------------------------------------------------ Failure path: schema-invalid repo-config
-
-(deftest add-repo-anomaly-invalid-input-on-missing-repo-type
+(deftest ^{:stratum 1} add-repo-anomaly-invalid-input-on-missing-repo-type
   (testing "repo-config without :repo/type yields :invalid-input anomaly —
             schema rejection short-circuits via make-repo-node-anomaly
             before the node is appended."
@@ -77,8 +75,7 @@
       (is (= schema/RepoNode (get-in result [:anomaly/data :schema]))))))
 
 ;------------------------------------------------------------------------------ Failure path: duplicate
-
-(deftest add-repo-anomaly-conflict-on-duplicate
+(deftest ^{:stratum 1} add-repo-anomaly-conflict-on-duplicate
   (testing "duplicate repo name yields :conflict anomaly"
     (let [d (dag/create-dag *manager* "test-dag")
           _ (dag/add-repo-anomaly *manager* (:dag/id d) repo-config)
@@ -88,14 +85,13 @@
       (is (= "tf" (get-in result [:anomaly/data :repo-name]))))))
 
 ;------------------------------------------------------------------------------ Alias compatibility
-
-(deftest add-repo-returns-anomaly-on-missing-dag
+(deftest ^{:stratum 1} add-repo-returns-anomaly-on-missing-dag
   (testing "stable alias returns anomaly data on missing DAG"
     (let [result (dag/add-repo *manager* (random-uuid) repo-config)]
       (is (anomaly/anomaly? result))
       (is (= :not-found (:anomaly/type result))))))
 
-(deftest add-repo-returns-anomaly-on-duplicate
+(deftest ^{:stratum 1} add-repo-returns-anomaly-on-duplicate
   (testing "stable alias returns anomaly data on duplicate repo"
     (let [d (dag/create-dag *manager* "test-dag")]
       (dag/add-repo *manager* (:dag/id d) repo-config)
@@ -103,3 +99,5 @@
         (is (anomaly/anomaly? result))
         (is (= :conflict (:anomaly/type result)))
         (is (= "tf" (get-in result [:anomaly/data :repo-name])))))))
+
+(use-fixtures :each manager-fixture)

--- a/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/queries_test.clj
+++ b/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/queries_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.repo-dag.anomaly.queries-test
   "Coverage for the read-only anomaly-returning protocol methods:
    compute-topo-order, affected-repos, upstream-repos, merge-order,
@@ -26,10 +25,13 @@
             [ai.miniforge.anomaly.interface :as anomaly]
             [ai.miniforge.repo-dag.interface :as dag]))
 
-(def ^:dynamic *manager* nil)
-(def ^:dynamic *dag-id* nil)
+;------------------------------------------------------------------------------ Layer 0
 
-(defn manager-and-dag-fixture [f]
+(def ^{:stratum 0} ^:dynamic *manager* nil)
+
+(def ^{:stratum 0} ^:dynamic *dag-id* nil)
+
+(defn ^{:stratum 0} manager-and-dag-fixture [f]
   (binding [*manager* (dag/create-manager)]
     (let [d (dag/create-dag *manager* "test-dag")]
       (dag/add-repo-anomaly *manager* (:dag/id d)
@@ -45,107 +47,104 @@
       (binding [*dag-id* (:dag/id d)]
         (f)))))
 
-(use-fixtures :each manager-and-dag-fixture)
+;------------------------------------------------------------------------------ Layer 1
 
 ;------------------------------------------------------------------------------ compute-topo-order
-
-(deftest compute-topo-order-anomaly-happy-path
+(deftest ^{:stratum 1} compute-topo-order-anomaly-happy-path
   (testing "successful topo-order returns the result map, not an anomaly"
     (let [result (dag/compute-topo-order-anomaly *manager* *dag-id*)]
       (is (not (anomaly/anomaly? result)))
       (is (true? (:success result)))
       (is (= ["repo-a" "repo-b"] (:order result))))))
 
-(deftest compute-topo-order-anomaly-not-found
+(deftest ^{:stratum 1} compute-topo-order-anomaly-not-found
   (testing "missing DAG yields :not-found anomaly"
     (let [result (dag/compute-topo-order-anomaly *manager* (random-uuid))]
       (is (anomaly/anomaly? result))
       (is (= :not-found (:anomaly/type result))))))
 
-(deftest compute-topo-order-alias-not-found
+(deftest ^{:stratum 1} compute-topo-order-alias-not-found
   (testing "stable alias returns :not-found anomaly"
     (let [result (dag/compute-topo-order *manager* (random-uuid))]
       (is (anomaly/anomaly? result))
       (is (= :not-found (:anomaly/type result))))))
 
 ;------------------------------------------------------------------------------ affected-repos
-
-(deftest affected-repos-anomaly-happy-path
+(deftest ^{:stratum 1} affected-repos-anomaly-happy-path
   (testing "successful query returns downstream set, not an anomaly"
     (let [result (dag/affected-repos-anomaly *manager* *dag-id* "repo-a")]
       (is (not (anomaly/anomaly? result)))
       (is (= #{"repo-b"} result)))))
 
-(deftest affected-repos-anomaly-not-found
+(deftest ^{:stratum 1} affected-repos-anomaly-not-found
   (testing "missing DAG yields :not-found anomaly"
     (let [result (dag/affected-repos-anomaly *manager* (random-uuid) "repo-a")]
       (is (anomaly/anomaly? result))
       (is (= :not-found (:anomaly/type result))))))
 
-(deftest affected-repos-alias-not-found
+(deftest ^{:stratum 1} affected-repos-alias-not-found
   (testing "stable alias returns :not-found anomaly"
     (let [result (dag/affected-repos *manager* (random-uuid) "repo-a")]
       (is (anomaly/anomaly? result))
       (is (= :not-found (:anomaly/type result))))))
 
 ;------------------------------------------------------------------------------ upstream-repos
-
-(deftest upstream-repos-anomaly-happy-path
+(deftest ^{:stratum 1} upstream-repos-anomaly-happy-path
   (testing "successful query returns upstream set, not an anomaly"
     (let [result (dag/upstream-repos-anomaly *manager* *dag-id* "repo-b")]
       (is (not (anomaly/anomaly? result)))
       (is (= #{"repo-a"} result)))))
 
-(deftest upstream-repos-anomaly-not-found
+(deftest ^{:stratum 1} upstream-repos-anomaly-not-found
   (testing "missing DAG yields :not-found anomaly"
     (let [result (dag/upstream-repos-anomaly *manager* (random-uuid) "repo-b")]
       (is (anomaly/anomaly? result))
       (is (= :not-found (:anomaly/type result))))))
 
-(deftest upstream-repos-alias-not-found
+(deftest ^{:stratum 1} upstream-repos-alias-not-found
   (testing "stable alias returns :not-found anomaly"
     (let [result (dag/upstream-repos *manager* (random-uuid) "repo-b")]
       (is (anomaly/anomaly? result))
       (is (= :not-found (:anomaly/type result))))))
 
 ;------------------------------------------------------------------------------ merge-order
-
-(deftest merge-order-anomaly-happy-path
+(deftest ^{:stratum 1} merge-order-anomaly-happy-path
   (testing "successful query returns merge-order map, not an anomaly"
     (let [result (dag/merge-order-anomaly *manager* *dag-id* #{"repo-a" "repo-b"})]
       (is (not (anomaly/anomaly? result)))
       (is (true? (:success result)))
       (is (= ["repo-a" "repo-b"] (:order result))))))
 
-(deftest merge-order-anomaly-not-found
+(deftest ^{:stratum 1} merge-order-anomaly-not-found
   (testing "missing DAG yields :not-found anomaly"
     (let [result (dag/merge-order-anomaly *manager* (random-uuid) #{"repo-a"})]
       (is (anomaly/anomaly? result))
       (is (= :not-found (:anomaly/type result))))))
 
-(deftest merge-order-alias-not-found
+(deftest ^{:stratum 1} merge-order-alias-not-found
   (testing "stable alias returns :not-found anomaly"
     (let [result (dag/merge-order *manager* (random-uuid) #{"repo-a"})]
       (is (anomaly/anomaly? result))
       (is (= :not-found (:anomaly/type result))))))
 
 ;------------------------------------------------------------------------------ validate-dag
-
-(deftest validate-dag-anomaly-happy-path
+(deftest ^{:stratum 1} validate-dag-anomaly-happy-path
   (testing "successful validate returns the result map, not an anomaly"
     (let [result (dag/validate-dag-anomaly *manager* *dag-id*)]
       (is (not (anomaly/anomaly? result)))
       (is (true? (:valid? result)))
       (is (= [] (:errors result))))))
 
-(deftest validate-dag-anomaly-not-found
+(deftest ^{:stratum 1} validate-dag-anomaly-not-found
   (testing "missing DAG yields :not-found anomaly"
     (let [result (dag/validate-dag-anomaly *manager* (random-uuid))]
       (is (anomaly/anomaly? result))
       (is (= :not-found (:anomaly/type result))))))
 
-(deftest validate-dag-alias-not-found
+(deftest ^{:stratum 1} validate-dag-alias-not-found
   (testing "stable alias returns :not-found anomaly"
     (let [result (dag/validate-dag *manager* (random-uuid))]
       (is (anomaly/anomaly? result))
       (is (= :not-found (:anomaly/type result))))))
+
+(use-fixtures :each manager-and-dag-fixture)

--- a/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/remove_edge_test.clj
+++ b/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/remove_edge_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.repo-dag.anomaly.remove-edge-test
   "Coverage for `dag/remove-edge-anomaly` and its stable alias
    `dag/remove-edge`. Only failure mode is `:not-found` — DAG missing."
@@ -23,17 +22,18 @@
             [ai.miniforge.anomaly.interface :as anomaly]
             [ai.miniforge.repo-dag.interface :as dag]))
 
-(def ^:dynamic *manager* nil)
+;------------------------------------------------------------------------------ Layer 0
 
-(defn manager-fixture [f]
+(def ^{:stratum 0} ^:dynamic *manager* nil)
+
+(defn ^{:stratum 0} manager-fixture [f]
   (binding [*manager* (dag/create-manager)]
     (f)))
 
-(use-fixtures :each manager-fixture)
+;------------------------------------------------------------------------------ Layer 1
 
 ;------------------------------------------------------------------------------ Happy path
-
-(deftest remove-edge-anomaly-returns-updated-dag
+(deftest ^{:stratum 1} remove-edge-anomaly-returns-updated-dag
   (testing "successful remove returns the updated DAG, not an anomaly"
     (let [d (dag/create-dag *manager* "test-dag")
           _ (dag/add-repo-anomaly *manager* (:dag/id d)
@@ -51,8 +51,7 @@
       (is (= 0 (count (:dag/edges result)))))))
 
 ;------------------------------------------------------------------------------ Failure path
-
-(deftest remove-edge-anomaly-not-found-when-dag-missing
+(deftest ^{:stratum 1} remove-edge-anomaly-not-found-when-dag-missing
   (testing "missing DAG yields :not-found anomaly"
     (let [missing-id (random-uuid)
           result (dag/remove-edge-anomaly *manager* missing-id "repo-a" "repo-b")]
@@ -61,9 +60,10 @@
       (is (= missing-id (get-in result [:anomaly/data :dag-id]))))))
 
 ;------------------------------------------------------------------------------ Alias compatibility
-
-(deftest remove-edge-returns-anomaly-on-missing-dag
+(deftest ^{:stratum 1} remove-edge-returns-anomaly-on-missing-dag
   (testing "stable alias returns anomaly data on missing DAG"
     (let [result (dag/remove-edge *manager* (random-uuid) "repo-a" "repo-b")]
       (is (anomaly/anomaly? result))
       (is (= :not-found (:anomaly/type result))))))
+
+(use-fixtures :each manager-fixture)

--- a/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/remove_repo_test.clj
+++ b/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/remove_repo_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.repo-dag.anomaly.remove-repo-test
   "Coverage for `dag/remove-repo-anomaly` and its stable alias
    `dag/remove-repo`. Only failure mode is `:not-found` — DAG missing."
@@ -23,22 +22,23 @@
             [ai.miniforge.anomaly.interface :as anomaly]
             [ai.miniforge.repo-dag.interface :as dag]))
 
-(def ^:dynamic *manager* nil)
+;------------------------------------------------------------------------------ Layer 0
 
-(defn manager-fixture [f]
+(def ^{:stratum 0} ^:dynamic *manager* nil)
+
+(defn ^{:stratum 0} manager-fixture [f]
   (binding [*manager* (dag/create-manager)]
     (f)))
 
-(use-fixtures :each manager-fixture)
-
-(def repo-config
+(def ^{:stratum 0} repo-config
   {:repo/url "https://github.com/acme/tf"
    :repo/name "tf"
    :repo/type :terraform-module})
 
-;------------------------------------------------------------------------------ Happy path
+;------------------------------------------------------------------------------ Layer 1
 
-(deftest remove-repo-anomaly-returns-updated-dag
+;------------------------------------------------------------------------------ Happy path
+(deftest ^{:stratum 1} remove-repo-anomaly-returns-updated-dag
   (testing "successful remove returns the updated DAG, not an anomaly"
     (let [d (dag/create-dag *manager* "test-dag")
           _ (dag/add-repo-anomaly *manager* (:dag/id d) repo-config)
@@ -47,8 +47,7 @@
       (is (= 0 (count (:dag/repos result)))))))
 
 ;------------------------------------------------------------------------------ Failure path
-
-(deftest remove-repo-anomaly-not-found-when-dag-missing
+(deftest ^{:stratum 1} remove-repo-anomaly-not-found-when-dag-missing
   (testing "missing DAG yields :not-found anomaly"
     (let [missing-id (random-uuid)
           result (dag/remove-repo-anomaly *manager* missing-id "tf")]
@@ -57,9 +56,10 @@
       (is (= missing-id (get-in result [:anomaly/data :dag-id]))))))
 
 ;------------------------------------------------------------------------------ Alias compatibility
-
-(deftest remove-repo-returns-anomaly-on-missing-dag
+(deftest ^{:stratum 1} remove-repo-returns-anomaly-on-missing-dag
   (testing "stable alias returns anomaly data on missing DAG"
     (let [result (dag/remove-repo *manager* (random-uuid) "tf")]
       (is (anomaly/anomaly? result))
       (is (= :not-found (:anomaly/type result))))))
+
+(use-fixtures :each manager-fixture)

--- a/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/validate_schema_test.clj
+++ b/components/repo-dag/test/ai/miniforge/repo_dag/anomaly/validate_schema_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.repo-dag.anomaly.validate-schema-test
   "Coverage for `core/validate-schema-anomaly` and its stable alias
    `core/validate-schema`. Schema rejection is an :invalid-input anomaly;
@@ -25,19 +24,22 @@
             [ai.miniforge.repo-dag.core :as core]
             [ai.miniforge.repo-dag.interface :as dag]))
 
-(def valid-repo
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} valid-repo
   {:repo/url "https://github.com/acme/tf"
    :repo/name "tf"
    :repo/type :terraform-module
    :repo/layer :foundations
    :repo/default-branch "main"})
 
-(def invalid-repo
+(def ^{:stratum 0} invalid-repo
   {:repo/name "missing-required-fields"})
 
-;------------------------------------------------------------------------------ Happy path
+;------------------------------------------------------------------------------ Layer 1
 
-(deftest validate-schema-anomaly-returns-value-on-success
+;------------------------------------------------------------------------------ Happy path
+(deftest ^{:stratum 1} validate-schema-anomaly-returns-value-on-success
   (testing "valid value passes through unchanged"
     (is (= valid-repo (core/validate-schema-anomaly dag/RepoNode valid-repo))))
   (testing "result is identical to the input (no copy)"
@@ -45,18 +47,17 @@
                     (core/validate-schema-anomaly dag/RepoNode valid-repo)))))
 
 ;------------------------------------------------------------------------------ Failure path
-
-(deftest validate-schema-anomaly-returns-anomaly-on-failure
+(deftest ^{:stratum 1} validate-schema-anomaly-returns-anomaly-on-failure
   (testing "invalid value yields a canonical anomaly"
     (let [result (core/validate-schema-anomaly dag/RepoNode invalid-repo)]
       (is (anomaly/anomaly? result)))))
 
-(deftest validate-schema-anomaly-uses-invalid-input-type
+(deftest ^{:stratum 1} validate-schema-anomaly-uses-invalid-input-type
   (testing "schema validation failure is :invalid-input"
     (let [result (core/validate-schema-anomaly dag/RepoNode invalid-repo)]
       (is (= :invalid-input (:anomaly/type result))))))
 
-(deftest validate-schema-anomaly-data-carries-context
+(deftest ^{:stratum 1} validate-schema-anomaly-data-carries-context
   (testing "anomaly carries schema, value, and humanized errors"
     (let [result (core/validate-schema-anomaly dag/RepoNode invalid-repo)
           data   (:anomaly/data result)]
@@ -66,12 +67,11 @@
       (is (map? (:errors data))))))
 
 ;------------------------------------------------------------------------------ Alias compatibility
-
-(deftest validate-schema-still-returns-on-success
+(deftest ^{:stratum 1} validate-schema-still-returns-on-success
   (testing "stable alias returns the value unchanged"
     (is (= valid-repo (core/validate-schema dag/RepoNode valid-repo)))))
 
-(deftest validate-schema-returns-anomaly-on-failure
+(deftest ^{:stratum 1} validate-schema-returns-anomaly-on-failure
   (testing "stable alias returns the same anomaly data on bad input"
     (let [result (core/validate-schema dag/RepoNode invalid-repo)
           data (:anomaly/data result)]

--- a/components/repo-dag/test/ai/miniforge/repo_dag/dag_crud_test.clj
+++ b/components/repo-dag/test/ai/miniforge/repo_dag/dag_crud_test.clj
@@ -15,27 +15,23 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.repo-dag.dag-crud-test
-  "Tests for DAG schema, creation, and CRUD operations (Layers 0-2)."
+  "Tests for DAG schema, creation, and CRUD operations."
   (:require [clojure.test :as test :refer [deftest testing is use-fixtures]]
             [ai.miniforge.anomaly.interface :as anomaly]
             [ai.miniforge.repo-dag.interface :as dag]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;------------------------------------------------------------------------------ Fixtures
+(def ^{:stratum 0} ^:dynamic *manager* nil)
 
-(def ^:dynamic *manager* nil)
-
-(defn manager-fixture [f]
+(defn ^{:stratum 0} manager-fixture [f]
   (binding [*manager* (dag/create-manager)]
     (f)))
 
-(use-fixtures :each manager-fixture)
-
-;------------------------------------------------------------------------------ Layer 0
 ;; Schema validation tests
-
-(deftest schema-validation-test
+(deftest ^{:stratum 0} schema-validation-test
   (testing "valid-repo-node? validates correctly"
     (is (dag/valid-repo-node?
          {:repo/url "https://github.com/acme/tf-modules"
@@ -64,9 +60,9 @@
     (is (= :foundations (dag/infer-layer :library)))))
 
 ;------------------------------------------------------------------------------ Layer 1
-;; DAG CRUD tests
 
-(deftest create-dag-test
+;; DAG CRUD tests
+(deftest ^{:stratum 1} create-dag-test
   (testing "creates DAG with required fields"
     (let [d (dag/create-dag *manager* "test-dag")]
       (is (uuid? (:dag/id d)))
@@ -82,7 +78,7 @@
     (let [d (dag/create-dag *manager* "test-dag")]
       (is (= d (dag/get-dag *manager* (:dag/id d)))))))
 
-(deftest add-repo-test
+(deftest ^{:stratum 1} add-repo-test
   (testing "adds repo with explicit layer"
     (let [d (dag/create-dag *manager* "test-dag")
           updated (dag/add-repo *manager* (:dag/id d)
@@ -116,7 +112,7 @@
         (is (= :conflict (:anomaly/type result)))
         (is (= "tf-modules" (get-in result [:anomaly/data :repo-name])))))))
 
-(deftest remove-repo-test
+(deftest ^{:stratum 1} remove-repo-test
   (testing "removes repo from DAG"
     (let [d (dag/create-dag *manager* "test-dag")
           _ (dag/add-repo *manager* (:dag/id d)
@@ -142,10 +138,8 @@
       (is (= 1 (count (:dag/repos updated))))
       (is (= 0 (count (:dag/edges updated)))))))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Edge operations tests
-
-(deftest add-edge-test
+(deftest ^{:stratum 1} add-edge-test
   (testing "adds edge between repos"
     (let [d (dag/create-dag *manager* "test-dag")
           _ (dag/add-repo *manager* (:dag/id d)
@@ -208,7 +202,7 @@
       (is (= "repo-a" (get-in result [:anomaly/data :from])))
       (is (= "repo-b" (get-in result [:anomaly/data :to]))))))
 
-(deftest remove-edge-test
+(deftest ^{:stratum 1} remove-edge-test
   (testing "removes edge from DAG"
     (let [d (dag/create-dag *manager* "test-dag")
           _ (dag/add-repo *manager* (:dag/id d)
@@ -223,3 +217,5 @@
                           :library-before-consumer :sequential)
           updated (dag/remove-edge *manager* (:dag/id d) "repo-a" "repo-b")]
       (is (= 0 (count (:dag/edges updated)))))))
+
+(use-fixtures :each manager-fixture)

--- a/components/repo-dag/test/ai/miniforge/repo_dag/dag_integration_test.clj
+++ b/components/repo-dag/test/ai/miniforge/repo_dag/dag_integration_test.clj
@@ -15,25 +15,22 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.repo-dag.dag-integration-test
   "Integration tests exercising realistic multi-layer DAG workflows."
   (:require [clojure.test :as test :refer [deftest testing is use-fixtures]]
             [ai.miniforge.repo-dag.interface :as dag]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;------------------------------------------------------------------------------ Fixtures
+(def ^{:stratum 0} ^:dynamic *manager* nil)
 
-(def ^:dynamic *manager* nil)
-
-(defn manager-fixture [f]
+(defn ^{:stratum 0} manager-fixture [f]
   (binding [*manager* (dag/create-manager)]
     (f)))
 
-(use-fixtures :each manager-fixture)
-
 ;------------------------------------------------------------------------------ Helpers
-
-(defn- build-infra-dag!
+(defn- ^{:stratum 0} build-infra-dag!
   "Builds a realistic infrastructure DAG:
    tf-modules -> tf-live -> k8s -> argocd -> app1
                                           -> app2"
@@ -64,9 +61,10 @@
     (dag/add-edge manager (:dag/id d) "argocd" "app2" :library-before-consumer :sequential)
     (:dag/id d)))
 
-;------------------------------------------------------------------------------ Integration tests
+;------------------------------------------------------------------------------ Layer 1
 
-(deftest full-pipeline-topo-order-test
+;------------------------------------------------------------------------------ Integration tests
+(deftest ^{:stratum 1} full-pipeline-topo-order-test
   (testing "realistic infra DAG produces valid topological order"
     (let [dag-id (build-infra-dag! *manager*)
           result (dag/compute-topo-order *manager* dag-id)
@@ -82,7 +80,7 @@
       (is (< (.indexOf order "argocd") (.indexOf order "app1")))
       (is (< (.indexOf order "argocd") (.indexOf order "app2"))))))
 
-(deftest full-pipeline-affected-repos-test
+(deftest ^{:stratum 1} full-pipeline-affected-repos-test
   (testing "change to tf-modules affects all downstream"
     (let [dag-id (build-infra-dag! *manager*)
           affected (dag/affected-repos *manager* dag-id "tf-modules")]
@@ -98,7 +96,7 @@
           affected (dag/affected-repos *manager* dag-id "app1")]
       (is (= #{} affected)))))
 
-(deftest full-pipeline-upstream-repos-test
+(deftest ^{:stratum 1} full-pipeline-upstream-repos-test
   (testing "app1 depends on entire chain"
     (let [dag-id (build-infra-dag! *manager*)
           upstream (dag/upstream-repos *manager* dag-id "app1")]
@@ -109,7 +107,7 @@
           upstream (dag/upstream-repos *manager* dag-id "tf-modules")]
       (is (= #{} upstream)))))
 
-(deftest full-pipeline-merge-order-test
+(deftest ^{:stratum 1} full-pipeline-merge-order-test
   (testing "merge order for subset respects dependencies"
     (let [dag-id (build-infra-dag! *manager*)
           result (dag/merge-order *manager* dag-id #{"tf-modules" "k8s" "app1"})]
@@ -119,14 +117,14 @@
         (is (< (.indexOf order "tf-modules") (.indexOf order "k8s")))
         (is (< (.indexOf order "k8s") (.indexOf order "app1")))))))
 
-(deftest full-pipeline-validation-test
+(deftest ^{:stratum 1} full-pipeline-validation-test
   (testing "realistic DAG passes validation"
     (let [dag-id (build-infra-dag! *manager*)
           result (dag/validate-dag *manager* dag-id)]
       (is (:valid? result))
       (is (empty? (:errors result))))))
 
-(deftest full-pipeline-layers-test
+(deftest ^{:stratum 1} full-pipeline-layers-test
   (testing "realistic DAG has repos in correct layers"
     (let [dag-id (build-infra-dag! *manager*)
           current-dag (dag/get-dag *manager* dag-id)
@@ -136,7 +134,7 @@
       (is (= #{"k8s" "argocd"} (set (:platform layers))))
       (is (= #{"app1" "app2"} (set (:application layers)))))))
 
-(deftest remove-middle-node-test
+(deftest ^{:stratum 1} remove-middle-node-test
   (testing "removing middle node breaks chain but keeps other repos"
     (let [dag-id (build-infra-dag! *manager*)
           updated (dag/remove-repo *manager* dag-id "k8s")]
@@ -150,7 +148,7 @@
         (is (contains? edge-pairs ["argocd" "app1"]))
         (is (contains? edge-pairs ["argocd" "app2"]))))))
 
-(deftest multiple-dags-independence-test
+(deftest ^{:stratum 1} multiple-dags-independence-test
   (testing "operations on one DAG do not affect another"
     (let [dag1-id (build-infra-dag! *manager*)
           d2 (dag/create-dag *manager* "other-dag")
@@ -160,3 +158,5 @@
       (is (= 6 (count (:dag/repos (dag/get-dag *manager* dag1-id)))))
       ;; dag2 should have 1 repo
       (is (= 1 (count (:dag/repos (dag/get-dag *manager* (:dag/id d2)))))))))
+
+(use-fixtures :each manager-fixture)

--- a/components/repo-dag/test/ai/miniforge/repo_dag/dag_queries_test.clj
+++ b/components/repo-dag/test/ai/miniforge/repo_dag/dag_queries_test.clj
@@ -15,26 +15,24 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.repo-dag.dag-queries-test
-  "Tests for affected repos, upstream repos, and merge order (Layers 5-6)."
+  "Tests for affected repos, upstream repos, and merge order."
   (:require [clojure.test :as test :refer [deftest testing is use-fixtures]]
             [ai.miniforge.repo-dag.interface :as dag]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;------------------------------------------------------------------------------ Fixtures
+(def ^{:stratum 0} ^:dynamic *manager* nil)
 
-(def ^:dynamic *manager* nil)
-
-(defn manager-fixture [f]
+(defn ^{:stratum 0} manager-fixture [f]
   (binding [*manager* (dag/create-manager)]
     (f)))
 
-(use-fixtures :each manager-fixture)
+;------------------------------------------------------------------------------ Layer 1
 
-;------------------------------------------------------------------------------ Layer 5
 ;; Affected repos and upstream repos tests
-
-(deftest affected-repos-test
+(deftest ^{:stratum 1} affected-repos-test
   (testing "returns direct downstream repos"
     (let [d (dag/create-dag *manager* "test-dag")
           _ (dag/add-repo *manager* (:dag/id d)
@@ -68,7 +66,7 @@
           affected (dag/affected-repos *manager* (:dag/id d) "b")]
       (is (= #{} affected)))))
 
-(deftest upstream-repos-test
+(deftest ^{:stratum 1} upstream-repos-test
   (testing "returns direct upstream repos"
     (let [d (dag/create-dag *manager* "test-dag")
           _ (dag/add-repo *manager* (:dag/id d)
@@ -102,10 +100,8 @@
           upstream (dag/upstream-repos *manager* (:dag/id d) "a")]
       (is (= #{} upstream)))))
 
-;------------------------------------------------------------------------------ Layer 6
 ;; Merge order tests
-
-(deftest merge-order-test
+(deftest ^{:stratum 1} merge-order-test
   (testing "computes merge order for subset of repos"
     (let [d (dag/create-dag *manager* "test-dag")
           _ (dag/add-repo *manager* (:dag/id d)
@@ -135,3 +131,5 @@
       (is (:success result))
       (is (= 2 (count (:order result))))
       (is (= #{"a" "b"} (set (:order result)))))))
+
+(use-fixtures :each manager-fixture)

--- a/components/repo-dag/test/ai/miniforge/repo_dag/dag_topology_test.clj
+++ b/components/repo-dag/test/ai/miniforge/repo_dag/dag_topology_test.clj
@@ -15,27 +15,25 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.repo-dag.dag-topology-test
-  "Tests for topological sort and cycle detection (Layers 3-4)."
+  "Tests for topological sort and cycle detection."
   (:require [clojure.test :as test :refer [deftest testing is use-fixtures]]
             [ai.miniforge.anomaly.interface :as anomaly]
             [ai.miniforge.repo-dag.interface :as dag]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;------------------------------------------------------------------------------ Fixtures
+(def ^{:stratum 0} ^:dynamic *manager* nil)
 
-(def ^:dynamic *manager* nil)
-
-(defn manager-fixture [f]
+(defn ^{:stratum 0} manager-fixture [f]
   (binding [*manager* (dag/create-manager)]
     (f)))
 
-(use-fixtures :each manager-fixture)
+;------------------------------------------------------------------------------ Layer 1
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Topological sort tests
-
-(deftest topo-sort-test
+(deftest ^{:stratum 1} topo-sort-test
   (testing "returns correct order for linear chain"
     (let [d (dag/create-dag *manager* "test-dag")
           _ (dag/add-repo *manager* (:dag/id d)
@@ -85,10 +83,8 @@
       (is (= 2 (count (:order result))))
       (is (= #{"a" "b"} (set (:order result)))))))
 
-;------------------------------------------------------------------------------ Layer 4
 ;; Cycle detection tests
-
-(deftest cycle-detection-test
+(deftest ^{:stratum 1} cycle-detection-test
   (testing "detects simple cycle on add-edge"
     (let [d (dag/create-dag *manager* "test-dag")
           _ (dag/add-repo *manager* (:dag/id d)
@@ -131,3 +127,5 @@
                                       {:edge/from "c" :edge/to "a" :edge/constraint :library-before-consumer :edge/merge-ordering :sequential}]}
           cycle-nodes (dag/find-cycle-nodes dag-with-cycle)]
       (is (= #{"a" "b" "c"} cycle-nodes)))))
+
+(use-fixtures :each manager-fixture)

--- a/components/repo-dag/test/ai/miniforge/repo_dag/dag_validation_test.clj
+++ b/components/repo-dag/test/ai/miniforge/repo_dag/dag_validation_test.clj
@@ -15,27 +15,25 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.repo-dag.dag-validation-test
-  "Tests for DAG validation, layers, and edge cases (Layers 7-9)."
+  "Tests for DAG validation, layers, and edge cases."
   (:require [clojure.test :as test :refer [deftest testing is use-fixtures]]
             [ai.miniforge.anomaly.interface :as anomaly]
             [ai.miniforge.repo-dag.interface :as dag]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;------------------------------------------------------------------------------ Fixtures
+(def ^{:stratum 0} ^:dynamic *manager* nil)
 
-(def ^:dynamic *manager* nil)
-
-(defn manager-fixture [f]
+(defn ^{:stratum 0} manager-fixture [f]
   (binding [*manager* (dag/create-manager)]
     (f)))
 
-(use-fixtures :each manager-fixture)
+;------------------------------------------------------------------------------ Layer 1
 
-;------------------------------------------------------------------------------ Layer 7
 ;; DAG validation tests
-
-(deftest validate-dag-test
+(deftest ^{:stratum 1} validate-dag-test
   (testing "valid DAG passes validation"
     (let [d (dag/create-dag *manager* "test-dag")
           _ (dag/add-repo *manager* (:dag/id d)
@@ -53,10 +51,8 @@
       (is (:valid? result))
       (is (empty? (:errors result))))))
 
-;------------------------------------------------------------------------------ Layer 8
 ;; Compute layers tests
-
-(deftest compute-layers-test
+(deftest ^{:stratum 1} compute-layers-test
   (testing "groups repos by layer"
     (let [d (dag/create-dag *manager* "test-dag")
           _ (dag/add-repo *manager* (:dag/id d)
@@ -78,10 +74,8 @@
       (is (= ["k8s"] (:platform layers)))
       (is (= ["app"] (:application layers))))))
 
-;------------------------------------------------------------------------------ Layer 9
 ;; Edge cases and error handling tests
-
-(deftest edge-cases-test
+(deftest ^{:stratum 1} edge-cases-test
   (testing "operations on nonexistent DAG"
     (let [fake-id (random-uuid)]
       (is (nil? (dag/get-dag *manager* fake-id)))
@@ -104,3 +98,5 @@
     (dag/create-dag *manager* "dag-1")
     (dag/reset-manager! *manager*)
     (is (= 0 (count (dag/get-all-dags *manager*))))))
+
+(use-fixtures :each manager-fixture)

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-repo-dag.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-repo-dag.md
@@ -1,0 +1,187 @@
+<!--
+  Title: fix: stratum-lint autofix for components/repo-dag (Wave 1)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix: stratum-lint autofix for components/repo-dag (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over `components/repo-dag` (`src` + `test`) to
+replace decorative `Layer N` headings with real ones derived from each
+file's actual same-file reference graph, and tag every top-level `def`/
+`defn`/`deftest` with `^{:stratum n}`. One of the Wave 1 batches from
+`work/stratum-lint-baseline-2026-07-24.md`. Mostly mechanical, but two
+classes of manual fix were needed beyond the autofix output: one stale
+decorative heading that now contradicted its surrounding real headings
+in `core.clj`, and six namespace docstrings (two in `src`, four in
+`test`) that hardcoded a layer count/range the fix made wrong. No
+executable logic changed anywhere.
+
+## Motivation
+
+Baseline findings for this component, confirmed via a fresh plain-lint
+run before touching anything (zero `SL001` — no upward-reference/cycle
+risk, matching the Wave 1 batch criteria):
+
+- `core.clj`: `SL003`, 4 distinct (decorative) layers against the
+  3-layer budget.
+- `interface.clj`: `SL003`, 6 distinct (decorative) layers.
+- `schema.clj`: `SL003`, 4 distinct (decorative) layers.
+- Four `dag_*_test.clj` files (`dag_crud_test`, `dag_queries_test`,
+  `dag_topology_test`, `dag_validation_test`): `SL004`, the shared
+  `*manager*` dynamic var and `manager-fixture` def sitting before the
+  first `Layer` heading — 2 findings each, 8 total.
+
+## Changes in Detail
+
+Ran, over the whole component:
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "bef8657a2efd3b1ba9e1a4f510693c9fbca45abd" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/repo-dag
+```
+
+All 3 `src` files and 11 `test` files were rewritten (`--fix` normalizes
+every file it touches, not just the ones with findings). Diffs are
+heading text, `^{:stratum n}` metadata, and def/deftest reordering only.
+
+Notable autofix outcomes worth calling out because they look alarming
+in a raw diff:
+
+- `interface.clj`'s 6 decorative headings (schema re-exports, manager
+  lifecycle, CRUD, queries, validation, pure functions) collapsed to a
+  **single** real layer. This file is a thin facade — every def just
+  delegates to `core/*` — so there are no same-file references between
+  its own defs at all; the 6-layer count the old headings implied was
+  entirely decorative.
+- Every test file with a `manager-fixture` had its bare
+  `(use-fixtures :each manager-fixture)` call swept to the end of the
+  file (the tool's documented behavior for unrecognized non-`def`
+  top-level forms — see `work/stratum-lint-baseline-2026-07-24.md`).
+  Verified this is behaviorally inert here: `use-fixtures` only
+  attaches fixture fns to the namespace's metadata, which `clojure.test`
+  reads at *test-run* time, long after the whole namespace (including
+  this call) has finished loading — so its position relative to the
+  `deftest` forms in the source doesn't matter. Confirmed empirically
+  too: all 67 tests still pass (see Testing Plan).
+- `schema.clj` picked up two whitespace-only re-spacings of already
+  same-line trailing comments (`:schema-before-impl])` and
+  `:same-pr-train])`, going from inconsistent 1/4-space gaps to a
+  uniform 2 spaces before the `;`). Checked both by hand — the comment
+  stayed attached to the same form in both cases; no displacement.
+
+One thing the autofix did **not** resolve, found during the mandated
+full-diff read: `core.clj` had a stale decorative
+`;---- Layer 0.7` sub-banner (with its own "Validation functions"
+comment) that the pre-fix file used as one of four undifferentiated
+`Layer 0.x` sub-dividers within old `Layer 0`. After the fix moved the
+def underneath it (`validate-dag-impl`) to the real `Layer 1`, the
+banner ended up sitting *inside* the real `Layer 1` region, reading
+"0.7" directly after the genuine `Layer 1` heading above it — backward,
+and contradictory. Dropped the `Layer 0.7` heading by hand, keeping
+"Validation functions" as a plain comment (same fix class as
+`5bc460080`, `verify_test.clj`'s leftover `Layer 1` banner). The other
+three `Layer 0.x` sub-dividers in the same file (`0.5`, `0.6`, `0.8`)
+were left alone — none of them jump backward past a real heading, so
+they aren't contradictory, just superseded decoration.
+
+Also updated by hand, six namespace docstrings whose hardcoded layer
+summary the fix invalidated:
+
+- `core.clj` and `schema.clj` each claimed a 3-layer breakdown
+  (`Layer 0`/`Layer 1`/`Layer 2`); the fix surfaced 5 real layers in
+  each. Rewrote both to describe the actual structure.
+- `dag_crud_test.clj`, `dag_queries_test.clj`, `dag_topology_test.clj`,
+  and `dag_validation_test.clj` each carried a stale
+  `"... (Layers N-M)"` parenthetical referencing an old cross-file test
+  numbering scheme (0-2, 3-4, 5-6, 7-9) that predates this tool and
+  never corresponded to any single file's real stratum count. Every one
+  of these files now has exactly 2 real layers (fixtures, then
+  everything that uses them), so the old ranges were doubly wrong.
+  Dropped the parenthetical from all four rather than substituting a
+  new number that carries no information beyond what the file's own
+  `;---- Layer N` headings already show.
+
+No `#?(...)` reader-conditional-wrapped defs in this component, so the
+SL008 fix in the current pin never came into play.
+
+## Testing Plan
+
+1. Ran plain (non-`--fix`) `stratum-lint` before any change — reproduced
+   the findings above exactly, confirmed 0 `SL001`.
+2. Ran `--fix` over the whole component — 14 files rewritten.
+3. Ran `--fix` a second time immediately after — zero diff, confirms
+   idempotency.
+4. Read the full diff for all 14 changed files. Found and hand-fixed the
+   contradictory `Layer 0.7` banner in `core.clj`; updated 6 stale
+   namespace docstrings (above); confirmed the two trailing-comment
+   re-spacings in `schema.clj` didn't displace anything.
+5. Ran `--fix` two more times after the hand edits — zero diff both
+   times, confirms the manual fixes are stable under the tool.
+6. `clj-kondo --lint components/repo-dag`: 0 errors, 0 warnings — both
+   before and after.
+7. Ran all 11 test namespaces directly via `clojure -M:dev:test`
+   (`add-edge-test`, `add-repo-test`, `queries-test`,
+   `remove-edge-test`, `remove-repo-test`, `validate-schema-test` under
+   `anomaly.*`, plus `dag-crud-test`, `dag-integration-test`,
+   `dag-queries-test`, `dag-topology-test`, `dag-validation-test`): 67
+   tests, 230 assertions, 0 failures, 0 errors.
+8. Re-ran plain `stratum-lint` after the fix: `SL001`/`SL002`/`SL004`
+   clear across the component. `SL003` remains, newly surfaced (higher
+   than the pre-fix decorative count, not a regression) on two files:
+   - `core.clj`: 5 real layers (pure DAG primitives/protocol/store
+     helpers → schema-validating siblings/traversal/validation →
+     schema-aware constructors/CRUD impls → the `InMemoryDagManager`
+     defrecord → the `create-manager` factory).
+   - `schema.clj`: 5 real layers (enums/base types/standalone schemas →
+     registry/`infer-layer` → `RepoNode`/`RepoEdge` → `RepoDag`/node-edge
+     validators → `valid-repo-dag?`).
+
+   Both are genuinely over the 3-layer budget the old decorative
+   headings hid by undercounting (4 vs the real 5), not a regression
+   this PR introduces — deferred to Wave 2 (real namespace split),
+   consistent with how prior Wave 1 PRs (e.g. `schema`, `control-plane`)
+   handled the same situation. `interface.clj`'s original `SL003` is
+   fully resolved (collapsed to 1 real layer, well under budget).
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+change — comment/metadata/order/docstring-only. Pre-commit's
+`lint:stratum` autofixer keeps this component clean going forward;
+`core.clj` and `schema.clj`'s `SL003` stay advisory
+(`MINIFORGE_STRATUM_BUDGET_MODE=warn` at commit time) until Wave 2
+splits them.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+- Precedent for the decorative-banner hand-fix: `5bc460080` (fix:
+  correct stale/placeholder Layer headings in phase-software-factory
+  tests)
+- Follow-on: Wave 2 namespace split for
+  `components/repo-dag/src/ai/miniforge/repo_dag/core.clj` and
+  `components/repo-dag/src/ai/miniforge/repo_dag/schema.clj` (5 real
+  layers each, over the 3-layer budget)
+
+## Checklist
+
+- [x] Plain lint confirmed zero `SL001` before touching anything
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Second `--fix` pass confirms idempotency (zero diff)
+- [x] Diff read in full for all 14 changed files
+- [x] Contradictory decorative `Layer 0.7` banner (`core.clj`) found and
+      removed by hand; keeping "Validation functions" as a plain comment
+- [x] Six namespace docstrings (`core.clj`, `schema.clj`,
+      `dag_crud_test.clj`, `dag_queries_test.clj`,
+      `dag_topology_test.clj`, `dag_validation_test.clj`) updated to
+      drop/replace stale layer counts or ranges
+- [x] Two further `--fix` passes after hand edits confirm stability
+      (zero diff)
+- [x] `clj-kondo` clean (0 errors, 0 warnings before/after)
+- [x] Component tests pass (67 tests, 230 assertions, 0 failures/errors)
+- [x] Plain lint re-run post-fix: zero `SL001`/`SL002`/`SL004`; `SL003`
+      remains on `core.clj` and `schema.clj` — newly surfaced by the fix
+      (not pre-existing), tracked as Wave 2 above
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
<!--
  Title: fix: stratum-lint autofix for components/repo-dag (Wave 1)
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# fix: stratum-lint autofix for components/repo-dag (Wave 1)

## Overview

Runs `stratum-lint --fix` over `components/repo-dag` (`src` + `test`) to
replace decorative `Layer N` headings with real ones derived from each
file's actual same-file reference graph, and tag every top-level `def`/
`defn`/`deftest` with `^{:stratum n}`. One of the Wave 1 batches from
`work/stratum-lint-baseline-2026-07-24.md`. Mostly mechanical, but two
classes of manual fix were needed beyond the autofix output: one stale
decorative heading that now contradicted its surrounding real headings
in `core.clj`, and six namespace docstrings (two in `src`, four in
`test`) that hardcoded a layer count/range the fix made wrong. No
executable logic changed anywhere.

## Motivation

Baseline findings for this component, confirmed via a fresh plain-lint
run before touching anything (zero `SL001` — no upward-reference/cycle
risk, matching the Wave 1 batch criteria):

- `core.clj`: `SL003`, 4 distinct (decorative) layers against the
  3-layer budget.
- `interface.clj`: `SL003`, 6 distinct (decorative) layers.
- `schema.clj`: `SL003`, 4 distinct (decorative) layers.
- Four `dag_*_test.clj` files (`dag_crud_test`, `dag_queries_test`,
  `dag_topology_test`, `dag_validation_test`): `SL004`, the shared
  `*manager*` dynamic var and `manager-fixture` def sitting before the
  first `Layer` heading — 2 findings each, 8 total.

## Changes in Detail

Ran, over the whole component:

```bash
bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "bef8657a2efd3b1ba9e1a4f510693c9fbca45abd" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/repo-dag
```

All 3 `src` files and 11 `test` files were rewritten (`--fix` normalizes
every file it touches, not just the ones with findings). Diffs are
heading text, `^{:stratum n}` metadata, and def/deftest reordering only.

Notable autofix outcomes worth calling out because they look alarming
in a raw diff:

- `interface.clj`'s 6 decorative headings (schema re-exports, manager
  lifecycle, CRUD, queries, validation, pure functions) collapsed to a
  **single** real layer. This file is a thin facade — every def just
  delegates to `core/*` — so there are no same-file references between
  its own defs at all; the 6-layer count the old headings implied was
  entirely decorative.
- Every test file with a `manager-fixture` had its bare
  `(use-fixtures :each manager-fixture)` call swept to the end of the
  file (the tool's documented behavior for unrecognized non-`def`
  top-level forms — see `work/stratum-lint-baseline-2026-07-24.md`).
  Verified this is behaviorally inert here: `use-fixtures` only
  attaches fixture fns to the namespace's metadata, which `clojure.test`
  reads at *test-run* time, long after the whole namespace (including
  this call) has finished loading — so its position relative to the
  `deftest` forms in the source doesn't matter. Confirmed empirically
  too: all 67 tests still pass (see Testing Plan).
- `schema.clj` picked up two whitespace-only re-spacings of already
  same-line trailing comments (`:schema-before-impl])` and
  `:same-pr-train])`, going from inconsistent 1/4-space gaps to a
  uniform 2 spaces before the `;`). Checked both by hand — the comment
  stayed attached to the same form in both cases; no displacement.

One thing the autofix did **not** resolve, found during the mandated
full-diff read: `core.clj` had a stale decorative
`;---- Layer 0.7` sub-banner (with its own "Validation functions"
comment) that the pre-fix file used as one of four undifferentiated
`Layer 0.x` sub-dividers within old `Layer 0`. After the fix moved the
def underneath it (`validate-dag-impl`) to the real `Layer 1`, the
banner ended up sitting *inside* the real `Layer 1` region, reading
"0.7" directly after the genuine `Layer 1` heading above it — backward,
and contradictory. Dropped the `Layer 0.7` heading by hand, keeping
"Validation functions" as a plain comment (same fix class as
`5bc460080`, `verify_test.clj`'s leftover `Layer 1` banner). The other
three `Layer 0.x` sub-dividers in the same file (`0.5`, `0.6`, `0.8`)
were left alone — none of them jump backward past a real heading, so
they aren't contradictory, just superseded decoration.

Also updated by hand, six namespace docstrings whose hardcoded layer
summary the fix invalidated:

- `core.clj` and `schema.clj` each claimed a 3-layer breakdown
  (`Layer 0`/`Layer 1`/`Layer 2`); the fix surfaced 5 real layers in
  each. Rewrote both to describe the actual structure.
- `dag_crud_test.clj`, `dag_queries_test.clj`, `dag_topology_test.clj`,
  and `dag_validation_test.clj` each carried a stale
  `"... (Layers N-M)"` parenthetical referencing an old cross-file test
  numbering scheme (0-2, 3-4, 5-6, 7-9) that predates this tool and
  never corresponded to any single file's real stratum count. Every one
  of these files now has exactly 2 real layers (fixtures, then
  everything that uses them), so the old ranges were doubly wrong.
  Dropped the parenthetical from all four rather than substituting a
  new number that carries no information beyond what the file's own
  `;---- Layer N` headings already show.

No `#?(...)` reader-conditional-wrapped defs in this component, so the
SL008 fix in the current pin never came into play.

## Testing Plan

1. Ran plain (non-`--fix`) `stratum-lint` before any change — reproduced
   the findings above exactly, confirmed 0 `SL001`.
2. Ran `--fix` over the whole component — 14 files rewritten.
3. Ran `--fix` a second time immediately after — zero diff, confirms
   idempotency.
4. Read the full diff for all 14 changed files. Found and hand-fixed the
   contradictory `Layer 0.7` banner in `core.clj`; updated 6 stale
   namespace docstrings (above); confirmed the two trailing-comment
   re-spacings in `schema.clj` didn't displace anything.
5. Ran `--fix` two more times after the hand edits — zero diff both
   times, confirms the manual fixes are stable under the tool.
6. `clj-kondo --lint components/repo-dag`: 0 errors, 0 warnings — both
   before and after.
7. Ran all 11 test namespaces directly via `clojure -M:dev:test`
   (`add-edge-test`, `add-repo-test`, `queries-test`,
   `remove-edge-test`, `remove-repo-test`, `validate-schema-test` under
   `anomaly.*`, plus `dag-crud-test`, `dag-integration-test`,
   `dag-queries-test`, `dag-topology-test`, `dag-validation-test`): 67
   tests, 230 assertions, 0 failures, 0 errors.
8. Re-ran plain `stratum-lint` after the fix: `SL001`/`SL002`/`SL004`
   clear across the component. `SL003` remains, newly surfaced (higher
   than the pre-fix decorative count, not a regression) on two files:
   - `core.clj`: 5 real layers (pure DAG primitives/protocol/store
     helpers → schema-validating siblings/traversal/validation →
     schema-aware constructors/CRUD impls → the `InMemoryDagManager`
     defrecord → the `create-manager` factory).
   - `schema.clj`: 5 real layers (enums/base types/standalone schemas →
     registry/`infer-layer` → `RepoNode`/`RepoEdge` → `RepoDag`/node-edge
     validators → `valid-repo-dag?`).

   Both are genuinely over the 3-layer budget the old decorative
   headings hid by undercounting (4 vs the real 5), not a regression
   this PR introduces — deferred to Wave 2 (real namespace split),
   consistent with how prior Wave 1 PRs (e.g. `schema`, `control-plane`)
   handled the same situation. `interface.clj`'s original `SL003` is
   fully resolved (collapsed to 1 real layer, well under budget).

## Deployment Plan

Merges to `main` like any other component change. No runtime behavior
change — comment/metadata/order/docstring-only. Pre-commit's
`lint:stratum` autofixer keeps this component clean going forward;
`core.clj` and `schema.clj`'s `SL003` stay advisory
(`MINIFORGE_STRATUM_BUDGET_MODE=warn` at commit time) until Wave 2
splits them.

## Related Issues/PRs

- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
- Precedent for the decorative-banner hand-fix: `5bc460080` (fix:
  correct stale/placeholder Layer headings in phase-software-factory
  tests)
- Follow-on: Wave 2 namespace split for
  `components/repo-dag/src/ai/miniforge/repo_dag/core.clj` and
  `components/repo-dag/src/ai/miniforge/repo_dag/schema.clj` (5 real
  layers each, over the 3-layer budget)

## Checklist

- [x] Plain lint confirmed zero `SL001` before touching anything
- [x] `--fix` run over the whole component (`src` + `test`)
- [x] Second `--fix` pass confirms idempotency (zero diff)
- [x] Diff read in full for all 14 changed files
- [x] Contradictory decorative `Layer 0.7` banner (`core.clj`) found and
      removed by hand; keeping "Validation functions" as a plain comment
- [x] Six namespace docstrings (`core.clj`, `schema.clj`,
      `dag_crud_test.clj`, `dag_queries_test.clj`,
      `dag_topology_test.clj`, `dag_validation_test.clj`) updated to
      drop/replace stale layer counts or ranges
- [x] Two further `--fix` passes after hand edits confirm stability
      (zero diff)
- [x] `clj-kondo` clean (0 errors, 0 warnings before/after)
- [x] Component tests pass (67 tests, 230 assertions, 0 failures/errors)
- [x] Plain lint re-run post-fix: zero `SL001`/`SL002`/`SL004`; `SL003`
      remains on `core.clj` and `schema.clj` — newly surfaced by the fix
      (not pre-existing), tracked as Wave 2 above
- [x] No `--no-verify`; pre-commit hook runs normally at commit time
