### PR TITLE
fix(ci): split pr-size into its own workflow so PR body edits re-trigger it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,10 @@
 name: CI
 
-# This workflow runs linting, tests, and builds on every push and PR, plus a
-# PR-only size check (pr-budget) that rejects a whole PR's cumulative diff
-# past 600 reportable lines -- the PR-level counterpart to the commit-time
-# `commit-budget` gate.
+# This workflow runs linting, tests, and builds on every push and PR. The
+# PR-only size check (pr-budget, rejecting a whole PR's cumulative diff past
+# 600 reportable lines) lives in its own workflow, pr-size.yml -- it needs to
+# re-run on PR body edits (e.g. a MINIFORGE_PR_BUDGET_OVERRIDE line), which
+# would otherwise needlessly re-trigger the expensive jobs below.
 # All output is captured in log files and uploaded as artifacts for debugging.
 # Logs are retained for 7 days and can be downloaded from the Actions UI.
 
@@ -26,49 +27,6 @@ env:
   MINIFORGE_CI_BOT_APP_ID: "3360143"
 
 jobs:
-  pr-size:
-    name: PR Size
-    # PR-level only: there's no meaningful base..head diff on a plain
-    # push to main (that's what commit-budget already covers per-commit).
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          # Need the merge-base between base and head, not just the
-          # shallow tip -- a depth-1 checkout wouldn't have it.
-          fetch-depth: 0
-
-      - name: Set up Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-
-      - name: Install Clojure
-        uses: DeLaGuardo/setup-clojure@12.5
-        with:
-          cli: latest
-          bb: latest
-
-      - name: Cache Clojure dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.m2/repository
-            ~/.gitlibs
-          key: clojure-${{ runner.os }}-${{ hashFiles('deps.edn', '**/deps.edn') }}
-          restore-keys: |
-            clojure-${{ runner.os }}-
-
-      - name: Check PR size budget
-        env:
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PR_BODY: ${{ github.event.pull_request.body }}
-        run: bb pr-budget
-
   structure:
     name: Structure
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -1,0 +1,55 @@
+name: PR Size
+
+# Split out from ci.yml so a body-only edit (e.g. adding a
+# MINIFORGE_PR_BUDGET_OVERRIDE line) re-triggers this check without also
+# re-running the expensive Build/Test/Test-Windows jobs in ci.yml. The
+# default `pull_request` trigger (opened/synchronize/reopened) does not fire
+# on `edited`; this workflow adds that type explicitly.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+
+jobs:
+  pr-size:
+    name: PR Size
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # Need the merge-base between base and head, not just the
+          # shallow tip -- a depth-1 checkout wouldn't have it.
+          fetch-depth: 0
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Install Clojure
+        uses: DeLaGuardo/setup-clojure@12.5
+        with:
+          cli: latest
+          bb: latest
+
+      - name: Cache Clojure dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+          key: clojure-${{ runner.os }}-${{ hashFiles('deps.edn', '**/deps.edn') }}
+          restore-keys: |
+            clojure-${{ runner.os }}-
+
+      - name: Check PR size budget
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: bb pr-budget


### PR DESCRIPTION
## Summary

- `pr-size` ran under `ci.yml`'s bare `pull_request:` trigger, which defaults to `opened`/`synchronize`/`reopened` and does not fire on `edited`. Adding a `MINIFORGE_PR_BUDGET_OVERRIDE: <rationale>` line to an already-open PR's body (via `gh pr edit` or the GitHub UI) never re-triggered the check.
- Confirmed directly on #1539: added an override to the body, then `gh run rerun` on the failed job still failed against the pre-edit body — `rerun` replays the stored event payload rather than fetching the current PR body.
- Moved the job verbatim into `.github/workflows/pr-size.yml` with `on: pull_request: types: [opened, synchronize, reopened, edited]`. Left `ci.yml`'s trigger untouched so Build/Test/Test-Windows don't re-run on every description tweak.
- Dropped the now-redundant `if: github.event_name == 'pull_request'` guard on the job — the new workflow's trigger only fires for `pull_request` events, so it's implied.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open(f))"` on both workflow files — parses cleanly.
- [x] `bb pr-budget` job body copied unchanged (same checkout/setup-java/install-clojure/cache/env steps) — no logic changes.
- [ ] Open a scratch PR, let the first pr-size run fail/pass, add an override line via `gh pr edit --body`, confirm a fresh "PR Size" run fires without a new commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)