### PR TITLE
fix(llm): make keepalive-prevents-stagnation test deterministic under CI jitter

### DIFF
--- a/components/llm/test/ai/miniforge/llm/interface_test.clj
+++ b/components/llm/test/ai/miniforge/llm/interface_test.clj
@@ -1059,49 +1059,19 @@
 ;; the JVM-side reader is alive. These tests lock both halves of the
 ;; contract — the bug pattern (silence => stagnation) and the fix
 ;; (keepalive masks silence).
-(deftest ^{:stratum 0} stagnation-fires-on-silence-without-keepalive-test
-  (testing "without keepalive, a silent monitor stagnates after the threshold"
-    ;; Bug demonstration: this is the dogfood failure mode in unit form.
-    ;; record-activity! once at start, then silence — the timer expires.
-    (let [monitor (pm/create-progress-monitor
-                   {:stagnation-threshold-ms 80
-                    :max-total-ms            5000
-                    :min-activity-interval-ms 1})]
-      (pm/record-activity! monitor :stream-init)
-      (Thread/sleep 200)
-      (let [timeout (pm/check-timeout monitor)]
-        (is (= :stagnation (:type timeout))
-            "silence beyond stagnation-threshold-ms ⇒ stagnation fires")))))
+;; Shared timing constants for the keepalive/stagnation trio below.
+;; stagnation-threshold-ms is set high relative to keepalive-interval-ms
+;; (25:1) so ordinary CI scheduler jitter on the daemon keepalive thread
+;; cannot cross the stagnation line — a single missed or delayed tick
+;; costs nowhere near the full window. Observed CI flake (run 30340889808):
+;; a loaded runner delayed the thread enough that 135ms elapsed against
+;; an 80ms threshold; 500ms gives ~3.7x headroom over that observed stall,
+;; without changing what the tests prove (real daemon thread, real clock).
+(def ^{:stratum 0} ^:private keepalive-test-stagnation-threshold-ms 500)
 
-(deftest ^{:stratum 0} keepalive-prevents-stagnation-during-silence-test
-  (testing "keepalive thread refreshes the monitor across silent periods"
-    (let [monitor (pm/create-progress-monitor
-                   {:stagnation-threshold-ms 80
-                    :max-total-ms            5000
-                    :min-activity-interval-ms 1})
-          stop! (pm/start-keepalive! monitor 20)]
-      (try
-        (pm/record-activity! monitor :stream-init)
-        (Thread/sleep 200)
-        (is (nil? (pm/check-timeout monitor))
-            "keepalive refreshes ⇒ stagnation timer never expires")
-        (finally
-          (stop!))))))
+(def ^{:stratum 0} ^:private keepalive-test-interval-ms 20)
 
-(deftest ^{:stratum 0} keepalive-stop-fn-halts-the-thread-test
-  (testing "stop! returned by start-keepalive! halts further refreshes"
-    (let [monitor (pm/create-progress-monitor
-                   {:stagnation-threshold-ms 80
-                    :max-total-ms            5000
-                    :min-activity-interval-ms 1})
-          stop! (pm/start-keepalive! monitor 20)]
-      (pm/record-activity! monitor :stream-init)
-      (Thread/sleep 50)
-      (stop!)
-      ;; Allow any in-flight tick to settle, then sleep past the threshold.
-      (Thread/sleep 200)
-      (is (= :stagnation (:type (pm/check-timeout monitor)))
-          "after stop!, silence stagnates as expected"))))
+(def ^{:stratum 0} ^:private keepalive-test-sleep-ms 600)
 
 (deftest ^{:stratum 0} keepalive-rejects-non-positive-interval-test
   (testing "start-keepalive! refuses non-positive interval-ms"
@@ -1415,6 +1385,50 @@
           ":tool-result must advance :last-activity-at to keep monitor alive"))))
 
 ;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} stagnation-fires-on-silence-without-keepalive-test
+  (testing "without keepalive, a silent monitor stagnates after the threshold"
+    ;; Bug demonstration: this is the dogfood failure mode in unit form.
+    ;; record-activity! once at start, then silence — the timer expires.
+    (let [monitor (pm/create-progress-monitor
+                   {:stagnation-threshold-ms keepalive-test-stagnation-threshold-ms
+                    :max-total-ms            5000
+                    :min-activity-interval-ms 1})]
+      (pm/record-activity! monitor :stream-init)
+      (Thread/sleep keepalive-test-sleep-ms)
+      (let [timeout (pm/check-timeout monitor)]
+        (is (= :stagnation (:type timeout))
+            "silence beyond stagnation-threshold-ms ⇒ stagnation fires")))))
+
+(deftest ^{:stratum 1} keepalive-prevents-stagnation-during-silence-test
+  (testing "keepalive thread refreshes the monitor across silent periods"
+    (let [monitor (pm/create-progress-monitor
+                   {:stagnation-threshold-ms keepalive-test-stagnation-threshold-ms
+                    :max-total-ms            5000
+                    :min-activity-interval-ms 1})
+          stop! (pm/start-keepalive! monitor keepalive-test-interval-ms)]
+      (try
+        (pm/record-activity! monitor :stream-init)
+        (Thread/sleep keepalive-test-sleep-ms)
+        (is (nil? (pm/check-timeout monitor))
+            "keepalive refreshes ⇒ stagnation timer never expires")
+        (finally
+          (stop!))))))
+
+(deftest ^{:stratum 1} keepalive-stop-fn-halts-the-thread-test
+  (testing "stop! returned by start-keepalive! halts further refreshes"
+    (let [monitor (pm/create-progress-monitor
+                   {:stagnation-threshold-ms keepalive-test-stagnation-threshold-ms
+                    :max-total-ms            5000
+                    :min-activity-interval-ms 1})
+          stop! (pm/start-keepalive! monitor keepalive-test-interval-ms)]
+      (pm/record-activity! monitor :stream-init)
+      (Thread/sleep 50)
+      (stop!)
+      ;; Allow any in-flight tick to settle, then sleep past the threshold.
+      (Thread/sleep keepalive-test-sleep-ms)
+      (is (= :stagnation (:type (pm/check-timeout monitor)))
+          "after stop!, silence stagnates as expected"))))
 
 (deftest ^{:stratum 1} start-stream-reader!-clean-shutdown-prints-no-stderr-test
   ;; Regression: pre-fix the daemon's `(catch Exception e ...)` caught


### PR DESCRIPTION
## Summary
- `keepalive-prevents-stagnation-during-silence-test` flaked on loaded CI runners (CI run 30340889808, an unrelated PR): the keepalive daemon thread's 20ms refresh tick occasionally landed late enough (observed 135ms) to cross the test's 80ms stagnation threshold — a false stagnation on a real, correctly-behaving keepalive.
- Widened `stagnation-threshold-ms` to 500 against the same 20ms interval (25:1 ratio, up from 4:1), giving a single delayed tick ~3.7x headroom over the observed stall before it can cross the line.
- Extracted the shared timing values (threshold/interval/sleep) into named constants — they were three copies of `80`/`20`/`200` across the trio of tests that lock this contract (stagnation fires without keepalive / keepalive prevents it / stop! re-enables it), so they now stay in sync by construction.
- No change to `progress-monitor.clj` — same real daemon thread, same real wall clock, same assertions. What the tests prove is unchanged; only the margin against scheduler jitter widened.

## Test plan
- [x] `bb lint:clj` on the changed file — 0 errors, 0 warnings
- [x] Direct `clojure.test` run of all 12 `components/llm/test` namespaces (186 tests, 1051 assertions) — 0 failures, 0 errors, on both the initial edit and again after rebasing onto current `origin/main` (this file had drifted 90 commits, needed a stratum-metadata-aware reapply)
- [x] `keepalive-prevents-stagnation-during-silence-test` run 25 times back-to-back (15 + 10 across two verification passes) with zero failures
- [ ] Full `bb test:poly` — attempted, but this sandbox has no Docker and hit a **pre-existing, unrelated** failure in `ai.miniforge.pr-lifecycle.monitor-worklist-test` (`ClassCastException: RegularEnumSet cannot be cast to HashSet` inside `babashka.fs/delete-tree`, likely a JDK 21 vs. `babashka.fs` version mismatch in this environment). That component is untouched by this diff; flagging separately rather than fixing here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)