### PR TITLE
fix: tighten :internal privacy events to require :advise capability

### DIFF
--- a/components/event-stream/src/ai/miniforge/event_stream/listeners.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/listeners.clj
@@ -46,8 +46,7 @@
 (def ^{:stratum 0} privacy->min-capability
   "Map from event privacy level to minimum listener capability required.
    :public events -> any listener (:observe)
-   :internal events -> :observe (same as :public; tiered gating not yet
-   implemented, see work/n08-oci-governance.spec.edn)
+   :internal events -> :advise or higher (covers llm/*, tool/*, agent/*)
    :confidential events -> :control only"
   {:public       :observe
    :internal     :advise

--- a/components/event-stream/src/ai/miniforge/event_stream/listeners.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/listeners.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.listeners
   "Listener registry with capability enforcement for N8 OCI compliance.
 
@@ -34,32 +33,75 @@
    [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Constants
 
-(def capability-levels
+;; Constants
+(def ^{:stratum 0} capability-levels
   "Valid listener capability levels, ordered by privilege."
   #{:observe :advise :control})
 
-(def capability-rank
+(def ^{:stratum 0} capability-rank
   "Numeric rank for capability comparison."
   {:observe 0 :advise 1 :control 2})
 
-(defn capability-sufficient?
-  "Check if actual capability meets or exceeds required capability."
-  [actual required]
-  (>= (get capability-rank actual 0)
-      (get capability-rank required 0)))
-
-(def privacy->min-capability
+(def ^{:stratum 0} privacy->min-capability
   "Map from event privacy level to minimum listener capability required.
    :public events -> any listener (:observe)
    :internal events -> :advise or higher
    :confidential events -> :control only"
   {:public       :observe
-   :internal     :observe
+   :internal     :advise
    :confidential :control})
 
-(defn event-requires-capability
+(defn ^{:stratum 0} matches-workflow?
+  "Check if event matches the workflow ID filter (nil/empty = match all)."
+  [wf-ids event]
+  (or (empty? wf-ids)
+      (contains? (set wf-ids) (:workflow/id event))))
+
+(defn ^{:stratum 0} matches-event-type?
+  "Check if event matches the event type filter (nil/empty = match all)."
+  [event-types event]
+  (or (empty? event-types)
+      (contains? (set event-types) (:event/type event))))
+
+(defn ^{:stratum 0} deregister-listener!
+  "Deregister a listener and remove its subscription.
+
+   Arguments:
+   - stream: Event stream atom
+   - listener-id: UUID returned from register-listener!
+   - reason: Optional reason string"
+  [stream listener-id & [reason]]
+  (let [listener (get-in @stream [:listeners listener-id])]
+    (when listener
+      ;; Unsubscribe from event stream
+      (core/unsubscribe! stream listener-id)
+      ;; Remove listener metadata
+      (swap! stream update :listeners dissoc listener-id)
+      ;; Emit listener/detached event
+      (core/publish! stream
+                     (core/listener-detached stream nil listener-id reason))
+      true)))
+
+(defn ^{:stratum 0} get-listener
+  "Get listener metadata by ID."
+  [stream listener-id]
+  (get-in @stream [:listeners listener-id]))
+
+(defn ^{:stratum 0} list-listeners
+  "List all registered listeners."
+  [stream]
+  (vals (get @stream :listeners {})))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} capability-sufficient?
+  "Check if actual capability meets or exceeds required capability."
+  [actual required]
+  (>= (get capability-rank actual 0)
+      (get capability-rank required 0)))
+
+(defn ^{:stratum 1} event-requires-capability
   "Return the minimum capability level required to receive an event.
 
    Uses schema-defined privacy levels with fallback overrides for
@@ -68,22 +110,10 @@
   (let [privacy (schema/event-privacy event-type)]
     (get privacy->min-capability privacy :observe)))
 
-(defn matches-workflow?
-  "Check if event matches the workflow ID filter (nil/empty = match all)."
-  [wf-ids event]
-  (or (empty? wf-ids)
-      (contains? (set wf-ids) (:workflow/id event))))
+;------------------------------------------------------------------------------ Layer 2
 
-(defn matches-event-type?
-  "Check if event matches the event type filter (nil/empty = match all)."
-  [event-types event]
-  (or (empty? event-types)
-      (contains? (set event-types) (:event/type event))))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; Listener registration
-
-(defn register-listener!
+(defn ^{:stratum 2} register-listener!
   "Register a listener with capability level.
 
    Arguments:
@@ -136,39 +166,8 @@
                      (core/listener-attached stream nil listener-id type capability))
       listener-id)))
 
-(defn deregister-listener!
-  "Deregister a listener and remove its subscription.
-
-   Arguments:
-   - stream: Event stream atom
-   - listener-id: UUID returned from register-listener!
-   - reason: Optional reason string"
-  [stream listener-id & [reason]]
-  (let [listener (get-in @stream [:listeners listener-id])]
-    (when listener
-      ;; Unsubscribe from event stream
-      (core/unsubscribe! stream listener-id)
-      ;; Remove listener metadata
-      (swap! stream update :listeners dissoc listener-id)
-      ;; Emit listener/detached event
-      (core/publish! stream
-                     (core/listener-detached stream nil listener-id reason))
-      true)))
-
-(defn get-listener
-  "Get listener metadata by ID."
-  [stream listener-id]
-  (get-in @stream [:listeners listener-id]))
-
-(defn list-listeners
-  "List all registered listeners."
-  [stream]
-  (vals (get @stream :listeners {})))
-
-;------------------------------------------------------------------------------ Layer 2
 ;; Advisory annotations
-
-(defn submit-annotation!
+(defn ^{:stratum 2} submit-annotation!
   "Submit an advisory annotation (requires :advise or :control capability).
 
    Arguments:
@@ -201,10 +200,8 @@
       (core/publish! stream event)
       event)))
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Control action submission (capability-gated)
-
-(defn submit-control-action!
+(defn ^{:stratum 2} submit-control-action!
   "Submit a control action via a listener (requires :control capability).
 
    Arguments:

--- a/components/event-stream/test/ai/miniforge/event_stream/listeners_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/listeners_test.clj
@@ -75,7 +75,6 @@
       (es/publish! stream (es/agent-started stream wf-id :implementer))
       (is (some #(= :agent/started (:event/type %)) @received)))))
 
-
 (deftest ^{:stratum 0} register-and-deregister-listener-test
   (testing "register-listener! returns a UUID and listener appears in list"
     (let [stream (es/create-event-stream {:sinks []})
@@ -110,7 +109,9 @@
         (is (= 0 (count (es/list-listeners stream))))
         ;; Should no longer receive events
         (es/publish! stream (es/workflow-started stream (random-uuid)))
-        ;; Only the attach/detach events + the one workflow event from before
+        ;; No new events after deregistration -- unsubscribe happens before
+        ;; :listener/detached publishes, and :listener/attached is :internal
+        ;; privacy so this :observe listener never saw it either.
         (is (= pre-count (count @received)))))))
 
 (deftest ^{:stratum 0} listener-filtering-test

--- a/components/event-stream/test/ai/miniforge/event_stream/listeners_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/listeners_test.clj
@@ -15,14 +15,15 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.event-stream.listeners-test
   (:require
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.event-stream.listeners :as listeners]))
 
-(deftest capability-sufficient-test
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} capability-sufficient-test
   (testing "observe meets observe requirement"
     (is (true? (listeners/capability-sufficient? :observe :observe))))
   (testing "advise meets observe requirement"
@@ -36,7 +37,47 @@
   (testing "observe does not meet control requirement"
     (is (false? (listeners/capability-sufficient? :observe :control)))))
 
-(deftest register-and-deregister-listener-test
+(deftest ^{:stratum 0} event-requires-capability-test
+  (testing ":public events require only :observe"
+    (is (= :observe (listeners/event-requires-capability :workflow/started))))
+  (testing ":internal events require :advise"
+    (is (= :advise (listeners/event-requires-capability :agent/started)))
+    (is (= :advise (listeners/event-requires-capability :llm/request)))
+    (is (= :advise (listeners/event-requires-capability :llm/response)))
+    (is (= :advise (listeners/event-requires-capability :tool/invoked))))
+  (testing ":confidential events require :control"
+    (is (= :control (listeners/event-requires-capability :control-action/requested)))))
+
+(deftest ^{:stratum 0} internal-privacy-delivery-test
+  (testing "observe-only listener does not receive :internal-privacy events"
+    (let [stream (es/create-event-stream {:sinks []})
+          received (atom [])
+          wf-id (random-uuid)
+          _lid (es/register-listener!
+                stream
+                {:listener/type :dashboard
+                 :listener/capability :observe
+                 :listener/identity {:principal "observer"}
+                 :listener/callback (fn [event] (swap! received conj event))})]
+      (es/publish! stream (es/agent-started stream wf-id :implementer))
+      (is (empty? @received))))
+
+  (testing "advise-capable listener does receive :internal-privacy events"
+    (let [stream (es/create-event-stream {:sinks []})
+          received (atom [])
+          wf-id (random-uuid)
+          _lid (es/register-listener!
+                stream
+                {:listener/type :enterprise
+                 :listener/capability :advise
+                 :listener/identity {:principal "advisor"}
+                 :listener/callback (fn [event] (swap! received conj event))})]
+      (es/publish! stream (es/agent-started stream wf-id :implementer))
+      ;; @received also carries this listener's own :listener/attached event
+      ;; (itself :internal-privacy, delivered because :advise qualifies).
+      (is (some #(= :agent/started (:event/type %)) @received)))))
+
+(deftest ^{:stratum 0} register-and-deregister-listener-test
   (testing "register-listener! returns a UUID and listener appears in list"
     (let [stream (es/create-event-stream {:sinks []})
           received (atom [])
@@ -73,7 +114,7 @@
         ;; Only the attach/detach events + the one workflow event from before
         (is (= pre-count (count @received)))))))
 
-(deftest listener-filtering-test
+(deftest ^{:stratum 0} listener-filtering-test
   (testing "listener with event-type filter only receives matching events"
     (let [stream (es/create-event-stream {:sinks []})
           received (atom [])
@@ -94,7 +135,7 @@
       (is (= 2 (count @received)))
       (is (every? #(#{:gate/passed :gate/failed} (:event/type %)) @received)))))
 
-(deftest invalid-capability-test
+(deftest ^{:stratum 0} invalid-capability-test
   (testing "registering with invalid capability throws"
     (let [stream (es/create-event-stream {:sinks []})]
       (is (thrown? Exception
@@ -105,7 +146,7 @@
                      :listener/identity {:principal "bad"}
                      :listener/callback (fn [_] nil)}))))))
 
-(deftest submit-annotation-test
+(deftest ^{:stratum 0} submit-annotation-test
   (testing "advise-capable listener can submit annotation"
     (let [stream (es/create-event-stream {:sinks []})
           listener-id (es/register-listener!


### PR DESCRIPTION
## Summary

- `privacy->min-capability` in `components/event-stream/src/ai/miniforge/event_stream/listeners.clj` mapped `:internal` events to `:observe` — the same floor as `:public` — despite the map's own docstring documenting `:advise` since the code's original introduction (#175). Never in sync from day one; not a regression.
- `:internal` is the default/catch-all privacy tier and covers `llm/request`, `llm/response`, `tool/invoked`, `tool/completed`, and all `agent/*` events — real prompt and tool-result content, not just lifecycle metadata.
- Reachable today via `web-dashboard`'s `POST /api/listeners`, which lets any authenticated operator self-declare `:listener/capability` (default `"observe"`) with no RBAC cross-check against session role. Anonymous/session-less callers are correctly blocked, but any logged-in operator could pull `:internal`-privacy payloads at the lowest capability tier.
- Neither `work/n08-oci-governance.spec.edn` nor `work/n08-privacy-retention.spec.edn` defines this `:public`/`:internal`/`:confidential` scheme — it predates both and is unrelated to their `:metadata-only`/`:redacted`/`:full` vocabulary. This is a pure least-privilege correction with no spec dependency.
- No test covered `privacy->min-capability` or `event-requires-capability` in either direction previously, and no existing test or the sole production caller depends on `:observe`-tier listeners seeing `:internal` events — verified via a full `poly test` run before and after.

## Test plan

- [x] `event-requires-capability-test`: asserts the mapping for representative events across all three privacy tiers (`:public` → `:observe`, `:internal` → `:advise`, `:confidential` → `:control`)
- [x] `internal-privacy-delivery-test`: end-to-end proof that an `:observe`-capability listener no longer receives `:internal`-privacy events (`agent/started`) while an `:advise`-capability listener does
- [x] Full `poly test` run (78 affected bricks, including `web-dashboard`): all green except one pre-existing, unrelated failure (`merge-parent-branches-integration-test` in `workflow`, a git-state idempotency test untouched by this change)
- [x] `clj-kondo`: 0 errors, 0 warnings

## Follow-up (not in this PR)

`handle-api-listener-register` (web-dashboard) lets any authenticated operator self-declare arbitrary capability (including `:control`) with zero cross-check against their session role — no per-endpoint RBAC exists yet. Spec (`N8-observability-control-interface.md` §2.3) requires RBAC integration for CONTROL; tied to the already-tracked #1460 (no authenticated identity threaded through). Separate decision, separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)