### PR TITLE
fix(supervisory-state): split schema.clj to clear the 3-layer stratum budget (SL003, Wave 2)

### DIFF
--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/entities.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/entities.clj
@@ -1,0 +1,328 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.supervisory-state.entities
+  "Open Malli schemas for the ten canonical supervisory entities, plus the
+   aggregate EntityTable that holds them, per N5-delta-supervisory-control-
+   plane §3.1 and the Rust supervisory-entities crate.
+
+   Built on the enum vocabulary, Malli `registry`, and standalone PR-scoring
+   sub-schemas (ReadinessFactor, RiskFactor, PolicyViolationSummary,
+   PolicyCounts) defined in `ai.miniforge.supervisory-state.schema` — this
+   namespace was split out of `schema.clj` (SL003, Wave 2) because these
+   entity schemas compose `registry` and, in turn, PrFleetEntry and
+   PolicyEvaluation compose other entities here, which together pushed the
+   single-file layer count over the 3-layer stratum budget.
+
+   All maps are open (additional keys pass through) per N5-delta-1 §12.4."
+  (:require
+   [ai.miniforge.supervisory-state.schema :as schema]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Entity schemas — open maps, mirror N5-delta-1 §3.1
+(def ^{:stratum 0} WorkflowRun
+  "A concrete execution instance of a workflow per N5-delta-1 §3.1.
+
+   Open: additional keys pass through validation."
+  [:map {:registry schema/registry}
+   [:workflow-run/id :workflow-run/id]
+   [:workflow-run/workflow-key [:string {:min 1}]]
+   [:workflow-run/intent string?]
+   [:workflow-run/status :workflow-run/status]
+   [:workflow-run/current-phase keyword?]
+   [:workflow-run/started-at :common/timestamp]
+   [:workflow-run/updated-at :common/timestamp]
+   [:workflow-run/trigger-source :workflow-run/trigger-source]
+   [:workflow-run/correlation-id :id/uuid]
+   [:workflow-run/artifact-ids {:optional true} [:vector :id/uuid]]
+   [:workflow-run/evidence-bundle-id {:optional true} [:maybe :id/uuid]]
+   ;; BD-1: canonical run-owned spec identity. Lifted from `:workflow/spec`
+   ;; on the lifecycle event so consumers do not have to recover it from
+   ;; correlated agent metadata. Open: producers may add further `:spec/*`
+   ;; keys without a contract bump.
+   [:workflow-run/spec {:optional true}
+    [:map
+     [:spec/title       {:optional true} [:string {:min 1}]]
+     [:spec/description {:optional true} [:string {:min 1}]]
+     [:spec/intent      {:optional true} map?]]]
+   ;; N14: foreign key to the long-lived `Spec` entity that owns this
+   ;; run. Optional — runs without a derivable spec identity (no title
+   ;; on the snapshot) remain Specless. Distinct from
+   ;; `:workflow-run/spec` (the per-run snapshot above) and stable
+   ;; across re-executions of the same spec.
+   [:workflow-run/spec-id {:optional true} :spec/id]
+   [:workflow-run/prs {:optional true}
+    [:vector
+     [:map
+      [:pr/repo [:string {:min 1}]]
+      [:pr/number :common/non-neg-int]
+      [:pr/url string?]
+      [:pr/branch string?]
+      [:pr/title {:optional true} [:maybe string?]]
+      [:pr/author {:optional true} [:maybe string?]]
+      [:pr/merge-order {:optional true} [:maybe :common/non-neg-int]]]]]])
+
+(def ^{:stratum 0} Spec
+  "A long-lived supervisory entity representing the operator's
+   top-level unit of work (N5-delta-3 §3.1, §5.1). One Spec owns N
+   WorkflowRuns over its lifetime.
+
+   Open map: additional keys pass through validation. Field types
+   chosen to be compatible with the existing per-run snapshot
+   (`:workflow-run/spec` above) and the spec-parser's `SpecIntent`
+   shape:
+
+   - `:spec/intent` is a structured map (per `SpecIntent` in
+     `spec-parser/.../schema.clj`); kept as open `map?` here so we
+     don't re-validate against the producer-side schema.
+   - `:spec/tags` accepts strings OR keywords (existing tag
+     conventions elsewhere in the codebase).
+   - `:spec/origin` discriminates `:miniforge` (specs known to this
+     runtime) from `:local-synthetic` (the Rust-core consumer
+     creates these ahead of upstream knowing about them, per
+     N5-delta-3 §5.3 reconciliation)."
+  [:map {:registry schema/registry}
+   [:spec/id         :spec/id]
+   [:spec/title      [:string {:min 1}]]
+   [:spec/status     :spec/status]
+   [:spec/created-at :common/timestamp]
+   [:spec/updated-at :common/timestamp]
+   [:spec/description {:optional true} :string]
+   [:spec/intent      {:optional true} map?]
+   [:spec/repo-url    {:optional true} :string]
+   [:spec/tags        {:optional true} [:vector [:or :string :keyword]]]
+   [:spec/origin      {:optional true} keyword?]])
+
+(def ^{:stratum 0} AgentSession
+  "An external or internal agent observable to the supervisory plane.
+
+   Mirrors the Rust supervisory-entities `AgentSession` shape. The
+   control-plane/registry component (N5-delta-1 §3.3) is the in-process
+   source; supervisory-state mirrors it from `:control-plane/agent-*` events."
+  [:map {:registry schema/registry}
+   [:agent/id :id/uuid]
+   [:agent/vendor [:string {:min 1}]]
+   [:agent/external-id [:string {:min 1}]]
+   [:agent/name [:string {:min 1}]]
+   [:agent/status :agent/status]
+   [:agent/capabilities [:vector keyword?]]
+   [:agent/heartbeat-interval-ms :common/non-neg-int]
+   [:agent/metadata [:map-of any? any?]]
+   [:agent/tags [:vector string?]]
+   [:agent/registered-at :common/timestamp]
+   [:agent/last-heartbeat :common/timestamp]
+   [:agent/task {:optional true} [:maybe string?]]])
+
+(def ^{:stratum 0} PrReadiness
+  "Merge-readiness score block per N5-delta-2 §2.1."
+  [:map {:registry schema/registry}
+   [:readiness/score number?]
+   [:readiness/threshold number?]
+   [:readiness/ready? boolean?]
+   [:readiness/factors [:vector schema/ReadinessFactor]]])
+
+(def ^{:stratum 0} PrRisk
+  "Risk-assessment score block per N5-delta-2 §2.2."
+  [:map {:registry schema/registry}
+   [:risk/score number?]
+   [:risk/level :risk/level]
+   [:risk/factors [:vector schema/RiskFactor]]])
+
+(def ^{:stratum 0} PrPolicy
+  "Aggregated external-PR policy result per N5-delta-2 §2.3."
+  [:map {:registry schema/registry}
+   [:policy/overall :policy/overall]
+   [:policy/packs-applied [:vector string?]]
+   [:policy/summary schema/PolicyCounts]
+   [:policy/violations [:vector schema/PolicyViolationSummary]]
+   [:policy/artifacts-checked {:optional true} [:maybe :common/non-neg-int]]])
+
+(def ^{:stratum 0} PolicyViolation
+  "A single rule failure within a PolicyEvaluation per N5-delta-1 §3.1."
+  [:map {:registry schema/registry}
+   [:violation/rule-id keyword?]
+   [:violation/severity :violation/severity]
+   [:violation/category :violation/category]
+   [:violation/message [:string {:min 1}]]
+   [:violation/location {:optional true} [:maybe string?]]
+   [:violation/remediable? boolean?]])
+
+(def ^{:stratum 0} AttentionItem
+  "A derived supervisory signal per N5-delta-1 §3.1 + §5."
+  [:map {:registry schema/registry}
+   [:attention/id :attention/id]
+   [:attention/severity :attention/severity]
+   [:attention/source-type :attention/source-type]
+   [:attention/source-id any?]
+   [:attention/summary [:string {:min 1}]]
+   [:attention/derived-at :common/timestamp]
+   [:attention/resolved? boolean?]])
+
+(def ^{:stratum 0} TaskNode
+  "A single DAG task observable in the Kanban view (N5 §3.2.5 / N5-δ3 §2.3).
+
+   `:task/status` is an OPEN keyword — workflow families may add their own
+   statuses via the DAG state-profile system. `:task/kanban-column` is the
+   closed display contract derived from status + dependency resolution per
+   N5-δ3 §2.3's status→column table; unknown statuses fall back to
+   `:blocked` so they surface visibly."
+  [:map {:registry schema/registry}
+   [:task/id :task/id]
+   [:task/workflow-run-id :id/uuid]
+   [:task/description string?]
+   [:task/type {:optional true} [:maybe keyword?]]
+   [:task/component {:optional true} [:maybe string?]]
+   [:task/status keyword?]
+   [:task/kanban-column :task/kanban-column]
+   [:task/dependencies {:optional true} [:vector :id/uuid]]
+   [:task/dependents   {:optional true} [:vector :id/uuid]]
+   [:task/started-at   {:optional true} [:maybe :common/timestamp]]
+   [:task/completed-at {:optional true} [:maybe :common/timestamp]]
+   [:task/elapsed-ms   {:optional true} [:maybe :common/non-neg-int]]
+   [:task/exclusive-files? {:optional true} boolean?]
+   [:task/stratum?         {:optional true} boolean?]])
+
+(def ^{:stratum 0} DecisionCard
+  "A pending or resolved decision request from an agent per N5-δ3 §2.4.
+
+   Today's `:control-plane/decision-created` / `-resolved` events carry a
+   thin payload (id, agent-id, summary, optional priority; resolution on
+   resolve). Richer fields — `:decision/type`, `:decision/context`,
+   `:decision/options`, `:decision/deadline`, `:decision/comment` — are
+   part of the entity shape so future control-plane extensions can
+   surface them; supervisory-state populates only what arrives on the
+   wire, per the open-map rule."
+  [:map {:registry schema/registry}
+   [:decision/id :decision/id]
+   [:decision/agent-id :id/uuid]
+   [:decision/workflow-run-id {:optional true} [:maybe :id/uuid]]
+   [:decision/type {:optional true} [:maybe :decision/type]]
+   [:decision/priority {:optional true} [:maybe :decision/priority]]
+   [:decision/status :decision/status]
+   [:decision/summary string?]
+   [:decision/context  {:optional true} [:maybe string?]]
+   [:decision/options  {:optional true} [:vector string?]]
+   [:decision/deadline {:optional true} [:maybe :common/timestamp]]
+   [:decision/created-at :common/timestamp]
+   [:decision/resolution {:optional true} [:maybe string?]]
+   [:decision/comment    {:optional true} [:maybe string?]]
+   [:decision/resolved-at {:optional true} [:maybe :common/timestamp]]])
+
+(def ^{:stratum 0} InterventionRequest
+  "A bounded supervisory control request per N5 supervisory delta §3.1.
+
+   The type and target-type stay open keywords at this boundary so replay and
+   downstream consumers preserve future spec-aligned additions."
+  [:map {:registry schema/registry}
+   [:intervention/id :intervention/id]
+   [:intervention/type keyword?]
+   [:intervention/target-type keyword?]
+   [:intervention/target-id any?]
+   [:intervention/requested-by [:string {:min 1}]]
+   [:intervention/request-source keyword?]
+   [:intervention/state :intervention/state]
+   [:intervention/requested-at :common/timestamp]
+   [:intervention/updated-at :common/timestamp]
+   [:intervention/justification {:optional true} [:maybe string?]]
+   [:intervention/details {:optional true} [:maybe map?]]
+   [:intervention/approval-required? {:optional true} boolean?]
+   [:intervention/reason {:optional true} [:maybe string?]]
+   [:intervention/outcome {:optional true} any?]])
+
+(def ^{:stratum 0} DependencyHealth
+  "Projected health for an external provider, platform, or user environment."
+  [:map {:registry schema/registry}
+   [:dependency/id :dependency/id]
+   [:dependency/source keyword?]
+   [:dependency/kind :dependency/kind]
+   [:dependency/status :dependency/status]
+   [:dependency/failure-count :common/non-neg-int]
+   [:dependency/window-size :common/non-neg-int]
+   [:dependency/incident-counts [:map-of :dependency/status :common/non-neg-int]]
+   [:dependency/vendor {:optional true} [:maybe keyword?]]
+   [:dependency/class {:optional true} [:maybe keyword?]]
+   [:dependency/retryability {:optional true} [:maybe keyword?]]
+   [:failure/class {:optional true} [:maybe keyword?]]
+   [:dependency/last-observed-at {:optional true} [:maybe :common/timestamp]]
+   [:dependency/last-recovered-at {:optional true} [:maybe :common/timestamp]]])
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Composite entities — fold in the Layer 0 entities above
+(def ^{:stratum 1} PrFleetEntry
+  "A pull request observable in the supervisory PR fleet view (N5/N9).
+
+   The four `:pr/readiness`, `:pr/risk`, `:pr/policy`, `:pr/recommendation`
+   fields are OPTIONAL pre-computed scores produced by the pr-scoring
+   component per N5-delta-2. Absent = \"not yet scored\" (§5.4),
+   distinct from a zero score. Consumers MUST NOT recompute."
+  [:map {:registry schema/registry}
+   [:pr/repo [:string {:min 1}]]
+   [:pr/number :common/non-neg-int]
+   [:pr/url string?]
+   [:pr/branch string?]
+   [:pr/title string?]
+   [:pr/status :pr/status]
+   [:pr/merge-order :common/non-neg-int]
+   [:pr/depends-on [:vector :common/non-neg-int]]
+   [:pr/blocks [:vector :common/non-neg-int]]
+   [:pr/ci-status :pr/ci-status]
+   [:pr/author {:optional true} [:maybe string?]]
+   [:pr/additions {:optional true} [:maybe :common/non-neg-int]]
+   [:pr/deletions {:optional true} [:maybe :common/non-neg-int]]
+   [:pr/changed-files-count {:optional true} [:maybe :common/non-neg-int]]
+   [:pr/behind-main {:optional true} [:maybe boolean?]]
+   [:pr/merged-at {:optional true} [:maybe :common/timestamp]]
+   [:pr/workflow-run-id {:optional true} [:maybe :id/uuid]]
+   [:pr/readiness {:optional true} [:maybe PrReadiness]]
+   [:pr/risk {:optional true} [:maybe PrRisk]]
+   [:pr/policy {:optional true} [:maybe PrPolicy]]
+   [:pr/recommendation {:optional true} [:maybe :pr/recommendation]]])
+
+(def ^{:stratum 1} PolicyEvaluation
+  "Immutable record of a completed policy evaluation per N5-delta-1 §3.1.
+
+  A re-evaluation MUST produce a new record with a fresh `:policy-eval/id`
+   rather than mutate a prior one."
+  [:map {:registry schema/registry}
+   [:policy-eval/id :policy-eval/id]
+   [:policy-eval/workflow-run-id {:optional true} [:maybe :id/uuid]]
+   [:policy-eval/gate-id {:optional true} [:maybe keyword?]]
+   [:policy-eval/target-type {:optional true} [:maybe :policy-eval/target-type]]
+   [:policy-eval/target-id {:optional true} [:maybe any?]]
+   [:policy-eval/passed? boolean?]
+   [:policy-eval/packs-applied [:vector string?]]
+   [:policy-eval/violations [:vector PolicyViolation]]
+   [:policy-eval/evaluated-at :common/timestamp]])
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Component-internal entity table — aggregates every entity above
+(def ^{:stratum 2} EntityTable
+  "Aggregate state held by the supervisory-state component."
+  [:map
+   [:specs         [:map-of :id/uuid Spec]]
+   [:workflows     [:map-of :id/uuid WorkflowRun]]
+   [:agents        [:map-of :id/uuid AgentSession]]
+   [:prs           [:map-of [:tuple string? :common/non-neg-int] PrFleetEntry]]
+   [:policy-evals  [:map-of :id/uuid PolicyEvaluation]]
+   [:attention     [:map-of :id/uuid AttentionItem]]
+   [:tasks         [:map-of :id/uuid TaskNode]]
+   [:decisions     [:map-of :id/uuid DecisionCard]]
+   [:interventions [:map-of :id/uuid InterventionRequest]]
+   [:dependencies  [:map-of :dependency/id DependencyHealth]]])

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/golden_fixtures.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/golden_fixtures.clj
@@ -37,6 +37,7 @@
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.response.interface :as response]
    [ai.miniforge.supervisory-state.emitter :as emitter]
+   [ai.miniforge.supervisory-state.entities :as entities]
    [ai.miniforge.supervisory-state.schema :as schema]
    [clojure.java.io :as io]
    [malli.core :as m]
@@ -342,15 +343,15 @@
    absent by design — those families originate in the miniforge-control
    Rust adapters (N5-delta-3) and their fixtures live with their
    producer."
-  [{:family :workflow-run :ctor emitter/workflow-upserted     :schema schema/WorkflowRun        :entity workflow-run-entity}
-   {:family :spec         :ctor emitter/spec-upserted         :schema schema/Spec               :entity spec-entity}
-   {:family :agent        :ctor emitter/agent-upserted        :schema schema/AgentSession       :entity agent-entity}
-   {:family :pr           :ctor emitter/pr-upserted           :schema schema/PrFleetEntry       :entity pr-entity}
-   {:family :policy-eval  :ctor emitter/policy-evaluated      :schema schema/PolicyEvaluation   :entity policy-eval-entity}
-   {:family :attention    :ctor emitter/attention-derived     :schema schema/AttentionItem      :entity attention-entity}
-   {:family :task-node    :ctor emitter/task-node-upserted    :schema schema/TaskNode           :entity task-node-entity}
-   {:family :decision     :ctor emitter/decision-upserted     :schema schema/DecisionCard       :entity decision-entity}
-   {:family :intervention :ctor emitter/intervention-upserted :schema schema/InterventionRequest :entity intervention-entity}
+  [{:family :workflow-run :ctor emitter/workflow-upserted     :schema entities/WorkflowRun        :entity workflow-run-entity}
+   {:family :spec         :ctor emitter/spec-upserted         :schema entities/Spec               :entity spec-entity}
+   {:family :agent        :ctor emitter/agent-upserted        :schema entities/AgentSession       :entity agent-entity}
+   {:family :pr           :ctor emitter/pr-upserted           :schema entities/PrFleetEntry       :entity pr-entity}
+   {:family :policy-eval  :ctor emitter/policy-evaluated      :schema entities/PolicyEvaluation   :entity policy-eval-entity}
+   {:family :attention    :ctor emitter/attention-derived     :schema entities/AttentionItem      :entity attention-entity}
+   {:family :task-node    :ctor emitter/task-node-upserted    :schema entities/TaskNode           :entity task-node-entity}
+   {:family :decision     :ctor emitter/decision-upserted     :schema entities/DecisionCard       :entity decision-entity}
+   {:family :intervention :ctor emitter/intervention-upserted :schema entities/InterventionRequest :entity intervention-entity}
    {:family :gate-decision :ctor gate-decision-ctor            :schema env/DecisionEnvelope      :entity golden-envelope}])
 
 ;------------------------------------------------------------------------------ Layer 4

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/interface.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.supervisory-state.interface
   "Public API for the supervisory-state component.
 
@@ -27,13 +26,14 @@
   (:require
    [ai.miniforge.supervisory-state.accumulator :as accumulator]
    [ai.miniforge.supervisory-state.core :as core]
+   [ai.miniforge.supervisory-state.entities :as entities]
    [ai.miniforge.supervisory-state.golden-fixtures :as golden-fixtures]
    [ai.miniforge.supervisory-state.schema :as schema]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Contract version + golden fixtures
 
-(def schema-version
+;; Contract version + golden fixtures
+(def ^{:stratum 0} schema-version
   "Version of the supervisory entity contract, stamped as
    `:supervisory/schema-version` on every supervisory snapshot event
    (N3 §3.19, including `:supervisory/policy-evaluated` and
@@ -41,7 +41,7 @@
    `schema/schema-version`."
   schema/schema-version)
 
-(def write-golden-fixtures!
+(def ^{:stratum 0} write-golden-fixtures!
   "Write the canonical golden fixtures — one pinned, schema-validated
    `:supervisory/*-upserted` event per entity family, serialized through
    the production transit encoder — plus `manifest.edn` into `:out-dir`.
@@ -50,155 +50,149 @@
    compatible; see the `fixtures:supervisory` bb task."
   golden-fixtures/write-golden-fixtures!)
 
-(def empty-table
+(def ^{:stratum 0} empty-table
   "Initial empty EntityTable. Seed value for [[apply-event]] /
    [[apply-events]] when folding an event sequence without a component."
   schema/empty-table)
 
-(def apply-event
+(def ^{:stratum 0} apply-event
   "Pure reducer: apply one event to an EntityTable, returning the (possibly
    identical) updated table. Unknown event types are ignored at the entity
    level. Lets consumers (replay tooling, workbench adapters, tests)
    materialize a table from an event sequence without a live stream."
   accumulator/apply-event)
 
-(def apply-events
+(def ^{:stratum 0} apply-events
   "Pure fold of an event sequence into an EntityTable via [[apply-event]]."
   accumulator/apply-events)
 
-;------------------------------------------------------------------------------ Layer 0
 ;; Schemas (re-exports)
-
-(def Spec
+(def ^{:stratum 0} Spec
   "Malli `[:map ...]` schema (open) for a long-lived Spec — the operator's
    top-level unit of work that owns N WorkflowRuns over its lifetime
    (N5-delta-3 §3.1, §5.1)."
-  schema/Spec)
+  entities/Spec)
 
-(def WorkflowRun
+(def ^{:stratum 0} WorkflowRun
   "Malli `[:map ...]` schema (open) for a WorkflowRun — one concrete
    execution instance of a workflow (N5-delta-1 §3.1)."
-  schema/WorkflowRun)
+  entities/WorkflowRun)
 
-(def AgentSession
+(def ^{:stratum 0} AgentSession
   "Malli `[:map ...]` schema (open) for an AgentSession — an external or
    internal agent observable to the supervisory plane (N5-delta-1 §3.3)."
-  schema/AgentSession)
+  entities/AgentSession)
 
-(def PrFleetEntry
+(def ^{:stratum 0} PrFleetEntry
   "Malli `[:map ...]` schema (open) for a PrFleetEntry — a pull request in
    the supervisory PR fleet view, with optional pre-computed readiness/risk/
    policy/recommendation scores (N5-delta-2)."
-  schema/PrFleetEntry)
+  entities/PrFleetEntry)
 
-(def PolicyEvaluation
+(def ^{:stratum 0} PolicyEvaluation
   "Malli `[:map ...]` schema (open) for a PolicyEvaluation — an immutable
    record of a completed policy evaluation (N5-delta-1 §3.1)."
-  schema/PolicyEvaluation)
+  entities/PolicyEvaluation)
 
-(def PolicyViolation
+(def ^{:stratum 0} PolicyViolation
   "Malli `[:map ...]` schema (open) for a PolicyViolation — a single rule
    failure within a PolicyEvaluation (N5-delta-1 §3.1)."
-  schema/PolicyViolation)
+  entities/PolicyViolation)
 
-(def AttentionItem
+(def ^{:stratum 0} AttentionItem
   "Malli `[:map ...]` schema (open) for an AttentionItem — a derived
    supervisory signal (N5-delta-1 §3.1 + §5)."
-  schema/AttentionItem)
+  entities/AttentionItem)
 
-(def InterventionRequest
+(def ^{:stratum 0} InterventionRequest
   "Malli `[:map ...]` schema (open) for an InterventionRequest — a bounded
    supervisory control request (N5 supervisory delta §3.1)."
-  schema/InterventionRequest)
+  entities/InterventionRequest)
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Lifecycle
-
-(def create
+(def ^{:stratum 0} create
   "Build a fresh supervisory-state component instance bound to `stream`.
    Returns an atom holding the component state; does not subscribe yet —
    call `start!` to begin consuming events."
   core/create)
 
-(def start!
+(def ^{:stratum 0} start!
   "Subscribe the component to its stream so it begins materializing the
    entity table from live events. Idempotent — repeat calls are no-ops.
    Returns the component. No startup replay of the event log."
   core/start!)
 
-(def stop!
+(def ^{:stratum 0} stop!
   "Unsubscribe the component from its stream. The entity table is retained
    so it stays queryable post-shutdown. Returns the component."
   core/stop!)
 
-(def attach!
+(def ^{:stratum 0} attach!
   "Create a component bound to `stream` and start it in one step
    (create + start!). Returns the started component."
   core/attach!)
 
-(def attached?
+(def ^{:stratum 0} attached?
   "True when supervisory-state is already subscribed to `stream`; false
    otherwise. Returns boolean."
   core/attached?)
 
-(def ensure-attached!
+(def ^{:stratum 0} ensure-attached!
   "Attach supervisory-state to `stream` exactly once, synchronized per
    stream so concurrent callers cannot double-attach. Returns a new
    component when an attachment is created; otherwise nil."
   core/ensure-attached!)
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Query API (reads only; consumers should prefer subscribing to
 ;; `:supervisory/*-upserted` events on the event stream)
-
-(def table
+(def ^{:stratum 0} table
   "Current entity table snapshot for `component` (pure read). Returns the
    EntityTable map: keys `:specs :workflows :agents :prs :policy-evals
    :attention :tasks :decisions :interventions :dependencies`, each a map
    of id -> entity."
   core/table)
 
-(def specs
+(def ^{:stratum 0} specs
   "All Spec entities in `component`. Returns a seq of Spec maps (empty when
    none)."
   core/specs)
 
-(def workflows
+(def ^{:stratum 0} workflows
   "All WorkflowRun entities in `component`. Returns a seq of WorkflowRun
    maps (empty when none)."
   core/workflows)
 
-(def agents
+(def ^{:stratum 0} agents
   "All AgentSession entities in `component`. Returns a seq of AgentSession
    maps (empty when none)."
   core/agents)
 
-(def prs
+(def ^{:stratum 0} prs
   "All PrFleetEntry entities in `component`. Returns a seq of PrFleetEntry
    maps (empty when none)."
   core/prs)
 
-(def policy-evals
+(def ^{:stratum 0} policy-evals
   "All PolicyEvaluation entities in `component`. Returns a seq of
    PolicyEvaluation maps (empty when none)."
   core/policy-evals)
 
-(def attention
+(def ^{:stratum 0} attention
   "All derived AttentionItem entities in `component`. Returns a seq of
    AttentionItem maps (empty when none)."
   core/attention)
 
-(def tasks
+(def ^{:stratum 0} tasks
   "All TaskNode entities in `component`. Returns a seq of TaskNode maps
    (empty when none)."
   core/tasks)
 
-(def decisions
+(def ^{:stratum 0} decisions
   "All DecisionCard entities in `component`. Returns a seq of DecisionCard
    maps (empty when none)."
   core/decisions)
 
-(def interventions
+(def ^{:stratum 0} interventions
   "All InterventionRequest entities in `component`. Returns a seq of
    InterventionRequest maps (empty when none)."
   core/interventions)

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/schema.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/schema.clj
@@ -16,7 +16,9 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns ai.miniforge.supervisory-state.schema
-  "Open Malli schemas for the canonical supervisory entities.
+  "Open Malli vocabulary for the canonical supervisory entities: contract
+   version, enums, the Malli registry, the standalone PR-scoring sub-schemas,
+   and the empty EntityTable seed.
 
    Mirrors N5-delta-supervisory-control-plane §3.1 and the Rust
    supervisory-entities crate (`miniforge-control/contracts/crates/
@@ -26,8 +28,14 @@
    in `ai.miniforge.schema.supervisory` which were never wired into a
    producer.
 
-   All maps are open (additional keys pass through) per
-   N5-delta-1 §12.4."
+   All maps are open (additional keys pass through) per N5-delta-1 §12.4.
+
+   The ten canonical entity schemas (WorkflowRun, Spec, AgentSession,
+   PrFleetEntry, PolicyEvaluation, PolicyViolation, AttentionItem, TaskNode,
+   DecisionCard, InterventionRequest, DependencyHealth) and the aggregate
+   EntityTable live in `ai.miniforge.supervisory-state.entities` — they
+   compose the `registry` defined here, which pushed this namespace over
+   the 3-layer stratum budget when they lived in one file (SL003, Wave 2)."
   (:require
    [ai.miniforge.schema.interface :as shared]))
 
@@ -151,8 +159,8 @@
   [:draft :active :completed :archived])
 
 ;; Per-PR scoring sub-entities (N5-delta-2 §2). All three are OPTIONAL on
-;; PrFleetEntry: absent = "not yet scored", per §5.4 — distinct from a
-;; score of zero.
+;; PrFleetEntry (`ai.miniforge.supervisory-state.entities`): absent = "not
+;; yet scored", per §5.4 — distinct from a score of zero.
 (def ^{:stratum 0} ReadinessFactor
   "One factor breakdown row from pr-train.readiness/explain-readiness
    per N5-delta-2 §2.1."
@@ -174,8 +182,9 @@
 
 (def ^{:stratum 0} PolicyViolationSummary
   "Per-violation display row on PrPolicy per N5-delta-2 §2.3. Distinct
-   from the authoritative PolicyViolation entity (§3.1 N5-delta-1) —
-   this is a display-facing projection."
+   from the authoritative PolicyViolation entity (§3.1 N5-delta-1,
+   `ai.miniforge.supervisory-state.entities`) — this is a display-facing
+   projection."
   [:map
    [:rule-id keyword?]
    [:severity :violation/severity]
@@ -211,7 +220,6 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
-;------------------------------------------------------------------------------ Layer 0a
 ;; Registry extensions for supervisory v1
 (def ^{:stratum 1} registry
   "Malli registry for supervisory v1 keyword types.
@@ -221,7 +229,11 @@
    depending on `ai.miniforge.schema.core/registry`. That registry is
    intentionally not on the schema component's public interface, and
    duplicating 3 lines here keeps supervisory-state from reaching across
-   a Polylith boundary."
+   a Polylith boundary.
+
+   Consumed by the entity schemas in `ai.miniforge.supervisory-state.entities`
+   via `{:registry registry}` — that same-namespace reference back to a
+   value defined here is what makes this a genuine second layer."
   {;; Primitives
    :id/uuid            uuid?
    :common/timestamp   inst?
@@ -287,297 +299,3 @@
    ;; spec identity at run-start time only.
    :spec/id                      :id/uuid
    :spec/status                  (into [:enum] spec-statuses)})
-
-;------------------------------------------------------------------------------ Layer 2
-
-;; Entity schemas — open maps, mirror N5-delta-1 §3.1
-(def ^{:stratum 2} WorkflowRun
-  "A concrete execution instance of a workflow per N5-delta-1 §3.1.
-
-   Open: additional keys pass through validation."
-  [:map {:registry registry}
-   [:workflow-run/id :workflow-run/id]
-   [:workflow-run/workflow-key [:string {:min 1}]]
-   [:workflow-run/intent string?]
-   [:workflow-run/status :workflow-run/status]
-   [:workflow-run/current-phase keyword?]
-   [:workflow-run/started-at :common/timestamp]
-   [:workflow-run/updated-at :common/timestamp]
-   [:workflow-run/trigger-source :workflow-run/trigger-source]
-   [:workflow-run/correlation-id :id/uuid]
-   [:workflow-run/artifact-ids {:optional true} [:vector :id/uuid]]
-   [:workflow-run/evidence-bundle-id {:optional true} [:maybe :id/uuid]]
-   ;; BD-1: canonical run-owned spec identity. Lifted from `:workflow/spec`
-   ;; on the lifecycle event so consumers do not have to recover it from
-   ;; correlated agent metadata. Open: producers may add further `:spec/*`
-   ;; keys without a contract bump.
-   [:workflow-run/spec {:optional true}
-    [:map
-     [:spec/title       {:optional true} [:string {:min 1}]]
-     [:spec/description {:optional true} [:string {:min 1}]]
-     [:spec/intent      {:optional true} map?]]]
-   ;; N14: foreign key to the long-lived `Spec` entity that owns this
-   ;; run. Optional — runs without a derivable spec identity (no title
-   ;; on the snapshot) remain Specless. Distinct from
-   ;; `:workflow-run/spec` (the per-run snapshot above) and stable
-   ;; across re-executions of the same spec.
-   [:workflow-run/spec-id {:optional true} :spec/id]
-   [:workflow-run/prs {:optional true}
-    [:vector
-     [:map
-      [:pr/repo [:string {:min 1}]]
-      [:pr/number :common/non-neg-int]
-      [:pr/url string?]
-      [:pr/branch string?]
-      [:pr/title {:optional true} [:maybe string?]]
-      [:pr/author {:optional true} [:maybe string?]]
-      [:pr/merge-order {:optional true} [:maybe :common/non-neg-int]]]]]])
-
-(def ^{:stratum 2} Spec
-  "A long-lived supervisory entity representing the operator's
-   top-level unit of work (N5-delta-3 §3.1, §5.1). One Spec owns N
-   WorkflowRuns over its lifetime.
-
-   Open map: additional keys pass through validation. Field types
-   chosen to be compatible with the existing per-run snapshot
-   (`:workflow-run/spec` above) and the spec-parser's `SpecIntent`
-   shape:
-
-   - `:spec/intent` is a structured map (per `SpecIntent` in
-     `spec-parser/.../schema.clj`); kept as open `map?` here so we
-     don't re-validate against the producer-side schema.
-   - `:spec/tags` accepts strings OR keywords (existing tag
-     conventions elsewhere in the codebase).
-   - `:spec/origin` discriminates `:miniforge` (specs known to this
-     runtime) from `:local-synthetic` (the Rust-core consumer
-     creates these ahead of upstream knowing about them, per
-     N5-delta-3 §5.3 reconciliation)."
-  [:map {:registry registry}
-   [:spec/id         :spec/id]
-   [:spec/title      [:string {:min 1}]]
-   [:spec/status     :spec/status]
-   [:spec/created-at :common/timestamp]
-   [:spec/updated-at :common/timestamp]
-   [:spec/description {:optional true} :string]
-   [:spec/intent      {:optional true} map?]
-   [:spec/repo-url    {:optional true} :string]
-   [:spec/tags        {:optional true} [:vector [:or :string :keyword]]]
-   [:spec/origin      {:optional true} keyword?]])
-
-(def ^{:stratum 2} AgentSession
-  "An external or internal agent observable to the supervisory plane.
-
-   Mirrors the Rust supervisory-entities `AgentSession` shape. The
-   control-plane/registry component (N5-delta-1 §3.3) is the in-process
-   source; supervisory-state mirrors it from `:control-plane/agent-*` events."
-  [:map {:registry registry}
-   [:agent/id :id/uuid]
-   [:agent/vendor [:string {:min 1}]]
-   [:agent/external-id [:string {:min 1}]]
-   [:agent/name [:string {:min 1}]]
-   [:agent/status :agent/status]
-   [:agent/capabilities [:vector keyword?]]
-   [:agent/heartbeat-interval-ms :common/non-neg-int]
-   [:agent/metadata [:map-of any? any?]]
-   [:agent/tags [:vector string?]]
-   [:agent/registered-at :common/timestamp]
-   [:agent/last-heartbeat :common/timestamp]
-   [:agent/task {:optional true} [:maybe string?]]])
-
-(def ^{:stratum 2} PrReadiness
-  "Merge-readiness score block per N5-delta-2 §2.1."
-  [:map {:registry registry}
-   [:readiness/score number?]
-   [:readiness/threshold number?]
-   [:readiness/ready? boolean?]
-   [:readiness/factors [:vector ReadinessFactor]]])
-
-(def ^{:stratum 2} PrRisk
-  "Risk-assessment score block per N5-delta-2 §2.2."
-  [:map {:registry registry}
-   [:risk/score number?]
-   [:risk/level :risk/level]
-   [:risk/factors [:vector RiskFactor]]])
-
-(def ^{:stratum 2} PrPolicy
-  "Aggregated external-PR policy result per N5-delta-2 §2.3."
-  [:map {:registry registry}
-   [:policy/overall :policy/overall]
-   [:policy/packs-applied [:vector string?]]
-   [:policy/summary PolicyCounts]
-   [:policy/violations [:vector PolicyViolationSummary]]
-   [:policy/artifacts-checked {:optional true} [:maybe :common/non-neg-int]]])
-
-(def ^{:stratum 2} PolicyViolation
-  "A single rule failure within a PolicyEvaluation per N5-delta-1 §3.1."
-  [:map {:registry registry}
-   [:violation/rule-id keyword?]
-   [:violation/severity :violation/severity]
-   [:violation/category :violation/category]
-   [:violation/message [:string {:min 1}]]
-   [:violation/location {:optional true} [:maybe string?]]
-   [:violation/remediable? boolean?]])
-
-(def ^{:stratum 2} AttentionItem
-  "A derived supervisory signal per N5-delta-1 §3.1 + §5."
-  [:map {:registry registry}
-   [:attention/id :attention/id]
-   [:attention/severity :attention/severity]
-   [:attention/source-type :attention/source-type]
-   [:attention/source-id any?]
-   [:attention/summary [:string {:min 1}]]
-   [:attention/derived-at :common/timestamp]
-   [:attention/resolved? boolean?]])
-
-(def ^{:stratum 2} TaskNode
-  "A single DAG task observable in the Kanban view (N5 §3.2.5 / N5-δ3 §2.3).
-
-   `:task/status` is an OPEN keyword — workflow families may add their own
-   statuses via the DAG state-profile system. `:task/kanban-column` is the
-   closed display contract derived from status + dependency resolution per
-   N5-δ3 §2.3's status→column table; unknown statuses fall back to
-   `:blocked` so they surface visibly."
-  [:map {:registry registry}
-   [:task/id :task/id]
-   [:task/workflow-run-id :id/uuid]
-   [:task/description string?]
-   [:task/type {:optional true} [:maybe keyword?]]
-   [:task/component {:optional true} [:maybe string?]]
-   [:task/status keyword?]
-   [:task/kanban-column :task/kanban-column]
-   [:task/dependencies {:optional true} [:vector :id/uuid]]
-   [:task/dependents   {:optional true} [:vector :id/uuid]]
-   [:task/started-at   {:optional true} [:maybe :common/timestamp]]
-   [:task/completed-at {:optional true} [:maybe :common/timestamp]]
-   [:task/elapsed-ms   {:optional true} [:maybe :common/non-neg-int]]
-   [:task/exclusive-files? {:optional true} boolean?]
-   [:task/stratum?         {:optional true} boolean?]])
-
-(def ^{:stratum 2} DecisionCard
-  "A pending or resolved decision request from an agent per N5-δ3 §2.4.
-
-   Today's `:control-plane/decision-created` / `-resolved` events carry a
-   thin payload (id, agent-id, summary, optional priority; resolution on
-   resolve). Richer fields — `:decision/type`, `:decision/context`,
-   `:decision/options`, `:decision/deadline`, `:decision/comment` — are
-   part of the entity shape so future control-plane extensions can
-   surface them; supervisory-state populates only what arrives on the
-   wire, per the open-map rule."
-  [:map {:registry registry}
-   [:decision/id :decision/id]
-   [:decision/agent-id :id/uuid]
-   [:decision/workflow-run-id {:optional true} [:maybe :id/uuid]]
-   [:decision/type {:optional true} [:maybe :decision/type]]
-   [:decision/priority {:optional true} [:maybe :decision/priority]]
-   [:decision/status :decision/status]
-   [:decision/summary string?]
-   [:decision/context  {:optional true} [:maybe string?]]
-   [:decision/options  {:optional true} [:vector string?]]
-   [:decision/deadline {:optional true} [:maybe :common/timestamp]]
-   [:decision/created-at :common/timestamp]
-   [:decision/resolution {:optional true} [:maybe string?]]
-   [:decision/comment    {:optional true} [:maybe string?]]
-   [:decision/resolved-at {:optional true} [:maybe :common/timestamp]]])
-
-(def ^{:stratum 2} InterventionRequest
-  "A bounded supervisory control request per N5 supervisory delta §3.1.
-
-   The type and target-type stay open keywords at this boundary so replay and
-   downstream consumers preserve future spec-aligned additions."
-  [:map {:registry registry}
-   [:intervention/id :intervention/id]
-   [:intervention/type keyword?]
-   [:intervention/target-type keyword?]
-   [:intervention/target-id any?]
-   [:intervention/requested-by [:string {:min 1}]]
-   [:intervention/request-source keyword?]
-   [:intervention/state :intervention/state]
-   [:intervention/requested-at :common/timestamp]
-   [:intervention/updated-at :common/timestamp]
-   [:intervention/justification {:optional true} [:maybe string?]]
-   [:intervention/details {:optional true} [:maybe map?]]
-   [:intervention/approval-required? {:optional true} boolean?]
-   [:intervention/reason {:optional true} [:maybe string?]]
-   [:intervention/outcome {:optional true} any?]])
-
-(def ^{:stratum 2} DependencyHealth
-  "Projected health for an external provider, platform, or user environment."
-  [:map {:registry registry}
-   [:dependency/id :dependency/id]
-   [:dependency/source keyword?]
-   [:dependency/kind :dependency/kind]
-   [:dependency/status :dependency/status]
-   [:dependency/failure-count :common/non-neg-int]
-   [:dependency/window-size :common/non-neg-int]
-   [:dependency/incident-counts [:map-of :dependency/status :common/non-neg-int]]
-   [:dependency/vendor {:optional true} [:maybe keyword?]]
-   [:dependency/class {:optional true} [:maybe keyword?]]
-   [:dependency/retryability {:optional true} [:maybe keyword?]]
-   [:failure/class {:optional true} [:maybe keyword?]]
-   [:dependency/last-observed-at {:optional true} [:maybe :common/timestamp]]
-   [:dependency/last-recovered-at {:optional true} [:maybe :common/timestamp]]])
-
-;------------------------------------------------------------------------------ Layer 3
-
-(def ^{:stratum 3} PrFleetEntry
-  "A pull request observable in the supervisory PR fleet view (N5/N9).
-
-   The four `:pr/readiness`, `:pr/risk`, `:pr/policy`, `:pr/recommendation`
-   fields are OPTIONAL pre-computed scores produced by the pr-scoring
-   component per N5-delta-2. Absent = \"not yet scored\" (§5.4),
-   distinct from a zero score. Consumers MUST NOT recompute."
-  [:map {:registry registry}
-   [:pr/repo [:string {:min 1}]]
-   [:pr/number :common/non-neg-int]
-   [:pr/url string?]
-   [:pr/branch string?]
-   [:pr/title string?]
-   [:pr/status :pr/status]
-   [:pr/merge-order :common/non-neg-int]
-   [:pr/depends-on [:vector :common/non-neg-int]]
-   [:pr/blocks [:vector :common/non-neg-int]]
-   [:pr/ci-status :pr/ci-status]
-   [:pr/author {:optional true} [:maybe string?]]
-   [:pr/additions {:optional true} [:maybe :common/non-neg-int]]
-   [:pr/deletions {:optional true} [:maybe :common/non-neg-int]]
-   [:pr/changed-files-count {:optional true} [:maybe :common/non-neg-int]]
-   [:pr/behind-main {:optional true} [:maybe boolean?]]
-   [:pr/merged-at {:optional true} [:maybe :common/timestamp]]
-   [:pr/workflow-run-id {:optional true} [:maybe :id/uuid]]
-   [:pr/readiness {:optional true} [:maybe PrReadiness]]
-   [:pr/risk {:optional true} [:maybe PrRisk]]
-   [:pr/policy {:optional true} [:maybe PrPolicy]]
-   [:pr/recommendation {:optional true} [:maybe :pr/recommendation]]])
-
-(def ^{:stratum 3} PolicyEvaluation
-  "Immutable record of a completed policy evaluation per N5-delta-1 §3.1.
-
-  A re-evaluation MUST produce a new record with a fresh `:policy-eval/id`
-   rather than mutate a prior one."
-  [:map {:registry registry}
-   [:policy-eval/id :policy-eval/id]
-   [:policy-eval/workflow-run-id {:optional true} [:maybe :id/uuid]]
-   [:policy-eval/gate-id {:optional true} [:maybe keyword?]]
-   [:policy-eval/target-type {:optional true} [:maybe :policy-eval/target-type]]
-   [:policy-eval/target-id {:optional true} [:maybe any?]]
-   [:policy-eval/passed? boolean?]
-   [:policy-eval/packs-applied [:vector string?]]
-   [:policy-eval/violations [:vector PolicyViolation]]
-   [:policy-eval/evaluated-at :common/timestamp]])
-
-;------------------------------------------------------------------------------ Layer 4
-
-;; Component-internal entity table
-(def ^{:stratum 4} EntityTable
-  "Aggregate state held by the supervisory-state component."
-  [:map
-   [:specs         [:map-of :id/uuid Spec]]
-   [:workflows     [:map-of :id/uuid WorkflowRun]]
-   [:agents        [:map-of :id/uuid AgentSession]]
-   [:prs           [:map-of [:tuple string? :common/non-neg-int] PrFleetEntry]]
-   [:policy-evals  [:map-of :id/uuid PolicyEvaluation]]
-   [:attention     [:map-of :id/uuid AttentionItem]]
-   [:tasks         [:map-of :id/uuid TaskNode]]
-   [:decisions     [:map-of :id/uuid DecisionCard]]
-   [:interventions [:map-of :id/uuid InterventionRequest]]
-   [:dependencies  [:map-of :dependency/id DependencyHealth]]])

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/schema.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/schema.clj
@@ -30,12 +30,13 @@
 
    All maps are open (additional keys pass through) per N5-delta-1 §12.4.
 
-   The ten canonical entity schemas (WorkflowRun, Spec, AgentSession,
-   PrFleetEntry, PolicyEvaluation, PolicyViolation, AttentionItem, TaskNode,
-   DecisionCard, InterventionRequest, DependencyHealth) and the aggregate
-   EntityTable live in `ai.miniforge.supervisory-state.entities` — they
-   compose the `registry` defined here, which pushed this namespace over
-   the 3-layer stratum budget when they lived in one file (SL003, Wave 2)."
+   The twelve canonical entity schemas (WorkflowRun, Spec, AgentSession,
+   PrReadiness, PrRisk, PrPolicy, PolicyViolation, AttentionItem, TaskNode,
+   DecisionCard, InterventionRequest, DependencyHealth), the composite
+   PrFleetEntry/PolicyEvaluation, and the aggregate EntityTable live in
+   `ai.miniforge.supervisory-state.entities` — they compose the `registry`
+   defined here, which pushed this namespace over the 3-layer stratum
+   budget when they lived in one file (SL003, Wave 2)."
   (:require
    [ai.miniforge.schema.interface :as shared]))
 
@@ -231,9 +232,11 @@
    duplicating 3 lines here keeps supervisory-state from reaching across
    a Polylith boundary.
 
-   Consumed by the entity schemas in `ai.miniforge.supervisory-state.entities`
-   via `{:registry registry}` — that same-namespace reference back to a
-   value defined here is what makes this a genuine second layer."
+   Composes the same-file Layer 0 enums (`workflow-run-statuses`,
+   `violation-severities`, `risk-levels`, etc.) into their `:workflow-run/
+   status`-style keyword entries below — that's what makes this a genuine
+   second layer. Consumed cross-namespace by the entity schemas in
+   `ai.miniforge.supervisory-state.entities` via `{:registry schema/registry}`."
   {;; Primitives
    :id/uuid            uuid?
    :common/timestamp   inst?

--- a/components/supervisory-state/test/ai/miniforge/supervisory_state/golden_fixtures_test.clj
+++ b/components/supervisory-state/test/ai/miniforge/supervisory_state/golden_fixtures_test.clj
@@ -27,6 +27,7 @@
    [ai.miniforge.supervisory-state.attention :as attention]
    [ai.miniforge.decision-envelope.interface :as env]
    [ai.miniforge.response.interface :as response]
+   [ai.miniforge.supervisory-state.entities :as entities]
    [ai.miniforge.supervisory-state.golden-fixtures :as golden-fixtures]
    [ai.miniforge.supervisory-state.schema :as schema]
    [clojure.java.io :as io]
@@ -63,22 +64,22 @@
   8)
 
 (def ^{:stratum 0} ^:private family->schema
-  {:workflow-run schema/WorkflowRun
-   :spec         schema/Spec
-   :agent        schema/AgentSession
-   :pr           schema/PrFleetEntry
-   :policy-eval  schema/PolicyEvaluation
-   :attention    schema/AttentionItem
-   :task-node    schema/TaskNode
-   :decision     schema/DecisionCard
-   :intervention schema/InterventionRequest
+  {:workflow-run entities/WorkflowRun
+   :spec         entities/Spec
+   :agent        entities/AgentSession
+   :pr           entities/PrFleetEntry
+   :policy-eval  entities/PolicyEvaluation
+   :attention    entities/AttentionItem
+   :task-node    entities/TaskNode
+   :decision     entities/DecisionCard
+   :intervention entities/InterventionRequest
    :gate-decision env/DecisionEnvelope})
 
 (deftest ^{:stratum 0} validate-result-returns-anomaly-for-invalid-entity
   (testing "invalid golden fixture entities are represented as anomaly data"
     (let [result (@#'golden-fixtures/validate-result
                   :workflow-run
-                  schema/WorkflowRun
+                  entities/WorkflowRun
                   {:not :valid})]
       (is (response/anomaly-map? result))
       (is (= :anomalies/incorrect (:anomaly/category result)))

--- a/docs/pull-requests/2026-07-28-fix-stratum-lint-supervisory-state-schema-split.md
+++ b/docs/pull-requests/2026-07-28-fix-stratum-lint-supervisory-state-schema-split.md
@@ -1,0 +1,320 @@
+<!--
+  Title: Split supervisory-state's schema.clj to clear SL003 (Wave 2)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix(supervisory-state): split schema.clj to clear the 3-layer stratum budget (SL003, Wave 2)
+
+## Overview
+
+`components/supervisory-state/src/ai/miniforge/supervisory_state/schema.clj`
+(583 lines) reported `stratum-lint`'s `SL003`: 5 distinct layers against
+the 3-layer budget (rule 210). Unlike the Wave 1 `--fix`-only PRs, this is
+a genuine over-budget file, not a decorative-heading mislabel — the same-
+file reference graph really is 5 deep. Split by hand into two namespaces,
+each landing at ≤ 3 real layers:
+
+- `schema.clj` (kept name) — contract version, enums, the Malli `registry`,
+  the four standalone PR-scoring sub-schemas (`ReadinessFactor`,
+  `RiskFactor`, `PolicyViolationSummary`, `PolicyCounts`), and the
+  `empty-table` seed. 2 real layers (enums/sub-schemas → `registry`).
+- `entities.clj` (new) — the ten canonical supervisory entity schemas plus
+  the aggregate `EntityTable`. 3 real layers (entities that only compose
+  `schema/registry` → `PrFleetEntry`/`PolicyEvaluation`, which compose
+  sibling entities in this file → `EntityTable`, which composes both).
+
+## Motivation
+
+Confirmed the baseline with a fresh plain-lint run before touching
+anything:
+
+```text
+components/supervisory-state/src/ai/miniforge/supervisory_state/schema.clj:568:1: SL003 file uses 5 distinct layers (max 3); split the namespace or extract a component
+```
+
+Reconstructed the file's actual same-file reference graph (not the
+existing — partially decorative — headings) by tracing which `def`s
+appear as bare symbols inside another `def`'s body:
+
+- **Layer 0** (26 defs): every enum vector, the four PR-scoring
+  sub-schemas (`ReadinessFactor`, `RiskFactor`, `PolicyViolationSummary`,
+  `PolicyCounts` — none reference `registry` or each other), and
+  `empty-table` (a plain literal map).
+- **Layer 1**: `registry`, which calls `(into [:enum] <layer-0-enum>)`
+  for ~20 of the Layer 0 enums — a real same-file dependency.
+- **Layer 2**: `WorkflowRun`, `Spec`, `AgentSession`, `PrReadiness`,
+  `PrRisk`, `PrPolicy`, `PolicyViolation`, `AttentionItem`, `TaskNode`,
+  `DecisionCard`, `InterventionRequest`, `DependencyHealth` — all consume
+  `registry` via `{:registry registry}`, and `PrReadiness`/`PrRisk`/
+  `PrPolicy` additionally reference the Layer 0 sub-schemas.
+- **Layer 3**: `PrFleetEntry` (composes `PrReadiness`/`PrRisk`/`PrPolicy`)
+  and `PolicyEvaluation` (composes `PolicyViolation`) — both same-file
+  references to Layer 2 defs.
+- **Layer 4**: `EntityTable`, which composes entities from both Layer 2
+  and Layer 3.
+
+Five real layers, matching the lint finding exactly — this ruled out a
+mechanical `--fix` (which only re-labels headings; it does not move code
+across files) and confirmed a genuine split was needed, per the file's
+own `SL003` message ("split the namespace or extract a component") and
+this repo's `languages/clojure` (210) namespace-splitting strategy.
+
+The split follows 210's guidance for `schema.clj`/`spec.clj`-shaped files
+directly: "if it's over budget it's likely because schemas reference/
+compose other schemas, creating layered dependency. Split by schema
+domain/grouping." The natural domain cut here is *vocabulary* (enums,
+registry, the four leaf sub-schemas that don't need the registry) versus
+*entities* (the ten canonical open-map entities the registry exists to
+serve, plus their two composites and the aggregate table) — not a finer
+per-entity split, since every entity in the "entities" group only
+depends on `registry` (an external reference once moved) and therefore
+lands at the same real layer as its siblings; only the two composites
+(`PrFleetEntry`, `PolicyEvaluation`) and the aggregate (`EntityTable`)
+add genuine additional layers.
+
+## Changes in Detail
+
+- **`schema.clj`** — kept the file name (per this component's convention
+  that `schema.clj` is the canonical Malli-schemas namespace) and kept
+  every symbol that stays a pure Layer 0/1 vocabulary def: `schema-
+  version`, all 21 enum vectors, `ReadinessFactor`, `RiskFactor`,
+  `PolicyViolationSummary`, `PolicyCounts`, `empty-table` (moved up next
+  to the other Layer 0 defs — it was previously sandwiched after the
+  `Layer 1` heading behind a stale, decorative `;---- Layer 0a` sub-
+  banner left over from an earlier ad hoc heading scheme; that stray
+  banner is deleted, matching the same tool-limitation class the Wave 1
+  `components/schema` PR hit and hand-fixed), and `registry`. Updated the
+  namespace docstring and a few in-line comments to point at
+  `ai.miniforge.supervisory-state.entities` for the symbols that moved,
+  instead of describing them in place. No `^{:stratum n}` metadata values
+  changed on anything that stayed (`empty-table` was already correctly
+  tagged `0`; only its physical position moved).
+- **`entities.clj`** (new) — the ten entity schemas, `PrFleetEntry`,
+  `PolicyEvaluation`, and `EntityTable`, moved verbatim (docstrings,
+  comments, key ordering unchanged) with two mechanical edits: every
+  `{:registry registry}` became `{:registry schema/registry}`, and the
+  four references to the sub-schemas that stayed behind became
+  `schema/ReadinessFactor`, `schema/RiskFactor`, `schema/PolicyCounts`,
+  `schema/PolicyViolationSummary`. Re-derived `^{:stratum n}` metadata
+  and headings for the new, shallower real depth (12 entities at Layer 0,
+  `PrFleetEntry`/`PolicyEvaluation` at Layer 1, `EntityTable` at Layer 2)
+  — confirmed byte-identical to the pre-split defs otherwise via a
+  normalized diff (substituting the qualified refs back to bare symbols
+  and comparing against the deleted block: zero content diff, only
+  heading/stratum-number lines differ).
+- **`interface.clj`** — added `[ai.miniforge.supervisory-state.entities
+  :as entities]` and repointed the eight re-exported entity schemas
+  (`Spec`, `WorkflowRun`, `AgentSession`, `PrFleetEntry`,
+  `PolicyEvaluation`, `PolicyViolation`, `AttentionItem`,
+  `InterventionRequest`) from `schema/X` to `entities/X`. `schema-
+  version` and `empty-table` re-exports are untouched — those symbols
+  did not move. By hand, this PR did not otherwise touch the file's
+  pre-existing `SL002` finding (a duplicate `Layer 0` heading, present
+  before this change and unrelated to the schema split) — but staging
+  the file triggered the repo's standard pre-commit `lint:stratum`
+  autofix, which resolved it as a mechanical side effect (headings +
+  `^{:stratum n}` metadata only — see Testing Plan item 9 and Deployment
+  Plan).
+- **`golden_fixtures.clj`** — added the `entities` require and repointed
+  the nine `:schema` values in the `families` table (used to validate
+  each golden fixture entity before serializing it) from `schema/X` to
+  `entities/X`. The two `schema/schema-version` uses are untouched.
+- **`golden_fixtures_test.clj`** — same-component test file that referred
+  to entity schemas directly (not through `.interface`, which is allowed
+  for same-component tests per rule 210's Polylith boundary — only
+  *cross-component* deps must go through `.interface`); added the
+  `entities` require and repointed `family->schema` and the one direct
+  `schema/WorkflowRun` use in `validate-result-returns-anomaly-for-
+  invalid-entity`. `schema/schema-version` is untouched.
+- Grepped the whole repo for `ai.miniforge.supervisory-state.schema`
+  before and after: no cross-component caller reaches past `.interface`
+  into `.schema` directly (`deps.edn` for every other component depends
+  on `ai.miniforge/supervisory-state`, i.e. the interface artifact, never
+  the raw source tree), and after the edit the only remaining
+  `schema/PolicyViolationSummary`-shaped bare reference is the intended
+  one inside `entities.clj` itself.
+- Did **not** touch `core.clj`, `attention.clj`, `emitter.clj`, or any
+  other sibling file beyond the two requires/re-export edits above — the
+  component's other pre-existing `SL003`/`SL004`/`SL002` findings
+  (`attention.clj` 7 layers, `core.clj` 4 layers, `emitter.clj` def-
+  before-heading, `interface.clj`'s duplicate-heading `SL002`) are
+  unrelated to `schema.clj` and out of scope for this PR (see Testing
+  Plan and Deployment Plan).
+
+## Testing Plan
+
+1. Ran plain (non-`--fix`) `stratum-lint` on `components/supervisory-
+   state` before any change — reproduced the exact `schema.clj` `SL003`
+   finding (5 layers) and also surfaced, unprompted, five *pre-existing*
+   findings in sibling files that this PR does not touch:
+   `attention.clj` (`SL003`, 7 layers), `core.clj` (`SL003`, 4 layers),
+   `emitter.clj` (`SL004`), `golden_fixtures.clj` (`SL003`, 6 layers),
+   `interface.clj` (`SL002`, duplicate `Layer 0` heading). None of these
+   mention `schema.clj` and all five reproduce identically after this
+   PR's change — confirmed by diffing the before/after lint output byte
+   for byte on those five lines.
+2. Applied the split, then ran plain `stratum-lint` again over the whole
+   component: `schema.clj`'s `SL003` finding is gone; `entities.clj`
+   (new) reports nothing. The five pre-existing findings above remain
+   unchanged — **the component as a whole is not lint-clean after this
+   PR**; only the finding this PR targets is resolved. Flagged explicitly
+   because the task brief anticipated a fully clean component-wide run
+   modulo one documented `core.clj` `SL001` false positive, and the
+   live state instead has several other genuinely over-budget/decorative
+   files that are each their own Wave 2 (or Wave 1 `SL002`/`SL004`) unit
+   of work.
+3. Ran the exact two commands to isolate the claim precisely:
+   - `bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "80699e378cb8ebbb6daeb928431aa4a6b373c07e"
+     :deps/root "clojure"}}}' -m stratum-lint.interface components/supervisory-state` → still exits 1 (the five
+     pre-existing, out-of-scope findings above).
+   - Same command scoped to just the two changed/new files
+     (`schema.clj entities.clj`) → exit 0, no output.
+   - Repeated both with this repo's currently-pinned `stratum-lint` SHA
+     from `tasks/stratum.clj` (`bef8657a2efd3b1ba9e1a4f510693c9fbca45abd`,
+     different from the SHA named in the task brief) — same result: the
+     two changed/new files are clean under both pins.
+4. Normalized-diff check: substituted `schema/registry` → `registry` and
+   the four qualified sub-schema refs back to bare symbols in
+   `entities.clj`, stripped the new namespace's header/ns form, and
+   diffed against the deleted block of the old `schema.clj`. Zero
+   content differences — only heading text and `^{:stratum n}` numbers
+   differ (2/3/4 → 0/1/2, as expected for a file that now starts its own
+   count from zero).
+5. `clj-kondo --lint components/supervisory-state`: 0 errors, 0 warnings.
+6. Component tests: `clojure -M:test -m cognitect.test-runner` (run from
+   `components/supervisory-state`) → 87 tests, 279 assertions, 0
+   failures, 0 errors (`accumulator-test`, `attention-test`, `core-test`,
+   `golden-fixtures-test`).
+7. `bb poly:check` (Polylith workspace structure check) — passes; the
+   two pre-existing warnings it reports (`config` non-top namespace,
+   `data-foundry` unnecessary component) are unrelated to this change
+   and unaffected by it.
+8. `bb test` (monorepo-wide stable-derived changed-and-affected suite):
+   completed with exit 0, no failures/errors reported anywhere in its
+   output. Took well over 10 minutes of wall clock — the shared dev
+   machine had five other `bb scripts/test-since-stable.bb` processes
+   running concurrently from sibling Wave 2 PRs' agents at the same
+   time, plus this run's own `dag-executor` suite waiting out several
+   120s Docker-unavailable timeouts (pre-existing behavior, unrelated to
+   this change — those tests SKIP when Docker isn't present). The
+   captured tail of the run's output (last ~200 lines) happened to land
+   inside `dag-executor`/`control-plane` output and doesn't show
+   `supervisory-state`'s own namespaces by name — that run scrolled by
+   earlier in the log — so this is corroborating, not the primary
+   evidence for this component specifically; item 6 (the component's own
+   test run) is the direct evidence for `supervisory-state` and its
+   golden-fixtures contract.
+9. Attempting to commit surfaced two things worth recording:
+   - The commit-budget pre-commit gate reported 658 reportable lines
+     (schema.clj's ~all-touched 276, entities.clj's new 267, plus the
+     three requires-only files) against the 200-line default — expected
+     for a namespace split where the "diff" is mostly relocated content,
+     not new logic. Committed with `MINIFORGE_COMMIT_BUDGET_OVERRIDE`
+     carrying that rationale, per this repo's documented escape hatch
+     for exactly this shape of change (see e.g.
+     `docs/pull-requests/2026-05-06-refactor-agent-component-cleanup.md`
+     and several Wave 1 stratum-lint PRs).
+   - The pre-commit `lint:stratum` autofix step re-ran `--fix` over all
+     five staged files as part of the gate itself. It left `entities.clj`
+     byte-identical to what was authored by hand (confirms the manual
+     layer assignment matches the tool's own inference) and made a
+     mechanical, headings/`^{:stratum n}`-metadata-only change to
+     `interface.clj`: collapsing its pre-existing decorative duplicate
+     `Layer 0` heading (the `SL002` finding noted above as "out of
+     scope") into a single real `Layer 0`, since every def there is an
+     independent pass-through with no same-file references. This is a
+     welcome side effect of the standard gate, not a change this PR set
+     out to make by hand — see Changes in Detail and Deployment Plan.
+     `golden_fixtures.clj` still reports its own pre-existing `SL003` (6
+     layers) after autofix, unrelated to this split; committed with
+     `MINIFORGE_STRATUM_BUDGET_MODE=warn`, the documented convention for
+     touching a file with a pre-existing over-budget finding this PR
+     does not resolve (see e.g.
+     `docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-workflow-resume.md`).
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+change: every moved schema value is byte-for-byte identical to its
+pre-split form (aside from qualifying formerly-same-file symbol refs with
+the new `schema/` alias, and `interface.clj`'s mechanical heading/
+metadata-only autofix). The public interface (`ai.miniforge.supervisory-
+state.interface`) exposes exactly the same symbols under exactly the same
+names as before — only their internal `def` target changed from
+`schema/X` to `entities/X`. `schema.clj`'s `SL003` is fully resolved, not
+deferred — no `MINIFORGE_STRATUM_BUDGET_MODE=warn` needed for this
+finding, and `interface.clj`'s `SL002` is now also resolved (side effect
+of the pre-commit autofix, not by-hand scope). The component's remaining
+pre-existing findings (`attention.clj` `SL003` 7 layers, `core.clj`
+`SL003` 4 layers — plus the documented `SL001` false positive at
+`core.clj:52`, `emitter.clj` `SL004`, `golden_fixtures.clj` `SL003` 6
+layers) remain open as separate Wave 2 (or Wave 1) units of work, tracked
+below; this commit carries `MINIFORGE_STRATUM_BUDGET_MODE=warn` only
+because it had to touch `golden_fixtures.clj`'s requires, not because it
+introduces any new over-budget file.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 2 — real
+  namespace splits).
+- Same deferred-then-split shape as
+  `docs/pull-requests/2026-07-26-fix-stratum-lint-bb-test-runner-namespace-split.md`.
+- Sibling `components/schema` (a *different*, shared component —
+  `ai.miniforge.schema.*`, consumed here as `shared/severities`) hit the
+  identical stray-`Layer 0a`-banner tool-limitation class in its own
+  Wave 1 PR: `docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-schema.md`.
+- Still open in `components/supervisory-state`, out of scope here:
+  `attention.clj` (`SL003`, 7 layers), `core.clj` (`SL003`, 4 layers —
+  also carries the documented `SL001` false positive at `core.clj:52`,
+  a `table` parameter shadowing the later `defn table`, per
+  `work/stratum-lint-baseline-2026-07-24.md`), `emitter.clj` (`SL004`),
+  `golden_fixtures.clj` (`SL003`, 6 layers). `interface.clj`'s `SL002`
+  (duplicate `Layer 0` heading) was resolved as a side effect of this
+  PR's pre-commit autofix — see Testing Plan item 9.
+
+## Checklist
+
+- [x] Plain lint reproduced the exact `schema.clj` `SL003` finding (5
+      layers) before any change, and separately captured the five
+      pre-existing findings on sibling files this PR does not touch
+- [x] Namespace split done by hand (data-only defs; `--fix` cannot move
+      code across files)
+- [x] `schema.clj` kept as the vocabulary namespace (enums, registry,
+      leaf sub-schemas, `empty-table`); stray decorative `;---- Layer 0a`
+      banner removed
+- [x] New `entities.clj` holds the ten entities + `PrFleetEntry` +
+      `PolicyEvaluation` + `EntityTable`, confirmed content-identical to
+      the deleted block via a normalized diff
+- [x] `interface.clj`, `golden_fixtures.clj`, `golden_fixtures_test.clj`
+      repointed for the symbols that moved; `schema-version`/
+      `empty-table` re-exports left untouched (they didn't move)
+- [x] Pre-commit `lint:stratum` autofix left `entities.clj` byte-
+      identical to the hand-authored version (confirms the by-hand layer
+      assignment matches the tool's own inference) and mechanically
+      resolved `interface.clj`'s pre-existing `SL002` as a side effect
+- [x] Grepped the whole repo for `ai.miniforge.supervisory-state.schema`
+      and for each moved entity schema symbol; no cross-component caller
+      reaches past `.interface`
+- [x] `core.clj`, `attention.clj`, `emitter.clj` untouched (verified via
+      `git status`/`git diff --stat`)
+- [x] Both new/changed files confirmed 0 findings via plain `stratum-
+      lint`, scoped individually and matching the task-specified pin and
+      this repo's currently-pinned SHA in `tasks/stratum.clj`
+- [x] Whole-component lint run is **not** clean after this PR — five
+      pre-existing, out-of-scope findings remain and are called out
+      explicitly rather than glossed over
+- [x] `clj-kondo` clean on `components/supervisory-state` (0/0)
+- [x] Component tests pass: 87 tests, 279 assertions, 0 failures/errors
+- [x] `bb poly:check` passes (pre-existing, unrelated warnings only)
+- [x] `bb test` (monorepo-wide, stable-derived changed-and-affected)
+      completed with exit 0; no failures/errors anywhere in its output
+      (see Testing Plan item 8 for the caveat on what its captured tail
+      does/doesn't show by name)
+- [x] Committed with `MINIFORGE_COMMIT_BUDGET_OVERRIDE` (namespace-split
+      shape, rationale in the commit) and `MINIFORGE_STRATUM_BUDGET_MODE=
+      warn` (pre-existing `golden_fixtures.clj` `SL003`, unrelated to
+      this split) — both documented, established escape hatches, not a
+      hook bypass
+- [x] No `--no-verify`; pre-commit hook ran normally (including its own
+      lint/format/smoke-test steps) at commit time


### PR DESCRIPTION
## Summary

- `components/supervisory-state/.../schema.clj` (583 lines) reported `stratum-lint` `SL003` at 5 real layers — entity schemas compose the Malli `registry`, and `PrFleetEntry`/`PolicyEvaluation`/`EntityTable` compose those entities in turn. Genuine over-budget file, not a decorative-heading mislabel — ruled out a mechanical `--fix`.
- Split by schema domain into two namespaces, each ≤ 3 real layers: `schema.clj` (kept name — enums, `registry`, leaf PR-scoring sub-schemas, `empty-table`; 2 layers) and new `entities.clj` (the ten canonical entity schemas + `PrFleetEntry`/`PolicyEvaluation`/`EntityTable`; 3 layers).
- `interface.clj`, `golden_fixtures.clj`, `golden_fixtures_test.clj` repointed for the eight/nine symbols that moved; `schema-version`/`empty-table` re-exports untouched since those didn't move.
- No behavior change — every moved schema value confirmed byte-identical to its pre-split form via a normalized diff.
- Side effect: pre-commit's `lint:stratum` autofix mechanically resolved `interface.clj`'s pre-existing `SL002` (duplicate `Layer 0` heading) while re-linting staged files — headings/metadata only, not by-hand scope of this PR.

Full write-up with the layer-by-layer reference-graph analysis, exact commands run, and every caveat: `docs/pull-requests/2026-07-28-fix-stratum-lint-supervisory-state-schema-split.md`.

## Test plan

- [x] Plain `stratum-lint` reproduced the exact `schema.clj` SL003 (5 layers) before any change
- [x] Both changed/new files (`schema.clj`, `entities.clj`) confirmed 0 findings via plain `stratum-lint`, under both the task-specified pin and this repo's currently-pinned SHA (`tasks/stratum.clj`)
- [x] Normalized diff confirms `entities.clj`'s moved defs are content-identical to the deleted block (only headings/`^{:stratum n}` numbers differ)
- [x] `clj-kondo --lint components/supervisory-state`: 0 errors, 0 warnings
- [x] Component tests: 87 tests, 279 assertions, 0 failures/errors
- [x] `bb poly:check`: passes (pre-existing, unrelated warnings only)
- [x] `bb test` (monorepo-wide): exit 0, no failures/errors
- [x] Pre-commit gate (lint, stratum-lint, format, 331-test smoke suite, GraalVM/Babashka compat): all passed
- [x] Whole-component `stratum-lint` run is **not** fully clean after this PR — `attention.clj`, `core.clj`, `emitter.clj`, `golden_fixtures.clj` carry pre-existing, unrelated findings tracked as separate Wave 1/2 units of work (see PR doc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

MINIFORGE_PR_BUDGET_OVERRIDE: genuine atomic namespace split (schema.clj -> schema.clj + entities.clj) committed with MINIFORGE_COMMIT_BUDGET_OVERRIDE for the same reason -- the moved schemas and their new home must land in one commit to compile; the diff is entirely relocated/re-qualified code, not new logic (see form-equality verification in the linked PR doc).

(PR description refreshed to re-trigger the PR Size check against the current body.)
