### PR TITLE
docs(architecture): source-verified corrections to the diagram suite

### DIFF
--- a/docs/architecture/diagrams/a1-estate.svg
+++ b/docs/architecture/diagrams/a1-estate.svg
@@ -58,7 +58,7 @@
   <text class="h" x="342" y="122">Workflow / orchestration core</text>
   <text class="m" x="342" y="142">workflow (FSM+DAG+checkpoints)</text>
   <text class="m" x="342" y="158">orchestrator · operator (meta-loop)</text>
-  <text class="m" x="342" y="174">dag-executor (OCI capsules)</text>
+  <text class="m" x="342" y="174">dag-executor (worktree|docker|k8s)</text>
   <text class="m" x="342" y="190">dag-primitives · loop · fsm</text>
   <text class="m" x="342" y="206">phase (interceptor registry+loader)</text>
   <text class="s" x="342" y="232">the engine — real, end-to-end</text>
@@ -143,11 +143,11 @@
 
   <rect class="grpO part" x="650" y="598" width="300" height="130" rx="8"/>
   <text class="h" x="662" y="620">Thin / partially wired</text>
-  <text class="m" x="662" y="640">datalevin (interface-only; persistence</text>
-  <text class="m" x="662" y="656">is files + R2, not the DB)</text>
-  <text class="m" x="662" y="672">HTTP LLM streaming → non-streaming</text>
-  <text class="m" x="662" y="688">workbench-orchestration-adapter</text>
-  <text class="s" x="662" y="712">(no CLI wiring yet)</text>
+  <text class="m" x="662" y="640">HTTP LLM streaming → non-streaming</text>
+  <text class="m" x="662" y="656">workbench-orchestration-adapter</text>
+  <text class="m" x="662" y="672">(no CLI wiring yet)</text>
+  <text class="s" x="662" y="696">note: datalevin is REAL — it backs the</text>
+  <text class="s" x="662" y="710">artifact + pipeline-pack stores</text>
 
   <rect class="note" x="970" y="598" width="310" height="130" rx="6"/>
   <text class="h" x="982" y="620">Three products, one brick set</text>

--- a/docs/architecture/diagrams/a2-core-loop.svg
+++ b/docs/architecture/diagrams/a2-core-loop.svg
@@ -53,8 +53,8 @@
   <rect class="st" x="356" y="212" width="408" height="120" rx="8"/>
   <text class="h" x="368" y="234">DAG orchestrator — parallel tasks</text>
   <text class="m" x="368" y="252">workflow/dag_orchestrator → dag-executor</text>
-  <text class="s" x="368" y="270">each task = a FULL sub-pipeline (explore→plan→</text>
-  <text class="s" x="368" y="284">implement→verify) in an OCI capsule</text>
+  <text class="s" x="368" y="270">each task = a FULL sub-pipeline; isolation ladder:</text>
+  <text class="s" x="368" y="284">worktree (fallback) → docker → k8s Jobs + plan-security</text>
   <text class="s" x="368" y="300">resumable: :pre-completed-ids + :dag/task-completed</text>
   <text class="s" x="368" y="316">multi-parent git merges: merge_resolution</text>
   <rect class="note" x="356" y="348" width="408" height="116" rx="6"/>
@@ -121,10 +121,11 @@
 
   <!-- gates row -->
   <rect class="gv" x="816" y="336" width="500" height="96" rx="8"/>
-  <text class="h" x="828" y="358">gates + policy (phase transitions)</text>
-  <text class="m" x="828" y="378">policy · policy-pack · gate: syntax · lint · no-secrets ·</text>
-  <text class="m" x="828" y="394">tests-pass · coverage</text>
-  <text class="s" x="828" y="414">fail → validate-and-repair loop back into the phase</text>
+  <text class="h" x="828" y="358">gates + compiled policy packs (fail-closed)</text>
+  <text class="m" x="828" y="374">enter → gates → leave (workflow/execution) · policy-pack/compiler</text>
+  <text class="m" x="828" y="390">gate: syntax · lint · no-secrets · tests-pass · coverage</text>
+  <text class="s" x="828" y="406">nil artifact FAILS the gate, never bypasses; policy-gates floor:</text>
+  <text class="s" x="828" y="420">overrides can never drop governance gates · fail → repair loop</text>
   <rect class="gv" x="1336" y="336" width="472" height="96" rx="8"/>
   <text class="h" x="1348" y="358">evidence-bundle</text>
   <text class="s" x="1348" y="378">provenance chains per phase/gate decision —</text>
@@ -149,7 +150,7 @@
   <text class="h" x="748" y="562">checkpoints + git bundles</text>
   <text class="m" x="748" y="580">~/.miniforge/checkpoints/&lt;wf&gt;/&lt;task&gt;.bundle</text>
   <text class="s" x="748" y="598">authoritative machine snapshot per workflow;</text>
-  <text class="s" x="748" y="612">bundles pushed to R2; bb harvest pulls them back as branches</text>
+  <text class="s" x="748" y="612">bb harvest = explicit LOCAL recovery: bundles → named branches</text>
   <rect class="rec" x="1176" y="540" width="330" height="90" rx="8"/>
   <text class="h" x="1188" y="562">supervisory surface</text>
   <text class="s" x="1188" y="582">event-stream → supervisory-state →</text>

--- a/docs/architecture/diagrams/a3-data-integrations.svg
+++ b/docs/architecture/diagrams/a3-data-integrations.svg
@@ -58,14 +58,14 @@
   <text class="m" x="498" y="370">  keyed [connector-ref schema-name]</text>
   <text class="s" x="498" y="392">formats: EDN (specs/config/defs) · Transit (goldens) ·</text>
   <text class="s" x="498" y="406">JSON (MCP, dashboard, GitHub) · git bundles</text>
-  <text class="s" x="498" y="428" font-style="italic">datalevin: interface exists, not meaningfully wired —</text>
-  <text class="s" x="498" y="442" font-style="italic">persistence is deliberately files + git + R2 today</text>
+  <text class="s" x="498" y="428" font-style="italic">datalevin backs the artifact + pipeline-pack stores;</text>
+  <text class="s" x="498" y="442" font-style="italic">workflow state itself stays files + git bundles</text>
 
   <rect class="fs" x="36" y="472" width="880" height="90" rx="8"/>
-  <text class="h" x="48" y="494">Cloudflare R2 — the off-box residue</text>
-  <text class="m" x="48" y="514">bb-r2 wraps wrangler: bundle push/pull</text>
-  <text class="m" x="48" y="530">bb harvest → fetches persisted task bundles back as harvest/&lt;wf&gt;/&lt;task&gt; branches</text>
-  <text class="s" x="48" y="550">workflow output survives the workstation; harvest is how another machine picks a task's work back up</text>
+  <text class="h" x="48" y="494">Harvest — local checkpoint recovery (no R2 in this loop)</text>
+  <text class="m" x="48" y="514">bb harvest → ~/.miniforge/checkpoints/&lt;wf&gt;/&lt;task&gt;.bundle → harvest/&lt;wf&gt;/&lt;task&gt; branches</text>
+  <text class="m" x="48" y="530">bb-r2 (wrangler wrapper) is a bb-utils helper consumed by Thesium risk — not miniforge's loop</text>
+  <text class="s" x="48" y="550">bundles preserve agent work as real commits; harvest is the explicit, user-driven merge step</text>
 
   <rect class="note" x="36" y="578" width="880" height="86" rx="6"/>
   <text class="h" x="52" y="600">Reading the map</text>
@@ -94,12 +94,12 @@
   <text class="s" x="1448" y="218">everything is shell-out or plain REST — no daemons</text>
 
   <rect class="ig" x="976" y="276" width="440" height="150" rx="8"/>
-  <text class="h" x="988" y="298">Container runtime (N11 capsules)</text>
-  <text class="m" x="988" y="318">dag-executor shells OCI CLIs: docker · podman · nerdctl</text>
-  <text class="m" x="988" y="334">selection: explicit → probe [podman docker nerdctl]</text>
-  <text class="m" x="988" y="350">per-runtime quirks in runtime/registry.edn</text>
-  <text class="s" x="988" y="372">no daemon API; fully-qualified images only;</text>
-  <text class="s" x="988" y="386">task capsules for DAG parallel execution</text>
+  <text class="h" x="988" y="298">Isolation ladder (dag-executor)</text>
+  <text class="m" x="988" y="318">worktree executor (fallback) → docker/OCI → k8s Jobs</text>
+  <text class="m" x="988" y="334">OCI CLIs: docker · podman · nerdctl (probe order)</text>
+  <text class="m" x="988" y="350">plan-security: capsule-isolation hard-stop policies</text>
+  <text class="s" x="988" y="372">(e.g. runtime-no-host-docker-socket) · no daemon API;</text>
+  <text class="s" x="988" y="386">fully-qualified images; per-runtime quirks in registry.edn</text>
   <rect class="ig" x="1436" y="276" width="450" height="150" rx="8"/>
   <text class="h" x="1448" y="298">MCP surfaces</text>
   <text class="m" x="1448" y="318">in-repo bases: mcp-context-server · lsp-mcp-bridge</text>

--- a/docs/architecture/diagrams/t1-five-planes.svg
+++ b/docs/architecture/diagrams/t1-five-planes.svg
@@ -36,8 +36,8 @@
   <rect class="built" x="36" y="326" width="588" height="86" rx="8"/>
   <text class="h" x="48" y="348">Learning layer</text>
   <text class="m" x="48" y="366">Observer → Meta-loop → Heuristic registry → Knowledge base</text>
-  <text class="s" x="48" y="386">self-improvement from run outcomes; training-capture</text>
-  <text class="s" x="36" y="436">runs on a workstation or CI · ~100 components, 4 bases (panel A1)</text>
+  <text class="s" x="48" y="386">meta agents = semantic doormen; operator = meta-meta (nearing release)</text>
+  <text class="s" x="36" y="436">runs on a workstation or CI · isolation ladder as-built: worktree → container → k8s Jobs</text>
   <text class="s" x="36" y="452">the engine exists and dogfoods itself daily (panel A2)</text>
 
   <!-- Plane 2 -->
@@ -119,8 +119,7 @@
   <text class="s" x="1380" y="636">(forcing function: proprietary data that can't leave the network)</text>
   <rect class="rec" x="1316" y="660" width="568" height="36" rx="6"/>
   <text class="t" x="1328" y="678" font-weight="bold">Thesium</text><text class="t" x="1400" y="678">standalone: GHA + R2 + data-plane gateway — NO Fleet dependency</text>
-  <rect class="rec" x="1316" y="702" width="568" height="34" rx="6"/>
-  <text class="t" x="1328" y="720" font-weight="bold">Engrammic</text><text class="t" x="1416" y="720">licenses Fleet — "Fleet is to Engrammic what k8s is to an app"</text>
+  <text class="s" x="1328" y="722" font-style="italic">(the licensing-model spec also names a fourth shape, now retired — spec predates it)</text>
 
   <!-- governance split strip -->
   <rect class="note" x="20" y="762" width="1880" height="90" rx="6"/>

--- a/docs/architecture/diagrams/t2-runs-loops.svg
+++ b/docs/architecture/diagrams/t2-runs-loops.svg
@@ -53,30 +53,32 @@
   <!-- LOOPS -->
   <rect class="zone" x="520" y="62" width="640" height="560" rx="6"/>
   <text class="zoneT" x="536" y="84">THREE NESTED LOOPS (product-vision · N5-delta-2)</text>
-  <rect class="lp" x="536" y="100" width="600" height="140" rx="8"/>
+  <rect class="lp" x="536" y="100" width="600" height="104" rx="8"/>
   <text class="h" x="548" y="122">Loop 0 — inner (the agent's own loop)</text>
   <text class="m" x="548" y="142">plan → implement → test → review → release</text>
-  <text class="s" x="548" y="162">validate-and-repair until gates pass; budget-bounded;</text>
-  <text class="s" x="548" y="176">semantic-intent checks ("IMPORT spec ⇒ 0 creates")</text>
-  <text class="s" x="548" y="196">runs inside the engine, no human in the loop</text>
-  <text class="s" x="548" y="216" font-style="italic">as-built today — panel A2 is this loop</text>
-  <rect class="lp" x="536" y="256" width="600" height="120" rx="8"/>
-  <text class="h" x="548" y="278">Loop 1 — outer (PR monitor)</text>
-  <text class="s" x="548" y="298">watches the open PR: resolves review feedback, pushes</text>
-  <text class="s" x="548" y="312">fixes, manages budget, escalates when stuck</text>
-  <text class="s" x="548" y="332">pr-lifecycle + pr-train as-built; the monitor loop is the</text>
-  <text class="s" x="548" y="346">designed autonomous version</text>
-  <rect class="lp" x="536" y="392" width="600" height="120" rx="8"/>
-  <text class="h" x="548" y="414">Loops 2/3 — meta (the human, from the console)</text>
-  <text class="s" x="548" y="434">observe everything; command when needed: pause · resume ·</text>
-  <text class="s" x="548" y="448">cancel · retry-from-phase · waive · force-safe-mode</text>
-  <text class="s" x="548" y="468">one operator, many runs — the control-room premise;</text>
-  <text class="s" x="548" y="482">commands flow ONLY through the intervention round-trip (right)</text>
+  <text class="s" x="548" y="162">validate-and-repair until gates pass; budget-bounded; no human</text>
+  <text class="s" x="548" y="182" font-style="italic">as-built today — panel A2 is this loop</text>
+  <rect class="lp" x="536" y="214" width="600" height="86" rx="8"/>
+  <text class="h" x="548" y="236">Loop 1 — outer (PR monitor)</text>
+  <text class="s" x="548" y="256">watches the open PR: resolves feedback, pushes fixes, manages</text>
+  <text class="s" x="548" y="270">budget, escalates when stuck (pr-lifecycle + pr-train as-built;</text>
+  <text class="s" x="548" y="284">the fully autonomous monitor is the designed version)</text>
+  <rect class="lp" x="536" y="310" width="600" height="100" rx="8"/>
+  <text class="h" x="548" y="332">Loop 2 — META AGENTS (doormen over meaning)</text>
+  <text class="s" x="548" y="352">a set of meta agents gate SEMANTIC INTENT and run specialized</text>
+  <text class="s" x="548" y="366">reviews: did the agent build something DIFFERENT than planned?</text>
+  <text class="s" x="548" y="380">("IMPORT spec ⇒ 0 creates" lives here) — a perfectly built</text>
+  <text class="s" x="548" y="394">wrong thing fails · meta-evaluator + coordinator (as-built roster)</text>
+  <rect class="lp" x="536" y="420" width="600" height="92" rx="8"/>
+  <text class="h" x="548" y="442">Loop 3 — META-META: the operator (plumbed, nearing release)</text>
+  <text class="s" x="548" y="462">the operator component orchestrates the meta loop itself;</text>
+  <text class="s" x="548" y="476">the human supervises it from the console — pause · resume · cancel ·</text>
+  <text class="s" x="548" y="490">retry · waive — always through the intervention round-trip (right)</text>
   <rect class="fx" x="536" y="528" width="600" height="80" rx="8"/>
   <text class="h" x="548" y="550">FSM roster — 10 machines on one fsm component</text>
   <text class="m" x="548" y="568">execution · supervision · degradation · pr-lifecycle · task ·</text>
   <text class="m" x="548" y="582">dag-task · inner-loop · agent-lifecycle · heuristic · circuit-breaker</text>
-  <text class="s" x="548" y="600">+ 2 state-tracked: intervention lifecycle, supervisory WorkflowRun projection</text>
+  <text class="s" x="548" y="600">ONE phase authority: the workflow FSM (current-phase-id) — all others observe, feeding back only via the orchestrator</text>
 
   <!-- GOVERNANCE -->
   <rect class="zone" x="1180" y="62" width="720" height="560" rx="6"/>
@@ -84,8 +86,8 @@
   <rect class="gv" x="1196" y="100" width="688" height="120" rx="8"/>
   <text class="h" x="1208" y="122">policy packs → gates → evidence bundles</text>
   <text class="m" x="1208" y="142">per-rule :rule/enforcement — hard-halt · require-approval · warn · audit</text>
-  <text class="s" x="1208" y="162">gates check AND repair; evidence bundles carry provenance chains +</text>
-  <text class="s" x="1208" y="176">semantic-intent validation for every transition</text>
+  <text class="s" x="1208" y="162">COMPILED packs (policy-pack/compiler) drive gates wired fail-closed at every</text>
+  <text class="s" x="1208" y="176">transition (as-built); evidence bundles carry provenance + semantic intent</text>
   <text class="s" x="1208" y="196" font-style="italic">known gap: today's deployment gate fails OPEN on vocabulary mismatch — T3 #4</text>
   <rect class="gv" x="1196" y="236" width="688" height="90" rx="8"/>
   <text class="h" x="1208" y="258">trust model</text>

--- a/docs/architecture/diagrams/t3-delta.svg
+++ b/docs/architecture/diagrams/t3-delta.svg
@@ -62,10 +62,10 @@
   <rect class="part" x="536" y="276" width="600" height="170" rx="8"/>
   <text class="h" x="548" y="298">PARTIAL — real but thin, or in progress</text>
   <text class="m" x="548" y="318">Phase D control path (control-plane-client crate exists; wiring in progress)</text>
-  <text class="m" x="548" y="334">N11 capsule ~50% · runtime policy gating at phase boundaries (unwired)</text>
+  <text class="m" x="548" y="334">N11 capsule ~50% (phase gates themselves: wired, fail-closed)</text>
   <text class="m" x="548" y="350">Fleet governance comps = in-memory 3-clj stubs: authz ·</text>
   <text class="m" x="548" y="366">conflict-detection · resource-management · policy-distribution · analytics</text>
-  <text class="m" x="548" y="382">HTTP LLM streaming (falls back) · datalevin (interface only)</text>
+  <text class="m" x="548" y="382">HTTP LLM streaming (falls back)</text>
   <text class="m" x="548" y="398">workbench-orchestration-adapter (no CLI wiring)</text>
   <text class="m" x="548" y="414">WorktreeInbox read-side: claude-code only; bash write-only</text>
   <rect class="spec" x="536" y="462" width="600" height="180" rx="8"/>


### PR DESCRIPTION
## What

Owner review of #1548 caught claims that came from stale planning docs or shallow survey reads. Every correction below was verified against origin/main source with file:line before fixing:

1. **Engrammic removed** (T1) — product retired; the licensing-model spec predates the shutdown.
2. **R2 removed from miniforge's loop** (A2/A3) — `tasks/harvest.clj` recovers **local** `~/.miniforge/checkpoints/` bundles as branches; `bb-r2` is a bb-utils helper consumed by Thesium risk.
3. **datalevin is real** (A1/A3) — backs the artifact store (`artifact/datalevin_store.clj`) and pipeline-pack store.
4. **Phase gates + compiled packs are as-built and fail-closed** (A2/T2/T3) — `workflow/execution.clj` enter→gates→leave, "a nil artifact fails the gate, never bypasses it", `policy-pack/compiler.clj`, and the `policy-gates` floor overrides can never drop. The March review's "unwired" claim was stale.
5. **One phase authority** (T2) — the workflow FSM's `current-phase-id` is the single answer to "what phase are we in"; the other nine machines observe and feed back only via the orchestrator.
6. **Isolation ladder added** (A1/A2/A3/T1) — worktree (fallback) → docker/OCI → k8s Jobs executors (`dag-executor/interface.clj:443-451`) + `plan_security.clj` capsule-isolation hard-stop policies.
7. **Loops corrected per owner** (T2/T1) — Loop 2 = **meta agents**: semantic-intent doormen and specialized reviewers (built ≠ planned fails, however well-built); Loop 3 = **meta-meta: the operator**, plumbed and nearing release; the human supervises it from the console through the intervention round-trip.

MINIFORGE_PR_BUDGET_OVERRIDE: SVG documentation corrections reviewed as rendered images, not line diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)