### PR TITLE
docs(architecture): ratify the Ariadne adoption RFC

### DIFF
--- a/docs/architecture/rfc-ariadne-adoption.md
+++ b/docs/architecture/rfc-ariadne-adoption.md
@@ -6,7 +6,8 @@
 
 # RFC: Adopting Ariadne in Miniforge
 
-**Status:** Proposed (2026-07-28). Graduated from the owner-reviewed
+**Status:** Accepted (2026-07-28, owner ratification — all three
+decisions below). Graduated from the owner-reviewed
 adoption assessment; the analysis below is unchanged from that
 review apart from naming and the ratification list.
 


### PR DESCRIPTION
Owner ratified all three decisions (adoption order; Fleet re-scope before further Fleet governance build; N10 subsumed by grants). Status flips Proposed → Accepted. Implementation planning follows in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)