### PR TITLE
fix: restore displaced ;; execute comment in tui-views update_test.clj

### DIFF
--- a/components/tui-views/test/ai/miniforge/tui_views/update_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/update_test.clj
@@ -196,7 +196,7 @@
     (into [[:input {:key :key/colon :char \:}]]   ;; enter command mode
           (conj (vec (for [ch cmd-str]
                        [:input {:key nil :char ch}]))
-                [:input :key/enter]))))
+                [:input :key/enter]))))  ;; execute
 
 ;; ---------------------------------------------------------------------------
 ;; PR event handler tests
@@ -930,4 +930,4 @@
     (let [m (util/apply-updates (util/fresh-model)
               [[:msg/workflow-added {:workflow-id wf-id-1 :name "test"}]
                [:msg/agent-started {:workflow-id wf-id-1 :agent :planner}]])]
-      (is (= :started (get-in m [:workflows 0 :agents :planner :status])))))  ;; execute
+      (is (= :started (get-in m [:workflows 0 :agents :planner :status])))))


### PR DESCRIPTION
## Summary
- Follow-up to #1535, caught by an adversarial post-merge review the user requested for that PR (74 files, too large for Copilot's automated review to cover).
- The `--fix` pass's appendix-relocation mechanism moved an orphaned `(testing ...)` block (pre-existing, not wrapped in any `deftest`) to the end of the file, carrying a same-line trailing comment (`;; execute`) that actually belonged to `execute-command`'s closing line earlier in the file.
- Moved the comment back. No test logic changed.

## Verification
- `clj-kondo`: 0 errors, 0 warnings
- `update_test.clj` namespace: 29 tests, 192 assertions, 0 failures, 0 errors

## Related
- The orphaned (non-`deftest`-wrapped) `testing` block itself predates this PR and is tracked as a separate follow-up (not fixed here, per the review's recommendation to keep this change minimal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)