### PR TITLE
fix: guard traverse-levels against DAG cycles and dangling deps

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/dag_plan.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_plan.clj
@@ -26,6 +26,7 @@
    converting a plan's tasks into validated DAG tasks (dependency
    normalization, phantom-dep dropping, stratum auto-wiring)."
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.logging.interface :as log]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -73,27 +74,6 @@
      :metrics {}}))
 
 ;--- Layer 0: Level Traversal
-(defn ^{:stratum 0} build-deps-map [tasks]
-  (->> tasks
-       (map (fn [t] [(:task/id t) (set (:task/dependencies t []))]))
-       (into {})))
-
-(defn ^{:stratum 0} traverse-levels [task-ids deps-map]
-  (loop [remaining (set task-ids)
-         completed #{}
-         level-count 0
-         max-width 0]
-    (if (empty? remaining)
-      {:levels level-count :max-width max-width}
-      (let [ready (->> remaining
-                       (filter #(every? completed (get deps-map % #{}))))
-            width (count ready)]
-        (recur (apply disj remaining ready)
-               (into completed ready)
-               (inc level-count)
-               (max max-width width))))))
-
-;--- Layer 0: Plan to DAG Conversion
 (defn ^{:stratum 0} normalize-task-id
   "Preserve task IDs in their domain-native form.
    UUID strings are parsed to UUIDs so mixed string/UUID inputs still align."
@@ -104,6 +84,47 @@
     (keyword? x) x
     :else x))
 
+(defn ^{:stratum 0} build-deps-map [tasks]
+  (->> tasks
+       (map (fn [t] [(:task/id t) (set (:task/dependencies t []))]))
+       (into {})))
+
+(defn ^{:stratum 0} traverse-levels
+  "BFS the dependency graph in ready-batches (\"levels\"), tracking the
+   widest batch for parallelism estimation.
+
+   A task id whose dependency never becomes `completed` — because it
+   participates in a cycle, or because it names an id absent from
+   `task-ids` entirely — would leave `ready` empty forever and spin the
+   loop with no progress. Detect that stall directly (empty `ready`
+   while `remaining` is non-empty) and return an anomaly instead,
+   following the `:anomalies/dag-non-forest` convention in
+   `ai.miniforge.dag-executor.branch-registry` for plan-shape defects
+   the runtime can't reconcile."
+  [task-ids deps-map]
+  (loop [remaining (set task-ids)
+         completed #{}
+         level-count 0
+         max-width 0]
+    (if (empty? remaining)
+      {:levels level-count :max-width max-width}
+      (let [ready (->> remaining
+                       (filter #(every? completed (get deps-map % #{}))))
+            width (count ready)]
+        (if (zero? width)
+          (anomaly/sub-anomaly
+           :conflict :anomalies/dag-unschedulable
+           "Plan has unschedulable tasks: a dependency cycle, or a task dependency id absent from the plan's own task ids"
+           ;; sort-by str so heterogeneous task-id types (UUID/keyword/
+           ;; string) still produce a total order — `sort` would throw
+           ;; on a mixed set.
+           {:unresolved-task-ids (vec (sort-by str remaining))})
+          (recur (apply disj remaining ready)
+                 (into completed ready)
+                 (inc level-count)
+                 (max max-width width)))))))
+
+;--- Layer 0: Plan to DAG Conversion
 (defn ^{:stratum 0} validate-deps
   "Filter deps to only those referencing actual task IDs. Warns on phantoms."
   [task-id raw-deps valid-task-ids logger]
@@ -157,23 +178,6 @@
    :error error
    :metrics (or metrics zero-metrics)})
 
-(defn ^{:stratum 1} compute-max-level-width [tasks]
-  (-> tasks
-      ((juxt #(map :task/id %) build-deps-map))
-      ((fn [[ids deps]] (traverse-levels ids deps)))
-      :max-width))
-
-(defn ^{:stratum 1} estimate-parallel-speedup [plan]
-  (let [tasks (:plan/tasks plan [])
-        task-count (count tasks)
-        deps-map (build-deps-map tasks)
-        {:keys [levels max-width]} (traverse-levels (map :task/id tasks) deps-map)]
-    {:parallelizable? (> max-width 1)
-     :task-count task-count
-     :max-parallel max-width
-     :levels levels
-     :estimated-speedup (if (pos? levels) (float (/ task-count levels)) 1.0)}))
-
 (defn ^{:stratum 1} plan-task->dag-task
   "Convert a single plan task to a DAG task with validated deps."
   [t valid-task-ids plan-id workflow-id context]
@@ -193,13 +197,52 @@
       (:task/exclusive-files t) (assoc :task/exclusive-files (:task/exclusive-files t))
       (:task/stratum t)         (assoc :task/stratum (:task/stratum t)))))
 
-;------------------------------------------------------------------------------ Layer 2
+(defn ^{:stratum 1} compute-max-level-width
+  "Widest ready-batch across the plan's dependency graph, or the
+   `:anomalies/dag-unschedulable` anomaly from `traverse-levels` when the
+   graph can't be fully traversed.
 
-;--- Layer 2: Plan Analysis
-(defn ^{:stratum 2} parallelizable-plan? [plan]
-  (let [tasks (:plan/tasks plan [])]
-    (when (> (count tasks) 1)
-      (> (compute-max-level-width tasks) 1))))
+   Normalizes :task/id / :task/dependencies before building the deps map
+   the same way `plan->dag-tasks` does — a plan whose tasks mix
+   string/UUID id representations must resolve identically here as it
+   will once `plan->dag-tasks` normalizes it, or `traverse-levels` sees a
+   dependency id that never matches a `completed` entry and misreports a
+   perfectly schedulable plan as unschedulable."
+  [tasks]
+  (let [norm-task (fn [t] (-> t
+                              (update :task/id normalize-task-id)
+                              (update :task/dependencies (fn [d] (map normalize-task-id (or d []))))))
+        norm-tasks (map norm-task tasks)
+        result (-> norm-tasks
+                   ((juxt #(map :task/id %) build-deps-map))
+                   ((fn [[ids deps]] (traverse-levels ids deps))))]
+    (if (anomaly/anomaly? result)
+      result
+      (:max-width result))))
+
+(defn ^{:stratum 1} estimate-parallel-speedup [plan]
+  (let [norm-task (fn [t] (-> t
+                              (update :task/id normalize-task-id)
+                              (update :task/dependencies (fn [d] (map normalize-task-id (or d []))))))
+        tasks (map norm-task (:plan/tasks plan []))
+        task-count (count tasks)
+        deps-map (build-deps-map tasks)
+        result (traverse-levels (map :task/id tasks) deps-map)]
+    (if (anomaly/anomaly? result)
+      {:parallelizable? false
+       :task-count task-count
+       :max-parallel 0
+       :levels 0
+       :estimated-speedup 1.0
+       :anomaly result}
+      (let [{:keys [levels max-width]} result]
+        {:parallelizable? (> max-width 1)
+         :task-count task-count
+         :max-parallel max-width
+         :levels levels
+         :estimated-speedup (if (pos? levels) (float (/ task-count levels)) 1.0)}))))
+
+;------------------------------------------------------------------------------ Layer 2
 
 (defn ^{:stratum 2} plan->dag-tasks [plan context]
   (let [tasks (:plan/tasks plan [])
@@ -209,3 +252,11 @@
         dag-tasks (mapv #(plan-task->dag-task % valid-task-ids (:plan/id plan) (:workflow-id context) ctx)
                         tasks)]
     (wire-stratum-deps dag-tasks)))
+
+;--- Layer 2: Plan Analysis
+(defn ^{:stratum 2} parallelizable-plan? [plan]
+  (let [tasks (:plan/tasks plan [])]
+    (when (> (count tasks) 1)
+      (let [width (compute-max-level-width tasks)]
+        (when-not (anomaly/anomaly? width)
+          (> width 1))))))

--- a/projects/miniforge/test/ai/miniforge/workflow/dag_orchestrator_test.clj
+++ b/projects/miniforge/test/ai/miniforge/workflow/dag_orchestrator_test.clj
@@ -20,7 +20,9 @@
   (:require
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.workflow.dag-orchestrator :as dag-orch]
+   [ai.miniforge.workflow.dag-plan :as dag-plan]
    [ai.miniforge.workflow.dag-task-runner :as task-runner]
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.logging.interface :as log]))
 
@@ -256,6 +258,26 @@
                {:a (dag/ok {}) :b (dag/err :f "err" {})}
                nil "wf-1")))))
 
+;; traverse-levels termination tests — a cycle or a dependency on a task
+;; id outside the plan must not spin `traverse-levels` forever (it used
+;; to: `ready` came back empty every iteration, so `remaining` never
+;; shrank). Covers the unschedulable-plan path feeding
+;; `estimate-parallel-speedup` / `parallelizable-plan?` /
+;; `maybe-parallelize-plan`.
+(deftest ^{:stratum 0} test-traverse-levels-cyclic-terminates
+  (testing "a dependency cycle among real task ids returns an anomaly instead of looping forever"
+    (let [result (dag-plan/traverse-levels [:a :b] {:a #{:b} :b #{:a}})]
+      (is (anomaly/anomaly? result))
+      (is (= :anomalies/dag-unschedulable (:anomaly/subtype result)))
+      (is (= #{:a :b} (set (:unresolved-task-ids (:anomaly/data result))))))))
+
+(deftest ^{:stratum 0} test-traverse-levels-dangling-dep-terminates
+  (testing "a dependency on a task id absent from task-ids returns an anomaly instead of looping forever"
+    (let [result (dag-plan/traverse-levels [:a] {:a #{:ghost}})]
+      (is (anomaly/anomaly? result))
+      (is (= :anomalies/dag-unschedulable (:anomaly/subtype result)))
+      (is (= #{:a} (set (:unresolved-task-ids (:anomaly/data result))))))))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (deftest ^{:stratum 1} test-parallelizable-plan-single-task
@@ -339,6 +361,43 @@
       (is (= 2 (:levels result)))
       (is (true? (:parallelizable? result)))
       (is (= 2.5 (:estimated-speedup result))))))
+
+(deftest ^{:stratum 1} test-parallelizable-plan-cyclic-terminates
+  (testing "cyclic plan is treated as not parallelizable rather than hanging"
+    (let [plan (make-plan [(make-task :a [:b])
+                           (make-task :b [:a])])]
+      (is (not (dag-orch/parallelizable-plan? plan))))))
+
+(deftest ^{:stratum 1} test-parallelizable-plan-dangling-dep-terminates
+  (testing "plan with a dependency on an unknown task id is treated as not parallelizable rather than hanging"
+    (let [plan (make-plan [(make-task :a [:ghost])
+                           (make-task :b [:ghost])])]
+      (is (not (dag-orch/parallelizable-plan? plan))))))
+
+(deftest ^{:stratum 1} test-estimate-speedup-cyclic-terminates
+  (testing "cyclic plan reports non-parallelizable and surfaces the anomaly"
+    (let [plan (make-plan [(make-task :a [:b])
+                           (make-task :b [:a])])
+          result (dag-orch/estimate-parallel-speedup plan)]
+      (is (false? (:parallelizable? result)))
+      (is (anomaly/anomaly? (:anomaly result))))))
+
+(deftest ^{:stratum 1} test-maybe-parallelize-plan-cyclic-terminates
+  (testing "maybe-parallelize-plan does not hang and skips DAG execution for a cyclic plan"
+    (let [plan (make-plan [(make-task :a [:b])
+                           (make-task :b [:a])])
+          logger (log/create-logger {:min-level :error})]
+      (is (nil? (dag-orch/maybe-parallelize-plan plan {:logger logger}))))))
+
+(deftest ^{:stratum 1} test-estimate-speedup-mixed-uuid-string-ids
+  (testing "a dependency given as a UUID string against a UUID :task/id is schedulable, not unschedulable"
+    (let [a (random-uuid)
+          plan (make-plan [(make-task a "Task A" [])
+                           (make-task (random-uuid) "Task B" [(str a)])])
+          result (dag-orch/estimate-parallel-speedup plan)]
+      (is (nil? (:anomaly result)))
+      (is (= 2 (:task-count result)))
+      (is (= 2 (:levels result))))))
 
 ;; plan->dag-tasks tests
 (deftest ^{:stratum 1} test-plan-to-dag-tasks-basic

--- a/projects/miniforge/test/ai/miniforge/workflow/dag_orchestrator_test.clj
+++ b/projects/miniforge/test/ai/miniforge/workflow/dag_orchestrator_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.workflow.dag-orchestrator-test
   "Tests for DAG orchestration of multi-task plans."
   (:require
@@ -26,9 +25,9 @@
    [ai.miniforge.logging.interface :as log]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Test fixtures
 
-(defn make-task
+;; Test fixtures
+(defn ^{:stratum 0} make-task
   "Create a task with given id, description, and dependencies."
   ([id] (make-task id (str "Task " id) []))
   ([id deps] (make-task id (str "Task " id) deps))
@@ -38,145 +37,27 @@
     :task/type :implement
     :task/dependencies deps}))
 
-(defn make-plan
+(defn ^{:stratum 0} make-plan
   "Create a plan with given tasks."
   [tasks]
   {:plan/id (random-uuid)
    :plan/name "test-plan"
    :plan/tasks tasks})
 
-;------------------------------------------------------------------------------ Layer 1
 ;; parallelizable-plan? tests
-
-(deftest test-parallelizable-plan-empty
+(deftest ^{:stratum 0} test-parallelizable-plan-empty
   (testing "empty plan is not parallelizable"
     (is (not (dag-orch/parallelizable-plan? {:plan/tasks []})))))
 
-(deftest test-parallelizable-plan-single-task
-  (testing "single task plan is not parallelizable"
-    (let [plan (make-plan [(make-task :a)])]
-      (is (not (dag-orch/parallelizable-plan? plan))))))
-
-(deftest test-parallelizable-plan-two-independent
-  (testing "two independent tasks are parallelizable"
-    (let [plan (make-plan [(make-task :a)
-                           (make-task :b)])]
-      (is (dag-orch/parallelizable-plan? plan)))))
-
-(deftest test-parallelizable-plan-sequential-chain
-  (testing "sequential chain is not parallelizable"
-    (let [plan (make-plan [(make-task :a)
-                           (make-task :b [:a])])]
-      (is (not (dag-orch/parallelizable-plan? plan))))))
-
-(deftest test-parallelizable-plan-diamond
-  (testing "diamond pattern (A→B,C→D) is parallelizable"
-    (let [plan (make-plan [(make-task :a)
-                           (make-task :b [:a])
-                           (make-task :c [:a])
-                           (make-task :d [:b :c])])]
-      (is (dag-orch/parallelizable-plan? plan)))))
-
-(deftest test-parallelizable-plan-fan-out
-  (testing "fan-out pattern (A→B,C,D) is parallelizable"
-    (let [plan (make-plan [(make-task :a)
-                           (make-task :b [:a])
-                           (make-task :c [:a])
-                           (make-task :d [:a])])]
-      (is (dag-orch/parallelizable-plan? plan)))))
-
-;------------------------------------------------------------------------------ Layer 2
 ;; estimate-parallel-speedup tests
-
-(deftest test-estimate-speedup-empty
+(deftest ^{:stratum 0} test-estimate-speedup-empty
   (testing "empty plan has no speedup"
     (let [result (dag-orch/estimate-parallel-speedup {:plan/tasks []})]
       (is (= 0 (:task-count result)))
       (is (= 0 (:max-parallel result)))
       (is (false? (:parallelizable? result))))))
 
-(deftest test-estimate-speedup-single
-  (testing "single task has no speedup"
-    (let [result (dag-orch/estimate-parallel-speedup
-                  (make-plan [(make-task :a)]))]
-      (is (= 1 (:task-count result)))
-      (is (= 1 (:max-parallel result)))
-      (is (= 1 (:levels result)))
-      (is (false? (:parallelizable? result)))
-      (is (= 1.0 (:estimated-speedup result))))))
-
-(deftest test-estimate-speedup-two-parallel
-  (testing "two parallel tasks have 2x speedup"
-    (let [result (dag-orch/estimate-parallel-speedup
-                  (make-plan [(make-task :a)
-                              (make-task :b)]))]
-      (is (= 2 (:task-count result)))
-      (is (= 2 (:max-parallel result)))
-      (is (= 1 (:levels result)))
-      (is (true? (:parallelizable? result)))
-      (is (= 2.0 (:estimated-speedup result))))))
-
-(deftest test-estimate-speedup-diamond
-  (testing "diamond pattern has correct speedup"
-    (let [result (dag-orch/estimate-parallel-speedup
-                  (make-plan [(make-task :a)
-                              (make-task :b [:a])
-                              (make-task :c [:a])
-                              (make-task :d [:b :c])]))]
-      (is (= 4 (:task-count result)))
-      (is (= 2 (:max-parallel result)))
-      (is (= 3 (:levels result)))
-      (is (true? (:parallelizable? result)))
-      ;; 4 tasks / 3 levels ≈ 1.33
-      (is (< 1.3 (:estimated-speedup result) 1.4)))))
-
-(deftest test-estimate-speedup-wide-fan
-  (testing "wide fan-out has high parallelism"
-    (let [result (dag-orch/estimate-parallel-speedup
-                  (make-plan [(make-task :root)
-                              (make-task :a [:root])
-                              (make-task :b [:root])
-                              (make-task :c [:root])
-                              (make-task :d [:root])]))]
-      (is (= 5 (:task-count result)))
-      (is (= 4 (:max-parallel result)))
-      (is (= 2 (:levels result)))
-      (is (true? (:parallelizable? result)))
-      (is (= 2.5 (:estimated-speedup result))))))
-
-;------------------------------------------------------------------------------ Layer 3
-;; plan->dag-tasks tests
-
-(deftest test-plan-to-dag-tasks-basic
-  (testing "converts plan tasks to DAG format"
-    (let [plan (make-plan [(make-task :a "Task A" [])
-                           (make-task :b "Task B" [:a])])
-          context {:workflow-id (random-uuid)}
-          result (dag-orch/plan->dag-tasks plan context)]
-      (is (= 2 (count result)))
-      (is (= :a (:task/id (first result))))
-      (is (= "Task A" (:task/description (first result))))
-      (is (= #{} (:task/deps (first result))))
-      (is (= :b (:task/id (second result))))
-      (is (= #{:a} (:task/deps (second result)))))))
-
-(deftest test-plan-to-dag-tasks-context
-  (testing "includes context in task definitions"
-    (let [plan-id (random-uuid)
-          workflow-id (random-uuid)
-          plan {:plan/id plan-id
-                :plan/tasks [(make-task :a)]}
-          context {:workflow-id workflow-id
-                   :llm-backend :mock-llm
-                   :artifact-store :mock-store}
-          result (dag-orch/plan->dag-tasks plan context)
-          task-context (:task/context (first result))]
-      (is (= plan-id (:parent-plan-id task-context)))
-      (is (= workflow-id (:parent-workflow-id task-context)))
-      (is (= :mock-llm (:llm-backend task-context)))
-      (is (= :mock-store (:artifact-store task-context))))))
-
-(deftest test-plan-to-dag-tasks-defaults
+(deftest ^{:stratum 0} test-plan-to-dag-tasks-defaults
   (testing "uses defaults for missing fields"
     (let [plan {:plan/tasks [{:task/id :minimal}]}
           result (dag-orch/plan->dag-tasks plan {})]
@@ -185,10 +66,8 @@
       (is (= #{} (:task/deps (first result))))
       (is (= [] (:task/acceptance-criteria (first result)))))))
 
-;------------------------------------------------------------------------------ Layer 4
 ;; execute-single-task tests
-
-(deftest test-execute-single-task-placeholder
+(deftest ^{:stratum 0} test-execute-single-task-placeholder
   (testing "returns placeholder result without LLM backend.
             Placeholder :metrics now uses dag-orchestrator/zero-metrics
             (`{:tokens 0 :cost-usd 0.0 :duration-ms 0}`) so the shape
@@ -209,17 +88,15 @@
                (:metrics data))
             "placeholder metrics shape matches dag-orchestrator/zero-metrics")))))
 
-(deftest test-execute-single-task-default-description
+(deftest ^{:stratum 0} test-execute-single-task-default-description
   (testing "uses default description when missing"
     (let [task-def {:task/id :no-desc}
           result (task-runner/execute-single-task task-def {})]
       (is (dag/ok? result))
       (is (= "Implement task" (:description (dag/unwrap result)))))))
 
-;------------------------------------------------------------------------------ Layer 5
 ;; create-task-executor-fn tests
-
-(deftest test-create-executor-fn-callbacks
+(deftest ^{:stratum 0} test-create-executor-fn-callbacks
   (testing "executor fn invokes callbacks"
     (let [started (atom [])
           completed (atom [])
@@ -235,17 +112,266 @@
       (is (= :task-1 (first (first @completed))))
       (is (dag/ok? result)))))
 
-(deftest test-create-executor-fn-no-callbacks
+(deftest ^{:stratum 0} test-create-executor-fn-no-callbacks
   (testing "executor fn works without callbacks"
     (let [executor (task-runner/create-task-executor-fn {} {})
           dag-context {:run-state {:run/tasks {:task-1 {:task/id :task-1}}}}
           result (executor :task-1 dag-context)]
       (is (dag/ok? result)))))
 
-;------------------------------------------------------------------------------ Layer 6
-;; execute-plan-as-dag tests
+;; Failure propagation tests
+(deftest ^{:stratum 0} test-propagate-failures
+  (testing "transitively skips tasks depending on failed tasks"
+    (let [tasks-map {:a {:task/deps #{}}
+                     :b {:task/deps #{:a}}
+                     :c {:task/deps #{:b}}
+                     :d {:task/deps #{}}}
+          ;; :a failed => :b and :c should be propagated, :d unaffected
+          all-failed (dag-orch/propagate-failures tasks-map #{:a})]
+      (is (contains? all-failed :a))
+      (is (contains? all-failed :b))
+      (is (contains? all-failed :c))
+      (is (not (contains? all-failed :d))))))
 
-(deftest test-execute-plan-as-dag-success
+(deftest ^{:stratum 0} test-compute-ready-tasks-excludes-failed
+  (testing "does not return tasks whose deps have failed"
+    (let [tasks-map {:a {:task/deps #{}}
+                     :b {:task/deps #{:a}}}
+          ;; :a failed, :b depends on :a => :b should not be ready
+          ready (dag-orch/compute-ready-tasks tasks-map #{} #{:a})]
+      (is (empty? ready) ":b should not be ready since :a failed"))))
+
+(deftest ^{:stratum 0} test-compute-ready-tasks-returns-roots
+  (testing "returns tasks with no deps when nothing is completed"
+    (let [tasks-map {:a {:task/deps #{}}
+                     :b {:task/deps #{}}
+                     :c {:task/deps #{:a :b}}}
+          ready (dag-orch/compute-ready-tasks tasks-map #{} #{})]
+      (is (= #{:a :b} (set (map first ready)))))))
+
+(deftest ^{:stratum 0} test-compute-ready-tasks-unlocks-dependents
+  (testing "completing deps unlocks dependent tasks"
+    (let [tasks-map {:a {:task/deps #{}}
+                     :b {:task/deps #{:a}}
+                     :c {:task/deps #{:a :b}}}
+          ;; :a completed, :b should be ready, :c still blocked on :b
+          ready (dag-orch/compute-ready-tasks tasks-map #{:a} #{})]
+      (is (= [:b] (map first ready))))))
+
+;; partition-results tests
+(deftest ^{:stratum 0} test-partition-results-mixed
+  (testing "separates ok and err results"
+    (let [results {:a (dag/ok {:done true})
+                   :b (dag/err :failed "boom" {})
+                   :c (dag/ok {:done true})}
+          {:keys [completed failed]} (dag-orch/partition-results results)]
+      (is (= #{:a :c} (set completed)))
+      (is (= #{:b} (set failed))))))
+
+(deftest ^{:stratum 0} test-partition-results-all-ok
+  (testing "all ok yields no failures"
+    (let [results {:a (dag/ok {}) :b (dag/ok {})}
+          {:keys [completed failed]} (dag-orch/partition-results results)]
+      (is (= 2 (count completed)))
+      (is (empty? failed)))))
+
+(deftest ^{:stratum 0} test-partition-results-all-failed
+  (testing "all failed yields no completions"
+    (let [results {:a (dag/err :f "e1" {}) :b (dag/err :f "e2" {})}
+          {:keys [completed failed]} (dag-orch/partition-results results)]
+      (is (empty? completed))
+      (is (= 2 (count failed))))))
+
+(deftest ^{:stratum 0} test-partition-results-empty
+  (testing "empty results yield empty partitions"
+    (let [{:keys [completed failed]} (dag-orch/partition-results {})]
+      (is (empty? completed))
+      (is (empty? failed)))))
+
+;; aggregate-results tests
+(deftest ^{:stratum 0} test-aggregate-results-accumulates-metrics
+  (testing "sums tokens, cost, and duration across results"
+    (let [results {:a (dag/ok {:artifacts [{:id 1}]
+                               :metrics {:tokens 100 :cost-usd 0.5 :duration-ms 1000}})
+                   :b (dag/ok {:artifacts [{:id 2} {:id 3}]
+                               :metrics {:tokens 200 :cost-usd 1.0 :duration-ms 2000}})}
+          agg (dag-orch/aggregate-results results)]
+      (is (= 3 (count (:artifacts agg))))
+      (is (= 300 (:total-tokens agg)))
+      (is (= 1.5 (:total-cost agg)))
+      (is (= 3000 (:total-duration agg))))))
+
+(deftest ^{:stratum 0} test-aggregate-results-defaults-missing-metrics
+  (testing "defaults to zero when metrics are absent"
+    (let [results {:a (dag/ok {:artifacts []})
+                   :b (dag/ok {})}
+          agg (dag-orch/aggregate-results results)]
+      (is (= 0 (:total-tokens agg)))
+      (is (= 0.0 (:total-cost agg)))
+      (is (= 0 (:total-duration agg))))))
+
+(deftest ^{:stratum 0} test-aggregate-results-empty
+  (testing "empty results yield zero aggregates"
+    (let [agg (dag-orch/aggregate-results {})]
+      (is (= 0 (:total-tokens agg)))
+      (is (empty? (:artifacts agg))))))
+
+;; Additional propagate-failures scenarios
+(deftest ^{:stratum 0} test-propagate-failures-diamond
+  (testing "diamond: failure at root cascades to all dependents"
+    (let [tasks-map {:a {:task/deps #{}}
+                     :b {:task/deps #{:a}}
+                     :c {:task/deps #{:a}}
+                     :d {:task/deps #{:b :c}}}
+          all-failed (dag-orch/propagate-failures tasks-map #{:a})]
+      (is (= #{:a :b :c :d} all-failed)))))
+
+(deftest ^{:stratum 0} test-propagate-failures-no-deps
+  (testing "independent tasks: failure in one doesn't affect others"
+    (let [tasks-map {:a {:task/deps #{}}
+                     :b {:task/deps #{}}
+                     :c {:task/deps #{}}}
+          all-failed (dag-orch/propagate-failures tasks-map #{:a})]
+      (is (= #{:a} all-failed)))))
+
+(deftest ^{:stratum 0} test-propagate-failures-empty
+  (testing "no failures yields empty set"
+    (let [tasks-map {:a {:task/deps #{}} :b {:task/deps #{:a}}}
+          all-failed (dag-orch/propagate-failures tasks-map #{})]
+      (is (empty? all-failed)))))
+
+(deftest ^{:stratum 0} test-propagate-failures-partial-deps
+  (testing "task with one failed dep and one ok dep still fails"
+    (let [tasks-map {:a {:task/deps #{}}
+                     :b {:task/deps #{}}
+                     :c {:task/deps #{:a :b}}}
+          ;; :a failed but :b did not — :c still transitively fails
+          all-failed (dag-orch/propagate-failures tasks-map #{:a})]
+      (is (contains? all-failed :c) ":c depends on :a which failed"))))
+
+;; emit-batch-events! tests
+(deftest ^{:stratum 0} test-emit-batch-events-nil-stream
+  (testing "does not throw with nil event stream"
+    (is (nil? (dag-orch/emit-batch-events!
+               {:a (dag/ok {}) :b (dag/err :f "err" {})}
+               nil "wf-1")))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} test-parallelizable-plan-single-task
+  (testing "single task plan is not parallelizable"
+    (let [plan (make-plan [(make-task :a)])]
+      (is (not (dag-orch/parallelizable-plan? plan))))))
+
+(deftest ^{:stratum 1} test-parallelizable-plan-two-independent
+  (testing "two independent tasks are parallelizable"
+    (let [plan (make-plan [(make-task :a)
+                           (make-task :b)])]
+      (is (dag-orch/parallelizable-plan? plan)))))
+
+(deftest ^{:stratum 1} test-parallelizable-plan-sequential-chain
+  (testing "sequential chain is not parallelizable"
+    (let [plan (make-plan [(make-task :a)
+                           (make-task :b [:a])])]
+      (is (not (dag-orch/parallelizable-plan? plan))))))
+
+(deftest ^{:stratum 1} test-parallelizable-plan-diamond
+  (testing "diamond pattern (A→B,C→D) is parallelizable"
+    (let [plan (make-plan [(make-task :a)
+                           (make-task :b [:a])
+                           (make-task :c [:a])
+                           (make-task :d [:b :c])])]
+      (is (dag-orch/parallelizable-plan? plan)))))
+
+(deftest ^{:stratum 1} test-parallelizable-plan-fan-out
+  (testing "fan-out pattern (A→B,C,D) is parallelizable"
+    (let [plan (make-plan [(make-task :a)
+                           (make-task :b [:a])
+                           (make-task :c [:a])
+                           (make-task :d [:a])])]
+      (is (dag-orch/parallelizable-plan? plan)))))
+
+(deftest ^{:stratum 1} test-estimate-speedup-single
+  (testing "single task has no speedup"
+    (let [result (dag-orch/estimate-parallel-speedup
+                  (make-plan [(make-task :a)]))]
+      (is (= 1 (:task-count result)))
+      (is (= 1 (:max-parallel result)))
+      (is (= 1 (:levels result)))
+      (is (false? (:parallelizable? result)))
+      (is (= 1.0 (:estimated-speedup result))))))
+
+(deftest ^{:stratum 1} test-estimate-speedup-two-parallel
+  (testing "two parallel tasks have 2x speedup"
+    (let [result (dag-orch/estimate-parallel-speedup
+                  (make-plan [(make-task :a)
+                              (make-task :b)]))]
+      (is (= 2 (:task-count result)))
+      (is (= 2 (:max-parallel result)))
+      (is (= 1 (:levels result)))
+      (is (true? (:parallelizable? result)))
+      (is (= 2.0 (:estimated-speedup result))))))
+
+(deftest ^{:stratum 1} test-estimate-speedup-diamond
+  (testing "diamond pattern has correct speedup"
+    (let [result (dag-orch/estimate-parallel-speedup
+                  (make-plan [(make-task :a)
+                              (make-task :b [:a])
+                              (make-task :c [:a])
+                              (make-task :d [:b :c])]))]
+      (is (= 4 (:task-count result)))
+      (is (= 2 (:max-parallel result)))
+      (is (= 3 (:levels result)))
+      (is (true? (:parallelizable? result)))
+      ;; 4 tasks / 3 levels ≈ 1.33
+      (is (< 1.3 (:estimated-speedup result) 1.4)))))
+
+(deftest ^{:stratum 1} test-estimate-speedup-wide-fan
+  (testing "wide fan-out has high parallelism"
+    (let [result (dag-orch/estimate-parallel-speedup
+                  (make-plan [(make-task :root)
+                              (make-task :a [:root])
+                              (make-task :b [:root])
+                              (make-task :c [:root])
+                              (make-task :d [:root])]))]
+      (is (= 5 (:task-count result)))
+      (is (= 4 (:max-parallel result)))
+      (is (= 2 (:levels result)))
+      (is (true? (:parallelizable? result)))
+      (is (= 2.5 (:estimated-speedup result))))))
+
+;; plan->dag-tasks tests
+(deftest ^{:stratum 1} test-plan-to-dag-tasks-basic
+  (testing "converts plan tasks to DAG format"
+    (let [plan (make-plan [(make-task :a "Task A" [])
+                           (make-task :b "Task B" [:a])])
+          context {:workflow-id (random-uuid)}
+          result (dag-orch/plan->dag-tasks plan context)]
+      (is (= 2 (count result)))
+      (is (= :a (:task/id (first result))))
+      (is (= "Task A" (:task/description (first result))))
+      (is (= #{} (:task/deps (first result))))
+      (is (= :b (:task/id (second result))))
+      (is (= #{:a} (:task/deps (second result)))))))
+
+(deftest ^{:stratum 1} test-plan-to-dag-tasks-context
+  (testing "includes context in task definitions"
+    (let [plan-id (random-uuid)
+          workflow-id (random-uuid)
+          plan {:plan/id plan-id
+                :plan/tasks [(make-task :a)]}
+          context {:workflow-id workflow-id
+                   :llm-backend :mock-llm
+                   :artifact-store :mock-store}
+          result (dag-orch/plan->dag-tasks plan context)
+          task-context (:task/context (first result))]
+      (is (= plan-id (:parent-plan-id task-context)))
+      (is (= workflow-id (:parent-workflow-id task-context)))
+      (is (= :mock-llm (:llm-backend task-context)))
+      (is (= :mock-store (:artifact-store task-context))))))
+
+;; execute-plan-as-dag tests
+(deftest ^{:stratum 1} test-execute-plan-as-dag-success
   (testing "executes parallel plan successfully"
     (let [[logger _] (log/collecting-logger)
           plan (make-plan [(make-task :a)
@@ -256,7 +382,7 @@
       (is (= 2 (:tasks-completed result)))
       (is (= 0 (:tasks-failed result))))))
 
-(deftest test-execute-plan-as-dag-with-deps
+(deftest ^{:stratum 1} test-execute-plan-as-dag-with-deps
   (testing "executes plan with dependencies"
     ;; Forest layout (single-parent): a, b are independent roots;
     ;; c depends only on a. Earlier draft had c depending on both
@@ -270,7 +396,7 @@
       (is (:success? result))
       (is (= 3 (:tasks-completed result))))))
 
-(deftest test-execute-plan-as-dag-callbacks
+(deftest ^{:stratum 1} test-execute-plan-as-dag-callbacks
   (testing "invokes task callbacks"
     (let [started (atom [])
           completed (atom [])
@@ -284,16 +410,14 @@
       (is (= 2 (count @completed)))
       (is (= (set @started) (set @completed))))))
 
-;------------------------------------------------------------------------------ Layer 7
 ;; maybe-parallelize-plan tests
-
-(deftest test-maybe-parallelize-sequential
+(deftest ^{:stratum 1} test-maybe-parallelize-sequential
   (testing "returns nil for sequential plan"
     (let [plan (make-plan [(make-task :a)
                            (make-task :b [:a])])]
       (is (nil? (dag-orch/maybe-parallelize-plan plan {}))))))
 
-(deftest test-maybe-parallelize-parallel
+(deftest ^{:stratum 1} test-maybe-parallelize-parallel
   (testing "executes parallelizable plan"
     (let [plan (make-plan [(make-task :a)
                            (make-task :b)])
@@ -302,7 +426,7 @@
       (is (:success? result))
       (is (= 2 (:tasks-completed result))))))
 
-(deftest test-maybe-parallelize-logs
+(deftest ^{:stratum 1} test-maybe-parallelize-logs
   (testing "logs parallelization decision"
     (let [[logger entries] (log/collecting-logger)
           plan (make-plan [(make-task :a)
@@ -311,10 +435,8 @@
           _ (dag-orch/maybe-parallelize-plan plan {:logger logger})]
       (is (some #(= :plan/parallelizing (:log/event %)) @entries)))))
 
-;------------------------------------------------------------------------------ Layer 8
 ;; Resume from pre-completed-ids tests
-
-(deftest test-execute-plan-with-pre-completed-ids
+(deftest ^{:stratum 1} test-execute-plan-with-pre-completed-ids
   (testing "skips pre-completed tasks and only executes remaining"
     (let [started (atom [])
           ;; Forest layout (single-parent): a, b roots; c→a only.
@@ -334,7 +456,7 @@
       ;; :b and :c should run (total completed = 3 including pre-completed)
       (is (= 3 (:tasks-completed result))))))
 
-(deftest test-execute-plan-with-all-pre-completed
+(deftest ^{:stratum 1} test-execute-plan-with-all-pre-completed
   (testing "returns immediately when all tasks are pre-completed"
     (let [started (atom [])
           plan (make-plan [(make-task :a) (make-task :b)])
@@ -345,7 +467,7 @@
       (is (= 2 (:tasks-completed result)))
       (is (empty? @started) "no tasks should have been executed"))))
 
-(deftest test-execute-plan-pre-completed-logs-resume
+(deftest ^{:stratum 1} test-execute-plan-pre-completed-logs-resume
   (testing "logs resume info when pre-completed-ids is non-empty"
     (let [[logger entries] (log/collecting-logger)
           plan (make-plan [(make-task :a) (make-task :b)])
@@ -353,7 +475,7 @@
           _ (dag-orch/execute-plan-as-dag plan context)]
       (is (some #(= :dag/resuming (:log/event %)) @entries)))))
 
-(deftest test-resume-preserves-artifacts-from-new-tasks
+(deftest ^{:stratum 1} test-resume-preserves-artifacts-from-new-tasks
   (testing "resumed execution includes artifacts from newly executed tasks"
     ;; Forest layout (single-parent): a, b roots; c→a only. The
     ;; artifact-aggregation contract under test is unaffected by the
@@ -372,157 +494,8 @@
       (is (vector? (:artifacts result))
           "artifacts should be collected as a vector"))))
 
-;------------------------------------------------------------------------------ Layer 9
-;; Failure propagation tests
-
-(deftest test-propagate-failures
-  (testing "transitively skips tasks depending on failed tasks"
-    (let [tasks-map {:a {:task/deps #{}}
-                     :b {:task/deps #{:a}}
-                     :c {:task/deps #{:b}}
-                     :d {:task/deps #{}}}
-          ;; :a failed => :b and :c should be propagated, :d unaffected
-          all-failed (dag-orch/propagate-failures tasks-map #{:a})]
-      (is (contains? all-failed :a))
-      (is (contains? all-failed :b))
-      (is (contains? all-failed :c))
-      (is (not (contains? all-failed :d))))))
-
-(deftest test-compute-ready-tasks-excludes-failed
-  (testing "does not return tasks whose deps have failed"
-    (let [tasks-map {:a {:task/deps #{}}
-                     :b {:task/deps #{:a}}}
-          ;; :a failed, :b depends on :a => :b should not be ready
-          ready (dag-orch/compute-ready-tasks tasks-map #{} #{:a})]
-      (is (empty? ready) ":b should not be ready since :a failed"))))
-
-(deftest test-compute-ready-tasks-returns-roots
-  (testing "returns tasks with no deps when nothing is completed"
-    (let [tasks-map {:a {:task/deps #{}}
-                     :b {:task/deps #{}}
-                     :c {:task/deps #{:a :b}}}
-          ready (dag-orch/compute-ready-tasks tasks-map #{} #{})]
-      (is (= #{:a :b} (set (map first ready)))))))
-
-(deftest test-compute-ready-tasks-unlocks-dependents
-  (testing "completing deps unlocks dependent tasks"
-    (let [tasks-map {:a {:task/deps #{}}
-                     :b {:task/deps #{:a}}
-                     :c {:task/deps #{:a :b}}}
-          ;; :a completed, :b should be ready, :c still blocked on :b
-          ready (dag-orch/compute-ready-tasks tasks-map #{:a} #{})]
-      (is (= [:b] (map first ready))))))
-
-;------------------------------------------------------------------------------ Layer 10
-;; partition-results tests
-
-(deftest test-partition-results-mixed
-  (testing "separates ok and err results"
-    (let [results {:a (dag/ok {:done true})
-                   :b (dag/err :failed "boom" {})
-                   :c (dag/ok {:done true})}
-          {:keys [completed failed]} (dag-orch/partition-results results)]
-      (is (= #{:a :c} (set completed)))
-      (is (= #{:b} (set failed))))))
-
-(deftest test-partition-results-all-ok
-  (testing "all ok yields no failures"
-    (let [results {:a (dag/ok {}) :b (dag/ok {})}
-          {:keys [completed failed]} (dag-orch/partition-results results)]
-      (is (= 2 (count completed)))
-      (is (empty? failed)))))
-
-(deftest test-partition-results-all-failed
-  (testing "all failed yields no completions"
-    (let [results {:a (dag/err :f "e1" {}) :b (dag/err :f "e2" {})}
-          {:keys [completed failed]} (dag-orch/partition-results results)]
-      (is (empty? completed))
-      (is (= 2 (count failed))))))
-
-(deftest test-partition-results-empty
-  (testing "empty results yield empty partitions"
-    (let [{:keys [completed failed]} (dag-orch/partition-results {})]
-      (is (empty? completed))
-      (is (empty? failed)))))
-
-;------------------------------------------------------------------------------ Layer 11
-;; aggregate-results tests
-
-(deftest test-aggregate-results-accumulates-metrics
-  (testing "sums tokens, cost, and duration across results"
-    (let [results {:a (dag/ok {:artifacts [{:id 1}]
-                               :metrics {:tokens 100 :cost-usd 0.5 :duration-ms 1000}})
-                   :b (dag/ok {:artifacts [{:id 2} {:id 3}]
-                               :metrics {:tokens 200 :cost-usd 1.0 :duration-ms 2000}})}
-          agg (dag-orch/aggregate-results results)]
-      (is (= 3 (count (:artifacts agg))))
-      (is (= 300 (:total-tokens agg)))
-      (is (= 1.5 (:total-cost agg)))
-      (is (= 3000 (:total-duration agg))))))
-
-(deftest test-aggregate-results-defaults-missing-metrics
-  (testing "defaults to zero when metrics are absent"
-    (let [results {:a (dag/ok {:artifacts []})
-                   :b (dag/ok {})}
-          agg (dag-orch/aggregate-results results)]
-      (is (= 0 (:total-tokens agg)))
-      (is (= 0.0 (:total-cost agg)))
-      (is (= 0 (:total-duration agg))))))
-
-(deftest test-aggregate-results-empty
-  (testing "empty results yield zero aggregates"
-    (let [agg (dag-orch/aggregate-results {})]
-      (is (= 0 (:total-tokens agg)))
-      (is (empty? (:artifacts agg))))))
-
-;------------------------------------------------------------------------------ Layer 12
-;; Additional propagate-failures scenarios
-
-(deftest test-propagate-failures-diamond
-  (testing "diamond: failure at root cascades to all dependents"
-    (let [tasks-map {:a {:task/deps #{}}
-                     :b {:task/deps #{:a}}
-                     :c {:task/deps #{:a}}
-                     :d {:task/deps #{:b :c}}}
-          all-failed (dag-orch/propagate-failures tasks-map #{:a})]
-      (is (= #{:a :b :c :d} all-failed)))))
-
-(deftest test-propagate-failures-no-deps
-  (testing "independent tasks: failure in one doesn't affect others"
-    (let [tasks-map {:a {:task/deps #{}}
-                     :b {:task/deps #{}}
-                     :c {:task/deps #{}}}
-          all-failed (dag-orch/propagate-failures tasks-map #{:a})]
-      (is (= #{:a} all-failed)))))
-
-(deftest test-propagate-failures-empty
-  (testing "no failures yields empty set"
-    (let [tasks-map {:a {:task/deps #{}} :b {:task/deps #{:a}}}
-          all-failed (dag-orch/propagate-failures tasks-map #{})]
-      (is (empty? all-failed)))))
-
-(deftest test-propagate-failures-partial-deps
-  (testing "task with one failed dep and one ok dep still fails"
-    (let [tasks-map {:a {:task/deps #{}}
-                     :b {:task/deps #{}}
-                     :c {:task/deps #{:a :b}}}
-          ;; :a failed but :b did not — :c still transitively fails
-          all-failed (dag-orch/propagate-failures tasks-map #{:a})]
-      (is (contains? all-failed :c) ":c depends on :a which failed"))))
-
-;------------------------------------------------------------------------------ Layer 13
-;; emit-batch-events! tests
-
-(deftest test-emit-batch-events-nil-stream
-  (testing "does not throw with nil event stream"
-    (is (nil? (dag-orch/emit-batch-events!
-               {:a (dag/ok {}) :b (dag/err :f "err" {})}
-               nil "wf-1")))))
-
-;------------------------------------------------------------------------------ Layer 14
 ;; Pre-completed with dependency chains
-
-(deftest test-pre-completed-with-dep-chain
+(deftest ^{:stratum 1} test-pre-completed-with-dep-chain
   (testing "pre-completing middle of chain unlocks downstream"
     (let [started (atom [])
           plan (make-plan [(make-task :a)
@@ -536,7 +509,7 @@
       (is (= 3 (:tasks-completed result)))
       (is (= [:c] @started) "only :c should have executed"))))
 
-(deftest test-unreached-tasks-tracked
+(deftest ^{:stratum 1} test-unreached-tasks-tracked
   (testing "unreached count is correct when failures block tasks"
     ;; This test verifies that the :tasks-unreached field is populated.
     ;; With placeholder execution (no llm-backend), all tasks succeed,


### PR DESCRIPTION
## Summary

- `traverse-levels` (`ai.miniforge.workflow.dag-plan`, split out of `dag-orchestrator` by #1485 mid-session) looped forever on a cyclic plan, or a plan referencing a dependency id absent from its own tasks — `ready` came back empty every iteration so `remaining` never shrank.
- This runs before `plan->dag-tasks` ever sanitizes dependency ids: `maybe-parallelize-plan` → `estimate-parallel-speedup` → `traverse-levels` operates on the plan's *raw* `:plan/tasks`, so a malformed plan hangs the DAG orchestrator's own parallelism check before any task runs.
- Fix: detect the no-progress case (empty `ready` while `remaining` is non-empty) and return an `:anomalies/dag-unschedulable` anomaly, matching the existing `:anomalies/dag-non-forest` convention in `ai.miniforge.dag-executor.branch-registry`. Propagated as "not parallelizable" through `compute-max-level-width`, `parallelizable-plan?`, and `estimate-parallel-speedup`, so callers fall back to sequential execution instead of hanging.
- Also normalizes `:task/id`/`:task/dependencies` before building the deps map (inline at the two call sites, not inside `build-deps-map` itself — normalizing there would have cascaded `build-deps-map` from stratum 0 to 1, pushing `compute-max-level-width`/`estimate-parallel-speedup` to 2 and `parallelizable-plan?` to 3, over `dag_plan.clj`'s 3-layer budget for no functional reason) — a plan mixing string/UUID id representations must resolve identically here as it will once `plan->dag-tasks` normalizes it.
- Confirmed `execute-dag-loop` (the actual task scheduler) already terminates safely on a stuck DAG via its empty-ready-tasks finalize path — this fix is isolated to the Layer-0/1 plan-analysis helpers that run ahead of it.
- First commit is a mechanical `stratum-lint --fix` reformat of the project-level test file (pre-existing `SL003` layer-budget finding, unrelated to this bug — confirmed by running the linter against the file unmodified). Second commit is the actual fix, kept small and reviewable.

## Test plan

- [x] Added `test-traverse-levels-cyclic-terminates` / `test-traverse-levels-dangling-dep-terminates` (direct unit coverage of the guard, against `dag-plan/traverse-levels`)
- [x] Added `test-parallelizable-plan-cyclic-terminates` / `test-parallelizable-plan-dangling-dep-terminates` / `test-estimate-speedup-cyclic-terminates` / `test-maybe-parallelize-plan-cyclic-terminates` (propagation through the higher-level entry points, still exposed via `dag-orchestrator`'s re-exports)
- [x] Added `test-estimate-speedup-mixed-uuid-string-ids` (a UUID-string dependency against a UUID `:task/id` is schedulable, not misreported as unschedulable)
- [x] `cd projects/miniforge && clojure -M -e "(require '[clojure.test :as t] 'ai.miniforge.workflow.dag-orchestrator-test) (t/run-tests 'ai.miniforge.workflow.dag-orchestrator-test)"` — 53 tests, 127 assertions, 0 failures, 0 errors (previously would have hung indefinitely on the new cyclic/dangling-dep cases)

MINIFORGE_PR_BUDGET_OVERRIDE: this PR bundles one mechanical `stratum-lint --fix` reformat commit for `projects/miniforge/test/.../dag_orchestrator_test.clj` (pre-existing SL003 layer-budget debt, unrelated to this bug — confirmed by running the linter against the file unmodified) with the actual traverse-levels fix, kept as a small separate commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
