### PR TITLE
fix: stratum-lint autofix for components/loop (Wave 1)

### DIFF
--- a/components/loop/src/ai/miniforge/loop/escalation.clj
+++ b/components/loop/src/ai/miniforge/loop/escalation.clj
@@ -15,23 +15,29 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.loop.escalation
   "Human escalation for retry budget exhaustion.
    Prompts user for hints when agent is stuck.
-   
-   Layer 0: Pure functions for prompt formatting
-   Layer 1: User interaction functions
-   Layer 2: Escalation integration with inner loop"
+
+   Layer 0: format-error-entry, read-user-input, and the
+     checkpoint/episode helpers (create-escalation-checkpoint,
+     result->response, escalated-result, abort-escalation) — no
+     same-file dependents among them
+   Layer 1: format-error-context (calls format-error-entry), prompt-user
+     (calls read-user-input), handle-escalation (calls the Layer 0
+     checkpoint/episode helpers)
+   Layer 2: format-escalation-prompt (calls format-error-context)
+   Layer 3: escalate-to-user (calls prompt-user and
+     format-escalation-prompt)"
   (:require
    [clojure.string :as str]
    [ai.miniforge.decision.interface :as decision]
    [ai.miniforge.loop.messages :as messages]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Prompt formatting (pure functions)
 
-(defn format-error-entry
+;; Prompt formatting (pure functions)
+(defn ^{:stratum 0} format-error-entry
   "Format a single error entry for display.
    Reads :anomaly/message and the anomaly classification when available,
    falls back to :message and :code for legacy shapes.
@@ -53,7 +59,47 @@
     (str (messages/t :escalation/error-line-prefix {:n (inc idx)}) msg
          (when code (messages/t :escalation/error-code-tag {:code code})))))
 
-(defn format-error-context
+;; User interaction
+(defn ^{:stratum 0} read-user-input
+  "Read a line of input from user. Can be mocked in tests."
+  []
+  (read-line))
+
+;; Inner loop integration
+(defn ^{:stratum 0} create-escalation-checkpoint
+  "Create a canonical checkpoint for an inner-loop escalation."
+  [loop-state & [opts]]
+  (decision/create-loop-escalation-checkpoint loop-state (or opts {})))
+
+(defn- ^{:stratum 0} result->response
+  [result]
+  (case (:action result)
+    :continue (decision/decision-response :input (:hints result))
+    :abort {:type :reject
+            :value :abort
+            :rationale (:reason result)
+            :authority-role (if (:reason result) :system :human)}
+    {:type :defer
+     :authority-role :human}))
+
+(defn- ^{:stratum 0} escalated-result
+  [result checkpoint episode]
+  (assoc result
+         :escalated true
+         :decision/checkpoint checkpoint
+         :decision/episode episode))
+
+(defn- ^{:stratum 0} abort-escalation
+  [reason checkpoint episode]
+  {:escalated true
+   :action :abort
+   :reason reason
+   :decision/checkpoint checkpoint
+   :decision/episode episode})
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} format-error-context
   "Format error context for user display.
    
    Arguments:
@@ -77,40 +123,7 @@
                 (when (> (count (str content)) 200) (messages/t :escalation/truncation-ellipsis))))
          (str "  " (messages/t :escalation/no-content)))))
 
-(defn format-escalation-prompt
-  "Format the escalation prompt for user.
-   
-   Arguments:
-   - loop-state - Current inner loop state
-   
-   Returns formatted prompt string."
-  [loop-state]
-  (let [errors (:loop/errors loop-state)
-        iteration (:loop/iteration loop-state)
-        artifact (:loop/artifact loop-state)
-        reason (get-in loop-state [:loop/termination :reason])]
-    (str "\n"
-         (messages/t :escalation/banner-separator) "\n"
-         (messages/t :escalation/banner-title) "\n"
-         (messages/t :escalation/banner-separator) "\n\n"
-         (format-error-context errors iteration artifact)
-         "\n\n"
-         (messages/t :escalation/termination-reason {:reason (name reason)}) "\n"
-         "\n" (messages/t :escalation/options-header) "\n"
-         (messages/t :escalation/option-hints) "\n"
-         (messages/t :escalation/option-abort) "\n"
-         "\n"
-         (messages/t :escalation/input-prompt))))
-
-;------------------------------------------------------------------------------ Layer 1
-;; User interaction
-
-(defn read-user-input
-  "Read a line of input from user. Can be mocked in tests."
-  []
-  (read-line))
-
-(defn prompt-user
+(defn ^{:stratum 1} prompt-user
   "Prompt user for input via stdin.
    
    Arguments:
@@ -130,67 +143,7 @@
       {:type :hints
        :content input})))
 
-(defn escalate-to-user
-  "Escalate to user for guidance.
-   
-   Arguments:
-   - loop-state - Current inner loop state
-   - & opts - Keyword options:
-     :prompt-fn - Custom prompt function (default: prompt-user)
-   
-   Returns:
-   {:action :continue :hints string} or
-   {:action :abort}"
-  [loop-state & {:keys [prompt-fn]}]
-  (let [actual-prompt-fn (or prompt-fn prompt-user)
-        prompt-text (format-escalation-prompt loop-state)
-        user-response (actual-prompt-fn prompt-text)]
-    (case (:type user-response)
-      :abort
-      {:action :abort}
-      
-      :hints
-      {:action :continue
-       :hints (:content user-response)}
-      
-      ;; Default to abort if unknown response
-      {:action :abort})))
-
-;------------------------------------------------------------------------------ Layer 2
-;; Inner loop integration
-
-(defn create-escalation-checkpoint
-  "Create a canonical checkpoint for an inner-loop escalation."
-  [loop-state & [opts]]
-  (decision/create-loop-escalation-checkpoint loop-state (or opts {})))
-
-(defn- result->response
-  [result]
-  (case (:action result)
-    :continue (decision/decision-response :input (:hints result))
-    :abort {:type :reject
-            :value :abort
-            :rationale (:reason result)
-            :authority-role (if (:reason result) :system :human)}
-    {:type :defer
-     :authority-role :human}))
-
-(defn- escalated-result
-  [result checkpoint episode]
-  (assoc result
-         :escalated true
-         :decision/checkpoint checkpoint
-         :decision/episode episode))
-
-(defn- abort-escalation
-  [reason checkpoint episode]
-  {:escalated true
-   :action :abort
-   :reason reason
-   :decision/checkpoint checkpoint
-   :decision/episode episode})
-
-(defn handle-escalation
+(defn ^{:stratum 1} handle-escalation
   "Handle escalation in inner loop.
    Called when loop reaches :escalated state.
    
@@ -222,6 +175,61 @@
         (abort-escalation no-fn-msg
                           resolved-checkpoint
                           updated-episode)))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} format-escalation-prompt
+  "Format the escalation prompt for user.
+   
+   Arguments:
+   - loop-state - Current inner loop state
+   
+   Returns formatted prompt string."
+  [loop-state]
+  (let [errors (:loop/errors loop-state)
+        iteration (:loop/iteration loop-state)
+        artifact (:loop/artifact loop-state)
+        reason (get-in loop-state [:loop/termination :reason])]
+    (str "\n"
+         (messages/t :escalation/banner-separator) "\n"
+         (messages/t :escalation/banner-title) "\n"
+         (messages/t :escalation/banner-separator) "\n\n"
+         (format-error-context errors iteration artifact)
+         "\n\n"
+         (messages/t :escalation/termination-reason {:reason (name reason)}) "\n"
+         "\n" (messages/t :escalation/options-header) "\n"
+         (messages/t :escalation/option-hints) "\n"
+         (messages/t :escalation/option-abort) "\n"
+         "\n"
+         (messages/t :escalation/input-prompt))))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} escalate-to-user
+  "Escalate to user for guidance.
+   
+   Arguments:
+   - loop-state - Current inner loop state
+   - & opts - Keyword options:
+     :prompt-fn - Custom prompt function (default: prompt-user)
+   
+   Returns:
+   {:action :continue :hints string} or
+   {:action :abort}"
+  [loop-state & {:keys [prompt-fn]}]
+  (let [actual-prompt-fn (or prompt-fn prompt-user)
+        prompt-text (format-escalation-prompt loop-state)
+        user-response (actual-prompt-fn prompt-text)]
+    (case (:type user-response)
+      :abort
+      {:action :abort}
+      
+      :hints
+      {:action :continue
+       :hints (:content user-response)}
+      
+      ;; Default to abort if unknown response
+      {:action :abort})))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/loop/src/ai/miniforge/loop/gates.clj
+++ b/components/loop/src/ai/miniforge/loop/gates.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.loop.gates
   "Validation gate protocol and built-in gate implementations.
 
@@ -23,9 +22,17 @@
    - ai.miniforge.loop.interface.protocols.gate (Gate protocol)
 
    This namespace contains the built-in gate implementations.
-   Layer 0: Pure functions for gate results
-   Layer 1: Built-in gates (syntax, lint, test, policy)
-   Layer 2: Gate runner and composition"
+   Layer 0: protocol re-exports, result predicates/constructors
+     (passed?, failed?, pass-result, fail-result, make-error), and
+     applicable-gates — no same-file dependents among them
+   Layer 1: the SyntaxGate/LintGate/TestGate/PolicyGate/CustomGate
+     defrecords (call the Layer 0 result constructors) and run-gate
+     (calls make-error)
+   Layer 2: the gate constructor fns (syntax-gate, lint-gate, test-gate,
+     policy-gate, custom-gate — call the matching Layer 1 defrecord) and
+     run-gates (calls run-gate)
+   Layer 3: default-gates, minimal-gates, strict-gates (call the Layer 2
+     gate constructors)"
   (:require
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.clock.interface :as clock]
@@ -34,29 +41,32 @@
    [ai.miniforge.logging.interface :as log]
    [clojure.string]))
 
-;; Re-export protocol for backward compatibility
-(def Gate p/Gate)
-(def check p/check)
-(def gate-id p/gate-id)
-(def gate-type p/gate-type)
-(def repair p/repair)
-
 ;------------------------------------------------------------------------------ Layer 0
-;; Gate result predicates
 
-(defn passed?
+;; Re-export protocol for backward compatibility
+(def ^{:stratum 0} Gate p/Gate)
+
+(def ^{:stratum 0} check p/check)
+
+(def ^{:stratum 0} gate-id p/gate-id)
+
+(def ^{:stratum 0} gate-type p/gate-type)
+
+(def ^{:stratum 0} repair p/repair)
+
+;; Gate result predicates
+(defn ^{:stratum 0} passed?
   "Check if a gate result or aggregate result indicates all gates passed."
   [result]
   (boolean (:passed? result)))
 
-(defn failed?
+(defn ^{:stratum 0} failed?
   "Check if a gate result or aggregate result indicates failure."
   [result]
   (not (:passed? result)))
 
 ;; Gate result constructors (pure functions)
-
-(defn pass-result
+(defn ^{:stratum 0} pass-result
   "Create a passing gate result."
   [gate-id gate-type & {:keys [warnings duration-ms]}]
   (cond-> {:gate/id gate-id
@@ -65,7 +75,7 @@
     warnings (assoc :gate/warnings warnings)
     duration-ms (assoc :gate/duration-ms duration-ms)))
 
-(defn fail-result
+(defn ^{:stratum 0} fail-result
   "Create a failing gate result.
    Includes :gate/anomaly — a canonical anomaly map preserving gate error
    richness.
@@ -96,7 +106,7 @@
     warnings (assoc :gate/warnings warnings)
     duration-ms (assoc :gate/duration-ms duration-ms)))
 
-(defn make-error
+(defn ^{:stratum 0} make-error
   "Create a gate error map."
   [code message & {:keys [file line column]}]
   (cond-> {:code code
@@ -105,10 +115,24 @@
                             line (assoc :line line)
                             column (assoc :column column)))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Built-in gates
+(defn ^{:stratum 0} applicable-gates
+  "Filter gates to only those applicable to the given artifact type.
+   If a gate has no :applies-to config, it applies to all artifacts."
+  [gates artifact]
+  (let [artifact-type (:artifact/type artifact)]
+    (filter
+     (fn [gate]
+       (let [config (when (satisfies? clojure.lang.ILookup gate)
+                      (:config gate))
+             applies-to (when config (:applies-to config))]
+         (or (nil? applies-to)
+             (contains? applies-to artifact-type))))
+     gates)))
 
-(defrecord SyntaxGate [id config]
+;------------------------------------------------------------------------------ Layer 1
+
+;; Built-in gates
+(defrecord ^{:stratum 1} SyntaxGate [id config]
   p/Gate
   (check [_this artifact context]
     (let [start (clock/now-ms)
@@ -145,15 +169,7 @@
      :changes []
      :remaining-violations violations}))
 
-(defn syntax-gate
-  "Create a syntax validation gate.
-   Checks that code artifacts can be parsed without errors."
-  ([] (syntax-gate :syntax-check {}))
-  ([id] (syntax-gate id {}))
-  ([id config] (->SyntaxGate id config)))
-
-
-(defrecord LintGate [id config]
+(defrecord ^{:stratum 1} LintGate [id config]
   p/Gate
   (check [_this artifact context]
     (let [start (clock/now-ms)
@@ -209,16 +225,7 @@
        :changes changes
        :remaining-violations remaining})))
 
-(defn lint-gate
-  "Create a lint validation gate.
-   Options:
-   - :fail-on-warning? - If true, warnings cause failure (default false)"
-  ([] (lint-gate :lint-check {}))
-  ([id] (lint-gate id {}))
-  ([id config] (->LintGate id config)))
-
-
-(defrecord TestGate [id config]
+(defrecord ^{:stratum 1} TestGate [id config]
   p/Gate
   (check [_this artifact context]
     (let [start (clock/now-ms)
@@ -257,16 +264,7 @@
      :changes []
      :remaining-violations violations}))
 
-(defn test-gate
-  "Create a test validation gate.
-   Options:
-   - :test-fn - Function (fn [artifact context] -> {:passed? bool :errors [...]})"
-  ([] (test-gate :test-check {}))
-  ([id] (test-gate id {}))
-  ([id config] (->TestGate id config)))
-
-
-(defrecord PolicyGate [id config]
+(defrecord ^{:stratum 1} PolicyGate [id config]
   p/Gate
   (check [_this artifact context]
     (let [start (clock/now-ms)
@@ -337,17 +335,7 @@
        :changes changes
        :remaining-violations remaining})))
 
-(defn policy-gate
-  "Create a policy validation gate.
-   Options:
-   - :policies - Vector of policy keywords to check
-                 Supported: :no-secrets, :no-todos, :require-docstrings"
-  ([] (policy-gate :policy-check {}))
-  ([id] (policy-gate id {}))
-  ([id config] (->PolicyGate id config)))
-
-
-(defrecord CustomGate [id type-kw check-fn]
+(defrecord ^{:stratum 1} CustomGate [id type-kw check-fn]
   p/Gate
   (check [_this artifact context]
     (let [start (clock/now-ms)]
@@ -371,18 +359,8 @@
      :changes []
      :remaining-violations violations}))
 
-(defn custom-gate
-  "Create a custom validation gate.
-   Arguments:
-   - id - Unique gate identifier
-   - check-fn - Function (fn [artifact context] -> gate-result-map)"
-  ([id check-fn] (custom-gate id :custom check-fn))
-  ([id type-kw check-fn] (->CustomGate id type-kw check-fn)))
-
-;------------------------------------------------------------------------------ Layer 2
 ;; Gate runner
-
-(defn run-gate
+(defn ^{:stratum 1} run-gate
   "Run a single gate check, handling errors gracefully.
    Returns the gate result map."
   [gate artifact context]
@@ -393,7 +371,49 @@
                    [(make-error :gate-execution-error
                                 (messages/t :gate/execution-failed {:error (.getMessage e)}))]))))
 
-(defn run-gates
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} syntax-gate
+  "Create a syntax validation gate.
+   Checks that code artifacts can be parsed without errors."
+  ([] (syntax-gate :syntax-check {}))
+  ([id] (syntax-gate id {}))
+  ([id config] (->SyntaxGate id config)))
+
+(defn ^{:stratum 2} lint-gate
+  "Create a lint validation gate.
+   Options:
+   - :fail-on-warning? - If true, warnings cause failure (default false)"
+  ([] (lint-gate :lint-check {}))
+  ([id] (lint-gate id {}))
+  ([id config] (->LintGate id config)))
+
+(defn ^{:stratum 2} test-gate
+  "Create a test validation gate.
+   Options:
+   - :test-fn - Function (fn [artifact context] -> {:passed? bool :errors [...]})"
+  ([] (test-gate :test-check {}))
+  ([id] (test-gate id {}))
+  ([id config] (->TestGate id config)))
+
+(defn ^{:stratum 2} policy-gate
+  "Create a policy validation gate.
+   Options:
+   - :policies - Vector of policy keywords to check
+                 Supported: :no-secrets, :no-todos, :require-docstrings"
+  ([] (policy-gate :policy-check {}))
+  ([id] (policy-gate id {}))
+  ([id config] (->PolicyGate id config)))
+
+(defn ^{:stratum 2} custom-gate
+  "Create a custom validation gate.
+   Arguments:
+   - id - Unique gate identifier
+   - check-fn - Function (fn [artifact context] -> gate-result-map)"
+  ([id check-fn] (custom-gate id :custom check-fn))
+  ([id type-kw check-fn] (->CustomGate id type-kw check-fn)))
+
+(defn ^{:stratum 2} run-gates
   "Run multiple gates against an artifact.
    Options:
    - :fail-fast? - Stop on first failure (default false)
@@ -439,24 +459,10 @@
                 ;; Continue running remaining gates
                 (recur (rest remaining) new-results new-failed new-errors)))))))))
 
-(defn applicable-gates
-  "Filter gates to only those applicable to the given artifact type.
-   If a gate has no :applies-to config, it applies to all artifacts."
-  [gates artifact]
-  (let [artifact-type (:artifact/type artifact)]
-    (filter
-     (fn [gate]
-       (let [config (when (satisfies? clojure.lang.ILookup gate)
-                      (:config gate))
-             applies-to (when config (:applies-to config))]
-         (or (nil? applies-to)
-             (contains? applies-to artifact-type))))
-     gates)))
+;------------------------------------------------------------------------------ Layer 3
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Gate set constructors
-
-(defn default-gates
+(defn ^{:stratum 3} default-gates
   "Create a default set of gates for code artifacts.
    Options:
    - :lint-fail-on-warning? - Lint gate fails on warnings (default false)
@@ -468,12 +474,12 @@
    (lint-gate :lint-check {:fail-on-warning? lint-fail-on-warning?})
    (policy-gate :policy-check {:policies policies})])
 
-(defn minimal-gates
+(defn ^{:stratum 3} minimal-gates
   "Create a minimal set of gates (syntax only)."
   []
   [(syntax-gate)])
 
-(defn strict-gates
+(defn ^{:stratum 3} strict-gates
   "Create a strict set of gates for production code.
    Includes all policies and fails on warnings."
   []

--- a/components/loop/src/ai/miniforge/loop/inner.clj
+++ b/components/loop/src/ai/miniforge/loop/inner.clj
@@ -15,14 +15,42 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.loop.inner
   "Inner loop state machine implementation.
    Manages the Generate -> Validate -> Repair cycle for artifact production.
 
-   Layer 0: Pure state transition functions
-   Layer 1: Step functions (generate, validate, repair)
-   Layer 2: Loop runner"
+   10 real layers (over the 3-layer budget; a namespace split is
+   deferred to Wave 2, see work/stratum-lint-baseline-2026-07-24.md):
+   Layer 0: FSM config/derived helpers (default-max-iterations,
+     initial-loop-state, default-loop-metrics, invalid-transition-message,
+     inner-loop-machine-definition, final-state-definition?,
+     transition-targets, derive-transition-events, add-metric-values,
+     sum-repair-result-metrics) and pure state accessors
+     (add-gate-results, add-repair-attempt, set-artifact, set-errors,
+     increment-iteration, set-termination, budget-exhausted?,
+     handle-terminal-state) — no same-file dependents among them
+   Layer 1: inner-loop-machine, derive-valid-transitions,
+     transition-events, terminal-states (derived from the Layer 0 machine
+     definition/helpers), create-inner-loop, update-metrics,
+     max-iterations-exceeded?, resume-after-escalation
+   Layer 2: valid-transitions (derived from derive-valid-transitions),
+     terminal-state? (calls terminal-states), handle-escalated-state
+     (calls handle-terminal-state and resume-after-escalation)
+   Layer 3: invalid-transition-data and valid-transition? (call
+     valid-transitions), should-terminate? (calls
+     max-iterations-exceeded?, budget-exhausted?, terminal-state?)
+   Layer 4: transition-result (calls transition-events and
+     invalid-transition-data), compute-termination-check (calls
+     should-terminate?)
+   Layer 5: transition (calls transition-result)
+   Layer 6: generate-step, validate-step, repair-step, and
+     handle-pre-termination (all call transition)
+   Layer 7: handle-pending-state, handle-generating-state,
+     handle-validating-state, handle-repairing-state (call the matching
+     Layer 6 step fn)
+   Layer 8: run-inner-loop (calls the Layer 7 handle-*-state fns and
+     handle-escalated-state)
+   Layer 9: run-simple (calls run-inner-loop)"
   (:require
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.fsm.interface :as fsm]
@@ -34,31 +62,28 @@
    [ai.miniforge.loop.repair :as repair]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; State machine definition and derived transition helpers
 
-(def default-max-iterations
+;; State machine definition and derived transition helpers
+(def ^{:stratum 0} default-max-iterations
   (inner-config/default-max-iterations))
 
-(def initial-loop-state
+(def ^{:stratum 0} initial-loop-state
   (inner-config/initial-loop-state))
 
-(def default-loop-metrics
+(def ^{:stratum 0} default-loop-metrics
   (inner-config/default-loop-metrics))
 
-(def invalid-transition-message
+(def ^{:stratum 0} invalid-transition-message
   (loop-messages/t :inner/invalid-transition))
 
-(def inner-loop-machine-definition
+(def ^{:stratum 0} inner-loop-machine-definition
   (inner-config/machine-definition))
 
-(def inner-loop-machine
-  (fsm/define-machine inner-loop-machine-definition))
-
-(defn- final-state-definition?
+(defn- ^{:stratum 0} final-state-definition?
   [[_ state-definition]]
   (= :final (:type state-definition)))
 
-(defn- transition-targets
+(defn- ^{:stratum 0} transition-targets
   [state-definition]
   (->> (get state-definition :on {})
        vals
@@ -68,15 +93,7 @@
                 (:target target-or-config))))
        set))
 
-(defn- derive-valid-transitions
-  [machine-definition]
-  (reduce-kv
-   (fn [transitions state state-definition]
-     (assoc transitions state (transition-targets state-definition)))
-   {}
-   (:fsm/states machine-definition)))
-
-(defn- derive-transition-events
+(defn- ^{:stratum 0} derive-transition-events
   [machine-definition]
   (reduce-kv
    (fn [event-map state state-definition]
@@ -91,26 +108,7 @@
    {}
    (:fsm/states machine-definition)))
 
-(def valid-transitions
-  "Valid state transitions in the inner loop state machine."
-  (derive-valid-transitions inner-loop-machine-definition))
-
-(def transition-events
-  (derive-transition-events inner-loop-machine-definition))
-
-(def terminal-states
-  (into #{}
-        (comp (filter final-state-definition?)
-              (map first))
-        (:fsm/states inner-loop-machine-definition)))
-
-(defn- invalid-transition-data
-  [from-state to-state]
-  {:from from-state
-   :to to-state
-   :valid-targets (get valid-transitions from-state #{})})
-
-(defn- add-metric-values
+(defn- ^{:stratum 0} add-metric-values
   [metrics metric-updates]
   (merge-with (fn sum-metric-values [old new]
                 (if (number? old)
@@ -119,50 +117,112 @@
               metrics
               metric-updates))
 
-(defn valid-transition?
-  "Check if a state transition is valid."
-  [from-state to-state]
-  (contains? (get valid-transitions from-state #{}) to-state))
+(defn- ^{:stratum 0} sum-repair-result-metrics
+  "repair/attempt-repair returns top-level shapes that hold per-attempt
+   results in `:results`. The metrics fields (`:tokens-used`,
+   `:cost-usd`) are on those entries, not on the outer map. Sum
+   them so the loop's :cost-usd / :tokens accumulators see what
+   each repair iteration actually cost.
 
-(defn terminal-state?
-  "Check if a state is terminal (no further transitions possible)."
-  [state]
-  (contains? terminal-states state))
+   Returns a `{:tokens N :cost-usd N}` map ready to thread into
+   `update-metrics`. Empty / missing :results yields zeros."
+  [repair-result]
+  (let [results (:results repair-result [])]
+    {:tokens   (->> results (map #(or (:tokens-used %) 0))  (reduce + 0))
+     :cost-usd (->> results (map #(or (:cost-usd %) 0.0))   (reduce + 0.0))}))
 
-(defn transition-result
-  "Attempt a state transition.
+(defn ^{:stratum 0} add-gate-results
+  "Add gate results to loop state."
+  [loop-state results]
+  (update loop-state :loop/gate-results into results))
 
-   Returns the updated loop state on success, or an `:invalid-input` anomaly
-   when the FSM rejects the transition."
-  [loop-state new-state]
-  (let [current-state (:loop/state loop-state)
-        transition-event (get transition-events [current-state new-state])]
-    (if-not transition-event
-      (anomaly/anomaly :invalid-input
-                       invalid-transition-message
-                       (invalid-transition-data current-state new-state))
-      (assoc loop-state
-             :loop/state new-state
-             :loop/updated-at (java.util.Date.)))))
+(defn ^{:stratum 0} add-repair-attempt
+  "Add a repair attempt to loop history."
+  [loop-state attempt]
+  (update loop-state :loop/repair-history conj attempt))
 
-(defn transition
-  "Boundary compatibility wrapper around [[transition-result]].
+(defn ^{:stratum 0} set-artifact
+  "Set the artifact in loop state."
+  [loop-state artifact]
+  (assoc loop-state :loop/artifact artifact))
 
-   Returns updated loop state on success. On FSM rejection, throws `ex-info`
-   to preserve the existing caller contract. Prefer the anomaly-returning
-   [[transition-result]] in non-boundary code when callers can branch on
-   anomaly data."
-  [loop-state new-state]
-  (let [result (transition-result loop-state new-state)]
-    (if (anomaly/anomaly? result)
-      (throw (ex-info invalid-transition-message
-                      (:anomaly/data result)))
-      result)))
+(defn ^{:stratum 0} set-errors
+  "Set the current errors in loop state."
+  [loop-state errors]
+  (assoc loop-state :loop/errors errors))
 
-;------------------------------------------------------------------------------ Layer 0
+(defn ^{:stratum 0} increment-iteration
+  "Increment the iteration counter."
+  [loop-state]
+  (update loop-state :loop/iteration inc))
+
+(defn ^{:stratum 0} set-termination
+  "Set termination reason and message."
+  [loop-state reason & {:keys [message]}]
+  (assoc loop-state :loop/termination
+         (cond-> {:reason reason}
+           message (assoc :message message))))
+
+(defn ^{:stratum 0} budget-exhausted?
+  "Check if budget constraints have been exceeded."
+  [loop-state]
+  (let [budget (get-in loop-state [:loop/config :budget])
+        metrics (:loop/metrics loop-state)]
+    (when budget
+      (or (and (:max-tokens budget)
+               (>= (:tokens metrics 0) (:max-tokens budget)))
+          (and (:max-cost-usd budget)
+               (>= (:cost-usd metrics 0.0) (:max-cost-usd budget)))
+          (and (:max-duration-ms budget)
+               (>= (:duration-ms metrics 0) (:max-duration-ms budget)))))))
+
+;; Loop runner helpers
+(defn ^{:stratum 0} handle-terminal-state
+  "Handle terminal states (complete, failed, escalated).
+   Returns the final result map."
+  [state logger]
+  (let [current-state (:loop/state state)
+        success? (= current-state :complete)]
+    (when logger
+      (if success?
+        (log/info logger :loop :inner/validation-passed
+                  {:message (loop-messages/t :inner/completed-successfully)
+                   :data {:iterations (:loop/iteration state)}})
+        (log/warn logger :loop :inner/escalated
+                  {:message (loop-messages/t :inner/terminated)
+                   :data {:state current-state
+                          :reason (get-in state [:loop/termination :reason])}})))
+    {:success success?
+     :artifact (when success? (:loop/artifact state))
+     :iterations (:loop/iteration state)
+     :metrics (:loop/metrics state)
+     :termination (:loop/termination state)
+     :final-state state}))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} inner-loop-machine
+  (fsm/define-machine inner-loop-machine-definition))
+
+(defn- ^{:stratum 1} derive-valid-transitions
+  [machine-definition]
+  (reduce-kv
+   (fn [transitions state state-definition]
+     (assoc transitions state (transition-targets state-definition)))
+   {}
+   (:fsm/states machine-definition)))
+
+(def ^{:stratum 1} transition-events
+  (derive-transition-events inner-loop-machine-definition))
+
+(def ^{:stratum 1} terminal-states
+  (into #{}
+        (comp (filter final-state-definition?)
+              (map first))
+        (:fsm/states inner-loop-machine-definition)))
+
 ;; Loop state constructors (pure functions)
-
-(defn create-inner-loop
+(defn ^{:stratum 1} create-inner-loop
   "Create a new inner loop state.
 
    Arguments:
@@ -188,61 +248,13 @@
      :loop/created-at (java.util.Date.)
      :loop/updated-at (java.util.Date.)}))
 
-(defn update-metrics
+(defn ^{:stratum 1} update-metrics
   "Update loop metrics with new values."
   [loop-state metric-updates]
   (update loop-state :loop/metrics add-metric-values metric-updates))
 
-(defn- sum-repair-result-metrics
-  "repair/attempt-repair returns top-level shapes that hold per-attempt
-   results in `:results`. The metrics fields (`:tokens-used`,
-   `:cost-usd`) are on those entries, not on the outer map. Sum
-   them so the loop's :cost-usd / :tokens accumulators see what
-   each repair iteration actually cost.
-
-   Returns a `{:tokens N :cost-usd N}` map ready to thread into
-   `update-metrics`. Empty / missing :results yields zeros."
-  [repair-result]
-  (let [results (:results repair-result [])]
-    {:tokens   (->> results (map #(or (:tokens-used %) 0))  (reduce + 0))
-     :cost-usd (->> results (map #(or (:cost-usd %) 0.0))   (reduce + 0.0))}))
-
-(defn add-gate-results
-  "Add gate results to loop state."
-  [loop-state results]
-  (update loop-state :loop/gate-results into results))
-
-(defn add-repair-attempt
-  "Add a repair attempt to loop history."
-  [loop-state attempt]
-  (update loop-state :loop/repair-history conj attempt))
-
-(defn set-artifact
-  "Set the artifact in loop state."
-  [loop-state artifact]
-  (assoc loop-state :loop/artifact artifact))
-
-(defn set-errors
-  "Set the current errors in loop state."
-  [loop-state errors]
-  (assoc loop-state :loop/errors errors))
-
-(defn increment-iteration
-  "Increment the iteration counter."
-  [loop-state]
-  (update loop-state :loop/iteration inc))
-
-(defn set-termination
-  "Set termination reason and message."
-  [loop-state reason & {:keys [message]}]
-  (assoc loop-state :loop/termination
-         (cond-> {:reason reason}
-           message (assoc :message message))))
-
-;------------------------------------------------------------------------------ Layer 0
 ;; Termination checks (pure functions)
-
-(defn max-iterations-exceeded?
+(defn ^{:stratum 1} max-iterations-exceeded?
   "Check if maximum iterations have been exceeded."
   [loop-state]
   (let [max-iter (get-in loop-state [:loop/config :max-iterations]
@@ -250,20 +262,72 @@
         current (get loop-state :loop/iteration 0)]
     (>= current max-iter)))
 
-(defn budget-exhausted?
-  "Check if budget constraints have been exceeded."
-  [loop-state]
-  (let [budget (get-in loop-state [:loop/config :budget])
-        metrics (:loop/metrics loop-state)]
-    (when budget
-      (or (and (:max-tokens budget)
-               (>= (:tokens metrics 0) (:max-tokens budget)))
-          (and (:max-cost-usd budget)
-               (>= (:cost-usd metrics 0.0) (:max-cost-usd budget)))
-          (and (:max-duration-ms budget)
-               (>= (:duration-ms metrics 0) (:max-duration-ms budget)))))))
+(defn ^{:stratum 1} resume-after-escalation
+  "Resume the loop after human escalation with provided hints."
+  [state hints]
+  (let [current-iter (:loop/iteration state)
+        current-max (get-in state [:loop/config :max-iterations]
+                            default-max-iterations)
+        current-count (get-in state [:loop/escalation :count] 0)
+        target-max (max (inc current-max) (inc current-iter))]
+    (-> state
+        (dissoc :loop/termination)
+        (assoc :loop/state :generating
+               :loop/override-termination? true
+               :loop/escalation {:hints hints
+                                 :resumed-at (java.util.Date.)
+                                 :count (inc current-count)})
+        (assoc-in [:loop/config :max-iterations] target-max)
+        (assoc :loop/updated-at (java.util.Date.)))))
 
-(defn should-terminate?
+;------------------------------------------------------------------------------ Layer 2
+
+(def ^{:stratum 2} valid-transitions
+  "Valid state transitions in the inner loop state machine."
+  (derive-valid-transitions inner-loop-machine-definition))
+
+(defn ^{:stratum 2} terminal-state?
+  "Check if a state is terminal (no further transitions possible)."
+  [state]
+  (contains? terminal-states state))
+
+(defn ^{:stratum 2} handle-escalated-state
+  "Handle escalated state - prompt user or terminate.
+   Returns {:next-state state :next-ctx ctx} or {:terminal result}."
+  [state ctx logger]
+  (let [escalation-count (get-in state [:loop/escalation :count] 0)]
+    (if (>= escalation-count 1)
+      {:terminal (handle-terminal-state
+                  (set-termination state :max-iterations
+                                   :message (loop-messages/t :inner/escalation-already-handled))
+                  logger)}
+      (let [result (escalation/handle-escalation state ctx)]
+        (if (= :continue (:action result))
+          (let [hints (:hints result)
+                resumed-state (resume-after-escalation state hints)
+                next-ctx (assoc ctx :escalation-hints hints)]
+            (when logger
+              (log/info logger :loop :inner/escalated
+                        {:message (loop-messages/t :inner/resuming-after-escalation)
+                         :data {:hints-provided? (boolean (seq hints))}}))
+            {:next-state resumed-state
+             :next-ctx next-ctx})
+          {:terminal (handle-terminal-state state logger)})))))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn- ^{:stratum 3} invalid-transition-data
+  [from-state to-state]
+  {:from from-state
+   :to to-state
+   :valid-targets (get valid-transitions from-state #{})})
+
+(defn ^{:stratum 3} valid-transition?
+  "Check if a state transition is valid."
+  [from-state to-state]
+  (contains? (get valid-transitions from-state #{}) to-state))
+
+(defn ^{:stratum 3} should-terminate?
   "Check if the loop should terminate.
    Returns {:terminate? bool :reason keyword} or nil."
   [loop-state]
@@ -279,10 +343,54 @@
 
     :else nil))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Step functions
+;------------------------------------------------------------------------------ Layer 4
 
-(defn generate-step
+(defn ^{:stratum 4} transition-result
+  "Attempt a state transition.
+
+   Returns the updated loop state on success, or an `:invalid-input` anomaly
+   when the FSM rejects the transition."
+  [loop-state new-state]
+  (let [current-state (:loop/state loop-state)
+        transition-event (get transition-events [current-state new-state])]
+    (if-not transition-event
+      (anomaly/anomaly :invalid-input
+                       invalid-transition-message
+                       (invalid-transition-data current-state new-state))
+      (assoc loop-state
+             :loop/state new-state
+             :loop/updated-at (java.util.Date.)))))
+
+(defn ^{:stratum 4} compute-termination-check
+  "Compute the termination result, allowing validation to complete once."
+  [state current-state override-termination?]
+  (when-not override-termination?
+    (let [termination (should-terminate? state)]
+      (if (and (= current-state :validating)
+               (= :max-iterations (:reason termination)))
+        nil
+        termination))))
+
+;------------------------------------------------------------------------------ Layer 5
+
+(defn ^{:stratum 5} transition
+  "Boundary compatibility wrapper around [[transition-result]].
+
+   Returns updated loop state on success. On FSM rejection, throws `ex-info`
+   to preserve the existing caller contract. Prefer the anomaly-returning
+   [[transition-result]] in non-boundary code when callers can branch on
+   anomaly data."
+  [loop-state new-state]
+  (let [result (transition-result loop-state new-state)]
+    (if (anomaly/anomaly? result)
+      (throw (ex-info invalid-transition-message
+                      (:anomaly/data result)))
+      result)))
+
+;------------------------------------------------------------------------------ Layer 6
+
+;; Step functions
+(defn ^{:stratum 6} generate-step
   "Execute the generate step using the provided agent/generate function.
 
    Arguments:
@@ -341,7 +449,7 @@
                                  :message (.getMessage e))
                 (transition :failed))))))))
 
-(defn validate-step
+(defn ^{:stratum 6} validate-step
   "Execute the validate step using provided gates.
 
    Arguments:
@@ -381,7 +489,7 @@
               (set-errors (:errors results))
               (transition :repairing)))))))
 
-(defn repair-step
+(defn ^{:stratum 6} repair-step
   "Execute the repair step using provided strategies.
 
    Arguments:
@@ -472,32 +580,7 @@
               ;; Loop back to try generating again
               (transition loop-state :generating))))))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Loop runner helpers
-
-(defn handle-terminal-state
-  "Handle terminal states (complete, failed, escalated).
-   Returns the final result map."
-  [state logger]
-  (let [current-state (:loop/state state)
-        success? (= current-state :complete)]
-    (when logger
-      (if success?
-        (log/info logger :loop :inner/validation-passed
-                  {:message (loop-messages/t :inner/completed-successfully)
-                   :data {:iterations (:loop/iteration state)}})
-        (log/warn logger :loop :inner/escalated
-                  {:message (loop-messages/t :inner/terminated)
-                   :data {:state current-state
-                          :reason (get-in state [:loop/termination :reason])}})))
-    {:success success?
-     :artifact (when success? (:loop/artifact state))
-     :iterations (:loop/iteration state)
-     :metrics (:loop/metrics state)
-     :termination (:loop/termination state)
-     :final-state state}))
-
-(defn handle-pre-termination
+(defn ^{:stratum 6} handle-pre-termination
   "Handle pre-termination conditions (budget exhausted, max iterations).
    Returns updated state transitioned to appropriate terminal state."
   [state termination-result]
@@ -508,82 +591,35 @@
                       :complete
                       :escalated)))))
 
-(defn resume-after-escalation
-  "Resume the loop after human escalation with provided hints."
-  [state hints]
-  (let [current-iter (:loop/iteration state)
-        current-max (get-in state [:loop/config :max-iterations]
-                            default-max-iterations)
-        current-count (get-in state [:loop/escalation :count] 0)
-        target-max (max (inc current-max) (inc current-iter))]
-    (-> state
-        (dissoc :loop/termination)
-        (assoc :loop/state :generating
-               :loop/override-termination? true
-               :loop/escalation {:hints hints
-                                 :resumed-at (java.util.Date.)
-                                 :count (inc current-count)})
-        (assoc-in [:loop/config :max-iterations] target-max)
-        (assoc :loop/updated-at (java.util.Date.)))))
+;------------------------------------------------------------------------------ Layer 7
 
-(defn handle-pending-state
+(defn ^{:stratum 7} handle-pending-state
   "Handle pending state - initiate generation.
    Returns updated state."
   [state generate-fn context]
   (generate-step state generate-fn context))
 
-(defn handle-generating-state
+(defn ^{:stratum 7} handle-generating-state
   "Handle generating state - continue generation.
    Returns updated state."
   [state generate-fn context]
   (generate-step state generate-fn context))
 
-(defn handle-validating-state
+(defn ^{:stratum 7} handle-validating-state
   "Handle validating state - run validation.
    Returns updated state."
   [state gates context]
   (validate-step state gates context))
 
-(defn handle-repairing-state
+(defn ^{:stratum 7} handle-repairing-state
   "Handle repairing state - attempt repair.
    Returns updated state."
   [state strategies context]
   (repair-step state strategies context))
 
-(defn handle-escalated-state
-  "Handle escalated state - prompt user or terminate.
-   Returns {:next-state state :next-ctx ctx} or {:terminal result}."
-  [state ctx logger]
-  (let [escalation-count (get-in state [:loop/escalation :count] 0)]
-    (if (>= escalation-count 1)
-      {:terminal (handle-terminal-state
-                  (set-termination state :max-iterations
-                                   :message (loop-messages/t :inner/escalation-already-handled))
-                  logger)}
-      (let [result (escalation/handle-escalation state ctx)]
-        (if (= :continue (:action result))
-          (let [hints (:hints result)
-                resumed-state (resume-after-escalation state hints)
-                next-ctx (assoc ctx :escalation-hints hints)]
-            (when logger
-              (log/info logger :loop :inner/escalated
-                        {:message (loop-messages/t :inner/resuming-after-escalation)
-                         :data {:hints-provided? (boolean (seq hints))}}))
-            {:next-state resumed-state
-             :next-ctx next-ctx})
-          {:terminal (handle-terminal-state state logger)})))))
+;------------------------------------------------------------------------------ Layer 8
 
-(defn compute-termination-check
-  "Compute the termination result, allowing validation to complete once."
-  [state current-state override-termination?]
-  (when-not override-termination?
-    (let [termination (should-terminate? state)]
-      (if (and (= current-state :validating)
-               (= :max-iterations (:reason termination)))
-        nil
-        termination))))
-
-(defn run-inner-loop
+(defn ^{:stratum 8} run-inner-loop
   "Run the inner loop to completion.
 
    Arguments:
@@ -653,7 +689,9 @@
                           {:state current-state
                            :loop-state state})))))))
 
-(defn run-simple
+;------------------------------------------------------------------------------ Layer 9
+
+(defn ^{:stratum 9} run-simple
   "Simplified runner for basic use cases.
    Uses default gates and strategies.
 

--- a/components/loop/src/ai/miniforge/loop/inner_config.clj
+++ b/components/loop/src/ai/miniforge/loop/inner_config.clj
@@ -15,27 +15,30 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.loop.inner-config
   "Configuration-as-data for the inner loop lifecycle."
   (:require [clojure.edn :as edn]
             [clojure.java.io :as io]))
 
-(def ^:private defaults
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private defaults
   (delay
     (if-let [resource (io/resource "config/loop/inner.edn")]
       (:loop/inner (edn/read-string (slurp resource)))
       {})))
 
-(defn default-max-iterations
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} default-max-iterations
   []
   (get @defaults :default-max-iterations 5))
 
-(defn initial-loop-state
+(defn ^{:stratum 1} initial-loop-state
   []
   (get @defaults :initial-loop-state :pending))
 
-(defn default-loop-metrics
+(defn ^{:stratum 1} default-loop-metrics
   []
   (get @defaults
        :default-loop-metrics
@@ -45,6 +48,6 @@
         :generate-calls 0
         :repair-calls 0}))
 
-(defn machine-definition
+(defn ^{:stratum 1} machine-definition
   []
   (get @defaults :machine-definition {}))

--- a/components/loop/src/ai/miniforge/loop/interface.clj
+++ b/components/loop/src/ai/miniforge/loop/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.loop.interface
   "Public API for the loop component.
    Provides inner loop (generate -> validate -> repair) and outer loop (SDLC phases)
@@ -31,91 +30,99 @@
    [ai.miniforge.loop.interface.protocols.repair-strategy :as repair-proto]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Schema re-exports
 
-(def InnerLoopState
+;; Schema re-exports
+(def ^{:stratum 0} InnerLoopState
   "Malli schema (a `[:map ...]` vector) for the inner loop state machine,
    tracking the generate -> validate -> repair cycle. Use with malli.core
    (m/validate, m/explain)."
   schema/InnerLoopState)
-(def InnerLoopResult
+
+(def ^{:stratum 0} InnerLoopResult
   "Malli schema (a `[:map ...]` vector) for the result of running an inner
    loop to completion: :success, optional :artifact, :iterations, :metrics,
    :termination. Use with malli.core."
   schema/InnerLoopResult)
-(def GateResult
+
+(def ^{:stratum 0} GateResult
   "Malli schema (a `[:map ...]` vector) for the result of running a
    validation gate: :gate/id, :gate/type, :gate/passed?, optional
    :gate/errors, :gate/warnings, :gate/duration-ms. Use with malli.core."
   schema/GateResult)
-(def GateConfig
+
+(def ^{:stratum 0} GateConfig
   "Malli schema (a `[:map ...]` vector) for gate configuration: :gate/id,
    :gate/type, optional :gate/enabled?, :gate/config, :gate/applies-to.
    Use with malli.core."
   schema/GateConfig)
-(def RepairAttempt
+
+(def ^{:stratum 0} RepairAttempt
   "Malli schema (a `[:map ...]` vector) for a single repair attempt:
    :repair/id, :repair/strategy, :repair/iteration, :repair/errors,
    :repair/success?, optional duration and tokens. Use with malli.core."
   schema/RepairAttempt)
-(def LoopMetrics
+
+(def ^{:stratum 0} LoopMetrics
   "Malli schema (a `[:map ...]` vector) for loop execution metrics: optional
    :tokens, :cost-usd, :duration-ms, :generate-calls, :repair-calls.
    Use with malli.core."
   schema/LoopMetrics)
-(def LoopBudget
+
+(def ^{:stratum 0} LoopBudget
   "Malli schema (a `[:map ...]` vector) for loop execution budget
    constraints: optional :max-tokens, :max-cost-usd, :max-duration-ms,
    :max-iterations. Use with malli.core."
   schema/LoopBudget)
-(def OuterLoopState
+
+(def ^{:stratum 0} OuterLoopState
   "Malli schema (a `[:map ...]` vector) for the outer loop state machine,
    tracking the SDLC phases. Use with malli.core."
   schema/OuterLoopState)
 
 ;; Enum values
-(def inner-loop-states
+(def ^{:stratum 0} inner-loop-states
   "Vector of the possible inner-loop state-machine state keywords, in order:
    [:pending :generating :validating :repairing :complete :failed :escalated]."
   schema/inner-loop-states)
-(def outer-loop-phases
+
+(def ^{:stratum 0} outer-loop-phases
   "Vector of the outer-loop SDLC phase keywords, in order:
    [:spec :plan :design :implement :verify :review :release :observe]."
   schema/outer-loop-phases)
-(def gate-types
+
+(def ^{:stratum 0} gate-types
   "Vector of the supported validation-gate type keywords:
    [:syntax :lint :test :policy :custom]."
   schema/gate-types)
-(def repair-strategies
+
+(def ^{:stratum 0} repair-strategies
   "Vector of the available repair-strategy keywords:
    [:llm-fix :retry :escalate]."
   schema/repair-strategies)
-(def termination-reasons
+
+(def ^{:stratum 0} termination-reasons
   "Vector of the loop-termination reason keywords:
    [:gates-passed :max-iterations :budget-exhausted :timeout
     :unrecoverable-error :manual-stop]."
   schema/termination-reasons)
 
-;------------------------------------------------------------------------------ Layer 0
 ;; Protocol re-exports
-
-(def Gate
+(def ^{:stratum 0} Gate
   "Protocol for validation gates. Implement to provide a custom gate;
    methods: (check this artifact context), (gate-id this), (gate-type this),
    (repair this artifact violations context). check returns a gate-result map
    with :gate/passed? and :gate/errors."
   gate-proto/Gate)
-(def RepairStrategy
+
+(def ^{:stratum 0} RepairStrategy
   "Protocol for artifact repair strategies. Implement to provide a custom
    strategy; methods: (can-repair? this errors context) -> boolean, and
    (repair this artifact errors context) -> map with :success?, :artifact or
    :errors, :strategy, optional :tokens-used/:duration-ms."
   repair-proto/RepairStrategy)
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Inner Loop API
-
-(defn create-inner-loop
+(defn ^{:stratum 0} create-inner-loop
   "Create a new inner loop state for a task.
 
    Arguments:
@@ -133,7 +140,7 @@
   ([task] (inner/create-inner-loop task {}))
   ([task context] (inner/create-inner-loop task context)))
 
-(defn run-inner-loop
+(defn ^{:stratum 0} run-inner-loop
   "Run the inner loop to completion.
 
    Arguments:
@@ -160,7 +167,7 @@
   [loop-state generate-fn gates strategies context]
   (inner/run-inner-loop loop-state generate-fn gates strategies context))
 
-(defn run-simple
+(defn ^{:stratum 0} run-simple
   "Simplified inner loop runner with default gates and strategies.
 
    Arguments:
@@ -183,8 +190,7 @@
   (inner/run-simple task generate-fn context))
 
 ;; Step-by-step control
-
-(defn generate-step
+(defn ^{:stratum 0} generate-step
   "Execute the generate step.
    Used for fine-grained control of the loop.
 
@@ -197,7 +203,7 @@
   [loop-state generate-fn context]
   (inner/generate-step loop-state generate-fn context))
 
-(defn validate-step
+(defn ^{:stratum 0} validate-step
   "Execute the validate step.
    Used for fine-grained control of the loop.
 
@@ -210,7 +216,7 @@
   [loop-state gates context]
   (inner/validate-step loop-state gates context))
 
-(defn repair-step
+(defn ^{:stratum 0} repair-step
   "Execute the repair step.
    Used for fine-grained control of the loop.
 
@@ -224,58 +230,53 @@
   (inner/repair-step loop-state strategies context))
 
 ;; Termination checks
-
-(defn should-terminate?
+(defn ^{:stratum 0} should-terminate?
   "Check if the loop should terminate.
    Returns {:terminate? bool :reason keyword} or nil."
   [loop-state]
   (inner/should-terminate? loop-state))
 
-(defn terminal-state?
+(defn ^{:stratum 0} terminal-state?
   "Check if a state is terminal (complete, failed, or escalated)."
   [state]
   (inner/terminal-state? state))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Escalation API
-
-(defn format-error-context
+(defn ^{:stratum 0} format-error-context
   "Format error context for user display."
   [errors iteration artifact]
   (escalation/format-error-context errors iteration artifact))
 
-(defn format-escalation-prompt
+(defn ^{:stratum 0} format-escalation-prompt
   "Format the escalation prompt for user."
   [loop-state]
   (escalation/format-escalation-prompt loop-state))
 
-(defn prompt-user
+(defn ^{:stratum 0} prompt-user
   "Prompt user for input via stdin."
   [prompt-text]
   (escalation/prompt-user prompt-text))
 
-(defn escalate-to-user
+(defn ^{:stratum 0} escalate-to-user
   "Escalate to user for guidance."
   [loop-state & {:keys [prompt-fn]}]
   (escalation/escalate-to-user loop-state :prompt-fn prompt-fn))
 
-(defn handle-escalation
+(defn ^{:stratum 0} handle-escalation
   "Handle escalation in inner loop.
    Context accepts :escalation-fn and optional :prompt-fn."
   [loop-state context]
   (escalation/handle-escalation loop-state context))
 
-(defn create-escalation-checkpoint
+(defn ^{:stratum 0} create-escalation-checkpoint
   "Create a canonical checkpoint for an inner-loop escalation."
   ([loop-state]
    (escalation/create-escalation-checkpoint loop-state))
   ([loop-state opts]
    (escalation/create-escalation-checkpoint loop-state opts)))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Gates API
-
-(defn syntax-gate
+(defn ^{:stratum 0} syntax-gate
   "Create a syntax validation gate.
    Checks that code artifacts can be parsed without errors.
 
@@ -286,7 +287,7 @@
   ([id] (gates/syntax-gate id))
   ([id config] (gates/syntax-gate id config)))
 
-(defn lint-gate
+(defn ^{:stratum 0} lint-gate
   "Create a lint validation gate.
    Options:
    - :fail-on-warning? - If true, warnings cause failure (default false)
@@ -298,7 +299,7 @@
   ([id] (gates/lint-gate id))
   ([id config] (gates/lint-gate id config)))
 
-(defn test-gate
+(defn ^{:stratum 0} test-gate
   "Create a test validation gate.
    Options:
    - :test-fn - Function (fn [artifact context] -> {:passed? bool :errors [...]})"
@@ -306,7 +307,7 @@
   ([id] (gates/test-gate id))
   ([id config] (gates/test-gate id config)))
 
-(defn policy-gate
+(defn ^{:stratum 0} policy-gate
   "Create a policy validation gate.
    Options:
    - :policies - Vector of policy keywords to check
@@ -318,7 +319,7 @@
   ([id] (gates/policy-gate id))
   ([id config] (gates/policy-gate id config)))
 
-(defn custom-gate
+(defn ^{:stratum 0} custom-gate
   "Create a custom validation gate.
    Arguments:
    - id - Unique gate identifier
@@ -326,7 +327,7 @@
   ([id check-fn] (gates/custom-gate id check-fn))
   ([id type-kw check-fn] (gates/custom-gate id type-kw check-fn)))
 
-(defn default-gates
+(defn ^{:stratum 0} default-gates
   "Create a default set of gates for code artifacts.
    Options:
    - :lint-fail-on-warning? - Lint gate fails on warnings (default false)
@@ -334,24 +335,24 @@
   [& opts]
   (apply gates/default-gates opts))
 
-(defn minimal-gates
+(defn ^{:stratum 0} minimal-gates
   "Create a minimal set of gates (syntax only)."
   []
   (gates/minimal-gates))
 
-(defn strict-gates
+(defn ^{:stratum 0} strict-gates
   "Create a strict set of gates for production code.
    Includes all policies and fails on warnings."
   []
   (gates/strict-gates))
 
-(defn check-gate
+(defn ^{:stratum 0} check-gate
   "Run a single gate check on an artifact.
    Returns gate result map with :gate/id, :gate/type, :gate/passed?, etc."
   [gate artifact context]
   (gates/check gate artifact context))
 
-(defn run-gates
+(defn ^{:stratum 0} run-gates
   "Run multiple gates against an artifact.
    Options:
    - :fail-fast? - Stop on first failure (default false)
@@ -365,52 +366,49 @@
   (apply gates/run-gates gates artifact context opts))
 
 ;; Gate result helpers
-
-(defn pass-result
+(defn ^{:stratum 0} pass-result
   "Create a passing gate result."
   [gate-id gate-type & opts]
   (apply gates/pass-result gate-id gate-type opts))
 
-(defn fail-result
+(defn ^{:stratum 0} fail-result
   "Create a failing gate result."
   [gate-id gate-type errors & opts]
   (apply gates/fail-result gate-id gate-type errors opts))
 
-(defn make-error
+(defn ^{:stratum 0} make-error
   "Create a gate error map."
   [code message & opts]
   (apply gates/make-error code message opts))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Repair API
-
-(defn llm-fix-strategy
+(defn ^{:stratum 0} llm-fix-strategy
   "Create an LLM-based repair strategy.
    Options:
    - :max-tokens - Maximum tokens for repair attempt (default 4000)"
   ([] (repair/llm-fix-strategy))
   ([config] (repair/llm-fix-strategy config)))
 
-(defn retry-strategy
+(defn ^{:stratum 0} retry-strategy
   "Create a simple retry strategy.
    Options:
    - :delay-ms - Delay before retry in milliseconds (default 1000)"
   ([] (repair/retry-strategy))
   ([config] (repair/retry-strategy config)))
 
-(defn escalate-strategy
+(defn ^{:stratum 0} escalate-strategy
   "Create an escalation strategy.
    This strategy always signals escalation to the outer loop."
   ([] (repair/escalate-strategy))
   ([config] (repair/escalate-strategy config)))
 
-(defn default-strategies
+(defn ^{:stratum 0} default-strategies
   "Create a default ordered list of repair strategies.
    Order: LLM fix -> Retry -> Escalate"
   []
   (repair/default-strategies))
 
-(defn attempt-repair
+(defn ^{:stratum 0} attempt-repair
   "Attempt to repair an artifact using available strategies.
    Options:
    - :max-attempts - Maximum repair attempts (default 3)
@@ -424,21 +422,18 @@
   (apply repair/attempt-repair strategies artifact errors context opts))
 
 ;; Repair result helpers
-
-(defn repair-success
+(defn ^{:stratum 0} repair-success
   "Create a successful repair result."
   [strategy artifact & opts]
   (apply repair/repair-success strategy artifact opts))
 
-(defn repair-failure
+(defn ^{:stratum 0} repair-failure
   "Create a failed repair result."
   [strategy errors & opts]
   (apply repair/repair-failure strategy errors opts))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Outer Loop API (P1 - stubs)
-
-(defn create-outer-loop
+(defn ^{:stratum 0} create-outer-loop
   "Create a new outer loop state.
    NOTE: Outer loop is a P1 stub implementation.
 
@@ -448,42 +443,42 @@
   ([spec] (outer/create-outer-loop spec {}))
   ([spec context] (outer/create-outer-loop spec context)))
 
-(defn advance-phase
+(defn ^{:stratum 0} advance-phase
   "Advance to the next phase.
    NOTE: Stub implementation."
   [loop-state context]
   (outer/advance-phase loop-state context))
 
-(defn rollback-phase
+(defn ^{:stratum 0} rollback-phase
   "Rollback to a previous phase.
    NOTE: Stub implementation."
   [loop-state target-phase context]
   (outer/rollback-phase loop-state target-phase context))
 
-(defn get-current-phase
+(defn ^{:stratum 0} get-current-phase
   "Get the current phase of the outer loop."
   [loop-state]
   (outer/get-current-phase loop-state))
 
-(defn run-outer-loop
+(defn ^{:stratum 0} run-outer-loop
   "Run the outer loop through all phases.
    NOTE: Stub implementation."
   [loop-state context]
   (outer/run-outer-loop loop-state context))
 
 ;; Phase definitions
-
-(def phases
+(def ^{:stratum 0} phases
   "Vector of the ordered outer-loop phase keywords:
    [:spec :plan :design :implement :verify :review :release :observe]."
   outer/phases)
-(def phase-definitions
+
+(def ^{:stratum 0} phase-definitions
   "Map keyed by phase keyword to its metadata map (:phase/id,
    :phase/description, :phase/agent, :phase/artifacts, :phase/requires).
    Look up a single phase with get-phase-definition."
   outer/phase-definitions)
 
-(defn get-phase-definition
+(defn ^{:stratum 0} get-phase-definition
   "Get the definition for a phase."
   [phase]
   (outer/get-phase-definition phase))

--- a/components/loop/src/ai/miniforge/loop/interface/protocols/gate.clj
+++ b/components/loop/src/ai/miniforge/loop/interface/protocols/gate.clj
@@ -15,14 +15,15 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.loop.interface.protocols.gate
   "Public protocol for validation gates.
 
    This is an extensibility point - users can implement custom gates
    by implementing this protocol.")
 
-(defprotocol Gate
+;------------------------------------------------------------------------------ Layer 0
+
+(defprotocol ^{:stratum 0} Gate
   "Protocol for validation gates.
    Gates check artifacts and return pass/fail results with errors."
   (check [this artifact context]

--- a/components/loop/src/ai/miniforge/loop/interface/protocols/repair_strategy.clj
+++ b/components/loop/src/ai/miniforge/loop/interface/protocols/repair_strategy.clj
@@ -15,14 +15,15 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.loop.interface.protocols.repair-strategy
   "Public protocol for artifact repair strategies.
 
    This is an extensibility point - users can implement custom repair
    strategies by implementing this protocol.")
 
-(defprotocol RepairStrategy
+;------------------------------------------------------------------------------ Layer 0
+
+(defprotocol ^{:stratum 0} RepairStrategy
   "Protocol for artifact repair strategies.
    Strategies attempt to fix validation errors in artifacts."
   (can-repair? [this errors context]

--- a/components/loop/src/ai/miniforge/loop/messages.clj
+++ b/components/loop/src/ai/miniforge/loop/messages.clj
@@ -15,13 +15,14 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.loop.messages
   "Component-level message catalog for loop.
    Delegates to the shared messages component."
   (:require [ai.miniforge.messages.interface :as messages]))
 
-(def t
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} t
   "Look up a loop message by key, with optional param substitution."
   (messages/create-translator "config/loop/messages/en-US.edn"
                               :loop/messages))

--- a/components/loop/src/ai/miniforge/loop/outer.clj
+++ b/components/loop/src/ai/miniforge/loop/outer.clj
@@ -15,16 +15,30 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.loop.outer
   "Outer loop state machine implementation.
    Manages the SDLC phases: spec -> plan -> design -> implement -> verify -> review -> release -> observe
 
    NOTE: This is a P1 stub implementation. Full implementation in future iteration.
 
-   Layer 0: Phase definitions and state transitions
-   Layer 1: Loop state management
-   Layer 2: Phase execution (stub)"
+   9 real layers (over the 3-layer budget; a namespace split is
+   deferred to Wave 2, see work/stratum-lint-baseline-2026-07-24.md):
+   Layer 0: phases, initial-phase, final-phase, phase-definitions,
+     rollback-event, add-history-entry, add-artifact, phase-succeeded?,
+     log-phase — no same-file dependents among them
+   Layer 1: rollback-transitions (calls phases, rollback-event),
+     get-phase-definition (calls phase-definitions)
+   Layer 2: phase-transition-map (calls rollback-transitions), run-phase
+     (calls get-phase-definition, log-phase, phase-succeeded?)
+   Layer 3: phase-machine-config (calls phase-transition-map)
+   Layer 4: phase-machine (calls phase-machine-config)
+   Layer 5: phase-fsm-state, create-outer-loop (both call phase-machine)
+   Layer 6: current-phase, transition-phase, is-complete? (call
+     phase-fsm-state and/or phase-machine)
+   Layer 7: valid-phase-transition?, get-current-phase, advance-phase,
+     rollback-phase (call transition-phase and/or current-phase)
+   Layer 8: run-outer-loop (calls advance-phase, run-phase,
+     is-complete?)"
   (:require
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.fsm.interface :as fsm]
@@ -33,20 +47,20 @@
    [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Phase definitions
 
-(def phases
+;; Phase definitions
+(def ^{:stratum 0} phases
   [:spec :plan :design :implement :verify :review :release :observe])
 
-(def ^:private initial-phase
+(def ^{:stratum 0} ^:private initial-phase
   "Initial outer-loop phase."
   :spec)
 
-(def ^:private final-phase
+(def ^{:stratum 0} ^:private final-phase
   "Terminal outer-loop phase."
   :observe)
 
-(def phase-definitions
+(def ^{:stratum 0} phase-definitions
   {:spec     {:phase/id :spec
               :phase/description (loop-messages/t :outer/spec-description)
               :phase/agent nil  ; No agent, external input
@@ -95,122 +109,12 @@
               :phase/artifacts [:telemetry]
               :phase/requires [:release]}})
 
-(defn- rollback-event
+(defn- ^{:stratum 0} rollback-event
   "Build the rollback event for a target phase."
   [target-phase]
   (keyword "loop" (str "rollback-to-" (name target-phase))))
 
-(defn- rollback-transitions
-  "Build rollback transitions for a phase."
-  [phase]
-  (->> phases
-       (take-while #(not= % phase))
-       (map (fn [target-phase]
-              [(rollback-event target-phase) target-phase]))
-       (into {})))
-
-(defn- phase-transition-map
-  "Build the transition map for a phase state."
-  [phase]
-  (let [next-phase (second (drop-while #(not= % phase) phases))
-        advance-transition (when next-phase {:loop/advance next-phase})
-        rollback-transition (rollback-transitions phase)
-        transitions (merge advance-transition rollback-transition)]
-    (cond-> {}
-      (seq transitions) (assoc :on transitions)
-      (= phase final-phase) (assoc :type :final))))
-
-(def ^:private phase-machine-config
-  "Outer-loop phase machine configuration."
-  {:fsm/id :outer-loop-phases
-   :fsm/initial initial-phase
-   :fsm/context {}
-   :fsm/states (into {}
-                     (map (fn [phase]
-                            [phase (phase-transition-map phase)]))
-                     phases)})
-
-(def ^:private phase-machine
-  "Compiled outer-loop phase machine."
-  (fsm/define-machine phase-machine-config))
-
-(defn- phase-fsm-state
-  "Get the authoritative phase machine snapshot."
-  [loop-state]
-  (get loop-state :loop/fsm-state (fsm/initialize phase-machine)))
-
-(defn- current-phase
-  "Get the authoritative phase from the FSM snapshot."
-  [loop-state]
-  (fsm/current-state (phase-fsm-state loop-state)))
-
-(defn- transition-phase
-  "Apply an outer-loop phase transition.
-
-   Returns updated loop state, or nil if the transition is forbidden — the FSM
-   has no such event from the current state (advancing past the terminal
-   :observe phase, rolling back to a later phase, etc.). The FSM raises
-   :anomalies/fsm-unknown-event for a forbidden transition through its
-   anomaly-returning result API; that one anomaly is converted to the documented
-   nil here (callers — advance-phase, rollback-phase, valid-phase-transition? —
-   branch on nil). Any other failure propagates from the FSM result API."
-  [loop-state event]
-  (let [current-state (phase-fsm-state loop-state)
-        current-phase (fsm/current-state current-state)
-        transitioned (fsm/transition-result phase-machine current-state event)]
-    (when-not (anomaly/anomaly? transitioned)
-      (let [next-phase (fsm/current-state transitioned)]
-        (when (and next-phase
-                   (not= current-phase next-phase))
-          (assoc loop-state
-                 :loop/fsm-state transitioned
-                 :loop/phase next-phase
-                 :loop/updated-at (java.util.Date.)))))))
-
-(defn valid-phase-transition?
-  "Check whether a phase transition event is allowed."
-  [phase event]
-  (some? (transition-phase {:loop/fsm-state {:_state phase}
-                            :loop/phase phase}
-                           event)))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Outer loop state management
-
-(defn create-outer-loop
-  "Create a new outer loop state.
-
-   Arguments:
-   - spec - Map with :spec/id and spec content
-   - context - Optional context map with :config, :budget, etc."
-  [spec context]
-  (let [created-at (java.util.Date.)
-        fsm-state (fsm/initialize phase-machine)
-        loop-phase (fsm/current-state fsm-state)]
-    {:loop/id (random-uuid)
-     :loop/type :outer
-     :loop/fsm-state fsm-state
-     :loop/phase loop-phase
-     :loop/spec {:spec/id (or (:spec/id spec) (random-uuid))}
-     :loop/artifacts {}
-     :loop/history [{:phase loop-phase
-                     :timestamp created-at
-                     :outcome :entered}]
-     :loop/config (get context :config {})
-     :loop/created-at created-at
-     :loop/updated-at created-at}))
-
-(defn get-current-phase
-  "Get the current phase of the outer loop."
-  [loop-state]
-  (current-phase loop-state))
-
-(defn get-phase-definition
-  "Get the definition for a phase."
-  [phase]
-  (get phase-definitions phase))
-
-(defn add-history-entry
+(defn ^{:stratum 0} add-history-entry
   "Add an entry to the loop history."
   [loop-state phase outcome & {:keys [message data]}]
   (update loop-state :loop/history conj
@@ -220,23 +124,20 @@
             message (assoc :message message)
             data (assoc :data data))))
 
-(defn add-artifact
+(defn ^{:stratum 0} add-artifact
   "Add an artifact reference to the loop state."
   [loop-state artifact-type artifact-id]
   (assoc-in loop-state [:loop/artifacts artifact-type] artifact-id))
 
-;------------------------------------------------------------------------------ Layer 1.5
 ;; Result helpers
-
-(defn phase-succeeded?
+(defn ^{:stratum 0} phase-succeeded?
   "Check if a phase result indicates success (supports both :success? and :status patterns)."
   [result]
   (or (:success? result)
       (response/success? result)))
 
 ;; Logging helpers
-
-(defn log-phase
+(defn ^{:stratum 0} log-phase
   "Log a phase event at the specified level, only when logger is available."
   [logger level event-kw phase message & [extra-data]]
   (when logger
@@ -247,54 +148,36 @@
         :warn (log/warn logger :loop event-kw entry)
         :error (log/error logger :loop event-kw entry)))))
 
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} rollback-transitions
+  "Build rollback transitions for a phase."
+  [phase]
+  (->> phases
+       (take-while #(not= % phase))
+       (map (fn [target-phase]
+              [(rollback-event target-phase) target-phase]))
+       (into {})))
+
+(defn ^{:stratum 1} get-phase-definition
+  "Get the definition for a phase."
+  [phase]
+  (get phase-definitions phase))
+
 ;------------------------------------------------------------------------------ Layer 2
-;; Phase execution (stubs)
 
-(defn advance-phase
-  "Advance to the next phase.
-   Stub implementation - just transitions without running inner loops.
+(defn- ^{:stratum 2} phase-transition-map
+  "Build the transition map for a phase state."
+  [phase]
+  (let [next-phase (second (drop-while #(not= % phase) phases))
+        advance-transition (when next-phase {:loop/advance next-phase})
+        rollback-transition (rollback-transitions phase)
+        transitions (merge advance-transition rollback-transition)]
+    (cond-> {}
+      (seq transitions) (assoc :on transitions)
+      (= phase final-phase) (assoc :type :final))))
 
-   Returns updated loop state or nil if cannot advance."
-  [loop-state context]
-  (let [logger (:logger context)
-        current (current-phase loop-state)
-        advanced-state (transition-phase loop-state :loop/advance)
-        next-phase (some-> advanced-state current-phase)]
-    (log-phase logger :info :outer/phase-completed current (loop-messages/t :outer/phase-completed))
-    (if advanced-state
-      (do
-        (log-phase logger :info :outer/phase-entered next-phase (loop-messages/t :outer/phase-entered))
-        (-> advanced-state
-            (add-history-entry current :completed)
-            (add-history-entry next-phase :entered)))
-      ;; Cannot advance or at end
-      (log-phase logger :warn :outer/phase-failed current (loop-messages/t :outer/cannot-advance-phase)
-                 {:next next-phase}))))
-
-(defn rollback-phase
-  "Rollback to a previous phase.
-   Stub implementation - just transitions without cleanup.
-
-   Returns updated loop state or nil if invalid rollback."
-  [loop-state target-phase context]
-  (let [logger (:logger context)
-        current (current-phase loop-state)
-        rollback-state (transition-phase loop-state (rollback-event target-phase))]
-    (if rollback-state
-      (do
-        (log-phase logger :warn :outer/phase-failed current (loop-messages/t :outer/rolling-back)
-                   {:to target-phase})
-        (-> rollback-state
-            (add-history-entry current :rolled-back
-                               :data {:target target-phase})
-            (add-history-entry target-phase :entered
-                               :message (loop-messages/t :outer/entered-via-rollback))))
-      (do
-        (log-phase logger :error :outer/phase-failed current (loop-messages/t :outer/invalid-rollback-target)
-                   {:target target-phase})
-        nil))))
-
-(defn run-phase
+(defn ^{:stratum 2} run-phase
   "Run the current phase using the appropriate agent.
 
    Delegates to the phase interceptor registry for real execution.
@@ -335,12 +218,152 @@
                                           (:phase/artifacts definition))
                          :phase phase}))))
 
-(defn is-complete?
+;------------------------------------------------------------------------------ Layer 3
+
+(def ^{:stratum 3} ^:private phase-machine-config
+  "Outer-loop phase machine configuration."
+  {:fsm/id :outer-loop-phases
+   :fsm/initial initial-phase
+   :fsm/context {}
+   :fsm/states (into {}
+                     (map (fn [phase]
+                            [phase (phase-transition-map phase)]))
+                     phases)})
+
+;------------------------------------------------------------------------------ Layer 4
+
+(def ^{:stratum 4} ^:private phase-machine
+  "Compiled outer-loop phase machine."
+  (fsm/define-machine phase-machine-config))
+
+;------------------------------------------------------------------------------ Layer 5
+
+(defn- ^{:stratum 5} phase-fsm-state
+  "Get the authoritative phase machine snapshot."
+  [loop-state]
+  (get loop-state :loop/fsm-state (fsm/initialize phase-machine)))
+
+;; Outer loop state management
+(defn ^{:stratum 5} create-outer-loop
+  "Create a new outer loop state.
+
+   Arguments:
+   - spec - Map with :spec/id and spec content
+   - context - Optional context map with :config, :budget, etc."
+  [spec context]
+  (let [created-at (java.util.Date.)
+        fsm-state (fsm/initialize phase-machine)
+        loop-phase (fsm/current-state fsm-state)]
+    {:loop/id (random-uuid)
+     :loop/type :outer
+     :loop/fsm-state fsm-state
+     :loop/phase loop-phase
+     :loop/spec {:spec/id (or (:spec/id spec) (random-uuid))}
+     :loop/artifacts {}
+     :loop/history [{:phase loop-phase
+                     :timestamp created-at
+                     :outcome :entered}]
+     :loop/config (get context :config {})
+     :loop/created-at created-at
+     :loop/updated-at created-at}))
+
+;------------------------------------------------------------------------------ Layer 6
+
+(defn- ^{:stratum 6} current-phase
+  "Get the authoritative phase from the FSM snapshot."
+  [loop-state]
+  (fsm/current-state (phase-fsm-state loop-state)))
+
+(defn- ^{:stratum 6} transition-phase
+  "Apply an outer-loop phase transition.
+
+   Returns updated loop state, or nil if the transition is forbidden — the FSM
+   has no such event from the current state (advancing past the terminal
+   :observe phase, rolling back to a later phase, etc.). The FSM raises
+   :anomalies/fsm-unknown-event for a forbidden transition through its
+   anomaly-returning result API; that one anomaly is converted to the documented
+   nil here (callers — advance-phase, rollback-phase, valid-phase-transition? —
+   branch on nil). Any other failure propagates from the FSM result API."
+  [loop-state event]
+  (let [current-state (phase-fsm-state loop-state)
+        current-phase (fsm/current-state current-state)
+        transitioned (fsm/transition-result phase-machine current-state event)]
+    (when-not (anomaly/anomaly? transitioned)
+      (let [next-phase (fsm/current-state transitioned)]
+        (when (and next-phase
+                   (not= current-phase next-phase))
+          (assoc loop-state
+                 :loop/fsm-state transitioned
+                 :loop/phase next-phase
+                 :loop/updated-at (java.util.Date.)))))))
+
+(defn ^{:stratum 6} is-complete?
   "Check if the outer loop has completed all phases."
   [loop-state]
   (fsm/final? phase-machine (phase-fsm-state loop-state)))
 
-(defn run-outer-loop
+;------------------------------------------------------------------------------ Layer 7
+
+(defn ^{:stratum 7} valid-phase-transition?
+  "Check whether a phase transition event is allowed."
+  [phase event]
+  (some? (transition-phase {:loop/fsm-state {:_state phase}
+                            :loop/phase phase}
+                           event)))
+
+(defn ^{:stratum 7} get-current-phase
+  "Get the current phase of the outer loop."
+  [loop-state]
+  (current-phase loop-state))
+
+;; Phase execution (stubs)
+(defn ^{:stratum 7} advance-phase
+  "Advance to the next phase.
+   Stub implementation - just transitions without running inner loops.
+
+   Returns updated loop state or nil if cannot advance."
+  [loop-state context]
+  (let [logger (:logger context)
+        current (current-phase loop-state)
+        advanced-state (transition-phase loop-state :loop/advance)
+        next-phase (some-> advanced-state current-phase)]
+    (log-phase logger :info :outer/phase-completed current (loop-messages/t :outer/phase-completed))
+    (if advanced-state
+      (do
+        (log-phase logger :info :outer/phase-entered next-phase (loop-messages/t :outer/phase-entered))
+        (-> advanced-state
+            (add-history-entry current :completed)
+            (add-history-entry next-phase :entered)))
+      ;; Cannot advance or at end
+      (log-phase logger :warn :outer/phase-failed current (loop-messages/t :outer/cannot-advance-phase)
+                 {:next next-phase}))))
+
+(defn ^{:stratum 7} rollback-phase
+  "Rollback to a previous phase.
+   Stub implementation - just transitions without cleanup.
+
+   Returns updated loop state or nil if invalid rollback."
+  [loop-state target-phase context]
+  (let [logger (:logger context)
+        current (current-phase loop-state)
+        rollback-state (transition-phase loop-state (rollback-event target-phase))]
+    (if rollback-state
+      (do
+        (log-phase logger :warn :outer/phase-failed current (loop-messages/t :outer/rolling-back)
+                   {:to target-phase})
+        (-> rollback-state
+            (add-history-entry current :rolled-back
+                               :data {:target target-phase})
+            (add-history-entry target-phase :entered
+                               :message (loop-messages/t :outer/entered-via-rollback))))
+      (do
+        (log-phase logger :error :outer/phase-failed current (loop-messages/t :outer/invalid-rollback-target)
+                   {:target target-phase})
+        nil))))
+
+;------------------------------------------------------------------------------ Layer 8
+
+(defn ^{:stratum 8} run-outer-loop
   "Run the outer loop through all phases.
    Stub implementation - advances through phases without real execution.
 

--- a/components/loop/src/ai/miniforge/loop/repair.clj
+++ b/components/loop/src/ai/miniforge/loop/repair.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.loop.repair
   "Repair strategy protocol and built-in implementations.
 
@@ -23,30 +22,41 @@
    - ai.miniforge.loop.interface.protocols.repair-strategy (RepairStrategy protocol)
 
    This namespace contains the built-in repair strategy implementations.
-   Layer 0: Pure functions for repair results
-   Layer 1: Built-in strategies (llm-fix, retry, escalate)
-   Layer 2: Repair orchestration"
+   Layer 0: protocol re-exports, result predicates/constructors
+     (succeeded?, repair-success, repair-failure, the make-*-result
+     helpers, create-repair-attempt), and the EscalateStrategy
+     defrecord — no same-file dependents among them
+   Layer 1: the LLMFixStrategy/RetryStrategy defrecords (call the Layer
+     0 result constructors), escalate-strategy (constructs an
+     EscalateStrategy), and the orchestration helpers (select-strategy,
+     try-repair-with-strategy, process-repair-result)
+   Layer 2: llm-fix-strategy, retry-strategy (construct the matching
+     Layer 1 defrecord), attempt-repair (calls the Layer 1 orchestration
+     helpers)
+   Layer 3: default-strategies (calls llm-fix-strategy, retry-strategy,
+     escalate-strategy)"
   (:require
    [ai.miniforge.loop.interface.protocols.repair-strategy :as p]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.loop.messages :as messages]))
 
-;; Re-export protocol for backward compatibility
-(def RepairStrategy p/RepairStrategy)
-(def can-repair? p/can-repair?)
-(def repair p/repair)
-
 ;------------------------------------------------------------------------------ Layer 0
-;; Repair result predicates
 
-(defn succeeded?
+;; Re-export protocol for backward compatibility
+(def ^{:stratum 0} RepairStrategy p/RepairStrategy)
+
+(def ^{:stratum 0} can-repair? p/can-repair?)
+
+(def ^{:stratum 0} repair p/repair)
+
+;; Repair result predicates
+(defn ^{:stratum 0} succeeded?
   "Check if a repair result indicates success."
   [result]
   (boolean (:success? result)))
 
 ;; Repair result constructors (pure functions)
-
-(defn repair-success
+(defn ^{:stratum 0} repair-success
   "Create a successful repair result."
   [strategy artifact & {:keys [tokens-used duration-ms message]}]
   (cond-> {:success? true
@@ -56,7 +66,7 @@
     duration-ms (assoc :duration-ms duration-ms)
     message (assoc :message message)))
 
-(defn repair-failure
+(defn ^{:stratum 0} repair-failure
   "Create a failed repair result."
   [strategy errors & {:keys [tokens-used duration-ms message]}]
   (cond-> {:success? false
@@ -66,10 +76,81 @@
     duration-ms (assoc :duration-ms duration-ms)
     message (assoc :message message)))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Built-in repair strategies
+(defrecord ^{:stratum 0} EscalateStrategy [_config]
+  p/RepairStrategy
+  (can-repair? [_this _errors _context]
+    ;; Escalate can always be used as a last resort
+    true)
 
-(defrecord LLMFixStrategy [config]
+  (repair [_this artifact errors context]
+    (let [start (System/currentTimeMillis)
+          logger (:logger context)]
+      (when logger
+        (log/warn logger :loop :inner/escalated
+                  {:message (messages/t :repair/escalating)
+                   :data {:error-count (count errors)
+                          :error-codes (mapv :code errors)}}))
+      ;; Escalation signals that the inner loop cannot handle this
+      {:success? false
+       :escalate? true
+       :artifact artifact
+       :errors errors
+       :strategy :escalate
+       :duration-ms (- (System/currentTimeMillis) start)
+       :message (messages/t :repair/escalating-resolution)})))
+
+(defn ^{:stratum 0} make-max-attempts-result
+  "Create a result map for max attempts exceeded."
+  [attempt results errors]
+  {:success? false
+   :attempts attempt
+   :results results
+   :errors errors
+   :message (messages/t :repair/max-attempts-exceeded)})
+
+(defn ^{:stratum 0} make-exhausted-strategies-result
+  "Create a result map for exhausted strategies."
+  [attempt results errors]
+  {:success? false
+   :attempts attempt
+   :results results
+   :errors errors
+   :message (messages/t :repair/strategies-exhausted)})
+
+(defn ^{:stratum 0} make-success-result
+  "Create a result map for successful repair."
+  [result attempt results]
+  {:success? true
+   :artifact (:artifact result)
+   :attempts (inc attempt)
+   :results (conj results result)
+   :strategy (:strategy result)})
+
+(defn ^{:stratum 0} make-escalation-result
+  "Create a result map for escalation."
+  [result attempt results errors]
+  {:success? false
+   :escalate? true
+   :attempts (inc attempt)
+   :results (conj results result)
+   :errors errors
+   :message (messages/t :repair/escalated)})
+
+(defn ^{:stratum 0} create-repair-attempt
+  "Create a repair attempt record for loop history."
+  [strategy iteration errors result]
+  {:repair/id (random-uuid)
+   :repair/strategy strategy
+   :repair/iteration iteration
+   :repair/errors errors
+   :repair/success? (:success? result false)
+   :repair/duration-ms (:duration-ms result)
+   :repair/tokens-used (:tokens-used result)})
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Built-in repair strategies
+(defrecord ^{:stratum 1} LLMFixStrategy [config]
   p/RepairStrategy
   (can-repair? [_this errors _context]
     ;; LLM can attempt to fix most errors except hardware/infrastructure issues
@@ -113,15 +194,7 @@
                           :message (messages/t :repair/no-repair-fn)}]
                         :duration-ms (- (System/currentTimeMillis) start))))))
 
-(defn llm-fix-strategy
-  "Create an LLM-based repair strategy.
-   Options:
-   - :max-tokens - Maximum tokens for repair attempt (default 4000)"
-  ([] (llm-fix-strategy {}))
-  ([config] (->LLMFixStrategy config)))
-
-
-(defrecord RetryStrategy [config]
+(defrecord ^{:stratum 1} RetryStrategy [config]
   p/RepairStrategy
   (can-repair? [_this errors _context]
     ;; Retry is suitable for transient errors
@@ -144,97 +217,27 @@
                       :duration-ms (- (System/currentTimeMillis) start)
                       :message (messages/t :repair/retry-completed)))))
 
-(defn retry-strategy
-  "Create a simple retry strategy.
-   Options:
-   - :delay-ms - Delay before retry in milliseconds (default 1000)"
-  ([] (retry-strategy {}))
-  ([config] (->RetryStrategy config)))
-
-
-(defrecord EscalateStrategy [_config]
-  p/RepairStrategy
-  (can-repair? [_this _errors _context]
-    ;; Escalate can always be used as a last resort
-    true)
-
-  (repair [_this artifact errors context]
-    (let [start (System/currentTimeMillis)
-          logger (:logger context)]
-      (when logger
-        (log/warn logger :loop :inner/escalated
-                  {:message (messages/t :repair/escalating)
-                   :data {:error-count (count errors)
-                          :error-codes (mapv :code errors)}}))
-      ;; Escalation signals that the inner loop cannot handle this
-      {:success? false
-       :escalate? true
-       :artifact artifact
-       :errors errors
-       :strategy :escalate
-       :duration-ms (- (System/currentTimeMillis) start)
-       :message (messages/t :repair/escalating-resolution)})))
-
-(defn escalate-strategy
+(defn ^{:stratum 1} escalate-strategy
   "Create an escalation strategy.
    This strategy always signals escalation to the outer loop."
   ([] (escalate-strategy {}))
   ([config] (->EscalateStrategy config)))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Repair orchestration
-
-(defn select-strategy
+(defn ^{:stratum 1} select-strategy
   "Select the first applicable repair strategy for the given errors.
    Returns nil if no strategy can handle the errors."
   [strategies errors context]
   (first (filter #(can-repair? % errors context) strategies)))
 
-(defn make-max-attempts-result
-  "Create a result map for max attempts exceeded."
-  [attempt results errors]
-  {:success? false
-   :attempts attempt
-   :results results
-   :errors errors
-   :message (messages/t :repair/max-attempts-exceeded)})
-
-(defn make-exhausted-strategies-result
-  "Create a result map for exhausted strategies."
-  [attempt results errors]
-  {:success? false
-   :attempts attempt
-   :results results
-   :errors errors
-   :message (messages/t :repair/strategies-exhausted)})
-
-(defn make-success-result
-  "Create a result map for successful repair."
-  [result attempt results]
-  {:success? true
-   :artifact (:artifact result)
-   :attempts (inc attempt)
-   :results (conj results result)
-   :strategy (:strategy result)})
-
-(defn make-escalation-result
-  "Create a result map for escalation."
-  [result attempt results errors]
-  {:success? false
-   :escalate? true
-   :attempts (inc attempt)
-   :results (conj results result)
-   :errors errors
-   :message (messages/t :repair/escalated)})
-
-(defn try-repair-with-strategy
+(defn ^{:stratum 1} try-repair-with-strategy
   "Try to repair using a single strategy.
    Returns result map or nil if strategy can't handle errors."
   [strategy artifact errors context]
   (when (can-repair? strategy errors context)
     (repair strategy artifact errors context)))
 
-(defn process-repair-result
+(defn ^{:stratum 1} process-repair-result
   "Process the result of a repair attempt.
    Returns a map with :action (:success, :escalate, or :continue) and :result."
   [result attempt results errors]
@@ -251,7 +254,23 @@
     {:action :continue
      :result result}))
 
-(defn attempt-repair
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} llm-fix-strategy
+  "Create an LLM-based repair strategy.
+   Options:
+   - :max-tokens - Maximum tokens for repair attempt (default 4000)"
+  ([] (llm-fix-strategy {}))
+  ([config] (->LLMFixStrategy config)))
+
+(defn ^{:stratum 2} retry-strategy
+  "Create a simple retry strategy.
+   Options:
+   - :delay-ms - Delay before retry in milliseconds (default 1000)"
+  ([] (retry-strategy {}))
+  ([config] (->RetryStrategy config)))
+
+(defn ^{:stratum 2} attempt-repair
   "Attempt to repair an artifact using available strategies.
    Tries strategies in order until one succeeds or all fail.
 
@@ -296,24 +315,15 @@
                    attempt
                    results)))))))
 
-(defn default-strategies
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} default-strategies
   "Create a default ordered list of repair strategies.
    Order: LLM fix -> Retry -> Escalate"
   []
   [(llm-fix-strategy)
    (retry-strategy)
    (escalate-strategy)])
-
-(defn create-repair-attempt
-  "Create a repair attempt record for loop history."
-  [strategy iteration errors result]
-  {:repair/id (random-uuid)
-   :repair/strategy strategy
-   :repair/iteration iteration
-   :repair/errors errors
-   :repair/success? (:success? result false)
-   :repair/duration-ms (:duration-ms result)
-   :repair/tokens-used (:tokens-used result)})
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/loop/src/ai/miniforge/loop/schema.clj
+++ b/components/loop/src/ai/miniforge/loop/schema.clj
@@ -15,33 +15,42 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.loop.schema
   "Malli schemas for loop state, gates, and repair strategies.
-   Layer 0: Base types and registries
-   Layer 1: Composite schemas (InnerLoopState, GateResult, RepairResult)"
+   Layer 0: enum vectors (inner-loop-states, outer-loop-phases,
+     gate-types, repair-strategies, termination-reasons) — no same-file
+     dependents among them
+   Layer 1: registry (references the Layer 0 enum vectors)
+   Layer 2: GateError, GateConfig, LoopMetrics, LoopBudget,
+     OuterLoopPhase, OuterLoopState (reference registry)
+   Layer 3: GateResult, RepairAttempt (reference GateError),
+     InnerLoopResult (references LoopMetrics)
+   Layer 4: InnerLoopState (references GateResult, RepairAttempt,
+     LoopMetrics, LoopBudget)"
   (:require
    [malli.core :as m]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Base types and enums
 
-(def inner-loop-states
+;; Base types and enums
+(def ^{:stratum 0} inner-loop-states
   [:pending :generating :validating :repairing :complete :failed :escalated])
 
-(def outer-loop-phases
+(def ^{:stratum 0} outer-loop-phases
   [:spec :plan :design :implement :verify :review :release :observe])
 
-(def gate-types
+(def ^{:stratum 0} gate-types
   [:syntax :lint :test :policy :custom])
 
-(def repair-strategies
+(def ^{:stratum 0} repair-strategies
   [:llm-fix :retry :escalate])
 
-(def termination-reasons
+(def ^{:stratum 0} termination-reasons
   [:gates-passed :max-iterations :budget-exhausted :timeout :unrecoverable-error :manual-stop])
 
-(def registry
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} registry
   "Malli registry for loop schema types."
   {;; Identifiers
    :id/uuid        uuid?
@@ -68,10 +77,10 @@
    :common/non-neg-int [:int {:min 0}]
    :common/pos-number [:double {:min 0.0}]})
 
-;------------------------------------------------------------------------------ Layer 1
-;; Gate schemas
+;------------------------------------------------------------------------------ Layer 2
 
-(def GateError
+;; Gate schemas
+(def ^{:stratum 2} GateError
   "Schema for a single gate error."
   [:map {:registry registry}
    [:code keyword?]
@@ -82,7 +91,59 @@
      [:line {:optional true} :common/non-neg-int]
      [:column {:optional true} :common/non-neg-int]]]])
 
-(def GateResult
+(def ^{:stratum 2} GateConfig
+  [:map {:registry registry}
+   [:gate/id :gate/id]
+   [:gate/type :gate/type]
+   [:gate/enabled? {:optional true :default true} boolean?]
+   [:gate/config {:optional true} [:map-of keyword? any?]]
+   [:gate/applies-to {:optional true} [:set keyword?]]])
+
+;; Loop metrics
+(def ^{:stratum 2} LoopMetrics
+  [:map {:registry registry}
+   [:tokens {:optional true} :common/non-neg-int]
+   [:cost-usd {:optional true} :common/pos-number]
+   [:duration-ms {:optional true} :common/non-neg-int]
+   [:generate-calls {:optional true} :common/non-neg-int]
+   [:repair-calls {:optional true} :common/non-neg-int]])
+
+(def ^{:stratum 2} LoopBudget
+  [:map {:registry registry}
+   [:max-tokens {:optional true} :common/non-neg-int]
+   [:max-cost-usd {:optional true} :common/pos-number]
+   [:max-duration-ms {:optional true} :common/non-neg-int]
+   [:max-iterations {:optional true} :common/non-neg-int]])
+
+;; Outer loop state schema (P1 - stub)
+(def ^{:stratum 2} OuterLoopPhase
+  "Schema for outer loop phase definition."
+  [:map {:registry registry}
+   [:phase/id keyword?]
+   [:phase/agent {:optional true} keyword?]
+   [:phase/artifacts {:optional true} [:vector keyword?]]
+   [:phase/requires {:optional true} [:vector keyword?]]])
+
+(def ^{:stratum 2} OuterLoopState
+  "Schema for the outer loop state machine.
+   Tracks the SDLC phases: plan -> design -> implement -> verify -> review -> release -> observe"
+  [:map {:registry registry}
+   [:loop/id :loop/id]
+   [:loop/type [:= :outer]]
+   [:loop/phase (into [:enum] outer-loop-phases)]
+   [:loop/spec {:optional true} [:map [:spec/id :id/uuid]]]
+   [:loop/artifacts {:optional true} [:map-of keyword? :id/uuid]]
+   [:loop/history {:optional true} [:vector [:map
+                                              [:phase keyword?]
+                                              [:timestamp :common/timestamp]
+                                              [:outcome keyword?]]]]
+   [:loop/config {:optional true} [:map-of keyword? any?]]
+   [:loop/created-at {:optional true} :common/timestamp]
+   [:loop/updated-at {:optional true} :common/timestamp]])
+
+;------------------------------------------------------------------------------ Layer 3
+
+(def ^{:stratum 3} GateResult
   [:map {:registry registry}
    [:gate/id :gate/id]
    [:gate/type :gate/type]
@@ -91,18 +152,8 @@
    [:gate/warnings {:optional true} [:vector GateError]]
    [:gate/duration-ms {:optional true} :common/non-neg-int]])
 
-(def GateConfig
-  [:map {:registry registry}
-   [:gate/id :gate/id]
-   [:gate/type :gate/type]
-   [:gate/enabled? {:optional true :default true} boolean?]
-   [:gate/config {:optional true} [:map-of keyword? any?]]
-   [:gate/applies-to {:optional true} [:set keyword?]]])
-
-;------------------------------------------------------------------------------ Layer 1
 ;; Repair schemas
-
-(def RepairAttempt
+(def ^{:stratum 3} RepairAttempt
   [:map {:registry registry}
    [:repair/id :id/uuid]
    [:repair/strategy :repair/strategy]
@@ -112,28 +163,26 @@
    [:repair/duration-ms {:optional true} :common/non-neg-int]
    [:repair/tokens-used {:optional true} :common/non-neg-int]])
 
-;------------------------------------------------------------------------------ Layer 1
-;; Loop metrics
-
-(def LoopMetrics
+;; Inner loop result
+(def ^{:stratum 3} InnerLoopResult
   [:map {:registry registry}
-   [:tokens {:optional true} :common/non-neg-int]
-   [:cost-usd {:optional true} :common/pos-number]
-   [:duration-ms {:optional true} :common/non-neg-int]
-   [:generate-calls {:optional true} :common/non-neg-int]
-   [:repair-calls {:optional true} :common/non-neg-int]])
+   [:success boolean?]
+   [:artifact {:optional true}
+    [:map
+     [:artifact/id :id/uuid]
+     [:artifact/type keyword?]
+     [:artifact/content {:optional true} any?]]]
+   [:iterations :common/non-neg-int]
+   [:metrics {:optional true} LoopMetrics]
+   [:termination {:optional true}
+    [:map
+     [:reason :termination/reason]
+     [:message {:optional true} :id/string]]]])
 
-(def LoopBudget
-  [:map {:registry registry}
-   [:max-tokens {:optional true} :common/non-neg-int]
-   [:max-cost-usd {:optional true} :common/pos-number]
-   [:max-duration-ms {:optional true} :common/non-neg-int]
-   [:max-iterations {:optional true} :common/non-neg-int]])
+;------------------------------------------------------------------------------ Layer 4
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Inner loop state schema
-
-(def InnerLoopState
+(def ^{:stratum 4} InnerLoopState
   [:map {:registry registry}
    ;; Required fields
    [:loop/id :loop/id]
@@ -185,52 +234,6 @@
     [:map
      [:reason :termination/reason]
      [:message {:optional true} :id/string]]]])
-
-;------------------------------------------------------------------------------ Layer 1
-;; Inner loop result
-
-(def InnerLoopResult
-  [:map {:registry registry}
-   [:success boolean?]
-   [:artifact {:optional true}
-    [:map
-     [:artifact/id :id/uuid]
-     [:artifact/type keyword?]
-     [:artifact/content {:optional true} any?]]]
-   [:iterations :common/non-neg-int]
-   [:metrics {:optional true} LoopMetrics]
-   [:termination {:optional true}
-    [:map
-     [:reason :termination/reason]
-     [:message {:optional true} :id/string]]]])
-
-;------------------------------------------------------------------------------ Layer 1
-;; Outer loop state schema (P1 - stub)
-
-(def OuterLoopPhase
-  "Schema for outer loop phase definition."
-  [:map {:registry registry}
-   [:phase/id keyword?]
-   [:phase/agent {:optional true} keyword?]
-   [:phase/artifacts {:optional true} [:vector keyword?]]
-   [:phase/requires {:optional true} [:vector keyword?]]])
-
-(def OuterLoopState
-  "Schema for the outer loop state machine.
-   Tracks the SDLC phases: plan -> design -> implement -> verify -> review -> release -> observe"
-  [:map {:registry registry}
-   [:loop/id :loop/id]
-   [:loop/type [:= :outer]]
-   [:loop/phase (into [:enum] outer-loop-phases)]
-   [:loop/spec {:optional true} [:map [:spec/id :id/uuid]]]
-   [:loop/artifacts {:optional true} [:map-of keyword? :id/uuid]]
-   [:loop/history {:optional true} [:vector [:map
-                                              [:phase keyword?]
-                                              [:timestamp :common/timestamp]
-                                              [:outcome keyword?]]]]
-   [:loop/config {:optional true} [:map-of keyword? any?]]
-   [:loop/created-at {:optional true} :common/timestamp]
-   [:loop/updated-at {:optional true} :common/timestamp]])
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/loop/test/ai/miniforge/loop/escalation_test.clj
+++ b/components/loop/test/ai/miniforge/loop/escalation_test.clj
@@ -15,15 +15,14 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.loop.escalation-test
   (:require [clojure.test :as test :refer [deftest testing is]]
             [ai.miniforge.loop.escalation :as escalation]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Test fixtures
 
-(def mock-loop-state
+;; Test fixtures
+(def ^{:stratum 0} mock-loop-state
   {:loop/id (random-uuid)
    :loop/state :escalated
    :loop/iteration 5
@@ -36,10 +35,8 @@
                    :artifact/content "(defn broken [\n  incomplete"}
    :loop/termination {:reason :max-iterations}})
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Prompt formatting tests
-
-(deftest format-error-context-test
+(deftest ^{:stratum 0} format-error-context-test
   (testing "formats errors and iteration count"
     (let [errors [{:code :syntax :message "Missing closing paren"}
                   {:code :lint :message "Unused var"}]
@@ -61,21 +58,8 @@
       (is (< (count result) (+ 300 (count "After 1 attempts"))))
       (is (re-find #"\.\.\.$" result)))))
 
-(deftest format-escalation-prompt-test
-  (testing "includes all necessary information"
-    (let [prompt (escalation/format-escalation-prompt mock-loop-state)]
-      (is (string? prompt))
-      (is (re-find #"AGENT ESCALATION" prompt))
-      (is (re-find #"After 5 attempts" prompt))
-      (is (re-find #"Parse error" prompt))
-      (is (re-find #"Options:" prompt))
-      (is (re-find #"Provide hints" prompt))
-      (is (re-find #"Abort" prompt)))))
-
-;------------------------------------------------------------------------------ Layer 2
 ;; User interaction tests
-
-(deftest prompt-user-test
+(deftest ^{:stratum 0} prompt-user-test
   (testing "abort input returns abort action"
     (with-redefs [escalation/read-user-input (fn [] "abort")]
       (let [result (escalation/prompt-user "test")]
@@ -98,7 +82,20 @@
         (is (= :hints (:type result)))
         (is (= "hint text" (:content result)))))))
 
-(deftest escalate-to-user-test
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} format-escalation-prompt-test
+  (testing "includes all necessary information"
+    (let [prompt (escalation/format-escalation-prompt mock-loop-state)]
+      (is (string? prompt))
+      (is (re-find #"AGENT ESCALATION" prompt))
+      (is (re-find #"After 5 attempts" prompt))
+      (is (re-find #"Parse error" prompt))
+      (is (re-find #"Options:" prompt))
+      (is (re-find #"Provide hints" prompt))
+      (is (re-find #"Abort" prompt)))))
+
+(deftest ^{:stratum 1} escalate-to-user-test
   (testing "returns continue action with hints"
     (let [mock-prompt (fn [_] {:type :hints :content "Try this fix"})
           result (escalation/escalate-to-user mock-loop-state :prompt-fn mock-prompt)]
@@ -118,10 +115,8 @@
           (is (map? result))
           (is (contains? result :action)))))))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Inner loop integration tests
-
-(deftest handle-escalation-test
+(deftest ^{:stratum 1} handle-escalation-test
   (testing "calls escalation function when provided"
     (let [mock-escalation (fn [_state & _opts] {:action :continue :hints "hint"})
           result (escalation/handle-escalation mock-loop-state
@@ -152,7 +147,7 @@
       (is (= :continue (:action result)))
       (is (= "custom" (:hints result))))))
 
-(deftest create-escalation-checkpoint-test
+(deftest ^{:stratum 1} create-escalation-checkpoint-test
   (testing "creates canonical checkpoint data from loop state"
     (let [checkpoint (escalation/create-escalation-checkpoint mock-loop-state)]
       (is (= :loop-escalation (get-in checkpoint [:source :kind])))

--- a/components/loop/test/ai/miniforge/loop/gate_anomaly_shape_test.clj
+++ b/components/loop/test/ai/miniforge/loop/gate_anomaly_shape_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.loop.gate-anomaly-shape-test
   "Lock the canonical anomaly shape produced by `gates/fail-result`
    after the W2 anomaly convergence flip.
@@ -35,18 +34,24 @@
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.loop.gates :as gates]))
 
-(def ^:private sample-errors
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private sample-errors
   [(gates/make-error :syntax-error "Unexpected EOF")
    (gates/make-error :missing-require "core required but not imported")])
 
-(defn- failing-syntax-check
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} failing-syntax-check
   "Factory: a `fail-result` for the canonical `:syntax-check`/`:syntax`
    gate with the test's `sample-errors`. Centralises the fixture so the
    `gates/fail-result` arglist is bound in exactly one place."
   []
   (gates/fail-result :syntax-check :syntax sample-errors))
 
-(deftest fail-result-emits-canonical-gate-anomaly
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} fail-result-emits-canonical-gate-anomaly
   (testing ":gate/anomaly satisfies the canonical anomaly contract"
     (let [anom (:gate/anomaly (failing-syntax-check))]
       (is (anomaly/anomaly? anom)
@@ -70,7 +75,7 @@
           "flat :gate/errors on the gate result is independent of the embedded anomaly")
       (is (false? (:gate/passed? result))))))
 
-(deftest fail-result-no-top-level-domain-keys-on-anomaly
+(deftest ^{:stratum 2} fail-result-no-top-level-domain-keys-on-anomaly
   (testing "domain payload does NOT leak onto the anomaly's top level"
     (let [anom (:gate/anomaly (failing-syntax-check))]
       (is (nil? (:anomaly.gate/errors anom))

--- a/components/loop/test/ai/miniforge/loop/gates_test.clj
+++ b/components/loop/test/ai/miniforge/loop/gates_test.clj
@@ -15,43 +15,79 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.loop.gates-test
   (:require [clojure.test :as test :refer [deftest testing is]]
             [ai.miniforge.loop.gates :as gates]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Test fixtures
 
-(def valid-code-artifact
+;; Test fixtures
+(def ^{:stratum 0} valid-code-artifact
   {:artifact/id (random-uuid)
    :artifact/type :code
    :artifact/content "(defn hello [] \"world\")"})
 
-(def invalid-syntax-artifact
+(def ^{:stratum 0} invalid-syntax-artifact
   {:artifact/id (random-uuid)
    :artifact/type :code
    :artifact/content "(defn hello ["})
 
-(def artifact-with-println
+(def ^{:stratum 0} artifact-with-println
   {:artifact/id (random-uuid)
    :artifact/type :code
    :artifact/content "(defn hello [] (println \"debug\") :ok)"})
 
-(def artifact-with-secret
+(def ^{:stratum 0} artifact-with-secret
   {:artifact/id (random-uuid)
    :artifact/type :code
    :artifact/content "(def api-key = \"sk-12345abcdef\")"})
 
-(def non-code-artifact
+(def ^{:stratum 0} non-code-artifact
   {:artifact/id (random-uuid)
    :artifact/type :spec
    :artifact/content {:description "A spec document"}})
 
-;------------------------------------------------------------------------------ Layer 1
-;; Gate protocol tests
+(deftest ^{:stratum 0} gate-set-constructors-test
+  (testing "default-gates returns expected gates"
+    (let [gates (gates/default-gates)]
+      (is (= 3 (count gates)))
+      (is (some #(= :syntax (gates/gate-type %)) gates))
+      (is (some #(= :lint (gates/gate-type %)) gates))
+      (is (some #(= :policy (gates/gate-type %)) gates))))
 
-(deftest syntax-gate-test
+  (testing "minimal-gates returns only syntax"
+    (let [gates (gates/minimal-gates)]
+      (is (= 1 (count gates)))
+      (is (= :syntax (gates/gate-type (first gates))))))
+
+  (testing "strict-gates returns all gates with strict config"
+    (let [gates (gates/strict-gates)]
+      (is (= 3 (count gates))))))
+
+;; Result constructor tests
+(deftest ^{:stratum 0} result-constructors-test
+  (testing "pass-result creates passing result"
+    (let [result (gates/pass-result :my-gate :syntax)]
+      (is (:gate/passed? result))
+      (is (= :my-gate (:gate/id result)))
+      (is (= :syntax (:gate/type result)))))
+
+  (testing "fail-result creates failing result"
+    (let [errors [(gates/make-error :some-error "Error message")]
+          result (gates/fail-result :my-gate :lint errors)]
+      (is (not (:gate/passed? result)))
+      (is (= errors (:gate/errors result)))))
+
+  (testing "make-error creates error map"
+    (let [error (gates/make-error :code "message" :file "test.clj" :line 10)]
+      (is (= :code (:code error)))
+      (is (= "message" (:message error)))
+      (is (= {:file "test.clj" :line 10} (:location error))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Gate protocol tests
+(deftest ^{:stratum 1} syntax-gate-test
   (let [gate (gates/syntax-gate)]
     (testing "gate-id returns correct id"
       (is (= :syntax-check (gates/gate-id gate))))
@@ -75,7 +111,7 @@
       (let [result (gates/check gate non-code-artifact {})]
         (is (:gate/passed? result))))))
 
-(deftest lint-gate-test
+(deftest ^{:stratum 1} lint-gate-test
   (let [gate (gates/lint-gate :my-lint {})]
     (testing "gate-id returns correct id"
       (is (= :my-lint (gates/gate-id gate))))
@@ -98,7 +134,7 @@
             result (gates/check strict-gate artifact-with-println {})]
         (is (not (:gate/passed? result)))))))
 
-(deftest policy-gate-test
+(deftest ^{:stratum 1} policy-gate-test
   (let [gate (gates/policy-gate :security {:policies [:no-secrets]})]
     (testing "gate-id returns correct id"
       (is (= :security (gates/gate-id gate))))
@@ -124,7 +160,7 @@
         (is (not (:gate/passed? result)))
         (is (= :todo-found (:code (first (:gate/errors result)))))))))
 
-(deftest test-gate-test
+(deftest ^{:stratum 1} test-gate-test
   (testing "test gate with no test-fn passes with warning"
     (let [gate (gates/test-gate)
           result (gates/check gate valid-code-artifact {})]
@@ -148,7 +184,7 @@
       (is (not (:gate/passed? result)))
       (is (= :test-failed (:code (first (:gate/errors result))))))))
 
-(deftest custom-gate-test
+(deftest ^{:stratum 1} custom-gate-test
   (testing "custom gate with passing check"
     (let [gate (gates/custom-gate :length-check
                                   (fn [_artifact _ctx]
@@ -167,10 +203,8 @@
           result (gates/check gate valid-code-artifact {})]
       (is (not (:gate/passed? result))))))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Gate runner tests
-
-(deftest run-gates-test
+(deftest ^{:stratum 1} run-gates-test
   (testing "all gates pass"
     (let [gates [(gates/syntax-gate)
                  (gates/lint-gate)]
@@ -200,49 +234,8 @@
       (is (not (:passed? result)))
       (is (= 0 @call-count)))))  ; slow-gate should not be called
 
-(deftest gate-set-constructors-test
-  (testing "default-gates returns expected gates"
-    (let [gates (gates/default-gates)]
-      (is (= 3 (count gates)))
-      (is (some #(= :syntax (gates/gate-type %)) gates))
-      (is (some #(= :lint (gates/gate-type %)) gates))
-      (is (some #(= :policy (gates/gate-type %)) gates))))
-
-  (testing "minimal-gates returns only syntax"
-    (let [gates (gates/minimal-gates)]
-      (is (= 1 (count gates)))
-      (is (= :syntax (gates/gate-type (first gates))))))
-
-  (testing "strict-gates returns all gates with strict config"
-    (let [gates (gates/strict-gates)]
-      (is (= 3 (count gates))))))
-
-;------------------------------------------------------------------------------ Layer 2
-;; Result constructor tests
-
-(deftest result-constructors-test
-  (testing "pass-result creates passing result"
-    (let [result (gates/pass-result :my-gate :syntax)]
-      (is (:gate/passed? result))
-      (is (= :my-gate (:gate/id result)))
-      (is (= :syntax (:gate/type result)))))
-
-  (testing "fail-result creates failing result"
-    (let [errors [(gates/make-error :some-error "Error message")]
-          result (gates/fail-result :my-gate :lint errors)]
-      (is (not (:gate/passed? result)))
-      (is (= errors (:gate/errors result)))))
-
-  (testing "make-error creates error map"
-    (let [error (gates/make-error :code "message" :file "test.clj" :line 10)]
-      (is (= :code (:code error)))
-      (is (= "message" (:message error)))
-      (is (= {:file "test.clj" :line 10} (:location error))))))
-
-;------------------------------------------------------------------------------ Layer 3
 ;; Gate repair tests (N1 conformance)
-
-(deftest gate-repair-protocol-test
+(deftest ^{:stratum 1} gate-repair-protocol-test
   (testing "syntax gate repair returns not repaired"
     (let [gate (gates/syntax-gate)
           violations [{:code :syntax-error :message "Parse error"}]

--- a/components/loop/test/ai/miniforge/loop/inner_test.clj
+++ b/components/loop/test/ai/miniforge/loop/inner_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.loop.inner-test
   (:require [clojure.test :as test :refer [deftest testing is]]
             [ai.miniforge.anomaly.interface :as anomaly]
@@ -26,30 +25,30 @@
             [ai.miniforge.loop.repair :as repair]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Test fixtures
 
-(def test-task
+;; Test fixtures
+(def ^{:stratum 0} test-task
   {:task/id (random-uuid)
    :task/type :implement})
 
-(defn make-generate-fn
+(defn ^{:stratum 0} make-generate-fn
   "Create a generate function that produces the given artifact."
   [artifact & {:keys [tokens] :or {tokens 100}}]
   (fn [_task _ctx]
     {:artifact artifact
      :tokens tokens}))
 
-(defn valid-artifact []
+(defn ^{:stratum 0} valid-artifact []
   {:artifact/id (random-uuid)
    :artifact/type :code
    :artifact/content "(defn hello [] \"world\")"})
 
-(defn invalid-artifact []
+(defn ^{:stratum 0} invalid-artifact []
   {:artifact/id (random-uuid)
    :artifact/type :code
    :artifact/content "(defn broken ["})
 
-(defn reachable-states
+(defn ^{:stratum 0} reachable-states
   [initial-state transitions]
   (loop [visited #{}
          pending [initial-state]]
@@ -61,10 +60,8 @@
                  (into (pop pending) next-states))))
       visited)))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; State transition tests
-
-(deftest valid-transition-test
+(deftest ^{:stratum 0} valid-transition-test
   (testing "pending -> generating is valid"
     (is (inner/valid-transition? :pending :generating)))
 
@@ -90,7 +87,7 @@
     (is (not (inner/valid-transition? :complete :pending)))
     (is (not (inner/valid-transition? :complete :generating)))))
 
-(deftest terminal-state-test
+(deftest ^{:stratum 0} terminal-state-test
   (testing ":complete is terminal"
     (is (inner/terminal-state? :complete)))
 
@@ -106,7 +103,29 @@
   (testing ":generating is not terminal"
     (is (not (inner/terminal-state? :generating)))))
 
-(deftest inner-loop-machine-reachability-test
+;------------------------------------------------------------------------------ sum-repair-result-metrics — pin per-attempt aggregation
+(def ^{:stratum 0} ^:private sum-repair-result-metrics
+  (var-get #'inner/sum-repair-result-metrics))
+
+;; Cost epsilon for IEEE-double tolerance — 0.005 + 0.012 ≈ 0.017
+;; round-trips through doubles without exact equality.
+(def ^{:stratum 0} ^:private cost-usd-epsilon 1.0e-6)
+
+(def ^{:stratum 0} ^:private repair-result-fixture
+  "Shape that matches what repair/attempt-repair returns:
+   per-attempt entries live under :results, NOT at the top level.
+   Aggregation has to traverse :results to see real token / cost
+   counts."
+  {:success? false
+   :attempts 2
+   :results  [{:strategy :llm-fix :tokens-used 500  :cost-usd 0.005}
+              {:strategy :retry   :tokens-used 0    :cost-usd 0.0}
+              {:strategy :llm-fix :tokens-used 1200 :cost-usd 0.012}]
+   :errors   [{:code :test}]})
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} inner-loop-machine-reachability-test
   (let [reachable (reachable-states inner/initial-loop-state
                                     inner/valid-transitions)
         expected-states #{:pending :generating :validating
@@ -119,7 +138,7 @@
       (is (true? (fsm/final? inner/inner-loop-machine {:_state :escalated})))
       (is (false? (fsm/final? inner/inner-loop-machine {:_state :generating}))))))
 
-(deftest transition-test
+(deftest ^{:stratum 1} transition-test
   (let [loop-state (inner/create-inner-loop test-task {})]
     (testing "transition-result returns updated state for valid transition"
       (let [next-state (inner/transition-result loop-state :generating)]
@@ -157,10 +176,8 @@
                                            (loop-messages/t :inner/invalid-transition)))
                               (inner/transition terminal-state :generating)))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Loop state creation tests
-
-(deftest create-inner-loop-test
+(deftest ^{:stratum 1} create-inner-loop-test
   (testing "creates loop with required fields"
     (let [loop-state (inner/create-inner-loop test-task {})]
       (is (uuid? (:loop/id loop-state)))
@@ -178,10 +195,8 @@
           loop-state (inner/create-inner-loop test-task {:budget budget})]
       (is (= budget (get-in loop-state [:loop/config :budget]))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Termination tests
-
-(deftest should-terminate-test
+(deftest ^{:stratum 1} should-terminate-test
   (testing "terminal state triggers termination"
     (let [loop-state (-> (inner/create-inner-loop test-task {})
                          (assoc :loop/state :complete))]
@@ -204,10 +219,8 @@
     (let [loop-state (inner/create-inner-loop test-task {:max-iterations 5})]
       (is (nil? (inner/should-terminate? loop-state))))))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Step function tests
-
-(deftest generate-step-test
+(deftest ^{:stratum 1} generate-step-test
   (testing "successful generation transitions to validating"
     (let [loop-state (inner/create-inner-loop test-task {})
           generate-fn (make-generate-fn (valid-artifact))
@@ -242,7 +255,7 @@
       (is (= "java.lang.Exception" (get-in anom [:anomaly/data :anomaly/ex-class]))
           "exception class preserved under :anomaly/data"))))
 
-(deftest validate-step-test
+(deftest ^{:stratum 1} validate-step-test
   (testing "all gates pass transitions to complete"
     (let [loop-state (-> (inner/create-inner-loop test-task {})
                          (assoc :loop/state :validating)
@@ -259,7 +272,7 @@
       (is (= :repairing (:loop/state result)))
       (is (seq (:loop/errors result))))))
 
-(deftest repair-step-test
+(deftest ^{:stratum 1} repair-step-test
   (let [mock-repair-fn (fn [artifact _errors _ctx]
                          {:success? true
                           :artifact (assoc artifact
@@ -288,10 +301,8 @@
                                     {})]
       (is (= :escalated (:loop/state result))))))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Full loop tests
-
-(deftest run-inner-loop-test
+(deftest ^{:stratum 1} run-inner-loop-test
   (testing "successful generation completes in one iteration"
     (let [loop-state (inner/create-inner-loop test-task {:max-iterations 5})
           generate-fn (make-generate-fn (valid-artifact))
@@ -356,7 +367,7 @@
       (is (not (:success result)))
       (is (= :max-iterations (get-in result [:termination :reason]))))))
 
-(deftest run-simple-test
+(deftest ^{:stratum 1} run-simple-test
   (testing "run-simple with valid generation"
     (let [result (inner/run-simple test-task
                                    (make-generate-fn (valid-artifact))
@@ -364,28 +375,7 @@
       (is (:success result))
       (is (= 1 (:iterations result))))))
 
-;------------------------------------------------------------------------------ sum-repair-result-metrics — pin per-attempt aggregation
-
-(def ^:private sum-repair-result-metrics
-  (var-get #'inner/sum-repair-result-metrics))
-
-;; Cost epsilon for IEEE-double tolerance — 0.005 + 0.012 ≈ 0.017
-;; round-trips through doubles without exact equality.
-(def ^:private cost-usd-epsilon 1.0e-6)
-
-(def ^:private repair-result-fixture
-  "Shape that matches what repair/attempt-repair returns:
-   per-attempt entries live under :results, NOT at the top level.
-   Aggregation has to traverse :results to see real token / cost
-   counts."
-  {:success? false
-   :attempts 2
-   :results  [{:strategy :llm-fix :tokens-used 500  :cost-usd 0.005}
-              {:strategy :retry   :tokens-used 0    :cost-usd 0.0}
-              {:strategy :llm-fix :tokens-used 1200 :cost-usd 0.012}]
-   :errors   [{:code :test}]})
-
-(deftest sum-repair-result-metrics-aggregates-from-results-vector-test
+(deftest ^{:stratum 1} sum-repair-result-metrics-aggregates-from-results-vector-test
   (testing "Per-attempt metrics in :results sum into the returned
             map. Pin the contract: callers can thread the result
             into update-metrics and have it flow into :loop/metrics
@@ -398,7 +388,7 @@
       (is (< (Math/abs (- 0.017 cost-usd)) cost-usd-epsilon)
           "cost-usd summed within IEEE rounding tolerance"))))
 
-(deftest sum-repair-result-metrics-handles-empty-or-missing-results-test
+(deftest ^{:stratum 1} sum-repair-result-metrics-handles-empty-or-missing-results-test
   (testing "Empty / missing :results returns zero metrics rather
             than nil — keeps downstream merge-with + safe."
     (let [no-results {:success? false :attempts 0}]

--- a/components/loop/test/ai/miniforge/loop/interface_test.clj
+++ b/components/loop/test/ai/miniforge/loop/interface_test.clj
@@ -15,32 +15,29 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.loop.interface-test
   (:require [clojure.test :as test :refer [deftest testing is]]
             [ai.miniforge.loop.interface :as loop]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Test fixtures
 
-(def test-task
+;; Test fixtures
+(def ^{:stratum 0} test-task
   {:task/id (random-uuid)
    :task/type :implement})
 
-(defn valid-artifact []
+(defn ^{:stratum 0} valid-artifact []
   {:artifact/id (random-uuid)
    :artifact/type :code
    :artifact/content "(defn hello [] \"world\")"})
 
-(defn make-generate-fn [artifact]
+(defn ^{:stratum 0} make-generate-fn [artifact]
   (fn [_task _ctx]
     {:artifact artifact
      :tokens 100}))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Schema re-export tests
-
-(deftest schema-exports-test
+(deftest ^{:stratum 0} schema-exports-test
   (testing "inner-loop-states contains expected values"
     (is (some #{:pending} loop/inner-loop-states))
     (is (some #{:complete} loop/inner-loop-states))
@@ -56,44 +53,14 @@
     (is (some #{:implement} loop/outer-loop-phases))
     (is (some #{:observe} loop/outer-loop-phases))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Inner loop API tests
-
-(deftest create-inner-loop-test
-  (testing "creates loop with default options"
-    (let [loop-state (loop/create-inner-loop test-task)]
-      (is (uuid? (:loop/id loop-state)))
-      (is (= :pending (:loop/state loop-state)))))
-
-  (testing "creates loop with custom options"
-    (let [loop-state (loop/create-inner-loop test-task {:max-iterations 10})]
-      (is (= 10 (get-in loop-state [:loop/config :max-iterations]))))))
-
-(deftest run-simple-test
-  (testing "successful run"
-    (let [result (loop/run-simple test-task
-                                  (make-generate-fn (valid-artifact))
-                                  {:max-iterations 3})]
-      (is (:success result))
-      (is (= 1 (:iterations result)))))
-
-  (testing "run with logging context"
-    (let [result (loop/run-simple test-task
-                                  (make-generate-fn (valid-artifact))
-                                  {:max-iterations 3
-                                   :logger nil})]
-      (is (:success result)))))
-
-(deftest termination-checks-test
+(deftest ^{:stratum 0} termination-checks-test
   (testing "terminal-state? detects terminal states"
     (is (loop/terminal-state? :complete))
     (is (loop/terminal-state? :failed))
     (is (not (loop/terminal-state? :pending)))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Gates API tests
-
-(deftest gate-constructors-test
+(deftest ^{:stratum 0} gate-constructors-test
   (testing "syntax-gate creation"
     (let [gate (loop/syntax-gate)]
       (is (some? gate))))
@@ -111,7 +78,7 @@
                                  (fn [_a _c] (loop/pass-result :custom-check :custom)))]
       (is (some? gate)))))
 
-(deftest gate-sets-test
+(deftest ^{:stratum 0} gate-sets-test
   (testing "default-gates returns gates"
     (let [gates (loop/default-gates)]
       (is (seq gates))
@@ -125,14 +92,7 @@
     (let [gates (loop/strict-gates)]
       (is (seq gates)))))
 
-(deftest run-gates-test
-  (testing "run-gates returns result"
-    (let [artifact (valid-artifact)
-          result (loop/run-gates (loop/minimal-gates) artifact {})]
-      (is (:passed? result))
-      (is (seq (:results result))))))
-
-(deftest result-helpers-test
+(deftest ^{:stratum 0} result-helpers-test
   (testing "pass-result creates passing result"
     (let [result (loop/pass-result :test :syntax)]
       (is (:gate/passed? result))))
@@ -148,10 +108,8 @@
       (is (= :code (:code error)))
       (is (= "message" (:message error))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Repair API tests
-
-(deftest strategy-constructors-test
+(deftest ^{:stratum 0} strategy-constructors-test
   (testing "llm-fix-strategy creation"
     (let [strategy (loop/llm-fix-strategy)]
       (is (some? strategy))))
@@ -164,28 +122,14 @@
     (let [strategy (loop/escalate-strategy)]
       (is (some? strategy)))))
 
-(deftest default-strategies-test
+(deftest ^{:stratum 0} default-strategies-test
   (testing "default-strategies returns ordered list"
     (let [strategies (loop/default-strategies)]
       (is (seq strategies))
       (is (= 3 (count strategies))))))
 
-(deftest repair-result-helpers-test
-  (testing "repair-success creates success result"
-    (let [result (loop/repair-success :llm-fix (valid-artifact))]
-      (is (:success? result))
-      (is (some? (:artifact result)))))
-
-  (testing "repair-failure creates failure result"
-    (let [result (loop/repair-failure :llm-fix
-                                      [{:code :err :message "Error"}])]
-      (is (not (:success? result)))
-      (is (seq (:errors result))))))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; Outer loop API tests (stubs)
-
-(deftest outer-loop-api-test
+(deftest ^{:stratum 0} outer-loop-api-test
   (let [spec {:spec/id (random-uuid)
               :description "Test spec"}]
     (testing "create-outer-loop"
@@ -219,10 +163,55 @@
         (is (= :implement (:phase/id def)))
         (is (= :implementer (:phase/agent def)))))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Integration tests
+;------------------------------------------------------------------------------ Layer 1
 
-(deftest step-by-step-control-test
+;; Inner loop API tests
+(deftest ^{:stratum 1} create-inner-loop-test
+  (testing "creates loop with default options"
+    (let [loop-state (loop/create-inner-loop test-task)]
+      (is (uuid? (:loop/id loop-state)))
+      (is (= :pending (:loop/state loop-state)))))
+
+  (testing "creates loop with custom options"
+    (let [loop-state (loop/create-inner-loop test-task {:max-iterations 10})]
+      (is (= 10 (get-in loop-state [:loop/config :max-iterations]))))))
+
+(deftest ^{:stratum 1} run-simple-test
+  (testing "successful run"
+    (let [result (loop/run-simple test-task
+                                  (make-generate-fn (valid-artifact))
+                                  {:max-iterations 3})]
+      (is (:success result))
+      (is (= 1 (:iterations result)))))
+
+  (testing "run with logging context"
+    (let [result (loop/run-simple test-task
+                                  (make-generate-fn (valid-artifact))
+                                  {:max-iterations 3
+                                   :logger nil})]
+      (is (:success result)))))
+
+(deftest ^{:stratum 1} run-gates-test
+  (testing "run-gates returns result"
+    (let [artifact (valid-artifact)
+          result (loop/run-gates (loop/minimal-gates) artifact {})]
+      (is (:passed? result))
+      (is (seq (:results result))))))
+
+(deftest ^{:stratum 1} repair-result-helpers-test
+  (testing "repair-success creates success result"
+    (let [result (loop/repair-success :llm-fix (valid-artifact))]
+      (is (:success? result))
+      (is (some? (:artifact result)))))
+
+  (testing "repair-failure creates failure result"
+    (let [result (loop/repair-failure :llm-fix
+                                      [{:code :err :message "Error"}])]
+      (is (not (:success? result)))
+      (is (seq (:errors result))))))
+
+;; Integration tests
+(deftest ^{:stratum 1} step-by-step-control-test
   (testing "manual step execution"
     (let [loop-state (loop/create-inner-loop test-task {})
           generate-fn (make-generate-fn (valid-artifact))

--- a/components/loop/test/ai/miniforge/loop/messages_test.clj
+++ b/components/loop/test/ai/miniforge/loop/messages_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.loop.messages-test
   "Tests for loop component message catalog."
   (:require
@@ -23,35 +22,35 @@
    [clojure.string :as str]
    [ai.miniforge.loop.messages :as messages]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; ============================================================================
 ;; Translator resolution
 ;; ============================================================================
-
-(deftest translator-exists-test
+(deftest ^{:stratum 0} translator-exists-test
   (testing "t is a function"
     (is (fn? messages/t))))
 
 ;; ============================================================================
 ;; Escalation messages
 ;; ============================================================================
-
-(deftest escalation-context-header-test
+(deftest ^{:stratum 0} escalation-context-header-test
   (testing "context header interpolates iteration count"
     (let [msg (messages/t :escalation/context-header {:iteration 3})]
       (is (str/includes? msg "3"))
       (is (str/includes? msg "attempts")))))
 
-(deftest escalation-banner-title-test
+(deftest ^{:stratum 0} escalation-banner-title-test
   (testing "banner title is AGENT ESCALATION"
     (is (= "AGENT ESCALATION" (messages/t :escalation/banner-title)))))
 
-(deftest escalation-options-test
+(deftest ^{:stratum 0} escalation-options-test
   (testing "options header and choices resolve"
     (is (string? (messages/t :escalation/options-header)))
     (is (str/includes? (messages/t :escalation/option-hints) "hints"))
     (is (str/includes? (messages/t :escalation/option-abort) "abort"))))
 
-(deftest escalation-termination-reason-test
+(deftest ^{:stratum 0} escalation-termination-reason-test
   (testing "termination reason interpolates reason"
     (let [msg (messages/t :escalation/termination-reason {:reason "max-iterations"})]
       (is (str/includes? msg "max-iterations")))))
@@ -59,20 +58,19 @@
 ;; ============================================================================
 ;; Repair messages
 ;; ============================================================================
-
-(deftest repair-max-attempts-exceeded-test
+(deftest ^{:stratum 0} repair-max-attempts-exceeded-test
   (testing "max attempts message resolves"
     (let [msg (messages/t :repair/max-attempts-exceeded)]
       (is (string? msg))
       (is (str/includes? msg "attempt")))))
 
-(deftest repair-strategies-exhausted-test
+(deftest ^{:stratum 0} repair-strategies-exhausted-test
   (testing "strategies exhausted message resolves"
     (let [msg (messages/t :repair/strategies-exhausted)]
       (is (string? msg))
       (is (str/includes? msg "strategies")))))
 
-(deftest repair-escalated-test
+(deftest ^{:stratum 0} repair-escalated-test
   (testing "escalated message resolves"
     (let [msg (messages/t :repair/escalated)]
       (is (string? msg))

--- a/components/loop/test/ai/miniforge/loop/metrics_accumulation_test.clj
+++ b/components/loop/test/ai/miniforge/loop/metrics_accumulation_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.loop.metrics-accumulation-test
   "Cross-cutting integration test for metrics accumulation.
 
@@ -32,40 +31,74 @@
    [ai.miniforge.loop.repair :as repair]))
 
 ;------------------------------------------------------------------------------ Layer 0
+
 ;; Factory functions
+(def ^{:stratum 0} tokens-per-generate 200)
 
-(def tokens-per-generate 200)
-(def tokens-per-repair 50)
-(def duration-tolerance-ms 50)
+(def ^{:stratum 0} tokens-per-repair 50)
 
-(defn make-task
+(def ^{:stratum 0} duration-tolerance-ms 50)
+
+(defn ^{:stratum 0} make-task
   "Create a test task."
   []
   {:task/id (random-uuid)
    :task/type :implement})
 
-(defn make-valid-artifact
+(defn ^{:stratum 0} make-valid-artifact
   "Create a syntactically valid code artifact."
   []
   {:artifact/id (random-uuid)
    :artifact/type :code
    :artifact/content "(defn hello [] \"world\")"})
 
-(defn make-invalid-artifact
+(defn ^{:stratum 0} make-invalid-artifact
   "Create an artifact with broken syntax."
   []
   {:artifact/id (random-uuid)
    :artifact/type :code
    :artifact/content "(defn broken ["})
 
-(defn make-generate-fn
+(defn ^{:stratum 0} make-phase-metrics
+  "Create a phase metrics map simulating a completed phase."
+  [phase-name tokens duration-ms]
+  {:phase phase-name
+   :tokens tokens
+   :duration-ms duration-ms
+   :generate-calls 1
+   :repair-calls 0})
+
+;; Outer loop phase advancement with metrics tracking
+(deftest ^{:stratum 0} outer-loop-phase-metrics-tracking-test
+  (testing "Phase advancement tracks history for metrics auditing"
+    (let [spec {:spec/id (random-uuid)
+                :description "Test metrics tracking"}
+          loop-state (outer/create-outer-loop spec {})
+          after-plan (outer/advance-phase loop-state {})
+          after-design (outer/advance-phase after-plan {})
+          after-implement (outer/advance-phase after-design {})
+          history (:loop/history after-implement)
+          outcomes (map :outcome history)]
+
+      (is (= :implement (outer/get-current-phase after-implement))
+          "Should reach implement phase")
+      (is (= 7 (count history))
+          "History should have entries for each phase transition")
+      (is (some #{:completed} outcomes)
+          "History should contain completed phases")
+      (is (some #{:entered} outcomes)
+          "History should contain entered phases"))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} make-generate-fn
   "Create a generate function returning a fixed artifact."
   [artifact]
   (fn [_task _ctx]
     {:artifact artifact
      :tokens tokens-per-generate}))
 
-(defn make-counted-generate-fn
+(defn ^{:stratum 1} make-counted-generate-fn
   "Create a generate function that counts invocations.
    Produces invalid artifacts for the first n-fails calls, then valid."
   [n-fails]
@@ -76,7 +109,7 @@
         {:artifact (make-invalid-artifact) :tokens tokens-per-generate}
         {:artifact (make-valid-artifact) :tokens tokens-per-generate}))))
 
-(defn make-mock-repair-fn
+(defn ^{:stratum 1} make-mock-repair-fn
   "Create a mock repair function that succeeds but costs tokens."
   []
   (fn [artifact _errors _ctx]
@@ -84,19 +117,94 @@
      :artifact (assoc artifact :artifact/content "(defn fixed [] :ok)")
      :tokens-used tokens-per-repair}))
 
-(defn make-phase-metrics
-  "Create a phase metrics map simulating a completed phase."
-  [phase-name tokens duration-ms]
-  {:phase phase-name
-   :tokens tokens
-   :duration-ms duration-ms
-   :generate-calls 1
-   :repair-calls 0})
+;; Budget enforcement: cost limit
+(deftest ^{:stratum 1} cost-budget-enforcement-test
+  (testing "Cost budget terminates over-budget workflow"
+    (let [task (make-task)
+          cost-limit 0.01
+          loop-state (inner/create-inner-loop
+                      task
+                      {:max-iterations 20
+                       :budget {:max-cost-usd cost-limit}})
+          ;; Pre-load the loop state with cost near the limit
+          preloaded (assoc-in loop-state [:loop/metrics :cost-usd] cost-limit)]
+      (is (true? (:terminate? (inner/should-terminate? preloaded)))
+          "Should detect budget exhaustion")
+      (is (= :budget-exhausted (:reason (inner/should-terminate? preloaded)))
+          "Reason should be budget-exhausted"))))
 
-;------------------------------------------------------------------------------ Layer 1
+;; Metrics merging from simulated parallel phases
+(deftest ^{:stratum 1} parallel-phase-metrics-merge-test
+  (testing "Metrics from multiple phases merge with addition"
+    (let [plan-metrics (make-phase-metrics :plan 500 2000)
+          implement-metrics (make-phase-metrics :implement 3000 8000)
+          review-metrics (make-phase-metrics :review 1000 3000)
+          all-metrics [plan-metrics implement-metrics review-metrics]
+          merged (reduce (fn [acc m]
+                           (merge-with (fn [a b]
+                                         (if (and (number? a) (number? b))
+                                           (+ a b)
+                                           b))
+                                       acc
+                                       (dissoc m :phase)))
+                         {}
+                         all-metrics)]
+      (is (= 4500 (:tokens merged))
+          "Token totals should sum across phases")
+      (is (= 13000 (:duration-ms merged))
+          "Duration totals should sum across phases")
+      (is (= 3 (:generate-calls merged))
+          "Generate call counts should sum"))))
+
+;; Inner loop update-metrics pure function
+(deftest ^{:stratum 1} update-metrics-pure-function-test
+  (testing "update-metrics merges numeric values additively"
+    (let [loop-state (inner/create-inner-loop (make-task) {})
+          updated (-> loop-state
+                      (inner/update-metrics {:tokens 100 :generate-calls 1})
+                      (inner/update-metrics {:tokens 200 :repair-calls 1})
+                      (inner/update-metrics {:tokens 50 :generate-calls 1}))
+          metrics (:loop/metrics updated)]
+      (is (= 350 (:tokens metrics))
+          "Tokens should accumulate additively")
+      (is (= 2 (:generate-calls metrics))
+          "Generate calls should accumulate")
+      (is (= 1 (:repair-calls metrics))
+          "Repair calls should accumulate"))))
+
+;; Zero-iteration edge case
+(deftest ^{:stratum 1} zero-iteration-metrics-test
+  (testing "Fresh loop state has zero metrics"
+    (let [loop-state (inner/create-inner-loop (make-task) {})
+          metrics (:loop/metrics loop-state)]
+      (is (zero? (:tokens metrics))
+          "Initial tokens should be zero")
+      (is (zero? (:generate-calls metrics))
+          "Initial generate calls should be zero")
+      (is (zero? (:repair-calls metrics))
+          "Initial repair calls should be zero")
+      (is (= 0.0 (:cost-usd metrics))
+          "Initial cost should be zero"))))
+
+;; Budget boundary: exactly at limit
+(deftest ^{:stratum 1} budget-boundary-at-limit-test
+  (testing "Budget at exact limit triggers termination"
+    (let [task (make-task)
+          token-limit 200
+          loop-state (inner/create-inner-loop
+                      task
+                      {:max-iterations 10
+                       :budget {:max-tokens token-limit}})
+          at-limit (assoc-in loop-state [:loop/metrics :tokens] token-limit)]
+      (is (true? (:terminate? (inner/should-terminate? at-limit)))
+          "Exactly at budget limit should trigger termination")
+      (is (= :budget-exhausted (:reason (inner/should-terminate? at-limit)))
+          "Reason should be budget-exhausted"))))
+
+;------------------------------------------------------------------------------ Layer 2
+
 ;; Inner loop metrics: single iteration
-
-(deftest single-iteration-metrics-test
+(deftest ^{:stratum 2} single-iteration-metrics-test
   (testing "Metrics after one successful generation"
     (let [task (make-task)
           loop-state (inner/create-inner-loop task {:max-iterations 5})
@@ -117,10 +225,8 @@
         (is (nat-int? (:duration-ms metrics))
             "Duration should be non-negative")))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Inner loop metrics: multi-iteration with repairs
-
-(deftest multi-iteration-metrics-accumulation-test
+(deftest ^{:stratum 2} multi-iteration-metrics-accumulation-test
   (testing "Metrics accumulate across generate and repair cycles"
     (let [task (make-task)
           fail-count 2
@@ -146,10 +252,8 @@
         (is (>= (:tokens metrics) (* expected-gen-calls tokens-per-generate))
             "Accumulated tokens should reflect all generate calls")))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Budget enforcement: token limit
-
-(deftest token-budget-enforcement-test
+(deftest ^{:stratum 2} token-budget-enforcement-test
   (testing "Token budget terminates over-budget workflow"
     (let [task (make-task)
           token-limit 250
@@ -170,10 +274,8 @@
       (is (>= (get-in result [:metrics :tokens]) token-limit)
           "Final token count should be at or above the limit"))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Budget enforcement: iteration limit
-
-(deftest iteration-budget-enforcement-test
+(deftest ^{:stratum 2} iteration-budget-enforcement-test
   (testing "Iteration limit terminates loop"
     (let [task (make-task)
           max-iter 3
@@ -189,120 +291,3 @@
           "Termination reason should be max-iterations")
       (is (<= (:iterations result) (inc max-iter))
           "Iterations should not exceed max + 1"))))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Budget enforcement: cost limit
-
-(deftest cost-budget-enforcement-test
-  (testing "Cost budget terminates over-budget workflow"
-    (let [task (make-task)
-          cost-limit 0.01
-          loop-state (inner/create-inner-loop
-                      task
-                      {:max-iterations 20
-                       :budget {:max-cost-usd cost-limit}})
-          ;; Pre-load the loop state with cost near the limit
-          preloaded (assoc-in loop-state [:loop/metrics :cost-usd] cost-limit)]
-      (is (true? (:terminate? (inner/should-terminate? preloaded)))
-          "Should detect budget exhaustion")
-      (is (= :budget-exhausted (:reason (inner/should-terminate? preloaded)))
-          "Reason should be budget-exhausted"))))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Metrics merging from simulated parallel phases
-
-(deftest parallel-phase-metrics-merge-test
-  (testing "Metrics from multiple phases merge with addition"
-    (let [plan-metrics (make-phase-metrics :plan 500 2000)
-          implement-metrics (make-phase-metrics :implement 3000 8000)
-          review-metrics (make-phase-metrics :review 1000 3000)
-          all-metrics [plan-metrics implement-metrics review-metrics]
-          merged (reduce (fn [acc m]
-                           (merge-with (fn [a b]
-                                         (if (and (number? a) (number? b))
-                                           (+ a b)
-                                           b))
-                                       acc
-                                       (dissoc m :phase)))
-                         {}
-                         all-metrics)]
-      (is (= 4500 (:tokens merged))
-          "Token totals should sum across phases")
-      (is (= 13000 (:duration-ms merged))
-          "Duration totals should sum across phases")
-      (is (= 3 (:generate-calls merged))
-          "Generate call counts should sum"))))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Outer loop phase advancement with metrics tracking
-
-(deftest outer-loop-phase-metrics-tracking-test
-  (testing "Phase advancement tracks history for metrics auditing"
-    (let [spec {:spec/id (random-uuid)
-                :description "Test metrics tracking"}
-          loop-state (outer/create-outer-loop spec {})
-          after-plan (outer/advance-phase loop-state {})
-          after-design (outer/advance-phase after-plan {})
-          after-implement (outer/advance-phase after-design {})
-          history (:loop/history after-implement)
-          outcomes (map :outcome history)]
-
-      (is (= :implement (outer/get-current-phase after-implement))
-          "Should reach implement phase")
-      (is (= 7 (count history))
-          "History should have entries for each phase transition")
-      (is (some #{:completed} outcomes)
-          "History should contain completed phases")
-      (is (some #{:entered} outcomes)
-          "History should contain entered phases"))))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Inner loop update-metrics pure function
-
-(deftest update-metrics-pure-function-test
-  (testing "update-metrics merges numeric values additively"
-    (let [loop-state (inner/create-inner-loop (make-task) {})
-          updated (-> loop-state
-                      (inner/update-metrics {:tokens 100 :generate-calls 1})
-                      (inner/update-metrics {:tokens 200 :repair-calls 1})
-                      (inner/update-metrics {:tokens 50 :generate-calls 1}))
-          metrics (:loop/metrics updated)]
-      (is (= 350 (:tokens metrics))
-          "Tokens should accumulate additively")
-      (is (= 2 (:generate-calls metrics))
-          "Generate calls should accumulate")
-      (is (= 1 (:repair-calls metrics))
-          "Repair calls should accumulate"))))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Zero-iteration edge case
-
-(deftest zero-iteration-metrics-test
-  (testing "Fresh loop state has zero metrics"
-    (let [loop-state (inner/create-inner-loop (make-task) {})
-          metrics (:loop/metrics loop-state)]
-      (is (zero? (:tokens metrics))
-          "Initial tokens should be zero")
-      (is (zero? (:generate-calls metrics))
-          "Initial generate calls should be zero")
-      (is (zero? (:repair-calls metrics))
-          "Initial repair calls should be zero")
-      (is (= 0.0 (:cost-usd metrics))
-          "Initial cost should be zero"))))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Budget boundary: exactly at limit
-
-(deftest budget-boundary-at-limit-test
-  (testing "Budget at exact limit triggers termination"
-    (let [task (make-task)
-          token-limit 200
-          loop-state (inner/create-inner-loop
-                      task
-                      {:max-iterations 10
-                       :budget {:max-tokens token-limit}})
-          at-limit (assoc-in loop-state [:loop/metrics :tokens] token-limit)]
-      (is (true? (:terminate? (inner/should-terminate? at-limit)))
-          "Exactly at budget limit should trigger termination")
-      (is (= :budget-exhausted (:reason (inner/should-terminate? at-limit)))
-          "Reason should be budget-exhausted"))))

--- a/components/loop/test/ai/miniforge/loop/outer_test.clj
+++ b/components/loop/test/ai/miniforge/loop/outer_test.clj
@@ -15,17 +15,18 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.loop.outer-test
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.loop.outer :as outer]))
 
-(def test-spec
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} test-spec
   {:spec/id (random-uuid)
    :description "Exercise outer-loop phase transitions"})
 
-(deftest valid-phase-transition-test
+(deftest ^{:stratum 0} valid-phase-transition-test
   (testing "advance and rollback transitions are explicit"
     (is (outer/valid-phase-transition? :spec :loop/advance))
     (is (outer/valid-phase-transition? :review :loop/advance))
@@ -36,14 +37,16 @@
     (is (not (outer/valid-phase-transition? :observe :loop/advance)))
     (is (not (outer/valid-phase-transition? :plan :loop/rollback-to-review)))))
 
-(deftest phase-definition-test
+(deftest ^{:stratum 0} phase-definition-test
   (testing "phase definitions expose localized descriptions"
     (is (= "Specification received and validated"
            (:phase/description (outer/get-phase-definition :spec))))
     (is (= "Monitor deployment and collect telemetry"
            (:phase/description (outer/get-phase-definition :observe))))))
 
-(deftest advance-phase-test
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} advance-phase-test
   (testing "advancing updates the authoritative phase and history"
     (let [loop-state (outer/create-outer-loop test-spec {})
           advanced (outer/advance-phase loop-state {})]
@@ -58,7 +61,7 @@
       (is (= :observe (outer/get-current-phase loop-state)))
       (is (nil? (outer/advance-phase loop-state {}))))))
 
-(deftest rollback-phase-test
+(deftest ^{:stratum 1} rollback-phase-test
   (testing "rollback to an earlier phase is allowed"
     (let [loop-state (nth (iterate #(outer/advance-phase % {}) (outer/create-outer-loop test-spec {}))
                           3)

--- a/components/loop/test/ai/miniforge/loop/repair_messages_test.clj
+++ b/components/loop/test/ai/miniforge/loop/repair_messages_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.loop.repair-messages-test
   "Tests that repair result factory functions use localized messages."
   (:require
@@ -23,11 +22,12 @@
    [ai.miniforge.loop.repair :as repair]
    [ai.miniforge.loop.messages :as messages]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; ============================================================================
 ;; Result factory functions use localized messages
 ;; ============================================================================
-
-(deftest make-max-attempts-result-uses-localized-message-test
+(deftest ^{:stratum 0} make-max-attempts-result-uses-localized-message-test
   (testing "message comes from the message catalog, not a hardcoded string"
     (let [result (repair/make-max-attempts-result 3 [] [{:code :err}])
           expected (messages/t :repair/max-attempts-exceeded)]
@@ -35,14 +35,14 @@
       (is (false? (:success? result)))
       (is (= 3 (:attempts result))))))
 
-(deftest make-exhausted-strategies-result-uses-localized-message-test
+(deftest ^{:stratum 0} make-exhausted-strategies-result-uses-localized-message-test
   (testing "message comes from the message catalog"
     (let [result (repair/make-exhausted-strategies-result 2 [] [{:code :err}])
           expected (messages/t :repair/strategies-exhausted)]
       (is (= expected (:message result)))
       (is (false? (:success? result))))))
 
-(deftest make-escalation-result-uses-localized-message-test
+(deftest ^{:stratum 0} make-escalation-result-uses-localized-message-test
   (testing "escalation message comes from the message catalog"
     (let [result (repair/make-escalation-result {:artifact "a"} 1 [] [{:code :err}])
           expected (messages/t :repair/escalated)]
@@ -50,7 +50,7 @@
       (is (true? (:escalate? result)))
       (is (false? (:success? result))))))
 
-(deftest make-success-result-has-no-message-test
+(deftest ^{:stratum 0} make-success-result-has-no-message-test
   (testing "success result does not include a message key"
     (let [result (repair/make-success-result {:artifact "a" :strategy :llm-fix} 0 [])]
       (is (true? (:success? result)))

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-loop.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-loop.md
@@ -1,0 +1,191 @@
+<!--
+  Title: fix: stratum-lint autofix for components/loop (Wave 1)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix: stratum-lint autofix for components/loop (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over `components/loop` (`src` + `test`) to
+replace decorative `Layer N` headings with real ones derived from each
+file's actual same-file reference graph, and tag every top-level `def`/
+`defn`/`deftest` with `^{:stratum n}`. One of the Wave 1 batches from
+`work/stratum-lint-baseline-2026-07-24.md` (batch 6, the largest
+component in this batch at 40 baseline findings). Mostly mechanical, but
+two classes of manual fix were needed beyond the autofix output: one
+stale decorative heading that now contradicted its surrounding real
+headings in `outer.clj`, and six namespace docstrings that hardcoded a
+layer count/description the fix made wrong. No executable logic changed
+anywhere.
+
+## Motivation
+
+Baseline findings for this component, confirmed via a fresh plain-lint
+run before touching anything (zero `SL001` — no upward-reference/cycle
+risk, matching the Wave 1 batch criteria):
+
+- `gates.clj`: 5 `SL004` (defs before the first `Layer` heading) + 1
+  `SL002` (heading reuse).
+- `repair.clj`: 3 `SL004` + non-monotonic headings.
+- `inner.clj`: 2 `SL002` (heading reuse).
+- `interface.clj`: 4 `SL002`.
+- `schema.clj`: 5 `SL002`.
+- Six `test/*.clj` files: 10 `SL002` + 1 `SL003` (`gates_test.clj`, 4
+  distinct decorative layers against the 3-layer budget).
+
+40 findings total (31 `SL002`, 8 `SL004`, 1 `SL003`, 0 `SL001`) —
+matches `work/stratum-lint-baseline-2026-07-24.md`'s per-component table
+exactly.
+
+## Changes in Detail
+
+Ran, over the whole component:
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "bef8657a2efd3b1ba9e1a4f510693c9fbca45abd" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/loop
+```
+
+20 of the component's files were rewritten (11 `src`, 9 `test`) —
+`--fix` normalizes every file it touches, not just the ones with
+findings. Diffs are heading text, `^{:stratum n}` metadata, and
+def/deftest reordering only; verified with a form-level equality check
+(read every top-level form from the pre-fix and post-fix version of
+each file via the Clojure reader and diffed the resulting multisets,
+which are insensitive to reordering and to metadata since Clojure's `=`
+ignores both) — every file matched exactly except three where the
+tool's regex-literal forms (`#"..."`) aren't `.equals()`-comparable in
+Java, a false-positive artifact of the verification method itself, not
+a real difference; confirmed those three by direct diff read instead.
+
+Notable autofix outcomes worth calling out because they look alarming
+in a raw diff:
+
+- `interface.clj`'s every def collapsed to a **single** real layer
+  (Layer 0). This file is a thin facade over `inner`/`outer`/`gates`/
+  `repair`/`escalation`/`schema` — every def just delegates to another
+  namespace, so there are no same-file references between its own defs
+  at all; the old headings implying 2 distinct layers were entirely
+  decorative.
+- `gates_test.clj`'s pre-fix `SL003` (4 decorative layers) collapsed to
+  2 real layers — the fixtures/constructor tests all sit at Layer 0,
+  and every other `deftest` (including the previously-stranded
+  `gate-repair-protocol-test` under an old "Layer 3") sits at Layer 1,
+  since none of the test groups actually depend on each other.
+- `inner.clj` and `outer.clj` each expanded from 3 decorative layers to
+  10 and 9 real layers respectively — the true FSM/step-function/runner
+  call chain is much deeper than the old banners implied. Both are
+  genuine `SL003` over-budget findings, not something this mechanical
+  pass can fix (see Testing Plan and Deployment Plan).
+
+One thing the autofix did **not** resolve, found during the mandated
+full-diff read: `outer.clj` had a stale decorative `;---- Layer 1.5`
+sub-banner (labeled "Result helpers") sitting directly below the real,
+generated `Layer 0` heading, with `phase-succeeded?` and `log-phase`
+(both correctly tagged `^{:stratum 0}` by the fix) underneath it. The
+non-integer "1.5" isn't recognized by stratum-lint's heading regex, so
+it survived from the old `Layer 0 / Layer 1 / Layer 2` decorative
+scheme untouched — reading "1.5" directly under a real "Layer 0" heading
+and above the real "Layer 1" heading, contradicting both. Dropped the
+`Layer 1.5` heading by hand, keeping "Result helpers" as a plain
+comment (same fix class as this program's prior batches, e.g.
+`components/knowledge`'s `store.clj` "Layer 0.5").
+
+Also updated by hand, six namespace docstrings whose hardcoded layer
+summary the fix invalidated — `escalation.clj` (3→4 real layers),
+`gates.clj` (3→4), `repair.clj` (3→4), `schema.clj` (2→5), `outer.clj`
+(3→9), and `inner.clj` (3→10). Rewrote each to name the actual
+functions/defs at every real layer and why (which same-file def each
+one calls), rather than the old thematic-but-untrue one-line-per-layer
+summaries. `inner.clj` and `outer.clj`'s docstrings additionally flag
+that their real layer count is over budget and point at
+`work/stratum-lint-baseline-2026-07-24.md` for the Wave 2 follow-on.
+
+No `#?(...)` reader-conditional-wrapped defs in this component, so the
+SL008 fix in the current pin never came into play, and no same-line
+trailing-comment displacement was found in any file.
+
+## Testing Plan
+
+1. Ran plain (non-`--fix`) `stratum-lint` before any change — reproduced
+   the 40 findings above exactly (31 `SL002`, 8 `SL004`, 1 `SL003`, 0
+   `SL001`), confirmed 0 `SL001` before proceeding.
+2. Ran `--fix` over the whole component — 20 files rewritten.
+3. Ran `--fix` a second time immediately after — zero diff (confirmed
+   both by the tool's own silent/no-rewrite output and by an md5 hash
+   comparison of every changed file before/after), confirms idempotency.
+4. Read the full diff for all 20 changed files, plus a form-level
+   equality check (Clojure reader, frequencies of top-level forms) as
+   an independent cross-check that no logic changed. Found and
+   hand-fixed the contradictory `Layer 1.5` banner in `outer.clj`;
+   updated 6 stale namespace docstrings (above).
+5. Ran `--fix` again after the hand edits — zero diff, confirms the
+   manual fixes are stable under the tool.
+6. `clj-kondo --lint components/loop`: 0 errors, 0 warnings — both
+   before and after.
+7. Ran all 9 test namespaces directly via `clojure -M:dev:test`
+   (`escalation-test`, `gate-anomaly-shape-test`, `gates-test`,
+   `inner-test`, `interface-test`, `messages-test`,
+   `metrics-accumulation-test`, `outer-test`, `repair-messages-test`):
+   69 tests, 324 assertions, 0 failures, 0 errors.
+8. Re-ran plain `stratum-lint` after the fix: `SL001`/`SL002`/`SL004`
+   clear across the component. `SL003` remains, newly surfaced (higher
+   than the pre-fix decorative count, not a regression) on six files:
+   - `escalation.clj`: 4 real layers.
+   - `gates.clj`: 4 real layers.
+   - `repair.clj`: 4 real layers.
+   - `schema.clj`: 5 real layers.
+   - `outer.clj`: 9 real layers.
+   - `inner.clj`: 10 real layers.
+
+   All six are genuinely over the 3-layer budget the old decorative
+   headings hid by undercounting, not a regression this PR introduces —
+   deferred to Wave 2 (real namespace split), consistent with how prior
+   Wave 1 PRs (e.g. `schema`, `repo-dag`) handled the same situation.
+   `gates_test.clj`'s original `SL003` is fully resolved (collapsed to 2
+   real layers, well under budget).
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+change — comment/metadata/order/docstring-only. Pre-commit's
+`lint:stratum` autofixer keeps this component clean going forward; the
+six files above keep their `SL003` advisory
+(`MINIFORGE_STRATUM_BUDGET_MODE=warn` at commit time) until Wave 2
+splits them — `inner.clj` (10 layers) and `outer.clj` (9 layers) are the
+deepest single-file call chains found anywhere in this program so far
+and are the priority candidates for that split.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1, batch 6)
+- Precedent for the decorative-banner hand-fix: prior Wave 1 batches,
+  e.g. `components/knowledge`'s `store.clj` "Layer 0.5" banner
+- Follow-on: Wave 2 namespace split for
+  `components/loop/src/ai/miniforge/loop/inner.clj` (10 real layers)
+  and `components/loop/src/ai/miniforge/loop/outer.clj` (9 real
+  layers), plus smaller splits for `escalation.clj`, `gates.clj`,
+  `repair.clj`, and `schema.clj` (4-5 real layers each)
+
+## Checklist
+
+- [x] Plain lint confirmed zero `SL001` before touching anything
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Second `--fix` pass confirms idempotency (zero diff, verified via
+      md5 hash comparison)
+- [x] Diff read in full for all 20 changed files, cross-checked with a
+      form-level equality comparison via the Clojure reader
+- [x] Contradictory decorative `Layer 1.5` banner (`outer.clj`) found
+      and removed by hand; keeping "Result helpers" as a plain comment
+- [x] Six namespace docstrings (`escalation.clj`, `gates.clj`,
+      `repair.clj`, `schema.clj`, `outer.clj`, `inner.clj`) updated to
+      match the real post-fix layer structure
+- [x] Further `--fix` pass after hand edits confirms stability (zero
+      diff)
+- [x] `clj-kondo` clean (0 errors, 0 warnings before/after)
+- [x] Component tests pass (69 tests, 324 assertions, 0 failures/errors)
+- [x] Plain lint re-run post-fix: zero `SL001`/`SL002`/`SL004`; `SL003`
+      remains on 6 files — newly surfaced by the fix (not pre-existing),
+      tracked as Wave 2 above
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
<!--
  Title: fix: stratum-lint autofix for components/loop (Wave 1)
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# fix: stratum-lint autofix for components/loop (Wave 1)

## Overview

Runs `stratum-lint --fix` over `components/loop` (`src` + `test`) to
replace decorative `Layer N` headings with real ones derived from each
file's actual same-file reference graph, and tag every top-level `def`/
`defn`/`deftest` with `^{:stratum n}`. One of the Wave 1 batches from
`work/stratum-lint-baseline-2026-07-24.md` (batch 6, the largest
component in this batch at 40 baseline findings). Mostly mechanical, but
two classes of manual fix were needed beyond the autofix output: one
stale decorative heading that now contradicted its surrounding real
headings in `outer.clj`, and six namespace docstrings that hardcoded a
layer count/description the fix made wrong. No executable logic changed
anywhere.

## Motivation

Baseline findings for this component, confirmed via a fresh plain-lint
run before touching anything (zero `SL001` — no upward-reference/cycle
risk, matching the Wave 1 batch criteria):

- `gates.clj`: 5 `SL004` (defs before the first `Layer` heading) + 1
  `SL002` (heading reuse).
- `repair.clj`: 3 `SL004` + non-monotonic headings.
- `inner.clj`: 2 `SL002` (heading reuse).
- `interface.clj`: 4 `SL002`.
- `schema.clj`: 5 `SL002`.
- Six `test/*.clj` files: 10 `SL002` + 1 `SL003` (`gates_test.clj`, 4
  distinct decorative layers against the 3-layer budget).

40 findings total (31 `SL002`, 8 `SL004`, 1 `SL003`, 0 `SL001`) —
matches `work/stratum-lint-baseline-2026-07-24.md`'s per-component table
exactly.

## Changes in Detail

Ran, over the whole component:

```bash
bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "bef8657a2efd3b1ba9e1a4f510693c9fbca45abd" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/loop
```

20 of the component's files were rewritten (11 `src`, 9 `test`) —
`--fix` normalizes every file it touches, not just the ones with
findings. Diffs are heading text, `^{:stratum n}` metadata, and
def/deftest reordering only; verified with a form-level equality check
(read every top-level form from the pre-fix and post-fix version of
each file via the Clojure reader and diffed the resulting multisets,
which are insensitive to reordering and to metadata since Clojure's `=`
ignores both) — every file matched exactly except three where the
tool's regex-literal forms (`#"..."`) aren't `.equals()`-comparable in
Java, a false-positive artifact of the verification method itself, not
a real difference; confirmed those three by direct diff read instead.

Notable autofix outcomes worth calling out because they look alarming
in a raw diff:

- `interface.clj`'s every def collapsed to a **single** real layer
  (Layer 0). This file is a thin facade over `inner`/`outer`/`gates`/
  `repair`/`escalation`/`schema` — every def just delegates to another
  namespace, so there are no same-file references between its own defs
  at all; the old headings implying 2 distinct layers were entirely
  decorative.
- `gates_test.clj`'s pre-fix `SL003` (4 decorative layers) collapsed to
  2 real layers — the fixtures/constructor tests all sit at Layer 0,
  and every other `deftest` (including the previously-stranded
  `gate-repair-protocol-test` under an old "Layer 3") sits at Layer 1,
  since none of the test groups actually depend on each other.
- `inner.clj` and `outer.clj` each expanded from 3 decorative layers to
  10 and 9 real layers respectively — the true FSM/step-function/runner
  call chain is much deeper than the old banners implied. Both are
  genuine `SL003` over-budget findings, not something this mechanical
  pass can fix (see Testing Plan and Deployment Plan).

One thing the autofix did **not** resolve, found during the mandated
full-diff read: `outer.clj` had a stale decorative `;---- Layer 1.5`
sub-banner (labeled "Result helpers") sitting directly below the real,
generated `Layer 0` heading, with `phase-succeeded?` and `log-phase`
(both correctly tagged `^{:stratum 0}` by the fix) underneath it. The
non-integer "1.5" isn't recognized by stratum-lint's heading regex, so
it survived from the old `Layer 0 / Layer 1 / Layer 2` decorative
scheme untouched — reading "1.5" directly under a real "Layer 0" heading
and above the real "Layer 1" heading, contradicting both. Dropped the
`Layer 1.5` heading by hand, keeping "Result helpers" as a plain
comment (same fix class as this program's prior batches, e.g.
`components/knowledge`'s `store.clj` "Layer 0.5").

Also updated by hand, six namespace docstrings whose hardcoded layer
summary the fix invalidated — `escalation.clj` (3→4 real layers),
`gates.clj` (3→4), `repair.clj` (3→4), `schema.clj` (2→5), `outer.clj`
(3→9), and `inner.clj` (3→10). Rewrote each to name the actual
functions/defs at every real layer and why (which same-file def each
one calls), rather than the old thematic-but-untrue one-line-per-layer
summaries. `inner.clj` and `outer.clj`'s docstrings additionally flag
that their real layer count is over budget and point at
`work/stratum-lint-baseline-2026-07-24.md` for the Wave 2 follow-on.

No `#?(...)` reader-conditional-wrapped defs in this component, so the
SL008 fix in the current pin never came into play, and no same-line
trailing-comment displacement was found in any file.

## Testing Plan

1. Ran plain (non-`--fix`) `stratum-lint` before any change — reproduced
   the 40 findings above exactly (31 `SL002`, 8 `SL004`, 1 `SL003`, 0
   `SL001`), confirmed 0 `SL001` before proceeding.
2. Ran `--fix` over the whole component — 20 files rewritten.
3. Ran `--fix` a second time immediately after — zero diff (confirmed
   both by the tool's own silent/no-rewrite output and by an md5 hash
   comparison of every changed file before/after), confirms idempotency.
4. Read the full diff for all 20 changed files, plus a form-level
   equality check (Clojure reader, frequencies of top-level forms) as
   an independent cross-check that no logic changed. Found and
   hand-fixed the contradictory `Layer 1.5` banner in `outer.clj`;
   updated 6 stale namespace docstrings (above).
5. Ran `--fix` again after the hand edits — zero diff, confirms the
   manual fixes are stable under the tool.
6. `clj-kondo --lint components/loop`: 0 errors, 0 warnings — both
   before and after.
7. Ran all 9 test namespaces directly via `clojure -M:dev:test`
   (`escalation-test`, `gate-anomaly-shape-test`, `gates-test`,
   `inner-test`, `interface-test`, `messages-test`,
   `metrics-accumulation-test`, `outer-test`, `repair-messages-test`):
   69 tests, 324 assertions, 0 failures, 0 errors.
8. Re-ran plain `stratum-lint` after the fix: `SL001`/`SL002`/`SL004`
   clear across the component. `SL003` remains, newly surfaced (higher
   than the pre-fix decorative count, not a regression) on six files:
   - `escalation.clj`: 4 real layers.
   - `gates.clj`: 4 real layers.
   - `repair.clj`: 4 real layers.
   - `schema.clj`: 5 real layers.
   - `outer.clj`: 9 real layers.
   - `inner.clj`: 10 real layers.

   All six are genuinely over the 3-layer budget the old decorative
   headings hid by undercounting, not a regression this PR introduces —
   deferred to Wave 2 (real namespace split), consistent with how prior
   Wave 1 PRs (e.g. `schema`, `repo-dag`) handled the same situation.
   `gates_test.clj`'s original `SL003` is fully resolved (collapsed to 2
   real layers, well under budget).

## Deployment Plan

Merges to `main` like any other component change. No runtime behavior
change — comment/metadata/order/docstring-only. Pre-commit's
`lint:stratum` autofixer keeps this component clean going forward; the
six files above keep their `SL003` advisory
(`MINIFORGE_STRATUM_BUDGET_MODE=warn` at commit time) until Wave 2
splits them — `inner.clj` (10 layers) and `outer.clj` (9 layers) are the
deepest single-file call chains found anywhere in this program so far
and are the priority candidates for that split.

## Related Issues/PRs

- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1, batch 6)
- Precedent for the decorative-banner hand-fix: prior Wave 1 batches,
  e.g. `components/knowledge`'s `store.clj` "Layer 0.5" banner
- Follow-on: Wave 2 namespace split for
  `components/loop/src/ai/miniforge/loop/inner.clj` (10 real layers)
  and `components/loop/src/ai/miniforge/loop/outer.clj` (9 real
  layers), plus smaller splits for `escalation.clj`, `gates.clj`,
  `repair.clj`, and `schema.clj` (4-5 real layers each)

## Checklist

- [x] Plain lint confirmed zero `SL001` before touching anything
- [x] `--fix` run over the whole component (`src` + `test`)
- [x] Second `--fix` pass confirms idempotency (zero diff, verified via
      md5 hash comparison)
- [x] Diff read in full for all 20 changed files, cross-checked with a
      form-level equality comparison via the Clojure reader
- [x] Contradictory decorative `Layer 1.5` banner (`outer.clj`) found
      and removed by hand; keeping "Result helpers" as a plain comment
- [x] Six namespace docstrings (`escalation.clj`, `gates.clj`,
      `repair.clj`, `schema.clj`, `outer.clj`, `inner.clj`) updated to
      match the real post-fix layer structure
- [x] Further `--fix` pass after hand edits confirms stability (zero
      diff)
- [x] `clj-kondo` clean (0 errors, 0 warnings before/after)
- [x] Component tests pass (69 tests, 324 assertions, 0 failures/errors)
- [x] Plain lint re-run post-fix: zero `SL001`/`SL002`/`SL004`; `SL003`
      remains on 6 files — newly surfaced by the fix (not pre-existing),
      tracked as Wave 2 above
- [x] No `--no-verify`; pre-commit hook runs normally at commit time
