### PR TITLE
fix(evidence-bundle): guard nil created-at in time-range query filters

### DIFF
--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/protocols/impl/evidence_bundle.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/protocols/impl/evidence_bundle.clj
@@ -184,4 +184,4 @@
 (defn ^{:stratum 1} query-bundles-impl
   "Query bundles by criteria."
   [bundles criteria]
-  (filter #(matches-criteria? % criteria) (vals @bundles)))
+  (vec (filter #(matches-criteria? % criteria) (vals @bundles))))

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/protocols/impl/evidence_bundle.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/protocols/impl/evidence_bundle.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.evidence-bundle.protocols.impl.evidence-bundle
   "Implementation functions for EvidenceBundle protocol.
    Pure functions organized in layers."
@@ -25,9 +24,9 @@
    [ai.miniforge.logging.interface :as log]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Evidence Collection Helpers
 
-(defn collect-phase-evidence
+;; Evidence Collection Helpers
+(defn ^{:stratum 0} collect-phase-evidence
   "Extract evidence from a phase execution.
    Returns phase evidence map per N6 spec."
   [phase-name phase-result]
@@ -43,29 +42,14 @@
      :phase/inner-loop-iterations (get phase-result :inner-loop-iterations 0)
      :phase/event-stream-range (get phase-result :event-stream-range {})}))
 
-(defn collect-all-phase-evidence
-  "Collect evidence from all executed phases.
-   Returns map of phase-name -> evidence."
-  [workflow-state]
-  (let [phases (:workflow/phases workflow-state {})]
-    (reduce-kv
-     (fn [acc phase-name phase-result]
-       (if-let [evidence (collect-phase-evidence phase-name phase-result)]
-         (assoc acc (keyword "evidence" (name phase-name)) evidence)
-         acc))
-     {}
-     phases)))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; Bundle Creation
-
-(defn extract-execution-evidence
+(defn ^{:stratum 0} extract-execution-evidence
   "Compatibility wrapper for execution evidence extraction.
    Delegates to the canonical collector implementation."
   [workflow-state]
   (collector/collect-execution-evidence workflow-state))
 
-(defn create-bundle-impl
+(defn ^{:stratum 0} create-bundle-impl
   "Create evidence bundle from workflow state.
    Merges N11 §9.1 execution evidence fields from :execution/output.
    Returns [bundle updated-bundles-atom-value]"
@@ -93,21 +77,19 @@
 
     [bundle new-bundles]))
 
-(defn get-bundle-impl
+(defn ^{:stratum 0} get-bundle-impl
   "Retrieve bundle by ID."
   [bundles bundle-id]
   (get @bundles bundle-id))
 
-(defn get-bundle-by-workflow-impl
+(defn ^{:stratum 0} get-bundle-by-workflow-impl
   "Retrieve bundle by workflow ID."
   [bundles workflow-id]
   (some #(when (= (:evidence-bundle/workflow-id %) workflow-id) %)
         (vals @bundles)))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Query Operations
-
-(defn matches-criteria?
+(defn ^{:stratum 0} matches-criteria?
   "Check if bundle matches query criteria."
   [bundle criteria]
   (every?
@@ -116,8 +98,8 @@
        :time-range
        (let [[start end] v
              created (:evidence-bundle/created-at bundle)]
-         (and (or (nil? start) (.isAfter created start))
-              (or (nil? end) (.isBefore created end))))
+         (and (or (nil? start) (and created (.isAfter created start)))
+              (or (nil? end) (and created (.isBefore created end)))))
 
        :intent-type
        (= v (get-in bundle [:evidence/intent :intent/type]))
@@ -128,15 +110,8 @@
        true))
    criteria))
 
-(defn query-bundles-impl
-  "Query bundles by criteria."
-  [bundles criteria]
-  (filter #(matches-criteria? % criteria) (vals @bundles)))
-
-;------------------------------------------------------------------------------ Layer 3
 ;; Validation
-
-(defn validate-bundle-impl
+(defn ^{:stratum 0} validate-bundle-impl
   "Validate bundle structure and integrity.
    Returns {:valid? bool :errors [...]}"
   [bundle]
@@ -173,10 +148,8 @@
     {:valid? (empty? @errors)
      :errors @errors}))
 
-;------------------------------------------------------------------------------ Layer 4
 ;; Export Operations
-
-(defn export-bundle-impl
+(defn ^{:stratum 0} export-bundle-impl
   "Export bundle to file.
    Returns true on success, false on error."
   [bundles logger bundle-id output-path]
@@ -192,3 +165,23 @@
                  {:data {:bundle-id bundle-id
                          :error (.getMessage e)}})
       false)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} collect-all-phase-evidence
+  "Collect evidence from all executed phases.
+   Returns map of phase-name -> evidence."
+  [workflow-state]
+  (let [phases (:workflow/phases workflow-state {})]
+    (reduce-kv
+     (fn [acc phase-name phase-result]
+       (if-let [evidence (collect-phase-evidence phase-name phase-result)]
+         (assoc acc (keyword "evidence" (name phase-name)) evidence)
+         acc))
+     {}
+     phases)))
+
+(defn ^{:stratum 1} query-bundles-impl
+  "Query bundles by criteria."
+  [bundles criteria]
+  (filter #(matches-criteria? % criteria) (vals @bundles)))

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/protocols/impl/provenance_tracer.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/protocols/impl/provenance_tracer.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.evidence-bundle.protocols.impl.provenance-tracer
   "Implementation functions for ProvenanceTracer protocol.
    Traces artifact chains and provenance."
@@ -23,52 +22,62 @@
    [ai.miniforge.artifact.interface :as artifact]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Provenance Query Helpers
 
-(defn get-artifact-with-provenance
+;; Provenance Query Helpers
+(defn ^{:stratum 0} get-artifact-with-provenance
   "Get artifact with full provenance information."
   [artifact-store artifact-id]
   (when-let [artifact (artifact/load-artifact artifact-store artifact-id)]
     artifact))
 
-(defn get-source-artifacts
-  "Get all source artifacts for a given artifact."
-  [artifact-store artifact-id]
-  (when-let [artifact (get-artifact-with-provenance artifact-store artifact-id)]
-    (let [source-ids (get-in artifact [:artifact/provenance :provenance/source-artifacts] [])]
-      (keep #(get-artifact-with-provenance artifact-store %) source-ids))))
-
-(defn get-workflow-artifacts
+(defn ^{:stratum 0} get-workflow-artifacts
   "Get all artifacts for a workflow."
   [artifact-store workflow-id]
   (let [artifacts (artifact/query artifact-store {})]
     (filter #(= workflow-id (get-in % [:artifact/provenance :provenance/workflow-id]))
             artifacts)))
 
+;; Intent Mismatch Detection
+(defn ^{:stratum 0} query-intent-mismatches-impl
+  "Find workflows where declared intent != actual behavior.
+   Returns vector of mismatch records."
+  [bundles opts]
+  (let [time-range (:time-range opts)
+        all-bundles (vals @bundles)
+        filtered-bundles (if time-range
+                           (let [[start end] time-range]
+                             (filter
+                              #(let [created (:evidence-bundle/created-at %)]
+                                 (and (or (nil? start) (and created (.isAfter created start)))
+                                      (or (nil? end) (and created (.isBefore created end)))))
+                              all-bundles))
+                           all-bundles)]
+
+    (keep
+     (fn [bundle]
+       (let [sem-val (:evidence/semantic-validation bundle)
+             declared (:semantic-validation/declared-intent sem-val)
+             actual (:semantic-validation/actual-behavior sem-val)
+             passed? (:semantic-validation/passed? sem-val)]
+
+         (when (and declared actual (not passed?))
+           {:workflow-id (:evidence-bundle/workflow-id bundle)
+            :declared-intent declared
+            :actual-behavior actual
+            :violation-details sem-val
+            :created-at (:evidence-bundle/created-at bundle)})))
+     filtered-bundles)))
+
 ;------------------------------------------------------------------------------ Layer 1
-;; Provenance Tracing
 
-(defn query-provenance-impl
-  "Get full provenance for an artifact.
-   Returns {:artifact {...} :workflow-id :original-intent {...}}"
-  [artifact-store bundles artifact-id]
+(defn ^{:stratum 1} get-source-artifacts
+  "Get all source artifacts for a given artifact."
+  [artifact-store artifact-id]
   (when-let [artifact (get-artifact-with-provenance artifact-store artifact-id)]
-    (let [workflow-id (get-in artifact [:artifact/provenance :provenance/workflow-id])
-          bundle (when workflow-id
-                   (some #(when (= (:evidence-bundle/workflow-id %) workflow-id) %)
-                         (vals @bundles)))
-          source-artifacts (get-source-artifacts artifact-store artifact-id)]
+    (let [source-ids (get-in artifact [:artifact/provenance :provenance/source-artifacts] [])]
+      (keep #(get-artifact-with-provenance artifact-store %) source-ids))))
 
-      {:artifact artifact
-       :workflow-id workflow-id
-       :original-intent (get bundle :evidence/intent)
-       :created-by-phase (get-in artifact [:artifact/provenance :provenance/phase])
-       :created-by-agent (get-in artifact [:artifact/provenance :provenance/agent])
-       :created-at (get-in artifact [:artifact/provenance :provenance/created-at])
-       :source-artifacts source-artifacts
-       :full-evidence-bundle bundle})))
-
-(defn trace-artifact-chain-impl
+(defn ^{:stratum 1} trace-artifact-chain-impl
   "Trace complete artifact chain for a workflow.
    Returns {:intent {...} :chain [...] :outcome {...}}"
   [artifact-store bundles workflow-id]
@@ -97,34 +106,24 @@
        :outcome (:evidence/outcome bundle)})))
 
 ;------------------------------------------------------------------------------ Layer 2
-;; Intent Mismatch Detection
 
-(defn query-intent-mismatches-impl
-  "Find workflows where declared intent != actual behavior.
-   Returns vector of mismatch records."
-  [bundles opts]
-  (let [time-range (:time-range opts)
-        all-bundles (vals @bundles)
-        filtered-bundles (if time-range
-                           (let [[start end] time-range]
-                             (filter
-                              #(let [created (:evidence-bundle/created-at %)]
-                                 (and (or (nil? start) (.isAfter created start))
-                                      (or (nil? end) (.isBefore created end))))
-                              all-bundles))
-                           all-bundles)]
+;; Provenance Tracing
+(defn ^{:stratum 2} query-provenance-impl
+  "Get full provenance for an artifact.
+   Returns {:artifact {...} :workflow-id :original-intent {...}}"
+  [artifact-store bundles artifact-id]
+  (when-let [artifact (get-artifact-with-provenance artifact-store artifact-id)]
+    (let [workflow-id (get-in artifact [:artifact/provenance :provenance/workflow-id])
+          bundle (when workflow-id
+                   (some #(when (= (:evidence-bundle/workflow-id %) workflow-id) %)
+                         (vals @bundles)))
+          source-artifacts (get-source-artifacts artifact-store artifact-id)]
 
-    (keep
-     (fn [bundle]
-       (let [sem-val (:evidence/semantic-validation bundle)
-             declared (:semantic-validation/declared-intent sem-val)
-             actual (:semantic-validation/actual-behavior sem-val)
-             passed? (:semantic-validation/passed? sem-val)]
-
-         (when (and declared actual (not passed?))
-           {:workflow-id (:evidence-bundle/workflow-id bundle)
-            :declared-intent declared
-            :actual-behavior actual
-            :violation-details sem-val
-            :created-at (:evidence-bundle/created-at bundle)})))
-     filtered-bundles)))
+      {:artifact artifact
+       :workflow-id workflow-id
+       :original-intent (get bundle :evidence/intent)
+       :created-by-phase (get-in artifact [:artifact/provenance :provenance/phase])
+       :created-by-agent (get-in artifact [:artifact/provenance :provenance/agent])
+       :created-at (get-in artifact [:artifact/provenance :provenance/created-at])
+       :source-artifacts source-artifacts
+       :full-evidence-bundle bundle})))

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/protocols/impl/provenance_tracer.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/protocols/impl/provenance_tracer.clj
@@ -53,20 +53,21 @@
                               all-bundles))
                            all-bundles)]
 
-    (keep
-     (fn [bundle]
-       (let [sem-val (:evidence/semantic-validation bundle)
-             declared (:semantic-validation/declared-intent sem-val)
-             actual (:semantic-validation/actual-behavior sem-val)
-             passed? (:semantic-validation/passed? sem-val)]
+    (vec
+     (keep
+      (fn [bundle]
+        (let [sem-val (:evidence/semantic-validation bundle)
+              declared (:semantic-validation/declared-intent sem-val)
+              actual (:semantic-validation/actual-behavior sem-val)
+              passed? (:semantic-validation/passed? sem-val)]
 
-         (when (and declared actual (not passed?))
-           {:workflow-id (:evidence-bundle/workflow-id bundle)
-            :declared-intent declared
-            :actual-behavior actual
-            :violation-details sem-val
-            :created-at (:evidence-bundle/created-at bundle)})))
-     filtered-bundles)))
+          (when (and declared actual (not passed?))
+            {:workflow-id (:evidence-bundle/workflow-id bundle)
+             :declared-intent declared
+             :actual-behavior actual
+             :violation-details sem-val
+             :created-at (:evidence-bundle/created-at bundle)})))
+      filtered-bundles))))
 
 ;------------------------------------------------------------------------------ Layer 1
 

--- a/components/evidence-bundle/test/ai/miniforge/evidence_bundle/query_bundles_test.clj
+++ b/components/evidence-bundle/test/ai/miniforge/evidence_bundle/query_bundles_test.clj
@@ -1,0 +1,74 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.evidence-bundle.query-bundles-test
+  "Tests for query criteria matching against evidence bundles.
+
+   Covers matches-criteria? and query-bundles-impl, including bundles
+   missing :evidence-bundle/created-at (schema requires the key, but
+   nothing enforces it against malformed/corrupted stored data)."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.evidence-bundle.protocols.impl.evidence-bundle :as impl]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; :time-range criteria — well-formed bundles
+(deftest ^{:stratum 0} matches-criteria-time-range-well-formed-test
+  (testing "Bundle with :evidence-bundle/created-at inside the range matches"
+    (let [now (java.time.Instant/now)
+          bundle {:evidence-bundle/created-at now}]
+      (is (true? (impl/matches-criteria?
+                  bundle
+                  {:time-range [(.minusSeconds now 60) (.plusSeconds now 60)]})))))
+
+  (testing "Bundle with :evidence-bundle/created-at outside the range does not match"
+    (let [now (java.time.Instant/now)
+          bundle {:evidence-bundle/created-at now}]
+      (is (false? (impl/matches-criteria?
+                   bundle
+                   {:time-range [(.plusSeconds now 60) nil]}))))))
+
+;; :time-range criteria — bundle missing :evidence-bundle/created-at
+(deftest ^{:stratum 0} matches-criteria-time-range-missing-created-at-test
+  (testing "Bundle missing :evidence-bundle/created-at filters out (does not match) rather than throwing, when :start is set"
+    (let [bundle {}]
+      (is (false? (impl/matches-criteria?
+                   bundle
+                   {:time-range [(java.time.Instant/now) nil]})))))
+
+  (testing "Bundle missing :evidence-bundle/created-at filters out (does not match) rather than throwing, when :end is set"
+    (let [bundle {}]
+      (is (false? (impl/matches-criteria?
+                   bundle
+                   {:time-range [nil (java.time.Instant/now)]})))))
+
+  (testing "query-bundles-impl excludes bundles missing :evidence-bundle/created-at instead of throwing an NPE"
+    (let [now (java.time.Instant/now)
+          good-bundle {:evidence-bundle/id (random-uuid)
+                       :evidence-bundle/created-at now}
+          bad-bundle {:evidence-bundle/id (random-uuid)}
+          bundles (atom {(:evidence-bundle/id good-bundle) good-bundle
+                         (:evidence-bundle/id bad-bundle) bad-bundle})
+          results (impl/query-bundles-impl
+                   bundles
+                   {:time-range [(.minusSeconds now 60) (.plusSeconds now 60)]})]
+      (is (= [good-bundle] results)))))
+
+(comment
+  (clojure.test/run-tests)
+  :leave-this-here)

--- a/components/evidence-bundle/test/ai/miniforge/evidence_bundle/query_bundles_test.clj
+++ b/components/evidence-bundle/test/ai/miniforge/evidence_bundle/query_bundles_test.clj
@@ -67,7 +67,8 @@
           results (impl/query-bundles-impl
                    bundles
                    {:time-range [(.minusSeconds now 60) (.plusSeconds now 60)]})]
-      (is (= [good-bundle] results)))))
+      (is (= [good-bundle] results))
+      (is (vector? results) "query-bundles-impl must return a vector per its documented contract"))))
 
 (comment
   (clojure.test/run-tests)

--- a/components/evidence-bundle/test/ai/miniforge/evidence_bundle/query_intent_mismatches_test.clj
+++ b/components/evidence-bundle/test/ai/miniforge/evidence_bundle/query_intent_mismatches_test.clj
@@ -50,7 +50,8 @@
           bundles (atom {(:evidence-bundle/id bundle) bundle})
           results (prov/query-intent-mismatches-impl
                    bundles {:time-range [(.minusSeconds now 60) (.plusSeconds now 60)]})]
-      (is (= 1 (count results)))))
+      (is (= 1 (count results)))
+      (is (vector? results) "query-intent-mismatches-impl must return a vector per its documented contract")))
 
   (testing "Bundle with :evidence-bundle/created-at outside the range is excluded"
     (let [now (java.time.Instant/now)

--- a/components/evidence-bundle/test/ai/miniforge/evidence_bundle/query_intent_mismatches_test.clj
+++ b/components/evidence-bundle/test/ai/miniforge/evidence_bundle/query_intent_mismatches_test.clj
@@ -1,0 +1,79 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.evidence-bundle.query-intent-mismatches-test
+  "Tests for query-intent-mismatches-impl's :time-range filtering,
+   including bundles missing :evidence-bundle/created-at (schema
+   requires the key, but nothing enforces it against malformed/corrupted
+   stored data)."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.evidence-bundle.protocols.impl.provenance-tracer :as prov]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Fixtures
+(defn- ^{:stratum 0} mismatch-bundle
+  "Bundle shaped to be picked up as an intent mismatch (declared != actual,
+   not passed?). `created-at` may be nil to simulate a corrupted bundle
+   missing the schema-required :evidence-bundle/created-at field."
+  [created-at]
+  (cond-> {:evidence-bundle/id (random-uuid)
+           :evidence-bundle/workflow-id (random-uuid)
+           :evidence/semantic-validation
+           {:semantic-validation/declared-intent {:intent/type :import}
+            :semantic-validation/actual-behavior {:intent/type :create}
+            :semantic-validation/passed? false}}
+    created-at (assoc :evidence-bundle/created-at created-at)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; :time-range criteria — well-formed bundles
+(deftest ^{:stratum 1} query-intent-mismatches-time-range-well-formed-test
+  (testing "Bundle with :evidence-bundle/created-at inside the range is included"
+    (let [now (java.time.Instant/now)
+          bundle (mismatch-bundle now)
+          bundles (atom {(:evidence-bundle/id bundle) bundle})
+          results (prov/query-intent-mismatches-impl
+                   bundles {:time-range [(.minusSeconds now 60) (.plusSeconds now 60)]})]
+      (is (= 1 (count results)))))
+
+  (testing "Bundle with :evidence-bundle/created-at outside the range is excluded"
+    (let [now (java.time.Instant/now)
+          bundle (mismatch-bundle now)
+          bundles (atom {(:evidence-bundle/id bundle) bundle})
+          results (prov/query-intent-mismatches-impl
+                   bundles {:time-range [(.plusSeconds now 60) nil]})]
+      (is (empty? results)))))
+
+;; :time-range criteria — bundle missing :evidence-bundle/created-at
+(deftest ^{:stratum 1} query-intent-mismatches-time-range-missing-created-at-test
+  (testing "Bundle missing :evidence-bundle/created-at is excluded rather than throwing, when :start is set"
+    (let [bundle (mismatch-bundle nil)
+          bundles (atom {(:evidence-bundle/id bundle) bundle})]
+      (is (empty? (prov/query-intent-mismatches-impl
+                   bundles {:time-range [(java.time.Instant/now) nil]})))))
+
+  (testing "Bundle missing :evidence-bundle/created-at is excluded rather than throwing, when :end is set"
+    (let [bundle (mismatch-bundle nil)
+          bundles (atom {(:evidence-bundle/id bundle) bundle})]
+      (is (empty? (prov/query-intent-mismatches-impl
+                   bundles {:time-range [nil (java.time.Instant/now)]}))))))
+
+(comment
+  (clojure.test/run-tests)
+  :leave-this-here)


### PR DESCRIPTION
## Summary
- `matches-criteria?` (evidence_bundle.clj) and `query-intent-mismatches-impl` (provenance_tracer.clj) called `.isAfter`/`.isBefore` directly on `:evidence-bundle/created-at`, a field the schema requires but nothing enforces against malformed/corrupted stored bundles.
- A bundle missing that field threw an NPE on any `:time-range` query instead of just failing to match.
- Both call sites now guard with `(and created ...)` so a missing timestamp filters the bundle out rather than crashing the query.

## Test plan
- [x] Added `query_bundles_test.clj` and `query_intent_mismatches_test.clj`, each covering: well-formed bundle in/out of range, and a bundle missing `:evidence-bundle/created-at` (must be excluded, not throw).
- [x] Verified fail-before/pass-after: stashed each fix in turn and reran its test — NPEs pre-fix, 0 failures post-fix.
- [x] Full evidence-bundle component suite: 114 tests, 0 failures, 0 errors.
- [x] Full-workspace `poly test`: 0 failures, 0 errors.