### PR TITLE
fix(evidence-bundle): split schema.clj to clear the 3-layer stratum budget (SL003, Wave 2)

### DIFF
--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/collector.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/collector.clj
@@ -24,6 +24,7 @@
    [ai.miniforge.content-hash.interface :as content-hash]
    [ai.miniforge.evidence-bundle.protocols.impl.semantic-validator :as semantic-validator]
    [ai.miniforge.evidence-bundle.schema :as schema]
+   [ai.miniforge.evidence-bundle.schema.compliance :as compliance]
    [ai.miniforge.evidence-bundle.scanner :as scanner]
    [ai.miniforge.event-stream.interface :as event-stream]
    [ai.miniforge.response.interface :as response]))
@@ -59,16 +60,17 @@
 ;; Compliance Defaults and Overrides
 (defn- ^{:stratum 0} build-default-compliance-metadata
   "Return the default compliance map for assembled evidence bundles.
-   Uses schema-defined defaults so the single source of truth lives in schema.clj.
-   Covers the assembly path; the template function covers manual construction."
+   Uses schema.compliance-defined defaults so the single source of truth
+   lives there. Covers the assembly path; the template function covers
+   manual construction."
   []
-  {:evidence/data-classification schema/default-data-classification
+  {:evidence/data-classification compliance/default-data-classification
    :evidence/contains-pii?       false
-   :evidence/retention-policy    {:retain-days  schema/default-retention-days
+   :evidence/retention-policy    {:retain-days  compliance/default-retention-days
                                   :auto-delete? true
                                   :legal-hold?  false}
    :evidence/regulatory-tags     #{}
-   :evidence/created-by          schema/default-created-by-principal})
+   :evidence/created-by          compliance/default-created-by-principal})
 
 (def ^{:stratum 0} ^:private compliance-override-keys
   "Allowed keys for workflow-spec and opts compliance override maps."

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/interface.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.evidence-bundle.interface
   "Public API for the evidence-bundle component.
    Handles evidence collection, storage, and provenance tracing per N6 spec."
@@ -25,35 +24,35 @@
    [ai.miniforge.evidence-bundle.collector :as collector]
    [ai.miniforge.evidence-bundle.extraction :as extraction]
    [ai.miniforge.evidence-bundle.schema :as schema]
+   [ai.miniforge.evidence-bundle.schema.compliance :as compliance]
+   [ai.miniforge.evidence-bundle.schema.domain :as domain]
    [ai.miniforge.evidence-bundle.interface.protocols.evidence-bundle :as p]
    [ai.miniforge.evidence-bundle.protocols.records.evidence-bundle :as records]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Protocol re-exports
 
-(def EvidenceBundle
+;; Protocol re-exports
+(def ^{:stratum 0} EvidenceBundle
   "Protocol for creating, storing, and querying evidence bundles.
    Methods: create-bundle, get-bundle, get-bundle-by-workflow,
    query-bundles, validate-bundle, export-bundle.
    Implemented by the manager returned from create-evidence-manager."
   p/EvidenceBundle)
 
-(def ProvenanceTracer
+(def ^{:stratum 0} ProvenanceTracer
   "Protocol for tracing artifact provenance chains.
    Methods: query-provenance, trace-artifact-chain, query-intent-mismatches.
    Implemented by the manager returned from create-evidence-manager."
   p/ProvenanceTracer)
 
-(def SemanticValidator
+(def ^{:stratum 0} SemanticValidator
   "Protocol for semantic intent validation.
    Methods: validate-intent, analyze-terraform-plan, analyze-kubernetes-manifest.
    Implemented by the manager returned from create-evidence-manager."
   p/SemanticValidator)
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Evidence Bundle Manager Creation
-
-(defn create-evidence-manager
+(defn ^{:stratum 0} create-evidence-manager
   "Create an evidence bundle manager.
 
    Options:
@@ -71,10 +70,8 @@
   [opts]
   (records/create-evidence-bundle-manager opts))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Evidence Bundle Operations
-
-(defn create-bundle
+(defn ^{:stratum 0} create-bundle
   "Create an evidence bundle for a completed workflow.
 
    Arguments:
@@ -94,19 +91,19 @@
   [manager workflow-id opts]
   (p/create-bundle manager workflow-id opts))
 
-(defn get-bundle
+(defn ^{:stratum 0} get-bundle
   "Retrieve an evidence bundle by ID.
    Returns evidence bundle map or nil if not found."
   [manager bundle-id]
   (p/get-bundle manager bundle-id))
 
-(defn get-bundle-by-workflow
+(defn ^{:stratum 0} get-bundle-by-workflow
   "Retrieve evidence bundle for a specific workflow.
    Returns evidence bundle map or nil if not found."
   [manager workflow-id]
   (p/get-bundle-by-workflow manager workflow-id))
 
-(defn query-bundles
+(defn ^{:stratum 0} query-bundles
   "Query evidence bundles by criteria.
 
    Criteria options:
@@ -122,13 +119,13 @@
   [manager criteria]
   (p/query-bundles manager criteria))
 
-(defn validate-bundle
+(defn ^{:stratum 0} validate-bundle
   "Validate evidence bundle structure and integrity.
    Returns {:valid? bool :errors [...]}"
   [manager bundle]
   (p/validate-bundle manager bundle))
 
-(defn export-bundle
+(defn ^{:stratum 0} export-bundle
   "Export evidence bundle to file (EDN format).
 
    Arguments:
@@ -143,10 +140,8 @@
   [manager bundle-id output-path]
   (p/export-bundle manager bundle-id output-path))
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Provenance Tracing
-
-(defn query-provenance
+(defn ^{:stratum 0} query-provenance
   "Get full provenance for an artifact.
 
    Returns map with:
@@ -164,7 +159,7 @@
   [manager artifact-id]
   (p/query-provenance manager artifact-id))
 
-(defn trace-artifact-chain
+(defn ^{:stratum 0} trace-artifact-chain
   "Trace complete artifact chain for a workflow.
 
    Returns map with:
@@ -177,7 +172,7 @@
   [manager workflow-id]
   (p/trace-artifact-chain manager workflow-id))
 
-(defn query-intent-mismatches
+(defn ^{:stratum 0} query-intent-mismatches
   "Find workflows where declared intent != actual behavior.
 
    Options:
@@ -195,10 +190,8 @@
   [manager opts]
   (p/query-intent-mismatches manager opts))
 
-;------------------------------------------------------------------------------ Layer 4
 ;; Semantic Validation
-
-(defn validate-intent
+(defn ^{:stratum 0} validate-intent
   "Validate implementation matches declared intent.
 
    Arguments:
@@ -216,7 +209,7 @@
   [manager intent implementation-artifacts]
   (p/validate-intent manager intent implementation-artifacts))
 
-(defn analyze-terraform-plan
+(defn ^{:stratum 0} analyze-terraform-plan
   "Analyze Terraform plan for resource changes.
 
    Returns map with:
@@ -229,7 +222,7 @@
   [manager plan-artifact]
   (p/analyze-terraform-plan manager plan-artifact))
 
-(defn analyze-kubernetes-manifest
+(defn ^{:stratum 0} analyze-kubernetes-manifest
   "Analyze Kubernetes manifest for resource changes.
 
    Returns map with:
@@ -242,10 +235,8 @@
   [manager manifest-artifact]
   (p/analyze-kubernetes-manifest manager manifest-artifact))
 
-;------------------------------------------------------------------------------ Layer 5
 ;; Evidence Collection Helpers
-
-(defn extract-intent
+(defn ^{:stratum 0} extract-intent
   "Extract intent from workflow specification.
    Returns intent evidence map per N6 spec.
 
@@ -254,7 +245,7 @@
   [workflow-spec]
   (collector/extract-intent workflow-spec))
 
-(defn assemble-evidence-bundle
+(defn ^{:stratum 0} assemble-evidence-bundle
   "Assemble complete evidence bundle from workflow state.
 
    This is a convenience function that combines all evidence collection steps.
@@ -281,7 +272,7 @@
   [workflow-id workflow-state artifact-store & [opts]]
   (collector/assemble-evidence-bundle workflow-id workflow-state artifact-store opts))
 
-(defn append-access-log-entry
+(defn ^{:stratum 0} append-access-log-entry
   "Append an access log entry to the bundle's :evidence/access-log.
    Stamps :access-log/timestamp on the entry when absent.
    Append-only contract: existing entries are never removed or mutated.
@@ -298,7 +289,7 @@
   [bundle entry]
   (collector/append-access-log-entry bundle entry))
 
-(defn auto-collect-evidence
+(defn ^{:stratum 0} auto-collect-evidence
   "Automatically collect evidence when workflow reaches terminal state.
 
    This function checks if the workflow is complete/failed and automatically
@@ -312,10 +303,8 @@
   [workflow-id workflow-state artifact-store]
   (collector/auto-collect-evidence workflow-id workflow-state artifact-store))
 
-;------------------------------------------------------------------------------ Layer 6
 ;; Content Hashing
-
-(defn content-hash
+(defn ^{:stratum 0} content-hash
   "Compute SHA-256 digest of artifact content.
    Returns hex-encoded hash string.
 
@@ -331,64 +320,59 @@
 
 ;------------------------------------------------------------------------------ Layer 7b
 ;; Chain Evidence
-
-(defn create-chain-evidence
+(defn ^{:stratum 0} create-chain-evidence
   "Create a chain-level evidence record from chain results."
   [chain-def chain-result & [opts]]
   (chain-evidence/create-chain-evidence chain-def chain-result opts))
 
-(defn summarize-step
+(defn ^{:stratum 0} summarize-step
   "Create a summary of a single chain step."
   [step-result step-index]
   (chain-evidence/summarize-step step-result step-index))
 
-(defn aggregate-metrics
+(defn ^{:stratum 0} aggregate-metrics
   "Aggregate metrics across chain step results."
   [step-results]
   (chain-evidence/aggregate-metrics step-results))
 
-;------------------------------------------------------------------------------ Layer 7
 ;; Schema Exports
-
-(def intent-types
+(def ^{:stratum 0} intent-types
   "Valid intent types per N6 spec."
-  schema/intent-types)
+  domain/intent-types)
 
-(def semantic-validation-rules
+(def ^{:stratum 0} semantic-validation-rules
   "Validation rules per N6 section 2.4.1."
-  schema/semantic-validation-rules)
+  domain/semantic-validation-rules)
 
-(def data-classifications
+(def ^{:stratum 0} data-classifications
   "Valid data classification levels for evidence bundles.
    Members: :public :internal :confidential :restricted."
-  schema/data-classifications)
+  compliance/data-classifications)
 
-(def regulatory-tag-values
+(def ^{:stratum 0} regulatory-tag-values
   "Regulatory frameworks that may apply to an evidence bundle.
    Members: :gdpr :hipaa :sox :pci."
-  schema/regulatory-tag-values)
+  compliance/regulatory-tag-values)
 
-(def default-retention-days
+(def ^{:stratum 0} default-retention-days
   "Default retention period for evidence bundles — 90 days.
    Callers can override per-bundle retention through :evidence/retention-policy
    in workflow-spec or opts compliance metadata."
-  schema/default-retention-days)
+  compliance/default-retention-days)
 
-(def default-data-classification
+(def ^{:stratum 0} default-data-classification
   "Default data classification for new evidence bundles — :internal.
    Operators must explicitly assign :public, :confidential, or :restricted."
-  schema/default-data-classification)
+  compliance/default-data-classification)
 
-(defn create-evidence-template
+(defn ^{:stratum 0} create-evidence-template
   "Create an empty evidence bundle template.
    Useful for testing or manual bundle construction."
   []
   (schema/create-evidence-bundle-template))
 
-;------------------------------------------------------------------------------ Layer 8
 ;; Artifact Extraction
-
-(defn extract-file
+(defn ^{:stratum 0} extract-file
   "Extract a single file from artifact and write to disk.
 
    File map should contain:
@@ -405,7 +389,7 @@
   [file-map]
   (extraction/extract-file file-map))
 
-(defn extract-files
+(defn ^{:stratum 0} extract-files
   "Extract multiple files from artifact and write to disk.
 
    Artifact should be a map containing:
@@ -424,7 +408,7 @@
   [artifact]
   (extraction/extract-files artifact))
 
-(defn load-artifact
+(defn ^{:stratum 0} load-artifact
   "Load artifact from an EDN file.
 
    Arguments:
@@ -437,7 +421,7 @@
   [artifact-path]
   (extraction/load-artifact artifact-path))
 
-(defn extract-artifact-from-file
+(defn ^{:stratum 0} extract-artifact-from-file
   "Load artifact from file and extract all files to disk.
 
    Convenience function combining load-artifact and extract-files.
@@ -452,7 +436,7 @@
   [artifact-path]
   (extraction/extract-artifact-from-file artifact-path))
 
-(defn validate-artifact
+(defn ^{:stratum 0} validate-artifact
   "Validate artifact structure for extraction.
 
    Returns map with:
@@ -465,7 +449,6 @@
   (extraction/validate-artifact artifact))
 
 ;------------------------------------------------------------------------------ Rich Comment
-
 (comment
   (require '[ai.miniforge.artifact.interface :as artifact])
 

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/protocols/impl/evidence_bundle.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/protocols/impl/evidence_bundle.clj
@@ -20,7 +20,8 @@
    Pure functions organized in layers."
   (:require
    [ai.miniforge.evidence-bundle.collector :as collector]
-   [ai.miniforge.evidence-bundle.schema :as schema]
+   [ai.miniforge.evidence-bundle.schema.domain :as domain]
+   [ai.miniforge.evidence-bundle.schema.validation :as validation]
    [ai.miniforge.logging.interface :as log]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -131,7 +132,7 @@
         ;; Validate intent structure
         intent (:evidence/intent bundle)
         intent-validation (when intent
-                            (schema/validate-schema schema/intent-schema intent))
+                            (validation/validate-schema domain/intent-schema intent))
 
         _ (when (and intent-validation (not (:valid? intent-validation)))
             (swap! errors concat (:errors intent-validation)))
@@ -139,8 +140,8 @@
         ;; Validate semantic validation structure (only if present and non-empty)
         sem-val (:evidence/semantic-validation bundle)
         sem-val-validation (when (and sem-val (seq sem-val))
-                             (schema/validate-schema
-                              schema/semantic-validation-schema sem-val))
+                             (validation/validate-schema
+                              domain/semantic-validation-schema sem-val))
 
         _ (when (and sem-val-validation (not (:valid? sem-val-validation)))
             (swap! errors concat (:errors sem-val-validation)))]

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/protocols/impl/semantic_validator.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/protocols/impl/semantic_validator.clj
@@ -15,18 +15,17 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.evidence-bundle.protocols.impl.semantic-validator
   "Implementation functions for SemanticValidator protocol.
    Validates that implementation matches declared intent."
   (:require
-   [ai.miniforge.evidence-bundle.schema :as schema]
+   [ai.miniforge.evidence-bundle.schema.domain :as domain]
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Terraform Plan Analysis
 
-(defn parse-terraform-change-line
+;; Terraform Plan Analysis
+(defn ^{:stratum 0} parse-terraform-change-line
   "Parse a single Terraform plan line for resource changes.
    Returns {:type :create|:update|:destroy|:recreate|:import}"
   [line]
@@ -49,7 +48,33 @@
     :else
     nil))
 
-(defn analyze-terraform-plan-impl
+;; Kubernetes Manifest Analysis
+(defn ^{:stratum 0} analyze-kubernetes-manifest-impl
+  "Analyze Kubernetes manifest for resource changes.
+   Returns {:creates N :updates N :destroys N}"
+  [manifest-artifact]
+  ;; Simplified implementation - count resources in manifest
+  (let [content (or (:artifact/content manifest-artifact) "")
+        ;; Count 'kind:' declarations as resources
+        resources (count (re-seq #"(?m)^kind:" content))]
+    {:creates resources
+     :updates 0
+     :destroys 0}))
+
+;; Semantic Validation Rules
+(defn ^{:stratum 0} check-rule
+  "Check if actual count matches rule.
+   Rule can be: 0 (must be zero), :pos (must be positive), :any (any value)"
+  [rule-value actual-count]
+  (case rule-value
+    0 (= 0 actual-count)
+    :pos (> actual-count 0)
+    :any true
+    (= rule-value actual-count)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} analyze-terraform-plan-impl
   "Analyze Terraform plan artifact for resource changes.
    Returns {:creates N :updates N :destroys N}"
   [plan-artifact]
@@ -68,40 +93,14 @@
      :updates updates
      :destroys (+ destroys recreate-destroys)}))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Kubernetes Manifest Analysis
-
-(defn analyze-kubernetes-manifest-impl
-  "Analyze Kubernetes manifest for resource changes.
-   Returns {:creates N :updates N :destroys N}"
-  [manifest-artifact]
-  ;; Simplified implementation - count resources in manifest
-  (let [content (or (:artifact/content manifest-artifact) "")
-        ;; Count 'kind:' declarations as resources
-        resources (count (re-seq #"(?m)^kind:" content))]
-    {:creates resources
-     :updates 0
-     :destroys 0}))
-
 ;------------------------------------------------------------------------------ Layer 2
-;; Semantic Validation Rules
 
-(defn check-rule
-  "Check if actual count matches rule.
-   Rule can be: 0 (must be zero), :pos (must be positive), :any (any value)"
-  [rule-value actual-count]
-  (case rule-value
-    0 (= 0 actual-count)
-    :pos (> actual-count 0)
-    :any true
-    (= rule-value actual-count)))
-
-(defn validate-intent-impl
+(defn ^{:stratum 2} validate-intent-impl
   "Validate implementation matches declared intent.
    Returns {:passed? bool :violations [...]}"
   [intent implementation-artifacts]
   (let [intent-type (:intent/type intent)
-        rules (get schema/semantic-validation-rules intent-type)
+        rules (get domain/semantic-validation-rules intent-type)
         violations (atom [])
 
         ;; Analyze all artifacts to count changes

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/schema.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/schema.clj
@@ -16,191 +16,25 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns ai.miniforge.evidence-bundle.schema
-  "Schema definitions for evidence bundles and related structures.
+  "Root evidence-bundle schema: the complete evidence bundle document, and
+   its default template.
+
+   Domain sub-schemas (intent, phase, policy, outcome, provenance, tool,
+   pack-promotion, supervision, control-action) live in schema.domain;
+   compliance/retention/access-log metadata lives in schema.compliance; the
+   optional-key marker and the generic validate-schema engine live in
+   schema.optional-key and schema.validation respectively (split out SL003,
+   Wave 2 — this file used to hold all of it, at 7 real layers).
+
    Based on N6 Evidence & Provenance Standard."
   (:require
-   [ai.miniforge.schema.interface :as shared]))
+   [ai.miniforge.evidence-bundle.schema.compliance :as compliance]
+   [ai.miniforge.evidence-bundle.schema.optional-key :as optional-key]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
-;; Schema Utilities
-(defrecord ^{:stratum 0} OptionalKey [key])
-
-;; Intent Schema
-(def ^{:stratum 0} intent-types
-  "Valid intent types per N6 spec."
-  #{:import :create :update :destroy :refactor :migrate})
-
-;; Phase Evidence Schema
-(def ^{:stratum 0} phase-result-status-values
-  "Valid status values for a phase result in the N6 environment model."
-  #{:success :failure :already-implemented :retrying :completed})
-
-;; Semantic Validation Schema
-(def ^{:stratum 0} semantic-validation-rules
-  "Validation rules per N6 section 2.4.1."
-  {:import  {:creates 0 :updates 0 :destroys 0}
-   :create  {:creates :pos :updates :any :destroys 0}
-   :update  {:creates 0 :updates :pos :destroys 0}
-   :destroy {:creates 0 :updates 0 :destroys :pos}
-   :refactor {:creates 0 :updates 0 :destroys 0}
-   :migrate {:creates :pos :updates 0 :destroys :pos}})
-
-(def ^{:stratum 0} semantic-validation-schema
-  "Schema for semantic validation evidence."
-  {:semantic-validation/declared-intent keyword?
-   :semantic-validation/actual-behavior keyword?
-   :semantic-validation/resource-creates nat-int?
-   :semantic-validation/resource-updates nat-int?
-   :semantic-validation/resource-destroys nat-int?
-   :semantic-validation/passed? boolean?
-   :semantic-validation/violations vector?
-   :semantic-validation/checked-at inst?})
-
-;; Policy Check Schema
-(def ^{:stratum 0} violation-severities
-  "Pass-through to the canonical severity scale (policy-clause via the
-   shared schema interface) — the local copy is gone."
-  (set shared/severities))
-
-(def ^{:stratum 0} policy-check-schema
-  "Schema for policy check evidence."
-  {:policy-check/pack-id string?
-   :policy-check/pack-version string?
-   :policy-check/phase keyword?
-   :policy-check/checked-at inst?
-   :policy-check/violations vector?
-   :policy-check/passed? boolean?
-   ;; nat-int?: evidence collection defaults a missing duration to 0
-   ;; (build-policy-check-evidence), which pos-int? would reject
-   :policy-check/duration-ms nat-int?
-   ;; nilable: legacy/mechanical gate results carry no DecisionEnvelope —
-   ;; the collector always writes the key, with nil for envelope-less checks
-   :policy-check/envelope (some-fn nil? map?)})
-
-;; Outcome Schema
-(def ^{:stratum 0} pr-statuses #{:open :merged :closed})
-
-;; Compliance Schema
-(def ^{:stratum 0} pii-handling-types #{:none :redacted :encrypted})
-
-(def ^{:stratum 0} data-classifications
-  "Valid data classification levels for evidence bundles."
-  #{:public :internal :confidential :restricted})
-
-(def ^{:stratum 0} regulatory-tag-values
-  "Regulatory frameworks that may apply to an evidence bundle."
-  #{:gdpr :hipaa :sox :pci})
-
-(def ^{:stratum 0} default-retention-days
-  "Default retention period for evidence bundles — 90 days aligns with the
-   team's baseline audit window. Callers can override per-bundle retention
-   through :evidence/retention-policy in workflow-spec or opts compliance
-   metadata for regulatory environments that require longer holds."
-  90)
-
-(def ^{:stratum 0} default-data-classification
-  "Default data classification for new evidence bundles. :internal rather
-   than :public ensures new bundles are never accidentally treated as safe
-   to share externally; operators promoting to :public must explicitly opt in.
-   :confidential and :restricted require manual assignment at bundle creation."
-  :internal)
-
-(def ^{:stratum 0} default-created-by-principal
-  "Default :evidence/created-by value for system-generated bundles.
-   The string 'system' is the canonical principal token for automated evidence
-   collection, distinct from a human user identity."
-  "system")
-
-(def ^{:stratum 0} retention-policy-schema
-  "Schema for retention policy sub-document."
-  {:retain-days pos-int?
-   :auto-delete? boolean?
-   :legal-hold? boolean?})
-
-;------------------------------------------------------------------------------ Layer 5a
-;; Rule Applied Schema
-(def ^{:stratum 0} rule-applied-schema
-  "Schema for a single rule-applied entry in the evidence bundle.
-   Captures which knowledge base rules were injected into agent context.
-   Keys match the manifest shape returned by knowledge store's
-   compute-manifest-entry, with :phase added by the collector."
-  {:id uuid?
-   :title string?
-   :role keyword?
-   :tags-matched vector?
-   :score number?
-   :phase keyword?})
-
-;; Pack Promotion Schema
-(def ^{:stratum 0} trust-levels
-  "Valid trust levels for pack promotion per N6 spec."
-  #{:untrusted :tainted :trusted})
-
-;------------------------------------------------------------------------------ Layer 1
-
-(defn ^{:stratum 1} optional-key
-  "Mark a schema key as optional."
-  [k]
-  (->OptionalKey k))
-
-(defn ^{:stratum 1} optional-key?
-  "Check if a key is marked as optional."
-  [k]
-  (instance? OptionalKey k))
-
-(def ^{:stratum 1} implement-phase-result-schema
-  "Schema for the implement phase result in the N6 environment model.
-
-   Code changes live in the execution environment's git working tree and are
-   NOT serialized here. The :environment-id identifies where changes landed;
-   :summary is the agent's description of changes made.
-   :metrics shape: {:tokens N :duration-ms N}"
-  {:status         (fn [s] (contains? phase-result-status-values s))
-   :environment-id string?
-   :summary        string?
-   :metrics        map?})
-
-(def ^{:stratum 1} verify-phase-result-schema
-  "Schema for the verify phase result in the N6 environment model.
-
-   Test results are captured in :metrics; no serialized code is stored.
-   :metrics shape: {:tokens N :duration-ms N :pass-count N :fail-count N
-                    :test-output string}"
-  {:status         (fn [s] (contains? phase-result-status-values s))
-   :environment-id string?
-   :summary        string?
-   :metrics        map?})
-
-(def ^{:stratum 1} release-phase-result-schema
-  "Schema for the release phase result in the N6 environment model.
-
-   PR metadata is captured in :metrics. Code provenance is derived from the
-   PR diff — the PR URL provides the authoritative record of what changed.
-   :metrics shape: {:tokens N :duration-ms N :pr-url string :branch string
-                    :commit-sha string}"
-  {:status         (fn [s] (contains? phase-result-status-values s))
-   :environment-id string?
-   :summary        string?
-   :metrics        map?})
-
-;------------------------------------------------------------------------------ Layer 5b
-;; Compliance Validators
-;; Named fns — not anonymous — so they can be tested independently and
-;; referenced by name in evidence-bundle-schema (rule 002: no anon fns in maps).
-(defn- ^{:stratum 1} valid-data-classification?
-  "Returns true when v is a member of data-classifications."
-  [v]
-  (contains? data-classifications v))
-
-(defn- ^{:stratum 1} valid-regulatory-tags?
-  "Returns true when v is a set containing only known regulatory tags."
-  [v]
-  (and (set? v)
-       (every? #(contains? regulatory-tag-values %) v)))
-
 ;; Template
-(defn ^{:stratum 1} create-evidence-bundle-template
+(defn ^{:stratum 0} create-evidence-bundle-template
   "Create an empty evidence bundle template with default compliance metadata."
   []
   {:evidence-bundle/id (random-uuid)
@@ -213,203 +47,17 @@
    :evidence/tool-invocations []
    :evidence/pack-promotions []
    :evidence/dependency-health {}
-   :evidence/data-classification default-data-classification
+   :evidence/data-classification compliance/default-data-classification
    :evidence/contains-pii? false
-   :evidence/retention-policy {:retain-days default-retention-days
+   :evidence/retention-policy {:retain-days compliance/default-retention-days
                                :auto-delete? true
                                :legal-hold? false}
    :evidence/regulatory-tags #{}
-   :evidence/created-by default-created-by-principal
+   :evidence/created-by compliance/default-created-by-principal
    :evidence/access-log []})
 
-;------------------------------------------------------------------------------ Layer 2
-
-(defn ^{:stratum 2} unwrap-key
-  "Unwrap an optional key to get the actual key."
-  [k]
-  (if (optional-key? k)
-    (:key k)
-    k))
-
-(def ^{:stratum 2} constraint-schema
-  "Schema for intent constraints."
-  {:constraint/type keyword?
-   :constraint/description string?
-   (optional-key :constraint/validation-fn) fn?})
-
-(def ^{:stratum 2} intent-schema
-  "Schema for intent evidence."
-  {:intent/type (fn [t] (contains? intent-types t))
-   :intent/description string?
-   :intent/business-reason string?
-   :intent/constraints (fn [cs] (every? map? cs))
-   :intent/declared-at inst?
-   (optional-key :intent/author) string?})
-
-(def ^{:stratum 2} phase-evidence-schema
-  "Schema for individual phase evidence."
-  {:phase/name keyword?
-   :phase/agent keyword?
-   :phase/agent-instance-id uuid?
-   :phase/started-at inst?
-   :phase/completed-at inst?
-   :phase/duration-ms pos-int?
-   :phase/output map?
-   :phase/artifacts (fn [as] (every? uuid? as))
-   (optional-key :phase/inner-loop-iterations) pos-int?
-   (optional-key :phase/event-stream-range) map?})
-
-(def ^{:stratum 2} violation-schema
-  "Schema for policy violation."
-  {:violation/rule-id string?
-   :violation/severity (fn [s] (contains? violation-severities s))
-   :violation/message string?
-   (optional-key :violation/location) map?
-   (optional-key :violation/remediation) string?
-   (optional-key :violation/auto-fixable?) boolean?})
-
-(def ^{:stratum 2} outcome-schema
-  "Schema for workflow outcome."
-  {:outcome/success boolean?
-   (optional-key :outcome/pr-number) pos-int?
-   (optional-key :outcome/pr-url) string?
-   (optional-key :outcome/pr-status) (fn [s] (contains? pr-statuses s))
-   (optional-key :outcome/pr-merged-at) inst?
-   (optional-key :outcome/error-message) string?
-   (optional-key :outcome/error-phase) keyword?
-   (optional-key :outcome/error-details) map?})
-
-(def ^{:stratum 2} compliance-schema
-  "Schema for compliance metadata."
-  {:compliance/created-at inst?
-   :compliance/sensitive-data boolean?
-   :compliance/pii-handling (fn [t] (contains? pii-handling-types t))
-   (optional-key :compliance/retention-policy) keyword?
-   (optional-key :compliance/auditor-notes) string?})
-
-(def ^{:stratum 2} access-log-entry-schema
-  "Schema for a single access log entry on an evidence bundle."
-  {:access-log/principal string?
-   :access-log/action keyword?
-   :access-log/timestamp inst?
-   (optional-key :access-log/reason) string?})
-
-;; Artifact Provenance Schema
-(def ^{:stratum 2} provenance-schema
-  "Schema for artifact provenance per N6 section 3.2."
-  {:provenance/workflow-id uuid?
-   :provenance/phase keyword?
-   :provenance/agent keyword?
-   :provenance/agent-instance-id uuid?
-   :provenance/created-at inst?
-   (optional-key :provenance/created-by-event-id) uuid?
-   (optional-key :provenance/source-artifacts) (fn [as] (every? uuid? as))
-   (optional-key :provenance/tool-executions) vector?
-   :provenance/content-hash string?
-   (optional-key :provenance/signature) string?})
-
-(def ^{:stratum 2} tool-execution-schema
-  "Schema for tool execution record."
-  {:tool/name keyword?
-   :tool/version string?
-   :tool/args map?
-   :tool/invoked-at inst?
-   :tool/duration-ms pos-int?
-   (optional-key :tool/exit-code) int?
-   (optional-key :tool/output-summary) string?})
-
-(def ^{:stratum 2} tool-invocation-schema
-  "Schema for tool invocation record."
-  {:tool/id keyword?
-   :tool/invoked-at inst?
-   :tool/duration-ms nat-int?
-   :tool/args map?
-   (optional-key :tool/result) (fn [_] true)
-   (optional-key :tool/exit-code) int?
-   (optional-key :tool/error) map?})
-
-(def ^{:stratum 2} pack-promotion-schema
-  "Schema for pack promotion evidence per N6 section 2.1."
-  {:pack/id string?
-   :pack/type keyword?
-   :from-trust (fn [t] (contains? trust-levels t))
-   :to-trust (fn [t] (contains? trust-levels t))
-   :promoted-by string?
-   :promoted-at inst?
-   :promotion-policy string?
-   :promotion-justification string?  ; REQUIRED: audit trail for trust decision
-   :pack-hash string?
-   (optional-key :pack-signature) string?})
-
-;; Supervision Decision Schema (N6 tool-use evidence)
-(def ^{:stratum 2} supervision-decision-schema
-  "Schema for individual supervision decision evidence."
-  {:supervision/tool-name string?
-   :supervision/decision string?
-   :supervision/timestamp inst?
-   (optional-key :supervision/reasoning) string?
-   (optional-key :supervision/meta-eval?) boolean?
-   (optional-key :supervision/confidence) float?
-   (optional-key :supervision/phase) keyword?})
-
-(def ^{:stratum 2} control-action-evidence-schema
-  "Schema for control action evidence."
-  {:control-action/id uuid?
-   :control-action/type keyword?
-   :control-action/requester map?
-   :control-action/timestamp inst?
-   :control-action/result keyword?
-   (optional-key :control-action/justification) string?
-   (optional-key :control-action/target) map?})
-
-;------------------------------------------------------------------------------ Layer 3
-
-;------------------------------------------------------------------------------ Layer 0b
-;; Schema Validation Helper
-;; Defined early so Layer 5+ schemas can reference it in named validator fns.
-(defn ^{:stratum 3} validate-schema
-  "Simple schema validation.
-   Returns {:valid? bool :errors [...]}"
-  [schema data]
-  (let [errors (atom [])]
-    (doseq [[k validator] schema]
-      (let [is-optional? (optional-key? k)
-            actual-key   (unwrap-key k)
-            v            (get data actual-key)]
-        (cond
-          (and (nil? v) (not is-optional?))
-          (swap! errors conj {:key actual-key :error "Required key missing"})
-
-          (and (some? v) (fn? validator) (not (validator v)))
-          (swap! errors conj {:key actual-key :error "Validation failed" :value v}))))
-    {:valid? (empty? @errors)
-     :errors @errors}))
-
-;------------------------------------------------------------------------------ Layer 4
-
-(defn- ^{:stratum 4} valid-retention-policy-map?
-  "Returns true when v is a map that satisfies retention-policy-schema."
-  [v]
-  (and (map? v)
-       (:valid? (validate-schema retention-policy-schema v))))
-
-(defn- ^{:stratum 4} valid-access-log-entry?
-  "Returns true when a single access log entry satisfies access-log-entry-schema."
-  [entry]
-  (:valid? (validate-schema access-log-entry-schema entry)))
-
-;------------------------------------------------------------------------------ Layer 5
-
-(defn- ^{:stratum 5} valid-access-log?
-  "Returns true when the access log is a vector of valid entries."
-  [v]
-  (and (vector? v)
-       (every? valid-access-log-entry? v)))
-
-;------------------------------------------------------------------------------ Layer 6
-
 ;; Evidence Bundle Schema
-(def ^{:stratum 6} evidence-bundle-schema
+(def ^{:stratum 0} evidence-bundle-schema
   "Complete schema for evidence bundle per N6 spec."
   {:evidence-bundle/id uuid?
    :evidence-bundle/workflow-id uuid?
@@ -423,55 +71,61 @@
    ;; :evidence/implement — summary + metrics (no :code/files)
    ;; :evidence/verify   — test output in :phase/output :metrics
    ;; :evidence/release  — PR metadata in :phase/output :metrics; code from PR diff
-   (optional-key :evidence/plan) map?
-   (optional-key :evidence/design) map?
-   (optional-key :evidence/implement) map?
-   (optional-key :evidence/verify) map?
-   (optional-key :evidence/review) map?
-   (optional-key :evidence/release) map?
-   (optional-key :evidence/observe) map?
+   (optional-key/optional-key :evidence/plan) map?
+   (optional-key/optional-key :evidence/design) map?
+   (optional-key/optional-key :evidence/implement) map?
+   (optional-key/optional-key :evidence/verify) map?
+   (optional-key/optional-key :evidence/review) map?
+   (optional-key/optional-key :evidence/release) map?
+   (optional-key/optional-key :evidence/observe) map?
 
    ;; Validation
-   (optional-key :evidence/semantic-validation) map?
+   (optional-key/optional-key :evidence/semantic-validation) map?
    :evidence/policy-checks vector?
-   (optional-key :evidence/tool-invocations) vector?
+   (optional-key/optional-key :evidence/tool-invocations) vector?
 
    ;; Pack Promotions (optional, for ETL workflows)
-   (optional-key :evidence/pack-promotions) vector?
+   (optional-key/optional-key :evidence/pack-promotions) vector?
 
    ;; Supervision Decisions (N6 tool-use evidence)
-   (optional-key :evidence/supervision-decisions) vector?
+   (optional-key/optional-key :evidence/supervision-decisions) vector?
 
    ;; Control Action Evidence
-   (optional-key :evidence/control-actions) vector?
+   (optional-key/optional-key :evidence/control-actions) vector?
 
    ;; Rules Applied (knowledge base rules injected into agents)
-   (optional-key :evidence/rules-applied) vector?
+   (optional-key/optional-key :evidence/rules-applied) vector?
 
    ;; Execution Evidence (N11 §9.1)
-   (optional-key :evidence/execution-mode) keyword?
-   (optional-key :evidence/runtime-class) keyword?
-   (optional-key :evidence/task-started-at) inst?
-   (optional-key :evidence/task-finished-at) inst?
-   (optional-key :evidence/image-digest) string?
+   (optional-key/optional-key :evidence/execution-mode) keyword?
+   (optional-key/optional-key :evidence/runtime-class) keyword?
+   (optional-key/optional-key :evidence/task-started-at) inst?
+   (optional-key/optional-key :evidence/task-finished-at) inst?
+   (optional-key/optional-key :evidence/image-digest) string?
 
    ;; Dependency Attribution
-   (optional-key :evidence/dependency-health) map?
-   (optional-key :evidence/failure-attribution) map?
+   (optional-key/optional-key :evidence/dependency-health) map?
+   (optional-key/optional-key :evidence/failure-attribution) map?
 
    ;; Outcome
    :evidence/outcome map?
 
    ;; Compliance
-   (optional-key :compliance/sensitive-data) boolean?
-   (optional-key :compliance/pii-handling) keyword?
-   (optional-key :compliance/retention-policy) keyword?
-   (optional-key :compliance/auditor-notes) string?
+   (optional-key/optional-key :compliance/sensitive-data) boolean?
+   (optional-key/optional-key :compliance/pii-handling) keyword?
+   (optional-key/optional-key :compliance/retention-policy) keyword?
+   (optional-key/optional-key :compliance/auditor-notes) string?
 
    ;; Compliance Metadata (extended) — all optional for backwards compatibility.
-   (optional-key :evidence/data-classification) valid-data-classification?
-   (optional-key :evidence/contains-pii?) boolean?
-   (optional-key :evidence/retention-policy) valid-retention-policy-map?
-   (optional-key :evidence/regulatory-tags) valid-regulatory-tags?
-   (optional-key :evidence/created-by) string?
-   (optional-key :evidence/access-log) valid-access-log?})
+   (optional-key/optional-key :evidence/data-classification) compliance/valid-data-classification?
+   (optional-key/optional-key :evidence/contains-pii?) boolean?
+   (optional-key/optional-key :evidence/retention-policy) compliance/valid-retention-policy-map?
+   (optional-key/optional-key :evidence/regulatory-tags) compliance/valid-regulatory-tags?
+   (optional-key/optional-key :evidence/created-by) string?
+   (optional-key/optional-key :evidence/access-log) compliance/valid-access-log?})
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (create-evidence-bundle-template)
+  evidence-bundle-schema
+  :end)

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/schema/compliance.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/schema/compliance.clj
@@ -1,0 +1,127 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.evidence-bundle.schema.compliance
+  "Compliance, retention, and access-log schemas for evidence bundles.
+
+   Data classification, PII handling, regulatory tags, retention policy, and
+   the audit access-log — the compliance-metadata subset of the N6 Evidence
+   & Provenance Standard, plus the predicates that validate them.
+
+   Split out of the former `schema.clj` (SL003, Wave 2) — this was its
+   Layer 0 (compliance constants/schemas) and Layer 2/4/5 (the `valid-*?`
+   predicates that validate them, which called down into the also-moved
+   `validate-schema`)."
+  (:require
+   [ai.miniforge.evidence-bundle.schema.optional-key :as optional-key]
+   [ai.miniforge.evidence-bundle.schema.validation :as validation]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} pii-handling-types #{:none :redacted :encrypted})
+
+(def ^{:stratum 0} data-classifications
+  "Valid data classification levels for evidence bundles."
+  #{:public :internal :confidential :restricted})
+
+(def ^{:stratum 0} regulatory-tag-values
+  "Regulatory frameworks that may apply to an evidence bundle."
+  #{:gdpr :hipaa :sox :pci})
+
+(def ^{:stratum 0} default-retention-days
+  "Default retention period for evidence bundles — 90 days aligns with the
+   team's baseline audit window. Callers can override per-bundle retention
+   through :evidence/retention-policy in workflow-spec or opts compliance
+   metadata for regulatory environments that require longer holds."
+  90)
+
+(def ^{:stratum 0} default-data-classification
+  "Default data classification for new evidence bundles. :internal rather
+   than :public ensures new bundles are never accidentally treated as safe
+   to share externally; operators promoting to :public must explicitly opt in.
+   :confidential and :restricted require manual assignment at bundle creation."
+  :internal)
+
+(def ^{:stratum 0} default-created-by-principal
+  "Default :evidence/created-by value for system-generated bundles.
+   The string 'system' is the canonical principal token for automated evidence
+   collection, distinct from a human user identity."
+  "system")
+
+(def ^{:stratum 0} retention-policy-schema
+  "Schema for retention policy sub-document."
+  {:retain-days pos-int?
+   :auto-delete? boolean?
+   :legal-hold? boolean?})
+
+(def ^{:stratum 0} access-log-entry-schema
+  "Schema for a single access log entry on an evidence bundle."
+  {:access-log/principal string?
+   :access-log/action keyword?
+   :access-log/timestamp inst?
+   (optional-key/optional-key :access-log/reason) string?})
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} compliance-schema
+  "Schema for compliance metadata."
+  {:compliance/created-at inst?
+   :compliance/sensitive-data boolean?
+   :compliance/pii-handling (fn [t] (contains? pii-handling-types t))
+   (optional-key/optional-key :compliance/retention-policy) keyword?
+   (optional-key/optional-key :compliance/auditor-notes) string?})
+
+;; Public (not `defn-`): evidence-bundle-schema in the root `schema` ns
+;; references these as validator predicates across the namespace boundary
+;; that this split introduced. Named fns — not anonymous — so they can be
+;; tested independently (rule 002: no anon fns in maps).
+(defn ^{:stratum 1} valid-data-classification?
+  "Returns true when v is a member of data-classifications."
+  [v]
+  (contains? data-classifications v))
+
+(defn ^{:stratum 1} valid-regulatory-tags?
+  "Returns true when v is a set containing only known regulatory tags."
+  [v]
+  (and (set? v)
+       (every? #(contains? regulatory-tag-values %) v)))
+
+(defn ^{:stratum 1} valid-retention-policy-map?
+  "Returns true when v is a map that satisfies retention-policy-schema."
+  [v]
+  (and (map? v)
+       (:valid? (validation/validate-schema retention-policy-schema v))))
+
+(defn ^{:stratum 1} valid-access-log-entry?
+  "Returns true when a single access log entry satisfies access-log-entry-schema."
+  [entry]
+  (:valid? (validation/validate-schema access-log-entry-schema entry)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} valid-access-log?
+  "Returns true when the access log is a vector of valid entries."
+  [v]
+  (and (vector? v)
+       (every? valid-access-log-entry? v)))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (valid-data-classification? :internal)
+  (valid-retention-policy-map? {:retain-days 90 :auto-delete? true :legal-hold? false})
+  (valid-access-log? [])
+  :end)

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/schema/domain.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/schema/domain.clj
@@ -1,0 +1,267 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.evidence-bundle.schema.domain
+  "Domain evidence schemas per the N6 Evidence & Provenance Standard.
+
+   Intent, phase results, policy checks and violations, outcome, artifact
+   provenance, tool execution, pack promotion, supervision decisions, control
+   actions, and knowledge-rule application — everything the evidence bundle
+   captures about a workflow's execution, distinct from the
+   compliance/retention subset in schema.compliance.
+
+   Split out of the former `schema.clj` (SL003, Wave 2) — this was most of
+   its Layer 0/1/2."
+  (:require
+   [ai.miniforge.evidence-bundle.schema.optional-key :as optional-key]
+   [ai.miniforge.schema.interface :as shared]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Intent Schema
+(def ^{:stratum 0} intent-types
+  "Valid intent types per N6 spec."
+  #{:import :create :update :destroy :refactor :migrate})
+
+(def ^{:stratum 0} semantic-validation-rules
+  "Validation rules per N6 section 2.4.1."
+  {:import  {:creates 0 :updates 0 :destroys 0}
+   :create  {:creates :pos :updates :any :destroys 0}
+   :update  {:creates 0 :updates :pos :destroys 0}
+   :destroy {:creates 0 :updates 0 :destroys :pos}
+   :refactor {:creates 0 :updates 0 :destroys 0}
+   :migrate {:creates :pos :updates 0 :destroys :pos}})
+
+(def ^{:stratum 0} semantic-validation-schema
+  "Schema for semantic validation evidence."
+  {:semantic-validation/declared-intent keyword?
+   :semantic-validation/actual-behavior keyword?
+   :semantic-validation/resource-creates nat-int?
+   :semantic-validation/resource-updates nat-int?
+   :semantic-validation/resource-destroys nat-int?
+   :semantic-validation/passed? boolean?
+   :semantic-validation/violations vector?
+   :semantic-validation/checked-at inst?})
+
+(def ^{:stratum 0} constraint-schema
+  "Schema for intent constraints."
+  {:constraint/type keyword?
+   :constraint/description string?
+   (optional-key/optional-key :constraint/validation-fn) fn?})
+
+;; Phase Evidence Schema
+(def ^{:stratum 0} phase-result-status-values
+  "Valid status values for a phase result in the N6 environment model."
+  #{:success :failure :already-implemented :retrying :completed})
+
+(def ^{:stratum 0} phase-evidence-schema
+  "Schema for individual phase evidence."
+  {:phase/name keyword?
+   :phase/agent keyword?
+   :phase/agent-instance-id uuid?
+   :phase/started-at inst?
+   :phase/completed-at inst?
+   :phase/duration-ms pos-int?
+   :phase/output map?
+   :phase/artifacts (fn [as] (every? uuid? as))
+   (optional-key/optional-key :phase/inner-loop-iterations) pos-int?
+   (optional-key/optional-key :phase/event-stream-range) map?})
+
+;; Policy Check Schema
+(def ^{:stratum 0} policy-check-schema
+  "Schema for policy check evidence."
+  {:policy-check/pack-id string?
+   :policy-check/pack-version string?
+   :policy-check/phase keyword?
+   :policy-check/checked-at inst?
+   :policy-check/violations vector?
+   :policy-check/passed? boolean?
+   ;; nat-int?: evidence collection defaults a missing duration to 0
+   ;; (build-policy-check-evidence), which pos-int? would reject
+   :policy-check/duration-ms nat-int?
+   ;; nilable: legacy/mechanical gate results carry no DecisionEnvelope —
+   ;; the collector always writes the key, with nil for envelope-less checks
+   :policy-check/envelope (some-fn nil? map?)})
+
+(def ^{:stratum 0} violation-severities
+  "Pass-through to the canonical severity scale (policy-clause via the
+   shared schema interface) — the local copy is gone."
+  (set shared/severities))
+
+;; Outcome Schema
+(def ^{:stratum 0} pr-statuses #{:open :merged :closed})
+
+;; Rule Applied Schema
+(def ^{:stratum 0} rule-applied-schema
+  "Schema for a single rule-applied entry in the evidence bundle.
+   Captures which knowledge base rules were injected into agent context.
+   Keys match the manifest shape returned by knowledge store's
+   compute-manifest-entry, with :phase added by the collector."
+  {:id uuid?
+   :title string?
+   :role keyword?
+   :tags-matched vector?
+   :score number?
+   :phase keyword?})
+
+;; Pack Promotion Schema
+(def ^{:stratum 0} trust-levels
+  "Valid trust levels for pack promotion per N6 spec."
+  #{:untrusted :tainted :trusted})
+
+;; Artifact Provenance Schema
+(def ^{:stratum 0} provenance-schema
+  "Schema for artifact provenance per N6 section 3.2."
+  {:provenance/workflow-id uuid?
+   :provenance/phase keyword?
+   :provenance/agent keyword?
+   :provenance/agent-instance-id uuid?
+   :provenance/created-at inst?
+   (optional-key/optional-key :provenance/created-by-event-id) uuid?
+   (optional-key/optional-key :provenance/source-artifacts) (fn [as] (every? uuid? as))
+   (optional-key/optional-key :provenance/tool-executions) vector?
+   :provenance/content-hash string?
+   (optional-key/optional-key :provenance/signature) string?})
+
+(def ^{:stratum 0} tool-execution-schema
+  "Schema for tool execution record."
+  {:tool/name keyword?
+   :tool/version string?
+   :tool/args map?
+   :tool/invoked-at inst?
+   :tool/duration-ms pos-int?
+   (optional-key/optional-key :tool/exit-code) int?
+   (optional-key/optional-key :tool/output-summary) string?})
+
+(def ^{:stratum 0} tool-invocation-schema
+  "Schema for tool invocation record."
+  {:tool/id keyword?
+   :tool/invoked-at inst?
+   :tool/duration-ms nat-int?
+   :tool/args map?
+   (optional-key/optional-key :tool/result) (fn [_] true)
+   (optional-key/optional-key :tool/exit-code) int?
+   (optional-key/optional-key :tool/error) map?})
+
+;; Supervision Decision Schema (N6 tool-use evidence)
+(def ^{:stratum 0} supervision-decision-schema
+  "Schema for individual supervision decision evidence."
+  {:supervision/tool-name string?
+   :supervision/decision string?
+   :supervision/timestamp inst?
+   (optional-key/optional-key :supervision/reasoning) string?
+   (optional-key/optional-key :supervision/meta-eval?) boolean?
+   (optional-key/optional-key :supervision/confidence) float?
+   (optional-key/optional-key :supervision/phase) keyword?})
+
+(def ^{:stratum 0} control-action-evidence-schema
+  "Schema for control action evidence."
+  {:control-action/id uuid?
+   :control-action/type keyword?
+   :control-action/requester map?
+   :control-action/timestamp inst?
+   :control-action/result keyword?
+   (optional-key/optional-key :control-action/justification) string?
+   (optional-key/optional-key :control-action/target) map?})
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} intent-schema
+  "Schema for intent evidence."
+  {:intent/type (fn [t] (contains? intent-types t))
+   :intent/description string?
+   :intent/business-reason string?
+   :intent/constraints (fn [cs] (every? map? cs))
+   :intent/declared-at inst?
+   (optional-key/optional-key :intent/author) string?})
+
+(def ^{:stratum 1} implement-phase-result-schema
+  "Schema for the implement phase result in the N6 environment model.
+
+   Code changes live in the execution environment's git working tree and are
+   NOT serialized here. The :environment-id identifies where changes landed;
+   :summary is the agent's description of changes made.
+   :metrics shape: {:tokens N :duration-ms N}"
+  {:status         (fn [s] (contains? phase-result-status-values s))
+   :environment-id string?
+   :summary        string?
+   :metrics        map?})
+
+(def ^{:stratum 1} verify-phase-result-schema
+  "Schema for the verify phase result in the N6 environment model.
+
+   Test results are captured in :metrics; no serialized code is stored.
+   :metrics shape: {:tokens N :duration-ms N :pass-count N :fail-count N
+                    :test-output string}"
+  {:status         (fn [s] (contains? phase-result-status-values s))
+   :environment-id string?
+   :summary        string?
+   :metrics        map?})
+
+(def ^{:stratum 1} release-phase-result-schema
+  "Schema for the release phase result in the N6 environment model.
+
+   PR metadata is captured in :metrics. Code provenance is derived from the
+   PR diff — the PR URL provides the authoritative record of what changed.
+   :metrics shape: {:tokens N :duration-ms N :pr-url string :branch string
+                    :commit-sha string}"
+  {:status         (fn [s] (contains? phase-result-status-values s))
+   :environment-id string?
+   :summary        string?
+   :metrics        map?})
+
+(def ^{:stratum 1} violation-schema
+  "Schema for policy violation."
+  {:violation/rule-id string?
+   :violation/severity (fn [s] (contains? violation-severities s))
+   :violation/message string?
+   (optional-key/optional-key :violation/location) map?
+   (optional-key/optional-key :violation/remediation) string?
+   (optional-key/optional-key :violation/auto-fixable?) boolean?})
+
+(def ^{:stratum 1} outcome-schema
+  "Schema for workflow outcome."
+  {:outcome/success boolean?
+   (optional-key/optional-key :outcome/pr-number) pos-int?
+   (optional-key/optional-key :outcome/pr-url) string?
+   (optional-key/optional-key :outcome/pr-status) (fn [s] (contains? pr-statuses s))
+   (optional-key/optional-key :outcome/pr-merged-at) inst?
+   (optional-key/optional-key :outcome/error-message) string?
+   (optional-key/optional-key :outcome/error-phase) keyword?
+   (optional-key/optional-key :outcome/error-details) map?})
+
+(def ^{:stratum 1} pack-promotion-schema
+  "Schema for pack promotion evidence per N6 section 2.1."
+  {:pack/id string?
+   :pack/type keyword?
+   :from-trust (fn [t] (contains? trust-levels t))
+   :to-trust (fn [t] (contains? trust-levels t))
+   :promoted-by string?
+   :promoted-at inst?
+   :promotion-policy string?
+   :promotion-justification string?  ; REQUIRED: audit trail for trust decision
+   :pack-hash string?
+   (optional-key/optional-key :pack-signature) string?})
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  intent-schema
+  phase-evidence-schema
+  violation-schema
+  outcome-schema
+  pack-promotion-schema
+  :end)

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/schema/optional_key.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/schema/optional_key.clj
@@ -1,0 +1,50 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.evidence-bundle.schema.optional-key
+  "Optional-key marker for evidence-bundle schema maps.
+
+   A schema map (see schema.domain, schema.compliance, schema itself) pairs
+   each key with a validator predicate; wrapping a key with `optional-key`
+   tells `schema.validation/validate-schema` the key may be absent from data
+   without failing validation.
+
+   Split out of the former `schema.clj` (SL003, Wave 2) — this was its
+   Layer 0/1 (the `OptionalKey` record and its constructor/predicate).")
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defrecord ^{:stratum 0} OptionalKey [key])
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} optional-key
+  "Mark a schema key as optional."
+  [k]
+  (->OptionalKey k))
+
+(defn ^{:stratum 1} optional-key?
+  "Check if a key is marked as optional."
+  [k]
+  (instance? OptionalKey k))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (optional-key :evidence/plan)
+  (optional-key? (optional-key :evidence/plan))
+  (optional-key? :evidence/plan)
+  :end)

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/schema/validation.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/schema/validation.clj
@@ -1,0 +1,63 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.evidence-bundle.schema.validation
+  "Generic schema-map validation engine for evidence-bundle schemas.
+
+   A schema map (schema.domain, schema.compliance, schema itself) pairs each
+   key — optionally wrapped via schema.optional-key/optional-key — with a
+   validator predicate; `validate-schema` checks a data map against one.
+
+   Split out of the former `schema.clj` (SL003, Wave 2) — this was its
+   Layer 2/3 (`unwrap-key` and `validate-schema`)."
+  (:require
+   [ai.miniforge.evidence-bundle.schema.optional-key :as optional-key]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} unwrap-key
+  "Unwrap an optional key to get the actual key."
+  [k]
+  (if (optional-key/optional-key? k)
+    (:key k)
+    k))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} validate-schema
+  "Simple schema validation.
+   Returns {:valid? bool :errors [...]}"
+  [schema data]
+  (let [errors (atom [])]
+    (doseq [[k validator] schema]
+      (let [is-optional? (optional-key/optional-key? k)
+            actual-key   (unwrap-key k)
+            v            (get data actual-key)]
+        (cond
+          (and (nil? v) (not is-optional?))
+          (swap! errors conj {:key actual-key :error "Required key missing"})
+
+          (and (some? v) (fn? validator) (not (validator v)))
+          (swap! errors conj {:key actual-key :error "Validation failed" :value v}))))
+    {:valid? (empty? @errors)
+     :errors @errors}))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (validate-schema {:a string?} {:a "x"})
+  (validate-schema {:a string? (optional-key/optional-key :b) string?} {:a "x"})
+  :end)

--- a/components/evidence-bundle/test/ai/miniforge/evidence_bundle/assembly_integration_test.clj
+++ b/components/evidence-bundle/test/ai/miniforge/evidence_bundle/assembly_integration_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.evidence-bundle.assembly-integration-test
   "Integration test for evidence bundle assembly.
 
@@ -28,22 +27,24 @@
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.content-hash.interface :as hash]
    [ai.miniforge.evidence-bundle.collector :as collector]
-   [ai.miniforge.evidence-bundle.schema :as schema]))
+   [ai.miniforge.evidence-bundle.schema :as schema]
+   [ai.miniforge.evidence-bundle.schema.domain :as domain]
+   [ai.miniforge.evidence-bundle.schema.validation :as validation]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Factory functions
 
-(defn make-workflow-id
+;; Factory functions
+(defn ^{:stratum 0} make-workflow-id
   "Create a random workflow UUID."
   []
   (random-uuid))
 
-(defn make-timestamp
+(defn ^{:stratum 0} make-timestamp
   "Create a timestamp for test data."
   []
   (java.time.Instant/now))
 
-(defn make-workflow-spec
+(defn ^{:stratum 0} make-workflow-spec
   "Create a workflow specification."
   [& {:keys [intent-type description]
       :or {intent-type :create
@@ -55,7 +56,61 @@
                   :constraint/description "No breaking changes"}]
    :author "test-agent"})
 
-(defn make-phase-data
+(deftest ^{:stratum 0} extract-intent-defaults-test
+  (testing "Intent extraction handles missing fields with defaults"
+    (let [minimal-spec {}
+          intent (collector/extract-intent minimal-spec)]
+      (is (= :update (:intent/type intent))
+          "Default intent type should be :update")
+      (is (string? (:intent/description intent))
+          "Description should default to empty string")
+      (is (string? (:intent/business-reason intent))
+          "Business reason should have a default"))))
+
+;; Bundle validation
+(deftest ^{:stratum 0} validate-bundle-template-test
+  (testing "Bundle template passes schema validation for present fields"
+    (let [template (schema/create-evidence-bundle-template)]
+      (is (uuid? (:evidence-bundle/id template))
+          "Template should have a UUID")
+      (is (inst? (:evidence-bundle/created-at template))
+          "Template should have a timestamp")
+      (is (vector? (:evidence/policy-checks template))
+          "Template should have policy-checks vector")
+      (is (vector? (:evidence/tool-invocations template))
+          "Template should have tool-invocations vector"))))
+
+(deftest ^{:stratum 0} validate-incomplete-bundle-test
+  (testing "Schema validation catches missing required fields"
+    (let [incomplete-bundle {:evidence-bundle/id (random-uuid)}
+          result (validation/validate-schema schema/evidence-bundle-schema
+                                             incomplete-bundle)]
+      (is (false? (:valid? result))
+          "Incomplete bundle should fail validation")
+      (is (pos? (count (:errors result)))
+          "Should report missing field errors"))))
+
+;; Content hashing
+(deftest ^{:stratum 0} content-hash-deterministic-test
+  (testing "Same content produces same hash"
+    (let [content {:key "value" :number 42}
+          hash1 (hash/content-hash content)
+          hash2 (hash/content-hash content)]
+      (is (= hash1 hash2)
+          "Hash should be deterministic")
+      (is (= 64 (count hash1))
+          "SHA-256 hex hash should be 64 characters"))))
+
+(deftest ^{:stratum 0} content-hash-different-content-test
+  (testing "Different content produces different hash"
+    (let [hash1 (hash/content-hash {:key "value-a"})
+          hash2 (hash/content-hash {:key "value-b"})]
+      (is (not= hash1 hash2)
+          "Different content should produce different hashes"))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} make-phase-data
   "Create phase execution data for a single phase."
   [& {:keys [agent status started-at completed-at duration-ms artifacts]
       :or {agent :implementer
@@ -74,7 +129,7 @@
      :output {:summary "Phase completed successfully"
               :metrics {:tokens 1000 :duration-ms duration-ms}}}))
 
-(defn make-workflow-state
+(defn ^{:stratum 1} make-workflow-state
   "Create a complete workflow state for bundle assembly."
   [& {:keys [workflow-id status phases gate-results pr-info error
              tool-invocations pack-promotions]
@@ -93,7 +148,7 @@
     pr-info (assoc :workflow/pr-info pr-info)
     error (assoc :workflow/error error)))
 
-(defn make-gate-result
+(defn ^{:stratum 1} make-gate-result
   "Create a gate result record."
   [& {:keys [pack-id phase passed?]
       :or {pack-id "test-pack" phase :implement passed? true}}]
@@ -106,10 +161,8 @@
    :passed? passed?
    :duration-ms 100})
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Intent extraction
-
-(deftest extract-intent-test
+(deftest ^{:stratum 1} extract-intent-test
   (testing "Intent is extracted from workflow specification"
     (let [spec (make-workflow-spec :intent-type :create
                                    :description "Build auth module")
@@ -123,21 +176,26 @@
       (is (inst? (:intent/declared-at intent))
           "Declared-at timestamp should be present"))))
 
-(deftest extract-intent-defaults-test
-  (testing "Intent extraction handles missing fields with defaults"
-    (let [minimal-spec {}
-          intent (collector/extract-intent minimal-spec)]
-      (is (= :update (:intent/type intent))
-          "Default intent type should be :update")
-      (is (string? (:intent/description intent))
-          "Description should default to empty string")
-      (is (string? (:intent/business-reason intent))
-          "Business reason should have a default"))))
+(deftest ^{:stratum 1} validate-intent-schema-test
+  (testing "Intent evidence schema validates required fields"
+    (let [valid-intent {:intent/type :create
+                        :intent/description "Build feature"
+                        :intent/business-reason "User demand"
+                        :intent/constraints []
+                        :intent/declared-at (make-timestamp)}
+          result (validation/validate-schema domain/intent-schema valid-intent)]
+      (is (true? (:valid? result))
+          "Valid intent should pass schema validation"))
 
-;------------------------------------------------------------------------------ Layer 1
+    (let [invalid-intent {:intent/type :create}
+          result (validation/validate-schema domain/intent-schema invalid-intent)]
+      (is (false? (:valid? result))
+          "Intent missing required fields should fail"))))
+
+;------------------------------------------------------------------------------ Layer 2
+
 ;; Phase evidence collection
-
-(deftest collect-single-phase-evidence-test
+(deftest ^{:stratum 2} collect-single-phase-evidence-test
   (testing "Evidence is collected for an executed phase"
     (let [workflow-state (make-workflow-state
                           :phases {:implement (make-phase-data :agent :implementer)})
@@ -159,14 +217,14 @@
       (is (map? (:phase/output evidence))
           "Output should be a map"))))
 
-(deftest collect-phase-evidence-missing-phase-test
+(deftest ^{:stratum 2} collect-phase-evidence-missing-phase-test
   (testing "Returns nil for unexecuted phase"
     (let [workflow-state (make-workflow-state :phases {})
           evidence (collector/collect-phase-evidence workflow-state :implement)]
       (is (nil? evidence)
           "Should return nil for unexecuted phase"))))
 
-(deftest collect-all-phases-test
+(deftest ^{:stratum 2} collect-all-phases-test
   (testing "Evidence is collected for all executed phases"
     (let [workflow-state (make-workflow-state
                           :phases {:plan (make-phase-data :agent :planner)
@@ -184,10 +242,8 @@
       (is (not (contains? all-evidence :evidence/verify))
           "Should not have evidence for unexecuted verify phase"))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Outcome evidence
-
-(deftest outcome-evidence-success-test
+(deftest ^{:stratum 2} outcome-evidence-success-test
   (testing "Outcome evidence for successful workflow"
     (let [workflow-state (make-workflow-state
                           :status :completed
@@ -203,7 +259,7 @@
       (is (= "https://github.com/org/repo/pull/42" (:outcome/pr-url outcome))
           "PR URL should be present"))))
 
-(deftest outcome-evidence-failure-test
+(deftest ^{:stratum 2} outcome-evidence-failure-test
   (testing "Outcome evidence for failed workflow"
     (let [workflow-state (make-workflow-state
                           :status :failed
@@ -217,10 +273,8 @@
       (is (= :implement (:outcome/error-phase outcome))
           "Error phase should be preserved"))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Policy check collection
-
-(deftest collect-policy-checks-test
+(deftest ^{:stratum 2} collect-policy-checks-test
   (testing "Policy checks are collected from gate results"
     (let [workflow-state (make-workflow-state
                           :gate-results [(make-gate-result :phase :implement :passed? true)
@@ -235,17 +289,15 @@
       (is (every? inst? (map :policy-check/checked-at checks))
           "All checks should have timestamps"))))
 
-(deftest collect-policy-checks-empty-test
+(deftest ^{:stratum 2} collect-policy-checks-empty-test
   (testing "Empty gate results produce empty vector"
     (let [workflow-state (make-workflow-state :gate-results [])
           checks (collector/collect-policy-checks workflow-state)]
       (is (empty? checks)
           "Should return empty vector when no gate results"))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Bundle assembly (without artifact store)
-
-(deftest assemble-bundle-required-fields-test
+(deftest ^{:stratum 2} assemble-bundle-required-fields-test
   (testing "Assembled bundle contains all required fields"
     (let [workflow-id (make-workflow-id)
           workflow-state (make-workflow-state
@@ -271,7 +323,7 @@
       (is (string? (:evidence/content-hash bundle))
           "Content hash should be present"))))
 
-(deftest assemble-bundle-with-phases-test
+(deftest ^{:stratum 2} assemble-bundle-with-phases-test
   (testing "Bundle includes phase evidence for executed phases"
     (let [workflow-id (make-workflow-id)
           workflow-state (make-workflow-state
@@ -293,71 +345,8 @@
       (is (nil? (:evidence/release bundle))
           "Release evidence should not be in bundle (not executed)"))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Bundle validation
-
-(deftest validate-bundle-template-test
-  (testing "Bundle template passes schema validation for present fields"
-    (let [template (schema/create-evidence-bundle-template)]
-      (is (uuid? (:evidence-bundle/id template))
-          "Template should have a UUID")
-      (is (inst? (:evidence-bundle/created-at template))
-          "Template should have a timestamp")
-      (is (vector? (:evidence/policy-checks template))
-          "Template should have policy-checks vector")
-      (is (vector? (:evidence/tool-invocations template))
-          "Template should have tool-invocations vector"))))
-
-(deftest validate-incomplete-bundle-test
-  (testing "Schema validation catches missing required fields"
-    (let [incomplete-bundle {:evidence-bundle/id (random-uuid)}
-          result (schema/validate-schema schema/evidence-bundle-schema
-                                         incomplete-bundle)]
-      (is (false? (:valid? result))
-          "Incomplete bundle should fail validation")
-      (is (pos? (count (:errors result)))
-          "Should report missing field errors"))))
-
-(deftest validate-intent-schema-test
-  (testing "Intent evidence schema validates required fields"
-    (let [valid-intent {:intent/type :create
-                        :intent/description "Build feature"
-                        :intent/business-reason "User demand"
-                        :intent/constraints []
-                        :intent/declared-at (make-timestamp)}
-          result (schema/validate-schema schema/intent-schema valid-intent)]
-      (is (true? (:valid? result))
-          "Valid intent should pass schema validation"))
-
-    (let [invalid-intent {:intent/type :create}
-          result (schema/validate-schema schema/intent-schema invalid-intent)]
-      (is (false? (:valid? result))
-          "Intent missing required fields should fail"))))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Content hashing
-
-(deftest content-hash-deterministic-test
-  (testing "Same content produces same hash"
-    (let [content {:key "value" :number 42}
-          hash1 (hash/content-hash content)
-          hash2 (hash/content-hash content)]
-      (is (= hash1 hash2)
-          "Hash should be deterministic")
-      (is (= 64 (count hash1))
-          "SHA-256 hex hash should be 64 characters"))))
-
-(deftest content-hash-different-content-test
-  (testing "Different content produces different hash"
-    (let [hash1 (hash/content-hash {:key "value-a"})
-          hash2 (hash/content-hash {:key "value-b"})]
-      (is (not= hash1 hash2)
-          "Different content should produce different hashes"))))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; Auto-collect evidence
-
-(deftest auto-collect-completed-workflow-test
+(deftest ^{:stratum 2} auto-collect-completed-workflow-test
   (testing "Auto-collect creates bundle for completed workflow"
     (let [workflow-id (make-workflow-id)
           workflow-state (make-workflow-state
@@ -370,7 +359,7 @@
       (is (uuid? (:evidence-bundle/id bundle))
           "Bundle should have an ID"))))
 
-(deftest auto-collect-failed-workflow-test
+(deftest ^{:stratum 2} auto-collect-failed-workflow-test
   (testing "Auto-collect creates bundle for failed workflow"
     (let [workflow-id (make-workflow-id)
           workflow-state (make-workflow-state
@@ -382,7 +371,7 @@
       (is (some? bundle)
           "Bundle should be created even for failed workflows"))))
 
-(deftest auto-collect-in-progress-workflow-test
+(deftest ^{:stratum 2} auto-collect-in-progress-workflow-test
   (testing "Auto-collect returns nil for in-progress workflow"
     (let [workflow-id (make-workflow-id)
           workflow-state (make-workflow-state
@@ -393,10 +382,8 @@
       (is (nil? bundle)
           "Bundle should not be created for running workflow"))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Rules-applied collection
-
-(deftest collect-rules-applied-test
+(deftest ^{:stratum 2} collect-rules-applied-test
   (testing "Rules-applied entries are collected from phase manifests"
     (let [rule-id (random-uuid)
           workflow-state (make-workflow-state
@@ -416,17 +403,15 @@
       (is (= :implement (:phase (first rules)))
           "Phase annotation should be :implement"))))
 
-(deftest collect-rules-applied-empty-test
+(deftest ^{:stratum 2} collect-rules-applied-empty-test
   (testing "Returns empty vector when no rules manifests exist"
     (let [workflow-state (make-workflow-state :phases {:implement (make-phase-data)})
           rules (collector/collect-rules-applied workflow-state)]
       (is (empty? rules)
           "Should return empty vector"))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Tool invocation collection
-
-(deftest collect-tool-invocations-test
+(deftest ^{:stratum 2} collect-tool-invocations-test
   (testing "Tool invocations are collected from workflow state"
     (let [invocation {:tool/id :gh-pr-create
                       :tool/invoked-at (make-timestamp)

--- a/components/evidence-bundle/test/ai/miniforge/evidence_bundle/collector_compliance_test.clj
+++ b/components/evidence-bundle/test/ai/miniforge/evidence_bundle/collector_compliance_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.evidence-bundle.collector-compliance-test
   "Unit tests for append-access-log-entry and the compliance-override path
    in assemble-evidence-bundle.
@@ -28,24 +27,22 @@
   (:require
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.evidence-bundle.collector :as collector]
-   [ai.miniforge.evidence-bundle.schema :as schema]))
+   [ai.miniforge.evidence-bundle.schema.compliance :as compliance]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Fixtures
 
-(def ^:private base-workflow-state
+;; Fixtures
+(def ^{:stratum 0} ^:private base-workflow-state
   {:workflow/status :completed
    :workflow/spec   {:intent/type :update
                      :description "test workflow"}
    :workflow/phases {}})
 
-(def ^:private workflow-id
+(def ^{:stratum 0} ^:private workflow-id
   #uuid "00000000-0000-0000-0000-000000000042")
 
-;------------------------------------------------------------------------------ Layer 1
 ;; append-access-log-entry
-
-(deftest append-access-log-entry-appends-entry
+(deftest ^{:stratum 0} append-access-log-entry-appends-entry
   (testing "entry is conj'd onto :evidence/access-log"
     (let [bundle {:evidence/access-log []}
           entry  {:access-log/principal "alice"
@@ -55,7 +52,7 @@
       (is (= 1 (count (:evidence/access-log result))))
       (is (= "alice" (:access-log/principal (first (:evidence/access-log result))))))))
 
-(deftest append-access-log-entry-preserves-existing
+(deftest ^{:stratum 0} append-access-log-entry-preserves-existing
   (testing "prior entries remain after append"
     (let [prior  {:access-log/principal "bob"
                   :access-log/action    :export
@@ -69,7 +66,7 @@
       (is (= "bob" (:access-log/principal (first (:evidence/access-log result)))))
       (is (= "alice" (:access-log/principal (second (:evidence/access-log result))))))))
 
-(deftest append-access-log-entry-normalizes-existing-log-to-vector
+(deftest ^{:stratum 0} append-access-log-entry-normalizes-existing-log-to-vector
   (testing "existing non-vector access logs keep append ordering"
     (let [prior  {:access-log/principal "bob"
                   :access-log/action    :export
@@ -83,7 +80,7 @@
       (is (vector? log))
       (is (= ["bob" "alice"] (mapv :access-log/principal log))))))
 
-(deftest append-access-log-entry-stamps-missing-timestamp
+(deftest ^{:stratum 0} append-access-log-entry-stamps-missing-timestamp
   (testing ":access-log/timestamp is added when absent"
     (let [bundle {:evidence/access-log []}
           entry  {:access-log/principal "carol"
@@ -93,7 +90,7 @@
       (is (contains? logged :access-log/timestamp))
       (is (instance? java.time.Instant (:access-log/timestamp logged))))))
 
-(deftest append-access-log-entry-stamps-nil-timestamp
+(deftest ^{:stratum 0} append-access-log-entry-stamps-nil-timestamp
   (testing ":access-log/timestamp nil is treated as missing"
     (let [bundle {:evidence/access-log []}
           entry  {:access-log/principal "carol"
@@ -103,7 +100,7 @@
           logged (first (:evidence/access-log result))]
       (is (instance? java.time.Instant (:access-log/timestamp logged))))))
 
-(deftest append-access-log-entry-preserves-existing-timestamp
+(deftest ^{:stratum 0} append-access-log-entry-preserves-existing-timestamp
   (testing ":access-log/timestamp is not overwritten when already present"
     (let [ts     (java.time.Instant/parse "2024-01-01T00:00:00Z")
           bundle {:evidence/access-log []}
@@ -114,7 +111,7 @@
           logged (first (:evidence/access-log result))]
       (is (= ts (:access-log/timestamp logged))))))
 
-(deftest append-access-log-entry-initializes-nil-access-log
+(deftest ^{:stratum 0} append-access-log-entry-initializes-nil-access-log
   (testing "missing :evidence/access-log is initialized as a vector"
     (let [bundle {}
           entry  {:access-log/principal "eve"
@@ -124,57 +121,53 @@
       (is (vector? (:evidence/access-log result)))
       (is (= 1 (count (:evidence/access-log result)))))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Compliance defaults via assembly
+;------------------------------------------------------------------------------ Layer 1
 
-(deftest assemble-sets-default-data-classification
-  (testing "assembled bundle carries schema/default-data-classification when no override"
+;; Compliance defaults via assembly
+(deftest ^{:stratum 1} assemble-sets-default-data-classification
+  (testing "assembled bundle carries compliance/default-data-classification when no override"
     (let [bundle (collector/assemble-evidence-bundle
                   workflow-id base-workflow-state nil)]
-      (is (= schema/default-data-classification
+      (is (= compliance/default-data-classification
              (:evidence/data-classification bundle))))))
 
-(deftest assemble-sets-default-retention-days
-  (testing "assembled bundle carries schema/default-retention-days when no override"
+(deftest ^{:stratum 1} assemble-sets-default-retention-days
+  (testing "assembled bundle carries compliance/default-retention-days when no override"
     (let [bundle (collector/assemble-evidence-bundle
                   workflow-id base-workflow-state nil)]
-      (is (= schema/default-retention-days
+      (is (= compliance/default-retention-days
              (get-in bundle [:evidence/retention-policy :retain-days]))))))
 
-(deftest assemble-sets-default-contains-pii-false
+(deftest ^{:stratum 1} assemble-sets-default-contains-pii-false
   (testing "assembled bundle has :evidence/contains-pii? false by default"
     (let [bundle (collector/assemble-evidence-bundle
                   workflow-id base-workflow-state nil)]
       (is (false? (:evidence/contains-pii? bundle))))))
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Compliance overrides via opts
-
-(deftest assemble-opts-override-data-classification
+(deftest ^{:stratum 1} assemble-opts-override-data-classification
   (testing "opts :compliance can override :evidence/data-classification"
     (let [bundle (collector/assemble-evidence-bundle
                   workflow-id base-workflow-state nil
                   {:compliance {:evidence/data-classification :confidential}})]
       (is (= :confidential (:evidence/data-classification bundle))))))
 
-(deftest assemble-opts-override-contains-pii
+(deftest ^{:stratum 1} assemble-opts-override-contains-pii
   (testing "opts :compliance can set :evidence/contains-pii? true"
     (let [bundle (collector/assemble-evidence-bundle
                   workflow-id base-workflow-state nil
                   {:compliance {:evidence/contains-pii? true}})]
       (is (true? (:evidence/contains-pii? bundle))))))
 
-(deftest assemble-opts-override-created-by
+(deftest ^{:stratum 1} assemble-opts-override-created-by
   (testing "opts :compliance can override :evidence/created-by"
     (let [bundle (collector/assemble-evidence-bundle
                   workflow-id base-workflow-state nil
                   {:compliance {:evidence/created-by "operator-alice"}})]
       (is (= "operator-alice" (:evidence/created-by bundle))))))
 
-;------------------------------------------------------------------------------ Layer 4
 ;; Compliance overrides via workflow-spec
-
-(deftest assemble-spec-override-data-classification
+(deftest ^{:stratum 1} assemble-spec-override-data-classification
   (testing "workflow-spec :compliance key overrides :evidence/data-classification"
     (let [state  (assoc base-workflow-state
                         :workflow/spec
@@ -184,7 +177,7 @@
           bundle (collector/assemble-evidence-bundle workflow-id state nil)]
       (is (= :restricted (:evidence/data-classification bundle))))))
 
-(deftest assemble-spec-overrides-take-priority-over-opts
+(deftest ^{:stratum 1} assemble-spec-overrides-take-priority-over-opts
   (testing "workflow-spec :compliance wins over opts :compliance"
     (let [state  (assoc base-workflow-state
                         :workflow/spec
@@ -197,7 +190,7 @@
       ;; spec is checked first by extract-compliance-overrides
       (is (= :restricted (:evidence/data-classification bundle))))))
 
-(deftest assemble-nil-spec-compliance-falls-back-to-opts
+(deftest ^{:stratum 1} assemble-nil-spec-compliance-falls-back-to-opts
   (testing "workflow-spec :compliance nil does not suppress opts :compliance"
     (let [state  (assoc base-workflow-state
                         :workflow/spec
@@ -209,7 +202,7 @@
                   {:compliance {:evidence/data-classification :confidential}})]
       (is (= :confidential (:evidence/data-classification bundle))))))
 
-(deftest assemble-non-map-spec-compliance-falls-back-to-opts
+(deftest ^{:stratum 1} assemble-non-map-spec-compliance-falls-back-to-opts
   (testing "workflow-spec :compliance non-map does not suppress opts :compliance"
     (let [state  (assoc base-workflow-state
                         :workflow/spec
@@ -221,7 +214,7 @@
                   {:compliance {:evidence/data-classification :confidential}})]
       (is (= :confidential (:evidence/data-classification bundle))))))
 
-(deftest assemble-filters-compliance-override-keys
+(deftest ^{:stratum 1} assemble-filters-compliance-override-keys
   (testing "override maps cannot replace non-compliance evidence keys"
     (let [bundle (collector/assemble-evidence-bundle
                   workflow-id base-workflow-state nil
@@ -230,10 +223,8 @@
       (is (= :confidential (:evidence/data-classification bundle)))
       (is (not= {:outcome/success false} (:evidence/outcome bundle))))))
 
-;------------------------------------------------------------------------------ Layer 5
 ;; Partial retention-policy merge
-
-(deftest assemble-partial-retention-policy-merge
+(deftest ^{:stratum 1} assemble-partial-retention-policy-merge
   (testing ":evidence/retention-policy override is merged one level deep"
     (let [bundle (collector/assemble-evidence-bundle
                   workflow-id base-workflow-state nil
@@ -243,7 +234,7 @@
       (is (true? (get-in bundle [:evidence/retention-policy :auto-delete?])))
       (is (false? (get-in bundle [:evidence/retention-policy :legal-hold?]))))))
 
-(deftest assemble-full-retention-policy-override
+(deftest ^{:stratum 1} assemble-full-retention-policy-override
   (testing "full :evidence/retention-policy override replaces all sub-keys"
     (let [bundle (collector/assemble-evidence-bundle
                   workflow-id base-workflow-state nil

--- a/components/evidence-bundle/test/ai/miniforge/evidence_bundle/compliance_metadata_test.clj
+++ b/components/evidence-bundle/test/ai/miniforge/evidence_bundle/compliance_metadata_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.evidence-bundle.compliance-metadata-test
   "Tests for compliance metadata assembly, defaults, overrides, and access-log.
 
@@ -31,148 +30,54 @@
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.evidence-bundle.collector :as collector]
-   [ai.miniforge.evidence-bundle.schema :as schema]))
+   [ai.miniforge.evidence-bundle.schema :as schema]
+   [ai.miniforge.evidence-bundle.schema.compliance :as compliance]
+   [ai.miniforge.evidence-bundle.schema.validation :as validation]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Fixtures and Named Constants
 
-(def ^:private workflow-id
+;; Fixtures and Named Constants
+(def ^{:stratum 0} ^:private workflow-id
   #uuid "cafebabe-0000-0000-0000-000000000001")
 
-(def ^:private base-workflow-state
+(def ^{:stratum 0} ^:private base-workflow-state
   {:workflow/status :completed
    :workflow/spec   {:intent/type :update
                      :description "compliance-metadata test workflow"}
    :workflow/phases {}})
 
-(def ^:private one-year-retention-days
+(def ^{:stratum 0} ^:private one-year-retention-days
   "Retention period used in override tests to verify a non-default value
    is accepted and survives the round-trip through assemble-evidence-bundle."
   365)
 
-(def ^:private two-year-retention-days
+(def ^{:stratum 0} ^:private two-year-retention-days
   "Two-year retention used in the validate-schema round-trip test to exercise
    a non-default :retain-days value end-to-end through assemble-evidence-bundle."
   730)
 
-(def ^:private seven-year-retention-days
+(def ^{:stratum 0} ^:private seven-year-retention-days
   "Seven-year retention (2555 days) used to test full override of all three
    retention-policy sub-keys simultaneously. SOX mandates 7 years."
   2555)
 
-(def ^:private preserved-access-log-first-timestamp
+(def ^{:stratum 0} ^:private preserved-access-log-first-timestamp
   "Stable timestamp for the first pre-existing access-log entry; verifies
    append-access-log-entry preserves earlier entries without mutation."
   (java.time.Instant/parse "2024-01-01T00:00:00Z"))
 
-(def ^:private preserved-access-log-second-timestamp
+(def ^{:stratum 0} ^:private preserved-access-log-second-timestamp
   "Stable timestamp for the second pre-existing access-log entry; verifies
    append ordering across multiple pre-existing entries."
   (java.time.Instant/parse "2024-06-01T00:00:00Z"))
 
-(def ^:private caller-supplied-access-log-timestamp
+(def ^{:stratum 0} ^:private caller-supplied-access-log-timestamp
   "Stable timestamp supplied by the caller; verifies append-access-log-entry
    does not replace a timestamp that is already present."
   (java.time.Instant/parse "2024-03-15T12:00:00Z"))
 
-;------------------------------------------------------------------------------ Layer 1
-;; assemble-evidence-bundle: Defaults and Overrides
-
-(deftest assemble-produces-default-compliance-metadata
-  (testing "assembled bundle carries default data-classification (:internal)"
-    (let [bundle (collector/assemble-evidence-bundle workflow-id base-workflow-state nil)]
-      (is (= schema/default-data-classification
-             (:evidence/data-classification bundle)))))
-  (testing "assembled bundle has :evidence/contains-pii? false by default"
-    (let [bundle (collector/assemble-evidence-bundle workflow-id base-workflow-state nil)]
-      (is (false? (:evidence/contains-pii? bundle)))))
-  (testing "assembled bundle has retention policy with schema-defined defaults"
-    (let [retention (:evidence/retention-policy
-                     (collector/assemble-evidence-bundle workflow-id base-workflow-state nil))]
-      (is (map? retention))
-      (is (= schema/default-retention-days (:retain-days retention)))
-      (is (true? (:auto-delete? retention)))
-      (is (false? (:legal-hold? retention)))))
-  (testing "assembled bundle has empty :evidence/regulatory-tags by default"
-    (let [bundle (collector/assemble-evidence-bundle workflow-id base-workflow-state nil)]
-      (is (= #{} (:evidence/regulatory-tags bundle)))))
-  (testing "assembled bundle has schema/default-created-by-principal"
-    (let [bundle (collector/assemble-evidence-bundle workflow-id base-workflow-state nil)]
-      (is (= schema/default-created-by-principal (:evidence/created-by bundle)))))
-  (testing "assembled bundle has empty :evidence/access-log by default"
-    (let [bundle (collector/assemble-evidence-bundle workflow-id base-workflow-state nil)]
-      (is (vector? (:evidence/access-log bundle)))
-      (is (empty? (:evidence/access-log bundle))))))
-
-(deftest assemble-applies-workflow-spec-compliance-overrides
-  (testing "workflow-spec :compliance overrides :evidence/data-classification"
-    (let [state  (assoc base-workflow-state :workflow/spec
-                        {:intent/type :update :description "classified"
-                         :compliance  {:evidence/data-classification :restricted}})
-          bundle (collector/assemble-evidence-bundle workflow-id state nil)]
-      (is (= :restricted (:evidence/data-classification bundle)))))
-  (testing "workflow-spec :compliance overrides :evidence/contains-pii?"
-    (let [state  (assoc base-workflow-state :workflow/spec
-                        {:intent/type :update :description "pii"
-                         :compliance  {:evidence/contains-pii? true}})
-          bundle (collector/assemble-evidence-bundle workflow-id state nil)]
-      (is (true? (:evidence/contains-pii? bundle)))))
-  (testing "workflow-spec :compliance overrides :evidence/regulatory-tags"
-    (let [state  (assoc base-workflow-state :workflow/spec
-                        {:intent/type :update :description "gdpr"
-                         :compliance  {:evidence/regulatory-tags #{:gdpr :sox}}})
-          bundle (collector/assemble-evidence-bundle workflow-id state nil)]
-      (is (= #{:gdpr :sox} (:evidence/regulatory-tags bundle))))))
-
-(deftest assemble-applies-opts-compliance-overrides
-  (testing "opts :compliance overrides :evidence/data-classification"
-    (let [bundle (collector/assemble-evidence-bundle
-                  workflow-id base-workflow-state nil
-                  {:compliance {:evidence/data-classification :confidential}})]
-      (is (= :confidential (:evidence/data-classification bundle)))))
-  (testing "opts :compliance overrides :evidence/contains-pii?"
-    (let [bundle (collector/assemble-evidence-bundle
-                  workflow-id base-workflow-state nil
-                  {:compliance {:evidence/contains-pii? true}})]
-      (is (true? (:evidence/contains-pii? bundle)))))
-  (testing "opts :compliance overrides :evidence/created-by"
-    (let [bundle (collector/assemble-evidence-bundle
-                  workflow-id base-workflow-state nil
-                  {:compliance {:evidence/created-by "operator-alice"}})]
-      (is (= "operator-alice" (:evidence/created-by bundle))))))
-
-(deftest assemble-partial-retention-policy-merges-with-defaults
-  (testing "only :legal-hold? true — :retain-days and :auto-delete? survive from defaults"
-    (let [bundle (collector/assemble-evidence-bundle
-                  workflow-id base-workflow-state nil
-                  {:compliance {:evidence/retention-policy {:legal-hold? true}}})]
-      (is (true?  (get-in bundle [:evidence/retention-policy :legal-hold?])))
-      (is (= schema/default-retention-days
-             (get-in bundle [:evidence/retention-policy :retain-days])))
-      (is (true? (get-in bundle [:evidence/retention-policy :auto-delete?])))))
-  (testing "only :retain-days supplied — :auto-delete? and :legal-hold? survive from defaults"
-    (let [bundle (collector/assemble-evidence-bundle
-                  workflow-id base-workflow-state nil
-                  {:compliance {:evidence/retention-policy
-                                {:retain-days one-year-retention-days}}})]
-      (is (= one-year-retention-days (get-in bundle [:evidence/retention-policy :retain-days])))
-      (is (true? (get-in bundle [:evidence/retention-policy :auto-delete?])))
-      (is (false? (get-in bundle [:evidence/retention-policy :legal-hold?])))))
-  (testing "full override replaces all three sub-keys"
-    (let [bundle (collector/assemble-evidence-bundle
-                  workflow-id base-workflow-state nil
-                  {:compliance {:evidence/retention-policy
-                                {:retain-days  seven-year-retention-days
-                                 :auto-delete? false
-                                 :legal-hold?  true}}})]
-      (is (= seven-year-retention-days (get-in bundle [:evidence/retention-policy :retain-days])))
-      (is (false? (get-in bundle [:evidence/retention-policy :auto-delete?])))
-      (is (true?  (get-in bundle [:evidence/retention-policy :legal-hold?]))))))
-
-;------------------------------------------------------------------------------ Layer 2
 ;; append-access-log-entry and validate-schema Round-Trips
-
-(deftest append-access-log-entry-appends-entries-correctly
+(deftest ^{:stratum 0} append-access-log-entry-appends-entries-correctly
   (testing "entry is appended to an empty access log"
     (let [result (collector/append-access-log-entry
                   {:evidence/access-log []}
@@ -195,7 +100,101 @@
       (is (= "bob"   (:access-log/principal (first  (:evidence/access-log result)))))
       (is (= "alice" (:access-log/principal (second (:evidence/access-log result))))))))
 
-(deftest append-access-log-entry-preserves-existing-entries
+;------------------------------------------------------------------------------ Layer 1
+
+;; assemble-evidence-bundle: Defaults and Overrides
+(deftest ^{:stratum 1} assemble-produces-default-compliance-metadata
+  (testing "assembled bundle carries default data-classification (:internal)"
+    (let [bundle (collector/assemble-evidence-bundle workflow-id base-workflow-state nil)]
+      (is (= compliance/default-data-classification
+             (:evidence/data-classification bundle)))))
+  (testing "assembled bundle has :evidence/contains-pii? false by default"
+    (let [bundle (collector/assemble-evidence-bundle workflow-id base-workflow-state nil)]
+      (is (false? (:evidence/contains-pii? bundle)))))
+  (testing "assembled bundle has retention policy with schema-defined defaults"
+    (let [retention (:evidence/retention-policy
+                     (collector/assemble-evidence-bundle workflow-id base-workflow-state nil))]
+      (is (map? retention))
+      (is (= compliance/default-retention-days (:retain-days retention)))
+      (is (true? (:auto-delete? retention)))
+      (is (false? (:legal-hold? retention)))))
+  (testing "assembled bundle has empty :evidence/regulatory-tags by default"
+    (let [bundle (collector/assemble-evidence-bundle workflow-id base-workflow-state nil)]
+      (is (= #{} (:evidence/regulatory-tags bundle)))))
+  (testing "assembled bundle has compliance/default-created-by-principal"
+    (let [bundle (collector/assemble-evidence-bundle workflow-id base-workflow-state nil)]
+      (is (= compliance/default-created-by-principal (:evidence/created-by bundle)))))
+  (testing "assembled bundle has empty :evidence/access-log by default"
+    (let [bundle (collector/assemble-evidence-bundle workflow-id base-workflow-state nil)]
+      (is (vector? (:evidence/access-log bundle)))
+      (is (empty? (:evidence/access-log bundle))))))
+
+(deftest ^{:stratum 1} assemble-applies-workflow-spec-compliance-overrides
+  (testing "workflow-spec :compliance overrides :evidence/data-classification"
+    (let [state  (assoc base-workflow-state :workflow/spec
+                        {:intent/type :update :description "classified"
+                         :compliance  {:evidence/data-classification :restricted}})
+          bundle (collector/assemble-evidence-bundle workflow-id state nil)]
+      (is (= :restricted (:evidence/data-classification bundle)))))
+  (testing "workflow-spec :compliance overrides :evidence/contains-pii?"
+    (let [state  (assoc base-workflow-state :workflow/spec
+                        {:intent/type :update :description "pii"
+                         :compliance  {:evidence/contains-pii? true}})
+          bundle (collector/assemble-evidence-bundle workflow-id state nil)]
+      (is (true? (:evidence/contains-pii? bundle)))))
+  (testing "workflow-spec :compliance overrides :evidence/regulatory-tags"
+    (let [state  (assoc base-workflow-state :workflow/spec
+                        {:intent/type :update :description "gdpr"
+                         :compliance  {:evidence/regulatory-tags #{:gdpr :sox}}})
+          bundle (collector/assemble-evidence-bundle workflow-id state nil)]
+      (is (= #{:gdpr :sox} (:evidence/regulatory-tags bundle))))))
+
+(deftest ^{:stratum 1} assemble-applies-opts-compliance-overrides
+  (testing "opts :compliance overrides :evidence/data-classification"
+    (let [bundle (collector/assemble-evidence-bundle
+                  workflow-id base-workflow-state nil
+                  {:compliance {:evidence/data-classification :confidential}})]
+      (is (= :confidential (:evidence/data-classification bundle)))))
+  (testing "opts :compliance overrides :evidence/contains-pii?"
+    (let [bundle (collector/assemble-evidence-bundle
+                  workflow-id base-workflow-state nil
+                  {:compliance {:evidence/contains-pii? true}})]
+      (is (true? (:evidence/contains-pii? bundle)))))
+  (testing "opts :compliance overrides :evidence/created-by"
+    (let [bundle (collector/assemble-evidence-bundle
+                  workflow-id base-workflow-state nil
+                  {:compliance {:evidence/created-by "operator-alice"}})]
+      (is (= "operator-alice" (:evidence/created-by bundle))))))
+
+(deftest ^{:stratum 1} assemble-partial-retention-policy-merges-with-defaults
+  (testing "only :legal-hold? true — :retain-days and :auto-delete? survive from defaults"
+    (let [bundle (collector/assemble-evidence-bundle
+                  workflow-id base-workflow-state nil
+                  {:compliance {:evidence/retention-policy {:legal-hold? true}}})]
+      (is (true?  (get-in bundle [:evidence/retention-policy :legal-hold?])))
+      (is (= compliance/default-retention-days
+             (get-in bundle [:evidence/retention-policy :retain-days])))
+      (is (true? (get-in bundle [:evidence/retention-policy :auto-delete?])))))
+  (testing "only :retain-days supplied — :auto-delete? and :legal-hold? survive from defaults"
+    (let [bundle (collector/assemble-evidence-bundle
+                  workflow-id base-workflow-state nil
+                  {:compliance {:evidence/retention-policy
+                                {:retain-days one-year-retention-days}}})]
+      (is (= one-year-retention-days (get-in bundle [:evidence/retention-policy :retain-days])))
+      (is (true? (get-in bundle [:evidence/retention-policy :auto-delete?])))
+      (is (false? (get-in bundle [:evidence/retention-policy :legal-hold?])))))
+  (testing "full override replaces all three sub-keys"
+    (let [bundle (collector/assemble-evidence-bundle
+                  workflow-id base-workflow-state nil
+                  {:compliance {:evidence/retention-policy
+                                {:retain-days  seven-year-retention-days
+                                 :auto-delete? false
+                                 :legal-hold?  true}}})]
+      (is (= seven-year-retention-days (get-in bundle [:evidence/retention-policy :retain-days])))
+      (is (false? (get-in bundle [:evidence/retention-policy :auto-delete?])))
+      (is (true?  (get-in bundle [:evidence/retention-policy :legal-hold?]))))))
+
+(deftest ^{:stratum 1} append-access-log-entry-preserves-existing-entries
   (testing "append-only: existing entries are never removed or mutated"
     (let [e1     {:access-log/principal "alice"
                   :access-log/action :read
@@ -219,7 +218,7 @@
              (:access-log/timestamp (nth log 1))))
       (is (= "carol" (:access-log/principal (nth log 2)))))))
 
-(deftest append-access-log-entry-stamps-timestamp-when-absent
+(deftest ^{:stratum 1} append-access-log-entry-stamps-timestamp-when-absent
   (testing ":access-log/timestamp is auto-added when missing"
     (let [result (collector/append-access-log-entry
                   {:evidence/access-log []}
@@ -238,11 +237,11 @@
       (is (= caller-supplied-access-log-timestamp
              (:access-log/timestamp logged))))))
 
-(deftest assembled-bundle-passes-validate-schema
+(deftest ^{:stratum 1} assembled-bundle-passes-validate-schema
   (testing "default assembled bundle satisfies evidence-bundle-schema"
-    (let [result (schema/validate-schema schema/evidence-bundle-schema
-                                         (collector/assemble-evidence-bundle
-                                          workflow-id base-workflow-state nil))]
+    (let [result (validation/validate-schema schema/evidence-bundle-schema
+                                             (collector/assemble-evidence-bundle
+                                              workflow-id base-workflow-state nil))]
       (is (:valid? result)
           (str "Default bundle must pass evidence-bundle-schema; errors: "
                (:errors result)))))
@@ -259,7 +258,7 @@
                                 {:retain-days  two-year-retention-days
                                  :auto-delete? false
                                  :legal-hold?  true}}})
-          result (schema/validate-schema schema/evidence-bundle-schema bundle)]
+          result (validation/validate-schema schema/evidence-bundle-schema bundle)]
       (is (:valid? result)
           (str "Overridden bundle must pass evidence-bundle-schema; errors: "
                (:errors result)))))
@@ -269,7 +268,7 @@
                    bundle
                    {:access-log/principal "auditor@example.com"
                     :access-log/action    :read})
-          result  (schema/validate-schema schema/evidence-bundle-schema bundle+)]
+          result  (validation/validate-schema schema/evidence-bundle-schema bundle+)]
       (is (:valid? result)
           (str "Bundle with access-log entry must pass evidence-bundle-schema; errors: "
                (:errors result))))))

--- a/components/evidence-bundle/test/ai/miniforge/evidence_bundle/schema_pack_promotion_test.clj
+++ b/components/evidence-bundle/test/ai/miniforge/evidence_bundle/schema_pack_promotion_test.clj
@@ -15,17 +15,18 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.evidence-bundle.schema-pack-promotion-test
   "Tests for pack-promotion-schema and evidence-bundle pack-promotions integration."
   (:require
    [clojure.test :refer [deftest is testing]]
-   [ai.miniforge.evidence-bundle.schema :as schema]))
+   [ai.miniforge.evidence-bundle.schema :as schema]
+   [ai.miniforge.evidence-bundle.schema.domain :as domain]
+   [ai.miniforge.evidence-bundle.schema.validation :as validation]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Test Helpers
 
-(defn- make-test-promotion
+;; Test Helpers
+(defn- ^{:stratum 0} make-test-promotion
   "Build a minimal valid pack-promotion map with the given justification string.
    All other fields use stable test values to isolate justification-specific tests."
   [justification]
@@ -40,10 +41,8 @@
    :pack-hash               "sha256:test"
    :pack-signature          ""})
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Pack Promotion Schema and Bundle Integration Tests
-
-(deftest test-pack-promotion-schema-valid
+(deftest ^{:stratum 0} test-pack-promotion-schema-valid
   (testing "Valid pack promotion record passes schema validation"
     (let [promotion {:pack/id "test-pack-001"
                      :pack/type :knowledge
@@ -55,12 +54,12 @@
                      :promotion-justification "passed knowledge-safety scans with no violations"
                      :pack-hash "sha256:abc123"
                      :pack-signature "sig456"}
-          result (schema/validate-schema schema/pack-promotion-schema promotion)]
+          result (validation/validate-schema domain/pack-promotion-schema promotion)]
       (is (:valid? result)
           "Valid promotion record should pass schema validation")
       (is (empty? (:errors result))))))
 
-(deftest test-pack-promotion-schema-requires-justification
+(deftest ^{:stratum 0} test-pack-promotion-schema-requires-justification
   (testing "Missing :promotion-justification fails validation"
     (let [promotion {:pack/id "test-pack-001"
                      :pack/type :knowledge
@@ -70,7 +69,7 @@
                      :promoted-at (java.time.Instant/now)
                      :promotion-policy "knowledge-safety"
                      :pack-hash "sha256:abc123"}
-          result (schema/validate-schema schema/pack-promotion-schema promotion)]
+          result (validation/validate-schema domain/pack-promotion-schema promotion)]
       (is (not (:valid? result))
           "Missing promotion-justification should fail validation")
       (is (some #(and (= :promotion-justification (:key %))
@@ -78,31 +77,7 @@
                 (:errors result))
           "Should report promotion-justification as missing"))))
 
-(deftest test-pack-promotion-justification-field
-  (testing "Promotion without justification fails; with justification passes"
-    (let [base             (dissoc (make-test-promotion "") :promotion-justification)
-          result-without   (schema/validate-schema schema/pack-promotion-schema base)
-          result-with      (schema/validate-schema schema/pack-promotion-schema
-                                                   (assoc base :promotion-justification
-                                                          "passed knowledge-safety scans"))]
-      (is (not (:valid? result-without))
-          "Promotion without justification should fail")
-      (is (:valid? result-with)
-          "Promotion with justification should pass")
-      (is (empty? (:errors result-with))))))
-
-(deftest test-pack-promotion-trust-levels
-  (testing "Valid trust levels pass; invalid trust level fails"
-    (let [valid-promotion   (make-test-promotion "passed scans")
-          invalid-promotion (assoc valid-promotion :from-trust :invalid-level)
-          result-valid      (schema/validate-schema schema/pack-promotion-schema valid-promotion)
-          result-invalid    (schema/validate-schema schema/pack-promotion-schema invalid-promotion)]
-      (is (:valid? result-valid)
-          "Valid trust levels should pass")
-      (is (not (:valid? result-invalid))
-          "Invalid trust level should fail"))))
-
-(deftest test-evidence-bundle-with-pack-promotions
+(deftest ^{:stratum 0} test-evidence-bundle-with-pack-promotions
   (testing "Evidence bundle accepts pack-promotions field"
     (let [bundle    (assoc (schema/create-evidence-bundle-template)
                            :evidence-bundle/workflow-id (random-uuid))
@@ -117,7 +92,7 @@
                      :pack-hash "sha256:test123"
                      :pack-signature ""}
           bundle+   (assoc bundle :evidence/pack-promotions [promotion])
-          result    (schema/validate-schema schema/evidence-bundle-schema bundle+)]
+          result    (validation/validate-schema schema/evidence-bundle-schema bundle+)]
       (is (= 1 (count (:evidence/pack-promotions bundle+))))
       (is (= "manual review approved"
              (-> bundle+ :evidence/pack-promotions first :promotion-justification)))
@@ -125,30 +100,56 @@
           (str "Bundle with pack promotions should pass evidence-bundle-schema; errors: "
                (:errors result))))))
 
-(deftest test-evidence-bundle-template-includes-pack-promotions
+(deftest ^{:stratum 0} test-evidence-bundle-template-includes-pack-promotions
   (testing "Evidence bundle template initializes pack-promotions as empty vector"
     (let [bundle (schema/create-evidence-bundle-template)]
       (is (contains? bundle :evidence/pack-promotions))
       (is (vector? (:evidence/pack-promotions bundle)))
       (is (empty? (:evidence/pack-promotions bundle))))))
 
-(deftest test-justification-content-examples
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} test-pack-promotion-justification-field
+  (testing "Promotion without justification fails; with justification passes"
+    (let [base             (dissoc (make-test-promotion "") :promotion-justification)
+          result-without   (validation/validate-schema domain/pack-promotion-schema base)
+          result-with      (validation/validate-schema domain/pack-promotion-schema
+                                                       (assoc base :promotion-justification
+                                                              "passed knowledge-safety scans"))]
+      (is (not (:valid? result-without))
+          "Promotion without justification should fail")
+      (is (:valid? result-with)
+          "Promotion with justification should pass")
+      (is (empty? (:errors result-with))))))
+
+(deftest ^{:stratum 1} test-pack-promotion-trust-levels
+  (testing "Valid trust levels pass; invalid trust level fails"
+    (let [valid-promotion   (make-test-promotion "passed scans")
+          invalid-promotion (assoc valid-promotion :from-trust :invalid-level)
+          result-valid      (validation/validate-schema domain/pack-promotion-schema valid-promotion)
+          result-invalid    (validation/validate-schema domain/pack-promotion-schema invalid-promotion)]
+      (is (:valid? result-valid)
+          "Valid trust levels should pass")
+      (is (not (:valid? result-invalid))
+          "Invalid trust level should fail"))))
+
+(deftest ^{:stratum 1} test-justification-content-examples
   (testing "Common justification strings all pass schema validation"
     (let [justifications ["passed knowledge-safety scans with no violations"
                           "manual review approved by security team"
                           "verified signature from trusted key 0x123ABC"
                           "meets all policy compliance requirements"
                           "automated validation completed successfully"]
-          results (map #(schema/validate-schema schema/pack-promotion-schema
-                                                (make-test-promotion %))
-                       justifications)]
+          results (map #(validation/validate-schema domain/pack-promotion-schema
+                                                    (make-test-promotion %))
+                           justifications)]
       (is (every? :valid? results))
       (is (every? #(empty? (:errors %)) results)))))
 
-(deftest test-schema-does-not-enforce-justification-content
+(deftest ^{:stratum 1} test-schema-does-not-enforce-justification-content
   (testing "Schema accepts empty justification string; content enforcement is business-layer concern"
-    (let [result (schema/validate-schema schema/pack-promotion-schema
-                                         (make-test-promotion ""))]
+    (let [result (validation/validate-schema domain/pack-promotion-schema
+                                             (make-test-promotion ""))]
       (is (:valid? result)
           "Schema accepts empty string — business logic is responsible for content checks"))))
 

--- a/components/evidence-bundle/test/ai/miniforge/evidence_bundle/schema_test.clj
+++ b/components/evidence-bundle/test/ai/miniforge/evidence_bundle/schema_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.evidence-bundle.schema-test
   "Tests for evidence bundle schema validation.
 
@@ -25,82 +24,83 @@
    backwards compatibility, and create-evidence-bundle-template defaults."
   (:require
    [clojure.test :refer [deftest is testing]]
-   [ai.miniforge.evidence-bundle.schema :as schema]))
+   [ai.miniforge.evidence-bundle.schema :as schema]
+   [ai.miniforge.evidence-bundle.schema.compliance :as compliance]
+   [ai.miniforge.evidence-bundle.schema.domain :as domain]
+   [ai.miniforge.evidence-bundle.schema.validation :as validation]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Core Schema Validation
 
-(deftest test-validate-schema-basic
+;; Core Schema Validation
+(deftest ^{:stratum 0} test-validate-schema-basic
   (testing "validate-schema accepts valid data"
     (let [valid-data {:constraint/type :pre
                       :constraint/description "Must exist"}
-          result (schema/validate-schema schema/constraint-schema valid-data)]
+          result (validation/validate-schema domain/constraint-schema valid-data)]
       (is (:valid? result))
       (is (empty? (:errors result)))))
   (testing "validate-schema rejects missing required keys"
     (let [invalid-data {:constraint/type :pre}
-          result (schema/validate-schema schema/constraint-schema invalid-data)]
+          result (validation/validate-schema domain/constraint-schema invalid-data)]
       (is (not (:valid? result)))
       (is (some #(= "Required key missing" (:error %)) (:errors result)))))
 
   (testing "Schema validation rejects present falsy values that fail validators"
     (let [invalid-data {:constraint/type :pre
                         :constraint/description false}
-          result (schema/validate-schema schema/constraint-schema invalid-data)]
+          result (validation/validate-schema domain/constraint-schema invalid-data)]
       (is (not (:valid? result)))
       (is (some #(= :constraint/description (:key %)) (:errors result))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Compliance Metadata Schema
-
-(deftest test-data-classifications-enum-contains-expected-members
+(deftest ^{:stratum 0} test-data-classifications-enum-contains-expected-members
   (testing "data-classifications contains all four N6-specified levels"
-    (is (contains? schema/data-classifications :public))
-    (is (contains? schema/data-classifications :internal))
-    (is (contains? schema/data-classifications :confidential))
-    (is (contains? schema/data-classifications :restricted)))
+    (is (contains? compliance/data-classifications :public))
+    (is (contains? compliance/data-classifications :internal))
+    (is (contains? compliance/data-classifications :confidential))
+    (is (contains? compliance/data-classifications :restricted)))
   (testing "data-classifications has no extra members beyond the four specified"
-    (is (= 4 (count schema/data-classifications)))))
+    (is (= 4 (count compliance/data-classifications)))))
 
-(deftest test-regulatory-tag-values-enum-contains-expected-members
+(deftest ^{:stratum 0} test-regulatory-tag-values-enum-contains-expected-members
   (testing "regulatory-tag-values contains all four N6-specified frameworks"
-    (is (contains? schema/regulatory-tag-values :gdpr))
-    (is (contains? schema/regulatory-tag-values :hipaa))
-    (is (contains? schema/regulatory-tag-values :sox))
-    (is (contains? schema/regulatory-tag-values :pci)))
+    (is (contains? compliance/regulatory-tag-values :gdpr))
+    (is (contains? compliance/regulatory-tag-values :hipaa))
+    (is (contains? compliance/regulatory-tag-values :sox))
+    (is (contains? compliance/regulatory-tag-values :pci)))
   (testing "regulatory-tag-values has no extra members beyond the four specified"
-    (is (= 4 (count schema/regulatory-tag-values)))))
+    (is (= 4 (count compliance/regulatory-tag-values)))))
 
-(deftest test-retention-policy-schema-accepts-valid-map
+(deftest ^{:stratum 0} test-retention-policy-schema-accepts-valid-map
   (testing "retention-policy-schema accepts a correctly shaped policy"
-    (let [result (schema/validate-schema schema/retention-policy-schema
-                                         {:retain-days 30 :auto-delete? true :legal-hold? false})]
+    (let [result (validation/validate-schema compliance/retention-policy-schema
+                                             {:retain-days 30 :auto-delete? true :legal-hold? false})]
       (is (:valid? result))
       (is (empty? (:errors result))))))
 
-(deftest test-retention-policy-schema-rejects-missing-keys
+(deftest ^{:stratum 0} test-retention-policy-schema-rejects-missing-keys
   (testing "retention-policy-schema rejects a map missing :retain-days"
-    (let [result (schema/validate-schema schema/retention-policy-schema
-                                         {:auto-delete? true :legal-hold? false})]
+    (let [result (validation/validate-schema compliance/retention-policy-schema
+                                             {:auto-delete? true :legal-hold? false})]
       (is (not (:valid? result)))
       (is (some #(= :retain-days (:key %)) (:errors result)))))
   (testing "retention-policy-schema rejects a map missing :legal-hold?"
-    (let [result (schema/validate-schema schema/retention-policy-schema
-                                         {:retain-days 30 :auto-delete? true})]
+    (let [result (validation/validate-schema compliance/retention-policy-schema
+                                             {:retain-days 30 :auto-delete? true})]
       (is (not (:valid? result)))
       (is (some #(= :legal-hold? (:key %)) (:errors result)))))
   (testing "retention-policy-schema rejects a map missing :auto-delete?"
-    (let [result (schema/validate-schema schema/retention-policy-schema
-                                         {:retain-days 30 :legal-hold? false})]
+    (let [result (validation/validate-schema compliance/retention-policy-schema
+                                             {:retain-days 30 :legal-hold? false})]
       (is (not (:valid? result)))
       (is (some #(= :auto-delete? (:key %)) (:errors result))))))
 
-(deftest test-access-log-entry-schema-accepts-valid-entry
+(deftest ^{:stratum 0} test-access-log-entry-schema-accepts-valid-entry
   (testing "access-log-entry-schema accepts a correctly shaped entry"
     (let [entry  {:access-log/principal "alice@example.com"
                   :access-log/action    :read
                   :access-log/timestamp (java.time.Instant/now)}
-          result (schema/validate-schema schema/access-log-entry-schema entry)]
+          result (validation/validate-schema compliance/access-log-entry-schema entry)]
       (is (:valid? result))
       (is (empty? (:errors result)))))
   (testing "access-log-entry-schema accepts entry with optional :access-log/reason"
@@ -108,30 +108,30 @@
                   :access-log/action    :export
                   :access-log/timestamp (java.time.Instant/now)
                   :access-log/reason    "quarterly compliance audit"}
-          result (schema/validate-schema schema/access-log-entry-schema entry)]
+          result (validation/validate-schema compliance/access-log-entry-schema entry)]
       (is (:valid? result)))))
 
-(deftest test-access-log-entry-schema-rejects-missing-fields
+(deftest ^{:stratum 0} test-access-log-entry-schema-rejects-missing-fields
   (testing "rejects entry missing :access-log/action"
-    (let [result (schema/validate-schema schema/access-log-entry-schema
-                                         {:access-log/principal "alice"
-                                          :access-log/timestamp (java.time.Instant/now)})]
+    (let [result (validation/validate-schema compliance/access-log-entry-schema
+                                             {:access-log/principal "alice"
+                                              :access-log/timestamp (java.time.Instant/now)})]
       (is (not (:valid? result)))
       (is (some #(= :access-log/action (:key %)) (:errors result)))))
   (testing "rejects entry missing :access-log/principal"
-    (let [result (schema/validate-schema schema/access-log-entry-schema
-                                         {:access-log/action    :read
-                                          :access-log/timestamp (java.time.Instant/now)})]
+    (let [result (validation/validate-schema compliance/access-log-entry-schema
+                                             {:access-log/action    :read
+                                              :access-log/timestamp (java.time.Instant/now)})]
       (is (not (:valid? result)))
       (is (some #(= :access-log/principal (:key %)) (:errors result)))))
   (testing "rejects entry missing :access-log/timestamp"
-    (let [result (schema/validate-schema schema/access-log-entry-schema
-                                         {:access-log/principal "alice"
-                                          :access-log/action    :read})]
+    (let [result (validation/validate-schema compliance/access-log-entry-schema
+                                             {:access-log/principal "alice"
+                                              :access-log/action    :read})]
       (is (not (:valid? result)))
       (is (some #(= :access-log/timestamp (:key %)) (:errors result))))))
 
-(deftest test-evidence-bundle-schema-accepts-bundle-with-new-optional-fields
+(deftest ^{:stratum 0} test-evidence-bundle-schema-accepts-bundle-with-new-optional-fields
   (testing "evidence-bundle-schema accepts a bundle carrying all six new compliance fields"
     (let [bundle (-> (schema/create-evidence-bundle-template)
                      (assoc :evidence-bundle/workflow-id (random-uuid))
@@ -146,34 +146,34 @@
                             [{:access-log/principal "auditor"
                               :access-log/action    :read
                               :access-log/timestamp (java.time.Instant/now)}]))
-          result (schema/validate-schema schema/evidence-bundle-schema bundle)]
+          result (validation/validate-schema schema/evidence-bundle-schema bundle)]
       (is (:valid? result)
           (str "Bundle with all new compliance fields should pass; errors: "
                (:errors result)))))
   (testing "evidence-bundle-schema accepts every member of data-classifications"
-    (doseq [cls schema/data-classifications]
+    (doseq [cls compliance/data-classifications]
       (let [bundle (-> (schema/create-evidence-bundle-template)
                        (assoc :evidence-bundle/workflow-id (random-uuid))
                        (assoc :evidence/data-classification cls))
-            result (schema/validate-schema schema/evidence-bundle-schema bundle)]
+            result (validation/validate-schema schema/evidence-bundle-schema bundle)]
         (is (:valid? result)
             (str "Classification " cls " should be accepted")))))
   (testing "evidence-bundle-schema rejects :evidence/data-classification outside the enum"
     (let [bundle (-> (schema/create-evidence-bundle-template)
                      (assoc :evidence-bundle/workflow-id (random-uuid))
                      (assoc :evidence/data-classification :ultra-secret))
-          result (schema/validate-schema schema/evidence-bundle-schema bundle)]
+          result (validation/validate-schema schema/evidence-bundle-schema bundle)]
       (is (not (:valid? result)))
       (is (some #(= :evidence/data-classification (:key %)) (:errors result)))))
   (testing "evidence-bundle-schema rejects unknown regulatory tags"
     (let [bundle (-> (schema/create-evidence-bundle-template)
                      (assoc :evidence-bundle/workflow-id (random-uuid))
                      (assoc :evidence/regulatory-tags #{:gdpr :unknown-framework}))
-          result (schema/validate-schema schema/evidence-bundle-schema bundle)]
+          result (validation/validate-schema schema/evidence-bundle-schema bundle)]
       (is (not (:valid? result)))
       (is (some #(= :evidence/regulatory-tags (:key %)) (:errors result))))))
 
-(deftest test-evidence-bundle-schema-backwards-compatible
+(deftest ^{:stratum 0} test-evidence-bundle-schema-backwards-compatible
   (testing "Bundles without the new compliance fields still pass validation"
     (let [legacy {:evidence-bundle/id (random-uuid)
                   :evidence-bundle/workflow-id (random-uuid)
@@ -182,19 +182,19 @@
                   :evidence/intent {}
                   :evidence/policy-checks []
                   :evidence/outcome {}}
-          result (schema/validate-schema schema/evidence-bundle-schema legacy)]
+          result (validation/validate-schema schema/evidence-bundle-schema legacy)]
       (is (:valid? result)
           "Legacy bundle without compliance fields must pass schema validation")
       (is (empty? (:errors result))))))
 
-(deftest test-evidence-bundle-schema-validates-nested-compliance-fields
+(deftest ^{:stratum 0} test-evidence-bundle-schema-validates-nested-compliance-fields
   (testing "evidence-bundle-schema validates :evidence/retention-policy via retention-policy-schema"
     (let [bundle (-> (schema/create-evidence-bundle-template)
                      (assoc :evidence-bundle/workflow-id (random-uuid))
                      (assoc :evidence/retention-policy {:retain-days -1
                                                         :auto-delete? true
                                                         :legal-hold? false}))
-          result (schema/validate-schema schema/evidence-bundle-schema bundle)]
+          result (validation/validate-schema schema/evidence-bundle-schema bundle)]
       (is (not (:valid? result)))))
   (testing "evidence-bundle-schema validates :evidence/access-log entries via access-log-entry-schema"
     (let [bad-entry {:access-log/principal "alice"
@@ -202,7 +202,7 @@
           bundle (-> (schema/create-evidence-bundle-template)
                      (assoc :evidence-bundle/workflow-id (random-uuid))
                      (assoc :evidence/access-log [bad-entry]))
-          result (schema/validate-schema schema/evidence-bundle-schema bundle)]
+          result (validation/validate-schema schema/evidence-bundle-schema bundle)]
       (is (not (:valid? result)))))
   (testing "evidence-bundle-schema requires :evidence/access-log to be a vector"
     (let [bad-access-log {:access-log/principal "alice"
@@ -211,11 +211,11 @@
           bundle (-> (schema/create-evidence-bundle-template)
                      (assoc :evidence-bundle/workflow-id (random-uuid))
                      (assoc :evidence/access-log bad-access-log))
-          result (schema/validate-schema schema/evidence-bundle-schema bundle)]
+          result (validation/validate-schema schema/evidence-bundle-schema bundle)]
       (is (not (:valid? result)))
       (is (some #(= :evidence/access-log (:key %)) (:errors result))))))
 
-(deftest test-create-evidence-bundle-template-compliance-defaults
+(deftest ^{:stratum 0} test-create-evidence-bundle-template-compliance-defaults
   (testing "Template emits all six compliance fields with correct defaults"
     (let [bundle (schema/create-evidence-bundle-template)]
       (is (= :internal (:evidence/data-classification bundle))
@@ -231,12 +231,12 @@
           ":auto-delete? defaults to true")
       (is (false? (get-in bundle [:evidence/retention-policy :legal-hold?]))
           ":legal-hold? defaults to false")
-      (is (= schema/default-retention-days
+      (is (= compliance/default-retention-days
              (get-in bundle [:evidence/retention-policy :retain-days]))
           ":retain-days equals the named schema constant")
       (is (= #{} (:evidence/regulatory-tags bundle))
           ":evidence/regulatory-tags defaults to empty set")
-      (is (= schema/default-created-by-principal (:evidence/created-by bundle))
+      (is (= compliance/default-created-by-principal (:evidence/created-by bundle))
           ":evidence/created-by defaults to system principal")
       (is (= [] (:evidence/access-log bundle))
           ":evidence/access-log defaults to empty vector"))))

--- a/docs/pull-requests/2026-07-28-fix-stratum-lint-wave2-evidence-bundle-schema.md
+++ b/docs/pull-requests/2026-07-28-fix-stratum-lint-wave2-evidence-bundle-schema.md
@@ -1,0 +1,240 @@
+# fix(evidence-bundle): split schema.clj to clear the 3-layer stratum budget (SL003, Wave 2)
+
+## Overview
+
+Splits `components/evidence-bundle/src/ai/miniforge/evidence_bundle/schema.clj`
+(477 lines, reported at 7 real layers) into five namespaces, each at or
+under rule 210's 3-layer budget. Unlike the Wave 1 `--fix` PRs (mechanical
+heading relabeling only), this is a genuine namespace split with real code
+movement: `schema.clj`'s over-budget report was not decorative
+mislabeling — it reflected an actual 7-deep same-file dependency chain.
+One of the per-component Wave 2 PRs tracked from
+`work/stratum-lint-baseline-2026-07-24.md`.
+
+## Motivation
+
+`schema.clj` mixed four unrelated concerns in one file, each layering on
+the last:
+
+1. An `OptionalKey` marker record + its constructor/predicate
+   (`optional-key`, `optional-key?`).
+2. A generic `validate-schema` engine (`unwrap-key` + `validate-schema`)
+   that calls into (1).
+3. Compliance/retention/access-log schemas and their `valid-*?`
+   predicates, which call into (2).
+4. Every other N6 domain schema (intent, phase, policy, outcome,
+   provenance, tool, pack-promotion, supervision, control-action) plus the
+   top-level `evidence-bundle-schema` composite and its default template.
+
+Because (3) depends on (2) which depends on (1), and the top-level
+`evidence-bundle-schema` in (4) depends on (3)'s predicates, the whole
+thing reduced to one 7-deep same-file reference chain: `OptionalKey` →
+`optional-key?` → `unwrap-key` → `validate-schema` →
+`valid-retention-policy-map?` / `valid-access-log-entry?` →
+`valid-access-log?` → `evidence-bundle-schema`. Rule 210 caps a file at 3
+strata; this needed an actual split, not a relabel.
+
+## Changes in Detail
+
+New files under `components/evidence-bundle/src/ai/miniforge/evidence_bundle/schema/`:
+
+- **`optional_key.clj`** (`ai.miniforge.evidence-bundle.schema.optional-key`,
+  2 real layers) — the `OptionalKey` record and its `optional-key`/
+  `optional-key?` constructor/predicate. Nothing else in the component
+  referenced these by name outside `schema.clj` itself (confirmed by
+  `grep -rn` before the split), so no other file's requires needed
+  updating for these two symbols.
+- **`validation.clj`** (`ai.miniforge.evidence-bundle.schema.validation`,
+  2 real layers) — `unwrap-key` and the generic `validate-schema` engine.
+  Requires `schema.optional-key`.
+- **`compliance.clj`** (`ai.miniforge.evidence-bundle.schema.compliance`,
+  3 real layers) — the compliance/PII/retention/access-log domain:
+  `pii-handling-types`, `data-classifications`, `regulatory-tag-values`,
+  the three `default-*` constants, `retention-policy-schema`,
+  `access-log-entry-schema`, `compliance-schema`, and the five `valid-*?`
+  predicates (`valid-data-classification?`, `valid-regulatory-tags?`,
+  `valid-retention-policy-map?`, `valid-access-log-entry?`,
+  `valid-access-log?`). These five predicates were `defn-` in the
+  original file; they had to become public here since `schema.clj`'s
+  `evidence-bundle-schema` now references them across a namespace
+  boundary. No external (non-component) consumer existed for them either
+  way. Requires `schema.optional-key` + `schema.validation`.
+- **`domain.clj`** (`ai.miniforge.evidence-bundle.schema.domain`,
+  2 real layers) — every other N6 domain schema: intent
+  (`intent-types`, `constraint-schema`, `intent-schema`,
+  `semantic-validation-rules`, `semantic-validation-schema`), phase
+  (`phase-result-status-values`, `phase-evidence-schema`, the three
+  `*-phase-result-schema` defs), policy/violation (`policy-check-schema`,
+  `violation-severities`, `violation-schema`), outcome (`pr-statuses`,
+  `outcome-schema`), provenance/tool (`provenance-schema`,
+  `tool-execution-schema`, `tool-invocation-schema`), pack promotion
+  (`trust-levels`, `pack-promotion-schema`), supervision/control
+  (`supervision-decision-schema`, `control-action-evidence-schema`), and
+  `rule-applied-schema`. These are genuinely disjoint N6 sub-domains, but
+  every one of them collapses to at most 1 same-file dependency hop once
+  the compliance subset and the `optional-key`/`validate-schema`
+  machinery are out of the file (e.g. `intent-schema` only depends on the
+  same-file `intent-types`; nothing here depends on anything else here),
+  so they land at 2 real layers together rather than needing further
+  splitting. Requires `schema.optional-key` + the cross-component
+  `ai.miniforge.schema.interface` (for `violation-severities`).
+
+`schema.clj` itself (root, `ai.miniforge.evidence-bundle.schema`, now 1
+real layer) keeps only `create-evidence-bundle-template` and
+`evidence-bundle-schema` — the top-level composite and its default
+template. Neither actually embeds any of the moved domain schemas
+directly (the bundle schema's phase/tool/pack-promotion/etc. fields are
+typed as bare `map?`/`vector?`, not as the domain sub-schemas), so once
+`optional-key` and the compliance predicates it calls are external
+requires, both remaining defs are independent — 1 layer, not the
+originally-reported 6.
+
+`interface.clj`'s Layer 7 schema-export pass-throughs
+(`intent-types`, `semantic-validation-rules` → now sourced from
+`schema.domain`; `data-classifications`, `regulatory-tag-values`,
+`default-retention-days`, `default-data-classification` → now sourced
+from `schema.compliance`) were repointed to the namespace each symbol
+actually moved to. `create-evidence-template` is unchanged — it still
+calls `schema/create-evidence-bundle-template`, which stayed in the root
+namespace.
+
+Same-component files (Polylith allows `.schema`/subnamespace references
+from within the component; only cross-component deps must go through
+`.interface`) that referenced moved symbols were repointed to the new
+namespaces: `collector.clj` and 5 test files
+(`schema_test.clj`, `schema_pack_promotion_test.clj`,
+`assembly_integration_test.clj`, `compliance_metadata_test.clj`,
+`collector_compliance_test.clj`) now require `schema.compliance` and/or
+`schema.validation` and/or `schema.domain` alongside (or instead of)
+`schema` itself, depending on which symbols they use.
+`protocols/impl/evidence_bundle.clj` and
+`protocols/impl/semantic_validator.clj` no longer require `schema` at
+all — everything they used (`validate-schema`, `intent-schema`,
+`semantic-validation-schema`, `semantic-validation-rules`) moved to
+`schema.validation`/`schema.domain`.
+
+No behavior change: same def names, same docstrings, same schema shapes,
+same validation semantics. The only externally-visible change is that 5
+predicates went from `defn-` to `defn` (required for the cross-namespace
+reference from the root `schema.clj`) — nothing outside the component
+referenced them under either visibility.
+
+## Testing Plan
+
+1. Read the full 477-line target file and `interface.clj` before touching
+   anything; `grep -rn "ai.miniforge.evidence-bundle.schema"` across the
+   whole repo to confirm no cross-component consumer requires `.schema`
+   directly (Polylith only allows that from within the component) — only
+   5 test files, `collector.clj`, and the two `protocols/impl/*.clj`
+   files did, all inside this component.
+2. Derived the real same-file dependency graph by hand (which def's body
+   references which other same-file def) to design the split — not by
+   running the linter's `--fix` (this is a real split, `--fix` only
+   relabels a file's own existing top-level defs, it doesn't move code
+   across files).
+3. Ran the stratum linter, non-warn mode, over the whole component:
+
+   ```bash
+   bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "80699e378cb8ebbb6daeb928431aa4a6b373c07e" :deps/root "clojure"}}}' -m stratum-lint.interface components/evidence-bundle
+   ```
+
+   Exit 1, non-empty output — see "known pre-existing gap" below.
+   `schema.clj`'s own `SL003` finding (was `schema.clj:409 file uses 7
+   distinct layers`) is gone; confirmed by diffing this run's output
+   against the same command run via `git stash` on the pre-change tree —
+   every remaining finding (`collector.clj` 6 layers, `extraction.clj` 4
+   layers, `interface.clj` 9 layers, `workflow_integration.clj` 4 layers,
+   `assembly_integration_test.clj` SL002 decorative headers,
+   `collector_compliance_test.clj` 6 layers) is byte-for-byte identical
+   before and after this change — none of it was introduced here, and
+   none of it is in scope for this PR (each is its own Wave 2 file).
+4. `clj-kondo --lint components/evidence-bundle`: 0 errors, 0 warnings.
+5. `bb test` (the monorepo-wide "changed-and-affected" suite) was started
+   but not used as the completion signal: it pulled in
+   `dag-executor.executor-test`, a slow, Docker-dependent test that was
+   still running past 13 minutes with repeated "Docker not available"
+   skip/retry cycles unrelated to this change, and this worktree shares
+   the host with sibling agents already running their own concurrent
+   `poly test`/`poly check` processes in other worktrees. Killed the
+   stray process rather than let it fight for the same JVM/Maven-cache
+   resources. Substituted per this task's own documented fallback:
+   - Component tests, run directly (bypassing the slow change-detection
+     wrapper) via `clojure -M:dev:test` against all 13 evidence-bundle
+     test namespaces (including the 5 touched by this PR):
+     **114 tests, 350 assertions, 0 failures, 0 errors, exit 0.**
+   - Poly-aware structural check: `clojure -M:poly check` — exit 0. Two
+     warnings only (`config`'s non-top-namespace test fixtures,
+     `data-foundry`'s unused `decision-envelope` component dep), both
+     pre-existing and unrelated to evidence-bundle.
+6. Adversarial self-review of the full diff: checked every moved def kept
+   its docstring, every `optional-key`/`validate-schema` call site was
+   repointed to its new namespace and not left dangling, no namespace
+   cycle was introduced (`schema.compliance` → `schema.validation` +
+   `schema.optional-key`; `schema.domain` → `schema.optional-key`;
+   root `schema` → `schema.compliance` + `schema.optional-key`; nothing
+   points back up), `interface.clj` still contains only pass-throughs
+   (no implementation logic moved into it), and re-verified
+   `schema.clj`'s own diff shows only mechanical `optional-key` →
+   `optional-key/optional-key` and `default-*` → `compliance/default-*`
+   substitutions with no schema-shape change.
+
+## Deployment Plan
+
+Merges to `main` like any other component change. No runtime behavior
+change — same def names, docstrings, and validation semantics; only
+namespace location and (for 5 previously-`defn-` compliance predicates)
+visibility changed. Pre-commit's `lint:stratum` autofixer keeps this
+component's headings honest going forward.
+
+## Known pre-existing gap (not touched by this PR)
+
+`bb -m stratum-lint.interface components/evidence-bundle` does not exit 0
+after this change — 4 other `src` files (`collector.clj`, `extraction.clj`,
+`interface.clj`, `workflow_integration.clj`) and 1 more test file
+(`collector_compliance_test.clj`) still report genuine `SL003` over-budget
+findings, plus `assembly_integration_test.clj` reports decorative-heading
+`SL002` findings. All of these predate this PR (confirmed via
+`git stash` diff of the linter's output) and are each their own Wave 2
+follow-up, matching this baseline's per-file PR granularity.
+
+## Related Issues/PRs
+
+- Baseline: `work/stratum-lint-baseline-2026-07-24.md` (Wave 1)
+- Wave 1 tone/format reference:
+  `docs/pull-requests/2026-07-25-fix-stratum-lint-wave1-fsm.md`
+- Follow-on Wave 2 splits still open in this component: `collector.clj`
+  (6 layers), `extraction.clj` (4 layers), `interface.clj` (9 layers,
+  though interface files are exempt from the hard cap per rule 210 —
+  worth a human call on whether it still warrants a split),
+  `workflow_integration.clj` (4 layers), and the `collector_compliance_test.clj`
+  / `assembly_integration_test.clj` heading cleanups.
+
+## Checklist
+
+- [x] Real dependency graph derived by hand before designing the split
+- [x] Split by schema domain/grouping (optional-key utility / generic
+      validator / compliance domain / N6 domain schemas / top-level
+      composite), not by artificially avoiding the "schemas only"
+      component-layout convention
+- [x] `interface.clj` repointed to the namespaces each re-exported symbol
+      actually moved to; still contains only pass-throughs
+- [x] All same-component internal references (`collector.clj`, 2
+      `protocols/impl/*.clj` files, 5 test files) repointed to the new
+      namespaces
+- [x] Each new/changed file verified ≤3 real layers, with `Layer N`
+      headings and `^{:stratum n}` metadata matching rule 210's
+      convention
+- [x] Stratum linter run in non-warn mode; `schema.clj`'s own `SL003`
+      finding confirmed cleared; all remaining findings confirmed
+      pre-existing via `git stash` diff (documented above, not silently
+      ignored)
+- [x] `clj-kondo` clean (0 errors, 0 warnings)
+- [x] Evidence-bundle test suite green: 114 tests, 350 assertions, 0
+      failures/errors (`clojure -M:dev:test`, direct run — `bb test`
+      substituted per the documented fallback; reason given above)
+- [x] `clojure -M:poly check` clean (0 errors; 2 pre-existing,
+      unrelated warnings)
+- [x] Adversarial self-review of the full diff for lost docstrings, stale
+      requires, namespace cycles, or implementation leaking into
+      `interface.clj`
+- [x] No `--no-verify`; pre-commit hook runs normally at commit time


### PR DESCRIPTION
## Summary

- Splits `components/evidence-bundle/src/ai/miniforge/evidence_bundle/schema.clj` (477 lines, 7 real layers per `stratum-lint`) into `schema/optional_key.clj`, `schema/validation.clj`, `schema/compliance.clj`, and `schema/domain.clj` (each ≤3 real layers), leaving `schema.clj` with just the top-level `evidence-bundle-schema` composite and its default template (1 real layer).
- Genuine namespace split (real dependency chain, not decorative mislabeling) — see full writeup at `docs/pull-requests/2026-07-28-fix-stratum-lint-wave2-evidence-bundle-schema.md`.
- No behavior change: same def names/docstrings/schema shapes/validation semantics. `interface.clj` and same-component callers (`collector.clj`, 2 `protocols/impl/*.clj` files, 5 test files) repointed to the symbols' new namespaces.
- `collector.clj`'s own pre-existing SL003 (6 layers, unrelated — only 2 lines touched here) is deferred to its own Wave 2 PR, same precedent as the fsm Wave 1 PR's `core.clj` deferral (`MINIFORGE_STRATUM_BUDGET_MODE=warn` at commit time).

## Test plan

- [x] `bb -Sdeps '{:deps {io.github.miniforge-ai/stratum-lint {:git/sha "80699e378cb8ebbb6daeb928431aa4a6b373c07e" :deps/root "clojure"}}}' -m stratum-lint.interface components/evidence-bundle` — `schema.clj`'s own `SL003` finding confirmed cleared (verified via `git stash` diff that all remaining findings are pre-existing, in other files, out of scope for this PR)
- [x] `clj-kondo --lint components/evidence-bundle` — 0 errors, 0 warnings
- [x] Evidence-bundle test suite (direct `clojure -M:dev:test` run, all 13 namespaces including the 5 touched) — 114 tests, 350 assertions, 0 failures/errors
- [x] `clojure -M:poly check` — clean (2 pre-existing, unrelated warnings only)
- [x] Full pre-commit gate (commit-budget override for the structural move, `poly:check`, `lint:clj`, `lint:stratum`, `fmt:md`, `test:precommit` [331 tests/1244 assertions], `test:graalvm` [8 tests/554 assertions]) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

MINIFORGE_PR_BUDGET_OVERRIDE: genuine atomic namespace split (schema.clj -> optional_key.clj + validation.clj + compliance.clj + domain.clj + trimmed schema.clj) committed with MINIFORGE_COMMIT_BUDGET_OVERRIDE for the same reason -- the moved schemas and their new home must land in one commit to compile; domain.clj alone is 204 reportable lines, so slicing further would fragment one coherent domain grouping without changing the total diff size.

(PR description refreshed to re-trigger the PR Size check against the current body.)
