### PR TITLE
fix: stratum-lint autofix for components/event-stream (Wave 1)

### DIFF
--- a/components/event-stream/src/ai/miniforge/event_stream/approval.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/approval.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.approval
   "Multi-party approval state machine for N8 OCI compliance.
 
@@ -32,26 +31,146 @@
    [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
+
 ;; Response predicates for builder responses
 ;; Local aliases that delegate to response/success? and response/error?
 ;; so call sites in this namespace stay terse.
-
-(def succeeded?
+(def ^{:stratum 0} succeeded?
   "Check if a builder response (from response/success) succeeded."
   response/success?)
 
-(def failed?
+(def ^{:stratum 0} failed?
   "Check if a builder response (from response/failure) failed."
   response/error?)
 
-;------------------------------------------------------------------------------ Layer 0
 ;; Approval request creation
-
-(def ^:const default-expiry-hours
+(def ^{:stratum 0} ^:const default-expiry-hours
   "Default approval request expiry in hours."
   24)
 
-(defn create-approval-request
+;; Approval signing
+(defn ^{:stratum 0} signer-authorized?
+  "Check if a signer is in the required-signers list."
+  [approval-request signer]
+  (some #{signer} (:approval/required-signers approval-request)))
+
+(defn ^{:stratum 0} already-signed?
+  "Check if a signer has already signed."
+  [approval-request signer]
+  (some #(= signer (:signer %)) (:approval/signatures approval-request)))
+
+(defn ^{:stratum 0} expired?
+  "Check if an approval request has expired."
+  [approval-request]
+  (let [now (java.util.Date.)
+        expires-at (:approval/expires-at approval-request)]
+    (when expires-at
+      (.after now expires-at))))
+
+(defn ^{:stratum 0} cancel-approval
+  "Cancel a pending approval request.
+
+   Arguments:
+   - approval-request - Approval request map
+   - canceller - Identifier of the person cancelling
+   - reason - Reason for cancellation
+
+   Returns:
+   - response/success with updated request on success
+   - response/failure if not pending"
+  [approval-request canceller reason]
+  (if (not= :pending (:approval/status approval-request))
+    (response/failure "Can only cancel pending approvals"
+                      {:data {:status (:approval/status approval-request)}})
+    (response/success
+     (assoc approval-request
+            :approval/status :cancelled
+            :approval/cancelled-by canceller
+            :approval/cancel-reason reason
+            :approval/cancelled-at (java.util.Date.)))))
+
+;; Approval manager (atom-backed store)
+(defn ^{:stratum 0} create-approval-manager
+  "Create an atom-backed approval manager.
+
+   Returns: Atom containing {:approvals {uuid approval-request}}"
+  []
+  (atom {:approvals {}}))
+
+(defn ^{:stratum 0} store-approval!
+  "Store an approval request in the manager.
+
+   Arguments:
+   - manager - Approval manager atom
+   - approval - Approval request map
+
+   Returns: The stored approval."
+  [manager approval]
+  (let [id (:approval/id approval)]
+    (swap! manager assoc-in [:approvals id] approval)
+    approval))
+
+(defn ^{:stratum 0} get-approval
+  "Get an approval request by ID.
+
+   Arguments:
+   - manager - Approval manager atom
+   - approval-id - UUID
+
+   Returns: Approval request or nil."
+  [manager approval-id]
+  (get-in @manager [:approvals approval-id]))
+
+(defn ^{:stratum 0} update-approval!
+  "Update an approval request in the manager.
+
+   Arguments:
+   - manager - Approval manager atom
+   - approval - Updated approval request map
+
+   Returns: The updated approval."
+  [manager approval]
+  (let [id (:approval/id approval)]
+    (swap! manager assoc-in [:approvals id] approval)
+    approval))
+
+;; Approval event constructors
+(defn ^{:stratum 0} approval-requested
+  "Create an approval/requested event."
+  [stream workflow-id approval-id action-id required-signers]
+  (-> (core/create-envelope stream :approval/requested workflow-id
+                            (str "Approval requested for action " action-id))
+      (assoc :approval/id approval-id
+             :approval/action-id action-id
+             :approval/required-signers required-signers)))
+
+(defn ^{:stratum 0} approval-signed
+  "Create an approval/signed event."
+  [stream workflow-id approval-id signer decision]
+  (-> (core/create-envelope stream :approval/signed workflow-id
+                            (str "Approval " (name decision) " by " signer))
+      (assoc :approval/id approval-id
+             :approval/signer signer
+             :approval/decision decision)))
+
+(defn ^{:stratum 0} approval-completed
+  "Create an approval/completed event."
+  [stream workflow-id approval-id final-status]
+  (-> (core/create-envelope stream :approval/completed workflow-id
+                            (str "Approval " (name final-status)))
+      (assoc :approval/id approval-id
+             :approval/final-status final-status)))
+
+(defn ^{:stratum 0} approval-expired
+  "Create an approval/expired event."
+  [stream workflow-id approval-id]
+  (-> (core/create-envelope stream :approval/expired workflow-id
+                            "Approval request expired")
+      (assoc :approval/id approval-id)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} create-approval-request
   "Create a new approval request.
 
    Arguments:
@@ -77,28 +196,7 @@
              :approval/expires-at expires-at}
       (:metadata opts) (assoc :approval/metadata (:metadata opts)))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Approval signing
-
-(defn signer-authorized?
-  "Check if a signer is in the required-signers list."
-  [approval-request signer]
-  (some #{signer} (:approval/required-signers approval-request)))
-
-(defn already-signed?
-  "Check if a signer has already signed."
-  [approval-request signer]
-  (some #(= signer (:signer %)) (:approval/signatures approval-request)))
-
-(defn expired?
-  "Check if an approval request has expired."
-  [approval-request]
-  (let [now (java.util.Date.)
-        expires-at (:approval/expires-at approval-request)]
-    (when expires-at
-      (.after now expires-at))))
-
-(defn submit-approval
+(defn ^{:stratum 1} submit-approval
   "Submit an approval or rejection for a request.
 
    Arguments:
@@ -156,10 +254,8 @@
           final (assoc updated :approval/status new-status)]
       (response/success final))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Status checking
-
-(defn check-approval-status
+(defn ^{:stratum 1} check-approval-status
   "Check the current status of an approval request, accounting for expiry.
 
    Arguments:
@@ -172,76 +268,9 @@
       :expired
       status)))
 
-(defn cancel-approval
-  "Cancel a pending approval request.
-
-   Arguments:
-   - approval-request - Approval request map
-   - canceller - Identifier of the person cancelling
-   - reason - Reason for cancellation
-
-   Returns:
-   - response/success with updated request on success
-   - response/failure if not pending"
-  [approval-request canceller reason]
-  (if (not= :pending (:approval/status approval-request))
-    (response/failure "Can only cancel pending approvals"
-                      {:data {:status (:approval/status approval-request)}})
-    (response/success
-     (assoc approval-request
-            :approval/status :cancelled
-            :approval/cancelled-by canceller
-            :approval/cancel-reason reason
-            :approval/cancelled-at (java.util.Date.)))))
-
 ;------------------------------------------------------------------------------ Layer 2
-;; Approval manager (atom-backed store)
 
-(defn create-approval-manager
-  "Create an atom-backed approval manager.
-
-   Returns: Atom containing {:approvals {uuid approval-request}}"
-  []
-  (atom {:approvals {}}))
-
-(defn store-approval!
-  "Store an approval request in the manager.
-
-   Arguments:
-   - manager - Approval manager atom
-   - approval - Approval request map
-
-   Returns: The stored approval."
-  [manager approval]
-  (let [id (:approval/id approval)]
-    (swap! manager assoc-in [:approvals id] approval)
-    approval))
-
-(defn get-approval
-  "Get an approval request by ID.
-
-   Arguments:
-   - manager - Approval manager atom
-   - approval-id - UUID
-
-   Returns: Approval request or nil."
-  [manager approval-id]
-  (get-in @manager [:approvals approval-id]))
-
-(defn update-approval!
-  "Update an approval request in the manager.
-
-   Arguments:
-   - manager - Approval manager atom
-   - approval - Updated approval request map
-
-   Returns: The updated approval."
-  [manager approval]
-  (let [id (:approval/id approval)]
-    (swap! manager assoc-in [:approvals id] approval)
-    approval))
-
-(defn list-approvals
+(defn ^{:stratum 2} list-approvals
   "List all approval requests, optionally filtered.
 
    Arguments:
@@ -254,42 +283,6 @@
     (if-let [status (:status opts)]
       (vec (filter #(= status (check-approval-status %)) approvals))
       (vec approvals))))
-
-;------------------------------------------------------------------------------ Layer 3
-;; Approval event constructors
-
-(defn approval-requested
-  "Create an approval/requested event."
-  [stream workflow-id approval-id action-id required-signers]
-  (-> (core/create-envelope stream :approval/requested workflow-id
-                            (str "Approval requested for action " action-id))
-      (assoc :approval/id approval-id
-             :approval/action-id action-id
-             :approval/required-signers required-signers)))
-
-(defn approval-signed
-  "Create an approval/signed event."
-  [stream workflow-id approval-id signer decision]
-  (-> (core/create-envelope stream :approval/signed workflow-id
-                            (str "Approval " (name decision) " by " signer))
-      (assoc :approval/id approval-id
-             :approval/signer signer
-             :approval/decision decision)))
-
-(defn approval-completed
-  "Create an approval/completed event."
-  [stream workflow-id approval-id final-status]
-  (-> (core/create-envelope stream :approval/completed workflow-id
-                            (str "Approval " (name final-status)))
-      (assoc :approval/id approval-id
-             :approval/final-status final-status)))
-
-(defn approval-expired
-  "Create an approval/expired event."
-  [stream workflow-id approval-id]
-  (-> (core/create-envelope stream :approval/expired workflow-id
-                            "Approval request expired")
-      (assoc :approval/id approval-id)))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/event-stream/src/ai/miniforge/event_stream/approval.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/approval.clj
@@ -22,10 +22,10 @@
    signing from authorized signers. Approval states flow:
    pending → approved | rejected | expired | cancelled.
 
-   Layer 0: Approval request creation
-   Layer 1: Approval signing and status checking
-   Layer 2: Approval manager (atom-backed store)
-   Layer 3: Approval event constructors"
+   Layer 0: Response predicates, expiry/signing checks, the approval
+            manager (atom-backed store), and approval event constructors
+   Layer 1: Approval request creation, signing, and status checks
+   Layer 2: Approval listing"
   (:require
    [ai.miniforge.event-stream.core :as core]
    [ai.miniforge.response.interface :as response]))

--- a/components/event-stream/src/ai/miniforge/event_stream/archive.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/archive.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.archive
   "BD-2b sub-3b: atomic workflow archive.
 
@@ -59,19 +58,22 @@
    [java.io File RandomAccessFile]
    [java.nio.file Files StandardCopyOption]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; STRATIFIED-DESIGN LAYERING
 ;;
 ;;   Layer 0  atomic file primitives (fsync, atomic rename, marker)
 ;;   Layer 1  manifest-bound transitions (stage-archiving!,
-;;            complete-snapshot-rename!, mark-archive-complete!)
+;;            complete-snapshot-rename!, mark-archive-complete!) and
+;;            the fleet-wide incomplete-archive scan
+;;            (scan-incomplete-archives — no upward calls, so it sits
+;;            alongside the other Layer 1 transitions rather than
+;;            with the Layer 3 driver below)
 ;;   Layer 2  workflow-bound orchestration
 ;;            (archive-workflow!, recover-incomplete-archive!)
-;;   Layer 3  fleet-level scan + recover
+;;   Layer 3  fleet-level recovery driver
 ;;            (recover-all-incomplete!)
-
-;------------------------------------------------------------------------------ Layer 0 — atomic file primitives
-
-(defn- fsync-file!
+(defn- ^{:stratum 0} fsync-file!
   "Force-flush `file`'s data + metadata to disk. No-op when `file`
    doesn't exist (the snapshot-tmp step may legitimately skip when
    there's no snapshot yet — sub-3c fills it in)."
@@ -80,7 +82,7 @@
     (with-open [raf (RandomAccessFile. file "rw")]
       (.force (.getChannel raf) true))))
 
-(defn- fsync-dir!
+(defn- ^{:stratum 0} fsync-dir!
   "Best-effort fsync on a directory. On macOS / Linux this commits
    the directory entries (renames, marker touches) to disk; on
    filesystems that don't support directory sync the call is a
@@ -98,7 +100,7 @@
         ;; clean shutdown.
         nil))))
 
-(defn- atomic-rename!
+(defn- ^{:stratum 0} atomic-rename!
   "Atomic rename `src` → `dst` via `Files/move` with `ATOMIC_MOVE` +
    `REPLACE_EXISTING`. Requires same filesystem. Returns the dst
    `Path` on success."
@@ -109,7 +111,7 @@
                           [StandardCopyOption/ATOMIC_MOVE
                            StandardCopyOption/REPLACE_EXISTING])))
 
-(defn- touch-marker!
+(defn- ^{:stratum 0} touch-marker!
   "Create an empty marker file at `path`. Used for
    `archived.marker` so a partial archive (missing the marker) is
    identifiable on next boot."
@@ -117,21 +119,21 @@
   (.mkdirs (.getParentFile path))
   (.createNewFile path))
 
-(defn- snapshot-path
+(defn- ^{:stratum 0} snapshot-path
   ^File [^File workflow-dir]
   (io/file workflow-dir (layout/snapshot-filename)))
 
-(defn- snapshot-tmp-path
+(defn- ^{:stratum 0} snapshot-tmp-path
   ^File [^File workflow-dir]
   (io/file workflow-dir (layout/snapshot-tmp-filename)))
 
-(defn- marker-path
+(defn- ^{:stratum 0} marker-path
   ^File [^File workflow-dir]
   (io/file workflow-dir (layout/archived-marker-filename)))
 
-;------------------------------------------------------------------------------ Layer 1 — manifest-bound transitions over Layer 0
+;------------------------------------------------------------------------------ Layer 1
 
-(defn- stage-archiving!
+(defn- ^{:stratum 1} stage-archiving!
   "Step 3–4: update the manifest to `archive_status = :archiving`,
    merge any snapshot watermark, and fsync. The manifest writer
    itself is already atomic + fsynced, so the file-level guarantee
@@ -147,7 +149,7 @@
       (fsync-dir! live-dir)
       staged-manifest)))
 
-(defn- complete-snapshot-rename!
+(defn- ^{:stratum 1} complete-snapshot-rename!
   "Step 5: rename `snapshot.transit.json.tmp` → `snapshot.transit.json`
    when the tmp exists. Sub-3c writes the tmp; sub-3b tolerates its
    absence (the manifest's `snapshot_status` stays `:none`)."
@@ -157,7 +159,7 @@
     (when (.exists tmp)
       (atomic-rename! tmp final))))
 
-(defn- mark-archive-complete!
+(defn- ^{:stratum 1} mark-archive-complete!
   "Step 7–8: stamp `archived_at` and `archive_status = :archived` on the
    manifest FIRST, then touch the archived marker, then fsync the archive
    directory plus its parent so both writes hit disk.
@@ -178,9 +180,30 @@
       (fsync-dir! (.getParentFile archived-dir))
       completed)))
 
-;------------------------------------------------------------------------------ Layer 2 — workflow-bound orchestration over Layer 1
+(defn ^{:stratum 1} scan-incomplete-archives
+  "List workflow-ids whose archive is half-completed under
+   `base-dir`. Result is a vector of `{:workflow-id ... :state ...}`
+   where `:state` is one of `:archiving-in-live` (step 5 onward
+   pending) or `:archived-no-marker` (step 7 pending). Useful for
+   the cleanup pass (sub-3c) and for startup recovery."
+  [base-dir]
+  (let [live     (sinks/live-dir base-dir)
+        archived (sinks/archived-dir base-dir)]
+    (vec
+      (concat
+        (for [^File d (when (.isDirectory live) (.listFiles live))
+              :when (.isDirectory d)
+              :let [m (manifest/load-manifest d)]
+              :when (and m (= :archiving (:archive_status m)))]
+          {:workflow-id (.getName d) :state :archiving-in-live})
+        (for [^File d (when (.isDirectory archived) (.listFiles archived))
+              :when (.isDirectory d)
+              :when (not (.exists (marker-path d)))]
+          {:workflow-id (.getName d) :state :archived-no-marker})))))
 
-(defn archive-workflow!
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} archive-workflow!
   "Archive a workflow's directory from `live/{wid}/` to
    `archived/{wid}/`. Returns the final `archived/{wid}/` `File`.
 
@@ -238,7 +261,7 @@
       (anomaly/let-ok [_completed (mark-archive-complete! archived)]
         archived))))
 
-(defn recover-incomplete-archive!
+(defn ^{:stratum 2} recover-incomplete-archive!
   "Resume a half-finished archive at `live-dir` (manifest's
    `archive_status` is `:archiving`) or `archived-dir` (missing
    `archived.marker`). Idempotent — completes whatever steps are
@@ -269,30 +292,9 @@
       ;; Nothing to do.
       :else nil)))
 
-;------------------------------------------------------------------------------ Layer 3 — fleet-level scan + recover over Layer 2
+;------------------------------------------------------------------------------ Layer 3
 
-(defn scan-incomplete-archives
-  "List workflow-ids whose archive is half-completed under
-   `base-dir`. Result is a vector of `{:workflow-id ... :state ...}`
-   where `:state` is one of `:archiving-in-live` (step 5 onward
-   pending) or `:archived-no-marker` (step 7 pending). Useful for
-   the cleanup pass (sub-3c) and for startup recovery."
-  [base-dir]
-  (let [live     (sinks/live-dir base-dir)
-        archived (sinks/archived-dir base-dir)]
-    (vec
-      (concat
-        (for [^File d (when (.isDirectory live) (.listFiles live))
-              :when (.isDirectory d)
-              :let [m (manifest/load-manifest d)]
-              :when (and m (= :archiving (:archive_status m)))]
-          {:workflow-id (.getName d) :state :archiving-in-live})
-        (for [^File d (when (.isDirectory archived) (.listFiles archived))
-              :when (.isDirectory d)
-              :when (not (.exists (marker-path d)))]
-          {:workflow-id (.getName d) :state :archived-no-marker})))))
-
-(defn recover-all-incomplete!
+(defn ^{:stratum 3} recover-all-incomplete!
   "Walk `base-dir` and finish every half-completed archive found by
    `scan-incomplete-archives`. Returns a vector of recovered
    workflow-ids, or the first anomaly returned by recovery. Intended

--- a/components/event-stream/src/ai/miniforge/event_stream/control.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/control.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.control
   "Structured control actions with RBAC for N8 OCI compliance.
 
@@ -30,43 +29,41 @@
    [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Control state management
 
-(defn create-control-state
+;; Control state management
+(defn ^{:stratum 0} create-control-state
   "Create a canonical control-state atom for workflow execution.
    Used by both CLI dashboard poller and TUI to drive pause/resume/cancel."
   []
   (atom {:paused false :stopped false :adjustments {}}))
 
-(defn pause!
+(defn ^{:stratum 0} pause!
   "Pause workflow execution."
   [control-state]
   (swap! control-state assoc :paused true))
 
-(defn resume!
+(defn ^{:stratum 0} resume!
   "Resume paused workflow execution."
   [control-state]
   (swap! control-state assoc :paused false))
 
-(defn cancel!
+(defn ^{:stratum 0} cancel!
   "Cancel workflow execution."
   [control-state]
   (swap! control-state assoc :stopped true))
 
-(defn paused?
+(defn ^{:stratum 0} paused?
   "Check if workflow is paused."
   [control-state]
   (:paused @control-state))
 
-(defn cancelled?
+(defn ^{:stratum 0} cancelled?
   "Check if workflow is cancelled."
   [control-state]
   (:stopped @control-state))
 
-;------------------------------------------------------------------------------ Layer 1a
 ;; RBAC role definitions
-
-(def default-roles
+(def ^{:stratum 0} default-roles
   "Default RBAC roles mapping role -> target-category -> permitted actions."
   {:operator {:workflows #{:pause :resume :retry :cancel}
               :agents #{:quarantine :adjust-budget}
@@ -77,14 +74,12 @@
            :fleet #{:emergency-stop :drain}
            :approvals #{:gate-override :budget-escalation}}})
 
-(def target-categories
+(def ^{:stratum 0} target-categories
   "Valid target types for control actions."
   #{:workflow :agent :fleet})
 
-;------------------------------------------------------------------------------ Layer 1b
 ;; Control action creation
-
-(defn create-control-action
+(defn ^{:stratum 0} create-control-action
   "Create a structured control action.
 
    Arguments:
@@ -105,28 +100,33 @@
     (:justification opts) (assoc :action/justification (:justification opts))
     (:parameters opts) (assoc :action/parameters (:parameters opts))))
 
-;------------------------------------------------------------------------------ Layer 1c
 ;; RBAC authorization
-
-(def target-type->category
+(def ^{:stratum 0} target-type->category
   "Map from target type to RBAC category keyword."
   {:workflow :workflows
    :agent    :agents
    :fleet    :fleet})
 
-(defn authorization-granted
+(defn ^{:stratum 0} authorization-granted
   "Build a granted authorization result."
   [reason]
   {:authorized? true :reason reason})
 
-(defn authorization-denied
+(defn ^{:stratum 0} authorization-denied
   "Build a denied authorization result with anomaly."
   [anomaly-category message context]
   {:authorized? false
    :reason message
    :anomaly (response/make-anomaly anomaly-category message context)})
 
-(defn authorize-action
+;; Approval-aware control action execution
+(def ^{:stratum 0} actions-requiring-approval
+  "Action types that require multi-party approval before execution."
+  #{:gate-override :budget-escalation})
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} authorize-action
   "Check RBAC authorization for a control action.
 
    Arguments:
@@ -164,10 +164,15 @@
                              :action-type action-type
                              :target-type target-type}))))
 
-;------------------------------------------------------------------------------ Layer 2a
-;; Control action execution
+(defn ^{:stratum 1} requires-approval?
+  "Check if a control action type requires multi-party approval."
+  [action-type]
+  (contains? actions-requiring-approval action-type))
 
-(defn execute-control-action!
+;------------------------------------------------------------------------------ Layer 2
+
+;; Control action execution
+(defn ^{:stratum 2} execute-control-action!
   "Execute a control action with RBAC authorization.
 
    Calls authorize-action before executing. Returns authorization failure
@@ -217,19 +222,9 @@
                           stream workflow-id action-id result))
           result)))))
 
-;------------------------------------------------------------------------------ Layer 2b
-;; Approval-aware control action execution
+;------------------------------------------------------------------------------ Layer 3
 
-(def actions-requiring-approval
-  "Action types that require multi-party approval before execution."
-  #{:gate-override :budget-escalation})
-
-(defn requires-approval?
-  "Check if a control action type requires multi-party approval."
-  [action-type]
-  (contains? actions-requiring-approval action-type))
-
-(defn execute-control-action-with-approval!
+(defn ^{:stratum 3} execute-control-action-with-approval!
   "Execute a control action, checking approval requirements first.
 
    If the action type requires approval (:gate-override, :budget-escalation),

--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.core
   "Event bus and event constructors for workflow observability."
   (:require
@@ -26,47 +25,26 @@
    [ai.miniforge.event-stream.sinks :as sinks]))
 
 ;------------------------------------------------------------------------------ Layer 0
+
 ;; Constants
+(def ^{:stratum 0} ^:const event-version "1.0.0")
 
-(def ^:const event-version "1.0.0")
-
-(def ^:private redirect-transition-type
+(def ^{:stratum 0} ^:private redirect-transition-type
   :transition/redirect)
 
-(def ^:private phase-transition-request-key
+(def ^{:stratum 0} ^:private phase-transition-request-key
   :phase/transition-request)
 
-(def ^:private transition-type-key
+(def ^{:stratum 0} ^:private transition-type-key
   :transition/type)
 
-(def ^:private transition-target-key
+(def ^{:stratum 0} ^:private transition-target-key
   :transition/target)
 
-(defn- phase-transition-request
-  [result]
-  (get result phase-transition-request-key))
-
-(defn- redirect-target
-  "Project a redirect target for legacy consumers.
-
-   The workflow runner now emits :phase/transition-request. This helper keeps
-   :phase/redirect-to available only when the transition request represents a
-  redirect, so older event consumers do not break while the newer event shape
-  remains authoritative."
-  [result]
-  (let [request (phase-transition-request result)
-        transition-type (get request transition-type-key)]
-    (when (= redirect-transition-type transition-type)
-      (get request transition-target-key))))
-
-;------------------------------------------------------------------------------ Layer 0
 ;; Event persistence via configurable sinks
 ;; Note: File persistence moved to sinks.clj for configurability
-
-;------------------------------------------------------------------------------ Layer 0
 ;; Event envelope constructor
-
-(defn- next-event-id
+(defn- ^{:stratum 0} next-event-id
   [generator]
   (cond
     (response/anomaly-map? generator) generator
@@ -75,7 +53,240 @@
     :else
     (random-uuid)))
 
-(defn create-envelope
+;; Event bus operations
+(defn ^{:stratum 0} create-event-stream
+  "Create an event stream with configurable sinks.
+
+   Options:
+     :logger              - Optional logger instance
+     :sinks               - Vector of sink functions (default: file sink)
+     :config              - Config map to create sinks from
+     :snowflake-generator - Optional snowflake event-id generator
+                            (BD-2b). When supplied, `create-envelope`
+                            uses it for `:event/id` so events sort
+                            lexically by creation order. Without it,
+                            `:event/id` falls back to `random-uuid`
+                            and the file sink uses the legacy
+                            `{timestamp}-{uuid}.json` filename.
+
+   Returns: Event stream atom
+
+   Example:
+     ;; Default file sink
+     (create-event-stream)
+
+     ;; Custom sinks
+     (create-event-stream {:sinks [(sinks/file-sink) (sinks/stdout-sink)]})
+
+     ;; From config
+     (create-event-stream {:config user-config})
+
+     ;; With a Snowflake event-id generator (BD-2b)
+     (create-event-stream {:snowflake-generator (snowflake/create-generator)})"
+  [& [opts]]
+  (let [;; Create sinks from config or use provided sinks or default
+        event-sinks (cond
+                      (:sinks opts) (:sinks opts)
+                      (:config opts) (sinks/create-sinks-from-config (:config opts))
+                      :else [(sinks/file-sink)])] ;; Default to file sink
+    (atom {:events []
+           :subscribers {}
+           :filters {}
+           :sequence-numbers {}
+           :logger (:logger opts)
+           :sinks event-sinks
+           ;; BD-2a: workflow-scoped publisher fence. Once a workflow id
+           ;; is in this set, `publish!` rejects further events for that
+           ;; workflow rather than running sinks/subscribers.
+           :quiesced-workflows #{}
+           ;; BD-2a: in-flight publish counter. `drain!` waits on this
+           ;; reaching zero before draining sinks. `publish!` increments
+           ;; on entry (after the quiesce check) and decrements in a
+           ;; finally so a sink exception still releases the slot.
+           :in-flight 0
+           ;; BD-2b: optional Snowflake event-id generator. When present,
+           ;; `create-envelope` calls it for `:event/id` so events sort
+           ;; lexically by creation order. nil = random-uuid fallback.
+           :snowflake-generator (:snowflake-generator opts)})))
+
+;; publish! helpers — small, single-purpose pieces composed by publish!
+;; itself. Each helper is testable in isolation; tests live in
+;; `publish_helpers_test.clj`.
+(defn- ^{:stratum 0} workflow-quiesced?
+  "True when `event`'s workflow id has been fenced via `quiesce!`."
+  [stream event]
+  (when-let [wid (:workflow/id event)]
+    (contains? (:quiesced-workflows @stream) wid)))
+
+(defn- ^{:stratum 0} rejection-result
+  "Build the structured rejection map returned to a publisher whose
+   workflow has been quiesced. Stable shape so callers can pattern-match."
+  [event reason]
+  {:rejected?   true
+   :reason      reason
+   :workflow-id (:workflow/id event)
+   :event-type  (:event/type event)})
+
+(defn- ^{:stratum 0} log-rejection!
+  "Surface a quiesce rejection at warn level if a logger is configured."
+  [logger event]
+  (when logger
+    (log/warn logger :event-stream :event/rejected-after-quiesce
+              {:message "publish! rejected: workflow quiesced"
+               :data    {:event-type  (:event/type event)
+                         :workflow-id (:workflow/id event)}})))
+
+(def ^{:stratum 0} ^:private quiesced-sentinel
+  "Sentinel value returned by `with-in-flight` when the event's workflow was
+   quiesced between the caller's fast-path check and the atomic increment,
+   closing the TOCTOU window. Distinct from nil so callers can distinguish
+   'quiesced-during-acquire' from 'no-workflow-id event'."
+  ::quiesced)
+
+(defn- ^{:stratum 0} try-acquire-in-flight!
+  "Atomically check the quiesce fence for `event`'s workflow and, if not
+   fenced, increment the in-flight counter.
+
+   Uses a decision volatile captured inside the `swap!` fn to signal the
+   outcome to the caller without polluting the stream map with temporary keys.
+   The `swap!` fn may be retried by the atom under contention — the volatile
+   is reset on each retry so the final value always reflects the last
+   successful swap.
+
+   Returns true when the slot was acquired (in-flight incremented), false
+   when the workflow was quiesced at the moment of the swap."
+  [stream event]
+  (let [wid      (:workflow/id event)
+        acquired (volatile! false)]
+    (swap! stream
+           (fn [s]
+             (if (and wid (contains? (:quiesced-workflows s) wid))
+               (do (vreset! acquired false) s)
+               (do (vreset! acquired true)
+                   (update s :in-flight inc)))))
+    @acquired))
+
+(defn- ^{:stratum 0} record-event!
+  "Append `event` to the in-memory event log."
+  [stream event]
+  (swap! stream update :events conj event))
+
+(defn- ^{:stratum 0} deliver-to-sink!
+  "Invoke `sink` with `event`, swallowing exceptions and logging them.
+   A failing sink must not break others or the publish path."
+  [sink event logger]
+  (try
+    (sink event)
+    (catch Exception e
+      (when logger
+        (log/warn logger :event-stream :sink-error
+                  {:message "Event sink failed"
+                   :data    {:event-type (:event/type event)
+                             :anomaly    (response/from-exception e)}})))))
+
+(defn- ^{:stratum 0} deliver-to-subscriber!
+  "Invoke `callback` for `event` when `filter-fn` accepts it,
+   swallowing exceptions and logging them."
+  [sub-id callback filter-fn event logger]
+  (when (filter-fn event)
+    (try
+      (callback event)
+      (catch Exception e
+        (when logger
+          (log/error logger :event-stream :event/callback-error
+                     {:message "Event callback failed"
+                      :data    {:subscriber-id sub-id
+                                :event-type    (:event/type event)
+                                :anomaly       (response/from-exception e)}}))))))
+
+(defn- ^{:stratum 0} log-published!
+  "Debug-log that `event` reached the subscribers."
+  [logger event]
+  (when logger
+    (log/debug logger :event-stream :event/published
+               {:message "Event published"
+                :data    {:event-type  (:event/type event)
+                          :workflow-id (:workflow/id event)
+                          :sequence    (:event/sequence-number event)}})))
+
+(defn ^{:stratum 0} subscribe!
+  ([stream subscriber-id callback]
+   (subscribe! stream subscriber-id callback (constantly true)))
+  ([stream subscriber-id callback filter-fn]
+   (swap! stream
+          (fn [s]
+            (-> s
+                (assoc-in [:subscribers subscriber-id] callback)
+                (assoc-in [:filters subscriber-id] filter-fn))))
+   subscriber-id))
+
+(defn ^{:stratum 0} unsubscribe! [stream subscriber-id]
+  (swap! stream
+         (fn [s]
+           (-> s
+               (update :subscribers dissoc subscriber-id)
+               (update :filters dissoc subscriber-id))))
+  nil)
+
+;; BD-2a: workflow-scoped publisher quiesce + sink drain barrier.
+;;
+;; `quiesce!` fences future publishes for a workflow so the terminal event
+;; for that workflow is genuinely the last. `drain!` waits for in-flight
+;; publishes to complete and then asks each sink that exposes a drain hook
+;; (under the sink's metadata) to flush. Together they replace the
+;; pre-BD-2a race where headless exits could land before background
+;; producers finished publishing or sinks finished writing.
+(defn- ^{:stratum 0} wait-for-condition
+  "Spin-wait until `pred` returns truthy or the deadline passes. Returns
+   the final pred value (truthy = condition met before deadline)."
+  [pred deadline-ms]
+  (loop []
+    (let [v (pred)]
+      (cond
+        v v
+        (>= (System/currentTimeMillis) deadline-ms) nil
+        :else (do (Thread/sleep 10) (recur))))))
+
+;; Query API
+(defn ^{:stratum 0} get-events [stream & [opts]]
+  (let [{:keys [workflow-id event-type offset limit]} opts
+        events (:events @stream)]
+    (cond->> events
+      workflow-id (filter #(= workflow-id (:workflow/id %)))
+      event-type (filter #(= event-type (:event/type %)))
+      offset (drop offset)
+      limit (take limit)
+      true vec)))
+
+(defn ^{:stratum 0} get-latest-status [stream workflow-id & [agent-id]]
+  (->> (:events @stream)
+       (filter #(= :agent/status (:event/type %)))
+       (filter #(= workflow-id (:workflow/id %)))
+       (filter #(or (nil? agent-id) (= agent-id (:agent/id %))))
+       last))
+
+(defn- ^{:stratum 0} dependency-id-string
+  [dependency-id]
+  (if (keyword? dependency-id)
+    (name dependency-id)
+    (str dependency-id)))
+
+;; Observer / knowledge failure events
+(defn- ^{:stratum 0} failure-message
+  [failure]
+  (cond
+    (instance? Throwable failure) (ex-message failure)
+    (map? failure) (or (:error failure) (:message failure) (pr-str failure))
+    (some? failure) (str failure)
+    :else nil))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} phase-transition-request
+  [result]
+  (get result phase-transition-request-key))
+
+(defn ^{:stratum 1} create-envelope
   "Create an event envelope with sequence numbering.
 
    When the stream carries a `:snowflake-generator` (BD-2b), the
@@ -133,94 +344,7 @@
            (:agent/id opts)          (assoc :agent/id (:agent/id opts))
            (:agent/instance-id opts) (assoc :agent/instance-id (:agent/instance-id opts))))))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Event bus operations
-
-(defn create-event-stream
-  "Create an event stream with configurable sinks.
-
-   Options:
-     :logger              - Optional logger instance
-     :sinks               - Vector of sink functions (default: file sink)
-     :config              - Config map to create sinks from
-     :snowflake-generator - Optional snowflake event-id generator
-                            (BD-2b). When supplied, `create-envelope`
-                            uses it for `:event/id` so events sort
-                            lexically by creation order. Without it,
-                            `:event/id` falls back to `random-uuid`
-                            and the file sink uses the legacy
-                            `{timestamp}-{uuid}.json` filename.
-
-   Returns: Event stream atom
-
-   Example:
-     ;; Default file sink
-     (create-event-stream)
-
-     ;; Custom sinks
-     (create-event-stream {:sinks [(sinks/file-sink) (sinks/stdout-sink)]})
-
-     ;; From config
-     (create-event-stream {:config user-config})
-
-     ;; With a Snowflake event-id generator (BD-2b)
-     (create-event-stream {:snowflake-generator (snowflake/create-generator)})"
-  [& [opts]]
-  (let [;; Create sinks from config or use provided sinks or default
-        event-sinks (cond
-                      (:sinks opts) (:sinks opts)
-                      (:config opts) (sinks/create-sinks-from-config (:config opts))
-                      :else [(sinks/file-sink)])] ;; Default to file sink
-    (atom {:events []
-           :subscribers {}
-           :filters {}
-           :sequence-numbers {}
-           :logger (:logger opts)
-           :sinks event-sinks
-           ;; BD-2a: workflow-scoped publisher fence. Once a workflow id
-           ;; is in this set, `publish!` rejects further events for that
-           ;; workflow rather than running sinks/subscribers.
-           :quiesced-workflows #{}
-           ;; BD-2a: in-flight publish counter. `drain!` waits on this
-           ;; reaching zero before draining sinks. `publish!` increments
-           ;; on entry (after the quiesce check) and decrements in a
-           ;; finally so a sink exception still releases the slot.
-           :in-flight 0
-           ;; BD-2b: optional Snowflake event-id generator. When present,
-           ;; `create-envelope` calls it for `:event/id` so events sort
-           ;; lexically by creation order. nil = random-uuid fallback.
-           :snowflake-generator (:snowflake-generator opts)})))
-
-;------------------------------------------------------------------------------ Layer 0
-;; publish! helpers — small, single-purpose pieces composed by publish!
-;; itself. Each helper is testable in isolation; tests live in
-;; `publish_helpers_test.clj`.
-
-(defn- workflow-quiesced?
-  "True when `event`'s workflow id has been fenced via `quiesce!`."
-  [stream event]
-  (when-let [wid (:workflow/id event)]
-    (contains? (:quiesced-workflows @stream) wid)))
-
-(defn- rejection-result
-  "Build the structured rejection map returned to a publisher whose
-   workflow has been quiesced. Stable shape so callers can pattern-match."
-  [event reason]
-  {:rejected?   true
-   :reason      reason
-   :workflow-id (:workflow/id event)
-   :event-type  (:event/type event)})
-
-(defn- log-rejection!
-  "Surface a quiesce rejection at warn level if a logger is configured."
-  [logger event]
-  (when logger
-    (log/warn logger :event-stream :event/rejected-after-quiesce
-              {:message "publish! rejected: workflow quiesced"
-               :data    {:event-type  (:event/type event)
-                         :workflow-id (:workflow/id event)}})))
-
-(defn- rejection-if-quiesced
+(defn- ^{:stratum 1} rejection-if-quiesced
   "Return the structured rejection map when `event`'s workflow is fenced,
    else nil. Logs the rejection as a side effect so callers don't have
    to do it twice."
@@ -229,37 +353,7 @@
     (log-rejection! (:logger @stream) event)
     (rejection-result event :workflow-quiesced)))
 
-(def ^:private quiesced-sentinel
-  "Sentinel value returned by `with-in-flight` when the event's workflow was
-   quiesced between the caller's fast-path check and the atomic increment,
-   closing the TOCTOU window. Distinct from nil so callers can distinguish
-   'quiesced-during-acquire' from 'no-workflow-id event'."
-  ::quiesced)
-
-(defn- try-acquire-in-flight!
-  "Atomically check the quiesce fence for `event`'s workflow and, if not
-   fenced, increment the in-flight counter.
-
-   Uses a decision volatile captured inside the `swap!` fn to signal the
-   outcome to the caller without polluting the stream map with temporary keys.
-   The `swap!` fn may be retried by the atom under contention — the volatile
-   is reset on each retry so the final value always reflects the last
-   successful swap.
-
-   Returns true when the slot was acquired (in-flight incremented), false
-   when the workflow was quiesced at the moment of the swap."
-  [stream event]
-  (let [wid      (:workflow/id event)
-        acquired (volatile! false)]
-    (swap! stream
-           (fn [s]
-             (if (and wid (contains? (:quiesced-workflows s) wid))
-               (do (vreset! acquired false) s)
-               (do (vreset! acquired true)
-                   (update s :in-flight inc)))))
-    @acquired))
-
-(defn- with-in-flight
+(defn- ^{:stratum 1} with-in-flight
   "Run `body-fn` while incrementing the stream's in-flight publish
    counter, decrementing in a finally so an exception still releases the
    slot. Returns body-fn's result, or `quiesced-sentinel` when the
@@ -277,145 +371,21 @@
       (finally
         (swap! stream update :in-flight dec)))))
 
-(defn- record-event!
-  "Append `event` to the in-memory event log."
-  [stream event]
-  (swap! stream update :events conj event))
-
-(defn- deliver-to-sink!
-  "Invoke `sink` with `event`, swallowing exceptions and logging them.
-   A failing sink must not break others or the publish path."
-  [sink event logger]
-  (try
-    (sink event)
-    (catch Exception e
-      (when logger
-        (log/warn logger :event-stream :sink-error
-                  {:message "Event sink failed"
-                   :data    {:event-type (:event/type event)
-                             :anomaly    (response/from-exception e)}})))))
-
-(defn- deliver-to-sinks!
+(defn- ^{:stratum 1} deliver-to-sinks!
   "Fan `event` out to every configured sink. Each sink runs in
    isolation via `deliver-to-sink!`."
   [sinks event logger]
   (doseq [sink sinks]
     (deliver-to-sink! sink event logger)))
 
-(defn- deliver-to-subscriber!
-  "Invoke `callback` for `event` when `filter-fn` accepts it,
-   swallowing exceptions and logging them."
-  [sub-id callback filter-fn event logger]
-  (when (filter-fn event)
-    (try
-      (callback event)
-      (catch Exception e
-        (when logger
-          (log/error logger :event-stream :event/callback-error
-                     {:message "Event callback failed"
-                      :data    {:subscriber-id sub-id
-                                :event-type    (:event/type event)
-                                :anomaly       (response/from-exception e)}}))))))
-
-(defn- deliver-to-subscribers!
+(defn- ^{:stratum 1} deliver-to-subscribers!
   "Fan `event` out to every subscriber that accepts it via its filter."
   [subscribers filters event logger]
   (doseq [[sub-id callback] subscribers]
     (let [filter-fn (get filters sub-id (constantly true))]
       (deliver-to-subscriber! sub-id callback filter-fn event logger))))
 
-(defn- log-published!
-  "Debug-log that `event` reached the subscribers."
-  [logger event]
-  (when logger
-    (log/debug logger :event-stream :event/published
-               {:message "Event published"
-                :data    {:event-type  (:event/type event)
-                          :workflow-id (:workflow/id event)
-                          :sequence    (:event/sequence-number event)}})))
-
-;------------------------------------------------------------------------------ Layer 1
-;; publish! orchestrates the helpers above as a small pipeline.
-
-(defn publish!
-  "Publish `event` to the stream.
-
-   When the event's workflow has been quiesced (BD-2a), short-circuits
-   with a structured `{:rejected? true ...}` map and runs no sinks or
-   subscribers. Otherwise: fan out to sinks, append to the in-memory
-   log, fan out to subscribers, log, and return `event`.
-
-   In-flight publishes are tracked so `quiesce!` / `drain!` can wait
-   for the stream to settle before reporting at-rest.
-
-   The quiesce fence is enforced atomically: `with-in-flight` fuses the
-   quiesce-check and the in-flight increment into a single `swap!`,
-   eliminating the TOCTOU window that allowed a publish to slip through
-   after `quiesce!` fenced the workflow."
-  [stream event]
-  (if (response/anomaly-map? event)
-    event
-    ;; Fast path: check quiesce before acquiring the in-flight slot so
-    ;; already-quiesced workflows skip the swap! entirely.
-    (or (rejection-if-quiesced stream event)
-        (let [result (with-in-flight stream event
-                       (fn []
-                         (let [{:keys [sinks subscribers filters logger]} @stream]
-                           (deliver-to-sinks! sinks event logger)
-                           (record-event! stream event)
-                           (deliver-to-subscribers! subscribers filters event logger)
-                           (log-published! logger event)
-                           event)))]
-          ;; with-in-flight returns quiesced-sentinel when the workflow was
-          ;; fenced during the atomic acquire (the TOCTOU window). Convert
-          ;; to the canonical rejection shape so callers see a consistent
-          ;; {:rejected? true ...} map regardless of which path triggered it.
-          (if (= result quiesced-sentinel)
-            (do (log-rejection! (:logger @stream) event)
-                (rejection-result event :workflow-quiesced))
-            result)))))
-
-(defn subscribe!
-  ([stream subscriber-id callback]
-   (subscribe! stream subscriber-id callback (constantly true)))
-  ([stream subscriber-id callback filter-fn]
-   (swap! stream
-          (fn [s]
-            (-> s
-                (assoc-in [:subscribers subscriber-id] callback)
-                (assoc-in [:filters subscriber-id] filter-fn))))
-   subscriber-id))
-
-(defn unsubscribe! [stream subscriber-id]
-  (swap! stream
-         (fn [s]
-           (-> s
-               (update :subscribers dissoc subscriber-id)
-               (update :filters dissoc subscriber-id))))
-  nil)
-
-;------------------------------------------------------------------------------ Layer 1
-;; BD-2a: workflow-scoped publisher quiesce + sink drain barrier.
-;;
-;; `quiesce!` fences future publishes for a workflow so the terminal event
-;; for that workflow is genuinely the last. `drain!` waits for in-flight
-;; publishes to complete and then asks each sink that exposes a drain hook
-;; (under the sink's metadata) to flush. Together they replace the
-;; pre-BD-2a race where headless exits could land before background
-;; producers finished publishing or sinks finished writing.
-
-(defn- wait-for-condition
-  "Spin-wait until `pred` returns truthy or the deadline passes. Returns
-   the final pred value (truthy = condition met before deadline)."
-  [pred deadline-ms]
-  (loop []
-    (let [v (pred)]
-      (cond
-        v v
-        (>= (System/currentTimeMillis) deadline-ms) nil
-        :else (do (Thread/sleep 10) (recur))))))
-
-(defn quiesce!
+(defn ^{:stratum 1} quiesce!
   "Fence publishers for `workflow-id` and wait for any in-flight publishes
    to settle. After return, `publish!` for that workflow returns
    `{:rejected? true :reason :workflow-quiesced ...}` instead of running
@@ -453,7 +423,7 @@
        {:ok? true :pending-publishers pending}
        {:ok? false :reason :timeout :pending-publishers pending}))))
 
-(defn drain!
+(defn ^{:stratum 1} drain!
   "Wait until every event accepted by `publish!` before this call has
    reached all configured sinks, including any sink-specific flush hook.
 
@@ -524,29 +494,61 @@
            {:ok? true :drained-count (count results)}))))))
 
 ;------------------------------------------------------------------------------ Layer 2
-;; Query API
 
-(defn get-events [stream & [opts]]
-  (let [{:keys [workflow-id event-type offset limit]} opts
-        events (:events @stream)]
-    (cond->> events
-      workflow-id (filter #(= workflow-id (:workflow/id %)))
-      event-type (filter #(= event-type (:event/type %)))
-      offset (drop offset)
-      limit (take limit)
-      true vec)))
+(defn- ^{:stratum 2} redirect-target
+  "Project a redirect target for legacy consumers.
 
-(defn get-latest-status [stream workflow-id & [agent-id]]
-  (->> (:events @stream)
-       (filter #(= :agent/status (:event/type %)))
-       (filter #(= workflow-id (:workflow/id %)))
-       (filter #(or (nil? agent-id) (= agent-id (:agent/id %))))
-       last))
+   The workflow runner now emits :phase/transition-request. This helper keeps
+   :phase/redirect-to available only when the transition request represents a
+  redirect, so older event consumers do not break while the newer event shape
+  remains authoritative."
+  [result]
+  (let [request (phase-transition-request result)
+        transition-type (get request transition-type-key)]
+    (when (= redirect-transition-type transition-type)
+      (get request transition-target-key))))
 
-;------------------------------------------------------------------------------ Layer 3
+;; publish! orchestrates the helpers above as a small pipeline.
+(defn ^{:stratum 2} publish!
+  "Publish `event` to the stream.
+
+   When the event's workflow has been quiesced (BD-2a), short-circuits
+   with a structured `{:rejected? true ...}` map and runs no sinks or
+   subscribers. Otherwise: fan out to sinks, append to the in-memory
+   log, fan out to subscribers, log, and return `event`.
+
+   In-flight publishes are tracked so `quiesce!` / `drain!` can wait
+   for the stream to settle before reporting at-rest.
+
+   The quiesce fence is enforced atomically: `with-in-flight` fuses the
+   quiesce-check and the in-flight increment into a single `swap!`,
+   eliminating the TOCTOU window that allowed a publish to slip through
+   after `quiesce!` fenced the workflow."
+  [stream event]
+  (if (response/anomaly-map? event)
+    event
+    ;; Fast path: check quiesce before acquiring the in-flight slot so
+    ;; already-quiesced workflows skip the swap! entirely.
+    (or (rejection-if-quiesced stream event)
+        (let [result (with-in-flight stream event
+                       (fn []
+                         (let [{:keys [sinks subscribers filters logger]} @stream]
+                           (deliver-to-sinks! sinks event logger)
+                           (record-event! stream event)
+                           (deliver-to-subscribers! subscribers filters event logger)
+                           (log-published! logger event)
+                           event)))]
+          ;; with-in-flight returns quiesced-sentinel when the workflow was
+          ;; fenced during the atomic acquire (the TOCTOU window). Convert
+          ;; to the canonical rejection shape so callers see a consistent
+          ;; {:rejected? true ...} map regardless of which path triggered it.
+          (if (= result quiesced-sentinel)
+            (do (log-rejection! (:logger @stream) event)
+                (rejection-result event :workflow-quiesced))
+            result)))))
+
 ;; Event constructors (N3 compliant)
-
-(defn workflow-started
+(defn ^{:stratum 2} workflow-started
   "Build a :workflow/started envelope. Multi-arity to preserve the legacy
    2/3-arg call shape used across the workspace.
 
@@ -567,36 +569,13 @@
        spec             (assoc :workflow/spec spec)
        trigger-event-id (assoc :routing/trigger-event-id trigger-event-id)))))
 
-(defn phase-started [stream workflow-id phase & [context]]
+(defn ^{:stratum 2} phase-started [stream workflow-id phase & [context]]
   (-> (create-envelope stream :workflow/phase-started workflow-id
                        (str (name phase) " phase started"))
       (assoc :workflow/phase phase)
       (cond-> context (assoc :phase/context context))))
 
-(defn phase-completed [stream workflow-id phase & [result]]
-  (let [outcome (get result :outcome :success)
-        request (phase-transition-request result)
-        redirect-to (or (redirect-target result)
-                        (:redirect-to result))]
-    (-> (create-envelope stream :workflow/phase-completed workflow-id
-                         (str (name phase) " phase " (name outcome)))
-        (assoc :workflow/phase phase
-               :phase/outcome outcome)
-        (cond->
-          (:duration-ms result) (assoc :phase/duration-ms (:duration-ms result))
-          (:review-decision result) (assoc :phase/review-decision (:review-decision result))
-          (:phase/blocked-reason result) (assoc :phase/blocked-reason (:phase/blocked-reason result))
-          (:artifacts result) (assoc :phase/artifacts (:artifacts result))
-          (:error result) (assoc :phase/error (:error result))
-          request (assoc :phase/transition-request request)
-          redirect-to (assoc :phase/redirect-to redirect-to)
-          (:tokens result) (assoc :phase/tokens (:tokens result))
-          (:cost-usd result) (assoc :phase/cost-usd (:cost-usd result))
-          (:meta result) (assoc :phase/meta (:meta result))
-          (:phase/termination-reason result)
-          (assoc :phase/termination-reason (:phase/termination-reason result))))))
-
-(defn workspace-persisted
+(defn ^{:stratum 2} workspace-persisted
   "Build a :workspace/persisted event recording that a phase's worktree was
    archived to a checkpoint. Surfaces the bundle path so dashboards and
    evidence bundles can offer 'inspect/resume from this checkpoint'
@@ -622,19 +601,19 @@
              :workspace/bundle-path (:bundle-path data)
              :workspace/tier        (get data :persist-tier :worktree))))
 
-(defn agent-chunk [stream workflow-id agent-id delta & [done?]]
+(defn ^{:stratum 2} agent-chunk [stream workflow-id agent-id delta & [done?]]
   (-> (create-envelope stream :agent/chunk workflow-id
                        (if done? "Agent stream completed" "Agent streaming"))
       (assoc :agent/id agent-id
              :chunk/delta delta)
       (cond-> done? (assoc :chunk/done? true))))
 
-(defn agent-status [stream workflow-id agent-id status-type message]
+(defn ^{:stratum 2} agent-status [stream workflow-id agent-id status-type message]
   (-> (create-envelope stream :agent/status workflow-id message)
       (assoc :agent/id agent-id
              :status/type status-type)))
 
-(defn agent-tool-call
+(defn ^{:stratum 2} agent-tool-call
   "Publish a :agent/tool-call event carrying the tool name(s) the agent
    just invoked, per N3 §3.x. Replaces the generic :agent/status
    :tool-calling emission for consumers that want structured tool data.
@@ -658,7 +637,7 @@
     tool-call-id        (assoc :tool/call-id tool-call-id)
     tool-args-preview   (assoc :tool/args-preview tool-args-preview)))
 
-(defn agent-tool-call-started
+(defn ^{:stratum 2} agent-tool-call-started
   "Build an :agent/tool-call-started event marking the moment an agent
    begins executing a named tool call or tool-use block.
 
@@ -682,7 +661,7 @@
     args-digest     (assoc :tool/args-digest args-digest)
     call-id         (assoc :tool/call-id call-id)))
 
-(defn tool-call-completed
+(defn ^{:stratum 2} tool-call-completed
   "Build a :tool/call-completed event closing the latency span opened by
    :agent/tool-call-started.
 
@@ -708,7 +687,7 @@
     (some? success?) (assoc :tool/success? success?)
     error           (assoc :tool/error error)))
 
-(defn phase-heartbeat
+(defn ^{:stratum 2} phase-heartbeat
   "Build a :workflow/phase-heartbeat event for long-running phase liveness
    signalling.
 
@@ -733,7 +712,7 @@
     (some? gap-since-last-event-ms)
     (assoc :phase/gap-since-last-event-ms gap-since-last-event-ms)))
 
-(defn workflow-completed [stream workflow-id status & [duration-ms opts]]
+(defn ^{:stratum 2} workflow-completed [stream workflow-id status & [duration-ms opts]]
   (-> (create-envelope stream :workflow/completed workflow-id
                        (str "Workflow " (name status)))
       (assoc :workflow/status status)
@@ -745,7 +724,7 @@
               (:workflow/evidence-bundle-id opts)
               (assoc :workflow/evidence-bundle-id (:workflow/evidence-bundle-id opts)))))
 
-(defn workflow-failed [stream workflow-id error & [{:keys [failure/class]}]]
+(defn ^{:stratum 2} workflow-failed [stream workflow-id error & [{:keys [failure/class]}]]
   (let [;; Handle anomaly maps, Throwables, and plain error maps
         anomaly-map (cond
                       (response/anomaly-map? error) error
@@ -771,7 +750,7 @@
                :workflow/retryable? (:retryable? event-data false))
         (cond-> class (assoc :failure/class class)))))
 
-(defn llm-request [stream workflow-id agent-id model & [prompt-tokens]]
+(defn ^{:stratum 2} llm-request [stream workflow-id agent-id model & [prompt-tokens]]
   (-> (create-envelope stream :llm/request workflow-id
                        (str "Calling " model (when prompt-tokens (str " (" prompt-tokens " tokens)"))))
       (assoc :agent/id agent-id
@@ -779,7 +758,7 @@
              :llm/request-id (random-uuid))
       (cond-> prompt-tokens (assoc :llm/prompt-tokens prompt-tokens))))
 
-(defn llm-response [stream workflow-id agent-id model request-id & [metrics]]
+(defn ^{:stratum 2} llm-response [stream workflow-id agent-id model request-id & [metrics]]
   (-> (create-envelope stream :llm/response workflow-id
                        (str "Response from " model
                             (when (:completion-tokens metrics)
@@ -793,51 +772,47 @@
         (:duration-ms metrics) (assoc :llm/duration-ms (:duration-ms metrics))
         (:cost-usd metrics) (assoc :llm/cost-usd (:cost-usd metrics)))))
 
-;------------------------------------------------------------------------------ Layer 4
 ;; Agent lifecycle events
-
-(defn agent-started [stream workflow-id agent-id & [context]]
+(defn ^{:stratum 2} agent-started [stream workflow-id agent-id & [context]]
   (-> (create-envelope stream :agent/started workflow-id
                        (str "Agent " (name agent-id) " started"))
       (assoc :agent/id agent-id)
       (cond-> context (assoc :agent/context context))))
 
-(defn agent-completed [stream workflow-id agent-id & [result]]
+(defn ^{:stratum 2} agent-completed [stream workflow-id agent-id & [result]]
   (-> (create-envelope stream :agent/completed workflow-id
                        (str "Agent " (name agent-id) " completed"))
       (assoc :agent/id agent-id)
       (cond-> result (assoc :agent/result result))))
 
-(defn agent-failed [stream workflow-id agent-id & [error {:keys [failure/class]}]]
+(defn ^{:stratum 2} agent-failed [stream workflow-id agent-id & [error {:keys [failure/class]}]]
   (-> (create-envelope stream :agent/failed workflow-id
                        (str "Agent " (name agent-id) " failed"))
       (assoc :agent/id agent-id)
       (cond-> error (assoc :agent/error error)
               class (assoc :failure/class class))))
 
-;------------------------------------------------------------------------------ Layer 4
 ;; Gate lifecycle events
-
-(defn gate-started [stream workflow-id gate-id & [artifact-summary]]
+(defn ^{:stratum 2} gate-started [stream workflow-id gate-id & [artifact-summary]]
   (-> (create-envelope stream :gate/started workflow-id
                        (str "Gate " (name gate-id) " started"))
       (assoc :gate/id gate-id)
       (cond-> artifact-summary (assoc :gate/artifact-summary artifact-summary))))
 
-(defn gate-passed [stream workflow-id gate-id & [duration-ms]]
+(defn ^{:stratum 2} gate-passed [stream workflow-id gate-id & [duration-ms]]
   (-> (create-envelope stream :gate/passed workflow-id
                        (str "Gate " (name gate-id) " passed"))
       (assoc :gate/id gate-id)
       (cond-> duration-ms (assoc :gate/duration-ms duration-ms))))
 
-(defn gate-failed [stream workflow-id gate-id & [violations {:keys [failure/class]}]]
+(defn ^{:stratum 2} gate-failed [stream workflow-id gate-id & [violations {:keys [failure/class]}]]
   (-> (create-envelope stream :gate/failed workflow-id
                        (str "Gate " (name gate-id) " failed"))
       (assoc :gate/id gate-id)
       (cond-> violations (assoc :gate/violations violations)
               class (assoc :failure/class class))))
 
-(defn gate-rule-applied
+(defn ^{:stratum 2} gate-rule-applied
   "Per-rule policy evidence event: records that policy `rule-id` was evaluated
    in `phase` with `status` (one of :passed, :failed, :skipped-by-phase,
    :not-applicable). Emitted for considered AND skipped rules so the full
@@ -856,50 +831,44 @@
               (:enforcement extra) (assoc :rule/enforcement (:enforcement extra))
               (:violation extra)   (assoc :rule/violation (:violation extra)))))
 
-;------------------------------------------------------------------------------ Layer 4
 ;; Tool lifecycle events
-
-(defn tool-invoked [stream workflow-id agent-id tool-id & [params-summary]]
+(defn ^{:stratum 2} tool-invoked [stream workflow-id agent-id tool-id & [params-summary]]
   (-> (create-envelope stream :tool/invoked workflow-id
                        (str "Tool " (name tool-id) " invoked by " (name agent-id)))
       (assoc :agent/id agent-id
              :tool/id tool-id)
       (cond-> params-summary (assoc :tool/params-summary params-summary))))
 
-(defn tool-completed [stream workflow-id agent-id tool-id & [result-summary]]
+(defn ^{:stratum 2} tool-completed [stream workflow-id agent-id tool-id & [result-summary]]
   (-> (create-envelope stream :tool/completed workflow-id
                        (str "Tool " (name tool-id) " completed"))
       (assoc :agent/id agent-id
              :tool/id tool-id)
       (cond-> result-summary (assoc :tool/result-summary result-summary))))
 
-;------------------------------------------------------------------------------ Layer 4
 ;; Milestone event
-
-(defn milestone-reached [stream workflow-id milestone-id & [description]]
+(defn ^{:stratum 2} milestone-reached [stream workflow-id milestone-id & [description]]
   (-> (create-envelope stream :workflow/milestone-reached workflow-id
                        (or description (str "Milestone " (name milestone-id) " reached")))
       (assoc :milestone/id milestone-id)))
 
-(defn milestone-started [stream workflow-id milestone-id & [description]]
+(defn ^{:stratum 2} milestone-started [stream workflow-id milestone-id & [description]]
   (-> (create-envelope stream :phase/milestone-started workflow-id
                        (or description (str "Milestone " (name milestone-id) " started")))
       (assoc :milestone/id milestone-id)))
 
-(defn milestone-completed [stream workflow-id milestone-id & [description]]
+(defn ^{:stratum 2} milestone-completed [stream workflow-id milestone-id & [description]]
   (-> (create-envelope stream :phase/milestone-completed workflow-id
                        (or description (str "Milestone " (name milestone-id) " completed")))
       (assoc :milestone/id milestone-id)))
 
-(defn milestone-failed [stream workflow-id milestone-id & [reason]]
+(defn ^{:stratum 2} milestone-failed [stream workflow-id milestone-id & [reason]]
   (-> (create-envelope stream :phase/milestone-failed workflow-id
                        (or reason (str "Milestone " (name milestone-id) " failed")))
       (assoc :milestone/id milestone-id)))
 
-;------------------------------------------------------------------------------ Layer 4
 ;; Task lifecycle (DAG) events
-
-(defn task-state-changed [stream workflow-id dag-id task-id from-state to-state & [context]]
+(defn ^{:stratum 2} task-state-changed [stream workflow-id dag-id task-id from-state to-state & [context]]
   (-> (create-envelope stream :task/state-changed workflow-id
                        (str "Task " task-id " " (name from-state) " -> " (name to-state)))
       (assoc :dag/id dag-id
@@ -908,24 +877,22 @@
              :task/to-state to-state)
       (cond-> context (assoc :task/context context))))
 
-(defn task-frontier-entered [stream workflow-id dag-id task-id & [frontier-size]]
+(defn ^{:stratum 2} task-frontier-entered [stream workflow-id dag-id task-id & [frontier-size]]
   (-> (create-envelope stream :task/frontier-entered workflow-id
                        (str "Task " task-id " entered frontier"))
       (assoc :dag/id dag-id
              :task/id task-id)
       (cond-> frontier-size (assoc :task/frontier-size frontier-size))))
 
-(defn task-skip-propagated [stream workflow-id dag-id task-id & [cause-task]]
+(defn ^{:stratum 2} task-skip-propagated [stream workflow-id dag-id task-id & [cause-task]]
   (-> (create-envelope stream :task/skip-propagated workflow-id
                        (str "Task " task-id " skip propagated"))
       (assoc :dag/id dag-id
              :task/id task-id)
       (cond-> cause-task (assoc :task/cause-task cause-task))))
 
-;------------------------------------------------------------------------------ Layer 4
 ;; Inter-agent messaging events
-
-(defn inter-agent-message-sent [stream workflow-id from-agent to-agent & [message-type]]
+(defn ^{:stratum 2} inter-agent-message-sent [stream workflow-id from-agent to-agent & [message-type]]
   (-> (create-envelope stream :agent/message-sent workflow-id
                        (str (name from-agent) " -> " (name to-agent)
                             (when message-type (str " (" (name message-type) ")"))))
@@ -933,7 +900,7 @@
              :to-agent/id to-agent)
       (cond-> message-type (assoc :message/type message-type))))
 
-(defn inter-agent-message-received [stream workflow-id from-agent to-agent & [message-type]]
+(defn ^{:stratum 2} inter-agent-message-received [stream workflow-id from-agent to-agent & [message-type]]
   (-> (create-envelope stream :agent/message-received workflow-id
                        (str (name to-agent) " <- " (name from-agent)
                             (when message-type (str " (" (name message-type) ")"))))
@@ -941,10 +908,8 @@
              :to-agent/id to-agent)
       (cond-> message-type (assoc :message/type message-type))))
 
-;------------------------------------------------------------------------------ Layer 4
 ;; Listener lifecycle events (N8)
-
-(defn listener-attached [stream workflow-id listener-id & [listener-type capability]]
+(defn ^{:stratum 2} listener-attached [stream workflow-id listener-id & [listener-type capability]]
   (-> (create-envelope stream :listener/attached workflow-id
                        (str "Listener " listener-id " attached"))
       (assoc :listener/id listener-id)
@@ -952,89 +917,44 @@
         listener-type (assoc :listener/type listener-type)
         capability (assoc :listener/capability capability))))
 
-(defn listener-detached [stream workflow-id listener-id & [reason]]
+(defn ^{:stratum 2} listener-detached [stream workflow-id listener-id & [reason]]
   (-> (create-envelope stream :listener/detached workflow-id
                        (str "Listener " listener-id " detached"))
       (assoc :listener/id listener-id)
       (cond-> reason (assoc :listener/reason reason))))
 
-(defn annotation-created [stream workflow-id listener-id annotation-type & [content]]
+(defn ^{:stratum 2} annotation-created [stream workflow-id listener-id annotation-type & [content]]
   (-> (create-envelope stream :annotation/created workflow-id
                        (str "Annotation from " listener-id ": " (name annotation-type)))
       (assoc :listener/id listener-id
              :annotation/type annotation-type)
       (cond-> content (assoc :annotation/content content))))
 
-;------------------------------------------------------------------------------ Layer 4
 ;; Chain lifecycle events
 ;; Chains are not workflow-scoped, so workflow-id is nil.
 ;; Message is derived from the event-type keyword.
-
-(defn chain-envelope
+(defn ^{:stratum 2} chain-envelope
   "Create an envelope for chain events. Chains are not workflow-scoped,
    so workflow-id is nil. Message is derived from the event-type keyword."
   [stream event-type]
   (create-envelope stream event-type nil (name event-type)))
 
-(defn chain-started [stream chain-id step-count]
-  (-> (chain-envelope stream :chain/started)
-      (assoc :chain/id chain-id
-             :chain/step-count step-count)))
-
-(defn chain-step-started [stream chain-id step-id step-index workflow-id]
-  (-> (chain-envelope stream :chain/step-started)
-      (assoc :chain/id chain-id
-             :step/id step-id
-             :step/index step-index
-             :step/workflow-id workflow-id)))
-
-(defn chain-step-completed [stream chain-id step-id step-index]
-  (-> (chain-envelope stream :chain/step-completed)
-      (assoc :chain/id chain-id
-             :step/id step-id
-             :step/index step-index)))
-
-(defn chain-step-failed [stream chain-id step-id step-index error & [{:keys [failure/class]}]]
-  (-> (chain-envelope stream :chain/step-failed)
-      (assoc :chain/id chain-id
-             :step/id step-id
-             :step/index step-index
-             :chain/error error)
-      (cond-> class (assoc :failure/class class))))
-
-(defn chain-completed [stream chain-id duration-ms step-count]
-  (-> (chain-envelope stream :chain/completed)
-      (assoc :chain/id chain-id
-             :chain/duration-ms duration-ms
-             :chain/step-count step-count)))
-
-(defn chain-failed [stream chain-id step-id error & [{:keys [failure/class]}]]
-  (-> (chain-envelope stream :chain/failed)
-      (assoc :chain/id chain-id
-             :chain/failed-step step-id
-             :chain/error error)
-      (cond-> class (assoc :failure/class class))))
-
-;------------------------------------------------------------------------------ Layer 4
 ;; Control action events (N8)
-
-(defn control-action-requested [stream workflow-id action-id action-type & [requester]]
+(defn ^{:stratum 2} control-action-requested [stream workflow-id action-id action-type & [requester]]
   (-> (create-envelope stream :control-action/requested workflow-id
                        (str "Control action " (name action-type) " requested"))
       (assoc :action/id action-id
              :action/type action-type)
       (cond-> requester (assoc :action/requester requester))))
 
-(defn control-action-executed [stream workflow-id action-id & [result]]
+(defn ^{:stratum 2} control-action-executed [stream workflow-id action-id & [result]]
   (-> (create-envelope stream :control-action/executed workflow-id
                        (str "Control action " action-id " executed"))
       (assoc :action/id action-id)
       (cond-> result (assoc :action/result result))))
 
-;------------------------------------------------------------------------------ Layer 4
 ;; OCI container events (N8)
-
-(defn container-started [stream workflow-id container-id & [opts]]
+(defn ^{:stratum 2} container-started [stream workflow-id container-id & [opts]]
   (-> (create-envelope stream :oci/container-started workflow-id
                        (str "Container " container-id " started"))
       (assoc :oci/container-id container-id)
@@ -1042,17 +962,15 @@
         (:image-digest opts) (assoc :oci/image-digest (:image-digest opts))
         (:trust-level opts)  (assoc :oci/trust-level (:trust-level opts)))))
 
-(defn container-completed [stream workflow-id container-id exit-code & [duration-ms]]
+(defn ^{:stratum 2} container-completed [stream workflow-id container-id exit-code & [duration-ms]]
   (-> (create-envelope stream :oci/container-completed workflow-id
                        (str "Container " container-id " completed (exit " exit-code ")"))
       (assoc :oci/container-id container-id
              :oci/exit-code exit-code)
       (cond-> duration-ms (assoc :oci/duration-ms duration-ms))))
 
-;------------------------------------------------------------------------------ Layer 4
 ;; Tool supervision events (N6/N8)
-
-(defn tool-use-evaluated
+(defn ^{:stratum 2} tool-use-evaluated
   "Emit when a tool-use request is evaluated by the supervisor.
 
    Captures both regex and meta-eval decisions for evidence trail."
@@ -1067,7 +985,7 @@
         (:confidence opts) (assoc :supervision/confidence (:confidence opts))
         (:phase opts)      (assoc :workflow/phase (:phase opts)))))
 
-(defn meta-loop-halt-requested
+(defn ^{:stratum 2} meta-loop-halt-requested
   "Emit when a meta-agent signals the meta-loop must halt the workflow.
 
    The REFUSE act for meta-supervision: makes the halt first-class on the stream
@@ -1084,10 +1002,8 @@
         (:detail opts) (assoc :halt/detail (:detail opts))
         (:phase opts)  (assoc :workflow/phase (:phase opts)))))
 
-;------------------------------------------------------------------------------ Layer 5
 ;; Control plane events
-
-(defn cp-agent-registered
+(defn ^{:stratum 2} cp-agent-registered
   "Emit when an external agent registers with the control plane."
   [stream workflow-id agent-id vendor & [opts]]
   (-> (create-envelope stream :control-plane/agent-registered workflow-id
@@ -1103,7 +1019,7 @@
         (:heartbeat-interval-ms opts)
         (assoc :cp/heartbeat-interval-ms (:heartbeat-interval-ms opts)))))
 
-(defn cp-agent-heartbeat
+(defn ^{:stratum 2} cp-agent-heartbeat
   "Emit when the control plane receives a heartbeat from an agent."
   [stream workflow-id agent-id status & [opts]]
   (-> (create-envelope stream :control-plane/agent-heartbeat workflow-id
@@ -1114,7 +1030,7 @@
         (:task opts) (assoc :cp/task (:task opts))
         (:metrics opts) (assoc :cp/metrics (:metrics opts)))))
 
-(defn cp-agent-state-changed
+(defn ^{:stratum 2} cp-agent-state-changed
   "Emit when an agent's normalized state changes."
   [stream workflow-id agent-id from-status to-status]
   (-> (create-envelope stream :control-plane/agent-state-changed workflow-id
@@ -1123,7 +1039,7 @@
              :cp/from-status from-status
              :cp/to-status to-status)))
 
-(defn cp-decision-created
+(defn ^{:stratum 2} cp-decision-created
   "Emit when an agent submits a decision request."
   [stream workflow-id agent-id decision-id summary & [priority-or-opts]]
   (let [opts (if (map? priority-or-opts)
@@ -1141,7 +1057,7 @@
         (:options opts) (assoc :cp/options (vec (:options opts)))
         (:deadline opts) (assoc :cp/deadline (:deadline opts))))))
 
-(defn cp-decision-resolved
+(defn ^{:stratum 2} cp-decision-resolved
   "Emit when a human resolves a decision."
   [stream workflow-id decision-id resolution & [comment]]
   (-> (create-envelope stream :control-plane/decision-resolved workflow-id
@@ -1150,7 +1066,7 @@
              :cp/resolution resolution)
       (cond-> comment (assoc :cp/comment comment))))
 
-(defn intervention-requested
+(defn ^{:stratum 2} intervention-requested
   "Emit when a bounded supervisory intervention is created."
   [stream workflow-id intervention]
   (let [message (messages/t :supervisory/intervention-requested
@@ -1159,7 +1075,7 @@
                          message)
         (merge intervention))))
 
-(defn intervention-state-changed
+(defn ^{:stratum 2} intervention-state-changed
   "Emit when an InterventionRequest changes lifecycle state."
   [stream workflow-id intervention-id to-state & [opts]]
   (let [message (messages/t :supervisory/intervention-state-changed
@@ -1210,12 +1126,10 @@
           (assoc :intervention/approval-required?
                  (:intervention/approval-required? opts))))))
 
-;------------------------------------------------------------------------------ Layer 5.5
 ;; Zettelkasten lifecycle events (added for miniforge-fleet's Phase
 ;; E.3 outbox path — Fleet's ingest consumes these to grow the
 ;; cross-instance event log).
-
-(defn zettel-promoted
+(defn ^{:stratum 2} zettel-promoted
   "Emit when a zettel revision transitions to `:trusted` state and
    becomes eligible to ride the Fleet event log.
 
@@ -1277,10 +1191,8 @@
       (:repo/id opts)      (assoc :repo/id (:repo/id opts))
       (:auth/context opts) (assoc :auth/context (:auth/context opts)))))
 
-;------------------------------------------------------------------------------ Layer 6
 ;; PR scoring events (N5-delta-2 §4.1)
-
-(defn pr-created
+(defn ^{:stratum 2} pr-created
   "Emit when a workflow-owned PR is created.
 
    This is the canonical fine-grained event that lets `supervisory-state`
@@ -1298,7 +1210,7 @@
         author      (assoc :pr/author author)
         merge-order (assoc :pr/merge-order merge-order))))
 
-(defn pr-scored
+(defn ^{:stratum 2} pr-scored
   "Emit when the pr-scoring component has computed readiness, risk, and
    policy scores for a PR, per N5-delta-2 §4.1. Produces the only event
    carrying the four `:pr/readiness`, `:pr/risk`, `:pr/policy`, and
@@ -1327,10 +1239,8 @@
         policy         (assoc :pr/policy policy)
         recommendation (assoc :pr/recommendation recommendation))))
 
-;------------------------------------------------------------------------------ Layer 6
 ;; Reliability metric events (N3 §3.17, N1 §5.5)
-
-(defn sli-computed
+(defn ^{:stratum 2} sli-computed
   "Emit when an SLI value is computed over a rolling window."
   [stream sli-name value window & [opts]]
   (-> (create-envelope stream :reliability/sli-computed nil
@@ -1345,7 +1255,7 @@
         (:tier opts)       (assoc :sli/tier (:tier opts))
         (:dimensions opts) (assoc :sli/dimensions (:dimensions opts)))))
 
-(defn slo-breach
+(defn ^{:stratum 2} slo-breach
   "Emit when an SLO target is missed for :standard or :critical tiers."
   [stream sli-name target actual tier window]
   (-> (create-envelope stream :reliability/slo-breach nil
@@ -1360,7 +1270,7 @@
              :slo/tier tier
              :slo/window window)))
 
-(defn error-budget-update
+(defn ^{:stratum 2} error-budget-update
   "Emit when error budget state is recomputed."
   [stream tier sli remaining burn-rate window]
   (-> (create-envelope stream :reliability/error-budget-update nil
@@ -1375,7 +1285,7 @@
              :budget/burn-rate burn-rate
              :budget/window window)))
 
-(defn degradation-mode-changed
+(defn ^{:stratum 2} degradation-mode-changed
   "Emit when the system transitions between degradation modes (N1 §5.5.5)."
   [stream from-mode to-mode trigger]
   (-> (create-envelope stream :reliability/degradation-mode-changed nil
@@ -1387,7 +1297,7 @@
              :degradation/to to-mode
              :degradation/trigger trigger)))
 
-(defn safe-mode-entered
+(defn ^{:stratum 2} safe-mode-entered
   "Emit when safe-mode is activated (N8 §3.4.4)."
   [stream trigger & [details]]
   (-> (create-envelope stream :safe-mode/entered nil
@@ -1395,7 +1305,7 @@
       (assoc :safe-mode/trigger trigger)
       (cond-> details (assoc :safe-mode/trigger-details details))))
 
-(defn safe-mode-exited
+(defn ^{:stratum 2} safe-mode-exited
   "Emit when safe-mode is deactivated (N8 §3.4.4)."
   [stream exited-by justification duration-ms workflows-queued]
   (-> (create-envelope stream :safe-mode/exited nil
@@ -1405,13 +1315,7 @@
              :safe-mode/duration-ms duration-ms
              :safe-mode/workflows-queued workflows-queued)))
 
-(defn- dependency-id-string
-  [dependency-id]
-  (if (keyword? dependency-id)
-    (name dependency-id)
-    (str dependency-id)))
-
-(defn- dependency-event
+(defn- ^{:stratum 2} dependency-event
   [stream event-type dependency previous-status message-key]
   (let [dependency-id (:dependency/id dependency)
         status (:dependency/status dependency)
@@ -1423,28 +1327,8 @@
         (cond-> previous-status
           (assoc :dependency/previous-status previous-status)))))
 
-(defn dependency-health-updated
-  "Emit when a dependency health projection changes."
-  [stream dependency & [previous-status]]
-  (dependency-event stream
-                    :dependency/health-updated
-                    dependency
-                    previous-status
-                    :dependency/health-updated))
-
-(defn dependency-recovered
-  "Emit when a dependency returns to healthy status."
-  [stream dependency & [previous-status]]
-  (dependency-event stream
-                    :dependency/recovered
-                    dependency
-                    previous-status
-                    :dependency/recovered))
-
-;------------------------------------------------------------------------------ Layer 6.1
 ;; Repository intelligence event constructors (RN-19/20)
-
-(defn repo-index-quality-measured
+(defn ^{:stratum 2} repo-index-quality-measured
   "Build a :repo-index/quality-measured event.
 
    Emitted by the index quality tracker (RN-19) when it samples the
@@ -1468,7 +1352,7 @@
              :index/staleness-ms staleness-ms)
       (cond-> (:measured-at opts) (assoc :index/measured-at (:measured-at opts)))))
 
-(defn repo-index-coverage-changed
+(defn ^{:stratum 2} repo-index-coverage-changed
   "Build a :repo-index/coverage-changed event.
 
    Emitted by the index quality tracker (RN-20) when the coverage ratio
@@ -1491,10 +1375,8 @@
              :index/coverage coverage)
       (cond-> (:changed-files opts) (assoc :index/changed-files (:changed-files opts)))))
 
-;------------------------------------------------------------------------------ Layer 6.2
 ;; Meta-loop events
-
-(defn meta-loop-cycle-completed
+(defn ^{:stratum 2} meta-loop-cycle-completed
   "Emit when a meta-loop cycle completes."
   [stream summary]
   (-> (create-envelope stream :meta-loop/cycle-completed nil
@@ -1504,7 +1386,7 @@
                                (:proposals summary 0)))
       (merge summary)))
 
-(defn meta-loop-cycle-failed
+(defn ^{:stratum 2} meta-loop-cycle-failed
   "Emit when a meta-loop cycle throws an unhandled exception."
   [stream error]
   (-> (create-envelope stream :meta-loop/cycle-failed nil
@@ -1512,10 +1394,8 @@
       (assoc :meta-loop/error (ex-message error)
              :meta-loop/error-class (.getName (class error)))))
 
-;------------------------------------------------------------------------------ Layer 6.5
 ;; Agent stream-stall and session events (GROUP 1+4, GROUP 2)
-
-(defn agent-session-captured
+(defn ^{:stratum 2} agent-session-captured
   "Build an :agent/session-captured event recording the backend session ID
    captured from the initial agent handshake.
 
@@ -1537,7 +1417,7 @@
              :agent/backend backend
              :agent/session-id session-id)))
 
-(defn agent-stream-stalled
+(defn ^{:stratum 2} agent-stream-stalled
   "Build an :agent/stream-stalled event indicating the agent output stream
    has gone silent beyond the configured gap threshold.
 
@@ -1562,39 +1442,27 @@
              :stream/gap-duration-ms gap-duration-ms
              :agent/backend backend)))
 
-;------------------------------------------------------------------------------ Layer 7
-;; Observer / knowledge failure events
-
-(defn- failure-message
-  [failure]
-  (cond
-    (instance? Throwable failure) (ex-message failure)
-    (map? failure) (or (:error failure) (:message failure) (pr-str failure))
-    (some? failure) (str failure)
-    :else nil))
-
-(defn observer-signal-failed
+(defn ^{:stratum 2} observer-signal-failed
   "Emit when observe-workflow-signal! fails to forward a signal to the meta-loop."
   [stream workflow-id error]
   (-> (create-envelope stream :observer/signal-failed workflow-id
                        (str "Observer signal failed: " (failure-message error)))
       (assoc :observer/error (failure-message error))))
 
-(defn knowledge-synthesis-failed
+(defn ^{:stratum 2} knowledge-synthesis-failed
   "Emit when synthesize-patterns! fails."
   [stream error]
   (-> (create-envelope stream :knowledge/synthesis-failed nil
                        (str "Knowledge synthesis failed: " (failure-message error)))
       (assoc :knowledge/error (failure-message error))))
 
-(defn knowledge-promotion-failed
+(defn ^{:stratum 2} knowledge-promotion-failed
   "Emit when promote-mature-learnings! fails."
   [stream error]
   (-> (create-envelope stream :knowledge/promotion-failed nil
                        (str "Knowledge promotion failed: " (failure-message error)))
       (assoc :knowledge/error (failure-message error))))
 
-;------------------------------------------------------------------------------ Layer 9
 ;; Routing trigger events (N5-delta-4 §4.2)
 ;;
 ;; The automation-edge-correlator classifies these via
@@ -1603,8 +1471,7 @@
 ;; triggers are PR-scoped, not workflow-scoped; the handler workflow's
 ;; `:workflow/started` (with `:routing/trigger-event-id` per N15-4) is
 ;; what brings the workflow id into scope on the correlator side.
-
-(defn pr-monitor-review-comments-arrived
+(defn ^{:stratum 2} pr-monitor-review-comments-arrived
   "Emit when the GitHub webhook (or polling fallback) reports new review
    comments on a PR Miniforge owns (N5-delta-4 §4.2.1).
 
@@ -1623,7 +1490,7 @@
                       :comments/count comments-count))
      agent-session-id (assoc :comments/agent-session-id agent-session-id))))
 
-(defn pr-monitor-ci-failed
+(defn ^{:stratum 2} pr-monitor-ci-failed
   "Emit when a CI status transitions to a non-success terminal state on a
    PR Miniforge owns (N5-delta-4 §4.2.2).
 
@@ -1639,7 +1506,7 @@
              :ci/check-name check-name
              :ci/conclusion conclusion)))
 
-(defn standards-review-posted
+(defn ^{:stratum 2} standards-review-posted
   "Emit when a standards-review comment lands on a PR (N5-delta-4 §4.2.3).
 
    `severity` is an open keyword — known values: `:advisory`, `:blocking`.
@@ -1657,6 +1524,88 @@
                       :review/severity severity))
      affected-workflow-run-id (assoc :affected/workflow-run-id
                                      affected-workflow-run-id))))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} phase-completed [stream workflow-id phase & [result]]
+  (let [outcome (get result :outcome :success)
+        request (phase-transition-request result)
+        redirect-to (or (redirect-target result)
+                        (:redirect-to result))]
+    (-> (create-envelope stream :workflow/phase-completed workflow-id
+                         (str (name phase) " phase " (name outcome)))
+        (assoc :workflow/phase phase
+               :phase/outcome outcome)
+        (cond->
+          (:duration-ms result) (assoc :phase/duration-ms (:duration-ms result))
+          (:review-decision result) (assoc :phase/review-decision (:review-decision result))
+          (:phase/blocked-reason result) (assoc :phase/blocked-reason (:phase/blocked-reason result))
+          (:artifacts result) (assoc :phase/artifacts (:artifacts result))
+          (:error result) (assoc :phase/error (:error result))
+          request (assoc :phase/transition-request request)
+          redirect-to (assoc :phase/redirect-to redirect-to)
+          (:tokens result) (assoc :phase/tokens (:tokens result))
+          (:cost-usd result) (assoc :phase/cost-usd (:cost-usd result))
+          (:meta result) (assoc :phase/meta (:meta result))
+          (:phase/termination-reason result)
+          (assoc :phase/termination-reason (:phase/termination-reason result))))))
+
+(defn ^{:stratum 3} chain-started [stream chain-id step-count]
+  (-> (chain-envelope stream :chain/started)
+      (assoc :chain/id chain-id
+             :chain/step-count step-count)))
+
+(defn ^{:stratum 3} chain-step-started [stream chain-id step-id step-index workflow-id]
+  (-> (chain-envelope stream :chain/step-started)
+      (assoc :chain/id chain-id
+             :step/id step-id
+             :step/index step-index
+             :step/workflow-id workflow-id)))
+
+(defn ^{:stratum 3} chain-step-completed [stream chain-id step-id step-index]
+  (-> (chain-envelope stream :chain/step-completed)
+      (assoc :chain/id chain-id
+             :step/id step-id
+             :step/index step-index)))
+
+(defn ^{:stratum 3} chain-step-failed [stream chain-id step-id step-index error & [{:keys [failure/class]}]]
+  (-> (chain-envelope stream :chain/step-failed)
+      (assoc :chain/id chain-id
+             :step/id step-id
+             :step/index step-index
+             :chain/error error)
+      (cond-> class (assoc :failure/class class))))
+
+(defn ^{:stratum 3} chain-completed [stream chain-id duration-ms step-count]
+  (-> (chain-envelope stream :chain/completed)
+      (assoc :chain/id chain-id
+             :chain/duration-ms duration-ms
+             :chain/step-count step-count)))
+
+(defn ^{:stratum 3} chain-failed [stream chain-id step-id error & [{:keys [failure/class]}]]
+  (-> (chain-envelope stream :chain/failed)
+      (assoc :chain/id chain-id
+             :chain/failed-step step-id
+             :chain/error error)
+      (cond-> class (assoc :failure/class class))))
+
+(defn ^{:stratum 3} dependency-health-updated
+  "Emit when a dependency health projection changes."
+  [stream dependency & [previous-status]]
+  (dependency-event stream
+                    :dependency/health-updated
+                    dependency
+                    previous-status
+                    :dependency/health-updated))
+
+(defn ^{:stratum 3} dependency-recovered
+  "Emit when a dependency returns to healthy status."
+  [stream dependency & [previous-status]]
+  (dependency-event stream
+                    :dependency/recovered
+                    dependency
+                    previous-status
+                    :dependency/recovered))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/event-stream/src/ai/miniforge/event_stream/digest.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/digest.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.digest
   "Content-digest utility for event payload summaries.
 
@@ -30,32 +29,30 @@
    [java.security MessageDigest]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Constants
 
-(def ^:const max-preview-bytes
+;; Constants
+(def ^{:stratum 0} ^:const max-preview-bytes
   "Maximum UTF-8 byte length retained in :digest/preview."
   1024)
 
-(def ^:const sha256-hex-length
+(def ^{:stratum 0} ^:const sha256-hex-length
   "Length of a SHA-256 digest rendered as lowercase hexadecimal."
   64)
 
-(def ^:private byte-hex-format
+(def ^{:stratum 0} ^:private byte-hex-format
   "Format string for rendering a byte as two lowercase hexadecimal chars."
   "%02x")
 
-(def ^:private unsigned-byte-mask
+(def ^{:stratum 0} ^:private unsigned-byte-mask
   "Mask used to render signed JVM bytes as unsigned byte values."
   0xff)
 
-(def ^:private sha256-algorithm
+(def ^{:stratum 0} ^:private sha256-algorithm
   "JCA algorithm name for SHA-256 digests."
   "SHA-256")
 
-;------------------------------------------------------------------------------ Layer 0
 ;; Internal helpers
-
-(defn- ->bytes
+(defn- ^{:stratum 0} ->bytes
   "Coerce `content` to a byte array deterministically.
 
    - `byte[]`  — returned as-is
@@ -67,20 +64,7 @@
     (string? content) (.getBytes ^String content StandardCharsets/UTF_8)
     :else             (.getBytes ^String (str content) StandardCharsets/UTF_8)))
 
-(defn- bytes->hex
-  "Convert a byte array to a lowercase hexadecimal string."
-  [^bytes ba]
-  (apply str (map #(format byte-hex-format
-                           (bit-and (int %) unsigned-byte-mask))
-                  ba)))
-
-(defn- sha256-hex
-  "Return the SHA-256 digest of `ba` as a lowercase hex string."
-  [^bytes ba]
-  (let [^MessageDigest md (MessageDigest/getInstance sha256-algorithm)]
-    (bytes->hex (.digest md ba))))
-
-(defn- utf8-preview
+(defn- ^{:stratum 0} utf8-preview
   "Return the longest Unicode-safe prefix whose UTF-8 byte count fits
    within `max-bytes`."
   [^String s max-bytes]
@@ -103,9 +87,26 @@
                      out))))))))
 
 ;------------------------------------------------------------------------------ Layer 1
-;; Public API
 
-(defn digest-content
+(defn- ^{:stratum 1} bytes->hex
+  "Convert a byte array to a lowercase hexadecimal string."
+  [^bytes ba]
+  (apply str (map #(format byte-hex-format
+                           (bit-and (int %) unsigned-byte-mask))
+                  ba)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- ^{:stratum 2} sha256-hex
+  "Return the SHA-256 digest of `ba` as a lowercase hex string."
+  [^bytes ba]
+  (let [^MessageDigest md (MessageDigest/getInstance sha256-algorithm)]
+    (bytes->hex (.digest md ba))))
+
+;------------------------------------------------------------------------------ Layer 3
+
+;; Public API
+(defn ^{:stratum 3} digest-content
   "Produce a bounded digest map from arbitrary content.
 
    Accepts strings, byte arrays, or any value (coerced via `str`).

--- a/components/event-stream/src/ai/miniforge/event_stream/event_type_registry.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/event_type_registry.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.event-type-registry
   "Authoritative registry of all server-side event types and their browser coverage.
 
@@ -52,12 +51,14 @@
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Registry — loaded from EDN resource
 
-(def ^:private registry-resource-path
+;; Registry — loaded from EDN resource
+(def ^{:stratum 0} ^:private registry-resource-path
   "config/event-stream/event-type-registry.edn")
 
-(def event-type-registry
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} event-type-registry
   "Complete mapping from constructor symbol name (as string) to serialised
    JSON event-type string, grouped by originating namespace.
 
@@ -74,37 +75,25 @@
       slurp
       edn/read-string))
 
-;------------------------------------------------------------------------------ Layer 0
-;; Derived views
+;------------------------------------------------------------------------------ Layer 2
 
-(def browser-handled-events
+;; Derived views
+(def ^{:stratum 2} browser-handled-events
   "The 6 event types currently handled in `handleWorkflowEvent` in app.js.
    All strings confirmed correct — no mismatches."
   (->> event-type-registry
        (filter :browser?)
        (mapv :json-string)))
+
 ;; => ["workflow/started" "workflow/phase-started" "workflow/phase-completed"
 ;;     "workflow/completed" "workflow/failed" "agent/chunk"]
-
-(def browser-unhandled-events
+(def ^{:stratum 2} browser-unhandled-events
   "Event types emitted server-side that the browser switch silently ignores.
    These are the gap items for Tasks 1–7."
   (->> event-type-registry
        (remove :browser?)
        (mapv :json-string)))
 
-(def naming-asymmetries
-  "13 constructors whose function name does not predict the namespace portion
-   of the serialised event-type string.  A developer reading only
-   `interface/events.clj` would guess the wrong browser case string.
-
-   Format: [constructor → json-string (note)]"
-  (->> event-type-registry
-       (filter :asymmetry?)
-       (mapv (fn [{:keys [constructor json-string asymmetry-note]}]
-               {:constructor    constructor
-                :json-string    json-string
-                :asymmetry-note asymmetry-note}))))
 ;; Asymmetries at a glance:
 ;;
 ;;   milestone-reached          → "workflow/milestone-reached"   (namespace: milestone → workflow)
@@ -118,11 +107,23 @@
 ;;   cp-agent-state-changed     → "control-plane/agent-state-changed" (prefix cp → control-plane)
 ;;   cp-decision-created        → "control-plane/decision-created"  (prefix cp → control-plane)
 ;;   cp-decision-resolved       → "control-plane/decision-resolved" (prefix cp → control-plane)
+(def ^{:stratum 2} naming-asymmetries
+  "13 constructors whose function name does not predict the namespace portion
+   of the serialised event-type string.  A developer reading only
+   `interface/events.clj` would guess the wrong browser case string.
 
-;------------------------------------------------------------------------------ Layer 0
+   Format: [constructor → json-string (note)]"
+  (->> event-type-registry
+       (filter :asymmetry?)
+       (mapv (fn [{:keys [constructor json-string asymmetry-note]}]
+               {:constructor    constructor
+                :json-string    json-string
+                :asymmetry-note asymmetry-note}))))
+
+;------------------------------------------------------------------------------ Layer 3
+
 ;; Audit summary (machine-readable)
-
-(def audit-summary
+(def ^{:stratum 3} audit-summary
   {:audit/date          "2026-05-24"
    :audit/source-server "components/event-stream/src/ai/miniforge/event_stream/interface/events.clj"
    :audit/source-browser "components/web-dashboard/resources/public/js/app.js"

--- a/components/event-stream/src/ai/miniforge/event_stream/heartbeat.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/heartbeat.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.heartbeat
   "Phase heartbeat scheduler."
   (:require
@@ -26,7 +25,9 @@
                          ThreadFactory TimeUnit]
    [java.util.concurrent.atomic AtomicLong]))
 
-(def ^:const default-interval-ms
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:const default-interval-ms
   "Default interval between heartbeat events. Expressed as
    `seconds × ms-per-second` so a reader recovers the human unit
    without reading the docstring — per .standards/foundations/
@@ -34,28 +35,13 @@
    composition is part of the intent."
   (* 30 1000))
 
-(def ^:private heartbeat-thread-counter
+(def ^{:stratum 0} ^:private heartbeat-thread-counter
   "Monotonic counter for naming heartbeat threads. Gives each
    scheduler a unique suffix so jstack output disambiguates threads
    when the same phase id runs concurrently across workflows."
   (AtomicLong. 0))
 
-(defn- daemon-thread-factory [phase-id]
-  (let [n (.incrementAndGet ^AtomicLong heartbeat-thread-counter)]
-    (reify ThreadFactory
-      (newThread [_ runnable]
-        (doto (Thread. runnable (str "miniforge-phase-heartbeat-"
-                                     (name phase-id) "-" n))
-          (.setDaemon true))))))
-
-(defn- resolve-interval-ms [opts]
-  (let [interval-ms (or (:interval-ms opts) default-interval-ms)]
-    (when-not (pos-int? interval-ms)
-      (throw (ex-info "Heartbeat interval must be a positive integer"
-                      {:interval-ms interval-ms})))
-    interval-ms))
-
-(defn- make-heartbeat-task
+(defn- ^{:stratum 0} make-heartbeat-task
   "Return one scheduled heartbeat emission task."
   [event-stream workflow-id phase-id active-since seq-num last-tick]
   (fn []
@@ -82,7 +68,35 @@
                    :data {:phase-id phase-id
                           :error (ex-message e)}})))))
 
-(defn start-heartbeat!
+(defn ^{:stratum 0} stop-heartbeat!
+  ([handle]
+   (stop-heartbeat! handle {}))
+  ([handle {:keys [may-interrupt?] :or {may-interrupt? false}}]
+   (when-let [^ScheduledFuture fut (:heartbeat/future handle)]
+     (.cancel fut (boolean may-interrupt?)))
+   (when-let [^ScheduledExecutorService executor (:heartbeat/executor handle)]
+     (.shutdown executor))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} daemon-thread-factory [phase-id]
+  (let [n (.incrementAndGet ^AtomicLong heartbeat-thread-counter)]
+    (reify ThreadFactory
+      (newThread [_ runnable]
+        (doto (Thread. runnable (str "miniforge-phase-heartbeat-"
+                                     (name phase-id) "-" n))
+          (.setDaemon true))))))
+
+(defn- ^{:stratum 1} resolve-interval-ms [opts]
+  (let [interval-ms (or (:interval-ms opts) default-interval-ms)]
+    (when-not (pos-int? interval-ms)
+      (throw (ex-info "Heartbeat interval must be a positive integer"
+                      {:interval-ms interval-ms})))
+    interval-ms))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} start-heartbeat!
   ([event-stream workflow-id phase-id]
    (start-heartbeat! event-stream workflow-id phase-id {}))
   ([event-stream workflow-id phase-id opts]
@@ -126,12 +140,3 @@
         :heartbeat/phase-id   phase-id
         :heartbeat/last-tick  last-tick
         :heartbeat/seq-num    seq-num}))))
-
-(defn stop-heartbeat!
-  ([handle]
-   (stop-heartbeat! handle {}))
-  ([handle {:keys [may-interrupt?] :or {may-interrupt? false}}]
-   (when-let [^ScheduledFuture fut (:heartbeat/future handle)]
-     (.cancel fut (boolean may-interrupt?)))
-   (when-let [^ScheduledExecutorService executor (:heartbeat/executor handle)]
-     (.shutdown executor))))

--- a/components/event-stream/src/ai/miniforge/event_stream/interface.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.interface
   "Canonical public boundary for the event-stream component.
    Public API groups live under ai.miniforge.event-stream.interface.* namespaces,
@@ -35,34 +34,40 @@
    [ai.miniforge.event-stream.sinks :as sinks]
    [ai.miniforge.event-stream.timeline :as timeline]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; ────────────────────────────────────────────────────────────────────────────
 ;; Stream lifecycle and control state
-
-(def create-control-state
+(def ^{:stratum 0} create-control-state
   "Create a control-state atom for driving workflow pause/resume/cancel
    from the CLI poller or TUI. Returns an atom holding
    {:paused false :stopped false :adjustments {}}."
   control-state/create-control-state)
-(def pause!
+
+(def ^{:stratum 0} pause!
   "Set the control-state atom's :paused flag true. Returns the new
    state map."
   control-state/pause!)
-(def resume!
+
+(def ^{:stratum 0} resume!
   "Clear the control-state atom's :paused flag (set false). Returns the
    new state map."
   control-state/resume!)
-(def cancel!
+
+(def ^{:stratum 0} cancel!
   "Set the control-state atom's :stopped flag true. Returns the new
    state map."
   control-state/cancel!)
-(def paused?
+
+(def ^{:stratum 0} paused?
   "Return the boolean :paused flag from a control-state atom."
   control-state/paused?)
-(def cancelled?
+
+(def ^{:stratum 0} cancelled?
   "Return the boolean :stopped flag from a control-state atom."
   control-state/cancelled?)
 
-(def create-event-stream
+(def ^{:stratum 0} create-event-stream
   "Create an event stream. Returns an atom holding the stream state
    (events vector, subscribers, filters, sinks, sequence numbers,
    quiesce fence, in-flight counter, optional snowflake generator).
@@ -70,7 +75,8 @@
    (builds sinks from config), :snowflake-generator (BD-2b event-id
    generator for lexically-sortable ids)."
   stream/create-event-stream)
-(def create-envelope
+
+(def ^{:stratum 0} create-envelope
   "Build an event envelope map with an atomically-assigned per-workflow
    sequence number. Returns a map carrying :event/type, :event/id (a
    uuid? — snowflake-encoded when the stream has a generator, else
@@ -79,7 +85,8 @@
    (:org/id, :workspace/id, :repo/id, :auth/context, :event/parent-id,
    :agent/id, :agent/instance-id)."
   stream/create-envelope)
-(def publish!
+
+(def ^{:stratum 0} publish!
   "Publish an event to the stream: fan out to sinks, append to the
    in-memory log, fan out to matching subscribers, log. Returns the
    published event map. If the event's workflow has been quiesced
@@ -87,20 +94,24 @@
    :workflow-quiesced :workflow-id ... :event-type ...} map without
    running sinks or subscribers."
   stream/publish!)
-(def subscribe!
+
+(def ^{:stratum 0} subscribe!
   "Register a callback for events. 3-arg form subscribes to all events;
    4-arg form takes a filter-fn (fn [event] -> bool) so only matching
    events are delivered. Returns the subscriber-id passed in."
   stream/subscribe!)
-(def unsubscribe!
+
+(def ^{:stratum 0} unsubscribe!
   "Remove a subscriber (and its filter) by id. Returns nil."
   stream/unsubscribe!)
-(def get-events
+
+(def ^{:stratum 0} get-events
   "Query the in-memory event log. Returns a vector of event maps.
    Optional opts map filters/pages: :workflow-id, :event-type, :offset,
    :limit."
   stream/get-events)
-(def get-latest-status
+
+(def ^{:stratum 0} get-latest-status
   "Return the most recent :agent/status event map for a workflow (and
    optionally a specific agent-id), or nil when none exist."
   stream/get-latest-status)
@@ -108,7 +119,7 @@
 ;; BD-2b: canonical on-disk paths. Exposed so callers outside this
 ;; component (cli workflow runner, sub-3 cleanup) agree with the file
 ;; sink on where a workflow's events + manifest live.
-(def workflow-dir
+(def ^{:stratum 0} workflow-dir
   "Return the per-workflow events directory as a java.io.File. As of
    BD-2b sub-3b this is `{base-dir}/live/{workflow-id}/` (an alias for
    the live-workflow-dir). The file sink and the manifest module both
@@ -117,7 +128,7 @@
    ~/.miniforge/events; (base-dir workflow-id)."
   sinks/workflow-dir)
 
-(def default-events-dir
+(def ^{:stratum 0} default-events-dir
   "The default events root (`~/.miniforge/events`) as a java.io.File —
    the base every other path fn in this family defaults to. Exposed so
    callers that must resolve the root themselves (the operator
@@ -125,14 +136,14 @@
    convention the file sink writes under instead of rebuilding it."
   sinks/default-events-dir)
 
-(def operator-dir
+(def ^{:stratum 0} operator-dir
   "The cross-workflow operator events directory (`{base-dir}/operator/`).
    Writer side: [[operator-event-file-path]] via the file sink; read
    side: the operator-event consumer (Phase D D-2). Arities: () defaults
    base-dir to ~/.miniforge/events; (base-dir)."
   sinks/operator-dir)
 
-(def serialize-event
+(def ^{:stratum 0} serialize-event
   "Serialize an event map to the canonical Transit-JSON wire string —
    the exact encoding the file sink writes to disk (verbose mode: no
    cache codes; UUIDs/instants as `~u...`/`~t...` tag-strings the Rust
@@ -142,7 +153,7 @@
    Pure: no IO."
   sinks/event->transit-json)
 
-(def digest-content
+(def ^{:stratum 0} digest-content
   "Produce a bounded, reproducible digest map from arbitrary content
    (string, byte array, or any value coerced via str). Returns
    {:digest/preview (Unicode-safe UTF-8 prefix capped at
@@ -151,7 +162,7 @@
   digest/digest-content)
 
 ;; BD-2a shutdown-ordering primitives.
-(def quiesce!
+(def ^{:stratum 0} quiesce!
   "Fence future publishes for a workflow (when :workflow-id is given)
    and wait for in-flight publishes to settle. After return, publish!
    for that workflow returns a rejection map. Without :workflow-id, adds
@@ -160,7 +171,8 @@
    :pending-publishers N}. Opts: :workflow-id, :timeout-ms (default
    5000)."
   stream/quiesce!)
-(def drain!
+
+(def ^{:stratum 0} drain!
   "Wait for every event published before this call to reach all sinks,
    including each sink's optional drain hook. Returns a map: {:ok? true
    :drained-count N}, {:ok? false :reason :timeout :pending-count N}, or
@@ -170,7 +182,7 @@
   stream/drain!)
 
 ;; Phase heartbeat scheduler — start/stop liveness signalling for long-running phases.
-(def start-heartbeat!
+(def ^{:stratum 0} start-heartbeat!
   "Start periodic :workflow/phase-heartbeat emission for a phase on a
    daemon scheduled executor. Returns an opaque stop handle map
    (:heartbeat/executor, :heartbeat/future, :heartbeat/phase-id,
@@ -179,7 +191,7 @@
    is not a positive integer. opts: {:interval-ms long} (default 30s)."
   heartbeat/start-heartbeat!)
 
-(def stop-heartbeat!
+(def ^{:stratum 0} stop-heartbeat!
   "Stop a heartbeat scheduler returned by start-heartbeat!. Nil-safe.
    Cancels the periodic ScheduledFuture (does not interrupt an in-flight
    tick unless opts :may-interrupt? is true) then shuts down the backing
@@ -188,226 +200,268 @@
 
 ;; ────────────────────────────────────────────────────────────────────────────
 ;; Event constructors
-
-(def workflow-started
+(def ^{:stratum 0} workflow-started
   "Build and return a :workflow/started event envelope map. Multi-arity
    for the legacy 2/3-arg call shape; the opts arity may carry
    :routing/trigger-event-id so the automation-edge-correlator links the
    handler workflow back to its routing trigger."
   events/workflow-started)
-(def phase-started
+
+(def ^{:stratum 0} phase-started
   "Build and return a :workflow/phase-started event envelope map for the
    given phase keyword; optional context is attached as :phase/context."
   events/phase-started)
-(def phase-completed
+
+(def ^{:stratum 0} phase-completed
   "Build and return a :workflow/phase-completed event envelope map.
    Records :phase/outcome (default :success) and, when present on the
    result, duration, artifacts, error, transition-request, redirect-to,
    tokens, cost, meta, and termination-reason."
   events/phase-completed)
-(def workspace-persisted
+
+(def ^{:stratum 0} workspace-persisted
   "Build and return a :workspace/persisted event envelope map recording
    that a phase's worktree was archived to a checkpoint (phase, env-id,
    branch, commit-sha, bundle-path, persist-tier)."
   events/workspace-persisted)
-(def agent-chunk
+
+(def ^{:stratum 0} agent-chunk
   "Build and return an :agent/chunk event envelope map carrying a
    streamed text delta for an agent; sets :chunk/done? when the optional
    done? flag is truthy."
   events/agent-chunk)
-(def agent-status
+
+(def ^{:stratum 0} agent-status
   "Build and return an :agent/status event envelope map carrying a
    status-type keyword and human message for an agent."
   events/agent-status)
-(def agent-tool-call
+
+(def ^{:stratum 0} agent-tool-call
   "Build and return an :agent/tool-call event envelope map carrying the
    tool name(s) an agent invoked (:tool/name, :tool/names, :tool/call-id,
    :tool/args-preview). Legacy event kept for existing consumers."
   events/agent-tool-call)
-(def agent-tool-call-started
+
+(def ^{:stratum 0} agent-tool-call-started
   "Build and return an :agent/tool-call-started event envelope map
    marking the start of a tool call (:tool/name, :tool/names,
    :tool/args-digest, :tool/call-id); opens the latency span closed by
    tool-call-completed."
   events/agent-tool-call-started)
-(def tool-call-completed
+
+(def ^{:stratum 0} tool-call-completed
   "Build and return a :tool/call-completed event envelope map closing
    the latency span opened by agent-tool-call-started (:tool/call-id,
    :tool/result-digest, :tool/duration-ms, :tool/success?, :tool/error)."
   events/tool-call-completed)
-(def phase-heartbeat
+
+(def ^{:stratum 0} phase-heartbeat
   "Build and return a :workflow/phase-heartbeat event envelope map for
    long-running phase liveness (:phase/active-since,
    :phase/events-emitted, :phase/last-event-at,
    :phase/gap-since-last-event-ms)."
   events/phase-heartbeat)
-(def workflow-completed
+
+(def ^{:stratum 0} workflow-completed
   "Build and return a :workflow/completed event envelope map carrying a
    status keyword and optional duration plus opts (tokens, cost,
    pr-info, pr-infos, evidence-bundle-id)."
   events/workflow-completed)
-(def workflow-failed
+
+(def ^{:stratum 0} workflow-failed
   "Build and return a :workflow/failed event envelope map. Normalizes
    the error (Throwable, anomaly map, or plain map) into
    :workflow/failure-reason, :workflow/error-details,
    :workflow/anomaly-code, and :workflow/retryable?; optional
    :failure/class."
   events/workflow-failed)
-(def llm-request
+
+(def ^{:stratum 0} llm-request
   "Build and return an :llm/request event envelope map for an LLM call
    (model, optional prompt-tokens); assigns a fresh :llm/request-id."
   events/llm-request)
-(def llm-response
+
+(def ^{:stratum 0} llm-response
   "Build and return an :llm/response event envelope map for an LLM
    response correlated by request-id; optional metrics add
    completion/total tokens, duration, and cost."
   events/llm-response)
-(def agent-started
+
+(def ^{:stratum 0} agent-started
   "Build and return an :agent/started event envelope map; optional
    context is attached as :agent/context."
   events/agent-started)
-(def agent-completed
+
+(def ^{:stratum 0} agent-completed
   "Build and return an :agent/completed event envelope map; optional
    result is attached as :agent/result."
   events/agent-completed)
-(def agent-failed
+
+(def ^{:stratum 0} agent-failed
   "Build and return an :agent/failed event envelope map; optional error
    becomes :agent/error and optional :failure/class is carried through."
   events/agent-failed)
-(def gate-started
+
+(def ^{:stratum 0} gate-started
   "Build and return a :gate/started event envelope map; optional
    artifact-summary is attached as :gate/artifact-summary."
   events/gate-started)
-(def gate-passed
+
+(def ^{:stratum 0} gate-passed
   "Build and return a :gate/passed event envelope map; optional
    duration-ms is attached as :gate/duration-ms."
   events/gate-passed)
-(def gate-failed
+
+(def ^{:stratum 0} gate-failed
   "Build and return a :gate/failed event envelope map; optional
    violations become :gate/violations and optional :failure/class is
    carried through."
   events/gate-failed)
-(def gate-rule-applied
+
+(def ^{:stratum 0} gate-rule-applied
   "Build and return a :gate/rule-applied event envelope map: per-rule
    policy evidence recording rule-id evaluated in phase with status
    (:passed, :failed, :skipped-by-phase, :not-applicable). Optional
    extra carries :severity, :enforcement, and a NON-SENSITIVE
    :violation summary."
   events/gate-rule-applied)
-(def tool-invoked
+
+(def ^{:stratum 0} tool-invoked
   "Build and return a :tool/invoked event envelope map for a tool an
    agent invoked; optional params-summary is attached as
    :tool/params-summary."
   events/tool-invoked)
-(def tool-completed
+
+(def ^{:stratum 0} tool-completed
   "Build and return a :tool/completed event envelope map; optional
    result-summary is attached as :tool/result-summary."
   events/tool-completed)
-(def milestone-reached
+
+(def ^{:stratum 0} milestone-reached
   "Build and return a :workflow/milestone-reached event envelope map for
    a milestone-id; optional description overrides the default message."
   events/milestone-reached)
-(def milestone-started
+
+(def ^{:stratum 0} milestone-started
   "Build and return a :phase/milestone-started event envelope map for a
    milestone-id; optional description overrides the default message."
   events/milestone-started)
-(def milestone-completed
+
+(def ^{:stratum 0} milestone-completed
   "Build and return a :phase/milestone-completed event envelope map for
    a milestone-id; optional description overrides the default message."
   events/milestone-completed)
-(def milestone-failed
+
+(def ^{:stratum 0} milestone-failed
   "Build and return a :phase/milestone-failed event envelope map for a
    milestone-id; optional reason overrides the default message."
   events/milestone-failed)
-(def task-state-changed
+
+(def ^{:stratum 0} task-state-changed
   "Build and return a :task/state-changed event envelope map recording a
    DAG task transitioning from-state to-state (:dag/id, :task/id,
    :task/from-state, :task/to-state); optional context as :task/context."
   events/task-state-changed)
-(def task-frontier-entered
+
+(def ^{:stratum 0} task-frontier-entered
   "Build and return a :task/frontier-entered event envelope map for a
    DAG task entering the ready frontier; optional frontier-size as
    :task/frontier-size."
   events/task-frontier-entered)
-(def task-skip-propagated
+
+(def ^{:stratum 0} task-skip-propagated
   "Build and return a :task/skip-propagated event envelope map for a DAG
    task skipped by upstream propagation; optional cause-task as
    :task/cause-task."
   events/task-skip-propagated)
-(def inter-agent-message-sent
+
+(def ^{:stratum 0} inter-agent-message-sent
   "Build and return an :agent/message-sent event envelope map for a
    message from one agent to another (:from-agent/id, :to-agent/id);
    optional message-type as :message/type."
   events/inter-agent-message-sent)
-(def inter-agent-message-received
+
+(def ^{:stratum 0} inter-agent-message-received
   "Build and return an :agent/message-received event envelope map for a
    message received by an agent (:from-agent/id, :to-agent/id); optional
    message-type as :message/type."
   events/inter-agent-message-received)
-(def listener-attached
+
+(def ^{:stratum 0} listener-attached
   "Build and return a :listener/attached event envelope map for a
    listener id; optional listener-type and capability as :listener/type
    / :listener/capability."
   events/listener-attached)
-(def listener-detached
+
+(def ^{:stratum 0} listener-detached
   "Build and return a :listener/detached event envelope map for a
    listener id; optional reason as :listener/reason."
   events/listener-detached)
-(def annotation-created
+
+(def ^{:stratum 0} annotation-created
   "Build and return an :annotation/created event envelope map for an
    advisory annotation from a listener (:listener/id,
    :annotation/type); optional content as :annotation/content."
   events/annotation-created)
-(def control-action-requested
+
+(def ^{:stratum 0} control-action-requested
   "Build and return a :control-action/requested event envelope map
    (:action/id, :action/type); optional requester as :action/requester."
   events/control-action-requested)
-(def control-action-executed
+
+(def ^{:stratum 0} control-action-executed
   "Build and return a :control-action/executed event envelope map for an
    action id; optional result as :action/result."
   events/control-action-executed)
-(def chain-started
+
+(def ^{:stratum 0} chain-started
   "Build and return a :chain/started event envelope map (chains are not
    workflow-scoped, so :workflow/id is nil) carrying :chain/id and
    :chain/step-count."
   events/chain-started)
-(def chain-step-started
+
+(def ^{:stratum 0} chain-step-started
   "Build and return a :chain/step-started event envelope map carrying
    :chain/id, :step/id, :step/index, and :step/workflow-id."
   events/chain-step-started)
-(def chain-step-completed
+
+(def ^{:stratum 0} chain-step-completed
   "Build and return a :chain/step-completed event envelope map carrying
    :chain/id, :step/id, and :step/index."
   events/chain-step-completed)
-(def chain-step-failed
+
+(def ^{:stratum 0} chain-step-failed
   "Build and return a :chain/step-failed event envelope map carrying
    :chain/id, :step/id, :step/index, and :chain/error; optional
    :failure/class."
   events/chain-step-failed)
-(def chain-completed
+
+(def ^{:stratum 0} chain-completed
   "Build and return a :chain/completed event envelope map carrying
    :chain/id, :chain/duration-ms, and :chain/step-count."
   events/chain-completed)
-(def chain-failed
+
+(def ^{:stratum 0} chain-failed
   "Build and return a :chain/failed event envelope map carrying
    :chain/id, :chain/failed-step, and :chain/error; optional
    :failure/class."
   events/chain-failed)
 
 ;; OCI container events
-(def container-started
+(def ^{:stratum 0} container-started
   "Build and return an :oci/container-started event envelope map for a
    container id; optional opts add :oci/image-digest and
    :oci/trust-level."
   events/container-started)
-(def container-completed
+
+(def ^{:stratum 0} container-completed
   "Build and return an :oci/container-completed event envelope map
    carrying :oci/container-id and :oci/exit-code; optional duration-ms
    as :oci/duration-ms."
   events/container-completed)
 
 ;; Tool supervision events
-(def tool-use-evaluated
+(def ^{:stratum 0} tool-use-evaluated
   "Build and return a :supervision/tool-use-evaluated event envelope map
    capturing a supervisor's decision on a tool-use request (:tool/name,
    :supervision/decision); optional opts add :supervision/reasoning,
@@ -415,59 +469,67 @@
   events/tool-use-evaluated)
 
 ;; Meta-loop supervision events
-(def meta-loop-halt-requested
+(def ^{:stratum 0} meta-loop-halt-requested
   "Build and return a :meta-loop/halt-requested event envelope map recording a
    meta-agent's REFUSE: :halt/halting-agent and :halt/reason-code (RefusalReason);
    optional opts add :halt/detail and :workflow/phase."
   events/meta-loop-halt-requested)
 
 ;; Control plane events
-(def cp-agent-registered
+(def ^{:stratum 0} cp-agent-registered
   "Build and return a :control-plane/agent-registered event envelope map
    for an external agent registering with the control plane (:cp/agent-id,
    :cp/vendor); optional opts add name, external-id, capabilities,
    metadata, tags, heartbeat-interval-ms."
   events/cp-agent-registered)
-(def cp-agent-heartbeat
+
+(def ^{:stratum 0} cp-agent-heartbeat
   "Build and return a :control-plane/agent-heartbeat event envelope map
    (:cp/agent-id, :cp/status); optional opts add :cp/task and
    :cp/metrics."
   events/cp-agent-heartbeat)
-(def cp-agent-state-changed
+
+(def ^{:stratum 0} cp-agent-state-changed
   "Build and return a :control-plane/agent-state-changed event envelope
    map recording an agent's normalized state transition (:cp/agent-id,
    :cp/from-status, :cp/to-status)."
   events/cp-agent-state-changed)
-(def cp-decision-created
+
+(def ^{:stratum 0} cp-decision-created
   "Build and return a :control-plane/decision-created event envelope map
    for an agent's decision request (:cp/agent-id, :cp/decision-id,
    :cp/summary); optional priority-or-opts add priority, type, context,
    options, deadline."
   events/cp-decision-created)
-(def cp-decision-resolved
+
+(def ^{:stratum 0} cp-decision-resolved
   "Build and return a :control-plane/decision-resolved event envelope
    map for a human-resolved decision (:cp/decision-id, :cp/resolution);
    optional comment as :cp/comment."
   events/cp-decision-resolved)
-(def intervention-requested
+
+(def ^{:stratum 0} intervention-requested
   "Build and return a :supervisory/intervention-requested event envelope
    map, merging the intervention map into the envelope."
   events/intervention-requested)
-(def intervention-state-changed
+
+(def ^{:stratum 0} intervention-state-changed
   "Build and return a :supervisory/intervention-state-changed event
    envelope map for an InterventionRequest lifecycle change
    (:intervention/id, :intervention/state); optional opts carry the
    many :intervention/* detail fields (from-state, type, target-type,
    target-id, requested-by, justification, outcome, ...)."
   events/intervention-state-changed)
-(def intervention-request-event
+
+(def ^{:stratum 0} intervention-request-event
   "Build the :supervisory/intervention-requested event an operator
    surface writes into the operator directory, or an :invalid-input
    anomaly when a required field is missing. Required:
    :intervention/type, :intervention/target-type, :intervention/target-id,
    :intervention/requested-by, :intervention/request-source. Pure."
   operator-requests/intervention-request-event)
-(def request-intervention!
+
+(def ^{:stratum 0} request-intervention!
   "Write an intervention request atomically into
    `{events-dir}/operator/` for the operator-event consumer (Phase D
    decision 1 — the one control channel). Takes the keys of
@@ -476,13 +538,14 @@
   operator-requests/request-intervention!)
 
 ;; PR scoring (N5-delta-2 §4.1)
-(def pr-created
+(def ^{:stratum 0} pr-created
   "Build and return a :pr/created event envelope map for a
    workflow-owned PR (:pr/repo, :pr/number, :pr/url, :pr/branch);
    optional title, author, merge-order. Lets consumers attach a PR to
    its owning workflow run."
   events/pr-created)
-(def pr-scored
+
+(def ^{:stratum 0} pr-scored
   "Build and return a :pr/scored event envelope map carrying PR scoring
    results (:pr/readiness, :pr/risk, :pr/policy, :pr/recommendation —
    any subset). Not inherently workflow-scoped; opts :workflow/id scopes
@@ -490,19 +553,21 @@
   events/pr-scored)
 
 ;; Routing trigger events (N5-delta-4 §4.2)
-(def pr-monitor-review-comments-arrived
+(def ^{:stratum 0} pr-monitor-review-comments-arrived
   "Build and return a :pr-monitor/review-comments-arrived event envelope
    map (:workflow/id nil — PR-scoped) for new review comments on an owned
    PR (:pr/repo, :pr/number, :comments/count); optional agent-session-id
    as :comments/agent-session-id."
   events/pr-monitor-review-comments-arrived)
-(def pr-monitor-ci-failed
+
+(def ^{:stratum 0} pr-monitor-ci-failed
   "Build and return a :pr-monitor/ci-failed event envelope map
    (:workflow/id nil) for a CI status reaching a non-success terminal
    state on an owned PR (:pr/repo, :pr/number, :ci/check-name,
    :ci/conclusion). :ci/conclusion is an open keyword."
   events/pr-monitor-ci-failed)
-(def standards-review-posted
+
+(def ^{:stratum 0} standards-review-posted
   "Build and return a :standards-review/posted event envelope map
    (:workflow/id nil) for a standards-review comment on a PR (:pr/repo,
    :pr/number, :review/severity). :review/severity is an open keyword;
@@ -510,7 +575,7 @@
   events/standards-review-posted)
 
 ;; Zettelkasten lifecycle (miniforge-fleet Phase E.3)
-(def zettel-promoted
+(def ^{:stratum 0} zettel-promoted
   "Build and return a :zettel/promoted event envelope map emitted when a
    zettel revision transitions to :trusted and becomes eligible to ride
    the Fleet event log. Carries the zettel's revision-keyed identity and
@@ -523,8 +588,7 @@
 
 ;; ────────────────────────────────────────────────────────────────────────────
 ;; Listener, control, approval, and callback APIs
-
-(def register-listener!
+(def ^{:stratum 0} register-listener!
   "Register a listener on the stream with a capability level (:observe,
    :advise, or :control), wrapping its callback with capability-based
    and user filters and emitting :listener/attached. Returns the new
@@ -533,16 +597,19 @@
    :listener/capability, :listener/identity, :listener/filters,
    :listener/callback, :listener/options."
   listeners/register-listener!)
-(def deregister-listener!
+
+(def ^{:stratum 0} deregister-listener!
   "Unsubscribe a listener by id, drop its metadata, and emit
    :listener/detached. Returns true when the listener existed, or nil
    when no listener matched the id."
   listeners/deregister-listener!)
-(def list-listeners
+
+(def ^{:stratum 0} list-listeners
   "Return a sequence of registered listener metadata maps for the
    stream (empty when none registered)."
   listeners/list-listeners)
-(def submit-annotation!
+
+(def ^{:stratum 0} submit-annotation!
   "Submit an advisory annotation from a listener; requires :advise or
    :control capability. Emits and returns the :annotation/created event
    map. Throws an :anomalies/not-found anomaly when the listener is
@@ -551,7 +618,7 @@
    :annotation/workflow-id."
   listeners/submit-annotation!)
 
-(def create-control-action
+(def ^{:stratum 0} create-control-action
   "Build a structured control-action map from an action-type keyword
    (:pause, :resume, :retry, :rollback, :cancel, :quarantine,
    :adjust-budget, :emergency-stop, :gate-override, ...), a target map
@@ -561,17 +628,20 @@
    :action/status :pending, :action/created-at, plus optional
    :action/justification and :action/parameters."
   control/create-control-action)
-(def default-roles
+
+(def ^{:stratum 0} default-roles
   "Default RBAC role definitions for structured control actions."
   control/default-roles)
-(def authorize-action
+
+(def ^{:stratum 0} authorize-action
   "Check RBAC authorization for a control action against role
    definitions. Returns {:authorized? true :reason string} when the
    role permits the action on the target category, else {:authorized?
    false :reason string :anomaly map} (unknown role / unknown target
    type / forbidden action)."
   control/authorize-action)
-(def execute-control-action!
+
+(def ^{:stratum 0} execute-control-action!
   "Authorize then execute a control action. Emits
    :control-action/requested before and :control-action/executed after.
    On RBAC denial returns {:status :denied :reason string :anomaly map}
@@ -579,11 +649,13 @@
    returns its result wrapped via response/success, or
    response/failure on a thrown exception."
   control/execute-control-action!)
-(def requires-approval?
+
+(def ^{:stratum 0} requires-approval?
   "Return true when the given action-type keyword requires multi-party
    approval (:gate-override or :budget-escalation), else false."
   control/requires-approval?)
-(def execute-control-action-with-approval!
+
+(def ^{:stratum 0} execute-control-action-with-approval!
   "Execute a control action, gating on approval first. When the action
    type requires approval, creates an approval request, emits
    :approval/requested, and returns {:status :awaiting-approval
@@ -593,16 +665,18 @@
    :approval-manager."
   control/execute-control-action-with-approval!)
 
-(def approval-succeeded?
+(def ^{:stratum 0} approval-succeeded?
   "Return true when a builder response (from response/success)
    succeeded, else false. Use to test submit-approval / cancel-approval
    results."
   approval/approval-succeeded?)
-(def approval-failed?
+
+(def ^{:stratum 0} approval-failed?
   "Return true when a builder response (from response/failure) failed,
    else false. Use to test submit-approval / cancel-approval results."
   approval/approval-failed?)
-(def create-approval-request
+
+(def ^{:stratum 0} create-approval-request
   "Create a new approval-request map requiring quorum-based signing.
    Args: action-id (UUID), required-signers (vector of strings), quorum
    (count), and optional opts (:expires-in-hours default 24,
@@ -611,7 +685,8 @@
    :approval/quorum, :approval/signatures [], :approval/created-at,
    :approval/expires-at, plus :approval/metadata when supplied."
   approval/create-approval-request)
-(def submit-approval
+
+(def ^{:stratum 0} submit-approval
   "Submit an :approve or :reject decision from a signer for an approval
    request. On success returns a builder success wrapping the updated
    request (status transitions to :approved on quorum, :rejected
@@ -619,39 +694,46 @@
    failure (anomaly) when not pending, expired, signer unauthorized,
    already signed, or the decision is invalid. Optional opts: :reason."
   approval/submit-approval)
-(def check-approval-status
+
+(def ^{:stratum 0} check-approval-status
   "Return the effective status keyword of an approval request, mapping
    a pending-but-expired request to :expired. One of :pending,
    :approved, :rejected, :expired, or :cancelled."
   approval/check-approval-status)
-(def cancel-approval
+
+(def ^{:stratum 0} cancel-approval
   "Cancel a pending approval request, recording canceller and reason.
    Returns a builder success wrapping the updated request (status
    :cancelled), or a builder failure when the request is not pending."
   approval/cancel-approval)
-(def create-approval-manager
+
+(def ^{:stratum 0} create-approval-manager
   "Create an atom-backed approval manager. Returns an atom holding
    {:approvals {}} keyed by approval id."
   approval/create-approval-manager)
-(def store-approval!
+
+(def ^{:stratum 0} store-approval!
   "Store an approval request in the manager atom under its :approval/id.
    Returns the stored approval map."
   approval/store-approval!)
-(def get-approval
+
+(def ^{:stratum 0} get-approval
   "Look up an approval request in the manager atom by id. Returns the
    approval map, or nil when absent."
   approval/get-approval)
-(def update-approval!
+
+(def ^{:stratum 0} update-approval!
   "Replace an approval request in the manager atom (keyed by its
    :approval/id). Returns the updated approval map."
   approval/update-approval!)
-(def list-approvals
+
+(def ^{:stratum 0} list-approvals
   "List approval requests held by the manager atom. Returns a vector of
    approval maps. Optional opts :status filters by effective status
    (via check-approval-status)."
   approval/list-approvals)
 
-(def create-streaming-callback
+(def ^{:stratum 0} create-streaming-callback
   "Callback invoked by the LLM client for each parsed stream event.
    Returns a stateful callback fn of one parsed-event map. On tool-use
    events emits both :agent/tool-call (legacy) and
@@ -665,47 +747,53 @@
 
 ;; ────────────────────────────────────────────────────────────────────────────
 ;; Reliability metric event constructors (N3 §3.17)
-
-(def sli-computed
+(def ^{:stratum 0} sli-computed
   "Build and return a :reliability/sli-computed event envelope map
    (:workflow/id nil) for an SLI value computed over a rolling window
    (:sli/name, :sli/value, :sli/window); optional opts add :sli/tier and
    :sli/dimensions."
   events/sli-computed)
-(def slo-breach
+
+(def ^{:stratum 0} slo-breach
   "Build and return a :reliability/slo-breach event envelope map
    (:workflow/id nil) for a missed SLO target (:slo/sli-name,
    :slo/target, :slo/actual, :slo/tier, :slo/window)."
   events/slo-breach)
-(def error-budget-update
+
+(def ^{:stratum 0} error-budget-update
   "Build and return a :reliability/error-budget-update event envelope
    map (:workflow/id nil) for recomputed error budget state
    (:budget/tier, :budget/sli, :budget/remaining, :budget/burn-rate,
    :budget/window)."
   events/error-budget-update)
-(def dependency-health-updated
+
+(def ^{:stratum 0} dependency-health-updated
   "Build and return a :dependency/health-updated event envelope map
    (:workflow/id nil) for a changed dependency health projection,
    merging the dependency map; optional previous-status as
    :dependency/previous-status."
   events/dependency-health-updated)
-(def dependency-recovered
+
+(def ^{:stratum 0} dependency-recovered
   "Build and return a :dependency/recovered event envelope map
    (:workflow/id nil) for a dependency returning to healthy, merging the
    dependency map; optional previous-status as
    :dependency/previous-status."
   events/dependency-recovered)
-(def degradation-mode-changed
+
+(def ^{:stratum 0} degradation-mode-changed
   "Build and return a :reliability/degradation-mode-changed event
    envelope map (:workflow/id nil) for a degradation-mode transition
    (:degradation/from, :degradation/to, :degradation/trigger)."
   events/degradation-mode-changed)
-(def safe-mode-entered
+
+(def ^{:stratum 0} safe-mode-entered
   "Build and return a :safe-mode/entered event envelope map (:workflow/id
    nil) recording safe-mode activation (:safe-mode/trigger); optional
    details as :safe-mode/trigger-details."
   events/safe-mode-entered)
-(def safe-mode-exited
+
+(def ^{:stratum 0} safe-mode-exited
   "Build and return a :safe-mode/exited event envelope map (:workflow/id
    nil) recording safe-mode deactivation (:safe-mode/exited-by,
    :safe-mode/justification, :safe-mode/duration-ms,
@@ -713,7 +801,7 @@
   events/safe-mode-exited)
 
 ;; Repository intelligence event constructors (RN-19/20)
-(def repo-index-quality-measured
+(def ^{:stratum 0} repo-index-quality-measured
   "Build and return a :repo-index/quality-measured event envelope map
    (:workflow/id nil) emitted by the index quality tracker (RN-19) when
    it samples the composite quality score for a named index
@@ -721,7 +809,7 @@
    optional opts add :index/measured-at."
   events/repo-index-quality-measured)
 
-(def repo-index-coverage-changed
+(def ^{:stratum 0} repo-index-coverage-changed
   "Build and return a :repo-index/coverage-changed event envelope map
    (:workflow/id nil) emitted by the index quality tracker (RN-20) when
    coverage for a named index changes beyond the configured threshold
@@ -731,13 +819,13 @@
 
 ;; ────────────────────────────────────────────────────────────────────────────
 ;; Meta-loop event constructors
-
-(def meta-loop-cycle-completed
+(def ^{:stratum 0} meta-loop-cycle-completed
   "Build and return a :meta-loop/cycle-completed event envelope map
    (:workflow/id nil), merging the summary map (signals, diagnoses,
    proposals counts)."
   events/meta-loop-cycle-completed)
-(def meta-loop-cycle-failed
+
+(def ^{:stratum 0} meta-loop-cycle-failed
   "Build and return a :meta-loop/cycle-failed event envelope map
    (:workflow/id nil) for an unhandled meta-loop exception
    (:meta-loop/error, :meta-loop/error-class)."
@@ -745,29 +833,31 @@
 
 ;; ────────────────────────────────────────────────────────────────────────────
 ;; Observer / knowledge failure event constructors
-
-(def observer-signal-failed
+(def ^{:stratum 0} observer-signal-failed
   "Build and return an :observer/signal-failed event envelope map for a
    failure forwarding a signal to the meta-loop (:observer/error)."
   events/observer-signal-failed)
-(def knowledge-synthesis-failed
+
+(def ^{:stratum 0} knowledge-synthesis-failed
   "Build and return a :knowledge/synthesis-failed event envelope map
    (:workflow/id nil) for a pattern-synthesis failure (:knowledge/error)."
   events/knowledge-synthesis-failed)
-(def knowledge-promotion-failed
+
+(def ^{:stratum 0} knowledge-promotion-failed
   "Build and return a :knowledge/promotion-failed event envelope map
    (:workflow/id nil) for a learning-promotion failure
    (:knowledge/error)."
   events/knowledge-promotion-failed)
 
 ;; Agent stream-stall and session events (GROUP 1+4, GROUP 2)
-(def agent-stream-stalled
+(def ^{:stratum 0} agent-stream-stalled
   "Build and return an :agent/stream-stalled event envelope map
    indicating the agent output stream has gone silent past the gap
    threshold (:workflow/phase, :stream/gap-duration-ms, :agent/backend).
    Consumed by the self-healing supervisor."
   events/agent-stream-stalled)
-(def agent-session-captured
+
+(def ^{:stratum 0} agent-session-captured
   "Build and return an :agent/session-captured event envelope map
    recording the backend session id from the initial handshake
    (:workflow/phase, :agent/backend, :agent/session-id). Must be emitted
@@ -776,15 +866,14 @@
 
 ;; ────────────────────────────────────────────────────────────────────────────
 ;; Event-stream reader — replay events from the file-sink layout
-
-(def strip-transit-prefix
+(def ^{:stratum 0} strip-transit-prefix
   "Turn a raw transit-JSON parse back into idiomatic Clojure data,
    walking maps and vectors recursively: strings prefixed with `~:`
    become keywords; `~u` / `~t` (UUID / instant) prefixes become the
    stripped string form. Returns the de-prefixed value."
   reader/strip-transit-prefix)
 
-(def read-event-file
+(def ^{:stratum 0} read-event-file
   "Parse one transit-JSON event file into an event map (prefixes
    stripped: `:event/type` back to a keyword, UUID/instant values as
    plain strings). Returns the parsed map, or nil when the file cannot
@@ -792,7 +881,7 @@
    branch on the nil themselves."
   reader/read-event-file)
 
-(def read-workflow-events
+(def ^{:stratum 0} read-workflow-events
   "Read every `.json` event file under a workflow directory, sorted by
    timestamp-prefixed filename, parsed as transit-JSON and de-prefixed.
    Arg `dir` is a java.io.File or String path. Returns a vector of
@@ -800,7 +889,7 @@
    Unparseable files are silently dropped."
   reader/read-workflow-events)
 
-(def read-workflow-events-by-id
+(def ^{:stratum 0} read-workflow-events-by-id
   "Read events for a workflow id under a base events dir, probing the
    archived → live → legacy layouts and reading the first that exists.
    Args: base-dir, workflow-id (UUID, keyword, or string). Returns a
@@ -810,8 +899,7 @@
 
 ;; ────────────────────────────────────────────────────────────────────────────
 ;; Event timeline renderer
-
-(def render-timeline
+(def ^{:stratum 0} render-timeline
   "Transform a seq of parsed event maps (as from read-workflow-events)
    into a human-readable multi-line timeline string, one line per event
    (HH:mm:ss  <phase>  <detail>) with inserted gap lines between events

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/approval.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/approval.clj
@@ -15,27 +15,26 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.interface.approval
   "Multi-party approval API for the event stream."
   (:require
    [ai.miniforge.event-stream.approval :as approval]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Approval management
 
-(def approval-succeeded?
+;; Approval management
+(def ^{:stratum 0} approval-succeeded?
   "Return true when a builder response (from response/success)
    succeeded, else false. Use to test submit-approval / cancel-approval
    results."
   approval/succeeded?)
 
-(def approval-failed?
+(def ^{:stratum 0} approval-failed?
   "Return true when a builder response (from response/failure) failed,
    else false. Use to test submit-approval / cancel-approval results."
   approval/failed?)
 
-(def create-approval-request
+(def ^{:stratum 0} create-approval-request
   "Create a new approval-request map requiring quorum-based signing.
    Args: action-id (UUID), required-signers (vector of strings), quorum
    (count), and optional opts (:expires-in-hours default 24,
@@ -45,7 +44,7 @@
    :approval/expires-at, plus :approval/metadata when supplied."
   approval/create-approval-request)
 
-(def submit-approval
+(def ^{:stratum 0} submit-approval
   "Submit an :approve or :reject decision from a signer for an approval
    request. On success returns a builder success wrapping the updated
    request (status transitions to :approved on quorum, :rejected
@@ -54,39 +53,39 @@
    already signed, or the decision is invalid. Optional opts: :reason."
   approval/submit-approval)
 
-(def check-approval-status
+(def ^{:stratum 0} check-approval-status
   "Return the effective status keyword of an approval request, mapping
    a pending-but-expired request to :expired. One of :pending,
    :approved, :rejected, :expired, or :cancelled."
   approval/check-approval-status)
 
-(def cancel-approval
+(def ^{:stratum 0} cancel-approval
   "Cancel a pending approval request, recording canceller and reason.
    Returns a builder success wrapping the updated request (status
    :cancelled), or a builder failure when the request is not pending."
   approval/cancel-approval)
 
-(def create-approval-manager
+(def ^{:stratum 0} create-approval-manager
   "Create an atom-backed approval manager. Returns an atom holding
    {:approvals {}} keyed by approval id."
   approval/create-approval-manager)
 
-(def store-approval!
+(def ^{:stratum 0} store-approval!
   "Store an approval request in the manager atom under its :approval/id.
    Returns the stored approval map."
   approval/store-approval!)
 
-(def get-approval
+(def ^{:stratum 0} get-approval
   "Look up an approval request in the manager atom by id. Returns the
    approval map, or nil when absent."
   approval/get-approval)
 
-(def update-approval!
+(def ^{:stratum 0} update-approval!
   "Replace an approval request in the manager atom (keyed by its
    :approval/id). Returns the updated approval map."
   approval/update-approval!)
 
-(def list-approvals
+(def ^{:stratum 0} list-approvals
   "List approval requests held by the manager atom. Returns a vector of
    approval maps. Optional opts :status filters by effective status
    (via check-approval-status)."

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/callbacks.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/callbacks.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.interface.callbacks
   "Streaming callback helpers for the event-stream public API."
   (:require
@@ -28,9 +27,9 @@
    [java.util.concurrent TimeUnit]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Convenience callbacks
 
-(defn- tool-use-line
+;; Convenience callbacks
+(defn- ^{:stratum 0} tool-use-line
   "Render a short terminal-visible line for a tool-use streaming event."
   [{:keys [tool-name tool-names]}]
   (let [names (or (seq tool-names)
@@ -38,7 +37,7 @@
     (when (seq names)
       (messages/t :stream/tool-use-line {:names (str/join ", " names)}))))
 
-(defn- maybe-digest
+(defn- ^{:stratum 0} maybe-digest
   "Apply digest-content to `content` only when content is non-nil.
    digest-content handles the 1KB threshold internally (preview is always
    capped; SHA-256 is always computed). We guard only against nil so the
@@ -47,7 +46,9 @@
   (when (some? content)
     (digest/digest-content content)))
 
-(defn create-streaming-callback
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} create-streaming-callback
   "Callback invoked by the LLM client for each parsed stream event.
 
    Expected parsed-event keys:

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/control.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/control.clj
@@ -15,16 +15,15 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.interface.control
   "Control-action API for the event stream."
   (:require
    [ai.miniforge.event-stream.control :as control]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Control actions
 
-(def create-control-action
+;; Control actions
+(def ^{:stratum 0} create-control-action
   "Build a structured control-action map from an action-type keyword
    (:pause, :resume, :retry, :rollback, :cancel, :quarantine,
    :adjust-budget, :emergency-stop, :gate-override, ...), a target map
@@ -35,11 +34,11 @@
    :action/justification and :action/parameters."
   control/create-control-action)
 
-(def default-roles
+(def ^{:stratum 0} default-roles
   "Default RBAC role definitions for structured control actions."
   control/default-roles)
 
-(def authorize-action
+(def ^{:stratum 0} authorize-action
   "Check RBAC authorization for a control action against role
    definitions. Returns {:authorized? true :reason string} when the
    role permits the action on the target category, else {:authorized?
@@ -47,7 +46,7 @@
    type / forbidden action)."
   control/authorize-action)
 
-(def execute-control-action!
+(def ^{:stratum 0} execute-control-action!
   "Authorize then execute a control action. Emits
    :control-action/requested before and :control-action/executed after.
    On RBAC denial returns {:status :denied :reason string :anomaly map}
@@ -56,12 +55,12 @@
    response/failure on a thrown exception."
   control/execute-control-action!)
 
-(def requires-approval?
+(def ^{:stratum 0} requires-approval?
   "Return true when the given action-type keyword requires multi-party
    approval (:gate-override or :budget-escalation), else false."
   control/requires-approval?)
 
-(def execute-control-action-with-approval!
+(def ^{:stratum 0} execute-control-action-with-approval!
   "Execute a control action, gating on approval first. When the action
    type requires approval, creates an approval request, emits
    :approval/requested, and returns {:status :awaiting-approval

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/control_state.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/control_state.clj
@@ -15,40 +15,39 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.interface.control-state
   "Control-state helpers for the event-stream public API."
   (:require
    [ai.miniforge.event-stream.control :as control]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Control state primitives
 
-(def create-control-state
+;; Control state primitives
+(def ^{:stratum 0} create-control-state
   "Create a control-state atom for driving workflow pause/resume/cancel
    from the CLI poller or TUI. Returns an atom holding
    {:paused false :stopped false :adjustments {}}."
   control/create-control-state)
 
-(def pause!
+(def ^{:stratum 0} pause!
   "Set the control-state atom's :paused flag true. Returns the new
    state map."
   control/pause!)
 
-(def resume!
+(def ^{:stratum 0} resume!
   "Clear the control-state atom's :paused flag (set false). Returns the
    new state map."
   control/resume!)
 
-(def cancel!
+(def ^{:stratum 0} cancel!
   "Set the control-state atom's :stopped flag true. Returns the new
    state map."
   control/cancel!)
 
-(def paused?
+(def ^{:stratum 0} paused?
   "Return the boolean :paused flag from a control-state atom."
   control/paused?)
 
-(def cancelled?
+(def ^{:stratum 0} cancelled?
   "Return the boolean :stopped flag from a control-state atom."
   control/cancelled?)

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/events.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/events.clj
@@ -15,84 +15,83 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.interface.events
   "Workflow, agent, gate, task, listener, control, chain, and control-plane event constructors."
   (:require
    [ai.miniforge.event-stream.core :as core]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Event constructors
 
-(def workflow-started
+;; Event constructors
+(def ^{:stratum 0} workflow-started
   "Build and return a :workflow/started event envelope map. Multi-arity
    for the legacy 2/3-arg call shape; the opts arity may carry
    :routing/trigger-event-id so the automation-edge-correlator links the
    handler workflow back to its routing trigger."
   core/workflow-started)
 
-(def phase-started
+(def ^{:stratum 0} phase-started
   "Build and return a :workflow/phase-started event envelope map for the
    given phase keyword; optional context is attached as :phase/context."
   core/phase-started)
 
-(def phase-completed
+(def ^{:stratum 0} phase-completed
   "Build and return a :workflow/phase-completed event envelope map.
    Records :phase/outcome (default :success) and, when present on the
    result, duration, artifacts, error, transition-request, redirect-to,
    tokens, cost, meta, and termination-reason."
   core/phase-completed)
 
-(def workspace-persisted
+(def ^{:stratum 0} workspace-persisted
   "Build and return a :workspace/persisted event envelope map recording
    that a phase's worktree was archived to a checkpoint (phase, env-id,
    branch, commit-sha, bundle-path, persist-tier)."
   core/workspace-persisted)
 
-(def agent-chunk
+(def ^{:stratum 0} agent-chunk
   "Build and return an :agent/chunk event envelope map carrying a
    streamed text delta for an agent; sets :chunk/done? when the optional
    done? flag is truthy."
   core/agent-chunk)
 
-(def agent-status
+(def ^{:stratum 0} agent-status
   "Build and return an :agent/status event envelope map carrying a
    status-type keyword and human message for an agent."
   core/agent-status)
 
-(def agent-tool-call
+(def ^{:stratum 0} agent-tool-call
   "Build and return an :agent/tool-call event envelope map carrying the
    tool name(s) an agent invoked (:tool/name, :tool/names, :tool/call-id,
    :tool/args-preview). Legacy event kept for existing consumers."
   core/agent-tool-call)
 
-(def agent-tool-call-started
+(def ^{:stratum 0} agent-tool-call-started
   "Build and return an :agent/tool-call-started event envelope map
    marking the start of a tool call (:tool/name, :tool/names,
    :tool/args-digest, :tool/call-id); opens the latency span closed by
    tool-call-completed."
   core/agent-tool-call-started)
 
-(def tool-call-completed
+(def ^{:stratum 0} tool-call-completed
   "Build and return a :tool/call-completed event envelope map closing
    the latency span opened by agent-tool-call-started (:tool/call-id,
    :tool/result-digest, :tool/duration-ms, :tool/success?, :tool/error)."
   core/tool-call-completed)
 
-(def phase-heartbeat
+(def ^{:stratum 0} phase-heartbeat
   "Build and return a :workflow/phase-heartbeat event envelope map for
    long-running phase liveness (:phase/active-since,
    :phase/events-emitted, :phase/last-event-at,
    :phase/gap-since-last-event-ms)."
   core/phase-heartbeat)
 
-(def workflow-completed
+(def ^{:stratum 0} workflow-completed
   "Build and return a :workflow/completed event envelope map carrying a
    status keyword and optional duration plus opts (tokens, cost,
    pr-info, pr-infos, evidence-bundle-id)."
   core/workflow-completed)
 
-(def workflow-failed
+(def ^{:stratum 0} workflow-failed
   "Build and return a :workflow/failed event envelope map. Normalizes
    the error (Throwable, anomaly map, or plain map) into
    :workflow/failure-reason, :workflow/error-details,
@@ -100,49 +99,49 @@
    :failure/class."
   core/workflow-failed)
 
-(def llm-request
+(def ^{:stratum 0} llm-request
   "Build and return an :llm/request event envelope map for an LLM call
    (model, optional prompt-tokens); assigns a fresh :llm/request-id."
   core/llm-request)
 
-(def llm-response
+(def ^{:stratum 0} llm-response
   "Build and return an :llm/response event envelope map for an LLM
    response correlated by request-id; optional metrics add
    completion/total tokens, duration, and cost."
   core/llm-response)
 
-(def agent-started
+(def ^{:stratum 0} agent-started
   "Build and return an :agent/started event envelope map; optional
    context is attached as :agent/context."
   core/agent-started)
 
-(def agent-completed
+(def ^{:stratum 0} agent-completed
   "Build and return an :agent/completed event envelope map; optional
    result is attached as :agent/result."
   core/agent-completed)
 
-(def agent-failed
+(def ^{:stratum 0} agent-failed
   "Build and return an :agent/failed event envelope map; optional error
    becomes :agent/error and optional :failure/class is carried through."
   core/agent-failed)
 
-(def gate-started
+(def ^{:stratum 0} gate-started
   "Build and return a :gate/started event envelope map; optional
    artifact-summary is attached as :gate/artifact-summary."
   core/gate-started)
 
-(def gate-passed
+(def ^{:stratum 0} gate-passed
   "Build and return a :gate/passed event envelope map; optional
    duration-ms is attached as :gate/duration-ms."
   core/gate-passed)
 
-(def gate-failed
+(def ^{:stratum 0} gate-failed
   "Build and return a :gate/failed event envelope map; optional
    violations become :gate/violations and optional :failure/class is
    carried through."
   core/gate-failed)
 
-(def gate-rule-applied
+(def ^{:stratum 0} gate-rule-applied
   "Build and return a :gate/rule-applied event envelope map: per-rule
    policy evidence recording rule-id evaluated in phase with status
    (:passed, :failed, :skipped-by-phase, :not-applicable). Optional
@@ -150,199 +149,193 @@
    :violation summary."
   core/gate-rule-applied)
 
-(def tool-invoked
+(def ^{:stratum 0} tool-invoked
   "Build and return a :tool/invoked event envelope map for a tool an
    agent invoked; optional params-summary is attached as
    :tool/params-summary."
   core/tool-invoked)
 
-(def tool-completed
+(def ^{:stratum 0} tool-completed
   "Build and return a :tool/completed event envelope map; optional
    result-summary is attached as :tool/result-summary."
   core/tool-completed)
 
-(def milestone-reached
+(def ^{:stratum 0} milestone-reached
   "Build and return a :workflow/milestone-reached event envelope map for
    a milestone-id; optional description overrides the default message."
   core/milestone-reached)
 
-(def milestone-started
+(def ^{:stratum 0} milestone-started
   "Build and return a :phase/milestone-started event envelope map for a
    milestone-id; optional description overrides the default message."
   core/milestone-started)
 
-(def milestone-completed
+(def ^{:stratum 0} milestone-completed
   "Build and return a :phase/milestone-completed event envelope map for
    a milestone-id; optional description overrides the default message."
   core/milestone-completed)
 
-(def milestone-failed
+(def ^{:stratum 0} milestone-failed
   "Build and return a :phase/milestone-failed event envelope map for a
    milestone-id; optional reason overrides the default message."
   core/milestone-failed)
 
-(def task-state-changed
+(def ^{:stratum 0} task-state-changed
   "Build and return a :task/state-changed event envelope map recording a
    DAG task transitioning from-state to-state (:dag/id, :task/id,
    :task/from-state, :task/to-state); optional context as :task/context."
   core/task-state-changed)
 
-(def task-frontier-entered
+(def ^{:stratum 0} task-frontier-entered
   "Build and return a :task/frontier-entered event envelope map for a
    DAG task entering the ready frontier; optional frontier-size as
    :task/frontier-size."
   core/task-frontier-entered)
 
-(def task-skip-propagated
+(def ^{:stratum 0} task-skip-propagated
   "Build and return a :task/skip-propagated event envelope map for a DAG
    task skipped by upstream propagation; optional cause-task as
    :task/cause-task."
   core/task-skip-propagated)
 
-(def inter-agent-message-sent
+(def ^{:stratum 0} inter-agent-message-sent
   "Build and return an :agent/message-sent event envelope map for a
    message from one agent to another (:from-agent/id, :to-agent/id);
    optional message-type as :message/type."
   core/inter-agent-message-sent)
 
-(def inter-agent-message-received
+(def ^{:stratum 0} inter-agent-message-received
   "Build and return an :agent/message-received event envelope map for a
    message received by an agent (:from-agent/id, :to-agent/id); optional
    message-type as :message/type."
   core/inter-agent-message-received)
 
-(def meta-loop-halt-requested
+(def ^{:stratum 0} meta-loop-halt-requested
   "Build and return a :meta-loop/halt-requested event envelope map recording a
    meta-agent's REFUSE: :halt/halting-agent and :halt/reason-code (RefusalReason);
    optional opts add :halt/detail and :workflow/phase."
   core/meta-loop-halt-requested)
 
-(def listener-attached
+(def ^{:stratum 0} listener-attached
   "Build and return a :listener/attached event envelope map for a
    listener id; optional listener-type and capability as :listener/type
    / :listener/capability."
   core/listener-attached)
 
-(def listener-detached
+(def ^{:stratum 0} listener-detached
   "Build and return a :listener/detached event envelope map for a
    listener id; optional reason as :listener/reason."
   core/listener-detached)
 
-(def annotation-created
+(def ^{:stratum 0} annotation-created
   "Build and return an :annotation/created event envelope map for an
    advisory annotation from a listener (:listener/id,
    :annotation/type); optional content as :annotation/content."
   core/annotation-created)
 
-(def control-action-requested
+(def ^{:stratum 0} control-action-requested
   "Build and return a :control-action/requested event envelope map
    (:action/id, :action/type); optional requester as :action/requester."
   core/control-action-requested)
 
-(def control-action-executed
+(def ^{:stratum 0} control-action-executed
   "Build and return a :control-action/executed event envelope map for an
    action id; optional result as :action/result."
   core/control-action-executed)
 
-(def chain-started
+(def ^{:stratum 0} chain-started
   "Build and return a :chain/started event envelope map (chains are not
    workflow-scoped, so :workflow/id is nil) carrying :chain/id and
    :chain/step-count."
   core/chain-started)
 
-(def chain-step-started
+(def ^{:stratum 0} chain-step-started
   "Build and return a :chain/step-started event envelope map carrying
    :chain/id, :step/id, :step/index, and :step/workflow-id."
   core/chain-step-started)
 
-(def chain-step-completed
+(def ^{:stratum 0} chain-step-completed
   "Build and return a :chain/step-completed event envelope map carrying
    :chain/id, :step/id, and :step/index."
   core/chain-step-completed)
 
-(def chain-step-failed
+(def ^{:stratum 0} chain-step-failed
   "Build and return a :chain/step-failed event envelope map carrying
    :chain/id, :step/id, :step/index, and :chain/error; optional
    :failure/class."
   core/chain-step-failed)
 
-(def chain-completed
+(def ^{:stratum 0} chain-completed
   "Build and return a :chain/completed event envelope map carrying
    :chain/id, :chain/duration-ms, and :chain/step-count."
   core/chain-completed)
 
-(def chain-failed
+(def ^{:stratum 0} chain-failed
   "Build and return a :chain/failed event envelope map carrying
    :chain/id, :chain/failed-step, and :chain/error; optional
    :failure/class."
   core/chain-failed)
 
-;------------------------------------------------------------------------------ Layer 1
 ;; OCI container event constructors
-
-(def container-started
+(def ^{:stratum 0} container-started
   "Build and return an :oci/container-started event envelope map for a
    container id; optional opts add :oci/image-digest and
    :oci/trust-level."
   core/container-started)
 
-(def container-completed
+(def ^{:stratum 0} container-completed
   "Build and return an :oci/container-completed event envelope map
    carrying :oci/container-id and :oci/exit-code; optional duration-ms
    as :oci/duration-ms."
   core/container-completed)
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Tool supervision event constructors
-
-(def tool-use-evaluated
+(def ^{:stratum 0} tool-use-evaluated
   "Build and return a :supervision/tool-use-evaluated event envelope map
    capturing a supervisor's decision on a tool-use request (:tool/name,
    :supervision/decision); optional opts add :supervision/reasoning,
    :supervision/meta-eval?, :supervision/confidence, :workflow/phase."
   core/tool-use-evaluated)
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Control plane event constructors
-
-(def cp-agent-registered
+(def ^{:stratum 0} cp-agent-registered
   "Build and return a :control-plane/agent-registered event envelope map
    for an external agent registering with the control plane (:cp/agent-id,
    :cp/vendor); optional opts add name, external-id, capabilities,
    metadata, tags, heartbeat-interval-ms."
   core/cp-agent-registered)
 
-(def cp-agent-heartbeat
+(def ^{:stratum 0} cp-agent-heartbeat
   "Build and return a :control-plane/agent-heartbeat event envelope map
    (:cp/agent-id, :cp/status); optional opts add :cp/task and
    :cp/metrics."
   core/cp-agent-heartbeat)
 
-(def cp-agent-state-changed
+(def ^{:stratum 0} cp-agent-state-changed
   "Build and return a :control-plane/agent-state-changed event envelope
    map recording an agent's normalized state transition (:cp/agent-id,
    :cp/from-status, :cp/to-status)."
   core/cp-agent-state-changed)
 
-(def cp-decision-created
+(def ^{:stratum 0} cp-decision-created
   "Build and return a :control-plane/decision-created event envelope map
    for an agent's decision request (:cp/agent-id, :cp/decision-id,
    :cp/summary); optional priority-or-opts add priority, type, context,
    options, deadline."
   core/cp-decision-created)
 
-(def cp-decision-resolved
+(def ^{:stratum 0} cp-decision-resolved
   "Build and return a :control-plane/decision-resolved event envelope
    map for a human-resolved decision (:cp/decision-id, :cp/resolution);
    optional comment as :cp/comment."
   core/cp-decision-resolved)
 
-(def intervention-requested
+(def ^{:stratum 0} intervention-requested
   "Build and return a :supervisory/intervention-requested event envelope
    map, merging the intervention map into the envelope."
   core/intervention-requested)
 
-(def intervention-state-changed
+(def ^{:stratum 0} intervention-state-changed
   "Build and return a :supervisory/intervention-state-changed event
    envelope map for an InterventionRequest lifecycle change
    (:intervention/id, :intervention/state); optional opts carry the
@@ -350,17 +343,15 @@
    target-id, requested-by, justification, outcome, ...)."
   core/intervention-state-changed)
 
-;------------------------------------------------------------------------------ Layer 2
 ;; PR scoring event constructors (N5-delta-2 §4.1)
-
-(def pr-created
+(def ^{:stratum 0} pr-created
   "Build and return a :pr/created event envelope map for a
    workflow-owned PR (:pr/repo, :pr/number, :pr/url, :pr/branch);
    optional title, author, merge-order. Lets consumers attach a PR to
    its owning workflow run."
   core/pr-created)
 
-(def pr-scored
+(def ^{:stratum 0} pr-scored
   "Build and return a :pr/scored event envelope map carrying PR scoring
    results (:pr/readiness, :pr/risk, :pr/policy, :pr/recommendation —
    any subset). Not inherently workflow-scoped; opts :workflow/id scopes
@@ -368,21 +359,21 @@
   core/pr-scored)
 
 ;; Routing trigger event constructors (N5-delta-4 §4.2)
-(def pr-monitor-review-comments-arrived
+(def ^{:stratum 0} pr-monitor-review-comments-arrived
   "Build and return a :pr-monitor/review-comments-arrived event envelope
    map (:workflow/id nil — PR-scoped) for new review comments on an owned
    PR (:pr/repo, :pr/number, :comments/count); optional agent-session-id
    as :comments/agent-session-id."
   core/pr-monitor-review-comments-arrived)
 
-(def pr-monitor-ci-failed
+(def ^{:stratum 0} pr-monitor-ci-failed
   "Build and return a :pr-monitor/ci-failed event envelope map
    (:workflow/id nil) for a CI status reaching a non-success terminal
    state on an owned PR (:pr/repo, :pr/number, :ci/check-name,
    :ci/conclusion). :ci/conclusion is an open keyword."
   core/pr-monitor-ci-failed)
 
-(def standards-review-posted
+(def ^{:stratum 0} standards-review-posted
   "Build and return a :standards-review/posted event envelope map
    (:workflow/id nil) for a standards-review comment on a PR (:pr/repo,
    :pr/number, :review/severity). :review/severity is an open keyword;
@@ -391,8 +382,7 @@
 
 ;; Zettelkasten lifecycle event constructors (miniforge-fleet
 ;; Phase E.3 outbox path).
-
-(def zettel-promoted
+(def ^{:stratum 0} zettel-promoted
   "Build and return a :zettel/promoted event envelope map emitted when a
    zettel revision transitions to :trusted and becomes eligible to ride
    the Fleet event log. Carries the zettel's revision-keyed identity and
@@ -403,116 +393,107 @@
    :auth/context)."
   core/zettel-promoted)
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Reliability metric event constructors (N3 §3.17)
-
-(def sli-computed
+(def ^{:stratum 0} sli-computed
   "Build and return a :reliability/sli-computed event envelope map
    (:workflow/id nil) for an SLI value computed over a rolling window
    (:sli/name, :sli/value, :sli/window); optional opts add :sli/tier and
    :sli/dimensions."
   core/sli-computed)
 
-(def slo-breach
+(def ^{:stratum 0} slo-breach
   "Build and return a :reliability/slo-breach event envelope map
    (:workflow/id nil) for a missed SLO target (:slo/sli-name,
    :slo/target, :slo/actual, :slo/tier, :slo/window)."
   core/slo-breach)
 
-(def error-budget-update
+(def ^{:stratum 0} error-budget-update
   "Build and return a :reliability/error-budget-update event envelope
    map (:workflow/id nil) for recomputed error budget state
    (:budget/tier, :budget/sli, :budget/remaining, :budget/burn-rate,
    :budget/window)."
   core/error-budget-update)
 
-(def dependency-health-updated
+(def ^{:stratum 0} dependency-health-updated
   "Build and return a :dependency/health-updated event envelope map
    (:workflow/id nil) for a changed dependency health projection,
    merging the dependency map; optional previous-status as
    :dependency/previous-status."
   core/dependency-health-updated)
 
-(def dependency-recovered
+(def ^{:stratum 0} dependency-recovered
   "Build and return a :dependency/recovered event envelope map
    (:workflow/id nil) for a dependency returning to healthy, merging the
    dependency map; optional previous-status as
    :dependency/previous-status."
   core/dependency-recovered)
 
-(def degradation-mode-changed
+(def ^{:stratum 0} degradation-mode-changed
   "Build and return a :reliability/degradation-mode-changed event
    envelope map (:workflow/id nil) for a degradation-mode transition
    (:degradation/from, :degradation/to, :degradation/trigger)."
   core/degradation-mode-changed)
 
-(def safe-mode-entered
+(def ^{:stratum 0} safe-mode-entered
   "Build and return a :safe-mode/entered event envelope map (:workflow/id
    nil) recording safe-mode activation (:safe-mode/trigger); optional
    details as :safe-mode/trigger-details."
   core/safe-mode-entered)
 
-(def safe-mode-exited
+(def ^{:stratum 0} safe-mode-exited
   "Build and return a :safe-mode/exited event envelope map (:workflow/id
    nil) recording safe-mode deactivation (:safe-mode/exited-by,
    :safe-mode/justification, :safe-mode/duration-ms,
    :safe-mode/workflows-queued)."
   core/safe-mode-exited)
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Meta-loop event constructors
-
-(def meta-loop-cycle-completed
+(def ^{:stratum 0} meta-loop-cycle-completed
   "Build and return a :meta-loop/cycle-completed event envelope map
    (:workflow/id nil), merging the summary map (signals, diagnoses,
    proposals counts)."
   core/meta-loop-cycle-completed)
 
-(def meta-loop-cycle-failed
+(def ^{:stratum 0} meta-loop-cycle-failed
   "Build and return a :meta-loop/cycle-failed event envelope map
    (:workflow/id nil) for an unhandled meta-loop exception
    (:meta-loop/error, :meta-loop/error-class)."
   core/meta-loop-cycle-failed)
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Observer / knowledge failure event constructors
-
-(def observer-signal-failed
+(def ^{:stratum 0} observer-signal-failed
   "Build and return an :observer/signal-failed event envelope map for a
    failure forwarding a signal to the meta-loop (:observer/error)."
   core/observer-signal-failed)
 
-(def knowledge-synthesis-failed
+(def ^{:stratum 0} knowledge-synthesis-failed
   "Build and return a :knowledge/synthesis-failed event envelope map
    (:workflow/id nil) for a pattern-synthesis failure (:knowledge/error)."
   core/knowledge-synthesis-failed)
 
-(def knowledge-promotion-failed
+(def ^{:stratum 0} knowledge-promotion-failed
   "Build and return a :knowledge/promotion-failed event envelope map
    (:workflow/id nil) for a learning-promotion failure
    (:knowledge/error)."
   core/knowledge-promotion-failed)
 
-;------------------------------------------------------------------------------ Layer 3.5
 ;; Agent stream-stall and session event constructors (GROUP 1+4, GROUP 2)
-
-(def agent-stream-stalled
+(def ^{:stratum 0} agent-stream-stalled
   "Build and return an :agent/stream-stalled event envelope map
    indicating the agent output stream has gone silent past the gap
    threshold (:workflow/phase, :stream/gap-duration-ms, :agent/backend).
    Consumed by the self-healing supervisor."
   core/agent-stream-stalled)
 
-(def agent-session-captured
+(def ^{:stratum 0} agent-session-captured
   "Build and return an :agent/session-captured event envelope map
    recording the backend session id from the initial handshake
    (:workflow/phase, :agent/backend, :agent/session-id). Must be emitted
    before the first tool call so resume-on-kill has a valid session id."
   core/agent-session-captured)
-;------------------------------------------------------------------------------ Layer 4
-;; Repository intelligence event constructors (RN-19/20)
 
-(def repo-index-quality-measured
+;; Repository intelligence event constructors (RN-19/20)
+(def ^{:stratum 0} repo-index-quality-measured
   "Build and return a :repo-index/quality-measured event envelope map
    (:workflow/id nil) emitted when the index quality tracker (RN-19)
    samples the composite quality score for a named index
@@ -520,7 +501,7 @@
    optional opts add :index/measured-at."
   core/repo-index-quality-measured)
 
-(def repo-index-coverage-changed
+(def ^{:stratum 0} repo-index-coverage-changed
   "Build and return a :repo-index/coverage-changed event envelope map
    (:workflow/id nil) emitted when the index quality tracker (RN-20)
    detects that coverage for a named index changed beyond the configured

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/listeners.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/listeners.clj
@@ -15,16 +15,15 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.interface.listeners
   "Listener management API for the event stream."
   (:require
    [ai.miniforge.event-stream.listeners :as listeners]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Listener management
 
-(def register-listener!
+;; Listener management
+(def ^{:stratum 0} register-listener!
   "Register a listener on the stream with a capability level (:observe,
    :advise, or :control), wrapping its callback with capability-based
    and user filters and emitting :listener/attached. Returns the new
@@ -34,18 +33,18 @@
    :listener/callback, :listener/options."
   listeners/register-listener!)
 
-(def deregister-listener!
+(def ^{:stratum 0} deregister-listener!
   "Unsubscribe a listener by id, drop its metadata, and emit
    :listener/detached. Returns true when the listener existed, or nil
    when no listener matched the id."
   listeners/deregister-listener!)
 
-(def list-listeners
+(def ^{:stratum 0} list-listeners
   "Return a sequence of registered listener metadata maps for the
    stream (empty when none registered)."
   listeners/list-listeners)
 
-(def submit-annotation!
+(def ^{:stratum 0} submit-annotation!
   "Submit an advisory annotation from a listener; requires :advise or
    :control capability. Emits and returns the :annotation/created event
    map. Throws an :anomalies/not-found anomaly when the listener is

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/stream.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/stream.clj
@@ -15,16 +15,15 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.interface.stream
   "Event-stream lifecycle and query API."
   (:require
    [ai.miniforge.event-stream.core :as core]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Event stream lifecycle and queries
 
-(def create-event-stream
+;; Event stream lifecycle and queries
+(def ^{:stratum 0} create-event-stream
   "Create an event stream. Returns an atom holding the stream state
    (events vector, subscribers, filters, sinks, sequence numbers,
    quiesce fence, in-flight counter, optional snowflake generator).
@@ -33,7 +32,7 @@
    generator for lexically-sortable ids)."
   core/create-event-stream)
 
-(def create-envelope
+(def ^{:stratum 0} create-envelope
   "Build an event envelope map with an atomically-assigned per-workflow
    sequence number. Returns a map carrying :event/type, :event/id (a
    uuid? — snowflake-encoded when the stream has a generator, else
@@ -43,7 +42,7 @@
    :agent/id, :agent/instance-id)."
   core/create-envelope)
 
-(def publish!
+(def ^{:stratum 0} publish!
   "Publish an event to the stream: fan out to sinks, append to the
    in-memory log, fan out to matching subscribers, log. Returns the
    published event map. If the event's workflow has been quiesced
@@ -52,29 +51,29 @@
    running sinks or subscribers."
   core/publish!)
 
-(def subscribe!
+(def ^{:stratum 0} subscribe!
   "Register a callback for events. 3-arg form subscribes to all events;
    4-arg form takes a filter-fn (fn [event] -> bool) so only matching
    events are delivered. Returns the subscriber-id passed in."
   core/subscribe!)
 
-(def unsubscribe!
+(def ^{:stratum 0} unsubscribe!
   "Remove a subscriber (and its filter) by id. Returns nil."
   core/unsubscribe!)
 
-(def get-events
+(def ^{:stratum 0} get-events
   "Query the in-memory event log. Returns a vector of event maps.
    Optional opts map filters/pages: :workflow-id, :event-type, :offset,
    :limit."
   core/get-events)
 
-(def get-latest-status
+(def ^{:stratum 0} get-latest-status
   "Return the most recent :agent/status event map for a workflow (and
    optionally a specific agent-id), or nil when none exist."
   core/get-latest-status)
 
 ;; BD-2a: shutdown ordering primitives.
-(def quiesce!
+(def ^{:stratum 0} quiesce!
   "Fence future publishes for a workflow (when :workflow-id is given)
    and wait for in-flight publishes to settle. After return, publish!
    for that workflow returns a rejection map. Without :workflow-id, adds
@@ -84,7 +83,7 @@
    5000)."
   core/quiesce!)
 
-(def drain!
+(def ^{:stratum 0} drain!
   "Wait for every event published before this call to reach all sinks,
    including each sink's optional drain hook. Returns a map: {:ok? true
    :drained-count N}, {:ok? false :reason :timeout :pending-count N}, or

--- a/components/event-stream/src/ai/miniforge/event_stream/listeners.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/listeners.clj
@@ -54,16 +54,21 @@
    :confidential :control})
 
 (defn ^{:stratum 0} matches-workflow?
-  "Check if event matches the workflow ID filter (nil/empty = match all)."
-  [wf-ids event]
-  (or (empty? wf-ids)
-      (contains? (set wf-ids) (:workflow/id event))))
+  "Check if event matches the workflow ID filter (nil/empty = match all).
+   `wf-id-set` must already be a set — callers on a hot path (e.g.
+   `register-listener!`'s per-event filter closure) build it once at
+   registration time rather than re-`set`ting a raw collection on
+   every call."
+  [wf-id-set event]
+  (or (empty? wf-id-set)
+      (contains? wf-id-set (:workflow/id event))))
 
 (defn ^{:stratum 0} matches-event-type?
-  "Check if event matches the event type filter (nil/empty = match all)."
-  [event-types event]
-  (or (empty? event-types)
-      (contains? (set event-types) (:event/type event))))
+  "Check if event matches the event type filter (nil/empty = match all).
+   `event-type-set` must already be a set — see `matches-workflow?`."
+  [event-type-set event]
+  (or (empty? event-type-set)
+      (contains? event-type-set (:event/type event))))
 
 (defn ^{:stratum 0} deregister-listener!
   "Deregister a listener and remove its subscription.
@@ -141,11 +146,11 @@
     ;; Build filter function from listener filters + capability enforcement
     (let [user-filter-fn (cond
                            (nil? filters) (constantly true)
-                           :else (let [wf-ids (:workflow-ids filters)
-                                       event-types (:event-types filters)]
+                           :else (let [wf-id-set (set (:workflow-ids filters))
+                                       event-type-set (set (:event-types filters))]
                                    (fn [event]
-                                     (and (matches-workflow? wf-ids event)
-                                          (matches-event-type? event-types event)))))
+                                     (and (matches-workflow? wf-id-set event)
+                                          (matches-event-type? event-type-set event)))))
           ;; Capability-based filter: listeners only receive events they're authorized for
           filter-fn (fn [event]
                       (and (capability-sufficient? capability

--- a/components/event-stream/src/ai/miniforge/event_stream/listeners.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/listeners.clj
@@ -46,7 +46,8 @@
 (def ^{:stratum 0} privacy->min-capability
   "Map from event privacy level to minimum listener capability required.
    :public events -> any listener (:observe)
-   :internal events -> :advise or higher
+   :internal events -> :observe (same as :public; tiered gating not yet
+   implemented, see work/n08-oci-governance.spec.edn)
    :confidential events -> :control only"
   {:public       :observe
    :internal     :observe

--- a/components/event-stream/src/ai/miniforge/event_stream/listeners.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/listeners.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.listeners
   "Listener registry with capability enforcement for N8 OCI compliance.
 
@@ -34,23 +33,17 @@
    [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Constants
 
-(def capability-levels
+;; Constants
+(def ^{:stratum 0} capability-levels
   "Valid listener capability levels, ordered by privilege."
   #{:observe :advise :control})
 
-(def capability-rank
+(def ^{:stratum 0} capability-rank
   "Numeric rank for capability comparison."
   {:observe 0 :advise 1 :control 2})
 
-(defn capability-sufficient?
-  "Check if actual capability meets or exceeds required capability."
-  [actual required]
-  (>= (get capability-rank actual 0)
-      (get capability-rank required 0)))
-
-(def privacy->min-capability
+(def ^{:stratum 0} privacy->min-capability
   "Map from event privacy level to minimum listener capability required.
    :public events -> any listener (:observe)
    :internal events -> :advise or higher
@@ -59,7 +52,56 @@
    :internal     :observe
    :confidential :control})
 
-(defn event-requires-capability
+(defn ^{:stratum 0} matches-workflow?
+  "Check if event matches the workflow ID filter (nil/empty = match all)."
+  [wf-ids event]
+  (or (empty? wf-ids)
+      (contains? (set wf-ids) (:workflow/id event))))
+
+(defn ^{:stratum 0} matches-event-type?
+  "Check if event matches the event type filter (nil/empty = match all)."
+  [event-types event]
+  (or (empty? event-types)
+      (contains? (set event-types) (:event/type event))))
+
+(defn ^{:stratum 0} deregister-listener!
+  "Deregister a listener and remove its subscription.
+
+   Arguments:
+   - stream: Event stream atom
+   - listener-id: UUID returned from register-listener!
+   - reason: Optional reason string"
+  [stream listener-id & [reason]]
+  (let [listener (get-in @stream [:listeners listener-id])]
+    (when listener
+      ;; Unsubscribe from event stream
+      (core/unsubscribe! stream listener-id)
+      ;; Remove listener metadata
+      (swap! stream update :listeners dissoc listener-id)
+      ;; Emit listener/detached event
+      (core/publish! stream
+                     (core/listener-detached stream nil listener-id reason))
+      true)))
+
+(defn ^{:stratum 0} get-listener
+  "Get listener metadata by ID."
+  [stream listener-id]
+  (get-in @stream [:listeners listener-id]))
+
+(defn ^{:stratum 0} list-listeners
+  "List all registered listeners."
+  [stream]
+  (vals (get @stream :listeners {})))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} capability-sufficient?
+  "Check if actual capability meets or exceeds required capability."
+  [actual required]
+  (>= (get capability-rank actual 0)
+      (get capability-rank required 0)))
+
+(defn ^{:stratum 1} event-requires-capability
   "Return the minimum capability level required to receive an event.
 
    Uses schema-defined privacy levels with fallback overrides for
@@ -68,22 +110,10 @@
   (let [privacy (schema/event-privacy event-type)]
     (get privacy->min-capability privacy :observe)))
 
-(defn matches-workflow?
-  "Check if event matches the workflow ID filter (nil/empty = match all)."
-  [wf-ids event]
-  (or (empty? wf-ids)
-      (contains? (set wf-ids) (:workflow/id event))))
+;------------------------------------------------------------------------------ Layer 2
 
-(defn matches-event-type?
-  "Check if event matches the event type filter (nil/empty = match all)."
-  [event-types event]
-  (or (empty? event-types)
-      (contains? (set event-types) (:event/type event))))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; Listener registration
-
-(defn register-listener!
+(defn ^{:stratum 2} register-listener!
   "Register a listener with capability level.
 
    Arguments:
@@ -136,39 +166,8 @@
                      (core/listener-attached stream nil listener-id type capability))
       listener-id)))
 
-(defn deregister-listener!
-  "Deregister a listener and remove its subscription.
-
-   Arguments:
-   - stream: Event stream atom
-   - listener-id: UUID returned from register-listener!
-   - reason: Optional reason string"
-  [stream listener-id & [reason]]
-  (let [listener (get-in @stream [:listeners listener-id])]
-    (when listener
-      ;; Unsubscribe from event stream
-      (core/unsubscribe! stream listener-id)
-      ;; Remove listener metadata
-      (swap! stream update :listeners dissoc listener-id)
-      ;; Emit listener/detached event
-      (core/publish! stream
-                     (core/listener-detached stream nil listener-id reason))
-      true)))
-
-(defn get-listener
-  "Get listener metadata by ID."
-  [stream listener-id]
-  (get-in @stream [:listeners listener-id]))
-
-(defn list-listeners
-  "List all registered listeners."
-  [stream]
-  (vals (get @stream :listeners {})))
-
-;------------------------------------------------------------------------------ Layer 2
 ;; Advisory annotations
-
-(defn submit-annotation!
+(defn ^{:stratum 2} submit-annotation!
   "Submit an advisory annotation (requires :advise or :control capability).
 
    Arguments:
@@ -201,10 +200,8 @@
       (core/publish! stream event)
       event)))
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Control action submission (capability-gated)
-
-(defn submit-control-action!
+(defn ^{:stratum 2} submit-control-action!
   "Submit a control action via a listener (requires :control capability).
 
    Arguments:

--- a/components/event-stream/src/ai/miniforge/event_stream/manifest.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/manifest.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.manifest
   "Per-workflow manifest: lifecycle state, archive state, snapshot
    watermark, owner lease (BD-2b sub-2 of the RFC at
@@ -55,6 +54,8 @@
    [java.time Instant]
    [java.util.concurrent Executors ScheduledExecutorService TimeUnit]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; STRATIFIED-DESIGN LAYERING
 ;;
 ;; Layers are a strict DAG: each layer is a vocabulary for the next
@@ -63,26 +64,35 @@
 ;; stratum; if you find yourself wanting one function in a layer to
 ;; call another, the called one belongs in a lower layer.
 ;;
-;; Quick map:
+;; Quick map (7 real layers per the same-file reference graph — over
+;; the 3-layer budget; SL003 deferred to a Wave 2 namespace split,
+;; see the stratum-lint Wave 1 PR doc for this component):
 ;;
-;;   Layer 0  defaults, data shapes, atomic Java-interop helpers
-;;            (snowflake-event-id-re, legal-archive-transitions,
-;;             manifest-path, iso-now, pid-string, hostname-string,
-;;             default-heartbeat-error-log!, stop-heartbeat!)
-;;   Layer 1  single-concern primitives built on Layer 0
-;;            (valid?, explain, legal-archive-transition?,
-;;             fresh-owner, renew-lease, lease-fresh?, owner-pid-alive?)
+;;   Layer 0  defaults, data shapes, atomic Java-interop helpers,
+;;            lease-freshness check
+;;            (defaults, snowflake-event-id-re,
+;;             legal-archive-transitions, iso-now, pid-string,
+;;             hostname-string, default-heartbeat-error-log!,
+;;             stop-heartbeat!, lease-fresh?)
+;;   Layer 1  single-concern primitives + config re-exports, built
+;;            on the Layer 0 vocabulary above
+;;            (schema-version, manifest-filename, workflow-statuses,
+;;             archive-statuses, snapshot-statuses,
+;;             default-lease-ttl-seconds, heartbeat-period-seconds,
+;;             legal-archive-transition?, renew-lease,
+;;             owner-pid-alive?, mark-terminal)
 ;;   Layer 2  compose Layer 1 primitives
-;;            (transition-archive, init-active, mark-terminal,
-;;             load-manifest, save-manifest!)
+;;            (Manifest schema, manifest-path, fresh-owner,
+;;             transition-archive)
 ;;   Layer 3  manifest-bound IO that composes Layer 2 read + write
+;;            (valid?, explain, init-active, load-manifest)
+;;   Layer 4  atomic manifest write
+;;            (save-manifest!)
+;;   Layer 5  lease renewal, composing read + write
 ;;            (renew-lease!)
-;;   Layer 4  scheduled / orchestration
+;;   Layer 6  scheduled orchestration
 ;;            (start-heartbeat!)
-
-;------------------------------------------------------------------------------ Layer 0 — atomic helpers, defaults, data
-
-(def defaults
+(def ^{:stratum 0} defaults
   "Manifest defaults loaded from
    `resources/config/event-stream/manifest-defaults.edn` at namespace
    load. Keys: `:schema-version`, `:manifest-filename`,
@@ -92,20 +102,132 @@
       slurp
       edn/read-string))
 
-(def schema-version       (:schema-version defaults))
-(def manifest-filename    (:manifest-filename defaults))
-(def workflow-statuses    (:workflow-statuses defaults))
-(def archive-statuses     (:archive-statuses defaults))
-(def snapshot-statuses    (:snapshot-statuses defaults))
-(def default-lease-ttl-seconds (:default-lease-ttl-seconds defaults))
-(def heartbeat-period-seconds  (:heartbeat-period-seconds defaults))
-
-(def ^:private snowflake-event-id-re
+(def ^{:stratum 0} ^:private snowflake-event-id-re
   "16-char lowercase hex per the BD-2b sub-1 Snowflake filename
    grammar. The cross-repo JSON Schema validates the same shape."
   #"^[0-9a-f]{16}$")
 
-(def Manifest
+(def ^{:stratum 0} ^:private legal-archive-transitions
+  "Forward-only edges. Backwards moves (e.g. archived → live) are
+   never legal — once events have been moved they don't come back."
+  {:live       #{:archiving}
+   :archiving  #{:archived :live}        ; rollback to :live on aborted archive
+   :archived   #{:tombstoned}
+   :tombstoned #{}})
+
+(defn- ^{:stratum 0} iso-now
+  "ISO-8601 instant for `lease_renewed_at` / `created_at` etc."
+  ^String []
+  (str (Instant/now)))
+
+(defn- ^{:stratum 0} pid-string
+  "Process id as a string. Built from the JMX runtime bean name —
+   `pid@host` on hotspot — so we don't need Java-9-only APIs."
+  ^String []
+  (let [name (.getName (ManagementFactory/getRuntimeMXBean))]
+    (first (str/split name #"@"))))
+
+(defn- ^{:stratum 0} hostname-string
+  "Best-effort canonical hostname. Falls back to `\"unknown-host\"` if
+   DNS / lookup fails — the field is informational, not load-bearing."
+  ^String []
+  (try (.getCanonicalHostName (InetAddress/getLocalHost))
+       (catch Exception _ "unknown-host")))
+
+(defn- ^{:stratum 0} default-heartbeat-error-log!
+  "Last-resort logging when no `:on-error` callback is supplied. Writes
+   a single-line warning to stderr so persistent IO failures during
+   the heartbeat are observable in the operator's terminal / CI logs
+   rather than silently disappearing. Accepts either a Throwable or an
+   anomaly map returned by `renew-lease!`. The workflow runner is the
+   normal caller and should prefer to wire its own logger via
+   `:on-error`."
+  [failure workflow-dir]
+  (binding [*out* *err*]
+    (println (str "WARNING: manifest heartbeat renew failed for "
+                  (.getAbsolutePath ^File (io/file workflow-dir))
+                  ": " (if (anomaly/anomaly? failure)
+                         (:anomaly/message failure)
+                         (.getMessage ^Throwable failure))))))
+
+(defn ^{:stratum 0} stop-heartbeat!
+  "Shut a heartbeat executor down. Waits up to `:timeout-ms` (default
+   1000) for the in-flight renew to finish, then forces. Independent
+   of `start-heartbeat!` — placed in Layer 0 because it has no other
+   calls into this namespace."
+  ([^ScheduledExecutorService ex] (stop-heartbeat! ex {}))
+  ([^ScheduledExecutorService ex {:keys [timeout-ms] :or {timeout-ms 1000}}]
+   (when ex
+     (.shutdown ex)
+     (when-not (.awaitTermination ex (long timeout-ms) TimeUnit/MILLISECONDS)
+       (.shutdownNow ex))
+     nil)))
+
+(defn ^{:stratum 0} lease-fresh?
+  "True if `manifest`'s lease was renewed within `ttl_seconds` of `now`.
+   Pure — caller passes `now` as an `Instant` for testability."
+  ([manifest] (lease-fresh? manifest (Instant/now)))
+  ([manifest ^Instant now]
+   (let [renewed (Instant/parse ^String (get-in manifest [:owner :lease_renewed_at]))
+         ttl-s   (long (get-in manifest [:owner :lease_ttl_seconds]))
+         age-s   (- (.getEpochSecond now) (.getEpochSecond renewed))]
+     (<= age-s ttl-s))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} schema-version       (:schema-version defaults))
+
+(def ^{:stratum 1} manifest-filename    (:manifest-filename defaults))
+
+(def ^{:stratum 1} workflow-statuses    (:workflow-statuses defaults))
+
+(def ^{:stratum 1} archive-statuses     (:archive-statuses defaults))
+
+(def ^{:stratum 1} snapshot-statuses    (:snapshot-statuses defaults))
+
+(def ^{:stratum 1} default-lease-ttl-seconds (:default-lease-ttl-seconds defaults))
+
+(def ^{:stratum 1} heartbeat-period-seconds  (:heartbeat-period-seconds defaults))
+
+(defn ^{:stratum 1} legal-archive-transition?
+  "True iff the manifest may move from `from` to `to`."
+  [from to]
+  (contains? (get legal-archive-transitions from #{}) to))
+
+(defn ^{:stratum 1} renew-lease
+  "Pure: update `manifest`'s `:owner.lease_renewed_at` to now. Does
+   not change pid/host/ttl — those are stamped at acquisition and
+   only re-stamped when the workflow is re-claimed."
+  [manifest]
+  (assoc-in manifest [:owner :lease_renewed_at] (iso-now)))
+
+(defn ^{:stratum 1} owner-pid-alive?
+  "True if the manifest's `:owner.pid` corresponds to a running
+   process on this host. Use `ProcessHandle/of` (Java 9+). Returns
+   false when host doesn't match — cross-host pid checks are out of
+   scope (single-machine non-goal per the RFC)."
+  [manifest]
+  (let [owner-host (get-in manifest [:owner :host])]
+    (and (= owner-host (hostname-string))
+         (try
+           (let [pid (Long/parseLong (get-in manifest [:owner :pid]))]
+             (.isPresent (java.lang.ProcessHandle/of pid)))
+           (catch Exception _ false)))))
+
+(defn ^{:stratum 1} mark-terminal
+  "Pure: set `status` to a terminal value (`:completed | :failed |
+   :cancelled`) and stamp `completed_at`. Does NOT change
+   archive_status — that's a separate state machine driven by sub-3."
+  [manifest status]
+  (assert (contains? #{:completed :failed :cancelled} status)
+          (str "mark-terminal expects a terminal status, got " status))
+  (assoc manifest
+         :status       status
+         :completed_at (iso-now)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(def ^{:stratum 2} Manifest
   "Open Malli schema for the per-workflow manifest map. Open: future
    keys (e.g. additional snapshot-status detail) pass through without
    a schema bump per the RFC's forward-compatibility rule. Constraints
@@ -134,87 +256,14 @@
      [:lease_renewed_at :string]
      [:lease_ttl_seconds [:int {:min 1}]]]]])
 
-(def ^:private legal-archive-transitions
-  "Forward-only edges. Backwards moves (e.g. archived → live) are
-   never legal — once events have been moved they don't come back."
-  {:live       #{:archiving}
-   :archiving  #{:archived :live}        ; rollback to :live on aborted archive
-   :archived   #{:tombstoned}
-   :tombstoned #{}})
-
-(defn- iso-now
-  "ISO-8601 instant for `lease_renewed_at` / `created_at` etc."
-  ^String []
-  (str (Instant/now)))
-
-(defn- pid-string
-  "Process id as a string. Built from the JMX runtime bean name —
-   `pid@host` on hotspot — so we don't need Java-9-only APIs."
-  ^String []
-  (let [name (.getName (ManagementFactory/getRuntimeMXBean))]
-    (first (str/split name #"@"))))
-
-(defn- hostname-string
-  "Best-effort canonical hostname. Falls back to `\"unknown-host\"` if
-   DNS / lookup fails — the field is informational, not load-bearing."
-  ^String []
-  (try (.getCanonicalHostName (InetAddress/getLocalHost))
-       (catch Exception _ "unknown-host")))
-
-(defn manifest-path
+(defn ^{:stratum 2} manifest-path
   "Return the manifest.json path under `workflow-dir`. The caller
    chooses live/{wid} vs archived/{wid} — manifest is the same shape
    in both."
   ^File [workflow-dir]
   (io/file workflow-dir manifest-filename))
 
-(defn- default-heartbeat-error-log!
-  "Last-resort logging when no `:on-error` callback is supplied. Writes
-   a single-line warning to stderr so persistent IO failures during
-   the heartbeat are observable in the operator's terminal / CI logs
-   rather than silently disappearing. Accepts either a Throwable or an
-   anomaly map returned by `renew-lease!`. The workflow runner is the
-   normal caller and should prefer to wire its own logger via
-   `:on-error`."
-  [failure workflow-dir]
-  (binding [*out* *err*]
-    (println (str "WARNING: manifest heartbeat renew failed for "
-                  (.getAbsolutePath ^File (io/file workflow-dir))
-                  ": " (if (anomaly/anomaly? failure)
-                         (:anomaly/message failure)
-                         (.getMessage ^Throwable failure))))))
-
-(defn stop-heartbeat!
-  "Shut a heartbeat executor down. Waits up to `:timeout-ms` (default
-   1000) for the in-flight renew to finish, then forces. Independent
-   of `start-heartbeat!` — placed in Layer 0 because it has no other
-   calls into this namespace."
-  ([^ScheduledExecutorService ex] (stop-heartbeat! ex {}))
-  ([^ScheduledExecutorService ex {:keys [timeout-ms] :or {timeout-ms 1000}}]
-   (when ex
-     (.shutdown ex)
-     (when-not (.awaitTermination ex (long timeout-ms) TimeUnit/MILLISECONDS)
-       (.shutdownNow ex))
-     nil)))
-
-;------------------------------------------------------------------------------ Layer 1 — single-concern primitives over Layer 0
-
-(defn valid?
-  "True if `m` matches the manifest schema."
-  [m]
-  (m/validate Manifest m))
-
-(defn explain
-  "Return a malli explanation when `m` does not match. nil when valid."
-  [m]
-  (m/explain Manifest m))
-
-(defn legal-archive-transition?
-  "True iff the manifest may move from `from` to `to`."
-  [from to]
-  (contains? (get legal-archive-transitions from #{}) to))
-
-(defn fresh-owner
+(defn ^{:stratum 2} fresh-owner
   "Build an owner map with the calling process's pid + host, marking
    the lease as renewed right now."
   ([] (fresh-owner default-lease-ttl-seconds))
@@ -224,39 +273,7 @@
     :lease_renewed_at  (iso-now)
     :lease_ttl_seconds ttl-seconds}))
 
-(defn renew-lease
-  "Pure: update `manifest`'s `:owner.lease_renewed_at` to now. Does
-   not change pid/host/ttl — those are stamped at acquisition and
-   only re-stamped when the workflow is re-claimed."
-  [manifest]
-  (assoc-in manifest [:owner :lease_renewed_at] (iso-now)))
-
-(defn lease-fresh?
-  "True if `manifest`'s lease was renewed within `ttl_seconds` of `now`.
-   Pure — caller passes `now` as an `Instant` for testability."
-  ([manifest] (lease-fresh? manifest (Instant/now)))
-  ([manifest ^Instant now]
-   (let [renewed (Instant/parse ^String (get-in manifest [:owner :lease_renewed_at]))
-         ttl-s   (long (get-in manifest [:owner :lease_ttl_seconds]))
-         age-s   (- (.getEpochSecond now) (.getEpochSecond renewed))]
-     (<= age-s ttl-s))))
-
-(defn owner-pid-alive?
-  "True if the manifest's `:owner.pid` corresponds to a running
-   process on this host. Use `ProcessHandle/of` (Java 9+). Returns
-   false when host doesn't match — cross-host pid checks are out of
-   scope (single-machine non-goal per the RFC)."
-  [manifest]
-  (let [owner-host (get-in manifest [:owner :host])]
-    (and (= owner-host (hostname-string))
-         (try
-           (let [pid (Long/parseLong (get-in manifest [:owner :pid]))]
-             (.isPresent (java.lang.ProcessHandle/of pid)))
-           (catch Exception _ false)))))
-
-;------------------------------------------------------------------------------ Layer 2 — compose Layer 1
-
-(defn transition-archive
+(defn ^{:stratum 2} transition-archive
   "Pure: move the manifest's `archive_status` from its current value
    to `to`, returning the updated manifest. Returns a canonical
    `:conflict` anomaly on illegal moves so callers can't silently
@@ -272,7 +289,19 @@
                         :to     to
                         :workflow-id (:workflow_id manifest)}))))
 
-(defn init-active
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} valid?
+  "True if `m` matches the manifest schema."
+  [m]
+  (m/validate Manifest m))
+
+(defn ^{:stratum 3} explain
+  "Return a malli explanation when `m` does not match. nil when valid."
+  [m]
+  (m/explain Manifest m))
+
+(defn ^{:stratum 3} init-active
   "Build a fresh `:active` / `:live` manifest for a new workflow.
    Owner is the calling process. Snapshot watermark starts at
    sequence 0 with no event id — sub-3 / BD-2c update it as
@@ -293,18 +322,7 @@
    :raw_events_retained_until nil
    :owner                    (fresh-owner ttl-seconds)})
 
-(defn mark-terminal
-  "Pure: set `status` to a terminal value (`:completed | :failed |
-   :cancelled`) and stamp `completed_at`. Does NOT change
-   archive_status — that's a separate state machine driven by sub-3."
-  [manifest status]
-  (assert (contains? #{:completed :failed :cancelled} status)
-          (str "mark-terminal expects a terminal status, got " status))
-  (assoc manifest
-         :status       status
-         :completed_at (iso-now)))
-
-(defn load-manifest
+(defn ^{:stratum 3} load-manifest
   "Read and parse a manifest from disk. Returns the parsed map (with
    keyword keys) or nil when the file is absent. Throws if present
    but unparseable — a corrupted manifest is a real bug, not a
@@ -322,7 +340,9 @@
           (string? (:archive_status raw))  (update :archive_status keyword)
           (string? (:snapshot_status raw)) (update :snapshot_status keyword))))))
 
-(defn save-manifest!
+;------------------------------------------------------------------------------ Layer 4
+
+(defn ^{:stratum 4} save-manifest!
   "Atomically write `manifest` to `workflow-dir/manifest.json`.
 
    Writes to `manifest.json.tmp` first, fsyncs, then `Files/move`s
@@ -368,9 +388,9 @@
                                StandardCopyOption/REPLACE_EXISTING]))
       final)))
 
-;------------------------------------------------------------------------------ Layer 3 — manifest-bound IO composing Layer 2 read + write
+;------------------------------------------------------------------------------ Layer 5
 
-(defn renew-lease!
+(defn ^{:stratum 5} renew-lease!
   "Re-stamp the lease and write the manifest atomically. Returns the
    updated manifest, an anomaly from `save-manifest!`, or nil when the
    manifest is absent. Idempotent — a missing manifest is a no-op so
@@ -382,9 +402,9 @@
       (anomaly/let-ok [_saved (save-manifest! workflow-dir renewed)]
         renewed))))
 
-;------------------------------------------------------------------------------ Layer 4 — scheduled orchestration
+;------------------------------------------------------------------------------ Layer 6
 
-(defn start-heartbeat!
+(defn ^{:stratum 6} start-heartbeat!
   "Start a single-threaded scheduled executor that renews the
    manifest's lease every `:period-seconds` (default
    `heartbeat-period-seconds`). Returns the executor handle for

--- a/components/event-stream/src/ai/miniforge/event_stream/messages.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/messages.clj
@@ -15,13 +15,14 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.messages
   "Component-level message catalog for event-stream.
    Delegates to the shared messages component."
   (:require [ai.miniforge.messages.interface :as messages]))
 
-(def t
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} t
   "Look up an event-stream message by key, with optional param substitution."
   (messages/create-translator "config/event-stream/messages/en-US.edn"
                               :event-stream/messages))

--- a/components/event-stream/src/ai/miniforge/event_stream/operator_requests.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/operator_requests.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.operator-requests
   "Writer side of the operator control channel (Phase D decision 1).
 
@@ -49,9 +48,9 @@
    [java.nio.file Files StandardCopyOption]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Request shaping
 
-(def ^:private required-request-keys
+;; Request shaping
+(def ^{:stratum 0} ^:private required-request-keys
   "Fields a client must supply. Everything else on the wire envelope is
    stamped here or re-derived server-side by the consumer."
   [:intervention/type
@@ -60,11 +59,7 @@
    :intervention/requested-by
    :intervention/request-source])
 
-(defn- missing-request-keys
-  [request]
-  (remove #(some? (get request %)) required-request-keys))
-
-(defn- target-uuid
+(defn- ^{:stratum 0} target-uuid
   "The target id as a UUID, or nil when it is not one. `parse-uuid`
    returns nil (never throws) for a malformed string on our Clojure, so
    this stays total."
@@ -73,26 +68,7 @@
     target-id
     (some-> target-id str parse-uuid)))
 
-(defn- invalid-workflow-target?
-  "True when a `:workflow`-targeted request carries a target id that is
-   not a UUID. Such a request cannot route to a run's audit trail, so it
-   is rejected as `:invalid-input` rather than written with no
-   `:workflow/id` (a silent soft-failure) — honouring the fn contract."
-  [request]
-  (and (= :workflow (:intervention/target-type request))
-       (nil? (target-uuid (:intervention/target-id request)))))
-
-(defn- request-workflow-id
-  "The `:workflow/id` the envelope routes on: present only for
-   workflow-targeted interventions whose target id is a UUID. Mirrors
-   the consumer's `intervention-workflow-id` so the request and its
-   lifecycle events land in the same run's audit trail. Assumes the
-   target has already passed [[invalid-workflow-target?]]."
-  [request]
-  (when (= :workflow (:intervention/target-type request))
-    (target-uuid (:intervention/target-id request))))
-
-(defn- proposed-intervention
+(defn- ^{:stratum 0} proposed-intervention
   "The InterventionRequest body of the wire event. `:proposed` state and
    the timestamps are the client's *claim*; the consumer rebuilds the
    record with server authority and ignores them. They are written
@@ -115,10 +91,53 @@
       (:intervention/details request)
       (assoc :intervention/details (:intervention/details request)))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Event construction
+;; Atomic publication into the operator directory
+(defn- ^{:stratum 0} write-event-file!
+  "Serialize `event` and land it in `{base-dir}/operator/` atomically:
+   write a sibling `.tmp` then `Files/move` with `ATOMIC_MOVE` — the
+   repo-wide atomic-update idiom (see `archive.clj`). A reader can never
+   observe a half-written request, and the `.tmp` suffix keeps the
+   partial file out of the consumer's `.json` listing."
+  ^java.io.File [base-dir event]
+  (let [target (sinks/operator-event-file-path base-dir event)
+        tmp (io/file (.getParentFile target) (str (.getName target) ".tmp"))]
+    (spit tmp (sinks/event->transit-json event) :encoding "UTF-8")
+    (Files/move (.toPath tmp)
+                (.toPath target)
+                (into-array java.nio.file.CopyOption
+                            [StandardCopyOption/ATOMIC_MOVE
+                             StandardCopyOption/REPLACE_EXISTING]))
+    target))
 
-(defn intervention-request-event
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} missing-request-keys
+  [request]
+  (remove #(some? (get request %)) required-request-keys))
+
+(defn- ^{:stratum 1} invalid-workflow-target?
+  "True when a `:workflow`-targeted request carries a target id that is
+   not a UUID. Such a request cannot route to a run's audit trail, so it
+   is rejected as `:invalid-input` rather than written with no
+   `:workflow/id` (a silent soft-failure) — honouring the fn contract."
+  [request]
+  (and (= :workflow (:intervention/target-type request))
+       (nil? (target-uuid (:intervention/target-id request)))))
+
+(defn- ^{:stratum 1} request-workflow-id
+  "The `:workflow/id` the envelope routes on: present only for
+   workflow-targeted interventions whose target id is a UUID. Mirrors
+   the consumer's `intervention-workflow-id` so the request and its
+   lifecycle events land in the same run's audit trail. Assumes the
+   target has already passed [[invalid-workflow-target?]]."
+  [request]
+  (when (= :workflow (:intervention/target-type request))
+    (target-uuid (:intervention/target-id request))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Event construction
+(defn ^{:stratum 2} intervention-request-event
   "Build the `:supervisory/intervention-requested` event for `request`,
    or an `:invalid-input` anomaly when a required field is missing.
 
@@ -152,27 +171,9 @@
                                    (request-workflow-id request)
                                    intervention))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Atomic publication into the operator directory
+;------------------------------------------------------------------------------ Layer 3
 
-(defn- write-event-file!
-  "Serialize `event` and land it in `{base-dir}/operator/` atomically:
-   write a sibling `.tmp` then `Files/move` with `ATOMIC_MOVE` — the
-   repo-wide atomic-update idiom (see `archive.clj`). A reader can never
-   observe a half-written request, and the `.tmp` suffix keeps the
-   partial file out of the consumer's `.json` listing."
-  ^java.io.File [base-dir event]
-  (let [target (sinks/operator-event-file-path base-dir event)
-        tmp (io/file (.getParentFile target) (str (.getName target) ".tmp"))]
-    (spit tmp (sinks/event->transit-json event) :encoding "UTF-8")
-    (Files/move (.toPath tmp)
-                (.toPath target)
-                (into-array java.nio.file.CopyOption
-                            [StandardCopyOption/ATOMIC_MOVE
-                             StandardCopyOption/REPLACE_EXISTING]))
-    target))
-
-(defn request-intervention!
+(defn ^{:stratum 3} request-intervention!
   "Write an intervention request into `{events-dir}/operator/` for the
    operator-event consumer to pick up.
 

--- a/components/event-stream/src/ai/miniforge/event_stream/reader.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/reader.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.reader
   "Read event streams back from the on-disk file sink.
 
@@ -39,9 +38,9 @@
    [clojure.java.io :as io]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Transit-JSON prefix stripping
 
-(defn strip-transit-prefix
+;; Transit-JSON prefix stripping
+(defn ^{:stratum 0} strip-transit-prefix
   "Turn the raw transit-JSON parse back into idiomatic Clojure data.
 
    - strings prefixed with `~:` become keywords
@@ -76,52 +75,7 @@
 
     :else x))
 
-;; ── Single-file reader ─────────────────────────────────────────────────────
-
-(defn read-event-file
-  "Parse one transit-JSON event file into an event map (transit
-   prefixes stripped, so `:event/type` comes back as a keyword and
-   UUID/instant values as plain strings).
-
-   Returns the parsed map, or nil when the file cannot be read or
-   parsed. Callers that must be LOUD about malformed files (the
-   operator-event consumer's append-only contract) branch on the nil
-   themselves — unlike [[read-workflow-events]], nothing is dropped
-   silently without the caller seeing it."
-  [f]
-  (try
-    (strip-transit-prefix
-     (json/parse-string (slurp (io/file f) :encoding "UTF-8") false))
-    (catch Exception _e nil)))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Directory reader
-
-(defn read-workflow-events
-  "Read every `.json` event file under a workflow directory, sorted by
-   filename (which is timestamp-prefixed). Parse each as transit-JSON
-   and strip the transit prefixes.
-
-   Arguments:
-   - `dir` — java.io.File or String path to the workflow events dir
-     (e.g. `~/.miniforge/events/<workflow-id>/`)
-
-   Returns a vector of parsed event maps, or nil if the directory
-   does not exist. Files that fail to parse are silently dropped —
-   one corrupt event file shouldn't kill a whole replay."
-  [dir]
-  (let [^java.io.File dir (io/file dir)]
-    (when (.exists dir)
-      (->> (.listFiles dir)
-           (filter #(.endsWith (.getName ^java.io.File %) ".json"))
-           (sort-by #(.getName ^java.io.File %))
-           (keep (fn [^java.io.File f]
-                   (try
-                     (strip-transit-prefix (json/parse-string (slurp f) false))
-                     (catch Exception _e nil))))
-           vec))))
-
-(defn workflow-events-dir
+(defn ^{:stratum 0} workflow-events-dir
   "Resolve the on-disk events directory for `workflow-id` under
    `base-dir`. Probes three locations in priority order and returns
    the first one that exists:
@@ -145,7 +99,53 @@
       (.isDirectory legacy)   legacy
       :else                   nil)))
 
-(defn read-workflow-events-by-id
+;------------------------------------------------------------------------------ Layer 1
+
+;; ── Single-file reader ─────────────────────────────────────────────────────
+(defn ^{:stratum 1} read-event-file
+  "Parse one transit-JSON event file into an event map (transit
+   prefixes stripped, so `:event/type` comes back as a keyword and
+   UUID/instant values as plain strings).
+
+   Returns the parsed map, or nil when the file cannot be read or
+   parsed. Callers that must be LOUD about malformed files (the
+   operator-event consumer's append-only contract) branch on the nil
+   themselves — unlike [[read-workflow-events]], nothing is dropped
+   silently without the caller seeing it."
+  [f]
+  (try
+    (strip-transit-prefix
+     (json/parse-string (slurp (io/file f) :encoding "UTF-8") false))
+    (catch Exception _e nil)))
+
+;; Directory reader
+(defn ^{:stratum 1} read-workflow-events
+  "Read every `.json` event file under a workflow directory, sorted by
+   filename (which is timestamp-prefixed). Parse each as transit-JSON
+   and strip the transit prefixes.
+
+   Arguments:
+   - `dir` — java.io.File or String path to the workflow events dir
+     (e.g. `~/.miniforge/events/<workflow-id>/`)
+
+   Returns a vector of parsed event maps, or nil if the directory
+   does not exist. Files that fail to parse are silently dropped —
+   one corrupt event file shouldn't kill a whole replay."
+  [dir]
+  (let [^java.io.File dir (io/file dir)]
+    (when (.exists dir)
+      (->> (.listFiles dir)
+           (filter #(.endsWith (.getName ^java.io.File %) ".json"))
+           (sort-by #(.getName ^java.io.File %))
+           (keep (fn [^java.io.File f]
+                   (try
+                     (strip-transit-prefix (json/parse-string (slurp f) false))
+                     (catch Exception _e nil))))
+           vec))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} read-workflow-events-by-id
   "Convenience: read events for a workflow id under a base events dir.
    Probes archived → live → legacy layouts via `workflow-events-dir`
    and reads from the first one that exists.

--- a/components/event-stream/src/ai/miniforge/event_stream/schema.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/schema.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.schema
   "N3-compliant event schemas for workflow observability.
 
@@ -35,15 +34,15 @@
    [ai.miniforge.event-stream.digest :as digest]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Shared payload schemas
 
-(def TransitionRequest
+;; Shared payload schemas
+(def ^{:stratum 0} TransitionRequest
   "Schema for a phase transition request payload."
   [:map
    [:transition/type keyword?]
    [:transition/target keyword?]])
 
-(def RefusalReason
+(def ^{:stratum 0} RefusalReason
   "Closed vocabulary for why an agent or phase refuses to proceed.
 
    One vocabulary shared by every refusal act on the stream — phase
@@ -73,8 +72,7 @@
 ;; `:map` entries; every event schema below uses `with-identity` to
 ;; append the same set. A single edit here propagates through every
 ;; event without missing one.
-
-(def ^:private identity-entries
+(def ^{:stratum 0} ^:private identity-entries
   "Four optional fields every event schema accepts so subscribers
    can scope authorization without retrofitting the wire format."
   [[:org/id       {:optional true} uuid?]
@@ -82,181 +80,14 @@
    [:repo/id      {:optional true} string?]
    [:auth/context {:optional true} map?]])
 
-(defn with-identity
-  "Pure: append the Decision-14 identity quartet to `base-schema`'s
-   `:map` entries. Order in Malli `:map` is irrelevant for validation;
-   the helper keeps the per-event schemas focused on their own
-   payload while every event accepts the same identity set."
-  [base-schema]
-  (into base-schema identity-entries))
-
-(def ^:private sha256-hex-pattern
+(def ^{:stratum 0} ^:private sha256-hex-pattern
   "Lowercase SHA-256 hexadecimal digest shape."
   (re-pattern (str "^[0-9a-f]{" digest/sha256-hex-length "}$")))
 
-(def DigestSummary
-  "Schema for bounded digest payloads attached to tool lifecycle events."
-  [:map
-   [:digest/preview string?]
-   [:digest/sha256 [:re sha256-hex-pattern]]
-   [:digest/original-size [:and int? [:>= 0]]]])
-
-;------------------------------------------------------------------------------ Layer 0
-;; Event envelope (base schema all events must conform to)
-
-(def EventEnvelope
-  "Base envelope schema for all events per N3 spec section 2."
-  (with-identity
-   [:map
-    [:event/type keyword?]              ; REQUIRED: event type identifier
-    [:event/id uuid?]                   ; REQUIRED: unique event ID
-    [:event/timestamp inst?]            ; REQUIRED: ISO-8601 timestamp
-    [:event/version string?]            ; REQUIRED: event schema version
-    [:event/sequence-number int?]       ; REQUIRED: monotonic sequence within workflow
-    [:workflow/id uuid?]                ; REQUIRED: workflow this event belongs to
-    [:workflow/phase {:optional true} keyword?]     ; OPTIONAL: current phase
-    [:agent/id {:optional true} keyword?]           ; OPTIONAL: agent that emitted event
-    [:agent/instance-id {:optional true} uuid?]     ; OPTIONAL: specific agent instance
-    [:event/parent-id {:optional true} uuid?]       ; OPTIONAL: parent event ID (for causality)
-    [:message string?]]))               ; REQUIRED: human-readable message
-
-;------------------------------------------------------------------------------ Layer 1
-;; Workflow lifecycle event schemas
-
-(def WorkflowStarted
-  "Schema for workflow/started event.
-
-   `:routing/trigger-event-id` (N5-delta-4 §4.3) is the bridge the
-   automation-edge-correlator uses to map a handler workflow back to its
-   originating routing trigger. Optional — workflows started outside the
-   routing path (operator-initiated runs, etc.) omit the field, and the
-   correlator's heuristic-fallback path (§3.5 case 2) covers the absence."
-  (with-identity
-   [:map
-      [:event/type [:= :workflow/started]]
-    [:event/id uuid?]
-    [:event/timestamp inst?]
-    [:event/version string?]
-    [:event/sequence-number int?]
-    [:workflow/id uuid?]
-    [:workflow/spec {:optional true} map?]
-    [:workflow/intent {:optional true} map?]
-    ;; Plain `uuid?`, not `[:maybe uuid?]`: the producer-side contract
-    ;; (`core/workflow-started`) explicitly omits this key when the value
-    ;; is nil rather than emitting `{:routing/trigger-event-id nil}`. The
-    ;; envelope is therefore EITHER a real uuid or the key is absent —
-    ;; never a nil payload. Schema enforces that invariant.
-    [:routing/trigger-event-id {:optional true} uuid?]
-    [:message string?]]))
-
-(def PhaseStarted
-  "Schema for workflow/phase-started event."
-  (with-identity
-   [:map
-      [:event/type [:= :workflow/phase-started]]
-    [:event/id uuid?]
-    [:event/timestamp inst?]
-    [:event/version string?]
-    [:event/sequence-number int?]
-    [:workflow/id uuid?]
-    [:workflow/phase keyword?]
-    [:phase/expected-agent {:optional true} keyword?]
-    [:phase/context {:optional true} map?]
-    [:message string?]]))
-
-(def PhaseCompleted
-  "Schema for workflow/phase-completed event."
-  (with-identity
-   [:map
-      [:event/type [:= :workflow/phase-completed]]
-    [:event/id uuid?]
-    [:event/timestamp inst?]
-    [:event/version string?]
-    [:event/sequence-number int?]
-    [:workflow/id uuid?]
-    [:workflow/phase keyword?]
-    [:phase/duration-ms {:optional true} int?]
-    ;; `:phase/outcome` is the typed-act surface for a phase boundary on the
-    ;; observed layer (stream + evidence). The internal phase-result `:status`
-    ;; stays a 2-valued control flag for the FSM; this enum carries the full act.
-    ;; INFORM → :success/:failure/:skipped; REFUSE → :blocked (+ :phase/blocked-reason);
-    ;; REQUEST(redirect) → :redirected (+ :phase/transition-request).
-    [:phase/outcome {:optional true}
-     [:enum :success :failure :skipped :blocked :redirected]]
-    ;; Machine-readable cause, present when :phase/outcome is :blocked.
-    [:phase/blocked-reason {:optional true} RefusalReason]
-    ;; Review verdict, present only for the review phase. Carried so resume can
-    ;; reconstruct a blocked review from events alone — the event is a writer of
-    ;; this datum, one canonical location, no lossy reconstruction.
-    [:phase/review-decision {:optional true} keyword?]
-    [:phase/artifacts {:optional true} [:vector uuid?]]
-    [:phase/transition-request {:optional true} TransitionRequest]
-    [:phase/redirect-to {:optional true} keyword?]
-    [:phase/error {:optional true} map?]
-    [:phase/tokens {:optional true} int?]
-    [:phase/cost-usd {:optional true} number?]
-    [:message string?]]))
-
-(def WorkspacePersisted
-  "Schema for workspace/persisted event.
-
-   Emitted at phase boundaries when persist-workspace! has captured a
-   checkpoint. Carries enough provenance for the dashboard / evidence
-   bundle to surface 'inspect or resume from this archive'."
-  (with-identity
-   [:map
-      [:event/type [:= :workspace/persisted]]
-    [:event/id uuid?]
-    [:event/timestamp inst?]
-    [:event/version string?]
-    [:event/sequence-number int?]
-    [:workflow/id uuid?]
-    [:workspace/phase {:optional true} keyword?]
-    [:workspace/env-id {:optional true} string?]
-    [:workspace/branch {:optional true} string?]
-    [:workspace/commit-sha {:optional true} string?]
-    [:workspace/bundle-path {:optional true} string?]
-    [:workspace/tier {:optional true} [:enum :worktree :remote]]
-    [:message string?]]))
-
-(def WorkflowCompleted
-  "Schema for workflow/completed event."
-  (with-identity
-   [:map
-      [:event/type [:= :workflow/completed]]
-    [:event/id uuid?]
-    [:event/timestamp inst?]
-    [:event/version string?]
-    [:event/sequence-number int?]
-    [:workflow/id uuid?]
-    [:workflow/status [:enum :success :failure :cancelled]]
-    [:workflow/duration-ms {:optional true} int?]
-    [:workflow/evidence-bundle-id {:optional true} uuid?]
-    [:workflow/tokens {:optional true} int?]
-    [:workflow/cost-usd {:optional true} number?]
-    [:message string?]]))
-
-(def WorkflowFailed
-  "Schema for workflow/failed event."
-  (with-identity
-   [:map
-      [:event/type [:= :workflow/failed]]
-    [:event/id uuid?]
-    [:event/timestamp inst?]
-    [:event/version string?]
-    [:event/sequence-number int?]
-    [:workflow/id uuid?]
-    [:workflow/failure-phase {:optional true} keyword?]
-    [:workflow/failure-reason {:optional true} string?]
-    [:workflow/error-details {:optional true} map?]
-    [:message string?]]))
-
-;------------------------------------------------------------------------------ Layer 1.4
 ;; Zettelkasten lifecycle event schemas (added for miniforge-fleet's
 ;; Phase E.3 outbox path — Fleet's ingest consumes these to grow the
 ;; cross-instance event log).
-
-(def ^:private zettel-type-enum
+(def ^{:stratum 0} ^:private zettel-type-enum
   "Closed enum of zettel types accepted in the outbox event stream.
 
    MUST stay in sync with `ai.miniforge.knowledge.schema/ZettelType`
@@ -267,412 +98,15 @@
    type, mirror the addition here."
   [:enum :rule :concept :learning :example :hub :question :decision])
 
-(def ZettelPromoted
-  "Schema for zettel/promoted event.
-
-   Emitted when a zettel revision transitions to `:trusted` state and
-   is therefore eligible to ride the Fleet event log per Decision 6
-   (trust on revision) + Decision 8 (privacy gates) of miniforge-
-   fleet's Phase E plan. The event carries the revision-keyed identity
-   triple plus the zettel's content + Fleet-share metadata so the
-   ingest path can run its boundary validation without a separate
-   round-trip into the local Zettelkasten store.
-
-   The producer attaches `:fleet/oss-version` per Decision 13 so
-   Fleet's E.4 quarantine + E.9 migration registry have the version
-   pin they need without a second event-shape change later.
-
-   Required fields beyond the envelope:
-     :zettel/id          UUID
-     :zettel/revision-id UUID
-     :zettel/digest      lowercase 64-char hex
-     :zettel/uid         human-readable id
-     :zettel/title       short display name
-     :zettel/content     markdown body
-     :zettel/type        closed enum mirroring knowledge.schema/ZettelType
-                          (`:rule` / `:concept` / `:learning` /
-                           `:example` / `:hub` / `:question` /
-                           `:decision`)
-     :fleet/oss-version  version pin (per Decision 13)
-
-   Optional Fleet-share intent (populated when the producer wants
-   the zettel to actually ride the Fleet event log; absence means
-   the promotion was local-only):
-     :fleet/shareable        boolean
-     :fleet/share-scope      :org / :team / :repo / :workflow
-     :privacy/classification :public-org / :internal / :restricted /
-                              :secret"
-  [:map
-   [:event/type [:= :zettel/promoted]]
-   [:event/id uuid?]
-   [:event/timestamp inst?]
-   [:event/version string?]
-   [:event/sequence-number int?]
-   [:workflow/id uuid?]
-
-   ;; Revision-keyed zettel identity (Decision 6).
-   [:zettel/id          uuid?]
-   [:zettel/revision-id uuid?]
-   [:zettel/digest      [:re #"^[0-9a-f]{64}$"]]
-
-   ;; Zettel content the Fleet ingest path validates against the
-   ;; privacy gates (Decision 8). Carried alongside the triple so
-   ;; subscribers don't need a round-trip to the producer's store.
-   [:zettel/uid     [:string {:min 1}]]
-   [:zettel/title   [:string {:min 1 :max 200}]]
-   [:zettel/content [:string {:min 1}]]
-   [:zettel/type    zettel-type-enum]
-
-   ;; Version provenance (Decision 13).
-   [:fleet/oss-version [:string {:min 1}]]
-
-   ;; Optional Fleet-share intent (Decision 8).
-   [:fleet/shareable        {:optional true} boolean?]
-   [:fleet/share-scope      {:optional true}
-    [:enum :org :team :repo :workflow]]
-   [:privacy/classification {:optional true}
-    [:enum :public-org :internal :restricted :secret]]
-
-   ;; Identity propagation (Decision 14, added in event-stream side
-   ;; via the matching PR for prerequisite #10).
-   [:org/id       {:optional true} uuid?]
-   [:workspace/id {:optional true} uuid?]
-   [:repo/id      {:optional true} string?]
-   [:auth/context {:optional true} map?]
-   [:message string?]])
-
-;------------------------------------------------------------------------------ Layer 1.5
-;; PR lifecycle event schemas
-
-(def PRCreated
-  "Schema for pr/created event.
-
-   Emitted when a workflow or operator-owned PR train creates a PR that
-   should appear in the supervisory PR fleet. `:workflow/id` is the owning
-   workflow run when one exists, and nil for operator-scoped train entries."
-  (with-identity
-   [:map
-      [:event/type [:= :pr/created]]
-    [:event/id uuid?]
-    [:event/timestamp inst?]
-    [:event/version string?]
-    [:event/sequence-number int?]
-    [:workflow/id [:maybe uuid?]]
-    [:pr/repo string?]
-    [:pr/number int?]
-    [:pr/url string?]
-    [:pr/branch string?]
-    [:pr/title {:optional true} string?]
-    [:pr/author {:optional true} string?]
-    [:pr/merge-order {:optional true} int?]
-    [:message string?]]))
-
-;------------------------------------------------------------------------------ Layer 2
-;; Agent lifecycle event schemas
-
-(def AgentStarted
-  "Schema for agent/started event."
-  (with-identity
-   [:map
-      [:event/type [:= :agent/started]]
-    [:event/id uuid?]
-    [:event/timestamp inst?]
-    [:event/version string?]
-    [:event/sequence-number int?]
-    [:workflow/id uuid?]
-    [:workflow/phase {:optional true} keyword?]
-    [:agent/id keyword?]
-    [:agent/instance-id {:optional true} uuid?]
-    [:agent/context {:optional true} map?]
-    [:message string?]]))
-
-(def AgentCompleted
-  "Schema for agent/completed event."
-  (with-identity
-   [:map
-      [:event/type [:= :agent/completed]]
-    [:event/id uuid?]
-    [:event/timestamp inst?]
-    [:event/version string?]
-    [:event/sequence-number int?]
-    [:workflow/id uuid?]
-    [:agent/id keyword?]
-    [:agent/instance-id {:optional true} uuid?]
-    [:agent/duration-ms {:optional true} int?]
-    [:agent/outcome {:optional true} [:enum :success :failure]]
-    [:agent/output {:optional true} map?]
-    [:agent/artifacts {:optional true} [:vector uuid?]]
-    [:message string?]]))
-
-(def AgentChunk
-  "Schema for agent/chunk event (streaming output)."
-  (with-identity
-   [:map
-      [:event/type [:= :agent/chunk]]
-    [:event/id uuid?]
-    [:event/timestamp inst?]
-    [:event/version string?]
-    [:event/sequence-number int?]
-    [:workflow/id uuid?]
-    [:agent/id keyword?]
-    [:chunk/delta string?]              ; The chunk of text
-    [:chunk/done? {:optional true} boolean?]
-    [:message string?]]))
-
-(def AgentStatus
-  "Schema for agent/status event (real-time progress)."
-  (with-identity
-   [:map
-      [:event/type [:= :agent/status]]
-    [:event/id uuid?]
-    [:event/timestamp inst?]
-    [:event/version string?]
-    [:event/sequence-number int?]
-    [:workflow/id uuid?]
-    [:workflow/phase {:optional true} keyword?]
-    [:agent/id keyword?]
-    [:agent/instance-id {:optional true} uuid?]
-    [:status/type [:enum :reading :thinking :generating :validating :repairing :running :waiting :communicating]]
-    [:status/detail {:optional true} string?]
-    [:status/progress-percent {:optional true} int?]
-    [:message string?]]))
-
-;------------------------------------------------------------------------------ Layer 2.5
-;; Tool-call lifecycle and phase heartbeat schemas (GROUP 1+2 foundation)
-
-(def AgentToolCallStarted
-  "Schema for agent/tool-call-started event.
-
-   Emitted when an agent begins executing a single tool call.  Distinct
-   from the legacy :agent/tool-call which records tool calls in aggregate;
-   this event marks the precise start of execution for one call so
-   latency and stuck-call detection are possible."
-  (with-identity
-   [:map
-      [:event/type [:= :agent/tool-call-started]]
-    [:event/id uuid?]
-    [:event/timestamp inst?]
-    [:event/version string?]
-    [:event/sequence-number int?]
-    [:workflow/id uuid?]
-    [:tool/name {:optional true} string?]
-    [:tool/names {:optional true} [:vector string?]]
-    [:tool/args-digest {:optional true} DigestSummary]
-    [:tool/call-id {:optional true} string?]
-    [:agent/id keyword?]
-    [:message string?]]))
-
-(def ToolCallCompleted
-  "Schema for tool/call-completed event.
-
-   Emitted when a tool call finishes (success or failure).  Pairs with
-   :agent/tool-call-started via :tool/call-id to close the latency span."
-  (with-identity
-   [:map
-      [:event/type [:= :tool/call-completed]]
-    [:event/id uuid?]
-    [:event/timestamp inst?]
-    [:event/version string?]
-    [:event/sequence-number int?]
-    [:workflow/id uuid?]
-    [:tool/call-id {:optional true} string?]
-    [:tool/result-digest {:optional true} DigestSummary]
-    [:tool/duration-ms {:optional true} int?]
-    [:tool/success? {:optional true} boolean?]
-    [:tool/error {:optional true} map?]
-    [:message string?]]))
-
-(def PhaseHeartbeat
-  "Schema for workflow/phase-heartbeat event.
-
-   Emitted periodically by long-running phases so supervisors can
-   detect stalls without requiring the phase to complete.  Carries
-   the time elapsed since the phase became active and the gap since
-   the last substantive event, enabling gap-based alerting."
-  (with-identity
-   [:map
-      [:event/type [:= :workflow/phase-heartbeat]]
-    [:event/id uuid?]
-    [:event/timestamp inst?]
-    [:event/version string?]
-    [:event/sequence-number int?]
-    [:workflow/id uuid?]
-    [:phase/active-since inst?]
-    [:phase/events-emitted int?]
-    [:phase/last-event-at inst?]
-    [:phase/gap-since-last-event-ms int?]
-    [:message string?]]))
-
-(def AgentStreamStalled
-  "Schema for agent/stream-stalled event."
-  (with-identity
-   [:map
-      [:event/type [:= :agent/stream-stalled]]
-    [:event/id uuid?]
-    [:event/timestamp inst?]
-    [:event/version string?]
-    [:event/sequence-number int?]
-    [:workflow/id uuid?]
-    [:workflow/phase keyword?]
-    [:stream/gap-duration-ms int?]
-    [:agent/backend keyword?]
-    [:message string?]]))
-
-(def AgentSessionCaptured
-  "Schema for agent/session-captured event."
-  (with-identity
-   [:map
-      [:event/type [:= :agent/session-captured]]
-    [:event/id uuid?]
-    [:event/timestamp inst?]
-    [:event/version string?]
-    [:event/sequence-number int?]
-    [:workflow/id uuid?]
-    [:workflow/phase keyword?]
-    [:agent/backend keyword?]
-    [:agent/session-id string?]
-    [:message string?]]))
-
-;------------------------------------------------------------------------------ Layer 3
-;; Self-healing event schemas
-
-(def WorkaroundApplied
-  "Schema for self-healing/workaround-applied event."
-  (with-identity
-   [:map
-      [:event/type [:= :self-healing/workaround-applied]]
-    [:event/id uuid?]
-    [:event/timestamp inst?]
-    [:event/version string?]
-    [:event/sequence-number int?]
-    [:workflow/id uuid?]
-    [:workaround-id {:optional true} keyword?]
-    [:pattern-id keyword?]
-    [:success? boolean?]
-    [:message string?]]))
-
-(def BackendSwitched
-  "Schema for self-healing/backend-switched event."
-  (with-identity
-   [:map
-      [:event/type [:= :self-healing/backend-switched]]
-    [:event/id uuid?]
-    [:event/timestamp inst?]
-    [:event/version string?]
-    [:event/sequence-number int?]
-    [:workflow/id uuid?]
-    [:from keyword?]
-    [:to keyword?]
-    [:reason string?]
-    [:cooldown-until inst?]
-    [:message string?]]))
-
-;------------------------------------------------------------------------------ Layer 4
-;; LLM event schemas
-
-(def LLMRequest
-  "Schema for llm/request event."
-  (with-identity
-   [:map
-      [:event/type [:= :llm/request]]
-    [:event/id uuid?]
-    [:event/timestamp inst?]
-    [:event/version string?]
-    [:event/sequence-number int?]
-    [:workflow/id uuid?]
-    [:agent/id {:optional true} keyword?]
-    [:agent/instance-id {:optional true} uuid?]
-    [:llm/model string?]
-    [:llm/prompt-tokens {:optional true} int?]
-    [:llm/request-id uuid?]
-    [:message string?]]))
-
-(def LLMResponse
-  "Schema for llm/response event."
-  (with-identity
-   [:map
-      [:event/type [:= :llm/response]]
-    [:event/id uuid?]
-    [:event/timestamp inst?]
-    [:event/version string?]
-    [:event/sequence-number int?]
-    [:workflow/id uuid?]
-    [:agent/id {:optional true} keyword?]
-    [:agent/instance-id {:optional true} uuid?]
-    [:llm/model string?]
-    [:llm/request-id uuid?]
-    [:llm/completion-tokens {:optional true} int?]
-    [:llm/total-tokens {:optional true} int?]
-    [:llm/duration-ms {:optional true} int?]
-    [:llm/cost-usd {:optional true} number?]
-    [:message string?]]))
-
-;------------------------------------------------------------------------------ Layer 4.5
-;; Dependency health event schemas
-
-(def DependencyHealthUpdated
-  "Schema for dependency/health-updated event."
-  (with-identity
-   [:map
-      [:event/type [:= :dependency/health-updated]]
-    [:event/id uuid?]
-    [:event/timestamp inst?]
-    [:event/version string?]
-    [:event/sequence-number int?]
-    [:workflow/id {:optional true} [:maybe uuid?]]
-    [:dependency/id keyword?]
-    [:dependency/source keyword?]
-    [:dependency/kind keyword?]
-    [:dependency/status keyword?]
-    [:dependency/failure-count int?]
-    [:dependency/window-size int?]
-    [:dependency/incident-counts map?]
-    [:dependency/vendor {:optional true} keyword?]
-    [:dependency/class {:optional true} keyword?]
-    [:dependency/retryability {:optional true} keyword?]
-    [:failure/class {:optional true} keyword?]
-    [:dependency/previous-status {:optional true} keyword?]
-    [:dependency/last-observed-at {:optional true} inst?]
-    [:dependency/last-recovered-at {:optional true} inst?]
-    [:message string?]]))
-
-(def DependencyRecovered
-  "Schema for dependency/recovered event."
-  (with-identity
-   [:map
-      [:event/type [:= :dependency/recovered]]
-    [:event/id uuid?]
-    [:event/timestamp inst?]
-    [:event/version string?]
-    [:event/sequence-number int?]
-    [:workflow/id {:optional true} [:maybe uuid?]]
-    [:dependency/id keyword?]
-    [:dependency/source keyword?]
-    [:dependency/kind keyword?]
-    [:dependency/status [:= :healthy]]
-    [:dependency/failure-count int?]
-    [:dependency/window-size int?]
-    [:dependency/incident-counts map?]
-    [:dependency/vendor {:optional true} keyword?]
-    [:dependency/class {:optional true} keyword?]
-    [:dependency/retryability {:optional true} keyword?]
-    [:failure/class {:optional true} keyword?]
-    [:dependency/previous-status {:optional true} keyword?]
-    [:dependency/last-observed-at {:optional true} inst?]
-    [:dependency/last-recovered-at {:optional true} inst?]
-    [:message string?]]))
-
-;------------------------------------------------------------------------------ Layer 5
 ;; Privacy levels and OCI event schemas (N8)
-
-(def PrivacyLevel
+(def ^{:stratum 0} PrivacyLevel
   "Privacy classification for events.
    - :public    — safe for external dashboards and audit logs
    - :internal  — visible to team members and internal tools
    - :confidential — restricted to control-plane operators only"
   [:enum :public :internal :confidential])
 
-(def default-event-privacy
+(def ^{:stratum 0} default-event-privacy
   "Built-in privacy level for each event type category.
    Events not listed default to :internal."
   {:workflow/started    :public
@@ -755,7 +189,98 @@
    :repo-index/quality-measured :internal
    :repo-index/coverage-changed :internal})
 
-(defn create-privacy-config
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} with-identity
+  "Pure: append the Decision-14 identity quartet to `base-schema`'s
+   `:map` entries. Order in Malli `:map` is irrelevant for validation;
+   the helper keeps the per-event schemas focused on their own
+   payload while every event accepts the same identity set."
+  [base-schema]
+  (into base-schema identity-entries))
+
+(def ^{:stratum 1} DigestSummary
+  "Schema for bounded digest payloads attached to tool lifecycle events."
+  [:map
+   [:digest/preview string?]
+   [:digest/sha256 [:re sha256-hex-pattern]]
+   [:digest/original-size [:and int? [:>= 0]]]])
+
+(def ^{:stratum 1} ZettelPromoted
+  "Schema for zettel/promoted event.
+
+   Emitted when a zettel revision transitions to `:trusted` state and
+   is therefore eligible to ride the Fleet event log per Decision 6
+   (trust on revision) + Decision 8 (privacy gates) of miniforge-
+   fleet's Phase E plan. The event carries the revision-keyed identity
+   triple plus the zettel's content + Fleet-share metadata so the
+   ingest path can run its boundary validation without a separate
+   round-trip into the local Zettelkasten store.
+
+   The producer attaches `:fleet/oss-version` per Decision 13 so
+   Fleet's E.4 quarantine + E.9 migration registry have the version
+   pin they need without a second event-shape change later.
+
+   Required fields beyond the envelope:
+     :zettel/id          UUID
+     :zettel/revision-id UUID
+     :zettel/digest      lowercase 64-char hex
+     :zettel/uid         human-readable id
+     :zettel/title       short display name
+     :zettel/content     markdown body
+     :zettel/type        closed enum mirroring knowledge.schema/ZettelType
+                          (`:rule` / `:concept` / `:learning` /
+                           `:example` / `:hub` / `:question` /
+                           `:decision`)
+     :fleet/oss-version  version pin (per Decision 13)
+
+   Optional Fleet-share intent (populated when the producer wants
+   the zettel to actually ride the Fleet event log; absence means
+   the promotion was local-only):
+     :fleet/shareable        boolean
+     :fleet/share-scope      :org / :team / :repo / :workflow
+     :privacy/classification :public-org / :internal / :restricted /
+                              :secret"
+  [:map
+   [:event/type [:= :zettel/promoted]]
+   [:event/id uuid?]
+   [:event/timestamp inst?]
+   [:event/version string?]
+   [:event/sequence-number int?]
+   [:workflow/id uuid?]
+
+   ;; Revision-keyed zettel identity (Decision 6).
+   [:zettel/id          uuid?]
+   [:zettel/revision-id uuid?]
+   [:zettel/digest      [:re #"^[0-9a-f]{64}$"]]
+
+   ;; Zettel content the Fleet ingest path validates against the
+   ;; privacy gates (Decision 8). Carried alongside the triple so
+   ;; subscribers don't need a round-trip to the producer's store.
+   [:zettel/uid     [:string {:min 1}]]
+   [:zettel/title   [:string {:min 1 :max 200}]]
+   [:zettel/content [:string {:min 1}]]
+   [:zettel/type    zettel-type-enum]
+
+   ;; Version provenance (Decision 13).
+   [:fleet/oss-version [:string {:min 1}]]
+
+   ;; Optional Fleet-share intent (Decision 8).
+   [:fleet/shareable        {:optional true} boolean?]
+   [:fleet/share-scope      {:optional true}
+    [:enum :org :team :repo :workflow]]
+   [:privacy/classification {:optional true}
+    [:enum :public-org :internal :restricted :secret]]
+
+   ;; Identity propagation (Decision 14, added in event-stream side
+   ;; via the matching PR for prerequisite #10).
+   [:org/id       {:optional true} uuid?]
+   [:workspace/id {:optional true} uuid?]
+   [:repo/id      {:optional true} string?]
+   [:auth/context {:optional true} map?]
+   [:message string?]])
+
+(defn ^{:stratum 1} create-privacy-config
   "Create a privacy configuration by merging overrides into defaults.
 
    Arguments:
@@ -765,7 +290,7 @@
   [overrides]
   (merge default-event-privacy overrides))
 
-(defn event-privacy
+(defn ^{:stratum 1} event-privacy
   "Get the privacy level for an event type.
 
    Arguments:
@@ -779,9 +304,465 @@
   ([event-type config]
    (get config event-type :internal)))
 
-;; Supervision event schema
+;------------------------------------------------------------------------------ Layer 2
 
-(def ToolUseEvaluated
+;; Event envelope (base schema all events must conform to)
+(def ^{:stratum 2} EventEnvelope
+  "Base envelope schema for all events per N3 spec section 2."
+  (with-identity
+   [:map
+    [:event/type keyword?]              ; REQUIRED: event type identifier
+    [:event/id uuid?]                   ; REQUIRED: unique event ID
+    [:event/timestamp inst?]            ; REQUIRED: ISO-8601 timestamp
+    [:event/version string?]            ; REQUIRED: event schema version
+    [:event/sequence-number int?]       ; REQUIRED: monotonic sequence within workflow
+    [:workflow/id uuid?]                ; REQUIRED: workflow this event belongs to
+    [:workflow/phase {:optional true} keyword?]     ; OPTIONAL: current phase
+    [:agent/id {:optional true} keyword?]           ; OPTIONAL: agent that emitted event
+    [:agent/instance-id {:optional true} uuid?]     ; OPTIONAL: specific agent instance
+    [:event/parent-id {:optional true} uuid?]       ; OPTIONAL: parent event ID (for causality)
+    [:message string?]]))  ; REQUIRED: human-readable message
+
+;; Workflow lifecycle event schemas
+(def ^{:stratum 2} WorkflowStarted
+  "Schema for workflow/started event.
+
+   `:routing/trigger-event-id` (N5-delta-4 §4.3) is the bridge the
+   automation-edge-correlator uses to map a handler workflow back to its
+   originating routing trigger. Optional — workflows started outside the
+   routing path (operator-initiated runs, etc.) omit the field, and the
+   correlator's heuristic-fallback path (§3.5 case 2) covers the absence."
+  (with-identity
+   [:map
+      [:event/type [:= :workflow/started]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:workflow/spec {:optional true} map?]
+    [:workflow/intent {:optional true} map?]
+    ;; Plain `uuid?`, not `[:maybe uuid?]`: the producer-side contract
+    ;; (`core/workflow-started`) explicitly omits this key when the value
+    ;; is nil rather than emitting `{:routing/trigger-event-id nil}`. The
+    ;; envelope is therefore EITHER a real uuid or the key is absent —
+    ;; never a nil payload. Schema enforces that invariant.
+    [:routing/trigger-event-id {:optional true} uuid?]
+    [:message string?]]))
+
+(def ^{:stratum 2} PhaseStarted
+  "Schema for workflow/phase-started event."
+  (with-identity
+   [:map
+      [:event/type [:= :workflow/phase-started]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:workflow/phase keyword?]
+    [:phase/expected-agent {:optional true} keyword?]
+    [:phase/context {:optional true} map?]
+    [:message string?]]))
+
+(def ^{:stratum 2} PhaseCompleted
+  "Schema for workflow/phase-completed event."
+  (with-identity
+   [:map
+      [:event/type [:= :workflow/phase-completed]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:workflow/phase keyword?]
+    [:phase/duration-ms {:optional true} int?]
+    ;; `:phase/outcome` is the typed-act surface for a phase boundary on the
+    ;; observed layer (stream + evidence). The internal phase-result `:status`
+    ;; stays a 2-valued control flag for the FSM; this enum carries the full act.
+    ;; INFORM → :success/:failure/:skipped; REFUSE → :blocked (+ :phase/blocked-reason);
+    ;; REQUEST(redirect) → :redirected (+ :phase/transition-request).
+    [:phase/outcome {:optional true}
+     [:enum :success :failure :skipped :blocked :redirected]]
+    ;; Machine-readable cause, present when :phase/outcome is :blocked.
+    [:phase/blocked-reason {:optional true} RefusalReason]
+    ;; Review verdict, present only for the review phase. Carried so resume can
+    ;; reconstruct a blocked review from events alone — the event is a writer of
+    ;; this datum, one canonical location, no lossy reconstruction.
+    [:phase/review-decision {:optional true} keyword?]
+    [:phase/artifacts {:optional true} [:vector uuid?]]
+    [:phase/transition-request {:optional true} TransitionRequest]
+    [:phase/redirect-to {:optional true} keyword?]
+    [:phase/error {:optional true} map?]
+    [:phase/tokens {:optional true} int?]
+    [:phase/cost-usd {:optional true} number?]
+    [:message string?]]))
+
+(def ^{:stratum 2} WorkspacePersisted
+  "Schema for workspace/persisted event.
+
+   Emitted at phase boundaries when persist-workspace! has captured a
+   checkpoint. Carries enough provenance for the dashboard / evidence
+   bundle to surface 'inspect or resume from this archive'."
+  (with-identity
+   [:map
+      [:event/type [:= :workspace/persisted]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:workspace/phase {:optional true} keyword?]
+    [:workspace/env-id {:optional true} string?]
+    [:workspace/branch {:optional true} string?]
+    [:workspace/commit-sha {:optional true} string?]
+    [:workspace/bundle-path {:optional true} string?]
+    [:workspace/tier {:optional true} [:enum :worktree :remote]]
+    [:message string?]]))
+
+(def ^{:stratum 2} WorkflowCompleted
+  "Schema for workflow/completed event."
+  (with-identity
+   [:map
+      [:event/type [:= :workflow/completed]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:workflow/status [:enum :success :failure :cancelled]]
+    [:workflow/duration-ms {:optional true} int?]
+    [:workflow/evidence-bundle-id {:optional true} uuid?]
+    [:workflow/tokens {:optional true} int?]
+    [:workflow/cost-usd {:optional true} number?]
+    [:message string?]]))
+
+(def ^{:stratum 2} WorkflowFailed
+  "Schema for workflow/failed event."
+  (with-identity
+   [:map
+      [:event/type [:= :workflow/failed]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:workflow/failure-phase {:optional true} keyword?]
+    [:workflow/failure-reason {:optional true} string?]
+    [:workflow/error-details {:optional true} map?]
+    [:message string?]]))
+
+;; PR lifecycle event schemas
+(def ^{:stratum 2} PRCreated
+  "Schema for pr/created event.
+
+   Emitted when a workflow or operator-owned PR train creates a PR that
+   should appear in the supervisory PR fleet. `:workflow/id` is the owning
+   workflow run when one exists, and nil for operator-scoped train entries."
+  (with-identity
+   [:map
+      [:event/type [:= :pr/created]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id [:maybe uuid?]]
+    [:pr/repo string?]
+    [:pr/number int?]
+    [:pr/url string?]
+    [:pr/branch string?]
+    [:pr/title {:optional true} string?]
+    [:pr/author {:optional true} string?]
+    [:pr/merge-order {:optional true} int?]
+    [:message string?]]))
+
+;; Agent lifecycle event schemas
+(def ^{:stratum 2} AgentStarted
+  "Schema for agent/started event."
+  (with-identity
+   [:map
+      [:event/type [:= :agent/started]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:workflow/phase {:optional true} keyword?]
+    [:agent/id keyword?]
+    [:agent/instance-id {:optional true} uuid?]
+    [:agent/context {:optional true} map?]
+    [:message string?]]))
+
+(def ^{:stratum 2} AgentCompleted
+  "Schema for agent/completed event."
+  (with-identity
+   [:map
+      [:event/type [:= :agent/completed]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:agent/id keyword?]
+    [:agent/instance-id {:optional true} uuid?]
+    [:agent/duration-ms {:optional true} int?]
+    [:agent/outcome {:optional true} [:enum :success :failure]]
+    [:agent/output {:optional true} map?]
+    [:agent/artifacts {:optional true} [:vector uuid?]]
+    [:message string?]]))
+
+(def ^{:stratum 2} AgentChunk
+  "Schema for agent/chunk event (streaming output)."
+  (with-identity
+   [:map
+      [:event/type [:= :agent/chunk]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:agent/id keyword?]
+    [:chunk/delta string?]              ; The chunk of text
+    [:chunk/done? {:optional true} boolean?]
+    [:message string?]]))
+
+(def ^{:stratum 2} AgentStatus
+  "Schema for agent/status event (real-time progress)."
+  (with-identity
+   [:map
+      [:event/type [:= :agent/status]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:workflow/phase {:optional true} keyword?]
+    [:agent/id keyword?]
+    [:agent/instance-id {:optional true} uuid?]
+    [:status/type [:enum :reading :thinking :generating :validating :repairing :running :waiting :communicating]]
+    [:status/detail {:optional true} string?]
+    [:status/progress-percent {:optional true} int?]
+    [:message string?]]))
+
+;; Tool-call lifecycle and phase heartbeat schemas (GROUP 1+2 foundation)
+(def ^{:stratum 2} AgentToolCallStarted
+  "Schema for agent/tool-call-started event.
+
+   Emitted when an agent begins executing a single tool call.  Distinct
+   from the legacy :agent/tool-call which records tool calls in aggregate;
+   this event marks the precise start of execution for one call so
+   latency and stuck-call detection are possible."
+  (with-identity
+   [:map
+      [:event/type [:= :agent/tool-call-started]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:tool/name {:optional true} string?]
+    [:tool/names {:optional true} [:vector string?]]
+    [:tool/args-digest {:optional true} DigestSummary]
+    [:tool/call-id {:optional true} string?]
+    [:agent/id keyword?]
+    [:message string?]]))
+
+(def ^{:stratum 2} ToolCallCompleted
+  "Schema for tool/call-completed event.
+
+   Emitted when a tool call finishes (success or failure).  Pairs with
+   :agent/tool-call-started via :tool/call-id to close the latency span."
+  (with-identity
+   [:map
+      [:event/type [:= :tool/call-completed]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:tool/call-id {:optional true} string?]
+    [:tool/result-digest {:optional true} DigestSummary]
+    [:tool/duration-ms {:optional true} int?]
+    [:tool/success? {:optional true} boolean?]
+    [:tool/error {:optional true} map?]
+    [:message string?]]))
+
+(def ^{:stratum 2} PhaseHeartbeat
+  "Schema for workflow/phase-heartbeat event.
+
+   Emitted periodically by long-running phases so supervisors can
+   detect stalls without requiring the phase to complete.  Carries
+   the time elapsed since the phase became active and the gap since
+   the last substantive event, enabling gap-based alerting."
+  (with-identity
+   [:map
+      [:event/type [:= :workflow/phase-heartbeat]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:phase/active-since inst?]
+    [:phase/events-emitted int?]
+    [:phase/last-event-at inst?]
+    [:phase/gap-since-last-event-ms int?]
+    [:message string?]]))
+
+(def ^{:stratum 2} AgentStreamStalled
+  "Schema for agent/stream-stalled event."
+  (with-identity
+   [:map
+      [:event/type [:= :agent/stream-stalled]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:workflow/phase keyword?]
+    [:stream/gap-duration-ms int?]
+    [:agent/backend keyword?]
+    [:message string?]]))
+
+(def ^{:stratum 2} AgentSessionCaptured
+  "Schema for agent/session-captured event."
+  (with-identity
+   [:map
+      [:event/type [:= :agent/session-captured]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:workflow/phase keyword?]
+    [:agent/backend keyword?]
+    [:agent/session-id string?]
+    [:message string?]]))
+
+;; Self-healing event schemas
+(def ^{:stratum 2} WorkaroundApplied
+  "Schema for self-healing/workaround-applied event."
+  (with-identity
+   [:map
+      [:event/type [:= :self-healing/workaround-applied]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:workaround-id {:optional true} keyword?]
+    [:pattern-id keyword?]
+    [:success? boolean?]
+    [:message string?]]))
+
+(def ^{:stratum 2} BackendSwitched
+  "Schema for self-healing/backend-switched event."
+  (with-identity
+   [:map
+      [:event/type [:= :self-healing/backend-switched]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:from keyword?]
+    [:to keyword?]
+    [:reason string?]
+    [:cooldown-until inst?]
+    [:message string?]]))
+
+;; LLM event schemas
+(def ^{:stratum 2} LLMRequest
+  "Schema for llm/request event."
+  (with-identity
+   [:map
+      [:event/type [:= :llm/request]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:agent/id {:optional true} keyword?]
+    [:agent/instance-id {:optional true} uuid?]
+    [:llm/model string?]
+    [:llm/prompt-tokens {:optional true} int?]
+    [:llm/request-id uuid?]
+    [:message string?]]))
+
+(def ^{:stratum 2} LLMResponse
+  "Schema for llm/response event."
+  (with-identity
+   [:map
+      [:event/type [:= :llm/response]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id uuid?]
+    [:agent/id {:optional true} keyword?]
+    [:agent/instance-id {:optional true} uuid?]
+    [:llm/model string?]
+    [:llm/request-id uuid?]
+    [:llm/completion-tokens {:optional true} int?]
+    [:llm/total-tokens {:optional true} int?]
+    [:llm/duration-ms {:optional true} int?]
+    [:llm/cost-usd {:optional true} number?]
+    [:message string?]]))
+
+;; Dependency health event schemas
+(def ^{:stratum 2} DependencyHealthUpdated
+  "Schema for dependency/health-updated event."
+  (with-identity
+   [:map
+      [:event/type [:= :dependency/health-updated]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id {:optional true} [:maybe uuid?]]
+    [:dependency/id keyword?]
+    [:dependency/source keyword?]
+    [:dependency/kind keyword?]
+    [:dependency/status keyword?]
+    [:dependency/failure-count int?]
+    [:dependency/window-size int?]
+    [:dependency/incident-counts map?]
+    [:dependency/vendor {:optional true} keyword?]
+    [:dependency/class {:optional true} keyword?]
+    [:dependency/retryability {:optional true} keyword?]
+    [:failure/class {:optional true} keyword?]
+    [:dependency/previous-status {:optional true} keyword?]
+    [:dependency/last-observed-at {:optional true} inst?]
+    [:dependency/last-recovered-at {:optional true} inst?]
+    [:message string?]]))
+
+(def ^{:stratum 2} DependencyRecovered
+  "Schema for dependency/recovered event."
+  (with-identity
+   [:map
+      [:event/type [:= :dependency/recovered]]
+    [:event/id uuid?]
+    [:event/timestamp inst?]
+    [:event/version string?]
+    [:event/sequence-number int?]
+    [:workflow/id {:optional true} [:maybe uuid?]]
+    [:dependency/id keyword?]
+    [:dependency/source keyword?]
+    [:dependency/kind keyword?]
+    [:dependency/status [:= :healthy]]
+    [:dependency/failure-count int?]
+    [:dependency/window-size int?]
+    [:dependency/incident-counts map?]
+    [:dependency/vendor {:optional true} keyword?]
+    [:dependency/class {:optional true} keyword?]
+    [:dependency/retryability {:optional true} keyword?]
+    [:failure/class {:optional true} keyword?]
+    [:dependency/previous-status {:optional true} keyword?]
+    [:dependency/last-observed-at {:optional true} inst?]
+    [:dependency/last-recovered-at {:optional true} inst?]
+    [:message string?]]))
+
+;; Supervision event schema
+(def ^{:stratum 2} ToolUseEvaluated
   "Schema for supervision/tool-use-evaluated event."
   (with-identity
    [:map
@@ -799,7 +780,7 @@
     [:workflow/phase {:optional true} keyword?]
     [:message string?]]))
 
-(def InterventionRequested
+(def ^{:stratum 2} InterventionRequested
   "Schema for supervisory/intervention-requested event."
   (with-identity
    [:map
@@ -823,7 +804,7 @@
     [:intervention/updated-at inst?]
     [:message string?]]))
 
-(def InterventionStateChanged
+(def ^{:stratum 2} InterventionStateChanged
   "Schema for supervisory/intervention-state-changed event."
   (with-identity
    [:map
@@ -850,7 +831,7 @@
     [:intervention/updated-at {:optional true} inst?]
     [:message string?]]))
 
-(def OperatorInterventionAnomaly
+(def ^{:stratum 2} OperatorInterventionAnomaly
   "Schema for confidential operator-consumer anomaly events."
   (with-identity
    [:map
@@ -882,8 +863,7 @@
 ;; (§3.5 case 2) covers absence at the producer side; the explicit-id path
 ;; (§3.5 case 1) needs N15-4's `:routing/trigger-event-id` on the handler
 ;; workflow's `:workflow/started`.
-
-(def PrMonitorReviewCommentsArrived
+(def ^{:stratum 2} PrMonitorReviewCommentsArrived
   "Schema for `:pr-monitor/review-comments-arrived` event (N5-delta-4 §4.2.1).
 
    Emitted by the PR-watcher sub-modules in `components/pr-lifecycle`
@@ -912,7 +892,7 @@
     [:comments/agent-session-id {:optional true} [:maybe uuid?]]
     [:message string?]]))
 
-(def PrMonitorCiFailed
+(def ^{:stratum 2} PrMonitorCiFailed
   "Schema for `:pr-monitor/ci-failed` event (N5-delta-4 §4.2.2).
 
    Emitted by the PR-watcher sub-modules in `components/pr-lifecycle`
@@ -936,7 +916,7 @@
     [:ci/conclusion keyword?]
     [:message string?]]))
 
-(def StandardsReviewPosted
+(def ^{:stratum 2} StandardsReviewPosted
   "Schema for `:standards-review/posted` event (N5-delta-4 §4.2.3).
 
    Emitted by `components/standards-reviewer` (deferred; the component
@@ -970,7 +950,7 @@
 ;; here we accept the entity as an open `map?` so that adding fields to the
 ;; producer's schema does not require a wire-schema edit in lockstep — the
 ;; consumer (Rust core) round-trips the open shape per §1.3.
-(def AutomationEdgeUpserted
+(def ^{:stratum 2} AutomationEdgeUpserted
   "Schema for `:supervisory/automation-edge-upserted` event (N5-delta-4 §4.1).
 
    Carries the full AutomationEdge entity in `:supervisory/entity`. The
@@ -1003,8 +983,7 @@
     [:message string?]]))
 
 ;; OCI container event schemas
-
-(def ContainerStarted
+(def ^{:stratum 2} ContainerStarted
   "Schema for oci/container-started event."
   (with-identity
    [:map
@@ -1019,7 +998,7 @@
     [:oci/trust-level {:optional true} [:enum :untrusted :trusted :privileged]]
     [:message string?]]))
 
-(def ContainerCompleted
+(def ^{:stratum 2} ContainerCompleted
   "Schema for oci/container-completed event."
   (with-identity
    [:map
@@ -1034,15 +1013,13 @@
     [:oci/duration-ms {:optional true} int?]
     [:message string?]]))
 
-;------------------------------------------------------------------------------ Layer 5.5
 ;; Reliability metric event schemas (RN-03, N3 §3.17)
 ;;
 ;; Schemas for the 4 reliability metric events emitted by the SLI
 ;; computation engine (RN-04). Field names match the assoc'd keys in
 ;; the existing core.clj constructors (sli-computed, slo-breach,
 ;; error-budget-update, degradation-mode-changed).
-
-(def SliComputed
+(def ^{:stratum 2} SliComputed
   "Schema for :reliability/sli-computed event.
 
    Emitted by the SLI computation engine (RN-04) each time an SLI value
@@ -1066,7 +1043,7 @@
     [:sli/dimensions {:optional true} map?]
     [:message string?]]))
 
-(def SloBreach
+(def ^{:stratum 2} SloBreach
   "Schema for :reliability/slo-breach event.
 
    Emitted when an SLO target is missed for :standard or :critical
@@ -1089,7 +1066,7 @@
     [:slo/window keyword?]
     [:message string?]]))
 
-(def ErrorBudgetUpdate
+(def ^{:stratum 2} ErrorBudgetUpdate
   "Schema for :reliability/error-budget-update event.
 
    Emitted when error-budget state is recomputed after each SLI window
@@ -1112,7 +1089,7 @@
     [:budget/window keyword?]
     [:message string?]]))
 
-(def DegradationModeChanged
+(def ^{:stratum 2} DegradationModeChanged
   "Schema for :reliability/degradation-mode-changed event.
 
    Emitted when the system transitions between degradation modes per
@@ -1131,15 +1108,13 @@
     [:degradation/trigger string?]
     [:message string?]]))
 
-;------------------------------------------------------------------------------ Layer 6
 ;; Repository intelligence event schemas (RN-19/20)
 ;;
 ;; Schemas for the 2 repo-index events emitted by the index quality
 ;; tracker (RN-19/20).  `:index/id` is a string slug identifying the
 ;; index (e.g. "main-code-index"); quality and coverage are ratios
 ;; in [0.0, 1.0]; staleness is elapsed wall-clock milliseconds.
-
-(def RepoIndexQualityMeasured
+(def ^{:stratum 2} RepoIndexQualityMeasured
   "Schema for :repo-index/quality-measured event.
 
    Emitted by the index quality tracker (RN-19) each time it samples
@@ -1164,7 +1139,7 @@
     [:index/measured-at {:optional true} inst?]
     [:message string?]]))
 
-(def RepoIndexCoverageChanged
+(def ^{:stratum 2} RepoIndexCoverageChanged
   "Schema for :repo-index/coverage-changed event.
 
    Emitted by the index quality tracker (RN-20) when the coverage ratio
@@ -1197,8 +1172,7 @@
 ;; decision is the third such act, but the PR-monitor runs on its own decoupled
 ;; event bus — see `pr-lifecycle/monitor-events` `:pr-monitor/decision-recorded`
 ;; — so its typed act lives there, not on this stream.)
-
-(def AgentMessageSent
+(def ^{:stratum 2} AgentMessageSent
   "Schema for `:agent/message-sent` event (N3 §3.7).
 
    Emitted by `core/inter-agent-message-sent` when one agent sends a message to
@@ -1219,7 +1193,7 @@
     [:message/content {:optional true} string?]
     [:message string?]]))
 
-(def AgentMessageReceived
+(def ^{:stratum 2} AgentMessageReceived
   "Schema for `:agent/message-received` event (N3 §3.7).
 
    Emitted by `core/inter-agent-message-received`. See AgentMessageSent for the
@@ -1239,7 +1213,7 @@
     [:message/content {:optional true} string?]
     [:message string?]]))
 
-(def MetaLoopHaltRequested
+(def ^{:stratum 2} MetaLoopHaltRequested
   "Schema for `:meta-loop/halt-requested` event.
 
    The REFUSE act for the meta-loop: a meta-agent (progress monitor, test-quality,

--- a/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.sinks
   "Configurable event sinks for different deployment scenarios.
 
@@ -53,48 +52,48 @@
    [java.time Instant ZonedDateTime ZoneOffset]
    [java.time.format DateTimeFormatter]))
 
-;;------------------------------------------------------------------------------ Defaults
+;------------------------------------------------------------------------------ Layer 0
 
-(def ^:private default-event-ttl-ms
+;;------------------------------------------------------------------------------ Defaults
+(def ^{:stratum 0} ^:private default-event-ttl-ms
   "How long a persisted event file is kept before cleanup prunes it —
    7 days. Long enough to debug a failed run days later; short enough that
    the on-disk event log doesn't grow unbounded on a busy fleet."
   (* 7 24 60 60 1000))
 
-(def ^:private default-fleet-sink-batch-size
+(def ^{:stratum 0} ^:private default-fleet-sink-batch-size
   "Events buffered before the fleet HTTP sink flushes a batch. 10 keeps
    request overhead low without holding events long enough to lose many on a
    crash between flushes."
   10)
 
-(def ^:private default-fleet-sink-flush-interval-ms
+(def ^{:stratum 0} ^:private default-fleet-sink-flush-interval-ms
   "Maximum time the fleet HTTP sink holds a partial batch before flushing it
    regardless of size — bounds delivery latency for low event rates. 5s."
   5000)
 
-(def ^:private default-fleet-sink-timeout-ms
+(def ^{:stratum 0} ^:private default-fleet-sink-timeout-ms
   "HTTP request timeout for a fleet-sink batch POST. 10s — generous for a
    batched upload over a slow link, short enough that a hung endpoint doesn't
    stall the flush loop indefinitely."
   10000)
 
 ;;------------------------------------------------------------------------------ Internal helpers
-
-(defn default-events-dir
+(defn ^{:stratum 0} default-events-dir
   "Return the default events directory (~/.miniforge/events). Public
    so the BD-2b sub-3b archive module and the cleanup pass (sub-3c)
    can resolve the same root the file sink writes under."
   ^java.io.File []
   (io/file (config/miniforge-home) "events"))
 
-(defn- now-sortable-str
+(defn- ^{:stratum 0} now-sortable-str
   "Return a sortable UTC timestamp string for use as a file-name prefix.
    Format: yyyyMMdd'T'HHmmss'Z', e.g. 20260411T100000Z."
   []
   (.format (DateTimeFormatter/ofPattern "yyyyMMdd'T'HHmmssSSS'Z'")
            (ZonedDateTime/now ZoneOffset/UTC)))
 
-(def ^:private instant-write-handler
+(def ^{:stratum 0} ^:private instant-write-handler
   "Transit write handler for java.time.Instant — writes the instant's
    RFC-3339 string under tag `t`, surfacing as a `~t...` tag-string in
    verbose Transit JSON (same shape Transit gives java.util.Date in
@@ -103,26 +102,7 @@
    (constantly "t")
    (fn [^Instant v] (str v))))
 
-(defn event->transit-json
-  "Serialize `event` to a Transit-JSON string using the verbose writer.
-   Verbose mode disables transit's cache codes (repeated keywords stay
-   literal, never `^0` references) and renders instants as RFC-3339
-   `~t...` tag-strings instead of compact `~m` millisecond strings, so
-   the Rust parser can decode them without millisecond arithmetic.
-   UUIDs render as `~u...` tag-strings. Custom handler for
-   java.time.Instant (not supported by Transit defaults).
-
-   Public: this is the canonical wire encoding for every event the file
-   sink persists. Contract tooling (supervisory golden fixtures) calls it
-   directly so vendored fixtures share the exact byte path with production."
-  [event]
-  (let [out (ByteArrayOutputStream.)
-        writer (transit/writer out :json-verbose
-                               {:handlers {Instant instant-write-handler}})]
-    (transit/write writer event)
-    (.toString out "UTF-8")))
-
-(defn- snowflake-uuid?
+(defn- ^{:stratum 0} snowflake-uuid?
   "True when `id` is a UUID whose low 64 bits are zero — the shape that
    `snowflake/long->uuid` produces. Random UUIDs collide on this with
    probability ~1 in 2^64, which is negligible."
@@ -130,41 +110,12 @@
   (and (uuid? id)
        (zero? (.getLeastSignificantBits ^java.util.UUID id))))
 
-(defn- event-filename
-  "Pick a filename for `event`.
-
-   New (BD-2b): when `:event/id` is a snowflake UUID,
-     `{event-id-hex16}__{workflow-seq-dec12}.transit.json`
-   sorts lex-by-creation across all workflows on this host.
-
-   Legacy: `{timestamp}-{uuid}.json` for streams without a snowflake
-   generator. Sort-by-creation still works via the timestamp prefix."
-  [event]
-  (let [id (:event/id event)
-        seq-num (long (or (:event/sequence-number event) 0))]
-    (if (snowflake-uuid? id)
-      (str (snowflake/uuid->hex id)
-           "__"
-           (format "%012d" seq-num)
-           ".transit.json")
-      (str (now-sortable-str) "-" (or id (random-uuid)) ".json"))))
-
-(defn- new-event-file-path
-  "Return a java.io.File for `event` inside `parent-dir`. Creates the
-   directory if needed. The filename is derived from the event itself
-   (BD-2b filename grammar — see `event-filename`)."
-  [parent-dir event]
-  (let [dir (io/file parent-dir)]
-    (.mkdirs dir)
-    (io/file dir (event-filename event))))
-
-(defn- ensure-parent-dir!
+(defn- ^{:stratum 0} ensure-parent-dir!
   [file-path]
   (some-> file-path .getParentFile .mkdirs))
 
-;;------------------------------------------------------------------------------ Layer 0: File Sink paths
-
-(defn- workflow-id-segment
+;; File Sink paths
+(defn- ^{:stratum 0} workflow-id-segment
   "Normalize a workflow-id into a path segment safe for the OS
    filesystem. Keywords become their plain name (`:canonical-sdlc` →
    `canonical-sdlc`) — `(str ...)` would otherwise include the colon
@@ -177,161 +128,8 @@
     (name workflow-id)
     (str workflow-id)))
 
-(defn live-dir
-  "Return the `{base-dir}/live/` directory that holds in-flight
-   workflows. Public so the archive module and cleanup pass can scan
-   it on boot for recovery / cleanup."
-  (^java.io.File [] (live-dir (default-events-dir)))
-  (^java.io.File [base-dir] (io/file base-dir (layout/live-subdir))))
-
-(defn archived-dir
-  "Return the `{base-dir}/archived/` directory that holds workflows
-   whose archive completed via BD-2b sub-3b's atomic move."
-  (^java.io.File [] (archived-dir (default-events-dir)))
-  (^java.io.File [base-dir] (io/file base-dir (layout/archived-subdir))))
-
-(defn live-workflow-dir
-  "Return `{base-dir}/live/{workflow-id}/`. Canonical path for an
-   in-flight workflow's event files + manifest."
-  (^java.io.File [workflow-id]
-   (live-workflow-dir (default-events-dir) workflow-id))
-  (^java.io.File [base-dir workflow-id]
-   (io/file (live-dir base-dir) (workflow-id-segment workflow-id))))
-
-(defn archived-workflow-dir
-  "Return `{base-dir}/archived/{workflow-id}/`. The destination of
-   the BD-2b sub-3b atomic archive operation."
-  (^java.io.File [workflow-id]
-   (archived-workflow-dir (default-events-dir) workflow-id))
-  (^java.io.File [base-dir workflow-id]
-   (io/file (archived-dir base-dir) (workflow-id-segment workflow-id))))
-
-(defn workflow-dir
-  "Return the per-workflow directory for an in-flight workflow. As of
-   BD-2b sub-3b this is an alias for `live-workflow-dir` —
-   `{base-dir}/live/{workflow-id}/`. The file sink for event files
-   and the manifest module (sub-2) both reference the same path so
-   archival's `mv live → archived` rename moves them together."
-  (^java.io.File [workflow-id]
-   (live-workflow-dir workflow-id))
-  (^java.io.File [base-dir workflow-id]
-   (live-workflow-dir base-dir workflow-id)))
-
-(defn event-file-path
-  "Return a java.io.File for a new event file in the per-workflow subdirectory.
-   Creates the subdirectory if needed. Filename derives from `event`'s
-   `:event/id` and `:event/sequence-number` (BD-2b filename grammar).
-
-   File layout (BD-2b sub-3b):
-     {base-dir}/live/{workflow-id}/{event-id-hex16}__{seq:012d}.transit.json
-                                  (or legacy {timestamp}-{uuid}.json for
-                                   non-snowflake streams).
-   The archive operation moves the whole `live/{wid}/` directory to
-   `archived/{wid}/` on terminal status.
-
-   Arguments:
-     base-dir    - Base directory (default: ~/.miniforge/events)
-     workflow-id - UUID or string workflow identifier
-     event       - The event whose envelope provides the filename fields"
-  ([workflow-id event]
-   (event-file-path (default-events-dir) workflow-id event))
-  ([base-dir workflow-id event]
-   (new-event-file-path (live-workflow-dir base-dir workflow-id) event)))
-
-(defn operator-dir
-  "Return the cross-workflow operator events directory under `base-dir`.
-   Writer side is [[operator-event-file-path]]; the operator-event
-   consumer (Phase D D-2) lists this directory on the read side."
-  (^java.io.File []
-   (operator-dir (default-events-dir)))
-  (^java.io.File [base-dir]
-   (io/file base-dir (layout/operator-subdir))))
-
-(defn operator-event-file-path
-  "Return a java.io.File for a new event file in the operator subdirectory.
-   Used by meta-loop, reliability, and degradation events (no :workflow/id).
-
-   File layout: {base-dir}/operator/{event-id-hex16}__{seq:012d}.transit.json
-                (or legacy {timestamp}-{uuid}.json for non-snowflake streams).
-
-   Arguments:
-     base-dir - Base directory (default: ~/.miniforge/events)
-     event    - The event whose envelope provides the filename fields"
-  ([event]
-   (operator-event-file-path (default-events-dir) event))
-  ([base-dir event]
-   (new-event-file-path (io/file base-dir (layout/operator-subdir)) event)))
-
-(defn cleanup-stale-events!
-  "Delete event files older than TTL from the events directory.
-   Walks all subdirectories (per-workflow and operator).
-
-   Arguments:
-     opts - Map with optional:
-       :events-dir - Directory to clean (default: ~/.miniforge/events)
-       :base-dir   - Alias for :events-dir
-       :ttl-ms     - Max age in milliseconds (default: 7 days)
-
-   Returns: Number of files deleted"
-  [& [opts]]
-  (let [ttl-ms (get opts :ttl-ms default-event-ttl-ms)
-        events-dir (or (:events-dir opts) (:base-dir opts) (default-events-dir))
-        cutoff (- (System/currentTimeMillis) ttl-ms)]
-    (if (.isDirectory events-dir)
-      (let [stale-files (->> (file-seq events-dir)
-                             (filter #(and (.isFile %)
-                                           (str/ends-with? (.getName %) ".json")
-                                           (< (.lastModified %) cutoff))))]
-        (doseq [f stale-files] (.delete f))
-        (count stale-files))
-      0)))
-
-(defn file-sink
-  "Create a file sink that writes each event as a Transit-JSON file.
-
-   File layout:
-     per-workflow:   {base-dir}/{workflow-id}/{event-id-hex16}__{seq:012d}.transit.json
-     cross-workflow: {base-dir}/operator/{event-id-hex16}__{seq:012d}.transit.json
-
-   The leading hex sorts by creation order when the event's :event/id is a
-   snowflake-encoded UUID (BD-2b). For events whose :event/id is a random
-   UUID (e.g. streams without a snowflake generator), the filename falls
-   back to the legacy {timestamp}-{uuid}.json shape so sort-by-creation
-   still works via the timestamp prefix.
-
-   Each event gets its own file (no append).
-
-   Performs lazy cleanup of stale event files (older than 7 days) on creation.
-
-   Arguments:
-     opts - Map with optional:
-       :base-dir - Base directory (default: ~/.miniforge/events)
-       :ttl-ms   - Max event file age in ms (default: 7 days)
-
-   Returns: Sink function (fn [event] -> nil)"
-  [& [opts]]
-  ;; Non-blocking cleanup on sink creation
-  (future (try (cleanup-stale-events! opts) (catch Exception _ nil)))
-  (fn [event]
-    (try
-      (let [base-dir (or (:base-dir opts) (default-events-dir))
-            file-path (if-let [workflow-id (:workflow/id event)]
-                        (event-file-path base-dir workflow-id event)
-                        (operator-event-file-path base-dir event))]
-        (ensure-parent-dir! file-path)
-        ;; Explicit UTF-8: payload strings can carry non-ASCII and these
-        ;; files are a cross-language contract surface — platform default
-        ;; encoding must never decide the on-disk bytes.
-        (spit file-path (event->transit-json event) :encoding "UTF-8"))
-      (catch Exception e
-        ;; Log to stderr so failures are visible without breaking the event stream
-        (binding [*out* *err*]
-          (println (str "WARNING: Event sink write failed: " (ex-message e))))
-        nil))))
-
-;;------------------------------------------------------------------------------ Layer 1: Stream Sinks
-
-(defn stdout-sink
+;; Stream Sinks
+(defn ^{:stratum 0} stdout-sink
   "Create a stdout sink that prints events to standard output.
 
    Useful for containers where stdout is collected by log aggregators.
@@ -359,7 +157,7 @@
           (binding [*out* *err*]
             (println (str "WARNING: Event sink write failed: " (ex-message e)))))))))
 
-(defn stderr-sink
+(defn ^{:stratum 0} stderr-sink
   "Create a stderr sink that prints events to standard error.
 
    Useful for error/warning events that should go to stderr stream.
@@ -386,9 +184,111 @@
             (binding [*out* *err*]
               (println (str "WARNING: Event sink write failed: " (ex-message e))))))))))
 
-;;------------------------------------------------------------------------------ Layer 2: Fleet Sink
+;; Multi-Sink
+(defn ^{:stratum 0} multi-sink
+  "Create a multi-sink that writes to multiple sinks simultaneously.
 
-(defn fleet-sink
+   Arguments:
+     sinks - Vector of sink functions
+
+   Returns: Combined sink function (fn [event] -> nil)"
+  [sinks]
+  (fn [event]
+    (doseq [sink sinks]
+      (try
+        (sink event)
+        (catch Exception _e
+          ;; Continue with other sinks even if one fails
+          nil)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} event->transit-json
+  "Serialize `event` to a Transit-JSON string using the verbose writer.
+   Verbose mode disables transit's cache codes (repeated keywords stay
+   literal, never `^0` references) and renders instants as RFC-3339
+   `~t...` tag-strings instead of compact `~m` millisecond strings, so
+   the Rust parser can decode them without millisecond arithmetic.
+   UUIDs render as `~u...` tag-strings. Custom handler for
+   java.time.Instant (not supported by Transit defaults).
+
+   Public: this is the canonical wire encoding for every event the file
+   sink persists. Contract tooling (supervisory golden fixtures) calls it
+   directly so vendored fixtures share the exact byte path with production."
+  [event]
+  (let [out (ByteArrayOutputStream.)
+        writer (transit/writer out :json-verbose
+                               {:handlers {Instant instant-write-handler}})]
+    (transit/write writer event)
+    (.toString out "UTF-8")))
+
+(defn- ^{:stratum 1} event-filename
+  "Pick a filename for `event`.
+
+   New (BD-2b): when `:event/id` is a snowflake UUID,
+     `{event-id-hex16}__{workflow-seq-dec12}.transit.json`
+   sorts lex-by-creation across all workflows on this host.
+
+   Legacy: `{timestamp}-{uuid}.json` for streams without a snowflake
+   generator. Sort-by-creation still works via the timestamp prefix."
+  [event]
+  (let [id (:event/id event)
+        seq-num (long (or (:event/sequence-number event) 0))]
+    (if (snowflake-uuid? id)
+      (str (snowflake/uuid->hex id)
+           "__"
+           (format "%012d" seq-num)
+           ".transit.json")
+      (str (now-sortable-str) "-" (or id (random-uuid)) ".json"))))
+
+(defn ^{:stratum 1} live-dir
+  "Return the `{base-dir}/live/` directory that holds in-flight
+   workflows. Public so the archive module and cleanup pass can scan
+   it on boot for recovery / cleanup."
+  (^java.io.File [] (live-dir (default-events-dir)))
+  (^java.io.File [base-dir] (io/file base-dir (layout/live-subdir))))
+
+(defn ^{:stratum 1} archived-dir
+  "Return the `{base-dir}/archived/` directory that holds workflows
+   whose archive completed via BD-2b sub-3b's atomic move."
+  (^java.io.File [] (archived-dir (default-events-dir)))
+  (^java.io.File [base-dir] (io/file base-dir (layout/archived-subdir))))
+
+(defn ^{:stratum 1} operator-dir
+  "Return the cross-workflow operator events directory under `base-dir`.
+   Writer side is [[operator-event-file-path]]; the operator-event
+   consumer (Phase D D-2) lists this directory on the read side."
+  (^java.io.File []
+   (operator-dir (default-events-dir)))
+  (^java.io.File [base-dir]
+   (io/file base-dir (layout/operator-subdir))))
+
+(defn ^{:stratum 1} cleanup-stale-events!
+  "Delete event files older than TTL from the events directory.
+   Walks all subdirectories (per-workflow and operator).
+
+   Arguments:
+     opts - Map with optional:
+       :events-dir - Directory to clean (default: ~/.miniforge/events)
+       :base-dir   - Alias for :events-dir
+       :ttl-ms     - Max age in milliseconds (default: 7 days)
+
+   Returns: Number of files deleted"
+  [& [opts]]
+  (let [ttl-ms (get opts :ttl-ms default-event-ttl-ms)
+        events-dir (or (:events-dir opts) (:base-dir opts) (default-events-dir))
+        cutoff (- (System/currentTimeMillis) ttl-ms)]
+    (if (.isDirectory events-dir)
+      (let [stale-files (->> (file-seq events-dir)
+                             (filter #(and (.isFile %)
+                                           (str/ends-with? (.getName %) ".json")
+                                           (< (.lastModified %) cutoff))))]
+        (doseq [f stale-files] (.delete f))
+        (count stale-files))
+      0)))
+
+;; Fleet Sink
+(defn ^{:stratum 1} fleet-sink
   "Create a fleet sink that sends events to fleet command via HTTP.
 
    Arguments:
@@ -465,27 +365,131 @@
           (when (or batch-full? time-exceeded?)
             (flush-batch!)))))))
 
-;;------------------------------------------------------------------------------ Layer 3: Multi-Sink
+;------------------------------------------------------------------------------ Layer 2
 
-(defn multi-sink
-  "Create a multi-sink that writes to multiple sinks simultaneously.
+(defn- ^{:stratum 2} new-event-file-path
+  "Return a java.io.File for `event` inside `parent-dir`. Creates the
+   directory if needed. The filename is derived from the event itself
+   (BD-2b filename grammar — see `event-filename`)."
+  [parent-dir event]
+  (let [dir (io/file parent-dir)]
+    (.mkdirs dir)
+    (io/file dir (event-filename event))))
+
+(defn ^{:stratum 2} live-workflow-dir
+  "Return `{base-dir}/live/{workflow-id}/`. Canonical path for an
+   in-flight workflow's event files + manifest."
+  (^java.io.File [workflow-id]
+   (live-workflow-dir (default-events-dir) workflow-id))
+  (^java.io.File [base-dir workflow-id]
+   (io/file (live-dir base-dir) (workflow-id-segment workflow-id))))
+
+(defn ^{:stratum 2} archived-workflow-dir
+  "Return `{base-dir}/archived/{workflow-id}/`. The destination of
+   the BD-2b sub-3b atomic archive operation."
+  (^java.io.File [workflow-id]
+   (archived-workflow-dir (default-events-dir) workflow-id))
+  (^java.io.File [base-dir workflow-id]
+   (io/file (archived-dir base-dir) (workflow-id-segment workflow-id))))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} workflow-dir
+  "Return the per-workflow directory for an in-flight workflow. As of
+   BD-2b sub-3b this is an alias for `live-workflow-dir` —
+   `{base-dir}/live/{workflow-id}/`. The file sink for event files
+   and the manifest module (sub-2) both reference the same path so
+   archival's `mv live → archived` rename moves them together."
+  (^java.io.File [workflow-id]
+   (live-workflow-dir workflow-id))
+  (^java.io.File [base-dir workflow-id]
+   (live-workflow-dir base-dir workflow-id)))
+
+(defn ^{:stratum 3} event-file-path
+  "Return a java.io.File for a new event file in the per-workflow subdirectory.
+   Creates the subdirectory if needed. Filename derives from `event`'s
+   `:event/id` and `:event/sequence-number` (BD-2b filename grammar).
+
+   File layout (BD-2b sub-3b):
+     {base-dir}/live/{workflow-id}/{event-id-hex16}__{seq:012d}.transit.json
+                                  (or legacy {timestamp}-{uuid}.json for
+                                   non-snowflake streams).
+   The archive operation moves the whole `live/{wid}/` directory to
+   `archived/{wid}/` on terminal status.
 
    Arguments:
-     sinks - Vector of sink functions
+     base-dir    - Base directory (default: ~/.miniforge/events)
+     workflow-id - UUID or string workflow identifier
+     event       - The event whose envelope provides the filename fields"
+  ([workflow-id event]
+   (event-file-path (default-events-dir) workflow-id event))
+  ([base-dir workflow-id event]
+   (new-event-file-path (live-workflow-dir base-dir workflow-id) event)))
 
-   Returns: Combined sink function (fn [event] -> nil)"
-  [sinks]
+(defn ^{:stratum 3} operator-event-file-path
+  "Return a java.io.File for a new event file in the operator subdirectory.
+   Used by meta-loop, reliability, and degradation events (no :workflow/id).
+
+   File layout: {base-dir}/operator/{event-id-hex16}__{seq:012d}.transit.json
+                (or legacy {timestamp}-{uuid}.json for non-snowflake streams).
+
+   Arguments:
+     base-dir - Base directory (default: ~/.miniforge/events)
+     event    - The event whose envelope provides the filename fields"
+  ([event]
+   (operator-event-file-path (default-events-dir) event))
+  ([base-dir event]
+   (new-event-file-path (io/file base-dir (layout/operator-subdir)) event)))
+
+;------------------------------------------------------------------------------ Layer 4
+
+(defn ^{:stratum 4} file-sink
+  "Create a file sink that writes each event as a Transit-JSON file.
+
+   File layout:
+     per-workflow:   {base-dir}/{workflow-id}/{event-id-hex16}__{seq:012d}.transit.json
+     cross-workflow: {base-dir}/operator/{event-id-hex16}__{seq:012d}.transit.json
+
+   The leading hex sorts by creation order when the event's :event/id is a
+   snowflake-encoded UUID (BD-2b). For events whose :event/id is a random
+   UUID (e.g. streams without a snowflake generator), the filename falls
+   back to the legacy {timestamp}-{uuid}.json shape so sort-by-creation
+   still works via the timestamp prefix.
+
+   Each event gets its own file (no append).
+
+   Performs lazy cleanup of stale event files (older than 7 days) on creation.
+
+   Arguments:
+     opts - Map with optional:
+       :base-dir - Base directory (default: ~/.miniforge/events)
+       :ttl-ms   - Max event file age in ms (default: 7 days)
+
+   Returns: Sink function (fn [event] -> nil)"
+  [& [opts]]
+  ;; Non-blocking cleanup on sink creation
+  (future (try (cleanup-stale-events! opts) (catch Exception _ nil)))
   (fn [event]
-    (doseq [sink sinks]
-      (try
-        (sink event)
-        (catch Exception _e
-          ;; Continue with other sinks even if one fails
-          nil)))))
+    (try
+      (let [base-dir (or (:base-dir opts) (default-events-dir))
+            file-path (if-let [workflow-id (:workflow/id event)]
+                        (event-file-path base-dir workflow-id event)
+                        (operator-event-file-path base-dir event))]
+        (ensure-parent-dir! file-path)
+        ;; Explicit UTF-8: payload strings can carry non-ASCII and these
+        ;; files are a cross-language contract surface — platform default
+        ;; encoding must never decide the on-disk bytes.
+        (spit file-path (event->transit-json event) :encoding "UTF-8"))
+      (catch Exception e
+        ;; Log to stderr so failures are visible without breaking the event stream
+        (binding [*out* *err*]
+          (println (str "WARNING: Event sink write failed: " (ex-message e))))
+        nil))))
 
-;;------------------------------------------------------------------------------ Layer 4: Sink Factory
+;------------------------------------------------------------------------------ Layer 5
 
-(defn create-sink
+;; Sink Factory
+(defn ^{:stratum 5} create-sink
   "Create a sink from configuration.
 
    Arguments:
@@ -528,7 +532,9 @@
                              {:config sink-config
                               :config/error :invalid-config})))
 
-(defn create-sinks-from-config
+;------------------------------------------------------------------------------ Layer 6
+
+(defn ^{:stratum 6} create-sinks-from-config
   "Create sinks from user configuration.
 
    Arguments:

--- a/components/event-stream/src/ai/miniforge/event_stream/snowflake.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/snowflake.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.snowflake
   "Twitter-Snowflake-style sortable event-id generator (BD-2b RFC v3/v4).
 
@@ -60,6 +59,8 @@
    [clojure.java.io :as io]
    [ai.miniforge.logging.interface :as log]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; NOTE: The worker-id lease path constructs java.io.RandomAccessFile,
 ;; calls .getChannel (FileChannel), .tryLock (returning FileLock), and
 ;; wraps bytes via java.nio.ByteBuffer. Those references appear FQN
@@ -67,44 +68,31 @@
 ;; loads in Babashka (which doesn't ship java.nio.channels.FileLock).
 ;; Worker-id leasing is JVM-only — the BB-runtime test loads the
 ;; namespace but never calls it, keeping event-stream BB-compatible.
-
-;------------------------------------------------------------------------------ Layer 0
 ;; Constants
-
-(def ^:const ^long miniforge-epoch-ms
+(def ^{:stratum 0} ^:const ^long miniforge-epoch-ms
   "ms since unix epoch for 2026-01-01T00:00:00Z. The 41-bit timestamp
    field is computed as (now - epoch). 41 bits ≈ 69.7 years from this
    epoch — comfortable headroom."
   1767225600000)
 
-(def ^:const ^long max-seq
+(def ^{:stratum 0} ^:const ^long max-seq
   "12-bit sequence — 4096 distinct ids per (ms × worker)."
   4095)
 
-(def ^:const ^long max-workers
+(def ^{:stratum 0} ^:const ^long max-workers
   "10-bit worker space — 1024 concurrent workers per host."
   1024)
 
-(def ^:const ^long worker-shift 12)
-(def ^:const ^long ts-shift 22)
+(def ^{:stratum 0} ^:const ^long worker-shift 12)
 
-;------------------------------------------------------------------------------ Layer 0
-;; Pure id-composition
+(def ^{:stratum 0} ^:const ^long ts-shift 22)
 
-(defn compose-id
-  "Compose a 64-bit snowflake from (ts-since-epoch-ms, worker-id, seq).
-   Pure: no clock or state."
-  ^long [^long ts-since-epoch ^long worker ^long sequence]
-  (bit-or (bit-shift-left ts-since-epoch ts-shift)
-          (bit-shift-left worker worker-shift)
-          sequence))
-
-(defn format-hex
+(defn ^{:stratum 0} format-hex
   "Render a 64-bit id as a 16-char lowercase hex string."
   ^String [^long id]
   (format "%016x" id))
 
-(defn long->uuid
+(defn ^{:stratum 0} long->uuid
   "Embed a 64-bit snowflake id into a `java.util.UUID` as the
    most-significant bits, with the low 64 bits zero. Keeps `:event/id`
    typed as uuid for existing consumers while making the leading hex
@@ -112,22 +100,106 @@
   ^java.util.UUID [^long id]
   (java.util.UUID. id 0))
 
-(defn uuid->hex
-  "Extract the 16-char lowercase hex of the snowflake bits from a UUID
-   created by `long->uuid`. Inverse of long->uuid for filename use."
-  ^String [^java.util.UUID uuid]
-  (format-hex (.getMostSignificantBits uuid)))
-
-;------------------------------------------------------------------------------ Layer 0
 ;; Generator state
-
-(defn- initial-state
+(defn- ^{:stratum 0} initial-state
   [worker-id]
   {:last-ts -1
    :last-seq -1
    :worker-id worker-id})
 
-(defn- next-state
+;; Worker-id leasing (FileLock-based)
+(defn- ^{:stratum 0} default-workers-dir
+  []
+  (io/file (config/miniforge-home) "events" ".workers"))
+
+(defn- ^{:stratum 0} lease-io-anomaly
+  [workers-dir lease-path id error]
+  (cond-> (response/make-anomaly
+           :anomalies/unavailable
+           (messages/t :snowflake/lease-io-failure
+                       {:worker-id id
+                        :lease-path (.getAbsolutePath lease-path)})
+           {:reason :lease-io-failure
+            :worker-id id
+            :lease-path (.getAbsolutePath lease-path)
+            :workers-dir (.getAbsolutePath workers-dir)})
+    error (assoc :anomaly/ex-message (ex-message error)
+                 :anomaly/ex-class (str (class error)))
+    (ex-data error) (assoc :anomaly/ex-data (ex-data error))))
+
+(defn- ^{:stratum 0} write-lease-metadata!
+  "Truncate `channel` and write the worker-id + acquire timestamp as
+   EDN. Force to disk. Metadata is informational only — the OS-level
+   FileLock release on JVM exit is what guarantees correctness, so
+   pid/host fields are not load-bearing and are deliberately omitted
+   to keep this namespace Babashka-loadable
+   (java.lang.management is not in BB)."
+  [channel worker-id]
+  (.truncate channel 0)
+  (let [meta  {:worker-id   worker-id
+               :acquired-at (System/currentTimeMillis)}
+        bytes (.getBytes (str (pr-str meta) "\n") "UTF-8")]
+    (.write channel (java.nio.ByteBuffer/wrap bytes))
+    (.force channel false)))
+
+(defn ^{:stratum 0} release-lease!
+  "Release a worker-id lease. Idempotent. The OS would release on JVM
+   exit anyway; this is for explicit teardown (tests, shutdown hooks)."
+  [{:keys [lock channel raf]}]
+  (when lock
+    (try (.release lock) (catch Exception _)))
+  (when channel
+    (try (.close channel) (catch Exception _)))
+  (when raf
+    (try (.close raf) (catch Exception _))))
+
+;; Id generation
+(defn- ^{:stratum 0} log-rollback!
+  [logger details]
+  (when logger
+    (log/warn logger :event-stream :snowflake/clock-rollback
+              {:message "Snowflake generator detected clock rollback; stalling"
+               :data    details})))
+
+(def ^{:stratum 0} ^:private ^:const ^long park-budget-nanos
+  "Park budget for the wait loop on clock-rollback / sequence-exhausted.
+   100µs is short enough to wake well before the next ms tick (so the
+   loop spins ~10× per ms in the worst case) but long enough to avoid
+   a CPU-burning busy-spin. `parkNanos` may wake earlier on signal —
+   that's fine, the outer loop simply re-checks the wall clock."
+  100000)
+
+(def ^{:stratum 0} ^:private park-nanos-method
+  "Lazily-resolved `java.util.concurrent.locks.LockSupport/parkNanos`
+   via `Class/forName` + reflection. The id-generation path only
+   executes on the JVM, but this namespace is transitively loaded
+   from Babashka-runtime bricks and BB does not ship
+   `java.util.concurrent.locks`. A static method call would force
+   compile-time class resolution and break BB load; this delay
+   defers it to the first JVM invocation."
+  (delay
+    (.getMethod (Class/forName "java.util.concurrent.locks.LockSupport")
+                "parkNanos"
+                (into-array Class [Long/TYPE]))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Pure id-composition
+(defn ^{:stratum 1} compose-id
+  "Compose a 64-bit snowflake from (ts-since-epoch-ms, worker-id, seq).
+   Pure: no clock or state."
+  ^long [^long ts-since-epoch ^long worker ^long sequence]
+  (bit-or (bit-shift-left ts-since-epoch ts-shift)
+          (bit-shift-left worker worker-shift)
+          sequence))
+
+(defn ^{:stratum 1} uuid->hex
+  "Extract the 16-char lowercase hex of the snowflake bits from a UUID
+   created by `long->uuid`. Inverse of long->uuid for filename use."
+  ^String [^java.util.UUID uuid]
+  (format-hex (.getMostSignificantBits uuid)))
+
+(defn- ^{:stratum 1} next-state
   "Pure: compute the next state from `state` and the current wall ms.
    Returns either a new state (advanced) or one of the sentinels:
      ::pre-epoch        wall ms is before the miniforge epoch — the
@@ -148,29 +220,7 @@
     :else
     (assoc state :last-ts now-ms :last-seq 0)))
 
-;------------------------------------------------------------------------------ Layer 0
-;; Worker-id leasing (FileLock-based)
-
-(defn- default-workers-dir
-  []
-  (io/file (config/miniforge-home) "events" ".workers"))
-
-(defn- lease-io-anomaly
-  [workers-dir lease-path id error]
-  (cond-> (response/make-anomaly
-           :anomalies/unavailable
-           (messages/t :snowflake/lease-io-failure
-                       {:worker-id id
-                        :lease-path (.getAbsolutePath lease-path)})
-           {:reason :lease-io-failure
-            :worker-id id
-            :lease-path (.getAbsolutePath lease-path)
-            :workers-dir (.getAbsolutePath workers-dir)})
-    error (assoc :anomaly/ex-message (ex-message error)
-                 :anomaly/ex-class (str (class error)))
-    (ex-data error) (assoc :anomaly/ex-data (ex-data error))))
-
-(defn- workers-exhausted-anomaly
+(defn- ^{:stratum 1} workers-exhausted-anomaly
   [workers-dir]
   (response/make-anomaly
    :anomalies/busy
@@ -180,22 +230,7 @@
     :max    max-workers
     :workers-dir (.getAbsolutePath workers-dir)}))
 
-(defn- write-lease-metadata!
-  "Truncate `channel` and write the worker-id + acquire timestamp as
-   EDN. Force to disk. Metadata is informational only — the OS-level
-   FileLock release on JVM exit is what guarantees correctness, so
-   pid/host fields are not load-bearing and are deliberately omitted
-   to keep this namespace Babashka-loadable
-   (java.lang.management is not in BB)."
-  [channel worker-id]
-  (.truncate channel 0)
-  (let [meta  {:worker-id   worker-id
-               :acquired-at (System/currentTimeMillis)}
-        bytes (.getBytes (str (pr-str meta) "\n") "UTF-8")]
-    (.write channel (java.nio.ByteBuffer/wrap bytes))
-    (.force channel false)))
-
-(defn- try-acquire-slot
+(defn- ^{:stratum 1} try-acquire-slot
   "Try to acquire an exclusive FileLock on `{workers-dir}/{id}.lease`.
    Returns a map `{:channel ... :lock ... :worker-id id}` on success,
    `nil` if the slot is held by another holder. Does not retry.
@@ -240,7 +275,38 @@
       (catch Exception e
         (lease-io-anomaly workers-dir lease-path id e)))))
 
-(defn acquire-worker-lease!
+(defn ^{:stratum 1} close!
+  "Release the generator's worker-id lease. Idempotent."
+  [generator]
+  (when-let [lease (:lease generator)]
+    (release-lease! lease)))
+
+(defn- ^{:stratum 1} park-briefly!
+  "Park the calling thread for up to `park-budget-nanos`. Used by the
+   id-generation loop in place of `Thread/sleep` so there's no
+   millisecond-rounded delay and the call surface stays
+   `LockSupport`-style rather than the deprecated sleep idiom. The
+   thread can wake earlier on spurious signal; callers must re-check
+   their condition."
+  []
+  (.invoke @park-nanos-method
+           nil
+           (into-array Object [(Long/valueOf park-budget-nanos)])))
+
+(defn- ^{:stratum 1} pre-epoch-anomaly
+  [now-ms worker-id]
+  (response/make-anomaly
+   :anomalies/incorrect
+   (messages/t :snowflake/pre-epoch-clock
+               {:now-ms now-ms :epoch-ms miniforge-epoch-ms})
+   {:reason     :pre-epoch-clock
+    :now-ms     now-ms
+    :epoch-ms   miniforge-epoch-ms
+    :worker-id  worker-id}))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} acquire-worker-lease!
   "Walk slots 0..1023 and acquire the first whose lease file is
    unlocked.
 
@@ -275,21 +341,30 @@
           lease lease
           :else (recur (inc id)))))))
 
-(defn release-lease!
-  "Release a worker-id lease. Idempotent. The OS would release on JVM
-   exit anyway; this is for explicit teardown (tests, shutdown hooks)."
-  [{:keys [lock channel raf]}]
-  (when lock
-    (try (.release lock) (catch Exception _)))
-  (when channel
-    (try (.close channel) (catch Exception _)))
-  (when raf
-    (try (.close raf) (catch Exception _))))
+(defn- ^{:stratum 2} handle-rollback!
+  "Side-effect: warn once on first rollback observation. Park before
+   the outer loop retries. Returns the new `warned?` value."
+  [{:keys [logger ^long worker-id]} now-ms last-ts warned?]
+  (when (not warned?)
+    (log-rollback! logger {:now-ms    now-ms
+                           :last-ts   last-ts
+                           :worker-id worker-id}))
+  (park-briefly!)
+  true)
 
-;------------------------------------------------------------------------------ Layer 1
+(defn- ^{:stratum 2} emit-id
+  "CAS the new state and return the composed id long. nil on CAS loss
+   (caller retries the outer loop)."
+  [state old new-state ^long worker-id]
+  (when (compare-and-set! state old new-state)
+    (compose-id (- ^long (:last-ts new-state) miniforge-epoch-ms)
+                worker-id
+                ^long (:last-seq new-state))))
+
+;------------------------------------------------------------------------------ Layer 3
+
 ;; Generator handle
-
-(defn create-generator
+(defn ^{:stratum 3} create-generator
   "Allocate a new snowflake generator. Acquires a worker-id lease under
    `:workers-dir` (default `~/.miniforge/events/.workers/`).
 
@@ -315,87 +390,7 @@
          :now-fn    now-fn
          :logger    logger}))))
 
-(defn close!
-  "Release the generator's worker-id lease. Idempotent."
-  [generator]
-  (when-let [lease (:lease generator)]
-    (release-lease! lease)))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Id generation
-
-(defn- log-rollback!
-  [logger details]
-  (when logger
-    (log/warn logger :event-stream :snowflake/clock-rollback
-              {:message "Snowflake generator detected clock rollback; stalling"
-               :data    details})))
-
-(def ^:private ^:const ^long park-budget-nanos
-  "Park budget for the wait loop on clock-rollback / sequence-exhausted.
-   100µs is short enough to wake well before the next ms tick (so the
-   loop spins ~10× per ms in the worst case) but long enough to avoid
-   a CPU-burning busy-spin. `parkNanos` may wake earlier on signal —
-   that's fine, the outer loop simply re-checks the wall clock."
-  100000)
-
-(def ^:private park-nanos-method
-  "Lazily-resolved `java.util.concurrent.locks.LockSupport/parkNanos`
-   via `Class/forName` + reflection. The id-generation path only
-   executes on the JVM, but this namespace is transitively loaded
-   from Babashka-runtime bricks and BB does not ship
-   `java.util.concurrent.locks`. A static method call would force
-   compile-time class resolution and break BB load; this delay
-   defers it to the first JVM invocation."
-  (delay
-    (.getMethod (Class/forName "java.util.concurrent.locks.LockSupport")
-                "parkNanos"
-                (into-array Class [Long/TYPE]))))
-
-(defn- park-briefly!
-  "Park the calling thread for up to `park-budget-nanos`. Used by the
-   id-generation loop in place of `Thread/sleep` so there's no
-   millisecond-rounded delay and the call surface stays
-   `LockSupport`-style rather than the deprecated sleep idiom. The
-   thread can wake earlier on spurious signal; callers must re-check
-   their condition."
-  []
-  (.invoke @park-nanos-method
-           nil
-           (into-array Object [(Long/valueOf park-budget-nanos)])))
-
-(defn- pre-epoch-anomaly
-  [now-ms worker-id]
-  (response/make-anomaly
-   :anomalies/incorrect
-   (messages/t :snowflake/pre-epoch-clock
-               {:now-ms now-ms :epoch-ms miniforge-epoch-ms})
-   {:reason     :pre-epoch-clock
-    :now-ms     now-ms
-    :epoch-ms   miniforge-epoch-ms
-    :worker-id  worker-id}))
-
-(defn- handle-rollback!
-  "Side-effect: warn once on first rollback observation. Park before
-   the outer loop retries. Returns the new `warned?` value."
-  [{:keys [logger ^long worker-id]} now-ms last-ts warned?]
-  (when (not warned?)
-    (log-rollback! logger {:now-ms    now-ms
-                           :last-ts   last-ts
-                           :worker-id worker-id}))
-  (park-briefly!)
-  true)
-
-(defn- emit-id
-  "CAS the new state and return the composed id long. nil on CAS loss
-   (caller retries the outer loop)."
-  [state old new-state ^long worker-id]
-  (when (compare-and-set! state old new-state)
-    (compose-id (- ^long (:last-ts new-state) miniforge-epoch-ms)
-                worker-id
-                ^long (:last-seq new-state))))
-
-(defn next-id-long!
+(defn ^{:stratum 3} next-id-long!
   "Internal: generate the next snowflake as a long. Parks on
    clock rollback or sequence exhaustion (≤100µs per retry via
    `LockSupport/parkNanos` rather than `Thread/sleep`).
@@ -417,7 +412,9 @@
             ;; Lost CAS race against another thread — retry with fresh state.
             (recur warned?))))))
 
-(defn next-id!
+;------------------------------------------------------------------------------ Layer 4
+
+(defn ^{:stratum 4} next-id!
   "Generate the next snowflake event id as a `java.util.UUID`. The
    snowflake bits live in the UUID's most-significant 64 bits; low 64
    bits are zero. The UUID's string form sorts lexically by creation
@@ -428,7 +425,7 @@
       id
       (long->uuid id))))
 
-(defn next-id-hex!
+(defn ^{:stratum 4} next-id-hex!
   "Generate the next snowflake event id as a 16-char lowercase hex
    string. Use this for filenames and other places where the UUID's
    hyphens are inconvenient."

--- a/components/event-stream/src/ai/miniforge/event_stream/storage_layout.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/storage_layout.clj
@@ -15,16 +15,17 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.storage-layout
   "Configuration-as-data for the event-stream on-disk storage layout."
   (:require
    [ai.miniforge.config.interface :as config]))
 
-(def ^:private resource-path
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private resource-path
   "config/event-stream/storage-layout.edn")
 
-(def ^:private required-keys
+(def ^{:stratum 0} ^:private required-keys
   [:live-subdir
    :archived-subdir
    :operator-subdir
@@ -32,7 +33,9 @@
    :snapshot-tmp-filename
    :archived-marker-filename])
 
-(defn- load-layout
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} load-layout
   []
   (let [layout (config/load-config-resource resource-path required-keys)
         missing (seq (remove #(string? (get layout %)) required-keys))]
@@ -42,29 +45,33 @@
                        :missing-string-keys (vec missing)})))
     layout))
 
-(def ^:private layout
+;------------------------------------------------------------------------------ Layer 2
+
+(def ^{:stratum 2} ^:private layout
   (delay (load-layout)))
 
-(defn live-subdir
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} live-subdir
   []
   (:live-subdir @layout))
 
-(defn archived-subdir
+(defn ^{:stratum 3} archived-subdir
   []
   (:archived-subdir @layout))
 
-(defn operator-subdir
+(defn ^{:stratum 3} operator-subdir
   []
   (:operator-subdir @layout))
 
-(defn snapshot-filename
+(defn ^{:stratum 3} snapshot-filename
   []
   (:snapshot-filename @layout))
 
-(defn snapshot-tmp-filename
+(defn ^{:stratum 3} snapshot-tmp-filename
   []
   (:snapshot-tmp-filename @layout))
 
-(defn archived-marker-filename
+(defn ^{:stratum 3} archived-marker-filename
   []
   (:archived-marker-filename @layout))

--- a/components/event-stream/src/ai/miniforge/event_stream/timeline.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/timeline.clj
@@ -139,7 +139,6 @@
         raw     (if (string? preview) preview (event-message event))]
     (truncate raw args-preview-length)))
 
-;; Public API
 (defn- ^{:stratum 1} index-tool-names
   "Build a `{tool-call-id → tool-name}` lookup map from the event stream.
 
@@ -300,6 +299,7 @@
 
 ;------------------------------------------------------------------------------ Layer 5
 
+;; Public API
 (defn ^{:stratum 5} render-timeline
   "Transform a seq of parsed event maps into a human-readable timeline string.
 

--- a/components/event-stream/src/ai/miniforge/event_stream/timeline.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/timeline.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.timeline
   "Pure namespace: transforms a seq of parsed event maps into a
    human-readable timeline string.
@@ -41,43 +40,124 @@
    [java.util Date TimeZone]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Constants
 
-(def ^:const default-gap-threshold-ms
+;; Constants
+(def ^{:stratum 0} ^:const default-gap-threshold-ms
   "Default gap threshold in milliseconds (60 seconds)."
   60000)
 
-(def ^:const args-preview-length
+(def ^{:stratum 0} ^:const args-preview-length
   "Maximum character length for the args-summary column."
   60)
 
-(def ^:private terminal-event-types
+(def ^{:stratum 0} ^:private terminal-event-types
   "Event types that denote workflow termination."
   #{:workflow/completed :workflow/failed})
 
-(def ^:private stall-event-types
+(def ^{:stratum 0} ^:private stall-event-types
   "Event types that denote stream stalls."
   #{:agent/stream-stalled})
 
-(def ^:private phase-lifecycle-types
+(def ^{:stratum 0} ^:private phase-lifecycle-types
   "Event types for phase start/stop lifecycle."
   #{:workflow/phase-started :workflow/phase-completed})
 
-;------------------------------------------------------------------------------ Layer 0
 ;; Time formatting helpers
-
-(defn- make-hms-formatter
+(defn- ^{:stratum 0} make-hms-formatter
   "Create a thread-local HH:mm:ss formatter in UTC."
   ^SimpleDateFormat []
   (doto (SimpleDateFormat. "HH:mm:ss")
     (.setTimeZone (TimeZone/getTimeZone "UTC"))))
 
-(def ^:private ^ThreadLocal hms-formatter-local
+(defn- ^{:stratum 0} ts->epoch-ms
+  "Coerce `ts` to epoch-ms long. Returns nil on failure."
+  [ts]
+  (try
+    (cond
+      (nil? ts)            nil
+      (instance? Date ts)  (.getTime ^Date ts)
+      (number? ts)         (long ts)
+      (string? ts)         (-> (java.time.Instant/parse ts)
+                               (.toEpochMilli))
+      :else                nil)
+    (catch Exception _
+      nil)))
+
+;; Field extraction helpers
+(defn- ^{:stratum 0} event-timestamp [event]
+  (:event/timestamp event))
+
+(defn- ^{:stratum 0} event-phase [event]
+  (or (:workflow/phase event) (messages/t :timeline/no-phase)))
+
+(defn- ^{:stratum 0} event-type [event]
+  (:event/type event))
+
+(defn- ^{:stratum 0} event-message
+  "Return the renderable event message, or an empty string when absent or malformed."
+  [event]
+  (let [message (get event :message)]
+    (if (string? message) message "")))
+
+(defn- ^{:stratum 0} truncate
+  "Truncate string `s` to at most `n` characters, appending the
+   localized `:timeline/truncation-suffix` if cut."
+  [s n]
+  (when (string? s)
+    (if (<= (count s) n)
+      s
+      (let [suffix        (str (messages/t :timeline/truncation-suffix))
+            suffix-length (min (count suffix) (max 0 n))
+            prefix-length (max 0 (- n suffix-length))]
+        (str (subs s 0 prefix-length)
+             (subs suffix 0 suffix-length))))))
+
+;; Duration helpers
+(defn- ^{:stratum 0} format-duration-ms
+  "Format `ms` as a human-readable duration string. Both shapes
+   (mins+secs, secs-only) flow through the user catalog."
+  [ms]
+  (let [total-s (long (/ ms 1000))
+        m       (long (/ total-s 60))
+        s       (long (rem total-s 60))]
+    (if (pos? m)
+      (messages/t :timeline/duration-mins-secs {:mins m :secs s})
+      (messages/t :timeline/duration-secs      {:secs s}))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} ^:private ^ThreadLocal hms-formatter-local
   "Thread-local SimpleDateFormat to avoid allocation on hot paths."
   (proxy [ThreadLocal] []
     (initialValue [] (make-hms-formatter))))
 
-(defn- format-hms
+(defn- ^{:stratum 1} args-summary
+  "Extract the args preview from an event, truncated to `args-preview-length` chars.
+   Prefers `:tool/args-digest :digest/preview`, falls back to `:message`."
+  [event]
+  (let [preview (get-in event [:tool/args-digest :digest/preview])
+        raw     (if (string? preview) preview (event-message event))]
+    (truncate raw args-preview-length)))
+
+;; Public API
+(defn- ^{:stratum 1} index-tool-names
+  "Build a `{tool-call-id → tool-name}` lookup map from the event stream.
+
+   `:tool/call-completed` events don't carry the tool name (per the
+   `ToolCallCompleted` schema) — the name lives on the paired
+   `:agent/tool-call-started` event. Pre-walk the stream once so the
+   completed-event renderer can look the name up without re-scanning."
+  [events]
+  (->> events
+       (filter #(and (= :agent/tool-call-started (event-type %))
+                     (:tool/call-id %)
+                     (:tool/name %)))
+       (reduce (fn [m e] (assoc m (:tool/call-id e) (:tool/name e)))
+               {})))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- ^{:stratum 2} format-hms
   "Format `ts` (a Date, long epoch-ms, or ISO-8601 string) as HH:mm:ss.
    Returns the localized `:timeline/unknown-time` sentinel when `ts` is
    nil or unparseable."
@@ -98,77 +178,10 @@
     (catch Exception _
       (messages/t :timeline/unknown-time))))
 
-(defn- ts->epoch-ms
-  "Coerce `ts` to epoch-ms long. Returns nil on failure."
-  [ts]
-  (try
-    (cond
-      (nil? ts)            nil
-      (instance? Date ts)  (.getTime ^Date ts)
-      (number? ts)         (long ts)
-      (string? ts)         (-> (java.time.Instant/parse ts)
-                               (.toEpochMilli))
-      :else                nil)
-    (catch Exception _
-      nil)))
+;------------------------------------------------------------------------------ Layer 3
 
-;------------------------------------------------------------------------------ Layer 1
-;; Field extraction helpers
-
-(defn- event-timestamp [event]
-  (:event/timestamp event))
-
-(defn- event-phase [event]
-  (or (:workflow/phase event) (messages/t :timeline/no-phase)))
-
-(defn- event-type [event]
-  (:event/type event))
-
-(defn- event-message
-  "Return the renderable event message, or an empty string when absent or malformed."
-  [event]
-  (let [message (get event :message)]
-    (if (string? message) message "")))
-
-(defn- truncate
-  "Truncate string `s` to at most `n` characters, appending the
-   localized `:timeline/truncation-suffix` if cut."
-  [s n]
-  (when (string? s)
-    (if (<= (count s) n)
-      s
-      (let [suffix        (str (messages/t :timeline/truncation-suffix))
-            suffix-length (min (count suffix) (max 0 n))
-            prefix-length (max 0 (- n suffix-length))]
-        (str (subs s 0 prefix-length)
-             (subs suffix 0 suffix-length))))))
-
-(defn- args-summary
-  "Extract the args preview from an event, truncated to `args-preview-length` chars.
-   Prefers `:tool/args-digest :digest/preview`, falls back to `:message`."
-  [event]
-  (let [preview (get-in event [:tool/args-digest :digest/preview])
-        raw     (if (string? preview) preview (event-message event))]
-    (truncate raw args-preview-length)))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Duration helpers
-
-(defn- format-duration-ms
-  "Format `ms` as a human-readable duration string. Both shapes
-   (mins+secs, secs-only) flow through the user catalog."
-  [ms]
-  (let [total-s (long (/ ms 1000))
-        m       (long (/ total-s 60))
-        s       (long (rem total-s 60))]
-    (if (pos? m)
-      (messages/t :timeline/duration-mins-secs {:mins m :secs s})
-      (messages/t :timeline/duration-secs      {:secs s}))))
-
-;------------------------------------------------------------------------------ Layer 2
 ;; Per-event-type render dispatch
-
-(defn- render-tool-call-started
+(defn- ^{:stratum 3} render-tool-call-started
   "`:agent/tool-call-started` — show tool name + args digest preview."
   [event]
   (let [ts       (format-hms (event-timestamp event))
@@ -177,7 +190,7 @@
         args-sum (args-summary event)]
     (format "%s  %s  %s  %s" ts phase tool args-sum)))
 
-(defn- render-tool-call-completed
+(defn- ^{:stratum 3} render-tool-call-completed
   "`:tool/call-completed` — show tool name + duration + success/error.
 
    Per `schema/ToolCallCompleted` the event does NOT carry `:tool/name`;
@@ -208,7 +221,7 @@
                    (str "  " status))]
     (format "%s  %s  %s%s" ts phase tool dur-str)))
 
-(defn- render-phase-lifecycle
+(defn- ^{:stratum 3} render-phase-lifecycle
   "`:workflow/phase-started` / `:workflow/phase-completed` — phase lifecycle."
   [event]
   (let [ts       (format-hms (event-timestamp event))
@@ -224,7 +237,7 @@
       (format "%s  %s  %s  %s" ts phase marker msg)
       (format "%s  %s  %s" ts phase marker))))
 
-(defn- render-terminal
+(defn- ^{:stratum 3} render-terminal
   "`:workflow/completed` / `:workflow/failed` — terminal status with the
    localized terminated marker."
   [event]
@@ -237,7 +250,7 @@
                    "")]
     (format "%s  %s  %s  %s" ts phase marker reason)))
 
-(defn- render-stall
+(defn- ^{:stratum 3} render-stall
   "`:agent/stream-stalled` — stall marker."
   [event]
   (let [ts     (format-hms (event-timestamp event))
@@ -247,7 +260,7 @@
                    (messages/t :timeline/stall-default-msg))]
     (format "%s  %s  %s  %s" ts phase marker msg)))
 
-(defn- render-generic
+(defn- ^{:stratum 3} render-generic
   "Catch-all for event types without a specific renderer."
   [event]
   (let [ts       (format-hms (event-timestamp event))
@@ -256,7 +269,19 @@
         msg      (event-message event)]
     (format "%s  %s  %s  %s" ts phase (str ev-type) (truncate msg args-preview-length))))
 
-(defn- render-event
+;; Gap line rendering
+(defn- ^{:stratum 3} render-gap-line
+  "Format a gap line between two events with timestamps `ts-a` and `ts-b`
+   and a computed gap of `gap-ms` milliseconds."
+  [ts-a ts-b gap-ms]
+  (messages/t :timeline/gap-line
+              {:ts-a (format-hms ts-a)
+               :ts-b (format-hms ts-b)
+               :gap  (format-duration-ms gap-ms)}))
+
+;------------------------------------------------------------------------------ Layer 4
+
+(defn- ^{:stratum 4} render-event
   "Dispatch to the appropriate per-event-type renderer.
 
    `tool-names-by-call-id` is the correlation map render-timeline
@@ -273,37 +298,9 @@
       (= et :tool/call-completed)           (render-tool-call-completed event tool-names-by-call-id)
       :else                                 (render-generic event))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Gap line rendering
+;------------------------------------------------------------------------------ Layer 5
 
-(defn- render-gap-line
-  "Format a gap line between two events with timestamps `ts-a` and `ts-b`
-   and a computed gap of `gap-ms` milliseconds."
-  [ts-a ts-b gap-ms]
-  (messages/t :timeline/gap-line
-              {:ts-a (format-hms ts-a)
-               :ts-b (format-hms ts-b)
-               :gap  (format-duration-ms gap-ms)}))
-
-;------------------------------------------------------------------------------ Layer 3
-;; Public API
-
-(defn- index-tool-names
-  "Build a `{tool-call-id → tool-name}` lookup map from the event stream.
-
-   `:tool/call-completed` events don't carry the tool name (per the
-   `ToolCallCompleted` schema) — the name lives on the paired
-   `:agent/tool-call-started` event. Pre-walk the stream once so the
-   completed-event renderer can look the name up without re-scanning."
-  [events]
-  (->> events
-       (filter #(and (= :agent/tool-call-started (event-type %))
-                     (:tool/call-id %)
-                     (:tool/name %)))
-       (reduce (fn [m e] (assoc m (:tool/call-id e) (:tool/name e)))
-               {})))
-
-(defn render-timeline
+(defn ^{:stratum 5} render-timeline
   "Transform a seq of parsed event maps into a human-readable timeline string.
 
    Each event renders as one line:

--- a/components/event-stream/test/ai/miniforge/event_stream/agent_tool_call_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/agent_tool_call_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.agent-tool-call-test
   "Structured :agent/tool-call events carry the tool name(s) the agent
    just invoked. Replaces the opaque :agent/status :tool-calling pings
@@ -24,9 +23,13 @@
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.event-stream.interface :as es]))
 
-(defn- stream [] (es/create-event-stream {:sinks []}))
+;------------------------------------------------------------------------------ Layer 0
 
-(deftest single-tool-call-carries-name
+(defn- ^{:stratum 0} stream [] (es/create-event-stream {:sinks []}))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} single-tool-call-carries-name
   (testing "single tool name from a Claude-style tool_use block"
     (let [s (stream)
           wf-id (random-uuid)
@@ -38,7 +41,7 @@
       (is (= "tu_abc123" (:tool/call-id ev)))
       (is (= :planner (:agent/id ev))))))
 
-(deftest multi-tool-block-carries-names-vector
+(deftest ^{:stratum 1} multi-tool-block-carries-names-vector
   (testing "Claude assistant block containing multiple tool_use items"
     (let [s (stream)
           ev (es/agent-tool-call s (random-uuid) :planner
@@ -48,7 +51,7 @@
       (is (nil? (:tool/name ev))
           "prefer :tool/names for the multi case"))))
 
-(deftest empty-tool-info-does-not-leak-nil-keys
+(deftest ^{:stratum 1} empty-tool-info-does-not-leak-nil-keys
   (testing "missing tool name/id/args do not emit nil-valued keys"
     (let [s (stream)
           ev (es/agent-tool-call s (random-uuid) :planner {})]
@@ -58,7 +61,7 @@
       (is (not (contains? ev :tool/call-id)))
       (is (not (contains? ev :tool/args-preview))))))
 
-(deftest args-preview-is-bounded
+(deftest ^{:stratum 1} args-preview-is-bounded
   (testing "callers pass a pre-truncated args preview; fn stores it as-is"
     (let [s (stream)
           preview "{:path \"components/agent/src/core.clj\"}"
@@ -68,7 +71,7 @@
       (is (< (count (:tool/args-preview ev)) 1024)
           "preview string stays under 1KB per event-sizing convention"))))
 
-(deftest distinct-event-type-from-agent-status
+(deftest ^{:stratum 1} distinct-event-type-from-agent-status
   (testing ":agent/tool-call is a new event type, NOT :agent/status"
     (let [s (stream)
           wf-id (random-uuid)

--- a/components/event-stream/test/ai/miniforge/event_stream/anomaly/listeners_anomaly_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/anomaly/listeners_anomaly_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.anomaly.listeners-anomaly-test
   "Coverage for `listeners/register-listener!`, `submit-annotation!`,
    and `submit-control-action!` boundary escalation via
@@ -33,9 +32,10 @@
   (:import
    (clojure.lang ExceptionInfo)))
 
-;------------------------------------------------------------------------------ register-listener! — invalid capability
+;------------------------------------------------------------------------------ Layer 0
 
-(deftest register-listener-invalid-capability-throws-anomaly
+;------------------------------------------------------------------------------ register-listener! — invalid capability
+(deftest ^{:stratum 0} register-listener-invalid-capability-throws-anomaly
   (testing "invalid capability raises :anomalies/incorrect via throw-anomaly!"
     (let [stream (es/create-event-stream {:sinks []})]
       (is (thrown-with-msg?
@@ -48,7 +48,7 @@
              :listener/identity {:principal "test"}
              :listener/callback (fn [_])}))))))
 
-(deftest register-listener-invalid-capability-carries-data
+(deftest ^{:stratum 0} register-listener-invalid-capability-carries-data
   (testing "anomaly ex-data carries :capability and :valid set"
     (let [stream (es/create-event-stream {:sinks []})
           thrown (try
@@ -66,8 +66,7 @@
       (is (= :anomalies/incorrect (:anomaly/category (ex-data thrown)))))))
 
 ;------------------------------------------------------------------------------ submit-annotation! — listener not found
-
-(deftest submit-annotation-listener-not-found-throws-anomaly
+(deftest ^{:stratum 0} submit-annotation-listener-not-found-throws-anomaly
   (testing "missing listener raises :anomalies/not-found via throw-anomaly!"
     (let [stream (es/create-event-stream {:sinks []})]
       (is (thrown-with-msg?
@@ -80,8 +79,7 @@
              :annotation/content "test"}))))))
 
 ;------------------------------------------------------------------------------ submit-annotation! — insufficient capability
-
-(deftest submit-annotation-insufficient-capability-throws-anomaly
+(deftest ^{:stratum 0} submit-annotation-insufficient-capability-throws-anomaly
   (testing "observe-only listener cannot submit annotation"
     (let [stream (es/create-event-stream {:sinks []})
           listener-id (es/register-listener!
@@ -99,7 +97,7 @@
             {:annotation/type :warning
              :annotation/content "x"}))))))
 
-(deftest submit-annotation-insufficient-capability-carries-data
+(deftest ^{:stratum 0} submit-annotation-insufficient-capability-carries-data
   (testing "anomaly ex-data carries listener-id + capability + required"
     (let [stream (es/create-event-stream {:sinks []})
           listener-id (es/register-listener!
@@ -123,8 +121,7 @@
       (is (= :anomalies/forbidden (:anomaly/category (ex-data thrown)))))))
 
 ;------------------------------------------------------------------------------ submit-control-action! — listener not found
-
-(deftest submit-control-action-listener-not-found-throws-anomaly
+(deftest ^{:stratum 0} submit-control-action-listener-not-found-throws-anomaly
   (testing "missing listener raises :anomalies/not-found via throw-anomaly!"
     (let [stream (es/create-event-stream {:sinks []})]
       (is (thrown-with-msg?
@@ -137,8 +134,7 @@
             (fn [_] :ok)))))))
 
 ;------------------------------------------------------------------------------ submit-control-action! — insufficient capability
-
-(deftest submit-control-action-insufficient-capability-throws-anomaly
+(deftest ^{:stratum 0} submit-control-action-insufficient-capability-throws-anomaly
   (testing "advise-only listener cannot submit control action"
     (let [stream (es/create-event-stream {:sinks []})
           listener-id (es/register-listener!

--- a/components/event-stream/test/ai/miniforge/event_stream/anomaly/sinks_anomaly_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/anomaly/sinks_anomaly_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.anomaly.sinks-anomaly-test
   "Coverage for `sinks/fleet-sink` and `sinks/create-sink` configuration
    validation.
@@ -32,16 +31,17 @@
   (:import
    (clojure.lang ExceptionInfo)))
 
-;------------------------------------------------------------------------------ fleet-sink missing :url
+;------------------------------------------------------------------------------ Layer 0
 
-(deftest fleet-sink-missing-url-rejects-config
+;------------------------------------------------------------------------------ fleet-sink missing :url
+(deftest ^{:stratum 0} fleet-sink-missing-url-rejects-config
   (testing "fleet-sink without :url throws IllegalArgumentException
             (programmer-error guard per rule 005)"
     (is (thrown-with-msg? IllegalArgumentException
                           #"Fleet sink requires :url"
                           (sinks/fleet-sink {:api-key "k"})))))
 
-(deftest fleet-sink-missing-api-key-rejects-config
+(deftest ^{:stratum 0} fleet-sink-missing-api-key-rejects-config
   (testing "fleet-sink without :api-key throws IllegalArgumentException
             (programmer-error guard per rule 005)"
     (is (thrown-with-msg? IllegalArgumentException
@@ -49,14 +49,13 @@
                           (sinks/fleet-sink {:url "https://fleet.example.com"})))))
 
 ;------------------------------------------------------------------------------ create-sink unknown type
-
-(deftest create-sink-unknown-type-throws-anomaly
+(deftest ^{:stratum 0} create-sink-unknown-type-throws-anomaly
   (testing "unknown map sink type raises :anomalies/unsupported"
     (is (thrown-with-msg? ExceptionInfo
                           #"Unknown sink type"
                           (sinks/create-sink {:type :bogus})))))
 
-(deftest create-sink-unknown-type-carries-data
+(deftest ^{:stratum 0} create-sink-unknown-type-carries-data
   (testing "anomaly ex-data carries :type"
     (let [thrown (try
                    (sinks/create-sink {:type :bogus})
@@ -67,14 +66,13 @@
       (is (= :anomalies/unsupported (:anomaly/category (ex-data thrown)))))))
 
 ;------------------------------------------------------------------------------ create-sink invalid configuration
-
-(deftest create-sink-invalid-config-throws-anomaly
+(deftest ^{:stratum 0} create-sink-invalid-config-throws-anomaly
   (testing "non-map non-vector sink-config raises :anomalies/incorrect"
     (is (thrown-with-msg? ExceptionInfo
                           #"Invalid sink configuration"
                           (sinks/create-sink 42)))))
 
-(deftest create-sink-invalid-config-carries-data
+(deftest ^{:stratum 0} create-sink-invalid-config-carries-data
   (testing "anomaly ex-data carries :config"
     (let [thrown (try
                    (sinks/create-sink "not-a-sink")

--- a/components/event-stream/test/ai/miniforge/event_stream/approval_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/approval_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.approval-test
   (:require
    [clojure.test :refer [deftest testing is]]
@@ -23,11 +22,12 @@
    [ai.miniforge.event-stream.approval :as approval]
    [ai.miniforge.response.interface :as response]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; ============================================================================
 ;; Quorum approval tests
 ;; ============================================================================
-
-(deftest quorum-approval-test
+(deftest ^{:stratum 0} quorum-approval-test
   (testing "quorum of 2 from 3 signers"
     (let [action-id (random-uuid)
           req (es/create-approval-request action-id ["alice" "bob" "carol"] 2)]
@@ -56,8 +56,7 @@
 ;; ============================================================================
 ;; Immediate rejection tests
 ;; ============================================================================
-
-(deftest rejection-test
+(deftest ^{:stratum 0} rejection-test
   (testing "any rejection immediately rejects"
     (let [req (es/create-approval-request (random-uuid) ["alice" "bob" "carol"] 3)
           r (es/submit-approval req "alice" :reject {:reason "Too risky"})]
@@ -68,8 +67,7 @@
 ;; ============================================================================
 ;; Expiry tests
 ;; ============================================================================
-
-(deftest expiry-test
+(deftest ^{:stratum 0} expiry-test
   (testing "check-approval-status detects expiry"
     ;; Backdate :approval/expires-at into the past so it is unambiguously
     ;; expired without waiting for wall-clock time to advance.
@@ -87,8 +85,7 @@
 ;; ============================================================================
 ;; Duplicate signer prevention tests
 ;; ============================================================================
-
-(deftest duplicate-signer-test
+(deftest ^{:stratum 0} duplicate-signer-test
   (testing "same signer cannot sign twice"
     (let [req (es/create-approval-request (random-uuid) ["alice" "bob"] 2)
           r1 (es/submit-approval req "alice" :approve)
@@ -100,8 +97,7 @@
 ;; ============================================================================
 ;; Unauthorized signer tests
 ;; ============================================================================
-
-(deftest unauthorized-signer-test
+(deftest ^{:stratum 0} unauthorized-signer-test
   (testing "unauthorized signer is rejected"
     (let [req (es/create-approval-request (random-uuid) ["alice" "bob"] 1)
           r (es/submit-approval req "eve" :approve)]
@@ -111,8 +107,7 @@
 ;; ============================================================================
 ;; Cancel tests
 ;; ============================================================================
-
-(deftest cancel-test
+(deftest ^{:stratum 0} cancel-test
   (testing "pending request can be cancelled"
     (let [req (es/create-approval-request (random-uuid) ["alice"] 1)
           r (es/cancel-approval req "admin" "No longer needed")]
@@ -129,8 +124,7 @@
 ;; ============================================================================
 ;; Approval manager tests
 ;; ============================================================================
-
-(deftest approval-manager-test
+(deftest ^{:stratum 0} approval-manager-test
   (testing "store and retrieve approval"
     (let [mgr (es/create-approval-manager)
           req (es/create-approval-request (random-uuid) ["alice"] 1)]
@@ -159,8 +153,7 @@
 ;; ============================================================================
 ;; Event emission tests
 ;; ============================================================================
-
-(deftest approval-events-test
+(deftest ^{:stratum 0} approval-events-test
   (testing "approval event constructors create correct events"
     (let [stream (es/create-event-stream {:sinks []})
           wf-id (random-uuid)
@@ -192,8 +185,7 @@
 ;; ============================================================================
 ;; Control action integration tests
 ;; ============================================================================
-
-(deftest control-action-with-approval-test
+(deftest ^{:stratum 0} control-action-with-approval-test
   (testing "gate-override requires approval"
     (is (true? (es/requires-approval? :gate-override)))
     (is (true? (es/requires-approval? :budget-escalation))))

--- a/components/event-stream/test/ai/miniforge/event_stream/archive_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/archive_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.archive-test
   "Tests for the BD-2b sub-3b atomic archive operation."
   (:require
@@ -28,9 +27,10 @@
   (:import
    [java.util UUID]))
 
-;------------------------------------------------------------------------------ Helpers
+;------------------------------------------------------------------------------ Layer 0
 
-(defn- with-temp-base [f]
+;------------------------------------------------------------------------------ Helpers
+(defn- ^{:stratum 0} with-temp-base [f]
   (let [dir (java.nio.file.Files/createTempDirectory
              "archive-test-"
              (into-array java.nio.file.attribute.FileAttribute []))]
@@ -40,10 +40,10 @@
         (doseq [file (reverse (file-seq (.toFile dir)))]
           (try (.delete ^java.io.File file) (catch Exception _)))))))
 
-(def ^:private test-workflow-id
+(def ^{:stratum 0} ^:private test-workflow-id
   (UUID/fromString "00000000-0000-0000-0000-000000000abc"))
 
-(defn- seed-live-workflow!
+(defn- ^{:stratum 0} seed-live-workflow!
   "Set up a live/{wid}/ directory with a fresh :active / :live
    manifest. Returns the live dir. Optional :extras let tests add
    sentinel event files so the rename can be verified end-to-end."
@@ -58,12 +58,13 @@
        (spit (io/file live "snapshot.transit.json.tmp") snapshot-tmp))
      live)))
 
-(defn- archived-dir-for [base wid]
+(defn- ^{:stratum 0} archived-dir-for [base wid]
   (sinks/archived-workflow-dir base wid))
 
-;------------------------------------------------------------------------------ archive-workflow! happy path
+;------------------------------------------------------------------------------ Layer 1
 
-(deftest archive-workflow!-renames-live-to-archived
+;------------------------------------------------------------------------------ archive-workflow! happy path
+(deftest ^{:stratum 1} archive-workflow!-renames-live-to-archived
   (with-temp-base
     (fn [base]
       (seed-live-workflow! base test-workflow-id
@@ -80,7 +81,7 @@
         (is (.exists (io/file archived "archived.marker"))
             "archived.marker is touched as step 7")))))
 
-(deftest archive-workflow!-transitions-manifest-to-archived
+(deftest ^{:stratum 1} archive-workflow!-transitions-manifest-to-archived
   (with-temp-base
     (fn [base]
       (seed-live-workflow! base test-workflow-id)
@@ -91,7 +92,7 @@
         (is (some? (:archived_at m))
             "archived_at must be stamped at step 7")))))
 
-(deftest archive-workflow!-accepts-snapshot-watermark
+(deftest ^{:stratum 1} archive-workflow!-accepts-snapshot-watermark
   (with-temp-base
     (fn [base]
       (seed-live-workflow! base test-workflow-id)
@@ -106,7 +107,7 @@
         (is (= "018f3a9c8e4b12d0"
                (get-in m [:snapshot_watermark :last_event_id])))))))
 
-(deftest archive-workflow!-tolerates-absent-snapshot-tmp
+(deftest ^{:stratum 1} archive-workflow!-tolerates-absent-snapshot-tmp
   ;; Sub-3c will write `snapshot.transit.json.tmp` before invoking
   ;; archive; sub-3b must not require it. Without the tmp, the
   ;; archive completes and `snapshot_status` stays `:none`.
@@ -119,7 +120,7 @@
             "no snapshot file when no tmp was staged")
         (is (= :none (:snapshot_status (manifest/load-manifest archived))))))))
 
-(deftest archive-workflow!-renames-snapshot-tmp-to-final
+(deftest ^{:stratum 1} archive-workflow!-renames-snapshot-tmp-to-final
   (with-temp-base
     (fn [base]
       (seed-live-workflow! base test-workflow-id
@@ -135,7 +136,7 @@
         (is (false? (.exists tmp))
             "tmp must be gone after the rename")))))
 
-(deftest archive-workflow!-throws-when-no-manifest
+(deftest ^{:stratum 1} archive-workflow!-throws-when-no-manifest
   (with-temp-base
     (fn [base]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
@@ -143,7 +144,7 @@
                             (archive/archive-workflow!
                              test-workflow-id {:base-dir base}))))))
 
-(deftest archive-workflow!-returns-manifest-save-anomaly
+(deftest ^{:stratum 1} archive-workflow!-returns-manifest-save-anomaly
   (with-temp-base
     (fn [base]
       (let [live (seed-live-workflow! base test-workflow-id)
@@ -161,8 +162,7 @@
             "archive side effects stop when manifest validation returns an anomaly")))))
 
 ;------------------------------------------------------------------------------ recover-incomplete-archive!
-
-(deftest recover-incomplete-archive!-finishes-archiving-state
+(deftest ^{:stratum 1} recover-incomplete-archive!-finishes-archiving-state
   ;; Live dir still exists, manifest is at :archiving. Simulates a
   ;; crash between steps 4 and 6. Recovery should atomic-rename and
   ;; complete the marker.
@@ -180,7 +180,7 @@
               "marker must be touched by the recovery")
           (is (= :archived (:archive_status (manifest/load-manifest archived)))))))))
 
-(deftest recover-incomplete-archive!-finishes-missing-marker
+(deftest ^{:stratum 1} recover-incomplete-archive!-finishes-missing-marker
   ;; Live dir is already gone, archived dir exists but no marker.
   ;; Simulates a crash between steps 6 and 7.
   (with-temp-base
@@ -199,7 +199,7 @@
             "missing marker is touched by the recovery")
         (is (= :archived (:archive_status (manifest/load-manifest archived))))))))
 
-(deftest recover-incomplete-archive!-is-no-op-when-no-recovery-needed
+(deftest ^{:stratum 1} recover-incomplete-archive!-is-no-op-when-no-recovery-needed
   ;; Both dirs absent (or both clean) — recovery returns nil and
   ;; doesn't error.
   (with-temp-base
@@ -207,8 +207,7 @@
       (is (nil? (archive/recover-incomplete-archive! base test-workflow-id))))))
 
 ;------------------------------------------------------------------------------ scan-incomplete-archives / recover-all-incomplete!
-
-(deftest scan-incomplete-archives-classifies-correctly
+(deftest ^{:stratum 1} scan-incomplete-archives-classifies-correctly
   (with-temp-base
     (fn [base]
       (let [wid-archiving  (UUID/fromString "00000000-0000-0000-0000-000000000001")
@@ -237,7 +236,7 @@
           (is (= 2 (count scanned))
               "clean live workflow must not show up as incomplete"))))))
 
-(deftest recover-all-incomplete!-runs-recovery-for-each
+(deftest ^{:stratum 1} recover-all-incomplete!-runs-recovery-for-each
   (with-temp-base
     (fn [base]
       (let [wid-a (UUID/fromString "00000000-0000-0000-0000-0000000000aa")
@@ -256,7 +255,7 @@
         (is (.exists (io/file (archived-dir-for base wid-a) "archived.marker")))
         (is (.exists (io/file (archived-dir-for base wid-b) "archived.marker")))))))
 
-(deftest recover-all-incomplete!-propagates-recovery-anomaly
+(deftest ^{:stratum 1} recover-all-incomplete!-propagates-recovery-anomaly
   (with-temp-base
     (fn [base]
       (let [wid (UUID/fromString "00000000-0000-0000-0000-0000000000cc")

--- a/components/event-stream/test/ai/miniforge/event_stream/control_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/control_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.control-test
   (:require
    [clojure.test :refer [deftest testing is]]
@@ -24,34 +23,34 @@
    [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Control state primitive tests
 
-(deftest create-control-state-test
+;; Control state primitive tests
+(deftest ^{:stratum 0} create-control-state-test
   (testing "returns atom with expected shape"
     (let [cs (control/create-control-state)]
       (is (instance? clojure.lang.Atom cs))
       (is (= {:paused false :stopped false :adjustments {}} @cs)))))
 
-(deftest pause!-test
+(deftest ^{:stratum 0} pause!-test
   (testing "sets :paused to true"
     (let [cs (control/create-control-state)]
       (control/pause! cs)
       (is (true? (:paused @cs))))))
 
-(deftest resume!-test
+(deftest ^{:stratum 0} resume!-test
   (testing "sets :paused to false"
     (let [cs (control/create-control-state)]
       (control/pause! cs)
       (control/resume! cs)
       (is (false? (:paused @cs))))))
 
-(deftest cancel!-test
+(deftest ^{:stratum 0} cancel!-test
   (testing "sets :stopped to true"
     (let [cs (control/create-control-state)]
       (control/cancel! cs)
       (is (true? (:stopped @cs))))))
 
-(deftest paused?-test
+(deftest ^{:stratum 0} paused?-test
   (testing "returns correct value"
     (let [cs (control/create-control-state)]
       (is (false? (control/paused? cs)))
@@ -60,14 +59,14 @@
       (control/resume! cs)
       (is (false? (control/paused? cs))))))
 
-(deftest cancelled?-test
+(deftest ^{:stratum 0} cancelled?-test
   (testing "returns correct value"
     (let [cs (control/create-control-state)]
       (is (false? (control/cancelled? cs)))
       (control/cancel! cs)
       (is (true? (control/cancelled? cs))))))
 
-(deftest control-state-interface-delegation-test
+(deftest ^{:stratum 0} control-state-interface-delegation-test
   (testing "interface delegates to control functions"
     (let [cs (es/create-control-state)]
       (is (false? (es/paused? cs)))
@@ -79,10 +78,8 @@
       (es/cancel! cs)
       (is (true? (es/cancelled? cs))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; RBAC and control action tests
-
-(deftest create-control-action-test
+(deftest ^{:stratum 0} create-control-action-test
   (testing "creates action with required fields"
     (let [action (es/create-control-action
                   :pause
@@ -104,7 +101,7 @@
       (is (= "Deployment failed" (:action/justification action)))
       (is (= {:to-commit "abc123"} (:action/parameters action))))))
 
-(deftest authorize-action-test
+(deftest ^{:stratum 0} authorize-action-test
   (testing "operator can pause workflow"
     (let [action (es/create-control-action
                   :pause
@@ -170,7 +167,7 @@
       (is (false? (:authorized? result)))
       (is (response/anomaly-map? (:anomaly result))))))
 
-(deftest execute-control-action-test
+(deftest ^{:stratum 0} execute-control-action-test
   (testing "successful execution emits events and returns success"
     (let [stream (es/create-event-stream {:sinks []})
           events (atom [])
@@ -203,7 +200,7 @@
       (is (false? (:success result)))
       (is (string? (get-in result [:error :message]))))))
 
-(deftest default-roles-test
+(deftest ^{:stratum 0} default-roles-test
   (testing "operator has expected workflow permissions"
     (is (= #{:pause :resume :retry :cancel}
            (get-in control/default-roles [:operator :workflows]))))

--- a/components/event-stream/test/ai/miniforge/event_stream/core_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/core_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.core-test
   "Direct unit tests for event-stream core — chain events, error handling,
    OCI events, control-plane events, and sink integration."
@@ -26,14 +25,15 @@
    [ai.miniforge.response.interface :as response]
    [ai.miniforge.event-stream.core :as core]))
 
-;------------------------------------------------------------------------------ Helpers
+;------------------------------------------------------------------------------ Layer 0
 
-(defn no-op-stream
+;------------------------------------------------------------------------------ Helpers
+(defn ^{:stratum 0} no-op-stream
   "Create an event stream with no sinks for isolated testing."
   []
   (core/create-event-stream {:sinks []}))
 
-(defn collect-stream
+(defn ^{:stratum 0} collect-stream
   "Create an event stream with a collecting sink for verifying sink calls."
   []
   (let [collected (atom [])
@@ -41,10 +41,74 @@
         stream (core/create-event-stream {:sinks [sink]})]
     {:stream stream :collected collected}))
 
-;------------------------------------------------------------------------------ Layer 0
-;; create-envelope
+(deftest ^{:stratum 0} create-envelope-propagates-snowflake-anomaly
+  (let [generator {:state     (atom {:last-ts -1
+                                     :last-seq -1
+                                     :worker-id 0})
+                   :worker-id 0
+                   :lease     {:worker-id 0}
+                   :now-fn    (constantly 0)}
+        stream (core/create-event-stream {:sinks []
+                                          :snowflake-generator generator})
+        result (core/create-envelope stream :test/event (random-uuid) "hello")]
+    (is (response/anomaly-map? result))
+    (is (= :anomalies/incorrect (:anomaly/category result)))
+    (is (= :pre-epoch-clock (:reason result)))))
 
-(deftest create-envelope-test
+(deftest ^{:stratum 0} create-envelope-propagates-anomaly-generator
+  (let [generator-anomaly (response/make-anomaly
+                           :anomalies/busy
+                           "No worker slots"
+                           {:reason :workers-exhausted})
+        stream (core/create-event-stream {:sinks []
+                                          :snowflake-generator generator-anomaly})
+        result (core/create-envelope stream :test/event (random-uuid) "hello")]
+    (is (identical? generator-anomaly result))))
+
+(deftest ^{:stratum 0} create-envelope-does-not-consume-sequence-on-id-anomaly
+  (let [wf-id (random-uuid)
+        generator {:state     (atom {:last-ts -1
+                                     :last-seq -1
+                                     :worker-id 0})
+                   :worker-id 0
+                   :lease     {:worker-id 0}
+                   :now-fn    (constantly 0)}
+        stream (core/create-event-stream {:sinks []
+                                          :snowflake-generator generator})
+        result (core/create-envelope stream :test/event wf-id "bad")]
+    (is (response/anomaly-map? result))
+    (swap! stream dissoc :snowflake-generator)
+    (is (= 0 (:event/sequence-number
+              (core/create-envelope stream :test/event wf-id "good"))))))
+
+(deftest ^{:stratum 0} publish-sink-error-handling-test
+  (testing "publish! continues when a sink throws"
+    (let [good-received (atom [])
+          bad-sink (fn [_] (throw (Exception. "sink boom")))
+          good-sink (fn [e] (swap! good-received conj e))
+          stream (core/create-event-stream {:sinks [bad-sink good-sink]})
+          event (core/create-envelope stream :test/err (random-uuid) "error test")]
+      (core/publish! stream event)
+      ;; Event still stored in memory and good sink received it
+      (is (= 1 (count (:events @stream))))
+      (is (= 1 (count @good-received))))))
+
+;; Dependency health event constructors
+(defn- ^{:stratum 0} dependency-health-entity
+  [overrides]
+  (merge {:dependency/id :anthropic
+          :dependency/source :external-provider
+          :dependency/kind :provider
+          :dependency/status :degraded
+          :dependency/failure-count 1
+          :dependency/window-size 5
+          :dependency/incident-counts {:degraded 1}}
+         overrides))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; create-envelope
+(deftest ^{:stratum 1} create-envelope-test
   (testing "produces well-formed event map"
     (let [stream (no-op-stream)
           wf-id (random-uuid)
@@ -84,10 +148,8 @@
       (is (nil? (:workflow/id env)))
       (is (= 0 (:event/sequence-number env))))))
 
-;------------------------------------------------------------------------------ Layer 0
 ;; knowledge failure constructors
-
-(deftest knowledge-promotion-failed-accepts-failure-data-test
+(deftest ^{:stratum 1} knowledge-promotion-failed-accepts-failure-data-test
   (testing "promotion failure event can be built from error data without ex-info"
     (let [stream (no-op-stream)
           event (core/knowledge-promotion-failed stream
@@ -98,7 +160,7 @@
       (is (= "Knowledge promotion failed: promotion blocked"
              (:message event))))))
 
-(deftest knowledge-failure-constructors-preserve-throwable-messages-test
+(deftest ^{:stratum 1} knowledge-failure-constructors-preserve-throwable-messages-test
   (testing "existing Throwable callers keep the same message behavior"
     (let [stream (no-op-stream)
           err (ex-info "synthesis failed" {:cause :test})
@@ -106,50 +168,8 @@
       (is (= :knowledge/synthesis-failed (:event/type event)))
       (is (= "synthesis failed" (:knowledge/error event))))))
 
-(deftest create-envelope-propagates-snowflake-anomaly
-  (let [generator {:state     (atom {:last-ts -1
-                                     :last-seq -1
-                                     :worker-id 0})
-                   :worker-id 0
-                   :lease     {:worker-id 0}
-                   :now-fn    (constantly 0)}
-        stream (core/create-event-stream {:sinks []
-                                          :snowflake-generator generator})
-        result (core/create-envelope stream :test/event (random-uuid) "hello")]
-    (is (response/anomaly-map? result))
-    (is (= :anomalies/incorrect (:anomaly/category result)))
-    (is (= :pre-epoch-clock (:reason result)))))
-
-(deftest create-envelope-propagates-anomaly-generator
-  (let [generator-anomaly (response/make-anomaly
-                           :anomalies/busy
-                           "No worker slots"
-                           {:reason :workers-exhausted})
-        stream (core/create-event-stream {:sinks []
-                                          :snowflake-generator generator-anomaly})
-        result (core/create-envelope stream :test/event (random-uuid) "hello")]
-    (is (identical? generator-anomaly result))))
-
-(deftest create-envelope-does-not-consume-sequence-on-id-anomaly
-  (let [wf-id (random-uuid)
-        generator {:state     (atom {:last-ts -1
-                                     :last-seq -1
-                                     :worker-id 0})
-                   :worker-id 0
-                   :lease     {:worker-id 0}
-                   :now-fn    (constantly 0)}
-        stream (core/create-event-stream {:sinks []
-                                          :snowflake-generator generator})
-        result (core/create-envelope stream :test/event wf-id "bad")]
-    (is (response/anomaly-map? result))
-    (swap! stream dissoc :snowflake-generator)
-    (is (= 0 (:event/sequence-number
-              (core/create-envelope stream :test/event wf-id "good"))))))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; publish! sink integration
-
-(deftest publish-calls-sinks-test
+(deftest ^{:stratum 1} publish-calls-sinks-test
   (testing "publish! calls all configured sinks"
     (let [{:keys [stream collected]} (collect-stream)
           event (core/create-envelope stream :test/sink (random-uuid) "sink test")]
@@ -157,7 +177,7 @@
       (is (= 1 (count @collected)))
       (is (= :test/sink (:event/type (first @collected)))))))
 
-(deftest publish-returns-anomaly-without-delivery
+(deftest ^{:stratum 1} publish-returns-anomaly-without-delivery
   (let [{:keys [stream collected]} (collect-stream)
         anomaly (response/make-anomaly
                  :anomalies/incorrect
@@ -168,19 +188,7 @@
     (is (empty? @collected))
     (is (empty? (:events @stream)))))
 
-(deftest publish-sink-error-handling-test
-  (testing "publish! continues when a sink throws"
-    (let [good-received (atom [])
-          bad-sink (fn [_] (throw (Exception. "sink boom")))
-          good-sink (fn [e] (swap! good-received conj e))
-          stream (core/create-event-stream {:sinks [bad-sink good-sink]})
-          event (core/create-envelope stream :test/err (random-uuid) "error test")]
-      (core/publish! stream event)
-      ;; Event still stored in memory and good sink received it
-      (is (= 1 (count (:events @stream))))
-      (is (= 1 (count @good-received))))))
-
-(deftest publish-subscriber-error-handling-test
+(deftest ^{:stratum 1} publish-subscriber-error-handling-test
   (testing "publish! continues when a subscriber callback throws"
     (let [stream (no-op-stream)
           received (atom [])]
@@ -191,10 +199,8 @@
         ;; Good subscriber still received the event
         (is (= 1 (count @received)))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; subscribe! and unsubscribe!
-
-(deftest subscribe-with-filter-test
+(deftest ^{:stratum 1} subscribe-with-filter-test
   (testing "subscriber with filter only receives matching events"
     (let [stream (no-op-stream)
           wf-id (random-uuid)
@@ -207,7 +213,7 @@
       (is (= 1 (count @received)))
       (is (= :special (:event/type (first @received)))))))
 
-(deftest unsubscribe-test
+(deftest ^{:stratum 1} unsubscribe-test
   (testing "unsubscribed callback no longer receives events"
     (let [stream (no-op-stream)
           received (atom [])]
@@ -217,10 +223,8 @@
       (core/publish! stream (core/create-envelope stream :b (random-uuid) "after"))
       (is (= 1 (count @received))))))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Query API
-
-(deftest get-events-combined-filters-test
+(deftest ^{:stratum 1} get-events-combined-filters-test
   (testing "workflow-id + event-type filters compose"
     (let [stream (no-op-stream)
           wf-1 (random-uuid)
@@ -233,7 +237,7 @@
         (is (= 1 (count results)))
         (is (= wf-1 (:workflow/id (first results))))))))
 
-(deftest get-latest-status-nil-agent-test
+(deftest ^{:stratum 1} get-latest-status-nil-agent-test
   (testing "get-latest-status with nil agent-id returns latest status across agents"
     (let [stream (no-op-stream)
           wf-id (random-uuid)]
@@ -242,10 +246,8 @@
       (let [latest (core/get-latest-status stream wf-id)]
         (is (= :generating (:status/type latest)))))))
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Chain event constructors
-
-(deftest workflow-started-routing-trigger-event-id-test
+(deftest ^{:stratum 1} workflow-started-routing-trigger-event-id-test
   (testing "2-arg and 3-arg call shapes preserved (backward compat)"
     (let [stream (no-op-stream)
           wf-id  (random-uuid)
@@ -277,7 +279,7 @@
           (str "nil opts value must not pollute the envelope — N5-delta-4 §4.3 "
                "leaves the field optional/absent on operator-initiated workflows")))))
 
-(deftest chain-envelope-test
+(deftest ^{:stratum 1} chain-envelope-test
   (testing "chain-envelope uses nil workflow-id and event-type as message"
     (let [stream (no-op-stream)
           env (core/chain-envelope stream :chain/started)]
@@ -285,7 +287,7 @@
       (is (nil? (:workflow/id env)))
       (is (= "started" (:message env))))))
 
-(deftest chain-started-test
+(deftest ^{:stratum 1} chain-started-test
   (testing "chain-started includes chain-id and step-count"
     (let [stream (no-op-stream)
           chain-id (random-uuid)
@@ -294,7 +296,7 @@
       (is (= chain-id (:chain/id event)))
       (is (= 5 (:chain/step-count event))))))
 
-(deftest chain-step-started-test
+(deftest ^{:stratum 1} chain-step-started-test
   (testing "chain-step-started includes step metadata"
     (let [stream (no-op-stream)
           chain-id (random-uuid)
@@ -307,14 +309,14 @@
       (is (= 0 (:step/index event)))
       (is (= wf-id (:step/workflow-id event))))))
 
-(deftest chain-step-completed-test
+(deftest ^{:stratum 1} chain-step-completed-test
   (testing "chain-step-completed captures step index"
     (let [stream (no-op-stream)
           event (core/chain-step-completed stream (random-uuid) :implement 1)]
       (is (= :chain/step-completed (:event/type event)))
       (is (= 1 (:step/index event))))))
 
-(deftest chain-step-failed-test
+(deftest ^{:stratum 1} chain-step-failed-test
   (testing "chain-step-failed captures error"
     (let [stream (no-op-stream)
           error {:message "compilation failed"}
@@ -322,7 +324,7 @@
       (is (= :chain/step-failed (:event/type event)))
       (is (= error (:chain/error event))))))
 
-(deftest chain-completed-test
+(deftest ^{:stratum 1} chain-completed-test
   (testing "chain-completed captures duration and step count"
     (let [stream (no-op-stream)
           chain-id (random-uuid)
@@ -332,7 +334,7 @@
       (is (= 12000 (:chain/duration-ms event)))
       (is (= 3 (:chain/step-count event))))))
 
-(deftest chain-failed-test
+(deftest ^{:stratum 1} chain-failed-test
   (testing "chain-failed captures failed step and error"
     (let [stream (no-op-stream)
           chain-id (random-uuid)
@@ -342,10 +344,8 @@
       (is (= :review (:chain/failed-step event)))
       (is (= {:message "timeout"} (:chain/error event))))))
 
-;------------------------------------------------------------------------------ Layer 4
 ;; OCI container events
-
-(deftest container-started-test
+(deftest ^{:stratum 1} container-started-test
   (testing "container-started creates event with container-id"
     (let [stream (no-op-stream)
           wf-id (random-uuid)
@@ -361,7 +361,7 @@
       (is (= "sha256:abc" (:oci/image-digest event)))
       (is (= :verified (:oci/trust-level event))))))
 
-(deftest container-completed-test
+(deftest ^{:stratum 1} container-completed-test
   (testing "container-completed captures exit code"
     (let [stream (no-op-stream)
           event (core/container-completed stream (random-uuid) "ctr-789" 0 5000)]
@@ -375,10 +375,8 @@
       (is (= 1 (:oci/exit-code event)))
       (is (nil? (:oci/duration-ms event))))))
 
-;------------------------------------------------------------------------------ Layer 4
 ;; Tool supervision events
-
-(deftest tool-use-evaluated-test
+(deftest ^{:stratum 1} tool-use-evaluated-test
   (testing "basic tool evaluation event"
     (let [stream (no-op-stream)
           event (core/tool-use-evaluated stream (random-uuid) "file-write" :allow)]
@@ -398,10 +396,8 @@
       (is (= 0.95 (:supervision/confidence event)))
       (is (= :implement (:workflow/phase event))))))
 
-;------------------------------------------------------------------------------ Layer 5
 ;; Control plane events
-
-(deftest cp-agent-registered-test
+(deftest ^{:stratum 1} cp-agent-registered-test
   (testing "creates registration event"
     (let [stream (no-op-stream)
           event (core/cp-agent-registered stream (random-uuid) "agent-1" :anthropic)]
@@ -429,7 +425,7 @@
       (is (= [:native] (:cp/tags event)))
       (is (= 15000 (:cp/heartbeat-interval-ms event))))))
 
-(deftest cp-agent-heartbeat-test
+(deftest ^{:stratum 1} cp-agent-heartbeat-test
   (testing "creates heartbeat event"
     (let [stream (no-op-stream)
           event (core/cp-agent-heartbeat stream (random-uuid) "agent-1" :active)]
@@ -445,7 +441,7 @@
       (is (= "Reviewing PR" (:cp/task event)))
       (is (= {:tokens 42} (:cp/metrics event))))))
 
-(deftest cp-agent-state-changed-test
+(deftest ^{:stratum 1} cp-agent-state-changed-test
   (testing "creates state-change event with from/to"
     (let [stream (no-op-stream)
           event (core/cp-agent-state-changed stream (random-uuid) "agent-1" :idle :active)]
@@ -453,7 +449,7 @@
       (is (= :idle (:cp/from-status event)))
       (is (= :active (:cp/to-status event))))))
 
-(deftest cp-decision-created-test
+(deftest ^{:stratum 1} cp-decision-created-test
   (testing "creates decision event"
     (let [stream (no-op-stream)
           decision-id (random-uuid)
@@ -480,7 +476,7 @@
       (is (= ["blue" "green"] (:cp/options event)))
       (is (= deadline (:cp/deadline event))))))
 
-(deftest cp-decision-resolved-test
+(deftest ^{:stratum 1} cp-decision-resolved-test
   (testing "creates resolved event"
     (let [stream (no-op-stream)
           decision-id (random-uuid)
@@ -497,7 +493,7 @@
                                            "Matches rollout plan")]
       (is (= "Matches rollout plan" (:cp/comment event))))))
 
-(deftest intervention-requested-test
+(deftest ^{:stratum 1} intervention-requested-test
   (testing "creates supervisory intervention requested event"
     (let [stream (no-op-stream)
           workflow-id (random-uuid)
@@ -518,7 +514,7 @@
       (is (= (messages/t :supervisory/intervention-requested {:type "pause"})
              (:message event))))))
 
-(deftest intervention-state-changed-test
+(deftest ^{:stratum 1} intervention-state-changed-test
   (testing "creates supervisory intervention lifecycle event"
     (let [stream (no-op-stream)
           intervention-id (random-uuid)
@@ -540,10 +536,8 @@
                           :state "applied"})
              (:message event))))))
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Workflow failed edge cases
-
-(deftest workflow-failed-with-exception-test
+(deftest ^{:stratum 1} workflow-failed-with-exception-test
   (testing "workflow-failed from Throwable extracts message and type"
     (let [stream (no-op-stream)
           wf-id (random-uuid)
@@ -553,7 +547,7 @@
       (is (string? (:workflow/failure-reason event)))
       (is (map? (:workflow/error-details event))))))
 
-(deftest workflow-failed-with-plain-map-test
+(deftest ^{:stratum 1} workflow-failed-with-plain-map-test
   (testing "workflow-failed from plain error map"
     (let [stream (no-op-stream)
           wf-id (random-uuid)
@@ -561,10 +555,8 @@
       (is (= :workflow/failed (:event/type event)))
       (is (= "API error" (:workflow/failure-reason event))))))
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Phase completed transition request
-
-(deftest phase-completed-transition-request-test
+(deftest ^{:stratum 1} phase-completed-transition-request-test
   (testing "phase-completed preserves transition requests and legacy redirect projection"
     (let [stream (no-op-stream)
           wf-id (random-uuid)
@@ -577,7 +569,7 @@
              (get-in event [:phase/transition-request :transition/target])))
       (is (= :implement (:phase/redirect-to event))))))
 
-(deftest phase-completed-with-error-test
+(deftest ^{:stratum 1} phase-completed-with-error-test
   (testing "phase-completed captures error details"
     (let [stream (no-op-stream)
           wf-id (random-uuid)
@@ -588,21 +580,7 @@
       (is (= :failure (:phase/outcome event)))
       (is (= {:message "compile error" :line 42} (:phase/error event))))))
 
-;------------------------------------------------------------------------------ Layer 3
-;; Dependency health event constructors
-
-(defn- dependency-health-entity
-  [overrides]
-  (merge {:dependency/id :anthropic
-          :dependency/source :external-provider
-          :dependency/kind :provider
-          :dependency/status :degraded
-          :dependency/failure-count 1
-          :dependency/window-size 5
-          :dependency/incident-counts {:degraded 1}}
-         overrides))
-
-(deftest dependency-health-updated-test
+(deftest ^{:stratum 1} dependency-health-updated-test
   (testing "dependency-health-updated carries dependency projection and prior status"
     (let [stream (no-op-stream)
           dependency (dependency-health-entity {})
@@ -616,7 +594,7 @@
                           :status "degraded"})
              (:message event))))))
 
-(deftest dependency-recovered-test
+(deftest ^{:stratum 1} dependency-recovered-test
   (testing "dependency-recovered carries healthy projection and prior status"
     (let [stream (no-op-stream)
           dependency (dependency-health-entity {:dependency/status :healthy
@@ -631,10 +609,8 @@
                           :status "healthy"})
              (:message event))))))
 
-;------------------------------------------------------------------------------ Layer 9
 ;; Routing trigger events (N5-delta-4 §4.2)
-
-(deftest pr-monitor-review-comments-arrived-test
+(deftest ^{:stratum 1} pr-monitor-review-comments-arrived-test
   (testing "without :comments/agent-session-id (shorter overload)"
     (let [stream (no-op-stream)
           event  (core/pr-monitor-review-comments-arrived
@@ -652,7 +628,7 @@
                        stream "miniforge-ai/miniforge" 999 3 session-id)]
       (is (= session-id (:comments/agent-session-id event))))))
 
-(deftest pr-monitor-ci-failed-test
+(deftest ^{:stratum 1} pr-monitor-ci-failed-test
   (testing "carries pr/repo, pr/number, ci/check-name, ci/conclusion"
     (let [stream (no-op-stream)
           event  (core/pr-monitor-ci-failed stream "miniforge-ai/miniforge"
@@ -663,7 +639,7 @@
       (is (= "tests" (:ci/check-name event)))
       (is (= :failure (:ci/conclusion event))))))
 
-(deftest standards-review-posted-test
+(deftest ^{:stratum 1} standards-review-posted-test
   (testing "without :affected/workflow-run-id (shorter overload)"
     (let [stream (no-op-stream)
           event  (core/standards-review-posted

--- a/components/event-stream/test/ai/miniforge/event_stream/digest_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/digest_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.digest-test
   "Tests for the content-digest utility."
   (:require
@@ -24,58 +23,74 @@
   (:import
    [java.nio.charset StandardCharsets]))
 
-(def ^:private empty-content "")
-(def ^:private hello-content "hello")
-(def ^:private multibyte-content "héllo")
-(def ^:private short-content "short content")
-(def ^:private fox-content "the quick brown fox")
-(def ^:private deterministic-content "deterministic test string")
-(def ^:private two-byte-codepoint "é")
-(def ^:private two-byte-codepoint-width 2)
-(def ^:private emoji-codepoint "😀")
-(def ^:private emoji-codepoint-width 4)
-(def ^:private empty-sha256
-  "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
-(def ^:private hello-sha256
-  "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824")
-(def ^:private lowercase-hex-shape #"^[0-9a-f]+$")
-(def ^:private sample-map {:tool/name "Read" :file "/foo.clj"})
+;------------------------------------------------------------------------------ Layer 0
 
-(defn- utf8-size
+(def ^{:stratum 0} ^:private empty-content "")
+
+(def ^{:stratum 0} ^:private hello-content "hello")
+
+(def ^{:stratum 0} ^:private multibyte-content "héllo")
+
+(def ^{:stratum 0} ^:private short-content "short content")
+
+(def ^{:stratum 0} ^:private fox-content "the quick brown fox")
+
+(def ^{:stratum 0} ^:private deterministic-content "deterministic test string")
+
+(def ^{:stratum 0} ^:private two-byte-codepoint "é")
+
+(def ^{:stratum 0} ^:private two-byte-codepoint-width 2)
+
+(def ^{:stratum 0} ^:private emoji-codepoint "😀")
+
+(def ^{:stratum 0} ^:private emoji-codepoint-width 4)
+
+(def ^{:stratum 0} ^:private empty-sha256
+  "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+
+(def ^{:stratum 0} ^:private hello-sha256
+  "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824")
+
+(def ^{:stratum 0} ^:private lowercase-hex-shape #"^[0-9a-f]+$")
+
+(def ^{:stratum 0} ^:private sample-map {:tool/name "Read" :file "/foo.clj"})
+
+(defn- ^{:stratum 0} utf8-size
   [^String s]
   (alength (.getBytes s StandardCharsets/UTF_8)))
 
-;------------------------------------------------------------------------------ happy path
+;------------------------------------------------------------------------------ Layer 1
 
-(deftest returns-required-keys
+;------------------------------------------------------------------------------ happy path
+(deftest ^{:stratum 1} returns-required-keys
   (testing "digest-content always returns all three keys"
     (let [result (digest/digest-content hello-content)]
       (is (contains? result :digest/preview))
       (is (contains? result :digest/sha256))
       (is (contains? result :digest/original-size)))))
 
-(deftest known-sha256-for-empty-string
+(deftest ^{:stratum 1} known-sha256-for-empty-string
   (testing "SHA-256 of empty string matches well-known value"
     (let [{:keys [:digest/sha256]} (digest/digest-content empty-content)]
       (is (= empty-sha256 sha256)))))
 
-(deftest known-sha256-for-hello
+(deftest ^{:stratum 1} known-sha256-for-hello
   (testing "SHA-256 of 'hello' matches well-known value"
     (let [{:keys [:digest/sha256]} (digest/digest-content hello-content)]
       (is (= hello-sha256 sha256)))))
 
-(deftest original-size-matches-utf8-byte-length
+(deftest ^{:stratum 1} original-size-matches-utf8-byte-length
   (testing "original-size is the byte count, not char count"
     (let [result (digest/digest-content multibyte-content)]
       (is (= (utf8-size multibyte-content) (:digest/original-size result))))))
 
-(deftest preview-capped-at-max-preview-bytes
+(deftest ^{:stratum 1} preview-capped-at-max-preview-bytes
   (testing "preview is at most max-preview-bytes regardless of input length"
     (let [big    (apply str (repeat (* 2 digest/max-preview-bytes) "x"))
           result (digest/digest-content big)]
       (is (= digest/max-preview-bytes (utf8-size (:digest/preview result)))))))
 
-(deftest preview-capped-by-utf8-byte-length
+(deftest ^{:stratum 1} preview-capped-by-utf8-byte-length
   (testing "preview cap counts UTF-8 bytes instead of characters"
     (let [content (apply str (repeat digest/max-preview-bytes two-byte-codepoint))
           preview (:digest/preview (digest/digest-content content))]
@@ -83,7 +98,7 @@
       (is (= (quot digest/max-preview-bytes two-byte-codepoint-width)
              (count preview))))))
 
-(deftest preview-keeps-code-points-intact
+(deftest ^{:stratum 1} preview-keeps-code-points-intact
   (testing "preview truncation does not split surrogate pairs"
     (let [content     (apply str (repeat digest/max-preview-bytes emoji-codepoint))
           preview     (:digest/preview (digest/digest-content content))
@@ -91,28 +106,27 @@
       (is (<= (utf8-size preview) digest/max-preview-bytes))
       (is (= (quot digest/max-preview-bytes emoji-codepoint-width) code-points)))))
 
-(deftest preview-is-exact-for-short-strings
+(deftest ^{:stratum 1} preview-is-exact-for-short-strings
   (testing "preview equals the full string when shorter than the byte cap"
     (let [result (digest/digest-content short-content)]
       (is (= short-content (:digest/preview result))))))
 
 ;------------------------------------------------------------------------------ edge cases
-
-(deftest accepts-byte-array
+(deftest ^{:stratum 1} accepts-byte-array
   (testing "byte arrays are digested without conversion error"
     (let [ba     (.getBytes hello-content StandardCharsets/UTF_8)
           result (digest/digest-content ba)]
       (is (= hello-sha256 (:digest/sha256 result)))
       (is (= (utf8-size hello-content) (:digest/original-size result))))))
 
-(deftest accepts-map-via-str-coercion
+(deftest ^{:stratum 1} accepts-map-via-str-coercion
   (testing "non-string non-bytes values are str-coerced before hashing"
     (let [result (digest/digest-content sample-map)]
       (is (string? (:digest/preview result)))
       (is (= digest/sha256-hex-length (count (:digest/sha256 result))))
       (is (pos? (:digest/original-size result))))))
 
-(deftest sha256-is-lowercase-hex
+(deftest ^{:stratum 1} sha256-is-lowercase-hex
   (testing "SHA-256 output is exactly 64 lowercase hex chars"
     (doseq [content [empty-content hello-content fox-content]]
       (let [{:keys [:digest/sha256]} (digest/digest-content content)]
@@ -121,7 +135,7 @@
         (is (re-matches lowercase-hex-shape sha256)
             (str "not lowercase hex for: " content))))))
 
-(deftest deterministic-for-same-input
+(deftest ^{:stratum 1} deterministic-for-same-input
   (testing "two calls with equal input produce equal digests"
     (let [r1 (digest/digest-content deterministic-content)
           r2 (digest/digest-content deterministic-content)]

--- a/components/event-stream/test/ai/miniforge/event_stream/event_type_registry_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/event_type_registry_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.event-type-registry-test
   "Tests for event type registry integrity and derived views."
   (:require
@@ -23,9 +22,9 @@
    [ai.miniforge.event-stream.event-type-registry :as registry]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Registry entry structure
 
-(deftest registry-entries-have-required-keys-test
+;; Registry entry structure
+(deftest ^{:stratum 0} registry-entries-have-required-keys-test
   (testing "every registry entry has :constructor, :event-type, :json-string, :browser?"
     (doseq [entry registry/event-type-registry]
       (is (string? (:constructor entry))
@@ -37,14 +36,14 @@
       (is (boolean? (:browser? entry))
           (str "Missing :browser? in " entry)))))
 
-(deftest registry-event-types-are-namespaced-keywords-test
+(deftest ^{:stratum 0} registry-event-types-are-namespaced-keywords-test
   (testing "every :event-type is a namespaced keyword"
     (doseq [entry registry/event-type-registry]
       (is (namespace (:event-type entry))
           (str ":event-type " (:event-type entry)
                " must be namespaced keyword")))))
 
-(deftest registry-json-strings-match-event-types-test
+(deftest ^{:stratum 0} registry-json-strings-match-event-types-test
   (testing "json-string is the keyword serialized (ns/name)"
     (doseq [entry registry/event-type-registry]
       (let [kw (:event-type entry)
@@ -53,7 +52,7 @@
             (str "Mismatch for " (:constructor entry)
                  ": expected " expected " got " (:json-string entry)))))))
 
-(deftest registry-constructors-are-unique-test
+(deftest ^{:stratum 0} registry-constructors-are-unique-test
   (testing "no duplicate constructor names"
     (let [names (map :constructor registry/event-type-registry)
           freq (frequencies names)
@@ -61,7 +60,7 @@
       (is (empty? dupes)
           (str "Duplicate constructors: " dupes)))))
 
-(deftest registry-event-types-are-unique-test
+(deftest ^{:stratum 0} registry-event-types-are-unique-test
   (testing "no duplicate event-type keywords"
     (let [types (map :event-type registry/event-type-registry)
           freq (frequencies types)
@@ -69,10 +68,8 @@
       (is (empty? dupes)
           (str "Duplicate event types: " dupes)))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Derived views consistency
-
-(deftest browser-handled-events-test
+(deftest ^{:stratum 0} browser-handled-events-test
   (testing "browser-handled-events matches entries with :browser? true"
     (let [expected (->> registry/event-type-registry
                         (filter :browser?)
@@ -82,7 +79,7 @@
   (testing "browser-handled-events is non-empty"
     (is (pos? (count registry/browser-handled-events)))))
 
-(deftest browser-unhandled-events-test
+(deftest ^{:stratum 0} browser-unhandled-events-test
   (testing "browser-unhandled-events matches entries with :browser? false"
     (let [expected (->> registry/event-type-registry
                         (remove :browser?)
@@ -94,7 +91,7 @@
            (+ (count registry/browser-handled-events)
               (count registry/browser-unhandled-events))))))
 
-(deftest naming-asymmetries-test
+(deftest ^{:stratum 0} naming-asymmetries-test
   (testing "naming-asymmetries matches entries with :asymmetry? true"
     (let [expected-count (->> registry/event-type-registry
                               (filter :asymmetry?)
@@ -107,10 +104,8 @@
       (is (string? (:json-string asym)))
       (is (string? (:asymmetry-note asym))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Audit summary consistency
-
-(deftest audit-summary-test
+(deftest ^{:stratum 0} audit-summary-test
   (testing "total count matches registry size"
     (is (= (count registry/event-type-registry)
            (:total-server-events registry/audit-summary))))

--- a/components/event-stream/test/ai/miniforge/event_stream/heartbeat_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/heartbeat_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.heartbeat-test
   (:require
    [clojure.test :refer [deftest is testing]]
@@ -24,13 +23,15 @@
   (:import
    [java.util.concurrent ScheduledExecutorService TimeUnit]))
 
-(defn- collecting-stream []
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} collecting-stream []
   (let [events (atom [])]
     {:events events
      :stream (core/create-event-stream
                {:sinks [(fn [event] (swap! events conj event))]})}))
 
-(defn- wait-for-events [events n]
+(defn- ^{:stratum 0} wait-for-events [events n]
   (let [deadline (+ (System/currentTimeMillis) 500)]
     (loop []
       (if (or (>= (count @events) n)
@@ -39,7 +40,22 @@
         (do (Thread/sleep 10)
             (recur))))))
 
-(deftest start-heartbeat!-returns-handle
+(deftest ^{:stratum 0} start-heartbeat!-rejects-non-IDeref-stream
+  (testing "WebSocket-backed (non-IDeref) stream is rejected at the call site, not inside the scheduler thread"
+    ;; The scheduled task uses swap!/swap-vals! on the event stream
+    ;; via core/publish!. Passing a plain map (WebSocket dispatch
+    ;; shape from the dashboard layer) would only crash inside the
+    ;; scheduler thread, after the executor was already alive.
+    ;; Fail loud at start time instead — caller sees the
+    ;; misconfiguration before any resource is allocated.
+    (let [ws-stream {:websocket :dummy-conn}]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"IDeref"
+                            (heartbeat/start-heartbeat! ws-stream (random-uuid) :plan))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} start-heartbeat!-returns-handle
   (let [{:keys [stream]} (collecting-stream)
         handle (heartbeat/start-heartbeat! stream (random-uuid) :plan
                                            {:interval-ms 5000})]
@@ -51,7 +67,7 @@
       (finally
         (heartbeat/stop-heartbeat! handle)))))
 
-(deftest heartbeat-emits-phase-liveness-events
+(deftest ^{:stratum 1} heartbeat-emits-phase-liveness-events
   (testing "heartbeat events carry workflow, phase, gap, and monotonic sequence"
     (let [{:keys [stream events]} (collecting-stream)
           workflow-id (random-uuid)
@@ -71,7 +87,7 @@
         (finally
           (heartbeat/stop-heartbeat! handle))))))
 
-(deftest stop-heartbeat!-halts-emissions
+(deftest ^{:stratum 1} stop-heartbeat!-halts-emissions
   (let [{:keys [stream events]} (collecting-stream)
         handle (heartbeat/start-heartbeat! stream (random-uuid) :test
                                            {:interval-ms 25})]
@@ -83,34 +99,21 @@
       (Thread/sleep 75)
       (is (= count-at-stop (count @events))))))
 
-(deftest stop-heartbeat!-is-safe
+(deftest ^{:stratum 1} stop-heartbeat!-is-safe
   (is (nil? (heartbeat/stop-heartbeat! nil)))
   (let [{:keys [stream]} (collecting-stream)
         handle (heartbeat/start-heartbeat! stream (random-uuid) :plan)]
     (heartbeat/stop-heartbeat! handle)
     (is (nil? (heartbeat/stop-heartbeat! handle)))))
 
-(deftest start-heartbeat!-rejects-invalid-interval
+(deftest ^{:stratum 1} start-heartbeat!-rejects-invalid-interval
   (let [{:keys [stream]} (collecting-stream)]
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
                           #"positive integer"
                           (heartbeat/start-heartbeat! stream (random-uuid) :plan
                                                       {:interval-ms 0})))))
 
-(deftest start-heartbeat!-rejects-non-IDeref-stream
-  (testing "WebSocket-backed (non-IDeref) stream is rejected at the call site, not inside the scheduler thread"
-    ;; The scheduled task uses swap!/swap-vals! on the event stream
-    ;; via core/publish!. Passing a plain map (WebSocket dispatch
-    ;; shape from the dashboard layer) would only crash inside the
-    ;; scheduler thread, after the executor was already alive.
-    ;; Fail loud at start time instead — caller sees the
-    ;; misconfiguration before any resource is allocated.
-    (let [ws-stream {:websocket :dummy-conn}]
-      (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                            #"IDeref"
-                            (heartbeat/start-heartbeat! ws-stream (random-uuid) :plan))))))
-
-(deftest stop-heartbeat!-cancels-scheduled-future
+(deftest ^{:stratum 1} stop-heartbeat!-cancels-scheduled-future
   (testing "the retained ScheduledFuture is cancelled (not just executor-shut-down)"
     ;; Lifecycle hygiene: cancelling the future explicitly is what
     ;; stops the periodic task, independent of the executor's

--- a/components/event-stream/test/ai/miniforge/event_stream/identity_propagation_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/identity_propagation_test.clj
@@ -9,7 +9,6 @@
 ;; You may obtain a copy of the License at
 ;;
 ;;     http://www.apache.org/licenses/LICENSE-2.0
-
 (ns ai.miniforge.event-stream.identity-propagation-test
   "Tests for the Decision-14 identity-propagation fields landed for
    miniforge-fleet's Phase E.1 prerequisite #10. Three areas:
@@ -31,15 +30,43 @@
    [java.util UUID]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Helpers.
 
-(defn- fresh-stream []
+;; Helpers.
+(defn- ^{:stratum 0} fresh-stream []
   (atom {:events [] :sequence-numbers {}}))
 
-;------------------------------------------------------------------------------ Layer 1
-;; create-envelope: legacy 4-arg arity.
+;; Schema acceptance — events with identity fields validate.
+(defn- ^{:stratum 0} envelope-shape
+  "Build a minimal EventEnvelope-compatible map with the identity fields populated."
+  [type-kw extra]
+  (merge {:event/type             type-kw
+          :event/id               (UUID/randomUUID)
+          :event/timestamp        (java.util.Date.)
+          :event/version          "1.0"
+          :event/sequence-number  0
+          :workflow/id            (UUID/randomUUID)
+          :org/id                 (UUID/randomUUID)
+          :workspace/id           (UUID/randomUUID)
+          :repo/id                "owner/repo"
+          :auth/context           {:auth/principal "alice"}
+          :message                "test"}
+         extra))
 
-(deftest test-legacy-arity-still-works
+(deftest ^{:stratum 0} test-events-without-identity-still-validate
+  (testing "events without any identity fields still validate (backward compat)"
+    (let [ev {:event/type :workflow/started
+              :event/id (UUID/randomUUID)
+              :event/timestamp (java.util.Date.)
+              :event/version "1.0"
+              :event/sequence-number 0
+              :workflow/id (UUID/randomUUID)
+              :message "test"}]
+      (is (m/validate schema/WorkflowStarted ev)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; create-envelope: legacy 4-arg arity.
+(deftest ^{:stratum 1} test-legacy-arity-still-works
   (testing "the 4-arg arity produces an envelope with no identity fields and validates"
     (let [stream (fresh-stream)
           wid (UUID/randomUUID)
@@ -51,10 +78,8 @@
       (is (= :workflow/started (:event/type ev)))
       (is (= wid (:workflow/id ev))))))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; create-envelope: identity kwargs.
-
-(deftest test-org-id-stamped-when-supplied
+(deftest ^{:stratum 1} test-org-id-stamped-when-supplied
   (testing ":org/id rides through to the envelope"
     (let [stream (fresh-stream)
           oid (UUID/randomUUID)
@@ -62,7 +87,7 @@
                                     {:org/id oid})]
       (is (= oid (:org/id ev))))))
 
-(deftest test-workspace-id-stamped-when-supplied
+(deftest ^{:stratum 1} test-workspace-id-stamped-when-supplied
   (testing ":workspace/id rides through to the envelope"
     (let [stream (fresh-stream)
           wsid (UUID/randomUUID)
@@ -70,14 +95,14 @@
                                      {:workspace/id wsid})]
       (is (= wsid (:workspace/id ev))))))
 
-(deftest test-repo-id-stamped-when-supplied
+(deftest ^{:stratum 1} test-repo-id-stamped-when-supplied
   (testing ":repo/id rides through (string slug shape)"
     (let [stream (fresh-stream)
           ev (core/create-envelope stream :workflow/started (UUID/randomUUID) "msg"
                                    {:repo/id "miniforge-ai/miniforge"})]
       (is (= "miniforge-ai/miniforge" (:repo/id ev))))))
 
-(deftest test-auth-context-stamped-when-supplied
+(deftest ^{:stratum 1} test-auth-context-stamped-when-supplied
   (testing ":auth/context rides through as an opaque map"
     (let [stream (fresh-stream)
           ctx {:auth/principal "alice" :auth/scopes #{:read :write}}
@@ -85,7 +110,7 @@
                                    {:auth/context ctx})]
       (is (= ctx (:auth/context ev))))))
 
-(deftest test-all-identity-fields-together
+(deftest ^{:stratum 1} test-all-identity-fields-together
   (testing "every identity field stamped together — full multi-tenant shape"
     (let [stream (fresh-stream)
           oid    (UUID/randomUUID)
@@ -108,7 +133,7 @@
       (is (= :planner (:agent/id ev)))
       (is (= aid (:agent/instance-id ev))))))
 
-(deftest test-empty-opts-equivalent-to-legacy-arity
+(deftest ^{:stratum 1} test-empty-opts-equivalent-to-legacy-arity
   (testing "passing {} as opts is identical to the 4-arg arity"
     (let [stream (fresh-stream)
           wid (UUID/randomUUID)
@@ -117,63 +142,31 @@
       (is (= (dissoc a :event/id :event/timestamp :event/sequence-number)
              (dissoc b :event/id :event/timestamp :event/sequence-number))))))
 
-;------------------------------------------------------------------------------ Layer 3
-;; Schema acceptance — events with identity fields validate.
-
-(defn- envelope-shape
-  "Build a minimal EventEnvelope-compatible map with the identity fields populated."
-  [type-kw extra]
-  (merge {:event/type             type-kw
-          :event/id               (UUID/randomUUID)
-          :event/timestamp        (java.util.Date.)
-          :event/version          "1.0"
-          :event/sequence-number  0
-          :workflow/id            (UUID/randomUUID)
-          :org/id                 (UUID/randomUUID)
-          :workspace/id           (UUID/randomUUID)
-          :repo/id                "owner/repo"
-          :auth/context           {:auth/principal "alice"}
-          :message                "test"}
-         extra))
-
-(deftest test-envelope-with-identity-validates
+(deftest ^{:stratum 1} test-envelope-with-identity-validates
   (testing "EventEnvelope accepts the four identity fields"
     (let [ev (envelope-shape :test/anything {})]
       (is (m/validate schema/EventEnvelope ev)))))
 
-(deftest test-workflow-started-with-identity-validates
+(deftest ^{:stratum 1} test-workflow-started-with-identity-validates
   (testing "WorkflowStarted accepts the four identity fields (closed-map check passes)"
     (let [ev (envelope-shape :workflow/started {})]
       (is (m/validate schema/WorkflowStarted ev)))))
 
-(deftest test-phase-completed-with-identity-validates
+(deftest ^{:stratum 1} test-phase-completed-with-identity-validates
   (testing "PhaseCompleted accepts the four identity fields"
     (let [ev (envelope-shape :workflow/phase-completed
                              {:workflow/phase :plan})]
       (is (m/validate schema/PhaseCompleted ev)))))
 
-(deftest test-tool-use-evaluated-with-identity-validates
+(deftest ^{:stratum 1} test-tool-use-evaluated-with-identity-validates
   (testing "ToolUseEvaluated accepts the four identity fields (later-added schema)"
     (let [ev (envelope-shape :supervision/tool-use-evaluated
                              {:tool/name "bash"
                               :supervision/decision "approved"})]
       (is (m/validate schema/ToolUseEvaluated ev)))))
 
-(deftest test-events-without-identity-still-validate
-  (testing "events without any identity fields still validate (backward compat)"
-    (let [ev {:event/type :workflow/started
-              :event/id (UUID/randomUUID)
-              :event/timestamp (java.util.Date.)
-              :event/version "1.0"
-              :event/sequence-number 0
-              :workflow/id (UUID/randomUUID)
-              :message "test"}]
-      (is (m/validate schema/WorkflowStarted ev)))))
-
-;------------------------------------------------------------------------------ Layer 4
 ;; Sequence numbering — atomic increment under concurrency.
-
-(deftest test-sequence-numbers-are-unique-under-concurrency
+(deftest ^{:stratum 1} test-sequence-numbers-are-unique-under-concurrency
   (testing "concurrent create-envelope calls for the same workflow get distinct :event/sequence-number values"
     ;; Reviewer flagged the original read-then-swap pattern as racey
     ;; — concurrent producers could observe the same seq number.

--- a/components/event-stream/test/ai/miniforge/event_stream/interface_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/interface_test.clj
@@ -15,13 +15,14 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.interface-test
   (:require
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.event-stream.interface :as es]))
 
-(deftest create-event-stream-test
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} create-event-stream-test
   (testing "creates event stream with initial state"
     (let [stream (es/create-event-stream {:sinks []})]
       (is (some? stream))
@@ -30,7 +31,7 @@
       (is (contains? @stream :events))
       (is (contains? @stream :subscribers)))))
 
-(deftest publish-and-subscribe-test
+(deftest ^{:stratum 0} publish-and-subscribe-test
   (testing "subscribers receive published events"
     (let [stream (es/create-event-stream {:sinks []})
           wf-id (random-uuid)
@@ -72,7 +73,7 @@
       ;; Only first event received
       (is (= 1 (count @received))))))
 
-(deftest event-envelope-test
+(deftest ^{:stratum 0} event-envelope-test
   (testing "events have required N3 envelope fields"
     (let [stream (es/create-event-stream {:sinks []})
           wf-id (random-uuid)
@@ -106,7 +107,7 @@
       (is (= 0 (:event/sequence-number e2)))
       (is (= 1 (:event/sequence-number e3))))))
 
-(deftest workflow-event-constructors-test
+(deftest ^{:stratum 0} workflow-event-constructors-test
   (testing "workflow-started includes spec when provided"
     (let [stream (es/create-event-stream {:sinks []})
           wf-id (random-uuid)
@@ -164,7 +165,7 @@
       (is (= "LLM timeout" (:workflow/failure-reason event)))
       (is (= error (:workflow/error-details event))))))
 
-(deftest dependency-event-constructors-test
+(deftest ^{:stratum 0} dependency-event-constructors-test
   (testing "dependency health events are exposed on the public interface"
     (let [stream (es/create-event-stream {:sinks []})
           dependency {:dependency/id :anthropic
@@ -186,7 +187,7 @@
       (is (= :dependency/recovered (:event/type recovered)))
       (is (= :healthy (:dependency/status recovered))))))
 
-(deftest agent-event-constructors-test
+(deftest ^{:stratum 0} agent-event-constructors-test
   (testing "agent-chunk captures delta and done status"
     (let [stream (es/create-event-stream {:sinks []})
           wf-id (random-uuid)]
@@ -207,7 +208,7 @@
       (is (= :generating (:status/type event)))
       (is (= "Writing code" (:message event))))))
 
-(deftest llm-event-constructors-test
+(deftest ^{:stratum 0} llm-event-constructors-test
   (testing "llm-request captures model and tokens"
     (let [stream (es/create-event-stream {:sinks []})
           wf-id (random-uuid)
@@ -229,7 +230,7 @@
       (is (= 850 (:llm/completion-tokens event)))
       (is (= 3200 (:llm/duration-ms event))))))
 
-(deftest get-events-test
+(deftest ^{:stratum 0} get-events-test
   (testing "get-events returns all events"
     (let [stream (es/create-event-stream {:sinks []})
           wf-id (random-uuid)]
@@ -266,7 +267,7 @@
       (is (= 1 (count (es/get-events stream {:offset 2}))))
       (is (= 1 (count (es/get-events stream {:offset 1 :limit 1})))))))
 
-(deftest get-latest-status-test
+(deftest ^{:stratum 0} get-latest-status-test
   (testing "returns most recent status event"
     (let [stream (es/create-event-stream {:sinks []})
           wf-id (random-uuid)]
@@ -286,7 +287,7 @@
       (let [impl-status (es/get-latest-status stream wf-id :implementer)]
         (is (= :implementer (:agent/id impl-status)))))))
 
-(deftest create-streaming-callback-test
+(deftest ^{:stratum 0} create-streaming-callback-test
   (testing "callback publishes agent-chunk events"
     (let [stream (es/create-event-stream {:sinks []})
           wf-id (random-uuid)
@@ -342,10 +343,8 @@
         (is (nat-int? (:tool/duration-ms completed)))
         (is (contains? completed :tool/result-digest))))))
 
-
 ;; --------------------------------------------------------------------------- New N3 event constructors
-
-(deftest agent-lifecycle-event-constructors-test
+(deftest ^{:stratum 0} agent-lifecycle-event-constructors-test
   (testing "agent-started creates event with agent-id and optional context"
     (let [stream (es/create-event-stream {:sinks []})
           wf-id (random-uuid)
@@ -371,7 +370,7 @@
       (is (= :reviewer (:agent/id event)))
       (is (= {:message "timeout"} (:agent/error event))))))
 
-(deftest gate-lifecycle-event-constructors-test
+(deftest ^{:stratum 0} gate-lifecycle-event-constructors-test
   (testing "gate-started creates event"
     (let [stream (es/create-event-stream {:sinks []})
           wf-id (random-uuid)
@@ -396,7 +395,7 @@
       (is (= :lint (:gate/id event)))
       (is (= violations (:gate/violations event))))))
 
-(deftest tool-lifecycle-event-constructors-test
+(deftest ^{:stratum 0} tool-lifecycle-event-constructors-test
   (testing "tool-invoked creates event"
     (let [stream (es/create-event-stream {:sinks []})
           wf-id (random-uuid)
@@ -414,7 +413,7 @@
       (is (= :tools/write-file (:tool/id event)))
       (is (= {:success true} (:tool/result-summary event))))))
 
-(deftest milestone-event-constructor-test
+(deftest ^{:stratum 0} milestone-event-constructor-test
   (testing "milestone-reached creates event"
     (let [stream (es/create-event-stream {:sinks []})
           wf-id (random-uuid)
@@ -423,7 +422,7 @@
       (is (= :tests-passing (:milestone/id event)))
       (is (= "All 42 tests pass" (:message event))))))
 
-(deftest task-lifecycle-event-constructors-test
+(deftest ^{:stratum 0} task-lifecycle-event-constructors-test
   (testing "task-state-changed creates event with from/to states"
     (let [stream (es/create-event-stream {:sinks []})
           wf-id (random-uuid)
@@ -451,7 +450,7 @@
       (is (= :task/skip-propagated (:event/type event)))
       (is (= cause (:task/cause-task event))))))
 
-(deftest inter-agent-message-event-constructors-test
+(deftest ^{:stratum 0} inter-agent-message-event-constructors-test
   (testing "inter-agent-message-sent creates event"
     (let [stream (es/create-event-stream {:sinks []})
           wf-id (random-uuid)
@@ -469,7 +468,7 @@
       (is (= :planner (:from-agent/id event)))
       (is (= :implementer (:to-agent/id event))))))
 
-(deftest listener-event-constructors-test
+(deftest ^{:stratum 0} listener-event-constructors-test
   (testing "listener-attached creates event"
     (let [stream (es/create-event-stream {:sinks []})
           wf-id (random-uuid)
@@ -499,7 +498,7 @@
       (is (= :warning (:annotation/type event)))
       (is (= "slow response" (:annotation/content event))))))
 
-(deftest control-action-event-constructors-test
+(deftest ^{:stratum 0} control-action-event-constructors-test
   (testing "control-action-requested creates event"
     (let [stream (es/create-event-stream {:sinks []})
           wf-id (random-uuid)

--- a/components/event-stream/test/ai/miniforge/event_stream/listeners_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/listeners_test.clj
@@ -15,14 +15,15 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.listeners-test
   (:require
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.event-stream.listeners :as listeners]))
 
-(deftest capability-sufficient-test
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} capability-sufficient-test
   (testing "observe meets observe requirement"
     (is (true? (listeners/capability-sufficient? :observe :observe))))
   (testing "advise meets observe requirement"
@@ -36,7 +37,7 @@
   (testing "observe does not meet control requirement"
     (is (false? (listeners/capability-sufficient? :observe :control)))))
 
-(deftest register-and-deregister-listener-test
+(deftest ^{:stratum 0} register-and-deregister-listener-test
   (testing "register-listener! returns a UUID and listener appears in list"
     (let [stream (es/create-event-stream {:sinks []})
           received (atom [])
@@ -73,7 +74,7 @@
         ;; Only the attach/detach events + the one workflow event from before
         (is (= pre-count (count @received)))))))
 
-(deftest listener-filtering-test
+(deftest ^{:stratum 0} listener-filtering-test
   (testing "listener with event-type filter only receives matching events"
     (let [stream (es/create-event-stream {:sinks []})
           received (atom [])
@@ -94,7 +95,7 @@
       (is (= 2 (count @received)))
       (is (every? #(#{:gate/passed :gate/failed} (:event/type %)) @received)))))
 
-(deftest invalid-capability-test
+(deftest ^{:stratum 0} invalid-capability-test
   (testing "registering with invalid capability throws"
     (let [stream (es/create-event-stream {:sinks []})]
       (is (thrown? Exception
@@ -105,7 +106,7 @@
                      :listener/identity {:principal "bad"}
                      :listener/callback (fn [_] nil)}))))))
 
-(deftest submit-annotation-test
+(deftest ^{:stratum 0} submit-annotation-test
   (testing "advise-capable listener can submit annotation"
     (let [stream (es/create-event-stream {:sinks []})
           listener-id (es/register-listener!

--- a/components/event-stream/test/ai/miniforge/event_stream/manifest_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/manifest_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.manifest-test
   "Tests for the BD-2b sub-2 per-workflow manifest module."
   (:require
@@ -27,9 +26,10 @@
    [java.time Instant]
    [java.util UUID]))
 
-;------------------------------------------------------------------------------ Helpers
+;------------------------------------------------------------------------------ Layer 0
 
-(defn- with-temp-dir [f]
+;------------------------------------------------------------------------------ Helpers
+(defn- ^{:stratum 0} with-temp-dir [f]
   (let [dir (java.nio.file.Files/createTempDirectory
              "manifest-test-"
              (into-array java.nio.file.attribute.FileAttribute []))]
@@ -41,63 +41,20 @@
 
 ;; The id is informational at the wire layer (tests round-trip it as a
 ;; UUID); workflow lifecycle wiring uses a real run id.
-(def ^:private test-workflow-id
+(def ^{:stratum 0} ^:private test-workflow-id
   (UUID/fromString "00000000-0000-0000-0000-000000000001"))
 
 ;; Default lease window for tests is much shorter than the production
 ;; default so `lease-fresh?` can be exercised against synthetic clock
 ;; advances without waiting wall-time minutes.
-(def ^:private ^:const ^long short-ttl-seconds 5)
+(def ^{:stratum 0} ^:private ^:const ^long short-ttl-seconds 5)
 
-;------------------------------------------------------------------------------ Schema
-
-(deftest init-active-produces-valid-manifest
-  (let [m (manifest/init-active test-workflow-id)]
-    (is (manifest/valid? m)
-        (str "init-active should produce a schema-valid manifest, got "
-             (pr-str (manifest/explain m))))
-    (is (= :active (:status m)))
-    (is (= :live (:archive_status m)))
-    (is (= :none (:snapshot_status m)))
-    (is (true? (:raw_events_retained m)))
-    (is (= 0 (get-in m [:snapshot_watermark :workflow_sequence_number])))
-    (is (nil? (get-in m [:snapshot_watermark :last_event_id])))))
-
-(deftest valid?-rejects-missing-required-fields
+(deftest ^{:stratum 0} valid?-rejects-missing-required-fields
   (is (not (manifest/valid? {})))
   (is (some? (manifest/explain {}))))
 
-(deftest valid?-rejects-unknown-status-enum
-  (let [m (assoc (manifest/init-active test-workflow-id)
-                 :status :wat)]
-    (is (not (manifest/valid? m))
-        "unknown :status enum value must fail validation")))
-
-(deftest valid?-rejects-negative-watermark-sequence
-  (let [m (assoc-in (manifest/init-active test-workflow-id)
-                    [:snapshot_watermark :workflow_sequence_number] -1)]
-    (is (not (manifest/valid? m))
-        "watermark sequence must be ≥ 0 to mirror the JSON Schema contract")))
-
-(deftest valid?-rejects-malformed-event-id
-  (let [base (manifest/init-active test-workflow-id)]
-    (is (not (manifest/valid?
-              (assoc-in base [:snapshot_watermark :last_event_id] "not-hex")))
-        "non-hex last_event_id must fail validation")
-    (is (not (manifest/valid?
-              (assoc-in base [:snapshot_watermark :last_event_id] "ABCDEF1234567890")))
-        "uppercase hex must fail (lowercase-only by RFC contract)")
-    (is (not (manifest/valid?
-              (assoc-in base [:snapshot_watermark :last_event_id] "abc")))
-        "wrong-length hex must fail")
-    (is (manifest/valid?
-         (assoc-in base [:snapshot_watermark :last_event_id]
-                   "018f3a9c8e4b12d0"))
-        "16-char lowercase hex passes")))
-
 ;------------------------------------------------------------------------------ State machine
-
-(deftest legal-archive-transitions-table
+(deftest ^{:stratum 0} legal-archive-transitions-table
   (testing "forward edges"
     (is (manifest/legal-archive-transition? :live :archiving))
     (is (manifest/legal-archive-transition? :archiving :archived))
@@ -113,7 +70,50 @@
     (is (not (manifest/legal-archive-transition? :archived :live)))
     (is (not (manifest/legal-archive-transition? :archived :archiving)))))
 
-(deftest transition-archive-returns-anomaly-on-illegal-move
+;------------------------------------------------------------------------------ Layer 1
+
+;------------------------------------------------------------------------------ Schema
+(deftest ^{:stratum 1} init-active-produces-valid-manifest
+  (let [m (manifest/init-active test-workflow-id)]
+    (is (manifest/valid? m)
+        (str "init-active should produce a schema-valid manifest, got "
+             (pr-str (manifest/explain m))))
+    (is (= :active (:status m)))
+    (is (= :live (:archive_status m)))
+    (is (= :none (:snapshot_status m)))
+    (is (true? (:raw_events_retained m)))
+    (is (= 0 (get-in m [:snapshot_watermark :workflow_sequence_number])))
+    (is (nil? (get-in m [:snapshot_watermark :last_event_id])))))
+
+(deftest ^{:stratum 1} valid?-rejects-unknown-status-enum
+  (let [m (assoc (manifest/init-active test-workflow-id)
+                 :status :wat)]
+    (is (not (manifest/valid? m))
+        "unknown :status enum value must fail validation")))
+
+(deftest ^{:stratum 1} valid?-rejects-negative-watermark-sequence
+  (let [m (assoc-in (manifest/init-active test-workflow-id)
+                    [:snapshot_watermark :workflow_sequence_number] -1)]
+    (is (not (manifest/valid? m))
+        "watermark sequence must be ≥ 0 to mirror the JSON Schema contract")))
+
+(deftest ^{:stratum 1} valid?-rejects-malformed-event-id
+  (let [base (manifest/init-active test-workflow-id)]
+    (is (not (manifest/valid?
+              (assoc-in base [:snapshot_watermark :last_event_id] "not-hex")))
+        "non-hex last_event_id must fail validation")
+    (is (not (manifest/valid?
+              (assoc-in base [:snapshot_watermark :last_event_id] "ABCDEF1234567890")))
+        "uppercase hex must fail (lowercase-only by RFC contract)")
+    (is (not (manifest/valid?
+              (assoc-in base [:snapshot_watermark :last_event_id] "abc")))
+        "wrong-length hex must fail")
+    (is (manifest/valid?
+         (assoc-in base [:snapshot_watermark :last_event_id]
+                   "018f3a9c8e4b12d0"))
+        "16-char lowercase hex passes")))
+
+(deftest ^{:stratum 1} transition-archive-returns-anomaly-on-illegal-move
   (let [m (manifest/init-active test-workflow-id)]
     (is (= :archiving
            (:archive_status (manifest/transition-archive m :archiving)))
@@ -128,7 +128,7 @@
       (is (= :live (get-in result [:anomaly/data :from])))
       (is (= :archived (get-in result [:anomaly/data :to]))))))
 
-(deftest mark-terminal-stamps-completed-at-and-status
+(deftest ^{:stratum 1} mark-terminal-stamps-completed-at-and-status
   (let [m (manifest/init-active test-workflow-id)]
     (let [done (manifest/mark-terminal m :completed)]
       (is (= :completed (:status done)))
@@ -139,8 +139,7 @@
         "mark-terminal must reject non-terminal status keywords")))
 
 ;------------------------------------------------------------------------------ Lease primitives
-
-(deftest renew-lease-bumps-renewed-at
+(deftest ^{:stratum 1} renew-lease-bumps-renewed-at
   ;; Pre-stamp `lease_renewed_at` with a known past instant so the
   ;; test doesn't depend on JVM clock resolution to observe a delta.
   (let [m       (-> (manifest/init-active test-workflow-id
@@ -155,7 +154,7 @@
     (is (.isAfter (Instant/parse ^String after)
                   (Instant/parse ^String before)))))
 
-(deftest lease-fresh?-respects-ttl
+(deftest ^{:stratum 1} lease-fresh?-respects-ttl
   (let [m   (manifest/init-active test-workflow-id
                                   {:ttl-seconds short-ttl-seconds})
         ;; Anchor a known renewed-at and probe the freshness window.
@@ -170,27 +169,26 @@
     (is (not (manifest/lease-fresh? m' (Instant/parse "2026-05-08T00:00:06Z")))
         "past TTL boundary is stale")))
 
-(deftest owner-pid-alive?-true-for-self
+(deftest ^{:stratum 1} owner-pid-alive?-true-for-self
   ;; The lease was just stamped with our own pid + host, so the
   ;; alive-check must return true for this process.
   (let [m (manifest/init-active test-workflow-id)]
     (is (manifest/owner-pid-alive? m))))
 
-(deftest owner-pid-alive?-false-for-different-host
+(deftest ^{:stratum 1} owner-pid-alive?-false-for-different-host
   (let [m (assoc-in (manifest/init-active test-workflow-id)
                     [:owner :host] "definitely-not-this-host.invalid")]
     (is (not (manifest/owner-pid-alive? m))
         "cross-host pid checks are out of scope; treat as not-alive")))
 
-(deftest owner-pid-alive?-false-for-bogus-pid
+(deftest ^{:stratum 1} owner-pid-alive?-false-for-bogus-pid
   (let [m (assoc-in (manifest/init-active test-workflow-id)
                     [:owner :pid] "99999999")]
     (is (not (manifest/owner-pid-alive? m))
         "a pid with no live process must be reported dead")))
 
 ;------------------------------------------------------------------------------ Atomic IO
-
-(deftest save-then-load-round-trips
+(deftest ^{:stratum 1} save-then-load-round-trips
   (with-temp-dir
     (fn [dir]
       (let [m       (manifest/init-active test-workflow-id)
@@ -203,12 +201,12 @@
         (is (= (:owner m) (:owner loaded))
             "owner round-trips byte-for-byte through JSON")))))
 
-(deftest load-manifest-returns-nil-when-absent
+(deftest ^{:stratum 1} load-manifest-returns-nil-when-absent
   (with-temp-dir
     (fn [dir]
       (is (nil? (manifest/load-manifest dir))))))
 
-(deftest save-manifest!-rejects-invalid-shape
+(deftest ^{:stratum 1} save-manifest!-rejects-invalid-shape
   (with-temp-dir
     (fn [dir]
       (let [bogus (assoc (manifest/init-active test-workflow-id)
@@ -221,14 +219,14 @@
         (is (false? (.exists (io/file dir "manifest.json")))
             "invalid manifests must not be persisted")))))
 
-(deftest renew-lease!-no-op-when-manifest-absent
+(deftest ^{:stratum 1} renew-lease!-no-op-when-manifest-absent
   (with-temp-dir
     (fn [dir]
       (is (nil? (manifest/renew-lease! dir))
           "missing manifest is a no-op so a heartbeat tick can race
            archival without crashing"))))
 
-(deftest renew-lease!-propagates-save-anomaly
+(deftest ^{:stratum 1} renew-lease!-propagates-save-anomaly
   (with-temp-dir
     (fn [dir]
       (let [m (manifest/init-active test-workflow-id)
@@ -239,7 +237,7 @@
         (with-redefs [manifest/save-manifest! (fn [_ _] save-anomaly)]
           (is (= save-anomaly (manifest/renew-lease! dir))))))))
 
-(deftest renew-lease!-bumps-on-disk
+(deftest ^{:stratum 1} renew-lease!-bumps-on-disk
   (with-temp-dir
     (fn [dir]
       (let [m       (-> (manifest/init-active test-workflow-id)

--- a/components/event-stream/test/ai/miniforge/event_stream/new_events_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/new_events_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.new-events-test
   "Tests for GROUP 1+2 foundation event constructors:
      :agent/tool-call-started, :tool/call-completed, :workflow/phase-heartbeat.
@@ -32,25 +31,37 @@
    [ai.miniforge.event-stream.messages :as messages]
    [ai.miniforge.event-stream.schema :as schema]))
 
-(defn- stream [] (es/create-event-stream {:sinks []}))
+;------------------------------------------------------------------------------ Layer 0
 
-(def ^:private sample-args-digest
+(defn- ^{:stratum 0} stream [] (es/create-event-stream {:sinks []}))
+
+(def ^{:stratum 0} ^:private sample-args-digest
   (es/digest-content {:file "/tmp/input.clj"}))
 
-(def ^:private sample-result-digest
+(def ^{:stratum 0} ^:private sample-result-digest
   (es/digest-content {:outcome :ok}))
 
-(def ^:private short-tool-duration-ms 42)
-(def ^:private failure-tool-duration-ms 10)
-(def ^:private sample-error-code 404)
-(def ^:private heartbeat-gap-ms 3000)
-(def ^:private heartbeat-events-emitted 17)
-(def ^:private stale-heartbeat-gap-ms 5000)
-(def ^:private heartbeat-event-count 42)
-(def ^:private zero-heartbeat-gap-ms 0)
-(def ^:private zero-heartbeat-event-count 0)
+(def ^{:stratum 0} ^:private short-tool-duration-ms 42)
 
-(deftest operator-scoped-pr-created-allows-nil-workflow
+(def ^{:stratum 0} ^:private failure-tool-duration-ms 10)
+
+(def ^{:stratum 0} ^:private sample-error-code 404)
+
+(def ^{:stratum 0} ^:private heartbeat-gap-ms 3000)
+
+(def ^{:stratum 0} ^:private heartbeat-events-emitted 17)
+
+(def ^{:stratum 0} ^:private stale-heartbeat-gap-ms 5000)
+
+(def ^{:stratum 0} ^:private heartbeat-event-count 42)
+
+(def ^{:stratum 0} ^:private zero-heartbeat-gap-ms 0)
+
+(def ^{:stratum 0} ^:private zero-heartbeat-event-count 0)
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} operator-scoped-pr-created-allows-nil-workflow
   (let [event (assoc (es/create-envelope (stream) :pr/created nil "PR joined train")
                      :pr/repo "acme/repo"
                      :pr/number 7
@@ -60,8 +71,7 @@
     (is (m/validate schema/PRCreated event))))
 
 ;------------------------------------------------------------------------------ :agent/tool-call-started
-
-(deftest agent-tool-call-started-event-type
+(deftest ^{:stratum 1} agent-tool-call-started-event-type
   (testing "emits :agent/tool-call-started event type"
     (let [ev (es/agent-tool-call-started
               (stream) (random-uuid) :implementer
@@ -70,7 +80,7 @@
       (is (= :agent/tool-call-started (:event/type ev)))
       (is (m/validate schema/AgentToolCallStarted ev)))))
 
-(deftest agent-tool-call-started-required-fields
+(deftest ^{:stratum 1} agent-tool-call-started-required-fields
   (testing "carries tool name, call-id, and agent-id"
     (let [wf-id (random-uuid)
           ev    (es/agent-tool-call-started
@@ -83,7 +93,7 @@
       (is (= "tc_002" (:tool/call-id ev)))
       (is (map? (:tool/args-digest ev))))))
 
-(deftest agent-tool-call-started-optional-fields-absent-when-nil
+(deftest ^{:stratum 1} agent-tool-call-started-optional-fields-absent-when-nil
   (testing "optional keys are absent when not supplied"
     (let [ev (es/agent-tool-call-started
               (stream) (random-uuid) :reviewer {})]
@@ -93,7 +103,7 @@
       (is (not (contains? ev :tool/call-id)))
       (is (not (contains? ev :tool/args-digest))))))
 
-(deftest agent-tool-call-started-carries-batched-tool-names
+(deftest ^{:stratum 1} agent-tool-call-started-carries-batched-tool-names
   (testing "multi-tool provider blocks retain the vector of tool names"
     (let [ev (es/agent-tool-call-started
               (stream) (random-uuid) :implementer
@@ -101,7 +111,7 @@
       (is (= ["Read" "Write"] (:tool/names ev)))
       (is (m/validate schema/AgentToolCallStarted ev)))))
 
-(deftest agent-tool-call-started-envelope-fields
+(deftest ^{:stratum 1} agent-tool-call-started-envelope-fields
   (testing "envelope fields are present and typed correctly"
     (let [ev (es/agent-tool-call-started
               (stream) (random-uuid) :tester
@@ -113,8 +123,7 @@
       (is (int? (:event/sequence-number ev))))))
 
 ;------------------------------------------------------------------------------ :tool/call-completed
-
-(deftest tool-call-completed-event-type
+(deftest ^{:stratum 1} tool-call-completed-event-type
   (testing "emits :tool/call-completed event type"
     (let [ev (es/tool-call-completed
               (stream) (random-uuid)
@@ -124,7 +133,7 @@
       (is (= :tool/call-completed (:event/type ev)))
       (is (m/validate schema/ToolCallCompleted ev)))))
 
-(deftest tool-call-completed-success-fields
+(deftest ^{:stratum 1} tool-call-completed-success-fields
   (testing "success path carries all expected keys"
     (let [wf-id (random-uuid)
           ev    (es/tool-call-completed
@@ -138,7 +147,7 @@
       (is (= short-tool-duration-ms (:tool/duration-ms ev)))
       (is (map? (:tool/result-digest ev))))))
 
-(deftest tool-call-completed-failure-carries-error
+(deftest ^{:stratum 1} tool-call-completed-failure-carries-error
   (testing "failure path carries :tool/error map"
     (let [ev (es/tool-call-completed
               (stream) (random-uuid)
@@ -149,7 +158,7 @@
       (is (false? (:tool/success? ev)))
       (is (= {:message "file not found" :code sample-error-code} (:tool/error ev))))))
 
-(deftest tool-call-completed-no-error-on-success
+(deftest ^{:stratum 1} tool-call-completed-no-error-on-success
   (testing "error key absent when not supplied"
     (let [ev (es/tool-call-completed
               (stream) (random-uuid)
@@ -158,7 +167,7 @@
                :tool/duration-ms failure-tool-duration-ms})]
       (is (not (contains? ev :tool/error))))))
 
-(deftest tool-call-completed-unknown-outcome-message
+(deftest ^{:stratum 1} tool-call-completed-unknown-outcome-message
   (testing "omitted success flag produces neutral completion message"
     (let [ev (es/tool-call-completed
               (stream) (random-uuid)
@@ -169,8 +178,7 @@
       (is (m/validate schema/ToolCallCompleted ev)))))
 
 ;------------------------------------------------------------------------------ :workflow/phase-heartbeat
-
-(deftest phase-heartbeat-event-type
+(deftest ^{:stratum 1} phase-heartbeat-event-type
   (testing "emits :workflow/phase-heartbeat event type"
     (let [now (java.util.Date.)
           ev  (es/phase-heartbeat
@@ -182,7 +190,7 @@
       (is (= :workflow/phase-heartbeat (:event/type ev)))
       (is (m/validate schema/PhaseHeartbeat ev)))))
 
-(deftest phase-heartbeat-required-fields
+(deftest ^{:stratum 1} phase-heartbeat-required-fields
   (testing "carries phase timing and event-count fields"
     (let [active-since (java.util.Date.)
           last-event   (java.util.Date.)
@@ -200,7 +208,7 @@
       (is (= last-event (:phase/last-event-at ev)))
       (is (= stale-heartbeat-gap-ms (:phase/gap-since-last-event-ms ev))))))
 
-(deftest phase-heartbeat-zero-gap-is-valid
+(deftest ^{:stratum 1} phase-heartbeat-zero-gap-is-valid
   (testing "gap of 0ms is a valid value (not treated as falsy)"
     (let [now (java.util.Date.)
           ev  (es/phase-heartbeat
@@ -213,8 +221,7 @@
       (is (= zero-heartbeat-event-count (:phase/events-emitted ev))))))
 
 ;------------------------------------------------------------------------------ backward compatibility
-
-(deftest legacy-agent-tool-call-unaffected
+(deftest ^{:stratum 1} legacy-agent-tool-call-unaffected
   (testing "legacy :agent/tool-call constructor still works and has the old event type"
     (let [ev (es/agent-tool-call (stream) (random-uuid) :implementer
                                  {:tool-name "Read" :tool-call-id "old_001"})]
@@ -222,7 +229,7 @@
       (is (= "Read" (:tool/name ev)))
       (is (= "old_001" (:tool/call-id ev))))))
 
-(deftest new-events-have-distinct-types-from-legacy
+(deftest ^{:stratum 1} new-events-have-distinct-types-from-legacy
   (testing "new event types do not collide with legacy :agent/tool-call"
     (let [s     (stream)
           wf-id (random-uuid)

--- a/components/event-stream/test/ai/miniforge/event_stream/privacy_map_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/privacy_map_test.clj
@@ -9,7 +9,6 @@
 ;; You may obtain a copy of the License at
 ;;
 ;;     http://www.apache.org/licenses/LICENSE-2.0
-
 (ns ai.miniforge.event-stream.privacy-map-test
   "Regression tests for explicit entries in `default-event-privacy`.
 
@@ -23,39 +22,35 @@
    [clojure.test :refer [deftest is testing]]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Phase heartbeat
 
-(deftest phase-heartbeat-privacy-is-internal
+;; Phase heartbeat
+(deftest ^{:stratum 0} phase-heartbeat-privacy-is-internal
   (testing ":workflow/phase-heartbeat carries phase metrics — :internal"
     (is (= :internal (schema/event-privacy :workflow/phase-heartbeat)))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Milestone sub-lifecycle
-
-(deftest milestone-started-privacy-is-public
+(deftest ^{:stratum 0} milestone-started-privacy-is-public
   (testing ":phase/milestone-started is a lifecycle event — :public like :workflow/milestone-reached"
     (is (= :public (schema/event-privacy :phase/milestone-started)))))
 
-(deftest milestone-completed-privacy-is-public
+(deftest ^{:stratum 0} milestone-completed-privacy-is-public
   (testing ":phase/milestone-completed is a lifecycle event — :public"
     (is (= :public (schema/event-privacy :phase/milestone-completed)))))
 
-(deftest milestone-failed-privacy-is-public
+(deftest ^{:stratum 0} milestone-failed-privacy-is-public
   (testing ":phase/milestone-failed is :public — consistent with :workflow/failed and :gate/failed"
     (is (= :public (schema/event-privacy :phase/milestone-failed)))))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Inter-agent messages
-
-(deftest agent-message-sent-privacy-is-internal
+(deftest ^{:stratum 0} agent-message-sent-privacy-is-internal
   (testing ":agent/message-sent carries routing metadata — :internal like :agent/status"
     (is (= :internal (schema/event-privacy :agent/message-sent)))))
 
-(deftest agent-message-received-privacy-is-internal
+(deftest ^{:stratum 0} agent-message-received-privacy-is-internal
   (testing ":agent/message-received carries routing metadata — :internal"
     (is (= :internal (schema/event-privacy :agent/message-received)))))
 
-(deftest operator-intervention-anomaly-privacy-is-confidential
+(deftest ^{:stratum 0} operator-intervention-anomaly-privacy-is-confidential
   (testing "operator anomalies can carry detailed errors — :confidential"
     (is (= :confidential
            (schema/event-privacy :operator/intervention-anomaly)))))

--- a/components/event-stream/test/ai/miniforge/event_stream/progress_integration_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/progress_integration_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.progress-integration-test
   "Integration tests for end-to-end event sequence coverage.
 
@@ -29,9 +28,9 @@
    [ai.miniforge.event-stream.interface :as es]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Test helpers
 
-(defn simulate-workflow-run!
+;; Test helpers
+(defn ^{:stratum 0} simulate-workflow-run!
   "Simulate a complete workflow run by publishing a realistic sequence of
    lifecycle events. Returns the event stream and captured events."
   []
@@ -68,15 +67,177 @@
     (es/publish! stream (es/workflow-completed stream wf-id :success 12000))
     {:stream stream :wf-id wf-id :events captured}))
 
-(defn event-type-seq
+(defn ^{:stratum 0} event-type-seq
   "Extract a vector of :event/type from captured events."
   [captured-atom]
   (mapv :event/type @captured-atom))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Event ordering and completeness tests
+;; Chain event end-to-end tests
+(deftest ^{:stratum 0} chain-event-constructors-test
+  (testing "Chain events are created with correct types and fields"
+    (let [stream (es/create-event-stream {:sinks []})]
+      (let [e (es/chain-started stream :deploy-chain 3)]
+        (is (= :chain/started (:event/type e)))
+        (is (= :deploy-chain (:chain/id e)))
+        (is (= 3 (:chain/step-count e))))
 
-(deftest workflow-lifecycle-event-ordering-test
+      (let [wf-id (random-uuid)
+            e (es/chain-step-started stream :deploy-chain :build 0 wf-id)]
+        (is (= :chain/step-started (:event/type e)))
+        (is (= :deploy-chain (:chain/id e)))
+        (is (= :build (:step/id e)))
+        (is (= 0 (:step/index e)))
+        (is (= wf-id (:step/workflow-id e))))
+
+      (let [e (es/chain-step-completed stream :deploy-chain :build 0)]
+        (is (= :chain/step-completed (:event/type e)))
+        (is (= :build (:step/id e))))
+
+      (let [e (es/chain-step-failed stream :deploy-chain :build 0 "oops")]
+        (is (= :chain/step-failed (:event/type e)))
+        (is (= "oops" (:chain/error e))))
+
+      (let [e (es/chain-completed stream :deploy-chain 15000 3)]
+        (is (= :chain/completed (:event/type e)))
+        (is (= 15000 (:chain/duration-ms e)))
+        (is (= 3 (:chain/step-count e))))
+
+      (let [e (es/chain-failed stream :deploy-chain :build "compile error")]
+        (is (= :chain/failed (:event/type e)))
+        (is (= :build (:chain/failed-step e)))
+        (is (= "compile error" (:chain/error e)))))))
+
+(deftest ^{:stratum 0} chain-event-sequence-test
+  (testing "Chain events follow correct lifecycle ordering"
+    (let [stream (es/create-event-stream {:sinks []})
+          captured (atom [])]
+      (es/subscribe! stream :test
+                     (fn [event] (swap! captured conj event)))
+      ;; Simulate chain execution
+      (es/publish! stream (es/chain-started stream :deploy-chain 2))
+      (es/publish! stream (es/chain-step-started stream :deploy-chain :build 0 (random-uuid)))
+      (es/publish! stream (es/chain-step-completed stream :deploy-chain :build 0))
+      (es/publish! stream (es/chain-step-started stream :deploy-chain :deploy 1 (random-uuid)))
+      (es/publish! stream (es/chain-step-completed stream :deploy-chain :deploy 1))
+      (es/publish! stream (es/chain-completed stream :deploy-chain 15000 2))
+      ;; Verify ordering
+      (let [types (mapv :event/type @captured)]
+        (is (= [:chain/started
+                :chain/step-started
+                :chain/step-completed
+                :chain/step-started
+                :chain/step-completed
+                :chain/completed]
+               types)
+            "Chain events must follow start → steps → completed order")))))
+
+(deftest ^{:stratum 0} chain-event-failed-sequence-test
+  (testing "Chain failure terminates sequence correctly"
+    (let [stream (es/create-event-stream {:sinks []})
+          captured (atom [])]
+      (es/subscribe! stream :test
+                     (fn [event] (swap! captured conj event)))
+      (es/publish! stream (es/chain-started stream :deploy-chain 2))
+      (es/publish! stream (es/chain-step-started stream :deploy-chain :build 0 (random-uuid)))
+      (es/publish! stream (es/chain-step-failed stream :deploy-chain :build 0 "compile error"))
+      (es/publish! stream (es/chain-failed stream :deploy-chain :build "compile error"))
+      (let [types (mapv :event/type @captured)]
+        (is (= [:chain/started
+                :chain/step-started
+                :chain/step-failed
+                :chain/failed]
+               types)
+            "Failed chain must end at chain/failed")))))
+
+(deftest ^{:stratum 0} chain-events-have-envelope-fields-test
+  (testing "Chain events have required N3 envelope fields"
+    (let [stream (es/create-event-stream {:sinks []})
+          e (es/chain-started stream :my-chain 2)]
+      (is (uuid? (:event/id e)) "Chain event must have UUID :event/id")
+      (is (inst? (:event/timestamp e)) "Chain event must have :event/timestamp")
+      (is (string? (:event/version e)) "Chain event must have :event/version")
+      (is (int? (:event/sequence-number e)) "Chain event must have :event/sequence-number"))))
+
+;; Multiple workflow isolation test
+(deftest ^{:stratum 0} multiple-workflow-isolation-test
+  (testing "Events from different workflows do not interfere"
+    (let [stream (es/create-event-stream {:sinks []})
+          wf-1 (random-uuid)
+          wf-2 (random-uuid)
+          captured (atom [])]
+      (es/subscribe! stream :test
+                     (fn [event] (swap! captured conj event)))
+      ;; Interleave events from two workflows
+      (es/publish! stream (es/workflow-started stream wf-1))
+      (es/publish! stream (es/workflow-started stream wf-2))
+      (es/publish! stream (es/phase-started stream wf-1 :plan))
+      (es/publish! stream (es/phase-started stream wf-2 :implement))
+      (es/publish! stream (es/workflow-completed stream wf-1 :success 5000))
+      (es/publish! stream (es/workflow-completed stream wf-2 :success 8000))
+      ;; Filter by workflow
+      (let [wf1-events (filter #(= wf-1 (:workflow/id %)) @captured)
+            wf2-events (filter #(= wf-2 (:workflow/id %)) @captured)]
+        (is (= 3 (count wf1-events)) "WF1 should have 3 events")
+        (is (= 3 (count wf2-events)) "WF2 should have 3 events")
+        ;; Verify phase association
+        (is (= :plan (:workflow/phase (second wf1-events))))
+        (is (= :implement (:workflow/phase (second wf2-events))))))))
+
+(deftest ^{:stratum 0} subscriber-filter-integration-test
+  (testing "Filtered subscriber only sees matching events in full workflow"
+    (let [stream (es/create-event-stream {:sinks []})
+          wf-id (random-uuid)
+          gate-events (atom [])]
+      (es/subscribe! stream :gate-only
+                     (fn [event] (swap! gate-events conj event))
+                     (fn [event] (#{:gate/started :gate/passed :gate/failed}
+                                   (:event/type event))))
+      ;; Run a full simulation
+      (es/publish! stream (es/workflow-started stream wf-id))
+      (es/publish! stream (es/phase-started stream wf-id :plan))
+      (es/publish! stream (es/gate-started stream wf-id :lint))
+      (es/publish! stream (es/gate-passed stream wf-id :lint 50))
+      (es/publish! stream (es/gate-started stream wf-id :test))
+      (es/publish! stream (es/gate-failed stream wf-id :test [{:msg "fail"}]))
+      (es/publish! stream (es/workflow-completed stream wf-id :success 1000))
+      ;; Only gate events should be received
+      (is (= 4 (count @gate-events)))
+      (is (every? #(#{:gate/started :gate/passed :gate/failed} (:event/type %))
+                  @gate-events)))))
+
+;; Edge case and robustness tests
+(deftest ^{:stratum 0} empty-workflow-run-test
+  (testing "Minimal workflow: just started and completed"
+    (let [stream (es/create-event-stream {:sinks []})
+          wf-id (random-uuid)
+          captured (atom [])]
+      (es/subscribe! stream :test
+                     (fn [event] (swap! captured conj event)))
+      (es/publish! stream (es/workflow-started stream wf-id))
+      (es/publish! stream (es/workflow-completed stream wf-id :success 100))
+      (is (= 2 (count @captured)))
+      (is (= :workflow/started (:event/type (first @captured))))
+      (is (= :workflow/completed (:event/type (second @captured)))))))
+
+(deftest ^{:stratum 0} workflow-failed-path-test
+  (testing "Workflow that fails emits started then failed"
+    (let [stream (es/create-event-stream {:sinks []})
+          wf-id (random-uuid)
+          captured (atom [])]
+      (es/subscribe! stream :test
+                     (fn [event] (swap! captured conj event)))
+      (es/publish! stream (es/workflow-started stream wf-id))
+      (es/publish! stream (es/phase-started stream wf-id :plan))
+      (es/publish! stream (es/agent-failed stream wf-id :planner {:message "timeout"}))
+      (es/publish! stream (es/workflow-failed stream wf-id {:message "Agent failed"}))
+      (let [types (mapv :event/type @captured)]
+        (is (= :workflow/started (first types)))
+        (is (= :workflow/failed (last types)))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Event ordering and completeness tests
+(deftest ^{:stratum 1} workflow-lifecycle-event-ordering-test
   (testing "Events are emitted in correct chronological order with monotonic sequence numbers"
     (let [{:keys [events]} (simulate-workflow-run!)
           evts @events
@@ -92,7 +253,7 @@
         (is (string? (:event/version e)) "Every event must have :event/version")
         (is (int? (:event/sequence-number e)) "Every event must have :event/sequence-number")))))
 
-(deftest required-lifecycle-events-present-test
+(deftest ^{:stratum 1} required-lifecycle-events-present-test
   (testing "All required lifecycle event types are present in a full run"
     (let [{:keys [events]} (simulate-workflow-run!)
           event-types (set (map :event/type @events))]
@@ -116,14 +277,14 @@
       ;; Milestone
       (is (contains? event-types :workflow/milestone-reached) "Must emit milestone"))))
 
-(deftest event-count-test
+(deftest ^{:stratum 1} event-count-test
   (testing "Full workflow run emits expected number of events"
     (let [{:keys [events]} (simulate-workflow-run!)]
       ;; 20 events in simulate-workflow-run!
       (is (= 20 (count @events))
           "Full simulation must emit exactly 20 events"))))
 
-(deftest event-causal-ordering-test
+(deftest ^{:stratum 1} event-causal-ordering-test
   (testing "Workflow-started is first and workflow-completed is last"
     (let [{:keys [events]} (simulate-workflow-run!)
           evts @events]
@@ -170,7 +331,7 @@
             (is (< started-seq completed-seq)
                 (str "Agent " (name agent-id) " started must precede completed"))))))))
 
-(deftest gate-event-ordering-test
+(deftest ^{:stratum 1} gate-event-ordering-test
   (testing "Gate-started precedes gate-passed/failed for each gate"
     (let [{:keys [events]} (simulate-workflow-run!)
           evts @events
@@ -189,7 +350,7 @@
             (is (< started-seq result-seq)
                 (str "Gate " (name gate-id) " started must precede result"))))))))
 
-(deftest tool-event-ordering-test
+(deftest ^{:stratum 1} tool-event-ordering-test
   (testing "Tool-invoked precedes tool-completed for same tool in same agent"
     (let [{:keys [events]} (simulate-workflow-run!)
           evts @events
@@ -208,189 +369,21 @@
               (is (< invoked-seq completed-seq)
                   (str "Tool " tool " invoked by " agent " must precede completed"))))))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Chain event end-to-end tests
-
-(deftest chain-event-constructors-test
-  (testing "Chain events are created with correct types and fields"
-    (let [stream (es/create-event-stream {:sinks []})]
-      (let [e (es/chain-started stream :deploy-chain 3)]
-        (is (= :chain/started (:event/type e)))
-        (is (= :deploy-chain (:chain/id e)))
-        (is (= 3 (:chain/step-count e))))
-
-      (let [wf-id (random-uuid)
-            e (es/chain-step-started stream :deploy-chain :build 0 wf-id)]
-        (is (= :chain/step-started (:event/type e)))
-        (is (= :deploy-chain (:chain/id e)))
-        (is (= :build (:step/id e)))
-        (is (= 0 (:step/index e)))
-        (is (= wf-id (:step/workflow-id e))))
-
-      (let [e (es/chain-step-completed stream :deploy-chain :build 0)]
-        (is (= :chain/step-completed (:event/type e)))
-        (is (= :build (:step/id e))))
-
-      (let [e (es/chain-step-failed stream :deploy-chain :build 0 "oops")]
-        (is (= :chain/step-failed (:event/type e)))
-        (is (= "oops" (:chain/error e))))
-
-      (let [e (es/chain-completed stream :deploy-chain 15000 3)]
-        (is (= :chain/completed (:event/type e)))
-        (is (= 15000 (:chain/duration-ms e)))
-        (is (= 3 (:chain/step-count e))))
-
-      (let [e (es/chain-failed stream :deploy-chain :build "compile error")]
-        (is (= :chain/failed (:event/type e)))
-        (is (= :build (:chain/failed-step e)))
-        (is (= "compile error" (:chain/error e)))))))
-
-(deftest chain-event-sequence-test
-  (testing "Chain events follow correct lifecycle ordering"
-    (let [stream (es/create-event-stream {:sinks []})
-          captured (atom [])]
-      (es/subscribe! stream :test
-                     (fn [event] (swap! captured conj event)))
-      ;; Simulate chain execution
-      (es/publish! stream (es/chain-started stream :deploy-chain 2))
-      (es/publish! stream (es/chain-step-started stream :deploy-chain :build 0 (random-uuid)))
-      (es/publish! stream (es/chain-step-completed stream :deploy-chain :build 0))
-      (es/publish! stream (es/chain-step-started stream :deploy-chain :deploy 1 (random-uuid)))
-      (es/publish! stream (es/chain-step-completed stream :deploy-chain :deploy 1))
-      (es/publish! stream (es/chain-completed stream :deploy-chain 15000 2))
-      ;; Verify ordering
-      (let [types (mapv :event/type @captured)]
-        (is (= [:chain/started
-                :chain/step-started
-                :chain/step-completed
-                :chain/step-started
-                :chain/step-completed
-                :chain/completed]
-               types)
-            "Chain events must follow start → steps → completed order")))))
-
-(deftest chain-event-failed-sequence-test
-  (testing "Chain failure terminates sequence correctly"
-    (let [stream (es/create-event-stream {:sinks []})
-          captured (atom [])]
-      (es/subscribe! stream :test
-                     (fn [event] (swap! captured conj event)))
-      (es/publish! stream (es/chain-started stream :deploy-chain 2))
-      (es/publish! stream (es/chain-step-started stream :deploy-chain :build 0 (random-uuid)))
-      (es/publish! stream (es/chain-step-failed stream :deploy-chain :build 0 "compile error"))
-      (es/publish! stream (es/chain-failed stream :deploy-chain :build "compile error"))
-      (let [types (mapv :event/type @captured)]
-        (is (= [:chain/started
-                :chain/step-started
-                :chain/step-failed
-                :chain/failed]
-               types)
-            "Failed chain must end at chain/failed")))))
-
-(deftest chain-events-have-envelope-fields-test
-  (testing "Chain events have required N3 envelope fields"
-    (let [stream (es/create-event-stream {:sinks []})
-          e (es/chain-started stream :my-chain 2)]
-      (is (uuid? (:event/id e)) "Chain event must have UUID :event/id")
-      (is (inst? (:event/timestamp e)) "Chain event must have :event/timestamp")
-      (is (string? (:event/version e)) "Chain event must have :event/version")
-      (is (int? (:event/sequence-number e)) "Chain event must have :event/sequence-number"))))
-
-;------------------------------------------------------------------------------ Layer 3
-;; Multiple workflow isolation test
-
-(deftest multiple-workflow-isolation-test
-  (testing "Events from different workflows do not interfere"
-    (let [stream (es/create-event-stream {:sinks []})
-          wf-1 (random-uuid)
-          wf-2 (random-uuid)
-          captured (atom [])]
-      (es/subscribe! stream :test
-                     (fn [event] (swap! captured conj event)))
-      ;; Interleave events from two workflows
-      (es/publish! stream (es/workflow-started stream wf-1))
-      (es/publish! stream (es/workflow-started stream wf-2))
-      (es/publish! stream (es/phase-started stream wf-1 :plan))
-      (es/publish! stream (es/phase-started stream wf-2 :implement))
-      (es/publish! stream (es/workflow-completed stream wf-1 :success 5000))
-      (es/publish! stream (es/workflow-completed stream wf-2 :success 8000))
-      ;; Filter by workflow
-      (let [wf1-events (filter #(= wf-1 (:workflow/id %)) @captured)
-            wf2-events (filter #(= wf-2 (:workflow/id %)) @captured)]
-        (is (= 3 (count wf1-events)) "WF1 should have 3 events")
-        (is (= 3 (count wf2-events)) "WF2 should have 3 events")
-        ;; Verify phase association
-        (is (= :plan (:workflow/phase (second wf1-events))))
-        (is (= :implement (:workflow/phase (second wf2-events))))))))
-
-(deftest subscriber-filter-integration-test
-  (testing "Filtered subscriber only sees matching events in full workflow"
-    (let [stream (es/create-event-stream {:sinks []})
-          wf-id (random-uuid)
-          gate-events (atom [])]
-      (es/subscribe! stream :gate-only
-                     (fn [event] (swap! gate-events conj event))
-                     (fn [event] (#{:gate/started :gate/passed :gate/failed}
-                                   (:event/type event))))
-      ;; Run a full simulation
-      (es/publish! stream (es/workflow-started stream wf-id))
-      (es/publish! stream (es/phase-started stream wf-id :plan))
-      (es/publish! stream (es/gate-started stream wf-id :lint))
-      (es/publish! stream (es/gate-passed stream wf-id :lint 50))
-      (es/publish! stream (es/gate-started stream wf-id :test))
-      (es/publish! stream (es/gate-failed stream wf-id :test [{:msg "fail"}]))
-      (es/publish! stream (es/workflow-completed stream wf-id :success 1000))
-      ;; Only gate events should be received
-      (is (= 4 (count @gate-events)))
-      (is (every? #(#{:gate/started :gate/passed :gate/failed} (:event/type %))
-                  @gate-events)))))
-
-;------------------------------------------------------------------------------ Layer 4
-;; Edge case and robustness tests
-
-(deftest empty-workflow-run-test
-  (testing "Minimal workflow: just started and completed"
-    (let [stream (es/create-event-stream {:sinks []})
-          wf-id (random-uuid)
-          captured (atom [])]
-      (es/subscribe! stream :test
-                     (fn [event] (swap! captured conj event)))
-      (es/publish! stream (es/workflow-started stream wf-id))
-      (es/publish! stream (es/workflow-completed stream wf-id :success 100))
-      (is (= 2 (count @captured)))
-      (is (= :workflow/started (:event/type (first @captured))))
-      (is (= :workflow/completed (:event/type (second @captured)))))))
-
-(deftest workflow-failed-path-test
-  (testing "Workflow that fails emits started then failed"
-    (let [stream (es/create-event-stream {:sinks []})
-          wf-id (random-uuid)
-          captured (atom [])]
-      (es/subscribe! stream :test
-                     (fn [event] (swap! captured conj event)))
-      (es/publish! stream (es/workflow-started stream wf-id))
-      (es/publish! stream (es/phase-started stream wf-id :plan))
-      (es/publish! stream (es/agent-failed stream wf-id :planner {:message "timeout"}))
-      (es/publish! stream (es/workflow-failed stream wf-id {:message "Agent failed"}))
-      (let [types (mapv :event/type @captured)]
-        (is (= :workflow/started (first types)))
-        (is (= :workflow/failed (last types)))))))
-
-(deftest get-events-integration-after-full-run-test
+(deftest ^{:stratum 1} get-events-integration-after-full-run-test
   (testing "get-events returns all events from a full workflow run"
     (let [{:keys [stream events]} (simulate-workflow-run!)
           stored (es/get-events stream)]
       (is (= (count @events) (count stored))
           "Stored event count must match subscribed event count"))))
 
-(deftest get-events-filtered-by-type-integration-test
+(deftest ^{:stratum 1} get-events-filtered-by-type-integration-test
   (testing "get-events filters by event-type correctly after full run"
     (let [{:keys [stream]} (simulate-workflow-run!)
           gate-events (es/get-events stream {:event-type :gate/started})]
       (is (= 2 (count gate-events))
           "Full run has 2 gate-started events (lint and test)"))))
 
-(deftest get-latest-status-integration-test
+(deftest ^{:stratum 1} get-latest-status-integration-test
   (testing "get-latest-status returns last agent status after full run"
     (let [{:keys [stream wf-id]} (simulate-workflow-run!)
           latest (es/get-latest-status stream wf-id)]

--- a/components/event-stream/test/ai/miniforge/event_stream/publish_helpers_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/publish_helpers_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.publish-helpers-test
   "Stratum-by-stratum tests for the helpers `publish!` composes. The
    helpers are private (`defn-`) so tests reach them via `#'`-vars.
@@ -26,19 +25,31 @@
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.event-stream.core :as core]))
 
-(def ^:private workflow-quiesced?       #'core/workflow-quiesced?)
-(def ^:private rejection-result         #'core/rejection-result)
-(def ^:private rejection-if-quiesced    #'core/rejection-if-quiesced)
-(def ^:private try-acquire-in-flight!   #'core/try-acquire-in-flight!)
-(def ^:private with-in-flight           #'core/with-in-flight)
-(def ^:private quiesced-sentinel        #'core/quiesced-sentinel)
-(def ^:private record-event!            #'core/record-event!)
-(def ^:private deliver-to-sink!       #'core/deliver-to-sink!)
-(def ^:private deliver-to-sinks!      #'core/deliver-to-sinks!)
-(def ^:private deliver-to-subscriber! #'core/deliver-to-subscriber!)
-(def ^:private deliver-to-subscribers! #'core/deliver-to-subscribers!)
+;------------------------------------------------------------------------------ Layer 0
 
-(defn- evt
+(def ^{:stratum 0} ^:private workflow-quiesced?       #'core/workflow-quiesced?)
+
+(def ^{:stratum 0} ^:private rejection-result         #'core/rejection-result)
+
+(def ^{:stratum 0} ^:private rejection-if-quiesced    #'core/rejection-if-quiesced)
+
+(def ^{:stratum 0} ^:private try-acquire-in-flight!   #'core/try-acquire-in-flight!)
+
+(def ^{:stratum 0} ^:private with-in-flight           #'core/with-in-flight)
+
+(def ^{:stratum 0} ^:private quiesced-sentinel        #'core/quiesced-sentinel)
+
+(def ^{:stratum 0} ^:private record-event!            #'core/record-event!)
+
+(def ^{:stratum 0} ^:private deliver-to-sink!       #'core/deliver-to-sink!)
+
+(def ^{:stratum 0} ^:private deliver-to-sinks!      #'core/deliver-to-sinks!)
+
+(def ^{:stratum 0} ^:private deliver-to-subscriber! #'core/deliver-to-subscriber!)
+
+(def ^{:stratum 0} ^:private deliver-to-subscribers! #'core/deliver-to-subscribers!)
+
+(defn- ^{:stratum 0} evt
   ([] (evt :test/event (random-uuid)))
   ([event-type wid]
    {:event/type event-type
@@ -47,9 +58,10 @@
     :event/sequence-number 0
     :message "test"}))
 
-;------------------------------------------------------------------------------ workflow-quiesced?
+;------------------------------------------------------------------------------ Layer 1
 
-(deftest workflow-quiesced?-tracks-quiesced-set
+;------------------------------------------------------------------------------ workflow-quiesced?
+(deftest ^{:stratum 1} workflow-quiesced?-tracks-quiesced-set
   (let [wid-a (random-uuid)
         wid-b (random-uuid)
         stream (atom {:quiesced-workflows #{wid-a}})]
@@ -59,8 +71,7 @@
         "missing :workflow/id is treated as not-quiesced — there's nothing to fence"))
 
 ;------------------------------------------------------------------------------ rejection-result
-
-(deftest rejection-result-shape-is-stable
+(deftest ^{:stratum 1} rejection-result-shape-is-stable
   (let [wid (random-uuid)
         result (rejection-result {:event/type :test/event :workflow/id wid} :workflow-quiesced)]
     (is (true? (:rejected? result)))
@@ -69,12 +80,11 @@
     (is (= :test/event (:event-type result)))))
 
 ;------------------------------------------------------------------------------ rejection-if-quiesced
-
-(deftest rejection-if-quiesced-returns-nil-when-not-fenced
+(deftest ^{:stratum 1} rejection-if-quiesced-returns-nil-when-not-fenced
   (let [stream (atom {:quiesced-workflows #{} :logger nil})]
     (is (nil? (rejection-if-quiesced stream (evt))))))
 
-(deftest rejection-if-quiesced-returns-result-when-fenced
+(deftest ^{:stratum 1} rejection-if-quiesced-returns-result-when-fenced
   (let [wid (random-uuid)
         stream (atom {:quiesced-workflows #{wid} :logger nil})
         result (rejection-if-quiesced stream (evt :test/event wid))]
@@ -82,8 +92,7 @@
     (is (= :workflow-quiesced (:reason result)))))
 
 ;------------------------------------------------------------------------------ try-acquire-in-flight!
-
-(deftest try-acquire-in-flight!-acquires-when-not-quiesced
+(deftest ^{:stratum 1} try-acquire-in-flight!-acquires-when-not-quiesced
   (let [wid    (random-uuid)
         stream (atom {:in-flight 0 :quiesced-workflows #{}})
         event  (evt :test/event wid)]
@@ -92,7 +101,7 @@
     (is (= 1 (:in-flight @stream))
         ":in-flight is incremented on acquire")))
 
-(deftest try-acquire-in-flight!-rejects-when-quiesced
+(deftest ^{:stratum 1} try-acquire-in-flight!-rejects-when-quiesced
   (let [wid    (random-uuid)
         stream (atom {:in-flight 0 :quiesced-workflows #{wid}})
         event  (evt :test/event wid)]
@@ -102,8 +111,7 @@
         ":in-flight is NOT incremented when fenced — the TOCTOU window is closed")))
 
 ;------------------------------------------------------------------------------ with-in-flight
-
-(deftest with-in-flight-increments-and-decrements-around-body
+(deftest ^{:stratum 1} with-in-flight-increments-and-decrements-around-body
   (let [stream   (atom {:in-flight 0})
         observed (atom nil)]
     (with-in-flight stream (evt)
@@ -113,18 +121,18 @@
     (is (= 1 @observed) "body sees the incremented counter")
     (is (= 0 (:in-flight @stream)) "post-call counter is decremented back to zero")))
 
-(deftest with-in-flight-decrements-on-body-exception
+(deftest ^{:stratum 1} with-in-flight-decrements-on-body-exception
   (let [stream (atom {:in-flight 0})]
     (is (thrown? Exception
                  (with-in-flight stream (evt) (fn [] (throw (RuntimeException. "boom"))))))
     (is (= 0 (:in-flight @stream))
         "decrement runs in finally so a body exception doesn't leak the slot")))
 
-(deftest with-in-flight-returns-body-value
+(deftest ^{:stratum 1} with-in-flight-returns-body-value
   (let [stream (atom {:in-flight 0})]
     (is (= :result (with-in-flight stream (evt) (constantly :result))))))
 
-(deftest with-in-flight-returns-quiesced-sentinel-when-fenced
+(deftest ^{:stratum 1} with-in-flight-returns-quiesced-sentinel-when-fenced
   ;; Pins the TOCTOU fix at the unit level: with-in-flight bypasses
   ;; body-fn and returns the sentinel when try-acquire-in-flight! finds
   ;; the workflow already fenced in its atomic swap!.
@@ -138,8 +146,7 @@
         ":in-flight must not be incremented when fenced")))
 
 ;------------------------------------------------------------------------------ record-event!
-
-(deftest record-event!-appends-to-events-vector
+(deftest ^{:stratum 1} record-event!-appends-to-events-vector
   (let [stream (atom {:events []})
         e1 (evt) e2 (evt)]
     (record-event! stream e1)
@@ -147,23 +154,21 @@
     (is (= [e1 e2] (:events @stream)))))
 
 ;------------------------------------------------------------------------------ deliver-to-sink!
-
-(deftest deliver-to-sink!-calls-the-sink
+(deftest ^{:stratum 1} deliver-to-sink!-calls-the-sink
   (let [calls (atom [])
         sink (fn [e] (swap! calls conj e))
         e (evt)]
     (deliver-to-sink! sink e nil)
     (is (= [e] @calls))))
 
-(deftest deliver-to-sink!-swallows-and-logs-exceptions
+(deftest ^{:stratum 1} deliver-to-sink!-swallows-and-logs-exceptions
   (let [throwing-sink (fn [_] (throw (RuntimeException. "sink failed")))]
     ;; Logger nil — must not throw on the swallow path.
     (is (nil? (deliver-to-sink! throwing-sink (evt) nil))
         "exception from sink must not propagate; nil return is fine")))
 
 ;------------------------------------------------------------------------------ deliver-to-sinks!
-
-(deftest deliver-to-sinks!-runs-all-sinks-even-when-one-throws
+(deftest ^{:stratum 1} deliver-to-sinks!-runs-all-sinks-even-when-one-throws
   (let [calls (atom [])
         good-sink (fn [e] (swap! calls conj [:good e]))
         bad-sink (fn [_] (throw (RuntimeException. "boom")))
@@ -176,8 +181,7 @@
     (is (= [:other e] (second @calls)))))
 
 ;------------------------------------------------------------------------------ deliver-to-subscriber!
-
-(deftest deliver-to-subscriber!-respects-filter
+(deftest ^{:stratum 1} deliver-to-subscriber!-respects-filter
   (let [calls (atom [])
         callback (fn [e] (swap! calls conj e))
         accept-fn (constantly true)
@@ -188,14 +192,13 @@
     (deliver-to-subscriber! :sub-1 callback accept-fn e nil)
     (is (= [e] @calls))))
 
-(deftest deliver-to-subscriber!-swallows-callback-exceptions
+(deftest ^{:stratum 1} deliver-to-subscriber!-swallows-callback-exceptions
   (let [throwing-cb (fn [_] (throw (RuntimeException. "cb failed")))]
     (is (nil? (deliver-to-subscriber! :sub-1 throwing-cb (constantly true) (evt) nil))
         "callback exception must not propagate")))
 
 ;------------------------------------------------------------------------------ deliver-to-subscribers!
-
-(deftest deliver-to-subscribers!-applies-filters-and-isolates-failures
+(deftest ^{:stratum 1} deliver-to-subscribers!-applies-filters-and-isolates-failures
   (let [calls (atom [])
         cb-a (fn [e] (swap! calls conj [:a e]))
         cb-b (fn [_] (throw (RuntimeException. "b boom")))

--- a/components/event-stream/test/ai/miniforge/event_stream/quiesce_drain_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/quiesce_drain_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.quiesce-drain-test
   "Contract tests for the BD-2a shutdown ordering primitives.
 
@@ -28,7 +27,9 @@
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.event-stream.core :as core]))
 
-(defn- recording-sink
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} recording-sink
   "Return [sink record] where `sink` collects events into `record` so
    tests can assert sink reach-through."
   []
@@ -36,7 +37,7 @@
         sink (fn [event] (swap! record conj event))]
     [sink record]))
 
-(defn- workflow-event
+(defn- ^{:stratum 0} workflow-event
   "Build a minimal event with `:workflow/id` for publish! tests. The
    envelope shape is what `create-envelope` would have produced; tests
    here construct it directly to avoid mutating sequence numbers."
@@ -48,72 +49,13 @@
    :workflow/id workflow-id
    :message "test"})
 
-;------------------------------------------------------------------------------ quiesce!
-
-(deftest quiesce-rejects-future-publishes-for-target-workflow
-  (let [[sink record] (recording-sink)
-        stream (core/create-event-stream {:sinks [sink]})
-        wid (random-uuid)
-        result-pre (core/publish! stream (workflow-event wid :test/event))
-        _quiesce (core/quiesce! stream {:workflow-id wid})
-        result-post (core/publish! stream (workflow-event wid :test/event))]
-    (is (= 1 (count @record))
-        "the sink should observe the pre-quiesce event but not the post-quiesce one")
-    (is (not (:rejected? result-pre)))
-    (is (true? (:rejected? result-post)))
-    (is (= :workflow-quiesced (:reason result-post)))
-    (is (= wid (:workflow-id result-post)))))
-
-(deftest quiesce-only-fences-named-workflow
-  (let [[sink record] (recording-sink)
-        stream (core/create-event-stream {:sinks [sink]})
-        wid-a (random-uuid)
-        wid-b (random-uuid)]
-    (core/quiesce! stream {:workflow-id wid-a})
-    (let [a-result (core/publish! stream (workflow-event wid-a :test/event))
-          b-result (core/publish! stream (workflow-event wid-b :test/event))]
-      (is (true? (:rejected? a-result))
-          "workflow A is quiesced and must reject")
-      (is (not (:rejected? b-result))
-          "workflow B is independent and must still publish")
-      (is (= 1 (count @record))
-          "only B's event reached the sink"))))
-
-(deftest quiesce-without-workflow-id-just-waits
-  ;; Without a target workflow, quiesce! adds no fence — it only waits
-  ;; for any currently in-flight publish to settle. Useful as a global
-  ;; barrier before drain! when no specific workflow is being torn down.
-  (let [stream (core/create-event-stream {:sinks []})]
-    (let [result (core/quiesce! stream {})]
-      (is (true? (:ok? result)))
-      (is (= 0 (:pending-publishers result))))
-    (let [wid (random-uuid)
-          ;; And publish still works after a no-target quiesce.
-          publish-result (core/publish! stream (workflow-event wid :test/event))]
-      (is (not (:rejected? publish-result))))))
-
-(deftest quiesce-returns-ok-when-stream-is-quiet
+(deftest ^{:stratum 0} quiesce-returns-ok-when-stream-is-quiet
   (let [stream (core/create-event-stream {:sinks []})
         result (core/quiesce! stream {:workflow-id (random-uuid) :timeout-ms 500})]
     (is (true? (:ok? result)))
     (is (= 0 (:pending-publishers result)))))
 
-;------------------------------------------------------------------------------ drain!
-
-(deftest drain-default-sinks-return-ok-immediately
-  ;; File / stdout / stderr sinks are synchronous in the publish! body, so
-  ;; once publish! returns there is nothing to drain. Sinks without a
-  ;; metadata `:drain` hook are assumed already-drained.
-  (let [[sink _record] (recording-sink)
-        stream (core/create-event-stream {:sinks [sink]})
-        wid (random-uuid)]
-    (dotimes [_ 5]
-      (core/publish! stream (workflow-event wid :test/event)))
-    (let [result (core/drain! stream {:timeout-ms 500})]
-      (is (true? (:ok? result)))
-      (is (= 1 (:drained-count result))))))
-
-(deftest drain-invokes-sink-drain-hook-when-present
+(deftest ^{:stratum 0} drain-invokes-sink-drain-hook-when-present
   ;; A sink that carries a drain hook under metadata (e.g. fleet-sink with
   ;; an internal batch) must receive the drain call and report status.
   (let [drain-called? (atom false)
@@ -127,7 +69,7 @@
     (is (true? @drain-called?))
     (is (true? (:ok? result)))))
 
-(deftest drain-reports-sink-error-with-structured-result
+(deftest ^{:stratum 0} drain-reports-sink-error-with-structured-result
   (let [bad-sink (with-meta
                    (fn [_event] nil)
                    {:drain (fn [_opts] {:ok? false :reason :sink-error :error "boom"})})
@@ -141,7 +83,7 @@
     (is (= 1 (count (:failed-sinks result))))
     (is (= "boom" (-> result :failed-sinks first :error)))))
 
-(deftest drain-reports-timeout-when-sink-hook-hangs
+(deftest ^{:stratum 0} drain-reports-timeout-when-sink-hook-hangs
   (let [hanging-sink (with-meta
                        (fn [_event] nil)
                        {:drain (fn [_opts]
@@ -154,7 +96,7 @@
     (is (= :sink-error (:reason result))
         "sink-reported timeout surfaces as a sink-error in the aggregate result")))
 
-(deftest drain-budget-short-circuits-remaining-sinks-when-deadline-passes
+(deftest ^{:stratum 0} drain-budget-short-circuits-remaining-sinks-when-deadline-passes
   ;; If an earlier sink consumes the entire drain budget, subsequent
   ;; sinks must not be granted "extra" wall time (which would happen
   ;; under a `(max 100 remaining)` floor). They are marked as timed out
@@ -178,7 +120,7 @@
     (is (= 2 (count (:failed-sinks result)))
         "both sinks contribute failure entries — the burner timed out, the later one was short-circuited")))
 
-(deftest drain-catches-sink-drain-exceptions
+(deftest ^{:stratum 0} drain-catches-sink-drain-exceptions
   (let [throwing-sink (with-meta
                         (fn [_event] nil)
                         {:drain (fn [_opts] (throw (ex-info "kaboom" {})))})
@@ -188,9 +130,71 @@
     (is (= :sink-error (:reason result)))
     (is (= "kaboom" (-> result :failed-sinks first :error)))))
 
-;------------------------------------------------------------------------------ ordering invariants
+(def ^{:stratum 0} ^:private with-in-flight-var  #'core/with-in-flight)
 
-(deftest publish-during-drain-does-not-bypass-quiesce
+(def ^{:stratum 0} ^:private quiesced-sentinel-var #'core/quiesced-sentinel)
+
+;------------------------------------------------------------------------------ Layer 1
+
+;------------------------------------------------------------------------------ quiesce!
+(deftest ^{:stratum 1} quiesce-rejects-future-publishes-for-target-workflow
+  (let [[sink record] (recording-sink)
+        stream (core/create-event-stream {:sinks [sink]})
+        wid (random-uuid)
+        result-pre (core/publish! stream (workflow-event wid :test/event))
+        _quiesce (core/quiesce! stream {:workflow-id wid})
+        result-post (core/publish! stream (workflow-event wid :test/event))]
+    (is (= 1 (count @record))
+        "the sink should observe the pre-quiesce event but not the post-quiesce one")
+    (is (not (:rejected? result-pre)))
+    (is (true? (:rejected? result-post)))
+    (is (= :workflow-quiesced (:reason result-post)))
+    (is (= wid (:workflow-id result-post)))))
+
+(deftest ^{:stratum 1} quiesce-only-fences-named-workflow
+  (let [[sink record] (recording-sink)
+        stream (core/create-event-stream {:sinks [sink]})
+        wid-a (random-uuid)
+        wid-b (random-uuid)]
+    (core/quiesce! stream {:workflow-id wid-a})
+    (let [a-result (core/publish! stream (workflow-event wid-a :test/event))
+          b-result (core/publish! stream (workflow-event wid-b :test/event))]
+      (is (true? (:rejected? a-result))
+          "workflow A is quiesced and must reject")
+      (is (not (:rejected? b-result))
+          "workflow B is independent and must still publish")
+      (is (= 1 (count @record))
+          "only B's event reached the sink"))))
+
+(deftest ^{:stratum 1} quiesce-without-workflow-id-just-waits
+  ;; Without a target workflow, quiesce! adds no fence — it only waits
+  ;; for any currently in-flight publish to settle. Useful as a global
+  ;; barrier before drain! when no specific workflow is being torn down.
+  (let [stream (core/create-event-stream {:sinks []})]
+    (let [result (core/quiesce! stream {})]
+      (is (true? (:ok? result)))
+      (is (= 0 (:pending-publishers result))))
+    (let [wid (random-uuid)
+          ;; And publish still works after a no-target quiesce.
+          publish-result (core/publish! stream (workflow-event wid :test/event))]
+      (is (not (:rejected? publish-result))))))
+
+;------------------------------------------------------------------------------ drain!
+(deftest ^{:stratum 1} drain-default-sinks-return-ok-immediately
+  ;; File / stdout / stderr sinks are synchronous in the publish! body, so
+  ;; once publish! returns there is nothing to drain. Sinks without a
+  ;; metadata `:drain` hook are assumed already-drained.
+  (let [[sink _record] (recording-sink)
+        stream (core/create-event-stream {:sinks [sink]})
+        wid (random-uuid)]
+    (dotimes [_ 5]
+      (core/publish! stream (workflow-event wid :test/event)))
+    (let [result (core/drain! stream {:timeout-ms 500})]
+      (is (true? (:ok? result)))
+      (is (= 1 (:drained-count result))))))
+
+;------------------------------------------------------------------------------ ordering invariants
+(deftest ^{:stratum 1} publish-during-drain-does-not-bypass-quiesce
   ;; Pin the contract that quiesce! prevents publishers from sneaking in
   ;; between quiesce! and drain!. Without the quiesce step, drain! cannot
   ;; cover late publishers — that's the v1 race the BD-2a primitives are
@@ -208,7 +212,7 @@
     (is (= 1 (count @record))
         "exactly one event reached the sink — the pre-quiesce one")))
 
-(deftest in-flight-tracking-decrements-on-sink-exception
+(deftest ^{:stratum 1} in-flight-tracking-decrements-on-sink-exception
   ;; A sink that throws must still release the in-flight slot, otherwise
   ;; quiesce! and drain! would wait forever on a stuck counter.
   (let [throwing-sink (fn [_event] (throw (RuntimeException. "sink boom")))
@@ -220,10 +224,7 @@
       (is (true? (:ok? result))
           "in-flight counter must release even when the sink throws"))))
 
-(def ^:private with-in-flight-var  #'core/with-in-flight)
-(def ^:private quiesced-sentinel-var #'core/quiesced-sentinel)
-
-(deftest publish-rejected-when-quiesced-during-atomic-acquire
+(deftest ^{:stratum 1} publish-rejected-when-quiesced-during-atomic-acquire
   ;; Pin the TOCTOU fix: a publish that clears the fast-path
   ;; rejection-if-quiesced check (stream not yet quiesced) but then
   ;; encounters a quiesce during the atomic acquire inside with-in-flight

--- a/components/event-stream/test/ai/miniforge/event_stream/reader_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/reader_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.reader-test
   (:require
    [clojure.test :refer [deftest testing is]]
@@ -23,7 +22,9 @@
    [cheshire.core :as json]
    [ai.miniforge.event-stream.reader :as reader]))
 
-(defn- with-temp-dir [body-fn]
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} with-temp-dir [body-fn]
   (let [dir (doto (io/file (System/getProperty "java.io.tmpdir")
                            (str "mf-reader-test-" (random-uuid)))
               .mkdirs)]
@@ -33,41 +34,45 @@
         (doseq [^java.io.File f (reverse (file-seq dir))]
           (.delete f))))))
 
-(defn- write-event! [^java.io.File dir filename event-map]
+(defn- ^{:stratum 0} write-event! [^java.io.File dir filename event-map]
   (spit (io/file dir filename) (json/generate-string event-map)))
 
-;------------------------------------------------------------------------------ Layer 0
 ;; strip-transit-prefix
-
-(deftest strip-transit-prefix-keyword-keys-test
+(deftest ^{:stratum 0} strip-transit-prefix-keyword-keys-test
   (testing "string keys starting with ~: become keywords"
     (is (= {:event/type :workflow/started}
            (reader/strip-transit-prefix
              {"~:event/type" "~:workflow/started"})))))
 
-(deftest strip-transit-prefix-nested-walk-test
+(deftest ^{:stratum 0} strip-transit-prefix-nested-walk-test
   (testing "walks into nested maps and vectors"
     (is (= {:a [:b {:c :d}]}
            (reader/strip-transit-prefix
              {"~:a" ["~:b" {"~:c" "~:d"}]})))))
 
-(deftest strip-transit-prefix-uuid-instant-test
+(deftest ^{:stratum 0} strip-transit-prefix-uuid-instant-test
   (testing "~u and ~t prefixes strip the 2-char prefix"
     (is (= "some-uuid" (reader/strip-transit-prefix "~usome-uuid")))
     (is (= "2026-04-21T00:00:00Z"
            (reader/strip-transit-prefix "~t2026-04-21T00:00:00Z")))))
 
-(deftest strip-transit-prefix-non-tagged-strings-test
+(deftest ^{:stratum 0} strip-transit-prefix-non-tagged-strings-test
   (testing "plain strings and primitives pass through"
     (is (= "hello" (reader/strip-transit-prefix "hello")))
     (is (= 42 (reader/strip-transit-prefix 42)))
     (is (nil? (reader/strip-transit-prefix nil)))
     (is (true? (reader/strip-transit-prefix true)))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; read-workflow-events — the resume-blocking bug
+(deftest ^{:stratum 0} read-workflow-events-missing-dir-returns-nil-test
+  (testing "non-existent directory → nil (no throw)"
+    (is (nil? (reader/read-workflow-events
+                (io/file (System/getProperty "java.io.tmpdir")
+                         (str "mf-reader-test-missing-" (random-uuid))))))))
 
-(deftest read-workflow-events-sorts-by-filename-test
+;------------------------------------------------------------------------------ Layer 1
+
+;; read-workflow-events — the resume-blocking bug
+(deftest ^{:stratum 1} read-workflow-events-sorts-by-filename-test
   (with-temp-dir
     (fn [dir]
       (write-event! dir "20260420T000002Z-eventB.json"
@@ -88,7 +93,7 @@
           (is (= :workflow/phase-completed (:event/type (last events))))
           (is (= :plan (:workflow/phase (second events)))))))))
 
-(deftest read-workflow-events-ignores-non-json-test
+(deftest ^{:stratum 1} read-workflow-events-ignores-non-json-test
   (with-temp-dir
     (fn [dir]
       (write-event! dir "good.json"
@@ -99,7 +104,7 @@
         (let [events (reader/read-workflow-events dir)]
           (is (= 1 (count events))))))))
 
-(deftest read-workflow-events-tolerates-corrupt-json-test
+(deftest ^{:stratum 1} read-workflow-events-tolerates-corrupt-json-test
   (with-temp-dir
     (fn [dir]
       (write-event! dir "20260420T000001Z-good.json"
@@ -114,13 +119,7 @@
           (is (= :workflow/started (:event/type (first events))))
           (is (= :workflow/completed (:event/type (last events)))))))))
 
-(deftest read-workflow-events-missing-dir-returns-nil-test
-  (testing "non-existent directory → nil (no throw)"
-    (is (nil? (reader/read-workflow-events
-                (io/file (System/getProperty "java.io.tmpdir")
-                         (str "mf-reader-test-missing-" (random-uuid))))))))
-
-(deftest read-workflow-events-by-id-composes-path-test
+(deftest ^{:stratum 1} read-workflow-events-by-id-composes-path-test
   (with-temp-dir
     (fn [base-dir]
       (let [wf-id (str (random-uuid))

--- a/components/event-stream/test/ai/miniforge/event_stream/reliability_schema_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/reliability_schema_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.reliability-schema-test
   "Tests for RN-03: 4 reliability metric schemas + 2 repo-index schemas
    and the constructor functions that produce conforming event maps.
@@ -32,16 +31,16 @@
    [ai.miniforge.event-stream.schema :as schema]
    [ai.miniforge.event-stream.interface :as es]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;; ---------------------------------------------------------------------------
 ;; Helpers
-
-(defn- make-stream []
+(defn- ^{:stratum 0} make-stream []
   (es/create-event-stream {:sinks []}))
 
 ;; ---------------------------------------------------------------------------
-;; Layer 5.5 — Reliability metric schemas
-
-(deftest sli-computed-schema-test
+;; Reliability metric schemas
+(deftest ^{:stratum 0} sli-computed-schema-test
   (testing "SliComputed positive validation"
     (let [event {:event/type            :reliability/sli-computed
                  :event/id              (random-uuid)
@@ -80,7 +79,7 @@
       (is (not (m/validate schema/SliComputed event))
           "missing :sli/window should fail"))))
 
-(deftest slo-breach-schema-test
+(deftest ^{:stratum 0} slo-breach-schema-test
   (testing "SloBreach positive validation"
     (let [event {:event/type            :reliability/slo-breach
                  :event/id              (random-uuid)
@@ -110,7 +109,7 @@
       (is (not (m/validate schema/SloBreach event))
           "missing :slo/actual should fail"))))
 
-(deftest error-budget-update-schema-test
+(deftest ^{:stratum 0} error-budget-update-schema-test
   (testing "ErrorBudgetUpdate positive validation"
     (let [event {:event/type            :reliability/error-budget-update
                  :event/id              (random-uuid)
@@ -140,7 +139,7 @@
       (is (not (m/validate schema/ErrorBudgetUpdate event))
           "missing :budget/burn-rate should fail"))))
 
-(deftest degradation-mode-changed-schema-test
+(deftest ^{:stratum 0} degradation-mode-changed-schema-test
   (testing "DegradationModeChanged positive validation"
     (let [event {:event/type            :reliability/degradation-mode-changed
                  :event/id              (random-uuid)
@@ -167,9 +166,8 @@
           "missing :degradation/trigger should fail"))))
 
 ;; ---------------------------------------------------------------------------
-;; Layer 6 — Repo-index schemas
-
-(deftest repo-index-quality-measured-schema-test
+;; Repo-index schemas
+(deftest ^{:stratum 0} repo-index-quality-measured-schema-test
   (testing "RepoIndexQualityMeasured positive validation"
     (let [event {:event/type            :repo-index/quality-measured
                  :event/id              (random-uuid)
@@ -210,7 +208,7 @@
       (is (not (m/validate schema/RepoIndexQualityMeasured event))
           "missing :index/id should fail"))))
 
-(deftest repo-index-coverage-changed-schema-test
+(deftest ^{:stratum 0} repo-index-coverage-changed-schema-test
   (testing "RepoIndexCoverageChanged positive validation"
     (let [event {:event/type               :repo-index/coverage-changed
                  :event/id                 (random-uuid)
@@ -245,8 +243,7 @@
 ;; :sli/value, :slo/target and :slo/actual are intentionally unconstrained —
 ;; they carry SLI-native units (a ratio for rate-based SLIs, an absolute
 ;; measure such as latency ms for others) — so they are not covered here.
-
-(defn- valid-error-budget [overrides]
+(defn- ^{:stratum 0} valid-error-budget [overrides]
   (merge {:event/type            :reliability/error-budget-update
           :event/id              (random-uuid)
           :event/timestamp       (java.util.Date.)
@@ -260,7 +257,7 @@
           :message               "Error budget update"}
          overrides))
 
-(defn- valid-quality-measured [overrides]
+(defn- ^{:stratum 0} valid-quality-measured [overrides]
   (merge {:event/type            :repo-index/quality-measured
           :event/id              (random-uuid)
           :event/timestamp       (java.util.Date.)
@@ -273,7 +270,7 @@
           :message               "Index quality measured"}
          overrides))
 
-(defn- valid-coverage-changed [overrides]
+(defn- ^{:stratum 0} valid-coverage-changed [overrides]
   (merge {:event/type              :repo-index/coverage-changed
           :event/id                (random-uuid)
           :event/timestamp         (java.util.Date.)
@@ -286,7 +283,9 @@
           :message                 "Index coverage changed"}
          overrides))
 
-(deftest range-bounds-rejection-test
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} range-bounds-rejection-test
   (testing "ErrorBudgetUpdate :budget/remaining must be a [0.0, 1.0] ratio"
     (is (m/validate schema/ErrorBudgetUpdate (valid-error-budget {:budget/remaining 0.0})))
     (is (m/validate schema/ErrorBudgetUpdate (valid-error-budget {:budget/remaining 1.0})))
@@ -308,8 +307,7 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Constructor output and round-trip tests
-
-(deftest sli-computed-constructor-test
+(deftest ^{:stratum 1} sli-computed-constructor-test
   (testing "sli-computed constructor produces correct :event/type"
     (let [stream (make-stream)
           event  (es/sli-computed stream :availability 0.999 :rolling-1h)]
@@ -331,7 +329,7 @@
           event  (es/sli-computed stream :latency 0.95 :rolling-5m {:tier :critical})]
       (is (= :critical (:sli/tier event))))))
 
-(deftest slo-breach-constructor-test
+(deftest ^{:stratum 1} slo-breach-constructor-test
   (testing "slo-breach constructor produces correct :event/type"
     (let [stream (make-stream)
           event  (es/slo-breach stream :availability 0.999 0.980 :standard :rolling-1h)]
@@ -350,7 +348,7 @@
       (is (m/validate schema/SloBreach event)
           "constructor output must satisfy SloBreach schema"))))
 
-(deftest error-budget-update-constructor-test
+(deftest ^{:stratum 1} error-budget-update-constructor-test
   (testing "error-budget-update constructor produces correct :event/type"
     (let [stream (make-stream)
           event  (es/error-budget-update stream :standard :availability 0.72 1.4 :rolling-30d)]
@@ -369,7 +367,7 @@
       (is (m/validate schema/ErrorBudgetUpdate event)
           "constructor output must satisfy ErrorBudgetUpdate schema"))))
 
-(deftest degradation-mode-changed-constructor-test
+(deftest ^{:stratum 1} degradation-mode-changed-constructor-test
   (testing "degradation-mode-changed constructor produces correct :event/type"
     (let [stream (make-stream)
           event  (es/degradation-mode-changed stream :normal :degraded "error-rate exceeded")]
@@ -386,7 +384,7 @@
       (is (m/validate schema/DegradationModeChanged event)
           "constructor output must satisfy DegradationModeChanged schema"))))
 
-(deftest repo-index-quality-measured-constructor-test
+(deftest ^{:stratum 1} repo-index-quality-measured-constructor-test
   (testing "repo-index-quality-measured produces correct :event/type"
     (let [stream (make-stream)
           event  (es/repo-index-quality-measured stream "main-code-index" 0.87 0.93 300000)]
@@ -412,7 +410,7 @@
                        {:measured-at measured-at})]
       (is (= measured-at (:index/measured-at event))))))
 
-(deftest repo-index-coverage-changed-constructor-test
+(deftest ^{:stratum 1} repo-index-coverage-changed-constructor-test
   (testing "repo-index-coverage-changed produces correct :event/type"
     (let [stream (make-stream)
           event  (es/repo-index-coverage-changed stream "main-code-index" 0.80 0.93)]

--- a/components/event-stream/test/ai/miniforge/event_stream/sinks_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/sinks_test.clj
@@ -100,21 +100,21 @@
 ;; create-sinks-from-config
 (deftest ^{:stratum 0} create-sinks-from-config-test
   (testing "defaults to file sink when no config"
-    (let [sinks (sinks/create-sinks-from-config {})]
-      (is (= 1 (count sinks)))
-      (is (fn? (first sinks)))))
+    (let [created-sinks (sinks/create-sinks-from-config {})]
+      (is (= 1 (count created-sinks)))
+      (is (fn? (first created-sinks)))))
 
   (testing "creates sinks from :observability :event-sinks"
-    (let [sinks (sinks/create-sinks-from-config
-                 {:observability {:event-sinks [:stdout]}})]
-      (is (= 1 (count sinks)))
-      (is (fn? (first sinks)))))
+    (let [created-sinks (sinks/create-sinks-from-config
+                         {:observability {:event-sinks [:stdout]}})]
+      (is (= 1 (count created-sinks)))
+      (is (fn? (first created-sinks)))))
 
   (testing "multiple sinks from config"
-    (let [sinks (sinks/create-sinks-from-config
-                 {:observability {:event-sinks [:file :stdout]}})]
-      (is (= 2 (count sinks)))
-      (is (every? fn? sinks)))))
+    (let [created-sinks (sinks/create-sinks-from-config
+                         {:observability {:event-sinks [:file :stdout]}})]
+      (is (= 2 (count created-sinks)))
+      (is (every? fn? created-sinks)))))
 
 ;------------------------------------------------------------------------------ Layer 1
 

--- a/components/event-stream/test/ai/miniforge/event_stream/sinks_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/sinks_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.sinks-test
   "Unit tests for event sink functions."
   (:require
@@ -27,9 +26,10 @@
    [ai.miniforge.event-stream.sinks :as sinks]
    [ai.miniforge.event-stream.test-helpers.http-mock :as http-mock]))
 
-;------------------------------------------------------------------------------ Helpers
+;------------------------------------------------------------------------------ Layer 0
 
-(defn with-temp-dir [f]
+;------------------------------------------------------------------------------ Helpers
+(defn ^{:stratum 0} with-temp-dir [f]
   (let [dir (java.nio.file.Files/createTempDirectory
               "sinks-test-"
               (into-array java.nio.file.attribute.FileAttribute []))]
@@ -39,7 +39,7 @@
         (doseq [file (reverse (file-seq (.toFile dir)))]
           (.delete ^java.io.File file))))))
 
-(defn sample-event [& [overrides]]
+(defn ^{:stratum 0} sample-event [& [overrides]]
   (merge {:event/type :workflow/started
           :event/id (random-uuid)
           :event/timestamp (java.util.Date.)
@@ -49,25 +49,81 @@
           :message "Test event"}
          overrides))
 
-(defn read-transit-json [s]
+(defn ^{:stratum 0} read-transit-json [s]
   (transit/read
    (transit/reader
     (java.io.ByteArrayInputStream. (.getBytes ^String s "UTF-8"))
     :json-verbose)))
 
-(defn list-files [^java.io.File dir]
+(defn ^{:stratum 0} list-files [^java.io.File dir]
   (when (.isDirectory dir)
     (vec (.listFiles dir))))
+
+;; create-sink factory
+(deftest ^{:stratum 0} create-sink-keyword-test
+  (testing ":file produces a function"
+    (is (fn? (sinks/create-sink :file))))
+
+  (testing ":stdout produces a function"
+    (is (fn? (sinks/create-sink :stdout))))
+
+  (testing ":stderr produces a function"
+    (is (fn? (sinks/create-sink :stderr)))))
+
+(deftest ^{:stratum 0} create-sink-map-test
+  (testing "map with :type :file produces file sink"
+    (is (fn? (sinks/create-sink {:type :file}))))
+
+  (testing "map with :type :stdout produces stdout sink"
+    (is (fn? (sinks/create-sink {:type :stdout}))))
+
+  (testing "map with :type :stderr and filter produces stderr sink"
+    (is (fn? (sinks/create-sink {:type :stderr :filter (constantly true)}))))
+
+  (testing "map with unknown type throws"
+    (is (thrown? Exception (sinks/create-sink {:type :unknown})))))
+
+(deftest ^{:stratum 0} create-sink-vector-test
+  (testing "vector creates multi-sink"
+    (let [_received-1 (atom [])
+          _received-2 (atom [])
+          ;; Use a vector of keyword sinks but verify via multi-sink behavior
+          sink (sinks/create-sink [:stdout :stdout])]
+      ;; Should be a function
+      (is (fn? sink)))))
+
+(deftest ^{:stratum 0} create-sink-invalid-test
+  (testing "invalid config throws"
+    (is (thrown? Exception (sinks/create-sink 42)))
+    (is (thrown? Exception (sinks/create-sink "invalid")))))
+
+;; create-sinks-from-config
+(deftest ^{:stratum 0} create-sinks-from-config-test
+  (testing "defaults to file sink when no config"
+    (let [sinks (sinks/create-sinks-from-config {})]
+      (is (= 1 (count sinks)))
+      (is (fn? (first sinks)))))
+
+  (testing "creates sinks from :observability :event-sinks"
+    (let [sinks (sinks/create-sinks-from-config
+                 {:observability {:event-sinks [:stdout]}})]
+      (is (= 1 (count sinks)))
+      (is (fn? (first sinks)))))
+
+  (testing "multiple sinks from config"
+    (let [sinks (sinks/create-sinks-from-config
+                 {:observability {:event-sinks [:file :stdout]}})]
+      (is (= 2 (count sinks)))
+      (is (every? fn? sinks)))))
+
+;------------------------------------------------------------------------------ Layer 1
 
 ;; `mock-http-client` lives in the shared
 ;; `ai.miniforge.event-stream.test-helpers.http-mock` namespace so other
 ;; sink tests can reuse the same proxy stubs without re-implementing
 ;; HttpClient's ~10 abstract methods.
-
-;------------------------------------------------------------------------------ Layer 0
 ;; workflow-dir / event-file-path normalisation
-
-(deftest workflow-dir-normalizes-keyword-id
+(deftest ^{:stratum 1} workflow-dir-normalizes-keyword-id
   ;; Keyword workflow ids (e.g. `:canonical-sdlc` from `workflow run`)
   ;; must NOT round-trip through `(str ...)` because the result
   ;; (`":canonical-sdlc"`) carries a colon — invalid on Windows and
@@ -85,7 +141,7 @@
         (is (= "wf-abc" (.getName string-path))
             "string id passes through unchanged")))))
 
-(deftest event-file-path-normalizes-keyword-workflow-id
+(deftest ^{:stratum 1} event-file-path-normalizes-keyword-workflow-id
   ;; Same normalisation must apply to event-file-path so events and
   ;; the manifest end up under identical workflow directories.
   (with-temp-dir
@@ -99,7 +155,7 @@
              normalisation as workflow-dir so events sit beside the
              manifest")))))
 
-(deftest event-file-path-test
+(deftest ^{:stratum 1} event-file-path-test
   (testing "returns a File path ending in .json under an explicit base-dir"
     (with-temp-dir
       (fn [dir]
@@ -146,10 +202,8 @@
           (is (re-matches #"\d{8}T\d{9}Z-[0-9a-f-]+\.json" filename)
               (str "expected legacy timestamp-leading filename, got: " filename)))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; file-sink
-
-(deftest file-sink-test
+(deftest ^{:stratum 1} file-sink-test
   (testing "writes event to per-workflow file as Transit-JSON"
     (with-temp-dir
       (fn [dir]
@@ -234,10 +288,8 @@
             (is (= :workflow/started
                    (:event/type (read-transit-json (slurp event-file)))))))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; stdout-sink
-
-(deftest stdout-sink-test
+(deftest ^{:stratum 1} stdout-sink-test
   (testing "prints event to stdout in edn format"
     (let [sink (sinks/stdout-sink {:compact true})
           event (sample-event)
@@ -254,10 +306,8 @@
       ;; Compact EDN should be a single line (no internal newlines before the closing brace)
       (is (str/starts-with? output "{")))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; stderr-sink
-
-(deftest stderr-sink-test
+(deftest ^{:stratum 1} stderr-sink-test
   (testing "only passes events matching filter"
     (let [_passed (atom [])
           sink (sinks/stderr-sink {:filter (fn [e] (= :workflow/failed (:event/type e)))})]
@@ -282,10 +332,8 @@
                    (str w))]
       (is (not (str/blank? output))))))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; multi-sink
-
-(deftest multi-sink-test
+(deftest ^{:stratum 1} multi-sink-test
   (testing "dispatches to all child sinks"
     (let [received-1 (atom [])
           received-2 (atom [])
@@ -311,71 +359,8 @@
       ;; Should not throw
       (is (nil? (multi (sample-event)))))))
 
-;------------------------------------------------------------------------------ Layer 3
-;; create-sink factory
-
-(deftest create-sink-keyword-test
-  (testing ":file produces a function"
-    (is (fn? (sinks/create-sink :file))))
-
-  (testing ":stdout produces a function"
-    (is (fn? (sinks/create-sink :stdout))))
-
-  (testing ":stderr produces a function"
-    (is (fn? (sinks/create-sink :stderr)))))
-
-(deftest create-sink-map-test
-  (testing "map with :type :file produces file sink"
-    (is (fn? (sinks/create-sink {:type :file}))))
-
-  (testing "map with :type :stdout produces stdout sink"
-    (is (fn? (sinks/create-sink {:type :stdout}))))
-
-  (testing "map with :type :stderr and filter produces stderr sink"
-    (is (fn? (sinks/create-sink {:type :stderr :filter (constantly true)}))))
-
-  (testing "map with unknown type throws"
-    (is (thrown? Exception (sinks/create-sink {:type :unknown})))))
-
-(deftest create-sink-vector-test
-  (testing "vector creates multi-sink"
-    (let [_received-1 (atom [])
-          _received-2 (atom [])
-          ;; Use a vector of keyword sinks but verify via multi-sink behavior
-          sink (sinks/create-sink [:stdout :stdout])]
-      ;; Should be a function
-      (is (fn? sink)))))
-
-(deftest create-sink-invalid-test
-  (testing "invalid config throws"
-    (is (thrown? Exception (sinks/create-sink 42)))
-    (is (thrown? Exception (sinks/create-sink "invalid")))))
-
-;------------------------------------------------------------------------------ Layer 4
-;; create-sinks-from-config
-
-(deftest create-sinks-from-config-test
-  (testing "defaults to file sink when no config"
-    (let [sinks (sinks/create-sinks-from-config {})]
-      (is (= 1 (count sinks)))
-      (is (fn? (first sinks)))))
-
-  (testing "creates sinks from :observability :event-sinks"
-    (let [sinks (sinks/create-sinks-from-config
-                 {:observability {:event-sinks [:stdout]}})]
-      (is (= 1 (count sinks)))
-      (is (fn? (first sinks)))))
-
-  (testing "multiple sinks from config"
-    (let [sinks (sinks/create-sinks-from-config
-                 {:observability {:event-sinks [:file :stdout]}})]
-      (is (= 2 (count sinks)))
-      (is (every? fn? sinks)))))
-
-;------------------------------------------------------------------------------ Layer 4
 ;; fleet-sink
-
-(deftest fleet-sink-test
+(deftest ^{:stratum 1} fleet-sink-test
   (testing "requires :url option"
     (is (thrown? Exception (sinks/fleet-sink {}))))
 
@@ -405,10 +390,8 @@
       (sink (sample-event))
       (is (true? @posted) "flush sends an HTTP POST on batch-size trigger"))))
 
-;------------------------------------------------------------------------------ Layer 1b
 ;; file-sink error reporting
-
-(deftest file-sink-reports-write-errors-to-stderr-test
+(deftest ^{:stratum 1} file-sink-reports-write-errors-to-stderr-test
   (testing "file-sink logs write failures to stderr instead of swallowing"
     (with-temp-dir
       (fn [dir]
@@ -429,10 +412,8 @@
                                 (str w))]
             (is (str/includes? stderr-output "WARNING"))))))))
 
-;------------------------------------------------------------------------------ Layer 0
 ;; cleanup-stale-events!
-
-(deftest cleanup-stale-events-test
+(deftest ^{:stratum 1} cleanup-stale-events-test
   (testing "returns 0 when events directory is empty"
     (with-temp-dir
       (fn [dir]

--- a/components/event-stream/test/ai/miniforge/event_stream/snowflake_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/snowflake_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.snowflake-test
   "Tests for the BD-2b Snowflake event-id generator."
   (:require
@@ -26,9 +25,10 @@
   (:import
    [java.util UUID]))
 
-;------------------------------------------------------------------------------ Helpers
+;------------------------------------------------------------------------------ Layer 0
 
-(defn- with-temp-workers-dir [f]
+;------------------------------------------------------------------------------ Helpers
+(defn- ^{:stratum 0} with-temp-workers-dir [f]
   (let [dir (java.nio.file.Files/createTempDirectory
              "snowflake-test-workers-"
              (into-array java.nio.file.attribute.FileAttribute []))]
@@ -38,7 +38,7 @@
         (doseq [file (reverse (file-seq (.toFile dir)))]
           (.delete ^java.io.File file))))))
 
-(defn- fixed-clock
+(defn- ^{:stratum 0} fixed-clock
   "Return a 0-arg fn that returns successive values from `times`. Once
    exhausted, repeats the last value (so the generator can spin without
    running off the end)."
@@ -58,35 +58,17 @@
 ;; first emission goes through the third (forward-time) branch. The
 ;; sentinel must be < any valid (ms, seq) pair the generator could
 ;; observe; -1 is the conventional Java/Clojure sentinel for unset.
-(def ^:private ^:const ^long unset-timestamp-sentinel -1)
-(def ^:private ^:const ^long unset-sequence-sentinel  -1)
+(def ^{:stratum 0} ^:private ^:const ^long unset-timestamp-sentinel -1)
+
+(def ^{:stratum 0} ^:private ^:const ^long unset-sequence-sentinel  -1)
 
 ;; Bypass the FileLock-based worker-id lease in unit tests by pinning a
 ;; deterministic worker id and providing a fake lease handle. `0` is
 ;; chosen for readability; any 0..max-workers-1 value works.
-(def ^:private ^:const ^long test-worker-id 0)
-
-(def ^:private fresh-test-state
-  "A fresh-but-quiesced generator state — what the production
-   `initial-state` factory would produce for the test worker-id, but
-   defined locally so tests don't reach into a private fn."
-  {:last-ts   unset-timestamp-sentinel
-   :last-seq  unset-sequence-sentinel
-   :worker-id test-worker-id})
-
-(def ^:private fake-test-lease
-  "Sentinel lease handle for tests that bypass the file-lock path."
-  {:worker-id test-worker-id})
-
-(defn- generator-with-fixed-clock [times]
-  {:state     (atom fresh-test-state)
-   :worker-id test-worker-id
-   :lease     fake-test-lease
-   :now-fn    (fixed-clock times)})
+(def ^{:stratum 0} ^:private ^:const ^long test-worker-id 0)
 
 ;------------------------------------------------------------------------------ Pure id-composition
-
-(deftest compose-id-packs-bits-correctly
+(deftest ^{:stratum 0} compose-id-packs-bits-correctly
   ;; Verify the bit layout: 41-bit ts << 22 | 10-bit worker << 12 | 12-bit seq.
   (let [id (sf/compose-id 0 0 0)]
     (is (zero? id)))
@@ -102,12 +84,12 @@
                    0xfff)
            id))))
 
-(deftest format-hex-produces-16-char-lowercase
+(deftest ^{:stratum 0} format-hex-produces-16-char-lowercase
   (is (= "0000000000000000" (sf/format-hex 0)))
   (is (= "0000000000000001" (sf/format-hex 1)))
-  (is (= "ffffffffffffffff" (sf/format-hex -1)))) ; all-ones long
+  (is (= "ffffffffffffffff" (sf/format-hex -1))))  ; all-ones long
 
-(deftest long->uuid-zeros-low-bits
+(deftest ^{:stratum 0} long->uuid-zeros-low-bits
   (let [u (sf/long->uuid 0x018f3a9c8e4b12d0)]
     (is (instance? UUID u))
     (is (= 0x018f3a9c8e4b12d0 (.getMostSignificantBits ^UUID u)))
@@ -116,13 +98,109 @@
   (is (= "00000000-0000-0000-0000-000000000000"
          (str (sf/long->uuid 0)))))
 
-(deftest uuid->hex-extracts-msb
+(deftest ^{:stratum 0} uuid->hex-extracts-msb
   (let [u (sf/long->uuid 0x018f3a9c8e4b12d0)]
     (is (= "018f3a9c8e4b12d0" (sf/uuid->hex u)))))
 
-;------------------------------------------------------------------------------ next-id! semantics
+(deftest ^{:stratum 0} create-generator-propagates-lease-anomaly
+  (let [lease-anomaly (response/make-anomaly
+                       :anomalies/busy
+                       "No worker slots"
+                       {:reason :workers-exhausted})
+        result (sf/create-generator {:lease lease-anomaly})]
+    (is (identical? lease-anomaly result))))
 
-(deftest next-id!-monotonic-within-same-ms
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} ^:private fresh-test-state
+  "A fresh-but-quiesced generator state — what the production
+   `initial-state` factory would produce for the test worker-id, but
+   defined locally so tests don't reach into a private fn."
+  {:last-ts   unset-timestamp-sentinel
+   :last-seq  unset-sequence-sentinel
+   :worker-id test-worker-id})
+
+(def ^{:stratum 1} ^:private fake-test-lease
+  "Sentinel lease handle for tests that bypass the file-lock path."
+  {:worker-id test-worker-id})
+
+;------------------------------------------------------------------------------ worker-id leasing
+(deftest ^{:stratum 1} acquire-worker-lease!-takes-id-zero-when-empty
+  (with-temp-workers-dir
+    (fn [dir]
+      (let [lease (sf/acquire-worker-lease! dir)]
+        (try
+          (is (= 0 (:worker-id lease)))
+          (is (.exists (io/file dir "0.lease")))
+          (finally (sf/release-lease! lease)))))))
+
+(deftest ^{:stratum 1} acquire-worker-lease!-skips-locked-slot
+  (with-temp-workers-dir
+    (fn [dir]
+      (let [first-lease (sf/acquire-worker-lease! dir)]
+        (try
+          (let [second-lease (sf/acquire-worker-lease! dir)]
+            (try
+              (is (= 0 (:worker-id first-lease)))
+              (is (= 1 (:worker-id second-lease))
+                  "a second concurrent acquire takes the next free slot")
+              (finally (sf/release-lease! second-lease))))
+          (finally (sf/release-lease! first-lease)))))))
+
+(deftest ^{:stratum 1} acquire-worker-lease!-reclaims-released-slot
+  (with-temp-workers-dir
+    (fn [dir]
+      (let [lease-a (sf/acquire-worker-lease! dir)]
+        (sf/release-lease! lease-a))
+      (let [lease-b (sf/acquire-worker-lease! dir)]
+        (try
+          (is (= 0 (:worker-id lease-b))
+              "after release, slot 0 becomes acquirable again")
+          (finally (sf/release-lease! lease-b)))))))
+
+(deftest ^{:stratum 1} release-lease!-is-idempotent
+  (with-temp-workers-dir
+    (fn [dir]
+      (let [lease (sf/acquire-worker-lease! dir)]
+        (sf/release-lease! lease)
+        (is (nil? (sf/release-lease! lease))
+            "second release is a no-op, not an error")))))
+
+(deftest ^{:stratum 1} acquire-worker-lease!-returns-anomaly-on-lease-io-failure
+  (with-temp-workers-dir
+    (fn [dir]
+      (let [not-a-dir (io/file dir "occupied")]
+        (spit not-a-dir "not a directory")
+        (let [result (sf/acquire-worker-lease! not-a-dir)]
+          (is (response/anomaly-map? result))
+          (is (= :anomalies/unavailable (:anomaly/category result)))
+          (is (= :lease-io-failure (:reason result)))
+          (is (string? (:anomaly/ex-message result)))
+          (is (string? (:anomaly/ex-class result))))))))
+
+(deftest ^{:stratum 1} create-generator-acquires-worker-lease
+  (with-temp-workers-dir
+    (fn [dir]
+      (let [gen (sf/create-generator {:workers-dir dir})]
+        (try
+          (is (some? (:lease gen)))
+          (is (= 0 (:worker-id gen)))
+          (let [u (sf/next-id! gen)]
+            (is (instance? UUID u)))
+          (finally (sf/close! gen)))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- ^{:stratum 2} generator-with-fixed-clock [times]
+  {:state     (atom fresh-test-state)
+   :worker-id test-worker-id
+   :lease     fake-test-lease
+   :now-fn    (fixed-clock times)})
+
+;------------------------------------------------------------------------------ Layer 3
+
+;------------------------------------------------------------------------------ next-id! semantics
+(deftest ^{:stratum 3} next-id!-monotonic-within-same-ms
   (let [base-ts sf/miniforge-epoch-ms
         gen (generator-with-fixed-clock (repeat 10 base-ts))
         ids (vec (repeatedly 5 #(sf/next-id-long! gen)))]
@@ -132,7 +210,7 @@
       (is (= [0 1 2 3 4] seqs)
           "sequence increments deterministically inside the same millisecond"))))
 
-(deftest next-id!-resets-sequence-on-ms-advance
+(deftest ^{:stratum 3} next-id!-resets-sequence-on-ms-advance
   (let [base-ts sf/miniforge-epoch-ms
         ;; First call at base-ts, second call at base-ts + 1ms.
         gen (generator-with-fixed-clock [base-ts (inc base-ts)])
@@ -141,7 +219,7 @@
     (is (zero? (bit-and id1 sf/max-seq)) "first id at new ms has seq=0")
     (is (zero? (bit-and id2 sf/max-seq)) "second id at next ms also resets to seq=0")))
 
-(deftest next-id!-advances-ms-on-sequence-exhaustion
+(deftest ^{:stratum 3} next-id!-advances-ms-on-sequence-exhaustion
   ;; Force seq to 4095 manually, then call next-id! at the same ms.
   ;; The generator must spin — but with a fixed-clock that returns
   ;; the same ms, it would spin forever. We simulate the wall clock
@@ -161,7 +239,7 @@
       (is (zero? (bit-and id sf/max-seq))
           "sequence resets at the new ms"))))
 
-(deftest next-id!-returns-anomaly-on-pre-epoch-clock
+(deftest ^{:stratum 3} next-id!-returns-anomaly-on-pre-epoch-clock
   ;; If the wall clock is somehow before the miniforge epoch, the bit
   ;; layout would corrupt (negative ts shifts into worker bits). Return
   ;; an explicit anomaly rather than silently emit garbage.
@@ -171,7 +249,7 @@
     (is (= :anomalies/incorrect (:anomaly/category result)))
     (is (= :pre-epoch-clock (:reason result)))))
 
-(deftest next-id-wrappers-propagate-pre-epoch-anomaly
+(deftest ^{:stratum 3} next-id-wrappers-propagate-pre-epoch-anomaly
   (let [uuid-result (sf/next-id!
                      (generator-with-fixed-clock [(- sf/miniforge-epoch-ms 1)]))
         hex-result  (sf/next-id-hex!
@@ -181,7 +259,7 @@
     (is (= :pre-epoch-clock (:reason uuid-result)))
     (is (= :pre-epoch-clock (:reason hex-result)))))
 
-(deftest next-id!-stalls-on-clock-rollback
+(deftest ^{:stratum 3} next-id!-stalls-on-clock-rollback
   (let [base-ts (+ sf/miniforge-epoch-ms 1000)
         ;; Call 1: time goes BACKWARD by 100ms. Generator must stall.
         ;; Once enough retries land back at base-ts, it succeeds.
@@ -198,7 +276,7 @@
       (is (= expected-ts ts-component)
           "rollback resolves once wall clock surpasses last-ts"))))
 
-(deftest next-id!-returns-uuid-with-zero-low-bits
+(deftest ^{:stratum 3} next-id!-returns-uuid-with-zero-low-bits
   (let [base-ts sf/miniforge-epoch-ms
         gen (generator-with-fixed-clock (repeat 5 base-ts))
         u (sf/next-id! gen)]
@@ -206,14 +284,14 @@
     (is (zero? (.getLeastSignificantBits ^UUID u))
         "snowflake UUIDs always have zero low 64 bits — that's the discriminator")))
 
-(deftest next-id-hex!-is-16-lowercase-hex
+(deftest ^{:stratum 3} next-id-hex!-is-16-lowercase-hex
   (let [base-ts sf/miniforge-epoch-ms
         gen (generator-with-fixed-clock (repeat 5 base-ts))
         h (sf/next-id-hex! gen)]
     (is (= 16 (count h)))
     (is (re-matches #"[0-9a-f]{16}" h))))
 
-(deftest next-id-hex!-sorts-by-creation-order
+(deftest ^{:stratum 3} next-id-hex!-sorts-by-creation-order
   ;; Three ids generated 100ms apart should sort lex.
   (let [base-ts sf/miniforge-epoch-ms
         gen (generator-with-fixed-clock [base-ts
@@ -224,77 +302,3 @@
         c (sf/next-id-hex! gen)]
     (is (< (compare a b) 0))
     (is (< (compare b c) 0))))
-
-;------------------------------------------------------------------------------ worker-id leasing
-
-(deftest acquire-worker-lease!-takes-id-zero-when-empty
-  (with-temp-workers-dir
-    (fn [dir]
-      (let [lease (sf/acquire-worker-lease! dir)]
-        (try
-          (is (= 0 (:worker-id lease)))
-          (is (.exists (io/file dir "0.lease")))
-          (finally (sf/release-lease! lease)))))))
-
-(deftest acquire-worker-lease!-skips-locked-slot
-  (with-temp-workers-dir
-    (fn [dir]
-      (let [first-lease (sf/acquire-worker-lease! dir)]
-        (try
-          (let [second-lease (sf/acquire-worker-lease! dir)]
-            (try
-              (is (= 0 (:worker-id first-lease)))
-              (is (= 1 (:worker-id second-lease))
-                  "a second concurrent acquire takes the next free slot")
-              (finally (sf/release-lease! second-lease))))
-          (finally (sf/release-lease! first-lease)))))))
-
-(deftest acquire-worker-lease!-reclaims-released-slot
-  (with-temp-workers-dir
-    (fn [dir]
-      (let [lease-a (sf/acquire-worker-lease! dir)]
-        (sf/release-lease! lease-a))
-      (let [lease-b (sf/acquire-worker-lease! dir)]
-        (try
-          (is (= 0 (:worker-id lease-b))
-              "after release, slot 0 becomes acquirable again")
-          (finally (sf/release-lease! lease-b)))))))
-
-(deftest release-lease!-is-idempotent
-  (with-temp-workers-dir
-    (fn [dir]
-      (let [lease (sf/acquire-worker-lease! dir)]
-        (sf/release-lease! lease)
-        (is (nil? (sf/release-lease! lease))
-            "second release is a no-op, not an error")))))
-
-(deftest acquire-worker-lease!-returns-anomaly-on-lease-io-failure
-  (with-temp-workers-dir
-    (fn [dir]
-      (let [not-a-dir (io/file dir "occupied")]
-        (spit not-a-dir "not a directory")
-        (let [result (sf/acquire-worker-lease! not-a-dir)]
-          (is (response/anomaly-map? result))
-          (is (= :anomalies/unavailable (:anomaly/category result)))
-          (is (= :lease-io-failure (:reason result)))
-          (is (string? (:anomaly/ex-message result)))
-          (is (string? (:anomaly/ex-class result))))))))
-
-(deftest create-generator-propagates-lease-anomaly
-  (let [lease-anomaly (response/make-anomaly
-                       :anomalies/busy
-                       "No worker slots"
-                       {:reason :workers-exhausted})
-        result (sf/create-generator {:lease lease-anomaly})]
-    (is (identical? lease-anomaly result))))
-
-(deftest create-generator-acquires-worker-lease
-  (with-temp-workers-dir
-    (fn [dir]
-      (let [gen (sf/create-generator {:workers-dir dir})]
-        (try
-          (is (some? (:lease gen)))
-          (is (= 0 (:worker-id gen)))
-          (let [u (sf/next-id! gen)]
-            (is (instance? UUID u)))
-          (finally (sf/close! gen)))))))

--- a/components/event-stream/test/ai/miniforge/event_stream/stall_events_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/stall_events_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.stall-events-test
   "Tests for GROUP 1+4 foundation: agent-stream-stalled constructor and
    phase-completed :phase/termination-reason extension, plus GROUP 2
@@ -28,23 +27,25 @@
    [ai.miniforge.event-stream.interface.events :as events]
    [ai.miniforge.event-stream.schema :as schema]))
 
-;------------------------------------------------------------------------------ Helpers
+;------------------------------------------------------------------------------ Layer 0
 
-(defn no-op-stream
+;------------------------------------------------------------------------------ Helpers
+(defn ^{:stratum 0} no-op-stream
   "Create a stream with no sinks — event constructors only build maps."
   []
   (core/create-event-stream {:sinks []}))
 
-;------------------------------------------------------------------------------ agent-stream-stalled
+;------------------------------------------------------------------------------ Layer 1
 
-(deftest agent-stream-stalled-type-test
+;------------------------------------------------------------------------------ agent-stream-stalled
+(deftest ^{:stratum 1} agent-stream-stalled-type-test
   (testing "event type is :agent/stream-stalled"
     (let [stream (no-op-stream)
           wf-id  (random-uuid)
           event  (core/agent-stream-stalled stream wf-id :implement 95000 :codex)]
       (is (= :agent/stream-stalled (:event/type event))))))
 
-(deftest agent-stream-stalled-fields-test
+(deftest ^{:stratum 1} agent-stream-stalled-fields-test
   (testing "carries phase-id, gap-duration-ms, and backend"
     (let [stream (no-op-stream)
           wf-id  (random-uuid)
@@ -76,7 +77,7 @@
       (is (= core/event-version (:event/version event)))
       (is (number? (:event/sequence-number event))))))
 
-(deftest agent-stream-stalled-works-with-any-backend-test
+(deftest ^{:stratum 1} agent-stream-stalled-works-with-any-backend-test
   (testing "backend keyword is preserved as-is"
     (doseq [backend [:codex :claude :openai :local]]
       (let [stream (no-op-stream)
@@ -84,8 +85,7 @@
         (is (= backend (:agent/backend event)))))))
 
 ;------------------------------------------------------------------------------ phase-completed :phase/termination-reason
-
-(deftest phase-completed-termination-reason-test
+(deftest ^{:stratum 1} phase-completed-termination-reason-test
   (testing "termination-reason :normal is passed through"
     (let [stream (no-op-stream)
           wf-id  (random-uuid)
@@ -136,15 +136,14 @@
       (is (= :normal (:phase/termination-reason event))))))
 
 ;------------------------------------------------------------------------------ agent-session-captured (GROUP 2)
-
-(deftest agent-session-captured-type-test
+(deftest ^{:stratum 1} agent-session-captured-type-test
   (testing "event type is :agent/session-captured"
     (let [stream (no-op-stream)
           wf-id  (random-uuid)
           event  (core/agent-session-captured stream wf-id :implement "cc-abc123" :claude-code)]
       (is (= :agent/session-captured (:event/type event))))))
 
-(deftest agent-session-captured-fields-test
+(deftest ^{:stratum 1} agent-session-captured-fields-test
   (testing "carries phase-id, session-id, and backend"
     (let [stream (no-op-stream)
           wf-id  (random-uuid)
@@ -176,7 +175,7 @@
       (is (= core/event-version (:event/version event)))
       (is (number? (:event/sequence-number event))))))
 
-(deftest agent-session-captured-works-with-any-backend-test
+(deftest ^{:stratum 1} agent-session-captured-works-with-any-backend-test
   (testing "backend keyword is preserved as-is"
     (doseq [backend [:codex :claude-code :openai :local]]
       (let [stream (no-op-stream)
@@ -185,8 +184,7 @@
         (is (= backend (:agent/backend event)))))))
 
 ;------------------------------------------------------------------------------ Re-export verification
-
-(deftest interface-events-re-export-test
+(deftest ^{:stratum 1} interface-events-re-export-test
   (testing "agent-stream-stalled is exported through interface.events"
     (is (fn? events/agent-stream-stalled)))
 
@@ -221,8 +219,7 @@
       (is (= (:agent/backend direct) (:agent/backend via-if))))))
 
 ;------------------------------------------------------------------------------ Malli schema validation
-
-(deftest agent-stream-stalled-validates-against-schema-test
+(deftest ^{:stratum 1} agent-stream-stalled-validates-against-schema-test
   (testing "constructed event satisfies schema/AgentStreamStalled"
     (let [stream (no-op-stream)
           event  (core/agent-stream-stalled stream (random-uuid) :implement 95000 :codex)]
@@ -230,7 +227,7 @@
           (str "validation errors: "
                (pr-str (m/explain schema/AgentStreamStalled event)))))))
 
-(deftest agent-session-captured-validates-against-schema-test
+(deftest ^{:stratum 1} agent-session-captured-validates-against-schema-test
   (testing "constructed event satisfies schema/AgentSessionCaptured"
     (let [stream (no-op-stream)
           event  (core/agent-session-captured stream (random-uuid) :implement

--- a/components/event-stream/test/ai/miniforge/event_stream/test_helpers/http_mock.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/test_helpers/http_mock.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.test-helpers.http-mock
   "Shared `java.net.http.HttpClient` stub for sink tests.
 
@@ -23,7 +22,9 @@
    assertions, and so other sink tests (e.g. a future
    logging/fleet-sink_test) can reuse the same stub shape.")
 
-(defn mock-http-client
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} mock-http-client
   "Construct a minimal `HttpClient` stub for tests.
    `send-fn` is called as `(send-fn req handler)` and must return an
    `HttpResponse`; defaults to a 200 no-op.  All other abstract methods

--- a/components/event-stream/test/ai/miniforge/event_stream/timeline_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/timeline_test.clj
@@ -15,25 +15,53 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.timeline-test
   (:require
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.event-stream.timeline :as sut]))
 
-;------------------------------------------------------------------------------ helpers
+;------------------------------------------------------------------------------ Layer 0
 
-(defn- epoch->date
+;------------------------------------------------------------------------------ helpers
+(defn- ^{:stratum 0} epoch->date
   "Coerce epoch-ms long to a java.util.Date."
   [ms]
   (java.util.Date. (long ms)))
 
-(def ^:private base-ms
+(def ^{:stratum 0} ^:private base-ms
   "A fixed epoch-ms (2025-01-01T00:00:00Z) for deterministic timestamps."
   1735689600000)
 
-(defn- mk-event
+;------------------------------------------------------------------------------ tests
+(deftest ^{:stratum 0} empty-events-returns-empty-string
+  (testing "empty / nil input yields empty string — consistent return type so callers don't have to nil-check"
+    (is (= "" (sut/render-timeline [])))
+    (is (= "" (sut/render-timeline nil)))
+    (is (= "" (sut/render-timeline [] {})))))
+
+(deftest ^{:stratum 0} events-without-timestamps-handled-gracefully
+  (testing "events with nil timestamp render with ?? placeholders but do not throw"
+    (let [event  {:event/type     :agent/tool-call-started
+                  :workflow/phase :implement
+                  :tool/name      "Read"}
+          result (sut/render-timeline [event])]
+      (is (string? result))
+      (is (str/includes? result "??:??:??"))))
+
+  (testing "gap detection is skipped when timestamps are absent"
+    (let [events [{:event/type     :agent/tool-call-started
+                   :tool/name      "Read"}
+                  {:event/type     :agent/tool-call-started
+                   :tool/name      "Write"}]
+          result (sut/render-timeline events)
+          lines  (str/split-lines result)]
+      ;; No gap line expected — timestamps are nil so gap cannot be computed
+      (is (= 2 (count lines))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} mk-event
   "Build a minimal event map with optional extra keys merged in."
   [event-type ts-offset-ms & {:as extra}]
   (merge {:event/type      event-type
@@ -41,15 +69,9 @@
           :workflow/phase  :implement}
          extra))
 
-;------------------------------------------------------------------------------ tests
+;------------------------------------------------------------------------------ Layer 2
 
-(deftest empty-events-returns-empty-string
-  (testing "empty / nil input yields empty string — consistent return type so callers don't have to nil-check"
-    (is (= "" (sut/render-timeline [])))
-    (is (= "" (sut/render-timeline nil)))
-    (is (= "" (sut/render-timeline [] {})))))
-
-(deftest tool-call-started-renders-correctly
+(deftest ^{:stratum 2} tool-call-started-renders-correctly
   (testing "agent/tool-call-started shows tool name and args digest preview"
     (let [event  (mk-event :agent/tool-call-started 0
                             :tool/name "Write"
@@ -60,7 +82,7 @@
       (is (str/includes? result "Writing src/foo.clj"))
       (is (str/includes? result "implement")))))
 
-(deftest tool-call-completed-uses-tool-success-flag-not-error-presence
+(deftest ^{:stratum 2} tool-call-completed-uses-tool-success-flag-not-error-presence
   (testing "tool/call-completed shows success status from :tool/success? per ToolCallCompleted schema"
     ;; ToolCallCompleted in schema.clj does NOT carry :tool/name; the
     ;; name is correlated via :tool/call-id back to the started event
@@ -96,7 +118,7 @@
       (is (str/includes? result "Read")
           "tool name still resolves via correlation in the error path"))))
 
-(deftest tool-call-completed-falls-back-to-call-id-when-no-started-event
+(deftest ^{:stratum 2} tool-call-completed-falls-back-to-call-id-when-no-started-event
   (testing "if the started event is missing, the completed event renders with :tool/call-id as the tool label"
     ;; Defensive: prevents <unknown> from showing up when there's a
     ;; correlatable id but no preceding started event (e.g. truncated
@@ -109,7 +131,7 @@
           "call-id substitutes for tool name when correlation is impossible")
       (is (not (str/includes? result "<unknown>"))))))
 
-(deftest tool-call-pair-renders-both-lines
+(deftest ^{:stratum 2} tool-call-pair-renders-both-lines
   (testing "started + completed pair produces two lines, name correlated via :tool/call-id"
     (let [events [(mk-event :agent/tool-call-started 0
                             :tool/name "Bash"
@@ -127,7 +149,7 @@
           "completed line carries the same tool name as started, via correlation")
       (is (str/includes? (second lines) "success")))))
 
-(deftest gap-detection-inserts-stall-line
+(deftest ^{:stratum 2} gap-detection-inserts-stall-line
   (testing "gap above threshold inserts a gap line between events"
     ;; Put events 90 seconds apart (above default 60s threshold)
     (let [events [(mk-event :agent/tool-call-started 0
@@ -160,7 +182,7 @@
       (is (= 3 (count lines)))
       (is (str/includes? (second lines) "event-stream gap (stalled)")))))
 
-(deftest terminal-event-renders-terminated-marker
+(deftest ^{:stratum 2} terminal-event-renders-terminated-marker
   (testing "workflow/completed renders TERMINATED marker"
     (let [event  (mk-event :workflow/completed 5000
                             :message "all phases passed")
@@ -175,7 +197,7 @@
       (is (str/includes? result "TERMINATED"))
       (is (str/includes? result "phase implement failed")))))
 
-(deftest phase-lifecycle-events-render
+(deftest ^{:stratum 2} phase-lifecycle-events-render
   (testing "workflow/phase-started renders phase started label"
     (let [event  (mk-event :workflow/phase-started 0
                             :workflow/phase :plan
@@ -190,7 +212,7 @@
           result (sut/render-timeline [event])]
       (is (str/includes? result "phase completed")))))
 
-(deftest stream-stall-event-renders
+(deftest ^{:stratum 2} stream-stall-event-renders
   (testing "agent/stream-stalled renders stall marker"
     (let [event  (mk-event :agent/stream-stalled 3000
                             :message "no output for 120s")
@@ -198,7 +220,7 @@
       (is (str/includes? result "[stall]"))
       (is (str/includes? result "no output for 120s")))))
 
-(deftest generic-event-renders-fallback
+(deftest ^{:stratum 2} generic-event-renders-fallback
   (testing "unknown event type renders event-type + message"
     (let [event  (mk-event :some/unknown-event 1000
                             :message "something happened")
@@ -206,7 +228,7 @@
       (is (str/includes? result ":some/unknown-event"))
       (is (str/includes? result "something happened")))))
 
-(deftest non-string-event-messages-render-as-empty-test
+(deftest ^{:stratum 2} non-string-event-messages-render-as-empty-test
   (testing "message-bearing renderers tolerate a missing message key"
     (doseq [event-type [:workflow/phase-started
                         :workflow/completed
@@ -241,26 +263,7 @@
       (is (str/includes? result ":failed"))
       (is (not (str/includes? result ":not-a-string"))))))
 
-(deftest events-without-timestamps-handled-gracefully
-  (testing "events with nil timestamp render with ?? placeholders but do not throw"
-    (let [event  {:event/type     :agent/tool-call-started
-                  :workflow/phase :implement
-                  :tool/name      "Read"}
-          result (sut/render-timeline [event])]
-      (is (string? result))
-      (is (str/includes? result "??:??:??"))))
-
-  (testing "gap detection is skipped when timestamps are absent"
-    (let [events [{:event/type     :agent/tool-call-started
-                   :tool/name      "Read"}
-                  {:event/type     :agent/tool-call-started
-                   :tool/name      "Write"}]
-          result (sut/render-timeline events)
-          lines  (str/split-lines result)]
-      ;; No gap line expected — timestamps are nil so gap cannot be computed
-      (is (= 2 (count lines))))))
-
-(deftest args-summary-truncated-at-60-chars
+(deftest ^{:stratum 2} args-summary-truncated-at-60-chars
   (testing "args preview longer than 60 chars is truncated"
     (let [long-preview (apply str (repeat 80 "x"))
           event        (mk-event :agent/tool-call-started 0
@@ -272,7 +275,7 @@
       ;; Must contain truncation indicator
       (is (str/includes? result "…")))))
 
-(deftest message-fallback-when-no-args-digest
+(deftest ^{:stratum 2} message-fallback-when-no-args-digest
   (testing "falls back to :message when :tool/args-digest is absent"
     (let [event  (mk-event :agent/tool-call-started 0
                             :tool/name "Bash"
@@ -280,7 +283,7 @@
           result (sut/render-timeline [event])]
       (is (str/includes? result "running tests")))))
 
-(deftest render-timeline-returns-string
+(deftest ^{:stratum 2} render-timeline-returns-string
   (testing "render-timeline with multiple events returns a single string"
     (let [events [(mk-event :workflow/phase-started 0 :workflow/phase :plan)
                   (mk-event :agent/tool-call-started 1000

--- a/components/event-stream/test/ai/miniforge/event_stream/typed_acts_schema_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/typed_acts_schema_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.typed-acts-schema-test
   "Schemas for the typed handoff acts: widened phase outcomes, the meta-loop
    REFUSE, and inter-agent messages."
@@ -25,9 +24,18 @@
    [clojure.test :refer [deftest is testing]]
    [malli.core :as m]))
 
-(defn- stream [] (es/create-event-stream {:sinks []}))
+;------------------------------------------------------------------------------ Layer 0
 
-(deftest phase-completed-accepts-blocked-and-redirected-test
+(defn- ^{:stratum 0} stream [] (es/create-event-stream {:sinks []}))
+
+(deftest ^{:stratum 0} refusal-reason-is-closed-test
+  (testing "RefusalReason admits the shared vocabulary and rejects unknowns"
+    (is (m/validate schema/RefusalReason :budget-exhausted))
+    (is (not (m/validate schema/RefusalReason :totally-made-up)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} phase-completed-accepts-blocked-and-redirected-test
   (testing "the widened :phase/outcome enum admits :blocked with a reason and :redirected"
     (let [s          (stream)
           wid        (random-uuid)
@@ -43,7 +51,7 @@
       (is (= :redirected (:phase/outcome redirected)))
       (is (m/validate schema/PhaseCompleted redirected)))))
 
-(deftest meta-loop-halt-requested-is-valid-test
+(deftest ^{:stratum 1} meta-loop-halt-requested-is-valid-test
   (testing "meta-loop-halt-requested builds a schema-valid REFUSE event"
     (let [ev (es/meta-loop-halt-requested (stream) (random-uuid)
                                           :conflict-detector :conflict
@@ -53,7 +61,7 @@
       (is (= :conflict-detector (:halt/halting-agent ev)))
       (is (m/validate schema/MetaLoopHaltRequested ev)))))
 
-(deftest inter-agent-messages-are-valid-test
+(deftest ^{:stratum 1} inter-agent-messages-are-valid-test
   (testing "inter-agent message constructors satisfy the now-defined schemas"
     (let [s    (stream)
           wid  (random-uuid)
@@ -61,8 +69,3 @@
           recv (es/inter-agent-message-received s wid :planner :implementer :clarification-response)]
       (is (m/validate schema/AgentMessageSent sent))
       (is (m/validate schema/AgentMessageReceived recv)))))
-
-(deftest refusal-reason-is-closed-test
-  (testing "RefusalReason admits the shared vocabulary and rejects unknowns"
-    (is (m/validate schema/RefusalReason :budget-exhausted))
-    (is (not (m/validate schema/RefusalReason :totally-made-up)))))

--- a/components/event-stream/test/ai/miniforge/event_stream/zettel_promoted_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/zettel_promoted_test.clj
@@ -9,7 +9,6 @@
 ;; You may obtain a copy of the License at
 ;;
 ;;     http://www.apache.org/licenses/LICENSE-2.0
-
 (ns ai.miniforge.event-stream.zettel-promoted-test
   "Tests for the `zettel-promoted` event constructor + schema (added
    for miniforge-fleet's Phase E.3 outbox path).
@@ -32,12 +31,12 @@
    [java.util UUID]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Helpers.
 
-(defn- fresh-stream []
+;; Helpers.
+(defn- ^{:stratum 0} fresh-stream []
   (atom {:events [] :sequence-numbers {}}))
 
-(defn- trusted-zettel
+(defn- ^{:stratum 0} trusted-zettel
   "Build a Decision-6-compliant zettel literal with optional Fleet-
    share intent. Skips the real `knowledge/create-zettel` constructor
    so this test stays inside the event-stream brick's dep boundary
@@ -57,10 +56,23 @@
     scope              (assoc :fleet/share-scope scope)
     classification     (assoc :privacy/classification classification)))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Constructor: minimal happy path.
+;; Registry + privacy classification.
+(deftest ^{:stratum 0} test-event-type-registry-knows-about-zettel-promoted
+  (testing "the constructor + serialised string are registered"
+    (let [entry (->> registry/event-type-registry
+                     (some #(when (= "zettel-promoted" (:constructor %)) %)))]
+      (is (some? entry) "registry should carry a zettel-promoted entry")
+      (is (= :zettel/promoted (:event-type entry)))
+      (is (= "zettel/promoted" (:json-string entry))))))
 
-(deftest test-zettel-promoted-stamps-envelope-and-revision-fields
+(deftest ^{:stratum 0} test-default-privacy-classifies-zettel-promoted-internal
+  (testing "default privacy is :internal — Fleet's gates decide cross-instance share"
+    (is (= :internal (schema/event-privacy :zettel/promoted)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Constructor: minimal happy path.
+(deftest ^{:stratum 1} test-zettel-promoted-stamps-envelope-and-revision-fields
   (testing "constructor stamps the envelope plus the Decision-6 revision triple + content"
     (let [stream      (fresh-stream)
           workflow-id (UUID/randomUUID)
@@ -83,16 +95,14 @@
       ;; Version pin
       (is (= "1.0.0" (:fleet/oss-version ev))))))
 
-(deftest test-zettel-promoted-validates-against-schema
+(deftest ^{:stratum 1} test-zettel-promoted-validates-against-schema
   (testing "the constructor's output validates against ZettelPromoted"
     (let [ev (core/zettel-promoted (fresh-stream) (UUID/randomUUID)
                                    (trusted-zettel) "1.0.0")]
       (is (m/validate schema/ZettelPromoted ev)))))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Constructor: optional Fleet-share intent rides through.
-
-(deftest test-fleet-shareable-rides-through
+(deftest ^{:stratum 1} test-fleet-shareable-rides-through
   (testing ":fleet/shareable from the zettel rides onto the event"
     (let [z  (trusted-zettel :shareable true :scope :org :classification :internal)
           ev (core/zettel-promoted (fresh-stream) (UUID/randomUUID) z "1.0.0")]
@@ -101,7 +111,7 @@
       (is (= :internal (:privacy/classification ev)))
       (is (m/validate schema/ZettelPromoted ev)))))
 
-(deftest test-default-share-intent-omitted
+(deftest ^{:stratum 1} test-default-share-intent-omitted
   (testing "a zettel without share-intent fields produces an event without those keys"
     (let [z  (trusted-zettel)
           ev (core/zettel-promoted (fresh-stream) (UUID/randomUUID) z "1.0.0")]
@@ -110,10 +120,8 @@
       (is (false? (contains? ev :privacy/classification)))
       (is (m/validate schema/ZettelPromoted ev)))))
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Constructor: identity propagation kwargs ride through via opts.
-
-(deftest test-identity-propagation-via-opts
+(deftest ^{:stratum 1} test-identity-propagation-via-opts
   (testing "envelope opts (org/id, workspace/id, repo/id, auth/context) ride through"
     (let [oid    (UUID/randomUUID)
           wsid   (UUID/randomUUID)
@@ -129,23 +137,21 @@
       (is (= {:auth/principal "alice"} (:auth/context ev)))
       (is (m/validate schema/ZettelPromoted ev)))))
 
-;------------------------------------------------------------------------------ Layer 4
 ;; Schema-level rejection.
-
-(deftest test-schema-rejects-event-without-version-pin
+(deftest ^{:stratum 1} test-schema-rejects-event-without-version-pin
   (testing "ZettelPromoted requires :fleet/oss-version (Decision 13)"
     (let [ev (core/zettel-promoted (fresh-stream) (UUID/randomUUID)
                                    (trusted-zettel) "1.0.0")]
       (is (false? (m/validate schema/ZettelPromoted (dissoc ev :fleet/oss-version)))))))
 
-(deftest test-schema-rejects-event-without-revision-triple
+(deftest ^{:stratum 1} test-schema-rejects-event-without-revision-triple
   (testing "ZettelPromoted requires the Decision-6 revision triple"
     (let [ev (core/zettel-promoted (fresh-stream) (UUID/randomUUID)
                                    (trusted-zettel) "1.0.0")]
       (is (false? (m/validate schema/ZettelPromoted (dissoc ev :zettel/digest))))
       (is (false? (m/validate schema/ZettelPromoted (dissoc ev :zettel/revision-id)))))))
 
-(deftest test-schema-rejects-uppercase-digest
+(deftest ^{:stratum 1} test-schema-rejects-uppercase-digest
   (testing ":zettel/digest must be lowercase 64-char hex (matches the OSS knowledge schema regex)"
     (let [ev (assoc (core/zettel-promoted (fresh-stream) (UUID/randomUUID)
                                           (trusted-zettel) "1.0.0")
@@ -153,7 +159,7 @@
                     "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF")]
       (is (false? (m/validate schema/ZettelPromoted ev))))))
 
-(deftest test-schema-rejects-unknown-zettel-type
+(deftest ^{:stratum 1} test-schema-rejects-unknown-zettel-type
   (testing ":zettel/type is constrained to the closed enum mirroring knowledge.schema/ZettelType"
     ;; Catches typos / drift between the OSS knowledge enum and this
     ;; mirrored copy. A new type added to knowledge.schema/ZettelType
@@ -164,7 +170,7 @@
         (is (false? (m/validate schema/ZettelPromoted (assoc base :zettel/type bad-type)))
             (str ":zettel/type " bad-type " should be rejected"))))))
 
-(deftest test-schema-accepts-every-knowledge-zettel-type
+(deftest ^{:stratum 1} test-schema-accepts-every-knowledge-zettel-type
   (testing "every value the OSS knowledge schema enumerates is accepted here"
     ;; Pin the sync requirement: if knowledge.schema/ZettelType
     ;; gains a value, this test surfaces the gap in the mirrored
@@ -174,18 +180,3 @@
       (doseq [t [:rule :concept :learning :example :hub :question :decision]]
         (is (m/validate schema/ZettelPromoted (assoc base :zettel/type t))
             (str ":zettel/type " t " should be accepted"))))))
-
-;------------------------------------------------------------------------------ Layer 5
-;; Registry + privacy classification.
-
-(deftest test-event-type-registry-knows-about-zettel-promoted
-  (testing "the constructor + serialised string are registered"
-    (let [entry (->> registry/event-type-registry
-                     (some #(when (= "zettel-promoted" (:constructor %)) %)))]
-      (is (some? entry) "registry should carry a zettel-promoted entry")
-      (is (= :zettel/promoted (:event-type entry)))
-      (is (= "zettel/promoted" (:json-string entry))))))
-
-(deftest test-default-privacy-classifies-zettel-promoted-internal
-  (testing "default privacy is :internal — Fleet's gates decide cross-instance share"
-    (is (= :internal (schema/event-privacy :zettel/promoted)))))

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-event-stream.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-event-stream.md
@@ -232,6 +232,26 @@ decision — see Related Issues for the follow-up. Re-ran `--fix` (zero
 diff), `clj-kondo` (0 errors/warnings), and `listeners_test.clj` (5
 tests, 21 assertions, 0 failures/errors) after the change.
 
+### Review-round fix: a stale namespace-docstring layer summary on `approval.clj`
+
+GitHub Copilot's third review pass flagged `approval.clj`'s namespace
+docstring: it claimed a 4-layer breakdown (`Layer 0: Approval request
+creation`, `Layer 1: Approval signing and status checking`, `Layer 2:
+Approval manager`, `Layer 3: Approval event constructors`) that no
+longer matches the file's real `^{:stratum n}` tags — verified
+directly by listing every top-level def's stratum: the file collapsed
+to 3 real layers (0, 1, 2) when `--fix` first ran, with a completely
+different grouping (response predicates, expiry/signing checks, the
+manager, and the event constructors are ALL real stratum 0; request
+creation/signing/status-checking is stratum 1; `list-approvals` alone
+is stratum 2). The same bug class this program has hit repeatedly
+(`adapter-claude-code`, `reliability`, `observer` — a stratum-lint
+`--fix` pass changes the real layer count/grouping but never touches
+prose describing the old one). Rewrote the docstring's layer summary
+to match the verified real structure. Re-ran `--fix` (zero diff),
+`clj-kondo` (0 errors/warnings), and `approval_test.clj` (9 tests, 45
+assertions, 0 failures/errors) after the change.
+
 ## Testing Plan
 
 1. Confirmed the stratum-lint pin in `tasks/stratum.clj`
@@ -330,6 +350,11 @@ tests, 21 assertions, 0 failures/errors) after the change.
     `listeners.clj`'s stale `privacy->min-capability` docstring above.
     Fixed, re-ran `--fix` (zero diff), `clj-kondo` (0 errors, 0
     warnings), and `listeners_test.clj` directly (5 tests, 21
+    assertions, 0 failures/errors).
+13. Third Copilot review pass (after the `listeners.clj` push) flagged
+    `approval.clj`'s stale namespace-docstring layer summary above.
+    Fixed, re-ran `--fix` (zero diff), `clj-kondo` (0 errors, 0
+    warnings), and `approval_test.clj` directly (9 tests, 45
     assertions, 0 failures/errors).
 
 ## Deployment Plan
@@ -473,4 +498,7 @@ time for these 12 files until Wave 2 splits them.
       map from code/spec alone; fixed the docstring to match current
       behavior rather than changing runtime access-control behavior;
       underlying policy question flagged separately in Related Issues
+- [x] Third Copilot review pass comment (`approval.clj`'s stale
+      namespace-docstring layer summary) verified directly against the
+      file's actual `^{:stratum n}` tags and fixed
 - [x] No `--no-verify`; pre-commit hook runs normally at commit time

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-event-stream.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-event-stream.md
@@ -1,0 +1,393 @@
+<!--
+  Title: stratum-lint autofix for components/event-stream (Wave 1)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix: stratum-lint autofix for components/event-stream (Wave 1)
+
+## Overview
+
+Runs `stratum-lint --fix` over `components/event-stream` (`src` + `test`)
+to replace decorative `Layer N` headings with real ones derived from
+each file's actual same-file reference graph, and tag every top-level
+`def`/`defn`/`deftest` with `^{:stratum n}`. One of the Wave 1 batches
+from `work/stratum-lint-baseline-2026-07-24.md` — the largest single
+component in the program to date (26 `src` files including one
+`.cljc`, 29 `test` files; 53 of the 55 rewritten by the fixer, 2 left
+untouched — see below).
+
+Mechanical for almost the whole diff, but the mandated full-diff read
+surfaced one real, pre-existing bug: a 13-line explanatory comment in
+`event_type_registry.clj` documenting `naming-asymmetries` was left
+stranded after a newly-inserted `Layer 3` heading, sitting directly
+against an unrelated one-line comment for a different def
+(`audit-summary`) — see Changes in Detail. Eight files also carried
+stale decorative `Layer N` sub-banners (trailing text or non-integer
+numbers) that `--fix`'s heading regex doesn't recognize and leaves
+untouched; all hand-cleaned. No executable logic changed anywhere.
+
+## Motivation
+
+Fresh plain-lint run against the current pin (`bef8657a`, confirmed
+matching `tasks/stratum.clj` on `main` before starting), zero `SL001`
+across the whole component — no upward-reference/cycle risk, clearing
+this component for a blind `--fix` run per the Wave 1 batch criteria:
+
+- `approval.clj`: `SL002` ×2, `SL003` (4 decorative layers)
+- `core.clj`: `SL002` ×15, `SL003` (9 decorative layers) — the worst
+  offender in the component, not previously called out in this
+  program's tracking
+- `digest.clj`: `SL002` ×1
+- `event_type_registry.clj`: `SL002` ×2
+- `interface/events.clj`: `SL002` ×4, `SL003` (5 decorative layers)
+- `listeners.clj`: `SL003` (4 decorative layers)
+- `schema.clj`: `SL002` ×1, `SL003` (7 decorative layers — the worst
+  per-file heading count)
+- `snowflake.clj`: `SL002` ×4
+- `timeline.clj`: `SL002` ×3, `SL003` (4 decorative layers)
+- `test/core_test.clj`: `SL004` ×2, `SL002` ×6, `SL003` (7 decorative
+  layers)
+- `test/event_type_registry_test.clj`: `SL002` ×1
+- `test/identity_propagation_test.clj`: `SL003` (5 decorative layers)
+- `test/progress_integration_test.clj`: `SL003` (5 decorative layers)
+- `test/reader_test.clj`: `SL004` ×2
+- `test/sinks_test.clj`: `SL004` ×4, `SL002` ×4, `SL003` (5 decorative
+  layers)
+- `test/zettel_promoted_test.clj`: `SL003` (6 decorative layers)
+
+62 findings total, 16 files — larger and shifted from the pointer
+list this task started from (that list was explicitly a partial
+snapshot; `core.clj`, `digest.clj`, and `event_type_registry.clj`
+weren't in it at all).
+
+`interface/manifest.cljc` carries a private `jvm-only!` helper plus
+seven `defn`/`def` pairs entirely inside `#?(:bb ... :clj ...)`
+reader-conditional branches — superficially the SL008 shape fixed
+upstream in [stratum-lint#15](https://github.com/miniforge-ai/stratum-lint/pull/15)
+(merged, pin bumped in #1526). Re-verified directly: a plain lint on
+just that file reports zero findings, and `--fix` on just that file
+produces zero diff. Safe — none of its callers are themselves
+recognized top-level defs (they're all inside the same `#?()` branches),
+so the tool's reference graph never connects them and SL008 doesn't
+fire. Left untouched, as expected.
+
+`test/operator_requests_test.clj` is the other file `--fix` left
+untouched — not a lookalike case, just already fully compliant: it
+already carried correct bare `Layer 0`/`1`/`2` headings and
+`^{:stratum n}` metadata on every `deftest` before this PR, so the
+fixer found nothing to change (zero diff on the very first `--fix`
+run). Confirmed via `git status` after the fix — it's the only test
+file with no changes at all.
+
+## Changes in Detail
+
+Ran, over the whole component, at the current `main` pin:
+
+```bash
+bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "bef8657a2efd3b1ba9e1a4f510693c9fbca45abd" :deps/root "clojure"}}}' -m stratum-lint.interface --fix components/event-stream
+```
+
+53 of the component's 55 `.clj`/`.cljc` files were rewritten (`--fix`
+normalizes every already-annotated file, not just the 16 with
+findings) — `interface/manifest.cljc` and `test/operator_requests_test.clj`
+are the two files left untouched, per the pre-checks above. Diffs are
+heading text, `^{:stratum n}` metadata, and def/deftest reordering only. Verified this with a
+line-multiset differential (added vs. removed lines per file,
+`^{:stratum n}` tags stripped) across all 53 changed files, not just a
+manual read: every file's added/removed line sets balance exactly
+except for the hand edits below and two harmless whitespace-only
+realignments of a trailing same-line comment (`schema.clj`,
+`test/snowflake_test.clj` — same comment, same line, same assertion,
+just different padding before the `;`).
+
+### Stale decorative `Layer N` banners hand-cleaned (8 files)
+
+`--fix`'s heading regex (`^;+\s*-*\s*Layer\s+(\d+)\s*-*\s*$`) only
+matches a bare integer with optional surrounding dashes/whitespace —
+trailing text or a non-integer number fails the match, so `--fix`
+leaves the old banner in place next to (or straddling) its own new,
+correct heading. Found and hand-cleaned:
+
+- `control.clj`: five old `Layer 1a`/`1b`/`1c`/`2a`/`2b` sub-banners,
+  each immediately followed by an existing plain description comment
+  — deleted the banner line, kept the description.
+- `archive.clj`: four old `Layer N — <label>` banners, one of which
+  (`Layer 3 — fleet-level scan + recover over Layer 2`) had been
+  *dragged along* with `scan-incomplete-archives` when `--fix` moved
+  it to its real stratum (1, not 3) — now sitting before the real
+  `Layer 2` heading and actively lying about the def below it.
+  Deleted all four (descriptions were already redundant with the
+  file's own `STRATIFIED-DESIGN LAYERING` comment block, rewritten
+  below to list the real 7-layer structure).
+- `manifest.clj`: five old `Layer N — <label>` banners, three of them
+  similarly dragged to sit before the wrong new heading (claiming
+  `Layer 1`/`3`/`4` while now sitting before real `Layer 3`/`5`/`6`
+  defs). Deleted all five; rewrote the file's `STRATIFIED-DESIGN
+  LAYERING` quick-map from a stale 5-layer description to the real
+  7-layer one `--fix` computed (see SL003 discussion below).
+- `schema.clj`: five old `Layer 1.4`/`1.5`/`2.5`/`4.5`/`5.5` sub-layer
+  banners (non-integer numbers), each already followed by its own
+  description comment — deleted the banner, kept the description.
+- `core.clj`: four old `Layer 5.5`/`6.1`/`6.2`/`6.5` sub-banners, same
+  shape and same fix as `schema.clj`.
+- `sinks.clj`: five old `Layer N: <label>` banners (double-semicolon,
+  colon-suffixed) — three had wrong numbers relative to their new
+  real stratum (`Layer 1`/`3`/`2`/`4` labels sitting before defs at
+  real stratum 0/0/1/5). Dropped the false `Layer N:` claim, kept the
+  label as a plain comment.
+- `interface/events.clj`: one old `Layer 3.5` banner before
+  `agent-stream-stalled` (real stratum 0, since this file is pure
+  re-exports) — dropped the claim, kept the description.
+- `test/sinks_test.clj`, `test/reliability_schema_test.clj`: one old
+  `Layer 1b` / two old `Layer 5.5`/`6` banners respectively, same
+  fix.
+
+### One real bug: a documentation block stranded by a heading insertion
+
+`event_type_registry.clj`'s 13-line `;; Asymmetries at a glance:`
+comment — a worked-example enumeration documenting `naming-asymmetries`
+(real stratum 2) — originally sat physically between `naming-asymmetries`
+and `audit-summary` (real stratum 3) in the pre-fix file. `--fix`
+inserted the new `Layer 3` heading at the start of that gap (comments
+aren't part of the reference graph, so `--fix` doesn't reposition them,
+only new headings), leaving the block sandwiched *under* `Layer 3` and
+crammed directly against `audit-summary`'s own one-line `;; Audit
+summary (machine-readable)` comment with no separation — a reader
+hitting `Layer 3` would reasonably expect what follows to describe
+`audit-summary`, not `naming-asymmetries`.
+
+First attempt at fixing this (moving the block above the heading, with
+a blank line before `Layer 3`) didn't survive: re-running `--fix`
+relocated the heading back to the start of the whole gap and dragged
+the comment block down again — the tool always inserts a heading at
+the first line of the gap between two defs and does not honor an
+internal blank line as a sub-boundary. Fixed properly by moving the
+block to sit directly above `naming-asymmetries` itself (still real
+stratum 2, no heading boundary crossed there), leaving `audit-summary`
+with a clean, accurate one-line comment after `Layer 3`. Re-ran `--fix`
+twice more after this — zero diff both times, confirming the placement
+is stable under the tool. No behavior change; comment-position only.
+
+### Stale namespace-level layer-count documentation updated (2 files)
+
+`archive.clj` and `manifest.clj` each carry a `STRATIFIED-DESIGN
+LAYERING` comment block summarizing which functions live at which
+layer. Both were stale after the fix recomputed real strata:
+
+- `archive.clj`: the map assigned `scan-incomplete-archives` to
+  "Layer 3 fleet-level scan + recover" by naming convention, but the
+  real reference graph places it at Layer 1 (no upward calls — it
+  only touches `manifest/load-manifest` and `marker-path`, both
+  Layer 0). Rewrote the map to list it under Layer 1 and narrowed
+  Layer 3's description to the actual sole remaining function there
+  (`recover-all-incomplete!`).
+- `manifest.clj`: the map described a 5-layer structure
+  (`defaults/data`, `single-concern primitives`, `compose primitives`,
+  `manifest-bound IO`, `scheduled/orchestration`); the real reference
+  graph is 7 layers deep (see SL003 below). Rewrote the map to list
+  all 7 real layers and their actual member functions.
+
+One self-inflicted near-miss during this edit: a wrapped continuation
+line reading `;;            Layer 0` (describing "built on Layer 0")
+sat alone on its own line and matched the heading regex verbatim,
+so the next `--fix` pass silently deleted it as a spurious extra
+`Layer 0` heading. Caught by the mandated re-run-after-hand-edits step
+(diff showed an unexpected file rewrite); fixed by rewording so
+"Layer 0" never appears alone on a line.
+
+## Testing Plan
+
+1. Confirmed the stratum-lint pin in `tasks/stratum.clj`
+   (`bef8657a2efd3b1ba9e1a4f510693c9fbca45abd`) matches current `main`
+   before branching — this program's history has seen stale-pin
+   staleness silently re-corrupt prior work.
+2. Ran plain (non-`--fix`) `stratum-lint` before any change —
+   reproduced the 62 findings above exactly, confirmed 0 `SL001`
+   across the whole component.
+3. Verified `interface/manifest.cljc`'s SL008 lookalike is a true
+   negative: isolated plain lint (zero findings) and isolated `--fix`
+   (zero diff) before touching anything else.
+4. Ran `--fix` over the whole component — 53 files rewritten.
+5. Ran `--fix` a second time immediately — zero diff, confirms
+   idempotency.
+6. Read the full diff for all 53 changed files. Verified the read with
+   a line-multiset differential per file (see Changes in Detail) in
+   addition to a manual pass over every `src` file's diff. Found and
+   fixed the one real bug (`event_type_registry.clj` comment
+   misattachment) and hand-cleaned 8 files' worth of stale decorative
+   headings plus 2 files' worth of stale layer-count documentation.
+7. Re-ran `--fix` after every hand edit (multiple passes, including
+   two more rounds specifically for the `event_type_registry.clj` fix
+   until the tool's heading-insertion behavior was understood and
+   the placement held) — final state is zero diff on a fresh `--fix`
+   pass.
+8. `clj-kondo --lint components/event-stream`: 0 errors both before
+   and after. 4 pre-existing warnings (`timeline.clj` unresolved
+   `clojure.string` namespace — a real pre-existing gap, unrelated to
+   this change; `operator_requests_test.clj` unused binding;
+   `publish_helpers_test.clj` and `quiesce_drain_test.clj` unused
+   `testing` referral) are unchanged in content and count before and
+   after — verified directly against copies of the original files,
+   only line numbers shifted from reordering.
+9. Component test suite: `components/event-stream/deps.edn`'s
+   standalone `:test` alias can't run `core_test.clj` on its own — it
+   requires `ai.miniforge.phase.interface`, which isn't declared as a
+   dep in this component's own `deps.edn` (a pre-existing gap on
+   `main`, unrelated to stratum-lint — confirmed by checking `HEAD`'s
+   version of `core_test.clj`, already requires it; matches the
+   already-tracked "component `deps.edn` missing local deps its own
+   src/test actually needs, masked by root flattening" issue class).
+   Ran instead via the root `:dev:test` aliases, which already
+   flatten every component's deps (including `phase`) — the same
+   classpath `poly test`/CI already use: every test namespace in the
+   component (28 namespaces; `test_helpers/http_mock.clj` is a helper
+   with no `deftest` forms, not a namespace of its own), 349 tests,
+   1747 assertions, 0 failures, 0 errors — 343 tests / 1724 assertions
+   across the 27 namespaces `--fix` actually touched, plus 6 tests /
+   23 assertions from `operator_requests_test.clj` (the one test file
+   left untouched, run separately for completeness). Cross-checked
+   `deftest` form counts per test file before vs. after the fix —
+   identical count in every one of the 27 changed test files,
+   confirming zero tests were dropped by the reordering.
+10. Re-ran plain `stratum-lint` after all fixes: `SL001`/`SL002`/`SL004`
+    clear across the component. `SL003` remains on 12 files, all
+    real over-budget files the old decorative/absent headings hid —
+    none of these are a regression this PR introduces, and all are
+    genuine linear reference-graph depth rather than sprawl (see
+    Deployment Plan for the deferral reasoning):
+
+    | File | Real layers |
+    |------|------------:|
+    | `manifest.clj` | 7 |
+    | `sinks.clj` | 7 |
+    | `timeline.clj` | 6 |
+    | `snowflake.clj` | 5 |
+    | `archive.clj` | 4 |
+    | `control.clj` | 4 |
+    | `core.clj` | 4 |
+    | `digest.clj` | 4 |
+    | `event_type_registry.clj` | 4 |
+    | `operator_requests.clj` | 4 |
+    | `storage_layout.clj` | 4 |
+    | `test/snowflake_test.clj` | 4 |
+
+    Of the files in the original 62-finding list, `approval.clj`,
+    `listeners.clj`, `schema.clj`, `interface/events.clj`,
+    `test/core_test.clj`, `test/identity_propagation_test.clj`,
+    `test/progress_integration_test.clj`, `test/sinks_test.clj`, and
+    `test/zettel_promoted_test.clj` all collapsed to ≤3 real layers —
+    the old decorative headings had overstated their depth. Four
+    files (`archive.clj`, `control.clj`, `digest.clj`,
+    `event_type_registry.clj`, `operator_requests.clj`,
+    `storage_layout.clj`) newly surface `SL003` at exactly 4 — one
+    over budget — purely because their old headings either didn't
+    exist in a form the tool recognized (silently skipped, not a
+    clean bill of health) or undercounted.
+
+## Deployment Plan
+
+Merges to `main` like any other component change. Almost entirely
+comment/metadata/order-only; the one real fix
+(`event_type_registry.clj`'s comment placement) has zero behavior
+impact — no code, only comment position, changed. Pre-commit's
+`lint:stratum` autofixer keeps this component clean going forward.
+
+**SL003 deferral, not resolution, for all 12 remaining files.** Every
+one was examined for a genuinely separable split before deferring —
+none qualified as "clean" within this PR's scope:
+
+- The four-layer files (`archive.clj`, `control.clj`, `core.clj`,
+  `digest.clj`, `event_type_registry.clj`, `operator_requests.clj`,
+  `storage_layout.clj`) are each a single linear pipeline with
+  exactly one function at the deepest layer (e.g. `storage_layout.clj`:
+  raw config → loader → memoized atom → six accessor functions;
+  `digest.clj`: byte conversion → hex conversion → sha256 → the one
+  public `digest-content`). Splitting a 4-deep chain with one function
+  per top layer into multiple namespaces would separate tightly
+  coupled steps with no independent reuse value — busywork, not a
+  real decomposition.
+- `snowflake.clj` (5) and `timeline.clj` (6) are the same shape at
+  greater depth: a Snowflake ID generator's lease-acquire → compose-id
+  → emit-id → generator-handle → public-API pipeline, and an event
+  timeline renderer's field-extraction → formatting → per-event-type
+  dispatch → line-render pipeline. Real sequential depth, not sprawl.
+- `manifest.clj` (7) and `sinks.clj` (7) are the deepest and the most
+  plausible split candidates — `sinks.clj`'s path-resolution helpers
+  (`default-events-dir` → `live-dir`/`archived-dir`/`operator-dir` →
+  `live-workflow-dir`/`archived-workflow-dir` → `workflow-dir`/
+  `event-file-path`) are conceptually separable from its sink
+  implementations, and splitting them into their own namespace would
+  likely drop both files' real depth below budget. Deferred anyway:
+  both are foundational, imported throughout the workspace
+  (`archive.clj`, the CLI, and others call into `sinks.clj`'s path
+  functions directly), and a split needs its own dedicated,
+  carefully-tested PR rather than being folded into a stratum-lint
+  autofix pass.
+- `core.clj` (4) is the highest-traffic file in the component: ~70
+  independent event-constructor functions that are all real stratum 2
+  siblings (each just calls `create-envelope` + `publish!`), one layer
+  over budget only because of the trailing `phase-completed`/chain-event
+  group at stratum 3. A real fix means extracting the event
+  constructors into their own namespace (mirroring what
+  `interface/events.clj` already re-exports) — Wave 2 scope, not a
+  same-PR addition to this one given how central this file is.
+
+This tracks the dominant pattern already established across ~30 prior
+Wave 1 PRs in this program (e.g. `schema`, `self-healing`,
+`release-executor` all deferred equivalent or smaller SL003 overages
+for the same reason: genuine reference-graph depth, not decorative
+inflation). `MINIFORGE_STRATUM_BUDGET_MODE=warn` is required at commit
+time for these 12 files until Wave 2 splits them.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+- Follow-on: Wave 2 namespace splits for the 12 files listed in
+  Testing Plan item 10, `sinks.clj` and `manifest.clj` first (largest
+  real depth, most concrete split candidates identified above)
+- Pre-existing, unrelated gap noticed while running tests:
+  `components/event-stream/deps.edn`'s `:test` alias is missing
+  `ai.miniforge/phase` as a dependency, even though
+  `test/ai/miniforge/event_stream/core_test.clj` requires
+  `ai.miniforge.phase.interface` — masked by the root `:dev`/`:test`
+  aliases' flattened classpath. Matches the already-tracked
+  component-`deps.edn`-transitive-gaps issue class (partially fixed
+  elsewhere, e.g. `gate`/`loop`, `workflow`/`pr-train`). Not fixed
+  here — out of scope for a stratum-lint autofix PR — but worth a
+  follow-up so `clojure -M:test` works standalone for this component.
+- `interface/manifest.cljc`'s SL008 lookalike shape: background in
+  [stratum-lint#15](https://github.com/miniforge-ai/stratum-lint/pull/15)
+  and PR #1526 (pin bump). Re-confirmed safe for this component in
+  Motivation above; no action needed.
+
+## Checklist
+
+- [x] Confirmed stratum-lint pin matches `main` before starting
+- [x] Zero `SL001` confirmed before running `--fix` (no cycle/upward-
+      reference risk)
+- [x] `interface/manifest.cljc` SL008-lookalike re-verified safe in
+      isolation (zero findings, zero `--fix` diff) before touching the
+      rest of the component
+- [x] `--fix` run over the whole component (`src` + `test`)
+- [x] Second `--fix` pass confirms idempotency (zero diff)
+- [x] Diff read in full for all 53 changed files, cross-checked with a
+      line-multiset differential per file
+- [x] One real bug found and fixed: `event_type_registry.clj`'s
+      `naming-asymmetries` documentation block, stranded by a heading
+      insertion, moved back to its correct position (comment-only,
+      verified stable under two more `--fix` re-runs)
+- [x] Eight files' stale decorative `Layer N` banners hand-cleaned;
+      two files' stale `STRATIFIED-DESIGN LAYERING` documentation
+      blocks rewritten to match real post-fix layer counts
+- [x] `clj-kondo` clean of new issues (0 errors before/after; 4
+      pre-existing warnings unchanged in content/count, confirmed
+      against the original files directly)
+- [x] Component tests pass (349 tests, 1747 assertions, 0
+      failures/errors) via the root `:dev:test` classpath; `deftest`
+      counts confirmed identical per file before/after
+- [x] Plain lint re-run post-fix: zero `SL001`/`SL002`/`SL004`;
+      `SL003` remains on 12 files, all documented above with real
+      layer counts and explicit split-feasibility reasoning, tracked
+      as Wave 2
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-event-stream.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-event-stream.md
@@ -213,6 +213,25 @@ the actual public `digest-content`). Moved the banner from above
 on the file afterward — zero diff, confirms the new placement is
 stable. No behavior change; comment-position only.
 
+### Review-round fix: a stale docstring on `listeners.clj`'s privacy/capability map
+
+GitHub Copilot's second review pass (after the `timeline.clj` fix
+above) flagged `privacy->min-capability`'s docstring: it claims
+`:internal events -> :advise or higher`, but the map itself sets
+`:internal :observe` — the same minimum capability as `:public`.
+Verified this is pre-existing (traces back to `components/event-stream`'s
+original introduction, #175 — long before stratum-lint touched this
+file) and that there's no test or spec to determine which side is
+"correct": `work/n08-oci-governance.spec.edn` documents the whole
+capability-gating layer as ~10% implemented and explicitly defers
+privacy-tier policy to a spec that doesn't define this mapping.
+Fixed the docstring to describe the map's actual current behavior
+(no behavior change) rather than tightening the map to match the old
+docstring's claim, which would be an unverifiable security-policy
+decision — see Related Issues for the follow-up. Re-ran `--fix` (zero
+diff), `clj-kondo` (0 errors/warnings), and `listeners_test.clj` (5
+tests, 21 assertions, 0 failures/errors) after the change.
+
 ## Testing Plan
 
 1. Confirmed the stratum-lint pin in `tasks/stratum.clj`
@@ -307,6 +326,11 @@ stable. No behavior change; comment-position only.
     pre-existing `clojure.string` warning), and ran
     `timeline_test.clj` directly (15 tests, 66 assertions, 0
     failures/errors).
+12. Second Copilot review pass (after the `timeline.clj` push) flagged
+    `listeners.clj`'s stale `privacy->min-capability` docstring above.
+    Fixed, re-ran `--fix` (zero diff), `clj-kondo` (0 errors, 0
+    warnings), and `listeners_test.clj` directly (5 tests, 21
+    assertions, 0 failures/errors).
 
 ## Deployment Plan
 
@@ -384,19 +408,32 @@ time for these 12 files until Wave 2 splits them.
   [stratum-lint#15](https://github.com/miniforge-ai/stratum-lint/pull/15)
   and PR #1526 (pin bump). Re-confirmed safe for this component in
   Motivation above; no action needed.
-- Pre-existing docstring/data mismatch noticed while verifying a
-  Copilot low-confidence (suppressed, not posted as an actionable
-  comment) note: `listeners.clj`'s `privacy->min-capability` docstring
-  says `:internal events -> :advise or higher`, but the map itself has
-  `:internal :observe` — the same minimum capability as `:public`,
-  meaning the `:internal` privacy tier currently adds no additional
-  access restriction over `:public`. Confirmed directly against the
-  code; pre-dates this PR (present since at least #854/#1158), not
-  introduced or touched by the stratum-lint fix. Not resolved here:
-  fixing the docstring would just paper over a possible real
-  authorization gap, and fixing the map would change runtime N8 OCI
-  access-control behavior — a decision that deserves its own
-  dedicated review, not a fold-in to a stratum-lint autofix PR.
+- Pre-existing docstring/data mismatch, first noticed via a Copilot
+  low-confidence suppressed note and confirmed as a real, separately
+  posted review comment on the second pass: `listeners.clj`'s
+  `privacy->min-capability` docstring said `:internal events -> :advise
+  or higher`, but the map itself has `:internal :observe` — the same
+  minimum capability as `:public`, meaning the `:internal` privacy tier
+  currently adds no additional access restriction over `:public`.
+  Confirmed pre-dating this PR back to `components/event-stream`'s
+  original introduction (#175) — the stratum-lint fix only reorders,
+  it never touched this docstring's text. No test covers
+  `privacy->min-capability` or its caller either way, and
+  `work/n08-oci-governance.spec.edn` documents the whole capability
+  layer as "~10% implemented," explicitly deferring privacy-tier
+  policy to a spec that doesn't define this mapping yet. Given that,
+  fixed the docstring to describe current behavior accurately rather
+  than changing the map — changing the map would be a security-policy
+  decision (tightening `:internal` event access) that isn't
+  verifiable as correct from the code alone, and doesn't belong in a
+  stratum-lint autofix PR. Matches this program's precedent for
+  exactly this situation (`observer`'s Wave 1 PR fixed a stale
+  docstring claiming unsupported `:json` format support by correcting
+  the doc to match the code, not the reverse, when the "right"
+  behavior wasn't obvious from code alone). The underlying
+  privacy-tiering policy question (should `:internal` require more
+  than `:observe`?) is a genuine product decision, flagged separately
+  for follow-up — not resolved here.
 
 ## Checklist
 
@@ -430,4 +467,10 @@ time for these 12 files until Wave 2 splits them.
 - [x] GitHub Copilot review comment (`timeline.clj`'s misplaced `;;
       Public API` banner) verified directly against the PR's GitHub
       API data and fixed; stability re-confirmed under `--fix`
+- [x] Second Copilot review pass comment (`listeners.clj`'s stale
+      `privacy->min-capability` docstring) verified directly, confirmed
+      pre-existing (traces to #175) and unresolvable to a "correct"
+      map from code/spec alone; fixed the docstring to match current
+      behavior rather than changing runtime access-control behavior;
+      underlying policy question flagged separately in Related Issues
 - [x] No `--no-verify`; pre-commit hook runs normally at commit time

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-event-stream.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-event-stream.md
@@ -265,6 +265,32 @@ functional change. Re-ran `--fix` (zero diff), `clj-kondo` (0
 errors/warnings), and `sinks_test.clj` directly (15 tests, 60
 assertions, 0 failures/errors) after the change.
 
+### Review-round fix: per-event set reallocation in the listener filter path
+
+GitHub Copilot's fifth review pass flagged `matches-workflow?` and
+`matches-event-type?`: both called `(set wf-ids)` / `(set event-types)`
+internally, but their only call site (`register-listener!`'s
+`user-filter-fn` closure) invokes them once per dispatched event, for
+the entire lifetime of a listener subscription — reallocating the set
+on every event instead of once at registration time. Verified the
+call graph directly: grepped `components/event-stream` (`src` and
+`test`) for every caller of either function — the one call site inside
+`listeners.clj` itself is the only one, no re-export in `interface.clj`
+or `interface/listeners.clj`, and no test calls either function
+directly with a raw collection (`web-dashboard/state/workflows.clj`
+has unrelated private functions of the same name, different arity, a
+naming coincidence in a different component). Safe to change the
+contract: `wf-ids`/`event-types` are now converted to sets once when
+`user-filter-fn` is built (`register-listener!`), and
+`matches-workflow?`/`matches-event-type?` now expect an already-built
+set (`empty?`/`contains?` only — no more `set` call per event).
+Semantics unchanged: `(set nil)` still produces `#{}`, so the
+no-filter case still short-circuits via `empty?` exactly as before.
+Re-ran `--fix` (zero diff), `clj-kondo` (0 errors/warnings), and both
+`listeners_test.clj` and `anomaly/listeners_anomaly_test.clj` (12
+tests, 35 assertions, 0 failures/errors) plus the full component suite
+(349 tests, 1747 assertions, 0 failures/errors) after the change.
+
 ## Testing Plan
 
 1. Confirmed the stratum-lint pin in `tasks/stratum.clj`
@@ -374,6 +400,13 @@ assertions, 0 failures/errors) after the change.
     Fixed, re-ran `--fix` (zero diff), `clj-kondo` (0 errors, 0
     warnings), and `sinks_test.clj` directly (15 tests, 60 assertions,
     0 failures/errors).
+15. Fifth Copilot review pass (after the `sinks_test.clj` push) flagged
+    `listeners.clj`'s per-event set reallocation above. Verified the
+    full call graph before changing the function contract (see detail
+    above), fixed, re-ran `--fix` (zero diff), `clj-kondo` (0 errors, 0
+    warnings), `listeners_test.clj` + `anomaly/listeners_anomaly_test.clj`
+    (12 tests, 35 assertions), and the full component suite (349
+    tests, 1747 assertions, 0 failures/errors).
 
 ## Deployment Plan
 
@@ -522,4 +555,9 @@ time for these 12 files until Wave 2 splits them.
 - [x] Fourth Copilot review pass comment (`sinks_test.clj`'s
       `sinks`-local-shadows-`sinks`-alias) verified directly and fixed
       in all three affected `testing` blocks
+- [x] Fifth Copilot review pass comment (`listeners.clj`'s per-event
+      `matches-workflow?`/`matches-event-type?` set reallocation)
+      verified directly, call graph confirmed safe to change (single
+      call site, no re-exports, no direct tests), fixed, full
+      component suite re-run clean (349 tests, 1747 assertions)
 - [x] No `--no-verify`; pre-commit hook runs normally at commit time

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-event-stream.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-event-stream.md
@@ -196,6 +196,23 @@ so the next `--fix` pass silently deleted it as a spurious extra
 (diff showed an unexpected file rewrite); fixed by rewording so
 "Layer 0" never appears alone on a line.
 
+### Review-round fix: a misplaced `;; Public API` banner (`timeline.clj`)
+
+GitHub Copilot's automated review on this PR flagged one real issue:
+the plain `;; Public API` grouping comment (not a `Layer N` heading —
+same class of pre-existing free-floating comment as
+`event_type_registry.clj`'s "Asymmetries at a glance" block above) sat
+directly above `index-tool-names`, a `defn-` (private). The file's
+only actual public function is `render-timeline` at the bottom
+(`defn`, real stratum 5) — every other function in the file is
+`defn-`. Verified directly against the PR's GitHub API data (not just
+the review summary) and cross-checked the same banner's correct usage
+elsewhere in the component (`digest.clj:108`, sitting directly above
+the actual public `digest-content`). Moved the banner from above
+`index-tool-names` to directly above `render-timeline`. Re-ran `--fix`
+on the file afterward — zero diff, confirms the new placement is
+stable. No behavior change; comment-position only.
+
 ## Testing Plan
 
 1. Confirmed the stratum-lint pin in `tasks/stratum.clj`
@@ -284,13 +301,20 @@ so the next `--fix` pass silently deleted it as a spurious extra
     over budget — purely because their old headings either didn't
     exist in a form the tool recognized (silently skipped, not a
     clean bill of health) or undercounted.
+11. GitHub Copilot review (post-push) flagged the `timeline.clj`
+    `;; Public API` misplacement above. Fixed, re-ran `--fix` (zero
+    diff, stable), re-ran `clj-kondo` on the file (0 errors, same 1
+    pre-existing `clojure.string` warning), and ran
+    `timeline_test.clj` directly (15 tests, 66 assertions, 0
+    failures/errors).
 
 ## Deployment Plan
 
 Merges to `main` like any other component change. Almost entirely
-comment/metadata/order-only; the one real fix
-(`event_type_registry.clj`'s comment placement) has zero behavior
-impact — no code, only comment position, changed. Pre-commit's
+comment/metadata/order-only; the two real fixes
+(`event_type_registry.clj`'s and `timeline.clj`'s comment placement)
+have zero behavior impact — no code, only comment position, changed.
+Pre-commit's
 `lint:stratum` autofixer keeps this component clean going forward.
 
 **SL003 deferral, not resolution, for all 12 remaining files.** Every
@@ -360,6 +384,19 @@ time for these 12 files until Wave 2 splits them.
   [stratum-lint#15](https://github.com/miniforge-ai/stratum-lint/pull/15)
   and PR #1526 (pin bump). Re-confirmed safe for this component in
   Motivation above; no action needed.
+- Pre-existing docstring/data mismatch noticed while verifying a
+  Copilot low-confidence (suppressed, not posted as an actionable
+  comment) note: `listeners.clj`'s `privacy->min-capability` docstring
+  says `:internal events -> :advise or higher`, but the map itself has
+  `:internal :observe` — the same minimum capability as `:public`,
+  meaning the `:internal` privacy tier currently adds no additional
+  access restriction over `:public`. Confirmed directly against the
+  code; pre-dates this PR (present since at least #854/#1158), not
+  introduced or touched by the stratum-lint fix. Not resolved here:
+  fixing the docstring would just paper over a possible real
+  authorization gap, and fixing the map would change runtime N8 OCI
+  access-control behavior — a decision that deserves its own
+  dedicated review, not a fold-in to a stratum-lint autofix PR.
 
 ## Checklist
 
@@ -390,4 +427,7 @@ time for these 12 files until Wave 2 splits them.
       `SL003` remains on 12 files, all documented above with real
       layer counts and explicit split-feasibility reasoning, tracked
       as Wave 2
+- [x] GitHub Copilot review comment (`timeline.clj`'s misplaced `;;
+      Public API` banner) verified directly against the PR's GitHub
+      API data and fixed; stability re-confirmed under `--fix`
 - [x] No `--no-verify`; pre-commit hook runs normally at commit time

--- a/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-event-stream.md
+++ b/docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-event-stream.md
@@ -252,6 +252,19 @@ to match the verified real structure. Re-ran `--fix` (zero diff),
 `clj-kondo` (0 errors/warnings), and `approval_test.clj` (9 tests, 45
 assertions, 0 failures/errors) after the change.
 
+### Review-round fix: a local binding shadowing the `sinks` namespace alias
+
+GitHub Copilot's fourth review pass flagged `sinks_test.clj`'s
+`create-sinks-from-config-test`: all three `testing` blocks bound
+their result to a local named `sinks`, shadowing the file's own
+`[ai.miniforge.event-stream.sinks :as sinks]` require within each
+block. Verified directly — confirmed all three `(let [sinks ...] ...)`
+forms. Renamed the local to `created-sinks` in all three blocks and
+updated the `is` assertions referencing it. Purely mechanical, no
+functional change. Re-ran `--fix` (zero diff), `clj-kondo` (0
+errors/warnings), and `sinks_test.clj` directly (15 tests, 60
+assertions, 0 failures/errors) after the change.
+
 ## Testing Plan
 
 1. Confirmed the stratum-lint pin in `tasks/stratum.clj`
@@ -356,6 +369,11 @@ assertions, 0 failures/errors) after the change.
     Fixed, re-ran `--fix` (zero diff), `clj-kondo` (0 errors, 0
     warnings), and `approval_test.clj` directly (9 tests, 45
     assertions, 0 failures/errors).
+14. Fourth Copilot review pass (after the `approval.clj` push) flagged
+    `sinks_test.clj`'s `sinks`-local-shadows-`sinks`-alias issue above.
+    Fixed, re-ran `--fix` (zero diff), `clj-kondo` (0 errors, 0
+    warnings), and `sinks_test.clj` directly (15 tests, 60 assertions,
+    0 failures/errors).
 
 ## Deployment Plan
 
@@ -501,4 +519,7 @@ time for these 12 files until Wave 2 splits them.
 - [x] Third Copilot review pass comment (`approval.clj`'s stale
       namespace-docstring layer summary) verified directly against the
       file's actual `^{:stratum n}` tags and fixed
+- [x] Fourth Copilot review pass comment (`sinks_test.clj`'s
+      `sinks`-local-shadows-`sinks`-alias) verified directly and fixed
+      in all three affected `testing` blocks
 - [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
## Summary

- Runs `stratum-lint --fix` over `components/event-stream` (`src` + `test`) — the largest component in the Wave 1 program (55 files, 53 rewritten).
- Full-diff read surfaced one real, pre-existing bug (comment-only, no behavior change): a documentation block in `event_type_registry.clj` was left stranded by a heading insertion, misattached next to an unrelated def's comment. Fixed.
- Eight files had stale decorative `Layer N` banners the fixer's regex doesn't recognize (trailing text or non-integer numbers); hand-cleaned.
- 12 files still carry a genuine `SL003` over-budget finding after the fix recomputed real layer counts. All deferred to Wave 2 with per-file split-feasibility reasoning — see the PR doc.

Full detail in `docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-event-stream.md`.

## Test plan

- [x] Zero `SL001` confirmed before running `--fix` (no cycle/upward-reference risk)
- [x] `interface/manifest.cljc`'s SL008-lookalike shape re-verified safe (zero findings, zero `--fix` diff) before touching anything else
- [x] `--fix` run twice — second pass is zero diff (idempotent)
- [x] Full diff read for all 53 changed files, cross-checked with a per-file line-multiset differential
- [x] `clj-kondo --lint components/event-stream`: 0 errors before/after; pre-existing warnings unchanged in content/count
- [x] Component tests: 349 tests, 1747 assertions, 0 failures/errors (via root `:dev:test` classpath — the component's own standalone `:test` alias has a pre-existing, unrelated `deps.edn` gap, flagged in Related Issues, not fixed here)
- [x] Plain lint re-run post-fix: `SL001`/`SL002`/`SL004` clear; `SL003` remains on 12 files, documented with real layer counts and deferred to Wave 2
- [x] Pre-commit hook ran normally (commit-budget + stratum-budget overrides used, both with explicit rationale — expected for a first-touch full-file autofix on this component)

🤖 Generated with [Claude Code](https://claude.com/claude-code)