### PR TITLE
feat: add PR-level size budget + adversarial-review-before-push rule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,12 @@ jobs:
           # shallow tip -- a depth-1 checkout wouldn't have it.
           fetch-depth: 0
 
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
       - name: Install Clojure
         uses: DeLaGuardo/setup-clojure@12.5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
-# This workflow runs linting, tests, and builds on every push and PR.
+# This workflow runs linting, tests, and builds on every push and PR, plus a
+# PR-only size check (pr-budget) that rejects a whole PR's cumulative diff
+# past 200 reportable lines -- the PR-level counterpart to the commit-time
+# `commit-budget` gate.
 # All output is captured in log files and uploaded as artifacts for debugging.
 # Logs are retained for 7 days and can be downloaded from the Actions UI.
 
@@ -23,6 +26,43 @@ env:
   MINIFORGE_CI_BOT_APP_ID: "3360143"
 
 jobs:
+  pr-size:
+    name: PR Size
+    # PR-level only: there's no meaningful base..head diff on a plain
+    # push to main (that's what commit-budget already covers per-commit).
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # Need the merge-base between base and head, not just the
+          # shallow tip -- a depth-1 checkout wouldn't have it.
+          fetch-depth: 0
+
+      - name: Install Clojure
+        uses: DeLaGuardo/setup-clojure@12.5
+        with:
+          cli: latest
+          bb: latest
+
+      - name: Cache Clojure dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+          key: clojure-${{ runner.os }}-${{ hashFiles('deps.edn', '**/deps.edn') }}
+          restore-keys: |
+            clojure-${{ runner.os }}-
+
+      - name: Check PR size budget
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: bb pr-budget
+
   structure:
     name: Structure
     runs-on: ubuntu-latest

--- a/agents.md
+++ b/agents.md
@@ -84,8 +84,58 @@ See `standards/miniforge/CLAUDE.md` for authoritative descriptions. Summary:
 
 - **Stratified Design** — dependencies flow downward only; no cycles; pure Domain layer
 - **Simple Made Easy** — values over state; data over syntax; no speculative complexity
-- **PR Discipline** — one stratum per PR, <400 lines, branch from main, never bypass hooks
+- **PR Discipline** — one stratum per PR, <200 lines (enforced in CI by
+  `bb pr-budget`, mirroring the commit-time `bb commit-budget` gate),
+  branch from main, never bypass hooks
 - **Specification-Driven** — N-series specs are implementation contracts; code conforms to specs
+- **Adversarial Review Before Push** — before opening or pushing to any
+  PR, review your own diff adversarially: read every changed file
+  assuming something is wrong until you've verified it isn't, not just
+  clj-kondo/tests passing. This applies doubly to mechanical/generated
+  diffs (codemods, autofixers, bulk renames) — a diff being "supposed
+  to be" behavior-neutral is a claim to verify, not a fact to assume.
+  GitHub Copilot's automated review silently declines to comment at
+  all past its own size threshold, so a large PR that skips this step
+  may receive zero real review. See `## PR Size and Review Discipline`
+  below for the incident that motivated this.
+
+## PR Size and Review Discipline
+
+Two related, previously-missing gates, added 2026-07-26:
+
+- **`bb pr-budget`** (CI, `pull_request` events only): rejects a PR
+  whose whole merge-base..head diff exceeds 200 reportable lines
+  (same blank/comment/generated-path exclusions as `bb commit-budget`).
+  This is distinct from `commit-budget`, which only ever looked at one
+  commit's staged diff — a PR made of a single large commit (or several
+  commits each individually under budget) sailed through unchecked
+  before this existed. Override via a `MINIFORGE_PR_BUDGET_OVERRIDE:
+  <rationale>` line in the PR description, visible to every reviewer
+  on the PR (unlike the commit-level env-var override, visible only in
+  local shell history / CI logs).
+- **Adversarial self-review before every push**, not just for PRs that
+  trip the size gate. Read the actual diff like a skeptical reviewer,
+  not the tool's own "this should be safe" framing.
+
+**Why both, together:** a mechanical stratum-lint autofix program
+(2026-07 Wave 1 remediation, tracked in
+`work/stratum-lint-baseline-2026-07-24.md`) shipped several PRs of
+74-98 changed files and 10,000+ changed lines each, each as one
+`MINIFORGE_COMMIT_BUDGET_OVERRIDE`'d commit — legal under the
+commit-only gate that existed at the time. GitHub Copilot's automated
+review silently declined to post any comments at all on the largest of
+these (past its own undocumented size ceiling), so the only real
+review those PRs got was a dedicated adversarial pass run by hand,
+*after* several had already merged. That pass found real defects
+(a comment-attachment bug, an undisclosed behavior change buried
+inside a PR whose description claimed "mechanical, no logic changes,"
+several stale/contradictory comments) that plain CI (lint + tests
+green) had not and could not catch. `pr-budget` exists so a PR that
+size can't reach merge without either being split up or explicitly
+flagging its own size with a reviewable rationale; the adversarial-review
+principle exists because passing CI was never sufficient evidence of
+correctness for a mechanical diff this large, and treating it as
+sufficient is what let the gap open in the first place.
 
 ## Writing Spec Task Descriptions (`work/*.spec.edn`)
 

--- a/bb.edn
+++ b/bb.edn
@@ -80,6 +80,11 @@
    :requires ([commit-budget])
    :task (commit-budget/run nil)}
 
+  pr-budget
+  {:doc  "CI-only: reject a whole PR's merge-base..head diff over 200 lines, same exclusions as commit-budget. Reads PR_BASE_SHA/PR_HEAD_SHA/PR_BODY from the environment. Override via a `MINIFORGE_PR_BUDGET_OVERRIDE: reason` line in the PR description."
+   :requires ([pr-budget])
+   :task (pr-budget/run nil)}
+
   ;; ──────────────────────────────────────────────────────────────────────────
   ;; Testing
   ;; ──────────────────────────────────────────────────────────────────────────

--- a/docs/pull-requests/2026-07-26-feat-pr-size-budget-and-review-discipline.md
+++ b/docs/pull-requests/2026-07-26-feat-pr-size-budget-and-review-discipline.md
@@ -1,0 +1,152 @@
+<!--
+  Title: Add a PR-level size budget and an adversarial-review-before-push rule
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# feat: PR-level size budget + adversarial-review-before-push standing rule
+
+## Overview
+
+Adds `bb pr-budget`, a CI-only gate that rejects a whole pull request's
+merge-base..head diff once it exceeds 200 reportable lines (same
+blank/comment/generated-path exclusions as the existing commit-time
+`bb commit-budget`), wired into `.github/workflows/ci.yml` as a new
+`pr-size` job that runs only on `pull_request` events. Also documents
+"review your own diff adversarially before pushing" as a standing
+principle in `agents.md`, alongside a new `## PR Size and Review
+Discipline` section explaining why both exist together.
+
+## Motivation
+
+The 2026-07 stratum-lint Wave 1 remediation program (tracked in
+`work/stratum-lint-baseline-2026-07-24.md`) shipped several PRs of
+74-98 changed files and 10,000+ changed lines each, every one as a
+single `MINIFORGE_COMMIT_BUDGET_OVERRIDE`'d commit — perfectly legal
+under the gate that existed, since `commit-budget` only ever looked at
+one commit's staged diff, never a PR's cumulative shape across however
+many commits it took to land. Two consequences surfaced directly:
+
+1. **GitHub Copilot's automated review silently declined to comment at
+   all** on the largest of these PRs (confirmed directly: zero inline
+   comments posted on a 74-file PR, despite being asked to review) —
+   past some undocumented size ceiling, a gargantuan PR gets
+   effectively zero automated review coverage, with no visible warning
+   that this happened.
+2. A dedicated adversarial review pass, run by hand after several of
+   these PRs had already merged, found real defects plain CI (lint +
+   tests green) had not and could not catch: a trailing comment
+   silently displaced onto the wrong test form during an automated
+   reorder, and — more seriously — a PR whose description claimed
+   "mechanical, no logic changes" while actually carrying an
+   undisclosed behavior change (a genuine bug fix folded into the same
+   commit as the mechanical rewrite it was found alongside).
+
+Passing CI was never sufficient evidence of correctness for a diff
+that size; treating it as sufficient is what let both of the above
+ship unreviewed. This PR closes the gate side (a PR that large can no
+longer merge without either being split up or explicitly flagging its
+own size with a reviewable rationale) and documents the practice side
+(review your own diff like a skeptical reviewer before pushing, not
+just "tests pass").
+
+## Changes in Detail
+
+- `tasks/pr_budget.clj` (new): PR-level counterpart to
+  `tasks/commit_budget.clj`. Reuses `commit-budget`'s pure line-
+  counting/exclusion functions directly (`parse-diff`,
+  `reportable-changes`, `total-lines`, `print-report!`) rather than
+  duplicating them, so a file that doesn't count against a commit
+  doesn't count against its PR either. Adds:
+  - `pr-diff`: `git diff --no-color -U0 <base>...<head>` (three-dot,
+    against the merge-base — matches what GitHub's own PR diff view
+    and `gh pr diff` report).
+  - `override-rationale`: looks for a `MINIFORGE_PR_BUDGET_OVERRIDE:
+    <rationale>` line in the PR description (not an env var, since a
+    CI job has no access to the author's local shell — a marker in
+    the PR body is visible to every reviewer on the PR, not just
+    whoever committed).
+  - `check-pr-budget!` / `run`: reads `PR_BASE_SHA` / `PR_HEAD_SHA` /
+    `PR_BODY` from the environment (set by the calling CI step from
+    the `pull_request` event payload).
+- `bb.edn`: new `pr-budget` task, deliberately NOT added to the
+  `pre-commit` `:depends` chain — it needs `PR_BASE_SHA`/`PR_HEAD_SHA`,
+  which don't exist locally; it's CI-only by design.
+- `.github/workflows/ci.yml`: new `pr-size` job, gated on
+  `github.event_name == 'pull_request'` (a push to `main` has no
+  meaningful base..head PR diff — that's what `commit-budget` already
+  covers, per commit). Uses `fetch-depth: 0` so the merge-base is
+  actually present locally. Passes `PR_BODY` via `env:`, not
+  interpolated into the `run:` shell string, per this repo's workflow-
+  injection-safety convention (untrusted PR-description text goes
+  through an environment variable, never directly into a shell
+  command).
+- `agents.md`: updated the existing "PR Discipline" bullet's stale
+  `<400 lines` aspiration to the actual enforced `<200 lines` ceiling;
+  added a new "Adversarial Review Before Push" principle; added the
+  `## PR Size and Review Discipline` section documenting the incident
+  and the reasoning above, so future agents reading this file get the
+  "why," not just the "what."
+
+## Testing Plan
+
+- `clj-kondo --lint tasks/pr_budget.clj tasks/commit_budget.clj`: 0
+  errors, 0 warnings.
+- Ran `bb pr-budget` locally against three real merge-base..head
+  ranges (fetched the relevant commits first):
+  1. A genuinely small PR (#1537, a 1-file/2-line comment fix):
+     `📏 pr-budget: 4 / 200 lines OK` — passes clean.
+  2. A Wave 1 mechanical-fix PR (#1528, `operator`, one of the
+     *smallest* in that program): `❌ PR BUDGET EXCEEDED: 1618 > 200
+     lines` — correctly rejected. Confirms even the smallest Wave 1
+     PRs would have tripped this gate had it existed at the time.
+  3. Same #1528 diff with `PR_BODY` containing
+     `MINIFORGE_PR_BUDGET_OVERRIDE: mechanical Wave 1 stratum-lint fix,
+     whole-component rewrite`: `📏 pr-budget: OVERRIDDEN (1618
+     reportable lines)`, exit 0 — override mechanism works.
+- Validated `.github/workflows/ci.yml` is well-formed YAML
+  (`python3 -c "import yaml; yaml.safe_load(...)"`).
+- `markdownlint agents.md` and the new PR doc: 0 errors (two
+  bullet-list line-length violations from the first draft, wrapped to
+  fix).
+- Did not modify `standards/miniforge` (a submodule, separate
+  governance) — the pre-existing "See `standards/miniforge/CLAUDE.md`
+  for authoritative descriptions" pointer in `agents.md` is unchanged;
+  this PR only updates the summary bullets and adds a new section in
+  the consuming repo's own `agents.md`.
+
+## Deployment Plan
+
+Merges to `main`. The `pr-size` CI job starts running on the next
+`pull_request` event automatically (no ruleset change needed to run
+it) but is **not required** in the repo's branch protection ruleset as
+part of this PR — recommend making it a required status check as a
+deliberate, separate follow-up once it's been observed passing/failing
+correctly on a few real PRs, rather than making it blocking on day
+one. Every future PR whose diff exceeds 200 reportable lines will need
+either splitting or an explicit `MINIFORGE_PR_BUDGET_OVERRIDE:` line —
+this includes the remainder of the stratum-lint Wave 1 program, which
+will need to shift from "one PR per component" to smaller per-file or
+per-file-group slices going forward.
+
+## Related Issues/PRs
+
+- Motivated by user-requested adversarial review of
+  [#1534](https://github.com/miniforge-ai/miniforge/pull/1534) (98
+  files) and [#1535](https://github.com/miniforge-ai/miniforge/pull/1535)
+  (74 files) from the stratum-lint Wave 1 program, and a follow-up fix
+  from that review: [#1537](https://github.com/miniforge-ai/miniforge/pull/1537).
+- Existing commit-level gate this mirrors: `tasks/commit_budget.clj`
+  (added 2026-05-02, `141840af3`).
+- Tracked in `work/stratum-lint-baseline-2026-07-24.md`'s program —
+  Wave 1 batch 7 is paused pending this landing.
+
+## Checklist
+
+- [x] `clj-kondo` clean on both budget task files
+- [x] Manually verified against 3 real PR diff ranges: small-clean-pass,
+      large-reject, large-with-override
+- [x] CI workflow YAML validated as well-formed
+- [x] `markdownlint` clean on both changed/added Markdown files
+- [x] No `standards/miniforge` submodule changes
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time

--- a/tasks/pr_budget.clj
+++ b/tasks/pr_budget.clj
@@ -84,14 +84,6 @@
               (println (str/trim err))))
           (System/exit 1)))))
 
-;; report (composes Layer 1)
-(defn ^{:stratum 0} print-report!
-  "Same shape as `commit-budget/print-report!`; kept separate (rather
-   than calling it directly) since PR-level output carries different
-   framing text below it."
-  [annotated total]
-  (cb/print-report! annotated total))
-
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn ^{:stratum 1} override-rationale
@@ -130,7 +122,7 @@
           (when (> total budget)
             (println (format "  WARNING: %d > %d — budget intentionally bypassed."
                               total budget)))
-          (print-report! annotated total))
+          (cb/print-report! annotated total))
 
       (<= total budget)
       (println (format "📏 pr-budget: %d / %d lines OK" total budget))
@@ -141,7 +133,7 @@
           (println (format "❌ PR BUDGET EXCEEDED: %d > %d lines" total budget))
           (println "════════════════════════════════════════════════════════════════")
           (println "")
-          (print-report! annotated total)
+          (cb/print-report! annotated total)
           (println "")
           (println "Why this exists:")
           (println "  Reviewer defect-detection drops sharply past ~200 LOC, and")
@@ -165,7 +157,8 @@
   "CI entry point. Reads `PR_BASE_SHA`/`PR_HEAD_SHA`/`PR_BODY` from the
    environment (set by the calling GitHub Actions step from the
    `pull_request` event payload) rather than taking CLI args, so the
-   workflow YAML stays a plain `bb -m pr-budget` invocation."
+   workflow YAML stays a plain `bb pr-budget` invocation (the bb.edn
+   task, not `bb -m pr-budget` -- this namespace has no `-main`)."
   [_opts]
   (let [base (System/getenv "PR_BASE_SHA")
         head (System/getenv "PR_HEAD_SHA")]

--- a/tasks/pr_budget.clj
+++ b/tasks/pr_budget.clj
@@ -95,11 +95,11 @@
   "Rationale string when `pr-body` contains the override marker, else
    nil. `pr-body` may be nil (e.g. an empty PR description)."
   [pr-body]
-  (some-> pr-body
-          (->> (re-find override-marker-re))
-          second
-          str/trim
-          not-empty))
+  (when pr-body
+    (some-> (re-find override-marker-re pr-body)
+            second
+            str/trim
+            not-empty)))
 
 ;------------------------------------------------------------------------------ Layer 2
 

--- a/tasks/pr_budget.clj
+++ b/tasks/pr_budget.clj
@@ -1,0 +1,176 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns pr-budget
+  "PR-level counterpart to `commit-budget` — a hard ceiling on the
+   WHOLE pull request's cumulative diff size, not just its latest
+   commit.
+
+   Why this exists as a separate gate: `commit-budget` runs at commit
+   time on the *staged* diff only. A single-commit PR is fully covered
+   by it, but nothing previously stopped a PR from packaging one
+   mechanical whole-file rewrite into exactly one commit that itself
+   sits at (or is overridden past) the 200-line ceiling — 74- and
+   98-file, 10k+-line PRs shipped this way during the stratum-lint
+   Wave 1 program, each as a single overridden commit. Copilot's
+   automated review silently declines to comment at all past its own
+   size threshold on PRs that large, so the only review such a PR
+   actually received was whatever a human or agent did by hand,
+   after the fact. This gate runs in CI against the merge-base..head
+   diff so it catches the PR's total shape regardless of how many
+   commits it took to get there.
+
+   Reuses `commit-budget`'s pure line-counting/exclusion logic
+   (comment/blank stripping, generated-path exclusions) so a file that
+   doesn't count against a commit doesn't count against its PR either.
+
+   Default: 200 lines, same bound as `commit-budget` (Smartbear 2010 /
+   Cisco 2018 review-throughput research this repo already leans on).
+   Override: add a line matching `MINIFORGE_PR_BUDGET_OVERRIDE: <rationale>`
+   to the PR description. Unlike the commit-level env-var override
+   (which only the person committing can see), this is visible to
+   every reviewer on the PR itself."
+  (:require [babashka.process :as p]
+            [clojure.string :as str]
+            [commit-budget :as cb]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; pure helpers (no in-namespace deps)
+(def ^{:stratum 0} default-budget
+  "Same ceiling as `commit-budget/default-budget` — one number, one
+   rationale, applied at both the commit and the PR level."
+  cb/default-budget)
+
+(def ^{:stratum 0} override-marker-re
+  "Matches `MINIFORGE_PR_BUDGET_OVERRIDE: <rationale>` (or `=`) anywhere
+   in the PR description, case-sensitive on the marker itself so it
+   can't be triggered by incidental prose. Captures the rationale."
+  #"(?m)^MINIFORGE_PR_BUDGET_OVERRIDE\s*[:=]\s*(.+)$")
+
+;; git wrapper (composes Layer 0 + commit-budget's pure parse/count fns)
+(defn ^{:stratum 0} pr-diff
+  "Parsed `git diff --no-color -U0 <base>...<head>` (three-dot: against
+   the merge-base, matching what GitHub's own PR diff view and `gh pr
+   diff` report) as per-file diff maps, reusing `commit-budget`'s
+   parser. Fails the task closed on a non-zero git exit, same posture
+   as `commit-budget/staged-diff` — an unreadable diff should never
+   silently pass."
+  [base-sha head-sha]
+  (let [{:keys [out err exit]}
+        (p/sh {:out :string :err :string}
+              "git" "diff" "--no-color" "-U0" (str base-sha "..." head-sha))]
+    (cond
+      (zero? exit) (cb/parse-diff out)
+      :else
+      (do (binding [*out* *err*]
+            (println (format "❌ pr-budget: `git diff` %s...%s exited %d"
+                              base-sha head-sha exit))
+            (when-not (str/blank? err)
+              (println (str/trim err))))
+          (System/exit 1)))))
+
+;; report (composes Layer 1)
+(defn ^{:stratum 0} print-report!
+  "Same shape as `commit-budget/print-report!`; kept separate (rather
+   than calling it directly) since PR-level output carries different
+   framing text below it."
+  [annotated total]
+  (cb/print-report! annotated total))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} override-rationale
+  "Rationale string when `pr-body` contains the override marker, else
+   nil. `pr-body` may be nil (e.g. an empty PR description)."
+  [pr-body]
+  (some-> pr-body
+          (->> (re-find override-marker-re))
+          second
+          str/trim
+          not-empty))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; CLI entry (composes Layer 2)
+(defn ^{:stratum 2} check-pr-budget!
+  "PR-level gate. `base-sha`/`head-sha` are the PR's base and head
+   commits (three-dot diff against their merge-base). `pr-body` is the
+   PR description text, used only to look for the override marker.
+
+   Returns nil when within budget or overridden; calls `(System/exit
+   1)` on a genuine over-budget PR so this composes as a required CI
+   check."
+  [base-sha head-sha pr-body budget]
+  (let [entries   (pr-diff base-sha head-sha)
+        annotated (cb/reportable-changes entries)
+        total     (cb/total-lines annotated)
+        rationale (override-rationale pr-body)]
+    (cond
+      (empty? entries)
+      (println "📏 pr-budget: no changed files in this diff")
+
+      rationale
+      (do (println (format "📏 pr-budget: OVERRIDDEN (%d reportable lines)" total))
+          (println (str "  rationale: " rationale))
+          (when (> total budget)
+            (println (format "  WARNING: %d > %d — budget intentionally bypassed."
+                              total budget)))
+          (print-report! annotated total))
+
+      (<= total budget)
+      (println (format "📏 pr-budget: %d / %d lines OK" total budget))
+
+      :else
+      (do (println "")
+          (println "════════════════════════════════════════════════════════════════")
+          (println (format "❌ PR BUDGET EXCEEDED: %d > %d lines" total budget))
+          (println "════════════════════════════════════════════════════════════════")
+          (println "")
+          (print-report! annotated total)
+          (println "")
+          (println "Why this exists:")
+          (println "  Reviewer defect-detection drops sharply past ~200 LOC, and")
+          (println "  GitHub Copilot's automated review silently declines to comment")
+          (println "  at all on PRs past its own size threshold -- past that point a")
+          (println "  gargantuan PR gets effectively zero automated review coverage.")
+          (println "")
+          (println "How to proceed:")
+          (println "  • Split the change into several smaller PRs -- e.g. one")
+          (println "    mechanical fix per file or small file-group, not one PR per")
+          (println "    whole component.")
+          (println "  • Genuine exception: add a line to the PR description reading")
+          (println "    `MINIFORGE_PR_BUDGET_OVERRIDE: <rationale>` and re-run this")
+          (println "    check (re-push or re-run the workflow).")
+          (println "")
+          (System/exit 1)))))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} run
+  "CI entry point. Reads `PR_BASE_SHA`/`PR_HEAD_SHA`/`PR_BODY` from the
+   environment (set by the calling GitHub Actions step from the
+   `pull_request` event payload) rather than taking CLI args, so the
+   workflow YAML stays a plain `bb -m pr-budget` invocation."
+  [_opts]
+  (let [base (System/getenv "PR_BASE_SHA")
+        head (System/getenv "PR_HEAD_SHA")]
+    (if (or (str/blank? base) (str/blank? head))
+      (do (binding [*out* *err*]
+            (println "❌ pr-budget: PR_BASE_SHA / PR_HEAD_SHA not set -- this task only runs under the pull_request CI job"))
+          (System/exit 1))
+      (check-pr-budget! base head (System/getenv "PR_BODY") default-budget))))

--- a/tasks/pr_budget.clj
+++ b/tasks/pr_budget.clj
@@ -59,8 +59,13 @@
 (def ^{:stratum 0} override-marker-re
   "Matches `MINIFORGE_PR_BUDGET_OVERRIDE: <rationale>` (or `=`) anywhere
    in the PR description, case-sensitive on the marker itself so it
-   can't be triggered by incidental prose. Captures the rationale."
-  #"(?m)^MINIFORGE_PR_BUDGET_OVERRIDE\s*[:=]\s*(.+)$")
+   can't be triggered by incidental prose. Captures the rationale.
+   Tolerates leading whitespace and a single markdown list/quote/emphasis
+   prefix (`-`, `*`, `>`, `_`) before the marker, since GitHub's editor
+   readily produces `  MINIFORGE_PR_BUDGET_OVERRIDE: ...` (indented) or
+   `> MINIFORGE_PR_BUDGET_OVERRIDE: ...` (blockquoted) without the
+   author intending anything other than a plain override line."
+  #"(?m)^\s*[-*>_]?\s*MINIFORGE_PR_BUDGET_OVERRIDE\s*[:=]\s*(.+)$")
 
 ;; git wrapper (composes Layer 0 + commit-budget's pure parse/count fns)
 (defn ^{:stratum 0} pr-diff


### PR DESCRIPTION
<!--
  Title: Add a PR-level size budget and an adversarial-review-before-push rule
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# feat: PR-level size budget + adversarial-review-before-push standing rule

## Overview

Adds `bb pr-budget`, a CI-only gate that rejects a whole pull request's
merge-base..head diff once it exceeds 200 reportable lines (same
blank/comment/generated-path exclusions as the existing commit-time
`bb commit-budget`), wired into `.github/workflows/ci.yml` as a new
`pr-size` job that runs only on `pull_request` events. Also documents
"review your own diff adversarially before pushing" as a standing
principle in `agents.md`, alongside a new `## PR Size and Review
Discipline` section explaining why both exist together.

## Motivation

The 2026-07 stratum-lint Wave 1 remediation program (tracked in
`work/stratum-lint-baseline-2026-07-24.md`) shipped several PRs of
74-98 changed files and 10,000+ changed lines each, every one as a
single `MINIFORGE_COMMIT_BUDGET_OVERRIDE`'d commit — perfectly legal
under the gate that existed, since `commit-budget` only ever looked at
one commit's staged diff, never a PR's cumulative shape across however
many commits it took to land. Two consequences surfaced directly:

1. **GitHub Copilot's automated review silently declined to comment at
   all** on the largest of these PRs (confirmed directly: zero inline
   comments posted on a 74-file PR, despite being asked to review) —
   past some undocumented size ceiling, a gargantuan PR gets
   effectively zero automated review coverage, with no visible warning
   that this happened.
2. A dedicated adversarial review pass, run by hand after several of
   these PRs had already merged, found real defects plain CI (lint +
   tests green) had not and could not catch: a trailing comment
   silently displaced onto the wrong test form during an automated
   reorder, and — more seriously — a PR whose description claimed
   "mechanical, no logic changes" while actually carrying an
   undisclosed behavior change (a genuine bug fix folded into the same
   commit as the mechanical rewrite it was found alongside).

Passing CI was never sufficient evidence of correctness for a diff
that size; treating it as sufficient is what let both of the above
ship unreviewed. This PR closes the gate side (a PR that large can no
longer merge without either being split up or explicitly flagging its
own size with a reviewable rationale) and documents the practice side
(review your own diff like a skeptical reviewer before pushing, not
just "tests pass").

## Changes in Detail

- `tasks/pr_budget.clj` (new): PR-level counterpart to
  `tasks/commit_budget.clj`. Reuses `commit-budget`'s pure line-
  counting/exclusion functions directly (`parse-diff`,
  `reportable-changes`, `total-lines`, `print-report!`) rather than
  duplicating them, so a file that doesn't count against a commit
  doesn't count against its PR either. Adds:
  - `pr-diff`: `git diff --no-color -U0 <base>...<head>` (three-dot,
    against the merge-base — matches what GitHub's own PR diff view
    and `gh pr diff` report).
  - `override-rationale`: looks for a `MINIFORGE_PR_BUDGET_OVERRIDE:
    <rationale>` line in the PR description (not an env var, since a
    CI job has no access to the author's local shell — a marker in
    the PR body is visible to every reviewer on the PR, not just
    whoever committed).
  - `check-pr-budget!` / `run`: reads `PR_BASE_SHA` / `PR_HEAD_SHA` /
    `PR_BODY` from the environment (set by the calling CI step from
    the `pull_request` event payload).
- `bb.edn`: new `pr-budget` task, deliberately NOT added to the
  `pre-commit` `:depends` chain — it needs `PR_BASE_SHA`/`PR_HEAD_SHA`,
  which don't exist locally; it's CI-only by design.
- `.github/workflows/ci.yml`: new `pr-size` job, gated on
  `github.event_name == 'pull_request'` (a push to `main` has no
  meaningful base..head PR diff — that's what `commit-budget` already
  covers, per commit). Uses `fetch-depth: 0` so the merge-base is
  actually present locally. Passes `PR_BODY` via `env:`, not
  interpolated into the `run:` shell string, per this repo's workflow-
  injection-safety convention (untrusted PR-description text goes
  through an environment variable, never directly into a shell
  command).
- `agents.md`: updated the existing "PR Discipline" bullet's stale
  `<400 lines` aspiration to the actual enforced `<200 lines` ceiling;
  added a new "Adversarial Review Before Push" principle; added the
  `## PR Size and Review Discipline` section documenting the incident
  and the reasoning above, so future agents reading this file get the
  "why," not just the "what."

## Testing Plan

- `clj-kondo --lint tasks/pr_budget.clj tasks/commit_budget.clj`: 0
  errors, 0 warnings.
- Ran `bb pr-budget` locally against three real merge-base..head
  ranges (fetched the relevant commits first):
  1. A genuinely small PR (#1537, a 1-file/2-line comment fix):
     `📏 pr-budget: 4 / 200 lines OK` — passes clean.
  2. A Wave 1 mechanical-fix PR (#1528, `operator`, one of the
     *smallest* in that program): `❌ PR BUDGET EXCEEDED: 1618 > 200
     lines` — correctly rejected. Confirms even the smallest Wave 1
     PRs would have tripped this gate had it existed at the time.
  3. Same #1528 diff with `PR_BODY` containing
     `MINIFORGE_PR_BUDGET_OVERRIDE: mechanical Wave 1 stratum-lint fix,
     whole-component rewrite`: `📏 pr-budget: OVERRIDDEN (1618
     reportable lines)`, exit 0 — override mechanism works.
- Validated `.github/workflows/ci.yml` is well-formed YAML
  (`python3 -c "import yaml; yaml.safe_load(...)"`).
- `markdownlint agents.md` and the new PR doc: 0 errors (two
  bullet-list line-length violations from the first draft, wrapped to
  fix).
- Did not modify `standards/miniforge` (a submodule, separate
  governance) — the pre-existing "See `standards/miniforge/CLAUDE.md`
  for authoritative descriptions" pointer in `agents.md` is unchanged;
  this PR only updates the summary bullets and adds a new section in
  the consuming repo's own `agents.md`.

## Deployment Plan

Merges to `main`. The `pr-size` CI job starts running on the next
`pull_request` event automatically (no ruleset change needed to run
it) but is **not required** in the repo's branch protection ruleset as
part of this PR — recommend making it a required status check as a
deliberate, separate follow-up once it's been observed passing/failing
correctly on a few real PRs, rather than making it blocking on day
one. Every future PR whose diff exceeds 200 reportable lines will need
either splitting or an explicit `MINIFORGE_PR_BUDGET_OVERRIDE:` line —
this includes the remainder of the stratum-lint Wave 1 program, which
will need to shift from "one PR per component" to smaller per-file or
per-file-group slices going forward.

## Related Issues/PRs

- Motivated by user-requested adversarial review of
  [#1534](https://github.com/miniforge-ai/miniforge/pull/1534) (98
  files) and [#1535](https://github.com/miniforge-ai/miniforge/pull/1535)
  (74 files) from the stratum-lint Wave 1 program, and a follow-up fix
  from that review: [#1537](https://github.com/miniforge-ai/miniforge/pull/1537).
- Existing commit-level gate this mirrors: `tasks/commit_budget.clj`
  (added 2026-05-02, `141840af3`).
- Tracked in `work/stratum-lint-baseline-2026-07-24.md`'s program —
  Wave 1 batch 7 is paused pending this landing.

## Checklist

- [x] `clj-kondo` clean on both budget task files
- [x] Manually verified against 3 real PR diff ranges: small-clean-pass,
      large-reject, large-with-override
- [x] CI workflow YAML validated as well-formed
- [x] `markdownlint` clean on both changed/added Markdown files
- [x] No `standards/miniforge` submodule changes
- [x] No `--no-verify`; pre-commit hook runs normally at commit time


---

MINIFORGE_PR_BUDGET_OVERRIDE: this PR is the gate's own introduction, self-tested (see Testing Plan) as a single cohesive feature -- new pr-budget task + bb.edn wiring + CI job + agents.md docs. Splitting it further would leave individually-meaningless pieces (the task is dead code without the bb.edn entry and CI wiring).
