### PR TITLE
fix: stratum-lint autofix for components/operator (Wave 1)

### DIFF
--- a/components/operator/src/ai/miniforge/operator/consumer.clj
+++ b/components/operator/src/ai/miniforge/operator/consumer.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.operator.consumer
   "Operator-event consumer — Phase D D-2.
 
@@ -68,18 +67,18 @@
    [java.util.concurrent Executors ScheduledExecutorService ThreadFactory TimeUnit]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Constants
 
-(def ^:const intervention-requested-event-type
+;; Constants
+(def ^{:stratum 0} ^:const intervention-requested-event-type
   :supervisory/intervention-requested)
 
-(def ^:const state-changed-event-type
+(def ^{:stratum 0} ^:const state-changed-event-type
   :supervisory/intervention-state-changed)
 
-(def ^:const anomaly-event-type
+(def ^{:stratum 0} ^:const anomaly-event-type
   :operator/intervention-anomaly)
 
-(def auto-approve-request-sources
+(def ^{:stratum 0} auto-approve-request-sources
   "Request sources whose interventions are auto-approved: the operator
    surfaces where a human performed the originating gesture, so a
    second approval step would approve the approver (Phase D decision 4,
@@ -100,28 +99,209 @@
    `:pending-human`."
   #{:cli :dashboard :native-app :tui})
 
-(def ^:private cursor-file-name ".processed")
-(def ^:private consumer-lock-file-name ".consumer.lock")
+(def ^{:stratum 0} ^:private cursor-file-name ".processed")
 
-(def ^:private empty-cursor
+(def ^{:stratum 0} ^:private consumer-lock-file-name ".consumer.lock")
+
+(def ^{:stratum 0} ^:private empty-cursor
   {:schema-version 1
    :processed-intervention-ids #{}
    :processed-files #{}})
 
-(def ^:private empty-pass-result
+(def ^{:stratum 0} ^:private empty-pass-result
   {:routed 0 :skipped 0 :anomalies 0})
 
-;; ── Processed cursor — the idempotency manifest ────────────────────────────
+;; ── File enumeration + parsing ─────────────────────────────────────────────
+(defn- ^{:stratum 0} list-event-files
+  "Event files in `operator-dir`, sorted by filename. Both filename
+   grammars sort by creation: the snowflake hex prefix lexically, the
+   legacy shape via its timestamp prefix."
+  [operator-dir]
+  (let [^java.io.File d (io/file operator-dir)]
+    (if (.isDirectory d)
+      (->> (or (.listFiles d) [])
+           (filter (fn [^java.io.File f]
+                     (and (.isFile f)
+                          (.endsWith (.getName f) ".json"))))
+           (sort-by (fn [^java.io.File f] (.getName f)))
+           vec)
+      [])))
 
-(defn- cursor-file
+(defn- ^{:stratum 0} revive-uuid
+  "Parse a UUID-shaped string back to a java.util.UUID. Non-string /
+   unparseable values pass through unchanged."
+  [v]
+  (if (string? v) (or (parse-uuid v) v) v))
+
+(defn- ^{:stratum 0} revive-inst
+  "Parse an RFC-3339 string back to a java.util.Date. Non-string /
+   unparseable values pass through unchanged."
+  [v]
+  (if (string? v)
+    (try (java.util.Date/from (Instant/parse v))
+         (catch Exception _e v))
+    v))
+
+(defn- ^{:stratum 0} valid-request-identities?
+  "True when request identity fields have their governed runtime types."
+  [event]
+  (and (or (nil? (:event/id event))
+           (uuid? (:event/id event)))
+       (uuid? (:intervention/id event))
+       (or (nil? (:workflow/id event))
+           (uuid? (:workflow/id event)))))
+
+(defn- ^{:stratum 0} remember-intervention-id
+  [acc intervention-id]
+  (update acc :cursor update :processed-intervention-ids conj intervention-id))
+
+(defn- ^{:stratum 0} remember-file
+  [acc file-name]
+  (update acc :cursor update :processed-files conj file-name))
+
+(defn- ^{:stratum 0} accept-every-request?
+  [_event]
+  true)
+
+(defn- ^{:stratum 0} transition-succeeded?
+  [result]
+  (true? (:success? result)))
+
+(defn- ^{:stratum 0} overlapping-file-lock?
+  "Babashka does not expose OverlappingFileLockException as a resolvable
+   catch class, so identify this one contention signal by its JVM class
+   name and rethrow every other exception."
+  [e]
+  (= "java.nio.channels.OverlappingFileLockException"
+     (.getName (class e))))
+
+(defn- ^{:stratum 0} event->request
+  "Extract the InterventionRequest fields from a parsed event map.
+   Only the request-identity fields are trusted from the wire; state
+   and timestamps are server-assigned by `create-intervention`."
+  [event]
+  (cond-> {:intervention/id (:intervention/id event)
+           :intervention/type (:intervention/type event)
+           :intervention/target-type (:intervention/target-type event)
+           :intervention/target-id (:intervention/target-id event)
+           :intervention/requested-by (:intervention/requested-by event)
+           :intervention/request-source (:intervention/request-source event)}
+    (:intervention/justification event)
+    (assoc :intervention/justification (:intervention/justification event))
+
+    (:intervention/details event)
+    (assoc :intervention/details
+           (dissoc (:intervention/details event) :failure/code))))
+
+;; Event publication
+(defn- ^{:stratum 0} intervention-workflow-id
+  "The `:workflow/id` to stamp on lifecycle events — present only when
+   the intervention targets a workflow, so its audit trail lands in the
+   run's own event directory. Coerced to a UUID (target ids arrive as
+   strings from the wire); an unparseable id yields nil rather than a
+   string key that would fork sequence numbering / quiesce fencing
+   away from the runner's UUID-keyed entries."
+  [interv]
+  (when (= :workflow (:intervention/target-type interv))
+    (let [target-id (:intervention/target-id interv)]
+      (if (uuid? target-id)
+        target-id
+        (some-> target-id str parse-uuid)))))
+
+;; ── Polling lifecycle ──────────────────────────────────────────────────────
+(def ^{:stratum 0} ^:const default-poll-interval-ms 1000)
+
+(def ^{:stratum 0} ^:const initial-poll-delay-ms 0)
+
+(defn- ^{:stratum 0} daemon-thread-factory
+  "Named daemon threads for the poller (the repo's background-scheduler
+   idiom — see event-stream `heartbeat.clj`): a consumer that is not
+   stopped on some shutdown path must never keep the JVM alive."
+  ^ThreadFactory []
+  (reify ThreadFactory
+    (newThread [_ runnable]
+      (doto (Thread. ^Runnable runnable "miniforge-operator-consumer")
+        (.setDaemon true)))))
+
+(defn ^{:stratum 0} stop!
+  "Stop a poller started by [[start!]]. Idempotent."
+  [{:keys [^ScheduledExecutorService executor]}]
+  (when executor
+    (.shutdownNow executor))
+  nil)
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; ── Processed cursor — the idempotency manifest ────────────────────────────
+(defn- ^{:stratum 1} cursor-file
   ^java.io.File [operator-dir]
   (io/file operator-dir cursor-file-name))
 
-(defn- consumer-lock-file
+(defn- ^{:stratum 1} consumer-lock-file
   ^java.io.File [operator-dir]
   (io/file operator-dir consumer-lock-file-name))
 
-(defn read-cursor
+(defn- ^{:stratum 1} revive-request-event
+  "Restore the typed identity fields `read-event-file`'s tag stripping
+   flattened to strings. Without this, republishing the event would
+   violate the event-stream schema (`:event/id` uuid?, timestamps
+   inst?) and re-serialize without `~u`/`~t` tags — and a string
+   `:workflow/id` would fork per-workflow sequence numbering and
+   quiesce fencing away from the UUID-keyed entries the runner uses."
+  [event]
+  (-> event
+      (update :event/id revive-uuid)
+      (update :intervention/id revive-uuid)
+      (update :event/timestamp revive-inst)
+      (update :intervention/requested-at revive-inst)
+      (update :intervention/updated-at revive-inst)
+      (cond->
+        (contains? event :workflow/id)
+        (update :workflow/id revive-uuid))))
+
+(defn ^{:stratum 1} publish-state-changed!
+  "Publish a `:supervisory/intervention-state-changed` event for
+   `interv`. The single canonical emitter for lifecycle transitions —
+   the application layer (D-3) publishes through here too, so every
+   transition carries the same envelope shape."
+  [stream interv]
+  (let [envelope (es/create-envelope
+                  stream
+                  state-changed-event-type
+                  (intervention-workflow-id interv)
+                  (messages/t :consumer/state-changed
+                              {:type (name (:intervention/type interv))
+                               :state (name (:intervention/state interv))}))]
+    (es/publish! stream (merge envelope interv))))
+
+(defn- ^{:stratum 1} publish-anomaly!
+  [stream file-name anomaly-data]
+  (let [envelope (es/create-envelope
+                  stream
+                  anomaly-event-type
+                  nil
+                  (or (:anomaly/message anomaly-data)
+                      (messages/t :consumer/event-anomaly {:file file-name})))]
+    (es/publish! stream (assoc envelope
+                               :source/file file-name
+                               :anomaly anomaly-data))))
+
+(defn- ^{:stratum 1} governed-request-event
+  "Build the governed audit event from the server-created intervention.
+   The wire event contributes only its valid source identity, already
+   captured in `created` by `event->request`. Everything else is
+   server-assigned: `es/intervention-requested` stamps a fresh
+   envelope, so `:event/id` (snowflake-ordered), `:event/timestamp`
+   (the audit clock), `:event/sequence-number`, and `:workflow/id`
+   routing all come from the server. Client-claimed identity,
+   timestamps, workflow routing, lifecycle state, and sequence are
+   ignored — never preferred over the server envelope."
+  [stream created]
+  (es/intervention-requested stream (intervention-workflow-id created) created))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} read-cursor
   "Read the processed cursor from `operator-dir`. A missing or
    unreadable cursor yields the empty cursor. Consumption is therefore
    at-least-once: a crash between routing and the end-of-pass cursor
@@ -140,7 +320,7 @@
         (catch Exception _e empty-cursor))
       empty-cursor)))
 
-(defn- write-cursor!
+(defn- ^{:stratum 2} write-cursor!
   "Persist `cursor` atomically: temp file + `Files/move` with
    `ATOMIC_MOVE` + `REPLACE_EXISTING` in the same directory (the
    repo-wide atomic-update idiom — see event-stream `archive.clj`
@@ -160,167 +340,8 @@
                             [StandardCopyOption/ATOMIC_MOVE
                              StandardCopyOption/REPLACE_EXISTING]))))
 
-;; ── File enumeration + parsing ─────────────────────────────────────────────
-
-(defn- list-event-files
-  "Event files in `operator-dir`, sorted by filename. Both filename
-   grammars sort by creation: the snowflake hex prefix lexically, the
-   legacy shape via its timestamp prefix."
-  [operator-dir]
-  (let [^java.io.File d (io/file operator-dir)]
-    (if (.isDirectory d)
-      (->> (or (.listFiles d) [])
-           (filter (fn [^java.io.File f]
-                     (and (.isFile f)
-                          (.endsWith (.getName f) ".json"))))
-           (sort-by (fn [^java.io.File f] (.getName f)))
-           vec)
-      [])))
-
-(defn- revive-uuid
-  "Parse a UUID-shaped string back to a java.util.UUID. Non-string /
-   unparseable values pass through unchanged."
-  [v]
-  (if (string? v) (or (parse-uuid v) v) v))
-
-(defn- revive-inst
-  "Parse an RFC-3339 string back to a java.util.Date. Non-string /
-   unparseable values pass through unchanged."
-  [v]
-  (if (string? v)
-    (try (java.util.Date/from (Instant/parse v))
-         (catch Exception _e v))
-    v))
-
-(defn- revive-request-event
-  "Restore the typed identity fields `read-event-file`'s tag stripping
-   flattened to strings. Without this, republishing the event would
-   violate the event-stream schema (`:event/id` uuid?, timestamps
-   inst?) and re-serialize without `~u`/`~t` tags — and a string
-   `:workflow/id` would fork per-workflow sequence numbering and
-   quiesce fencing away from the UUID-keyed entries the runner uses."
-  [event]
-  (-> event
-      (update :event/id revive-uuid)
-      (update :intervention/id revive-uuid)
-      (update :event/timestamp revive-inst)
-      (update :intervention/requested-at revive-inst)
-      (update :intervention/updated-at revive-inst)
-      (cond->
-        (contains? event :workflow/id)
-        (update :workflow/id revive-uuid))))
-
-(defn- valid-request-identities?
-  "True when request identity fields have their governed runtime types."
-  [event]
-  (and (or (nil? (:event/id event))
-           (uuid? (:event/id event)))
-       (uuid? (:intervention/id event))
-       (or (nil? (:workflow/id event))
-           (uuid? (:workflow/id event)))))
-
-(defn- remember-intervention-id
-  [acc intervention-id]
-  (update acc :cursor update :processed-intervention-ids conj intervention-id))
-
-(defn- remember-file
-  [acc file-name]
-  (update acc :cursor update :processed-files conj file-name))
-
-(defn- accept-every-request?
-  [_event]
-  true)
-
-(defn- transition-succeeded?
-  [result]
-  (true? (:success? result)))
-
-(defn- overlapping-file-lock?
-  "Babashka does not expose OverlappingFileLockException as a resolvable
-   catch class, so identify this one contention signal by its JVM class
-   name and rethrow every other exception."
-  [e]
-  (= "java.nio.channels.OverlappingFileLockException"
-     (.getName (class e))))
-
-(defn- event->request
-  "Extract the InterventionRequest fields from a parsed event map.
-   Only the request-identity fields are trusted from the wire; state
-   and timestamps are server-assigned by `create-intervention`."
-  [event]
-  (cond-> {:intervention/id (:intervention/id event)
-           :intervention/type (:intervention/type event)
-           :intervention/target-type (:intervention/target-type event)
-           :intervention/target-id (:intervention/target-id event)
-           :intervention/requested-by (:intervention/requested-by event)
-           :intervention/request-source (:intervention/request-source event)}
-    (:intervention/justification event)
-    (assoc :intervention/justification (:intervention/justification event))
-
-    (:intervention/details event)
-    (assoc :intervention/details
-           (dissoc (:intervention/details event) :failure/code))))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Event publication
-
-(defn- intervention-workflow-id
-  "The `:workflow/id` to stamp on lifecycle events — present only when
-   the intervention targets a workflow, so its audit trail lands in the
-   run's own event directory. Coerced to a UUID (target ids arrive as
-   strings from the wire); an unparseable id yields nil rather than a
-   string key that would fork sequence numbering / quiesce fencing
-   away from the runner's UUID-keyed entries."
-  [interv]
-  (when (= :workflow (:intervention/target-type interv))
-    (let [target-id (:intervention/target-id interv)]
-      (if (uuid? target-id)
-        target-id
-        (some-> target-id str parse-uuid)))))
-
-(defn publish-state-changed!
-  "Publish a `:supervisory/intervention-state-changed` event for
-   `interv`. The single canonical emitter for lifecycle transitions —
-   the application layer (D-3) publishes through here too, so every
-   transition carries the same envelope shape."
-  [stream interv]
-  (let [envelope (es/create-envelope
-                  stream
-                  state-changed-event-type
-                  (intervention-workflow-id interv)
-                  (messages/t :consumer/state-changed
-                              {:type (name (:intervention/type interv))
-                               :state (name (:intervention/state interv))}))]
-    (es/publish! stream (merge envelope interv))))
-
-(defn- publish-anomaly!
-  [stream file-name anomaly-data]
-  (let [envelope (es/create-envelope
-                  stream
-                  anomaly-event-type
-                  nil
-                  (or (:anomaly/message anomaly-data)
-                      (messages/t :consumer/event-anomaly {:file file-name})))]
-    (es/publish! stream (assoc envelope
-                               :source/file file-name
-                               :anomaly anomaly-data))))
-
-(defn- governed-request-event
-  "Build the governed audit event from the server-created intervention.
-   The wire event contributes only its valid source identity, already
-   captured in `created` by `event->request`. Everything else is
-   server-assigned: `es/intervention-requested` stamps a fresh
-   envelope, so `:event/id` (snowflake-ordered), `:event/timestamp`
-   (the audit clock), `:event/sequence-number`, and `:workflow/id`
-   routing all come from the server. Client-claimed identity,
-   timestamps, workflow routing, lifecycle state, and sequence are
-   ignored — never preferred over the server envelope."
-  [stream created]
-  (es/intervention-requested stream (intervention-workflow-id created) created))
-
 ;; ── Single-event routing ───────────────────────────────────────────────────
-
-(defn- route-intervention!
+(defn- ^{:stratum 2} route-intervention!
   "Create → approval-gate → (optional) apply. Returns the intervention
    id on success, or nil when the request was rejected as an anomaly."
   [operator-stream destination apply! event file-name]
@@ -350,10 +371,10 @@
                 (apply! destination gated))
               (:intervention/id created)))))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Consumption pass
+;------------------------------------------------------------------------------ Layer 3
 
-(defn- consume-operator-dir!
+;; Consumption pass
+(defn- ^{:stratum 3} consume-operator-dir!
   [operator-dir stream apply! accept? stream-for]
   (let [cursor (read-cursor operator-dir)
         files (->> (list-event-files operator-dir)
@@ -421,7 +442,9 @@
       (write-cursor! operator-dir (:cursor result)))
     (dissoc result :cursor)))
 
-(defn consume-pass!
+;------------------------------------------------------------------------------ Layer 4
+
+(defn ^{:stratum 4} consume-pass!
   "Run one consumption pass over `{events-dir}/operator/`.
 
    Options:
@@ -490,22 +513,9 @@
             empty-pass-result
             (throw e)))))))
 
-;; ── Polling lifecycle ──────────────────────────────────────────────────────
+;------------------------------------------------------------------------------ Layer 5
 
-(def ^:const default-poll-interval-ms 1000)
-(def ^:const initial-poll-delay-ms 0)
-
-(defn- daemon-thread-factory
-  "Named daemon threads for the poller (the repo's background-scheduler
-   idiom — see event-stream `heartbeat.clj`): a consumer that is not
-   stopped on some shutdown path must never keep the JVM alive."
-  ^ThreadFactory []
-  (reify ThreadFactory
-    (newThread [_ runnable]
-      (doto (Thread. ^Runnable runnable "miniforge-operator-consumer")
-        (.setDaemon true)))))
-
-(defn start!
+(defn ^{:stratum 5} start!
   "Start a background poller running [[consume-pass!]] on a fixed
    delay. Options are those of [[consume-pass!]] plus :interval-ms
    (default 1000). Returns a handle for [[stop!]].
@@ -529,10 +539,3 @@
                              (long (or interval-ms default-poll-interval-ms))
                              TimeUnit/MILLISECONDS)
     {:executor executor}))
-
-(defn stop!
-  "Stop a poller started by [[start!]]. Idempotent."
-  [{:keys [^ScheduledExecutorService executor]}]
-  (when executor
-    (.shutdownNow executor))
-  nil)

--- a/components/operator/src/ai/miniforge/operator/core.clj
+++ b/components/operator/src/ai/miniforge/operator/core.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.operator.core
   "Core operator implementation.
    Manages meta-loop: observe signals, detect patterns, propose improvements."
@@ -29,19 +28,17 @@
    [ai.miniforge.logging.interface :as log]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Configuration
 
-(def default-config
+;; Configuration
+(def ^{:stratum 0} default-config
   "Default operator configuration."
   (config/load-config-resource "config/operator/defaults.edn"
                                [:signal-retention-ms :pattern-window-ms
                                 :min-pattern-occurrences
                                 :auto-apply-threshold :shadow-period-ms]))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Signal management
-
-(defn create-signal
+(defn ^{:stratum 0} create-signal
   "Create a signal record."
   [type data]
   {:signal/id (random-uuid)
@@ -49,16 +46,14 @@
    :signal/data data
    :signal/timestamp (System/currentTimeMillis)})
 
-(defn prune-old-signals
+(defn ^{:stratum 0} prune-old-signals
   "Remove signals older than retention period."
   [signals retention-ms]
   (let [cutoff (- (System/currentTimeMillis) retention-ms)]
     (filterv #(> (:signal/timestamp %) cutoff) signals)))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Pattern detection
-
-(defn detect-repeated-failures
+(defn ^{:stratum 0} detect-repeated-failures
   "Detect repeated failure patterns."
   [signals min-occurrences]
   (let [failures (->> signals
@@ -73,7 +68,7 @@
                  :pattern/confidence (min 1.0 (/ (count sigs) 10.0))
                  :pattern/signals (map :signal/id sigs)})))))
 
-(defn detect-rollback-patterns
+(defn ^{:stratum 0} detect-rollback-patterns
   "Detect rollback patterns."
   [signals min-occurrences]
   (let [rollbacks (->> signals
@@ -89,7 +84,7 @@
                  :pattern/confidence (min 1.0 (/ (count sigs) 5.0))
                  :pattern/signals (map :signal/id sigs)})))))
 
-(defn detect-repair-patterns
+(defn ^{:stratum 0} detect-repair-patterns
   "Detect repair patterns from inner loop."
   [signals min-occurrences]
   (let [repairs (->> signals
@@ -104,27 +99,8 @@
                  :pattern/confidence (min 1.0 (/ (count sigs) 5.0))
                  :pattern/signals (map :signal/id sigs)})))))
 
-(defrecord SimplePatternDetector [config]
-  proto/PatternDetector
-
-  (detect [_this signals]
-    (let [min-occ (:min-pattern-occurrences config)]
-      (concat
-       (detect-repeated-failures signals min-occ)
-       (detect-rollback-patterns signals min-occ)
-       (detect-repair-patterns signals min-occ))))
-
-  (get-pattern-types [_this]
-    #{:repeated-phase-failure :frequent-rollback :recurring-repair}))
-
-(defn create-pattern-detector
-  ([] (create-pattern-detector default-config))
-  ([config] (->SimplePatternDetector config)))
-
-;------------------------------------------------------------------------------ Layer 3
 ;; Improvement generation
-
-(defn generate-for-repeated-failure
+(defn ^{:stratum 0} generate-for-repeated-failure
   "Generate improvement for repeated phase failures."
   [pattern]
   {:improvement/id (random-uuid)
@@ -141,7 +117,7 @@
    :improvement/status :proposed
    :improvement/created-at (System/currentTimeMillis)})
 
-(defn generate-for-frequent-rollback
+(defn ^{:stratum 0} generate-for-frequent-rollback
   "Generate improvement for frequent rollbacks."
   [pattern]
   {:improvement/id (random-uuid)
@@ -157,7 +133,7 @@
    :improvement/status :proposed
    :improvement/created-at (System/currentTimeMillis)})
 
-(defn generate-for-recurring-repair
+(defn ^{:stratum 0} generate-for-recurring-repair
   "Generate improvement for recurring repair patterns."
   [pattern]
   {:improvement/id (random-uuid)
@@ -174,30 +150,8 @@
    :improvement/status :proposed
    :improvement/created-at (System/currentTimeMillis)})
 
-(defrecord SimpleImprovementGenerator []
-  proto/ImprovementGenerator
-
-  (generate-improvements [_this patterns _context]
-    (mapcat
-     (fn [pattern]
-       (case (:pattern/type pattern)
-         :repeated-phase-failure [(generate-for-repeated-failure pattern)]
-         :frequent-rollback [(generate-for-frequent-rollback pattern)]
-         :recurring-repair [(generate-for-recurring-repair pattern)]
-         []))
-     patterns))
-
-  (get-supported-patterns [_this]
-    #{:repeated-phase-failure :frequent-rollback :recurring-repair}))
-
-(defn create-improvement-generator
-  []
-  (->SimpleImprovementGenerator))
-
-;------------------------------------------------------------------------------ Layer 4
 ;; Governance
-
-(defrecord SimpleGovernance [config]
+(defrecord ^{:stratum 0} SimpleGovernance [config]
   proto/Governance
 
   (requires-approval? [_this improvement]
@@ -235,14 +189,59 @@
        :required-confidence 0.95
        :shadow-period-ms (* 24 60 60 1000)})))
 
-(defn create-governance
+(defn ^{:stratum 0} create-llm-pattern-detector*
+  "Create an LLM-powered pattern detector.
+   Returns nil if construction fails."
+  [llm-backend]
+  (try
+    (llm-pattern-detector/create-llm-pattern-detector {:llm-client llm-backend})
+    (catch Exception _e nil)))
+
+(defn ^{:stratum 0} create-llm-improvement-generator*
+  "Create an LLM-powered improvement generator.
+   Returns nil if construction fails."
+  [llm-backend]
+  (try
+    (llm-improvement-generator/create-llm-improvement-generator {:llm-client llm-backend})
+    (catch Exception _e nil)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defrecord ^{:stratum 1} SimplePatternDetector [config]
+  proto/PatternDetector
+
+  (detect [_this signals]
+    (let [min-occ (:min-pattern-occurrences config)]
+      (concat
+       (detect-repeated-failures signals min-occ)
+       (detect-rollback-patterns signals min-occ)
+       (detect-repair-patterns signals min-occ))))
+
+  (get-pattern-types [_this]
+    #{:repeated-phase-failure :frequent-rollback :recurring-repair}))
+
+(defrecord ^{:stratum 1} SimpleImprovementGenerator []
+  proto/ImprovementGenerator
+
+  (generate-improvements [_this patterns _context]
+    (mapcat
+     (fn [pattern]
+       (case (:pattern/type pattern)
+         :repeated-phase-failure [(generate-for-repeated-failure pattern)]
+         :frequent-rollback [(generate-for-frequent-rollback pattern)]
+         :recurring-repair [(generate-for-recurring-repair pattern)]
+         []))
+     patterns))
+
+  (get-supported-patterns [_this]
+    #{:repeated-phase-failure :frequent-rollback :recurring-repair}))
+
+(defn ^{:stratum 1} create-governance
   ([] (create-governance default-config))
   ([config] (->SimpleGovernance config)))
 
-;------------------------------------------------------------------------------ Layer 5
 ;; Main Operator implementation
-
-(defrecord SimpleOperator [config signals proposals pattern-detector
+(defrecord ^{:stratum 1} SimpleOperator [config signals proposals pattern-detector
                            improvement-generator governance
                            knowledge-store logger]
   proto/Operator
@@ -376,6 +375,48 @@
                           :reason reason}})
         rejected))))
 
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} create-pattern-detector
+  ([] (create-pattern-detector default-config))
+  ([config] (->SimplePatternDetector config)))
+
+(defn ^{:stratum 2} create-improvement-generator
+  []
+  (->SimpleImprovementGenerator))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} create-operator
+  "Create an operator (meta-agent).
+
+   Options:
+   - :knowledge-store - Knowledge store for rule storage
+   - :config          - Override default configuration
+   - :llm-backend     - LLM client (implements LLMClient protocol).
+                        When provided, uses LLMPatternDetector and
+                        LLMImprovementGenerator instead of the simple
+                        rule-based implementations. Falls back to simple
+                        implementations if the LLM namespaces cannot be loaded."
+  ([] (create-operator {}))
+  ([{:keys [knowledge-store config llm-backend]}]
+   (let [merged-config (merge default-config config)
+         pattern-detector    (or (when llm-backend
+                                   (create-llm-pattern-detector* llm-backend))
+                                 (create-pattern-detector merged-config))
+         improvement-generator (or (when llm-backend
+                                     (create-llm-improvement-generator* llm-backend))
+                                   (create-improvement-generator))]
+     (->SimpleOperator
+      merged-config
+      (atom [])
+      (atom {})
+      pattern-detector
+      improvement-generator
+      (create-governance merged-config)
+      knowledge-store
+      (log/create-logger {:min-level :info})))))
+
 ;; Implement WorkflowObserver to receive workflow events
 (extend-type SimpleOperator
   wf/WorkflowObserver
@@ -419,52 +460,6 @@
                                   :from-phase from-phase
                                   :to-phase to-phase
                                   :reason reason}})))
-
-(defn create-llm-pattern-detector*
-  "Create an LLM-powered pattern detector.
-   Returns nil if construction fails."
-  [llm-backend]
-  (try
-    (llm-pattern-detector/create-llm-pattern-detector {:llm-client llm-backend})
-    (catch Exception _e nil)))
-
-(defn create-llm-improvement-generator*
-  "Create an LLM-powered improvement generator.
-   Returns nil if construction fails."
-  [llm-backend]
-  (try
-    (llm-improvement-generator/create-llm-improvement-generator {:llm-client llm-backend})
-    (catch Exception _e nil)))
-
-(defn create-operator
-  "Create an operator (meta-agent).
-
-   Options:
-   - :knowledge-store - Knowledge store for rule storage
-   - :config          - Override default configuration
-   - :llm-backend     - LLM client (implements LLMClient protocol).
-                        When provided, uses LLMPatternDetector and
-                        LLMImprovementGenerator instead of the simple
-                        rule-based implementations. Falls back to simple
-                        implementations if the LLM namespaces cannot be loaded."
-  ([] (create-operator {}))
-  ([{:keys [knowledge-store config llm-backend]}]
-   (let [merged-config (merge default-config config)
-         pattern-detector    (or (when llm-backend
-                                   (create-llm-pattern-detector* llm-backend))
-                                 (create-pattern-detector merged-config))
-         improvement-generator (or (when llm-backend
-                                     (create-llm-improvement-generator* llm-backend))
-                                   (create-improvement-generator))]
-     (->SimpleOperator
-      merged-config
-      (atom [])
-      (atom {})
-      pattern-detector
-      improvement-generator
-      (create-governance merged-config)
-      knowledge-store
-      (log/create-logger {:min-level :info})))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/operator/src/ai/miniforge/operator/defaults.clj
+++ b/components/operator/src/ai/miniforge/operator/defaults.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.operator.defaults
   "Default configuration for operator LLM components.
 
@@ -23,9 +22,9 @@
    without modifying code.")
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Pattern detector defaults
 
-(def pattern-detector-system-prompt
+;; Pattern detector defaults
+(def ^{:stratum 0} pattern-detector-system-prompt
   "You are a workflow pattern analyzer for a software engineering meta-agent.
 Your job: detect meaningful patterns in workflow execution signals.
 
@@ -46,14 +45,8 @@ Respond with ONLY a JSON array of pattern objects, no other text:
 
 Return an empty array [] if no significant patterns are detected.")
 
-(def pattern-detector-defaults
-  {:system-prompt pattern-detector-system-prompt
-   :max-tokens 500})
-
-;------------------------------------------------------------------------------ Layer 1
 ;; Improvement generator defaults
-
-(def improvement-generator-system-prompt
+(def ^{:stratum 0} improvement-generator-system-prompt
   "You are a process improvement advisor for a software engineering meta-agent.
 Your job: generate concrete improvement proposals from detected workflow patterns.
 
@@ -75,7 +68,7 @@ Respond with ONLY a JSON array of improvement objects, no other text:
 
 Return an empty array [] if no improvements can be confidently proposed.")
 
-(def improvement-types
+(def ^{:stratum 0} improvement-types
   "All improvement types the generator can produce."
   #{:prompt-change
     :gate-adjustment
@@ -84,7 +77,13 @@ Return an empty array [] if no improvements can be confidently proposed.")
     :budget-adjustment
     :workflow-modification})
 
-(def improvement-generator-defaults
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} pattern-detector-defaults
+  {:system-prompt pattern-detector-system-prompt
+   :max-tokens 500})
+
+(def ^{:stratum 1} improvement-generator-defaults
   {:system-prompt improvement-generator-system-prompt
    :improvement-types improvement-types
    :max-tokens 600})

--- a/components/operator/src/ai/miniforge/operator/interface.clj
+++ b/components/operator/src/ai/miniforge/operator/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.operator.interface
   "Public API for the operator (meta-agent) component.
    Manages the meta-loop: observe signals, detect patterns, propose improvements."
@@ -26,64 +25,64 @@
    [ai.miniforge.operator.intervention :as intervention]
    [ai.miniforge.operator.protocol :as proto]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; ────────────────────────────────────────────────────────────────────────────
 ;; Protocol re-exports
-
-(def Operator
+(def ^{:stratum 0} Operator
   "Protocol satisfied by the meta-agent: observe signals, analyze patterns,
    propose/apply/reject improvements. Implement to provide an operator backend."
   proto/Operator)
 
-(def PatternDetector
+(def ^{:stratum 0} PatternDetector
   "Protocol satisfied by pattern detectors: turn a sequence of signals into a
    sequence of detected patterns. Implement to provide custom detection."
   proto/PatternDetector)
 
-(def ImprovementGenerator
+(def ^{:stratum 0} ImprovementGenerator
   "Protocol satisfied by improvement generators: turn detected patterns plus
    context into a sequence of improvement proposals."
   proto/ImprovementGenerator)
 
-(def Governance
+(def ^{:stratum 0} Governance
   "Protocol satisfied by governance backends: decide whether an improvement
    needs human approval, may auto-apply, and resolve per-type approval policy."
   proto/Governance)
 
 ;; Type definitions
-(def signal-types
+(def ^{:stratum 0} signal-types
   "Set of keywords naming the signal types the operator can observe
    (e.g. :workflow-complete, :workflow-failed, :phase-rollback)."
   proto/signal-types)
 
-(def improvement-types
+(def ^{:stratum 0} improvement-types
   "Set of keywords naming the improvement types the operator can propose
    (e.g. :prompt-change, :gate-adjustment, :policy-update)."
   proto/improvement-types)
 
-(def intervention-types
+(def ^{:stratum 0} intervention-types
   "Set of keywords naming the bounded v1 supervisory intervention vocabulary
    (e.g. :acknowledge, :retry, :cancel, :force-safe-mode)."
   intervention/intervention-types)
 
-(def intervention-target-types
+(def ^{:stratum 0} intervention-target-types
   "Set of keywords naming the recognized intervention target categories
    (e.g. :attention, :workflow, :policy-eval, :pr, :degradation, :supervision)."
   intervention/target-types)
 
-(def intervention-lifecycle-states
+(def ^{:stratum 0} intervention-lifecycle-states
   "Set of keywords naming all valid intervention lifecycle states, including
    the initial state, every transition endpoint, and the terminal states."
   intervention/lifecycle-states)
 
-(def intervention-terminal-states
+(def ^{:stratum 0} intervention-terminal-states
   "Set of keywords naming the terminal intervention lifecycle states:
    :rejected, :verified, :failed."
   intervention/terminal-states)
 
 ;; ────────────────────────────────────────────────────────────────────────────
 ;; Operator creation
-
-(def create-operator
+(def ^{:stratum 0} create-operator
   "Create an operator (meta-agent).
 
    The operator observes workflow executions, detects patterns,
@@ -98,25 +97,24 @@
      (create-operator {:knowledge-store k-store})"
   core/create-operator)
 
-(def create-pattern-detector
+(def ^{:stratum 0} create-pattern-detector
   "Create a pattern detector.
    Detects patterns in workflow signals."
   core/create-pattern-detector)
 
-(def create-improvement-generator
+(def ^{:stratum 0} create-improvement-generator
   "Create an improvement generator.
    Generates improvement proposals from detected patterns."
   core/create-improvement-generator)
 
-(def create-governance
+(def ^{:stratum 0} create-governance
   "Create a governance manager.
    Controls improvement approval policies."
   core/create-governance)
 
 ;; ────────────────────────────────────────────────────────────────────────────
 ;; Bounded supervisory interventions
-
-(def create-intervention
+(def ^{:stratum 0} create-intervention
   "Create a bounded InterventionRequest map.
 
    Canonical, anomaly-returning entry point: returns the constructed
@@ -124,88 +122,87 @@
    step of the validation cascade rejects the request."
   intervention/create-intervention)
 
-(def create-intervention!
+(def ^{:stratum 0} create-intervention!
   "Boundary variant of [[create-intervention]] that throws `ex-info`
    on validation failure. Prefer [[create-intervention]] in non-boundary
    code."
   intervention/create-intervention!)
 
-(def approval-required?
+(def ^{:stratum 0} approval-required?
   "Check whether an intervention type defaults to a pending-human step."
   intervention/approval-required?)
 
-(def valid-intervention-type?
+(def ^{:stratum 0} valid-intervention-type?
   "Check if an intervention type is part of the bounded vocabulary."
   intervention/valid-type?)
 
-(def valid-intervention-target-type?
+(def ^{:stratum 0} valid-intervention-target-type?
   "Check if an intervention target type is recognized."
   intervention/valid-target-type?)
 
-(def valid-intervention-state?
+(def ^{:stratum 0} valid-intervention-state?
   "Check if an intervention lifecycle state is valid."
   intervention/valid-state?)
 
-(def intervention-terminal-state?
+(def ^{:stratum 0} intervention-terminal-state?
   "Check if an intervention lifecycle state is terminal."
   intervention/terminal-state?)
 
-(def intervention-target-type
+(def ^{:stratum 0} intervention-target-type
   "Resolve the default target type for an intervention."
   intervention/intervention-target-type)
 
-(def valid-intervention-transition?
+(def ^{:stratum 0} valid-intervention-transition?
   "Check if an intervention lifecycle transition is valid."
   intervention/valid-transition?)
 
-(def next-intervention-state
+(def ^{:stratum 0} next-intervention-state
   "Resolve the next lifecycle state for an intervention transition."
   intervention/next-state)
 
-(def transition-intervention
+(def ^{:stratum 0} transition-intervention
   "Apply a lifecycle transition to an intervention."
   intervention/transition)
 
-(def start-intervention-approval
+(def ^{:stratum 0} start-intervention-approval
   "Move an intervention into :pending-human."
   intervention/start-approval)
 
-(def approve-intervention
+(def ^{:stratum 0} approve-intervention
   "Approve an intervention."
   intervention/approve)
 
-(def reject-intervention
+(def ^{:stratum 0} reject-intervention
   "Reject an intervention."
   intervention/reject)
 
-(def dispatch-intervention
+(def ^{:stratum 0} dispatch-intervention
   "Mark an intervention as dispatched."
   intervention/dispatch)
 
-(def apply-intervention-result
+(def ^{:stratum 0} apply-intervention-result
   "Mark an intervention as applied."
   intervention/apply-result)
 
-(def verify-intervention
+(def ^{:stratum 0} verify-intervention
   "Mark an intervention as verified."
   intervention/verify)
 
-(def fail-intervention
+(def ^{:stratum 0} fail-intervention
   "Mark an intervention as failed."
   intervention/fail)
 
-(def supported-target-types
+(def ^{:stratum 0} supported-target-types
   "Return the supported target types for an intervention type."
   intervention/supported-target-types)
 
-(def bounded-intervention-vocabulary?
+(def ^{:stratum 0} bounded-intervention-vocabulary?
   "Check if a set of intervention types is within the bounded vocabulary."
   intervention/bounded-vocabulary?)
 
 ;; ────────────────────────────────────────────────────────────────────────────
 ;; Operator-event consumer (Phase D D-2)
-
-(def consume-operator-events!
+(def ^{:stratum 0} consume-operator-events!
   "Run one consumption pass over `{events-dir}/operator/`: parse
    intervention-requested events, validate, route through the
    lifecycle (auto-approving operator-driven request sources), publish
@@ -217,36 +214,35 @@
    {:routed n :skipped n :anomalies n}."
   consumer/consume-pass!)
 
-(def start-operator-consumer!
+(def ^{:stratum 0} start-operator-consumer!
   "Start a fixed-delay background poller running the consumer pass.
    Options are those of [[consume-operator-events!]] plus :interval-ms
    (default 1000). Returns a handle for [[stop-operator-consumer!]]."
   consumer/start!)
 
-(def stop-operator-consumer!
+(def ^{:stratum 0} stop-operator-consumer!
   "Stop a poller started by [[start-operator-consumer!]]. Idempotent."
   consumer/stop!)
 
-(def auto-approve-request-sources
+(def ^{:stratum 0} auto-approve-request-sources
   "Request sources whose interventions are auto-approved (the human IS
    the approver): the operator surfaces, not delegated agents."
   consumer/auto-approve-request-sources)
 
 ;; ── Intervention application (Phase D D-3) ──────────────────────────────────
-
-(def register-live-runner!
+(def ^{:stratum 0} register-live-runner!
   "Register a live runner's control handles for a workflow id so
    interventions can act on it. `handles` must include
    {:control-state <atom>} and should include :event-stream so governed
    lifecycle events retain the workflow's sequence counter."
   application/register-runner!)
 
-(def register-degradation-manager!
+(def ^{:stratum 0} register-degradation-manager!
   "Register the process-scoped degradation manager used by safe-mode
    interventions."
   application/register-degradation-manager!)
 
-(def register-resume-launcher!
+(def ^{:stratum 0} register-resume-launcher!
   "Register the process-scoped resume launcher used by `:retry` /
    `:retry-from-phase` (Phase D D-3b). Takes a handles map carrying
    `:launch!` — `(fn [resume-plan] → {:resume/run-id …})` — and an
@@ -254,7 +250,7 @@
    retries fail `:no-resume-launcher`."
   application/register-resume-launcher!)
 
-(def register-policy-evaluator!
+(def ^{:stratum 0} register-policy-evaluator!
   "Register the process-scoped PR policy evaluator used by
    `:re-evaluate` (Phase D D-3b). Takes `(fn [request] → evaluation)`
    returning the `policy-pack/evaluate-external-pr` result shape. Pass
@@ -263,22 +259,22 @@
    receive."
   application/register-policy-evaluator!)
 
-(def deregister-live-runner!
+(def ^{:stratum 0} deregister-live-runner!
   "Remove a workflow id from the live-runner registry. Idempotent."
   application/deregister-runner!)
 
-(def live-intervention-target?
+(def ^{:stratum 0} live-intervention-target?
   "Ownership predicate for a process-scoped operator consumer. Returns
    true for process-global targets and for workflow targets registered
    to a live runner in this process."
   application/live-intervention-target?)
 
-(def live-intervention-stream
+(def ^{:stratum 0} live-intervention-stream
   "Return the registered workflow event stream for a workflow-targeted
    intervention, or nil when the operator stream should be used."
   application/live-intervention-stream)
 
-(def apply-intervention!
+(def ^{:stratum 0} apply-intervention!
   "The D-3 `:apply!` hook: apply one approved intervention to its
    mechanism — control-state flags on a live runner, no-effect verbs,
    safe-mode, and (D-3b) the resume launcher for `:retry` /
@@ -292,8 +288,7 @@
 
 ;; ────────────────────────────────────────────────────────────────────────────
 ;; Signal observation
-
-(defn observe-signal
+(defn ^{:stratum 0} observe-signal
   "Record an observation signal.
 
    signal: {:type keyword :data map}
@@ -312,7 +307,7 @@
   [operator signal]
   (proto/observe-signal operator signal))
 
-(defn get-signals
+(defn ^{:stratum 0} get-signals
   "Query recorded signals.
 
    query:
@@ -326,8 +321,7 @@
 
 ;; ────────────────────────────────────────────────────────────────────────────
 ;; Pattern analysis
-
-(defn analyze-patterns
+(defn ^{:stratum 0} analyze-patterns
   "Analyze signals for patterns.
 
    Arguments:
@@ -344,7 +338,7 @@
   [operator window-ms]
   (proto/analyze-patterns operator window-ms))
 
-(defn detect-patterns
+(defn ^{:stratum 0} detect-patterns
   "Detect patterns in a sequence of signals.
 
    Arguments:
@@ -355,7 +349,7 @@
   [detector signals]
   (proto/detect detector signals))
 
-(defn generate-improvements
+(defn ^{:stratum 0} generate-improvements
   "Generate improvement proposals from patterns.
 
    Arguments:
@@ -369,8 +363,7 @@
 
 ;; ────────────────────────────────────────────────────────────────────────────
 ;; Improvement management
-
-(defn propose-improvement
+(defn ^{:stratum 0} propose-improvement
   "Propose a process improvement.
 
    improvement:
@@ -391,7 +384,7 @@
   [operator improvement]
   (proto/propose-improvement operator improvement))
 
-(defn get-proposals
+(defn ^{:stratum 0} get-proposals
   "Query improvement proposals.
 
    query:
@@ -402,7 +395,7 @@
   [operator query]
   (proto/get-proposals operator query))
 
-(defn apply-improvement
+(defn ^{:stratum 0} apply-improvement
   "Apply an approved improvement.
 
    Returns {:success? bool :applied improvement-map} when the proposal is in
@@ -412,7 +405,7 @@
   [operator proposal-id]
   (proto/apply-improvement operator proposal-id))
 
-(defn reject-improvement
+(defn ^{:stratum 0} reject-improvement
   "Reject an improvement proposal.
 
    Returns the updated proposal map (with :improvement/rejection-reason) when
@@ -424,18 +417,17 @@
 
 ;; ────────────────────────────────────────────────────────────────────────────
 ;; Governance
-
-(defn requires-approval?
+(defn ^{:stratum 0} requires-approval?
   "Check if improvement requires human approval."
   [governance improvement]
   (proto/requires-approval? governance improvement))
 
-(defn can-auto-apply?
+(defn ^{:stratum 0} can-auto-apply?
   "Check if improvement can be applied automatically."
   [governance improvement]
   (proto/can-auto-apply? governance improvement))
 
-(defn get-approval-policy
+(defn ^{:stratum 0} get-approval-policy
   "Get the approval policy for an improvement type.
 
    Returns:

--- a/components/operator/src/ai/miniforge/operator/intervention.clj
+++ b/components/operator/src/ai/miniforge/operator/intervention.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.operator.intervention
   "Pure bounded intervention lifecycle helpers.
 
@@ -28,90 +27,19 @@
    [clojure.set :as set]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Config
 
-(def ^:private intervention-config-resource
+;; Config
+(def ^{:stratum 0} ^:private intervention-config-resource
   "Classpath location of the intervention lifecycle config."
   "config/operator/intervention.edn")
 
-(defn- load-intervention-config
-  []
-  (:operator/intervention
-   (config/load-config-resource intervention-config-resource
-                                [:operator/intervention])))
-
-(def ^:private intervention-config
-  (delay (load-intervention-config)))
-
-(def ^:private initial-state
-  (:initial-state @intervention-config))
-
-(def approval-required-types
-  "Interventions that default to an explicit human approval step because the
-   requested action materially changes runtime posture or execution."
-  (:approval-required-types @intervention-config))
-
-(def terminal-states
-  (:terminal-states @intervention-config))
-
-(def default-target-type-by-intervention
-  "Default target type for each intervention."
-  (:default-target-type-by-intervention @intervention-config))
-
-(def lifecycle-transitions
-  "Valid intervention lifecycle transitions. Map of [from-state event] -> to-state."
-  (:lifecycle-transitions @intervention-config))
-
-(def intervention-types
-  "Bounded v1 intervention vocabulary per N5-delta-supervisory-control-plane
-   §7.1."
-  (set (keys default-target-type-by-intervention)))
-
-(def target-types
-  (set (vals default-target-type-by-intervention)))
-
-(def lifecycle-states
-  "Intervention lifecycle states per N5-delta-supervisory-control-plane §3.3."
-  (-> (set (mapcat (fn [[[from-state _event] to-state]]
-                     [from-state to-state])
-                   lifecycle-transitions))
-      (conj initial-state)
-      (set/union terminal-states)))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Construction and validation
-
-(defn approval-required?
-  [intervention-type]
-  (contains? approval-required-types intervention-type))
-
-(defn valid-type?
-  [intervention-type]
-  (contains? intervention-types intervention-type))
-
-(defn valid-target-type?
-  [target-type]
-  (contains? target-types target-type))
-
-(defn valid-state?
-  [state]
-  (contains? lifecycle-states state))
-
-(defn terminal-state?
-  [state]
-  (contains? terminal-states state))
-
-(defn intervention-target-type
-  [intervention-type]
-  (get default-target-type-by-intervention intervention-type))
-
-(defn- intervention-transition-error
+(defn- ^{:stratum 0} intervention-transition-error
   [error message]
   {:success? false
    :error error
    :message message})
 
-(defn- with-optional-intervention-attrs
+(defn- ^{:stratum 0} with-optional-intervention-attrs
   [intervention opts]
   (cond-> intervention
     (:reason opts) (assoc :intervention/reason (:reason opts))
@@ -121,21 +49,12 @@
             (fn [existing]
               (merge (or existing {}) (:details opts))))))
 
-(defn- transition-opts
+(defn- ^{:stratum 0} transition-opts
   [key value]
   (cond-> {}
     value (assoc key value)))
 
-(defn- validate-intervention-type
-  "Return an `:invalid-input` anomaly when `type` is not in the bounded
-   vocabulary, else nil."
-  [type]
-  (when-not (valid-type? type)
-    (anomaly/anomaly :invalid-input
-                     (messages/t :intervention/unknown-type)
-                     {:intervention/type type})))
-
-(defn- validate-target-type-resolvable
+(defn- ^{:stratum 0} validate-target-type-resolvable
   "Return an `:invalid-input` anomaly when no target type can be resolved
    for `type` (neither caller-supplied nor a default in the vocabulary),
    else nil."
@@ -145,31 +64,7 @@
                      (messages/t :intervention/target-type-required)
                      {:intervention/type type})))
 
-(defn- validate-target-type-known
-  "Return an `:invalid-input` anomaly when the resolved target type is
-   not in the recognized set, else nil."
-  [type resolved-target-type]
-  (when-not (valid-target-type? resolved-target-type)
-    (anomaly/anomaly :invalid-input
-                     (messages/t :intervention/unknown-target-type)
-                     {:intervention/type type
-                      :intervention/target-type resolved-target-type})))
-
-(defn- validate-target-type-supported
-  "Return an `:invalid-input` anomaly when a known target category does
-   not match the bounded category assigned to the intervention type."
-  [type resolved-target-type]
-  (let [supported-target-type (intervention-target-type type)]
-    (when (not= supported-target-type resolved-target-type)
-      (anomaly/anomaly :invalid-input
-                       (messages/t :intervention/unsupported-target-type
-                                   {:type type
-                                    :target-type resolved-target-type})
-                       {:intervention/type type
-                        :intervention/target-type resolved-target-type
-                        :intervention/supported-target-type supported-target-type}))))
-
-(defn- validate-target-id
+(defn- ^{:stratum 0} validate-target-id
   "Return an `:invalid-input` anomaly when `target-id` is missing, else
    nil."
   [type target-id]
@@ -178,7 +73,7 @@
                      (messages/t :intervention/target-id-required)
                      {:intervention/type type})))
 
-(defn- validate-requester
+(defn- ^{:stratum 0} validate-requester
   "Return an `:invalid-input` anomaly when either `requested-by` or
    `request-source` is missing, else nil."
   [type requested-by request-source]
@@ -189,7 +84,72 @@
                       :intervention/requested-by requested-by
                       :intervention/request-source request-source})))
 
-(defn- build-intervention
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} load-intervention-config
+  []
+  (:operator/intervention
+   (config/load-config-resource intervention-config-resource
+                                [:operator/intervention])))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(def ^{:stratum 2} ^:private intervention-config
+  (delay (load-intervention-config)))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(def ^{:stratum 3} ^:private initial-state
+  (:initial-state @intervention-config))
+
+(def ^{:stratum 3} approval-required-types
+  "Interventions that default to an explicit human approval step because the
+   requested action materially changes runtime posture or execution."
+  (:approval-required-types @intervention-config))
+
+(def ^{:stratum 3} terminal-states
+  (:terminal-states @intervention-config))
+
+(def ^{:stratum 3} default-target-type-by-intervention
+  "Default target type for each intervention."
+  (:default-target-type-by-intervention @intervention-config))
+
+(def ^{:stratum 3} lifecycle-transitions
+  "Valid intervention lifecycle transitions. Map of [from-state event] -> to-state."
+  (:lifecycle-transitions @intervention-config))
+
+;------------------------------------------------------------------------------ Layer 4
+
+(def ^{:stratum 4} intervention-types
+  "Bounded v1 intervention vocabulary per N5-delta-supervisory-control-plane
+   §7.1."
+  (set (keys default-target-type-by-intervention)))
+
+(def ^{:stratum 4} target-types
+  (set (vals default-target-type-by-intervention)))
+
+(def ^{:stratum 4} lifecycle-states
+  "Intervention lifecycle states per N5-delta-supervisory-control-plane §3.3."
+  (-> (set (mapcat (fn [[[from-state _event] to-state]]
+                     [from-state to-state])
+                   lifecycle-transitions))
+      (conj initial-state)
+      (set/union terminal-states)))
+
+;; Construction and validation
+(defn ^{:stratum 4} approval-required?
+  [intervention-type]
+  (contains? approval-required-types intervention-type))
+
+(defn ^{:stratum 4} terminal-state?
+  [state]
+  (contains? terminal-states state))
+
+(defn ^{:stratum 4} intervention-target-type
+  [intervention-type]
+  (get default-target-type-by-intervention intervention-type))
+
+(defn- ^{:stratum 4} build-intervention
   "Assemble a validated InterventionRequest map from `request`. Assumes
    all preconditions have already been checked."
   [{:as request} resolved-target-type approval-required?* now]
@@ -212,7 +172,118 @@
       approval-required?*
       (assoc :intervention/approval-required? true))))
 
-(defn create-intervention
+;; Lifecycle helpers
+(defn ^{:stratum 4} valid-transition?
+  [current-state event]
+  (contains? lifecycle-transitions [current-state event]))
+
+(defn ^{:stratum 4} next-state
+  [current-state event]
+  (get lifecycle-transitions [current-state event]))
+
+;------------------------------------------------------------------------------ Layer 5
+
+(defn ^{:stratum 5} valid-type?
+  [intervention-type]
+  (contains? intervention-types intervention-type))
+
+(defn ^{:stratum 5} valid-target-type?
+  [target-type]
+  (contains? target-types target-type))
+
+(defn ^{:stratum 5} valid-state?
+  [state]
+  (contains? lifecycle-states state))
+
+(defn- ^{:stratum 5} validate-target-type-supported
+  "Return an `:invalid-input` anomaly when a known target category does
+   not match the bounded category assigned to the intervention type."
+  [type resolved-target-type]
+  (let [supported-target-type (intervention-target-type type)]
+    (when (not= supported-target-type resolved-target-type)
+      (anomaly/anomaly :invalid-input
+                       (messages/t :intervention/unsupported-target-type
+                                   {:type type
+                                    :target-type resolved-target-type})
+                       {:intervention/type type
+                        :intervention/target-type resolved-target-type
+                        :intervention/supported-target-type supported-target-type}))))
+
+(defn ^{:stratum 5} supported-target-types
+  [intervention-type]
+  (let [target-type (intervention-target-type intervention-type)]
+    (if target-type
+      #{target-type}
+      #{})))
+
+(defn ^{:stratum 5} bounded-vocabulary?
+  [types]
+  (empty? (set/difference (set types) intervention-types)))
+
+;------------------------------------------------------------------------------ Layer 6
+
+(defn- ^{:stratum 6} validate-intervention-type
+  "Return an `:invalid-input` anomaly when `type` is not in the bounded
+   vocabulary, else nil."
+  [type]
+  (when-not (valid-type? type)
+    (anomaly/anomaly :invalid-input
+                     (messages/t :intervention/unknown-type)
+                     {:intervention/type type})))
+
+(defn- ^{:stratum 6} validate-target-type-known
+  "Return an `:invalid-input` anomaly when the resolved target type is
+   not in the recognized set, else nil."
+  [type resolved-target-type]
+  (when-not (valid-target-type? resolved-target-type)
+    (anomaly/anomaly :invalid-input
+                     (messages/t :intervention/unknown-target-type)
+                     {:intervention/type type
+                      :intervention/target-type resolved-target-type})))
+
+(defn ^{:stratum 6} transition
+  "Apply a lifecycle transition to `intervention`.
+
+   `opts` may carry:
+   - :reason
+   - :outcome
+   - :details
+   - :updated-at"
+  ([intervention event]
+   (transition intervention event {}))
+
+  ([intervention event opts]
+   (let [current-state (:intervention/state intervention)
+         next (next-state current-state event)
+         updated-at (or (:updated-at opts) (java.util.Date.))]
+     (cond
+       (not (valid-state? current-state))
+       (intervention-transition-error
+        :invalid-state
+        (messages/t :intervention/invalid-state {:state current-state}))
+
+       (terminal-state? current-state)
+       (intervention-transition-error
+        :terminal-state
+        (messages/t :intervention/terminal-state {:state current-state}))
+
+       (nil? next)
+       (intervention-transition-error
+        :invalid-transition
+        (messages/t :intervention/invalid-transition
+                    {:state current-state
+                     :event event}))
+
+       :else
+       {:success? true
+        :intervention (-> intervention
+                          (assoc :intervention/state next
+                                 :intervention/updated-at updated-at)
+                          (with-optional-intervention-attrs opts))}))))
+
+;------------------------------------------------------------------------------ Layer 7
+
+(defn ^{:stratum 7} create-intervention
   "Create a new InterventionRequest map.
 
    Canonical, anomaly-returning entry point. Returns the constructed
@@ -253,7 +324,46 @@
         (validate-requester type requested-by request-source)
         (build-intervention request resolved-target-type approval-required?* now))))
 
-(defn create-intervention!
+(defn ^{:stratum 7} start-approval
+  [intervention]
+  (transition intervention :require-human))
+
+(defn ^{:stratum 7} approve
+  [intervention]
+  (transition intervention :approve))
+
+(defn ^{:stratum 7} reject
+  ([intervention]
+   (reject intervention nil))
+  ([intervention reason]
+   (transition intervention :reject (transition-opts :reason reason))))
+
+(defn ^{:stratum 7} dispatch
+  "Dispatch an approved intervention to the orchestrator."
+  [intervention]
+  (transition intervention :dispatch))
+
+(defn ^{:stratum 7} apply-result
+  ([intervention]
+   (apply-result intervention nil))
+  ([intervention outcome]
+   (transition intervention :apply (transition-opts :outcome outcome))))
+
+(defn ^{:stratum 7} verify
+  ([intervention]
+   (verify intervention nil))
+  ([intervention outcome]
+   (transition intervention :verify (transition-opts :outcome outcome))))
+
+(defn ^{:stratum 7} fail
+  ([intervention]
+   (fail intervention nil))
+  ([intervention reason]
+   (transition intervention :fail (transition-opts :reason reason))))
+
+;------------------------------------------------------------------------------ Layer 8
+
+(defn ^{:stratum 8} create-intervention!
   "Boundary wrapper around [[create-intervention]]. Calls the canonical
    anomaly-returning fn; on anomaly result raises an `ex-info` carrying
    the anomaly's message and `:anomaly/data` shape so legacy callers
@@ -267,102 +377,3 @@
       (throw (ex-info (:anomaly/message result)
                       (:anomaly/data result)))
       result)))
-
-;------------------------------------------------------------------------------ Layer 2
-;; Lifecycle helpers
-
-(defn valid-transition?
-  [current-state event]
-  (contains? lifecycle-transitions [current-state event]))
-
-(defn next-state
-  [current-state event]
-  (get lifecycle-transitions [current-state event]))
-
-(defn transition
-  "Apply a lifecycle transition to `intervention`.
-
-   `opts` may carry:
-   - :reason
-   - :outcome
-   - :details
-   - :updated-at"
-  ([intervention event]
-   (transition intervention event {}))
-
-  ([intervention event opts]
-   (let [current-state (:intervention/state intervention)
-         next (next-state current-state event)
-         updated-at (or (:updated-at opts) (java.util.Date.))]
-     (cond
-       (not (valid-state? current-state))
-       (intervention-transition-error
-        :invalid-state
-        (messages/t :intervention/invalid-state {:state current-state}))
-
-       (terminal-state? current-state)
-       (intervention-transition-error
-        :terminal-state
-        (messages/t :intervention/terminal-state {:state current-state}))
-
-       (nil? next)
-       (intervention-transition-error
-        :invalid-transition
-        (messages/t :intervention/invalid-transition
-                    {:state current-state
-                     :event event}))
-
-       :else
-       {:success? true
-        :intervention (-> intervention
-                          (assoc :intervention/state next
-                                 :intervention/updated-at updated-at)
-                          (with-optional-intervention-attrs opts))}))))
-
-(defn start-approval
-  [intervention]
-  (transition intervention :require-human))
-
-(defn approve
-  [intervention]
-  (transition intervention :approve))
-
-(defn reject
-  ([intervention]
-   (reject intervention nil))
-  ([intervention reason]
-   (transition intervention :reject (transition-opts :reason reason))))
-
-(defn dispatch
-  "Dispatch an approved intervention to the orchestrator."
-  [intervention]
-  (transition intervention :dispatch))
-
-(defn apply-result
-  ([intervention]
-   (apply-result intervention nil))
-  ([intervention outcome]
-   (transition intervention :apply (transition-opts :outcome outcome))))
-
-(defn verify
-  ([intervention]
-   (verify intervention nil))
-  ([intervention outcome]
-   (transition intervention :verify (transition-opts :outcome outcome))))
-
-(defn fail
-  ([intervention]
-   (fail intervention nil))
-  ([intervention reason]
-   (transition intervention :fail (transition-opts :reason reason))))
-
-(defn supported-target-types
-  [intervention-type]
-  (let [target-type (intervention-target-type intervention-type)]
-    (if target-type
-      #{target-type}
-      #{})))
-
-(defn bounded-vocabulary?
-  [types]
-  (empty? (set/difference (set types) intervention-types)))

--- a/components/operator/src/ai/miniforge/operator/llm_improvement_generator.clj
+++ b/components/operator/src/ai/miniforge/operator/llm_improvement_generator.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.operator.llm-improvement-generator
   "LLM-powered improvement generator for the operator meta-loop.
 
@@ -35,11 +34,10 @@
    [ai.miniforge.operator.protocol :as proto]))
 
 ;------------------------------------------------------------------------------ Layer 0
+
 ;; Prompt construction
-
 ;; System prompt and improvement types sourced from defaults — override via config
-
-(defn summarize-pattern
+(defn ^{:stratum 0} summarize-pattern
   "Create a compact string summary of a single detected pattern."
   [pattern]
   (let [type-str  (name (:pattern/type pattern))
@@ -55,7 +53,17 @@
          "  Description: " desc "\n"
          "  Rationale: " rationale)))
 
-(defn build-generate-prompt
+;; Response parsing
+(defn ^{:stratum 0} parse-improvement-type
+  "Parse an improvement type string to keyword, returning nil for unknown types."
+  [type-str allowed-types]
+  (let [kw (keyword (str/lower-case (str/trim (str type-str))))]
+    (when (contains? allowed-types kw)
+      kw)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} build-generate-prompt
   "Build prompt for improvement generation from detected patterns.
 
    context may contain :workflow-id, :phase, :budget, etc. for additional grounding."
@@ -75,17 +83,7 @@
          context-text
          "\n\nGenerate improvement proposals for these patterns as JSON.")))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Response parsing
-
-(defn parse-improvement-type
-  "Parse an improvement type string to keyword, returning nil for unknown types."
-  [type-str allowed-types]
-  (let [kw (keyword (str/lower-case (str/trim (str type-str))))]
-    (when (contains? allowed-types kw)
-      kw)))
-
-(defn parse-improvement
+(defn ^{:stratum 1} parse-improvement
   "Parse a single improvement map from LLM JSON output into a canonical improvement map."
   [raw allowed-types]
   (let [imp-type (parse-improvement-type (:type raw) allowed-types)]
@@ -105,7 +103,9 @@
        :improvement/created-at   (System/currentTimeMillis)
        :improvement/source       :llm})))
 
-(defn parse-generate-response
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} parse-generate-response
   "Parse LLM JSON response into a sequence of improvement maps.
 
    Returns empty sequence on parse failure (fail-open)."
@@ -122,10 +122,10 @@
     (catch Exception _e
       [])))
 
-;------------------------------------------------------------------------------ Layer 2
-;; LLMImprovementGenerator record
+;------------------------------------------------------------------------------ Layer 3
 
-(defrecord LLMImprovementGenerator [llm-client config]
+;; LLMImprovementGenerator record
+(defrecord ^{:stratum 3} LLMImprovementGenerator [llm-client config]
   proto/ImprovementGenerator
 
   (generate-improvements [_this patterns context]
@@ -159,10 +159,10 @@
       :frequent-rollback
       :recurring-repair}))
 
-;------------------------------------------------------------------------------ Layer 3
-;; Constructor
+;------------------------------------------------------------------------------ Layer 4
 
-(defn create-llm-improvement-generator
+;; Constructor
+(defn ^{:stratum 4} create-llm-improvement-generator
   "Create an LLM-powered improvement generator.
 
    Arguments:

--- a/components/operator/src/ai/miniforge/operator/llm_pattern_detector.clj
+++ b/components/operator/src/ai/miniforge/operator/llm_pattern_detector.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.operator.llm-pattern-detector
   "LLM-powered pattern detector for the operator meta-loop.
 
@@ -35,11 +34,10 @@
    [ai.miniforge.operator.protocol :as proto]))
 
 ;------------------------------------------------------------------------------ Layer 0
+
 ;; Prompt construction
-
 ;; System prompt sourced from defaults — override via config :system-prompt
-
-(defn summarize-signal
+(defn ^{:stratum 0} summarize-signal
   "Create a compact string summary of a single signal."
   [sig]
   (let [type-str (name (:signal/type sig))
@@ -54,7 +52,19 @@
          (when (:workflow-id data) (str "wf=" (:workflow-id data) " "))
          "ts=" ts)))
 
-(defn build-detect-prompt
+;; Response parsing
+(defn ^{:stratum 0} parse-pattern-type
+  "Parse a pattern type string to keyword, returning nil for unknown types."
+  [type-str]
+  (let [kw (keyword (str/lower-case (str/trim (str type-str))))]
+    (when (contains? #{:repeated-failure :performance-degradation
+                       :resource-waste :anti-pattern :improvement-opportunity}
+                     kw)
+      kw)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} build-detect-prompt
   "Build prompt for pattern detection from a sequence of signals.
 
    Keeps total input under ~1000 tokens by limiting signal count and summary length."
@@ -76,19 +86,7 @@
          signal-lines
          "\n\nAnalyze these signals and return detected patterns as JSON.")))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Response parsing
-
-(defn parse-pattern-type
-  "Parse a pattern type string to keyword, returning nil for unknown types."
-  [type-str]
-  (let [kw (keyword (str/lower-case (str/trim (str type-str))))]
-    (when (contains? #{:repeated-failure :performance-degradation
-                       :resource-waste :anti-pattern :improvement-opportunity}
-                     kw)
-      kw)))
-
-(defn parse-pattern
+(defn ^{:stratum 1} parse-pattern
   "Parse a single pattern map from LLM JSON output into a canonical pattern map."
   [raw]
   (let [pattern-type (parse-pattern-type (:type raw))]
@@ -105,7 +103,9 @@
        :pattern/rationale   (get raw :rationale "No rationale provided")
        :pattern/source      :llm})))
 
-(defn parse-detect-response
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} parse-detect-response
   "Parse LLM JSON response into a sequence of pattern maps.
 
    Returns empty sequence on parse failure (fail-open)."
@@ -122,10 +122,10 @@
     (catch Exception _e
       [])))
 
-;------------------------------------------------------------------------------ Layer 2
-;; LLMPatternDetector record
+;------------------------------------------------------------------------------ Layer 3
 
-(defrecord LLMPatternDetector [llm-client config]
+;; LLMPatternDetector record
+(defrecord ^{:stratum 3} LLMPatternDetector [llm-client config]
   proto/PatternDetector
 
   (detect [_this signals]
@@ -153,10 +153,10 @@
       :anti-pattern
       :improvement-opportunity}))
 
-;------------------------------------------------------------------------------ Layer 3
-;; Constructor
+;------------------------------------------------------------------------------ Layer 4
 
-(defn create-llm-pattern-detector
+;; Constructor
+(defn ^{:stratum 4} create-llm-pattern-detector
   "Create an LLM-powered pattern detector.
 
    Arguments:

--- a/components/operator/src/ai/miniforge/operator/messages.clj
+++ b/components/operator/src/ai/miniforge/operator/messages.clj
@@ -15,13 +15,14 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.operator.messages
   "Component-level message catalog for operator.
    Delegates to the shared messages component."
   (:require [ai.miniforge.messages.interface :as messages]))
 
-(def t
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} t
   "Look up an operator message by key, with optional param substitution."
   (messages/create-translator "config/operator/messages/en-US.edn"
                               :operator/messages))

--- a/components/operator/src/ai/miniforge/operator/protocol.clj
+++ b/components/operator/src/ai/miniforge/operator/protocol.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.operator.protocol
   "Operator protocols for meta-loop management.
 
@@ -26,9 +25,9 @@
    - Manages the self-improvement loop")
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Signal types
 
-(def signal-types
+;; Signal types
+(def ^{:stratum 0} signal-types
   #{:workflow-complete
     :workflow-failed
     :phase-rollback
@@ -38,7 +37,7 @@
     :budget-exceeded
     :quality-regression})
 
-(def improvement-types
+(def ^{:stratum 0} improvement-types
   #{:prompt-change
     :gate-adjustment
     :policy-update
@@ -46,10 +45,8 @@
     :budget-adjustment
     :workflow-modification})
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Operator protocol
-
-(defprotocol Operator
+(defprotocol ^{:stratum 0} Operator
   "Protocol for the meta-agent that manages self-improvement."
 
   (observe-signal [this signal]
@@ -87,10 +84,8 @@
      :proposed state (already :applied, :rejected, or missing) — callers must
      nil-check."))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Pattern detector protocol
-
-(defprotocol PatternDetector
+(defprotocol ^{:stratum 0} PatternDetector
   "Protocol for detecting patterns in workflow signals."
 
   (detect [this signals]
@@ -100,10 +95,8 @@
   (get-pattern-types [this]
     "Get the pattern types this detector can identify."))
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Improvement generator protocol
-
-(defprotocol ImprovementGenerator
+(defprotocol ^{:stratum 0} ImprovementGenerator
   "Protocol for generating improvement proposals from patterns."
 
   (generate-improvements [this patterns context]
@@ -113,10 +106,8 @@
   (get-supported-patterns [this]
     "Get pattern types this generator can handle."))
 
-;------------------------------------------------------------------------------ Layer 4
 ;; Governance protocol
-
-(defprotocol Governance
+(defprotocol ^{:stratum 0} Governance
   "Protocol for improvement governance.
    Controls what improvements can be applied automatically vs requiring approval."
 

--- a/components/operator/test/ai/miniforge/operator/anomaly/create_intervention_test.clj
+++ b/components/operator/test/ai/miniforge/operator/anomaly/create_intervention_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.operator.anomaly.create-intervention-test
   "Coverage for the anomaly-returning `create-intervention` and its
    boundary-throwing sibling `create-intervention!`. Every validation
@@ -35,9 +34,10 @@
             [ai.miniforge.operator.intervention :as intervention]
             [ai.miniforge.operator.messages :as messages]))
 
-;------------------------------------------------------------------------------ Helpers
+;------------------------------------------------------------------------------ Layer 0
 
-(defn- intervention-request
+;------------------------------------------------------------------------------ Helpers
+(defn- ^{:stratum 0} intervention-request
   [intervention-type target-id & {:as extra}]
   (merge {:intervention/type intervention-type
           :intervention/target-id target-id
@@ -45,9 +45,65 @@
           :intervention/request-source :tui}
          extra))
 
-;------------------------------------------------------------------------------ Happy path
+;------------------------------------------------------------------------------ Failure path: missing target-id
+(deftest ^{:stratum 0} create-intervention-invalid-input-on-missing-target-id
+  (testing "missing :intervention/target-id yields :invalid-input"
+    (let [result (op/create-intervention
+                  {:intervention/type :retry
+                   :intervention/requested-by "operator@example.com"
+                   :intervention/request-source :tui})]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (= (messages/t :intervention/target-id-required)
+             (:anomaly/message result)))
+      (is (= :retry
+             (get-in result [:anomaly/data :intervention/type]))))))
 
-(deftest create-intervention-returns-request-on-success
+;------------------------------------------------------------------------------ Failure path: missing requester
+(deftest ^{:stratum 0} create-intervention-invalid-input-on-missing-requested-by
+  (testing "missing :intervention/requested-by yields :invalid-input"
+    (let [result (op/create-intervention
+                  {:intervention/type :retry
+                   :intervention/target-id (random-uuid)
+                   :intervention/request-source :tui})]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (= (messages/t :intervention/requester-required)
+             (:anomaly/message result)))
+      (is (nil? (get-in result [:anomaly/data :intervention/requested-by])))
+      (is (= :tui
+             (get-in result [:anomaly/data :intervention/request-source]))))))
+
+(deftest ^{:stratum 0} create-intervention-invalid-input-on-missing-request-source
+  (testing "missing :intervention/request-source yields :invalid-input"
+    (let [result (op/create-intervention
+                  {:intervention/type :retry
+                   :intervention/target-id (random-uuid)
+                   :intervention/requested-by "operator@example.com"})]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (= (messages/t :intervention/requester-required)
+             (:anomaly/message result)))
+      (is (= "operator@example.com"
+             (get-in result [:anomaly/data :intervention/requested-by])))
+      (is (nil? (get-in result [:anomaly/data :intervention/request-source]))))))
+
+;------------------------------------------------------------------------------ Cascade short-circuits in order
+(deftest ^{:stratum 0} create-intervention-cascade-stops-at-first-rejection
+  (testing "an unknown type short-circuits before later checks would also fire —
+            request omits target-id and requester, but only the type anomaly
+            surfaces"
+    (let [result (op/create-intervention
+                  {:intervention/type :unknown-action})]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (= (messages/t :intervention/unknown-type)
+             (:anomaly/message result))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;------------------------------------------------------------------------------ Happy path
+(deftest ^{:stratum 1} create-intervention-returns-request-on-success
   (testing "valid request returns the constructed intervention, not an anomaly"
     (let [target-id (random-uuid)
           result (op/create-intervention
@@ -58,8 +114,7 @@
       (is (= :proposed (:intervention/state result))))))
 
 ;------------------------------------------------------------------------------ Failure path: unknown intervention type
-
-(deftest create-intervention-invalid-input-on-unknown-type
+(deftest ^{:stratum 1} create-intervention-invalid-input-on-unknown-type
   (testing "unknown intervention type yields :invalid-input anomaly"
     (let [result (op/create-intervention
                   (intervention-request :unknown-action (random-uuid)))]
@@ -71,8 +126,7 @@
              (get-in result [:anomaly/data :intervention/type]))))))
 
 ;------------------------------------------------------------------------------ Failure path: target type cannot be resolved
-
-(deftest create-intervention-invalid-input-when-target-type-unresolvable
+(deftest ^{:stratum 1} create-intervention-invalid-input-when-target-type-unresolvable
   (testing "intervention type with no default target type and no caller-supplied
             target type yields :invalid-input — exercised via a synthetic type
             patched into the bounded vocabulary"
@@ -91,8 +145,7 @@
                (get-in result [:anomaly/data :intervention/type])))))))
 
 ;------------------------------------------------------------------------------ Failure path: target type not recognized
-
-(deftest create-intervention-invalid-input-on-unknown-target-type
+(deftest ^{:stratum 1} create-intervention-invalid-input-on-unknown-target-type
   (testing "caller-supplied target type that is not in the recognized set yields
             :invalid-input"
     (let [result (op/create-intervention
@@ -106,8 +159,7 @@
              (get-in result [:anomaly/data :intervention/target-type]))))))
 
 ;------------------------------------------------------------------------------ Failure path: target type unsupported by verb
-
-(deftest create-intervention-invalid-input-on-unsupported-target-type
+(deftest ^{:stratum 1} create-intervention-invalid-input-on-unsupported-target-type
   (testing "a workflow verb cannot be redirected to another known target type"
     (let [result (op/create-intervention
                   (intervention-request :pause (random-uuid)
@@ -118,67 +170,8 @@
              (get-in result
                      [:anomaly/data :intervention/supported-target-type]))))))
 
-;------------------------------------------------------------------------------ Failure path: missing target-id
-
-(deftest create-intervention-invalid-input-on-missing-target-id
-  (testing "missing :intervention/target-id yields :invalid-input"
-    (let [result (op/create-intervention
-                  {:intervention/type :retry
-                   :intervention/requested-by "operator@example.com"
-                   :intervention/request-source :tui})]
-      (is (anomaly/anomaly? result))
-      (is (= :invalid-input (:anomaly/type result)))
-      (is (= (messages/t :intervention/target-id-required)
-             (:anomaly/message result)))
-      (is (= :retry
-             (get-in result [:anomaly/data :intervention/type]))))))
-
-;------------------------------------------------------------------------------ Failure path: missing requester
-
-(deftest create-intervention-invalid-input-on-missing-requested-by
-  (testing "missing :intervention/requested-by yields :invalid-input"
-    (let [result (op/create-intervention
-                  {:intervention/type :retry
-                   :intervention/target-id (random-uuid)
-                   :intervention/request-source :tui})]
-      (is (anomaly/anomaly? result))
-      (is (= :invalid-input (:anomaly/type result)))
-      (is (= (messages/t :intervention/requester-required)
-             (:anomaly/message result)))
-      (is (nil? (get-in result [:anomaly/data :intervention/requested-by])))
-      (is (= :tui
-             (get-in result [:anomaly/data :intervention/request-source]))))))
-
-(deftest create-intervention-invalid-input-on-missing-request-source
-  (testing "missing :intervention/request-source yields :invalid-input"
-    (let [result (op/create-intervention
-                  {:intervention/type :retry
-                   :intervention/target-id (random-uuid)
-                   :intervention/requested-by "operator@example.com"})]
-      (is (anomaly/anomaly? result))
-      (is (= :invalid-input (:anomaly/type result)))
-      (is (= (messages/t :intervention/requester-required)
-             (:anomaly/message result)))
-      (is (= "operator@example.com"
-             (get-in result [:anomaly/data :intervention/requested-by])))
-      (is (nil? (get-in result [:anomaly/data :intervention/request-source]))))))
-
-;------------------------------------------------------------------------------ Cascade short-circuits in order
-
-(deftest create-intervention-cascade-stops-at-first-rejection
-  (testing "an unknown type short-circuits before later checks would also fire —
-            request omits target-id and requester, but only the type anomaly
-            surfaces"
-    (let [result (op/create-intervention
-                  {:intervention/type :unknown-action})]
-      (is (anomaly/anomaly? result))
-      (is (= :invalid-input (:anomaly/type result)))
-      (is (= (messages/t :intervention/unknown-type)
-             (:anomaly/message result))))))
-
 ;------------------------------------------------------------------------------ Boundary variant
-
-(deftest create-intervention-bang-throws-on-anomaly
+(deftest ^{:stratum 1} create-intervention-bang-throws-on-anomaly
   (testing "boundary variant throws ex-info carrying the anomaly's message"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
                           (re-pattern (java.util.regex.Pattern/quote
@@ -186,7 +179,7 @@
                           (op/create-intervention!
                            (intervention-request :unknown-action (random-uuid)))))))
 
-(deftest create-intervention-bang-returns-on-success
+(deftest ^{:stratum 1} create-intervention-bang-returns-on-success
   (testing "boundary variant returns the constructed intervention on success"
     (let [target-id (random-uuid)
           result (op/create-intervention!

--- a/components/operator/test/ai/miniforge/operator/consumer_test.clj
+++ b/components/operator/test/ai/miniforge/operator/consumer_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.operator.consumer-test
   "Operator-event consumer (Phase D D-2) tests.
 
@@ -36,15 +35,61 @@
    [java.nio.file Files]
    [java.nio.file.attribute FileAttribute]))
 
-;------------------------------------------------------------------------------ Helpers
+;------------------------------------------------------------------------------ Layer 0
 
-(def ^:const max-workspace-walk-hops
+;------------------------------------------------------------------------------ Helpers
+(def ^{:stratum 0} ^:const max-workspace-walk-hops
   "Upper bound on parent-directory hops when locating workspace.edn —
    deep enough for any worktree nesting, small enough to fail fast when
    the tests run outside the workspace entirely."
   8)
 
-(defn- find-workspace-root
+(defn- ^{:stratum 0} temp-events-dir
+  ^java.io.File []
+  (.toFile (Files/createTempDirectory "operator-consumer-test"
+                                      (make-array FileAttribute 0))))
+
+(defn- ^{:stratum 0} stage-operator-file!
+  "Copy fixture content into `{events-dir}/operator/{file-name}`."
+  [events-dir file-name content]
+  (let [target (io/file events-dir "operator" file-name)]
+    (io/make-parents target)
+    (spit target content :encoding "UTF-8")
+    target))
+
+(defn- ^{:stratum 0} memory-stream
+  "An event stream with no sinks: published events accumulate in the
+   in-memory log only, so assertions read `es/get-events`."
+  []
+  (es/create-event-stream {:sinks []}))
+
+(defn- ^{:stratum 0} events-of-type
+  [stream event-type]
+  (filterv #(= event-type (:event/type %)) (es/get-events stream)))
+
+(defn- ^{:stratum 0} reject-every-request?
+  [_event]
+  false)
+
+;------------------------------------------------------------------------------ Golden contract gate
+(def ^{:stratum 0} ^:const golden-fixture-count
+  "Fixture scenarios the Rust generator commits (see manifest.edn).
+   Pinned so a silently shrunken vendored corpus fails loudly."
+  6)
+
+(deftest ^{:stratum 0} invalid-request-identities-are-rejected
+  (let [valid {:event/id (random-uuid)
+               :intervention/id (random-uuid)
+               :workflow/id (random-uuid)}]
+    (is (#'consumer/valid-request-identities? valid))
+    (doseq [k [:event/id :intervention/id :workflow/id]]
+      (is (false? (#'consumer/valid-request-identities?
+                   (assoc valid k "not-a-uuid")))
+          (name k)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} find-workspace-root
   []
   (loop [dir (io/file (System/getProperty "user.dir")) hops 0]
     (cond
@@ -54,106 +99,93 @@
                       {:user-dir (System/getProperty "user.dir")}))
       :else (recur (.getParentFile dir) (inc hops)))))
 
-(defn- golden-dir
+;------------------------------------------------------------------------------ Malformed input is loud, never silent
+(deftest ^{:stratum 1} unreadable-file-emits-anomaly-once
+  (let [events-dir (temp-events-dir)
+        stream (memory-stream)]
+    (stage-operator-file! events-dir "garbage.json" "{not json at all")
+    (is (= {:routed 0 :skipped 0 :anomalies 1}
+           (consumer/consume-pass! {:events-dir events-dir :stream stream})))
+    (let [anomalies (events-of-type stream consumer/anomaly-event-type)]
+      (is (= 1 (count anomalies)))
+      (is (= "garbage.json" (:source/file (first anomalies))))
+      (is (= (get-in (first anomalies) [:anomaly :anomaly/message])
+             (:message (first anomalies)))
+          "the envelope surfaces the specific anomaly message"))
+    (is (= {:routed 0 :skipped 0 :anomalies 0}
+           (consumer/consume-pass! {:events-dir events-dir :stream stream}))
+        "an anomalous file is remembered, not re-reported every pass")
+    (is (.exists (io/file events-dir "operator" "garbage.json"))
+        "append-only: the consumer never deletes operator events")))
+
+(deftest ^{:stratum 1} invalid-intervention-emits-anomaly
+  (testing "a valid request id is remembered after request validation fails"
+    (let [events-dir (temp-events-dir)
+          stream (memory-stream)
+          content (str "{\"~:event/type\":\"~:supervisory/intervention-requested\","
+                       "\"~:intervention/id\":\"~u00000000-0000-4000-8000-00000000dead\","
+                       "\"~:intervention/type\":\"~:frobnicate\","
+                       "\"~:intervention/target-id\":\"t-1\","
+                       "\"~:intervention/requested-by\":\"op@example.invalid\","
+                       "\"~:intervention/request-source\":\"~:tui\"}")]
+      (stage-operator-file!
+       events-dir "bad-type.json"
+       content)
+      (is (= {:routed 0 :skipped 0 :anomalies 1}
+             (consumer/consume-pass! {:events-dir events-dir :stream stream})))
+      (stage-operator-file! events-dir "bad-type-redelivery.json" content)
+      (is (= {:routed 0 :skipped 1 :anomalies 0}
+             (consumer/consume-pass! {:events-dir events-dir :stream stream})))
+      (is (= 1 (count (events-of-type stream consumer/anomaly-event-type)))
+          "a new filename for the same intervention id must not repeat the anomaly"))))
+
+(deftest ^{:stratum 1} foreign-operator-events-are-skipped-quietly
+  (testing "meta-loop/train events legitimately share the directory"
+    (let [events-dir (temp-events-dir)
+          stream (memory-stream)]
+      (stage-operator-file!
+       events-dir "pr-merged.json"
+       "{\"~:event/type\":\"~:pr/merged\",\"~:pr/number\":42}")
+      (is (= {:routed 0 :skipped 1 :anomalies 0}
+             (consumer/consume-pass! {:events-dir events-dir :stream stream})))
+      (is (empty? (es/get-events stream))
+          "foreign events are neither routed nor flagged")
+      (is (= {:routed 0 :skipped 0 :anomalies 0}
+             (consumer/consume-pass! {:events-dir events-dir :stream stream}))
+          "and each file is examined once"))))
+
+;------------------------------------------------------------------------------ Approval gate + application hook
+(deftest ^{:stratum 1} non-operator-source-parks-at-pending-human
+  (let [events-dir (temp-events-dir)
+        stream (memory-stream)]
+    (stage-operator-file!
+     events-dir "api-pause.json"
+     (str "{\"~:event/type\":\"~:supervisory/intervention-requested\","
+          "\"~:intervention/id\":\"~u00000000-0000-4000-8000-0000000000f1\","
+          "\"~:intervention/type\":\"~:pause\","
+          "\"~:intervention/target-id\":\"00000000-0000-4000-8000-0000000000aa\","
+          "\"~:intervention/requested-by\":\"delegate@example.invalid\","
+          "\"~:intervention/request-source\":\"~:api\"}"))
+    (consumer/consume-pass! {:events-dir events-dir :stream stream})
+    (let [changes (events-of-type stream consumer/state-changed-event-type)]
+      (is (= 1 (count changes)))
+      (is (= :pending-human (:intervention/state (first changes)))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- ^{:stratum 2} golden-dir
   ^java.io.File []
   (io/file (find-workspace-root) "contracts" "operator-events" "golden"))
 
-(defn- temp-events-dir
-  ^java.io.File []
-  (.toFile (Files/createTempDirectory "operator-consumer-test"
-                                      (make-array FileAttribute 0))))
+;------------------------------------------------------------------------------ Layer 3
 
-(defn- stage-operator-file!
-  "Copy fixture content into `{events-dir}/operator/{file-name}`."
-  [events-dir file-name content]
-  (let [target (io/file events-dir "operator" file-name)]
-    (io/make-parents target)
-    (spit target content :encoding "UTF-8")
-    target))
-
-(defn- stage-golden!
+(defn- ^{:stratum 3} stage-golden!
   [events-dir fixture-name]
   (stage-operator-file! events-dir fixture-name
                         (slurp (io/file (golden-dir) fixture-name)
                                :encoding "UTF-8")))
 
-(defn- memory-stream
-  "An event stream with no sinks: published events accumulate in the
-   in-memory log only, so assertions read `es/get-events`."
-  []
-  (es/create-event-stream {:sinks []}))
-
-(defn- events-of-type
-  [stream event-type]
-  (filterv #(= event-type (:event/type %)) (es/get-events stream)))
-
-(defn- reject-every-request?
-  [_event]
-  false)
-
-;------------------------------------------------------------------------------ Golden contract gate
-
-(def ^:const golden-fixture-count
-  "Fixture scenarios the Rust generator commits (see manifest.edn).
-   Pinned so a silently shrunken vendored corpus fails loudly."
-  6)
-
-(deftest golden-fixtures-route-through-the-lifecycle
-  (testing "every vendored Rust-produced fixture parses, validates, and routes"
-    (let [manifest (edn/read-string
-                    (slurp (io/file (golden-dir) "manifest.edn")
-                           :encoding "UTF-8"))
-          fixture-names (mapv #(str (name %) ".transit.json")
-                              (:fixture/scenarios manifest))]
-      (is (= golden-fixture-count (count fixture-names)))
-      ;; One events-dir per scenario: the deterministic generator stamps
-      ;; the SAME intervention id on every fixture, and the consumer's
-      ;; id-level idempotency (correct per Phase D) would dedup 2..N in
-      ;; a shared directory. Isolation tests the contract per scenario.
-      (doseq [f fixture-names]
-        (testing f
-          (let [events-dir (temp-events-dir)
-                stream (memory-stream)]
-            (stage-golden! events-dir f)
-            (is (= {:routed 1 :skipped 0 :anomalies 0}
-                   (consumer/consume-pass! {:events-dir events-dir
-                                            :stream stream})))
-            (is (= 1 (count (events-of-type
-                             stream
-                             consumer/intervention-requested-event-type))))
-            ;; Every fixture carries a request-source in
-            ;; consumer/auto-approve-request-sources (:tui or
-            ;; :native-app) → auto-approved.
-            (let [changes (events-of-type
-                           stream consumer/state-changed-event-type)]
-              (is (= 1 (count changes)))
-              (is (= :approved (:intervention/state (first changes)))))))))))
-
-(deftest republished-events-carry-typed-identity
-  (testing "tag-stripped strings are revived before republish (schema:
-            :event/id uuid?, timestamps inst?, :workflow/id uuid?)"
-    (let [events-dir (temp-events-dir)
-          stream (memory-stream)]
-      (stage-golden! events-dir "pause.transit.json")
-      (consumer/consume-pass! {:events-dir events-dir :stream stream})
-      (let [requested (first (events-of-type
-                              stream consumer/intervention-requested-event-type))
-            change (first (events-of-type
-                           stream consumer/state-changed-event-type))]
-        (is (uuid? (:event/id requested)))
-        (is (uuid? (:intervention/id requested)))
-        (is (uuid? (:workflow/id requested)))
-        (is (inst? (:event/timestamp requested)))
-        (is (inst? (:intervention/requested-at requested)))
-        (is (uuid? (:intervention/id change)))
-        (is (uuid? (:workflow/id change))
-            "workflow-targeted lifecycle events must key sequence
-             numbering by the same UUID the runner uses")
-        (is (< (:event/sequence-number requested)
-               (:event/sequence-number change))
-            "republishing the request advances the workflow sequence")))))
-
-(deftest governed-republish-uses-server-lifecycle-and-target
+(deftest ^{:stratum 3} governed-republish-uses-server-lifecycle-and-target
   (testing "client-claimed state, timestamps, and workflow routing are ignored"
     (let [events-dir (temp-events-dir)
           stream (memory-stream)
@@ -190,22 +222,7 @@
             "the governed event timestamp is the server audit clock,
              not the client-claimed wire time")))))
 
-(deftest workflow-request-routes-to-its-registered-stream
-  (let [events-dir (temp-events-dir)
-        operator-stream (memory-stream)
-        workflow-stream (memory-stream)]
-    (stage-golden! events-dir "pause.transit.json")
-    (is (= {:routed 1 :skipped 0 :anomalies 0}
-           (consumer/consume-pass!
-            {:events-dir events-dir
-             :stream operator-stream
-             :stream-for (constantly workflow-stream)})))
-    (is (empty? (es/get-events operator-stream)))
-    (is (= [consumer/intervention-requested-event-type
-            consumer/state-changed-event-type]
-           (mapv :event/type (es/get-events workflow-stream))))))
-
-(deftest routed-request-anomalies-stay-on-the-operator-stream
+(deftest ^{:stratum 3} routed-request-anomalies-stay-on-the-operator-stream
   (let [events-dir (temp-events-dir)
         operator-stream (memory-stream)
         workflow-stream (memory-stream)
@@ -223,31 +240,7 @@
            (mapv :event/type (es/get-events operator-stream))))
     (is (empty? (es/get-events workflow-stream)))))
 
-(deftest invalid-request-identities-are-rejected
-  (let [valid {:event/id (random-uuid)
-               :intervention/id (random-uuid)
-               :workflow/id (random-uuid)}]
-    (is (#'consumer/valid-request-identities? valid))
-    (doseq [k [:event/id :intervention/id :workflow/id]]
-      (is (false? (#'consumer/valid-request-identities?
-                   (assoc valid k "not-a-uuid")))
-          (name k)))))
-
-;------------------------------------------------------------------------------ Idempotency
-
-(deftest second-pass-is-a-no-op
-  (let [events-dir (temp-events-dir)
-        stream (memory-stream)]
-    (stage-golden! events-dir "pause.transit.json")
-    (is (= {:routed 1 :skipped 0 :anomalies 0}
-           (consumer/consume-pass! {:events-dir events-dir :stream stream})))
-    (let [event-count (count (es/get-events stream))]
-      (is (= {:routed 0 :skipped 0 :anomalies 0}
-             (consumer/consume-pass! {:events-dir events-dir :stream stream})))
-      (is (= event-count (count (es/get-events stream)))
-          "a processed file must publish nothing on re-scan"))))
-
-(deftest duplicate-intervention-id-under-new-filename-is-skipped
+(deftest ^{:stratum 3} duplicate-intervention-id-under-new-filename-is-skipped
   (testing "id-level idempotency survives re-delivery as a different file"
     (let [events-dir (temp-events-dir)
           stream (memory-stream)
@@ -259,7 +252,92 @@
       (is (= {:routed 0 :skipped 1 :anomalies 0}
              (consumer/consume-pass! {:events-dir events-dir :stream stream}))))))
 
-(deftest cursor-survives-restart
+;------------------------------------------------------------------------------ Layer 4
+
+(deftest ^{:stratum 4} golden-fixtures-route-through-the-lifecycle
+  (testing "every vendored Rust-produced fixture parses, validates, and routes"
+    (let [manifest (edn/read-string
+                    (slurp (io/file (golden-dir) "manifest.edn")
+                           :encoding "UTF-8"))
+          fixture-names (mapv #(str (name %) ".transit.json")
+                              (:fixture/scenarios manifest))]
+      (is (= golden-fixture-count (count fixture-names)))
+      ;; One events-dir per scenario: the deterministic generator stamps
+      ;; the SAME intervention id on every fixture, and the consumer's
+      ;; id-level idempotency (correct per Phase D) would dedup 2..N in
+      ;; a shared directory. Isolation tests the contract per scenario.
+      (doseq [f fixture-names]
+        (testing f
+          (let [events-dir (temp-events-dir)
+                stream (memory-stream)]
+            (stage-golden! events-dir f)
+            (is (= {:routed 1 :skipped 0 :anomalies 0}
+                   (consumer/consume-pass! {:events-dir events-dir
+                                            :stream stream})))
+            (is (= 1 (count (events-of-type
+                             stream
+                             consumer/intervention-requested-event-type))))
+            ;; Every fixture carries a request-source in
+            ;; consumer/auto-approve-request-sources (:tui or
+            ;; :native-app) → auto-approved.
+            (let [changes (events-of-type
+                           stream consumer/state-changed-event-type)]
+              (is (= 1 (count changes)))
+              (is (= :approved (:intervention/state (first changes)))))))))))
+
+(deftest ^{:stratum 4} republished-events-carry-typed-identity
+  (testing "tag-stripped strings are revived before republish (schema:
+            :event/id uuid?, timestamps inst?, :workflow/id uuid?)"
+    (let [events-dir (temp-events-dir)
+          stream (memory-stream)]
+      (stage-golden! events-dir "pause.transit.json")
+      (consumer/consume-pass! {:events-dir events-dir :stream stream})
+      (let [requested (first (events-of-type
+                              stream consumer/intervention-requested-event-type))
+            change (first (events-of-type
+                           stream consumer/state-changed-event-type))]
+        (is (uuid? (:event/id requested)))
+        (is (uuid? (:intervention/id requested)))
+        (is (uuid? (:workflow/id requested)))
+        (is (inst? (:event/timestamp requested)))
+        (is (inst? (:intervention/requested-at requested)))
+        (is (uuid? (:intervention/id change)))
+        (is (uuid? (:workflow/id change))
+            "workflow-targeted lifecycle events must key sequence
+             numbering by the same UUID the runner uses")
+        (is (< (:event/sequence-number requested)
+               (:event/sequence-number change))
+            "republishing the request advances the workflow sequence")))))
+
+(deftest ^{:stratum 4} workflow-request-routes-to-its-registered-stream
+  (let [events-dir (temp-events-dir)
+        operator-stream (memory-stream)
+        workflow-stream (memory-stream)]
+    (stage-golden! events-dir "pause.transit.json")
+    (is (= {:routed 1 :skipped 0 :anomalies 0}
+           (consumer/consume-pass!
+            {:events-dir events-dir
+             :stream operator-stream
+             :stream-for (constantly workflow-stream)})))
+    (is (empty? (es/get-events operator-stream)))
+    (is (= [consumer/intervention-requested-event-type
+            consumer/state-changed-event-type]
+           (mapv :event/type (es/get-events workflow-stream))))))
+
+;------------------------------------------------------------------------------ Idempotency
+(deftest ^{:stratum 4} second-pass-is-a-no-op
+  (let [events-dir (temp-events-dir)
+        stream (memory-stream)]
+    (stage-golden! events-dir "pause.transit.json")
+    (is (= {:routed 1 :skipped 0 :anomalies 0}
+           (consumer/consume-pass! {:events-dir events-dir :stream stream})))
+    (let [event-count (count (es/get-events stream))]
+      (is (= {:routed 0 :skipped 0 :anomalies 0}
+             (consumer/consume-pass! {:events-dir events-dir :stream stream})))
+      (is (= event-count (count (es/get-events stream)))
+          "a processed file must publish nothing on re-scan"))))
+
+(deftest ^{:stratum 4} cursor-survives-restart
   (testing "a fresh consumer (new process) trusts the on-disk cursor"
     (let [events-dir (temp-events-dir)
           stream-a (memory-stream)
@@ -270,7 +348,7 @@
              (consumer/consume-pass! {:events-dir events-dir :stream stream-b})))
       (is (empty? (es/get-events stream-b))))))
 
-(deftest unowned-request-is-deferred-without-advancing-cursors
+(deftest ^{:stratum 4} unowned-request-is-deferred-without-advancing-cursors
   (let [events-dir (temp-events-dir)
         stream (memory-stream)]
     (stage-golden! events-dir "pause.transit.json")
@@ -283,7 +361,7 @@
     (is (= {:routed 1 :skipped 0 :anomalies 0}
            (consumer/consume-pass! {:events-dir events-dir :stream stream})))))
 
-(deftest held-consumer-lock-defers-the-entire-pass
+(deftest ^{:stratum 4} held-consumer-lock-defers-the-entire-pass
   (let [events-dir (temp-events-dir)
         stream (memory-stream)
         lock-file (io/file events-dir "operator" ".consumer.lock")]
@@ -299,81 +377,7 @@
     (is (= {:routed 1 :skipped 0 :anomalies 0}
            (consumer/consume-pass! {:events-dir events-dir :stream stream})))))
 
-;------------------------------------------------------------------------------ Malformed input is loud, never silent
-
-(deftest unreadable-file-emits-anomaly-once
-  (let [events-dir (temp-events-dir)
-        stream (memory-stream)]
-    (stage-operator-file! events-dir "garbage.json" "{not json at all")
-    (is (= {:routed 0 :skipped 0 :anomalies 1}
-           (consumer/consume-pass! {:events-dir events-dir :stream stream})))
-    (let [anomalies (events-of-type stream consumer/anomaly-event-type)]
-      (is (= 1 (count anomalies)))
-      (is (= "garbage.json" (:source/file (first anomalies))))
-      (is (= (get-in (first anomalies) [:anomaly :anomaly/message])
-             (:message (first anomalies)))
-          "the envelope surfaces the specific anomaly message"))
-    (is (= {:routed 0 :skipped 0 :anomalies 0}
-           (consumer/consume-pass! {:events-dir events-dir :stream stream}))
-        "an anomalous file is remembered, not re-reported every pass")
-    (is (.exists (io/file events-dir "operator" "garbage.json"))
-        "append-only: the consumer never deletes operator events")))
-
-(deftest invalid-intervention-emits-anomaly
-  (testing "a valid request id is remembered after request validation fails"
-    (let [events-dir (temp-events-dir)
-          stream (memory-stream)
-          content (str "{\"~:event/type\":\"~:supervisory/intervention-requested\","
-                       "\"~:intervention/id\":\"~u00000000-0000-4000-8000-00000000dead\","
-                       "\"~:intervention/type\":\"~:frobnicate\","
-                       "\"~:intervention/target-id\":\"t-1\","
-                       "\"~:intervention/requested-by\":\"op@example.invalid\","
-                       "\"~:intervention/request-source\":\"~:tui\"}")]
-      (stage-operator-file!
-       events-dir "bad-type.json"
-       content)
-      (is (= {:routed 0 :skipped 0 :anomalies 1}
-             (consumer/consume-pass! {:events-dir events-dir :stream stream})))
-      (stage-operator-file! events-dir "bad-type-redelivery.json" content)
-      (is (= {:routed 0 :skipped 1 :anomalies 0}
-             (consumer/consume-pass! {:events-dir events-dir :stream stream})))
-      (is (= 1 (count (events-of-type stream consumer/anomaly-event-type)))
-          "a new filename for the same intervention id must not repeat the anomaly"))))
-
-(deftest foreign-operator-events-are-skipped-quietly
-  (testing "meta-loop/train events legitimately share the directory"
-    (let [events-dir (temp-events-dir)
-          stream (memory-stream)]
-      (stage-operator-file!
-       events-dir "pr-merged.json"
-       "{\"~:event/type\":\"~:pr/merged\",\"~:pr/number\":42}")
-      (is (= {:routed 0 :skipped 1 :anomalies 0}
-             (consumer/consume-pass! {:events-dir events-dir :stream stream})))
-      (is (empty? (es/get-events stream))
-          "foreign events are neither routed nor flagged")
-      (is (= {:routed 0 :skipped 0 :anomalies 0}
-             (consumer/consume-pass! {:events-dir events-dir :stream stream}))
-          "and each file is examined once"))))
-
-;------------------------------------------------------------------------------ Approval gate + application hook
-
-(deftest non-operator-source-parks-at-pending-human
-  (let [events-dir (temp-events-dir)
-        stream (memory-stream)]
-    (stage-operator-file!
-     events-dir "api-pause.json"
-     (str "{\"~:event/type\":\"~:supervisory/intervention-requested\","
-          "\"~:intervention/id\":\"~u00000000-0000-4000-8000-0000000000f1\","
-          "\"~:intervention/type\":\"~:pause\","
-          "\"~:intervention/target-id\":\"00000000-0000-4000-8000-0000000000aa\","
-          "\"~:intervention/requested-by\":\"delegate@example.invalid\","
-          "\"~:intervention/request-source\":\"~:api\"}"))
-    (consumer/consume-pass! {:events-dir events-dir :stream stream})
-    (let [changes (events-of-type stream consumer/state-changed-event-type)]
-      (is (= 1 (count changes)))
-      (is (= :pending-human (:intervention/state (first changes)))))))
-
-(deftest apply-hook-receives-only-approved-interventions
+(deftest ^{:stratum 4} apply-hook-receives-only-approved-interventions
   (let [events-dir (temp-events-dir)
         stream (memory-stream)
         applied (atom [])]
@@ -386,7 +390,7 @@
     (is (= :approved (:intervention/state (first @applied))))
     (is (= :pause (:intervention/type (first @applied))))))
 
-(deftest approval-transition-failure-emits-anomaly
+(deftest ^{:stratum 4} approval-transition-failure-emits-anomaly
   (let [events-dir (temp-events-dir)
         stream (memory-stream)]
     (stage-golden! events-dir "pause.transit.json")
@@ -401,7 +405,7 @@
       (is (= :invalid-transition
              (get-in event [:anomaly :anomaly/data :error]))))))
 
-(deftest workflow-targeted-state-changes-carry-workflow-id
+(deftest ^{:stratum 4} workflow-targeted-state-changes-carry-workflow-id
   (testing "audit trail lands in the run's own event directory"
     (let [events-dir (temp-events-dir)
           stream (memory-stream)]

--- a/components/operator/test/ai/miniforge/operator/core_test.clj
+++ b/components/operator/test/ai/miniforge/operator/core_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.operator.core-test
   "Tests for the pure helpers in operator.core. The full SimpleOperator record
    has runtime dependencies on workflow / knowledge / logging components and is
@@ -27,34 +26,20 @@
             [ai.miniforge.operator.protocol :as proto]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Test fixtures
 
-(defn- signal
+;; Test fixtures
+(defn- ^{:stratum 0} signal
   [type & {:as data}]
   (sut/create-signal type (or data {})))
 
-(defn- failure-signal-for
-  [phase]
-  (signal :workflow-failed :phase phase))
-
-(defn- rollback-signal-from-to
-  [from-phase to-phase]
-  (signal :phase-rollback :from-phase from-phase :to-phase to-phase))
-
-(defn- repair-signal-for
-  [error-type]
-  (signal :repair-pattern :error-type error-type))
-
-(defrecord FakeLLMClient [response]
+(defrecord ^{:stratum 0} FakeLLMClient [response]
   llm-client/LLMClient
   (complete* [_this _request] response)
   (complete-stream* [_this _request _on-chunk] response)
   (get-config [_this] {}))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; default-config
-
-(deftest default-config-shape-test
+(deftest ^{:stratum 0} default-config-shape-test
   (testing "default-config carries the documented retention/window/threshold keys"
     (let [c sut/default-config]
       (is (pos-int? (:signal-retention-ms c)))
@@ -64,10 +49,8 @@
       (is (<= 0.0 (:auto-apply-threshold c) 1.0))
       (is (pos-int? (:shadow-period-ms c))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; create-signal
-
-(deftest create-signal-required-fields-test
+(deftest ^{:stratum 0} create-signal-required-fields-test
   (testing "create-signal stamps id, type, data, and timestamp"
     (let [s (sut/create-signal :workflow-failed {:phase :implement})]
       (is (uuid? (:signal/id s)))
@@ -75,16 +58,14 @@
       (is (= {:phase :implement} (:signal/data s)))
       (is (number? (:signal/timestamp s))))))
 
-(deftest create-signal-uniqueness-test
+(deftest ^{:stratum 0} create-signal-uniqueness-test
   (testing "Each call gets a fresh id"
     (let [a (sut/create-signal :x {})
           b (sut/create-signal :x {})]
       (is (not= (:signal/id a) (:signal/id b))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; prune-old-signals
-
-(deftest prune-old-signals-keeps-recent-test
+(deftest ^{:stratum 0} prune-old-signals-keeps-recent-test
   (testing "Recent signals (within retention) are kept"
     (let [now (System/currentTimeMillis)
           recent {:signal/id (random-uuid) :signal/type :x
@@ -94,104 +75,18 @@
           kept   (sut/prune-old-signals [recent old] 5000)]
       (is (= [recent] kept)))))
 
-(deftest prune-old-signals-keeps-empty-input-test
+(deftest ^{:stratum 0} prune-old-signals-keeps-empty-input-test
   (testing "Empty input returns empty (and is a vector for filterv)"
     (is (= [] (sut/prune-old-signals [] 1000)))
     (is (vector? (sut/prune-old-signals [] 1000)))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; detect-repeated-failures
-
-(deftest detect-repeated-failures-yields-pattern-test
-  (testing "When a phase fails ≥ min-occurrences times, a :repeated-phase-failure pattern fires"
-    (let [signals (vec (repeatedly 3 #(failure-signal-for :implement)))
-          [pat] (sut/detect-repeated-failures signals 3)]
-      (is (= :repeated-phase-failure (:pattern/type pat)))
-      (is (= :implement (:pattern/phase pat)))
-      (is (= 3 (:pattern/occurrences pat)))
-      (is (number? (:pattern/confidence pat)))
-      (is (= 3 (count (:pattern/signals pat)))))))
-
-(deftest detect-repeated-failures-below-threshold-test
-  (testing "Fewer than min-occurrences failures yield no pattern"
-    (is (empty? (sut/detect-repeated-failures
-                 [(failure-signal-for :implement)
-                  (failure-signal-for :implement)]
-                 3)))))
-
-(deftest detect-repeated-failures-confidence-clamped-to-1-test
-  (testing "Confidence is clamped to 1.0 even when count exceeds the divisor"
-    (let [signals (vec (repeatedly 50 #(failure-signal-for :implement)))
-          [pat] (sut/detect-repeated-failures signals 3)]
-      (is (= 1.0 (:pattern/confidence pat))))))
-
-(deftest detect-repeated-failures-groups-by-phase-test
-  (testing "Failures across distinct phases yield separate patterns"
-    (let [signals (concat (repeatedly 3 #(failure-signal-for :implement))
-                          (repeatedly 3 #(failure-signal-for :verify)))
-          patterns (sut/detect-repeated-failures signals 3)
-          phases (set (map :pattern/phase patterns))]
-      (is (= #{:implement :verify} phases)))))
-
-;------------------------------------------------------------------------------ Layer 2
-;; detect-rollback-patterns
-
-(deftest detect-rollback-patterns-test
-  (testing "Frequent rollbacks from the same phase yield a :frequent-rollback pattern"
-    (let [signals (concat (repeatedly 3 #(rollback-signal-from-to :implement :plan))
-                          [(rollback-signal-from-to :implement :review)])
-          [pat] (sut/detect-rollback-patterns signals 3)]
-      (is (= :frequent-rollback (:pattern/type pat)))
-      (is (= :implement (:pattern/from-phase pat)))
-      (is (= 4 (:pattern/occurrences pat)))
-      (is (= #{:plan :review} (set (:pattern/to-phases pat)))))))
-
-(deftest detect-rollback-patterns-below-threshold-test
-  (testing "Fewer than min-occurrences rollbacks from one phase yield no pattern"
-    (is (empty? (sut/detect-rollback-patterns
-                 [(rollback-signal-from-to :implement :plan)]
-                 3)))))
-
-;------------------------------------------------------------------------------ Layer 2
-;; detect-repair-patterns
-
-(deftest detect-repair-patterns-test
-  (testing "Recurring repairs of the same error type yield a :recurring-repair pattern"
-    (let [signals (vec (repeatedly 3 #(repair-signal-for :missing-import)))
-          [pat] (sut/detect-repair-patterns signals 3)]
-      (is (= :recurring-repair (:pattern/type pat)))
-      (is (= :missing-import (:pattern/error-type pat)))
-      (is (= 3 (:pattern/occurrences pat))))))
-
-;------------------------------------------------------------------------------ Layer 2
-;; SimplePatternDetector — protocol composition
-
-(deftest pattern-detector-detect-combines-all-three-detectors-test
-  (testing "SimplePatternDetector runs all three detectors and concatenates results"
-    (let [detector (sut/create-pattern-detector
-                    {:min-pattern-occurrences 3})
-          signals (concat (repeatedly 3 #(failure-signal-for :implement))
-                          (repeatedly 3 #(rollback-signal-from-to :review :plan))
-                          (repeatedly 3 #(repair-signal-for :missing-paren)))
-          patterns (proto/detect detector signals)]
-      (is (= #{:repeated-phase-failure :frequent-rollback :recurring-repair}
-             (set (map :pattern/type patterns)))))))
-
-(deftest pattern-detector-get-pattern-types-test
+(deftest ^{:stratum 0} pattern-detector-get-pattern-types-test
   (testing "get-pattern-types reports the three documented detected types"
     (is (= #{:repeated-phase-failure :frequent-rollback :recurring-repair}
            (proto/get-pattern-types (sut/create-pattern-detector))))))
 
-(deftest create-llm-pattern-detector-direct-constructor-test
-  (testing "LLM pattern detector construction uses the direct component namespace"
-    (let [detector (sut/create-llm-pattern-detector*
-                    (->FakeLLMClient {:success true :content "[]" }))]
-      (is (satisfies? proto/PatternDetector detector)))))
-
-;------------------------------------------------------------------------------ Layer 3
 ;; Improvement generators
-
-(deftest generate-for-repeated-failure-shape-test
+(deftest ^{:stratum 0} generate-for-repeated-failure-shape-test
   (testing "generate-for-repeated-failure produces a :gate-adjustment proposal"
     (let [pattern {:pattern/type :repeated-phase-failure
                    :pattern/phase :implement
@@ -206,7 +101,7 @@
       (is (= pattern (:improvement/source-pattern imp)))
       (is (string? (:improvement/rationale imp))))))
 
-(deftest generate-for-frequent-rollback-shape-test
+(deftest ^{:stratum 0} generate-for-frequent-rollback-shape-test
   (testing "generate-for-frequent-rollback produces a :workflow-modification proposal"
     (let [pattern {:pattern/type :frequent-rollback
                    :pattern/from-phase :review
@@ -218,7 +113,7 @@
       (is (= :review (:improvement/target imp)))
       (is (= [:plan :implement] (-> imp :improvement/change :rollback-targets))))))
 
-(deftest generate-for-recurring-repair-shape-test
+(deftest ^{:stratum 0} generate-for-recurring-repair-shape-test
   (testing "generate-for-recurring-repair produces a :rule-addition proposal"
     (let [pattern {:pattern/type :recurring-repair
                    :pattern/error-type :missing-import
@@ -229,10 +124,8 @@
       (is (= :knowledge-base (:improvement/target imp)))
       (is (= :missing-import (-> imp :improvement/change :error-type))))))
 
-;------------------------------------------------------------------------------ Layer 3
 ;; SimpleImprovementGenerator — protocol composition
-
-(deftest improvement-generator-dispatches-by-pattern-type-test
+(deftest ^{:stratum 0} improvement-generator-dispatches-by-pattern-type-test
   (testing "Each pattern type generates the corresponding improvement type"
     (let [gen (sut/create-improvement-generator)
           patterns [{:pattern/type :repeated-phase-failure :pattern/phase :implement
@@ -248,42 +141,34 @@
       (is (= 3 (count imps)))
       (is (= #{:gate-adjustment :workflow-modification :rule-addition} types)))))
 
-(deftest improvement-generator-supported-patterns-test
+(deftest ^{:stratum 0} improvement-generator-supported-patterns-test
   (testing "get-supported-patterns reports the three handled pattern types"
     (is (= #{:repeated-phase-failure :frequent-rollback :recurring-repair}
            (proto/get-supported-patterns (sut/create-improvement-generator))))))
 
-(deftest create-llm-improvement-generator-direct-constructor-test
-  (testing "LLM improvement generator construction uses the direct component namespace"
-    (let [generator (sut/create-llm-improvement-generator*
-                     (->FakeLLMClient {:success true :content "[]" }))]
-      (is (satisfies? proto/ImprovementGenerator generator)))))
-
-;------------------------------------------------------------------------------ Layer 4
 ;; SimpleGovernance
-
-(deftest governance-requires-approval-for-policy-update-test
+(deftest ^{:stratum 0} governance-requires-approval-for-policy-update-test
   (testing "Policy update is always behind approval, regardless of confidence"
     (let [g (sut/create-governance)]
       (is (true? (proto/requires-approval? g
                                            {:improvement/type :policy-update
                                             :improvement/confidence 1.0}))))))
 
-(deftest governance-requires-approval-for-workflow-modification-test
+(deftest ^{:stratum 0} governance-requires-approval-for-workflow-modification-test
   (testing "Workflow modification is also always behind approval"
     (let [g (sut/create-governance)]
       (is (true? (proto/requires-approval? g
                                            {:improvement/type :workflow-modification
                                             :improvement/confidence 1.0}))))))
 
-(deftest governance-low-confidence-requires-approval-test
+(deftest ^{:stratum 0} governance-low-confidence-requires-approval-test
   (testing "Confidence below auto-apply-threshold triggers approval even for safe types"
     (let [g (sut/create-governance)]
       (is (true? (proto/requires-approval? g
                                            {:improvement/type :gate-adjustment
                                             :improvement/confidence 0.5}))))))
 
-(deftest governance-high-confidence-safe-type-can-auto-apply-test
+(deftest ^{:stratum 0} governance-high-confidence-safe-type-can-auto-apply-test
   (testing "Safe type at high confidence can auto-apply"
     (let [g (sut/create-governance)
           imp {:improvement/type :gate-adjustment
@@ -291,7 +176,7 @@
       (is (false? (proto/requires-approval? g imp)))
       (is (true? (proto/can-auto-apply? g imp))))))
 
-(deftest governance-approval-policy-by-type-test
+(deftest ^{:stratum 0} governance-approval-policy-by-type-test
   (testing "get-approval-policy returns documented policy for each known type"
     (let [g (sut/create-governance)]
       (is (false? (-> (proto/get-approval-policy g :prompt-change)         :auto-approve?)))
@@ -301,9 +186,107 @@
       (is (true?  (-> (proto/get-approval-policy g :budget-adjustment)     :auto-approve?)))
       (is (false? (-> (proto/get-approval-policy g :workflow-modification) :auto-approve?))))))
 
-(deftest governance-approval-policy-default-test
+(deftest ^{:stratum 0} governance-approval-policy-default-test
   (testing "Unknown improvement types fall back to approval-required default"
     (let [g (sut/create-governance)
           policy (proto/get-approval-policy g :totally-unknown-type)]
       (is (false? (:auto-approve? policy)))
       (is (number? (:required-confidence policy))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} failure-signal-for
+  [phase]
+  (signal :workflow-failed :phase phase))
+
+(defn- ^{:stratum 1} rollback-signal-from-to
+  [from-phase to-phase]
+  (signal :phase-rollback :from-phase from-phase :to-phase to-phase))
+
+(defn- ^{:stratum 1} repair-signal-for
+  [error-type]
+  (signal :repair-pattern :error-type error-type))
+
+(deftest ^{:stratum 1} create-llm-pattern-detector-direct-constructor-test
+  (testing "LLM pattern detector construction uses the direct component namespace"
+    (let [detector (sut/create-llm-pattern-detector*
+                    (->FakeLLMClient {:success true :content "[]" }))]
+      (is (satisfies? proto/PatternDetector detector)))))
+
+(deftest ^{:stratum 1} create-llm-improvement-generator-direct-constructor-test
+  (testing "LLM improvement generator construction uses the direct component namespace"
+    (let [generator (sut/create-llm-improvement-generator*
+                     (->FakeLLMClient {:success true :content "[]" }))]
+      (is (satisfies? proto/ImprovementGenerator generator)))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; detect-repeated-failures
+(deftest ^{:stratum 2} detect-repeated-failures-yields-pattern-test
+  (testing "When a phase fails ≥ min-occurrences times, a :repeated-phase-failure pattern fires"
+    (let [signals (vec (repeatedly 3 #(failure-signal-for :implement)))
+          [pat] (sut/detect-repeated-failures signals 3)]
+      (is (= :repeated-phase-failure (:pattern/type pat)))
+      (is (= :implement (:pattern/phase pat)))
+      (is (= 3 (:pattern/occurrences pat)))
+      (is (number? (:pattern/confidence pat)))
+      (is (= 3 (count (:pattern/signals pat)))))))
+
+(deftest ^{:stratum 2} detect-repeated-failures-below-threshold-test
+  (testing "Fewer than min-occurrences failures yield no pattern"
+    (is (empty? (sut/detect-repeated-failures
+                 [(failure-signal-for :implement)
+                  (failure-signal-for :implement)]
+                 3)))))
+
+(deftest ^{:stratum 2} detect-repeated-failures-confidence-clamped-to-1-test
+  (testing "Confidence is clamped to 1.0 even when count exceeds the divisor"
+    (let [signals (vec (repeatedly 50 #(failure-signal-for :implement)))
+          [pat] (sut/detect-repeated-failures signals 3)]
+      (is (= 1.0 (:pattern/confidence pat))))))
+
+(deftest ^{:stratum 2} detect-repeated-failures-groups-by-phase-test
+  (testing "Failures across distinct phases yield separate patterns"
+    (let [signals (concat (repeatedly 3 #(failure-signal-for :implement))
+                          (repeatedly 3 #(failure-signal-for :verify)))
+          patterns (sut/detect-repeated-failures signals 3)
+          phases (set (map :pattern/phase patterns))]
+      (is (= #{:implement :verify} phases)))))
+
+;; detect-rollback-patterns
+(deftest ^{:stratum 2} detect-rollback-patterns-test
+  (testing "Frequent rollbacks from the same phase yield a :frequent-rollback pattern"
+    (let [signals (concat (repeatedly 3 #(rollback-signal-from-to :implement :plan))
+                          [(rollback-signal-from-to :implement :review)])
+          [pat] (sut/detect-rollback-patterns signals 3)]
+      (is (= :frequent-rollback (:pattern/type pat)))
+      (is (= :implement (:pattern/from-phase pat)))
+      (is (= 4 (:pattern/occurrences pat)))
+      (is (= #{:plan :review} (set (:pattern/to-phases pat)))))))
+
+(deftest ^{:stratum 2} detect-rollback-patterns-below-threshold-test
+  (testing "Fewer than min-occurrences rollbacks from one phase yield no pattern"
+    (is (empty? (sut/detect-rollback-patterns
+                 [(rollback-signal-from-to :implement :plan)]
+                 3)))))
+
+;; detect-repair-patterns
+(deftest ^{:stratum 2} detect-repair-patterns-test
+  (testing "Recurring repairs of the same error type yield a :recurring-repair pattern"
+    (let [signals (vec (repeatedly 3 #(repair-signal-for :missing-import)))
+          [pat] (sut/detect-repair-patterns signals 3)]
+      (is (= :recurring-repair (:pattern/type pat)))
+      (is (= :missing-import (:pattern/error-type pat)))
+      (is (= 3 (:pattern/occurrences pat))))))
+
+;; SimplePatternDetector — protocol composition
+(deftest ^{:stratum 2} pattern-detector-detect-combines-all-three-detectors-test
+  (testing "SimplePatternDetector runs all three detectors and concatenates results"
+    (let [detector (sut/create-pattern-detector
+                    {:min-pattern-occurrences 3})
+          signals (concat (repeatedly 3 #(failure-signal-for :implement))
+                          (repeatedly 3 #(rollback-signal-from-to :review :plan))
+                          (repeatedly 3 #(repair-signal-for :missing-paren)))
+          patterns (proto/detect detector signals)]
+      (is (= #{:repeated-phase-failure :frequent-rollback :recurring-repair}
+             (set (map :pattern/type patterns)))))))

--- a/components/operator/test/ai/miniforge/operator/defaults_test.clj
+++ b/components/operator/test/ai/miniforge/operator/defaults_test.clj
@@ -15,16 +15,15 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.operator.defaults-test
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.string :as str]
             [ai.miniforge.operator.defaults :as sut]))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Pattern detector defaults
+;------------------------------------------------------------------------------ Layer 0
 
-(deftest pattern-detector-system-prompt-shape-test
+;; Pattern detector defaults
+(deftest ^{:stratum 0} pattern-detector-system-prompt-shape-test
   (testing "Pattern detector system prompt mentions all five documented pattern types"
     (let [p sut/pattern-detector-system-prompt]
       (is (string? p))
@@ -36,16 +35,14 @@
       ;; The prompt instructs the model to return JSON only.
       (is (str/includes? p "JSON")))))
 
-(deftest pattern-detector-defaults-shape-test
+(deftest ^{:stratum 0} pattern-detector-defaults-shape-test
   (testing "Pattern detector defaults bundles the prompt and a max-tokens budget"
     (let [d sut/pattern-detector-defaults]
       (is (= sut/pattern-detector-system-prompt (:system-prompt d)))
       (is (pos-int? (:max-tokens d))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Improvement generator defaults
-
-(deftest improvement-generator-system-prompt-shape-test
+(deftest ^{:stratum 0} improvement-generator-system-prompt-shape-test
   (testing "Improvement generator prompt mentions every documented improvement type"
     (let [p sut/improvement-generator-system-prompt
           types ["prompt-change" "gate-adjustment" "policy-update"
@@ -56,13 +53,13 @@
             (str "Prompt should mention improvement type: " t)))
       (is (str/includes? p "JSON")))))
 
-(deftest improvement-types-set-test
+(deftest ^{:stratum 0} improvement-types-set-test
   (testing "improvement-types is a set containing the documented six types"
     (is (= #{:prompt-change :gate-adjustment :policy-update
              :rule-addition :budget-adjustment :workflow-modification}
            sut/improvement-types))))
 
-(deftest improvement-generator-defaults-shape-test
+(deftest ^{:stratum 0} improvement-generator-defaults-shape-test
   (testing "Improvement generator defaults bundles prompt, type set, and token budget"
     (let [d sut/improvement-generator-defaults]
       (is (= sut/improvement-generator-system-prompt (:system-prompt d)))

--- a/components/operator/test/ai/miniforge/operator/interface_test.clj
+++ b/components/operator/test/ai/miniforge/operator/interface_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.operator.interface-test
   "Tests for the operator (meta-agent) component."
   (:require
@@ -24,29 +23,30 @@
    [ai.miniforge.operator.interface :as op]
    [ai.miniforge.operator.protocol :as proto]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; ============================================================================
 ;; Operator creation tests
 ;; ============================================================================
-
-(deftest create-operator-test
+(deftest ^{:stratum 0} create-operator-test
   (testing "create-operator returns an operator"
     (let [operator (op/create-operator)]
       (is (some? operator))
       (is (satisfies? proto/Operator operator)))))
 
-(deftest create-pattern-detector-test
+(deftest ^{:stratum 0} create-pattern-detector-test
   (testing "create-pattern-detector returns a detector"
     (let [detector (op/create-pattern-detector)]
       (is (some? detector))
       (is (satisfies? proto/PatternDetector detector)))))
 
-(deftest create-improvement-generator-test
+(deftest ^{:stratum 0} create-improvement-generator-test
   (testing "create-improvement-generator returns a generator"
     (let [generator (op/create-improvement-generator)]
       (is (some? generator))
       (is (satisfies? proto/ImprovementGenerator generator)))))
 
-(deftest create-governance-test
+(deftest ^{:stratum 0} create-governance-test
   (testing "create-governance returns a governance manager"
     (let [governance (op/create-governance)]
       (is (some? governance))
@@ -55,8 +55,7 @@
 ;; ============================================================================
 ;; Signal observation tests
 ;; ============================================================================
-
-(deftest observe-signal-test
+(deftest ^{:stratum 0} observe-signal-test
   (testing "observe-signal records a signal"
     (let [operator (op/create-operator)
           signal {:type :workflow-failed
@@ -66,7 +65,7 @@
       (is (some? (:signal/timestamp recorded)))
       (is (= :workflow-failed (:signal/type recorded))))))
 
-(deftest get-signals-test
+(deftest ^{:stratum 0} get-signals-test
   (testing "get-signals returns recorded signals"
     (let [operator (op/create-operator)]
       ;; Record some signals
@@ -89,8 +88,7 @@
 ;; ============================================================================
 ;; Pattern detection tests
 ;; ============================================================================
-
-(deftest detect-patterns-test
+(deftest ^{:stratum 0} detect-patterns-test
   (testing "detect-patterns finds patterns"
     (let [detector (op/create-pattern-detector)
           ;; Create signals that form a pattern (3+ repeated failures)
@@ -103,7 +101,7 @@
       (is (seq patterns))
       (is (some #(= :repeated-phase-failure (:pattern/type %)) patterns)))))
 
-(deftest analyze-patterns-test
+(deftest ^{:stratum 0} analyze-patterns-test
   (testing "analyze-patterns returns patterns and recommendations"
     (let [operator (op/create-operator)]
       ;; Create failure signals to trigger pattern detection
@@ -119,8 +117,7 @@
 ;; ============================================================================
 ;; Improvement management tests
 ;; ============================================================================
-
-(deftest propose-improvement-test
+(deftest ^{:stratum 0} propose-improvement-test
   (testing "propose-improvement creates a proposal"
     (let [operator (op/create-operator)
           improvement {:type :rule-addition
@@ -131,7 +128,7 @@
       (is (uuid? (:proposal-id result)))
       (is (= :proposed (:status result))))))
 
-(deftest get-proposals-test
+(deftest ^{:stratum 0} get-proposals-test
   (testing "get-proposals returns proposals"
     (let [operator (op/create-operator)]
       (op/propose-improvement operator {:type :rule-addition :target :test :rationale "Test"})
@@ -145,7 +142,7 @@
         (let [proposals (op/get-proposals operator {:type :rule-addition})]
           (is (= 1 (count proposals))))))))
 
-(deftest apply-improvement-test
+(deftest ^{:stratum 0} apply-improvement-test
   (testing "apply-improvement updates proposal status"
     (let [operator (op/create-operator)
           {:keys [proposal-id]} (op/propose-improvement operator
@@ -156,7 +153,7 @@
       (is (:success? result))
       (is (= :applied (get-in result [:applied :improvement/status]))))))
 
-(deftest apply-improvement-idempotency-test
+(deftest ^{:stratum 0} apply-improvement-idempotency-test
   (testing "apply-improvement returns nil when proposal is not in :proposed state"
     (let [operator (op/create-operator)
           {:keys [proposal-id]} (op/propose-improvement operator
@@ -171,7 +168,7 @@
         (let [proposals (op/get-proposals operator {:status :applied})]
           (is (= 1 (count proposals))))))))
 
-(deftest apply-improvement-guards-rejected-test
+(deftest ^{:stratum 0} apply-improvement-guards-rejected-test
   (testing "apply-improvement cannot override a human rejection"
     (let [operator (op/create-operator)
           {:keys [proposal-id]} (op/propose-improvement operator
@@ -183,7 +180,7 @@
       (let [proposals (op/get-proposals operator {:status :rejected})]
         (is (= 1 (count proposals)))))))
 
-(deftest reject-improvement-test
+(deftest ^{:stratum 0} reject-improvement-test
   (testing "reject-improvement updates proposal with reason"
     (let [operator (op/create-operator)
           {:keys [proposal-id]} (op/propose-improvement operator
@@ -194,7 +191,7 @@
       (is (= :rejected (:improvement/status rejected)))
       (is (= "Not applicable" (:improvement/rejection-reason rejected))))))
 
-(deftest reject-improvement-idempotency-test
+(deftest ^{:stratum 0} reject-improvement-idempotency-test
   (testing "reject-improvement returns nil when proposal is already :rejected"
     (let [operator (op/create-operator)
           {:keys [proposal-id]} (op/propose-improvement operator
@@ -209,8 +206,7 @@
 ;; ============================================================================
 ;; Governance tests
 ;; ============================================================================
-
-(deftest governance-requires-approval-test
+(deftest ^{:stratum 0} governance-requires-approval-test
   (testing "governance correctly identifies approval requirements"
     (let [governance (op/create-governance)]
 
@@ -229,7 +225,7 @@
                            :improvement/confidence 0.5}]
           (is (true? (op/requires-approval? governance improvement))))))))
 
-(deftest get-approval-policy-test
+(deftest ^{:stratum 0} get-approval-policy-test
   (testing "approval policies are defined for improvement types"
     (let [governance (op/create-governance)]
 
@@ -243,15 +239,14 @@
 ;; ============================================================================
 ;; Type definitions tests
 ;; ============================================================================
-
-(deftest signal-types-test
+(deftest ^{:stratum 0} signal-types-test
   (testing "signal types are defined"
     (is (set? op/signal-types))
     (is (contains? op/signal-types :workflow-complete))
     (is (contains? op/signal-types :workflow-failed))
     (is (contains? op/signal-types :phase-rollback))))
 
-(deftest improvement-types-test
+(deftest ^{:stratum 0} improvement-types-test
   (testing "improvement types are defined"
     (is (set? op/improvement-types))
     (is (contains? op/improvement-types :prompt-change))
@@ -261,8 +256,7 @@
 ;; ============================================================================
 ;; Knowledge store integration tests
 ;; ============================================================================
-
-(deftest apply-improvement-writes-rule-exactly-once-test
+(deftest ^{:stratum 0} apply-improvement-writes-rule-exactly-once-test
   (testing "apply-improvement writes exactly one rule to the knowledge store"
     (let [k-store  (knowledge/create-store)
           operator (op/create-operator {:knowledge-store k-store})

--- a/components/operator/test/ai/miniforge/operator/intervention_test.clj
+++ b/components/operator/test/ai/miniforge/operator/intervention_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.operator.intervention-test
   "Tests for bounded intervention lifecycle helpers."
   (:require
@@ -24,9 +23,9 @@
    [ai.miniforge.operator.interface :as op]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Helpers
 
-(defn- intervention-request
+;; Helpers
+(defn- ^{:stratum 0} intervention-request
   [intervention-type target-id & {:as extra}]
   (merge {:intervention/type intervention-type
           :intervention/target-id target-id
@@ -35,9 +34,9 @@
          extra))
 
 ;------------------------------------------------------------------------------ Layer 1
-;; Unit tests
 
-(deftest create-intervention-defaults-target-type-and-state
+;; Unit tests
+(deftest ^{:stratum 1} create-intervention-defaults-target-type-and-state
   (testing "given a retry intervention → workflow target type and proposed state are inferred"
     (let [request (op/create-intervention
                    (intervention-request :retry (random-uuid)))]
@@ -47,14 +46,14 @@
       (is (inst? (:intervention/requested-at request)))
       (is (inst? (:intervention/updated-at request))))))
 
-(deftest risky-interventions-default-to-approval-required
+(deftest ^{:stratum 1} risky-interventions-default-to-approval-required
   (testing "given a cancel intervention → approval is required by default"
     (let [request (op/create-intervention
                    (intervention-request :cancel (random-uuid)))]
       (is (true? (op/approval-required? :cancel)))
       (is (true? (:intervention/approval-required? request))))))
 
-(deftest intervention-lifecycle-reaches-verified
+(deftest ^{:stratum 1} intervention-lifecycle-reaches-verified
   (testing "given an intervention through approve, dispatch, apply, verify → it ends in verified"
     (let [created (op/create-intervention
                    (intervention-request :pause (random-uuid)))
@@ -68,7 +67,7 @@
       (is (= :verified (:intervention/state verified)))
       (is (= {:visible-state :paused-by-supervisor} (:intervention/outcome verified))))))
 
-(deftest intervention-can-enter-pending-human
+(deftest ^{:stratum 1} intervention-can-enter-pending-human
   (testing "given a risky intervention → the lifecycle supports an explicit pending-human step"
     (let [created (op/create-intervention
                    (intervention-request :request-human-review (random-uuid)))
@@ -77,7 +76,7 @@
       (is (= :pending-human (:intervention/state pending)))
       (is (= :approved (:intervention/state approved))))))
 
-(deftest invalid-intervention-operations-return-errors
+(deftest ^{:stratum 1} invalid-intervention-operations-return-errors
   (testing "given a terminal intervention → further transitions are rejected"
     (let [created (op/create-intervention
                    (intervention-request :waive (random-uuid)))

--- a/components/operator/test/ai/miniforge/operator/llm_improvement_generator_test.clj
+++ b/components/operator/test/ai/miniforge/operator/llm_improvement_generator_test.clj
@@ -15,14 +15,15 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.operator.llm-improvement-generator-test
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.llm.interface.protocols.llm-client :as llm-client]
             [ai.miniforge.operator.llm-improvement-generator :as sut]
             [ai.miniforge.operator.protocol :as proto]))
 
-(defrecord FakeLLMClient [response requests]
+;------------------------------------------------------------------------------ Layer 0
+
+(defrecord ^{:stratum 0} FakeLLMClient [response requests]
   llm-client/LLMClient
   (complete* [_this request]
     (swap! requests conj request)
@@ -32,7 +33,9 @@
     response)
   (get-config [_this] {}))
 
-(deftest generate-improvements-uses-public-llm-interface-test
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} generate-improvements-uses-public-llm-interface-test
   (testing "LLM improvement generator calls the client and parses JSON improvements"
     (let [requests (atom [])
           client (->FakeLLMClient {:success true

--- a/components/operator/test/ai/miniforge/operator/llm_pattern_detector_test.clj
+++ b/components/operator/test/ai/miniforge/operator/llm_pattern_detector_test.clj
@@ -15,14 +15,15 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.operator.llm-pattern-detector-test
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.llm.interface.protocols.llm-client :as llm-client]
             [ai.miniforge.operator.llm-pattern-detector :as sut]
             [ai.miniforge.operator.protocol :as proto]))
 
-(defrecord FakeLLMClient [response requests]
+;------------------------------------------------------------------------------ Layer 0
+
+(defrecord ^{:stratum 0} FakeLLMClient [response requests]
   llm-client/LLMClient
   (complete* [_this request]
     (swap! requests conj request)
@@ -32,7 +33,9 @@
     response)
   (get-config [_this] {}))
 
-(deftest detect-uses-public-llm-interface-test
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} detect-uses-public-llm-interface-test
   (testing "LLM pattern detector calls the client and parses JSON patterns"
     (let [requests (atom [])
           client (->FakeLLMClient {:success true

--- a/components/operator/test/ai/miniforge/operator/protocol_test.clj
+++ b/components/operator/test/ai/miniforge/operator/protocol_test.clj
@@ -15,28 +15,26 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.operator.protocol-test
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.operator.protocol :as sut]))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Closed-set enums declared by the protocol namespace
+;------------------------------------------------------------------------------ Layer 0
 
-(deftest signal-types-stable-test
+;; Closed-set enums declared by the protocol namespace
+(deftest ^{:stratum 0} signal-types-stable-test
   (testing "signal-types declares the documented closed set of observation signals"
     (is (= #{:workflow-complete :workflow-failed :phase-rollback
              :repeated-failure :repair-pattern :human-override
              :budget-exceeded :quality-regression}
            sut/signal-types))))
 
-(deftest improvement-types-stable-test
+(deftest ^{:stratum 0} improvement-types-stable-test
   (testing "improvement-types declares the documented six improvement actions"
     (is (= #{:prompt-change :gate-adjustment :policy-update
              :rule-addition :budget-adjustment :workflow-modification}
            sut/improvement-types))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Protocol vars are present.
 ;;
 ;; defprotocol creates a Clojure *var* (the value here) bound to a map that
@@ -44,8 +42,7 @@
 ;; class side-effect, but the var is the canonical entry point for callers
 ;; using satisfies? / extend-protocol. We assert the var is defined and that
 ;; its protocol map declares the documented methods.
-
-(deftest protocols-defined-test
+(deftest ^{:stratum 0} protocols-defined-test
   (testing "All four documented protocols are defined as protocol vars
             and declare the documented methods on each."
     (is (map? sut/Operator))

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-operator.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-operator.md
@@ -1,0 +1,202 @@
+<!--
+  Title: Fix stratum-lint autofix for components/operator (Wave 1)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix: stratum-lint autofix for components/operator (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over `components/operator` (`src` + `test`) to
+replace decorative `Layer N` banners with real `Layer N` headings and
+`^{:stratum n}` metadata derived from each file's actual same-file
+reference graph. Mechanical: no logic changes, no execution-order changes.
+Wave 1 batch 6 of the program tracked in
+`work/stratum-lint-baseline-2026-07-24.md`.
+
+## Motivation
+
+Plain (non-`--fix`) `stratum-lint` on `components/operator` reported zero
+`SL001` (upward-reference/cycle risk) — confirmed before touching
+anything, since this component was not among the six already spot-checked
+in the baseline triage. Findings were all `SL003` (over the 3-layer
+budget) and `SL002` (non-monotonic heading reuse):
+
+```text
+application.clj:401:1: SL003 file uses 7 distinct layers (max 3)
+core.clj:242:1: SL003 file uses 6 distinct layers (max 3)
+llm_improvement_generator.clj:162:1: SL003 file uses 4 distinct layers (max 3)
+llm_pattern_detector.clj:156:1: SL003 file uses 4 distinct layers (max 3)
+mechanism.clj:303:1: SL003 file uses 4 distinct layers (max 3)
+protocol.clj:116:1: SL003 file uses 5 distinct layers (max 3)
+core_test.clj: SL002 Layer 1/2/3 headings repeated non-monotonically (x6)
+core_test.clj:262:1: SL003 file uses 5 distinct layers (max 3)
+defaults_test.clj:45:1: SL002 Layer 1 heading repeated
+protocol_test.clj:39:1: SL002 Layer 1 heading repeated
+```
+
+## Changes in Detail
+
+Ran, over the whole component:
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "bef8657a2efd3b1ba9e1a4f510693c9fbca45abd" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/operator
+```
+
+18 of the component's 20 `.clj` files were rewritten (9 `src`, 9 `test`).
+`application.clj` and `mechanism.clj` were left untouched: their existing
+`Layer 0..N` headings were already strictly monotonic and matched the
+real reference graph exactly — genuinely over budget (7 and 4 real
+layers respectively), not decorative, so `--fix` had nothing to correct.
+Diffs elsewhere are heading text, `^{:stratum n}` metadata, and
+def/deftest reordering only — no executable line changed. Notable
+findings from the recomputed real dependency graph:
+
+- `protocol.clj` declares two type sets and four independent protocols
+  (`Operator`, `PatternDetector`, `ImprovementGenerator`, `Governance`)
+  with no same-file reference between any of them. The old headings
+  numbered them 0-4 sequentially by writing order; real stratum for
+  every def is 0. Pre-fix `SL003` (5 layers) was a sequential-numbering
+  artifact, fully resolved.
+- `interface.clj` is a pure re-export/delegation layer: every `def`/`defn`
+  calls straight into `core/*`, `intervention/*`, `consumer/*`, or
+  `application/*` (required namespaces, not same-file defs). Real stratum
+  for every def is 0.
+- `core.clj` has genuine same-file structure, now 4 real layers (was
+  reported as 6 pre-fix, 4 post-fix, still `SL003`). `default-config`,
+  the signal helpers, the three pattern detectors, the three improvement
+  generators, `SimpleGovernance`, and the two `create-llm-*` fallback
+  constructors sit at real Layer 0 (no same-file def calls). The
+  `SimplePatternDetector`/`SimpleImprovementGenerator`/`SimpleOperator`
+  defrecords (calling Layer 0 helpers) land at Layer 1;
+  `create-pattern-detector`/`create-improvement-generator` at Layer 2;
+  `create-operator` (constructs a `SimpleOperator` via `->SimpleOperator`)
+  at Layer 3. `--fix` moved the `extend-type SimpleOperator` block (a
+  non-`def` top-level form) to the file's appendix, after all real
+  layers — verified this does not break compile order: `SimpleOperator`
+  is defined at Layer 1, well before the appendix runs.
+- `consumer.clj` is the deepest real chain in `src`: 6 layers, driven by
+  the cursor-file helpers (call the Layer-0 filename constants),
+  `read-cursor`/`write-cursor!` (call the cursor-file helpers),
+  `route-intervention!`, `consume-operator-dir!`, `consume-pass!`, and
+  `start!` each one layer above what they call. `stop!` has no same-file
+  dependency and landed at real Layer 0 alongside the polling constants,
+  even though it is defined and used far from them in the file.
+- `intervention.clj` is the single deepest chain in the component: 9 real
+  layers, driven by a `(delay (load-intervention-config))` indirection —
+  `intervention-config-resource` (L0) → `load-intervention-config` (L1)
+  → `intervention-config` (L2) → the five config-derived defs (L3) →
+  `intervention-types`/`target-types`/`lifecycle-states` plus
+  `approval-required?`/`terminal-state?`/`intervention-target-type`/
+  `build-intervention` (L4) → `valid-transition?`/`next-state` (also L4)
+  → `valid-type?`/`valid-target-type?`/`valid-state?`/
+  `validate-target-type-supported`/`supported-target-types`/
+  `bounded-vocabulary?` (L5) → `validate-intervention-type`/
+  `validate-target-type-known`/`transition` (L6) → `create-intervention`
+  and every lifecycle-transition wrapper (`start-approval`, `approve`,
+  `reject`, `dispatch`, `apply-result`, `verify`, `fail`) (L7) →
+  `create-intervention!` (L8). Genuine complexity, not a labeling
+  artifact — every def's real dependency count checked by hand against
+  its rewritten position.
+- `llm_improvement_generator.clj` / `llm_pattern_detector.clj`: the
+  `parse-*-type` helpers have no same-file dependency and moved to real
+  Layer 0 alongside `summarize-pattern`/`summarize-signal` (previously
+  both were under a "Layer 1" banner below `build-*-prompt`, which
+  itself calls `summarize-*` and so genuinely sits one layer above).
+- `core_test.clj`: the fixture helpers (`signal`, `FakeLLMClient`) and
+  every `deftest` calling neither them nor a pattern/rollback/repair
+  signal helper landed at real Layer 0; `failure-signal-for`/
+  `rollback-signal-from-to`/`repair-signal-for` (call `signal`) plus the
+  two direct-LLM-constructor tests landed at Layer 1; the detector tests
+  that call the phase-2 signal helpers landed at Layer 2. The old
+  headings repeated "Layer 1"/"Layer 2"/"Layer 3" non-monotonically
+  instead of separating these three real strata.
+- `consumer_test.clj`: `find-workspace-root` (calls a Layer-0 constant)
+  is Layer 1; `golden-dir` (calls `find-workspace-root`) is Layer 2;
+  `stage-golden!` (calls `golden-dir`) is Layer 3; every `deftest` using
+  `stage-golden!` or a golden fixture lands at Layer 4.
+- `messages.clj`: gained its first real heading (`Layer 0` on the sole
+  `def t`) — previously had no `Layer N` heading at all, the documented
+  "no heading = silently skipped" limitation, not a clean bill of
+  health.
+
+No same-line trailing comment was displaced onto the wrong def, and no
+stale decorative banner was left contradicting a real heading — checked
+by reading the full diff and the full resulting content of all 18
+changed files, not just the diff hunks. A `grep` for any leftover
+`;; ... Layer N` or `Layer N:`-style banner across the component's `src`
+and `test` trees came back empty.
+
+## Testing Plan
+
+1. Ran plain `stratum-lint` before the fix — reproduced the findings
+   above exactly (14 findings this run vs. 13 in the 2026-07-24
+   baseline; main had moved on in the interim, no material difference).
+   Confirmed zero `SL001` before proceeding, per this component's stated
+   risk (not pre-vetted as `SL001`-free).
+2. Ran `--fix`, then a second `--fix` pass immediately after — no
+   `rewrote` output, zero diff, confirms idempotency.
+3. Read the full diff and the full resulting content for all 18 changed
+   files. Confirmed only heading text, `^{:stratum n}` metadata, and
+   def/deftest reordering changed; independently re-derived the expected
+   real stratum for every def from its same-file reference graph and
+   matched it against what `--fix` produced, including the 9-layer
+   `intervention.clj` chain.
+4. `clj-kondo --lint components/operator`: 0 errors, 0 warnings.
+5. Ran the component's test namespaces directly (`clojure -M:dev:test`,
+   requiring and running `core-test`, `defaults-test`, `protocol-test`,
+   `intervention-test`, `interface-test`, `consumer-test`,
+   `llm-improvement-generator-test`, `llm-pattern-detector-test`,
+   `anomaly.create-intervention-test`, `application-test`,
+   `mechanism-test` — the last two were untouched by `--fix` but included
+   for full component coverage): 132 tests, 459 assertions, 0 failures,
+   0 errors.
+6. Re-ran plain `stratum-lint` after the fix:
+   - `protocol.clj`, `interface.clj`, `defaults.clj`, `messages.clj`,
+     `core_test.clj`, `defaults_test.clj`, `protocol_test.clj`,
+     `interface_test.clj`, `intervention_test.clj`,
+     `llm_improvement_generator_test.clj`, `llm_pattern_detector_test.clj`,
+     `anomaly/create_intervention_test.clj`: **resolved**, all now
+     within the 3-layer budget.
+   - `application.clj` (7), `consumer.clj` (6), `core.clj` (4),
+     `intervention.clj` (9), `llm_improvement_generator.clj` (5),
+     `llm_pattern_detector.clj` (5), `mechanism.clj` (4),
+     `consumer_test.clj` (5): still `SL003`, now precisely measured
+     (some counts moved from the pre-fix numbers as the tool correctly
+     merged/split what the old decorative headings had miscounted).
+     Genuine over-budget files, Wave 2 scope (namespace split), not
+     addressed here.
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+change — comment/metadata/order-only. Pre-commit's `lint:stratum`
+autofixer keeps this component clean going forward; the eight files
+still over budget stay advisory (`MINIFORGE_STRATUM_BUDGET_MODE=warn` at
+commit time) until Wave 2 splits them.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+- Follow-on: Wave 2 namespace splits for `application.clj`,
+  `consumer.clj`, `core.clj`, `intervention.clj`,
+  `llm_improvement_generator.clj`, `llm_pattern_detector.clj`,
+  `mechanism.clj`, and `consumer_test.clj` (all genuinely over the
+  3-layer budget, confirmed real, not decorative).
+
+## Checklist
+
+- [x] Plain lint run first; confirmed zero `SL001` before proceeding
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Second `--fix` pass confirms idempotency (zero diff)
+- [x] Diff and full file content read for all 18 changed files;
+      mechanical-only, real stratum independently re-derived and checked
+      for every def, including the 9-layer `intervention.clj` chain
+- [x] `clj-kondo` clean (0 errors, 0 warnings)
+- [x] Component test namespaces pass (132 tests, 459 assertions, 0
+      failures/errors)
+- [x] Plain lint re-run post-fix: 12 files resolved; 8 files remain
+      `SL003` (genuine over-budget, documented above with precise counts,
+      tracked as Wave 2)
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
<!--
  Title: Fix stratum-lint autofix for components/operator (Wave 1)
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# fix: stratum-lint autofix for components/operator (Wave 1)

## Overview

Runs `stratum-lint --fix` over `components/operator` (`src` + `test`) to
replace decorative `Layer N` banners with real `Layer N` headings and
`^{:stratum n}` metadata derived from each file's actual same-file
reference graph. Mechanical: no logic changes, no execution-order changes.
Wave 1 batch 6 of the program tracked in
`work/stratum-lint-baseline-2026-07-24.md`.

## Motivation

Plain (non-`--fix`) `stratum-lint` on `components/operator` reported zero
`SL001` (upward-reference/cycle risk) — confirmed before touching
anything, since this component was not among the six already spot-checked
in the baseline triage. Findings were all `SL003` (over the 3-layer
budget) and `SL002` (non-monotonic heading reuse):

```text
application.clj:401:1: SL003 file uses 7 distinct layers (max 3)
core.clj:242:1: SL003 file uses 6 distinct layers (max 3)
llm_improvement_generator.clj:162:1: SL003 file uses 4 distinct layers (max 3)
llm_pattern_detector.clj:156:1: SL003 file uses 4 distinct layers (max 3)
mechanism.clj:303:1: SL003 file uses 4 distinct layers (max 3)
protocol.clj:116:1: SL003 file uses 5 distinct layers (max 3)
core_test.clj: SL002 Layer 1/2/3 headings repeated non-monotonically (x6)
core_test.clj:262:1: SL003 file uses 5 distinct layers (max 3)
defaults_test.clj:45:1: SL002 Layer 1 heading repeated
protocol_test.clj:39:1: SL002 Layer 1 heading repeated
```

## Changes in Detail

Ran, over the whole component:

```bash
bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "bef8657a2efd3b1ba9e1a4f510693c9fbca45abd" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/operator
```

18 of the component's 20 `.clj` files were rewritten (9 `src`, 9 `test`).
`application.clj` and `mechanism.clj` were left untouched: their existing
`Layer 0..N` headings were already strictly monotonic and matched the
real reference graph exactly — genuinely over budget (7 and 4 real
layers respectively), not decorative, so `--fix` had nothing to correct.
Diffs elsewhere are heading text, `^{:stratum n}` metadata, and
def/deftest reordering only — no executable line changed. Notable
findings from the recomputed real dependency graph:

- `protocol.clj` declares two type sets and four independent protocols
  (`Operator`, `PatternDetector`, `ImprovementGenerator`, `Governance`)
  with no same-file reference between any of them. The old headings
  numbered them 0-4 sequentially by writing order; real stratum for
  every def is 0. Pre-fix `SL003` (5 layers) was a sequential-numbering
  artifact, fully resolved.
- `interface.clj` is a pure re-export/delegation layer: every `def`/`defn`
  calls straight into `core/*`, `intervention/*`, `consumer/*`, or
  `application/*` (required namespaces, not same-file defs). Real stratum
  for every def is 0.
- `core.clj` has genuine same-file structure, now 4 real layers (was
  reported as 6 pre-fix, 4 post-fix, still `SL003`). `default-config`,
  the signal helpers, the three pattern detectors, the three improvement
  generators, `SimpleGovernance`, and the two `create-llm-*` fallback
  constructors sit at real Layer 0 (no same-file def calls). The
  `SimplePatternDetector`/`SimpleImprovementGenerator`/`SimpleOperator`
  defrecords (calling Layer 0 helpers) land at Layer 1;
  `create-pattern-detector`/`create-improvement-generator` at Layer 2;
  `create-operator` (constructs a `SimpleOperator` via `->SimpleOperator`)
  at Layer 3. `--fix` moved the `extend-type SimpleOperator` block (a
  non-`def` top-level form) to the file's appendix, after all real
  layers — verified this does not break compile order: `SimpleOperator`
  is defined at Layer 1, well before the appendix runs.
- `consumer.clj` is the deepest real chain in `src`: 6 layers, driven by
  the cursor-file helpers (call the Layer-0 filename constants),
  `read-cursor`/`write-cursor!` (call the cursor-file helpers),
  `route-intervention!`, `consume-operator-dir!`, `consume-pass!`, and
  `start!` each one layer above what they call. `stop!` has no same-file
  dependency and landed at real Layer 0 alongside the polling constants,
  even though it is defined and used far from them in the file.
- `intervention.clj` is the single deepest chain in the component: 9 real
  layers, driven by a `(delay (load-intervention-config))` indirection —
  `intervention-config-resource` (L0) → `load-intervention-config` (L1)
  → `intervention-config` (L2) → the five config-derived defs (L3) →
  `intervention-types`/`target-types`/`lifecycle-states` plus
  `approval-required?`/`terminal-state?`/`intervention-target-type`/
  `build-intervention` (L4) → `valid-transition?`/`next-state` (also L4)
  → `valid-type?`/`valid-target-type?`/`valid-state?`/
  `validate-target-type-supported`/`supported-target-types`/
  `bounded-vocabulary?` (L5) → `validate-intervention-type`/
  `validate-target-type-known`/`transition` (L6) → `create-intervention`
  and every lifecycle-transition wrapper (`start-approval`, `approve`,
  `reject`, `dispatch`, `apply-result`, `verify`, `fail`) (L7) →
  `create-intervention!` (L8). Genuine complexity, not a labeling
  artifact — every def's real dependency count checked by hand against
  its rewritten position.
- `llm_improvement_generator.clj` / `llm_pattern_detector.clj`: the
  `parse-*-type` helpers have no same-file dependency and moved to real
  Layer 0 alongside `summarize-pattern`/`summarize-signal` (previously
  both were under a "Layer 1" banner below `build-*-prompt`, which
  itself calls `summarize-*` and so genuinely sits one layer above).
- `core_test.clj`: the fixture helpers (`signal`, `FakeLLMClient`) and
  every `deftest` calling neither them nor a pattern/rollback/repair
  signal helper landed at real Layer 0; `failure-signal-for`/
  `rollback-signal-from-to`/`repair-signal-for` (call `signal`) plus the
  two direct-LLM-constructor tests landed at Layer 1; the detector tests
  that call the phase-2 signal helpers landed at Layer 2. The old
  headings repeated "Layer 1"/"Layer 2"/"Layer 3" non-monotonically
  instead of separating these three real strata.
- `consumer_test.clj`: `find-workspace-root` (calls a Layer-0 constant)
  is Layer 1; `golden-dir` (calls `find-workspace-root`) is Layer 2;
  `stage-golden!` (calls `golden-dir`) is Layer 3; every `deftest` using
  `stage-golden!` or a golden fixture lands at Layer 4.
- `messages.clj`: gained its first real heading (`Layer 0` on the sole
  `def t`) — previously had no `Layer N` heading at all, the documented
  "no heading = silently skipped" limitation, not a clean bill of
  health.

No same-line trailing comment was displaced onto the wrong def, and no
stale decorative banner was left contradicting a real heading — checked
by reading the full diff and the full resulting content of all 18
changed files, not just the diff hunks. A `grep` for any leftover
`;; ... Layer N` or `Layer N:`-style banner across the component's `src`
and `test` trees came back empty.

## Testing Plan

1. Ran plain `stratum-lint` before the fix — reproduced the findings
   above exactly (14 findings this run vs. 13 in the 2026-07-24
   baseline; main had moved on in the interim, no material difference).
   Confirmed zero `SL001` before proceeding, per this component's stated
   risk (not pre-vetted as `SL001`-free).
2. Ran `--fix`, then a second `--fix` pass immediately after — no
   `rewrote` output, zero diff, confirms idempotency.
3. Read the full diff and the full resulting content for all 18 changed
   files. Confirmed only heading text, `^{:stratum n}` metadata, and
   def/deftest reordering changed; independently re-derived the expected
   real stratum for every def from its same-file reference graph and
   matched it against what `--fix` produced, including the 9-layer
   `intervention.clj` chain.
4. `clj-kondo --lint components/operator`: 0 errors, 0 warnings.
5. Ran the component's test namespaces directly (`clojure -M:dev:test`,
   requiring and running `core-test`, `defaults-test`, `protocol-test`,
   `intervention-test`, `interface-test`, `consumer-test`,
   `llm-improvement-generator-test`, `llm-pattern-detector-test`,
   `anomaly.create-intervention-test`, `application-test`,
   `mechanism-test` — the last two were untouched by `--fix` but included
   for full component coverage): 132 tests, 459 assertions, 0 failures,
   0 errors.
6. Re-ran plain `stratum-lint` after the fix:
   - `protocol.clj`, `interface.clj`, `defaults.clj`, `messages.clj`,
     `core_test.clj`, `defaults_test.clj`, `protocol_test.clj`,
     `interface_test.clj`, `intervention_test.clj`,
     `llm_improvement_generator_test.clj`, `llm_pattern_detector_test.clj`,
     `anomaly/create_intervention_test.clj`: **resolved**, all now
     within the 3-layer budget.
   - `application.clj` (7), `consumer.clj` (6), `core.clj` (4),
     `intervention.clj` (9), `llm_improvement_generator.clj` (5),
     `llm_pattern_detector.clj` (5), `mechanism.clj` (4),
     `consumer_test.clj` (5): still `SL003`, now precisely measured
     (some counts moved from the pre-fix numbers as the tool correctly
     merged/split what the old decorative headings had miscounted).
     Genuine over-budget files, Wave 2 scope (namespace split), not
     addressed here.

## Deployment Plan

Merges to `main` like any other component change. No runtime behavior
change — comment/metadata/order-only. Pre-commit's `lint:stratum`
autofixer keeps this component clean going forward; the eight files
still over budget stay advisory (`MINIFORGE_STRATUM_BUDGET_MODE=warn` at
commit time) until Wave 2 splits them.

## Related Issues/PRs

- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
- Follow-on: Wave 2 namespace splits for `application.clj`,
  `consumer.clj`, `core.clj`, `intervention.clj`,
  `llm_improvement_generator.clj`, `llm_pattern_detector.clj`,
  `mechanism.clj`, and `consumer_test.clj` (all genuinely over the
  3-layer budget, confirmed real, not decorative).

## Checklist

- [x] Plain lint run first; confirmed zero `SL001` before proceeding
- [x] `--fix` run over the whole component (`src` + `test`)
- [x] Second `--fix` pass confirms idempotency (zero diff)
- [x] Diff and full file content read for all 18 changed files;
      mechanical-only, real stratum independently re-derived and checked
      for every def, including the 9-layer `intervention.clj` chain
- [x] `clj-kondo` clean (0 errors, 0 warnings)
- [x] Component test namespaces pass (132 tests, 459 assertions, 0
      failures/errors)
- [x] Plain lint re-run post-fix: 12 files resolved; 8 files remain
      `SL003` (genuine over-budget, documented above with precise counts,
      tracked as Wave 2)
- [x] No `--no-verify`; pre-commit hook runs normally at commit time
