### PR TITLE
fix(schema): split core.clj and logging.clj to clear the 3-layer stratum budget (SL003, Wave 2)

### DIFF
--- a/components/schema/src/ai/miniforge/schema/core.clj
+++ b/components/schema/src/ai/miniforge/schema/core.clj
@@ -16,128 +16,26 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns ai.miniforge.schema.core
-  "Core domain schemas for miniforge.
-   Layer 0: Base enum vocabularies, severities, and normalize-severity
-   Layer 1: severity-order and the shared malli registry
-   Layer 2: compare-severity/Severity and standalone composite schemas
-            (Agent, TaskConstraints, TaskResult, Metrics, MetaAgentConfig, ...)
-   Layer 3: more-severe and top-level composites depending on Layer 2
+  "Core domain composite schemas for miniforge. Enum vocabularies, severity
+   helpers, and the shared malli registry live in `vocab.clj` (split out
+   under SL003, Wave 2) — this file only holds the `:map` composites built
+   on top of that registry.
+   Layer 0: Standalone composites depending only on `vocab/registry`
+            (Agent, TaskConstraints, TaskResult, ArtifactOrigin,
+            WorkflowBudget, Metrics, MetaAgentConfig, MetaAgentHealthCheck)
+   Layer 1: Top-level composites depending on Layer 0
             (Task, Artifact, Workflow, MetaCoordinatorState)"
   (:require
-   [ai.miniforge.policy-clause.interface :as clause]
+   [ai.miniforge.schema.vocab :as vocab]
    [malli.core :as m]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
-;; Base enum vocabularies and severity helpers
-(def ^{:stratum 0} agent-roles
-  [:planner :architect :implementer :tester :reviewer :sre :security :release :historian :operator])
-
-(def ^{:stratum 0} meta-agent-roles
-  "Meta-agent roles for workflow monitoring and control."
-  [:progress-monitor :test-quality :conflict-detector :resource-manager :evidence-collector])
-
-(def ^{:stratum 0} task-types
-  [:plan :design :implement :test :review :deploy])
-
-(def ^{:stratum 0} task-statuses
-  [:pending :running :completed :failed :blocked])
-
-(def ^{:stratum 0} artifact-types
-  [:spec :plan :adr :code :test :review :manifest :image :telemetry :incident])
-
-(def ^{:stratum 0} workflow-phases
-  [:plan :design :implement :verify :review :release :observe])
-
-(def ^{:stratum 0} workflow-statuses
-  [:pending :running :paused :completed :failed :cancelled])
-
-(def ^{:stratum 0} severities
-  "Canonical severity levels, most to least severe. Defined by the
-   policy-clause component (Ariadne step 1a) and passed through here so
-   every schema consumer keeps one import site. A violation's severity
-   is the severity of the rule it violates, so one scale — not a
-   per-producer vocabulary. Legacy `:major`/`:minor` map to
-   `:high`/`:low` via `normalize-severity`."
-  clause/severities)
-
-(def ^{:stratum 0} normalize-severity
-  "Coerce a legacy severity keyword to the canonical enum: `:major` → `:high`,
-   `:minor` → `:low`; every canonical value is returned unchanged. Pass-through
-   to policy-clause."
-  clause/normalize-severity)
-
-(def ^{:stratum 0} severity-order
-  "Rank per severity, 0 = most severe. Pass-through to policy-clause so the order
-   table cannot drift from the enum."
-  clause/severity-order)
-
-(def ^{:stratum 0} compare-severity
-  "Compare two severities. Negative when `a` is more severe than `b`, positive
-   when less, 0 when equal. An unknown severity on either side returns an
-   `:invalid-input` anomaly (subtype `:anomalies.policy-clause/unknown-severity`)
-   — the pre-Ariadne sort-unknown-last default was a fail-open and is gone."
-  clause/compare-severity)
-
-(def ^{:stratum 0} more-severe
-  "Return the more severe of two severities, or an anomaly when either is
-   unknown (see `compare-severity`)."
-  clause/more-severe)
-
-;------------------------------------------------------------------------------ Layer 1
-
-(def ^{:stratum 1} registry
-  "Malli registry for base schema types."
-  {;; Identifiers
-   :id/uuid        uuid?
-   :id/string      [:string {:min 1}]
-
-   ;; Agent types
-   :agent/id       :id/uuid
-   :agent/role     (into [:enum] agent-roles)
-   :agent/capability keyword?
-
-   ;; Meta-agent types
-   :meta-agent/id  keyword?
-   :meta-agent/role (into [:enum] meta-agent-roles)
-   :meta-agent/status [:enum :healthy :warning :halt]
-   :meta-agent/priority [:enum :high :medium :low]
-
-   ;; Task types
-   :task/id        :id/uuid
-   :task/type      (into [:enum] task-types)
-   :task/status    (into [:enum] task-statuses)
-
-   ;; Artifact types
-   :artifact/id    :id/uuid
-   :artifact/type  (into [:enum] artifact-types)
-   :artifact/version [:string {:min 1}]
-
-   ;; Workflow types
-   :workflow/id    :id/uuid
-   :workflow/phase (into [:enum] workflow-phases)
-   :workflow/status (into [:enum] workflow-statuses)
-
-   ;; Severity (canonical, shared across policy + supervisory + display)
-   :severity (into [:enum] severities)
-
-   ;; Common types
-   :common/timestamp inst?
-   :common/non-neg-int [:int {:min 0}]
-   :common/pos-number [:double {:min 0.0}]})
-
-;------------------------------------------------------------------------------ Layer 2
-
-(def ^{:stratum 2} Severity
-  "Malli enum for a canonical severity level (see `severities`). Reuses the
-   `:severity` registry entry so there is one constructed enum, not two copies."
-  (:severity registry))
-
 ;; Composite schemas
-(def ^{:stratum 2} Agent
+(def ^{:stratum 0} Agent
   "Schema for an AI agent.
    Agents are pure functions: (context, task) -> (artifacts, decisions, signals)"
-  [:map {:registry registry}
+  [:map {:registry vocab/registry}
    [:agent/id :agent/id]
    [:agent/role :agent/role]
    [:agent/capabilities {:optional true} [:set :agent/capability]]
@@ -152,9 +50,9 @@
        [:tokens {:optional true} :common/non-neg-int]
        [:cost-usd {:optional true} :common/pos-number]]]]]])
 
-(def ^{:stratum 2} TaskConstraints
+(def ^{:stratum 0} TaskConstraints
   "Schema for task execution constraints."
-  [:map {:registry registry}
+  [:map {:registry vocab/registry}
    [:budget {:optional true}
     [:map
      [:tokens {:optional true} :common/non-neg-int]
@@ -164,9 +62,9 @@
    [:policies {:optional true} [:vector keyword?]]
    [:max-iterations {:optional true} :common/non-neg-int]])
 
-(def ^{:stratum 2} TaskResult
+(def ^{:stratum 0} TaskResult
   "Schema for task execution result."
-  [:map {:registry registry}
+  [:map {:registry vocab/registry}
    [:outcome [:enum :success :failure :escalated]]
    [:error {:optional true} :id/string]
    [:signals {:optional true} [:vector keyword?]]
@@ -177,35 +75,35 @@
      [:cost-usd {:optional true} :common/pos-number]
      [:iterations {:optional true} :common/non-neg-int]]]])
 
-(def ^{:stratum 2} ArtifactOrigin
+(def ^{:stratum 0} ArtifactOrigin
   "Schema for artifact provenance origin."
-  [:map {:registry registry}
+  [:map {:registry vocab/registry}
    [:intent-id {:optional true} :id/uuid]
    [:agent-id {:optional true} :agent/id]
    [:task-id {:optional true} :task/id]])
 
-(def ^{:stratum 2} WorkflowBudget
+(def ^{:stratum 0} WorkflowBudget
   "Schema for workflow budget allocation."
-  [:map {:registry registry}
+  [:map {:registry vocab/registry}
    [:tokens {:optional true} :common/non-neg-int]
    [:cost-usd {:optional true} :common/pos-number]
    [:duration-ms {:optional true} :common/non-neg-int]])
 
-(def ^{:stratum 2} Metrics
+(def ^{:stratum 0} Metrics
   "Schema for an agent/phase result's `:metrics` map. `:tokens` and
    `:duration-ms` are REQUIRED and non-nil — they are consumed by cost and
    accumulation arithmetic, so a missing or nil value is a boundary violation
    (it throws a message-less NPE downstream). `:non-neg-int` already rejects a
    present nil; making the keys required also rejects an absent one."
-  [:map {:registry registry}
+  [:map {:registry vocab/registry}
    [:tokens :common/non-neg-int]
    [:duration-ms :common/non-neg-int]
    [:cost-usd {:optional true} :common/pos-number]
    [:iterations {:optional true} :common/non-neg-int]])
 
-(def ^{:stratum 2} MetaAgentConfig
+(def ^{:stratum 0} MetaAgentConfig
   "Schema for meta-agent configuration."
-  [:map {:registry registry}
+  [:map {:registry vocab/registry}
    [:id :meta-agent/id]
    [:name :id/string]
    [:can-halt? boolean?]
@@ -213,20 +111,20 @@
    [:priority :meta-agent/priority]
    [:enabled? boolean?]])
 
-(def ^{:stratum 2} MetaAgentHealthCheck
+(def ^{:stratum 0} MetaAgentHealthCheck
   "Schema for meta-agent health check result."
-  [:map {:registry registry}
+  [:map {:registry vocab/registry}
    [:status :meta-agent/status]
    [:agent/id :meta-agent/id]
    [:message :id/string]
    [:data {:optional true} [:map-of keyword? any?]]
    [:checked-at :common/timestamp]])
 
-;------------------------------------------------------------------------------ Layer 3
+;------------------------------------------------------------------------------ Layer 1
 
-(def ^{:stratum 3} Task
+(def ^{:stratum 1} Task
   "Schema for a unit of work assigned to an agent."
-  [:map {:registry registry}
+  [:map {:registry vocab/registry}
    [:task/id :task/id]
    [:task/type :task/type]
    [:task/status :task/status]
@@ -238,9 +136,9 @@
    [:task/constraints {:optional true} TaskConstraints]
    [:task/result {:optional true} TaskResult]])
 
-(def ^{:stratum 3} Artifact
+(def ^{:stratum 1} Artifact
   "Schema for a versioned work product with provenance."
-  [:map {:registry registry}
+  [:map {:registry vocab/registry}
    [:artifact/id :artifact/id]
    [:artifact/type :artifact/type]
    [:artifact/version :artifact/version]
@@ -251,9 +149,9 @@
    [:artifact/metadata {:optional true} [:map-of keyword? any?]]
    [:artifact/created-at {:optional true} :common/timestamp]])
 
-(def ^{:stratum 3} Workflow
+(def ^{:stratum 1} Workflow
   "Schema for an outer loop SDLC delivery instance."
-  [:map {:registry registry}
+  [:map {:registry vocab/registry}
    [:workflow/id :workflow/id]
    [:workflow/name {:optional true} :id/string]
    [:workflow/status :workflow/status]
@@ -275,9 +173,9 @@
       [:enabled? {:optional true} boolean?]
       [:config {:optional true} [:map-of keyword? any?]]]]]])
 
-(def ^{:stratum 3} MetaCoordinatorState
+(def ^{:stratum 1} MetaCoordinatorState
   "Schema for meta-agent coordinator state."
-  [:map {:registry registry}
+  [:map {:registry vocab/registry}
    [:status :meta-agent/status]
    [:checks [:vector MetaAgentHealthCheck]]
    [:halt-reason {:optional true} :id/string]

--- a/components/schema/src/ai/miniforge/schema/interface.clj
+++ b/components/schema/src/ai/miniforge/schema/interface.clj
@@ -24,7 +24,9 @@
    [malli.error :as me]
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.schema.core :as core]
+   [ai.miniforge.schema.vocab :as vocab]
    [ai.miniforge.schema.logging :as logging]
+   [ai.miniforge.schema.logging-vocab :as logging-vocab]
    [ai.miniforge.schema.supervisory :as supervisory]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -138,58 +140,58 @@
 (def ^{:stratum 0} agent-roles
   "Vector of canonical agent role keywords, ordered by implementation priority
    (`:planner`, `:architect`, `:implementer`, ...)."
-  core/agent-roles)
+  vocab/agent-roles)
 
 (def ^{:stratum 0} task-types
   "Vector of task-type keywords (`:plan`, `:design`, `:implement`, `:test`,
    `:review`, `:deploy`)."
-  core/task-types)
+  vocab/task-types)
 
 (def ^{:stratum 0} task-statuses
   "Vector of task-status keywords (`:pending`, `:running`, `:completed`,
    `:failed`, `:blocked`)."
-  core/task-statuses)
+  vocab/task-statuses)
 
 (def ^{:stratum 0} artifact-types
   "Vector of artifact-type keywords (`:spec`, `:plan`, `:adr`, `:code`,
    `:test`, `:review`, `:manifest`, `:image`, `:telemetry`, `:incident`)."
-  core/artifact-types)
+  vocab/artifact-types)
 
 (def ^{:stratum 0} workflow-phases
   "Vector of outer-loop SDLC phase keywords (`:plan`, `:design`, `:implement`,
    `:verify`, `:review`, `:release`, `:observe`)."
-  core/workflow-phases)
+  vocab/workflow-phases)
 
 (def ^{:stratum 0} workflow-statuses
   "Vector of workflow-status keywords (`:pending`, `:running`, `:paused`,
    `:completed`, `:failed`, `:cancelled`)."
-  core/workflow-statuses)
+  vocab/workflow-statuses)
 
 (def ^{:stratum 0} severities
   "Canonical severity levels, most to least severe
    (`:critical :high :medium :low :info`). One source of truth for rule,
    violation, attention, and display severity."
-  core/severities)
+  vocab/severities)
 
 (def ^{:stratum 0} Severity
   "Malli enum schema for a canonical severity level."
-  core/Severity)
+  vocab/Severity)
 
 (def ^{:stratum 0} severity-order
   "Map from severity keyword to rank (0 = most severe), derived from
    `severities`."
-  core/severity-order)
+  vocab/severity-order)
 
 (def ^{:stratum 0} normalize-severity
   "Coerce a legacy severity (`:major` → `:high`, `:minor` → `:low`) to the
    canonical enum; canonical/other values pass through unchanged."
-  core/normalize-severity)
+  vocab/normalize-severity)
 
 (def ^{:stratum 0} compare-severity
   "Compare two severities: negative when the first is more severe, positive when
    less, 0 when equal. Unknown severities return an `:invalid-input` anomaly
    instead of sorting last."
-  core/compare-severity)
+  vocab/compare-severity)
 
 (def ^{:stratum 0} rank-severity
   "Checked severity rank (0 = most severe); anomaly for unknown values."
@@ -212,27 +214,27 @@
 (def ^{:stratum 0} more-severe
   "Return the more severe of two severities, or an anomaly when either is
    unknown."
-  core/more-severe)
+  vocab/more-severe)
 
 (def ^{:stratum 0} log-levels
   "Vector of log severity keywords, most to least verbose (`:trace`, `:debug`,
    `:info`, `:warn`, `:error`, `:fatal`)."
-  logging/log-levels)
+  logging-vocab/log-levels)
 
 (def ^{:stratum 0} log-categories
   "Vector of log category keywords (`:agent`, `:loop`, `:policy`, `:artifact`,
    `:system`)."
-  logging/log-categories)
+  logging-vocab/log-categories)
 
 (def ^{:stratum 0} all-events
   "Vector of all known log-event keywords across the agent, loop, policy,
    artifact, and system taxonomies."
-  logging/all-events)
+  logging-vocab/all-events)
 
 (def ^{:stratum 0} scenario-tags
   "Vector of standard scenario-test tag keywords (`:canary`, `:shadow`,
    `:regression`, ...)."
-  logging/scenario-tags)
+  logging-vocab/scenario-tags)
 
 ;; Supervisory enum value sets
 (def ^{:stratum 0} eval-results

--- a/components/schema/src/ai/miniforge/schema/logging.clj
+++ b/components/schema/src/ai/miniforge/schema/logging.clj
@@ -16,134 +16,53 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns ai.miniforge.schema.logging
-  "Logging schemas for miniforge structured EDN logging.
-   Layer 0: Base event/level/category vocabularies
-   Layer 1: all-events (aggregates the Layer 0 event vocabularies)
-   Layer 2: logging-registry (the malli registry)
-   Layer 3: Composite schemas (LogContext, ScenarioContext, TraceContext,
-            PerfMetrics, LogEntry, Scenario)"
+  "Logging schemas for miniforge structured EDN logging. Event/level/category
+   vocabularies and the logging registry live in `logging-vocab.clj` (split
+   out under SL003, Wave 2) — this file only holds the `:map` composites
+   built on top of that registry.
+   Layer 0: Composite schemas (LogContext, ScenarioContext, TraceContext,
+            PerfMetrics, LogEntry, Scenario) — each depends only on
+            `logging-vocab/logging-registry`, not on one another"
   (:require
    [malli.core :as m]
-   [ai.miniforge.schema.core :as core]))
+   [ai.miniforge.schema.logging-vocab :as logging-vocab]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
-;; Base types and event taxonomy
-(def ^{:stratum 0} log-levels
-  [:trace :debug :info :warn :error :fatal])
-
-(def ^{:stratum 0} log-categories
-  [:agent :loop :policy :artifact :system])
-
-(def ^{:stratum 0} loop-types
-  "Types of control loops in the system."
-  [:inner :outer :meta])
-
-(def ^{:stratum 0} agent-events
-  "Events emitted by agent operations."
-  [:agent/task-started
-   :agent/task-completed
-   :agent/task-failed
-   :agent/prompt-sent
-   :agent/response-received
-   :agent/memory-updated])
-
-(def ^{:stratum 0} loop-events
-  "Events emitted by control loops."
-  [:inner/iteration-started
-   :inner/validation-passed
-   :inner/validation-failed
-   :inner/repair-attempted
-   :inner/escalated
-   :outer/phase-entered
-   :outer/phase-completed
-   :outer/phase-failed
-   :outer/workflow-completed
-   :meta/signal-collected
-   :meta/improvement-proposed
-   :meta/improvement-applied])
-
-(def ^{:stratum 0} policy-events
-  "Events emitted by policy evaluation."
-  [:policy/gate-evaluated
-   :policy/budget-checked
-   :policy/budget-exceeded
-   :policy/escalation
-   :policy/human-required
-   :policy/human-approved])
-
-(def ^{:stratum 0} artifact-events
-  "Events emitted by artifact operations."
-  [:artifact/created
-   :artifact/versioned
-   :artifact/linked
-   :artifact/validation])
-
-(def ^{:stratum 0} system-events
-  "Events emitted by system operations."
-  [:system/startup
-   :system/shutdown
-   :system/config-changed
-   :system/plugin-loaded
-   :system/health-check])
-
-(def ^{:stratum 0} scenario-tags
-  [:canary :shadow :regression :smoke :stress :chaos :golden-path :error-recovery :rollback])
-
-;------------------------------------------------------------------------------ Layer 1
-
-(def ^{:stratum 1} all-events
-  (vec (concat agent-events loop-events policy-events artifact-events system-events)))
-
-;------------------------------------------------------------------------------ Layer 2
-
-(def ^{:stratum 2} logging-registry
-  "Malli registry for logging schema types."
-  (merge
-   core/registry
-   {:log/id        :id/uuid
-    :log/level     (into [:enum] log-levels)
-    :log/category  (into [:enum] log-categories)
-    :log/event     (into [:enum] all-events)
-    :log/loop-type (into [:enum] loop-types)
-    :scenario/tag  (into [:enum] scenario-tags)}))
-
-;------------------------------------------------------------------------------ Layer 3
-
 ;; Composite schemas
-(def ^{:stratum 3} LogContext
+(def ^{:stratum 0} LogContext
   "Schema for log entry context fields."
-  [:map {:registry logging-registry}
+  [:map {:registry logging-vocab/logging-registry}
    [:ctx/workflow-id {:optional true} :workflow/id]
    [:ctx/task-id {:optional true} :task/id]
    [:ctx/agent-id {:optional true} :agent/id]
    [:ctx/phase {:optional true} :workflow/phase]
    [:ctx/loop {:optional true} :log/loop-type]])
 
-(def ^{:stratum 3} ScenarioContext
+(def ^{:stratum 0} ScenarioContext
   "Schema for scenario tracking in logs."
-  [:map {:registry logging-registry}
+  [:map {:registry logging-vocab/logging-registry}
    [:scenario/id {:optional true} :id/uuid]
    [:scenario/tags {:optional true} [:set :scenario/tag]]])
 
-(def ^{:stratum 3} TraceContext
+(def ^{:stratum 0} TraceContext
   "Schema for distributed tracing correlation."
-  [:map {:registry logging-registry}
+  [:map {:registry logging-vocab/logging-registry}
    [:trace/id {:optional true} :id/uuid]
    [:span/id {:optional true} :id/uuid]
    [:parent-span/id {:optional true} :id/uuid]])
 
-(def ^{:stratum 3} PerfMetrics
+(def ^{:stratum 0} PerfMetrics
   "Schema for performance metrics in log entries."
-  [:map {:registry logging-registry}
+  [:map {:registry logging-vocab/logging-registry}
    [:perf/duration-ms {:optional true} :common/non-neg-int]
    [:perf/tokens-used {:optional true} :common/non-neg-int]
    [:perf/cost-usd {:optional true} :common/pos-number]])
 
-(def ^{:stratum 3} LogEntry
+(def ^{:stratum 0} LogEntry
   "Schema for a structured log entry.
    Core data substrate for debugging, tracing, and meta loop signals."
-  [:map {:registry logging-registry}
+  [:map {:registry logging-vocab/logging-registry}
    ;; Required fields
    [:log/id :log/id]
    [:log/timestamp :common/timestamp]
@@ -178,9 +97,9 @@
    [:perf/tokens-used {:optional true} :common/non-neg-int]
    [:perf/cost-usd {:optional true} :common/pos-number]])
 
-(def ^{:stratum 3} Scenario
+(def ^{:stratum 0} Scenario
   "Schema for a test scenario definition."
-  [:map {:registry logging-registry}
+  [:map {:registry logging-vocab/logging-registry}
    [:scenario/id :id/uuid]
    [:scenario/name [:string {:min 1}]]
    [:scenario/tags {:optional true} [:set :scenario/tag]]
@@ -221,7 +140,7 @@
   (m/explain LogEntry {:log/id "not-uuid" :log/level :invalid})
 
   ;; Check all events are valid
-  (every? #(m/validate (into [:enum] all-events) %) all-events)
+  (every? #(m/validate (into [:enum] logging-vocab/all-events) %) logging-vocab/all-events)
   ;; => true
 
   :leave-this-here)

--- a/components/schema/src/ai/miniforge/schema/logging.clj
+++ b/components/schema/src/ai/miniforge/schema/logging.clj
@@ -17,7 +17,7 @@
 ;; limitations under the License.
 (ns ai.miniforge.schema.logging
   "Logging schemas for miniforge structured EDN logging. Event/level/category
-   vocabularies and the logging registry live in `logging-vocab.clj` (split
+   vocabularies and the logging registry live in `logging_vocab.clj` (split
    out under SL003, Wave 2) — this file only holds the `:map` composites
    built on top of that registry.
    Layer 0: Composite schemas (LogContext, ScenarioContext, TraceContext,

--- a/components/schema/src/ai/miniforge/schema/logging_vocab.clj
+++ b/components/schema/src/ai/miniforge/schema/logging_vocab.clj
@@ -1,0 +1,118 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.schema.logging-vocab
+  "Event/level/category vocabularies and the logging malli registry. Split
+   out of `logging.clj` (SL003, Wave 2) so the log/scenario composite
+   schemas in `logging.clj` have a vocabulary to depend on without pushing
+   either file over the 3-layer budget.
+   Layer 0: Base event/level/category vocabularies
+   Layer 1: all-events (aggregates the Layer 0 event vocabularies)
+   Layer 2: logging-registry (the malli registry, extends `vocab/registry`)"
+  (:require
+   [ai.miniforge.schema.vocab :as vocab]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Base types and event taxonomy
+(def ^{:stratum 0} log-levels
+  [:trace :debug :info :warn :error :fatal])
+
+(def ^{:stratum 0} log-categories
+  [:agent :loop :policy :artifact :system])
+
+(def ^{:stratum 0} loop-types
+  "Types of control loops in the system."
+  [:inner :outer :meta])
+
+(def ^{:stratum 0} agent-events
+  "Events emitted by agent operations."
+  [:agent/task-started
+   :agent/task-completed
+   :agent/task-failed
+   :agent/prompt-sent
+   :agent/response-received
+   :agent/memory-updated])
+
+(def ^{:stratum 0} loop-events
+  "Events emitted by control loops."
+  [:inner/iteration-started
+   :inner/validation-passed
+   :inner/validation-failed
+   :inner/repair-attempted
+   :inner/escalated
+   :outer/phase-entered
+   :outer/phase-completed
+   :outer/phase-failed
+   :outer/workflow-completed
+   :meta/signal-collected
+   :meta/improvement-proposed
+   :meta/improvement-applied])
+
+(def ^{:stratum 0} policy-events
+  "Events emitted by policy evaluation."
+  [:policy/gate-evaluated
+   :policy/budget-checked
+   :policy/budget-exceeded
+   :policy/escalation
+   :policy/human-required
+   :policy/human-approved])
+
+(def ^{:stratum 0} artifact-events
+  "Events emitted by artifact operations."
+  [:artifact/created
+   :artifact/versioned
+   :artifact/linked
+   :artifact/validation])
+
+(def ^{:stratum 0} system-events
+  "Events emitted by system operations."
+  [:system/startup
+   :system/shutdown
+   :system/config-changed
+   :system/plugin-loaded
+   :system/health-check])
+
+(def ^{:stratum 0} scenario-tags
+  [:canary :shadow :regression :smoke :stress :chaos :golden-path :error-recovery :rollback])
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} all-events
+  (vec (concat agent-events loop-events policy-events artifact-events system-events)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(def ^{:stratum 2} logging-registry
+  "Malli registry for logging schema types."
+  (merge
+   vocab/registry
+   {:log/id        :id/uuid
+    :log/level     (into [:enum] log-levels)
+    :log/category  (into [:enum] log-categories)
+    :log/event     (into [:enum] all-events)
+    :log/loop-type (into [:enum] loop-types)
+    :scenario/tag  (into [:enum] scenario-tags)}))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Check all events are valid
+  (require '[malli.core :as m])
+  (every? #(m/validate (into [:enum] all-events) %) all-events)
+  ;; => true
+
+  :leave-this-here)

--- a/components/schema/src/ai/miniforge/schema/supervisory.clj
+++ b/components/schema/src/ai/miniforge/schema/supervisory.clj
@@ -15,7 +15,7 @@
    Layer 2: Composite schemas (WorkflowRun, PolicyEvaluation, PolicyViolation,
             AttentionItem, Waiver, EvidenceBundle)"
   (:require
-   [ai.miniforge.schema.core :as core]))
+   [ai.miniforge.schema.vocab :as vocab]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -27,10 +27,10 @@
   [:style :security :testing :documentation :architecture :process :budget])
 
 (def ^{:stratum 0} violation-severities
-  "Pass-through to the canonical severity scale (policy-clause via core).
+  "Pass-through to the canonical severity scale (policy-clause via vocab).
    Enum use only — the canonical most-to-least order replaces the reversed
    copy that used to live here."
-  core/severities)
+  vocab/severities)
 
 (def ^{:stratum 0} attention-source-types
   [:workflow :policy :agent :system :human])
@@ -38,9 +38,9 @@
 ;------------------------------------------------------------------------------ Layer 1
 
 (def ^{:stratum 1} supervisory-registry
-  "Malli registry extending core registry with supervisory types."
+  "Malli registry extending the base registry with supervisory types."
   (merge
-   core/registry
+   vocab/registry
    {;; Evaluation types
     :eval/id            :id/uuid
     :eval/result        (into [:enum] eval-results)

--- a/components/schema/src/ai/miniforge/schema/vocab.clj
+++ b/components/schema/src/ai/miniforge/schema/vocab.clj
@@ -1,0 +1,145 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.schema.vocab
+  "Base enum vocabularies, severity helpers, and the shared malli registry
+   for the schema component. Split out of `core.clj` (SL003, Wave 2) so the
+   composite entity schemas in `core.clj` have a vocabulary to depend on
+   without pushing either file over the 3-layer budget.
+   Layer 0: Base enum vocabularies and severity pass-throughs
+   Layer 1: registry — the shared malli registry, built from Layer 0
+   Layer 2: Severity — the constructed enum schema, built from registry"
+  (:require
+   [ai.miniforge.policy-clause.interface :as clause]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Base enum vocabularies and severity helpers
+(def ^{:stratum 0} agent-roles
+  [:planner :architect :implementer :tester :reviewer :sre :security :release :historian :operator])
+
+(def ^{:stratum 0} meta-agent-roles
+  "Meta-agent roles for workflow monitoring and control."
+  [:progress-monitor :test-quality :conflict-detector :resource-manager :evidence-collector])
+
+(def ^{:stratum 0} task-types
+  [:plan :design :implement :test :review :deploy])
+
+(def ^{:stratum 0} task-statuses
+  [:pending :running :completed :failed :blocked])
+
+(def ^{:stratum 0} artifact-types
+  [:spec :plan :adr :code :test :review :manifest :image :telemetry :incident])
+
+(def ^{:stratum 0} workflow-phases
+  [:plan :design :implement :verify :review :release :observe])
+
+(def ^{:stratum 0} workflow-statuses
+  [:pending :running :paused :completed :failed :cancelled])
+
+(def ^{:stratum 0} severities
+  "Canonical severity levels, most to least severe. Defined by the
+   policy-clause component (Ariadne step 1a) and passed through here so
+   every schema consumer keeps one import site. A violation's severity
+   is the severity of the rule it violates, so one scale — not a
+   per-producer vocabulary. Legacy `:major`/`:minor` map to
+   `:high`/`:low` via `normalize-severity`."
+  clause/severities)
+
+(def ^{:stratum 0} normalize-severity
+  "Coerce a legacy severity keyword to the canonical enum: `:major` → `:high`,
+   `:minor` → `:low`; every canonical value is returned unchanged. Pass-through
+   to policy-clause."
+  clause/normalize-severity)
+
+(def ^{:stratum 0} severity-order
+  "Rank per severity, 0 = most severe. Pass-through to policy-clause so the order
+   table cannot drift from the enum."
+  clause/severity-order)
+
+(def ^{:stratum 0} compare-severity
+  "Compare two severities. Negative when `a` is more severe than `b`, positive
+   when less, 0 when equal. An unknown severity on either side returns an
+   `:invalid-input` anomaly (subtype `:anomalies.policy-clause/unknown-severity`)
+   — the pre-Ariadne sort-unknown-last default was a fail-open and is gone."
+  clause/compare-severity)
+
+(def ^{:stratum 0} more-severe
+  "Return the more severe of two severities, or an anomaly when either is
+   unknown (see `compare-severity`)."
+  clause/more-severe)
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} registry
+  "Malli registry for base schema types."
+  {;; Identifiers
+   :id/uuid        uuid?
+   :id/string      [:string {:min 1}]
+
+   ;; Agent types
+   :agent/id       :id/uuid
+   :agent/role     (into [:enum] agent-roles)
+   :agent/capability keyword?
+
+   ;; Meta-agent types
+   :meta-agent/id  keyword?
+   :meta-agent/role (into [:enum] meta-agent-roles)
+   :meta-agent/status [:enum :healthy :warning :halt]
+   :meta-agent/priority [:enum :high :medium :low]
+
+   ;; Task types
+   :task/id        :id/uuid
+   :task/type      (into [:enum] task-types)
+   :task/status    (into [:enum] task-statuses)
+
+   ;; Artifact types
+   :artifact/id    :id/uuid
+   :artifact/type  (into [:enum] artifact-types)
+   :artifact/version [:string {:min 1}]
+
+   ;; Workflow types
+   :workflow/id    :id/uuid
+   :workflow/phase (into [:enum] workflow-phases)
+   :workflow/status (into [:enum] workflow-statuses)
+
+   ;; Severity (canonical, shared across policy + supervisory + display)
+   :severity (into [:enum] severities)
+
+   ;; Common types
+   :common/timestamp inst?
+   :common/non-neg-int [:int {:min 0}]
+   :common/pos-number [:double {:min 0.0}]})
+
+;------------------------------------------------------------------------------ Layer 2
+
+(def ^{:stratum 2} Severity
+  "Malli enum for a canonical severity level (see `severities`). Reuses the
+   `:severity` registry entry so there is one constructed enum, not two copies."
+  (:severity registry))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Base registry has entries for every domain id/enum
+  (contains? registry :agent/role)
+  ;; => true
+
+  ;; Severity enum matches the canonical severities vocabulary
+  (= severities [:critical :high :medium :low :info])
+  ;; => true
+
+  :leave-this-here)

--- a/docs/meta-agents.md
+++ b/docs/meta-agents.md
@@ -304,7 +304,7 @@ Workflow runner integrates coordinator:
 2. **Add to Registry**
 
    ```clojure
-   ;; In components/schema/src/ai/miniforge/schema/core.clj
+   ;; In components/schema/src/ai/miniforge/schema/vocab.clj
    (def meta-agent-roles
      [...existing...
       :my-agent])

--- a/docs/pull-requests/2026-07-28-fix-stratum-lint-wave2-schema-split.md
+++ b/docs/pull-requests/2026-07-28-fix-stratum-lint-wave2-schema-split.md
@@ -1,0 +1,243 @@
+# fix(schema): split core.clj and logging.clj to clear the 3-layer stratum budget (SL003, Wave 2)
+
+## Overview
+
+Splits two over-budget files in `components/schema` into a vocabulary
+namespace plus a slimmer composite-schema namespace each, so every file
+in the component lands at or under the 3-layer `SL003` budget for real
+(computed, not decorative) layers. No executable logic changed: def
+bodies, docstrings, and validation semantics are copied verbatim to
+their new location; only namespace headers, `:require` forms, `Layer N`
+headings, and `^{:stratum n}` metadata change.
+
+- `core.clj` (327 lines, 4 real layers) → `vocab.clj` (enums + severity
+  pass-throughs + `registry` + `Severity`, 3 layers) + `core.clj`
+  (composite entity schemas, 2 layers).
+- `logging.clj` (228 lines, 4 real layers) → `logging-vocab.clj` (event
+  taxonomy + `all-events` + `logging-registry`, 3 layers) +
+  `logging.clj` (composite log/scenario schemas, 1 layer).
+
+## Motivation
+
+This is the Wave 2 follow-on flagged by the Wave 1 mechanical pass for
+this component (`docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-schema.md`):
+that PR's `--fix` run corrected `core.clj` and `logging.clj` from
+decorative (undercounted) 2-layer headings to their real 4-layer
+structure, which is genuinely over the 3-layer budget rule 210 sets
+(`.cursor/rules/languages/clojure.mdc`). Confirmed independently before
+touching anything, via a fresh plain-lint run:
+
+```text
+components/schema/src/ai/miniforge/schema/core.clj:225:1: SL003 file uses 4 distinct layers (max 3); split the namespace or extract a component
+components/schema/src/ai/miniforge/schema/logging.clj:111:1: SL003 file uses 4 distinct layers (max 3); split the namespace or extract a component
+```
+
+Zero `SL001`/`SL002`/`SL004` findings on the component going in — no
+upward-reference/cycle risk to reason about, and no decorative-heading
+cleanup needed first.
+
+The task that seeded this PR named only `core.clj`, but `logging.clj`
+carries the identical defect (same shape: a vocabulary/registry stratum
+feeding a composite-schema stratum, one layer too many when kept in one
+file) and is explicitly called out as a Wave 2 target in the Wave 1 PR
+above. Leaving it unsplit would leave the component's `SL003` count
+non-zero, so it's fixed in the same PR rather than deferred again.
+
+## Changes in Detail
+
+### `core.clj` → `vocab.clj` + `core.clj`
+
+Real reference graph in the pre-split file: the base enum vectors
+(`agent-roles`, `task-types`, ...) and the policy-clause severity
+pass-throughs (`severities`, `normalize-severity`, `severity-order`,
+`compare-severity`, `more-severe`) are independent leaves; `registry`
+(a malli registry map) is built from those enums; `Severity` (a
+constructed malli enum) pulls `:severity` out of `registry`; the eight
+"standalone" composite `:map` schemas (`Agent`, `TaskConstraints`,
+`TaskResult`, `ArtifactOrigin`, `WorkflowBudget`, `Metrics`,
+`MetaAgentConfig`, `MetaAgentHealthCheck`) each reference `registry`
+only; and the four top-level composites (`Task`, `Artifact`, `Workflow`,
+`MetaCoordinatorState`) embed those standalone composites as sub-schemas
+(`Task` embeds `TaskConstraints`/`TaskResult`, `Artifact` embeds
+`ArtifactOrigin`, `Workflow` embeds `WorkflowBudget`,
+`MetaCoordinatorState` embeds `MetaAgentHealthCheck`). That's 4 real
+layers in one file.
+
+New `vocab.clj` takes everything through `Severity` (3 layers: enums →
+`registry` → `Severity`) — a self-contained vocabulary namespace with no
+dependency on the composite schemas. `core.clj` keeps only the
+`:map` composites, now requiring `vocab` for `registry`: the eight
+standalone composites collapse to a single real layer (Layer 0 relative
+to this file — they only reference `vocab/registry`, not each other),
+and the four top-level composites are Layer 1 (they reference the
+Layer-0 composites in the same file). 2 real layers, within budget.
+
+### `logging.clj` → `logging-vocab.clj` + `logging.clj`
+
+Same shape. The event/level/category vocabularies (`log-levels`,
+`agent-events`, `scenario-tags`, ...) are leaves; `all-events` (Layer 1)
+aggregates the event vocabularies; `logging-registry` (Layer 2) merges
+`vocab/registry` with logging-specific registry entries built from the
+vocabularies and `all-events`. The six composite schemas (`LogContext`,
+`ScenarioContext`, `TraceContext`, `PerfMetrics`, `LogEntry`,
+`Scenario`) each reference only `logging-registry` — none of them
+reference each other (`LogEntry` re-lists the same keys `LogContext`
+etc. declare rather than embedding them as sub-schemas; that redundancy
+predates this PR and is out of scope here — no behavior change).
+
+New `logging-vocab.clj` takes the vocabularies through `logging-registry`
+(3 layers, requires `vocab` for the base `registry` merge). `logging.clj`
+keeps only the six composite schemas, now requiring `logging-vocab`:
+since none of the six reference each other, they all land at a single
+real layer (Layer 0) — a full layer under budget, room to spare.
+
+### `interface.clj`
+
+`interface.clj` re-exports individual symbols by qualified reference
+(`core/agent-roles`, `logging/log-levels`, ...), not through `*ns*`
+inspection, so nothing here changes shape — only which required
+namespace each pass-through def points at changes:
+
+- `agent-roles`, `task-types`, `task-statuses`, `artifact-types`,
+  `workflow-phases`, `workflow-statuses`, `severities`, `Severity`,
+  `severity-order`, `normalize-severity`, `compare-severity`,
+  `more-severe`: `core/*` → `vocab/*`.
+- `log-levels`, `log-categories`, `all-events`, `scenario-tags`:
+  `logging/*` → `logging-vocab/*`.
+- `Agent`, `Task`, `Artifact`, `Workflow`, `TaskConstraints`,
+  `TaskResult`, `ArtifactOrigin`, `WorkflowBudget`, `Metrics`,
+  `LogEntry`, `Scenario`: unchanged (`core/*` / `logging/*` — these
+  symbols didn't move). `registry` itself was never re-exported through
+  `interface.clj`, so no change needed there.
+
+`interface.clj`'s own real-layer count is unaffected: its layers are
+computed from same-file references between its `def`s, and this PR
+doesn't add or remove any same-file dependency there, only repoints
+which external var a handful of pass-throughs source from.
+
+### Same-component internal callers
+
+`logging.clj` and `supervisory.clj` both required `ai.miniforge.schema.core`
+directly for `core/registry` (and `supervisory.clj` also for
+`core/severities`) — legal per rule 210 (same-component files may
+reference `.core`/subnamespaces directly; only cross-component calls
+must go through `.interface`). Both now require `ai.miniforge.schema.vocab`
+instead and reference `vocab/registry` / `vocab/severities`, since that's
+where those symbols live now. `logging.clj` additionally now requires the
+new `logging-vocab` for its own composite schemas' registry.
+
+A repo-wide grep for `ai.miniforge.schema.core` outside this component
+turned up only two comments (in `automation-edge-correlator/schema.clj`
+and `-interface.clj`) documenting the cross-component-avoidance pattern,
+and one in `supervisory-state/schema.clj` — none are actual requires, so
+no cross-component fix was needed. `components/schema/test/` doesn't
+reference `.core`/`.logging`/`.supervisory` directly anywhere (only
+`.interface`), so no test-file updates were needed either.
+
+## Testing Plan
+
+1. Read `core.clj`, `logging.clj`, `supervisory.clj`, and `interface.clj`
+   in full before making any change, and grepped the whole repo for
+   `ai.miniforge.schema.core` to confirm no cross-component `.core`
+   requires existed to fix.
+2. Plain `stratum-lint` before any change reproduced the 2 `SL003`
+   findings above exactly (`core.clj` and `logging.clj`, 4 layers each).
+3. Designed and applied the split (this PR's diff).
+4. Ran `--fix` over the whole component after the split: zero diff (the
+   `Layer N` headings and `^{:stratum n}` metadata written by hand
+   already match what the tool derives). Ran it a second time
+   immediately after: zero diff again, confirms idempotency.
+5. Read the full diff for every changed/new file. `core.clj` and
+   `logging.clj`'s `(comment ...)` rich-comment blocks were checked
+   symbol-by-symbol against what moved — `logging.clj`'s comment
+   referenced bare `all-events`, which no longer resolves there, so it
+   was rewritten to `logging-vocab/all-events` (the file already
+   requires `logging-vocab`, and the comment needs valid refs even
+   though it isn't compiled at load time). No docstring was dropped or
+   truncated in the moves.
+6. Plain `stratum-lint` re-run over `components/schema`:
+
+   ```bash
+   bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "80699e378cb8ebbb6daeb928431aa4a6b373c07e" :deps/root "clojure"}}}' -m stratum-lint.interface components/schema
+   ```
+
+   Exit `0`, no output — zero `SL001`/`SL002`/`SL003`/`SL004` findings
+   across the whole component, including the 2 new files.
+7. `clj-kondo --lint components/schema`: 0 errors, 8 pre-existing
+   warnings (deprecated `schema/validate`, exercised by its own
+   backward-compat test coverage — present before this PR, unrelated to
+   the split).
+8. Ran the 6 schema-component test namespaces directly
+   (`clojure -M:test`, via `clojure.test/run-tests`): 36 tests, 139
+   assertions, 0 failures, 0 errors.
+9. `clojure -M:poly check`: passes; only two pre-existing warnings
+   unrelated to this component (`config` non-top namespace in test
+   fixtures, an unnecessary `decision-envelope` component reference in
+   `data-foundry`).
+10. Tried `bb test` (stable-derived changed-and-affected) for full
+    coverage. This branch's stable tag predates a large amount of merged
+    work, so in practice it exercises most of the workspace, not just
+    schema's dependents, and it got through hundreds of tests across
+    many components with 0 failures/0 errors — but it does not complete
+    in this sandbox: it stalls in `dag-executor.executor-test`, which
+    retries against a Docker daemon this environment doesn't have
+    (`SKIPPED: Docker not available` after each ~120s retry) and never
+    returns. Waited it out past 9 minutes of retries before it was
+    terminated (`EXIT:143`/`SIGTERM`) — a pre-existing environment
+    limitation unrelated to this change, not a test failure.
+11. Fell back to targeted direct test runs (`clojure -M:test` +
+    `clojure.test/run-tests`, same technique as step 8) for the
+    dependent components most exposed to this split: the two components
+    whose comments reference `schema.core` directly
+    (`automation-edge-correlator` + `supervisory-state`: 137 tests, 396
+    assertions, 0 failures/0 errors) plus `task` (38 tests, 128
+    assertions) and `gate` (42 tests, 122 assertions), both 0
+    failures/0 errors — central, heavy consumers of `schema.interface`'s
+    `Task`/`Workflow`/severity surface.
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+change — namespace/require/heading/metadata-only. Pre-commit's
+`lint:stratum` autofixer keeps this component clean going forward; both
+of the component's `SL003` findings are now resolved (not deferred to
+`warn` mode).
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+- Predecessor: `docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-schema.md`
+  (mechanical relabeling; flagged both `core.clj` and `logging.clj` as
+  Wave 2 targets)
+
+## Checklist
+
+- [x] Full-file reads of `core.clj`/`interface.clj` and a repo-wide grep
+      for `ai.miniforge.schema.core` before making any change
+- [x] Split designed around the real same-file reference graph, not a
+      mechanical line-count cut
+- [x] `core.clj` → `vocab.clj` (3 layers) + `core.clj` (2 layers)
+- [x] `logging.clj` → `logging-vocab.clj` (3 layers) + `logging.clj`
+      (1 layer)
+- [x] `interface.clj` re-exports repointed to whichever namespace now
+      owns each moved symbol; no implementation logic added to it
+- [x] Same-component internal requires (`logging.clj`, `supervisory.clj`)
+      repointed from `.core` to `.vocab`
+- [x] `--fix` run after the split: zero diff; second `--fix` pass
+      confirms idempotency
+- [x] Full diff read for every changed/new file; one stale bare-symbol
+      reference in a `(comment ...)` block found and fixed
+- [x] Plain `stratum-lint` over the whole component: exit 0, no findings
+- [x] `clj-kondo` clean of new issues (0 errors; 8 pre-existing warnings
+      unchanged)
+- [x] Schema component tests: 36 tests, 139 assertions, 0 failures/errors
+- [x] `clojure -M:poly check`: passes (2 pre-existing, unrelated warnings)
+- [x] `bb test`: does not complete in this sandbox (stalls on the
+      Docker-gated `dag-executor.executor-test`, killed after 9+ minutes
+      of retries, `EXIT:143`) — everything it did run before that point
+      was 0 failures/0 errors; not this change's fault
+- [x] Fallback direct dependent-component tests in place of full `bb
+      test`: `automation-edge-correlator` + `supervisory-state` (137
+      tests/396 assertions), `task` (38/128), `gate` (42/122) — all 0
+      failures/0 errors
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time

--- a/docs/pull-requests/2026-07-28-fix-stratum-lint-wave2-schema-split.md
+++ b/docs/pull-requests/2026-07-28-fix-stratum-lint-wave2-schema-split.md
@@ -13,7 +13,7 @@ headings, and `^{:stratum n}` metadata change.
 - `core.clj` (327 lines, 4 real layers) → `vocab.clj` (enums + severity
   pass-throughs + `registry` + `Severity`, 3 layers) + `core.clj`
   (composite entity schemas, 2 layers).
-- `logging.clj` (228 lines, 4 real layers) → `logging-vocab.clj` (event
+- `logging.clj` (228 lines, 4 real layers) → `logging_vocab.clj` (event
   taxonomy + `all-events` + `logging-registry`, 3 layers) +
   `logging.clj` (composite log/scenario schemas, 1 layer).
 
@@ -72,7 +72,7 @@ to this file — they only reference `vocab/registry`, not each other),
 and the four top-level composites are Layer 1 (they reference the
 Layer-0 composites in the same file). 2 real layers, within budget.
 
-### `logging.clj` → `logging-vocab.clj` + `logging.clj`
+### `logging.clj` → `logging_vocab.clj` + `logging.clj`
 
 Same shape. The event/level/category vocabularies (`log-levels`,
 `agent-events`, `scenario-tags`, ...) are leaves; `all-events` (Layer 1)
@@ -85,7 +85,7 @@ reference each other (`LogEntry` re-lists the same keys `LogContext`
 etc. declare rather than embedding them as sub-schemas; that redundancy
 predates this PR and is out of scope here — no behavior change).
 
-New `logging-vocab.clj` takes the vocabularies through `logging-registry`
+New `logging_vocab.clj` takes the vocabularies through `logging-registry`
 (3 layers, requires `vocab` for the base `registry` merge). `logging.clj`
 keeps only the six composite schemas, now requiring `logging-vocab`:
 since none of the six reference each other, they all land at a single
@@ -217,7 +217,7 @@ of the component's `SL003` findings are now resolved (not deferred to
 - [x] Split designed around the real same-file reference graph, not a
       mechanical line-count cut
 - [x] `core.clj` → `vocab.clj` (3 layers) + `core.clj` (2 layers)
-- [x] `logging.clj` → `logging-vocab.clj` (3 layers) + `logging.clj`
+- [x] `logging.clj` → `logging_vocab.clj` (3 layers) + `logging.clj`
       (1 layer)
 - [x] `interface.clj` re-exports repointed to whichever namespace now
       owns each moved symbol; no implementation logic added to it


### PR DESCRIPTION
## Summary

- Wave 2 namespace split for `components/schema`, follow-on to
  `docs/pull-requests/2026-07-26-fix-stratum-lint-wave1-schema.md`,
  which flagged both `core.clj` and `logging.clj` as over the 3-layer
  `SL003` budget (4 real layers each) once Wave 1's mechanical `--fix`
  corrected their decorative headings.
- `core.clj` (327 lines, 4 layers) → `vocab.clj` (enums + severity
  pass-throughs + `registry` + `Severity`, 3 layers) + `core.clj`
  (composite entity schemas, 2 layers).
- `logging.clj` (228 lines, 4 layers) → `logging-vocab.clj` (event
  taxonomy + `all-events` + `logging-registry`, 3 layers) +
  `logging.clj` (composite log/scenario schemas, 1 layer).
- `interface.clj` and the two same-component internal requires
  (`logging.clj`, `supervisory.clj`) repointed to wherever each symbol
  now lives. No behavior change — same def bodies, docstrings, and
  validation semantics throughout.
- Full write-up: `docs/pull-requests/2026-07-28-fix-stratum-lint-wave2-schema-split.md`

Commits are sliced under the repo's 200-reportable-line commit budget,
each landing in a compilable state (new vocab namespaces added first
and unused, then consumers repointed, then the dead code removed from
`core.clj` last).

## Test plan

- [x] Plain `stratum-lint` before: 2 `SL003` findings (`core.clj`,
      `logging.clj`, 4 layers each)
- [x] Plain `stratum-lint` after (non-warn mode):
      `bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "80699e378cb8ebbb6daeb928431aa4a6b373c07e" :deps/root "clojure"}}}' -m stratum-lint.interface components/schema`
      → exit `0`, no output
- [x] `--fix` re-run over the whole component after the split: zero
      diff (idempotent)
- [x] `clj-kondo --lint components/schema`: 0 errors, 8 pre-existing
      warnings (deprecated `schema/validate`, unrelated to this change)
- [x] Schema component tests direct (`clojure -M:test` +
      `clojure.test/run-tests`): 36 tests, 139 assertions, 0
      failures/errors
- [x] `clojure -M:poly check`: passes (2 pre-existing unrelated
      warnings)
- [x] `bb test` does not complete in this sandbox — stalls retrying
      `dag-executor.executor-test` against a Docker daemon that isn't
      available here, killed after 9+ minutes (`EXIT:143`); everything
      it ran before that point was 0 failures/0 errors. Environment
      limitation, not a result of this change.
- [x] Fallback direct dependent-component tests in place of full `bb
      test`: `automation-edge-correlator` + `supervisory-state` (the
      two components with an in-repo comment referencing
      `schema.core`) — 137 tests/396 assertions; `task` — 38/128;
      `gate` — 42/122. All 0 failures/0 errors.
- [x] Every commit's own pre-commit hook run (commit-budget, poly
      check, clj-kondo, stratum-lint, and the pre-commit smoke suite —
      331 tests/1244 assertions plus 8 GraalVM-compat tests) passed
      cleanly at each of the 5 slices, confirming the working tree
      compiles and the curated smoke set stays green at every
      intermediate step, not just the tip.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>