### PR TITLE
fix(gate): split pre_verify_lint.clj to clear the 3-layer stratum budget (SL003, Wave 2)

### DIFF
--- a/components/gate/src/ai/miniforge/gate/pre_verify_lint.clj
+++ b/components/gate/src/ai/miniforge/gate/pre_verify_lint.clj
@@ -8,75 +8,24 @@
    for minutes of JVM startup + test execution. Uses the same linter
    configuration from tech-fingerprints.edn as `bb miniforge scan`.
 
-   Technology detection lives in `pre-verify-lint.technology`.
+   Technology detection lives in `pre-verify-lint.technology`; linter
+   execution and error-shape translation live in
+   `pre-verify-lint.execution`. This file only wires the gate into the
+   registry.
 
-   Layer 0: Linter execution
-   Layer 1: Check entry point
-   Layer 2: Gate registration"
+   Layer 0: Gate registration"
   (:require
-   [ai.miniforge.policy-clause.interface :as clause]
-   [ai.miniforge.connector-linter.interface :as linter]
-   [ai.miniforge.gate.pre-verify-lint.technology :as technology]
-   [ai.miniforge.gate.registry :as registry]
-   [ai.miniforge.repo-analyzer.interface :as repo-analyzer]))
+   [ai.miniforge.gate.pre-verify-lint.execution :as execution]
+   [ai.miniforge.gate.registry :as registry]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
-;; Linter execution
-(defn- ^{:stratum 0} resolve-worktree
-  "Get the worktree path from context."
-  [ctx]
-  (or (get ctx :execution/worktree-path)
-      (get ctx :worktree-path)
-      "."))
-
-(defn- ^{:stratum 0} violation->lint-error
-  "Convert a linter violation to a gate error map. The violation carries a
-   POLICY severity (:rule/severity); the gate error map speaks the
-   mechanical scale, so it crosses via policy-clause — the one crossing
-   point between the two axes. Rule severities are schema-validated, so an
-   unknown value is a programmer error: the throw lands in check-gate's
-   exception-to-failed-gate seam (fail-closed)."
-  [v]
-  (let [mech (clause/severity->mechanical (get v :rule/severity :high))]
-    (when-not (keyword? mech)
-      (throw (ex-info "Unknown rule severity on lint violation" {:anomaly mech})))
-    {:type     :lint-error
-     :file     (get v :file)
-     :line     (get v :line 0)
-     :message  (get v :current "")
-     :rule-id  (get v :rule/id)
-     :severity mech}))
-
-(defn ^{:stratum 0} repair-pre-verify-lint
-  "Lint errors cannot be auto-repaired — return to agent."
-  [_artifact errors _ctx]
-  {:success? false
-   :errors errors})
-
-;------------------------------------------------------------------------------ Layer 1
-
-(defn ^{:stratum 1} check-pre-verify-lint
-  "Run configured linters on the worktree before verify."
-  [artifact ctx]
-  (let [worktree   (resolve-worktree ctx)
-        techs      (technology/detect-technologies artifact)
-        fps        @repo-analyzer/fingerprints
-        result     (linter/run-all worktree fps techs)
-        violations (:violations result)]
-    (if (empty? violations)
-      {:passed? true}
-      {:passed? false
-       :errors (mapv violation->lint-error violations)})))
-
-;------------------------------------------------------------------------------ Layer 2
-
-(defmethod ^{:stratum 2} registry/get-gate :pre-verify-lint
+(defmethod ^{:stratum 0} registry/get-gate :pre-verify-lint
   [_]
   {:name        :pre-verify-lint
    :description "Run language linters before test execution to catch errors fast"
-   :check       check-pre-verify-lint
-   :repair      repair-pre-verify-lint})
+   :check       execution/check-pre-verify-lint
+   :repair      execution/repair-pre-verify-lint})
 
 ;; Gate registration
 (registry/register-gate! :pre-verify-lint)

--- a/components/gate/src/ai/miniforge/gate/pre_verify_lint.clj
+++ b/components/gate/src/ai/miniforge/gate/pre_verify_lint.clj
@@ -8,30 +8,19 @@
    for minutes of JVM startup + test execution. Uses the same linter
    configuration from tech-fingerprints.edn as `bb miniforge scan`.
 
-   Layer 0: Technology detection and linter execution
-   Layer 1: Gate registration"
+   Technology detection lives in `pre-verify-lint.technology`.
+
+   Layer 0: Linter execution
+   Layer 1: Check entry point
+   Layer 2: Gate registration"
   (:require
    [ai.miniforge.policy-clause.interface :as clause]
    [ai.miniforge.connector-linter.interface :as linter]
+   [ai.miniforge.gate.pre-verify-lint.technology :as technology]
    [ai.miniforge.gate.registry :as registry]
-   [ai.miniforge.repo-analyzer.interface :as repo-analyzer]
-   [clojure.string :as str]))
+   [ai.miniforge.repo-analyzer.interface :as repo-analyzer]))
 
 ;------------------------------------------------------------------------------ Layer 0
-
-;; Technology detection
-(def ^{:stratum 0} ^:private ext->tech
-  "File extension to technology mapping."
-  {"clj" :clojure "cljs" :clojure "cljc" :clojure
-   "py" :python "rs" :rust "go" :go
-   "js" :javascript "ts" :typescript
-   "swift" :swift "rb" :ruby})
-
-(defn- ^{:stratum 0} file-extension
-  "Extract extension from a file path."
-  [path]
-  (when-let [idx (str/last-index-of (str path) ".")]
-    (subs (str path) (inc idx))))
 
 ;; Linter execution
 (defn- ^{:stratum 0} resolve-worktree
@@ -67,25 +56,11 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
-(defn- ^{:stratum 1} file->tech
-  "Map a file entry to its technology keyword, or nil."
-  [file-entry]
-  (get ext->tech (file-extension (get file-entry :path ""))))
-
-;------------------------------------------------------------------------------ Layer 2
-
-(defn- ^{:stratum 2} detect-technologies
-  "Detect technologies from written file extensions."
-  [artifact]
-  (into #{} (keep file->tech) (get artifact :code/files [])))
-
-;------------------------------------------------------------------------------ Layer 3
-
-(defn ^{:stratum 3} check-pre-verify-lint
+(defn ^{:stratum 1} check-pre-verify-lint
   "Run configured linters on the worktree before verify."
   [artifact ctx]
   (let [worktree   (resolve-worktree ctx)
-        techs      (detect-technologies artifact)
+        techs      (technology/detect-technologies artifact)
         fps        @repo-analyzer/fingerprints
         result     (linter/run-all worktree fps techs)
         violations (:violations result)]
@@ -94,9 +69,9 @@
       {:passed? false
        :errors (mapv violation->lint-error violations)})))
 
-;------------------------------------------------------------------------------ Layer 4
+;------------------------------------------------------------------------------ Layer 2
 
-(defmethod ^{:stratum 4} registry/get-gate :pre-verify-lint
+(defmethod ^{:stratum 2} registry/get-gate :pre-verify-lint
   [_]
   {:name        :pre-verify-lint
    :description "Run language linters before test execution to catch errors fast"

--- a/components/gate/src/ai/miniforge/gate/pre_verify_lint/execution.clj
+++ b/components/gate/src/ai/miniforge/gate/pre_verify_lint/execution.clj
@@ -1,0 +1,68 @@
+;; Title: Miniforge.ai
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;; Licensed under the Apache License, Version 2.0
+(ns ai.miniforge.gate.pre-verify-lint.execution
+  "Linter execution for the pre-verify lint gate.
+
+   Resolves the worktree to lint, runs the configured linters over the
+   technologies the artifact touches, and translates linter violations
+   into the gate's mechanical error shape.
+
+   Layer 0: Worktree resolution, violation translation, and repair (all
+            independent of each other)
+   Layer 1: Check entry point, composing Layer 0 plus the technology
+            detector and the linter runner"
+  (:require
+   [ai.miniforge.connector-linter.interface :as linter]
+   [ai.miniforge.gate.pre-verify-lint.technology :as technology]
+   [ai.miniforge.policy-clause.interface :as clause]
+   [ai.miniforge.repo-analyzer.interface :as repo-analyzer]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Linter execution
+(defn- ^{:stratum 0} resolve-worktree
+  "Get the worktree path from context."
+  [ctx]
+  (or (get ctx :execution/worktree-path)
+      (get ctx :worktree-path)
+      "."))
+
+(defn- ^{:stratum 0} violation->lint-error
+  "Convert a linter violation to a gate error map. The violation carries a
+   POLICY severity (:rule/severity); the gate error map speaks the
+   mechanical scale, so it crosses via policy-clause — the one crossing
+   point between the two axes. Rule severities are schema-validated, so an
+   unknown value is a programmer error: the throw lands in check-gate's
+   exception-to-failed-gate seam (fail-closed)."
+  [v]
+  (let [mech (clause/severity->mechanical (get v :rule/severity :high))]
+    (when-not (keyword? mech)
+      (throw (ex-info "Unknown rule severity on lint violation" {:anomaly mech})))
+    {:type     :lint-error
+     :file     (get v :file)
+     :line     (get v :line 0)
+     :message  (get v :current "")
+     :rule-id  (get v :rule/id)
+     :severity mech}))
+
+(defn ^{:stratum 0} repair-pre-verify-lint
+  "Lint errors cannot be auto-repaired — return to agent."
+  [_artifact errors _ctx]
+  {:success? false
+   :errors errors})
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} check-pre-verify-lint
+  "Run configured linters on the worktree before verify."
+  [artifact ctx]
+  (let [worktree   (resolve-worktree ctx)
+        techs      (technology/detect-technologies artifact)
+        fps        @repo-analyzer/fingerprints
+        result     (linter/run-all worktree fps techs)
+        violations (:violations result)]
+    (if (empty? violations)
+      {:passed? true}
+      {:passed? false
+       :errors (mapv violation->lint-error violations)})))

--- a/components/gate/src/ai/miniforge/gate/pre_verify_lint/technology.clj
+++ b/components/gate/src/ai/miniforge/gate/pre_verify_lint/technology.clj
@@ -1,0 +1,45 @@
+;; Title: Miniforge.ai
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;; Licensed under the Apache License, Version 2.0
+(ns ai.miniforge.gate.pre-verify-lint.technology
+  "Technology detection for the pre-verify lint gate.
+
+   Maps an artifact's written files to the set of technologies (:clojure,
+   :python, :rust, ...) they touch, by file extension. The pre-verify lint
+   gate uses this set to select which configured linters to run.
+
+   Layer 0: Extension table and single-file extraction
+   Layer 1: File-entry to technology mapping
+   Layer 2: Artifact-level technology detection"
+  (:require
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Technology detection
+(def ^{:stratum 0} ^:private ext->tech
+  "File extension to technology mapping."
+  {"clj" :clojure "cljs" :clojure "cljc" :clojure
+   "py" :python "rs" :rust "go" :go
+   "js" :javascript "ts" :typescript
+   "swift" :swift "rb" :ruby})
+
+(defn- ^{:stratum 0} file-extension
+  "Extract extension from a file path."
+  [path]
+  (when-let [idx (str/last-index-of (str path) ".")]
+    (subs (str path) (inc idx))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} file->tech
+  "Map a file entry to its technology keyword, or nil."
+  [file-entry]
+  (get ext->tech (file-extension (get file-entry :path ""))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} detect-technologies
+  "Detect technologies from written file extensions."
+  [artifact]
+  (into #{} (keep file->tech) (get artifact :code/files [])))

--- a/components/gate/test/ai/miniforge/gate/pre_verify_lint/execution_test.clj
+++ b/components/gate/test/ai/miniforge/gate/pre_verify_lint/execution_test.clj
@@ -1,0 +1,20 @@
+;; Title: Miniforge.ai
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;; Licensed under the Apache License, Version 2.0
+(ns ai.miniforge.gate.pre-verify-lint.execution-test
+  "Tests for pre-verify lint's linter execution and error translation."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.gate.pre-verify-lint.execution :as sut]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} check-pre-verify-lint-no-linter-test
+  (testing "passes when linter not available"
+    (let [result (sut/check-pre-verify-lint {} {})]
+      (is (true? (:passed? result))))))
+
+(deftest ^{:stratum 0} repair-always-fails-test
+  (testing "repair returns failure — lint errors need agent"
+    (let [result (sut/repair-pre-verify-lint {} [{:type :lint-error}] {})]
+      (is (false? (:success? result))))))

--- a/components/gate/test/ai/miniforge/gate/pre_verify_lint/technology_test.clj
+++ b/components/gate/test/ai/miniforge/gate/pre_verify_lint/technology_test.clj
@@ -1,0 +1,24 @@
+;; Title: Miniforge.ai
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;; Licensed under the Apache License, Version 2.0
+(ns ai.miniforge.gate.pre-verify-lint.technology-test
+  "Tests for pre-verify lint's technology detection."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.gate.pre-verify-lint.technology :as sut]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} detect-technologies-test
+  (testing "detects Clojure from file extensions"
+    (let [artifact {:code/files [{:path "src/core.clj" :action :create}]}]
+      (is (contains? (sut/detect-technologies artifact) :clojure))))
+
+  (testing "detects multiple languages"
+    (let [artifact {:code/files [{:path "src/main.rs" :action :create}
+                                 {:path "src/app.py" :action :create}]}]
+      (is (contains? (sut/detect-technologies artifact) :rust))
+      (is (contains? (sut/detect-technologies artifact) :python))))
+
+  (testing "returns empty for no files"
+    (is (empty? (sut/detect-technologies {:code/files []})))))

--- a/components/gate/test/ai/miniforge/gate/pre_verify_lint_test.clj
+++ b/components/gate/test/ai/miniforge/gate/pre_verify_lint_test.clj
@@ -2,22 +2,26 @@
 ;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
 ;; Licensed under the Apache License, Version 2.0
 (ns ai.miniforge.gate.pre-verify-lint-test
-  "Tests for the pre-verify lint gate.
+  "Tests for the pre-verify lint gate's registration and wiring.
 
-   Technology-detection behavior lives in
-   `pre-verify-lint.technology-test`."
+   Check/repair behavior lives in `pre-verify-lint.execution-test`; technology
+   detection behavior lives in `pre-verify-lint.technology-test`. This file
+   only confirms the gate is wired correctly under `:pre-verify-lint`."
   (:require
    [clojure.test :refer [deftest testing is]]
-   [ai.miniforge.gate.pre-verify-lint :as sut]))
+   [ai.miniforge.gate.pre-verify-lint]
+   [ai.miniforge.gate.pre-verify-lint.execution :as execution]
+   [ai.miniforge.gate.registry :as registry]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
-(deftest ^{:stratum 0} check-pre-verify-lint-no-linter-test
-  (testing "passes when linter not available"
-    (let [result (sut/check-pre-verify-lint {} {})]
-      (is (true? (:passed? result))))))
+(deftest ^{:stratum 0} pre-verify-lint-registered-test
+  (testing "the gate registers under :pre-verify-lint"
+    (is (contains? (registry/list-gates) :pre-verify-lint))))
 
-(deftest ^{:stratum 0} repair-always-fails-test
-  (testing "repair returns failure — lint errors need agent"
-    (let [result (sut/repair-pre-verify-lint {} [{:type :lint-error}] {})]
-      (is (false? (:success? result))))))
+(deftest ^{:stratum 0} pre-verify-lint-wires-execution-fns-test
+  (testing "get-gate resolves to execution's check/repair functions"
+    (let [gate (registry/get-gate :pre-verify-lint)]
+      (is (= :pre-verify-lint (:name gate)))
+      (is (= execution/check-pre-verify-lint (:check gate)))
+      (is (= execution/repair-pre-verify-lint (:repair gate))))))

--- a/components/gate/test/ai/miniforge/gate/pre_verify_lint_test.clj
+++ b/components/gate/test/ai/miniforge/gate/pre_verify_lint_test.clj
@@ -2,15 +2,15 @@
 ;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
 ;; Licensed under the Apache License, Version 2.0
 (ns ai.miniforge.gate.pre-verify-lint-test
-  "Tests for the pre-verify lint gate."
+  "Tests for the pre-verify lint gate.
+
+   Technology-detection behavior lives in
+   `pre-verify-lint.technology-test`."
   (:require
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.gate.pre-verify-lint :as sut]))
 
 ;------------------------------------------------------------------------------ Layer 0
-
-;; Access private functions
-(def ^{:stratum 0} detect-technologies (var-get #'sut/detect-technologies))
 
 (deftest ^{:stratum 0} check-pre-verify-lint-no-linter-test
   (testing "passes when linter not available"
@@ -21,19 +21,3 @@
   (testing "repair returns failure — lint errors need agent"
     (let [result (sut/repair-pre-verify-lint {} [{:type :lint-error}] {})]
       (is (false? (:success? result))))))
-
-;------------------------------------------------------------------------------ Layer 1
-
-(deftest ^{:stratum 1} detect-technologies-test
-  (testing "detects Clojure from file extensions"
-    (let [artifact {:code/files [{:path "src/core.clj" :action :create}]}]
-      (is (contains? (detect-technologies artifact) :clojure))))
-
-  (testing "detects multiple languages"
-    (let [artifact {:code/files [{:path "src/main.rs" :action :create}
-                                 {:path "src/app.py" :action :create}]}]
-      (is (contains? (detect-technologies artifact) :rust))
-      (is (contains? (detect-technologies artifact) :python))))
-
-  (testing "returns empty for no files"
-    (is (empty? (detect-technologies {:code/files []})))))

--- a/docs/pull-requests/2026-07-28-fix-stratum-lint-wave2-gate-pre-verify-lint.md
+++ b/docs/pull-requests/2026-07-28-fix-stratum-lint-wave2-gate-pre-verify-lint.md
@@ -1,0 +1,135 @@
+# fix: split gate/pre_verify_lint.clj to clear the 3-layer stratum budget (SL003, Wave 2)
+
+## Overview
+
+Splits `components/gate/src/ai/miniforge/gate/pre_verify_lint.clj` (107
+lines, reporting 5 real layers) into three files, none over 3 layers:
+technology detection, linter execution, and gate registration. This is a
+genuine namespace split (Wave 2), not a mechanical relabeling — Wave 1
+already cleared decorative `Layer N` mislabeling across this component
+(`work/stratum-lint-baseline-2026-07-24.md`
+/ `docs/pull-requests/2026-07-24-fix-stratum-lint-wave1-gate.md`), which
+left `pre_verify_lint.clj` correctly labeled but still genuinely over
+budget at 5 layers.
+
+## Motivation
+
+Rule 210 (`.cursor/rules/languages/clojure.mdc`,
+`.cursor/rules/foundations/stratified-design.mdc`) caps a namespace at 3
+layers; beyond that the file must be decomposed, not relabeled. The
+pre-Wave-2 file mixed four concerns in one namespace:
+
+1. File-extension → technology mapping (`ext->tech`, `file-extension`,
+   `file->tech`, `detect-technologies`) — 3 layers on its own.
+2. Worktree resolution + linter-violation → gate-error translation
+   (`resolve-worktree`, `violation->lint-error`).
+3. The check entry point (`check-pre-verify-lint`), which composes both
+   of the above plus the repair stub.
+4. The `defmethod`/`register-gate!` wiring into the gate registry.
+
+Stacked into one namespace this reaches 5 real layers. No sibling gate in
+this component runs a multi-file split (`syntax.clj`, `lint.clj`, etc. are
+all single-file, ≤3 layers), but other components in this repo do use a
+`<name>/<sub>.clj` subdirectory for a same-namespace-family split (e.g.
+`agent-runtime/agent_runtime/error_classifier`,
+`bb-dev-tools/bb_dev_tools/adapters`), so `pre_verify_lint/technology.clj`
+and `pre_verify_lint/execution.clj` follow that repo-wide convention rather
+than inventing a new one.
+
+## Changes in Detail
+
+- **`pre_verify_lint/technology.clj`** (new, `ai.miniforge.gate.pre-verify-lint.technology`)
+  — `ext->tech`, `file-extension` (Layer 0), `file->tech` (Layer 1),
+  `detect-technologies` (Layer 2). Unchanged logic, moved verbatim.
+- **`pre_verify_lint/execution.clj`** (new, `ai.miniforge.gate.pre-verify-lint.execution`)
+  — `resolve-worktree`, `violation->lint-error`, `repair-pre-verify-lint`
+  (Layer 0, mutually independent), `check-pre-verify-lint` (Layer 1,
+  composes Layer 0 plus `technology/detect-technologies` and
+  `connector-linter.interface/run-all`). Unchanged logic, moved verbatim;
+  only the `detect-technologies` call site now goes through the
+  `technology` namespace alias instead of a same-file def.
+- **`pre_verify_lint.clj`** — now only the `defmethod registry/get-gate
+  :pre-verify-lint` and `(registry/register-gate! :pre-verify-lint)` side
+  effect, at a single Layer 0. `:check`/`:repair` point at
+  `execution/check-pre-verify-lint` and `execution/repair-pre-verify-lint`.
+  This matches how this file's own docstring already described its role
+  (self-registering gate, not a shared interface other gates require) and
+  is the same shape every sibling gate file in this component uses for its
+  own `defmethod`.
+- **`interface.clj`** — untouched. It requires `ai.miniforge.gate.pre-verify-lint`
+  only for the registration side effect; that require still transitively
+  loads the two new namespaces, so no interface change was needed
+  (confirmed: gates dispatch through the registry by keyword, and grepping
+  the repo for `pre_verify_lint`/`pre-verify-lint` found no other direct
+  requirer outside this component's own source, tests, and `bb.edn`'s
+  classpath comment).
+- Tests split to mirror the source: `pre_verify_lint/technology_test.clj`
+  and `pre_verify_lint/execution_test.clj` carry the moved test bodies
+  (now calling the public `detect-technologies`/`check-pre-verify-lint`/
+  `repair-pre-verify-lint` directly — no more `var-get` private-var
+  reach-around, since those functions now live in their own namespace and
+  need to be public for `execution.clj`/`technology.clj` to use each
+  other and to be exercised by their own test file).
+  `pre_verify_lint_test.clj` now only asserts the wiring itself: the gate
+  registers under `:pre-verify-lint` and `get-gate` resolves to
+  `execution`'s exact check/repair functions.
+
+No behavior change: same gate keyword, same check/repair semantics, same
+error/violation shapes.
+
+## Testing Plan
+
+1. Stratum linter, non-warn mode, whole component:
+
+   ```bash
+   bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "80699e378cb8ebbb6daeb928431aa4a6b373c07e" :deps/root "clojure"}}}' -m stratum-lint.interface components/gate
+   ```
+
+   Before this change: 5 findings, including
+   `pre_verify_lint.clj:97:1: SL003 file uses 5 distinct layers (max 3)`.
+   After this change: that finding is gone; the file's own change
+   introduces zero new findings. 4 pre-existing `SL003` findings remain in
+   this component (`capabilities.clj`, `format.clj`, `policy_pack.clj`,
+   `precommit_discipline.clj`) — confirmed present on `main` before this
+   branch touched anything (stashed the diff and re-ran the same command),
+   so they're separate, already-tracked Wave 2 targets, not something this
+   change reintroduced.
+2. `clj-kondo --lint components/gate`: 0 errors, 0 warnings, before and
+   after.
+3. `bb test` (full monorepo, stable-derived changed-and-affected —
+   deliberately not `bb check:affected-tests`, since that only runs
+   changed bricks and not dependents; this team has been burned by that
+   gap before).
+4. Adversarial self-review of the diff: confirmed no def lost its
+   docstring in the move, no stale require, `ext->tech` and
+   `violation->lint-error` kept their original `^:private`/`defn-`
+   visibility (they'd briefly gone public in an earlier pass of this
+   change and were reverted), and the `defmethod`/`register-gate!` side
+   effect still fires at load time from the same file it always did.
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+change — this is a structural split with the registration side effect
+staying exactly where the registry/interface machinery expects it
+(`pre_verify_lint.clj`, required from `gate/interface.clj`).
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md`
+- Wave 1 (decorative fix, same component):
+  `docs/pull-requests/2026-07-24-fix-stratum-lint-wave1-gate.md`
+- Wave 1 tone/rigor reference (mechanical relabeling example):
+  `docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-fsm.md`
+
+## Checklist
+
+- [x] Stratum linter clean for the changed file (zero new/remaining
+      findings vs. this file; 4 pre-existing unrelated findings confirmed
+      present on `main`)
+- [x] `clj-kondo` clean before/after (0 errors, 0 warnings)
+- [x] `bb test` run (see Testing Plan for result)
+- [x] No behavior change: same gate keyword, same check/repair semantics
+- [x] `interface.clj` confirmed unaffected (side-effect require still
+      resolves transitively)
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time

--- a/docs/pull-requests/2026-07-28-fix-stratum-lint-wave2-gate-pre-verify-lint.md
+++ b/docs/pull-requests/2026-07-28-fix-stratum-lint-wave2-gate-pre-verify-lint.md
@@ -128,7 +128,11 @@ staying exactly where the registry/interface machinery expects it
       findings vs. this file; 4 pre-existing unrelated findings confirmed
       present on `main`)
 - [x] `clj-kondo` clean before/after (0 errors, 0 warnings)
-- [x] `bb test` run (see Testing Plan for result)
+- [x] `ai.miniforge.gate.*` test namespaces run directly (118 tests, 351
+      assertions, 0 failures/errors) plus the pre-commit hook's own
+      331-test smoke suite on both commits, both green — full-monorepo
+      `bb test` did not finish (Docker-dependent `dag-executor` retries
+      unrelated to this change; see Testing Plan)
 - [x] No behavior change: same gate keyword, same check/repair semantics
 - [x] `interface.clj` confirmed unaffected (side-effect require still
       resolves transitively)


### PR DESCRIPTION
## Summary

- Splits `components/gate/src/ai/miniforge/gate/pre_verify_lint.clj` (5 real layers, over rule 210's 3-layer budget) into `pre_verify_lint/technology.clj` (technology detection, 3 layers), `pre_verify_lint/execution.clj` (linter execution + error translation, 2 layers), and `pre_verify_lint.clj` itself (just the `defmethod`/`register-gate!` wiring, 1 layer).
- No behavior change: same `:pre-verify-lint` gate keyword, same check/repair semantics.
- Landed as two source-split commits (technology, then execution) plus a docs commit, to stay under this repo's 200-line commit budget.

Full writeup: `docs/pull-requests/2026-07-28-fix-stratum-lint-wave2-gate-pre-verify-lint.md`

## Test plan

- [x] `bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "80699e378cb8ebbb6daeb928431aa4a6b373c07e" :deps/root "clojure"}}}' -m stratum-lint.interface components/gate` — the `pre_verify_lint.clj` `SL003` finding is gone; 4 pre-existing `SL003` findings in other gate-component files remain (confirmed present on `main` before this branch, unrelated Wave 2 targets).
- [x] `clj-kondo --lint components/gate` — 0 errors, 0 warnings.
- [x] Direct gate-component test run (`clojure -M:test`, all 15 `ai.miniforge.gate.*` test namespaces) — 118 tests, 351 assertions, 0 failures, 0 errors.
- [x] Pre-commit hook's smoke suite (16 namespaces) — 331 tests, 1244 assertions, 0 failures, 0 errors — plus GraalVM/Babashka compat (8 tests, 554 assertions, 0 failures) — ran automatically on both source commits.
- [ ] `bb test` (full monorepo, stable-derived changed-and-affected) — started but did not finish in this environment; it stalled repeatedly retrying Docker-dependent `dag-executor` tests (`Docker not available` here), unrelated to this change. CI should complete this run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)