### PR TITLE
fix: stratum-lint autofix for components/pr-lifecycle (Wave 1)

### DIFF
--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/ci_monitor.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/ci_monitor.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.ci-monitor
   "CI status monitoring for PRs.
 
@@ -30,9 +29,9 @@
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; CI status types
 
-(def ci-statuses
+;; CI status types
+(def ^{:stratum 0} ci-statuses
   "Possible CI check statuses."
   #{:pending    ; Checks running
     :success    ; All checks passed
@@ -42,14 +41,12 @@
     :timed-out  ; Checks timed out
     :unknown})  ; Could not determine status
 
-(def terminal-statuses
+(def ^{:stratum 0} terminal-statuses
   "CI statuses that indicate checks are complete."
   #{:success :failure :neutral :cancelled :timed-out})
 
-;------------------------------------------------------------------------------ Layer 0
 ;; GitHub CLI helpers
-
-(defn run-gh-command
+(defn ^{:stratum 0} run-gh-command
   "Run a gh CLI command and return result."
   [args worktree-path]
   (try
@@ -67,7 +64,70 @@
     (catch Exception e
       (dag/err :gh-exception (.getMessage e)))))
 
-(defn get-pr-checks
+;; Value coercion
+(defn- ^{:stratum 0} keywordize-val
+  "Coerce a map value to a lower-case keyword, returning `default` when nil."
+  [m k default]
+  (or (some-> (get m k) str/lower-case keyword) default))
+
+(defn ^{:stratum 0} get-check-logs
+  "Get logs for failed checks.
+
+   Arguments:
+   - worktree-path: Path to git worktree
+   - pr-number: PR number
+   - check-name: Name of the check
+
+   Returns result with logs."
+  [_worktree-path _pr-number check-name]
+  ;; Note: gh doesn't have a direct way to get check logs
+  ;; This would typically go through the GitHub API or action artifacts
+  (dag/ok {:logs nil
+           :message "Log retrieval requires GitHub API access"
+           :check-name check-name}))
+
+;; Monitoring loop
+(defn ^{:stratum 0} create-ci-monitor
+  "Create a CI monitor for a PR.
+
+   Arguments:
+   - dag-id: DAG run ID
+   - run-id: Run instance ID
+   - task-id: Task ID
+   - pr-number: PR number
+   - worktree-path: Path to git worktree
+
+   Options:
+   - :poll-interval-ms - Polling interval (default 30000)
+   - :timeout-ms - Total timeout (default 3600000 = 1 hour)
+   - :event-bus - Event bus for publishing events
+
+   Returns monitor state atom."
+  [dag-id run-id task-id pr-number worktree-path
+   & {:keys [poll-interval-ms timeout-ms event-bus]
+      :or {poll-interval-ms 30000 timeout-ms 3600000}}]
+  (atom {:dag-id dag-id
+         :run-id run-id
+         :task-id task-id
+         :pr-number pr-number
+         :worktree-path worktree-path
+         :poll-interval-ms poll-interval-ms
+         :timeout-ms timeout-ms
+         :event-bus event-bus
+         :status :pending
+         :started-at nil
+         :last-poll nil
+         :polls 0
+         :running? false}))
+
+(defn ^{:stratum 0} stop-ci-monitor
+  "Stop a running CI monitor."
+  [monitor]
+  (swap! monitor assoc :running? false))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} get-pr-checks
   "Get CI check status for a PR.
 
    Arguments:
@@ -92,7 +152,7 @@
           (dag/ok {:checks [] :raw (:output (:data result))})))
       result)))
 
-(defn get-pr-status
+(defn ^{:stratum 1} get-pr-status
   "Get overall PR status including checks.
 
    Returns result with :state :mergeable :reviewDecision etc."
@@ -105,18 +165,8 @@
       (dag/ok {:raw (:output (:data result))})
       result)))
 
-;------------------------------------------------------------------------------ Layer 0.5
-;; Value coercion
-
-(defn- keywordize-val
-  "Coerce a map value to a lower-case keyword, returning `default` when nil."
-  [m k default]
-  (or (some-> (get m k) str/lower-case keyword) default))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; Status computation
-
-(defn compute-ci-status
+(defn ^{:stratum 1} compute-ci-status
   "Compute overall CI status from individual checks.
 
    Arguments:
@@ -161,59 +211,9 @@
      :neutral neutral
      :total (count checks)}))
 
-(defn get-check-logs
-  "Get logs for failed checks.
-
-   Arguments:
-   - worktree-path: Path to git worktree
-   - pr-number: PR number
-   - check-name: Name of the check
-
-   Returns result with logs."
-  [_worktree-path _pr-number check-name]
-  ;; Note: gh doesn't have a direct way to get check logs
-  ;; This would typically go through the GitHub API or action artifacts
-  (dag/ok {:logs nil
-           :message "Log retrieval requires GitHub API access"
-           :check-name check-name}))
-
 ;------------------------------------------------------------------------------ Layer 2
-;; Monitoring loop
 
-(defn create-ci-monitor
-  "Create a CI monitor for a PR.
-
-   Arguments:
-   - dag-id: DAG run ID
-   - run-id: Run instance ID
-   - task-id: Task ID
-   - pr-number: PR number
-   - worktree-path: Path to git worktree
-
-   Options:
-   - :poll-interval-ms - Polling interval (default 30000)
-   - :timeout-ms - Total timeout (default 3600000 = 1 hour)
-   - :event-bus - Event bus for publishing events
-
-   Returns monitor state atom."
-  [dag-id run-id task-id pr-number worktree-path
-   & {:keys [poll-interval-ms timeout-ms event-bus]
-      :or {poll-interval-ms 30000 timeout-ms 3600000}}]
-  (atom {:dag-id dag-id
-         :run-id run-id
-         :task-id task-id
-         :pr-number pr-number
-         :worktree-path worktree-path
-         :poll-interval-ms poll-interval-ms
-         :timeout-ms timeout-ms
-         :event-bus event-bus
-         :status :pending
-         :started-at nil
-         :last-poll nil
-         :polls 0
-         :running? false}))
-
-(defn poll-ci-status
+(defn ^{:stratum 2} poll-ci-status
   "Poll CI status once.
 
    Arguments:
@@ -266,7 +266,9 @@
                                            (str/join ", "
                                                      (map :name (:failed computed)))))))}))))
 
-(defn run-ci-monitor
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} run-ci-monitor
   "Run the CI monitor until checks complete or timeout.
 
    Arguments:
@@ -328,11 +330,6 @@
           (do
             (Thread/sleep poll-interval-ms)
             (recur)))))))
-
-(defn stop-ci-monitor
-  "Stop a running CI monitor."
-  [monitor]
-  (swap! monitor assoc :running? false))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/classifier.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/classifier.clj
@@ -11,7 +11,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.classifier
   "Comment classification for PR reviews.
 
@@ -31,16 +30,16 @@
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Schemas + bot detection
 
-(def ClassifiedComment
+;; Schemas + bot detection
+(def ^{:stratum 0} ClassifiedComment
   [:map
    [:category keyword?]
    [:confidence keyword?]
    [:method keyword?]
    [:comment map?]])
 
-(def ClassificationStats
+(def ^{:stratum 0} ClassificationStats
   [:map
    [:total nat-int?]
    [:change-requests nat-int?]
@@ -49,74 +48,33 @@
    [:bot-comments nat-int?]
    [:noise nat-int?]])
 
-(def ClassifiedCommentsBatch
-  [:map
-   [:change-requests [:vector ClassifiedComment]]
-   [:questions [:vector ClassifiedComment]]
-   [:approvals [:vector ClassifiedComment]]
-   [:bot-comments [:vector ClassifiedComment]]
-   [:noise [:vector ClassifiedComment]]
-   [:all [:vector ClassifiedComment]]
-   [:stats ClassificationStats]])
-
-(defn- validate!
+(defn- ^{:stratum 0} validate!
   [result-schema value]
   (schema/validate result-schema value))
 
-(def bot-login-patterns
+(def ^{:stratum 0} bot-login-patterns
   "Login substrings and suffixes for known bots."
   #{"dependabot" "renovate" "codecov" "github-actions"
     "stale" "mergify" "greenkeeper" "snyk-bot"
     "sonarcloud" "codeclimate" "coveralls"
     "hound" "percy" "chromatic" "netlify"})
 
-(defn bot-author?
-  "Check if a comment author is a bot.
-
-   Matches known bot login patterns and the [bot] suffix convention."
-  [author]
-  (when (and author (string? author) (seq author))
-    (let [lower (str/lower-case author)]
-      (or (some #(str/includes? lower %) bot-login-patterns)
-          (str/ends-with? lower "[bot]")
-          (str/ends-with? lower "-bot")
-          (str/ends-with? lower "-app")))))
-
-;------------------------------------------------------------------------------ Layer 0
 ;; Approval detection
-
-(def approval-phrases
+(def ^{:stratum 0} approval-phrases
   "Phrases that indicate approval."
   #{"lgtm" "looks good to me" "looks good" "approved" "ship it"
     "+1" "looks great" "well done" "nice work" "excellent"
     "no objections" "good to go" "thumbs up"})
 
-(defn approval-comment?
-  "Check if a comment body expresses approval."
-  [body]
-  (when (and body (seq body))
-    (let [lower (str/lower-case (str/trim body))]
-      (boolean (some #(str/includes? lower %) approval-phrases)))))
-
-;------------------------------------------------------------------------------ Layer 0
 ;; Question detection (heuristic)
-
-(def ^:private question-patterns
+(def ^{:stratum 0} ^:private question-patterns
   "Regex patterns that suggest a comment is a question."
   [#"\?"
    #"(?i)^(why|what|how|when|where|could you|can you|would you|should we|is this|are these|do we|does this)"
    #"(?i)\b(curious|wondering|question|clarify|explain|understand|reason for)\b"])
 
-(defn question-comment?
-  "Check if a comment body is a question (heuristic)."
-  [body]
-  (when (and body (seq body))
-    (boolean (some #(re-find % body) question-patterns))))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; LLM-based classification
-
-(def classification-prompt-template
+(def ^{:stratum 0} classification-prompt-template
   "Prompt template for LLM-based comment classification.
 
    The generate-fn receives this prompt and returns a single category word."
@@ -134,12 +92,7 @@ Comment:
 Respond with ONLY the category name (change-request, question, approval, or noise).
 Do not include any other text.")
 
-(defn build-classify-prompt
-  "Build the classification prompt for a comment body."
-  [body]
-  (format classification-prompt-template (str/replace (or body "") "\"" "\\\"" )))
-
-(defn parse-llm-classification
+(defn ^{:stratum 0} parse-llm-classification
   "Parse the LLM response into a classification keyword.
 
    Returns nil if the response cannot be parsed."
@@ -153,18 +106,53 @@ Do not include any other text.")
             "noise"          :noise}
            cleaned))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Unified classifier
+(defn- ^{:stratum 0} grouped-comments
+  [classified-comments]
+  (group-by :category classified-comments))
 
-(defn- heuristic-category
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} ClassifiedCommentsBatch
+  [:map
+   [:change-requests [:vector ClassifiedComment]]
+   [:questions [:vector ClassifiedComment]]
+   [:approvals [:vector ClassifiedComment]]
+   [:bot-comments [:vector ClassifiedComment]]
+   [:noise [:vector ClassifiedComment]]
+   [:all [:vector ClassifiedComment]]
+   [:stats ClassificationStats]])
+
+(defn ^{:stratum 1} bot-author?
+  "Check if a comment author is a bot.
+
+   Matches known bot login patterns and the [bot] suffix convention."
+  [author]
+  (when (and author (string? author) (seq author))
+    (let [lower (str/lower-case author)]
+      (or (some #(str/includes? lower %) bot-login-patterns)
+          (str/ends-with? lower "[bot]")
+          (str/ends-with? lower "-bot")
+          (str/ends-with? lower "-app")))))
+
+(defn ^{:stratum 1} approval-comment?
+  "Check if a comment body expresses approval."
   [body]
-  (cond
-    (question-comment? body)                                          :question
-    (pos? (triage/score-indicators body triage/actionable-indicators)) :change-request
-    (approval-comment? body)                                          :approval
-    :else                                                             :noise))
+  (when (and body (seq body))
+    (let [lower (str/lower-case (str/trim body))]
+      (boolean (some #(str/includes? lower %) approval-phrases)))))
 
-(defn- build-classification
+(defn ^{:stratum 1} question-comment?
+  "Check if a comment body is a question (heuristic)."
+  [body]
+  (when (and body (seq body))
+    (boolean (some #(re-find % body) question-patterns))))
+
+(defn ^{:stratum 1} build-classify-prompt
+  "Build the classification prompt for a comment body."
+  [body]
+  (format classification-prompt-template (str/replace (or body "") "\"" "\\\"" )))
+
+(defn- ^{:stratum 1} build-classification
   [category confidence method comment]
   (validate!
    ClassifiedComment
@@ -173,25 +161,7 @@ Do not include any other text.")
     :method method
     :comment comment}))
 
-(defn- llm-category
-  [body generate-fn]
-  (let [prompt   (build-classify-prompt body)
-        response (try (generate-fn prompt) (catch Exception _e nil))]
-    (parse-llm-classification response)))
-
-(defn- classify-human-comment
-  [comment body generate-fn]
-  (if generate-fn
-    (if-let [category (llm-category body generate-fn)]
-      (build-classification category :high :llm comment)
-      (build-classification (heuristic-category body) :low :heuristic-fallback comment))
-    (build-classification (heuristic-category body) :medium :heuristic comment)))
-
-(defn- grouped-comments
-  [classified-comments]
-  (group-by :category classified-comments))
-
-(defn- stats-for
+(defn- ^{:stratum 1} stats-for
   [classified-comments grouped]
   (validate!
    ClassificationStats
@@ -202,7 +172,36 @@ Do not include any other text.")
     :bot-comments    (count (get grouped :bot-comment))
     :noise           (count (get grouped :noise))}))
 
-(defn classify-comment
+;------------------------------------------------------------------------------ Layer 2
+
+;; Unified classifier
+(defn- ^{:stratum 2} heuristic-category
+  [body]
+  (cond
+    (question-comment? body)                                          :question
+    (pos? (triage/score-indicators body triage/actionable-indicators)) :change-request
+    (approval-comment? body)                                          :approval
+    :else                                                             :noise))
+
+(defn- ^{:stratum 2} llm-category
+  [body generate-fn]
+  (let [prompt   (build-classify-prompt body)
+        response (try (generate-fn prompt) (catch Exception _e nil))]
+    (parse-llm-classification response)))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn- ^{:stratum 3} classify-human-comment
+  [comment body generate-fn]
+  (if generate-fn
+    (if-let [category (llm-category body generate-fn)]
+      (build-classification category :high :llm comment)
+      (build-classification (heuristic-category body) :low :heuristic-fallback comment))
+    (build-classification (heuristic-category body) :medium :heuristic comment)))
+
+;------------------------------------------------------------------------------ Layer 4
+
+(defn ^{:stratum 4} classify-comment
   "Classify a single comment into a category.
 
    Arguments:
@@ -241,7 +240,9 @@ Do not include any other text.")
       :else
       (classify-human-comment comment body generate-fn))))
 
-(defn classify-comments
+;------------------------------------------------------------------------------ Layer 5
+
+(defn ^{:stratum 5} classify-comments
   "Classify a batch of comments.
 
    Arguments:

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/conflict_resolution.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/conflict_resolution.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.conflict-resolution
   "Spec §6.4 hook: when a PR transitions MERGEABLE→NON_MERGEABLE
    (CONFLICTING with its base branch), invoke the multi-parent merge
@@ -44,9 +43,9 @@
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; State classification
 
-(def conflict-marker-re
+;; State classification
+(def ^{:stratum 0} conflict-marker-re
   "Heuristic match for GitHub `mergeable` and `mergeStateStatus`
    fields when the PR is CONFLICTING with its base. We match both
    the lowercase `mergeable: \"CONFLICTING\"` and the
@@ -57,29 +56,8 @@
    is don't auto-resolve)."
   #"(?i)CONFLICTING|\"mergeStateStatus\"\s*:\s*\"DIRTY\"")
 
-(defn classify-merge-state
-  "Parse GitHub's mergeable / mergeStateStatus JSON output into a
-   simple keyword. Inputs come from `gh pr view --json
-   mergeable,mergeStateStatus`. Returns one of:
-   - :mergeable     — clean, OK to merge
-   - :conflicting   — CONFLICTING with base; resolution can engage
-   - :unknown       — GitHub hasn't computed yet, or anything else
-
-   Conservative on classification: only emit :conflicting when we
-   see a clear conflict signal. UNKNOWN/PENDING stay :unknown so
-   the caller polls again rather than running the resolution
-   sub-workflow on a state GitHub itself isn't sure about."
-  [gh-output]
-  (cond
-    (or (nil? gh-output) (str/blank? gh-output)) :unknown
-    (re-find conflict-marker-re gh-output) :conflicting
-    (re-find #"(?i)\"mergeable\"\s*:\s*\"MERGEABLE\"" gh-output) :mergeable
-    :else :unknown))
-
-;------------------------------------------------------------------------------ Layer 0
 ;; Worktree probes (Stage 3b)
-
-(defn- run-cmd
+(defn- ^{:stratum 0} run-cmd
   [cwd args]
   (try
     (let [r (apply process/shell
@@ -92,67 +70,8 @@
     (catch Exception e
       (dag/err :command-exception (.getMessage e) {:args args}))))
 
-(defn extract-conflict-paths
-  "Run `git diff --name-only --diff-filter=U` in `worktree-path` to
-   list paths the index has marked unmerged. Returns a vector of
-   relative path strings (possibly empty), or a dag/err if git
-   itself failed.
-
-   Spec §6.1 conflict-input requires this list — the resolution
-   agent reads each path's content (via build-resolution-task in
-   workflow.merge-resolution) so the LLM can see what to fix."
-  [worktree-path]
-  (let [r (run-cmd worktree-path
-                   ["git" "diff" "--name-only" "--diff-filter=U"])]
-    (if (dag/ok? r)
-      (let [out (:output (:data r))]
-        (dag/ok (if (str/blank? out)
-                  []
-                  (vec (str/split-lines out)))))
-      r)))
-
-(defn rev-parse
-  "Resolve a ref to a full SHA in `worktree-path`. Wraps `git
-   rev-parse <ref>` and returns the trimmed SHA via dag/ok or a
-   dag/err on failure."
-  [worktree-path ref]
-  (let [r (run-cmd worktree-path ["git" "rev-parse" ref])]
-    (if (dag/ok? r)
-      (dag/ok {:sha (:output (:data r))})
-      r)))
-
-(defn push-resolution!
-  "Push the worktree's current HEAD to origin/<pr-branch> via plain
-   `git push`. The resolution commit is a merge commit on top of
-   the PR branch's existing HEAD (parents = [PR-HEAD base-HEAD]),
-   so the push is a fast-forward update of the PR branch — no
-   force-push needed.
-
-   Plain push rejects non-fast-forwards by default, which is the
-   right safety: if upstream moved out from under us between merge
-   attempt and push, the conflict-input we resolved against is
-   stale and we'd want to re-evaluate rather than overwrite the
-   new state.
-
-   Returns dag/ok `{:pushed-sha <sha>}` on success, or the dag/err
-   from the underlying git push on failure."
-  [worktree-path pr-branch]
-  (let [push-r (run-cmd worktree-path
-                        ["git" "push" "origin"
-                         (str "HEAD:" pr-branch)])]
-    (if (dag/ok? push-r)
-      (let [sha-r (rev-parse worktree-path "HEAD")]
-        (if (dag/ok? sha-r)
-          (dag/ok {:pushed?    true
-                   :pushed-sha (:sha (:data sha-r))
-                   :pr-branch  pr-branch})
-          sha-r))
-      push-r)))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; conflict-input shape
-
-(defn build-pr-conflict-input
+(defn ^{:stratum 0} build-pr-conflict-input
   "Assemble the conflict-input map that workflow.merge-resolution/
    resolve-conflict! expects, with the two-parent shape from spec
    §6.4: PR branch + PR base. Order is fixed (PR branch first, base
@@ -182,10 +101,90 @@
    :merge/conflicts  (mapv (fn [p] {:path p :stages ["1" "2" "3"]})
                            conflict-paths)})
 
-;------------------------------------------------------------------------------ Layer 2
-;; Public entry — orchestrate the §6.4 hook (Stage 3c)
+;------------------------------------------------------------------------------ Layer 1
 
-(defn resolve-pr-conflicts!
+(defn ^{:stratum 1} classify-merge-state
+  "Parse GitHub's mergeable / mergeStateStatus JSON output into a
+   simple keyword. Inputs come from `gh pr view --json
+   mergeable,mergeStateStatus`. Returns one of:
+   - :mergeable     — clean, OK to merge
+   - :conflicting   — CONFLICTING with base; resolution can engage
+   - :unknown       — GitHub hasn't computed yet, or anything else
+
+   Conservative on classification: only emit :conflicting when we
+   see a clear conflict signal. UNKNOWN/PENDING stay :unknown so
+   the caller polls again rather than running the resolution
+   sub-workflow on a state GitHub itself isn't sure about."
+  [gh-output]
+  (cond
+    (or (nil? gh-output) (str/blank? gh-output)) :unknown
+    (re-find conflict-marker-re gh-output) :conflicting
+    (re-find #"(?i)\"mergeable\"\s*:\s*\"MERGEABLE\"" gh-output) :mergeable
+    :else :unknown))
+
+(defn ^{:stratum 1} extract-conflict-paths
+  "Run `git diff --name-only --diff-filter=U` in `worktree-path` to
+   list paths the index has marked unmerged. Returns a vector of
+   relative path strings (possibly empty), or a dag/err if git
+   itself failed.
+
+   Spec §6.1 conflict-input requires this list — the resolution
+   agent reads each path's content (via build-resolution-task in
+   workflow.merge-resolution) so the LLM can see what to fix."
+  [worktree-path]
+  (let [r (run-cmd worktree-path
+                   ["git" "diff" "--name-only" "--diff-filter=U"])]
+    (if (dag/ok? r)
+      (let [out (:output (:data r))]
+        (dag/ok (if (str/blank? out)
+                  []
+                  (vec (str/split-lines out)))))
+      r)))
+
+(defn ^{:stratum 1} rev-parse
+  "Resolve a ref to a full SHA in `worktree-path`. Wraps `git
+   rev-parse <ref>` and returns the trimmed SHA via dag/ok or a
+   dag/err on failure."
+  [worktree-path ref]
+  (let [r (run-cmd worktree-path ["git" "rev-parse" ref])]
+    (if (dag/ok? r)
+      (dag/ok {:sha (:output (:data r))})
+      r)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} push-resolution!
+  "Push the worktree's current HEAD to origin/<pr-branch> via plain
+   `git push`. The resolution commit is a merge commit on top of
+   the PR branch's existing HEAD (parents = [PR-HEAD base-HEAD]),
+   so the push is a fast-forward update of the PR branch — no
+   force-push needed.
+
+   Plain push rejects non-fast-forwards by default, which is the
+   right safety: if upstream moved out from under us between merge
+   attempt and push, the conflict-input we resolved against is
+   stale and we'd want to re-evaluate rather than overwrite the
+   new state.
+
+   Returns dag/ok `{:pushed-sha <sha>}` on success, or the dag/err
+   from the underlying git push on failure."
+  [worktree-path pr-branch]
+  (let [push-r (run-cmd worktree-path
+                        ["git" "push" "origin"
+                         (str "HEAD:" pr-branch)])]
+    (if (dag/ok? push-r)
+      (let [sha-r (rev-parse worktree-path "HEAD")]
+        (if (dag/ok? sha-r)
+          (dag/ok {:pushed?    true
+                   :pushed-sha (:sha (:data sha-r))
+                   :pr-branch  pr-branch})
+          sha-r))
+      push-r)))
+
+;------------------------------------------------------------------------------ Layer 3
+
+;; Public entry — orchestrate the §6.4 hook (Stage 3c)
+(defn ^{:stratum 3} resolve-pr-conflicts!
   "Spec §6.4 entry point. Run the merge-resolution sub-workflow on
    a PR that's CONFLICTING with its base, then push the resolution
    commit to the PR branch.

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/controller.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/controller.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.controller
   "PR lifecycle controller - orchestrates task→PR→merge workflow.
 
@@ -38,15 +37,15 @@
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Controller state
 
-(def ^:private lifecycle-loop-sleep-ms
+;; Controller state
+(def ^{:stratum 0} ^:private lifecycle-loop-sleep-ms
   1000)
 
-(def ^:private lifecycle-failed-status
+(def ^{:stratum 0} ^:private lifecycle-failed-status
   :failed)
 
-(defn iter-budget-result
+(defn ^{:stratum 0} iter-budget-result
   "Anomaly-returning iter-budget check.
 
    Returns `:ok` when `current` < `max-iters`, or a `:conflict`
@@ -62,7 +61,7 @@
                      {:task-id task-id :iterations current})
     :ok))
 
-(defn pr-creation-result
+(defn ^{:stratum 0} pr-creation-result
   "Anomaly-returning PR-creation check.
 
    Returns `:ok` when `pr-result` is a successful DAG result, or a
@@ -78,47 +77,31 @@
                      {:error (:error pr-result)})
     :ok))
 
-(defn- remove-nil-values
+(defn- ^{:stratum 0} remove-nil-values
   "Drop entries whose values are nil."
   [m]
   (into {} (remove (comp nil? val)) m))
 
-(defn- format-acceptance-criteria
+(defn- ^{:stratum 0} format-acceptance-criteria
   [criteria]
   (->> criteria
        (map #(messages/t :controller/criterion-line {:criterion %}))
        (str/join "\n")))
 
-(defn- task-id-fragment
+(defn- ^{:stratum 0} task-id-fragment
   [task-id]
   (let [task-id-string (str task-id)
         fragment-length (min 8 (count task-id-string))]
     (subs task-id-string 0 fragment-length)))
 
-(defn- build-commit-message
+(defn- ^{:stratum 0} build-commit-message
   [task task-id]
   (let [title (get task :task/title (messages/t :controller/default-commit-title))]
     (messages/t :controller/commit-message
                 {:title title
                  :task-id task-id})))
 
-(defn- build-pr-title
-  [task task-id]
-  (get task :task/title
-       (messages/t :controller/default-pr-title
-                   {:task-fragment (task-id-fragment task-id)})))
-
-(defn- build-pr-body
-  [task]
-  (let [description (get task :task/description
-                         (messages/t :controller/default-task-description))
-        criteria (format-acceptance-criteria
-                  (get task :task/acceptance-criteria []))]
-    (messages/t :controller/pr-body-template
-                {:description description
-                 :criteria criteria})))
-
-(defn- controller-config-map
+(defn- ^{:stratum 0} controller-config-map
   [worktree-path merge-policy controller-defaults]
   {:worktree-path worktree-path
    :merge-policy merge-policy
@@ -128,7 +111,7 @@
    :auto-resolve-comments (:auto-resolve-comments controller-defaults)
    :branch-name-prefix (:branch-name-prefix controller-defaults)})
 
-(defn- invalid-transition-anomaly
+(defn- ^{:stratum 0} invalid-transition-anomaly
   "Create an anomaly describing an invalid controller status transition."
   [current-status new-status transition-result]
   (anomaly/anomaly :conflict
@@ -139,17 +122,44 @@
                     :message (controller-fsm/transition-error-message transition-result)
                     :valid-targets (controller-fsm/valid-targets current-status)}))
 
-(defn- result-status
+(defn- ^{:stratum 0} result-status
   "Return a normalized status keyword for result payloads."
   [result]
   (if (schema/succeeded? result) :succeeded :failed))
 
-(defn- fix-completion-data
+(defn ^{:stratum 0} add-history!
+  "Add an event to controller history."
+  [controller event-type data]
+  (swap! controller update :history conj
+         {:type event-type
+          :data data
+          :timestamp (java.util.Date.)})
+  nil)
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} build-pr-title
+  [task task-id]
+  (get task :task/title
+       (messages/t :controller/default-pr-title
+                   {:task-fragment (task-id-fragment task-id)})))
+
+(defn- ^{:stratum 1} build-pr-body
+  [task]
+  (let [description (get task :task/description
+                         (messages/t :controller/default-task-description))
+        criteria (format-acceptance-criteria
+                  (get task :task/acceptance-criteria []))]
+    (messages/t :controller/pr-body-template
+                {:description description
+                 :criteria criteria})))
+
+(defn- ^{:stratum 1} fix-completion-data
   "Create history payload for a completed fix attempt."
   [fix-result]
   {:result-status (result-status fix-result)})
 
-(defn- transition-status
+(defn- ^{:stratum 1} transition-status
   "Validate and apply a status transition to the current controller snapshot."
   [controller-state new-status]
   (let [current-status (:status controller-state)
@@ -160,7 +170,7 @@
              :updated-at (java.util.Date.))
       (invalid-transition-anomaly current-status new-status transition-result))))
 
-(defn create-controller
+(defn ^{:stratum 1} create-controller
   "Create a PR lifecycle controller for a task.
 
    Arguments:
@@ -223,88 +233,7 @@
            :created-at created-at
            :updated-at created-at})))
 
-(defn update-status!
-  "Update controller status using the formal PR lifecycle FSM."
-  [controller new-status]
-  (loop []
-    (let [current-state @controller
-          updated-state (transition-status current-state new-status)]
-      (if (anomaly/anomaly? updated-state)
-        updated-state
-        (if (compare-and-set! controller current-state updated-state)
-        (:status updated-state)
-          (recur))))))
-
-(defn add-history!
-  "Add an event to controller history."
-  [controller event-type data]
-  (swap! controller update :history conj
-         {:type event-type
-          :data data
-          :timestamp (java.util.Date.)})
-  nil)
-
-;------------------------------------------------------------------------------ Layer 1
-;; PR creation steps
-
-(defn fail-controller!
-  "Mark controller as failed and return a DAG error."
-  [controller error-key error-msg]
-  (update-status! controller lifecycle-failed-status)
-  (dag/err error-key error-msg))
-
-(defn create-and-checkout-branch!
-  "Create and checkout a new branch for the task.
-   Returns the branch result or a DAG error."
-  [controller worktree-path branch-name]
-  (let [branch-result (release/create-branch! worktree-path branch-name)]
-    (if (schema/succeeded? branch-result)
-      branch-result
-      (do
-        (add-history! controller :pr-creation-failed {:error (:error branch-result)})
-        (fail-controller! controller :branch-creation-failed (:error branch-result))))))
-
-(defn apply-code-to-files!
-  "Apply the code artifact to the worktree.
-   Returns the apply result or a DAG error."
-  [controller worktree-path code-artifact logger]
-  (let [apply-result (fix/apply-fix-to-worktree worktree-path code-artifact logger)]
-    (if (dag/err? apply-result)
-      (fail-controller! controller :artifact-apply-failed (:error apply-result))
-      apply-result)))
-
-(defn commit-changes!
-  "Stage and commit all changes with the given task info.
-   Returns the commit result or a DAG error."
-  [controller worktree-path task task-id]
-  (let [commit-msg (build-commit-message task task-id)
-        commit-result (release/commit-changes! worktree-path commit-msg)]
-    (if (schema/succeeded? commit-result)
-      commit-result
-      (fail-controller! controller :commit-failed (:error commit-result)))))
-
-(defn push-and-create-pr!
-  "Push the branch and open a GitHub PR.
-   Returns the PR info map or a DAG error."
-  [controller worktree-path branch-name base-branch task task-id commit-result]
-  (let [push-result (release/push-branch! worktree-path branch-name)]
-    (if-not (schema/succeeded? push-result)
-      (fail-controller! controller :push-failed (:error push-result))
-      (let [pr-title (build-pr-title task task-id)
-            pr-body (build-pr-body task)
-            pr-result (release/create-pr! worktree-path
-                                          {:title pr-title
-                                           :body pr-body
-                                           :base-branch base-branch})]
-        (if-not (schema/succeeded? pr-result)
-          (fail-controller! controller :pr-creation-failed (:error pr-result))
-          {:pr/id       (:pr-number pr-result)
-           :pr/url      (:pr-url pr-result)
-           :pr/branch   branch-name
-           :pr/base-sha nil
-           :pr/head-sha (:commit-sha commit-result)})))))
-
-(defn finalize-pr-creation!
+(defn ^{:stratum 1} finalize-pr-creation!
   "Record PR info on the controller, publish the event, and log success."
   [controller pr-info dag-id run-id task-id event-bus logger]
   (swap! controller assoc :pr pr-info)
@@ -323,53 +252,31 @@
                :data {:pr-url (:pr/url pr-info)}}))
   (dag/ok pr-info))
 
-;------------------------------------------------------------------------------ Layer 1
-;; PR creation orchestrator
+;------------------------------------------------------------------------------ Layer 2
 
-(defn create-pr!
-  "Create a PR for the task.
+(defn ^{:stratum 2} update-status!
+  "Update controller status using the formal PR lifecycle FSM."
+  [controller new-status]
+  (loop []
+    (let [current-state @controller
+          updated-state (transition-status current-state new-status)]
+      (if (anomaly/anomaly? updated-state)
+        updated-state
+        (if (compare-and-set! controller current-state updated-state)
+        (:status updated-state)
+          (recur))))))
 
-   Arguments:
-   - controller: Controller state atom
-   - code-artifact: Code artifact to commit
+;------------------------------------------------------------------------------ Layer 3
 
-   Returns result with PR info."
-  [controller code-artifact]
-  (let [{dag-id :dag/id run-id :run/id task-id :task/id
-         :keys [task config event-bus logger]} @controller
-        {:keys [worktree-path branch-name-prefix]} config
-        branch-name (str branch-name-prefix (task-id-fragment task-id))]
+;; PR creation steps
+(defn ^{:stratum 3} fail-controller!
+  "Mark controller as failed and return a DAG error."
+  [controller error-key error-msg]
+  (update-status! controller lifecycle-failed-status)
+  (dag/err error-key error-msg))
 
-    (update-status! controller :creating-pr)
-    (add-history! controller :pr-creation-started {:branch branch-name})
-
-    (when logger
-      (log/info logger :pr-lifecycle :controller/creating-pr
-                {:message (messages/t :controller/creating-pr)
-                 :data {:task-id task-id :branch branch-name}}))
-
-    (let [branch-result (create-and-checkout-branch! controller worktree-path branch-name)]
-      (if (dag/err? branch-result)
-        branch-result
-        (let [apply-result (apply-code-to-files! controller worktree-path code-artifact logger)]
-          (if (dag/err? apply-result)
-            apply-result
-            (let [commit-result (commit-changes! controller worktree-path task task-id)]
-              (if (dag/err? commit-result)
-                commit-result
-                (let [pr-info (push-and-create-pr! controller worktree-path branch-name
-                                                   (:base-branch branch-result)
-                                                   task task-id commit-result)]
-                  (if (dag/err? pr-info)
-                    pr-info
-                    (finalize-pr-creation! controller pr-info
-                                           dag-id run-id task-id
-                                           event-bus logger)))))))))))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; Monitoring
-
-(defn start-ci-monitoring!
+(defn ^{:stratum 3} start-ci-monitoring!
   "Start CI monitoring for the PR."
   [controller]
   (let [{dag-id :dag/id run-id :run/id task-id :task/id
@@ -386,7 +293,7 @@
       (swap! controller assoc :ci-monitor monitor)
       monitor)))
 
-(defn start-review-monitoring!
+(defn ^{:stratum 3} start-review-monitoring!
   "Start review monitoring for the PR."
   [controller]
   (let [{dag-id :dag/id run-id :run/id task-id :task/id
@@ -404,10 +311,8 @@
       (swap! controller assoc :review-monitor monitor)
       monitor)))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Fix handling
-
-(defn handle-ci-failure!
+(defn ^{:stratum 3} handle-ci-failure!
   "Handle a CI failure by running the fix loop."
   [controller ci-logs]
   (let [{task-id :task/id :keys [task pr config event-bus logger generate-fn]} @controller
@@ -443,7 +348,7 @@
           (add-history! controller :ci-fix-completed (fix-completion-data fix-result))
           fix-result)))))
 
-(defn handle-review-feedback!
+(defn ^{:stratum 3} handle-review-feedback!
   "Handle review feedback by running the fix loop."
   [controller review-comments]
   (let [{task-id :task/id :keys [task pr config event-bus logger generate-fn]} @controller
@@ -476,10 +381,8 @@
           (add-history! controller :review-fix-completed (fix-completion-data fix-result))
           fix-result)))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Merge
-
-(defn attempt-merge!
+(defn ^{:stratum 3} attempt-merge!
   "Attempt to merge the PR."
   [controller]
   (let [{dag-id :dag/id run-id :run/id task-id :task/id
@@ -519,10 +422,106 @@
         (add-history! controller :merge-blocked {:reason (:error merge-result)}))
       merge-result)))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Main control loop
+;------------------------------------------------------------------------------ Layer 4
 
-(defn run-lifecycle!
+(defn ^{:stratum 4} create-and-checkout-branch!
+  "Create and checkout a new branch for the task.
+   Returns the branch result or a DAG error."
+  [controller worktree-path branch-name]
+  (let [branch-result (release/create-branch! worktree-path branch-name)]
+    (if (schema/succeeded? branch-result)
+      branch-result
+      (do
+        (add-history! controller :pr-creation-failed {:error (:error branch-result)})
+        (fail-controller! controller :branch-creation-failed (:error branch-result))))))
+
+(defn ^{:stratum 4} apply-code-to-files!
+  "Apply the code artifact to the worktree.
+   Returns the apply result or a DAG error."
+  [controller worktree-path code-artifact logger]
+  (let [apply-result (fix/apply-fix-to-worktree worktree-path code-artifact logger)]
+    (if (dag/err? apply-result)
+      (fail-controller! controller :artifact-apply-failed (:error apply-result))
+      apply-result)))
+
+(defn ^{:stratum 4} commit-changes!
+  "Stage and commit all changes with the given task info.
+   Returns the commit result or a DAG error."
+  [controller worktree-path task task-id]
+  (let [commit-msg (build-commit-message task task-id)
+        commit-result (release/commit-changes! worktree-path commit-msg)]
+    (if (schema/succeeded? commit-result)
+      commit-result
+      (fail-controller! controller :commit-failed (:error commit-result)))))
+
+(defn ^{:stratum 4} push-and-create-pr!
+  "Push the branch and open a GitHub PR.
+   Returns the PR info map or a DAG error."
+  [controller worktree-path branch-name base-branch task task-id commit-result]
+  (let [push-result (release/push-branch! worktree-path branch-name)]
+    (if-not (schema/succeeded? push-result)
+      (fail-controller! controller :push-failed (:error push-result))
+      (let [pr-title (build-pr-title task task-id)
+            pr-body (build-pr-body task)
+            pr-result (release/create-pr! worktree-path
+                                          {:title pr-title
+                                           :body pr-body
+                                           :base-branch base-branch})]
+        (if-not (schema/succeeded? pr-result)
+          (fail-controller! controller :pr-creation-failed (:error pr-result))
+          {:pr/id       (:pr-number pr-result)
+           :pr/url      (:pr-url pr-result)
+           :pr/branch   branch-name
+           :pr/base-sha nil
+           :pr/head-sha (:commit-sha commit-result)})))))
+
+;------------------------------------------------------------------------------ Layer 5
+
+;; PR creation orchestrator
+(defn ^{:stratum 5} create-pr!
+  "Create a PR for the task.
+
+   Arguments:
+   - controller: Controller state atom
+   - code-artifact: Code artifact to commit
+
+   Returns result with PR info."
+  [controller code-artifact]
+  (let [{dag-id :dag/id run-id :run/id task-id :task/id
+         :keys [task config event-bus logger]} @controller
+        {:keys [worktree-path branch-name-prefix]} config
+        branch-name (str branch-name-prefix (task-id-fragment task-id))]
+
+    (update-status! controller :creating-pr)
+    (add-history! controller :pr-creation-started {:branch branch-name})
+
+    (when logger
+      (log/info logger :pr-lifecycle :controller/creating-pr
+                {:message (messages/t :controller/creating-pr)
+                 :data {:task-id task-id :branch branch-name}}))
+
+    (let [branch-result (create-and-checkout-branch! controller worktree-path branch-name)]
+      (if (dag/err? branch-result)
+        branch-result
+        (let [apply-result (apply-code-to-files! controller worktree-path code-artifact logger)]
+          (if (dag/err? apply-result)
+            apply-result
+            (let [commit-result (commit-changes! controller worktree-path task task-id)]
+              (if (dag/err? commit-result)
+                commit-result
+                (let [pr-info (push-and-create-pr! controller worktree-path branch-name
+                                                   (:base-branch branch-result)
+                                                   task task-id commit-result)]
+                  (if (dag/err? pr-info)
+                    pr-info
+                    (finalize-pr-creation! controller pr-info
+                                           dag-id run-id task-id
+                                           event-bus logger)))))))))))
+
+;------------------------------------------------------------------------------ Layer 6
+
+;; Main control loop
+(defn ^{:stratum 6} run-lifecycle!
   "Run the full PR lifecycle for a task.
 
    This is the main entry point that orchestrates:

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/controller_config.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/controller_config.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.controller-config
   "Load PR lifecycle controller defaults from EDN configuration."
   (:require
@@ -23,9 +22,9 @@
    [ai.miniforge.schema.interface :as schema]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Schemas + config loading
 
-(def ControllerDefaults
+;; Schemas + config loading
+(def ^{:stratum 0} ControllerDefaults
   [:map
    [:max-fix-iterations nat-int?]
    [:ci-poll-interval-ms nat-int?]
@@ -33,31 +32,37 @@
    [:auto-resolve-comments boolean?]
    [:branch-name-prefix :string]])
 
-(def ControllerConfig
-  [:map
-   [:pr-lifecycle/controller-defaults ControllerDefaults]])
-
-(def ^:private controller-defaults-resource
+(def ^{:stratum 0} ^:private controller-defaults-resource
   "Classpath resource holding controller defaults."
   "config/pr-lifecycle/controller-defaults.edn")
 
-(defn- validate!
+(defn- ^{:stratum 0} validate!
   [result-schema value]
   (schema/validate result-schema value))
 
-(defn- load-controller-config
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} ControllerConfig
+  [:map
+   [:pr-lifecycle/controller-defaults ControllerDefaults]])
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- ^{:stratum 2} load-controller-config
   []
   (validate! ControllerConfig
              (config/load-config-resource controller-defaults-resource
                                           [:pr-lifecycle/controller-defaults])))
 
-(def ^:private controller-config
+;------------------------------------------------------------------------------ Layer 3
+
+(def ^{:stratum 3} ^:private controller-config
   (delay (load-controller-config)))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Public helpers
+;------------------------------------------------------------------------------ Layer 4
 
-(defn controller-defaults
+;; Public helpers
+(defn ^{:stratum 4} controller-defaults
   "Return the PR lifecycle controller defaults map."
   []
   (:pr-lifecycle/controller-defaults @controller-config))

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/events.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/events.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.events
   "PR lifecycle events.
 
@@ -26,9 +25,9 @@
    [ai.miniforge.logging.interface :as log]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Event types
 
-(def event-types
+;; Event types
+(def ^{:stratum 0} event-types
   "Valid PR lifecycle event types."
   #{:pr/opened           ; PR successfully created
     :pr/ci-passed        ; CI checks passed
@@ -40,12 +39,10 @@
     :pr/closed           ; PR closed without merge
     :pr/rebase-needed    ; Base branch moved, rebase required
     :pr/conflict         ; Merge conflict detected
-    :pr/fix-pushed})     ; Fix commit pushed
+    :pr/fix-pushed})  ; Fix commit pushed
 
-;------------------------------------------------------------------------------ Layer 0
 ;; Event constructors
-
-(defn create-event
+(defn ^{:stratum 0} create-event
   "Create a PR lifecycle event.
 
    Arguments:
@@ -71,126 +68,8 @@
     :event/timestamp (java.util.Date.)}
    data))
 
-(defn pr-opened
-  [dag-id run-id task-id pr-id pr-url branch sha]
-  (create-event :pr/opened
-                {:dag/id dag-id
-                 :run/id run-id
-                 :task/id task-id
-                 :pr/id pr-id
-                 :pr/url pr-url
-                 :pr/branch branch
-                 :pr/sha sha}))
-
-(defn ci-passed
-  [dag-id run-id task-id pr-id sha]
-  (create-event :pr/ci-passed
-                {:dag/id dag-id
-                 :run/id run-id
-                 :task/id task-id
-                 :pr/id pr-id
-                 :pr/sha sha}))
-
-(defn ci-failed
-  [dag-id run-id task-id pr-id sha logs]
-  (create-event :pr/ci-failed
-                {:dag/id dag-id
-                 :run/id run-id
-                 :task/id task-id
-                 :pr/id pr-id
-                 :pr/sha sha
-                 :ci/logs logs}))
-
-(defn review-approved
-  [dag-id run-id task-id pr-id approvers]
-  (create-event :pr/review-approved
-                {:dag/id dag-id
-                 :run/id run-id
-                 :task/id task-id
-                 :pr/id pr-id
-                 :review/approvers approvers}))
-
-(defn review-changes-requested
-  [dag-id run-id task-id pr-id comments]
-  (create-event :pr/review-changes-requested
-                {:dag/id dag-id
-                 :run/id run-id
-                 :task/id task-id
-                 :pr/id pr-id
-                 :review/comments comments}))
-
-(defn comment-actionable
-  [dag-id run-id task-id pr-id comment-data]
-  (create-event :pr/comment-actionable
-                {:dag/id dag-id
-                 :run/id run-id
-                 :task/id task-id
-                 :pr/id pr-id
-                 :comment comment-data}))
-
-(defn merged
-  "Create a merged event.
-
-   `labels` is an optional set of strings — the GitHub-native label
-   names attached to the PR at merge time. Carrying them here lets
-   downstream watchers (e.g. the pr-label-actions M2 brick) match
-   without re-querying GitHub. The 5-arity preserves backward
-   compatibility for callers that don't have label data on hand;
-   they default to an empty set."
-  ([dag-id run-id task-id pr-id merge-sha]
-   (merged dag-id run-id task-id pr-id merge-sha #{}))
-  ([dag-id run-id task-id pr-id merge-sha labels]
-   (create-event :pr/merged
-                 {:dag/id dag-id
-                  :run/id run-id
-                  :task/id task-id
-                  :pr/id pr-id
-                  :pr/merge-sha merge-sha
-                  :pr/labels (set labels)})))
-
-(defn closed
-  "Create a closed (without merge) event."
-  [dag-id run-id task-id pr-id reason]
-  (create-event :pr/closed
-                {:dag/id dag-id
-                 :run/id run-id
-                 :task/id task-id
-                 :pr/id pr-id
-                 :close/reason reason}))
-
-(defn rebase-needed
-  [dag-id run-id task-id pr-id base-sha]
-  (create-event :pr/rebase-needed
-                {:dag/id dag-id
-                 :run/id run-id
-                 :task/id task-id
-                 :pr/id pr-id
-                 :pr/base-sha base-sha}))
-
-(defn conflict
-  "Create a conflict detected event."
-  [dag-id run-id task-id pr-id conflicting-files]
-  (create-event :pr/conflict
-                {:dag/id dag-id
-                 :run/id run-id
-                 :task/id task-id
-                 :pr/id pr-id
-                 :conflict/files conflicting-files}))
-
-(defn fix-pushed
-  [dag-id run-id task-id pr-id sha fix-type]
-  (create-event :pr/fix-pushed
-                {:dag/id dag-id
-                 :run/id run-id
-                 :task/id task-id
-                 :pr/id pr-id
-                 :pr/sha sha
-                 :fix/type fix-type})) ; :ci-fix :review-fix :conflict-fix
-
-;------------------------------------------------------------------------------ Layer 1
 ;; Event channel/bus
-
-(defn create-event-bus
+(defn ^{:stratum 0} create-event-bus
   "Create an event bus for publishing and subscribing to events.
 
    Returns an atom containing:
@@ -202,7 +81,7 @@
          :subscribers {}
          :filters {}}))
 
-(defn publish!
+(defn ^{:stratum 0} publish!
   "Publish an event to the event bus.
    Notifies all subscribers whose filters match."
   [event-bus event logger]
@@ -230,7 +109,7 @@
                          :subscriber-count (count subscribers)}}))
     event))
 
-(defn subscribe!
+(defn ^{:stratum 0} subscribe!
   "Subscribe to events on the event bus.
 
    Arguments:
@@ -250,7 +129,7 @@
                 (assoc-in [:filters subscriber-id] filter-fn))))
    subscriber-id))
 
-(defn unsubscribe!
+(defn ^{:stratum 0} unsubscribe!
   "Unsubscribe from events."
   [event-bus subscriber-id]
   (swap! event-bus
@@ -260,26 +139,144 @@
                (update :filters dissoc subscriber-id))))
   nil)
 
-(defn events-for-task
+(defn ^{:stratum 0} events-for-task
   "Get all events for a specific task."
   [event-bus task-id]
   (->> (:events @event-bus)
        (filter #(= task-id (:task/id %)))
        vec))
 
-(defn events-for-pr
+(defn ^{:stratum 0} events-for-pr
   "Get all events for a specific PR."
   [event-bus pr-id]
   (->> (:events @event-bus)
        (filter #(= pr-id (:pr/id %)))
        vec))
 
-(defn latest-event
+(defn ^{:stratum 0} latest-event
   "Get the most recent event matching a predicate."
   [event-bus pred]
   (->> (:events @event-bus)
        (filter pred)
        last))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} pr-opened
+  [dag-id run-id task-id pr-id pr-url branch sha]
+  (create-event :pr/opened
+                {:dag/id dag-id
+                 :run/id run-id
+                 :task/id task-id
+                 :pr/id pr-id
+                 :pr/url pr-url
+                 :pr/branch branch
+                 :pr/sha sha}))
+
+(defn ^{:stratum 1} ci-passed
+  [dag-id run-id task-id pr-id sha]
+  (create-event :pr/ci-passed
+                {:dag/id dag-id
+                 :run/id run-id
+                 :task/id task-id
+                 :pr/id pr-id
+                 :pr/sha sha}))
+
+(defn ^{:stratum 1} ci-failed
+  [dag-id run-id task-id pr-id sha logs]
+  (create-event :pr/ci-failed
+                {:dag/id dag-id
+                 :run/id run-id
+                 :task/id task-id
+                 :pr/id pr-id
+                 :pr/sha sha
+                 :ci/logs logs}))
+
+(defn ^{:stratum 1} review-approved
+  [dag-id run-id task-id pr-id approvers]
+  (create-event :pr/review-approved
+                {:dag/id dag-id
+                 :run/id run-id
+                 :task/id task-id
+                 :pr/id pr-id
+                 :review/approvers approvers}))
+
+(defn ^{:stratum 1} review-changes-requested
+  [dag-id run-id task-id pr-id comments]
+  (create-event :pr/review-changes-requested
+                {:dag/id dag-id
+                 :run/id run-id
+                 :task/id task-id
+                 :pr/id pr-id
+                 :review/comments comments}))
+
+(defn ^{:stratum 1} comment-actionable
+  [dag-id run-id task-id pr-id comment-data]
+  (create-event :pr/comment-actionable
+                {:dag/id dag-id
+                 :run/id run-id
+                 :task/id task-id
+                 :pr/id pr-id
+                 :comment comment-data}))
+
+(defn ^{:stratum 1} merged
+  "Create a merged event.
+
+   `labels` is an optional set of strings — the GitHub-native label
+   names attached to the PR at merge time. Carrying them here lets
+   downstream watchers (e.g. the pr-label-actions M2 brick) match
+   without re-querying GitHub. The 5-arity preserves backward
+   compatibility for callers that don't have label data on hand;
+   they default to an empty set."
+  ([dag-id run-id task-id pr-id merge-sha]
+   (merged dag-id run-id task-id pr-id merge-sha #{}))
+  ([dag-id run-id task-id pr-id merge-sha labels]
+   (create-event :pr/merged
+                 {:dag/id dag-id
+                  :run/id run-id
+                  :task/id task-id
+                  :pr/id pr-id
+                  :pr/merge-sha merge-sha
+                  :pr/labels (set labels)})))
+
+(defn ^{:stratum 1} closed
+  "Create a closed (without merge) event."
+  [dag-id run-id task-id pr-id reason]
+  (create-event :pr/closed
+                {:dag/id dag-id
+                 :run/id run-id
+                 :task/id task-id
+                 :pr/id pr-id
+                 :close/reason reason}))
+
+(defn ^{:stratum 1} rebase-needed
+  [dag-id run-id task-id pr-id base-sha]
+  (create-event :pr/rebase-needed
+                {:dag/id dag-id
+                 :run/id run-id
+                 :task/id task-id
+                 :pr/id pr-id
+                 :pr/base-sha base-sha}))
+
+(defn ^{:stratum 1} conflict
+  "Create a conflict detected event."
+  [dag-id run-id task-id pr-id conflicting-files]
+  (create-event :pr/conflict
+                {:dag/id dag-id
+                 :run/id run-id
+                 :task/id task-id
+                 :pr/id pr-id
+                 :conflict/files conflicting-files}))
+
+(defn ^{:stratum 1} fix-pushed
+  [dag-id run-id task-id pr-id sha fix-type]
+  (create-event :pr/fix-pushed
+                {:dag/id dag-id
+                 :run/id run-id
+                 :task/id task-id
+                 :pr/id pr-id
+                 :pr/sha sha
+                 :fix/type fix-type}))  ; :ci-fix :review-fix :conflict-fix
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/fix_loop.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/fix_loop.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.fix-loop
   "Automated fix generation for CI failures and review feedback.
 
@@ -33,9 +32,9 @@
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Fix context building
 
-(defn create-fix-context
+;; Fix context building
+(defn ^{:stratum 0} create-fix-context
   "Build context pack for fix generation.
 
    Arguments:
@@ -81,7 +80,7 @@
 
    :fix/created-at (java.util.Date.)})
 
-(defn build-fix-prompt
+(defn ^{:stratum 0} build-fix-prompt
   "Build a prompt for the fix agent based on failure type.
 
    Arguments:
@@ -127,10 +126,8 @@
            "Summary: " summary "\n\n"
            "Affected files: " affected-files))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Fix generation
-
-(defn generate-fix
+(defn ^{:stratum 0} generate-fix
   "Generate a fix using the inner loop.
 
    Arguments:
@@ -161,10 +158,8 @@
     ;; Use inner loop for generate → validate → repair cycle
     (loop/run-simple task generate-fn loop-context)))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Fix application
-
-(defn apply-fix-to-worktree
+(defn ^{:stratum 0} apply-fix-to-worktree
   "Apply a fix artifact to the git worktree.
 
    Arguments:
@@ -200,7 +195,7 @@
                       :data {:error (.getMessage e)}}))
         (dag/err :fix-apply-failed (.getMessage e))))))
 
-(defn commit-fix
+(defn ^{:stratum 0} commit-fix
   "Commit fix changes and push to the PR branch.
 
    Arguments:
@@ -235,10 +230,8 @@
             (dag/err :push-failed (:error push-result))))
         (dag/err :commit-failed (:error stage-result))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Conversation resolution
-
-(defn resolve-comment-thread
+(defn ^{:stratum 0} resolve-comment-thread
   "Resolve a conversation thread after creating a fix PR.
 
    Arguments:
@@ -288,10 +281,10 @@
                                        (not parent-pr-number) "no parent-pr-number")}}))
         (dag/ok {:skipped true :reason "missing-metadata"})))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Fix loop orchestration
+;------------------------------------------------------------------------------ Layer 1
 
-(defn run-fix-loop
+;; Fix loop orchestration
+(defn ^{:stratum 1} run-fix-loop
   "Run the complete fix loop for a failure.
 
    This is the main entry point for automated fix generation.
@@ -426,9 +419,9 @@
                    new-metrics)))))))
 
 ;------------------------------------------------------------------------------ Layer 2
-;; Specialized fix functions
 
-(defn fix-ci-failure
+;; Specialized fix functions
+(defn ^{:stratum 2} fix-ci-failure
   "Convenience function for fixing CI failures.
 
    Arguments:
@@ -447,7 +440,7 @@
     (run-fix-loop task pr-info failure-info generate-fn context
                   :worktree-path (:worktree-path context))))
 
-(defn fix-review-feedback
+(defn ^{:stratum 2} fix-review-feedback
   "Convenience function for fixing review feedback.
 
    Arguments:
@@ -478,7 +471,7 @@
                   :worktree-path (:worktree-path context)
                   :auto-resolve-comments (:auto-resolve-comments context true))))
 
-(defn fix-merge-conflict
+(defn ^{:stratum 2} fix-merge-conflict
   "Convenience function for fixing merge conflicts.
 
    Arguments:

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/fsm.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/fsm.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.fsm
   "Finite State Machine for PR lifecycle controller status transitions.
 
@@ -29,9 +28,9 @@
    [ai.miniforge.schema.interface :as schema]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; FSM definition
 
-(def PrLifecycleFsmConfig
+;; FSM definition
+(def ^{:stratum 0} PrLifecycleFsmConfig
   [:map
    [:pr-lifecycle/fsm
     [:map
@@ -40,119 +39,29 @@
      [:terminal-statuses [:set keyword?]]
      [:status-transition-events [:map-of [:tuple keyword? keyword?] keyword?]]]]])
 
-(def ^:private fsm-config-resource
+(def ^{:stratum 0} ^:private fsm-config-resource
   "Classpath resource holding the PR lifecycle FSM definition."
   "config/pr-lifecycle/fsm.edn")
 
-(defn- validate!
+(defn- ^{:stratum 0} validate!
   [result-schema value]
   (schema/validate result-schema value))
 
-(defn- load-fsm-config
-  []
-  (validate! PrLifecycleFsmConfig
-             (config/load-config-resource fsm-config-resource
-                                          [:pr-lifecycle/fsm])))
-
-(def ^:private fsm-config
-  "Validated PR lifecycle FSM configuration loaded eagerly at require time."
-  (load-fsm-config))
-
-(def initial-status
-  "Initial controller status."
-  (get-in fsm-config [:pr-lifecycle/fsm :initial-status]))
-
-(def controller-status-order
-  "Ordered controller statuses for machine compilation."
-  (get-in fsm-config [:pr-lifecycle/fsm :statuses]))
-
-(def status-transition-events
-  "Configured controller transitions keyed by `[from-status to-status]`."
-  (get-in fsm-config [:pr-lifecycle/fsm :status-transition-events]))
-
-(def controller-statuses
-  "Valid controller statuses."
-  (set controller-status-order))
-
-(def terminal-statuses
-  "Terminal controller statuses."
-  (get-in fsm-config [:pr-lifecycle/fsm :terminal-statuses]))
-
-(defn valid-status?
-  "Check whether `status` is a recognized controller status."
-  [status]
-  (contains? controller-statuses status))
-
-(defn terminal-status?
-  "Check whether `status` is terminal."
-  [status]
-  (contains? terminal-statuses status))
-
-(defn succeeded?
+(defn ^{:stratum 0} succeeded?
   "Check whether a controller transition result succeeded."
   [result]
   (schema/succeeded? result))
 
-(defn failed?
+(defn ^{:stratum 0} failed?
   "Check whether a controller transition result failed."
   [result]
   (schema/failed? result))
 
-(defn- transition-targets
-  "Return all configured targets from `from-status`."
-  [from-status]
-  (->> status-transition-events
-       (keep (fn [[[source-status target-status] _event]]
-               (when (= source-status from-status)
-                 target-status)))
-       set))
-
-(defn- machine-state-definition
-  "Return the machine state definition for a controller status."
-  [status]
-  (if (terminal-status? status)
-    {:type :final}
-    {:on (into {}
-               (for [[[source-status target-status] event] status-transition-events
-                     :when (= source-status status)]
-                 [event target-status]))}))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Transition validation
-
-(defn valid-transition?
-  "Check whether the controller may move from `from-status` to `to-status`.
-
-   Same-state transitions are treated as valid idempotent updates."
-  [from-status to-status]
-  (and (valid-status? from-status)
-       (valid-status? to-status)
-       (or (= from-status to-status)
-           (contains? status-transition-events [from-status to-status]))))
-
-(defn valid-targets
-  "Return the valid target statuses from `from-status`, including itself."
-  [from-status]
-  (if (valid-status? from-status)
-    (conj (transition-targets from-status) from-status)
-    #{}))
-
-;------------------------------------------------------------------------------ Layer 2
 ;; Transition execution
-
-(def ^:private transition-data-key
+(def ^{:stratum 0} ^:private transition-data-key
   :transition)
 
-(declare transition-failure)
-
-(defn- transition-result
-  "Create a successful controller transition result."
-  [state event]
-  (let [transition {:state state
-                    :event event}]
-    (schema/success transition-data-key transition)))
-
-(defn- transition-error
+(defn- ^{:stratum 0} transition-error
   "Create a structured controller transition error map."
   [error-code from-status to-status]
   (let [message (case error-code
@@ -172,43 +81,151 @@
     {:code error-code
      :message message}))
 
-(defn transition-state
-  "Return the target controller state from a transition result."
-  [result]
-  (get-in result [transition-data-key :state]))
-
-(defn transition-event
-  "Return the transition event from a transition result."
-  [result]
-  (get-in result [transition-data-key :event]))
-
-(defn transition-error-code
+(defn ^{:stratum 0} transition-error-code
   "Return the transition error code from a failed result."
   [result]
   (get-in result [:error :code]))
 
-(defn transition-error-message
+(defn ^{:stratum 0} transition-error-message
   "Return the transition error message from a failed result."
   [result]
   (get-in result [:error :message]))
 
-(def controller-state-definitions
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} load-fsm-config
+  []
+  (validate! PrLifecycleFsmConfig
+             (config/load-config-resource fsm-config-resource
+                                          [:pr-lifecycle/fsm])))
+
+(defn- ^{:stratum 1} transition-result
+  "Create a successful controller transition result."
+  [state event]
+  (let [transition {:state state
+                    :event event}]
+    (schema/success transition-data-key transition)))
+
+(defn ^{:stratum 1} transition-state
+  "Return the target controller state from a transition result."
+  [result]
+  (get-in result [transition-data-key :state]))
+
+(defn ^{:stratum 1} transition-event
+  "Return the transition event from a transition result."
+  [result]
+  (get-in result [transition-data-key :event]))
+
+(defn- ^{:stratum 1} transition-failure
+  "Return a consistent controller transition failure result."
+  [error-code from-status to-status]
+  (let [error (transition-error error-code from-status to-status)]
+    (schema/failure transition-data-key error)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(def ^{:stratum 2} ^:private fsm-config
+  "Validated PR lifecycle FSM configuration loaded eagerly at require time."
+  (load-fsm-config))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(def ^{:stratum 3} initial-status
+  "Initial controller status."
+  (get-in fsm-config [:pr-lifecycle/fsm :initial-status]))
+
+(def ^{:stratum 3} controller-status-order
+  "Ordered controller statuses for machine compilation."
+  (get-in fsm-config [:pr-lifecycle/fsm :statuses]))
+
+(def ^{:stratum 3} status-transition-events
+  "Configured controller transitions keyed by `[from-status to-status]`."
+  (get-in fsm-config [:pr-lifecycle/fsm :status-transition-events]))
+
+(def ^{:stratum 3} terminal-statuses
+  "Terminal controller statuses."
+  (get-in fsm-config [:pr-lifecycle/fsm :terminal-statuses]))
+
+;------------------------------------------------------------------------------ Layer 4
+
+(def ^{:stratum 4} controller-statuses
+  "Valid controller statuses."
+  (set controller-status-order))
+
+(defn ^{:stratum 4} terminal-status?
+  "Check whether `status` is terminal."
+  [status]
+  (contains? terminal-statuses status))
+
+(defn- ^{:stratum 4} transition-targets
+  "Return all configured targets from `from-status`."
+  [from-status]
+  (->> status-transition-events
+       (keep (fn [[[source-status target-status] _event]]
+               (when (= source-status from-status)
+                 target-status)))
+       set))
+
+;------------------------------------------------------------------------------ Layer 5
+
+(defn ^{:stratum 5} valid-status?
+  "Check whether `status` is a recognized controller status."
+  [status]
+  (contains? controller-statuses status))
+
+(defn- ^{:stratum 5} machine-state-definition
+  "Return the machine state definition for a controller status."
+  [status]
+  (if (terminal-status? status)
+    {:type :final}
+    {:on (into {}
+               (for [[[source-status target-status] event] status-transition-events
+                     :when (= source-status status)]
+                 [event target-status]))}))
+
+;------------------------------------------------------------------------------ Layer 6
+
+;; Transition validation
+(defn ^{:stratum 6} valid-transition?
+  "Check whether the controller may move from `from-status` to `to-status`.
+
+   Same-state transitions are treated as valid idempotent updates."
+  [from-status to-status]
+  (and (valid-status? from-status)
+       (valid-status? to-status)
+       (or (= from-status to-status)
+           (contains? status-transition-events [from-status to-status]))))
+
+(defn ^{:stratum 6} valid-targets
+  "Return the valid target statuses from `from-status`, including itself."
+  [from-status]
+  (if (valid-status? from-status)
+    (conj (transition-targets from-status) from-status)
+    #{}))
+
+(def ^{:stratum 6} controller-state-definitions
   "Machine state definitions keyed by controller status."
   (zipmap controller-status-order
           (map machine-state-definition controller-status-order)))
 
-(def controller-machine-config
+;------------------------------------------------------------------------------ Layer 7
+
+(def ^{:stratum 7} controller-machine-config
   "PR lifecycle controller machine configuration."
   {:fsm/id :pr-lifecycle-controller
    :fsm/initial initial-status
    :fsm/context {}
    :fsm/states controller-state-definitions})
 
-(def controller-machine
+;------------------------------------------------------------------------------ Layer 8
+
+(def ^{:stratum 8} controller-machine
   "Compiled controller machine."
   (fsm/define-machine controller-machine-config))
 
-(defn transition
+;------------------------------------------------------------------------------ Layer 9
+
+(defn ^{:stratum 9} transition
   "Attempt a controller status transition.
 
    Returns:
@@ -235,12 +252,6 @@
             new-state (fsm/current-state new-state-map)]
         (transition-result new-state event))
       (transition-failure :invalid-transition from-status to-status))))
-
-(defn- transition-failure
-  "Return a consistent controller transition failure result."
-  [error-code from-status to-status]
-  (let [error (transition-error error-code from-status to-status)]
-    (schema/failure transition-data-key error)))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.github
   "GitHub API operations for PR conversation management.
 
@@ -29,9 +28,9 @@
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; GitHub CLI helpers
 
-(defn run-gh-command
+;; GitHub CLI helpers
+(defn ^{:stratum 0} run-gh-command
   "Run a gh CLI command and return result.
 
    Arguments:
@@ -56,7 +55,71 @@
     (catch Exception e
       (dag/err :gh-exception (.getMessage e)))))
 
-(defn graphql-query
+;; Batched review posting (N13 §2.2 Standards Reviewer)
+(def ^{:stratum 0} review-marker
+  "Invisible HTML comment appended to every review body posted via
+   `post-review!`. Lets `review-scheduler/existing-review-shas`
+   recognize prior posts authored by the N13 Standards Reviewer
+   (GitHub doesn't surface a stable bot identity for reviews posted
+   under a personal access token, so we tag the body instead).
+   Renders as nothing in PR Markdown."
+  "<!-- miniforge:policy-eval -->")
+
+(defn- ^{:stratum 0} run-gh-with-stdin
+  "Run a `gh` command piping `stdin-body` over stdin. Returns the
+   same DAG-shaped result as `run-gh-command`. Used for `gh api ...
+   --input -` invocations where the JSON body is too large or too
+   nested to fit `-f`/`-F` field-pair encoding."
+  [args worktree-path stdin-body]
+  (try
+    (let [result (apply process/shell
+                        {:dir (str worktree-path)
+                         :in stdin-body
+                         :out :string
+                         :err :string
+                         :continue true}
+                        args)]
+      (if (zero? (:exit result))
+        (dag/ok {:output (str/trim (:out result ""))})
+        (dag/err :gh-command-failed
+                 (str/trim (:err result ""))
+                 {:exit-code (:exit result)
+                  :command args})))
+    (catch Exception e
+      (dag/err :gh-exception (.getMessage e)))))
+
+(defn- ^{:stratum 0} review-comment->github-comment
+  "Translate one comment record from `compliance-scanner.comments`
+   (`{:comment/path :comment/line :comment/body ...}`) to the inline-
+   comment shape GitHub's create-review API expects."
+  [c]
+  (let [path (or (:comment/path c) (:path c))
+        line (or (:comment/line c) (:line c))
+        body (or (:comment/body c) (:body c))]
+    {:path path
+     :line line
+     :side "RIGHT"
+     :body body}))
+
+(defn ^{:stratum 0} git-head-sha
+  "Return the full HEAD SHA of `worktree-path`, or nil if `git
+   rev-parse` fails. Used to populate `commit_id` for the create-review
+   API, which 422s on inline `comments[]` payloads without it."
+  [worktree-path]
+  (try
+    (let [r (process/shell {:dir (str worktree-path)
+                            :out :string
+                            :err :string
+                            :continue true}
+                           "git" "rev-parse" "HEAD")]
+      (when (zero? (:exit r))
+        (let [sha (str/trim (:out r ""))]
+          (when (seq sha) sha))))
+    (catch Throwable _ nil)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} graphql-query
   "Execute a GraphQL query via gh CLI.
 
    Arguments:
@@ -86,7 +149,44 @@
           (dag/err :json-parse-error (.getMessage e))))
       result)))
 
-(defn graphql-mutation
+(defn ^{:stratum 1} reply-to-comment
+  "Post a reply to a review comment thread.
+
+   Arguments:
+   - worktree-path: Path to git worktree
+   - pr-number: Pull request number
+   - comment-id: Comment ID to reply to
+   - message: Reply message text
+
+   Returns DAG result with reply info or error"
+  [worktree-path pr-number comment-id message]
+  (let [;; Use gh API to post reply to PR review comment
+        args ["gh" "api"
+              (str "repos/{owner}/{repo}/pulls/" pr-number "/comments/" comment-id "/replies")
+              "-X" "POST"
+              "-f" (str "body=" message)]
+        result (run-gh-command args worktree-path)]
+    (if (dag/ok? result)
+      (try
+        (let [parsed (json/parse-string (:output (:data result)) true)]
+          (dag/ok {:reply-id (:id parsed)
+                   :url (:html_url parsed)
+                   :body (:body parsed)}))
+        (catch Exception e
+          (dag/err :json-parse-error (.getMessage e))))
+      result)))
+
+(defn- ^{:stratum 1} ensure-marker
+  "Append `review-marker` to `body` if not already present.
+   Idempotent. Used unconditionally by `post-review!`."
+  [body]
+  (if (and (string? body) (str/includes? body review-marker))
+    body
+    (str (or body "") "\n\n" review-marker)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} graphql-mutation
   "Execute a GraphQL mutation via gh CLI.
 
    Arguments:
@@ -100,10 +200,8 @@
   [mutation worktree-path & {:keys [variables]}]
   (graphql-query mutation worktree-path :variables variables))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; GitHub API operations
-
-(defn get-thread-id
+(defn ^{:stratum 2} get-thread-id
   "Get GraphQL thread ID from a comment ID.
 
    GitHub review comments have both a REST API comment ID and a
@@ -165,135 +263,7 @@
                             :pr-number pr-number})))
               result)))))))
 
-(defn reply-to-comment
-  "Post a reply to a review comment thread.
-
-   Arguments:
-   - worktree-path: Path to git worktree
-   - pr-number: Pull request number
-   - comment-id: Comment ID to reply to
-   - message: Reply message text
-
-   Returns DAG result with reply info or error"
-  [worktree-path pr-number comment-id message]
-  (let [;; Use gh API to post reply to PR review comment
-        args ["gh" "api"
-              (str "repos/{owner}/{repo}/pulls/" pr-number "/comments/" comment-id "/replies")
-              "-X" "POST"
-              "-f" (str "body=" message)]
-        result (run-gh-command args worktree-path)]
-    (if (dag/ok? result)
-      (try
-        (let [parsed (json/parse-string (:output (:data result)) true)]
-          (dag/ok {:reply-id (:id parsed)
-                   :url (:html_url parsed)
-                   :body (:body parsed)}))
-        (catch Exception e
-          (dag/err :json-parse-error (.getMessage e))))
-      result)))
-
-(defn resolve-conversation
-  "Mark a conversation thread as resolved via GraphQL.
-
-   Arguments:
-   - worktree-path: Path to git worktree
-   - thread-id: GraphQL thread ID (starts with 'PRRT_' or 'RT_')
-
-   Returns DAG result with resolution status or error"
-  [worktree-path thread-id]
-  (let [mutation (str "mutation {
-  resolveReviewThread(input: {threadId: \"" thread-id "\"}) {
-    thread {
-      id
-      isResolved
-    }
-  }
-}")
-        result (graphql-mutation mutation worktree-path)]
-    (if (dag/ok? result)
-      (let [thread (get-in (:data result) [:data :resolveReviewThread :thread])
-            is-resolved (:isResolved thread)]
-        (if is-resolved
-          (dag/ok {:thread-id (:id thread)
-                   :resolved true})
-          (dag/err :resolution-failed
-                   "Thread resolution returned false"
-                   {:thread-id thread-id :thread thread})))
-      result)))
-
-;------------------------------------------------------------------------------ Layer 1.5
-;; Batched review posting (N13 §2.2 Standards Reviewer)
-
-(def review-marker
-  "Invisible HTML comment appended to every review body posted via
-   `post-review!`. Lets `review-scheduler/existing-review-shas`
-   recognize prior posts authored by the N13 Standards Reviewer
-   (GitHub doesn't surface a stable bot identity for reviews posted
-   under a personal access token, so we tag the body instead).
-   Renders as nothing in PR Markdown."
-  "<!-- miniforge:policy-eval -->")
-
-(defn- ensure-marker
-  "Append `review-marker` to `body` if not already present.
-   Idempotent. Used unconditionally by `post-review!`."
-  [body]
-  (if (and (string? body) (str/includes? body review-marker))
-    body
-    (str (or body "") "\n\n" review-marker)))
-
-(defn- run-gh-with-stdin
-  "Run a `gh` command piping `stdin-body` over stdin. Returns the
-   same DAG-shaped result as `run-gh-command`. Used for `gh api ...
-   --input -` invocations where the JSON body is too large or too
-   nested to fit `-f`/`-F` field-pair encoding."
-  [args worktree-path stdin-body]
-  (try
-    (let [result (apply process/shell
-                        {:dir (str worktree-path)
-                         :in stdin-body
-                         :out :string
-                         :err :string
-                         :continue true}
-                        args)]
-      (if (zero? (:exit result))
-        (dag/ok {:output (str/trim (:out result ""))})
-        (dag/err :gh-command-failed
-                 (str/trim (:err result ""))
-                 {:exit-code (:exit result)
-                  :command args})))
-    (catch Exception e
-      (dag/err :gh-exception (.getMessage e)))))
-
-(defn- review-comment->github-comment
-  "Translate one comment record from `compliance-scanner.comments`
-   (`{:comment/path :comment/line :comment/body ...}`) to the inline-
-   comment shape GitHub's create-review API expects."
-  [c]
-  (let [path (or (:comment/path c) (:path c))
-        line (or (:comment/line c) (:line c))
-        body (or (:comment/body c) (:body c))]
-    {:path path
-     :line line
-     :side "RIGHT"
-     :body body}))
-
-(defn git-head-sha
-  "Return the full HEAD SHA of `worktree-path`, or nil if `git
-   rev-parse` fails. Used to populate `commit_id` for the create-review
-   API, which 422s on inline `comments[]` payloads without it."
-  [worktree-path]
-  (try
-    (let [r (process/shell {:dir (str worktree-path)
-                            :out :string
-                            :err :string
-                            :continue true}
-                           "git" "rev-parse" "HEAD")]
-      (when (zero? (:exit r))
-        (let [sha (str/trim (:out r ""))]
-          (when (seq sha) sha))))
-    (catch Throwable _ nil)))
-
-(defn post-review!
+(defn ^{:stratum 2} post-review!
   "Post a single PR review batching multiple inline comments.
 
    Uses the create-a-review REST endpoint
@@ -347,10 +317,41 @@
             (dag/err :json-parse-error (.getMessage e))))
         result))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; High-level conversation operations
+;------------------------------------------------------------------------------ Layer 3
 
-(defn link-fix-pr-to-comment
+(defn ^{:stratum 3} resolve-conversation
+  "Mark a conversation thread as resolved via GraphQL.
+
+   Arguments:
+   - worktree-path: Path to git worktree
+   - thread-id: GraphQL thread ID (starts with 'PRRT_' or 'RT_')
+
+   Returns DAG result with resolution status or error"
+  [worktree-path thread-id]
+  (let [mutation (str "mutation {
+  resolveReviewThread(input: {threadId: \"" thread-id "\"}) {
+    thread {
+      id
+      isResolved
+    }
+  }
+}")
+        result (graphql-mutation mutation worktree-path)]
+    (if (dag/ok? result)
+      (let [thread (get-in (:data result) [:data :resolveReviewThread :thread])
+            is-resolved (:isResolved thread)]
+        (if is-resolved
+          (dag/ok {:thread-id (:id thread)
+                   :resolved true})
+          (dag/err :resolution-failed
+                   "Thread resolution returned false"
+                   {:thread-id thread-id :thread thread})))
+      result)))
+
+;------------------------------------------------------------------------------ Layer 4
+
+;; High-level conversation operations
+(defn ^{:stratum 4} link-fix-pr-to-comment
   "Link a fix PR to a review comment and resolve the conversation.
 
    This is the main entry point for conversation resolution after

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/interface.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.interface
   "Public API for the PR lifecycle component.
 
@@ -56,16 +55,16 @@
    [ai.miniforge.pr-lifecycle.responder :as responder]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Events
 
-(def event-types
+;; Events
+(def ^{:stratum 0} event-types
   "Valid PR lifecycle event types.
    :pr/opened :pr/ci-passed :pr/ci-failed :pr/review-approved
    :pr/review-changes-requested :pr/comment-actionable :pr/merged
    :pr/closed :pr/rebase-needed :pr/conflict :pr/fix-pushed"
   events/event-types)
 
-(def create-event-bus
+(def ^{:stratum 0} create-event-bus
   "Create an event bus for publishing and subscribing to PR events.
 
    Example:
@@ -73,11 +72,11 @@
      (subscribe! bus :my-handler (fn [e] (println e)))"
   events/create-event-bus)
 
-(def publish!
+(def ^{:stratum 0} publish!
   "Publish an event to the event bus."
   events/publish!)
 
-(def subscribe!
+(def ^{:stratum 0} subscribe!
   "Subscribe to events on the event bus.
 
    Example:
@@ -86,20 +85,20 @@
                  (fn [e] (#{:pr/ci-passed :pr/ci-failed} (:event/type e))))"
   events/subscribe!)
 
-(def unsubscribe!
+(def ^{:stratum 0} unsubscribe!
   "Unsubscribe from events."
   events/unsubscribe!)
 
-(def events-for-task
+(def ^{:stratum 0} events-for-task
   "Get all events for a specific task."
   events/events-for-task)
 
-(def events-for-pr
+(def ^{:stratum 0} events-for-pr
   "Get all events for a specific PR."
   events/events-for-pr)
 
 ;; Event constructors
-(def pr-opened
+(def ^{:stratum 0} pr-opened
   "Build a `:pr/opened` event map.
    Args: [dag-id run-id task-id pr-id pr-url branch sha].
    Returns an event map with `:event/id` `:event/type :pr/opened`
@@ -107,42 +106,42 @@
    :pr/branch :pr/sha`. Pure constructor — never throws."
   events/pr-opened)
 
-(def ci-passed
+(def ^{:stratum 0} ci-passed
   "Build a `:pr/ci-passed` event map.
    Args: [dag-id run-id task-id pr-id sha]. Returns an event map with
    `:event/type :pr/ci-passed` plus `:dag/id :run/id :task/id :pr/id
    :pr/sha`. Pure constructor."
   events/ci-passed)
 
-(def ci-failed
+(def ^{:stratum 0} ci-failed
   "Build a `:pr/ci-failed` event map.
    Args: [dag-id run-id task-id pr-id sha logs]. Returns an event map
    with `:event/type :pr/ci-failed` plus `:dag/id :run/id :task/id
    :pr/id :pr/sha :ci/logs`. Pure constructor."
   events/ci-failed)
 
-(def review-approved
+(def ^{:stratum 0} review-approved
   "Build a `:pr/review-approved` event map.
    Args: [dag-id run-id task-id pr-id approvers]. Returns an event map
    with `:event/type :pr/review-approved` plus `:dag/id :run/id
    :task/id :pr/id :review/approvers`. Pure constructor."
   events/review-approved)
 
-(def review-changes-requested
+(def ^{:stratum 0} review-changes-requested
   "Build a `:pr/review-changes-requested` event map.
    Args: [dag-id run-id task-id pr-id comments]. Returns an event map
    with `:event/type :pr/review-changes-requested` plus `:dag/id
    :run/id :task/id :pr/id :review/comments`. Pure constructor."
   events/review-changes-requested)
 
-(def comment-actionable
+(def ^{:stratum 0} comment-actionable
   "Build a `:pr/comment-actionable` event map.
    Args: [dag-id run-id task-id pr-id comment-data]. Returns an event
    map with `:event/type :pr/comment-actionable` plus `:dag/id :run/id
    :task/id :pr/id :comment`. Pure constructor."
   events/comment-actionable)
 
-(def merged
+(def ^{:stratum 0} merged
   "Build a `:pr/merged` event map.
    Arities: [dag-id run-id task-id pr-id merge-sha] (labels default to
    an empty set) and [... merge-sha labels] where `labels` is a
@@ -151,14 +150,14 @@
    :task/id :pr/id :pr/merge-sha :pr/labels`. Pure constructor."
   events/merged)
 
-(def rebase-needed
+(def ^{:stratum 0} rebase-needed
   "Build a `:pr/rebase-needed` event map.
    Args: [dag-id run-id task-id pr-id base-sha]. Returns an event map
    with `:event/type :pr/rebase-needed` plus `:dag/id :run/id :task/id
    :pr/id :pr/base-sha`. Pure constructor."
   events/rebase-needed)
 
-(def fix-pushed
+(def ^{:stratum 0} fix-pushed
   "Build a `:pr/fix-pushed` event map.
    Args: [dag-id run-id task-id pr-id sha fix-type] where `fix-type`
    is one of `:ci-fix` `:review-fix` `:conflict-fix`. Returns an event
@@ -166,10 +165,8 @@
    :task/id :pr/id :pr/sha :fix/type`. Pure constructor."
   events/fix-pushed)
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Comment triage
-
-(def classify-comment
+(def ^{:stratum 0} classify-comment
   "Classify a comment as actionable or non-actionable.
 
    Arguments:
@@ -186,7 +183,7 @@
      ; => {:actionable? true :reason :actionable-indicators ...}"
   triage/classify-comment)
 
-(def triage-comments
+(def ^{:stratum 0} triage-comments
   "Triage a collection of comments.
 
    Options:
@@ -200,29 +197,27 @@
      (triage-comments [\"LGTM\" \"Please add tests\"])"
   triage/triage-comments)
 
-(def parse-ci-failure
+(def ^{:stratum 0} parse-ci-failure
   "Parse CI failure logs into structured actionable items.
 
    Returns {:test-failures [...] :lint-errors [...] :build-errors [...]
             :actionable-summary string}"
   triage/parse-ci-failure)
 
-(def extract-failing-files
+(def ^{:stratum 0} extract-failing-files
   "Extract file paths mentioned in CI failures."
   triage/extract-failing-files)
 
-(def extract-requested-changes
+(def ^{:stratum 0} extract-requested-changes
   "Extract specific requested changes from review comments."
   triage/extract-requested-changes)
 
-(def group-changes-by-file
+(def ^{:stratum 0} group-changes-by-file
   "Group requested changes by file for efficient processing."
   triage/group-changes-by-file)
 
-;------------------------------------------------------------------------------ Layer 2
 ;; CI monitoring
-
-(def create-ci-monitor
+(def ^{:stratum 0} create-ci-monitor
   "Create a CI monitor for a PR.
 
    Options:
@@ -234,12 +229,12 @@
      (def monitor (create-ci-monitor dag-id run-id task-id 123 \"/path/to/repo\"))"
   ci/create-ci-monitor)
 
-(def poll-ci-status
+(def ^{:stratum 0} poll-ci-status
   "Poll CI status once.
    Returns {:status keyword :checks [...] :event event-or-nil}"
   ci/poll-ci-status)
 
-(def run-ci-monitor
+(def ^{:stratum 0} run-ci-monitor
   "Run the CI monitor until checks complete or timeout.
 
    Options:
@@ -249,19 +244,17 @@
    Returns final status map."
   ci/run-ci-monitor)
 
-(def stop-ci-monitor
+(def ^{:stratum 0} stop-ci-monitor
   "Stop a running CI monitor."
   ci/stop-ci-monitor)
 
-(def compute-ci-status
+(def ^{:stratum 0} compute-ci-status
   "Compute overall CI status from individual checks.
    Returns {:status keyword :passed [] :failed [] :pending []}"
   ci/compute-ci-status)
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Review monitoring
-
-(def create-review-monitor
+(def ^{:stratum 0} create-review-monitor
   "Create a review monitor for a PR.
 
    Options:
@@ -275,12 +268,12 @@
                                          :required-approvals 2))"
   review/create-review-monitor)
 
-(def poll-review-status
+(def ^{:stratum 0} poll-review-status
   "Poll review status once.
    Returns {:status keyword :reviews {...} :new-comments [...] :events [...]}"
   review/poll-review-status)
 
-(def run-review-monitor
+(def ^{:stratum 0} run-review-monitor
   "Run the review monitor.
 
    Options:
@@ -290,19 +283,17 @@
    Returns final status map."
   review/run-review-monitor)
 
-(def stop-review-monitor
+(def ^{:stratum 0} stop-review-monitor
   "Stop a running review monitor."
   review/stop-review-monitor)
 
-(def compute-review-status
+(def ^{:stratum 0} compute-review-status
   "Compute overall review status from reviews.
    Returns {:status keyword :approvers [...] :changes-requested-by [...]}"
   review/compute-review-status)
 
-;------------------------------------------------------------------------------ Layer 2
 ;; GitHub conversation management
-
-(def get-thread-id
+(def ^{:stratum 0} get-thread-id
   "Get GraphQL thread ID from a comment ID.
 
    GitHub review comments have both a REST API comment ID and a
@@ -320,7 +311,7 @@
      ; => {:success true :data {:thread-id \"PRRT_...\" :is-resolved false}}"
   github/get-thread-id)
 
-(def reply-to-comment
+(def ^{:stratum 0} reply-to-comment
   "Post a reply to a review comment thread.
 
    Arguments:
@@ -336,7 +327,7 @@
      ; => {:success true :data {:reply-id ... :url \"https://...\"}}"
   github/reply-to-comment)
 
-(def resolve-conversation
+(def ^{:stratum 0} resolve-conversation
   "Mark a conversation thread as resolved via GraphQL.
 
    Arguments:
@@ -350,7 +341,7 @@
      ; => {:success true :data {:thread-id \"PRRT_...\" :resolved true}}"
   github/resolve-conversation)
 
-(def link-fix-pr-to-comment
+(def ^{:stratum 0} link-fix-pr-to-comment
   "Link a fix PR to a review comment and resolve the conversation.
 
    This is the main entry point for conversation resolution after
@@ -376,13 +367,13 @@
      ; => {:success true :data {:reply-posted true :resolved true :thread-id \"PRRT_...\"}}"
   github/link-fix-pr-to-comment)
 
-(def git-head-sha
+(def ^{:stratum 0} git-head-sha
   "Return the full HEAD SHA of `worktree-path`, or nil. Convenience
    helper for callers of `post-review!` that need a `commit-id` after
    a `gh pr checkout`."
   github/git-head-sha)
 
-(def post-review!
+(def ^{:stratum 0} post-review!
   "Post a single PR review batching multiple inline comments
    (N13 §2.2 Standards Reviewer end-cap).
 
@@ -417,33 +408,31 @@
      ; => {:ok? true :data {:review-id ... :url \"https://...\" ...}}"
   github/post-review!)
 
-(def review-marker
+(def ^{:stratum 0} review-marker
   "Invisible HTML comment appended to every review body posted via
    `post-review!`. Lets `existing-review-shas` recognize prior posts
    authored by the N13 Standards Reviewer."
   github/review-marker)
 
-;------------------------------------------------------------------------------ Layer 2.5
 ;; Review scheduling (N13 §2.2 auto-trigger)
-
-(def existing-review-shas
+(def ^{:stratum 0} existing-review-shas
   "Return `(dag/ok #{sha …})` of head SHAs for which we've already
    posted a marker-bearing standards review on `pr-number`.
    Pages through `gh api .../reviews --paginate`."
   review-scheduler/existing-review-shas)
 
-(def pr-needs-review?
+(def ^{:stratum 0} pr-needs-review?
   "Pure predicate: true when `pr` (a `:pr/sha`-bearing map from
    `pr-poller/poll-open-prs`) has no entry in `existing-shas`."
   review-scheduler/pr-needs-review?)
 
-(def partition-needs-review
+(def ^{:stratum 0} partition-needs-review
   "Split a vector of `pr-poller`-shaped PR maps into
    `{:needs-review [...] :already-reviewed [...]}` against the
    `existing-shas-by-pr` map (keyed by `:pr/number`)."
   review-scheduler/partition-needs-review)
 
-(def with-pr-worktree
+(def ^{:stratum 0} with-pr-worktree
   "Bracketing helper: fetch PR head, create an ephemeral detached
    worktree at `sha` under `/tmp/mf-review-<sha>`, invoke `f` with
    `{:worktree-path string :sha string}`, then clean up. Returns
@@ -451,23 +440,21 @@
    failing DAG result on setup failure."
   review-scheduler/with-pr-worktree)
 
-(def fetch-pr-head!
+(def ^{:stratum 0} fetch-pr-head!
   "Fetch the PR head into `refs/miniforge-review/pr-<n>`. DAG result."
   review-scheduler/fetch-pr-head!)
 
-;------------------------------------------------------------------------------ Layer 2.7
 ;; Listener registry (N13 §2.7)
-
-(def listener-registry-default-storage-path
+(def ^{:stratum 0} listener-registry-default-storage-path
   "Default on-disk path for the listener registry artifact, relative
    to the worktree root."
   listener-registry/default-storage-path)
 
-(def listener-registry-default-ttl-seconds
+(def ^{:stratum 0} listener-registry-default-ttl-seconds
   "Default `:ttl-seconds` per spec §Lifecycle (7 days)."
   listener-registry/default-ttl-seconds)
 
-(def register-listener!
+(def ^{:stratum 0} register-listener!
   "Persist a new listener entry per N13 §2.7. Required `params` keys:
    `:pr/url :pr/repo-id :pr/number :agent/id :runtime :resume-channel
    :registered-by`. Returns DAG result `(dag/ok {:listener-id <uuid>
@@ -478,101 +465,97 @@
    `:workflow`) per spec §Registration moments."
   listener-registry/register!)
 
-(def unregister-listener!
+(def ^{:stratum 0} unregister-listener!
   "Transition `listener-id` (under `pr-url`) to `:cancelled`. Returns
    `(dag/err :listener-registry/listener-not-found ...)` if no such
    entry exists."
   listener-registry/unregister!)
 
-(def mark-listener-dispatched!
+(def ^{:stratum 0} mark-listener-dispatched!
   "Transition `listener-id` to `:dispatched`, recording
    `:resume/dispatched-at` and `:resume/dispatch-id`. Called by the
    Resume Signal Dispatcher (separate component) on a successful
    primer delivery."
   listener-registry/mark-dispatched!)
 
-(def cancel-listeners-on-pr-close!
+(def ^{:stratum 0} cancel-listeners-on-pr-close!
   "Transition every `:active` listener for `pr-url` to `:cancelled`.
    Called when `pull_request.closed` arrives with `merged: false`."
   listener-registry/mark-cancelled-on-pr-close!)
 
-(def sweep-expired-listeners!
+(def ^{:stratum 0} sweep-expired-listeners!
   "Transition every `:active` entry whose TTL has elapsed to
    `:expired`. Idempotent."
   listener-registry/sweep-expired!)
 
-(def read-listener-registry
+(def ^{:stratum 0} read-listener-registry
   "Load the registry from `worktree-path`'s `.miniforge/listener-registry.edn`.
    Returns `(dag/ok <registry>)` (empty registry on missing file) or
    typed error on parse failure."
   listener-registry/read-registry)
 
-(def listeners-for-pr
+(def ^{:stratum 0} listeners-for-pr
   "Pure: return all entries (any status) for `pr-url`."
   listener-registry/entries-for-pr)
 
-(def active-listeners-for-pr
+(def ^{:stratum 0} active-listeners-for-pr
   "Pure: return entries with `:status :active` for `pr-url`."
   listener-registry/active-entries-for-pr)
 
-(def listeners-for-agent
+(def ^{:stratum 0} listeners-for-agent
   "Pure: return all entries (any status) bound to `agent-id` across
    all PRs."
   listener-registry/entries-for-agent)
 
-;------------------------------------------------------------------------------ Layer 2.8
 ;; Resume Signal Dispatcher (N13 §2.7 §Dispatch)
-
-(def resume-dispatcher-supported-channel-kinds
+(def ^{:stratum 0} resume-dispatcher-supported-channel-kinds
   "Channel kinds with a real handler in v0 (`#{:webhook}`)."
   resume-dispatcher/supported-channel-kinds)
 
-(def build-resume-primer
+(def ^{:stratum 0} build-resume-primer
   "Pure: build the N13 §2.7 resume primer from a merged-PR record
    + a single listener entry. See `resume-dispatcher/build-primer`."
   resume-dispatcher/build-primer)
 
-(def channel-supported?
+(def ^{:stratum 0} channel-supported?
   "Pure predicate: true when the listener's channel kind has a real
    handler in v0."
   resume-dispatcher/channel-supported?)
 
-(def dispatch-resume-listener!
+(def ^{:stratum 0} dispatch-resume-listener!
   "Build primer + dispatch via the listener's channel + mark
    `:dispatched` on success. Returns DAG result. Channel-side
    failures decorate `:error :data` with `:listener/id` for
    correlation."
   resume-dispatcher/dispatch-listener!)
 
-(def dispatch-pr-merge!
+(def ^{:stratum 0} dispatch-pr-merge!
   "Walk every `:active` listener for `pr-url` and dispatch each.
    Returns `{:pr-url :listener-count :dispatched [...] :failed [...]}`.
    Per-listener failures don't abort — they're collected."
   resume-dispatcher/dispatch-pr-merge!)
 
-;------------------------------------------------------------------------------ Layer 2.9
 ;; Comment Response Agent — policy-eval path (N13 §2.5)
-
-(def policy-eval-author
+(def ^{:stratum 0} policy-eval-author
   "GitHub login the N13 Standards Reviewer posts under
    (`miniforge-policy-evaluator[bot]`)."
   policy-eval-responder/policy-eval-author)
 
-(def policy-eval-comment?
+(def ^{:stratum 0} policy-eval-comment?
   "True when `comment` was posted by the N13 Standards Reviewer."
   policy-eval-responder/policy-eval-comment?)
 
-(def classify-policy-eval-fix
+(def ^{:stratum 0} classify-policy-eval-fix
   "Pure: decide what to do with one policy-eval comment. Returns
    `{:action :apply | :escalate | :skip :reason ... :payload ...}`."
   policy-eval-responder/classify-fix)
 
-(def plan-policy-eval-fixes
+(def ^{:stratum 0} plan-policy-eval-fixes
   "Pure: partition a vector of comments into
    `{:to-apply [...] :to-escalate [...] :to-skip [...]}`."
   policy-eval-responder/plan-fixes)
 
-(def respond-to-policy-comments!
+(def ^{:stratum 0} respond-to-policy-comments!
   "Top-level entry: filter to policy-eval comments, plan, apply
    single-line `:violation/suggested-fix` patches in-place, commit
    + push, reply + resolve on each fixed thread.
@@ -584,10 +567,8 @@
    Returns DAG result with the full per-pass summary."
   policy-eval-responder/respond-to-policy-comments!)
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Fix loop
-
-(def create-fix-context
+(def ^{:stratum 0} create-fix-context
   "Build context pack for fix generation.
 
    Arguments:
@@ -601,16 +582,16 @@
    - :previous-fixes - Previous fix attempts"
   fix/create-fix-context)
 
-(def build-fix-prompt
+(def ^{:stratum 0} build-fix-prompt
   "Build a prompt for the fix agent based on failure type."
   fix/build-fix-prompt)
 
-(def generate-fix
+(def ^{:stratum 0} generate-fix
   "Generate a fix using the inner loop.
    Returns {:success? bool :artifact patch-artifact :metrics {...}}"
   fix/generate-fix)
 
-(def run-fix-loop
+(def ^{:stratum 0} run-fix-loop
   "Run the complete fix loop for a failure.
 
    Options:
@@ -621,30 +602,28 @@
    Returns {:success? bool :commit-sha string :attempts int :metrics {...}}"
   fix/run-fix-loop)
 
-(def fix-ci-failure
+(def ^{:stratum 0} fix-ci-failure
   "Convenience function for fixing CI failures."
   fix/fix-ci-failure)
 
-(def fix-review-feedback
+(def ^{:stratum 0} fix-review-feedback
   "Convenience function for fixing review feedback."
   fix/fix-review-feedback)
 
-(def fix-merge-conflict
+(def ^{:stratum 0} fix-merge-conflict
   "Convenience function for fixing merge conflicts."
   fix/fix-merge-conflict)
 
-;------------------------------------------------------------------------------ Layer 4
 ;; Merge
-
-(def default-merge-policy
+(def ^{:stratum 0} default-merge-policy
   "Default merge policy configuration."
   merge/default-merge-policy)
 
-(def merge-methods
+(def ^{:stratum 0} merge-methods
   "Supported merge methods: :merge :squash :rebase"
   merge/merge-methods)
 
-(def evaluate-merge-readiness
+(def ^{:stratum 0} evaluate-merge-readiness
   "Evaluate if a PR is ready to merge according to policy.
    Returns {:ready? bool :checks {...} :blocking [...]}
 
@@ -652,7 +631,7 @@
      (evaluate-merge-readiness \"/path/to/repo\" 123 default-merge-policy)"
   merge/evaluate-merge-readiness)
 
-(def merge-pr!
+(def ^{:stratum 0} merge-pr!
   "Merge a PR using gh CLI.
 
    Options:
@@ -662,27 +641,25 @@
      (merge-pr! \"/path/to/repo\" 123 :policy {:method :squash})"
   merge/merge-pr!)
 
-(def enable-auto-merge!
+(def ^{:stratum 0} enable-auto-merge!
   "Enable auto-merge for a PR."
   merge/enable-auto-merge!)
 
-(def disable-auto-merge!
+(def ^{:stratum 0} disable-auto-merge!
   "Disable auto-merge for a PR."
   merge/disable-auto-merge!)
 
-(def rebase-pr!
+(def ^{:stratum 0} rebase-pr!
   "Rebase a PR onto the latest base branch."
   merge/rebase-pr!)
 
-(def attempt-merge
+(def ^{:stratum 0} attempt-merge
   "Attempt to merge a PR, handling common failure cases.
    Returns result with merge status and events."
   merge/attempt-merge)
 
-;------------------------------------------------------------------------------ Layer 5
 ;; Controller (full lifecycle orchestration)
-
-(def create-controller
+(def ^{:stratum 0} create-controller
   "Create a PR lifecycle controller for a task.
 
    Arguments:
@@ -705,32 +682,32 @@
                                   :generate-fn my-generator))"
   controller/create-controller)
 
-(def create-pr!
+(def ^{:stratum 0} create-pr!
   "Create a PR for the task.
    Returns result with PR info."
   controller/create-pr!)
 
-(def start-ci-monitoring!
+(def ^{:stratum 0} start-ci-monitoring!
   "Start CI monitoring for the PR."
   controller/start-ci-monitoring!)
 
-(def start-review-monitoring!
+(def ^{:stratum 0} start-review-monitoring!
   "Start review monitoring for the PR."
   controller/start-review-monitoring!)
 
-(def handle-ci-failure!
+(def ^{:stratum 0} handle-ci-failure!
   "Handle a CI failure by running the fix loop."
   controller/handle-ci-failure!)
 
-(def handle-review-feedback!
+(def ^{:stratum 0} handle-review-feedback!
   "Handle review feedback by running the fix loop."
   controller/handle-review-feedback!)
 
-(def attempt-merge!
+(def ^{:stratum 0} attempt-merge!
   "Attempt to merge the PR."
   controller/attempt-merge!)
 
-(def run-lifecycle!
+(def ^{:stratum 0} run-lifecycle!
   "Run the full PR lifecycle for a task.
 
    This is the main entry point that orchestrates:
@@ -755,10 +732,8 @@
                      :on-event #(println \"Event:\" %))"
   controller/run-lifecycle!)
 
-;------------------------------------------------------------------------------ Layer 1.5
 ;; Comment classification (category-based, complements triage)
-
-(def categorize-comment
+(def ^{:stratum 0} categorize-comment
   "Classify a comment into a category: :change-request :question :approval
    :bot-comment :noise.
 
@@ -776,7 +751,7 @@
      ; => {:category :change-request :confidence :medium :method :heuristic ...}"
   classifier/classify-comment)
 
-(def categorize-comments
+(def ^{:stratum 0} categorize-comments
   "Classify a batch of comments into categories.
 
    Returns {:change-requests [...] :questions [...] :approvals [...]
@@ -788,41 +763,37 @@
                           :self-author \"miniforge[bot]\")"
   classifier/classify-comments)
 
-;------------------------------------------------------------------------------ Layer 5.5
 ;; PR Poller (GitHub adapter)
-
-(def poll-open-prs
+(def ^{:stratum 0} poll-open-prs
   "Poll GitHub for open PRs authored by a given login.
    Returns DAG result with :prs vector of PR info maps."
   poller/poll-open-prs)
 
-(def current-github-login
+(def ^{:stratum 0} current-github-login
   "Resolve the authenticated GitHub login (default :self-author for PR
    monitoring), or nil. See `pr-poller/current-github-login`."
   poller/current-github-login)
 
-(def fetch-pr-comments
+(def ^{:stratum 0} fetch-pr-comments
   "Fetch all comments for a PR (review + issue comments).
    Returns DAG result with :comments vector."
   poller/fetch-pr-comments)
 
-(def post-pr-comment
+(def ^{:stratum 0} post-pr-comment
   "Post an issue comment on a PR.
    Returns DAG result with :comment-posted true."
   poller/post-comment)
 
-(def load-watermarks
+(def ^{:stratum 0} load-watermarks
   "Load polling watermarks from persistent storage."
   poller/load-watermarks)
 
-(def save-watermarks!
+(def ^{:stratum 0} save-watermarks!
   "Persist polling watermarks to disk."
   poller/save-watermarks!)
 
-;------------------------------------------------------------------------------ Layer 6
 ;; PR Monitor Loop (autonomous comment resolution)
-
-(def create-pr-monitor
+(def ^{:stratum 0} create-pr-monitor
   "Create a PR monitor loop state.
 
    Required config keys:
@@ -846,7 +817,7 @@
                                 :generate-fn my-llm-fn}))"
   monitor/create-monitor)
 
-(def run-pr-monitor-loop
+(def ^{:stratum 0} run-pr-monitor-loop
   "Run the PR monitor loop continuously.
 
    Polls open PRs, classifies comments, routes to handlers.
@@ -859,53 +830,45 @@
    Returns evidence summary when loop completes."
   monitor/run-monitor-loop)
 
-(def stop-pr-monitor-loop
+(def ^{:stratum 0} stop-pr-monitor-loop
   "Stop a running PR monitor loop gracefully."
   monitor/stop-monitor-loop)
 
-(def pr-monitor-evidence
+(def ^{:stratum 0} pr-monitor-evidence
   "Get current evidence from the PR monitor."
   monitor/monitor-evidence)
 
-(def pr-monitor-running?
+(def ^{:stratum 0} pr-monitor-running?
   "Check if the PR monitor loop is currently running."
   monitor/monitor-running?)
 
-;------------------------------------------------------------------------------ Layer 6
 ;; PR Monitor Budget
-
-(def create-pr-budget
+(def ^{:stratum 0} create-pr-budget
   "Create a budget tracker for a PR.
    Returns budget state map."
   mbudget/create-budget)
 
-(def budget-summary
+(def ^{:stratum 0} budget-summary
   "Get budget status summary for events and logging."
   mbudget/budget-summary)
 
-(def any-budget-exhausted?
+(def ^{:stratum 0} any-budget-exhausted?
   "Check if any budget dimension is exhausted.
    Returns nil if OK, or :comment-limit :pr-limit :time-limit."
   mbudget/any-budget-exhausted?)
 
-;------------------------------------------------------------------------------ Layer 6
 ;; PR Monitor Events
-
-(def monitor-event-types
+(def ^{:stratum 0} monitor-event-types
   "Valid PR monitor loop event types (:pr-monitor/*)."
   mevents/monitor-event-types)
 
-;------------------------------------------------------------------------------ Layer 6
 ;; PR Monitor Config
-
-(def monitor-defaults
+(def ^{:stratum 0} monitor-defaults
   "Return the shared PR monitor defaults map."
   mconfig/monitor-defaults)
 
-;------------------------------------------------------------------------------ Layer 6
 ;; PR Monitor Worklist
-
-(def WorklistEntry
+(def ^{:stratum 0} WorklistEntry
   "Malli schema for the persisted work-list EDN written to disk.
 
    - :worklist/repo-key   — 12-hex-char prefix of SHA-256(remote-origin-url)
@@ -917,7 +880,7 @@
    in the component (rule 8)."
   mworklist/WorklistEntry)
 
-(def worklist-path
+(def ^{:stratum 0} worklist-path
   "Compute the absolute path for the work-list EDN file.
 
    Arguments:
@@ -927,14 +890,14 @@
    Returns: <home-dir>/pr-monitor/<rkey>.edn"
   mworklist/worklist-path)
 
-(def worklist-repo-key
+(def ^{:stratum 0} worklist-repo-key
   "Derive a stable, filesystem-safe key from `remote-url` (e.g. the
    value of `git remote get-url origin`).
 
    Returns a 12-character lowercase hex prefix of the SHA-256 digest."
   mworklist/repo-key)
 
-(def persist-worklist!
+(def ^{:stratum 0} persist-worklist!
   "Validate `entry` against WorklistEntry and write it as EDN to `path`.
    Creates parent directories as needed.
 
@@ -943,7 +906,7 @@
    - `(schema/failure :worklist <msg>)` on validation or I/O failure."
   mworklist/persist-worklist!)
 
-(def load-worklist
+(def ^{:stratum 0} load-worklist
   "Read and validate a WorklistEntry EDN from `path`.
 
    Returns:
@@ -952,7 +915,7 @@
      or content does not satisfy WorklistEntry."
   mworklist/load-worklist)
 
-(def prune-closed-prs
+(def ^{:stratum 0} prune-closed-prs
   "Remove merged or closed PR entries from `entry` by querying GitHub.
 
    For each PR in `:worklist/prs`, shells `gh pr view <number> --repo
@@ -964,6 +927,41 @@
    - An anomaly map if any `gh` invocation fails — worklist is left
      unchanged rather than silently dropping unchecked PRs."
   mworklist/prune-closed-prs)
+
+;; PR Comment Responder
+(def ^{:stratum 0} parse-pr-url
+  "Extract owner, repo, and PR number from a GitHub PR URL.
+   Returns {:owner :repo :number} or nil."
+  responder/parse-pr-url)
+
+(def ^{:stratum 0} respond-to-comments!
+  "Fetch review comments, fix them, push, reply, and resolve.
+
+   Arguments:
+   - pr-url: GitHub PR URL
+   - worktree-path: Path to local git checkout on the PR branch
+   - run-fix-fn: (fn [spec opts] result) — runs a fix workflow
+   - push-fn: (fn [] bool) — pushes changes to remote
+   - opts: Additional options passed to run-fix-fn
+
+   Returns:
+   {:pr-number :comments-found :files-processed :fixes :pushed?}
+
+   Returns an anomaly map unchanged when the PR URL is invalid or PR
+   comment fetching fails.
+
+   Example:
+     (respond-to-comments!
+       \"https://github.com/org/repo/pull/123\"
+       \"/path/to/worktree\"
+       (fn [spec opts] (run-workflow-from-spec! spec opts))
+       (fn [] (zero? (:exit (sh \"git\" \"push\"))))
+       {:quiet true})"
+  responder/respond-to-comments!)
+
+(def ^{:stratum 0} build-fix-spec
+  "Build a workflow spec from a group of review comments on a file."
+  responder/build-fix-spec)
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
@@ -1046,40 +1044,3 @@
   ; => {:success? true :worklist {...}}
 
   :leave-this-here)
-
-;------------------------------------------------------------------------------ Layer 7
-;; PR Comment Responder
-
-(def parse-pr-url
-  "Extract owner, repo, and PR number from a GitHub PR URL.
-   Returns {:owner :repo :number} or nil."
-  responder/parse-pr-url)
-
-(def respond-to-comments!
-  "Fetch review comments, fix them, push, reply, and resolve.
-
-   Arguments:
-   - pr-url: GitHub PR URL
-   - worktree-path: Path to local git checkout on the PR branch
-   - run-fix-fn: (fn [spec opts] result) — runs a fix workflow
-   - push-fn: (fn [] bool) — pushes changes to remote
-   - opts: Additional options passed to run-fix-fn
-
-   Returns:
-   {:pr-number :comments-found :files-processed :fixes :pushed?}
-
-   Returns an anomaly map unchanged when the PR URL is invalid or PR
-   comment fetching fails.
-
-   Example:
-     (respond-to-comments!
-       \"https://github.com/org/repo/pull/123\"
-       \"/path/to/worktree\"
-       (fn [spec opts] (run-workflow-from-spec! spec opts))
-       (fn [] (zero? (:exit (sh \"git\" \"push\"))))
-       {:quiet true})"
-  responder/respond-to-comments!)
-
-(def build-fix-spec
-  "Build a workflow spec from a group of review comments on a file."
-  responder/build-fix-spec)

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/listener_registry.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/listener_registry.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.listener-registry
   "Persistent registry of agents waiting on PR merges (N13 §2.7,
    `specs/informative/n13-listener-registry.md`).
@@ -48,9 +47,9 @@
    [malli.core :as m]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Configuration (loaded from per-component EDN at namespace-load)
 
-(def ^:private config
+;; Configuration (loaded from per-component EDN at namespace-load)
+(def ^{:stratum 0} ^:private config
   "Component config loaded from `resources/config/listener-registry/defaults.edn`.
    Keeps constants (storage path, valid enums, version, TTL) out of
    source so operators can tune without recompiling."
@@ -58,104 +57,14 @@
       slurp
       edn/read-string))
 
-(def registry-version
-  "On-disk artifact format version. Tracks the spec document version."
-  (:registry/version config))
+(defn- ^{:stratum 0} now-inst [] (java.util.Date.))
 
-(def default-storage-path
-  "Default path under the worktree where the registry artifact lives."
-  (:default-storage-path config))
-
-(def default-ttl-seconds
-  "Default `:ttl-seconds` per spec §Lifecycle."
-  (:default-ttl-seconds config))
-
-(def valid-runtimes        (:valid-runtimes config))
-(def valid-channel-kinds   (:valid-channel-kinds config))
-(def valid-statuses        (:valid-statuses config))
-
-(def valid-registered-by
-  "The three canonical registration moments per spec §Registration moments.
-   Registration with any other `:registered-by` MUST be rejected."
-  (:valid-registered-by config))
-
-(def ChannelKindEnum  (into [:enum] valid-channel-kinds))
-(def RuntimeEnum      (into [:enum] valid-runtimes))
-(def StatusEnum       (into [:enum] valid-statuses))
-(def RegisteredByEnum (into [:enum] valid-registered-by))
-
-(def ResumeChannel
-  [:map
-   [:channel/kind   ChannelKindEnum]
-   [:channel/target :string]
-   [:channel/auth   {:optional true} [:maybe :map]]])
-
-(def ListenerEntry
-  [:map
-   [:listener/id          uuid?]
-   [:pr/url               :string]
-   [:pr/repo-id           :string]
-   [:pr/number            pos-int?]
-   [:agent/id             :string]
-   [:session/id           {:optional true} [:maybe :string]]
-   [:runtime              RuntimeEnum]
-   [:resume-channel       ResumeChannel]
-   [:registered-at        inst?]
-   [:registered-by        RegisteredByEnum]
-   [:ttl-seconds          {:optional true} pos-int?]
-   [:status               StatusEnum]
-   [:resume/dispatched-at {:optional true} [:maybe inst?]]
-   [:resume/dispatch-id   {:optional true} [:maybe uuid?]]
-   [:notes                {:optional true} [:maybe :string]]])
-
-(def Registry
-  [:map
-   [:registry/version      :string]
-   [:registry/last-updated inst?]
-   [:registry/listeners    [:map-of :string [:vector ListenerEntry]]]])
-
-(defn validate-entry
-  "Return a DAG result for `entry` validation. Used by `register!`."
-  [entry]
-  (if (m/validate ListenerEntry entry)
-    (dag/ok entry)
-    (dag/err :listener-registry/invalid-entry
-             "invalid listener entry"
-             {:errors (m/explain ListenerEntry entry)
-              :anomaly :listener-registry/invalid-entry})))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Pure state operations
-
-(def empty-registry
-  {:registry/version      registry-version
-   :registry/last-updated #inst "1970-01-01T00:00:00.000-00:00"
-   :registry/listeners    {}})
-
-(defn- now-inst [] (java.util.Date.))
-
-(defn- with-touched-timestamp
-  [registry]
-  (assoc registry :registry/last-updated (now-inst)))
-
-(defn add-entry
-  "Pure: append `entry` to the registry under its `:pr/url` key."
-  [registry entry]
-  (-> registry
-      (update-in [:registry/listeners (:pr/url entry)] (fnil conj []) entry)
-      with-touched-timestamp))
-
-(defn entries-for-pr
+(defn ^{:stratum 0} entries-for-pr
   "Return all entries (any status) for `pr-url`, or empty vector."
   [registry pr-url]
   (get-in registry [:registry/listeners pr-url] []))
 
-(defn active-entries-for-pr
-  "Return the subset of entries-for-pr with `:status :active`."
-  [registry pr-url]
-  (filterv #(= :active (:status %)) (entries-for-pr registry pr-url)))
-
-(defn entries-for-agent
+(defn ^{:stratum 0} entries-for-agent
   "Return all entries (any status) bound to `agent-id` across all PRs."
   [registry agent-id]
   (into []
@@ -163,71 +72,109 @@
               (filter #(= agent-id (:agent/id %))))
         (:registry/listeners registry)))
 
-(defn update-entry-status
-  "Pure: find the entry matching `listener-id` (within the listeners
-   for `pr-url`) and apply `update-fn` to it. Returns the updated
-   registry (with bumped timestamp). When the entry is not found,
-   returns the registry unchanged.
-
-   `update-fn` receives the entry and returns its replacement."
-  [registry pr-url listener-id update-fn]
-  (let [path  [:registry/listeners pr-url]
-        bucket (get-in registry path [])
-        idx   (first (keep-indexed
-                      (fn [i e]
-                        (when (= listener-id (:listener/id e)) i))
-                      bucket))]
-    (if idx
-      (-> registry
-          (update-in path
-                     (fn [b] (update b idx update-fn)))
-          with-touched-timestamp)
-      registry)))
-
-(defn auto-expirable?
-  "Pure: true when `entry` is `:active`, has `:ttl-seconds`, and the
-   wall-clock cutoff (`registered-at + ttl-seconds`) is in the past
-   relative to `now`."
-  [entry now]
-  (and (= :active (:status entry))
-       (let [ttl (or (:ttl-seconds entry) default-ttl-seconds)
-             reg-at (.getTime ^java.util.Date (:registered-at entry))
-             cutoff (+ reg-at (* 1000 ttl))]
-         (<= cutoff (.getTime ^java.util.Date now)))))
-
-;; ── Entry construction (Layer 1; consumes only Layer 0/1) ───────────
-
-(defn- new-listener-id [] (random-uuid))
-
-(defn- build-entry
-  "Pure: assemble a fully-shaped `ListenerEntry` from `params`,
-   stamping a fresh `:listener/id`, `:registered-at`, default
-   `:ttl-seconds`, and `:status :active`."
-  [params]
-  {:listener/id     (new-listener-id)
-   :pr/url          (:pr/url params)
-   :pr/repo-id      (:pr/repo-id params)
-   :pr/number       (:pr/number params)
-   :agent/id        (:agent/id params)
-   :session/id      (:session/id params)
-   :runtime         (:runtime params)
-   :resume-channel  (:resume-channel params)
-   :registered-at   (now-inst)
-   :registered-by   (:registered-by params)
-   :ttl-seconds     (or (:ttl-seconds params) default-ttl-seconds)
-   :status          :active
-   :notes           (:notes params)})
+;; ── Entry construction ───────────
+(defn- ^{:stratum 0} new-listener-id [] (random-uuid))
 
 ;; ── Per-entry status updates (pure functions over one entry) ────────
-
-(defn- mark-cancelled
+(defn- ^{:stratum 0} mark-cancelled
   "Pure entry update: any → :cancelled. Caller is responsible for
    sourcing only `:active` entries via `check-active-entry` /
    `active-entries-for-pr`."
   [entry]
   (assoc entry :status :cancelled))
 
-(defn- mark-dispatched
+(defn- ^{:stratum 0} mark-expired
+  "Pure entry update: any → :expired."
+  [entry]
+  (assoc entry :status :expired))
+
+;; ── Result + error builders (pure DAG-result construction) ──────────
+(defn- ^{:stratum 0} not-found-error
+  [pr-url listener-id]
+  (dag/err :listener-registry/listener-not-found
+           (str "no listener entry " listener-id " for " pr-url)
+           {:pr-url pr-url :listener-id listener-id}))
+
+(defn- ^{:stratum 0} wrong-status-error
+  [pr-url listener-id current-status]
+  (dag/err :listener-registry/wrong-status
+           (str "listener " listener-id " on " pr-url
+                " is " current-status ", expected :active")
+           {:pr-url          pr-url
+            :listener-id     listener-id
+            :current-status  current-status
+            :expected-status :active}))
+
+(defn- ^{:stratum 0} registration-success
+  "Build the success payload returned to the caller of `register!`."
+  [entry write-result]
+  (dag/ok {:listener-id (:listener/id entry)
+           :path        (:path (:data write-result))}))
+
+(defn- ^{:stratum 0} pair-with-pr-url
+  "Pure: turn one `[pr-url entries]` map-entry into a seq of
+   `[pr-url entry]` pairs."
+  [[pr-url entries]]
+  (map (fn [e] [pr-url e]) entries))
+
+(defn- ^{:stratum 0} trailing-forms-error
+  [path trailing]
+  (dag/err :listener-registry/read-failed
+           (str "registry file " path " has trailing forms after first value")
+           {:path path
+            :trailing trailing}))
+
+(defn- ^{:stratum 0} read-failure
+  "Build a typed `:listener-registry/read-failed` for a slurp /
+   parse / I/O exception. Surfaces ex-data when present."
+  [path ^Throwable e]
+  (dag/err :listener-registry/read-failed
+           (str "failed to read " path ": " (.getMessage e))
+           (cond-> {:path path}
+             (ex-data e) (assoc :ex-data (ex-data e)))))
+
+(defn- ^{:stratum 0} best-effort-delete!
+  "Try to delete `path`; swallow any throwable. Used to keep
+   `.miniforge/` clean of leftover `.tmp` files when an atomic
+   move fails (e.g., on filesystems that don't support it)."
+  [path]
+  (try (fs/delete path) (catch Throwable _ nil)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} registry-version
+  "On-disk artifact format version. Tracks the spec document version."
+  (:registry/version config))
+
+(def ^{:stratum 1} default-storage-path
+  "Default path under the worktree where the registry artifact lives."
+  (:default-storage-path config))
+
+(def ^{:stratum 1} default-ttl-seconds
+  "Default `:ttl-seconds` per spec §Lifecycle."
+  (:default-ttl-seconds config))
+
+(def ^{:stratum 1} valid-runtimes        (:valid-runtimes config))
+
+(def ^{:stratum 1} valid-channel-kinds   (:valid-channel-kinds config))
+
+(def ^{:stratum 1} valid-statuses        (:valid-statuses config))
+
+(def ^{:stratum 1} valid-registered-by
+  "The three canonical registration moments per spec §Registration moments.
+   Registration with any other `:registered-by` MUST be rejected."
+  (:valid-registered-by config))
+
+(defn- ^{:stratum 1} with-touched-timestamp
+  [registry]
+  (assoc registry :registry/last-updated (now-inst)))
+
+(defn ^{:stratum 1} active-entries-for-pr
+  "Return the subset of entries-for-pr with `:status :active`."
+  [registry pr-url]
+  (filterv #(= :active (:status %)) (entries-for-pr registry pr-url)))
+
+(defn- ^{:stratum 1} mark-dispatched
   "Pure entry-update factory: returns a fn that stamps `:dispatched`
    + `:resume/dispatched-at` + `:resume/dispatch-id` on an entry.
    Closes over `dispatch-id` to avoid an inline anonymous fn at the
@@ -239,106 +186,15 @@
            :resume/dispatched-at (now-inst)
            :resume/dispatch-id dispatch-id)))
 
-(defn- mark-expired
-  "Pure entry update: any → :expired."
-  [entry]
-  (assoc entry :status :expired))
-
-;; ── Result + error builders (pure DAG-result construction) ──────────
-
-(defn- not-found-error
-  [pr-url listener-id]
-  (dag/err :listener-registry/listener-not-found
-           (str "no listener entry " listener-id " for " pr-url)
-           {:pr-url pr-url :listener-id listener-id}))
-
-(defn- wrong-status-error
-  [pr-url listener-id current-status]
-  (dag/err :listener-registry/wrong-status
-           (str "listener " listener-id " on " pr-url
-                " is " current-status ", expected :active")
-           {:pr-url          pr-url
-            :listener-id     listener-id
-            :current-status  current-status
-            :expected-status :active}))
-
-(defn- registration-success
-  "Build the success payload returned to the caller of `register!`."
-  [entry write-result]
-  (dag/ok {:listener-id (:listener/id entry)
-           :path        (:path (:data write-result))}))
-
 ;; ── Lookup + active-entry assertion (pure registry queries) ─────────
-
-(defn- find-listener
+(defn- ^{:stratum 1} find-listener
   "Pure: locate the entry matching `listener-id` within the bucket
    for `pr-url`. Returns the entry or nil."
   [registry pr-url listener-id]
   (first (filter #(= listener-id (:listener/id %))
                  (entries-for-pr registry pr-url))))
 
-(defn- check-active-entry
-  "Return `(dag/ok entry)` when the listener exists in `registry`
-   under `pr-url` AND is currently `:active`. Otherwise a typed
-   error per the two failure modes."
-  [registry pr-url listener-id]
-  (let [entry (find-listener registry pr-url listener-id)]
-    (cond
-      (nil? entry)                    (not-found-error pr-url listener-id)
-      (not= :active (:status entry))  (wrong-status-error pr-url listener-id (:status entry))
-      :else                           (dag/ok entry))))
-
-;; ── Bulk-operation helpers (pure reducers + transducer steps) ───────
-
-(defn- apply-cancel-to
-  "Reduce step: cancel one `entry` in-place under its known `pr-url`.
-   Closure-free — `pr-url` arrives via the entry's bucket lookup."
-  [pr-url registry entry]
-  (update-entry-status registry pr-url (:listener/id entry) mark-cancelled))
-
-(defn- apply-expire-to
-  "Reduce step: expire one [pr-url entry] pair in `registry`."
-  [registry [pr-url entry]]
-  (update-entry-status registry pr-url (:listener/id entry) mark-expired))
-
-(defn- pair-with-pr-url
-  "Pure: turn one `[pr-url entries]` map-entry into a seq of
-   `[pr-url entry]` pairs."
-  [[pr-url entries]]
-  (map (fn [e] [pr-url e]) entries))
-
-(defn- pair-expirable?
-  "Pure: predicate for [pr-url entry] pairs against a fixed `now`.
-   Returns a function so `filter` doesn't need a closure-bearing
-   anonymous fn at the call site."
-  [now]
-  (fn [[_ entry]] (auto-expirable? entry now)))
-
-(defn- collect-expirable-pairs
-  "Pure: walk `registry`'s listener buckets and return a vector of
-   `[pr-url entry]` pairs whose entries are auto-expirable as of
-   `now`."
-  [registry now]
-  (into []
-        (comp (mapcat pair-with-pr-url)
-              (filter (pair-expirable? now)))
-        (:registry/listeners registry)))
-
-;------------------------------------------------------------------------------ Layer 2
-;; Persistence (read + write-rename)
-
-(defn- storage-path
-  [worktree-path]
-  (str (fs/path (str worktree-path) default-storage-path)))
-
-(defn- trailing-forms-error
-  [path trailing]
-  (dag/err :listener-registry/read-failed
-           (str "registry file " path " has trailing forms after first value")
-           {:path path
-            :trailing trailing}))
-
-(defn- read-single-edn-form
+(defn- ^{:stratum 1} read-single-edn-form
   "Read exactly one EDN form from `raw`, asserting EOF after.
    Returns a DAG result containing the parsed value. Parse failures
    inside `edn/read` still bubble to `read-registry`'s I/O boundary;
@@ -359,70 +215,124 @@
       (dag/ok first-form)
       (trailing-forms-error path next-form))))
 
-(defn- schema-error
-  "Build a typed `:listener-registry/read-failed` for a registry value
-   that parsed but doesn't match the `Registry` malli schema."
-  [path parsed]
-  (dag/err :listener-registry/read-failed
-           (str "registry file " path " failed Registry schema validation")
-           {:path    path
-            :explain (m/explain Registry parsed)}))
+;------------------------------------------------------------------------------ Layer 2
 
-(defn- decode-registry-blob
-  "Pure: parse and validate `raw`. Treats blank as `empty-registry`.
-   Returns DAG result. Splits the work out of `read-registry` so the
-   stage check (file exists, content non-blank, parses, schema-valid)
-   doesn't need the cond-inside-cond-inside-cond shape."
-  [path raw]
-  (if (str/blank? raw)
-    (dag/ok empty-registry)
-    (let [parse-r (read-single-edn-form path raw)]
-      (if-not (dag/ok? parse-r)
-        parse-r
-        (let [parsed (:data parse-r)]
-          (if (m/validate Registry parsed)
-            (dag/ok parsed)
-            (schema-error path parsed)))))))
+(def ^{:stratum 2} ChannelKindEnum  (into [:enum] valid-channel-kinds))
 
-(defn- read-failure
-  "Build a typed `:listener-registry/read-failed` for a slurp /
-   parse / I/O exception. Surfaces ex-data when present."
-  [path ^Throwable e]
-  (dag/err :listener-registry/read-failed
-           (str "failed to read " path ": " (.getMessage e))
-           (cond-> {:path path}
-             (ex-data e) (assoc :ex-data (ex-data e)))))
+(def ^{:stratum 2} RuntimeEnum      (into [:enum] valid-runtimes))
 
-(defn read-registry
-  "Read the registry from `worktree-path`'s `.miniforge/listener-registry.edn`.
-   Returns `(dag/ok <registry>)` on success; `(dag/ok empty-registry)`
-   on missing or blank file. Returns `(dag/err :listener-registry/read-failed ...)`
-   on:
-   - parse failure (corrupt EDN)
-   - trailing forms after the first value (silent corruption mode)
-   - schema mismatch against the malli `Registry` schema (e.g.
-     `:registry/listeners` value is a list rather than a vector,
-     which would later trip up `update-entry-status`)
+(def ^{:stratum 2} StatusEnum       (into [:enum] valid-statuses))
 
-   Schema-mismatch errors carry an `:explain` key under `:data` with
-   the malli explanation so callers can surface a structured diagnostic."
+(def ^{:stratum 2} RegisteredByEnum (into [:enum] valid-registered-by))
+
+;; Pure state operations
+(def ^{:stratum 2} empty-registry
+  {:registry/version      registry-version
+   :registry/last-updated #inst "1970-01-01T00:00:00.000-00:00"
+   :registry/listeners    {}})
+
+(defn ^{:stratum 2} add-entry
+  "Pure: append `entry` to the registry under its `:pr/url` key."
+  [registry entry]
+  (-> registry
+      (update-in [:registry/listeners (:pr/url entry)] (fnil conj []) entry)
+      with-touched-timestamp))
+
+(defn ^{:stratum 2} update-entry-status
+  "Pure: find the entry matching `listener-id` (within the listeners
+   for `pr-url`) and apply `update-fn` to it. Returns the updated
+   registry (with bumped timestamp). When the entry is not found,
+   returns the registry unchanged.
+
+   `update-fn` receives the entry and returns its replacement."
+  [registry pr-url listener-id update-fn]
+  (let [path  [:registry/listeners pr-url]
+        bucket (get-in registry path [])
+        idx   (first (keep-indexed
+                      (fn [i e]
+                        (when (= listener-id (:listener/id e)) i))
+                      bucket))]
+    (if idx
+      (-> registry
+          (update-in path
+                     (fn [b] (update b idx update-fn)))
+          with-touched-timestamp)
+      registry)))
+
+(defn ^{:stratum 2} auto-expirable?
+  "Pure: true when `entry` is `:active`, has `:ttl-seconds`, and the
+   wall-clock cutoff (`registered-at + ttl-seconds`) is in the past
+   relative to `now`."
+  [entry now]
+  (and (= :active (:status entry))
+       (let [ttl (or (:ttl-seconds entry) default-ttl-seconds)
+             reg-at (.getTime ^java.util.Date (:registered-at entry))
+             cutoff (+ reg-at (* 1000 ttl))]
+         (<= cutoff (.getTime ^java.util.Date now)))))
+
+(defn- ^{:stratum 2} build-entry
+  "Pure: assemble a fully-shaped `ListenerEntry` from `params`,
+   stamping a fresh `:listener/id`, `:registered-at`, default
+   `:ttl-seconds`, and `:status :active`."
+  [params]
+  {:listener/id     (new-listener-id)
+   :pr/url          (:pr/url params)
+   :pr/repo-id      (:pr/repo-id params)
+   :pr/number       (:pr/number params)
+   :agent/id        (:agent/id params)
+   :session/id      (:session/id params)
+   :runtime         (:runtime params)
+   :resume-channel  (:resume-channel params)
+   :registered-at   (now-inst)
+   :registered-by   (:registered-by params)
+   :ttl-seconds     (or (:ttl-seconds params) default-ttl-seconds)
+   :status          :active
+   :notes           (:notes params)})
+
+(defn- ^{:stratum 2} check-active-entry
+  "Return `(dag/ok entry)` when the listener exists in `registry`
+   under `pr-url` AND is currently `:active`. Otherwise a typed
+   error per the two failure modes."
+  [registry pr-url listener-id]
+  (let [entry (find-listener registry pr-url listener-id)]
+    (cond
+      (nil? entry)                    (not-found-error pr-url listener-id)
+      (not= :active (:status entry))  (wrong-status-error pr-url listener-id (:status entry))
+      :else                           (dag/ok entry))))
+
+;; Persistence (read + write-rename)
+(defn- ^{:stratum 2} storage-path
   [worktree-path]
-  (let [path (storage-path worktree-path)]
-    (try
-      (if (fs/exists? path)
-        (decode-registry-blob path (slurp path))
-        (dag/ok empty-registry))
-      (catch Throwable e
-        (read-failure path e)))))
+  (str (fs/path (str worktree-path) default-storage-path)))
 
-(defn- best-effort-delete!
-  "Try to delete `path`; swallow any throwable. Used to keep
-   `.miniforge/` clean of leftover `.tmp` files when an atomic
-   move fails (e.g., on filesystems that don't support it)."
-  [path]
-  (try (fs/delete path) (catch Throwable _ nil)))
+;------------------------------------------------------------------------------ Layer 3
 
-(defn write-registry!
+(def ^{:stratum 3} ResumeChannel
+  [:map
+   [:channel/kind   ChannelKindEnum]
+   [:channel/target :string]
+   [:channel/auth   {:optional true} [:maybe :map]]])
+
+;; ── Bulk-operation helpers (pure reducers + transducer steps) ───────
+(defn- ^{:stratum 3} apply-cancel-to
+  "Reduce step: cancel one `entry` in-place under its known `pr-url`.
+   Closure-free — `pr-url` arrives via the entry's bucket lookup."
+  [pr-url registry entry]
+  (update-entry-status registry pr-url (:listener/id entry) mark-cancelled))
+
+(defn- ^{:stratum 3} apply-expire-to
+  "Reduce step: expire one [pr-url entry] pair in `registry`."
+  [registry [pr-url entry]]
+  (update-entry-status registry pr-url (:listener/id entry) mark-expired))
+
+(defn- ^{:stratum 3} pair-expirable?
+  "Pure: predicate for [pr-url entry] pairs against a fixed `now`.
+   Returns a function so `filter` doesn't need a closure-bearing
+   anonymous fn at the call site."
+  [now]
+  (fn [[_ entry]] (auto-expirable? entry now)))
+
+(defn ^{:stratum 3} write-registry!
   "Write `registry` atomically to `worktree-path`'s storage path.
    Strategy: serialize EDN, write to `<path>.tmp`, then `mv` over
    the canonical path. Eliminates partial reads from concurrent
@@ -455,10 +365,111 @@
                  (str "failed to write " path ": " (.getMessage e))
                  {:path path})))))
 
-;------------------------------------------------------------------------------ Layer 3
-;; Lifecycle entry points (orchestrate Layer 1/2 ops; do I/O)
+;------------------------------------------------------------------------------ Layer 4
 
-(defn- persist-new-entry!
+(def ^{:stratum 4} ListenerEntry
+  [:map
+   [:listener/id          uuid?]
+   [:pr/url               :string]
+   [:pr/repo-id           :string]
+   [:pr/number            pos-int?]
+   [:agent/id             :string]
+   [:session/id           {:optional true} [:maybe :string]]
+   [:runtime              RuntimeEnum]
+   [:resume-channel       ResumeChannel]
+   [:registered-at        inst?]
+   [:registered-by        RegisteredByEnum]
+   [:ttl-seconds          {:optional true} pos-int?]
+   [:status               StatusEnum]
+   [:resume/dispatched-at {:optional true} [:maybe inst?]]
+   [:resume/dispatch-id   {:optional true} [:maybe uuid?]]
+   [:notes                {:optional true} [:maybe :string]]])
+
+(defn- ^{:stratum 4} collect-expirable-pairs
+  "Pure: walk `registry`'s listener buckets and return a vector of
+   `[pr-url entry]` pairs whose entries are auto-expirable as of
+   `now`."
+  [registry now]
+  (into []
+        (comp (mapcat pair-with-pr-url)
+              (filter (pair-expirable? now)))
+        (:registry/listeners registry)))
+
+;------------------------------------------------------------------------------ Layer 5
+
+(def ^{:stratum 5} Registry
+  [:map
+   [:registry/version      :string]
+   [:registry/last-updated inst?]
+   [:registry/listeners    [:map-of :string [:vector ListenerEntry]]]])
+
+(defn ^{:stratum 5} validate-entry
+  "Return a DAG result for `entry` validation. Used by `register!`."
+  [entry]
+  (if (m/validate ListenerEntry entry)
+    (dag/ok entry)
+    (dag/err :listener-registry/invalid-entry
+             "invalid listener entry"
+             {:errors (m/explain ListenerEntry entry)
+              :anomaly :listener-registry/invalid-entry})))
+
+;------------------------------------------------------------------------------ Layer 6
+
+(defn- ^{:stratum 6} schema-error
+  "Build a typed `:listener-registry/read-failed` for a registry value
+   that parsed but doesn't match the `Registry` malli schema."
+  [path parsed]
+  (dag/err :listener-registry/read-failed
+           (str "registry file " path " failed Registry schema validation")
+           {:path    path
+            :explain (m/explain Registry parsed)}))
+
+;------------------------------------------------------------------------------ Layer 7
+
+(defn- ^{:stratum 7} decode-registry-blob
+  "Pure: parse and validate `raw`. Treats blank as `empty-registry`.
+   Returns DAG result. Splits the work out of `read-registry` so the
+   stage check (file exists, content non-blank, parses, schema-valid)
+   doesn't need the cond-inside-cond-inside-cond shape."
+  [path raw]
+  (if (str/blank? raw)
+    (dag/ok empty-registry)
+    (let [parse-r (read-single-edn-form path raw)]
+      (if-not (dag/ok? parse-r)
+        parse-r
+        (let [parsed (:data parse-r)]
+          (if (m/validate Registry parsed)
+            (dag/ok parsed)
+            (schema-error path parsed)))))))
+
+;------------------------------------------------------------------------------ Layer 8
+
+(defn ^{:stratum 8} read-registry
+  "Read the registry from `worktree-path`'s `.miniforge/listener-registry.edn`.
+   Returns `(dag/ok <registry>)` on success; `(dag/ok empty-registry)`
+   on missing or blank file. Returns `(dag/err :listener-registry/read-failed ...)`
+   on:
+   - parse failure (corrupt EDN)
+   - trailing forms after the first value (silent corruption mode)
+   - schema mismatch against the malli `Registry` schema (e.g.
+     `:registry/listeners` value is a list rather than a vector,
+     which would later trip up `update-entry-status`)
+
+   Schema-mismatch errors carry an `:explain` key under `:data` with
+   the malli explanation so callers can surface a structured diagnostic."
+  [worktree-path]
+  (let [path (storage-path worktree-path)]
+    (try
+      (if (fs/exists? path)
+        (decode-registry-blob path (slurp path))
+        (dag/ok empty-registry))
+      (catch Throwable e
+        (read-failure path e)))))
+
+;------------------------------------------------------------------------------ Layer 9
+
+;; Lifecycle entry points (orchestrate the above ops; do I/O)
+(defn- ^{:stratum 9} persist-new-entry!
   "Read → add → write. Internal helper for `register!`. Assumes the
    caller has already validated the entry."
   [worktree-path entry]
@@ -471,7 +482,66 @@
           (registration-success entry write-r)
           write-r)))))
 
-(defn register!
+(defn- ^{:stratum 9} transition-from-active!
+  "Internal: load → assert entry is `:active` → update → write.
+
+   Returns:
+   - `:listener-registry/listener-not-found` when no such entry exists.
+   - `:listener-registry/wrong-status` when the entry isn't `:active`
+     — guards against overwriting terminal states (`:dispatched`,
+     `:expired`, `:cancelled`) per spec §Lifecycle, which models all
+     transitions as `:active → X`.
+   - `(dag/ok ...)` from `write-registry!` on the happy path.
+
+   `update-fn` receives the entry (guaranteed `:status :active`) and
+   returns its replacement."
+  [worktree-path pr-url listener-id update-fn]
+  (let [r (read-registry worktree-path)]
+    (if-not (dag/ok? r)
+      r
+      (let [registry (:data r)
+            check    (check-active-entry registry pr-url listener-id)]
+        (if-not (dag/ok? check)
+          check
+          (write-registry! worktree-path
+                           (update-entry-status registry pr-url listener-id update-fn)))))))
+
+(defn ^{:stratum 9} mark-cancelled-on-pr-close!
+  "Transition every `:active` listener for `pr-url` to `:cancelled`.
+   Called when `pull_request.closed` arrives with `merged: false`
+   (spec §Deregistration). Returns DAG result with the count of
+   transitioned entries."
+  [worktree-path pr-url]
+  (let [r (read-registry worktree-path)]
+    (if-not (dag/ok? r)
+      r
+      (let [registry (:data r)
+            actives  (active-entries-for-pr registry pr-url)
+            next-reg (reduce (partial apply-cancel-to pr-url) registry actives)
+            write-r  (write-registry! worktree-path next-reg)]
+        (if (dag/ok? write-r)
+          (dag/ok {:cancelled-count (count actives) :pr-url pr-url})
+          write-r)))))
+
+(defn ^{:stratum 9} sweep-expired!
+  "Transition every `:active` entry whose TTL has elapsed to
+   `:expired`. Returns DAG result with the count of transitioned
+   entries. Idempotent — re-running yields a count of 0."
+  [worktree-path]
+  (let [r (read-registry worktree-path)]
+    (if-not (dag/ok? r)
+      r
+      (let [registry (:data r)
+            stale    (collect-expirable-pairs registry (now-inst))
+            next-reg (reduce apply-expire-to registry stale)
+            write-r  (write-registry! worktree-path next-reg)]
+        (if (dag/ok? write-r)
+          (dag/ok {:expired-count (count stale)})
+          write-r)))))
+
+;------------------------------------------------------------------------------ Layer 10
+
+(defn ^{:stratum 10} register!
   "Persist a new listener entry for `pr-url` against `agent-id`.
 
    Required keys in `params`:
@@ -504,31 +574,7 @@
           validation
           (persist-new-entry! worktree-path (:data validation)))))))
 
-(defn- transition-from-active!
-  "Internal: load → assert entry is `:active` → update → write.
-
-   Returns:
-   - `:listener-registry/listener-not-found` when no such entry exists.
-   - `:listener-registry/wrong-status` when the entry isn't `:active`
-     — guards against overwriting terminal states (`:dispatched`,
-     `:expired`, `:cancelled`) per spec §Lifecycle, which models all
-     transitions as `:active → X`.
-   - `(dag/ok ...)` from `write-registry!` on the happy path.
-
-   `update-fn` receives the entry (guaranteed `:status :active`) and
-   returns its replacement."
-  [worktree-path pr-url listener-id update-fn]
-  (let [r (read-registry worktree-path)]
-    (if-not (dag/ok? r)
-      r
-      (let [registry (:data r)
-            check    (check-active-entry registry pr-url listener-id)]
-        (if-not (dag/ok? check)
-          check
-          (write-registry! worktree-path
-                           (update-entry-status registry pr-url listener-id update-fn)))))))
-
-(defn unregister!
+(defn ^{:stratum 10} unregister!
   "Transition `listener-id` for `pr-url` from `:active` to `:cancelled`.
 
    Returns typed error when:
@@ -539,7 +585,7 @@
   [worktree-path pr-url listener-id]
   (transition-from-active! worktree-path pr-url listener-id mark-cancelled))
 
-(defn mark-dispatched!
+(defn ^{:stratum 10} mark-dispatched!
   "Transition `listener-id` for `pr-url` from `:active` to
    `:dispatched`, recording `:resume/dispatched-at` and
    `:resume/dispatch-id`. Called by the Resume Signal Dispatcher
@@ -551,36 +597,3 @@
    listeners."
   [worktree-path pr-url listener-id dispatch-id]
   (transition-from-active! worktree-path pr-url listener-id (mark-dispatched dispatch-id)))
-
-(defn mark-cancelled-on-pr-close!
-  "Transition every `:active` listener for `pr-url` to `:cancelled`.
-   Called when `pull_request.closed` arrives with `merged: false`
-   (spec §Deregistration). Returns DAG result with the count of
-   transitioned entries."
-  [worktree-path pr-url]
-  (let [r (read-registry worktree-path)]
-    (if-not (dag/ok? r)
-      r
-      (let [registry (:data r)
-            actives  (active-entries-for-pr registry pr-url)
-            next-reg (reduce (partial apply-cancel-to pr-url) registry actives)
-            write-r  (write-registry! worktree-path next-reg)]
-        (if (dag/ok? write-r)
-          (dag/ok {:cancelled-count (count actives) :pr-url pr-url})
-          write-r)))))
-
-(defn sweep-expired!
-  "Transition every `:active` entry whose TTL has elapsed to
-   `:expired`. Returns DAG result with the count of transitioned
-   entries. Idempotent — re-running yields a count of 0."
-  [worktree-path]
-  (let [r (read-registry worktree-path)]
-    (if-not (dag/ok? r)
-      r
-      (let [registry (:data r)
-            stale    (collect-expirable-pairs registry (now-inst))
-            next-reg (reduce apply-expire-to registry stale)
-            write-r  (write-registry! worktree-path next-reg)]
-        (if (dag/ok? write-r)
-          (dag/ok {:expired-count (count stale)})
-          write-r)))))

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.merge
   "Merge policy enforcement and PR merging.
 
@@ -33,9 +32,9 @@
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Anomaly detection (dual shape during W2 convergence)
 
-(defn- any-anomaly?
+;; Anomaly detection (dual shape during W2 convergence)
+(defn- ^{:stratum 0} any-anomaly?
   "True when `x` is either a canonical anomaly (`:anomaly/type`) or a
    legacy response anomaly (`:anomaly/category`).
 
@@ -51,16 +50,14 @@
   (or (anomaly/anomaly? x)
       (response/anomaly-map? x)))
 
-;------------------------------------------------------------------------------ Layer 0
 ;; Merge policies
-
-(def merge-methods
+(def ^{:stratum 0} merge-methods
   "Supported merge methods."
   #{:merge    ; Create merge commit
     :squash   ; Squash and merge
-    :rebase}) ; Rebase and merge
+    :rebase})  ; Rebase and merge
 
-(def default-merge-policy
+(def ^{:stratum 0} default-merge-policy
   "Default merge policy."
   {:method :squash
    :require-ci-green? true
@@ -77,10 +74,8 @@
    ;; injects workflow.merge-resolution/resolve-conflict! there).
    :auto-resolve-conflicts? true})
 
-;------------------------------------------------------------------------------ Layer 0
 ;; GitHub CLI helpers
-
-(defn run-gh-command
+(defn ^{:stratum 0} run-gh-command
   "Run a gh CLI command and return result."
   [args worktree-path]
   (try
@@ -98,10 +93,29 @@
     (catch Exception e
       (dag/err :gh-exception (.getMessage e)))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Merge readiness checks
+(defn ^{:stratum 0} check-unresolved-threads
+  "Check if PR has unresolved comment threads."
+  [_worktree-path _pr-number]
+  ;; gh doesn't have a direct way to check this
+  ;; Would need GitHub API for accurate count
+  (dag/ok {:has-unresolved? false
+           :note "Thread resolution check requires GitHub API"}))
 
-(defn check-ci-status
+;; Conflict-resolution dispatch (Stage 3d, spec §6.4)
+(defn- ^{:stratum 0} parse-gh-json
+  "Parse `gh --json` output as JSON via Cheshire. Returns the parsed
+   map (keywordized keys) on success or nil if the body isn't valid
+   JSON. Cheshire matches what github.clj / pr_poller.clj already
+   use; the prior regex-based parse here was brittle to formatting
+   and escaping changes in gh's output."
+  [body]
+  (try (json/parse-string body true)
+       (catch Exception _ nil)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Merge readiness checks
+(defn ^{:stratum 1} check-ci-status
   "Check if CI is green for a PR."
   [worktree-path pr-number]
   (let [result (run-gh-command
@@ -112,7 +126,7 @@
       (dag/ok {:ci-green? false
                :error (:error result)}))))
 
-(defn check-review-status
+(defn ^{:stratum 1} check-review-status
   "Check if PR has required approvals."
   [worktree-path pr-number _required-approvals]
   (let [result (run-gh-command
@@ -125,7 +139,7 @@
                  :raw output}))
       result)))
 
-(defn check-branch-status
+(defn ^{:stratum 1} check-branch-status
   "Check if PR branch is up-to-date with base."
   [worktree-path pr-number]
   (let [result (run-gh-command
@@ -140,60 +154,8 @@
                  :raw output}))
       result)))
 
-(defn check-unresolved-threads
-  "Check if PR has unresolved comment threads."
-  [_worktree-path _pr-number]
-  ;; gh doesn't have a direct way to check this
-  ;; Would need GitHub API for accurate count
-  (dag/ok {:has-unresolved? false
-           :note "Thread resolution check requires GitHub API"}))
-
-(defn evaluate-merge-readiness
-  "Evaluate if a PR is ready to merge according to policy.
-
-   Arguments:
-   - worktree-path: Path to git worktree
-   - pr-number: PR number
-   - policy: Merge policy map
-
-   Returns {:ready? bool :checks {...} :blocking [...]}."
-  [worktree-path pr-number policy]
-  (let [ci-check (when (:require-ci-green? policy)
-                   (check-ci-status worktree-path pr-number))
-        review-check (when (:require-approvals? policy)
-                       (check-review-status worktree-path pr-number
-                                            (:required-approvals policy)))
-        branch-check (when (:require-branch-up-to-date? policy)
-                       (check-branch-status worktree-path pr-number))
-        thread-check (when (:require-no-unresolved-threads? policy)
-                       (check-unresolved-threads worktree-path pr-number))
-
-        checks {:ci ci-check
-                :review review-check
-                :branch branch-check
-                :threads thread-check}
-
-        blocking (cond-> []
-                   (and ci-check (not (:ci-green? (:data ci-check))))
-                   (conj :ci-not-green)
-
-                   (and review-check (not (:approved? (:data review-check))))
-                   (conj :not-approved)
-
-                   (and branch-check (not (:up-to-date? (:data branch-check))))
-                   (conj :branch-not-up-to-date)
-
-                   (and thread-check (:has-unresolved? (:data thread-check)))
-                   (conj :unresolved-threads))]
-
-    {:ready? (empty? blocking)
-     :checks checks
-     :blocking blocking}))
-
-;------------------------------------------------------------------------------ Layer 2
 ;; Merge execution
-
-(defn merge-pr!
+(defn ^{:stratum 1} merge-pr!
   "Merge a PR using gh CLI.
 
    Arguments:
@@ -219,7 +181,7 @@
                :output (:output (:data result))})
       result)))
 
-(defn enable-auto-merge!
+(defn ^{:stratum 1} enable-auto-merge!
   "Enable auto-merge for a PR (merges when all checks pass).
 
    Arguments:
@@ -241,7 +203,7 @@
       (dag/ok {:auto-merge-enabled? true})
       result)))
 
-(defn disable-auto-merge!
+(defn ^{:stratum 1} disable-auto-merge!
   "Disable auto-merge for a PR."
   [worktree-path pr-number]
   (let [result (run-gh-command
@@ -251,7 +213,7 @@
       (dag/ok {:auto-merge-disabled? true})
       result)))
 
-(defn rebase-pr!
+(defn ^{:stratum 1} rebase-pr!
   "Rebase a PR onto the latest base branch.
 
    Arguments:
@@ -285,20 +247,7 @@
               (dag/err :push-failed (:error push-result))))
           (dag/err :rebase-failed (:error rebase-result)))))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Conflict-resolution dispatch (Stage 3d, spec §6.4)
-
-(defn- parse-gh-json
-  "Parse `gh --json` output as JSON via Cheshire. Returns the parsed
-   map (keywordized keys) on success or nil if the body isn't valid
-   JSON. Cheshire matches what github.clj / pr_poller.clj already
-   use; the prior regex-based parse here was brittle to formatting
-   and escaping changes in gh's output."
-  [body]
-  (try (json/parse-string body true)
-       (catch Exception _ nil)))
-
-(defn- pr-info-from-gh
+(defn- ^{:stratum 1} pr-info-from-gh
   "Fetch the fields conflict-resolution/resolve-pr-conflicts! needs
    from `gh pr view`: PR number, branch (headRefName), base
    (baseRefName), head SHA (headRefOid), base SHA (baseRefOid).
@@ -340,7 +289,7 @@
                                (not head-sha)    (conj :headRefOid)
                                (not base-sha)    (conj :baseRefOid))}))))))
 
-(defn- normalize-resolution-outcome
+(defn- ^{:stratum 1} normalize-resolution-outcome
   "conflict-resolution/resolve-pr-conflicts! can return:
    - dag/ok on success;
    - dag/err on infrastructure failure; or
@@ -365,7 +314,72 @@
              {:anomaly outcome})
     outcome))
 
-(defn- attempt-conflict-resolution!
+;; Merge orchestration
+(defn ^{:stratum 1} fetch-pr-labels!
+  "Fetch the label names attached to a PR via `gh pr view --json labels`.
+
+   Returns a `#{}` of label-name strings (GitHub-native, literal,
+   no case-folding). Returns `#{}` on any failure — label fetch is
+   best-effort and never blocks the merge-event publish path. The
+   first downstream consumer is the M2 pr-label-actions watcher."
+  [worktree-path pr-number]
+  (try
+    (let [result (run-gh-command
+                  ["gh" "pr" "view" (str pr-number) "--json" "labels"]
+                  worktree-path)]
+      (if (dag/ok? result)
+        (let [body (json/parse-string (:output (:data result)) true)]
+          (->> (:labels body)
+               (keep :name)
+               set))
+        #{}))
+    (catch Exception _ #{})))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} evaluate-merge-readiness
+  "Evaluate if a PR is ready to merge according to policy.
+
+   Arguments:
+   - worktree-path: Path to git worktree
+   - pr-number: PR number
+   - policy: Merge policy map
+
+   Returns {:ready? bool :checks {...} :blocking [...]}."
+  [worktree-path pr-number policy]
+  (let [ci-check (when (:require-ci-green? policy)
+                   (check-ci-status worktree-path pr-number))
+        review-check (when (:require-approvals? policy)
+                       (check-review-status worktree-path pr-number
+                                            (:required-approvals policy)))
+        branch-check (when (:require-branch-up-to-date? policy)
+                       (check-branch-status worktree-path pr-number))
+        thread-check (when (:require-no-unresolved-threads? policy)
+                       (check-unresolved-threads worktree-path pr-number))
+
+        checks {:ci ci-check
+                :review review-check
+                :branch branch-check
+                :threads thread-check}
+
+        blocking (cond-> []
+                   (and ci-check (not (:ci-green? (:data ci-check))))
+                   (conj :ci-not-green)
+
+                   (and review-check (not (:approved? (:data review-check))))
+                   (conj :not-approved)
+
+                   (and branch-check (not (:up-to-date? (:data branch-check))))
+                   (conj :branch-not-up-to-date)
+
+                   (and thread-check (:has-unresolved? (:data thread-check)))
+                   (conj :unresolved-threads))]
+
+    {:ready? (empty? blocking)
+     :checks checks
+     :blocking blocking}))
+
+(defn- ^{:stratum 2} attempt-conflict-resolution!
   "Spec §6.4 dispatch: when `branch-check` raw output classifies as
    :conflicting AND policy enables auto-resolve AND context carries
    `:resolve-fn`, run conflict-resolution/resolve-pr-conflicts! and
@@ -392,30 +406,9 @@
              :resolve-fn    resolve-fn
              :context       context})))))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Merge orchestration
+;------------------------------------------------------------------------------ Layer 3
 
-(defn fetch-pr-labels!
-  "Fetch the label names attached to a PR via `gh pr view --json labels`.
-
-   Returns a `#{}` of label-name strings (GitHub-native, literal,
-   no case-folding). Returns `#{}` on any failure — label fetch is
-   best-effort and never blocks the merge-event publish path. The
-   first downstream consumer is the M2 pr-label-actions watcher."
-  [worktree-path pr-number]
-  (try
-    (let [result (run-gh-command
-                  ["gh" "pr" "view" (str pr-number) "--json" "labels"]
-                  worktree-path)]
-      (if (dag/ok? result)
-        (let [body (json/parse-string (:output (:data result)) true)]
-          (->> (:labels body)
-               (keep :name)
-               set))
-        #{}))
-    (catch Exception _ #{})))
-
-(defn attempt-merge
+(defn ^{:stratum 3} attempt-merge
   "Attempt to merge a PR, handling common failure cases.
 
    Arguments:

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/messages.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/messages.clj
@@ -15,13 +15,14 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.messages
   "Component-level message catalog for PR lifecycle.
    Delegates to the shared messages component."
   (:require [ai.miniforge.messages.interface :as messages]))
 
-(def t
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} t
   "Look up a PR lifecycle message by key, with optional param substitution."
   (messages/create-translator "config/pr-lifecycle/messages/en-US.edn"
                               :pr-lifecycle/messages))

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_budget.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_budget.clj
@@ -11,7 +11,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.monitor-budget
   "Per-PR budget tracking for the PR monitor loop.
 
@@ -29,9 +28,9 @@
    [clojure.java.io :as io]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Schemas + budget defaults
 
-(def BudgetState
+;; Schemas + budget defaults
+(def ^{:stratum 0} BudgetState
   [:map
    [:pr-number pos-int?]
    [:limits [:map
@@ -44,14 +43,57 @@
    [:questions-answered nat-int?]
    [:fixes-pushed nat-int?]])
 
-(defn- validate!
+(defn- ^{:stratum 0} validate!
   [result-schema value]
   (schema/validate result-schema value))
 
-;------------------------------------------------------------------------------ Layer 0
-;; Budget state
+;; Budget operations
+(defn ^{:stratum 0} record-fix-attempt
+  "Record a fix attempt for a comment. Returns updated budget state."
+  [budget comment-id]
+  (-> budget
+      (update-in [:comment-attempts comment-id] (fnil inc 0))
+      (update :total-attempts inc)))
 
-(defn create-budget
+(defn ^{:stratum 0} record-question-answered
+  "Record a question answered (does not consume fix budget)."
+  [budget]
+  (update budget :questions-answered inc))
+
+(defn ^{:stratum 0} record-fix-pushed
+  "Record a successful fix push."
+  [budget]
+  (update budget :fixes-pushed inc))
+
+(defn ^{:stratum 0} comment-attempts-remaining
+  "How many fix attempts remain for a specific comment."
+  [budget comment-id]
+  (let [max-per-comment (get-in budget [:limits :max-fix-attempts-per-comment])
+        used (get-in budget [:comment-attempts comment-id] 0)]
+    (max 0 (- max-per-comment used))))
+
+(defn ^{:stratum 0} total-attempts-remaining
+  "How many total fix attempts remain for the PR."
+  [budget]
+  (let [max-total (get-in budget [:limits :max-total-fix-attempts-per-pr])
+        used (:total-attempts budget)]
+    (max 0 (- max-total used))))
+
+(defn ^{:stratum 0} hours-elapsed
+  "Hours elapsed since monitoring started."
+  [budget]
+  (let [started (.getTime ^java.util.Date (:started-at budget))
+        now (System/currentTimeMillis)]
+    (/ (double (- now started)) 3600000.0)))
+
+;; Budget persistence
+(def ^{:stratum 0} ^:private state-dir
+  (str (mf-config/miniforge-home) "/state/pr-monitor"))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Budget state
+(defn ^{:stratum 1} create-budget
   "Create a new budget tracker for a PR.
 
    Arguments:
@@ -71,72 +113,61 @@
       :questions-answered 0
       :fixes-pushed 0})))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Budget operations
-
-(defn record-fix-attempt
-  "Record a fix attempt for a comment. Returns updated budget state."
-  [budget comment-id]
-  (-> budget
-      (update-in [:comment-attempts comment-id] (fnil inc 0))
-      (update :total-attempts inc)))
-
-(defn record-question-answered
-  "Record a question answered (does not consume fix budget)."
-  [budget]
-  (update budget :questions-answered inc))
-
-(defn record-fix-pushed
-  "Record a successful fix push."
-  [budget]
-  (update budget :fixes-pushed inc))
-
-(defn comment-attempts-remaining
-  "How many fix attempts remain for a specific comment."
-  [budget comment-id]
-  (let [max-per-comment (get-in budget [:limits :max-fix-attempts-per-comment])
-        used (get-in budget [:comment-attempts comment-id] 0)]
-    (max 0 (- max-per-comment used))))
-
-(defn total-attempts-remaining
-  "How many total fix attempts remain for the PR."
-  [budget]
-  (let [max-total (get-in budget [:limits :max-total-fix-attempts-per-pr])
-        used (:total-attempts budget)]
-    (max 0 (- max-total used))))
-
-(defn hours-elapsed
-  "Hours elapsed since monitoring started."
-  [budget]
-  (let [started (.getTime ^java.util.Date (:started-at budget))
-        now (System/currentTimeMillis)]
-    (/ (double (- now started)) 3600000.0)))
-
-(defn time-remaining-hours
+(defn ^{:stratum 1} time-remaining-hours
   "Hours remaining before abandon deadline."
   [budget]
   (let [max-hours (get-in budget [:limits :abandon-after-hours])]
     (max 0.0 (- (double max-hours) (hours-elapsed budget)))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Budget checks (hard stops)
-
-(defn comment-budget-exhausted?
+(defn ^{:stratum 1} comment-budget-exhausted?
   "Check if the per-comment budget is exhausted."
   [budget comment-id]
   (zero? (comment-attempts-remaining budget comment-id)))
 
-(defn pr-budget-exhausted?
+(defn ^{:stratum 1} pr-budget-exhausted?
   "Check if the total PR budget is exhausted."
   [budget]
   (zero? (total-attempts-remaining budget)))
 
-(defn time-budget-exhausted?
+(defn ^{:stratum 1} save-budget!
+  "Persist budget state to disk."
+  [budget]
+  (let [dir (io/file state-dir)
+        _ (when-not (.exists dir) (.mkdirs dir))
+        f (io/file state-dir (str "budget-" (:pr-number budget) ".edn"))]
+    (spit f (pr-str budget))))
+
+(defn ^{:stratum 1} load-budget
+  "Load persisted budget for a PR, if it exists."
+  [pr-number]
+  (let [f (io/file state-dir (str "budget-" pr-number ".edn"))]
+    (when (.exists f)
+      (try
+        (edn/read-string (slurp f))
+        (catch Exception _e nil)))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} time-budget-exhausted?
   "Check if the time budget is exhausted."
   [budget]
   (<= (time-remaining-hours budget) 0.0))
 
-(defn any-budget-exhausted?
+(defn ^{:stratum 2} budget-summary
+  "Generate a summary of current budget status for events and logging."
+  [budget]
+  {:total-attempts-used (:total-attempts budget)
+   :total-attempts-remaining (total-attempts-remaining budget)
+   :hours-elapsed (hours-elapsed budget)
+   :hours-remaining (time-remaining-hours budget)
+   :fixes-pushed (:fixes-pushed budget)
+   :questions-answered (:questions-answered budget)
+   :comment-attempts (:comment-attempts budget)})
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} any-budget-exhausted?
   "Check if any budget dimension is exhausted.
 
    Returns nil if budget OK, or a keyword indicating which limit was hit:
@@ -148,40 +179,6 @@
     (and comment-id
          (comment-budget-exhausted? budget comment-id)) :comment-limit
     :else                                               nil))
-
-(defn budget-summary
-  "Generate a summary of current budget status for events and logging."
-  [budget]
-  {:total-attempts-used (:total-attempts budget)
-   :total-attempts-remaining (total-attempts-remaining budget)
-   :hours-elapsed (hours-elapsed budget)
-   :hours-remaining (time-remaining-hours budget)
-   :fixes-pushed (:fixes-pushed budget)
-   :questions-answered (:questions-answered budget)
-   :comment-attempts (:comment-attempts budget)})
-
-;------------------------------------------------------------------------------ Layer 1
-;; Budget persistence
-
-(def ^:private state-dir
-  (str (mf-config/miniforge-home) "/state/pr-monitor"))
-
-(defn save-budget!
-  "Persist budget state to disk."
-  [budget]
-  (let [dir (io/file state-dir)
-        _ (when-not (.exists dir) (.mkdirs dir))
-        f (io/file state-dir (str "budget-" (:pr-number budget) ".edn"))]
-    (spit f (pr-str budget))))
-
-(defn load-budget
-  "Load persisted budget for a PR, if it exists."
-  [pr-number]
-  (let [f (io/file state-dir (str "budget-" pr-number ".edn"))]
-    (when (.exists f)
-      (try
-        (edn/read-string (slurp f))
-        (catch Exception _e nil)))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_config.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_config.clj
@@ -11,7 +11,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.monitor-config
   "Load shared PR monitor defaults from EDN configuration."
   (:require
@@ -19,9 +18,9 @@
    [ai.miniforge.schema.interface :as schema]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Schemas + config loading
 
-(def MonitorDefaults
+;; Schemas + config loading
+(def ^{:stratum 0} MonitorDefaults
   [:map
    [:poll-interval-ms nat-int?]
    [:self-author {:optional true} [:maybe :string]]
@@ -29,15 +28,19 @@
    [:max-total-fix-attempts-per-pr pos-int?]
    [:abandon-after-hours pos-int?]])
 
-(def MonitorConfig
-  [:map
-   [:pr-monitor/defaults MonitorDefaults]])
-
-(defn- validate!
+(defn- ^{:stratum 0} validate!
   [result-schema value]
   (schema/validate result-schema value))
 
-(defn- load-monitor-config
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} MonitorConfig
+  [:map
+   [:pr-monitor/defaults MonitorDefaults]])
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- ^{:stratum 2} load-monitor-config
   []
   (->> (config/load-config-resource
         "config/pr-monitor/defaults.edn"
@@ -45,18 +48,22 @@
         {:hint "Add components/pr-lifecycle/resources to your classpath"})
        (validate! MonitorConfig)))
 
-(def ^:private monitor-config
+;------------------------------------------------------------------------------ Layer 3
+
+(def ^{:stratum 3} ^:private monitor-config
   (delay (load-monitor-config)))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Public helpers
+;------------------------------------------------------------------------------ Layer 4
 
-(defn monitor-defaults
+;; Public helpers
+(defn ^{:stratum 4} monitor-defaults
   "Return the shared PR monitor defaults map."
   []
   (:pr-monitor/defaults @monitor-config))
 
-(defn budget-defaults
+;------------------------------------------------------------------------------ Layer 5
+
+(defn ^{:stratum 5} budget-defaults
   "Return just the budget-related defaults used by the monitor loop."
   []
   (select-keys (monitor-defaults)

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_events.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_events.clj
@@ -11,7 +11,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.monitor-events
   "PR monitor loop event types and constructors.
 
@@ -23,9 +22,9 @@
    [ai.miniforge.pr-lifecycle.events :as events]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Event types
 
-(def monitor-event-types
+;; Event types
+(def ^{:stratum 0} monitor-event-types
   "Valid PR monitor loop event types."
   #{:pr-monitor/poll-completed       ; Poll cycle completed
     :pr-monitor/comment-received     ; New comment detected
@@ -40,25 +39,23 @@
     :pr-monitor/escalated            ; Escalated to human intervention
     :pr-monitor/cycle-completed      ; Full monitor cycle completed
     :pr-monitor/loop-started         ; Monitor loop started for a PR
-    :pr-monitor/loop-stopped})       ; Monitor loop stopped
+    :pr-monitor/loop-stopped})  ; Monitor loop stopped
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Event constructors
-
-(defn poll-completed
+(defn ^{:stratum 0} poll-completed
   "Create a poll-completed event."
   [pr-number data]
   (events/create-event :pr-monitor/poll-completed
                        (merge {:pr/id pr-number} data)))
 
-(defn comment-received
+(defn ^{:stratum 0} comment-received
   "Create a comment-received event."
   [pr-number comment-data]
   (events/create-event :pr-monitor/comment-received
                        {:pr/id pr-number
                         :comment comment-data}))
 
-(defn comment-classified
+(defn ^{:stratum 0} comment-classified
   "Create a comment-classified event."
   [pr-number comment-data classification]
   (events/create-event :pr-monitor/comment-classified
@@ -66,7 +63,7 @@
                         :comment comment-data
                         :classification classification}))
 
-(defn decision-recorded
+(defn ^{:stratum 0} decision-recorded
   "Create a decision-recorded event: the typed classify→act decision for a
    comment. `action` is the chosen verb (:fix :answer :approve :skip), recorded
    as one act with provenance back to the comment and its classification."
@@ -78,7 +75,7 @@
                         :decision/category category
                         :decision/confidence confidence}))
 
-(defn fix-started
+(defn ^{:stratum 0} fix-started
   "Create a fix-started event."
   [pr-number comment-id attempt]
   (events/create-event :pr-monitor/fix-started
@@ -86,7 +83,7 @@
                         :comment/id comment-id
                         :fix/attempt attempt}))
 
-(defn fix-pushed
+(defn ^{:stratum 0} fix-pushed
   "Create a fix-pushed event."
   [pr-number comment-id commit-sha]
   (events/create-event :pr-monitor/fix-pushed
@@ -94,7 +91,7 @@
                         :comment/id comment-id
                         :pr/sha commit-sha}))
 
-(defn reply-posted
+(defn ^{:stratum 0} reply-posted
   "Create a reply-posted event."
   [pr-number comment-id reply-type]
   (events/create-event :pr-monitor/reply-posted
@@ -102,14 +99,14 @@
                         :comment/id comment-id
                         :reply/type reply-type}))
 
-(defn question-answered
+(defn ^{:stratum 0} question-answered
   "Create a question-answered event."
   [pr-number comment-id]
   (events/create-event :pr-monitor/question-answered
                        {:pr/id pr-number
                         :comment/id comment-id}))
 
-(defn budget-warning
+(defn ^{:stratum 0} budget-warning
   "Create a budget-warning event."
   [pr-number budget-remaining budget-total]
   (events/create-event :pr-monitor/budget-warning
@@ -117,13 +114,13 @@
                         :budget/remaining budget-remaining
                         :budget/total budget-total}))
 
-(defn budget-exhausted
+(defn ^{:stratum 0} budget-exhausted
   "Create a budget-exhausted event. This is a hard stop."
   [pr-number budget-data]
   (events/create-event :pr-monitor/budget-exhausted
                        (merge {:pr/id pr-number} budget-data)))
 
-(defn escalated
+(defn ^{:stratum 0} escalated
   "Create an escalated-to-human event."
   [pr-number reason data]
   (events/create-event :pr-monitor/escalated
@@ -131,13 +128,13 @@
                                :escalation/reason reason}
                               data)))
 
-(defn cycle-completed
+(defn ^{:stratum 0} cycle-completed
   "Create a cycle-completed event."
   [pr-number cycle-data]
   (events/create-event :pr-monitor/cycle-completed
                        (merge {:pr/id pr-number} cycle-data)))
 
-(defn loop-started
+(defn ^{:stratum 0} loop-started
   "Create a loop-started event."
   [pr-number config]
   (events/create-event :pr-monitor/loop-started
@@ -147,7 +144,7 @@
                                                      :max-total-fix-attempts-per-pr
                                                      :abandon-after-hours])}))
 
-(defn loop-stopped
+(defn ^{:stratum 0} loop-stopped
   "Create a loop-stopped event."
   [pr-number reason]
   (events/create-event :pr-monitor/loop-stopped

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_handlers.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_handlers.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.monitor-handlers
   "Comment handlers for the PR monitor loop."
   (:require
@@ -28,13 +27,13 @@
    [ai.miniforge.pr-lifecycle.pr-poller :as poller]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Helpers
 
-(defn- succeeded?
+;; Helpers
+(defn- ^{:stratum 0} succeeded?
   [result]
   (true? (:success? result)))
 
-(def ^:private category->action
+(def ^{:stratum 0} ^:private category->action
   "The PR-monitor's action verb for each classified-comment category. The
    closed vocabulary the classify→act decision records."
   {:change-request :fix
@@ -43,15 +42,94 @@
    :bot-comment    :skip
    :noise          :skip})
 
-(defn- decision-action
+(defn ^{:stratum 0} handle-question
+  "Handle a question comment by generating and posting a reply."
+  [monitor pr-info classified-comment]
+  (let [{:keys [worktree-path generate-fn logger]} (:config @monitor)
+        pr-number (:pr/number pr-info)
+        comment (:comment classified-comment)
+        comment-id (:comment/id comment)
+        body (:comment/body comment)]
+    (if-not generate-fn
+      (do
+        (when logger
+          (log/warn logger :pr-monitor :handler/no-generate-fn
+                    {:message "Cannot answer question — no generate-fn configured"
+                     :data {:pr-number pr-number}}))
+        {:success? false :reason :no-generate-fn})
+      (let [prompt (str "You are miniforge, an autonomous software development agent. "
+                        "A reviewer left this question on a pull request you authored. "
+                        "Answer clearly and concisely. Do not make code changes.\n\n"
+                        "Question:\n" body "\n\n"
+                        "Write only the answer text, no preamble.")
+            answer (try
+                     (generate-fn prompt)
+                     (catch Exception e
+                       (when logger
+                         (log/error logger :pr-monitor :handler/llm-error
+                                    {:message "LLM call failed for question"
+                                     :data {:error (.getMessage e)}}))
+                       nil))]
+        (if answer
+          (let [reply-body (str answer
+                                "\n\n---\n*Answered by miniforge's autonomous PR monitor.*")
+                post-result (poller/post-comment worktree-path pr-number reply-body)]
+            (if (dag/ok? post-result)
+              (do
+                (state/emit! monitor (mevents/question-answered pr-number comment-id))
+                (state/emit! monitor (mevents/reply-posted pr-number comment-id
+                                                           :question-reply))
+                (let [pr-budget (state/get-or-create-budget monitor pr-number)]
+                  (state/update-budget! monitor pr-number
+                                        (budget/record-question-answered pr-budget)))
+                (swap! monitor update-in [:evidence :questions-answered] conj
+                       {:comment-id comment-id :at (java.util.Date.)})
+                (swap! monitor update-in [:evidence :comments-addressed] inc)
+                (when logger
+                  (log/info logger :pr-monitor :handler/question-answered
+                            {:message (str "Answered question on PR #" pr-number)
+                             :data {:comment-id comment-id}}))
+                {:success? true :type :question-answered})
+              (do
+                (when logger
+                  (log/warn logger :pr-monitor :handler/post-failed
+                            {:message "Failed to post question answer"
+                             :data {:pr-number pr-number}}))
+                {:success? false :reason :post-failed})))
+          {:success? false :reason :llm-failed})))))
+
+(defn ^{:stratum 0} handle-bot-comment
+  "Handle a bot comment. Log and skip."
+  [monitor _pr-info classified-comment]
+  (let [logger (get-in @monitor [:config :logger])
+        comment (:comment classified-comment)]
+    (when logger
+      (log/debug logger :pr-monitor :handler/bot-comment
+                 {:message "Bot comment — skipping"
+                  :data {:author (:comment/author comment)}}))
+    {:success? true :type :bot-skipped}))
+
+(defn ^{:stratum 0} handle-approval
+  "Handle an approval comment. Log and skip."
+  [monitor pr-info classified-comment]
+  (let [logger (get-in @monitor [:config :logger])
+        pr-number (:pr/number pr-info)
+        comment (:comment classified-comment)]
+    (when logger
+      (log/info logger :pr-monitor :handler/approval
+                {:message (str "Approval received on PR #" pr-number)
+                 :data {:author (:comment/author comment)}}))
+    {:success? true :type :approval-noted}))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} decision-action
   "Action verb for a classified comment's category; unknown categories → :skip."
   [category]
   (get category->action category :skip))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Comment handlers
-
-(defn handle-change-request
+(defn ^{:stratum 1} handle-change-request
   "Handle a change-request comment by running one fix-loop attempt."
   [monitor pr-info classified-comment]
   (let [{:keys [worktree-path generate-fn logger event-bus]} (:config @monitor)
@@ -131,89 +209,10 @@
                            :data {:reason (:reason fix-result) :attempt attempt}}))
               {:success? false :reason (:reason fix-result) :attempt attempt})))))))
 
-(defn handle-question
-  "Handle a question comment by generating and posting a reply."
-  [monitor pr-info classified-comment]
-  (let [{:keys [worktree-path generate-fn logger]} (:config @monitor)
-        pr-number (:pr/number pr-info)
-        comment (:comment classified-comment)
-        comment-id (:comment/id comment)
-        body (:comment/body comment)]
-    (if-not generate-fn
-      (do
-        (when logger
-          (log/warn logger :pr-monitor :handler/no-generate-fn
-                    {:message "Cannot answer question — no generate-fn configured"
-                     :data {:pr-number pr-number}}))
-        {:success? false :reason :no-generate-fn})
-      (let [prompt (str "You are miniforge, an autonomous software development agent. "
-                        "A reviewer left this question on a pull request you authored. "
-                        "Answer clearly and concisely. Do not make code changes.\n\n"
-                        "Question:\n" body "\n\n"
-                        "Write only the answer text, no preamble.")
-            answer (try
-                     (generate-fn prompt)
-                     (catch Exception e
-                       (when logger
-                         (log/error logger :pr-monitor :handler/llm-error
-                                    {:message "LLM call failed for question"
-                                     :data {:error (.getMessage e)}}))
-                       nil))]
-        (if answer
-          (let [reply-body (str answer
-                                "\n\n---\n*Answered by miniforge's autonomous PR monitor.*")
-                post-result (poller/post-comment worktree-path pr-number reply-body)]
-            (if (dag/ok? post-result)
-              (do
-                (state/emit! monitor (mevents/question-answered pr-number comment-id))
-                (state/emit! monitor (mevents/reply-posted pr-number comment-id
-                                                           :question-reply))
-                (let [pr-budget (state/get-or-create-budget monitor pr-number)]
-                  (state/update-budget! monitor pr-number
-                                        (budget/record-question-answered pr-budget)))
-                (swap! monitor update-in [:evidence :questions-answered] conj
-                       {:comment-id comment-id :at (java.util.Date.)})
-                (swap! monitor update-in [:evidence :comments-addressed] inc)
-                (when logger
-                  (log/info logger :pr-monitor :handler/question-answered
-                            {:message (str "Answered question on PR #" pr-number)
-                             :data {:comment-id comment-id}}))
-                {:success? true :type :question-answered})
-              (do
-                (when logger
-                  (log/warn logger :pr-monitor :handler/post-failed
-                            {:message "Failed to post question answer"
-                             :data {:pr-number pr-number}}))
-                {:success? false :reason :post-failed})))
-          {:success? false :reason :llm-failed})))))
-
-(defn handle-bot-comment
-  "Handle a bot comment. Log and skip."
-  [monitor _pr-info classified-comment]
-  (let [logger (get-in @monitor [:config :logger])
-        comment (:comment classified-comment)]
-    (when logger
-      (log/debug logger :pr-monitor :handler/bot-comment
-                 {:message "Bot comment — skipping"
-                  :data {:author (:comment/author comment)}}))
-    {:success? true :type :bot-skipped}))
-
-(defn handle-approval
-  "Handle an approval comment. Log and skip."
-  [monitor pr-info classified-comment]
-  (let [logger (get-in @monitor [:config :logger])
-        pr-number (:pr/number pr-info)
-        comment (:comment classified-comment)]
-    (when logger
-      (log/info logger :pr-monitor :handler/approval
-                {:message (str "Approval received on PR #" pr-number)
-                 :data {:author (:comment/author comment)}}))
-    {:success? true :type :approval-noted}))
-
 ;------------------------------------------------------------------------------ Layer 2
-;; Routing
 
-(defn route-comment
+;; Routing
+(defn ^{:stratum 2} route-comment
   "Route a classified comment to the appropriate handler, recording the typed
    classify→act decision first so the choice is one explicit act with provenance
    rather than an inference from which handler ran."
@@ -231,4 +230,3 @@
       :approval (handle-approval monitor pr-info classified)
       :noise {:success? true :type :noise-skipped}
       {:success? true :type :unknown-skipped :category category})))
-

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_state.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_state.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.monitor-state
   "Shared monitor loop state and persistence helpers."
   (:require
@@ -26,13 +25,44 @@
    [ai.miniforge.pr-lifecycle.pr-poller :as poller]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Configuration + state
 
-(def default-config
+;; Configuration + state
+(def ^{:stratum 0} default-config
   "Default PR monitor loop configuration loaded from shared EDN."
   (config/monitor-defaults))
 
-(defn create-monitor
+(defn ^{:stratum 0} emit!
+  "Publish an event to the configured event bus when present."
+  [monitor event]
+  (let [{:keys [event-bus logger]} (:config @monitor)]
+    (when event-bus
+      (events/publish! event-bus event logger))))
+
+(defn ^{:stratum 0} load-budget-from-disk!
+  "Load a persisted budget into monitor state when it exists."
+  [monitor pr-number]
+  (when-let [persisted (budget/load-budget pr-number)]
+    (swap! monitor assoc-in [:budgets pr-number] persisted)
+    persisted))
+
+(defn ^{:stratum 0} update-budget!
+  "Persist the latest budget state for a PR."
+  [monitor pr-number budget-state]
+  (swap! monitor assoc-in [:budgets pr-number] budget-state)
+  (budget/save-budget! budget-state))
+
+(defn ^{:stratum 0} log-loop-start!
+  "Log loop startup when a logger is present."
+  [monitor author]
+  (let [{:keys [poll-interval-ms logger]} (:config @monitor)]
+    (when logger
+      (log/info logger :pr-monitor :loop/started
+                {:message (str "PR monitor loop started for author: " author)
+                 :data {:poll-interval-ms poll-interval-ms}}))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} create-monitor
   "Create a PR monitor loop state atom from config."
   [config]
   (let [merged (merge default-config config)]
@@ -48,19 +78,7 @@
                       :fixes-pushed []
                       :questions-answered []}})))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Shared helpers
-
-(declare load-budget-from-disk!)
-
-(defn emit!
-  "Publish an event to the configured event bus when present."
-  [monitor event]
-  (let [{:keys [event-bus logger]} (:config @monitor)]
-    (when event-bus
-      (events/publish! event-bus event logger))))
-
-(defn get-or-create-budget
+(defn ^{:stratum 1} get-or-create-budget
   "Get an existing budget for a PR, loading from disk when available."
   [monitor pr-number]
   (or (get-in @monitor [:budgets pr-number])
@@ -74,25 +92,3 @@
                                    :abandon-after-hours]))]
         (swap! monitor assoc-in [:budgets pr-number] created)
         created)))
-
-(defn load-budget-from-disk!
-  "Load a persisted budget into monitor state when it exists."
-  [monitor pr-number]
-  (when-let [persisted (budget/load-budget pr-number)]
-    (swap! monitor assoc-in [:budgets pr-number] persisted)
-    persisted))
-
-(defn update-budget!
-  "Persist the latest budget state for a PR."
-  [monitor pr-number budget-state]
-  (swap! monitor assoc-in [:budgets pr-number] budget-state)
-  (budget/save-budget! budget-state))
-
-(defn log-loop-start!
-  "Log loop startup when a logger is present."
-  [monitor author]
-  (let [{:keys [poll-interval-ms logger]} (:config @monitor)]
-    (when logger
-      (log/info logger :pr-monitor :loop/started
-                {:message (str "PR monitor loop started for author: " author)
-                 :data {:poll-interval-ms poll-interval-ms}}))))

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_worklist.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_worklist.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.monitor-worklist
   "Persisted PR monitor work-list — schema, path helpers, and disk I/O.
 
@@ -57,44 +56,44 @@
    [java.security MessageDigest]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Named constants and Malli schema
 
-(def ^:private t
+;; Named constants and Malli schema
+(def ^{:stratum 0} ^:private t
   "Component-scoped message translator. All emitted strings go through this."
   (msg/create-translator "config/pr-lifecycle/messages/system.edn"
                          :pr-lifecycle/system))
 
-(def ^:private pr-monitor-dir-name
+(def ^{:stratum 0} ^:private pr-monitor-dir-name
   "Subdirectory name under home-dir for all work-list files."
   "pr-monitor")
 
-(def ^:private worklist-file-extension
+(def ^{:stratum 0} ^:private worklist-file-extension
   "File extension for persisted work-list EDN files."
   ".edn")
 
-(def ^:private sha-algorithm
+(def ^{:stratum 0} ^:private sha-algorithm
   "Hash algorithm for repo-key derivation."
   "SHA-256")
 
-(def ^:private repo-key-prefix-length
+(def ^{:stratum 0} ^:private repo-key-prefix-length
   "Number of hex characters taken from the SHA-256 digest as the repo-key."
   12)
 
-(def ^:private unsigned-byte-mask
+(def ^{:stratum 0} ^:private unsigned-byte-mask
   "Mask for converting a signed Java byte to unsigned (0–255) for hex formatting."
   0xff)
 
-(def ^:private open-pr-state
+(def ^{:stratum 0} ^:private open-pr-state
   "GitHub PR state string indicating the PR is still open."
   "OPEN")
 
-(def ^:private gh-state-pattern
+(def ^{:stratum 0} ^:private gh-state-pattern
   "Regex to extract the state field from `gh pr view --json state` output.
    Tolerates optional whitespace around the colon — `gh`'s JSON is compact
    today, but a pretty-printed `\"state\": \"OPEN\"` must still match."
   #"\"state\"\s*:\s*\"([^\"]+)\"")
 
-(def WorklistPrEntry
+(def ^{:stratum 0} WorklistPrEntry
   "Malli schema for a single PR entry inside a WorklistEntry.
 
    Operational parameters (:pr/poll-interval, :pr/abandon-after-hours)
@@ -108,7 +107,9 @@
    [:pr/poll-interval {:optional true} :int]
    [:pr/abandon-after-hours {:optional true} :int]])
 
-(def WorklistEntry
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} WorklistEntry
   "Malli schema for the persisted work-list EDN file.
 
    - :worklist/repo-key   — 12-hex-char prefix of SHA-256(remote-origin-url)
@@ -119,27 +120,15 @@
    [:worklist/prs [:vector WorklistPrEntry]]
    [:worklist/updated-at inst?]])
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Pure helpers
-
-(defn- sha256-hex
+(defn- ^{:stratum 1} sha256-hex
   "Return the full lowercase hex SHA-256 digest of `s`."
   [s]
   (let [md    (MessageDigest/getInstance sha-algorithm)
         bytes (.digest md (.getBytes ^String s StandardCharsets/UTF_8))]
     (apply str (map #(format "%02x" (bit-and % unsigned-byte-mask)) bytes))))
 
-(defn repo-key
-  "Derive a stable, filesystem-safe key from `remote-url` (typically the
-   value of `git remote get-url origin`).
-
-   Returns the first `repo-key-prefix-length` characters of the lowercase
-   hex SHA-256 digest — long enough to be collision-resistant across the
-   repos a single monitor instance will track."
-  [remote-url]
-  (subs (sha256-hex remote-url) 0 repo-key-prefix-length))
-
-(defn worklist-path
+(defn ^{:stratum 1} worklist-path
   "Compute the absolute path for the work-list EDN file.
 
    - `home-dir` — miniforge home directory (from app-config/home-dir)
@@ -149,74 +138,7 @@
   [home-dir rkey]
   (str (fs/path home-dir pr-monitor-dir-name (str rkey worklist-file-extension))))
 
-(defn- validate-entry
-  "Return `entry` when it satisfies WorklistEntry, or an :invalid-input anomaly.
-   Pure — no I/O."
-  [entry]
-  (if (m/validate WorklistEntry entry)
-    entry
-    (anomaly/validation-anomaly
-     (t :worklist/validation-failed)
-     :WorklistEntry
-     entry
-     (me/humanize (m/explain WorklistEntry entry)))))
-
-;------------------------------------------------------------------------------ Layer 2
-;; Disk I/O and GitHub shell calls
-
-(defn persist-worklist!
-  "Validate `entry` against WorklistEntry and write it as EDN to `path`.
-   Creates parent directories as needed.
-
-   Returns:
-   - `(schema/success :worklist entry)` on success.
-   - `(schema/failure :worklist <msg>)` on validation or I/O failure.
-   Dynamic context (path, errors) in the :error value, not the message key."
-  [path entry]
-  (let [validated (validate-entry entry)]
-    (if (anomaly/anomaly? validated)
-      (schema/failure :worklist
-                      {:message (t :worklist/invalid-entry)
-                       :errors  (get-in validated [:anomaly/data :errors])})
-      (try+
-       (fs/create-dirs (fs/parent path))
-       (spit path (pr-str entry))
-       (schema/success :worklist entry)
-       (catch Object ex
-         (schema/failure :worklist
-                         {:message (t :worklist/write-failed)
-                          :path    path
-                          :cause   (ex-message ex)}))))))
-
-(defn load-worklist
-  "Read and validate a WorklistEntry EDN from `path`.
-
-   Returns:
-   - `(schema/success :worklist entry)` on success.
-   - `(schema/failure :worklist <msg>)` when path is missing, unreadable,
-     or content does not satisfy WorklistEntry."
-  [path]
-  (cond
-    (not (fs/exists? path))
-    (schema/failure :worklist {:message (t :worklist/not-found) :path path})
-
-    :else
-    (try+
-     (let [entry     (edn/read-string (slurp path))
-           validated (validate-entry entry)]
-       (if (anomaly/anomaly? validated)
-         (schema/failure :worklist
-                         {:message (t :worklist/corrupt)
-                          :path    path
-                          :errors  (get-in validated [:anomaly/data :errors])})
-         (schema/success :worklist entry)))
-     (catch Object ex
-       (schema/failure :worklist
-                       {:message (t :worklist/read-failed)
-                        :path    path
-                        :cause   (ex-message ex)})))))
-
-(defn- fetch-pr-state
+(defn- ^{:stratum 1} fetch-pr-state
   "Shell `gh pr view <number> --repo <repo> --json state` and return the
    state string (\"OPEN\", \"MERGED\", \"CLOSED\"), or an anomaly on
    process failure or missing output field."
@@ -241,7 +163,31 @@
                       {:pr/number number :pr/repo repo
                        :cause (ex-message ex)}))))
 
-(defn prune-closed-prs
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} repo-key
+  "Derive a stable, filesystem-safe key from `remote-url` (typically the
+   value of `git remote get-url origin`).
+
+   Returns the first `repo-key-prefix-length` characters of the lowercase
+   hex SHA-256 digest — long enough to be collision-resistant across the
+   repos a single monitor instance will track."
+  [remote-url]
+  (subs (sha256-hex remote-url) 0 repo-key-prefix-length))
+
+(defn- ^{:stratum 2} validate-entry
+  "Return `entry` when it satisfies WorklistEntry, or an :invalid-input anomaly.
+   Pure — no I/O."
+  [entry]
+  (if (m/validate WorklistEntry entry)
+    entry
+    (anomaly/validation-anomaly
+     (t :worklist/validation-failed)
+     :WorklistEntry
+     entry
+     (me/humanize (m/explain WorklistEntry entry)))))
+
+(defn ^{:stratum 2} prune-closed-prs
   "Remove merged or closed PR entries from `entry` by querying GitHub.
 
    For each PR in `:worklist/prs`, shells `gh pr view <number> --repo
@@ -274,6 +220,61 @@
                    (if (= state open-pr-state)
                      (conj kept pr-entry)
                      kept))))))))
+
+;------------------------------------------------------------------------------ Layer 3
+
+;; Disk I/O and GitHub shell calls
+(defn ^{:stratum 3} persist-worklist!
+  "Validate `entry` against WorklistEntry and write it as EDN to `path`.
+   Creates parent directories as needed.
+
+   Returns:
+   - `(schema/success :worklist entry)` on success.
+   - `(schema/failure :worklist <msg>)` on validation or I/O failure.
+   Dynamic context (path, errors) in the :error value, not the message key."
+  [path entry]
+  (let [validated (validate-entry entry)]
+    (if (anomaly/anomaly? validated)
+      (schema/failure :worklist
+                      {:message (t :worklist/invalid-entry)
+                       :errors  (get-in validated [:anomaly/data :errors])})
+      (try+
+       (fs/create-dirs (fs/parent path))
+       (spit path (pr-str entry))
+       (schema/success :worklist entry)
+       (catch Object ex
+         (schema/failure :worklist
+                         {:message (t :worklist/write-failed)
+                          :path    path
+                          :cause   (ex-message ex)}))))))
+
+(defn ^{:stratum 3} load-worklist
+  "Read and validate a WorklistEntry EDN from `path`.
+
+   Returns:
+   - `(schema/success :worklist entry)` on success.
+   - `(schema/failure :worklist <msg>)` when path is missing, unreadable,
+     or content does not satisfy WorklistEntry."
+  [path]
+  (cond
+    (not (fs/exists? path))
+    (schema/failure :worklist {:message (t :worklist/not-found) :path path})
+
+    :else
+    (try+
+     (let [entry     (edn/read-string (slurp path))
+           validated (validate-entry entry)]
+       (if (anomaly/anomaly? validated)
+         (schema/failure :worklist
+                         {:message (t :worklist/corrupt)
+                          :path    path
+                          :errors  (get-in validated [:anomaly/data :errors])})
+         (schema/success :worklist entry)))
+     (catch Object ex
+       (schema/failure :worklist
+                       {:message (t :worklist/read-failed)
+                        :path    path
+                        :cause   (ex-message ex)})))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/policy_eval/fs.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/policy_eval/fs.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.policy-eval.fs
   "N13 §2.5 Comment Response Agent — Layer 2: File I/O.
 
@@ -34,9 +33,10 @@
    [clojure.java.io :as io]
    [clojure.string :as str]))
 
-;; ── path safety ──────────────────────────────────────────────────────
+;------------------------------------------------------------------------------ Layer 0
 
-(defn- safe-worktree-path
+;; ── path safety ──────────────────────────────────────────────────────
+(defn- ^{:stratum 0} safe-worktree-path
   "Resolve `relative-path` under `worktree-root`. Returns the
    canonical absolute path string when the target stays inside the
    worktree root, or returns nil when `relative-path` escapes
@@ -76,8 +76,7 @@
     (catch SecurityException _ nil)))
 
 ;; ── content read/write (trailing-newline preserving) ─────────────────
-
-(defn- read-content
+(defn- ^{:stratum 0} read-content
   "Slurp `path` and return `{:lines <vec> :trailing-newline? <bool>}`.
    Preserves trailing-newline info so round-trips don't drop the final `\\n`
    or silently normalize CRLF."
@@ -87,12 +86,23 @@
         lines    (vec (str/split-lines content))]
     {:lines lines :trailing-newline? trailing}))
 
-(defn- write-content!
+(defn- ^{:stratum 0} write-content!
   "Join `lines` with `\\n`, append trailing `\\n` when `trailing-newline?`
    is true, and write to `path`."
   [path lines trailing-newline?]
   (spit path (cond-> (str/join "\n" lines)
                trailing-newline? (str "\n"))))
+
+(defn- ^{:stratum 0} guard-file-exists
+  "Step 2: require the resolved file to actually exist."
+  [{:keys [abs relative-path] :as ctx}]
+  (if (fs/exists? abs)
+    (dag/ok ctx)
+    (dag/err :policy-eval/file-not-found
+             (str "file " abs " not present in worktree")
+             {:path relative-path})))
+
+;------------------------------------------------------------------------------ Layer 1
 
 ;; ── pipeline guards ──────────────────────────────────────────────────
 ;;
@@ -100,8 +110,7 @@
 ;; `(dag/ok new-ctx)` enriching the context, or `(dag/err ...)` with the
 ;; typed failure code for this step. The public entry chains them via
 ;; `dag/when-let-ok` — see the railway-binding rule (dewey 211).
-
-(defn- guard-path
+(defn- ^{:stratum 1} guard-path
   "Step 1: resolve `relative-path` under `worktree-path`. Bails out
    with `:policy-eval/path-traversal` on absolute paths, ..-segments,
    or canonicalization escapes."
@@ -112,16 +121,7 @@
              (str "relative-path escapes worktree root: " relative-path)
              {:path relative-path :worktree-path (str worktree-path)})))
 
-(defn- guard-file-exists
-  "Step 2: require the resolved file to actually exist."
-  [{:keys [abs relative-path] :as ctx}]
-  (if (fs/exists? abs)
-    (dag/ok ctx)
-    (dag/err :policy-eval/file-not-found
-             (str "file " abs " not present in worktree")
-             {:path relative-path})))
-
-(defn- guard-line-in-range
+(defn- ^{:stratum 1} guard-line-in-range
   "Step 3: read the file content, verify `line-number` is within
    bounds, and enrich the ctx with the file's lines + the current
    line content for the writer step."
@@ -140,7 +140,7 @@
                      :line              line-number
                      :before            (nth lines idx))))))
 
-(defn- write-or-skip!
+(defn- ^{:stratum 1} write-or-skip!
   "Step 4: idempotency guard + write. When `before == replacement`,
    skip the write and return `:already-applied` so the caller can
    exclude the no-op from the commit path. Otherwise rewrite the
@@ -159,9 +159,10 @@
                :before before
                :after  replacement}))))
 
-;; ── public entry ─────────────────────────────────────────────────────
+;------------------------------------------------------------------------------ Layer 2
 
-(defn apply-single-line-replacement!
+;; ── public entry ─────────────────────────────────────────────────────
+(defn ^{:stratum 2} apply-single-line-replacement!
   "Replace line `line-number` (1-indexed, matching GitHub comment
    line semantics) in `worktree-path/relative-path` with
    `replacement`. Returns DAG result with `{:path :line :before :after}`
@@ -187,7 +188,9 @@
                (str "failed to apply fix to " relative-path ": " (.getMessage e))
                {:path relative-path :line line-number}))))
 
-(defn materialize-fix!
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} materialize-fix!
   "Apply one planned `:to-apply` entry's suggested-fix to disk.
    Returns the DAG result from `apply-single-line-replacement!`
    decorated with the originating comment-id for traceability."

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/policy_eval/git.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/policy_eval/git.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.policy-eval.git
   "N13 §2.5 Comment Response Agent — Layer 3a: git commit + push.
 
@@ -28,7 +27,9 @@
    [babashka.process :as process]
    [clojure.string :as str]))
 
-(defn- git-sh
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} git-sh
   "Run `git -C worktree-path <args>`. Returns DAG result."
   [worktree-path & args]
   (try
@@ -44,18 +45,7 @@
     (catch Throwable e
       (dag/err :policy-eval/git-failed (.getMessage e) {:args (vec args)}))))
 
-(defn- stage-paths!
-  "git add each unique path in `applied-fixes`."
-  [worktree-path applied-fixes]
-  (let [paths (distinct (map :path applied-fixes))]
-    (reduce
-     (fn [acc path]
-       (let [r (git-sh worktree-path "add" "--" path)]
-         (if (dag/ok? r) acc (reduced r))))
-     (dag/ok {:staged-count (count paths)})
-     paths)))
-
-(defn- commit-message
+(defn- ^{:stratum 0} commit-message
   "Build a commit message summarizing the applied fixes."
   [applied-fixes]
   (let [n (count applied-fixes)]
@@ -68,7 +58,22 @@
          "\n\n"
          "Applied by miniforge pr-lifecycle/policy-eval-responder per N13 §2.5.")))
 
-(defn commit-and-push!
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} stage-paths!
+  "git add each unique path in `applied-fixes`."
+  [worktree-path applied-fixes]
+  (let [paths (distinct (map :path applied-fixes))]
+    (reduce
+     (fn [acc path]
+       (let [r (git-sh worktree-path "add" "--" path)]
+         (if (dag/ok? r) acc (reduced r))))
+     (dag/ok {:staged-count (count paths)})
+     paths)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} commit-and-push!
   "Stage all touched files, commit, push. Returns DAG result with
    `{:commit-sha :pushed?}` on success.
 

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/policy_eval/payload.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/policy_eval/payload.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.policy-eval.payload
   "N13 §2.5 Comment Response Agent — Layer 0: Foundations.
 
@@ -34,21 +33,25 @@
   (:require
    [ai.miniforge.compliance-scanner.interface :as scanner]))
 
-(def policy-eval-author
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} policy-eval-author
   "GitHub login the renderer posts under (per
    `compliance-scanner.comments/violation->comment`)."
   "miniforge-policy-evaluator[bot]")
 
-(defn policy-eval-comment?
-  "True when `comment` was posted by the N13 Standards Reviewer
-   (matched by author login). Comments from other bots / humans are
-   handled by the general LLM responder, not by this module."
-  [comment]
-  (= policy-eval-author (:comment/author comment)))
-
-(defn extract-policy-payload
+(defn ^{:stratum 0} extract-policy-payload
   "Return the embedded `:comment/payload` map from `comment`'s body,
    or nil. Delegates to `compliance-scanner.interface/extract-comment-payload`
    so the round-trip is the inverse of the renderer."
   [comment]
   (scanner/extract-comment-payload (:comment/body comment)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} policy-eval-comment?
+  "True when `comment` was posted by the N13 Standards Reviewer
+   (matched by author login). Comments from other bots / humans are
+   handled by the general LLM responder, not by this module."
+  [comment]
+  (= policy-eval-author (:comment/author comment)))

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/policy_eval/plan.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/policy_eval/plan.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.policy-eval.plan
   "N13 §2.5 Comment Response Agent — Layer 1: Domain (pure planning).
 
@@ -29,7 +28,9 @@
    [ai.miniforge.pr-lifecycle.policy-eval.payload :as payload]
    [clojure.string :as str]))
 
-(defn- multi-line?
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} multi-line?
   "True when the suggested-fix spans more than one line. v0 skips
    these because applying a multi-line replacement requires knowing
    the original span, which the comment doesn't carry directly."
@@ -37,7 +38,7 @@
   (and (string? suggested-fix)
        (str/includes? suggested-fix "\n")))
 
-(defn- plan-decision
+(defn- ^{:stratum 0} plan-decision
   "Factory: build a `classify-fix` result map. Single source of
    truth for the `{:action :reason :payload}` shape — avoids hand-
    constructing the same map at every cond branch in `classify-fix`."
@@ -46,7 +47,9 @@
    :reason  reason
    :payload payload})
 
-(defn classify-fix
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} classify-fix
   "Pure: decide what to do with a single policy-eval comment.
    Returns `{:action :apply | :escalate | :skip
              :reason  <keyword>
@@ -69,7 +72,9 @@
       :else
       (plan-decision :apply :ok p))))
 
-(defn plan-fixes
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} plan-fixes
   "Pure: walk a vector of comments, classify each, and partition into
    `{:to-apply [...] :to-escalate [...] :to-skip [...]}`. Each entry
    carries the original comment + its classification."

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/policy_eval/reply.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/policy_eval/reply.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.policy-eval.reply
   "N13 §2.5 Comment Response Agent — Layer 3b: reply + resolve.
 
@@ -28,11 +27,15 @@
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.pr-lifecycle.github :as github]))
 
-(defn- short-sha
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} short-sha
   [sha]
   (subs sha 0 (min 10 (count sha))))
 
-(defn- fix-reply-message
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} fix-reply-message
   [commit-sha fix]
   (str "Auto-applied in `" (short-sha commit-sha) "`:\n\n"
        "```diff\n"
@@ -41,7 +44,9 @@
        "```\n\n"
        "<sub>Posted by `policy-eval-responder` per N13 §2.5</sub>"))
 
-(defn reply-and-resolve-one!
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} reply-and-resolve-one!
   "Post the reply on `comment-id`, look up the thread id, resolve it.
    Returns DAG result with `{:reply-posted :resolved :thread-id?}`.
    Resolution is best-effort — if the thread lookup or resolve call
@@ -62,7 +67,9 @@
                      :thread-id tid
                      :reply-url (-> reply-r :data :url)})))))))
 
-(defn reply-and-resolve-fixed!
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} reply-and-resolve-fixed!
   "For each applied fix, post a reply on its comment thread + resolve.
    Returns a vector of per-fix DAG results."
   [worktree-path pr-number commit-sha applied-fixes]

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/policy_eval_responder.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/policy_eval_responder.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.policy-eval-responder
   "N13 §2.5 Comment Response Agent — orchestrator.
 
@@ -58,27 +57,32 @@
    [ai.miniforge.pr-lifecycle.policy-eval.plan :as plan]
    [ai.miniforge.pr-lifecycle.policy-eval.reply :as reply]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; ── re-exports ───────────────────────────────────────────────────────
 ;;
 ;; The public surface of the responder is what `pr-lifecycle/interface`
 ;; (and the test suite) reaches for. Keeping the names accessible at
 ;; the umbrella namespace lets callers stay decoupled from the internal
 ;; decomposition — they touch one ns, not five.
+(def ^{:stratum 0} policy-eval-author      payload/policy-eval-author)
 
-(def policy-eval-author      payload/policy-eval-author)
-(def policy-eval-comment?    payload/policy-eval-comment?)
-(def classify-fix            plan/classify-fix)
-(def plan-fixes              plan/plan-fixes)
-(def apply-single-line-replacement! fs/apply-single-line-replacement!)
-(def materialize-fix!        fs/materialize-fix!)
+(def ^{:stratum 0} policy-eval-comment?    payload/policy-eval-comment?)
+
+(def ^{:stratum 0} classify-fix            plan/classify-fix)
+
+(def ^{:stratum 0} plan-fixes              plan/plan-fixes)
+
+(def ^{:stratum 0} apply-single-line-replacement! fs/apply-single-line-replacement!)
+
+(def ^{:stratum 0} materialize-fix!        fs/materialize-fix!)
 
 ;; ── orchestrator ─────────────────────────────────────────────────────
 ;;
 ;; The whole point of decomposition is here: a top-to-bottom pipeline
 ;; with each strata's work landing in its own ns, and the orchestrator
 ;; doing only the assembly. No nested cond, no inline business rules.
-
-(defn- bucket-results
+(defn- ^{:stratum 0} bucket-results
   "Pure: partition `materialize-fix!` results into the three buckets
    the summary needs. `:already-applied` no-ops must NOT enter the
    commit path — they're returned in their own bucket so the caller
@@ -92,7 +96,7 @@
      :already-applied (mapv :data noop-ok)
      :failed-to-apply (mapv :error (filter (complement dag/ok?) results))}))
 
-(defn- summary
+(defn- ^{:stratum 0} summary
   "Build the DAG-ok summary map. `git-data` is nil when no commit
    was attempted (zero applied fixes); otherwise it carries
    `{:commit-sha :pushed?}`."
@@ -106,7 +110,9 @@
            :pushed?         (boolean (:pushed? git-data))
            :replies         (or replies [])}))
 
-(defn respond-to-policy-comments!
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} respond-to-policy-comments!
   "Top-level entry point. See namespace docstring for pipeline
    contract and bucket semantics.
 

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/pr_poller.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/pr_poller.clj
@@ -11,7 +11,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.pr-poller
   "GitHub PR polling adapter with watermark persistence.
 
@@ -33,17 +32,14 @@
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Schemas + watermark persistence
 
-(def WatermarkEntry
+;; Schemas + watermark persistence
+(def ^{:stratum 0} WatermarkEntry
   [:map
    [:last-seen-at :string]
    [:advanced-at :string]])
 
-(def Watermarks
-  [:map-of int? WatermarkEntry])
-
-(def PrInfo
+(def ^{:stratum 0} PrInfo
   [:map
    [:pr/number int?]
    [:pr/url :string]
@@ -52,7 +48,7 @@
    [:pr/sha :string]
    [:pr/updated-at :string]])
 
-(def PrComment
+(def ^{:stratum 0} PrComment
   [:map
    [:comment/id int?]
    [:comment/body {:optional true} [:maybe :string]]
@@ -62,59 +58,16 @@
    [:comment/path {:optional true} [:maybe :string]]
    [:comment/line {:optional true} [:maybe int?]]])
 
-(defn- validate!
+(defn- ^{:stratum 0} validate!
   [result-schema value]
   (schema/validate result-schema value))
 
-(def ^:private state-dir
+(def ^{:stratum 0} ^:private state-dir
   "Base directory for PR monitor state."
   (str (mf-config/miniforge-home) "/state/pr-monitor"))
 
-(defn- ensure-state-dir!
-  "Ensure the state directory exists."
-  []
-  (let [dir (io/file state-dir)]
-    (when-not (.exists dir)
-      (.mkdirs dir))))
-
-(defn load-watermarks
-  "Load watermarks from persistent storage.
-
-   Returns map of PR number → {:last-seen-at string :advanced-at string}.
-   Safe to call on restart — returns empty map when no state exists."
-  []
-  (let [f (io/file state-dir "watermarks.edn")]
-    (if (.exists f)
-      (try
-        (->> f
-             slurp
-             edn/read-string
-             (validate! Watermarks))
-        (catch Exception _e {}))
-      {})))
-
-(defn save-watermarks!
-  "Persist watermarks to disk. Idempotent and safe to call every cycle."
-  [watermarks]
-  (ensure-state-dir!)
-  (spit (io/file state-dir "watermarks.edn")
-        (pr-str watermarks)))
-
-(defn advance-watermark
-  "Advance the watermark for a PR to the given timestamp.
-
-   Returns updated watermarks map (pure — call save-watermarks! to persist)."
-  [watermarks pr-number timestamp]
-  (validate!
-   Watermarks
-   (assoc watermarks pr-number
-          {:last-seen-at timestamp
-           :advanced-at (str (java.util.Date.))})))
-
-;------------------------------------------------------------------------------ Layer 0
 ;; GitHub CLI helpers
-
-(defn- run-gh
+(defn- ^{:stratum 0} run-gh
   "Run a gh CLI command and return DAG result.
 
    Arguments:
@@ -137,10 +90,36 @@
     (catch Exception e
       (dag/err :gh-exception (.getMessage e)))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; PR listing
+(defn ^{:stratum 0} comments-since
+  "Filter comments to only those created after a watermark timestamp.
 
-(defn- normalize-pr
+   Arguments:
+   - comments: Vector of comment maps with :comment/created-at
+   - since: Timestamp string (ISO 8601) or nil for all comments
+
+   Returns filtered comments sorted by creation time."
+  [comments since]
+  (if-not since
+    (vec (sort-by :comment/created-at comments))
+    (->> comments
+         (filter #(pos? (compare (str (:comment/created-at %)) (str since))))
+         (sort-by :comment/created-at)
+         vec)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} Watermarks
+  [:map-of int? WatermarkEntry])
+
+(defn- ^{:stratum 1} ensure-state-dir!
+  "Ensure the state directory exists."
+  []
+  (let [dir (io/file state-dir)]
+    (when-not (.exists dir)
+      (.mkdirs dir))))
+
+;; PR listing
+(defn- ^{:stratum 1} normalize-pr
   [pr]
   (validate!
    PrInfo
@@ -151,7 +130,94 @@
     :pr/sha (:headRefOid pr)
     :pr/updated-at (:updatedAt pr)}))
 
-(defn poll-open-prs
+(defn ^{:stratum 1} current-github-login
+  "Resolve the authenticated GitHub login via `gh api user --jq .login`.
+
+   Used as the default `:self-author` for PR monitoring so the monitor loop
+   can find PRs this instance authored when no self-author is configured.
+   Returns the login string, or nil when gh is unauthenticated/unavailable."
+  [worktree-path]
+  (let [result (run-gh ["gh" "api" "user" "--jq" ".login"] worktree-path)]
+    (when (dag/ok? result)
+      (let [login (str/trim (:output (:data result) ""))]
+        (when (seq login) login)))))
+
+;; Comment fetching
+(defn- ^{:stratum 1} normalize-comment
+  [comment comment-type]
+  (validate!
+   PrComment
+   (cond-> {:comment/id (:id comment)
+            :comment/body (:body comment)
+            :comment/author (get-in comment [:user :login])
+            :comment/created-at (:created_at comment)
+            :comment/type comment-type}
+     (:path comment)
+     (assoc :comment/path (:path comment))
+
+     (:original_line comment)
+     (assoc :comment/line (:original_line comment))
+
+     (:line comment)
+     (assoc :comment/line (:line comment)))))
+
+;; Comment posting
+(defn ^{:stratum 1} post-comment
+  "Post an issue comment on a PR.
+
+   Arguments:
+   - worktree-path: Path to git repo
+   - pr-number: PR number
+   - body: Comment body text
+
+   Returns DAG result with :comment-posted true on success."
+  [worktree-path pr-number body]
+  (let [result (run-gh
+                ["gh" "pr" "comment" (str pr-number)
+                 "--body" body]
+                worktree-path)]
+    (if (dag/ok? result)
+      (dag/ok {:comment-posted true
+               :pr-number pr-number})
+      result)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} load-watermarks
+  "Load watermarks from persistent storage.
+
+   Returns map of PR number → {:last-seen-at string :advanced-at string}.
+   Safe to call on restart — returns empty map when no state exists."
+  []
+  (let [f (io/file state-dir "watermarks.edn")]
+    (if (.exists f)
+      (try
+        (->> f
+             slurp
+             edn/read-string
+             (validate! Watermarks))
+        (catch Exception _e {}))
+      {})))
+
+(defn ^{:stratum 2} save-watermarks!
+  "Persist watermarks to disk. Idempotent and safe to call every cycle."
+  [watermarks]
+  (ensure-state-dir!)
+  (spit (io/file state-dir "watermarks.edn")
+        (pr-str watermarks)))
+
+(defn ^{:stratum 2} advance-watermark
+  "Advance the watermark for a PR to the given timestamp.
+
+   Returns updated watermarks map (pure — call save-watermarks! to persist)."
+  [watermarks pr-number timestamp]
+  (validate!
+   Watermarks
+   (assoc watermarks pr-number
+          {:last-seen-at timestamp
+           :advanced-at (str (java.util.Date.))})))
+
+(defn ^{:stratum 2} poll-open-prs
   "Poll GitHub for open PRs authored by a given login.
 
    Arguments:
@@ -180,40 +246,7 @@
           (dag/err :json-parse-error (.getMessage e))))
       result)))
 
-(defn current-github-login
-  "Resolve the authenticated GitHub login via `gh api user --jq .login`.
-
-   Used as the default `:self-author` for PR monitoring so the monitor loop
-   can find PRs this instance authored when no self-author is configured.
-   Returns the login string, or nil when gh is unauthenticated/unavailable."
-  [worktree-path]
-  (let [result (run-gh ["gh" "api" "user" "--jq" ".login"] worktree-path)]
-    (when (dag/ok? result)
-      (let [login (str/trim (:output (:data result) ""))]
-        (when (seq login) login)))))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Comment fetching
-
-(defn- normalize-comment
-  [comment comment-type]
-  (validate!
-   PrComment
-   (cond-> {:comment/id (:id comment)
-            :comment/body (:body comment)
-            :comment/author (get-in comment [:user :login])
-            :comment/created-at (:created_at comment)
-            :comment/type comment-type}
-     (:path comment)
-     (assoc :comment/path (:path comment))
-
-     (:original_line comment)
-     (assoc :comment/line (:original_line comment))
-
-     (:line comment)
-     (assoc :comment/line (:line comment)))))
-
-(defn- parse-gh-comments
+(defn- ^{:stratum 2} parse-gh-comments
   "Parse JSON output from gh api into normalized comment maps."
   [raw comment-type]
   (when-not (str/blank? raw)
@@ -222,7 +255,9 @@
         (into [] (map #(normalize-comment % comment-type)) parsed))
       (catch Exception _e []))))
 
-(defn fetch-pr-comments
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} fetch-pr-comments
   "Fetch all comments for a PR via GitHub REST API.
 
    Fetches both review comments (inline code comments) and issue comments
@@ -268,48 +303,10 @@
                                (or issue-comments []))]
         (dag/ok {:comments all-comments})))))
 
-(defn comments-since
-  "Filter comments to only those created after a watermark timestamp.
+;------------------------------------------------------------------------------ Layer 4
 
-   Arguments:
-   - comments: Vector of comment maps with :comment/created-at
-   - since: Timestamp string (ISO 8601) or nil for all comments
-
-   Returns filtered comments sorted by creation time."
-  [comments since]
-  (if-not since
-    (vec (sort-by :comment/created-at comments))
-    (->> comments
-         (filter #(pos? (compare (str (:comment/created-at %)) (str since))))
-         (sort-by :comment/created-at)
-         vec)))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Comment posting
-
-(defn post-comment
-  "Post an issue comment on a PR.
-
-   Arguments:
-   - worktree-path: Path to git repo
-   - pr-number: PR number
-   - body: Comment body text
-
-   Returns DAG result with :comment-posted true on success."
-  [worktree-path pr-number body]
-  (let [result (run-gh
-                ["gh" "pr" "comment" (str pr-number)
-                 "--body" body]
-                worktree-path)]
-    (if (dag/ok? result)
-      (dag/ok {:comment-posted true
-               :pr-number pr-number})
-      result)))
-
-;------------------------------------------------------------------------------ Layer 2
 ;; Orchestrated polling
-
-(defn poll-pr-for-new-comments
+(defn ^{:stratum 4} poll-pr-for-new-comments
   "Poll a single PR for new comments since its watermark.
 
    Fetches comments, filters by watermark, advances watermark.

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/responder.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/responder.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.responder
   "Automated PR comment response — fetch review comments, generate fixes,
    push, reply, and resolve conversation threads.
@@ -34,9 +33,9 @@
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; PR URL parsing and comment filtering
 
-(defn parse-pr-url
+;; PR URL parsing and comment filtering
+(defn ^{:stratum 0} parse-pr-url
   "Extract owner, repo, and PR number from a GitHub PR URL.
    Returns {:owner :repo :number} or nil."
   [url]
@@ -45,34 +44,11 @@
      :repo (nth match 2)
      :number (parse-long (nth match 3))}))
 
-(defn parse-pr-url-result
-  "Anomaly-returning version of `parse-pr-url`. Returns the parsed map
-   when `url` is a recognizable GitHub PR URL, or an `:invalid-input`
-   anomaly carrying `:url` in `:anomaly/data`.
-
-   This is the canonical, anomaly-returning entry point. The
-   orchestrator returns the anomaly unchanged so callers can decide
-   how to surface it."
-  [url]
-  (or (parse-pr-url url)
-      (anomaly/anomaly :invalid-input
-                       "Could not parse PR number from URL"
-                       {:url url})))
-
-(def ^:private bot-authors
+(def ^{:stratum 0} ^:private bot-authors
   "Authors to exclude from comment processing."
   #{"github-actions" "github-actions[bot]" "miniforge[bot]"})
 
-(defn filter-actionable-comments
-  "Filter review comments to unresolved, non-bot, code-review comments.
-   Returns vector of normalized comment maps."
-  [comments]
-  (->> comments
-       (remove #(contains? bot-authors (:comment/author %)))
-       (filter #(= :review-comment (:comment/type %)))
-       vec))
-
-(defn group-comments-by-file
+(defn ^{:stratum 0} group-comments-by-file
   "Group comments by their file path for batch processing.
    Returns [{:path :comments :description :comment-ids}]."
   [comments]
@@ -85,38 +61,22 @@
                 :description (str/join "\n\n" (map :comment/body cs))
                 :comment-ids (mapv :comment/id cs)}))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Context gathering
-
-(defn- fetch-pr-diff
+(defn- ^{:stratum 0} fetch-pr-diff
   "Fetch the PR diff once for all comment groups."
   [worktree-path pr-number]
   (let [r (process/sh "gh" "pr" "diff" (str pr-number) :dir worktree-path)]
     (when (zero? (:exit r)) (:out r))))
 
-(defn- read-file-content
+(defn- ^{:stratum 0} read-file-content
   "Read a file's content from the worktree. Returns nil if missing."
   [worktree-path path]
   (try
     (slurp (str worktree-path "/" path))
     (catch Exception _ nil)))
 
-(defn gather-context
-  "Gather PR diff and file contents for all comment groups upfront.
-   Returns {:diff string :files [{:path :content}]}."
-  [worktree-path pr-number groups]
-  (let [diff (fetch-pr-diff worktree-path pr-number)
-        paths (distinct (map :path groups))
-        files (->> paths
-                   (map (fn [p] {:path p :content (read-file-content worktree-path p)}))
-                   (filter :content)
-                   vec)]
-    {:diff diff :files files}))
-
-;------------------------------------------------------------------------------ Layer 2
 ;; Fix spec generation
-
-(defn build-fix-spec
+(defn ^{:stratum 0} build-fix-spec
   "Build a lightweight workflow spec from review comments on a file.
    Uses :comment-fix workflow (implement + gates only) instead of full SDLC.
    Includes pre-gathered file contents so the explore phase is skipped."
@@ -134,10 +94,8 @@
       file-content
       (assoc :task/existing-files [{:path path :content file-content}]))))
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Reply and resolution
-
-(defn reply-and-resolve!
+(defn ^{:stratum 0} reply-and-resolve!
   "Reply to a review comment and resolve its conversation thread.
    Returns {:replied? bool :resolved? bool :error string-or-nil}."
   [worktree-path pr-number comment-id message]
@@ -155,10 +113,8 @@
      :error (when-not replied?
               (get-in reply-result [:error :message] "Reply failed"))}))
 
-;------------------------------------------------------------------------------ Layer 4
 ;; Orchestration primitives
-
-(defn- fix-succeeded?
+(defn- ^{:stratum 0} fix-succeeded?
   "True when a workflow result indicates success or partial success.
    A DAG workflow may fail overall but still produce PRs for completed tasks."
   [result]
@@ -167,25 +123,7 @@
        (or (not= :failed (get result :execution/status))
            (seq (get-in result [:execution/dag-result :pr-infos])))))
 
-(defn- run-fix-for-group
-  "Run a fix workflow for a comment group. Returns result map or {:error msg}."
-  [run-fix-fn group context opts]
-  (let [spec (build-fix-spec group context)]
-    (try
-      (run-fix-fn spec opts)
-      (catch Exception e
-        {:error (.getMessage e)}))))
-
-(defn- reply-to-fixed-comments
-  "Reply and resolve all comments in a group after a successful fix."
-  [worktree-path pr-number comment-ids fix-pr-url]
-  (let [message (if fix-pr-url
-                  (str "Fixed in " fix-pr-url)
-                  "Fixed in latest push. Changes address the review feedback.")]
-    (mapv #(reply-and-resolve! worktree-path pr-number % message)
-          comment-ids)))
-
-(defn- fix-result
+(defn- ^{:stratum 0} fix-result
   "Build a normalized fix result map."
   [path comment-ids succeeded? reply-results error]
   {:path path
@@ -195,7 +133,73 @@
    :resolved? (when reply-results (every? :resolved? reply-results))
    :error error})
 
-(defn- process-comment-group
+(defn- ^{:stratum 0} respond-result
+  "Build the response summary map."
+  [pr-number comments-found files-processed fixes pushed?]
+  {:pr-number pr-number
+   :comments-found comments-found
+   :files-processed files-processed
+   :fixes fixes
+   :pushed? pushed?})
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} parse-pr-url-result
+  "Anomaly-returning version of `parse-pr-url`. Returns the parsed map
+   when `url` is a recognizable GitHub PR URL, or an `:invalid-input`
+   anomaly carrying `:url` in `:anomaly/data`.
+
+   This is the canonical, anomaly-returning entry point. The
+   orchestrator returns the anomaly unchanged so callers can decide
+   how to surface it."
+  [url]
+  (or (parse-pr-url url)
+      (anomaly/anomaly :invalid-input
+                       "Could not parse PR number from URL"
+                       {:url url})))
+
+(defn ^{:stratum 1} filter-actionable-comments
+  "Filter review comments to unresolved, non-bot, code-review comments.
+   Returns vector of normalized comment maps."
+  [comments]
+  (->> comments
+       (remove #(contains? bot-authors (:comment/author %)))
+       (filter #(= :review-comment (:comment/type %)))
+       vec))
+
+(defn ^{:stratum 1} gather-context
+  "Gather PR diff and file contents for all comment groups upfront.
+   Returns {:diff string :files [{:path :content}]}."
+  [worktree-path pr-number groups]
+  (let [diff (fetch-pr-diff worktree-path pr-number)
+        paths (distinct (map :path groups))
+        files (->> paths
+                   (map (fn [p] {:path p :content (read-file-content worktree-path p)}))
+                   (filter :content)
+                   vec)]
+    {:diff diff :files files}))
+
+(defn- ^{:stratum 1} run-fix-for-group
+  "Run a fix workflow for a comment group. Returns result map or {:error msg}."
+  [run-fix-fn group context opts]
+  (let [spec (build-fix-spec group context)]
+    (try
+      (run-fix-fn spec opts)
+      (catch Exception e
+        {:error (.getMessage e)}))))
+
+(defn- ^{:stratum 1} reply-to-fixed-comments
+  "Reply and resolve all comments in a group after a successful fix."
+  [worktree-path pr-number comment-ids fix-pr-url]
+  (let [message (if fix-pr-url
+                  (str "Fixed in " fix-pr-url)
+                  "Fixed in latest push. Changes address the review feedback.")]
+    (mapv #(reply-and-resolve! worktree-path pr-number % message)
+          comment-ids)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- ^{:stratum 2} process-comment-group
   "Fix one file's comments, reply on success. Returns fix result map."
   [worktree-path pr-number run-fix-fn context opts {:keys [path comment-ids] :as group}]
   (let [result (run-fix-for-group run-fix-fn group context opts)
@@ -206,7 +210,7 @@
                   (reply-to-fixed-comments worktree-path pr-number comment-ids fix-pr-url) nil)
       (fix-result path comment-ids false nil (get result :error)))))
 
-(defn fetch-actionable-comments-result
+(defn ^{:stratum 2} fetch-actionable-comments-result
   "Anomaly-returning fetch + filter. Returns
    `{:comments vector :groups vector}` on success, or a `:fault`
    anomaly when the upstream `poller/fetch-pr-comments` errors.
@@ -226,19 +230,10 @@
         {:comments actionable
          :groups (group-comments-by-file actionable)}))))
 
-(defn- respond-result
-  "Build the response summary map."
-  [pr-number comments-found files-processed fixes pushed?]
-  {:pr-number pr-number
-   :comments-found comments-found
-   :files-processed files-processed
-   :fixes fixes
-   :pushed? pushed?})
+;------------------------------------------------------------------------------ Layer 3
 
-;------------------------------------------------------------------------------ Layer 5
 ;; Main entry point
-
-(defn respond-to-comments!
+(defn ^{:stratum 3} respond-to-comments!
   "Fetch review comments, generate fixes in parallel, push, reply, and resolve.
 
    Comment groups (one per file) are processed in parallel via futures.

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/resume_dispatcher.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/resume_dispatcher.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.resume-dispatcher
   "Resume Signal Dispatcher (N13 §2.7 §Dispatch).
 
@@ -51,9 +50,9 @@
    [malli.core :as m]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Configuration + primer schema
 
-(def ^:private config
+;; Configuration + primer schema
+(def ^{:stratum 0} ^:private config
   "Component config loaded from
    `resources/config/resume-dispatcher/defaults.edn`. Tunables for
    webhook retry budget, request timeout, etc., live in EDN so
@@ -62,26 +61,14 @@
       slurp
       edn/read-string))
 
-(def webhook-max-attempts
-  "Number of webhook POST attempts (initial + retries) before giving up."
-  (:webhook/max-attempts config))
-
-(def webhook-timeout-ms
-  "Per-attempt timeout for the webhook POST."
-  (:webhook/timeout-ms config))
-
-(def webhook-backoff-base-ms
-  "Initial backoff (doubled per retry)."
-  (:webhook/backoff-base-ms config))
-
-(def supported-channel-kinds
+(def ^{:stratum 0} supported-channel-kinds
   "Channel kinds with a real handler in v0.
    `:pty` and `:miniforge-ipc` are recognized as valid registry
    values (per listener-registry config) but dispatch is not wired
    yet — they return `:resume-dispatcher/not-yet-wired`."
   #{:webhook})
 
-(def ResumePrimer
+(def ^{:stratum 0} ResumePrimer
   "Resume primer payload delivered to each listener (N13 §2.7)."
   [:map
    [:resume/pr-url       :string]
@@ -92,10 +79,8 @@
                           [:agent/id   :string]
                           [:session/id {:optional true} [:maybe :string]]]]])
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Pure helpers (primer construction + channel classification)
-
-(defn build-primer
+(defn ^{:stratum 0} build-primer
   "Pure: assemble the resume primer per N13 §2.7 from a merged-PR
    record + a single listener entry.
 
@@ -112,38 +97,7 @@
    :resume/listener     (cond-> {:agent/id (:agent/id listener)}
                           (:session/id listener) (assoc :session/id (:session/id listener)))})
 
-(defn validate-primer-result
-  "Validate primer shape. Returns a DAG ok result carrying the primer, or a
-   DAG err result with the same diagnostic payload the legacy throwing wrapper
-   exposes."
-  [primer]
-  (if (m/validate ResumePrimer primer)
-    (dag/ok primer)
-    (dag/err :resume-dispatcher/invalid-primer
-             "invalid resume primer"
-             {:errors (m/explain ResumePrimer primer)
-              :anomaly :resume-dispatcher/invalid-primer
-              :primer primer})))
-
-(defn validate-primer!
-  "Boundary wrapper around the canonical DAG-result-returning
-   `validate-primer-result`. Prefer `validate-primer-result`; this retains
-   the historical ex-info contract for direct callers."
-  [primer]
-  (let [result (validate-primer-result primer)]
-    (if (dag/ok? result)
-      (:data result)
-      (throw (ex-info (get-in result [:error :message])
-                      (get-in result [:error :data]))))))
-
-(defn channel-supported?
-  "Pure predicate: true when the listener's channel kind has a real
-   handler in v0."
-  [listener]
-  (contains? supported-channel-kinds
-             (get-in listener [:resume-channel :channel/kind])))
-
-(defn- not-yet-wired-error
+(defn- ^{:stratum 0} not-yet-wired-error
   "Build the typed error returned for `:pty` / `:miniforge-ipc`
    listeners until the cooperating runtimes ship."
   [listener]
@@ -155,51 +109,7 @@
              {:channel/kind kind
               :listener/id  (:listener/id listener)})))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Channel handlers (per-kind I/O)
-
-(defn- backoff-ms
-  "Pure: exponential backoff for webhook retries — base * 2^attempt."
-  [attempt]
-  (* webhook-backoff-base-ms (long (Math/pow 2 attempt))))
-
-(defn- timeout-seconds
-  "Convert `webhook-timeout-ms` to a curl `--max-time` string with
-   millisecond precision. `curl --max-time` accepts decimals, so we
-   format `<seconds>.<thousandths>` rather than `(quot ms 1000)` —
-   the latter truncates to 0 if operators tune `:webhook/timeout-ms`
-   below 1000ms, and `--max-time 0` disables the timeout entirely
-   (would let the dispatcher hang on a slow/broken endpoint)."
-  []
-  (format "%.3f" (/ (double webhook-timeout-ms) 1000.0)))
-
-(defn- post-webhook-once
-  "Single HTTP POST attempt to the listener's `:channel/target` URL.
-   Returns DAG result. Curl invoked via `babashka.process` to keep
-   this brick BB-compatible without pulling extra HTTP deps."
-  [target-url json-body]
-  (try
-    (let [r (process/shell {:in json-body
-                            :out :string
-                            :err :string
-                            :continue true}
-                           "curl" "--silent" "--show-error" "--fail"
-                           "--max-time" (timeout-seconds)
-                           "-X" "POST"
-                           "-H" "Content-Type: application/json"
-                           "--data-binary" "@-"
-                           target-url)]
-      (if (zero? (:exit r))
-        (dag/ok {:body (str/trim (:out r ""))})
-        (dag/err :resume-dispatcher/webhook-http-failed
-                 (str "curl exit " (:exit r) ": " (str/trim (:err r "")))
-                 {:exit-code (:exit r) :target target-url})))
-    (catch Throwable e
-      (dag/err :resume-dispatcher/webhook-exception
-               (.getMessage e)
-               {:target target-url}))))
-
-(defn sleep!
+(defn ^{:stratum 0} sleep!
   "Synchronous backoff wait between retry attempts. Wraps
    `Thread/sleep` in a redefable var so unit tests can null it out
    without forcing `#'ns/var` quoting on a private.
@@ -229,7 +139,100 @@
   [ms]
   (Thread/sleep (long ms)))
 
-(defn- post-webhook-with-retry
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} webhook-max-attempts
+  "Number of webhook POST attempts (initial + retries) before giving up."
+  (:webhook/max-attempts config))
+
+(def ^{:stratum 1} webhook-timeout-ms
+  "Per-attempt timeout for the webhook POST."
+  (:webhook/timeout-ms config))
+
+(def ^{:stratum 1} webhook-backoff-base-ms
+  "Initial backoff (doubled per retry)."
+  (:webhook/backoff-base-ms config))
+
+(defn ^{:stratum 1} validate-primer-result
+  "Validate primer shape. Returns a DAG ok result carrying the primer, or a
+   DAG err result with the same diagnostic payload the legacy throwing wrapper
+   exposes."
+  [primer]
+  (if (m/validate ResumePrimer primer)
+    (dag/ok primer)
+    (dag/err :resume-dispatcher/invalid-primer
+             "invalid resume primer"
+             {:errors (m/explain ResumePrimer primer)
+              :anomaly :resume-dispatcher/invalid-primer
+              :primer primer})))
+
+(defn ^{:stratum 1} channel-supported?
+  "Pure predicate: true when the listener's channel kind has a real
+   handler in v0."
+  [listener]
+  (contains? supported-channel-kinds
+             (get-in listener [:resume-channel :channel/kind])))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} validate-primer!
+  "Boundary wrapper around the canonical DAG-result-returning
+   `validate-primer-result`. Prefer `validate-primer-result`; this retains
+   the historical ex-info contract for direct callers."
+  [primer]
+  (let [result (validate-primer-result primer)]
+    (if (dag/ok? result)
+      (:data result)
+      (throw (ex-info (get-in result [:error :message])
+                      (get-in result [:error :data]))))))
+
+;; Channel handlers (per-kind I/O)
+(defn- ^{:stratum 2} backoff-ms
+  "Pure: exponential backoff for webhook retries — base * 2^attempt."
+  [attempt]
+  (* webhook-backoff-base-ms (long (Math/pow 2 attempt))))
+
+(defn- ^{:stratum 2} timeout-seconds
+  "Convert `webhook-timeout-ms` to a curl `--max-time` string with
+   millisecond precision. `curl --max-time` accepts decimals, so we
+   format `<seconds>.<thousandths>` rather than `(quot ms 1000)` —
+   the latter truncates to 0 if operators tune `:webhook/timeout-ms`
+   below 1000ms, and `--max-time 0` disables the timeout entirely
+   (would let the dispatcher hang on a slow/broken endpoint)."
+  []
+  (format "%.3f" (/ (double webhook-timeout-ms) 1000.0)))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn- ^{:stratum 3} post-webhook-once
+  "Single HTTP POST attempt to the listener's `:channel/target` URL.
+   Returns DAG result. Curl invoked via `babashka.process` to keep
+   this brick BB-compatible without pulling extra HTTP deps."
+  [target-url json-body]
+  (try
+    (let [r (process/shell {:in json-body
+                            :out :string
+                            :err :string
+                            :continue true}
+                           "curl" "--silent" "--show-error" "--fail"
+                           "--max-time" (timeout-seconds)
+                           "-X" "POST"
+                           "-H" "Content-Type: application/json"
+                           "--data-binary" "@-"
+                           target-url)]
+      (if (zero? (:exit r))
+        (dag/ok {:body (str/trim (:out r ""))})
+        (dag/err :resume-dispatcher/webhook-http-failed
+                 (str "curl exit " (:exit r) ": " (str/trim (:err r "")))
+                 {:exit-code (:exit r) :target target-url})))
+    (catch Throwable e
+      (dag/err :resume-dispatcher/webhook-exception
+               (.getMessage e)
+               {:target target-url}))))
+
+;------------------------------------------------------------------------------ Layer 4
+
+(defn- ^{:stratum 4} post-webhook-with-retry
   "Webhook POST with bounded retries + exponential backoff.
 
    Backoff schedule: a failed attempt at index `i` sleeps
@@ -258,7 +261,9 @@
           (sleep! (backoff-ms attempt))
           (recur (inc attempt)))))))
 
-(defn- dispatch-via-webhook!
+;------------------------------------------------------------------------------ Layer 5
+
+(defn- ^{:stratum 5} dispatch-via-webhook!
   "Send the primer to the listener's webhook URL. Returns DAG result.
    Cheshire's default keyword serialization already preserves the
    `<ns>/<name>` form (e.g. `:resume/pr-url → \"resume/pr-url\"`),
@@ -276,15 +281,17 @@
       :else
       (post-webhook-with-retry target body))))
 
-(def ^:private channel-handlers
+;------------------------------------------------------------------------------ Layer 6
+
+(def ^{:stratum 6} ^:private channel-handlers
   "Channel-kind → handler. Closed v0 set; unsupported kinds route to
    `not-yet-wired-error`."
   {:webhook dispatch-via-webhook!})
 
-;------------------------------------------------------------------------------ Layer 3
-;; Dispatcher entry points (orchestrate registry + channel + transition)
+;------------------------------------------------------------------------------ Layer 7
 
-(defn dispatch-to-channel!
+;; Dispatcher entry points (orchestrate registry + channel + transition)
+(defn ^{:stratum 7} dispatch-to-channel!
   "Pure-ish wrapper: validate primer, look up channel handler,
    invoke. Returns DAG result. Does NOT mark the listener
    `:dispatched` — that's the caller's job after success."
@@ -298,7 +305,9 @@
           (handler (:data primer-result) listener)
           (not-yet-wired-error listener))))))
 
-(defn dispatch-listener!
+;------------------------------------------------------------------------------ Layer 8
+
+(defn ^{:stratum 8} dispatch-listener!
   "Build primer + dispatch + mark dispatched on success.
    Returns `(dag/ok {:listener/id ... :dispatch-id ... :outcome :delivered})`
    on success or the failing DAG result with `:listener/id` attached
@@ -334,7 +343,9 @@
                     :dispatch-id dispatch-id
                     :mark-error  (:error mark-r)}))))))
 
-(defn dispatch-pr-merge!
+;------------------------------------------------------------------------------ Layer 9
+
+(defn ^{:stratum 9} dispatch-pr-merge!
   "Walk every `:active` listener for `pr-url` and dispatch each.
    Always returns a DAG result for shape consistency:
 

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/review_monitor.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/review_monitor.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.review-monitor
   "Review and comment monitoring for PRs.
 
@@ -31,20 +30,18 @@
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Review status types
 
-(def review-states
+;; Review status types
+(def ^{:stratum 0} review-states
   "Possible review states."
   #{:pending           ; Awaiting reviews
     :approved          ; Required approvals met
     :changes-requested ; Reviewer requested changes
     :commented         ; Review submitted with comments only
-    :dismissed})       ; Review was dismissed
+    :dismissed})  ; Review was dismissed
 
-;------------------------------------------------------------------------------ Layer 0
 ;; GitHub CLI helpers
-
-(defn run-gh-command
+(defn ^{:stratum 0} run-gh-command
   "Run a gh CLI command and return result."
   [args worktree-path]
   (try
@@ -62,36 +59,8 @@
     (catch Exception e
       (dag/err :gh-exception (.getMessage e)))))
 
-(defn get-pr-reviews
-  "Get reviews for a PR.
-
-   Returns result with review information."
-  [worktree-path pr-number]
-  (let [result (run-gh-command
-                ["gh" "pr" "view" (str pr-number) "--json"
-                 "reviews,reviewDecision"]
-                worktree-path)]
-    (if (dag/ok? result)
-      (dag/ok {:raw (:output (:data result))})
-      result)))
-
-(defn get-pr-comments
-  "Get comments on a PR (both review comments and issue comments).
-
-   Returns result with comments."
-  [worktree-path pr-number]
-  (let [result (run-gh-command
-                ["gh" "pr" "view" (str pr-number) "--json"
-                 "comments,reviewComments"]
-                worktree-path)]
-    (if (dag/ok? result)
-      (dag/ok {:raw (:output (:data result))})
-      result)))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; Review status computation
-
-(defn parse-review-decision
+(defn ^{:stratum 0} parse-review-decision
   "Parse GitHub review decision into our status.
 
    reviewDecision can be: APPROVED, CHANGES_REQUESTED, REVIEW_REQUIRED, or empty"
@@ -102,7 +71,7 @@
     "REVIEW_REQUIRED" :pending
     :pending))
 
-(defn compute-review-status
+(defn ^{:stratum 0} compute-review-status
   "Compute overall review status from reviews.
 
    Arguments:
@@ -136,7 +105,7 @@
      :approval-count (count unique-approvers)
      :required-approvals required-approvals}))
 
-(defn extract-review-comments
+(defn ^{:stratum 0} extract-review-comments
   "Extract actionable comments from reviews.
 
    Returns sequence of comment maps."
@@ -151,10 +120,8 @@
                :line (:line c)}))
        vec))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Comment tracking
-
-(defn create-comment-tracker
+(defn ^{:stratum 0} create-comment-tracker
   "Create a tracker for PR comments.
 
    Tracks seen comments to detect new ones."
@@ -162,7 +129,7 @@
   (atom {:seen-ids #{}
          :comments []}))
 
-(defn track-comment!
+(defn ^{:stratum 0} track-comment!
   "Track a comment, returning true if it's new."
   [tracker comment]
   (let [comment-id (or (:id comment)
@@ -176,7 +143,40 @@
                    (update :comments conj comment)))))
     (not already-seen?)))
 
-(defn new-comments
+(defn ^{:stratum 0} stop-review-monitor
+  "Stop a running review monitor."
+  [monitor]
+  (swap! monitor assoc :running? false))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} get-pr-reviews
+  "Get reviews for a PR.
+
+   Returns result with review information."
+  [worktree-path pr-number]
+  (let [result (run-gh-command
+                ["gh" "pr" "view" (str pr-number) "--json"
+                 "reviews,reviewDecision"]
+                worktree-path)]
+    (if (dag/ok? result)
+      (dag/ok {:raw (:output (:data result))})
+      result)))
+
+(defn ^{:stratum 1} get-pr-comments
+  "Get comments on a PR (both review comments and issue comments).
+
+   Returns result with comments."
+  [worktree-path pr-number]
+  (let [result (run-gh-command
+                ["gh" "pr" "view" (str pr-number) "--json"
+                 "comments,reviewComments"]
+                worktree-path)]
+    (if (dag/ok? result)
+      (dag/ok {:raw (:output (:data result))})
+      result)))
+
+(defn ^{:stratum 1} new-comments
   "Get comments that are new since last check.
 
    Arguments:
@@ -189,10 +189,8 @@
        (filter #(track-comment! tracker %))
        vec))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Monitoring
-
-(defn create-review-monitor
+(defn ^{:stratum 1} create-review-monitor
   "Create a review monitor for a PR.
 
    Arguments:
@@ -228,7 +226,9 @@
          :polls 0
          :running? false}))
 
-(defn poll-review-status
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} poll-review-status
   "Poll review status once.
 
    Arguments:
@@ -305,7 +305,9 @@
          :actionable-comments actionable-comments
          :events events}))))
 
-(defn run-review-monitor
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} run-review-monitor
   "Run the review monitor until approved or changes requested.
 
    Note: This doesn't necessarily terminate - it runs until
@@ -359,11 +361,6 @@
           (do
             (Thread/sleep poll-interval-ms)
             (recur)))))))
-
-(defn stop-review-monitor
-  "Stop a running review monitor."
-  [monitor]
-  (swap! monitor assoc :running? false))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/review_scheduler.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/review_scheduler.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.review-scheduler
   "Auto-trigger plumbing for the N13 Standards Reviewer (#818).
 
@@ -35,7 +34,9 @@
    [cheshire.core :as json]
    [clojure.string :as str]))
 
-(defn- run-gh
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} run-gh
   [args worktree-path]
   (try
     (let [r (apply process/shell
@@ -49,7 +50,36 @@
     (catch Exception e
       (dag/err :gh-exception (.getMessage e)))))
 
-(defn existing-review-shas
+;; Per-PR ephemeral worktree
+(defn- ^{:stratum 0} git-sh
+  "Run a git subcommand from `repo` and return DAG result. Args are
+   the trailing args after `git -C <repo>`."
+  [repo & args]
+  (try
+    (let [r (apply process/shell
+                   {:dir (str repo)
+                    :out :string :err :string :continue true}
+                   "git" "-C" (str repo) args)]
+      (if (zero? (:exit r))
+        (dag/ok {:output (str/trim (:out r ""))})
+        (dag/err :git-command-failed (str/trim (:err r ""))
+                 {:exit-code (:exit r) :args (vec args)})))
+    (catch Exception e
+      (dag/err :git-exception (.getMessage e)))))
+
+;; Review-needs predicate
+(defn ^{:stratum 0} pr-needs-review?
+  "Pure predicate. Returns true when `pr` (a `:pr/sha`-bearing map
+   from `pr-poller/poll-open-prs`) has no entry in `existing-shas`
+   (the set returned by `existing-review-shas`)."
+  [pr existing-shas]
+  (let [sha (:pr/sha pr)]
+    (and (string? sha)
+         (not (contains? (or existing-shas #{}) sha)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} existing-review-shas
   "Return a `(dag/ok #{sha …})` of head SHAs for which we've already
    posted a standards review on `pr-number`. A review counts if its
    body contains `review-marker`.
@@ -80,26 +110,7 @@
           (dag/err :json-parse-error (.getMessage e))))
       result)))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Per-PR ephemeral worktree
-
-(defn- git-sh
-  "Run a git subcommand from `repo` and return DAG result. Args are
-   the trailing args after `git -C <repo>`."
-  [repo & args]
-  (try
-    (let [r (apply process/shell
-                   {:dir (str repo)
-                    :out :string :err :string :continue true}
-                   "git" "-C" (str repo) args)]
-      (if (zero? (:exit r))
-        (dag/ok {:output (str/trim (:out r ""))})
-        (dag/err :git-command-failed (str/trim (:err r ""))
-                 {:exit-code (:exit r) :args (vec args)})))
-    (catch Exception e
-      (dag/err :git-exception (.getMessage e)))))
-
-(defn fetch-pr-head!
+(defn ^{:stratum 1} fetch-pr-head!
   "Fetch the PR head into a stable local ref so an ephemeral worktree
    can check it out without racing FETCH_HEAD. Ref shape is
    `refs/miniforge-review/pr-<n>`. Returns DAG result."
@@ -107,7 +118,7 @@
   (git-sh base-repo "fetch" "origin"
           (str "+refs/pull/" pr-number "/head:refs/miniforge-review/pr-" pr-number)))
 
-(defn add-pr-worktree!
+(defn ^{:stratum 1} add-pr-worktree!
   "Create a detached-HEAD worktree at `sha` rooted under `tmp-dir`.
    Returns DAG result with `:worktree-path`."
   [base-repo sha tmp-dir]
@@ -116,7 +127,7 @@
       (dag/ok {:worktree-path (str tmp-dir)})
       r)))
 
-(defn remove-pr-worktree!
+(defn ^{:stratum 1} remove-pr-worktree!
   "Best-effort cleanup of a previously-added ephemeral worktree.
    Always attempts both `git worktree remove --force` AND filesystem
    delete so a half-created worktree doesn't leak."
@@ -125,7 +136,23 @@
     (try (fs/delete-tree worktree-path) (catch Throwable _ nil))
     (dag/ok {:removed worktree-path})))
 
-(defn with-pr-worktree
+(defn ^{:stratum 1} partition-needs-review
+  "Split a vector of `pr-poller`-shaped PR maps into
+   `{:needs-review [...] :already-reviewed [...]}` against the
+   `existing-shas-by-pr` map (keyed by `:pr/number`)."
+  [prs existing-shas-by-pr]
+  (reduce
+   (fn [acc pr]
+     (let [shas (get existing-shas-by-pr (:pr/number pr) #{})]
+       (if (pr-needs-review? pr shas)
+         (update acc :needs-review conj pr)
+         (update acc :already-reviewed conj pr))))
+   {:needs-review [] :already-reviewed []}
+   prs))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} with-pr-worktree
   "Bracketing helper: fetch PR head, create an ephemeral detached
    worktree at that SHA under `/tmp/mf-review-<sha>`, invoke `f`
    with the worktree path + the resolved SHA, then clean up.
@@ -167,29 +194,3 @@
                 (dag/ok {:result r :sha sha}))
               (finally
                 (remove-pr-worktree! base-repo tmp)))))))))
-
-;------------------------------------------------------------------------------ Layer 2
-;; Review-needs predicate
-
-(defn pr-needs-review?
-  "Pure predicate. Returns true when `pr` (a `:pr/sha`-bearing map
-   from `pr-poller/poll-open-prs`) has no entry in `existing-shas`
-   (the set returned by `existing-review-shas`)."
-  [pr existing-shas]
-  (let [sha (:pr/sha pr)]
-    (and (string? sha)
-         (not (contains? (or existing-shas #{}) sha)))))
-
-(defn partition-needs-review
-  "Split a vector of `pr-poller`-shaped PR maps into
-   `{:needs-review [...] :already-reviewed [...]}` against the
-   `existing-shas-by-pr` map (keyed by `:pr/number`)."
-  [prs existing-shas-by-pr]
-  (reduce
-   (fn [acc pr]
-     (let [shas (get existing-shas-by-pr (:pr/number pr) #{})]
-       (if (pr-needs-review? pr shas)
-         (update acc :needs-review conj pr)
-         (update acc :already-reviewed conj pr))))
-   {:needs-review [] :already-reviewed []}
-   prs))

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/triage.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/triage.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.triage
   "Comment triage for PR reviews.
 
@@ -25,9 +24,9 @@
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Comment classification
 
-(def actionable-indicators
+;; Comment classification
+(def ^{:stratum 0} actionable-indicators
   "Keywords/phrases that indicate an actionable comment."
   #{;; Direct requests
     "please" "should" "must" "need to" "needs to" "required"
@@ -41,7 +40,7 @@
     ;; Design/architecture
     "violation" "constraint" "requirement" "spec"})
 
-(def non-actionable-indicators
+(def ^{:stratum 0} non-actionable-indicators
   "Keywords/phrases that indicate a non-actionable comment."
   #{;; Approval/praise
     "lgtm" "looks good" "great" "nice" "well done" "excellent"
@@ -53,7 +52,7 @@
     ;; Information only
     "fyi" "for your information" "just noting" "reminder"})
 
-(defn score-indicators
+(defn ^{:stratum 0} score-indicators
   "Score text against a set of indicators.
    Returns count of matching indicators."
   [text indicators]
@@ -62,10 +61,8 @@
          (filter #(str/includes? lower-text %))
          count)))
 
-;------------------------------------------------------------------------------ Layer 0
 ;; Comment structure
-
-(defn parse-comment
+(defn ^{:stratum 0} parse-comment
   "Parse a raw comment into structured form.
 
    Input can be:
@@ -84,10 +81,109 @@
      :comment/path (:path raw)
      :comment/line (:line raw)}))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Triage logic
+;; CI failure triage
+(defn ^{:stratum 0} parse-ci-failure
+  "Parse CI failure logs into structured actionable items.
 
-(defn classify-comment
+   Arguments:
+   - logs: CI log output (string or lines)
+
+   Returns {:test-failures [...] :lint-errors [...] :build-errors [...]
+            :actionable-summary string}"
+  [logs]
+  (let [lines (if (string? logs)
+                (str/split-lines logs)
+                logs)
+        _lower-lines (map str/lower-case lines)
+
+        ;; Extract test failures
+        test-failures (->> lines
+                           (filter #(or (str/includes? % "FAIL")
+                                        (str/includes? % "ERROR")
+                                        (str/includes? % "AssertionError")
+                                        (re-find #"expected:.*actual:" %)))
+                           (take 20)
+                           vec)
+
+        ;; Extract lint errors
+        lint-errors (->> lines
+                         (filter #(or (str/includes? % "warning:")
+                                      (str/includes? % "error:")
+                                      (re-find #":\d+:\d+:" %)))
+                         (take 20)
+                         vec)
+
+        ;; Extract build errors
+        build-errors (->> lines
+                          (filter #(or (str/includes? % "BUILD FAILED")
+                                       (str/includes? % "compilation failed")
+                                       (str/includes? % "Could not resolve")))
+                          vec)]
+    {:test-failures test-failures
+     :lint-errors lint-errors
+     :build-errors build-errors
+     :actionable-summary (str/join "\n"
+                                   (concat
+                                    (when (seq test-failures)
+                                      [(str (count test-failures) " test failure(s)")])
+                                    (when (seq lint-errors)
+                                      [(str (count lint-errors) " lint error(s)")])
+                                    (when (seq build-errors)
+                                      [(str (count build-errors) " build error(s)")])))}))
+
+(defn ^{:stratum 0} extract-failing-files
+  "Extract file paths mentioned in CI failures.
+
+   Returns set of file paths."
+  [ci-failure]
+  (let [all-lines (concat (:test-failures ci-failure)
+                          (:lint-errors ci-failure)
+                          (:build-errors ci-failure))
+        ;; Common file path patterns
+        path-patterns [#"([a-zA-Z0-9_/\-\.]+\.(clj|cljs|cljc|edn|java|py|js|ts))"
+                       #"at\s+([a-zA-Z0-9_/\-\.]+):\d+"
+                       #"in\s+file\s+([a-zA-Z0-9_/\-\.]+)"]]
+    (->> all-lines
+         (mapcat (fn [line]
+                   (mapcat #(re-seq % line) path-patterns)))
+         (map second)
+         (filter some?)
+         (remove #(str/starts-with? % "java."))
+         set)))
+
+;; Review request triage
+(defn ^{:stratum 0} extract-requested-changes
+  "Extract specific requested changes from review comments.
+
+   Returns sequence of {:file path :change description :original comment}"
+  [actionable-comments]
+  (->> actionable-comments
+       (map (fn [{:keys [comment]}]
+              (let [body (:comment/body comment)
+                    path (:comment/path comment)
+                    line (:comment/line comment)]
+                {:file path
+                 :line line
+                 :change body
+                 :original comment})))
+       (filter :file) ; Only comments with file context
+       vec))
+
+(defn ^{:stratum 0} group-changes-by-file
+  "Group requested changes by file for efficient processing."
+  [requested-changes]
+  (->> requested-changes
+       (group-by :file)
+       (map (fn [[file changes]]
+              {:file file
+               :changes (vec changes)
+               :lines (set (keep :line changes))}))
+       vec))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Triage logic
+(defn ^{:stratum 1} classify-comment
   "Classify a comment as actionable or non-actionable.
 
    Arguments:
@@ -140,7 +236,9 @@
                   :non-actionable non-actionable-matches}
      :comment parsed}))
 
-(defn triage-comments
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} triage-comments
   "Triage a collection of comments.
 
    Arguments:
@@ -168,109 +266,6 @@
              :actionable-count (count actionable)
              :non-actionable-count (count non-actionable)
              :policy policy}}))
-
-;------------------------------------------------------------------------------ Layer 2
-;; CI failure triage
-
-(defn parse-ci-failure
-  "Parse CI failure logs into structured actionable items.
-
-   Arguments:
-   - logs: CI log output (string or lines)
-
-   Returns {:test-failures [...] :lint-errors [...] :build-errors [...]
-            :actionable-summary string}"
-  [logs]
-  (let [lines (if (string? logs)
-                (str/split-lines logs)
-                logs)
-        _lower-lines (map str/lower-case lines)
-
-        ;; Extract test failures
-        test-failures (->> lines
-                           (filter #(or (str/includes? % "FAIL")
-                                        (str/includes? % "ERROR")
-                                        (str/includes? % "AssertionError")
-                                        (re-find #"expected:.*actual:" %)))
-                           (take 20)
-                           vec)
-
-        ;; Extract lint errors
-        lint-errors (->> lines
-                         (filter #(or (str/includes? % "warning:")
-                                      (str/includes? % "error:")
-                                      (re-find #":\d+:\d+:" %)))
-                         (take 20)
-                         vec)
-
-        ;; Extract build errors
-        build-errors (->> lines
-                          (filter #(or (str/includes? % "BUILD FAILED")
-                                       (str/includes? % "compilation failed")
-                                       (str/includes? % "Could not resolve")))
-                          vec)]
-    {:test-failures test-failures
-     :lint-errors lint-errors
-     :build-errors build-errors
-     :actionable-summary (str/join "\n"
-                                   (concat
-                                    (when (seq test-failures)
-                                      [(str (count test-failures) " test failure(s)")])
-                                    (when (seq lint-errors)
-                                      [(str (count lint-errors) " lint error(s)")])
-                                    (when (seq build-errors)
-                                      [(str (count build-errors) " build error(s)")])))}))
-
-(defn extract-failing-files
-  "Extract file paths mentioned in CI failures.
-
-   Returns set of file paths."
-  [ci-failure]
-  (let [all-lines (concat (:test-failures ci-failure)
-                          (:lint-errors ci-failure)
-                          (:build-errors ci-failure))
-        ;; Common file path patterns
-        path-patterns [#"([a-zA-Z0-9_/\-\.]+\.(clj|cljs|cljc|edn|java|py|js|ts))"
-                       #"at\s+([a-zA-Z0-9_/\-\.]+):\d+"
-                       #"in\s+file\s+([a-zA-Z0-9_/\-\.]+)"]]
-    (->> all-lines
-         (mapcat (fn [line]
-                   (mapcat #(re-seq % line) path-patterns)))
-         (map second)
-         (filter some?)
-         (remove #(str/starts-with? % "java."))
-         set)))
-
-;------------------------------------------------------------------------------ Layer 3
-;; Review request triage
-
-(defn extract-requested-changes
-  "Extract specific requested changes from review comments.
-
-   Returns sequence of {:file path :change description :original comment}"
-  [actionable-comments]
-  (->> actionable-comments
-       (map (fn [{:keys [comment]}]
-              (let [body (:comment/body comment)
-                    path (:comment/path comment)
-                    line (:comment/line comment)]
-                {:file path
-                 :line line
-                 :change body
-                 :original comment})))
-       (filter :file) ; Only comments with file context
-       vec))
-
-(defn group-changes-by-file
-  "Group requested changes by file for efficient processing."
-  [requested-changes]
-  (->> requested-changes
-       (group-by :file)
-       (map (fn [[file changes]]
-              {:file file
-               :changes (vec changes)
-               :lines (set (keep :line changes))}))
-       vec))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/anomaly/fetch_actionable_comments_result_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/anomaly/fetch_actionable_comments_result_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.anomaly.fetch-actionable-comments-result-test
   "Coverage for `responder/fetch-actionable-comments-result`
    (anomaly-returning).
@@ -29,9 +28,10 @@
    [ai.miniforge.pr-lifecycle.pr-poller :as poller]
    [ai.miniforge.pr-lifecycle.responder :as responder]))
 
-;------------------------------------------------------------------------------ Happy path
+;------------------------------------------------------------------------------ Layer 0
 
-(deftest fetch-result-returns-comments-and-groups-on-success
+;------------------------------------------------------------------------------ Happy path
+(deftest ^{:stratum 0} fetch-result-returns-comments-and-groups-on-success
   (testing "successful poller fetch returns {:comments :groups}"
     (with-redefs [poller/fetch-pr-comments
                   (fn [_ _]
@@ -45,7 +45,7 @@
         (is (vector? (:groups result)))
         (is (= 1 (count (:comments result))))))))
 
-(deftest fetch-result-filters-bot-comments
+(deftest ^{:stratum 0} fetch-result-filters-bot-comments
   (testing "bot-authored comments are filtered out"
     (with-redefs [poller/fetch-pr-comments
                   (fn [_ _]
@@ -62,8 +62,7 @@
         (is (= "alice" (:comment/author (first (:comments result)))))))))
 
 ;------------------------------------------------------------------------------ Failure path
-
-(deftest fetch-result-returns-anomaly-on-poller-err
+(deftest ^{:stratum 0} fetch-result-returns-anomaly-on-poller-err
   (testing "poller DAG err yields :fault anomaly"
     (with-redefs [poller/fetch-pr-comments
                   (fn [_ _] (dag/err :network "down"))]
@@ -73,7 +72,7 @@
         (is (= 42 (:pr-number (:anomaly/data result))))
         (is (= "down" (:error (:anomaly/data result))))))))
 
-(deftest fetch-result-anomaly-message-stable
+(deftest ^{:stratum 0} fetch-result-anomaly-message-stable
   (testing ":anomaly/message is the canonical fetch-failure string"
     (with-redefs [poller/fetch-pr-comments
                   (fn [_ _] (dag/err :downstream "boom"))]

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/anomaly/iter_budget_result_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/anomaly/iter_budget_result_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.anomaly.iter-budget-result-test
   "Coverage for `controller/iter-budget-result` (anomaly-returning) and
    fix-loop boundary behavior in `handle-ci-failure!` /
@@ -28,22 +27,22 @@
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.pr-lifecycle.controller :as controller]))
 
-(def ^:private test-task
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private test-task
   {:task/id (random-uuid)
    :task/type :implement
    :task/description "test task"})
 
 ;------------------------------------------------------------------------------ Happy path (anomaly-returning API)
-
-(deftest iter-budget-result-returns-ok-when-under-budget
+(deftest ^{:stratum 0} iter-budget-result-returns-ok-when-under-budget
   (testing "current < max returns :ok"
     (is (= :ok (controller/iter-budget-result "task-1" 0 3)))
     (is (= :ok (controller/iter-budget-result "task-1" 1 3)))
     (is (= :ok (controller/iter-budget-result "task-1" 2 3)))))
 
 ;------------------------------------------------------------------------------ Failure path (anomaly-returning API)
-
-(deftest iter-budget-result-returns-anomaly-when-at-budget
+(deftest ^{:stratum 0} iter-budget-result-returns-anomaly-when-at-budget
   (testing "current = max returns :conflict anomaly"
     (let [result (controller/iter-budget-result "task-1" 3 3)]
       (is (anomaly/anomaly? result))
@@ -51,22 +50,23 @@
       (is (= "task-1" (:task-id (:anomaly/data result))))
       (is (= 3 (:iterations (:anomaly/data result)))))))
 
-(deftest iter-budget-result-returns-anomaly-when-over-budget
+(deftest ^{:stratum 0} iter-budget-result-returns-anomaly-when-over-budget
   (testing "current > max returns :conflict anomaly"
     (let [result (controller/iter-budget-result "task-1" 5 3)]
       (is (anomaly/anomaly? result))
       (is (= :conflict (:anomaly/type result)))
       (is (= 5 (:iterations (:anomaly/data result)))))))
 
-(deftest iter-budget-result-zero-budget-rejects-immediately
+(deftest ^{:stratum 0} iter-budget-result-zero-budget-rejects-immediately
   (testing "max=0 rejects on first attempt (current=0)"
     (let [result (controller/iter-budget-result "task-1" 0 0)]
       (is (anomaly/anomaly? result))
       (is (= :conflict (:anomaly/type result))))))
 
-;------------------------------------------------------------------------------ Boundary helper returns anomaly after side effects
+;------------------------------------------------------------------------------ Layer 1
 
-(deftest handle-ci-failure-returns-budget-anomaly
+;------------------------------------------------------------------------------ Boundary helper returns anomaly after side effects
+(deftest ^{:stratum 1} handle-ci-failure-returns-budget-anomaly
   (testing "handle-ci-failure! returns :conflict anomaly"
     (let [ctrl (controller/create-controller
                 "dag" "run" "task" test-task
@@ -78,7 +78,7 @@
         (is (= :conflict (:anomaly/type result)))
         (is (= "Max fix iterations exceeded" (:anomaly/message result)))))))
 
-(deftest handle-review-feedback-returns-budget-anomaly
+(deftest ^{:stratum 1} handle-review-feedback-returns-budget-anomaly
   (testing "handle-review-feedback! returns :conflict anomaly"
     (let [ctrl (controller/create-controller
                 "dag" "run" "task" test-task
@@ -90,7 +90,7 @@
         (is (= :conflict (:anomaly/type result)))
         (is (= "Max fix iterations exceeded" (:anomaly/message result)))))))
 
-(deftest boundary-sets-failed-status-on-budget-exhaustion
+(deftest ^{:stratum 1} boundary-sets-failed-status-on-budget-exhaustion
   (testing "boundary helper transitions controller to :failed before throwing"
     (let [ctrl (controller/create-controller
                 "dag" "run" "task" test-task
@@ -100,7 +100,7 @@
       (controller/handle-ci-failure! ctrl "logs")
       (is (= :failed (:status @ctrl))))))
 
-(deftest boundary-records-history-on-budget-exhaustion
+(deftest ^{:stratum 1} boundary-records-history-on-budget-exhaustion
   (testing "boundary helper records :max-fix-iterations-exceeded in history"
     (let [ctrl (controller/create-controller
                 "dag" "run" "task" test-task

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/anomaly/normalize_resolution_shape_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/anomaly/normalize_resolution_shape_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.anomaly.normalize-resolution-shape-test
   "Locks the dual-shape anomaly detection in
    `merge/normalize-resolution-outcome` for the W2 anomaly
@@ -40,12 +39,12 @@
    [ai.miniforge.pr-lifecycle.merge :as merge]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Fixtures + factories
 
-(def ^:private unresolvable-message
+;; Fixtures + factories
+(def ^{:stratum 0} ^:private unresolvable-message
   "Merge conflict could not be auto-resolved")
 
-(def ^:private conflicting-readiness
+(def ^{:stratum 0} ^:private conflicting-readiness
   "Readiness map shaped like evaluate-merge-readiness output where the
    branch check failed via CONFLICTING (DIRTY mergeStateStatus) — the
    shape that triggers `attempt-conflict-resolution!`'s dispatch into
@@ -55,32 +54,14 @@
                                :raw "{\"mergeable\":\"CONFLICTING\",\"mergeStateStatus\":\"DIRTY\"}"})}
    :blocking [:branch-not-up-to-date]})
 
-(def ^:private gh-pr-info-output
+(def ^{:stratum 0} ^:private gh-pr-info-output
   (str "{\"number\":123,"
        "\"headRefName\":\"feat/x\","
        "\"baseRefName\":\"main\","
        "\"headRefOid\":\"abc1234\","
        "\"baseRefOid\":\"def5678\"}"))
 
-(defn- legacy-unresolvable-anomaly
-  "Legacy-shape (`:anomaly/category`) terminal anomaly — what
-   workflow.merge-resolution returns today, pre W2 batch 4."
-  []
-  {:anomaly/category  :anomalies/dag-multi-parent-unresolvable
-   :anomaly/message   unresolvable-message
-   :resolution/reason :budget-exhausted})
-
-(defn- canonical-unresolvable-anomaly
-  "Canonical-shape (`:anomaly/type` + `:anomaly/subtype`) terminal
-   anomaly — what workflow.merge-resolution returns after W2 batch 4
-   flips the workflow brick."
-  []
-  (anomaly/sub-anomaly :conflict
-                       :anomalies/dag-multi-parent-unresolvable
-                       unresolvable-message
-                       {:resolution/reason :budget-exhausted}))
-
-(defn- merge-context
+(defn- ^{:stratum 0} merge-context
   "Context map for `merge/attempt-merge` with an injected no-op
    resolve-fn (the real one is stubbed via with-redefs of
    `conflict-resolution/resolve-pr-conflicts!`)."
@@ -91,7 +72,27 @@
    :pr-id      123
    :resolve-fn (fn [_] (dag/ok {}))})
 
-(defn- attempt-merge-with-resolution
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} legacy-unresolvable-anomaly
+  "Legacy-shape (`:anomaly/category`) terminal anomaly — what
+   workflow.merge-resolution returns today, pre W2 batch 4."
+  []
+  {:anomaly/category  :anomalies/dag-multi-parent-unresolvable
+   :anomaly/message   unresolvable-message
+   :resolution/reason :budget-exhausted})
+
+(defn- ^{:stratum 1} canonical-unresolvable-anomaly
+  "Canonical-shape (`:anomaly/type` + `:anomaly/subtype`) terminal
+   anomaly — what workflow.merge-resolution returns after W2 batch 4
+   flips the workflow brick."
+  []
+  (anomaly/sub-anomaly :conflict
+                       :anomalies/dag-multi-parent-unresolvable
+                       unresolvable-message
+                       {:resolution/reason :budget-exhausted}))
+
+(defn- ^{:stratum 1} attempt-merge-with-resolution
   "Run `merge/attempt-merge` with `resolve-pr-conflicts!` stubbed to
    return the supplied terminal anomaly. Returns the attempt-merge
    result for the caller to assert on."
@@ -106,10 +107,10 @@
                          merge/default-merge-policy
                          (merge-context))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Dual-shape detection
+;------------------------------------------------------------------------------ Layer 2
 
-(deftest legacy-shape-anomaly-normalizes-to-conflict-unresolvable
+;; Dual-shape detection
+(deftest ^{:stratum 2} legacy-shape-anomaly-normalizes-to-conflict-unresolvable
   (testing "legacy `:anomaly/category` terminal anomaly normalizes
             to a dag/err with :conflict-unresolvable code"
     (let [terminal (legacy-unresolvable-anomaly)
@@ -119,7 +120,7 @@
       (is (= terminal (get-in result [:error :data :anomaly]))
           "original anomaly preserved for diagnostic surfacing"))))
 
-(deftest canonical-shape-anomaly-normalizes-to-conflict-unresolvable
+(deftest ^{:stratum 2} canonical-shape-anomaly-normalizes-to-conflict-unresolvable
   (testing "canonical `:anomaly/type` terminal anomaly (post W2
             batch 4 workflow flip) also normalizes to a dag/err with
             :conflict-unresolvable code"
@@ -132,7 +133,7 @@
       (is (= unresolvable-message (:message (:error result)))
           ":anomaly/message carries through to the dag/err message"))))
 
-(deftest canonical-and-legacy-shapes-both-detected-by-any-anomaly
+(deftest ^{:stratum 2} canonical-and-legacy-shapes-both-detected-by-any-anomaly
   (testing "both shapes that `any-anomaly?` must recognise yield the
             same downstream :conflict-unresolvable normalization. This
             locks the dual-shape contract: if a future change drops

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/anomaly/parse_pr_url_result_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/anomaly/parse_pr_url_result_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.anomaly.parse-pr-url-result-test
   "Coverage for `responder/parse-pr-url-result` (anomaly-returning) and
    the anomaly passthrough via `responder/respond-to-comments!`.
@@ -28,9 +27,10 @@
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.pr-lifecycle.responder :as responder]))
 
-;------------------------------------------------------------------------------ Happy path
+;------------------------------------------------------------------------------ Layer 0
 
-(deftest parse-pr-url-result-returns-parsed-on-valid-url
+;------------------------------------------------------------------------------ Happy path
+(deftest ^{:stratum 0} parse-pr-url-result-returns-parsed-on-valid-url
   (testing "github URL parses to {:owner :repo :number}"
     (let [result (responder/parse-pr-url-result
                   "https://github.com/miniforge-ai/miniforge/pull/123")]
@@ -40,27 +40,25 @@
       (is (= 123 (:number result))))))
 
 ;------------------------------------------------------------------------------ Failure path
-
-(deftest parse-pr-url-result-returns-anomaly-on-non-github-url
+(deftest ^{:stratum 0} parse-pr-url-result-returns-anomaly-on-non-github-url
   (testing "non-github URL yields :invalid-input anomaly"
     (let [result (responder/parse-pr-url-result "https://gitlab.com/foo/bar/pull/1")]
       (is (anomaly/anomaly? result))
       (is (= :invalid-input (:anomaly/type result)))
       (is (= "https://gitlab.com/foo/bar/pull/1" (:url (:anomaly/data result)))))))
 
-(deftest parse-pr-url-result-returns-anomaly-on-malformed-url
+(deftest ^{:stratum 0} parse-pr-url-result-returns-anomaly-on-malformed-url
   (testing "malformed URL yields :invalid-input anomaly"
     (let [result (responder/parse-pr-url-result "not-a-url")]
       (is (anomaly/anomaly? result))
       (is (= :invalid-input (:anomaly/type result))))))
 
-(deftest parse-pr-url-result-returns-anomaly-on-nil
+(deftest ^{:stratum 0} parse-pr-url-result-returns-anomaly-on-nil
   (testing "nil URL yields :invalid-input anomaly"
     (is (anomaly/anomaly? (responder/parse-pr-url-result nil)))))
 
 ;------------------------------------------------------------------------------ Orchestrator preserves anomaly values
-
-(deftest respond-to-comments-preserves-url-parse-anomaly
+(deftest ^{:stratum 0} respond-to-comments-preserves-url-parse-anomaly
   (testing "respond-to-comments! returns parse anomaly unchanged"
     (let [result (responder/respond-to-comments! "https://gitlab.com/x/y/pull/1"
                                                  "/tmp"

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/anomaly/pr_creation_result_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/anomaly/pr_creation_result_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.anomaly.pr-creation-result-test
   "Coverage for `controller/pr-creation-result` (anomaly-returning).
 
@@ -28,15 +27,15 @@
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.pr-lifecycle.controller :as controller]))
 
-;------------------------------------------------------------------------------ Happy path
+;------------------------------------------------------------------------------ Layer 0
 
-(deftest pr-creation-result-returns-ok-on-success
+;------------------------------------------------------------------------------ Happy path
+(deftest ^{:stratum 0} pr-creation-result-returns-ok-on-success
   (testing "successful DAG result returns :ok"
     (is (= :ok (controller/pr-creation-result (dag/ok {:pr/id "PR-1"}))))))
 
 ;------------------------------------------------------------------------------ Failure path
-
-(deftest pr-creation-result-returns-anomaly-on-dag-err
+(deftest ^{:stratum 0} pr-creation-result-returns-anomaly-on-dag-err
   (testing "DAG err result returns :fault anomaly"
     (let [pr-result (dag/err :network "connection refused")
           result (controller/pr-creation-result pr-result)]
@@ -45,7 +44,7 @@
       (is (some? (:error (:anomaly/data result))))
       (is (= "PR creation failed" (:anomaly/message result))))))
 
-(deftest pr-creation-result-carries-error-detail
+(deftest ^{:stratum 0} pr-creation-result-carries-error-detail
   (testing ":anomaly/data carries the underlying DAG error"
     (let [pr-result (dag/err :auth "token expired")
           result (controller/pr-creation-result pr-result)]

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/ci_monitor_property_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/ci_monitor_property_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.ci-monitor-property-test
   "Property-based tests for CI monitor status computation.
 
@@ -31,32 +30,66 @@
    [ai.miniforge.pr-lifecycle.ci-monitor :as ci]
    [ai.miniforge.response.interface :as response]))
 
-;------------------------------------------------------------------------------ Helpers
+;------------------------------------------------------------------------------ Layer 0
 
-(def valid-states
+;------------------------------------------------------------------------------ Helpers
+(def ^{:stratum 0} valid-states
   "Realistic GitHub check states."
   ["COMPLETED" "QUEUED" "WAITING" "IN_PROGRESS" nil])
 
-(def valid-conclusions
+(def ^{:stratum 0} valid-conclusions
   "Realistic GitHub check conclusions."
   ["SUCCESS" "FAILURE" "NEUTRAL" "CANCELLED" "SKIPPED"
    "ACTION_REQUIRED" "TIMED_OUT" nil])
 
-(defn random-check
+;------------------------------------------------------------------------------ Property: All-success yields :success
+(deftest ^{:stratum 0} compute-ci-status-all-success-test
+  (testing "Property: all COMPLETED/SUCCESS checks always yield :success"
+    (doseq [n (range 1 20)]
+      (let [checks (vec (repeat n {:name "test" :state "COMPLETED" :conclusion "SUCCESS"}))
+            result (ci/compute-ci-status checks)]
+        (is (response/success? result)
+            (str n " SUCCESS checks should yield :success"))))))
+
+;------------------------------------------------------------------------------ Property: Empty yields :unknown
+(deftest ^{:stratum 0} compute-ci-status-empty-yields-unknown-test
+  (testing "Property: empty checks always yield :unknown"
+    ;; Run multiple times to ensure consistency
+    (dotimes [_ 10]
+      (is (= :unknown (:status (ci/compute-ci-status [])))))))
+
+;------------------------------------------------------------------------------ Property: Pending blocks success
+(deftest ^{:stratum 0} compute-ci-status-pending-blocks-success-test
+  (testing "Property: QUEUED check prevents :success status (unless failure present)"
+    (dotimes [_ 50]
+      (let [success-checks (vec (for [i (range (inc (rand-int 5)))]
+                                  {:name (str "pass-" i) :state "COMPLETED" :conclusion "SUCCESS"}))
+            pending-check {:name "queued" :state "QUEUED" :conclusion nil}
+            checks (conj success-checks pending-check)
+            result (ci/compute-ci-status checks)]
+        (is (= :pending (:status result))
+            "QUEUED check should block :success status")))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} random-check
   "Generate a random CI check map."
   [i]
   {:name (str "check-" i)
    :state (rand-nth valid-states)
    :conclusion (rand-nth valid-conclusions)})
 
-(defn random-checks
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} random-checks
   "Generate n random CI check maps."
   [n]
   (mapv random-check (range n)))
 
-;------------------------------------------------------------------------------ Property: Total invariant
+;------------------------------------------------------------------------------ Layer 3
 
-(deftest compute-ci-status-total-invariant-test
+;------------------------------------------------------------------------------ Property: Total invariant
+(deftest ^{:stratum 3} compute-ci-status-total-invariant-test
   (testing "Property: :total always equals input count for random checks"
     (dotimes [_ 100]
       (let [n (rand-int 20)
@@ -66,8 +99,7 @@
             (str "Total should be " n " for " n " checks"))))))
 
 ;------------------------------------------------------------------------------ Property: Status in ci-statuses
-
-(deftest compute-ci-status-recognized-status-test
+(deftest ^{:stratum 3} compute-ci-status-recognized-status-test
   (testing "Property: status is always a member of ci-statuses for random checks"
     (dotimes [_ 100]
       (let [checks (random-checks (rand-int 20))
@@ -76,8 +108,7 @@
             (str "Status " (:status result) " should be in ci-statuses"))))))
 
 ;------------------------------------------------------------------------------ Property: Result map shape
-
-(deftest compute-ci-status-result-shape-test
+(deftest ^{:stratum 3} compute-ci-status-result-shape-test
   (testing "Property: result always contains required keys"
     (dotimes [_ 50]
       (let [checks (random-checks (rand-int 15))
@@ -95,8 +126,7 @@
         (is (integer? (:total result)))))))
 
 ;------------------------------------------------------------------------------ Property: Failure precedence
-
-(deftest compute-ci-status-failure-precedence-test
+(deftest ^{:stratum 3} compute-ci-status-failure-precedence-test
   (testing "Property: if any check has FAILURE conclusion with COMPLETED state, status is :failure"
     (dotimes [_ 50]
       (let [base-checks (random-checks (rand-int 10))
@@ -106,40 +136,8 @@
         (is (= :failure (:status result))
             "Failure should always take precedence")))))
 
-;------------------------------------------------------------------------------ Property: All-success yields :success
-
-(deftest compute-ci-status-all-success-test
-  (testing "Property: all COMPLETED/SUCCESS checks always yield :success"
-    (doseq [n (range 1 20)]
-      (let [checks (vec (repeat n {:name "test" :state "COMPLETED" :conclusion "SUCCESS"}))
-            result (ci/compute-ci-status checks)]
-        (is (response/success? result)
-            (str n " SUCCESS checks should yield :success"))))))
-
-;------------------------------------------------------------------------------ Property: Empty yields :unknown
-
-(deftest compute-ci-status-empty-yields-unknown-test
-  (testing "Property: empty checks always yield :unknown"
-    ;; Run multiple times to ensure consistency
-    (dotimes [_ 10]
-      (is (= :unknown (:status (ci/compute-ci-status [])))))))
-
-;------------------------------------------------------------------------------ Property: Pending blocks success
-
-(deftest compute-ci-status-pending-blocks-success-test
-  (testing "Property: QUEUED check prevents :success status (unless failure present)"
-    (dotimes [_ 50]
-      (let [success-checks (vec (for [i (range (inc (rand-int 5)))]
-                                  {:name (str "pass-" i) :state "COMPLETED" :conclusion "SUCCESS"}))
-            pending-check {:name "queued" :state "QUEUED" :conclusion nil}
-            checks (conj success-checks pending-check)
-            result (ci/compute-ci-status checks)]
-        (is (= :pending (:status result))
-            "QUEUED check should block :success status")))))
-
 ;------------------------------------------------------------------------------ Property: Grouped counts are non-negative
-
-(deftest compute-ci-status-grouped-counts-non-negative-test
+(deftest ^{:stratum 3} compute-ci-status-grouped-counts-non-negative-test
   (testing "Property: all grouped count vectors have non-negative length"
     (dotimes [_ 50]
       (let [checks (random-checks (rand-int 15))
@@ -150,8 +148,7 @@
         (is (>= (count (:neutral result)) 0))))))
 
 ;------------------------------------------------------------------------------ Property: Deterministic
-
-(deftest compute-ci-status-deterministic-test
+(deftest ^{:stratum 3} compute-ci-status-deterministic-test
   (testing "Property: same input always produces same output"
     (dotimes [_ 20]
       (let [checks (random-checks (inc (rand-int 10)))

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/ci_monitor_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/ci_monitor_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.ci-monitor-test
   "Unit tests for CI monitoring.
 
@@ -30,15 +29,16 @@
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.response.interface :as response]))
 
-;------------------------------------------------------------------------------ Status Types
+;------------------------------------------------------------------------------ Layer 0
 
-(deftest ci-statuses-test
+;------------------------------------------------------------------------------ Status Types
+(deftest ^{:stratum 0} ci-statuses-test
   (testing "All expected CI statuses are defined"
     (is (= 7 (count ci/ci-statuses)))
     (are [status] (contains? ci/ci-statuses status)
       :pending :success :failure :neutral :cancelled :timed-out :unknown)))
 
-(deftest terminal-statuses-test
+(deftest ^{:stratum 0} terminal-statuses-test
   (testing "Terminal statuses are a subset of CI statuses"
     (is (every? ci/ci-statuses ci/terminal-statuses)))
   (testing "Pending and unknown are not terminal"
@@ -46,8 +46,7 @@
     (is (not (contains? ci/terminal-statuses :unknown)))))
 
 ;------------------------------------------------------------------------------ Status Computation
-
-(deftest compute-ci-status-all-passing-test
+(deftest ^{:stratum 0} compute-ci-status-all-passing-test
   (testing "All checks passing yields :success"
     (let [checks [{:name "tests" :state "COMPLETED" :conclusion "SUCCESS"}
                   {:name "lint" :state "COMPLETED" :conclusion "SUCCESS"}
@@ -59,7 +58,7 @@
       (is (empty? (:pending result)))
       (is (= 3 (:total result))))))
 
-(deftest compute-ci-status-with-failure-test
+(deftest ^{:stratum 0} compute-ci-status-with-failure-test
   (testing "Any failure yields :failure even if others pass"
     (let [checks [{:name "tests" :state "COMPLETED" :conclusion "SUCCESS"}
                   {:name "lint" :state "COMPLETED" :conclusion "FAILURE"}]
@@ -68,7 +67,7 @@
       (is (= 1 (count (:failed result))))
       (is (= 1 (count (:passed result)))))))
 
-(deftest compute-ci-status-pending-test
+(deftest ^{:stratum 0} compute-ci-status-pending-test
   (testing "Queued checks yield :pending status"
     (let [checks [{:name "tests" :state "QUEUED" :conclusion nil}
                   {:name "lint" :state "COMPLETED" :conclusion "SUCCESS"}]
@@ -82,34 +81,34 @@
       (is (response/success? result)
           "IN_PROGRESS maps to :in_progress (underscore), not :in-progress (hyphen), so it falls to :unknown"))))
 
-(deftest compute-ci-status-failure-takes-precedence-over-pending-test
+(deftest ^{:stratum 0} compute-ci-status-failure-takes-precedence-over-pending-test
   (testing "Failure takes precedence over pending"
     (let [checks [{:name "tests" :state "COMPLETED" :conclusion "FAILURE"}
                   {:name "lint" :state "IN_PROGRESS" :conclusion nil}]
           result (ci/compute-ci-status checks)]
       (is (= :failure (:status result))))))
 
-(deftest compute-ci-status-queued-test
+(deftest ^{:stratum 0} compute-ci-status-queued-test
   (testing "Queued checks count as pending"
     (let [checks [{:name "tests" :state "QUEUED" :conclusion nil}]
           result (ci/compute-ci-status checks)]
       (is (= :pending (:status result)))
       (is (= 1 (count (:pending result)))))))
 
-(deftest compute-ci-status-neutral-test
+(deftest ^{:stratum 0} compute-ci-status-neutral-test
   (testing "Only neutral checks yield :neutral"
     (let [checks [{:name "optional" :state "COMPLETED" :conclusion "NEUTRAL"}]
           result (ci/compute-ci-status checks)]
       (is (= :neutral (:status result)))
       (is (= 1 (count (:neutral result)))))))
 
-(deftest compute-ci-status-empty-checks-test
+(deftest ^{:stratum 0} compute-ci-status-empty-checks-test
   (testing "Empty checks yield :unknown"
     (let [result (ci/compute-ci-status [])]
       (is (= :unknown (:status result)))
       (is (= 0 (:total result))))))
 
-(deftest compute-ci-status-cancelled-test
+(deftest ^{:stratum 0} compute-ci-status-cancelled-test
   (testing "Cancelled checks are grouped correctly"
     (let [checks [{:name "tests" :state "COMPLETED" :conclusion "CANCELLED"}]
           result (ci/compute-ci-status checks)]
@@ -117,13 +116,13 @@
       ;; in the final output; it falls through to check other conditions
       (is (some? (:status result))))))
 
-(deftest compute-ci-status-action-required-test
+(deftest ^{:stratum 0} compute-ci-status-action-required-test
   (testing "Action required counts as failure"
     (let [checks [{:name "review" :state "COMPLETED" :conclusion "ACTION_REQUIRED"}]
           result (ci/compute-ci-status checks)]
       (is (= :failure (:status result))))))
 
-(deftest compute-ci-status-skipped-test
+(deftest ^{:stratum 0} compute-ci-status-skipped-test
   (testing "Skipped checks count as neutral"
     (let [checks [{:name "optional" :state "COMPLETED" :conclusion "SKIPPED"}
                   {:name "tests" :state "COMPLETED" :conclusion "SUCCESS"}]
@@ -131,21 +130,20 @@
       (is (response/success? result)
           "Success should take precedence over neutral"))))
 
-(deftest compute-ci-status-waiting-test
+(deftest ^{:stratum 0} compute-ci-status-waiting-test
   (testing "Waiting state counts as pending"
     (let [checks [{:name "deploy" :state "WAITING" :conclusion nil}]
           result (ci/compute-ci-status checks)]
       (is (= :pending (:status result))))))
 
-(deftest compute-ci-status-nil-state-test
+(deftest ^{:stratum 0} compute-ci-status-nil-state-test
   (testing "Nil state and conclusion handled gracefully"
     (let [checks [{:name "unknown" :state nil :conclusion nil}]
           result (ci/compute-ci-status checks)]
       (is (some? (:status result))))))
 
 ;------------------------------------------------------------------------------ Monitor Creation
-
-(deftest create-ci-monitor-test
+(deftest ^{:stratum 0} create-ci-monitor-test
   (testing "Monitor initializes with correct state"
     (let [dag-id (random-uuid)
           run-id (random-uuid)
@@ -161,7 +159,7 @@
       (is (nil? (:started-at @monitor)))
       (is (= 0 (:polls @monitor))))))
 
-(deftest create-ci-monitor-custom-options-test
+(deftest ^{:stratum 0} create-ci-monitor-custom-options-test
   (testing "Monitor respects custom options"
     (let [bus (atom {})
           monitor (ci/create-ci-monitor
@@ -173,7 +171,7 @@
       (is (= 60000 (:timeout-ms @monitor)))
       (is (= bus (:event-bus @monitor))))))
 
-(deftest create-ci-monitor-defaults-test
+(deftest ^{:stratum 0} create-ci-monitor-defaults-test
   (testing "Monitor uses sensible defaults"
     (let [monitor (ci/create-ci-monitor
                     (random-uuid) (random-uuid) (random-uuid) 1 "/tmp")]
@@ -182,8 +180,7 @@
       (is (nil? (:event-bus @monitor))))))
 
 ;------------------------------------------------------------------------------ Stop Monitor
-
-(deftest stop-ci-monitor-test
+(deftest ^{:stratum 0} stop-ci-monitor-test
   (testing "stop-ci-monitor sets running? to false"
     (let [monitor (ci/create-ci-monitor
                     (random-uuid) (random-uuid) (random-uuid) 1 "/tmp")]
@@ -193,8 +190,7 @@
       (is (false? (:running? @monitor))))))
 
 ;------------------------------------------------------------------------------ Mocked gh CLI: run-gh-command
-
-(deftest run-gh-command-success-test
+(deftest ^{:stratum 0} run-gh-command-success-test
   (testing "Successful gh command returns dag/ok with trimmed output"
     (with-redefs [babashka.process/shell
                   (fn [& _args]
@@ -203,7 +199,7 @@
         (is (dag/ok? result))
         (is (= "some output" (:output (:data result))))))))
 
-(deftest run-gh-command-failure-test
+(deftest ^{:stratum 0} run-gh-command-failure-test
   (testing "Failed gh command returns dag/err with error message"
     (with-redefs [babashka.process/shell
                   (fn [& _args]
@@ -212,7 +208,7 @@
         (is (dag/err? result))
         (is (= :gh-command-failed (get-in result [:error :code])))))))
 
-(deftest run-gh-command-exception-test
+(deftest ^{:stratum 0} run-gh-command-exception-test
   (testing "Exception during gh command returns dag/err"
     (with-redefs [babashka.process/shell
                   (fn [& _args]
@@ -222,8 +218,7 @@
         (is (= :gh-exception (get-in result [:error :code])))))))
 
 ;------------------------------------------------------------------------------ Mocked gh CLI: get-pr-checks
-
-(deftest get-pr-checks-success-test
+(deftest ^{:stratum 0} get-pr-checks-success-test
   (testing "get-pr-checks returns parsed checks on success"
     (with-redefs [ci/run-gh-command
                   (fn [_args _path]
@@ -232,7 +227,7 @@
         (is (dag/ok? result))
         (is (vector? (:checks (:data result))))))))
 
-(deftest get-pr-checks-unparseable-output-test
+(deftest ^{:stratum 0} get-pr-checks-unparseable-output-test
   (testing "get-pr-checks falls back to empty checks on parse error"
     (with-redefs [ci/run-gh-command
                   (fn [_args _path]
@@ -242,7 +237,7 @@
         (is (= [] (:checks (:data result))))
         (is (some? (:raw (:data result))))))))
 
-(deftest get-pr-checks-failure-propagates-test
+(deftest ^{:stratum 0} get-pr-checks-failure-propagates-test
   (testing "get-pr-checks propagates error when gh command fails"
     (with-redefs [ci/run-gh-command
                   (fn [_args _path]
@@ -251,7 +246,7 @@
         (is (dag/err? result))
         (is (= :gh-command-failed (get-in result [:error :code])))))))
 
-(deftest get-pr-checks-empty-json-array-test
+(deftest ^{:stratum 0} get-pr-checks-empty-json-array-test
   (testing "get-pr-checks handles empty JSON array (no checks configured)"
     (with-redefs [ci/run-gh-command
                   (fn [_args _path]
@@ -262,8 +257,7 @@
         (is (some? (:data result)))))))
 
 ;------------------------------------------------------------------------------ Mocked poll-ci-status
-
-(deftest poll-ci-status-success-all-passing-test
+(deftest ^{:stratum 0} poll-ci-status-success-all-passing-test
   (testing "poll-ci-status returns :success when all checks pass"
     (with-redefs [ci/get-pr-checks
                   (fn [_path _pr]
@@ -277,7 +271,7 @@
         (is (= 2 (count (:passed (:checks result)))))
         (is (empty? (:failed (:checks result))))))))
 
-(deftest poll-ci-status-with-failures-test
+(deftest ^{:stratum 0} poll-ci-status-with-failures-test
   (testing "poll-ci-status returns :failure when any check fails"
     (with-redefs [ci/get-pr-checks
                   (fn [_path _pr]
@@ -290,7 +284,7 @@
         (is (= :failure (:status result)))
         (is (= 1 (count (:failed (:checks result)))))))))
 
-(deftest poll-ci-status-pending-checks-test
+(deftest ^{:stratum 0} poll-ci-status-pending-checks-test
   (testing "poll-ci-status returns :pending when checks are still running"
     (with-redefs [ci/get-pr-checks
                   (fn [_path _pr]
@@ -304,7 +298,7 @@
         (is (nil? (:event result))
             "No event should be generated for non-terminal status")))))
 
-(deftest poll-ci-status-no-checks-test
+(deftest ^{:stratum 0} poll-ci-status-no-checks-test
   (testing "poll-ci-status returns :unknown when no checks exist"
     (with-redefs [ci/get-pr-checks
                   (fn [_path _pr]
@@ -317,7 +311,7 @@
         (is (nil? (:event result))
             "No event for :unknown status")))))
 
-(deftest poll-ci-status-gh-failure-returns-unknown-test
+(deftest ^{:stratum 0} poll-ci-status-gh-failure-returns-unknown-test
   (testing "poll-ci-status returns :unknown on gh command failure"
     (with-redefs [ci/get-pr-checks
                   (fn [_path _pr]
@@ -329,7 +323,7 @@
         (is (= :unknown (:status result)))
         (is (some? (:error result)))))))
 
-(deftest poll-ci-status-increments-poll-count-test
+(deftest ^{:stratum 0} poll-ci-status-increments-poll-count-test
   (testing "Each poll increments the poll counter"
     (with-redefs [ci/get-pr-checks
                   (fn [_path _pr]
@@ -342,7 +336,7 @@
         (ci/poll-ci-status monitor nil)
         (is (= 3 (:polls @monitor)))))))
 
-(deftest poll-ci-status-updates-last-poll-timestamp-test
+(deftest ^{:stratum 0} poll-ci-status-updates-last-poll-timestamp-test
   (testing "Poll sets last-poll timestamp"
     (with-redefs [ci/get-pr-checks
                   (fn [_path _pr]
@@ -354,7 +348,7 @@
         (ci/poll-ci-status monitor nil)
         (is (inst? (:last-poll @monitor)))))))
 
-(deftest poll-ci-status-updates-monitor-status-test
+(deftest ^{:stratum 0} poll-ci-status-updates-monitor-status-test
   (testing "Poll updates the monitor atom's :status field"
     (with-redefs [ci/get-pr-checks
                   (fn [_path _pr]
@@ -367,8 +361,7 @@
         (is (response/success? @monitor))))))
 
 ;------------------------------------------------------------------------------ Status Change Detection
-
-(deftest poll-ci-status-generates-ci-passed-event-test
+(deftest ^{:stratum 0} poll-ci-status-generates-ci-passed-event-test
   (testing "Transition to :success generates a :pr/ci-passed event"
     (with-redefs [ci/get-pr-checks
                   (fn [_path _pr]
@@ -383,7 +376,7 @@
         (is (= :pr/ci-passed (:event/type (:event result))))
         (is (= 42 (:pr/id (:event result))))))))
 
-(deftest poll-ci-status-generates-ci-failed-event-test
+(deftest ^{:stratum 0} poll-ci-status-generates-ci-failed-event-test
   (testing "Transition to :failure generates a :pr/ci-failed event"
     (with-redefs [ci/get-pr-checks
                   (fn [_path _pr]
@@ -399,7 +392,7 @@
         (is (string? (:ci/logs (:event result)))
             "Failed event should include log summary")))))
 
-(deftest poll-ci-status-no-event-for-pending-test
+(deftest ^{:stratum 0} poll-ci-status-no-event-for-pending-test
   (testing "No event generated when status remains :pending"
     (with-redefs [ci/get-pr-checks
                   (fn [_path _pr]
@@ -416,7 +409,7 @@
           (is (= :pending (:status r2)))
           (is (nil? (:event r2))))))))
 
-(deftest poll-ci-status-no-event-for-unknown-on-error-test
+(deftest ^{:stratum 0} poll-ci-status-no-event-for-unknown-on-error-test
   (testing "No event generated when poll fails (:unknown is non-terminal)"
     (with-redefs [ci/get-pr-checks
                   (fn [_path _pr]
@@ -429,7 +422,7 @@
         (is (nil? (:event result))
             ":unknown is non-terminal, no event should be emitted")))))
 
-(deftest poll-ci-status-neutral-generates-event-test
+(deftest ^{:stratum 0} poll-ci-status-neutral-generates-event-test
   (testing "Transition to :neutral (terminal) generates a ci-failed event"
     (with-redefs [ci/get-pr-checks
                   (fn [_path _pr]
@@ -443,7 +436,7 @@
         (is (some? (:event result)))
         (is (= :pr/ci-failed (:event/type (:event result))))))))
 
-(deftest poll-ci-status-failed-event-includes-check-names-test
+(deftest ^{:stratum 0} poll-ci-status-failed-event-includes-check-names-test
   (testing "Failed event logs mention the names of failed checks"
     (with-redefs [ci/get-pr-checks
                   (fn [_path _pr]
@@ -462,13 +455,12 @@
             "Logs should mention all failed check names")))))
 
 ;------------------------------------------------------------------------------ Retry Logic on Transient Failures
-
-(deftest poll-ci-status-unknown-is-non-terminal-test
+(deftest ^{:stratum 0} poll-ci-status-unknown-is-non-terminal-test
   (testing ":unknown from transient failure is non-terminal, allowing retry"
     (is (not (contains? ci/terminal-statuses :unknown))
         ":unknown must not be terminal so monitor continues polling")))
 
-(deftest run-ci-monitor-retry-on-transient-failure-test
+(deftest ^{:stratum 0} run-ci-monitor-retry-on-transient-failure-test
   (testing "Monitor retries after transient failures and eventually succeeds"
     (let [call-count (atom 0)
           monitor (ci/create-ci-monitor
@@ -489,7 +481,7 @@
           (is (>= @call-count 3)
               "Should have polled at least 3 times (2 failures + 1 success)"))))))
 
-(deftest run-ci-monitor-retry-mixed-failures-then-real-failure-test
+(deftest ^{:stratum 0} run-ci-monitor-retry-mixed-failures-then-real-failure-test
   (testing "Monitor retries transient errors but stops at genuine CI failure"
     (let [call-count (atom 0)
           monitor (ci/create-ci-monitor
@@ -510,8 +502,7 @@
           (is (>= @call-count 3)))))))
 
 ;------------------------------------------------------------------------------ Timeout Handling
-
-(deftest run-ci-monitor-timeout-with-pending-checks-test
+(deftest ^{:stratum 0} run-ci-monitor-timeout-with-pending-checks-test
   (testing "Monitor times out when checks stay pending indefinitely"
     (let [monitor (ci/create-ci-monitor
                     (random-uuid) (random-uuid) (random-uuid) 42 "/tmp/repo"
@@ -526,7 +517,7 @@
           (is (false? (:running? @monitor))
               "Monitor should be stopped after timeout"))))))
 
-(deftest run-ci-monitor-timeout-with-persistent-errors-test
+(deftest ^{:stratum 0} run-ci-monitor-timeout-with-persistent-errors-test
   (testing "Monitor times out when gh command keeps failing"
     (let [monitor (ci/create-ci-monitor
                     (random-uuid) (random-uuid) (random-uuid) 42 "/tmp/repo"
@@ -539,7 +530,7 @@
           (is (= :timed-out (:status result)))
           (is (true? (:timeout result))))))))
 
-(deftest run-ci-monitor-timeout-sets-monitor-status-test
+(deftest ^{:stratum 0} run-ci-monitor-timeout-sets-monitor-status-test
   (testing "Timeout sets monitor atom status to :timed-out"
     (let [monitor (ci/create-ci-monitor
                     (random-uuid) (random-uuid) (random-uuid) 42 "/tmp/repo"
@@ -552,8 +543,7 @@
         (is (= :timed-out (:status @monitor)))))))
 
 ;------------------------------------------------------------------------------ run-ci-monitor: Successful Completion
-
-(deftest run-ci-monitor-success-completes-immediately-test
+(deftest ^{:stratum 0} run-ci-monitor-success-completes-immediately-test
   (testing "Monitor completes immediately when first poll shows success"
     (let [monitor (ci/create-ci-monitor
                     (random-uuid) (random-uuid) (random-uuid) 42 "/tmp/repo"
@@ -566,7 +556,7 @@
           (is (response/success? result))
           (is (false? (:running? @monitor))))))))
 
-(deftest run-ci-monitor-failure-completes-immediately-test
+(deftest ^{:stratum 0} run-ci-monitor-failure-completes-immediately-test
   (testing "Monitor completes immediately when first poll shows failure"
     (let [monitor (ci/create-ci-monitor
                     (random-uuid) (random-uuid) (random-uuid) 42 "/tmp/repo"
@@ -580,8 +570,7 @@
           (is (false? (:running? @monitor))))))))
 
 ;------------------------------------------------------------------------------ run-ci-monitor: Callbacks
-
-(deftest run-ci-monitor-on-poll-callback-test
+(deftest ^{:stratum 0} run-ci-monitor-on-poll-callback-test
   (testing "on-poll callback is invoked for each poll cycle"
     (let [poll-results (atom [])
           call-count (atom 0)
@@ -602,7 +591,7 @@
         (is (response/success? (last @poll-results))
             "Last poll result should be the terminal one")))))
 
-(deftest run-ci-monitor-on-complete-callback-test
+(deftest ^{:stratum 0} run-ci-monitor-on-complete-callback-test
   (testing "on-complete callback is invoked with final result"
     (let [complete-result (atom nil)
           monitor (ci/create-ci-monitor
@@ -618,8 +607,7 @@
         (is (response/success? @complete-result))))))
 
 ;------------------------------------------------------------------------------ run-ci-monitor: Event Bus Integration
-
-(deftest run-ci-monitor-publishes-event-to-bus-test
+(deftest ^{:stratum 0} run-ci-monitor-publishes-event-to-bus-test
   (testing "Terminal status event is published to the event bus"
     (let [bus (events/create-event-bus)
           monitor (ci/create-ci-monitor
@@ -634,7 +622,7 @@
         (is (= 1 (count (:events @bus))))
         (is (= :pr/ci-passed (:event/type (first (:events @bus)))))))))
 
-(deftest run-ci-monitor-publishes-failure-event-to-bus-test
+(deftest ^{:stratum 0} run-ci-monitor-publishes-failure-event-to-bus-test
   (testing "CI failure event is published to the event bus"
     (let [bus (events/create-event-bus)
           monitor (ci/create-ci-monitor
@@ -649,7 +637,7 @@
         (is (= 1 (count (:events @bus))))
         (is (= :pr/ci-failed (:event/type (first (:events @bus)))))))))
 
-(deftest run-ci-monitor-no-event-published-on-timeout-test
+(deftest ^{:stratum 0} run-ci-monitor-no-event-published-on-timeout-test
   (testing "No terminal event is published when monitor times out"
     (let [bus (events/create-event-bus)
           monitor (ci/create-ci-monitor
@@ -665,8 +653,7 @@
             "No events should be published for non-terminal poll results")))))
 
 ;------------------------------------------------------------------------------ run-ci-monitor: Started-at & Running State
-
-(deftest run-ci-monitor-sets-started-at-test
+(deftest ^{:stratum 0} run-ci-monitor-sets-started-at-test
   (testing "run-ci-monitor sets :started-at timestamp"
     (let [monitor (ci/create-ci-monitor
                     (random-uuid) (random-uuid) (random-uuid) 42 "/tmp/repo"
@@ -679,7 +666,7 @@
         (ci/run-ci-monitor monitor nil)
         (is (inst? (:started-at @monitor)))))))
 
-(deftest run-ci-monitor-running-false-after-completion-test
+(deftest ^{:stratum 0} run-ci-monitor-running-false-after-completion-test
   (testing "Monitor is not running after completion"
     (let [monitor (ci/create-ci-monitor
                     (random-uuid) (random-uuid) (random-uuid) 42 "/tmp/repo"
@@ -692,8 +679,7 @@
         (is (false? (:running? @monitor)))))))
 
 ;------------------------------------------------------------------------------ get-check-logs
-
-(deftest get-check-logs-returns-nil-logs-test
+(deftest ^{:stratum 0} get-check-logs-returns-nil-logs-test
   (testing "get-check-logs returns ok with nil logs (stub implementation)"
     (let [result (ci/get-check-logs "/tmp" 42 "tests")]
       (is (dag/ok? result))
@@ -701,8 +687,7 @@
       (is (= "tests" (:check-name (:data result)))))))
 
 ;------------------------------------------------------------------------------ get-pr-status
-
-(deftest get-pr-status-success-test
+(deftest ^{:stratum 0} get-pr-status-success-test
   (testing "get-pr-status returns raw output on success"
     (let [json-output "{\"state\":\"OPEN\",\"mergeable\":\"MERGEABLE\"}"]
       (with-redefs [ci/run-gh-command
@@ -712,7 +697,7 @@
           (is (dag/ok? result))
           (is (= json-output (:raw (:data result)))))))))
 
-(deftest get-pr-status-failure-test
+(deftest ^{:stratum 0} get-pr-status-failure-test
   (testing "get-pr-status propagates error on failure"
     (with-redefs [ci/run-gh-command
                   (fn [_args _path]

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/classifier_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/classifier_test.clj
@@ -15,16 +15,15 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.classifier-test
   (:require
    [ai.miniforge.pr-lifecycle.classifier :as sut]
    [clojure.test :refer [deftest is testing]]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Classifier tests
 
-(deftest classify-comment-test
+;; Classifier tests
+(deftest ^{:stratum 0} classify-comment-test
   (testing "filters self comments as noise"
     (is (= {:category :noise
             :confidence :high
@@ -53,7 +52,7 @@
                                               :generate-fn (fn [_] "not-a-category"))
                         [:category :confidence :method])))))
 
-(deftest classify-comments-batch-test
+(deftest ^{:stratum 0} classify-comments-batch-test
   (testing "groups comments by category and reports stats"
     (let [result (sut/classify-comments
                   [{:body "Please add tests" :author "alice"}

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/conflict_resolution_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/conflict_resolution_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.conflict-resolution-test
   "Stage 3 slices 3a + 3b + 3c: tests for the pure-data classifiers,
    the conflict-input builder, the git-plumbing probes, and the
@@ -30,9 +29,10 @@
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]))
 
-;------------------------------------------------------------------------------ Test data
+;------------------------------------------------------------------------------ Layer 0
 
-(def ^:private sample-pr
+;------------------------------------------------------------------------------ Test data
+(def ^{:stratum 0} ^:private sample-pr
   {:pr/id        123
    :pr/branch    "feat/widget"
    :pr/base      "main"
@@ -40,8 +40,7 @@
    :pr/base-sha  "def5678cafebabe"})
 
 ;------------------------------------------------------------------------------ classify-merge-state
-
-(deftest classify-merge-state-recognizes-conflicting-test
+(deftest ^{:stratum 0} classify-merge-state-recognizes-conflicting-test
   (testing "GitHub mergeable=CONFLICTING and/or mergeStateStatus=DIRTY
             classify as :conflicting — the only signals the §6.4
             hook should auto-engage on."
@@ -53,14 +52,14 @@
             "{\"mergeable\":\"UNKNOWN\",\"mergeStateStatus\":\"DIRTY\"}"))
         "DIRTY alone is enough — GitHub flags conflicts that way")))
 
-(deftest classify-merge-state-recognizes-mergeable-test
+(deftest ^{:stratum 0} classify-merge-state-recognizes-mergeable-test
   (testing "Clean mergeable PRs classify as :mergeable so the
             caller's auto-engage check short-circuits."
     (is (= :mergeable
            (sut/classify-merge-state
             "{\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\"}")))))
 
-(deftest classify-merge-state-defaults-to-unknown-test
+(deftest ^{:stratum 0} classify-merge-state-defaults-to-unknown-test
   (testing "Anything we can't confidently classify falls into
             :unknown. Nil / blank / weird payloads must not auto-
             trigger resolution — the caller polls or surfaces
@@ -73,9 +72,19 @@
             "{\"mergeable\":\"UNKNOWN\",\"mergeStateStatus\":\"PENDING\"}"))
         "GitHub still computing → :unknown, not :mergeable")))
 
-;------------------------------------------------------------------------------ build-pr-conflict-input
+;------------------------------------------------------------------------------ extract-conflict-paths (real git fixture)
+(defn- ^{:stratum 0} run-git! [cwd & args]
+  (let [r (apply shell/sh "git" "-C" cwd args)]
+    (when-not (zero? (:exit r))
+      (throw (ex-info (str "git " (str/join " " args) " failed: "
+                           (:err r))
+                      {:cwd cwd :result r})))
+    r))
 
-(deftest build-pr-conflict-input-shape-test
+;------------------------------------------------------------------------------ Layer 1
+
+;------------------------------------------------------------------------------ build-pr-conflict-input
+(deftest ^{:stratum 1} build-pr-conflict-input-shape-test
   (testing "Two-parent shape per spec §6.4: PR branch first (order 0),
             base second (order 1). Order is fixed so replays produce
             the same input-key. Conflicts carry the placeholder
@@ -102,7 +111,7 @@
       (is (= ["src/conflict.txt" "src/other.clj"]
              (mapv :path (:merge/conflicts input)))))))
 
-(deftest build-pr-conflict-input-empty-paths-test
+(deftest ^{:stratum 1} build-pr-conflict-input-empty-paths-test
   (testing "Zero conflict paths still produces a valid shape with
             an empty :merge/conflicts vector. Caller's no-conflicts
             check is what prevents the dead-end resolution
@@ -110,17 +119,7 @@
     (let [input (sut/build-pr-conflict-input sample-pr [])]
       (is (= [] (:merge/conflicts input))))))
 
-;------------------------------------------------------------------------------ extract-conflict-paths (real git fixture)
-
-(defn- run-git! [cwd & args]
-  (let [r (apply shell/sh "git" "-C" cwd args)]
-    (when-not (zero? (:exit r))
-      (throw (ex-info (str "git " (str/join " " args) " failed: "
-                           (:err r))
-                      {:cwd cwd :result r})))
-    r))
-
-(defn- temp-conflict-repo!
+(defn- ^{:stratum 1} temp-conflict-repo!
   "Set up a real repo with an induced conflict between two branches.
    Returns the repo path; caller deletes when done."
   []
@@ -148,20 +147,7 @@
               "fixture expected merge to conflict"))
     repo))
 
-(deftest extract-conflict-paths-returns-unmerged-paths-test
-  (testing "extract-conflict-paths reads `git diff --name-only
-            --diff-filter=U` so an unmerged index surfaces as a
-            vector of relative paths. Real-git fixture rather than
-            a mock — the filter behaviour is git's, not ours, so a
-            mock would just re-encode our own assumption."
-    (let [repo (temp-conflict-repo!)]
-      (try
-        (let [r (sut/extract-conflict-paths repo)]
-          (is (dag/ok? r))
-          (is (= ["conflict.txt"] (:data r))))
-        (finally (fs/delete-tree repo))))))
-
-(deftest extract-conflict-paths-empty-when-no-conflicts-test
+(deftest ^{:stratum 1} extract-conflict-paths-empty-when-no-conflicts-test
   (testing "Clean worktree → empty vector, not nil. Caller branches
             on (empty? paths) and would mis-handle nil."
     (let [repo (str (fs/create-temp-dir {:prefix "pr-clean-test-"}))]
@@ -179,8 +165,7 @@
         (finally (fs/delete-tree repo))))))
 
 ;------------------------------------------------------------------------------ rev-parse + push-resolution! (push mocked — no remote)
-
-(deftest rev-parse-resolves-head-test
+(deftest ^{:stratum 1} rev-parse-resolves-head-test
   (testing "rev-parse against HEAD on a fresh init+commit returns
             the 40-char commit SHA via dag/ok."
     (let [repo (str (fs/create-temp-dir {:prefix "pr-rev-test-"}))]
@@ -198,7 +183,7 @@
               "rev-parse returns full SHA"))
         (finally (fs/delete-tree repo))))))
 
-(deftest push-resolution-surfaces-failure-when-no-remote-test
+(deftest ^{:stratum 1} push-resolution-surfaces-failure-when-no-remote-test
   (testing "push-resolution! against a repo with no `origin` remote
             surfaces git's failure as a dag/err with :command-failed.
             Without this, an unconfigured remote would silently
@@ -218,9 +203,54 @@
           (is (= :command-failed (:code (:error r)))))
         (finally (fs/delete-tree repo))))))
 
-;------------------------------------------------------------------------------ resolve-pr-conflicts! (orchestrator)
+(deftest ^{:stratum 1} resolve-pr-conflicts-no-conflicts-detected-test
+  (testing "If extract-conflict-paths comes back empty (caller
+            staged the wrong worktree, or git already cleaned the
+            markers), resolve-pr-conflicts! short-circuits with a
+            clear dag/err rather than handing an empty conflict-
+            input to the resolver — that would fail downstream
+            with a less helpful message."
+    (let [repo (str (fs/create-temp-dir {:prefix "pr-empty-test-"}))]
+      (try
+        (run-git! repo "init" "-b" "main")
+        (run-git! repo "config" "user.email" "t@t")
+        (run-git! repo "config" "user.name" "t")
+        (run-git! repo "config" "commit.gpgsign" "false")
+        (spit (str repo "/x.txt") "x\n")
+        (run-git! repo "add" "x.txt")
+        (run-git! repo "commit" "-m" "x")
+        (let [resolve-called? (atom false)
+              r (sut/resolve-pr-conflicts!
+                 {:worktree-path repo
+                  :pr            sample-pr
+                  :resolve-fn    (fn [_]
+                                   (reset! resolve-called? true)
+                                   (dag/ok {}))
+                  :context       {}})]
+          (is (dag/err? r))
+          (is (= :no-conflicts-detected (:code (:error r))))
+          (is (false? @resolve-called?)
+              "the injected resolver was not called — short-circuit
+               happened before the dead-end invocation"))
+        (finally (fs/delete-tree repo))))))
 
-(deftest resolve-pr-conflicts-happy-path-test
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} extract-conflict-paths-returns-unmerged-paths-test
+  (testing "extract-conflict-paths reads `git diff --name-only
+            --diff-filter=U` so an unmerged index surfaces as a
+            vector of relative paths. Real-git fixture rather than
+            a mock — the filter behaviour is git's, not ours, so a
+            mock would just re-encode our own assumption."
+    (let [repo (temp-conflict-repo!)]
+      (try
+        (let [r (sut/extract-conflict-paths repo)]
+          (is (dag/ok? r))
+          (is (= ["conflict.txt"] (:data r))))
+        (finally (fs/delete-tree repo))))))
+
+;------------------------------------------------------------------------------ resolve-pr-conflicts! (orchestrator)
+(deftest ^{:stratum 2} resolve-pr-conflicts-happy-path-test
   (testing "End-to-end on a real conflicted worktree with an injected
             resolve-fn that simulates the merge-resolution sub-
             workflow's success contract: writes a clean file, commits,
@@ -258,7 +288,7 @@
             (is (= "feat/widget" (:pr-branch (:data r)))))
           (finally (fs/delete-tree repo)))))))
 
-(deftest resolve-pr-conflicts-forwards-resolver-keys-test
+(deftest ^{:stratum 2} resolve-pr-conflicts-forwards-resolver-keys-test
   (testing "resolve-pr-conflicts! must hand the resolver exactly the
             keys workflow.merge-resolution/resolve-conflict!
             destructures: :conflict-input, :host-repo,
@@ -299,38 +329,7 @@
             (is (some? (:conflict-input opts))))
           (finally (fs/delete-tree repo)))))))
 
-(deftest resolve-pr-conflicts-no-conflicts-detected-test
-  (testing "If extract-conflict-paths comes back empty (caller
-            staged the wrong worktree, or git already cleaned the
-            markers), resolve-pr-conflicts! short-circuits with a
-            clear dag/err rather than handing an empty conflict-
-            input to the resolver — that would fail downstream
-            with a less helpful message."
-    (let [repo (str (fs/create-temp-dir {:prefix "pr-empty-test-"}))]
-      (try
-        (run-git! repo "init" "-b" "main")
-        (run-git! repo "config" "user.email" "t@t")
-        (run-git! repo "config" "user.name" "t")
-        (run-git! repo "config" "commit.gpgsign" "false")
-        (spit (str repo "/x.txt") "x\n")
-        (run-git! repo "add" "x.txt")
-        (run-git! repo "commit" "-m" "x")
-        (let [resolve-called? (atom false)
-              r (sut/resolve-pr-conflicts!
-                 {:worktree-path repo
-                  :pr            sample-pr
-                  :resolve-fn    (fn [_]
-                                   (reset! resolve-called? true)
-                                   (dag/ok {}))
-                  :context       {}})]
-          (is (dag/err? r))
-          (is (= :no-conflicts-detected (:code (:error r))))
-          (is (false? @resolve-called?)
-              "the injected resolver was not called — short-circuit
-               happened before the dead-end invocation"))
-        (finally (fs/delete-tree repo))))))
-
-(deftest resolve-pr-conflicts-passes-unresolvable-anomaly-through-test
+(deftest ^{:stratum 2} resolve-pr-conflicts-passes-unresolvable-anomaly-through-test
   (testing "When the injected resolver returns the
             :dag-multi-parent-unresolvable terminal anomaly,
             resolve-pr-conflicts! passes it through unchanged so

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/controller_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/controller_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.controller-test
   "Unit tests for the PR lifecycle controller state machine.
 
@@ -36,40 +35,41 @@
    [ai.miniforge.release-executor.interface :as release]
    [ai.miniforge.schema.interface :as schema]))
 
-;------------------------------------------------------------------------------ Test Data
+;------------------------------------------------------------------------------ Layer 0
 
-(def test-task
+;------------------------------------------------------------------------------ Test Data
+(def ^{:stratum 0} test-task
   {:task/id "task-abc"
    :task/title "Implement feature X"
    :task/description "Add the feature"
    :task/acceptance-criteria ["Tests pass" "No lint errors"]
    :task/constraints ["No breaking changes"]})
 
-(defn- max-fix-iterations-exceeded-pattern
+(defn- ^{:stratum 0} max-fix-iterations-exceeded-pattern
   []
   (re-pattern
    (java.util.regex.Pattern/quote
     (messages/t :controller/max-fix-iterations-exceeded))))
 
-(defn- release-success
+(defn- ^{:stratum 0} release-success
   [data]
   (merge {:success? true} data))
 
-(defn- release-failure
+(defn- ^{:stratum 0} release-failure
   [error]
   {:success? false
    :error error})
 
-(defn- fix-success
+(defn- ^{:stratum 0} fix-success
   [data]
   (merge {:success? true} data))
 
-(defn- fix-failure
+(defn- ^{:stratum 0} fix-failure
   [reason]
   {:success? false
    :reason reason})
 
-(defn- pr-info
+(defn- ^{:stratum 0} pr-info
   "Factory for the `pr-lifecycle` PR-info map stored on `(:pr @controller)`.
    Defaults exercise the fix-loop's expected shape (id/branch/head-sha);
    pass overrides to vary individual fields per test."
@@ -79,23 +79,24 @@
           :pr/head-sha "abc"}
          overrides))
 
-(defn make-event-collector
+(defn ^{:stratum 0} make-event-collector
   "Create a minimal event bus that collects published events."
   []
   (let [events (atom [])]
     {:publish! (fn [event] (swap! events conj event) nil)
      :events events}))
 
-(defn transition-error-data
+(defn ^{:stratum 0} transition-error-data
   "Return anomaly data for an invalid controller status transition."
   [controller target-status]
   (let [result (controller/update-status! controller target-status)]
     (when (anomaly/anomaly? result)
       (:anomaly/data result))))
 
-;------------------------------------------------------------------------------ Controller Creation
+;------------------------------------------------------------------------------ Layer 1
 
-(deftest create-controller-initial-state-test
+;------------------------------------------------------------------------------ Controller Creation
+(deftest ^{:stratum 1} create-controller-initial-state-test
   (testing "Controller initializes with :pending status"
     (let [ctrl (controller/create-controller
                  "dag-1" "run-1" "task-1" test-task
@@ -108,7 +109,7 @@
       (is (inst? (:created-at @ctrl)))
       (is (inst? (:updated-at @ctrl))))))
 
-(deftest create-controller-ids-test
+(deftest ^{:stratum 1} create-controller-ids-test
   (testing "Controller stores DAG/run/task IDs"
     (let [ctrl (controller/create-controller
                  "dag-1" "run-1" "task-1" test-task
@@ -118,14 +119,14 @@
       (is (= "task-1" (:task/id @ctrl)))
       (is (uuid? (:controller/id @ctrl))))))
 
-(deftest create-controller-stores-task-test
+(deftest ^{:stratum 1} create-controller-stores-task-test
   (testing "Controller stores the task definition"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task
                  :worktree-path "/tmp")]
       (is (= test-task (:task @ctrl))))))
 
-(deftest create-controller-default-config-test
+(deftest ^{:stratum 1} create-controller-default-config-test
   (testing "Controller uses default configuration values"
     (let [defaults (controller-config/controller-defaults)
           ctrl (controller/create-controller
@@ -144,7 +145,7 @@
       (is (= (:branch-name-prefix defaults)
              (get-in @ctrl [:config :branch-name-prefix]))))))
 
-(deftest create-controller-custom-config-test
+(deftest ^{:stratum 1} create-controller-custom-config-test
   (testing "Controller accepts custom configuration"
     (let [custom-policy {:method :rebase :require-ci-green? false}
           ctrl (controller/create-controller
@@ -164,7 +165,7 @@
       (is (= (:branch-name-prefix (controller-config/controller-defaults))
              (get-in @ctrl [:config :branch-name-prefix]))))))
 
-(deftest create-controller-nil-options-preserve-defaults-test
+(deftest ^{:stratum 1} create-controller-nil-options-preserve-defaults-test
   (testing "Nil options do not overwrite configured defaults"
     (let [defaults (controller-config/controller-defaults)
           ctrl (controller/create-controller
@@ -180,7 +181,7 @@
       (is (= (:auto-resolve-comments defaults)
              (get-in @ctrl [:config :auto-resolve-comments]))))))
 
-(deftest create-controller-with-dependencies-test
+(deftest ^{:stratum 1} create-controller-with-dependencies-test
   (testing "Controller stores event-bus, logger, generate-fn"
     (let [bus (make-event-collector)
           gen-fn (fn [& _] nil)
@@ -193,15 +194,14 @@
       (is (= gen-fn (:generate-fn @ctrl))))))
 
 ;------------------------------------------------------------------------------ Config Validation
-
-(deftest create-controller-nil-worktree-path-test
+(deftest ^{:stratum 1} create-controller-nil-worktree-path-test
   (testing "Controller accepts nil worktree-path (stored as nil in config)"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task)]
       (is (nil? (get-in @ctrl [:config :worktree-path])))
       (is (= :pending (:status @ctrl))))))
 
-(deftest create-controller-merge-policy-validation-test
+(deftest ^{:stratum 1} create-controller-merge-policy-validation-test
   (testing "Custom merge policy is stored verbatim without defaults merging"
     (let [partial-policy {:method :rebase}
           ctrl (controller/create-controller
@@ -212,7 +212,7 @@
       (is (nil? (get-in @ctrl [:config :merge-policy :require-ci-green?]))
           "Partial policy should not be merged with defaults"))))
 
-(deftest create-controller-zero-max-iterations-test
+(deftest ^{:stratum 1} create-controller-zero-max-iterations-test
   (testing "Controller allows zero max-fix-iterations"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task
@@ -220,7 +220,7 @@
                  :max-fix-iterations 0)]
       (is (= 0 (get-in @ctrl [:config :max-fix-iterations]))))))
 
-(deftest create-controller-config-keys-complete-test
+(deftest ^{:stratum 1} create-controller-config-keys-complete-test
   (testing "Config map contains exactly the expected keys"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task
@@ -231,15 +231,14 @@
              (set (keys (:config @ctrl))))))))
 
 ;------------------------------------------------------------------------------ State Machine Transitions via update-status!
-
-(deftest update-status-returns-new-status-test
+(deftest ^{:stratum 1} update-status-returns-new-status-test
   (testing "update-status! returns the new status value"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task
                  :worktree-path "/tmp")]
       (is (= :creating-pr (controller/update-status! ctrl :creating-pr))))))
 
-(deftest update-status-updates-timestamp-test
+(deftest ^{:stratum 1} update-status-updates-timestamp-test
   (testing "update-status! updates the :updated-at timestamp"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task
@@ -254,7 +253,7 @@
           (is (not= before-ts after-ts))
           (is (.after ^java.util.Date after-ts ^java.util.Date before-ts)))))))
 
-(deftest state-machine-full-happy-path-test
+(deftest ^{:stratum 1} state-machine-full-happy-path-test
   (testing "State transitions through the full happy path: pending -> creating-pr -> monitoring-ci -> monitoring-review -> ready-to-merge -> merging -> merged"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task
@@ -277,7 +276,7 @@
       (controller/update-status! ctrl :merged)
       (is (= :merged (:status @ctrl))))))
 
-(deftest state-machine-ci-failure-fix-loop-test
+(deftest ^{:stratum 1} state-machine-ci-failure-fix-loop-test
   (testing "State transitions through CI failure/fix loop: pending -> creating-pr -> monitoring-ci -> fixing -> monitoring-ci -> monitoring-review -> merged"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task
@@ -309,7 +308,7 @@
       (controller/update-status! ctrl :merged)
       (is (= :merged (:status @ctrl))))))
 
-(deftest state-machine-review-changes-requested-loop-test
+(deftest ^{:stratum 1} state-machine-review-changes-requested-loop-test
   (testing "State transitions through review changes requested loop"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task
@@ -335,7 +334,7 @@
       (controller/update-status! ctrl :merged)
       (is (= :merged (:status @ctrl))))))
 
-(deftest state-machine-failure-terminal-test
+(deftest ^{:stratum 1} state-machine-failure-terminal-test
   (testing ":failed is a terminal state - controller records failure"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task
@@ -345,8 +344,7 @@
       (is (= :failed (:status @ctrl))))))
 
 ;------------------------------------------------------------------------------ Invalid / Unexpected State Transitions
-
-(deftest invalid-status-value-rejected-test
+(deftest ^{:stratum 1} invalid-status-value-rejected-test
   (testing "Controller rejects unknown statuses and preserves the current state"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task
@@ -355,7 +353,7 @@
       (is (= :invalid-target-status (:error error-data)))
       (is (= :pending (:status @ctrl))))))
 
-(deftest backward-transition-rejected-test
+(deftest ^{:stratum 1} backward-transition-rejected-test
   (testing "Controller rejects backward transitions that are outside the FSM"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task
@@ -367,7 +365,7 @@
       (is (= #{:monitoring-ci :monitoring-review :fixing :failed}
              (:valid-targets error-data))))))
 
-(deftest transition-from-terminal-state-rejected-test
+(deftest ^{:stratum 1} transition-from-terminal-state-rejected-test
   (testing "Transitioning away from :merged is rejected"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task
@@ -381,7 +379,7 @@
         (is (= :terminal-state (:error error-data)))
         (is (= :merged (:status @ctrl)))))))
 
-(deftest transition-from-failed-state-rejected-test
+(deftest ^{:stratum 1} transition-from-failed-state-rejected-test
   (testing "Transitioning away from :failed is rejected"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task
@@ -391,7 +389,7 @@
         (is (= :terminal-state (:error error-data)))
         (is (= :failed (:status @ctrl)))))))
 
-(deftest idempotent-transition-remains-valid-test
+(deftest ^{:stratum 1} idempotent-transition-remains-valid-test
   (testing "Controller allows same-state transitions for idempotent status updates"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task
@@ -401,8 +399,7 @@
       (is (= :monitoring-ci (:status @ctrl))))))
 
 ;------------------------------------------------------------------------------ add-history! Function
-
-(deftest add-history-appends-event-test
+(deftest ^{:stratum 1} add-history-appends-event-test
   (testing "add-history! appends an event with type, data, and timestamp"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task
@@ -414,14 +411,14 @@
         (is (= {:pr-id 42} (:data event)))
         (is (inst? (:timestamp event)))))))
 
-(deftest add-history-returns-nil-test
+(deftest ^{:stratum 1} add-history-returns-nil-test
   (testing "add-history! returns nil"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task
                  :worktree-path "/tmp")]
       (is (nil? (controller/add-history! ctrl :test-event {}))))))
 
-(deftest add-history-preserves-order-test
+(deftest ^{:stratum 1} add-history-preserves-order-test
   (testing "add-history! preserves chronological order"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task
@@ -433,8 +430,7 @@
              (mapv :type (:history @ctrl)))))))
 
 ;------------------------------------------------------------------------------ Fix Iteration Enforcement
-
-(deftest handle-ci-failure-max-iterations-test
+(deftest ^{:stratum 1} handle-ci-failure-max-iterations-test
   (testing "handle-ci-failure! returns anomaly when max iterations exceeded"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task
@@ -448,7 +444,7 @@
         (is (re-find (max-fix-iterations-exceeded-pattern)
                      (:anomaly/message result)))))))
 
-(deftest handle-review-feedback-max-iterations-test
+(deftest ^{:stratum 1} handle-review-feedback-max-iterations-test
   (testing "handle-review-feedback! returns anomaly when max iterations exceeded"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task
@@ -461,7 +457,7 @@
         (is (re-find (max-fix-iterations-exceeded-pattern)
                      (:anomaly/message result)))))))
 
-(deftest handle-ci-failure-increments-iteration-before-max-test
+(deftest ^{:stratum 1} handle-ci-failure-increments-iteration-before-max-test
   (testing "handle-ci-failure! transitions to :fixing and increments counter"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task
@@ -484,7 +480,7 @@
       (is (= :fixing (:status @ctrl)))
       (is (= 1 (:fix-iterations @ctrl))))))
 
-(deftest handle-ci-failure-sets-failed-on-max-test
+(deftest ^{:stratum 1} handle-ci-failure-sets-failed-on-max-test
   (testing "handle-ci-failure! sets :failed status when at max"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task
@@ -494,7 +490,7 @@
       (controller/handle-ci-failure! ctrl "logs")
       (is (= :failed (:status @ctrl))))))
 
-(deftest handle-ci-failure-records-history-on-max-exceeded-test
+(deftest ^{:stratum 1} handle-ci-failure-records-history-on-max-exceeded-test
   (testing "handle-ci-failure! records :max-fix-iterations-exceeded in history"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task
@@ -504,7 +500,7 @@
       (controller/handle-ci-failure! ctrl "logs")
       (is (some #(= :max-fix-iterations-exceeded (:type %)) (:history @ctrl))))))
 
-(deftest handle-ci-failure-zero-max-iterations-test
+(deftest ^{:stratum 1} handle-ci-failure-zero-max-iterations-test
   (testing "handle-ci-failure! immediately returns anomaly when max-fix-iterations is 0"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task
@@ -516,7 +512,7 @@
       (is (re-find (max-fix-iterations-exceeded-pattern)
                    (:anomaly/message result))))))
 
-(deftest handle-ci-failure-records-normalized-result-status-test
+(deftest ^{:stratum 1} handle-ci-failure-records-normalized-result-status-test
   (testing "handle-ci-failure! records normalized result status in history"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task
@@ -532,7 +528,7 @@
         (is (= {:result-status :succeeded}
                (:data (last (:history @ctrl)))))))))
 
-(deftest handle-review-feedback-records-normalized-result-status-test
+(deftest ^{:stratum 1} handle-review-feedback-records-normalized-result-status-test
   (testing "handle-review-feedback! records normalized result status in history"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task
@@ -549,8 +545,7 @@
                (:data (last (:history @ctrl)))))))))
 
 ;------------------------------------------------------------------------------ State Manipulation (via atom)
-
-(deftest controller-status-transitions-test
+(deftest ^{:stratum 1} controller-status-transitions-test
   (testing "Status can be manually transitioned for testing"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task
@@ -572,7 +567,7 @@
       (swap! ctrl assoc :status :merged)
       (is (= :merged (:status @ctrl))))))
 
-(deftest controller-pr-info-storage-test
+(deftest ^{:stratum 1} controller-pr-info-storage-test
   (testing "PR info can be stored and retrieved"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task
@@ -585,7 +580,7 @@
       (is (= 42 (get-in @ctrl [:pr :pr/id])))
       (is (= "feat/bar" (get-in @ctrl [:pr :pr/branch]))))))
 
-(deftest controller-history-accumulation-test
+(deftest ^{:stratum 1} controller-history-accumulation-test
   (testing "History events accumulate correctly"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task
@@ -600,7 +595,7 @@
       (is (= [:pr-created :ci-passed :merged]
              (mapv :type (:history @ctrl)))))))
 
-(deftest controller-fix-iteration-counter-test
+(deftest ^{:stratum 1} controller-fix-iteration-counter-test
   (testing "Fix iteration counter increments correctly"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task
@@ -612,7 +607,7 @@
       (swap! ctrl update :fix-iterations inc)
       (is (= 3 (:fix-iterations @ctrl))))))
 
-(deftest controller-monitors-nil-initially-test
+(deftest ^{:stratum 1} controller-monitors-nil-initially-test
   (testing "CI and review monitors are nil initially"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task
@@ -621,8 +616,7 @@
       (is (nil? (:review-monitor @ctrl))))))
 
 ;------------------------------------------------------------------------------ Extracted PR creation steps
-
-(defn make-controller
+(defn ^{:stratum 1} make-controller
   "Create a test controller with minimal config."
   ([] (make-controller {}))
   ([overrides]
@@ -633,9 +627,10 @@
        (swap! ctrl merge overrides))
      ctrl)))
 
-;; fail-controller!
+;------------------------------------------------------------------------------ Layer 2
 
-(deftest fail-controller-sets-status-and-returns-err
+;; fail-controller!
+(deftest ^{:stratum 2} fail-controller-sets-status-and-returns-err
   (testing "fail-controller! sets :failed status and returns a DAG error"
     (let [ctrl (make-controller)]
       (is (= :pending (:status @ctrl)))
@@ -645,8 +640,7 @@
         (is (= :some-error (get-in result [:error :code])))))))
 
 ;; create-and-checkout-branch!
-
-(deftest create-and-checkout-branch-success
+(deftest ^{:stratum 2} create-and-checkout-branch-success
   (testing "Returns branch result on success"
     (let [ctrl (make-controller)]
       (with-redefs [release/create-branch! (fn [_path _name]
@@ -655,7 +649,7 @@
           (is (schema/succeeded? result))
           (is (= "main" (:base-branch result))))))))
 
-(deftest create-and-checkout-branch-failure
+(deftest ^{:stratum 2} create-and-checkout-branch-failure
   (testing "Returns DAG error on failure and adds history"
     (let [ctrl (make-controller)]
       (with-redefs [release/create-branch! (fn [_path _name]
@@ -665,7 +659,7 @@
           (is (= :failed (:status @ctrl)))
           (is (some #(= :pr-creation-failed (:type %)) (:history @ctrl))))))))
 
-(deftest run-lifecycle-pr-creation-failure-reports-current-status
+(deftest ^{:stratum 2} run-lifecycle-pr-creation-failure-reports-current-status
   (testing "PR creation anomaly result reports the controller's actual status"
     (let [ctrl (make-controller)]
       (with-redefs [release/create-branch! (fn [_path _name]
@@ -676,8 +670,7 @@
           (is (= "PR creation failed" (:error result))))))))
 
 ;; apply-code-to-files!
-
-(deftest apply-code-to-files-success
+(deftest ^{:stratum 2} apply-code-to-files-success
   (testing "Returns apply result on success"
     (let [ctrl (make-controller)]
       (with-redefs [fix/apply-fix-to-worktree (fn [_path _artifact _logger]
@@ -685,7 +678,7 @@
         (let [result (controller/apply-code-to-files! ctrl "/tmp" {:code/files []} nil)]
           (is (= {:applied true} result)))))))
 
-(deftest apply-code-to-files-failure
+(deftest ^{:stratum 2} apply-code-to-files-failure
   (testing "Returns DAG error when fix/apply returns error"
     (let [ctrl (make-controller)]
       (with-redefs [fix/apply-fix-to-worktree (fn [_path _artifact _logger]
@@ -695,8 +688,7 @@
           (is (= :failed (:status @ctrl))))))))
 
 ;; commit-changes!
-
-(deftest commit-changes-success
+(deftest ^{:stratum 2} commit-changes-success
   (testing "Returns commit result on success"
     (let [ctrl (make-controller)
           task-id "task-00000001"]
@@ -706,7 +698,7 @@
           (is (schema/succeeded? result))
           (is (= "abc123" (:commit-sha result))))))))
 
-(deftest commit-changes-failure
+(deftest ^{:stratum 2} commit-changes-failure
   (testing "Returns DAG error on commit failure"
     (let [ctrl (make-controller)]
       (with-redefs [release/commit-changes! (fn [_path _msg]
@@ -715,7 +707,7 @@
           (is (dag/err? result))
           (is (= :failed (:status @ctrl))))))))
 
-(deftest commit-changes-uses-task-title-in-message
+(deftest ^{:stratum 2} commit-changes-uses-task-title-in-message
   (testing "Commit message includes task title"
     (let [ctrl (make-controller)
           captured-msg (atom nil)]
@@ -726,8 +718,7 @@
         (is (.contains @captured-msg "Implement feature X"))))))
 
 ;; push-and-create-pr!
-
-(deftest push-and-create-pr-success
+(deftest ^{:stratum 2} push-and-create-pr-success
   (testing "Returns PR info map on success"
     (let [ctrl (make-controller)]
       (with-redefs [release/push-branch! (fn [_path _branch]
@@ -745,7 +736,7 @@
           (is (= "feat/x" (:pr/branch result)))
           (is (= "abc123" (:pr/head-sha result))))))))
 
-(deftest push-and-create-pr-push-failure
+(deftest ^{:stratum 2} push-and-create-pr-push-failure
   (testing "Returns DAG error when push fails"
     (let [ctrl (make-controller)]
       (with-redefs [release/push-branch! (fn [_path _branch]
@@ -755,7 +746,7 @@
           (is (dag/err? result))
           (is (= :failed (:status @ctrl))))))))
 
-(deftest push-and-create-pr-pr-creation-failure
+(deftest ^{:stratum 2} push-and-create-pr-pr-creation-failure
   (testing "Returns DAG error when PR creation fails"
     (let [ctrl (make-controller)]
       (with-redefs [release/push-branch! (fn [_path _branch]
@@ -766,7 +757,7 @@
                                                       test-task "t-1" {:commit-sha "x"})]
           (is (dag/err? result)))))))
 
-(deftest push-and-create-pr-includes-acceptance-criteria
+(deftest ^{:stratum 2} push-and-create-pr-includes-acceptance-criteria
   (testing "PR body includes acceptance criteria from task"
     (let [ctrl (make-controller)
           captured-opts (atom nil)]
@@ -780,8 +771,7 @@
         (is (.contains (:body @captured-opts) "No lint errors"))))))
 
 ;; finalize-pr-creation!
-
-(deftest finalize-pr-creation-records-pr-and-returns-ok
+(deftest ^{:stratum 2} finalize-pr-creation-records-pr-and-returns-ok
   (testing "Stores PR on controller, adds history, returns dag/ok"
     (let [ctrl (make-controller)
           pr     (pr-info :pr/id 42 :pr/url "url")
@@ -790,7 +780,7 @@
       (is (= 42 (get-in @ctrl [:pr :pr/id])))
       (is (some #(= :pr-created (:type %)) (:history @ctrl))))))
 
-(deftest finalize-pr-creation-publishes-event
+(deftest ^{:stratum 2} finalize-pr-creation-publishes-event
   (testing "Publishes pr-opened event when event-bus is present"
     (let [ctrl (make-controller)
           published (atom [])

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/events_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/events_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.events-test
   "Unit tests for the PR lifecycle event system.
 
@@ -24,9 +23,10 @@
    [clojure.test :refer [deftest testing is are]]
    [ai.miniforge.pr-lifecycle.events :as events]))
 
-;------------------------------------------------------------------------------ Event Types
+;------------------------------------------------------------------------------ Layer 0
 
-(deftest event-types-test
+;------------------------------------------------------------------------------ Event Types
+(deftest ^{:stratum 0} event-types-test
   (testing "All expected event types are defined"
     (is (= 11 (count events/event-types))
         "Should have exactly 11 event types")
@@ -44,12 +44,23 @@
       :pr/fix-pushed)))
 
 ;------------------------------------------------------------------------------ Event Constructors
+(def ^{:stratum 0} dag-id (random-uuid))
 
-(def dag-id (random-uuid))
-(def run-id (random-uuid))
-(def task-id (random-uuid))
+(def ^{:stratum 0} run-id (random-uuid))
 
-(deftest create-event-test
+(def ^{:stratum 0} task-id (random-uuid))
+
+;------------------------------------------------------------------------------ Event Bus
+(deftest ^{:stratum 0} create-event-bus-test
+  (testing "create-event-bus initializes with empty state"
+    (let [bus (events/create-event-bus)]
+      (is (= [] (:events @bus)))
+      (is (= {} (:subscribers @bus)))
+      (is (= {} (:filters @bus))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} create-event-test
   (testing "create-event produces well-formed event with required fields"
     (let [event (events/create-event :pr/opened {:dag/id dag-id :task/id task-id})]
       (is (uuid? (:event/id event))
@@ -66,7 +77,7 @@
       (is (= "data" (:custom event)))
       (is (= 42 (:count event))))))
 
-(deftest pr-opened-constructor-test
+(deftest ^{:stratum 1} pr-opened-constructor-test
   (testing "pr-opened creates event with all PR fields"
     (let [event (events/pr-opened dag-id run-id task-id 123
                                    "https://example.com/pr/123"
@@ -80,40 +91,40 @@
       (is (= "feat/foo" (:pr/branch event)))
       (is (= "abc123" (:pr/sha event))))))
 
-(deftest ci-passed-constructor-test
+(deftest ^{:stratum 1} ci-passed-constructor-test
   (testing "ci-passed creates event with SHA"
     (let [event (events/ci-passed dag-id run-id task-id 123 "abc123")]
       (is (= :pr/ci-passed (:event/type event)))
       (is (= 123 (:pr/id event)))
       (is (= "abc123" (:pr/sha event))))))
 
-(deftest ci-failed-constructor-test
+(deftest ^{:stratum 1} ci-failed-constructor-test
   (testing "ci-failed creates event with logs"
     (let [event (events/ci-failed dag-id run-id task-id 123 "abc123" "FAIL in test-foo")]
       (is (= :pr/ci-failed (:event/type event)))
       (is (= "FAIL in test-foo" (:ci/logs event))))))
 
-(deftest review-approved-constructor-test
+(deftest ^{:stratum 1} review-approved-constructor-test
   (testing "review-approved creates event with approvers"
     (let [event (events/review-approved dag-id run-id task-id 123 ["alice" "bob"])]
       (is (= :pr/review-approved (:event/type event)))
       (is (= ["alice" "bob"] (:review/approvers event))))))
 
-(deftest review-changes-requested-constructor-test
+(deftest ^{:stratum 1} review-changes-requested-constructor-test
   (testing "review-changes-requested creates event with comments"
     (let [comments [{:body "Fix this" :path "src/foo.clj"}]
           event (events/review-changes-requested dag-id run-id task-id 123 comments)]
       (is (= :pr/review-changes-requested (:event/type event)))
       (is (= comments (:review/comments event))))))
 
-(deftest comment-actionable-constructor-test
+(deftest ^{:stratum 1} comment-actionable-constructor-test
   (testing "comment-actionable creates event with comment data"
     (let [comment-data {:body "Please add tests" :author "reviewer"}
           event (events/comment-actionable dag-id run-id task-id 123 comment-data)]
       (is (= :pr/comment-actionable (:event/type event)))
       (is (= comment-data (:comment event))))))
 
-(deftest merged-constructor-test
+(deftest ^{:stratum 1} merged-constructor-test
   (testing "merged creates event with merge SHA"
     (let [event (events/merged dag-id run-id task-id 123 "merge-sha-abc")]
       (is (= :pr/merged (:event/type event)))
@@ -133,42 +144,33 @@
     (let [event (events/merged dag-id run-id task-id 123 "abc" #{"dogfood-fix"})]
       (is (= #{"dogfood-fix"} (:pr/labels event))))))
 
-(deftest closed-constructor-test
+(deftest ^{:stratum 1} closed-constructor-test
   (testing "closed creates event with reason"
     (let [event (events/closed dag-id run-id task-id 123 "superseded")]
       (is (= :pr/closed (:event/type event)))
       (is (= "superseded" (:close/reason event))))))
 
-(deftest rebase-needed-constructor-test
+(deftest ^{:stratum 1} rebase-needed-constructor-test
   (testing "rebase-needed creates event with base SHA"
     (let [event (events/rebase-needed dag-id run-id task-id 123 "base-sha")]
       (is (= :pr/rebase-needed (:event/type event)))
       (is (= "base-sha" (:pr/base-sha event))))))
 
-(deftest conflict-constructor-test
+(deftest ^{:stratum 1} conflict-constructor-test
   (testing "conflict creates event with conflicting files"
     (let [files ["src/a.clj" "src/b.clj"]
           event (events/conflict dag-id run-id task-id 123 files)]
       (is (= :pr/conflict (:event/type event)))
       (is (= files (:conflict/files event))))))
 
-(deftest fix-pushed-constructor-test
+(deftest ^{:stratum 1} fix-pushed-constructor-test
   (testing "fix-pushed creates event with SHA and fix type"
     (let [event (events/fix-pushed dag-id run-id task-id 123 "fix-sha" :ci-fix)]
       (is (= :pr/fix-pushed (:event/type event)))
       (is (= "fix-sha" (:pr/sha event)))
       (is (= :ci-fix (:fix/type event))))))
 
-;------------------------------------------------------------------------------ Event Bus
-
-(deftest create-event-bus-test
-  (testing "create-event-bus initializes with empty state"
-    (let [bus (events/create-event-bus)]
-      (is (= [] (:events @bus)))
-      (is (= {} (:subscribers @bus)))
-      (is (= {} (:filters @bus))))))
-
-(deftest publish-test
+(deftest ^{:stratum 1} publish-test
   (testing "publish! adds event to bus log"
     (let [bus (events/create-event-bus)
           event (events/ci-passed dag-id run-id task-id 123 "sha")]
@@ -200,7 +202,7 @@
           "Only CI event should be delivered")
       (is (= :pr/ci-passed (:event/type (first @received)))))))
 
-(deftest subscribe-test
+(deftest ^{:stratum 1} subscribe-test
   (testing "subscribe! returns subscriber-id"
     (let [bus (events/create-event-bus)
           id (events/subscribe! bus :my-sub identity)]
@@ -214,7 +216,7 @@
       (events/publish! bus (events/merged dag-id run-id task-id 1 "b") nil)
       (is (= 2 @received)))))
 
-(deftest unsubscribe-test
+(deftest ^{:stratum 1} unsubscribe-test
   (testing "unsubscribe! removes subscriber"
     (let [bus (events/create-event-bus)
           received (atom 0)]
@@ -226,7 +228,7 @@
       (is (= 1 @received)
           "Should not receive events after unsubscribe"))))
 
-(deftest publish-callback-error-handling-test
+(deftest ^{:stratum 1} publish-callback-error-handling-test
   (testing "publish! continues and event is logged even if subscriber throws"
     (let [bus (events/create-event-bus)]
       (events/subscribe! bus :thrower (fn [_] (throw (Exception. "boom"))))
@@ -234,8 +236,7 @@
       (is (= 1 (count (:events @bus)))))))
 
 ;------------------------------------------------------------------------------ Event Queries
-
-(deftest events-for-task-test
+(deftest ^{:stratum 1} events-for-task-test
   (testing "events-for-task filters by task ID"
     (let [bus (events/create-event-bus)
           t1 (random-uuid)
@@ -247,7 +248,7 @@
         (is (= 2 (count t1-events)))
         (is (every? #(= t1 (:task/id %)) t1-events))))))
 
-(deftest events-for-pr-test
+(deftest ^{:stratum 1} events-for-pr-test
   (testing "events-for-pr filters by PR ID"
     (let [bus (events/create-event-bus)]
       (events/publish! bus (events/ci-passed dag-id run-id task-id 100 "a") nil)
@@ -257,7 +258,7 @@
         (is (= 2 (count pr100-events)))
         (is (every? #(= 100 (:pr/id %)) pr100-events))))))
 
-(deftest latest-event-test
+(deftest ^{:stratum 1} latest-event-test
   (testing "latest-event returns most recent matching event"
     (let [bus (events/create-event-bus)]
       (events/publish! bus (events/ci-passed dag-id run-id task-id 1 "first") nil)

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/fix_loop_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/fix_loop_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.fix-loop-test
   "Unit tests for fix loop context building and prompt generation.
 
@@ -28,23 +27,89 @@
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.pr-lifecycle.fix-loop :as fix]))
 
-;------------------------------------------------------------------------------ Test Data
+;------------------------------------------------------------------------------ Layer 0
 
-(def test-task
+;------------------------------------------------------------------------------ Test Data
+(def ^{:stratum 0} test-task
   {:task/id (random-uuid)
    :task/title "Implement feature X"
    :task/acceptance-criteria ["Tests pass" "No lint errors"]
    :task/constraints ["No breaking changes"]})
 
-(def test-pr-info
+(def ^{:stratum 0} test-pr-info
   {:pr/id 123
    :pr/url "https://github.com/org/repo/pull/123"
    :pr/branch "feat/feature-x"
    :pr/head-sha "abc123"})
 
-;------------------------------------------------------------------------------ Fix Context Creation
+;------------------------------------------------------------------------------ Prompt Building
+(deftest ^{:stratum 0} build-fix-prompt-ci-failure-test
+  (testing "CI failure prompt includes relevant info"
+    (let [ctx {:fix/task-id (random-uuid)
+               :fix/type :ci-failure
+               :fix/failure-summary "2 test failures"
+               :fix/affected-files #{"src/foo.clj"}
+               :fix/failing-tests ["FAIL in (test-foo)" "FAIL in (test-bar)"]
+               :fix/lint-errors ["src/foo.clj:10: warning"]
+               :fix/build-errors []}
+          prompt (fix/build-fix-prompt ctx)]
+      (is (string? prompt))
+      (is (str/includes? prompt "Fix CI failures"))
+      (is (str/includes? prompt "2 test failures"))
+      (is (str/includes? prompt "FAIL in (test-foo)"))
+      (is (str/includes? prompt "warning")))))
 
-(deftest create-fix-context-ci-failure-test
+(deftest ^{:stratum 0} build-fix-prompt-review-changes-test
+  (testing "Review changes prompt includes requested changes"
+    (let [ctx {:fix/task-id (random-uuid)
+               :fix/type :review-changes
+               :fix/failure-summary "1 change"
+               :fix/affected-files #{}
+               :fix/review-comments [{:file "src/a.clj" :line 10 :change "Fix null check"}]}
+          prompt (fix/build-fix-prompt ctx)]
+      (is (str/includes? prompt "Address review feedback"))
+      (is (str/includes? prompt "Fix null check")))))
+
+(deftest ^{:stratum 0} build-fix-prompt-conflict-test
+  (testing "Conflict prompt mentions conflicting files"
+    (let [ctx {:fix/task-id (random-uuid)
+               :fix/type :conflict
+               :fix/failure-summary "2 conflicts"
+               :fix/affected-files #{"src/a.clj" "src/b.clj"}}
+          prompt (fix/build-fix-prompt ctx)]
+      (is (str/includes? prompt "Resolve merge conflicts"))
+      (is (str/includes? prompt "src/a.clj")))))
+
+(deftest ^{:stratum 0} build-fix-prompt-default-type-test
+  (testing "Unknown fix type produces generic prompt"
+    (let [ctx {:fix/task-id (random-uuid)
+               :fix/type :unknown
+               :fix/failure-summary "something broke"
+               :fix/affected-files #{}}
+          prompt (fix/build-fix-prompt ctx)]
+      (is (str/includes? prompt "Fix issues"))
+      (is (str/includes? prompt "something broke")))))
+
+;------------------------------------------------------------------------------ Resolve Comment Thread (Skip Logic)
+(deftest ^{:stratum 0} resolve-comment-thread-skips-without-metadata-test
+  (testing "Skips resolution when comment-id is missing"
+    (let [ctx {:fix/comment-id nil :fix/parent-pr-number 123}
+          result (fix/resolve-comment-thread "/tmp" ctx 456 nil)]
+      (is (dag/ok? result))
+      (is (true? (:skipped (:data result)))))))
+
+(deftest ^{:stratum 0} resolve-comment-thread-skips-when-disabled-test
+  (testing "Skips resolution when auto-resolve is false"
+    (let [ctx {:fix/comment-id 789 :fix/parent-pr-number 123}
+          result (fix/resolve-comment-thread "/tmp" ctx 456 nil
+                                              :auto-resolve false)]
+      (is (dag/ok? result))
+      (is (true? (:skipped (:data result)))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;------------------------------------------------------------------------------ Fix Context Creation
+(deftest ^{:stratum 1} create-fix-context-ci-failure-test
   (testing "CI failure context has correct structure"
     (let [failure {:type :ci-failure
                    :summary "2 test failures"
@@ -62,7 +127,7 @@
       (is (vector? (:fix/previous-fixes ctx)))
       (is (inst? (:fix/created-at ctx))))))
 
-(deftest create-fix-context-review-changes-test
+(deftest ^{:stratum 1} create-fix-context-review-changes-test
   (testing "Review changes context includes comments"
     (let [comments [{:body "Fix the null check" :path "src/foo.clj"}]
           failure {:type :review-changes
@@ -72,7 +137,7 @@
       (is (= :review-changes (:fix/type ctx)))
       (is (= comments (:fix/review-comments ctx))))))
 
-(deftest create-fix-context-conflict-test
+(deftest ^{:stratum 1} create-fix-context-conflict-test
   (testing "Conflict context includes conflict files"
     (let [failure {:type :conflict
                    :summary "2 files with conflicts"
@@ -81,7 +146,7 @@
       (is (= :conflict (:fix/type ctx)))
       (is (= ["src/a.clj" "src/b.clj"] (:fix/conflict-files ctx))))))
 
-(deftest create-fix-context-with-previous-fixes-test
+(deftest ^{:stratum 1} create-fix-context-with-previous-fixes-test
   (testing "Previous fixes are included in context"
     (let [failure {:type :ci-failure :summary "test failures"}
           prev [{:attempt 1 :error "first try failed"}]
@@ -89,7 +154,7 @@
                                        :previous-fixes prev)]
       (is (= prev (:fix/previous-fixes ctx))))))
 
-(deftest create-fix-context-comment-metadata-test
+(deftest ^{:stratum 1} create-fix-context-comment-metadata-test
   (testing "Comment metadata for conversation resolution"
     (let [failure {:type :review-changes
                    :summary "1 change"
@@ -98,69 +163,3 @@
           ctx (fix/create-fix-context test-task test-pr-info failure)]
       (is (= 456 (:fix/comment-id ctx)))
       (is (= 100 (:fix/parent-pr-number ctx))))))
-
-;------------------------------------------------------------------------------ Prompt Building
-
-(deftest build-fix-prompt-ci-failure-test
-  (testing "CI failure prompt includes relevant info"
-    (let [ctx {:fix/task-id (random-uuid)
-               :fix/type :ci-failure
-               :fix/failure-summary "2 test failures"
-               :fix/affected-files #{"src/foo.clj"}
-               :fix/failing-tests ["FAIL in (test-foo)" "FAIL in (test-bar)"]
-               :fix/lint-errors ["src/foo.clj:10: warning"]
-               :fix/build-errors []}
-          prompt (fix/build-fix-prompt ctx)]
-      (is (string? prompt))
-      (is (str/includes? prompt "Fix CI failures"))
-      (is (str/includes? prompt "2 test failures"))
-      (is (str/includes? prompt "FAIL in (test-foo)"))
-      (is (str/includes? prompt "warning")))))
-
-(deftest build-fix-prompt-review-changes-test
-  (testing "Review changes prompt includes requested changes"
-    (let [ctx {:fix/task-id (random-uuid)
-               :fix/type :review-changes
-               :fix/failure-summary "1 change"
-               :fix/affected-files #{}
-               :fix/review-comments [{:file "src/a.clj" :line 10 :change "Fix null check"}]}
-          prompt (fix/build-fix-prompt ctx)]
-      (is (str/includes? prompt "Address review feedback"))
-      (is (str/includes? prompt "Fix null check")))))
-
-(deftest build-fix-prompt-conflict-test
-  (testing "Conflict prompt mentions conflicting files"
-    (let [ctx {:fix/task-id (random-uuid)
-               :fix/type :conflict
-               :fix/failure-summary "2 conflicts"
-               :fix/affected-files #{"src/a.clj" "src/b.clj"}}
-          prompt (fix/build-fix-prompt ctx)]
-      (is (str/includes? prompt "Resolve merge conflicts"))
-      (is (str/includes? prompt "src/a.clj")))))
-
-(deftest build-fix-prompt-default-type-test
-  (testing "Unknown fix type produces generic prompt"
-    (let [ctx {:fix/task-id (random-uuid)
-               :fix/type :unknown
-               :fix/failure-summary "something broke"
-               :fix/affected-files #{}}
-          prompt (fix/build-fix-prompt ctx)]
-      (is (str/includes? prompt "Fix issues"))
-      (is (str/includes? prompt "something broke")))))
-
-;------------------------------------------------------------------------------ Resolve Comment Thread (Skip Logic)
-
-(deftest resolve-comment-thread-skips-without-metadata-test
-  (testing "Skips resolution when comment-id is missing"
-    (let [ctx {:fix/comment-id nil :fix/parent-pr-number 123}
-          result (fix/resolve-comment-thread "/tmp" ctx 456 nil)]
-      (is (dag/ok? result))
-      (is (true? (:skipped (:data result)))))))
-
-(deftest resolve-comment-thread-skips-when-disabled-test
-  (testing "Skips resolution when auto-resolve is false"
-    (let [ctx {:fix/comment-id 789 :fix/parent-pr-number 123}
-          result (fix/resolve-comment-thread "/tmp" ctx 456 nil
-                                              :auto-resolve false)]
-      (is (dag/ok? result))
-      (is (true? (:skipped (:data result)))))))

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/fsm_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/fsm_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.fsm-test
   "Unit tests for the PR lifecycle controller FSM."
   (:require
@@ -25,17 +24,33 @@
    [ai.miniforge.schema.interface :as schema]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Test helpers
 
-(defn- transition-result
+;; Test helpers
+(defn- ^{:stratum 0} transition-result
   "Apply a controller FSM transition and return the result map."
   [from-status to-status]
   (sut/transition from-status to-status))
 
-;------------------------------------------------------------------------------ Layer 1
-;; FSM validation
+(deftest ^{:stratum 0} valid-transition-predicate-test
+  (testing "valid-transition? requires recognized statuses"
+    (is (true? (sut/valid-transition? :monitoring-ci :monitoring-ci)))
+    (is (true? (sut/valid-transition? :monitoring-ci :monitoring-review)))
+    (is (false? (sut/valid-transition? :bogus-status :bogus-status)))
+    (is (false? (sut/valid-transition? :bogus-status :creating-pr)))))
 
-(deftest valid-transition-happy-path-test
+(deftest ^{:stratum 0} valid-targets-test
+  (testing "valid targets reflect the configured transition graph"
+    (is (= #{:pending :creating-pr :monitoring-ci :failed}
+           (sut/valid-targets :pending)))
+    (is (= #{:ready-to-merge :monitoring-ci :merged :failed}
+           (sut/valid-targets :ready-to-merge)))
+    (is (= #{}
+           (sut/valid-targets :bogus-status)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; FSM validation
+(deftest ^{:stratum 1} valid-transition-happy-path-test
   (testing "happy path transitions succeed through merge"
     (let [creating-pr (transition-result :pending :creating-pr)
           monitoring-ci (transition-result :creating-pr :monitoring-ci)
@@ -55,7 +70,7 @@
       (is (schema/succeeded? merged))
       (is (= {:state :merged :event :merge} (:transition merged))))))
 
-(deftest valid-transition-fix-loop-test
+(deftest ^{:stratum 1} valid-transition-fix-loop-test
   (testing "fix loop transitions return to CI monitoring"
     (let [start-fixing (transition-result :monitoring-ci :fixing)
           restart-ci (transition-result :fixing :monitoring-ci)
@@ -67,7 +82,7 @@
       (is (schema/succeeded? restart-fixing))
       (is (= {:state :fixing :event :start-fixing} (:transition restart-fixing))))))
 
-(deftest invalid-status-and-transition-test
+(deftest ^{:stratum 1} invalid-status-and-transition-test
   (testing "invalid statuses and undefined transitions are rejected"
     (let [invalid-state-result (transition-result :bogus-status :creating-pr)
           invalid-target-result (transition-result :pending :bogus-status)
@@ -87,14 +102,14 @@
                           :to-status :pending})
              (sut/transition-error-message invalid-transition-result))))))
 
-(deftest terminal-state-rejected-test
+(deftest ^{:stratum 1} terminal-state-rejected-test
   (testing "terminal statuses reject further transitions"
     (is (= :terminal-state
            (sut/transition-error-code (transition-result :merged :monitoring-ci))))
     (is (= :terminal-state
            (sut/transition-error-code (transition-result :failed :creating-pr))))))
 
-(deftest same-state-transition-remains-idempotent-test
+(deftest ^{:stratum 1} same-state-transition-remains-idempotent-test
   (testing "same-state transitions are allowed as idempotent updates"
     (let [monitoring-ci (transition-result :monitoring-ci :monitoring-ci)
           merged (transition-result :merged :merged)]
@@ -102,19 +117,3 @@
       (is (= {:state :monitoring-ci :event nil} (:transition monitoring-ci)))
       (is (schema/succeeded? merged))
       (is (= {:state :merged :event nil} (:transition merged))))))
-
-(deftest valid-transition-predicate-test
-  (testing "valid-transition? requires recognized statuses"
-    (is (true? (sut/valid-transition? :monitoring-ci :monitoring-ci)))
-    (is (true? (sut/valid-transition? :monitoring-ci :monitoring-review)))
-    (is (false? (sut/valid-transition? :bogus-status :bogus-status)))
-    (is (false? (sut/valid-transition? :bogus-status :creating-pr)))))
-
-(deftest valid-targets-test
-  (testing "valid targets reflect the configured transition graph"
-    (is (= #{:pending :creating-pr :monitoring-ci :failed}
-           (sut/valid-targets :pending)))
-    (is (= #{:ready-to-merge :monitoring-ci :merged :failed}
-           (sut/valid-targets :ready-to-merge)))
-    (is (= #{}
-           (sut/valid-targets :bogus-status)))))

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/github_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/github_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.github-test
   "Tests for the github.clj batched-review posting (N13 §2.2)."
   (:require [babashka.process :as process]
@@ -25,9 +24,10 @@
             [ai.miniforge.dag-executor.interface :as dag]
             [ai.miniforge.pr-lifecycle.github :as github]))
 
-;; ── helpers ──────────────────────────────────────────────────────────
+;------------------------------------------------------------------------------ Layer 0
 
-(defn- capture-shell
+;; ── helpers ──────────────────────────────────────────────────────────
+(defn- ^{:stratum 0} capture-shell
   "Replace `process/shell` with a stub that records every invocation
    (args + stdin) into `calls-atom` and returns `result`. Returns a
    no-arg fn suitable for `with-redefs`."
@@ -36,14 +36,14 @@
     (swap! calls-atom conj {:opts opts :args (vec args)})
     result))
 
-(def ^:private fake-review-success
+(def ^{:stratum 0} ^:private fake-review-success
   (json/generate-string
    {:id 999001 :html_url "https://github.com/o/r/pull/42#pullrequestreview-999001"
     :state "COMMENTED"}))
 
-(def ^:private fixture-sha "deadbeefcafef00ddeadbeefcafef00ddeadbeef")
+(def ^{:stratum 0} ^:private fixture-sha "deadbeefcafef00ddeadbeefcafef00ddeadbeef")
 
-(def ^:private comment-renderer-shape
+(def ^{:stratum 0} ^:private comment-renderer-shape
   [{:comment/author "miniforge-policy-evaluator[bot]"
     :comment/path   "components/agent/src/foo.clj"
     :comment/line   42
@@ -53,12 +53,13 @@
     :comment/line   7
     :comment/body   "**Rule Y**"}])
 
-(def ^:private flat-shape
+(def ^{:stratum 0} ^:private flat-shape
   [{:path "src/baz.clj" :line 1 :body "flat-shape body"}])
 
-;; ── tests ────────────────────────────────────────────────────────────
+;------------------------------------------------------------------------------ Layer 1
 
-(deftest post-review-uses-create-review-endpoint-via-stdin
+;; ── tests ────────────────────────────────────────────────────────────
+(deftest ^{:stratum 1} post-review-uses-create-review-endpoint-via-stdin
   (testing "post-review! shells out to the right gh api endpoint with --input -"
     (let [calls (atom [])
           stub  (capture-shell calls
@@ -77,7 +78,7 @@
           (is (= true (get-in call [:opts :continue]))
               "exit codes returned, not thrown"))))))
 
-(deftest post-review-translates-renderer-shape-to-github-comments
+(deftest ^{:stratum 1} post-review-translates-renderer-shape-to-github-comments
   (testing "stdin JSON has comments[] with path/line/side/body keys per render record + commit_id"
     (let [calls (atom [])
           stub  (capture-shell calls
@@ -99,7 +100,7 @@
                 :body (-> comment-renderer-shape first :comment/body)}
                (first (:comments payload))))))))
 
-(deftest post-review-marker-is-idempotent
+(deftest ^{:stratum 1} post-review-marker-is-idempotent
   (testing "supplied body that already contains the marker isn't double-tagged"
     (let [calls (atom [])
           stub  (capture-shell calls
@@ -113,7 +114,7 @@
             n (count (re-seq (re-pattern (java.util.regex.Pattern/quote github/review-marker)) body))]
         (is (= 1 n) "marker appears exactly once even when caller pre-marked")))))
 
-(deftest post-review-rejects-missing-commit-id
+(deftest ^{:stratum 1} post-review-rejects-missing-commit-id
   (testing "missing/blank commit-id short-circuits with :missing-commit-id, never shells out"
     (let [calls (atom [])
           stub  (capture-shell calls {:exit 0 :out "" :err ""})]
@@ -126,7 +127,7 @@
       (is (zero? (count @calls))
           "no shell invocation when commit-id missing — fail fast"))))
 
-(deftest post-review-accepts-flat-shape-too
+(deftest ^{:stratum 1} post-review-accepts-flat-shape-too
   (testing "{:path :line :body} also flows through unchanged"
     (let [calls (atom [])
           stub  (capture-shell calls
@@ -139,7 +140,7 @@
         (is (= {:path "src/baz.clj" :line 1 :side "RIGHT" :body "flat-shape body"}
                (first (:comments payload))))))))
 
-(deftest post-review-success-shape
+(deftest ^{:stratum 1} post-review-success-shape
   (testing "successful gh response is parsed into {:review-id :url :state :comment-count}"
     (let [calls (atom [])
           stub  (capture-shell calls
@@ -152,7 +153,7 @@
           (is (= 2 (-> r :data :comment-count)))
           (is (re-find #"#pullrequestreview-999001" (-> r :data :url))))))))
 
-(deftest post-review-gh-failure-returns-typed-error
+(deftest ^{:stratum 1} post-review-gh-failure-returns-typed-error
   (testing "non-zero gh exit yields :gh-command-failed with stderr + exit code"
     (let [calls (atom [])
           stub  (capture-shell calls
@@ -164,7 +165,7 @@
           (is (re-find #"422" (get-in r [:error :message])))
           (is (= 1 (get-in r [:error :data :exit-code]))))))))
 
-(deftest post-review-shell-exception-returns-typed-error
+(deftest ^{:stratum 1} post-review-shell-exception-returns-typed-error
   (testing "process/shell throwing yields :gh-exception"
     (let [stub (fn [& _] (throw (ex-info "boom" {})))]
       (with-redefs [process/shell stub]

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/integration_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/integration_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.integration-test
   "Integration test for PR lifecycle state machine.
 
@@ -31,54 +30,40 @@
    [ai.miniforge.release-executor.interface]
    [ai.miniforge.response.interface :as response]))
 
-;------------------------------------------------------------------------------ Mock Data
+;------------------------------------------------------------------------------ Layer 0
 
-(def mock-task
+;------------------------------------------------------------------------------ Mock Data
+(def ^{:stratum 0} mock-task
   {:task/id "test-task-1"
    :task/description "Implement feature X"
    :task/acceptance-criteria ["Feature works" "Tests pass"]
    :task/constraints ["No breaking changes"]})
 
-(def mock-pr-info
+(def ^{:stratum 0} mock-pr-info
   {:pr-number 123
    :pr-url "https://github.com/org/repo/pull/123"
    :branch "feature/test-feature"
    :commit-sha "abc123def456"})
 
-(def mock-ci-success
+(def ^{:stratum 0} mock-ci-success
   {:status :success
    :checks [{:name "tests" :conclusion "success"}
             {:name "lint" :conclusion "success"}]})
 
-(def mock-ci-failure
+(def ^{:stratum 0} mock-ci-failure
   {:status :failure
    :checks [{:name "tests" :conclusion "failure" :details "Test suite failed"}]})
 
-(def mock-review-approved
+(def ^{:stratum 0} mock-review-approved
   {:status :approved
    :reviews [{:user "reviewer1" :state "APPROVED"}]})
 
-(def mock-review-changes-requested
+(def ^{:stratum 0} mock-review-changes-requested
   {:status :changes_requested
    :reviews [{:user "reviewer1" :state "CHANGES_REQUESTED"
               :comments ["Please fix the error handling"]}]})
 
-;------------------------------------------------------------------------------ Mock Implementations
-
-(defn mock-release-executor
-  "Mock release executor that simulates PR creation."
-  [success?]
-  (fn [_workflow-state _exec-context _opts]
-    (if success?
-      {:success? true
-       :artifacts [{:artifact/type :release
-                    :artifact/content mock-pr-info}]
-       :metrics {:tokens 100 :duration-ms 1000}}
-      {:success? false
-       :errors [{:type :pr-creation-failed
-                 :message "Failed to create PR"}]})))
-
-(defn mock-ci-monitor
+(defn ^{:stratum 0} mock-ci-monitor
   "Mock CI monitor that returns predefined CI status."
   [ci-results-seq]
   (let [results (atom ci-results-seq)]
@@ -87,7 +72,7 @@
         (swap! results rest)
         result))))
 
-(defn mock-review-monitor
+(defn ^{:stratum 0} mock-review-monitor
   "Mock review monitor that returns predefined review status."
   [review-results-seq]
   (let [results (atom review-results-seq)]
@@ -96,7 +81,7 @@
         (swap! results rest)
         result))))
 
-(defn mock-merge-operation
+(defn ^{:stratum 0} mock-merge-operation
   "Mock merge operation."
   [success?]
   (fn [_repo-path _pr-number merge-policy]
@@ -107,7 +92,7 @@
       {:success? false
        :error "Merge conflict detected"})))
 
-(defn mock-fix-generator
+(defn ^{:stratum 0} mock-fix-generator
   "Mock fix generator that returns a code artifact."
   [success?]
   (fn [_task error-details _context]
@@ -121,7 +106,7 @@
       (response/failure
        (ex-info "Fix generation failed" {:error error-details})))))
 
-(defn collect-events
+(defn ^{:stratum 0} collect-events
   "Create an event collector that captures all emitted events."
   []
   (let [events (atom [])]
@@ -130,9 +115,47 @@
                  nil)
      :events events}))
 
-;------------------------------------------------------------------------------ Helper Functions
+(defn ^{:stratum 0} get-status [controller]
+  (:status @controller))
 
-(defn create-test-controller
+(defn ^{:stratum 0} get-pr-info [controller]
+  (:pr @controller))
+
+(defn ^{:stratum 0} get-history [controller]
+  (:history @controller))
+
+(defn ^{:stratum 0} simulate-pr-creation!
+  "Simulate PR creation by updating controller state."
+  [controller pr-info]
+  (swap! controller assoc
+         :status :monitoring-ci
+         :pr pr-info)
+  pr-info)
+
+(defn ^{:stratum 0} simulate-ci-result!
+  "Simulate CI result by updating controller."
+  [controller ci-result]
+  (swap! controller assoc :last-ci-result ci-result)
+  ci-result)
+
+;------------------------------------------------------------------------------ Layer 1
+
+;------------------------------------------------------------------------------ Mock Implementations
+(defn ^{:stratum 1} mock-release-executor
+  "Mock release executor that simulates PR creation."
+  [success?]
+  (fn [_workflow-state _exec-context _opts]
+    (if success?
+      {:success? true
+       :artifacts [{:artifact/type :release
+                    :artifact/content mock-pr-info}]
+       :metrics {:tokens 100 :duration-ms 1000}}
+      {:success? false
+       :errors [{:type :pr-creation-failed
+                 :message "Failed to create PR"}]})))
+
+;------------------------------------------------------------------------------ Helper Functions
+(defn ^{:stratum 1} create-test-controller
   "Create a controller with mocked dependencies."
   [& {:keys [generate-fn _ci-monitor-fn _review-monitor-fn _merge-fn]
       :or {generate-fn (mock-fix-generator true)}}]
@@ -146,32 +169,10 @@
                   :review-poll-interval-ms 100)
      :events (:events event-collector)}))
 
-(defn get-status [controller]
-  (:status @controller))
-
-(defn get-pr-info [controller]
-  (:pr @controller))
-
-(defn get-history [controller]
-  (:history @controller))
-
-(defn simulate-pr-creation!
-  "Simulate PR creation by updating controller state."
-  [controller pr-info]
-  (swap! controller assoc
-         :status :monitoring-ci
-         :pr pr-info)
-  pr-info)
-
-(defn simulate-ci-result!
-  "Simulate CI result by updating controller."
-  [controller ci-result]
-  (swap! controller assoc :last-ci-result ci-result)
-  ci-result)
+;------------------------------------------------------------------------------ Layer 2
 
 ;------------------------------------------------------------------------------ Tests
-
-(deftest controller-creation-test
+(deftest ^{:stratum 2} controller-creation-test
   (testing "Controller creation initializes state correctly"
     (let [{:keys [controller]} (create-test-controller)]
       (is (= :pending (get-status controller))
@@ -183,7 +184,7 @@
       (is (some? (:controller/id @controller))
           "Controller should have an ID"))))
 
-(deftest pr-creation-flow-test
+(deftest ^{:stratum 2} pr-creation-flow-test
   (testing "PR creation updates controller state"
     (with-redefs [ai.miniforge.release-executor.interface/execute-release-phase
                   (mock-release-executor true)]
@@ -199,7 +200,7 @@
         (is (= 123 (:pr-number (get-pr-info controller)))
             "PR number should be accessible")))))
 
-(deftest ci-monitoring-happy-path-test
+(deftest ^{:stratum 2} ci-monitoring-happy-path-test
   (testing "CI monitoring transitions to review monitoring on success"
     (let [{:keys [controller]} (create-test-controller
                                 :ci-monitor-fn (mock-ci-monitor [mock-ci-success]))]
@@ -214,7 +215,7 @@
                   (:checks mock-ci-success))
           "All checks should pass"))))
 
-(deftest ci-failure-triggers-fix-loop-test
+(deftest ^{:stratum 2} ci-failure-triggers-fix-loop-test
   (testing "CI failure triggers fix loop"
     (let [{:keys [controller]} (create-test-controller
                                 :ci-monitor-fn (mock-ci-monitor [mock-ci-failure])
@@ -230,7 +231,7 @@
                 (:checks mock-ci-failure))
           "At least one check should fail"))))
 
-(deftest review-approval-flow-test
+(deftest ^{:stratum 2} review-approval-flow-test
   (testing "Review approval transitions to ready-to-merge"
     (let [{:keys [controller]} (create-test-controller
                                 :ci-monitor-fn (mock-ci-monitor [mock-ci-success])
@@ -246,7 +247,7 @@
       (is (= :ready-to-merge (get-status controller))
           "Controller should be ready to merge after approval"))))
 
-(deftest review-changes-requested-test
+(deftest ^{:stratum 2} review-changes-requested-test
   (testing "Changes requested triggers fix loop"
     (let [{:keys [controller]} (create-test-controller
                                 :review-monitor-fn (mock-review-monitor [mock-review-changes-requested])
@@ -261,7 +262,7 @@
       (is (seq (:reviews mock-review-changes-requested))
           "Review should have comments"))))
 
-(deftest merge-success-flow-test
+(deftest ^{:stratum 2} merge-success-flow-test
   (testing "Successful merge completes lifecycle"
     (with-redefs [ai.miniforge.pr-lifecycle.merge/merge-pr!
                   (mock-merge-operation true)]
@@ -278,7 +279,7 @@
         (is (= :merged (get-status controller))
             "Controller should be in :merged state")))))
 
-(deftest merge-conflict-handling-test
+(deftest ^{:stratum 2} merge-conflict-handling-test
   (testing "Merge conflict triggers rebase or fix"
     (with-redefs [ai.miniforge.pr-lifecycle.merge/merge-pr!
                   (mock-merge-operation false)]
@@ -295,7 +296,7 @@
         (is (= :fixing (get-status controller))
             "Controller should enter fixing state on merge conflict")))))
 
-(deftest max-fix-iterations-enforcement-test
+(deftest ^{:stratum 2} max-fix-iterations-enforcement-test
   (testing "Max fix iterations causes failure"
     (let [{:keys [controller]} (create-test-controller
                                 :generate-fn (mock-fix-generator false))]
@@ -308,7 +309,7 @@
               (get-in @controller [:config :max-fix-iterations]))
           "Fix iterations should reach max limit"))))
 
-(deftest event-emission-test
+(deftest ^{:stratum 2} event-emission-test
   (testing "Events are emitted for state transitions"
     (let [{:keys [controller events]} (create-test-controller)]
 
@@ -324,7 +325,7 @@
       (is (vector? @events)
           "Events should be collected in a vector"))))
 
-(deftest history-tracking-test
+(deftest ^{:stratum 2} history-tracking-test
   (testing "Controller tracks history of events"
     (let [{:keys [controller]} (create-test-controller)]
 
@@ -347,7 +348,7 @@
         (is (= :ci-passed (:type (second history)))
             "Second event should be :ci-passed")))))
 
-(deftest concurrent-monitoring-test
+(deftest ^{:stratum 2} concurrent-monitoring-test
   (testing "CI and review monitoring can run concurrently"
     (let [{:keys [controller]} (create-test-controller
                                 :ci-monitor-fn (mock-ci-monitor [mock-ci-success])
@@ -366,7 +367,7 @@
       (is (get-in @controller [:review-monitor :active])
           "Review monitor should be active"))))
 
-(deftest full-happy-path-simulation-test
+(deftest ^{:stratum 2} full-happy-path-simulation-test
   (testing "Full lifecycle: PR → CI pass → Review approve → Merge"
     (let [{:keys [controller]} (create-test-controller)]
 
@@ -395,7 +396,7 @@
       (is (some? (get-pr-info controller))
           "PR info should be retained after merge"))))
 
-(deftest error-recovery-test
+(deftest ^{:stratum 2} error-recovery-test
   (testing "Controller can recover from transient errors"
     (let [{:keys [controller]} (create-test-controller
                                 ;; First check fails, second succeeds

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/label_actions_config_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/label_actions_config_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.label-actions-config-test
   "Structural validity tests for the M1 PR-label-actions registry EDN.
 
@@ -26,16 +25,22 @@
             [clojure.set :as set]
             [clojure.test :refer [deftest is testing]]))
 
-(def ^:private config-path
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private config-path
   "config/pr-lifecycle/label-actions.edn")
 
-(defn- load-registry []
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} load-registry []
   (-> (io/resource config-path)
       slurp
       edn/read-string
       :pr-label-actions/registry))
 
-(deftest registry-resource-loads
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} registry-resource-loads
   (testing "the registry resource exists on the classpath and parses as EDN"
     (let [r (io/resource config-path)]
       (is (some? r)
@@ -43,7 +48,7 @@
     (let [registry (load-registry)]
       (is (map? registry) "Registry must be a map keyed by label string"))))
 
-(deftest registry-keys-are-strings
+(deftest ^{:stratum 2} registry-keys-are-strings
   (testing "label keys are STRINGS (GitHub-native), never keywords or symbols"
     (let [registry (load-registry)]
       (doseq [[k _] registry]
@@ -51,7 +56,7 @@
             (str "Label registry key " (pr-str k)
                  " must be a string — GitHub labels are not keywords"))))))
 
-(deftest dogfood-fix-entry-shape
+(deftest ^{:stratum 2} dogfood-fix-entry-shape
   (testing "the seed dogfood-fix entry has the canonical M1 shape"
     (let [entry (get (load-registry) "dogfood-fix")]
       (is (some? entry) "dogfood-fix entry must be present in the registry")
@@ -66,7 +71,7 @@
         (is (= true (:workflow.base-sha/not-ancestor-of-merge applies))
             ":applies-when must declare the not-ancestor-of-merge predicate")))))
 
-(deftest every-entry-has-required-keys
+(deftest ^{:stratum 2} every-entry-has-required-keys
   (testing "every registry entry declares :action, :description, :on-conflict, :applies-when"
     (let [registry (load-registry)
           required #{:action :description :on-conflict :applies-when}]

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/listener_registry_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/listener_registry_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.listener-registry-test
   "Tests for the N13 §2.7 listener registry persistence primitive."
   (:require [babashka.fs :as fs]
@@ -24,21 +23,19 @@
             [ai.miniforge.dag-executor.interface :as dag]
             [ai.miniforge.pr-lifecycle.listener-registry :as reg]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; ── fixture: ephemeral worktree ──────────────────────────────────────
+(def ^{:stratum 0} ^:dynamic *worktree* nil)
 
-(def ^:dynamic *worktree* nil)
-
-(defn worktree-fixture [f]
+(defn ^{:stratum 0} worktree-fixture [f]
   (let [w (str (fs/create-temp-dir {:prefix "listener-registry-test-"}))]
     (try
       (binding [*worktree* w] (f))
       (finally (try (fs/delete-tree w) (catch Throwable _ nil))))))
 
-(use-fixtures :each worktree-fixture)
-
 ;; ── helpers ──────────────────────────────────────────────────────────
-
-(def ^:private base-params
+(def ^{:stratum 0} ^:private base-params
   {:pr/url         "https://github.com/o/r/pull/42"
    :pr/repo-id     "o/r"
    :pr/number      42
@@ -48,7 +45,28 @@
                     :channel/target "pty-7"}
    :registered-by  :authoring-agent})
 
-(defn- count-listeners-on-disk
+;; ── auto-expiry ──────────────────────────────────────────────────────
+(deftest ^{:stratum 0} auto-expirable-predicate
+  (let [now    (java.util.Date.)
+        old    (java.util.Date. (- (.getTime now)
+                                   (* 1000 (+ reg/default-ttl-seconds 60))))
+        recent (java.util.Date. (- (.getTime now) 1000))
+        active-old   {:status :active :registered-at old   :ttl-seconds reg/default-ttl-seconds}
+        active-fresh {:status :active :registered-at recent :ttl-seconds reg/default-ttl-seconds}
+        cancelled-old {:status :cancelled :registered-at old :ttl-seconds reg/default-ttl-seconds}]
+    (is (true?  (reg/auto-expirable? active-old now)))
+    (is (false? (reg/auto-expirable? active-fresh now)))
+    (is (false? (reg/auto-expirable? cancelled-old now))
+        "non-active entries don't auto-expire")))
+
+(defn- ^{:stratum 0} past-inst
+  "Return an inst `seconds-ago` before now."
+  [seconds-ago]
+  (java.util.Date. (- (.getTime (java.util.Date.)) (* 1000 seconds-ago))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} count-listeners-on-disk
   "Read the file directly and tally entries (cross-checks our pure ops)."
   []
   (let [path (str (fs/path *worktree* reg/default-storage-path))]
@@ -58,14 +76,13 @@
       0)))
 
 ;; ── read-registry ────────────────────────────────────────────────────
-
-(deftest read-on-missing-file-yields-empty-registry
+(deftest ^{:stratum 1} read-on-missing-file-yields-empty-registry
   (let [r (reg/read-registry *worktree*)]
     (is (dag/ok? r))
     (is (= reg/registry-version (-> r :data :registry/version)))
     (is (= {} (-> r :data :registry/listeners)))))
 
-(deftest read-on-blank-file-yields-empty-registry
+(deftest ^{:stratum 1} read-on-blank-file-yields-empty-registry
   (let [path (str (fs/path *worktree* reg/default-storage-path))]
     (fs/create-dirs (fs/parent path))
     (spit path "")
@@ -73,7 +90,7 @@
       (is (dag/ok? r))
       (is (= reg/registry-version (-> r :data :registry/version))))))
 
-(deftest read-on-corrupt-edn-returns-typed-error
+(deftest ^{:stratum 1} read-on-corrupt-edn-returns-typed-error
   (let [path (str (fs/path *worktree* reg/default-storage-path))]
     (fs/create-dirs (fs/parent path))
     (spit path "this is { not edn")
@@ -81,43 +98,7 @@
       (is (not (dag/ok? r)))
       (is (= :listener-registry/read-failed (get-in r [:error :code]))))))
 
-;; ── register! ────────────────────────────────────────────────────────
-
-(deftest register-happy-path
-  (testing "register! persists an entry and returns its id"
-    (let [r (reg/register! *worktree* base-params)]
-      (is (dag/ok? r))
-      (is (uuid? (-> r :data :listener-id)))
-      (is (= 1 (count-listeners-on-disk))))))
-
-(deftest register-rejects-bad-registered-by
-  (testing "registration outside the three canonical moments is rejected (spec §Registration moments)"
-    (doseq [bad [:rogue :unknown nil "authoring-agent"]]
-      (let [r (reg/register! *worktree* (assoc base-params :registered-by bad))]
-        (is (not (dag/ok? r))
-            (str "input " (pr-str bad)))
-        (is (= :listener-registry/invalid-registered-by (get-in r [:error :code])))))
-    (is (zero? (count-listeners-on-disk))
-        "no entry written when registration is rejected")))
-
-(deftest register-rejects-malformed-entry
-  (testing "missing required fields fail malli validation, surface typed error"
-    (let [r (reg/register! *worktree* (dissoc base-params :pr/number))]
-      (is (not (dag/ok? r)))
-      (is (= :listener-registry/invalid-entry (get-in r [:error :code]))))
-    (is (zero? (count-listeners-on-disk)))))
-
-(deftest register-multiple-entries-on-same-pr
-  (testing "multiple agents may bind to the same PR"
-    (let [r1 (reg/register! *worktree* base-params)
-          r2 (reg/register! *worktree* (assoc base-params :agent/id "agent-B"))]
-      (is (dag/ok? r1))
-      (is (dag/ok? r2))
-      (is (not= (-> r1 :data :listener-id) (-> r2 :data :listener-id))
-          "each registration gets a fresh listener-id")
-      (is (= 2 (count-listeners-on-disk))))))
-
-(deftest register-defaults-ttl
+(deftest ^{:stratum 1} register-defaults-ttl
   (let [r (reg/register! *worktree* (dissoc base-params :ttl-seconds))]
     (is (dag/ok? r))
     (let [reg-state (:data (reg/read-registry *worktree*))
@@ -125,8 +106,7 @@
       (is (= reg/default-ttl-seconds (:ttl-seconds entry))))))
 
 ;; ── transitions ──────────────────────────────────────────────────────
-
-(deftest unregister-marks-cancelled
+(deftest ^{:stratum 1} unregister-marks-cancelled
   (let [r1 (reg/register! *worktree* base-params)
         lid (-> r1 :data :listener-id)
         r2 (reg/unregister! *worktree* (:pr/url base-params) lid)]
@@ -136,12 +116,12 @@
       (is (= 1 (count entries)))
       (is (= :cancelled (:status (first entries)))))))
 
-(deftest unregister-missing-listener-returns-typed-error
+(deftest ^{:stratum 1} unregister-missing-listener-returns-typed-error
   (let [r (reg/unregister! *worktree* (:pr/url base-params) (random-uuid))]
     (is (not (dag/ok? r)))
     (is (= :listener-registry/listener-not-found (get-in r [:error :code])))))
 
-(deftest mark-dispatched-records-dispatch-id-and-timestamp
+(deftest ^{:stratum 1} mark-dispatched-records-dispatch-id-and-timestamp
   (let [r1 (reg/register! *worktree* base-params)
         lid (-> r1 :data :listener-id)
         did (random-uuid)
@@ -154,7 +134,7 @@
       (is (= did (:resume/dispatch-id entry)))
       (is (inst? (:resume/dispatched-at entry))))))
 
-(deftest cancel-on-pr-close-transitions-only-active-entries
+(deftest ^{:stratum 1} cancel-on-pr-close-transitions-only-active-entries
   (testing "actives become :cancelled, already-dispatched/cancelled stay put"
     (let [_  (reg/register! *worktree* base-params)
           r2 (reg/register! *worktree* (assoc base-params :agent/id "agent-B"))
@@ -172,27 +152,11 @@
                           set)]
         (is (= #{:cancelled :dispatched} statuses))))))
 
-;; ── auto-expiry ──────────────────────────────────────────────────────
-
-(deftest auto-expirable-predicate
-  (let [now    (java.util.Date.)
-        old    (java.util.Date. (- (.getTime now)
-                                   (* 1000 (+ reg/default-ttl-seconds 60))))
-        recent (java.util.Date. (- (.getTime now) 1000))
-        active-old   {:status :active :registered-at old   :ttl-seconds reg/default-ttl-seconds}
-        active-fresh {:status :active :registered-at recent :ttl-seconds reg/default-ttl-seconds}
-        cancelled-old {:status :cancelled :registered-at old :ttl-seconds reg/default-ttl-seconds}]
-    (is (true?  (reg/auto-expirable? active-old now)))
-    (is (false? (reg/auto-expirable? active-fresh now)))
-    (is (false? (reg/auto-expirable? cancelled-old now))
-        "non-active entries don't auto-expire")))
-
 ;; Deterministic registry construction: build the snapshot directly
 ;; via pure helpers so we can dial `:registered-at` into the past
 ;; without touching wall-clock time. Avoids the Thread/sleep
 ;; flakiness that bites under CI load.
-
-(defn- write-state!
+(defn- ^{:stratum 1} write-state!
   "Build a registry from `entries`, write it through `write-registry!`,
    and return the entries actually persisted. `entries` are caller-
    supplied entry maps (must include all required fields)."
@@ -202,7 +166,7 @@
     (assert (dag/ok? r) "test fixture failed to write registry")
     entries))
 
-(defn- entry
+(defn- ^{:stratum 1} entry
   "Build a fully-shaped ListenerEntry for tests with the supplied
    overrides. Required keys default from base-params; `:registered-at`
    defaults to now."
@@ -222,12 +186,169 @@
           :notes           nil}
          overrides))
 
-(defn- past-inst
-  "Return an inst `seconds-ago` before now."
-  [seconds-ago]
-  (java.util.Date. (- (.getTime (java.util.Date.)) (* 1000 seconds-ago))))
+;; ── lookup ───────────────────────────────────────────────────────────
+(deftest ^{:stratum 1} lookup-by-pr-and-by-agent
+  (let [_ (reg/register! *worktree* base-params)
+        _ (reg/register! *worktree* (assoc base-params :agent/id "agent-B"))
+        _ (reg/register! *worktree* (assoc base-params
+                                           :pr/url "https://github.com/o/r/pull/99"
+                                           :pr/number 99))
+        registry (:data (reg/read-registry *worktree*))]
+    (is (= 2 (count (reg/entries-for-pr registry (:pr/url base-params)))))
+    (is (= 1 (count (reg/entries-for-pr registry "https://github.com/o/r/pull/99"))))
+    (is (= 2 (count (reg/entries-for-agent registry "agent-A")))
+        "agent-A is bound to PR 42 and PR 99")
+    (is (= 1 (count (reg/entries-for-agent registry "agent-B"))))))
 
-(deftest sweep-expired-transitions-stale-actives
+;; ── persistence atomicity ────────────────────────────────────────────
+(deftest ^{:stratum 1} write-rename-atomicity
+  (testing "no .tmp files leak after register!"
+    (reg/register! *worktree* base-params)
+    (let [tmp-files (filter #(re-find #"\.tmp$" (str %))
+                            (fs/list-dir (fs/path *worktree* ".miniforge")))]
+      (is (empty? tmp-files)
+          "the temp file used for write-rename should be gone after a successful write"))))
+
+(deftest ^{:stratum 1} write-creates-miniforge-dir-when-missing
+  (testing ".miniforge/ is created on first register"
+    (let [mf-dir (fs/path *worktree* ".miniforge")]
+      (is (not (fs/exists? mf-dir)) "fresh worktree has no .miniforge dir")
+      (reg/register! *worktree* base-params)
+      (is (fs/exists? mf-dir) ".miniforge dir created")
+      (is (fs/exists? (fs/path mf-dir "listener-registry.edn"))
+          "registry artifact written"))))
+
+;; ── transition guards (terminal states are sticky) ───────────────────
+(deftest ^{:stratum 1} unregister-rejects-non-active-entries
+  (testing "unregister! returns :wrong-status on already-cancelled entries (no overwrite)"
+    (let [r1 (reg/register! *worktree* base-params)
+          lid (-> r1 :data :listener-id)
+          _   (reg/unregister! *worktree* (:pr/url base-params) lid) ; first call: ok
+          r2  (reg/unregister! *worktree* (:pr/url base-params) lid)] ; second: guard fires
+      (is (not (dag/ok? r2)))
+      (is (= :listener-registry/wrong-status (get-in r2 [:error :code])))
+      (is (= :cancelled (get-in r2 [:error :data :current-status])))
+      (is (= :active    (get-in r2 [:error :data :expected-status]))))))
+
+(deftest ^{:stratum 1} unregister-rejects-dispatched-entries
+  (testing "unregister! does NOT downgrade a :dispatched entry to :cancelled"
+    (let [r1 (reg/register! *worktree* base-params)
+          lid (-> r1 :data :listener-id)
+          _   (reg/mark-dispatched! *worktree* (:pr/url base-params) lid (random-uuid))
+          r2  (reg/unregister! *worktree* (:pr/url base-params) lid)]
+      (is (not (dag/ok? r2)))
+      (is (= :listener-registry/wrong-status (get-in r2 [:error :code])))
+      (let [entries (reg/entries-for-pr (:data (reg/read-registry *worktree*))
+                                        (:pr/url base-params))]
+        (is (= :dispatched (:status (first entries)))
+            "entry remains :dispatched, not silently overwritten")))))
+
+(deftest ^{:stratum 1} mark-dispatched-rejects-non-active-entries
+  (testing "mark-dispatched! refuses to dispatch a cancelled listener"
+    (let [r1 (reg/register! *worktree* base-params)
+          lid (-> r1 :data :listener-id)
+          _   (reg/unregister! *worktree* (:pr/url base-params) lid)
+          r2  (reg/mark-dispatched! *worktree* (:pr/url base-params) lid (random-uuid))]
+      (is (not (dag/ok? r2)))
+      (is (= :listener-registry/wrong-status (get-in r2 [:error :code])))
+      (is (= :cancelled (get-in r2 [:error :data :current-status]))))))
+
+(deftest ^{:stratum 1} mark-dispatched-is-not-idempotent-by-design
+  (testing "double-dispatch is rejected, not silently re-stamped"
+    (let [r1 (reg/register! *worktree* base-params)
+          lid (-> r1 :data :listener-id)
+          d1  (random-uuid)
+          d2  (random-uuid)
+          _   (reg/mark-dispatched! *worktree* (:pr/url base-params) lid d1)
+          r2  (reg/mark-dispatched! *worktree* (:pr/url base-params) lid d2)]
+      (is (not (dag/ok? r2)))
+      (let [entries (reg/entries-for-pr (:data (reg/read-registry *worktree*))
+                                        (:pr/url base-params))
+            entry (first entries)]
+        (is (= d1 (:resume/dispatch-id entry))
+            "first dispatch-id sticks; second call doesn't overwrite")))))
+
+;; ── read strictness (trailing forms + schema) ────────────────────────
+(deftest ^{:stratum 1} read-rejects-trailing-forms
+  (testing "valid registry followed by trailing data is rejected as :read-failed"
+    (let [path (str (fs/path *worktree* reg/default-storage-path))]
+      (fs/create-dirs (fs/parent path))
+      (spit path (str (pr-str reg/empty-registry) " {:trailing :junk}")))
+    (let [r (reg/read-registry *worktree*)]
+      (is (not (dag/ok? r)))
+      (is (= :listener-registry/read-failed (get-in r [:error :code]))))))
+
+(deftest ^{:stratum 1} read-rejects-schema-mismatch
+  (testing ":registry/listeners as a list (not a vector) fails malli validation on load"
+    (let [path (str (fs/path *worktree* reg/default-storage-path))
+          ;; bypass our normal write so we can craft a bad-but-shaped artifact
+          bad  {:registry/version reg/registry-version
+                :registry/last-updated (java.util.Date.)
+                :registry/listeners {"https://github.com/o/r/pull/1"
+                                     '({:listener/id (random-uuid)})}}]
+      (fs/create-dirs (fs/parent path))
+      (spit path (pr-str bad)))
+    (let [r (reg/read-registry *worktree*)]
+      (is (not (dag/ok? r)))
+      (is (= :listener-registry/read-failed (get-in r [:error :code])))
+      (is (some? (get-in r [:error :data :explain]))
+          "malli explain payload is included so callers can diagnose"))))
+
+;; ── tmp file cleanup on move failure ─────────────────────────────────
+(deftest ^{:stratum 1} write-cleans-up-tmp-on-move-failure
+  (testing "if fs/move throws, the .tmp file written by spit is best-effort-deleted"
+    (let [path (str (fs/path *worktree* reg/default-storage-path))
+          tmp-path (str path ".tmp")]
+      (with-redefs [babashka.fs/move (fn [& _]
+                                        (throw (java.lang.UnsupportedOperationException.
+                                                "atomic-move not supported on this fs (simulated)")))]
+        (let [r (reg/write-registry! *worktree* reg/empty-registry)]
+          (is (not (dag/ok? r)))
+          (is (= :listener-registry/write-failed (get-in r [:error :code])))
+          (is (= tmp-path (get-in r [:error :data :tmp-path])))
+          (is (= "java.lang.UnsupportedOperationException"
+                 (get-in r [:error :data :exception-class])))
+          (is (not (fs/exists? tmp-path))
+              ".tmp file should be deleted on move failure to avoid accumulating stale artifacts"))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; ── register! ────────────────────────────────────────────────────────
+(deftest ^{:stratum 2} register-happy-path
+  (testing "register! persists an entry and returns its id"
+    (let [r (reg/register! *worktree* base-params)]
+      (is (dag/ok? r))
+      (is (uuid? (-> r :data :listener-id)))
+      (is (= 1 (count-listeners-on-disk))))))
+
+(deftest ^{:stratum 2} register-rejects-bad-registered-by
+  (testing "registration outside the three canonical moments is rejected (spec §Registration moments)"
+    (doseq [bad [:rogue :unknown nil "authoring-agent"]]
+      (let [r (reg/register! *worktree* (assoc base-params :registered-by bad))]
+        (is (not (dag/ok? r))
+            (str "input " (pr-str bad)))
+        (is (= :listener-registry/invalid-registered-by (get-in r [:error :code])))))
+    (is (zero? (count-listeners-on-disk))
+        "no entry written when registration is rejected")))
+
+(deftest ^{:stratum 2} register-rejects-malformed-entry
+  (testing "missing required fields fail malli validation, surface typed error"
+    (let [r (reg/register! *worktree* (dissoc base-params :pr/number))]
+      (is (not (dag/ok? r)))
+      (is (= :listener-registry/invalid-entry (get-in r [:error :code]))))
+    (is (zero? (count-listeners-on-disk)))))
+
+(deftest ^{:stratum 2} register-multiple-entries-on-same-pr
+  (testing "multiple agents may bind to the same PR"
+    (let [r1 (reg/register! *worktree* base-params)
+          r2 (reg/register! *worktree* (assoc base-params :agent/id "agent-B"))]
+      (is (dag/ok? r1))
+      (is (dag/ok? r2))
+      (is (not= (-> r1 :data :listener-id) (-> r2 :data :listener-id))
+          "each registration gets a fresh listener-id")
+      (is (= 2 (count-listeners-on-disk))))))
+
+(deftest ^{:stratum 2} sweep-expired-transitions-stale-actives
   (testing "sweep-expired! flips :active entries past TTL to :expired (deterministic)"
     (let [stale (entry {:agent/id "agent-A"
                         :ttl-seconds 60
@@ -247,7 +368,7 @@
                             set)]
           (is (= #{:expired :active} statuses)))))))
 
-(deftest sweep-expired-is-idempotent
+(deftest ^{:stratum 2} sweep-expired-is-idempotent
   (testing "running sweep twice yields 0 the second time (deterministic)"
     (write-state! [(entry {:agent/id "agent-A"
                            :ttl-seconds 60
@@ -257,132 +378,4 @@
       (is (= 1 (-> r1 :data :expired-count)))
       (is (= 0 (-> r2 :data :expired-count))))))
 
-;; ── lookup ───────────────────────────────────────────────────────────
-
-(deftest lookup-by-pr-and-by-agent
-  (let [_ (reg/register! *worktree* base-params)
-        _ (reg/register! *worktree* (assoc base-params :agent/id "agent-B"))
-        _ (reg/register! *worktree* (assoc base-params
-                                           :pr/url "https://github.com/o/r/pull/99"
-                                           :pr/number 99))
-        registry (:data (reg/read-registry *worktree*))]
-    (is (= 2 (count (reg/entries-for-pr registry (:pr/url base-params)))))
-    (is (= 1 (count (reg/entries-for-pr registry "https://github.com/o/r/pull/99"))))
-    (is (= 2 (count (reg/entries-for-agent registry "agent-A")))
-        "agent-A is bound to PR 42 and PR 99")
-    (is (= 1 (count (reg/entries-for-agent registry "agent-B"))))))
-
-;; ── persistence atomicity ────────────────────────────────────────────
-
-(deftest write-rename-atomicity
-  (testing "no .tmp files leak after register!"
-    (reg/register! *worktree* base-params)
-    (let [tmp-files (filter #(re-find #"\.tmp$" (str %))
-                            (fs/list-dir (fs/path *worktree* ".miniforge")))]
-      (is (empty? tmp-files)
-          "the temp file used for write-rename should be gone after a successful write"))))
-
-(deftest write-creates-miniforge-dir-when-missing
-  (testing ".miniforge/ is created on first register"
-    (let [mf-dir (fs/path *worktree* ".miniforge")]
-      (is (not (fs/exists? mf-dir)) "fresh worktree has no .miniforge dir")
-      (reg/register! *worktree* base-params)
-      (is (fs/exists? mf-dir) ".miniforge dir created")
-      (is (fs/exists? (fs/path mf-dir "listener-registry.edn"))
-          "registry artifact written"))))
-
-;; ── transition guards (terminal states are sticky) ───────────────────
-
-(deftest unregister-rejects-non-active-entries
-  (testing "unregister! returns :wrong-status on already-cancelled entries (no overwrite)"
-    (let [r1 (reg/register! *worktree* base-params)
-          lid (-> r1 :data :listener-id)
-          _   (reg/unregister! *worktree* (:pr/url base-params) lid) ; first call: ok
-          r2  (reg/unregister! *worktree* (:pr/url base-params) lid)] ; second: guard fires
-      (is (not (dag/ok? r2)))
-      (is (= :listener-registry/wrong-status (get-in r2 [:error :code])))
-      (is (= :cancelled (get-in r2 [:error :data :current-status])))
-      (is (= :active    (get-in r2 [:error :data :expected-status]))))))
-
-(deftest unregister-rejects-dispatched-entries
-  (testing "unregister! does NOT downgrade a :dispatched entry to :cancelled"
-    (let [r1 (reg/register! *worktree* base-params)
-          lid (-> r1 :data :listener-id)
-          _   (reg/mark-dispatched! *worktree* (:pr/url base-params) lid (random-uuid))
-          r2  (reg/unregister! *worktree* (:pr/url base-params) lid)]
-      (is (not (dag/ok? r2)))
-      (is (= :listener-registry/wrong-status (get-in r2 [:error :code])))
-      (let [entries (reg/entries-for-pr (:data (reg/read-registry *worktree*))
-                                        (:pr/url base-params))]
-        (is (= :dispatched (:status (first entries)))
-            "entry remains :dispatched, not silently overwritten")))))
-
-(deftest mark-dispatched-rejects-non-active-entries
-  (testing "mark-dispatched! refuses to dispatch a cancelled listener"
-    (let [r1 (reg/register! *worktree* base-params)
-          lid (-> r1 :data :listener-id)
-          _   (reg/unregister! *worktree* (:pr/url base-params) lid)
-          r2  (reg/mark-dispatched! *worktree* (:pr/url base-params) lid (random-uuid))]
-      (is (not (dag/ok? r2)))
-      (is (= :listener-registry/wrong-status (get-in r2 [:error :code])))
-      (is (= :cancelled (get-in r2 [:error :data :current-status]))))))
-
-(deftest mark-dispatched-is-not-idempotent-by-design
-  (testing "double-dispatch is rejected, not silently re-stamped"
-    (let [r1 (reg/register! *worktree* base-params)
-          lid (-> r1 :data :listener-id)
-          d1  (random-uuid)
-          d2  (random-uuid)
-          _   (reg/mark-dispatched! *worktree* (:pr/url base-params) lid d1)
-          r2  (reg/mark-dispatched! *worktree* (:pr/url base-params) lid d2)]
-      (is (not (dag/ok? r2)))
-      (let [entries (reg/entries-for-pr (:data (reg/read-registry *worktree*))
-                                        (:pr/url base-params))
-            entry (first entries)]
-        (is (= d1 (:resume/dispatch-id entry))
-            "first dispatch-id sticks; second call doesn't overwrite")))))
-
-;; ── read strictness (trailing forms + schema) ────────────────────────
-
-(deftest read-rejects-trailing-forms
-  (testing "valid registry followed by trailing data is rejected as :read-failed"
-    (let [path (str (fs/path *worktree* reg/default-storage-path))]
-      (fs/create-dirs (fs/parent path))
-      (spit path (str (pr-str reg/empty-registry) " {:trailing :junk}")))
-    (let [r (reg/read-registry *worktree*)]
-      (is (not (dag/ok? r)))
-      (is (= :listener-registry/read-failed (get-in r [:error :code]))))))
-
-(deftest read-rejects-schema-mismatch
-  (testing ":registry/listeners as a list (not a vector) fails malli validation on load"
-    (let [path (str (fs/path *worktree* reg/default-storage-path))
-          ;; bypass our normal write so we can craft a bad-but-shaped artifact
-          bad  {:registry/version reg/registry-version
-                :registry/last-updated (java.util.Date.)
-                :registry/listeners {"https://github.com/o/r/pull/1"
-                                     '({:listener/id (random-uuid)})}}]
-      (fs/create-dirs (fs/parent path))
-      (spit path (pr-str bad)))
-    (let [r (reg/read-registry *worktree*)]
-      (is (not (dag/ok? r)))
-      (is (= :listener-registry/read-failed (get-in r [:error :code])))
-      (is (some? (get-in r [:error :data :explain]))
-          "malli explain payload is included so callers can diagnose"))))
-
-;; ── tmp file cleanup on move failure ─────────────────────────────────
-
-(deftest write-cleans-up-tmp-on-move-failure
-  (testing "if fs/move throws, the .tmp file written by spit is best-effort-deleted"
-    (let [path (str (fs/path *worktree* reg/default-storage-path))
-          tmp-path (str path ".tmp")]
-      (with-redefs [babashka.fs/move (fn [& _]
-                                        (throw (java.lang.UnsupportedOperationException.
-                                                "atomic-move not supported on this fs (simulated)")))]
-        (let [r (reg/write-registry! *worktree* reg/empty-registry)]
-          (is (not (dag/ok? r)))
-          (is (= :listener-registry/write-failed (get-in r [:error :code])))
-          (is (= tmp-path (get-in r [:error :data :tmp-path])))
-          (is (= "java.lang.UnsupportedOperationException"
-                 (get-in r [:error :data :exception-class])))
-          (is (not (fs/exists? tmp-path))
-              ".tmp file should be deleted on move failure to avoid accumulating stale artifacts"))))))
+(use-fixtures :each worktree-fixture)

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/merge_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/merge_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.merge-test
   "Unit tests for merge policy and readiness evaluation.
 
@@ -27,17 +26,17 @@
    [ai.miniforge.pr-lifecycle.conflict-resolution :as conflict-resolution]
    [ai.miniforge.pr-lifecycle.merge :as merge]))
 
-;------------------------------------------------------------------------------ Merge Methods
+;------------------------------------------------------------------------------ Layer 0
 
-(deftest merge-methods-test
+;------------------------------------------------------------------------------ Merge Methods
+(deftest ^{:stratum 0} merge-methods-test
   (testing "All merge methods are defined"
     (is (= 3 (count merge/merge-methods)))
     (are [method] (contains? merge/merge-methods method)
       :merge :squash :rebase)))
 
 ;------------------------------------------------------------------------------ Default Merge Policy
-
-(deftest default-merge-policy-test
+(deftest ^{:stratum 0} default-merge-policy-test
   (testing "Default policy has expected values"
     (let [policy merge/default-merge-policy]
       (is (= :squash (:method policy))
@@ -51,8 +50,7 @@
       (is (true? (:auto-rebase-on-stale? policy))))))
 
 ;------------------------------------------------------------------------------ Merge Readiness Evaluation
-
-(deftest evaluate-merge-readiness-all-green-test
+(deftest ^{:stratum 0} evaluate-merge-readiness-all-green-test
   (testing "All checks passing yields ready"
     (with-redefs [merge/check-ci-status
                   (fn [_ _] (dag/ok {:ci-green? true}))
@@ -67,7 +65,7 @@
         (is (true? (:ready? result)))
         (is (empty? (:blocking result)))))))
 
-(deftest evaluate-merge-readiness-ci-not-green-test
+(deftest ^{:stratum 0} evaluate-merge-readiness-ci-not-green-test
   (testing "CI not green blocks merge"
     (with-redefs [merge/check-ci-status
                   (fn [_ _] (dag/ok {:ci-green? false}))
@@ -82,7 +80,7 @@
         (is (false? (:ready? result)))
         (is (some #{:ci-not-green} (:blocking result)))))))
 
-(deftest evaluate-merge-readiness-not-approved-test
+(deftest ^{:stratum 0} evaluate-merge-readiness-not-approved-test
   (testing "Missing approval blocks merge"
     (with-redefs [merge/check-ci-status
                   (fn [_ _] (dag/ok {:ci-green? true}))
@@ -97,7 +95,7 @@
         (is (false? (:ready? result)))
         (is (some #{:not-approved} (:blocking result)))))))
 
-(deftest evaluate-merge-readiness-branch-stale-test
+(deftest ^{:stratum 0} evaluate-merge-readiness-branch-stale-test
   (testing "Stale branch blocks merge"
     (with-redefs [merge/check-ci-status
                   (fn [_ _] (dag/ok {:ci-green? true}))
@@ -112,7 +110,7 @@
         (is (false? (:ready? result)))
         (is (some #{:branch-not-up-to-date} (:blocking result)))))))
 
-(deftest evaluate-merge-readiness-unresolved-threads-test
+(deftest ^{:stratum 0} evaluate-merge-readiness-unresolved-threads-test
   (testing "Unresolved threads block merge"
     (with-redefs [merge/check-ci-status
                   (fn [_ _] (dag/ok {:ci-green? true}))
@@ -127,7 +125,7 @@
         (is (false? (:ready? result)))
         (is (some #{:unresolved-threads} (:blocking result)))))))
 
-(deftest evaluate-merge-readiness-multiple-blockers-test
+(deftest ^{:stratum 0} evaluate-merge-readiness-multiple-blockers-test
   (testing "Multiple blocking conditions are all reported"
     (with-redefs [merge/check-ci-status
                   (fn [_ _] (dag/ok {:ci-green? false}))
@@ -142,7 +140,7 @@
         (is (false? (:ready? result)))
         (is (= 4 (count (:blocking result))))))))
 
-(deftest evaluate-merge-readiness-relaxed-policy-test
+(deftest ^{:stratum 0} evaluate-merge-readiness-relaxed-policy-test
   (testing "Relaxed policy skips disabled checks"
     (let [relaxed-policy {:method :squash
                           :require-ci-green? false
@@ -156,8 +154,7 @@
       (is (empty? (:blocking result))))))
 
 ;------------------------------------------------------------------------------ Attempt Merge with Mocks
-
-(deftest attempt-merge-ready-and-succeeds-test
+(deftest ^{:stratum 0} attempt-merge-ready-and-succeeds-test
   (testing "Merge succeeds when ready"
     (with-redefs [merge/evaluate-merge-readiness
                   (fn [_ _ _] {:ready? true :checks {} :blocking []})
@@ -169,7 +166,7 @@
         (is (dag/ok? result))
         (is (true? (:merged? (:data result))))))))
 
-(deftest attempt-merge-not-ready-no-rebase-test
+(deftest ^{:stratum 0} attempt-merge-not-ready-no-rebase-test
   (testing "Merge blocked without auto-rebase yields error"
     (with-redefs [merge/evaluate-merge-readiness
                   (fn [_ _ _] {:ready? false
@@ -182,8 +179,7 @@
         (is (dag/err? result))))))
 
 ;------------------------------------------------------------------------------ Stage 3d: conflict-resolution dispatch
-
-(def ^:private conflicting-readiness
+(def ^{:stratum 0} ^:private conflicting-readiness
   "Readiness map shaped like evaluate-merge-readiness output where
    the branch check failed via CONFLICTING (DIRTY mergeStateStatus)."
   {:ready? false
@@ -191,7 +187,42 @@
                              :raw "{\"mergeable\":\"CONFLICTING\",\"mergeStateStatus\":\"DIRTY\"}"})}
    :blocking [:branch-not-up-to-date]})
 
-(deftest attempt-merge-conflicting-engages-resolver-test
+(deftest ^{:stratum 0} pr-info-from-gh-rejects-malformed-json-test
+  (testing "PR #805 review fix: pr-info-from-gh now parses gh's
+            JSON output via Cheshire (the same parser
+            github.clj / pr_poller.clj already use). When gh's
+            output isn't valid JSON, return a structured
+            :pr-info-invalid-json dag/err instead of silently
+            returning nils. The previous regex parser would have
+            quietly succeeded on partial matches and broken
+            downstream — Cheshire fails loud."
+    (with-redefs [merge/run-gh-command
+                  (fn [_ _]
+                    (dag/ok {:output "not actually json {{{"}))]
+      (let [r (#'merge/pr-info-from-gh "/tmp" 123)]
+        (is (dag/err? r))
+        (is (= :pr-info-invalid-json (:code (:error r))))))))
+
+(deftest ^{:stratum 0} pr-info-from-gh-parses-valid-json-test
+  (testing "Happy path: well-formed gh JSON output parses into
+            the {:pr/* ...} shape via Cheshire."
+    (with-redefs [merge/run-gh-command
+                  (fn [_ _]
+                    (dag/ok {:output (str "{\"number\":42,"
+                                          "\"headRefName\":\"feat/y\","
+                                          "\"baseRefName\":\"develop\","
+                                          "\"headRefOid\":\"sha-head\","
+                                          "\"baseRefOid\":\"sha-base\"}")}))]
+      (let [r (#'merge/pr-info-from-gh "/tmp" 42)]
+        (is (dag/ok? r))
+        (is (= "feat/y" (:pr/branch (:data r))))
+        (is (= "develop" (:pr/base (:data r))))
+        (is (= "sha-head" (:pr/head-sha (:data r))))
+        (is (= "sha-base" (:pr/base-sha (:data r))))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} attempt-merge-conflicting-engages-resolver-test
   (testing "When branch-check raw classifies as :conflicting AND
             policy enables auto-resolve AND context carries
             :resolve-fn, attempt-merge dispatches to
@@ -229,7 +260,7 @@
               "attempt-merge returns the resolution outcome directly
                — no rebase fallback when conflict-resolution engaged"))))))
 
-(deftest attempt-merge-conflicting-without-resolver-falls-through-test
+(deftest ^{:stratum 1} attempt-merge-conflicting-without-resolver-falls-through-test
   (testing "When the branch is :conflicting but context has no
             :resolve-fn (workflow side didn't inject one), the
             conflict-resolution dispatch declines (returns nil)
@@ -248,7 +279,7 @@
         (is (= :not-ready (:code (:error result)))
             "fell through to the not-ready path")))))
 
-(deftest attempt-merge-conflicting-unresolvable-anomaly-becomes-dag-err-test
+(deftest ^{:stratum 1} attempt-merge-conflicting-unresolvable-anomaly-becomes-dag-err-test
   (testing "PR #805 review fix: conflict-resolution can return a
             terminal `:dag-multi-parent-unresolvable` anomaly map.
             Letting that bubble out of attempt-merge breaks the
@@ -289,40 +320,7 @@
           (is (= terminal-anomaly (get-in result [:error :data :anomaly]))
               "original anomaly preserved for diagnostic surfacing"))))))
 
-(deftest pr-info-from-gh-rejects-malformed-json-test
-  (testing "PR #805 review fix: pr-info-from-gh now parses gh's
-            JSON output via Cheshire (the same parser
-            github.clj / pr_poller.clj already use). When gh's
-            output isn't valid JSON, return a structured
-            :pr-info-invalid-json dag/err instead of silently
-            returning nils. The previous regex parser would have
-            quietly succeeded on partial matches and broken
-            downstream — Cheshire fails loud."
-    (with-redefs [merge/run-gh-command
-                  (fn [_ _]
-                    (dag/ok {:output "not actually json {{{"}))]
-      (let [r (#'merge/pr-info-from-gh "/tmp" 123)]
-        (is (dag/err? r))
-        (is (= :pr-info-invalid-json (:code (:error r))))))))
-
-(deftest pr-info-from-gh-parses-valid-json-test
-  (testing "Happy path: well-formed gh JSON output parses into
-            the {:pr/* ...} shape via Cheshire."
-    (with-redefs [merge/run-gh-command
-                  (fn [_ _]
-                    (dag/ok {:output (str "{\"number\":42,"
-                                          "\"headRefName\":\"feat/y\","
-                                          "\"baseRefName\":\"develop\","
-                                          "\"headRefOid\":\"sha-head\","
-                                          "\"baseRefOid\":\"sha-base\"}")}))]
-      (let [r (#'merge/pr-info-from-gh "/tmp" 42)]
-        (is (dag/ok? r))
-        (is (= "feat/y" (:pr/branch (:data r))))
-        (is (= "develop" (:pr/base (:data r))))
-        (is (= "sha-head" (:pr/head-sha (:data r))))
-        (is (= "sha-base" (:pr/base-sha (:data r))))))))
-
-(deftest attempt-merge-conflicting-with-policy-disabled-falls-through-test
+(deftest ^{:stratum 1} attempt-merge-conflicting-with-policy-disabled-falls-through-test
   (testing "Even with a :resolve-fn on context, if policy's
             :auto-resolve-conflicts? is false, the dispatch
             declines and we fall through to rebase/not-ready.

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/monitor_budget_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/monitor_budget_test.clj
@@ -15,16 +15,15 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.monitor-budget-test
   (:require
    [ai.miniforge.pr-lifecycle.monitor-budget :as sut]
    [clojure.test :refer [deftest is testing]]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Budget tests
 
-(deftest record-fix-attempt-test
+;; Budget tests
+(deftest ^{:stratum 0} record-fix-attempt-test
   (testing "defaults are loaded from monitor config"
     (let [budget (sut/create-budget 42)]
       (is (= 3 (get-in budget [:limits :max-fix-attempts-per-comment])))
@@ -42,7 +41,7 @@
       (is (= 1 (sut/comment-attempts-remaining budget 1001)))
       (is (= 7 (sut/total-attempts-remaining budget))))))
 
-(deftest any-budget-exhausted-test
+(deftest ^{:stratum 0} any-budget-exhausted-test
   (testing "reports comment limit when a single comment runs out of attempts"
     (let [budget (-> (sut/create-budget 42)
                      (sut/record-fix-attempt 1001)

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/monitor_handlers_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/monitor_handlers_test.clj
@@ -15,14 +15,15 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.monitor-handlers-test
   (:require
    [ai.miniforge.pr-lifecycle.monitor-handlers :as handlers]
    [ai.miniforge.pr-lifecycle.monitor-state :as state]
    [clojure.test :refer [deftest is testing]]))
 
-(deftest decision-action-maps-categories-test
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} decision-action-maps-categories-test
   (testing "each comment category maps to the PR-monitor's action verb"
     (is (= :fix     (#'handlers/decision-action :change-request)))
     (is (= :answer  (#'handlers/decision-action :question)))
@@ -31,7 +32,7 @@
     (is (= :skip    (#'handlers/decision-action :noise)))
     (is (= :skip    (#'handlers/decision-action :anything-unrecognised)))))
 
-(deftest route-comment-records-typed-decision-test
+(deftest ^{:stratum 0} route-comment-records-typed-decision-test
   (testing "route-comment emits one :pr-monitor/decision-recorded act with provenance"
     (let [emitted (atom [])]
       (with-redefs [state/emit! (fn [_ ev] (swap! emitted conj ev))

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/monitor_loop_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/monitor_loop_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.monitor-loop-test
   (:require
    [ai.miniforge.pr-lifecycle.events :as events]
@@ -23,7 +22,9 @@
    [ai.miniforge.pr-lifecycle.pr-poller :as poller]
    [clojure.test :refer [deftest is testing]]))
 
-(deftest actionable-comments-test
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} actionable-comments-test
   (testing "change requests and questions are routed, approvals are not"
     (let [classified {:change-requests [{:comment {:id 1}}]
                       :questions [{:comment {:id 2}}]
@@ -32,7 +33,7 @@
              (mapv #(get-in % [:comment :id])
                    (#'sut/actionable-comments classified)))))))
 
-(deftest time-budget-stop-result-test
+(deftest ^{:stratum 0} time-budget-stop-result-test
   (testing "time budget exhaustion yields a stopped cycle result"
     (let [result (#'sut/time-budget-stop-result 42)]
       (is (= 0 (:processed result)))
@@ -42,9 +43,8 @@
 ;; ---------------------------------------------------------------------------
 ;; Loop lifecycle event emission tests
 ;; ---------------------------------------------------------------------------
-
 ;; A minimal fake PR info that satisfies run-cycle's expectations.
-(def ^:private fake-pr
+(def ^{:stratum 0} ^:private fake-pr
   {:pr/number  99
    :pr/url     "https://github.com/example/repo/pull/99"
    :pr/title   "Test PR"
@@ -52,32 +52,12 @@
    :pr/sha     "abc123"
    :pr/updated-at "2026-06-15T00:00:00Z"})
 
-(defn- ok
+(defn- ^{:stratum 0} ok
   "Wrap data in a result map that dag/err? treats as success."
   [data]
   {:ok? true :data data})
 
-(defn- no-prs
-  "poll-open-prs stub that always returns an empty PR list."
-  [_worktree-path _author]
-  (ok {:prs []}))
-
-(defn- one-pr-then-empty
-  "Returns a poll-open-prs stub that yields [fake-pr] for n-iters calls, then empty."
-  [n-iters]
-  (let [call-count (atom 0)]
-    (fn [_worktree-path _author]
-      (if (< @call-count n-iters)
-        (do (swap! call-count inc)
-            (ok {:prs [fake-pr]}))
-        (ok {:prs []})))))
-
-(defn- no-new-comments
-  "poll-pr-for-new-comments stub: no new comments, empty watermarks."
-  [_worktree-path _pr-number _watermarks _logger]
-  (ok {:new-comments [] :watermarks {}}))
-
-(defn- make-test-monitor
+(defn- ^{:stratum 0} make-test-monitor
   "Build a monitor atom directly, bypassing classpath config and disk I/O.
    Caller supplies extra-config keys to merge; pass an :event-bus (via
    extra-config) when asserting on emissions — it defaults to nil otherwise."
@@ -105,7 +85,43 @@
                   :fixes-pushed       []
                   :questions-answered []}})))
 
-(defn- run-with-stubs
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} no-prs
+  "poll-open-prs stub that always returns an empty PR list."
+  [_worktree-path _author]
+  (ok {:prs []}))
+
+(defn- ^{:stratum 1} one-pr-then-empty
+  "Returns a poll-open-prs stub that yields [fake-pr] for n-iters calls, then empty."
+  [n-iters]
+  (let [call-count (atom 0)]
+    (fn [_worktree-path _author]
+      (if (< @call-count n-iters)
+        (do (swap! call-count inc)
+            (ok {:prs [fake-pr]}))
+        (ok {:prs []})))))
+
+(defn- ^{:stratum 1} no-new-comments
+  "poll-pr-for-new-comments stub: no new comments, empty watermarks."
+  [_worktree-path _pr-number _watermarks _logger]
+  (ok {:new-comments [] :watermarks {}}))
+
+;; ---------------------------------------------------------------------------
+;; (4) Manual stop reason (unit-level, no loop needed)
+(deftest ^{:stratum 1} manual-stop-reason-test
+  (testing "stop-monitor-loop sets :running? false and :stop-reason :manual-stop"
+    (let [monitor (make-test-monitor {})]
+      (swap! monitor assoc :running? true)
+      (sut/stop-monitor-loop monitor)
+      (is (false? (:running? @monitor))
+          ":running? must be false after stop")
+      (is (= :manual-stop (:stop-reason @monitor))
+          "stop reason must be :manual-stop"))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- ^{:stratum 2} run-with-stubs
   "Run run-monitor-loop inside with-redefs that replace all I/O-touching poller
    functions.  poll-open-prs-fn controls which PRs each iteration sees."
   [monitor poll-open-prs-fn]
@@ -114,10 +130,11 @@
                 poller/save-watermarks!          (constantly nil)]
     (sut/run-monitor-loop monitor "bot")))
 
+;------------------------------------------------------------------------------ Layer 3
+
 ;; ---------------------------------------------------------------------------
 ;; (1) Loop start emission
-
-(deftest loop-started-event-emitted-test
+(deftest ^{:stratum 3} loop-started-event-emitted-test
   (testing "run-monitor-loop emits :pr-monitor/loop-started on entry before polling"
     (let [bus     (events/create-event-bus)
           monitor (make-test-monitor {:event-bus bus})]
@@ -135,8 +152,7 @@
 
 ;; ---------------------------------------------------------------------------
 ;; (2) Per-iteration heartbeat
-
-(deftest cycle-completed-heartbeat-test
+(deftest ^{:stratum 3} cycle-completed-heartbeat-test
   (testing "finalize-loop-iteration! emits :pr-monitor/cycle-completed per iteration"
     (let [n-iters 3
           bus     (events/create-event-bus)
@@ -158,8 +174,7 @@
 
 ;; ---------------------------------------------------------------------------
 ;; (3) Loop stop emission
-
-(deftest loop-stopped-event-emitted-test
+(deftest ^{:stratum 3} loop-stopped-event-emitted-test
   (testing "run-monitor-loop emits :pr-monitor/loop-stopped when no open PRs found"
     (let [bus     (events/create-event-bus)
           monitor (make-test-monitor {:event-bus bus})]
@@ -174,22 +189,8 @@
             "stop reason is :no-open-prs")))))
 
 ;; ---------------------------------------------------------------------------
-;; (4) Manual stop reason (unit-level, no loop needed)
-
-(deftest manual-stop-reason-test
-  (testing "stop-monitor-loop sets :running? false and :stop-reason :manual-stop"
-    (let [monitor (make-test-monitor {})]
-      (swap! monitor assoc :running? true)
-      (sut/stop-monitor-loop monitor)
-      (is (false? (:running? @monitor))
-          ":running? must be false after stop")
-      (is (= :manual-stop (:stop-reason @monitor))
-          "stop reason must be :manual-stop"))))
-
-;; ---------------------------------------------------------------------------
 ;; (5) Event ordering
-
-(deftest event-ordering-test
+(deftest ^{:stratum 3} event-ordering-test
   (testing "loop-started precedes any cycle-completed; loop-stopped is last"
     (let [n-iters 2
           bus     (events/create-event-bus)

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/monitor_state_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/monitor_state_test.clj
@@ -15,20 +15,21 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.monitor-state-test
   (:require
    [ai.miniforge.pr-lifecycle.monitor-budget :as budget]
    [ai.miniforge.pr-lifecycle.monitor-state :as sut]
    [clojure.test :refer [deftest is testing]]))
 
-(deftest create-monitor-test
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} create-monitor-test
   (testing "shared defaults are loaded into the monitor config"
     (let [monitor (sut/create-monitor {:self-author "miniforge[bot]"})]
       (is (= 60000 (get-in @monitor [:config :poll-interval-ms])))
       (is (= "miniforge[bot]" (get-in @monitor [:config :self-author]))))))
 
-(deftest load-budget-from-disk!-test
+(deftest ^{:stratum 0} load-budget-from-disk!-test
   (testing "persisted budgets are loaded and cached on the monitor"
     (let [monitor (atom {:config {} :budgets {}})
           persisted {:pr-number 42 :limits {} :comment-attempts {} :total-attempts 0

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/monitor_worklist_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/monitor_worklist_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.monitor-worklist-test
   "Tests for the PR monitor work-list namespace.
 
@@ -30,11 +29,12 @@
    [ai.miniforge.schema.interface :as schema]
    [ai.miniforge.pr-lifecycle.monitor-worklist :as worklist]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;------------------------------------------------------------------------------ Fixtures
+(def ^{:stratum 0} ^:private known-url "https://github.com/miniforge-ai/miniforge.git")
 
-(def ^:private known-url "https://github.com/miniforge-ai/miniforge.git")
-
-(defn- make-pr-entry
+(defn- ^{:stratum 0} make-pr-entry
   "Build a minimal valid WorklistPrEntry."
   [number repo]
   {:pr/url      (str "https://github.com/" repo "/pull/" number)
@@ -42,7 +42,73 @@
    :pr/repo     repo
    :pr/added-at (java.util.Date.)})
 
-(defn- make-entry
+;; worklist-path
+(deftest ^{:stratum 0} worklist-path-test
+  (testing "assembles path under pr-monitor subdir with .edn extension"
+    (let [home "/home/user/.miniforge"
+          rkey "abc123def456"
+          path (worklist/worklist-path home rkey)]
+      (is (str/includes? path "pr-monitor"))
+      (is (str/includes? path rkey))
+      (is (str/ends-with? path ".edn"))))
+
+  (testing "path starts with home-dir"
+    (let [home "/custom/home"
+          path (worklist/worklist-path home "deadbeef1234")]
+      (is (str/starts-with? path home)))))
+
+(deftest ^{:stratum 0} persist-worklist-invalid-entry-test
+  (testing "returns schema/failure on schema mismatch, no file written"
+    (fs/with-temp-dir [tmp {}]
+      (let [path  (str (fs/path tmp "worklist.edn"))
+            ;; Missing required :worklist/updated-at
+            entry {:worklist/repo-key "abc123def456"
+                   :worklist/prs      []}]
+        (let [result (worklist/persist-worklist! path entry)]
+          (is (schema/failed? result))
+          (is (not (fs/exists? path))))))))
+
+(deftest ^{:stratum 0} load-worklist-missing-test
+  (testing "returns schema/failure for a non-existent path"
+    (let [result (worklist/load-worklist "/no/such/path/worklist.edn")]
+      (is (schema/failed? result))
+      (is (some? (:error result))))))
+
+(deftest ^{:stratum 0} load-worklist-corrupt-edn-test
+  (testing "returns schema/failure for unparseable EDN"
+    (fs/with-temp-dir [tmp {}]
+      (let [path (str (fs/path tmp "worklist.edn"))]
+        (spit path "this is not valid EDN }{{{")
+        (is (schema/failed? (worklist/load-worklist path))))))
+
+  (testing "returns schema/failure for EDN that fails WorklistEntry schema"
+    (fs/with-temp-dir [tmp {}]
+      (let [path (str (fs/path tmp "worklist.edn"))]
+        ;; Valid EDN but wrong shape
+        (spit path (pr-str {:not-a-worklist true}))
+        (is (schema/failed? (worklist/load-worklist path)))))))
+
+(deftest ^{:stratum 0} fetch-pr-state-tolerates-whitespace-json-test
+  ;; Copilot #1198: gh's --json is compact today, but a pretty-printed
+  ;; `"state": "OPEN"` (whitespace around the colon) must still parse.
+  (testing "whitespace around the colon in gh JSON still extracts the state"
+    (with-redefs [process/process (fn [& _] (future {:exit 0
+                                                     :out "{\n  \"state\": \"OPEN\"\n}"
+                                                     :err ""}))]
+      (is (= "OPEN"
+             (#'ai.miniforge.pr-lifecycle.monitor-worklist/fetch-pr-state
+              {:pr/number 1 :pr/repo "org/repo"})))))
+  (testing "compact JSON still parses"
+    (with-redefs [process/process (fn [& _] (future {:exit 0
+                                                     :out "{\"state\":\"MERGED\"}"
+                                                     :err ""}))]
+      (is (= "MERGED"
+             (#'ai.miniforge.pr-lifecycle.monitor-worklist/fetch-pr-state
+              {:pr/number 2 :pr/repo "org/repo"}))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} make-entry
   "Build a minimal valid WorklistEntry for testing."
   ([]
    (make-entry [(make-pr-entry 42 "org/repo")]))
@@ -51,13 +117,14 @@
     :worklist/prs        prs
     :worklist/updated-at (java.util.Date.)}))
 
-(def ^:private open-pr   (make-pr-entry 1 "org/repo"))
-(def ^:private merged-pr (make-pr-entry 2 "org/repo"))
-(def ^:private closed-pr (make-pr-entry 3 "org/repo"))
+(def ^{:stratum 1} ^:private open-pr   (make-pr-entry 1 "org/repo"))
 
-;------------------------------------------------------------------------------ Layer 1: repo-key
+(def ^{:stratum 1} ^:private merged-pr (make-pr-entry 2 "org/repo"))
 
-(deftest repo-key-deterministic-test
+(def ^{:stratum 1} ^:private closed-pr (make-pr-entry 3 "org/repo"))
+
+;; repo-key
+(deftest ^{:stratum 1} repo-key-deterministic-test
   (testing "same URL always produces the same key"
     (is (= (worklist/repo-key known-url)
            (worklist/repo-key known-url))))
@@ -72,25 +139,10 @@
   (testing "key is lowercase hex"
     (is (re-matches #"[0-9a-f]+" (worklist/repo-key known-url)))))
 
-;------------------------------------------------------------------------------ Layer 1: worklist-path
+;------------------------------------------------------------------------------ Layer 2
 
-(deftest worklist-path-test
-  (testing "assembles path under pr-monitor subdir with .edn extension"
-    (let [home "/home/user/.miniforge"
-          rkey "abc123def456"
-          path (worklist/worklist-path home rkey)]
-      (is (str/includes? path "pr-monitor"))
-      (is (str/includes? path rkey))
-      (is (str/ends-with? path ".edn"))))
-
-  (testing "path starts with home-dir"
-    (let [home "/custom/home"
-          path (worklist/worklist-path home "deadbeef1234")]
-      (is (str/starts-with? path home)))))
-
-;------------------------------------------------------------------------------ Layer 2: persist-worklist!
-
-(deftest persist-worklist-happy-test
+;; persist-worklist!
+(deftest ^{:stratum 2} persist-worklist-happy-test
   (testing "creates dirs and writes EDN, returns schema/success"
     (fs/with-temp-dir [tmp {}]
       (let [rkey  "abc123def456"
@@ -101,18 +153,7 @@
           (is (= entry (:worklist result)))
           (is (fs/exists? path)))))))
 
-(deftest persist-worklist-invalid-entry-test
-  (testing "returns schema/failure on schema mismatch, no file written"
-    (fs/with-temp-dir [tmp {}]
-      (let [path  (str (fs/path tmp "worklist.edn"))
-            ;; Missing required :worklist/updated-at
-            entry {:worklist/repo-key "abc123def456"
-                   :worklist/prs      []}]
-        (let [result (worklist/persist-worklist! path entry)]
-          (is (schema/failed? result))
-          (is (not (fs/exists? path))))))))
-
-(deftest persist-worklist-io-error-test
+(deftest ^{:stratum 2} persist-worklist-io-error-test
   (testing "returns schema/failure when a file blocks directory creation"
     (fs/with-temp-dir [tmp {}]
       ;; Place a regular file where fs/create-dirs would need to create a dir
@@ -123,9 +164,8 @@
               result (worklist/persist-worklist! path entry)]
           (is (schema/failed? result)))))))
 
-;------------------------------------------------------------------------------ Layer 2: load-worklist
-
-(deftest load-worklist-happy-test
+;; load-worklist
+(deftest ^{:stratum 2} load-worklist-happy-test
   (testing "round-trips a persisted entry"
     (fs/with-temp-dir [tmp {}]
       (let [rkey  "abc123def456"
@@ -136,29 +176,8 @@
           (is (schema/succeeded? result))
           (is (= entry (:worklist result))))))))
 
-(deftest load-worklist-missing-test
-  (testing "returns schema/failure for a non-existent path"
-    (let [result (worklist/load-worklist "/no/such/path/worklist.edn")]
-      (is (schema/failed? result))
-      (is (some? (:error result))))))
-
-(deftest load-worklist-corrupt-edn-test
-  (testing "returns schema/failure for unparseable EDN"
-    (fs/with-temp-dir [tmp {}]
-      (let [path (str (fs/path tmp "worklist.edn"))]
-        (spit path "this is not valid EDN }{{{")
-        (is (schema/failed? (worklist/load-worklist path))))))
-
-  (testing "returns schema/failure for EDN that fails WorklistEntry schema"
-    (fs/with-temp-dir [tmp {}]
-      (let [path (str (fs/path tmp "worklist.edn"))]
-        ;; Valid EDN but wrong shape
-        (spit path (pr-str {:not-a-worklist true}))
-        (is (schema/failed? (worklist/load-worklist path)))))))
-
-;------------------------------------------------------------------------------ Layer 2: prune-closed-prs
-
-(deftest prune-keeps-open-drops-merged-closed-test
+;; prune-closed-prs
+(deftest ^{:stratum 2} prune-keeps-open-drops-merged-closed-test
   (testing "keeps OPEN entries, drops MERGED and CLOSED"
     (with-redefs [ai.miniforge.pr-lifecycle.monitor-worklist/fetch-pr-state
                   (fn [{:pr/keys [number]}]
@@ -190,25 +209,7 @@
                     (:worklist/updated-at entry))
             "dropping a PR must advance the last-write instant")))))
 
-(deftest fetch-pr-state-tolerates-whitespace-json-test
-  ;; Copilot #1198: gh's --json is compact today, but a pretty-printed
-  ;; `"state": "OPEN"` (whitespace around the colon) must still parse.
-  (testing "whitespace around the colon in gh JSON still extracts the state"
-    (with-redefs [process/process (fn [& _] (future {:exit 0
-                                                     :out "{\n  \"state\": \"OPEN\"\n}"
-                                                     :err ""}))]
-      (is (= "OPEN"
-             (#'ai.miniforge.pr-lifecycle.monitor-worklist/fetch-pr-state
-              {:pr/number 1 :pr/repo "org/repo"})))))
-  (testing "compact JSON still parses"
-    (with-redefs [process/process (fn [& _] (future {:exit 0
-                                                     :out "{\"state\":\"MERGED\"}"
-                                                     :err ""}))]
-      (is (= "MERGED"
-             (#'ai.miniforge.pr-lifecycle.monitor-worklist/fetch-pr-state
-              {:pr/number 2 :pr/repo "org/repo"}))))))
-
-(deftest prune-gh-failure-test
+(deftest ^{:stratum 2} prune-gh-failure-test
   (testing "returns anomaly when fetch-pr-state returns anomaly"
     (with-redefs [ai.miniforge.pr-lifecycle.monitor-worklist/fetch-pr-state
                   (fn [pr]

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/policy_eval_responder_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/policy_eval_responder_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.policy-eval-responder-test
   "Tests for the N13 §2.5 Comment Response Agent (deterministic
    policy-eval path)."
@@ -28,32 +27,18 @@
             [ai.miniforge.pr-lifecycle.github :as github]
             [ai.miniforge.pr-lifecycle.policy-eval-responder :as sut]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; ── fixture: ephemeral worktree ──────────────────────────────────────
+(def ^{:stratum 0} ^:dynamic *worktree* nil)
 
-(def ^:dynamic *worktree* nil)
-
-(defn worktree-fixture [f]
+(defn ^{:stratum 0} worktree-fixture [f]
   (let [w (str (fs/create-temp-dir {:prefix "policy-eval-responder-test-"}))]
     (try
       (binding [*worktree* w] (f))
       (finally (try (fs/delete-tree w) (catch Throwable _ nil))))))
 
-(use-fixtures :each worktree-fixture)
-
-;; ── helpers ──────────────────────────────────────────────────────────
-
-(defn- write-file!
-  "Write `content` to `*worktree*/relative-path`, creating dirs."
-  [relative-path content]
-  (let [abs (str (fs/path *worktree* relative-path))]
-    (fs/create-dirs (fs/parent abs))
-    (spit abs content)))
-
-(defn- read-file
-  [relative-path]
-  (slurp (str (fs/path *worktree* relative-path))))
-
-(def ^:private fixable-payload
+(def ^{:stratum 0} ^:private fixable-payload
   {:violation/rule-id        :ai.miniforge.standards/exceptions-as-data
    :violation/severity       :warning
    :violation/auto-fixable?  true
@@ -62,13 +47,7 @@
    :violation/pack-id        "miniforge-standards"
    :violation/pack-version   "1.4.0"})
 
-(def ^:private non-fixable-payload
-  (assoc fixable-payload
-         :violation/auto-fixable? false
-         :violation/suggested-fix nil
-         :violation/rule-id :ai.miniforge.standards/no-credentials-in-source))
-
-(defn- comment-with
+(defn- ^{:stratum 0} comment-with
   "Build a comment record carrying `payload` rendered into the body."
   [path line payload & {:keys [author id]
                         :or {author sut/policy-eval-author
@@ -93,37 +72,7 @@
      :comment/line   line
      :comment/body   body}))
 
-;; ── classify-fix ─────────────────────────────────────────────────────
-
-(deftest classify-fix-apply-on-fixable-single-line
-  (let [c (comment-with "src/foo.clj" 5 fixable-payload)
-        r (sut/classify-fix c)]
-    (is (= :apply (:action r)))
-    (is (= :ok (:reason r)))
-    (is (some? (:payload r)))))
-
-(deftest classify-fix-escalate-on-not-fixable
-  (let [c (comment-with "src/sec.clj" 7 non-fixable-payload)
-        r (sut/classify-fix c)]
-    (is (= :escalate (:action r)))
-    (is (= :violation/auto-fixable?-false (:reason r)))))
-
-(deftest classify-fix-escalate-on-multi-line-suggestion
-  (let [p (assoc fixable-payload
-                 :violation/suggested-fix "line one\nline two\nline three")
-        c (comment-with "src/foo.clj" 5 p)
-        r (sut/classify-fix c)]
-    (is (= :escalate (:action r)))
-    (is (= :policy-eval/multi-line-not-supported (:reason r)))))
-
-(deftest classify-fix-escalate-on-blank-suggestion
-  (let [p (assoc fixable-payload :violation/suggested-fix "")
-        c (comment-with "src/foo.clj" 5 p)
-        r (sut/classify-fix c)]
-    (is (= :escalate (:action r)))
-    (is (= :no-suggested-fix (:reason r)))))
-
-(deftest classify-fix-skip-on-no-payload
+(deftest ^{:stratum 0} classify-fix-skip-on-no-payload
   (let [c {:comment/id 1 :comment/author sut/policy-eval-author
            :comment/path "src/x.clj" :comment/line 1
            :comment/body "no edn payload here"}
@@ -131,9 +80,72 @@
     (is (= :skip (:action r)))
     (is (= :no-payload (:reason r)))))
 
-;; ── plan-fixes (partition) ───────────────────────────────────────────
+;------------------------------------------------------------------------------ Layer 1
 
-(deftest plan-fixes-partitions-correctly
+;; ── helpers ──────────────────────────────────────────────────────────
+(defn- ^{:stratum 1} write-file!
+  "Write `content` to `*worktree*/relative-path`, creating dirs."
+  [relative-path content]
+  (let [abs (str (fs/path *worktree* relative-path))]
+    (fs/create-dirs (fs/parent abs))
+    (spit abs content)))
+
+(defn- ^{:stratum 1} read-file
+  [relative-path]
+  (slurp (str (fs/path *worktree* relative-path))))
+
+(def ^{:stratum 1} ^:private non-fixable-payload
+  (assoc fixable-payload
+         :violation/auto-fixable? false
+         :violation/suggested-fix nil
+         :violation/rule-id :ai.miniforge.standards/no-credentials-in-source))
+
+;; ── classify-fix ─────────────────────────────────────────────────────
+(deftest ^{:stratum 1} classify-fix-apply-on-fixable-single-line
+  (let [c (comment-with "src/foo.clj" 5 fixable-payload)
+        r (sut/classify-fix c)]
+    (is (= :apply (:action r)))
+    (is (= :ok (:reason r)))
+    (is (some? (:payload r)))))
+
+(deftest ^{:stratum 1} classify-fix-escalate-on-multi-line-suggestion
+  (let [p (assoc fixable-payload
+                 :violation/suggested-fix "line one\nline two\nline three")
+        c (comment-with "src/foo.clj" 5 p)
+        r (sut/classify-fix c)]
+    (is (= :escalate (:action r)))
+    (is (= :policy-eval/multi-line-not-supported (:reason r)))))
+
+(deftest ^{:stratum 1} classify-fix-escalate-on-blank-suggestion
+  (let [p (assoc fixable-payload :violation/suggested-fix "")
+        c (comment-with "src/foo.clj" 5 p)
+        r (sut/classify-fix c)]
+    (is (= :escalate (:action r)))
+    (is (= :no-suggested-fix (:reason r)))))
+
+(deftest ^{:stratum 1} apply-single-line-replacement-rejects-missing-file
+  (let [r (sut/apply-single-line-replacement!
+           *worktree* "no/such.clj" 1 "(replacement)")]
+    (is (not (dag/ok? r)))
+    (is (= :policy-eval/file-not-found (get-in r [:error :code])))))
+
+(deftest ^{:stratum 1} materialize-fix-decorates-with-comment-id-on-failure
+  (let [c (comment-with "no/such.clj" 1 fixable-payload :id 42)
+        entry {:comment c :payload fixable-payload}
+        r (sut/materialize-fix! *worktree* entry)]
+    (is (not (dag/ok? r)))
+    (is (= 42 (get-in r [:error :data :comment/id])))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} classify-fix-escalate-on-not-fixable
+  (let [c (comment-with "src/sec.clj" 7 non-fixable-payload)
+        r (sut/classify-fix c)]
+    (is (= :escalate (:action r)))
+    (is (= :violation/auto-fixable?-false (:reason r)))))
+
+;; ── plan-fixes (partition) ───────────────────────────────────────────
+(deftest ^{:stratum 2} plan-fixes-partitions-correctly
   (let [a (comment-with "src/a.clj" 1 fixable-payload :id 100)
         b (comment-with "src/b.clj" 2 non-fixable-payload :id 101)
         c (comment-with "src/c.clj" 3 fixable-payload :id 102)
@@ -145,8 +157,7 @@
     (is (empty? (:to-skip plan)))))
 
 ;; ── apply-single-line-replacement! ───────────────────────────────────
-
-(deftest apply-single-line-replacement-success
+(deftest ^{:stratum 2} apply-single-line-replacement-success
   (write-file! "src/foo.clj" "(ns foo)\n(throw (ex-info \"x\" {}))\n(println :ok)\n")
   (let [r (sut/apply-single-line-replacement!
            *worktree* "src/foo.clj" 2
@@ -159,13 +170,7 @@
     (is (not (str/includes? (read-file "src/foo.clj")
                             "(throw (ex-info \"x\" {}))")))))
 
-(deftest apply-single-line-replacement-rejects-missing-file
-  (let [r (sut/apply-single-line-replacement!
-           *worktree* "no/such.clj" 1 "(replacement)")]
-    (is (not (dag/ok? r)))
-    (is (= :policy-eval/file-not-found (get-in r [:error :code])))))
-
-(deftest apply-single-line-replacement-rejects-out-of-range-line
+(deftest ^{:stratum 2} apply-single-line-replacement-rejects-out-of-range-line
   (write-file! "src/short.clj" "line1\nline2\n")
   (let [r (sut/apply-single-line-replacement!
            *worktree* "src/short.clj" 999 "(x)")]
@@ -173,7 +178,7 @@
     (is (= :policy-eval/line-out-of-range (get-in r [:error :code])))
     (is (= 999 (get-in r [:error :data :line])))))
 
-(deftest apply-single-line-replacement-rejects-path-traversal
+(deftest ^{:stratum 2} apply-single-line-replacement-rejects-path-traversal
   (testing "absolute paths + ..-segments are rejected before any file I/O"
     (write-file! "src/inside.clj" "ok\n")
     (doseq [bad ["/etc/passwd"
@@ -186,7 +191,7 @@
     (testing "the legitimate inside file still wrote fine"
       (is (= "ok" (str/trim (read-file "src/inside.clj")))))))
 
-(deftest apply-single-line-replacement-no-op-when-already-applied
+(deftest ^{:stratum 2} apply-single-line-replacement-no-op-when-already-applied
   (testing "before == replacement → :already-applied, no file rewrite, no spurious diff"
     (write-file! "src/idem.clj" "(ns idem)\n(def x 1)\n")
     (let [before-mtime (.lastModified (java.io.File. (str (fs/path *worktree* "src/idem.clj"))))]
@@ -199,7 +204,7 @@
           (is (= before-mtime after-mtime)
               "file mtime unchanged — write was skipped"))))))
 
-(deftest apply-single-line-replacement-preserves-trailing-newline
+(deftest ^{:stratum 2} apply-single-line-replacement-preserves-trailing-newline
   (testing "file with trailing newline keeps its trailing newline after edit"
     (write-file! "src/trail.clj" "line1\nline2\nline3\n")
     (sut/apply-single-line-replacement! *worktree* "src/trail.clj" 2 "line2-new")
@@ -212,8 +217,7 @@
         "no spurious trailing newline added")))
 
 ;; ── materialize-fix! decorates with comment-id ───────────────────────
-
-(deftest materialize-fix-decorates-with-comment-id-on-success
+(deftest ^{:stratum 2} materialize-fix-decorates-with-comment-id-on-success
   (write-file! "src/foo.clj" "line1\n(throw (ex-info \"x\" {}))\nline3\n")
   (let [c (comment-with "src/foo.clj" 2 fixable-payload :id 999)
         entry {:comment c :payload fixable-payload}
@@ -221,16 +225,8 @@
     (is (dag/ok? r))
     (is (= 999 (-> r :data :comment/id)))))
 
-(deftest materialize-fix-decorates-with-comment-id-on-failure
-  (let [c (comment-with "no/such.clj" 1 fixable-payload :id 42)
-        entry {:comment c :payload fixable-payload}
-        r (sut/materialize-fix! *worktree* entry)]
-    (is (not (dag/ok? r)))
-    (is (= 42 (get-in r [:error :data :comment/id])))))
-
 ;; ── respond-to-policy-comments! end-to-end with mocks ────────────────
-
-(deftest respond-end-to-end-only-policy-eval-comments-considered
+(deftest ^{:stratum 2} respond-end-to-end-only-policy-eval-comments-considered
   (testing "comments from non-policy-eval authors are ignored entirely"
     (write-file! "src/foo.clj" "ok\n")
     (let [human-comment {:comment/id 1
@@ -245,7 +241,7 @@
       (is (empty? (-> r :data :skipped))
           "human comments are filtered out before plan-fixes; never enter the buckets"))))
 
-(deftest respond-end-to-end-applies-fixes-and-replies
+(deftest ^{:stratum 2} respond-end-to-end-applies-fixes-and-replies
   (testing "applies fixable comments → commits → pushes → replies + resolves"
     (write-file! "src/foo.clj" "(ns foo)\n(throw (ex-info \"x\" {}))\n(println :ok)\n")
     (write-file! "src/bar.clj" "(println :before)\n")
@@ -291,7 +287,7 @@
           (is (str/includes? (read-file "src/bar.clj")
                              "(println :after)")))))))
 
-(deftest respond-end-to-end-escalates-non-fixable
+(deftest ^{:stratum 2} respond-end-to-end-escalates-non-fixable
   (testing "non-fixable comments end up in :escalated, not :applied"
     (write-file! "src/sec.clj" "ok\n")
     (let [c (comment-with "src/sec.clj" 1 non-fixable-payload :id 333)
@@ -305,7 +301,7 @@
       (is (nil? (:commit-sha data))
           "no commit because nothing was applied"))))
 
-(deftest respond-end-to-end-no-commit-when-zero-fixes
+(deftest ^{:stratum 2} respond-end-to-end-no-commit-when-zero-fixes
   (testing "all-escalated-no-applies path doesn't try to commit/push"
     (let [stub (fn [_ & args] (throw (ex-info "should not be called" {:args args})))]
       (with-redefs [process/shell stub]
@@ -315,7 +311,7 @@
           (is (false? (-> r :data :pushed?))
               "pushed? is false when nothing applied — no git operations"))))))
 
-(deftest respond-end-to-end-already-applied-skips-commit
+(deftest ^{:stratum 2} respond-end-to-end-already-applied-skips-commit
   (testing "all-:already-applied path doesn't commit (would be empty diff)"
     (write-file! "src/idem.clj" "(ns idem)\n(anomaly/throw-anomaly :foo/bad-state {})\n")
     (let [stub (fn [_ & args] (throw (ex-info "should not be called" {:args args})))]
@@ -331,3 +327,5 @@
               ":already-applied entries surface in their own bucket")
           (is (nil? (:commit-sha d))
               "no commit when all fixes are no-ops"))))))
+
+(use-fixtures :each worktree-fixture)

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/pr_poller_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/pr_poller_test.clj
@@ -15,14 +15,15 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.pr-poller-test
   (:require
    [ai.miniforge.pr-lifecycle.pr-poller :as sut]
    [ai.miniforge.dag-executor.interface :as dag]
    [clojure.test :refer [deftest is testing]]))
 
-(deftest current-github-login-test
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} current-github-login-test
   (testing "returns the trimmed login on success"
     (with-redefs [sut/run-gh (fn [_args _wt] (dag/ok {:output "  octocat\n"}))]
       (is (= "octocat" (sut/current-github-login "/tmp/repo")))))
@@ -33,7 +34,7 @@
     (with-redefs [sut/run-gh (fn [_args _wt] (dag/ok {:output "   "}))]
       (is (nil? (sut/current-github-login "/tmp/repo"))))))
 
-(deftest parse-gh-comments-test
+(deftest ^{:stratum 0} parse-gh-comments-test
   (testing "normalizes review comments with file context"
     (let [comments (#'sut/parse-gh-comments
                     "[{\"id\":1,\"body\":\"Please fix\",\"created_at\":\"2026-04-01T12:00:00Z\",\"path\":\"src/core.clj\",\"line\":42,\"user\":{\"login\":\"reviewer\"}}]"
@@ -43,7 +44,7 @@
       (is (= "src/core.clj" (:comment/path (first comments))))
       (is (= 42 (:comment/line (first comments)))))))
 
-(deftest comments-since-test
+(deftest ^{:stratum 0} comments-since-test
   (testing "returns comments strictly newer than the watermark"
     (let [comments [{:comment/created-at "2026-04-01T12:00:00Z" :comment/id 1}
                     {:comment/created-at "2026-04-01T12:05:00Z" :comment/id 2}]]

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/responder_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/responder_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.responder-test
   "Unit tests for PR comment responder.
    Tests URL parsing, comment filtering, spec generation, and orchestration
@@ -30,9 +29,9 @@
    [ai.miniforge.pr-lifecycle.responder :as responder]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; PR URL parsing
 
-(deftest parse-pr-url-test
+;; PR URL parsing
+(deftest ^{:stratum 0} parse-pr-url-test
   (testing "parses standard GitHub PR URL"
     (let [result (responder/parse-pr-url "https://github.com/miniforge-ai/miniforge/pull/483")]
       (is (= "miniforge-ai" (:owner result)))
@@ -48,10 +47,8 @@
     (is (nil? (responder/parse-pr-url "not a url")))
     (is (nil? (responder/parse-pr-url nil)))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Comment filtering
-
-(def review-comment
+(def ^{:stratum 0} review-comment
   {:comment/id 123
    :comment/body "Extract this function"
    :comment/author "reviewer"
@@ -59,63 +56,21 @@
    :comment/line 42
    :comment/type :review-comment})
 
-(def bot-comment
+(def ^{:stratum 0} bot-comment
   {:comment/id 456
    :comment/body "CI passed"
    :comment/author "github-actions[bot]"
    :comment/path "src/foo.clj"
    :comment/type :review-comment})
 
-(def issue-comment
+(def ^{:stratum 0} issue-comment
   {:comment/id 789
    :comment/body "General feedback"
    :comment/author "reviewer"
    :comment/type :issue-comment})
 
-(deftest filter-actionable-comments-test
-  (testing "keeps human review comments"
-    (let [result (responder/filter-actionable-comments [review-comment])]
-      (is (= 1 (count result)))))
-
-  (testing "filters bot comments"
-    (let [result (responder/filter-actionable-comments [review-comment bot-comment])]
-      (is (= 1 (count result)))
-      (is (= "reviewer" (:comment/author (first result))))))
-
-  (testing "filters issue comments (not inline review)"
-    (let [result (responder/filter-actionable-comments [review-comment issue-comment])]
-      (is (= 1 (count result)))))
-
-  (testing "returns empty for no actionable comments"
-    (is (empty? (responder/filter-actionable-comments [bot-comment issue-comment])))))
-
-;------------------------------------------------------------------------------ Layer 2
-;; Comment grouping
-
-(def comment-on-bar
-  (assoc review-comment :comment/id 124 :comment/path "src/bar.clj"))
-
-(def second-comment-on-foo
-  (assoc review-comment :comment/id 125 :comment/body "Also fix this"))
-
-(deftest group-comments-by-file-test
-  (testing "groups comments by path"
-    (let [groups (responder/group-comments-by-file
-                  [review-comment comment-on-bar second-comment-on-foo])]
-      (is (= 2 (count groups)))
-      (let [foo-group (first (filter #(= "src/foo.clj" (:path %)) groups))]
-        (is (= 2 (count (:comment-ids foo-group))))
-        (is (= #{123 125} (set (:comment-ids foo-group)))))))
-
-  (testing "skips comments without path"
-    (let [no-path (dissoc review-comment :comment/path)
-          groups (responder/group-comments-by-file [no-path])]
-      (is (empty? groups)))))
-
-;------------------------------------------------------------------------------ Layer 3
 ;; Fix spec generation
-
-(deftest build-fix-spec-test
+(deftest ^{:stratum 0} build-fix-spec-test
   (testing "generates valid workflow spec with context"
     (let [group {:path "src/foo.clj"
                  :description "Extract this function"
@@ -134,10 +89,8 @@
           spec (responder/build-fix-spec group {:diff nil :files []})]
       (is (nil? (:task/existing-files spec))))))
 
-;------------------------------------------------------------------------------ Layer 4
 ;; Orchestration
-
-(deftest respond-to-comments-no-comments-test
+(deftest ^{:stratum 0} respond-to-comments-no-comments-test
   (testing "returns clean result when no comments found"
     (with-redefs [poller/fetch-pr-comments
                   (fn [_ _] (dag/ok {:comments []}))]
@@ -151,7 +104,60 @@
         (is (= 0 (:files-processed result)))
         (is (false? (:pushed? result)))))))
 
-(deftest respond-to-comments-comments-without-file-groups-test
+(deftest ^{:stratum 0} respond-to-comments-invalid-url-test
+  (testing "returns anomaly on unparseable PR URL"
+    (let [result (responder/respond-to-comments! "not-a-url" "/tmp" (fn [_ _] {}) (fn [] true) {})]
+      (is (anomaly/anomaly? result))
+      (is (= :invalid-input (:anomaly/type result))))))
+
+(deftest ^{:stratum 0} respond-to-comments-fetch-failure-test
+  (testing "returns fetch anomaly without running fixes or pushing"
+    (let [fix-called? (atom false)
+          push-called? (atom false)]
+      (with-redefs [poller/fetch-pr-comments
+                    (fn [_ _] (dag/err :network "down"))]
+        (let [result (responder/respond-to-comments!
+                      "https://github.com/org/repo/pull/1"
+                      "/tmp/worktree"
+                      (fn [& _]
+                        (reset! fix-called? true)
+                        {})
+                      (fn []
+                        (reset! push-called? true)
+                        true)
+                      {})]
+          (is (anomaly/anomaly? result))
+          (is (= :fault (:anomaly/type result)))
+          (is (false? @fix-called?))
+          (is (false? @push-called?)))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} filter-actionable-comments-test
+  (testing "keeps human review comments"
+    (let [result (responder/filter-actionable-comments [review-comment])]
+      (is (= 1 (count result)))))
+
+  (testing "filters bot comments"
+    (let [result (responder/filter-actionable-comments [review-comment bot-comment])]
+      (is (= 1 (count result)))
+      (is (= "reviewer" (:comment/author (first result))))))
+
+  (testing "filters issue comments (not inline review)"
+    (let [result (responder/filter-actionable-comments [review-comment issue-comment])]
+      (is (= 1 (count result)))))
+
+  (testing "returns empty for no actionable comments"
+    (is (empty? (responder/filter-actionable-comments [bot-comment issue-comment])))))
+
+;; Comment grouping
+(def ^{:stratum 1} comment-on-bar
+  (assoc review-comment :comment/id 124 :comment/path "src/bar.clj"))
+
+(def ^{:stratum 1} second-comment-on-foo
+  (assoc review-comment :comment/id 125 :comment/body "Also fix this"))
+
+(deftest ^{:stratum 1} respond-to-comments-comments-without-file-groups-test
   (testing "counts actionable comments even when no file groups are processable"
     (with-redefs [poller/fetch-pr-comments
                   (fn [_ _] (dag/ok {:comments [(dissoc review-comment :comment/path)]}))]
@@ -165,7 +171,7 @@
         (is (= 0 (:files-processed result)))
         (is (false? (:pushed? result)))))))
 
-(deftest respond-to-comments-with-comments-test
+(deftest ^{:stratum 1} respond-to-comments-with-comments-test
   (testing "processes comments, runs fix, and reports results"
     (let [fix-calls (atom [])]
       (with-redefs [poller/fetch-pr-comments
@@ -192,7 +198,7 @@
           (is (true? (get-in result [:fixes 0 :replied?])))
           (is (true? (get-in result [:fixes 0 :resolved?]))))))))
 
-(deftest respond-to-comments-fix-failure-test
+(deftest ^{:stratum 1} respond-to-comments-fix-failure-test
   (testing "reports failure and skips reply when fix fails"
     (with-redefs [poller/fetch-pr-comments
                   (fn [_ _] (dag/ok {:comments [review-comment]}))]
@@ -207,7 +213,7 @@
         (is (nil? (get-in result [:fixes 0 :replied?])))
         (is (false? (:pushed? result)))))))
 
-(deftest respond-to-comments-partial-success-test
+(deftest ^{:stratum 1} respond-to-comments-partial-success-test
   (testing "treats DAG partial success (failed status but PRs produced) as success"
     (with-redefs [poller/fetch-pr-comments
                   (fn [_ _] (dag/ok {:comments [review-comment]}))
@@ -228,7 +234,7 @@
         (is (true? (get-in result [:fixes 0 :replied?])))
         (is (true? (:pushed? result)))))))
 
-(deftest respond-to-comments-total-failure-test
+(deftest ^{:stratum 1} respond-to-comments-total-failure-test
   (testing "treats DAG failure with no PRs as failure"
     (with-redefs [poller/fetch-pr-comments
                   (fn [_ _] (dag/ok {:comments [review-comment]}))]
@@ -242,32 +248,21 @@
         (is (false? (get-in result [:fixes 0 :succeeded?])))
         (is (false? (:pushed? result)))))))
 
-(deftest respond-to-comments-invalid-url-test
-  (testing "returns anomaly on unparseable PR URL"
-    (let [result (responder/respond-to-comments! "not-a-url" "/tmp" (fn [_ _] {}) (fn [] true) {})]
-      (is (anomaly/anomaly? result))
-      (is (= :invalid-input (:anomaly/type result))))))
+;------------------------------------------------------------------------------ Layer 2
 
-(deftest respond-to-comments-fetch-failure-test
-  (testing "returns fetch anomaly without running fixes or pushing"
-    (let [fix-called? (atom false)
-          push-called? (atom false)]
-      (with-redefs [poller/fetch-pr-comments
-                    (fn [_ _] (dag/err :network "down"))]
-        (let [result (responder/respond-to-comments!
-                      "https://github.com/org/repo/pull/1"
-                      "/tmp/worktree"
-                      (fn [& _]
-                        (reset! fix-called? true)
-                        {})
-                      (fn []
-                        (reset! push-called? true)
-                        true)
-                      {})]
-          (is (anomaly/anomaly? result))
-          (is (= :fault (:anomaly/type result)))
-          (is (false? @fix-called?))
-          (is (false? @push-called?)))))))
+(deftest ^{:stratum 2} group-comments-by-file-test
+  (testing "groups comments by path"
+    (let [groups (responder/group-comments-by-file
+                  [review-comment comment-on-bar second-comment-on-foo])]
+      (is (= 2 (count groups)))
+      (let [foo-group (first (filter #(= "src/foo.clj" (:path %)) groups))]
+        (is (= 2 (count (:comment-ids foo-group))))
+        (is (= #{123 125} (set (:comment-ids foo-group)))))))
+
+  (testing "skips comments without path"
+    (let [no-path (dissoc review-comment :comment/path)
+          groups (responder/group-comments-by-file [no-path])]
+      (is (empty? groups)))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/resume_dispatcher_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/resume_dispatcher_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.resume-dispatcher-test
   "Tests for the N13 §2.7 Resume Signal Dispatcher."
   (:require [babashka.fs :as fs]
@@ -28,17 +27,16 @@
             [ai.miniforge.pr-lifecycle.listener-registry :as registry]
             [ai.miniforge.pr-lifecycle.resume-dispatcher :as sut]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; ── fixture: ephemeral worktree ──────────────────────────────────────
+(def ^{:stratum 0} ^:dynamic *worktree* nil)
 
-(def ^:dynamic *worktree* nil)
-
-(defn worktree-fixture [f]
+(defn ^{:stratum 0} worktree-fixture [f]
   (let [w (str (fs/create-temp-dir {:prefix "resume-dispatcher-test-"}))]
     (try
       (binding [*worktree* w] (f))
       (finally (try (fs/delete-tree w) (catch Throwable _ nil))))))
-
-(use-fixtures :each worktree-fixture)
 
 ;; ── fixtures ─────────────────────────────────────────────────────────
 ;; Loaded from `resources/test-fixtures/resume-dispatcher/fixtures.edn`
@@ -47,60 +45,23 @@
 ;; `resources/test-fixtures/` convention compliance-scanner uses —
 ;; placing the file under `resources/` keeps it on the workspace
 ;; classpath without per-component test-alias tweaks.
-
-(def ^:private fixtures
+(def ^{:stratum 0} ^:private fixtures
   (-> (io/resource "test-fixtures/resume-dispatcher/fixtures.edn")
       slurp
       edn/read-string))
 
-(def ^:private pr-url               (:pr-url fixtures))
-(def ^:private base-listener-params (:base-listener-params fixtures))
-(def ^:private merged-pr            (:merged-pr fixtures))
-
-(defn- register-listener!
-  [overrides]
-  (let [r (registry/register! *worktree* (merge base-listener-params overrides))]
-    (assert (dag/ok? r))
-    (-> r :data :listener-id)))
-
-(defn- capture-shell
+(defn- ^{:stratum 0} capture-shell
   [calls-atom result]
   (fn [opts & args]
     (swap! calls-atom conj {:opts opts :args (vec args)})
     result))
 
-(defn- entry-by-id
-  "Read registry from disk, find entry by listener-id."
-  [listener-id]
-  (let [reg (-> (registry/read-registry *worktree*) :data)
-        bucket (registry/entries-for-pr reg pr-url)]
-    (first (filter #(= listener-id (:listener/id %)) bucket))))
-
-;; ── build-primer (pure) ──────────────────────────────────────────────
-
-(deftest build-primer-shape
-  (testing "primer has all spec-required keys + omits :session/id when absent"
-    (let [listener (assoc base-listener-params :session/id nil :listener/id (random-uuid))
-          primer (sut/build-primer merged-pr listener)]
-      (is (= pr-url (:resume/pr-url primer)))
-      (is (= "abc1234deadbeef" (:resume/merge-sha primer)))
-      (is (= #inst "2026-05-10T20:54:45.000-00:00" (:resume/merged-at primer)))
-      (is (= "+50 / -12 across 3 files" (:resume/diff-summary primer)))
-      (is (= "agent-A" (get-in primer [:resume/listener :agent/id])))
-      (is (not (contains? (:resume/listener primer) :session/id))
-          "session/id is dropped when nil — spec marks it optional"))))
-
-(deftest build-primer-includes-session-when-present
-  (let [listener (assoc base-listener-params :session/id "sess-001" :listener/id (random-uuid))
-        primer (sut/build-primer merged-pr listener)]
-    (is (= "sess-001" (get-in primer [:resume/listener :session/id])))))
-
-(deftest validate-primer-throws-on-bad-shape
+(deftest ^{:stratum 0} validate-primer-throws-on-bad-shape
   (testing "validate-primer! throws ex-info with anomaly tag on missing required keys"
     (is (thrown? clojure.lang.ExceptionInfo
                  (sut/validate-primer! {:resume/pr-url "x"})))))
 
-(deftest validate-primer-result-returns-dag-error-on-bad-shape
+(deftest ^{:stratum 0} validate-primer-result-returns-dag-error-on-bad-shape
   (testing "validate-primer-result returns a DAG error instead of throwing"
     (let [result (sut/validate-primer-result {:resume/pr-url "x"})]
       (is (false? (get result :ok?)))
@@ -112,9 +73,49 @@
              (get-in result [:error :data :primer])))
       (is (some? (get-in result [:error :data :errors]))))))
 
-;; ── channel-supported? + not-yet-wired ───────────────────────────────
+;------------------------------------------------------------------------------ Layer 1
 
-(deftest channel-supported-only-webhook-in-v0
+(def ^{:stratum 1} ^:private pr-url               (:pr-url fixtures))
+
+(def ^{:stratum 1} ^:private base-listener-params (:base-listener-params fixtures))
+
+(def ^{:stratum 1} ^:private merged-pr            (:merged-pr fixtures))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- ^{:stratum 2} register-listener!
+  [overrides]
+  (let [r (registry/register! *worktree* (merge base-listener-params overrides))]
+    (assert (dag/ok? r))
+    (-> r :data :listener-id)))
+
+(defn- ^{:stratum 2} entry-by-id
+  "Read registry from disk, find entry by listener-id."
+  [listener-id]
+  (let [reg (-> (registry/read-registry *worktree*) :data)
+        bucket (registry/entries-for-pr reg pr-url)]
+    (first (filter #(= listener-id (:listener/id %)) bucket))))
+
+;; ── build-primer (pure) ──────────────────────────────────────────────
+(deftest ^{:stratum 2} build-primer-shape
+  (testing "primer has all spec-required keys + omits :session/id when absent"
+    (let [listener (assoc base-listener-params :session/id nil :listener/id (random-uuid))
+          primer (sut/build-primer merged-pr listener)]
+      (is (= pr-url (:resume/pr-url primer)))
+      (is (= "abc1234deadbeef" (:resume/merge-sha primer)))
+      (is (= #inst "2026-05-10T20:54:45.000-00:00" (:resume/merged-at primer)))
+      (is (= "+50 / -12 across 3 files" (:resume/diff-summary primer)))
+      (is (= "agent-A" (get-in primer [:resume/listener :agent/id])))
+      (is (not (contains? (:resume/listener primer) :session/id))
+          "session/id is dropped when nil — spec marks it optional"))))
+
+(deftest ^{:stratum 2} build-primer-includes-session-when-present
+  (let [listener (assoc base-listener-params :session/id "sess-001" :listener/id (random-uuid))
+        primer (sut/build-primer merged-pr listener)]
+    (is (= "sess-001" (get-in primer [:resume/listener :session/id])))))
+
+;; ── channel-supported? + not-yet-wired ───────────────────────────────
+(deftest ^{:stratum 2} channel-supported-only-webhook-in-v0
   (is (true?  (sut/channel-supported?
                (assoc base-listener-params
                       :resume-channel {:channel/kind :webhook
@@ -128,7 +129,7 @@
                       :resume-channel {:channel/kind :miniforge-ipc
                                        :channel/target "topic-x"})))))
 
-(deftest dispatch-to-channel-pty-returns-not-yet-wired
+(deftest ^{:stratum 2} dispatch-to-channel-pty-returns-not-yet-wired
   (testing ":pty listener gets :resume-dispatcher/not-yet-wired with kind in :data"
     (let [listener (assoc base-listener-params
                           :listener/id (random-uuid)
@@ -140,7 +141,7 @@
       (is (= :resume-dispatcher/not-yet-wired (get-in r [:error :code])))
       (is (= :pty (get-in r [:error :data :channel/kind]))))))
 
-(deftest dispatch-to-channel-miniforge-ipc-returns-not-yet-wired
+(deftest ^{:stratum 2} dispatch-to-channel-miniforge-ipc-returns-not-yet-wired
   (let [listener (assoc base-listener-params
                         :listener/id (random-uuid)
                         :resume-channel {:channel/kind :miniforge-ipc
@@ -150,8 +151,7 @@
     (is (= :miniforge-ipc (get-in r [:error :data :channel/kind])))))
 
 ;; ── webhook handler ──────────────────────────────────────────────────
-
-(deftest dispatch-webhook-happy-path
+(deftest ^{:stratum 2} dispatch-webhook-happy-path
   (testing "successful webhook POST shells out to curl with the right args + JSON body"
     (let [calls (atom [])
           stub  (capture-shell calls {:exit 0 :out "" :err ""})]
@@ -171,7 +171,7 @@
             (is (= pr-url (:resume/pr-url payload)))
             (is (= "abc1234deadbeef" (:resume/merge-sha payload)))))))))
 
-(deftest dispatch-webhook-passes-fractional-seconds-to-curl
+(deftest ^{:stratum 2} dispatch-webhook-passes-fractional-seconds-to-curl
   (testing "curl --max-time receives fractional seconds (so a sub-1000ms timeout doesn't truncate to 0)"
     (let [calls (atom [])
           stub  (capture-shell calls {:exit 0 :out "" :err ""})]
@@ -189,7 +189,7 @@
             (is (not= "0" seconds-str)
                 "--max-time 0 would disable the timeout entirely (would let dispatcher hang)")))))))
 
-(deftest dispatch-webhook-rejects-blank-target
+(deftest ^{:stratum 2} dispatch-webhook-rejects-blank-target
   (let [listener (assoc base-listener-params
                         :listener/id (random-uuid)
                         :resume-channel {:channel/kind :webhook :channel/target ""})
@@ -198,7 +198,7 @@
     (is (not (dag/ok? r)))
     (is (= :resume-dispatcher/missing-target (get-in r [:error :code])))))
 
-(deftest dispatch-webhook-retries-on-failure
+(deftest ^{:stratum 2} dispatch-webhook-retries-on-failure
   (testing "transient failure is retried up to webhook-max-attempts; success on retry → ok"
     (let [calls (atom 0)
           ;; Fail twice, succeed on third.
@@ -216,7 +216,7 @@
           (is (dag/ok? r))
           (is (= 3 @calls) "retried twice before success"))))))
 
-(deftest dispatch-webhook-backoff-schedule
+(deftest ^{:stratum 2} dispatch-webhook-backoff-schedule
   (testing "backoff sleeps after attempts 0 + 1 (with backoff-ms 0 + 1) but NOT after attempt 2 (last)"
     (let [sleeps (atom [])
           ;; Always fail so we exhaust all attempts.
@@ -232,7 +232,7 @@
                  @sleeps)
               "backoff schedule: base*1 then base*2; no sleep after the final attempt"))))))
 
-(deftest dispatch-webhook-exhausts-attempts
+(deftest ^{:stratum 2} dispatch-webhook-exhausts-attempts
   (testing "persistent failure exhausts webhook-max-attempts and returns the last error"
     (let [calls (atom 0)
           stub (fn [_opts & _args]
@@ -248,9 +248,25 @@
               "called exactly webhook-max-attempts times")
           (is (= :resume-dispatcher/webhook-http-failed (get-in r [:error :code]))))))))
 
-;; ── dispatch-listener! (delivery + mark) ─────────────────────────────
+(deftest ^{:stratum 2} dispatch-pr-merge-bubbles-registry-read-failure-as-dag-err
+  (testing "registry read failure bubbles up as the same DAG error shape (not a partial summary)"
+    (with-redefs [registry/read-registry
+                  (fn [_]
+                    {:ok? false
+                     :error {:code :listener-registry/read-failed
+                             :message "synthetic disk failure"
+                             :data {:path "/dev/null"}}})]
+      (let [r (sut/dispatch-pr-merge! *worktree* pr-url merged-pr)]
+        (is (not (dag/ok? r))
+            "registry-read failure bubbles as DAG err, not a half-built summary")
+        (is (= :listener-registry/read-failed (get-in r [:error :code])))
+        (is (nil? (:dispatched r))
+            "no summary keys present on the err return — caller branches on dag/ok?")))))
 
-(deftest dispatch-listener-marks-on-success
+;------------------------------------------------------------------------------ Layer 3
+
+;; ── dispatch-listener! (delivery + mark) ─────────────────────────────
+(deftest ^{:stratum 3} dispatch-listener-marks-on-success
   (testing "successful delivery transitions listener :active → :dispatched and stamps dispatch-id"
     (let [stub (capture-shell (atom []) {:exit 0 :out "" :err ""})]
       (with-redefs [process/shell stub]
@@ -265,7 +281,7 @@
             (is (= (-> r :data :dispatch-id) (:resume/dispatch-id post)))
             (is (inst? (:resume/dispatched-at post)))))))))
 
-(deftest dispatch-listener-decorates-failure-with-listener-id
+(deftest ^{:stratum 3} dispatch-listener-decorates-failure-with-listener-id
   (testing "delivery failure surfaces :listener/id on :error :data for diagnostics"
     (let [stub (capture-shell (atom []) {:exit 22 :out "" :err "boom"})]
       (with-redefs [process/shell stub]
@@ -279,8 +295,7 @@
                 "listener stays :active when delivery fails — next pass retries")))))))
 
 ;; ── dispatch-pr-merge! (whole-PR pass) ───────────────────────────────
-
-(deftest dispatch-pr-merge-walks-only-active-listeners
+(deftest ^{:stratum 3} dispatch-pr-merge-walks-only-active-listeners
   (testing "dispatch-pr-merge! processes :active listeners; skips already-dispatched/cancelled"
     (let [stub (capture-shell (atom []) {:exit 0 :out "" :err ""})]
       (with-redefs [process/shell stub]
@@ -301,7 +316,7 @@
           (is (= 0 (count (:failed summary))))
           (is (= a (-> summary :dispatched first :listener/id))))))))
 
-(deftest dispatch-pr-merge-collects-failures-without-aborting
+(deftest ^{:stratum 3} dispatch-pr-merge-collects-failures-without-aborting
   (testing "per-listener failures don't abort the pass — they're collected"
     ;; Stub by URL match so per-listener outcomes are deterministic.
     ;; agent-A targets the failing endpoint; agent-B targets the OK one.
@@ -334,7 +349,7 @@
           (is (= 1 (count (:dispatched summary)))
               "agent-B success despite agent-A failure"))))))
 
-(deftest dispatch-pr-merge-pty-listener-not-yet-wired
+(deftest ^{:stratum 3} dispatch-pr-merge-pty-listener-not-yet-wired
   (testing ":pty listener flows through as a :failed entry with not-yet-wired"
     (let [pty-listener-id (register-listener!
                            {:agent/id "pty-agent"
@@ -348,17 +363,4 @@
              (get-in (first (:failed summary)) [:error :code])))
       (is (= pty-listener-id (get-in (first (:failed summary)) [:error :data :listener/id]))))))
 
-(deftest dispatch-pr-merge-bubbles-registry-read-failure-as-dag-err
-  (testing "registry read failure bubbles up as the same DAG error shape (not a partial summary)"
-    (with-redefs [registry/read-registry
-                  (fn [_]
-                    {:ok? false
-                     :error {:code :listener-registry/read-failed
-                             :message "synthetic disk failure"
-                             :data {:path "/dev/null"}}})]
-      (let [r (sut/dispatch-pr-merge! *worktree* pr-url merged-pr)]
-        (is (not (dag/ok? r))
-            "registry-read failure bubbles as DAG err, not a half-built summary")
-        (is (= :listener-registry/read-failed (get-in r [:error :code])))
-        (is (nil? (:dispatched r))
-            "no summary keys present on the err return — caller branches on dag/ok?")))))
+(use-fixtures :each worktree-fixture)

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/review_monitor_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/review_monitor_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.review-monitor-test
   "Unit tests for review monitoring.
 
@@ -27,46 +26,45 @@
    [ai.miniforge.pr-lifecycle.review-monitor :as review]
    [ai.miniforge.dag-executor.interface :as dag]))
 
-;------------------------------------------------------------------------------ Review States
+;------------------------------------------------------------------------------ Layer 0
 
-(deftest review-states-test
+;------------------------------------------------------------------------------ Review States
+(deftest ^{:stratum 0} review-states-test
   (testing "All expected review states are defined"
     (is (= 5 (count review/review-states)))
     (are [state] (contains? review/review-states state)
       :pending :approved :changes-requested :commented :dismissed)))
 
 ;------------------------------------------------------------------------------ Review Decision Parsing
-
-(deftest parse-review-decision-approved-test
+(deftest ^{:stratum 0} parse-review-decision-approved-test
   (testing "APPROVED parses correctly"
     (is (= :approved (review/parse-review-decision "APPROVED")))))
 
-(deftest parse-review-decision-changes-requested-test
+(deftest ^{:stratum 0} parse-review-decision-changes-requested-test
   (testing "CHANGES_REQUESTED parses correctly"
     (is (= :changes-requested (review/parse-review-decision "CHANGES_REQUESTED")))))
 
-(deftest parse-review-decision-review-required-test
+(deftest ^{:stratum 0} parse-review-decision-review-required-test
   (testing "REVIEW_REQUIRED parses to :pending"
     (is (= :pending (review/parse-review-decision "REVIEW_REQUIRED")))))
 
-(deftest parse-review-decision-empty-test
+(deftest ^{:stratum 0} parse-review-decision-empty-test
   (testing "Empty/nil decision parses to :pending"
     (is (= :pending (review/parse-review-decision "")))
     (is (= :pending (review/parse-review-decision nil)))))
 
-(deftest parse-review-decision-case-insensitive-test
+(deftest ^{:stratum 0} parse-review-decision-case-insensitive-test
   (testing "Decision parsing is case-insensitive"
     (is (= :approved (review/parse-review-decision "approved")))
     (is (= :changes-requested (review/parse-review-decision "changes_requested")))))
 
-(deftest parse-review-decision-unknown-value-test
+(deftest ^{:stratum 0} parse-review-decision-unknown-value-test
   (testing "Unrecognized decision defaults to :pending"
     (is (= :pending (review/parse-review-decision "SOMETHING_ELSE")))
     (is (= :pending (review/parse-review-decision "dismissed")))))
 
 ;------------------------------------------------------------------------------ Review Status Computation
-
-(deftest compute-review-status-single-approval-test
+(deftest ^{:stratum 0} compute-review-status-single-approval-test
   (testing "Single approval meets single-approval requirement"
     (let [reviews [{:author "alice" :state "APPROVED"}]
           result (review/compute-review-status reviews 1)]
@@ -74,7 +72,7 @@
       (is (= 1 (:approval-count result)))
       (is (contains? (set (:approvers result)) "alice")))))
 
-(deftest compute-review-status-multiple-approvals-test
+(deftest ^{:stratum 0} compute-review-status-multiple-approvals-test
   (testing "Multiple approvals meet higher requirement"
     (let [reviews [{:author "alice" :state "APPROVED"}
                    {:author "bob" :state "APPROVED"}]
@@ -82,7 +80,7 @@
       (is (= :approved (:status result)))
       (is (= 2 (:approval-count result))))))
 
-(deftest compute-review-status-insufficient-approvals-test
+(deftest ^{:stratum 0} compute-review-status-insufficient-approvals-test
   (testing "Insufficient approvals yield :pending"
     (let [reviews [{:author "alice" :state "APPROVED"}]
           result (review/compute-review-status reviews 2)]
@@ -90,7 +88,7 @@
       (is (= 1 (:approval-count result)))
       (is (= 2 (:required-approvals result))))))
 
-(deftest compute-review-status-changes-requested-test
+(deftest ^{:stratum 0} compute-review-status-changes-requested-test
   (testing "Changes requested takes precedence over approvals"
     (let [reviews [{:author "alice" :state "APPROVED"}
                    {:author "bob" :state "CHANGES_REQUESTED"}]
@@ -98,7 +96,7 @@
       (is (= :changes-requested (:status result)))
       (is (= ["bob"] (:changes-requested-by result))))))
 
-(deftest compute-review-status-same-reviewer-override-test
+(deftest ^{:stratum 0} compute-review-status-same-reviewer-override-test
   (testing "Same reviewer's changes-requested cancels their approval"
     (let [reviews [{:author "alice" :state "APPROVED"}
                    {:author "alice" :state "CHANGES_REQUESTED"}]
@@ -107,15 +105,14 @@
       ;; alice's approval is cancelled by their changes-requested
       (is (= 0 (:approval-count result))))))
 
-(deftest compute-review-status-empty-reviews-test
+(deftest ^{:stratum 0} compute-review-status-empty-reviews-test
   (testing "No reviews yields :pending"
     (let [result (review/compute-review-status [] 1)]
       (is (= :pending (:status result)))
       (is (= 0 (:approval-count result))))))
 
 ;------------------------------------------------------------------------------ Multiple Reviewer Handling
-
-(deftest compute-review-status-three-reviewers-mixed-test
+(deftest ^{:stratum 0} compute-review-status-three-reviewers-mixed-test
   (testing "Three reviewers with mixed states"
     (let [reviews [{:author "alice" :state "APPROVED"}
                    {:author "bob" :state "CHANGES_REQUESTED"}
@@ -129,7 +126,7 @@
       (is (contains? (set (:approvers result)) "alice"))
       (is (contains? (set (:approvers result)) "charlie")))))
 
-(deftest compute-review-status-multiple-changes-requested-test
+(deftest ^{:stratum 0} compute-review-status-multiple-changes-requested-test
   (testing "Multiple reviewers requesting changes"
     (let [reviews [{:author "alice" :state "CHANGES_REQUESTED"}
                    {:author "bob" :state "CHANGES_REQUESTED"}
@@ -139,7 +136,7 @@
       (is (= 2 (count (:changes-requested-by result))))
       (is (= #{"alice" "bob"} (set (:changes-requested-by result)))))))
 
-(deftest compute-review-status-all-approved-high-threshold-test
+(deftest ^{:stratum 0} compute-review-status-all-approved-high-threshold-test
   (testing "All reviewers approved with high approval threshold"
     (let [reviews [{:author "alice" :state "APPROVED"}
                    {:author "bob" :state "APPROVED"}
@@ -150,7 +147,7 @@
       (is (= 4 (:approval-count result)))
       (is (= 3 (:required-approvals result))))))
 
-(deftest compute-review-status-reviewer-approves-then-requests-changes-test
+(deftest ^{:stratum 0} compute-review-status-reviewer-approves-then-requests-changes-test
   (testing "Reviewer who first approved then requested changes"
     (let [reviews [{:author "alice" :state "APPROVED"}
                    {:author "bob" :state "APPROVED"}
@@ -162,7 +159,7 @@
       (is (contains? (set (:approvers result)) "alice"))
       (is (not (contains? (set (:approvers result)) "bob"))))))
 
-(deftest compute-review-status-only-one-of-many-approved-test
+(deftest ^{:stratum 0} compute-review-status-only-one-of-many-approved-test
   (testing "One approval when three are required yields pending"
     (let [reviews [{:author "alice" :state "APPROVED"}]
           result (review/compute-review-status reviews 3)]
@@ -171,8 +168,7 @@
       (is (= 3 (:required-approvals result))))))
 
 ;------------------------------------------------------------------------------ Review State Transitions
-
-(deftest review-state-transition-pending-to-approved-test
+(deftest ^{:stratum 0} review-state-transition-pending-to-approved-test
   (testing "Transition from pending to approved when approvals met"
     (let [pending-result (review/compute-review-status [] 1)
           approved-result (review/compute-review-status
@@ -180,7 +176,7 @@
       (is (= :pending (:status pending-result)))
       (is (= :approved (:status approved-result))))))
 
-(deftest review-state-transition-pending-to-changes-requested-test
+(deftest ^{:stratum 0} review-state-transition-pending-to-changes-requested-test
   (testing "Transition from pending to changes-requested"
     (let [pending-result (review/compute-review-status [] 1)
           changes-result (review/compute-review-status
@@ -188,7 +184,7 @@
       (is (= :pending (:status pending-result)))
       (is (= :changes-requested (:status changes-result))))))
 
-(deftest review-state-transition-changes-requested-to-approved-test
+(deftest ^{:stratum 0} review-state-transition-changes-requested-to-approved-test
   (testing "Transition from changes-requested to approved after new approval"
     (let [;; Initially bob requests changes
           cr-result (review/compute-review-status
@@ -201,7 +197,7 @@
       ;; Still changes-requested because changes_requested takes precedence
       (is (= :changes-requested (:status approved-result))))))
 
-(deftest review-state-transition-approved-to-changes-requested-test
+(deftest ^{:stratum 0} review-state-transition-approved-to-changes-requested-test
   (testing "Transition from approved back to changes-requested"
     (let [approved-result (review/compute-review-status
                             [{:author "alice" :state "APPROVED"}] 1)
@@ -211,7 +207,7 @@
       (is (= :approved (:status approved-result)))
       (is (= :changes-requested (:status reverted-result))))))
 
-(deftest review-state-transition-incremental-approvals-test
+(deftest ^{:stratum 0} review-state-transition-incremental-approvals-test
   (testing "Progressive accumulation of approvals"
     (let [one-of-three (review/compute-review-status
                          [{:author "alice" :state "APPROVED"}] 3)
@@ -227,8 +223,7 @@
       (is (= :approved (:status three-of-three))))))
 
 ;------------------------------------------------------------------------------ Review Comment Extraction
-
-(deftest extract-review-comments-test
+(deftest ^{:stratum 0} extract-review-comments-test
   (testing "Extracts comments from CHANGES_REQUESTED reviews"
     (let [reviews [{:state "CHANGES_REQUESTED"
                     :comments [{:body "Fix this" :author "bob" :path "src/a.clj" :line 10}]}
@@ -238,12 +233,12 @@
       (is (= 1 (count comments)))
       (is (= "Fix this" (:body (first comments)))))))
 
-(deftest extract-review-comments-empty-test
+(deftest ^{:stratum 0} extract-review-comments-empty-test
   (testing "No CHANGES_REQUESTED reviews yields empty comments"
     (let [reviews [{:state "APPROVED" :comments [{:body "OK"}]}]]
       (is (empty? (review/extract-review-comments reviews))))))
 
-(deftest extract-review-comments-multiple-reviewers-test
+(deftest ^{:stratum 0} extract-review-comments-multiple-reviewers-test
   (testing "Extracts comments from multiple CHANGES_REQUESTED reviews"
     (let [reviews [{:state "CHANGES_REQUESTED"
                     :comments [{:body "Fix naming" :author "alice" :path "src/a.clj" :line 5}
@@ -256,7 +251,7 @@
       (is (= 3 (count comments)))
       (is (= #{"alice" "bob"} (set (map :author comments)))))))
 
-(deftest extract-review-comments-preserves-path-and-line-test
+(deftest ^{:stratum 0} extract-review-comments-preserves-path-and-line-test
   (testing "Extracted comments preserve file path and line info"
     (let [reviews [{:state "CHANGES_REQUESTED"
                     :comments [{:body "Fix" :author "alice" :path "src/core.clj" :line 42}]}]
@@ -265,14 +260,13 @@
       (is (= 42 (:line (first comments)))))))
 
 ;------------------------------------------------------------------------------ Comment Tracking
-
-(deftest create-comment-tracker-test
+(deftest ^{:stratum 0} create-comment-tracker-test
   (testing "Tracker initializes with empty state"
     (let [tracker (review/create-comment-tracker)]
       (is (empty? (:seen-ids @tracker)))
       (is (empty? (:comments @tracker))))))
 
-(deftest track-comment-new-test
+(deftest ^{:stratum 0} track-comment-new-test
   (testing "New comment returns true and is tracked"
     (let [tracker (review/create-comment-tracker)
           comment {:id 1 :body "Hello" :author "alice"}
@@ -281,7 +275,7 @@
       (is (= 1 (count (:comments @tracker))))
       (is (contains? (:seen-ids @tracker) 1)))))
 
-(deftest track-comment-duplicate-test
+(deftest ^{:stratum 0} track-comment-duplicate-test
   (testing "Duplicate comment returns false"
     (let [tracker (review/create-comment-tracker)
           comment {:id 1 :body "Hello" :author "alice"}]
@@ -291,14 +285,14 @@
         (is (= 1 (count (:comments @tracker)))
             "Duplicate should not be added again")))))
 
-(deftest track-comment-hash-fallback-test
+(deftest ^{:stratum 0} track-comment-hash-fallback-test
   (testing "Comments without :id use hash-based dedup"
     (let [tracker (review/create-comment-tracker)
           comment {:body "Hello" :author "alice"}]
       (is (true? (review/track-comment! tracker comment)))
       (is (false? (review/track-comment! tracker comment))))))
 
-(deftest new-comments-filtering-test
+(deftest ^{:stratum 0} new-comments-filtering-test
   (testing "new-comments returns only unseen comments"
     (let [tracker (review/create-comment-tracker)
           c1 {:id 1 :body "First"}
@@ -310,7 +304,7 @@
         (is (= 2 (count result)))
         (is (= #{2 3} (set (map :id result))))))))
 
-(deftest track-multiple-unique-comments-test
+(deftest ^{:stratum 0} track-multiple-unique-comments-test
   (testing "Multiple unique comments are all tracked"
     (let [tracker (review/create-comment-tracker)
           comments (mapv (fn [i] {:id i :body (str "Comment " i) :author "alice"})
@@ -321,8 +315,7 @@
       (is (= 5 (count (:seen-ids @tracker)))))))
 
 ;------------------------------------------------------------------------------ Monitor Creation
-
-(deftest create-review-monitor-test
+(deftest ^{:stratum 0} create-review-monitor-test
   (testing "Monitor initializes with correct state"
     (let [dag-id (random-uuid)
           run-id (random-uuid)
@@ -335,7 +328,7 @@
       (is (= 1 (:required-approvals @monitor)))
       (is (some? (:comment-tracker @monitor))))))
 
-(deftest create-review-monitor-custom-options-test
+(deftest ^{:stratum 0} create-review-monitor-custom-options-test
   (testing "Monitor respects custom options"
     (let [monitor (review/create-review-monitor
                     (random-uuid) (random-uuid) (random-uuid) 1 "/tmp"
@@ -347,8 +340,7 @@
       (is (= :all (:triage-policy @monitor))))))
 
 ;------------------------------------------------------------------------------ Stop Monitor
-
-(deftest stop-review-monitor-test
+(deftest ^{:stratum 0} stop-review-monitor-test
   (testing "stop-review-monitor sets running? to false"
     (let [monitor (review/create-review-monitor
                     (random-uuid) (random-uuid) (random-uuid) 1 "/tmp")]
@@ -357,8 +349,7 @@
       (is (false? (:running? @monitor))))))
 
 ;------------------------------------------------------------------------------ Mocked gh CLI: run-gh-command
-
-(deftest run-gh-command-success-test
+(deftest ^{:stratum 0} run-gh-command-success-test
   (testing "Successful gh command returns dag/ok with trimmed output"
     (with-redefs [babashka.process/shell
                   (fn [& _args]
@@ -367,7 +358,7 @@
         (is (dag/ok? result))
         (is (= "some output" (:output (:data result))))))))
 
-(deftest run-gh-command-failure-test
+(deftest ^{:stratum 0} run-gh-command-failure-test
   (testing "Failed gh command returns dag/err with error message"
     (with-redefs [babashka.process/shell
                   (fn [& _args]
@@ -375,7 +366,7 @@
       (let [result (review/run-gh-command ["gh" "pr" "view" "999"] "/tmp/repo")]
         (is (dag/err? result))))))
 
-(deftest run-gh-command-exception-test
+(deftest ^{:stratum 0} run-gh-command-exception-test
   (testing "Exception during gh command returns dag/err"
     (with-redefs [babashka.process/shell
                   (fn [& _args]
@@ -384,8 +375,7 @@
         (is (dag/err? result))))))
 
 ;------------------------------------------------------------------------------ Mocked gh CLI: get-pr-reviews
-
-(deftest get-pr-reviews-success-test
+(deftest ^{:stratum 0} get-pr-reviews-success-test
   (testing "get-pr-reviews returns raw JSON output on success"
     (let [json-output "{\"reviews\":[],\"reviewDecision\":\"APPROVED\"}"]
       (with-redefs [babashka.process/shell
@@ -395,7 +385,7 @@
           (is (dag/ok? result))
           (is (= json-output (:raw (:data result)))))))))
 
-(deftest get-pr-reviews-failure-test
+(deftest ^{:stratum 0} get-pr-reviews-failure-test
   (testing "get-pr-reviews propagates error on failure"
     (with-redefs [babashka.process/shell
                   (fn [& _args]
@@ -404,8 +394,7 @@
         (is (dag/err? result))))))
 
 ;------------------------------------------------------------------------------ Mocked gh CLI: get-pr-comments
-
-(deftest get-pr-comments-success-test
+(deftest ^{:stratum 0} get-pr-comments-success-test
   (testing "get-pr-comments returns raw JSON output on success"
     (let [json-output "{\"comments\":[{\"body\":\"LGTM\"}]}"]
       (with-redefs [babashka.process/shell
@@ -415,7 +404,7 @@
           (is (dag/ok? result))
           (is (= json-output (:raw (:data result)))))))))
 
-(deftest get-pr-comments-failure-test
+(deftest ^{:stratum 0} get-pr-comments-failure-test
   (testing "get-pr-comments propagates error on failure"
     (with-redefs [babashka.process/shell
                   (fn [& _args]
@@ -424,8 +413,7 @@
         (is (dag/err? result))))))
 
 ;------------------------------------------------------------------------------ Mocked poll-review-status
-
-(deftest poll-review-status-with-mock-success-test
+(deftest ^{:stratum 0} poll-review-status-with-mock-success-test
   (testing "poll-review-status updates monitor state on successful poll"
     (with-redefs [review/get-pr-reviews
                   (fn [_path _pr]
@@ -445,7 +433,7 @@
           ;; Last poll timestamp set
           (is (some? (:last-poll @monitor))))))))
 
-(deftest poll-review-status-with-mock-failure-test
+(deftest ^{:stratum 0} poll-review-status-with-mock-failure-test
   (testing "poll-review-status returns :unknown on gh failure"
     (with-redefs [review/get-pr-reviews
                   (fn [_path _pr]
@@ -460,7 +448,7 @@
         (is (= :unknown (:status result)))
         (is (some? (:error result)))))))
 
-(deftest poll-review-status-increments-poll-count-test
+(deftest ^{:stratum 0} poll-review-status-increments-poll-count-test
   (testing "Each poll increments the poll counter"
     (with-redefs [review/get-pr-reviews
                   (fn [_path _pr]

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/review_scheduler_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/review_scheduler_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.review-scheduler-test
   "Tests for the review-scheduler — marker detection, predicate,
    partition. Excludes the bracketing `with-pr-worktree` (covered
@@ -28,56 +27,37 @@
             [ai.miniforge.pr-lifecycle.github :as github]
             [ai.miniforge.pr-lifecycle.review-scheduler :as sched]))
 
-;; ── helpers ──────────────────────────────────────────────────────────
+;------------------------------------------------------------------------------ Layer 0
 
-(defn- capture-shell
+;; ── helpers ──────────────────────────────────────────────────────────
+(defn- ^{:stratum 0} capture-shell
   [calls-atom result]
   (fn [opts & args]
     (swap! calls-atom conj {:opts opts :args (vec args)})
     result))
 
-(def ^:private sha-a "a000000000000000000000000000000000000001")
-(def ^:private sha-b "b000000000000000000000000000000000000002")
-(def ^:private sha-c "c000000000000000000000000000000000000003")
+(def ^{:stratum 0} ^:private sha-a "a000000000000000000000000000000000000001")
 
-(defn- review [sha author body]
+(def ^{:stratum 0} ^:private sha-b "b000000000000000000000000000000000000002")
+
+(def ^{:stratum 0} ^:private sha-c "c000000000000000000000000000000000000003")
+
+(defn- ^{:stratum 0} review [sha author body]
   {:id (rand-int 100000)
    :commit_id sha
    :user {:login author}
    :body body})
 
-(def ^:private mixed-reviews-json
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} ^:private mixed-reviews-json
   (json/generate-string
    [(review sha-a "miniforge-bot" (str "policy-review: 3 violations\n\n" github/review-marker))
     (review sha-b "human-reviewer" "looks good, ship it")
     (review sha-a "human-reviewer" "+1")
     (review sha-c "miniforge-bot" (str "policy-review: 0 violations\n\n" github/review-marker))]))
 
-;; ── existing-review-shas ─────────────────────────────────────────────
-
-(deftest existing-review-shas-filters-by-marker
-  (testing "only reviews carrying review-marker contribute SHAs"
-    (let [stub (capture-shell (atom [])
-                              {:exit 0 :out mixed-reviews-json :err ""})]
-      (with-redefs [process/shell stub]
-        (let [r (sched/existing-review-shas "/some/repo" 42)]
-          (is (dag/ok? r))
-          (is (= #{sha-a sha-c} (:data r))
-              "SHAs are union of all marker-bearing reviews; non-marker reviews ignored")))))
-  (testing "no reviews → empty set, still ok"
-    (let [stub (capture-shell (atom []) {:exit 0 :out "[]" :err ""})]
-      (with-redefs [process/shell stub]
-        (let [r (sched/existing-review-shas "/some/repo" 42)]
-          (is (dag/ok? r))
-          (is (= #{} (:data r)))))))
-  (testing "blank stdout → empty set, still ok (gh paginate edge)"
-    (let [stub (capture-shell (atom []) {:exit 0 :out "" :err ""})]
-      (with-redefs [process/shell stub]
-        (let [r (sched/existing-review-shas "/some/repo" 42)]
-          (is (dag/ok? r))
-          (is (= #{} (:data r))))))))
-
-(deftest existing-review-shas-handles-paginate-concat
+(deftest ^{:stratum 1} existing-review-shas-handles-paginate-concat
   (testing "gh --paginate emits multiple JSON arrays back-to-back; we concat them"
     (let [page1 [(review sha-a "x" (str "p1\n" github/review-marker))]
           page2 [(review sha-b "y" "no marker")
@@ -89,7 +69,7 @@
           (is (dag/ok? r))
           (is (= #{sha-a sha-c} (:data r))))))))
 
-(deftest existing-review-shas-shells-correct-endpoint
+(deftest ^{:stratum 1} existing-review-shas-shells-correct-endpoint
   (testing "shells out to `gh api repos/{owner}/{repo}/pulls/<n>/reviews --paginate` in worktree dir"
     (let [calls (atom [])
           stub  (capture-shell calls {:exit 0 :out "[]" :err ""})]
@@ -102,7 +82,7 @@
                (:args call)))
         (is (= "/some/repo" (str (get-in call [:opts :dir]))))))))
 
-(deftest existing-review-shas-gh-failure-bubbles-up
+(deftest ^{:stratum 1} existing-review-shas-gh-failure-bubbles-up
   (testing "non-zero gh exit → typed :gh-command-failed"
     (let [stub (capture-shell (atom [])
                               {:exit 1 :out "" :err "HTTP 401"})]
@@ -112,8 +92,7 @@
           (is (= :gh-command-failed (get-in r [:error :code]))))))))
 
 ;; ── predicates ───────────────────────────────────────────────────────
-
-(deftest pr-needs-review-honors-existing-shas
+(deftest ^{:stratum 1} pr-needs-review-honors-existing-shas
   (testing "true when pr/sha not in existing-shas"
     (is (true? (sched/pr-needs-review? {:pr/sha sha-a} #{sha-b sha-c})))
     (is (true? (sched/pr-needs-review? {:pr/sha sha-a} #{}))
@@ -129,8 +108,7 @@
     (is (false? (sched/pr-needs-review? {:pr/sha 42} #{})))))
 
 ;; ── with-pr-worktree cleanup invariants ──────────────────────────────
-
-(deftest with-pr-worktree-cleans-up-on-add-failure
+(deftest ^{:stratum 1} with-pr-worktree-cleans-up-on-add-failure
   (testing "when add-pr-worktree! fails, remove-pr-worktree! is still invoked"
     (let [calls (atom [])]
       (with-redefs [sched/fetch-pr-head!
@@ -155,7 +133,7 @@
           (is (not (some #{:unreached} (map identity []))) ; sanity placeholder
               ":unreached marker would only show up if f ran"))))))
 
-(deftest with-pr-worktree-runs-f-then-cleanup-on-success
+(deftest ^{:stratum 1} with-pr-worktree-runs-f-then-cleanup-on-success
   (testing "happy path: fetch ok, add ok, f runs, cleanup runs in finally"
     (let [calls (atom [])]
       (with-redefs [sched/fetch-pr-head!
@@ -186,7 +164,7 @@
                 "f received a worktree-path that includes the SHA")
             (is (= sha-a (last f-call)))))))))
 
-(deftest with-pr-worktree-cleans-up-on-f-exception
+(deftest ^{:stratum 1} with-pr-worktree-cleans-up-on-f-exception
   (testing "f exception still triggers cleanup, then rethrows"
     (let [calls (atom [])]
       (with-redefs [sched/fetch-pr-head! (fn [_ _] (dag/ok {:output ""}))
@@ -203,7 +181,7 @@
         (is (= [:add :remove] @calls)
             "remove ran in the finally even though f threw")))))
 
-(deftest with-pr-worktree-skips-on-fetch-failure
+(deftest ^{:stratum 1} with-pr-worktree-skips-on-fetch-failure
   (testing "fetch failure short-circuits — no add, no remove (nothing was created)"
     (let [calls (atom [])]
       (with-redefs [sched/fetch-pr-head!
@@ -219,7 +197,7 @@
           (is (= [:fetch] @calls)
               "fetch tried; add+remove not invoked (nothing was created)"))))))
 
-(deftest partition-needs-review-splits-prs
+(deftest ^{:stratum 1} partition-needs-review-splits-prs
   (testing "splits into :needs-review / :already-reviewed by PR-keyed map"
     (let [prs [{:pr/number 1 :pr/sha sha-a}
                {:pr/number 2 :pr/sha sha-b}
@@ -234,3 +212,28 @@
       (is (= #{2 3} (set (map :pr/number needs-review))))
       (is (= 1 (count already-reviewed)))
       (is (= [1] (mapv :pr/number already-reviewed))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; ── existing-review-shas ─────────────────────────────────────────────
+(deftest ^{:stratum 2} existing-review-shas-filters-by-marker
+  (testing "only reviews carrying review-marker contribute SHAs"
+    (let [stub (capture-shell (atom [])
+                              {:exit 0 :out mixed-reviews-json :err ""})]
+      (with-redefs [process/shell stub]
+        (let [r (sched/existing-review-shas "/some/repo" 42)]
+          (is (dag/ok? r))
+          (is (= #{sha-a sha-c} (:data r))
+              "SHAs are union of all marker-bearing reviews; non-marker reviews ignored")))))
+  (testing "no reviews → empty set, still ok"
+    (let [stub (capture-shell (atom []) {:exit 0 :out "[]" :err ""})]
+      (with-redefs [process/shell stub]
+        (let [r (sched/existing-review-shas "/some/repo" 42)]
+          (is (dag/ok? r))
+          (is (= #{} (:data r)))))))
+  (testing "blank stdout → empty set, still ok (gh paginate edge)"
+    (let [stub (capture-shell (atom []) {:exit 0 :out "" :err ""})]
+      (with-redefs [process/shell stub]
+        (let [r (sched/existing-review-shas "/some/repo" 42)]
+          (is (dag/ok? r))
+          (is (= #{} (:data r))))))))

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/triage_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/triage_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.pr-lifecycle.triage-test
   "Unit tests for comment triage and CI failure parsing.
 
@@ -26,9 +25,10 @@
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.pr-lifecycle.triage :as triage]))
 
-;------------------------------------------------------------------------------ Comment Parsing
+;------------------------------------------------------------------------------ Layer 0
 
-(deftest parse-comment-string-test
+;------------------------------------------------------------------------------ Comment Parsing
+(deftest ^{:stratum 0} parse-comment-string-test
   (testing "parse-comment from plain string"
     (let [parsed (triage/parse-comment "Fix the bug")]
       (is (= "Fix the bug" (:comment/body parsed)))
@@ -36,7 +36,7 @@
       (is (nil? (:comment/path parsed)))
       (is (nil? (:comment/line parsed))))))
 
-(deftest parse-comment-map-test
+(deftest ^{:stratum 0} parse-comment-map-test
   (testing "parse-comment from structured map"
     (let [parsed (triage/parse-comment {:body "Fix this"
                                          :author "alice"
@@ -48,8 +48,7 @@
       (is (= 42 (:comment/line parsed))))))
 
 ;------------------------------------------------------------------------------ Comment Classification
-
-(deftest classify-actionable-comment-test
+(deftest ^{:stratum 0} classify-actionable-comment-test
   (testing "Comment with fix request is actionable"
     (let [result (triage/classify-comment "Please fix the null pointer exception")]
       (is (:actionable? result))
@@ -65,7 +64,7 @@
       (is (:actionable? result))
       (is (pos? (get-in result [:scores :actionable]))))))
 
-(deftest classify-non-actionable-comment-test
+(deftest ^{:stratum 0} classify-non-actionable-comment-test
   (testing "LGTM comment is non-actionable"
     (let [result (triage/classify-comment "LGTM, looks good!")]
       (is (not (:actionable? result)))
@@ -79,7 +78,7 @@
     (let [result (triage/classify-comment "nit: maybe rename this variable")]
       (is (not (:actionable? result))))))
 
-(deftest classify-empty-comment-test
+(deftest ^{:stratum 0} classify-empty-comment-test
   (testing "Empty comment is non-actionable"
     (let [result (triage/classify-comment "")]
       (is (not (:actionable? result)))
@@ -89,7 +88,7 @@
     (let [result (triage/classify-comment {:body nil})]
       (is (not (:actionable? result))))))
 
-(deftest classify-whitelisted-author-test
+(deftest ^{:stratum 0} classify-whitelisted-author-test
   (testing "Whitelisted author always actionable"
     (let [result (triage/classify-comment
                    {:body "Just a note" :author "boss"}
@@ -97,7 +96,7 @@
       (is (:actionable? result))
       (is (= :whitelisted-author (:reason result))))))
 
-(deftest classify-threshold-test
+(deftest ^{:stratum 0} classify-threshold-test
   (testing "Higher threshold requires more indicators"
     (let [result-low (triage/classify-comment "please check" :threshold 1)
           result-high (triage/classify-comment "please check" :threshold 5)]
@@ -106,7 +105,7 @@
       (is (not (:actionable? result-high))
           "High threshold should not match"))))
 
-(deftest classify-mixed-signals-test
+(deftest ^{:stratum 0} classify-mixed-signals-test
   (testing "Actionable wins when score exceeds non-actionable"
     (let [result (triage/classify-comment
                    "Please fix this bug, it's a security issue")]
@@ -118,7 +117,7 @@
     (let [result (triage/classify-comment "Looks good, LGTM, nice work!")]
       (is (not (:actionable? result))))))
 
-(deftest classify-indicators-returned-test
+(deftest ^{:stratum 0} classify-indicators-returned-test
   (testing "Matching indicators are returned for inspection"
     (let [result (triage/classify-comment "Please fix the error")]
       (is (seq (get-in result [:indicators :actionable])))
@@ -126,8 +125,7 @@
       (is (some #{"fix"} (get-in result [:indicators :actionable]))))))
 
 ;------------------------------------------------------------------------------ Batch Triage
-
-(deftest triage-comments-default-policy-test
+(deftest ^{:stratum 0} triage-comments-default-policy-test
   (testing "Default policy returns only actionable comments"
     (let [comments ["Please fix the bug"
                     "LGTM"
@@ -140,20 +138,20 @@
       (is (= :actionable-only (get-in result [:stats :policy])))
       (is (every? :actionable? (:actionable result))))))
 
-(deftest triage-comments-all-policy-test
+(deftest ^{:stratum 0} triage-comments-all-policy-test
   (testing ":all policy returns all classified comments"
     (let [comments ["Fix this" "LGTM"]
           result (triage/triage-comments comments :policy :all)]
       (is (= 2 (count (:actionable result)))
           "All comments should appear in :actionable when policy is :all"))))
 
-(deftest triage-comments-none-policy-test
+(deftest ^{:stratum 0} triage-comments-none-policy-test
   (testing ":none policy returns empty actionable"
     (let [comments ["Fix this" "Security bug here"]
           result (triage/triage-comments comments :policy :none)]
       (is (empty? (:actionable result))))))
 
-(deftest triage-empty-comments-test
+(deftest ^{:stratum 0} triage-empty-comments-test
   (testing "Triaging empty sequence returns zero stats"
     (let [result (triage/triage-comments [])]
       (is (= 0 (get-in result [:stats :total])))
@@ -161,8 +159,7 @@
       (is (empty? (:non-actionable result))))))
 
 ;------------------------------------------------------------------------------ CI Failure Parsing
-
-(deftest parse-ci-failure-test-failures-test
+(deftest ^{:stratum 0} parse-ci-failure-test-failures-test
   (testing "Parses test failure lines from logs"
     (let [logs "FAIL in (test-foo)
 expected: 1
@@ -174,7 +171,7 @@ Something else"
       (is (some #(clojure.string/includes? % "FAIL") (:test-failures result)))
       (is (some #(clojure.string/includes? % "ERROR") (:test-failures result))))))
 
-(deftest parse-ci-failure-lint-errors-test
+(deftest ^{:stratum 0} parse-ci-failure-lint-errors-test
   (testing "Parses lint error lines from logs"
     (let [logs "src/foo.clj:10:5: error: undefined symbol
 src/bar.clj:20:1: warning: unused import"
@@ -183,7 +180,7 @@ src/bar.clj:20:1: warning: unused import"
       (is (some #(clojure.string/includes? % "error:") (:lint-errors result)))
       (is (some #(clojure.string/includes? % "warning:") (:lint-errors result))))))
 
-(deftest parse-ci-failure-build-errors-test
+(deftest ^{:stratum 0} parse-ci-failure-build-errors-test
   (testing "Parses build error lines from logs"
     (let [logs "Compiling stuff...
 BUILD FAILED
@@ -192,7 +189,7 @@ Could not resolve dependency foo/bar"
       (is (= 2 (count (:build-errors result))))
       (is (some #(clojure.string/includes? % "BUILD FAILED") (:build-errors result))))))
 
-(deftest parse-ci-failure-summary-test
+(deftest ^{:stratum 0} parse-ci-failure-summary-test
   (testing "Generates actionable summary from parsed results"
     (let [logs "FAIL in (test-foo)
 BUILD FAILED"
@@ -201,21 +198,20 @@ BUILD FAILED"
       (is (clojure.string/includes? (:actionable-summary result) "test failure"))
       (is (clojure.string/includes? (:actionable-summary result) "build error")))))
 
-(deftest parse-ci-failure-empty-logs-test
+(deftest ^{:stratum 0} parse-ci-failure-empty-logs-test
   (testing "Empty logs produce empty results"
     (let [result (triage/parse-ci-failure "")]
       (is (empty? (:test-failures result)))
       (is (empty? (:lint-errors result)))
       (is (empty? (:build-errors result))))))
 
-(deftest parse-ci-failure-lines-input-test
+(deftest ^{:stratum 0} parse-ci-failure-lines-input-test
   (testing "Accepts pre-split lines as input"
     (let [result (triage/parse-ci-failure ["FAIL in (test-foo)" "All good"])]
       (is (= 1 (count (:test-failures result)))))))
 
 ;------------------------------------------------------------------------------ File Extraction
-
-(deftest extract-failing-files-test
+(deftest ^{:stratum 0} extract-failing-files-test
   (testing "Extracts file paths from CI failure data"
     (let [failure {:test-failures ["at foo_test.clj:42"
                                    "in src/bar.clj line 10"]
@@ -226,7 +222,7 @@ BUILD FAILED"
       (is (contains? files "foo_test.clj"))
       (is (contains? files "src/baz.clj")))))
 
-(deftest extract-failing-files-filters-java-test
+(deftest ^{:stratum 0} extract-failing-files-filters-java-test
   (testing "Filters out java.* paths"
     (let [failure {:test-failures ["at java.lang.Thread:123"]
                    :lint-errors []
@@ -234,14 +230,13 @@ BUILD FAILED"
           files (triage/extract-failing-files failure)]
       (is (not (some #(clojure.string/starts-with? % "java.") files))))))
 
-(deftest extract-failing-files-empty-test
+(deftest ^{:stratum 0} extract-failing-files-empty-test
   (testing "Empty failure data returns empty set"
     (let [failure {:test-failures [] :lint-errors [] :build-errors []}]
       (is (empty? (triage/extract-failing-files failure))))))
 
 ;------------------------------------------------------------------------------ Review Change Extraction
-
-(deftest extract-requested-changes-test
+(deftest ^{:stratum 0} extract-requested-changes-test
   (testing "Extracts file-scoped changes from actionable comments"
     (let [comments [{:comment {:comment/body "Fix the null check"
                                :comment/path "src/foo.clj"
@@ -257,7 +252,7 @@ BUILD FAILED"
       (is (= "src/foo.clj" (:file (first changes))))
       (is (= 42 (:line (first changes)))))))
 
-(deftest group-changes-by-file-test
+(deftest ^{:stratum 0} group-changes-by-file-test
   (testing "Groups changes by file path"
     (let [changes [{:file "src/a.clj" :line 10 :change "Fix A"}
                    {:file "src/a.clj" :line 20 :change "Fix A2"}
@@ -271,6 +266,6 @@ BUILD FAILED"
         (is (= #{10 20} (:lines a-group)))
         (is (= 1 (count (:changes b-group))))))))
 
-(deftest group-changes-empty-test
+(deftest ^{:stratum 0} group-changes-empty-test
   (testing "Empty changes produce empty groups"
     (is (empty? (triage/group-changes-by-file [])))))

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-pr-lifecycle.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-pr-lifecycle.md
@@ -1,0 +1,221 @@
+<!--
+  Title: fix: stratum-lint autofix for components/pr-lifecycle (Wave 1)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix: stratum-lint autofix for components/pr-lifecycle (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over `components/pr-lifecycle` (`src` + `test`)
+to replace decorative `Layer N` banners and missing headings with real
+`Layer N` headings and `^{:stratum n}` metadata derived from each file's
+actual same-file reference graph. Mechanical: no logic changes. Also
+hand-fixes 15 stale decorative heading/comment artifacts across 4 files
+that now contradict the recomputed real headings, and removes 2
+now-dead `declare` forms left over once reordering placed their forward-
+declared def earlier in the file than the declaration itself. One of the
+Wave 1 batch 6 per-component PRs from
+`work/stratum-lint-baseline-2026-07-24.md` — the largest component in
+this batch (38 pre-fix findings).
+
+## Motivation
+
+Plain (non-`--fix`) `stratum-lint` on `components/pr-lifecycle` reported
+38 findings, **zero `SL001`**:
+
+```text
+30 SL002 (Layer heading reused/non-monotonic)
+ 6 SL003 (file over the 3-layer budget)
+ 2 SL004 (def before first Layer heading)
+```
+
+Zero `SL001`, confirming this component carries no upward-reference/cycle
+risk requiring human triage before running the mechanical fixer.
+
+## Changes in Detail
+
+Ran, over the whole component:
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "bef8657a2efd3b1ba9e1a4f510693c9fbca45abd" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/pr-lifecycle
+```
+
+61 of the component's `.clj` files were rewritten (31 `src`, 30 `test`).
+One file, `src/.../monitor_loop.clj`, was **not** rewritten and reported
+`SL007 reference cycle prevents stratification: continue-loop! ->
+step-monitor-loop!` — a genuine same-file mutual recursion between the
+loop's two step functions (`continue-loop!` calls `step-monitor-loop!`
+at the end of a sleep/retry branch; `step-monitor-loop!` calls
+`continue-loop!` at the end of its own success branch). This is not a
+new tool bug: `tasks/stratum.clj`'s own docstring for
+`autofix-and-restage!` documents exit 1 as reserved for exactly this
+case ("a parse failure, or a same-file reference cycle"). The file
+wasn't in the original 38-finding list (it already lint-passed
+pre-fix) and is untouched by this diff — confirmed via `git diff
+--stat` showing no entry for it.
+
+Verified no functional content moved or changed beyond reorder +
+metadata, two ways:
+
+1. Stripped comments/blank lines/`^{:stratum n}` annotations from both
+   the pre-fix and post-fix text of all 61 files and diffed — non-empty
+   only for cosmetic double-space artifacts from the stripping itself
+   (metadata removal leaves a doubled space around `def`/`defn` heads).
+2. Stronger check: read every top-level `def`/`defn`/`defn-`/
+   `defrecord`/`defmethod`/`deftest` form from both versions of each
+   file with the Clojure reader, stripped `:stratum` from its metadata,
+   `pr-str`'d it, and compared the sorted multiset of (head+name,
+   canonical-form) pairs old vs. new per file — **identical across all
+   61 files**. This confirms every def's name, arglist, docstring, and
+   body is byte-for-byte the same before and after; only physical
+   position and heading/metadata changed. Also confirmed `(:require
+   ...)` clauses are untouched in every file's `ns` form, and that the
+   only non-`def` top-level forms in the component (`(comment ...)`
+   scratch blocks, `(declare ...)`) were left in place — no bare
+   side-effecting top-level call exists in this component, so the
+   known "appendix sweep reorders a call relative to its dependents"
+   failure mode doesn't apply here.
+
+**Decorative banner cleanup (15 instances, 4 files).** Orphaned
+`Layer N` artifacts, invisible to `--fix`'s heading regex (which only
+recognizes a bare `;---- Layer <int>` line), left behind once real
+integer headings were regenerated around them:
+
+- `ci_monitor.clj`: one fractional `;---- Layer 0.5` banner (no label
+  of its own) sitting inside what `--fix` computed as a single real
+  `Layer 0` span. Dropped, kept the plain `;; Value coercion` comment
+  already on the next line.
+- `github.clj`: same shape, one fractional `;---- Layer 1.5` banner
+  inside the real `Layer 0` span. Dropped, kept `;; Batched review
+  posting (N13 §2.2 Standards Reviewer)`.
+- `interface.clj`: six fractional banners (`Layer 2.5`, `2.7`, `2.8`,
+  `2.9`, `1.5`, `5.5`) — leftovers from before `--fix` collapsed this
+  namespace's real depth to a single `Layer 0` (an interface file
+  mostly re-exports other namespaces' functions by reference, so its
+  same-file reference graph is flat; this fully resolves the file's
+  original `SL003` — 8 layers pre-fix, 0 extra layers post-fix). All
+  six had a plain descriptive comment immediately following; dropped
+  the fractional banner, kept the label.
+- `listener_registry.clj`: two short unicode-dash inline comments
+  (not matching the tool's banner regex at all) with stale
+  parentheticals — `;; ── Entry construction (Layer 1; consumes only
+  Layer 0/1) ───────────` sitting next to a real-stratum-0 def, and
+  `;; Lifecycle entry points (orchestrate Layer 1/2 ops; do I/O)`
+  sitting directly under the real `Layer 9` heading. Both predate this
+  file's real depth turning out to be far greater than its old
+  cargo-cult headings suggested (see `SL003` note below); dropped the
+  now-wrong layer references, kept the descriptive text.
+- `test/monitor_worklist_test.clj`: five full-width `;---- Layer N:
+  <label>` banners (`Layer 1: worklist-path`, `Layer 1: repo-key`,
+  `Layer 2: persist-worklist!`, `Layer 2: load-worklist`, `Layer 2:
+  prune-closed-prs`) — one per `deftest` group, the classic
+  per-function-group banner pattern from the baseline diagnosis.
+  Converted each to a plain `;; <label>` comment.
+
+Re-ran `--fix` after these edits — zero diff, confirming the manual
+edits didn't interact with stratum computation (comments aren't part of
+the reference graph).
+
+**Dead-code cleanup found via `clj-kondo` (2 files).** Reordering
+surfaced two `declare` forms that are now genuinely redundant because
+the def they forward-declare landed earlier in the file than the
+declaration itself once physically reordered to its real stratum:
+`fsm.clj`'s `(declare transition-failure)` (real def already at
+`Layer 1`, well before this trailing declare) and `monitor_state.clj`'s
+`(declare load-budget-from-disk!)` (real def already earlier in the
+file; this was also the file's last line, trailing a now-orphaned `;;
+Shared helpers` comment). `clj-kondo` flagged both as "Redundant
+declare" — new warnings not present pre-fix. Removed both declares
+(and the orphaned comment in `monitor_state.clj`); re-ran `clj-kondo`
+and confirmed the warning count returned to the pre-existing baseline
+exactly. Re-ran `--fix` again after — zero diff.
+
+## Testing Plan
+
+1. Ran plain `stratum-lint` before the fix — reproduced the 38 findings
+   above exactly (30 `SL002`, 6 `SL003`, 2 `SL004`), zero `SL001`.
+2. Ran `--fix`, then a second `--fix` pass immediately after — zero
+   rewrites (only the `monitor_loop.clj` `SL007` diagnostic, unchanged),
+   confirming idempotency.
+3. Read the full diff for all 61 changed files; used the def-body
+   multiset comparison described above to confirm nothing beyond
+   heading/metadata/order changed, then found and hand-fixed the 15
+   stale decorative heading/comment artifacts and the 2 dead `declare`
+   forms described above. Re-ran `--fix` after each round of manual
+   edits — zero diff both times.
+4. `clj-kondo --lint components/pr-lifecycle`: 0 errors, 2 warnings
+   (redundant `let` in `test/monitor_worklist_test.clj`) + 2 info
+   (redundant `ignore` in `test/integration_test.clj`). Confirmed
+   pre-existing via `git stash` + re-lint on the unmodified tree — same
+   2 warnings + 2 info (different line numbers, since content moved),
+   nothing else.
+5. Ran the component's test namespaces directly via `clojure -M:dev:test
+   -e` (30 namespaces — every `test/` namespace including the 5
+   `anomaly/` namespaces, from repo root): **422 tests, 2410 assertions,
+   0 failures, 0 errors.** This includes
+   `ai.miniforge.pr-lifecycle.monitor-worklist-test`, which per the Wave
+   1 batch 6 briefing has a known pre-existing environment flake
+   (`babashka.fs/delete-tree` throwing `ClassCastException` in its
+   cleanup fixture) — it did not reproduce across 3 separate runs (once
+   in isolation twice, once as part of the full 30-namespace suite);
+   all runs passed cleanly.
+6. Re-ran plain `stratum-lint` after the fix. `SL001`/`SL002`/`SL004`
+   clear. `SL003` remains on 21 files (up from 6 pre-fix — most of the
+   old headings under-counted real depth once measured from the true
+   reference graph):
+   `ci_monitor.clj` (4), `classifier.clj` (6), `conflict_resolution.clj`
+   (4), `controller.clj` (7), `controller_config.clj` (5), `fsm.clj`
+   (10), `github.clj` (5), `listener_registry.clj` (11), `merge.clj`
+   (4), `monitor_budget.clj` (4), `monitor_config.clj` (6),
+   `monitor_worklist.clj` (4), `policy_eval/fs.clj` (4),
+   `policy_eval/reply.clj` (4), `pr_poller.clj` (5), `responder.clj`
+   (4), `resume_dispatcher.clj` (10), `review_monitor.clj` (4),
+   `test/ci_monitor_property_test.clj` (4),
+   `test/monitor_loop_test.clj` (4), `test/resume_dispatcher_test.clj`
+   (4). All real over-budget files (Wave 2 scope: namespace split), not
+   addressed here. Notably `interface.clj` (originally 8 layers) and
+   `triage.clj` (originally 4) both fully resolved to within budget once
+   their real (shallower) depth was measured — the opposite direction
+   from `listener_registry.clj`, whose real depth (11) turned out
+   larger than its pre-fix headings implied (4).
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+change — every def's body is unchanged (verified above); the only
+non-cosmetic edits are removing 2 dead `declare` forms, which are
+no-ops once their target is already defined. Pre-commit's
+`lint:stratum` autofixer keeps this component clean going forward; the
+21 `SL003` files stay advisory (`MINIFORGE_STRATUM_BUDGET_MODE=warn` at
+commit time) until Wave 2 splits them.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+- Follow-on: Wave 2 namespace splits for the 21 `SL003` files listed
+  above, `listener_registry.clj` (11 real layers) and `fsm.clj` /
+  `resume_dispatcher.clj` (10 each) being the most over budget.
+
+## Checklist
+
+- [x] Confirmed zero `SL001` before running `--fix`
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Second `--fix` pass confirms idempotency (zero diff)
+- [x] Diff read in full for all 61 changed files; verified mechanical-only
+      via def-body multiset comparison
+- [x] 15 stale decorative `Layer N` heading/comment artifacts across 4
+      files hand-fixed (comment-only); `--fix` re-run confirms stability
+- [x] 2 dead `declare` forms (surfaced by `clj-kondo`, caused by
+      reordering) removed
+- [x] `clj-kondo` clean (0 errors, 2 warnings + 2 info, confirmed
+      pre-existing via `git stash`)
+- [x] Component tests pass (422 tests, 2410 assertions, 0
+      failures/errors); known `monitor-worklist-test` flake did not
+      reproduce
+- [x] Plain lint re-run post-fix: `SL003` remains on 21 files, documented
+      above with precise counts, tracked as Wave 2
+- [x] `monitor_loop.clj`'s `SL007` reference-cycle diagnostic
+      investigated and confirmed pre-existing/expected, file untouched
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
<!--
  Title: fix: stratum-lint autofix for components/pr-lifecycle (Wave 1)
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# fix: stratum-lint autofix for components/pr-lifecycle (Wave 1)

## Overview

Runs `stratum-lint --fix` over `components/pr-lifecycle` (`src` + `test`)
to replace decorative `Layer N` banners and missing headings with real
`Layer N` headings and `^{:stratum n}` metadata derived from each file's
actual same-file reference graph. Mechanical: no logic changes. Also
hand-fixes 15 stale decorative heading/comment artifacts across 4 files
that now contradict the recomputed real headings, and removes 2
now-dead `declare` forms left over once reordering placed their forward-
declared def earlier in the file than the declaration itself. One of the
Wave 1 batch 6 per-component PRs from
`work/stratum-lint-baseline-2026-07-24.md` — the largest component in
this batch (38 pre-fix findings).

## Motivation

Plain (non-`--fix`) `stratum-lint` on `components/pr-lifecycle` reported
38 findings, **zero `SL001`**:

```text
30 SL002 (Layer heading reused/non-monotonic)
 6 SL003 (file over the 3-layer budget)
 2 SL004 (def before first Layer heading)
```

Zero `SL001`, confirming this component carries no upward-reference/cycle
risk requiring human triage before running the mechanical fixer.

## Changes in Detail

Ran, over the whole component:

```bash
bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "bef8657a2efd3b1ba9e1a4f510693c9fbca45abd" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/pr-lifecycle
```

61 of the component's `.clj` files were rewritten (31 `src`, 30 `test`).
One file, `src/.../monitor_loop.clj`, was **not** rewritten and reported
`SL007 reference cycle prevents stratification: continue-loop! ->
step-monitor-loop!` — a genuine same-file mutual recursion between the
loop's two step functions (`continue-loop!` calls `step-monitor-loop!`
at the end of a sleep/retry branch; `step-monitor-loop!` calls
`continue-loop!` at the end of its own success branch). This is not a
new tool bug: `tasks/stratum.clj`'s own docstring for
`autofix-and-restage!` documents exit 1 as reserved for exactly this
case ("a parse failure, or a same-file reference cycle"). The file
wasn't in the original 38-finding list (it already lint-passed
pre-fix) and is untouched by this diff — confirmed via `git diff
--stat` showing no entry for it.

Verified no functional content moved or changed beyond reorder +
metadata, two ways:

1. Stripped comments/blank lines/`^{:stratum n}` annotations from both
   the pre-fix and post-fix text of all 61 files and diffed — non-empty
   only for cosmetic double-space artifacts from the stripping itself
   (metadata removal leaves a doubled space around `def`/`defn` heads).
2. Stronger check: read every top-level `def`/`defn`/`defn-`/
   `defrecord`/`defmethod`/`deftest` form from both versions of each
   file with the Clojure reader, stripped `:stratum` from its metadata,
   `pr-str`'d it, and compared the sorted multiset of (head+name,
   canonical-form) pairs old vs. new per file — **identical across all
   61 files**. This confirms every def's name, arglist, docstring, and
   body is byte-for-byte the same before and after; only physical
   position and heading/metadata changed. Also confirmed `(:require
   ...)` clauses are untouched in every file's `ns` form, and that the
   only non-`def` top-level forms in the component (`(comment ...)`
   scratch blocks, `(declare ...)`) were left in place — no bare
   side-effecting top-level call exists in this component, so the
   known "appendix sweep reorders a call relative to its dependents"
   failure mode doesn't apply here.

**Decorative banner cleanup (15 instances, 4 files).** Orphaned
`Layer N` artifacts, invisible to `--fix`'s heading regex (which only
recognizes a bare `;---- Layer <int>` line), left behind once real
integer headings were regenerated around them:

- `ci_monitor.clj`: one fractional `;---- Layer 0.5` banner (no label
  of its own) sitting inside what `--fix` computed as a single real
  `Layer 0` span. Dropped, kept the plain `;; Value coercion` comment
  already on the next line.
- `github.clj`: same shape, one fractional `;---- Layer 1.5` banner
  inside the real `Layer 0` span. Dropped, kept `;; Batched review
  posting (N13 §2.2 Standards Reviewer)`.
- `interface.clj`: six fractional banners (`Layer 2.5`, `2.7`, `2.8`,
  `2.9`, `1.5`, `5.5`) — leftovers from before `--fix` collapsed this
  namespace's real depth to a single `Layer 0` (an interface file
  mostly re-exports other namespaces' functions by reference, so its
  same-file reference graph is flat; this fully resolves the file's
  original `SL003` — 8 layers pre-fix, 0 extra layers post-fix). All
  six had a plain descriptive comment immediately following; dropped
  the fractional banner, kept the label.
- `listener_registry.clj`: two short unicode-dash inline comments
  (not matching the tool's banner regex at all) with stale
  parentheticals — `;; ── Entry construction (Layer 1; consumes only
  Layer 0/1) ───────────` sitting next to a real-stratum-0 def, and
  `;; Lifecycle entry points (orchestrate Layer 1/2 ops; do I/O)`
  sitting directly under the real `Layer 9` heading. Both predate this
  file's real depth turning out to be far greater than its old
  cargo-cult headings suggested (see `SL003` note below); dropped the
  now-wrong layer references, kept the descriptive text.
- `test/monitor_worklist_test.clj`: five full-width `;---- Layer N:
  <label>` banners (`Layer 1: worklist-path`, `Layer 1: repo-key`,
  `Layer 2: persist-worklist!`, `Layer 2: load-worklist`, `Layer 2:
  prune-closed-prs`) — one per `deftest` group, the classic
  per-function-group banner pattern from the baseline diagnosis.
  Converted each to a plain `;; <label>` comment.

Re-ran `--fix` after these edits — zero diff, confirming the manual
edits didn't interact with stratum computation (comments aren't part of
the reference graph).

**Dead-code cleanup found via `clj-kondo` (2 files).** Reordering
surfaced two `declare` forms that are now genuinely redundant because
the def they forward-declare landed earlier in the file than the
declaration itself once physically reordered to its real stratum:
`fsm.clj`'s `(declare transition-failure)` (real def already at
`Layer 1`, well before this trailing declare) and `monitor_state.clj`'s
`(declare load-budget-from-disk!)` (real def already earlier in the
file; this was also the file's last line, trailing a now-orphaned `;;
Shared helpers` comment). `clj-kondo` flagged both as "Redundant
declare" — new warnings not present pre-fix. Removed both declares
(and the orphaned comment in `monitor_state.clj`); re-ran `clj-kondo`
and confirmed the warning count returned to the pre-existing baseline
exactly. Re-ran `--fix` again after — zero diff.

## Testing Plan

1. Ran plain `stratum-lint` before the fix — reproduced the 38 findings
   above exactly (30 `SL002`, 6 `SL003`, 2 `SL004`), zero `SL001`.
2. Ran `--fix`, then a second `--fix` pass immediately after — zero
   rewrites (only the `monitor_loop.clj` `SL007` diagnostic, unchanged),
   confirming idempotency.
3. Read the full diff for all 61 changed files; used the def-body
   multiset comparison described above to confirm nothing beyond
   heading/metadata/order changed, then found and hand-fixed the 15
   stale decorative heading/comment artifacts and the 2 dead `declare`
   forms described above. Re-ran `--fix` after each round of manual
   edits — zero diff both times.
4. `clj-kondo --lint components/pr-lifecycle`: 0 errors, 2 warnings
   (redundant `let` in `test/monitor_worklist_test.clj`) + 2 info
   (redundant `ignore` in `test/integration_test.clj`). Confirmed
   pre-existing via `git stash` + re-lint on the unmodified tree — same
   2 warnings + 2 info (different line numbers, since content moved),
   nothing else.
5. Ran the component's test namespaces directly via `clojure -M:dev:test
   -e` (30 namespaces — every `test/` namespace including the 5
   `anomaly/` namespaces, from repo root): **422 tests, 2410 assertions,
   0 failures, 0 errors.** This includes
   `ai.miniforge.pr-lifecycle.monitor-worklist-test`, which per the Wave
   1 batch 6 briefing has a known pre-existing environment flake
   (`babashka.fs/delete-tree` throwing `ClassCastException` in its
   cleanup fixture) — it did not reproduce across 3 separate runs (once
   in isolation twice, once as part of the full 30-namespace suite);
   all runs passed cleanly.
6. Re-ran plain `stratum-lint` after the fix. `SL001`/`SL002`/`SL004`
   clear. `SL003` remains on 21 files (up from 6 pre-fix — most of the
   old headings under-counted real depth once measured from the true
   reference graph):
   `ci_monitor.clj` (4), `classifier.clj` (6), `conflict_resolution.clj`
   (4), `controller.clj` (7), `controller_config.clj` (5), `fsm.clj`
   (10), `github.clj` (5), `listener_registry.clj` (11), `merge.clj`
   (4), `monitor_budget.clj` (4), `monitor_config.clj` (6),
   `monitor_worklist.clj` (4), `policy_eval/fs.clj` (4),
   `policy_eval/reply.clj` (4), `pr_poller.clj` (5), `responder.clj`
   (4), `resume_dispatcher.clj` (10), `review_monitor.clj` (4),
   `test/ci_monitor_property_test.clj` (4),
   `test/monitor_loop_test.clj` (4), `test/resume_dispatcher_test.clj`
   (4). All real over-budget files (Wave 2 scope: namespace split), not
   addressed here. Notably `interface.clj` (originally 8 layers) and
   `triage.clj` (originally 4) both fully resolved to within budget once
   their real (shallower) depth was measured — the opposite direction
   from `listener_registry.clj`, whose real depth (11) turned out
   larger than its pre-fix headings implied (4).

## Deployment Plan

Merges to `main` like any other component change. No runtime behavior
change — every def's body is unchanged (verified above); the only
non-cosmetic edits are removing 2 dead `declare` forms, which are
no-ops once their target is already defined. Pre-commit's
`lint:stratum` autofixer keeps this component clean going forward; the
21 `SL003` files stay advisory (`MINIFORGE_STRATUM_BUDGET_MODE=warn` at
commit time) until Wave 2 splits them.

## Related Issues/PRs

- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
- Follow-on: Wave 2 namespace splits for the 21 `SL003` files listed
  above, `listener_registry.clj` (11 real layers) and `fsm.clj` /
  `resume_dispatcher.clj` (10 each) being the most over budget.

## Checklist

- [x] Confirmed zero `SL001` before running `--fix`
- [x] `--fix` run over the whole component (`src` + `test`)
- [x] Second `--fix` pass confirms idempotency (zero diff)
- [x] Diff read in full for all 61 changed files; verified mechanical-only
      via def-body multiset comparison
- [x] 15 stale decorative `Layer N` heading/comment artifacts across 4
      files hand-fixed (comment-only); `--fix` re-run confirms stability
- [x] 2 dead `declare` forms (surfaced by `clj-kondo`, caused by
      reordering) removed
- [x] `clj-kondo` clean (0 errors, 2 warnings + 2 info, confirmed
      pre-existing via `git stash`)
- [x] Component tests pass (422 tests, 2410 assertions, 0
      failures/errors); known `monitor-worklist-test` flake did not
      reproduce
- [x] Plain lint re-run post-fix: `SL003` remains on 21 files, documented
      above with precise counts, tracked as Wave 2
- [x] `monitor_loop.clj`'s `SL007` reference-cycle diagnostic
      investigated and confirmed pre-existing/expected, file untouched
- [x] No `--no-verify`; pre-commit hook runs normally at commit time
