### PR TITLE
fix(workflow-runner): narrow load-or-create-workflow catch to :anomalies/not-found

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -41,7 +41,7 @@
    [ai.miniforge.cli.workflow-runner.dashboard :as dashboard]
    [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.response.interface :as response]
-   [slingshot.slingshot :refer [try+]]
+   [slingshot.slingshot :refer [try+ throw+]]
    [ai.miniforge.dag-executor.interface :as gc-queue]
    [ai.miniforge.cli.worktree :as worktree]
    [ai.miniforge.cli.workflow-runner.gc-hooks :as gc-hooks]))

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -796,9 +796,9 @@
 
 (defn ^{:stratum 2} load-or-create-workflow [load-workflow workflow-type workflow-version]
   (let [workflow-type (resolve-workflow-alias workflow-type)]
-    (try
+    (try+
       (load-and-validate-workflow load-workflow workflow-type workflow-version)
-      (catch Exception e
+      (catch [:anomaly/category :anomalies/not-found] _
         (case workflow-type
           :test-only
           {:workflow/id :test-only
@@ -815,7 +815,7 @@
                                {:phase :done}]
            :workflow/config {:max-tokens 20000 :max-iterations 5}}
 
-          (throw e))))))
+          (throw+))))))
 
 (defn ^{:stratum 2} execute-with-events [{:keys [run-pipeline workflow workflow-input context artifact-store
                                      event-stream workflow-id sandbox-cleanup opts]}]


### PR DESCRIPTION
## Summary

- `load-or-create-workflow` used `(catch Exception)` for `:test-only` and `:comment-fix` types, silently swallowing *all* exceptions — including `:anomalies.workflow/invalid-config` thrown when a custom workflow file exists but fails schema validation
- Changed to `(try+` / `(catch [:anomaly/category :anomalies/not-found] _)` so only a genuinely missing workflow file triggers the inline fallback; config validation errors propagate to the caller

## Motivation

When an operator has a custom `:test-only` or `:comment-fix` workflow that contains a schema error, the old code discarded the error and ran the hardcoded skeleton (2-phase, `max-iterations 10/5`) with no warning. The operator had no signal that their configuration was broken; the run appeared to succeed while silently ignoring their policy.

## Changes

| File/Area | Change |
|-----------|--------|
| `bases/cli/.../workflow_runner.clj:797-818` | `try` → `try+`; `catch Exception e` → `catch [:anomaly/category :anomalies/not-found]`; `(throw e)` → `(throw+)` |

## Testing

- [x] Change is narrowly scoped: `:anomalies/not-found` (file missing) continues to fall back to the inline workflow; `:anomalies.workflow/invalid-config` (file present but invalid) now propagates
- [x] Existing `alias_test.clj` happy-path coverage is unaffected — the mock loader returns a valid workflow, the catch is never reached
- [ ] `bb test` — full poly test suite requires bb + Clojure CLI not available in sweep environment; change is a 3-line narrowing of exception scope with no logic restructuring

## Checklist

### Required

- [x] Pre-commit validation passes (no `--no-verify`)
- [x] No commented-out tests
- [x] Focused PR (single concern)

### Best Practices

- [x] Follows exceptions-as-data rule (dewey 005): propagate errors as values / anomalies; narrow catch scope
- [x] Uses `try+` per clojure-exception-handling rule (dewey 211)

## Related

- Caught by daily repo health sweep (2026-07-28)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZzPHMDRfrDKQ1GrinZiVG)_