### PR TITLE
fix(gate): bind *read-eval* false in syntax-gate read-string calls

### DIFF
--- a/components/gate/src/ai/miniforge/gate/syntax.clj
+++ b/components/gate/src/ai/miniforge/gate/syntax.clj
@@ -35,11 +35,12 @@
   (try
     (let [rdr (java.io.PushbackReader. (java.io.StringReader. code-str))
           eof (Object.)
-          forms (loop [forms []]
-                  (let [form (read {:eof eof} rdr)]
-                    (if (identical? form eof)
-                      forms
-                      (recur (conj forms form)))))]
+          forms (binding [*read-eval* false]
+                  (loop [forms []]
+                    (let [form (read {:eof eof} rdr)]
+                      (if (identical? form eof)
+                        forms
+                        (recur (conj forms form))))))]
       {:valid? true :form-count (count forms)})
     (catch Exception ex
       {:valid? false

--- a/components/gate/src/ai/miniforge/gate/syntax.clj
+++ b/components/gate/src/ai/miniforge/gate/syntax.clj
@@ -25,7 +25,7 @@
 
 ;; Syntax checking
 (defn ^{:stratum 0} parse-clojure
-  "Parse Clojure code using read-string for AST validation.
+  "Parse Clojure code using clojure.core/read with a PushbackReader.
 
    Reads all top-level forms (not just the first one).
 
@@ -35,13 +35,13 @@
   (try
     (let [rdr (java.io.PushbackReader. (java.io.StringReader. code-str))
           eof (Object.)
-          forms (binding [*read-eval* false]
-                  (loop [forms []]
-                    (let [form (read {:eof eof} rdr)]
-                      (if (identical? form eof)
-                        forms
-                        (recur (conj forms form))))))]
-      {:valid? true :form-count (count forms)})
+          form-count (binding [*read-eval* false]
+                       (loop [n 0]
+                         (let [form (read {:eof eof} rdr)]
+                           (if (identical? form eof)
+                             n
+                             (recur (inc n))))))]
+      {:valid? true :form-count form-count})
     (catch Exception ex
       {:valid? false
        :error (ex-message ex)})))

--- a/components/loop/src/ai/miniforge/loop/gates.clj
+++ b/components/loop/src/ai/miniforge/loop/gates.clj
@@ -151,7 +151,8 @@
                  (seq content))
           (do
             #_{:clj-kondo/ignore [:unused-value]}
-            (read-string content)  ; Parse to check syntax; result intentionally unused
+            (binding [*read-eval* false]
+              (read-string content))  ; Parse to check syntax; result intentionally unused
             (pass-result id :syntax
                          :duration-ms (clock/elapsed-since start)))
           ;; For non-code artifacts, pass by default


### PR DESCRIPTION
## What

Bind `*read-eval*` to `false` before every call to `read` / `read-string` on untrusted artifact content in the two syntax-gate implementations.

## Why

JVM Clojure defaults `*read-eval*` to `true`. The `#=()` reader dispatch form causes the Clojure reader to **evaluate arbitrary JVM code at read time** — before any gate logic runs. When these gates process LLM-generated code (the normal case), a prompt-injection attack that plants a `#=()` form in the generated content triggers arbitrary JVM code execution inside the agent process. This is a prompt-injection → RCE path with no additional prerequisites.

## Files changed

| File | Change |
|------|--------|
| `components/loop/src/ai/miniforge/loop/gates.clj` | Wrap `(read-string content)` in `SyntaxGate/check` with `(binding [*read-eval* false] ...)` |
| `components/gate/src/ai/miniforge/gate/syntax.clj` | Wrap the `read` loop inside `parse-clojure` with `(binding [*read-eval* false] ...)` |

The change is minimal and surgical — no logic altered, only the reader eval flag suppressed for the duration of each parse call.

## Test plan

- [ ] Confirm `(binding [*read-eval* false] (read-string "#=(java.lang.Runtime/getRuntime)"))` throws `EvalReader not allowed` rather than executing.
- [ ] Run existing gate unit tests: `bb test:gates` (or equivalent) — all tests should pass unchanged.
- [ ] Manually pass a well-formed Clojure artifact through `SyntaxGate` and `check-syntax` — both should return `{:passed? true}` / `pass-result`.
- [ ] Pass a malformed artifact — both should return the appropriate failure result with a syntax-error message.

---
_Generated by [Claude Code](https://claude.ai/code/session_012we1oYMe8F56UzugDdcHQF)_