### PR TITLE
fix: stratum-lint autofix for bases/cli (Wave 1)

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/app_config.clj
+++ b/bases/cli/src/ai/miniforge/cli/app_config.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.app-config
   "Project-composed CLI app identity and filesystem layout."
   (:require
@@ -24,22 +23,31 @@
    [ai.miniforge.cli.resource-config :as resource-config]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Resource loading
 
-(def app-config-resource
+;; Resource loading
+(def ^{:stratum 0} app-config-resource
   "Classpath resource path for CLI app identity."
   "config/cli/app.edn")
 
-(def default-status-config
+(def ^{:stratum 0} default-status-config
   "Defaults for workflow status rendering and health classification."
   {:running-stale-threshold-ms 300000})
 
-(defn- normalize-profile
+(defn- ^{:stratum 0} normalize-profile
   [profile]
   (-> profile
       (update :help-examples #(vec (or % [])))))
 
-(defn app-profile
+(defn ^{:stratum 0} getenv
+  "Environment-variable lookup seam. Public so tests can rebind it via
+   `with-redefs` when validating MINIFORGE_HOME resolution; not part of
+   the external API."
+  [var-name]
+  (System/getenv var-name))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} app-profile
   "Resolve the active CLI app profile from the classpath."
   []
   (-> (resource-config/merged-resource-config app-config-resource
@@ -47,86 +55,83 @@
                                               {})
       normalize-profile))
 
-(defn pr-monitor-config
+(defn ^{:stratum 1} pr-monitor-config
   "Resolve PR monitor CLI config from the classpath."
   []
   (resource-config/merged-resource-config app-config-resource
                                           :cli-app/pr-monitor
                                           {}))
 
-(defn status-config
+(defn ^{:stratum 1} status-config
   "Resolve workflow status CLI config from the classpath."
   []
   (resource-config/merged-resource-config app-config-resource
                                           :cli-app/status
                                           default-status-config))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Identity helpers
+;------------------------------------------------------------------------------ Layer 2
 
-(defn binary-name []
+;; Identity helpers
+(defn ^{:stratum 2} binary-name []
   (:name (app-profile)))
 
-(defn display-name []
+(defn ^{:stratum 2} display-name []
   (:display-name (app-profile)))
 
-(defn description []
+(defn ^{:stratum 2} description []
   (:description (app-profile)))
 
-(defn system-check-title []
+(defn ^{:stratum 2} system-check-title []
   (:system-check-title (app-profile)))
 
-(defn home-dir-name []
+(defn ^{:stratum 2} home-dir-name []
   (:home-dir-name (app-profile)))
 
-(defn getenv
-  "Environment-variable lookup seam. Public so tests can rebind it via
-   `with-redefs` when validating MINIFORGE_HOME resolution; not part of
-   the external API."
-  [var-name]
-  (System/getenv var-name))
+(defn ^{:stratum 2} tui-package []
+  (:tui-package (app-profile)))
 
-(defn default-home-dir
+(defn ^{:stratum 2} help-examples []
+  (:help-examples (app-profile)))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} default-home-dir
   "Profile-derived default home directory. Public so tests can rebind
    it via `with-redefs`; not part of the external API."
   []
   (str (fs/home) "/" (home-dir-name)))
 
-(defn home-dir []
-  (or (getenv "MINIFORGE_HOME")
-      (default-home-dir)))
-
-(defn tui-package []
-  (:tui-package (app-profile)))
-
-(defn help-examples []
-  (:help-examples (app-profile)))
-
-(defn command-string
+(defn ^{:stratum 3} command-string
   "Build a CLI command string prefixed with the active binary name."
   [& parts]
   (str/join " " (cons (binary-name) (remove str/blank? parts))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Filesystem layout helpers
+;------------------------------------------------------------------------------ Layer 4
 
-(defn config-path []
+(defn ^{:stratum 4} home-dir []
+  (or (getenv "MINIFORGE_HOME")
+      (default-home-dir)))
+
+;------------------------------------------------------------------------------ Layer 5
+
+;; Filesystem layout helpers
+(defn ^{:stratum 5} config-path []
   (str (home-dir) "/config.edn"))
 
-(defn artifacts-dir []
+(defn ^{:stratum 5} artifacts-dir []
   (str (home-dir) "/artifacts"))
 
-(defn worktrees-dir []
+(defn ^{:stratum 5} worktrees-dir []
   (str (home-dir) "/worktrees"))
 
-(defn events-dir []
+(defn ^{:stratum 5} events-dir []
   (str (home-dir) "/events"))
 
-(defn logs-dir []
+(defn ^{:stratum 5} logs-dir []
   (str (home-dir) "/logs"))
 
-(defn dashboard-port-file []
+(defn ^{:stratum 5} dashboard-port-file []
   (str (home-dir) "/dashboard.port"))
 
-(defn state-file []
+(defn ^{:stratum 5} state-file []
   (str (home-dir) "/state.edn"))

--- a/bases/cli/src/ai/miniforge/cli/backends.clj
+++ b/bases/cli/src/ai/miniforge/cli/backends.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.backends
   "Backend discovery and management for Miniforge CLI.
 
@@ -28,36 +27,21 @@
    [babashka.process :as process]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Backend specifications
 
-(def ^:private backend-config-resource
+;; Backend specifications
+(def ^{:stratum 0} ^:private backend-config-resource
   "Classpath resource path for backend metadata and defaults."
   "config/cli/backends.edn")
 
-(def ^:private backend-config
-  (resource-config/merged-resource-config
-   backend-config-resource
-   nil
-   {:backend/defaults {:current :codex}
-    :backend/specs {}}))
-
-(def backend-specs
-  (:backend/specs backend-config))
-
-(def ^:private backend-defaults
-  (:backend/defaults backend-config))
-
-(defn- availability-status
+(defn- ^{:stratum 0} availability-status
   "Build a standard backend availability status map."
   [available status message]
   {:available available
    :status status
    :message message})
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Status checking
-
-(defn check-command-available?
+(defn ^{:stratum 0} check-command-available?
   "Check if a command is available on PATH."
   [cmd]
   (try
@@ -66,60 +50,8 @@
     (catch Exception _
       false)))
 
-(defn check-backend-status
-  "Check the status of a backend.
-
-   Returns map with:
-   - :available - boolean
-   - :status - :available, :not-installed
-   - :message - human-readable status message"
-  [backend-id]
-  (let [spec (get backend-specs backend-id)
-        {:keys [check-type command]} spec]
-    (case check-type
-      :builtin
-      (availability-status true :available (messages/t :backends/status-builtin))
-
-      :cli
-      (if (check-command-available? command)
-        (availability-status true :available
-                             (messages/t :backends/status-cli-found {:command command}))
-        (availability-status false :not-installed
-                             (messages/t :backends/status-cli-missing {:command command})))
-
-      ;; Unknown check type
-      (availability-status false :unknown (messages/t :backends/status-unknown)))))
-
-;------------------------------------------------------------------------------ Layer 2
-;; Backend information
-
-(defn get-backend-info
-  "Get detailed information about a backend."
-  [backend-id]
-  (let [spec (get backend-specs backend-id)
-        status (check-backend-status backend-id)]
-    (merge spec status {:backend-id backend-id})))
-
-(defn list-backends
-  "List all available backends with their status.
-
-   Returns sequence of backend info maps, sorted by availability."
-  []
-  (let [backends (map get-backend-info (keys backend-specs))]
-    (sort-by (juxt (comp not :available) :provider) backends)))
-
-(defn get-current-backend
-  "Get the currently configured backend from config or env var."
-  [config]
-  (or (:backend (:llm config))
-      (when-let [env-backend (System/getenv "MINIFORGE_LLM_BACKEND")]
-        (keyword env-backend))
-      (get backend-defaults :current :codex)))
-
-;------------------------------------------------------------------------------ Layer 3
 ;; Display helpers
-
-(defn status-icon
+(defn ^{:stratum 0} status-icon
   "Get status icon for backend."
   [status]
   (case status
@@ -127,7 +59,16 @@
     :not-installed "❌"
     "❓"))
 
-(defn format-backend-status
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} ^:private backend-config
+  (resource-config/merged-resource-config
+   backend-config-resource
+   nil
+   {:backend/defaults {:current :codex}
+    :backend/specs {}}))
+
+(defn ^{:stratum 1} format-backend-status
   "Format backend status for display."
   [backend-info current-backend]
   (let [{:keys [backend-id provider description status message models installation docs-url]} backend-info
@@ -154,19 +95,85 @@
                                  docs-url)
                          (messages/t :backends/docs-line {:docs-url docs-url}))]))))
 
-(defn print-backends
-  "Print all backends with their status."
-  [config]
-  (let [backends (list-backends)
-        current (get-current-backend config)]
-    (println)
-    (println (messages/t :backends/list-header))
-    (println)
-    (doseq [backend backends]
-      (println (format-backend-status backend current))
-      (println))))
+;------------------------------------------------------------------------------ Layer 2
 
-(defn print-backend-error
+(def ^{:stratum 2} backend-specs
+  (:backend/specs backend-config))
+
+(def ^{:stratum 2} ^:private backend-defaults
+  (:backend/defaults backend-config))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} check-backend-status
+  "Check the status of a backend.
+
+   Returns map with:
+   - :available - boolean
+   - :status - :available, :not-installed
+   - :message - human-readable status message"
+  [backend-id]
+  (let [spec (get backend-specs backend-id)
+        {:keys [check-type command]} spec]
+    (case check-type
+      :builtin
+      (availability-status true :available (messages/t :backends/status-builtin))
+
+      :cli
+      (if (check-command-available? command)
+        (availability-status true :available
+                             (messages/t :backends/status-cli-found {:command command}))
+        (availability-status false :not-installed
+                             (messages/t :backends/status-cli-missing {:command command})))
+
+      ;; Unknown check type
+      (availability-status false :unknown (messages/t :backends/status-unknown)))))
+
+(defn ^{:stratum 3} get-current-backend
+  "Get the currently configured backend from config or env var."
+  [config]
+  (or (:backend (:llm config))
+      (when-let [env-backend (System/getenv "MINIFORGE_LLM_BACKEND")]
+        (keyword env-backend))
+      (get backend-defaults :current :codex)))
+
+;------------------------------------------------------------------------------ Layer 4
+
+;; Backend information
+(defn ^{:stratum 4} get-backend-info
+  "Get detailed information about a backend."
+  [backend-id]
+  (let [spec (get backend-specs backend-id)
+        status (check-backend-status backend-id)]
+    (merge spec status {:backend-id backend-id})))
+
+(defn ^{:stratum 4} validate-backend
+  "Validate that a backend can be used.
+   Returns {:valid? true/false :message string}."
+  [backend-id]
+  (if-not (contains? backend-specs backend-id)
+    {:valid? false
+     :message (messages/t :backends/validate-unknown
+                          {:backend (name backend-id)
+                           :command (app-config/command-string "config backends")})}
+    (let [status (check-backend-status backend-id)]
+      (if (:available status)
+        {:valid? true
+         :message (:message status)}
+        {:valid? false
+         :message (:message status)}))))
+
+;------------------------------------------------------------------------------ Layer 5
+
+(defn ^{:stratum 5} list-backends
+  "List all available backends with their status.
+
+   Returns sequence of backend info maps, sorted by availability."
+  []
+  (let [backends (map get-backend-info (keys backend-specs))]
+    (sort-by (juxt (comp not :available) :provider) backends)))
+
+(defn ^{:stratum 5} print-backend-error
   "Print helpful error message when backend is not available."
   [backend-id]
   (let [info (get-backend-info backend-id)
@@ -189,18 +196,16 @@
       (println (messages/t :backends/unknown-issue {:backend backend-name})))
     (println)))
 
-(defn validate-backend
-  "Validate that a backend can be used.
-   Returns {:valid? true/false :message string}."
-  [backend-id]
-  (if-not (contains? backend-specs backend-id)
-    {:valid? false
-     :message (messages/t :backends/validate-unknown
-                          {:backend (name backend-id)
-                           :command (app-config/command-string "config backends")})}
-    (let [status (check-backend-status backend-id)]
-      (if (:available status)
-        {:valid? true
-         :message (:message status)}
-        {:valid? false
-         :message (:message status)}))))
+;------------------------------------------------------------------------------ Layer 6
+
+(defn ^{:stratum 6} print-backends
+  "Print all backends with their status."
+  [config]
+  (let [backends (list-backends)
+        current (get-current-backend config)]
+    (println)
+    (println (messages/t :backends/list-header))
+    (println)
+    (doseq [backend backends]
+      (println (format-backend-status backend current))
+      (println))))

--- a/bases/cli/src/ai/miniforge/cli/config.clj
+++ b/bases/cli/src/ai/miniforge/cli/config.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.config
   "Enhanced configuration management for Miniforge CLI.
 
@@ -31,16 +30,70 @@
    [ai.miniforge.cli.resource-config :as resource-config]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Configuration paths and utilities
 
-(def default-user-config-path
+;; Configuration paths and utilities
+(def ^{:stratum 0} default-user-config-path
   (app-config/config-path))
 
-(def default-config-resource
+(def ^{:stratum 0} default-config-resource
   "Classpath resource path for the fallback user config."
   "config/cli/user-defaults.edn")
 
-(def default-config
+(defn ^{:stratum 0} style
+  "Apply terminal styling using ANSI escape codes."
+  [text color]
+  (let [colors {:red "31" :green "32" :yellow "33" :cyan "36"}]
+    (str "\033[" (get colors color "37") "m" text "\033[0m")))
+
+(defn ^{:stratum 0} write-config-file
+  "Write config to file with pretty printing."
+  [path config]
+  (fs/create-dirs (fs/parent path))
+  (spit path (with-out-str (pprint/pprint config))))
+
+;; Config display and manipulation
+(defn ^{:stratum 0} format-config-value
+  "Format a config value for display."
+  [v]
+  (cond
+    (keyword? v) (name v)
+    (string? v) v
+    :else (pr-str v)))
+
+(defn ^{:stratum 0} parse-config-key
+  "Parse config key path (e.g., 'llm.backend' -> [:llm :backend])."
+  [key-str]
+  (when key-str
+    (mapv keyword (str/split key-str #"\."))))
+
+(defn ^{:stratum 0} parse-config-value
+  "Parse config value from string."
+  [value-str]
+  (try
+    (read-string value-str)
+    (catch Exception _
+      value-str)))
+
+(defn ^{:stratum 0} get-llm-backend
+  "Get LLM backend from config, with workflow override support."
+  [config workflow-override]
+  (or workflow-override
+      (get-in config [:llm :backend])
+      :opencode))
+
+(defn ^{:stratum 0} get-llm-timeout
+  "Get LLM timeout from config."
+  [config]
+  (get-in config [:llm :timeout-ms] 300000))
+
+(defn ^{:stratum 0} get-llm-line-timeout
+  "Get LLM line timeout from config."
+  [config]
+  (get-in config [:llm :line-timeout-ms] 60000))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} default-config
   ;; Static defaults load from EDN; :artifacts :dir is resolved from the
   ;; runtime home dir so MINIFORGE_HOME overrides keep working. Merge (not
   ;; assoc) so any :artifacts keys from the loaded EDN survive while the
@@ -48,25 +101,17 @@
   (update (resource-config/merged-resource-config default-config-resource)
           :artifacts merge {:dir (app-config/artifacts-dir)}))
 
-(defn style
-  "Apply terminal styling using ANSI escape codes."
-  [text color]
-  (let [colors {:red "31" :green "32" :yellow "33" :cyan "36"}]
-    (str "\033[" (get colors color "37") "m" text "\033[0m")))
-
-(defn print-success [msg]
+(defn ^{:stratum 1} print-success [msg]
   (println (style msg :green)))
 
-(defn print-error [msg]
+(defn ^{:stratum 1} print-error [msg]
   (println (style (messages/t :config/error-prefix {:message msg}) :red)))
 
-(defn print-info [msg]
+(defn ^{:stratum 1} print-info [msg]
   (println (style msg :cyan)))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Config file operations
-
-(defn read-config-file
+(defn ^{:stratum 1} read-config-file
   "Read config file, returns nil if doesn't exist."
   [path]
   (when (fs/exists? path)
@@ -76,56 +121,7 @@
         (println (style (messages/t :config/warning-read-failed {:message (.getMessage e)}) :yellow))
         nil))))
 
-(defn write-config-file
-  "Write config to file with pretty printing."
-  [path config]
-  (fs/create-dirs (fs/parent path))
-  (spit path (with-out-str (pprint/pprint config))))
-
-(defn load-merged-config
-  "Load config with env var overrides."
-  [path]
-  (let [file-config (or (read-config-file path) {})
-        merged (merge-with (fn [v1 v2]
-                            (if (map? v1)
-                              (merge v1 v2)
-                              v2))
-                          default-config
-                          file-config)]
-    ;; Apply env var overrides
-    (cond-> merged
-      (System/getenv "MINIFORGE_LLM_BACKEND")
-      (assoc-in [:llm :backend] (keyword (System/getenv "MINIFORGE_LLM_BACKEND")))
-
-      (System/getenv "MINIFORGE_LLM_MODEL")
-      (assoc-in [:llm :model] (System/getenv "MINIFORGE_LLM_MODEL")))))
-
-;------------------------------------------------------------------------------ Layer 2
-;; Config display and manipulation
-
-(defn format-config-value
-  "Format a config value for display."
-  [v]
-  (cond
-    (keyword? v) (name v)
-    (string? v) v
-    :else (pr-str v)))
-
-(defn parse-config-key
-  "Parse config key path (e.g., 'llm.backend' -> [:llm :backend])."
-  [key-str]
-  (when key-str
-    (mapv keyword (str/split key-str #"\."))))
-
-(defn parse-config-value
-  "Parse config value from string."
-  [value-str]
-  (try
-    (read-string value-str)
-    (catch Exception _
-      value-str)))
-
-(defn display-config
+(defn ^{:stratum 1} display-config
   "Display configuration in human-readable format."
   [config config-path]
   (println)
@@ -171,34 +167,27 @@
   (println (messages/t :config/env-model))
   (println))
 
-;------------------------------------------------------------------------------ Layer 3
-;; Command implementations
+;------------------------------------------------------------------------------ Layer 2
 
-(defn cmd-list
-  "List all configuration values."
-  [opts]
-  (let [config-path (or (:config opts) default-user-config-path)
-        config (load-merged-config config-path)]
-    (display-config config config-path)))
+(defn ^{:stratum 2} load-merged-config
+  "Load config with env var overrides."
+  [path]
+  (let [file-config (or (read-config-file path) {})
+        merged (merge-with (fn [v1 v2]
+                            (if (map? v1)
+                              (merge v1 v2)
+                              v2))
+                          default-config
+                          file-config)]
+    ;; Apply env var overrides
+    (cond-> merged
+      (System/getenv "MINIFORGE_LLM_BACKEND")
+      (assoc-in [:llm :backend] (keyword (System/getenv "MINIFORGE_LLM_BACKEND")))
 
-(defn cmd-get
-  "Get a specific configuration value."
-  [opts]
-  (let [key-str (:key opts)
-        config-path (or (:config opts) default-user-config-path)]
-    (if-not key-str
-      (do
-        (print-error (messages/t :config/get-missing-key))
-        (println (messages/t :config/get-usage {:command (app-config/command-string "config get <key>")}))
-        (println (messages/t :config/get-example {:command (app-config/command-string "config get llm.backend")})))
-      (let [config (load-merged-config config-path)
-            key-path (parse-config-key key-str)
-            value (get-in config key-path)]
-        (if value
-          (println (pr-str value))
-          (print-error (messages/t :config/get-not-found {:key key-str})))))))
+      (System/getenv "MINIFORGE_LLM_MODEL")
+      (assoc-in [:llm :model] (System/getenv "MINIFORGE_LLM_MODEL")))))
 
-(defn cmd-set
+(defn ^{:stratum 2} cmd-set
   "Set a configuration value."
   [opts]
   (let [key-str (:key opts)
@@ -219,7 +208,7 @@
         (println (messages/t :config/set-saved {:path config-path}))
         (println)))))
 
-(defn cmd-init
+(defn ^{:stratum 2} cmd-init
   "Initialize user config file."
   [opts]
   (let [config-path (or (:config opts) default-user-config-path)]
@@ -236,7 +225,7 @@
         (println (messages/t :config/init-view-hint {:command (app-config/command-string "config list")}))
         (println)))))
 
-(defn cmd-edit
+(defn ^{:stratum 2} cmd-edit
   "Open config file in $EDITOR."
   [opts]
   (let [config-path (or (:config opts) default-user-config-path)
@@ -251,7 +240,7 @@
       (catch Exception e
         (print-error (messages/t :config/edit-failed {:message (.getMessage e)}))))))
 
-(defn cmd-reset
+(defn ^{:stratum 2} cmd-reset
   "Reset config to defaults."
   [opts]
   (let [config-path (or (:config opts) default-user-config-path)]
@@ -268,14 +257,7 @@
           (println))
         (println (messages/t :config/reset-cancelled))))))
 
-(defn cmd-backends
-  "List available backends with status."
-  [opts]
-  (let [config-path (or (:config opts) default-user-config-path)
-        config (load-merged-config config-path)]
-    (backends/print-backends config)))
-
-(defn cmd-backend
+(defn ^{:stratum 2} cmd-backend
   "Set the LLM backend (shorthand for 'config set llm.backend')."
   [opts]
   (let [backend-str (:backend opts)
@@ -311,7 +293,7 @@
           ;; Backend not available, show helpful error
           (backends/print-backend-error backend-kw))))))
 
-(defn cmd-validate
+(defn ^{:stratum 2} cmd-validate
   "Validate configuration file."
   [opts]
   (let [config-path (or (:config opts) default-user-config-path)]
@@ -344,29 +326,45 @@
             (println)
             (println (messages/t :config/validate-reset-hint {:command (app-config/command-string "config reset")}))))))))
 
-;------------------------------------------------------------------------------ Compatibility functions for workflow-runner
+;------------------------------------------------------------------------------ Layer 3
 
-(defn load-config
+;; Command implementations
+(defn ^{:stratum 3} cmd-list
+  "List all configuration values."
+  [opts]
+  (let [config-path (or (:config opts) default-user-config-path)
+        config (load-merged-config config-path)]
+    (display-config config config-path)))
+
+(defn ^{:stratum 3} cmd-get
+  "Get a specific configuration value."
+  [opts]
+  (let [key-str (:key opts)
+        config-path (or (:config opts) default-user-config-path)]
+    (if-not key-str
+      (do
+        (print-error (messages/t :config/get-missing-key))
+        (println (messages/t :config/get-usage {:command (app-config/command-string "config get <key>")}))
+        (println (messages/t :config/get-example {:command (app-config/command-string "config get llm.backend")})))
+      (let [config (load-merged-config config-path)
+            key-path (parse-config-key key-str)
+            value (get-in config key-path)]
+        (if value
+          (println (pr-str value))
+          (print-error (messages/t :config/get-not-found {:key key-str})))))))
+
+(defn ^{:stratum 3} cmd-backends
+  "List available backends with status."
+  [opts]
+  (let [config-path (or (:config opts) default-user-config-path)
+        config (load-merged-config config-path)]
+    (backends/print-backends config)))
+
+;------------------------------------------------------------------------------ Compatibility functions for workflow-runner
+(defn ^{:stratum 3} load-config
   "Load configuration with environment variable overrides.
    Compatible with old workflow-runner code."
   ([] (load-merged-config default-user-config-path))
   ([opts]
    (let [config-path (or (:config-file opts) default-user-config-path)]
      (load-merged-config config-path))))
-
-(defn get-llm-backend
-  "Get LLM backend from config, with workflow override support."
-  [config workflow-override]
-  (or workflow-override
-      (get-in config [:llm :backend])
-      :opencode))
-
-(defn get-llm-timeout
-  "Get LLM timeout from config."
-  [config]
-  (get-in config [:llm :timeout-ms] 300000))
-
-(defn get-llm-line-timeout
-  "Get LLM line timeout from config."
-  [config]
-  (get-in config [:llm :line-timeout-ms] 60000))

--- a/bases/cli/src/ai/miniforge/cli/main.clj
+++ b/bases/cli/src/ai/miniforge/cli/main.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.main
   "CLI entry point for MiniForge Core and product CLIs.
 
@@ -86,9 +85,9 @@
    [slingshot.slingshot :refer [try+]]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Composition seams (optional web/TUI providers) and pure helpers
 
-(defn- optional-composition-var
+;; Composition seams (optional web/TUI providers) and pure helpers
+(defn- ^{:stratum 0} optional-composition-var
   "Resolve a provider whose entire component is optional for this CLI product.
    This is the CLI's only late-binding boundary: miniforge-core loads this
    namespace without web-dashboard or TUI components on its classpath."
@@ -98,7 +97,7 @@
     (ns-resolve ns-sym var-sym)
     (catch Throwable _ nil)))
 
-(defn- caught-message
+(defn- ^{:stratum 0} caught-message
   [caught throwable]
   (cond
     (instance? Throwable caught)
@@ -114,104 +113,31 @@
     :else
     (str caught)))
 
-(defn- create-pr-train-manager
-  "Build the PR-train manager bound to `event-stream` so train
-   mutations (add-pr, complete-merge) publish governed events that
-   supervisory-state materializes for the consoles."
-  ([]
-   (create-pr-train-manager nil))
-  ([event-stream]
-   (try+
-     (if event-stream
-       (pr-train/create-manager {:event-stream event-stream})
-       (pr-train/create-manager))
-     (catch Object e
-       (println (messages/t :web/pr-train-warning
-                            {:error (caught-message e (:throwable &throw-context))}))
-       nil))))
-
-(defn- create-repo-dag-manager
-  []
-  (try+
-    (repo-dag/create-manager)
-    (catch Object e
-      (println (messages/t :web/repo-dag-warning
-                           {:error (caught-message e (:throwable &throw-context))}))
-      nil)))
-
-(defn- optional-web-launcher
-  "Compose the dashboard command when the product includes web-dashboard."
-  []
-  (when-let [start! (optional-composition-var
-                     'ai.miniforge.web-dashboard.interface
-                     'start!)]
-    (fn [{:keys [port]}]
-      (let [event-stream (es/create-event-stream)
-            _ (supervisory/ensure-attached! event-stream)
-            pr-train-manager (create-pr-train-manager event-stream)
-            repo-dag-manager (create-repo-dag-manager)]
-        (start! {:port port
-                 :event-stream event-stream
-                 :pr-train-manager pr-train-manager
-                 :repo-dag-manager repo-dag-manager})))))
-
-(def web-launcher
-  (optional-web-launcher))
-
-(def web-available?
-  (some? web-launcher))
-
-(alter-var-root #'cmd-monitoring/*web-available?* (constantly web-available?))
-(alter-var-root #'cmd-monitoring/*start-web-dashboard!* (constantly web-launcher))
-
-;; TUI components loaded conditionally (only in JVM/jlink bundled runtime).
-;; This is an optional composition seam: miniforge-core includes the CLI
-;; without bundling the JVM TUI component.
-(def tui-launcher
-  (optional-composition-var 'ai.miniforge.tui-views.interface 'start-standalone-tui!))
-
-(def tui-available?
-  (some? tui-launcher))
-
-;; Propagate TUI availability to monitoring commands
-(alter-var-root #'cmd-monitoring/*tui-available?* (constantly tui-available?))
-(alter-var-root #'cmd-monitoring/*start-standalone-tui!* (constantly tui-launcher))
-(when tui-launcher
-  (cmd-shared/register-optional-fn!
-   'ai.miniforge.tui-views.interface/start-standalone-tui!
-   tui-launcher))
-(when-let [start-fleet-tui! (optional-composition-var 'ai.miniforge.tui-views.interface
-                                                      'start-fleet-tui!)]
-  (cmd-shared/register-optional-fn!
-   'ai.miniforge.tui-views.interface/start-fleet-tui!
-   start-fleet-tui!))
-
 ;; ── Constants and pure helpers ──────────────────────────────────────────────
-
-(def version-info
+(def ^{:stratum 0} version-info
   {:name (app-config/binary-name)
    :version "2026.01.20.1"
    :description (app-config/description)})
 
-(defn current-time-ms
+(defn ^{:stratum 0} current-time-ms
   "Current epoch time in milliseconds. Public so CLI tests can rebind it."
   []
   (System/currentTimeMillis))
 
-(defn get-opts
+(defn ^{:stratum 0} get-opts
   "Extract opts from dispatch result."
   [m]
   (if (contains? m :opts)
     (:opts m)
     m))
 
-(defn check-command
+(defn ^{:stratum 0} check-command
   "Check if a command is available."
   [cmd]
   (let [{:keys [exit]} (process/sh "which" cmd)]
     (zero? exit)))
 
-(defn- timestamp->epoch-ms
+(defn- ^{:stratum 0} timestamp->epoch-ms
   [timestamp]
   (cond
     (instance? java.util.Date timestamp)
@@ -227,7 +153,129 @@
 
     :else nil))
 
-(defn- stale-running?
+(defn- ^{:stratum 0} status-label
+  [status]
+  (messages/t (keyword "status" (str "value-" (name status)))))
+
+(defn ^{:stratum 0} workflow-list-cmd [_m] (workflow-runner/list-workflows!))
+
+(defn ^{:stratum 0} chain-list-cmd [_m] (workflow-runner/list-chains!))
+
+(defn ^{:stratum 0} logs-list-cmd [_m] (observability/handle-logs {:subcommand "list"}))
+
+(defn ^{:stratum 0} events-list-cmd [_m] (observability/handle-events {:subcommand "list"}))
+
+(defn ^{:stratum 0} worktree-cmd [m] (cmd-worktree/worktree-cmd m))
+
+(defn ^{:stratum 0} runtime-info-cmd [m] (cmd-runtime/runtime-info-cmd m))
+
+(defn ^{:stratum 0} runtime-run-cmd [m] (cmd-runtime/runtime-run-cmd m))
+
+(defn ^{:stratum 0} hook-eval-cmd
+  "Evaluate a tool-use request from a Claude PreToolUse hook.
+
+   Reads JSON from stdin, evaluates against policy, writes decision to stdout."
+  [_m]
+  (System/exit (agent/hook-eval-stdin!)))
+
+(defn ^{:stratum 0} lsp-mcp-bridge-cmd
+  "Run the LSP-to-MCP bridge server (spawned by Claude Code/Desktop/Codex as MCP server).
+
+   Reads MINIFORGE_PROJECT_DIR env for the project root. Invoked automatically
+   by the MCP client; not intended for direct user use."
+  [_m]
+  (lsp-bridge/-main))
+
+(defn ^{:stratum 0} lsp-status-cmd [_m]
+  (lsp-tasks/status))
+
+(defn ^{:stratum 0} lsp-install-cmd [m]
+  (lsp-tasks/install (:args m)))
+
+(defn ^{:stratum 0} lsp-setup-cmd [m]
+  (lsp-tasks/setup (:args m)))
+
+(defn ^{:stratum 0} help-cmd
+  [_m]
+  (let [binary-name (app-config/binary-name)
+        description (app-config/description)
+        command-lines (messages/t :help/command-lines)
+        note (messages/t :help/note {:binary binary-name})
+        tui-install (when-let [tui-package (app-config/tui-package)]
+                      (messages/t :help/tui-install {:tui-package tui-package}))]
+    (println (str "\n"
+                  (messages/t :help/title {:binary binary-name
+                                           :description description})
+                  "\n\n"
+                  (messages/t :help/usage {:binary binary-name})
+                  "\n\n"
+                  (str/join "\n" command-lines)
+                  "\n\nNote:\n  "
+                  note
+                  (when tui-install
+                    (str "\n  " tui-install))
+                  "\n\nExamples:\n"
+                  (str/join "\n" (map #(str "  " (app-config/command-string %))
+                                      (app-config/help-examples)))
+                  "\n"))))
+
+(defn- ^{:stratum 0} handle-unknown-command
+  "Print help for an unrecognized CLI command."
+  [{:keys [wrong-input dispatch all-commands]}]
+  (display/print-error (messages/t :main/unknown-command
+                                   {:command (str/join " " (conj (vec dispatch) wrong-input))}))
+  (println)
+  (when (and (= (first dispatch) "fleet")
+             (contains? #{"web" "dashboard" "tui"} wrong-input))
+    (println (messages/t :main/did-you-mean))
+    (println (str "  " (app-config/command-string (if (= wrong-input "dashboard") "web" wrong-input))))
+    (println))
+  (when (seq all-commands)
+    (println (messages/t :main/available-commands
+                         {:scope (if (seq dispatch)
+                                   (str "'" (str/join " " dispatch) "' ")
+                                   "")}))
+    (doseq [cmd all-commands]
+      (println (str "  " (app-config/command-string (str/join " " (conj (vec dispatch) cmd))))))
+    (println))
+  (println (messages/t :main/run-help
+                       {:command (app-config/command-string "help")}))
+  (System/exit 1))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} create-pr-train-manager
+  "Build the PR-train manager bound to `event-stream` so train
+   mutations (add-pr, complete-merge) publish governed events that
+   supervisory-state materializes for the consoles."
+  ([]
+   (create-pr-train-manager nil))
+  ([event-stream]
+   (try+
+     (if event-stream
+       (pr-train/create-manager {:event-stream event-stream})
+       (pr-train/create-manager))
+     (catch Object e
+       (println (messages/t :web/pr-train-warning
+                            {:error (caught-message e (:throwable &throw-context))}))
+       nil))))
+
+(defn- ^{:stratum 1} create-repo-dag-manager
+  []
+  (try+
+    (repo-dag/create-manager)
+    (catch Object e
+      (println (messages/t :web/repo-dag-warning
+                           {:error (caught-message e (:throwable &throw-context))}))
+      nil)))
+
+;; TUI components loaded conditionally (only in JVM/jlink bundled runtime).
+;; This is an optional composition seam: miniforge-core includes the CLI
+;; without bundling the JVM TUI component.
+(def ^{:stratum 1} tui-launcher
+  (optional-composition-var 'ai.miniforge.tui-views.interface 'start-standalone-tui!))
+
+(defn- ^{:stratum 1} stale-running?
   [last-updated]
   (when-let [last-updated-ms (timestamp->epoch-ms last-updated)]
     (let [configured-threshold-ms (:running-stale-threshold-ms (app-config/status-config))
@@ -238,36 +286,7 @@
       (> (- (current-time-ms) last-updated-ms)
          threshold-ms))))
 
-(defn- reconstructed-status
-  [reconstructed last-updated]
-  (cond
-    (wr/completed? reconstructed) :completed
-    (wr/failed? reconstructed) :failed
-    (wr/paused? reconstructed) :paused
-    (stale-running? last-updated) :stale
-    :else :running))
-
-(defn- status-label
-  [status]
-  (messages/t (keyword "status" (str "value-" (name status)))))
-
-(defn- workflow-status-summary
-  [workflow-id]
-  (let [events-dir (app-config/events-dir)
-        events (es/read-workflow-events-by-id events-dir workflow-id)
-        reconstructed (wr/reconstruct-context events-dir workflow-id)
-        last-event (last events)]
-    (when (anomaly/anomaly? reconstructed)
-      (throw (ex-info (:anomaly/message reconstructed) reconstructed)))
-    {:workflow-id workflow-id
-     :status (reconstructed-status reconstructed (:event/timestamp last-event))
-     :spec-name (some-> reconstructed :workflow-spec :name)
-     :event-count (:event-count reconstructed)
-     :completed-phases (:completed-phases reconstructed)
-     :completed-dag-task-count (count (:completed-dag-tasks reconstructed))
-     :last-updated (:event/timestamp last-event)}))
-
-(defn- print-workflow-status
+(defn- ^{:stratum 1} print-workflow-status
   [{:keys [workflow-id status spec-name event-count completed-phases
            completed-dag-task-count last-updated]}]
   (let [unknown (messages/t :status/value-unknown)
@@ -284,29 +303,13 @@
     (println (messages/t :status/field-completed-dag-tasks
                          {:value completed-dag-task-count}))))
 
-(defn- all-workflow-summaries
-  []
-  (let [events-dir (app-config/events-dir)]
-    (if (fs/exists? events-dir)
-      (->> (fs/list-dir events-dir)
-           (filter fs/directory?)
-           (map #(fs/file-name %))
-           (keep (fn [workflow-id]
-                   (try
-                     (workflow-status-summary workflow-id)
-                     (catch Exception _ nil))))
-           (sort-by :last-updated #(compare %2 %1)))
-      [])))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; Command implementations
-
-(defn version-cmd
+(defn ^{:stratum 1} version-cmd
   [_m]
   (println (str (:name version-info) " " (:version version-info)))
   (println (:description version-info)))
 
-(defn doctor-cmd
+(defn ^{:stratum 1} doctor-cmd
   [_m]
   (println "\n" (display/style (app-config/system-check-title) :foreground :cyan :bold true) "\n")
 
@@ -339,7 +342,266 @@
 
     (println)))
 
-(defn status-cmd
+;; Config commands — one-liner delegates
+(defn ^{:stratum 1} config-init-cmd [m] (config/cmd-init (get-opts m)))
+
+(defn ^{:stratum 1} config-list-cmd [m] (config/cmd-list (get-opts m)))
+
+(defn ^{:stratum 1} config-get-cmd [m] (config/cmd-get (get-opts m)))
+
+(defn ^{:stratum 1} config-set-cmd [m] (config/cmd-set (get-opts m)))
+
+(defn ^{:stratum 1} config-edit-cmd [m] (config/cmd-edit (get-opts m)))
+
+(defn ^{:stratum 1} config-reset-cmd [m] (config/cmd-reset (get-opts m)))
+
+(defn ^{:stratum 1} config-backends-cmd [m] (config/cmd-backends (get-opts m)))
+
+(defn ^{:stratum 1} config-backend-cmd [m] (config/cmd-backend (get-opts m)))
+
+(defn ^{:stratum 1} config-validate-cmd [m] (config/cmd-validate (get-opts m)))
+
+;; Workflow commands
+(defn ^{:stratum 1} workflow-run-cmd
+  [m]
+  (let [{:keys [workflow-id version input input-json output quiet dashboard-url]} (get-opts m)]
+    (if-not workflow-id
+      (display/print-error (messages/t :workflow-run/usage
+                                       {:command (app-config/command-string "workflow run <workflow-id> [options]")}))
+      (try
+        (workflow-runner/run-workflow!
+         (keyword (str/replace workflow-id #"^:" ""))
+         {:version (or version "latest")
+          :input input
+          :input-json input-json
+          :output (or output :pretty)
+          :quiet (boolean quiet)
+          :dashboard-url dashboard-url})
+        (catch Exception e
+          (display/print-error (messages/t :workflow-run/failed
+                                           {:error (ex-message e)})))))))
+
+;; Workflow subcommands — spec-driven execution and lifecycle (N5)
+(defn ^{:stratum 1} workflow-execute-cmd [m] (cmd-workflow/workflow-execute-cmd (get-opts m)))
+
+(defn ^{:stratum 1} workflow-inspect-cmd [m] (cmd-workflow/workflow-inspect-cmd (get-opts m)))
+
+(defn ^{:stratum 1} workflow-status-cmd  [m] (cmd-workflow/workflow-status-cmd  (get-opts m)))
+
+(defn ^{:stratum 1} workflow-cancel-cmd  [m] (cmd-workflow/workflow-cancel-cmd  (get-opts m)))
+
+(defn ^{:stratum 1} workflow-gc-scratch-cmd [m] (cmd-workflow/workflow-gc-scratch-cmd (get-opts m)))
+
+;; Chain commands
+(defn ^{:stratum 1} chain-run-cmd
+  [m]
+  (let [{:keys [chain-id version spec input-json quiet]} (get-opts m)]
+    (if-not chain-id
+      (display/print-error (messages/t :chain-run/usage
+                                       {:command (app-config/command-string "chain run <chain-id> [options]")}))
+      (try
+        (workflow-runner/run-chain!
+         (keyword (str/replace chain-id #"^:" ""))
+         {:version (or version "latest")
+          :spec spec
+          :input-json input-json
+          :quiet (boolean quiet)})
+        (catch Exception e
+          (display/print-error (messages/t :chain-run/failed
+                                           {:error (ex-message e)})))))))
+
+;; Observability commands
+(defn ^{:stratum 1} logs-tail-cmd [m] (observability/handle-logs (assoc (get-opts m) :subcommand "tail")))
+
+(defn ^{:stratum 1} events-tail-cmd [m] (observability/handle-events (assoc (get-opts m) :subcommand "tail")))
+
+(defn ^{:stratum 1} events-show-cmd
+  "Render a human-readable timeline for a workflow from the local event log.
+   Delegates to the GROUP 3b events command module."
+  [m]
+  (cmd-events/events-show-cmd (get-opts m)))
+
+;; Delegated commands
+(defn ^{:stratum 1} run-cmd [m] (cmd-run/run-cmd (get-opts m)))
+
+(defn ^{:stratum 1} resume-cmd
+  "First-class `mf resume <workflow-id>` subcommand. The `<workflow-id>`
+   can be passed positionally, or via `--workflow-id`/`-w` / the legacy
+   `--resume`/`-r` flag (kept so existing docs keep working)."
+  [m]
+  (let [opts (get-opts m)
+        args (:args m)
+        wf-id (or (:workflow-id opts)
+                  (:resume opts)
+                  (first args))]
+    (if (str/blank? (str wf-id))
+      (display/print-error (messages/t :resume/missing-workflow-id))
+      (cmd-resume/resume-workflow wf-id opts))))
+
+(defn ^{:stratum 1} scan-cmd [m] (cmd-scan/scan-cmd (get-opts m)))
+
+(defn ^{:stratum 1} init-cmd [m] (cmd-init/init-cmd (get-opts m)))
+
+(defn ^{:stratum 1} web-cmd [m] (cmd-monitoring/web-cmd (get-opts m)))
+
+(defn ^{:stratum 1} tui-cmd [m] (cmd-monitoring/tui-cmd (get-opts m)))
+
+(defn ^{:stratum 1} fleet-start-cmd [m] (cmd-fleet/fleet-start-cmd (get-opts m)))
+
+(defn ^{:stratum 1} fleet-stop-cmd [m] (cmd-fleet/fleet-stop-cmd (get-opts m)))
+
+(defn ^{:stratum 1} fleet-status-cmd [m] (cmd-fleet/fleet-status-cmd (get-opts m) config/default-user-config-path config/default-config))
+
+(defn ^{:stratum 1} fleet-add-cmd [m] (cmd-fleet/fleet-add-cmd (get-opts m) config/default-user-config-path config/default-config))
+
+(defn ^{:stratum 1} fleet-remove-cmd [m] (cmd-fleet/fleet-remove-cmd (get-opts m) config/default-user-config-path config/default-config))
+
+(defn ^{:stratum 1} fleet-watch-cmd [m] (cmd-fleet/fleet-watch-cmd (get-opts m)))
+
+(defn ^{:stratum 1} fleet-prs-cmd [m] (cmd-fleet/fleet-prs-cmd (get-opts m) config/default-user-config-path config/default-config))
+
+(defn ^{:stratum 1} pr-list-cmd [m]
+  (cmd-pr/pr-list-cmd (get-opts m)
+                      (fn [config-path]
+                        (cmd-fleet/load-config config-path config/default-user-config-path config/default-config))))
+
+(defn ^{:stratum 1} pr-review-cmd [m] (cmd-pr/pr-review-cmd (get-opts m)))
+
+(defn ^{:stratum 1} pr-respond-cmd [m] (cmd-pr/pr-respond-cmd (get-opts m)))
+
+(defn ^{:stratum 1} pr-merge-cmd [m] (cmd-pr/pr-merge-cmd (get-opts m)))
+
+(defn ^{:stratum 1} pr-monitor-cmd [m] (cmd-pr/pr-monitor-cmd (get-opts m)))
+
+(defn ^{:stratum 1} pr-review-monitor-cmd [m] (cmd-pr-review-monitor/pr-review-monitor-cmd (get-opts m)))
+
+(defn ^{:stratum 1} pr-resume-dispatcher-cmd [m] (cmd-pr-resume/pr-resume-dispatcher-cmd (get-opts m)))
+
+(defn ^{:stratum 1} pr-policy-respond-cmd [m] (cmd-pr-policy/pr-policy-respond-cmd (get-opts m)))
+
+;; Control Plane commands
+(defn ^{:stratum 1} cp-status-cmd [m] (cmd-cp/status-cmd (get-opts m)))
+
+(defn ^{:stratum 1} cp-decisions-cmd [m] (cmd-cp/decisions-cmd (get-opts m)))
+
+(defn ^{:stratum 1} cp-resolve-cmd [m] (cmd-cp/resolve-cmd (get-opts m)))
+
+(defn ^{:stratum 1} cp-terminate-cmd [m] (cmd-cp/terminate-cmd (get-opts m)))
+
+;; Policy commands (N5)
+(defn ^{:stratum 1} policy-list-cmd    [m] (cmd-policy/policy-list-cmd    (get-opts m)))
+
+(defn ^{:stratum 1} policy-show-cmd    [m] (cmd-policy/policy-show-cmd    (get-opts m)))
+
+(defn ^{:stratum 1} policy-install-cmd [m] (cmd-policy/policy-install-cmd (get-opts m)))
+
+;; Evidence commands (N5)
+(defn ^{:stratum 1} evidence-list-cmd   [m] (cmd-evidence/evidence-list-cmd   (get-opts m)))
+
+(defn ^{:stratum 1} evidence-show-cmd   [m] (cmd-evidence/evidence-show-cmd   (get-opts m)))
+
+(defn ^{:stratum 1} evidence-export-cmd [m] (cmd-evidence/evidence-export-cmd (get-opts m)))
+
+;; Artifact commands (N5)
+(defn ^{:stratum 1} artifact-list-cmd       [m] (cmd-artifact/artifact-list-cmd       (get-opts m)))
+
+(defn ^{:stratum 1} artifact-provenance-cmd [m] (cmd-artifact/artifact-provenance-cmd (get-opts m)))
+
+;; ETL commands (N5)
+(defn ^{:stratum 1} etl-repo-cmd     [m] (cmd-etl/etl-repo-cmd     (get-opts m)))
+
+(defn ^{:stratum 1} etl-run-cmd      [m] (cmd-etl/etl-run-cmd      (get-opts m)))
+
+(defn ^{:stratum 1} etl-list-cmd     [m] (cmd-etl/etl-list-cmd     (get-opts m)))
+
+(defn ^{:stratum 1} etl-validate-cmd [m] (cmd-etl/etl-validate-cmd (get-opts m)))
+
+(defn ^{:stratum 1} etl-registry-cmd [m] (cmd-etl/etl-registry-cmd (get-opts m)))
+
+(defn ^{:stratum 1} context-server-cmd
+  "Run the MCP context server (internal — spawned as subprocess by the agent).
+
+   Reads JSON-RPC 2.0 from stdin, serves context_read/context_grep/context_glob
+   from a pre-populated cache with filesystem fallback, plus context_write which
+   writes to --workdir (the agent's worktree). Invoked automatically; not
+   intended for direct user use."
+  [m]
+  (let [{:keys [artifact-dir source-root workdir]} (get-opts m)]
+    (mcp-context-server/start-server artifact-dir source-root workdir)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- ^{:stratum 2} optional-web-launcher
+  "Compose the dashboard command when the product includes web-dashboard."
+  []
+  (when-let [start! (optional-composition-var
+                     'ai.miniforge.web-dashboard.interface
+                     'start!)]
+    (fn [{:keys [port]}]
+      (let [event-stream (es/create-event-stream)
+            _ (supervisory/ensure-attached! event-stream)
+            pr-train-manager (create-pr-train-manager event-stream)
+            repo-dag-manager (create-repo-dag-manager)]
+        (start! {:port port
+                 :event-stream event-stream
+                 :pr-train-manager pr-train-manager
+                 :repo-dag-manager repo-dag-manager})))))
+
+(def ^{:stratum 2} tui-available?
+  (some? tui-launcher))
+
+(defn- ^{:stratum 2} reconstructed-status
+  [reconstructed last-updated]
+  (cond
+    (wr/completed? reconstructed) :completed
+    (wr/failed? reconstructed) :failed
+    (wr/paused? reconstructed) :paused
+    (stale-running? last-updated) :stale
+    :else :running))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(def ^{:stratum 3} web-launcher
+  (optional-web-launcher))
+
+(defn- ^{:stratum 3} workflow-status-summary
+  [workflow-id]
+  (let [events-dir (app-config/events-dir)
+        events (es/read-workflow-events-by-id events-dir workflow-id)
+        reconstructed (wr/reconstruct-context events-dir workflow-id)
+        last-event (last events)]
+    (when (anomaly/anomaly? reconstructed)
+      (throw (ex-info (:anomaly/message reconstructed) reconstructed)))
+    {:workflow-id workflow-id
+     :status (reconstructed-status reconstructed (:event/timestamp last-event))
+     :spec-name (some-> reconstructed :workflow-spec :name)
+     :event-count (:event-count reconstructed)
+     :completed-phases (:completed-phases reconstructed)
+     :completed-dag-task-count (count (:completed-dag-tasks reconstructed))
+     :last-updated (:event/timestamp last-event)}))
+
+;------------------------------------------------------------------------------ Layer 4
+
+(def ^{:stratum 4} web-available?
+  (some? web-launcher))
+
+(defn- ^{:stratum 4} all-workflow-summaries
+  []
+  (let [events-dir (app-config/events-dir)]
+    (if (fs/exists? events-dir)
+      (->> (fs/list-dir events-dir)
+           (filter fs/directory?)
+           (map #(fs/file-name %))
+           (keep (fn [workflow-id]
+                   (try
+                     (workflow-status-summary workflow-id)
+                     (catch Exception _ nil))))
+           (sort-by :last-updated #(compare %2 %1)))
+      [])))
+
+;------------------------------------------------------------------------------ Layer 5
+
+(defn ^{:stratum 5} status-cmd
   [m]
   (let [{:keys [workflow-id]} (get-opts m)]
     (if workflow-id
@@ -361,209 +623,10 @@
                                  {:value (or last-updated unknown)})))
           (println (str "  " none)))))))
 
-;; Config commands — one-liner delegates
-(defn config-init-cmd [m] (config/cmd-init (get-opts m)))
-(defn config-list-cmd [m] (config/cmd-list (get-opts m)))
-(defn config-get-cmd [m] (config/cmd-get (get-opts m)))
-(defn config-set-cmd [m] (config/cmd-set (get-opts m)))
-(defn config-edit-cmd [m] (config/cmd-edit (get-opts m)))
-(defn config-reset-cmd [m] (config/cmd-reset (get-opts m)))
-(defn config-backends-cmd [m] (config/cmd-backends (get-opts m)))
-(defn config-backend-cmd [m] (config/cmd-backend (get-opts m)))
-(defn config-validate-cmd [m] (config/cmd-validate (get-opts m)))
+;------------------------------------------------------------------------------ Layer 6
 
-;; Workflow commands
-(defn workflow-run-cmd
-  [m]
-  (let [{:keys [workflow-id version input input-json output quiet dashboard-url]} (get-opts m)]
-    (if-not workflow-id
-      (display/print-error (messages/t :workflow-run/usage
-                                       {:command (app-config/command-string "workflow run <workflow-id> [options]")}))
-      (try
-        (workflow-runner/run-workflow!
-         (keyword (str/replace workflow-id #"^:" ""))
-         {:version (or version "latest")
-          :input input
-          :input-json input-json
-          :output (or output :pretty)
-          :quiet (boolean quiet)
-          :dashboard-url dashboard-url})
-        (catch Exception e
-          (display/print-error (messages/t :workflow-run/failed
-                                           {:error (ex-message e)})))))))
-
-(defn workflow-list-cmd [_m] (workflow-runner/list-workflows!))
-
-;; Workflow subcommands — spec-driven execution and lifecycle (N5)
-(defn workflow-execute-cmd [m] (cmd-workflow/workflow-execute-cmd (get-opts m)))
-(defn workflow-inspect-cmd [m] (cmd-workflow/workflow-inspect-cmd (get-opts m)))
-(defn workflow-status-cmd  [m] (cmd-workflow/workflow-status-cmd  (get-opts m)))
-(defn workflow-cancel-cmd  [m] (cmd-workflow/workflow-cancel-cmd  (get-opts m)))
-(defn workflow-gc-scratch-cmd [m] (cmd-workflow/workflow-gc-scratch-cmd (get-opts m)))
-
-;; Chain commands
-(defn chain-run-cmd
-  [m]
-  (let [{:keys [chain-id version spec input-json quiet]} (get-opts m)]
-    (if-not chain-id
-      (display/print-error (messages/t :chain-run/usage
-                                       {:command (app-config/command-string "chain run <chain-id> [options]")}))
-      (try
-        (workflow-runner/run-chain!
-         (keyword (str/replace chain-id #"^:" ""))
-         {:version (or version "latest")
-          :spec spec
-          :input-json input-json
-          :quiet (boolean quiet)})
-        (catch Exception e
-          (display/print-error (messages/t :chain-run/failed
-                                           {:error (ex-message e)})))))))
-
-(defn chain-list-cmd [_m] (workflow-runner/list-chains!))
-
-;; Observability commands
-(defn logs-tail-cmd [m] (observability/handle-logs (assoc (get-opts m) :subcommand "tail")))
-(defn logs-list-cmd [_m] (observability/handle-logs {:subcommand "list"}))
-(defn events-tail-cmd [m] (observability/handle-events (assoc (get-opts m) :subcommand "tail")))
-(defn events-list-cmd [_m] (observability/handle-events {:subcommand "list"}))
-(defn events-show-cmd
-  "Render a human-readable timeline for a workflow from the local event log.
-   Delegates to the GROUP 3b events command module."
-  [m]
-  (cmd-events/events-show-cmd (get-opts m)))
-
-;; Delegated commands
-(defn run-cmd [m] (cmd-run/run-cmd (get-opts m)))
-
-(defn resume-cmd
-  "First-class `mf resume <workflow-id>` subcommand. The `<workflow-id>`
-   can be passed positionally, or via `--workflow-id`/`-w` / the legacy
-   `--resume`/`-r` flag (kept so existing docs keep working)."
-  [m]
-  (let [opts (get-opts m)
-        args (:args m)
-        wf-id (or (:workflow-id opts)
-                  (:resume opts)
-                  (first args))]
-    (if (str/blank? (str wf-id))
-      (display/print-error (messages/t :resume/missing-workflow-id))
-      (cmd-resume/resume-workflow wf-id opts))))
-(defn scan-cmd [m] (cmd-scan/scan-cmd (get-opts m)))
-(defn init-cmd [m] (cmd-init/init-cmd (get-opts m)))
-(defn worktree-cmd [m] (cmd-worktree/worktree-cmd m))
-(defn runtime-info-cmd [m] (cmd-runtime/runtime-info-cmd m))
-(defn runtime-run-cmd [m] (cmd-runtime/runtime-run-cmd m))
-(defn web-cmd [m] (cmd-monitoring/web-cmd (get-opts m)))
-(defn tui-cmd [m] (cmd-monitoring/tui-cmd (get-opts m)))
-(defn fleet-start-cmd [m] (cmd-fleet/fleet-start-cmd (get-opts m)))
-(defn fleet-stop-cmd [m] (cmd-fleet/fleet-stop-cmd (get-opts m)))
-(defn fleet-status-cmd [m] (cmd-fleet/fleet-status-cmd (get-opts m) config/default-user-config-path config/default-config))
-(defn fleet-add-cmd [m] (cmd-fleet/fleet-add-cmd (get-opts m) config/default-user-config-path config/default-config))
-(defn fleet-remove-cmd [m] (cmd-fleet/fleet-remove-cmd (get-opts m) config/default-user-config-path config/default-config))
-(defn fleet-watch-cmd [m] (cmd-fleet/fleet-watch-cmd (get-opts m)))
-(defn fleet-prs-cmd [m] (cmd-fleet/fleet-prs-cmd (get-opts m) config/default-user-config-path config/default-config))
-(defn pr-list-cmd [m]
-  (cmd-pr/pr-list-cmd (get-opts m)
-                      (fn [config-path]
-                        (cmd-fleet/load-config config-path config/default-user-config-path config/default-config))))
-(defn pr-review-cmd [m] (cmd-pr/pr-review-cmd (get-opts m)))
-(defn pr-respond-cmd [m] (cmd-pr/pr-respond-cmd (get-opts m)))
-(defn pr-merge-cmd [m] (cmd-pr/pr-merge-cmd (get-opts m)))
-(defn pr-monitor-cmd [m] (cmd-pr/pr-monitor-cmd (get-opts m)))
-(defn pr-review-monitor-cmd [m] (cmd-pr-review-monitor/pr-review-monitor-cmd (get-opts m)))
-(defn pr-resume-dispatcher-cmd [m] (cmd-pr-resume/pr-resume-dispatcher-cmd (get-opts m)))
-(defn pr-policy-respond-cmd [m] (cmd-pr-policy/pr-policy-respond-cmd (get-opts m)))
-
-;; Control Plane commands
-(defn cp-status-cmd [m] (cmd-cp/status-cmd (get-opts m)))
-(defn cp-decisions-cmd [m] (cmd-cp/decisions-cmd (get-opts m)))
-(defn cp-resolve-cmd [m] (cmd-cp/resolve-cmd (get-opts m)))
-(defn cp-terminate-cmd [m] (cmd-cp/terminate-cmd (get-opts m)))
-
-;; Policy commands (N5)
-(defn policy-list-cmd    [m] (cmd-policy/policy-list-cmd    (get-opts m)))
-(defn policy-show-cmd    [m] (cmd-policy/policy-show-cmd    (get-opts m)))
-(defn policy-install-cmd [m] (cmd-policy/policy-install-cmd (get-opts m)))
-
-;; Evidence commands (N5)
-(defn evidence-list-cmd   [m] (cmd-evidence/evidence-list-cmd   (get-opts m)))
-(defn evidence-show-cmd   [m] (cmd-evidence/evidence-show-cmd   (get-opts m)))
-(defn evidence-export-cmd [m] (cmd-evidence/evidence-export-cmd (get-opts m)))
-
-;; Artifact commands (N5)
-(defn artifact-list-cmd       [m] (cmd-artifact/artifact-list-cmd       (get-opts m)))
-(defn artifact-provenance-cmd [m] (cmd-artifact/artifact-provenance-cmd (get-opts m)))
-
-;; ETL commands (N5)
-(defn etl-repo-cmd     [m] (cmd-etl/etl-repo-cmd     (get-opts m)))
-(defn etl-run-cmd      [m] (cmd-etl/etl-run-cmd      (get-opts m)))
-(defn etl-list-cmd     [m] (cmd-etl/etl-list-cmd     (get-opts m)))
-(defn etl-validate-cmd [m] (cmd-etl/etl-validate-cmd (get-opts m)))
-(defn etl-registry-cmd [m] (cmd-etl/etl-registry-cmd (get-opts m)))
-
-(defn hook-eval-cmd
-  "Evaluate a tool-use request from a Claude PreToolUse hook.
-
-   Reads JSON from stdin, evaluates against policy, writes decision to stdout."
-  [_m]
-  (System/exit (agent/hook-eval-stdin!)))
-
-(defn context-server-cmd
-  "Run the MCP context server (internal — spawned as subprocess by the agent).
-
-   Reads JSON-RPC 2.0 from stdin, serves context_read/context_grep/context_glob
-   from a pre-populated cache with filesystem fallback, plus context_write which
-   writes to --workdir (the agent's worktree). Invoked automatically; not
-   intended for direct user use."
-  [m]
-  (let [{:keys [artifact-dir source-root workdir]} (get-opts m)]
-    (mcp-context-server/start-server artifact-dir source-root workdir)))
-
-(defn lsp-mcp-bridge-cmd
-  "Run the LSP-to-MCP bridge server (spawned by Claude Code/Desktop/Codex as MCP server).
-
-   Reads MINIFORGE_PROJECT_DIR env for the project root. Invoked automatically
-   by the MCP client; not intended for direct user use."
-  [_m]
-  (lsp-bridge/-main))
-
-(defn lsp-status-cmd [_m]
-  (lsp-tasks/status))
-
-(defn lsp-install-cmd [m]
-  (lsp-tasks/install (:args m)))
-
-(defn lsp-setup-cmd [m]
-  (lsp-tasks/setup (:args m)))
-
-(defn help-cmd
-  [_m]
-  (let [binary-name (app-config/binary-name)
-        description (app-config/description)
-        command-lines (messages/t :help/command-lines)
-        note (messages/t :help/note {:binary binary-name})
-        tui-install (when-let [tui-package (app-config/tui-package)]
-                      (messages/t :help/tui-install {:tui-package tui-package}))]
-    (println (str "\n"
-                  (messages/t :help/title {:binary binary-name
-                                           :description description})
-                  "\n\n"
-                  (messages/t :help/usage {:binary binary-name})
-                  "\n\n"
-                  (str/join "\n" command-lines)
-                  "\n\nNote:\n  "
-                  note
-                  (when tui-install
-                    (str "\n  " tui-install))
-                  "\n\nExamples:\n"
-                  (str/join "\n" (map #(str "  " (app-config/command-string %))
-                                      (app-config/help-examples)))
-                  "\n"))))
-
-;------------------------------------------------------------------------------ Layer 2
 ;; CLI dispatch
-
-(def dispatch-table
+(def ^{:stratum 6} dispatch-table
   [{:cmds ["version"] :fn version-cmd}
    {:cmds ["doctor"]  :fn doctor-cmd}
    {:cmds ["help"]    :fn help-cmd}
@@ -833,30 +896,9 @@
    {:cmds ["etl" "validate"]  :fn etl-validate-cmd :args->opts [:pack]}
    {:cmds ["etl" "registry"]  :fn etl-registry-cmd}])
 
-(defn- handle-unknown-command
-  "Print help for an unrecognized CLI command."
-  [{:keys [wrong-input dispatch all-commands]}]
-  (display/print-error (messages/t :main/unknown-command
-                                   {:command (str/join " " (conj (vec dispatch) wrong-input))}))
-  (println)
-  (when (and (= (first dispatch) "fleet")
-             (contains? #{"web" "dashboard" "tui"} wrong-input))
-    (println (messages/t :main/did-you-mean))
-    (println (str "  " (app-config/command-string (if (= wrong-input "dashboard") "web" wrong-input))))
-    (println))
-  (when (seq all-commands)
-    (println (messages/t :main/available-commands
-                         {:scope (if (seq dispatch)
-                                   (str "'" (str/join " " dispatch) "' ")
-                                   "")}))
-    (doseq [cmd all-commands]
-      (println (str "  " (app-config/command-string (str/join " " (conj (vec dispatch) cmd))))))
-    (println))
-  (println (messages/t :main/run-help
-                       {:command (app-config/command-string "help")}))
-  (System/exit 1))
+;------------------------------------------------------------------------------ Layer 7
 
-(defn -main
+(defn ^{:stratum 7} -main
   "CLI entry point."
   [& args]
   (try+
@@ -864,6 +906,26 @@
     #_{:clj-kondo/ignore [:unresolved-symbol]}
     (catch [:type :org.babashka/cli :cause :no-match] data
       (handle-unknown-command data))))
+
+(alter-var-root #'cmd-monitoring/*web-available?* (constantly web-available?))
+
+(alter-var-root #'cmd-monitoring/*start-web-dashboard!* (constantly web-launcher))
+
+;; Propagate TUI availability to monitoring commands
+(alter-var-root #'cmd-monitoring/*tui-available?* (constantly tui-available?))
+
+(alter-var-root #'cmd-monitoring/*start-standalone-tui!* (constantly tui-launcher))
+
+(when tui-launcher
+  (cmd-shared/register-optional-fn!
+   'ai.miniforge.tui-views.interface/start-standalone-tui!
+   tui-launcher))
+
+(when-let [start-fleet-tui! (optional-composition-var 'ai.miniforge.tui-views.interface
+                                                      'start-fleet-tui!)]
+  (cmd-shared/register-optional-fn!
+   'ai.miniforge.tui-views.interface/start-fleet-tui!
+   start-fleet-tui!))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/bases/cli/src/ai/miniforge/cli/main/commands/artifact_cmds.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/artifact_cmds.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.main.commands.artifact-cmds
   "Artifact commands: list, provenance.
 
@@ -31,12 +30,31 @@
    [ai.miniforge.cli.messages :as messages]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Helpers
 
-(defn- artifacts-dir []
+;; Helpers
+(defn- ^{:stratum 0} artifacts-dir []
   (app-config/artifacts-dir))
 
-(defn- scan-artifact-files []
+(defn- ^{:stratum 0} create-artifact-store []
+  (artifact/create-transit-store {:dir (app-config/home-dir)}))
+
+(defn ^{:stratum 0} format-file-size
+  "Format a byte count into a human-readable size string."
+  [bytes]
+  (cond
+    (< bytes shared/bytes-per-kb) (str bytes "B")
+    (< bytes shared/bytes-per-mb) (format "%.1fKB" (/ bytes (double shared/bytes-per-kb)))
+    :else                         (format "%.1fMB" (/ bytes (double shared/bytes-per-mb)))))
+
+;; Display helpers
+(defn- ^{:stratum 0} keyword->str
+  "Convert a value to string, rendering keywords as their name."
+  [v]
+  (if (keyword? v) (name v) (str v)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} scan-artifact-files []
   (let [dir (io/file (artifacts-dir))]
     (if (.exists dir)
       (->> (file-seq dir)
@@ -46,36 +64,17 @@
            vec)
       [])))
 
-(defn- create-artifact-store []
-  (artifact/create-transit-store {:dir (app-config/home-dir)}))
-
-(defn- list-component-artifacts []
+(defn- ^{:stratum 1} list-component-artifacts []
   (try
     (vec (artifact/query (create-artifact-store) {}))
     (catch Exception _ nil)))
 
-(defn- get-component-provenance [id]
+(defn- ^{:stratum 1} get-component-provenance [id]
   (try
     (artifact/get-provenance (create-artifact-store) id)
     (catch Exception _ nil)))
 
-(defn format-file-size
-  "Format a byte count into a human-readable size string."
-  [bytes]
-  (cond
-    (< bytes shared/bytes-per-kb) (str bytes "B")
-    (< bytes shared/bytes-per-mb) (format "%.1fKB" (/ bytes (double shared/bytes-per-kb)))
-    :else                         (format "%.1fMB" (/ bytes (double shared/bytes-per-mb)))))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Display helpers
-
-(defn- keyword->str
-  "Convert a value to string, rendering keywords as their name."
-  [v]
-  (if (keyword? v) (name v) (str v)))
-
-(def ^:private provenance-spec
+(def ^{:stratum 1} ^:private provenance-spec
   {:header   :artifact/provenance-header
    :fields   [[:artifact/workflow-id :artifact/provenance-workflow {:transform keyword->str}]
               [:artifact/phase       :artifact/provenance-phase    {:transform keyword->str}]
@@ -87,15 +86,15 @@
               {:key :artifact/files :header :artifact/provenance-files
                :entry :artifact/provenance-file-entry :entry-fn (fn [p] {:path p})}]})
 
-(defn- display-provenance
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- ^{:stratum 2} display-provenance
   "Render the full provenance block for an artifact."
   [id provenance]
   (display/render-detail (assoc provenance-spec :header-params {:id id}) provenance))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Command implementations
-
-(defn artifact-list-cmd
+(defn ^{:stratum 2} artifact-list-cmd
   "List artifacts produced by workflow runs.
 
    Uses the artifact component's list function if available,
@@ -128,7 +127,9 @@
           (println (messages/t :artifact/none))))))
   (println))
 
-(defn artifact-provenance-cmd
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} artifact-provenance-cmd
   "Show provenance chain for an artifact by ID.
 
    Provenance includes: workflow run, phase that produced it, agent,

--- a/bases/cli/src/ai/miniforge/cli/main/commands/control_plane.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/control_plane.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.main.commands.control-plane
   "Control Plane CLI commands.
 
@@ -34,18 +33,16 @@
    [ai.miniforge.cli.main.display :as display]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Color mappings (loaded from resource catalog)
 
-(defn- status->color [status]
+;; Color mappings (loaded from resource catalog)
+(defn- ^{:stratum 0} status->color [status]
   (get (messages/t :cp/status-colors) status :white))
 
-(defn- priority->color [priority]
+(defn- ^{:stratum 0} priority->color [priority]
   (get (messages/t :cp/priority-colors) priority :white))
 
-;------------------------------------------------------------------------------ Layer 0
 ;; Dashboard discovery
-
-(defn- discover-dashboard-url
+(defn- ^{:stratum 0} discover-dashboard-url
   "Read the dashboard port from discovery file.
    Returns base URL string or nil."
   []
@@ -57,10 +54,8 @@
           (str "http://localhost:" port))
         (catch Exception _ nil)))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; HTTP client helpers
-
-(defn- http-get
+(defn- ^{:stratum 0} http-get
   "Simple HTTP GET. Returns parsed JSON body or nil."
   [url]
   (try
@@ -76,7 +71,7 @@
       (display/print-error (ex-message e))
       nil)))
 
-(defn- http-post
+(defn- ^{:stratum 0} http-post
   "Simple HTTP POST with JSON body. Returns parsed JSON body or nil."
   [url body]
   (try
@@ -97,7 +92,9 @@
       (display/print-error (ex-message e))
       nil)))
 
-(defn- with-dashboard
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} with-dashboard
   "Execute f with discovered dashboard base URL. Prints error if not found."
   [f]
   (if-let [base-url (discover-dashboard-url)]
@@ -108,9 +105,9 @@
       (println (messages/t :cp/dashboard-try-again)))))
 
 ;------------------------------------------------------------------------------ Layer 2
-;; CLI commands
 
-(defn status-cmd
+;; CLI commands
+(defn ^{:stratum 2} status-cmd
   "Show control plane agent summary."
   [_opts]
   (with-dashboard
@@ -146,7 +143,7 @@
                                         :vendor (get a :agent/vendor fallback)}))))))
             (println))))))
 
-(defn decisions-cmd
+(defn ^{:stratum 2} decisions-cmd
   "Show pending decisions."
   [_opts]
   (with-dashboard
@@ -179,7 +176,7 @@
                     (println))))))
           (println))))))
 
-(defn resolve-cmd
+(defn ^{:stratum 2} resolve-cmd
   "Resolve a pending decision."
   [opts]
   (let [decision-id (:decision-id opts)
@@ -200,7 +197,7 @@
                                       :foreground :green))
               (println (display/style (messages/t :cp/resolve-failed) :foreground :red)))))))))
 
-(defn terminate-cmd
+(defn ^{:stratum 2} terminate-cmd
   "Terminate an agent."
   [opts]
   (let [agent-id (:agent-id opts)]

--- a/bases/cli/src/ai/miniforge/cli/main/commands/etl.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/etl.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.main.commands.etl
   "ETL commands:
      - `etl repo <url>`                — clone+analyze a git repository
@@ -44,9 +43,9 @@
    [ai.miniforge.schema.interface :as schema]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Helpers — shared by etl repo
 
-(defn validate-git-url
+;; Helpers — shared by etl repo
+(defn ^{:stratum 0} validate-git-url
   "Return true when url begins with a recognised git transport prefix."
   [url]
   (boolean
@@ -55,7 +54,7 @@
        (str/starts-with? url "ssh://")
        (str/starts-with? url "http://"))))
 
-(defn- git-clone-temp
+(defn- ^{:stratum 0} git-clone-temp
   "Shallow-clone `url` into a temporary directory.
    Returns a schema/success or schema/failure result."
   [url]
@@ -69,10 +68,8 @@
     (catch Exception e
       (schema/failure :path (ex-message e)))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Pack-path resolution (shared by run + validate)
-
-(defn- single-file-under
+(defn- ^{:stratum 0} single-file-under
   "If exactly one .edn file lives under `dir/subdir`, return its abs path;
    otherwise nil (caller decides whether to error)."
   [dir subdir]
@@ -82,29 +79,7 @@
         (when (= 1 (count ednfiles))
           (str (first ednfiles)))))))
 
-(defn- resolve-pipeline-path
-  "Resolve `pack-or-pipeline` into `[pack-dir pipeline-path]` as absolute
-   paths. `pack-dir` is nil when the caller passed a pipeline EDN
-   directly (no envs/ lookup possible)."
-  [pack-or-pipeline]
-  (let [f (fs/file pack-or-pipeline)]
-    (cond
-      (fs/directory? f)
-      (if-let [p (single-file-under f "pipelines")]
-        [(str (fs/absolutize f)) (str (fs/absolutize p))]
-        (response/throw-anomaly! :anomalies/not-found
-                                 (str "Could not find a single pipelines/*.edn under " f)
-                                 {:pack-dir (str (fs/absolutize f))}))
-
-      (and (fs/regular-file? f) (str/ends-with? (str f) ".edn"))
-      [nil (str (fs/absolutize f))]
-
-      :else
-      (response/throw-anomaly! :anomalies/incorrect
-                               (str "Not a pack directory or pipeline EDN: " pack-or-pipeline)
-                               {:input pack-or-pipeline}))))
-
-(defn- resolve-env-path
+(defn- ^{:stratum 0} resolve-env-path
   "Resolve `--env`, which may be a `.edn` path or a bare env name that
    maps to `<pack-dir>/envs/<name>.edn`. Returns an absolute path or
    throws on an unresolvable input."
@@ -131,24 +106,8 @@
                              (str "--env was a name but pipeline was given directly; pass a .edn path instead: " env)
                              {:env env})))
 
-(defn- resolve-pack-paths
-  "Given the positional arg to `etl run` / `etl validate` and the `--env`
-   flag, return `[pipeline-path env-path]` as absolute file paths, or
-   throw ex-info on an unresolvable input.
-
-   - If `pack-or-pipeline` is a directory, look for one `pipelines/*.edn`.
-   - If it's an .edn file, use it as the pipeline.
-   - `env` may be a path or a bare env name that resolves to
-     `<pack>/envs/<name>.edn` when pack-or-pipeline is a directory."
-  [pack-or-pipeline env]
-  (let [[pack-dir pipeline-path] (resolve-pipeline-path pack-or-pipeline)
-        env-path                 (resolve-env-path env pack-dir)]
-    [pipeline-path env-path]))
-
-;------------------------------------------------------------------------------ Layer 2
 ;; JVM shell-out (run / list / validate)
-
-(defn- find-miniforge-root
+(defn- ^{:stratum 0} find-miniforge-root
   "Walk up from `start` until a directory containing both `workspace.edn`
    and `bases/etl/deps.edn` is found. Returns the absolute path or nil
    if no such ancestor exists (i.e., not inside a miniforge checkout
@@ -167,7 +126,31 @@
        :else
        (recur (fs/parent dir))))))
 
-(defn- shell-etl!
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} resolve-pipeline-path
+  "Resolve `pack-or-pipeline` into `[pack-dir pipeline-path]` as absolute
+   paths. `pack-dir` is nil when the caller passed a pipeline EDN
+   directly (no envs/ lookup possible)."
+  [pack-or-pipeline]
+  (let [f (fs/file pack-or-pipeline)]
+    (cond
+      (fs/directory? f)
+      (if-let [p (single-file-under f "pipelines")]
+        [(str (fs/absolutize f)) (str (fs/absolutize p))]
+        (response/throw-anomaly! :anomalies/not-found
+                                 (str "Could not find a single pipelines/*.edn under " f)
+                                 {:pack-dir (str (fs/absolutize f))}))
+
+      (and (fs/regular-file? f) (str/ends-with? (str f) ".edn"))
+      [nil (str (fs/absolutize f))]
+
+      :else
+      (response/throw-anomaly! :anomalies/incorrect
+                               (str "Not a pack directory or pipeline EDN: " pack-or-pipeline)
+                               {:input pack-or-pipeline}))))
+
+(defn- ^{:stratum 1} shell-etl!
   "Shell out to the JVM etl entry point from the miniforge root. `args`
    are the post-`-m` args: the subcommand name and its flags. Streams
    stdout/stderr to the user's terminal. Returns the subprocess exit
@@ -182,10 +165,8 @@
     (do (display/print-error (messages/t :etl/run-requires-checkout))
         1)))
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Repository analysis (etl repo)
-
-(defn- analyze-repo-url!
+(defn- ^{:stratum 1} analyze-repo-url!
   "Clone repo and run repo-analyzer against the temporary checkout."
   [url]
   (let [clone-result (git-clone-temp url)]
@@ -210,10 +191,24 @@
             (try (fs/delete-tree repo-path)
                  (catch Exception _ nil))))))))
 
-;------------------------------------------------------------------------------ Layer 4
-;; Command implementations
+;------------------------------------------------------------------------------ Layer 2
 
-(defn etl-repo-cmd
+(defn- ^{:stratum 2} resolve-pack-paths
+  "Given the positional arg to `etl run` / `etl validate` and the `--env`
+   flag, return `[pipeline-path env-path]` as absolute file paths, or
+   throw ex-info on an unresolvable input.
+
+   - If `pack-or-pipeline` is a directory, look for one `pipelines/*.edn`.
+   - If it's an .edn file, use it as the pipeline.
+   - `env` may be a path or a bare env name that resolves to
+     `<pack>/envs/<name>.edn` when pack-or-pipeline is a directory."
+  [pack-or-pipeline env]
+  (let [[pack-dir pipeline-path] (resolve-pipeline-path pack-or-pipeline)
+        env-path                 (resolve-env-path env pack-dir)]
+    [pipeline-path env-path]))
+
+;; Command implementations
+(defn ^{:stratum 2} etl-repo-cmd
   "Run the ETL pipeline against a git repository URL.
 
    Clones the repository, extracts structured metadata (languages, packs,
@@ -234,7 +229,26 @@
             (when (pos? exit-code)
               (shared/exit! exit-code))))))))
 
-(defn etl-run-cmd
+(defn ^{:stratum 2} etl-list-cmd
+  "List pipeline EDN files discovered under a search path.
+
+   Usage: miniforge etl list [<search-path>]
+          (defaults to `.`)"
+  [opts]
+  (let [path (get opts :paths ".")]
+    (shared/exit! (shell-etl! ["list" path]))))
+
+(defn ^{:stratum 2} etl-registry-cmd
+  "Export the product-owned ETL state-variable registry as EDN or JSON."
+  [opts]
+  (if-let [out (:out opts)]
+    (shared/exit! (shell-etl! ["registry" "--out" out]))
+    (shared/usage-error! :etl/registry-usage
+                         "etl registry --out <registry.edn|.json>")))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} etl-run-cmd
   "Execute a Data Foundry ETL pack.
 
    Usage:
@@ -271,16 +285,7 @@
           (display/print-error (ex-message e))
           (shared/exit! 1))))))
 
-(defn etl-list-cmd
-  "List pipeline EDN files discovered under a search path.
-
-   Usage: miniforge etl list [<search-path>]
-          (defaults to `.`)"
-  [opts]
-  (let [path (get opts :paths ".")]
-    (shared/exit! (shell-etl! ["list" path]))))
-
-(defn etl-validate-cmd
+(defn ^{:stratum 3} etl-validate-cmd
   "Load + resolve a pack without executing. Surfaces loader, env, or
    resolver errors.
 
@@ -296,14 +301,6 @@
         (catch clojure.lang.ExceptionInfo e
           (display/print-error (ex-message e))
           (shared/exit! 1))))))
-
-(defn etl-registry-cmd
-  "Export the product-owned ETL state-variable registry as EDN or JSON."
-  [opts]
-  (if-let [out (:out opts)]
-    (shared/exit! (shell-etl! ["registry" "--out" out]))
-    (shared/usage-error! :etl/registry-usage
-                         "etl registry --out <registry.edn|.json>")))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/bases/cli/src/ai/miniforge/cli/main/commands/events.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/events.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.main.commands.events
   "CLI `events show <workflow-id>` subcommand.
 
@@ -42,24 +41,24 @@
    [ai.miniforge.event-stream.interface :as es]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Constants
 
-(def ^:private default-gap-threshold-secs
+;; Constants
+(def ^{:stratum 0} ^:private default-gap-threshold-secs
   "Gap detection threshold in seconds used when --gap-threshold is absent."
   60)
 
 ;------------------------------------------------------------------------------ Layer 1
-;; Pure helpers
 
-(defn- gap-threshold-ms
+;; Pure helpers
+(defn- ^{:stratum 1} gap-threshold-ms
   "Convert a seconds threshold to milliseconds, falling back to the default."
   [threshold-secs]
   (* (or threshold-secs default-gap-threshold-secs) 1000))
 
 ;------------------------------------------------------------------------------ Layer 2
-;; Core (testable) implementation
 
-(defn events-show
+;; Core (testable) implementation
+(defn ^{:stratum 2} events-show
   "Read and render the event log for `workflow-id` under `base-dir`.
 
    Arguments:
@@ -114,9 +113,9 @@
        :exit-code 1})))
 
 ;------------------------------------------------------------------------------ Layer 3
-;; CLI command entry point
 
-(defn events-show-cmd
+;; CLI command entry point
+(defn ^{:stratum 3} events-show-cmd
   "CLI handler for `miniforge events show <workflow-id>`.
 
    Accepted opts (injected by babashka.cli dispatch):

--- a/bases/cli/src/ai/miniforge/cli/main/commands/evidence.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/evidence.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.main.commands.evidence
   "Evidence bundle commands: show, export, list.
 
@@ -32,20 +31,12 @@
    [ai.miniforge.cli.messages :as messages]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Helpers
 
-(defn- evidence-dir []
+;; Helpers
+(defn- ^{:stratum 0} evidence-dir []
   (str (app-config/home-dir) "/evidence"))
 
-(defn- scan-evidence-dir []
-  (let [dir (io/file (evidence-dir))]
-    (when (.exists dir)
-      (->> (.listFiles dir)
-           (filter #(.isFile %))
-           (sort-by #(.lastModified %) >)
-           vec))))
-
-(defn load-bundle-from-file
+(defn ^{:stratum 0} load-bundle-from-file
   "Load an evidence bundle from an EDN file. Returns nil on failure."
   [file]
   (try
@@ -53,10 +44,8 @@
       (edn/read-string (slurp file)))
     (catch Exception _ nil)))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Display helpers
-
-(def ^:private bundle-detail-spec
+(def ^{:stratum 0} ^:private bundle-detail-spec
   {:header   :evidence/show-header
    :fields   [[:bundle/workflow-id :evidence/show-workflow {:default "—"}]
               [:bundle/status      :evidence/show-status   {:default "unknown"}]
@@ -69,7 +58,7 @@
                                    :id   (get a :artifact/id "")})}
               {:key :bundle/phases :header :evidence/show-phases}]})
 
-(def ^:private phase-evidence-keys
+(def ^{:stratum 0} ^:private phase-evidence-keys
   [:evidence/plan
    :evidence/design
    :evidence/implement
@@ -78,12 +67,12 @@
    :evidence/release
    :evidence/observe])
 
-(defn- active-dependency?
+(defn- ^{:stratum 0} active-dependency?
   [dependency]
   (contains? #{:degraded :unavailable :misconfigured :operator-action-required}
              (:dependency/status dependency)))
 
-(defn- label
+(defn- ^{:stratum 0} label
   [value]
   (cond
     (keyword? value) (name value)
@@ -91,14 +80,36 @@
     (nil? value) "unknown"
     :else (str value)))
 
-(defn- dependency-issue-count
+;; Command implementations
+(defn- ^{:stratum 0} display-component-bundles
+  "Render bundles returned from the evidence-bundle component interface."
+  [bundles]
+  (if (seq bundles)
+    (doseq [bundle bundles]
+      (println (messages/t :evidence/bundle-entry
+                          {:id          (display/style (get bundle :bundle/id "unknown") :foreground :bold)
+                           :workflow-id (get bundle :bundle/workflow-id "—")
+                           :status      (get bundle :bundle/status "unknown")})))
+    (println (messages/t :evidence/none))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} scan-evidence-dir []
+  (let [dir (io/file (evidence-dir))]
+    (when (.exists dir)
+      (->> (.listFiles dir)
+           (filter #(.isFile %))
+           (sort-by #(.lastModified %) >)
+           vec))))
+
+(defn- ^{:stratum 1} dependency-issue-count
   [dependency-health]
   (->> dependency-health
        vals
        (filter active-dependency?)
        count))
 
-(defn- failure-attribution-summary
+(defn- ^{:stratum 1} failure-attribution-summary
   [failure-attribution]
   (when (seq failure-attribution)
     (let [source (or (:failure/source failure-attribution)
@@ -112,13 +123,33 @@
                             :unknown)]
       (str (label source) " / " (label vendor) " / " (label failure-class)))))
 
-(defn- canonical-phase-names
+(defn- ^{:stratum 1} canonical-phase-names
   [bundle]
   (->> phase-evidence-keys
        (filter #(contains? bundle %))
        (mapv (comp keyword name))))
 
-(defn- normalize-bundle-detail
+(defn- ^{:stratum 1} load-bundle-for-show
+  "Load a bundle from the component interface or the filesystem."
+  [id]
+  (or (shared/call-optional-provider 'ai.miniforge.evidence-bundle.interface/get-bundle id)
+      (let [f (io/file (str (evidence-dir) "/" id ".edn"))]
+        (when (.exists f) (load-bundle-from-file f)))))
+
+(defn- ^{:stratum 1} export-bundle-fallback
+  "Copy the raw EDN bundle file as-is when the export component is unavailable."
+  [id fmt]
+  (let [src (io/file (str (evidence-dir) "/" id ".edn"))]
+    (if (.exists src)
+      (let [dest (str (evidence-dir) "/" id "-export." fmt)]
+        (fs/copy (str src) dest {:replace-existing true})
+        (display/print-success (messages/t :evidence/export-raw {:path dest})))
+      (do (display/print-error (messages/t :evidence/export-not-found {:id id}))
+          (shared/exit! 1)))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- ^{:stratum 2} normalize-bundle-detail
   [bundle]
   (let [dependency-health (or (:evidence/dependency-health bundle) {})
         artifacts (or (:bundle/artifacts bundle) [])
@@ -139,34 +170,7 @@
      :bundle/failure-attribution (failure-attribution-summary
                                   (:evidence/failure-attribution bundle))}))
 
-(defn- display-bundle-detail
-  "Render the detail view for a single evidence bundle."
-  [id bundle]
-  (display/render-detail (assoc bundle-detail-spec :header-params {:id id})
-                         (normalize-bundle-detail bundle)))
-
-(defn- load-bundle-for-show
-  "Load a bundle from the component interface or the filesystem."
-  [id]
-  (or (shared/call-optional-provider 'ai.miniforge.evidence-bundle.interface/get-bundle id)
-      (let [f (io/file (str (evidence-dir) "/" id ".edn"))]
-        (when (.exists f) (load-bundle-from-file f)))))
-
-;------------------------------------------------------------------------------ Layer 2
-;; Command implementations
-
-(defn- display-component-bundles
-  "Render bundles returned from the evidence-bundle component interface."
-  [bundles]
-  (if (seq bundles)
-    (doseq [bundle bundles]
-      (println (messages/t :evidence/bundle-entry
-                          {:id          (display/style (get bundle :bundle/id "unknown") :foreground :bold)
-                           :workflow-id (get bundle :bundle/workflow-id "—")
-                           :status      (get bundle :bundle/status "unknown")})))
-    (println (messages/t :evidence/none))))
-
-(defn- display-filesystem-bundles
+(defn- ^{:stratum 2} display-filesystem-bundles
   "Render bundles discovered via filesystem scan."
   []
   (let [files (scan-evidence-dir)]
@@ -188,49 +192,7 @@
         (println (messages/t :evidence/none))
         (println (messages/t :evidence/evidence-dir {:dir (evidence-dir)}))))))
 
-(defn evidence-list-cmd
-  "List all available evidence bundles.
-
-   Shows bundles from the evidence-bundle component if available,
-   otherwise scans ~/.miniforge/evidence/."
-  [_opts]
-  (println)
-  (println (display/style (messages/t :evidence/header) :foreground :cyan :bold true))
-  (println)
-  (let [component-result (shared/call-optional-provider
-                          'ai.miniforge.evidence-bundle.interface/list-bundles)]
-    (if component-result
-      (display-component-bundles component-result)
-      (display-filesystem-bundles)))
-  (println))
-
-(defn evidence-show-cmd
-  "Show the contents of an evidence bundle by ID."
-  [opts]
-  (let [{:keys [id]} opts]
-    (if-not id
-      (shared/usage-error! :evidence/show-usage "evidence show <id>")
-      (let [bundle (load-bundle-for-show id)]
-        (if-not bundle
-          (do (display/print-error
-               (messages/t :evidence/not-found
-                          {:id id
-                           :command (app-config/command-string "evidence list")}))
-              (shared/exit! 1))
-          (display-bundle-detail id bundle))))))
-
-(defn- export-bundle-fallback
-  "Copy the raw EDN bundle file as-is when the export component is unavailable."
-  [id fmt]
-  (let [src (io/file (str (evidence-dir) "/" id ".edn"))]
-    (if (.exists src)
-      (let [dest (str (evidence-dir) "/" id "-export." fmt)]
-        (fs/copy (str src) dest {:replace-existing true})
-        (display/print-success (messages/t :evidence/export-raw {:path dest})))
-      (do (display/print-error (messages/t :evidence/export-not-found {:id id}))
-          (shared/exit! 1)))))
-
-(defn evidence-export-cmd
+(defn ^{:stratum 2} evidence-export-cmd
   "Export an evidence bundle to a file in the requested format.
 
    Supported formats: edn (default), json, html."
@@ -248,6 +210,47 @@
             (when-let [path (:path result)]
               (println (messages/t :evidence/export-path {:path path}))))
           (export-bundle-fallback id fmt))))))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn- ^{:stratum 3} display-bundle-detail
+  "Render the detail view for a single evidence bundle."
+  [id bundle]
+  (display/render-detail (assoc bundle-detail-spec :header-params {:id id})
+                         (normalize-bundle-detail bundle)))
+
+(defn ^{:stratum 3} evidence-list-cmd
+  "List all available evidence bundles.
+
+   Shows bundles from the evidence-bundle component if available,
+   otherwise scans ~/.miniforge/evidence/."
+  [_opts]
+  (println)
+  (println (display/style (messages/t :evidence/header) :foreground :cyan :bold true))
+  (println)
+  (let [component-result (shared/call-optional-provider
+                          'ai.miniforge.evidence-bundle.interface/list-bundles)]
+    (if component-result
+      (display-component-bundles component-result)
+      (display-filesystem-bundles)))
+  (println))
+
+;------------------------------------------------------------------------------ Layer 4
+
+(defn ^{:stratum 4} evidence-show-cmd
+  "Show the contents of an evidence bundle by ID."
+  [opts]
+  (let [{:keys [id]} opts]
+    (if-not id
+      (shared/usage-error! :evidence/show-usage "evidence show <id>")
+      (let [bundle (load-bundle-for-show id)]
+        (if-not bundle
+          (do (display/print-error
+               (messages/t :evidence/not-found
+                          {:id id
+                           :command (app-config/command-string "evidence list")}))
+              (shared/exit! 1))
+          (display-bundle-detail id bundle))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/bases/cli/src/ai/miniforge/cli/main/commands/fleet.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/fleet.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.main.commands.fleet
   "Fleet management commands."
   (:require
@@ -29,9 +28,9 @@
    [ai.miniforge.cli.main.display :as display]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Config helpers
 
-(defn load-config
+;; Config helpers
+(defn ^{:stratum 0} load-config
   "Load configuration from file, merging with defaults."
   [path default-config-path default-config]
   (let [config-path (or path default-config-path)]
@@ -39,27 +38,25 @@
       (merge-with merge default-config (edn/read-string (slurp config-path)))
       default-config)))
 
-(defn save-config
+(defn ^{:stratum 0} save-config
   "Save configuration to file."
   [config path default-config-path]
   (let [config-path (or path default-config-path)]
     (fs/create-dirs (fs/parent config-path))
     (spit config-path (pr-str config))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Fleet commands
-
-(defn fleet-start-cmd
+(defn ^{:stratum 0} fleet-start-cmd
   [_opts]
   (display/print-info (messages/t :fleet/starting-daemon))
   (println (messages/t :fleet/daemon-todo)))
 
-(defn fleet-stop-cmd
+(defn ^{:stratum 0} fleet-stop-cmd
   [_opts]
   (display/print-info (messages/t :fleet/stopping-daemon))
   (println (messages/t :fleet/daemon-todo)))
 
-(def ^:private fleet-status-spec
+(def ^{:stratum 0} ^:private fleet-status-spec
   {:header :fleet/status-header
    :fields [[:fleet/repositories     :fleet/repositories      {:param :count}]
             [:fleet/active-workflows :fleet/active-workflows  {:param :count}]
@@ -67,48 +64,8 @@
             [:fleet/completed        :fleet/completed          {:param :count}]
             [:fleet/failed           :fleet/failed             {:param :count}]]})
 
-(defn fleet-status-cmd
-  [opts default-config-path default-config]
-  (let [config (load-config (:config opts) default-config-path default-config)
-        repos (get-in config [:fleet :repos] [])
-        state-file (app-config/state-file)
-        state (if (fs/exists? state-file)
-                (edn/read-string (slurp state-file))
-                {:workflows {:active 0 :pending 0 :completed 0 :failed 0}})]
-    (display/render-detail
-     fleet-status-spec
-     {:fleet/repositories     (count repos)
-      :fleet/active-workflows (get-in state [:workflows :active] 0)
-      :fleet/pending-workflows (get-in state [:workflows :pending] 0)
-      :fleet/completed        (get-in state [:workflows :completed] 0)
-      :fleet/failed           (get-in state [:workflows :failed] 0)})))
-
-(defn fleet-add-cmd
-  [opts default-config-path default-config]
-  (let [{:keys [repo config]} opts]
-    (if-not repo
-      (display/print-error (messages/t :fleet/add-usage {:command (app-config/command-string "fleet add <repo>")}))
-      (let [cfg (load-config config default-config-path default-config)
-            repos (get-in cfg [:fleet :repos] [])
-            new-cfg (assoc-in cfg [:fleet :repos] (conj repos repo))]
-        (save-config new-cfg config default-config-path)
-        (display/print-success (messages/t :fleet/added {:repo repo}))))))
-
-(defn fleet-remove-cmd
-  [opts default-config-path default-config]
-  (let [{:keys [repo config]} opts]
-    (if-not repo
-      (display/print-error (messages/t :fleet/remove-usage {:command (app-config/command-string "fleet remove <repo>")}))
-      (let [cfg (load-config config default-config-path default-config)
-            repos (get-in cfg [:fleet :repos] [])
-            new-cfg (assoc-in cfg [:fleet :repos] (vec (remove #{repo} repos)))]
-        (save-config new-cfg config default-config-path)
-        (display/print-success (messages/t :fleet/removed {:repo repo}))))))
-
-;------------------------------------------------------------------------------ Layer 2
 ;; fleet watch — TUI fleet monitor
-
-(defn fleet-watch-cmd
+(defn ^{:stratum 0} fleet-watch-cmd
   "Launch the TUI fleet monitor.
 
    Opens the two-pane fleet dashboard showing repos, PRs, and live
@@ -138,10 +95,8 @@
                             {:command (app-config/command-string "web")}))
         (shared/exit! 1)))))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; fleet prs — PRs across fleet
-
-(defn- fetch-prs-for-repo [repo]
+(defn- ^{:stratum 0} fetch-prs-for-repo [repo]
   (let [result (process/sh "gh" "pr" "list" "--repo" repo
                             "--json" "number,title,state,author,createdAt,additions,deletions,changedFiles"
                             "--limit" (str shared/max-prs-per-repo))]
@@ -149,7 +104,7 @@
       (try (json/parse-string (:out result) true)
            (catch Exception _ [])))))
 
-(defn- pr-risk-level
+(defn- ^{:stratum 0} pr-risk-level
   "Classify PR risk from total changed lines and changed file count."
   [total-lines changed-files]
   (cond
@@ -159,7 +114,47 @@
         (> changed-files shared/pr-risk-files-medium)) :medium
     :else                                               :low))
 
-(defn- display-pr-row
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} fleet-status-cmd
+  [opts default-config-path default-config]
+  (let [config (load-config (:config opts) default-config-path default-config)
+        repos (get-in config [:fleet :repos] [])
+        state-file (app-config/state-file)
+        state (if (fs/exists? state-file)
+                (edn/read-string (slurp state-file))
+                {:workflows {:active 0 :pending 0 :completed 0 :failed 0}})]
+    (display/render-detail
+     fleet-status-spec
+     {:fleet/repositories     (count repos)
+      :fleet/active-workflows (get-in state [:workflows :active] 0)
+      :fleet/pending-workflows (get-in state [:workflows :pending] 0)
+      :fleet/completed        (get-in state [:workflows :completed] 0)
+      :fleet/failed           (get-in state [:workflows :failed] 0)})))
+
+(defn ^{:stratum 1} fleet-add-cmd
+  [opts default-config-path default-config]
+  (let [{:keys [repo config]} opts]
+    (if-not repo
+      (display/print-error (messages/t :fleet/add-usage {:command (app-config/command-string "fleet add <repo>")}))
+      (let [cfg (load-config config default-config-path default-config)
+            repos (get-in cfg [:fleet :repos] [])
+            new-cfg (assoc-in cfg [:fleet :repos] (conj repos repo))]
+        (save-config new-cfg config default-config-path)
+        (display/print-success (messages/t :fleet/added {:repo repo}))))))
+
+(defn ^{:stratum 1} fleet-remove-cmd
+  [opts default-config-path default-config]
+  (let [{:keys [repo config]} opts]
+    (if-not repo
+      (display/print-error (messages/t :fleet/remove-usage {:command (app-config/command-string "fleet remove <repo>")}))
+      (let [cfg (load-config config default-config-path default-config)
+            repos (get-in cfg [:fleet :repos] [])
+            new-cfg (assoc-in cfg [:fleet :repos] (vec (remove #{repo} repos)))]
+        (save-config new-cfg config default-config-path)
+        (display/print-success (messages/t :fleet/removed {:repo repo}))))))
+
+(defn- ^{:stratum 1} display-pr-row
   "Print a single PR row with risk annotation."
   [{:keys [number title author additions deletions changedFiles]}]
   (let [total       (+ (or additions 0) (or deletions 0))
@@ -180,7 +175,9 @@
                   " " short-title
                   "  (" (get author :login "?") ")"))))
 
-(defn fleet-prs-cmd
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} fleet-prs-cmd
   "List open PRs across all fleet-configured repositories.
 
    Equivalent to running `pr list` for every repo in [:fleet :repos].

--- a/bases/cli/src/ai/miniforge/cli/main/commands/init.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/init.clj
@@ -1,7 +1,6 @@
 ;; Title: Miniforge.ai
 ;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
 ;; Licensed under the Apache License, Version 2.0
-
 (ns ai.miniforge.cli.main.commands.init
   "Init command — analyze a repository and write .miniforge/config.edn.
 
@@ -18,12 +17,13 @@
    [clojure.pprint :as pprint]))
 
 ;------------------------------------------------------------------------------ Layer 0
+
 ;; Pure data + helpers with no in-namespace dependencies.
+(def ^{:stratum 0} ^:private config-dir ".miniforge")
 
-(def ^:private config-dir ".miniforge")
-(def ^:private config-file "config.edn")
+(def ^{:stratum 0} ^:private config-file "config.edn")
 
-(defn- format-config
+(defn- ^{:stratum 0} format-config
   "Format a repo config map as pretty-printed EDN with a header comment."
   [config]
   (str ";; Miniforge repository configuration\n"
@@ -31,7 +31,7 @@
        ";; See: work/repo-config-profile.spec.edn\n\n"
        (with-out-str (pprint/pprint config))))
 
-(defn- build-config
+(defn- ^{:stratum 0} build-config
   "Build the .miniforge/config.edn map from analysis results."
   [analysis]
   (cond-> {:repo/technologies (:technologies analysis)
@@ -39,7 +39,7 @@
     (:git-host analysis)
     (assoc :repo/host (:git-host analysis))))
 
-(defn- print-analysis
+(defn- ^{:stratum 0} print-analysis
   "Print the analysis results to the user."
   [analysis]
   (display/print-info (messages/t :init/analysis-technologies
@@ -51,14 +51,14 @@
                                   {:value (pr-str (:packs analysis))})))
 
 ;------------------------------------------------------------------------------ Layer 1
-;; Composes Layer 0 path constants.
 
-(def ^:private config-path (str config-dir "/" config-file))
+;; Composes Layer 0 path constants.
+(def ^{:stratum 1} ^:private config-path (str config-dir "/" config-file))
 
 ;------------------------------------------------------------------------------ Layer 2
-;; Composes Layer 1.
 
-(defn- write-config!
+;; Composes Layer 1.
+(defn- ^{:stratum 2} write-config!
   "Write the config file. Returns the path written."
   [repo-path config]
   (let [dir  (fs/path repo-path config-dir)
@@ -68,9 +68,9 @@
     (str path)))
 
 ;------------------------------------------------------------------------------ Layer 3
-;; Command entry point
 
-(defn init-cmd
+;; Command entry point
+(defn ^{:stratum 3} init-cmd
   "CLI entry point for the init command."
   [opts]
   (let [repo-path (get opts :repo (str (fs/cwd)))]

--- a/bases/cli/src/ai/miniforge/cli/main/commands/monitoring.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/monitoring.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.main.commands.monitoring
   "Web dashboard and TUI monitoring commands."
   (:require
@@ -26,20 +25,29 @@
    [ai.miniforge.cli.main.display :as display]
    [ai.miniforge.cli.messages :as messages]))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Web dashboard command
+;------------------------------------------------------------------------------ Layer 0
 
-(defn exit!
+;; Web dashboard command
+(defn ^{:stratum 0} exit!
   [code]
   (System/exit code))
 
-(def ^:dynamic *web-available?* false)
+(def ^{:stratum 0} ^:dynamic *web-available?* false)
 
-(def ^:dynamic *start-web-dashboard!*
+(def ^{:stratum 0} ^:dynamic *start-web-dashboard!*
   "Injected JVM dashboard launcher. Nil when the dashboard component is not on the classpath."
   nil)
 
-(defn web-cmd
+;; TUI availability and launcher are composed by the parent CLI namespace.
+(def ^{:stratum 0} ^:dynamic *tui-available?* false)
+
+(def ^{:stratum 0} ^:dynamic *start-standalone-tui!*
+  "Injected JVM TUI launcher. Nil when the TUI component is not on the classpath."
+  nil)
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} web-cmd
   "Start web dashboard for workflow monitoring."
   [opts]
   (let [{:keys [port open]} opts
@@ -89,14 +97,7 @@
                                            {:error (ex-message e)}))
           (exit! 1))))))
 
-;; TUI availability and launcher are composed by the parent CLI namespace.
-(def ^:dynamic *tui-available?* false)
-
-(def ^:dynamic *start-standalone-tui!*
-  "Injected JVM TUI launcher. Nil when the TUI component is not on the classpath."
-  nil)
-
-(defn tui-cmd
+(defn ^{:stratum 1} tui-cmd
   "Start terminal UI for workflow monitoring.
    Launches standalone TUI that tail-follows app event files."
   [opts]

--- a/bases/cli/src/ai/miniforge/cli/main/commands/plan_executor.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/plan_executor.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.main.commands.plan-executor
   "Execute pre-planned DAG or plan files directly, skipping explore/plan phases."
   (:require
@@ -30,14 +29,34 @@
    [java.util UUID]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Format normalization
 
-(defn deterministic-uuid
+;; Format normalization
+(defn ^{:stratum 0} deterministic-uuid
   "Generate a deterministic UUID from a string id (for DAG task-id → UUID conversion)."
   [s]
   (UUID/nameUUIDFromBytes (.getBytes (str s) "UTF-8")))
 
-(defn normalize-dag-task
+(defn ^{:stratum 0} detect-plan-format
+  "Detect whether input is already plan format or needs conversion."
+  [parsed]
+  (cond
+    (:plan/id parsed) :plan
+    (:dag-id parsed)  :dag
+    :else             nil))
+
+;; Execution context setup
+(defn ^{:stratum 0} build-execution-workflow
+  "Build a workflow definition for plan execution (implement → verify → done)."
+  [plan-id]
+  {:workflow/id (keyword (str "plan-exec-" plan-id))
+   :workflow/version "2.0.0"
+   :workflow/name (str "Plan execution: " plan-id)
+   :workflow/pipeline [{:phase :implement} {:phase :verify} {:phase :done}]
+   :workflow/config {:max-tokens 20000 :max-iterations 50}})
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} normalize-dag-task
   "Normalize a DAG-format task to plan-format task."
   [task]
   (let [task-id (if (uuid? (:task/id task))
@@ -60,37 +79,19 @@
      :task/acceptance-criteria criteria
      :task/type (:task/type task :implement)}))
 
-(defn normalize-dag-to-plan
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} normalize-dag-to-plan
   "Convert DAG format ({:dag-id, :tasks}) to plan format ({:plan/id, :plan/tasks})."
   [dag]
   {:plan/id (:dag-id dag)
    :plan/title (or (:description dag) (:dag-id dag))
    :plan/tasks (mapv normalize-dag-task (:tasks dag))})
 
-(defn detect-plan-format
-  "Detect whether input is already plan format or needs conversion."
-  [parsed]
-  (cond
-    (:plan/id parsed) :plan
-    (:dag-id parsed)  :dag
-    :else             nil))
+;------------------------------------------------------------------------------ Layer 3
 
-;------------------------------------------------------------------------------ Layer 1
-;; Execution context setup
-
-(defn build-execution-workflow
-  "Build a workflow definition for plan execution (implement → verify → done)."
-  [plan-id]
-  {:workflow/id (keyword (str "plan-exec-" plan-id))
-   :workflow/version "2.0.0"
-   :workflow/name (str "Plan execution: " plan-id)
-   :workflow/pipeline [{:phase :implement} {:phase :verify} {:phase :done}]
-   :workflow/config {:max-tokens 20000 :max-iterations 50}})
-
-;------------------------------------------------------------------------------ Layer 2
 ;; Public API
-
-(defn execute-plan
+(defn ^{:stratum 3} execute-plan
   "Execute a pre-planned DAG or plan file directly via dag-orchestrator.
 
    Normalizes DAG format to plan format if needed, sets up execution context,

--- a/bases/cli/src/ai/miniforge/cli/main/commands/policy.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/policy.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.main.commands.policy
   "Policy pack commands: list, show, install.
 
@@ -33,23 +32,30 @@
    [ai.miniforge.cli.messages :as messages]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Helpers
 
-(defn- packs-dir []
+;; Helpers
+(defn- ^{:stratum 0} packs-dir []
   (str (app-config/home-dir) "/packs"))
 
-(defn- load-pack-from-resource [pack-id]
+(defn- ^{:stratum 0} load-pack-from-resource [pack-id]
   (let [resource-path (str "policy_pack/packs/" pack-id ".pack.edn")]
     (when-let [url (io/resource resource-path)]
       (try (edn/read-string (slurp url))
            (catch Exception _ nil)))))
 
-(defn- load-pack-from-path [pack-path]
+(defn- ^{:stratum 0} load-pack-from-path [pack-path]
   (when (fs/exists? pack-path)
     (try (edn/read-string (slurp (str pack-path)))
          (catch Exception _ nil))))
 
-(defn- installed-pack-files []
+(defn- ^{:stratum 0} builtin-pack-ids
+  "Known built-in pack IDs to probe on the classpath."
+  []
+  ["foundations-1.0.0" "miniforge-standards"])
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} installed-pack-files []
   (let [dir (io/file (packs-dir))]
     (if (.exists dir)
       (->> (.listFiles dir)
@@ -58,27 +64,53 @@
            vec)
       [])))
 
-(defn- builtin-pack-ids
-  "Known built-in pack IDs to probe on the classpath."
-  []
-  ["foundations-1.0.0" "miniforge-standards"])
-
-(defn- component-packs []
+(defn- ^{:stratum 1} component-packs []
   (try
     (:loaded (policy-pack/load-all-packs (packs-dir)))
     (catch Exception _ nil)))
 
-(defn- load-installed-pack [pack-id]
+(defn- ^{:stratum 1} load-installed-pack [pack-id]
   (let [result (try
                  (policy-pack/load-pack (str (packs-dir) "/" pack-id ".pack.edn"))
                  (catch Exception _ nil))]
     (when (:success? result)
       (:pack result))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Command implementations
+(defn ^{:stratum 1} policy-install-cmd
+  "Install a policy pack from a local .pack.edn file.
 
-(defn policy-list-cmd
+   Copies the pack into ~/.miniforge/packs/ so it is picked up
+   by `scan` and `policy list`."
+  [opts]
+  (let [{:keys [path]} opts]
+    (if-not path
+      (shared/usage-error! :policy/install-usage "policy install <path>")
+      (if-not (fs/exists? path)
+        (do (display/print-error (messages/t :policy/install-not-found {:path path}))
+            (shared/exit! 1))
+        (let [pack (try (edn/read-string (slurp (str path)))
+                        (catch Exception _e nil))]
+          (if-not pack
+            (do (display/print-error (messages/t :policy/install-invalid {:path path}))
+                (shared/exit! 1))
+            (let [dest-dir  (packs-dir)
+                  file-name (fs/file-name path)
+                  ;; Ensure .pack.edn suffix
+                  dest-name (if (str/ends-with? (str file-name) ".pack.edn")
+                              (str file-name)
+                              (str file-name ".pack.edn"))
+                  dest-path (str dest-dir "/" dest-name)]
+              (fs/create-dirs dest-dir)
+              (fs/copy path dest-path {:replace-existing true})
+              (display/print-success (messages/t :policy/install-success {:name dest-name}))
+              (println (messages/t :policy/install-location {:path dest-path}))
+              (when-let [id (:pack/id pack)]
+                (println (messages/t :policy/install-pack-id {:id id}))))))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Command implementations
+(defn ^{:stratum 2} policy-list-cmd
   "List all available policy packs.
 
    Shows installed packs from ~/.miniforge/packs/ and built-in classpath packs."
@@ -121,7 +153,7 @@
               (println (messages/t :policy/builtin-entry {:id id}))))))))
   (println))
 
-(defn policy-show-cmd
+(defn ^{:stratum 2} policy-show-cmd
   "Show rules and metadata for a policy pack.
 
    Checks installed packs, then classpath resources."
@@ -159,37 +191,6 @@
                                                 :foreground :yellow))
                                 (when desc (str "\n    " desc)))))))
             (println)))))))
-
-(defn policy-install-cmd
-  "Install a policy pack from a local .pack.edn file.
-
-   Copies the pack into ~/.miniforge/packs/ so it is picked up
-   by `scan` and `policy list`."
-  [opts]
-  (let [{:keys [path]} opts]
-    (if-not path
-      (shared/usage-error! :policy/install-usage "policy install <path>")
-      (if-not (fs/exists? path)
-        (do (display/print-error (messages/t :policy/install-not-found {:path path}))
-            (shared/exit! 1))
-        (let [pack (try (edn/read-string (slurp (str path)))
-                        (catch Exception _e nil))]
-          (if-not pack
-            (do (display/print-error (messages/t :policy/install-invalid {:path path}))
-                (shared/exit! 1))
-            (let [dest-dir  (packs-dir)
-                  file-name (fs/file-name path)
-                  ;; Ensure .pack.edn suffix
-                  dest-name (if (str/ends-with? (str file-name) ".pack.edn")
-                              (str file-name)
-                              (str file-name ".pack.edn"))
-                  dest-path (str dest-dir "/" dest-name)]
-              (fs/create-dirs dest-dir)
-              (fs/copy path dest-path {:replace-existing true})
-              (display/print-success (messages/t :policy/install-success {:name dest-name}))
-              (println (messages/t :policy/install-location {:path dest-path}))
-              (when-let [id (:pack/id pack)]
-                (println (messages/t :policy/install-pack-id {:id id}))))))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/bases/cli/src/ai/miniforge/cli/main/commands/pr.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/pr.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.main.commands.pr
   "PR operations using GitHub CLI."
   (:require
@@ -33,23 +32,13 @@
    [ai.miniforge.pr-lifecycle.interface :as pr-lifecycle]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Shell helpers
 
-(defn- sh! [& args]
+;; Shell helpers
+(defn- ^{:stratum 0} sh! [& args]
   (apply process/sh args))
 
-(defn- checkout-pr! [pr-number]
-  (let [r (sh! "gh" "pr" "checkout" (str pr-number))]
-    (when (zero? (:exit r))
-      (str/trim (:out (sh! "git" "branch" "--show-current"))))))
-
-(defn- push! []
-  (zero? (:exit (sh! "git" "push"))))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; PR commands
-
-(defn pr-list-cmd
+(defn ^{:stratum 0} pr-list-cmd
   "List PRs using GitHub CLI."
   [opts load-config-fn]
   (let [{:keys [repo config]} opts
@@ -91,7 +80,34 @@
                     (display/print-error (messages/t :pr/list-failed {:error (:err result2)}))))))
             (display/print-error (messages/t :pr/query-failed {:error (:err result)}))))))))
 
-(defn- gh-pr-base-ref
+(defn ^{:stratum 0} pr-merge-cmd
+  [opts]
+  (let [{:keys [url]} opts]
+    (if-not url
+      (display/print-error (messages/t :pr/merge-usage {:command (app-config/command-string "pr merge <pr-url>")}))
+      (do
+        (display/print-info (messages/t :pr/merging {:url url}))
+        (println (messages/t :pr/merge-todo))))))
+
+;; PR Monitor (continuous loop)
+(defn ^{:stratum 0} pr-monitor-cmd
+  "Delegates to pr-monitor/pr-monitor-cmd, which supports both a fresh
+   `--author` start and resuming from the persisted work-list (written by
+   the observe phase). See that namespace for full docs."
+  [opts]
+  (pr-monitor/pr-monitor-cmd opts))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} checkout-pr! [pr-number]
+  (let [r (sh! "gh" "pr" "checkout" (str pr-number))]
+    (when (zero? (:exit r))
+      (str/trim (:out (sh! "git" "branch" "--show-current"))))))
+
+(defn- ^{:stratum 1} push! []
+  (zero? (:exit (sh! "git" "push"))))
+
+(defn- ^{:stratum 1} gh-pr-base-ref
   "Resolve the base-branch ref for `pr-number` via the GitHub CLI.
    Returns a remote-prefixed ref like \"origin/main\", or nil on failure."
   [pr-number]
@@ -102,7 +118,9 @@
         (when (seq base-name)
           (str "origin/" base-name))))))
 
-(defn pr-review-cmd
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} pr-review-cmd
   "N13 §2.2 Standards Reviewer entry point.
 
    Checks out the given PR URL, derives the base ref, and runs the
@@ -163,7 +181,7 @@
        (messages/t :pr/review-usage
                    {:command (app-config/command-string "pr review <pr-url>")})))))
 
-(defn pr-respond-cmd
+(defn ^{:stratum 2} pr-respond-cmd
   [opts]
   (let [{:keys [url]} opts]
     (if-not url
@@ -197,22 +215,3 @@
                             :pushed   (if (:pushed? result)
                                         (messages/t :pr/respond-pushed)
                                         "")})))))))))
-
-(defn pr-merge-cmd
-  [opts]
-  (let [{:keys [url]} opts]
-    (if-not url
-      (display/print-error (messages/t :pr/merge-usage {:command (app-config/command-string "pr merge <pr-url>")}))
-      (do
-        (display/print-info (messages/t :pr/merging {:url url}))
-        (println (messages/t :pr/merge-todo))))))
-
-;------------------------------------------------------------------------------ Layer 1
-;; PR Monitor (continuous loop)
-
-(defn pr-monitor-cmd
-  "Delegates to pr-monitor/pr-monitor-cmd, which supports both a fresh
-   `--author` start and resuming from the persisted work-list (written by
-   the observe phase). See that namespace for full docs."
-  [opts]
-  (pr-monitor/pr-monitor-cmd opts))

--- a/bases/cli/src/ai/miniforge/cli/main/commands/pr_monitor.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/pr_monitor.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.main.commands.pr-monitor
   "PR monitor loop — work-list resume and fresh-monitor paths.
 
@@ -35,30 +34,32 @@
    [ai.miniforge.schema.interface :as schema]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Constants and shell primitives
 
-(def ^:private ms-per-second
+;; Constants and shell primitives
+(def ^{:stratum 0} ^:private ms-per-second
   "Milliseconds in one second.
    Converts poll-interval-s (config/worklist unit) to poll-interval-ms
    (pr-lifecycle internal unit). Extracted per rule 006 — used in three sites."
   1000)
 
-(def ^:private default-poll-interval-ms
+(def ^{:stratum 0} ^:private default-poll-interval-ms
   "Fallback used in run-monitor! when the monitor atom does not yet carry
    [:config :poll-interval-ms]. Mirrors the pr-lifecycle monitor default (60 s)."
   60000)
 
-(defn- sh! [& args]
+(defn- ^{:stratum 0} sh! [& args]
   (apply process/sh args))
 
-(defn- remote-origin-url
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} remote-origin-url
   "Return the git remote origin URL for `repo-path`, or nil on failure."
   [repo-path]
   (let [r (sh! "git" "-C" repo-path "remote" "get-url" "origin")]
     (when (zero? (:exit r))
       (str/trim (:out r)))))
 
-(defn- resolve-author
+(defn- ^{:stratum 1} resolve-author
   "Resolve the GitHub author login from `author-opt` flag, gh CLI, or `default-author`."
   [author-opt default-author]
   (or author-opt
@@ -68,7 +69,7 @@
             (when (seq login) login))))
       default-author))
 
-(defn- parse-poll-interval
+(defn- ^{:stratum 1} parse-poll-interval
   "Parse poll-interval string in seconds, with bounds checking.
    Returns milliseconds, or nil when the value is out-of-range or unparseable."
   [interval-str {:keys [min-poll-interval-s max-poll-interval-s]}]
@@ -85,7 +86,7 @@
         (display/print-error (messages/t :pr/monitor-interval-invalid {:value interval-str}))
         nil))))
 
-(defn- worklist-poll-ms
+(defn- ^{:stratum 1} worklist-poll-ms
   "Derive poll-interval in milliseconds from the PR entries in a worklist.
    Takes the minimum :pr/poll-interval (seconds) across all entries.
    Returns nil when no entries carry that key — caller uses monitor default."
@@ -94,10 +95,8 @@
            (apply min)
            (* ms-per-second)))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Monitor session — compose Layer 0 with pr-lifecycle calls
-
-(defn- run-monitor!
+(defn- ^{:stratum 1} run-monitor!
   "Create a PR monitor from `mon-opts`, install a shutdown hook, run the loop.
    Single implementation shared by the fresh-monitor and resume paths."
   [mon-opts author]
@@ -117,7 +116,9 @@
       (let [evidence (pr-lifecycle/run-pr-monitor-loop monitor author)]
         (display/print-info (messages/t :pr/monitor-stopped {:evidence (pr-str evidence)}))))))
 
-(defn- resume-from-worklist!
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- ^{:stratum 2} resume-from-worklist!
   "Load persisted worklist for `repo-path`, prune closed PRs, then run monitor.
 
    Scope note: the work-list is used as a resume GATE (only resume when a
@@ -174,12 +175,12 @@
                 (let [poll-ms  (worklist-poll-ms prs)
                       mon-opts (cond-> {:worktree-path repo-path :self-author author}
                                  poll-ms (assoc :poll-interval-ms poll-ms))]    ; H
-                  (run-monitor! mon-opts author))))))))))        ; H G F E D C B A defn
+                  (run-monitor! mon-opts author))))))))))  ; H G F E D C B A defn
 
-;------------------------------------------------------------------------------ Layer 2
+;------------------------------------------------------------------------------ Layer 3
+
 ;; Entry point
-
-(defn pr-monitor-cmd
+(defn ^{:stratum 3} pr-monitor-cmd
   "Start the PR monitor loop for autonomous comment resolution.
 
    With --author: creates a fresh monitor polling that author's open PRs.

--- a/bases/cli/src/ai/miniforge/cli/main/commands/pr_policy_respond.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/pr_policy_respond.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.main.commands.pr-policy-respond
   "N13 §2.5 Comment Response Agent CLI — policy-eval (deterministic) path.
 
@@ -38,9 +37,10 @@
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.pr-lifecycle.interface :as pr-lifecycle]))
 
-;; ── error rendering ──────────────────────────────────────────────────
+;------------------------------------------------------------------------------ Layer 0
 
-(defn- error-message
+;; ── error rendering ──────────────────────────────────────────────────
+(defn- ^{:stratum 0} error-message
   "Translate the typed `:error` map on `ctx` into the operator-facing
    string. New `:kind`s should land here (and in the messages catalog)
    rather than re-stringifying at call sites."
@@ -51,13 +51,79 @@
     :checkout-failed (messages/t :pr/policy-respond-checkout-failed {:n (:n error)})
     :fetch-failed    (messages/t :pr/policy-respond-fetch-failed    {:n (:n error)})))
 
-(defn- commit-sha-text
+(defn- ^{:stratum 0} commit-sha-text
   "Return a commit SHA when it is a string; otherwise return the display sentinel."
   [data]
   (let [commit-sha (get data :commit-sha)]
     (if (string? commit-sha) commit-sha "—")))
 
-(defn- print-summary!
+(defn- ^{:stratum 0} print-failure!
+  [pr-number r]
+  (display/print-error
+   (messages/t :pr/policy-respond-failed
+               {:n pr-number
+                :code (str (get-in r [:error :code]))
+                :message (or (get-in r [:error :message]) "")})))
+
+;; ── infra helpers (worktree-scoped shell ops) ────────────────────────
+(defn- ^{:stratum 0} checkout-pr!
+  "Run `gh pr checkout <pr-number>` in `worktree-path`. Returns the
+   current branch on success, nil on failure."
+  [worktree-path pr-number]
+  (try
+    (let [r (process/shell {:dir (str worktree-path)
+                            :out :string :err :string :continue true}
+                           "gh" "pr" "checkout" (str pr-number))]
+      (when (zero? (:exit r))
+        (let [b (process/shell {:dir (str worktree-path)
+                                :out :string :err :string :continue true}
+                               "git" "branch" "--show-current")]
+          (when (zero? (:exit b))
+            (str/trim (:out b ""))))))
+    (catch Throwable _ nil)))
+
+(defn- ^{:stratum 0} fetch-comments
+  "Fetch the raw PR comments via the pr-lifecycle interface. Returns
+   the comments vector or nil on failure."
+  [worktree-path pr-number]
+  (let [r (pr-lifecycle/fetch-pr-comments worktree-path pr-number)]
+    (when (dag/ok? r)
+      (get-in r [:data :comments]))))
+
+;; ── pipeline steps ───────────────────────────────────────────────────
+;;
+;; Each step takes ctx, returns ctx. If ctx already carries `:error`
+;; the step is a no-op (early-bail) so downstream stages don't need
+;; per-step guards. Names match the operator's pipeline-style example.
+(defn- ^{:stratum 0} pr-policy-parse-url!
+  "Step 1: parse the operator-supplied URL, derive the PR number."
+  [{:keys [opts error] :as ctx}]
+  (if error
+    ctx
+    (let [url (:url opts)]
+      (cond
+        (or (nil? url) (str/blank? url))
+        (assoc ctx :error {:kind :usage})
+
+        :else
+        (let [{:keys [number]} (pr-lifecycle/parse-pr-url url)]
+          (if-not number
+            (assoc ctx :error {:kind :bad-url})
+            (assoc ctx :url url :number number)))))))
+
+(defn- ^{:stratum 0} pr-policy-respond!
+  "Step 4: hand off to the deterministic responder. Its DAG-result
+   becomes `:result` on the ctx — the finalize step decides whether
+   to render summary or failure."
+  [{:keys [error cwd number comments] :as ctx}]
+  (if error
+    ctx
+    (assoc ctx :result
+           (pr-lifecycle/respond-to-policy-comments! cwd number comments))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} print-summary!
   [pr-number r]
   (let [d (:data r)
         applied   (count (:applied d))
@@ -78,63 +144,7 @@
                    {:cid (str (-> e :comment :comment/id))
                     :reason (str (:reason e))})))))
 
-(defn- print-failure!
-  [pr-number r]
-  (display/print-error
-   (messages/t :pr/policy-respond-failed
-               {:n pr-number
-                :code (str (get-in r [:error :code]))
-                :message (or (get-in r [:error :message]) "")})))
-
-;; ── infra helpers (worktree-scoped shell ops) ────────────────────────
-
-(defn- checkout-pr!
-  "Run `gh pr checkout <pr-number>` in `worktree-path`. Returns the
-   current branch on success, nil on failure."
-  [worktree-path pr-number]
-  (try
-    (let [r (process/shell {:dir (str worktree-path)
-                            :out :string :err :string :continue true}
-                           "gh" "pr" "checkout" (str pr-number))]
-      (when (zero? (:exit r))
-        (let [b (process/shell {:dir (str worktree-path)
-                                :out :string :err :string :continue true}
-                               "git" "branch" "--show-current")]
-          (when (zero? (:exit b))
-            (str/trim (:out b ""))))))
-    (catch Throwable _ nil)))
-
-(defn- fetch-comments
-  "Fetch the raw PR comments via the pr-lifecycle interface. Returns
-   the comments vector or nil on failure."
-  [worktree-path pr-number]
-  (let [r (pr-lifecycle/fetch-pr-comments worktree-path pr-number)]
-    (when (dag/ok? r)
-      (get-in r [:data :comments]))))
-
-;; ── pipeline steps ───────────────────────────────────────────────────
-;;
-;; Each step takes ctx, returns ctx. If ctx already carries `:error`
-;; the step is a no-op (early-bail) so downstream stages don't need
-;; per-step guards. Names match the operator's pipeline-style example.
-
-(defn- pr-policy-parse-url!
-  "Step 1: parse the operator-supplied URL, derive the PR number."
-  [{:keys [opts error] :as ctx}]
-  (if error
-    ctx
-    (let [url (:url opts)]
-      (cond
-        (or (nil? url) (str/blank? url))
-        (assoc ctx :error {:kind :usage})
-
-        :else
-        (let [{:keys [number]} (pr-lifecycle/parse-pr-url url)]
-          (if-not number
-            (assoc ctx :error {:kind :bad-url})
-            (assoc ctx :url url :number number)))))))
-
-(defn- pr-policy-checkout!
+(defn- ^{:stratum 1} pr-policy-checkout!
   "Step 2: switch the working tree to the PR branch via `gh pr checkout`."
   [{:keys [error number] :as ctx}]
   (if error
@@ -145,7 +155,7 @@
         (assoc ctx :cwd cwd :branch branch)
         (assoc ctx :error {:kind :checkout-failed :n number})))))
 
-(defn- pr-policy-fetch-comments!
+(defn- ^{:stratum 1} pr-policy-fetch-comments!
   "Step 3: pull every PR comment via pr-lifecycle."
   [{:keys [error cwd number branch] :as ctx}]
   (if error
@@ -156,17 +166,9 @@
         (assoc ctx :comments comments)
         (assoc ctx :error {:kind :fetch-failed :n number})))))
 
-(defn- pr-policy-respond!
-  "Step 4: hand off to the deterministic responder. Its DAG-result
-   becomes `:result` on the ctx — the finalize step decides whether
-   to render summary or failure."
-  [{:keys [error cwd number comments] :as ctx}]
-  (if error
-    ctx
-    (assoc ctx :result
-           (pr-lifecycle/respond-to-policy-comments! cwd number comments))))
+;------------------------------------------------------------------------------ Layer 2
 
-(defn- pr-policy-finalize!
+(defn- ^{:stratum 2} pr-policy-finalize!
   "Step 5: terminal render. Three exclusive branches in order:
    ctx-level error, responder-level error, success summary."
   [{:keys [error number result] :as ctx}]
@@ -176,9 +178,10 @@
     :else               (print-summary! number result))
   ctx)
 
-;; ── command entry ────────────────────────────────────────────────────
+;------------------------------------------------------------------------------ Layer 3
 
-(defn pr-policy-respond-cmd
+;; ── command entry ────────────────────────────────────────────────────
+(defn ^{:stratum 3} pr-policy-respond-cmd
   "CLI entry for `bb miniforge pr policy-respond <pr-url>`.
 
    Pipeline: parse-url → checkout → fetch-comments → respond → finalize.

--- a/bases/cli/src/ai/miniforge/cli/main/commands/pr_resume_dispatcher.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/pr_resume_dispatcher.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.main.commands.pr-resume-dispatcher
   "N13 §2.7 Resume Signal Dispatcher CLI.
 
@@ -34,9 +33,10 @@
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.pr-lifecycle.interface :as pr-lifecycle]))
 
-;; ── helpers ──────────────────────────────────────────────────────────
+;------------------------------------------------------------------------------ Layer 0
 
-(defn- gh-pr-merge-state
+;; ── helpers ──────────────────────────────────────────────────────────
+(defn- ^{:stratum 0} gh-pr-merge-state
   "Query GitHub for `pr-number`'s merge state in `worktree-path`'s
    repo. Returns `{:state :MERGED|:OPEN|:CLOSED :merge-sha string?
    :merged-at string?}` map on success or nil on gh failure.
@@ -56,24 +56,14 @@
            :merged-at (:mergedAt parsed)})))
     (catch Throwable _ nil)))
 
-(defn- parse-iso-inst
+(defn- ^{:stratum 0} parse-iso-inst
   "Parse an ISO-8601 string from gh into a java.util.Date, or nil."
   [s]
   (try
     (java.util.Date/from (java.time.Instant/parse s))
     (catch Throwable _ nil)))
 
-(defn- merged-pr-record
-  "Build the merged-PR record consumed by `dispatch-pr-merge!` from a
-   listener entry + the gh response."
-  [listener gh-response]
-  {:pr/url       (:pr/url listener)
-   :merge/sha    (:merge-sha gh-response)
-   :merged-at    (or (parse-iso-inst (:merged-at gh-response))
-                     (java.util.Date.))
-   :diff-summary nil}) ; v0 omits diff-summary; gh diff --stat is a follow-up
-
-(defn- group-active-listeners-by-pr
+(defn- ^{:stratum 0} group-active-listeners-by-pr
   "Pure: group `entries-for-agent`-style listener bundle into
    `{pr-url [listener ...]}` filtered to `:active`."
   [registry]
@@ -86,7 +76,7 @@
               acc)))
         {})))
 
-(defn- print-listener-failure!
+(defn- ^{:stratum 0} print-listener-failure!
   "Render one per-listener failure entry from the dispatch summary's
    `:failed` vector to a typed error line. Pulled out so the
    `doseq` body stays a single named call."
@@ -97,7 +87,19 @@
                 :code    (str (get-in failure [:error :code]))
                 :message (or (get-in failure [:error :message]) "")})))
 
-(defn- print-dispatch-result!
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} merged-pr-record
+  "Build the merged-PR record consumed by `dispatch-pr-merge!` from a
+   listener entry + the gh response."
+  [listener gh-response]
+  {:pr/url       (:pr/url listener)
+   :merge/sha    (:merge-sha gh-response)
+   :merged-at    (or (parse-iso-inst (:merged-at gh-response))
+                     (java.util.Date.))
+   :diff-summary nil})  ; v0 omits diff-summary; gh diff --stat is a follow-up
+
+(defn- ^{:stratum 1} print-dispatch-result!
   "Render the operator-facing summary of one
    `dispatch-pr-merge!` call. Branches on `(dag/ok? r)` first
    because the dispatcher returns a DAG result (per its public
@@ -124,7 +126,9 @@
                     :total  (:listener-count summary)}))
       (run! print-listener-failure! (:failed summary)))))
 
-(defn- dispatch-merged-pr!
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- ^{:stratum 2} dispatch-merged-pr!
   "For one PR with at least one `:active` listener: query gh, decide
    if merged, dispatch + mark on yes."
   [worktree-path pr-url listeners]
@@ -146,7 +150,9 @@
        (pr-lifecycle/dispatch-pr-merge!
         worktree-path pr-url (merged-pr-record (first listeners) gh))))))
 
-(defn- run-pass!
+;------------------------------------------------------------------------------ Layer 3
+
+(defn- ^{:stratum 3} run-pass!
   "One pass: read registry, group active listeners by PR, dispatch each."
   [worktree-path]
   (let [r (pr-lifecycle/read-listener-registry worktree-path)]
@@ -165,9 +171,10 @@
         (doseq [[pr-url listeners] groups]
           (dispatch-merged-pr! worktree-path pr-url listeners))))))
 
-;; ── command entry ────────────────────────────────────────────────────
+;------------------------------------------------------------------------------ Layer 4
 
-(defn pr-resume-dispatcher-cmd
+;; ── command entry ────────────────────────────────────────────────────
+(defn ^{:stratum 4} pr-resume-dispatcher-cmd
   "CLI entry for `bb miniforge pr resume-dispatch`.
 
    v0: single-pass. The persistent loop is a v1 follow-up.

--- a/bases/cli/src/ai/miniforge/cli/main/commands/pr_review.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/pr_review.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.main.commands.pr-review
   "PR Review implementation — N13 §2.2 Standards Reviewer entry point.
 
@@ -50,32 +49,22 @@
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.pr-lifecycle.interface :as pr-lifecycle]))
 
-(def ^:private default-standards-path ".standards")
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private default-standards-path ".standards")
 
 ;; ── Table layout for emit-table ──────────────────────────────────────
 ;; Column widths (chars). Tuned for 100-col terminals: file paths get
 ;; the bulk, line is 6 (covers up to a million-line file), severity is
 ;; 12 (longest keyword name like ":warning" plus padding), rule trails
 ;; with no fixed width.
-(def ^:private file-col-width      60)
-(def ^:private line-col-width      6)
-(def ^:private severity-col-width  12)
+(def ^{:stratum 0} ^:private file-col-width      60)
 
-(def ^:private table-header-fmt
-  (str "%-" file-col-width "s %-" line-col-width "s %-" severity-col-width "s %s%n"))
+(def ^{:stratum 0} ^:private line-col-width      6)
 
-(def ^:private table-row-fmt
-  (str "%-" file-col-width "s %-" line-col-width "d %-" severity-col-width "s %s%n"))
+(def ^{:stratum 0} ^:private severity-col-width  12)
 
-(defn- separator-row
-  "Build the dashed underline row used between header and body."
-  []
-  (let [dashes (fn [n] (apply str (repeat n "-")))]
-    (str (dashes file-col-width) " "
-         (dashes line-col-width) " "
-         (dashes severity-col-width) " ----")))
-
-(defn- resolve-pack
+(defn- ^{:stratum 0} resolve-pack
   "Resolve a pack by name or path; returns the loaded pack map or nil."
   [pack-ref]
   (cond
@@ -89,7 +78,7 @@
       (when-let [url (io/resource resource-path)]
         (edn/read-string (slurp url))))))
 
-(defn- pack-info
+(defn- ^{:stratum 0} pack-info
   "Best-effort pack-info extraction for the rendered comment payload.
    Falls back to {:pack/id <pack-ref-or-default> :pack/version \"0.0.0\"}
    when the pack does not declare an id/version."
@@ -108,7 +97,7 @@
     :else
     {:pack/id "miniforge-standards" :pack/version "0.0.0"}))
 
-(defn- print-summary
+(defn- ^{:stratum 0} print-summary
   "Print a one-line summary of the review."
   [{:pr-review/keys [summary]}]
   (display/print-info
@@ -119,33 +108,19 @@
                 :files        (:files-affected summary)
                 :rules        (:rules-violated summary)})))
 
-(defn- emit-table
-  "Print a human-readable table of comments."
-  [comments]
-  (when (seq comments)
-    (println)
-    (printf table-header-fmt "FILE" "LINE" "SEVERITY" "RULE")
-    (println (separator-row))
-    (doseq [c comments]
-      (printf table-row-fmt
-              (:comment/path c)
-              (:comment/line c)
-              (name (or (get-in c [:comment/payload :violation/severity]) :info))
-              (str (get-in c [:comment/payload :violation/rule-id]))))))
-
-(defn- emit-edn
+(defn- ^{:stratum 0} emit-edn
   "Print the comments vector as pretty EDN to stdout."
   [comments]
   (pprint/pprint comments))
 
-(defn- emit-json
+(defn- ^{:stratum 0} emit-json
   "Print the comments vector as RFC 8259-compliant JSON via cheshire.
    Keywords are stringified; the internal `(str)` call in the key-fn
    handles the leading colon for deterministic output."
   [comments]
   (println (json/generate-string comments {:key-fn name})))
 
-(defn- review-summary-body
+(defn- ^{:stratum 0} review-summary-body
   "Build the markdown body for the posted PR review from the
    pr-review result's summary."
   [{:pr-review/keys [summary]}]
@@ -156,7 +131,23 @@
                :files        (:files-affected summary)
                :rules        (:rules-violated summary)}))
 
-(defn- maybe-post-review!
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} ^:private table-header-fmt
+  (str "%-" file-col-width "s %-" line-col-width "s %-" severity-col-width "s %s%n"))
+
+(def ^{:stratum 1} ^:private table-row-fmt
+  (str "%-" file-col-width "s %-" line-col-width "d %-" severity-col-width "s %s%n"))
+
+(defn- ^{:stratum 1} separator-row
+  "Build the dashed underline row used between header and body."
+  []
+  (let [dashes (fn [n] (apply str (repeat n "-")))]
+    (str (dashes file-col-width) " "
+         (dashes line-col-width) " "
+         (dashes severity-col-width) " ----")))
+
+(defn- ^{:stratum 1} maybe-post-review!
   "When the operator opted in via `--post`, batch-post the rendered
    comments to the PR via `pr-lifecycle.interface/post-review!`.
 
@@ -196,7 +187,25 @@
                        {:code    (str (get-in r [:error :code]))
                         :message (get-in r [:error :message])})))))))
 
-(defn run-pr-review!
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- ^{:stratum 2} emit-table
+  "Print a human-readable table of comments."
+  [comments]
+  (when (seq comments)
+    (println)
+    (printf table-header-fmt "FILE" "LINE" "SEVERITY" "RULE")
+    (println (separator-row))
+    (doseq [c comments]
+      (printf table-row-fmt
+              (:comment/path c)
+              (:comment/line c)
+              (name (or (get-in c [:comment/payload :violation/severity]) :info))
+              (str (get-in c [:comment/payload :violation/rule-id]))))))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} run-pr-review!
   "Run a PR-scoped standards review against an existing repo checkout.
 
    Arguments:
@@ -256,7 +265,9 @@
                           result))
     result))
 
-(defn run-pr-review-by-path-cmd
+;------------------------------------------------------------------------------ Layer 4
+
+(defn ^{:stratum 4} run-pr-review-by-path-cmd
   "CLI entry point for `miniforge pr review --repo <path> --base <ref>`.
 
    For when the operator already has a checkout — useful in dogfood and

--- a/bases/cli/src/ai/miniforge/cli/main/commands/pr_review_monitor.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/pr_review_monitor.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.main.commands.pr-review-monitor
   "N13 §2.2 Standards Reviewer auto-trigger.
 
@@ -37,9 +36,10 @@
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.pr-lifecycle.interface :as pr-lifecycle]))
 
-;; ── helpers ──────────────────────────────────────────────────────────
+;------------------------------------------------------------------------------ Layer 0
 
-(defn- gh-pr-base-ref
+;; ── helpers ──────────────────────────────────────────────────────────
+(defn- ^{:stratum 0} gh-pr-base-ref
   "Resolve the base-branch ref for `pr-number` via `gh pr view`,
    running in `worktree-path` so {owner}/{repo} resolves from the
    git remote. Returns `\"origin/<base>\"` or nil on failure."
@@ -57,7 +57,22 @@
           (when (seq name) (str "origin/" name)))))
     (catch Throwable _ nil)))
 
-(defn- review-one-pr!
+(defn- ^{:stratum 0} existing-shas-by-pr
+  "For each PR in `prs`, look up the marker-bearing review SHAs.
+   Returns a map keyed by `:pr/number`. PRs whose lookup fails get
+   an empty set (so we treat them as needing review and let the
+   per-PR error path catch any subsequent failure)."
+  [base-repo prs]
+  (reduce
+   (fn [acc {:pr/keys [number]}]
+     (let [r (pr-lifecycle/existing-review-shas base-repo number)]
+       (assoc acc number (if (dag/ok? r) (:data r) #{}))))
+   {}
+   prs))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} review-one-pr!
   "Bracket: ephemeral worktree at PR head SHA → run pr-review with
    --post against that worktree. Per-PR errors don't abort the pass
    — they're surfaced to the operator and we move on."
@@ -88,20 +103,9 @@
                         :code (str (get-in r [:error :code]))
                         :message (or (get-in r [:error :message]) "")})))))))
 
-(defn- existing-shas-by-pr
-  "For each PR in `prs`, look up the marker-bearing review SHAs.
-   Returns a map keyed by `:pr/number`. PRs whose lookup fails get
-   an empty set (so we treat them as needing review and let the
-   per-PR error path catch any subsequent failure)."
-  [base-repo prs]
-  (reduce
-   (fn [acc {:pr/keys [number]}]
-     (let [r (pr-lifecycle/existing-review-shas base-repo number)]
-       (assoc acc number (if (dag/ok? r) (:data r) #{}))))
-   {}
-   prs))
+;------------------------------------------------------------------------------ Layer 2
 
-(defn- run-pass!
+(defn- ^{:stratum 2} run-pass!
   "One pass over the in-scope open PR set."
   [base-repo author review-opts]
   (let [r (pr-lifecycle/poll-open-prs base-repo author)]
@@ -126,9 +130,10 @@
           (doseq [pr needs-review]
             (review-one-pr! base-repo pr review-opts)))))))
 
-;; ── command entry ────────────────────────────────────────────────────
+;------------------------------------------------------------------------------ Layer 3
 
-(defn pr-review-monitor-cmd
+;; ── command entry ────────────────────────────────────────────────────
+(defn ^{:stratum 3} pr-review-monitor-cmd
   "CLI entry for `bb miniforge pr review-monitor`.
 
    v0: single-pass when `--once` (the only mode). The persistent

--- a/bases/cli/src/ai/miniforge/cli/main/commands/resume.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/resume.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.main.commands.resume
   "CLI adapter for workflow resume.
 
@@ -44,63 +43,30 @@
    [ai.miniforge.workflow-resume.interface :as wr]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Events dir (module-level for test redef-ability)
 
-(def events-dir
+;; Events dir (module-level for test redef-ability)
+(def ^{:stratum 0} events-dir
   (app-config/events-dir))
 
-(def load-workflow
+(def ^{:stratum 0} load-workflow
   "Workflow loader dependency, exposed as a var so tests can rebind the
    CLI boundary without dynamic namespace resolution."
   workflow/load-workflow)
 
-(def run-pipeline
+(def ^{:stratum 0} run-pipeline
   "Workflow runner dependency, exposed as a var so tests can rebind the
    CLI boundary without dynamic namespace resolution."
   workflow/run-pipeline)
 
-(defn- anomaly-category
+(defn- ^{:stratum 0} anomaly-category
   [a]
   (case (:anomaly/type a)
     :not-found :anomalies/not-found
     :invalid-input :anomalies/incorrect
     :anomalies/fault))
 
-(defn- throw-resume-anomaly!
-  [a]
-  (when (anomaly/anomaly? a)
-    (response/throw-anomaly! (anomaly-category a)
-                             (:anomaly/message a)
-                             (merge (:anomaly/data a)
-                                    (select-keys a [:anomaly/type
-                                                    :anomaly/subtype
-                                                    :anomaly/at])))))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Thin delegations kept for compatibility with existing callers/tests
-
-(defn read-event-file
-  "Read events for a workflow. Thin wrapper — the actual replay lives
-   in `event-stream/reader`. Prefer calling the component directly in
-   new code."
-  [workflow-id]
-  (es/read-workflow-events-by-id events-dir workflow-id))
-
-(defn resolve-resume-workflow
-  "Resolve workflow identity for a resumed run, using the CLI's
-   default selection profile as fallback. Thin wrapper over the
-   component's `resolve-workflow-identity`."
-  [reconstructed]
-  (let [result (wr/resolve-workflow-identity
-                reconstructed
-                #(selection-config/resolve-selection-profile :default))]
-    (throw-resume-anomaly! result)
-    result))
-
-;------------------------------------------------------------------------------ Layer 1.5
 ;; Status semantics
-
-(def terminal-statuses
+(def ^{:stratum 0} terminal-statuses
   "Workflow execution statuses that mean the run has actually finished —
    either successfully or definitively failed. Anything outside this set
    (`:running`, `:pending`, `:paused`, nil) means the runner returned
@@ -108,12 +74,7 @@
    fast-fail blocker filed as work/workflow-resume-status-handling.spec.edn."
   #{:completed :completed-with-warnings :failed :aborted :cancelled})
 
-(defn terminal-status?
-  "True when `status` represents a finished workflow."
-  [status]
-  (contains? terminal-statuses status))
-
-(defn- resume-print-phase
+(defn- ^{:stratum 0} resume-print-phase
   "Pick the phase name to render in `Resuming from phase: X`. Prefer
    the FSM machine snapshot's recorded `:execution/current-phase` so
    the print reflects where the run actually parked — falling back to
@@ -124,10 +85,48 @@
         (some-> (:execution/current-phase machine-snapshot) name))
       (some-> (:phase (first remaining-pipeline)) name)))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Public API — invoked by both `mf resume <id>` and `mf run --resume`
+;------------------------------------------------------------------------------ Layer 1
 
-(defn resume-workflow
+(defn- ^{:stratum 1} throw-resume-anomaly!
+  [a]
+  (when (anomaly/anomaly? a)
+    (response/throw-anomaly! (anomaly-category a)
+                             (:anomaly/message a)
+                             (merge (:anomaly/data a)
+                                    (select-keys a [:anomaly/type
+                                                    :anomaly/subtype
+                                                    :anomaly/at])))))
+
+;; Thin delegations kept for compatibility with existing callers/tests
+(defn ^{:stratum 1} read-event-file
+  "Read events for a workflow. Thin wrapper — the actual replay lives
+   in `event-stream/reader`. Prefer calling the component directly in
+   new code."
+  [workflow-id]
+  (es/read-workflow-events-by-id events-dir workflow-id))
+
+(defn ^{:stratum 1} terminal-status?
+  "True when `status` represents a finished workflow."
+  [status]
+  (contains? terminal-statuses status))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} resolve-resume-workflow
+  "Resolve workflow identity for a resumed run, using the CLI's
+   default selection profile as fallback. Thin wrapper over the
+   component's `resolve-workflow-identity`."
+  [reconstructed]
+  (let [result (wr/resolve-workflow-identity
+                reconstructed
+                #(selection-config/resolve-selection-profile :default))]
+    (throw-resume-anomaly! result)
+    result))
+
+;------------------------------------------------------------------------------ Layer 3
+
+;; Public API — invoked by both `mf resume <id>` and `mf run --resume`
+(defn ^{:stratum 3} resume-workflow
   "Resume a workflow from its last checkpoint.
 
    Reconstructs context via the workflow-resume component, trims the

--- a/bases/cli/src/ai/miniforge/cli/main/commands/run.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/run.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.main.commands.run
   "Run command — execute workflows from spec files, plan files, or DAG files."
   (:require
@@ -32,32 +31,17 @@
    [slingshot.slingshot :refer [try+]]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Error handling
 
-(defn- classify-error
+;; Error handling
+(defn- ^{:stratum 0} classify-error
   "Attempt runtime error classification. Returns classification or nil."
   [e]
   (try
     (agent-runtime/classify-error e (ex-data e))
     (catch Exception _ nil)))
 
-(defn- print-run-error-and-exit!
-  "Print error details and exit with code 1."
-  [e]
-  (let [classification (classify-error e)]
-    (if classification
-      (display/print-classified-error classification)
-      (do
-        (display/print-error (messages/t :run/failed {:error (ex-message e)}))
-        (when-let [data (ex-data e)]
-          (println (messages/t :run/error-details {:details (pr-str data)}))))))
-  (flush)
-  (System/exit 1))
-
-;------------------------------------------------------------------------------ Layer 0
 ;; Input type detection
-
-(defn detect-input-type
+(defn ^{:stratum 0} detect-input-type
   "Detect the type of a parsed input file.
    Returns :spec, :dag, :plan, or nil."
   [parsed]
@@ -67,20 +51,18 @@
     (:plan/id parsed)    :plan
     :else                nil))
 
-(defn read-edn-file
+(defn ^{:stratum 0} read-edn-file
   "Read an EDN file, returning the parsed data."
   [path]
   (edn/read-string (slurp (str path))))
 
-(defn markdown-spec?
+(defn ^{:stratum 0} markdown-spec?
   "True if path has a markdown extension."
   [path]
   (contains? #{"md" "markdown"} (fs/extension (str path))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Shared workflow execution path
-
-(defn- run-spec-workflow
+(defn- ^{:stratum 0} run-spec-workflow
   "Parse, validate, and execute a workflow spec from path.
    Used by both the markdown and EDN code paths.
    Returns the workflow result map, or nil on validation failure."
@@ -110,10 +92,25 @@
         (workflow-runner/run-workflow-from-spec!
          (assoc parsed-spec :spec/path spec-path) runner-opts)))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Run command
+;------------------------------------------------------------------------------ Layer 1
 
-(defn run-cmd
+(defn- ^{:stratum 1} print-run-error-and-exit!
+  "Print error details and exit with code 1."
+  [e]
+  (let [classification (classify-error e)]
+    (if classification
+      (display/print-classified-error classification)
+      (do
+        (display/print-error (messages/t :run/failed {:error (ex-message e)}))
+        (when-let [data (ex-data e)]
+          (println (messages/t :run/error-details {:details (pr-str data)}))))))
+  (flush)
+  (System/exit 1))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Run command
+(defn ^{:stratum 2} run-cmd
   "Execute a workflow from a spec, plan, or DAG file.
 
    Dispatch order:

--- a/bases/cli/src/ai/miniforge/cli/main/commands/runtime.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/runtime.clj
@@ -1,7 +1,6 @@
 ;; Title: Miniforge.ai
 ;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
 ;; Licensed under the Apache License, Version 2.0
-
 (ns ai.miniforge.cli.main.commands.runtime
   "`mf runtime` subcommands — info / run.
 
@@ -23,14 +22,12 @@
    [ai.miniforge.dag-executor.interface :as dag]))
 
 ;------------------------------------------------------------------------------ Layer 0
+
 ;; Config sourcing — MINIFORGE_RUNTIME handling lives in the shared
 ;; `runtime-env` leaf namespace so the workflow-runner sandbox applies the
 ;; same override these commands do.
-
-;------------------------------------------------------------------------------ Layer 1
 ;; Render helpers
-
-(defn- format-probed-kind
+(defn- ^{:stratum 0} format-probed-kind
   "Render one entry from the auto-probe :probed list — '<kind> (<version>)'
    for available kinds, '<kind> — <reason>' for unavailable."
   [{:keys [kind available? runtime-version reason]}]
@@ -42,48 +39,15 @@
                 {:kind   (name kind)
                  :reason (or reason "")})))
 
-(defn- format-probed-list
-  [probed]
-  (when (seq probed)
-    (str/join ", " (map format-probed-kind probed))))
-
-;------------------------------------------------------------------------------ Layer 2
-;; `mf runtime info`
-
-(defn- print-info-success
-  "Render a successful selection as human-readable lines plus the raw
-   descriptor as EDN at the end (so `mf runtime info` is grep-able and
-   programmable)."
-  [{:keys [descriptor kind selection runtime-version probed]}]
-  (println (messages/t :runtime/info-kind             {:kind (name kind)}))
-  (println (messages/t :runtime/info-executable       {:executable (dag/runtime-executable descriptor)}))
-  (println (messages/t :runtime/info-runtime-version  {:runtime-version (or runtime-version "?")}))
-  (println (messages/t :runtime/info-selection        {:selection (name selection)}))
-  (when (seq probed)
-    (println (messages/t :runtime/info-probed         {:probed (format-probed-list probed)})))
-  (println)
-  (pprint/pprint descriptor))
-
-(defn- print-info-error
+(defn- ^{:stratum 0} print-info-error
   [error]
   (display/print-error
    (messages/t :runtime/error-no-runtime
                {:code    (some-> (:code error) name)
                 :message (:message error)})))
 
-(defn runtime-info-cmd
-  "Resolve the runtime per N11-delta §3 and print the result. Used both
-   from `mf runtime info` and from the doctor."
-  [_m]
-  (let [result (dag/select-runtime (runtime-env/selection-config))]
-    (if (dag/ok? result)
-      (print-info-success (:data result))
-      (print-info-error (:error result)))))
-
-;------------------------------------------------------------------------------ Layer 3
 ;; `mf runtime run -- <args>`
-
-(defn- forward-args
+(defn- ^{:stratum 0} forward-args
   "Pull the args list off the babashka.cli dispatch map and strip a
    leading `--` separator if present. Matches the convention used by
    `mf worktree run -- <cmd>`."
@@ -92,7 +56,31 @@
        (remove #{"--"})
        vec))
 
-(defn runtime-run-cmd
+;; Doctor integration
+(defn- ^{:stratum 0} format-runtime-line
+  "One-line summary for the doctor. Uses display/style for color."
+  [{:keys [kind selection runtime-version]}]
+  (str (display/style "✓" :foreground :green) " "
+       (messages/t :runtime/doctor-line
+                   {:kind            (name kind)
+                    :runtime-version (or runtime-version "?")
+                    :selection       (name selection)})))
+
+(defn- ^{:stratum 0} print-runtime-error-line
+  [error]
+  (println (display/style "✗" :foreground :red) " "
+           (messages/t :runtime/doctor-error-line
+                       {:code    (some-> (:code error) name)
+                        :message (:message error)})))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} format-probed-list
+  [probed]
+  (when (seq probed)
+    (str/join ", " (map format-probed-kind probed))))
+
+(defn ^{:stratum 1} runtime-run-cmd
   "Resolve the runtime, then exec `<resolved-exe> <args>`. Args after
    `--` are forwarded verbatim. Exit code propagates.
 
@@ -113,26 +101,24 @@
         (when (and (number? exit) (not (zero? exit)))
           (System/exit exit))))))
 
-;------------------------------------------------------------------------------ Layer 4
-;; Doctor integration
+;------------------------------------------------------------------------------ Layer 2
 
-(defn- format-runtime-line
-  "One-line summary for the doctor. Uses display/style for color."
-  [{:keys [kind selection runtime-version]}]
-  (str (display/style "✓" :foreground :green) " "
-       (messages/t :runtime/doctor-line
-                   {:kind            (name kind)
-                    :runtime-version (or runtime-version "?")
-                    :selection       (name selection)})))
+;; `mf runtime info`
+(defn- ^{:stratum 2} print-info-success
+  "Render a successful selection as human-readable lines plus the raw
+   descriptor as EDN at the end (so `mf runtime info` is grep-able and
+   programmable)."
+  [{:keys [descriptor kind selection runtime-version probed]}]
+  (println (messages/t :runtime/info-kind             {:kind (name kind)}))
+  (println (messages/t :runtime/info-executable       {:executable (dag/runtime-executable descriptor)}))
+  (println (messages/t :runtime/info-runtime-version  {:runtime-version (or runtime-version "?")}))
+  (println (messages/t :runtime/info-selection        {:selection (name selection)}))
+  (when (seq probed)
+    (println (messages/t :runtime/info-probed         {:probed (format-probed-list probed)})))
+  (println)
+  (pprint/pprint descriptor))
 
-(defn- print-runtime-error-line
-  [error]
-  (println (display/style "✗" :foreground :red) " "
-           (messages/t :runtime/doctor-error-line
-                       {:code    (some-> (:code error) name)
-                        :message (:message error)})))
-
-(defn print-doctor-runtime-section
+(defn ^{:stratum 2} print-doctor-runtime-section
   "Emit the runtime block of `mf doctor`. Picked up by main.clj's
    doctor-cmd."
   []
@@ -148,3 +134,14 @@
       (do (print-runtime-error-line (:error result))
           (println "  " (messages/t :runtime/doctor-override-hint
                                     {:env-var runtime-env/runtime-env-var}))))))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} runtime-info-cmd
+  "Resolve the runtime per N11-delta §3 and print the result. Used both
+   from `mf runtime info` and from the doctor."
+  [_m]
+  (let [result (dag/select-runtime (runtime-env/selection-config))]
+    (if (dag/ok? result)
+      (print-info-success (:data result))
+      (print-info-error (:error result)))))

--- a/bases/cli/src/ai/miniforge/cli/main/commands/scan.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/scan.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.main.commands.scan
   "Scan command — run compliance scanner against a repository.
 
@@ -36,12 +35,13 @@
    [ai.miniforge.semantic-analyzer.interface :as semantic]))
 
 ;------------------------------------------------------------------------------ Layer 0
+
 ;; Pack resolution
+(def ^{:stratum 0} ^:private default-standards-path ".standards")
 
-(def ^:private default-standards-path ".standards")
-(def ^:private repo-config-path ".miniforge/config.edn")
+(def ^{:stratum 0} ^:private repo-config-path ".miniforge/config.edn")
 
-(defn- resolve-pack
+(defn- ^{:stratum 0} resolve-pack
   "Resolve a pack by name or path. Returns the loaded pack map or nil."
   [pack-ref]
   (cond
@@ -53,24 +53,7 @@
       (when-let [url (io/resource resource-path)]
         (edn/read-string (slurp url))))))
 
-(defn- load-repo-config
-  "Load .miniforge/config.edn from the repo root. Returns nil if absent."
-  [repo-path]
-  (let [path (fs/path repo-path repo-config-path)]
-    (when (fs/exists? path)
-      (edn/read-string (slurp (str path))))))
-
-(defn- resolve-packs-from-config
-  "Load all packs declared in :repo/packs. Returns merged pack or nil."
-  [repo-config]
-  (let [pack-names (get repo-config :repo/packs [])]
-    (when (seq pack-names)
-      (let [packs (keep resolve-pack pack-names)
-            rules (vec (mapcat :pack/rules packs))]
-        (when (seq rules)
-          {:pack/rules rules})))))
-
-(defn- resolve-rules-selector
+(defn- ^{:stratum 0} resolve-rules-selector
   "Parse the --rules option into a selector value."
   [rules-opt]
   (cond
@@ -79,24 +62,7 @@
     (= "always-apply" rules-opt) :always-apply
     :else                      (keyword rules-opt)))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Pipeline steps
-
-(defn- build-scan-opts
-  "Build scan options from CLI opts and repo config.
-   Priority: --pack flag > repo config :repo/packs > no pack."
-  [repo-path opts]
-  (let [explicit-pack (when-let [p (get opts :pack)] (resolve-pack p))
-        repo-config   (when-not explicit-pack (load-repo-config repo-path))
-        config-pack   (when repo-config (resolve-packs-from-config repo-config))
-        pack          (or explicit-pack config-pack)
-        rules         (resolve-rules-selector (get opts :rules))
-        since         (get opts :since)]
-    (cond-> {:rules rules}
-      pack  (assoc :pack pack)
-      since (assoc :since since))))
-
-(defn- print-scan-summary
+(defn- ^{:stratum 0} print-scan-summary
   "Print scan result summary. Returns the scan result."
   [scan-result]
   (display/print-info
@@ -106,7 +72,7 @@
                 :duration-ms (:scan-duration-ms scan-result)}))
   scan-result)
 
-(defn- classify-and-report
+(defn- ^{:stratum 0} classify-and-report
   "Classify violations and print counts. Returns classified violations."
   [violations]
   (let [classified (scanner/classify violations)
@@ -117,7 +83,7 @@
                  {:auto-count auto-count :review-count review-count}))
     classified))
 
-(defn- plan-and-print
+(defn- ^{:stratum 0} plan-and-print
   "Generate plan, optionally print work spec. Returns plan result."
   [classified repo-path report?]
   (let [plan-result (scanner/plan classified repo-path)]
@@ -126,7 +92,7 @@
       (println (:work-spec plan-result)))
     plan-result))
 
-(defn- execute-if-requested
+(defn- ^{:stratum 0} execute-if-requested
   "Apply auto-fixes if --execute flag is set."
   [plan-result repo-path execute?]
   (when (and execute? (seq (filter :auto-fixable? (mapcat :task/violations (:dag-tasks plan-result)))))
@@ -137,7 +103,7 @@
                    {:fixed (get exec-result :violations-fixed 0)
                     :files (get exec-result :files-changed 0)})))))
 
-(defn- run-linters
+(defn- ^{:stratum 0} run-linters
   "Run language-specific linters for detected technologies.
    Returns vector of linter violations."
   [repo-path repo-config]
@@ -161,7 +127,7 @@
                                             {:tech (name tech) :duration-ms duration-ms}))))
         (:violations result)))))
 
-(defn- run-linter-fixes!
+(defn- ^{:stratum 0} run-linter-fixes!
   "Run linter --fix for detected technologies."
   [repo-path repo-config]
   (let [detected (get repo-config :repo/technologies #{})
@@ -175,7 +141,7 @@
                                           :scan/linter-fix-applied
                                           :scan/linter-fix-failed))})))))
 
-(defn- print-rule-result
+(defn- ^{:stratum 0} print-rule-result
   "Print a single rule's analysis result."
   [result]
   (let [rule-name (name (get result :rule/id :unknown))
@@ -192,12 +158,31 @@
                     :files       (:files-analyzed result)
                     :duration-ms (:duration-ms result)})))))
 
-(defn- rule-has-matching-files?
+(defn- ^{:stratum 0} rule-has-matching-files?
   "True when a rule's file globs match at least one file in the repo."
   [repo-path rule]
   (seq (semantic/select-files-for-rule repo-path rule)))
 
-(defn- run-semantic-analysis
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} load-repo-config
+  "Load .miniforge/config.edn from the repo root. Returns nil if absent."
+  [repo-path]
+  (let [path (fs/path repo-path repo-config-path)]
+    (when (fs/exists? path)
+      (edn/read-string (slurp (str path))))))
+
+(defn- ^{:stratum 1} resolve-packs-from-config
+  "Load all packs declared in :repo/packs. Returns merged pack or nil."
+  [repo-config]
+  (let [pack-names (get repo-config :repo/packs [])]
+    (when (seq pack-names)
+      (let [packs (keep resolve-pack pack-names)
+            rules (vec (mapcat :pack/rules packs))]
+        (when (seq rules)
+          {:pack/rules rules})))))
+
+(defn- ^{:stratum 1} run-semantic-analysis
   "Run LLM-based semantic analysis on behavioral rules in parallel.
    Only runs rules that have matching files in the repo."
   [repo-path standards-path]
@@ -228,7 +213,26 @@
                                       {:message (.getMessage e)}))
       [])))
 
-(defn- run-scan
+;------------------------------------------------------------------------------ Layer 2
+
+;; Pipeline steps
+(defn- ^{:stratum 2} build-scan-opts
+  "Build scan options from CLI opts and repo config.
+   Priority: --pack flag > repo config :repo/packs > no pack."
+  [repo-path opts]
+  (let [explicit-pack (when-let [p (get opts :pack)] (resolve-pack p))
+        repo-config   (when-not explicit-pack (load-repo-config repo-path))
+        config-pack   (when repo-config (resolve-packs-from-config repo-config))
+        pack          (or explicit-pack config-pack)
+        rules         (resolve-rules-selector (get opts :rules))
+        since         (get opts :since)]
+    (cond-> {:rules rules}
+      pack  (assoc :pack pack)
+      since (assoc :since since))))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn- ^{:stratum 3} run-scan
   "Execute the scan→linters→semantic→classify→plan→execute pipeline."
   [repo-path opts]
   (let [standards   (get opts :standards default-standards-path)
@@ -288,10 +292,10 @@
               (run-linter-fixes! repo-path repo-config))
             (execute-if-requested plan-result repo-path true)))))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Command entry point
+;------------------------------------------------------------------------------ Layer 4
 
-(defn scan-cmd
+;; Command entry point
+(defn ^{:stratum 4} scan-cmd
   "CLI entry point for the scan command."
   [opts]
   (let [repo-path (get opts :repo (str (fs/cwd)))]

--- a/bases/cli/src/ai/miniforge/cli/main/commands/shared.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/shared.clj
@@ -99,7 +99,7 @@
 
 ;------------------------------------------------------------------------------ Layer 2
 
-;; Composes Layer 0.
+;; Composes Layer 1.
 (defn ^{:stratum 2} call-optional-provider
   "Look up optional provider `fn-sym` and immediately apply it to `args`.
    Returns nil when no provider is registered or the provider fails."

--- a/bases/cli/src/ai/miniforge/cli/main/commands/shared.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/shared.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.main.commands.shared
   "Shared utilities for CLI command implementations.
 
@@ -27,45 +26,52 @@
    [ai.miniforge.cli.messages :as messages]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Constants + helpers with no in-namespace dependencies.
 
-(def max-artifacts-display
+;; Constants + helpers with no in-namespace dependencies.
+(def ^{:stratum 0} max-artifacts-display
   "Maximum number of artifact files to display in a listing."
   50)
 
-(def bytes-per-kb
+(def ^{:stratum 0} bytes-per-kb
   "Bytes in a kilobyte."
   1024)
 
-(def bytes-per-mb
+(def ^{:stratum 0} bytes-per-mb
   "Bytes in a megabyte."
   1048576)
 
-(def max-prs-per-repo
+(def ^{:stratum 0} max-prs-per-repo
   "Maximum PRs to fetch per repository in fleet commands."
   20)
 
-(def pr-risk-lines-high
+(def ^{:stratum 0} pr-risk-lines-high
   "Line-change threshold above which a PR is considered high risk."
   500)
 
-(def pr-risk-lines-medium
+(def ^{:stratum 0} pr-risk-lines-medium
   "Line-change threshold above which a PR is considered medium risk."
   100)
 
-(def pr-risk-files-high
+(def ^{:stratum 0} pr-risk-files-high
   "Changed-files threshold above which a PR is considered high risk."
   20)
 
-(def pr-risk-files-medium
+(def ^{:stratum 0} pr-risk-files-medium
   "Changed-files threshold above which a PR is considered medium risk."
   5)
 
-(def optional-functions
+(def ^{:stratum 0} optional-functions
   "Explicitly composed optional CLI providers, keyed by their legacy symbol IDs."
   {})
 
-(defn register-optional-fn!
+(defn ^{:stratum 0} exit!
+  "Wrapper around System/exit that can be redef'd in tests."
+  [code]
+  (System/exit code))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} register-optional-fn!
   "Register an optional CLI provider function under `fn-sym`.
    Optional providers are composed by entry points that know the classpath
    includes the backing component."
@@ -77,22 +83,24 @@
   (alter-var-root #'optional-functions assoc fn-sym f)
   f)
 
-(defn optional-provider
+(defn ^{:stratum 1} optional-provider
   "Look up an explicitly composed optional provider by symbol.
    Returns the registered function, or nil when no provider is available.
    Does NOT call the function."
   [fn-sym]
   (get optional-functions fn-sym))
 
-(defn exit!
-  "Wrapper around System/exit that can be redef'd in tests."
-  [code]
-  (System/exit code))
+(defn ^{:stratum 1} usage-error!
+  "Print a usage error with the given message key and command string, then exit 1."
+  [message-key command-suffix]
+  (display/print-error
+   (messages/t message-key {:command (app-config/command-string command-suffix)}))
+  (exit! 1))
 
-;------------------------------------------------------------------------------ Layer 1
+;------------------------------------------------------------------------------ Layer 2
+
 ;; Composes Layer 0.
-
-(defn call-optional-provider
+(defn ^{:stratum 2} call-optional-provider
   "Look up optional provider `fn-sym` and immediately apply it to `args`.
    Returns nil when no provider is registered or the provider fails."
   [fn-sym & args]
@@ -103,10 +111,3 @@
         (.interrupt (Thread/currentThread))
         nil)
       (catch Exception _ nil))))
-
-(defn usage-error!
-  "Print a usage error with the given message key and command string, then exit 1."
-  [message-key command-suffix]
-  (display/print-error
-   (messages/t message-key {:command (app-config/command-string command-suffix)}))
-  (exit! 1))

--- a/bases/cli/src/ai/miniforge/cli/main/commands/tui.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/tui.clj
@@ -15,16 +15,15 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.main.commands.tui
   "TUI command — launch standalone TUI monitor."
   (:require
    [ai.miniforge.cli.main.commands.monitoring :as monitoring]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; TUI command
 
-(defn tui-cmd
+;; TUI command
+(defn ^{:stratum 0} tui-cmd
   "Launch standalone TUI that monitors workflow event files.
    Tail-follows app event files for live workflow state."
   [opts]

--- a/bases/cli/src/ai/miniforge/cli/main/commands/worktree.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/worktree.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.main.commands.worktree
   "User-facing helpers for resolving and executing inside the correct worktree."
   (:require
@@ -26,24 +25,26 @@
    [ai.miniforge.cli.worktree :as worktree]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Pure helpers
 
-(defn command-args
+;; Pure helpers
+(defn ^{:stratum 0} command-args
   [m]
   (vec (get m :args [])))
 
-(defn command-target
+(defn ^{:stratum 0} command-target
   [opts]
   (get opts :path (System/getProperty "user.dir")))
 
-(defn resolve-root
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} resolve-root
   [opts]
   (worktree/worktree-root (command-target opts)))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Execution
+;------------------------------------------------------------------------------ Layer 2
 
-(defn path-cmd
+;; Execution
+(defn ^{:stratum 2} path-cmd
   [opts]
   (let [root (resolve-root opts)
         target (command-target opts)]
@@ -54,7 +55,7 @@
          (messages/t :worktree/root-not-found {:path target}))
         (System/exit 1)))))
 
-(defn run-cmd
+(defn ^{:stratum 2} run-cmd
   [opts args]
   (let [root (resolve-root opts)
         target (command-target opts)
@@ -84,7 +85,9 @@
             exit (get @proc :exit 1)]
         (System/exit exit)))))
 
-(defn worktree-cmd
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} worktree-cmd
   [m]
   (let [opts (if (contains? m :opts) (:opts m) m)
         args (command-args m)

--- a/bases/cli/src/ai/miniforge/cli/main/display.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/display.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.main.display
   "Terminal styling and error display for CLI output."
   (:require
@@ -23,9 +22,9 @@
    [ai.miniforge.cli.messages :as messages]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; ANSI styling primitives
 
-(def ansi-colors
+;; ANSI styling primitives
+(def ^{:stratum 0} ansi-colors
   {:red     "31"
    :green   "32"
    :yellow  "33"
@@ -34,31 +33,8 @@
    :cyan    "36"
    :white   "37"})
 
-(defn style
-  "Apply terminal styling using ANSI escape codes."
-  [text & {:keys [foreground bold]}]
-  (let [codes (cond-> []
-                bold (conj "1")
-                foreground (conj (get ansi-colors foreground "37")))]
-    (if (seq codes)
-      (str "\033[" (str/join ";" codes) "m" text "\033[0m")
-      text)))
-
-(defn print-error [msg]
-  (println (style (messages/t :classified-error/error-prefix
-                              {:message msg})
-                  :foreground :red)))
-
-(defn print-success [msg]
-  (println (style msg :foreground :green)))
-
-(defn print-info [msg]
-  (println (style msg :foreground :cyan)))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; Data-driven detail rendering
-
-(defn render-fields
+(defn ^{:stratum 0} render-fields
   "Render entity fields from a data-driven spec.
    Each field is [data-key message-key & [opts-map]].
    Skips nil values. Supports :default, :transform, and :param (default :value)."
@@ -71,7 +47,7 @@
               param-key   (or param :value)]
           (println (messages/t msg-key {param-key display-val})))))))
 
-(defn render-section
+(defn ^{:stratum 0} render-section
   "Render a titled section with child entries.
    section: {:key K :header H :entry E :entry-fn (fn [item] -> params) :max N}"
   [entity {:keys [key header entry entry-fn max]}]
@@ -82,7 +58,55 @@
       (doseq [item (cond->> items max (take max))]
         (println (messages/t entry (if entry-fn (entry-fn item) {:value (str item)})))))))
 
-(defn render-detail
+(defn ^{:stratum 0} print-agent-backend-error-context
+  [completed-work]
+  (if (seq completed-work)
+    (println (messages/t :classified-error/agent-backend-context-success))
+    (println (messages/t :classified-error/agent-backend-context))))
+
+(defn ^{:stratum 0} print-task-code-error-context
+  [completed-work]
+  (println (messages/t :classified-error/task-code-context))
+  (when (seq completed-work)
+    (println)
+    (println (messages/t :classified-error/partial-work))
+    (doseq [work completed-work]
+      (println (str "  ⏸️  " work)))))
+
+(defn ^{:stratum 0} get-retry-recommendation
+  [error-type]
+  (case error-type
+    :task-code (messages/t :classified-error/retry-task-code)
+    :external (messages/t :classified-error/retry-external)
+    :agent-backend (messages/t :classified-error/retry-agent-backend)
+    (messages/t :classified-error/retry-generic)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} style
+  "Apply terminal styling using ANSI escape codes."
+  [text & {:keys [foreground bold]}]
+  (let [codes (cond-> []
+                bold (conj "1")
+                foreground (conj (get ansi-colors foreground "37")))]
+    (if (seq codes)
+      (str "\033[" (str/join ";" codes) "m" text "\033[0m")
+      text)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} print-error [msg]
+  (println (style (messages/t :classified-error/error-prefix
+                              {:message msg})
+                  :foreground :red)))
+
+(defn ^{:stratum 2} print-success [msg]
+  (println (style msg :foreground :green)))
+
+(defn ^{:stratum 2} print-info [msg]
+  (println (style msg :foreground :cyan)))
+
+(defn ^{:stratum 2} render-detail
   "Render a complete detail view: header + fields + sections."
   [{:keys [header header-params fields sections]} entity]
   (println)
@@ -94,8 +118,7 @@
   (println))
 
 ;; Error classification display
-
-(defn print-agent-backend-error-header
+(defn ^{:stratum 2} print-agent-backend-error-header
   [completed-work]
   (println (style (messages/t :classified-error/agent-backend-header)
                   :foreground :yellow :bold true))
@@ -106,37 +129,22 @@
     (doseq [work completed-work]
       (println (str "  " (style "✅" :foreground :green) " " work)))))
 
-(defn print-task-code-error-header
+(defn ^{:stratum 2} print-task-code-error-header
   []
   (println (style (messages/t :classified-error/task-code-header)
                   :foreground :red :bold true)))
 
-(defn print-external-error-header
+(defn ^{:stratum 2} print-external-error-header
   []
   (println (style (messages/t :classified-error/external-header)
                   :foreground :yellow :bold true)))
 
-(defn print-generic-error-header
+(defn ^{:stratum 2} print-generic-error-header
   []
   (println (style (messages/t :classified-error/generic-header)
                   :foreground :red :bold true)))
 
-(defn print-agent-backend-error-context
-  [completed-work]
-  (if (seq completed-work)
-    (println (messages/t :classified-error/agent-backend-context-success))
-    (println (messages/t :classified-error/agent-backend-context))))
-
-(defn print-task-code-error-context
-  [completed-work]
-  (println (messages/t :classified-error/task-code-context))
-  (when (seq completed-work)
-    (println)
-    (println (messages/t :classified-error/partial-work))
-    (doseq [work completed-work]
-      (println (str "  ⏸️  " work)))))
-
-(defn print-external-error-context
+(defn ^{:stratum 2} print-external-error-context
   [completed-work]
   (println (messages/t :classified-error/external-context))
   (when (seq completed-work)
@@ -145,23 +153,7 @@
     (doseq [work completed-work]
       (println (str "  " (style "✅" :foreground :green) " " work)))))
 
-(defn print-error-header-by-type
-  [error-type completed-work]
-  (case error-type
-    :agent-backend (print-agent-backend-error-header completed-work)
-    :task-code (print-task-code-error-header)
-    :external (print-external-error-header)
-    (print-generic-error-header)))
-
-(defn print-error-context
-  [error-type completed-work]
-  (case error-type
-    :agent-backend (print-agent-backend-error-context completed-work)
-    :task-code (print-task-code-error-context completed-work)
-    :external (print-external-error-context completed-work)
-    nil))
-
-(defn print-error-report-url
+(defn ^{:stratum 2} print-error-report-url
   [report-url vendor]
   (when report-url
     (println)
@@ -170,15 +162,7 @@
                   vendor ":"))
     (println (str "   " report-url))))
 
-(defn get-retry-recommendation
-  [error-type]
-  (case error-type
-    :task-code (messages/t :classified-error/retry-task-code)
-    :external (messages/t :classified-error/retry-external)
-    :agent-backend (messages/t :classified-error/retry-agent-backend)
-    (messages/t :classified-error/retry-generic)))
-
-(defn print-retry-recommendation
+(defn ^{:stratum 2} print-retry-recommendation
   [should-retry error-type completed-work]
   (println)
   (if should-retry
@@ -191,10 +175,28 @@
                    (messages/t :classified-error/no-retry-success)
                    (messages/t :classified-error/no-retry-failure))))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Composite error display
+;------------------------------------------------------------------------------ Layer 3
 
-(defn print-classified-error
+(defn ^{:stratum 3} print-error-header-by-type
+  [error-type completed-work]
+  (case error-type
+    :agent-backend (print-agent-backend-error-header completed-work)
+    :task-code (print-task-code-error-header)
+    :external (print-external-error-header)
+    (print-generic-error-header)))
+
+(defn ^{:stratum 3} print-error-context
+  [error-type completed-work]
+  (case error-type
+    :agent-backend (print-agent-backend-error-context completed-work)
+    :task-code (print-task-code-error-context completed-work)
+    :external (print-external-error-context completed-work)
+    nil))
+
+;------------------------------------------------------------------------------ Layer 4
+
+;; Composite error display
+(defn ^{:stratum 4} print-classified-error
   "Display a classified error with rich formatting."
   [error-classification]
   (when error-classification

--- a/bases/cli/src/ai/miniforge/cli/messages.clj
+++ b/bases/cli/src/ai/miniforge/cli/messages.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.messages
   "Resource-backed message catalog for shared CLI user-facing copy."
   (:require
@@ -24,27 +23,51 @@
    [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
+
 ;; Catalog loading
+(def ^{:stratum 0} default-locale "en-US")
 
-(def default-locale "en-US")
-
-(defn- locale-resource
+(defn- ^{:stratum 0} locale-resource
   [locale]
   (str "config/cli/messages/" locale ".edn"))
 
-(defn- lang->locale
+(defn- ^{:stratum 0} lang->locale
   "Convert POSIX LANG (e.g. 'en_US.UTF-8') to BCP 47 tag (e.g. 'en-US')."
   [lang]
   (when-let [base (some-> lang (str/split #"\.") first not-empty)]
     (str/replace base "_" "-")))
 
-(defn active-locale
+;; Template rendering
+(defn- ^{:stratum 0} render-string
+  [template params]
+  (reduce-kv (fn [rendered key value]
+               (str/replace rendered
+                            (str "{" (name key) "}")
+                            (str value)))
+             template
+             params))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} active-locale
   []
   (or (some-> (System/getenv "MINIFORGE_LOCALE") str/trim not-empty)
       (lang->locale (System/getenv "LANG"))
       default-locale))
 
-(defn catalog
+(defn- ^{:stratum 1} render-value
+  [value params]
+  (cond
+    (string? value) (render-string value params)
+    (vector? value) (mapv #(render-value % params) value)
+    (map? value) (into {} (map (fn [[key entry]]
+                                 [key (render-value entry params)]))
+                     value)
+    :else value))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} catalog
   "Load the active message catalog, falling back to English."
   ([] (catalog (active-locale)))
   ([locale]
@@ -55,29 +78,9 @@
        catalog-data
        (catalog default-locale)))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Template rendering
+;------------------------------------------------------------------------------ Layer 3
 
-(defn- render-string
-  [template params]
-  (reduce-kv (fn [rendered key value]
-               (str/replace rendered
-                            (str "{" (name key) "}")
-                            (str value)))
-             template
-             params))
-
-(defn- render-value
-  [value params]
-  (cond
-    (string? value) (render-string value params)
-    (vector? value) (mapv #(render-value % params) value)
-    (map? value) (into {} (map (fn [[key entry]]
-                                 [key (render-value entry params)]))
-                     value)
-    :else value))
-
-(defn t
+(defn ^{:stratum 3} t
   "Return a rendered message value for `message-key`.
 
    Supports strings, vectors, and maps loaded from EDN resources."

--- a/bases/cli/src/ai/miniforge/cli/observability.clj
+++ b/bases/cli/src/ai/miniforge/cli/observability.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.observability
   "CLI commands for logs, events, and workflow observability.
 
@@ -33,9 +32,10 @@
    [ai.miniforge.cli.messages :as messages]
    [ai.miniforge.logging.interface :as logging]))
 
-;;------------------------------------------------------------------------------ ANSI Colors
+;------------------------------------------------------------------------------ Layer 0
 
-(def ansi-codes
+;;------------------------------------------------------------------------------ ANSI Colors
+(def ^{:stratum 0} ansi-codes
   {:reset "\u001b[0m"
    :bold "\u001b[1m"
    :cyan "\u001b[36m"
@@ -46,18 +46,14 @@
    :blue "\u001b[34m"
    :magenta "\u001b[35m"})
 
-(defn colorize [color text]
-  (str (get ansi-codes color "") text (:reset ansi-codes)))
-
-(defn format-timestamp [inst]
+(defn ^{:stratum 0} format-timestamp [inst]
   (when inst
     (let [formatter (java.time.format.DateTimeFormatter/ofPattern "HH:mm:ss.SSS")]
       (.format (java.time.LocalDateTime/ofInstant inst (java.time.ZoneId/systemDefault))
                formatter))))
 
 ;;------------------------------------------------------------------------------ Layer 0: File Discovery
-
-(defn event-file-path
+(defn ^{:stratum 0} event-file-path
   "Get path to event file for a workflow.
 
    Arguments:
@@ -69,7 +65,7 @@
         event-file (str workflow-id ".edn")]
     (.getPath (io/file events-dir event-file))))
 
-(defn log-file-path
+(defn ^{:stratum 0} log-file-path
   "Get path to log file for a workflow.
 
    Arguments:
@@ -81,7 +77,7 @@
         log-file (str workflow-id ".log")]
     (.getPath (io/file logs-dir log-file))))
 
-(defn find-log-files
+(defn ^{:stratum 0} find-log-files
   "Find all log files in the active CLI app logs directory.
 
    Returns: Vector of file paths sorted by modification time (newest first)"
@@ -95,7 +91,7 @@
            (mapv #(.getAbsolutePath %)))
       [])))
 
-(defn find-event-stream-files
+(defn ^{:stratum 0} find-event-stream-files
   "Find event stream files (workflow execution events).
 
    Returns: Vector of file paths sorted by modification time (newest first)"
@@ -109,9 +105,8 @@
            (mapv #(.getAbsolutePath %)))
       [])))
 
-;;------------------------------------------------------------------------------ Layer 1: Log Parsing
-
-(defn parse-log-line
+;; Log Parsing
+(defn ^{:stratum 0} parse-log-line
   "Parse a single log line (EDN format).
 
    Arguments:
@@ -125,7 +120,137 @@
       (catch Exception _
         nil))))
 
-(defn format-log-entry
+;; Tailing Helpers
+(defn ^{:stratum 0} show-last-n-lines
+  "Show last N lines from a file without following.
+
+   Arguments:
+     file-path - Path to file
+     parse-fn - Function to parse each line
+     format-fn - Function to format parsed entry
+     lines - Number of lines to show
+     filter-fn - Optional predicate to filter entries"
+  [file-path parse-fn format-fn lines & [filter-fn]]
+  (let [file (io/file file-path)
+        filter-fn (or filter-fn (constantly true))]
+    (with-open [rdr (io/reader file)]
+      (doseq [line (take-last lines (line-seq rdr))]
+        (when-let [entry (parse-fn line)]
+          (when (filter-fn entry)
+            (println (format-fn entry))))))))
+
+;; Workflow timeline (show)
+(defn- ^{:stratum 0} workflow-events-dir
+  "Path to the per-workflow event directory for a given workflow id."
+  [workflow-id]
+  (io/file (app-config/events-dir) (str workflow-id)))
+
+(defn- ^{:stratum 0} strip-transit-prefix
+  "Transit-json keys arrive as '~:foo/bar'. Strip the prefix so our code
+   can use keyword accessors. Recursive walk over maps + vectors."
+  [x]
+  (cond
+    (map? x)
+    (reduce-kv (fn [acc k v]
+                 (let [k' (if (and (string? k) (.startsWith ^String k "~:"))
+                            (keyword (subs k 2))
+                            k)]
+                   (assoc acc k' (strip-transit-prefix v))))
+               {}
+               x)
+
+    (vector? x)
+    (mapv strip-transit-prefix x)
+
+    (and (string? x) (.startsWith ^String x "~:"))
+    (keyword (subs x 2))
+
+    (and (string? x) (.startsWith ^String x "~t"))
+    (subs x 2)
+
+    (and (string? x) (.startsWith ^String x "~u"))
+    (subs x 2)
+
+    :else x))
+
+(defn- ^{:stratum 0} ts-short
+  "Render the :event/timestamp field (may be a plain string after transit
+   stripping) as HH:MM:SS."
+  [ts]
+  (let [s (str ts)]
+    (cond
+      (re-find #"\d\d:\d\d:\d\d" s)
+      (first (re-find #"(\d\d:\d\d:\d\d)" s))
+      :else
+      (subs s 0 (min 8 (count s))))))
+
+(defn- ^{:stratum 0} summarize-event
+  "One-line summary for a single event. Emphasizes tool names, phase
+   outcomes, DAG decisions."
+  [ev]
+  (let [t (:event/type ev)
+        phase (:workflow/phase ev)
+        tool (:tool/name ev)
+        tool-names (:tool/names ev)
+        dag-outcome (:dag/outcome ev)
+        dag-reason (:dag/reason ev)
+        outcome (:phase/outcome ev)
+        duration (:phase/duration-ms ev)
+        err (or (:phase/error ev)
+                (get-in ev [:dag/diagnostic :result/error :error/message]))]
+    (cond
+      (= :workflow/phase-started t)
+      (str "→ " (some-> phase name) " started")
+
+      (= :workflow/phase-completed t)
+      (str "✓ " (some-> phase name) " " (some-> outcome name)
+           (when duration (format " (%.1fs)" (/ duration 1000.0)))
+           (when err (str " — " (subs (str err) 0 (min 160 (count (str err)))))))
+
+      (= :agent/tool-call t)
+      (str "  • tool " (or tool
+                           (when (seq tool-names) (str/join "," (map str tool-names)))
+                           "(unnamed)"))
+
+      (= :agent/status t)
+      (str "  · " (or (:status/type ev) "status") " — " (:message ev ""))
+
+      (= :agent/chunk t)
+      (str "  … chunk "
+           (if (:chunk/done? ev) "done" "streaming"))
+
+      (= :workflow/dag-considered t)
+      (str "⇒ DAG " (some-> dag-outcome name)
+           (when dag-reason (str " — " (name dag-reason))))
+
+      (= :workflow/started t) "▶ workflow started"
+      (= :workflow/completed t) (str "■ workflow completed — " (some-> (:workflow/status ev) name))
+      (= :workflow/failed t) (str "✗ workflow failed — " (:workflow/failure-reason ev ""))
+
+      :else (str (some-> t name)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} colorize [color text]
+  (str (get ansi-codes color "") text (:reset ansi-codes)))
+
+(defn- ^{:stratum 1} read-workflow-events
+  "Read + parse every .json event file under the workflow directory, sorted
+   by filename (which is timestamp-prefixed)."
+  [dir]
+  (when (.exists ^java.io.File dir)
+    (->> (.listFiles ^java.io.File dir)
+         (filter #(.endsWith (.getName ^java.io.File %) ".json"))
+         (sort-by #(.getName ^java.io.File %))
+         (keep (fn [f]
+                 (try
+                   (let [raw (json/parse-string (slurp f) false)]
+                     (strip-transit-prefix raw))
+                   (catch Exception _e nil)))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} format-log-entry
   "Format a log entry for display.
 
    Arguments:
@@ -152,8 +277,7 @@
            (str " " (colorize :gray (pr-str context)))))))
 
 ;;------------------------------------------------------------------------------ Layer 2: Event Parsing
-
-(defn format-event
+(defn ^{:stratum 2} format-event
   "Format an event for display.
 
    Arguments:
@@ -182,9 +306,8 @@
            (str (colorize :magenta (str "wf-" (subs (str workflow-id) 0 8))) " "))
          (or message (pr-str (dissoc event :event/timestamp :event/type :workflow/id))))))
 
-;;------------------------------------------------------------------------------ Layer 3: File Tailing
-
-(defn tail-file
+;; File Tailing
+(defn ^{:stratum 2} tail-file
   "Tail a file and print each new line.
 
    Arguments:
@@ -222,27 +345,7 @@
       (finally
         (.close raf)))))
 
-;;------------------------------------------------------------------------------ Layer 4: Tailing Helpers
-
-(defn show-last-n-lines
-  "Show last N lines from a file without following.
-
-   Arguments:
-     file-path - Path to file
-     parse-fn - Function to parse each line
-     format-fn - Function to format parsed entry
-     lines - Number of lines to show
-     filter-fn - Optional predicate to filter entries"
-  [file-path parse-fn format-fn lines & [filter-fn]]
-  (let [file (io/file file-path)
-        filter-fn (or filter-fn (constantly true))]
-    (with-open [rdr (io/reader file)]
-      (doseq [line (take-last lines (line-seq rdr))]
-        (when-let [entry (parse-fn line)]
-          (when (filter-fn entry)
-            (println (format-fn entry))))))))
-
-(defn print-stream-header
+(defn ^{:stratum 2} print-stream-header
   "Print header for stream tailing.
 
    Arguments:
@@ -256,7 +359,66 @@
     (println (colorize :gray extra-info)))
   (println (colorize :gray (apply str (repeat 80 "─")))))
 
-(defn tail-stream-file
+;; Command Helpers
+(defn ^{:stratum 2} list-files-command
+  "List files with sizes.
+
+   Arguments:
+     find-fn - Function to find files
+     label - Label for output (e.g., 'log files')"
+  [find-fn label]
+  (let [files (find-fn)]
+    (if (seq files)
+      (do
+        (println (colorize :cyan (messages/t :observability/available-files {:label label})))
+        (doseq [f files]
+          (let [size-mb (/ (.length (io/file f)) 1024.0 1024.0)]
+            (println (messages/t :observability/file-entry {:path f :size (format "%.2f" size-mb)})))))
+      (println (colorize :yellow (messages/t :observability/no-files-found {:label label}))))))
+
+(defn ^{:stratum 2} cat-file-command
+  "Display contents of a file.
+
+   Arguments:
+     file - File path to display"
+  [file]
+  (if file
+    (println (slurp file))
+    (println (colorize :red (messages/t :observability/file-required)))))
+
+(defn ^{:stratum 2} show-events
+  "Render a human-readable timeline for a specific workflow.
+
+   Output per line: HH:MM:SS  summary. Filters are available via opts.
+
+   Opts:
+     :filter     — keyword event-type to include (default: show all)
+     :no-chunks  — drop :agent/chunk events (default: true; too noisy)
+     :no-status  — drop :agent/status events (default: false)"
+  [{:keys [workflow-id filter no-chunks no-status]
+    :or {no-chunks true no-status false}}]
+  (if-not workflow-id
+    (do (println (colorize :red "error: workflow-id is required"))
+        (println "usage: mf events show <workflow-id>"))
+    (let [dir (workflow-events-dir workflow-id)
+          events (read-workflow-events dir)]
+      (if (empty? events)
+        (println (colorize :yellow (str "No events found for workflow " workflow-id
+                                        " (looked in " (.getPath dir) ")")))
+        (let [kept (cond->> events
+                     filter     (clojure.core/filter #(= filter (:event/type %)))
+                     no-chunks  (remove #(= :agent/chunk (:event/type %)))
+                     no-status  (remove #(= :agent/status (:event/type %))))]
+          (println (colorize :cyan (str "Timeline for workflow " workflow-id
+                                        " — " (count kept) " event(s)")))
+          (println (colorize :gray (apply str (repeat 80 "─"))))
+          (doseq [ev kept]
+            (println (colorize :gray (ts-short (:event/timestamp ev)))
+                     (summarize-event ev))))))))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} tail-stream-file
   "Generic file tailing for logs/events.
 
    Arguments:
@@ -285,9 +447,10 @@
         (show-last-n-lines file-path parse-fn format-fn lines filter-fn)))
     (println (colorize :yellow (messages/t :observability/file-not-found {:file-path file-path})))))
 
-;;------------------------------------------------------------------------------ Layer 5: Stream Tailing
+;------------------------------------------------------------------------------ Layer 4
 
-(defn tail-logs
+;; Stream Tailing
+(defn ^{:stratum 4} tail-logs
   "Tail MiniForge logs.
 
    Options:
@@ -324,7 +487,7 @@
       :else
       (println (colorize :yellow (messages/t :observability/no-log-files {:dir (app-config/logs-dir)}))))))
 
-(defn tail-events
+(defn ^{:stratum 4} tail-events
   "Tail MiniForge workflow events in real-time.
 
    Options:
@@ -370,37 +533,10 @@
       :else
       (println (colorize :yellow (messages/t :observability/no-event-files {:dir (app-config/events-dir)}))))))
 
-;;------------------------------------------------------------------------------ Layer 6: Command Helpers
+;------------------------------------------------------------------------------ Layer 5
 
-(defn list-files-command
-  "List files with sizes.
-
-   Arguments:
-     find-fn - Function to find files
-     label - Label for output (e.g., 'log files')"
-  [find-fn label]
-  (let [files (find-fn)]
-    (if (seq files)
-      (do
-        (println (colorize :cyan (messages/t :observability/available-files {:label label})))
-        (doseq [f files]
-          (let [size-mb (/ (.length (io/file f)) 1024.0 1024.0)]
-            (println (messages/t :observability/file-entry {:path f :size (format "%.2f" size-mb)})))))
-      (println (colorize :yellow (messages/t :observability/no-files-found {:label label}))))))
-
-(defn cat-file-command
-  "Display contents of a file.
-
-   Arguments:
-     file - File path to display"
-  [file]
-  (if file
-    (println (slurp file))
-    (println (colorize :red (messages/t :observability/file-required)))))
-
-;;------------------------------------------------------------------------------ Layer 7: CLI Commands
-
-(defn logs-command
+;; CLI Commands
+(defn ^{:stratum 5} logs-command
   "Handle 'mf logs' command.
 
    Subcommands:
@@ -418,142 +554,7 @@
                 (println (colorize :green (messages/t :observability/cleanup-result {:count count}))))
     (println (colorize :red (messages/t :observability/unknown-subcommand {:subcommand subcommand})))))
 
-;;------------------------------------------------------------------------------ Layer 2.5: Workflow timeline (show)
-
-(defn- workflow-events-dir
-  "Path to the per-workflow event directory for a given workflow id."
-  [workflow-id]
-  (io/file (app-config/events-dir) (str workflow-id)))
-
-(defn- strip-transit-prefix
-  "Transit-json keys arrive as '~:foo/bar'. Strip the prefix so our code
-   can use keyword accessors. Recursive walk over maps + vectors."
-  [x]
-  (cond
-    (map? x)
-    (reduce-kv (fn [acc k v]
-                 (let [k' (if (and (string? k) (.startsWith ^String k "~:"))
-                            (keyword (subs k 2))
-                            k)]
-                   (assoc acc k' (strip-transit-prefix v))))
-               {}
-               x)
-
-    (vector? x)
-    (mapv strip-transit-prefix x)
-
-    (and (string? x) (.startsWith ^String x "~:"))
-    (keyword (subs x 2))
-
-    (and (string? x) (.startsWith ^String x "~t"))
-    (subs x 2)
-
-    (and (string? x) (.startsWith ^String x "~u"))
-    (subs x 2)
-
-    :else x))
-
-(defn- read-workflow-events
-  "Read + parse every .json event file under the workflow directory, sorted
-   by filename (which is timestamp-prefixed)."
-  [dir]
-  (when (.exists ^java.io.File dir)
-    (->> (.listFiles ^java.io.File dir)
-         (filter #(.endsWith (.getName ^java.io.File %) ".json"))
-         (sort-by #(.getName ^java.io.File %))
-         (keep (fn [f]
-                 (try
-                   (let [raw (json/parse-string (slurp f) false)]
-                     (strip-transit-prefix raw))
-                   (catch Exception _e nil)))))))
-
-(defn- ts-short
-  "Render the :event/timestamp field (may be a plain string after transit
-   stripping) as HH:MM:SS."
-  [ts]
-  (let [s (str ts)]
-    (cond
-      (re-find #"\d\d:\d\d:\d\d" s)
-      (first (re-find #"(\d\d:\d\d:\d\d)" s))
-      :else
-      (subs s 0 (min 8 (count s))))))
-
-(defn- summarize-event
-  "One-line summary for a single event. Emphasizes tool names, phase
-   outcomes, DAG decisions."
-  [ev]
-  (let [t (:event/type ev)
-        phase (:workflow/phase ev)
-        tool (:tool/name ev)
-        tool-names (:tool/names ev)
-        dag-outcome (:dag/outcome ev)
-        dag-reason (:dag/reason ev)
-        outcome (:phase/outcome ev)
-        duration (:phase/duration-ms ev)
-        err (or (:phase/error ev)
-                (get-in ev [:dag/diagnostic :result/error :error/message]))]
-    (cond
-      (= :workflow/phase-started t)
-      (str "→ " (some-> phase name) " started")
-
-      (= :workflow/phase-completed t)
-      (str "✓ " (some-> phase name) " " (some-> outcome name)
-           (when duration (format " (%.1fs)" (/ duration 1000.0)))
-           (when err (str " — " (subs (str err) 0 (min 160 (count (str err)))))))
-
-      (= :agent/tool-call t)
-      (str "  • tool " (or tool
-                           (when (seq tool-names) (str/join "," (map str tool-names)))
-                           "(unnamed)"))
-
-      (= :agent/status t)
-      (str "  · " (or (:status/type ev) "status") " — " (:message ev ""))
-
-      (= :agent/chunk t)
-      (str "  … chunk "
-           (if (:chunk/done? ev) "done" "streaming"))
-
-      (= :workflow/dag-considered t)
-      (str "⇒ DAG " (some-> dag-outcome name)
-           (when dag-reason (str " — " (name dag-reason))))
-
-      (= :workflow/started t) "▶ workflow started"
-      (= :workflow/completed t) (str "■ workflow completed — " (some-> (:workflow/status ev) name))
-      (= :workflow/failed t) (str "✗ workflow failed — " (:workflow/failure-reason ev ""))
-
-      :else (str (some-> t name)))))
-
-(defn show-events
-  "Render a human-readable timeline for a specific workflow.
-
-   Output per line: HH:MM:SS  summary. Filters are available via opts.
-
-   Opts:
-     :filter     — keyword event-type to include (default: show all)
-     :no-chunks  — drop :agent/chunk events (default: true; too noisy)
-     :no-status  — drop :agent/status events (default: false)"
-  [{:keys [workflow-id filter no-chunks no-status]
-    :or {no-chunks true no-status false}}]
-  (if-not workflow-id
-    (do (println (colorize :red "error: workflow-id is required"))
-        (println "usage: mf events show <workflow-id>"))
-    (let [dir (workflow-events-dir workflow-id)
-          events (read-workflow-events dir)]
-      (if (empty? events)
-        (println (colorize :yellow (str "No events found for workflow " workflow-id
-                                        " (looked in " (.getPath dir) ")")))
-        (let [kept (cond->> events
-                     filter     (clojure.core/filter #(= filter (:event/type %)))
-                     no-chunks  (remove #(= :agent/chunk (:event/type %)))
-                     no-status  (remove #(= :agent/status (:event/type %))))]
-          (println (colorize :cyan (str "Timeline for workflow " workflow-id
-                                        " — " (count kept) " event(s)")))
-          (println (colorize :gray (apply str (repeat 80 "─"))))
-          (doseq [ev kept]
-            (println (colorize :gray (ts-short (:event/timestamp ev)))
-                     (summarize-event ev))))))))
-
-(defn events-command
+(defn ^{:stratum 5} events-command
   "Handle 'mf events' command.
 
    Subcommands:
@@ -572,14 +573,15 @@
                          :no-status no-status})
     (println (colorize :red (messages/t :observability/unknown-subcommand {:subcommand subcommand})))))
 
-;;------------------------------------------------------------------------------ Public API
+;------------------------------------------------------------------------------ Layer 6
 
-(defn handle-logs
+;;------------------------------------------------------------------------------ Public API
+(defn ^{:stratum 6} handle-logs
   "Entry point for 'mf logs' command."
   [args]
   (logs-command args))
 
-(defn handle-events
+(defn ^{:stratum 6} handle-events
   "Entry point for 'mf events' command."
   [args]
   (events-command args))

--- a/bases/cli/src/ai/miniforge/cli/resource_config.clj
+++ b/bases/cli/src/ai/miniforge/cli/resource_config.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.resource-config
   "Helpers for resource-backed CLI configuration and messages."
   (:require
@@ -23,9 +22,9 @@
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Resource loading
 
-(defn resource-precedence
+;; Resource loading
+(defn ^{:stratum 0} resource-precedence
   "Sort classpath resources so base defaults load before component/project overrides."
   [resource]
   (let [path (str resource)]
@@ -35,11 +34,13 @@
       (str/includes? path "/projects/") 2
       :else 3)))
 
-(defn read-edn-resource
+(defn ^{:stratum 0} read-edn-resource
   [resource]
   (-> resource slurp edn/read-string))
 
-(defn merged-resource-config
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} merged-resource-config
   "Load and merge EDN resources from the classpath.
 
    `section-key` extracts the relevant sub-map from each resource when provided."

--- a/bases/cli/src/ai/miniforge/cli/runtime_env.clj
+++ b/bases/cli/src/ai/miniforge/cli/runtime_env.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.runtime-env
   "MINIFORGE_RUNTIME environment sourcing for container-runtime selection.
 
@@ -26,18 +25,24 @@
   (:require
    [clojure.string :as str]))
 
-(def runtime-env-var
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} runtime-env-var
   "MINIFORGE_RUNTIME environment variable — overrides file config per
    N11-delta §2.1."
   "MINIFORGE_RUNTIME")
 
-(defn env-runtime-kind
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} env-runtime-kind
   "Read MINIFORGE_RUNTIME from the environment and coerce to a keyword.
    Returns nil when unset or blank."
   []
   (some-> (System/getenv runtime-env-var) str/trim not-empty keyword))
 
-(defn selection-config
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} selection-config
   "Build the config map passed to the runtime selector: `base` (or {} when
    called with no args) with the env override applied on top. The env is
    read once — the predicate and the assoc must see the same value."

--- a/bases/cli/src/ai/miniforge/cli/spec_parser.clj
+++ b/bases/cli/src/ai/miniforge/cli/spec_parser.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.spec-parser
   "CLI entry point for spec parsing.
 
@@ -25,10 +24,11 @@
   (:require
    [ai.miniforge.spec-parser.interface :as spec-parser]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;------------------------------------------------------------------------------ Public API
 ;; Thin delegation to spec-parser component
-
-(defn parse-spec-file
+(defn ^{:stratum 0} parse-spec-file
   "Parse a workflow specification file and normalize to canonical :spec/* format.
 
    Supported formats:
@@ -41,7 +41,7 @@
   [path]
   (spec-parser/parse-spec-file path))
 
-(defn validate-spec
+(defn ^{:stratum 0} validate-spec
   "Validate a normalized spec against the Malli SpecPayload schema.
 
    Returns:

--- a/bases/cli/src/ai/miniforge/cli/tui.clj
+++ b/bases/cli/src/ai/miniforge/cli/tui.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.tui
   "Two-pane TUI components for the fleet dashboard.
 
@@ -33,9 +32,9 @@
    [cheshire.core :as json]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Terminal utilities
 
-(def ansi-colors
+;; Terminal utilities
+(def ^{:stratum 0} ansi-colors
   "ANSI color codes for foreground colors."
   {:red     "31"
    :green   "32"
@@ -53,7 +52,7 @@
    :bright-cyan "96"
    :bright-white "97"})
 
-(def ansi-bg-colors
+(def ^{:stratum 0} ansi-bg-colors
   "ANSI color codes for background colors."
   {:bg-black "40"
    :bg-red "41"
@@ -66,35 +65,15 @@
    :bg-bright-blue "104"
    :bg-bright-cyan "106"})
 
-(defn style
-  "Apply ANSI styling to text.
-
-   Options:
-   - :fg - Foreground color keyword
-   - :bg - Background color keyword (e.g. :bg-blue)
-   - :bold - Bold text
-   - :dim - Dim text
-   - :reverse - Reverse video (swap fg/bg)"
-  [text & {:keys [fg bg bold dim reverse]}]
-  (let [codes (cond-> []
-                bold (conj "1")
-                dim (conj "2")
-                reverse (conj "7")
-                fg (conj (get ansi-colors fg "37"))
-                bg (conj (get ansi-bg-colors bg)))]
-    (if (seq codes)
-      (str "\033[" (str/join ";" (remove nil? codes)) "m" text "\033[0m")
-      text)))
-
-(defn clear-screen []
+(defn ^{:stratum 0} clear-screen []
   (print "\033[2J\033[H")
   (flush))
 
-(defn move-cursor [row col]
+(defn ^{:stratum 0} move-cursor [row col]
   (print (str "\033[" row ";" col "H"))
   (flush))
 
-(defn get-terminal-size
+(defn ^{:stratum 0} get-terminal-size
   "Get terminal dimensions [width height]."
   []
   (try
@@ -102,30 +81,28 @@
           [h w] (str/split (str/trim (:out result)) #" ")]
       [(Integer/parseInt w) (Integer/parseInt h)])
     (catch Exception _
-      [120 40]))) ; fallback
+      [120 40])))  ; fallback
 
-(defn hide-cursor []
+(defn ^{:stratum 0} hide-cursor []
   (print "\033[?25l")
   (flush))
 
-(defn show-cursor []
+(defn ^{:stratum 0} show-cursor []
   (print "\033[?25h")
   (flush))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Risk/complexity scoring
-
-(def risk-colors
+(def ^{:stratum 0} risk-colors
   {:low :green
    :medium :yellow
    :high :red})
 
-(def risk-icons
+(def ^{:stratum 0} risk-icons
   {:low "●"
    :medium "◐"
    :high "◉"})
 
-(defn analyze-pr-risk
+(defn ^{:stratum 0} analyze-pr-risk
   "Analyze a PR and return risk assessment.
 
    This is a heuristic-based analysis. In the future, this could
@@ -202,25 +179,175 @@
      :suggested-action suggested-action
      :reasons reasons}))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Two-pane layout rendering
-
-(defn repeat-char [c n]
+(defn ^{:stratum 0} repeat-char [c n]
   (apply str (repeat n c)))
 
-(defn truncate [s max-len]
+(defn ^{:stratum 0} truncate [s max-len]
   (if (> (count s) max-len)
     (str (subs s 0 (- max-len 1)) "…")
     s))
 
-(defn pad-right [s width]
+(defn ^{:stratum 0} render-repo-item
+  "Render a repo as a tree item."
+  [repo pr-count expanded? selected?]
+  {:label (str repo " (" pr-count ")")
+   :selected? selected?
+   :expanded? expanded?
+   :has-children? (pos? pr-count)
+   :depth 0})
+
+;; Interactive navigation state
+(defn ^{:stratum 0} create-nav-state
+  "Create initial navigation state for the two-pane view."
+  [repos-with-prs]
+  {:repos repos-with-prs
+   :expanded-repos #{}
+   :selected-index 0
+   :flat-items [] ; computed from repos + expansion state
+   :mode :browse})  ; :browse, :detail, :chat
+
+(defn ^{:stratum 0} flatten-nav-items
+  "Flatten repos and PRs into a navigable list based on expansion state."
+  [{:keys [repos expanded-repos]}]
+  (vec (mapcat (fn [{:keys [repo prs]}]
+                 (let [expanded? (contains? expanded-repos repo)]
+                   (concat [{:type :repo :repo repo :prs prs :expanded? expanded?}]
+                           (when expanded?
+                             (map #(assoc % :type :pr :repo repo) prs)))))
+               repos)))
+
+(defn ^{:stratum 0} nav-up [state]
+  (update state :selected-index #(max 0 (dec %))))
+
+(defn ^{:stratum 0} nav-down [state]
+  (let [max-idx (dec (count (:flat-items state)))]
+    (update state :selected-index #(min max-idx (inc %)))))
+
+(defn ^{:stratum 0} get-selected-item [state]
+  (get-in state [:flat-items (:selected-index state)]))
+
+;; GitHub integration
+(defn ^{:stratum 0} fetch-pr-details
+  "Fetch detailed PR info including additions/deletions."
+  [repo number]
+  (let [result (process/sh "gh" "pr" "view" (str number)
+                           "--repo" repo
+                           "--json" "number,title,state,author,url,additions,deletions,changedFiles,body")]
+    (when (zero? (:exit result))
+      (try
+        (json/parse-string (:out result) true)
+        (catch Exception _ nil)))))
+
+;; Keyboard input handling
+(defn ^{:stratum 0} map-char-to-key
+  "Map a character to a key command."
+  [c]
+  (case c
+    \j :down
+    \k :up
+    \q :quit
+    \a :approve
+    \r :reject
+    \d :diff
+    \c :chat
+    \o :open
+    \b :batch-approve
+    \n :next-risky
+    \space :toggle
+    \return :enter
+    \newline :enter
+    ;; Default
+    c))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} style
+  "Apply ANSI styling to text.
+
+   Options:
+   - :fg - Foreground color keyword
+   - :bg - Background color keyword (e.g. :bg-blue)
+   - :bold - Bold text
+   - :dim - Dim text
+   - :reverse - Reverse video (swap fg/bg)"
+  [text & {:keys [fg bg bold dim reverse]}]
+  (let [codes (cond-> []
+                bold (conj "1")
+                dim (conj "2")
+                reverse (conj "7")
+                fg (conj (get ansi-colors fg "37"))
+                bg (conj (get ansi-bg-colors bg)))]
+    (if (seq codes)
+      (str "\033[" (str/join ";" (remove nil? codes)) "m" text "\033[0m")
+      text)))
+
+(defn ^{:stratum 1} pad-right [s width]
   (let [s (or s "")
         len (count s)]
     (if (>= len width)
       (subs s 0 width)
       (str s (repeat-char " " (- width len))))))
 
-(defn render-box
+(defn ^{:stratum 1} render-pr-list-item
+  "Render a PR as a tree item."
+  [{:keys [number title]} analysis selected?]
+  {:label (str "#" number " " (truncate title 35))
+   :selected? selected?
+   :expanded? false
+   :has-children? false
+   :depth 1
+   :risk (:risk analysis)})
+
+(defn ^{:stratum 1} update-flat-items
+  "Recompute flat items after state change."
+  [state]
+  (assoc state :flat-items (flatten-nav-items state)))
+
+(defn ^{:stratum 1} fetch-prs-for-repos
+  "Fetch PRs for multiple repos with analysis."
+  [repos]
+  (vec (for [repo repos]
+         (let [result (process/sh "gh" "pr" "list" "--repo" repo
+                                  "--json" "number,title,state,author,url,additions,deletions,changedFiles"
+                                  "--limit" "20")
+               prs (when (zero? (:exit result))
+                     (try
+                       (json/parse-string (:out result) true)
+                       (catch Exception _ [])))]
+           {:repo repo
+            :prs (vec (for [pr prs]
+                        (assoc pr
+                               :repo repo
+                               :analysis (analyze-pr-risk pr))))}))))
+
+(defn ^{:stratum 1} read-key
+  "Read a single keypress without requiring Enter.
+   Uses stty raw mode with direct /dev/tty access.
+   Returns keyword for special keys, char otherwise."
+  []
+  (try
+    ;; Set terminal to raw mode, read one char, restore
+    (process/sh "stty" "raw" "-echo" :in (java.io.File. "/dev/tty"))
+    (let [tty-stream (java.io.FileInputStream. "/dev/tty")
+          char-code (.read tty-stream)]
+      (.close tty-stream)
+      (process/sh "stty" "cooked" "echo" :in (java.io.File. "/dev/tty"))
+      (cond
+        ;; EOF or error
+        (neg? char-code) :escape
+        ;; Escape key (ASCII 27)
+        (= char-code 27) :escape
+        ;; Map character to command
+        :else (map-char-to-key (char char-code))))
+    (catch Exception _
+      ;; Try to restore terminal on error
+      (try (process/sh "stty" "cooked" "echo" :in (java.io.File. "/dev/tty")) (catch Exception _))
+      :error)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} render-box
   "Render a box with title and content lines.
    Uses blue borders for XTreeGold-style visibility.
    Returns vector of strings (one per line)."
@@ -243,7 +370,7 @@
                                                 (style "│" :fg :blue)))))]
     (vec (concat [top-line] padded-lines [bottom-line]))))
 
-(defn render-tree-item
+(defn ^{:stratum 2} render-tree-item
   "Render a single tree item with proper indentation and icons.
    Uses XTreeGold-inspired blue highlight for selected items."
   [{:keys [label selected? expanded? has-children? depth risk]} width]
@@ -265,7 +392,50 @@
       ;; Normal: bright cyan text for visibility
       (style line-content :fg :bright-cyan))))
 
-(defn render-two-pane
+;; PR detail rendering
+(defn ^{:stratum 2} render-pr-detail
+  "Render detailed view of a PR for the right pane."
+  [{:keys [number title author state repo] :as _pr} analysis]
+  (let [{:keys [risk complexity summary suggested-action reasons]} analysis]
+    {:title (str "PR #" number " " (truncate repo 30))
+     :sections
+     [{:title "OVERVIEW"
+       :content [(str "Title: " title)
+                 (str "Author: " (get author :login "unknown"))
+                 (str "State: " state)
+                 (str "Risk: " (style (str/upper-case (name risk))
+                                      :fg (get risk-colors risk :white) :bold true)
+                      "  Complexity: " (str/upper-case (name complexity)))]}
+
+      {:title "AI SUMMARY"
+       :content [summary
+                 ""
+                 (when (seq reasons)
+                   (str "Factors: " (str/join ", " reasons)))]}
+
+      {:title "SUGGESTED ACTION"
+       :content [(style suggested-action
+                        :fg (case risk :low :green :medium :yellow :red)
+                        :bold true)]}
+
+      {:title "QUICK ACTIONS"
+       :content ["[a] Approve   [r] Reject   [d] View diff"
+                 "[c] Chat      [o] Open in browser"
+                 "[j/k] Navigate   [q] Back"]}]}))
+
+(defn ^{:stratum 2} toggle-expand [state]
+  (let [item (get-in state [:flat-items (:selected-index state)])]
+    (if (= :repo (:type item))
+      (-> state
+          (update :expanded-repos #(if (contains? % (:repo item))
+                                     (disj % (:repo item))
+                                     (conj % (:repo item))))
+          update-flat-items)
+      state)))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} render-two-pane
   "Render a two-pane layout with XTreeGold-inspired color scheme.
 
    left-pane: {:title string :items [{:label :selected? :expanded? :has-children? :depth :risk}]}
@@ -306,183 +476,6 @@
     (str/join "\n" (concat combined-lines
                            [(style status-line :fg :bright-white :bg :bg-blue)]
                            [(style hints-line :fg :bright-cyan :bold true)]))))
-
-;------------------------------------------------------------------------------ Layer 3
-;; PR detail rendering
-
-(defn render-pr-detail
-  "Render detailed view of a PR for the right pane."
-  [{:keys [number title author state repo] :as _pr} analysis]
-  (let [{:keys [risk complexity summary suggested-action reasons]} analysis]
-    {:title (str "PR #" number " " (truncate repo 30))
-     :sections
-     [{:title "OVERVIEW"
-       :content [(str "Title: " title)
-                 (str "Author: " (get author :login "unknown"))
-                 (str "State: " state)
-                 (str "Risk: " (style (str/upper-case (name risk))
-                                      :fg (get risk-colors risk :white) :bold true)
-                      "  Complexity: " (str/upper-case (name complexity)))]}
-
-      {:title "AI SUMMARY"
-       :content [summary
-                 ""
-                 (when (seq reasons)
-                   (str "Factors: " (str/join ", " reasons)))]}
-
-      {:title "SUGGESTED ACTION"
-       :content [(style suggested-action
-                        :fg (case risk :low :green :medium :yellow :red)
-                        :bold true)]}
-
-      {:title "QUICK ACTIONS"
-       :content ["[a] Approve   [r] Reject   [d] View diff"
-                 "[c] Chat      [o] Open in browser"
-                 "[j/k] Navigate   [q] Back"]}]}))
-
-(defn render-pr-list-item
-  "Render a PR as a tree item."
-  [{:keys [number title]} analysis selected?]
-  {:label (str "#" number " " (truncate title 35))
-   :selected? selected?
-   :expanded? false
-   :has-children? false
-   :depth 1
-   :risk (:risk analysis)})
-
-(defn render-repo-item
-  "Render a repo as a tree item."
-  [repo pr-count expanded? selected?]
-  {:label (str repo " (" pr-count ")")
-   :selected? selected?
-   :expanded? expanded?
-   :has-children? (pos? pr-count)
-   :depth 0})
-
-;------------------------------------------------------------------------------ Layer 4
-;; Interactive navigation state
-
-(defn create-nav-state
-  "Create initial navigation state for the two-pane view."
-  [repos-with-prs]
-  {:repos repos-with-prs
-   :expanded-repos #{}
-   :selected-index 0
-   :flat-items [] ; computed from repos + expansion state
-   :mode :browse}) ; :browse, :detail, :chat
-
-(defn flatten-nav-items
-  "Flatten repos and PRs into a navigable list based on expansion state."
-  [{:keys [repos expanded-repos]}]
-  (vec (mapcat (fn [{:keys [repo prs]}]
-                 (let [expanded? (contains? expanded-repos repo)]
-                   (concat [{:type :repo :repo repo :prs prs :expanded? expanded?}]
-                           (when expanded?
-                             (map #(assoc % :type :pr :repo repo) prs)))))
-               repos)))
-
-(defn update-flat-items
-  "Recompute flat items after state change."
-  [state]
-  (assoc state :flat-items (flatten-nav-items state)))
-
-(defn nav-up [state]
-  (update state :selected-index #(max 0 (dec %))))
-
-(defn nav-down [state]
-  (let [max-idx (dec (count (:flat-items state)))]
-    (update state :selected-index #(min max-idx (inc %)))))
-
-(defn toggle-expand [state]
-  (let [item (get-in state [:flat-items (:selected-index state)])]
-    (if (= :repo (:type item))
-      (-> state
-          (update :expanded-repos #(if (contains? % (:repo item))
-                                     (disj % (:repo item))
-                                     (conj % (:repo item))))
-          update-flat-items)
-      state)))
-
-(defn get-selected-item [state]
-  (get-in state [:flat-items (:selected-index state)]))
-
-;------------------------------------------------------------------------------ Layer 5
-;; GitHub integration
-
-(defn fetch-pr-details
-  "Fetch detailed PR info including additions/deletions."
-  [repo number]
-  (let [result (process/sh "gh" "pr" "view" (str number)
-                           "--repo" repo
-                           "--json" "number,title,state,author,url,additions,deletions,changedFiles,body")]
-    (when (zero? (:exit result))
-      (try
-        (json/parse-string (:out result) true)
-        (catch Exception _ nil)))))
-
-(defn fetch-prs-for-repos
-  "Fetch PRs for multiple repos with analysis."
-  [repos]
-  (vec (for [repo repos]
-         (let [result (process/sh "gh" "pr" "list" "--repo" repo
-                                  "--json" "number,title,state,author,url,additions,deletions,changedFiles"
-                                  "--limit" "20")
-               prs (when (zero? (:exit result))
-                     (try
-                       (json/parse-string (:out result) true)
-                       (catch Exception _ [])))]
-           {:repo repo
-            :prs (vec (for [pr prs]
-                        (assoc pr
-                               :repo repo
-                               :analysis (analyze-pr-risk pr))))}))))
-
-;------------------------------------------------------------------------------ Layer 6
-;; Keyboard input handling
-
-(defn map-char-to-key
-  "Map a character to a key command."
-  [c]
-  (case c
-    \j :down
-    \k :up
-    \q :quit
-    \a :approve
-    \r :reject
-    \d :diff
-    \c :chat
-    \o :open
-    \b :batch-approve
-    \n :next-risky
-    \space :toggle
-    \return :enter
-    \newline :enter
-    ;; Default
-    c))
-
-(defn read-key
-  "Read a single keypress without requiring Enter.
-   Uses stty raw mode with direct /dev/tty access.
-   Returns keyword for special keys, char otherwise."
-  []
-  (try
-    ;; Set terminal to raw mode, read one char, restore
-    (process/sh "stty" "raw" "-echo" :in (java.io.File. "/dev/tty"))
-    (let [tty-stream (java.io.FileInputStream. "/dev/tty")
-          char-code (.read tty-stream)]
-      (.close tty-stream)
-      (process/sh "stty" "cooked" "echo" :in (java.io.File. "/dev/tty"))
-      (cond
-        ;; EOF or error
-        (neg? char-code) :escape
-        ;; Escape key (ASCII 27)
-        (= char-code 27) :escape
-        ;; Map character to command
-        :else (map-char-to-key (char char-code))))
-    (catch Exception _
-      ;; Try to restore terminal on error
-      (try (process/sh "stty" "cooked" "echo" :in (java.io.File. "/dev/tty")) (catch Exception _))
-      :error)))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/bases/cli/src/ai/miniforge/cli/web.clj
+++ b/bases/cli/src/ai/miniforge/cli/web.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.web
   "Fleet dashboard web server."
   (:require
@@ -27,17 +26,28 @@
    [ai.miniforge.cli.web.handlers :as handlers]
    [ai.miniforge.cli.web.sse :as sse]))
 
-(def ^:dynamic *port* 8787)
-(def server-atom (atom nil))
+;------------------------------------------------------------------------------ Layer 0
 
-(defn parse-repos-from-config []
+(def ^{:stratum 0} ^:dynamic *port* 8787)
+
+(def ^{:stratum 0} server-atom (atom nil))
+
+(defn ^{:stratum 0} parse-repos-from-config []
   (-> (app-config/config-path)
       java.io.File.
       (as-> f (when (.exists f) (slurp f)))
       (some-> edn/read-string (get-in [:fleet :repos]))
       (or [])))
 
-(defn handler [{:keys [uri request-method] :as req}]
+(def ^{:stratum 0} register-workflow-stream! sse/register!)
+
+(def ^{:stratum 0} unregister-workflow-stream! sse/unregister!)
+
+(def ^{:stratum 0} get-workflow-stream sse/get-stream)
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} handler [{:keys [uri request-method] :as req}]
   (let [repos (parse-repos-from-config)]
     (cond
       (and (= uri "/") (= request-method :get))
@@ -76,17 +86,15 @@
       :else
       (response/not-found "Not found"))))
 
-(def register-workflow-stream! sse/register!)
-(def unregister-workflow-stream! sse/unregister!)
-(def get-workflow-stream sse/get-stream)
-
-(defn stop-server! []
+(defn ^{:stratum 1} stop-server! []
   (when-let [server @server-atom]
     (server)
     (reset! server-atom nil)
     (println "Server stopped.")))
 
-(defn start-server! [& {:keys [port] :or {port *port*}}]
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} start-server! [& {:keys [port] :or {port *port*}}]
   (when @server-atom (stop-server!))
   (println (str "Starting fleet dashboard at http://localhost:" port))
   (reset! server-atom (http/run-server handler {:port port}))

--- a/bases/cli/src/ai/miniforge/cli/web/components.clj
+++ b/bases/cli/src/ai/miniforge/cli/web/components.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.web.components
   "HTML components for dashboard."
   (:require
@@ -28,43 +27,45 @@
    [ai.miniforge.cli.web.risk :as risk]
    [ai.miniforge.cli.web.fleet :as fleet]))
 
-(def ^:const language-tag
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:const language-tag
   "en")
 
-(def ^:const page-title-key
+(def ^{:stratum 0} ^:const page-title-key
   :web-ui/page-title)
 
-(def ^:const selected-class
+(def ^{:stratum 0} ^:const selected-class
   "selected")
 
-(def ^:const sidebar-refresh-style
+(def ^{:stratum 0} ^:const sidebar-refresh-style
   "padding: 4px 8px; font-size: 11px;")
 
-(def ^:const batch-approve-style
+(def ^{:stratum 0} ^:const batch-approve-style
   "padding: 6px 12px;")
 
-(def ^:const empty-state-style
+(def ^{:stratum 0} ^:const empty-state-style
   "margin-top: 8px;")
 
-(def ^:const ai-placeholder-style
+(def ^{:stratum 0} ^:const ai-placeholder-style
   "color: var(--text-muted); font-style: italic; padding: 12px;")
 
-(def ^:const summary-message-style
+(def ^{:stratum 0} ^:const summary-message-style
   "margin-top: 16px;")
 
-(def ^:const factors-style
+(def ^{:stratum 0} ^:const factors-style
   "margin-top: 8px; color: var(--text-secondary);")
 
-(def ^:const chat-empty-style
+(def ^{:stratum 0} ^:const chat-empty-style
   "color: var(--text-muted); font-size: 13px;")
 
-(def ^:const chat-response-style
+(def ^{:stratum 0} ^:const chat-response-style
   "white-space: pre-wrap; word-wrap: break-word;")
 
-(def css-styles
+(def ^{:stratum 0} css-styles
   (slurp (io/file "bases/cli/resources/dashboard.css")))
 
-(def ^:const keyboard-shortcuts-script
+(def ^{:stratum 0} ^:const keyboard-shortcuts-script
   "
         document.addEventListener('keydown', function(e) {
           if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
@@ -82,13 +83,59 @@
         });
       ")
 
-(defn- t
+(defn- ^{:stratum 0} t
   ([message-key]
    (messages/t message-key))
   ([message-key params]
    (messages/t message-key params)))
 
-(defn page [body]
+(defn ^{:stratum 0} toast [message success?]
+  (h/html
+   [:div.toast {:class (if success? "toast-success" "toast-error")
+                :hx-swap-oob "true"
+                :_ "on load wait 3s then remove me"}
+    message]))
+
+(def ^{:stratum 0} status-indicator
+  status-components/status-indicator)
+
+(def ^{:stratum 0} workflow-status-icon
+  status-components/workflow-status-icon)
+
+(def ^{:stratum 0} workflow-status
+  status-components/workflow-status)
+
+(defn ^{:stratum 0} pr-url [repo number]
+  (str "/api/pr/" (java.net.URLEncoder/encode repo "UTF-8") "/" number))
+
+(defn- ^{:stratum 0} repo-item-selected?
+  [selected-pr repo number]
+  (and selected-pr
+       (= (:repo selected-pr) repo)
+       (= (:number selected-pr) number)))
+
+(defn- ^{:stratum 0} pr-counts
+  [all-prs]
+  {:total (count all-prs)
+   :low (count (filter #(= :low (get-in % [:analysis :risk])) all-prs))
+   :medium (count (filter #(= :medium (get-in % [:analysis :risk])) all-prs))
+   :high (count (filter #(= :high (get-in % [:analysis :risk])) all-prs))})
+
+(defn- ^{:stratum 0} stat-pill
+  [class-name text]
+  [:span {:class class-name} text])
+
+(defn- ^{:stratum 0} keyboard-hint
+  [prefix-key suffix-key label]
+  [:span
+   [:kbd prefix-key]
+   "/"
+   [:kbd suffix-key]
+   (str " " label)])
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} page [body]
   (str
    "<!DOCTYPE html>"
    (h/html
@@ -103,36 +150,20 @@
       body
       [:script (raw-string keyboard-shortcuts-script)]]])))
 
-(defn toast [message success?]
-  (h/html
-   [:div.toast {:class (if success? "toast-success" "toast-error")
-                :hx-swap-oob "true"
-                :_ "on load wait 3s then remove me"}
-    message]))
-
-(defn chat-message [question response]
+(defn ^{:stratum 1} chat-message [question response]
   (h/html
    [:div
     [:div.chat-message.user question]
     [:div.chat-message.assistant
      [:pre {:style chat-response-style} response]]]))
 
-(def status-indicator
-  status-components/status-indicator)
-
-(def workflow-status-icon
-  status-components/workflow-status-icon)
-
-(def workflow-status
-  status-components/workflow-status)
-
-(defn ai-summary [summary]
+(defn ^{:stratum 1} ai-summary [summary]
   (h/html
    [:div.ai-summary
     [:div.ai-summary-header [:span "🤖"] [:span (t :web-ui/ai-analysis)]]
     [:div.ai-summary-content (:summary summary)]]))
 
-(defn ai-summary-placeholder [repo number]
+(defn ^{:stratum 1} ai-summary-placeholder [repo number]
   (h/html
    [:div
     {:hx-post (str "/api/pr/" (java.net.URLEncoder/encode repo "UTF-8") "/" number "/summary")
@@ -140,13 +171,13 @@
     [:div {:style ai-placeholder-style}
      (t :web-ui/ai-summary-loading)]]))
 
-(defn ai-summary-error [message]
+(defn ^{:stratum 1} ai-summary-error [message]
   (h/html
    [:div.ai-summary
     [:div.ai-summary-header [:span "⚠️"] [:span (t :web-ui/summary-unavailable)]]
     [:div.ai-summary-content {:style "color: var(--text-muted)"} message]]))
 
-(defn empty-detail []
+(defn ^{:stratum 1} empty-detail []
   (h/html
    [:div.empty-state
     [:div.empty-state-icon "📋"]
@@ -154,15 +185,100 @@
     [:p {:style empty-state-style}
      (t :web-ui/empty-detail-body)]]))
 
-(defn- batch-approve-confirm
+(defn- ^{:stratum 1} batch-approve-confirm
   [count]
   (t :web-ui/batch-approve-confirm {:count count}))
 
-(defn- batch-approve-label
+(defn- ^{:stratum 1} batch-approve-label
   [count]
   (t :web-ui/batch-approve-label {:count count}))
 
-(defn fleet-summary [summary]
+(defn- ^{:stratum 1} risk-label
+  [risk-level]
+  (t (case risk-level
+       :low :web-ui/risk-low
+       :medium :web-ui/risk-medium
+       :high :web-ui/risk-high
+       :web-ui/risk-unknown)))
+
+(defn- ^{:stratum 1} recommendation-box
+  [risk-level suggested-action]
+  (let [background-color (get risk/bg-colors risk-level)
+        style-value (str "margin-top: 16px; padding: 12px; border-radius: 6px; background: "
+                         background-color)]
+    [:div {:style style-value}
+     [:strong (t :web-ui/recommendation-prefix)]
+     suggested-action]))
+
+(defn- ^{:stratum 1} action-buttons
+  [repo number url]
+  [:div.actions
+   [:button.btn.btn-success
+    {:hx-post (str (pr-url repo number) "/approve")
+     :hx-target "#toast-container"
+     :hx-swap "innerHTML"}
+    (t :web-ui/approve-button)]
+   [:button.btn.btn-danger
+    {:hx-post (str (pr-url repo number) "/reject")
+     :hx-target "#toast-container"
+     :hx-swap "innerHTML"
+     :hx-prompt (t :web-ui/reject-prompt)}
+    (t :web-ui/reject-button)]
+   [:a.btn.btn-secondary {:href url :target "_blank"}
+    (t :web-ui/open-github-button)]])
+
+(defn- ^{:stratum 1} quick-question-buttons
+  [repo number]
+  (for [{:keys [label prompt]} (t :web-ui/chat-quick-questions)]
+    [:button.quick-question
+     {:hx-post (str (pr-url repo number) "/chat")
+      :hx-target "#chat-messages"
+      :hx-swap "beforeend"
+      :hx-vals (str "{\"question\": \"" prompt "\"}")}
+     label]))
+
+(defn- ^{:stratum 1} repo-pr-item
+  [repo selected-pr {:keys [number title analysis]}]
+  (let [selected? (repo-item-selected? selected-pr repo number)
+        item-class (when selected? selected-class)]
+    [:div.pr-item
+     {:class item-class
+      :hx-get (pr-url repo number)
+      :hx-target "#detail-panel"
+      :hx-swap "innerHTML"}
+     [:span.pr-risk-dot {:class (str "pr-risk-" (name (:risk analysis)))}]
+     [:span.pr-number (str "#" number)]
+     [:span.pr-title title]]))
+
+(defn- ^{:stratum 1} sidebar-header
+  []
+  [:div.sidebar-header
+   [:span (t :web-ui/repositories-heading)]
+   [:button.btn.btn-secondary
+    {:hx-get "/api/refresh"
+     :hx-target "#main-content"
+     :hx-swap "innerHTML"
+     :style sidebar-refresh-style}
+    (t :web-ui/refresh-button)]])
+
+(defn- ^{:stratum 1} fleet-header
+  [fleet-status]
+  [:div.header
+   [:div {:style "display: flex; align-items: center; gap: 16px;"}
+    [:h1 (t :web-ui/fleet-dashboard-heading)]
+    (status-indicator fleet-status)]])
+
+(defn- ^{:stratum 1} keyboard-hints
+  []
+  [:div.keyboard-hints
+   (keyboard-hint "j" "k" (t :web-ui/hint-navigate))
+   [:span [:kbd "r"] (str " " (t :web-ui/hint-refresh))]
+   [:span [:kbd "a"] (str " " (t :web-ui/hint-approve))]
+   [:span [:kbd "x"] (str " " (t :web-ui/hint-reject))]])
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} fleet-summary [summary]
   (let [{:keys [total recommendation high-risk medium-risk low-risk]} summary
         icon (cond
                (pos? (:count high-risk)) "🚨"
@@ -184,18 +300,7 @@
            :hx-confirm (batch-approve-confirm (:count low-risk))}
           (batch-approve-label (:count low-risk))])]])))
 
-(defn pr-url [repo number]
-  (str "/api/pr/" (java.net.URLEncoder/encode repo "UTF-8") "/" number))
-
-(defn- risk-label
-  [risk-level]
-  (t (case risk-level
-       :low :web-ui/risk-low
-       :medium :web-ui/risk-medium
-       :high :web-ui/risk-high
-       :web-ui/risk-unknown)))
-
-(defn- detail-header
+(defn- ^{:stratum 2} detail-header
   [risk-level number repo author additions deletions]
   (let [author-login (get author :login (t :web-ui/unknown-author))]
     [:div.detail-header
@@ -209,7 +314,7 @@
       [:span (t :web-ui/author-meta {:author author-login})]
       [:span (t :web-ui/change-meta {:additions additions :deletions deletions})]]]))
 
- (defn- analysis-stats
+(defn- ^{:stratum 2} analysis-stats
   [risk-level complexity total-changes file-count]
   [:div.stats-grid
    [:div.stat-card
@@ -226,64 +331,13 @@
     [:div.stat-card-value file-count]
     [:div.stat-card-label (t :web-ui/files-modified-label)]]])
 
-(defn- recommendation-box
-  [risk-level suggested-action]
-  (let [background-color (get risk/bg-colors risk-level)
-        style-value (str "margin-top: 16px; padding: 12px; border-radius: 6px; background: "
-                         background-color)]
-    [:div {:style style-value}
-     [:strong (t :web-ui/recommendation-prefix)]
-     suggested-action]))
-
-(defn- ai-analysis-section
-  [repo number {:keys [risk complexity summary suggested-action reasons total-changes file-count]}]
-  [:div.section
-   [:div.section-title (t :web-ui/ai-analysis)]
-   (analysis-stats risk complexity total-changes file-count)
-   [:div {:style summary-message-style}
-    [:strong (t :web-ui/summary-prefix)]
-    summary]
-   (when (seq reasons)
-     [:div {:style factors-style}
-      [:strong (t :web-ui/factors-prefix)]
-      (str/join ", " reasons)])
-   (recommendation-box risk suggested-action)
-   [:div#ai-summary-container (ai-summary-placeholder repo number)]])
-
-(defn- action-buttons
-  [repo number url]
-  [:div.actions
-   [:button.btn.btn-success
-    {:hx-post (str (pr-url repo number) "/approve")
-     :hx-target "#toast-container"
-     :hx-swap "innerHTML"}
-    (t :web-ui/approve-button)]
-   [:button.btn.btn-danger
-    {:hx-post (str (pr-url repo number) "/reject")
-     :hx-target "#toast-container"
-     :hx-swap "innerHTML"
-     :hx-prompt (t :web-ui/reject-prompt)}
-    (t :web-ui/reject-button)]
-   [:a.btn.btn-secondary {:href url :target "_blank"}
-    (t :web-ui/open-github-button)]])
-
-(defn- detail-actions
+(defn- ^{:stratum 2} detail-actions
   [repo number url]
   [:div.section
    [:div.section-title (t :web-ui/actions-heading)]
    (action-buttons repo number url)])
 
-(defn- quick-question-buttons
-  [repo number]
-  (for [{:keys [label prompt]} (t :web-ui/chat-quick-questions)]
-    [:button.quick-question
-     {:hx-post (str (pr-url repo number) "/chat")
-      :hx-target "#chat-messages"
-      :hx-swap "beforeend"
-      :hx-vals (str "{\"question\": \"" prompt "\"}")}
-     label]))
-
-(defn- chat-section
+(defn- ^{:stratum 2} chat-section
   [repo number]
   [:div.chat-section
    [:div.chat-header
@@ -306,7 +360,66 @@
     [:button.btn.btn-primary {:type "submit"}
      (t :web-ui/chat-submit-button)]]])
 
-(defn pr-detail [{:keys [number title author url repo additions deletions analysis]}]
+(defn- ^{:stratum 2} repo-group
+  [selected-pr {:keys [repo prs]}]
+  [:div.repo-group
+   [:div.repo-header.expanded
+    [:span.repo-icon "📦"]
+    [:span.repo-name repo]
+    [:span.repo-count (count prs)]]
+   [:div.pr-list
+    (for [pr prs]
+      (repo-pr-item repo selected-pr pr))]])
+
+(defn- ^{:stratum 2} batch-approve-safe-button
+  [safe-count]
+  [:button.btn.btn-success
+   {:hx-post "/api/batch-approve"
+    :hx-target "#toast-container"
+    :hx-swap "innerHTML"
+    :hx-confirm (batch-approve-confirm safe-count)
+    :style batch-approve-style}
+   (t :web-ui/batch-approve-safe)])
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn- ^{:stratum 3} ai-analysis-section
+  [repo number {:keys [risk complexity summary suggested-action reasons total-changes file-count]}]
+  [:div.section
+   [:div.section-title (t :web-ui/ai-analysis)]
+   (analysis-stats risk complexity total-changes file-count)
+   [:div {:style summary-message-style}
+    [:strong (t :web-ui/summary-prefix)]
+    summary]
+   (when (seq reasons)
+     [:div {:style factors-style}
+      [:strong (t :web-ui/factors-prefix)]
+      (str/join ", " reasons)])
+   (recommendation-box risk suggested-action)
+   [:div#ai-summary-container (ai-summary-placeholder repo number)]])
+
+(defn ^{:stratum 3} repo-tree [repos-with-prs selected-pr]
+  (h/html
+   [:div.sidebar
+    (sidebar-header)
+    [:div.sidebar-content
+     (for [repo-group-data repos-with-prs]
+       (repo-group selected-pr repo-group-data))
+     (workflow-status (map :repo repos-with-prs))]]))
+
+(defn- ^{:stratum 3} dashboard-stats
+  [{:keys [total low medium high]}]
+  [:div.header-stats
+   (stat-pill "stat" (t :web-ui/pr-total {:count total}))
+   (stat-pill "stat stat-low" (t :web-ui/pr-low {:count low}))
+   (stat-pill "stat stat-medium" (t :web-ui/pr-medium {:count medium}))
+   (stat-pill "stat stat-high" (t :web-ui/pr-high {:count high}))
+   (when (pos? low)
+     (batch-approve-safe-button low))])
+
+;------------------------------------------------------------------------------ Layer 4
+
+(defn ^{:stratum 4} pr-detail [{:keys [number title author url repo additions deletions analysis]}]
   (let [risk-level (get analysis :risk)]
     (h/html
      [:div
@@ -319,118 +432,18 @@
        (detail-actions repo number url)
        (chat-section repo number)]])))
 
-(defn- repo-item-selected?
-  [selected-pr repo number]
-  (and selected-pr
-       (= (:repo selected-pr) repo)
-       (= (:number selected-pr) number)))
+;------------------------------------------------------------------------------ Layer 5
 
-(defn- repo-pr-item
-  [repo selected-pr {:keys [number title analysis]}]
-  (let [selected? (repo-item-selected? selected-pr repo number)
-        item-class (when selected? selected-class)]
-    [:div.pr-item
-     {:class item-class
-      :hx-get (pr-url repo number)
-      :hx-target "#detail-panel"
-      :hx-swap "innerHTML"}
-     [:span.pr-risk-dot {:class (str "pr-risk-" (name (:risk analysis)))}]
-     [:span.pr-number (str "#" number)]
-     [:span.pr-title title]]))
-
-(defn- repo-group
-  [selected-pr {:keys [repo prs]}]
-  [:div.repo-group
-   [:div.repo-header.expanded
-    [:span.repo-icon "📦"]
-    [:span.repo-name repo]
-    [:span.repo-count (count prs)]]
-   [:div.pr-list
-    (for [pr prs]
-      (repo-pr-item repo selected-pr pr))]])
-
-(defn- sidebar-header
-  []
-  [:div.sidebar-header
-   [:span (t :web-ui/repositories-heading)]
-   [:button.btn.btn-secondary
-    {:hx-get "/api/refresh"
-     :hx-target "#main-content"
-     :hx-swap "innerHTML"
-     :style sidebar-refresh-style}
-    (t :web-ui/refresh-button)]])
-
-(defn repo-tree [repos-with-prs selected-pr]
-  (h/html
-   [:div.sidebar
-    (sidebar-header)
-    [:div.sidebar-content
-     (for [repo-group-data repos-with-prs]
-       (repo-group selected-pr repo-group-data))
-     (workflow-status (map :repo repos-with-prs))]]))
-
-(defn- pr-counts
-  [all-prs]
-  {:total (count all-prs)
-   :low (count (filter #(= :low (get-in % [:analysis :risk])) all-prs))
-   :medium (count (filter #(= :medium (get-in % [:analysis :risk])) all-prs))
-   :high (count (filter #(= :high (get-in % [:analysis :risk])) all-prs))})
-
-(defn- fleet-header
-  [fleet-status]
-  [:div.header
-   [:div {:style "display: flex; align-items: center; gap: 16px;"}
-    [:h1 (t :web-ui/fleet-dashboard-heading)]
-    (status-indicator fleet-status)]])
-
-(defn- stat-pill
-  [class-name text]
-  [:span {:class class-name} text])
-
-(defn- batch-approve-safe-button
-  [safe-count]
-  [:button.btn.btn-success
-   {:hx-post "/api/batch-approve"
-    :hx-target "#toast-container"
-    :hx-swap "innerHTML"
-    :hx-confirm (batch-approve-confirm safe-count)
-    :style batch-approve-style}
-   (t :web-ui/batch-approve-safe)])
-
-(defn- dashboard-stats
-  [{:keys [total low medium high]}]
-  [:div.header-stats
-   (stat-pill "stat" (t :web-ui/pr-total {:count total}))
-   (stat-pill "stat stat-low" (t :web-ui/pr-low {:count low}))
-   (stat-pill "stat stat-medium" (t :web-ui/pr-medium {:count medium}))
-   (stat-pill "stat stat-high" (t :web-ui/pr-high {:count high}))
-   (when (pos? low)
-     (batch-approve-safe-button low))])
-
-(defn- detail-panel
+(defn- ^{:stratum 5} detail-panel
   [selected-pr]
   [:div#detail-panel.detail-panel
    (if selected-pr
      (pr-detail selected-pr)
      (empty-detail))])
 
-(defn- keyboard-hint
-  [prefix-key suffix-key label]
-  [:span
-   [:kbd prefix-key]
-   "/"
-   [:kbd suffix-key]
-   (str " " label)])
+;------------------------------------------------------------------------------ Layer 6
 
-(defn- keyboard-hints
-  []
-  [:div.keyboard-hints
-   (keyboard-hint "j" "k" (t :web-ui/hint-navigate))
-   [:span [:kbd "r"] (str " " (t :web-ui/hint-refresh))]
-   [:span [:kbd "a"] (str " " (t :web-ui/hint-approve))]
-   [:span [:kbd "x"] (str " " (t :web-ui/hint-reject))]])
-
-(defn dashboard [repos-with-prs selected-pr fleet-status]
+(defn ^{:stratum 6} dashboard [repos-with-prs selected-pr fleet-status]
   (let [all-prs (mapcat :prs repos-with-prs)
         counts (pr-counts all-prs)
         summary (fleet/generate-summary repos-with-prs)]

--- a/bases/cli/src/ai/miniforge/cli/web/components/status.clj
+++ b/bases/cli/src/ai/miniforge/cli/web/components/status.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.web.components.status
   "Status-oriented dashboard fragments."
   (:require
@@ -23,16 +22,18 @@
    [ai.miniforge.cli.messages :as messages]
    [ai.miniforge.cli.web.fleet :as fleet]))
 
-(def ^:const no-workflows-style
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:const no-workflows-style
   "color: var(--text-muted); font-size: 12px; text-align: center;")
 
-(defn- t
+(defn- ^{:stratum 0} t
   ([message-key]
    (messages/t message-key))
   ([message-key params]
    (messages/t message-key params)))
 
-(defn- overall-status-key
+(defn- ^{:stratum 0} overall-status-key
   [overall]
   (case overall
     :healthy :web-ui/status-healthy
@@ -41,12 +42,24 @@
     :error :web-ui/status-error
     :web-ui/status-unknown))
 
-(defn- workflow-stat
+(defn- ^{:stratum 0} workflow-stat
   [class-name value]
   [:span {:class class-name}
    [:span value]])
 
-(defn status-indicator
+(defn ^{:stratum 0} workflow-status-icon
+  [run]
+  (let [status (get run :status)
+        conclusion (get run :conclusion)]
+    (cond
+      (= status "in_progress") "⏳"
+      (= conclusion "success") "✓"
+      (#{"failure" "timed_out" "startup_failure"} conclusion) "✗"
+      :else "○")))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} status-indicator
   [status]
   (let [overall (get status :overall)
         status-class (name overall)
@@ -59,31 +72,25 @@
       [:span.status-dot]
       [:span status-text]])))
 
-(defn workflow-status-icon
-  [run]
-  (let [status (get run :status)
-        conclusion (get run :conclusion)]
-    (cond
-      (= status "in_progress") "⏳"
-      (= conclusion "success") "✓"
-      (#{"failure" "timed_out" "startup_failure"} conclusion) "✗"
-      :else "○")))
-
-(defn- workflow-run
+(defn- ^{:stratum 1} workflow-run
   [{:keys [workflowName createdAt] :as run}]
   [:div.workflow-run
    [:span.workflow-run-status (workflow-status-icon run)]
    [:span.workflow-run-name workflowName]
    [:span.workflow-run-time (fleet/format-time-ago createdAt)]])
 
-(defn- workflow-runs
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- ^{:stratum 2} workflow-runs
   [runs]
   (if (seq runs)
     (map workflow-run runs)
     [[:div {:style no-workflows-style}
       (t :web-ui/workflow-status-none)]]))
 
-(defn workflow-status
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} workflow-status
   [repos]
   (let [{:keys [running failed succeeded runs]} (fleet/get-workflow-status repos)
         running-value (str running " ⏳")

--- a/bases/cli/src/ai/miniforge/cli/web/fleet.clj
+++ b/bases/cli/src/ai/miniforge/cli/web/fleet.clj
@@ -15,12 +15,13 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.web.fleet
   "Fleet status and aggregation."
   (:require [ai.miniforge.cli.web.github :as github]))
 
-(defn format-time-ago [iso-timestamp]
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} format-time-ago [iso-timestamp]
   (try
     (let [then (java.time.Instant/parse iso-timestamp)
           now (java.time.Instant/now)
@@ -35,7 +36,7 @@
         :else (str days "d ago")))
     (catch Exception _ "unknown")))
 
-(defn get-workflow-status [repos]
+(defn ^{:stratum 0} get-workflow-status [repos]
   (let [all-runs (->> repos
                       (mapcat #(map (fn [run] (assoc run :repo %))
                                     (github/fetch-workflow-runs %))))
@@ -51,7 +52,7 @@
      :succeeded (count succeeded)
      :runs (->> all-runs (sort-by :createdAt) reverse (take 5))}))
 
-(defn get-status [repos]
+(defn ^{:stratum 0} get-status [repos]
   (let [gh-status (github/check-auth)
         repo-statuses (when (:available gh-status)
                         (map github/check-repo repos))
@@ -68,7 +69,7 @@
                 :else :healthy)
      :last-check (java.time.Instant/now)}))
 
-(defn generate-summary [repos-with-prs]
+(defn ^{:stratum 0} generate-summary [repos-with-prs]
   (let [all-prs (mapcat :prs repos-with-prs)
         high-risk (filter #(= :high (get-in % [:analysis :risk])) all-prs)
         medium-risk (filter #(= :medium (get-in % [:analysis :risk])) all-prs)

--- a/bases/cli/src/ai/miniforge/cli/web/github.clj
+++ b/bases/cli/src/ai/miniforge/cli/web/github.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.web.github
   "GitHub CLI operations."
   (:require
@@ -24,25 +23,29 @@
    [cheshire.core :as json]
    [ai.miniforge.cli.web.risk :as risk]))
 
-(defn sh-success? [result]
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} sh-success? [result]
   (zero? (:exit result)))
 
-(defn sh-error-msg [result default]
+(defn ^{:stratum 0} sh-error-msg [result default]
   (str/trim (or (:err result) (:out result) default)))
 
-(defn check-auth []
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} check-auth []
   (let [result (process/sh "gh" "auth" "status")]
     {:available (sh-success? result)
      :message (if (sh-success? result) "Authenticated" "Not authenticated")}))
 
-(defn check-claude-cli []
+(defn ^{:stratum 1} check-claude-cli []
   (sh-success? (process/sh "which" "claude")))
 
-(defn check-repo [repo]
+(defn ^{:stratum 1} check-repo [repo]
   {:accessible (sh-success? (process/sh "gh" "repo" "view" repo "--json" "name"))
    :repo repo})
 
-(defn fetch-prs [repo]
+(defn ^{:stratum 1} fetch-prs [repo]
   (let [result (process/sh "gh" "pr" "list" "--repo" repo
                            "--json" "number,title,state,author,url,additions,deletions,changedFiles,createdAt,labels"
                            "--limit" "50")]
@@ -52,24 +55,17 @@
              (mapv #(assoc % :repo repo :analysis (risk/analyze-pr %))))
         (catch Exception _ [])))))
 
-(defn fetch-all-prs [repos]
-  (->> repos
-       (keep (fn [repo]
-               (when-let [prs (fetch-prs repo)]
-                 {:repo repo :prs prs})))
-       vec))
-
-(defn fetch-pr-diff [repo number]
+(defn ^{:stratum 1} fetch-pr-diff [repo number]
   (let [result (process/sh "gh" "pr" "diff" (str number) "--repo" repo)]
     (when (sh-success? result) (:out result))))
 
-(defn fetch-pr-body [repo number]
+(defn ^{:stratum 1} fetch-pr-body [repo number]
   (let [result (process/sh "gh" "pr" "view" (str number) "--repo" repo "--json" "body,title,labels")]
     (when (sh-success? result)
       (try (json/parse-string (:out result) true)
            (catch Exception _ nil)))))
 
-(defn fetch-workflow-runs [repo]
+(defn ^{:stratum 1} fetch-workflow-runs [repo]
   (let [result (process/sh "gh" "run" "list" "--repo" repo
                            "--json" "workflowName,status,conclusion,createdAt,databaseId"
                            "--limit" "10")]
@@ -78,7 +74,7 @@
            (catch Exception _ []))
       [])))
 
-(defn approve-pr! [repo number]
+(defn ^{:stratum 1} approve-pr! [repo number]
   (let [result (process/sh "gh" "pr" "review" (str number) "--repo" repo "--approve")]
     {:success (sh-success? result)
      :message (if (sh-success? result)
@@ -86,7 +82,7 @@
                 (str "❌ Failed to approve PR #" number ": "
                      (sh-error-msg result "Unknown error. Check gh CLI authentication.")))}))
 
-(defn request-changes! [repo number reason]
+(defn ^{:stratum 1} request-changes! [repo number reason]
   (let [result (process/sh "gh" "pr" "review" (str number)
                            "--repo" repo "--request-changes" "--body" reason)]
     {:success (sh-success? result)
@@ -95,7 +91,16 @@
                 (str "❌ Failed to request changes: "
                      (sh-error-msg result "Unknown error. Check gh CLI authentication.")))}))
 
-(defn generate-pr-summary [repo number]
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} fetch-all-prs [repos]
+  (->> repos
+       (keep (fn [repo]
+               (when-let [prs (fetch-prs repo)]
+                 {:repo repo :prs prs})))
+       vec))
+
+(defn ^{:stratum 2} generate-pr-summary [repo number]
   (if-not (check-claude-cli)
     {:success false
      :summary "Claude CLI not available. Install from https://claude.ai/download"}
@@ -113,7 +118,7 @@
             {:success true :summary (str/trim (:out result))}
             {:success false :summary (str "Claude CLI error: " (sh-error-msg result "Unknown"))}))))))
 
-(defn chat-about-pr [repo number question diff-context]
+(defn ^{:stratum 2} chat-about-pr [repo number question diff-context]
   (if-not (check-claude-cli)
     {:success false :response "❌ Claude CLI not available."}
     (let [prompt (str "You are reviewing PR #" number " in " repo ".\n\n"

--- a/bases/cli/src/ai/miniforge/cli/web/handlers.clj
+++ b/bases/cli/src/ai/miniforge/cli/web/handlers.clj
@@ -30,10 +30,17 @@
 
 ;------------------------------------------------------------------------------ Layer 0
 
-(defn ^{:stratum 0} parse-pr-path [uri]
-  (let [path-parts (str/split (subs uri 8) #"/")]
-    {:repo (java.net.URLDecoder/decode (first path-parts) "UTF-8")
-     :number (Integer/parseInt (second path-parts))}))
+(defn ^{:stratum 0} parse-pr-path
+  "Parse `{:repo ... :number ...}` out of an `/api/pr/<repo>/<number>...`
+   URI. Returns nil on a malformed path (missing/non-numeric PR number,
+   undecodable repo segment) instead of throwing, so callers can respond
+   with a 400 rather than crash request handling on untrusted input."
+  [uri]
+  (try
+    (let [path-parts (str/split (subs uri 8) #"/")]
+      {:repo (java.net.URLDecoder/decode (first path-parts) "UTF-8")
+       :number (Integer/parseInt (second path-parts))})
+    (catch Exception _ nil)))
 
 (defn ^{:stratum 0} parse-body-question [req]
   (when-let [body-str (some-> req :body slurp)]
@@ -88,40 +95,45 @@
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn ^{:stratum 1} pr-detail [uri]
-  (let [{:keys [repo number]} (parse-pr-path uri)
-        pr (->> (github/fetch-prs repo)
-                (filter #(= (:number %) number))
-                first)]
-    (if pr
-      (response/html (c/pr-detail pr))
-      (response/not-found "PR not found"))))
+  (if-let [{:keys [repo number]} (parse-pr-path uri)]
+    (let [pr (->> (github/fetch-prs repo)
+                  (filter #(= (:number %) number))
+                  first)]
+      (if pr
+        (response/html (c/pr-detail pr))
+        (response/not-found "PR not found")))
+    (response/bad-request "Invalid PR path")))
 
 (defn ^{:stratum 1} approve [uri]
-  (let [{:keys [repo number]} (parse-pr-path uri)
-        result (github/approve-pr! repo number)]
-    (response/html (c/toast (:message result) (:success result)))))
+  (if-let [{:keys [repo number]} (parse-pr-path uri)]
+    (let [result (github/approve-pr! repo number)]
+      (response/html (c/toast (:message result) (:success result))))
+    (response/bad-request "Invalid PR path")))
 
 (defn ^{:stratum 1} reject [uri req]
-  (let [{:keys [repo number]} (parse-pr-path uri)
-        reason (get-in req [:headers "hx-prompt"] "Changes requested")
-        result (github/request-changes! repo number reason)]
-    (response/html (c/toast (:message result) (:success result)))))
+  (if-let [{:keys [repo number]} (parse-pr-path uri)]
+    (let [reason (get-in req [:headers "hx-prompt"] "Changes requested")
+          result (github/request-changes! repo number reason)]
+      (response/html (c/toast (:message result) (:success result))))
+    (response/bad-request "Invalid PR path")))
 
 (defn ^{:stratum 1} chat [uri req]
-  (let [{:keys [repo number]} (parse-pr-path uri)
-        question (or (parse-body-question req) "What are the key changes in this PR?")
-        diff (github/fetch-pr-diff repo number)
-        resp (if diff
-               (:response (github/chat-about-pr repo number question diff))
-               "Could not fetch PR diff. Make sure you have access to this repository.")]
-    (response/html (c/chat-message question resp))))
+  (if-let [{:keys [repo number]} (parse-pr-path uri)]
+    (let [question (or (parse-body-question req) "What are the key changes in this PR?")
+          diff (github/fetch-pr-diff repo number)
+          resp (if diff
+                 (:response (github/chat-about-pr repo number question diff))
+                 "Could not fetch PR diff. Make sure you have access to this repository.")]
+      (response/html (c/chat-message question resp)))
+    (response/bad-request "Invalid PR path")))
 
 (defn ^{:stratum 1} summary [uri]
-  (let [{:keys [repo number]} (parse-pr-path uri)
-        result (github/generate-pr-summary repo number)]
-    (if (and (not (:success result)) (anomaly/anomaly-map? (:anomaly result)))
-      (response/from-anomaly (:anomaly result))
-      (response/html
-       (if (:success result)
-         (c/ai-summary result)
-         (c/ai-summary-error (:summary result)))))))
+  (if-let [{:keys [repo number]} (parse-pr-path uri)]
+    (let [result (github/generate-pr-summary repo number)]
+      (if (and (not (:success result)) (anomaly/anomaly-map? (:anomaly result)))
+        (response/from-anomaly (:anomaly result))
+        (response/html
+         (if (:success result)
+           (c/ai-summary result)
+           (c/ai-summary-error (:summary result))))))
+    (response/bad-request "Invalid PR path")))

--- a/bases/cli/src/ai/miniforge/cli/web/handlers.clj
+++ b/bases/cli/src/ai/miniforge/cli/web/handlers.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.web.handlers
   "HTTP route handlers."
   (:require
@@ -29,12 +28,14 @@
    [ai.miniforge.cli.web.sse :as sse]
    [ai.miniforge.response.interface :as anomaly]))
 
-(defn parse-pr-path [uri]
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} parse-pr-path [uri]
   (let [path-parts (str/split (subs uri 8) #"/")]
     {:repo (java.net.URLDecoder/decode (first path-parts) "UTF-8")
      :number (Integer/parseInt (second path-parts))}))
 
-(defn parse-body-question [req]
+(defn ^{:stratum 0} parse-body-question [req]
   (when-let [body-str (some-> req :body slurp)]
     (cond
       (str/starts-with? (str/trim body-str) "{")
@@ -48,38 +49,18 @@
                        (java.net.URLDecoder/decode v "UTF-8")))))
            first))))
 
-(defn index [repos]
+(defn ^{:stratum 0} index [repos]
   (->> (c/dashboard (github/fetch-all-prs repos) nil (fleet/get-status repos))
        c/page
        response/html))
 
-(defn refresh [repos]
+(defn ^{:stratum 0} refresh [repos]
   (let [repos-with-prs (github/fetch-all-prs repos)]
     (->> (str (c/repo-tree repos-with-prs nil)
               (h/html [:div#detail-panel.detail-panel (c/empty-detail)]))
          response/html)))
 
-(defn pr-detail [uri]
-  (let [{:keys [repo number]} (parse-pr-path uri)
-        pr (->> (github/fetch-prs repo)
-                (filter #(= (:number %) number))
-                first)]
-    (if pr
-      (response/html (c/pr-detail pr))
-      (response/not-found "PR not found"))))
-
-(defn approve [uri]
-  (let [{:keys [repo number]} (parse-pr-path uri)
-        result (github/approve-pr! repo number)]
-    (response/html (c/toast (:message result) (:success result)))))
-
-(defn reject [uri req]
-  (let [{:keys [repo number]} (parse-pr-path uri)
-        reason (get-in req [:headers "hx-prompt"] "Changes requested")
-        result (github/request-changes! repo number reason)]
-    (response/html (c/toast (:message result) (:success result)))))
-
-(defn batch-approve [repos]
+(defn ^{:stratum 0} batch-approve [repos]
   (let [safe-prs (->> (github/fetch-all-prs repos)
                       (mapcat :prs)
                       (filter #(= :low (get-in % [:analysis :risk]))))
@@ -88,7 +69,45 @@
     (response/html (c/toast (str "Approved " success-count " of " (count safe-prs) " PRs")
                             (= success-count (count safe-prs))))))
 
-(defn chat [uri req]
+(defn ^{:stratum 0} status [repos]
+  (->> (fleet/get-status repos)
+       c/status-indicator
+       response/html))
+
+(defn ^{:stratum 0} workflows [repos]
+  (response/html (c/workflow-status repos)))
+
+(defn ^{:stratum 0} workflow-stream [uri req]
+  (let [workflow-id-str (second (re-find #"/api/workflows/([^/]+)/stream" uri))
+        workflow-id (try (java.util.UUID/fromString workflow-id-str)
+                         (catch Exception _ nil))]
+    (if-not workflow-id
+      (response/bad-request "Invalid workflow ID")
+      (sse/handle-stream workflow-id req))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} pr-detail [uri]
+  (let [{:keys [repo number]} (parse-pr-path uri)
+        pr (->> (github/fetch-prs repo)
+                (filter #(= (:number %) number))
+                first)]
+    (if pr
+      (response/html (c/pr-detail pr))
+      (response/not-found "PR not found"))))
+
+(defn ^{:stratum 1} approve [uri]
+  (let [{:keys [repo number]} (parse-pr-path uri)
+        result (github/approve-pr! repo number)]
+    (response/html (c/toast (:message result) (:success result)))))
+
+(defn ^{:stratum 1} reject [uri req]
+  (let [{:keys [repo number]} (parse-pr-path uri)
+        reason (get-in req [:headers "hx-prompt"] "Changes requested")
+        result (github/request-changes! repo number reason)]
+    (response/html (c/toast (:message result) (:success result)))))
+
+(defn ^{:stratum 1} chat [uri req]
   (let [{:keys [repo number]} (parse-pr-path uri)
         question (or (parse-body-question req) "What are the key changes in this PR?")
         diff (github/fetch-pr-diff repo number)
@@ -97,12 +116,7 @@
                "Could not fetch PR diff. Make sure you have access to this repository.")]
     (response/html (c/chat-message question resp))))
 
-(defn status [repos]
-  (->> (fleet/get-status repos)
-       c/status-indicator
-       response/html))
-
-(defn summary [uri]
+(defn ^{:stratum 1} summary [uri]
   (let [{:keys [repo number]} (parse-pr-path uri)
         result (github/generate-pr-summary repo number)]
     (if (and (not (:success result)) (anomaly/anomaly-map? (:anomaly result)))
@@ -111,14 +125,3 @@
        (if (:success result)
          (c/ai-summary result)
          (c/ai-summary-error (:summary result)))))))
-
-(defn workflows [repos]
-  (response/html (c/workflow-status repos)))
-
-(defn workflow-stream [uri req]
-  (let [workflow-id-str (second (re-find #"/api/workflows/([^/]+)/stream" uri))
-        workflow-id (try (java.util.UUID/fromString workflow-id-str)
-                         (catch Exception _ nil))]
-    (if-not workflow-id
-      (response/bad-request "Invalid workflow ID")
-      (sse/handle-stream workflow-id req))))

--- a/bases/cli/src/ai/miniforge/cli/web/response.clj
+++ b/bases/cli/src/ai/miniforge/cli/web/response.clj
@@ -15,30 +15,31 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.web.response
   "HTTP response constructors."
   (:require
    [ai.miniforge.response.interface :as anomaly]))
 
-(defn html [body]
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} html [body]
   {:status 200
    :headers {"Content-Type" "text/html; charset=utf-8"}
    :body (str body)})
 
-(defn not-found [msg]
+(defn ^{:stratum 0} not-found [msg]
   {:status 404 :body msg})
 
-(defn bad-request [msg]
+(defn ^{:stratum 0} bad-request [msg]
   {:status 400 :body msg})
 
-(defn from-anomaly
+(defn ^{:stratum 0} from-anomaly
   "Create an HTTP response from a canonical anomaly map.
    Uses the boundary translator — only call at HTTP edges."
   [anomaly-map]
   (anomaly/anomaly->http-response anomaly-map))
 
-(defn sse-headers []
+(defn ^{:stratum 0} sse-headers []
   {:status 200
    :headers {"Content-Type" "text/event-stream"
              "Cache-Control" "no-cache"

--- a/bases/cli/src/ai/miniforge/cli/web/risk.clj
+++ b/bases/cli/src/ai/miniforge/cli/web/risk.clj
@@ -15,25 +15,26 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.web.risk
   "PR risk analysis - pure functions."
   (:require [clojure.string :as str]))
 
-(def colors
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} colors
   {:low "#22c55e"
    :medium "#eab308"
    :high "#ef4444"})
 
-(def bg-colors
+(def ^{:stratum 0} bg-colors
   {:low "rgba(34, 197, 94, 0.1)"
    :medium "rgba(234, 179, 8, 0.1)"
    :high "rgba(239, 68, 68, 0.1)"})
 
-(defn title-contains? [title-lower & terms]
+(defn ^{:stratum 0} title-contains? [title-lower & terms]
   (some #(str/includes? title-lower %) terms))
 
-(defn classify-risk [total-changes file-count is-docs? is-deps? is-refactor?]
+(defn ^{:stratum 0} classify-risk [total-changes file-count is-docs? is-deps? is-refactor?]
   (cond
     (and is-docs? (< total-changes 100)) :low
     (and is-deps? (< file-count 3)) :low
@@ -43,14 +44,14 @@
     (and is-refactor? (> total-changes 200)) :high
     :else :medium))
 
-(defn classify-complexity [total-changes]
+(defn ^{:stratum 0} classify-complexity [total-changes]
   (cond
     (< total-changes 20) :trivial
     (< total-changes 100) :simple
     (< total-changes 300) :moderate
     :else :complex))
 
-(defn summarize-type [is-docs? is-deps? is-fix? is-refactor? is-feature?]
+(defn ^{:stratum 0} summarize-type [is-docs? is-deps? is-fix? is-refactor? is-feature?]
   (cond
     is-docs? "Documentation update"
     is-deps? "Dependency version bump"
@@ -59,13 +60,15 @@
     is-feature? "New feature"
     :else "Code changes"))
 
-(defn build-reasons [total-changes file-count is-refactor?]
+(defn ^{:stratum 0} build-reasons [total-changes file-count is-refactor?]
   (cond-> []
     (> total-changes 300) (conj (str total-changes " lines changed"))
     (> file-count 10) (conj (str file-count " files modified"))
     is-refactor? (conj "Refactoring changes")))
 
-(defn analyze-pr [{:keys [title additions deletions changedFiles]}]
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} analyze-pr [{:keys [title additions deletions changedFiles]}]
   (let [total-changes (+ (or additions 0) (or deletions 0))
         file-count (or changedFiles 0)
         title-lower (str/lower-case (or title ""))

--- a/bases/cli/src/ai/miniforge/cli/web/sse.clj
+++ b/bases/cli/src/ai/miniforge/cli/web/sse.clj
@@ -51,7 +51,12 @@
   (when-let [sub-id (get-in @subscriptions [workflow-id channel])]
     (when-let [event-stream (get @streams workflow-id)]
       (es/unsubscribe! event-stream sub-id))
-    (swap! subscriptions update workflow-id dissoc channel)))
+    (swap! subscriptions
+           (fn [m]
+             (let [remaining (dissoc (get m workflow-id) channel)]
+               (if (empty? remaining)
+                 (dissoc m workflow-id)
+                 (assoc m workflow-id remaining)))))))
 
 (defn ^{:stratum 1} register! [workflow-id event-stream]
   (swap! streams assoc workflow-id event-stream)

--- a/bases/cli/src/ai/miniforge/cli/web/sse.clj
+++ b/bases/cli/src/ai/miniforge/cli/web/sse.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.web.sse
   "Server-Sent Events for workflow streaming."
   (:require
@@ -26,9 +25,13 @@
    [ai.miniforge.automation-edge-correlator.interface :as correlator]
    [ai.miniforge.cli.web.response :as response]))
 
-(def streams (atom {}))
+;------------------------------------------------------------------------------ Layer 0
 
-(defn get-or-create-stream [workflow-id]
+(def ^{:stratum 0} streams (atom {}))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} get-or-create-stream [workflow-id]
   (or (get @streams workflow-id)
       (let [stream (es/create-event-stream)]
         (supervisory/attach! stream)
@@ -37,7 +40,26 @@
         (swap! streams assoc workflow-id stream)
         stream)))
 
-(defn on-open [workflow-id channel]
+(defn ^{:stratum 1} on-close [workflow-id channel]
+  (when-let [sub-id (get-in @streams [workflow-id :subscribers channel])]
+    (when-let [event-stream (get @streams workflow-id)]
+      (es/unsubscribe! event-stream sub-id))
+    (swap! streams update-in [workflow-id :subscribers] dissoc channel)))
+
+(defn ^{:stratum 1} register! [workflow-id event-stream]
+  (swap! streams assoc workflow-id event-stream)
+  workflow-id)
+
+(defn ^{:stratum 1} unregister! [workflow-id]
+  (swap! streams dissoc workflow-id)
+  nil)
+
+(defn ^{:stratum 1} get-stream [workflow-id]
+  (get @streams workflow-id))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} on-open [workflow-id channel]
   (let [event-stream (get-or-create-stream workflow-id)
         sub-id (random-uuid)]
     (swap! streams assoc-in [workflow-id :subscribers channel] sub-id)
@@ -49,24 +71,9 @@
                                       "data: " (json/generate-string event) "\n\n")
                                  false)))))
 
-(defn on-close [workflow-id channel]
-  (when-let [sub-id (get-in @streams [workflow-id :subscribers channel])]
-    (when-let [event-stream (get @streams workflow-id)]
-      (es/unsubscribe! event-stream sub-id))
-    (swap! streams update-in [workflow-id :subscribers] dissoc channel)))
+;------------------------------------------------------------------------------ Layer 3
 
-(defn handle-stream [workflow-id req]
+(defn ^{:stratum 3} handle-stream [workflow-id req]
   (http/as-channel req
     {:on-open (partial on-open workflow-id)
      :on-close (partial on-close workflow-id)}))
-
-(defn register! [workflow-id event-stream]
-  (swap! streams assoc workflow-id event-stream)
-  workflow-id)
-
-(defn unregister! [workflow-id]
-  (swap! streams dissoc workflow-id)
-  nil)
-
-(defn get-stream [workflow-id]
-  (get @streams workflow-id))

--- a/bases/cli/src/ai/miniforge/cli/web/sse.clj
+++ b/bases/cli/src/ai/miniforge/cli/web/sse.clj
@@ -29,6 +29,13 @@
 
 (def ^{:stratum 0} streams (atom {}))
 
+;; `streams` values are event-stream atoms (`es/create-event-stream`), not
+;; maps — assoc-in/update-in on a `streams` entry would try to `assoc`
+;; onto that atom directly and throw `ClassCastException`. Per-channel
+;; subscription ids are tracked separately here instead:
+;; {workflow-id {channel sub-id}}.
+(def ^{:stratum 0} subscriptions (atom {}))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn ^{:stratum 1} get-or-create-stream [workflow-id]
@@ -41,10 +48,10 @@
         stream)))
 
 (defn ^{:stratum 1} on-close [workflow-id channel]
-  (when-let [sub-id (get-in @streams [workflow-id :subscribers channel])]
+  (when-let [sub-id (get-in @subscriptions [workflow-id channel])]
     (when-let [event-stream (get @streams workflow-id)]
       (es/unsubscribe! event-stream sub-id))
-    (swap! streams update-in [workflow-id :subscribers] dissoc channel)))
+    (swap! subscriptions update workflow-id dissoc channel)))
 
 (defn ^{:stratum 1} register! [workflow-id event-stream]
   (swap! streams assoc workflow-id event-stream)
@@ -52,6 +59,7 @@
 
 (defn ^{:stratum 1} unregister! [workflow-id]
   (swap! streams dissoc workflow-id)
+  (swap! subscriptions dissoc workflow-id)
   nil)
 
 (defn ^{:stratum 1} get-stream [workflow-id]
@@ -62,7 +70,7 @@
 (defn ^{:stratum 2} on-open [workflow-id channel]
   (let [event-stream (get-or-create-stream workflow-id)
         sub-id (random-uuid)]
-    (swap! streams assoc-in [workflow-id :subscribers channel] sub-id)
+    (swap! subscriptions assoc-in [workflow-id channel] sub-id)
     (http/send! channel (response/sse-headers) false)
     (es/subscribe! event-stream sub-id
                    (fn [event]

--- a/bases/cli/src/ai/miniforge/cli/web/sse.clj
+++ b/bases/cli/src/ai/miniforge/cli/web/sse.clj
@@ -63,6 +63,9 @@
   workflow-id)
 
 (defn ^{:stratum 1} unregister! [workflow-id]
+  (when-let [event-stream (get @streams workflow-id)]
+    (doseq [[_channel sub-id] (get @subscriptions workflow-id)]
+      (es/unsubscribe! event-stream sub-id)))
   (swap! streams dissoc workflow-id)
   (swap! subscriptions dissoc workflow-id)
   nil)

--- a/bases/cli/src/ai/miniforge/cli/workflow_recommendation_config.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_recommendation_config.clj
@@ -15,38 +15,41 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.workflow-recommendation-config
   "Resource-driven workflow recommendation prompt configuration."
   (:require
    [ai.miniforge.cli.resource-config :as resource-config]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Resource loading
 
-(def recommendation-config-resource
+;; Resource loading
+(def ^{:stratum 0} recommendation-config-resource
   "Classpath resource path for workflow recommendation prompt config."
   "config/workflow/recommendation-prompt.edn")
 
-(def default-recommendation-config-resource
+(def ^{:stratum 0} default-recommendation-config-resource
   "Classpath resource path for base workflow recommendation prompt config."
   "config/workflow/recommendation-prompt-default.edn")
 
-(defn default-prompt-config
-  "Load the base workflow recommendation prompt config from resources."
-  []
-  (resource-config/merged-resource-config default-recommendation-config-resource
-                                          :workflow-recommendation/prompt
-                                          {}))
-
-(defn- merge-prompt-config
+(defn- ^{:stratum 0} merge-prompt-config
   "Merge prompt config maps, preserving nested summary labels."
   [base override]
   (-> base
       (merge override)
       (update :summary-labels #(merge (:summary-labels base) %))))
 
-(defn recommendation-prompt-config
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} default-prompt-config
+  "Load the base workflow recommendation prompt config from resources."
+  []
+  (resource-config/merged-resource-config default-recommendation-config-resource
+                                          :workflow-recommendation/prompt
+                                          {}))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} recommendation-prompt-config
   "Resolve the active workflow recommendation prompt config from the classpath."
   []
   (merge-prompt-config (default-prompt-config)

--- a/bases/cli/src/ai/miniforge/cli/workflow_recommender.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_recommender.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.workflow-recommender
   "LLM-based workflow recommendation system.
 
@@ -34,10 +33,10 @@
    [ai.miniforge.workflow.interface :as workflow]
    [ai.miniforge.response.interface :as response]))
 
-;;------------------------------------------------------------------------------ Layer 0
-;; Prompt templates
+;------------------------------------------------------------------------------ Layer 0
 
-(defn build-workflow-summary
+;; Prompt templates
+(defn ^{:stratum 0} build-workflow-summary
   "Build a concise summary of a workflow for LLM prompt.
 
    Arguments:
@@ -58,17 +57,7 @@
          (when (:has-testing chars)
            (str "\n  " (:has-testing summary-labels))))))
 
-(defn build-workflow-summaries
-  "Build summaries for all available workflows.
-
-   Arguments:
-     workflows - Sequence of workflow definition maps
-
-   Returns: String with workflow summaries"
-  [workflows]
-  (str/join "\n\n" (map build-workflow-summary workflows)))
-
-(defn extract-spec-summary
+(defn ^{:stratum 0} extract-spec-summary
   "Extract key information from spec for LLM analysis.
 
    Arguments:
@@ -87,7 +76,83 @@
          (when constraints (str "Constraints: " (pr-str constraints) "\n\n"))
          (when workflow-type (str "Preferred workflow: " workflow-type)))))
 
-(defn build-recommendation-prompt
+;; LLM interaction
+(defn ^{:stratum 0} parse-llm-response
+  "Parse JSON response from LLM.
+
+   Arguments:
+     response-text - String response from LLM
+
+   Returns: Parsed map or nil"
+  [response-text]
+  (try
+    ;; Try to extract JSON from response (may have markdown code blocks)
+    ;; Use (?s) flag so . matches newlines — LLM JSON typically spans multiple lines
+    (let [json-text (if (str/includes? response-text "```")
+                      (second (re-find #"(?s)```(?:json)?\s*(\{.*?\})\s*```" response-text))
+                      response-text)
+          parsed (json/parse-string (or json-text response-text) true)]
+      ;; Convert workflow string to keyword
+      (update parsed :workflow keyword))
+    (catch Exception e
+      (println (messages/t :recommender/parse-warning {:error (ex-message e)}))
+      nil)))
+
+(defn ^{:stratum 0} call-llm-for-recommendation
+  "Call LLM to get workflow recommendation.
+
+   Arguments:
+     llm-client - LLM client (from ai.miniforge.llm.interface)
+     prompt - String prompt
+
+   Returns: LLM response map or nil"
+  [llm-client prompt]
+  (when llm-client
+    (try
+      (let [result (llm/complete llm-client {:prompt prompt :max-tokens 500})]
+        (when (:success result)
+          (:content result)))
+      (catch Exception e
+        (println (messages/t :recommender/llm-failed-warning {:error (ex-message e)}))
+        nil))))
+
+;; Fallback recommendations
+(defn ^{:stratum 0} recommend-by-task-type
+  "Fallback recommendation based on task type.
+
+   Arguments:
+     spec - Task specification map
+     available-workflows - Sequence of workflows
+
+   Returns: Workflow recommendation map"
+  [spec available-workflows]
+  (let [task-type (get spec :spec/workflow-type :simple)
+        matching-workflows (filter #(some #{task-type} (:workflow/task-types %)) available-workflows)]
+    (if (seq matching-workflows)
+      {:workflow (:workflow/id (first matching-workflows))
+       :confidence 0.5
+       :reasoning (messages/t :recommender/fallback-task-type {:task-type task-type})
+       :source :fallback}
+      {:workflow (selection-config/resolve-selection-profile :default available-workflows)
+       :confidence 0.3
+       :reasoning (messages/t :recommender/fallback-default)
+       :source :fallback})))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} build-workflow-summaries
+  "Build summaries for all available workflows.
+
+   Arguments:
+     workflows - Sequence of workflow definition maps
+
+   Returns: String with workflow summaries"
+  [workflows]
+  (str/join "\n\n" (map build-workflow-summary workflows)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} build-recommendation-prompt
   "Build LLM prompt for workflow recommendation.
 
    Arguments:
@@ -114,52 +179,10 @@
          "\n\n"
          (:json-instruction prompt-config))))
 
-;;------------------------------------------------------------------------------ Layer 1
-;; LLM interaction
+;------------------------------------------------------------------------------ Layer 3
 
-(defn parse-llm-response
-  "Parse JSON response from LLM.
-
-   Arguments:
-     response-text - String response from LLM
-
-   Returns: Parsed map or nil"
-  [response-text]
-  (try
-    ;; Try to extract JSON from response (may have markdown code blocks)
-    ;; Use (?s) flag so . matches newlines — LLM JSON typically spans multiple lines
-    (let [json-text (if (str/includes? response-text "```")
-                      (second (re-find #"(?s)```(?:json)?\s*(\{.*?\})\s*```" response-text))
-                      response-text)
-          parsed (json/parse-string (or json-text response-text) true)]
-      ;; Convert workflow string to keyword
-      (update parsed :workflow keyword))
-    (catch Exception e
-      (println (messages/t :recommender/parse-warning {:error (ex-message e)}))
-      nil)))
-
-(defn call-llm-for-recommendation
-  "Call LLM to get workflow recommendation.
-
-   Arguments:
-     llm-client - LLM client (from ai.miniforge.llm.interface)
-     prompt - String prompt
-
-   Returns: LLM response map or nil"
-  [llm-client prompt]
-  (when llm-client
-    (try
-      (let [result (llm/complete llm-client {:prompt prompt :max-tokens 500})]
-        (when (:success result)
-          (:content result)))
-      (catch Exception e
-        (println (messages/t :recommender/llm-failed-warning {:error (ex-message e)}))
-        nil))))
-
-;;------------------------------------------------------------------------------ Layer 2
 ;; Recommendation logic
-
-(defn recommend-workflow
+(defn ^{:stratum 3} recommend-workflow
   "Recommend a workflow using LLM semantic analysis.
 
    Arguments:
@@ -201,31 +224,9 @@
       (catch Exception e
         (response/from-exception e)))))
 
-;;------------------------------------------------------------------------------ Layer 3
-;; Fallback recommendations
+;------------------------------------------------------------------------------ Layer 4
 
-(defn recommend-by-task-type
-  "Fallback recommendation based on task type.
-
-   Arguments:
-     spec - Task specification map
-     available-workflows - Sequence of workflows
-
-   Returns: Workflow recommendation map"
-  [spec available-workflows]
-  (let [task-type (get spec :spec/workflow-type :simple)
-        matching-workflows (filter #(some #{task-type} (:workflow/task-types %)) available-workflows)]
-    (if (seq matching-workflows)
-      {:workflow (:workflow/id (first matching-workflows))
-       :confidence 0.5
-       :reasoning (messages/t :recommender/fallback-task-type {:task-type task-type})
-       :source :fallback}
-      {:workflow (selection-config/resolve-selection-profile :default available-workflows)
-       :confidence 0.3
-       :reasoning (messages/t :recommender/fallback-default)
-       :source :fallback})))
-
-(defn recommend-workflow-with-fallback
+(defn ^{:stratum 4} recommend-workflow-with-fallback
   "Recommend workflow with LLM, falling back to rule-based if needed.
 
    Arguments:

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.workflow-runner
   (:require
    [ai.miniforge.anomaly.interface :as anomaly]
@@ -48,53 +47,22 @@
    [ai.miniforge.cli.workflow-runner.gc-hooks :as gc-hooks]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Work spec kanban lifecycle
 
-(def ^:private work-dirs
+;; Work spec kanban lifecycle
+(def ^{:stratum 0} ^:private work-dirs
   "Kanban folder structure under work/."
   {:in-progress "work/in-progress"
    :done        "work/done"
    :failed      "work/failed"})
 
-(defn- work-spec?
+(defn- ^{:stratum 0} work-spec?
   "True when the spec provenance points to a file under work/."
   [provenance]
   (when-let [source (:source-file provenance)]
     (str/starts-with? (str source) "work/")))
 
-(defn- move-spec!
-  "Move a work spec file to the target kanban folder.
-   No-op if the spec isn't under work/ or the file doesn't exist."
-  [provenance target-key]
-  (when (work-spec? provenance)
-    (let [source (str (:source-file provenance))
-          target-dir (get work-dirs target-key)]
-      (when (and target-dir (fs/exists? source))
-        (fs/create-dirs target-dir)
-        (let [target (str target-dir "/" (fs/file-name source))]
-          (fs/move source target {:replace-existing true})
-          target)))))
-
-(defn move-spec-to-in-progress!
-  "Move a work spec to in-progress when execution starts.
-   Returns updated provenance with new source-file path,
-   or the original provenance if the move was a no-op."
-  [provenance]
-  (if-let [new-path (move-spec! provenance :in-progress)]
-    (assoc provenance :source-file new-path)
-    provenance))
-
-(defn move-spec-on-completion!
-  "Move a work spec to done or failed based on workflow result."
-  [provenance result]
-  (if (phase/succeeded? result)
-    (move-spec! provenance :done)
-    (move-spec! provenance :failed)))
-
-;------------------------------------------------------------------------------ Layer 0.5
 ;; Meta-loop context — process-scoped, accumulates metrics across workflows
-
-(defn- trigger-meta-loop-after-workflow!
+(defn- ^{:stratum 0} trigger-meta-loop-after-workflow!
   "Record workflow outcome and run a background meta-loop cycle.
    Failures are swallowed — the meta-loop must never crash the workflow runner."
   [workflow-id status failure-class]
@@ -105,19 +73,17 @@
         (agent/run-cycle-from-context! ctx))
       (catch Exception _e nil))))
 
-;------------------------------------------------------------------------------ Layer 0.6
 ;; Workflow interface resolution and pipeline helpers
-
-(defn resolve-workflow-interface []
+(defn ^{:stratum 0} resolve-workflow-interface []
   {:load-workflow workflow/load-workflow
    :run-pipeline  workflow/run-pipeline})
 
-(defn create-phase-callbacks [_quiet]
+(defn ^{:stratum 0} create-phase-callbacks [_quiet]
   ;; Phase progress is handled by the event-stream subscription
   ;; (display/start-progress!). Callbacks retained as extension point.
   {})
 
-(defn load-and-validate-workflow [load-workflow workflow-id version]
+(defn ^{:stratum 0} load-and-validate-workflow [load-workflow workflow-id version]
   (let [{:keys [workflow validation]} (load-workflow workflow-id version {})]
     (when-not workflow
       (response/throw-anomaly! :anomalies/not-found
@@ -129,7 +95,7 @@
                                {:workflow-id workflow-id :validation validation}))
     workflow))
 
-(defn create-artifact-store [quiet]
+(defn ^{:stratum 0} create-artifact-store [quiet]
   (try
     (artifact/create-transit-store)
     (catch Exception _e
@@ -137,7 +103,6 @@
         (println (display/colorize :yellow (messages/t :workflow-runner/artifact-store-warning))))
       nil)))
 
-;------------------------------------------------------------------------------ Layer 0.7
 ;; Deferred scratch-ref GC — thin delegation to workflow-runner.gc-hooks
 ;;
 ;; gc-hooks is a *pure* namespace (no external requires).  Its functions accept
@@ -145,29 +110,26 @@
 ;; partial + def) so that `with-redefs` on the gc-hooks vars is intercepted
 ;; correctly at call time — partial captures the function value at load time,
 ;; bypassing with-redefs in tests.
-
-(defn- enqueue-workflow-gc-best-effort!
+(defn- ^{:stratum 0} enqueue-workflow-gc-best-effort!
   "Append `workflow-id` to the scratch-ref GC queue.
    Never throws — GC housekeeping must not interfere with the workflow result."
   [workflow-id]
   (gc-hooks/enqueue-workflow-gc-best-effort! gc-queue/enqueue-workflow-gc! workflow-id))
 
-(defn- run-gc-pass-best-effort!
+(defn- ^{:stratum 0} run-gc-pass-best-effort!
   "Run the deferred scratch-ref GC pass piggybacked on workflow start.
    Never throws."
   []
   (gc-hooks/run-gc-pass-best-effort! worktree/worktree-root gc-queue/run-deferred-gc!))
 
-;------------------------------------------------------------------------------ Layer 0.8
 ;; Source-root and execution-context validation helpers
-
-(defn- valid-source-root?
+(defn- ^{:stratum 0} valid-source-root?
   [source-root]
   (and source-root
        (fs/exists? source-root)
        (fs/exists? (fs/path source-root ".git"))))
 
-(defn- normalize-path
+(defn- ^{:stratum 0} normalize-path
   [path]
   (when path
     (let [resolved (-> path
@@ -177,60 +139,13 @@
              (fs/canonicalize resolved)
              (.normalize resolved))))))
 
-(defn- source-dir-under-root?
-  [source-dir source-root]
-  (let [source-dir-path (some-> source-dir normalize-path fs/path)
-        source-root-path (some-> source-root normalize-path fs/path)]
-    (or (nil? source-dir-path)
-        (nil? source-root-path)
-        (.startsWith source-dir-path source-root-path))))
-
-(defn- assert-valid-source-root!
-  [context]
-  (let [source-root (:source-root context)]
-    (when-not (valid-source-root? source-root)
-      (response/throw-anomaly! :anomalies/incorrect
-                               (str "Invalid workflow source root: " source-root)
-                               {:source-root source-root
-                                :worktree-path (:worktree-path context)}))))
-
-(defn- assert-execution-worktree!
-  [context]
-  (let [expected (normalize-path (get-in context [:execution/opts :worktree-path]))
-        actual (normalize-path (:worktree-path context))]
-    (when (and expected actual (not= expected actual))
-      (response/throw-anomaly! :anomalies/incorrect
-                               (str "Execution worktree mismatch: expected "
-                                    expected " but runtime is using " actual)
-                               {:expected-worktree expected
-                                :actual-worktree actual
-                                :source-root (:source-root context)}))))
-
-(defn- assert-source-dir-alignment!
-  [spec context]
-  (let [source-dir (:spec/source-dir spec)
-        source-root (:source-root context)]
-    (when-not (source-dir-under-root? source-dir source-root)
-      (response/throw-anomaly! :anomalies/incorrect
-                               (str "Spec source directory is outside the workflow source root: "
-                                    source-dir)
-                               {:source-dir source-dir
-                                :source-root source-root
-                                :worktree-path (:worktree-path context)}))))
-
-(defn- assert-runtime-alignment!
-  [spec context]
-  (assert-valid-source-root! context)
-  (assert-execution-worktree! context)
-  (assert-source-dir-alignment! spec context))
-
-(defn- print-colored-lines!
+(defn- ^{:stratum 0} print-colored-lines!
   [quiet lines]
   (when-not quiet
     (doseq [[color line] lines]
       (println (display/colorize color line)))))
 
-(defn- runtime-provenance-lines
+(defn- ^{:stratum 0} runtime-provenance-lines
   [context]
   (concat
    [[:cyan (messages/t :workflow-runner/runtime-source
@@ -248,32 +163,13 @@
    (when (:git-dirty? context)
      [[:yellow (messages/t :workflow-runner/runtime-dirty-warning)]])))
 
-(defn- print-runtime-provenance!
-  [quiet context]
-  (print-colored-lines! quiet (runtime-provenance-lines context)))
-
-(def ^:private workflow-runner-config
+(def ^{:stratum 0} ^:private workflow-runner-config
   (delay
     (resource-config/merged-resource-config "config/cli/workflow-runner.edn"
                                             :workflow-runner
                                             {})))
 
-(defn- backend-preflight-config []
-  (:backend-preflight @workflow-runner-config))
-
-(defn- backend-preflight-prompt []
-  (:prompt (backend-preflight-config)))
-
-(defn- backend-preflight-timeout-ms []
-  (:timeout-ms (backend-preflight-config)))
-
-(defn- backend-version-timeout-ms []
-  (:version-timeout-ms (backend-preflight-config)))
-
-(defn- claude-preflight-args []
-  (:claude-args (backend-preflight-config)))
-
-(defn- executable-file?
+(defn- ^{:stratum 0} executable-file?
   [path]
   (let [file (some-> path fs/file)]
     (and file
@@ -281,50 +177,344 @@
          (not (fs/directory? file))
          (fs/executable? file))))
 
-(defn- direct-command-path?
+(defn- ^{:stratum 0} direct-command-path?
   [cmd]
   (boolean (re-find #"[\\/]" (or cmd ""))))
 
-(defn- normalize-command-path
+(defn- ^{:stratum 0} path-entries
+  []
+  (str/split (or (System/getenv "PATH") "") #":"))
+
+(defn- ^{:stratum 0} cli-process-env
+  []
+  (when (System/getenv "CLAUDECODE")
+    (into {} (remove (fn [[k _]] (= k "CLAUDECODE"))) (System/getenv))))
+
+(defn- ^{:stratum 0} stream-reader
+  [stream]
+  (future
+    (with-open [stream stream]
+      (slurp stream))))
+
+(defn- ^{:stratum 0} destroy-cli-process!
+  [^Process process]
+  (try
+    (.destroyForcibly process)
+    (.waitFor process 1000 java.util.concurrent.TimeUnit/MILLISECONDS)
+    (catch Exception _ nil)))
+
+(defn- ^{:stratum 0} await-stream
+  [stream-future]
+  (try
+    @stream-future
+    (catch Exception _ "")))
+
+(defn- ^{:stratum 0} success-response
+  [output]
+  (response/success output))
+
+(defn- ^{:stratum 0} failure-response
+  [category error-type message data]
+  (-> (response/failure message {:data (assoc data :type error-type)})
+      (assoc :anomaly (response/make-anomaly category message data))))
+
+(defn- ^{:stratum 0} response-output
+  [response]
+  (let [output (get response :output)]
+    (merge (select-keys response [:content :exit-code :version])
+           (if (map? output) output {}))))
+
+(defn- ^{:stratum 0} response-succeeded?
+  [response]
+  (or (true? (:success response))
+      (response/success? response)))
+
+(defn- ^{:stratum 0} with-backend-version
+  [stamp version]
+  (assoc stamp :cmd-version version))
+
+(defn- ^{:stratum 0} backend-provenance-lines
+  [{:keys [backend cmd-path cmd-version]}]
+  (concat
+   [[:cyan (messages/t :workflow-runner/backend-label
+                       {:backend (name backend)})]]
+   (when cmd-path
+     [[:cyan (messages/t :workflow-runner/backend-path {:path cmd-path})]])
+   (when cmd-version
+     [[:cyan (messages/t :workflow-runner/backend-version {:version cmd-version})]])))
+
+(defn- ^{:stratum 0} parse-preflight-payload
+  [content]
+  (try
+    (some-> content str/trim not-empty (json/parse-string true))
+    (catch Exception _ nil)))
+
+(defn- ^{:stratum 0} backend-stream-content
+  [stream-parser output]
+  (let [content (atom "")]
+    (doseq [line (str/split-lines (or output ""))]
+      (when-let [parsed (stream-parser line)]
+        (when-let [delta (:delta parsed)]
+          (swap! content str delta))))
+    (some-> @content str/trim not-empty)))
+
+(defn- ^{:stratum 0} backend-cli-missing!
+  [{:keys [backend cmd]}]
+  (response/throw-anomaly! :anomalies/incorrect
+                           (messages/t :workflow-runner/cli-not-on-path {:cmd cmd})
+                           {:backend backend
+                            :cmd cmd
+                            :path (System/getenv "PATH")}))
+
+(defn- ^{:stratum 0} backend-version-failed!
+  [{:keys [backend cmd cmd-path]} version-response]
+  (response/throw-anomaly! :anomalies/unavailable
+                           (messages/t :workflow-runner/backend-version-failed
+                                       {:backend (name backend)})
+                           {:backend backend
+                            :cmd cmd
+                            :cmd-path cmd-path
+                            :version-error (get-in version-response [:error :message])
+                            :version-error-data (get-in version-response [:error :data])}))
+
+(defn ^{:stratum 0} close-artifact-store [artifact-store]
+  (when artifact-store
+    (try
+      (artifact/close-store artifact-store)
+      (catch Exception _))))
+
+(defn ^{:stratum 0} select-workflow-type
+  "Select workflow type using LLM recommendation if not explicitly specified.
+   Checks :spec/workflow-type first, then :workflow/type as a fallback for
+   specs that use the shorter key."
+  [spec llm-client quiet]
+  (if-let [explicit-type (or (:spec/workflow-type spec)
+                             (:workflow/type spec))]
+    (do
+      (when-not quiet
+        (println (display/colorize :cyan (messages/t :workflow-runner/user-specified {:workflow-type (name explicit-type)}))))
+      explicit-type)
+    (let [recommendation (recommender/recommend-workflow-with-fallback spec llm-client)]
+      (when-not quiet
+        (println (display/colorize :cyan (messages/t :workflow-runner/auto-selected {:workflow-type (name (:workflow recommendation))})))
+        (println (messages/t :workflow-runner/auto-selected-reason {:reasoning (:reasoning recommendation)}))
+        (when (= :llm (:source recommendation))
+          (println (messages/t :workflow-runner/auto-selected-confidence {:confidence (format "%.0f%%" (* 100 (:confidence recommendation 0.0)))})))
+        (println (display/colorize :yellow (messages/t :workflow-runner/auto-selected-override))))
+      (:workflow recommendation))))
+
+(def ^{:stratum 0} ^:private workflow-aliases
+  "Map legacy/alternate workflow type keywords to their canonical counterparts.
+   Many work specs use :standard-sdlc but the only registered workflow is
+   :canonical-sdlc."
+  {:standard-sdlc :canonical-sdlc})
+
+(defn ^{:stratum 0} execute-workflow-pipeline [run-pipeline workflow input callbacks artifact-store event-stream]
+  (-> callbacks
+      (cond-> artifact-store (assoc :artifact-store artifact-store))
+      (cond-> event-stream (assoc :event-stream event-stream))
+      (->> (run-pipeline workflow input))))
+
+(defn- ^{:stratum 0} failure-message
+  "Build a meaningful failure message from a workflow result.
+   Falls back to execution status when no explicit errors exist."
+  [result]
+  (let [errors (:execution/errors result)
+        status (get result :execution/status :unknown)]
+    (if (seq errors)
+      (str (first errors))
+      (str "Workflow ended with status: " (name status)))))
+
+;; Execution orchestration
+(defn- ^{:stratum 0} publish-failure-event!
+  "Publish a workflow failure event, swallowing exceptions."
+  [event-stream workflow-id error-type message]
+  (try
+    (es/publish! event-stream
+                 (es/workflow-failed event-stream workflow-id
+                                     {:message message
+                                      :errors [{:type error-type :message message}]}))
+    (catch Exception _ nil)))
+
+(defn- ^{:stratum 0} best-effort-shutdown?
+  "Honor `MINIFORGE_BEST_EFFORT_SHUTDOWN` as the documented escape hatch
+   for local/dev loops that don't care about event durability. Default
+   off — normal headless mode treats drain failures as errors."
+  []
+  (let [v (System/getenv "MINIFORGE_BEST_EFFORT_SHUTDOWN")]
+    (boolean (and v (contains? #{"1" "true" "yes" "on"} (str/lower-case v))))))
+
+;; BD-2b sub-3a: per-workflow manifest lifecycle.
+;; manifest operations
+(def ^{:stratum 0} ^:dynamic *manifest-ops*
+  "Manifest operations used by the workflow lifecycle helpers."
+  {:init-active       es-manifest/init-active
+   :load-manifest     es-manifest/load-manifest
+   :mark-terminal     es-manifest/mark-terminal
+   :save-manifest!    es-manifest/save-manifest!
+   :start-heartbeat!  es-manifest/start-heartbeat!
+   :stop-heartbeat!   es-manifest/stop-heartbeat!
+   :archive-workflow! es-manifest/archive-workflow!})
+
+(defn ^{:stratum 0} format-workflow-listing [workflows]
+  (if (empty? workflows)
+    (println (messages/t :workflow-runner/no-workflows))
+    (do
+      (println (display/colorize :cyan (messages/t :workflow-runner/available-workflows)))
+      (println (display/colorize :cyan (apply str (repeat 60 "─"))))
+      (doseq [{:workflow/keys [id version description type]} workflows]
+        (println (str (display/colorize :bold (str "  " (name id)))
+                      " (v" version ")"
+                      "  " (display/colorize :yellow (messages/t :workflow-runner/workflow-type-label {:type (or type :unknown)}))
+                      (when description (str "\n    " description))))
+        (println))
+      (println (display/colorize :cyan (apply str (repeat 60 "─")))))))
+
+;; Spec-driven execution
+(defn- ^{:stratum 0} governed-workflow-id
+  "A UUID workflow id for a governed run. The operator control channel
+   routes `:pause`/`:resume`/`:cancel` interventions by coercing the
+   target id to a UUID, so a run WITHOUT a UUID id is uncontrollable —
+   its interventions can't reach its live-runner registry or audit
+   trail. Use the spec's `:session-id` when it already is a UUID (or a
+   UUID string); otherwise mint one. A PRESENT-but-non-UUID session-id
+   is warned about (it was silently discarded); an absent one is the
+   normal case and mints quietly."
+  [session-id quiet]
+  (or (when (uuid? session-id) session-id)
+      (when (string? session-id) (parse-uuid session-id))
+      (let [fresh (random-uuid)]
+        (when (and (some? session-id) (not quiet))
+          (println (display/colorize
+                    :yellow
+                    (messages/t :workflow-runner/non-uuid-session-id
+                                {:session-id (pr-str session-id)
+                                 :workflow-id (str fresh)}))))
+        fresh)))
+
+;; ── Chain-driven execution ─────────────────────────────────────────────────
+(defn ^{:stratum 0} resolve-chain-input
+  "Resolve chain input from a spec file path or inline JSON."
+  [opts]
+  (let [spec-path (:spec opts)
+        inline-json (:input-json opts)]
+    (cond
+      inline-json (json/parse-string inline-json true)
+      spec-path (let [parsed (edn/read-string (slurp spec-path))
+                      enriched (context/decorate-spec-with-runtime-context parsed {})]
+                  (context/spec->workflow-input enriched))
+      :else {})))
+
+(defn ^{:stratum 0} print-chain-header
+  "Print chain execution banner."
+  [chain-id chain-def quiet]
+  (when-not quiet
+    (println)
+    (println (display/colorize :cyan (messages/t :workflow-runner/chain-header {:chain-id (name chain-id)})))
+    (println (display/colorize :cyan (messages/t :workflow-runner/chain-description {:description (:chain/description chain-def)})))
+    (println (display/colorize :cyan (messages/t :workflow-runner/chain-steps {:count (count (:chain/steps chain-def))})))
+    (println (display/colorize :cyan (apply str (repeat 60 "─"))))))
+
+(defn ^{:stratum 0} print-chain-result
+  "Print chain execution result summary."
+  [result quiet]
+  (when-not quiet
+    (let [steps (:chain/step-results result)
+          duration (:chain/duration-ms result)]
+      (println)
+      (println (display/colorize :cyan (apply str (repeat 60 "─"))))
+      (if (phase/succeeded? result)
+        (println (display/colorize :green (messages/t :workflow-runner/chain-completed {:count (count steps) :duration duration})))
+        (let [failed-step (some #(when (phase/failed? %) (:step/id %)) steps)]
+          (println (display/colorize :red (messages/t :workflow-runner/chain-failed-at {:step (when failed-step (name failed-step))}))))))))
+
+(defn ^{:stratum 0} list-chains!
+  "List all available chain definitions."
+  []
+  (try
+    (let [chains (workflow/list-chains)]
+      (if (empty? chains)
+        (println (messages/t :workflow-runner/no-chains))
+        (do
+          (println (display/colorize :cyan (messages/t :workflow-runner/available-chains)))
+          (println (display/colorize :cyan (apply str (repeat 60 "─"))))
+          (doseq [{:keys [id version description steps]} chains]
+            (println (str (display/colorize :bold (str "  " (name id)))
+                          " (v" version ")"
+                          "  " (messages/t :workflow-runner/chain-steps-label {:steps steps})))
+            (when description
+              (println (str "    " description)))
+            (println))
+          (println (display/colorize :cyan (apply str (repeat 60 "─")))))))
+    (catch Exception e
+      (println (display/colorize :red (messages/t :workflow-runner/list-chains-failed {:error (ex-message e)})))
+      (throw e))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} move-spec!
+  "Move a work spec file to the target kanban folder.
+   No-op if the spec isn't under work/ or the file doesn't exist."
+  [provenance target-key]
+  (when (work-spec? provenance)
+    (let [source (str (:source-file provenance))
+          target-dir (get work-dirs target-key)]
+      (when (and target-dir (fs/exists? source))
+        (fs/create-dirs target-dir)
+        (let [target (str target-dir "/" (fs/file-name source))]
+          (fs/move source target {:replace-existing true})
+          target)))))
+
+(defn- ^{:stratum 1} source-dir-under-root?
+  [source-dir source-root]
+  (let [source-dir-path (some-> source-dir normalize-path fs/path)
+        source-root-path (some-> source-root normalize-path fs/path)]
+    (or (nil? source-dir-path)
+        (nil? source-root-path)
+        (.startsWith source-dir-path source-root-path))))
+
+(defn- ^{:stratum 1} assert-valid-source-root!
+  [context]
+  (let [source-root (:source-root context)]
+    (when-not (valid-source-root? source-root)
+      (response/throw-anomaly! :anomalies/incorrect
+                               (str "Invalid workflow source root: " source-root)
+                               {:source-root source-root
+                                :worktree-path (:worktree-path context)}))))
+
+(defn- ^{:stratum 1} assert-execution-worktree!
+  [context]
+  (let [expected (normalize-path (get-in context [:execution/opts :worktree-path]))
+        actual (normalize-path (:worktree-path context))]
+    (when (and expected actual (not= expected actual))
+      (response/throw-anomaly! :anomalies/incorrect
+                               (str "Execution worktree mismatch: expected "
+                                    expected " but runtime is using " actual)
+                               {:expected-worktree expected
+                                :actual-worktree actual
+                                :source-root (:source-root context)}))))
+
+(defn- ^{:stratum 1} print-runtime-provenance!
+  [quiet context]
+  (print-colored-lines! quiet (runtime-provenance-lines context)))
+
+(defn- ^{:stratum 1} backend-preflight-config []
+  (:backend-preflight @workflow-runner-config))
+
+(defn- ^{:stratum 1} normalize-command-path
   [path]
   (when (executable-file? path)
     (str (-> path
              fs/path
              fs/absolutize))))
 
-(defn- portable-command-path
-  [cmd]
-  (some-> cmd
-          fs/which
-          normalize-command-path))
-
-(defn- path-entries
-  []
-  (str/split (or (System/getenv "PATH") "") #":"))
-
-(defn- matching-command-path
+(defn- ^{:stratum 1} matching-command-path
   [entry cmd]
   (let [candidate (fs/path entry cmd)]
     (when (executable-file? candidate)
       (str candidate))))
 
-(defn- resolve-cli-command-path
-  [cmd]
-  (cond
-    (str/blank? cmd) nil
-    (direct-command-path? cmd)
-    (normalize-command-path cmd)
-
-    :else
-    (or (portable-command-path cmd)
-        (some #(matching-command-path % cmd) (path-entries)))))
-
-(defn- cli-process-env
-  []
-  (when (System/getenv "CLAUDECODE")
-    (into {} (remove (fn [[k _]] (= k "CLAUDECODE"))) (System/getenv))))
-
-(defn- start-cli-process
+(defn- ^{:stratum 1} start-cli-process
   [cmd workdir]
   (let [builder (ProcessBuilder. ^java.util.List cmd)]
     (when-let [process-env (cli-process-env)]
@@ -336,26 +526,239 @@
       (.directory builder (java.io.File. workdir)))
     (.start builder)))
 
-(defn- stream-reader
-  [stream]
-  (future
-    (with-open [stream stream]
-      (slurp stream))))
+(defn- ^{:stratum 1} response-summary
+  [response]
+  (merge
+   (select-keys response [:success :error :anomaly :exit-code])
+   (select-keys (response-output response)
+                [:content :exit-code :version])))
 
-(defn- destroy-cli-process!
-  [^Process process]
-  (try
-    (.destroyForcibly process)
-    (.waitFor process 1000 java.util.concurrent.TimeUnit/MILLISECONDS)
-    (catch Exception _ nil)))
+(defn- ^{:stratum 1} print-backend-provenance!
+  [quiet {:keys [backend cmd-path cmd-version]}]
+  (print-colored-lines! quiet (backend-provenance-lines {:backend backend
+                                                         :cmd-path cmd-path
+                                                         :cmd-version cmd-version})))
 
-(defn- await-stream
-  [stream-future]
-  (try
-    @stream-future
-    (catch Exception _ "")))
+(defn- ^{:stratum 1} normalized-preflight-content
+  [content]
+  (loop [candidate (some-> content str/trim not-empty)]
+    (let [parsed (parse-preflight-payload candidate)
+          nested (or (some-> parsed :result str/trim not-empty)
+                     (some-> parsed :content str/trim not-empty))]
+      (cond
+        (and (:result parsed)
+             (not (and (= "result" (:type parsed))
+                       (= "success" (:subtype parsed))
+                       (not (:is_error parsed)))))
+        nil
 
-(defn- run-cli-command
+        (and nested (not= nested candidate))
+        (recur nested)
+
+        :else
+        candidate))))
+
+(defn- ^{:stratum 1} decoded-preflight-content
+  [backend-config output]
+  (if-let [stream-parser (:stream-parser backend-config)]
+    (backend-stream-content stream-parser output)
+    (some-> output str/trim not-empty)))
+
+(defn- ^{:stratum 1} ensure-cli-command-path!
+  [stamp]
+  (when-not (:cmd-path stamp)
+    (backend-cli-missing! stamp))
+  stamp)
+
+(defn ^{:stratum 1} resolve-workflow-alias
+  "Resolve a workflow type through the alias map. Returns the canonical type
+   if an alias exists, otherwise returns the type unchanged."
+  [workflow-type]
+  (get workflow-aliases workflow-type workflow-type))
+
+(defn ^{:stratum 1} publish-completion-event [event-stream workflow-id result]
+  (let [status (if (phase/succeeded? result) :success :failure)
+        duration-ms (get-in result [:execution/metrics :duration-ms])]
+    (es/publish! event-stream
+                 (if (= status :success)
+                   (es/workflow-completed event-stream workflow-id status duration-ms)
+                   (es/workflow-failed event-stream workflow-id
+                                       {:message (failure-message result)
+                                        :errors (or (seq (:execution/errors result))
+                                                    [{:type :unknown-failure
+                                                      :message (failure-message result)}])})))))
+
+;; lifecycle helpers
+;; Peers; none calls another. `run-workflow!` composes them at Layer 2.
+(defn ^{:stratum 1} start-workflow-manifest!
+  "Init the manifest at `manifest-dir` and start the heartbeat. Returns
+   `{:dir java.io.File :heartbeat ScheduledExecutorService :marked? atom}`
+   for the matching `finish-workflow-manifest!`. Returns nil when no
+   event stream is configured (dashboard-only run) — no on-disk
+   manifest to maintain in that case."
+  [workflow-id event-stream]
+  (when event-stream
+    (let [dir (es/workflow-dir workflow-id)]
+      ((:save-manifest! *manifest-ops*) dir ((:init-active *manifest-ops*) workflow-id))
+      {:dir       dir
+       :heartbeat ((:start-heartbeat! *manifest-ops*) dir)
+       :marked?   (atom false)})))
+
+(defn ^{:stratum 1} mark-manifest-terminal!
+  "Stamp the manifest with a terminal `status` (`:completed |
+   :failed | :cancelled`). Idempotent via the `:marked?` atom — the
+   happy path marks `:completed` after drain, the finally block falls
+   back to `:cancelled` only if no prior mark fired.
+
+   Only flips `marked?` after a successful load + save. If the
+   manifest file is absent (e.g. it was deleted or never written by
+   sub-3b's archive flow), this is a no-op that leaves `marked?`
+   false so a subsequent attempt (e.g. the finally's :cancelled
+   fallback) can still try to write."
+  [{:keys [dir marked?]} status]
+  (when (and dir (not @marked?))
+    (when-let [m ((:load-manifest *manifest-ops*) dir)]
+      ((:save-manifest! *manifest-ops*) dir ((:mark-terminal *manifest-ops*) m status))
+      (reset! marked? true))))
+
+(defn ^{:stratum 1} finish-workflow-manifest!
+  "Stop the heartbeat. Caller is expected to have already called
+   `mark-manifest-terminal!` for the happy path; this is the
+   shutdown-time cleanup. Swallows exceptions so a manifest IO
+   failure during cleanup doesn't mask the workflow result.
+
+   `stop-heartbeat!` can raise `InterruptedException` via
+   `awaitTermination`. Swallowing it without restoring the interrupt
+   flag breaks cooperative cancellation — outer frames lose the
+   signal that they're being asked to shut down. We re-interrupt the
+   current thread in that case and still return nil so the cleanup
+   stays best-effort."
+  [{:keys [heartbeat]}]
+  (when heartbeat
+    (try
+      ((:stop-heartbeat! *manifest-ops*) heartbeat)
+      (catch InterruptedException _
+        (.interrupt (Thread/currentThread))
+        nil)
+      (catch Exception _ nil))))
+
+(defn ^{:stratum 1} archive-workflow-manifest!
+  "Run BD-2b sub-3b's atomic archive on `workflow-id`'s `live/`
+   directory. Called from the happy path after `mark-manifest-terminal!`
+   succeeds — at that point the manifest is at terminal status with
+   `archive_status = :live` and ready to transition to `:archived`.
+
+   Best-effort: archive failures (e.g. the manifest disappeared
+   between mark and archive, or the rename hit an IO error) are
+   logged to stderr but don't propagate. The boot-time
+   `archive/recover-all-incomplete!` pass picks up any half-finished
+   archives on next start. The finally's `:cancelled` fallback does
+   NOT archive — those workflows wait for the scheduled cleanup
+   pass (sub-3c) so a crashing pipeline can't get half-archived state
+   stuck on disk via the recovery flow."
+  [{:keys [dir marked?]} workflow-id]
+  (when (and dir @marked?)
+    (try
+      (let [result ((:archive-workflow! *manifest-ops*) workflow-id)]
+        (when (anomaly/anomaly? result)
+          (binding [*out* *err*]
+            (println (str "WARNING: archive of workflow " workflow-id
+                          " failed: " (:anomaly/message result)
+                          " (will be recovered by the cleanup pass)")))))
+      (catch Exception e
+        (binding [*out* *err*]
+          (println (str "WARNING: archive of workflow " workflow-id
+                        " failed: " (.getMessage e)
+                        " (will be recovered by the cleanup pass)")))))))
+
+(defn- ^{:stratum 1} event-stream-shutdown!
+  "Run the BD-2a shutdown sequence on `es`: quiesce publishers for
+   `workflow-id`, then drain sinks. Returns the structured drain result
+   for inclusion in the run result map, or `nil` when no event stream
+   exists (dashboard-url runs).
+
+   On a non-OK drain in normal mode (best-effort off), throws an
+   ex-info carrying the drain result so the caller's catch path renders
+   the failure and the CLI exits non-zero. Best-effort mode logs the
+   degradation to stderr and returns the result without throwing."
+  [es workflow-id {:keys [quiet]}]
+  (when es
+    (es/quiesce! es {:workflow-id workflow-id :timeout-ms 5000})
+    (let [drain-result (es/drain! es {:timeout-ms 5000})]
+      (when-not (:ok? drain-result)
+        (let [best-effort? (best-effort-shutdown?)
+              msg (str "Event-stream drain incomplete on shutdown: "
+                       (name (:reason drain-result :unknown))
+                       (when-let [pending (:pending-count drain-result)]
+                         (str " (pending=" pending ")"))
+                       (when-let [failed (:failed-sinks drain-result)]
+                         (str " (failed-sinks=" (count failed) ")")))]
+          (binding [*out* *err*]
+            (println (cond-> msg
+                       (not quiet) (->> (display/colorize :yellow))
+                       best-effort? (str " [MINIFORGE_BEST_EFFORT_SHUTDOWN=1, continuing]"))))
+          (when-not best-effort?
+            (response/throw-anomaly! :anomalies/fault
+                                     msg
+                                     {:reason :event-stream-drain-failed
+                                      :drain-result drain-result}))))
+      drain-result)))
+
+(defn ^{:stratum 1} list-workflows-from-resources []
+  (let [list-workflows workflow/list-workflows]
+    (->> (list-workflows)
+         (sort-by (juxt :workflow/id :workflow/version))
+         format-workflow-listing)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} move-spec-to-in-progress!
+  "Move a work spec to in-progress when execution starts.
+   Returns updated provenance with new source-file path,
+   or the original provenance if the move was a no-op."
+  [provenance]
+  (if-let [new-path (move-spec! provenance :in-progress)]
+    (assoc provenance :source-file new-path)
+    provenance))
+
+(defn ^{:stratum 2} move-spec-on-completion!
+  "Move a work spec to done or failed based on workflow result."
+  [provenance result]
+  (if (phase/succeeded? result)
+    (move-spec! provenance :done)
+    (move-spec! provenance :failed)))
+
+(defn- ^{:stratum 2} assert-source-dir-alignment!
+  [spec context]
+  (let [source-dir (:spec/source-dir spec)
+        source-root (:source-root context)]
+    (when-not (source-dir-under-root? source-dir source-root)
+      (response/throw-anomaly! :anomalies/incorrect
+                               (str "Spec source directory is outside the workflow source root: "
+                                    source-dir)
+                               {:source-dir source-dir
+                                :source-root source-root
+                                :worktree-path (:worktree-path context)}))))
+
+(defn- ^{:stratum 2} backend-preflight-prompt []
+  (:prompt (backend-preflight-config)))
+
+(defn- ^{:stratum 2} backend-preflight-timeout-ms []
+  (:timeout-ms (backend-preflight-config)))
+
+(defn- ^{:stratum 2} backend-version-timeout-ms []
+  (:version-timeout-ms (backend-preflight-config)))
+
+(defn- ^{:stratum 2} claude-preflight-args []
+  (:claude-args (backend-preflight-config)))
+
+(defn- ^{:stratum 2} portable-command-path
+  [cmd]
+  (some-> cmd
+          fs/which
+          normalize-command-path))
+
+(defn- ^{:stratum 2} run-cli-command
   [cmd timeout-ms & {:keys [workdir]}]
   (let [^Process process (start-cli-process cmd workdir)
         _ (.close (.getOutputStream process))
@@ -376,270 +779,11 @@
        :err (await-stream err-future)
        :exit (.exitValue process)})))
 
-(defn- success-response
-  [output]
-  (response/success output))
-
-(defn- failure-response
-  [category error-type message data]
-  (-> (response/failure message {:data (assoc data :type error-type)})
-      (assoc :anomaly (response/make-anomaly category message data))))
-
-(defn- response-output
-  [response]
-  (let [output (get response :output)]
-    (merge (select-keys response [:content :exit-code :version])
-           (if (map? output) output {}))))
-
-(defn- response-succeeded?
-  [response]
-  (or (true? (:success response))
-      (response/success? response)))
-
-(defn- response-summary
-  [response]
-  (merge
-   (select-keys response [:success :error :anomaly :exit-code])
-   (select-keys (response-output response)
-                [:content :exit-code :version])))
-
-(defn- read-cli-version
-  [cmd-path]
-  (let [{:keys [out err exit timeout-ms]} (run-cli-command [cmd-path "--version"] (backend-version-timeout-ms))]
-    (cond
-      timeout-ms
-      (failure-response :anomalies/unavailable
-                        "backend_version_timeout"
-                        (messages/t :workflow-runner/backend-version-timeout
-                                    {:timeout-ms timeout-ms})
-                        {:cmd-path cmd-path
-                         :timeout-ms timeout-ms})
-
-      (zero? exit)
-      (if-let [version (or (some-> out str/trim not-empty)
-                           (some-> err str/trim not-empty))]
-        (success-response {:version version})
-        (failure-response :anomalies/unavailable
-                          "backend_version_empty_output"
-                          (messages/t :workflow-runner/backend-version-empty)
-                          {:cmd-path cmd-path
-                           :exit-code exit}))
-
-      :else
-      (failure-response :anomalies/unavailable
-                        "backend_version_cli_error"
-                        (or (some-> err str/trim not-empty)
-                            (some-> out str/trim not-empty)
-                            (messages/t :workflow-runner/backend-version-exit
-                                        {:exit-code exit}))
-                        {:cmd-path cmd-path
-                         :exit-code exit}))))
-
-(defn- backend-stamp
-  [llm-client]
-  (when-let [backend (llm/client-backend llm-client)]
-    (let [backend-config (get llm/backends backend)
-          cmd (:cmd backend-config)
-          cmd-path (when (:requires-cli? backend-config)
-                     (resolve-cli-command-path cmd))]
-      {:backend backend
-       :backend-config backend-config
-       :cmd cmd
-       :cmd-path cmd-path})))
-
-(defn- with-backend-version
-  [stamp version]
-  (assoc stamp :cmd-version version))
-
-(defn- backend-provenance-lines
-  [{:keys [backend cmd-path cmd-version]}]
-  (concat
-   [[:cyan (messages/t :workflow-runner/backend-label
-                       {:backend (name backend)})]]
-   (when cmd-path
-     [[:cyan (messages/t :workflow-runner/backend-path {:path cmd-path})]])
-   (when cmd-version
-     [[:cyan (messages/t :workflow-runner/backend-version {:version cmd-version})]])))
-
-(defn- print-backend-provenance!
-  [quiet {:keys [backend cmd-path cmd-version]}]
-  (print-colored-lines! quiet (backend-provenance-lines {:backend backend
-                                                         :cmd-path cmd-path
-                                                         :cmd-version cmd-version})))
-
-(defn- claude-preflight-command
-  [cmd-path]
-  (into [cmd-path "-p" (backend-preflight-prompt)]
-        (claude-preflight-args)))
-
-(defn- cli-required-backend-stamp
-  [llm-client]
-  (when-let [stamp (backend-stamp llm-client)]
-    (when (:requires-cli? (:backend-config stamp))
-      stamp)))
-
-(defn- parse-preflight-payload
-  [content]
-  (try
-    (some-> content str/trim not-empty (json/parse-string true))
-    (catch Exception _ nil)))
-
-(defn- normalized-preflight-content
-  [content]
-  (loop [candidate (some-> content str/trim not-empty)]
-    (let [parsed (parse-preflight-payload candidate)
-          nested (or (some-> parsed :result str/trim not-empty)
-                     (some-> parsed :content str/trim not-empty))]
-      (cond
-        (and (:result parsed)
-             (not (and (= "result" (:type parsed))
-                       (= "success" (:subtype parsed))
-                       (not (:is_error parsed)))))
-        nil
-
-        (and nested (not= nested candidate))
-        (recur nested)
-
-        :else
-        candidate))))
-
-(defn- preflight-success?
+(defn- ^{:stratum 2} preflight-success?
   [content]
   (= {:ok true} (parse-preflight-payload (normalized-preflight-content content))))
 
-(defn- backend-stream-content
-  [stream-parser output]
-  (let [content (atom "")]
-    (doseq [line (str/split-lines (or output ""))]
-      (when-let [parsed (stream-parser line)]
-        (when-let [delta (:delta parsed)]
-          (swap! content str delta))))
-    (some-> @content str/trim not-empty)))
-
-(defn- decoded-preflight-content
-  [backend-config output]
-  (if-let [stream-parser (:stream-parser backend-config)]
-    (backend-stream-content stream-parser output)
-    (some-> output str/trim not-empty)))
-
-(defn- generic-preflight-command
-  [llm-client]
-  (let [{:keys [backend model]} (:config llm-client)
-        {:keys [cmd args-fn]} (get llm/backends backend)
-        request (cond-> {:prompt (backend-preflight-prompt)}
-                  model (assoc :model model))]
-    (into [cmd] (args-fn request))))
-
-(defn- run-generic-backend-preflight
-  [llm-client cmd-path workdir]
-  (let [{:keys [backend]} (:config llm-client)
-        backend-config (get llm/backends backend)
-        full-cmd (into [cmd-path] (rest (generic-preflight-command llm-client)))
-        {:keys [out err exit timeout-ms]} (run-cli-command full-cmd
-                                                           (backend-preflight-timeout-ms)
-                                                           :workdir workdir)
-        content (decoded-preflight-content backend-config out)]
-    (cond
-      timeout-ms
-      (failure-response :anomalies/unavailable
-                        "backend_preflight_timeout"
-                        err
-                        {:cmd-path cmd-path
-                         :timeout-ms timeout-ms
-                         :exit-code exit})
-
-      (not (zero? exit))
-      (failure-response :anomalies/unavailable
-                        "backend_preflight_cli_error"
-                        (or (some-> err str/trim not-empty)
-                            content
-                            (messages/t :workflow-runner/backend-preflight-exit
-                                        {:exit-code exit}))
-                        {:cmd-path cmd-path
-                         :stdout (some-> out str/trim not-empty)
-                         :stderr (some-> err str/trim not-empty)
-                         :exit-code exit})
-
-      (preflight-success? content)
-      (success-response {:content content
-                         :exit-code exit})
-
-      :else
-      (failure-response :anomalies/unavailable
-                        "backend_preflight_unexpected_output"
-                        (messages/t :workflow-runner/backend-preflight-failed
-                                    {:backend (name backend)})
-                        {:cmd-path cmd-path
-                         :stdout (some-> out str/trim not-empty)
-                         :stderr (some-> err str/trim not-empty)
-                         :content (normalized-preflight-content content)
-                         :exit-code exit}))))
-
-(defn- run-claude-backend-preflight
-  [cmd-path workdir]
-  (let [{:keys [out err exit timeout-ms]} (run-cli-command (claude-preflight-command cmd-path)
-                                                           (backend-preflight-timeout-ms)
-                                                           :workdir workdir)
-        trimmed (some-> out str/trim)
-        content (normalized-preflight-content trimmed)]
-    (cond
-      timeout-ms
-      (assoc (failure-response :anomalies/unavailable
-                               "backend_preflight_timeout"
-                               err
-                               {:cmd-path cmd-path
-                                :timeout-ms timeout-ms
-                                :exit-code exit})
-             :exit-code exit)
-
-      (not (zero? exit))
-      (assoc (failure-response :anomalies/unavailable
-                               "backend_preflight_cli_error"
-                               (or (some-> err str/trim not-empty)
-                                   trimmed
-                                   (messages/t :workflow-runner/backend-preflight-exit
-                                               {:exit-code exit}))
-                               {:cmd-path cmd-path
-                                :exit-code exit})
-             :exit-code exit)
-
-      (preflight-success? content)
-      (-> (success-response {:content content
-                             :exit-code exit})
-          (assoc :exit-code exit
-                 :content content))
-
-      :else
-      (assoc (failure-response :anomalies/unavailable
-                               "backend_preflight_unexpected_output"
-                               (messages/t :workflow-runner/claude-preflight-unexpected-output)
-                               {:cmd-path cmd-path
-                                :stdout trimmed
-                                :content content
-                                :stderr (some-> err str/trim not-empty)
-                                :exit-code exit})
-             :exit-code exit))))
-
-(defn- backend-cli-missing!
-  [{:keys [backend cmd]}]
-  (response/throw-anomaly! :anomalies/incorrect
-                           (messages/t :workflow-runner/cli-not-on-path {:cmd cmd})
-                           {:backend backend
-                            :cmd cmd
-                            :path (System/getenv "PATH")}))
-
-(defn- backend-version-failed!
-  [{:keys [backend cmd cmd-path]} version-response]
-  (response/throw-anomaly! :anomalies/unavailable
-                           (messages/t :workflow-runner/backend-version-failed
-                                       {:backend (name backend)})
-                           {:backend backend
-                            :cmd cmd
-                            :cmd-path cmd-path
-                            :version-error (get-in version-response [:error :message])
-                            :version-error-data (get-in version-response [:error :data])}))
-
-(defn- backend-preflight-failed!
+(defn- ^{:stratum 2} backend-preflight-failed!
   [{:keys [backend cmd cmd-path cmd-version]} probe-response]
   (response/throw-anomaly! :anomalies/unavailable
                            (messages/t :workflow-runner/backend-preflight-failed
@@ -650,81 +794,7 @@
                             :cmd-version cmd-version
                             :probe-response (response-summary probe-response)}))
 
-(defn- run-backend-probe
-  [llm-client {:keys [backend cmd-path]} workdir]
-  (if (= backend :claude)
-    (run-claude-backend-preflight cmd-path workdir)
-    (run-generic-backend-preflight llm-client cmd-path workdir)))
-
-(defn- ensure-cli-command-path!
-  [stamp]
-  (when-not (:cmd-path stamp)
-    (backend-cli-missing! stamp))
-  stamp)
-
-(defn- versioned-backend-stamp
-  [stamp]
-  (let [version-response (read-cli-version (:cmd-path stamp))
-        version (get-in (response-output version-response) [:version])]
-    (when-not (response-succeeded? version-response)
-      (backend-version-failed! stamp version-response))
-    (with-backend-version stamp version)))
-
-(defn- verify-backend-probe!
-  [llm-client stamp workdir]
-  (let [probe-response (run-backend-probe llm-client stamp workdir)]
-    (when-not (response-succeeded? probe-response)
-      (backend-preflight-failed! stamp probe-response))
-    stamp))
-
-(defn- run-backend-preflight!
-  [quiet llm-client context]
-  (when-let [stamp (cli-required-backend-stamp llm-client)]
-    (let [stamp (-> stamp
-                    ensure-cli-command-path!
-                    versioned-backend-stamp)]
-      (print-backend-provenance! quiet stamp)
-      (verify-backend-probe! llm-client stamp (:worktree-path context)))))
-
-(defn close-artifact-store [artifact-store]
-  (when artifact-store
-    (try
-      (artifact/close-store artifact-store)
-      (catch Exception _))))
-
-(defn select-workflow-type
-  "Select workflow type using LLM recommendation if not explicitly specified.
-   Checks :spec/workflow-type first, then :workflow/type as a fallback for
-   specs that use the shorter key."
-  [spec llm-client quiet]
-  (if-let [explicit-type (or (:spec/workflow-type spec)
-                             (:workflow/type spec))]
-    (do
-      (when-not quiet
-        (println (display/colorize :cyan (messages/t :workflow-runner/user-specified {:workflow-type (name explicit-type)}))))
-      explicit-type)
-    (let [recommendation (recommender/recommend-workflow-with-fallback spec llm-client)]
-      (when-not quiet
-        (println (display/colorize :cyan (messages/t :workflow-runner/auto-selected {:workflow-type (name (:workflow recommendation))})))
-        (println (messages/t :workflow-runner/auto-selected-reason {:reasoning (:reasoning recommendation)}))
-        (when (= :llm (:source recommendation))
-          (println (messages/t :workflow-runner/auto-selected-confidence {:confidence (format "%.0f%%" (* 100 (:confidence recommendation 0.0)))})))
-        (println (display/colorize :yellow (messages/t :workflow-runner/auto-selected-override))))
-      (:workflow recommendation))))
-
-(def ^:private workflow-aliases
-  "Map legacy/alternate workflow type keywords to their canonical counterparts.
-   Many work specs use :standard-sdlc but the only registered workflow is
-   :canonical-sdlc."
-  {:standard-sdlc :canonical-sdlc})
-
-(defn resolve-workflow-alias
-  "Resolve a workflow type through the alias map. Returns the canonical type
-   if an alias exists, otherwise returns the type unchanged."
-  [workflow-type]
-  (get workflow-aliases workflow-type workflow-type))
-
-(defn load-or-create-workflow [load-workflow workflow-type workflow-version]
+(defn ^{:stratum 2} load-or-create-workflow [load-workflow workflow-type workflow-version]
   (let [workflow-type (resolve-workflow-alias workflow-type)]
     (try
       (load-and-validate-workflow load-workflow workflow-type workflow-version)
@@ -747,48 +817,7 @@
 
           (throw e))))))
 
-(defn execute-workflow-pipeline [run-pipeline workflow input callbacks artifact-store event-stream]
-  (-> callbacks
-      (cond-> artifact-store (assoc :artifact-store artifact-store))
-      (cond-> event-stream (assoc :event-stream event-stream))
-      (->> (run-pipeline workflow input))))
-
-(defn- failure-message
-  "Build a meaningful failure message from a workflow result.
-   Falls back to execution status when no explicit errors exist."
-  [result]
-  (let [errors (:execution/errors result)
-        status (get result :execution/status :unknown)]
-    (if (seq errors)
-      (str (first errors))
-      (str "Workflow ended with status: " (name status)))))
-
-(defn publish-completion-event [event-stream workflow-id result]
-  (let [status (if (phase/succeeded? result) :success :failure)
-        duration-ms (get-in result [:execution/metrics :duration-ms])]
-    (es/publish! event-stream
-                 (if (= status :success)
-                   (es/workflow-completed event-stream workflow-id status duration-ms)
-                   (es/workflow-failed event-stream workflow-id
-                                       {:message (failure-message result)
-                                        :errors (or (seq (:execution/errors result))
-                                                    [{:type :unknown-failure
-                                                      :message (failure-message result)}])})))))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Execution orchestration
-
-(defn- publish-failure-event!
-  "Publish a workflow failure event, swallowing exceptions."
-  [event-stream workflow-id error-type message]
-  (try
-    (es/publish! event-stream
-                 (es/workflow-failed event-stream workflow-id
-                                     {:message message
-                                      :errors [{:type error-type :message message}]}))
-    (catch Exception _ nil)))
-
-(defn execute-with-events [{:keys [run-pipeline workflow workflow-input context artifact-store
+(defn ^{:stratum 2} execute-with-events [{:keys [run-pipeline workflow workflow-input context artifact-store
                                      event-stream workflow-id sandbox-cleanup opts]}]
   (let [completed? (atom false)]
     (try+
@@ -822,146 +851,7 @@
           (when-not (:quiet opts)
             (println (display/colorize :yellow (messages/t :workflow-runner/sandbox-released)))))))))
 
-(defn- best-effort-shutdown?
-  "Honor `MINIFORGE_BEST_EFFORT_SHUTDOWN` as the documented escape hatch
-   for local/dev loops that don't care about event durability. Default
-   off — normal headless mode treats drain failures as errors."
-  []
-  (let [v (System/getenv "MINIFORGE_BEST_EFFORT_SHUTDOWN")]
-    (boolean (and v (contains? #{"1" "true" "yes" "on"} (str/lower-case v))))))
-
-;; BD-2b sub-3a: per-workflow manifest lifecycle.
-
-;------------------------------------------------------------------------------ Layer 1 — manifest operations
-
-(def ^:dynamic *manifest-ops*
-  "Manifest operations used by the workflow lifecycle helpers."
-  {:init-active       es-manifest/init-active
-   :load-manifest     es-manifest/load-manifest
-   :mark-terminal     es-manifest/mark-terminal
-   :save-manifest!    es-manifest/save-manifest!
-   :start-heartbeat!  es-manifest/start-heartbeat!
-   :stop-heartbeat!   es-manifest/stop-heartbeat!
-   :archive-workflow! es-manifest/archive-workflow!})
-
-;------------------------------------------------------------------------------ Layer 2 — lifecycle helpers
-;; Peers; none calls another. `run-workflow!` composes them at Layer 3.
-
-(defn start-workflow-manifest!
-  "Init the manifest at `manifest-dir` and start the heartbeat. Returns
-   `{:dir java.io.File :heartbeat ScheduledExecutorService :marked? atom}`
-   for the matching `finish-workflow-manifest!`. Returns nil when no
-   event stream is configured (dashboard-only run) — no on-disk
-   manifest to maintain in that case."
-  [workflow-id event-stream]
-  (when event-stream
-    (let [dir (es/workflow-dir workflow-id)]
-      ((:save-manifest! *manifest-ops*) dir ((:init-active *manifest-ops*) workflow-id))
-      {:dir       dir
-       :heartbeat ((:start-heartbeat! *manifest-ops*) dir)
-       :marked?   (atom false)})))
-
-(defn mark-manifest-terminal!
-  "Stamp the manifest with a terminal `status` (`:completed |
-   :failed | :cancelled`). Idempotent via the `:marked?` atom — the
-   happy path marks `:completed` after drain, the finally block falls
-   back to `:cancelled` only if no prior mark fired.
-
-   Only flips `marked?` after a successful load + save. If the
-   manifest file is absent (e.g. it was deleted or never written by
-   sub-3b's archive flow), this is a no-op that leaves `marked?`
-   false so a subsequent attempt (e.g. the finally's :cancelled
-   fallback) can still try to write."
-  [{:keys [dir marked?]} status]
-  (when (and dir (not @marked?))
-    (when-let [m ((:load-manifest *manifest-ops*) dir)]
-      ((:save-manifest! *manifest-ops*) dir ((:mark-terminal *manifest-ops*) m status))
-      (reset! marked? true))))
-
-(defn finish-workflow-manifest!
-  "Stop the heartbeat. Caller is expected to have already called
-   `mark-manifest-terminal!` for the happy path; this is the
-   shutdown-time cleanup. Swallows exceptions so a manifest IO
-   failure during cleanup doesn't mask the workflow result.
-
-   `stop-heartbeat!` can raise `InterruptedException` via
-   `awaitTermination`. Swallowing it without restoring the interrupt
-   flag breaks cooperative cancellation — outer frames lose the
-   signal that they're being asked to shut down. We re-interrupt the
-   current thread in that case and still return nil so the cleanup
-   stays best-effort."
-  [{:keys [heartbeat]}]
-  (when heartbeat
-    (try
-      ((:stop-heartbeat! *manifest-ops*) heartbeat)
-      (catch InterruptedException _
-        (.interrupt (Thread/currentThread))
-        nil)
-      (catch Exception _ nil))))
-
-(defn archive-workflow-manifest!
-  "Run BD-2b sub-3b's atomic archive on `workflow-id`'s `live/`
-   directory. Called from the happy path after `mark-manifest-terminal!`
-   succeeds — at that point the manifest is at terminal status with
-   `archive_status = :live` and ready to transition to `:archived`.
-
-   Best-effort: archive failures (e.g. the manifest disappeared
-   between mark and archive, or the rename hit an IO error) are
-   logged to stderr but don't propagate. The boot-time
-   `archive/recover-all-incomplete!` pass picks up any half-finished
-   archives on next start. The finally's `:cancelled` fallback does
-   NOT archive — those workflows wait for the scheduled cleanup
-   pass (sub-3c) so a crashing pipeline can't get half-archived state
-   stuck on disk via the recovery flow."
-  [{:keys [dir marked?]} workflow-id]
-  (when (and dir @marked?)
-    (try
-      (let [result ((:archive-workflow! *manifest-ops*) workflow-id)]
-        (when (anomaly/anomaly? result)
-          (binding [*out* *err*]
-            (println (str "WARNING: archive of workflow " workflow-id
-                          " failed: " (:anomaly/message result)
-                          " (will be recovered by the cleanup pass)")))))
-      (catch Exception e
-        (binding [*out* *err*]
-          (println (str "WARNING: archive of workflow " workflow-id
-                        " failed: " (.getMessage e)
-                        " (will be recovered by the cleanup pass)")))))))
-
-(defn- event-stream-shutdown!
-  "Run the BD-2a shutdown sequence on `es`: quiesce publishers for
-   `workflow-id`, then drain sinks. Returns the structured drain result
-   for inclusion in the run result map, or `nil` when no event stream
-   exists (dashboard-url runs).
-
-   On a non-OK drain in normal mode (best-effort off), throws an
-   ex-info carrying the drain result so the caller's catch path renders
-   the failure and the CLI exits non-zero. Best-effort mode logs the
-   degradation to stderr and returns the result without throwing."
-  [es workflow-id {:keys [quiet]}]
-  (when es
-    (es/quiesce! es {:workflow-id workflow-id :timeout-ms 5000})
-    (let [drain-result (es/drain! es {:timeout-ms 5000})]
-      (when-not (:ok? drain-result)
-        (let [best-effort? (best-effort-shutdown?)
-              msg (str "Event-stream drain incomplete on shutdown: "
-                       (name (:reason drain-result :unknown))
-                       (when-let [pending (:pending-count drain-result)]
-                         (str " (pending=" pending ")"))
-                       (when-let [failed (:failed-sinks drain-result)]
-                         (str " (failed-sinks=" (count failed) ")")))]
-          (binding [*out* *err*]
-            (println (cond-> msg
-                       (not quiet) (->> (display/colorize :yellow))
-                       best-effort? (str " [MINIFORGE_BEST_EFFORT_SHUTDOWN=1, continuing]"))))
-          (when-not best-effort?
-            (response/throw-anomaly! :anomalies/fault
-                                     msg
-                                     {:reason :event-stream-drain-failed
-                                      :drain-result drain-result}))))
-      drain-result)))
-
-(defn run-workflow! [workflow-id {:keys [version output quiet event-stream dashboard-url]
+(defn ^{:stratum 2} run-workflow! [workflow-id {:keys [version output quiet event-stream dashboard-url]
                                     :or {version "latest" output :pretty quiet false}
                                     :as opts}]
   ;; Piggyback deferred GC on each workflow start — deletes scratch refs
@@ -1038,58 +928,226 @@
                   {:pretty true})))
       (throw e))))
 
-(defn format-workflow-listing [workflows]
-  (if (empty? workflows)
-    (println (messages/t :workflow-runner/no-workflows))
-    (do
-      (println (display/colorize :cyan (messages/t :workflow-runner/available-workflows)))
-      (println (display/colorize :cyan (apply str (repeat 60 "─"))))
-      (doseq [{:workflow/keys [id version description type]} workflows]
-        (println (str (display/colorize :bold (str "  " (name id)))
-                      " (v" version ")"
-                      "  " (display/colorize :yellow (messages/t :workflow-runner/workflow-type-label {:type (or type :unknown)}))
-                      (when description (str "\n    " description))))
-        (println))
-      (println (display/colorize :cyan (apply str (repeat 60 "─")))))))
-
-(defn list-workflows-from-resources []
-  (let [list-workflows workflow/list-workflows]
-    (->> (list-workflows)
-         (sort-by (juxt :workflow/id :workflow/version))
-         format-workflow-listing)))
-
-(defn list-workflows! []
+(defn ^{:stratum 2} list-workflows! []
   (try
     (list-workflows-from-resources)
     (catch Exception e
       (println (display/colorize :red (messages/t :workflow-runner/list-failed {:error (ex-message e)})))
       (throw e))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Spec-driven execution
+;------------------------------------------------------------------------------ Layer 3
 
-(defn- governed-workflow-id
-  "A UUID workflow id for a governed run. The operator control channel
-   routes `:pause`/`:resume`/`:cancel` interventions by coercing the
-   target id to a UUID, so a run WITHOUT a UUID id is uncontrollable —
-   its interventions can't reach its live-runner registry or audit
-   trail. Use the spec's `:session-id` when it already is a UUID (or a
-   UUID string); otherwise mint one. A PRESENT-but-non-UUID session-id
-   is warned about (it was silently discarded); an absent one is the
-   normal case and mints quietly."
-  [session-id quiet]
-  (or (when (uuid? session-id) session-id)
-      (when (string? session-id) (parse-uuid session-id))
-      (let [fresh (random-uuid)]
-        (when (and (some? session-id) (not quiet))
-          (println (display/colorize
-                    :yellow
-                    (messages/t :workflow-runner/non-uuid-session-id
-                                {:session-id (pr-str session-id)
-                                 :workflow-id (str fresh)}))))
-        fresh)))
+(defn- ^{:stratum 3} assert-runtime-alignment!
+  [spec context]
+  (assert-valid-source-root! context)
+  (assert-execution-worktree! context)
+  (assert-source-dir-alignment! spec context))
 
-(defn run-workflow-from-spec! [spec {:keys [quiet] :or {quiet false} :as opts}]
+(defn- ^{:stratum 3} resolve-cli-command-path
+  [cmd]
+  (cond
+    (str/blank? cmd) nil
+    (direct-command-path? cmd)
+    (normalize-command-path cmd)
+
+    :else
+    (or (portable-command-path cmd)
+        (some #(matching-command-path % cmd) (path-entries)))))
+
+(defn- ^{:stratum 3} read-cli-version
+  [cmd-path]
+  (let [{:keys [out err exit timeout-ms]} (run-cli-command [cmd-path "--version"] (backend-version-timeout-ms))]
+    (cond
+      timeout-ms
+      (failure-response :anomalies/unavailable
+                        "backend_version_timeout"
+                        (messages/t :workflow-runner/backend-version-timeout
+                                    {:timeout-ms timeout-ms})
+                        {:cmd-path cmd-path
+                         :timeout-ms timeout-ms})
+
+      (zero? exit)
+      (if-let [version (or (some-> out str/trim not-empty)
+                           (some-> err str/trim not-empty))]
+        (success-response {:version version})
+        (failure-response :anomalies/unavailable
+                          "backend_version_empty_output"
+                          (messages/t :workflow-runner/backend-version-empty)
+                          {:cmd-path cmd-path
+                           :exit-code exit}))
+
+      :else
+      (failure-response :anomalies/unavailable
+                        "backend_version_cli_error"
+                        (or (some-> err str/trim not-empty)
+                            (some-> out str/trim not-empty)
+                            (messages/t :workflow-runner/backend-version-exit
+                                        {:exit-code exit}))
+                        {:cmd-path cmd-path
+                         :exit-code exit}))))
+
+(defn- ^{:stratum 3} claude-preflight-command
+  [cmd-path]
+  (into [cmd-path "-p" (backend-preflight-prompt)]
+        (claude-preflight-args)))
+
+(defn- ^{:stratum 3} generic-preflight-command
+  [llm-client]
+  (let [{:keys [backend model]} (:config llm-client)
+        {:keys [cmd args-fn]} (get llm/backends backend)
+        request (cond-> {:prompt (backend-preflight-prompt)}
+                  model (assoc :model model))]
+    (into [cmd] (args-fn request))))
+
+;------------------------------------------------------------------------------ Layer 4
+
+(defn- ^{:stratum 4} backend-stamp
+  [llm-client]
+  (when-let [backend (llm/client-backend llm-client)]
+    (let [backend-config (get llm/backends backend)
+          cmd (:cmd backend-config)
+          cmd-path (when (:requires-cli? backend-config)
+                     (resolve-cli-command-path cmd))]
+      {:backend backend
+       :backend-config backend-config
+       :cmd cmd
+       :cmd-path cmd-path})))
+
+(defn- ^{:stratum 4} run-generic-backend-preflight
+  [llm-client cmd-path workdir]
+  (let [{:keys [backend]} (:config llm-client)
+        backend-config (get llm/backends backend)
+        full-cmd (into [cmd-path] (rest (generic-preflight-command llm-client)))
+        {:keys [out err exit timeout-ms]} (run-cli-command full-cmd
+                                                           (backend-preflight-timeout-ms)
+                                                           :workdir workdir)
+        content (decoded-preflight-content backend-config out)]
+    (cond
+      timeout-ms
+      (failure-response :anomalies/unavailable
+                        "backend_preflight_timeout"
+                        err
+                        {:cmd-path cmd-path
+                         :timeout-ms timeout-ms
+                         :exit-code exit})
+
+      (not (zero? exit))
+      (failure-response :anomalies/unavailable
+                        "backend_preflight_cli_error"
+                        (or (some-> err str/trim not-empty)
+                            content
+                            (messages/t :workflow-runner/backend-preflight-exit
+                                        {:exit-code exit}))
+                        {:cmd-path cmd-path
+                         :stdout (some-> out str/trim not-empty)
+                         :stderr (some-> err str/trim not-empty)
+                         :exit-code exit})
+
+      (preflight-success? content)
+      (success-response {:content content
+                         :exit-code exit})
+
+      :else
+      (failure-response :anomalies/unavailable
+                        "backend_preflight_unexpected_output"
+                        (messages/t :workflow-runner/backend-preflight-failed
+                                    {:backend (name backend)})
+                        {:cmd-path cmd-path
+                         :stdout (some-> out str/trim not-empty)
+                         :stderr (some-> err str/trim not-empty)
+                         :content (normalized-preflight-content content)
+                         :exit-code exit}))))
+
+(defn- ^{:stratum 4} run-claude-backend-preflight
+  [cmd-path workdir]
+  (let [{:keys [out err exit timeout-ms]} (run-cli-command (claude-preflight-command cmd-path)
+                                                           (backend-preflight-timeout-ms)
+                                                           :workdir workdir)
+        trimmed (some-> out str/trim)
+        content (normalized-preflight-content trimmed)]
+    (cond
+      timeout-ms
+      (assoc (failure-response :anomalies/unavailable
+                               "backend_preflight_timeout"
+                               err
+                               {:cmd-path cmd-path
+                                :timeout-ms timeout-ms
+                                :exit-code exit})
+             :exit-code exit)
+
+      (not (zero? exit))
+      (assoc (failure-response :anomalies/unavailable
+                               "backend_preflight_cli_error"
+                               (or (some-> err str/trim not-empty)
+                                   trimmed
+                                   (messages/t :workflow-runner/backend-preflight-exit
+                                               {:exit-code exit}))
+                               {:cmd-path cmd-path
+                                :exit-code exit})
+             :exit-code exit)
+
+      (preflight-success? content)
+      (-> (success-response {:content content
+                             :exit-code exit})
+          (assoc :exit-code exit
+                 :content content))
+
+      :else
+      (assoc (failure-response :anomalies/unavailable
+                               "backend_preflight_unexpected_output"
+                               (messages/t :workflow-runner/claude-preflight-unexpected-output)
+                               {:cmd-path cmd-path
+                                :stdout trimmed
+                                :content content
+                                :stderr (some-> err str/trim not-empty)
+                                :exit-code exit})
+             :exit-code exit))))
+
+(defn- ^{:stratum 4} versioned-backend-stamp
+  [stamp]
+  (let [version-response (read-cli-version (:cmd-path stamp))
+        version (get-in (response-output version-response) [:version])]
+    (when-not (response-succeeded? version-response)
+      (backend-version-failed! stamp version-response))
+    (with-backend-version stamp version)))
+
+;------------------------------------------------------------------------------ Layer 5
+
+(defn- ^{:stratum 5} cli-required-backend-stamp
+  [llm-client]
+  (when-let [stamp (backend-stamp llm-client)]
+    (when (:requires-cli? (:backend-config stamp))
+      stamp)))
+
+(defn- ^{:stratum 5} run-backend-probe
+  [llm-client {:keys [backend cmd-path]} workdir]
+  (if (= backend :claude)
+    (run-claude-backend-preflight cmd-path workdir)
+    (run-generic-backend-preflight llm-client cmd-path workdir)))
+
+;------------------------------------------------------------------------------ Layer 6
+
+(defn- ^{:stratum 6} verify-backend-probe!
+  [llm-client stamp workdir]
+  (let [probe-response (run-backend-probe llm-client stamp workdir)]
+    (when-not (response-succeeded? probe-response)
+      (backend-preflight-failed! stamp probe-response))
+    stamp))
+
+;------------------------------------------------------------------------------ Layer 7
+
+(defn- ^{:stratum 7} run-backend-preflight!
+  [quiet llm-client context]
+  (when-let [stamp (cli-required-backend-stamp llm-client)]
+    (let [stamp (-> stamp
+                    ensure-cli-command-path!
+                    versioned-backend-stamp)]
+      (print-backend-provenance! quiet stamp)
+      (verify-backend-probe! llm-client stamp (:worktree-path context)))))
+
+;------------------------------------------------------------------------------ Layer 8
+
+(defn ^{:stratum 8} run-workflow-from-spec! [spec {:keys [quiet] :or {quiet false} :as opts}]
   ;; Piggyback deferred GC on each spec-driven workflow start.
   (run-gc-pass-best-effort!)
   (try+
@@ -1187,85 +1245,7 @@
           (flush))
         (throw e)))))
 
-;------------------------------------------------------------------------------ Layer 2b
-;; Resume workflow from checkpointed DAG state
-
-(defn resume-workflow-from-spec!
-  "Resume a previously failed or paused workflow from checkpointed DAG state.
-
-   Arguments:
-   - workflow-id: UUID string of the workflow to resume
-   - spec: The original spec map (same spec file used for the initial run)
-   - opts: Same opts as run-workflow-from-spec!"
-  [workflow-id-str spec {:keys [quiet] :or {quiet false} :as opts}]
-  (let [resume-ctx (try
-                     (workflow-resume/resume-context workflow-id-str)
-                     (catch Exception e
-                       (when-not quiet
-                         (println (display/colorize :red
-                                   (messages/t :workflow-runner/resume-state-failed {:error (ex-message e)}))))
-                       nil))]
-    (when-not quiet
-      (println (display/colorize :cyan
-                (messages/t :workflow-runner/resuming {:workflow-id workflow-id-str})))
-      (println (display/colorize :cyan
-                (messages/t :workflow-runner/previously-completed {:count (count (:pre-completed-ids resume-ctx))})))
-      (when (seq (:pre-completed-artifacts resume-ctx))
-        (println (display/colorize :cyan
-                  (messages/t :workflow-runner/recovered-artifacts {:count (count (:pre-completed-artifacts resume-ctx))})))))
-    (if (and resume-ctx (seq (:pre-completed-ids resume-ctx)))
-      ;; Re-run with pre-completed task IDs injected
-      (let [execution-opts (-> (get opts :execution-opts {})
-                               (assoc :pre-completed-dag-tasks
-                                      (:pre-completed-ids resume-ctx))
-                               (assoc :pre-completed-artifacts
-                                      (:pre-completed-artifacts resume-ctx)))
-            opts-with-resume (assoc opts :execution-opts execution-opts)]
-        (run-workflow-from-spec! spec opts-with-resume))
-      (do
-        (when-not quiet
-          (println (display/colorize :yellow
-                    (messages/t :workflow-runner/no-completed-tasks))))
-        (run-workflow-from-spec! spec opts)))))
-
-;; ── Chain-driven execution ─────────────────────────────────────────────────
-
-(defn resolve-chain-input
-  "Resolve chain input from a spec file path or inline JSON."
-  [opts]
-  (let [spec-path (:spec opts)
-        inline-json (:input-json opts)]
-    (cond
-      inline-json (json/parse-string inline-json true)
-      spec-path (let [parsed (edn/read-string (slurp spec-path))
-                      enriched (context/decorate-spec-with-runtime-context parsed {})]
-                  (context/spec->workflow-input enriched))
-      :else {})))
-
-(defn print-chain-header
-  "Print chain execution banner."
-  [chain-id chain-def quiet]
-  (when-not quiet
-    (println)
-    (println (display/colorize :cyan (messages/t :workflow-runner/chain-header {:chain-id (name chain-id)})))
-    (println (display/colorize :cyan (messages/t :workflow-runner/chain-description {:description (:chain/description chain-def)})))
-    (println (display/colorize :cyan (messages/t :workflow-runner/chain-steps {:count (count (:chain/steps chain-def))})))
-    (println (display/colorize :cyan (apply str (repeat 60 "─"))))))
-
-(defn print-chain-result
-  "Print chain execution result summary."
-  [result quiet]
-  (when-not quiet
-    (let [steps (:chain/step-results result)
-          duration (:chain/duration-ms result)]
-      (println)
-      (println (display/colorize :cyan (apply str (repeat 60 "─"))))
-      (if (phase/succeeded? result)
-        (println (display/colorize :green (messages/t :workflow-runner/chain-completed {:count (count steps) :duration duration})))
-        (let [failed-step (some #(when (phase/failed? %) (:step/id %)) steps)]
-          (println (display/colorize :red (messages/t :workflow-runner/chain-failed-at {:step (when failed-step (name failed-step))}))))))))
-
-(defn run-chain!
+(defn ^{:stratum 8} run-chain!
   "Execute a chain of workflows.
 
    Arguments:
@@ -1312,24 +1292,43 @@
           (println (display/colorize :red (messages/t :workflow-runner/chain-execution-failed {:error (ex-message e)}))))
         (throw e)))))
 
-(defn list-chains!
-  "List all available chain definitions."
-  []
-  (try
-    (let [chains (workflow/list-chains)]
-      (if (empty? chains)
-        (println (messages/t :workflow-runner/no-chains))
-        (do
-          (println (display/colorize :cyan (messages/t :workflow-runner/available-chains)))
-          (println (display/colorize :cyan (apply str (repeat 60 "─"))))
-          (doseq [{:keys [id version description steps]} chains]
-            (println (str (display/colorize :bold (str "  " (name id)))
-                          " (v" version ")"
-                          "  " (messages/t :workflow-runner/chain-steps-label {:steps steps})))
-            (when description
-              (println (str "    " description)))
-            (println))
-          (println (display/colorize :cyan (apply str (repeat 60 "─")))))))
-    (catch Exception e
-      (println (display/colorize :red (messages/t :workflow-runner/list-chains-failed {:error (ex-message e)})))
-      (throw e))))
+;------------------------------------------------------------------------------ Layer 9
+
+;; Resume workflow from checkpointed DAG state
+(defn ^{:stratum 9} resume-workflow-from-spec!
+  "Resume a previously failed or paused workflow from checkpointed DAG state.
+
+   Arguments:
+   - workflow-id: UUID string of the workflow to resume
+   - spec: The original spec map (same spec file used for the initial run)
+   - opts: Same opts as run-workflow-from-spec!"
+  [workflow-id-str spec {:keys [quiet] :or {quiet false} :as opts}]
+  (let [resume-ctx (try
+                     (workflow-resume/resume-context workflow-id-str)
+                     (catch Exception e
+                       (when-not quiet
+                         (println (display/colorize :red
+                                   (messages/t :workflow-runner/resume-state-failed {:error (ex-message e)}))))
+                       nil))]
+    (when-not quiet
+      (println (display/colorize :cyan
+                (messages/t :workflow-runner/resuming {:workflow-id workflow-id-str})))
+      (println (display/colorize :cyan
+                (messages/t :workflow-runner/previously-completed {:count (count (:pre-completed-ids resume-ctx))})))
+      (when (seq (:pre-completed-artifacts resume-ctx))
+        (println (display/colorize :cyan
+                  (messages/t :workflow-runner/recovered-artifacts {:count (count (:pre-completed-artifacts resume-ctx))})))))
+    (if (and resume-ctx (seq (:pre-completed-ids resume-ctx)))
+      ;; Re-run with pre-completed task IDs injected
+      (let [execution-opts (-> (get opts :execution-opts {})
+                               (assoc :pre-completed-dag-tasks
+                                      (:pre-completed-ids resume-ctx))
+                               (assoc :pre-completed-artifacts
+                                      (:pre-completed-artifacts resume-ctx)))
+            opts-with-resume (assoc opts :execution-opts execution-opts)]
+        (run-workflow-from-spec! spec opts-with-resume))
+      (do
+        (when-not quiet
+          (println (display/colorize :yellow
+                    (messages/t :workflow-runner/no-completed-tasks))))
+        (run-workflow-from-spec! spec opts)))))

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/context.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/context.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.workflow-runner.context
   "Workflow input resolution and runtime context creation."
   (:require
@@ -32,9 +31,9 @@
    [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Input resolution
 
-(defn read-input-file [path]
+;; Input resolution
+(defn ^{:stratum 0} read-input-file [path]
   (when path
     (let [file (fs/file path)]
       (when-not (fs/exists? file)
@@ -50,7 +49,7 @@
                                   (str "Unsupported file format: " ext " (use .edn or .json)")
                                   {:path path :extension ext}))))))
 
-(defn parse-inline-json [s]
+(defn ^{:stratum 0} parse-inline-json [s]
   (when s
     (try
       (json/parse-string s true)
@@ -59,63 +58,24 @@
                                 (str "Failed to parse input JSON: " (ex-message e))
                                 {:input s})))))
 
-(defn resolve-input [{:keys [input input-json]}]
-  (cond
-    input-json (parse-inline-json input-json)
-    input (read-input-file input)
-    :else {}))
-
-(defn- resolve-git-field
+(defn- ^{:stratum 0} resolve-git-field
   [dir & args]
   (let [{:keys [exit out]} (apply shell/sh (concat ["git"] args [:dir dir]))]
     (when (zero? exit)
       (some-> out str/trim not-empty))))
 
-(defn- resolve-git-bool
-  [dir & args]
-  (boolean (apply resolve-git-field dir args)))
-
-(defn get-git-info
-  ([] (get-git-info nil))
-  ([start-path]
-   (try
-     (when-let [root (worktree/worktree-root start-path)]
-       (let [branch (resolve-git-field root "rev-parse" "--abbrev-ref" "HEAD")
-             commit (resolve-git-field root "rev-parse" "--short" "HEAD")]
-         (when (and branch commit)
-           {:git-branch branch
-            :git-commit commit})))
-     (catch Exception _ nil))))
-
-(defn get-git-state
-  ([] (get-git-state nil))
-  ([start-path]
-   (try
-     (when-let [root (worktree/worktree-root start-path)]
-       (let [branch (resolve-git-field root "rev-parse" "--abbrev-ref" "HEAD")
-             commit (resolve-git-field root "rev-parse" "--short" "HEAD")
-             upstream (resolve-git-field root "rev-parse" "--abbrev-ref" "--symbolic-full-name" "@{upstream}")
-             dirty? (resolve-git-bool root "status" "--porcelain")]
-         (when (and branch commit)
-           {:git-branch branch
-            :git-commit commit
-            :git-upstream upstream
-            :git-dirty? dirty?
-            :git-detached? (= "HEAD" branch)})))
-     (catch Exception _ nil))))
-
-(defn- execution-worktree-path
+(defn- ^{:stratum 0} execution-worktree-path
   [execution-opts]
   (get execution-opts :worktree-path))
 
-(defn- source-root-path
+(defn- ^{:stratum 0} source-root-path
   [source-dir]
   (or (worktree/worktree-root source-dir)
       source-dir
       (worktree/worktree-root)
       (System/getProperty "user.dir")))
 
-(defn get-files-in-scope
+(defn ^{:stratum 0} get-files-in-scope
   "Resolve scope paths to actual file paths.
 
    Handles both individual files and directories. Directories are expanded
@@ -137,7 +97,7 @@
                    (catch Exception _ [path]))))
        vec))
 
-(defn spec->workflow-input [enriched-spec]
+(defn ^{:stratum 0} spec->workflow-input [enriched-spec]
   (merge (:spec/raw-data enriched-spec)
          {:title (:spec/title enriched-spec)
           :description (:spec/description enriched-spec)
@@ -157,10 +117,67 @@
           ;; PR → spec mapping).
           :spec/path (:spec/path enriched-spec)}))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Context decoration
+(defn ^{:stratum 0} create-llm-client
+  ([workflow spec quiet] (create-llm-client workflow spec quiet nil))
+  ([workflow spec quiet backend-override]
+   (try
+     (let [cfg (config/load-config)
+           llm-backend (config/get-llm-backend
+                        cfg
+                            (or backend-override
+                                (get-in workflow [:workflow/config :llm-backend])
+                                (:spec/llm-backend spec)))]
+       (llm/create-client {:backend llm-backend}))
+     (catch Exception e
+       (when-not quiet
+         (println (display/colorize :yellow (str "Warning: Could not create LLM client (" (ex-message e) "), agents will use fallback mode"))))
+       nil))))
 
-(defn decorate-spec-with-runtime-context [spec {:keys [iteration parent-task-id] :or {iteration 1}}]
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} resolve-input [{:keys [input input-json]}]
+  (cond
+    input-json (parse-inline-json input-json)
+    input (read-input-file input)
+    :else {}))
+
+(defn- ^{:stratum 1} resolve-git-bool
+  [dir & args]
+  (boolean (apply resolve-git-field dir args)))
+
+(defn ^{:stratum 1} get-git-info
+  ([] (get-git-info nil))
+  ([start-path]
+   (try
+     (when-let [root (worktree/worktree-root start-path)]
+       (let [branch (resolve-git-field root "rev-parse" "--abbrev-ref" "HEAD")
+             commit (resolve-git-field root "rev-parse" "--short" "HEAD")]
+         (when (and branch commit)
+           {:git-branch branch
+            :git-commit commit})))
+     (catch Exception _ nil))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} get-git-state
+  ([] (get-git-state nil))
+  ([start-path]
+   (try
+     (when-let [root (worktree/worktree-root start-path)]
+       (let [branch (resolve-git-field root "rev-parse" "--abbrev-ref" "HEAD")
+             commit (resolve-git-field root "rev-parse" "--short" "HEAD")
+             upstream (resolve-git-field root "rev-parse" "--abbrev-ref" "--symbolic-full-name" "@{upstream}")
+             dirty? (resolve-git-bool root "status" "--porcelain")]
+         (when (and branch commit)
+           {:git-branch branch
+            :git-commit commit
+            :git-upstream upstream
+            :git-dirty? dirty?
+            :git-detached? (= "HEAD" branch)})))
+     (catch Exception _ nil))))
+
+;; Context decoration
+(defn ^{:stratum 2} decorate-spec-with-runtime-context [spec {:keys [iteration parent-task-id] :or {iteration 1}}]
   (let [cwd (or (worktree/worktree-root) (str (fs/cwd)))
         git-info (get-git-info cwd)
         files-in-scope (get-files-in-scope (:spec/intent spec))]
@@ -177,26 +194,10 @@
                     :iteration iteration}
              parent-task-id (assoc :parent-task-id parent-task-id)))))
 
-(defn create-llm-client
-  ([workflow spec quiet] (create-llm-client workflow spec quiet nil))
-  ([workflow spec quiet backend-override]
-   (try
-     (let [cfg (config/load-config)
-           llm-backend (config/get-llm-backend
-                        cfg
-                            (or backend-override
-                                (get-in workflow [:workflow/config :llm-backend])
-                                (:spec/llm-backend spec)))]
-       (llm/create-client {:backend llm-backend}))
-     (catch Exception e
-       (when-not quiet
-         (println (display/colorize :yellow (str "Warning: Could not create LLM client (" (ex-message e) "), agents will use fallback mode"))))
-       nil))))
+;------------------------------------------------------------------------------ Layer 3
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Workflow context assembly
-
-(defn create-workflow-context [{:keys [callbacks artifact-store event-stream workflow-id
+(defn ^{:stratum 3} create-workflow-context [{:keys [callbacks artifact-store event-stream workflow-id
                                        workflow-type workflow-version llm-client quiet
                                        spec-title control-state skip-lifecycle-events
                                        execution-opts source-dir

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/control.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/control.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.workflow-runner.control
   "Governed control-path wiring shared by every CLI runner path
    (Phase D D-3/D-4).
@@ -41,20 +40,20 @@
    [ai.miniforge.supervisory-state.interface :as supervisory]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Process-scoped singletons
 
-(defonce ^:private meta-loop-ctx
+;; Process-scoped singletons
+(defonce ^{:stratum 0} ^:private meta-loop-ctx
   ;; Lazily initialized when the first governed workflow starts.
   ;; Uses a dedicated operator-level event stream (no workflow-id → operator.edn).
   (atom nil))
 
-(defonce ^:private operator-consumer-handle
+(defonce ^{:stratum 0} ^:private operator-consumer-handle
   ;; Exactly one operator-directory consumer per process. Starting one per
   ;; workflow races the shared on-disk cursor and can publish a target
   ;; workflow's audit trail through the wrong workflow stream.
   (atom nil))
 
-(defn- create-meta-loop-ctx!
+(defn- ^{:stratum 0} create-meta-loop-ctx!
   []
   (let [operator-stream (es/create-event-stream)
         _supervisor (supervisory/attach! operator-stream)
@@ -65,7 +64,16 @@
         _correlator (correlator/attach! operator-stream)]
     (agent/create-meta-loop-context operator-stream)))
 
-(defn meta-loop-context!
+(defn ^{:stratum 0} release-workflow-control!
+  "Drop `workflow-id` from the live-runner registry. Interventions
+   aimed at it stop being applicable the moment the runner is gone —
+   which is the honest answer, not a silent no-op. Idempotent."
+  [workflow-id]
+  (operator/deregister-live-runner! workflow-id))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} meta-loop-context!
   "The process-wide meta-loop context, created on first use."
   []
   ;; Double-checked locking. The inner `or` is NOT the outer one repeated:
@@ -80,10 +88,8 @@
         (or @meta-loop-ctx
             (reset! meta-loop-ctx (create-meta-loop-ctx!))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Consumer lifecycle
-
-(defn- ensure-operator-consumer!
+(defn- ^{:stratum 1} ensure-operator-consumer!
   [ctx]
   ;; Double-checked locking (see meta-loop-context!). The inner re-check
   ;; matters more here: without it a race would `start-operator-consumer!`
@@ -100,9 +106,9 @@
                       :stream-for operator/live-intervention-stream}))))))
 
 ;------------------------------------------------------------------------------ Layer 2
-;; Runner registration
 
-(defn register-workflow-control!
+;; Runner registration
+(defn ^{:stratum 2} register-workflow-control!
   "Make `workflow-id` controllable from the governed operator channel:
    publish this runner's control handles and guarantee the process
    consumer is polling. Call inside the runner's `try`, after every
@@ -119,10 +125,3 @@
       (catch Throwable e
         (operator/deregister-live-runner! workflow-id)
         (throw e)))))
-
-(defn release-workflow-control!
-  "Drop `workflow-id` from the live-runner registry. Interventions
-   aimed at it stop being applicable the moment the runner is gone —
-   which is the honest answer, not a silent no-op. Idempotent."
-  [workflow-id]
-  (operator/deregister-live-runner! workflow-id))

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/dashboard.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/dashboard.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.workflow-runner.dashboard
   "Dashboard auto-discovery and status display.
 
@@ -35,9 +34,9 @@
    [ai.miniforge.cli.workflow-runner.display :as display]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Auto-discovery
 
-(defn pid-alive?
+;; Auto-discovery
+(defn ^{:stratum 0} pid-alive?
   "Check if a process with the given PID is still running."
   [pid]
   (try
@@ -45,7 +44,9 @@
       (.isPresent (java.lang.ProcessHandle/of (long pid))))
     (catch Exception _ false)))
 
-(defn discover-dashboard-url
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} discover-dashboard-url
   "Auto-discover running dashboard from the app-configured dashboard port file.
    Returns dashboard URL string or nil. Verifies the dashboard PID is alive
    and cleans up stale discovery files from crashed processes."
@@ -62,10 +63,10 @@
             (do (.delete discovery-file) nil)))))
     (catch Exception _ nil)))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Status display
+;------------------------------------------------------------------------------ Layer 2
 
-(defn print-dashboard-status!
+;; Status display
+(defn ^{:stratum 2} print-dashboard-status!
   "Print dashboard URL (if discovered) and events directory path."
   [quiet]
   (when-not quiet

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/display.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/display.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.workflow-runner.display
   "Terminal output formatting for workflow execution."
   (:require
@@ -27,9 +26,9 @@
    [ai.miniforge.event-stream.interface :as es]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; ANSI color primitives
 
-(def ansi-codes
+;; ANSI color primitives
+(def ^{:stratum 0} ansi-codes
   {:reset "\u001b[0m"
    :bold "\u001b[1m"
    :cyan "\u001b[36m"
@@ -37,20 +36,123 @@
    :yellow "\u001b[33m"
    :red "\u001b[31m"})
 
-(defn colorize [color text]
-  (str (get ansi-codes color "") text (:reset ansi-codes)))
-
-(defn format-duration [ms]
+(defn ^{:stratum 0} format-duration [ms]
   (cond
     (< ms 1000) (str ms "ms")
     (< ms 60000) (format "%.1fs" (/ ms 1000.0))
     :else (format "%.1fm" (/ ms 60000.0))))
 
-(defn- humanize-keyword
+(defn- ^{:stratum 0} humanize-keyword
   [kw]
   (some-> kw name (str/replace "-" " ")))
 
-(defn- dependency-display-name
+(defn- ^{:stratum 0} dependency-kind-label
+  [event]
+  (messages/t (keyword "workflow-runner.dependency-kind"
+                       (name (or (:dependency/kind event) :environment)))))
+
+(defn- ^{:stratum 0} dependency-status-label
+  [event]
+  (messages/t (keyword "workflow-runner.dependency-status"
+                       (name (or (:dependency/status event) :healthy)))))
+
+(defn- ^{:stratum 0} strip-ansi
+  "Remove ANSI escape codes from a string."
+  [s]
+  (str/replace s #"\u001b\[[0-9;]*m" ""))
+
+(defn- ^{:stratum 0} demo-defaults
+  "Fill in '?' defaults for nil event params so format-event-line produces
+   visible placeholders instead of empty strings."
+  [event]
+  (let [evt (:event/type event)]
+    (cond-> event
+      (and (#{:workflow/phase-started :workflow/phase-completed} evt)
+           (nil? (or (:workflow/phase event) (:phase event))))
+      (assoc :workflow/phase "?")
+
+      (and (#{:agent/started :agent/completed :agent/failed :agent/status} evt)
+           (nil? (or (:agent/id event) (:agent event))))
+      (assoc :agent/id "?")
+
+      (and (#{:gate/started :gate/passed :gate/failed} evt)
+           (nil? (or (:gate/id event) (:gate event))))
+      (assoc :gate/id "?")
+
+      (and (#{:tool/invoked :tool/completed} evt)
+           (nil? (:tool/id event)))
+      (assoc :tool/id "?")
+
+      (and (= :workflow/milestone-reached evt)
+           (nil? (:message event)))
+      (assoc :message "?")
+
+      (and (= :workflow/failed evt)
+           (nil? (:workflow/failure-reason event)))
+      (assoc :workflow/failure-reason "unknown"))))
+
+;------------------------------------------------------------------------------ Layer 1b
+;; Compact summary helpers (pure)
+(defn- ^{:stratum 0} phase-outcome-symbol
+  "Return a display symbol for a phase outcome keyword."
+  [outcome]
+  (case outcome
+    :failure "✗"
+    :failed  "✗"
+    :error   "✗"
+    :skipped "○"
+    "✓"))
+
+(defn- ^{:stratum 0} phase-summary-outcome
+  [phase-result]
+  (let [status (get phase-result :status :unknown)]
+    (case status
+      :success :completed
+      :completed :completed
+      :already-implemented :completed
+      :done :completed
+      :error :failure
+      :failed :failure
+      :failure :failure
+      status)))
+
+(defn- ^{:stratum 0} phase-summary-duration-ms
+  [phase-result]
+  (or (:duration-ms phase-result)
+      (get-in phase-result [:metrics :duration-ms])
+      (get-in phase-result [:phase/metrics :duration-ms])))
+
+(defn- ^{:stratum 0} workflow-phase-result-entries
+  [result]
+  (when (map? result)
+    (seq (:execution/phase-results result))))
+
+(defn ^{:stratum 0} extract-failed-tasks
+  "Read failed DAG task ids from the canonical workflow DAG result.
+
+  Returns a vec of task-id strings, or nil when the workflow result does not
+  carry `[:execution/dag-result :failed-task-ids]`."
+  [result]
+  (when-let [ids (seq (get-in result [:execution/dag-result :failed-task-ids]))]
+    (not-empty (vec (map #(if (keyword? %) (name %) (str %)) ids)))))
+
+(defn- ^{:stratum 0} pr-info-url
+  [pr-info]
+  (or (:pr-url pr-info)
+      (:pr/url pr-info)))
+
+(defn- ^{:stratum 0} workflow-pr-infos
+  [result]
+  (concat (get result :execution/dag-pr-infos [])
+          (when-let [pr-info (:workflow/pr-info result)]
+            [pr-info])))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} colorize [color text]
+  (str (get ansi-codes color "") text (:reset ansi-codes)))
+
+(defn- ^{:stratum 1} dependency-display-name
   [event]
   (or (some-> (:dependency/vendor event) humanize-keyword str/capitalize)
       (let [dependency-id (:dependency/id event)]
@@ -61,17 +163,58 @@
           :else nil))
       "?"))
 
-(defn- dependency-kind-label
-  [event]
-  (messages/t (keyword "workflow-runner.dependency-kind"
-                       (name (or (:dependency/kind event) :environment)))))
+(defn- ^{:stratum 1} phase-result-summary-entry
+  [[phase-id phase-result]]
+  (when (map? phase-result)
+    {:phase       phase-id
+     :outcome     (phase-summary-outcome phase-result)
+     :duration-ms (phase-summary-duration-ms phase-result)}))
 
-(defn- dependency-status-label
-  [event]
-  (messages/t (keyword "workflow-runner.dependency-status"
-                       (name (or (:dependency/status event) :healthy)))))
+(defn ^{:stratum 1} extract-pr-urls
+  "Extract PR URLs from workflow-owned PR info.
 
-(defn- dependency-event-line
+  Reads the canonical workflow context producers for PR info:
+  `:execution/dag-pr-infos` for DAG runs and `:workflow/pr-info` for the
+  release phase's single-PR path. Returns a vec of URL strings, or nil."
+  [result]
+  (when (map? result)
+    (let [all (distinct (keep pr-info-url (workflow-pr-infos result)))]
+      (not-empty (vec all)))))
+
+(defn- ^{:stratum 1} format-phase-line
+  "Format a single phase summary line using message catalog."
+  [{:keys [phase outcome duration-ms]}]
+  (let [symbol (phase-outcome-symbol outcome)
+        phase-str (cond
+                    (nil? phase)     "?"
+                    (keyword? phase) (name phase)
+                    :else            (str phase))]
+    (if duration-ms
+      (messages/t :workflow-runner/compact-phase-line
+                  {:symbol   symbol
+                   :phase    phase-str
+                   :duration (format-duration duration-ms)})
+      (messages/t :workflow-runner/compact-phase-no-dur
+                  {:symbol symbol
+                   :phase  phase-str}))))
+
+(defn- ^{:stratum 1} compact-failed-task-lines
+  [result]
+  (when-let [task-ids (extract-failed-tasks result)]
+    [(messages/t :workflow-runner/compact-failed-tasks
+                 {:task-ids (str/join ", " task-ids)})]))
+
+(defn- ^{:stratum 1} compact-metrics-lines
+  [metrics]
+  (when metrics
+    [(messages/t :workflow-runner/metrics
+                 {:tokens   (get metrics :tokens 0)
+                  :cost     (format "%.4f" (get metrics :cost-usd 0.0))
+                  :duration (format-duration (get metrics :duration-ms 0))})]))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- ^{:stratum 2} dependency-event-line
   [event message-key color]
   (colorize color
             (messages/t message-key
@@ -79,10 +222,8 @@
                          :kind (dependency-kind-label event)
                          :status (dependency-status-label event)})))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Workflow progress output
-
-(defn print-workflow-header [workflow-id version quiet?]
+(defn ^{:stratum 2} print-workflow-header [workflow-id version quiet?]
   (when-not quiet?
     (println (colorize :cyan (str "\n" (apply str (repeat 65 "━")))))
     (println (colorize :bold (messages/t :workflow-runner/header
@@ -94,7 +235,94 @@
     (println (colorize :cyan (str (apply str (repeat 65 "━")) "\n")))
     (flush)))
 
-(defn format-event-line
+(defn ^{:stratum 2} print-workflow-summary [result]
+  (let [{:execution/keys [status metrics errors]} result
+        success? (= status :completed)]
+    (println (if success?
+               (colorize :green (messages/t :workflow-runner/summary-success))
+               (colorize :red (messages/t :workflow-runner/summary-failure))))
+    (when metrics
+      (println (messages/t :workflow-runner/metrics
+                           {:tokens (:tokens metrics 0)
+                            :cost (format "%.4f" (:cost-usd metrics 0.0))
+                            :duration (format-duration (:duration-ms metrics 0))})))
+    (when (seq errors)
+      (println (colorize :red (str "\n" (messages/t :workflow-runner/errors))))
+      (doseq [err errors]
+        (println (str "  • " err))))))
+
+(defn ^{:stratum 2} extract-phase-summaries
+  "Extract phase summaries from canonical workflow execution results.
+
+  Reads only `:execution/phase-results`, the workflow context's documented
+  phase-result authority. Returns a vec of
+  {:phase :outcome :duration-ms} maps, or nil when no phase breakdown is found."
+  [result]
+  (when-let [entries (workflow-phase-result-entries result)]
+    (not-empty (vec (keep phase-result-summary-entry entries)))))
+
+(defn- ^{:stratum 2} compact-status-line
+  [success?]
+  (if success?
+    (colorize :green (messages/t :workflow-runner/summary-success))
+    (colorize :red   (messages/t :workflow-runner/summary-failure))))
+
+(defn- ^{:stratum 2} compact-pr-lines
+  [result]
+  (when-let [urls (extract-pr-urls result)]
+    [(messages/t :workflow-runner/compact-prs-created
+                 {:urls (str/join "  " urls)})]))
+
+(defn- ^{:stratum 2} compact-error-lines
+  [success? errors]
+  (when (and (not success?) (seq errors))
+    (into [(colorize :red (str "\n" (messages/t :workflow-runner/errors)))]
+          (map #(str "  • " %) errors))))
+
+(defn- ^{:stratum 2} compact-footer-lines
+  [hr]
+  [(colorize :cyan (str hr "\n"))
+   (messages/t :workflow-runner/compact-events-pointer
+               {:events-dir (app-config/events-dir)})
+   (messages/t :workflow-runner/compact-full-hint)])
+
+;; Error help output
+(defn ^{:stratum 2} print-error-header
+  "Print error header with message, details, and cause."
+  [msg data cause]
+  (println (colorize :red (str "\n" (messages/t :workflow-runner/load-failed))))
+  (println (messages/t :workflow-runner/error {:message msg}))
+  (when data
+    (println (messages/t :workflow-runner/details {:details (pr-str data)})))
+  (when cause
+    (println (messages/t :workflow-runner/cause {:cause (ex-message cause)})))
+  (println (colorize :yellow (str "\n" (messages/t :workflow-runner/possible-causes))))
+  (println (messages/t :workflow-runner/cause-missing-dep))
+  (println (messages/t :workflow-runner/cause-compile))
+  (println (messages/t :workflow-runner/cause-cycle)))
+
+(defn ^{:stratum 2} print-namespace-resolution-help
+  "Print help for namespace resolution errors."
+  []
+  (println (colorize :cyan (str "\n" (messages/t :workflow-runner/namespace-help-header))))
+  (println (messages/t :workflow-runner/namespace-help-dep))
+  (println (messages/t :workflow-runner/namespace-help-build)))
+
+(defn ^{:stratum 2} print-babashka-fallback-help
+  "Print help for Babashka compatibility issues."
+  []
+  (println (colorize :cyan (str "\n" (messages/t :workflow-runner/bb-help-header))))
+  (println (messages/t :workflow-runner/bb-help-command)))
+
+(defn ^{:stratum 2} print-general-debugging-help
+  "Print general debugging tips."
+  []
+  (println (colorize :cyan (str "\n" (messages/t :workflow-runner/debug-header))))
+  (println (messages/t :workflow-runner/debug-command)))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} format-event-line
   "Format a concise progress line for a lifecycle event. Returns nil for unknown events."
   [event]
   (let [evt (:event/type event)
@@ -176,42 +404,13 @@
                               (str " (" (format-duration d) ")")))
       nil)))
 
-(defn- strip-ansi
-  "Remove ANSI escape codes from a string."
-  [s]
-  (str/replace s #"\u001b\[[0-9;]*m" ""))
+(defn- ^{:stratum 3} compact-phase-lines
+  [result]
+  (map format-phase-line (or (extract-phase-summaries result) [])))
 
-(defn- demo-defaults
-  "Fill in '?' defaults for nil event params so format-event-line produces
-   visible placeholders instead of empty strings."
-  [event]
-  (let [evt (:event/type event)]
-    (cond-> event
-      (and (#{:workflow/phase-started :workflow/phase-completed} evt)
-           (nil? (or (:workflow/phase event) (:phase event))))
-      (assoc :workflow/phase "?")
+;------------------------------------------------------------------------------ Layer 4
 
-      (and (#{:agent/started :agent/completed :agent/failed :agent/status} evt)
-           (nil? (or (:agent/id event) (:agent event))))
-      (assoc :agent/id "?")
-
-      (and (#{:gate/started :gate/passed :gate/failed} evt)
-           (nil? (or (:gate/id event) (:gate event))))
-      (assoc :gate/id "?")
-
-      (and (#{:tool/invoked :tool/completed} evt)
-           (nil? (:tool/id event)))
-      (assoc :tool/id "?")
-
-      (and (= :workflow/milestone-reached evt)
-           (nil? (:message event)))
-      (assoc :message "?")
-
-      (and (= :workflow/failed evt)
-           (nil? (:workflow/failure-reason event)))
-      (assoc :workflow/failure-reason "unknown"))))
-
-(defn format-demo-line
+(defn ^{:stratum 4} format-demo-line
   "Format a plain-text (no ANSI) progress line for demo/test output.
    Delegates to format-event-line with nil-defaulted params, then strips ANSI.
    Uses '?' for nil values and 'unknown' for missing failure reasons."
@@ -231,7 +430,7 @@
                                       stripped)
           stripped)))))
 
-(defn start-progress!
+(defn ^{:stratum 4} start-progress!
   "Subscribe to lifecycle events and print concise progress lines.
    Returns a cleanup function."
   [event-stream quiet?]
@@ -250,168 +449,7 @@
       (fn []
         (es/unsubscribe! event-stream sub-id)))))
 
-(defn print-workflow-summary [result]
-  (let [{:execution/keys [status metrics errors]} result
-        success? (= status :completed)]
-    (println (if success?
-               (colorize :green (messages/t :workflow-runner/summary-success))
-               (colorize :red (messages/t :workflow-runner/summary-failure))))
-    (when metrics
-      (println (messages/t :workflow-runner/metrics
-                           {:tokens (:tokens metrics 0)
-                            :cost (format "%.4f" (:cost-usd metrics 0.0))
-                            :duration (format-duration (:duration-ms metrics 0))})))
-    (when (seq errors)
-      (println (colorize :red (str "\n" (messages/t :workflow-runner/errors))))
-      (doseq [err errors]
-        (println (str "  • " err))))))
-
-;------------------------------------------------------------------------------ Layer 1b
-;; Compact summary helpers (pure)
-
-(defn- phase-outcome-symbol
-  "Return a display symbol for a phase outcome keyword."
-  [outcome]
-  (case outcome
-    :failure "✗"
-    :failed  "✗"
-    :error   "✗"
-    :skipped "○"
-    "✓"))
-
-(defn- phase-summary-outcome
-  [phase-result]
-  (let [status (get phase-result :status :unknown)]
-    (case status
-      :success :completed
-      :completed :completed
-      :already-implemented :completed
-      :done :completed
-      :error :failure
-      :failed :failure
-      :failure :failure
-      status)))
-
-(defn- phase-summary-duration-ms
-  [phase-result]
-  (or (:duration-ms phase-result)
-      (get-in phase-result [:metrics :duration-ms])
-      (get-in phase-result [:phase/metrics :duration-ms])))
-
-(defn- phase-result-summary-entry
-  [[phase-id phase-result]]
-  (when (map? phase-result)
-    {:phase       phase-id
-     :outcome     (phase-summary-outcome phase-result)
-     :duration-ms (phase-summary-duration-ms phase-result)}))
-
-(defn- workflow-phase-result-entries
-  [result]
-  (when (map? result)
-    (seq (:execution/phase-results result))))
-
-(defn extract-phase-summaries
-  "Extract phase summaries from canonical workflow execution results.
-
-  Reads only `:execution/phase-results`, the workflow context's documented
-  phase-result authority. Returns a vec of
-  {:phase :outcome :duration-ms} maps, or nil when no phase breakdown is found."
-  [result]
-  (when-let [entries (workflow-phase-result-entries result)]
-    (not-empty (vec (keep phase-result-summary-entry entries)))))
-
-(defn extract-failed-tasks
-  "Read failed DAG task ids from the canonical workflow DAG result.
-
-  Returns a vec of task-id strings, or nil when the workflow result does not
-  carry `[:execution/dag-result :failed-task-ids]`."
-  [result]
-  (when-let [ids (seq (get-in result [:execution/dag-result :failed-task-ids]))]
-    (not-empty (vec (map #(if (keyword? %) (name %) (str %)) ids)))))
-
-(defn- pr-info-url
-  [pr-info]
-  (or (:pr-url pr-info)
-      (:pr/url pr-info)))
-
-(defn- workflow-pr-infos
-  [result]
-  (concat (get result :execution/dag-pr-infos [])
-          (when-let [pr-info (:workflow/pr-info result)]
-            [pr-info])))
-
-(defn extract-pr-urls
-  "Extract PR URLs from workflow-owned PR info.
-
-  Reads the canonical workflow context producers for PR info:
-  `:execution/dag-pr-infos` for DAG runs and `:workflow/pr-info` for the
-  release phase's single-PR path. Returns a vec of URL strings, or nil."
-  [result]
-  (when (map? result)
-    (let [all (distinct (keep pr-info-url (workflow-pr-infos result)))]
-      (not-empty (vec all)))))
-
-(defn- format-phase-line
-  "Format a single phase summary line using message catalog."
-  [{:keys [phase outcome duration-ms]}]
-  (let [symbol (phase-outcome-symbol outcome)
-        phase-str (cond
-                    (nil? phase)     "?"
-                    (keyword? phase) (name phase)
-                    :else            (str phase))]
-    (if duration-ms
-      (messages/t :workflow-runner/compact-phase-line
-                  {:symbol   symbol
-                   :phase    phase-str
-                   :duration (format-duration duration-ms)})
-      (messages/t :workflow-runner/compact-phase-no-dur
-                  {:symbol symbol
-                   :phase  phase-str}))))
-
-(defn- compact-status-line
-  [success?]
-  (if success?
-    (colorize :green (messages/t :workflow-runner/summary-success))
-    (colorize :red   (messages/t :workflow-runner/summary-failure))))
-
-(defn- compact-phase-lines
-  [result]
-  (map format-phase-line (or (extract-phase-summaries result) [])))
-
-(defn- compact-failed-task-lines
-  [result]
-  (when-let [task-ids (extract-failed-tasks result)]
-    [(messages/t :workflow-runner/compact-failed-tasks
-                 {:task-ids (str/join ", " task-ids)})]))
-
-(defn- compact-pr-lines
-  [result]
-  (when-let [urls (extract-pr-urls result)]
-    [(messages/t :workflow-runner/compact-prs-created
-                 {:urls (str/join "  " urls)})]))
-
-(defn- compact-metrics-lines
-  [metrics]
-  (when metrics
-    [(messages/t :workflow-runner/metrics
-                 {:tokens   (get metrics :tokens 0)
-                  :cost     (format "%.4f" (get metrics :cost-usd 0.0))
-                  :duration (format-duration (get metrics :duration-ms 0))})]))
-
-(defn- compact-error-lines
-  [success? errors]
-  (when (and (not success?) (seq errors))
-    (into [(colorize :red (str "\n" (messages/t :workflow-runner/errors)))]
-          (map #(str "  • " %) errors))))
-
-(defn- compact-footer-lines
-  [hr]
-  [(colorize :cyan (str hr "\n"))
-   (messages/t :workflow-runner/compact-events-pointer
-               {:events-dir (app-config/events-dir)})
-   (messages/t :workflow-runner/compact-full-hint)])
-
-(defn- compact-summary-lines
+(defn- ^{:stratum 4} compact-summary-lines
   [result]
   (let [{:execution/keys [status metrics errors]} result
         success? (= status :completed)
@@ -425,7 +463,9 @@
             (compact-error-lines success? errors)
             (compact-footer-lines hr))))
 
-(defn format-compact-summary
+;------------------------------------------------------------------------------ Layer 5
+
+(defn ^{:stratum 5} format-compact-summary
   "Build a compact multi-line string summarising a workflow result.
 
   Lines included:
@@ -443,13 +483,17 @@
   ([result _workflow-id]
    (str/join "\n" (compact-summary-lines result))))
 
-(defn print-pretty-result
+;------------------------------------------------------------------------------ Layer 6
+
+(defn ^{:stratum 6} print-pretty-result
   "Print a compact human-readable summary of the workflow result.
    Full EDN dump is available via --output edn."
   [result]
   (println (format-compact-summary result)))
 
-(defn print-result [result {:keys [output quiet]}]
+;------------------------------------------------------------------------------ Layer 7
+
+(defn ^{:stratum 7} print-result [result {:keys [output quiet]}]
   (when-not quiet
     (case output
       :json   (println (json/generate-string result {:pretty true}))
@@ -457,39 +501,3 @@
       :edn    (clojure.pprint/pprint result)
       (clojure.pprint/pprint result)))
   (flush))
-
-;------------------------------------------------------------------------------ Layer 2
-;; Error help output
-
-(defn print-error-header
-  "Print error header with message, details, and cause."
-  [msg data cause]
-  (println (colorize :red (str "\n" (messages/t :workflow-runner/load-failed))))
-  (println (messages/t :workflow-runner/error {:message msg}))
-  (when data
-    (println (messages/t :workflow-runner/details {:details (pr-str data)})))
-  (when cause
-    (println (messages/t :workflow-runner/cause {:cause (ex-message cause)})))
-  (println (colorize :yellow (str "\n" (messages/t :workflow-runner/possible-causes))))
-  (println (messages/t :workflow-runner/cause-missing-dep))
-  (println (messages/t :workflow-runner/cause-compile))
-  (println (messages/t :workflow-runner/cause-cycle)))
-
-(defn print-namespace-resolution-help
-  "Print help for namespace resolution errors."
-  []
-  (println (colorize :cyan (str "\n" (messages/t :workflow-runner/namespace-help-header))))
-  (println (messages/t :workflow-runner/namespace-help-dep))
-  (println (messages/t :workflow-runner/namespace-help-build)))
-
-(defn print-babashka-fallback-help
-  "Print help for Babashka compatibility issues."
-  []
-  (println (colorize :cyan (str "\n" (messages/t :workflow-runner/bb-help-header))))
-  (println (messages/t :workflow-runner/bb-help-command)))
-
-(defn print-general-debugging-help
-  "Print general debugging tips."
-  []
-  (println (colorize :cyan (str "\n" (messages/t :workflow-runner/debug-header))))
-  (println (messages/t :workflow-runner/debug-command)))

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/display.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/display.clj
@@ -91,7 +91,6 @@
            (nil? (:workflow/failure-reason event)))
       (assoc :workflow/failure-reason "unknown"))))
 
-;------------------------------------------------------------------------------ Layer 1b
 ;; Compact summary helpers (pure)
 (defn- ^{:stratum 0} phase-outcome-symbol
   "Return a display symbol for a phase outcome keyword."

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/gc_hooks.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/gc_hooks.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.workflow-runner.gc-hooks
   "Lightweight, pure GC-queue hooks called on workflow lifecycle events.
 
@@ -40,13 +39,14 @@
      (partial enqueue-workflow-gc-best-effort! gc-queue/enqueue-workflow-gc!)
      (partial run-gc-pass-best-effort! worktree/worktree-root gc-queue/run-deferred-gc!)
 
-   Layer 0: enqueue on workflow finish (accepts enqueue-fn)
-   Layer 1: GC pass on workflow start (accepts worktree-root-fn + gc-fn)")
+   Layer 0 — both: `enqueue-workflow-gc-best-effort!` (accepts enqueue-fn)
+   and `run-gc-pass-best-effort!` (accepts worktree-root-fn + gc-fn) are
+   peers; neither calls the other.")
 
-;;------------------------------------------------------------------------------ Layer 0
+;------------------------------------------------------------------------------ Layer 0
+
 ;; Enqueue hook — called at workflow completion (success or failure)
-
-(defn enqueue-workflow-gc-best-effort!
+(defn ^{:stratum 0} enqueue-workflow-gc-best-effort!
   "Append `workflow-id` to the scratch-ref GC queue via `enqueue-fn`.
 
    `enqueue-fn` — a 1-arity function that accepts the workflow-id string and
@@ -60,10 +60,8 @@
     (enqueue-fn workflow-id)
     (catch Exception _ nil)))
 
-;;------------------------------------------------------------------------------ Layer 1
 ;; GC pass hook — called once at each workflow start
-
-(defn run-gc-pass-best-effort!
+(defn ^{:stratum 0} run-gc-pass-best-effort!
   "Run the deferred scratch-ref GC pass using the current git repo root.
 
    `worktree-root-fn` — a 0-arity function that returns the parent git repo

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/help.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/help.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.workflow-runner.help
   "Per-subcommand `--help` rendering for the workflow-runner-facing CLI
    subcommands (`workflow run/list/execute/status/cancel` and
@@ -39,23 +38,17 @@
 
 ;------------------------------------------------------------------------------ Layer 0
 
-(def help-flag-keys
+(def ^{:stratum 0} help-flag-keys
   "Keys reserved for the help flag itself. Stripped from the usage
    table so `--help` doesn't appear inside its own description block."
   #{:help})
 
-(defn help-requested?
+(defn ^{:stratum 0} help-requested?
   "Truthy when the parsed `opts` map carries the `--help` / `-h` flag."
   [opts]
   (boolean (:help opts)))
 
-(defn- without-help-flag
-  "Drop the help flag from a babashka.cli `:spec` map so it doesn't
-   appear inside the flag table its presence triggered."
-  [spec]
-  (into {} (remove (fn [[k _]] (contains? help-flag-keys k))) spec))
-
-(defn- usage-line
+(defn- ^{:stratum 0} usage-line
   "First-line usage banner for a subcommand."
   [subcommand positional]
   (let [binary (app-config/binary-name)
@@ -67,35 +60,7 @@
          (remove str/blank?)
          (str/join " "))))
 
-(defn- flag-table
-  "Auto-generate the flag table from a babashka.cli `:spec`. Returns
-   nil when the (filtered) spec has no entries."
-  [spec]
-  (let [filtered (without-help-flag spec)]
-    (when (seq filtered)
-      (cli/format-opts {:spec filtered}))))
-
-;------------------------------------------------------------------------------ Layer 1
-
-(defn usage-text
-  "Render the full localized usage block for a registry entry."
-  [{:keys [subcommand summary-key spec positional]}]
-  (let [usage   (messages/t :workflow-runner.help/usage-prefix
-                            {:line (usage-line subcommand positional)})
-        summary (messages/t summary-key)
-        table   (flag-table spec)]
-    (->> [(messages/t :workflow-runner.help/subcommand-heading
-                      {:subcommand subcommand})
-          summary
-          ""
-          usage
-          (when table
-            (messages/t :workflow-runner.help/options-heading))
-          table]
-         (remove nil?)
-         (str/join "\n"))))
-
-(defn group-usage-text
+(defn ^{:stratum 0} group-usage-text
   "Render the localized parent-level usage block for a subcommand group."
   [{:keys [group summary-key subcommands]}]
   (let [usage    (messages/t :workflow-runner.help/group-usage-prefix
@@ -118,19 +83,66 @@
           (str/join "\n" rows)]
          (str/join "\n"))))
 
-;------------------------------------------------------------------------------ Layer 2
+;------------------------------------------------------------------------------ Layer 1
 
-(defn print-usage!
-  "Print the localized usage block for `entry` to stdout."
-  [entry]
-  (println (usage-text entry)))
+(defn- ^{:stratum 1} without-help-flag
+  "Drop the help flag from a babashka.cli `:spec` map so it doesn't
+   appear inside the flag table its presence triggered."
+  [spec]
+  (into {} (remove (fn [[k _]] (contains? help-flag-keys k))) spec))
 
-(defn print-group-usage!
+(defn ^{:stratum 1} print-group-usage!
   "Print the localized parent-level usage block for `group-entry`."
   [group-entry]
   (println (group-usage-text group-entry)))
 
-(defn handler-with-help
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- ^{:stratum 2} flag-table
+  "Auto-generate the flag table from a babashka.cli `:spec`. Returns
+   nil when the (filtered) spec has no entries."
+  [spec]
+  (let [filtered (without-help-flag spec)]
+    (when (seq filtered)
+      (cli/format-opts {:spec filtered}))))
+
+(defn ^{:stratum 2} group-handler
+  "Return a dispatch handler that prints the group-level usage block
+   for `group-entry` (e.g. `registry/workflow-group-help`)."
+  [group-entry]
+  (fn group-help-handler [_m]
+    (print-group-usage! group-entry)))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} usage-text
+  "Render the full localized usage block for a registry entry."
+  [{:keys [subcommand summary-key spec positional]}]
+  (let [usage   (messages/t :workflow-runner.help/usage-prefix
+                            {:line (usage-line subcommand positional)})
+        summary (messages/t summary-key)
+        table   (flag-table spec)]
+    (->> [(messages/t :workflow-runner.help/subcommand-heading
+                      {:subcommand subcommand})
+          summary
+          ""
+          usage
+          (when table
+            (messages/t :workflow-runner.help/options-heading))
+          table]
+         (remove nil?)
+         (str/join "\n"))))
+
+;------------------------------------------------------------------------------ Layer 4
+
+(defn ^{:stratum 4} print-usage!
+  "Print the localized usage block for `entry` to stdout."
+  [entry]
+  (println (usage-text entry)))
+
+;------------------------------------------------------------------------------ Layer 5
+
+(defn ^{:stratum 5} handler-with-help
   "Wrap a dispatch handler `cmd-fn` so that `--help` / `-h` short-circuits
    to a localized usage block. `subcommand-key` is one of the keys in
    `registry/subcommands` (e.g. `:workflow-run`)."
@@ -145,10 +157,3 @@
         (if (help-requested? opts)
           (print-usage! entry)
           (cmd-fn m))))))
-
-(defn group-handler
-  "Return a dispatch handler that prints the group-level usage block
-   for `group-entry` (e.g. `registry/workflow-group-help`)."
-  [group-entry]
-  (fn group-help-handler [_m]
-    (print-group-usage! group-entry)))

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/help/registry.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/help/registry.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.workflow-runner.help.registry
   "Pure data registry of every workflow-runner CLI subcommand
    (`workflow run/list/execute/status/cancel` and `chain run/list`).
@@ -36,17 +35,33 @@
 
 ;------------------------------------------------------------------------------ Layer 0
 
-(def ^:private help-flag-spec
+(def ^{:stratum 0} ^:private help-flag-spec
   "The `--help`/`-h` boolean flag added to every workflow-runner
    subcommand spec. Single definition keeps the alias consistent."
   {:coerce :boolean :alias :h})
 
-(defn with-help-flag
+(def ^{:stratum 0} workflow-subcommand-keys
+  "Display order for `mf workflow --help`."
+  [:workflow-run :workflow-list :workflow-execute :workflow-status
+   :workflow-inspect :workflow-cancel :workflow-gc-scratch])
+
+(def ^{:stratum 0} chain-subcommand-keys
+  "Display order for `mf chain --help`."
+  [:chain-run :chain-list])
+
+(defn- ^{:stratum 0} subcommand-leaf [entry]
+  (-> (:subcommand entry) (str/split #"\s+") last))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} with-help-flag
   "Return `spec` with the `--help`/`-h` boolean flag merged in. Idempotent."
   [spec]
   (assoc spec :help help-flag-spec))
 
-(def workflow-run-flag-spec
+;------------------------------------------------------------------------------ Layer 2
+
+(def ^{:stratum 2} workflow-run-flag-spec
   (with-help-flag
     {:version       {:coerce :string  :alias :v :default "latest"}
      :input         {:alias :i}
@@ -55,43 +70,43 @@
      :quiet         {:coerce :boolean :alias :q}
      :dashboard-url {:coerce :string  :alias :d}}))
 
-(def workflow-list-flag-spec
+(def ^{:stratum 2} workflow-list-flag-spec
   (with-help-flag {}))
 
-(def workflow-execute-flag-spec
+(def ^{:stratum 2} workflow-execute-flag-spec
   (with-help-flag
     {:worktree       {:alias :w}
      :backend        {:coerce :keyword :alias :b}
      :execution-mode {:coerce :keyword :alias :m}
      :quiet          {:coerce :boolean :alias :q}}))
 
-(def workflow-status-flag-spec
+(def ^{:stratum 2} workflow-status-flag-spec
   (with-help-flag {}))
 
-(def workflow-inspect-flag-spec
+(def ^{:stratum 2} workflow-inspect-flag-spec
   (with-help-flag {}))
 
-(def workflow-cancel-flag-spec
+(def ^{:stratum 2} workflow-cancel-flag-spec
   (with-help-flag {}))
 
-(def workflow-gc-scratch-flag-spec
+(def ^{:stratum 2} workflow-gc-scratch-flag-spec
   (with-help-flag
     {:max-age-days {:coerce :int :alias :a :default 7}
      :repo-path    {:coerce :string :alias :r}}))
 
-(def chain-run-flag-spec
+(def ^{:stratum 2} chain-run-flag-spec
   (with-help-flag
     {:version    {:coerce :string :alias :v :default "latest"}
      :spec       {:alias :s}
      :input-json {}
      :quiet      {:coerce :boolean :alias :q}}))
 
-(def chain-list-flag-spec
+(def ^{:stratum 2} chain-list-flag-spec
   (with-help-flag {}))
 
-;------------------------------------------------------------------------------ Layer 1
+;------------------------------------------------------------------------------ Layer 3
 
-(def subcommands
+(def ^{:stratum 3} subcommands
   "Keyword-addressable registry of every workflow-runner subcommand.
    Each value is the input shape consumed by the help renderer."
   {:workflow-run     {:subcommand  "workflow run"
@@ -131,45 +146,35 @@
                       :spec        chain-list-flag-spec
                       :positional  []}})
 
-(def workflow-subcommand-keys
-  "Display order for `mf workflow --help`."
-  [:workflow-run :workflow-list :workflow-execute :workflow-status
-   :workflow-inspect :workflow-cancel :workflow-gc-scratch])
+;------------------------------------------------------------------------------ Layer 4
 
-(def chain-subcommand-keys
-  "Display order for `mf chain --help`."
-  [:chain-run :chain-list])
-
-(defn spec-for
+(defn ^{:stratum 4} spec-for
   "Look up the babashka.cli `:spec` for a subcommand by key."
   [subcommand-key]
   (:spec (get subcommands subcommand-key)))
 
-(defn entry-for
+(defn ^{:stratum 4} entry-for
   "Look up the full registry entry for `subcommand-key`. Returns nil
    when unknown — callers may treat that as a programming error."
   [subcommand-key]
   (get subcommands subcommand-key))
 
-;------------------------------------------------------------------------------ Layer 2
-
-(defn- subcommand-leaf [entry]
-  (-> (:subcommand entry) (str/split #"\s+") last))
-
-(defn- group-subcommand-rows [entry-keys]
+(defn- ^{:stratum 4} group-subcommand-rows [entry-keys]
   (map (fn [entry-key]
          (let [entry (get subcommands entry-key)]
            {:name        (subcommand-leaf entry)
             :summary-key (:summary-key entry)}))
        entry-keys))
 
-(def workflow-group-help
+;------------------------------------------------------------------------------ Layer 5
+
+(def ^{:stratum 5} workflow-group-help
   "Input shape for the `workflow` parent's `--help` listing."
   {:group       "workflow"
    :summary-key :workflow-runner.help/workflow-summary
    :subcommands (group-subcommand-rows workflow-subcommand-keys)})
 
-(def chain-group-help
+(def ^{:stratum 5} chain-group-help
   "Input shape for the `chain` parent's `--help` listing."
   {:group       "chain"
    :summary-key :workflow-runner.help/chain-summary

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/sandbox.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/sandbox.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.workflow-runner.sandbox
   "Container sandbox setup for isolated workflow execution. Runtime-agnostic:
    the host's container runtime is auto-selected (Podman first, Docker
@@ -35,15 +34,15 @@
    [ai.miniforge.dag-executor.interface :as dag]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; No in-namespace dependencies.
 
-(defn sandbox-release-fn [executor environment-id]
+;; No in-namespace dependencies.
+(defn ^{:stratum 0} sandbox-release-fn [executor environment-id]
   (fn []
     (try
       (dag/release-environment! executor environment-id)
       (catch Exception _ nil))))
 
-(defn- git-remote-url
+(defn- ^{:stratum 0} git-remote-url
   "Get git remote origin URL from a directory. Returns nil on failure."
   [dir]
   (try
@@ -53,15 +52,15 @@
         (str/trim (:out result))))
     (catch Exception _ nil)))
 
-(defn infer-branch [spec enriched-spec]
+(defn ^{:stratum 0} infer-branch [spec enriched-spec]
   (or (:spec/branch spec)
       (get-in enriched-spec [:spec/context :git-branch])
       "main"))
 
 ;------------------------------------------------------------------------------ Layer 1
-;; Composes Layer 0.
 
-(defn infer-repo-url [spec enriched-spec]
+;; Composes Layer 0.
+(defn ^{:stratum 1} infer-repo-url [spec enriched-spec]
   (or (:spec/repo-url spec)
       (get-in enriched-spec [:spec/context :repo-url])
       ;; If spec came from a file in a different repo, use that repo's remote.
@@ -72,10 +71,10 @@
       (git-remote-url ".")))
 
 ;------------------------------------------------------------------------------ Layer 2
+
 ;; Sandbox preparation — composes Layer 1 (`infer-repo-url`) plus
 ;; Layer 0 (`infer-branch`).
-
-(defn prepare-sandbox [spec enriched-spec]
+(defn ^{:stratum 2} prepare-sandbox [spec enriched-spec]
   (let [prep-result (dag/prepare-runtime-executor!
                      (runtime-env/selection-config {:image-type :clojure}))]
     (if-not (dag/ok? prep-result)
@@ -96,9 +95,9 @@
                      :sandbox-workdir "/workspace"})))))))
 
 ;------------------------------------------------------------------------------ Layer 3
-;; Composes Layer 2.
 
-(defn setup-sandbox-context [base-context sandbox? spec enriched-spec quiet]
+;; Composes Layer 2.
+(defn ^{:stratum 3} setup-sandbox-context [base-context sandbox? spec enriched-spec quiet]
   (if-not sandbox?
     [base-context nil]
     (do

--- a/bases/cli/src/ai/miniforge/cli/workflow_selection_config.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_selection_config.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.workflow-selection-config
   "Resource-driven workflow selection profile resolution."
   (:require
@@ -23,19 +22,33 @@
    [clojure.edn :as edn]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Resource loading
 
-(def selection-profiles-resource
+;; Resource loading
+(def ^{:stratum 0} selection-profiles-resource
   "Classpath resource path for workflow selection profile mappings."
   "config/workflow/selection-profiles.edn")
 
-(defn- read-selection-profile-config
+(defn- ^{:stratum 0} read-selection-profile-config
   "Read a single selection profile config resource."
   [resource]
   (let [config (-> resource slurp edn/read-string)]
     (get config :workflow-selection/profiles {})))
 
-(defn configured-selection-profiles
+;; Generic fallback resolution
+(defn- ^{:stratum 0} workflow-characteristics
+  "Resolve workflow characteristics through the workflow interface."
+  [workflow-def]
+  (workflow/workflow-characteristics workflow-def))
+
+(defn- ^{:stratum 0} available-workflow-definitions
+  "Return full workflow definitions from the registry for fallback scoring."
+  []
+  (workflow/ensure-initialized!)
+  (keep workflow/get-workflow (workflow/list-workflow-ids)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} configured-selection-profiles
   "Merge workflow selection profile mappings from all matching classpath resources."
   []
   (->> (enumeration-seq (.getResources (clojure.lang.RT/baseLoader)
@@ -43,21 +56,7 @@
        (map read-selection-profile-config)
        (apply merge {})))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Generic fallback resolution
-
-(defn- workflow-characteristics
-  "Resolve workflow characteristics through the workflow interface."
-  [workflow-def]
-  (workflow/workflow-characteristics workflow-def))
-
-(defn- available-workflow-definitions
-  "Return full workflow definitions from the registry for fallback scoring."
-  []
-  (workflow/ensure-initialized!)
-  (keep workflow/get-workflow (workflow/list-workflow-ids)))
-
-(defn- simplest-workflow-id
+(defn- ^{:stratum 1} simplest-workflow-id
   "Choose the simplest available workflow by phase count and max iterations."
   [available-workflows]
   (->> available-workflows
@@ -67,7 +66,7 @@
        first
        :workflow/id))
 
-(defn- most-comprehensive-workflow-id
+(defn- ^{:stratum 1} most-comprehensive-workflow-id
   "Choose the most comprehensive available workflow by phase count."
   [available-workflows]
   (->> available-workflows
@@ -77,7 +76,9 @@
        first
        :workflow/id))
 
-(defn- resolve-profile-fallback
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- ^{:stratum 2} resolve-profile-fallback
   "Resolve a profile via generic workflow characteristics when no config is present."
   [profile available-workflows]
   (case profile
@@ -87,10 +88,10 @@
                  (most-comprehensive-workflow-id available-workflows))
     nil))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Public API
+;------------------------------------------------------------------------------ Layer 3
 
-(defn resolve-selection-profile
+;; Public API
+(defn ^{:stratum 3} resolve-selection-profile
   "Resolve a logical selection profile to a concrete workflow id.
 
    Profiles are app-owned configuration. If a configured profile points at a

--- a/bases/cli/src/ai/miniforge/cli/workflow_selector.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_selector.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.workflow-selector
   "Intelligent workflow selection based on spec characteristics.
 
@@ -31,9 +30,9 @@
    [ai.miniforge.cli.workflow-selection-config :as selection-config]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Spec feature extraction
 
-(defn extract-type
+;; Spec feature extraction
+(defn ^{:stratum 0} extract-type
   "Extract task type from spec.
    After normalization, :spec/intent is guaranteed to be set."
   [spec]
@@ -41,21 +40,21 @@
       (get-in spec [:spec/raw-data :type])
       :unknown))
 
-(defn extract-implementation-plan
+(defn ^{:stratum 0} extract-implementation-plan
   "Extract implementation plan details from spec."
   [spec]
   (or (get-in spec [:spec/raw-data :implementation-plan])
       (get-in spec [:spec/intent :implementation-plan])
       (:implementation-plan spec)))
 
-(defn count-prs
+(defn ^{:stratum 0} count-prs
   "Count number of PRs/phases in implementation plan."
   [impl-plan]
   (when impl-plan
     (count (filter (fn [[k _v]] (str/starts-with? (name k) "pr-"))
                    impl-plan))))
 
-(defn has-dependencies?
+(defn ^{:stratum 0} has-dependencies?
   "Check if implementation plan has dependencies between phases."
   [impl-plan]
   (when impl-plan
@@ -65,7 +64,7 @@
                      (not-empty (:base v)))))
           impl-plan)))
 
-(defn extract-description-keywords
+(defn ^{:stratum 0} extract-description-keywords
   "Extract significant keywords from spec description."
   [spec]
   (let [desc (str/lower-case (or (:spec/description spec) ""))
@@ -97,19 +96,7 @@
                     (str/includes? desc "quick"))
             [:small-scope])))))
 
-(defn estimate-size
-  "Estimate scope size from spec."
-  [spec impl-plan]
-  (let [keywords (extract-description-keywords spec)
-        pr-count (count-prs impl-plan)]
-    (cond
-      (and pr-count (>= pr-count 5)) :large
-      (contains? keywords :large-scope) :large
-      (contains? keywords :small-scope) :small
-      (and pr-count (>= pr-count 3)) :medium
-      :else :unknown)))
-
-(defn extract-constraints-mentions
+(defn ^{:stratum 0} extract-constraints-mentions
   "Extract constraint mentions from spec."
   [spec]
   (let [constraints (get spec :spec/constraints [])]
@@ -127,7 +114,110 @@
                       constraints)
             [:zero-linting])))))
 
-(defn analyze-spec
+(defn ^{:stratum 0} selection-result
+  "Build a selection result from a logical profile."
+  [profile confidence reason]
+  {:selection-profile profile
+   :workflow-type (selection-config/resolve-selection-profile profile)
+   :confidence confidence
+   :reason reason})
+
+(defn ^{:stratum 0} explain-selection
+  "Generate user-facing explanation for workflow selection.
+
+   Returns string suitable for printing to console.
+
+   Example:
+     ℹ️  Auto-selected workflow: canonical-sdlc-v1
+         Reason: Multi-phase refactoring with 6 PRs requires comprehensive review
+         Override with :spec/workflow-type in your spec"
+  [selection]
+  (let [{:keys [workflow-type confidence reason]} selection
+        confidence-marker (case confidence
+                            :high ""
+                            :medium (messages/t :selector/confidence-medium)
+                            :low (messages/t :selector/confidence-low)
+                            "")]
+    (str (messages/t :selector/auto-selected
+                     {:workflow (name workflow-type)
+                      :confidence-marker confidence-marker}) "\n"
+         (messages/t :selector/reason {:reason reason}) "\n"
+         (messages/t :selector/override-hint))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} estimate-size
+  "Estimate scope size from spec."
+  [spec impl-plan]
+  (let [keywords (extract-description-keywords spec)
+        pr-count (count-prs impl-plan)]
+    (cond
+      (and pr-count (>= pr-count 5)) :large
+      (contains? keywords :large-scope) :large
+      (contains? keywords :small-scope) :small
+      (and pr-count (>= pr-count 3)) :medium
+      :else :unknown)))
+
+;; Rule matching
+(defn ^{:stratum 1} match-multi-phase-rule
+  "Multi-phase implementation → comprehensive profile"
+  [features]
+  (when (and (:pr-count features)
+             (>= (:pr-count features) 4))
+    (selection-result :comprehensive
+                      :high
+                      (messages/t :selector/reason-multi-phase
+                                  {:pr-count (:pr-count features)}))))
+
+(defn ^{:stratum 1} match-refactoring-stratification-rule
+  "Refactoring with stratification → comprehensive profile"
+  [features]
+  (when (and (or (= (:type features) :refactoring)
+                 (contains? (:keywords features) :refactoring))
+             (or (contains? (:keywords features) :stratified-design)
+                 (contains? (:constraint-mentions features) :rule-210)))
+    (selection-result :comprehensive
+                      :high
+                      (messages/t :selector/reason-refactoring-stratification))))
+
+(defn ^{:stratum 1} match-large-feature-rule
+  "Large feature → comprehensive profile"
+  [features]
+  (when (and (= (:size features) :large)
+             (not (contains? (:keywords features) :bugfix))
+             (not (contains? (:keywords features) :docs-only)))
+    (selection-result :comprehensive
+                      :medium
+                      (messages/t :selector/reason-large-feature))))
+
+(defn ^{:stratum 1} match-bugfix-rule
+  "Bug fix → fast profile"
+  [features]
+  (when (or (= (:type features) :bugfix)
+            (contains? (:keywords features) :bugfix))
+    (selection-result :fast
+                      :high
+                      (messages/t :selector/reason-bugfix))))
+
+(defn ^{:stratum 1} match-docs-only-rule
+  "Docs only → fast profile"
+  [features]
+  (when (or (= (:type features) :docs)
+            (contains? (:keywords features) :docs-only))
+    (selection-result :fast
+                      :high
+                      (messages/t :selector/reason-docs-only))))
+
+(defn ^{:stratum 1} match-unknown-rule
+  "Unknown/ambiguous → default profile"
+  [_features]
+  (selection-result :default
+                    :low
+                    (messages/t :selector/reason-unknown)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} analyze-spec
   "Analyze spec and extract decision features.
 
    Returns map with:
@@ -152,74 +242,7 @@
      :size size
      :constraint-mentions (extract-constraints-mentions spec)}))
 
-(defn selection-result
-  "Build a selection result from a logical profile."
-  [profile confidence reason]
-  {:selection-profile profile
-   :workflow-type (selection-config/resolve-selection-profile profile)
-   :confidence confidence
-   :reason reason})
-
-;------------------------------------------------------------------------------ Layer 1
-;; Rule matching
-
-(defn match-multi-phase-rule
-  "Multi-phase implementation → comprehensive profile"
-  [features]
-  (when (and (:pr-count features)
-             (>= (:pr-count features) 4))
-    (selection-result :comprehensive
-                      :high
-                      (messages/t :selector/reason-multi-phase
-                                  {:pr-count (:pr-count features)}))))
-
-(defn match-refactoring-stratification-rule
-  "Refactoring with stratification → comprehensive profile"
-  [features]
-  (when (and (or (= (:type features) :refactoring)
-                 (contains? (:keywords features) :refactoring))
-             (or (contains? (:keywords features) :stratified-design)
-                 (contains? (:constraint-mentions features) :rule-210)))
-    (selection-result :comprehensive
-                      :high
-                      (messages/t :selector/reason-refactoring-stratification))))
-
-(defn match-large-feature-rule
-  "Large feature → comprehensive profile"
-  [features]
-  (when (and (= (:size features) :large)
-             (not (contains? (:keywords features) :bugfix))
-             (not (contains? (:keywords features) :docs-only)))
-    (selection-result :comprehensive
-                      :medium
-                      (messages/t :selector/reason-large-feature))))
-
-(defn match-bugfix-rule
-  "Bug fix → fast profile"
-  [features]
-  (when (or (= (:type features) :bugfix)
-            (contains? (:keywords features) :bugfix))
-    (selection-result :fast
-                      :high
-                      (messages/t :selector/reason-bugfix))))
-
-(defn match-docs-only-rule
-  "Docs only → fast profile"
-  [features]
-  (when (or (= (:type features) :docs)
-            (contains? (:keywords features) :docs-only))
-    (selection-result :fast
-                      :high
-                      (messages/t :selector/reason-docs-only))))
-
-(defn match-unknown-rule
-  "Unknown/ambiguous → default profile"
-  [_features]
-  (selection-result :default
-                    :low
-                    (messages/t :selector/reason-unknown)))
-
-(def selection-rules
+(def ^{:stratum 2} selection-rules
   "Ordered list of selection rules. First matching rule wins."
   [match-multi-phase-rule
    match-refactoring-stratification-rule
@@ -228,7 +251,9 @@
    match-docs-only-rule
    match-unknown-rule])
 
-(defn match-rule
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} match-rule
   "Apply selection rules to features and return first match.
 
    Rules are applied in order:
@@ -246,10 +271,10 @@
   [features]
   (some (fn [rule-fn] (rule-fn features)) selection-rules))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Workflow selection with reasoning
+;------------------------------------------------------------------------------ Layer 4
 
-(defn select-workflow
+;; Workflow selection with reasoning
+(defn ^{:stratum 4} select-workflow
   "Select appropriate workflow based on spec analysis.
 
    Returns map with:
@@ -269,28 +294,6 @@
   (let [features (analyze-spec spec)
         selection (match-rule features)]
     (assoc selection :features features)))
-
-(defn explain-selection
-  "Generate user-facing explanation for workflow selection.
-
-   Returns string suitable for printing to console.
-
-   Example:
-     ℹ️  Auto-selected workflow: canonical-sdlc-v1
-         Reason: Multi-phase refactoring with 6 PRs requires comprehensive review
-         Override with :spec/workflow-type in your spec"
-  [selection]
-  (let [{:keys [workflow-type confidence reason]} selection
-        confidence-marker (case confidence
-                            :high ""
-                            :medium (messages/t :selector/confidence-medium)
-                            :low (messages/t :selector/confidence-low)
-                            "")]
-    (str (messages/t :selector/auto-selected
-                     {:workflow (name workflow-type)
-                      :confidence-marker confidence-marker}) "\n"
-         (messages/t :selector/reason {:reason reason}) "\n"
-         (messages/t :selector/override-hint))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/bases/cli/src/ai/miniforge/cli/worktree.clj
+++ b/bases/cli/src/ai/miniforge/cli/worktree.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.worktree
   "Resolve the nearest checkout root, preferring the nearest .git marker.
 
@@ -28,27 +27,31 @@
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Path resolution
 
-(def ^:private git-marker-name
+;; Path resolution
+(def ^{:stratum 0} ^:private git-marker-name
   ".git")
 
-(defn- file->dir
+(defn- ^{:stratum 0} file->dir
   [path]
   (let [file (fs/file path)]
     (if (fs/directory? file)
       file
       (fs/parent file))))
 
-(defn- canonical-dir
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} canonical-dir
   [path]
   (some-> path file->dir fs/canonicalize str))
 
-(defn- git-marker-path
+(defn- ^{:stratum 1} git-marker-path
   [dir]
   (fs/path dir git-marker-name))
 
-(defn nearest-git-root
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} nearest-git-root
   "Walk upward from start-path and return the nearest directory containing
    a .git file or directory. Returns nil when no checkout is found."
   ([] (nearest-git-root (System/getProperty "user.dir")))
@@ -62,7 +65,9 @@
            (or (nil? parent) (= dir parent)) nil
            :else (recur parent)))))))
 
-(defn worktree-root
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} worktree-root
   "Return the canonical checkout root for start-path.
 
    Prefers the nearest .git marker. Falls back to git rev-parse only when
@@ -76,10 +81,10 @@
          (when (zero? exit)
            (some-> out str/trim not-empty))))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Git metadata
+;------------------------------------------------------------------------------ Layer 4
 
-(defn git-info
+;; Git metadata
+(defn ^{:stratum 4} git-info
   "Return basic git metadata for the resolved worktree root.
 
    Returns nil when start-path is not inside a git checkout."

--- a/bases/cli/test/ai/miniforge/cli/anomaly/etl_anomaly_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/anomaly/etl_anomaly_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.anomaly.etl-anomaly-test
   "Coverage for `cli.main.commands.etl` boundary escalation via
    `response/throw-anomaly!`.
@@ -31,9 +30,10 @@
   (:import
    (clojure.lang ExceptionInfo)))
 
-;------------------------------------------------------------------------------ resolve-pipeline-path (private)
+;------------------------------------------------------------------------------ Layer 0
 
-(deftest resolve-pipeline-path-empty-dir-throws-not-found
+;------------------------------------------------------------------------------ resolve-pipeline-path (private)
+(deftest ^{:stratum 0} resolve-pipeline-path-empty-dir-throws-not-found
   (testing "empty pack dir with no pipelines/*.edn raises :anomalies/not-found"
     (let [tmp (fs/create-temp-dir {:prefix "cli-etl-test-"})]
       (try
@@ -50,7 +50,7 @@
         (finally
           (fs/delete-tree tmp))))))
 
-(deftest resolve-pipeline-path-nonexistent-path-throws-incorrect
+(deftest ^{:stratum 0} resolve-pipeline-path-nonexistent-path-throws-incorrect
   (testing "non-dir non-edn path raises :anomalies/incorrect"
     (let [thrown (try (@#'etl/resolve-pipeline-path "/no/such/thing")
                       nil
@@ -60,7 +60,7 @@
       (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown))))
       (is (= "/no/such/thing" (:input (ex-data thrown)))))))
 
-(deftest resolve-pipeline-path-valid-edn-returns-path
+(deftest ^{:stratum 0} resolve-pipeline-path-valid-edn-returns-path
   (testing "direct pipeline EDN file returns [nil <abs-path>]"
     (let [tmp (fs/create-temp-file {:suffix ".edn"})]
       (try
@@ -70,8 +70,7 @@
           (fs/delete-if-exists tmp))))))
 
 ;------------------------------------------------------------------------------ resolve-env-path (private)
-
-(deftest resolve-env-path-nil-throws-incorrect
+(deftest ^{:stratum 0} resolve-env-path-nil-throws-incorrect
   (testing "nil env raises :anomalies/incorrect"
     (let [thrown (try (@#'etl/resolve-env-path nil nil)
                       nil
@@ -80,7 +79,7 @@
       (is (re-find #"missing --env" (.getMessage thrown)))
       (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown)))))))
 
-(deftest resolve-env-path-name-without-pack-dir-throws-incorrect
+(deftest ^{:stratum 0} resolve-env-path-name-without-pack-dir-throws-incorrect
   (testing "env name without pack-dir raises :anomalies/incorrect"
     (let [thrown (try (@#'etl/resolve-env-path "prod" nil)
                       nil
@@ -90,7 +89,7 @@
       (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown))))
       (is (= "prod" (:env (ex-data thrown)))))))
 
-(deftest resolve-env-path-name-missing-in-pack-throws-not-found
+(deftest ^{:stratum 0} resolve-env-path-name-missing-in-pack-throws-not-found
   (testing "env name not found under pack-dir/envs raises :anomalies/not-found"
     (let [tmp (fs/create-temp-dir {:prefix "cli-etl-pack-"})]
       (try
@@ -104,7 +103,7 @@
         (finally
           (fs/delete-tree tmp))))))
 
-(deftest resolve-env-path-valid-edn-returns-abs
+(deftest ^{:stratum 0} resolve-env-path-valid-edn-returns-abs
   (testing "env .edn path returns absolutized path"
     (let [tmp (fs/create-temp-file {:suffix ".edn"})]
       (try

--- a/bases/cli/test/ai/miniforge/cli/app_config_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/app_config_test.clj
@@ -15,14 +15,15 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.app-config-test
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.cli.app-config :as app-config]
    [ai.miniforge.cli.resource-config :as resource-config]))
 
-(deftest default-app-profile-test
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} default-app-profile-test
   (let [profile (app-config/app-profile)]
     (testing "base CLI exposes a resource-backed profile"
       (is (= (:name profile) (app-config/binary-name)))
@@ -35,7 +36,7 @@
       (is (.endsWith (app-config/events-dir)
                      (str "/" (:home-dir-name profile) "/events"))))))
 
-(deftest app-profile-loads-resource-backed-config-test
+(deftest ^{:stratum 0} app-profile-loads-resource-backed-config-test
   (testing "app profile delegates to the resource-backed config loader"
     (with-redefs [resource-config/merged-resource-config
                   (fn [_resource _key _default]
@@ -45,7 +46,7 @@
         (is (= "miniforge-core" (:name profile)))
         (is (= ["run demo" "doctor"] (:help-examples profile)))))))
 
-(deftest home-dir-prefers-miniforge-home-env-test
+(deftest ^{:stratum 0} home-dir-prefers-miniforge-home-env-test
   (testing "MINIFORGE_HOME overrides the default CLI home path"
     (with-redefs [app-config/getenv (fn [var-name]
                                       (when (= "MINIFORGE_HOME" var-name)
@@ -54,7 +55,7 @@
       (is (= "/tmp/mf-home" (app-config/home-dir)))
       (is (= "/tmp/mf-home/events" (app-config/events-dir))))))
 
-(deftest home-dir-falls-back-to-profile-based-default-test
+(deftest ^{:stratum 0} home-dir-falls-back-to-profile-based-default-test
   (testing "default CLI home path stays profile-derived when MINIFORGE_HOME is unset"
     (with-redefs [app-config/getenv (constantly nil)
                   app-config/default-home-dir (constantly "/Users/test/.miniforge-core")]

--- a/bases/cli/test/ai/miniforge/cli/backends_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/backends_test.clj
@@ -15,16 +15,15 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.backends-test
   (:require
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.cli.backends :as backends]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Resource-backed backend config
 
-(deftest backend-specs-loaded-from-resource-test
+;; Resource-backed backend config
+(deftest ^{:stratum 0} backend-specs-loaded-from-resource-test
   (testing "backend specs include opencode from resource config"
     (is (= "OpenCode" (get-in backends/backend-specs [:opencode :provider]))))
 

--- a/bases/cli/test/ai/miniforge/cli/config_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/config_test.clj
@@ -15,14 +15,15 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.config-test
   "Tests for Aero configuration management."
   (:require [clojure.test :refer [deftest testing is]]
             [ai.miniforge.cli.config :as config]
             [clojure.java.io :as io]))
 
-(deftest load-config-test
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} load-config-test
   (testing "load-config loads configuration from resources"
     (let [cfg (config/load-config)]
       (is (map? cfg))
@@ -48,7 +49,7 @@
     (let [cfg (config/load-config {:config-file (io/file "/nonexistent/config.edn")})]
       (is (map? cfg)))))
 
-(deftest get-llm-backend-test
+(deftest ^{:stratum 0} get-llm-backend-test
   (testing "get-llm-backend returns workflow override when provided"
     (let [cfg {:llm {:backend :anthropic}}]
       (is (= :openai (config/get-llm-backend cfg :openai)))))
@@ -61,7 +62,7 @@
     (is (= :opencode (config/get-llm-backend {} nil)))
     (is (= :opencode (config/get-llm-backend {:llm {}} nil)))))
 
-(deftest get-llm-timeout-test
+(deftest ^{:stratum 0} get-llm-timeout-test
   (testing "get-llm-timeout returns config value"
     (let [cfg {:llm {:timeout-ms 600000}}]
       (is (= 600000 (config/get-llm-timeout cfg)))))
@@ -70,7 +71,7 @@
     (is (= 300000 (config/get-llm-timeout {})))
     (is (= 300000 (config/get-llm-timeout {:llm {}})))))
 
-(deftest get-llm-line-timeout-test
+(deftest ^{:stratum 0} get-llm-line-timeout-test
   (testing "get-llm-line-timeout returns config value"
     (let [cfg {:llm {:line-timeout-ms 120000}}]
       (is (= 120000 (config/get-llm-line-timeout cfg)))))
@@ -79,7 +80,7 @@
     (is (= 60000 (config/get-llm-line-timeout {})))
     (is (= 60000 (config/get-llm-line-timeout {:llm {}})))))
 
-(deftest config-structure-test
+(deftest ^{:stratum 0} config-structure-test
   (testing "config.edn has expected structure"
     (let [cfg (config/load-config)]
       (testing "llm config section"
@@ -101,7 +102,7 @@
       (testing "artifacts config section"
         (is (string? (get-in cfg [:artifacts :dir])))))))
 
-(deftest env-overrides-test
+(deftest ^{:stratum 0} env-overrides-test
   (testing "config respects environment variable overrides"
     ;; This test documents the behavior but doesn't test actual env vars
     ;; since that would require setting system properties

--- a/bases/cli/test/ai/miniforge/cli/main/commands/artifact_cmds_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/artifact_cmds_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.main.commands.artifact-cmds-test
   "Unit tests for artifact CLI commands."
   (:require
@@ -24,9 +23,10 @@
    [ai.miniforge.cli.main.commands.artifact-cmds :as sut]
    [ai.miniforge.cli.main.commands.shared :as shared]))
 
-;------------------------------------------------------------------------------ Layer 0: Factory helpers
+;------------------------------------------------------------------------------ Layer 0
 
-(defn make-provenance
+;------------------------------------------------------------------------------ Layer 0: Factory helpers
+(defn ^{:stratum 0} make-provenance
   "Build a minimal provenance map for testing."
   ([]
    (make-provenance {}))
@@ -40,9 +40,8 @@
            :artifact/files ["src/core.clj"]}
           overrides)))
 
-;------------------------------------------------------------------------------ Layer 1: Tests
-
-(deftest format-file-size-test
+;; Tests
+(deftest ^{:stratum 0} format-file-size-test
   (testing "bytes under 1KB display as bytes"
     (is (= "512B" (sut/format-file-size 512))))
 
@@ -54,14 +53,14 @@
     (is (= "1.0MB" (sut/format-file-size shared/bytes-per-mb)))
     (is (= "2.5MB" (sut/format-file-size (* 2.5 shared/bytes-per-mb))))))
 
-(deftest artifact-list-cmd-no-component-empty-dir-test
+(deftest ^{:stratum 0} artifact-list-cmd-no-component-empty-dir-test
   (testing "list command shows 'no artifacts' when dir is empty"
     (with-redefs [sut/list-component-artifacts (constantly nil)
                   app-config/artifacts-dir (constantly "/tmp/nonexistent-artifacts")]
       (let [output (with-out-str (sut/artifact-list-cmd {}))]
         (is (re-find #"(?i)no artifacts" output))))))
 
-(deftest artifact-list-cmd-component-result-test
+(deftest ^{:stratum 0} artifact-list-cmd-component-result-test
   (testing "list command displays component results when available"
     (with-redefs [sut/list-component-artifacts
                   (constantly [{:artifact/id "art-1"
@@ -71,23 +70,14 @@
       (let [output (with-out-str (sut/artifact-list-cmd {}))]
         (is (.contains output "art-1"))))))
 
-(deftest artifact-provenance-cmd-missing-id-test
+(deftest ^{:stratum 0} artifact-provenance-cmd-missing-id-test
   (testing "provenance command exits with error when no id provided"
     (let [exited? (atom false)]
       (with-redefs [shared/exit! (fn [_] (reset! exited? true))]
         (with-out-str (sut/artifact-provenance-cmd {}))
         (is @exited?)))))
 
-(deftest artifact-provenance-cmd-with-provenance-test
-  (testing "provenance command displays provenance data"
-    (let [prov (make-provenance)]
-      (with-redefs [sut/get-component-provenance (constantly prov)
-                    app-config/artifacts-dir (constantly "/tmp/test")]
-        (let [output (with-out-str (sut/artifact-provenance-cmd {:id "art-1"}))]
-          (is (.contains output "wf-123"))
-          (is (.contains output "agent-1")))))))
-
-(deftest artifact-provenance-cmd-not-found-test
+(deftest ^{:stratum 0} artifact-provenance-cmd-not-found-test
   (testing "provenance command shows error when artifact not found"
     (let [exited? (atom false)]
       (with-redefs [sut/get-component-provenance (constantly nil)
@@ -95,3 +85,14 @@
                     shared/exit! (fn [_] (reset! exited? true))]
         (with-out-str (sut/artifact-provenance-cmd {:id "missing"}))
         (is @exited?)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} artifact-provenance-cmd-with-provenance-test
+  (testing "provenance command displays provenance data"
+    (let [prov (make-provenance)]
+      (with-redefs [sut/get-component-provenance (constantly prov)
+                    app-config/artifacts-dir (constantly "/tmp/test")]
+        (let [output (with-out-str (sut/artifact-provenance-cmd {:id "art-1"}))]
+          (is (.contains output "wf-123"))
+          (is (.contains output "agent-1")))))))

--- a/bases/cli/test/ai/miniforge/cli/main/commands/etl_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/etl_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.main.commands.etl-test
   "Unit tests for ETL CLI commands."
   (:require
@@ -25,18 +24,18 @@
    [ai.miniforge.cli.main.commands.etl :as sut]
    [ai.miniforge.cli.main.commands.shared :as shared]))
 
-;------------------------------------------------------------------------------ Layer 0: Factory helpers
+;------------------------------------------------------------------------------ Layer 0
 
-(defn make-etl-opts
+;------------------------------------------------------------------------------ Layer 0: Factory helpers
+(defn ^{:stratum 0} make-etl-opts
   "Build a minimal ETL opts map for testing."
   ([]
    (make-etl-opts {}))
   ([overrides]
    (merge {:url "https://github.com/example/repo"} overrides)))
 
-;------------------------------------------------------------------------------ Layer 1: Tests
-
-(deftest validate-git-url-test
+;; Tests
+(deftest ^{:stratum 0} validate-git-url-test
   (testing "HTTPS URL is valid"
     (is (true? (sut/validate-git-url "https://github.com/org/repo"))))
 
@@ -55,21 +54,21 @@
   (testing "empty string is invalid"
     (is (false? (sut/validate-git-url "")))))
 
-(deftest etl-repo-cmd-missing-url-test
+(deftest ^{:stratum 0} etl-repo-cmd-missing-url-test
   (testing "command exits with error when no url provided"
     (let [exited? (atom false)]
       (with-redefs [shared/exit! (fn [_] (reset! exited? true))]
         (with-out-str (sut/etl-repo-cmd {}))
         (is @exited?)))))
 
-(deftest etl-repo-cmd-invalid-url-test
+(deftest ^{:stratum 0} etl-repo-cmd-invalid-url-test
   (testing "command exits with error for invalid URL"
     (let [exited? (atom false)]
       (with-redefs [shared/exit! (fn [_] (reset! exited? true))]
         (with-out-str (sut/etl-repo-cmd {:url "bad-url"}))
         (is @exited?)))))
 
-(deftest etl-repo-cmd-analyzes-repo-directly-test
+(deftest ^{:stratum 0} etl-repo-cmd-analyzes-repo-directly-test
   (testing "valid repo URLs use the direct repo-analyzer interface"
     (let [repo-dir (.toFile
                     (java.nio.file.Files/createTempDirectory
@@ -100,7 +99,7 @@
                   [:analyze (.getAbsolutePath repo-dir)]]
                  @calls)))))))
 
-(deftest etl-repo-cmd-exits-on-clone-failure-test
+(deftest ^{:stratum 0} etl-repo-cmd-exits-on-clone-failure-test
   (testing "clone failures become a non-zero command exit"
     (let [exit-code (atom nil)]
       (with-redefs-fn {#'sut/git-clone-temp
@@ -114,7 +113,7 @@
             (sut/etl-repo-cmd {:url "https://github.com/example/repo"}))
           (is (= 1 @exit-code)))))))
 
-(deftest etl-repo-cmd-exits-on-analysis-failure-test
+(deftest ^{:stratum 0} etl-repo-cmd-exits-on-analysis-failure-test
   (testing "repo-analyzer failures become a non-zero command exit"
     (let [repo-dir (.toFile
                     (java.nio.file.Files/createTempDirectory

--- a/bases/cli/test/ai/miniforge/cli/main/commands/events_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/events_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.main.commands.events-test
   "Unit / integration tests for the `events show` CLI command.
 
@@ -36,11 +35,12 @@
    [ai.miniforge.cli.main.commands.shared :as shared]
    [ai.miniforge.event-stream.interface :as es]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;------------------------------------------------------------------------------ Fixtures & factories
+(def ^{:stratum 0} ^:dynamic *tmp-dir* nil)
 
-(def ^:dynamic *tmp-dir* nil)
-
-(defn tmp-dir-fixture [f]
+(defn ^{:stratum 0} tmp-dir-fixture [f]
   (let [dir (str (fs/create-temp-dir {:prefix "events-test-"}))]
     (binding [*tmp-dir* dir]
       (try
@@ -48,11 +48,8 @@
         (finally
           (fs/delete-tree dir))))))
 
-(use-fixtures :each tmp-dir-fixture)
-
 ;; Synthetic event vectors used across tests.
-
-(defn- make-started-event
+(defn- ^{:stratum 0} make-started-event
   "Minimal `:workflow/started` event."
   [& {:as overrides}]
   (merge {:event/type      :workflow/started
@@ -61,7 +58,7 @@
           :workflow/phase  :plan}
          overrides))
 
-(defn- make-completed-event
+(defn- ^{:stratum 0} make-completed-event
   "Minimal `:workflow/completed` event."
   [& {:as overrides}]
   (merge {:event/type      :workflow/completed
@@ -70,16 +67,95 @@
           :workflow/phase  :release}
          overrides))
 
-(def ^:private synthetic-events
+(def ^{:stratum 0} ^:private nonexistent-base-dir
+  "/nonexistent/events/dir/that/does/not/exist")
+
+(deftest ^{:stratum 0} events-show-cmd-missing-workflow-id-exits-1
+  (testing "exits 1 and prints usage when workflow-id is absent"
+    (let [exit-code (atom nil)]
+      (with-redefs [shared/exit! (fn [code] (reset! exit-code code))]
+        (with-out-str
+          (sut/events-show-cmd {:workflow-id nil})))
+      (is (= 1 @exit-code)))))
+
+(deftest ^{:stratum 0} events-show-cmd-blank-workflow-id-exits-1
+  (testing "exits 1 when workflow-id is an empty string"
+    (let [exit-code (atom nil)]
+      (with-redefs [shared/exit! (fn [code] (reset! exit-code code))]
+        (with-out-str
+          (sut/events-show-cmd {:workflow-id ""})))
+      (is (= 1 @exit-code)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} ^:private synthetic-events
   [(make-started-event)
    (make-completed-event)])
 
-(def ^:private nonexistent-base-dir
-  "/nonexistent/events/dir/that/does/not/exist")
+(deftest ^{:stratum 1} events-show-errors-when-workflow-id-blank
+  (testing "pure command returns :error when workflow-id is blank"
+    (let [result (sut/events-show *tmp-dir* " " {})]
+      (is (= :error (:status result)))
+      (is (= 1 (:exit-code result))))))
 
-;------------------------------------------------------------------------------ Layer 0: events-show pure fn
+(deftest ^{:stratum 1} events-show-errors-when-base-dir-missing
+  (testing "returns :error when the events base directory does not exist"
+    (let [result (sut/events-show nonexistent-base-dir "any-wf-id" {})]
+      (is (= :error (:status result)))
+      (is (pos-int? (:exit-code result)))
+      (is (str/includes? (:message result) "not found")))))
 
-(deftest events-show-returns-ok-for-valid-events
+(deftest ^{:stratum 1} events-show-errors-when-workflow-not-found
+  (testing "returns :error when reader returns nil (workflow-id unknown)"
+    (let [result (with-redefs [es/read-workflow-events-by-id (fn [_ _] nil)]
+                   (sut/events-show *tmp-dir* "ghost-wf-id" {}))]
+      (is (= :error (:status result)))
+      (is (pos-int? (:exit-code result)))
+      (is (str/includes? (:message result) "ghost-wf-id")))))
+
+(deftest ^{:stratum 1} events-show-empty-rendered-timeline-has-fallback
+  (let [result (with-redefs [es/read-workflow-events-by-id (fn [_ _] [])
+                             es/render-timeline (fn [_ _] "")]
+                 (sut/events-show *tmp-dir* "test-wf-abc123" {}))]
+    (is (= :ok (:status result)))
+    (is (str/includes? (:output result) "no renderable events"))))
+
+(deftest ^{:stratum 1} events-show-reader-exception-is-error
+  (let [result (with-redefs [es/read-workflow-events-by-id
+                             (fn [_ _] (throw (ex-info "broken reader" {})))]
+                 (sut/events-show *tmp-dir* "test-wf-abc123" {}))]
+    (is (= :error (:status result)))
+    (is (= 1 (:exit-code result)))
+    (is (str/includes? (:message result) "broken reader"))))
+
+(deftest ^{:stratum 1} events-show-cmd-workflow-not-found-exits-1
+  (testing "exits 1 when reader returns nil (workflow-id not in any layout)"
+    (let [exit-code (atom nil)]
+      (with-redefs [app-config/events-dir
+                    (fn [] *tmp-dir*)
+                    es/read-workflow-events-by-id
+                    (fn [_ _] nil)
+                    shared/exit!
+                    (fn [code] (reset! exit-code code))]
+        (with-out-str
+          (sut/events-show-cmd {:workflow-id "ghost-wf-id"})))
+      (is (= 1 @exit-code)))))
+
+(deftest ^{:stratum 1} events-show-cmd-events-dir-missing-exits-1
+  (testing "exits 1 when the events directory itself does not exist"
+    (let [exit-code (atom nil)]
+      (with-redefs [app-config/events-dir
+                    (fn [] nonexistent-base-dir)
+                    shared/exit!
+                    (fn [code] (reset! exit-code code))]
+        (with-out-str
+          (sut/events-show-cmd {:workflow-id "any-wf-id"})))
+      (is (= 1 @exit-code)))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; events-show pure fn
+(deftest ^{:stratum 2} events-show-returns-ok-for-valid-events
   (testing "returns :ok status with non-blank output for a normal event sequence"
     (let [result (with-redefs [es/read-workflow-events-by-id
                                (fn [_ _] synthetic-events)
@@ -89,28 +165,7 @@
       (is (= :ok (:status result)))
       (is (= "rendered timeline" (:output result))))))
 
-(deftest events-show-errors-when-workflow-id-blank
-  (testing "pure command returns :error when workflow-id is blank"
-    (let [result (sut/events-show *tmp-dir* " " {})]
-      (is (= :error (:status result)))
-      (is (= 1 (:exit-code result))))))
-
-(deftest events-show-errors-when-base-dir-missing
-  (testing "returns :error when the events base directory does not exist"
-    (let [result (sut/events-show nonexistent-base-dir "any-wf-id" {})]
-      (is (= :error (:status result)))
-      (is (pos-int? (:exit-code result)))
-      (is (str/includes? (:message result) "not found")))))
-
-(deftest events-show-errors-when-workflow-not-found
-  (testing "returns :error when reader returns nil (workflow-id unknown)"
-    (let [result (with-redefs [es/read-workflow-events-by-id (fn [_ _] nil)]
-                   (sut/events-show *tmp-dir* "ghost-wf-id" {}))]
-      (is (= :error (:status result)))
-      (is (pos-int? (:exit-code result)))
-      (is (str/includes? (:message result) "ghost-wf-id")))))
-
-(deftest events-show-raw-mode-dumps-edn
+(deftest ^{:stratum 2} events-show-raw-mode-dumps-edn
   (testing ":raw true produces EDN output containing the event type keyword"
     (let [result (with-redefs [es/read-workflow-events-by-id
                                (fn [_ _] synthetic-events)]
@@ -119,7 +174,7 @@
       (is (str/includes? (:output result) "workflow/started"))
       (is (str/includes? (:output result) "workflow/completed")))))
 
-(deftest events-show-custom-gap-threshold
+(deftest ^{:stratum 2} events-show-custom-gap-threshold
   (testing "custom gap-threshold-secs is accepted without error"
     (let [result (with-redefs [es/read-workflow-events-by-id
                                (fn [_ _] synthetic-events)
@@ -130,24 +185,8 @@
       (is (= :ok (:status result)))
       (is (= "gap=5000" (:output result))))))
 
-(deftest events-show-empty-rendered-timeline-has-fallback
-  (let [result (with-redefs [es/read-workflow-events-by-id (fn [_ _] [])
-                             es/render-timeline (fn [_ _] "")]
-                 (sut/events-show *tmp-dir* "test-wf-abc123" {}))]
-    (is (= :ok (:status result)))
-    (is (str/includes? (:output result) "no renderable events"))))
-
-(deftest events-show-reader-exception-is-error
-  (let [result (with-redefs [es/read-workflow-events-by-id
-                             (fn [_ _] (throw (ex-info "broken reader" {})))]
-                 (sut/events-show *tmp-dir* "test-wf-abc123" {}))]
-    (is (= :error (:status result)))
-    (is (= 1 (:exit-code result)))
-    (is (str/includes? (:message result) "broken reader"))))
-
-;------------------------------------------------------------------------------ Layer 1: events-show-cmd CLI handler
-
-(deftest events-show-cmd-happy-path-prints-timeline
+;; events-show-cmd CLI handler
+(deftest ^{:stratum 2} events-show-cmd-happy-path-prints-timeline
   (testing "prints rendered timeline to stdout when events exist"
     (let [exit-code (atom nil)
           output    (with-redefs [app-config/events-dir
@@ -163,47 +202,7 @@
       (is (nil? @exit-code) "exit! must not be called on success")
       (is (not (str/blank? output))))))
 
-(deftest events-show-cmd-missing-workflow-id-exits-1
-  (testing "exits 1 and prints usage when workflow-id is absent"
-    (let [exit-code (atom nil)]
-      (with-redefs [shared/exit! (fn [code] (reset! exit-code code))]
-        (with-out-str
-          (sut/events-show-cmd {:workflow-id nil})))
-      (is (= 1 @exit-code)))))
-
-(deftest events-show-cmd-blank-workflow-id-exits-1
-  (testing "exits 1 when workflow-id is an empty string"
-    (let [exit-code (atom nil)]
-      (with-redefs [shared/exit! (fn [code] (reset! exit-code code))]
-        (with-out-str
-          (sut/events-show-cmd {:workflow-id ""})))
-      (is (= 1 @exit-code)))))
-
-(deftest events-show-cmd-workflow-not-found-exits-1
-  (testing "exits 1 when reader returns nil (workflow-id not in any layout)"
-    (let [exit-code (atom nil)]
-      (with-redefs [app-config/events-dir
-                    (fn [] *tmp-dir*)
-                    es/read-workflow-events-by-id
-                    (fn [_ _] nil)
-                    shared/exit!
-                    (fn [code] (reset! exit-code code))]
-        (with-out-str
-          (sut/events-show-cmd {:workflow-id "ghost-wf-id"})))
-      (is (= 1 @exit-code)))))
-
-(deftest events-show-cmd-events-dir-missing-exits-1
-  (testing "exits 1 when the events directory itself does not exist"
-    (let [exit-code (atom nil)]
-      (with-redefs [app-config/events-dir
-                    (fn [] nonexistent-base-dir)
-                    shared/exit!
-                    (fn [code] (reset! exit-code code))]
-        (with-out-str
-          (sut/events-show-cmd {:workflow-id "any-wf-id"})))
-      (is (= 1 @exit-code)))))
-
-(deftest events-show-cmd-raw-flag-dumps-edn
+(deftest ^{:stratum 2} events-show-cmd-raw-flag-dumps-edn
   (testing "--raw dumps parsed events as EDN including keyword names"
     (let [exit-code (atom nil)
           output    (with-redefs [app-config/events-dir
@@ -218,6 +217,8 @@
       (is (nil? @exit-code) "exit! must not be called on success")
       (is (str/includes? output "workflow/started"))
       (is (str/includes? output "workflow/completed")))))
+
+(use-fixtures :each tmp-dir-fixture)
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/bases/cli/test/ai/miniforge/cli/main/commands/evidence_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/evidence_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.main.commands.evidence-test
   "Unit tests for evidence bundle CLI commands."
   (:require
@@ -25,11 +24,12 @@
    [ai.miniforge.cli.main.commands.evidence :as sut]
    [ai.miniforge.cli.main.commands.shared :as shared]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;------------------------------------------------------------------------------ Layer 0: Fixtures & factories
+(def ^{:stratum 0} ^:dynamic *tmp-dir* nil)
 
-(def ^:dynamic *tmp-dir* nil)
-
-(defn tmp-dir-fixture [f]
+(defn ^{:stratum 0} tmp-dir-fixture [f]
   (let [dir (str (fs/create-temp-dir {:prefix "evidence-test-"}))]
     (binding [*tmp-dir* dir]
       (try
@@ -37,9 +37,7 @@
         (finally
           (fs/delete-tree dir))))))
 
-(use-fixtures :each tmp-dir-fixture)
-
-(defn- make-artifact
+(defn- ^{:stratum 0} make-artifact
   "Factory for a single bundle artifact entry. Defaults to a code artifact;
    override `:artifact/type` or `:artifact/id` to vary per test."
   [& {:as overrides}]
@@ -47,26 +45,26 @@
           :artifact/id   "art-1"}
          overrides))
 
-(defn- make-phase
+(defn- ^{:stratum 0} make-phase
   "Factory for a phase entry under `:evidence/plan` or `:evidence/implement`."
   [phase-name & {:as overrides}]
   (merge {:phase/name phase-name}
          overrides))
 
-(defn- make-outcome
+(defn- ^{:stratum 0} make-outcome
   "Factory for an `:evidence/outcome` value."
   [& {:as overrides}]
   (merge {:outcome/success false}
          overrides))
 
-(defn- make-dependency-health
+(defn- ^{:stratum 0} make-dependency-health
   "Factory for a single `:evidence/dependency-health` entry."
   [& {:as overrides}]
   (merge {:dependency/id     :anthropic
           :dependency/status :degraded}
          overrides))
 
-(defn- make-failure-attribution
+(defn- ^{:stratum 0} make-failure-attribution
   "Factory for an `:evidence/failure-attribution` map."
   [& {:as overrides}]
   (merge {:failure/source   :external-provider
@@ -75,7 +73,31 @@
           :dependency/class :rate-limit}
          overrides))
 
-(defn- make-bundle
+(defn- ^{:stratum 0} make-list-bundle
+  "Factory for the minimal bundle shape returned by the optional provider in list output."
+  [& {:as overrides}]
+  (merge {:bundle/id          "b-1"
+          :bundle/workflow-id "wf-1"
+          :bundle/status      "complete"}
+         overrides))
+
+(deftest ^{:stratum 0} evidence-show-cmd-missing-id-test
+  (testing "show command exits with error when no id provided"
+    (let [exited? (atom false)]
+      (with-redefs [shared/exit! (fn [_] (reset! exited? true))]
+        (with-out-str (sut/evidence-show-cmd {}))
+        (is @exited?)))))
+
+(deftest ^{:stratum 0} evidence-export-cmd-missing-id-test
+  (testing "export command exits with error when no id provided"
+    (let [exited? (atom false)]
+      (with-redefs [shared/exit! (fn [_] (reset! exited? true))]
+        (with-out-str (sut/evidence-export-cmd {}))
+        (is @exited?)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} make-bundle
   "Factory for a minimal legacy evidence bundle. Pass overrides as kwargs."
   [& {:as overrides}]
   (merge {:bundle/id          "bundle-1"
@@ -86,15 +108,7 @@
           :bundle/phases      [:plan :implement]}
          overrides))
 
-(defn- make-list-bundle
-  "Factory for the minimal bundle shape returned by the optional provider in list output."
-  [& {:as overrides}]
-  (merge {:bundle/id          "b-1"
-          :bundle/workflow-id "wf-1"
-          :bundle/status      "complete"}
-         overrides))
-
-(defn- make-canonical-bundle
+(defn- ^{:stratum 1} make-canonical-bundle
   "Factory for a canonical-form evidence bundle including dependency-health
    and failure-attribution. Pass overrides as kwargs."
   [& {:as overrides}]
@@ -109,29 +123,21 @@
          overrides))
 
 ;------------------------------------------------------------------------------ Layer 1: Tests
-
-(deftest evidence-list-cmd-no-component-empty-dir-test
+(deftest ^{:stratum 1} evidence-list-cmd-no-component-empty-dir-test
   (testing "list command shows 'no bundles' when dir is empty"
     (with-redefs [shared/call-optional-provider (constantly nil)
                   app-config/home-dir (constantly *tmp-dir*)]
       (let [output (with-out-str (sut/evidence-list-cmd {}))]
         (is (re-find #"(?i)no evidence" output))))))
 
-(deftest evidence-list-cmd-component-results-test
+(deftest ^{:stratum 1} evidence-list-cmd-component-results-test
   (testing "list command displays component results when available"
     (with-redefs [shared/call-optional-provider
                   (constantly [(make-list-bundle)])]
       (let [output (with-out-str (sut/evidence-list-cmd {}))]
         (is (.contains output "b-1"))))))
 
-(deftest evidence-show-cmd-missing-id-test
-  (testing "show command exits with error when no id provided"
-    (let [exited? (atom false)]
-      (with-redefs [shared/exit! (fn [_] (reset! exited? true))]
-        (with-out-str (sut/evidence-show-cmd {}))
-        (is @exited?)))))
-
-(deftest evidence-show-cmd-not-found-test
+(deftest ^{:stratum 1} evidence-show-cmd-not-found-test
   (testing "show command reports not found for unknown bundle"
     (let [exited? (atom false)]
       (with-redefs [shared/call-optional-provider (constantly nil)
@@ -140,7 +146,20 @@
         (with-out-str (sut/evidence-show-cmd {:id "missing"}))
         (is @exited?)))))
 
-(deftest evidence-show-cmd-with-bundle-test
+(deftest ^{:stratum 1} load-bundle-from-file-test
+  (testing "loads valid EDN file"
+    (let [f (java.io.File. (str *tmp-dir* "/test.edn"))]
+      (spit f (pr-str {:bundle/id "b-1"}))
+      (is (= {:bundle/id "b-1"} (sut/load-bundle-from-file f)))))
+
+  (testing "returns nil for non-EDN file"
+    (let [f (java.io.File. (str *tmp-dir* "/test.json"))]
+      (spit f "{}")
+      (is (nil? (sut/load-bundle-from-file f))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} evidence-show-cmd-with-bundle-test
   (testing "show command displays bundle details from filesystem"
     (let [evidence-path (str *tmp-dir* "/evidence")]
       (fs/create-dirs evidence-path)
@@ -150,7 +169,7 @@
         (let [output (with-out-str (sut/evidence-show-cmd {:id "test-bundle"}))]
           (is (.contains output "wf-1")))))))
 
-(deftest evidence-show-cmd-with-canonical-bundle-test
+(deftest ^{:stratum 2} evidence-show-cmd-with-canonical-bundle-test
   (testing "show command normalizes canonical evidence bundle fields"
     (let [evidence-path (str *tmp-dir* "/evidence")]
       (fs/create-dirs evidence-path)
@@ -163,20 +182,4 @@
           (is (.contains output "external-provider / anthropic / rate-limit"))
           (is (.contains output "Dependencies: 1")))))))
 
-(deftest evidence-export-cmd-missing-id-test
-  (testing "export command exits with error when no id provided"
-    (let [exited? (atom false)]
-      (with-redefs [shared/exit! (fn [_] (reset! exited? true))]
-        (with-out-str (sut/evidence-export-cmd {}))
-        (is @exited?)))))
-
-(deftest load-bundle-from-file-test
-  (testing "loads valid EDN file"
-    (let [f (java.io.File. (str *tmp-dir* "/test.edn"))]
-      (spit f (pr-str {:bundle/id "b-1"}))
-      (is (= {:bundle/id "b-1"} (sut/load-bundle-from-file f)))))
-
-  (testing "returns nil for non-EDN file"
-    (let [f (java.io.File. (str *tmp-dir* "/test.json"))]
-      (spit f "{}")
-      (is (nil? (sut/load-bundle-from-file f))))))
+(use-fixtures :each tmp-dir-fixture)

--- a/bases/cli/test/ai/miniforge/cli/main/commands/fleet_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/fleet_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.main.commands.fleet-test
   "Unit tests for fleet CLI commands: config loading, saving, add/remove."
   (:require
@@ -25,13 +24,14 @@
    [ai.miniforge.cli.messages :as messages]
    [ai.miniforge.cli.main.commands.fleet :as sut]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; ============================================================================
 ;; Temp directory fixture
 ;; ============================================================================
+(def ^{:stratum 0} ^:dynamic *tmp-dir* nil)
 
-(def ^:dynamic *tmp-dir* nil)
-
-(defn tmp-dir-fixture [f]
+(defn ^{:stratum 0} tmp-dir-fixture [f]
   (let [dir (str (fs/create-temp-dir {:prefix "fleet-test-"}))]
     (binding [*tmp-dir* dir]
       (try
@@ -39,29 +39,41 @@
         (finally
           (fs/delete-tree dir))))))
 
-(use-fixtures :each tmp-dir-fixture)
-
 ;; ============================================================================
 ;; Helpers
 ;; ============================================================================
-
-(def default-config
+(def ^{:stratum 0} default-config
   {:fleet {:repos []}
    :version "test"})
 
-(defn tmp-path [& segments]
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} tmp-path [& segments]
   (apply str *tmp-dir* "/" segments))
 
 ;; ============================================================================
 ;; load-config tests
 ;; ============================================================================
-
-(deftest load-config-missing-file-returns-defaults-test
+(deftest ^{:stratum 1} load-config-missing-file-returns-defaults-test
   (testing "Returns default config when file does not exist"
     (let [result (sut/load-config nil "/nonexistent/config.edn" default-config)]
       (is (= default-config result)))))
 
-(deftest load-config-reads-existing-file-test
+(deftest ^{:stratum 1} fleet-add-cmd-no-repo-prints-error-test
+  (testing "Prints error when no repo is provided"
+    (let [output (with-out-str
+                   (sut/fleet-add-cmd {:repo nil} nil default-config))]
+      (is (.contains output "Usage")))))
+
+(deftest ^{:stratum 1} fleet-remove-cmd-no-repo-prints-error-test
+  (testing "Prints error when no repo is provided"
+    (let [output (with-out-str
+                   (sut/fleet-remove-cmd {:repo nil} nil default-config))]
+      (is (.contains output "Usage")))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} load-config-reads-existing-file-test
   (testing "Reads and merges config from existing file"
     (let [path (tmp-path "config.edn")
           file-config {:fleet {:repos ["org/repo-1"]}}]
@@ -69,7 +81,7 @@
       (let [result (sut/load-config path nil default-config)]
         (is (= ["org/repo-1"] (get-in result [:fleet :repos])))))))
 
-(deftest load-config-merges-with-defaults-test
+(deftest ^{:stratum 2} load-config-merges-with-defaults-test
   (testing "File config is merged with defaults (file wins on conflict)"
     (let [path (tmp-path "config.edn")
           file-config {:fleet {:repos ["r1"]} :extra :data}]
@@ -80,7 +92,7 @@
         (is (= "test" (:version result))
             "Default keys not in file are preserved")))))
 
-(deftest load-config-explicit-path-overrides-default-path-test
+(deftest ^{:stratum 2} load-config-explicit-path-overrides-default-path-test
   (testing "Explicit path takes precedence over default config path"
     (let [explicit (tmp-path "explicit.edn")
           default-path (tmp-path "default.edn")]
@@ -89,7 +101,7 @@
       (let [result (sut/load-config explicit default-path default-config)]
         (is (= ["explicit"] (get-in result [:fleet :repos])))))))
 
-(deftest load-config-nil-path-uses-default-path-test
+(deftest ^{:stratum 2} load-config-nil-path-uses-default-path-test
   (testing "nil explicit path falls back to default config path"
     (let [default-path (tmp-path "default.edn")]
       (spit default-path (pr-str {:fleet {:repos ["from-default"]}}))
@@ -99,22 +111,21 @@
 ;; ============================================================================
 ;; save-config tests
 ;; ============================================================================
-
-(deftest save-config-creates-parent-dirs-test
+(deftest ^{:stratum 2} save-config-creates-parent-dirs-test
   (testing "Creates parent directories if they don't exist"
     (let [path (tmp-path "nested" "dir" "config.edn")]
       (sut/save-config {:fleet {:repos ["r1"]}} path nil)
       (is (fs/exists? path))
       (is (= {:fleet {:repos ["r1"]}} (edn/read-string (slurp path)))))))
 
-(deftest save-config-uses-default-path-when-nil-test
+(deftest ^{:stratum 2} save-config-uses-default-path-when-nil-test
   (testing "Uses default path when explicit path is nil"
     (let [default-path (tmp-path "default-save.edn")]
       (sut/save-config {:data true} nil default-path)
       (is (fs/exists? default-path))
       (is (= {:data true} (edn/read-string (slurp default-path)))))))
 
-(deftest save-config-overwrites-existing-test
+(deftest ^{:stratum 2} save-config-overwrites-existing-test
   (testing "Overwrites existing config file"
     (let [path (tmp-path "overwrite.edn")]
       (spit path (pr-str {:old :data}))
@@ -124,8 +135,7 @@
 ;; ============================================================================
 ;; fleet-add-cmd tests
 ;; ============================================================================
-
-(deftest fleet-add-cmd-adds-repo-test
+(deftest ^{:stratum 2} fleet-add-cmd-adds-repo-test
   (testing "Adds a repo to the fleet config"
     (let [path (tmp-path "add-config.edn")]
       (spit path (pr-str {:fleet {:repos []}}))
@@ -133,7 +143,7 @@
       (let [saved (edn/read-string (slurp path))]
         (is (= ["org/new-repo"] (get-in saved [:fleet :repos])))))))
 
-(deftest fleet-add-cmd-appends-to-existing-repos-test
+(deftest ^{:stratum 2} fleet-add-cmd-appends-to-existing-repos-test
   (testing "Appends to existing repos without removing them"
     (let [path (tmp-path "append-config.edn")]
       (spit path (pr-str {:fleet {:repos ["org/existing"]}}))
@@ -141,17 +151,10 @@
       (let [saved (edn/read-string (slurp path))]
         (is (= ["org/existing" "org/new"] (get-in saved [:fleet :repos])))))))
 
-(deftest fleet-add-cmd-no-repo-prints-error-test
-  (testing "Prints error when no repo is provided"
-    (let [output (with-out-str
-                   (sut/fleet-add-cmd {:repo nil} nil default-config))]
-      (is (.contains output "Usage")))))
-
 ;; ============================================================================
 ;; fleet-remove-cmd tests
 ;; ============================================================================
-
-(deftest fleet-remove-cmd-removes-repo-test
+(deftest ^{:stratum 2} fleet-remove-cmd-removes-repo-test
   (testing "Removes a repo from the fleet config"
     (let [path (tmp-path "remove-config.edn")]
       (spit path (pr-str {:fleet {:repos ["org/a" "org/b" "org/c"]}}))
@@ -159,7 +162,7 @@
       (let [saved (edn/read-string (slurp path))]
         (is (= ["org/a" "org/c"] (get-in saved [:fleet :repos])))))))
 
-(deftest fleet-remove-cmd-noop-for-missing-repo-test
+(deftest ^{:stratum 2} fleet-remove-cmd-noop-for-missing-repo-test
   (testing "Removing a repo not in config is a no-op"
     (let [path (tmp-path "noop-config.edn")]
       (spit path (pr-str {:fleet {:repos ["org/a"]}}))
@@ -167,17 +170,10 @@
       (let [saved (edn/read-string (slurp path))]
         (is (= ["org/a"] (get-in saved [:fleet :repos])))))))
 
-(deftest fleet-remove-cmd-no-repo-prints-error-test
-  (testing "Prints error when no repo is provided"
-    (let [output (with-out-str
-                   (sut/fleet-remove-cmd {:repo nil} nil default-config))]
-      (is (.contains output "Usage")))))
-
 ;; ============================================================================
 ;; fleet-status-cmd tests
 ;; ============================================================================
-
-(deftest fleet-status-cmd-shows-repo-count-test
+(deftest ^{:stratum 2} fleet-status-cmd-shows-repo-count-test
   (testing "Status output includes repository count"
     (let [path (tmp-path "status-config.edn")]
       (spit path (pr-str {:fleet {:repos ["org/a" "org/b"]}}))
@@ -185,7 +181,7 @@
                      (sut/fleet-status-cmd {:config path} nil default-config))]
         (is (.contains output (messages/t :fleet/repositories {:count 2})))))))
 
-(deftest fleet-status-cmd-shows-default-state-when-no-state-file-test
+(deftest ^{:stratum 2} fleet-status-cmd-shows-default-state-when-no-state-file-test
   (testing "Shows zero counts when state file does not exist"
     (let [path (tmp-path "status-config2.edn")]
       (spit path (pr-str {:fleet {:repos []}}))
@@ -195,3 +191,5 @@
         (is (.contains output (messages/t :fleet/pending-workflows {:count 0})))
         (is (.contains output (messages/t :fleet/completed {:count 0})))
         (is (.contains output (messages/t :fleet/failed {:count 0})))))))
+
+(use-fixtures :each tmp-dir-fixture)

--- a/bases/cli/test/ai/miniforge/cli/main/commands/monitoring_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/monitoring_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.main.commands.monitoring-test
   (:require
    [clojure.test :refer [deftest is testing]]
@@ -25,11 +24,53 @@
    [ai.miniforge.cli.main.commands.monitoring :as sut]
    [ai.miniforge.cli.main.display :as display]))
 
-(defn- exit-ex
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} exit-ex
   [code]
   (ex-info "exit" {:code code}))
 
-(deftest web-cmd-unavailable-uses-message-catalog-test
+(deftest ^{:stratum 0} web-cmd-uses-injected-launcher-test
+  (testing "Web startup uses the launcher composed by cli.main"
+    (let [started (atom nil)
+          exit-code (atom nil)]
+      (binding [sut/*web-available?* true
+                sut/*start-web-dashboard!* (fn [opts]
+                                             (reset! started opts)
+                                             (throw (ex-info "stop" {})))]
+        (with-redefs [config/load-config (constantly {:dashboard {:port 9191}})
+                      messages/t (fn
+                                   ([k] (name k))
+                                   ([k params] (str (name k) params)))
+                      display/print-info (fn [& _] nil)
+                      display/print-error (fn [& _] nil)
+                      sut/exit! (fn [code] (reset! exit-code code))]
+          (sut/web-cmd {}))
+        (is (= {:port 9191} @started))
+        (is (= 1 @exit-code))))))
+
+(deftest ^{:stratum 0} tui-cmd-uses-injected-launcher-test
+  (testing "TUI startup uses the launcher composed by cli.main"
+    (let [started (atom nil)
+          shut-down? (atom false)
+          exit-code (atom nil)]
+      (binding [sut/*tui-available?* true
+                sut/*start-standalone-tui!* (fn [opts]
+                                              (reset! started opts))]
+        (with-redefs [messages/t (fn
+                                   ([k] (name k))
+                                   ([k params] (str (name k) params)))
+                      display/print-info (fn [& _] nil)
+                      clojure.core/shutdown-agents (fn [] (reset! shut-down? true))
+                      sut/exit! (fn [code] (reset! exit-code code))]
+          (sut/tui-cmd {:events-dir "/tmp/events"}))
+        (is (= {:events-dir "/tmp/events"} @started))
+        (is @shut-down?)
+        (is (= 0 @exit-code))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} web-cmd-unavailable-uses-message-catalog-test
   (testing "Web dashboard is unavailable when the composed launcher is missing"
     (binding [sut/*web-available?* false
               sut/*start-web-dashboard!* nil]
@@ -51,26 +92,7 @@
           (is (.contains output "WEB-NOT-AVAILABLE"))
           (is (.contains output "WEB-REQUIRES-JVM")))))))
 
-(deftest web-cmd-uses-injected-launcher-test
-  (testing "Web startup uses the launcher composed by cli.main"
-    (let [started (atom nil)
-          exit-code (atom nil)]
-      (binding [sut/*web-available?* true
-                sut/*start-web-dashboard!* (fn [opts]
-                                             (reset! started opts)
-                                             (throw (ex-info "stop" {})))]
-        (with-redefs [config/load-config (constantly {:dashboard {:port 9191}})
-                      messages/t (fn
-                                   ([k] (name k))
-                                   ([k params] (str (name k) params)))
-                      display/print-info (fn [& _] nil)
-                      display/print-error (fn [& _] nil)
-                      sut/exit! (fn [code] (reset! exit-code code))]
-          (sut/web-cmd {}))
-        (is (= {:port 9191} @started))
-        (is (= 1 @exit-code))))))
-
-(deftest tui-cmd-unavailable-uses-message-catalog-test
+(deftest ^{:stratum 1} tui-cmd-unavailable-uses-message-catalog-test
   (testing "TUI unavailable output reads user-facing copy from the message catalog"
     (binding [sut/*tui-available?* false]
       (with-redefs [messages/t (fn
@@ -99,7 +121,7 @@
           (is (.contains output "TUI-INSTALL"))
           (is (.contains output "TUI-USE-WEB")))))))
 
-(deftest tui-cmd-missing-launcher-uses-unavailable-path-test
+(deftest ^{:stratum 1} tui-cmd-missing-launcher-uses-unavailable-path-test
   (testing "TUI is unavailable when the composed launcher is missing"
     (binding [sut/*tui-available?* true
               sut/*start-standalone-tui!* nil]
@@ -126,22 +148,3 @@
                            (is (= 1 (:code (ex-data e)))))))]
           (is (.contains output "TUI-NOT-AVAILABLE"))
           (is (.contains output "TUI-REQUIRES-JVM")))))))
-
-(deftest tui-cmd-uses-injected-launcher-test
-  (testing "TUI startup uses the launcher composed by cli.main"
-    (let [started (atom nil)
-          shut-down? (atom false)
-          exit-code (atom nil)]
-      (binding [sut/*tui-available?* true
-                sut/*start-standalone-tui!* (fn [opts]
-                                              (reset! started opts))]
-        (with-redefs [messages/t (fn
-                                   ([k] (name k))
-                                   ([k params] (str (name k) params)))
-                      display/print-info (fn [& _] nil)
-                      clojure.core/shutdown-agents (fn [] (reset! shut-down? true))
-                      sut/exit! (fn [code] (reset! exit-code code))]
-          (sut/tui-cmd {:events-dir "/tmp/events"}))
-        (is (= {:events-dir "/tmp/events"} @started))
-        (is @shut-down?)
-        (is (= 0 @exit-code))))))

--- a/bases/cli/test/ai/miniforge/cli/main/commands/policy_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/policy_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.main.commands.policy-test
   "Unit tests for policy pack CLI commands."
   (:require
@@ -25,11 +24,12 @@
    [ai.miniforge.cli.main.commands.policy :as sut]
    [ai.miniforge.cli.main.commands.shared :as shared]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;------------------------------------------------------------------------------ Layer 0: Fixtures & factories
+(def ^{:stratum 0} ^:dynamic *tmp-dir* nil)
 
-(def ^:dynamic *tmp-dir* nil)
-
-(defn tmp-dir-fixture [f]
+(defn ^{:stratum 0} tmp-dir-fixture [f]
   (let [dir (str (fs/create-temp-dir {:prefix "policy-test-"}))]
     (binding [*tmp-dir* dir]
       (try
@@ -37,9 +37,7 @@
         (finally
           (fs/delete-tree dir))))))
 
-(use-fixtures :each tmp-dir-fixture)
-
-(defn make-pack
+(defn ^{:stratum 0} make-pack
   "Build a minimal policy pack for testing."
   ([]
    (make-pack {}))
@@ -52,16 +50,7 @@
                          :rule/description "Test rule"}]}
           overrides)))
 
-;------------------------------------------------------------------------------ Layer 1: Tests
-
-(deftest policy-list-cmd-no-component-empty-dir-test
-  (testing "list command shows 'no packs' when no packs available"
-    (with-redefs [sut/component-packs (constantly nil)
-                  app-config/home-dir (constantly *tmp-dir*)]
-      (let [output (with-out-str (sut/policy-list-cmd {}))]
-        (is (re-find #"(?i)no installed" output))))))
-
-(deftest policy-list-cmd-component-results-test
+(deftest ^{:stratum 0} policy-list-cmd-component-results-test
   (testing "list command displays component results when available"
     (with-redefs [sut/component-packs
                   (constantly [{:pack/id "foundations-1.0.0"
@@ -70,14 +59,38 @@
       (let [output (with-out-str (sut/policy-list-cmd {}))]
         (is (.contains output "foundations-1.0.0"))))))
 
-(deftest policy-show-cmd-missing-pack-id-test
+(deftest ^{:stratum 0} policy-show-cmd-missing-pack-id-test
   (testing "show command exits with error when no pack-id provided"
     (let [exited? (atom false)]
       (with-redefs [shared/exit! (fn [_] (reset! exited? true))]
         (with-out-str (sut/policy-show-cmd {}))
         (is @exited?)))))
 
-(deftest policy-show-cmd-not-found-test
+(deftest ^{:stratum 0} policy-install-cmd-missing-path-test
+  (testing "install command exits with error when no path provided"
+    (let [exited? (atom false)]
+      (with-redefs [shared/exit! (fn [_] (reset! exited? true))]
+        (with-out-str (sut/policy-install-cmd {}))
+        (is @exited?)))))
+
+(deftest ^{:stratum 0} policy-install-cmd-file-not-found-test
+  (testing "install command exits with error when pack file doesn't exist"
+    (let [exited? (atom false)]
+      (with-redefs [shared/exit! (fn [_] (reset! exited? true))]
+        (with-out-str (sut/policy-install-cmd {:path "/tmp/nonexistent.pack.edn"}))
+        (is @exited?)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;------------------------------------------------------------------------------ Layer 1: Tests
+(deftest ^{:stratum 1} policy-list-cmd-no-component-empty-dir-test
+  (testing "list command shows 'no packs' when no packs available"
+    (with-redefs [sut/component-packs (constantly nil)
+                  app-config/home-dir (constantly *tmp-dir*)]
+      (let [output (with-out-str (sut/policy-list-cmd {}))]
+        (is (re-find #"(?i)no installed" output))))))
+
+(deftest ^{:stratum 1} policy-show-cmd-not-found-test
   (testing "show command reports not found for unknown pack"
     (let [exited? (atom false)]
       (with-redefs [sut/load-installed-pack (constantly nil)
@@ -86,21 +99,7 @@
         (with-out-str (sut/policy-show-cmd {:pack-id "nonexistent"}))
         (is @exited?)))))
 
-(deftest policy-install-cmd-missing-path-test
-  (testing "install command exits with error when no path provided"
-    (let [exited? (atom false)]
-      (with-redefs [shared/exit! (fn [_] (reset! exited? true))]
-        (with-out-str (sut/policy-install-cmd {}))
-        (is @exited?)))))
-
-(deftest policy-install-cmd-file-not-found-test
-  (testing "install command exits with error when pack file doesn't exist"
-    (let [exited? (atom false)]
-      (with-redefs [shared/exit! (fn [_] (reset! exited? true))]
-        (with-out-str (sut/policy-install-cmd {:path "/tmp/nonexistent.pack.edn"}))
-        (is @exited?)))))
-
-(deftest policy-install-cmd-valid-pack-test
+(deftest ^{:stratum 1} policy-install-cmd-valid-pack-test
   (testing "install command copies a valid pack file"
     (let [pack (make-pack)
           src-path (str *tmp-dir* "/my-pack.pack.edn")]
@@ -109,3 +108,5 @@
         (let [output (with-out-str (sut/policy-install-cmd {:path src-path}))]
           (is (.contains output "Installed"))
           (is (fs/exists? (str *tmp-dir* "/packs/my-pack.pack.edn"))))))))
+
+(use-fixtures :each tmp-dir-fixture)

--- a/bases/cli/test/ai/miniforge/cli/main/commands/pr_monitor_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/pr_monitor_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.main.commands.pr-monitor-test
   "Unit tests for pr-monitor-cmd's worklist-resume and fresh-monitor paths.
 
@@ -40,14 +39,14 @@
    [ai.miniforge.schema.interface :as schema]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Fixtures
 
-(def ^:private cli-cfg
+;; Fixtures
+(def ^{:stratum 0} ^:private cli-cfg
   {:default-self-author "miniforge[bot]"
    :min-poll-interval-s 5
    :max-poll-interval-s 3600})
 
-(def ^:private open-pr-entry
+(def ^{:stratum 0} ^:private open-pr-entry
   {:pr/url                 "https://github.com/org/repo/pull/42"
    :pr/number              42
    :pr/repo                "org/repo"
@@ -55,31 +54,26 @@
    :pr/poll-interval       60
    :pr/abandon-after-hours 72})
 
-(def ^:private sample-worklist
-  {:worklist/repo-key   "abc123def456"
-   :worklist/prs        [open-pr-entry]
-   :worklist/updated-at (java.util.Date.)})
+(defn- ^{:stratum 0} exit-ex [code] (ex-info "exit!" {:code code}))
 
-(defn- exit-ex [code] (ex-info "exit!" {:code code}))
-
-(defn- capturing-msgs
+(defn- ^{:stratum 0} capturing-msgs
   "display/print-* stub that records every string."
   []
   (let [msgs (atom [])]
     {:msgs msgs :fn (fn [msg] (swap! msgs conj msg))}))
 
-(defn- fake-monitor
+(defn- ^{:stratum 0} fake-monitor
   "Atom that mimics a monitor state atom with a populated poll-interval."
   []
   (atom {:config {:poll-interval-ms 60000}}))
 
-(defn- noop-t
+(defn- ^{:stratum 0} noop-t
   "messages/t stub: returns a string embedding the key name so tests can
    check which key was used without loading the full message catalog."
   ([k]   (name k))
   ([k _] (name k)))
 
-(defn- run-cmd
+(defn- ^{:stratum 0} run-cmd
   "Call sut/pr-monitor-cmd, catching exit! exceptions. Returns the exit code
    when exit! was called, or nil for a normal return."
   [opts]
@@ -91,9 +85,14 @@
         (:code (ex-data e))))))
 
 ;------------------------------------------------------------------------------ Layer 1
-;; (d) No remote URL → exit 1
 
-(deftest no-remote-url-exits-1-test
+(def ^{:stratum 1} ^:private sample-worklist
+  {:worklist/repo-key   "abc123def456"
+   :worklist/prs        [open-pr-entry]
+   :worklist/updated-at (java.util.Date.)})
+
+;; (d) No remote URL → exit 1
+(deftest ^{:stratum 1} no-remote-url-exits-1-test
   (testing "exits 1 when git remote get-url origin fails"
     (let [{errors :msgs err-fn :fn} (capturing-msgs)]
       (with-redefs [sut/remote-origin-url     (constantly nil)
@@ -104,10 +103,8 @@
         (is (= 1 (run-cmd {:repo "/some/repo"}))))
       (is (= 1 (count @errors))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; (c) No work-list on disk → exit 1
-
-(deftest no-worklist-exits-1-test
+(deftest ^{:stratum 1} no-worklist-exits-1-test
   (testing "exits 1 when load-worklist returns a failure result"
     (let [{errors :msgs err-fn :fn} (capturing-msgs)]
       (with-redefs [sut/remote-origin-url        (constantly "https://github.com/org/repo.git")
@@ -122,10 +119,34 @@
         (is (= 1 (run-cmd {:repo "/some/repo"}))))
       (is (= 1 (count @errors))))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; (b) All PRs pruned → returns normally (exit 0 by default)
+(deftest ^{:stratum 1} fresh-author-path-skips-worklist-test
+  (testing "(g) --author starts a fresh monitor and never loads a work-list (Copilot #1209)"
+    (let [loaded?           (atom false)
+          monitor-opts-seen (atom nil)
+          loop-author       (atom nil)
+          mon               (fake-monitor)]
+      (with-redefs [pr-lifecycle/load-worklist        (fn [_]
+                                                        (reset! loaded? true)
+                                                        (schema/failure :worklist "should not be called"))
+                    pr-lifecycle/create-pr-monitor    (fn [opts] (reset! monitor-opts-seen opts) mon)
+                    pr-lifecycle/run-pr-monitor-loop  (fn [_monitor author]
+                                                        (reset! loop-author author)
+                                                        {:comments-received 0})
+                    pr-lifecycle/stop-pr-monitor-loop (fn [_] nil)
+                    app-config/pr-monitor-config      (constantly cli-cfg)
+                    display/print-info                (fn [_] nil)
+                    display/print-error               (fn [_] nil)
+                    messages/t                        noop-t]
+        (run-cmd {:author "alice" :repo "/some/repo"}))
+      (is (false? @loaded?) "fresh --author path must NOT load a work-list")
+      (is (= "alice" @loop-author) "monitors the supplied author")
+      (is (= "/some/repo" (:worktree-path @monitor-opts-seen)))
+      (is (= "alice" (:self-author @monitor-opts-seen))))))
 
-(deftest empty-worklist-after-prune-returns-normally-test
+;------------------------------------------------------------------------------ Layer 2
+
+;; (b) All PRs pruned → returns normally (exit 0 by default)
+(deftest ^{:stratum 2} empty-worklist-after-prune-returns-normally-test
   (testing "prints status and returns without calling exit! when all PRs are closed"
     (let [{infos :msgs info-fn :fn}  (capturing-msgs)
           pruned-wl                   (assoc sample-worklist :worklist/prs [])]
@@ -144,10 +165,8 @@
       (is (some #(.contains % "monitor-worklist-empty") @infos)
           "should print the empty-worklist key"))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; (e) Prune returns anomaly → exit 1
-
-(deftest prune-anomaly-exits-1-test
+(deftest ^{:stratum 2} prune-anomaly-exits-1-test
   (testing "exits 1 when prune-closed-prs returns an anomaly"
     (let [{errors :msgs err-fn :fn} (capturing-msgs)
           gh-fail                    (anomaly/anomaly :fault "gh cli failed" {})]
@@ -165,10 +184,8 @@
         (is (= 1 (run-cmd {:repo "/some/repo"}))))
       (is (= 1 (count @errors))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; (f) Author unresolvable → exit 1
-
-(deftest nil-author-exits-1-test
+(deftest ^{:stratum 2} nil-author-exits-1-test
   (testing "exits 1 when neither gh api user nor default-self-author yields an author"
     (let [{errors :msgs err-fn :fn} (capturing-msgs)]
       (with-redefs [sut/remote-origin-url        (constantly "https://github.com/org/repo.git")
@@ -187,10 +204,8 @@
         (is (= 1 (run-cmd {:repo "/some/repo"}))))
       (is (= 1 (count @errors))))))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; (a) Open PRs in worklist → monitor created and loop runs
-
-(deftest resume-from-worklist-runs-monitor-test
+(deftest ^{:stratum 2} resume-from-worklist-runs-monitor-test
   (testing "creates monitor with worklist-derived poll-interval and runs loop"
     (let [monitor-opts-seen (atom nil)
           loop-ran          (atom false)
@@ -224,30 +239,6 @@
       (is (= "/some/repo" (:worktree-path @monitor-opts-seen)))
       (is (= (* 60 1000) (:poll-interval-ms @monitor-opts-seen))
           "poll-interval-ms should derive from the PR entry's :pr/poll-interval (60 s)"))))
-
-(deftest fresh-author-path-skips-worklist-test
-  (testing "(g) --author starts a fresh monitor and never loads a work-list (Copilot #1209)"
-    (let [loaded?           (atom false)
-          monitor-opts-seen (atom nil)
-          loop-author       (atom nil)
-          mon               (fake-monitor)]
-      (with-redefs [pr-lifecycle/load-worklist        (fn [_]
-                                                        (reset! loaded? true)
-                                                        (schema/failure :worklist "should not be called"))
-                    pr-lifecycle/create-pr-monitor    (fn [opts] (reset! monitor-opts-seen opts) mon)
-                    pr-lifecycle/run-pr-monitor-loop  (fn [_monitor author]
-                                                        (reset! loop-author author)
-                                                        {:comments-received 0})
-                    pr-lifecycle/stop-pr-monitor-loop (fn [_] nil)
-                    app-config/pr-monitor-config      (constantly cli-cfg)
-                    display/print-info                (fn [_] nil)
-                    display/print-error               (fn [_] nil)
-                    messages/t                        noop-t]
-        (run-cmd {:author "alice" :repo "/some/repo"}))
-      (is (false? @loaded?) "fresh --author path must NOT load a work-list")
-      (is (= "alice" @loop-author) "monitors the supplied author")
-      (is (= "/some/repo" (:worktree-path @monitor-opts-seen)))
-      (is (= "alice" (:self-author @monitor-opts-seen))))))
 
 (comment
   (clojure.test/run-tests 'ai.miniforge.cli.main.commands.pr-monitor-test)

--- a/bases/cli/test/ai/miniforge/cli/main/commands/resume_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/resume_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.main.commands.resume-test
   (:require
    [ai.miniforge.anomaly.interface :as anomaly]
@@ -33,7 +32,9 @@
    [ai.miniforge.workflow-resume.interface :as wr]
    [slingshot.slingshot :refer [try+]]))
 
-(deftest resolve-resume-workflow-test
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} resolve-resume-workflow-test
   (testing "recorded workflow spec wins over configured fallback"
     (with-redefs [selection-config/resolve-selection-profile
                   (fn [_profile]
@@ -61,7 +62,7 @@
            #"Could not resolve a workflow type for resume"
            (sut/resolve-resume-workflow {}))))))
 
-(deftest throw-resume-anomaly-preserves-canonical-metadata-test
+(deftest ^{:stratum 0} throw-resume-anomaly-preserves-canonical-metadata-test
   (testing "CLI escalation keeps the original return-value anomaly fields"
     (let [source (anomaly/anomaly :invalid-input
                                   "Invalid resume request"
@@ -74,10 +75,8 @@
       (is (= (:anomaly/at source) (:anomaly/at thrown)))
       (is (= "bad" (:workflow-id thrown))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; read-event-file — bug fix coverage
-
-(defn- with-temp-events-dir [body-fn]
+(defn- ^{:stratum 0} with-temp-events-dir [body-fn]
   (let [base (doto (io/file (System/getProperty "java.io.tmpdir")
                             (str "mf-resume-test-" (random-uuid)))
                .mkdirs)]
@@ -87,44 +86,10 @@
         (doseq [^java.io.File f (reverse (file-seq base))]
           (.delete f))))))
 
-(defn- write-event! [^java.io.File dir filename event-map]
+(defn- ^{:stratum 0} write-event! [^java.io.File dir filename event-map]
   (spit (io/file dir filename) (json/generate-string event-map)))
 
-(deftest read-event-file-reads-per-event-json-from-workflow-dir-test
-  ;; Regression guard for the iter-20 resume bug. Before this fix,
-  ;; read-event-file looked for a single {workflow-id}.edn file that
-  ;; was never written (the sink writes one .json per event to a dir),
-  ;; so `mf run --resume <id>` always threw :anomalies/not-found.
-  (with-temp-events-dir
-    (fn [base-dir]
-      (let [wf-id (str (random-uuid))
-            wf-dir (doto (io/file base-dir wf-id) .mkdirs)]
-        (write-event! wf-dir "20260420T000001Z-a.json"
-                      {"~:event/type" "~:workflow/started"
-                       "~:workflow/id" (str "~u" wf-id)})
-        (write-event! wf-dir "20260420T000002Z-b.json"
-                      {"~:event/type" "~:workflow/phase-completed"
-                       "~:workflow/phase" "~:plan"
-                       "~:phase/outcome" "~:success"})
-        (testing "reads events in timestamp order with transit prefixes stripped"
-          (with-redefs [sut/events-dir (.getPath base-dir)]
-            (let [events (sut/read-event-file wf-id)]
-              (is (= 2 (count events)))
-              (is (= :workflow/started (:event/type (first events))))
-              (is (= :workflow/phase-completed (:event/type (second events))))
-              (is (= :plan (:workflow/phase (second events))))
-              (is (= :success (:phase/outcome (second events)))))))))))
-
-(deftest read-event-file-missing-workflow-returns-nil-test
-  ;; The CLI wrapper now returns nil for missing workflows; the
-  ;; user-facing :anomalies/not-found comes from the workflow-resume
-  ;; component's `reconstruct-context` when callers use that path.
-  (with-temp-events-dir
-    (fn [base-dir]
-      (with-redefs [sut/events-dir (.getPath base-dir)]
-        (is (nil? (sut/read-event-file (str (random-uuid)))))))))
-
-(deftest resume-workflow-passes-dag-recovery-data-test
+(deftest ^{:stratum 0} resume-workflow-passes-dag-recovery-data-test
   (let [workflow-id (random-uuid)
         run-pipeline-opts (atom nil)
         run-pipeline-workflow (atom nil)
@@ -173,7 +138,7 @@
                 :bundle-path "/tmp/task-a.bundle"}
                (:resume-workspace @run-pipeline-opts)))))))
 
-(deftest terminal-status-predicate-test
+(deftest ^{:stratum 0} terminal-status-predicate-test
   (testing "explicit terminal statuses are accepted"
     (doseq [s [:completed :completed-with-warnings :failed :aborted :cancelled]]
       (is (sut/terminal-status? s) (str s " must be terminal"))))
@@ -181,7 +146,7 @@
     (doseq [s [:running :pending :paused nil :unknown :draining]]
       (is (not (sut/terminal-status? s)) (str s " must NOT be terminal")))))
 
-(deftest resume-workflow-non-terminal-status-throws-test
+(deftest ^{:stratum 0} resume-workflow-non-terminal-status-throws-test
   ;; Regression for the silent fast-fail blocker from the 2026-05-16
   ;; event-log-tool-visibility dogfood. Resume used to print
   ;; "Resumed workflow completed with status: :running" and exit 0,
@@ -214,7 +179,7 @@
            (sut/resume-workflow workflow-id {:quiet true}))
           "Resume must throw, not silently return, when run-pipeline returns :running"))))
 
-(deftest resume-print-phase-prefers-fsm-snapshot-test
+(deftest ^{:stratum 0} resume-print-phase-prefers-fsm-snapshot-test
   (testing "machine snapshot's :execution/current-phase wins over pipeline head"
     (is (= "verify"
            (#'sut/resume-print-phase
@@ -229,7 +194,7 @@
   (testing "both empty → nil"
     (is (nil? (#'sut/resume-print-phase nil [])))))
 
-(deftest resume-workflow-trims-failed-checkpoint-before-running-test
+(deftest ^{:stratum 0} resume-workflow-trims-failed-checkpoint-before-running-test
   (let [workflow-id (random-uuid)
         run-pipeline-opts (atom nil)
         run-pipeline-workflow (atom nil)
@@ -275,3 +240,39 @@
         (is (true? (:resume-reset-terminal? @run-pipeline-opts)))
         (is (= workflow-id
                (get-in @run-pipeline-opts [:resume-machine-snapshot :execution/id])))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} read-event-file-reads-per-event-json-from-workflow-dir-test
+  ;; Regression guard for the iter-20 resume bug. Before this fix,
+  ;; read-event-file looked for a single {workflow-id}.edn file that
+  ;; was never written (the sink writes one .json per event to a dir),
+  ;; so `mf run --resume <id>` always threw :anomalies/not-found.
+  (with-temp-events-dir
+    (fn [base-dir]
+      (let [wf-id (str (random-uuid))
+            wf-dir (doto (io/file base-dir wf-id) .mkdirs)]
+        (write-event! wf-dir "20260420T000001Z-a.json"
+                      {"~:event/type" "~:workflow/started"
+                       "~:workflow/id" (str "~u" wf-id)})
+        (write-event! wf-dir "20260420T000002Z-b.json"
+                      {"~:event/type" "~:workflow/phase-completed"
+                       "~:workflow/phase" "~:plan"
+                       "~:phase/outcome" "~:success"})
+        (testing "reads events in timestamp order with transit prefixes stripped"
+          (with-redefs [sut/events-dir (.getPath base-dir)]
+            (let [events (sut/read-event-file wf-id)]
+              (is (= 2 (count events)))
+              (is (= :workflow/started (:event/type (first events))))
+              (is (= :workflow/phase-completed (:event/type (second events))))
+              (is (= :plan (:workflow/phase (second events))))
+              (is (= :success (:phase/outcome (second events)))))))))))
+
+(deftest ^{:stratum 1} read-event-file-missing-workflow-returns-nil-test
+  ;; The CLI wrapper now returns nil for missing workflows; the
+  ;; user-facing :anomalies/not-found comes from the workflow-resume
+  ;; component's `reconstruct-context` when callers use that path.
+  (with-temp-events-dir
+    (fn [base-dir]
+      (with-redefs [sut/events-dir (.getPath base-dir)]
+        (is (nil? (sut/read-event-file (str (random-uuid)))))))))

--- a/bases/cli/test/ai/miniforge/cli/main/commands/run_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/run_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.main.commands.run-test
   (:require
    [clojure.test :refer [deftest is testing]]
@@ -25,7 +24,9 @@
    [ai.miniforge.cli.spec-parser :as spec-parser]
    [ai.miniforge.cli.workflow-runner :as workflow-runner]))
 
-(deftest run-spec-workflow-propagates-worktree-into-execution-opts-test
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} run-spec-workflow-propagates-worktree-into-execution-opts-test
   (testing "--worktree becomes authoritative execution worktree metadata"
     (let [captured-spec (atom nil)
           captured-opts (atom nil)]
@@ -48,7 +49,7 @@
                (:spec/source-dir @captured-spec))
             "source-dir should stay anchored to the spec's repo, not the execution worktree")))))
 
-(deftest detect-input-type-and-markdown-spec-regression-test
+(deftest ^{:stratum 0} detect-input-type-and-markdown-spec-regression-test
   (testing "markdown-spec? recognizes markdown spec files"
     (is (true? (#'sut/markdown-spec? "/tmp/behavioral.md")))
     (is (true? (#'sut/markdown-spec? "/tmp/behavioral.markdown")))

--- a/bases/cli/test/ai/miniforge/cli/main/commands/shared_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/shared_test.clj
@@ -15,13 +15,14 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.main.commands.shared-test
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.cli.main.commands.shared :as sut]))
 
-(deftest optional-provider-registry-test
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} optional-provider-registry-test
   (testing "registered optional providers are available by symbol"
     (let [provider (fn [x] [:ok x])]
       (with-redefs [sut/optional-functions {}]

--- a/bases/cli/test/ai/miniforge/cli/main/display_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/display_test.clj
@@ -15,14 +15,15 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.main.display-test
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.cli.messages :as messages]
    [ai.miniforge.cli.main.display :as sut]))
 
-(deftest print-error-uses-message-catalog-test
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} print-error-uses-message-catalog-test
   (testing "generic error output reads its prefix from the message catalog"
     (with-redefs [messages/t (fn [k params]
                                (case k

--- a/bases/cli/test/ai/miniforge/cli/main_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.main-test
   (:require
    [clojure.test :refer [deftest is testing]]
@@ -29,7 +28,9 @@
    [ai.miniforge.workflow-resume.interface :as wr]
    [slingshot.slingshot :refer [throw+]]))
 
-(deftest help-cmd-uses-generic-workflow-examples-test
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} help-cmd-uses-generic-workflow-examples-test
   (testing "CLI help shows generic workflow examples instead of SDLC-specific ones"
     (let [output (with-out-str (sut/help-cmd {}))
           title (messages/t :help/title {:binary (app-config/binary-name)
@@ -39,7 +40,7 @@
         (is (.contains output (app-config/command-string example))))
       (is (not (.contains output "canonical-sdlc-v1"))))))
 
-(deftest help-cmd-reads-copy-from-message-catalog-test
+(deftest ^{:stratum 0} help-cmd-reads-copy-from-message-catalog-test
   (testing "help output is assembled from message resources rather than hardcoded strings"
     (with-redefs [app-config/binary-name (constantly "engine")
                   app-config/description (constantly "desc")
@@ -65,7 +66,7 @@
         (is (.contains output "NOTE:engine"))
         (is (.contains output "TUI:engine-tui"))))))
 
-(deftest create-pr-train-manager-handles-construction-errors-test
+(deftest ^{:stratum 0} create-pr-train-manager-handles-construction-errors-test
   (testing "manager construction failure logs a warning and returns nil"
     (with-redefs [pr-train/create-manager
                   (fn [] (throw (ex-info "train boom" {})))]
@@ -73,7 +74,7 @@
                      (is (nil? (#'sut/create-pr-train-manager))))]
         (is (.contains output "train boom"))))))
 
-(deftest create-pr-train-manager-handles-non-throwable-sling-test
+(deftest ^{:stratum 0} create-pr-train-manager-handles-non-throwable-sling-test
   (testing "slingshot data throws do not break the warning path"
     (with-redefs [pr-train/create-manager
                   (fn [] (throw+ {:type :boom :message "train data boom"}))]
@@ -81,7 +82,7 @@
                      (is (nil? (#'sut/create-pr-train-manager))))]
         (is (.contains output "train data boom"))))))
 
-(deftest create-repo-dag-manager-handles-construction-errors-test
+(deftest ^{:stratum 0} create-repo-dag-manager-handles-construction-errors-test
   (testing "manager construction failure logs a warning and returns nil"
     (with-redefs [repo-dag/create-manager
                   (fn [] (throw (ex-info "dag boom" {})))]
@@ -89,16 +90,14 @@
                      (is (nil? (#'sut/create-repo-dag-manager))))]
         (is (.contains output "dag boom"))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Dispatch table coverage
+(def ^{:stratum 0} ^:private test-running-stale-threshold-ms 300000)
 
-(def ^:private test-running-stale-threshold-ms 300000)
+(def ^{:stratum 0} ^:private test-invalid-running-stale-threshold "invalid-threshold")
 
-(def ^:private test-invalid-running-stale-threshold "invalid-threshold")
+(def ^{:stratum 0} ^:private test-reconstructed-event-count 1)
 
-(def ^:private test-reconstructed-event-count 1)
-
-(deftest dispatch-table-includes-pr-monitor-test
+(deftest ^{:stratum 0} dispatch-table-includes-pr-monitor-test
   (testing "pr monitor command is registered in dispatch table"
     (let [entries (filter #(= ["pr" "monitor"] (:cmds %)) sut/dispatch-table)]
       (is (= 1 (count entries)) "Exactly one pr monitor entry")
@@ -107,7 +106,12 @@
              (:spec (first entries)))
           "Spec includes --author, --poll-interval, and --repo"))))
 
-(deftest workflow-status-summary-marks-quiet-running-checkpoints-stale-test
+;; pr-monitor-cmd helpers
+(def ^{:stratum 0} ^:private test-bounds {:min-poll-interval-s 5 :max-poll-interval-s 3600})
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} workflow-status-summary-marks-quiet-running-checkpoints-stale-test
   (testing "running workflows with old last events are surfaced as stale"
     (let [now-ms (.toEpochMilli (java.time.Instant/parse "2026-05-17T00:16:00Z"))
           stale-ts "2026-05-17T00:10:59Z"]
@@ -128,7 +132,7 @@
         (is (= :stale
                (:status (#'sut/workflow-status-summary "workflow-id"))))))))
 
-(deftest workflow-status-summary-keeps-recent-running-checkpoints-running-test
+(deftest ^{:stratum 1} workflow-status-summary-keeps-recent-running-checkpoints-running-test
   (testing "running workflows with recent events remain running"
     (let [now-ms (.toEpochMilli (java.time.Instant/parse "2026-05-17T00:16:00Z"))
           recent-ts "2026-05-17T00:12:00Z"]
@@ -149,7 +153,7 @@
         (is (= :running
                (:status (#'sut/workflow-status-summary "workflow-id"))))))))
 
-(deftest workflow-status-summary-falls-back-for-invalid-stale-threshold-test
+(deftest ^{:stratum 1} workflow-status-summary-falls-back-for-invalid-stale-threshold-test
   (testing "invalid stale threshold config falls back to the default threshold"
     (let [now-ms (.toEpochMilli (java.time.Instant/parse "2026-05-17T00:16:00Z"))
           stale-ts "2026-05-17T00:10:59Z"]
@@ -170,12 +174,7 @@
         (is (= :stale
                (:status (#'sut/workflow-status-summary "workflow-id"))))))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; pr-monitor-cmd helpers
-
-(def ^:private test-bounds {:min-poll-interval-s 5 :max-poll-interval-s 3600})
-
-(deftest parse-poll-interval-test
+(deftest ^{:stratum 1} parse-poll-interval-test
   (testing "Valid interval returns milliseconds"
     (is (= 30000 (#'cmd-pr-monitor/parse-poll-interval "30" test-bounds))))
   (testing "Nil interval returns nil (domain default applies)"

--- a/bases/cli/test/ai/miniforge/cli/messages_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/messages_test.clj
@@ -15,14 +15,15 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.messages-test
   (:require
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.cli.messages :as messages]))
 
-(deftest message-catalog-renders-placeholders-test
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} message-catalog-renders-placeholders-test
   (let [english-catalog (messages/catalog "en")
         usage-template (:help/usage english-catalog)
         help-template (:main/run-help english-catalog)]
@@ -32,14 +33,14 @@
       (is (= (str/replace help-template "{command}" "miniforge help")
              (messages/t :main/run-help {:command "miniforge help"}))))))
 
-(deftest message-catalog-falls-back-to-english-test
+(deftest ^{:stratum 0} message-catalog-falls-back-to-english-test
   (testing "unknown locales fall back to the English catalog"
     (let [english-usage (messages/t :help/usage {:binary "moteur"})]
       (with-redefs [messages/active-locale (constantly :fr)]
         (is (= english-usage
                (messages/t :help/usage {:binary "moteur"})))))))
 
-(deftest etl-usage-messages-exist-test
+(deftest ^{:stratum 0} etl-usage-messages-exist-test
   (doseq [message-key [:etl/run-usage :etl/validate-usage :etl/registry-usage]]
     (is (= "Usage: miniforge etl command"
            (messages/t message-key {:command "miniforge etl command"})))))

--- a/bases/cli/test/ai/miniforge/cli/scan_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/scan_test.clj
@@ -1,7 +1,6 @@
 ;; Title: Miniforge.ai
 ;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
 ;; Licensed under the Apache License, Version 2.0
-
 (ns ai.miniforge.cli.scan-test
   "Tests for the scan CLI command — pack resolution, selector parsing, pipeline."
   (:require
@@ -9,16 +8,21 @@
    [ai.miniforge.compliance-scanner.interface :as compliance-scanner]
    [ai.miniforge.cli.main.commands.scan :as sut]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; Access private functions via var
-(def resolve-rules-selector (var-get #'sut/resolve-rules-selector))
-(def resolve-pack (var-get #'sut/resolve-pack))
-(def build-scan-opts (var-get #'sut/build-scan-opts))
+(def ^{:stratum 0} resolve-rules-selector (var-get #'sut/resolve-rules-selector))
+
+(def ^{:stratum 0} resolve-pack (var-get #'sut/resolve-pack))
+
+(def ^{:stratum 0} build-scan-opts (var-get #'sut/build-scan-opts))
+
+;------------------------------------------------------------------------------ Layer 1
 
 ;; ============================================================================
 ;; Rule selector parsing
 ;; ============================================================================
-
-(deftest resolve-rules-selector-test
+(deftest ^{:stratum 1} resolve-rules-selector-test
   (testing "nil defaults to :all"
     (is (= :all (resolve-rules-selector nil))))
 
@@ -34,8 +38,7 @@
 ;; ============================================================================
 ;; Pack resolution
 ;; ============================================================================
-
-(deftest resolve-pack-from-classpath-test
+(deftest ^{:stratum 1} resolve-pack-from-classpath-test
   (testing "loads reference pack by name from classpath"
     (let [pack (resolve-pack "foundations-1.0.0")]
       (is (some? pack))
@@ -46,7 +49,7 @@
   (testing "returns nil for nonexistent pack"
     (is (nil? (resolve-pack "nonexistent-pack-9999")))))
 
-(deftest resolve-pack-from-file-test
+(deftest ^{:stratum 1} resolve-pack-from-file-test
   (testing "loads pack from file path"
     (let [pack (resolve-pack "components/compliance-scanner/resources/test-fixtures/clojure-210-pack.edn")]
       (is (some? pack))
@@ -56,8 +59,7 @@
 ;; ============================================================================
 ;; Scan opts construction
 ;; ============================================================================
-
-(deftest build-scan-opts-test
+(deftest ^{:stratum 1} build-scan-opts-test
   (testing "defaults to :all rules"
     (let [opts (build-scan-opts "." {})]
       (is (= :all (:rules opts)))))
@@ -78,8 +80,7 @@
 ;; ============================================================================
 ;; Negative-mode violation messages
 ;; ============================================================================
-
-(deftest negative-mode-uses-rule-title-test
+(deftest ^{:stratum 1} negative-mode-uses-rule-title-test
   (testing "negative-mode violations use rule title, not hardcoded header message"
     (let [k8s    (resolve-pack "kubernetes-1.0.0")
           result (compliance-scanner/scan "." ".standards" {:rules :all :pack k8s})]

--- a/bases/cli/test/ai/miniforge/cli/typed_defaults_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/typed_defaults_test.clj
@@ -15,14 +15,15 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.typed-defaults-test
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.cli.main.commands.pr-policy-respond :as pr-policy]
    [ai.miniforge.cli.workflow-runner :as workflow-runner]))
 
-(deftest commit-sha-text-is-always-a-string-test
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} commit-sha-text-is-always-a-string-test
   (testing "valid commit SHAs are preserved"
     (is (= "abc123" (#'pr-policy/commit-sha-text {:commit-sha "abc123"}))))
   (testing "absent and malformed commit SHAs use the display sentinel"
@@ -33,7 +34,7 @@
                   {:commit-sha 42}]]
       (is (= "—" (#'pr-policy/commit-sha-text data))))))
 
-(deftest response-output-is-always-a-map-test
+(deftest ^{:stratum 0} response-output-is-always-a-map-test
   (testing "valid response output is merged into top-level projection fields"
     (is (= {:content "outer" :exit-code 0 :detail :ok}
            (#'workflow-runner/response-output

--- a/bases/cli/test/ai/miniforge/cli/web/components_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/web/components_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.web.components-test
   (:require
    [clojure.string :as str]
@@ -23,7 +22,9 @@
    [ai.miniforge.cli.web.components :as sut]
    [ai.miniforge.cli.web.fleet :as fleet]))
 
-(def sample-analysis
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} sample-analysis
   {:risk :low
    :complexity :simple
    :summary "Documentation update"
@@ -32,7 +33,33 @@
    :total-changes 18
    :file-count 2})
 
-(def sample-selected-pr
+(deftest ^{:stratum 0} page-uses-localized-title-test
+  (testing "the dashboard page title comes from the message catalog"
+    (let [html (sut/page [:div "body"])]
+      (is (str/includes? html "<title>Miniforge Fleet Dashboard</title>")))))
+
+(deftest ^{:stratum 0} workflow-status-renders-localized-summary-test
+  (testing "workflow status renders counts and the empty-state copy"
+    (with-redefs [fleet/get-workflow-status (constantly {:running 1
+                                                         :failed 2
+                                                         :succeeded 3
+                                                         :runs []})]
+      (let [html (str (sut/workflow-status ["miniforge"]))]
+        (is (str/includes? html "Workflow Status"))
+        (is (str/includes? html "1 ⏳"))
+        (is (str/includes? html "2 ✗"))
+        (is (str/includes? html "3 ✓"))
+        (is (str/includes? html "No recent workflows"))))))
+
+(deftest ^{:stratum 0} empty-detail-renders-localized-empty-state-test
+  (testing "empty detail renders the localized empty state copy"
+    (let [html (str (sut/empty-detail))]
+      (is (str/includes? html "Select a PR to view details"))
+      (is (str/includes? html "Choose a pull request from the list")))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} sample-selected-pr
   {:number 42
    :title "Improve dashboard coverage"
    :author {:login "chris"}
@@ -42,16 +69,13 @@
    :deletions 6
    :analysis sample-analysis})
 
-(def sample-fleet
+;------------------------------------------------------------------------------ Layer 2
+
+(def ^{:stratum 2} sample-fleet
   [{:repo "miniforge"
     :prs [sample-selected-pr]}])
 
-(deftest page-uses-localized-title-test
-  (testing "the dashboard page title comes from the message catalog"
-    (let [html (sut/page [:div "body"])]
-      (is (str/includes? html "<title>Miniforge Fleet Dashboard</title>")))))
-
-(deftest pr-detail-renders-localized-controls-test
+(deftest ^{:stratum 2} pr-detail-renders-localized-controls-test
   (testing "PR detail renders localized section and action labels"
     (let [html (str (sut/pr-detail sample-selected-pr))]
       (is (str/includes? html "AI Analysis"))
@@ -59,7 +83,9 @@
       (is (str/includes? html "Open in GitHub"))
       (is (str/includes? html "What could break?")))))
 
-(deftest dashboard-renders-summary-and-shortcuts-test
+;------------------------------------------------------------------------------ Layer 3
+
+(deftest ^{:stratum 3} dashboard-renders-summary-and-shortcuts-test
   (testing "dashboard renders localized counts, actions, and keyboard hints"
     (with-redefs [fleet/generate-summary (constantly {:total 1
                                                       :recommendation "Review the safe PR."
@@ -76,22 +102,3 @@
         (is (str/includes? html "Approve all 1 low-risk PRs?"))
         (is (str/includes? html "j</kbd>/"))
         (is (str/includes? html "refresh"))))))
-
-(deftest workflow-status-renders-localized-summary-test
-  (testing "workflow status renders counts and the empty-state copy"
-    (with-redefs [fleet/get-workflow-status (constantly {:running 1
-                                                         :failed 2
-                                                         :succeeded 3
-                                                         :runs []})]
-      (let [html (str (sut/workflow-status ["miniforge"]))]
-        (is (str/includes? html "Workflow Status"))
-        (is (str/includes? html "1 ⏳"))
-        (is (str/includes? html "2 ✗"))
-        (is (str/includes? html "3 ✓"))
-        (is (str/includes? html "No recent workflows"))))))
-
-(deftest empty-detail-renders-localized-empty-state-test
-  (testing "empty detail renders the localized empty state copy"
-    (let [html (str (sut/empty-detail))]
-      (is (str/includes? html "Select a PR to view details"))
-      (is (str/includes? html "Choose a pull request from the list")))))

--- a/bases/cli/test/ai/miniforge/cli/web/handlers_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/web/handlers_test.clj
@@ -1,0 +1,55 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.web.handlers-test
+  "Regression coverage for the malformed-/api/pr/-path bug found in PR
+   review: `parse-pr-path` used to throw NullPointerException /
+   NumberFormatException on a short or non-numeric path, crashing
+   request handling instead of returning 400. Fixed by having
+   parse-pr-path return nil on any parse failure, with every caller
+   short-circuiting to a bad-request response."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.cli.web.github :as github]
+   [ai.miniforge.cli.web.handlers :as sut]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} parse-pr-path-parses-a-well-formed-path-test
+  (testing "repo + numeric PR are extracted and the repo segment is URL-decoded"
+    (is (= {:repo "org/repo" :number 42}
+           (sut/parse-pr-path "/api/pr/org%2Frepo/42")))))
+
+(deftest ^{:stratum 0} parse-pr-path-returns-nil-on-malformed-paths-test
+  (testing "no PR number segment at all"
+    (is (nil? (sut/parse-pr-path "/api/pr/"))))
+  (testing "repo segment but no PR number segment"
+    (is (nil? (sut/parse-pr-path "/api/pr/org%2Frepo"))))
+  (testing "non-numeric PR number segment"
+    (is (nil? (sut/parse-pr-path "/api/pr/org%2Frepo/not-a-number")))))
+
+(deftest ^{:stratum 0} pr-detail-returns-bad-request-for-a-malformed-path-without-throwing-test
+  (testing "malformed path short-circuits to a 400 before touching the github component"
+    (with-redefs [github/fetch-prs (fn [& _] (throw (ex-info "should not be called" {})))]
+      (is (= {:status 400 :body "Invalid PR path"}
+             (sut/pr-detail "/api/pr/org%2Frepo/not-a-number"))))))
+
+(deftest ^{:stratum 0} approve-returns-bad-request-for-a-malformed-path-without-throwing-test
+  (testing "malformed path short-circuits to a 400 before touching the github component"
+    (with-redefs [github/approve-pr! (fn [& _] (throw (ex-info "should not be called" {})))]
+      (is (= {:status 400 :body "Invalid PR path"}
+             (sut/approve "/api/pr/"))))))

--- a/bases/cli/test/ai/miniforge/cli/web/sse_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/web/sse_test.clj
@@ -24,6 +24,7 @@
   (:require
    [clojure.test :refer [deftest testing is use-fixtures]]
    [org.httpkit.server :as http]
+   [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.cli.web.sse :as sse]))
 
 (use-fixtures :each
@@ -86,3 +87,15 @@
       (sse/unregister! "wf-5")
       (is (nil? (sse/get-stream "wf-5")))
       (is (nil? (get @sse/subscriptions "wf-5"))))))
+
+(deftest ^{:stratum 0} unregister-unsubscribes-still-open-channels-before-dropping-state-test
+  (testing "channels never closed via on-close still get es/unsubscribe! called on unregister!"
+    (with-redefs [http/send! (constantly true)]
+      (sse/on-open "wf-7" :channel-a)
+      (sse/on-open "wf-7" :channel-b)
+      (let [unsubscribed (atom #{})]
+        (with-redefs [es/unsubscribe! (fn [_stream sub-id] (swap! unsubscribed conj sub-id) nil)]
+          (let [expected-sub-ids (set (vals (get @sse/subscriptions "wf-7")))]
+            (sse/unregister! "wf-7")
+            (is (= expected-sub-ids @unsubscribed)
+                "both still-open channels' subscriber ids must be unsubscribed, not silently orphaned")))))))

--- a/bases/cli/test/ai/miniforge/cli/web/sse_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/web/sse_test.clj
@@ -65,6 +65,16 @@
       (is (some? (sse/get-stream "wf-3"))
           "the event stream itself must survive a single channel closing"))))
 
+(deftest ^{:stratum 0} on-close-drops-the-workflow-key-once-its-last-channel-closes-test
+  (testing "no empty {workflow-id {}} entry is left behind in subscriptions"
+    (with-redefs [http/send! (constantly true)]
+      (sse/on-open "wf-6" :channel-a)
+      (sse/on-close "wf-6" :channel-a)
+      (is (not (contains? @sse/subscriptions "wf-6"))
+          (str "expected wf-6 to be fully removed from subscriptions, got: " @sse/subscriptions))
+      (is (some? (sse/get-stream "wf-6"))
+          "the event stream itself is unaffected — only subscription bookkeeping is pruned"))))
+
 (deftest ^{:stratum 0} on-close-is-a-no-op-for-an-unknown-channel-test
   (testing "closing a channel that was never opened doesn't throw"
     (is (nil? (sse/on-close "wf-4" :never-opened)))))

--- a/bases/cli/test/ai/miniforge/cli/web/sse_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/web/sse_test.clj
@@ -1,0 +1,78 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.web.sse-test
+  "Regression coverage for the on-open/on-close subscription bookkeeping
+   bug found in PR review: `streams` holds event-stream atoms (not
+   maps), so tracking per-channel subscriber ids via assoc-in/update-in
+   directly on a `streams` entry throws ClassCastException. Fixed by
+   tracking channel->sub-id in a separate `subscriptions` atom."
+  (:require
+   [clojure.test :refer [deftest testing is use-fixtures]]
+   [org.httpkit.server :as http]
+   [ai.miniforge.cli.web.sse :as sse]))
+
+(use-fixtures :each
+  (fn [f]
+    (reset! sse/streams {})
+    (reset! sse/subscriptions {})
+    (f)
+    (reset! sse/streams {})
+    (reset! sse/subscriptions {})))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} on-open-registers-stream-and-subscription-without-throwing-test
+  (testing "the first SSE connect for a workflow-id no longer throws ClassCastException"
+    (with-redefs [http/send! (constantly true)]
+      (is (uuid? (sse/on-open "wf-1" :channel-a))
+          "on-open returns the subscriber id without throwing")
+      (is (some? (sse/get-stream "wf-1"))
+          "get-or-create-stream should have registered the event stream")
+      (is (= 1 (count (get @sse/subscriptions "wf-1")))
+          (str "subscriptions should be tracked for wf-1, got: " @sse/subscriptions)))))
+
+(deftest ^{:stratum 0} on-open-supports-multiple-channels-for-the-same-workflow-test
+  (testing "two browser tabs watching the same workflow each get their own subscription"
+    (with-redefs [http/send! (constantly true)]
+      (sse/on-open "wf-2" :channel-a)
+      (sse/on-open "wf-2" :channel-b)
+      (is (= #{:channel-a :channel-b} (set (keys (get @sse/subscriptions "wf-2")))))
+      (is (= (sse/get-stream "wf-2") (sse/get-stream "wf-2"))
+          "both channels share the same underlying event stream for the workflow"))))
+
+(deftest ^{:stratum 0} on-close-removes-only-its-own-channel-subscription-test
+  (testing "closing one channel doesn't disturb the stream or a sibling channel's subscription"
+    (with-redefs [http/send! (constantly true)]
+      (sse/on-open "wf-3" :channel-a)
+      (sse/on-open "wf-3" :channel-b)
+      (sse/on-close "wf-3" :channel-a)
+      (is (= #{:channel-b} (set (keys (get @sse/subscriptions "wf-3")))))
+      (is (some? (sse/get-stream "wf-3"))
+          "the event stream itself must survive a single channel closing"))))
+
+(deftest ^{:stratum 0} on-close-is-a-no-op-for-an-unknown-channel-test
+  (testing "closing a channel that was never opened doesn't throw"
+    (is (nil? (sse/on-close "wf-4" :never-opened)))))
+
+(deftest ^{:stratum 0} unregister-clears-both-streams-and-subscriptions-test
+  (testing "unregister! clears subscription bookkeeping alongside the stream itself"
+    (with-redefs [http/send! (constantly true)]
+      (sse/on-open "wf-5" :channel-a)
+      (sse/unregister! "wf-5")
+      (is (nil? (sse/get-stream "wf-5")))
+      (is (nil? (get @sse/subscriptions "wf-5"))))))

--- a/bases/cli/test/ai/miniforge/cli/workflow_recommendation_config_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_recommendation_config_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.workflow-recommendation-config-test
   (:require
    [clojure.edn :as edn]
@@ -23,7 +22,9 @@
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.cli.workflow-recommendation-config :as cfg]))
 
-(defn- read-resource-section
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} read-resource-section
   [resource-path]
   (-> resource-path
       io/resource
@@ -31,7 +32,9 @@
       edn/read-string
       :workflow-recommendation/prompt))
 
-(deftest recommendation-prompt-config-test
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} recommendation-prompt-config-test
   (testing "software-factory prompt config loads from resources"
     (let [config (cfg/recommendation-prompt-config)
           prompt-resource (read-resource-section "config/workflow/recommendation-prompt.edn")]
@@ -42,7 +45,7 @@
       (is (= (get-in prompt-resource [:summary-labels :has-testing])
              (get-in config [:summary-labels :has-testing]))))))
 
-(deftest default-prompt-config-loads-from-resource-test
+(deftest ^{:stratum 1} default-prompt-config-loads-from-resource-test
   (testing "fallback recommendation prompt config is resource-backed"
     (let [default-config (cfg/default-prompt-config)
           default-resource (read-resource-section "config/workflow/recommendation-prompt-default.edn")]

--- a/bases/cli/test/ai/miniforge/cli/workflow_recommender_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_recommender_test.clj
@@ -15,14 +15,15 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.workflow-recommender-test
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.cli.workflow-recommendation-config :as cfg]
    [ai.miniforge.cli.workflow-recommender :as recommender]))
 
-(deftest build-recommendation-prompt-test
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} build-recommendation-prompt-test
   (let [available-workflows [{:workflow/id :quick-fix
                               :workflow/task-types [:bugfix :docs]}
                              {:workflow/id :canonical-sdlc
@@ -61,7 +62,7 @@
             (is (.contains prompt (get-in prompt-config [:summary-labels :has-review])))
             (is (.contains prompt (get-in prompt-config [:summary-labels :has-testing])))))))))
 
-(deftest recommend-by-task-type-test
+(deftest ^{:stratum 0} recommend-by-task-type-test
   (let [available-workflows [{:workflow/id :quick-fix
                               :workflow/task-types [:bugfix :docs]}
                              {:workflow/id :canonical-sdlc

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/alias_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/alias_test.clj
@@ -15,16 +15,16 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.workflow-runner.alias-test
   "Tests for workflow type aliasing and spec key fallback in the workflow runner."
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.cli.workflow-runner :as sut]))
 
-;------------------------------------------------------------------------------ resolve-workflow-alias
+;------------------------------------------------------------------------------ Layer 0
 
-(deftest resolve-workflow-alias-test
+;------------------------------------------------------------------------------ resolve-workflow-alias
+(deftest ^{:stratum 0} resolve-workflow-alias-test
   (testing ":standard-sdlc resolves to :canonical-sdlc"
     (is (= :canonical-sdlc (sut/resolve-workflow-alias :standard-sdlc))))
 
@@ -36,8 +36,7 @@
     (is (= :test-only (sut/resolve-workflow-alias :test-only)))))
 
 ;------------------------------------------------------------------------------ load-or-create-workflow alias integration
-
-(deftest load-or-create-workflow-aliases-standard-sdlc-test
+(deftest ^{:stratum 0} load-or-create-workflow-aliases-standard-sdlc-test
   (testing ":standard-sdlc is resolved to :canonical-sdlc before loading"
     (let [loaded-type (atom nil)
           fake-loader (fn [workflow-id _version _opts]
@@ -49,8 +48,7 @@
           ":standard-sdlc should be translated to :canonical-sdlc before the loader is called"))))
 
 ;------------------------------------------------------------------------------ select-workflow-type spec key fallback
-
-(deftest select-workflow-type-reads-workflow-type-key-test
+(deftest ^{:stratum 0} select-workflow-type-reads-workflow-type-key-test
   (testing ":spec/workflow-type takes precedence over :workflow/type"
     (let [spec {:spec/workflow-type :explicit-type
                 :workflow/type :fallback-type}

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/context_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/context_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.workflow-runner.context-test
   (:require
    [clojure.test :refer [deftest is testing]]
@@ -23,7 +22,9 @@
    [ai.miniforge.cli.workflow-runner.context :as sut]
    [ai.miniforge.event-stream.interface :as es]))
 
-(deftest create-workflow-context-prefers-explicit-execution-worktree-test
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} create-workflow-context-prefers-explicit-execution-worktree-test
   (testing "execution-opts worktree-path overrides discovered repo root"
     (with-redefs [worktree/worktree-root (constantly "/tmp/repo-root")
                   es/create-streaming-callback (fn [& _] nil)
@@ -42,7 +43,7 @@
         (is (= {:worktree-path "/tmp/execution-worktree"}
                (:execution/opts context)))))))
 
-(deftest create-workflow-context-falls-back-to-discovered-worktree-test
+(deftest ^{:stratum 0} create-workflow-context-falls-back-to-discovered-worktree-test
   (testing "repo root is used only when no explicit execution worktree is present"
     (with-redefs [worktree/worktree-root (constantly "/tmp/repo-root")
                   es/create-streaming-callback (fn [& _] nil)

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/display_output_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/display_output_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.workflow-runner.display-output-test
   "Unit tests for display output functions: print-workflow-header,
    print-workflow-summary, print-result, print-pretty-result,
@@ -32,155 +31,24 @@
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.cli.workflow-runner.display :as display]))
 
-;------------------------------------------------------------------------------ Helpers
+;------------------------------------------------------------------------------ Layer 0
 
-(defn- capture-stdout
+;------------------------------------------------------------------------------ Helpers
+(defn- ^{:stratum 0} capture-stdout
   "Execute body-fn and return all stdout output as a string.
    Uses with-out-str (thread-local *out* binding) for parallel-safe isolation."
   [body-fn]
   (with-out-str (body-fn)))
 
-;------------------------------------------------------------------------------ Layer 0
-;; print-workflow-header
-
-(deftest print-workflow-header-normal-test
-  (testing "print-workflow-header prints header with workflow-id and version"
-    (let [out (capture-stdout
-                #(display/print-workflow-header :my-workflow "1.0.0" false))]
-      (is (not (str/blank? out))
-          "Non-quiet mode should produce output")
-      ;; Should contain ANSI codes (cyan, bold)
-      (is (str/includes? out "\u001b")
-          "Header should contain ANSI color codes"))))
-
-(deftest print-workflow-header-quiet-test
-  (testing "print-workflow-header produces no output when quiet"
-    (let [out (capture-stdout
-                #(display/print-workflow-header :my-workflow "1.0.0" true))]
-      (is (str/blank? out)
-          "Quiet mode should produce no output"))))
-
-(deftest print-workflow-header-keyword-workflow-id-test
-  (testing "print-workflow-header converts keyword workflow-id via name"
-    (let [out (capture-stdout
-                #(display/print-workflow-header :feature-build "2.0.0" false))]
-      ;; The header renders (name :feature-build) = "feature-build"
-      (is (not (str/blank? out))))))
-
-;------------------------------------------------------------------------------ Layer 1
-;; print-workflow-summary
-
-(deftest print-workflow-summary-success-test
-  (testing "print-workflow-summary renders success with metrics"
-    (let [result {:execution/status :completed
-                  :execution/metrics {:tokens 5000
-                                      :cost-usd 0.0123
-                                      :duration-ms 45000}}
-          out (capture-stdout #(display/print-workflow-summary result))]
-      (is (not (str/blank? out)))
-      ;; Should contain green success marker
-      (is (str/includes? out (get display/ansi-codes :green))
-          "Success should use green color")
-      ;; Should contain formatted metrics
-      (is (str/includes? out "5000")
-          "Should display token count")
-      (is (str/includes? out "0.0123")
-          "Should display cost")
-      (is (str/includes? out "45.0s")
-          "Should display formatted duration"))))
-
-(deftest print-workflow-summary-failure-test
-  (testing "print-workflow-summary renders failure with errors"
-    (let [result {:execution/status :failed
-                  :execution/errors ["Agent timeout" "Gate lint failed"]}
-          out (capture-stdout #(display/print-workflow-summary result))]
-      (is (not (str/blank? out)))
-      ;; Should contain red failure marker
-      (is (str/includes? out (get display/ansi-codes :red))
-          "Failure should use red color")
-      ;; Should list errors
-      (is (str/includes? out "Agent timeout")
-          "Should display first error")
-      (is (str/includes? out "Gate lint failed")
-          "Should display second error"))))
-
-(deftest print-workflow-summary-no-metrics-test
-  (testing "print-workflow-summary handles result without metrics"
-    (let [result {:execution/status :completed}
-          out (capture-stdout #(display/print-workflow-summary result))]
-      (is (not (str/blank? out))
-          "Should still produce output without metrics"))))
-
-(deftest print-workflow-summary-no-errors-test
-  (testing "print-workflow-summary handles failure without errors list"
-    (let [result {:execution/status :failed}
-          out (capture-stdout #(display/print-workflow-summary result))]
-      (is (not (str/blank? out))
-          "Should still produce output without errors"))))
-
-(deftest print-workflow-summary-empty-errors-test
-  (testing "print-workflow-summary handles empty errors vector"
-    (let [result {:execution/status :failed
-                  :execution/errors []}
-          out (capture-stdout #(display/print-workflow-summary result))]
-      ;; Empty errors should not produce error section
-      (is (not (str/blank? out))))))
-
-;------------------------------------------------------------------------------ Layer 2
-;; print-result (output format dispatch)
-
-(deftest print-result-json-test
-  (testing "print-result with :json output produces valid JSON"
-    (let [result {:execution/status :completed :data "hello"}
-          out (capture-stdout #(display/print-result result {:output :json}))]
-      (is (not (str/blank? out)))
-      ;; Should be parseable JSON
-      (let [parsed (json/parse-string out true)]
-        (is (map? parsed))
-        (is (= "hello" (:data parsed)))))))
-
-(deftest print-result-edn-default-test
+(deftest ^{:stratum 0} print-result-edn-default-test
   (testing "print-result with nil output mode falls through to pprint"
     (let [result {:execution/status :completed}
           out (with-out-str (display/print-result result {:output nil}))]
       (is (not (str/blank? out))
           "Default mode should pprint the result"))))
 
-(deftest print-result-pretty-quiet-test
-  (testing "print-result with :pretty and quiet=true produces no output"
-    (let [result {:execution/status :completed}
-          out (capture-stdout #(display/print-result result {:output :pretty :quiet true}))]
-      (is (str/blank? out)
-          "Pretty mode with quiet should produce no output"))))
-
-(deftest print-result-pretty-not-quiet-test
-  (testing "print-result with :pretty and quiet=false produces full output"
-    (let [result {:execution/status :completed
-                  :execution/metrics {:tokens 100 :cost-usd 0.001 :duration-ms 500}}
-          out (capture-stdout #(display/print-result result {:output :pretty :quiet false}))]
-      (is (not (str/blank? out))
-          "Pretty mode without quiet should produce output"))))
-
-(deftest print-result-edn-preserves-full-result-test
-  (testing "print-result with :edn preserves access to the full result"
-    (let [result {:execution/status :completed
-                  :large-payload {:nested [:kept]}}
-          out (capture-stdout #(display/print-result result {:output :edn}))]
-      (is (str/includes? out ":large-payload"))
-      (is (str/includes? out ":nested")))))
-
-(deftest print-result-quiet-suppresses-machine-output-test
-  (testing "quiet mode suppresses all output branches"
-    (doseq [output [:json :edn nil]]
-      (let [out (capture-stdout #(display/print-result {:execution/status :completed}
-                                                       {:output output :quiet true}))]
-        (is (str/blank? out)
-            (str "Expected no output for " output))))))
-
-;------------------------------------------------------------------------------ Layer 2.5
 ;; compact-result-summary helpers
-
-(deftest phase-summaries-known-shapes-test
+(deftest ^{:stratum 0} phase-summaries-known-shapes-test
   (testing "extract-phase-summaries reads the canonical execution phase results"
     (is (= [{:phase :plan :outcome :completed :duration-ms 1000}]
            (display/extract-phase-summaries
@@ -188,14 +56,14 @@
                                               :metrics {:duration-ms 1000}}}})))
     (is (nil? (display/extract-phase-summaries {:phases [{:phase :plan}]})))))
 
-(deftest failed-task-ids-known-shapes-test
+(deftest ^{:stratum 0} failed-task-ids-known-shapes-test
   (testing "extract-failed-tasks reads the canonical execution DAG result"
     (is (= ["a"]
            (display/extract-failed-tasks
             {:execution/dag-result {:failed-task-ids [:a]}})))
     (is (nil? (display/extract-failed-tasks {:failed-task-ids [:a]})))))
 
-(deftest pr-urls-known-shapes-test
+(deftest ^{:stratum 0} pr-urls-known-shapes-test
   (testing "extract-pr-urls reads workflow-owned PR info"
     (is (= ["https://github.com/miniforge-ai/miniforge/pull/1"]
            (display/extract-pr-urls
@@ -208,7 +76,7 @@
     (is (nil? (display/extract-pr-urls
                {:pr/url "https://github.com/miniforge-ai/miniforge/pull/3"})))))
 
-(deftest compact-result-summary-renders-operator-view-test
+(deftest ^{:stratum 0} compact-result-summary-renders-operator-view-test
   (testing "format-compact-summary renders status, phases, tasks, PRs, metrics, errors, and hint"
     (let [out (display/format-compact-summary
                {:execution/status :failed
@@ -228,103 +96,22 @@
       (is (str/includes? out "compile failed"))
       (is (str/includes? out "--output edn")))))
 
-;------------------------------------------------------------------------------ Layer 3
-;; print-pretty-result
-
-(deftest print-pretty-result-test
-  (testing "print-pretty-result renders separator lines and summary"
-    (let [result {:execution/status :completed
-                  :execution/metrics {:tokens 200 :cost-usd 0.005 :duration-ms 3000}}
-          out (capture-stdout #(display/print-pretty-result result))]
-      (is (not (str/blank? out)))
-      ;; Should contain cyan separator lines (━ repeated)
-      (is (str/includes? out "━")
-          "Should contain box-drawing separator")
-      (is (str/includes? out "--output edn"))
-      (is (not (str/includes? out ":execution/status"))
-          "Pretty mode should not pprint the full EDN result"))))
-
-(deftest print-pretty-result-failed-test
-  (testing "print-pretty-result renders failure with errors"
-    (let [result {:execution/status :failed
-                  :execution/errors ["compile error"]}
-          out (capture-stdout #(display/print-pretty-result result))]
-      (is (not (str/blank? out)))
-      (is (str/includes? out "compile error")))))
-
-;------------------------------------------------------------------------------ Layer 4
-;; Error help output functions
-
-(deftest print-error-header-test
-  (testing "print-error-header renders error message, details, and cause"
-    (let [cause (Exception. "root cause")
-          out (capture-stdout
-                #(display/print-error-header "Something broke" {:key "val"} cause))]
-      (is (not (str/blank? out)))
-      (is (str/includes? out "Something broke")
-          "Should contain error message")
-      (is (str/includes? out ":key")
-          "Should contain data details")
-      (is (str/includes? out "root cause")
-          "Should contain cause message")
-      ;; Should contain red coloring for error header
-      (is (str/includes? out (get display/ansi-codes :red))))))
-
-(deftest print-error-header-nil-data-test
-  (testing "print-error-header handles nil data gracefully"
-    (let [out (capture-stdout
-                #(display/print-error-header "Error" nil nil))]
-      (is (not (str/blank? out)))
-      (is (str/includes? out "Error")))))
-
-(deftest print-error-header-nil-cause-test
-  (testing "print-error-header handles nil cause gracefully"
-    (let [out (capture-stdout
-                #(display/print-error-header "Error" {:x 1} nil))]
-      (is (not (str/blank? out))))))
-
-(deftest print-namespace-resolution-help-test
-  (testing "print-namespace-resolution-help prints namespace help"
-    (let [out (capture-stdout #(display/print-namespace-resolution-help))]
-      (is (not (str/blank? out))
-          "Should produce help output")
-      (is (str/includes? out (get display/ansi-codes :cyan))
-          "Should use cyan coloring"))))
-
-(deftest print-babashka-fallback-help-test
-  (testing "print-babashka-fallback-help prints Babashka help"
-    (let [out (capture-stdout #(display/print-babashka-fallback-help))]
-      (is (not (str/blank? out))
-          "Should produce help output")
-      (is (str/includes? out (get display/ansi-codes :cyan))
-          "Should use cyan coloring"))))
-
-(deftest print-general-debugging-help-test
-  (testing "print-general-debugging-help prints debugging tips"
-    (let [out (capture-stdout #(display/print-general-debugging-help))]
-      (is (not (str/blank? out))
-          "Should produce help output")
-      (is (str/includes? out (get display/ansi-codes :cyan))
-          "Should use cyan coloring"))))
-
-;------------------------------------------------------------------------------ Layer 5
 ;; format-event-line edge cases
-
-(deftest format-event-line-workflow-completed-no-duration-test
+(deftest ^{:stratum 0} format-event-line-workflow-completed-no-duration-test
   (testing "workflow/completed without :workflow/duration-ms omits duration suffix"
     (let [line (display/format-event-line {:event/type :workflow/completed})]
       (is (string? line))
       (is (not (str/includes? line "("))
           "Without duration, no parenthesized suffix"))))
 
-(deftest format-event-line-workflow-failed-no-reason-test
+(deftest ^{:stratum 0} format-event-line-workflow-failed-no-reason-test
   (testing "workflow/failed without :workflow/failure-reason omits reason suffix"
     (let [line (display/format-event-line {:event/type :workflow/failed})]
       (is (string? line))
       (is (not (str/includes? line ":"))
           "Without reason, no colon-separated suffix"))))
 
-(deftest format-event-line-phase-completed-no-duration-test
+(deftest ^{:stratum 0} format-event-line-phase-completed-no-duration-test
   (testing "phase/phase-completed without :phase/duration-ms omits duration"
     (let [line (display/format-event-line {:event/type :workflow/phase-completed
                                            :workflow/phase :plan
@@ -333,38 +120,13 @@
       (is (not (str/includes? line "("))
           "Without duration, no parenthesized suffix"))))
 
-(def ^:private red-ansi "[31m")
-(def ^:private green-ansi "[32m")
-(def ^:private yellow-ansi "[33m")
+(def ^{:stratum 0} ^:private red-ansi "[31m")
 
-(deftest format-event-line-phase-completed-success-is-green-with-check
-  (let [line (display/format-event-line {:event/type :workflow/phase-completed
-                                         :workflow/phase :plan
-                                         :phase/outcome :success})]
-    (is (str/includes? line green-ansi)
-        "success outcome must render green")
-    (is (str/includes? line "✓")
-        "success outcome must use the ✓ glyph")))
+(def ^{:stratum 0} ^:private green-ansi "[32m")
 
-(deftest format-event-line-phase-completed-failure-is-red-with-cross
-  (let [line (display/format-event-line {:event/type :workflow/phase-completed
-                                         :workflow/phase :implement
-                                         :phase/outcome :failure})]
-    (is (str/includes? line red-ansi)
-        "failure outcome must render red so it stops reading as success")
-    (is (str/includes? line "✗")
-        "failure outcome must use the ✗ glyph")
-    (is (not (str/includes? line green-ansi))
-        "failure outcome must not include a green code anywhere in the line")))
+(def ^{:stratum 0} ^:private yellow-ansi "[33m")
 
-(deftest format-event-line-phase-completed-skipped-is-yellow
-  (let [line (display/format-event-line {:event/type :workflow/phase-completed
-                                         :workflow/phase :release
-                                         :phase/outcome :skipped})]
-    (is (str/includes? line yellow-ansi)
-        "skipped outcome must render yellow")))
-
-(deftest format-event-line-agent-status-default-status-test
+(deftest ^{:stratum 0} format-event-line-agent-status-default-status-test
   (testing "agent/status with no message/status falls back to default-status"
     (let [line (display/format-event-line {:event/type :agent/status
                                            :agent/id :planner})]
@@ -372,7 +134,7 @@
       ;; Should contain the default status message ("working")
       (is (some? line)))))
 
-(deftest format-event-line-chain-completed-with-duration-test
+(deftest ^{:stratum 0} format-event-line-chain-completed-with-duration-test
   (testing "chain/completed includes formatted duration"
     (let [line (display/format-event-line {:event/type :chain/completed
                                            :chain/id :deploy
@@ -381,14 +143,14 @@
       (is (str/includes? line "1.5m")
           "Should include formatted duration"))))
 
-(deftest format-event-line-chain-completed-no-duration-test
+(deftest ^{:stratum 0} format-event-line-chain-completed-no-duration-test
   (testing "chain/completed without duration omits suffix"
     (let [line (display/format-event-line {:event/type :chain/completed
                                            :chain/id :deploy})]
       (is (string? line))
       (is (not (str/includes? line "("))))))
 
-(deftest format-event-line-dependency-health-updated-test
+(deftest ^{:stratum 0} format-event-line-dependency-health-updated-test
   (testing "dependency/health-updated surfaces dependency blame"
     (let [line (display/format-event-line {:event/type :dependency/health-updated
                                            :dependency/id :anthropic
@@ -399,7 +161,7 @@
       (is (str/includes? line "Anthropic"))
       (is (str/includes? line "unavailable")))))
 
-(deftest format-event-line-dependency-recovered-test
+(deftest ^{:stratum 0} format-event-line-dependency-recovered-test
   (testing "dependency/recovered surfaces recovery attribution"
     (let [line (display/format-event-line {:event/type :dependency/recovered
                                            :dependency/id :anthropic
@@ -409,10 +171,8 @@
       (is (string? line))
       (is (str/includes? line "recovered")))))
 
-;------------------------------------------------------------------------------ Layer 6
 ;; start-progress! integration
-
-(deftest start-progress-subscribes-and-prints-test
+(deftest ^{:stratum 0} start-progress-subscribes-and-prints-test
   (testing "start-progress! prints lifecycle events and returns a cleanup fn"
     (let [stream (es/create-event-stream {:sinks []})
           wf-id (random-uuid)
@@ -424,7 +184,7 @@
       (is (not (str/blank? output))
           "Published workflow events should render progress output"))))
 
-(deftest start-progress-cleanup-stops-output-test
+(deftest ^{:stratum 0} start-progress-cleanup-stops-output-test
   (testing "cleanup unsubscribes the progress listener"
     (let [stream (es/create-event-stream {:sinks []})
           wf-id (random-uuid)]
@@ -436,7 +196,7 @@
         (is (str/blank? output)
             "No output should be produced after cleanup")))))
 
-(deftest start-progress-deduplicates-identical-lines-test
+(deftest ^{:stratum 0} start-progress-deduplicates-identical-lines-test
   (testing "back-to-back identical event lines are deduplicated"
     (let [stream (es/create-event-stream {:sinks []})
           wf-id (random-uuid)
@@ -449,7 +209,7 @@
       (is (= 1 (count (remove str/blank? (str/split-lines output))))
           "Duplicate lines should only print once"))))
 
-(deftest start-progress-different-events-not-deduplicated-test
+(deftest ^{:stratum 0} start-progress-different-events-not-deduplicated-test
   (testing "distinct events each produce their own output line"
     (let [stream (es/create-event-stream {:sinks []})
           wf-id (random-uuid)
@@ -462,45 +222,43 @@
       (is (= 3 (count (remove str/blank? (str/split-lines output))))
           "Distinct events must each print once"))))
 
-;------------------------------------------------------------------------------ Layer 7
 ;; format-demo-line edge cases
-
-(deftest format-demo-line-nil-phase-test
+(deftest ^{:stratum 0} format-demo-line-nil-phase-test
   (testing "format-demo-line uses ? for nil phase"
     (let [line (display/format-demo-line {:event/type :workflow/phase-started})]
       (is (string? line))
       (is (str/includes? line "?")
           "Nil phase should render as ?"))))
 
-(deftest format-demo-line-nil-agent-test
+(deftest ^{:stratum 0} format-demo-line-nil-agent-test
   (testing "format-demo-line uses ? for nil agent"
     (let [line (display/format-demo-line {:event/type :agent/started})]
       (is (string? line))
       (is (str/includes? line "?")
           "Nil agent should render as ?"))))
 
-(deftest format-demo-line-nil-gate-test
+(deftest ^{:stratum 0} format-demo-line-nil-gate-test
   (testing "format-demo-line uses ? for nil gate"
     (let [line (display/format-demo-line {:event/type :gate/passed})]
       (is (string? line))
       (is (str/includes? line "?")
           "Nil gate should render as ?"))))
 
-(deftest format-demo-line-workflow-completed-no-duration-test
+(deftest ^{:stratum 0} format-demo-line-workflow-completed-no-duration-test
   (testing "format-demo-line workflow/completed without duration shows ?"
     (let [line (display/format-demo-line {:event/type :workflow/completed})]
       (is (string? line))
       (is (str/includes? line "?")
           "Missing duration should render as ?"))))
 
-(deftest format-demo-line-workflow-failed-no-reason-test
+(deftest ^{:stratum 0} format-demo-line-workflow-failed-no-reason-test
   (testing "format-demo-line workflow/failed without reason shows unknown"
     (let [line (display/format-demo-line {:event/type :workflow/failed})]
       (is (string? line))
       (is (str/includes? line "unknown")
           "Missing reason should render as unknown"))))
 
-(deftest format-demo-line-phase-completed-no-duration-test
+(deftest ^{:stratum 0} format-demo-line-phase-completed-no-duration-test
   (testing "format-demo-line phase-completed without duration shows ?"
     (let [line (display/format-demo-line {:event/type :workflow/phase-completed
                                           :workflow/phase :plan})]
@@ -508,7 +266,7 @@
       (is (str/includes? line "?")
           "Missing duration should render as ?"))))
 
-(deftest format-demo-line-no-ansi-for-all-types-test
+(deftest ^{:stratum 0} format-demo-line-no-ansi-for-all-types-test
   (testing "No demo-mode output contains ANSI codes for any supported event type"
     (let [events [{:event/type :workflow/started}
                   {:event/type :workflow/completed :workflow/duration-ms 1000}
@@ -535,15 +293,13 @@
             (is (not (str/includes? line "\u001b"))
                 (str "Demo line for " (:event/type e) " must not contain ANSI codes"))))))))
 
-;------------------------------------------------------------------------------ Layer 7
 ;; format-duration additional edge cases
-
-(deftest format-duration-large-values-test
+(deftest ^{:stratum 0} format-duration-large-values-test
   (testing "Very large durations format as minutes"
     (is (= "60.0m" (display/format-duration 3600000)))
     (is (= "100.0m" (display/format-duration 6000000)))))
 
-(deftest format-duration-exact-boundaries-test
+(deftest ^{:stratum 0} format-duration-exact-boundaries-test
   (testing "Exact boundary at 1000ms"
     (is (= "1.0s" (display/format-duration 1000))))
   (testing "Exact boundary at 60000ms"
@@ -553,10 +309,8 @@
   (testing "Just below 60000ms"
     (is (= "60.0s" (display/format-duration 59999)))))
 
-;------------------------------------------------------------------------------ Layer 8
 ;; colorize composition tests
-
-(deftest colorize-all-known-colors-test
+(deftest ^{:stratum 0} colorize-all-known-colors-test
   (testing "All known color keys produce correct ANSI prefix"
     (doseq [[k code] display/ansi-codes
             :when (not= k :reset)]
@@ -565,6 +319,234 @@
             (str "Color " k " should start with its ANSI code"))
         (is (str/ends-with? result (:reset display/ansi-codes))
             (str "Color " k " should end with reset code"))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; print-workflow-header
+(deftest ^{:stratum 1} print-workflow-header-normal-test
+  (testing "print-workflow-header prints header with workflow-id and version"
+    (let [out (capture-stdout
+                #(display/print-workflow-header :my-workflow "1.0.0" false))]
+      (is (not (str/blank? out))
+          "Non-quiet mode should produce output")
+      ;; Should contain ANSI codes (cyan, bold)
+      (is (str/includes? out "\u001b")
+          "Header should contain ANSI color codes"))))
+
+(deftest ^{:stratum 1} print-workflow-header-quiet-test
+  (testing "print-workflow-header produces no output when quiet"
+    (let [out (capture-stdout
+                #(display/print-workflow-header :my-workflow "1.0.0" true))]
+      (is (str/blank? out)
+          "Quiet mode should produce no output"))))
+
+(deftest ^{:stratum 1} print-workflow-header-keyword-workflow-id-test
+  (testing "print-workflow-header converts keyword workflow-id via name"
+    (let [out (capture-stdout
+                #(display/print-workflow-header :feature-build "2.0.0" false))]
+      ;; The header renders (name :feature-build) = "feature-build"
+      (is (not (str/blank? out))))))
+
+;; print-workflow-summary
+(deftest ^{:stratum 1} print-workflow-summary-success-test
+  (testing "print-workflow-summary renders success with metrics"
+    (let [result {:execution/status :completed
+                  :execution/metrics {:tokens 5000
+                                      :cost-usd 0.0123
+                                      :duration-ms 45000}}
+          out (capture-stdout #(display/print-workflow-summary result))]
+      (is (not (str/blank? out)))
+      ;; Should contain green success marker
+      (is (str/includes? out (get display/ansi-codes :green))
+          "Success should use green color")
+      ;; Should contain formatted metrics
+      (is (str/includes? out "5000")
+          "Should display token count")
+      (is (str/includes? out "0.0123")
+          "Should display cost")
+      (is (str/includes? out "45.0s")
+          "Should display formatted duration"))))
+
+(deftest ^{:stratum 1} print-workflow-summary-failure-test
+  (testing "print-workflow-summary renders failure with errors"
+    (let [result {:execution/status :failed
+                  :execution/errors ["Agent timeout" "Gate lint failed"]}
+          out (capture-stdout #(display/print-workflow-summary result))]
+      (is (not (str/blank? out)))
+      ;; Should contain red failure marker
+      (is (str/includes? out (get display/ansi-codes :red))
+          "Failure should use red color")
+      ;; Should list errors
+      (is (str/includes? out "Agent timeout")
+          "Should display first error")
+      (is (str/includes? out "Gate lint failed")
+          "Should display second error"))))
+
+(deftest ^{:stratum 1} print-workflow-summary-no-metrics-test
+  (testing "print-workflow-summary handles result without metrics"
+    (let [result {:execution/status :completed}
+          out (capture-stdout #(display/print-workflow-summary result))]
+      (is (not (str/blank? out))
+          "Should still produce output without metrics"))))
+
+(deftest ^{:stratum 1} print-workflow-summary-no-errors-test
+  (testing "print-workflow-summary handles failure without errors list"
+    (let [result {:execution/status :failed}
+          out (capture-stdout #(display/print-workflow-summary result))]
+      (is (not (str/blank? out))
+          "Should still produce output without errors"))))
+
+(deftest ^{:stratum 1} print-workflow-summary-empty-errors-test
+  (testing "print-workflow-summary handles empty errors vector"
+    (let [result {:execution/status :failed
+                  :execution/errors []}
+          out (capture-stdout #(display/print-workflow-summary result))]
+      ;; Empty errors should not produce error section
+      (is (not (str/blank? out))))))
+
+;; print-result (output format dispatch)
+(deftest ^{:stratum 1} print-result-json-test
+  (testing "print-result with :json output produces valid JSON"
+    (let [result {:execution/status :completed :data "hello"}
+          out (capture-stdout #(display/print-result result {:output :json}))]
+      (is (not (str/blank? out)))
+      ;; Should be parseable JSON
+      (let [parsed (json/parse-string out true)]
+        (is (map? parsed))
+        (is (= "hello" (:data parsed)))))))
+
+(deftest ^{:stratum 1} print-result-pretty-quiet-test
+  (testing "print-result with :pretty and quiet=true produces no output"
+    (let [result {:execution/status :completed}
+          out (capture-stdout #(display/print-result result {:output :pretty :quiet true}))]
+      (is (str/blank? out)
+          "Pretty mode with quiet should produce no output"))))
+
+(deftest ^{:stratum 1} print-result-pretty-not-quiet-test
+  (testing "print-result with :pretty and quiet=false produces full output"
+    (let [result {:execution/status :completed
+                  :execution/metrics {:tokens 100 :cost-usd 0.001 :duration-ms 500}}
+          out (capture-stdout #(display/print-result result {:output :pretty :quiet false}))]
+      (is (not (str/blank? out))
+          "Pretty mode without quiet should produce output"))))
+
+(deftest ^{:stratum 1} print-result-edn-preserves-full-result-test
+  (testing "print-result with :edn preserves access to the full result"
+    (let [result {:execution/status :completed
+                  :large-payload {:nested [:kept]}}
+          out (capture-stdout #(display/print-result result {:output :edn}))]
+      (is (str/includes? out ":large-payload"))
+      (is (str/includes? out ":nested")))))
+
+(deftest ^{:stratum 1} print-result-quiet-suppresses-machine-output-test
+  (testing "quiet mode suppresses all output branches"
+    (doseq [output [:json :edn nil]]
+      (let [out (capture-stdout #(display/print-result {:execution/status :completed}
+                                                       {:output output :quiet true}))]
+        (is (str/blank? out)
+            (str "Expected no output for " output))))))
+
+;; print-pretty-result
+(deftest ^{:stratum 1} print-pretty-result-test
+  (testing "print-pretty-result renders separator lines and summary"
+    (let [result {:execution/status :completed
+                  :execution/metrics {:tokens 200 :cost-usd 0.005 :duration-ms 3000}}
+          out (capture-stdout #(display/print-pretty-result result))]
+      (is (not (str/blank? out)))
+      ;; Should contain cyan separator lines (━ repeated)
+      (is (str/includes? out "━")
+          "Should contain box-drawing separator")
+      (is (str/includes? out "--output edn"))
+      (is (not (str/includes? out ":execution/status"))
+          "Pretty mode should not pprint the full EDN result"))))
+
+(deftest ^{:stratum 1} print-pretty-result-failed-test
+  (testing "print-pretty-result renders failure with errors"
+    (let [result {:execution/status :failed
+                  :execution/errors ["compile error"]}
+          out (capture-stdout #(display/print-pretty-result result))]
+      (is (not (str/blank? out)))
+      (is (str/includes? out "compile error")))))
+
+;; Error help output functions
+(deftest ^{:stratum 1} print-error-header-test
+  (testing "print-error-header renders error message, details, and cause"
+    (let [cause (Exception. "root cause")
+          out (capture-stdout
+                #(display/print-error-header "Something broke" {:key "val"} cause))]
+      (is (not (str/blank? out)))
+      (is (str/includes? out "Something broke")
+          "Should contain error message")
+      (is (str/includes? out ":key")
+          "Should contain data details")
+      (is (str/includes? out "root cause")
+          "Should contain cause message")
+      ;; Should contain red coloring for error header
+      (is (str/includes? out (get display/ansi-codes :red))))))
+
+(deftest ^{:stratum 1} print-error-header-nil-data-test
+  (testing "print-error-header handles nil data gracefully"
+    (let [out (capture-stdout
+                #(display/print-error-header "Error" nil nil))]
+      (is (not (str/blank? out)))
+      (is (str/includes? out "Error")))))
+
+(deftest ^{:stratum 1} print-error-header-nil-cause-test
+  (testing "print-error-header handles nil cause gracefully"
+    (let [out (capture-stdout
+                #(display/print-error-header "Error" {:x 1} nil))]
+      (is (not (str/blank? out))))))
+
+(deftest ^{:stratum 1} print-namespace-resolution-help-test
+  (testing "print-namespace-resolution-help prints namespace help"
+    (let [out (capture-stdout #(display/print-namespace-resolution-help))]
+      (is (not (str/blank? out))
+          "Should produce help output")
+      (is (str/includes? out (get display/ansi-codes :cyan))
+          "Should use cyan coloring"))))
+
+(deftest ^{:stratum 1} print-babashka-fallback-help-test
+  (testing "print-babashka-fallback-help prints Babashka help"
+    (let [out (capture-stdout #(display/print-babashka-fallback-help))]
+      (is (not (str/blank? out))
+          "Should produce help output")
+      (is (str/includes? out (get display/ansi-codes :cyan))
+          "Should use cyan coloring"))))
+
+(deftest ^{:stratum 1} print-general-debugging-help-test
+  (testing "print-general-debugging-help prints debugging tips"
+    (let [out (capture-stdout #(display/print-general-debugging-help))]
+      (is (not (str/blank? out))
+          "Should produce help output")
+      (is (str/includes? out (get display/ansi-codes :cyan))
+          "Should use cyan coloring"))))
+
+(deftest ^{:stratum 1} format-event-line-phase-completed-success-is-green-with-check
+  (let [line (display/format-event-line {:event/type :workflow/phase-completed
+                                         :workflow/phase :plan
+                                         :phase/outcome :success})]
+    (is (str/includes? line green-ansi)
+        "success outcome must render green")
+    (is (str/includes? line "✓")
+        "success outcome must use the ✓ glyph")))
+
+(deftest ^{:stratum 1} format-event-line-phase-completed-failure-is-red-with-cross
+  (let [line (display/format-event-line {:event/type :workflow/phase-completed
+                                         :workflow/phase :implement
+                                         :phase/outcome :failure})]
+    (is (str/includes? line red-ansi)
+        "failure outcome must render red so it stops reading as success")
+    (is (str/includes? line "✗")
+        "failure outcome must use the ✗ glyph")
+    (is (not (str/includes? line green-ansi))
+        "failure outcome must not include a green code anywhere in the line")))
+
+(deftest ^{:stratum 1} format-event-line-phase-completed-skipped-is-yellow
+  (let [line (display/format-event-line {:event/type :workflow/phase-completed
+                                         :workflow/phase :release
+                                         :phase/outcome :skipped})]
+    (is (str/includes? line yellow-ansi)
+        "skipped outcome must render yellow")))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/display_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/display_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.workflow-runner.display-test
   (:require
    [clojure.test :refer [deftest is testing]]
@@ -24,7 +23,9 @@
    [ai.miniforge.cli.messages :as messages]
    [ai.miniforge.cli.workflow-runner.display :as sut]))
 
-(deftest print-workflow-header-uses-app-display-name-test
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} print-workflow-header-uses-app-display-name-test
   (testing "workflow runner header uses the active app display name"
     (with-redefs [app-config/display-name (constantly "MiniForge Core")]
       (let [output (with-out-str (sut/print-workflow-header :simple-v2 "latest" false))]
@@ -38,7 +39,7 @@
                        (messages/t :workflow-runner/version
                                    {:version "latest"})))))))
 
-(deftest workflow-runner-event-lines-use-message-catalog-test
+(deftest ^{:stratum 0} workflow-runner-event-lines-use-message-catalog-test
   (testing "event formatting reads labels from the message catalog"
     (with-redefs [messages/t (fn
                                ([k]
@@ -55,7 +56,7 @@
                                          :phase/outcome :completed})]
         (is (.contains line "PHASE:extract:completed"))))))
 
-(deftest workflow-runner-error-help-uses-message-catalog-test
+(deftest ^{:stratum 0} workflow-runner-error-help-uses-message-catalog-test
   (testing "error help output is assembled from message resources"
     (with-redefs [messages/t (fn
                                ([k]
@@ -81,8 +82,7 @@
         (is (.contains output "CAUSE-CYCLE"))))))
 
 ;------------------------------------------------------------------------------ extract-phase-summaries
-
-(deftest extract-phase-summaries-from-execution-phase-results-test
+(deftest ^{:stratum 0} extract-phase-summaries-from-execution-phase-results-test
   (testing "extracts from canonical :execution/phase-results"
     (let [result {:execution/phase-results
                   {:build {:status :success :metrics {:duration-ms 1200}}
@@ -91,39 +91,37 @@
               {:phase :test  :outcome :failure   :duration-ms 300}]
              (sut/extract-phase-summaries result))))))
 
-(deftest extract-phase-summaries-nil-when-no-phases-test
+(deftest ^{:stratum 0} extract-phase-summaries-nil-when-no-phases-test
   (testing "returns nil when no phase data present"
     (is (nil? (sut/extract-phase-summaries {:execution/status :completed})))
     (is (nil? (sut/extract-phase-summaries {:phases [{:phase :legacy}]})))
     (is (nil? (sut/extract-phase-summaries {})))))
 
-(deftest extract-phase-summaries-nil-on-non-map-test
+(deftest ^{:stratum 0} extract-phase-summaries-nil-on-non-map-test
   (testing "returns nil for non-map input"
     (is (nil? (sut/extract-phase-summaries nil)))
     (is (nil? (sut/extract-phase-summaries [1 2 3])))))
 
 ;------------------------------------------------------------------------------ extract-failed-tasks
-
-(deftest extract-failed-tasks-from-canonical-dag-result-test
+(deftest ^{:stratum 0} extract-failed-tasks-from-canonical-dag-result-test
   (testing "extracts from canonical :execution/dag-result"
     (is (= ["task-a" "task-b"]
            (sut/extract-failed-tasks
             {:execution/dag-result {:failed-task-ids [:task-a "task-b"]}})))))
 
-(deftest extract-failed-tasks-nil-when-none-test
+(deftest ^{:stratum 0} extract-failed-tasks-nil-when-none-test
   (testing "returns nil when no failed tasks"
     (is (nil? (sut/extract-failed-tasks {:failed-task-ids ["legacy"]})))
     (is (nil? (sut/extract-failed-tasks {})))))
 
 ;------------------------------------------------------------------------------ extract-pr-urls
-
-(deftest extract-pr-urls-from-workflow-pr-info-test
+(deftest ^{:stratum 0} extract-pr-urls-from-workflow-pr-info-test
   (testing "extracts from the release phase PR info"
     (is (= ["https://github.com/org/repo/pull/42"]
            (sut/extract-pr-urls
             {:workflow/pr-info {:pr-url "https://github.com/org/repo/pull/42"}})))))
 
-(deftest extract-pr-urls-from-dag-pr-infos-test
+(deftest ^{:stratum 0} extract-pr-urls-from-dag-pr-infos-test
   (testing "extracts URL values from DAG PR info"
     (let [result {:execution/dag-pr-infos [{:pr-url "https://github.com/org/repo/pull/1"}
                                            {:pr/url "https://github.com/org/repo/pull/2"}]}]
@@ -131,15 +129,14 @@
               "https://github.com/org/repo/pull/2"]
              (sut/extract-pr-urls result))))))
 
-(deftest extract-pr-urls-nil-when-none-test
+(deftest ^{:stratum 0} extract-pr-urls-nil-when-none-test
   (testing "returns nil when no PR URLs present"
     (is (nil? (sut/extract-pr-urls {:pr/url "https://github.com/org/repo/pull/42"})))
     (is (nil? (sut/extract-pr-urls {:execution/status :completed})))
     (is (nil? (sut/extract-pr-urls {})))))
 
 ;------------------------------------------------------------------------------ format-compact-summary
-
-(deftest format-compact-summary-success-contains-status-test
+(deftest ^{:stratum 0} format-compact-summary-success-contains-status-test
   (testing "compact summary for a successful run includes success marker"
     (with-redefs [app-config/events-dir (constantly "/tmp/events")]
       (let [result {:execution/status :completed
@@ -148,7 +145,7 @@
         (is (string? s))
         (is (str/includes? s (messages/t :workflow-runner/summary-success)))))))
 
-(deftest format-compact-summary-failure-contains-errors-test
+(deftest ^{:stratum 0} format-compact-summary-failure-contains-errors-test
   (testing "compact summary for a failed run includes errors"
     (with-redefs [app-config/events-dir (constantly "/tmp/events")]
       (let [result {:execution/status :failed
@@ -156,7 +153,7 @@
             s (sut/format-compact-summary result)]
         (is (str/includes? s "gate lint failed"))))))
 
-(deftest format-compact-summary-includes-phase-lines-test
+(deftest ^{:stratum 0} format-compact-summary-includes-phase-lines-test
   (testing "compact summary includes one line per phase when phases present"
     (with-redefs [app-config/events-dir (constantly "/tmp/events")]
       (let [result {:execution/status :completed
@@ -167,7 +164,7 @@
         (is (str/includes? s "build"))
         (is (str/includes? s "test"))))))
 
-(deftest format-compact-summary-includes-failed-tasks-test
+(deftest ^{:stratum 0} format-compact-summary-includes-failed-tasks-test
   (testing "compact summary includes failed task IDs when present"
     (with-redefs [app-config/events-dir (constantly "/tmp/events")]
       (let [result {:execution/status :failed
@@ -176,7 +173,7 @@
         (is (str/includes? s "task-x"))
         (is (str/includes? s "task-y"))))))
 
-(deftest format-compact-summary-includes-pr-urls-test
+(deftest ^{:stratum 0} format-compact-summary-includes-pr-urls-test
   (testing "compact summary includes PR URLs when present"
     (with-redefs [app-config/events-dir (constantly "/tmp/events")]
       (let [result {:execution/status :completed
@@ -184,22 +181,21 @@
             s (sut/format-compact-summary result)]
         (is (str/includes? s "https://github.com/org/repo/pull/10"))))))
 
-(deftest format-compact-summary-includes-events-pointer-test
+(deftest ^{:stratum 0} format-compact-summary-includes-events-pointer-test
   (testing "compact summary includes events directory pointer"
     (with-redefs [app-config/events-dir (constantly "/my/events/dir")]
       (let [result {:execution/status :completed}
             s (sut/format-compact-summary result)]
         (is (str/includes? s "/my/events/dir"))))))
 
-(deftest format-compact-summary-includes-full-hint-test
+(deftest ^{:stratum 0} format-compact-summary-includes-full-hint-test
   (testing "compact summary includes --output edn hint"
     (with-redefs [app-config/events-dir (constantly "/tmp/events")]
       (let [s (sut/format-compact-summary {:execution/status :completed})]
         (is (str/includes? s "edn"))))))
 
 ;------------------------------------------------------------------------------ print-pretty-result
-
-(deftest print-pretty-result-no-pprint-test
+(deftest ^{:stratum 0} print-pretty-result-no-pprint-test
   (testing "print-pretty-result does not dump raw EDN pprint"
     (with-redefs [app-config/events-dir (constantly "/tmp/events")]
       (let [result {:execution/status :completed
@@ -212,28 +208,27 @@
         (is (str/includes? out (messages/t :workflow-runner/summary-success)))))))
 
 ;------------------------------------------------------------------------------ print-result dispatch
-
-(deftest print-result-edn-branch-pprints-test
+(deftest ^{:stratum 0} print-result-edn-branch-pprints-test
   (testing ":edn output produces a clojure.pprint dump"
     (let [result {:execution/status :completed :data 99}
           out (with-out-str (sut/print-result result {:output :edn :quiet false}))]
       ;; pprint includes the map keys
       (is (str/includes? out ":data")))))
 
-(deftest print-result-json-branch-test
+(deftest ^{:stratum 0} print-result-json-branch-test
   (testing ":json output produces JSON"
     (let [result {:execution/status :completed}
           out (with-out-str (sut/print-result result {:output :json :quiet false}))]
       (is (str/includes? out "{")))))
 
-(deftest print-result-pretty-branch-test
+(deftest ^{:stratum 0} print-result-pretty-branch-test
   (testing ":pretty output calls compact summary"
     (with-redefs [app-config/events-dir (constantly "/tmp/events")]
       (let [result {:execution/status :completed}
             out (with-out-str (sut/print-result result {:output :pretty :quiet false}))]
         (is (str/includes? out (messages/t :workflow-runner/summary-success)))))))
 
-(deftest print-result-else-branch-pprints-test
+(deftest ^{:stratum 0} print-result-else-branch-pprints-test
   (testing "unknown output keyword falls back to pprint"
     (let [result {:execution/status :completed :mystery-key true}
           out (with-out-str (sut/print-result result {:output :unknown-format :quiet false}))]

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/gc_hooks_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/gc_hooks_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.workflow-runner.gc-hooks-test
   "Unit tests for the deferred GC hooks in workflow-runner.gc-hooks.
 
@@ -33,9 +32,10 @@
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.cli.workflow-runner.gc-hooks :as sut]))
 
-;;------------------------------------------------------------------------------ enqueue-workflow-gc-best-effort!
+;------------------------------------------------------------------------------ Layer 0
 
-(deftest enqueue-best-effort!-delegates-to-enqueue-fn-test
+;;------------------------------------------------------------------------------ enqueue-workflow-gc-best-effort!
+(deftest ^{:stratum 0} enqueue-best-effort!-delegates-to-enqueue-fn-test
   (testing "calls enqueue-fn with the workflow-id"
     (let [captured   (atom nil)
           enqueue-fn (fn [id]
@@ -44,13 +44,13 @@
       (sut/enqueue-workflow-gc-best-effort! enqueue-fn "wf-unit-test")
       (is (= "wf-unit-test" @captured)))))
 
-(deftest enqueue-best-effort!-swallows-exceptions-test
+(deftest ^{:stratum 0} enqueue-best-effort!-swallows-exceptions-test
   (testing "never propagates an exception thrown by enqueue-fn"
     (let [throwing-fn (fn [_] (throw (Exception. "simulated failure")))]
       ;; Must not throw — return value is irrelevant.
       (is (nil? (sut/enqueue-workflow-gc-best-effort! throwing-fn "wf-exception-test"))))))
 
-(deftest enqueue-best-effort!-returns-result-on-success-test
+(deftest ^{:stratum 0} enqueue-best-effort!-returns-result-on-success-test
   (testing "returns the result produced by enqueue-fn on the happy path"
     (let [ok-result   {:status :ok :data {:workflow-id "wf-ok" :queue-size 1}}
           enqueue-fn  (constantly ok-result)]
@@ -58,8 +58,7 @@
              (sut/enqueue-workflow-gc-best-effort! enqueue-fn "wf-ok"))))))
 
 ;;------------------------------------------------------------------------------ run-gc-pass-best-effort!
-
-(deftest run-gc-pass!-calls-gc-fn-when-repo-root-exists-test
+(deftest ^{:stratum 0} run-gc-pass!-calls-gc-fn-when-repo-root-exists-test
   (testing "calls gc-fn with the repo root when worktree-root-fn returns non-nil"
     (let [captured-repo    (atom nil)
           worktree-root-fn (constantly "/fake/repo/root")
@@ -69,7 +68,7 @@
       (sut/run-gc-pass-best-effort! worktree-root-fn gc-fn)
       (is (= "/fake/repo/root" @captured-repo)))))
 
-(deftest run-gc-pass!-no-op-when-worktree-root-nil-test
+(deftest ^{:stratum 0} run-gc-pass!-no-op-when-worktree-root-nil-test
   (testing "does not call gc-fn when worktree-root-fn returns nil"
     (let [called?          (atom false)
           worktree-root-fn (constantly nil)
@@ -79,18 +78,18 @@
       (sut/run-gc-pass-best-effort! worktree-root-fn gc-fn)
       (is (not @called?)))))
 
-(deftest run-gc-pass!-swallows-exceptions-test
+(deftest ^{:stratum 0} run-gc-pass!-swallows-exceptions-test
   (testing "never propagates an exception thrown by gc-fn"
     (let [worktree-root-fn (constantly "/some/repo")
           throwing-gc-fn   (fn [_] (throw (Exception. "git exploded")))]
       ;; Must not throw.
       (is (nil? (sut/run-gc-pass-best-effort! worktree-root-fn throwing-gc-fn))))))
 
-(deftest run-gc-pass!-returns-nil-when-worktree-root-nil-test
+(deftest ^{:stratum 0} run-gc-pass!-returns-nil-when-worktree-root-nil-test
   (testing "returns nil (not an error) when worktree-root-fn returns nil"
     (is (nil? (sut/run-gc-pass-best-effort! (constantly nil) identity)))))
 
-(deftest run-gc-pass!-returns-gc-fn-result-on-success-test
+(deftest ^{:stratum 0} run-gc-pass!-returns-gc-fn-result-on-success-test
   (testing "returns the result from gc-fn when everything succeeds"
     (let [gc-result        {:status :ok :data {:pruned 2 :remaining 0 :gc-result {}}}
           worktree-root-fn (constantly "/some/repo")
@@ -98,7 +97,7 @@
       (is (= gc-result
              (sut/run-gc-pass-best-effort! worktree-root-fn gc-fn))))))
 
-(deftest run-gc-pass!-swallows-worktree-root-fn-exception-test
+(deftest ^{:stratum 0} run-gc-pass!-swallows-worktree-root-fn-exception-test
   (testing "never propagates an exception thrown by worktree-root-fn"
     (let [throwing-root-fn (fn [] (throw (Exception. "fs gone")))]
       ;; The outer try/catch Exception in run-gc-pass-best-effort! covers

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/gc_integration_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/gc_integration_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.workflow-runner.gc-integration-test
   "Integration tests for the GC hook wiring pattern used in workflow-runner.
 
@@ -52,31 +51,13 @@
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.cli.workflow-runner.gc-hooks :as gc-hooks]))
 
-;;------------------------------------------------------------------------------ Helpers
+;------------------------------------------------------------------------------ Layer 0
 
-(defn- ok-result [data]
+;;------------------------------------------------------------------------------ Helpers
+(defn- ^{:stratum 0} ok-result [data]
   {:status :ok :data data})
 
-;;------------------------------------------------------------------------------ GC pass at workflow start
-
-(deftest gc-pass-invoked-at-workflow-start-test
-  (testing "GC pass hook is called once at the top of the workflow"
-    (let [gc-called? (atom false)
-          repo-fn    (constantly "/fake/repo")
-          gc-fn      (fn [_] (reset! gc-called? true) (ok-result {:pruned 0 :remaining 0 :gc-result nil}))]
-      ;; Mirrors the first line of run-workflow! / run-workflow-from-spec!
-      (gc-hooks/run-gc-pass-best-effort! repo-fn gc-fn)
-      (is @gc-called? "GC pass must be invoked at workflow start"))))
-
-(deftest gc-pass-forwards-repo-root-test
-  (testing "GC pass forwards the worktree root path to gc-fn"
-    (let [captured (atom nil)
-          repo-fn  (constantly "/expected/repo/root")
-          gc-fn    (fn [root] (reset! captured root) (ok-result {:pruned 0 :remaining 0 :gc-result nil}))]
-      (gc-hooks/run-gc-pass-best-effort! repo-fn gc-fn)
-      (is (= "/expected/repo/root" @captured)))))
-
-(deftest gc-pass-skipped-outside-git-repo-test
+(deftest ^{:stratum 0} gc-pass-skipped-outside-git-repo-test
   (testing "GC pass is a no-op when not inside a git repository"
     (let [gc-called? (atom false)
           repo-fn    (constantly nil)   ; no git repo
@@ -84,41 +65,7 @@
       (gc-hooks/run-gc-pass-best-effort! repo-fn gc-fn)
       (is (not @gc-called?) "gc-fn must NOT be called when repo root is nil"))))
 
-;;------------------------------------------------------------------------------ Enqueue in finally block — normal exit
-
-(deftest enqueue-called-on-normal-workflow-completion-test
-  (testing "Enqueue fires in finally when the workflow body completes normally"
-    (let [enqueued   (atom nil)
-          enqueue-fn (fn [wf-id]
-                       (reset! enqueued wf-id)
-                       (ok-result {:workflow-id wf-id :queue-size 1}))]
-      ;; Mirrors the finally block in run-workflow! on the success path.
-      (try
-        :simulated-workflow-success
-        (finally
-          (gc-hooks/enqueue-workflow-gc-best-effort! enqueue-fn "wf-normal-exit")))
-      (is (= "wf-normal-exit" @enqueued)
-          "enqueue-fn must be called with the workflow-id on normal completion"))))
-
-;;------------------------------------------------------------------------------ Enqueue in finally block — exception exit
-
-(deftest enqueue-called-on-exception-exit-test
-  (testing "Enqueue fires in finally even when the workflow body throws"
-    (let [enqueued   (atom nil)
-          enqueue-fn (fn [wf-id]
-                       (reset! enqueued wf-id)
-                       (ok-result {:workflow-id wf-id :queue-size 1}))]
-      ;; Mirrors the finally block in run-workflow! on the exception path.
-      (try
-        (try
-          (throw (Exception. "simulated workflow failure"))
-          (finally
-            (gc-hooks/enqueue-workflow-gc-best-effort! enqueue-fn "wf-exception-exit")))
-        (catch Exception _ nil))
-      (is (= "wf-exception-exit" @enqueued)
-          "enqueue-fn must be called even when the workflow body throws"))))
-
-(deftest enqueue-exception-does-not-mask-workflow-exception-test
+(deftest ^{:stratum 0} enqueue-exception-does-not-mask-workflow-exception-test
   (testing "An exception inside enqueue-fn does not mask the workflow's own exception"
     (let [throwing-enqueue-fn (fn [_] (throw (Exception. "enqueue exploded")))]
       ;; gc-hooks/enqueue-workflow-gc-best-effort! swallows enqueue-fn exceptions.
@@ -135,9 +82,60 @@
         (is (= "original workflow error" (ex-message @caught))
             "The enqueue exception must not replace the workflow exception")))))
 
-;;------------------------------------------------------------------------------ Full lifecycle pattern
+;------------------------------------------------------------------------------ Layer 1
 
-(deftest full-lifecycle-gc-pass-then-workflow-then-enqueue-test
+;;------------------------------------------------------------------------------ GC pass at workflow start
+(deftest ^{:stratum 1} gc-pass-invoked-at-workflow-start-test
+  (testing "GC pass hook is called once at the top of the workflow"
+    (let [gc-called? (atom false)
+          repo-fn    (constantly "/fake/repo")
+          gc-fn      (fn [_] (reset! gc-called? true) (ok-result {:pruned 0 :remaining 0 :gc-result nil}))]
+      ;; Mirrors the first line of run-workflow! / run-workflow-from-spec!
+      (gc-hooks/run-gc-pass-best-effort! repo-fn gc-fn)
+      (is @gc-called? "GC pass must be invoked at workflow start"))))
+
+(deftest ^{:stratum 1} gc-pass-forwards-repo-root-test
+  (testing "GC pass forwards the worktree root path to gc-fn"
+    (let [captured (atom nil)
+          repo-fn  (constantly "/expected/repo/root")
+          gc-fn    (fn [root] (reset! captured root) (ok-result {:pruned 0 :remaining 0 :gc-result nil}))]
+      (gc-hooks/run-gc-pass-best-effort! repo-fn gc-fn)
+      (is (= "/expected/repo/root" @captured)))))
+
+;;------------------------------------------------------------------------------ Enqueue in finally block — normal exit
+(deftest ^{:stratum 1} enqueue-called-on-normal-workflow-completion-test
+  (testing "Enqueue fires in finally when the workflow body completes normally"
+    (let [enqueued   (atom nil)
+          enqueue-fn (fn [wf-id]
+                       (reset! enqueued wf-id)
+                       (ok-result {:workflow-id wf-id :queue-size 1}))]
+      ;; Mirrors the finally block in run-workflow! on the success path.
+      (try
+        :simulated-workflow-success
+        (finally
+          (gc-hooks/enqueue-workflow-gc-best-effort! enqueue-fn "wf-normal-exit")))
+      (is (= "wf-normal-exit" @enqueued)
+          "enqueue-fn must be called with the workflow-id on normal completion"))))
+
+;;------------------------------------------------------------------------------ Enqueue in finally block — exception exit
+(deftest ^{:stratum 1} enqueue-called-on-exception-exit-test
+  (testing "Enqueue fires in finally even when the workflow body throws"
+    (let [enqueued   (atom nil)
+          enqueue-fn (fn [wf-id]
+                       (reset! enqueued wf-id)
+                       (ok-result {:workflow-id wf-id :queue-size 1}))]
+      ;; Mirrors the finally block in run-workflow! on the exception path.
+      (try
+        (try
+          (throw (Exception. "simulated workflow failure"))
+          (finally
+            (gc-hooks/enqueue-workflow-gc-best-effort! enqueue-fn "wf-exception-exit")))
+        (catch Exception _ nil))
+      (is (= "wf-exception-exit" @enqueued)
+          "enqueue-fn must be called even when the workflow body throws"))))
+
+;;------------------------------------------------------------------------------ Full lifecycle pattern
+(deftest ^{:stratum 1} full-lifecycle-gc-pass-then-workflow-then-enqueue-test
   (testing "Full GC lifecycle: pass at start → workflow → enqueue in finally"
     (let [gc-started? (atom false)
           enqueued    (atom nil)

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/help/registry_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/help/registry_test.clj
@@ -15,21 +15,22 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.workflow-runner.help.registry-test
   "Shape tests for the pure-data subcommand registry."
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.cli.workflow-runner.help.registry :as sut]))
 
-(deftest registry-covers-every-workflow-runner-subcommand-test
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} registry-covers-every-workflow-runner-subcommand-test
   (testing "subcommands map contains every workflow / chain subcommand by key"
     (is (= #{:workflow-run :workflow-list :workflow-execute :workflow-status
              :workflow-inspect :workflow-cancel :workflow-gc-scratch
              :chain-run :chain-list}
            (set (keys sut/subcommands))))))
 
-(deftest every-subcommand-spec-carries-the-help-flag-test
+(deftest ^{:stratum 0} every-subcommand-spec-carries-the-help-flag-test
   (testing "every registered subcommand spec includes the --help / -h flag"
     (doseq [[subcommand-key entry] sut/subcommands]
       (let [help-spec (get-in entry [:spec :help])]
@@ -38,14 +39,14 @@
         (is (= :h (:alias help-spec))
             (str "subcommand " subcommand-key " must alias --help to -h"))))))
 
-(deftest spec-for-returns-the-registered-flag-spec-test
+(deftest ^{:stratum 0} spec-for-returns-the-registered-flag-spec-test
   (testing "spec-for round-trips through the registry"
     (is (= (get-in sut/subcommands [:workflow-run :spec])
            (sut/spec-for :workflow-run))))
   (testing "spec-for returns nil for unknown keys (callers treat as error)"
     (is (nil? (sut/spec-for :no-such-subcommand)))))
 
-(deftest group-listings-cover-every-child-test
+(deftest ^{:stratum 0} group-listings-cover-every-child-test
   (testing "workflow group lists every workflow-* subcommand"
     (is (= #{:workflow-run :workflow-list :workflow-execute :workflow-status
              :workflow-inspect :workflow-cancel :workflow-gc-scratch}

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/help_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/help_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.workflow-runner.help-test
   "Tests for `--help` / `-h` rendering on workflow-runner CLI subcommands."
   (:require
@@ -24,7 +23,9 @@
    [ai.miniforge.cli.workflow-runner.help :as sut]
    [ai.miniforge.cli.workflow-runner.help.registry :as registry]))
 
-(defn- record-call-fn
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} record-call-fn
   "Factory returning [fn calls-atom]; the fn appends every dispatch
    map it sees to the atom. Lets handler-with-help tests assert
    delegation without coupling to the real subcommand handlers."
@@ -36,17 +37,15 @@
      calls]))
 
 ;------------------------------------------------------------------------------ Layer 0 — predicate
-
-(deftest help-requested?-recognizes-true-and-false-test
+(deftest ^{:stratum 0} help-requested?-recognizes-true-and-false-test
   (testing "truthy when :help is true"
     (is (true? (sut/help-requested? {:help true}))))
   (testing "false when :help is missing or false"
     (is (false? (sut/help-requested? {})))
     (is (false? (sut/help-requested? {:help false})))))
 
-;------------------------------------------------------------------------------ Layer 1 — rendering
-
-(deftest usage-text-renders-subcommand-and-flags-test
+;; rendering
+(deftest ^{:stratum 0} usage-text-renders-subcommand-and-flags-test
   (testing "every subcommand renders a usage block containing its name "
     (testing "and at least one of its declared flags"
       (doseq [[subcommand-key entry] registry/subcommands]
@@ -62,13 +61,13 @@
                   (str "expected " subcommand-key " usage to mention --"
                        flag-name)))))))))
 
-(deftest usage-text-omits-help-flag-from-flag-table-test
+(deftest ^{:stratum 0} usage-text-omits-help-flag-from-flag-table-test
   (testing "the --help flag itself is not listed inside its own usage table"
     (let [entry  (registry/entry-for :workflow-run)
           output (sut/usage-text entry)]
       (is (not (str/includes? output "--help"))))))
 
-(deftest group-usage-text-lists-every-child-subcommand-test
+(deftest ^{:stratum 0} group-usage-text-lists-every-child-subcommand-test
   (testing "workflow group usage lists every workflow subcommand by leaf name"
     (let [output (sut/group-usage-text registry/workflow-group-help)]
       (is (str/includes? output "workflow"))
@@ -82,9 +81,33 @@
         (is (str/includes? output leaf)
             (str "expected chain group usage to list '" leaf "'"))))))
 
-;------------------------------------------------------------------------------ Layer 2 — handler-with-help delegation
+(deftest ^{:stratum 0} handler-with-help-rejects-unknown-subcommand-key-test
+  (testing "wiring an unknown subcommand-key fails fast at construction time"
+    (is (thrown? Exception
+                 (sut/handler-with-help :no-such-subcommand
+                                        (fn [_m] :should-not-run))))))
 
-(deftest handler-with-help-short-circuits-on-help-flag-test
+;; group-handler
+(deftest ^{:stratum 0} group-handler-prints-group-usage-test
+  (testing "workflow group handler prints every workflow subcommand leaf"
+    (let [handler (sut/group-handler registry/workflow-group-help)
+          output  (with-out-str (handler {}))]
+      (doseq [leaf ["run" "list" "execute" "status" "cancel"]]
+        (is (str/includes? output leaf)
+            (str "expected output to list '" leaf "'"))))))
+
+;; per-subcommand sweep
+(deftest ^{:stratum 0} print-usage!-includes-subcommand-name-for-every-registered-entry-test
+  (testing "every entry in the registry renders a usable --help block"
+    (doseq [[subcommand-key entry] registry/subcommands]
+      (let [output (with-out-str (sut/print-usage! entry))]
+        (is (str/includes? output (:subcommand entry))
+            (str subcommand-key " --help output should contain its name"))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; handler-with-help delegation
+(deftest ^{:stratum 1} handler-with-help-short-circuits-on-help-flag-test
   (testing "--help triggers the usage block and does not call the wrapped cmd-fn"
     (let [[cmd-fn calls] (record-call-fn)
           wrapped        (sut/handler-with-help :workflow-run cmd-fn)
@@ -93,7 +116,7 @@
       (is (empty? @calls)
           "cmd-fn must not be invoked when --help is set"))))
 
-(deftest handler-with-help-delegates-when-help-absent-test
+(deftest ^{:stratum 1} handler-with-help-delegates-when-help-absent-test
   (testing "without --help, the wrapped cmd-fn receives the original dispatch map"
     (let [[cmd-fn calls] (record-call-fn)
           wrapped        (sut/handler-with-help :workflow-run cmd-fn)
@@ -101,28 +124,3 @@
       (wrapped dispatch-map)
       (is (= [dispatch-map] @calls)
           "cmd-fn should be called once with the original dispatch map"))))
-
-(deftest handler-with-help-rejects-unknown-subcommand-key-test
-  (testing "wiring an unknown subcommand-key fails fast at construction time"
-    (is (thrown? Exception
-                 (sut/handler-with-help :no-such-subcommand
-                                        (fn [_m] :should-not-run))))))
-
-;------------------------------------------------------------------------------ Layer 2 — group-handler
-
-(deftest group-handler-prints-group-usage-test
-  (testing "workflow group handler prints every workflow subcommand leaf"
-    (let [handler (sut/group-handler registry/workflow-group-help)
-          output  (with-out-str (handler {}))]
-      (doseq [leaf ["run" "list" "execute" "status" "cancel"]]
-        (is (str/includes? output leaf)
-            (str "expected output to list '" leaf "'"))))))
-
-;------------------------------------------------------------------------------ Layer 2 — per-subcommand sweep
-
-(deftest print-usage!-includes-subcommand-name-for-every-registered-entry-test
-  (testing "every entry in the registry renders a usable --help block"
-    (doseq [[subcommand-key entry] registry/subcommands]
-      (let [output (with-out-str (sut/print-usage! entry))]
-        (is (str/includes? output (:subcommand entry))
-            (str subcommand-key " --help output should contain its name"))))))

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/kanban_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/kanban_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.workflow-runner.kanban-test
   "Tests for work spec kanban lifecycle — provenance tracking and file moves."
   (:require
@@ -24,13 +23,14 @@
    [babashka.fs :as fs]
    [ai.miniforge.cli.workflow-runner :as sut]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; ============================================================================
 ;; Helpers
 ;; ============================================================================
+(def ^{:stratum 0} ^:dynamic *test-dir* nil)
 
-(def ^:dynamic *test-dir* nil)
-
-(defn with-temp-work-dir [f]
+(defn ^{:stratum 0} with-temp-work-dir [f]
   (let [dir (str (fs/create-temp-dir {:prefix "kanban-test-"}))]
     (binding [*test-dir* dir]
       (try
@@ -38,9 +38,37 @@
         (finally
           (fs/delete-tree dir))))))
 
-(use-fixtures :each with-temp-work-dir)
+(deftest ^{:stratum 0} move-spec-to-in-progress-non-work-spec-test
+  (testing "non-work spec provenance is returned unchanged"
+    (let [provenance {:source-file "/tmp/not-a-work-spec.edn"}]
+      (is (= provenance (sut/move-spec-to-in-progress! provenance))))))
 
-(defn create-work-spec!
+;; ============================================================================
+;; failure-message
+;; ============================================================================
+(deftest ^{:stratum 0} failure-message-with-errors-test
+  (testing "uses first error entry when errors exist"
+    (let [result {:execution/errors [{:type :gate-failed :message "lint failed"}]
+                  :execution/status :failed}
+          msg (#'sut/failure-message result)]
+      (is (str/includes? msg "lint failed")))))
+
+(deftest ^{:stratum 0} failure-message-without-errors-test
+  (testing "includes execution status when no errors"
+    (let [result {:execution/errors []
+                  :execution/status :failed}
+          msg (#'sut/failure-message result)]
+      (is (str/includes? msg "failed")))))
+
+(deftest ^{:stratum 0} failure-message-nil-errors-test
+  (testing "handles nil errors gracefully"
+    (let [result {:execution/status :timeout}
+          msg (#'sut/failure-message result)]
+      (is (str/includes? msg "timeout")))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} create-work-spec!
   "Create a dummy spec file at work/<name> inside the test dir."
   [name]
   (let [work-dir (str *test-dir* "/work")
@@ -49,7 +77,7 @@
     (spit path "{:spec/title \"test\"}")
     path))
 
-(defmacro with-test-kanban
+(defmacro ^{:stratum 1} with-test-kanban
   "Redirect kanban dirs and work-spec? predicate to use the temp test dir."
   [& body]
   `(let [prefix# (str *test-dir* "/work/")]
@@ -61,11 +89,12 @@
                                       (str/starts-with? (str src#) prefix#)))]
        ~@body)))
 
+;------------------------------------------------------------------------------ Layer 2
+
 ;; ============================================================================
 ;; move-spec-to-in-progress! returns updated provenance
 ;; ============================================================================
-
-(deftest move-spec-to-in-progress-returns-updated-provenance-test
+(deftest ^{:stratum 2} move-spec-to-in-progress-returns-updated-provenance-test
   (testing "provenance source-file is updated to the new in-progress path"
     (let [spec-path (create-work-spec! "test.spec.edn")
           provenance {:source-file spec-path}]
@@ -76,7 +105,7 @@
           (is (fs/exists? (:source-file updated)))
           (is (not (fs/exists? spec-path))))))))
 
-(deftest move-spec-on-completion-uses-updated-provenance-test
+(deftest ^{:stratum 2} move-spec-on-completion-uses-updated-provenance-test
   (testing "after move-to-in-progress, move-on-completion finds the file"
     (let [spec-path (create-work-spec! "lifecycle.spec.edn")
           provenance {:source-file spec-path}]
@@ -87,7 +116,7 @@
           (is (fs/exists? (str *test-dir* "/work/done/lifecycle.spec.edn")))
           (is (not (fs/exists? (:source-file updated)))))))))
 
-(deftest move-spec-on-failure-uses-updated-provenance-test
+(deftest ^{:stratum 2} move-spec-on-failure-uses-updated-provenance-test
   (testing "failed workflow moves spec to failed directory"
     (let [spec-path (create-work-spec! "broken.spec.edn")
           provenance {:source-file spec-path}]
@@ -97,31 +126,4 @@
           (is (fs/exists? (str *test-dir* "/work/failed/broken.spec.edn")))
           (is (not (fs/exists? (:source-file updated)))))))))
 
-(deftest move-spec-to-in-progress-non-work-spec-test
-  (testing "non-work spec provenance is returned unchanged"
-    (let [provenance {:source-file "/tmp/not-a-work-spec.edn"}]
-      (is (= provenance (sut/move-spec-to-in-progress! provenance))))))
-
-;; ============================================================================
-;; failure-message
-;; ============================================================================
-
-(deftest failure-message-with-errors-test
-  (testing "uses first error entry when errors exist"
-    (let [result {:execution/errors [{:type :gate-failed :message "lint failed"}]
-                  :execution/status :failed}
-          msg (#'sut/failure-message result)]
-      (is (str/includes? msg "lint failed")))))
-
-(deftest failure-message-without-errors-test
-  (testing "includes execution status when no errors"
-    (let [result {:execution/errors []
-                  :execution/status :failed}
-          msg (#'sut/failure-message result)]
-      (is (str/includes? msg "failed")))))
-
-(deftest failure-message-nil-errors-test
-  (testing "handles nil errors gracefully"
-    (let [result {:execution/status :timeout}
-          msg (#'sut/failure-message result)]
-      (is (str/includes? msg "timeout")))))
+(use-fixtures :each with-temp-work-dir)

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/manifest_wiring_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/manifest_wiring_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.workflow-runner.manifest-wiring-test
   "Unit tests for the BD-2b sub-3a manifest wiring helpers in
    `workflow_runner.clj`. The manifest module itself
@@ -29,9 +28,10 @@
    [ai.miniforge.event-stream.interface :as es]
    [clojure.test :refer [deftest is]]))
 
-;------------------------------------------------------------------------------ Fixture
+;------------------------------------------------------------------------------ Layer 0
 
-(defn- mock-manifest-fns
+;------------------------------------------------------------------------------ Fixture
+(defn- ^{:stratum 0} mock-manifest-fns
   "Build a map of mock manifest fns recording every call into `calls`.
    `start-heartbeat!` returns a sentinel handle that `stop-heartbeat!`
    recognises."
@@ -50,7 +50,65 @@
                          heartbeat-handle)
      'stop-heartbeat!  (fn [hb] (swap! calls conj [:stop-heartbeat hb]))}))
 
-(defn- with-mocked-manifest
+;------------------------------------------------------------------------------ archive-workflow-manifest!
+(deftest ^{:stratum 0} archive-workflow-manifest!-no-op-when-marked?-false
+  ;; If mark-manifest-terminal! never wrote (manifest absent or no
+  ;; event stream), there's nothing to archive — the archive op
+  ;; would error on the missing manifest. Skip in that case.
+  (let [archive-calls (atom [])]
+    (with-redefs [sut/*manifest-ops* {:archive-workflow! (fn [& args]
+                                                           (swap! archive-calls conj args))}]
+      (let [handle {:dir (java.io.File. "/tmp/x") :marked? (atom false)}]
+        (sut/archive-workflow-manifest! handle :wid)
+        (is (empty? @archive-calls)
+            "no archive call when marked? is false")))))
+
+(deftest ^{:stratum 0} archive-workflow-manifest!-no-op-when-dir-nil
+  ;; nil dir means dashboard-only run; no manifest to archive.
+  (let [archive-calls (atom [])]
+    (with-redefs [sut/*manifest-ops* {:archive-workflow! (fn [& args]
+                                                           (swap! archive-calls conj args))}]
+      (sut/archive-workflow-manifest! {:dir nil :marked? (atom true)} :wid)
+      (is (empty? @archive-calls)))))
+
+(deftest ^{:stratum 0} archive-workflow-manifest!-invokes-archive-workflow!
+  (let [archive-calls (atom [])]
+    (with-redefs [sut/*manifest-ops* {:archive-workflow! (fn [& args]
+                                                           (swap! archive-calls conj args))}]
+      (sut/archive-workflow-manifest!
+       {:dir (java.io.File. "/tmp/x") :marked? (atom true)}
+       :wid)
+      (is (= [[:wid]] @archive-calls)
+          "archive-workflow! called once with the workflow id"))))
+
+(deftest ^{:stratum 0} archive-workflow-manifest!-swallows-archive-failures
+  ;; Per the docstring, archive failures must not propagate — the
+  ;; boot-time recovery pass picks up half-finished archives. A
+  ;; failing archive should log to stderr and return nil.
+  (with-redefs [sut/*manifest-ops* {:archive-workflow! (fn [& _]
+                                                         (throw (RuntimeException. "rename failed")))}]
+    (binding [*err* (java.io.PrintWriter. (java.io.StringWriter.))]
+      (is (nil? (sut/archive-workflow-manifest!
+                 {:dir (java.io.File. "/tmp/x") :marked? (atom true)}
+                 :wid))
+          "archive exception must not propagate"))))
+
+(deftest ^{:stratum 0} archive-workflow-manifest!-logs-archive-anomalies
+  (let [archive-anomaly (anomaly/anomaly :invalid-input
+                                         "manifest invalid"
+                                         {:reason :test})]
+    (with-redefs [sut/*manifest-ops* {:archive-workflow! (fn [& _]
+                                                           archive-anomaly)}]
+      (let [err (java.io.StringWriter.)]
+        (binding [*err* err]
+          (is (nil? (sut/archive-workflow-manifest!
+                     {:dir (java.io.File. "/tmp/x") :marked? (atom true)}
+                     :wid)))
+          (is (re-find #"manifest invalid" (str err))))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} with-mocked-manifest
   "Bind manifest interface functions. Returns whatever `f` returns;
    the call log is in `calls`."
   [f]
@@ -66,48 +124,7 @@
                   es/workflow-dir (fn [wid] (java.io.File. (str "/tmp/test-" wid)))]
       (f calls))))
 
-;------------------------------------------------------------------------------ start-workflow-manifest!
-
-(deftest start-workflow-manifest!-no-op-when-event-stream-is-nil
-  (with-mocked-manifest
-    (fn [calls]
-      (is (nil? (sut/start-workflow-manifest! :wid nil)))
-      (is (empty? @calls)
-          "no manifest writes when there's no event stream
-           (dashboard-only runs don't persist events)"))))
-
-(deftest start-workflow-manifest!-inits-and-starts-heartbeat
-  (with-mocked-manifest
-    (fn [calls]
-      (let [handle (sut/start-workflow-manifest! :wid :fake-es)
-            ordered (mapv first @calls)]
-        (is (some? handle))
-        (is (some? (:dir handle)))
-        (is (= :mock-heartbeat-handle (:heartbeat handle)))
-        (is (false? @(:marked? handle))
-            "marked? starts false; flips on first mark-manifest-terminal!")
-        (is (= [:init-active :save :start-heartbeat] ordered)
-            "lifecycle order: build active manifest → save → start heartbeat")))))
-
-;------------------------------------------------------------------------------ mark-manifest-terminal!
-
-(deftest mark-manifest-terminal!-no-op-when-handle-nil
-  (with-mocked-manifest
-    (fn [calls]
-      (sut/mark-manifest-terminal! nil :completed)
-      (is (empty? @calls)))))
-
-(deftest mark-manifest-terminal!-loads-marks-and-saves
-  (with-mocked-manifest
-    (fn [calls]
-      (let [handle (sut/start-workflow-manifest! :wid :fake-es)]
-        (reset! calls [])
-        (sut/mark-manifest-terminal! handle :completed)
-        (is (= [:load :mark-terminal :save] (mapv first @calls))
-            "mark-terminal must load → transition → save in order")
-        (is (true? @(:marked? handle)))))))
-
-(deftest mark-manifest-terminal!-leaves-marked?-false-when-manifest-absent
+(deftest ^{:stratum 1} mark-manifest-terminal!-leaves-marked?-false-when-manifest-absent
   ;; load-manifest returns nil when the file isn't on disk (e.g. the
   ;; archive flow moved it between ticks). Marking must not flip the
   ;; idempotency flag in that case — otherwise the finally's
@@ -135,39 +152,7 @@
         (is (= [:load] (mapv first @calls))
             "load was attempted but no save fired (nothing to update)")))))
 
-(deftest mark-manifest-terminal!-idempotent-via-marked?
-  (with-mocked-manifest
-    (fn [calls]
-      (let [handle (sut/start-workflow-manifest! :wid :fake-es)]
-        (reset! calls [])
-        (sut/mark-manifest-terminal! handle :completed)
-        ;; Second call (e.g. the finally block firing :cancelled after
-        ;; the happy path already marked :completed) must be a no-op
-        ;; so we don't overwrite the success status.
-        (sut/mark-manifest-terminal! handle :cancelled)
-        (let [statuses (filter #(= :mark-terminal (first %)) @calls)]
-          (is (= 1 (count statuses))
-              "second mark-manifest-terminal! must not fire after marked? is true")
-          (is (= [:mark-terminal :completed] (first statuses))
-              "the first status sticks"))))))
-
-;------------------------------------------------------------------------------ finish-workflow-manifest!
-
-(deftest finish-workflow-manifest!-no-op-when-handle-nil
-  (with-mocked-manifest
-    (fn [calls]
-      (sut/finish-workflow-manifest! nil)
-      (is (empty? @calls)))))
-
-(deftest finish-workflow-manifest!-stops-heartbeat
-  (with-mocked-manifest
-    (fn [calls]
-      (let [handle (sut/start-workflow-manifest! :wid :fake-es)]
-        (reset! calls [])
-        (sut/finish-workflow-manifest! handle)
-        (is (= [[:stop-heartbeat :mock-heartbeat-handle]] @calls))))))
-
-(deftest finish-workflow-manifest!-swallows-throwables
+(deftest ^{:stratum 1} finish-workflow-manifest!-swallows-throwables
   ;; stop-heartbeat! is called from a finally block during shutdown.
   ;; An IO failure there must not mask the actual workflow result.
   (let [calls (atom [])
@@ -185,64 +170,7 @@
         (is (nil? (sut/finish-workflow-manifest! handle))
             "stop-heartbeat! throw must not propagate")))))
 
-;------------------------------------------------------------------------------ archive-workflow-manifest!
-
-(deftest archive-workflow-manifest!-no-op-when-marked?-false
-  ;; If mark-manifest-terminal! never wrote (manifest absent or no
-  ;; event stream), there's nothing to archive — the archive op
-  ;; would error on the missing manifest. Skip in that case.
-  (let [archive-calls (atom [])]
-    (with-redefs [sut/*manifest-ops* {:archive-workflow! (fn [& args]
-                                                           (swap! archive-calls conj args))}]
-      (let [handle {:dir (java.io.File. "/tmp/x") :marked? (atom false)}]
-        (sut/archive-workflow-manifest! handle :wid)
-        (is (empty? @archive-calls)
-            "no archive call when marked? is false")))))
-
-(deftest archive-workflow-manifest!-no-op-when-dir-nil
-  ;; nil dir means dashboard-only run; no manifest to archive.
-  (let [archive-calls (atom [])]
-    (with-redefs [sut/*manifest-ops* {:archive-workflow! (fn [& args]
-                                                           (swap! archive-calls conj args))}]
-      (sut/archive-workflow-manifest! {:dir nil :marked? (atom true)} :wid)
-      (is (empty? @archive-calls)))))
-
-(deftest archive-workflow-manifest!-invokes-archive-workflow!
-  (let [archive-calls (atom [])]
-    (with-redefs [sut/*manifest-ops* {:archive-workflow! (fn [& args]
-                                                           (swap! archive-calls conj args))}]
-      (sut/archive-workflow-manifest!
-       {:dir (java.io.File. "/tmp/x") :marked? (atom true)}
-       :wid)
-      (is (= [[:wid]] @archive-calls)
-          "archive-workflow! called once with the workflow id"))))
-
-(deftest archive-workflow-manifest!-swallows-archive-failures
-  ;; Per the docstring, archive failures must not propagate — the
-  ;; boot-time recovery pass picks up half-finished archives. A
-  ;; failing archive should log to stderr and return nil.
-  (with-redefs [sut/*manifest-ops* {:archive-workflow! (fn [& _]
-                                                         (throw (RuntimeException. "rename failed")))}]
-    (binding [*err* (java.io.PrintWriter. (java.io.StringWriter.))]
-      (is (nil? (sut/archive-workflow-manifest!
-                 {:dir (java.io.File. "/tmp/x") :marked? (atom true)}
-                 :wid))
-          "archive exception must not propagate"))))
-
-(deftest archive-workflow-manifest!-logs-archive-anomalies
-  (let [archive-anomaly (anomaly/anomaly :invalid-input
-                                         "manifest invalid"
-                                         {:reason :test})]
-    (with-redefs [sut/*manifest-ops* {:archive-workflow! (fn [& _]
-                                                           archive-anomaly)}]
-      (let [err (java.io.StringWriter.)]
-        (binding [*err* err]
-          (is (nil? (sut/archive-workflow-manifest!
-                     {:dir (java.io.File. "/tmp/x") :marked? (atom true)}
-                     :wid)))
-          (is (re-find #"manifest invalid" (str err))))))))
-
-(deftest finish-workflow-manifest!-restores-interrupt-flag
+(deftest ^{:stratum 1} finish-workflow-manifest!-restores-interrupt-flag
   ;; stop-heartbeat! raises InterruptedException via awaitTermination.
   ;; Swallowing it without restoring the thread's interrupt flag
   ;; breaks cooperative cancellation — outer frames lose the signal
@@ -270,3 +198,75 @@
         (is (true? interrupted?)
             "current thread's interrupt flag must be restored
              so cooperative-cancellation callers above us see it")))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;------------------------------------------------------------------------------ start-workflow-manifest!
+(deftest ^{:stratum 2} start-workflow-manifest!-no-op-when-event-stream-is-nil
+  (with-mocked-manifest
+    (fn [calls]
+      (is (nil? (sut/start-workflow-manifest! :wid nil)))
+      (is (empty? @calls)
+          "no manifest writes when there's no event stream
+           (dashboard-only runs don't persist events)"))))
+
+(deftest ^{:stratum 2} start-workflow-manifest!-inits-and-starts-heartbeat
+  (with-mocked-manifest
+    (fn [calls]
+      (let [handle (sut/start-workflow-manifest! :wid :fake-es)
+            ordered (mapv first @calls)]
+        (is (some? handle))
+        (is (some? (:dir handle)))
+        (is (= :mock-heartbeat-handle (:heartbeat handle)))
+        (is (false? @(:marked? handle))
+            "marked? starts false; flips on first mark-manifest-terminal!")
+        (is (= [:init-active :save :start-heartbeat] ordered)
+            "lifecycle order: build active manifest → save → start heartbeat")))))
+
+;------------------------------------------------------------------------------ mark-manifest-terminal!
+(deftest ^{:stratum 2} mark-manifest-terminal!-no-op-when-handle-nil
+  (with-mocked-manifest
+    (fn [calls]
+      (sut/mark-manifest-terminal! nil :completed)
+      (is (empty? @calls)))))
+
+(deftest ^{:stratum 2} mark-manifest-terminal!-loads-marks-and-saves
+  (with-mocked-manifest
+    (fn [calls]
+      (let [handle (sut/start-workflow-manifest! :wid :fake-es)]
+        (reset! calls [])
+        (sut/mark-manifest-terminal! handle :completed)
+        (is (= [:load :mark-terminal :save] (mapv first @calls))
+            "mark-terminal must load → transition → save in order")
+        (is (true? @(:marked? handle)))))))
+
+(deftest ^{:stratum 2} mark-manifest-terminal!-idempotent-via-marked?
+  (with-mocked-manifest
+    (fn [calls]
+      (let [handle (sut/start-workflow-manifest! :wid :fake-es)]
+        (reset! calls [])
+        (sut/mark-manifest-terminal! handle :completed)
+        ;; Second call (e.g. the finally block firing :cancelled after
+        ;; the happy path already marked :completed) must be a no-op
+        ;; so we don't overwrite the success status.
+        (sut/mark-manifest-terminal! handle :cancelled)
+        (let [statuses (filter #(= :mark-terminal (first %)) @calls)]
+          (is (= 1 (count statuses))
+              "second mark-manifest-terminal! must not fire after marked? is true")
+          (is (= [:mark-terminal :completed] (first statuses))
+              "the first status sticks"))))))
+
+;------------------------------------------------------------------------------ finish-workflow-manifest!
+(deftest ^{:stratum 2} finish-workflow-manifest!-no-op-when-handle-nil
+  (with-mocked-manifest
+    (fn [calls]
+      (sut/finish-workflow-manifest! nil)
+      (is (empty? @calls)))))
+
+(deftest ^{:stratum 2} finish-workflow-manifest!-stops-heartbeat
+  (with-mocked-manifest
+    (fn [calls]
+      (let [handle (sut/start-workflow-manifest! :wid :fake-es)]
+        (reset! calls [])
+        (sut/finish-workflow-manifest! handle)
+        (is (= [[:stop-heartbeat :mock-heartbeat-handle]] @calls))))))

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/operator_wiring_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/operator_wiring_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.workflow-runner.operator-wiring-test
   (:require
    [ai.miniforge.agent.interface :as agent]
@@ -28,7 +27,7 @@
 
 ;------------------------------------------------------------------------------ Layer 0
 
-(defn- with-clean-operator-state
+(defn- ^{:stratum 0} with-clean-operator-state
   [f]
   (let [context-state (var-get #'sut/meta-loop-ctx)
         consumer-state (var-get #'sut/operator-consumer-handle)
@@ -44,7 +43,7 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
-(deftest workflow-registration-starts-one-process-consumer
+(deftest ^{:stratum 1} workflow-registration-starts-one-process-consumer
   (with-clean-operator-state
     (fn []
       (let [starts (atom [])
@@ -83,7 +82,7 @@
           (is (identical? operator/live-intervention-stream
                           (:stream-for (first @starts)))))))))
 
-(deftest consumer-startup-failure-deregisters-the-runner
+(deftest ^{:stratum 1} consumer-startup-failure-deregisters-the-runner
   (testing "registration is rolled back before startup failure propagates"
     (with-clean-operator-state
       (fn []

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/preflight_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/preflight_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.workflow-runner.preflight-test
   (:require
    [babashka.fs :as fs]
@@ -25,23 +24,18 @@
    [ai.miniforge.llm.interface :as llm]
    [ai.miniforge.cli.workflow-runner :as sut]))
 
-(defn- temp-repo-root []
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} temp-repo-root []
   (let [root (str (fs/create-temp-dir {:prefix "mf-preflight-"}))]
     (fs/create-dirs (fs/path root ".git"))
     root))
 
-(defn- shell-path []
+(defn- ^{:stratum 0} shell-path []
   (or (some-> (fs/which "sh") str)
       "/bin/sh"))
 
-(deftest run-cli-command-captures-short-lived-process-output-test
-  (testing "probe helper captures stdout, stderr, and exit code for short-lived commands"
-    (let [result (#'sut/run-cli-command [(shell-path) "-lc" "printf ok; printf warn >&2"] 5000)]
-      (is (= "ok" (:out result)))
-      (is (= "warn" (:err result)))
-      (is (= 0 (:exit result))))))
-
-(deftest await-stream-waits-for-reader-completion-test
+(deftest ^{:stratum 0} await-stream-waits-for-reader-completion-test
   (testing "stream join waits for a completed reader instead of dropping late output"
     (let [started-at (System/currentTimeMillis)
           result (#'sut/await-stream (future
@@ -51,44 +45,7 @@
       (is (= "late-output" result))
       (is (<= 1000 elapsed-ms)))))
 
-(deftest run-cli-command-times-out-fast-test
-  (testing "probe helper returns a timeout result instead of hanging the caller"
-    (let [result (#'sut/run-cli-command [(shell-path) "-lc" "sleep 1"] 10)]
-      (is (= -1 (:exit result)))
-      (is (= 10 (:timeout-ms result)))
-      (is (str/includes? (:err result) "10")))))
-
-(deftest assert-runtime-alignment-rejects-worktree-mismatch-test
-  (testing "explicit execution worktree must survive into runtime context"
-    (let [source-root (temp-repo-root)
-          source-dir (str (fs/path source-root "work"))]
-      (try+
-        (#'sut/assert-runtime-alignment!
-         {:spec/source-dir source-dir}
-         {:source-root source-root
-          :worktree-path "/tmp/runtime-worktree"
-          :execution/opts {:worktree-path "/tmp/expected-worktree"}})
-        (is false "expected execution worktree mismatch anomaly")
-        (catch [:anomaly/category :anomalies/incorrect]
-               {:keys [expected-worktree actual-worktree]}
-          (is (= "/tmp/expected-worktree" expected-worktree))
-          (is (= "/tmp/runtime-worktree" actual-worktree)))))))
-
-(deftest assert-runtime-alignment-rejects-source-dir-outside-root-test
-  (testing "spec source directory must stay under the resolved source root"
-    (let [source-root (temp-repo-root)]
-      (try+
-        (#'sut/assert-runtime-alignment!
-         {:spec/source-dir "/tmp/outside-spec-root"}
-         {:source-root source-root
-          :worktree-path "/tmp/runtime-worktree"
-          :execution/opts {:worktree-path "/tmp/runtime-worktree"}})
-        (is false "expected source-dir alignment anomaly")
-        (catch [:anomaly/category :anomalies/incorrect]
-               {:keys [source-dir]}
-          (is (= "/tmp/outside-spec-root" source-dir)))))))
-
-(deftest print-runtime-provenance-includes-startup-warnings-test
+(deftest ^{:stratum 0} print-runtime-provenance-includes-startup-warnings-test
   (testing "startup provenance prints upstream and source checkout warnings"
     (let [output (with-out-str
                    (#'sut/print-runtime-provenance!
@@ -106,19 +63,7 @@
       (is (str/includes? output "detached HEAD"))
       (is (str/includes? output "uncommitted changes")))))
 
-(deftest assert-runtime-alignment-normalizes-parent-segments-test
-  (testing "source-dir alignment accepts normalized paths under the source root"
-    (let [source-root (temp-repo-root)
-          nested-work (str (fs/path source-root "work" "nested"))]
-      (fs/create-dirs nested-work)
-      (#'sut/assert-runtime-alignment!
-       {:spec/source-dir (str (fs/path nested-work ".."))}
-       {:source-root source-root
-        :worktree-path "/tmp/runtime-worktree"
-        :execution/opts {:worktree-path "/tmp/runtime-worktree"}})
-      (is true))))
-
-(deftest run-backend-preflight-stamps-resolved-cli-and-version-test
+(deftest ^{:stratum 0} run-backend-preflight-stamps-resolved-cli-and-version-test
   (testing "backend preflight resolves the inherited CLI path and prints the stamp"
     (let [llm-client (llm/mock-client {:output "{\"ok\":true}"})
           preflight-client (atom nil)
@@ -144,7 +89,7 @@
       (is (str/includes? output "Backend Version: 2.1.126"))
       (is (nil? @preflight-client)))))
 
-(deftest run-backend-preflight-fails-closed-on-bad-cli-health-test
+(deftest ^{:stratum 0} run-backend-preflight-fails-closed-on-bad-cli-health-test
   (testing "backend preflight carries the resolved path and version when the probe fails"
     (let [llm-client (llm/mock-client {:output "{\"ok\":true}"})]
       (try+
@@ -168,7 +113,7 @@
           (is (= "2.1.89" cmd-version))
           (is (= "backend_preflight_timeout" (get-in probe-response [:error :type]))))))))
 
-(deftest run-backend-preflight-accepts-claude-result-wrapper-test
+(deftest ^{:stratum 0} run-backend-preflight-accepts-claude-result-wrapper-test
   (testing "Claude preflight accepts success envelopes whose result field contains the canonical payload"
     (let [llm-client (llm/mock-client {:output "{\"ok\":true}"})
           output (with-out-str
@@ -187,7 +132,7 @@
       (is (str/includes? output "Backend Path: /opt/homebrew/bin/claude"))
       (is (str/includes? output "Backend Version: 2.1.118 (Claude Code)")))))
 
-(deftest run-backend-preflight-rejects-claude-error-wrapper-test
+(deftest ^{:stratum 0} run-backend-preflight-rejects-claude-error-wrapper-test
   (testing "Claude preflight rejects wrapped payloads when the outer result envelope is not successful"
     (let [llm-client (llm/mock-client {:output "{\"ok\":true}"})]
       (try+
@@ -209,7 +154,7 @@
                  (get-in probe-response [:error :data :type])))
           (is (nil? (:content probe-response))))))))
 
-(deftest run-backend-preflight-exercises-generic-cli-success-path-test
+(deftest ^{:stratum 0} run-backend-preflight-exercises-generic-cli-success-path-test
   (testing "non-Claude CLI backends decode streamed CLI output and accept the canonical ok payload"
     (let [llm-client (llm/create-client {:backend :codex})
           seen-cmd (atom nil)
@@ -238,3 +183,61 @@
       (is (= "Reply with exactly {\"ok\":true}" (last @seen-cmd)))
       (is (= 30000 @seen-timeout))
       (is (= "/tmp/runtime-worktree" @seen-workdir)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} run-cli-command-captures-short-lived-process-output-test
+  (testing "probe helper captures stdout, stderr, and exit code for short-lived commands"
+    (let [result (#'sut/run-cli-command [(shell-path) "-lc" "printf ok; printf warn >&2"] 5000)]
+      (is (= "ok" (:out result)))
+      (is (= "warn" (:err result)))
+      (is (= 0 (:exit result))))))
+
+(deftest ^{:stratum 1} run-cli-command-times-out-fast-test
+  (testing "probe helper returns a timeout result instead of hanging the caller"
+    (let [result (#'sut/run-cli-command [(shell-path) "-lc" "sleep 1"] 10)]
+      (is (= -1 (:exit result)))
+      (is (= 10 (:timeout-ms result)))
+      (is (str/includes? (:err result) "10")))))
+
+(deftest ^{:stratum 1} assert-runtime-alignment-rejects-worktree-mismatch-test
+  (testing "explicit execution worktree must survive into runtime context"
+    (let [source-root (temp-repo-root)
+          source-dir (str (fs/path source-root "work"))]
+      (try+
+        (#'sut/assert-runtime-alignment!
+         {:spec/source-dir source-dir}
+         {:source-root source-root
+          :worktree-path "/tmp/runtime-worktree"
+          :execution/opts {:worktree-path "/tmp/expected-worktree"}})
+        (is false "expected execution worktree mismatch anomaly")
+        (catch [:anomaly/category :anomalies/incorrect]
+               {:keys [expected-worktree actual-worktree]}
+          (is (= "/tmp/expected-worktree" expected-worktree))
+          (is (= "/tmp/runtime-worktree" actual-worktree)))))))
+
+(deftest ^{:stratum 1} assert-runtime-alignment-rejects-source-dir-outside-root-test
+  (testing "spec source directory must stay under the resolved source root"
+    (let [source-root (temp-repo-root)]
+      (try+
+        (#'sut/assert-runtime-alignment!
+         {:spec/source-dir "/tmp/outside-spec-root"}
+         {:source-root source-root
+          :worktree-path "/tmp/runtime-worktree"
+          :execution/opts {:worktree-path "/tmp/runtime-worktree"}})
+        (is false "expected source-dir alignment anomaly")
+        (catch [:anomaly/category :anomalies/incorrect]
+               {:keys [source-dir]}
+          (is (= "/tmp/outside-spec-root" source-dir)))))))
+
+(deftest ^{:stratum 1} assert-runtime-alignment-normalizes-parent-segments-test
+  (testing "source-dir alignment accepts normalized paths under the source root"
+    (let [source-root (temp-repo-root)
+          nested-work (str (fs/path source-root "work" "nested"))]
+      (fs/create-dirs nested-work)
+      (#'sut/assert-runtime-alignment!
+       {:spec/source-dir (str (fs/path nested-work ".."))}
+       {:source-root source-root
+        :worktree-path "/tmp/runtime-worktree"
+        :execution/opts {:worktree-path "/tmp/runtime-worktree"}})
+      (is true))))

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/runner_control_wiring_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/runner_control_wiring_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.workflow-runner.runner-control-wiring-test
   "Phase D D-4: every CLI runner path joins the governed control path.
 
@@ -41,9 +40,9 @@
    [clojure.test :refer [deftest is testing]]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Recording harness
 
-(defn- recorder
+;; Recording harness
+(defn- ^{:stratum 0} recorder
   "Redef map that records registration/release calls into `calls`."
   [calls]
   {:register (fn [workflow-id control-state event-stream]
@@ -56,11 +55,30 @@
               (swap! calls conj {:call :release :workflow-id workflow-id})
               nil)})
 
-(defn- calls-of
+(defn- ^{:stratum 0} calls-of
   [calls call-type]
   (filterv #(= call-type (:call %)) @calls))
 
-(defn- registered-and-released?
+(deftest ^{:stratum 0} governed-workflow-id-is-always-a-uuid
+  (testing "the operator channel routes by UUID, so a governed run must have one"
+    (let [gwid #'runner/governed-workflow-id]
+      ;; a UUID session-id is adopted as-is
+      (let [u (random-uuid)]
+        (is (= u (gwid u true))))
+      ;; a UUID *string* is parsed and adopted (same run, controllable)
+      (let [u (random-uuid)]
+        (is (= u (gwid (str u) true))))
+      ;; a non-UUID session-id is discarded for a fresh UUID rather than
+      ;; leaving the run uncontrollable
+      (is (uuid? (gwid "named-session" true)))
+      (is (not= "named-session" (gwid "named-session" true)))
+      ;; an absent session-id is the normal case: a fresh UUID
+      (is (uuid? (gwid nil true)))
+      (is (uuid? (gwid :a-keyword true))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} registered-and-released?
   "The same workflow id was registered once and released once."
   [calls]
   (let [registered (mapv :workflow-id (calls-of calls :register))
@@ -68,10 +86,10 @@
     (and (= 1 (count registered))
          (= registered released))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Chain runner
+;------------------------------------------------------------------------------ Layer 2
 
-(deftest chain-runner-registers-and-releases-control
+;; Chain runner
+(deftest ^{:stratum 2} chain-runner-registers-and-releases-control
   (testing "run-chain! joins the governed control path"
     (let [calls (atom [])
           {:keys [register release]} (recorder calls)
@@ -98,7 +116,7 @@
           (is (identical? stream (:event-stream registration)))
           (is (some? (:control-state registration))))))))
 
-(deftest chain-runner-releases-control-when-the-chain-throws
+(deftest ^{:stratum 2} chain-runner-releases-control-when-the-chain-throws
   (testing "a failed chain still stops claiming interventions"
     (let [calls (atom [])
           {:keys [register release]} (recorder calls)
@@ -122,10 +140,8 @@
                               (runner/run-chain! :some-chain {:quiet true})))
         (is (registered-and-released? calls))))))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Plan executor
-
-(deftest plan-executor-registers-and-releases-control
+(deftest ^{:stratum 2} plan-executor-registers-and-releases-control
   (testing "execute-plan joins the governed control path"
     (let [calls (atom [])
           {:keys [register release]} (recorder calls)
@@ -146,7 +162,7 @@
           (is (identical? stream (:event-stream registration)))
           (is (some? (:control-state registration))))))))
 
-(deftest plan-executor-releases-control-when-the-plan-throws
+(deftest ^{:stratum 2} plan-executor-releases-control-when-the-plan-throws
   (testing "a failed plan still stops claiming interventions"
     (let [calls (atom [])
           {:keys [register release]} (recorder calls)
@@ -166,20 +182,3 @@
                               (plan-executor/execute-plan
                                {:plan/id "p1" :plan/tasks []} {:quiet true})))
         (is (registered-and-released? calls))))))
-
-(deftest governed-workflow-id-is-always-a-uuid
-  (testing "the operator channel routes by UUID, so a governed run must have one"
-    (let [gwid #'runner/governed-workflow-id]
-      ;; a UUID session-id is adopted as-is
-      (let [u (random-uuid)]
-        (is (= u (gwid u true))))
-      ;; a UUID *string* is parsed and adopted (same run, controllable)
-      (let [u (random-uuid)]
-        (is (= u (gwid (str u) true))))
-      ;; a non-UUID session-id is discarded for a fresh UUID rather than
-      ;; leaving the run uncontrollable
-      (is (uuid? (gwid "named-session" true)))
-      (is (not= "named-session" (gwid "named-session" true)))
-      ;; an absent session-id is the normal case: a fresh UUID
-      (is (uuid? (gwid nil true)))
-      (is (uuid? (gwid :a-keyword true))))))

--- a/bases/cli/test/ai/miniforge/cli/workflow_selection_config_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_selection_config_test.clj
@@ -15,20 +15,21 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.workflow-selection-config-test
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.cli.workflow-selection-config :as cfg]))
 
-(deftest configured-selection-profiles-test
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} configured-selection-profiles-test
   (testing "software-factory workflow selection profiles load from resources"
     (let [profiles (cfg/configured-selection-profiles)]
       (is (= :canonical-sdlc (:comprehensive profiles)))
       (is (= :quick-fix (:fast profiles)))
       (is (= :canonical-sdlc (:default profiles))))))
 
-(deftest resolve-selection-profile-test
+(deftest ^{:stratum 0} resolve-selection-profile-test
   (testing "configured profiles resolve to available workflows"
     (let [available-workflows [{:workflow/id :canonical-sdlc
                                 :workflow/phases [{:phase/id :explore}

--- a/bases/cli/test/ai/miniforge/cli/workflow_selector_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_selector_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.workflow-selector-test
   "Tests for intelligent workflow selection."
   (:require
@@ -23,9 +22,10 @@
    [ai.miniforge.cli.messages :as messages]
    [ai.miniforge.cli.workflow-selector :as ws]))
 
-;------------------------------------------------------------------------------ Test Data
+;------------------------------------------------------------------------------ Layer 0
 
-(def multi-phase-refactor-spec
+;------------------------------------------------------------------------------ Test Data
+(def ^{:stratum 0} multi-phase-refactor-spec
   "Emojui-style spec with 6 PRs and stratified design"
   {:spec/title "Memento Views Refactor"
    :spec/description "Multi-phase refactor of 5 memory view pages to follow stratified design"
@@ -40,52 +40,78 @@
      :pr-7-heatmap-view {:branch "feature/memento-heatmap-view"}}}
    :spec/constraints ["Follow stratified design" "≤400 lines per file (Rule 720)"]})
 
-(def bugfix-spec
+(def ^{:stratum 0} bugfix-spec
   "Simple bug fix spec"
   {:spec/title "Fix authentication timeout"
    :spec/description "Fix bug where auth token expires too quickly"
    :spec/intent {:type :bugfix}})
 
-(def docs-spec
+(def ^{:stratum 0} docs-spec
   "Documentation-only spec"
   {:spec/title "Update API documentation"
    :spec/description "Update API docs only"
    :spec/intent {:type :docs}})
 
-(def large-feature-spec
+(def ^{:stratum 0} large-feature-spec
   "Large feature without explicit phases"
   {:spec/title "Add new payment system"
    :spec/description "Large comprehensive payment processing system with Stripe integration"
    :spec/raw-data {:type :feature}})
 
-(def small-feature-spec
+(def ^{:stratum 0} small-feature-spec
   "Small feature spec"
   {:spec/title "Add tooltip"
    :spec/description "Add simple tooltip to button"
    :spec/raw-data {:type :feature}})
 
-(def explicit-workflow-spec
+(def ^{:stratum 0} explicit-workflow-spec
   "Spec with explicit workflow-type"
   {:spec/title "Custom workflow"
    :spec/workflow-type :simple-test-v1
    :spec/description "Test with explicit workflow"})
 
-(def refactor-with-rule-210-spec
+(def ^{:stratum 0} refactor-with-rule-210-spec
   "Refactoring spec mentioning Rule 210"
   {:spec/title "Stratified refactor"
    :spec/description "Refactor to use layered architecture"
    :spec/raw-data {:type :refactoring}
    :spec/constraints ["≤3 layers (Rule 210)" "Stratified design"]})
 
-(def unknown-spec
+(def ^{:stratum 0} unknown-spec
   "Spec with minimal information"
   {:spec/title "Do something"
    :spec/description "Something needs to be done"})
 
-;------------------------------------------------------------------------------ Layer 0 Tests
-;; Spec analysis
+(deftest ^{:stratum 0} explain-selection-test
+  (testing "explain-selection generates user-facing explanation"
+    (let [reason (messages/t :selector/reason-multi-phase {:pr-count 6})
+          selection {:workflow-type :canonical-sdlc
+                     :confidence :high
+                     :reason reason}
+          explanation (ws/explain-selection selection)]
+      (is (string? explanation))
+      (is (.contains explanation "canonical-sdlc"))
+      (is (.contains explanation reason))
+      (is (.contains explanation (messages/t :selector/override-hint)))))
 
-(deftest analyze-spec-test
+  (testing "explain-selection shows confidence markers"
+    (let [high-conf (ws/explain-selection {:workflow-type :canonical-sdlc
+                                           :confidence :high
+                                           :reason "Test"})
+          medium-conf (ws/explain-selection {:workflow-type :quick-fix
+                                             :confidence :medium
+                                             :reason "Test"})
+          low-conf (ws/explain-selection {:workflow-type :quick-fix
+                                          :confidence :low
+                                          :reason "Test"})]
+      (is (not (.contains high-conf "confidence")))
+      (is (.contains medium-conf (messages/t :selector/confidence-medium)))
+      (is (.contains low-conf (messages/t :selector/confidence-low))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Spec analysis
+(deftest ^{:stratum 1} analyze-spec-test
   (testing "analyze-spec extracts features from multi-phase refactor"
     (let [features (ws/analyze-spec multi-phase-refactor-spec)]
       (is (= :refactoring (:type features)))
@@ -120,8 +146,7 @@
 
 ;------------------------------------------------------------------------------ Layer 1 Tests
 ;; Rule matching
-
-(deftest match-rule-test
+(deftest ^{:stratum 1} match-rule-test
   (testing "Multi-phase implementation rule matches"
     (let [features (ws/analyze-spec multi-phase-refactor-spec)
           result (ws/match-rule features)]
@@ -165,10 +190,8 @@
       (is (= :default (:selection-profile result)))
       (is (= :low (:confidence result))))))
 
-;------------------------------------------------------------------------------ Layer 2 Tests
 ;; Workflow selection with reasoning
-
-(deftest select-workflow-test
+(deftest ^{:stratum 1} select-workflow-test
   (testing "select-workflow returns complete result for multi-phase refactor"
     (let [result (ws/select-workflow multi-phase-refactor-spec)]
       (is (= :canonical-sdlc (:workflow-type result)))
@@ -202,36 +225,9 @@
       (is (= :default (:selection-profile result)))
       (is (= :low (:confidence result))))))
 
-(deftest explain-selection-test
-  (testing "explain-selection generates user-facing explanation"
-    (let [reason (messages/t :selector/reason-multi-phase {:pr-count 6})
-          selection {:workflow-type :canonical-sdlc
-                     :confidence :high
-                     :reason reason}
-          explanation (ws/explain-selection selection)]
-      (is (string? explanation))
-      (is (.contains explanation "canonical-sdlc"))
-      (is (.contains explanation reason))
-      (is (.contains explanation (messages/t :selector/override-hint)))))
-
-  (testing "explain-selection shows confidence markers"
-    (let [high-conf (ws/explain-selection {:workflow-type :canonical-sdlc
-                                           :confidence :high
-                                           :reason "Test"})
-          medium-conf (ws/explain-selection {:workflow-type :quick-fix
-                                             :confidence :medium
-                                             :reason "Test"})
-          low-conf (ws/explain-selection {:workflow-type :quick-fix
-                                          :confidence :low
-                                          :reason "Test"})]
-      (is (not (.contains high-conf "confidence")))
-      (is (.contains medium-conf (messages/t :selector/confidence-medium)))
-      (is (.contains low-conf (messages/t :selector/confidence-low))))))
-
 ;------------------------------------------------------------------------------ Integration Tests
 ;; End-to-end workflow selection
-
-(deftest workflow-selection-integration-test
+(deftest ^{:stratum 1} workflow-selection-integration-test
   (testing "Emojui-style multi-phase refactor selects canonical-sdlc-v1"
     (let [result (ws/select-workflow multi-phase-refactor-spec)]
       (is (= :canonical-sdlc (:workflow-type result)))
@@ -250,8 +246,7 @@
       (is (not= :simple-test-v1 (:workflow-type result))))))
 
 ;------------------------------------------------------------------------------ Edge Cases
-
-(deftest edge-cases-test
+(deftest ^{:stratum 1} edge-cases-test
   (testing "Empty spec defaults to canonical-sdlc (default profile)"
     (let [result (ws/select-workflow {})]
       (is (= :canonical-sdlc (:workflow-type result)))

--- a/bases/cli/test/ai/miniforge/cli/worktree_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/worktree_test.clj
@@ -15,20 +15,23 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cli.worktree-test
   (:require
    [babashka.fs :as fs]
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.cli.worktree :as sut]))
 
-(defn- delete-tree!
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} delete-tree!
   [path]
   (when (fs/exists? path)
     (doseq [entry (reverse (file-seq (fs/file path)))]
       (fs/delete entry))))
 
-(deftest worktree-root-prefers-nearest-git-marker-test
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} worktree-root-prefers-nearest-git-marker-test
   (let [tmp (fs/create-temp-dir {:prefix "miniforge-worktree-root-"})
         repo-root (fs/path tmp "repo")
         nested-worktree (fs/path repo-root ".claude" "worktrees" "agent-123")
@@ -43,7 +46,7 @@
       (finally
         (delete-tree! tmp)))))
 
-(deftest worktree-root-finds-parent-repo-when-no-child-marker-test
+(deftest ^{:stratum 1} worktree-root-finds-parent-repo-when-no-child-marker-test
   (let [tmp (fs/create-temp-dir {:prefix "miniforge-worktree-parent-"})
         repo-root (fs/path tmp "repo")
         nested-src (fs/path repo-root "components" "sample")]

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-cli.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-cli.md
@@ -6,15 +6,27 @@
 
 ## Overview
 
+**Update after initial review:** the base commit (`3fa5cc503`) is the
+mechanical `stratum-lint --fix` pass described below and does carry no
+logic changes. Two follow-up commits were added afterward in direct
+response to genuine bugs Copilot's review found in files this pass
+already touches — a `ClassCastException` in `web/sse.clj` and an
+unhandled-exception-on-malformed-input bug in `web/handlers.clj`, both
+pre-existing and unrelated to the stratum-lint reordering itself. See
+"Post-Review Fixes" below for the full detail on both; flagged here
+per review feedback so this description doesn't undersell the PR's
+actual scope.
+
 Runs `stratum-lint --fix` over `bases/cli` (`src` + `test`) to replace
 decorative `Layer N` banners and missing headings with real `Layer N`
 headings and `^{:stratum n}` metadata derived from each file's actual
-same-file reference graph. Mechanical: no logic changes. Also hand-fixes
-26 stale decorative `Layer N` comments across 11 files that are now
-invisible to `--fix`'s heading regex and contradict the recomputed real
-headings, and one stale docstring (`workflow_runner/gc_hooks.clj`) whose
-"Layer 0 / Layer 1" description no longer matched the real (single-layer)
-structure. One of the Wave 1 batch 6 per-component/base PRs from
+same-file reference graph. The autofix pass itself is mechanical: no
+logic changes. Also hand-fixes 26 stale decorative `Layer N` comments
+across 11 files that are now invisible to `--fix`'s heading regex and
+contradict the recomputed real headings, and one stale docstring
+(`workflow_runner/gc_hooks.clj`) whose "Layer 0 / Layer 1" description
+no longer matched the real (single-layer) structure. One of the Wave 1
+batch 6 per-component/base PRs from
 `work/stratum-lint-baseline-2026-07-24.md`; `bases/cli` is a Polylith
 BASE, not a component, but the same fix mechanics apply.
 
@@ -124,6 +136,46 @@ Left their docstrings as-is rather than hand-writing a description of a
 structure that Wave 2 will restructure again; flagged here for whoever
 picks up the split.
 
+## Post-Review Fixes
+
+Two genuine, pre-existing bugs Copilot's review found in files the
+mechanical pass already touches — both verified independently before
+fixing, both untouched by the autofix itself (confirmed via `git diff
+origin/main` on each file: only heading/metadata/reordering churn
+before these commits, logic byte-identical), both landed as their own
+commit with a dedicated regression test:
+
+1. **`web/sse.clj` (`0813e3716`, then `0fb24f09b`):** `streams` maps
+   `workflow-id -> event-stream atom` (`es/create-event-stream` returns
+   `(atom {...})`, confirmed via `components/event-stream`). `on-open`
+   and `on-close` were doing `assoc-in`/`update-in` directly on a
+   `streams` entry to track per-channel subscriber ids — this tries to
+   `assoc` onto that atom and throws `ClassCastException: class
+   clojure.lang.Atom cannot be cast to class clojure.lang.Associative`
+   on the first SSE connect for any workflow. Fixed by tracking
+   channel→sub-id in a separate `subscriptions` atom instead. A
+   follow-up review comment also caught that `on-close` left an empty
+   `{workflow-id {}}` entry behind once the last channel closed
+   (unbounded growth on a long-running server) — fixed by dropping the
+   `workflow-id` key entirely once its channel map goes empty. Added
+   `bases/cli/test/ai/miniforge/cli/web/sse_test.clj` (6 tests).
+   Reproduced both bugs by reverting the fix locally and re-running the
+   new tests against the original logic before restoring it — both
+   throw/leak exactly as described.
+2. **`web/handlers.clj` (`101bc5a0c`):** `parse-pr-path` unconditionally
+   ran `Integer/parseInt` on the second path segment of an
+   `/api/pr/<repo>/<number>` URI with no validation, so a malformed
+   request (`GET /api/pr/`, a non-numeric PR number, etc.) threw
+   `NullPointerException`/`NumberFormatException` straight out of
+   request handling instead of a 400 — this is externally reachable,
+   untrusted input. Fixed by wrapping the parse in `try`/`catch` (nil on
+   failure, matching the existing `workflow-stream` pattern already in
+   the same file) and updating all 5 callers (`pr-detail`, `approve`,
+   `reject`, `chat`, `summary`) to return `response/bad-request` instead
+   of proceeding with a nil repo/number. Added
+   `bases/cli/test/ai/miniforge/cli/web/handlers_test.clj` (4 tests).
+   Same revert-and-reproduce verification as above.
+
 ## Testing Plan
 
 1. Ran plain `stratum-lint` before the fix — reproduced the 28 findings
@@ -142,13 +194,15 @@ picks up the split.
    `git show origin/main:<path>` comparison on the unmodified tree — same
    2 warnings (different line numbers only, from reordering), nothing
    else.
-5. Ran the base's 40 test namespaces directly via `clojure -M:dev:test
+5. Ran the base's 42 test namespaces directly via `clojure -M:dev:test
    -e` (both `src` and `test`, requiring every namespace under
-   `bases/cli/test` and calling `clojure.test/run-tests` on all of them):
-   **302 tests, 845 assertions, 1 failure, 1 error** — both confirmed
-   pre-existing and unrelated to this diff by running the same two test
-   namespaces against the unmodified `origin/main` tree (identical
-   failure/error, same messages):
+   `bases/cli/test` — including the two new namespaces added by the
+   Post-Review Fixes above, `web/sse_test.clj` and
+   `web/handlers_test.clj` — and calling `clojure.test/run-tests` on all
+   of them): **312 tests, 863 assertions, 1 failure, 1 error** — both
+   confirmed pre-existing and unrelated to this diff by running the same
+   two test namespaces against the unmodified `origin/main` tree
+   (identical failure/error, same messages):
    - `ai.miniforge.cli.scan-test` `negative-mode-uses-rule-title-test`:
      `NullPointerException` inside `ai.miniforge.compliance-scanner.scan`
      (a different component entirely, not touched by this diff).
@@ -183,8 +237,13 @@ carry-over) alongside `MINIFORGE_COMMIT_BUDGET_OVERRIDE=1`.
 
 ## Deployment Plan
 
-Merges to `main` like any other base change. No runtime behavior change —
-purely heading/metadata/comment/one-docstring-sentence churn. Pre-commit's
+Merges to `main` like any other base change. The stratum-lint autofix
+itself is purely heading/metadata/comment/one-docstring-sentence churn,
+no runtime behavior change. The two Post-Review Fixes above do change
+runtime behavior, both strictly toward correctness: SSE subscribe/close
+no longer throws on the first connect for a workflow, and a malformed
+`/api/pr/...` request now returns 400 instead of crashing the handler —
+no existing caller relied on either failure mode. Pre-commit's
 `lint:stratum` autofixer keeps this base clean going forward; the 37
 `SL003` files stay advisory (`MINIFORGE_STRATUM_BUDGET_MODE=warn` at
 commit time) until Wave 2 splits them.
@@ -214,8 +273,13 @@ commit time) until Wave 2 splits them.
       actual reference graph and correctly left unchanged
 - [x] `clj-kondo` clean (0 errors, 2 pre-existing warnings, confirmed via
       comparison against `origin/main`)
-- [x] Base tests pass (302 tests, 845 assertions, 1 pre-existing failure
+- [x] Base tests pass (312 tests, 863 assertions, 1 pre-existing failure
       + 1 pre-existing error, both confirmed unrelated on `origin/main`)
 - [x] Plain lint re-run post-fix: `SL003` remains on 37 files, documented
       above with precise counts, tracked as Wave 2
+- [x] Two genuine bugs found in Copilot review (`web/sse.clj`
+      `ClassCastException` + unbounded subscription-map growth,
+      `web/handlers.clj` unhandled exception on malformed input) fixed
+      with dedicated regression tests; each reproduced against the
+      original logic before the fix was restored
 - [x] No `--no-verify`; pre-commit hook runs normally at commit time

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-cli.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-cli.md
@@ -1,0 +1,221 @@
+<!--
+  Title: fix: stratum-lint autofix for bases/cli (Wave 1)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+## Overview
+
+Runs `stratum-lint --fix` over `bases/cli` (`src` + `test`) to replace
+decorative `Layer N` banners and missing headings with real `Layer N`
+headings and `^{:stratum n}` metadata derived from each file's actual
+same-file reference graph. Mechanical: no logic changes. Also hand-fixes
+26 stale decorative `Layer N` comments across 11 files that are now
+invisible to `--fix`'s heading regex and contradict the recomputed real
+headings, and one stale docstring (`workflow_runner/gc_hooks.clj`) whose
+"Layer 0 / Layer 1" description no longer matched the real (single-layer)
+structure. One of the Wave 1 batch 6 per-component/base PRs from
+`work/stratum-lint-baseline-2026-07-24.md`; `bases/cli` is a Polylith
+BASE, not a component, but the same fix mechanics apply.
+
+## Motivation
+
+Plain (non-`--fix`) `stratum-lint` on `bases/cli` reported 28 findings,
+**zero `SL001`** (confirmed before running `--fix`, per the Wave 1 runbook
+— this base was not pre-vetted as SL001-free, so this was a hard
+precondition, not a formality):
+
+```text
+10 SL002 (heading reused / not strictly increasing)
+10 SL003 (file over the 3-layer budget, measured from decorative headings)
+ 8 SL004 (def appears before the first Layer heading)
+```
+
+Matches the baseline doc's per-component table exactly (`bases/cli | 28 |
+0 | 10 | 10 | 8`).
+
+## Changes in Detail
+
+Ran, over the whole base:
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "bef8657a2efd3b1ba9e1a4f510693c9fbca45abd" :deps/root "clojure"}}}' -m stratum-lint.interface --fix bases/cli
+```
+
+96 files were rewritten (57 `src`, 39 `test`). No SL008 reader-conditional
+refusal encountered.
+
+**Idempotency and content verification.** A second `--fix` pass
+immediately after produced zero diff. For all 96 files, stripped
+comments/blank lines/`^{:stratum n}` annotations from both the pre-fix and
+post-fix text and diffed the sorted, normalized result: identical for 92
+of 96 files. The remaining 4 are accounted for below (3 cosmetic, 1
+intentional docstring fix) — no unaccounted content drift. Also grepped
+the diff for the known same-line trailing-comment displacement pattern
+(`foo])  ; comment`): 2 hits, both verified by direct inspection to remain
+attached to their original def, only the space count before `;` changed
+(1 space → 2) — not a misattachment.
+
+**Decorative banner cleanup (26 instances, 11 files).** Single- and
+double-semicolon `;---- Layer N[.: ]<label>` comments left behind by
+earlier manual edits — invisible to `--fix`'s heading regex — now
+contradicted the regenerated real headings (checked systematically: every
+`Layer N`-shaped comment in the diff was traced against the real heading
+immediately governing its position, i.e. the last strictly-formatted
+bare `;---- Layer N` line above it):
+
+- `observability.clj`: 7 contradicting banners (e.g. `Layer 1: Log
+  Parsing` sitting in the real Layer 0 span, `Layer 7: CLI Commands`
+  sitting in the real Layer 5 span). Dropped the wrong numbers, kept each
+  label as a plain `;; <label>` comment — matches the exact convention
+  established in the `web-dashboard` Wave 1 PR (#1525 follow-up,
+  `27357297d`). Two correctly-numbered banners (`Layer 0: File
+  Discovery`, `Layer 2: Event Parsing`) already matched their real
+  stratum and were left alone, per the same precedent.
+- `workflow_runner.clj`: 6 instances — four (`Layer 0.5`–`Layer 0.8`) were
+  bare non-integer stray headings with no unique text (the real label
+  was already on the very next line as a separate plain comment), deleted
+  outright; one (`Layer 1 — manifest operations`, real stratum 0) and one
+  (`Layer 2 — lifecycle helpers`, real stratum 1) had wrong numbers
+  dropped, label kept. Also fixed a stale in-prose reference next to the
+  latter (`` `run-workflow!` composes them at Layer 3 `` → real stratum is
+  2, corrected the number in the sentence itself). A stray `Layer 2b`
+  banner (leftover from an old numbering scheme, no relation to the
+  current 0–9 real structure) sitting inside the real Layer 9 span was
+  also deleted — no unique text beyond the wrong label.
+- `main/commands/resume.clj`: one stray `Layer 1.5` banner, no unique
+  text (label already present on the next line), deleted.
+- 6 test files (`main/commands/artifact_cmds_test.clj`,
+  `main/commands/etl_test.clj`, `main/commands/events_test.clj` (2),
+  `workflow_runner/display_output_test.clj`,
+  `workflow_runner/help_test.clj` (4), `workflow_selector_test.clj` (2)):
+  same shape — one decorative `Layer N: <label>` banner per `deftest`
+  group, each now contradicting the real (collapsed) stratum. Dropped
+  wrong numbers where a distinct label existed; deleted outright where
+  the very next line already carried the same description.
+
+Re-ran `--fix` after all of the above — zero diff, confirming the
+manual comment/docstring edits don't interact with stratum computation.
+
+**False positive caught before editing:** `workflow_runner/sandbox.clj:76`
+(`;; Layer 0 (\`infer-branch\`).`) was initially flagged by a triage
+script as contradicting its surrounding real-Layer-2 context, but reading
+it in place showed it's a **correct** cross-reference — it documents that
+`prepare-sandbox` (real stratum 2) composes `infer-repo-url` (real
+stratum 1) and `infer-branch` (real stratum 0), both true facts about
+those functions' own strata, not a claim about the comment's own section.
+Left unchanged. `sandbox.clj`'s ns docstring "Stratification" block
+(Layer 0–3) is fully accurate post-fix and was also left alone.
+
+**Genuine stale docstring fixed:** `workflow_runner/gc_hooks.clj`'s ns
+docstring described the file as two layers (`Layer 0: enqueue...` /
+`Layer 1: GC pass...`), but `--fix` collapsed the real structure to a
+single Layer 0 — both functions take their side-effecting collaborators
+as injected arguments and don't call each other. Reworded the docstring
+to describe them as Layer-0 peers instead of a two-layer split.
+
+**Three other files' ns docstrings carry a "Stratification" description
+that is now stale** (`workflow_selector.clj`: documents 3 layers, real is
+5; `workflow_runner/help.clj`: documents 3, real is 6;
+`workflow_runner/help/registry.clj`: documents 3, real is 6) — but all
+three files remain over the 3-layer budget after `--fix` (SL003, see
+below) and are Wave 2 (namespace split) candidates per the baseline doc.
+Left their docstrings as-is rather than hand-writing a description of a
+structure that Wave 2 will restructure again; flagged here for whoever
+picks up the split.
+
+## Testing Plan
+
+1. Ran plain `stratum-lint` before the fix — reproduced the 28 findings
+   above exactly (10 `SL002`, 10 `SL003`, 8 `SL004`), zero `SL001`.
+2. Ran `--fix`, then a second `--fix` pass immediately after — zero diff,
+   confirms idempotency.
+3. Read the full diff for all 96 changed files; confirmed via the
+   normalized-content multiset check (above) that nothing beyond
+   heading/metadata/order/the one intentional docstring edit changed.
+   Found and hand-fixed the 26 stale decorative `Layer N` comments across
+   11 files described above; re-ran `--fix` after each round of manual
+   edits — zero diff, confirming stability.
+4. `clj-kondo --lint bases/cli`: 0 errors, 2 warnings (`Redundant let
+   expression` in `workflow_runner/gc_integration_test.clj`, unused
+   `testing` refer in `worktree_test.clj`). Confirmed pre-existing via
+   `git show origin/main:<path>` comparison on the unmodified tree — same
+   2 warnings (different line numbers only, from reordering), nothing
+   else.
+5. Ran the base's 40 test namespaces directly via `clojure -M:dev:test
+   -e` (both `src` and `test`, requiring every namespace under
+   `bases/cli/test` and calling `clojure.test/run-tests` on all of them):
+   **302 tests, 845 assertions, 1 failure, 1 error** — both confirmed
+   pre-existing and unrelated to this diff by running the same two test
+   namespaces against the unmodified `origin/main` tree (identical
+   failure/error, same messages):
+   - `ai.miniforge.cli.scan-test` `negative-mode-uses-rule-title-test`:
+     `NullPointerException` inside `ai.miniforge.compliance-scanner.scan`
+     (a different component entirely, not touched by this diff).
+   - `ai.miniforge.cli.workflow-runner.preflight-test`
+     `run-backend-preflight-exercises-generic-cli-success-path-test`:
+     depends on which CLI backend binary is actually on this machine's
+     `PATH` (`claude` here); fails the same way on `origin/main`.
+6. Re-ran plain `stratum-lint` after the fix. `SL001`/`SL002`/`SL004`
+   clear. `SL003` remains on 37 files (up from 10 pre-fix — the old
+   decorative headings under-counted real depth on most of them once
+   measured from the true reference graph, the same effect documented in
+   the `web-dashboard` Wave 1 PR): `app_config.clj` (6), `backends.clj`
+   (7), `config.clj` (4), `main.clj` (8), `artifact_cmds.clj` (4),
+   `etl.clj` (4), `events.clj` (4), `evidence.clj` (5), `init.clj` (4),
+   `plan_executor.clj` (4), `pr_monitor.clj` (4), `pr_policy_respond.clj`
+   (4), `pr_resume_dispatcher.clj` (5), `pr_review.clj` (5),
+   `pr_review_monitor.clj` (4), `resume.clj` (4), `runtime.clj` (4),
+   `scan.clj` (5), `main/commands/worktree.clj` (4), `main/display.clj`
+   (5), `messages.clj` (4), `observability.clj` (7), `tui.clj` (4),
+   `web/components.clj` (7), `web/components/status.clj` (4), `web/sse.clj`
+   (4), `workflow_recommender.clj` (5), `workflow_runner.clj` (10),
+   `workflow_runner/context.clj` (4), `workflow_runner/display.clj` (8),
+   `workflow_runner/help.clj` (6), `workflow_runner/help/registry.clj`
+   (6), `workflow_runner/sandbox.clj` (4), `workflow_selection_config.clj`
+   (4), `workflow_selector.clj` (5), top-level `worktree.clj` (5),
+   `test/web/components_test.clj` (4). All real over-budget files (Wave 2
+   scope: namespace split), not addressed here.
+
+Committed with `MINIFORGE_STRATUM_BUDGET_MODE=warn` (37 pre-existing
+over-budget files remain, per Wave 1's documented handling of SL003
+carry-over) alongside `MINIFORGE_COMMIT_BUDGET_OVERRIDE=1`.
+
+## Deployment Plan
+
+Merges to `main` like any other base change. No runtime behavior change —
+purely heading/metadata/comment/one-docstring-sentence churn. Pre-commit's
+`lint:stratum` autofixer keeps this base clean going forward; the 37
+`SL003` files stay advisory (`MINIFORGE_STRATUM_BUDGET_MODE=warn` at
+commit time) until Wave 2 splits them.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+- Follow-on: Wave 2 namespace splits for the 37 `SL003` files listed
+  above, `workflow_runner.clj` (10 real layers) and `main.clj` (8) being
+  the most over budget. `workflow_selector.clj`,
+  `workflow_runner/help.clj`, and `workflow_runner/help/registry.clj`
+  additionally carry a stale ns-docstring "Stratification" description
+  (documents 3 layers, real is 5–6) that should get rewritten as part of
+  their split rather than patched piecemeal beforehand.
+
+## Checklist
+
+- [x] Confirmed zero `SL001` before running `--fix`
+- [x] `--fix` run over the whole base (`src` + `test`)
+- [x] Second `--fix` pass confirms idempotency (zero diff)
+- [x] Diff read in full for all 96 changed files; verified mechanical-only
+      via normalized-content comparison
+- [x] 26 stale decorative `Layer N` comments across 11 files hand-fixed
+      (comment-only); one stale docstring description hand-fixed
+      (`gc_hooks.clj`); `--fix` re-run confirms stability
+- [x] One triage false-positive (`sandbox.clj:76`) checked against the
+      actual reference graph and correctly left unchanged
+- [x] `clj-kondo` clean (0 errors, 2 pre-existing warnings, confirmed via
+      comparison against `origin/main`)
+- [x] Base tests pass (302 tests, 845 assertions, 1 pre-existing failure
+      + 1 pre-existing error, both confirmed unrelated on `origin/main`)
+- [x] Plain lint re-run post-fix: `SL003` remains on 37 files, documented
+      above with precise counts, tracked as Wave 2
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
<!--
  Title: fix: stratum-lint autofix for bases/cli (Wave 1)
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

## Overview

**Update after initial review:** the base commit (`3fa5cc503`) is the
mechanical `stratum-lint --fix` pass described below and does carry no
logic changes. Two follow-up commits were added afterward in direct
response to genuine bugs Copilot's review found in files this pass
already touches — a `ClassCastException` in `web/sse.clj` and an
unhandled-exception-on-malformed-input bug in `web/handlers.clj`, both
pre-existing and unrelated to the stratum-lint reordering itself. See
"Post-Review Fixes" below for the full detail on both; flagged here
per review feedback so this description doesn't undersell the PR's
actual scope.

Runs `stratum-lint --fix` over `bases/cli` (`src` + `test`) to replace
decorative `Layer N` banners and missing headings with real `Layer N`
headings and `^{:stratum n}` metadata derived from each file's actual
same-file reference graph. The autofix pass itself is mechanical: no
logic changes. Also hand-fixes 26 stale decorative `Layer N` comments
across 11 files that are now invisible to `--fix`'s heading regex and
contradict the recomputed real headings, and one stale docstring
(`workflow_runner/gc_hooks.clj`) whose "Layer 0 / Layer 1" description
no longer matched the real (single-layer) structure. One of the Wave 1
batch 6 per-component/base PRs from
`work/stratum-lint-baseline-2026-07-24.md`; `bases/cli` is a Polylith
BASE, not a component, but the same fix mechanics apply.

## Motivation

Plain (non-`--fix`) `stratum-lint` on `bases/cli` reported 28 findings,
**zero `SL001`** (confirmed before running `--fix`, per the Wave 1 runbook
— this base was not pre-vetted as SL001-free, so this was a hard
precondition, not a formality):

```text
10 SL002 (heading reused / not strictly increasing)
10 SL003 (file over the 3-layer budget, measured from decorative headings)
 8 SL004 (def appears before the first Layer heading)
```

Matches the baseline doc's per-component table exactly (`bases/cli | 28 |
0 | 10 | 10 | 8`).

## Changes in Detail

Ran, over the whole base:

```bash
bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "bef8657a2efd3b1ba9e1a4f510693c9fbca45abd" :deps/root "clojure"}}}' -m stratum-lint.interface --fix bases/cli
```

96 files were rewritten (57 `src`, 39 `test`). No SL008 reader-conditional
refusal encountered.

**Idempotency and content verification.** A second `--fix` pass
immediately after produced zero diff. For all 96 files, stripped
comments/blank lines/`^{:stratum n}` annotations from both the pre-fix and
post-fix text and diffed the sorted, normalized result: identical for 92
of 96 files. The remaining 4 are accounted for below (3 cosmetic, 1
intentional docstring fix) — no unaccounted content drift. Also grepped
the diff for the known same-line trailing-comment displacement pattern
(`foo])  ; comment`): 2 hits, both verified by direct inspection to remain
attached to their original def, only the space count before `;` changed
(1 space → 2) — not a misattachment.

**Decorative banner cleanup (26 instances, 11 files).** Single- and
double-semicolon `;---- Layer N[.: ]<label>` comments left behind by
earlier manual edits — invisible to `--fix`'s heading regex — now
contradicted the regenerated real headings (checked systematically: every
`Layer N`-shaped comment in the diff was traced against the real heading
immediately governing its position, i.e. the last strictly-formatted
bare `;---- Layer N` line above it):

- `observability.clj`: 7 contradicting banners (e.g. `Layer 1: Log
  Parsing` sitting in the real Layer 0 span, `Layer 7: CLI Commands`
  sitting in the real Layer 5 span). Dropped the wrong numbers, kept each
  label as a plain `;; <label>` comment — matches the exact convention
  established in the `web-dashboard` Wave 1 PR (#1525 follow-up,
  `27357297d`). Two correctly-numbered banners (`Layer 0: File
  Discovery`, `Layer 2: Event Parsing`) already matched their real
  stratum and were left alone, per the same precedent.
- `workflow_runner.clj`: 6 instances — four (`Layer 0.5`–`Layer 0.8`) were
  bare non-integer stray headings with no unique text (the real label
  was already on the very next line as a separate plain comment), deleted
  outright; one (`Layer 1 — manifest operations`, real stratum 0) and one
  (`Layer 2 — lifecycle helpers`, real stratum 1) had wrong numbers
  dropped, label kept. Also fixed a stale in-prose reference next to the
  latter (`` `run-workflow!` composes them at Layer 3 `` → real stratum is
  2, corrected the number in the sentence itself). A stray `Layer 2b`
  banner (leftover from an old numbering scheme, no relation to the
  current 0–9 real structure) sitting inside the real Layer 9 span was
  also deleted — no unique text beyond the wrong label.
- `main/commands/resume.clj`: one stray `Layer 1.5` banner, no unique
  text (label already present on the next line), deleted.
- 6 test files (`main/commands/artifact_cmds_test.clj`,
  `main/commands/etl_test.clj`, `main/commands/events_test.clj` (2),
  `workflow_runner/display_output_test.clj`,
  `workflow_runner/help_test.clj` (4), `workflow_selector_test.clj` (2)):
  same shape — one decorative `Layer N: <label>` banner per `deftest`
  group, each now contradicting the real (collapsed) stratum. Dropped
  wrong numbers where a distinct label existed; deleted outright where
  the very next line already carried the same description.

Re-ran `--fix` after all of the above — zero diff, confirming the
manual comment/docstring edits don't interact with stratum computation.

**False positive caught before editing:** `workflow_runner/sandbox.clj:76`
(`;; Layer 0 (\`infer-branch\`).`) was initially flagged by a triage
script as contradicting its surrounding real-Layer-2 context, but reading
it in place showed it's a **correct** cross-reference — it documents that
`prepare-sandbox` (real stratum 2) composes `infer-repo-url` (real
stratum 1) and `infer-branch` (real stratum 0), both true facts about
those functions' own strata, not a claim about the comment's own section.
Left unchanged. `sandbox.clj`'s ns docstring "Stratification" block
(Layer 0–3) is fully accurate post-fix and was also left alone.

**Genuine stale docstring fixed:** `workflow_runner/gc_hooks.clj`'s ns
docstring described the file as two layers (`Layer 0: enqueue...` /
`Layer 1: GC pass...`), but `--fix` collapsed the real structure to a
single Layer 0 — both functions take their side-effecting collaborators
as injected arguments and don't call each other. Reworded the docstring
to describe them as Layer-0 peers instead of a two-layer split.

**Three other files' ns docstrings carry a "Stratification" description
that is now stale** (`workflow_selector.clj`: documents 3 layers, real is
5; `workflow_runner/help.clj`: documents 3, real is 6;
`workflow_runner/help/registry.clj`: documents 3, real is 6) — but all
three files remain over the 3-layer budget after `--fix` (SL003, see
below) and are Wave 2 (namespace split) candidates per the baseline doc.
Left their docstrings as-is rather than hand-writing a description of a
structure that Wave 2 will restructure again; flagged here for whoever
picks up the split.

## Post-Review Fixes

Two genuine, pre-existing bugs Copilot's review found in files the
mechanical pass already touches — both verified independently before
fixing, both untouched by the autofix itself (confirmed via `git diff
origin/main` on each file: only heading/metadata/reordering churn
before these commits, logic byte-identical), both landed as their own
commit with a dedicated regression test:

1. **`web/sse.clj` (`0813e3716`, then `0fb24f09b`):** `streams` maps
   `workflow-id -> event-stream atom` (`es/create-event-stream` returns
   `(atom {...})`, confirmed via `components/event-stream`). `on-open`
   and `on-close` were doing `assoc-in`/`update-in` directly on a
   `streams` entry to track per-channel subscriber ids — this tries to
   `assoc` onto that atom and throws `ClassCastException: class
   clojure.lang.Atom cannot be cast to class clojure.lang.Associative`
   on the first SSE connect for any workflow. Fixed by tracking
   channel→sub-id in a separate `subscriptions` atom instead. A
   follow-up review comment also caught that `on-close` left an empty
   `{workflow-id {}}` entry behind once the last channel closed
   (unbounded growth on a long-running server) — fixed by dropping the
   `workflow-id` key entirely once its channel map goes empty. Added
   `bases/cli/test/ai/miniforge/cli/web/sse_test.clj` (6 tests).
   Reproduced both bugs by reverting the fix locally and re-running the
   new tests against the original logic before restoring it — both
   throw/leak exactly as described.
2. **`web/handlers.clj` (`101bc5a0c`):** `parse-pr-path` unconditionally
   ran `Integer/parseInt` on the second path segment of an
   `/api/pr/<repo>/<number>` URI with no validation, so a malformed
   request (`GET /api/pr/`, a non-numeric PR number, etc.) threw
   `NullPointerException`/`NumberFormatException` straight out of
   request handling instead of a 400 — this is externally reachable,
   untrusted input. Fixed by wrapping the parse in `try`/`catch` (nil on
   failure, matching the existing `workflow-stream` pattern already in
   the same file) and updating all 5 callers (`pr-detail`, `approve`,
   `reject`, `chat`, `summary`) to return `response/bad-request` instead
   of proceeding with a nil repo/number. Added
   `bases/cli/test/ai/miniforge/cli/web/handlers_test.clj` (4 tests).
   Same revert-and-reproduce verification as above.

## Testing Plan

1. Ran plain `stratum-lint` before the fix — reproduced the 28 findings
   above exactly (10 `SL002`, 10 `SL003`, 8 `SL004`), zero `SL001`.
2. Ran `--fix`, then a second `--fix` pass immediately after — zero diff,
   confirms idempotency.
3. Read the full diff for all 96 changed files; confirmed via the
   normalized-content multiset check (above) that nothing beyond
   heading/metadata/order/the one intentional docstring edit changed.
   Found and hand-fixed the 26 stale decorative `Layer N` comments across
   11 files described above; re-ran `--fix` after each round of manual
   edits — zero diff, confirming stability.
4. `clj-kondo --lint bases/cli`: 0 errors, 2 warnings (`Redundant let
   expression` in `workflow_runner/gc_integration_test.clj`, unused
   `testing` refer in `worktree_test.clj`). Confirmed pre-existing via
   `git show origin/main:<path>` comparison on the unmodified tree — same
   2 warnings (different line numbers only, from reordering), nothing
   else.
5. Ran the base's 42 test namespaces directly via `clojure -M:dev:test
   -e` (both `src` and `test`, requiring every namespace under
   `bases/cli/test` — including the two new namespaces added by the
   Post-Review Fixes above, `web/sse_test.clj` and
   `web/handlers_test.clj` — and calling `clojure.test/run-tests` on all
   of them): **312 tests, 863 assertions, 1 failure, 1 error** — both
   confirmed pre-existing and unrelated to this diff by running the same
   two test namespaces against the unmodified `origin/main` tree
   (identical failure/error, same messages):
   - `ai.miniforge.cli.scan-test` `negative-mode-uses-rule-title-test`:
     `NullPointerException` inside `ai.miniforge.compliance-scanner.scan`
     (a different component entirely, not touched by this diff).
   - `ai.miniforge.cli.workflow-runner.preflight-test`
     `run-backend-preflight-exercises-generic-cli-success-path-test`:
     depends on which CLI backend binary is actually on this machine's
     `PATH` (`claude` here); fails the same way on `origin/main`.
6. Re-ran plain `stratum-lint` after the fix. `SL001`/`SL002`/`SL004`
   clear. `SL003` remains on 37 files (up from 10 pre-fix — the old
   decorative headings under-counted real depth on most of them once
   measured from the true reference graph, the same effect documented in
   the `web-dashboard` Wave 1 PR): `app_config.clj` (6), `backends.clj`
   (7), `config.clj` (4), `main.clj` (8), `artifact_cmds.clj` (4),
   `etl.clj` (4), `events.clj` (4), `evidence.clj` (5), `init.clj` (4),
   `plan_executor.clj` (4), `pr_monitor.clj` (4), `pr_policy_respond.clj`
   (4), `pr_resume_dispatcher.clj` (5), `pr_review.clj` (5),
   `pr_review_monitor.clj` (4), `resume.clj` (4), `runtime.clj` (4),
   `scan.clj` (5), `main/commands/worktree.clj` (4), `main/display.clj`
   (5), `messages.clj` (4), `observability.clj` (7), `tui.clj` (4),
   `web/components.clj` (7), `web/components/status.clj` (4), `web/sse.clj`
   (4), `workflow_recommender.clj` (5), `workflow_runner.clj` (10),
   `workflow_runner/context.clj` (4), `workflow_runner/display.clj` (8),
   `workflow_runner/help.clj` (6), `workflow_runner/help/registry.clj`
   (6), `workflow_runner/sandbox.clj` (4), `workflow_selection_config.clj`
   (4), `workflow_selector.clj` (5), top-level `worktree.clj` (5),
   `test/web/components_test.clj` (4). All real over-budget files (Wave 2
   scope: namespace split), not addressed here.

Committed with `MINIFORGE_STRATUM_BUDGET_MODE=warn` (37 pre-existing
over-budget files remain, per Wave 1's documented handling of SL003
carry-over) alongside `MINIFORGE_COMMIT_BUDGET_OVERRIDE=1`.

## Deployment Plan

Merges to `main` like any other base change. The stratum-lint autofix
itself is purely heading/metadata/comment/one-docstring-sentence churn,
no runtime behavior change. The two Post-Review Fixes above do change
runtime behavior, both strictly toward correctness: SSE subscribe/close
no longer throws on the first connect for a workflow, and a malformed
`/api/pr/...` request now returns 400 instead of crashing the handler —
no existing caller relied on either failure mode. Pre-commit's
`lint:stratum` autofixer keeps this base clean going forward; the 37
`SL003` files stay advisory (`MINIFORGE_STRATUM_BUDGET_MODE=warn` at
commit time) until Wave 2 splits them.

## Related Issues/PRs

- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
- Follow-on: Wave 2 namespace splits for the 37 `SL003` files listed
  above, `workflow_runner.clj` (10 real layers) and `main.clj` (8) being
  the most over budget. `workflow_selector.clj`,
  `workflow_runner/help.clj`, and `workflow_runner/help/registry.clj`
  additionally carry a stale ns-docstring "Stratification" description
  (documents 3 layers, real is 5–6) that should get rewritten as part of
  their split rather than patched piecemeal beforehand.

## Checklist

- [x] Confirmed zero `SL001` before running `--fix`
- [x] `--fix` run over the whole base (`src` + `test`)
- [x] Second `--fix` pass confirms idempotency (zero diff)
- [x] Diff read in full for all 96 changed files; verified mechanical-only
      via normalized-content comparison
- [x] 26 stale decorative `Layer N` comments across 11 files hand-fixed
      (comment-only); one stale docstring description hand-fixed
      (`gc_hooks.clj`); `--fix` re-run confirms stability
- [x] One triage false-positive (`sandbox.clj:76`) checked against the
      actual reference graph and correctly left unchanged
- [x] `clj-kondo` clean (0 errors, 2 pre-existing warnings, confirmed via
      comparison against `origin/main`)
- [x] Base tests pass (312 tests, 863 assertions, 1 pre-existing failure
      + 1 pre-existing error, both confirmed unrelated on `origin/main`)
- [x] Plain lint re-run post-fix: `SL003` remains on 37 files, documented
      above with precise counts, tracked as Wave 2
- [x] Two genuine bugs found in Copilot review (`web/sse.clj`
      `ClassCastException` + unbounded subscription-map growth,
      `web/handlers.clj` unhandled exception on malformed input) fixed
      with dedicated regression tests; each reproduced against the
      original logic before the fix was restored
- [x] No `--no-verify`; pre-commit hook runs normally at commit time
