### PR TITLE
fix: stratum-lint autofix for components/repo-index (Wave 1)

### DIFF
--- a/components/repo-index/src/ai/miniforge/repo_index/factory.clj
+++ b/components/repo-index/src/ai/miniforge/repo_index/factory.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.repo-index.factory
   "Factory functions for repo-index domain maps.
 
@@ -25,9 +24,9 @@
    Layer 0 — pure data construction, no I/O or side effects.")
 
 ;------------------------------------------------------------------------------ Layer 0
-;; FileRecord
 
-(defn ->file-record
+;; FileRecord
+(defn ^{:stratum 0} ->file-record
   "Create a FileRecord map."
   [path blob-sha size lines language generated?]
   {:path path
@@ -37,10 +36,8 @@
    :language language
    :generated? generated?})
 
-;------------------------------------------------------------------------------ Layer 0
 ;; RepoIndex
-
-(defn ->repo-index
+(defn ^{:stratum 0} ->repo-index
   "Create a RepoIndex map from entries and computed language frequencies."
   [tree-sha repo-root entries languages]
   {:tree-sha tree-sha
@@ -51,10 +48,8 @@
    :languages languages
    :indexed-at (java.util.Date.)})
 
-;------------------------------------------------------------------------------ Layer 0
 ;; RepoMapEntry
-
-(defn ->repo-map-entry
+(defn ^{:stratum 0} ->repo-map-entry
   "Create a RepoMapEntry map from a FileRecord."
   [{:keys [path language lines size]}]
   {:path path
@@ -62,10 +57,8 @@
    :lines lines
    :size size})
 
-;------------------------------------------------------------------------------ Layer 0
 ;; RepoMapSlice
-
-(defn ->repo-map-slice
+(defn ^{:stratum 0} ->repo-map-slice
   "Create a RepoMapSlice result map."
   [tree-sha entries text total-files shown-files truncated? token-estimate]
   {:tree-sha tree-sha
@@ -76,10 +69,8 @@
    :truncated? truncated?
    :token-estimate token-estimate})
 
-;------------------------------------------------------------------------------ Layer 0
 ;; FileContent (returned by get-file)
-
-(defn ->file-content
+(defn ^{:stratum 0} ->file-content
   "Create a file-content result map."
   [path content lines truncated?]
   {:path path
@@ -87,37 +78,33 @@
    :lines lines
    :truncated? truncated?})
 
-;------------------------------------------------------------------------------ Layer 0
 ;; Render accumulator (used internally by repo-map generation)
-
-(defn ->render-acc
+(defn ^{:stratum 0} ->render-acc
   "Create the initial render accumulator."
   []
   {:text "" :tokens 0 :shown 0 :truncated? false})
 
-(defn render-acc-with
+(defn ^{:stratum 0} render-acc-with
   "Create a render accumulator with updated fields."
   [text tokens shown truncated?]
   {:text text :tokens tokens :shown shown :truncated? truncated?})
 
-;------------------------------------------------------------------------------ Layer 0
 ;; Search domain maps
-
-(defn ->snippet
+(defn ^{:stratum 0} ->snippet
   "Create a search result snippet map."
   [start-line end-line text]
   {:start-line start-line
    :end-line end-line
    :text text})
 
-(defn ->search-hit
+(defn ^{:stratum 0} ->search-hit
   "Create a search hit result map."
   [path score snippets]
   {:path path
    :score score
    :snippets snippets})
 
-(defn ->doc-entry
+(defn ^{:stratum 0} ->doc-entry
   "Create a document entry for the search inverted index."
   [path token-count term-freqs content]
   {:path path
@@ -125,13 +112,13 @@
    :term-freqs term-freqs
    :content content})
 
-(defn ->inverted-index
+(defn ^{:stratum 0} ->inverted-index
   "Create an empty inverted index accumulator."
   []
   {:term->doc-ids {}
    :doc-freq {}})
 
-(defn ->search-index
+(defn ^{:stratum 0} ->search-index
   "Create a SearchIndex map from docs, corpus stats, and inverted index."
   [doc-map doc-count avg-doc-length term->doc-ids doc-freq]
   {:docs doc-map

--- a/components/repo-index/src/ai/miniforge/repo_index/interface.clj
+++ b/components/repo-index/src/ai/miniforge/repo_index/interface.clj
@@ -15,15 +15,14 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.repo-index.interface
   "Public API for the repo-index component.
 
    Provides repository scanning, repo map generation, and file retrieval.
 
-   Layer 0: Schema re-exports
-   Layer 1: Index building and repo map
-   Layer 2: File retrieval"
+   Layer 0: Schema re-exports, index/map/search building, and index lookups
+   Layer 1: Single-file retrieval and repo-map text convenience
+   Layer 2: Batch file retrieval"
   (:require [ai.miniforge.repo-index.messages :as messages]
             [ai.miniforge.repo-index.schema :as schema]
             [ai.miniforge.repo-index.factory :as factory]
@@ -35,55 +34,51 @@
             [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Messages
 
-(def t
+;; Messages
+(def ^{:stratum 0} t
   "Look up a repo-index message by key, with optional param substitution."
   messages/t)
 
-;------------------------------------------------------------------------------ Layer 0
 ;; Schema re-exports
-
-(def FileRecord
+(def ^{:stratum 0} FileRecord
   "Malli schema (a [:map ...] vector) for a single file entry in the repo index.
    Keys: :path (non-empty string), :blob-sha (string, min 7), :size (int),
    :lines (int), :language (string or nil), :generated? (boolean)."
   schema/FileRecord)
 
-(def RepoIndex
+(def ^{:stratum 0} RepoIndex
   "Malli schema (a [:map ...] vector) for a complete repo index.
    Keys: :tree-sha (string, min 7), :repo-root (non-empty string),
    :files (vector of FileRecord), :file-count (int), :total-lines (int),
    :languages (map of string->int), :indexed-at (inst)."
   schema/RepoIndex)
 
-(def RepoMapEntry
+(def ^{:stratum 0} RepoMapEntry
   "Malli schema (a [:map ...] vector) for a single entry in the repo map.
    Keys: :path (non-empty string), :lang (string or nil), :lines (int),
    :size (int)."
   schema/RepoMapEntry)
 
-(def RepoMapSlice
+(def ^{:stratum 0} RepoMapSlice
   "Malli schema (a [:map ...] vector) for a token-budgeted repo map slice.
    Keys: :tree-sha (string, min 7), :entries (vector of RepoMapEntry),
    :total-files (int), :shown-files (int), :truncated? (boolean),
    :token-estimate (int)."
   schema/RepoMapSlice)
 
-(def SearchHit
+(def ^{:stratum 0} SearchHit
   "Malli schema (a [:map ...] vector) for a single search result.
    Keys: :path (non-empty string), :score (double), :snippets (vector of Snippet)."
   schema/SearchHit)
 
-(def Snippet
+(def ^{:stratum 0} Snippet
   "Malli schema (a [:map ...] vector) for a search result snippet.
    Keys: :start-line (int), :end-line (int), :text (string)."
   schema/Snippet)
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Index building
-
-(defn build-index
+(defn ^{:stratum 0} build-index
   "Build a repo index for a git repository.
 
    Uses cached index if tree-sha hasn't changed, otherwise performs a full scan.
@@ -102,10 +97,8 @@
           (storage/save-index repo-root index)
           index)))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Repo map
-
-(defn repo-map
+(defn ^{:stratum 0} repo-map
   "Generate a token-budgeted repo map from a repo index.
 
    Arguments:
@@ -119,15 +112,8 @@
   ([index] (repo-map/generate index))
   ([index opts] (repo-map/generate index opts)))
 
-(defn repo-map-text
-  "Convenience: generate repo map and return just the rendered text."
-  ([index] (:text (repo-map index)))
-  ([index opts] (:text (repo-map index opts))))
-
-;------------------------------------------------------------------------------ Layer 2
 ;; Lexical search
-
-(defn build-search-index
+(defn ^{:stratum 0} build-search-index
   "Build a BM25 search index from a repo index.
 
    Should be called once after build-index; the result is reusable for
@@ -141,7 +127,7 @@
   [repo-index]
   (search-lex/build-search-index repo-index))
 
-(defn search-lex
+(defn ^{:stratum 0} search-lex
   "Search the codebase by keyword using BM25 ranking.
 
    Arguments:
@@ -158,15 +144,13 @@
   ([search-index query] (search-lex/search search-index query))
   ([search-index query opts] (search-lex/search search-index query opts)))
 
-;------------------------------------------------------------------------------ Layer 3
 ;; File retrieval
-
-(defn- find-in-index
+(defn- ^{:stratum 0} find-in-index
   "Find a file record in the index by path. Returns nil if absent."
   [index file-path]
   (first (filter #(= (:path %) file-path) (:files index))))
 
-(defn- read-file-limited
+(defn- ^{:stratum 0} read-file-limited
   "Read a file from disk, truncating to max-lines.
    Returns a file-content map or nil on error."
   [repo-root file-path max-lines]
@@ -184,7 +168,19 @@
     (catch Exception _
       nil)))
 
-(defn get-file
+(defn ^{:stratum 0} find-files
+  "Find files in the index matching a predicate."
+  [index pred]
+  (filterv pred (:files index)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} repo-map-text
+  "Convenience: generate repo map and return just the rendered text."
+  ([index] (:text (repo-map index)))
+  ([index opts] (:text (repo-map index opts))))
+
+(defn ^{:stratum 1} get-file
   "Read a single file's contents from disk, using the index for validation.
 
    Arguments:
@@ -201,24 +197,21 @@
      (when (find-in-index index file-path)
        (read-file-limited (:repo-root index) file-path max-lines)))))
 
-(defn get-files
+(defn ^{:stratum 1} files-by-language
+  "Get all non-generated files for a given language."
+  [index language]
+  (find-files index
+    (fn [f] (and (= (:language f) language) (not (:generated? f))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} get-files
   "Read multiple files from disk, using the index for validation."
   ([index file-paths] (get-files index file-paths {}))
   ([index file-paths opts]
    (->> file-paths
         (map #(get-file index % opts))
         (filterv some?))))
-
-(defn find-files
-  "Find files in the index matching a predicate."
-  [index pred]
-  (filterv pred (:files index)))
-
-(defn files-by-language
-  "Get all non-generated files for a given language."
-  [index language]
-  (find-files index
-    (fn [f] (and (= (:language f) language) (not (:generated? f))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/repo-index/src/ai/miniforge/repo_index/messages.clj
+++ b/components/repo-index/src/ai/miniforge/repo_index/messages.clj
@@ -15,12 +15,13 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.repo-index.messages
   "Component-level message catalog for repo-index.
    Delegates to the shared messages component."
   (:require [ai.miniforge.messages.interface :as messages]))
 
-(def t
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} t
   (messages/create-translator "config/repo-index/messages/en-US.edn"
                               :repo-index/messages))

--- a/components/repo-index/src/ai/miniforge/repo_index/repo_map.clj
+++ b/components/repo-index/src/ai/miniforge/repo_index/repo_map.clj
@@ -18,7 +18,7 @@
 (ns ai.miniforge.repo-index.repo-map
   "Generate token-budgeted repo maps from a repo index.
 
-   Layer 1 — depends on factory (Layer 0)."
+   Depends on factory."
   (:require [clojure.string :as str]
             [ai.miniforge.repo-index.factory :as factory]
             [ai.miniforge.repo-index.messages :as messages]))

--- a/components/repo-index/src/ai/miniforge/repo_index/repo_map.clj
+++ b/components/repo-index/src/ai/miniforge/repo_index/repo_map.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.repo-index.repo-map
   "Generate token-budgeted repo maps from a repo index.
 
@@ -25,47 +24,82 @@
             [ai.miniforge.repo-index.messages :as messages]))
 
 ;------------------------------------------------------------------------------ Layer 0
+
 ;; Token estimation
+(def ^{:stratum 0} ^:private chars-per-token 4)
 
-(def ^:private chars-per-token 4)
-
-(defn- estimate-tokens
-  "Estimate token count for a string."
-  [s]
-  (int (Math/ceil (/ (count s) chars-per-token))))
-
-;------------------------------------------------------------------------------ Layer 0
 ;; Formatting helpers
-
-(defn- top-directory
+(defn- ^{:stratum 0} top-directory
   "Extract the top-level directory from a path, or '.' for root files."
   [path]
   (let [parts (str/split path #"/")]
     (if (> (count parts) 1) (first parts) ".")))
 
-(defn- format-entry
+(defn- ^{:stratum 0} format-entry
   "Format a single RepoMapEntry as a markdown table row."
   [{:keys [path lang lines size]}]
   (str "| " path " | " (or lang "-") " | " lines " | " size " |"))
 
-(defn- format-group-header
+(defn- ^{:stratum 0} format-group-header
   "Format a directory group header with table columns."
   [dir file-count total-lines]
   (str "\n### " dir "/ (" file-count " files, " total-lines " lines)\n"
        (messages/t :repo-map/table-header) "\n"
        (messages/t :repo-map/table-separator)))
 
-(defn- format-language-summary
+(defn- ^{:stratum 0} format-language-summary
   "Format language frequency map as a comma-separated summary."
   [languages]
   (->> (sort-by (comp - val) languages)
        (map (fn [[k v]] (str k " (" v ")")))
        (str/join ", ")))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Budget-aware group rendering
+(defn- ^{:stratum 0} append-full-group
+  "Append a complete directory group to the render accumulator."
+  [acc group-text group-tokens group-entry-count]
+  (factory/render-acc-with
+    (str (:text acc) "\n" group-text)
+    (+ (:tokens acc) group-tokens)
+    (+ (:shown acc) group-entry-count)
+    false))
 
-(defn- render-group-rows
+;; Public API
+(def ^{:stratum 0} default-token-budget 500)
+
+(defn- ^{:stratum 0} prepare-entries
+  "Filter, sort, and convert files to RepoMapEntry maps."
+  [files exclude-gen?]
+  (->> (cond->> files exclude-gen? (remove :generated?))
+       (sort-by :path)
+       (mapv factory/->repo-map-entry)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} estimate-tokens
+  "Estimate token count for a string."
+  [s]
+  (int (Math/ceil (/ (count s) chars-per-token))))
+
+(defn- ^{:stratum 1} render-group-text
+  "Render a complete directory group as markdown text."
+  [group-header group-entries]
+  (str group-header "\n" (str/join "\n" (map format-entry group-entries))))
+
+;; Repo map header
+(defn- ^{:stratum 1} build-header
+  "Build the repo map header with summary statistics."
+  [index entry-count total-entry-lines]
+  (str "## " (messages/t :repo-map/header-title) "\n"
+       (messages/t :repo-map/tree-label) ": " (:tree-sha index) "\n"
+       (messages/t :repo-map/files-label) ": " entry-count " | "
+       (messages/t :repo-map/lines-label) ": " total-entry-lines " | "
+       (messages/t :repo-map/languages-label) ": "
+       (format-language-summary (:languages index)) "\n"))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Budget-aware group rendering
+(defn- ^{:stratum 2} render-group-rows
   "Render as many rows as fit within the remaining token budget.
    Returns {:rows [...] :row-tokens n}."
   [tokens header-tokens group-entries remaining-budget]
@@ -79,7 +113,9 @@
     {:rows [] :row-tokens 0}
     group-entries))
 
-(defn- fit-partial-group
+;------------------------------------------------------------------------------ Layer 3
+
+(defn- ^{:stratum 3} fit-partial-group
   "Try to fit as many entries from a group as the budget allows."
   [acc group-header group-entries remaining-budget]
   (let [{:keys [tokens shown]} acc
@@ -94,21 +130,9 @@
         true)
       (assoc acc :truncated? true))))
 
-(defn- append-full-group
-  "Append a complete directory group to the render accumulator."
-  [acc group-text group-tokens group-entry-count]
-  (factory/render-acc-with
-    (str (:text acc) "\n" group-text)
-    (+ (:tokens acc) group-tokens)
-    (+ (:shown acc) group-entry-count)
-    false))
+;------------------------------------------------------------------------------ Layer 4
 
-(defn- render-group-text
-  "Render a complete directory group as markdown text."
-  [group-header group-entries]
-  (str group-header "\n" (str/join "\n" (map format-entry group-entries))))
-
-(defn- render-directory-group
+(defn- ^{:stratum 4} render-directory-group
   "Render one directory group into the accumulator, respecting the budget."
   [remaining-budget grouped]
   (fn [{:keys [tokens truncated?] :as acc} dir]
@@ -123,39 +147,18 @@
           (fit-partial-group acc group-header group-entries remaining-budget)
           (append-full-group acc group-text group-tokens (count group-entries)))))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Repo map header
+;------------------------------------------------------------------------------ Layer 5
 
-(defn- build-header
-  "Build the repo map header with summary statistics."
-  [index entry-count total-entry-lines]
-  (str "## " (messages/t :repo-map/header-title) "\n"
-       (messages/t :repo-map/tree-label) ": " (:tree-sha index) "\n"
-       (messages/t :repo-map/files-label) ": " entry-count " | "
-       (messages/t :repo-map/lines-label) ": " total-entry-lines " | "
-       (messages/t :repo-map/languages-label) ": "
-       (format-language-summary (:languages index)) "\n"))
-
-;------------------------------------------------------------------------------ Layer 2
-;; Public API
-
-(def default-token-budget 500)
-
-(defn- prepare-entries
-  "Filter, sort, and convert files to RepoMapEntry maps."
-  [files exclude-gen?]
-  (->> (cond->> files exclude-gen? (remove :generated?))
-       (sort-by :path)
-       (mapv factory/->repo-map-entry)))
-
-(defn- walk-directory-groups
+(defn- ^{:stratum 5} walk-directory-groups
   "Walk directory groups accumulating text within the token budget."
   [remaining-budget grouped dir-order]
   (reduce (render-directory-group remaining-budget grouped)
           (factory/->render-acc)
           dir-order))
 
-(defn generate
+;------------------------------------------------------------------------------ Layer 6
+
+(defn ^{:stratum 6} generate
   "Generate a token-budgeted repo map from a repo index.
 
    Arguments:

--- a/components/repo-index/src/ai/miniforge/repo_index/scanner.clj
+++ b/components/repo-index/src/ai/miniforge/repo_index/scanner.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.repo-index.scanner
   "Walk git tree via `git ls-tree` to build a repo index.
 
@@ -26,51 +25,12 @@
             [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
+
 ;; Configuration (loaded from EDN resource)
+(def ^{:stratum 0} ^:private config-path "config/repo-index/scanner.edn")
 
-(def ^:private config-path "config/repo-index/scanner.edn")
-
-(defn- load-scanner-config []
-  (if-let [res (io/resource config-path)]
-    (get (edn/read-string (slurp res)) :repo-index/scanner {})
-    {}))
-
-(def ^:private scanner-config (delay (load-scanner-config)))
-
-(defn- extension->language []
-  (get @scanner-config :extension->language {}))
-
-(defn- special-filenames []
-  (get @scanner-config :special-filenames {}))
-
-(defn- generated-path-patterns []
-  (->> (get @scanner-config :generated-path-patterns [])
-       (mapv re-pattern)))
-
-;------------------------------------------------------------------------------ Layer 0
-;; Language detection
-
-(defn- detect-language
-  "Detect language from file path extension or special filename."
-  [path]
-  (let [filename (last (str/split path #"/"))
-        lower-filename (str/lower-case filename)]
-    (or (get (special-filenames) lower-filename)
-        (when-let [ext (last (re-find #"\.(\w+)$" filename))]
-          (get (extension->language) (str/lower-case ext))))))
-
-;------------------------------------------------------------------------------ Layer 0
-;; Generated file detection
-
-(defn- generated-by-path?
-  "Check if a file path matches known generated file patterns."
-  [path]
-  (boolean (some #(re-find % path) (generated-path-patterns))))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; Git commands
-
-(defn- run-git-command
+(defn- ^{:stratum 0} run-git-command
   "Execute a git command in repo-root and return trimmed stdout, or nil on failure.
 
    Clears git environment overrides (GIT_DIR, GIT_WORK_TREE, GIT_INDEX_FILE)
@@ -92,21 +52,8 @@
     (catch Exception _
       nil)))
 
-(defn- run-git-ls-tree
-  "Execute `git ls-tree -r --long HEAD` and return raw output lines."
-  [repo-root]
-  (when-let [output (run-git-command repo-root ["git" "ls-tree" "-r" "--long" "HEAD"])]
-    (str/split-lines output)))
-
-(defn- run-git-rev-parse-tree
-  "Get the tree SHA for HEAD."
-  [repo-root]
-  (run-git-command repo-root ["git" "rev-parse" "HEAD^{tree}"]))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; Parsing
-
-(defn- parse-ls-tree-line
+(defn- ^{:stratum 0} parse-ls-tree-line
   "Parse a single line of `git ls-tree -r --long` output.
    Format: <mode> <type> <sha> <size> <path>
    Returns nil for non-blob entries."
@@ -117,7 +64,7 @@
        :blob-sha blob-sha
        :size (parse-long size-str)})))
 
-(defn- count-lines
+(defn- ^{:stratum 0} count-lines
   "Count lines in a file. Returns 0 for binary/unreadable files."
   [repo-root path]
   (try
@@ -128,15 +75,7 @@
     (catch Exception _
       0)))
 
-(defn- enrich-blob-entry
-  "Enrich a parsed blob entry with language, line count, and generated? flag."
-  [repo-root {:keys [path blob-sha size]}]
-  (factory/->file-record path blob-sha size
-                         (or (count-lines repo-root path) 0)
-                         (detect-language path)
-                         (generated-by-path? path)))
-
-(defn- compute-language-frequencies
+(defn- ^{:stratum 0} compute-language-frequencies
   "Compute language frequency map from non-generated file entries."
   [entries]
   (->> entries
@@ -144,10 +83,72 @@
        (keep :language)
        frequencies))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Public scan
+;------------------------------------------------------------------------------ Layer 1
 
-(defn scan
+(defn- ^{:stratum 1} load-scanner-config []
+  (if-let [res (io/resource config-path)]
+    (get (edn/read-string (slurp res)) :repo-index/scanner {})
+    {}))
+
+(defn- ^{:stratum 1} run-git-ls-tree
+  "Execute `git ls-tree -r --long HEAD` and return raw output lines."
+  [repo-root]
+  (when-let [output (run-git-command repo-root ["git" "ls-tree" "-r" "--long" "HEAD"])]
+    (str/split-lines output)))
+
+(defn- ^{:stratum 1} run-git-rev-parse-tree
+  "Get the tree SHA for HEAD."
+  [repo-root]
+  (run-git-command repo-root ["git" "rev-parse" "HEAD^{tree}"]))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(def ^{:stratum 2} ^:private scanner-config (delay (load-scanner-config)))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn- ^{:stratum 3} extension->language []
+  (get @scanner-config :extension->language {}))
+
+(defn- ^{:stratum 3} special-filenames []
+  (get @scanner-config :special-filenames {}))
+
+(defn- ^{:stratum 3} generated-path-patterns []
+  (->> (get @scanner-config :generated-path-patterns [])
+       (mapv re-pattern)))
+
+;------------------------------------------------------------------------------ Layer 4
+
+;; Language detection
+(defn- ^{:stratum 4} detect-language
+  "Detect language from file path extension or special filename."
+  [path]
+  (let [filename (last (str/split path #"/"))
+        lower-filename (str/lower-case filename)]
+    (or (get (special-filenames) lower-filename)
+        (when-let [ext (last (re-find #"\.(\w+)$" filename))]
+          (get (extension->language) (str/lower-case ext))))))
+
+;; Generated file detection
+(defn- ^{:stratum 4} generated-by-path?
+  "Check if a file path matches known generated file patterns."
+  [path]
+  (boolean (some #(re-find % path) (generated-path-patterns))))
+
+;------------------------------------------------------------------------------ Layer 5
+
+(defn- ^{:stratum 5} enrich-blob-entry
+  "Enrich a parsed blob entry with language, line count, and generated? flag."
+  [repo-root {:keys [path blob-sha size]}]
+  (factory/->file-record path blob-sha size
+                         (or (count-lines repo-root path) 0)
+                         (detect-language path)
+                         (generated-by-path? path)))
+
+;------------------------------------------------------------------------------ Layer 6
+
+;; Public scan
+(defn ^{:stratum 6} scan
   "Scan a git repository and build a repo index.
 
    Arguments:

--- a/components/repo-index/src/ai/miniforge/repo_index/scanner.clj
+++ b/components/repo-index/src/ai/miniforge/repo_index/scanner.clj
@@ -18,7 +18,7 @@
 (ns ai.miniforge.repo-index.scanner
   "Walk git tree via `git ls-tree` to build a repo index.
 
-   Layer 1 — config-driven language detection and generated-file patterns."
+   Config-driven language detection and generated-file patterns."
   (:require [ai.miniforge.repo-index.factory :as factory]
             [clojure.edn :as edn]
             [clojure.java.io :as io]

--- a/components/repo-index/src/ai/miniforge/repo_index/schema.clj
+++ b/components/repo-index/src/ai/miniforge/repo_index/schema.clj
@@ -15,16 +15,15 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.repo-index.schema
   "Malli schemas for repo index domain types.
 
    Layer 0 — pure data definitions, no dependencies.")
 
 ;------------------------------------------------------------------------------ Layer 0
-;; File Record
 
-(def FileRecord
+;; File Record
+(def ^{:stratum 0} FileRecord
   [:map
    [:path [:string {:min 1}]]
    [:blob-sha [:string {:min 7}]]
@@ -33,10 +32,25 @@
    [:language [:maybe :string]]
    [:generated? :boolean]])
 
-;------------------------------------------------------------------------------ Layer 0
-;; Repo Index
+;; Repo Map Slice
+(def ^{:stratum 0} RepoMapEntry
+  [:map
+   [:path [:string {:min 1}]]
+   [:lang [:maybe :string]]
+   [:lines :int]
+   [:size :int]])
 
-(def RepoIndex
+;; Search Hit
+(def ^{:stratum 0} Snippet
+  [:map
+   [:start-line :int]
+   [:end-line :int]
+   [:text [:string {:min 0}]]])
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Repo Index
+(def ^{:stratum 1} RepoIndex
   [:map
    [:tree-sha [:string {:min 7}]]
    [:repo-root [:string {:min 1}]]
@@ -46,17 +60,7 @@
    [:languages [:map-of :string :int]]
    [:indexed-at inst?]])
 
-;------------------------------------------------------------------------------ Layer 0
-;; Repo Map Slice
-
-(def RepoMapEntry
-  [:map
-   [:path [:string {:min 1}]]
-   [:lang [:maybe :string]]
-   [:lines :int]
-   [:size :int]])
-
-(def RepoMapSlice
+(def ^{:stratum 1} RepoMapSlice
   [:map
    [:tree-sha [:string {:min 7}]]
    [:entries [:vector RepoMapEntry]]
@@ -65,16 +69,7 @@
    [:truncated? :boolean]
    [:token-estimate :int]])
 
-;------------------------------------------------------------------------------ Layer 0
-;; Search Hit
-
-(def Snippet
-  [:map
-   [:start-line :int]
-   [:end-line :int]
-   [:text [:string {:min 0}]]])
-
-(def SearchHit
+(def ^{:stratum 1} SearchHit
   [:map
    [:path [:string {:min 1}]]
    [:score :double]

--- a/components/repo-index/src/ai/miniforge/repo_index/schema.clj
+++ b/components/repo-index/src/ai/miniforge/repo_index/schema.clj
@@ -32,7 +32,7 @@
    [:language [:maybe :string]]
    [:generated? :boolean]])
 
-;; Repo Map Slice
+;; RepoMapEntry
 (def ^{:stratum 0} RepoMapEntry
   [:map
    [:path [:string {:min 1}]]
@@ -40,7 +40,7 @@
    [:lines :int]
    [:size :int]])
 
-;; Search Hit
+;; Snippet
 (def ^{:stratum 0} Snippet
   [:map
    [:start-line :int]
@@ -60,6 +60,7 @@
    [:languages [:map-of :string :int]]
    [:indexed-at inst?]])
 
+;; RepoMapSlice
 (def ^{:stratum 1} RepoMapSlice
   [:map
    [:tree-sha [:string {:min 7}]]
@@ -69,6 +70,7 @@
    [:truncated? :boolean]
    [:token-estimate :int]])
 
+;; SearchHit
 (def ^{:stratum 1} SearchHit
   [:map
    [:path [:string {:min 1}]]

--- a/components/repo-index/src/ai/miniforge/repo_index/search_lex.clj
+++ b/components/repo-index/src/ai/miniforge/repo_index/search_lex.clj
@@ -21,7 +21,7 @@
    Pure Clojure implementation — no JNI dependencies. Suitable for
    single-repo indexing (thousands of files, not millions).
 
-   Layer 1 — depends on factory (Layer 0)."
+   Depends on factory."
   (:require [clojure.edn :as edn]
             [clojure.java.io :as io]
             [clojure.string :as str]

--- a/components/repo-index/src/ai/miniforge/repo_index/search_lex.clj
+++ b/components/repo-index/src/ai/miniforge/repo_index/search_lex.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.repo-index.search-lex
   "BM25 lexical search over repo file contents.
 
@@ -29,36 +28,19 @@
             [ai.miniforge.repo-index.factory :as factory]))
 
 ;------------------------------------------------------------------------------ Layer 0
+
 ;; Configuration (loaded from EDN resource)
+(def ^{:stratum 0} ^:private config-path "config/repo-index/search.edn")
 
-(def ^:private config-path "config/repo-index/search.edn")
-
-(defn- load-search-config []
-  (if-let [res (io/resource config-path)]
-    (get (edn/read-string (slurp res)) :repo-index/search {})
-    {}))
-
-(def ^:private search-config (delay (load-search-config)))
-
-(defn- bm25-k1 [] (get @search-config :bm25-k1 1.2))
-(defn- bm25-b  [] (get @search-config :bm25-b 0.75))
-(defn- default-max-results [] (get @search-config :default-max-results 10))
-(defn- default-context-lines [] (get @search-config :default-context-lines 3))
-(defn- default-max-hits [] (get @search-config :default-max-hits 5))
-
-;------------------------------------------------------------------------------ Layer 0
 ;; Tokenization
-
-(defn- tokenize
+(defn- ^{:stratum 0} tokenize
   "Split text into lowercase word tokens."
   [text]
   (->> (str/split (str/lower-case text) #"[^a-z0-9_-]+")
        (remove str/blank?)))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Index construction
-
-(defn- read-file-content
+(defn- ^{:stratum 0} read-file-content
   "Read file content from disk. Returns nil for binary/unreadable files."
   [repo-root path]
   (try
@@ -68,14 +50,7 @@
     (catch Exception _
       nil)))
 
-(defn- build-doc-entry
-  "Build a document entry for the inverted index."
-  [repo-root {:keys [path]}]
-  (when-let [content (read-file-content repo-root path)]
-    (let [tokens (tokenize content)]
-      (factory/->doc-entry path (count tokens) (frequencies tokens) content))))
-
-(defn- build-inverted-index
+(defn- ^{:stratum 0} build-inverted-index
   "Build an inverted index from document entries.
    Returns {:term->doc-ids {term #{doc-id ...}} :doc-freq {term count}}."
   [docs]
@@ -91,14 +66,79 @@
     (factory/->inverted-index)
     docs))
 
-(defn- compute-avg-doc-length
+(defn- ^{:stratum 0} compute-avg-doc-length
   "Compute average document length from doc entries."
   [docs]
   (if (seq docs)
     (double (/ (reduce + 0 (map :token-count docs)) (count docs)))
     0.0))
 
-(defn build-search-index
+;; BM25 scoring
+(defn- ^{:stratum 0} idf
+  "Compute inverse document frequency for a term."
+  [doc-count doc-freq-for-term]
+  (Math/log (+ 1.0 (/ (- doc-count doc-freq-for-term 0.5)
+                       (+ doc-freq-for-term 0.5)))))
+
+;; Context extraction
+(defn- ^{:stratum 0} extract-snippet
+  "Extract a snippet around a matching line with context."
+  [lines line-idx context-lines]
+  (let [start (max 0 (- line-idx context-lines))
+        end (min (count lines) (+ line-idx context-lines 1))]
+    (factory/->snippet (inc start) (inc (dec end))
+                       (str/join "\n" (subvec lines start end)))))
+
+(defn- ^{:stratum 0} find-matching-lines
+  "Find line indices containing any query term."
+  [content query-terms]
+  (let [lines (str/split-lines content)
+        lower-lines (mapv str/lower-case lines)]
+    (->> (range (count lower-lines))
+         (filter (fn [i]
+                   (let [line (nth lower-lines i)]
+                     (some #(str/includes? line %) query-terms))))
+         vec)))
+
+;; Candidate collection
+(defn- ^{:stratum 0} collect-candidates
+  "Collect all document paths matching any query term."
+  [search-index query-terms]
+  (reduce
+    (fn [paths term]
+      (into paths (get (:term->doc-ids search-index) term #{})))
+    #{}
+    query-terms))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} load-search-config []
+  (if-let [res (io/resource config-path)]
+    (get (edn/read-string (slurp res)) :repo-index/search {})
+    {}))
+
+(defn- ^{:stratum 1} build-doc-entry
+  "Build a document entry for the inverted index."
+  [repo-root {:keys [path]}]
+  (when-let [content (read-file-content repo-root path)]
+    (let [tokens (tokenize content)]
+      (factory/->doc-entry path (count tokens) (frequencies tokens) content))))
+
+(defn- ^{:stratum 1} build-snippets
+  "Build preview snippets for matching lines in a document."
+  [content query-terms context-lines max-hits]
+  (let [lines (into [] (str/split-lines content))
+        matching (find-matching-lines content query-terms)]
+    (->> matching
+         (take max-hits)
+         (mapv #(extract-snippet lines % context-lines))
+         (filterv #(not (str/blank? (:text %)))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(def ^{:stratum 2} ^:private search-config (delay (load-search-config)))
+
+(defn ^{:stratum 2} build-search-index
   "Build a BM25 search index from a repo index.
 
    Arguments:
@@ -117,16 +157,21 @@
                             (:term->doc-ids inv-idx)
                             (:doc-freq inv-idx))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; BM25 scoring
+;------------------------------------------------------------------------------ Layer 3
 
-(defn- idf
-  "Compute inverse document frequency for a term."
-  [doc-count doc-freq-for-term]
-  (Math/log (+ 1.0 (/ (- doc-count doc-freq-for-term 0.5)
-                       (+ doc-freq-for-term 0.5)))))
+(defn- ^{:stratum 3} bm25-k1 [] (get @search-config :bm25-k1 1.2))
 
-(defn- bm25-term-score
+(defn- ^{:stratum 3} bm25-b  [] (get @search-config :bm25-b 0.75))
+
+(defn- ^{:stratum 3} default-max-results [] (get @search-config :default-max-results 10))
+
+(defn- ^{:stratum 3} default-context-lines [] (get @search-config :default-context-lines 3))
+
+(defn- ^{:stratum 3} default-max-hits [] (get @search-config :default-max-hits 5))
+
+;------------------------------------------------------------------------------ Layer 4
+
+(defn- ^{:stratum 4} bm25-term-score
   "Compute BM25 score for a single term in a single document."
   [tf-in-doc doc-length avg-doc-length idf-value]
   (let [k1 (bm25-k1)
@@ -136,7 +181,9 @@
                        (* k1 (+ (- 1.0 b) (* b (/ doc-length avg-doc-length)))))]
     (* idf-value (/ numerator denominator))))
 
-(defn- score-document
+;------------------------------------------------------------------------------ Layer 5
+
+(defn- ^{:stratum 5} score-document
   "Score a document against query terms."
   [doc query-terms search-index]
   (let [{:keys [avg-doc-length doc-count doc-freq]} search-index
@@ -152,51 +199,9 @@
       0.0
       query-terms)))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Context extraction
+;------------------------------------------------------------------------------ Layer 6
 
-(defn- extract-snippet
-  "Extract a snippet around a matching line with context."
-  [lines line-idx context-lines]
-  (let [start (max 0 (- line-idx context-lines))
-        end (min (count lines) (+ line-idx context-lines 1))]
-    (factory/->snippet (inc start) (inc (dec end))
-                       (str/join "\n" (subvec lines start end)))))
-
-(defn- find-matching-lines
-  "Find line indices containing any query term."
-  [content query-terms]
-  (let [lines (str/split-lines content)
-        lower-lines (mapv str/lower-case lines)]
-    (->> (range (count lower-lines))
-         (filter (fn [i]
-                   (let [line (nth lower-lines i)]
-                     (some #(str/includes? line %) query-terms))))
-         vec)))
-
-(defn- build-snippets
-  "Build preview snippets for matching lines in a document."
-  [content query-terms context-lines max-hits]
-  (let [lines (into [] (str/split-lines content))
-        matching (find-matching-lines content query-terms)]
-    (->> matching
-         (take max-hits)
-         (mapv #(extract-snippet lines % context-lines))
-         (filterv #(not (str/blank? (:text %)))))))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Candidate collection
-
-(defn- collect-candidates
-  "Collect all document paths matching any query term."
-  [search-index query-terms]
-  (reduce
-    (fn [paths term]
-      (into paths (get (:term->doc-ids search-index) term #{})))
-    #{}
-    query-terms))
-
-(defn- score-and-rank
+(defn- ^{:stratum 6} score-and-rank
   "Score candidate documents and return top results."
   [search-index candidate-paths query-terms max-results]
   (->> candidate-paths
@@ -208,10 +213,10 @@
        (sort-by :score >)
        (take max-results)))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Public search API
+;------------------------------------------------------------------------------ Layer 7
 
-(defn search
+;; Public search API
+(defn ^{:stratum 7} search
   "Search the index with a query string.
 
    Arguments:

--- a/components/repo-index/src/ai/miniforge/repo_index/storage.clj
+++ b/components/repo-index/src/ai/miniforge/repo_index/storage.clj
@@ -18,7 +18,7 @@
 (ns ai.miniforge.repo-index.storage
   "Persist and load repo indexes to `.miniforge/index/`.
 
-   Layer 1 — depends on schema (Layer 0)."
+   Layer 0 — filesystem I/O only; no dependency on schema or factory."
   (:require [clojure.java.io :as io]
             [clojure.edn :as edn]))
 

--- a/components/repo-index/src/ai/miniforge/repo_index/storage.clj
+++ b/components/repo-index/src/ai/miniforge/repo_index/storage.clj
@@ -18,7 +18,7 @@
 (ns ai.miniforge.repo-index.storage
   "Persist and load repo indexes to `.miniforge/index/`.
 
-   Layer 0 — filesystem I/O only; no dependency on schema or factory."
+   Filesystem I/O only — no dependency on schema or factory."
   (:require [clojure.java.io :as io]
             [clojure.edn :as edn]))
 

--- a/components/repo-index/src/ai/miniforge/repo_index/storage.clj
+++ b/components/repo-index/src/ai/miniforge/repo_index/storage.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.repo-index.storage
   "Persist and load repo indexes to `.miniforge/index/`.
 
@@ -24,26 +23,30 @@
             [clojure.edn :as edn]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Path helpers
 
-(def ^:private index-dir-name
+;; Path helpers
+(def ^{:stratum 0} ^:private index-dir-name
   "Directory name for storing indexes within the repo."
   ".miniforge/index")
 
-(defn- index-dir
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} index-dir
   "Get the index directory path for a repo root."
   [repo-root]
   (io/file repo-root index-dir-name))
 
-(defn- index-file
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- ^{:stratum 2} index-file
   "Get the index file path for a given tree-sha."
   [repo-root tree-sha]
   (io/file (index-dir repo-root) (str tree-sha ".edn")))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Persistence
+;------------------------------------------------------------------------------ Layer 3
 
-(defn save-index
+;; Persistence
+(defn ^{:stratum 3} save-index
   "Save a repo index to disk, keyed by tree-sha.
 
    Arguments:
@@ -62,7 +65,7 @@
     (catch Exception _
       nil)))
 
-(defn load-index
+(defn ^{:stratum 3} load-index
   "Load a previously saved repo index by tree-sha.
 
    Arguments:
@@ -79,7 +82,9 @@
     (catch Exception _
       nil)))
 
-(defn cached-index
+;------------------------------------------------------------------------------ Layer 4
+
+(defn ^{:stratum 4} cached-index
   "Load the cached index for the current HEAD tree-sha, if available.
 
    Arguments:

--- a/components/repo-index/test/ai/miniforge/repo_index/factory_test.clj
+++ b/components/repo-index/test/ai/miniforge/repo_index/factory_test.clj
@@ -15,15 +15,14 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.repo-index.factory-test
   (:require [clojure.test :refer [deftest testing is]]
             [ai.miniforge.repo-index.factory :as sut]))
 
-;------------------------------------------------------------------------------ Layer 1
-;; ->file-record
+;------------------------------------------------------------------------------ Layer 0
 
-(deftest file-record-shape-test
+;; ->file-record
+(deftest ^{:stratum 0} file-record-shape-test
   (testing "->file-record carries every documented key with the supplied value"
     (let [r (sut/->file-record "src/a.clj" "abc1234" 1024 42 "clojure" false)]
       (is (= "src/a.clj" (:path r)))
@@ -33,15 +32,13 @@
       (is (= "clojure"   (:language r)))
       (is (false?        (:generated? r))))))
 
-(deftest file-record-allows-nil-language-test
+(deftest ^{:stratum 0} file-record-allows-nil-language-test
   (testing "Language may be nil for files of unknown type"
     (let [r (sut/->file-record "f.bin" "abc1234" 0 0 nil false)]
       (is (nil? (:language r))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; ->repo-index
-
-(deftest repo-index-shape-test
+(deftest ^{:stratum 0} repo-index-shape-test
   (testing "->repo-index computes :file-count, :total-lines, and stamps :indexed-at"
     (let [files [(sut/->file-record "a.clj" "abc1234" 1 10 "clojure" false)
                  (sut/->file-record "b.py"  "def5678" 2 20 "python"  false)]
@@ -54,7 +51,7 @@
       (is (= {"clojure" 1 "python" 1} (:languages idx)))
       (is (inst? (:indexed-at idx))))))
 
-(deftest repo-index-empty-test
+(deftest ^{:stratum 0} repo-index-empty-test
   (testing "Empty entries produces zero counts but still stamps :indexed-at"
     (let [idx (sut/->repo-index "tree-sha-aaa" "/repo" [] {})]
       (is (= 0 (:file-count idx)))
@@ -62,10 +59,8 @@
       (is (= {} (:languages idx)))
       (is (inst? (:indexed-at idx))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; ->repo-map-entry
-
-(deftest repo-map-entry-from-file-record-test
+(deftest ^{:stratum 0} repo-map-entry-from-file-record-test
   (testing "->repo-map-entry projects path/lang/lines/size from a file record;
             :blob-sha and :generated? are dropped"
     (let [fr (sut/->file-record "src/x.clj" "abc1234" 100 5 "clojure" false)
@@ -77,15 +72,13 @@
       (is (not (contains? e :blob-sha)))
       (is (not (contains? e :generated?))))))
 
-(deftest repo-map-entry-renames-language-to-lang-test
+(deftest ^{:stratum 0} repo-map-entry-renames-language-to-lang-test
   (testing "FileRecord's :language becomes RepoMapEntry's :lang (note rename)"
     (is (= "rust" (:lang (sut/->repo-map-entry
                           (sut/->file-record "f.rs" "abc1234" 1 1 "rust" false)))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; ->repo-map-slice
-
-(deftest repo-map-slice-shape-test
+(deftest ^{:stratum 0} repo-map-slice-shape-test
   (testing "->repo-map-slice carries every supplied positional argument as a key"
     (let [s (sut/->repo-map-slice "tree-sha" [{:path "a"}] "## map" 100 1 true 50)]
       (is (= "tree-sha"   (:tree-sha s)))
@@ -96,10 +89,8 @@
       (is (true?          (:truncated? s)))
       (is (= 50           (:token-estimate s))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; ->file-content
-
-(deftest file-content-shape-test
+(deftest ^{:stratum 0} file-content-shape-test
   (testing "->file-content carries the four documented keys"
     (let [c (sut/->file-content "src/a.clj" "(ns a)" 1 false)]
       (is (= "src/a.clj" (:path c)))
@@ -107,28 +98,24 @@
       (is (= 1           (:lines c)))
       (is (false?        (:truncated? c))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; ->render-acc / render-acc-with
-
-(deftest render-acc-initial-shape-test
+(deftest ^{:stratum 0} render-acc-initial-shape-test
   (testing "->render-acc returns the initial empty accumulator"
     (is (= {:text "" :tokens 0 :shown 0 :truncated? false}
            (sut/->render-acc)))))
 
-(deftest render-acc-with-overrides-test
+(deftest ^{:stratum 0} render-acc-with-overrides-test
   (testing "render-acc-with produces an accumulator with the given fields"
     (is (= {:text "x" :tokens 5 :shown 1 :truncated? true}
            (sut/render-acc-with "x" 5 1 true)))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; ->snippet / ->search-hit
-
-(deftest snippet-shape-test
+(deftest ^{:stratum 0} snippet-shape-test
   (testing "->snippet carries start-line, end-line, and text"
     (is (= {:start-line 10 :end-line 12 :text "hit"}
            (sut/->snippet 10 12 "hit")))))
 
-(deftest search-hit-shape-test
+(deftest ^{:stratum 0} search-hit-shape-test
   (testing "->search-hit carries path, score, and snippets"
     (let [snip (sut/->snippet 1 1 "x")
           hit  (sut/->search-hit "src/a.clj" 0.95 [snip])]
@@ -136,10 +123,8 @@
       (is (= 0.95        (:score hit)))
       (is (= [snip]      (:snippets hit))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; ->doc-entry / ->inverted-index / ->search-index
-
-(deftest doc-entry-shape-test
+(deftest ^{:stratum 0} doc-entry-shape-test
   (testing "->doc-entry stores path, token-count, term-freqs, and content"
     (let [entry (sut/->doc-entry "src/a.clj" 5 {"a" 2 "b" 3} "(ns a)")]
       (is (= "src/a.clj"   (:path entry)))
@@ -147,11 +132,11 @@
       (is (= {"a" 2 "b" 3} (:term-freqs entry)))
       (is (= "(ns a)"      (:content entry))))))
 
-(deftest inverted-index-empty-test
+(deftest ^{:stratum 0} inverted-index-empty-test
   (testing "->inverted-index returns the documented empty shape"
     (is (= {:term->doc-ids {} :doc-freq {}} (sut/->inverted-index)))))
 
-(deftest search-index-shape-test
+(deftest ^{:stratum 0} search-index-shape-test
   (testing "->search-index aggregates docs, corpus stats, and posting lists"
     (let [idx (sut/->search-index {"a.clj" {:path "a.clj"}} 1 5.0
                                   {"foo" #{"a.clj"}} {"foo" 1})]

--- a/components/repo-index/test/ai/miniforge/repo_index/interface_test.clj
+++ b/components/repo-index/test/ai/miniforge/repo_index/interface_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.repo-index.interface-test
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.repo-index.interface :as repo-index]
@@ -24,7 +23,9 @@
             [ai.miniforge.repo-index.schema :as schema]
             [malli.core :as m]))
 
-(deftest scanner-parse-test
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} scanner-parse-test
   (testing "detect-language via scanner"
     (let [idx (scanner/scan ".")]
       (is (some? idx) "scan should succeed in a git repo")
@@ -35,7 +36,7 @@
         (is (map? (:languages idx)))
         (is (vector? (:files idx)))))))
 
-(deftest scanner-schema-test
+(deftest ^{:stratum 0} scanner-schema-test
   (testing "scanned index conforms to RepoIndex schema"
     (let [idx (scanner/scan ".")]
       (when idx
@@ -43,7 +44,7 @@
             (str "RepoIndex schema mismatch: "
                  (m/explain schema/RepoIndex idx)))))))
 
-(deftest scanner-file-record-test
+(deftest ^{:stratum 0} scanner-file-record-test
   (testing "individual file records conform to FileRecord schema"
     (let [idx (scanner/scan ".")]
       (when idx
@@ -52,7 +53,7 @@
               (str "FileRecord schema mismatch for " (:path f) ": "
                    (m/explain schema/FileRecord f))))))))
 
-(deftest repo-map-test
+(deftest ^{:stratum 0} repo-map-test
   (testing "repo map generation"
     (let [idx (scanner/scan ".")]
       (when idx
@@ -63,7 +64,7 @@
           (is (pos? (:shown-files rmap)))
           (is (boolean? (:truncated? rmap))))))))
 
-(deftest repo-map-budget-test
+(deftest ^{:stratum 0} repo-map-budget-test
   (testing "repo map respects token budget"
     (let [idx (scanner/scan ".")]
       (when idx
@@ -74,7 +75,7 @@
           (is (>= (:shown-files rmap-large) (:shown-files rmap-small))
               "larger budget should show more files"))))))
 
-(deftest build-index-test
+(deftest ^{:stratum 0} build-index-test
   (testing "build-index produces a valid index"
     (let [idx (repo-index/build-index ".")]
       (is (some? idx))
@@ -82,7 +83,7 @@
         (is (string? (:tree-sha idx)))
         (is (vector? (:files idx)))))))
 
-(deftest get-file-test
+(deftest ^{:stratum 0} get-file-test
   (testing "get-file retrieves a known file"
     (let [idx (repo-index/build-index ".")]
       (when idx
@@ -93,13 +94,13 @@
             (is (string? (:content result)))
             (is (pos? (:lines result)))))))))
 
-(deftest get-file-not-in-index-test
+(deftest ^{:stratum 0} get-file-not-in-index-test
   (testing "get-file returns nil for files not in index"
     (let [idx (repo-index/build-index ".")]
       (when idx
         (is (nil? (repo-index/get-file idx "nonexistent-file-xyz.txt")))))))
 
-(deftest files-by-language-test
+(deftest ^{:stratum 0} files-by-language-test
   (testing "files-by-language filters correctly"
     (let [idx (repo-index/build-index ".")]
       (when idx

--- a/components/repo-index/test/ai/miniforge/repo_index/repo_map_test.clj
+++ b/components/repo-index/test/ai/miniforge/repo_index/repo_map_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.repo-index.repo-map-test
   "Tests for repo-map generation. Builds synthetic indexes (no scanner / git
    I/O) so we can isolate the token-budget and grouping logic from any real
@@ -26,13 +25,13 @@
             [ai.miniforge.repo-index.factory :as factory]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Test fixtures and factories
 
-(defn- file
+;; Test fixtures and factories
+(defn- ^{:stratum 0} file
   [path lang lines size & {:keys [generated?] :or {generated? false}}]
   (factory/->file-record path "abc1234" size lines lang generated?))
 
-(defn- index-of
+(defn- ^{:stratum 0} index-of
   "Build a synthetic index from a vector of file records."
   ([files] (index-of files {}))
   ([files {:keys [tree-sha languages]
@@ -40,7 +39,13 @@
                   languages {}}}]
    (factory/->repo-index tree-sha "/repo" files languages)))
 
-(defn- big-index
+(deftest ^{:stratum 0} generate-default-token-budget-constant-test
+  (testing "default-token-budget is the documented 500"
+    (is (= 500 sut/default-token-budget))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} big-index
   "Build an index with N files in `dir` such that the budget logic can be
    exercised. Each file has lines=1, size=10 to keep arithmetic simple."
   [dir n]
@@ -48,10 +53,8 @@
                    (file (str dir "/f" i ".clj") "clojure" 1 10)))
             {:languages {"clojure" n}}))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Empty / trivial inputs
-
-(deftest generate-empty-index-test
+(deftest ^{:stratum 1} generate-empty-index-test
   (testing "Empty index produces a slice with zero files shown and not truncated"
     (let [r (sut/generate (index-of []))]
       (is (= 0 (:total-files r)))
@@ -61,14 +64,8 @@
       (is (pos? (:token-estimate r))) ;; the header still costs tokens
       (is (vector? (:entries r))))))
 
-(deftest generate-default-token-budget-constant-test
-  (testing "default-token-budget is the documented 500"
-    (is (= 500 sut/default-token-budget))))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; Single small group fits within budget
-
-(deftest generate-fits-everything-when-budget-is-large-test
+(deftest ^{:stratum 1} generate-fits-everything-when-budget-is-large-test
   (testing "With a generous budget, all files are shown and not truncated"
     (let [files [(file "src/a.clj" "clojure" 10 100)
                  (file "src/b.clj" "clojure" 20 200)
@@ -80,31 +77,8 @@
       (is (false? (:truncated? r)))
       (is (= 3 (count (:entries r)))))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Truncation behaviour under a tight budget
-
-(deftest generate-truncates-when-budget-too-small-test
-  (testing "With a tight budget, only some files are shown and :truncated? is true"
-    (let [r (sut/generate (big-index "src" 50) {:token-budget 80})]
-      (is (= 50 (:total-files r)))
-      (is (true? (:truncated? r)))
-      (is (< (:shown-files r) (:total-files r)))
-      ;; The slice's :entries should be exactly :shown-files long.
-      (is (= (:shown-files r) (count (:entries r)))))))
-
-(deftest generate-larger-budget-never-reduces-shown-files-test
-  (testing "Increasing the budget never reduces the number of shown files
-            (monotone, not strictly increasing — when both budgets fit
-            everything, both will report the same shown-files count)"
-    (let [idx (big-index "src" 100)
-          small (sut/generate idx {:token-budget 80})
-          large (sut/generate idx {:token-budget 5000})]
-      (is (>= (:shown-files large) (:shown-files small))))))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; Generated-file filtering
-
-(deftest generate-excludes-generated-by-default-test
+(deftest ^{:stratum 1} generate-excludes-generated-by-default-test
   (testing "By default, files marked :generated? true are excluded"
     (let [files [(file "src/a.clj" "clojure" 10 100)
                  (file "build/gen.clj" "clojure" 1000 9999 :generated? true)]
@@ -112,7 +86,7 @@
       (is (= 1 (:total-files r)))
       (is (not (some #(= "build/gen.clj" (:path %)) (:entries r)))))))
 
-(deftest generate-includes-generated-when-opted-in-test
+(deftest ^{:stratum 1} generate-includes-generated-when-opted-in-test
   (testing "Setting :exclude-generated? false includes generated files"
     (let [files [(file "src/a.clj" "clojure" 10 100)
                  (file "build/gen.clj" "clojure" 1 1 :generated? true)]
@@ -120,10 +94,8 @@
                                             :exclude-generated? false})]
       (is (= 2 (:total-files r))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Markdown / grouping shape
-
-(deftest generate-groups-by-top-directory-test
+(deftest ^{:stratum 1} generate-groups-by-top-directory-test
   (testing "The rendered text groups entries under top-directory headers"
     (let [files [(file "src/a.clj" "clojure" 1 10)
                  (file "src/b.clj" "clojure" 1 10)
@@ -137,7 +109,7 @@
       ;; Root-level files group under the synthetic "." directory.
       (is (str/includes? text "### ./")))))
 
-(deftest generate-text-includes-tree-sha-and-counts-test
+(deftest ^{:stratum 1} generate-text-includes-tree-sha-and-counts-test
   (testing "Header includes the tree-sha and the file/line summary"
     (let [files [(file "src/a.clj" "clojure" 5 50)
                  (file "src/b.clj" "clojure" 7 70)]
@@ -150,7 +122,7 @@
       (is (str/includes? text "2"))
       (is (str/includes? text "12")))))
 
-(deftest generate-language-summary-includes-each-language-test
+(deftest ^{:stratum 1} generate-language-summary-includes-each-language-test
   (testing "The header summary lists each language present"
     (let [files [(file "src/a.clj" "clojure" 1 10)
                  (file "src/b.py"  "python"  1 10)
@@ -163,7 +135,7 @@
         (is (str/includes? text lang)
             (str "language " lang " should appear in the header summary"))))))
 
-(deftest generate-entries-sorted-by-path-test
+(deftest ^{:stratum 1} generate-entries-sorted-by-path-test
   (testing "Entries are sorted alphabetically by :path within each group"
     (let [files [(file "src/zz.clj" "clojure" 1 10)
                  (file "src/aa.clj" "clojure" 1 10)
@@ -172,10 +144,29 @@
           paths (map :path (:entries r))]
       (is (= ["src/aa.clj" "src/mm.clj" "src/zz.clj"] paths)))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Token estimate matches structure
+;------------------------------------------------------------------------------ Layer 2
 
-(deftest generate-token-estimate-grows-with-shown-files-test
+;; Truncation behaviour under a tight budget
+(deftest ^{:stratum 2} generate-truncates-when-budget-too-small-test
+  (testing "With a tight budget, only some files are shown and :truncated? is true"
+    (let [r (sut/generate (big-index "src" 50) {:token-budget 80})]
+      (is (= 50 (:total-files r)))
+      (is (true? (:truncated? r)))
+      (is (< (:shown-files r) (:total-files r)))
+      ;; The slice's :entries should be exactly :shown-files long.
+      (is (= (:shown-files r) (count (:entries r)))))))
+
+(deftest ^{:stratum 2} generate-larger-budget-never-reduces-shown-files-test
+  (testing "Increasing the budget never reduces the number of shown files
+            (monotone, not strictly increasing — when both budgets fit
+            everything, both will report the same shown-files count)"
+    (let [idx (big-index "src" 100)
+          small (sut/generate idx {:token-budget 80})
+          large (sut/generate idx {:token-budget 5000})]
+      (is (>= (:shown-files large) (:shown-files small))))))
+
+;; Token estimate matches structure
+(deftest ^{:stratum 2} generate-token-estimate-grows-with-shown-files-test
   (testing "More shown files ⇒ larger token-estimate (monotone with capacity)"
     (let [idx (big-index "src" 50)
           small (sut/generate idx {:token-budget 80})

--- a/components/repo-index/test/ai/miniforge/repo_index/schema_test.clj
+++ b/components/repo-index/test/ai/miniforge/repo_index/schema_test.clj
@@ -15,16 +15,15 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.repo-index.schema-test
   (:require [clojure.test :refer [deftest is testing]]
             [malli.core :as m]
             [ai.miniforge.repo-index.schema :as sut]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Test fixtures
 
-(defn- valid-file-record
+;; Test fixtures
+(defn- ^{:stratum 0} valid-file-record
   [& {:as overrides}]
   (merge {:path "src/a.clj"
           :blob-sha "abc1234"
@@ -34,77 +33,18 @@
           :generated? false}
          overrides))
 
-(defn- valid-repo-index
-  [& {:as overrides}]
-  (merge {:tree-sha    "abc1234"
-          :repo-root   "/repo"
-          :files       [(valid-file-record)]
-          :file-count  1
-          :total-lines 42
-          :languages   {"clojure" 1}
-          :indexed-at  (java.util.Date.)}
-         overrides))
-
-;------------------------------------------------------------------------------ Layer 1
-;; FileRecord
-
-(deftest file-record-valid-test
-  (testing "Fully populated FileRecord validates"
-    (is (m/validate sut/FileRecord (valid-file-record)))))
-
-(deftest file-record-allows-nil-language-test
-  (testing ":language is :maybe :string — nil is valid"
-    (is (m/validate sut/FileRecord (valid-file-record :language nil)))))
-
-(deftest file-record-rejects-empty-path-test
-  (testing "An empty :path fails validation (min 1)"
-    (is (not (m/validate sut/FileRecord (valid-file-record :path ""))))))
-
-(deftest file-record-rejects-short-blob-sha-test
-  (testing ":blob-sha must be at least 7 characters"
-    (is (not (m/validate sut/FileRecord (valid-file-record :blob-sha "abc"))))))
-
-(deftest file-record-rejects-non-int-size-test
-  (testing ":size must be an int"
-    (is (not (m/validate sut/FileRecord (valid-file-record :size "1024"))))))
-
-(deftest file-record-rejects-missing-required-test
-  (testing "Missing :generated? fails validation (required key)"
-    (is (not (m/validate sut/FileRecord (dissoc (valid-file-record) :generated?))))))
-
-;------------------------------------------------------------------------------ Layer 1
-;; RepoIndex
-
-(deftest repo-index-valid-test
-  (testing "Fully populated RepoIndex with one file validates"
-    (is (m/validate sut/RepoIndex (valid-repo-index)))))
-
-(deftest repo-index-empty-files-vector-valid-test
-  (testing "Empty :files vector is allowed"
-    (is (m/validate sut/RepoIndex (valid-repo-index :files [])))))
-
-(deftest repo-index-rejects-non-inst-indexed-at-test
-  (testing ":indexed-at must satisfy inst?"
-    (is (not (m/validate sut/RepoIndex (valid-repo-index :indexed-at "2026-04-30"))))))
-
-(deftest repo-index-rejects-bad-language-map-test
-  (testing ":languages must be string → int"
-    (is (not (m/validate sut/RepoIndex (valid-repo-index :languages {"clojure" "many"}))))))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; RepoMapEntry / RepoMapSlice
-
-(deftest repo-map-entry-valid-test
+(deftest ^{:stratum 0} repo-map-entry-valid-test
   (testing "RepoMapEntry with a non-nil :lang validates"
     (is (m/validate sut/RepoMapEntry
                     {:path "src/a.clj" :lang "clojure" :lines 10 :size 100}))))
 
-(deftest repo-map-entry-allows-nil-lang-test
+(deftest ^{:stratum 0} repo-map-entry-allows-nil-lang-test
   (testing ":lang is :maybe :string — nil is valid"
     (is (m/validate sut/RepoMapEntry
                     {:path "src/a.clj" :lang nil :lines 10 :size 100}))))
 
-(deftest repo-map-slice-valid-test
+(deftest ^{:stratum 0} repo-map-slice-valid-test
   (testing "Fully populated RepoMapSlice validates"
     (is (m/validate sut/RepoMapSlice
                     {:tree-sha "abc1234"
@@ -114,7 +54,7 @@
                      :truncated? false
                      :token-estimate 50}))))
 
-(deftest repo-map-slice-allows-text-key-test
+(deftest ^{:stratum 0} repo-map-slice-allows-text-key-test
   (testing "factory/->repo-map-slice and repo-map/generate both populate a
             :text key (the rendered markdown). The schema doesn't list it,
             but Malli's :map is open by default — so values that include
@@ -129,7 +69,7 @@
                      :truncated? false
                      :token-estimate 0}))))
 
-(deftest repo-map-slice-empty-entries-valid-test
+(deftest ^{:stratum 0} repo-map-slice-empty-entries-valid-test
   (testing "Empty :entries vector is allowed"
     (is (m/validate sut/RepoMapSlice
                     {:tree-sha "abc1234"
@@ -139,32 +79,87 @@
                      :truncated? false
                      :token-estimate 0}))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Snippet / SearchHit
-
-(deftest snippet-valid-test
+(deftest ^{:stratum 0} snippet-valid-test
   (testing "Fully populated Snippet validates"
     (is (m/validate sut/Snippet
                     {:start-line 10 :end-line 12 :text "match"}))))
 
-(deftest snippet-empty-text-valid-test
+(deftest ^{:stratum 0} snippet-empty-text-valid-test
   (testing "Snippet text may be the empty string (min 0)"
     (is (m/validate sut/Snippet
                     {:start-line 0 :end-line 0 :text ""}))))
 
-(deftest search-hit-valid-test
+(deftest ^{:stratum 0} search-hit-valid-test
   (testing "Fully populated SearchHit validates"
     (is (m/validate sut/SearchHit
                     {:path "src/a.clj"
                      :score 0.95
                      :snippets [{:start-line 1 :end-line 1 :text "x"}]}))))
 
-(deftest search-hit-rejects-non-double-score-test
+(deftest ^{:stratum 0} search-hit-rejects-non-double-score-test
   (testing ":score must be a double"
     (is (not (m/validate sut/SearchHit
                          {:path "src/a.clj" :score 1 :snippets []})))))
 
-(deftest search-hit-empty-snippets-valid-test
+(deftest ^{:stratum 0} search-hit-empty-snippets-valid-test
   (testing "Empty :snippets vector is allowed"
     (is (m/validate sut/SearchHit
                     {:path "src/a.clj" :score 0.0 :snippets []}))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} valid-repo-index
+  [& {:as overrides}]
+  (merge {:tree-sha    "abc1234"
+          :repo-root   "/repo"
+          :files       [(valid-file-record)]
+          :file-count  1
+          :total-lines 42
+          :languages   {"clojure" 1}
+          :indexed-at  (java.util.Date.)}
+         overrides))
+
+;; FileRecord
+(deftest ^{:stratum 1} file-record-valid-test
+  (testing "Fully populated FileRecord validates"
+    (is (m/validate sut/FileRecord (valid-file-record)))))
+
+(deftest ^{:stratum 1} file-record-allows-nil-language-test
+  (testing ":language is :maybe :string — nil is valid"
+    (is (m/validate sut/FileRecord (valid-file-record :language nil)))))
+
+(deftest ^{:stratum 1} file-record-rejects-empty-path-test
+  (testing "An empty :path fails validation (min 1)"
+    (is (not (m/validate sut/FileRecord (valid-file-record :path ""))))))
+
+(deftest ^{:stratum 1} file-record-rejects-short-blob-sha-test
+  (testing ":blob-sha must be at least 7 characters"
+    (is (not (m/validate sut/FileRecord (valid-file-record :blob-sha "abc"))))))
+
+(deftest ^{:stratum 1} file-record-rejects-non-int-size-test
+  (testing ":size must be an int"
+    (is (not (m/validate sut/FileRecord (valid-file-record :size "1024"))))))
+
+(deftest ^{:stratum 1} file-record-rejects-missing-required-test
+  (testing "Missing :generated? fails validation (required key)"
+    (is (not (m/validate sut/FileRecord (dissoc (valid-file-record) :generated?))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; RepoIndex
+(deftest ^{:stratum 2} repo-index-valid-test
+  (testing "Fully populated RepoIndex with one file validates"
+    (is (m/validate sut/RepoIndex (valid-repo-index)))))
+
+(deftest ^{:stratum 2} repo-index-empty-files-vector-valid-test
+  (testing "Empty :files vector is allowed"
+    (is (m/validate sut/RepoIndex (valid-repo-index :files [])))))
+
+(deftest ^{:stratum 2} repo-index-rejects-non-inst-indexed-at-test
+  (testing ":indexed-at must satisfy inst?"
+    (is (not (m/validate sut/RepoIndex (valid-repo-index :indexed-at "2026-04-30"))))))
+
+(deftest ^{:stratum 2} repo-index-rejects-bad-language-map-test
+  (testing ":languages must be string → int"
+    (is (not (m/validate sut/RepoIndex (valid-repo-index :languages {"clojure" "many"}))))))

--- a/components/repo-index/test/ai/miniforge/repo_index/search_lex_test.clj
+++ b/components/repo-index/test/ai/miniforge/repo_index/search_lex_test.clj
@@ -15,14 +15,15 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.repo-index.search-lex-test
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.repo-index.interface :as repo-index]
             [ai.miniforge.repo-index.schema :as schema]
             [malli.core :as m]))
 
-(deftest build-search-index-test
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} build-search-index-test
   (testing "builds a search index from a repo index"
     (let [idx (repo-index/build-index ".")
           si (repo-index/build-search-index idx)]
@@ -33,7 +34,7 @@
       (is (map? (:term->doc-ids si)))
       (is (map? (:doc-freq si))))))
 
-(deftest search-basic-test
+(deftest ^{:stratum 0} search-basic-test
   (testing "search returns ranked results"
     (let [idx (repo-index/build-index ".")
           si (repo-index/build-search-index idx)
@@ -44,7 +45,7 @@
       (is (every? #(contains? % :score) results))
       (is (every? #(contains? % :snippets) results)))))
 
-(deftest search-schema-test
+(deftest ^{:stratum 0} search-schema-test
   (testing "search results conform to SearchHit schema"
     (let [idx (repo-index/build-index ".")
           si (repo-index/build-search-index idx)
@@ -53,7 +54,7 @@
         (is (m/validate schema/SearchHit hit)
             (str "SearchHit schema mismatch for " (:path hit)))))))
 
-(deftest search-relevance-test
+(deftest ^{:stratum 0} search-relevance-test
   (testing "search ranks relevant files in top results"
     (let [idx (repo-index/build-index ".")
           si (repo-index/build-search-index idx)
@@ -63,14 +64,14 @@
       (is (some #(re-find #"scanner" %) top-paths)
           (str "Expected scanner file in top 5, got: " top-paths)))))
 
-(deftest search-max-results-test
+(deftest ^{:stratum 0} search-max-results-test
   (testing "search respects :max-results"
     (let [idx (repo-index/build-index ".")
           si (repo-index/build-search-index idx)
           results (repo-index/search-lex si "defn" {:max-results 3})]
       (is (<= (count results) 3)))))
 
-(deftest search-snippets-test
+(deftest ^{:stratum 0} search-snippets-test
   (testing "snippets contain context around matches"
     (let [idx (repo-index/build-index ".")
           si (repo-index/build-search-index idx)
@@ -84,7 +85,7 @@
           (is (>= (:end-line s) (:start-line s)))
           (is (string? (:text s))))))))
 
-(deftest search-no-results-test
+(deftest ^{:stratum 0} search-no-results-test
   (testing "search returns empty vector when no terms match"
     (let [idx (repo-index/build-index ".")
           si (repo-index/build-search-index idx)
@@ -94,7 +95,7 @@
       (is (vector? results))
       (is (zero? (count results))))))
 
-(deftest search-scores-descending-test
+(deftest ^{:stratum 0} search-scores-descending-test
   (testing "results are sorted by score descending"
     (let [idx (repo-index/build-index ".")
           si (repo-index/build-search-index idx)

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-repo-index.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-repo-index.md
@@ -1,0 +1,185 @@
+<!--
+  Title: fix: stratum-lint autofix for components/repo-index (Wave 1)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix: stratum-lint autofix for components/repo-index (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over `components/repo-index` (`src` + `test`) to
+replace decorative `Layer N` headings with real ones derived from each
+file's actual same-file reference graph, and tag every top-level `def`/
+`defn`/`deftest` with `^{:stratum n}`. One of the Wave 1 batches from
+`work/stratum-lint-baseline-2026-07-24.md` — the largest so far in this
+batch (36 pre-existing findings). One manual fix beyond the autofix
+output: `interface.clj`'s namespace docstring hardcoded a 3-layer
+breakdown that the fix invalidated. No executable logic changed anywhere.
+
+## Motivation
+
+Baseline findings for this component, confirmed via a fresh plain-lint
+run before touching anything (zero `SL001` — no upward-reference/cycle
+risk, matching the Wave 1 batch criteria): 35 `SL002` (decorative
+`Layer N` headings repeated as section banners instead of one heading
+per real stratum) across `factory.clj`, `interface.clj`, `repo_map.clj`,
+`scanner.clj`, `schema.clj`, `search_lex.clj`, and all 4 test files that
+already carried a heading; plus 1 `SL003` (`interface.clj`, reporting 4
+distinct layers against the 3-layer budget). 36 findings total, matching
+the baseline document exactly.
+
+## Changes in Detail
+
+Ran, over the whole component:
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "bef8657a2efd3b1ba9e1a4f510693c9fbca45abd" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/repo-index
+```
+
+13 files were rewritten: 8 in `src` (`factory.clj`, `interface.clj`,
+`messages.clj`, `repo_map.clj`, `scanner.clj`, `schema.clj`,
+`search_lex.clj`, `storage.clj`) and 5 in `test`
+(`factory_test.clj`, `interface_test.clj`, `repo_map_test.clj`,
+`schema_test.clj`, `search_lex_test.clj`). `--fix` normalizes every file
+it touches, not just the ones with pre-existing findings —
+`messages.clj`, `storage.clj`, and `interface_test.clj` had zero
+findings under plain lint (no `Layer` heading at all, so the plain
+checker silently skips them) but still picked up a first real `Layer 0`
+heading and `^{:stratum n}` metadata from `--fix`. Diffs are heading
+text, `^{:stratum n}` metadata, and def/deftest reordering only.
+
+Notable autofix outcomes worth calling out because they look alarming in
+a raw diff:
+
+- `schema.clj` reordered `RepoMapEntry` and `Snippet` ahead of
+  `RepoIndex`/`RepoMapSlice`/`SearchHit`: the latter three reference the
+  former as nested Malli schemas (`[:vector RepoMapEntry]`,
+  `[:vector Snippet]`), a real same-file dependency the old headings
+  didn't reflect (everything was decoratively labeled `Layer 0`).
+  Verified both new layers (0 and 1) are internally dependency-free and
+  correctly ordered.
+- `interface.clj` collapsed from 4 decorative layers to 3 real ones (0,
+  1, 2) and now clears `SL003` — the file's facade functions
+  (`build-index`, `repo-map`, `build-search-index`, `search-lex`,
+  `find-in-index`, `read-file-limited`, `find-files`) turned out to have
+  no same-file dependencies on each other, all landing at Layer 0;
+  `repo-map-text`/`get-file`/`files-by-language` depend on those and
+  landed at Layer 1; `get-files` depends on `get-file` and landed at
+  Layer 2.
+- `repo_map.clj`, `scanner.clj`, `search_lex.clj`, and `storage.clj` each
+  surfaced a *higher* real layer count than any decorative heading in the
+  file previously implied (7, 7, 8, and 5 real layers respectively,
+  against a 3-layer budget) — see the `SL003` note under Testing Plan.
+  Traced each file's full same-file call chain by hand to confirm the
+  fix's reordering is a correct topological sort with no forward
+  references (e.g. `repo_map.clj`: `chars-per-token` → `estimate-tokens`
+  → `render-group-rows` → `fit-partial-group` → `render-directory-group`
+  → `walk-directory-groups` → `generate`, each layer's defs calling only
+  defs at a strictly lower layer).
+- `schema_test.clj` and `repo_map_test.clj` reordered several `deftest`
+  forms below the test-fixture helpers they call (`valid-repo-index`,
+  `big-index`) once those helpers themselves picked up a non-zero
+  stratum from calling another same-file helper. Reordering `deftest`
+  forms has no behavioral effect; confirmed via the full test run below.
+
+One thing the autofix did **not** resolve, found during the mandated
+full-diff read: `interface.clj`'s namespace docstring carried a
+hardcoded `Layer 0: Schema re-exports` / `Layer 1: Index building and
+repo map` / `Layer 2: File retrieval` breakdown that no longer matched
+the real structure above (index/map/search building and index lookups
+are now all Layer 0; `repo-map-text`/`get-file`/`files-by-language` are
+Layer 1; only `get-files` is Layer 2). This is plain docstring prose, not
+a `;---- Layer N` banner the tool parses, so `--fix` left it untouched.
+Rewrote it by hand to describe the actual post-fix structure.
+
+No `#?(...)` reader-conditional-wrapped defs in this component, so the
+SL008 fix in the current pin never came into play.
+
+## Testing Plan
+
+1. Ran plain (non-`--fix`) `stratum-lint` before any change — reproduced
+   the baseline's 36 findings exactly (35 `SL002`, 1 `SL003`), confirmed
+   0 `SL001`.
+2. Ran `--fix` over the whole component — 13 files rewritten.
+3. Ran `--fix` a second time immediately after — zero diff, confirms
+   idempotency.
+4. Read the full diff for all 13 changed files. Traced the real
+   same-file reference graph by hand for each file that reordered defs
+   (`schema.clj`, `interface.clj`, `repo_map.clj`, `scanner.clj`,
+   `search_lex.clj`, `schema_test.clj`, `repo_map_test.clj`) to confirm
+   every reorder is a correct topological sort — no forward references,
+   no cycles. Found and hand-fixed the one stale namespace docstring in
+   `interface.clj` (above). Checked all same-line trailing comments
+   (none present in this component's changed regions) and all remaining
+   `;; Layer N` style comments in the diff (none contradicted a
+   regenerated heading).
+5. Ran `--fix` once more after the hand edit — zero diff, confirms the
+   manual fix is stable under the tool.
+6. `clj-kondo --lint components/repo-index`: 0 errors, 0 warnings — both
+   before (via `git stash`) and after.
+7. Ran all 5 test namespaces directly via `clojure -M:dev:test`
+   (`factory-test`, `interface-test`, `repo-map-test`, `schema-test`,
+   `search-lex-test`): 64 tests, 3668 assertions, 0 failures, 0 errors.
+8. Re-ran plain `stratum-lint` after the fix: `SL001`/`SL002`/`SL004`
+   clear across the component. `SL003` remains, newly surfaced (higher
+   than the pre-fix decorative count, not a regression) on four files:
+   - `repo_map.clj`: 7 real layers (token estimation/formatting
+     primitives → budget-aware row rendering → partial-group fitting →
+     directory-group rendering → the directory walk → `generate`).
+   - `scanner.clj`: 7 real layers (config path/git-command/parsing
+     primitives → config loading and git tree/rev-parse wrappers →
+     the memoized config delay → config accessors → language/generated
+     detection → entry enrichment → `scan`).
+   - `search_lex.clj`: 8 real layers (tokenization/index/BM25/snippet/
+     candidate primitives → config loading and doc-entry/snippet
+     building → the memoized config delay and `build-search-index` →
+     BM25 config accessors → `bm25-term-score` → `score-document` →
+     `score-and-rank` → `search`).
+   - `storage.clj`: 5 real layers (the index-dir-name constant →
+     `index-dir` → `index-file` → `save-index`/`load-index` →
+     `cached-index`).
+
+   All four are genuinely over the 3-layer budget the old decorative
+   headings hid (each file's pre-fix headings topped out at 1 or 2,
+   never reflecting the real depth), not a regression this PR
+   introduces — deferred to Wave 2 (real namespace split), consistent
+   with how prior Wave 1 PRs handled the same situation.
+   `interface.clj`'s original `SL003` is fully resolved (down to 3 real
+   layers, at budget).
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+change — comment/metadata/order/docstring-only. Pre-commit's
+`lint:stratum` autofixer keeps this component clean going forward;
+`repo_map.clj`, `scanner.clj`, `search_lex.clj`, and `storage.clj`'s
+`SL003` stay advisory (`MINIFORGE_STRATUM_BUDGET_MODE=warn` at commit
+time) until Wave 2 splits them.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+- Follow-on: Wave 2 namespace split for
+  `components/repo-index/src/ai/miniforge/repo_index/repo_map.clj`,
+  `scanner.clj`, `search_lex.clj`, and `storage.clj` (5-8 real layers
+  each, over the 3-layer budget)
+
+## Checklist
+
+- [x] Plain lint confirmed zero `SL001` before touching anything
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Second `--fix` pass confirms idempotency (zero diff)
+- [x] Diff read in full for all 13 changed files; reorderings traced
+      against each file's real same-file reference graph by hand
+- [x] Stale namespace docstring layer breakdown in `interface.clj`
+      updated to describe the actual post-fix structure
+- [x] Further `--fix` pass after the hand edit confirms stability (zero
+      diff)
+- [x] `clj-kondo` clean (0 errors, 0 warnings before/after)
+- [x] Component tests pass (64 tests, 3668 assertions, 0 failures/errors)
+- [x] Plain lint re-run post-fix: zero `SL001`/`SL002`/`SL004`; `SL003`
+      remains on `repo_map.clj`, `scanner.clj`, `search_lex.clj`, and
+      `storage.clj` — newly surfaced by the fix (not pre-existing),
+      tracked as Wave 2 above
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
<!--
  Title: fix: stratum-lint autofix for components/repo-index (Wave 1)
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# fix: stratum-lint autofix for components/repo-index (Wave 1)

## Overview

Runs `stratum-lint --fix` over `components/repo-index` (`src` + `test`) to
replace decorative `Layer N` headings with real ones derived from each
file's actual same-file reference graph, and tag every top-level `def`/
`defn`/`deftest` with `^{:stratum n}`. One of the Wave 1 batches from
`work/stratum-lint-baseline-2026-07-24.md` — the largest so far in this
batch (36 pre-existing findings). One manual fix beyond the autofix
output: `interface.clj`'s namespace docstring hardcoded a 3-layer
breakdown that the fix invalidated. No executable logic changed anywhere.

## Motivation

Baseline findings for this component, confirmed via a fresh plain-lint
run before touching anything (zero `SL001` — no upward-reference/cycle
risk, matching the Wave 1 batch criteria): 35 `SL002` (decorative
`Layer N` headings repeated as section banners instead of one heading
per real stratum) across `factory.clj`, `interface.clj`, `repo_map.clj`,
`scanner.clj`, `schema.clj`, `search_lex.clj`, and all 4 test files that
already carried a heading; plus 1 `SL003` (`interface.clj`, reporting 4
distinct layers against the 3-layer budget). 36 findings total, matching
the baseline document exactly.

## Changes in Detail

Ran, over the whole component:

```bash
bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "bef8657a2efd3b1ba9e1a4f510693c9fbca45abd" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/repo-index
```

13 files were rewritten: 8 in `src` (`factory.clj`, `interface.clj`,
`messages.clj`, `repo_map.clj`, `scanner.clj`, `schema.clj`,
`search_lex.clj`, `storage.clj`) and 5 in `test`
(`factory_test.clj`, `interface_test.clj`, `repo_map_test.clj`,
`schema_test.clj`, `search_lex_test.clj`). `--fix` normalizes every file
it touches, not just the ones with pre-existing findings —
`messages.clj`, `storage.clj`, and `interface_test.clj` had zero
findings under plain lint (no `Layer` heading at all, so the plain
checker silently skips them) but still picked up a first real `Layer 0`
heading and `^{:stratum n}` metadata from `--fix`. Diffs are heading
text, `^{:stratum n}` metadata, and def/deftest reordering only.

Notable autofix outcomes worth calling out because they look alarming in
a raw diff:

- `schema.clj` reordered `RepoMapEntry` and `Snippet` ahead of
  `RepoIndex`/`RepoMapSlice`/`SearchHit`: the latter three reference the
  former as nested Malli schemas (`[:vector RepoMapEntry]`,
  `[:vector Snippet]`), a real same-file dependency the old headings
  didn't reflect (everything was decoratively labeled `Layer 0`).
  Verified both new layers (0 and 1) are internally dependency-free and
  correctly ordered.
- `interface.clj` collapsed from 4 decorative layers to 3 real ones (0,
  1, 2) and now clears `SL003` — the file's facade functions
  (`build-index`, `repo-map`, `build-search-index`, `search-lex`,
  `find-in-index`, `read-file-limited`, `find-files`) turned out to have
  no same-file dependencies on each other, all landing at Layer 0;
  `repo-map-text`/`get-file`/`files-by-language` depend on those and
  landed at Layer 1; `get-files` depends on `get-file` and landed at
  Layer 2.
- `repo_map.clj`, `scanner.clj`, `search_lex.clj`, and `storage.clj` each
  surfaced a *higher* real layer count than any decorative heading in the
  file previously implied (7, 7, 8, and 5 real layers respectively,
  against a 3-layer budget) — see the `SL003` note under Testing Plan.
  Traced each file's full same-file call chain by hand to confirm the
  fix's reordering is a correct topological sort with no forward
  references (e.g. `repo_map.clj`: `chars-per-token` → `estimate-tokens`
  → `render-group-rows` → `fit-partial-group` → `render-directory-group`
  → `walk-directory-groups` → `generate`, each layer's defs calling only
  defs at a strictly lower layer).
- `schema_test.clj` and `repo_map_test.clj` reordered several `deftest`
  forms below the test-fixture helpers they call (`valid-repo-index`,
  `big-index`) once those helpers themselves picked up a non-zero
  stratum from calling another same-file helper. Reordering `deftest`
  forms has no behavioral effect; confirmed via the full test run below.

One thing the autofix did **not** resolve, found during the mandated
full-diff read: `interface.clj`'s namespace docstring carried a
hardcoded `Layer 0: Schema re-exports` / `Layer 1: Index building and
repo map` / `Layer 2: File retrieval` breakdown that no longer matched
the real structure above (index/map/search building and index lookups
are now all Layer 0; `repo-map-text`/`get-file`/`files-by-language` are
Layer 1; only `get-files` is Layer 2). This is plain docstring prose, not
a `;---- Layer N` banner the tool parses, so `--fix` left it untouched.
Rewrote it by hand to describe the actual post-fix structure.

No `#?(...)` reader-conditional-wrapped defs in this component, so the
SL008 fix in the current pin never came into play.

## Testing Plan

1. Ran plain (non-`--fix`) `stratum-lint` before any change — reproduced
   the baseline's 36 findings exactly (35 `SL002`, 1 `SL003`), confirmed
   0 `SL001`.
2. Ran `--fix` over the whole component — 13 files rewritten.
3. Ran `--fix` a second time immediately after — zero diff, confirms
   idempotency.
4. Read the full diff for all 13 changed files. Traced the real
   same-file reference graph by hand for each file that reordered defs
   (`schema.clj`, `interface.clj`, `repo_map.clj`, `scanner.clj`,
   `search_lex.clj`, `schema_test.clj`, `repo_map_test.clj`) to confirm
   every reorder is a correct topological sort — no forward references,
   no cycles. Found and hand-fixed the one stale namespace docstring in
   `interface.clj` (above). Checked all same-line trailing comments
   (none present in this component's changed regions) and all remaining
   `;; Layer N` style comments in the diff (none contradicted a
   regenerated heading).
5. Ran `--fix` once more after the hand edit — zero diff, confirms the
   manual fix is stable under the tool.
6. `clj-kondo --lint components/repo-index`: 0 errors, 0 warnings — both
   before (via `git stash`) and after.
7. Ran all 5 test namespaces directly via `clojure -M:dev:test`
   (`factory-test`, `interface-test`, `repo-map-test`, `schema-test`,
   `search-lex-test`): 64 tests, 3668 assertions, 0 failures, 0 errors.
8. Re-ran plain `stratum-lint` after the fix: `SL001`/`SL002`/`SL004`
   clear across the component. `SL003` remains, newly surfaced (higher
   than the pre-fix decorative count, not a regression) on four files:
   - `repo_map.clj`: 7 real layers (token estimation/formatting
     primitives → budget-aware row rendering → partial-group fitting →
     directory-group rendering → the directory walk → `generate`).
   - `scanner.clj`: 7 real layers (config path/git-command/parsing
     primitives → config loading and git tree/rev-parse wrappers →
     the memoized config delay → config accessors → language/generated
     detection → entry enrichment → `scan`).
   - `search_lex.clj`: 8 real layers (tokenization/index/BM25/snippet/
     candidate primitives → config loading and doc-entry/snippet
     building → the memoized config delay and `build-search-index` →
     BM25 config accessors → `bm25-term-score` → `score-document` →
     `score-and-rank` → `search`).
   - `storage.clj`: 5 real layers (the index-dir-name constant →
     `index-dir` → `index-file` → `save-index`/`load-index` →
     `cached-index`).

   All four are genuinely over the 3-layer budget the old decorative
   headings hid (each file's pre-fix headings topped out at 1 or 2,
   never reflecting the real depth), not a regression this PR
   introduces — deferred to Wave 2 (real namespace split), consistent
   with how prior Wave 1 PRs handled the same situation.
   `interface.clj`'s original `SL003` is fully resolved (down to 3 real
   layers, at budget).

## Deployment Plan

Merges to `main` like any other component change. No runtime behavior
change — comment/metadata/order/docstring-only. Pre-commit's
`lint:stratum` autofixer keeps this component clean going forward;
`repo_map.clj`, `scanner.clj`, `search_lex.clj`, and `storage.clj`'s
`SL003` stay advisory (`MINIFORGE_STRATUM_BUDGET_MODE=warn` at commit
time) until Wave 2 splits them.

## Related Issues/PRs

- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
- Follow-on: Wave 2 namespace split for
  `components/repo-index/src/ai/miniforge/repo_index/repo_map.clj`,
  `scanner.clj`, `search_lex.clj`, and `storage.clj` (5-8 real layers
  each, over the 3-layer budget)

## Checklist

- [x] Plain lint confirmed zero `SL001` before touching anything
- [x] `--fix` run over the whole component (`src` + `test`)
- [x] Second `--fix` pass confirms idempotency (zero diff)
- [x] Diff read in full for all 13 changed files; reorderings traced
      against each file's real same-file reference graph by hand
- [x] Stale namespace docstring layer breakdown in `interface.clj`
      updated to describe the actual post-fix structure
- [x] Further `--fix` pass after the hand edit confirms stability (zero
      diff)
- [x] `clj-kondo` clean (0 errors, 0 warnings before/after)
- [x] Component tests pass (64 tests, 3668 assertions, 0 failures/errors)
- [x] Plain lint re-run post-fix: zero `SL001`/`SL002`/`SL004`; `SL003`
      remains on `repo_map.clj`, `scanner.clj`, `search_lex.clj`, and
      `storage.clj` — newly surfaced by the fix (not pre-existing),
      tracked as Wave 2 above
- [x] No `--no-verify`; pre-commit hook runs normally at commit time
