### PR TITLE
fix(ci): pin create-github-app-token to full SHA in notify-website

### DIFF
--- a/.github/workflows/notify-website.yml
+++ b/.github/workflows/notify-website.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Generate website token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         with:
           app-id: ${{ env.MINIFORGE_CI_BOT_APP_ID }}
           private-key: ${{ secrets.MINIFORGE_CI_BOT_KEY }}


### PR DESCRIPTION
Mirrors the Copilot supply-chain finding from miniforge-ai/thesium-career#567 onto this repo's copy of the workflow (merged in #1564): `actions/create-github-app-token` pinned to its full commit SHA, matching the existing pin on `peter-evans/repository-dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)