### PR TITLE
docs(explainers): borrowed robots replace the cousin's robot

### DIFF
--- a/docs/architecture/explainers/fort-3-porch.svg
+++ b/docs/architecture/explainers/fort-3-porch.svg
@@ -31,14 +31,14 @@
   <rect x="364" y="158" width="66" height="16" rx="8" fill="#fffde7" stroke="#c8b900"/>
   <text x="397" y="170" text-anchor="middle" font-size="8.5" fill="#6a5a10">3 parts at once</text>
   <rect x="148" y="212" width="90" height="70" rx="5" fill="#ffffff" stroke="#8a8a82" stroke-width="1.5" stroke-dasharray="5 3"/>
-  <text x="193" y="230" text-anchor="middle" font-size="9.5" fill="#333">cousin's robot:</text>
+  <text x="193" y="230" text-anchor="middle" font-size="9.5" fill="#333">borrowed robot:</text>
   <text x="193" y="243" text-anchor="middle" font-size="9.5" fill="#333">birdhouse</text>
   <rect x="160" y="252" width="66" height="16" rx="8" fill="#ffe6cc" stroke="#d79b00"/>
   <text x="193" y="264" text-anchor="middle" font-size="8.5" fill="#8a5a00">stuck?</text>
   <rect x="250" y="212" width="192" height="70" rx="5" fill="#eef4fb" stroke="#6c8ebf" stroke-width="1"/>
-  <text x="346" y="236" text-anchor="middle" font-size="10.5" fill="#274b73">you didn't hire the cousin's robot —</text>
-  <text x="346" y="250" text-anchor="middle" font-size="10.5" fill="#274b73">the board shows it anyway, and you</text>
-  <text x="346" y="264" text-anchor="middle" font-size="10.5" fill="#274b73">can slide a note its way</text>
+  <text x="346" y="236" text-anchor="middle" font-size="10.5" fill="#274b73">a friend lent you this one — not on</text>
+  <text x="346" y="250" text-anchor="middle" font-size="10.5" fill="#274b73">the team, so no coach hands it jobs.</text>
+  <text x="346" y="264" text-anchor="middle" font-size="10.5" fill="#274b73">YOU tell it what to do, from here</text>
 
   <!-- the jar -->
   <rect x="510" y="140" width="150" height="170" rx="10" fill="#fcfcfa" stroke="#b8b8b0" stroke-width="1.5"/>
@@ -73,5 +73,5 @@
   <text x="430" y="466" font-size="12" fill="#333">same as everything else</text>
 
   <rect x="120" y="500" width="660" height="44" rx="8" fill="#fffde7" stroke="#c8b900" stroke-width="1.5"/>
-  <text x="450" y="527" text-anchor="middle" font-size="15" fill="#4a4a20">Watching your yard doesn't require having hired everyone in it.</text>
+  <text x="450" y="527" text-anchor="middle" font-size="15" fill="#4a4a20">The team listens to its coach; the borrowed robots listen only to you.</text>
 </svg>

--- a/docs/architecture/explainers/miniforge-for-a-nine-year-old.md
+++ b/docs/architecture/explainers/miniforge-for-a-nine-year-old.md
@@ -84,8 +84,8 @@ board that shows **everything happening in your yard at once** —
 every fort, what's building, what's stuck, what's got a red
 sticker. And not every robot in your yard is on the fort team.
 You've also got a couple of **borrowed robots** — a friend lent
-them to you, and they're terrific builders. They're yours, and
-they're in *your* yard, but they're not on the team, so the coach
+them to you, and they're terrific builders. They work for you,
+in *your* yard, but they're not on the team, so the coach
 doesn't hand them jobs. If you want a borrowed robot to build a
 birdhouse, *you* tell it — right from the porch, one note at a
 time. The board shows them the same way as everyone else — busy,

--- a/docs/architecture/explainers/miniforge-for-a-nine-year-old.md
+++ b/docs/architecture/explainers/miniforge-for-a-nine-year-old.md
@@ -185,7 +185,7 @@ to hang passes on.
 | the diary | the append-only event stream |
 | sticky notes until there aren't any | the PR review loop; the designed autonomous monitor |
 | the porch board — your whole yard, one view | the operator console — the control-room premise |
-| the borrowed robots, coachless | bare agents (Claude Code / codex sessions) — you direct them from the console; adapter-observed, not orchestrated by miniforge (yet) |
+| the borrowed robots, coachless | bare agents (Claude Code / codex sessions) — you direct them from the console; adapter-observed, not orchestrated by Miniforge (yet) |
 | notes in the jar, never shouting | the intervention round-trip — every supervisory write is a logged InterventionRequest first |
 | the safety rules, each with a seriousness | policy packs; per-rule enforcement: hard-halt / require-approval / warn / audit |
 | the helpful neighbor who never blocks | Fleet — advisory coordination, pack distribution; mostly spec-only today |

--- a/docs/architecture/explainers/miniforge-for-a-nine-year-old.md
+++ b/docs/architecture/explainers/miniforge-for-a-nine-year-old.md
@@ -27,10 +27,13 @@ Every fort goes the same way:
 
 1. **Look at the yard.** Where's the good tree? Where's the swing
    we can't touch?
-2. **Make the job list.** One robot turns your drawing into jobs:
-   *ladder first, then floor, then walls, then lookout.* And if
-   your drawing already lists the jobs? It doesn't redo your
-   thinking — it just checks the list makes sense and gets going.
+2. **Make the job list.** The team has a **coach**. The coach
+   turns your drawing into jobs — *ladder first, then floor, then
+   walls, then lookout* — and hands each robot its job. You never
+   boss a team robot around one at a time; that's the coach's
+   whole job. And if your drawing already lists the jobs? The
+   coach doesn't redo your thinking — just checks the list makes
+   sense and gets going.
 3. **Build.**
 4. **Wiggle test.** A checker grabs every board and *wiggles* it.
    Loose board? Red sticker. Red sticker means **fix it and test
@@ -79,12 +82,16 @@ fort-building too:
 You don't stand in the yard all day. You sit on the porch with a
 board that shows **everything happening in your yard at once** —
 every fort, what's building, what's stuck, what's got a red
-sticker. And not just your fort team: sometimes another robot is
-working in your yard that your team didn't hire — your cousin left
-his robot here for the week, and it's building a birdhouse in the
-corner. Your board shows it too — busy, stuck, done — and you can
-slide a note its way. **Watching your yard doesn't require having
-hired everyone in it.**
+sticker. And not every robot in your yard is on the fort team.
+You've also got a couple of **borrowed robots** — a friend lent
+them to you, and they're terrific builders. They're yours, and
+they're in *your* yard, but they're not on the team, so the coach
+doesn't hand them jobs. If you want a borrowed robot to build a
+birdhouse, *you* tell it — right from the porch, one note at a
+time. The board shows them the same way as everyone else — busy,
+stuck, done. **The team listens to its coach; the borrowed robots
+listen only to you.** (Maybe someday the coach takes the borrowed
+robots onto the team. Not yet.)
 
 Two porch rules, and they never bend:
 
@@ -165,6 +172,7 @@ to hang passes on.
 | your drawing | a work spec — intent + constraints |
 | the garage board, flops kept pinned | the `work/` kanban; failures keep their trail |
 | look → job list → build → tests → show → learn | the phase pipeline: explore → plan → implement → verify → review → release → observe |
+| the coach | the orchestrator — turns the spec into tasks and hands each agent its work |
 | not redoing your thinking | the 0-token `plan-from-spec-tasks` path |
 | the wiggle test, red stickers | fail-closed gates at phase transitions; validate-and-repair |
 | nobody builds on a red sticker | gate failure blocks the next phase — never bypassed |
@@ -177,7 +185,7 @@ to hang passes on.
 | the diary | the append-only event stream |
 | sticky notes until there aren't any | the PR review loop; the designed autonomous monitor |
 | the porch board — your whole yard, one view | the operator console — the control-room premise |
-| the cousin's robot you didn't hire | bare-agent supervision (Claude Code / codex sessions, adapter-observed) |
+| the borrowed robots, coachless | bare agents (Claude Code / codex sessions) — you direct them from the console; adapter-observed, not orchestrated by miniforge (yet) |
 | notes in the jar, never shouting | the intervention round-trip — every supervisory write is a logged InterventionRequest first |
 | the safety rules, each with a seriousness | policy packs; per-rule enforcement: hard-halt / require-approval / warn / audit |
 | the helpful neighbor who never blocks | Fleet — advisory coordination, pack distribution; mostly spec-only today |

--- a/docs/architecture/explainers/miniforge-for-a-nine-year-old.md
+++ b/docs/architecture/explainers/miniforge-for-a-nine-year-old.md
@@ -84,7 +84,7 @@ board that shows **everything happening in your yard at once** —
 every fort, what's building, what's stuck, what's got a red
 sticker. And not every robot in your yard is on the fort team.
 You've also got a couple of **borrowed robots** — a friend lent
-them to you, and they're terrific builders. They work for you,
+them to you, and they're terrific builders. They work for you
 in *your* yard, but they're not on the team, so the coach
 doesn't hand them jobs. If you want a borrowed robot to build a
 birdhouse, *you* tell it — right from the porch, one note at a


### PR DESCRIPTION
Follow-up to #1550, applying the owner's correction to the bare-agent framing.

The story had a "cousin's robot you didn't hire" working in your yard. Wrong model: you cannot supervise someone else's raw agent — every agent in the yard is one you spawned (local or your cloud). The real distinction is orchestration:

- **Team robots** have a **coach** (the orchestrator) who turns the drawing into jobs and hands them out. You never direct a team robot one at a time.
- **Borrowed robots** (Claude Code / codex sessions) are yours but coachless — you direct them yourself from the porch (the operator console, not miniforge — at least not yet).

Changes: story §how-the-robots-build introduces the coach; §porch replaces the cousin passage; translation table gains a coach row and rewrites the bare-agent row; fort-3-porch.svg card, caption, and banner updated (screenshot-verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)