### PR TITLE
fix(loop): applicable-gates reads :gate/applies-to, fixes satisfies? crash

### DIFF
--- a/components/loop/src/ai/miniforge/loop/gates.clj
+++ b/components/loop/src/ai/miniforge/loop/gates.clj
@@ -117,14 +117,16 @@
 
 (defn ^{:stratum 0} applicable-gates
   "Filter gates to only those applicable to the given artifact type.
-   If a gate has no :applies-to config, it applies to all artifacts."
+   If a gate has no :gate/applies-to config, it applies to all artifacts.
+   :gate/applies-to matches the GateConfig malli schema
+   (ai.miniforge.loop.schema/GateConfig)."
   [gates artifact]
   (let [artifact-type (:artifact/type artifact)]
     (filter
      (fn [gate]
-       (let [config (when (satisfies? clojure.lang.ILookup gate)
+       (let [config (when (instance? clojure.lang.ILookup gate)
                       (:config gate))
-             applies-to (when config (:applies-to config))]
+             applies-to (when config (:gate/applies-to config))]
          (or (nil? applies-to)
              (contains? applies-to artifact-type))))
      gates)))

--- a/components/loop/test/ai/miniforge/loop/gates_test.clj
+++ b/components/loop/test/ai/miniforge/loop/gates_test.clj
@@ -86,6 +86,31 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
+;; applicable-gates tests
+(deftest ^{:stratum 1} applicable-gates-test
+  (testing "gate with no :gate/applies-to config applies to all artifact types"
+    (let [gate (gates/policy-gate :security {:policies [:no-secrets]})]
+      (is (= [gate] (gates/applicable-gates [gate] valid-code-artifact)))
+      (is (= [gate] (gates/applicable-gates [gate] non-code-artifact)))))
+
+  (testing "gate with :gate/applies-to is filtered to matching artifact types"
+    (let [code-only-gate (gates/policy-gate :security
+                                            {:policies [:no-secrets]
+                                             :gate/applies-to #{:code}})]
+      (is (= [code-only-gate] (gates/applicable-gates [code-only-gate] valid-code-artifact)))
+      (is (empty? (gates/applicable-gates [code-only-gate] non-code-artifact)))))
+
+  (testing "mixed gates: only applicable ones are kept per artifact type"
+    (let [unrestricted (gates/syntax-gate)
+          code-only (gates/policy-gate :security
+                                       {:policies [:no-secrets]
+                                        :gate/applies-to #{:code}})
+          spec-only (gates/lint-gate :spec-lint {:gate/applies-to #{:spec}})]
+      (is (= [unrestricted code-only]
+             (gates/applicable-gates [unrestricted code-only spec-only] valid-code-artifact)))
+      (is (= [unrestricted spec-only]
+             (gates/applicable-gates [unrestricted code-only spec-only] non-code-artifact))))))
+
 ;; Gate protocol tests
 (deftest ^{:stratum 1} syntax-gate-test
   (let [gate (gates/syntax-gate)]


### PR DESCRIPTION
## Summary
- `applicable-gates` in `components/loop/src/ai/miniforge/loop/gates.clj` read unnamespaced `:applies-to`, while the public `GateConfig` malli schema (`schema.clj`) and `interface.clj`'s docstring document `:gate/applies-to` — a caller following the public schema would have it silently ignored. Flagged by Copilot on #1529.
- While adding test coverage, found the function was actually unreachable in practice: `(satisfies? clojure.lang.ILookup gate)` always threw `NullPointerException`, since `ILookup` is a raw Java interface, not a Clojure protocol, and `satisfies?` only works on the latter. Switched to `instance?`.
- Confirmed via `git log -S` that both the function and the schema field were introduced in the same original commit (7375a446c) — a same-commit naming slip, not deliberate unwired scaffolding. `applicable-gates` has zero callers anywhere in the repo, so left wiring it into `run-gates`/`interface.clj` out of scope; no spec doc indicates that was ever the intent.

## Test plan
- [x] Added `applicable-gates-test` (`gates_test.clj`): no-`:gate/applies-to`-means-applies-to-all, filtered-to-matching-type, and mixed gate sets.
- [x] `clojure -M:poly test :loop` — full loop component + dependents, 0 failures, 0 errors.
- [x] Pre-commit smoke suite (331 tests, 1241 assertions) passed.
- [x] Committed with `MINIFORGE_STRATUM_BUDGET_MODE=warn`: `gates.clj` carries a pre-existing SL003 finding (4 stratum layers vs. 3-layer budget) predating this change, unrelated to the fix — same precedent as other Wave 1 stratum-lint PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)