### PR TITLE
docs(ariadne): canonical home in miniforge, versioned and tagged

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -34,7 +34,7 @@
 - **[Orchestrator Architecture](design/orchestrator-architecture.md)** -- Coordination, phase transitions, event routing
 - **[RFC: Adopting Ariadne](architecture/rfc-ariadne-adoption.md)** -- Tenancy, grants, clause labels, transacted
   effects for miniforge
-- **[Ariadne architecture](architecture/ariadne/tenancy-ownership-access.md)** -- the portable tenancy / ownership /
+- **[Ariadne architecture](architecture/ariadne/tenancy-ownership-access.md)** -- The portable tenancy / ownership /
   access architecture itself; versioned and tagged (`ariadne/v*`)
 - **[Knowledge Component](design/knowledge-component.md)** -- Symbol resolution, trust model, caching
 - **[Policy Pack Taxonomy](design/policy-pack-taxonomy.md)** -- Pack classification, lifecycle, governance

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -34,6 +34,8 @@
 - **[Orchestrator Architecture](design/orchestrator-architecture.md)** -- Coordination, phase transitions, event routing
 - **[RFC: Adopting Ariadne](architecture/rfc-ariadne-adoption.md)** -- Tenancy, grants, clause labels, transacted
   effects for miniforge
+- **[Ariadne architecture](architecture/ariadne/tenancy-ownership-access.md)** -- the portable tenancy / ownership /
+  access architecture itself; versioned and tagged (`ariadne/v*`)
 - **[Knowledge Component](design/knowledge-component.md)** -- Symbol resolution, trust model, caching
 - **[Policy Pack Taxonomy](design/policy-pack-taxonomy.md)** -- Pack classification, lifecycle, governance
 - **[Compliance Scanner](design/compliance-scanner.md)** -- Scan, classify, plan, execute

--- a/docs/architecture/ariadne/CHANGELOG.md
+++ b/docs/architecture/ariadne/CHANGELOG.md
@@ -1,0 +1,58 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Ariadne changelog
+
+Bump types are defined in [VERSIONING.md](VERSIONING.md). Entries above
+PATCH state what an adopter has to do about the change.
+
+## v1.6.0 — 2026-07-28 (MINOR)
+
+First tagged and publicly published version. Ariadne moves here from
+the private `thesium-career` repository, which is where it was
+distilled; this repository is now its canonical home, because Miniforge
+is an adopter and the architecture is written to be portable.
+
+**No axiom, interface, or vocabulary changed.** The mechanics ratified
+by [rfc-ariadne-adoption.md](../rfc-ariadne-adoption.md) and built in
+adoption step 1 are the same mechanics. An implementation written
+against the untagged v1.5 lineage needs no changes.
+
+Changed:
+
+- **§10 Instantiations emptied.** The section held a table of
+  adopter-specific mappings (including systems that are not public and
+  a proposal not yet made to the organization it named). Instantiation
+  records now live with their adopters. The section number is retained
+  as a placeholder — renumbering would break every citation, which
+  VERSIONING.md classifies as a major change.
+- **Licensed-feed examples genericized.** §12 and §13 used a named
+  commercial market-data vendor as the worked example. The mechanism is
+  unchanged; the licensor is now the generic `license:market-data`.
+  The concrete instantiation stays private with the product that holds
+  that licence.
+- **Example principal renamed** from a real person to `alice`.
+- **Added** `VERSIONING.md` — tag scheme, bump semantics, the
+  compatibility surface a major bump protects, and the fork workflow.
+- **Added** this changelog.
+- **Version line added** to the spec header, pinning the tag.
+
+## v1.0 – v1.5 — untagged lineage
+
+Developed in `thesium-career` between 2026-07-26 and 2026-07-27, from
+ADR 008 and its implementation review. Not tagged, not separately
+published; the history is in that repository. Notable states:
+
+- **v1.0** — initial distillation: axioms, four layers, the Zanzibar
+  relation layer, ownership-by-provenance, offboarding and takeaway.
+- **v1.2** — agent orchestration as principals; tools as a disclosure
+  surface; elevation and scoped grants.
+- **v1.4** — third-party rights: licensed feeds and open-web intake;
+  App Store and DMG authentication posture.
+- **v1.5** — semantic-convergence pass: clause sets replace scalar
+  labels, authority-declared policy transforms, decision envelopes,
+  transacted effects, the freshness contract, and scoped taint. This is
+  the state Miniforge ratified and adopted in step 1.

--- a/docs/architecture/ariadne/VERSIONING.md
+++ b/docs/architecture/ariadne/VERSIONING.md
@@ -1,0 +1,104 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Versioning Ariadne
+
+Ariadne is a portable architecture. Systems adopt it, adapt it, and
+fork it, and they need to be able to say precisely *which* Ariadne they
+adopted — and to work out later what changed. This file defines how
+that works.
+
+## Tags are the unit of adoption
+
+Every published version is a git tag in this repository:
+
+```text
+ariadne/vMAJOR.MINOR.PATCH
+```
+
+The `ariadne/` prefix keeps these separate from the engine's own
+release tags (`v2026.MM.DD.N`) and stable markers (`stable/*`). A tag
+points at a commit where the whole architecture unit — the spec, its
+diagrams, and its explainers — is internally consistent.
+
+**Cite the tag, never `main`.** An adoption document that links to
+`main` describes a moving target, which defeats the point of recording
+an adoption at all.
+
+## What a version bump means
+
+Semantic versioning, with the compatibility surface defined below in
+architecture terms rather than API terms.
+
+| Bump | Meaning for an adopter | Examples |
+|---|---|---|
+| **MAJOR** | A fork must re-derive. Something an implementation was entitled to rely on has changed. | An axiom (A1–A3) changes; one of the six frozen interfaces (§13) changes shape incompatibly; a decision rule inverts (a default that permitted now denies); sections are renumbered. |
+| **MINOR** | A fork can adopt additively. Existing derivations stay valid. | A new mechanism or section; a new optional clause field; a new obligation type or reason code; a worked example added; adopter-specific material removed. |
+| **PATCH** | Nothing to adopt. | Clarification, typo, prose tightening, a diagram redrawn without a semantic change. |
+
+## The compatibility surface — what a MAJOR bump protects
+
+These are the things an implementation is entitled to build against.
+They do not change without a major bump:
+
+1. **The axioms.** A1 people are tenants; A2 exactly one
+   `owner_tenant_id` per record; A3 membership is a relation, never
+   containment.
+2. **The six frozen interfaces** (§13): `PolicyClause`,
+   `PolicyTransform`, `DestinationDescriptor`,
+   `ExecutionGrant`/`Delegation`, `DecisionEnvelope`,
+   `ProposedTransaction`.
+3. **Section numbering.** Adoption documents, code comments, and
+   review threads cite sections by number. Renumbering silently
+   invalidates every one of those citations, so it is a breaking
+   change — which is why §10 is an empty placeholder rather than a
+   reclaimed number.
+4. **The clause and decision vocabularies** — the enforcement actions
+   and their relaxation semantics, and the decision values an envelope
+   can carry.
+
+Everything else — prose, rationale, defense material, worked examples,
+diagrams — can change in a minor or patch release.
+
+## Forking
+
+The intended workflow for a system that adapts Ariadne rather than
+adopting it verbatim:
+
+1. **Fork at a tag.** Record the tag in your own adoption document
+   (`adopted: ariadne/v1.6.0`), not the date you copied it.
+2. **Keep your deltas separate and named.** A fork is best described
+   as "Ariadne v1.6.0 plus these deltas", so the deltas stay legible
+   as the upstream moves.
+3. **Diff tags to see what to adopt.** To review what changed between
+   the version you forked and a later one:
+
+   ```bash
+   git diff ariadne/v1.6.0..ariadne/v1.7.0 -- docs/architecture/ariadne/
+   ```
+
+   The changelog states the bump type, which tells you whether that
+   diff is something you can take additively or something that
+   requires re-deriving.
+4. **Say which version you mean.** "Our fork of Ariadne v1.6.0" is a
+   statement someone can verify. "Our version of Ariadne" is not.
+
+## Releasing a new version
+
+1. Land the content change on `main` through the normal review process.
+2. Add a `CHANGELOG.md` entry stating the bump type and, for anything
+   above PATCH, what an adopter has to do about it.
+3. Update the `**Version:**` line at the top of the spec.
+4. Tag the merge commit and push the tag:
+
+   ```bash
+   git tag -a ariadne/vX.Y.Z -m "Ariadne vX.Y.Z"
+   git push origin ariadne/vX.Y.Z
+   ```
+
+Tags are never moved or deleted once pushed. A published version that
+turns out to be wrong is superseded by the next version, not rewritten
+— an adopter who forked from it needs it to keep existing.

--- a/docs/architecture/ariadne/diagrams/01-core-model.svg
+++ b/docs/architecture/ariadne/diagrams/01-core-model.svg
@@ -1,0 +1,251 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1040" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="aP" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#9673a6"/></marker>
+    <marker id="aB" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#3a76b8"/></marker>
+    <marker id="aR" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#c0392b"/></marker>
+    <style>
+      .band{fill:#1e5f96;} .bandT{fill:#fff;font-size:20px;font-weight:bold;} .bandS{fill:#cfe2f3;font-size:12px;}
+      .zone{fill:#fcfcfa;stroke:#b8b8b0;stroke-width:1.2;} .zoneT{fill:#1e5f96;font-size:13px;font-weight:bold;letter-spacing:.4px;}
+      .pt{fill:#d5e8d4;stroke:#82b366;stroke-width:1.5;} .ot{fill:#dae8fc;stroke:#6c8ebf;stroke-width:1.5;}
+      .pr{fill:#fff2cc;stroke:#d6b656;stroke-width:1.5;} .rel{fill:#e1d5e7;stroke:#9673a6;stroke-width:1.5;}
+      .rec{fill:#ffffff;stroke:#8a8a82;stroke-width:1;} .ext{fill:#ffe6cc;stroke:#d79b00;stroke-width:1.5;}
+      .dis{fill:#f8cecc;stroke:#b85450;stroke-width:1;}
+      .h{font-size:13px;font-weight:bold;fill:#232323;} .t{font-size:11.5px;fill:#333;} .s{font-size:10.5px;fill:#555;}
+      .m{font-family:Menlo,Consolas,monospace;font-size:10px;fill:#4a355c;} .mS{font-family:Menlo,Consolas,monospace;font-size:9.5px;fill:#4a355c;}
+      .note{fill:#fffde7;stroke:#c8b900;stroke-width:1;} .noteT{font-size:11px;fill:#4a4a20;}
+      .eP{stroke:#9673a6;stroke-width:1.6;fill:none;} .eB{stroke:#3a76b8;stroke-width:1.4;fill:none;}
+      .bad{stroke:#c0392b;stroke-width:1.6;fill:none;} .ok{stroke:#4a9a4a;stroke-width:1.6;fill:none;}
+      .lgT{font-size:11px;fill:#333;}
+    </style>
+  </defs>
+
+  <rect width="1920" height="1040" fill="#ffffff"/>
+  <rect class="band" x="0" y="0" width="1920" height="44"/>
+  <text class="bandT" x="20" y="29">Tenancy, Ownership &amp; Access — 1. Core Model</text>
+  <text class="bandS" x="1900" y="28" text-anchor="end">ADR 008 · tenancy-ownership-access.md §2–§4 · people are tenants · one owner per record · membership is a relation</text>
+
+  <!-- ZONES -->
+  <rect class="zone" x="20" y="62" width="600" height="800" rx="6"/>
+  <text class="zoneT" x="36" y="84">PERSONAL TENANTS — a person IS a tenant of one</text>
+  <rect class="zone" x="640" y="62" width="560" height="800" rx="6"/>
+  <text class="zoneT" x="656" y="84">RELATION GRAPH — Zanzibar tuples: the only cross-boundary mechanism</text>
+  <rect class="zone" x="1220" y="62" width="430" height="800" rx="6"/>
+  <text class="zoneT" x="1236" y="84">ORGANIZATIONAL TENANT</text>
+  <rect class="zone" x="1670" y="62" width="230" height="800" rx="6"/>
+  <text class="zoneT" x="1686" y="84">NON-RESIDENT AUTHORITIES</text>
+
+  <!-- tenant:chris -->
+  <rect class="pt" x="44" y="104" width="270" height="380" rx="8"/>
+  <text class="h" x="60" y="128">tenant:chris</text>
+  <text class="s" x="60" y="144">personal · exactly one person</text>
+  <rect class="pr" x="60" y="156" width="238" height="34" rx="6"/>
+  <text class="h" x="72" y="177" font-size="12">principal:chris</text>
+  <text class="s" x="176" y="177">#controller (may be several)</text>
+  <text class="s" x="60" y="212" font-weight="bold">owns (owner_tenant_id = tenant:chris)</text>
+  <rect class="rec" x="60" y="222" width="238" height="30" rx="4"/>
+  <text class="t" x="70" y="241">evidence: resume, portfolio</text>
+  <rect class="dis" x="232" y="227" width="58" height="18" rx="9"/><text class="s" x="261" y="240" text-anchor="middle">:private</text>
+  <rect class="rec" x="60" y="258" width="238" height="30" rx="4"/>
+  <text class="t" x="70" y="277">claims + profile (derived)</text>
+  <rect class="dis" x="212" y="263" width="78" height="18" rx="9"/><text class="s" x="251" y="276" text-anchor="middle">:confidential*</text>
+  <rect class="rec" x="60" y="294" width="238" height="30" rx="4"/>
+  <text class="t" x="70" y="313">projections: fit report, growth read</text>
+  <rect class="rec" x="60" y="330" width="238" height="30" rx="4"/>
+  <text class="t" x="70" y="349">commissioned review (default)</text>
+  <text class="s" x="60" y="382">* inherited from :confidential org sources —</text>
+  <text class="s" x="60" y="396">restriction is the imposer's, record is chris's</text>
+  <text class="s" x="60" y="424" font-style="italic">subject-id ≡ personal-tenant id.</text>
+  <text class="s" x="60" y="438" font-style="italic">No separate user / subject layer.</text>
+  <text class="s" x="60" y="452" font-style="italic">B2C = this box alone; human-owner checks</text>
+  <text class="s" x="60" y="466" font-style="italic">trivial; agent principals resolve delegations.</text>
+
+  <!-- tenant:alex -->
+  <rect class="pt" x="340" y="104" width="256" height="200" rx="8"/>
+  <text class="h" x="356" y="128">tenant:alex</text>
+  <text class="s" x="356" y="144">personal · teammate (bottom-up adoption)</text>
+  <rect class="pr" x="356" y="156" width="224" height="30" rx="6"/>
+  <text class="h" x="368" y="175" font-size="12">principal:alex</text>
+  <rect class="rec" x="356" y="194" width="224" height="28" rx="4"/>
+  <text class="t" x="366" y="212">evidence + claims + projections</text>
+  <text class="s" x="356" y="242">rides license:L as #seat — manager pays,</text>
+  <text class="s" x="356" y="256">owns none of alex's records (§3.7)</text>
+
+  <!-- external principals card -->
+  <rect class="pr" x="340" y="330" width="256" height="120" rx="8"/>
+  <text class="h" x="356" y="354">principals without residency here</text>
+  <rect class="pr" x="356" y="366" width="110" height="28" rx="6"/><text class="t" x="366" y="384">principal:dana</text>
+  <rect class="pr" x="478" y="366" width="102" height="28" rx="6"/><text class="t" x="488" y="384">principal:sam</text>
+  <text class="s" x="356" y="414">hold relations INTO tenants (manager,</text>
+  <text class="s" x="356" y="428">coach); own nothing by holding them</text>
+
+  <!-- containment vs relation callout -->
+  <rect class="note" x="44" y="520" width="552" height="150" rx="6"/>
+  <text class="h" x="60" y="544">Membership is a relation — NEVER containment</text>
+  <!-- containment mini (crossed) -->
+  <rect x="60" y="558" width="150" height="92" rx="6" fill="#dae8fc" stroke="#6c8ebf"/>
+  <rect x="76" y="586" width="118" height="50" rx="6" fill="#d5e8d4" stroke="#82b366"/>
+  <text class="s" x="86" y="606">person nested</text>
+  <text class="s" x="86" y="620">inside org</text>
+  <line class="bad" x1="62" y1="560" x2="208" y2="648"/><line class="bad" x1="208" y1="560" x2="62" y2="648"/>
+  <text class="s" x="60" y="664" fill="#c0392b">✗ offboarding = data migration</text>
+  <!-- relation mini (ok) -->
+  <rect x="260" y="574" width="96" height="46" rx="6" fill="#dae8fc" stroke="#6c8ebf"/><text class="s" x="272" y="601">tenant:org</text>
+  <rect x="452" y="574" width="112" height="46" rx="6" fill="#d5e8d4" stroke="#82b366"/><text class="s" x="464" y="601">tenant:person</text>
+  <line class="eP" x1="356" y1="597" x2="450" y2="597" marker-end="url(#aP)"/>
+  <text class="mS" x="403" y="590" text-anchor="middle">#employee</text>
+  <text class="s" x="260" y="664" fill="#3a7a3a">✓ offboarding = delete one tuple; no data moves</text>
+
+  <!-- axioms strip -->
+  <rect class="note" x="44" y="690" width="552" height="150" rx="6"/>
+  <text class="h" x="60" y="714">Axioms</text>
+  <text class="t" x="60" y="736">A1 — People are tenants: the subject of a record is a personal tenant.</text>
+  <text class="t" x="60" y="756">A2 — Every record has exactly ONE owner tenant. Visibility for a</text>
+  <text class="t" x="80" y="772">second party is a granted relation, never a second owner.</text>
+  <text class="t" x="60" y="792">A3 — Employment / coaching / seats are tuples between tenants;</text>
+  <text class="t" x="80" y="808">severing one revokes access and moves nothing.</text>
+
+  <!-- RELATION GRAPH ZONE -->
+  <rect class="rel" x="664" y="104" width="512" height="76" rx="8"/>
+  <text class="h" x="680" y="128">check(principal, relation, object)</text>
+  <text class="s" x="680" y="146">the ONLY authorization question</text>
+  <text class="s" x="680" y="162">local: in-process fn (trivially #owner) · hosted: SpiceDB / OpenFGA, same seam</text>
+
+  <!-- tuples -->
+  <text class="s" x="680" y="196" font-weight="bold">relation tuples — object#relation@subject</text>
+  <rect class="rel" x="664" y="208" width="512" height="30" rx="5"/>
+  <text class="m" x="676" y="227">tenant:acme#employee@tenant:chris</text>
+  <text class="s" x="1000" y="227">employment</text>
+  <rect class="rel" x="664" y="244" width="512" height="30" rx="5"/>
+  <text class="m" x="676" y="263">engagement:chris-acme#manager@principal:dana</text>
+  <text class="s" x="1000" y="263">role scoped to engagement</text>
+  <rect class="rel" x="664" y="280" width="512" height="30" rx="5"/>
+  <text class="m" x="676" y="299">tenant:chris#coach@principal:sam</text>
+  <text class="s" x="1000" y="299">Studio / Coach shape</text>
+  <rect class="rel" x="664" y="316" width="512" height="30" rx="5"/>
+  <text class="m" x="676" y="335">assessment:A#engagement@engagement:chris-acme</text>
+  <text class="s" x="1000" y="335">record hangs off the engagement</text>
+  <rect class="rel" x="664" y="352" width="512" height="30" rx="5"/>
+  <text class="m" x="676" y="371">rubric:R#viewer@tenant:acme#employee</text>
+  <text class="s" x="1000" y="371">userset: all employees</text>
+  <rect class="rel" x="664" y="388" width="512" height="30" rx="5"/>
+  <text class="m" x="676" y="407">evidence:E#owner@tenant:chris</text>
+  <text class="s" x="1000" y="407">materialized from owner col.</text>
+  <rect class="rel" x="664" y="424" width="512" height="30" rx="5"/>
+  <text class="m" x="676" y="443">license:L#holder@tenant:dana · license:L#seat@tenant:alex</text>
+  <text class="s" x="1060" y="443">entitlement</text>
+
+  <!-- role facts note -->
+  <rect class="note" x="664" y="478" width="512" height="66" rx="6"/>
+  <text class="t" x="680" y="500">Role facts live in tuples — no roles array on a session or context.</text>
+  <text class="t" x="680" y="518">A role is a relation somebody granted and somebody can revoke.</text>
+  <text class="t" x="680" y="536">Negative-authorization tests exist before any second principal does.</text>
+
+  <!-- four layers mini -->
+  <rect class="note" x="664" y="560" width="512" height="130" rx="6"/>
+  <text class="h" x="680" y="584">Four orthogonal layers (§3) — none leaks into another's schema</text>
+  <rect class="rec" x="680" y="596" width="228" height="38" rx="4"/><text class="t" x="690" y="612" font-weight="bold">Authentication</text><text class="s" x="690" y="627">who is the principal? (deferred locally)</text>
+  <rect class="rel" x="920" y="596" width="240" height="38" rx="4"/><text class="t" x="930" y="612" font-weight="bold">Authorization</text><text class="s" x="930" y="627">check() over relation tuples</text>
+  <rect class="dis" x="680" y="640" width="228" height="38" rx="4"/><text class="t" x="690" y="656" font-weight="bold">Disclosure &amp; processing</text><text class="s" x="690" y="671">clauses: destination × purpose × operation</text>
+  <rect class="ext" x="920" y="640" width="240" height="38" rx="4"/><text class="t" x="930" y="656" font-weight="bold">Entitlement</text><text class="s" x="930" y="671">license tuples — gates compute, never data</text>
+
+  <!-- workspace note -->
+  <rect class="note" x="664" y="706" width="512" height="134" rx="6"/>
+  <text class="h" x="680" y="730">Deployment shapes, one model</text>
+  <text class="t" x="680" y="752">B2C local: tenant = subject = the one personal tenant; resolver is a</text>
+  <text class="t" x="680" y="768">pure function; no login; checks trivially #owner.</text>
+  <text class="t" x="680" y="788">Bottom-up team: personal tenants + license/seat + #manager tuples —</text>
+  <text class="t" x="680" y="804">no org tenant required, nobody owns anyone's records.</text>
+  <text class="t" x="680" y="824">Enterprise: org tenant appears additively; its claim reaches forward.</text>
+
+  <!-- ORG TENANT -->
+  <rect class="ot" x="1244" y="104" width="382" height="420" rx="8"/>
+  <text class="h" x="1260" y="128">tenant:acme</text>
+  <text class="s" x="1260" y="144">organizational · multi-member · structurally identical to personal</text>
+  <rect class="rec" x="1260" y="158" width="350" height="30" rx="4"/>
+  <text class="t" x="1270" y="177">workspace/default</text>
+  <text class="s" x="1400" y="177">(team / cycle contexts when needed)</text>
+  <text class="s" x="1260" y="212" font-weight="bold">owns (assets &amp; channels — never people's records)</text>
+  <rect class="rec" x="1260" y="222" width="350" height="30" rx="4"/>
+  <text class="t" x="1270" y="241">rubric / CSP lens (shared via #viewer userset)</text>
+  <rect class="rec" x="1260" y="258" width="350" height="30" rx="4"/>
+  <text class="t" x="1270" y="277">JD corpus · catalog entries</text>
+  <rect class="rec" x="1260" y="294" width="350" height="30" rx="4"/>
+  <text class="t" x="1270" y="313">connector bindings (Jira · git · docs channels)</text>
+  <rect class="rec" x="1260" y="330" width="350" height="30" rx="4"/>
+  <text class="t" x="1270" y="349">org-channel intake: artifacts / evidence</text>
+  <rect class="dis" x="1544" y="335" width="58" height="18" rx="9"/><text class="s" x="1573" y="348" text-anchor="middle">:conf.</text>
+  <rect class="pr" x="1260" y="376" width="350" height="34" rx="6"/>
+  <text class="t" x="1270" y="390" font-weight="bold">principal:dana</text>
+  <text class="s" x="1270" y="404">HR admin / manager — operates via granted relations</text>
+  <text class="s" x="1260" y="434" font-style="italic">A record's TYPE never implies its owner kind:</text>
+  <text class="s" x="1260" y="448" font-style="italic">a CSP lens is org-owned here, personal-owned in B2C.</text>
+  <text class="s" x="1260" y="462" font-style="italic">The creating context decides — owner is a column,</text>
+  <text class="s" x="1260" y="476" font-style="italic">not a rule per type.</text>
+
+  <!-- commissioning note -->
+  <rect class="note" x="1244" y="544" width="382" height="120" rx="6"/>
+  <text class="h" x="1260" y="568">Commissioning = visibility, not ownership</text>
+  <text class="t" x="1260" y="590">A review run under acme's cycle: chris keeps the record;</text>
+  <text class="t" x="1260" y="606">acme holds #commissioner / #viewer relations.</text>
+  <text class="t" x="1260" y="626">Official-record semantics only by explicit org policy</text>
+  <text class="t" x="1260" y="642">flip at onboarding — a named opt-in, never the default.</text>
+
+  <!-- offboarding note -->
+  <rect class="note" x="1244" y="680" width="382" height="160" rx="6"/>
+  <text class="h" x="1260" y="704">Offboarding (§7)</text>
+  <text class="t" x="1260" y="726">Delete employment + seat tuples →</text>
+  <text class="t" x="1260" y="742">· acme's relations into tenant:chris revoked</text>
+  <text class="t" x="1260" y="758">· chris's access to acme-owned intake revoked</text>
+  <text class="t" x="1260" y="774">· tenant:chris and everything it owns: untouched</text>
+  <text class="t" x="1260" y="794">Entitlement gates compute, never data. Takeaway</text>
+  <text class="t" x="1260" y="810">export: always available, hard policy, no off switch.</text>
+
+  <!-- NON-RESIDENT -->
+  <rect class="ext" x="1690" y="104" width="192" height="240" rx="8"/>
+  <text class="h" x="1702" y="128">licensor</text>
+  <text class="mS" x="1702" y="146">license:eodhd</text>
+  <text class="s" x="1702" y="168">imposes terms on payloads</text>
+  <text class="s" x="1702" y="182">that ride its feed (§12)</text>
+  <text class="s" x="1702" y="204">not in the tuple store —</text>
+  <text class="s" x="1702" y="218">no principal inside can</text>
+  <text class="s" x="1702" y="232">lower its restrictions</text>
+  <text class="s" x="1702" y="252">comply, or renegotiate</text>
+  <text class="s" x="1702" y="266">out-of-band</text>
+  <text class="s" x="1702" y="290">expiry = one relation cut</text>
+  <text class="s" x="1702" y="304">(diagram 5)</text>
+
+  <rect class="ext" x="1690" y="368" width="192" height="200" rx="8"/>
+  <text class="h" x="1702" y="392">web authors</text>
+  <text class="s" x="1702" y="412">rights-holders of scraped</text>
+  <text class="s" x="1702" y="426">content — public is NOT</text>
+  <text class="s" x="1702" y="440">public domain (Berne)</text>
+  <text class="s" x="1702" y="462">default label:</text>
+  <rect class="dis" x="1702" y="472" width="168" height="20" rx="10"/>
+  <text class="s" x="1786" y="486" text-anchor="middle">third-party-unknown</text>
+  <text class="s" x="1702" y="512">upgrades = recorded</text>
+  <text class="s" x="1702" y="526">human determinations</text>
+
+  <!-- relation edges across zones -->
+  <path class="eP" d="M1244,180 C1210,180 1206,223 1178,223" marker-end="url(#aP)"/>
+  <path class="eP" d="M664,223 C560,223 420,210 314,210" marker-end="url(#aP)"/>
+  <path class="eP" d="M664,259 C630,259 620,380 596,380" marker-end="url(#aP)"/>
+  <path class="eP" d="M1244,391 C1215,391 1216,263 1176,263" marker-end="url(#aP)"/>
+
+  <!-- LEGEND -->
+  <rect class="zone" x="20" y="880" width="1880" height="140" rx="6"/>
+  <text class="zoneT" x="36" y="902">LEGEND — consistent across diagrams 1–5</text>
+  <rect class="pt" x="40" y="916" width="26" height="16" rx="3"/><text class="lgT" x="74" y="929">personal tenant</text>
+  <rect class="ot" x="200" y="916" width="26" height="16" rx="3"/><text class="lgT" x="234" y="929">organizational tenant</text>
+  <rect class="pr" x="400" y="916" width="26" height="16" rx="3"/><text class="lgT" x="434" y="929">principal (human)</text>
+  <rect x="580" y="916" width="26" height="16" rx="3" fill="#fff2cc" stroke="#d6b656" stroke-dasharray="4 2"/><text class="lgT" x="614" y="929">agent principal (owns nothing)</text>
+  <rect class="rel" x="830" y="916" width="26" height="16" rx="3"/><text class="lgT" x="864" y="929">relation tuple / Zanzibar engine</text>
+  <rect class="rec" x="1090" y="916" width="26" height="16" rx="3"/><text class="lgT" x="1124" y="929">record / store / asset</text>
+  <rect class="ext" x="1300" y="916" width="26" height="16" rx="3"/><text class="lgT" x="1334" y="929">gate · entitlement · non-resident authority</text>
+  <rect class="dis" x="1630" y="916" width="26" height="16" rx="3"/><text class="lgT" x="1664" y="929">disclosure / rights label</text>
+  <line class="eP" x1="40" y1="962" x2="90" y2="962" marker-end="url(#aP)"/><text class="lgT" x="100" y="966">relation (tuple) edge</text>
+  <line class="eB" x1="280" y1="962" x2="330" y2="962" marker-end="url(#aB)"/><text class="lgT" x="340" y="966">data / ownership flow</text>
+  <line class="ok" x1="520" y1="962" x2="570" y2="962"/><text class="lgT" x="580" y="966">permitted flow</text>
+  <line x1="720" y1="962" x2="770" y2="962" stroke="#d79b00" stroke-width="1.6"/><text class="lgT" x="780" y="966">escalation (HIL elevation)</text>
+  <line class="bad" x1="980" y1="962" x2="1030" y2="962"/><text class="lgT" x="1040" y="966">refused / severed</text>
+  <text class="lgT" x="40" y="998" font-style="italic">Reading order: 1 core model → 2 request path → 3 ownership by provenance → 4 agent orchestration &amp; tool gates → 5 revocation &amp; third-party rights.</text>
+</svg>

--- a/docs/architecture/ariadne/diagrams/02-request-path.svg
+++ b/docs/architecture/ariadne/diagrams/02-request-path.svg
@@ -1,0 +1,186 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 900" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="aB" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#3a76b8"/></marker>
+    <marker id="aG" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#4a9a4a"/></marker>
+    <marker id="aR" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#c0392b"/></marker>
+    <style>
+      .band{fill:#1e5f96;} .bandT{fill:#fff;font-size:20px;font-weight:bold;} .bandS{fill:#cfe2f3;font-size:12px;}
+      .zone{fill:#fcfcfa;stroke:#b8b8b0;stroke-width:1.2;} .zoneT{fill:#1e5f96;font-size:13px;font-weight:bold;letter-spacing:.4px;}
+      .pt{fill:#d5e8d4;stroke:#82b366;stroke-width:1.5;} .ot{fill:#dae8fc;stroke:#6c8ebf;stroke-width:1.5;}
+      .rel{fill:#e1d5e7;stroke:#9673a6;stroke-width:1.5;} .rec{fill:#ffffff;stroke:#8a8a82;stroke-width:1;}
+      .ext{fill:#ffe6cc;stroke:#d79b00;stroke-width:1.5;} .dis{fill:#f8cecc;stroke:#b85450;stroke-width:1;}
+      .h{font-size:13px;font-weight:bold;fill:#232323;} .t{font-size:11.5px;fill:#333;} .s{font-size:10.5px;fill:#555;}
+      .m{font-family:Menlo,Consolas,monospace;font-size:10px;fill:#4a355c;}
+      .note{fill:#fffde7;stroke:#c8b900;stroke-width:1;}
+      .eB{stroke:#3a76b8;stroke-width:1.6;fill:none;} .ok{stroke:#4a9a4a;stroke-width:1.8;fill:none;}
+      .bad{stroke:#c0392b;stroke-width:1.5;fill:none;}
+      .q{font-size:11px;font-weight:bold;fill:#1e5f96;}
+    </style>
+  </defs>
+
+  <rect width="1920" height="900" fill="#ffffff"/>
+  <rect class="band" x="0" y="0" width="1920" height="44"/>
+  <text class="bandT" x="20" y="29">Tenancy, Ownership &amp; Access — 2. Request Path: Four Orthogonal Layers</text>
+  <text class="bandS" x="1900" y="28" text-anchor="end">§3, §5 · one context shape for every deployment · four questions, four layers, no schema leaks</text>
+
+  <!-- ZONES -->
+  <rect class="zone" x="20" y="62" width="260" height="560" rx="6"/>
+  <text class="zoneT" x="36" y="84">ENTRY POINTS</text>
+  <rect class="zone" x="300" y="62" width="340" height="560" rx="6"/>
+  <text class="zoneT" x="316" y="84">RESOLUTION (deployment-shaped)</text>
+  <rect class="zone" x="660" y="62" width="320" height="560" rx="6"/>
+  <text class="zoneT" x="676" y="84">THE INVOCATION CONTEXT</text>
+  <rect class="zone" x="1000" y="62" width="900" height="560" rx="6"/>
+  <text class="zoneT" x="1016" y="84">SCOPED STORE ACCESS — every read/write runs the gauntlet</text>
+
+  <!-- entries -->
+  <rect class="rec" x="44" y="120" width="212" height="56" rx="6"/>
+  <text class="h" x="56" y="144">CLI</text>
+  <text class="s" x="56" y="162">subcommands · --subject flags</text>
+  <rect class="rec" x="44" y="200" width="212" height="56" rx="6"/>
+  <text class="h" x="56" y="224">Data-plane API</text>
+  <text class="s" x="56" y="242">/v1/runs · subject, not user</text>
+  <rect class="rec" x="44" y="280" width="212" height="56" rx="6"/>
+  <text class="h" x="56" y="304">Desktop app</text>
+  <text class="s" x="56" y="322">lens structs carry subject</text>
+  <rect class="note" x="44" y="376" width="212" height="120" rx="6"/>
+  <text class="h" x="56" y="398">Wire discipline</text>
+  <text class="s" x="56" y="418">field renamed: user → subject</text>
+  <text class="s" x="56" y="434">derived-identity strings deleted:</text>
+  <text class="m" x="56" y="450">"{user}--{run_id}"  ✗</text>
+  <text class="s" x="56" y="468">run scope is an explicit</text>
+  <text class="s" x="56" y="482">context field, never string glue</text>
+
+  <!-- resolvers -->
+  <rect class="pt" x="324" y="120" width="292" height="140" rx="8"/>
+  <text class="h" x="338" y="144">SELF-RESOLVER (dev/test/internal)</text>
+  <text class="t" x="338" y="166">pure fn(request, local state) — no login</text>
+  <text class="s" x="338" y="186">tenant = subject = the one personal tenant</text>
+  <text class="s" x="338" y="202">workspace = workspace/default</text>
+  <text class="s" x="338" y="218">principal = the local operator</text>
+  <text class="s" x="338" y="238">only check: requested subject EXISTS (404, not auth)</text>
+  <rect class="ot" x="324" y="290" width="292" height="120" rx="8"/>
+  <text class="h" x="338" y="314">IDENTITY RESOLVER (shipped tiers)</text>
+  <text class="t" x="338" y="336">paid/pro/corp: identity-backed ALWAYS —</text>
+  <text class="s" x="338" y="356">platform identity (App Store) or own IdP (DMG);</text>
+  <text class="s" x="338" y="372">free tier: per-product choice. identity ≠ hosted —</text>
+  <text class="s" x="338" y="388">store stays local. context shape: IDENTICAL</text>
+  <rect class="note" x="324" y="440" width="292" height="88" rx="6"/>
+  <text class="t" x="338" y="464">Resolution is deployment-shaped;</text>
+  <text class="t" x="338" y="480">the context is not. Downstream code</text>
+  <text class="t" x="338" y="496">cannot tell which resolver ran —</text>
+  <text class="t" x="338" y="512">and never branches on it.</text>
+
+  <!-- context -->
+  <rect class="rel" x="684" y="120" width="272" height="220" rx="8"/>
+  <text class="h" x="698" y="144">InvocationContext</text>
+  <text class="m" x="698" y="170">:tenant/id      "chris"</text>
+  <text class="m" x="698" y="190">:workspace/id   "workspace/default"</text>
+  <text class="m" x="698" y="210">:principal/id   "chris"</text>
+  <text class="m" x="698" y="230">:subject/id     "chris"</text>
+  <text class="m" x="698" y="250">:run/id         (optional, explicit)</text>
+  <text class="m" x="698" y="270">:purpose (+ :purpose-basis)</text>
+  <text class="m" x="698" y="290">+ relation/policy revision pins</text>
+  <text class="s" x="698" y="312">threaded to every store/pipeline call;</text>
+  <text class="s" x="698" y="326">purpose is resolver-set, never model-set</text>
+  <rect class="note" x="684" y="368" width="272" height="104" rx="6"/>
+  <text class="h" x="698" y="390">One id shape, one validator</text>
+  <text class="s" x="698" y="410">a single shared component defines the</text>
+  <text class="s" x="698" y="426">legal identifier for every store that puts</text>
+  <text class="s" x="698" y="442">an id in a path, row, filename, or hash —</text>
+  <text class="s" x="698" y="458">all stores REJECT; none sanitize</text>
+
+  <!-- store API -->
+  <rect class="rec" x="1024" y="120" width="240" height="130" rx="8"/>
+  <text class="h" x="1038" y="144">Store API (ctx-scoped)</text>
+  <text class="m" x="1038" y="168">(list-fit-reports ctx)</text>
+  <text class="m" x="1038" y="188">(save-artifact! ctx a)</text>
+  <text class="m" x="1038" y="208">(get-profile ctx)</text>
+  <text class="s" x="1038" y="234">keys by owner tenant resolved from ctx</text>
+
+  <!-- GAUNTLET -->
+  <text class="q" x="1310" y="120">1 · WHO IS ASKING?</text>
+  <rect class="rec" x="1290" y="130" width="132" height="84" rx="8" stroke-dasharray="5 3"/>
+  <text class="h" x="1302" y="152">Authentication</text>
+  <text class="s" x="1302" y="170">resolver-selected per</text>
+  <text class="s" x="1302" y="184">channel × tier (see left);</text>
+  <text class="s" x="1302" y="198">reserved slot: principal</text>
+
+  <text class="q" x="1470" y="120">2 · MAY THEY?</text>
+  <rect class="rel" x="1450" y="130" width="150" height="84" rx="8"/>
+  <text class="h" x="1462" y="152">Authorization</text>
+  <text class="m" x="1462" y="170">check(p, rel, obj)</text>
+  <text class="s" x="1462" y="186">over relation tuples —</text>
+  <text class="s" x="1462" y="200">local #owner / hosted engine</text>
+
+  <text class="q" x="1650" y="120">3 · DOES THE RECORD PERMIT?</text>
+  <rect class="dis" x="1630" y="130" width="150" height="84" rx="8"/>
+  <text class="h" x="1642" y="152">Disclosure veto</text>
+  <text class="s" x="1642" y="170">policy clauses: destination ×</text>
+  <text class="s" x="1642" y="184">purpose × operation —</text>
+  <text class="s" x="1642" y="198">vetoes ANY relation path</text>
+
+  <text class="q" x="1310" y="290">4 · MAY THIS TENANT COMPUTE?</text>
+  <rect class="ext" x="1290" y="300" width="150" height="84" rx="8"/>
+  <text class="h" x="1302" y="322">Entitlement</text>
+  <text class="s" x="1302" y="340">license tuples on the</text>
+  <text class="s" x="1302" y="354">paying tenant — gates</text>
+  <text class="s" x="1302" y="368">COMPUTE, never data</text>
+
+  <rect class="rec" x="1490" y="300" width="290" height="84" rx="8"/>
+  <text class="h" x="1504" y="322">Stores — one DB, columns not files</text>
+  <text class="s" x="1504" y="342">owner_tenant_id on every owned record;</text>
+  <text class="s" x="1504" y="356">tenancy = columns + scoped queries;</text>
+  <text class="s" x="1504" y="370">no per-tenant DBs, no RLS until hosted scale</text>
+
+  <!-- flow arrows -->
+  <path class="eB" d="M256,148 C300,148 300,175 322,178" marker-end="url(#aB)"/>
+  <path class="eB" d="M256,228 C290,228 292,220 322,205" marker-end="url(#aB)"/>
+  <path class="eB" d="M256,308 C300,308 300,330 322,335" marker-end="url(#aB)"/>
+  <path class="eB" d="M616,180 C650,180 650,200 682,205" marker-end="url(#aB)"/>
+  <path class="eB" d="M616,345 C650,345 650,250 682,240" marker-end="url(#aB)"/>
+  <path class="eB" d="M956,215 C990,215 990,185 1022,185" marker-end="url(#aB)"/>
+  <path class="ok" d="M1264,172 L1288,172" marker-end="url(#aG)"/>
+  <path class="ok" d="M1422,172 L1448,172" marker-end="url(#aG)"/>
+  <path class="ok" d="M1600,172 L1628,172" marker-end="url(#aG)"/>
+  <path class="ok" d="M1705,214 C1705,260 1480,262 1442,300" marker-end="url(#aG)"/>
+  <path class="ok" d="M1440,342 L1488,342" marker-end="url(#aG)"/>
+
+  <!-- refusals -->
+  <path class="bad" d="M1525,214 L1525,252" marker-end="url(#aR)"/>
+  <rect class="dis" x="1450" y="254" width="150" height="22" rx="11"/><text class="s" x="1525" y="269" text-anchor="middle">no relation path → refuse</text>
+  <path class="bad" d="M1705,384 L1705,420" marker-end="url(#aR)"/>
+  <rect class="dis" x="1640" y="422" width="130" height="22" rx="11"/><text class="s" x="1705" y="437" text-anchor="middle">record veto → refuse</text>
+  <path class="bad" d="M1365,384 L1365,420" marker-end="url(#aR)"/>
+  <rect class="dis" x="1270" y="422" width="190" height="22" rx="11"/><text class="s" x="1365" y="437" text-anchor="middle">no entitlement → no new compute</text>
+  <text class="s" x="1290" y="466" font-style="italic">…but reading / exporting owned data NEVER</text>
+  <text class="s" x="1290" y="480" font-style="italic">fails entitlement — property right of the owner</text>
+
+  <!-- seam note -->
+  <rect class="note" x="1024" y="290" width="240" height="150" rx="6"/>
+  <text class="h" x="1038" y="312">The check seam</text>
+  <text class="s" x="1038" y="332">local: in-process function over the</text>
+  <text class="s" x="1038" y="346">same tuple vocabulary; one personal</text>
+  <text class="s" x="1038" y="360">tenant → every check is #owner, true</text>
+  <text class="s" x="1038" y="380">hosted: SpiceDB / OpenFGA replaces the</text>
+  <text class="s" x="1038" y="394">function behind the same signature;</text>
+  <text class="s" x="1038" y="408">zookies / caching / rewrite rules stay</text>
+  <text class="s" x="1038" y="422">the engine's concern, not the domain's</text>
+
+  <!-- orthogonality strip -->
+  <rect class="note" x="1024" y="470" width="856" height="130" rx="6"/>
+  <text class="h" x="1038" y="494">Why four layers stay separate</text>
+  <text class="t" x="1038" y="516">Disclosure ≠ access: a :public record inside the wrong boundary is still unreachable without a relation path; a #manager relation never reads :confidential.</text>
+  <text class="t" x="1038" y="536">Entitlement ≠ access: "may this tenant run a growth read" and "may this principal see this record" are different questions with different answers.</text>
+  <text class="t" x="1038" y="556">Authentication is a slot, not a dependency: the context shape does not change when tokens arrive.</text>
+  <text class="t" x="1038" y="576">Role facts live in tuples (§4) — no roles array rides the context.</text>
+  <text class="t" x="1038" y="594">The runtime's full question is decide() → a decision envelope: reasons, obligations, revision pins (§13.3).</text>
+
+  <!-- legend -->
+  <rect class="zone" x="20" y="646" width="1880" height="90" rx="6"/>
+  <text class="zoneT" x="36" y="668">FLOW</text>
+  <line class="eB" x1="40" y1="692" x2="90" y2="692" marker-end="url(#aB)"/><text class="s" x="100" y="696">request / context propagation</text>
+  <line class="ok" x1="300" y1="692" x2="350" y2="692" marker-end="url(#aG)"/><text class="s" x="360" y="696">passes gate</text>
+  <line class="bad" x1="480" y1="692" x2="530" y2="692" marker-end="url(#aR)"/><text class="s" x="540" y="696">refused</text>
+  <text class="s" x="40" y="722" font-style="italic">Migration order (§9): M1 identifiers + context → M2 thread context, rename wire → M3 stamp ownership (ids adopted verbatim — hash landmine) → M4 kill derived identities → M5 relations + tests.</text>
+</svg>

--- a/docs/architecture/ariadne/diagrams/03-ownership-provenance.svg
+++ b/docs/architecture/ariadne/diagrams/03-ownership-provenance.svg
@@ -1,0 +1,205 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 960" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="aB" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#3a76b8"/></marker>
+    <marker id="aP" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#9673a6"/></marker>
+    <marker id="aO" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#d79b00"/></marker>
+    <style>
+      .band{fill:#1e5f96;} .bandT{fill:#fff;font-size:20px;font-weight:bold;} .bandS{fill:#cfe2f3;font-size:12px;}
+      .zone{fill:#fcfcfa;stroke:#b8b8b0;stroke-width:1.2;} .zoneT{fill:#1e5f96;font-size:13px;font-weight:bold;letter-spacing:.4px;}
+      .pt{fill:#d5e8d4;stroke:#82b366;stroke-width:1.5;} .ot{fill:#dae8fc;stroke:#6c8ebf;stroke-width:1.5;}
+      .rel{fill:#e1d5e7;stroke:#9673a6;stroke-width:1.5;} .rec{fill:#ffffff;stroke:#8a8a82;stroke-width:1;}
+      .ext{fill:#ffe6cc;stroke:#d79b00;stroke-width:1.5;} .dis{fill:#f8cecc;stroke:#b85450;stroke-width:1;}
+      .h{font-size:13px;font-weight:bold;fill:#232323;} .t{font-size:11.5px;fill:#333;} .s{font-size:10.5px;fill:#555;}
+      .m{font-family:Menlo,Consolas,monospace;font-size:10px;fill:#4a355c;}
+      .note{fill:#fffde7;stroke:#c8b900;stroke-width:1;}
+      .eB{stroke:#3a76b8;stroke-width:1.6;fill:none;} .eP{stroke:#9673a6;stroke-width:1.6;fill:none;}
+      .eO{stroke:#d79b00;stroke-width:1.6;fill:none;}
+      .own{font-size:10px;font-weight:bold;}
+    </style>
+  </defs>
+
+  <rect width="1920" height="960" fill="#ffffff"/>
+  <rect class="band" x="0" y="0" width="1920" height="44"/>
+  <text class="bandT" x="20" y="29">Tenancy, Ownership &amp; Access — 3. Ownership by Provenance</text>
+  <text class="bandS" x="1900" y="28" text-anchor="end">§6 · owner = a column stamped by the creating context · a record's type NEVER implies its owner kind</text>
+
+  <!-- zones -->
+  <rect class="zone" x="20" y="62" width="360" height="700" rx="6"/>
+  <text class="zoneT" x="36" y="84">INTAKE CHANNELS</text>
+  <rect class="zone" x="400" y="62" width="330" height="700" rx="6"/>
+  <text class="zoneT" x="416" y="84">SUBSTRATE — artifacts · evidence</text>
+  <rect class="zone" x="830" y="62" width="340" height="700" rx="6"/>
+  <text class="zoneT" x="846" y="84">DERIVED IDENTITY — claims · profile</text>
+  <rect class="zone" x="1190" y="62" width="710" height="700" rx="6"/>
+  <text class="zoneT" x="1206" y="84">PROJECTIONS &amp; SHARED ASSETS</text>
+
+  <!-- IP boundary -->
+  <line x1="790" y1="70" x2="790" y2="755" stroke="#b03030" stroke-width="3" stroke-dasharray="10 6"/>
+  <text x="783" y="420" font-size="13" font-weight="bold" fill="#b03030" transform="rotate(-90 783 420)">THE IP BOUNDARY — DERIVATION</text>
+
+  <!-- channels -->
+  <rect class="ot" x="44" y="104" width="312" height="120" rx="8"/>
+  <text class="h" x="58" y="128">Org-bound connectors</text>
+  <text class="s" x="58" y="146">Jira · git · review docs · Teams/Slack — the</text>
+  <text class="s" x="58" y="160">employer's channels carry the employer's IP claim</text>
+  <rect class="rec" x="58" y="172" width="180" height="22" rx="11" fill="#dae8fc"/><text class="own" x="148" y="187" text-anchor="middle" fill="#274b73">owner: tenant:acme (org)</text>
+  <rect class="dis" x="248" y="172" width="94" height="22" rx="11"/><text class="s" x="295" y="187" text-anchor="middle">:confidential</text>
+  <text class="s" x="58" y="212" font-style="italic">connector bindings are org-owned assets</text>
+
+  <rect class="pt" x="44" y="244" width="312" height="110" rx="8"/>
+  <text class="h" x="58" y="268">Personal drop folder / self-import</text>
+  <text class="s" x="58" y="286">resume · portfolio · personal projects — no</text>
+  <text class="s" x="58" y="300">employer claim exists on this route</text>
+  <rect class="rec" x="58" y="314" width="196" height="22" rx="11" fill="#d5e8d4"/><text class="own" x="156" y="329" text-anchor="middle" fill="#3a6a34">owner: tenant:chris (personal)</text>
+
+  <rect class="ext" x="44" y="374" width="312" height="120" rx="8"/>
+  <text class="h" x="58" y="398">Licensed feed</text>
+  <text class="s" x="58" y="416">e.g. market data (EODHD pattern) — custodian</text>
+  <text class="s" x="58" y="430">owns the manifest; the PAYLOAD rights are the licensor's</text>
+  <rect class="rec" x="58" y="444" width="150" height="22" rx="11" fill="#d5e8d4"/><text class="own" x="133" y="459" text-anchor="middle" fill="#3a6a34">custodian: intake tenant</text>
+  <rect class="dis" x="218" y="444" width="124" height="22" rx="11"/><text class="s" x="280" y="459" text-anchor="middle">rights: licensed [TTL]</text>
+  <text class="s" x="58" y="482" font-style="italic">access routes through license relation → diagram 5</text>
+
+  <rect class="ext" x="44" y="514" width="312" height="120" rx="8"/>
+  <text class="h" x="58" y="538">Open-web fetch</text>
+  <text class="s" x="58" y="556">scraped pages — public is NOT public domain;</text>
+  <text class="s" x="58" y="570">copyright defaults on (Berne)</text>
+  <rect class="dis" x="58" y="584" width="172" height="22" rx="11"/><text class="s" x="144" y="599" text-anchor="middle">rights: third-party-unknown</text>
+  <text class="s" x="58" y="622" font-style="italic">ephemeral use · upgrade = recorded human determination</text>
+
+  <rect class="note" x="44" y="662" width="312" height="84" rx="6"/>
+  <text class="h" x="58" y="684">Provenance rule</text>
+  <text class="t" x="58" y="704">Substrate takes the intake channel's tenant. No</text>
+  <text class="t" x="58" y="720">per-record adjudication on the normal path —</text>
+  <text class="t" x="58" y="736">corrections are privileged and audited (§6).</text>
+
+  <!-- substrate -->
+  <rect class="ot" x="424" y="104" width="282" height="150" rx="8"/>
+  <text class="h" x="438" y="128">org-owned substrate</text>
+  <rect class="rec" x="438" y="140" width="254" height="26" rx="4"/><text class="t" x="448" y="157">artifact: sprint retro doc</text>
+  <rect class="rec" x="438" y="172" width="254" height="26" rx="4"/><text class="t" x="448" y="189">evidence: PR history extract</text>
+  <rect class="dis" x="438" y="206" width="94" height="20" rx="10"/><text class="s" x="485" y="220" text-anchor="middle">:confidential</text>
+  <text class="s" x="544" y="221">employer keeps these on exit</text>
+
+  <rect class="pt" x="424" y="286" width="282" height="150" rx="8"/>
+  <text class="h" x="438" y="310">personal-owned substrate</text>
+  <rect class="rec" x="438" y="322" width="254" height="26" rx="4"/><text class="t" x="448" y="339">artifact: resume.pdf</text>
+  <rect class="rec" x="438" y="354" width="254" height="26" rx="4"/><text class="t" x="448" y="371">evidence: side-project repo</text>
+  <rect class="dis" x="438" y="388" width="74" height="20" rx="10"/><text class="s" x="475" y="402" text-anchor="middle">:private</text>
+
+  <rect class="note" x="424" y="470" width="282" height="130" rx="6"/>
+  <text class="h" x="438" y="492">Unowned world-state: the bigger risk</text>
+  <text class="t" x="438" y="512">Shared corpora, catalogs, event logs, license</text>
+  <text class="t" x="438" y="528">state — install-scoped with NO owner at all.</text>
+  <text class="t" x="438" y="546">Migration must ADD ownership to these, not</text>
+  <text class="t" x="438" y="562">merely re-scope what already had a key.</text>
+  <text class="t" x="438" y="582">(observed: jobs table, rubric catalog, events)</text>
+
+  <rect class="note" x="424" y="624" width="282" height="122" rx="6"/>
+  <text class="h" x="438" y="646">Identity landmine</text>
+  <text class="m" x="438" y="666">artifact-id = sha256(owner-id</text>
+  <text class="m" x="438" y="680">              + source-path)</text>
+  <text class="t" x="438" y="700">content addresses can embed the id string:</text>
+  <text class="t" x="438" y="716">adopt existing ids VERBATIM at migration —</text>
+  <text class="t" x="438" y="732">rename = silent re-key of the whole store.</text>
+
+  <!-- derived -->
+  <rect class="pt" x="854" y="104" width="292" height="200" rx="8"/>
+  <text class="h" x="868" y="128">claims + profile</text>
+  <rect class="rec" x="868" y="140" width="264" height="26" rx="4"/><text class="t" x="878" y="157">claim: "led multi-region migration"</text>
+  <rect class="dis" x="868" y="174" width="150" height="20" rx="10"/><text class="s" x="943" y="188" text-anchor="middle">:confidential (inherited)</text>
+  <rect class="rec" x="868" y="204" width="264" height="26" rx="4"/><text class="t" x="878" y="221">profile: synthesized professional identity</text>
+  <rect class="rec" x="868" y="240" width="264" height="22" rx="11" fill="#d5e8d4"/><text class="own" x="1000" y="255" text-anchor="middle" fill="#3a6a34">owner: the subject's personal tenant — ALWAYS</text>
+  <text class="s" x="868" y="284" font-style="italic">regardless of source provenance (the resume norm:</text>
+  <text class="s" x="868" y="298" font-style="italic">the experience is the person's; the documents aren't)</text>
+
+  <rect class="note" x="854" y="330" width="292" height="140" rx="6"/>
+  <text class="h" x="868" y="352">Clause inheritance (§13.1)</text>
+  <text class="t" x="868" y="374">Derived records carry EVERY source clause</text>
+  <text class="t" x="868" y="390">(union); a clause is removed only by its</text>
+  <text class="t" x="868" y="410">authority's declared policy transformation,</text>
+  <text class="t" x="868" y="426">run by a trusted capability version. Ownership</text>
+  <text class="t" x="868" y="442">transfers at derivation; clauses do not.</text>
+
+  <rect class="note" x="854" y="494" width="292" height="120" rx="6"/>
+  <text class="h" x="868" y="516">Rights inheritance (licensed sources)</text>
+  <text class="t" x="868" y="538">Term-driven, not automatic: the license's</text>
+  <text class="t" x="868" y="554">derivation clause decides. EODHD pattern:</text>
+  <text class="t" x="868" y="572">raw series → licensed [TTL] · derived</text>
+  <text class="t" x="868" y="588">analytics → owned. No terms? third-party.</text>
+
+  <rect class="note" x="854" y="640" width="292" height="106" rx="6"/>
+  <text class="h" x="868" y="662">On offboarding</text>
+  <text class="t" x="868" y="684">The employer keeps (and re-closes) its</text>
+  <text class="t" x="868" y="700">documents; the person keeps the derived</text>
+  <text class="t" x="868" y="716">identity — still carrying inherited gates.</text>
+  <text class="t" x="868" y="732">Neither side keeps the other's property.</text>
+
+  <!-- projections -->
+  <rect class="pt" x="1214" y="104" width="320" height="140" rx="8"/>
+  <text class="h" x="1228" y="128">Self-serve projections</text>
+  <rect class="rec" x="1228" y="140" width="292" height="26" rx="4"/><text class="t" x="1238" y="157">fit report · growth read · eval run · story</text>
+  <rect class="rec" x="1228" y="176" width="228" height="22" rx="11" fill="#d5e8d4"/><text class="own" x="1342" y="191" text-anchor="middle" fill="#3a6a34">owner: the subject's personal tenant</text>
+  <text class="s" x="1228" y="222" font-style="italic">run for oneself, owned by oneself</text>
+
+  <rect class="pt" x="1214" y="272" width="320" height="220" rx="8"/>
+  <text class="h" x="1228" y="296">Commissioned projections</text>
+  <rect class="rec" x="1228" y="308" width="292" height="26" rx="4"/><text class="t" x="1238" y="325">review run under acme's cycle</text>
+  <rect class="rec" x="1228" y="344" width="252" height="22" rx="11" fill="#d5e8d4"/><text class="own" x="1354" y="359" text-anchor="middle" fill="#3a6a34">owner: tenant:chris (subject) — the DEFAULT</text>
+  <text class="s" x="1228" y="386" font-weight="bold">commissioning tenant gets relations, not ownership:</text>
+  <rect class="rel" x="1228" y="396" width="292" height="24" rx="5"/><text class="m" x="1238" y="412">review:V#commissioner@tenant:acme</text>
+  <rect class="rel" x="1228" y="426" width="292" height="24" rx="5"/><text class="m" x="1238" y="442">review:V#viewer@tenant:acme</text>
+  <text class="m" x="1228" y="470">review:V#engagement@engagement:chris-acme</text>
+  <text class="s" x="1228" y="484" font-style="italic">visibility granted, property kept — bounded by the engagement</text>
+
+  <rect class="dis" x="1214" y="516" width="320" height="96" rx="8"/>
+  <text class="h" x="1228" y="540">Exception: official-record policy flip</text>
+  <text class="t" x="1228" y="562">HR-integrated deployments may org-own</text>
+  <text class="t" x="1228" y="578">commissioned reviews — an explicit, NAMED</text>
+  <text class="t" x="1228" y="594">org-tenant policy set at onboarding. Its cost to</text>
+  <text class="t" x="1228" y="608">employees is visible by design: out of the takeaway.</text>
+
+  <!-- lenses -->
+  <rect class="rec" x="1560" y="104" width="316" height="240" rx="8"/>
+  <text class="h" x="1574" y="128">Shared assets — lenses</text>
+  <text class="s" x="1574" y="146">JD lens · growth rubric / CSP · templates · catalogs</text>
+  <rect class="rec" x="1574" y="160" width="288" height="22" rx="11" fill="#fffde7" stroke="#c8b900"/><text class="own" x="1718" y="175" text-anchor="middle" fill="#6a5a10">owner: the IMPORTING tenant — whichever kind</text>
+  <text class="s" x="1574" y="204" font-weight="bold">the same record type, two legitimate owners:</text>
+  <rect class="ot" x="1574" y="216" width="288" height="34" rx="6"/>
+  <text class="t" x="1586" y="230">corporate onboarding imports the CSP</text>
+  <text class="s" x="1586" y="244">→ org-owned, shared via #viewer userset</text>
+  <rect class="pt" x="1574" y="258" width="288" height="34" rx="6"/>
+  <text class="t" x="1586" y="272">B2C user imports the same document</text>
+  <text class="s" x="1586" y="286">→ personal-owned; no org exists to own it</text>
+  <text class="s" x="1574" y="318" font-style="italic">ownership and person-keying are different axes:</text>
+  <text class="s" x="1574" y="332" font-style="italic">a rubric carries no person fields either way</text>
+
+  <!-- defaults rail -->
+  <rect class="note" x="1214" y="640" width="662" height="106" rx="6"/>
+  <text class="h" x="1228" y="662">Ownership defaults — one line each</text>
+  <text class="t" x="1228" y="684">intake substrate → the channel's tenant · derived identity → the person, always · self-serve projections → the person</text>
+  <text class="t" x="1228" y="702">shared assets → the importing tenant · commissioned projections → the person + commissioner relations (flip = named org policy)</text>
+  <text class="t" x="1228" y="726" font-style="italic">The creating context decides; the owner is a COLUMN on the record, not a rule per type.</text>
+
+  <!-- flow arrows -->
+  <path class="eB" d="M356,164 C390,164 390,175 422,178" marker-end="url(#aB)"/>
+  <path class="eB" d="M356,300 C390,300 390,350 422,355" marker-end="url(#aB)"/>
+  <path class="eO" d="M356,434 C395,434 480,452 560,438" marker-end="url(#aO)" stroke-dasharray="5 3"/>
+  <text class="s" x="380" y="456" fill="#a06a00">payload custody · rights ride separately</text>
+  <path class="eB" d="M706,180 C770,180 770,200 852,200" marker-end="url(#aB)"/>
+  <path class="eB" d="M706,360 C770,360 770,230 852,225" marker-end="url(#aB)"/>
+  <text class="s" x="742" y="160" fill="#3a76b8">synthesis</text>
+  <path class="eB" d="M1146,200 C1180,200 1180,170 1212,170" marker-end="url(#aB)"/>
+  <path class="eB" d="M1146,220 C1180,220 1180,340 1212,345" marker-end="url(#aB)"/>
+  <text class="s" x="1176" y="136" fill="#3a76b8" text-anchor="middle">projected</text>
+  <text class="s" x="1176" y="148" fill="#3a76b8" text-anchor="middle">via lenses</text>
+  <path class="eP" d="M1534,408 C1548,408 1552,300 1560,240" marker-end="url(#aP)" stroke-dasharray="5 3"/>
+
+  <!-- legend -->
+  <rect class="zone" x="20" y="782" width="1880" height="80" rx="6"/>
+  <text class="zoneT" x="36" y="804">READING</text>
+  <line class="eB" x1="40" y1="828" x2="90" y2="828" marker-end="url(#aB)"/><text class="s" x="100" y="832">data flow (intake → substrate → derivation → projection)</text>
+  <line class="eP" x1="440" y1="828" x2="490" y2="828" marker-end="url(#aP)"/><text class="s" x="500" y="832">relation granted instead of ownership</text>
+  <line class="eO" x1="760" y1="828" x2="810" y2="828" marker-end="url(#aO)" stroke-dasharray="5 3"/><text class="s" x="820" y="832">licensed payload — rights ride separately (diagram 5)</text>
+  <text class="s" x="1220" y="832" font-style="italic">Bold dashed red line = the derivation boundary where ownership changes hands but restrictions do not.</text>
+</svg>

--- a/docs/architecture/ariadne/diagrams/04-agent-tool-gates.svg
+++ b/docs/architecture/ariadne/diagrams/04-agent-tool-gates.svg
@@ -1,0 +1,244 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1120" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="aB" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#3a76b8"/></marker>
+    <marker id="aP" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#9673a6"/></marker>
+    <marker id="aG" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#4a9a4a"/></marker>
+    <marker id="aO" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#d79b00"/></marker>
+    <marker id="aR" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#c0392b"/></marker>
+    <style>
+      .band{fill:#1e5f96;} .bandT{fill:#fff;font-size:20px;font-weight:bold;} .bandS{fill:#cfe2f3;font-size:12px;}
+      .zone{fill:#fcfcfa;stroke:#b8b8b0;stroke-width:1.2;} .zoneT{fill:#1e5f96;font-size:13px;font-weight:bold;letter-spacing:.4px;}
+      .pt{fill:#d5e8d4;stroke:#82b366;stroke-width:1.5;} .ot{fill:#dae8fc;stroke:#6c8ebf;stroke-width:1.5;}
+      .pr{fill:#fff2cc;stroke:#d6b656;stroke-width:1.5;} .ag{fill:#fff2cc;stroke:#d6b656;stroke-width:1.5;stroke-dasharray:5 3;}
+      .rel{fill:#e1d5e7;stroke:#9673a6;stroke-width:1.5;} .rec{fill:#ffffff;stroke:#8a8a82;stroke-width:1;}
+      .ext{fill:#ffe6cc;stroke:#d79b00;stroke-width:1.5;} .dis{fill:#f8cecc;stroke:#b85450;stroke-width:1;}
+      .h{font-size:13px;font-weight:bold;fill:#232323;} .t{font-size:11.5px;fill:#333;} .s{font-size:10.5px;fill:#555;}
+      .m{font-family:Menlo,Consolas,monospace;font-size:10px;fill:#4a355c;} .mS{font-family:Menlo,Consolas,monospace;font-size:9.5px;fill:#4a355c;}
+      .note{fill:#fffde7;stroke:#c8b900;stroke-width:1;}
+      .eB{stroke:#3a76b8;stroke-width:1.6;fill:none;} .eP{stroke:#9673a6;stroke-width:1.6;fill:none;}
+      .ok{stroke:#4a9a4a;stroke-width:1.8;fill:none;} .eO{stroke:#d79b00;stroke-width:1.8;fill:none;}
+      .bad{stroke:#c0392b;stroke-width:1.6;fill:none;}
+      .q{font-size:11px;font-weight:bold;fill:#1e5f96;}
+    </style>
+  </defs>
+
+  <rect width="1920" height="1120" fill="#ffffff"/>
+  <rect class="band" x="0" y="0" width="1920" height="44"/>
+  <text class="bandT" x="20" y="29">Tenancy, Ownership &amp; Access — 4. Agent Orchestration: Transacted Effects</text>
+  <text class="bandS" x="1900" y="28" text-anchor="end">§11, §13 · models propose; deterministic authority, information-flow, and effect-control systems decide and execute</text>
+
+  <!-- zones -->
+  <rect class="zone" x="20" y="62" width="440" height="940" rx="6"/>
+  <text class="zoneT" x="36" y="84">DELEGATION — authority lives outside the model</text>
+  <rect class="zone" x="480" y="62" width="850" height="940" rx="6"/>
+  <text class="zoneT" x="496" y="84">TRANSACTED INVOCATION — propose → decide → commit → reconcile</text>
+  <rect class="zone" x="1350" y="62" width="550" height="940" rx="6"/>
+  <text class="zoneT" x="1366" y="84">RELAXATION &amp; SCOPED GRANTS — the human side</text>
+
+  <!-- DELEGATION -->
+  <rect class="pr" x="44" y="104" width="392" height="60" rx="8"/>
+  <text class="h" x="58" y="128">principal:chris (human)</text>
+  <text class="s" x="58" y="146">delegates — is never impersonated by the agent</text>
+
+  <rect class="rel" x="44" y="180" width="392" height="150" rx="8"/>
+  <text class="h" x="58" y="204">delegation:D — a first-class grant object</text>
+  <text class="mS" x="58" y="224">delegation:D#grantor@principal:chris</text>
+  <text class="mS" x="58" y="240">delegation:D#grantee@principal:agent-a</text>
+  <text class="mS" x="58" y="256">delegation:D#basis@engagement:chris-acme</text>
+  <text class="mS" x="58" y="272">run:R#delegation@delegation:D</text>
+  <text class="s" x="58" y="292">record: scope · purpose · argument constraints ·</text>
+  <text class="s" x="58" y="306">allowed capability versions · :delegable? · TTL ·</text>
+  <text class="s" x="58" y="320">policy version · immutable GENERATION (lineage target)</text>
+
+  <rect class="ag" x="44" y="348" width="392" height="76" rx="8"/>
+  <text class="h" x="58" y="372">principal:agent-a (instance)</text>
+  <text class="s" x="58" y="390">tenant-less · owns nothing · expiring · execution</text>
+  <text class="s" x="58" y="404">artifacts → launching tenant; domain outputs → §6</text>
+
+  <rect class="ag" x="44" y="440" width="392" height="86" rx="8"/>
+  <text class="h" x="58" y="464">principal:agent-a.1 (child)</text>
+  <text class="s" x="58" y="482" font-weight="bold">delegation needs :delegable? — a separate authority;</text>
+  <text class="s" x="58" y="496">child constraints fit within the parent's DELEGABLE</text>
+  <text class="s" x="58" y="510">constraints. Monotone through orchestration depth.</text>
+  <path class="eP" d="M240,164 L240,178" marker-end="url(#aP)"/>
+  <path class="eP" d="M240,330 L240,346" marker-end="url(#aP)"/>
+  <path class="eP" d="M240,424 L240,438" marker-end="url(#aP)"/>
+
+  <rect class="note" x="44" y="548" width="392" height="112" rx="6"/>
+  <text class="h" x="58" y="572">The injection argument</text>
+  <text class="t" x="58" y="594">Injected text can talk the model into WANTING anything.</text>
+  <text class="t" x="58" y="610">Authority lives in grant objects the injected text cannot</text>
+  <text class="t" x="58" y="626">write. Blast radius of a rogue agent = its grants, and</text>
+  <text class="t" x="58" y="642">the model classifies nothing (destination, purpose, effect).</text>
+
+  <rect class="note" x="44" y="676" width="392" height="104" rx="6"/>
+  <text class="h" x="58" y="700">Why not agent-as-tenant?</text>
+  <text class="t" x="58" y="722">Tenants exist to own; an agent must own nothing.</text>
+  <text class="t" x="58" y="738">A tenant would let records land as the property of a</text>
+  <text class="t" x="58" y="754">process — decommission becomes data migration:</text>
+  <text class="t" x="58" y="770">the containment trap, rearranged.</text>
+
+  <rect class="note" x="44" y="796" width="392" height="90" rx="6"/>
+  <text class="h" x="58" y="820">Sandboxing ≠ this</text>
+  <text class="t" x="58" y="842">Sandbox bounds the process; grants bound authority;</text>
+  <text class="t" x="58" y="858">clauses bound egress. Only the last two survive hosted</text>
+  <text class="t" x="58" y="874">compute, new tools, or spawned children.</text>
+
+  <rect class="note" x="44" y="902" width="392" height="86" rx="6"/>
+  <text class="h" x="58" y="926">Revocation (§13.5)</text>
+  <text class="t" x="58" y="948">Cutting D (or its basis) is authoritative immediately;</text>
+  <text class="t" x="58" y="964">the commit worker completes it — freshness recheck,</text>
+  <text class="t" x="58" y="980">lease fencing, stale-generation results rejected.</text>
+
+  <!-- PIPELINE -->
+  <rect class="rec" x="504" y="104" width="380" height="88" rx="8"/>
+  <text class="h" x="518" y="128">1 · agent/model PROPOSAL → canonical transaction</text>
+  <text class="s" x="518" y="148">capability version · binding · canonical arguments ·</text>
+  <text class="s" x="518" y="162">labeled input refs · destination · expected effect</text>
+  <text class="s" x="518" y="180" font-style="italic">trusted resolvers classify destination/effect — never the model</text>
+
+  <path class="eB" d="M694,192 L694,214" marker-end="url(#aB)"/>
+
+  <rect class="ext" x="504" y="216" width="380" height="240" rx="8"/>
+  <text class="h" x="518" y="240">2 · POLICY DECISION — decide(), three planes</text>
+  <rect class="rel" x="518" y="252" width="352" height="56" rx="6"/>
+  <text class="t" x="530" y="270" font-weight="bold">authority</text>
+  <text class="s" x="530" y="286">capability grant + object access + grant lineage (basis valid?)</text>
+  <rect class="dis" x="518" y="314" width="352" height="56" rx="6"/>
+  <text class="t" x="530" y="332" font-weight="bold">information flow / processing</text>
+  <text class="s" x="530" y="348">every input clause × purpose (basis-rooted) × destination</text>
+  <rect class="rec" x="518" y="376" width="352" height="56" rx="6"/>
+  <text class="t" x="530" y="394" font-weight="bold">effect</text>
+  <text class="s" x="530" y="410">impact class within grant · argument constraints</text>
+  <text class="s" x="518" y="448" font-style="italic">object access is part of authority — not a separate peer gate</text>
+
+  <path class="eB" d="M694,456 L694,478" marker-end="url(#aB)"/>
+
+  <rect class="rel" x="504" y="480" width="380" height="104" rx="8"/>
+  <text class="h" x="518" y="504">3 · DECISION ENVELOPE (not a boolean)</text>
+  <text class="s" x="518" y="524">allowed? · reason codes · obligations (redact field, zero</text>
+  <text class="s" x="518" y="538">retention) · required approvals · relation revision · policy</text>
+  <text class="s" x="518" y="552">digest · grant generations · effect-scope digest · validity</text>
+  <text class="s" x="518" y="572" font-style="italic">rides the approval hash, commit recheck, receipt, audit</text>
+
+  <path class="bad" d="M884,532 L920,532" marker-end="url(#aR)"/>
+  <rect class="dis" x="924" y="510" width="150" height="44" rx="6"/>
+  <text class="s" x="936" y="528" font-weight="bold">refused</text>
+  <text class="s" x="936" y="542">reason codes say why</text>
+
+  <path class="eO" d="M884,500 C1150,500 1200,150 1348,150" marker-end="url(#aO)"/>
+  <text class="s" x="1120" y="480" fill="#a06a00">approvals required → relaxation workflow (right)</text>
+
+  <path class="ok" d="M694,584 L694,606" marker-end="url(#aG)"/>
+
+  <rect class="pt" x="504" y="608" width="380" height="110" rx="8"/>
+  <text class="h" x="518" y="632">4 · COMMIT WORKER (the only committer)</text>
+  <text class="s" x="518" y="652">lease + fencing generation in the commit condition ·</text>
+  <text class="s" x="518" y="666">freshness recheck ≥ every relevant revocation/policy</text>
+  <text class="s" x="518" y="680">watermark (never the run-start snapshot) · idempotency</text>
+  <text class="s" x="518" y="694">key · approval hash still matches the exact transaction</text>
+  <text class="s" x="518" y="712" font-style="italic">unknown-outcome is a first-class state</text>
+
+  <path class="eB" d="M694,718 L694,740" marker-end="url(#aB)"/>
+
+  <rect class="rec" x="504" y="742" width="380" height="72" rx="8"/>
+  <text class="h" x="518" y="766">5 · RECONCILE → RECEIPT → AUDIT / EVAL</text>
+  <text class="s" x="518" y="786">what crossed the boundary is compensated and audited,</text>
+  <text class="s" x="518" y="800">never retroactively de-authorized (three revocations, §13.5)</text>
+
+  <!-- model routing card -->
+  <rect class="ot" x="904" y="104" width="402" height="200" rx="8"/>
+  <text class="h" x="918" y="128">Model calls take the SAME path</text>
+  <text class="s" x="918" y="148">a model endpoint is a capability binding: retention,</text>
+  <text class="s" x="918" y="162">training policy, residency, trust boundary, quality, cost</text>
+  <text class="t" x="918" y="186" font-weight="bold">routing = optimizer over policy-cleared bindings:</text>
+  <text class="s" x="918" y="206">1 discover capability-compatible bindings</text>
+  <text class="s" x="918" y="220">2 validate grant + lineage · 3 clauses × purpose ×</text>
+  <text class="s" x="918" y="234">destination × effect · 4 drop forbidden (residency,</text>
+  <text class="s" x="918" y="248">retention, training, rights) · 5 entitlement/budget/limits</text>
+  <text class="s" x="918" y="262">6 rank survivors (quality, latency, cost, health) · 7 invoke</text>
+  <text class="s" x="918" y="282" font-weight="bold">fallback re-runs eligibility, not just ranking</text>
+
+  <rect class="note" x="904" y="326" width="402" height="130" rx="6"/>
+  <text class="h" x="918" y="350">Scoped taint on the shared blackboard (§13.4)</text>
+  <text class="s" x="918" y="370">artifact label = its ACTUAL inputs · agent context =</text>
+  <text class="s" x="918" y="384">what that agent actually read · run summary = audit</text>
+  <text class="s" x="918" y="398">upper bound · the blackboard is a container, NOT a</text>
+  <text class="s" x="918" y="412">flow between everything on it</text>
+  <text class="s" x="918" y="432" font-style="italic">subtask eligibility from the subtask's inputs — A's</text>
+  <text class="s" x="918" y="446" font-style="italic">confidential read does not taint B's public branch</text>
+
+  <rect class="note" x="904" y="608" width="402" height="106" rx="6"/>
+  <text class="h" x="918" y="632">Tool = channel; mailbox = domain (§11.6)</text>
+  <text class="s" x="918" y="652">reading mail is intake — provenance-owned, store-checked;</text>
+  <text class="s" x="918" y="666">sending is egress — trusted resolver derives the</text>
+  <text class="s" x="918" y="680">destination from the recipient argument, per invocation</text>
+  <text class="s" x="918" y="700" font-style="italic">argument constraints live on the grant and binding</text>
+
+  <rect class="note" x="904" y="742" width="402" height="150" rx="6"/>
+  <text class="h" x="918" y="766">Known limits — conceded up front</text>
+  <text class="s" x="918" y="786">label creep: clause union ratchets → authority-defined</text>
+  <text class="s" x="918" y="800">transforms + granular payloads + normalization/digests</text>
+  <text class="s" x="918" y="818">aggregation: jointly-sensitive publics pass the union —</text>
+  <text class="s" x="918" y="832">aggregates may get clauses at creation; detection o.o.s.</text>
+  <text class="s" x="918" y="850">irreversibility: a sent prompt/email/payment cannot be</text>
+  <text class="s" x="918" y="864">un-sent — reconciliation, compensation, audit (§13.5)</text>
+
+  <!-- RELAXATION ZONE -->
+  <rect class="rec" x="1374" y="110" width="502" height="80" rx="8"/>
+  <text class="h" x="1388" y="134">relaxation request (agent may ask — never approve)</text>
+  <text class="t" x="1388" y="156">carries the rendered payload + its clauses + the destination;</text>
+  <text class="t" x="1388" y="172">out-of-band — not a tool the agent calls with its own arguments</text>
+
+  <rect class="dis" x="1374" y="204" width="502" height="88" rx="8"/>
+  <text class="h" x="1388" y="228">an approval request is itself a disclosure</text>
+  <text class="t" x="1388" y="250">the approver must be entitled to see the payload; otherwise a</text>
+  <text class="t" x="1388" y="266">policy-safe redacted preview, an artifact reference, or a</text>
+  <text class="t" x="1388" y="282">differently-authorized approver. No laundering via the queue.</text>
+
+  <rect class="ot" x="1374" y="306" width="502" height="96" rx="8"/>
+  <text class="h" x="1388" y="330">per-clause relaxation mode — machine-readable (§13.1)</text>
+  <text class="t" x="1388" y="352">approval-workflow · quorum · proof-of-contract · authority-</text>
+  <text class="t" x="1388" y="368">defined policy transform · automatic embargo release · NONE</text>
+  <text class="s" x="1388" y="388" font-style="italic">every unsatisfied clause's authority must authorize — not just the strictest</text>
+
+  <rect class="ext" x="1374" y="426" width="502" height="168" rx="8"/>
+  <text class="h" x="1388" y="450">approval mints a SCOPED grant — the fatigue fix</text>
+  <rect class="rec" x="1388" y="462" width="112" height="52" rx="6"/><text class="t" x="1398" y="480" font-weight="bold">once</text><text class="s" x="1398" y="496">this invocation</text><text class="s" x="1398" y="508">(default)</text>
+  <rect class="rec" x="1510" y="462" width="112" height="52" rx="6"/><text class="t" x="1520" y="480" font-weight="bold">session</text><text class="s" x="1520" y="496">dies with the</text><text class="s" x="1520" y="508">taint it judged</text>
+  <rect class="rec" x="1632" y="462" width="112" height="52" rx="6"/><text class="t" x="1642" y="480" font-weight="bold">context</text><text class="s" x="1642" y="496">repo / cycle ·</text><text class="s" x="1642" y="508">time-boxed</text>
+  <rect class="dis" x="1754" y="462" width="108" height="52" rx="6"/><text class="t" x="1764" y="480" font-weight="bold">permanent</text><text class="s" x="1764" y="496">= transform via</text><text class="s" x="1764" y="508">authority (§13.1)</text>
+  <rect class="rel" x="1388" y="526" width="474" height="26" rx="5"/>
+  <text class="mS" x="1398" y="543">class:review#flow[dest⊆related]@principal:agent-a {session:S, ttl:2h}</text>
+  <text class="s" x="1388" y="568">condition tuples in the same store as all authority — auditable,</text>
+  <text class="s" x="1388" y="582">revocable, expiring (PIM / JIT ≡ Myers–Liskov DLM)</text>
+
+  <rect class="note" x="1374" y="616" width="502" height="76" rx="6"/>
+  <text class="h" x="1388" y="640">Grants attach to FLOWS, not tools</text>
+  <text class="t" x="1388" y="660">(principal, record class, destination, scope) — granting the TOOL</text>
+  <text class="t" x="1388" y="676">reopens laundering. "Always allow this tool" = channel bypass.</text>
+
+  <rect class="note" x="1374" y="708" width="502" height="72" rx="6"/>
+  <text class="h" x="1388" y="732">Elevation never relabels</text>
+  <text class="t" x="1388" y="752">a flow exception attached to (payload, destination, invocation);</text>
+  <text class="t" x="1388" y="768">persistent relaxation = the clause authority's mechanism only.</text>
+
+  <rect class="note" x="1374" y="796" width="502" height="96" rx="6"/>
+  <text class="h" x="1388" y="820">Person-held vs credential-scoped roles (§4)</text>
+  <text class="t" x="1388" y="842">human roles bind to the person's TENANT (resolved through its</text>
+  <text class="t" x="1388" y="858">#controller relations — survives IdP/device change); direct</text>
+  <text class="t" x="1388" y="874">principal relations are for agents, service accounts, devices.</text>
+
+  <path class="ok" d="M1374,540 C1340,540 1330,560 1320,600 C1300,680 940,700 888,660" marker-end="url(#aG)" stroke-dasharray="6 3"/>
+  <text class="s" x="1100" y="576" fill="#4a9a4a" text-anchor="middle">minted grant re-enters the</text>
+  <text class="s" x="1100" y="590" fill="#4a9a4a" text-anchor="middle">decision for its scope/TTL</text>
+
+  <!-- legend -->
+  <rect class="zone" x="20" y="1018" width="1880" height="72" rx="6"/>
+  <text class="zoneT" x="36" y="1040">FLOW</text>
+  <line class="eP" x1="90" y1="1062" x2="140" y2="1062" marker-end="url(#aP)"/><text class="s" x="150" y="1066">delegation / relation</text>
+  <line class="eB" x1="300" y1="1062" x2="350" y2="1062" marker-end="url(#aB)"/><text class="s" x="360" y="1066">pipeline step</text>
+  <line class="ok" x1="480" y1="1062" x2="530" y2="1062" marker-end="url(#aG)"/><text class="s" x="540" y="1066">decision: proceed</text>
+  <line class="eO" x1="690" y1="1062" x2="740" y2="1062" marker-end="url(#aO)"/><text class="s" x="750" y="1066">approvals required → relaxation workflow</text>
+  <line class="bad" x1="1010" y1="1062" x2="1060" y2="1062" marker-end="url(#aR)"/><text class="s" x="1070" y="1066">refused (envelope carries reason codes)</text>
+</svg>

--- a/docs/architecture/ariadne/diagrams/05-revocation-rights.svg
+++ b/docs/architecture/ariadne/diagrams/05-revocation-rights.svg
@@ -1,0 +1,202 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1000" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="aB" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#3a76b8"/></marker>
+    <marker id="aP" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#9673a6"/></marker>
+    <marker id="aG" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#4a9a4a"/></marker>
+    <marker id="aR" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#c0392b"/></marker>
+    <style>
+      .band{fill:#1e5f96;} .bandT{fill:#fff;font-size:20px;font-weight:bold;} .bandS{fill:#cfe2f3;font-size:12px;}
+      .zone{fill:#fcfcfa;stroke:#b8b8b0;stroke-width:1.2;} .zoneT{fill:#1e5f96;font-size:13px;font-weight:bold;letter-spacing:.4px;}
+      .pt{fill:#d5e8d4;stroke:#82b366;stroke-width:1.5;} .ot{fill:#dae8fc;stroke:#6c8ebf;stroke-width:1.5;}
+      .rel{fill:#e1d5e7;stroke:#9673a6;stroke-width:1.5;} .rec{fill:#ffffff;stroke:#8a8a82;stroke-width:1;}
+      .ext{fill:#ffe6cc;stroke:#d79b00;stroke-width:1.5;} .dis{fill:#f8cecc;stroke:#b85450;stroke-width:1;}
+      .h{font-size:13px;font-weight:bold;fill:#232323;} .t{font-size:11.5px;fill:#333;} .s{font-size:10.5px;fill:#555;}
+      .m{font-family:Menlo,Consolas,monospace;font-size:10px;fill:#4a355c;} .mS{font-family:Menlo,Consolas,monospace;font-size:9.5px;fill:#4a355c;}
+      .note{fill:#fffde7;stroke:#c8b900;stroke-width:1;}
+      .eB{stroke:#3a76b8;stroke-width:1.6;fill:none;} .eP{stroke:#9673a6;stroke-width:1.6;fill:none;}
+      .ok{stroke:#4a9a4a;stroke-width:1.8;fill:none;} .bad{stroke:#c0392b;stroke-width:1.8;fill:none;}
+      .cut{stroke:#c0392b;stroke-width:2.4;}
+    </style>
+  </defs>
+
+  <rect width="1920" height="1000" fill="#ffffff"/>
+  <rect class="band" x="0" y="0" width="1920" height="44"/>
+  <text class="bandT" x="20" y="29">Tenancy, Ownership &amp; Access — 5. Revocation &amp; Third-Party Rights</text>
+  <text class="bandS" x="1900" y="28" text-anchor="end">§7, §12, §13.5 · one authoritative relation cut, completed by runtime enforcement · possession is not rights</text>
+
+  <!-- ZONE: three domains -->
+  <rect class="zone" x="20" y="62" width="1140" height="520" rx="6"/>
+  <text class="zoneT" x="36" y="84">ONE MECHANISM, THREE DOMAINS — one authoritative cut; runtime enforcement completes it; no data moves</text>
+
+  <!-- lane 1 employment -->
+  <text class="h" x="44" y="116">employee offboarding</text>
+  <rect class="rel" x="44" y="126" width="300" height="28" rx="5"/>
+  <text class="m" x="56" y="144">tenant:acme#employee@tenant:chris</text>
+  <line class="cut" x1="330" y1="120" x2="366" y2="160"/><line class="cut" x1="366" y1="120" x2="330" y2="160"/>
+  <path class="bad" d="M370,140 L420,140" marker-end="url(#aR)"/>
+  <rect class="rec" x="424" y="98" width="332" height="120" rx="8"/>
+  <text class="t" x="436" y="120">· acme's relations into tenant:chris — revoked</text>
+  <text class="t" x="436" y="138">· chris's access to acme-owned intake — revoked</text>
+  <text class="t" x="436" y="156">· tenant:chris + everything it owns — untouched</text>
+  <text class="t" x="436" y="174">· claims persist, still carrying inherited gates</text>
+  <text class="t" x="436" y="192">· path to personal = re-license, not migration</text>
+  <text class="s" x="436" y="210" font-style="italic">the employer keeps its documents; neither side keeps the other's property</text>
+
+  <!-- lane 2 agent -->
+  <text class="h" x="44" y="262">agent decommission</text>
+  <rect class="rel" x="44" y="272" width="300" height="28" rx="5"/>
+  <text class="mS" x="56" y="290">principal:chris#delegate@principal:agent-a</text>
+  <line class="cut" x1="330" y1="266" x2="366" y2="306"/><line class="cut" x1="366" y1="266" x2="330" y2="306"/>
+  <path class="bad" d="M370,286 L420,286" marker-end="url(#aR)"/>
+  <rect class="rec" x="424" y="244" width="332" height="104" rx="8"/>
+  <text class="t" x="436" y="266">· cut is authoritative; commit-time recheck completes it</text>
+  <text class="t" x="436" y="284">· execution artifacts → launching tenant; outputs → §6</text>
+  <text class="t" x="436" y="302">· audit trail survives: every act attributable</text>
+  <text class="t" x="436" y="320">· grant lineage: descendants die with their basis</text>
+  <text class="s" x="436" y="338" font-style="italic">the agent owned nothing, so nothing strands</text>
+
+  <!-- lane 3 license -->
+  <text class="h" x="44" y="392">license expiry / invalidation</text>
+  <rect class="rel" x="44" y="402" width="300" height="28" rx="5"/>
+  <text class="mS" x="56" y="420">license:eodhd#beneficiary@tenant:chris [TTL]</text>
+  <line class="cut" x1="330" y1="396" x2="366" y2="436"/><line class="cut" x1="366" y1="396" x2="330" y2="436"/>
+  <path class="bad" d="M370,416 L420,416" marker-end="url(#aR)"/>
+  <rect class="rec" x="424" y="374" width="332" height="120" rx="8"/>
+  <text class="t" x="436" y="396">· payload access severed at check time — one cut</text>
+  <text class="t" x="436" y="414">  reaches every record routed through the license</text>
+  <text class="t" x="436" y="432">· quarantine (grace / renewal) → purge per terms</text>
+  <text class="t" x="436" y="450">· manifest + fingerprint (the custodian's) survive</text>
+  <text class="t" x="436" y="468">· renewal re-fetches into the same identity</text>
+  <text class="s" x="436" y="486" font-style="italic">no re-stamping of a million rows — the graph route IS the switch</text>
+
+  <rect class="rec" x="44" y="510" width="712" height="58" rx="6"/>
+  <text class="h" x="58" y="532">runtime enforcement completes every cut (§13.5)</text>
+  <text class="mS" x="58" y="552">cut → new revision/watermark → queued work canceled → leases fenced → commits rechecked → stale results rejected</text>
+
+  <!-- unifier -->
+  <rect class="note" x="790" y="98" width="346" height="396" rx="8"/>
+  <text class="h" x="806" y="124">Why this repetition matters</text>
+  <text class="t" x="806" y="148">The licensor is a NON-RESIDENT tenant.</text>
+  <text class="t" x="806" y="166">The license is its employment tuple.</text>
+  <text class="t" x="806" y="184">Expiry is offboarding.</text>
+  <text class="t" x="806" y="212">Same shape, third time. One mechanism</text>
+  <text class="t" x="806" y="230">handles employee exit, agent kill-switch,</text>
+  <text class="t" x="806" y="248">and contract lapse — because ownership</text>
+  <text class="t" x="806" y="266">never crossed the boundary in the first</text>
+  <text class="t" x="806" y="284">place; only relations did.</text>
+  <text class="t" x="806" y="312" font-weight="bold">Entitlement gates compute, never data —</text>
+  <text class="t" x="806" y="330">no tension with license expiry: licensed</text>
+  <text class="t" x="806" y="348">payloads were never the tenant's property;</text>
+  <text class="t" x="806" y="366">the license was the only path to them.</text>
+  <text class="t" x="806" y="384">The path dying with the license is the</text>
+  <text class="t" x="806" y="402">invariant working.</text>
+  <text class="s" x="806" y="434" font-style="italic">Interview lead: three different revocation</text>
+  <text class="s" x="806" y="450" font-style="italic">problems, one mechanism, no data movement.</text>
+  <text class="s" x="806" y="466" font-style="italic">That convergence is the architecture's proof.</text>
+
+  <!-- ZONE: license routing -->
+  <rect class="zone" x="1180" y="62" width="720" height="520" rx="6"/>
+  <text class="zoneT" x="1196" y="84">LICENSE AS A RELATION OBJECT — §12</text>
+
+  <rect class="rec" x="1204" y="110" width="180" height="60" rx="8"/>
+  <text class="h" x="1216" y="134">record:R</text>
+  <text class="s" x="1216" y="152">licensed payload (raw series)</text>
+  <rect class="ext" x="1470" y="110" width="180" height="60" rx="8"/>
+  <text class="h" x="1482" y="134">license:eodhd</text>
+  <text class="s" x="1482" y="152">terms · TTL · derivation clause</text>
+  <rect class="pt" x="1716" y="110" width="160" height="60" rx="8"/>
+  <text class="h" x="1728" y="134">tenant:chris</text>
+  <text class="s" x="1728" y="152">custodian / beneficiary</text>
+  <path class="eP" d="M1384,140 L1468,140" marker-end="url(#aP)"/>
+  <text class="mS" x="1426" y="132" text-anchor="middle">#rights</text>
+  <path class="eP" d="M1650,140 L1714,140" marker-end="url(#aP)"/>
+  <text class="mS" x="1682" y="132" text-anchor="middle">#beneficiary</text>
+  <text class="s" x="1204" y="192" font-style="italic">readability routes THROUGH the license node — check(chris, read, R) traverses #rights → #beneficiary; expired TTL = no path</text>
+
+  <text class="h" x="1204" y="226">terms classes — UX projections over policy clauses (§13.1)</text>
+  <rect class="pt" x="1204" y="238" width="120" height="24" rx="12"/><text class="s" x="1264" y="254" text-anchor="middle">owned</text>
+  <rect class="ext" x="1334" y="238" width="150" height="24" rx="12"/><text class="s" x="1409" y="254" text-anchor="middle">licensed [TTL, terms]</text>
+  <rect class="rec" x="1494" y="238" width="140" height="24" rx="12"/><text class="s" x="1564" y="254" text-anchor="middle">public-domain (proven)</text>
+  <rect class="dis" x="1644" y="238" width="160" height="24" rx="12"/><text class="s" x="1724" y="254" text-anchor="middle">third-party-unknown</text>
+
+  <rect class="note" x="1204" y="284" width="672" height="90" rx="6"/>
+  <text class="h" x="1218" y="306">Derivation clause — term-driven, not automatic</text>
+  <text class="t" x="1218" y="328">EODHD pattern: raw series → licensed [TTL] · derived analytics → owned (yours).</text>
+  <text class="t" x="1218" y="346">Absent explicit terms: derived keeps the third-party label — the safe default.</text>
+  <text class="s" x="1218" y="364" font-style="italic">same rule as claims-over-employer-evidence: the governing agreement decides, machine-readably</text>
+
+  <rect class="note" x="1204" y="392" width="672" height="86" rx="6"/>
+  <text class="h" x="1218" y="414">Open-web intake — public ≠ public domain (Berne: copyright defaults on)</text>
+  <text class="t" x="1218" y="436">default: third-party-unknown + ephemeral use — transient task-scoped retention; derived claims OK</text>
+  <text class="t" x="1218" y="454">(facts aren't copyrightable); raw retention / redistribution / external egress refused by default.</text>
+  <text class="t" x="1218" y="472">Upgrades = recorded human determinations via the elevation machinery (diagram 4).</text>
+
+  <rect class="dis" x="1204" y="496" width="672" height="66" rx="6"/>
+  <text class="h" x="1218" y="518">The liability inversion</text>
+  <text class="t" x="1218" y="538">Frontier-lab class-action posture: no rights label at intake, retention by default, no record of any decision.</text>
+  <text class="t" x="1218" y="554">This model: conservative label by default; the risky position is a named human's audited determination.</text>
+
+  <!-- ZONE: takeaway -->
+  <rect class="zone" x="20" y="602" width="1880" height="310" rx="6"/>
+  <text class="zoneT" x="36" y="624">THE TAKEAWAY EXPORT — always available, hard policy, no off switch</text>
+
+  <rect class="pt" x="44" y="650" width="240" height="120" rx="8"/>
+  <text class="h" x="58" y="674">tenant:chris — all records</text>
+  <text class="s" x="58" y="694">evidence · claims · profile · projections</text>
+  <text class="s" x="58" y="710">+ org-channel intake (acme-owned)</text>
+  <text class="s" x="58" y="726">+ licensed payloads (eodhd rights)</text>
+  <text class="s" x="58" y="742">+ scraped raw pages (third-party)</text>
+
+  <path class="eB" d="M284,710 L336,710" marker-end="url(#aB)"/>
+  <rect class="ot" x="340" y="650" width="230" height="120" rx="8"/>
+  <text class="h" x="354" y="674">filter 1 — OWNERSHIP</text>
+  <text class="t" x="354" y="696">org-owned intake: excluded</text>
+  <text class="t" x="354" y="712">before disclosure even applies</text>
+  <text class="s" x="354" y="734" font-style="italic">employer-IP-clean</text>
+  <text class="s" x="354" y="748" font-style="italic">by construction</text>
+
+  <path class="eB" d="M570,710 L622,710" marker-end="url(#aB)"/>
+  <rect class="ext" x="626" y="650" width="230" height="120" rx="8"/>
+  <text class="h" x="640" y="674">filter 2 — RIGHTS</text>
+  <text class="t" x="640" y="696">licensed payloads: out</text>
+  <text class="t" x="640" y="712">manifests/pointers (yours): ride —</text>
+  <text class="t" x="640" y="728">re-fetch under your own license</text>
+  <text class="s" x="640" y="750" font-style="italic">licensor-clean, same construction</text>
+
+  <path class="eB" d="M856,710 L908,710" marker-end="url(#aB)"/>
+  <rect class="dis" x="912" y="650" width="230" height="120" rx="8"/>
+  <text class="h" x="926" y="674">filter 3 — EXPORTABILITY</text>
+  <text class="t" x="926" y="696">:never-export — stays</text>
+  <text class="t" x="926" y="712">:requires-user-unlock — prompts</text>
+  <text class="t" x="926" y="728">inherited gates travel WITH the</text>
+  <text class="t" x="926" y="744">records they gate</text>
+
+  <path class="ok" d="M1142,710 L1194,710" marker-end="url(#aG)"/>
+  <rect class="pt" x="1198" y="650" width="250" height="120" rx="8"/>
+  <text class="h" x="1212" y="674">the bundle — a SNAPSHOT</text>
+  <text class="t" x="1212" y="696">consistency token · data + policy + relation</text>
+  <text class="t" x="1212" y="712">versions · hashes · machine-readable</text>
+  <text class="t" x="1212" y="728">exclusion reasons · ids/provenance intact</text>
+  <text class="s" x="1212" y="750" font-style="italic">digital equivalent of taking your resume</text>
+
+  <path class="ok" d="M1448,710 L1500,710" marker-end="url(#aG)"/>
+  <rect class="rec" x="1504" y="650" width="230" height="120" rx="8"/>
+  <text class="h" x="1518" y="674">restore = tenant restore</text>
+  <text class="t" x="1518" y="696">fresh install imports records as-is;</text>
+  <text class="t" x="1518" y="712">not re-ingestion; owner-only</text>
+  <text class="t" x="1518" y="728">affordance</text>
+  <text class="s" x="1518" y="750" font-style="italic">the B2C conversion funnel</text>
+
+  <rect class="note" x="44" y="794" width="1690 " height="96" rx="6"/>
+  <text class="h" x="58" y="818">Hard policy — deliberately no configuration surface</text>
+  <text class="t" x="58" y="840">No org setting, policy pack, or deployment flag disables or narrows the takeaway — the switch's existence is what invites the procurement demand,</text>
+  <text class="t" x="58" y="858">and the bundle is employer- and licensor-clean by construction, so there is nothing of theirs to protect. Any commercial exception is a per-contract</text>
+  <text class="t" x="58" y="876">bespoke fork, priced as such. Available at ANY time — by offboarding day, the company laptop may already be gone. Also the GDPR export/erasure unit.</text>
+
+  <!-- legend -->
+  <rect class="zone" x="20" y="930" width="1880" height="52" rx="6"/>
+  <line class="cut" x1="44" y1="956" x2="64" y2="972"/><line class="cut" x1="64" y1="956" x2="44" y2="972"/><text class="s" x="76" y="968">relation deleted / TTL expired</text>
+  <line class="eP" x1="280" y1="964" x2="330" y2="964" marker-end="url(#aP)"/><text class="s" x="340" y="968">relation route (check traverses it)</text>
+  <line class="eB" x1="580" y1="964" x2="630" y2="964" marker-end="url(#aB)"/><text class="s" x="640" y="968">export pipeline</text>
+  <line class="ok" x1="800" y1="964" x2="850" y2="964" marker-end="url(#aG)"/><text class="s" x="860" y="968">survives every filter — the owner's property</text>
+</svg>

--- a/docs/architecture/ariadne/explainers/README.md
+++ b/docs/architecture/ariadne/explainers/README.md
@@ -1,0 +1,21 @@
+# Architecture explainers (ELI9)
+
+Plain-language companions to the Ariadne tenancy/policy architecture
+(`../tenancy-ownership-access.md`) and its diagram suite. One shared
+story-world (robots, doorkeepers, stickers, passes) with the
+miniforge factory story in the
+[miniforge-ai/miniforge](https://github.com/miniforge-ai/miniforge)
+repo under `docs/architecture/explainers/`.
+
+1. `tenancy-for-a-nine-year-old.md` (+ `eli9-*.svg`) — editable
+   markdown source for the tenancy story.
+2. `routing-for-a-nine-year-old.md` — editable markdown source for
+   the policy/routing story.
+3. `the-robot-helpers-and-the-sticker-rules.html`,
+   `your-house-their-clubhouse-and-the-passes.html` — the published
+   story pages (self-contained HTML with inline figures). CANONICAL
+   here; projected to `https://miniforge.ai/architectures/` by
+   `miniforge-ai/miniforge-website` (its sync-content workflow pulls
+   on `notify-website.yml` dispatch or daily cron). Edit here, never
+   on the website repo. When a story's markdown changes, update its
+   HTML in the same PR — the HTML is what ships.

--- a/docs/architecture/ariadne/explainers/eli9-1-slips.svg
+++ b/docs/architecture/ariadne/explainers/eli9-1-slips.svg
@@ -1,0 +1,74 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 520" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#3a76b8"/></marker>
+    <marker id="ar" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#c0392b"/></marker>
+  </defs>
+  <rect width="900" height="520" fill="#ffffff"/>
+  <text x="450" y="42" text-anchor="middle" font-size="24" font-weight="bold" fill="#1e5f96">Robots never open doors. Robots write slips.</text>
+
+  <!-- robot -->
+  <line x1="150" y1="120" x2="150" y2="102" stroke="#d6b656" stroke-width="3"/>
+  <circle cx="150" cy="96" r="7" fill="#d79b00"/>
+  <rect x="110" y="120" width="80" height="64" rx="14" fill="#fff2cc" stroke="#d6b656" stroke-width="2.5"/>
+  <circle cx="136" cy="146" r="7" fill="#232323"/>
+  <circle cx="164" cy="146" r="7" fill="#232323"/>
+  <path d="M134,166 Q150,176 166,166" stroke="#232323" stroke-width="2.5" fill="none"/>
+  <rect x="118" y="192" width="64" height="52" rx="10" fill="#fff2cc" stroke="#d6b656" stroke-width="2.5"/>
+  <text x="150" y="276" text-anchor="middle" font-size="16" font-weight="bold" fill="#8a6d1a">the robot</text>
+  <text x="150" y="296" text-anchor="middle" font-size="13" fill="#8a6d1a">very smart, very gullible</text>
+
+  <!-- whisper note -->
+  <path d="M60,120 Q40,150 62,178" stroke="#c0392b" stroke-width="2" fill="none" stroke-dasharray="5 4" marker-end="url(#ar)"/>
+  <text x="52" y="106" font-size="13" fill="#c0392b">someone whispers</text>
+  <text x="52" y="122" font-size="13" fill="#c0392b">a sneaky note…</text>
+
+  <!-- slip -->
+  <rect x="255" y="140" width="170" height="110" rx="8" fill="#ffffff" stroke="#8a8a82" stroke-width="2" transform="rotate(-3 340 195)"/>
+  <text x="340" y="170" text-anchor="middle" font-size="15" font-weight="bold" fill="#232323" transform="rotate(-3 340 195)">REQUEST SLIP</text>
+  <text x="340" y="196" text-anchor="middle" font-size="14" fill="#333" transform="rotate(-3 340 195)">mail my drawing</text>
+  <text x="340" y="216" text-anchor="middle" font-size="14" fill="#333" transform="rotate(-3 340 195)">to Grandma</text>
+  <path d="M196,190 L250,190" stroke="#3a76b8" stroke-width="2.5" marker-end="url(#a)"/>
+  <text x="223" y="180" text-anchor="middle" font-size="13" fill="#3a76b8">writes</text>
+
+  <!-- mailbox -->
+  <rect x="470" y="150" width="90" height="66" rx="14" fill="#dae8fc" stroke="#6c8ebf" stroke-width="2.5"/>
+  <rect x="500" y="172" width="46" height="8" rx="4" fill="#6c8ebf"/>
+  <rect x="505" y="216" width="14" height="52" fill="#6c8ebf"/>
+  <text x="515" y="292" text-anchor="middle" font-size="14" fill="#3a5a80">the mailbox</text>
+  <path d="M432,195 L466,187" stroke="#3a76b8" stroke-width="2.5" marker-end="url(#a)"/>
+
+  <!-- doorkeeper -->
+  <rect x="620" y="122" width="76" height="24" rx="6" fill="#8a8a82"/>
+  <circle cx="658" cy="164" r="24" fill="#f5f5f5" stroke="#8a8a82" stroke-width="2.5"/>
+  <circle cx="649" cy="160" r="3.5" fill="#232323"/>
+  <circle cx="667" cy="160" r="3.5" fill="#232323"/>
+  <line x1="649" y1="175" x2="667" y2="175" stroke="#232323" stroke-width="2.5"/>
+  <rect x="626" y="190" width="64" height="70" rx="10" fill="#f5f5f5" stroke="#8a8a82" stroke-width="2.5"/>
+  <rect x="700" y="196" width="58" height="72" rx="5" fill="#fffde7" stroke="#c8b900" stroke-width="2"/>
+  <text x="729" y="216" text-anchor="middle" font-size="11" fill="#4a4a20">RULES</text>
+  <line x1="708" y1="228" x2="750" y2="228" stroke="#c8b900" stroke-width="2"/>
+  <line x1="708" y1="242" x2="750" y2="242" stroke="#c8b900" stroke-width="2"/>
+  <line x1="708" y1="256" x2="750" y2="256" stroke="#c8b900" stroke-width="2"/>
+  <text x="658" y="292" text-anchor="middle" font-size="16" font-weight="bold" fill="#555">the doorkeeper</text>
+  <text x="658" y="312" text-anchor="middle" font-size="13" fill="#555">a robot with NO EARS — just</text>
+  <text x="658" y="328" text-anchor="middle" font-size="13" fill="#555">a pass slot. things, never words.</text>
+  <path d="M562,190 L616,190" stroke="#3a76b8" stroke-width="2.5" marker-end="url(#a)"/>
+  <text x="589" y="180" text-anchor="middle" font-size="13" fill="#3a76b8">reads</text>
+
+  <!-- door -->
+  <rect x="800" y="120" width="70" height="150" rx="8" fill="#d5e8d4" stroke="#82b366" stroke-width="3"/>
+  <circle cx="856" cy="196" r="6" fill="#82b366"/>
+  <text x="835" y="310" text-anchor="middle" font-size="14" fill="#3a6a34">the door</text>
+  <path d="M760,200 L796,196" stroke="#3a76b8" stroke-width="2.5" marker-end="url(#a)"/>
+  <text x="726" y="292" font-size="13" fill="#4a9a4a">opens only if</text>
+  <text x="726" y="308" font-size="13" fill="#4a9a4a">the rules say yes</text>
+
+  <!-- forbidden direct path -->
+  <path d="M150,340 C400,420 680,410 862,282" stroke="#c0392b" stroke-width="2.5" fill="none" stroke-dasharray="8 6" marker-end="url(#ar)"/>
+  <line x1="470" y1="360" x2="520" y2="410" stroke="#c0392b" stroke-width="5"/>
+  <line x1="520" y1="360" x2="470" y2="410" stroke="#c0392b" stroke-width="5"/>
+  <text x="495" y="444" text-anchor="middle" font-size="16" font-weight="bold" fill="#c0392b">a robot touching a door directly: never happens</text>
+
+  <rect x="120" y="466" width="660" height="40" rx="8" fill="#fffde7" stroke="#c8b900" stroke-width="1.5"/>
+  <text x="450" y="492" text-anchor="middle" font-size="16" fill="#4a4a20">The smart one proposes. The boring one decides. That's the whole trick.</text>
+</svg>

--- a/docs/architecture/ariadne/explainers/eli9-2-stickers.svg
+++ b/docs/architecture/ariadne/explainers/eli9-2-stickers.svg
@@ -1,0 +1,77 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 560" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#3a76b8"/></marker>
+  </defs>
+  <rect width="900" height="560" fill="#ffffff"/>
+  <text x="450" y="42" text-anchor="middle" font-size="24" font-weight="bold" fill="#1e5f96">Everything wears stickers — and stickers never lie</text>
+
+  <!-- GLUE LAW -->
+  <text x="60" y="86" font-size="18" font-weight="bold" fill="#232323">The glue law</text>
+
+  <rect x="60" y="100" width="150" height="120" rx="6" fill="#ffffff" stroke="#8a8a82" stroke-width="2"/>
+  <line x1="76" y1="130" x2="194" y2="130" stroke="#c8c8c0" stroke-width="2"/>
+  <line x1="76" y1="150" x2="194" y2="150" stroke="#c8c8c0" stroke-width="2"/>
+  <line x1="76" y1="170" x2="160" y2="170" stroke="#c8c8c0" stroke-width="2"/>
+  <circle cx="90" cy="112" r="16" fill="#dae8fc" stroke="#6c8ebf" stroke-width="2"/>
+  <text x="90" y="117" text-anchor="middle" font-size="11" font-weight="bold" fill="#274b73">MOM</text>
+  <text x="135" y="210" text-anchor="middle" font-size="12" fill="#555">"stays in the house"</text>
+
+  <text x="240" y="168" font-size="30" font-weight="bold" fill="#555">+</text>
+
+  <rect x="280" y="100" width="150" height="120" rx="6" fill="#ffffff" stroke="#8a8a82" stroke-width="2"/>
+  <line x1="296" y1="130" x2="414" y2="130" stroke="#c8c8c0" stroke-width="2"/>
+  <line x1="296" y1="150" x2="414" y2="150" stroke="#c8c8c0" stroke-width="2"/>
+  <line x1="296" y1="170" x2="380" y2="170" stroke="#c8c8c0" stroke-width="2"/>
+  <circle cx="310" cy="112" r="16" fill="#ffe6cc" stroke="#d79b00" stroke-width="2"/>
+  <text x="310" y="117" text-anchor="middle" font-size="9" font-weight="bold" fill="#8a5a00">LIBR.</text>
+  <text x="355" y="210" text-anchor="middle" font-size="12" fill="#555">"back by June"</text>
+
+  <path d="M446,160 L492,160" stroke="#3a76b8" stroke-width="3" marker-end="url(#a)"/>
+  <text x="469" y="148" text-anchor="middle" font-size="13" fill="#3a76b8">glue, copy,</text>
+  <text x="469" y="184" text-anchor="middle" font-size="13" fill="#3a76b8">or summarize</text>
+
+  <rect x="510" y="92" width="180" height="136" rx="6" fill="#fffdf5" stroke="#8a8a82" stroke-width="2.5"/>
+  <line x1="528" y1="130" x2="672" y2="130" stroke="#c8c8c0" stroke-width="2"/>
+  <line x1="528" y1="150" x2="672" y2="150" stroke="#c8c8c0" stroke-width="2"/>
+  <line x1="528" y1="170" x2="672" y2="170" stroke="#c8c8c0" stroke-width="2"/>
+  <line x1="528" y1="190" x2="620" y2="190" stroke="#c8c8c0" stroke-width="2"/>
+  <circle cx="544" cy="108" r="16" fill="#dae8fc" stroke="#6c8ebf" stroke-width="2"/>
+  <text x="544" y="113" text-anchor="middle" font-size="11" font-weight="bold" fill="#274b73">MOM</text>
+  <circle cx="584" cy="108" r="16" fill="#ffe6cc" stroke="#d79b00" stroke-width="2"/>
+  <text x="584" y="113" text-anchor="middle" font-size="9" font-weight="bold" fill="#8a5a00">LIBR.</text>
+  <text x="600" y="244" text-anchor="middle" font-size="13" font-weight="bold" fill="#333">the new paper wears BOTH</text>
+  <text x="600" y="262" text-anchor="middle" font-size="12" fill="#555">a summary of a secret is still a secret</text>
+
+  <!-- PEEL LAW -->
+  <text x="60" y="316" font-size="18" font-weight="bold" fill="#232323">The peel law</text>
+  <rect x="60" y="330" width="360" height="120" rx="8" fill="#fcfcfa" stroke="#b8b8b0" stroke-width="1.5"/>
+  <circle cx="110" cy="372" r="20" fill="#ffe6cc" stroke="#d79b00" stroke-width="2"/>
+  <text x="110" y="377" text-anchor="middle" font-size="10" font-weight="bold" fill="#8a5a00">LIBR.</text>
+  <text x="150" y="360" font-size="13" fill="#333">only the LIBRARY peels the library sticker —</text>
+  <text x="150" y="378" font-size="13" fill="#333">and only the way it promised in advance:</text>
+  <text x="150" y="398" font-size="13" fill="#8a5a00" font-weight="bold">"ask me" · "off by itself in June" · "never"</text>
+  <text x="150" y="426" font-size="12.5" fill="#c0392b" font-weight="bold">Mom can't peel it. You can't peel it. Every</text>
+  <text x="150" y="442" font-size="12.5" fill="#c0392b" font-weight="bold">sticker's owner must be okay — every time.</text>
+
+  <!-- BLUR MACHINE -->
+  <text x="470" y="316" font-size="18" font-weight="bold" fill="#232323">The one honest exception: the approved machine</text>
+  <rect x="470" y="330" width="410" height="120" rx="8" fill="#fcfcfa" stroke="#b8b8b0" stroke-width="1.5"/>
+  <rect x="490" y="356" width="60" height="70" rx="4" fill="#ffffff" stroke="#8a8a82" stroke-width="2"/>
+  <circle cx="504" cy="368" r="10" fill="#dae8fc" stroke="#6c8ebf" stroke-width="1.5"/>
+  <circle cx="528" cy="368" r="10" fill="#f8cecc" stroke="#b85450" stroke-width="1.5"/>
+  <path d="M556,390 L588,390" stroke="#3a76b8" stroke-width="2.5" marker-end="url(#a)"/>
+  <rect x="592" y="352" width="96" height="78" rx="10" fill="#e1d5e7" stroke="#9673a6" stroke-width="2.5"/>
+  <text x="640" y="384" text-anchor="middle" font-size="13" font-weight="bold" fill="#4a355c">BLUR-O-</text>
+  <text x="640" y="402" text-anchor="middle" font-size="13" font-weight="bold" fill="#4a355c">MATIC</text>
+  <path d="M692,390 L724,390" stroke="#3a76b8" stroke-width="2.5" marker-end="url(#a)"/>
+  <rect x="728" y="356" width="60" height="70" rx="4" fill="#ffffff" stroke="#8a8a82" stroke-width="2"/>
+  <circle cx="742" cy="368" r="10" fill="#dae8fc" stroke="#6c8ebf" stroke-width="1.5"/>
+  <circle cx="800" cy="416" r="22" fill="#d5e8d4" stroke="#82b366" stroke-width="2.5"/>
+  <text x="800" y="412" text-anchor="middle" font-size="9" fill="#3a6a34">SIGNED</text>
+  <text x="800" y="424" text-anchor="middle" font-size="12" font-weight="bold" fill="#3a6a34">✓</text>
+  <text x="676" y="446" text-anchor="middle" font-size="12" fill="#555">the sticker's owner approved THIS machine; it signs its work</text>
+
+  <rect x="60" y="478" width="820" height="60" rx="8" fill="#fffde7" stroke="#c8b900" stroke-width="1.5"/>
+  <text x="450" y="503" text-anchor="middle" font-size="15" fill="#4a4a20">The robot is never allowed to say "I blurred it, trust me."</text>
+  <text x="450" y="524" text-anchor="middle" font-size="15" font-weight="bold" fill="#4a4a20">Only the machine's signature counts.</text>
+</svg>

--- a/docs/architecture/ariadne/explainers/eli9-3-doorkeeper.svg
+++ b/docs/architecture/ariadne/explainers/eli9-3-doorkeeper.svg
@@ -1,0 +1,79 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 560" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#3a76b8"/></marker>
+    <marker id="ao" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#d79b00"/></marker>
+    <marker id="ar" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#c0392b"/></marker>
+  </defs>
+  <rect width="900" height="560" fill="#ffffff"/>
+  <text x="450" y="42" text-anchor="middle" font-size="24" font-weight="bold" fill="#1e5f96">The doorkeeper asks three questions — all three must pass</text>
+
+  <!-- Q1 hall pass -->
+  <rect x="50" y="76" width="255" height="180" rx="10" fill="#e1d5e7" stroke="#9673a6" stroke-width="2"/>
+  <text x="66" y="102" font-size="16" font-weight="bold" fill="#4a355c">1 · "Got a hall pass?"</text>
+  <rect x="70" y="116" width="216" height="110" rx="8" fill="#ffffff" stroke="#9673a6" stroke-width="1.5"/>
+  <text x="82" y="138" font-size="13" font-weight="bold" fill="#4a355c">HALL PASS — robot-a</text>
+  <text x="82" y="158" font-size="12" fill="#333">may: mail letters to family</text>
+  <text x="82" y="176" font-size="12" fill="#333">because: chris said so (tue)</text>
+  <text x="82" y="194" font-size="12" fill="#333">expires: bedtime</text>
+  <text x="82" y="212" font-size="12" fill="#c0392b" font-weight="bold">lending: not allowed</text>
+  <text x="66" y="246" font-size="11.5" fill="#4a355c">if the "because" goes away, the pass dies too</text>
+
+  <!-- Q2 stickers -->
+  <rect x="322" y="76" width="255" height="180" rx="10" fill="#f8cecc" stroke="#b85450" stroke-width="2"/>
+  <text x="338" y="102" font-size="16" font-weight="bold" fill="#7a3230">2 · "Stickers all okay?"</text>
+  <rect x="342" y="116" width="90" height="70" rx="5" fill="#ffffff" stroke="#8a8a82" stroke-width="1.5"/>
+  <circle cx="358" cy="130" r="11" fill="#dae8fc" stroke="#6c8ebf" stroke-width="1.5"/>
+  <circle cx="384" cy="130" r="11" fill="#d5e8d4" stroke="#82b366" stroke-width="1.5"/>
+  <circle cx="410" cy="130" r="11" fill="#f8cecc" stroke="#b85450" stroke-width="2"/>
+  <text x="410" y="134" text-anchor="middle" font-size="8" fill="#7a3230">house</text>
+  <text x="338" y="212" font-size="12.5" fill="#333">every sticker gets a vote.</text>
+  <text x="338" y="230" font-size="12.5" font-weight="bold" fill="#7a3230">one "stays home" vote wins,</text>
+  <text x="338" y="246" font-size="12.5" font-weight="bold" fill="#7a3230">even against nine yeses.</text>
+  <text x="452" y="140" font-size="12" fill="#555">← the slip wants</text>
+  <text x="452" y="156" font-size="12" fill="#555">to mail THIS</text>
+
+  <!-- Q3 how big -->
+  <rect x="594" y="76" width="255" height="180" rx="10" fill="#ffe6cc" stroke="#d79b00" stroke-width="2"/>
+  <text x="610" y="102" font-size="16" font-weight="bold" fill="#8a5a00">3 · "How big a deal?"</text>
+  <rect x="612" y="116" width="100" height="26" rx="13" fill="#d5e8d4" stroke="#82b366" stroke-width="1.5"/><text x="662" y="134" text-anchor="middle" font-size="12" fill="#3a6a34">just looking</text>
+  <rect x="612" y="150" width="100" height="26" rx="13" fill="#d5e8d4" stroke="#82b366" stroke-width="1.5"/><text x="662" y="168" text-anchor="middle" font-size="12" fill="#3a6a34">drafting</text>
+  <rect x="612" y="184" width="130" height="26" rx="13" fill="#f8cecc" stroke="#b85450" stroke-width="2"/><text x="677" y="202" text-anchor="middle" font-size="12" font-weight="bold" fill="#7a3230">mailing · spending</text>
+  <rect x="612" y="218" width="130" height="26" rx="13" fill="#f8cecc" stroke="#b85450" stroke-width="2"/><text x="677" y="236" text-anchor="middle" font-size="12" font-weight="bold" fill="#7a3230">deleting — no undo!</text>
+  <text x="756" y="204" font-size="20" fill="#c0392b">→</text>
+  <text x="782" y="196" font-size="12" fill="#7a3230">needs a</text>
+  <text x="782" y="212" font-size="12" font-weight="bold" fill="#7a3230">grown-up</text>
+
+  <!-- grown-up approval -->
+  <rect x="50" y="290" width="400" height="130" rx="10" fill="#fcfcfa" stroke="#b8b8b0" stroke-width="1.5"/>
+  <text x="66" y="316" font-size="16" font-weight="bold" fill="#232323">Big deals: the grown-up sees the real thing</text>
+  <circle cx="100" cy="360" r="18" fill="#d5e8d4" stroke="#82b366" stroke-width="2"/>
+  <rect x="84" y="382" width="32" height="26" rx="8" fill="#d5e8d4" stroke="#82b366" stroke-width="2"/>
+  <rect x="140" y="340" width="120" height="66" rx="4" fill="#ffffff" stroke="#8a8a82" stroke-width="1.5"/>
+  <text x="200" y="362" text-anchor="middle" font-size="11" fill="#333">the ACTUAL letter,</text>
+  <text x="200" y="378" text-anchor="middle" font-size="11" fill="#333">word for word —</text>
+  <text x="200" y="394" text-anchor="middle" font-size="11" font-weight="bold" fill="#c0392b">never the robot's summary</text>
+  <text x="280" y="366" font-size="12.5" fill="#333">…and only a grown-up</text>
+  <text x="280" y="382" font-size="12.5" fill="#333">who's ALLOWED to read</text>
+  <text x="280" y="398" font-size="12.5" fill="#333">it may approve it</text>
+
+  <!-- receipt -->
+  <rect x="470" y="290" width="180" height="130" rx="6" fill="#fffde7" stroke="#c8b900" stroke-width="2"/>
+  <text x="560" y="314" text-anchor="middle" font-size="14" font-weight="bold" fill="#4a4a20">RECEIPT</text>
+  <text x="560" y="338" text-anchor="middle" font-size="13" fill="#c0392b" font-weight="bold">NO.</text>
+  <text x="560" y="360" text-anchor="middle" font-size="12" fill="#333">question 2 failed:</text>
+  <text x="560" y="376" text-anchor="middle" font-size="12" fill="#333">"stays home" sticker</text>
+  <text x="560" y="400" text-anchor="middle" font-size="11" font-style="italic" fill="#555">every decision gets one</text>
+
+  <!-- line check -->
+  <rect x="670" y="290" width="180" height="130" rx="10" fill="#fcfcfa" stroke="#b8b8b0" stroke-width="1.5"/>
+  <text x="760" y="314" text-anchor="middle" font-size="14" font-weight="bold" fill="#232323">checked at the door</text>
+  <text x="760" y="336" text-anchor="middle" font-size="12" fill="#333">pass taken away while</text>
+  <text x="760" y="352" text-anchor="middle" font-size="12" fill="#333">the robot stood in line?</text>
+  <text x="760" y="372" text-anchor="middle" font-size="12" font-weight="bold" fill="#c0392b">still stopped.</text>
+  <text x="760" y="394" text-anchor="middle" font-size="11.5" font-style="italic" fill="#555">"but I was already in</text>
+  <text x="760" y="408" text-anchor="middle" font-size="11.5" font-style="italic" fill="#555">line!" never works</text>
+
+  <rect x="50" y="452" width="800" height="60" rx="8" fill="#fffde7" stroke="#c8b900" stroke-width="1.5"/>
+  <text x="450" y="477" text-anchor="middle" font-size="15" fill="#4a4a20">You don't argue with the doorkeeper by being clever.</text>
+  <text x="450" y="498" text-anchor="middle" font-size="15" font-weight="bold" fill="#4a4a20">You argue by showing a better hall pass, or a properly peeled sticker.</text>
+</svg>

--- a/docs/architecture/ariadne/explainers/eli9-4-router.svg
+++ b/docs/architecture/ariadne/explainers/eli9-4-router.svg
@@ -1,0 +1,90 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 560" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#3a76b8"/></marker>
+    <marker id="ao" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#d79b00"/></marker>
+  </defs>
+  <rect width="900" height="560" fill="#ffffff"/>
+  <text x="450" y="40" text-anchor="middle" font-size="24" font-weight="bold" fill="#1e5f96">Picking a helper: cross off first, THEN pick the best</text>
+
+  <!-- the package -->
+  <rect x="40" y="80" width="130" height="90" rx="6" fill="#ffffff" stroke="#8a8a82" stroke-width="2"/>
+  <circle cx="62" cy="98" r="13" fill="#f8cecc" stroke="#b85450" stroke-width="2"/>
+  <text x="62" y="102" text-anchor="middle" font-size="8" fill="#7a3230">house</text>
+  <circle cx="92" cy="98" r="13" fill="#dae8fc" stroke="#6c8ebf" stroke-width="1.5"/>
+  <text x="105" y="146" text-anchor="middle" font-size="12" fill="#333">the job + its</text>
+  <text x="105" y="162" text-anchor="middle" font-size="12" fill="#333">stickers</text>
+
+  <!-- STEP 1 -->
+  <rect x="200" y="70" width="670" height="220" rx="10" fill="#fcfcfa" stroke="#b8b8b0" stroke-width="1.5"/>
+  <text x="216" y="96" font-size="16" font-weight="bold" fill="#c0392b">STEP 1 — the stickers cross helpers off. No contest yet.</text>
+
+  <!-- helpers -->
+  <g>
+    <circle cx="270" cy="150" r="26" fill="#d5e8d4" stroke="#82b366" stroke-width="2.5"/>
+    <text x="270" y="146" text-anchor="middle" font-size="11" font-weight="bold" fill="#3a6a34">ZIP</text>
+    <text x="270" y="160" text-anchor="middle" font-size="9" fill="#3a6a34">fast</text>
+    <text x="270" y="200" text-anchor="middle" font-size="11" fill="#555">keeps nothing</text>
+  </g>
+  <g>
+    <circle cx="390" cy="150" r="26" fill="#d5e8d4" stroke="#82b366" stroke-width="2.5"/>
+    <text x="390" y="146" text-anchor="middle" font-size="11" font-weight="bold" fill="#3a6a34">PENNY</text>
+    <text x="390" y="160" text-anchor="middle" font-size="9" fill="#3a6a34">cheap</text>
+    <text x="390" y="200" text-anchor="middle" font-size="11" fill="#555">keeps nothing</text>
+  </g>
+  <g>
+    <circle cx="510" cy="150" r="26" fill="#d5e8d4" stroke="#82b366" stroke-width="2.5"/>
+    <text x="510" y="146" text-anchor="middle" font-size="11" font-weight="bold" fill="#3a6a34">SAGE</text>
+    <text x="510" y="160" text-anchor="middle" font-size="9" fill="#3a6a34">genius</text>
+    <text x="510" y="200" text-anchor="middle" font-size="11" fill="#555">keeps nothing</text>
+  </g>
+  <g>
+    <circle cx="640" cy="150" r="26" fill="#f5f5f5" stroke="#8a8a82" stroke-width="2"/>
+    <text x="640" y="146" text-anchor="middle" font-size="11" font-weight="bold" fill="#555">GABBY</text>
+    <text x="640" y="160" text-anchor="middle" font-size="9" fill="#555">genius!</text>
+    <text x="640" y="200" text-anchor="middle" font-size="11" font-weight="bold" fill="#c0392b">blabs everything</text>
+    <line x1="614" y1="124" x2="666" y2="176" stroke="#c0392b" stroke-width="5"/>
+    <line x1="666" y1="124" x2="614" y2="176" stroke="#c0392b" stroke-width="5"/>
+  </g>
+  <g>
+    <circle cx="780" cy="150" r="26" fill="#f5f5f5" stroke="#8a8a82" stroke-width="2"/>
+    <text x="780" y="146" text-anchor="middle" font-size="11" font-weight="bold" fill="#555">XEROXA</text>
+    <text x="780" y="160" text-anchor="middle" font-size="9" fill="#555">free!</text>
+    <text x="780" y="200" text-anchor="middle" font-size="11" font-weight="bold" fill="#c0392b">keeps copies</text>
+    <line x1="754" y1="124" x2="806" y2="176" stroke="#c0392b" stroke-width="5"/>
+    <line x1="806" y1="124" x2="754" y2="176" stroke="#c0392b" stroke-width="5"/>
+  </g>
+  <text x="216" y="248" font-size="13" fill="#7a3230" font-weight="bold">the "stays in the house" sticker crossed off Gabby and Xeroxa BEFORE anyone</text>
+  <text x="216" y="266" font-size="13" fill="#7a3230" font-weight="bold">compared smartness or price. Genius and free never entered into it.</text>
+
+  <path class="e" d="M170,125 L196,125" stroke="#3a76b8" stroke-width="2.5" marker-end="url(#a)" fill="none"/>
+
+  <!-- STEP 2 -->
+  <rect x="200" y="316" width="440" height="150" rx="10" fill="#fcfcfa" stroke="#b8b8b0" stroke-width="1.5"/>
+  <text x="216" y="342" font-size="16" font-weight="bold" fill="#3a6a34">STEP 2 — NOW the contest, among who's left</text>
+  <circle cx="270" cy="400" r="24" fill="#d5e8d4" stroke="#82b366" stroke-width="2.5"/>
+  <text x="270" y="405" text-anchor="middle" font-size="10" font-weight="bold" fill="#3a6a34">ZIP</text>
+  <circle cx="350" cy="400" r="24" fill="#d5e8d4" stroke="#82b366" stroke-width="2.5"/>
+  <text x="350" y="405" text-anchor="middle" font-size="10" font-weight="bold" fill="#3a6a34">PENNY</text>
+  <circle cx="430" cy="400" r="24" fill="#d5e8d4" stroke="#82b366" stroke-width="3.5"/>
+  <text x="430" y="405" text-anchor="middle" font-size="10" font-weight="bold" fill="#3a6a34">SAGE</text>
+  <circle cx="430" cy="366" r="12" fill="#fff2cc" stroke="#d6b656" stroke-width="2"/>
+  <text x="430" y="371" text-anchor="middle" font-size="11">★</text>
+  <text x="480" y="396" font-size="12.5" fill="#333">best of the ALLOWED:</text>
+  <text x="480" y="412" font-size="12.5" fill="#333">smartest wins today</text>
+  <text x="216" y="448" font-size="12" font-style="italic" fill="#555">fastest? cheapest? smartest? — a fair fight, because everyone here is safe</text>
+
+  <!-- fallback -->
+  <rect x="660" y="316" width="210" height="150" rx="10" fill="#ffe6cc" stroke="#d79b00" stroke-width="2"/>
+  <text x="765" y="342" text-anchor="middle" font-size="15" font-weight="bold" fill="#8a5a00">Sage is sick today?</text>
+  <circle cx="710" cy="386" r="20" fill="#d5e8d4" stroke="#82b366" stroke-width="2"/>
+  <rect x="700" y="376" width="20" height="8" rx="4" fill="#c0392b"/>
+  <text x="740" y="382" font-size="12" fill="#333">don't just grab</text>
+  <text x="740" y="398" font-size="12" fill="#333">the next name —</text>
+  <text x="765" y="426" text-anchor="middle" font-size="13" font-weight="bold" fill="#c0392b">RE-DO the crossing-off</text>
+  <text x="765" y="444" text-anchor="middle" font-size="11" font-style="italic" fill="#8a5a00">"the good one was busy" never</text>
+  <text x="765" y="458" text-anchor="middle" font-size="11" font-style="italic" fill="#8a5a00">makes the blabbermouth okay</text>
+  <path d="M765,316 C765,300 700,296 660,292" stroke="#d79b00" stroke-width="2.5" fill="none" stroke-dasharray="6 4" marker-end="url(#ao)"/>
+
+  <rect x="40" y="492" width="830" height="50" rx="8" fill="#fffde7" stroke="#c8b900" stroke-width="1.5"/>
+  <text x="455" y="523" text-anchor="middle" font-size="15" font-weight="bold" fill="#4a4a20">Choosing the best model only ever happens among the models the rules already allowed.</text>
+</svg>

--- a/docs/architecture/ariadne/explainers/eli9-5-houses.svg
+++ b/docs/architecture/ariadne/explainers/eli9-5-houses.svg
@@ -1,0 +1,89 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 540" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="aB" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#3a76b8"/></marker>
+    <marker id="aG" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#4a9a4a"/></marker>
+  </defs>
+  <rect width="900" height="540" fill="#ffffff"/>
+  <text x="450" y="40" text-anchor="middle" font-size="24" font-weight="bold" fill="#1e5f96">Everyone has a house. Joining prints passes — it never moves houses.</text>
+
+  <!-- Alice's house -->
+  <path d="M60,160 L150,110 L240,160 Z" fill="#d5e8d4" stroke="#82b366" stroke-width="2.5"/>
+  <rect x="78" y="160" width="144" height="120" fill="#d5e8d4" stroke="#82b366" stroke-width="2.5"/>
+  <rect x="130" y="222" width="38" height="58" rx="3" fill="#82b366"/>
+  <circle cx="160" cy="252" r="4" fill="#d5e8d4"/>
+  <rect x="92" y="176" width="52" height="34" rx="3" fill="#ffffff" stroke="#82b366" stroke-width="1.5"/>
+  <text x="118" y="190" text-anchor="middle" font-size="8" fill="#3a6a34">skills</text>
+  <text x="118" y="201" text-anchor="middle" font-size="8" fill="#3a6a34">notebook</text>
+  <rect x="156" y="176" width="52" height="34" rx="3" fill="#ffffff" stroke="#82b366" stroke-width="1.5"/>
+  <text x="182" y="190" text-anchor="middle" font-size="8" fill="#3a6a34">soccer</text>
+  <text x="182" y="201" text-anchor="middle" font-size="8" fill="#3a6a34">shelf</text>
+  <text x="150" y="304" text-anchor="middle" font-size="14" font-weight="bold" fill="#3a6a34">ALICE'S HOUSE</text>
+  <text x="150" y="322" text-anchor="middle" font-size="11.5" fill="#3a6a34">everything of hers lives here —</text>
+  <text x="150" y="337" text-anchor="middle" font-size="11.5" fill="#3a6a34">exactly one house per thing</text>
+
+  <!-- clubhouse -->
+  <path d="M660,160 L770,104 L880,160 Z" fill="#dae8fc" stroke="#6c8ebf" stroke-width="2.5"/>
+  <rect x="678" y="160" width="184" height="120" fill="#dae8fc" stroke="#6c8ebf" stroke-width="2.5"/>
+  <rect x="748" y="222" width="42" height="58" rx="3" fill="#6c8ebf"/>
+  <rect x="692" y="176" width="64" height="34" rx="3" fill="#ffffff" stroke="#6c8ebf" stroke-width="1.5"/>
+  <text x="724" y="190" text-anchor="middle" font-size="8" fill="#274b73">rulebook ·</text>
+  <text x="724" y="201" text-anchor="middle" font-size="8" fill="#274b73">game plans</text>
+  <rect x="766" y="176" width="64" height="34" rx="3" fill="#ffffff" stroke="#6c8ebf" stroke-width="1.5"/>
+  <text x="798" y="190" text-anchor="middle" font-size="8" fill="#274b73">bulletin</text>
+  <text x="798" y="201" text-anchor="middle" font-size="8" fill="#274b73">board</text>
+  <text x="770" y="304" text-anchor="middle" font-size="14" font-weight="bold" fill="#274b73">THE CLUBHOUSE</text>
+  <text x="770" y="322" text-anchor="middle" font-size="11.5" fill="#274b73">just a house a club owns —</text>
+  <text x="770" y="337" text-anchor="middle" font-size="11.5" fill="#274b73">the club's stuff lives here</text>
+
+  <!-- doorkeeper between -->
+  <circle cx="450" cy="96" r="15" fill="#f5f5f5" stroke="#8a8a82" stroke-width="2"/>
+  <rect x="436" y="78" width="28" height="10" rx="3" fill="#8a8a82"/>
+  <line x1="444" y1="98" x2="456" y2="98" stroke="#232323" stroke-width="2"/>
+  <text x="450" y="130" text-anchor="middle" font-size="10.5" fill="#555">a doorkeeper at every door:</text>
+  <text x="450" y="143" text-anchor="middle" font-size="10.5" fill="#555">no ears, just a pass slot</text>
+
+  <!-- pass 1: club -> alice -->
+  <rect x="300" y="168" width="300" height="86" rx="8" fill="#dae8fc" stroke="#6c8ebf" stroke-width="2.5"/>
+  <text x="316" y="190" font-size="13" font-weight="bold" fill="#274b73">MEMBER PASS</text>
+  <text x="316" y="208" font-size="11" fill="#333">for: Alice · opens: field + club balls + bulletin room</text>
+  <text x="316" y="224" font-size="11" fill="#333">why: joined the club · until: torn up</text>
+  <text x="316" y="244" font-size="10" font-style="italic" fill="#555">printed by the club</text>
+  <path d="M676,214 L604,214" stroke="#3a76b8" stroke-width="2.5" marker-end="url(#aB)"/>
+  <path d="M298,214 L246,214" stroke="#3a76b8" stroke-width="2.5" marker-end="url(#aB)"/>
+
+  <!-- alice's ball at practice -->
+  <rect x="300" y="280" width="300" height="100" rx="8" fill="#d5e8d4" stroke="#82b366" stroke-width="2.5"/>
+  <circle cx="330" cy="306" r="12" fill="#ffffff" stroke="#3a6a34" stroke-width="2"/>
+  <path d="M324,300 L336,312 M336,300 L324,312" stroke="#3a6a34" stroke-width="1"/>
+  <text x="350" y="302" font-size="13" font-weight="bold" fill="#3a6a34">ALICE'S BALL, AT PRACTICE</text>
+  <text x="316" y="326" font-size="11" fill="#333">tossing it onto the field mints the pass:</text>
+  <text x="316" y="342" font-size="11" fill="#333">the team may use it — during practice.</text>
+  <text x="316" y="358" font-size="11" fill="#333">practice ends → it goes home with her.</text>
+  <text x="316" y="374" font-size="10" font-style="italic" fill="#555">used-by-everyone never means owned-by-the-club</text>
+  <path d="M246,330 L298,330" stroke="#4a9a4a" stroke-width="2.5" marker-end="url(#aG)"/>
+  <path d="M604,330 L676,330" stroke="#4a9a4a" stroke-width="2.5" marker-end="url(#aG)"/>
+  <text x="640" y="320" text-anchor="middle" font-size="10" fill="#4a9a4a">to the field</text>
+
+  <!-- crossed-out craning -->
+  <rect x="60" y="380" width="190" height="130" rx="8" fill="#fcfcfa" stroke="#b8b8b0" stroke-width="1.5"/>
+  <path d="M110,448 L145,430 L180,448 Z" fill="#dae8fc" stroke="#6c8ebf" stroke-width="1.5"/>
+  <rect x="118" y="448" width="54" height="40" fill="#dae8fc" stroke="#6c8ebf" stroke-width="1.5"/>
+  <path d="M128,466 L145,457 L162,466 Z" fill="#d5e8d4" stroke="#82b366" stroke-width="1.5"/>
+  <rect x="132" y="466" width="26" height="20" fill="#d5e8d4" stroke="#82b366" stroke-width="1.5"/>
+  <line x1="70" y1="392" x2="240" y2="500" stroke="#c0392b" stroke-width="4.5"/>
+  <line x1="240" y1="392" x2="70" y2="500" stroke="#c0392b" stroke-width="4.5"/>
+  <text x="155" y="527" text-anchor="middle" font-size="11.5" font-weight="bold" fill="#c0392b">a house inside the clubhouse: never</text>
+
+  <!-- robots note -->
+  <rect x="640" y="380" width="240" height="130" rx="8" fill="#fffde7" stroke="#c8b900" stroke-width="1.5"/>
+  <text x="656" y="404" font-size="13" font-weight="bold" fill="#4a4a20">whose robot? doesn't matter</text>
+  <text x="656" y="424" font-size="11.5" fill="#4a4a20">yours, the club's, rented — robots</text>
+  <text x="656" y="440" font-size="11.5" fill="#4a4a20">own nothing and work on passes</text>
+  <text x="656" y="456" font-size="11.5" fill="#4a4a20">lent to them. Whose robot did the</text>
+  <text x="656" y="472" font-size="11.5" fill="#4a4a20">work never decides whose stuff</text>
+  <text x="656" y="488" font-size="11.5" fill="#4a4a20">the work is. Passes decide.</text>
+
+  <rect x="280" y="420" width="340" height="66" rx="8" fill="#fffde7" stroke="#c8b900" stroke-width="1.5"/>
+  <text x="450" y="446" text-anchor="middle" font-size="13.5" fill="#4a4a20">Joining prints passes, never moves houses.</text>
+  <text x="450" y="468" text-anchor="middle" font-size="13.5" font-weight="bold" fill="#4a4a20">A thing that never moved in never has to move out.</text>
+</svg>

--- a/docs/architecture/ariadne/explainers/eli9-6-whose-paper.svg
+++ b/docs/architecture/ariadne/explainers/eli9-6-whose-paper.svg
@@ -1,0 +1,91 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 560" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="aB" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#3a76b8"/></marker>
+    <marker id="aG" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#4a9a4a"/></marker>
+  </defs>
+  <rect width="900" height="560" fill="#ffffff"/>
+  <text x="450" y="40" text-anchor="middle" font-size="24" font-weight="bold" fill="#1e5f96">Where it was made decides — and what you learned is always yours</text>
+
+  <!-- coach's office -->
+  <rect x="40" y="80" width="210" height="120" rx="8" fill="#dae8fc" stroke="#6c8ebf" stroke-width="2.5"/>
+  <text x="145" y="104" text-anchor="middle" font-size="13" font-weight="bold" fill="#274b73">THE COACH'S OFFICE</text>
+  <rect x="58" y="116" width="120" height="40" rx="3" fill="#ffffff" stroke="#6c8ebf" stroke-width="1.5"/>
+  <text x="118" y="132" text-anchor="middle" font-size="8.5" fill="#274b73">game plans · season notes</text>
+  <text x="118" y="146" text-anchor="middle" font-size="8.5" fill="#274b73">MADE at this desk</text>
+  <rect x="192" y="116" width="42" height="60" rx="3" fill="#6c8ebf"/>
+  <circle cx="226" cy="146" r="3.5" fill="#dae8fc"/>
+  <rect x="200" y="130" width="14" height="16" rx="2" fill="#f8cecc" stroke="#b85450" stroke-width="1.5"/>
+  <text x="118" y="174" text-anchor="middle" font-size="10" font-weight="bold" fill="#c0392b">your member pass does</text>
+  <text x="118" y="188" text-anchor="middle" font-size="10" font-weight="bold" fill="#c0392b">NOT open this door</text>
+
+  <!-- handed copy -->
+  <path d="M250,140 L306,140" stroke="#3a76b8" stroke-width="2.5" marker-end="url(#aB)"/>
+  <text x="278" y="128" text-anchor="middle" font-size="10" fill="#3a76b8">when it's</text>
+  <text x="278" y="158" text-anchor="middle" font-size="10" fill="#3a76b8">FINISHED</text>
+  <rect x="310" y="86" width="190" height="118" rx="8" fill="#fcfcfa" stroke="#b8b8b0" stroke-width="1.5"/>
+  <text x="405" y="108" text-anchor="middle" font-size="12" font-weight="bold" fill="#232323">the coach hands out copies</text>
+  <rect x="330" y="118" width="80" height="52" rx="4" fill="#ffffff" stroke="#8a8a82" stroke-width="1.5"/>
+  <text x="370" y="136" text-anchor="middle" font-size="8.5" fill="#333">forward</text>
+  <text x="370" y="148" text-anchor="middle" font-size="8.5" fill="#333">game plan</text>
+  <circle cx="344" cy="128" r="9" fill="#dae8fc" stroke="#6c8ebf" stroke-width="1.5"/>
+  <text x="344" y="131" text-anchor="middle" font-size="5.5" fill="#274b73">team</text>
+  <text x="424" y="136" font-size="9.5" fill="#555">your copy → your</text>
+  <text x="424" y="149" font-size="9.5" fill="#555">house, wearing the</text>
+  <text x="424" y="162" font-size="9.5" fill="#555">club's sticker</text>
+  <text x="405" y="182" text-anchor="middle" font-size="9.5" font-style="italic" fill="#555">the original never left the desk ·</text>
+  <text x="405" y="195" text-anchor="middle" font-size="9.5" font-style="italic" fill="#555">the notes are never handed out</text>
+
+  <!-- made at home -->
+  <rect x="40" y="234" width="210" height="76" rx="8" fill="#d5e8d4" stroke="#82b366" stroke-width="2.5"/>
+  <text x="145" y="260" text-anchor="middle" font-size="13" font-weight="bold" fill="#3a6a34">MADE AT YOUR HOUSE</text>
+  <text x="145" y="282" text-anchor="middle" font-size="11" fill="#3a6a34">your drawings · your projects</text>
+  <path d="M250,272 L306,272" stroke="#4a9a4a" stroke-width="2.5" marker-end="url(#aG)"/>
+  <rect x="310" y="240" width="190" height="64" rx="8" fill="#d5e8d4" stroke="#82b366" stroke-width="2"/>
+  <text x="405" y="266" text-anchor="middle" font-size="13" font-weight="bold" fill="#3a6a34">your house</text>
+  <text x="405" y="286" text-anchor="middle" font-size="11" fill="#3a6a34">yours, forever</text>
+
+  <rect x="130" y="330" width="290" height="40" rx="8" fill="#fffde7" stroke="#c8b900" stroke-width="1.5"/>
+  <text x="275" y="349" text-anchor="middle" font-size="12.5" fill="#4a4a20">nobody sorts paper by paper —</text>
+  <text x="275" y="364" text-anchor="middle" font-size="12.5" font-weight="bold" fill="#4a4a20">where it was MADE decides</text>
+
+  <!-- right: the learning rule -->
+  <rect x="520" y="80" width="350" height="290" rx="10" fill="#fcfcfa" stroke="#b8b8b0" stroke-width="1.5"/>
+  <text x="695" y="108" text-anchor="middle" font-size="16" font-weight="bold" fill="#3a6a34">the most important rule</text>
+
+  <text x="545" y="140" font-size="12.5" fill="#333">learned at the club, on club fields,</text>
+  <text x="545" y="156" font-size="12.5" fill="#333">with club drills…</text>
+  <circle cx="620" cy="196" r="16" fill="#fce5cd" stroke="#b8860b" stroke-width="2"/>
+  <path d="M610,220 Q620,230 630,220" stroke="#232323" stroke-width="2" fill="none"/>
+  <circle cx="660" cy="210" r="10" fill="#ffffff" stroke="#232323" stroke-width="2"/>
+  <text x="700" y="205" font-size="11" fill="#555">⚽ corner kick, bent!</text>
+
+  <path d="M660,240 L660,272" stroke="#4a9a4a" stroke-width="2.5" marker-end="url(#aG)"/>
+
+  <rect x="545" y="272" width="230" height="88" rx="6" fill="#d5e8d4" stroke="#82b366" stroke-width="2.5"/>
+  <text x="660" y="292" text-anchor="middle" font-size="12" font-weight="bold" fill="#3a6a34">SKILLS NOTEBOOK — in YOUR house</text>
+  <text x="557" y="314" font-size="11.5" fill="#333">✓ bend a corner kick</text>
+  <rect x="700" y="302" width="60" height="18" rx="9" fill="#f8cecc" stroke="#b85450" stroke-width="1.5"/>
+  <text x="730" y="315" text-anchor="middle" font-size="8.5" fill="#7a3230">club secret</text>
+  <text x="557" y="336" font-size="10.5" font-style="italic" fill="#555">the special play's sticker rides along —</text>
+  <text x="557" y="350" font-size="10.5" font-style="italic" fill="#555">yours to have, theirs to gate</text>
+
+  <text x="800" y="300" font-size="11" fill="#3a6a34" font-weight="bold">the club keeps</text>
+  <text x="800" y="315" font-size="11" fill="#3a6a34" font-weight="bold">its drill sheets;</text>
+  <text x="800" y="330" font-size="11" fill="#3a6a34" font-weight="bold">you keep</text>
+  <text x="800" y="345" font-size="11" fill="#3a6a34" font-weight="bold">your feet</text>
+
+  <!-- bottom: commissioned report -->
+  <rect x="40" y="400" width="830" height="120" rx="10" fill="#fcfcfa" stroke="#b8b8b0" stroke-width="1.5"/>
+  <text x="60" y="428" font-size="15" font-weight="bold" fill="#232323">The coach asks for a season report about you</text>
+  <rect x="60" y="442" width="150" height="62" rx="6" fill="#d5e8d4" stroke="#82b366" stroke-width="2.5"/>
+  <text x="135" y="466" text-anchor="middle" font-size="12" font-weight="bold" fill="#3a6a34">the report</text>
+  <text x="135" y="484" text-anchor="middle" font-size="11" fill="#3a6a34">lives in YOUR house</text>
+  <rect x="260" y="442" width="150" height="62" rx="6" fill="#e1d5e7" stroke="#9673a6" stroke-width="2"/>
+  <text x="335" y="464" text-anchor="middle" font-size="11" font-weight="bold" fill="#4a355c">READING PASS</text>
+  <text x="335" y="480" text-anchor="middle" font-size="9" fill="#4a355c">for: Coach · opens: this report</text>
+  <text x="335" y="494" text-anchor="middle" font-size="9" fill="#4a355c">why: fall season · until: it ends</text>
+  <text x="335" y="518" text-anchor="middle" font-size="11" fill="#4a355c">the coach gets a READING PASS</text>
+  <text x="460" y="462" font-size="12.5" fill="#333">a pass to read it —</text>
+  <text x="460" y="480" font-size="12.5" font-weight="bold" fill="#333">never a hand to carry it off.</text>
+  <text x="460" y="500" font-size="11.5" font-style="italic" fill="#555">season ends → the pass dies by itself → the report stays on your shelf.</text>
+</svg>

--- a/docs/architecture/ariadne/explainers/eli9-7-four-booths.svg
+++ b/docs/architecture/ariadne/explainers/eli9-7-four-booths.svg
@@ -1,0 +1,67 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 500" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="aG" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#4a9a4a"/></marker>
+  </defs>
+  <rect width="900" height="500" fill="#ffffff"/>
+  <text x="450" y="40" text-anchor="middle" font-size="24" font-weight="bold" fill="#1e5f96">Four questions at every door — none does another's job</text>
+
+  <!-- booth template x4 -->
+  <!-- booth 1 -->
+  <rect x="40" y="90" width="190" height="230" rx="10" fill="#f5f5f5" stroke="#8a8a82" stroke-width="2.5"/>
+  <rect x="40" y="90" width="190" height="44" rx="10" fill="#8a8a82"/>
+  <text x="135" y="118" text-anchor="middle" font-size="15" font-weight="bold" fill="#ffffff">1 · WHO ARE YOU?</text>
+  <rect x="88" y="160" width="94" height="50" rx="8" fill="#fff2cc" stroke="#d6b656" stroke-width="2"/>
+  <circle cx="112" cy="185" r="10" fill="none" stroke="#8a6d1a" stroke-width="2.5"/>
+  <rect x="122" y="182" width="34" height="6" rx="3" fill="#8a6d1a"/>
+  <text x="135" y="238" text-anchor="middle" font-size="12" fill="#555">show a key</text>
+  <text x="135" y="266" text-anchor="middle" font-size="11" font-style="italic" fill="#555">keys prove it's you;</text>
+  <text x="135" y="282" text-anchor="middle" font-size="11" font-style="italic" fill="#555">they decide nothing else</text>
+
+  <!-- booth 2 -->
+  <rect x="260" y="90" width="190" height="230" rx="10" fill="#f0e8f4" stroke="#9673a6" stroke-width="2.5"/>
+  <rect x="260" y="90" width="190" height="44" rx="10" fill="#9673a6"/>
+  <text x="355" y="118" text-anchor="middle" font-size="15" font-weight="bold" fill="#ffffff">2 · SHOW THE PASS</text>
+  <rect x="308" y="164" width="94" height="44" rx="6" fill="#e1d5e7" stroke="#9673a6" stroke-width="2"/>
+  <text x="355" y="182" text-anchor="middle" font-size="10" font-weight="bold" fill="#4a355c">PASS</text>
+  <text x="355" y="198" text-anchor="middle" font-size="8.5" fill="#4a355c">who · door · why · until</text>
+  <text x="355" y="238" text-anchor="middle" font-size="12" fill="#4a355c">owner · member pass ·</text>
+  <text x="355" y="254" text-anchor="middle" font-size="12" fill="#4a355c">reading pass · library card</text>
+  <text x="355" y="282" text-anchor="middle" font-size="11" font-style="italic" fill="#555">no pass, no entry —</text>
+  <text x="355" y="298" text-anchor="middle" font-size="11" font-style="italic" fill="#555">however nice you are</text>
+
+  <!-- booth 3 -->
+  <rect x="480" y="90" width="190" height="230" rx="10" fill="#fbeeee" stroke="#b85450" stroke-width="2.5"/>
+  <rect x="480" y="90" width="190" height="44" rx="10" fill="#b85450"/>
+  <text x="575" y="111" text-anchor="middle" font-size="14" font-weight="bold" fill="#ffffff">3 · WHAT DO ITS OWN</text>
+  <text x="575" y="127" text-anchor="middle" font-size="14" font-weight="bold" fill="#ffffff">STICKERS SAY?</text>
+  <rect x="536" y="158" width="78" height="56" rx="5" fill="#ffffff" stroke="#8a8a82" stroke-width="2"/>
+  <circle cx="552" cy="172" r="11" fill="#f8cecc" stroke="#b85450" stroke-width="2"/>
+  <circle cx="578" cy="172" r="11" fill="#dae8fc" stroke="#6c8ebf" stroke-width="1.5"/>
+  <text x="575" y="240" text-anchor="middle" font-size="12" fill="#7a3230">the paper itself votes</text>
+  <text x="575" y="268" text-anchor="middle" font-size="11" font-style="italic" fill="#555">this booth is the whole</text>
+  <text x="575" y="284" text-anchor="middle" font-size="11" font-style="italic" fill="#555">robot story</text>
+
+  <!-- booth 4 -->
+  <rect x="700" y="90" width="190" height="230" rx="10" fill="#fdf3e6" stroke="#d79b00" stroke-width="2.5"/>
+  <rect x="700" y="90" width="190" height="44" rx="10" fill="#d79b00"/>
+  <text x="795" y="118" text-anchor="middle" font-size="15" font-weight="bold" fill="#ffffff">4 · GOT TOKENS?</text>
+  <circle cx="770" cy="180" r="16" fill="#ffe6cc" stroke="#d79b00" stroke-width="2.5"/>
+  <text x="770" y="186" text-anchor="middle" font-size="14" font-weight="bold" fill="#8a5a00">T</text>
+  <circle cx="806" cy="180" r="16" fill="#ffe6cc" stroke="#d79b00" stroke-width="2.5"/>
+  <text x="806" y="186" text-anchor="middle" font-size="14" font-weight="bold" fill="#8a5a00">T</text>
+  <text x="795" y="238" text-anchor="middle" font-size="12" fill="#8a5a00">the arcade machines —</text>
+  <text x="795" y="254" text-anchor="middle" font-size="12" fill="#8a5a00">fancy helpers cost tokens</text>
+  <text x="795" y="282" text-anchor="middle" font-size="11" font-style="italic" fill="#555">no tokens →</text>
+  <text x="795" y="298" text-anchor="middle" font-size="11" font-style="italic" fill="#555">no NEW games</text>
+
+  <path d="M232,205 L256,205" stroke="#4a9a4a" stroke-width="2.5" marker-end="url(#aG)"/>
+  <path d="M452,205 L476,205" stroke="#4a9a4a" stroke-width="2.5" marker-end="url(#aG)"/>
+  <path d="M672,205 L696,205" stroke="#4a9a4a" stroke-width="2.5" marker-end="url(#aG)"/>
+
+  <text x="450" y="356" text-anchor="middle" font-size="13.5" fill="#555">each booth knows ONLY its own question — and none of them have ears: passes in, decisions out, no talking</text>
+
+  <rect x="120" y="386" width="660" height="84" rx="10" fill="#fffde7" stroke="#c8b900" stroke-width="2"/>
+  <text x="450" y="416" text-anchor="middle" font-size="17" font-weight="bold" fill="#4a4a20">Tokens buy machine time — never your own toy box.</text>
+  <text x="450" y="440" text-anchor="middle" font-size="14" fill="#4a4a20">Running out of tokens can stop new games. It can never bolt the front door of the house</text>
+  <text x="450" y="458" text-anchor="middle" font-size="14" fill="#4a4a20">you already own. Your stuff doesn't rent itself back to you.</text>
+</svg>

--- a/docs/architecture/ariadne/explainers/eli9-8-leaving-day.svg
+++ b/docs/architecture/ariadne/explainers/eli9-8-leaving-day.svg
@@ -1,0 +1,63 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 560" font-family="Helvetica, Arial, sans-serif">
+  <rect width="900" height="560" fill="#ffffff"/>
+  <text x="450" y="40" text-anchor="middle" font-size="24" font-weight="bold" fill="#1e5f96">Every goodbye is a torn pass — and the moving-box promise</text>
+
+  <!-- big torn pass icon -->
+  <g transform="translate(450,110)">
+    <path d="M-70,-28 L-6,-28 L-14,-14 L-4,0 L-12,14 L-6,28 L-70,28 Z" fill="#e1d5e7" stroke="#9673a6" stroke-width="2.5" transform="rotate(-4)"/>
+    <path d="M70,-28 L2,-28 L-6,-14 L4,0 L-4,14 L2,28 L70,28 Z" fill="#e1d5e7" stroke="#9673a6" stroke-width="2.5" transform="rotate(5) translate(14,2)"/>
+    <text x="-40" y="6" text-anchor="middle" font-size="10" fill="#4a355c" transform="rotate(-4)">PA</text>
+    <text x="52" y="6" text-anchor="middle" font-size="10" fill="#4a355c" transform="rotate(5)">SS</text>
+  </g>
+  <text x="450" y="172" text-anchor="middle" font-size="13" font-weight="bold" fill="#555">the same small motion, every goodbye</text>
+
+  <!-- four goodbye rows -->
+  <g>
+    <rect x="60" y="200" width="180" height="52" rx="8" fill="#fcfcfa" stroke="#b8b8b0" stroke-width="1.5"/>
+    <text x="150" y="222" text-anchor="middle" font-size="13.5" font-weight="bold" fill="#232323">leaving the club</text>
+    <text x="150" y="240" text-anchor="middle" font-size="10.5" fill="#555">the member pass</text>
+    <rect x="270" y="212" width="56" height="30" rx="4" fill="#e1d5e7" stroke="#9673a6" stroke-width="1.5"/>
+    <line x1="266" y1="208" x2="330" y2="246" stroke="#c0392b" stroke-width="3.5"/>
+    <line x1="330" y1="208" x2="266" y2="246" stroke="#c0392b" stroke-width="3.5"/>
+    <text x="360" y="231" font-size="11.5" fill="#555">club keeps club papers · your house untouched · your skills notebook rides along</text>
+  </g>
+  <g>
+    <rect x="60" y="268" width="180" height="52" rx="8" fill="#fcfcfa" stroke="#b8b8b0" stroke-width="1.5"/>
+    <text x="150" y="290" text-anchor="middle" font-size="13.5" font-weight="bold" fill="#232323">season over</text>
+    <text x="150" y="308" text-anchor="middle" font-size="10.5" fill="#555">reading pass dies by itself</text>
+    <rect x="270" y="280" width="56" height="30" rx="4" fill="#e1d5e7" stroke="#9673a6" stroke-width="1.5"/>
+    <line x1="266" y1="276" x2="330" y2="314" stroke="#c0392b" stroke-width="3.5"/>
+    <line x1="330" y1="276" x2="266" y2="314" stroke="#c0392b" stroke-width="3.5"/>
+    <text x="360" y="299" font-size="11.5" fill="#555">the coach's reading pass expires — the report stays on your shelf</text>
+  </g>
+  <g>
+    <rect x="60" y="336" width="180" height="52" rx="8" fill="#fcfcfa" stroke="#b8b8b0" stroke-width="1.5"/>
+    <text x="150" y="358" text-anchor="middle" font-size="13.5" font-weight="bold" fill="#232323">robot retired</text>
+    <text x="150" y="376" text-anchor="middle" font-size="10.5" fill="#555">its lent passes</text>
+    <rect x="270" y="348" width="56" height="30" rx="4" fill="#e1d5e7" stroke="#9673a6" stroke-width="1.5"/>
+    <line x1="266" y1="344" x2="330" y2="382" stroke="#c0392b" stroke-width="3.5"/>
+    <line x1="330" y1="344" x2="266" y2="382" stroke="#c0392b" stroke-width="3.5"/>
+    <text x="360" y="367" font-size="11.5" fill="#555">it owned nothing, so nothing is stranded — every act still signed in the logbook</text>
+  </g>
+  <g>
+    <rect x="60" y="404" width="180" height="52" rx="8" fill="#fcfcfa" stroke="#b8b8b0" stroke-width="1.5"/>
+    <text x="150" y="426" text-anchor="middle" font-size="13.5" font-weight="bold" fill="#232323">library card expires</text>
+    <text x="150" y="444" text-anchor="middle" font-size="10.5" fill="#555">a pass with a date</text>
+    <rect x="270" y="416" width="56" height="30" rx="4" fill="#e1d5e7" stroke="#9673a6" stroke-width="1.5"/>
+    <line x1="266" y1="412" x2="330" y2="450" stroke="#c0392b" stroke-width="3.5"/>
+    <line x1="330" y1="412" x2="266" y2="450" stroke="#c0392b" stroke-width="3.5"/>
+    <text x="360" y="435" font-size="11.5" fill="#555">the book walks home to its shelf — your book report doesn't move</text>
+  </g>
+
+  <text x="450" y="480" text-anchor="middle" font-size="13" font-style="italic" fill="#555">no boxes, no arguments — nobody ever held anyone else's things, only passes to visit them</text>
+
+  <!-- moving box promise -->
+  <g transform="translate(84,500)">
+    <rect x="0" y="6" width="44" height="30" fill="#f6e0b5" stroke="#b8860b" stroke-width="2"/>
+    <path d="M0,6 L10,-4 L54,-4 L44,6 Z" fill="#fce5cd" stroke="#b8860b" stroke-width="2"/>
+    <line x1="22" y1="6" x2="22" y2="36" stroke="#b8860b" stroke-width="1.5"/>
+  </g>
+  <rect x="150" y="494" width="690" height="52" rx="10" fill="#d5e8d4" stroke="#82b366" stroke-width="2.5"/>
+  <text x="495" y="516" text-anchor="middle" font-size="15" font-weight="bold" fill="#3a6a34">Any day: pack your own house into boxes and go. No switch bolts your own door.</text>
+  <text x="495" y="537" text-anchor="middle" font-size="13" fill="#3a6a34">club papers were never in your house · borrowed books walk home · locked stickers travel locked</text>
+</svg>

--- a/docs/architecture/ariadne/explainers/routing-for-a-nine-year-old.md
+++ b/docs/architecture/ariadne/explainers/routing-for-a-nine-year-old.md
@@ -1,0 +1,199 @@
+# The Robot Helpers and the Sticker Rules
+
+*The agent policy and routing architecture
+(`../tenancy-ownership-access.md` §11, §13), explained the way
+Feynman would insist on: if you can't say it simply, you don't
+understand it yet. Companion to
+[Your House, Their Clubhouse, and the Passes](tenancy-for-a-nine-year-old.md),
+which covers whose things are whose. Grown-up translation table at
+the end.*
+
+---
+
+## The robots never open doors
+
+Your house has robot helpers. They are very smart — and very
+gullible. Anyone who slips a note into a robot's ear can talk it
+into wanting almost anything. That's not the robot being bad; it's
+just how robots are.
+
+So we made one house rule that fixes everything else:
+
+> **Robots never open doors. Robots write request slips.**
+
+When a robot wants to do something — send a letter, spend a dollar,
+show your drawing to a neighbor — it writes exactly what it wants
+on a slip and puts the slip in a mailbox. A very careful, very
+boring doorkeeper reads every slip. The doorkeeper is a robot too —
+but a robot with **no ears**. There is nowhere to whisper into. You
+can hand it a slip, a pass, a sticker: things, never words. It
+cannot be talked into anything, because it cannot be talked to at
+all. It only follows rules.
+
+The smart one proposes. The boring one decides. That's the whole
+trick, and everything else is details.
+
+![Robots write slips; the doorkeeper decides](eli9-1-slips.svg)
+
+## Everything has stickers
+
+Every piece of information in the house wears **stickers**. A
+sticker says three things:
+
+1. **Who put it there.** Mom, the library, grandma's cookbook
+   company. The sticker remembers its owner forever.
+2. **Where this may go.** Stays in your room; stays in the house;
+   may go to school; may go anywhere.
+3. **What it may be used for.** Homework yes, showing off no.
+
+Two sticker laws:
+
+**Glue law.** If you glue two papers together — or copy a bit of
+one onto the other, or write a summary of them — the new paper gets
+**all the stickers from both**. You cannot lose a sticker by
+rewriting the words. A summary of a secret is still a secret.
+
+**Peel law.** Nobody can peel a sticker except the one who put it
+on — and even they must peel it the way they promised in advance:
+maybe "ask me and I'll say yes or no," maybe "it comes off by
+itself next summer," maybe "never." The library's sticker doesn't
+come off because Mom says so, and Mom's doesn't come off because
+the library says so. Every sticker's owner has to be okay with it,
+every time.
+
+There is one honest exception: some sticker-owners approve a
+special **machine** — like a photocopier that blurs out faces. If a
+paper goes through *that exact machine*, certain stickers come off,
+and the machine signs its name saying it did the job properly. The
+robot is never allowed to say "I blurred it, trust me." Only the
+machine's signature counts.
+
+And one more thing about stickers — the sneakiest trap in the whole
+house, closed by the simplest rule: what if a whispered note talks a
+robot into *drawing* a sticker? A fake "may go anywhere," inked right on
+the paper? Nothing happens, because **robots never touch stickers at
+all.** Every paper travels in a clear **envelope**, and stickers
+live on the envelope — and only doorkeepers seal, open, or stamp
+envelopes. When a robot makes a new paper, the doorkeeper envelopes
+it and stamps on the stickers from everything the robot had been
+reading — the glue law is the doorkeeper's job, not the robot's. So
+a sticker a robot draws is just a *picture* of a sticker, on the
+paper, inside the envelope. The doorkeeper reads envelopes. It has
+never once read a picture.
+
+![Stickers: glue law, peel law, and the blur machine](eli9-2-stickers.svg)
+
+## The doorkeeper asks three questions
+
+For every slip, the doorkeeper checks three separate things — and
+all three have to pass:
+
+1. **"Do you have a hall pass for this door?"** You gave each robot
+   its own pass. A pass names what the robot may do, expires on its
+   own, and remembers *why* it exists — so if the reason goes away,
+   the pass dies with it. A robot can lend a smaller pass to a
+   helper robot, but only if its own pass says "lending allowed,"
+   and the lent pass can never be bigger than the original.
+2. **"Do all the stickers allow where this is going?"** Every
+   sticker on everything mentioned in the slip gets a vote. One
+   "stays in the house" sticker means it stays in the house — even
+   if nine other stickers say fine.
+3. **"How big a deal is this?"** Looking at something is small.
+   Writing a draft is small. Mailing a letter, spending money,
+   deleting things — those can't be undone, so they're big. Big
+   deals need a grown-up to say yes first. And the grown-up gets
+   shown *exactly* what will go out the door — never the robot's
+   own summary of it.
+
+The doorkeeper then writes a **receipt**: yes or no, and the
+reasons. If the answer was no, the receipt says which question
+failed. Nobody argues with the doorkeeper by being clever; you
+argue by showing a better hall pass or a peeled sticker.
+
+One more doorkeeper habit, and it matters: passes are checked **at
+the moment the door opens**, not when the robot got in line. If you
+took a robot's pass away while it was standing in line, it still
+gets stopped at the door. "But I was already in line!" doesn't work
+on the boring doorkeeper.
+
+![Three questions at the door; big deals need a grown-up](eli9-3-doorkeeper.svg)
+
+## Picking which helper does the job
+
+Some jobs get sent out to helpers outside the house — some helpers
+are fast, some are cheap, some are brilliant, and some *blab
+everything they hear* or keep copies of what you show them.
+
+Here is the rule that makes routing safe, and it works like
+order of operations in math:
+
+> **First cross off everyone the stickers forbid.
+> Only then pick the best of who's left.**
+
+A paper with a "stays in the house" sticker can never go to the
+neighbor kid — even if he's the smartest helper on the street, even
+if he's free, even if he's standing right there. He was crossed off
+before the contest started. The contest — fastest? cheapest?
+smartest? — only ever happens between helpers the stickers already
+allow.
+
+And if your chosen helper is sick today, you don't just grab the
+next name on the list. You **re-do the crossing-off** for the new
+helper. "The good one was busy" has never once made it okay to
+hand a secret to a blabbermouth.
+
+One more thing the crossing-off knows: **it remembers.** A helper
+who broke a promise last month — kept a copy they swore not to
+keep, took twice as long as the slip allowed — gets crossed off for
+a while too, before the contest, like everyone else the rules
+forbid. Being fast and brilliant buys nothing back until the
+penalty box empties.
+
+![Cross off first, then pick the best](eli9-4-router.svg)
+
+## The blackboard
+
+The robots share a big blackboard where they leave notes for each
+other. Stickers ride on **each note** — not on the blackboard.
+
+So if robot A pins up a note made from secret stuff, and robot B
+never reads that note, robot B's work stays unstickered. B can
+still use the fast outside helper for its own public job. Only the
+robots that actually *read* the secret note carry its stickers
+forward. The blackboard is furniture, not glue.
+
+---
+
+## The same story in grown-up words
+
+| In the story | In the architecture |
+|---|---|
+| the gullible robot | the model / agent — persuadable by any injected text |
+| the request slip | `ProposedTransaction` — the model proposes, never executes |
+| the boring doorkeeper | the deterministic runtime — `decide(…)` |
+| the doorkeeper's missing ears | the runtime accepts only typed inputs (proposals, grants, clauses) — no natural-language surface for injection to grab |
+| stickers live on the envelope, never the paper | the label plane is runtime-maintained metadata — model output is payload only; output clauses are computed from actual inputs, never declared |
+| a drawn sticker is just a picture | in-band "labels" are content; forgery is unrepresentable, and transform receipts are runtime-attested |
+| a sticker | `PolicyClause` — authority + destination constraints + purpose + operations |
+| who put the sticker on | the clause's authority (a tenant, a licensor, a contract) |
+| the glue law | clause union on derivation — labels survive rewriting |
+| the peel law | relaxation modes — every affected authority must authorize, its declared way |
+| the blur machine + signature | `PolicyTransform` — an authority-approved transform run by a trusted capability version, with attestation |
+| the hall pass | `ExecutionGrant` / `Delegation` — scoped, expiring, lineage-bearing |
+| "lending allowed" | `:delegable?` — a separate authority from holding |
+| the three questions | the three planes: authority, information flow, effect |
+| big deals need a grown-up | effect classes; irreversible/high-impact effects require human approval |
+| shown exactly what goes out | approval binds to the rendered payload's hash — and the approver must be allowed to see it |
+| the receipt | `DecisionEnvelope` — allowed?, reason codes, obligations, revision pins |
+| checked when the door opens | commit-time recheck under the freshness contract |
+| cross off, then contest | policy-first routing: eligibility filter before quality/latency/cost ranking |
+| re-do the crossing-off | fallback re-runs eligibility, never just ranking |
+| the crossing-off remembers | breach history is an eligibility input — revocations for cause drop a binding from the candidate set before ranking |
+| stickers on notes, not the blackboard | scoped taint: artifact-level labels; the blackboard is a container, not a flow |
+
+The one-sentence version, suitable for saying out loud:
+
+> **Models propose. Deterministic authority, information-flow, and
+> effect-control systems decide and execute — and choosing the best
+> model only ever happens among the models the rules already
+> allowed.**

--- a/docs/architecture/ariadne/explainers/tenancy-for-a-nine-year-old.md
+++ b/docs/architecture/ariadne/explainers/tenancy-for-a-nine-year-old.md
@@ -1,0 +1,338 @@
+# Your House, Their Clubhouse, and the Passes
+
+*The tenancy, ownership, and rights architecture
+(`../tenancy-ownership-access.md` §1–§10, §12), explained simply —
+in the same world as
+[The Robot Helpers and the Sticker Rules](routing-for-a-nine-year-old.md).
+Same house, same doorkeeper, same stickers; this story is about
+whose things are whose. Together the two stories are the simplicity
+invariant: if a future change to the architecture cannot be told in
+the story, the change is suspect. Grown-up translation table at the
+end.*
+
+---
+
+## Everyone has a house
+
+You remember the house with the robot helpers and the boring
+doorkeeper. Now zoom out: **everyone has a house of their own.**
+Everything you have lives in your house — your drawings, your
+report cards, your skills notebook. That is what "yours" *means*
+here: **every single thing lives in exactly one house.** First
+rule; it never bends.
+
+Clubs have buildings too. The soccer club's clubhouse holds the
+club's own things — the rulebook, the bulletin board, the game
+plans. A clubhouse isn't fancier than a house; it's just a house
+that a club owns.
+
+And every door everywhere — your house, the clubhouse, the coach's
+office, the library desk, the gate to the practice field — has a
+**doorkeeper** standing at it. Here's the doorkeepers' secret, and
+it's the whole trick of this world: they're robots too, but a
+special kind — **no ears, just a pass slot.** You can hand a
+doorkeeper a pass. You cannot talk to one. Nobody has ever talked a
+doorkeeper into anything, because nobody has ever talked *to* a
+doorkeeper at all.
+
+## Joining a club prints passes. It never moves houses
+
+Nobody walks through anyone else's door without a **pass**. You've
+seen passes already — the robots carry them. A pass always says
+four things: *who* it's for, *which door or shelf* it opens, *why
+it exists*, and *when it expires*. If the why goes away, the pass
+dies with it.
+
+So what is "joining the soccer club"? The club prints **you** a
+member pass — it opens the practice field, the bulletin board room,
+and the bin of club balls. Sometimes the club pays for everything:
+club balls, club uniforms. You use them there, through your pass.
+They never come home as yours.
+
+And then you *play*. Here's the part that matters: **the season is
+a thing you do together, on the field.** The coach sees your corner
+kicks because the coach was standing right there coaching them —
+not because anyone opened a door into your house. Playing together
+is its own shared place, and everyone in it sees what happens in
+it. Nobody needs a pass into anybody's house to play on a team.
+
+Now bring **your own ball** to practice. The moment you toss it
+onto the field, you've minted a little pass without saying a word:
+*the team may use my ball — during practice.* Practice ends, the
+ball goes home with you. It was never the club's, not even a
+little, no matter how many teammates kicked it. **Used-by-everyone
+never means owned-by-the-club.** And if you'd rather not bring it
+tomorrow, you just… don't. That's the whole revocation.
+
+Notice what never happened in any of this: your house did not get
+picked up and craned into the clubhouse. Nothing of yours moved
+anywhere, and nobody got a pass into your house at all. Joining a
+club is **printing passes, never moving houses** — and that's why
+leaving will be easy later. A thing that never moved in never has
+to move out.
+
+![Everyone has a house; joining prints passes](eli9-5-houses.svg)
+
+One small thing about you and your keys: you might have a front
+door key, a spare at grandma's, a new one after you lost the old
+one. Keys prove it's *you* at the door. Losing a key, or adding
+one, never changes whose house it is.
+
+And the robots? Robots work everywhere in this world — your robots,
+the club's robots, even a robot you rent for an afternoon. Here's
+the thing that surprises grown-ups: **it never matters who owns the
+robot.** Robots own nothing and hold nothing of their own — a robot
+working for you works on passes lent from yours (smaller ones, and
+only if yours say "lending allowed" — you know this from the robot
+story). Whose robot did the work never decides whose stuff the
+work is. The passes and the slips decide.
+
+## Whose paper is it?
+
+Whose is a paper? **It belongs to the place where it was made** —
+copies may travel later, but belonging doesn't:
+
+- The game plans and the coach's notes get written at the coach's
+  desk, in the coach's office. Club papers, belonging to the club.
+  And notice a detail: **your member pass doesn't open the coach's
+  office.** Being in the club never meant every club door — the
+  office door has a doorkeeper like every other, and it won't take
+  your member pass. "But I'm on the team!" lands on nothing,
+  because doorkeepers have no ears.
+- Your drawings and projects get made at your house. Yours.
+
+Nobody stands sorting paper by paper. **Where it was made
+decides.** That's the whole rule, so there's never an argument
+about any single paper.
+
+When the forward game plan is *finished*, the coach walks out and
+hands the forwards their copies. That's the club **choosing** to
+share a club paper: the copy was made *for you*, so your copy comes
+home to your house — wearing the club's sticker — "team eyes only" —
+which rides wherever the copy goes (glue law). The original never
+left the coach's desk. And the coach's notes? Those may never be
+handed out at all — some club papers no member ever sees. (Years
+from now the coach might give their old notebook to their kid who's
+becoming a coach. That's the owner giving the *thing itself* away —
+always the owner's to do, and nobody else's.)
+
+But here is the most important rule in the whole story:
+
+> **What you learned is always yours.**
+
+You got better at soccer *at the club*, with *club drills*, on
+*club fields*. Doesn't matter. "I can bend a corner kick" goes in
+the skills notebook in **your** house, forever. The club keeps its
+drill sheets; you keep your feet. When you're twenty and trying out
+somewhere new, that notebook is what you bring — that's what a
+skills notebook is *for*.
+
+One catch, and it's fair: if what you learned includes a club
+secret — the special play nobody else knows — the secret's sticker
+rides along in your notebook (glue law, from the robot story). The
+skill is yours to keep; the secret detail is still the club's to
+unlock. Yours to have, theirs to gate.
+
+And when the coach asks for a season report about you? The report
+is about you, for your growing up — so it lives in **your** house.
+The coach gets a **reading pass** to that one report, through the
+season. A pass to read it — never a hand to carry it off. Season
+ends, pass dies, report stays.
+
+![Where it was made decides; what you learned is always yours](eli9-6-whose-paper.svg)
+
+## The doorkeeper's four questions
+
+At every door, every time, the doorkeeper asks four questions. Each
+question is its own question — on purpose, so no answer can be
+stretched to cover another:
+
+1. **"Who are you?"** Show a key. Keys prove it's you; they decide
+   nothing else.
+2. **"Show the pass for THIS door."** Owner of the house? That's
+   the deepest pass there is. Member pass, reading pass, library
+   card — each opens exactly what it names. No pass, no entry,
+   however nice you are.
+3. **"What do the thing's own stickers say?"** Even inside a door
+   your pass opens, each paper votes for itself — where it may go,
+   what it may be used for. (This question is the whole robot
+   story.)
+4. **"Tokens, for the big machines?"** The fancy helpers cost
+   tokens to run. No tokens, no new machine time.
+
+And the token rule has a hard edge worth saying twice: **tokens buy
+machine time, never your own house.** Running out of tokens can
+stop new jobs. It can never, ever bolt your own front door against
+you. Your stuff doesn't rent itself back to you.
+
+![Four questions at every door](eli9-7-four-booths.svg)
+
+## Borrowed things
+
+The library book on your shelf is *in* your house — but it isn't
+*yours*. Holding a thing was never the same as owning it.
+
+Your **library card is a pass with a date on it**: you to the
+library, until June. Through it you may read the book, learn from
+it, write a book report. When the card expires, the book goes home
+to its shelf — every page. You never got to photocopy it, so
+there's nothing to sneak.
+
+But your **book report is yours.** That's what lending a book
+*means*: read, learn, make something of your own. The report stays
+in your house; the book goes back. (If the library had a special
+rule — "no quoting page 12" — that sticker rides on your report.
+Glue law, as always.)
+
+And the comic you found on the street? It's *somebody's*. You don't
+know whose, and "I found it" doesn't make it yours. Read it today,
+fine; copy it into your own zine, no — not unless a grown-up checks
+and writes down that it's really free to use. Not knowing the owner
+makes you *more* careful, not less.
+
+## Mary's hall pass
+
+A pass is a deal in both directions — and the rules ride on the
+pass. Mary got a hall pass at school: *bathroom, and back.* But the
+school store was right there, and candy bars are candy bars. So
+instead of going back to class she went to the store, bought one,
+and ate the whole thing before strolling back — half a class
+later.
+
+Here's the thing: **no doorkeeper could have stopped her.** Her
+pass was real. The hallway was allowed. Every door she passed did
+exactly its job. She got caught anyway — at turn-in. The logbook
+had the store door's stamp and the times, and stamps and times
+don't lie. Gates stop what they can. **Logbooks catch the rest.**
+
+And then two things happened, and only the first one is the usual
+one. The pass was done — fine, it was done anyway. But also: **no
+hall passes for Mary for the rest of the semester.** Breaking a
+pass's rules doesn't just end that pass. It changes whether you get
+the *next* one.
+
+The library plays the same game with bigger stakes. Keep the book
+past your card's date and the library does exactly the thing you
+agreed to when they handed you the card: a fine, and no new
+borrowing until it's paid. Nobody's surprised — the deal was on the
+card the whole time. Sometimes the consequence of breaking a deal
+is more than a torn-up pass, and you signed up for it on the day
+you took the pass.
+
+## Sneaky Bob
+
+Sneaky Bob has boxes he'd rather not keep at his own house — if
+anyone ever comes asking, he wants them found at *yours*. So he
+gets clever.
+
+First he tries fake envelopes: official-looking stamps that say
+"this belongs at Alice's house." The doorkeeper doesn't even look
+up. An envelope means something only when a doorkeeper's *own*
+stamp is on it, and stamps happen at doors, when a pass is shown.
+Bob has no pass to your house. There is no envelope he can bring
+that substitutes for one.
+
+So he tries the porch. Every house has one open spot on purpose —
+the delivery porch, where people can leave things for you. At three
+in the morning, Bob dumps his boxes there. But here's the porch
+rule: **nothing becomes yours just because it showed up.** Things
+on the porch are marked *delivered — not accepted*, and the
+doorkeeper's logbook records exactly when each one arrived and who
+left it (or that no pass was shown at all). You take a thing
+inside, or you don't. Sweep it off the porch, and it was never
+yours for a single minute.
+
+And the frame-up itself? It dies at the **logbook**. Every single
+thing inside your house has a line in the doorkeeper's own
+handwriting: who brought it, through which door, with which pass.
+Bob can't write in the logbook. Nobody can — it's the doorkeeper's
+hand or nothing. So when the police come asking, they don't read
+piles; they read logbooks. The logbook is the end of Sneaky Bob.
+
+Notice this is the library rule's mirror: holding a thing was never
+the same as owning it — and being *handed* a thing was never the
+same as answering for it.
+
+## Goodbyes, and the moving-box promise
+
+Watch how many different goodbyes turn out to be the same small
+thing — **a pass gets torn up:**
+
+- Leaving the club? Your member pass — torn. The club balls stay
+  in their bin.
+- Season over? The field goes quiet; the coach's reading pass dies
+  on its own; the report stays on your shelf. Your ball is already
+  home — it always was.
+- Robot retired? Its lent passes — torn. It owned nothing, so
+  nothing is stranded.
+- Library card expired? The book walks home to its shelf; your
+  report doesn't move.
+
+No boxes, no arguments, nothing carried anywhere. Nobody ever
+*held* anyone else's things — only passes to visit them. Tear the
+pass and the visit is over; every house still holds exactly what it
+always held.
+
+And the last rule, the one this whole story protects:
+
+> **Any day you like, you can pack your own house into moving boxes
+> and go. There is no switch, anywhere, that bolts your own door
+> against you.**
+
+Not a club rule, not fine print, nothing — on purpose. If such a
+switch existed, every club would demand it be flipped, and then it
+wouldn't be your house anymore. And packing is simple, because the
+first rule did all the work: club papers were never in your house.
+Borrowed books walk home. Stickers with locks travel still locked.
+There is nothing in your boxes that belongs to anyone else — which
+is exactly why no one gets a say about your boxes.
+
+![Every goodbye is a torn pass; the moving-box promise](eli9-8-leaving-day.svg)
+
+---
+
+## The same story in grown-up words
+
+| In the story | In the architecture |
+|---|---|
+| your house | a personal tenant — a person IS a tenant; every record has exactly one owner (A1, A2) |
+| the clubhouse | an organizational tenant — structurally the same, owned by a club |
+| a pass (who · which door · why · until) | a relation/grant — scoped, expiring, lineage-bearing; membership is a relation, never containment (A3) |
+| the season, played together on the field | an engagement object — a shared process; org roles see engagement things, never the inside of your house |
+| bringing your ball to practice | an owner-granted, activity-scoped grant — implicit, auto-expiring; use never transfers ownership |
+| the club pays for everything | org-owned assets, used through membership; they never become yours |
+| "the why goes away, the pass dies" | grant lineage — authorization requires a still-valid basis |
+| keys | credentials authenticating a principal; `#controller` relations bind them to the tenant |
+| whose robot never matters | agents are tenant-less principals; outputs follow ownership rules, not robot ownership |
+| papers live where they're made | creation-context provenance — the creating context stamps the owner |
+| the coach's office your pass doesn't open | org-interior workspaces and records — membership never means all-access |
+| being handed the finished game plan | an org sharing its asset: your copy carries the club's clause ("team eyes only") |
+| the coach's notes, never handed out | org-internal records members never see |
+| nobody sorts paper by paper | no per-record adjudication on the normal path |
+| "what you learned is always yours" | the IP boundary: claims and profile are personal-owned, always — the resume norm |
+| the secret's sticker rides along | inherited disclosure clauses gate details without changing ownership |
+| the coach's reading pass | `#commissioner` / `#viewer` relations — commissioning grants visibility, not ownership |
+| the four questions | the four layers: authentication, authorization, disclosure & processing, entitlement |
+| a doorkeeper at every door | every boundary crossing is a policy decision point |
+| Sneaky Bob's fake envelopes | forged ownership/provenance fails runtime attestation — labels are stamped only at authorized doors |
+| the delivery porch | push-capable intake is quarantine: custody-pending until the owner (or the owner's standing rule) accepts — delivery is not acceptance |
+| the doorkeeper's logbook | every record carries its runtime-written creating context (principal, channel, revision) — the audit trail attributes the act, not mere possession |
+| Mary's candy-bar detour | grants are purpose-bound; adherence that can't be gated in the moment is audited via receipts and the provenance log |
+| no hall passes this semester | breach degrades the grantor's future granting policy for that grantee — not just the instance |
+| the fine that was on the card all along | pre-agreed remedies ride the grant's terms; for non-resident authorities the system supplies attested evidence, not enforcement |
+| gates stop what they can; logbooks catch the rest | prevention at decision points + detection at reconciliation — both required |
+| doorkeepers have no ears | the policy runtime accepts only typed inputs (passes, slips, stickers) — no natural-language surface, so injection has nothing to grab |
+| tokens never bolt your door | entitlement gates compute, never data |
+| the library card with a date | a license as a relation object, time-boxed — access routes through it |
+| the book goes home; the report stays | expiry quarantines/purges licensed payloads; term-driven derivation keeps your analytics |
+| "no quoting page 12" rides the report | license clauses ride derived work — `PolicyTransform` is the only legitimate way off |
+| the street comic | third-party-unknown intake — public is not public domain; upgrades are recorded human determinations |
+| every goodbye is a torn pass | one revocation mechanism: cut the relation; runtime enforcement completes it |
+| the moving-box promise | the takeaway export — always available, hard policy, no configuration surface |
+| what's not in the boxes | ownership filter, then rights filter, then exportability — clean by construction |
+
+And the two stories snap together without a seam: houses and passes
+say *whose things are whose and who may visit*; slips and stickers
+say *how anything gets done without trusting the persuadable part*.
+The doorkeeper is the same doorkeeper. That's the entire
+architecture.

--- a/docs/architecture/ariadne/explainers/the-robot-helpers-and-the-sticker-rules.html
+++ b/docs/architecture/ariadne/explainers/the-robot-helpers-and-the-sticker-rules.html
@@ -1,0 +1,429 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>The Robot Helpers and the Sticker Rules — miniforge.ai</title>
+  <meta name="description" content="Miniforge's agent policy and routing architecture, explained simply: slips, stickers, doorkeepers, and picking helpers.">
+  <link rel="canonical" href="https://miniforge.ai/architectures/eli9-robot-helpers-sticker-rules">
+  <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
+</head>
+<body>
+<div style="max-width:640px;margin:0 auto 28px;font-family:Menlo,Consolas,monospace;font-size:12px;letter-spacing:.08em">
+<a href="/architectures" style="color:#ff5e1a;text-decoration:none">&larr; MINIFORGE.AI // DRAWING REGISTER</a>
+</div>
+
+<style>
+:root { --bg:#faf9f6; --ink:#26221c; --sub:#6a635a; --accent:#ff5e1a; --card:#ffffff; --line:#e0dcd4; }
+@media (prefers-color-scheme: dark) { :root { --bg:#1c1a17; --ink:#ece8e0; --sub:#a49c90; --card:#26231e; --line:#3a362f; } }
+:root[data-theme="dark"] { --bg:#1c1a17; --ink:#ece8e0; --sub:#a49c90; --card:#26231e; --line:#3a362f; }
+:root[data-theme="light"] { --bg:#faf9f6; --ink:#26221c; --sub:#6a635a; --card:#ffffff; --line:#e0dcd4; }
+body { background:var(--bg); color:var(--ink); font-family:Georgia, 'Times New Roman', serif; margin:0; padding:40px 20px 80px; line-height:1.65; }
+h1 { font-family:Helvetica, Arial, sans-serif; color:var(--accent); font-size:34px; text-align:center; max-width:700px; margin:0 auto 8px; text-wrap:balance; }
+h2 { font-family:Helvetica, Arial, sans-serif; color:var(--accent); font-size:23px; max-width:640px; margin:44px auto 8px; }
+p, blockquote { max-width:640px; margin:14px auto; font-size:17px; }
+p.li { margin:8px auto; padding-left:1.2em; }
+em { color:var(--sub); }
+blockquote { border-left:4px solid var(--accent); padding:10px 20px; background:var(--card); border-radius:0 8px 8px 0; font-size:18px; }
+code { font-family:Menlo, Consolas, monospace; font-size:.85em; background:rgba(30,95,150,.12); padding:1px 5px; border-radius:4px; }
+hr { border:none; border-top:1px solid var(--line); max-width:640px; margin:40px auto; }
+.fig { max-width:960px; margin:26px auto; background:#ffffff; border:1px solid var(--line); border-radius:10px; padding:10px; overflow-x:auto; }
+.fig svg { display:block; min-width:760px; width:100%; height:auto; }
+.twrap { max-width:860px; margin:20px auto; overflow-x:auto; background:#ffffff; border:1px solid var(--line); border-radius:8px; }
+table { border-collapse:collapse; width:100%; font-family:Helvetica, Arial, sans-serif; font-size:13.5px; color:#26221c; }
+th, td { text-align:left; padding:8px 12px; border-bottom:1px solid #e8e4dc; }
+th { background:#f0eee8; }
+</style>
+<h1>The Robot Helpers and the Sticker Rules</h1>
+<p><em>The agent policy and routing architecture (<code>../tenancy-ownership-access.md</code> §11, §13), explained the way Feynman would insist on: if you can't say it simply, you don't understand it yet. Companion to Your House, Their Clubhouse, and the Passes, which covers whose things are whose. Grown-up translation table at the end.</em></p>
+<hr>
+<h2>The robots never open doors</h2>
+<p>Your house has robot helpers. They are very smart — and very gullible. Anyone who slips a note into a robot's ear can talk it into wanting almost anything. That's not the robot being bad; it's just how robots are.</p>
+<p>So we made one house rule that fixes everything else:</p>
+<blockquote><strong>Robots never open doors. Robots write request slips.</strong></blockquote>
+<p>When a robot wants to do something — send a letter, spend a dollar, show your drawing to a neighbor — it writes exactly what it wants on a slip and puts the slip in a mailbox. A very careful, very boring doorkeeper reads every slip. The doorkeeper is a robot too — but a robot with <strong>no ears</strong>. There is nowhere to whisper into. You can hand it a slip, a pass, a sticker: things, never words. It cannot be talked into anything, because it cannot be talked to at all. It only follows rules.</p>
+<p>The smart one proposes. The boring one decides. That's the whole trick, and everything else is details.</p>
+<p></p><div class="fig"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 520" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="fig1-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#3a76b8"/></marker>
+    <marker id="fig1-ar" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#c0392b"/></marker>
+  </defs>
+  <rect width="900" height="520" fill="#ffffff"/>
+  <text x="450" y="42" text-anchor="middle" font-size="24" font-weight="bold" fill="#1e5f96">Robots never open doors. Robots write slips.</text>
+
+  <!-- robot -->
+  <line x1="150" y1="120" x2="150" y2="102" stroke="#d6b656" stroke-width="3"/>
+  <circle cx="150" cy="96" r="7" fill="#d79b00"/>
+  <rect x="110" y="120" width="80" height="64" rx="14" fill="#fff2cc" stroke="#d6b656" stroke-width="2.5"/>
+  <circle cx="136" cy="146" r="7" fill="#232323"/>
+  <circle cx="164" cy="146" r="7" fill="#232323"/>
+  <path d="M134,166 Q150,176 166,166" stroke="#232323" stroke-width="2.5" fill="none"/>
+  <rect x="118" y="192" width="64" height="52" rx="10" fill="#fff2cc" stroke="#d6b656" stroke-width="2.5"/>
+  <text x="150" y="276" text-anchor="middle" font-size="16" font-weight="bold" fill="#8a6d1a">the robot</text>
+  <text x="150" y="296" text-anchor="middle" font-size="13" fill="#8a6d1a">very smart, very gullible</text>
+
+  <!-- whisper note -->
+  <path d="M60,120 Q40,150 62,178" stroke="#c0392b" stroke-width="2" fill="none" stroke-dasharray="5 4" marker-end="url(#fig1-ar)"/>
+  <text x="52" y="106" font-size="13" fill="#c0392b">someone whispers</text>
+  <text x="52" y="122" font-size="13" fill="#c0392b">a sneaky note…</text>
+
+  <!-- slip -->
+  <rect x="255" y="140" width="170" height="110" rx="8" fill="#ffffff" stroke="#8a8a82" stroke-width="2" transform="rotate(-3 340 195)"/>
+  <text x="340" y="170" text-anchor="middle" font-size="15" font-weight="bold" fill="#232323" transform="rotate(-3 340 195)">REQUEST SLIP</text>
+  <text x="340" y="196" text-anchor="middle" font-size="14" fill="#333" transform="rotate(-3 340 195)">mail my drawing</text>
+  <text x="340" y="216" text-anchor="middle" font-size="14" fill="#333" transform="rotate(-3 340 195)">to Grandma</text>
+  <path d="M196,190 L250,190" stroke="#3a76b8" stroke-width="2.5" marker-end="url(#fig1-a)"/>
+  <text x="223" y="180" text-anchor="middle" font-size="13" fill="#3a76b8">writes</text>
+
+  <!-- mailbox -->
+  <rect x="470" y="150" width="90" height="66" rx="14" fill="#dae8fc" stroke="#6c8ebf" stroke-width="2.5"/>
+  <rect x="500" y="172" width="46" height="8" rx="4" fill="#6c8ebf"/>
+  <rect x="505" y="216" width="14" height="52" fill="#6c8ebf"/>
+  <text x="515" y="292" text-anchor="middle" font-size="14" fill="#3a5a80">the mailbox</text>
+  <path d="M432,195 L466,187" stroke="#3a76b8" stroke-width="2.5" marker-end="url(#fig1-a)"/>
+
+  <!-- doorkeeper -->
+  <rect x="620" y="122" width="76" height="24" rx="6" fill="#8a8a82"/>
+  <circle cx="658" cy="164" r="24" fill="#f5f5f5" stroke="#8a8a82" stroke-width="2.5"/>
+  <circle cx="649" cy="160" r="3.5" fill="#232323"/>
+  <circle cx="667" cy="160" r="3.5" fill="#232323"/>
+  <line x1="649" y1="175" x2="667" y2="175" stroke="#232323" stroke-width="2.5"/>
+  <rect x="626" y="190" width="64" height="70" rx="10" fill="#f5f5f5" stroke="#8a8a82" stroke-width="2.5"/>
+  <rect x="700" y="196" width="58" height="72" rx="5" fill="#fffde7" stroke="#c8b900" stroke-width="2"/>
+  <text x="729" y="216" text-anchor="middle" font-size="11" fill="#4a4a20">RULES</text>
+  <line x1="708" y1="228" x2="750" y2="228" stroke="#c8b900" stroke-width="2"/>
+  <line x1="708" y1="242" x2="750" y2="242" stroke="#c8b900" stroke-width="2"/>
+  <line x1="708" y1="256" x2="750" y2="256" stroke="#c8b900" stroke-width="2"/>
+  <text x="658" y="292" text-anchor="middle" font-size="16" font-weight="bold" fill="#555">the doorkeeper</text>
+  <text x="658" y="312" text-anchor="middle" font-size="13" fill="#555">a robot with NO EARS — just</text>
+  <text x="658" y="328" text-anchor="middle" font-size="13" fill="#555">a pass slot. things, never words.</text>
+  <path d="M562,190 L616,190" stroke="#3a76b8" stroke-width="2.5" marker-end="url(#fig1-a)"/>
+  <text x="589" y="180" text-anchor="middle" font-size="13" fill="#3a76b8">reads</text>
+
+  <!-- door -->
+  <rect x="800" y="120" width="70" height="150" rx="8" fill="#d5e8d4" stroke="#82b366" stroke-width="3"/>
+  <circle cx="856" cy="196" r="6" fill="#82b366"/>
+  <text x="835" y="310" text-anchor="middle" font-size="14" fill="#3a6a34">the door</text>
+  <path d="M760,200 L796,196" stroke="#3a76b8" stroke-width="2.5" marker-end="url(#fig1-a)"/>
+  <text x="726" y="292" font-size="13" fill="#4a9a4a">opens only if</text>
+  <text x="726" y="308" font-size="13" fill="#4a9a4a">the rules say yes</text>
+
+  <!-- forbidden direct path -->
+  <path d="M150,340 C400,420 680,410 862,282" stroke="#c0392b" stroke-width="2.5" fill="none" stroke-dasharray="8 6" marker-end="url(#fig1-ar)"/>
+  <line x1="470" y1="360" x2="520" y2="410" stroke="#c0392b" stroke-width="5"/>
+  <line x1="520" y1="360" x2="470" y2="410" stroke="#c0392b" stroke-width="5"/>
+  <text x="495" y="444" text-anchor="middle" font-size="16" font-weight="bold" fill="#c0392b">a robot touching a door directly: never happens</text>
+
+  <rect x="120" y="466" width="660" height="40" rx="8" fill="#fffde7" stroke="#c8b900" stroke-width="1.5"/>
+  <text x="450" y="492" text-anchor="middle" font-size="16" fill="#4a4a20">The smart one proposes. The boring one decides. That's the whole trick.</text>
+</svg>
+</div><p></p>
+<h2>Everything has stickers</h2>
+<p>Every piece of information in the house wears <strong>stickers</strong>. A sticker says three things:</p>
+<p class="li"><strong>Who put it there.</strong> Mom, the library, grandma's cookbook company. The sticker remembers its owner forever.</p>
+<p class="li"><strong>Where this may go.</strong> Stays in your room; stays in the house; may go to school; may go anywhere.</p>
+<p class="li"><strong>What it may be used for.</strong> Homework yes, showing off no.</p>
+<p>Two sticker laws:</p>
+<p><strong>Glue law.</strong> If you glue two papers together — or copy a bit of one onto the other, or write a summary of them — the new paper gets <strong>all the stickers from both</strong>. You cannot lose a sticker by rewriting the words. A summary of a secret is still a secret.</p>
+<p><strong>Peel law.</strong> Nobody can peel a sticker except the one who put it on — and even they must peel it the way they promised in advance: maybe "ask me and I'll say yes or no," maybe "it comes off by itself next summer," maybe "never." The library's sticker doesn't come off because Mom says so, and Mom's doesn't come off because the library says so. Every sticker's owner has to be okay with it, every time.</p>
+<p>There is one honest exception: some sticker-owners approve a special <strong>machine</strong> — like a photocopier that blurs out faces. If a paper goes through <em>that exact machine</em>, certain stickers come off, and the machine signs its name saying it did the job properly. The robot is never allowed to say "I blurred it, trust me." Only the machine's signature counts.</p>
+<p>And one more thing about stickers — the sneakiest trap in the whole house, closed by the simplest rule: what if a whispered note talks a robot into <em>drawing</em> a sticker? A fake "may go anywhere," inked right on the paper? Nothing happens, because <strong>robots never touch stickers at all.</strong> Every paper travels in a clear <strong>envelope</strong>, and stickers live on the envelope — and only doorkeepers seal, open, or stamp envelopes. When a robot makes a new paper, the doorkeeper envelopes it and stamps on the stickers from everything the robot had been reading — the glue law is the doorkeeper's job, not the robot's. So a sticker a robot draws is just a <em>picture</em> of a sticker, on the paper, inside the envelope. The doorkeeper reads envelopes. It has never once read a picture.</p>
+<p></p><div class="fig"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 560" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="fig2-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#3a76b8"/></marker>
+  </defs>
+  <rect width="900" height="560" fill="#ffffff"/>
+  <text x="450" y="42" text-anchor="middle" font-size="24" font-weight="bold" fill="#1e5f96">Everything wears stickers — and stickers never lie</text>
+
+  <!-- GLUE LAW -->
+  <text x="60" y="86" font-size="18" font-weight="bold" fill="#232323">The glue law</text>
+
+  <rect x="60" y="100" width="150" height="120" rx="6" fill="#ffffff" stroke="#8a8a82" stroke-width="2"/>
+  <line x1="76" y1="130" x2="194" y2="130" stroke="#c8c8c0" stroke-width="2"/>
+  <line x1="76" y1="150" x2="194" y2="150" stroke="#c8c8c0" stroke-width="2"/>
+  <line x1="76" y1="170" x2="160" y2="170" stroke="#c8c8c0" stroke-width="2"/>
+  <circle cx="90" cy="112" r="16" fill="#dae8fc" stroke="#6c8ebf" stroke-width="2"/>
+  <text x="90" y="117" text-anchor="middle" font-size="11" font-weight="bold" fill="#274b73">MOM</text>
+  <text x="135" y="210" text-anchor="middle" font-size="12" fill="#555">"stays in the house"</text>
+
+  <text x="240" y="168" font-size="30" font-weight="bold" fill="#555">+</text>
+
+  <rect x="280" y="100" width="150" height="120" rx="6" fill="#ffffff" stroke="#8a8a82" stroke-width="2"/>
+  <line x1="296" y1="130" x2="414" y2="130" stroke="#c8c8c0" stroke-width="2"/>
+  <line x1="296" y1="150" x2="414" y2="150" stroke="#c8c8c0" stroke-width="2"/>
+  <line x1="296" y1="170" x2="380" y2="170" stroke="#c8c8c0" stroke-width="2"/>
+  <circle cx="310" cy="112" r="16" fill="#ffe6cc" stroke="#d79b00" stroke-width="2"/>
+  <text x="310" y="117" text-anchor="middle" font-size="9" font-weight="bold" fill="#8a5a00">LIBR.</text>
+  <text x="355" y="210" text-anchor="middle" font-size="12" fill="#555">"back by June"</text>
+
+  <path d="M446,160 L492,160" stroke="#3a76b8" stroke-width="3" marker-end="url(#fig2-a)"/>
+  <text x="469" y="148" text-anchor="middle" font-size="13" fill="#3a76b8">glue, copy,</text>
+  <text x="469" y="184" text-anchor="middle" font-size="13" fill="#3a76b8">or summarize</text>
+
+  <rect x="510" y="92" width="180" height="136" rx="6" fill="#fffdf5" stroke="#8a8a82" stroke-width="2.5"/>
+  <line x1="528" y1="130" x2="672" y2="130" stroke="#c8c8c0" stroke-width="2"/>
+  <line x1="528" y1="150" x2="672" y2="150" stroke="#c8c8c0" stroke-width="2"/>
+  <line x1="528" y1="170" x2="672" y2="170" stroke="#c8c8c0" stroke-width="2"/>
+  <line x1="528" y1="190" x2="620" y2="190" stroke="#c8c8c0" stroke-width="2"/>
+  <circle cx="544" cy="108" r="16" fill="#dae8fc" stroke="#6c8ebf" stroke-width="2"/>
+  <text x="544" y="113" text-anchor="middle" font-size="11" font-weight="bold" fill="#274b73">MOM</text>
+  <circle cx="584" cy="108" r="16" fill="#ffe6cc" stroke="#d79b00" stroke-width="2"/>
+  <text x="584" y="113" text-anchor="middle" font-size="9" font-weight="bold" fill="#8a5a00">LIBR.</text>
+  <text x="600" y="244" text-anchor="middle" font-size="13" font-weight="bold" fill="#333">the new paper wears BOTH</text>
+  <text x="600" y="262" text-anchor="middle" font-size="12" fill="#555">a summary of a secret is still a secret</text>
+
+  <!-- PEEL LAW -->
+  <text x="60" y="316" font-size="18" font-weight="bold" fill="#232323">The peel law</text>
+  <rect x="60" y="330" width="360" height="120" rx="8" fill="#fcfcfa" stroke="#b8b8b0" stroke-width="1.5"/>
+  <circle cx="110" cy="372" r="20" fill="#ffe6cc" stroke="#d79b00" stroke-width="2"/>
+  <text x="110" y="377" text-anchor="middle" font-size="10" font-weight="bold" fill="#8a5a00">LIBR.</text>
+  <text x="150" y="360" font-size="13" fill="#333">only the LIBRARY peels the library sticker —</text>
+  <text x="150" y="378" font-size="13" fill="#333">and only the way it promised in advance:</text>
+  <text x="150" y="398" font-size="13" fill="#8a5a00" font-weight="bold">"ask me" · "off by itself in June" · "never"</text>
+  <text x="150" y="426" font-size="12.5" fill="#c0392b" font-weight="bold">Mom can't peel it. You can't peel it. Every</text>
+  <text x="150" y="442" font-size="12.5" fill="#c0392b" font-weight="bold">sticker's owner must be okay — every time.</text>
+
+  <!-- BLUR MACHINE -->
+  <text x="470" y="316" font-size="18" font-weight="bold" fill="#232323">The one honest exception: the approved machine</text>
+  <rect x="470" y="330" width="410" height="120" rx="8" fill="#fcfcfa" stroke="#b8b8b0" stroke-width="1.5"/>
+  <rect x="490" y="356" width="60" height="70" rx="4" fill="#ffffff" stroke="#8a8a82" stroke-width="2"/>
+  <circle cx="504" cy="368" r="10" fill="#dae8fc" stroke="#6c8ebf" stroke-width="1.5"/>
+  <circle cx="528" cy="368" r="10" fill="#f8cecc" stroke="#b85450" stroke-width="1.5"/>
+  <path d="M556,390 L588,390" stroke="#3a76b8" stroke-width="2.5" marker-end="url(#fig2-a)"/>
+  <rect x="592" y="352" width="96" height="78" rx="10" fill="#e1d5e7" stroke="#9673a6" stroke-width="2.5"/>
+  <text x="640" y="384" text-anchor="middle" font-size="13" font-weight="bold" fill="#4a355c">BLUR-O-</text>
+  <text x="640" y="402" text-anchor="middle" font-size="13" font-weight="bold" fill="#4a355c">MATIC</text>
+  <path d="M692,390 L724,390" stroke="#3a76b8" stroke-width="2.5" marker-end="url(#fig2-a)"/>
+  <rect x="728" y="356" width="60" height="70" rx="4" fill="#ffffff" stroke="#8a8a82" stroke-width="2"/>
+  <circle cx="742" cy="368" r="10" fill="#dae8fc" stroke="#6c8ebf" stroke-width="1.5"/>
+  <circle cx="800" cy="416" r="22" fill="#d5e8d4" stroke="#82b366" stroke-width="2.5"/>
+  <text x="800" y="412" text-anchor="middle" font-size="9" fill="#3a6a34">SIGNED</text>
+  <text x="800" y="424" text-anchor="middle" font-size="12" font-weight="bold" fill="#3a6a34">✓</text>
+  <text x="676" y="446" text-anchor="middle" font-size="12" fill="#555">the sticker's owner approved THIS machine; it signs its work</text>
+
+  <rect x="60" y="478" width="820" height="60" rx="8" fill="#fffde7" stroke="#c8b900" stroke-width="1.5"/>
+  <text x="450" y="503" text-anchor="middle" font-size="15" fill="#4a4a20">The robot is never allowed to say "I blurred it, trust me."</text>
+  <text x="450" y="524" text-anchor="middle" font-size="15" font-weight="bold" fill="#4a4a20">Only the machine's signature counts.</text>
+</svg>
+</div><p></p>
+<h2>The doorkeeper asks three questions</h2>
+<p>For every slip, the doorkeeper checks three separate things — and all three have to pass:</p>
+<p class="li"><strong>"Do you have a hall pass for this door?"</strong> You gave each robot its own pass. A pass names what the robot may do, expires on its own, and remembers <em>why</em> it exists — so if the reason goes away, the pass dies with it. A robot can lend a smaller pass to a helper robot, but only if its own pass says "lending allowed," and the lent pass can never be bigger than the original.</p>
+<p class="li"><strong>"Do all the stickers allow where this is going?"</strong> Every sticker on everything mentioned in the slip gets a vote. One "stays in the house" sticker means it stays in the house — even if nine other stickers say fine.</p>
+<p class="li"><strong>"How big a deal is this?"</strong> Looking at something is small. Writing a draft is small. Mailing a letter, spending money, deleting things — those can't be undone, so they're big. Big deals need a grown-up to say yes first. And the grown-up gets shown <em>exactly</em> what will go out the door — never the robot's own summary of it.</p>
+<p>The doorkeeper then writes a <strong>receipt</strong>: yes or no, and the reasons. If the answer was no, the receipt says which question failed. Nobody argues with the doorkeeper by being clever; you argue by showing a better hall pass or a peeled sticker.</p>
+<p>One more doorkeeper habit, and it matters: passes are checked <strong>at the moment the door opens</strong>, not when the robot got in line. If you took a robot's pass away while it was standing in line, it still gets stopped at the door. "But I was already in line!" doesn't work on the boring doorkeeper.</p>
+<p></p><div class="fig"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 560" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="fig3-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#3a76b8"/></marker>
+    <marker id="fig3-ao" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#d79b00"/></marker>
+    <marker id="fig3-ar" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#c0392b"/></marker>
+  </defs>
+  <rect width="900" height="560" fill="#ffffff"/>
+  <text x="450" y="42" text-anchor="middle" font-size="24" font-weight="bold" fill="#1e5f96">The doorkeeper asks three questions — all three must pass</text>
+
+  <!-- Q1 hall pass -->
+  <rect x="50" y="76" width="255" height="180" rx="10" fill="#e1d5e7" stroke="#9673a6" stroke-width="2"/>
+  <text x="66" y="102" font-size="16" font-weight="bold" fill="#4a355c">1 · "Got a hall pass?"</text>
+  <rect x="70" y="116" width="216" height="110" rx="8" fill="#ffffff" stroke="#9673a6" stroke-width="1.5"/>
+  <text x="82" y="138" font-size="13" font-weight="bold" fill="#4a355c">HALL PASS — robot-a</text>
+  <text x="82" y="158" font-size="12" fill="#333">may: mail letters to family</text>
+  <text x="82" y="176" font-size="12" fill="#333">because: chris said so (tue)</text>
+  <text x="82" y="194" font-size="12" fill="#333">expires: bedtime</text>
+  <text x="82" y="212" font-size="12" fill="#c0392b" font-weight="bold">lending: not allowed</text>
+  <text x="66" y="246" font-size="11.5" fill="#4a355c">if the "because" goes away, the pass dies too</text>
+
+  <!-- Q2 stickers -->
+  <rect x="322" y="76" width="255" height="180" rx="10" fill="#f8cecc" stroke="#b85450" stroke-width="2"/>
+  <text x="338" y="102" font-size="16" font-weight="bold" fill="#7a3230">2 · "Stickers all okay?"</text>
+  <rect x="342" y="116" width="90" height="70" rx="5" fill="#ffffff" stroke="#8a8a82" stroke-width="1.5"/>
+  <circle cx="358" cy="130" r="11" fill="#dae8fc" stroke="#6c8ebf" stroke-width="1.5"/>
+  <circle cx="384" cy="130" r="11" fill="#d5e8d4" stroke="#82b366" stroke-width="1.5"/>
+  <circle cx="410" cy="130" r="11" fill="#f8cecc" stroke="#b85450" stroke-width="2"/>
+  <text x="410" y="134" text-anchor="middle" font-size="8" fill="#7a3230">house</text>
+  <text x="338" y="212" font-size="12.5" fill="#333">every sticker gets a vote.</text>
+  <text x="338" y="230" font-size="12.5" font-weight="bold" fill="#7a3230">one "stays home" vote wins,</text>
+  <text x="338" y="246" font-size="12.5" font-weight="bold" fill="#7a3230">even against nine yeses.</text>
+  <text x="452" y="140" font-size="12" fill="#555">← the slip wants</text>
+  <text x="452" y="156" font-size="12" fill="#555">to mail THIS</text>
+
+  <!-- Q3 how big -->
+  <rect x="594" y="76" width="255" height="180" rx="10" fill="#ffe6cc" stroke="#d79b00" stroke-width="2"/>
+  <text x="610" y="102" font-size="16" font-weight="bold" fill="#8a5a00">3 · "How big a deal?"</text>
+  <rect x="612" y="116" width="100" height="26" rx="13" fill="#d5e8d4" stroke="#82b366" stroke-width="1.5"/><text x="662" y="134" text-anchor="middle" font-size="12" fill="#3a6a34">just looking</text>
+  <rect x="612" y="150" width="100" height="26" rx="13" fill="#d5e8d4" stroke="#82b366" stroke-width="1.5"/><text x="662" y="168" text-anchor="middle" font-size="12" fill="#3a6a34">drafting</text>
+  <rect x="612" y="184" width="130" height="26" rx="13" fill="#f8cecc" stroke="#b85450" stroke-width="2"/><text x="677" y="202" text-anchor="middle" font-size="12" font-weight="bold" fill="#7a3230">mailing · spending</text>
+  <rect x="612" y="218" width="130" height="26" rx="13" fill="#f8cecc" stroke="#b85450" stroke-width="2"/><text x="677" y="236" text-anchor="middle" font-size="12" font-weight="bold" fill="#7a3230">deleting — no undo!</text>
+  <text x="756" y="204" font-size="20" fill="#c0392b">→</text>
+  <text x="782" y="196" font-size="12" fill="#7a3230">needs a</text>
+  <text x="782" y="212" font-size="12" font-weight="bold" fill="#7a3230">grown-up</text>
+
+  <!-- grown-up approval -->
+  <rect x="50" y="290" width="400" height="130" rx="10" fill="#fcfcfa" stroke="#b8b8b0" stroke-width="1.5"/>
+  <text x="66" y="316" font-size="16" font-weight="bold" fill="#232323">Big deals: the grown-up sees the real thing</text>
+  <circle cx="100" cy="360" r="18" fill="#d5e8d4" stroke="#82b366" stroke-width="2"/>
+  <rect x="84" y="382" width="32" height="26" rx="8" fill="#d5e8d4" stroke="#82b366" stroke-width="2"/>
+  <rect x="140" y="340" width="120" height="66" rx="4" fill="#ffffff" stroke="#8a8a82" stroke-width="1.5"/>
+  <text x="200" y="362" text-anchor="middle" font-size="11" fill="#333">the ACTUAL letter,</text>
+  <text x="200" y="378" text-anchor="middle" font-size="11" fill="#333">word for word —</text>
+  <text x="200" y="394" text-anchor="middle" font-size="11" font-weight="bold" fill="#c0392b">never the robot's summary</text>
+  <text x="280" y="366" font-size="12.5" fill="#333">…and only a grown-up</text>
+  <text x="280" y="382" font-size="12.5" fill="#333">who's ALLOWED to read</text>
+  <text x="280" y="398" font-size="12.5" fill="#333">it may approve it</text>
+
+  <!-- receipt -->
+  <rect x="470" y="290" width="180" height="130" rx="6" fill="#fffde7" stroke="#c8b900" stroke-width="2"/>
+  <text x="560" y="314" text-anchor="middle" font-size="14" font-weight="bold" fill="#4a4a20">RECEIPT</text>
+  <text x="560" y="338" text-anchor="middle" font-size="13" fill="#c0392b" font-weight="bold">NO.</text>
+  <text x="560" y="360" text-anchor="middle" font-size="12" fill="#333">question 2 failed:</text>
+  <text x="560" y="376" text-anchor="middle" font-size="12" fill="#333">"stays home" sticker</text>
+  <text x="560" y="400" text-anchor="middle" font-size="11" font-style="italic" fill="#555">every decision gets one</text>
+
+  <!-- line check -->
+  <rect x="670" y="290" width="180" height="130" rx="10" fill="#fcfcfa" stroke="#b8b8b0" stroke-width="1.5"/>
+  <text x="760" y="314" text-anchor="middle" font-size="14" font-weight="bold" fill="#232323">checked at the door</text>
+  <text x="760" y="336" text-anchor="middle" font-size="12" fill="#333">pass taken away while</text>
+  <text x="760" y="352" text-anchor="middle" font-size="12" fill="#333">the robot stood in line?</text>
+  <text x="760" y="372" text-anchor="middle" font-size="12" font-weight="bold" fill="#c0392b">still stopped.</text>
+  <text x="760" y="394" text-anchor="middle" font-size="11.5" font-style="italic" fill="#555">"but I was already in</text>
+  <text x="760" y="408" text-anchor="middle" font-size="11.5" font-style="italic" fill="#555">line!" never works</text>
+
+  <rect x="50" y="452" width="800" height="60" rx="8" fill="#fffde7" stroke="#c8b900" stroke-width="1.5"/>
+  <text x="450" y="477" text-anchor="middle" font-size="15" fill="#4a4a20">You don't argue with the doorkeeper by being clever.</text>
+  <text x="450" y="498" text-anchor="middle" font-size="15" font-weight="bold" fill="#4a4a20">You argue by showing a better hall pass, or a properly peeled sticker.</text>
+</svg>
+</div><p></p>
+<h2>Picking which helper does the job</h2>
+<p>Some jobs get sent out to helpers outside the house — some helpers are fast, some are cheap, some are brilliant, and some <em>blab everything they hear</em> or keep copies of what you show them.</p>
+<p>Here is the rule that makes routing safe, and it works like order of operations in math:</p>
+<blockquote><strong>First cross off everyone the stickers forbid. Only then pick the best of who's left.</strong></blockquote><p>A paper with a "stays in the house" sticker can never go to the neighbor kid — even if he's the smartest helper on the street, even if he's free, even if he's standing right there. He was crossed off before the contest started. The contest — fastest? cheapest? smartest? — only ever happens between helpers the stickers already allow.</p>
+<p>And if your chosen helper is sick today, you don't just grab the next name on the list. You <strong>re-do the crossing-off</strong> for the new helper. "The good one was busy" has never once made it okay to hand a secret to a blabbermouth.</p>
+<p>One more thing the crossing-off knows: <strong>it remembers.</strong> A helper who broke a promise last month — kept a copy they swore not to keep, took twice as long as the slip allowed — gets crossed off for a while too, before the contest, like everyone else the rules forbid. Being fast and brilliant buys nothing back until the penalty box empties.</p>
+<p></p><div class="fig"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 560" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="fig4-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#3a76b8"/></marker>
+    <marker id="fig4-ao" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#d79b00"/></marker>
+  </defs>
+  <rect width="900" height="560" fill="#ffffff"/>
+  <text x="450" y="40" text-anchor="middle" font-size="24" font-weight="bold" fill="#1e5f96">Picking a helper: cross off first, THEN pick the best</text>
+
+  <!-- the package -->
+  <rect x="40" y="80" width="130" height="90" rx="6" fill="#ffffff" stroke="#8a8a82" stroke-width="2"/>
+  <circle cx="62" cy="98" r="13" fill="#f8cecc" stroke="#b85450" stroke-width="2"/>
+  <text x="62" y="102" text-anchor="middle" font-size="8" fill="#7a3230">house</text>
+  <circle cx="92" cy="98" r="13" fill="#dae8fc" stroke="#6c8ebf" stroke-width="1.5"/>
+  <text x="105" y="146" text-anchor="middle" font-size="12" fill="#333">the job + its</text>
+  <text x="105" y="162" text-anchor="middle" font-size="12" fill="#333">stickers</text>
+
+  <!-- STEP 1 -->
+  <rect x="200" y="70" width="670" height="220" rx="10" fill="#fcfcfa" stroke="#b8b8b0" stroke-width="1.5"/>
+  <text x="216" y="96" font-size="16" font-weight="bold" fill="#c0392b">STEP 1 — the stickers cross helpers off. No contest yet.</text>
+
+  <!-- helpers -->
+  <g>
+    <circle cx="270" cy="150" r="26" fill="#d5e8d4" stroke="#82b366" stroke-width="2.5"/>
+    <text x="270" y="146" text-anchor="middle" font-size="11" font-weight="bold" fill="#3a6a34">ZIP</text>
+    <text x="270" y="160" text-anchor="middle" font-size="9" fill="#3a6a34">fast</text>
+    <text x="270" y="200" text-anchor="middle" font-size="11" fill="#555">keeps nothing</text>
+  </g>
+  <g>
+    <circle cx="390" cy="150" r="26" fill="#d5e8d4" stroke="#82b366" stroke-width="2.5"/>
+    <text x="390" y="146" text-anchor="middle" font-size="11" font-weight="bold" fill="#3a6a34">PENNY</text>
+    <text x="390" y="160" text-anchor="middle" font-size="9" fill="#3a6a34">cheap</text>
+    <text x="390" y="200" text-anchor="middle" font-size="11" fill="#555">keeps nothing</text>
+  </g>
+  <g>
+    <circle cx="510" cy="150" r="26" fill="#d5e8d4" stroke="#82b366" stroke-width="2.5"/>
+    <text x="510" y="146" text-anchor="middle" font-size="11" font-weight="bold" fill="#3a6a34">SAGE</text>
+    <text x="510" y="160" text-anchor="middle" font-size="9" fill="#3a6a34">genius</text>
+    <text x="510" y="200" text-anchor="middle" font-size="11" fill="#555">keeps nothing</text>
+  </g>
+  <g>
+    <circle cx="640" cy="150" r="26" fill="#f5f5f5" stroke="#8a8a82" stroke-width="2"/>
+    <text x="640" y="146" text-anchor="middle" font-size="11" font-weight="bold" fill="#555">GABBY</text>
+    <text x="640" y="160" text-anchor="middle" font-size="9" fill="#555">genius!</text>
+    <text x="640" y="200" text-anchor="middle" font-size="11" font-weight="bold" fill="#c0392b">blabs everything</text>
+    <line x1="614" y1="124" x2="666" y2="176" stroke="#c0392b" stroke-width="5"/>
+    <line x1="666" y1="124" x2="614" y2="176" stroke="#c0392b" stroke-width="5"/>
+  </g>
+  <g>
+    <circle cx="780" cy="150" r="26" fill="#f5f5f5" stroke="#8a8a82" stroke-width="2"/>
+    <text x="780" y="146" text-anchor="middle" font-size="11" font-weight="bold" fill="#555">XEROXA</text>
+    <text x="780" y="160" text-anchor="middle" font-size="9" fill="#555">free!</text>
+    <text x="780" y="200" text-anchor="middle" font-size="11" font-weight="bold" fill="#c0392b">keeps copies</text>
+    <line x1="754" y1="124" x2="806" y2="176" stroke="#c0392b" stroke-width="5"/>
+    <line x1="806" y1="124" x2="754" y2="176" stroke="#c0392b" stroke-width="5"/>
+  </g>
+  <text x="216" y="248" font-size="13" fill="#7a3230" font-weight="bold">the "stays in the house" sticker crossed off Gabby and Xeroxa BEFORE anyone</text>
+  <text x="216" y="266" font-size="13" fill="#7a3230" font-weight="bold">compared smartness or price. Genius and free never entered into it.</text>
+
+  <path class="e" d="M170,125 L196,125" stroke="#3a76b8" stroke-width="2.5" marker-end="url(#fig4-a)" fill="none"/>
+
+  <!-- STEP 2 -->
+  <rect x="200" y="316" width="440" height="150" rx="10" fill="#fcfcfa" stroke="#b8b8b0" stroke-width="1.5"/>
+  <text x="216" y="342" font-size="16" font-weight="bold" fill="#3a6a34">STEP 2 — NOW the contest, among who's left</text>
+  <circle cx="270" cy="400" r="24" fill="#d5e8d4" stroke="#82b366" stroke-width="2.5"/>
+  <text x="270" y="405" text-anchor="middle" font-size="10" font-weight="bold" fill="#3a6a34">ZIP</text>
+  <circle cx="350" cy="400" r="24" fill="#d5e8d4" stroke="#82b366" stroke-width="2.5"/>
+  <text x="350" y="405" text-anchor="middle" font-size="10" font-weight="bold" fill="#3a6a34">PENNY</text>
+  <circle cx="430" cy="400" r="24" fill="#d5e8d4" stroke="#82b366" stroke-width="3.5"/>
+  <text x="430" y="405" text-anchor="middle" font-size="10" font-weight="bold" fill="#3a6a34">SAGE</text>
+  <circle cx="430" cy="366" r="12" fill="#fff2cc" stroke="#d6b656" stroke-width="2"/>
+  <text x="430" y="371" text-anchor="middle" font-size="11">★</text>
+  <text x="480" y="396" font-size="12.5" fill="#333">best of the ALLOWED:</text>
+  <text x="480" y="412" font-size="12.5" fill="#333">smartest wins today</text>
+  <text x="216" y="448" font-size="12" font-style="italic" fill="#555">fastest? cheapest? smartest? — a fair fight, because everyone here is safe</text>
+
+  <!-- fallback -->
+  <rect x="660" y="316" width="210" height="150" rx="10" fill="#ffe6cc" stroke="#d79b00" stroke-width="2"/>
+  <text x="765" y="342" text-anchor="middle" font-size="15" font-weight="bold" fill="#8a5a00">Sage is sick today?</text>
+  <circle cx="710" cy="386" r="20" fill="#d5e8d4" stroke="#82b366" stroke-width="2"/>
+  <rect x="700" y="376" width="20" height="8" rx="4" fill="#c0392b"/>
+  <text x="740" y="382" font-size="12" fill="#333">don't just grab</text>
+  <text x="740" y="398" font-size="12" fill="#333">the next name —</text>
+  <text x="765" y="426" text-anchor="middle" font-size="13" font-weight="bold" fill="#c0392b">RE-DO the crossing-off</text>
+  <text x="765" y="444" text-anchor="middle" font-size="11" font-style="italic" fill="#8a5a00">"the good one was busy" never</text>
+  <text x="765" y="458" text-anchor="middle" font-size="11" font-style="italic" fill="#8a5a00">makes the blabbermouth okay</text>
+  <path d="M765,316 C765,300 700,296 660,292" stroke="#d79b00" stroke-width="2.5" fill="none" stroke-dasharray="6 4" marker-end="url(#fig4-ao)"/>
+
+  <rect x="40" y="492" width="830" height="50" rx="8" fill="#fffde7" stroke="#c8b900" stroke-width="1.5"/>
+  <text x="455" y="523" text-anchor="middle" font-size="15" font-weight="bold" fill="#4a4a20">Choosing the best model only ever happens among the models the rules already allowed.</text>
+</svg>
+</div><p></p>
+<h2>The blackboard</h2>
+<p>The robots share a big blackboard where they leave notes for each other. Stickers ride on <strong>each note</strong> — not on the blackboard.</p>
+<p>So if robot A pins up a note made from secret stuff, and robot B never reads that note, robot B's work stays unstickered. B can still use the fast outside helper for its own public job. Only the robots that actually <em>read</em> the secret note carry its stickers forward. The blackboard is furniture, not glue.</p>
+<hr>
+<h2>The same story in grown-up words</h2>
+<div class="twrap"><table>
+<tr><th>In the story</th><th>In the architecture</th></tr>
+<tr><td>the gullible robot</td><td>the model / agent — persuadable by any injected text</td></tr>
+<tr><td>the request slip</td><td><code>ProposedTransaction</code> — the model proposes, never executes</td></tr>
+<tr><td>the boring doorkeeper</td><td>the deterministic runtime — <code>decide(…)</code></td></tr>
+<tr><td>the doorkeeper's missing ears</td><td>the runtime accepts only typed inputs (proposals, grants, clauses) — no natural-language surface for injection to grab</td></tr>
+<tr><td>stickers live on the envelope, never the paper</td><td>the label plane is runtime-maintained metadata — model output is payload only; output clauses are computed from actual inputs, never declared</td></tr>
+<tr><td>a drawn sticker is just a picture</td><td>in-band "labels" are content; forgery is unrepresentable, and transform receipts are runtime-attested</td></tr>
+<tr><td>a sticker</td><td><code>PolicyClause</code> — authority + destination constraints + purpose + operations</td></tr>
+<tr><td>who put the sticker on</td><td>the clause's authority (a tenant, a licensor, a contract)</td></tr>
+<tr><td>the glue law</td><td>clause union on derivation — labels survive rewriting</td></tr>
+<tr><td>the peel law</td><td>relaxation modes — every affected authority must authorize, its declared way</td></tr>
+<tr><td>the blur machine + signature</td><td><code>PolicyTransform</code> — an authority-approved transform run by a trusted capability version, with attestation</td></tr>
+<tr><td>the hall pass</td><td><code>ExecutionGrant</code> / <code>Delegation</code> — scoped, expiring, lineage-bearing</td></tr>
+<tr><td>"lending allowed"</td><td><code>:delegable?</code> — a separate authority from holding</td></tr>
+<tr><td>the three questions</td><td>the three planes: authority, information flow, effect</td></tr>
+<tr><td>big deals need a grown-up</td><td>effect classes; irreversible/high-impact effects require human approval</td></tr>
+<tr><td>shown exactly what goes out</td><td>approval binds to the rendered payload's hash — and the approver must be allowed to see it</td></tr>
+<tr><td>the receipt</td><td><code>DecisionEnvelope</code> — allowed?, reason codes, obligations, revision pins</td></tr>
+<tr><td>checked when the door opens</td><td>commit-time recheck under the freshness contract</td></tr>
+<tr><td>cross off, then contest</td><td>policy-first routing: eligibility filter before quality/latency/cost ranking</td></tr>
+<tr><td>re-do the crossing-off</td><td>fallback re-runs eligibility, never just ranking</td></tr>
+<tr><td>the crossing-off remembers</td><td>breach history is an eligibility input — revocations for cause drop a binding from the candidate set before ranking</td></tr>
+<tr><td>stickers on notes, not the blackboard</td><td>scoped taint: artifact-level labels; the blackboard is a container, not a flow</td></tr>
+</table></div>
+<p>The one-sentence version, suitable for saying out loud:</p>
+<blockquote><strong>Models propose. Deterministic authority, information-flow, and effect-control systems decide and execute — and choosing the best model only ever happens among the models the rules already allowed.</strong></blockquote>
+<div style="max-width:640px;margin:40px auto 0;font-family:Menlo,Consolas,monospace;font-size:12px;letter-spacing:.08em">
+<a href="/architectures" style="color:#ff5e1a;text-decoration:none">&larr; BACK TO THE DRAWING REGISTER</a>
+</div>
+</body>
+</html>

--- a/docs/architecture/ariadne/explainers/your-house-their-clubhouse-and-the-passes.html
+++ b/docs/architecture/ariadne/explainers/your-house-their-clubhouse-and-the-passes.html
@@ -1,0 +1,455 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Your House, Their Clubhouse, and the Passes — miniforge.ai</title>
+  <meta name="description" content="The tenancy, ownership, and rights architecture explained simply: houses, clubhouses, passes, and the moving-box promise.">
+  <link rel="canonical" href="https://miniforge.ai/architectures/eli9-your-house-their-clubhouse">
+  <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
+</head>
+<body>
+<div style="max-width:640px;margin:0 auto 28px;font-family:Menlo,Consolas,monospace;font-size:12px;letter-spacing:.08em">
+<a href="/architectures" style="color:#ff5e1a;text-decoration:none">&larr; MINIFORGE.AI // DRAWING REGISTER</a>
+</div>
+
+<style>
+:root { --bg:#faf9f6; --ink:#26221c; --sub:#6a635a; --accent:#ff5e1a; --card:#ffffff; --line:#e0dcd4; }
+@media (prefers-color-scheme: dark) { :root { --bg:#1c1a17; --ink:#ece8e0; --sub:#a49c90; --card:#26231e; --line:#3a362f; } }
+:root[data-theme="dark"] { --bg:#1c1a17; --ink:#ece8e0; --sub:#a49c90; --card:#26231e; --line:#3a362f; }
+:root[data-theme="light"] { --bg:#faf9f6; --ink:#26221c; --sub:#6a635a; --card:#ffffff; --line:#e0dcd4; }
+body { background:var(--bg); color:var(--ink); font-family:Georgia, 'Times New Roman', serif; margin:0; padding:40px 20px 80px; line-height:1.65; }
+h1 { font-family:Helvetica, Arial, sans-serif; color:var(--accent); font-size:34px; text-align:center; max-width:700px; margin:0 auto 8px; text-wrap:balance; }
+h2 { font-family:Helvetica, Arial, sans-serif; color:var(--accent); font-size:23px; max-width:640px; margin:44px auto 8px; }
+p, blockquote { max-width:640px; margin:14px auto; font-size:17px; }
+p.li { margin:8px auto; padding-left:1.2em; }
+em { color:var(--sub); }
+blockquote { border-left:4px solid var(--accent); padding:10px 20px; background:var(--card); border-radius:0 8px 8px 0; font-size:18px; }
+code { font-family:Menlo, Consolas, monospace; font-size:.85em; background:rgba(30,95,150,.12); padding:1px 5px; border-radius:4px; }
+hr { border:none; border-top:1px solid var(--line); max-width:640px; margin:40px auto; }
+.fig { max-width:960px; margin:26px auto; background:#ffffff; border:1px solid var(--line); border-radius:10px; padding:10px; overflow-x:auto; }
+.fig svg { display:block; min-width:760px; width:100%; height:auto; }
+.twrap { max-width:860px; margin:20px auto; overflow-x:auto; background:#ffffff; border:1px solid var(--line); border-radius:8px; }
+table { border-collapse:collapse; width:100%; font-family:Helvetica, Arial, sans-serif; font-size:13.5px; color:#26221c; }
+th, td { text-align:left; padding:8px 12px; border-bottom:1px solid #e8e4dc; }
+th { background:#f0eee8; }
+</style>
+<h1>Your House, Their Clubhouse, and the Passes</h1>
+<p><em>The tenancy, ownership, and rights architecture (<code>../tenancy-ownership-access.md</code> §1–§10, §12), explained simply — in the same world as The Robot Helpers and the Sticker Rules. Same house, same doorkeeper, same stickers; this story is about whose things are whose. Together the two stories are the simplicity invariant: if a future change to the architecture cannot be told in the story, the change is suspect. Grown-up translation table at the end.</em></p>
+<hr>
+<h2>Everyone has a house</h2>
+<p>You remember the house with the robot helpers and the boring doorkeeper. Now zoom out: <strong>everyone has a house of their own.</strong> Everything you have lives in your house — your drawings, your report cards, your skills notebook. That is what "yours" <em>means</em> here: <strong>every single thing lives in exactly one house.</strong> First rule; it never bends.</p>
+<p>Clubs have buildings too. The soccer club's clubhouse holds the club's own things — the rulebook, the bulletin board, the game plans. A clubhouse isn't fancier than a house; it's just a house that a club owns.</p>
+<p>And every door everywhere — your house, the clubhouse, the coach's office, the library desk, the gate to the practice field — has a <strong>doorkeeper</strong> standing at it. Here's the doorkeepers' secret, and it's the whole trick of this world: they're robots too, but a special kind — <strong>no ears, just a pass slot.</strong> You can hand a doorkeeper a pass. You cannot talk to one. Nobody has ever talked a doorkeeper into anything, because nobody has ever talked <em>to</em> a doorkeeper at all.</p>
+<h2>Joining a club prints passes. It never moves houses.</h2>
+<p>Nobody walks through anyone else's door without a <strong>pass</strong>. You've seen passes already — the robots carry them. A pass always says four things: <em>who</em> it's for, <em>which door or shelf</em> it opens, <em>why it exists</em>, and <em>when it expires</em>. If the why goes away, the pass dies with it.</p>
+<p>So what is "joining the soccer club"? The club prints <strong>you</strong> a member pass — it opens the practice field, the bulletin board room, and the bin of club balls. Sometimes the club pays for everything: club balls, club uniforms. You use them there, through your pass. They never come home as yours.</p>
+<p>And then you <em>play</em>. Here's the part that matters: <strong>the season is a thing you do together, on the field.</strong> The coach sees your corner kicks because the coach was standing right there coaching them — not because anyone opened a door into your house. Playing together is its own shared place, and everyone in it sees what happens in it. Nobody needs a pass into anybody's house to play on a team.</p>
+<p>Now bring <strong>your own ball</strong> to practice. The moment you toss it onto the field, you've minted a little pass without saying a word: <em>the team may use my ball — during practice.</em> Practice ends, the ball goes home with you. It was never the club's, not even a little, no matter how many teammates kicked it. <strong>Used-by-everyone never means owned-by-the-club.</strong> And if you'd rather not bring it tomorrow, you just… don't. That's the whole revocation.</p>
+<p>Notice what never happened in any of this: your house did not get picked up and craned into the clubhouse. Nothing of yours moved anywhere, and nobody got a pass into your house at all. Joining a club is <strong>printing passes, never moving houses</strong> — and that's why leaving will be easy later. A thing that never moved in never has to move out.</p>
+<p></p><div class="fig"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 540" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="fig1-aB" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#3a76b8"/></marker>
+    <marker id="fig1-aG" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#4a9a4a"/></marker>
+  </defs>
+  <rect width="900" height="540" fill="#ffffff"/>
+  <text x="450" y="40" text-anchor="middle" font-size="24" font-weight="bold" fill="#1e5f96">Everyone has a house. Joining prints passes — it never moves houses.</text>
+
+  <!-- Alice's house -->
+  <path d="M60,160 L150,110 L240,160 Z" fill="#d5e8d4" stroke="#82b366" stroke-width="2.5"/>
+  <rect x="78" y="160" width="144" height="120" fill="#d5e8d4" stroke="#82b366" stroke-width="2.5"/>
+  <rect x="130" y="222" width="38" height="58" rx="3" fill="#82b366"/>
+  <circle cx="160" cy="252" r="4" fill="#d5e8d4"/>
+  <rect x="92" y="176" width="52" height="34" rx="3" fill="#ffffff" stroke="#82b366" stroke-width="1.5"/>
+  <text x="118" y="190" text-anchor="middle" font-size="8" fill="#3a6a34">skills</text>
+  <text x="118" y="201" text-anchor="middle" font-size="8" fill="#3a6a34">notebook</text>
+  <rect x="156" y="176" width="52" height="34" rx="3" fill="#ffffff" stroke="#82b366" stroke-width="1.5"/>
+  <text x="182" y="190" text-anchor="middle" font-size="8" fill="#3a6a34">soccer</text>
+  <text x="182" y="201" text-anchor="middle" font-size="8" fill="#3a6a34">shelf</text>
+  <text x="150" y="304" text-anchor="middle" font-size="14" font-weight="bold" fill="#3a6a34">ALICE'S HOUSE</text>
+  <text x="150" y="322" text-anchor="middle" font-size="11.5" fill="#3a6a34">everything of hers lives here —</text>
+  <text x="150" y="337" text-anchor="middle" font-size="11.5" fill="#3a6a34">exactly one house per thing</text>
+
+  <!-- clubhouse -->
+  <path d="M660,160 L770,104 L880,160 Z" fill="#dae8fc" stroke="#6c8ebf" stroke-width="2.5"/>
+  <rect x="678" y="160" width="184" height="120" fill="#dae8fc" stroke="#6c8ebf" stroke-width="2.5"/>
+  <rect x="748" y="222" width="42" height="58" rx="3" fill="#6c8ebf"/>
+  <rect x="692" y="176" width="64" height="34" rx="3" fill="#ffffff" stroke="#6c8ebf" stroke-width="1.5"/>
+  <text x="724" y="190" text-anchor="middle" font-size="8" fill="#274b73">rulebook ·</text>
+  <text x="724" y="201" text-anchor="middle" font-size="8" fill="#274b73">game plans</text>
+  <rect x="766" y="176" width="64" height="34" rx="3" fill="#ffffff" stroke="#6c8ebf" stroke-width="1.5"/>
+  <text x="798" y="190" text-anchor="middle" font-size="8" fill="#274b73">bulletin</text>
+  <text x="798" y="201" text-anchor="middle" font-size="8" fill="#274b73">board</text>
+  <text x="770" y="304" text-anchor="middle" font-size="14" font-weight="bold" fill="#274b73">THE CLUBHOUSE</text>
+  <text x="770" y="322" text-anchor="middle" font-size="11.5" fill="#274b73">just a house a club owns —</text>
+  <text x="770" y="337" text-anchor="middle" font-size="11.5" fill="#274b73">the club's stuff lives here</text>
+
+  <!-- doorkeeper between -->
+  <circle cx="450" cy="96" r="15" fill="#f5f5f5" stroke="#8a8a82" stroke-width="2"/>
+  <rect x="436" y="78" width="28" height="10" rx="3" fill="#8a8a82"/>
+  <line x1="444" y1="98" x2="456" y2="98" stroke="#232323" stroke-width="2"/>
+  <text x="450" y="130" text-anchor="middle" font-size="10.5" fill="#555">a doorkeeper at every door:</text>
+  <text x="450" y="143" text-anchor="middle" font-size="10.5" fill="#555">no ears, just a pass slot</text>
+
+  <!-- pass 1: club -> alice -->
+  <rect x="300" y="168" width="300" height="86" rx="8" fill="#dae8fc" stroke="#6c8ebf" stroke-width="2.5"/>
+  <text x="316" y="190" font-size="13" font-weight="bold" fill="#274b73">MEMBER PASS</text>
+  <text x="316" y="208" font-size="11" fill="#333">for: Alice · opens: field + club balls + bulletin room</text>
+  <text x="316" y="224" font-size="11" fill="#333">why: joined the club · until: torn up</text>
+  <text x="316" y="244" font-size="10" font-style="italic" fill="#555">printed by the club</text>
+  <path d="M676,214 L604,214" stroke="#3a76b8" stroke-width="2.5" marker-end="url(#fig1-aB)"/>
+  <path d="M298,214 L246,214" stroke="#3a76b8" stroke-width="2.5" marker-end="url(#fig1-aB)"/>
+
+  <!-- alice's ball at practice -->
+  <rect x="300" y="280" width="300" height="100" rx="8" fill="#d5e8d4" stroke="#82b366" stroke-width="2.5"/>
+  <circle cx="330" cy="306" r="12" fill="#ffffff" stroke="#3a6a34" stroke-width="2"/>
+  <path d="M324,300 L336,312 M336,300 L324,312" stroke="#3a6a34" stroke-width="1"/>
+  <text x="350" y="302" font-size="13" font-weight="bold" fill="#3a6a34">ALICE'S BALL, AT PRACTICE</text>
+  <text x="316" y="326" font-size="11" fill="#333">tossing it onto the field mints the pass:</text>
+  <text x="316" y="342" font-size="11" fill="#333">the team may use it — during practice.</text>
+  <text x="316" y="358" font-size="11" fill="#333">practice ends → it goes home with her.</text>
+  <text x="316" y="374" font-size="10" font-style="italic" fill="#555">used-by-everyone never means owned-by-the-club</text>
+  <path d="M246,330 L298,330" stroke="#4a9a4a" stroke-width="2.5" marker-end="url(#fig1-aG)"/>
+  <path d="M604,330 L676,330" stroke="#4a9a4a" stroke-width="2.5" marker-end="url(#fig1-aG)"/>
+  <text x="640" y="320" text-anchor="middle" font-size="10" fill="#4a9a4a">to the field</text>
+
+  <!-- crossed-out craning -->
+  <rect x="60" y="380" width="190" height="130" rx="8" fill="#fcfcfa" stroke="#b8b8b0" stroke-width="1.5"/>
+  <path d="M110,448 L145,430 L180,448 Z" fill="#dae8fc" stroke="#6c8ebf" stroke-width="1.5"/>
+  <rect x="118" y="448" width="54" height="40" fill="#dae8fc" stroke="#6c8ebf" stroke-width="1.5"/>
+  <path d="M128,466 L145,457 L162,466 Z" fill="#d5e8d4" stroke="#82b366" stroke-width="1.5"/>
+  <rect x="132" y="466" width="26" height="20" fill="#d5e8d4" stroke="#82b366" stroke-width="1.5"/>
+  <line x1="70" y1="392" x2="240" y2="500" stroke="#c0392b" stroke-width="4.5"/>
+  <line x1="240" y1="392" x2="70" y2="500" stroke="#c0392b" stroke-width="4.5"/>
+  <text x="155" y="527" text-anchor="middle" font-size="11.5" font-weight="bold" fill="#c0392b">a house inside the clubhouse: never</text>
+
+  <!-- robots note -->
+  <rect x="640" y="380" width="240" height="130" rx="8" fill="#fffde7" stroke="#c8b900" stroke-width="1.5"/>
+  <text x="656" y="404" font-size="13" font-weight="bold" fill="#4a4a20">whose robot? doesn't matter</text>
+  <text x="656" y="424" font-size="11.5" fill="#4a4a20">yours, the club's, rented — robots</text>
+  <text x="656" y="440" font-size="11.5" fill="#4a4a20">own nothing and work on passes</text>
+  <text x="656" y="456" font-size="11.5" fill="#4a4a20">lent to them. Whose robot did the</text>
+  <text x="656" y="472" font-size="11.5" fill="#4a4a20">work never decides whose stuff</text>
+  <text x="656" y="488" font-size="11.5" fill="#4a4a20">the work is. Passes decide.</text>
+
+  <rect x="280" y="420" width="340" height="66" rx="8" fill="#fffde7" stroke="#c8b900" stroke-width="1.5"/>
+  <text x="450" y="446" text-anchor="middle" font-size="13.5" fill="#4a4a20">Joining prints passes, never moves houses.</text>
+  <text x="450" y="468" text-anchor="middle" font-size="13.5" font-weight="bold" fill="#4a4a20">A thing that never moved in never has to move out.</text>
+</svg>
+</div><p></p>
+<p>One small thing about you and your keys: you might have a front door key, a spare at grandma's, a new one after you lost the old one. Keys prove it's <em>you</em> at the door. Losing a key, or adding one, never changes whose house it is.</p>
+<p>And the robots? Robots work everywhere in this world — your robots, the club's robots, even a robot you rent for an afternoon. Here's the thing that surprises grown-ups: <strong>it never matters who owns the robot.</strong> Robots own nothing and hold nothing of their own — a robot working for you works on passes lent from yours (smaller ones, and only if yours say "lending allowed" — you know this from the robot story). Whose robot did the work never decides whose stuff the work is. The passes and the slips decide.</p>
+<h2>Whose paper is it?</h2>
+<p>Whose is a paper? <strong>It belongs to the place where it was made</strong> — copies may travel later, but belonging doesn't:</p>
+<p class="li">The game plans and the coach's notes get written at the coach's desk, in the coach's office. Club papers, belonging to the club. And notice a detail: <strong>your member pass doesn't open the coach's office.</strong> Being in the club never meant every club door — the office door has a doorkeeper like every other, and it won't take your member pass. "But I'm on the team!" lands on nothing, because doorkeepers have no ears.</p>
+<p class="li">Your drawings and projects get made at your house. Yours.</p>
+<p>Nobody stands sorting paper by paper. <strong>Where it was made decides.</strong> That's the whole rule, so there's never an argument about any single paper.</p>
+<p>When the forward game plan is <em>finished</em>, the coach walks out and hands the forwards their copies. That's the club <strong>choosing</strong> to share a club paper: the copy was made <em>for you</em>, so your copy comes home to your house — wearing the club's sticker — "team eyes only" — which rides wherever the copy goes (glue law). The original never left the coach's desk. And the coach's notes? Those may never be handed out at all — some club papers no member ever sees. (Years from now the coach might give their old notebook to their kid who's becoming a coach. That's the owner giving the <em>thing itself</em> away — always the owner's to do, and nobody else's.)</p>
+<p>But here is the most important rule in the whole story:</p>
+<blockquote><strong>What you learned is always yours.</strong></blockquote>
+<p>You got better at soccer <em>at the club</em>, with <em>club drills</em>, on <em>club fields</em>. Doesn't matter. "I can bend a corner kick" goes in the skills notebook in <strong>your</strong> house, forever. The club keeps its drill sheets; you keep your feet. When you're twenty and trying out somewhere new, that notebook is what you bring — that's what a skills notebook is <em>for</em>.</p>
+<p>One catch, and it's fair: if what you learned includes a club secret — the special play nobody else knows — the secret's sticker rides along in your notebook (glue law, from the robot story). The skill is yours to keep; the secret detail is still the club's to unlock. Yours to have, theirs to gate.</p>
+<p>And when the coach asks for a season report about you? The report is about you, for your growing up — so it lives in <strong>your</strong> house. The coach gets a <strong>reading pass</strong> to that one report, through the season. A pass to read it — never a hand to carry it off. Season ends, pass dies, report stays.</p>
+<p></p><div class="fig"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 560" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="fig2-aB" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#3a76b8"/></marker>
+    <marker id="fig2-aG" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#4a9a4a"/></marker>
+  </defs>
+  <rect width="900" height="560" fill="#ffffff"/>
+  <text x="450" y="40" text-anchor="middle" font-size="24" font-weight="bold" fill="#1e5f96">Where it was made decides — and what you learned is always yours</text>
+
+  <!-- coach's office -->
+  <rect x="40" y="80" width="210" height="120" rx="8" fill="#dae8fc" stroke="#6c8ebf" stroke-width="2.5"/>
+  <text x="145" y="104" text-anchor="middle" font-size="13" font-weight="bold" fill="#274b73">THE COACH'S OFFICE</text>
+  <rect x="58" y="116" width="120" height="40" rx="3" fill="#ffffff" stroke="#6c8ebf" stroke-width="1.5"/>
+  <text x="118" y="132" text-anchor="middle" font-size="8.5" fill="#274b73">game plans · season notes</text>
+  <text x="118" y="146" text-anchor="middle" font-size="8.5" fill="#274b73">MADE at this desk</text>
+  <rect x="192" y="116" width="42" height="60" rx="3" fill="#6c8ebf"/>
+  <circle cx="226" cy="146" r="3.5" fill="#dae8fc"/>
+  <rect x="200" y="130" width="14" height="16" rx="2" fill="#f8cecc" stroke="#b85450" stroke-width="1.5"/>
+  <text x="118" y="174" text-anchor="middle" font-size="10" font-weight="bold" fill="#c0392b">your member pass does</text>
+  <text x="118" y="188" text-anchor="middle" font-size="10" font-weight="bold" fill="#c0392b">NOT open this door</text>
+
+  <!-- handed copy -->
+  <path d="M250,140 L306,140" stroke="#3a76b8" stroke-width="2.5" marker-end="url(#fig2-aB)"/>
+  <text x="278" y="128" text-anchor="middle" font-size="10" fill="#3a76b8">when it's</text>
+  <text x="278" y="158" text-anchor="middle" font-size="10" fill="#3a76b8">FINISHED</text>
+  <rect x="310" y="86" width="190" height="118" rx="8" fill="#fcfcfa" stroke="#b8b8b0" stroke-width="1.5"/>
+  <text x="405" y="108" text-anchor="middle" font-size="12" font-weight="bold" fill="#232323">the coach hands out copies</text>
+  <rect x="330" y="118" width="80" height="52" rx="4" fill="#ffffff" stroke="#8a8a82" stroke-width="1.5"/>
+  <text x="370" y="136" text-anchor="middle" font-size="8.5" fill="#333">forward</text>
+  <text x="370" y="148" text-anchor="middle" font-size="8.5" fill="#333">game plan</text>
+  <circle cx="344" cy="128" r="9" fill="#dae8fc" stroke="#6c8ebf" stroke-width="1.5"/>
+  <text x="344" y="131" text-anchor="middle" font-size="5.5" fill="#274b73">team</text>
+  <text x="424" y="136" font-size="9.5" fill="#555">your copy → your</text>
+  <text x="424" y="149" font-size="9.5" fill="#555">house, wearing the</text>
+  <text x="424" y="162" font-size="9.5" fill="#555">club's sticker</text>
+  <text x="405" y="182" text-anchor="middle" font-size="9.5" font-style="italic" fill="#555">the original never left the desk ·</text>
+  <text x="405" y="195" text-anchor="middle" font-size="9.5" font-style="italic" fill="#555">the notes are never handed out</text>
+
+  <!-- made at home -->
+  <rect x="40" y="234" width="210" height="76" rx="8" fill="#d5e8d4" stroke="#82b366" stroke-width="2.5"/>
+  <text x="145" y="260" text-anchor="middle" font-size="13" font-weight="bold" fill="#3a6a34">MADE AT YOUR HOUSE</text>
+  <text x="145" y="282" text-anchor="middle" font-size="11" fill="#3a6a34">your drawings · your projects</text>
+  <path d="M250,272 L306,272" stroke="#4a9a4a" stroke-width="2.5" marker-end="url(#fig2-aG)"/>
+  <rect x="310" y="240" width="190" height="64" rx="8" fill="#d5e8d4" stroke="#82b366" stroke-width="2"/>
+  <text x="405" y="266" text-anchor="middle" font-size="13" font-weight="bold" fill="#3a6a34">your house</text>
+  <text x="405" y="286" text-anchor="middle" font-size="11" fill="#3a6a34">yours, forever</text>
+
+  <rect x="130" y="330" width="290" height="40" rx="8" fill="#fffde7" stroke="#c8b900" stroke-width="1.5"/>
+  <text x="275" y="349" text-anchor="middle" font-size="12.5" fill="#4a4a20">nobody sorts paper by paper —</text>
+  <text x="275" y="364" text-anchor="middle" font-size="12.5" font-weight="bold" fill="#4a4a20">where it was MADE decides</text>
+
+  <!-- right: the learning rule -->
+  <rect x="520" y="80" width="350" height="290" rx="10" fill="#fcfcfa" stroke="#b8b8b0" stroke-width="1.5"/>
+  <text x="695" y="108" text-anchor="middle" font-size="16" font-weight="bold" fill="#3a6a34">the most important rule</text>
+
+  <text x="545" y="140" font-size="12.5" fill="#333">learned at the club, on club fields,</text>
+  <text x="545" y="156" font-size="12.5" fill="#333">with club drills…</text>
+  <circle cx="620" cy="196" r="16" fill="#fce5cd" stroke="#b8860b" stroke-width="2"/>
+  <path d="M610,220 Q620,230 630,220" stroke="#232323" stroke-width="2" fill="none"/>
+  <circle cx="660" cy="210" r="10" fill="#ffffff" stroke="#232323" stroke-width="2"/>
+  <text x="700" y="205" font-size="11" fill="#555">⚽ corner kick, bent!</text>
+
+  <path d="M660,240 L660,272" stroke="#4a9a4a" stroke-width="2.5" marker-end="url(#fig2-aG)"/>
+
+  <rect x="545" y="272" width="230" height="88" rx="6" fill="#d5e8d4" stroke="#82b366" stroke-width="2.5"/>
+  <text x="660" y="292" text-anchor="middle" font-size="12" font-weight="bold" fill="#3a6a34">SKILLS NOTEBOOK — in YOUR house</text>
+  <text x="557" y="314" font-size="11.5" fill="#333">✓ bend a corner kick</text>
+  <rect x="700" y="302" width="60" height="18" rx="9" fill="#f8cecc" stroke="#b85450" stroke-width="1.5"/>
+  <text x="730" y="315" text-anchor="middle" font-size="8.5" fill="#7a3230">club secret</text>
+  <text x="557" y="336" font-size="10.5" font-style="italic" fill="#555">the special play's sticker rides along —</text>
+  <text x="557" y="350" font-size="10.5" font-style="italic" fill="#555">yours to have, theirs to gate</text>
+
+  <text x="800" y="300" font-size="11" fill="#3a6a34" font-weight="bold">the club keeps</text>
+  <text x="800" y="315" font-size="11" fill="#3a6a34" font-weight="bold">its drill sheets;</text>
+  <text x="800" y="330" font-size="11" fill="#3a6a34" font-weight="bold">you keep</text>
+  <text x="800" y="345" font-size="11" fill="#3a6a34" font-weight="bold">your feet</text>
+
+  <!-- bottom: commissioned report -->
+  <rect x="40" y="400" width="830" height="120" rx="10" fill="#fcfcfa" stroke="#b8b8b0" stroke-width="1.5"/>
+  <text x="60" y="428" font-size="15" font-weight="bold" fill="#232323">The coach asks for a season report about you</text>
+  <rect x="60" y="442" width="150" height="62" rx="6" fill="#d5e8d4" stroke="#82b366" stroke-width="2.5"/>
+  <text x="135" y="466" text-anchor="middle" font-size="12" font-weight="bold" fill="#3a6a34">the report</text>
+  <text x="135" y="484" text-anchor="middle" font-size="11" fill="#3a6a34">lives in YOUR house</text>
+  <rect x="260" y="442" width="150" height="62" rx="6" fill="#e1d5e7" stroke="#9673a6" stroke-width="2"/>
+  <text x="335" y="464" text-anchor="middle" font-size="11" font-weight="bold" fill="#4a355c">READING PASS</text>
+  <text x="335" y="480" text-anchor="middle" font-size="9" fill="#4a355c">for: Coach · opens: this report</text>
+  <text x="335" y="494" text-anchor="middle" font-size="9" fill="#4a355c">why: fall season · until: it ends</text>
+  <text x="335" y="518" text-anchor="middle" font-size="11" fill="#4a355c">the coach gets a READING PASS</text>
+  <text x="460" y="462" font-size="12.5" fill="#333">a pass to read it —</text>
+  <text x="460" y="480" font-size="12.5" font-weight="bold" fill="#333">never a hand to carry it off.</text>
+  <text x="460" y="500" font-size="11.5" font-style="italic" fill="#555">season ends → the pass dies by itself → the report stays on your shelf.</text>
+</svg>
+</div><p></p>
+<h2>The doorkeeper's four questions</h2>
+<p>At every door, every time, the doorkeeper asks four questions. Each question is its own question — on purpose, so no answer can be stretched to cover another:</p>
+<p class="li"><strong>"Who are you?"</strong> Show a key. Keys prove it's you; they decide nothing else.</p>
+<p class="li"><strong>"Show the pass for THIS door."</strong> Owner of the house? That's the deepest pass there is. Member pass, reading pass, library card — each opens exactly what it names. No pass, no entry, however nice you are.</p>
+<p class="li"><strong>"What do the thing's own stickers say?"</strong> Even inside a door your pass opens, each paper votes for itself — where it may go, what it may be used for. (This question is the whole robot story.)</p>
+<p class="li"><strong>"Tokens, for the big machines?"</strong> The fancy helpers cost tokens to run. No tokens, no new machine time.</p>
+<p>And the token rule has a hard edge worth saying twice: <strong>tokens buy machine time, never your own house.</strong> Running out of tokens can stop new jobs. It can never, ever bolt your own front door against you. Your stuff doesn't rent itself back to you.</p>
+<p></p><div class="fig"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 500" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="fig3-aG" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#4a9a4a"/></marker>
+  </defs>
+  <rect width="900" height="500" fill="#ffffff"/>
+  <text x="450" y="40" text-anchor="middle" font-size="24" font-weight="bold" fill="#1e5f96">Four questions at every door — none does another's job</text>
+
+  <!-- booth template x4 -->
+  <!-- booth 1 -->
+  <rect x="40" y="90" width="190" height="230" rx="10" fill="#f5f5f5" stroke="#8a8a82" stroke-width="2.5"/>
+  <rect x="40" y="90" width="190" height="44" rx="10" fill="#8a8a82"/>
+  <text x="135" y="118" text-anchor="middle" font-size="15" font-weight="bold" fill="#ffffff">1 · WHO ARE YOU?</text>
+  <rect x="88" y="160" width="94" height="50" rx="8" fill="#fff2cc" stroke="#d6b656" stroke-width="2"/>
+  <circle cx="112" cy="185" r="10" fill="none" stroke="#8a6d1a" stroke-width="2.5"/>
+  <rect x="122" y="182" width="34" height="6" rx="3" fill="#8a6d1a"/>
+  <text x="135" y="238" text-anchor="middle" font-size="12" fill="#555">show a key</text>
+  <text x="135" y="266" text-anchor="middle" font-size="11" font-style="italic" fill="#555">keys prove it's you;</text>
+  <text x="135" y="282" text-anchor="middle" font-size="11" font-style="italic" fill="#555">they decide nothing else</text>
+
+  <!-- booth 2 -->
+  <rect x="260" y="90" width="190" height="230" rx="10" fill="#f0e8f4" stroke="#9673a6" stroke-width="2.5"/>
+  <rect x="260" y="90" width="190" height="44" rx="10" fill="#9673a6"/>
+  <text x="355" y="118" text-anchor="middle" font-size="15" font-weight="bold" fill="#ffffff">2 · SHOW THE PASS</text>
+  <rect x="308" y="164" width="94" height="44" rx="6" fill="#e1d5e7" stroke="#9673a6" stroke-width="2"/>
+  <text x="355" y="182" text-anchor="middle" font-size="10" font-weight="bold" fill="#4a355c">PASS</text>
+  <text x="355" y="198" text-anchor="middle" font-size="8.5" fill="#4a355c">who · door · why · until</text>
+  <text x="355" y="238" text-anchor="middle" font-size="12" fill="#4a355c">owner · member pass ·</text>
+  <text x="355" y="254" text-anchor="middle" font-size="12" fill="#4a355c">reading pass · library card</text>
+  <text x="355" y="282" text-anchor="middle" font-size="11" font-style="italic" fill="#555">no pass, no entry —</text>
+  <text x="355" y="298" text-anchor="middle" font-size="11" font-style="italic" fill="#555">however nice you are</text>
+
+  <!-- booth 3 -->
+  <rect x="480" y="90" width="190" height="230" rx="10" fill="#fbeeee" stroke="#b85450" stroke-width="2.5"/>
+  <rect x="480" y="90" width="190" height="44" rx="10" fill="#b85450"/>
+  <text x="575" y="111" text-anchor="middle" font-size="14" font-weight="bold" fill="#ffffff">3 · WHAT DO ITS OWN</text>
+  <text x="575" y="127" text-anchor="middle" font-size="14" font-weight="bold" fill="#ffffff">STICKERS SAY?</text>
+  <rect x="536" y="158" width="78" height="56" rx="5" fill="#ffffff" stroke="#8a8a82" stroke-width="2"/>
+  <circle cx="552" cy="172" r="11" fill="#f8cecc" stroke="#b85450" stroke-width="2"/>
+  <circle cx="578" cy="172" r="11" fill="#dae8fc" stroke="#6c8ebf" stroke-width="1.5"/>
+  <text x="575" y="240" text-anchor="middle" font-size="12" fill="#7a3230">the paper itself votes</text>
+  <text x="575" y="268" text-anchor="middle" font-size="11" font-style="italic" fill="#555">this booth is the whole</text>
+  <text x="575" y="284" text-anchor="middle" font-size="11" font-style="italic" fill="#555">robot story</text>
+
+  <!-- booth 4 -->
+  <rect x="700" y="90" width="190" height="230" rx="10" fill="#fdf3e6" stroke="#d79b00" stroke-width="2.5"/>
+  <rect x="700" y="90" width="190" height="44" rx="10" fill="#d79b00"/>
+  <text x="795" y="118" text-anchor="middle" font-size="15" font-weight="bold" fill="#ffffff">4 · GOT TOKENS?</text>
+  <circle cx="770" cy="180" r="16" fill="#ffe6cc" stroke="#d79b00" stroke-width="2.5"/>
+  <text x="770" y="186" text-anchor="middle" font-size="14" font-weight="bold" fill="#8a5a00">T</text>
+  <circle cx="806" cy="180" r="16" fill="#ffe6cc" stroke="#d79b00" stroke-width="2.5"/>
+  <text x="806" y="186" text-anchor="middle" font-size="14" font-weight="bold" fill="#8a5a00">T</text>
+  <text x="795" y="238" text-anchor="middle" font-size="12" fill="#8a5a00">the arcade machines —</text>
+  <text x="795" y="254" text-anchor="middle" font-size="12" fill="#8a5a00">fancy helpers cost tokens</text>
+  <text x="795" y="282" text-anchor="middle" font-size="11" font-style="italic" fill="#555">no tokens →</text>
+  <text x="795" y="298" text-anchor="middle" font-size="11" font-style="italic" fill="#555">no NEW games</text>
+
+  <path d="M232,205 L256,205" stroke="#4a9a4a" stroke-width="2.5" marker-end="url(#fig3-aG)"/>
+  <path d="M452,205 L476,205" stroke="#4a9a4a" stroke-width="2.5" marker-end="url(#fig3-aG)"/>
+  <path d="M672,205 L696,205" stroke="#4a9a4a" stroke-width="2.5" marker-end="url(#fig3-aG)"/>
+
+  <text x="450" y="356" text-anchor="middle" font-size="13.5" fill="#555">each booth knows ONLY its own question — and none of them have ears: passes in, decisions out, no talking</text>
+
+  <rect x="120" y="386" width="660" height="84" rx="10" fill="#fffde7" stroke="#c8b900" stroke-width="2"/>
+  <text x="450" y="416" text-anchor="middle" font-size="17" font-weight="bold" fill="#4a4a20">Tokens buy machine time — never your own toy box.</text>
+  <text x="450" y="440" text-anchor="middle" font-size="14" fill="#4a4a20">Running out of tokens can stop new games. It can never bolt the front door of the house</text>
+  <text x="450" y="458" text-anchor="middle" font-size="14" fill="#4a4a20">you already own. Your stuff doesn't rent itself back to you.</text>
+</svg>
+</div><p></p>
+<h2>Borrowed things</h2>
+<p>The library book on your shelf is <em>in</em> your house — but it isn't <em>yours</em>. Holding a thing was never the same as owning it.</p>
+<p>Your <strong>library card is a pass with a date on it</strong>: you to the library, until June. Through it you may read the book, learn from it, write a book report. When the card expires, the book goes home to its shelf — every page. You never got to photocopy it, so there's nothing to sneak.</p>
+<p>But your <strong>book report is yours.</strong> That's what lending a book <em>means</em>: read, learn, make something of your own. The report stays in your house; the book goes back. (If the library had a special rule — "no quoting page 12" — that sticker rides on your report. Glue law, as always.)</p>
+<p>And the comic you found on the street? It's <em>somebody's</em>. You don't know whose, and "I found it" doesn't make it yours. Read it today, fine; copy it into your own zine, no — not unless a grown-up checks and writes down that it's really free to use. Not knowing the owner makes you <em>more</em> careful, not less.</p>
+<h2>Mary's hall pass</h2>
+<p>A pass is a deal in both directions — and the rules ride on the pass. Mary got a hall pass at school: <em>bathroom, and back.</em> But the school store was right there, and candy bars are candy bars. So instead of going back to class she went to the store, bought one, and ate the whole thing before strolling back — half a class later.</p>
+<p>Here's the thing: <strong>no doorkeeper could have stopped her.</strong> Her pass was real. The hallway was allowed. Every door she passed did exactly its job. She got caught anyway — at turn-in. The logbook had the store door's stamp and the times, and stamps and times don't lie. Gates stop what they can. <strong>Logbooks catch the rest.</strong></p>
+<p>And then two things happened, and only the first one is the usual one. The pass was done — fine, it was done anyway. But also: <strong>no hall passes for Mary for the rest of the semester.</strong> Breaking a pass's rules doesn't just end that pass. It changes whether you get the <em>next</em> one.</p>
+<p>The library plays the same game with bigger stakes. Keep the book past your card's date and the library does exactly the thing you agreed to when they handed you the card: a fine, and no new borrowing until it's paid. Nobody's surprised — the deal was on the card the whole time. Sometimes the consequence of breaking a deal is more than a torn-up pass, and you signed up for it on the day you took the pass.</p>
+<h2>Sneaky Bob</h2>
+<p>Sneaky Bob has boxes he'd rather not keep at his own house — if anyone ever comes asking, he wants them found at <em>yours</em>. So he gets clever.</p>
+<p>First he tries fake envelopes: official-looking stamps that say "this belongs at Alice's house." The doorkeeper doesn't even look up. An envelope means something only when a doorkeeper's <em>own</em> stamp is on it, and stamps happen at doors, when a pass is shown. Bob has no pass to your house. There is no envelope he can bring that substitutes for one.</p>
+<p>So he tries the porch. Every house has one open spot on purpose — the delivery porch, where people can leave things for you. At three in the morning, Bob dumps his boxes there. But here's the porch rule: <strong>nothing becomes yours just because it showed up.</strong> Things on the porch are marked <em>delivered — not accepted</em>, and the doorkeeper's logbook records exactly when each one arrived and who left it (or that no pass was shown at all). You take a thing inside, or you don't. Sweep it off the porch, and it was never yours for a single minute.</p>
+<p>And the frame-up itself? It dies at the <strong>logbook</strong>. Every single thing inside your house has a line in the doorkeeper's own handwriting: who brought it, through which door, with which pass. Bob can't write in the logbook. Nobody can — it's the doorkeeper's hand or nothing. So when the police come asking, they don't read piles; they read logbooks. The logbook is the end of Sneaky Bob.</p>
+<p>Notice this is the library rule's mirror: holding a thing was never the same as owning it — and being <em>handed</em> a thing was never the same as answering for it.</p>
+<h2>Goodbyes, and the moving-box promise</h2>
+<p>Watch how many different goodbyes turn out to be the same small thing — <strong>a pass gets torn up:</strong></p>
+<p class="li">Leaving the club? Your member pass — torn. The club balls stay in their bin.</p>
+<p class="li">Season over? The field goes quiet; the coach's reading pass dies on its own; the report stays on your shelf. Your ball is already home — it always was.</p>
+<p class="li">Robot retired? Its lent passes — torn. It owned nothing, so nothing is stranded.</p>
+<p class="li">Library card expired? The book walks home to its shelf; your report doesn't move.</p>
+<p>No boxes, no arguments, nothing carried anywhere. Nobody ever <em>held</em> anyone else's things — only passes to visit them. Tear the pass and the visit is over; every house still holds exactly what it always held.</p>
+<p>And the last rule, the one this whole story protects:</p>
+<blockquote><strong>Any day you like, you can pack your own house into moving boxes and go. There is no switch, anywhere, that bolts your own door against you.</strong></blockquote><p>Not a club rule, not fine print, nothing — on purpose. If such a switch existed, every club would demand it be flipped, and then it wouldn't be your house anymore. And packing is simple, because the first rule did all the work: club papers were never in your house. Borrowed books walk home. Stickers with locks travel still locked. There is nothing in your boxes that belongs to anyone else — which is exactly why no one gets a say about your boxes.</p>
+<p></p><div class="fig"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 560" font-family="Helvetica, Arial, sans-serif">
+  <rect width="900" height="560" fill="#ffffff"/>
+  <text x="450" y="40" text-anchor="middle" font-size="24" font-weight="bold" fill="#1e5f96">Every goodbye is a torn pass — and the moving-box promise</text>
+
+  <!-- big torn pass icon -->
+  <g transform="translate(450,110)">
+    <path d="M-70,-28 L-6,-28 L-14,-14 L-4,0 L-12,14 L-6,28 L-70,28 Z" fill="#e1d5e7" stroke="#9673a6" stroke-width="2.5" transform="rotate(-4)"/>
+    <path d="M70,-28 L2,-28 L-6,-14 L4,0 L-4,14 L2,28 L70,28 Z" fill="#e1d5e7" stroke="#9673a6" stroke-width="2.5" transform="rotate(5) translate(14,2)"/>
+    <text x="-40" y="6" text-anchor="middle" font-size="10" fill="#4a355c" transform="rotate(-4)">PA</text>
+    <text x="52" y="6" text-anchor="middle" font-size="10" fill="#4a355c" transform="rotate(5)">SS</text>
+  </g>
+  <text x="450" y="172" text-anchor="middle" font-size="13" font-weight="bold" fill="#555">the same small motion, every goodbye</text>
+
+  <!-- four goodbye rows -->
+  <g>
+    <rect x="60" y="200" width="180" height="52" rx="8" fill="#fcfcfa" stroke="#b8b8b0" stroke-width="1.5"/>
+    <text x="150" y="222" text-anchor="middle" font-size="13.5" font-weight="bold" fill="#232323">leaving the club</text>
+    <text x="150" y="240" text-anchor="middle" font-size="10.5" fill="#555">the member pass</text>
+    <rect x="270" y="212" width="56" height="30" rx="4" fill="#e1d5e7" stroke="#9673a6" stroke-width="1.5"/>
+    <line x1="266" y1="208" x2="330" y2="246" stroke="#c0392b" stroke-width="3.5"/>
+    <line x1="330" y1="208" x2="266" y2="246" stroke="#c0392b" stroke-width="3.5"/>
+    <text x="360" y="231" font-size="11.5" fill="#555">club keeps club papers · your house untouched · your skills notebook rides along</text>
+  </g>
+  <g>
+    <rect x="60" y="268" width="180" height="52" rx="8" fill="#fcfcfa" stroke="#b8b8b0" stroke-width="1.5"/>
+    <text x="150" y="290" text-anchor="middle" font-size="13.5" font-weight="bold" fill="#232323">season over</text>
+    <text x="150" y="308" text-anchor="middle" font-size="10.5" fill="#555">reading pass dies by itself</text>
+    <rect x="270" y="280" width="56" height="30" rx="4" fill="#e1d5e7" stroke="#9673a6" stroke-width="1.5"/>
+    <line x1="266" y1="276" x2="330" y2="314" stroke="#c0392b" stroke-width="3.5"/>
+    <line x1="330" y1="276" x2="266" y2="314" stroke="#c0392b" stroke-width="3.5"/>
+    <text x="360" y="299" font-size="11.5" fill="#555">the coach's reading pass expires — the report stays on your shelf</text>
+  </g>
+  <g>
+    <rect x="60" y="336" width="180" height="52" rx="8" fill="#fcfcfa" stroke="#b8b8b0" stroke-width="1.5"/>
+    <text x="150" y="358" text-anchor="middle" font-size="13.5" font-weight="bold" fill="#232323">robot retired</text>
+    <text x="150" y="376" text-anchor="middle" font-size="10.5" fill="#555">its lent passes</text>
+    <rect x="270" y="348" width="56" height="30" rx="4" fill="#e1d5e7" stroke="#9673a6" stroke-width="1.5"/>
+    <line x1="266" y1="344" x2="330" y2="382" stroke="#c0392b" stroke-width="3.5"/>
+    <line x1="330" y1="344" x2="266" y2="382" stroke="#c0392b" stroke-width="3.5"/>
+    <text x="360" y="367" font-size="11.5" fill="#555">it owned nothing, so nothing is stranded — every act still signed in the logbook</text>
+  </g>
+  <g>
+    <rect x="60" y="404" width="180" height="52" rx="8" fill="#fcfcfa" stroke="#b8b8b0" stroke-width="1.5"/>
+    <text x="150" y="426" text-anchor="middle" font-size="13.5" font-weight="bold" fill="#232323">library card expires</text>
+    <text x="150" y="444" text-anchor="middle" font-size="10.5" fill="#555">a pass with a date</text>
+    <rect x="270" y="416" width="56" height="30" rx="4" fill="#e1d5e7" stroke="#9673a6" stroke-width="1.5"/>
+    <line x1="266" y1="412" x2="330" y2="450" stroke="#c0392b" stroke-width="3.5"/>
+    <line x1="330" y1="412" x2="266" y2="450" stroke="#c0392b" stroke-width="3.5"/>
+    <text x="360" y="435" font-size="11.5" fill="#555">the book walks home to its shelf — your book report doesn't move</text>
+  </g>
+
+  <text x="450" y="480" text-anchor="middle" font-size="13" font-style="italic" fill="#555">no boxes, no arguments — nobody ever held anyone else's things, only passes to visit them</text>
+
+  <!-- moving box promise -->
+  <g transform="translate(84,500)">
+    <rect x="0" y="6" width="44" height="30" fill="#f6e0b5" stroke="#b8860b" stroke-width="2"/>
+    <path d="M0,6 L10,-4 L54,-4 L44,6 Z" fill="#fce5cd" stroke="#b8860b" stroke-width="2"/>
+    <line x1="22" y1="6" x2="22" y2="36" stroke="#b8860b" stroke-width="1.5"/>
+  </g>
+  <rect x="150" y="494" width="690" height="52" rx="10" fill="#d5e8d4" stroke="#82b366" stroke-width="2.5"/>
+  <text x="495" y="516" text-anchor="middle" font-size="15" font-weight="bold" fill="#3a6a34">Any day: pack your own house into boxes and go. No switch bolts your own door.</text>
+  <text x="495" y="537" text-anchor="middle" font-size="13" fill="#3a6a34">club papers were never in your house · borrowed books walk home · locked stickers travel locked</text>
+</svg>
+</div><p></p>
+<hr>
+<h2>The same story in grown-up words</h2>
+<div class="twrap"><table>
+<tr><th>In the story</th><th>In the architecture</th></tr>
+<tr><td>your house</td><td>a personal tenant — a person IS a tenant; every record has exactly one owner (A1, A2)</td></tr>
+<tr><td>the clubhouse</td><td>an organizational tenant — structurally the same, owned by a club</td></tr>
+<tr><td>a pass (who · which door · why · until)</td><td>a relation/grant — scoped, expiring, lineage-bearing; membership is a relation, never containment (A3)</td></tr>
+<tr><td>the season, played together on the field</td><td>an engagement object — a shared process; org roles see engagement things, never the inside of your house</td></tr>
+<tr><td>bringing your ball to practice</td><td>an owner-granted, activity-scoped grant — implicit, auto-expiring; use never transfers ownership</td></tr>
+<tr><td>the club pays for everything</td><td>org-owned assets, used through membership; they never become yours</td></tr>
+<tr><td>"the why goes away, the pass dies"</td><td>grant lineage — authorization requires a still-valid basis</td></tr>
+<tr><td>keys</td><td>credentials authenticating a principal; <code>#controller</code> relations bind them to the tenant</td></tr>
+<tr><td>whose robot never matters</td><td>agents are tenant-less principals; outputs follow ownership rules, not robot ownership</td></tr>
+<tr><td>papers live where they're made</td><td>creation-context provenance — the creating context stamps the owner</td></tr>
+<tr><td>the coach's office your pass doesn't open</td><td>org-interior workspaces and records — membership never means all-access</td></tr>
+<tr><td>being handed the finished game plan</td><td>an org sharing its asset: your copy carries the club's clause ("team eyes only")</td></tr>
+<tr><td>the coach's notes, never handed out</td><td>org-internal records members never see</td></tr>
+<tr><td>nobody sorts paper by paper</td><td>no per-record adjudication on the normal path</td></tr>
+<tr><td>"what you learned is always yours"</td><td>the IP boundary: claims and profile are personal-owned, always — the resume norm</td></tr>
+<tr><td>the secret's sticker rides along</td><td>inherited disclosure clauses gate details without changing ownership</td></tr>
+<tr><td>the coach's reading pass</td><td><code>#commissioner</code> / <code>#viewer</code> relations — commissioning grants visibility, not ownership</td></tr>
+<tr><td>the four questions</td><td>the four layers: authentication, authorization, disclosure & processing, entitlement</td></tr>
+<tr><td>a doorkeeper at every door</td><td>every boundary crossing is a policy decision point</td></tr>
+<tr><td>Sneaky Bob's fake envelopes</td><td>forged ownership/provenance fails runtime attestation — labels are stamped only at authorized doors</td></tr>
+<tr><td>the delivery porch</td><td>push-capable intake is quarantine: custody-pending until the owner (or the owner's standing rule) accepts — delivery is not acceptance</td></tr>
+<tr><td>the doorkeeper's logbook</td><td>every record carries its runtime-written creating context (principal, channel, revision) — the audit trail attributes the act, not mere possession</td></tr>
+<tr><td>Mary's candy-bar detour</td><td>grants are purpose-bound; adherence that can't be gated in the moment is audited via receipts and the provenance log</td></tr>
+<tr><td>no hall passes this semester</td><td>breach degrades the grantor's future granting policy for that grantee — not just the instance</td></tr>
+<tr><td>the fine that was on the card all along</td><td>pre-agreed remedies ride the grant's terms; for non-resident authorities the system supplies attested evidence, not enforcement</td></tr>
+<tr><td>gates stop what they can; logbooks catch the rest</td><td>prevention at decision points + detection at reconciliation — both required</td></tr>
+<tr><td>doorkeepers have no ears</td><td>the policy runtime accepts only typed inputs (passes, slips, stickers) — no natural-language surface, so injection has nothing to grab</td></tr>
+<tr><td>tokens never bolt your door</td><td>entitlement gates compute, never data</td></tr>
+<tr><td>the library card with a date</td><td>a license as a relation object, time-boxed — access routes through it</td></tr>
+<tr><td>the book goes home; the report stays</td><td>expiry quarantines/purges licensed payloads; term-driven derivation keeps your analytics</td></tr>
+<tr><td>"no quoting page 12" rides the report</td><td>license clauses ride derived work — <code>PolicyTransform</code> is the only legitimate way off</td></tr>
+<tr><td>the street comic</td><td>third-party-unknown intake — public is not public domain; upgrades are recorded human determinations</td></tr>
+<tr><td>every goodbye is a torn pass</td><td>one revocation mechanism: cut the relation; runtime enforcement completes it</td></tr>
+<tr><td>the moving-box promise</td><td>the takeaway export — always available, hard policy, no configuration surface</td></tr>
+<tr><td>what's not in the boxes</td><td>ownership filter, then rights filter, then exportability — clean by construction</td></tr>
+</table></div>
+<p>And the two stories snap together without a seam: houses and passes say <em>whose things are whose and who may visit</em>; slips and stickers say <em>how anything gets done without trusting the persuadable part</em>. The doorkeeper is the same doorkeeper. That's the entire architecture.</p>
+
+<div style="max-width:640px;margin:40px auto 0;font-family:Menlo,Consolas,monospace;font-size:12px;letter-spacing:.08em">
+<a href="/architectures" style="color:#ff5e1a;text-decoration:none">&larr; BACK TO THE DRAWING REGISTER</a>
+</div>
+</body>
+</html>

--- a/docs/architecture/ariadne/tenancy-ownership-access.md
+++ b/docs/architecture/ariadne/tenancy-ownership-access.md
@@ -1,0 +1,1358 @@
+# Ariadne — Tenancy, Ownership, and Access
+
+**Name.** Ariadne gave Theseus the thread that let him walk into
+the labyrinth and get back out. This architecture is that thread:
+provenance and authority traceable in both directions, and a
+guaranteed way out — revocation, takeaway export, leaving day.
+The name pairs with the Theseus engine (Thesium's), where the
+model was first distilled; the architecture itself is
+engine-agnostic and portable.
+
+**Version:** 1.6.0 — tagged `ariadne/v1.6.0`. Cite the tag, not
+`main`: see [VERSIONING.md](VERSIONING.md) for what a major/minor/patch
+bump means and how to fork against a fixed version.
+
+**Status:** v1.5 lineage (2026-07-27; semantic-convergence pass — §11
+rewritten to §13 mechanics, authority-defined policy
+transformations, clause destination-constraints with expiry
+polarity and relaxation modes, purpose-basis, first-class
+delegations, decision envelopes, freshness contract, scoped taint),
+distilled from ADR 008 and its implementation review (both in the
+Thesium Career repository, where this architecture was first written;
+that ADR is the product's own instantiation record, not part of the
+portable architecture). Generic by intent: the model is written to be instantiated in
+any product where people and organizations both hold data. Lineage:
+first implemented for Ixi; ADR 008 adds the Zanzibar relation layer
+and higher-fidelity personal ↔ org ↔ corporate interaction rules.
+
+**Intended reuse:** interview articulation, an RFC for a corporate
+codebase, adoption in other Miniforge products. §8 carries the
+defense material; §11 extends the model to
+agent orchestration and tool egress; §12 to third-party rights —
+licensed feeds and open-web intake; §13 is the executable contract
+the runtime enforces.
+
+**Diagrams** (full-fidelity visual companion, one legend across all
+five, in [diagrams/](diagrams/)):
+
+1. [Core model](diagrams/01-core-model.svg) — tenants, principals,
+   relations; containment vs relation; the four layers; axioms.
+2. [Request path](diagrams/02-request-path.svg) — resolvers, the
+   invocation context, the four-gate gauntlet, the check seam.
+3. [Ownership by provenance](diagrams/03-ownership-provenance.svg) —
+   intake channels, the IP boundary, projections, shared assets.
+4. [Agent orchestration & tool egress](diagrams/04-agent-tool-gates.svg)
+   — delegation, the three tool gates, the disclosure lattice,
+   elevation and scoped grants.
+5. [Revocation & third-party rights](diagrams/05-revocation-rights.svg)
+   — one revocation mechanism across three domains, license routing,
+   the takeaway export.
+
+**Explained simply** (two stories, one universe — together they are
+the simplicity invariant: a change that cannot be told in the story
+is suspect):
+
+- [Your House, Their Clubhouse, and the Passes](explainers/tenancy-for-a-nine-year-old.md)
+  — §1–§9, §12: tenants, membership, provenance, the four layers,
+  licenses, offboarding.
+- [The Robot Helpers and the Sticker Rules](explainers/routing-for-a-nine-year-old.md)
+  — §11, §13: agents, clauses, the doorkeeper, routing.
+
+---
+
+## 1. The problem this solves
+
+Most systems start with one identity: a `user` string (or id) that is
+simultaneously *who is operating*, *who the data is about*, and *how
+rows are keyed*. That conflation is invisible while every operator is
+also the subject of their own data. It becomes structural debt the
+moment any of these appear:
+
+- an operator who is not the subject (an admin, a manager, a coach, a
+  teacher, a support engineer);
+- an organization that shares assets with its members (a rubric, a
+  catalog, a workspace) while members hold data that is *theirs*;
+- offboarding, where the question "what leaves with the person and
+  what stays with the org" must have a structural answer, not a
+  policy document;
+- hosting, where "who may read this row" needs an enforceable answer.
+
+The usual industry answer is org-centric: the workspace owns
+everything inside it. That answer fails any product whose value
+proposition includes *the person's data outlives the membership* —
+and it is unavailable entirely in bottom-up adoption, where no org
+entity exists yet.
+
+This architecture gives ownership, access, and portability a single
+model that serves a single-person local deployment and a multi-org
+hosted deployment without branching, and that can be adopted
+incrementally in a system that has the one-string shape today.
+
+## 2. Core model — four concepts
+
+```text
+Tenant     — the unit of ownership. Two kinds, structurally identical:
+             personal        exactly one person
+             organizational  a company / school / team-of-record
+Principal  — the stable security actor: who is operating.
+             Credentials and tokens are artifacts that AUTHENTICATE
+             a principal; they are not the principal. Binds to
+             tenants via #controller relations (usually one person,
+             one personal tenant); may hold relations into other
+             tenants (admin, manager, coach).
+Workspace  — a context within an organizational tenant (team, program,
+             cycle). A single default until org features need more.
+Engagement — a scoped org↔person process object (an employment, a
+             team membership, a review cycle). Org-granted roles
+             attach to the engagement, never to the person's whole
+             tenant (§4); revoking it revokes everything derived
+             through it.
+Relation   — a Zanzibar-style tuple linking principals and tenants to
+             objects: membership, employment, visibility, commission.
+```
+
+Three axioms carry most of the weight:
+
+**A1. People are tenants.** There is no separate "subject" or "user"
+identity layer. The person a record is about is a personal tenant,
+and `subject-id` *is* a personal-tenant id. This collapses what would
+otherwise be a fourth identity dimension into the ownership dimension
+that already exists.
+
+**A2. Every record has exactly one owner tenant.** One owner slot, no
+dual owner/subject stamping. Anything a second party may see is a
+granted relation, not a second owner. Ownership answers "which
+tenant controls this record's lifecycle, namespace, grants, and
+default portability" (§6); it never encodes "who may see it."
+
+**A3. Membership is a relation, never containment.** A person's
+tenant is *related to* an organization's tenant
+(`tenant:org#member@tenant:person`); it is never nested inside it.
+Joining is writing one tuple; leaving is deleting it. No data moves
+in either direction. Containment would make the org transitively hold
+personal data — offboarding becomes data migration, and
+the-org-owns-your-data returns by structure rather than by decision.
+
+## 3. Four orthogonal layers
+
+The design's discipline is keeping four questions in four layers that
+never leak into each other's schema:
+
+| layer | question | mechanism |
+|---|---|---|
+| Authentication | who is this principal? | resolver-selected per channel and tier: dev/test/trusted-internal self-resolved; shipped paid identity-backed; free per product (§5) |
+| Authorization | may this principal do this to this object? | `check(principal, relation, object)` over relation tuples |
+| Disclosure & processing | what does this record permit — to whom, for what purpose? | per-record policy clauses (audience × exportability × purpose, each carrying its imposing authority — §13.1), evaluated as a record-side veto inside the access check |
+| Entitlement | may this tenant use this feature? | licensing tuples attached to the paying tenant |
+
+Two of these are commonly conflated and must not be:
+
+- **Disclosure is not access control.** A record marked confidential
+  says what the record permits regardless of who asks; a relation
+  tuple says who may ask. A manager relation does not read a
+  confidential record; a public record inside the wrong boundary is
+  still unreachable without a relation path. Modeling tenancy as
+  visibility tiers on a confidentiality enum fails exactly here.
+- **Entitlement is not access.** "May this tenant run this compute"
+  and "may this principal see this record" are different questions
+  with different answers. Fixed rule: **entitlement gates compute,
+  never data** — losing a license never locks reading or exporting
+  what your tenant owns. That is a property right of the owner, not a
+  feature.
+
+## 4. Authorization: the Zanzibar layer
+
+Access is answered only by `check(principal, relation, object)` over
+tuples of the form `object#relation@subject`, where the subject may
+be a principal, a tenant, or a userset (`object#relation`).
+Representative vocabulary:
+
+```text
+record:E#owner@tenant:alice                  ; materialized from the owner column
+tenant:alice#controller@principal:alice      ; identity claims the tenant (§5)
+tenant:acme#employee@tenant:alice            ; employment — the "nesting" relation, as a tuple
+engagement:alice-acme#organization@tenant:acme ; the engagement's org side
+engagement:alice-acme#subject@tenant:alice   ; the employment scoped as an object
+engagement:alice-acme#manager@tenant:dana    ; org-granted role — over the ENGAGEMENT,
+                                             ; never over alice's whole tenant
+assessment:A#engagement@engagement:alice-acme ; commissioned records hang off
+                                             ; the engagement, in the graph
+assessment:A#subject@tenant:alice            ; a two-party record
+asset:R#viewer@tenant:acme#employee          ; userset: all employees may read
+license:L#holder@tenant:dana                 ; entitlement is tuple-shaped too
+license:L#seat@tenant:alice
+```
+
+Org-granted roles attach to an **engagement object** (an employment,
+a team, a review cycle), not to the person's tenant. A tenant-wide
+`#manager` would expose self-serve records, other employers'
+engagements, and private imports; scoping through the engagement
+bounds access to what the engagement commissions — and because
+commissioned records link to the engagement in the graph
+(`assessment:A#engagement@…`), that bound is graph semantics, not
+prose. Revoking the engagement revokes everything derived through
+it. Person-granted relations (a coach the person hires themselves)
+may legitimately be tenant-wide — the owner is granting over their
+own property.
+
+**Person-held roles bind to the person's tenant, resolved through
+its controllers** (`engagement:alice-acme#manager@tenant:dana`,
+exercised by any principal in `tenant:dana#controller` — so Dana
+changing IdP or device does not orphan the role). Direct principal relations are for
+credential-scoped actors: agents, service accounts, workload and
+device identities, where the principal *is* the right grain.
+
+Design consequences:
+
+- **Role facts live in tuples, not on a context or a session.** There
+  is no `roles: [admin]` set threaded through calls; a role is a
+  relation somebody granted and somebody can revoke.
+- **The checker is a seam.** Locally it is an in-process function
+  over the same tuple vocabulary; in the single-tenant case every
+  check resolves through `#owner` and is trivially true. When hosting
+  begins, a Zanzibar implementation (SpiceDB, OpenFGA) replaces the
+  function behind the same `check` signature. Tuple storage, rewrite
+  rules, and consistency tokens (zookies) are that system's concern —
+  they never enter the domain schema.
+- **Negative tests precede the second principal.** A principal with
+  no relation path to a record must be refused by scoped store APIs
+  even while no second principal exists in any real deployment. That
+  is the cheapest moment those tests will ever be written.
+
+## 5. The invocation context
+
+Every entry point (CLI, API handler) resolves one context and threads
+it to every store and pipeline call:
+
+```text
+InvocationContext
+  tenant      — the operating tenant (org or personal)
+  workspace   — a default until org features need more
+  principal   — who is operating
+  subject     — personal-tenant id of the person the operation is about
+  purpose     — processing purpose (service-delivery, analysis, …),
+                evaluated against clause allowed-purposes (§13.1)
+  purpose-basis — what roots the purpose in trusted authority: the
+                grant, engagement, or workflow version that
+                established it. Purpose is set by the trusted
+                resolver or workflow runtime, never asserted by the
+                model; a child agent may narrow it, never widen it
+  run?        — optional explicit run scope
+  revisions   — relation-revision and policy-revision pins, stamped
+                by the runtime for freshness checks (§13.5)
+```
+
+Person-centric products bind one `subject`; the general form is a
+subject *scope* — zero or several subjects — without changing
+anything else here.
+
+Rules:
+
+- **Resolution is deployment-shaped; the context is not.** A local
+  single-operator deployment resolves tenant = subject = the one
+  personal tenant, workspace = default, with no login and no
+  ceremony — a pure function of the request plus local state. A
+  hosted deployment resolves the same fields from authentication.
+  Downstream code cannot tell the difference and never branches.
+- **Store APIs take the context, not naked ids.**
+  `list(ctx)`, `save(ctx, record)` — internally keyed by the owner
+  tenant resolved from the context, with every read/write routed
+  through `check`. Call sites stop threading a bare user-id
+  positional argument, which is the mechanical change that retires
+  the one-string identity.
+- **No derived-identity string conventions.** Patterns like
+  `"{user}--{run_id}"` synthesizing a scoped identity by
+  concatenation are deleted, not migrated; scoping is an explicit
+  context field.
+- **One identifier shape, one validator.** A single shared component
+  defines the legal id shape for every store that embeds an id in a
+  path, filename, row, or hash — before typed ids are introduced.
+  Divergent per-store validation (reject here, sanitize there) is a
+  real observed failure: the same id passes one store and fails
+  another.
+
+**Authentication posture is channel-and-tier policy, not
+architecture.** "Self-authorized local" is a *resolver selection*,
+not a property of the product. The context shape never varies; the
+resolver that establishes `principal` does:
+
+```text
+dev / test / trusted-internal builds → self-resolved: the local
+                                       operator, no ceremony
+shipped free tier                    → decided per product:
+                                       self-resolved OR identity-backed
+shipped paid / pro / corp tiers      → identity-backed, ALWAYS —
+                                       platform identity (App Store)
+                                       or the product's own IdP (DMG),
+                                       whatever the channel
+```
+
+Three consequences, one demand:
+
+- **Identity-backed ≠ hosted.** Binding the principal to a durable
+  identity moves nothing off-box. The quadrant (self-resolved vs
+  identity-backed) × (local vs hosted store) has four valid cells;
+  a shipped local-first product occupies identity + local, and any
+  off-box confidentiality claim survives authentication untouched.
+- **What identity buys**, in existing machinery: entitlement tuples
+  anchored to a durable tenant (store receipts / subscriptions map
+  to `license:` tuples), multi-device as one tenant with many
+  installs, and tenant recovery off dead hardware — complementing,
+  not replacing, the takeaway export.
+- **The free-tier fork is reversible** precisely because the slot
+  is reserved: a free tier shipped self-resolved can adopt identity
+  later without a schema change.
+- **The demand: tenant ids never derive from identities.** The
+  identity maps to the principal in the authentication layer; the
+  principal maps to the tenant; the tenant id stays stable
+  underneath both. A self-resolved free-tier tenant upgraded later
+  is *claimed* by the new identity — bound, never re-keyed. Derive
+  the tenant id from the platform's user id and the upgrade re-keys
+  every content address that embeds it (the §9 M3 landmine, again).
+  Mechanically, claiming writes a validated `#controller` relation
+  (`tenant:alice#controller@principal:alice`, as in §4; an
+  additional device or IdP principal gets its own controller
+  tuple); a tenant can
+  exist with zero current controllers (pre-claim, recovery,
+  deceased-subject custody), and several identities can control one
+  tenant (multiple IdPs, devices). The same-human-two-devices case
+  needs an explicit link/merge policy — never a silent auto-merge.
+
+## 6. Ownership defaults: provenance, not type
+
+The subtle rule set. First, what "owner" means here:
+`owner_tenant_id` is **system control and custody** — the tenant
+that controls the record's lifecycle, namespace, access grants, and
+default portability. It is not a universal legal conclusion; legal
+and policy interests ride separately as relations and clauses
+(subject, commissioner, rights holder, restriction authority — §12,
+§13.1). With that narrowed: **a record's type never implies its
+owner kind** — the creating context decides, which is why the owner
+is a column on the record rather than a rule per type. The defaults:
+
+| record class | owner |
+|---|---|
+| intake / raw material | the **intake channel's tenant** — org-bound connectors land org-owned; personal import lands personal-owned |
+| derived identity — what the system synthesizes *about a person* | the person's tenant, **always**; disclosure inherited from sources |
+| self-serve outputs the person runs for themselves | the person's tenant |
+| shared assets — rubrics, catalogs, templates, workspaces, connector bindings | the **importing tenant**, whichever kind it is |
+| commissioned outputs — work run under an org's process about a person | the person's tenant **by default**; the commissioning tenant holds `#commissioner` / `#viewer` relations; org ownership only by explicit, named org-level policy |
+
+Three rules resolve where ownership and IP claims intersect:
+
+**Provenance rule.** Raw intake is not one thing: material arriving
+through company channels carries the employer's IP claim; material
+the person brings carries none. The route in already has an owner —
+channels/connectors are tenant-owned assets — so intake takes the
+channel's tenant. No per-record adjudication on the normal
+ingestion path. Corrections (a mis-bound connector, a mistaken
+import, a tenant merge) exist as a privileged, audited process that
+recomputes policy and provenance afterward — rare by design, never
+a routine knob. Where no org tenant exists, every channel is
+personal and there is nothing to claim.
+
+**Delivery is not acceptance.** A channel a tenant deliberately
+leaves open to outside senders (a drop folder, inbound mail) is
+pushable by anyone — by design — which is exactly what an
+ownership-planting attack abuses: park liability-bearing material
+in a victim's tenant so possession attributes to them. Two
+defenses, both structural. Externally-pushed material lands
+*custody-pending*: provenance records the arrival (source, channel,
+time, authenticating principal if any), and the record joins the
+tenant's owned set only on acceptance — by the owner, or by a
+standing rule the owner set. And provenance itself is
+runtime-written at the door: forged ownership metadata fails
+attestation (§13.4), and every record's creating context names the
+principal and channel that produced it — the audit trail attributes
+the *act* of delivery, never mere presence. "Possession is not
+rights" (§12) has a mirror: delivery is not liability.
+
+**Derivation rule (the IP boundary).** What the system synthesizes
+about a person is personal-owned regardless of source provenance —
+the norm that has always governed resumes: the experience is the
+person's, the documents are the employer's. The source restriction
+travels as *inherited disclosure*, not as ownership: a derived record
+built from confidential org material persists in the person's tenant
+but cannot export the confidential specifics. Derived records inherit
+the **most restrictive** disclosure of their sources. On exit, the
+employer keeps (and re-closes) its documents; the person keeps the
+derived identity, still gated.
+
+**Commission rule.** Output produced under an org's process for a
+person's benefit belongs to the person; the org gets visibility
+relations. Deployments that genuinely need official-record semantics
+flip this by an explicit org-level policy set at onboarding — an
+opt-in with a name and a visible cost, never the architecture's
+default.
+
+One more empirical warning from the source system: the bigger
+migration risk was not user-keyed data but **unowned data** — shared
+corpora, catalogs, event logs, license state that were install-scoped
+world-state with no owner at all. Migration must *add* ownership to
+those, not merely re-scope what already had a key.
+
+## 7. Offboarding and portability
+
+Offboarding is the model's proof. It composes structurally:
+
+1. **Tuple delete.** Removing the employment/membership and seat
+   tuples revokes the org's relations into the person's tenant and
+   the person's access to org-owned records. The personal tenant and
+   everything it owns are untouched. Nothing converts, because
+   nothing was ever the org's.
+2. **Entitlement gates compute, never data** (§3). Losing the seat
+   never locks reading or exporting one's own tenant. The path from
+   corporate to personal use is a re-license against the same tenant,
+   not a migration.
+3. **The takeaway export is first-class and always available.** The
+   person can export their tenant at any time — not only at
+   offboarding, by which point the hardware may already be
+   surrendered. Contents: exactly the records the person's tenant
+   owns, each filtered through the disclosure export gate. Org-owned
+   intake is excluded *by ownership* before disclosure even applies —
+   so the bundle cannot contain employer IP by construction, which is
+   the whole defense. Restore is a tenant restore (ids, provenance,
+   disclosure intact), not re-ingestion.
+4. **The takeaway right is hard policy with no configuration
+   surface.** There is deliberately no org setting, policy pack, or
+   deployment flag that disables or narrows it — the existence of the
+   switch is what invites the procurement demand, and the bundle is
+   clean by construction, so there is nothing of the org's to
+   protect. Any commercial exception is a per-contract bespoke fork,
+   priced as such — not a feature.
+
+The asymmetry is the point: the employer keeps its documents; the
+person keeps their derived identity; neither side keeps the other's
+property. In product terms the takeaway export is also the retention
+funnel — the departing member leaves with their tenant in hand and a
+personal re-license path, instead of both sides losing the
+accumulated value.
+
+Side effect worth naming: the personal tenant is a natural unit of
+erasure and export, which is the shape GDPR-style
+portability/deletion requests want.
+
+## 8. Defense — alternatives rejected, objections answered
+
+### Alternatives (each considered and rejected in the source ADR)
+
+- **Owner column only, no context.** Adds ownership but keeps
+  operator and subject conflated in one identity — which is the
+  actual bug observed in practice (import paths and boundary builders
+  silently stamping operator = subject = owner).
+- **Full multi-tenant infrastructure now** (identity provider,
+  hosted relation engine, membership admin). Builds hosting machinery
+  with zero hosted users, against local-first constraints. The model
+  is adopted now precisely because the *vocabulary* is cheap and the
+  *infrastructure* is deferrable behind the `check` seam.
+- **Do nothing until hosting.** Every new feature keeps minting
+  string-keyed records and ownerless world-state; shapes harden into
+  de facto contracts that must be re-keyed under live load. (Observed
+  concretely: a content-address formula that embedded the user string
+  — see migration §M3.)
+- **Tenancy as tiers on the confidentiality enum.** Conflates
+  disclosure with access; someone gains access by a record being
+  "public" within the wrong boundary. The axes must stay orthogonal.
+- **Dual stamping: `tenant_id` + `subject_id` on every record.**
+  (The v1 draft of the source ADR.) Ownership becomes two-keyed
+  everywhere; offboarding requires moving or re-keying data out of
+  the employer's tenant; and it invents an identity layer that
+  people-are-tenants gets for free.
+- **Containment: personal tenants nested inside org tenants.**
+  Uniform ownership, but the org transitively holds personal data —
+  offboarding becomes data migration. Zanzibar has no containment
+  primitive anyway; hierarchy is tuples plus rewrite rules, so the
+  relation form is the same expressiveness without the trap.
+- **Org owns everything** (the industry-standard corporate-workspace
+  model). Rejected as the *default* on three grounds: the member's
+  data dies on exit, killing any data-outlives-membership value
+  proposition; it is meaningless in bottom-up adoption where no org
+  tenant exists; and it is unnecessary — official-record deployments
+  get the semantics as a named, explicit policy flip.
+- **Person owns everything, including org-channel intake.** The
+  mirror error: the employer's documents walk out with every
+  departing employee. Enterprise buyers will not accept it, and it misstates the
+  IP reality the provenance rule encodes.
+
+### Objections and answers
+
+**"Why ReBAC instead of RBAC/roles?"** Roles are facts someone
+granted; tuples make grant and revoke first-class and auditable.
+Usersets express groups (`asset#viewer@tenant:org#employee`) without
+a parallel groups system. RBAC is expressible inside ReBAC (a role is
+a relation); the converse — per-object, per-person sharing — is
+where RBAC deployments grow ad-hoc side tables.
+
+**"Isn't this over-engineering for a single-user product?"** The
+local resolver reduces the machinery to constant context fields and
+trivially-true checks — measured cost is a parameter through
+signatures. What it buys even single-user: new code asks "may this
+principal see this record" instead of assuming yes, and negative
+tests exist before the second principal does. A personal deployment
+stays a tenant of one indefinitely; the cost never grows.
+
+**"Where's consistency handled? The new-enemy problem?"** In the
+hosted engine, deliberately. Zanzibar-class systems solve stale-tuple
+/ new-enemy ordering with snapshot tokens (zookies); the domain keeps
+them out of its schema by treating `check` as the seam. Locally the
+question is moot (one principal, in-process function).
+
+**"Performance of check-per-read?"** Locally: an in-process function
+short-circuiting on `#owner`. Hosted: the engine's caching and
+denormalization problem — Zanzibar's published design and its open
+implementations exist precisely because this is solvable at scale.
+
+**"Why not per-tenant databases or row-level security now?"** Both
+are physical isolation strategies, not models. Columns + scoped
+queries + the check seam preserve the option; choosing cells/RLS
+early buys operational cost before any hosted user exists.
+
+**"What stops the org from demanding the takeaway switch?"** Nothing
+stops the ask; the architecture removes the surface. The bundle
+contains no org property by construction (ownership excludes it;
+inherited disclosure gates the residue), so the demand has no
+technical object — and the absence of the knob is deliberate policy,
+with the bespoke-contract fork as the priced escape valve.
+
+**"Authentication is deferred — isn't that a hole?"** It is a
+separate layer with a reserved slot (`principal`), not an omission
+inside this model. Self-resolution is the posture of dev, test, and
+trusted-internal builds; shipped paid tiers are identity-backed from
+day one, and the shipped free tier picks its posture per product
+(§5). The slot fills without the shape changing — which is the
+point of reserving it.
+
+## 9. Migration pattern (from a one-string system)
+
+Generalized from the source system's five-step sequence; each step
+leaves the product fully working, none requires login or hosting.
+
+- **M1 — identifiers + context.** One id-validation component adopted
+  by every store that embeds ids in paths/rows/hashes; the
+  `InvocationContext` schema; a local resolver at each entry point.
+  No storage change.
+- **M2 — thread the context.** Entry points build a context;
+  pipeline/store signatures take it; bare user-id positional
+  arguments removed; wire field renamed `user` → `subject`.
+- **M3 — stamp ownership.** `owner_tenant_id` on owned records per
+  the §6 defaults; owners *added* to previously unowned world-state.
+  Existing id strings are registered as personal tenants and adopted
+  **verbatim** — landmine: if any content-address or hash embeds the
+  id string, renaming re-keys the store; values must survive
+  migration untouched.
+- **M4 — kill derived-identity conventions.** Explicit run/scope
+  fields replace string-concatenation identities.
+- **M5 — relations + tests.** The `check` seam + local tuple checker;
+  operator/subject taken from context everywhere they were collapsed;
+  disclosure-inheritance and negative-authorization tests land.
+
+Sequencing rationale: vocabulary before storage (M1–M2 make every
+call site say what it means), storage before enforcement (M3 gives
+`check` something to materialize `#owner` from), enforcement last
+(M5) when it can be tested against real shapes.
+
+## 10. Instantiations
+
+Instantiation records live with their adopters, not here: an adopting
+system documents its own mapping (and its own migration state) in its
+own repository, at the Ariadne version it adopted. Miniforge's is
+[rfc-ariadne-adoption.md](../rfc-ariadne-adoption.md).
+
+Keeping this section empty is deliberate. A portable architecture that
+accumulates adopter-specific tables stops being portable, and adopters
+should not have to read someone else's domain to find the mechanism.
+
+## 11. Agent orchestration: principals, not tenants
+
+Agents (single or multi-agent systems) fit the model without new
+concepts — but only if they land on the right side of the
+tenant/principal split.
+
+### 11.1 An agent is a principal that owns nothing
+
+Tenants exist to own, and an agent must own nothing. The rule that
+reconciles this with §6: **execution artifacts follow the launching
+context; domain outputs follow the ownership defaults for the
+artifact class they become.** Run state, working memory, and
+execution traces belong to the launching/operating tenant (the
+session is a channel, and the channel has an owner). What the run
+*produces* is classified like any other record: subject-derived
+output → the subject's personal tenant (the commission rule); an
+org operational report → the org tenant. A runtime that stamps all
+agent outputs with the session owner silently bypasses the
+derivation and commission rules — that is the bug this rule exists
+to forbid.
+Giving an agent a tenant creates an ownership boundary where a
+person's or org's records can land as the property of a process —
+then decommissioning the agent becomes data migration, which is the
+containment trap (§8, nesting) rearranged.
+
+The model already reserves the slot: a principal maps to a personal
+tenant *usually* 1:1. An agent principal is the exception — a
+principal with no tenant behind it. Each agent instance gets its own
+principal id and never operates as the human's principal.
+Impersonation is banned by construction; delegation is explicit.
+
+### 11.2 Delegation is granted; attenuation is monotone
+
+A delegation is a **first-class grant object**, not a bare tuple.
+Tuples express its reachability; the grant record holds identity,
+constraints, and lineage:
+
+```text
+delegation:D#grantor@principal:alice         ; who delegated
+delegation:D#grantee@principal:agent-a       ; to whom
+delegation:D#basis@engagement:alice-acme     ; why it exists (lineage)
+run:R#delegation@delegation:D                ; which run rides it
+```
+
+with the grant record carrying scope, purpose, argument constraints,
+allowed capability versions, `:delegable?`, TTL, policy version, and
+revocation state (§13.6). Two simultaneous delegations between the
+same human and agent can then differ in scope and expiry without
+colliding — and lineage points at an immutable grant *generation*,
+so recreating a same-named relation later never resurrects a
+descendant's validity.
+
+Consequences:
+
+- **Audit.** Every action is attributable to the agent principal;
+  on-behalf-of derives from the delegation object. No log
+  archaeology to distinguish the human's hand from the agent's.
+- **Revocation.** Cutting the delegation (or its basis) is
+  authoritative immediately; the runtime completes it — commit-time
+  recheck, lease fencing, stale-result rejection (§13.5). No data
+  moves, same shape as offboarding.
+- **Blast radius.** A rogue, buggy, or prompt-injected agent can
+  reach exactly what its grants allow and nothing else. This is the
+  central argument: injected text can talk the model into *wanting*
+  anything, so authority must live outside the model — in grant
+  objects the injected text cannot write.
+- **Sub-agent chains.** Delegating requires the separate
+  `:delegable?` authority — holding a capability never implies the
+  right to pass it on — and a child's constraints must fit within
+  the parent's *delegable* constraints. Attenuation stays monotone
+  through orchestration depth; the confused-deputy escalation path
+  is closed structurally.
+- **Expiry.** Agent grants are task-scoped and short-lived by
+  default (condition TTLs); locally the resolver bounds the
+  lifetime.
+
+### 11.3 Tools: the agent proposes; the runtime decides
+
+An agent never invokes an effectful tool. It **proposes a
+transaction** — capability version, binding, canonical arguments,
+labeled input references, destination, expected effect — and the
+deterministic runtime evaluates the proposal across three planes
+(§13.3):
+
+1. **Authority** — capability grant, object access, and grant
+   lineage: may this principal use this binding, on these records,
+   under a still-valid basis? Tool bindings are tenant-owned assets
+   (same class as connector bindings), so who may invoke them is
+   ordinary relation vocabulary; store-level checks run with the
+   agent principal in the invocation context — no parallel
+   enforcement path for data.
+2. **Information flow** — do the inputs' policy clauses admit this
+   destination, for this purpose (§11.4, §13.1)?
+3. **Effect** — is the operation's impact class within the grant
+   (§13.3)?
+
+Parameter-level constraints — "only these recipients," "under this
+spend cap" — are argument constraints on the grant and binding, and
+the *classification* of arguments is never the model's to assert:
+trusted destination-resolution code derives the destination from
+canonical arguments, the capability version fixes the possible
+effect classes, and the resolver establishes purpose (§5). The
+model proposes arguments; it does not classify their consequences.
+
+### 11.4 Tools are a disclosure surface
+
+Every tool invocation with effects beyond the process is a
+disclosure event: data crosses a boundary toward some audience. The
+record-side policy (confidentiality × exportability) already says
+what each record permits; the missing half is what audience the
+tool's effect reaches. So each tool binding carries an **egress
+audience**:
+
+```text
+local      — computes in-process; no egress (a parser, a scorer)
+tenant     — effects stay within the operating tenant's boundary
+related    — reaches principals in related tenants (a shared
+             workspace, a commissioner's view)
+external   — leaves the trust boundary entirely (email out, web
+             POST, third-party API)
+```
+
+The invocation rule: every input to the call — records, derived
+values, context taint (below) — contributes its **policy clauses**
+(§13.1), and the resolved destination must satisfy *every* clause.
+The ladder above is UX shorthand; the decision compares a
+structured destination descriptor against each clause's constraints
+(§13.2).
+
+- Every clause satisfied: proceeds, silently.
+- A clause unsatisfied, where its relaxation mechanism permits:
+  **human-in-the-loop elevation** — approved through that clause's
+  authority, per invocation, and recorded.
+- A clause whose relaxation mode is *none* (`never-export`-class):
+  refused. No ask path exists, so the queue cannot be farmed by
+  injected content.
+
+This is label-based information-flow control (decentralized, per
+Myers–Liskov: each clause carries its authority) with tools as the
+declassification points and elevation as the declassifier. Two acts
+must stay distinct: **elevation never relabels** — it is a flow
+exception attached to (payload, destination, invocation), and the
+record keeps its clauses; a *persistent* relaxation is the separate
+act §13.1 defines, authorized by every affected clause's authority.
+Conflating them makes every approval quietly launder the record for
+all future flows.
+
+Two properties make this hold against adversarial content:
+
+- **Inheritance closes the laundering hole.** Derived values carry
+  every source clause (§13.1), so summarize-the-confidential-doc-
+  then-email-the-summary meets the same gate as emailing the
+  original. The agent cannot downgrade by transformation — only an
+  authority-defined policy transformation, executed by a trusted
+  capability version, removes a clause (§13.1).
+- **Elevation is human-only and out-of-band.** The elevation
+  affordance is not a tool the agent can call with arguments it
+  authored — otherwise injection simply asks for elevation politely.
+  It is a channel to the human that renders exactly what will cross
+  the boundary, scoped to that invocation, never a standing setting.
+  The two downgrade paths — writing tuples, approving elevation —
+  both live outside the model channel. That pair is the whole
+  security argument for agentic operation.
+
+The friction objection answers itself: the audience comparison
+silences `local` and `tenant` tools entirely; elevation fires only on
+above-audience flows, which is precisely where a human should be
+looking. The thing to resist is *unscoped, self-service* standing
+grants — they are how scope creep returns; the disciplined form is
+§11.5's scoped grants. Frequent elevation prompts remain a
+diagnostic: either labels are wrong or payloads are too coarse.
+
+Three known limits, conceded up front:
+
+- **Label creep.** Clause union ratchets monotonically: long
+  derivation chains accumulate restriction, then elevation fatigue,
+  then rubber-stamping. The corrections are authority-defined
+  policy transformations (§13.1 — the legitimate clause-removal
+  path), granular payloads (a call that sends only what it needs
+  carries fewer clauses), and clause normalization/subsumption so
+  semantically identical clauses do not multiply.
+- **Aggregation.** N individually-public records can be jointly
+  sensitive; the union of empty clause sets is empty, so the
+  mechanism passes what the compilation discloses. The model's
+  partial answer: aggregates are derived records and may receive
+  clauses at creation exceeding their sources'. Automatic detection
+  of jointly-sensitive aggregates is out of scope.
+- **Context taint.** An agent's working context is itself a labeled
+  surface: tool results flow in and later flow out through other
+  tools. The enforced v1 is scoped, not global (§13.4): an
+  artifact's clauses come from its actual inputs; an agent's
+  context carries the union of what that agent actually read. The
+  agent's reply to its human is an egress channel like any other —
+  its audience is the delegating principal, which is why it is
+  usually silent.
+
+### 11.5 Elevation at scale: scoped grants and label authority
+
+Per-invocation elevation does not survive contact with real
+workloads: the human approving the fifteenth identical flow stops
+reading, and fatigue converts the gate into a rubber stamp. The fix
+is not weakening the gate; it is letting an approval mint a **scoped
+grant**:
+
+```text
+once       — this invocation only (the default)
+session    — this agent session; dies with the context it was
+             evaluated against
+context    — a named scope (a repo, a workspace, a review cycle),
+             time-boxed
+permanent  — not a grant: a persistent relaxation through the
+             clause authority's mechanism (§13.1)
+```
+
+- **Grants are tuples with conditions** (TTL, session id — SpiceDB
+  caveats, OpenFGA conditions), living in the same store as all
+  other authority: auditable, revocable by delete, expiring by
+  default. This is just-in-time privileged access (PIM, in
+  Microsoft's vocabulary): time-boxed, context-scoped,
+  approval-routed, re-certified — never silently permanent.
+- **Grants attach to flows, not tools.** A grant names (principal,
+  record class, audience, scope). Granting the *tool* reopens the
+  laundering hole — any payload rides the approved channel. This is
+  the gap in current agent harnesses: "always allow this tool" is a
+  channel bypass, not a flow decision.
+- **Session scope is taint-coherent.** The approval was informed by
+  what the session had read; a new session is new taint, so
+  re-approval is the correct default, not friction.
+
+**Label authority: a clause is relaxed only through the mechanism
+its imposing authority defined.** Record ownership is not enough.
+Self-service relaxation — including persistent transformation —
+applies only to clauses your own tenant imposed. A record you own
+can carry a clause that is not yours: a claim derived from another
+tenant's confidential sources inherits their clause (§6, §13.1).
+The record is yours; that clause is theirs; relaxing it goes
+through *their* declared mechanism — approval workflow, quorum,
+policy transformation, automatic embargo release, or none (§13.1).
+Authorities need not be tenants: licensors, contracts, and
+compliance regimes impose clauses without residing in the system
+(§12). You cannot change the escalation surface of a clause you did
+not impose, no matter what you hold.
+
+The clause's authority publishes the **relaxation workflow**: for
+this record class × destination × requesting principal, which
+scopes may be granted, by which approvers, at what TTL. Requests
+route to those approvers; the agent may request — the request
+carries the rendered payload and its clauses — and never
+self-approves. A relaxation mode of *none* keeps no request path,
+so the queue cannot be farmed by injected content. And **an
+approval request is itself a disclosure**: rendering the payload to
+an approver is an information flow, so the approver must be
+entitled to see it — otherwise the workflow shows a policy-safe
+redacted preview or routes to a differently-authorized approver
+(§13.3). The model cannot bypass disclosure by asking a broadly
+visible queue to display the data.
+
+This is the decentralized label model (Myers–Liskov): labels carry
+their policy's owner, and only that owner declassifies. The PIM
+framing and the DLM framing are the same design seen from
+operations and from theory.
+
+### 11.6 When the tool and the domain are the same thing
+
+Email complects the two: it is a tool (send) and a domain (messages,
+threads, a mailbox that is itself owned data). The decomposition uses
+axes the model already has:
+
+- **The domain records** — messages, threads, the mailbox — are
+  ordinary owned records. A connected mailbox is an intake channel;
+  the provenance rule stamps ownership; *reading* mail through the
+  tool is intake plus store-checked reads. No egress ceiling is
+  involved in reading.
+- **The channel** — the send binding — is a tenant-owned asset with
+  an egress audience.
+- **The audience may be argument-dependent.** A recipient field means
+  the binding has no single static ceiling: sending to yourself, to a
+  teammate, and to an arbitrary third party are different audiences.
+  Resolve the audience per invocation from the argument (self /
+  same-tenant / related tenant / external), then run the same
+  record-versus-audience comparison. Where per-invocation resolution
+  is unwanted, split the binding by destination class — send-to-self,
+  send-within-org, send-external — each with a fixed ceiling and its
+  own capability tuple.
+
+The model survives the tool/domain entanglement because "what may
+be disclosed" has always meant "to whom, for what" — a clause
+constrains destinations, not tools. The tool never had one ceiling;
+the *invocation* has one resolved destination. The recipient
+argument resolves the destination descriptor (by trusted resolver
+code, §11.3); the payload's clause set resolves the data side; the
+clause-versus-destination decision (§11.4, §13.2) is unchanged.
+
+### 11.7 Ownership mapping and objections
+
+| agent artifact | disposition |
+|---|---|
+| definitions — prompts, configs, tool bindings | shared assets, owned by the authoring tenant (same class as lenses) |
+| instances | principals: tenant-less, tuple-scoped, expiring |
+| run state, working memory, execution traces | the launching/operating tenant (execution artifacts) |
+| domain outputs | the §6 defaults for what the artifact becomes — subject-derived → personal; org report → org |
+| compute | billed to the delegating tenant's entitlement |
+
+**"Why not just sandbox the agent?"** Sandboxing bounds the process;
+tuples bound authority; disclosure bounds egress. Different failure
+modes — and only the last two survive the agent moving to hosted
+compute, gaining a new tool, or spawning children.
+
+**"Can't a well-tested agent be trusted with elevation?"** The gate
+is not about the agent's intent. The agent's input channel is
+writable by adversarial content, so any authority reachable from the
+prompt is reachable from an injection. Trustworthiness of the model
+does not change who can write to it.
+
+**"Doesn't this slow orchestration down?"** The capability check is
+one tuple lookup; the data checks were already there; the audience
+comparison is an enum compare except when it correctly stops
+something. The expensive path — elevation — is rare by construction
+and expensive on purpose.
+
+## 12. Third-party rights: licensed and public intake
+
+Connector intake stamps ownership by the channel's tenant (§6), and
+disclosure labels classify what each record permits. Both are
+insufficient for payloads whose underlying rights belong to someone
+outside the system: a licensed data feed, a scraped web page.
+**Possession is not rights.** The owner column says who custodies
+the record inside the system; it cannot say the record is yours to
+keep, redistribute, or retain past a contract date. Conflating the
+two accrues legal liability at intake speed.
+
+### 12.1 The rights label and the external authority
+
+Records carry a rights component alongside disclosure:
+`{rights-holder, license-ref, terms-class}`, with terms classes:
+
+```text
+owned                — the custodian tenant holds the rights
+licensed             — use-bound: retention, redistribution, and
+                       derivation limits, with an expiry
+public-domain        — affirmatively determined, not assumed
+third-party-unknown  — provenance known, terms unknown (the default
+                       for open-web intake)
+```
+
+The label-authority rule (§11.5) extends without modification: a
+license term is a restriction imposed by an authority that is not
+resident in the tuple store. No principal inside the system can
+lower it — compliance or out-of-band renegotiation are the only
+moves. The decentralized label model was built for exactly this:
+the policy's owner need not be a member of your system to be the
+only party who can relax it. In the executable form (§13.1) rights
+and disclosure are one mechanism: a rights label is a policy clause
+whose authority happens to be non-resident — not a parallel label
+system.
+
+### 12.2 License as a relation object; expiry as offboarding
+
+```text
+record:R#rights@license:market-data      ; readability routes through
+                                         ; the license node
+license:market-data#beneficiary@tenant:alice ; time-boxed grant
+```
+
+- **Access to licensed payloads routes through the license
+  object,** evaluated at check time. Expiry or invalidation cuts
+  one relation and severs every record behind it — no re-stamping
+  of a million rows. Structurally this is offboarding again: the
+  licensor is a non-resident tenant, the license is the employment
+  tuple, expiry is the tuple delete.
+- **Expiry semantics follow the terms:** quarantine first (checks
+  fail, payload held through a grace/renewal window), purge where
+  the contract requires destruction. Content-addressing splits the
+  cost: the catalog entry and fingerprint are the custodian's and
+  survive; the payload evicts; renewal re-fetches into the same
+  identity.
+- **No tension with "entitlement gates compute, never data"
+  (§7).** That invariant protects the tenant's *property* from a
+  product-license lapse. Licensed payloads were never the tenant's
+  property — the license is the only path to them, so the path
+  dying with the license is the invariant working, not an exception
+  to it.
+
+### 12.3 Derivation across a license boundary
+
+Disclosure inheritance stays most-restrictive (§6). Rights
+inheritance is **term-driven**: the license object carries a
+derivation clause stating what derived records may be. A financial
+feed of this kind licenses the raw series for use with
+retention bounds while derived analytics belong to the analyst —
+so raw quotes carry `licensed` with expiry, and the model's own
+outputs over them carry `owned`. Absent explicit terms, derived
+records keep the third-party rights label — the safe default.
+
+This is consistent with the claims-are-the-IP-boundary rule (§6),
+not a second system: there the governing agreement is the
+employment norm (the resume convention); here it is the license
+contract. In both, what crosses the derivation boundary is decided
+by the governing agreement — the model just makes the agreement
+machine-readable instead of hard-coding one norm. In §13.1 terms,
+a derivation clause *is* an authority-defined policy
+transformation: clause union is the default, and only a trusted
+capability version applying the licensor's declared transform may
+drop the raw-data clauses from the analytics — emitting proof of
+which transform ran.
+
+### 12.4 The open web: public is not public domain
+
+Copyright defaults on — a scraped page has an author and unknown
+terms, and "publicly reachable" grants nothing. Default label for
+open-web intake: `third-party-unknown` with ephemeral-use terms:
+
+- transient retention, scoped to the task or session;
+- derived claims and summaries permitted — facts are not
+  copyrightable, expression is; the derivation carries the
+  third-party label until determined otherwise;
+- raw-payload retention, redistribution, and external egress
+  refused by default.
+
+Upgrading the label is a **recorded human determination** — a
+license discovered, terms of service that permit, public-domain
+status confirmed — through the same elevation machinery (§11.4–
+11.5), with the determination and the determiner in the audit
+trail. The liability position several frontier labs bought into
+class actions is precisely the inverse: no rights label at intake,
+retention by default, and no record of anyone deciding anything.
+This architecture makes the conservative label the default and the
+risky position a named human's recorded decision.
+
+Fetch terms ride the binding: a web-fetch binding carries
+per-source terms knowledge (API terms, site ToS) the same way
+connector bindings carry egress audiences — the channel knows its
+contract in both directions.
+
+**The takeaway export filters by rights as it filters by
+ownership.** Licensed payloads and unknown-rights raw payloads stay
+out of the bundle; manifests and pointers — the custodian's own
+records — ride, so a departing person re-fetches under their own
+license rather than carrying the licensor's property out.
+Employer-IP-clean, licensor-clean, same construction.
+
+## 13. The executable contract
+
+Everything above is the conceptual model; this section is what the
+model compiles to when a runtime enforces it. Sourced from an
+adversarial review of v1.3; each subsection is the simplified form
+of a gap that survived scrutiny. The organizing thesis is worth
+stating once:
+
+> **Models propose. Deterministic authority, information-flow, and
+> effect-control systems decide and execute.**
+
+### 13.1 Labels are clause sets, not scalars
+
+A scalar "most restrictive" label loses *whose* restriction it is
+when sources from different authorities combine — derive from
+Acme-confidential and licensor-restricted material and one enum
+cannot say who may relax the result. The normative label is a set
+of clauses:
+
+```clojure
+{:policy-clauses
+ [{:authority [:tenant "acme"]        ; resident imposer
+   :allowed-operations #{:read :derive}          ; no :export — operations
+                                                 ; ARE the exportability axis
+   :allowed-purposes   #{:service-delivery}
+   :destination-constraints                      ; what the decision
+   {:trust-zones       #{:local :tenant}         ; compares against the
+    :regions           #{:us}                    ; destination descriptor
+    :max-retention     :zero                     ; (§13.2)
+    :training-use      :forbidden}
+   :validity   {:valid-until nil}
+   :relaxation {:mode :approval-workflow         ; HOW exceptions are
+                :workflow-ref "acme-release-v3"}} ; authorized (§11.5)
+  {:authority [:license "market-data"] ; non-resident imposer (§12)
+   :allowed-operations #{:read :derive}
+   :allowed-purposes   #{:analysis}
+   :destination-constraints {:trust-zones #{:local}}
+   :validity   {:valid-until #inst "2099-01-01T00:00:00Z"  ; placeholder
+                :on-expiry :deny}                ; expiry POLARITY: a
+   :relaxation {:mode :policy-transform}}]}      ; license dies closed;
+                                                 ; an embargo would say
+                                                 ; :on-expiry :release
+```
+
+- **Derivation = clause union.** A derived value carries every
+  source clause; effective permission is the intersection of what
+  the clauses allow. "Most restrictive input governs" survives as a
+  consequence, with authorship intact.
+- **Elevation must satisfy every applicable authority**, not the
+  strictest one — two imposers means two approval routes (§11.5).
+- One mechanism covers disclosure, org restrictions, licensed
+  rights, and third-party rights. Exportability is not a parallel
+  enum: it is the `:export` member of a clause's
+  `:allowed-operations`. The four coarse classes and the audience
+  ladder remain as UX and indexing shorthand over this.
+- The declared `purpose` on the invocation context (§5) is checked
+  against clause `allowed-purposes`: reading for service delivery
+  does not license training, cross-customer analytics, persisted
+  embeddings, or marketing. Purpose is a dimension of the
+  disclosure axis, not a fifth layer — and it is rooted in a
+  `purpose-basis` (§5), never model-asserted.
+- **Expiry has polarity.** `:on-expiry :deny` (a license: permission
+  ends, payload quarantines) and `:on-expiry :release` (an embargo:
+  the restriction ends) must never share an ambiguous field —
+  dropping an expired license clause by default would silently
+  broaden access.
+- **Relaxation is machine-readable per clause** — approval workflow,
+  quorum, policy transform, automatic release, or none — not
+  inferred from the authority's kind (§11.5).
+- Clause sets are **normalized**: deduplication, subsumption, and a
+  content-addressed policy digest keep union bounded through long
+  derivation graphs and make labels cacheable and comparable.
+
+**Authority-defined policy transformations** are the one legitimate
+clause-removal path, resolving clause union against term-driven
+derivation (§12.3). Default: output clauses = union of input
+clauses, always. A clause is removed or rewritten only when the
+deterministic runtime applies a transformation the clause's
+authority declared:
+
+```clojure
+{:transform-id        "market-data-derived-analytics-v2"
+ :authority           [:license "market-data"]
+ :input-clause-match  {:license-ref "market-data"}
+ :consume-clauses     #{:raw-retention :raw-redistribution}
+ :emit-clauses        #{:citation-required}
+ :capability-versions #{"analytics-engine@4.2"}  ; ONLY these may run it
+ :proof-ref           "contract-clause:12.4"}
+```
+
+The output records which transform ran, over which input policy
+digests, producing which output digest — attested by the runtime.
+The same mechanism covers trusted redaction, extraction of
+non-sensitive facts, approved-mechanism aggregation, embargo
+release, and the employer-evidence → employee-claim conversion (§6).
+The model never decides a transformation succeeded; a trusted
+capability version performs it and emits proof. Without this
+concept, either union overtaints forever or application code drops
+clauses ad hoc — model-mediated declassification by the back door.
+
+### 13.2 Destinations are structured, not rungs
+
+`local < tenant < related < external` is not a total order: a
+tenant can be 50,000 people, "related" can be one contracted
+partner, "external" can be the subject's own inbox, and a local
+plugin can leak telemetry. The decision evaluates a destination
+descriptor — recipient set, trust zone, tenant boundary, retention,
+training-use — against each clause. Keep the ladder for display;
+never let it be the thing the policy engine compares.
+
+### 13.3 Effects are a separate plane from egress
+
+Deleting a database discloses nothing. Every invocation carries two
+independent classifications: an **egress class** (where information
+flows — §11.4) and an **effect class** (what state or commitment
+changes): observe / derive / reversible write / irreversible or
+high-impact (financial, legal, privileged-administrative,
+destructive). The tool model is three planes, each with its own
+gate:
+
+1. **Authority** — may this principal invoke this capability?
+2. **Information flow** — may these inputs reach this destination?
+3. **Effect** — may this principal cause this operation and impact?
+
+**Effects are transacted, not invoked.** The model never calls an
+effectful tool; it *proposes a transaction* (the mixture-of-agents
+(MoA) transacted-blackboard experiment is this plane's
+implementation:
+proposals land on a shared blackboard, and the deterministic
+runtime is the only committer). The protocol: propose → prepare →
+authorize (all three planes) → approve if the effect or egress
+class requires a human → commit → reconcile → receipt.
+Approval binds to a hash of the exact transaction (arguments,
+rendered payload, destination, capability version, policy
+snapshot); any change after approval invalidates it. Commits carry
+idempotency keys and an `unknown-outcome` state with reconciliation
+— an effect that may or may not have happened is a first-class
+state, not an exception.
+
+**The full decision operation is `decide`, not `check`.** `check`
+remains the ReBAC primitive; the runtime's question is
+`decide(context, operation, binding, labeled-inputs, destination,
+proposed-effect)`, returning a **decision envelope**, not a
+boolean: allowed?, reason codes, obligations (redact this field,
+zero provider retention), required approvals, and the revision pins
+— relation revision, policy digest, grant generations, destination
+and effect-scope digests, validity window. The envelope goes into
+the approval hash, the commit-time recheck, the effect receipt, the
+audit trail, and fallback-eligibility evaluation. A rejection is
+debuggable because the envelope says why.
+
+### 13.4 Taint is enforced, and model calls are egress
+
+The v1 taint representation is chosen, not aspirational — and it is
+**scoped**, which matters the moment a run has more than one agent
+on a shared blackboard:
+
+```text
+artifact label      = union (or transform) of the artifact's
+                      ACTUAL inputs
+agent-context taint = union of the artifacts that agent actually
+                      read
+run policy summary  = conservative upper bound, for audit and
+                      fail-safe use only
+blackboard          = a container — placement on it is NOT a flow
+                      between everything on it
+```
+
+Agent A reading a confidential document taints A's context and A's
+outputs — not agent B's public-only branch that never read A's
+artifacts. Globally tainting every branch would destroy the value
+of parallel orchestration, and provider eligibility for a subtask
+is computed from that subtask's *actual* labeled inputs, not the
+most restrictive fact read anywhere in the parent run. Tools
+receive labeled values or artifact references, never bare strings;
+finer-grained (claim/span-level) provenance is a later optimization
+against label creep, not a prerequisite. And a model call is itself
+an egressing tool: the provider is a destination with retention,
+training, and residency attributes, evaluated like any other —
+which is what makes model routing a policy question (§13.6).
+
+**The label plane is writable only by the runtime** — the dual of
+the injection argument (§11.2): the doorkeeper has no
+natural-language input, and the model has no label output. Values
+travel as payload plus policy reference; the model's output channel
+is payload only. Output clauses are *computed* from the inputs
+actually read, never declared by the model — so a forged in-band
+label is just content: it hashes as payload and parses as nothing.
+A model claiming a transform ran fails identically, because
+transform receipts are runtime-attested against the trusted
+capability registry (§13.1). Label forgery is not detected; it is
+unrepresentable. The remaining attack surface is exactly the
+legitimate declassification points — transforms and elevation —
+which are trusted-capability-only and human-only by construction.
+
+### 13.5 Revocation: authoritative at the store, effective at commit time
+
+"One tuple cut severs everything" is true of the relation state and
+insufficient for enforcement: caches, in-flight calls, queued work,
+and already-authorized workers all outlive the delete. The
+transacted-effect protocol closes the gap structurally — every
+commit rechecks policy, and the recheck has a **freshness
+contract**: a consequential commit authorizes against a view at
+least as fresh as every relevant revocation/policy watermark the
+runtime knows, or uses a fully current check. Never the run-start
+snapshot for an external effect; never a worker-chosen older token;
+the lease/fencing generation is part of the commit condition, and a
+revocation event advances the minimum acceptable revision for
+affected workers. Queued and in-flight work fails the recheck;
+stale-generation results are rejected; cache staleness is bounded
+and stated. This matters locally too: one human principal, but many
+workload principals running concurrently.
+
+Three meanings of revocation stay distinct: **authority
+revocation** (future actions denied — the relation cut),
+**execution cancellation** (queued/in-flight work stopped or its
+results rejected — the runtime's job above), and **effect
+reversal** — which may be impossible. A prompt already transmitted,
+a sent email, a completed payment cannot be un-sent; what crossed
+the commit boundary is handled by reconciliation, compensation, and
+audit, never by pretending authorization applies retroactively.
+
+**Revocation for cause, and consequences beyond it.** A grant is
+conditional — valid only while its terms are followed. Cheap
+conditions are monitored in-line (TTL, budgets, argument
+constraints); purpose adherence often cannot be gated at the moment
+of use and is *audited instead*: decision envelopes, receipts, and
+the provenance log make breach visible at reconciliation even when
+every gate passed — the pass was real; the detour wasn't. Gates
+prevent what they can; the audit trail catches the rest, which is
+why receipts exist beyond forensics. Breach then triggers three
+grantor-side responses, all declared policy, none ad hoc: the
+instance dies (ordinary revocation); the grantor's *granting
+policy* for that grantee degrades — future requests are denied or
+narrowed for a declared period; and any pre-agreed remedies in the
+grant's terms execute — the fine you accepted along with the
+library card. For non-resident authorities (§12), the system's
+contribution to remedies is attested evidence, not enforcement. Breach history
+is also an eligibility input (§13.6): a binding or agent with
+recent revocations for cause drops out of routing's candidate set
+before ranking, like any other policy filter.
+
+Grants additionally carry **lineage**: each records the basis
+relation or grant that justified it, and authorization requires the
+grant *and a still-valid basis* — cascading revocation without
+sweeping descendants. Delegation is its own authority: holding a
+capability does not imply the right to delegate it (`:delegable?`
+is a separate, default-false property), and a child's constraints must
+fit within the parent's *delegable* constraints, not merely the
+parent's own.
+
+### 13.6 Registry: describe, authorize, route, invoke
+
+Four object types, not one tool record: **capability definition**
+(semantic operation, schemas, effect class) → **capability
+version** (immutable implementation, sandbox/network profile,
+idempotency and retry safety) → **tenant binding** (credentials,
+destination resolver, provider terms, data-processing profile) →
+**execution grant** (why this principal/run may use this binding
+now: basis, argument constraints, purpose, expiry). Models are
+capability bindings like any other — with modalities, quality,
+cost, retention/training policy, residency, and trust boundary.
+The routing sequence: discover capability-compatible bindings →
+validate the grant and its lineage → evaluate clauses, purpose,
+destination, effect → drop candidates forbidden by residency,
+retention, training-use, rights, or tenant policy → apply
+entitlement, budget, context-window, and availability limits → rank
+survivors by quality, latency, cost, health → invoke → stamp the
+output with capability version, policy digest, provenance, and any
+applied transform. **A fallback re-runs eligibility, not just
+ranking** — a tenant-safe model's failure must not silently fail
+over to a provider the clauses forbid. Routing is thus not another
+policy subsystem: it is an optimizer over the set of bindings the
+authority and information-flow runtime already proved eligible.
+
+Six interfaces to freeze before implementing any of this:
+`PolicyClause`, `PolicyTransform`, `DestinationDescriptor`,
+`ExecutionGrant`/`Delegation`, `DecisionEnvelope`,
+`ProposedTransaction`.
+
+### 13.7 Runtime obligations
+
+Compressed; each is a fail-closed contract, not advice:
+
+- **Atomicity.** A record is unreadable until owner, clauses,
+  rights, and provenance all exist (transactional write + outbox
+  projection; missing policy metadata fails closed). Deletion and
+  rights expiry reach derived copies: caches, indexes, embeddings.
+- **List authorization.** `check` answers point queries; listing
+  uses relation-service list-objects or authorized indexes rather
+  than a per-row check loop, and the API rechecks the selected page
+  in one batched call at a consistency token before returning
+  content — no unchecked search results.
+- **Relation mutation is an API, not a function.** The injection
+  argument (§11.2) holds only if ordinary application code cannot
+  write tuples. Grant management checks grantor authority,
+  delegability, scope narrowing, and basis; policy and rewrite-rule
+  changes are versioned and audited, because a rewrite change can
+  expand access retroactively.
+- **Export is a snapshot.** The takeaway bundle binds tenant, time,
+  data versions, policy versions, a consistency token, hashes, and
+  machine-readable exclusion reasons — not a long series of
+  unrelated reads. The no-off-switch rule (§7) stands; externally
+  imposed holds (legal preservation, safety, rights expiry) are
+  explicit, audited external-authority clauses, never org
+  convenience switches.
+- **Audit splits.** A tenant-visible activity record owned by the
+  tenant; a platform security record owned by the platform security
+  domain; correlation ids link them; payload content stays out of
+  the security log.
+
+### 13.8 The compressed framing
+
+For presenting the whole system in one breath: every agent run gets
+a distinct principal and an attenuated delegation rooted in the
+commissioning tenant; models never hold ambient authority; model
+and tool calls pass separate capability, information-flow, and
+effect gates; inputs keep policy and provenance through the run;
+effects are proposed, authorized, optionally approved, idempotently
+committed, reconciled, and audited; and routing selects only among
+providers policy has already cleared. The personal-versus-org
+ownership rules (§6–§7) are the product thesis underneath — the
+deeper follow-up, not the opening.
+
+---
+
+The invariants that must survive any instantiation: people
+are tenants (A1); one owner per record — owner meaning control and
+custody (A2, §6); membership as relation (A3); the four layers stay
+orthogonal (§3); ownership follows provenance, type never implies
+owner kind (§6); entitlement gates compute, never data; the
+takeaway export has no off switch (§7); agents are principals and
+own nothing, with child grants fitting within the parent's
+*delegable* constraints (§11.2); labels are clause sets — derived
+values carry every source clause, and a clause is removed only by
+an authority-defined policy transformation executed by a trusted
+capability version (§13.1); **a restriction is relaxed only through
+the relaxation mechanism authorized by every authority whose clause
+would otherwise forbid the operation** — tenants, licensors,
+contracts, and compliance regimes alike (§11.5, §13.1); elevation
+is a recorded act that never relabels; grants are first-class,
+scoped, expiring, lineage-bearing objects that attach to flows
+rather than tools (§11.2, §11.5); possession is not rights —
+licensed access routes through the license relation and dies with
+it, and unknown-rights intake defaults to the most restrictive
+plausible terms (§12); egress and effect are separate planes and
+effects are transacted — proposed by models, decided as envelopes,
+committed only by the deterministic runtime under the freshness
+contract (§13.3, §13.5); taint is scoped to artifact, agent
+context, and run — a shared blackboard is a container, not a flow
+(§13.4); execution artifacts follow the launching context while
+domain outputs follow §6 (§11.1); and org-granted roles scope to
+engagements, never to a person's whole tenant (§4).

--- a/docs/architecture/ariadne/tenancy-ownership-access.md
+++ b/docs/architecture/ariadne/tenancy-ownership-access.md
@@ -12,18 +12,24 @@ engine-agnostic and portable.
 `main`: see [VERSIONING.md](VERSIONING.md) for what a major/minor/patch
 bump means and how to fork against a fixed version.
 
-**Status:** v1.5 lineage (2026-07-27; semantic-convergence pass — §11
-rewritten to §13 mechanics, authority-defined policy
-transformations, clause destination-constraints with expiry
-polarity and relaxation modes, purpose-basis, first-class
-delegations, decision envelopes, freshness contract, scoped taint),
-distilled from ADR 008 and its implementation review (both in the
-Thesium Career repository, where this architecture was first written;
-that ADR is the product's own instantiation record, not part of the
-portable architecture). Generic by intent: the model is written to be instantiated in
-any product where people and organizations both hold data. Lineage:
-first implemented for Ixi; ADR 008 adds the Zanzibar relation layer
-and higher-fidelity personal ↔ org ↔ corporate interaction rules.
+1.6.0 is the current and only tagged version; earlier `v1.x` numbers
+in the history below were untagged working revisions, superseded by
+this one. See [CHANGELOG.md](CHANGELOG.md).
+
+**Origin.** Distilled from ADR 008 and its implementation review (both
+in the Thesium Career repository, where this architecture was first
+written; that ADR is the product's own instantiation record, not part
+of the portable architecture). Lineage: first implemented for Ixi;
+ADR 008 added the Zanzibar relation layer and higher-fidelity
+personal ↔ org ↔ corporate interaction rules. The last untagged
+revision (2026-07-27) was a semantic-convergence pass that rewrote §11
+to §13 mechanics: authority-defined policy transformations, clause
+destination-constraints with expiry polarity and relaxation modes,
+purpose-basis, first-class delegations, decision envelopes, the
+freshness contract, and scoped taint.
+
+Generic by intent: the model is written to be instantiated in any
+product where people and organizations both hold data.
 
 **Intended reuse:** interview articulation, an RFC for a corporate
 codebase, adoption in other Miniforge products. §8 carries the

--- a/docs/architecture/rfc-ariadne-adoption.md
+++ b/docs/architecture/rfc-ariadne-adoption.md
@@ -12,9 +12,9 @@ adoption assessment; the analysis below is unchanged from that
 review apart from naming and the ratification list.
 
 **Ariadne** is the tenancy/ownership/access architecture distilled
-in [thesium-career's
-`docs/architecture/tenancy-ownership-access.md`](https://github.com/miniforge-ai/thesium-career/blob/main/docs/architecture/tenancy-ownership-access.md)
-(v1.5): clause-set policy labels, `decide()` decision envelopes,
+in [`docs/architecture/ariadne/tenancy-ownership-access.md`](ariadne/tenancy-ownership-access.md),
+**adopted at tag `ariadne/v1.6.0`**: clause-set policy labels,
+`decide()` decision envelopes,
 execution grants with lineage, transacted effects, tenants and
 Zanzibar-style relations, revocation-for-cause. It is
 engine-agnostic by design; this RFC assesses its adoption for
@@ -39,6 +39,12 @@ is analysis in support of them.
    re-expressed as ExecutionGrants + attestation + breach-history
    routing eligibility; N10 and half of N12 get rewritten as
    profiles of Ariadne's six frozen interfaces.
+
+**Adopted version:** `ariadne/v1.6.0`. Adoption is pinned to a tag,
+not to `main` — see [ariadne/VERSIONING.md](ariadne/VERSIONING.md) for
+bump semantics and the fork workflow. v1.6.0 carries the same axioms,
+interfaces, and vocabularies as the untagged v1.5 lineage this RFC was
+written against; step 1 was built against those mechanics unchanged.
 
 Router placement (a miniforge function consumed by data planes) is
 already decided in principle and is not re-opened here.
@@ -223,6 +229,6 @@ it pays for itself before anyone believes in the rest.
 
 *Sources: as-built and target panels (miniforge #1548 + #1549
 corrections, source-verified); the contradiction register (T3);
-Ariadne v1.5 §§2–13; N-spec status per
+Ariadne v1.6.0 §§2–13; N-spec status per
 ROADMAP and the 2026-06-10 design review; Fleet specs N10–N12;
 governance audit 2026-07-05.*


### PR DESCRIPTION
Ariadne moves from the private `thesium-career` repo to its canonical home here, and gains a version contract.

**Why here.** Miniforge is an adopter (RFC accepted #1553, step 1 built and merged), and the architecture is portable by intent — its own header says it is written to be instantiated in any product. It was also already half-published: the two ELI9 stories explaining it are live on miniforge.ai, and both website sync PRs project its diagrams onto public sites. Meanwhile the public RFC linked into a private repo, so **every public reader got a 404 on the one document defining what we adopted**. That link now resolves.

Moved as one unit so relative links survive: spec, 5 diagrams, 2 explainers, 8 illustrations → `docs/architecture/ariadne/`.

**Publication scrub** (per owner direction):
- §10's instantiation table **emptied** — it named systems that are not public and carried a mapping for an organization the proposal has not yet been made to. Adopter mappings now live with adopters. The section *number* is kept as a placeholder: renumbering would invalidate every `§N` citation in the RFC, the merged work specs, code docstrings, and the diagrams — which `VERSIONING.md` classifies as a major change.
- Licensed-feed examples **genericized** to `license:market-data`; the named vendor is specific to Thesium Risk and stays private with the product holding that licence.
- Example principal → `alice`.

**Versioning** (the fork contract):
- Tag scheme `ariadne/vMAJOR.MINOR.PATCH`, namespaced away from engine releases (`v2026.MM.DD.N`) and `stable/*`.
- Bump semantics defined in *architecture* terms, plus an explicit **compatibility surface** a major bump protects: the three axioms, the six frozen §13 interfaces, section numbering, and the clause/decision vocabularies.
- Fork workflow: fork at a tag, name your deltas, `git diff ariadne/v1.6.0..ariadne/v1.7.0` to review what to adopt, cite the version you mean.
- `CHANGELOG.md` records v1.6.0 and the untagged v1.0–v1.5 lineage.

**v1.6.0, not v1.5** — content changed (section emptied, examples genericized), so calling it v1.5 would misrepresent it to anyone diffing. **No axiom, interface, or vocabulary changed**, so step 1's implementation needs nothing.

After merge I'll tag `ariadne/v1.6.0` on the merge commit and repoint both website sync scripts (they currently read the diagrams from thesium-career).

MINIFORGE_PR_BUDGET_OVERRIDE: repo-to-repo relocation of one document unit plus its versioning contract; splitting would leave the spec's relative links broken mid-wave

🤖 Generated with [Claude Code](https://claude.com/claude-code)