### PR TITLE
fix: wrap orphaned testing block in deftest in tui-views update_test.clj

### DIFF
--- a/components/tui-views/test/ai/miniforge/tui_views/update_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/update_test.clj
@@ -516,6 +516,13 @@
       (is (= :sync-prs (:type (:side-effect m))))
       (is (str/includes? (:flash-message m) "Syncing")))))
 
+(deftest ^{:stratum 1} agent-started-routes-through-root-update-test
+  (testing "Agent started message is routed through the root update"
+    (let [m (util/apply-updates (util/fresh-model)
+              [[:msg/workflow-added {:workflow-id wf-id-1 :name "test"}]
+               [:msg/agent-started {:workflow-id wf-id-1 :agent :planner}]])]
+      (is (= :started (get-in m [:workflows 0 :agents :planner :status]))))))
+
 ;------------------------------------------------------------------------------ Layer 2
 
 (deftest ^{:stratum 2} navigation-test
@@ -925,9 +932,3 @@
       ;; Active detail should be unchanged
       (is (= 1 (count (get-in m [:detail :phases]))))
       (is (= :plan (:phase (first (get-in m [:detail :phases]))))))))
-
-(testing "Agent started message is routed through the root update"
-    (let [m (util/apply-updates (util/fresh-model)
-              [[:msg/workflow-added {:workflow-id wf-id-1 :name "test"}]
-               [:msg/agent-started {:workflow-id wf-id-1 :agent :planner}]])]
-      (is (= :started (get-in m [:workflows 0 :agents :planner :status])))))


### PR DESCRIPTION
## Summary
- A `testing` block asserting agent-started routing sat outside any `deftest` in `update_test.clj`. `clojure.test`'s `inc-report-counter` no-ops when `*report-counters*` isn't bound (true outside `run-tests`/`test-var`), so the assertion never counted toward pass/fail and could not fail CI even if the underlying behavior regressed.
- Wrapped it in `(deftest agent-started-routes-through-root-update-test ...)`. The repo's stratum-lint pre-commit hook relocated it into the Layer 1 section and tagged it `^{:stratum 1}` to match its dependencies.

## Test plan
- [x] Verified the fix catches regressions: temporarily changed the expected value to `:bogus`, confirmed the namespace run failed (`1 failures`), then restored it.
- [x] Ran the full `ai.miniforge.tui-views.update-test` namespace: 30 tests, 193 assertions, 0 failures, 0 errors.
- [x] Pre-commit smoke suite (16 namespaces, 331 tests) and GraalVM/Babashka compatibility checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)