### PR TITLE
fix: restructure bb-test-runner's reader-conditional to clear SL008

### DIFF
--- a/components/bb-test-runner/src/ai/miniforge/bb_test_runner/core.cljc
+++ b/components/bb-test-runner/src/ai/miniforge/bb_test_runner/core.cljc
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.bb-test-runner.core
   "Discover and run every `*_test.clj` file under each `/test` root on
    the Babashka classpath. The discovery helpers here are pure and
@@ -40,54 +39,46 @@
    [java.util ArrayList Collection Collections Random]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Path and deps helpers (pure)
 
-(def ^:private cloverage-version
+;; Path and deps helpers (pure)
+(def ^{:stratum 0} ^:private cloverage-version
   "1.2.4")
 
-(def ^:private default-coverage-output
+(def ^{:stratum 0} ^:private default-coverage-output
   "target/coverage")
 
-(def ^:private stable-tag-glob-patterns
+(def ^{:stratum 0} ^:private stable-tag-glob-patterns
   "Supported stable-tag glob patterns.
    The repo has historical `stable-*` tags and a few older `stable/*`
    variants, so the wrapper treats both as stable baselines."
   ["stable-*" "stable/*"])
 
-(def ^:private default-heartbeat-seconds
+(def ^{:stratum 0} ^:private default-heartbeat-seconds
   30)
 
-(def ^:private default-expand-start-size
+(def ^{:stratum 0} ^:private default-expand-start-size
   1)
 
-(def ^:private git-worktree-env-keys
+(def ^{:stratum 0} ^:private git-worktree-env-keys
   ["GIT_INDEX_FILE" "GIT_DIR" "GIT_WORK_TREE" "GIT_COMMON_DIR"])
 
-(def ^:private changed-or-affected-projects-argv
+(def ^{:stratum 0} ^:private changed-or-affected-projects-argv
   ["clojure" "-M:poly" "ws" "get:changes:changed-or-affected-projects"
    "skip:dev" "color-mode:none"])
 
-(defn- path-segments
+(defn- ^{:stratum 0} path-segments
   [path]
   (str/split path #"/"))
 
-(defn- test-segment?
+(defn- ^{:stratum 0} test-segment?
   [segment]
   (boolean (re-find #"^test($|-)" segment)))
 
-(defn- resource-segment?
+(defn- ^{:stratum 0} resource-segment?
   [segment]
   (str/includes? segment "resources"))
 
-(defn- test-path?
-  [path]
-  (some test-segment? (path-segments path)))
-
-(defn- resource-path?
-  [path]
-  (some resource-segment? (path-segments path)))
-
-(defn path->ns-symbol
+(defn ^{:stratum 0} path->ns-symbol
   "Convert a `*_test.clj` file path, relative to a classpath `/test`
    root, into its namespace symbol. Strips `.clj`, converts `/` to `.`,
    and underscores to hyphens."
@@ -98,68 +89,13 @@
       (str/replace "_" "-")
       symbol))
 
-(defn discover-test-namespaces
-  "Given a seq of `/test` roots, return a seq of `{:file :ns}` maps for
-   every `*_test.clj` under each root."
-  [roots]
-  (mapcat (fn [root]
-            (->> (fs/glob root "**_test.clj")
-                 (map (fn [p]
-                        {:file (str p)
-                         :ns   (path->ns-symbol
-                                (str (fs/relativize root p)))}))))
-          roots))
-
-(defn- normalized-alias-keys
+(defn- ^{:stratum 0} normalized-alias-keys
   [{:keys [alias-key alias-keys]}]
   (vec (or alias-keys
            (when alias-key [alias-key])
            [:test])))
 
-(defn merge-deps-config
-  "Merge the root deps.edn data with one or more alias keys into a
-   runnable config map of `{:paths [...], :deps {...}}`."
-  [deps-config opts]
-  (let [alias-keys (normalized-alias-keys opts)
-        alias-configs (map #(get-in deps-config [:aliases %] {}) alias-keys)
-        alias-paths (mapcat #(get % :extra-paths []) alias-configs)
-        alias-deps (apply merge (map #(get % :extra-deps {}) alias-configs))
-        base-paths (get deps-config :paths [])
-        base-deps (get deps-config :deps {})]
-    {:paths (vec (concat base-paths alias-paths))
-     :deps (merge base-deps alias-deps)}))
-
-(defn classify-coverage-paths
-  "Split merged classpath paths into source and test roots for
-   Cloverage. Resource roots are excluded from instrumentation."
-  [paths]
-  (let [test-paths (->> paths
-                        (filter test-path?)
-                        vec)
-        source-paths (->> paths
-                          (remove test-path?)
-                          (remove resource-path?)
-                          vec)]
-    {:source-paths source-paths
-     :test-paths test-paths}))
-
-(defn build-coverage-sdeps
-  "Build an ad hoc deps map suitable for running Cloverage against the
-   repo's test classpath."
-  [deps-config opts]
-  (let [{:keys [paths deps]} (merge-deps-config deps-config opts)]
-    {:paths paths
-     :deps (assoc deps
-                  'cloverage/cloverage
-                  {:mvn/version cloverage-version})}))
-
-(defn stable-tag-globs
-  "Return the stable-tag glob patterns recognized by Miniforge's
-   stable-derived test scope."
-  []
-  stable-tag-glob-patterns)
-
-(defn stable-tags-present?
+(defn ^{:stratum 0} stable-tags-present?
   "True when `tags` contains at least one recognized stable tag."
   [tags]
   (boolean
@@ -170,7 +106,7 @@
                       (str/starts-with? normalized "stable/")))))
          tags)))
 
-(defn parse-project-selector
+(defn ^{:stratum 0} parse-project-selector
   "Parse a Polylith project selector or env value into a vector of
    project names.
 
@@ -190,43 +126,116 @@
          (remove str/blank?)
          vec)))
 
-(defn format-project-selector
+(defn ^{:stratum 0} format-project-selector
   "Render an explicit Polylith project selector argument from project
    names."
   [projects]
   (when (seq projects)
     (str "project:" (str/join ":" projects))))
 
-(defn changed-projects-command
-  "Return the argv that queries Polylith for the current changed-or-
-   affected project set."
-  []
-  changed-or-affected-projects-argv)
-
-(defn changed-projects-since-stable-command
-  "Return the argv that queries Polylith for changed-or-affected
-   projects since the current stable tag anchor."
-  []
-  (let [argv (vec (changed-projects-command))
-        marker "get:changes:changed-or-affected-projects"
-        marker-index (.indexOf argv marker)]
-    (if (neg? marker-index)
-      (throw (ex-info "Invariant failed: changed-projects command is missing the Polylith change marker."
-                      {:argv argv
-                       :marker marker}))
-      (let [insert-index (inc marker-index)]
-        (vec (concat (subvec argv 0 insert-index)
-                     ["since:stable"]
-                     (subvec argv insert-index)))))))
-
-(defn- parse-error
+(defn- ^{:stratum 0} parse-error
   [code message data]
   {:ok? false
    :error {:code code
            :message message
            :data data}})
 
-(defn parse-project-list-output
+(defn- ^{:stratum 0} shuffle-projects
+  [projects seed]
+  (let [alist (ArrayList. ^Collection projects)]
+    (Collections/shuffle alist (Random. (long (or seed 0))))
+    (vec alist)))
+
+(defn ^{:stratum 0} bisect-project-groups
+  "Return contiguous project groups in breadth-first binary partition
+   order."
+  [projects]
+  (let [root (vec projects)]
+    (loop [queue (cond-> PersistentQueue/EMPTY
+                   (> (count root) 1) (conj root))
+           groups []]
+      (if (empty? queue)
+        groups
+        (let [group (peek queue)
+              queue-tail (pop queue)
+              mid (quot (count group) 2)
+              left (subvec group 0 mid)
+              right (subvec group mid)
+              next-groups (cond-> groups
+                            (seq left) (conj left)
+                            (seq right) (conj right))
+              next-queue (cond-> queue-tail
+                           (> (count left) 1) (conj left)
+                           (> (count right) 1) (conj right))]
+          (recur next-queue next-groups))))))
+
+(defn ^{:stratum 0} load-deps-config
+  "Read and parse a repo-local deps.edn file."
+  [repo-root]
+  (let [deps-path (str (fs/path repo-root "deps.edn"))]
+    (edn/read-string
+     (String. (Files/readAllBytes (.toPath (fs/file deps-path)))
+              StandardCharsets/UTF_8))))
+
+(defn- ^{:stratum 0} classpath-test-roots
+  "Return the `/test` roots on the current Babashka classpath. Under
+   JVM Clojure, `babashka.classpath` doesn't exist, so this throws an
+   explicit unsupported-runtime error instead."
+  []
+  #?(:bb (->> (bb-classpath/split-classpath (bb-classpath/get-classpath))
+              (filter #(str/ends-with? % "/test")))
+     :default (throw (ex-info "Unsupported runtime: bb-test-runner run-all is only available under Babashka"
+                              {:runtime :jvm
+                               :namespace 'ai.miniforge.bb-test-runner.core}))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} test-path?
+  [path]
+  (some test-segment? (path-segments path)))
+
+(defn- ^{:stratum 1} resource-path?
+  [path]
+  (some resource-segment? (path-segments path)))
+
+(defn ^{:stratum 1} discover-test-namespaces
+  "Given a seq of `/test` roots, return a seq of `{:file :ns}` maps for
+   every `*_test.clj` under each root."
+  [roots]
+  (mapcat (fn [root]
+            (->> (fs/glob root "**_test.clj")
+                 (map (fn [p]
+                        {:file (str p)
+                         :ns   (path->ns-symbol
+                                (str (fs/relativize root p)))}))))
+          roots))
+
+(defn ^{:stratum 1} merge-deps-config
+  "Merge the root deps.edn data with one or more alias keys into a
+   runnable config map of `{:paths [...], :deps {...}}`."
+  [deps-config opts]
+  (let [alias-keys (normalized-alias-keys opts)
+        alias-configs (map #(get-in deps-config [:aliases %] {}) alias-keys)
+        alias-paths (mapcat #(get % :extra-paths []) alias-configs)
+        alias-deps (apply merge (map #(get % :extra-deps {}) alias-configs))
+        base-paths (get deps-config :paths [])
+        base-deps (get deps-config :deps {})]
+    {:paths (vec (concat base-paths alias-paths))
+     :deps (merge base-deps alias-deps)}))
+
+(defn ^{:stratum 1} stable-tag-globs
+  "Return the stable-tag glob patterns recognized by Miniforge's
+   stable-derived test scope."
+  []
+  stable-tag-glob-patterns)
+
+(defn ^{:stratum 1} changed-projects-command
+  "Return the argv that queries Polylith for the current changed-or-
+   affected project set."
+  []
+  changed-or-affected-projects-argv)
+
+(defn ^{:stratum 1} parse-project-list-output
   "Parse a Polylith `ws get:changes:changed-or-affected-projects`
    response into a vector of project names.
 
@@ -251,7 +260,7 @@
                        {:output output
                         :cause (.getMessage e)}))))))
 
-(defn sanitize-git-worktree-env
+(defn ^{:stratum 1} sanitize-git-worktree-env
   "Remove git worktree/index variables that must not leak into child
    processes.
 
@@ -262,7 +271,7 @@
   [env]
   (apply dissoc env git-worktree-env-keys))
 
-(defn heartbeat-seconds
+(defn ^{:stratum 1} heartbeat-seconds
   "Return the heartbeat interval, defaulting to 30 seconds.
    Invalid, missing, or non-positive values fall back to the default."
   [env]
@@ -279,7 +288,7 @@
           parsed
           default-heartbeat-seconds)))))
 
-(defn- parse-long-arg
+(defn- ^{:stratum 1} parse-long-arg
   [arg prefix]
   (let [raw (subs arg (count prefix))]
     (try
@@ -292,14 +301,126 @@
                       :expected-format (str prefix "N")
                       :cause (.getMessage ex)})))))
 
-(defn- assoc-long-arg
+(defn ^{:stratum 1} order-projects
+  "Apply diagnostic ordering controls to a project vector."
+  [projects {:keys [direction order seed]}]
+  (let [ordered (case order
+                  :random (shuffle-projects projects seed)
+                  (vec projects))]
+    (case direction
+      :back (vec (reverse ordered))
+      ordered)))
+
+(defn- ^{:stratum 1} positive-start-size
+  [project-count requested-size]
+  (-> (or requested-size default-expand-start-size)
+      (max default-expand-start-size)
+      (min project-count)))
+
+(defn ^{:stratum 1} coverage-install-args
+  "Build the JVM argv that prefetches the Cloverage tool dependency."
+  []
+  ["-P"
+   "-Sdeps"
+   (pr-str {:deps {'cloverage/cloverage {:mvn/version cloverage-version}}})])
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} classify-coverage-paths
+  "Split merged classpath paths into source and test roots for
+   Cloverage. Resource roots are excluded from instrumentation."
+  [paths]
+  (let [test-paths (->> paths
+                        (filter test-path?)
+                        vec)
+        source-paths (->> paths
+                          (remove test-path?)
+                          (remove resource-path?)
+                          vec)]
+    {:source-paths source-paths
+     :test-paths test-paths}))
+
+(defn ^{:stratum 2} build-coverage-sdeps
+  "Build an ad hoc deps map suitable for running Cloverage against the
+   repo's test classpath."
+  [deps-config opts]
+  (let [{:keys [paths deps]} (merge-deps-config deps-config opts)]
+    {:paths paths
+     :deps (assoc deps
+                  'cloverage/cloverage
+                  {:mvn/version cloverage-version})}))
+
+(defn ^{:stratum 2} changed-projects-since-stable-command
+  "Return the argv that queries Polylith for changed-or-affected
+   projects since the current stable tag anchor."
+  []
+  (let [argv (vec (changed-projects-command))
+        marker "get:changes:changed-or-affected-projects"
+        marker-index (.indexOf argv marker)]
+    (if (neg? marker-index)
+      (throw (ex-info "Invariant failed: changed-projects command is missing the Polylith change marker."
+                      {:argv argv
+                       :marker marker}))
+      (let [insert-index (inc marker-index)]
+        (vec (concat (subvec argv 0 insert-index)
+                     ["since:stable"]
+                     (subvec argv insert-index)))))))
+
+(defn- ^{:stratum 2} assoc-long-arg
   [acc k arg prefix]
   (let [parsed (parse-long-arg arg prefix)]
     (if (:ok? parsed)
       (assoc acc k (:data parsed))
       (reduced parsed))))
 
-(defn parse-diagnostic-args
+(defn ^{:stratum 2} expand-project-groups
+  "Return additive project groups that double in size until they cover
+   the full ordered project set."
+  [projects start-size]
+  (let [project-vec (vec projects)
+        project-count (count project-vec)]
+    (if (zero? project-count)
+      []
+      (loop [group-size (positive-start-size project-count start-size)
+             groups []]
+        (let [group (subvec project-vec 0 group-size)
+              next-groups (conj groups group)]
+          (if (= group-size project-count)
+            next-groups
+            (recur (min project-count (* 2 group-size))
+                   next-groups)))))))
+
+;; Wiring — the actual task entry points
+(defn ^{:stratum 2} run-all
+  "Require every discovered test namespace, run `clojure.test`, and
+   exit non-zero via `System/exit` on any failure or error.
+
+   Babashka-only: relies on `babashka.classpath`. The function-local require is
+   the intentional test discovery boundary; discovered test namespaces are data,
+   not static product dependencies."
+  []
+  (let [files (discover-test-namespaces (classpath-test-roots))]
+    (doseq [{:keys [ns]} files]
+      (require ns))
+    (let [{:keys [fail error]} (apply t/run-tests (map :ns files))]
+      (System/exit (if (pos? (+ (or fail 0) (or error 0))) 1 0)))))
+
+(defn ^{:stratum 2} install-coverage-tool
+  "Prefetch the Cloverage dependency into the repo's local Clojure cache."
+  [{:keys [repo-root]}]
+  (let [root (or repo-root ".")
+        args (coverage-install-args)]
+    (shell/with-sh-dir root
+      (let [{:keys [exit out err]} (apply shell/sh "clojure" args)]
+        (when-not (str/blank? out)
+          (println out))
+        (when-not (str/blank? err)
+          (.println System/err err))
+        exit))))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} parse-diagnostic-args
   "Parse supported stable-derived diagnostic CLI arguments.
 
    Supported forms:
@@ -335,69 +456,7 @@
    {}
    args))
 
-(defn- shuffle-projects
-  [projects seed]
-  (let [alist (ArrayList. ^Collection projects)]
-    (Collections/shuffle alist (Random. (long (or seed 0))))
-    (vec alist)))
-
-(defn order-projects
-  "Apply diagnostic ordering controls to a project vector."
-  [projects {:keys [direction order seed]}]
-  (let [ordered (case order
-                  :random (shuffle-projects projects seed)
-                  (vec projects))]
-    (case direction
-      :back (vec (reverse ordered))
-      ordered)))
-
-(defn- positive-start-size
-  [project-count requested-size]
-  (-> (or requested-size default-expand-start-size)
-      (max default-expand-start-size)
-      (min project-count)))
-
-(defn expand-project-groups
-  "Return additive project groups that double in size until they cover
-   the full ordered project set."
-  [projects start-size]
-  (let [project-vec (vec projects)
-        project-count (count project-vec)]
-    (if (zero? project-count)
-      []
-      (loop [group-size (positive-start-size project-count start-size)
-             groups []]
-        (let [group (subvec project-vec 0 group-size)
-              next-groups (conj groups group)]
-          (if (= group-size project-count)
-            next-groups
-            (recur (min project-count (* 2 group-size))
-                   next-groups)))))))
-
-(defn bisect-project-groups
-  "Return contiguous project groups in breadth-first binary partition
-   order."
-  [projects]
-  (let [root (vec projects)]
-    (loop [queue (cond-> PersistentQueue/EMPTY
-                   (> (count root) 1) (conj root))
-           groups []]
-      (if (empty? queue)
-        groups
-        (let [group (peek queue)
-              queue-tail (pop queue)
-              mid (quot (count group) 2)
-              left (subvec group 0 mid)
-              right (subvec group mid)
-              next-groups (cond-> groups
-                            (seq left) (conj left)
-                            (seq right) (conj right))
-              next-queue (cond-> queue-tail
-                           (> (count left) 1) (conj left)
-                           (> (count right) 1) (conj right))]
-          (recur next-queue next-groups))))))
-
-(defn diagnostic-test-plan
+(defn ^{:stratum 3} diagnostic-test-plan
   "Return a stable-derived diagnostic plan over an explicit project
    vector."
   [{:keys [mode projects start-size direction order seed]}]
@@ -434,10 +493,8 @@
                   (range)
                   project-groups)}))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Coverage command derivation (pure)
-
-(defn coverage-args
+(defn ^{:stratum 3} coverage-args
   "Build the JVM command argv for a Cloverage run over the repo at the
    given deps config."
   [deps-config {:keys [output-dir fail-threshold] :as opts
@@ -460,67 +517,9 @@
                  source-args
                  test-args))))
 
-(defn load-deps-config
-  "Read and parse a repo-local deps.edn file."
-  [repo-root]
-  (let [deps-path (str (fs/path repo-root "deps.edn"))]
-    (edn/read-string
-     (String. (Files/readAllBytes (.toPath (fs/file deps-path)))
-              StandardCharsets/UTF_8))))
+;------------------------------------------------------------------------------ Layer 4
 
-(defn coverage-install-args
-  "Build the JVM argv that prefetches the Cloverage tool dependency."
-  []
-  ["-P"
-   "-Sdeps"
-   (pr-str {:deps {'cloverage/cloverage {:mvn/version cloverage-version}}})])
-
-#?(:bb
-   (defn- classpath-test-roots
-     "Return the `/test` roots on the current Babashka classpath."
-     []
-     (->> (bb-classpath/split-classpath (bb-classpath/get-classpath))
-          (filter #(str/ends-with? % "/test"))))
-
-   :clj
-   (defn- classpath-test-roots
-     "JVM placeholder for the Babashka-only classpath discovery path."
-     []
-     (throw (ex-info "Unsupported runtime: bb-test-runner run-all is only available under Babashka"
-                     {:runtime :jvm
-                      :namespace 'ai.miniforge.bb-test-runner.core}))))
-
-;------------------------------------------------------------------------------ Layer 2
-;; Wiring — the actual task entry points
-
-(defn run-all
-  "Require every discovered test namespace, run `clojure.test`, and
-   exit non-zero via `System/exit` on any failure or error.
-
-   Babashka-only: relies on `babashka.classpath`. The function-local require is
-   the intentional test discovery boundary; discovered test namespaces are data,
-   not static product dependencies."
-  []
-  (let [files (discover-test-namespaces (classpath-test-roots))]
-    (doseq [{:keys [ns]} files]
-      (require ns))
-    (let [{:keys [fail error]} (apply t/run-tests (map :ns files))]
-      (System/exit (if (pos? (+ (or fail 0) (or error 0))) 1 0)))))
-
-(defn install-coverage-tool
-  "Prefetch the Cloverage dependency into the repo's local Clojure cache."
-  [{:keys [repo-root]}]
-  (let [root (or repo-root ".")
-        args (coverage-install-args)]
-    (shell/with-sh-dir root
-      (let [{:keys [exit out err]} (apply shell/sh "clojure" args)]
-        (when-not (str/blank? out)
-          (println out))
-        (when-not (str/blank? err)
-          (.println System/err err))
-        exit))))
-
-(defn run-coverage
+(defn ^{:stratum 4} run-coverage
   "Run Cloverage for the repo rooted at `repo-root` using the selected
    deps.edn alias. Streams output and returns the process exit code."
   [{:keys [repo-root] :as opts}]

--- a/docs/pull-requests/2026-07-26-fix-sl008-bb-test-runner-reader-cond.md
+++ b/docs/pull-requests/2026-07-26-fix-sl008-bb-test-runner-reader-cond.md
@@ -1,0 +1,147 @@
+# fix: restructure bb-test-runner's reader-conditional to clear SL008
+
+## Overview
+
+`components/bb-test-runner/src/ai/miniforge/bb_test_runner/core.cljc`
+defines `classpath-test-roots` as a whole top-level
+`#?(:bb (defn- classpath-test-roots ...) :clj (defn- classpath-test-roots
+...))` form, referenced by the same-file `run-all`. This is exactly the
+shape `stratum-lint`'s `SL008` guard (added in
+[stratum-lint#15](https://github.com/miniforge-ai/stratum-lint/pull/15),
+merged same day, pin bumped in miniforge PR
+[#1515](https://github.com/miniforge-ai/miniforge/pull/1515)) exists to
+catch: `--fix`'s `def-form?` never recognizes a `defn`/`defn-` nested
+inside a reader-conditional splice, so a naive `--fix` pass would
+silently relocate `classpath-test-roots` past `run-all` and break
+compilation, the same way `create-datalevin-store` broke
+`components/artifact/interface.cljc` before that Wave 1 PR (#1514)
+restructured it.
+
+SL008 now refuses instead of corrupting the file — but that turns the
+first `--fix` pass over this component (whenever its own Wave 1 PR
+lands) into a hard pre-commit block rather than a silent bug. Cheaper to
+restructure now than to hit the block later.
+
+Confirmed via direct testing, not just inspection, that this is the
+*only* remaining at-risk file: grepped the tree for the same
+`#?(:bb ... :clj ...)`-wrapped top-level `defn`/`defn-` shape and ran
+plain lint + `--fix` (current pin) against every hit not already fixed.
+`workflow/interface/resume.cljc` and
+`event-stream/interface/manifest.cljc` both produced zero diff — their
+wrapped defs have no same-file caller recognized outside another
+wrapped form, so they're not at risk. `bb-test-runner/core.cljc` tripped
+SL008 exactly as predicted. No new stratum-lint issue was filed:
+stratum-lint#15's own PR body already names this exact file as a second
+confirmed hit, so an issue would have duplicated a fix that's already
+merged.
+
+## Changes in Detail
+
+`classpath-test-roots` restructured to match the convention
+`components/datalevin/interface.cljc` and `components/artifact/interface.cljc`
+already use: the `#?()` split now lives inside the function body instead
+of wrapping the whole top-level form, and uses `:default` instead of
+`:clj` (this codebase's `.cljc` reader-conditional convention — `:clj`
+would leave the else branch invisible to some non-JVM-Clojure readers
+that only understand `:default`).
+
+```clojure
+(defn- classpath-test-roots
+  "Return the `/test` roots on the current Babashka classpath. Under
+   JVM Clojure, `babashka.classpath` doesn't exist, so this throws an
+   explicit unsupported-runtime error instead."
+  []
+  #?(:bb (->> (bb-classpath/split-classpath (bb-classpath/get-classpath))
+              (filter #(str/ends-with? % "/test")))
+     :default (throw (ex-info "Unsupported runtime: bb-test-runner run-all is only available under Babashka"
+                              {:runtime :jvm
+                               :namespace 'ai.miniforge.bb-test-runner.core}))))
+```
+
+Behavior is unchanged: same Babashka classpath lookup, same JVM-side
+`ex-info` throw. Only the reader-conditional's syntactic position moved
+by hand.
+
+**Scope grew once staged, unavoidably.** `classpath-test-roots` was
+previously invisible to `stratum-lint`'s reference graph (the whole
+point of the SL008 bug). The moment it became a normal, recognized
+`defn-`, pre-commit's `lint:stratum` autofix hook ran its one-time
+full-file `--fix` pass over this file for the first time and added
+`^{:stratum n}` metadata to every def in it (234/235 line diff) — this
+is the documented, expected behavior on first touch of a not-yet-Waved
+file, not something this PR chose to do.
+
+That full pass also surfaced a genuine, pre-existing `SL003`: the file
+uses 5 distinct layers against the 3-layer budget. This is unrelated to
+the SL008 fix — it's this component's real Wave 1 finding, just hidden
+until `--fix` could see the full reference graph. Splitting the
+namespace to resolve it is out of scope for a fix that's supposed to be
+about one reader-conditional; deferred to this component's own future
+Wave 1 PR (`work/stratum-lint-baseline-2026-07-24.md`), same as
+`components/artifact`'s `transit_store.clj`/`transit_store_test.clj`
+findings were deferred in PR #1514. Committed with
+`MINIFORGE_STRATUM_BUDGET_MODE=warn` to pass the pre-commit gate for
+this one, already-known, already-deferred finding.
+
+## Testing Plan
+
+1. Loaded the namespace under both runtimes: `bb -e "(require
+   'ai.miniforge.bb-test-runner.core)"` succeeds; under JVM Clojure
+   (`clojure -Sdeps ... -M -e ...` with the component's paths/deps on
+   the classpath), the namespace loads and calling
+   `classpath-test-roots` throws the expected
+   `Unsupported runtime: bb-test-runner run-all is only available under
+   Babashka` `ex-info`, matching the pre-change JVM placeholder exactly.
+2. `clj-kondo --lint components/bb-test-runner`: 0 errors, 0 warnings.
+3. Plain (non-`--fix`) `stratum-lint` on the changed file: silent — no
+   SL008, no other finding.
+4. Ran the component's own test suite (`cognitect.test-runner` against
+   `components/bb-test-runner/test`): 32 tests, 64 assertions, 0
+   failures/errors.
+5. Confirmed via direct experiment that a plain `--fix` pass over the
+   whole file now succeeds (no more SL008) but also fully restratifies
+   every def in the file — this happened for real at commit time via
+   the `lint:stratum` pre-commit hook, not just in a manual test. Ran
+   `--fix` a second time afterward: zero diff, confirms the committed
+   state is a stable fixed point.
+6. Re-ran `clj-kondo` and the component test suite (32 tests, 64
+   assertions, 0 failures/errors) against the final, fully-restratified
+   file actually being committed — not just the pre-hook minimal edit.
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+change: only the reader-conditional restructure and the mechanical
+`^{:stratum n}` tagging that followed from it. The SL003 finding (5
+layers, over budget) is deferred, not resolved — this component's own
+Wave 1 namespace-split PR remains open work, tracked in
+`work/stratum-lint-baseline-2026-07-24.md`.
+
+## Related Issues/PRs
+
+- Upstream fix: [stratum-lint#15](https://github.com/miniforge-ai/stratum-lint/pull/15)
+  (SL008 guard, merged)
+- Pin bump: miniforge [#1515](https://github.com/miniforge-ai/miniforge/pull/1515)
+- Origin of the pattern: miniforge [#1514](https://github.com/miniforge-ai/miniforge/pull/1514)
+  (`components/artifact` Wave 1, `interface.cljc` restructure)
+- Baseline/wave tracking: `work/stratum-lint-baseline-2026-07-24.md`
+
+## Checklist
+
+- [x] Grepped the tree for other `#?(:bb ...)`-wrapped top-level
+      `defn`/`defn-` forms; tested all remaining unresolved candidates
+      directly against the current stratum-lint pin
+- [x] Confirmed `workflow/interface/resume.cljc` and
+      `event-stream/interface/manifest.cljc` are safe (zero diff under
+      `--fix`), not just safe-by-inspection
+- [x] Restructured `bb-test-runner/core.cljc`'s only at-risk def
+- [x] Verified under both `bb` and JVM Clojure
+- [x] `clj-kondo` clean
+- [x] Plain lint clean (no SL008)
+- [x] Component tests pass (32 tests, 64 assertions, 0 failures/errors)
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time
+- [x] Second `--fix` pass confirms idempotency (zero diff)
+- [x] Pre-existing SL003 (5 layers, over budget) documented and deferred
+      to this component's own Wave 1 PR, same pattern as PR #1514's
+      deferred `transit_store.clj` findings; committed with
+      `MINIFORGE_STRATUM_BUDGET_MODE=warn` for this one known finding


### PR DESCRIPTION
## Summary

- `classpath-test-roots` in `components/bb-test-runner/src/ai/miniforge/bb_test_runner/core.cljc` was a whole top-level `#?(:bb ... :clj ...)` form referenced by same-file `run-all` — exactly the shape `stratum-lint`'s `SL008` guard ([stratum-lint#15](https://github.com/miniforge-ai/stratum-lint/pull/15), pin bumped in #1515) exists to catch, since `--fix` can't see a `defn` nested inside a reader conditional and would otherwise silently relocate it past its caller (the same class of bug that broke `components/artifact/interface.cljc` in #1514).
- Restructured to match the `datalevin`/`artifact` convention: the `#?()` split now lives inside the function body, `:default` not `:clj`.
- Confirmed by directly testing `--fix` against every other `#?(:bb ...)`-wrapped top-level def in the tree: `workflow/interface/resume.cljc` and `event-stream/interface/manifest.cljc` are genuinely safe (zero diff), so this was the only remaining at-risk file. No new stratum-lint issue filed — PR #15's own body already names this exact file.
- Making the def visible triggered pre-commit's one-time full-file `--fix` pass (expected on first touch of a not-yet-Waved file), which mechanically tagged every def with `^{:stratum n}` and surfaced a genuine, pre-existing `SL003` (5 layers, budget 3) — unrelated to this fix, deferred to bb-test-runner's own future Wave 1 PR, same pattern as PR #1514's deferred `transit_store.clj` findings. Committed with `MINIFORGE_STRATUM_BUDGET_MODE=warn` and `MINIFORGE_COMMIT_BUDGET_OVERRIDE` for those two known, documented findings.

Full detail in `docs/pull-requests/2026-07-26-fix-sl008-bb-test-runner-reader-cond.md`.

## Test plan

- [x] Loaded under both `bb` and JVM Clojure; JVM branch throws the expected `ex-info`
- [x] `clj-kondo --lint components/bb-test-runner`: 0 errors, 0 warnings
- [x] Plain lint clean (no SL008)
- [x] Component tests: 32 tests, 64 assertions, 0 failures/errors
- [x] Second `--fix` pass: zero diff (stable fixed point)
- [x] Pre-commit smoke suite (331 tests, 1241 assertions) and GraalVM/Babashka compatibility (8 tests, 546 assertions) both passed
- [x] SL003 (5 layers, over budget) documented and deferred to a future Wave 1 PR for this component
- [x] No `--no-verify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)