### PR TITLE
feat(gate,execution-grant): grant constraints as a decide() input class (Ariadne 2b)

### DIFF
--- a/components/decision-envelope/src/ai/miniforge/decision_envelope/core.clj
+++ b/components/decision-envelope/src/ai/miniforge/decision_envelope/core.clj
@@ -39,7 +39,12 @@
     :reason/unknown-enforcement
     :reason/unknown-severity
     :reason/missing-artifact
-    :reason/gate-check-failed})
+    :reason/gate-check-failed
+    ;; A ceiling that denies only sometimes is not a ceiling. Both grant
+    ;; reasons are deny-class, so an effect over budget or lacking
+    ;; authority cannot be downgraded to an obligation and proceed.
+    :reason/grant-exceeded
+    :reason/grant-absent})
 
 (def ^{:stratum 0} ^:private obligation-only-types
   "Obligation types compatible with :allow-with-obligations. An

--- a/components/decision-envelope/src/ai/miniforge/decision_envelope/schema.clj
+++ b/components/decision-envelope/src/ai/miniforge/decision_envelope/schema.clj
@@ -42,7 +42,11 @@
    :reason/unknown-severity
    :reason/missing-artifact
    :reason/gate-check-failed
-   :reason/no-violations])
+   :reason/no-violations
+   ;; Ariadne 2b — authority, not policy: the action may be legal and
+   ;; still be beyond what this principal was granted.
+   :reason/grant-exceeded
+   :reason/grant-absent])
 
 (def ^{:stratum 0} obligation-types
   "Registered obligation types: what an :allow-with-obligations or a

--- a/components/execution-grant/src/ai/miniforge/execution_grant/constraints.clj
+++ b/components/execution-grant/src/ai/miniforge/execution_grant/constraints.clj
@@ -1,0 +1,158 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.execution-grant.constraints
+  "The ONE check site for whether an effect is within its grant
+   (Ariadne step 2b, §13.5).
+
+   This is the representational fix for T3 contradiction 9. The 3h40m
+   runaway happened because a ceiling was wired to one of two channels
+   and the other went unmetered. Wiring each channel individually is
+   the mistake; a ceiling belongs on the GRANT, and every path to an
+   effect passes through `authorize` here.
+
+   `authorize` is called TWICE per effect — once at decide() and again
+   at commit (step 2c). Same function, different instants: a grant that
+   was live at decide and revoked before commit fails the second call.
+   That is the whole point of re-checking rather than trusting the
+   first answer.
+
+   Everything fails CLOSED. A nil grant, an inactive grant, and an
+   unresolvable ancestry all deny; absence is not silence (§13.7)."
+  (:require
+   [ai.miniforge.execution-grant.lineage :as lineage]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Usage → ceiling correspondence
+(def ^{:stratum 0} usage->constraint
+  "Which ceiling bounds which observed quantity. Adding a usage axis
+   without its ceiling here would silently make that axis unbounded, so
+   the map is the single place the correspondence is stated."
+  {:usage/cost-usd :constraint/max-cost-usd
+   :usage/tokens :constraint/max-tokens
+   :usage/count :constraint/max-count})
+
+(def ^{:stratum 0} legacy-budget-aliases
+  "The scattered budget key spellings found across the tree, mapped to
+   their constraint axis. Three namespaces express one concept three
+   ways today — `agent/role-defaults.edn` uses `{:tokens :cost-usd}`,
+   `orchestrator` and `loop` use `{:max-tokens :max-cost-usd}`, and
+   `workflow/validator` uses `{:budget/tokens :budget/cost-usd}`. That
+   divergence is the evidence for moving ceilings onto grants; this map
+   is the migration path, not a fourth spelling.
+
+   Iteration and duration keys are deliberately ABSENT: `:iterations`
+   still governs phase looping (not an irreversible effect), and the
+   time ceiling is `:grant/expires-at`, not a constraint axis."
+  {:tokens :constraint/max-tokens
+   :max-tokens :constraint/max-tokens
+   :budget/tokens :constraint/max-tokens
+   :cost-usd :constraint/max-cost-usd
+   :max-cost-usd :constraint/max-cost-usd
+   :budget/cost-usd :constraint/max-cost-usd})
+
+(defn ^{:stratum 0} authorized?
+  "True when `authorize` returned `:authorized`."
+  [result]
+  (= :authorized (:grant/outcome result)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Breach detection
+(defn ^{:stratum 1} breaches
+  "Ceilings `usage` exceeds on `grant`, as a vector of
+   `{:constraint/axis :constraint/limit :constraint/observed}`.
+
+   An absent ceiling is unbounded and cannot be breached; an absent
+   usage reading is not evidence of a breach. Only a reading strictly
+   above a stated ceiling counts — a run that lands exactly ON its
+   budget spent what it was given, not more.
+
+   A reading that is present but NOT a number counts as a breach. It is
+   not a pass (we cannot show it is under the ceiling) and it must not
+   throw (a crash at the check site neither denies nor allows — it just
+   takes the effect path down). Unverifiable is denied, same as
+   everywhere else here."
+  [grant usage]
+  (into []
+        (keep (fn [[usage-key axis]]
+                (let [limit (get (:grant/constraints grant) axis)
+                      observed (get usage usage-key)]
+                  (when (and (some? limit)
+                             (some? observed)
+                             (or (not (number? observed))
+                                 (> observed limit)))
+                    {:constraint/axis axis
+                     :constraint/limit limit
+                     :constraint/observed observed}))))
+        usage->constraint))
+
+(defn ^{:stratum 1} budget->constraints
+  "Translate a legacy budget map into `:grant/constraints`. Unknown keys
+   are dropped rather than guessed at — a key this map does not know is
+   a ceiling nobody has decided the meaning of, and inventing one would
+   re-create the divergence this is meant to end."
+  [budget]
+  (into {}
+        (keep (fn [[k v]]
+                (when-let [axis (get legacy-budget-aliases k)]
+                  (when (some? v) [axis v]))))
+        budget))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; The check site
+(defn ^{:stratum 2} authorize
+  "Is this effect authorized by `grant`, given `usage`, as of `now`?
+
+   Returns one of:
+     {:grant/outcome :authorized :grant/id id}
+     {:grant/outcome :absent}                        - no grant at all
+     {:grant/outcome :inactive :grant/id id
+      :grant/revocation-reason r}                    - revoked, expired,
+                                                       or unverifiable
+                                                       ancestry
+     {:grant/outcome :exceeded :grant/id id
+      :constraint/breaches [...]}                    - over a ceiling
+
+   The 3-arity form is root-only, mirroring `lineage/active?`: a grant
+   naming a parent it was given no way to resolve is NOT authorized,
+   because an unverified grant must never read as a live one. Pass a
+   `lookup` to authorize a delegated grant."
+  ([grant usage now] (authorize grant usage now nil))
+  ([grant usage now lookup]
+   (if (nil? grant)
+     {:grant/outcome :absent}
+     (let [active? (if lookup
+                     (lineage/active? grant now lookup)
+                     (lineage/active? grant now))
+           over (when active? (breaches grant usage))]
+       (cond
+         (not active?)
+         {:grant/outcome :inactive
+          :grant/id (:grant/id grant)
+          :grant/revocation-reason (:grant/revocation-reason grant)}
+
+         (seq over)
+         {:grant/outcome :exceeded
+          :grant/id (:grant/id grant)
+          :constraint/breaches over}
+
+         :else
+         {:grant/outcome :authorized
+          :grant/id (:grant/id grant)})))))

--- a/components/execution-grant/src/ai/miniforge/execution_grant/constraints.clj
+++ b/components/execution-grant/src/ai/miniforge/execution_grant/constraints.clj
@@ -83,11 +83,12 @@
    above a stated ceiling counts — a run that lands exactly ON its
    budget spent what it was given, not more.
 
-   A reading that is present but NOT a number counts as a breach. It is
-   not a pass (we cannot show it is under the ceiling) and it must not
-   throw (a crash at the check site neither denies nor allows — it just
-   takes the effect path down). Unverifiable is denied, same as
-   everywhere else here."
+   A present-but-NON-NUMERIC value on either side — a malformed reading
+   OR a malformed ceiling on a persisted grant — counts as a breach. It
+   is not a pass (we cannot show the reading is under the ceiling) and
+   it must not throw (a crash at the check site neither denies nor
+   allows — it just takes the effect path down). Unverifiable is denied,
+   same as everywhere else here."
   [grant usage]
   (into []
         (keep (fn [[usage-key axis]]
@@ -95,7 +96,8 @@
                       observed (get usage usage-key)]
                   (when (and (some? limit)
                              (some? observed)
-                             (or (not (number? observed))
+                             (or (not (number? limit))
+                                 (not (number? observed))
                                  (> observed limit)))
                     {:constraint/axis axis
                      :constraint/limit limit

--- a/components/execution-grant/src/ai/miniforge/execution_grant/interface.clj
+++ b/components/execution-grant/src/ai/miniforge/execution_grant/interface.clj
@@ -25,6 +25,7 @@
    liveness over lineage."
   (:require
    [ai.miniforge.execution-grant.attenuation :as attenuation]
+   [ai.miniforge.execution-grant.constraints :as constraints]
    [ai.miniforge.execution-grant.core :as core]
    [ai.miniforge.execution-grant.lineage :as lineage]
    [ai.miniforge.execution-grant.schema :as schema]))
@@ -89,3 +90,21 @@
 (def ^{:stratum 0} attenuation-violations
   "Every axis on which a child fails to attenuate its parent."
   attenuation/violations)
+
+(def ^{:stratum 0} authorize
+  "The one check site: is this effect within its grant, as of now?
+   Called at decide() and AGAIN at commit — a grant live at the first
+   call and revoked before the second fails the second."
+  constraints/authorize)
+
+(def ^{:stratum 0} authorized?
+  "True when an `authorize` result is `:authorized`."
+  constraints/authorized?)
+
+(def ^{:stratum 0} breaches
+  "Ceilings a usage reading exceeds on a grant."
+  constraints/breaches)
+
+(def ^{:stratum 0} budget->constraints
+  "Translate a legacy budget map into `:grant/constraints`."
+  constraints/budget->constraints)

--- a/components/execution-grant/test/ai/miniforge/execution_grant/constraints_test.clj
+++ b/components/execution-grant/test/ai/miniforge/execution_grant/constraints_test.clj
@@ -172,3 +172,26 @@
     (let [g (spend-grant)]
       (is (grant/authorized? (grant/authorize g {:usage/cost-usd 4.0} now)))
       (is (= :exceeded (:grant/outcome (grant/authorize g {:usage/cost-usd 5.5} now)))))))
+
+(deftest ^{:stratum 2} malformed-ceiling-is-a-breach-test
+  ;; A persisted grant could carry a non-numeric ceiling. The check site
+  ;; must not throw on it — unverifiable is denied, on BOTH sides of the
+  ;; comparison, not just the usage side.
+  (let [;; `issue` REJECTS this shape — the factory is not the hole. The
+        ;; hole is a grant that reached the check site without passing
+        ;; through it: read back from a store, hand-assembled, or
+        ;; deserialized. Build it that way deliberately.
+        g (assoc-in (spend-grant) [:grant/constraints :constraint/max-cost-usd] "five")]
+    (is (not (grant/valid? (grant/issue {:principal "p"
+                                         :effect-class :effect/spend
+                                         :scope {}
+                                         :constraints {:constraint/max-cost-usd "five"}
+                                         :delegable? false
+                                         :expires-at later}
+                                        now)))
+        "the factory refuses a non-numeric ceiling outright")
+    (is (not (grant/valid? g)) "and such a grant is not schema-valid")
+    (is (= [:constraint/max-cost-usd]
+           (mapv :constraint/axis (grant/breaches g {:usage/cost-usd 1.0})))
+        "but the check site must still deny rather than throw")
+    (is (= :exceeded (:grant/outcome (grant/authorize g {:usage/cost-usd 1.0} now))))))

--- a/components/execution-grant/test/ai/miniforge/execution_grant/constraints_test.clj
+++ b/components/execution-grant/test/ai/miniforge/execution_grant/constraints_test.clj
@@ -1,0 +1,174 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.execution-grant.constraints-test
+  (:require
+   [ai.miniforge.execution-grant.interface :as grant]
+   [clojure.test :refer [deftest is testing]])
+  (:import
+   [java.time Instant]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} now (Instant/parse "2026-07-31T00:00:00Z"))
+
+(def ^{:stratum 0} later (Instant/parse "2026-07-31T01:00:00Z"))
+
+(def ^{:stratum 0} much-later (Instant/parse "2026-08-01T00:00:00Z"))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} spend-grant
+  ([] (spend-grant {}))
+  ([overrides]
+   (grant/issue (merge {:principal "agent:implementer"
+                        :effect-class :effect/spend
+                        :scope {:workflow-run "run-1"}
+                        :constraints {:constraint/max-cost-usd 5.0
+                                      :constraint/max-tokens 100000}
+                        :delegable? true
+                        :expires-at later}
+                       overrides)
+                now)))
+
+(deftest ^{:stratum 1} legacy-budget-mapping-test
+  (testing "all three spellings in the tree map to the same axes"
+    ;; agent/role-defaults.edn, orchestrator+loop, and workflow/validator
+    ;; each spell one concept differently — that divergence is why
+    ;; ceilings move onto grants.
+    (is (= {:constraint/max-tokens 100000 :constraint/max-cost-usd 5.0}
+           (grant/budget->constraints {:tokens 100000 :cost-usd 5.0})))
+    (is (= {:constraint/max-tokens 100000 :constraint/max-cost-usd 10.0}
+           (grant/budget->constraints {:max-tokens 100000 :max-cost-usd 10.0})))
+    (is (= {:constraint/max-tokens 50 :constraint/max-cost-usd 1.0}
+           (grant/budget->constraints {:budget/tokens 50 :budget/cost-usd 1.0}))))
+
+  (testing "keys with no decided meaning are dropped, not guessed at"
+    (is (= {} (grant/budget->constraints {:iterations 5 :time-seconds 60})))
+    (is (= {} (grant/budget->constraints {:timeout-ms 1800000})))
+    (is (= {} (grant/budget->constraints {:some-future-key 1}))))
+
+  (testing "nil values do not become ceilings of nil"
+    (is (= {} (grant/budget->constraints {:tokens nil :cost-usd nil}))))
+
+  (testing "a mapped budget is usable as grant constraints"
+    (let [g (grant/issue {:principal "agent:x"
+                          :effect-class :effect/spend
+                          :scope {}
+                          :constraints (grant/budget->constraints {:tokens 10 :cost-usd 1.0})
+                          :delegable? false
+                          :expires-at later}
+                         now)]
+      (is (grant/valid? g))
+      (is (= :exceeded (:grant/outcome (grant/authorize g {:usage/tokens 11} now)))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} breaches-detects-only-real-overages-test
+  (let [g (spend-grant)]
+    (testing "under every ceiling is no breach"
+      (is (empty? (grant/breaches g {:usage/cost-usd 1.0 :usage/tokens 10}))))
+    (testing "exactly ON a ceiling is not a breach — that budget was granted"
+      (is (empty? (grant/breaches g {:usage/cost-usd 5.0 :usage/tokens 100000}))))
+    (testing "over a ceiling reports the axis, limit, and observation"
+      (let [[b :as all] (grant/breaches g {:usage/cost-usd 5.01})]
+        (is (= 1 (count all)))
+        (is (= :constraint/max-cost-usd (:constraint/axis b)))
+        (is (= 5.0 (:constraint/limit b)))
+        (is (= 5.01 (:constraint/observed b)))))
+    (testing "an unbounded axis cannot be breached"
+      (is (empty? (grant/breaches (spend-grant {:constraints {}})
+                                  {:usage/cost-usd 9999.0}))))
+    (testing "an absent usage reading is not evidence of a breach"
+      (is (empty? (grant/breaches g {}))))
+    (testing "a non-numeric reading breaches rather than throwing"
+      ;; A crash at the check site neither denies nor allows — it takes
+      ;; the effect path down. Unverifiable is denied, like everywhere
+      ;; else in this component.
+      (is (= [:constraint/max-cost-usd]
+             (mapv :constraint/axis (grant/breaches g {:usage/cost-usd "lots"}))))
+      (is (= :exceeded (:grant/outcome (grant/authorize g {:usage/tokens :unknown} now)))))))
+
+(deftest ^{:stratum 2} authorize-fails-closed-test
+  (testing "no grant at all is :absent — absence is not silence"
+    (is (= :absent (:grant/outcome (grant/authorize nil {} now)))))
+
+  (testing "a revoked grant is :inactive and carries the cause"
+    (let [r (grant/revoke (spend-grant) :breach/cost-exceeded now)
+          result (grant/authorize r {} now)]
+      (is (= :inactive (:grant/outcome result)))
+      (is (= :breach/cost-exceeded (:grant/revocation-reason result)))))
+
+  (testing "an expired grant is :inactive even with a clean revocation stamp"
+    (let [g (spend-grant)]
+      (is (nil? (:grant/revoked-at g)))
+      (is (= :inactive (:grant/outcome (grant/authorize g {} much-later))))))
+
+  (testing "a delegated grant with no lookup is NOT authorized"
+    (let [parent (spend-grant)
+          child (grant/delegate parent
+                                {:principal "agent:sub"
+                                 :scope {:workflow-run "run-1"}
+                                 :constraints {:constraint/max-cost-usd 1.0
+                                               :constraint/max-tokens 10}
+                                 :expires-at later}
+                                now)]
+      (is (= :inactive (:grant/outcome (grant/authorize child {} now)))
+          "an unverified grant must never read as a live one")
+      (is (grant/authorized?
+           (grant/authorize child {} now
+                            (fn [id] (when (= id (:grant/id parent)) parent)))))))
+
+  (testing "within ceilings on a live grant is :authorized"
+    (is (grant/authorized? (grant/authorize (spend-grant)
+                                            {:usage/cost-usd 1.0}
+                                            now)))))
+
+(deftest ^{:stratum 2} ceiling-holds-on-every-path-test
+  ;; The two-channel lesson (T3 contradiction 9): the 3h40m runaway
+  ;; happened because a ceiling was wired to one of two code paths and
+  ;; the other went unmetered. A ceiling that lives on the GRANT is
+  ;; enforced by the same call no matter which path reaches the effect,
+  ;; so there is no second path to forget to wire.
+  (let [g (spend-grant)
+        over {:usage/cost-usd 6.0}
+        path-a (grant/authorize g over now)
+        path-b (grant/authorize g over now (constantly nil))]
+    (is (= :exceeded (:grant/outcome path-a)))
+    (is (= :exceeded (:grant/outcome path-b))
+        "a second caller cannot reach the effect through an unmetered route")
+    (is (= (:constraint/breaches path-a) (:constraint/breaches path-b)))))
+
+(deftest ^{:stratum 2} recheck-at-commit-catches-what-decide-could-not-test
+  (testing "a grant revoked between decide and commit fails the commit"
+    (let [g (spend-grant)
+          at-decide (grant/authorize g {:usage/cost-usd 1.0} now)
+          revoked (grant/revoke g :breach/cost-exceeded now)
+          at-commit (grant/authorize revoked {:usage/cost-usd 1.0} now)]
+      (is (grant/authorized? at-decide))
+      (is (not (grant/authorized? at-commit)))
+      (is (= :inactive (:grant/outcome at-commit)))))
+
+  (testing "a grant that expires between decide and commit fails the commit"
+    (let [g (spend-grant)]
+      (is (grant/authorized? (grant/authorize g {} now)))
+      (is (not (grant/authorized? (grant/authorize g {} much-later))))))
+
+  (testing "usage that grew past the ceiling between the two calls fails the second"
+    (let [g (spend-grant)]
+      (is (grant/authorized? (grant/authorize g {:usage/cost-usd 4.0} now)))
+      (is (= :exceeded (:grant/outcome (grant/authorize g {:usage/cost-usd 5.5} now)))))))

--- a/components/gate/src/ai/miniforge/gate/decide.clj
+++ b/components/gate/src/ai/miniforge/gate/decide.clj
@@ -49,8 +49,13 @@
 
 ;; Grant translation (Ariadne 2b)
 (defn- ^{:stratum 0} breach-detail
+  "Render one breach. `axis` is printed defensively rather than
+   `name`-d: this translator takes plain data, and a malformed entry
+   must still produce a deny reason instead of throwing on its way to
+   describing one."
   [{:constraint/keys [axis limit observed]}]
-  (str (name axis) ": " observed " exceeds " limit))
+  (str (if (keyword? axis) (name axis) (pr-str axis))
+       ": " observed " exceeds " limit))
 
 ;------------------------------------------------------------------------------ Layer 1
 
@@ -119,10 +124,18 @@
                 :reason/detail (str "grant is not active"
                                     (when-let [r (:grant/revocation-reason result)]
                                       (str " (revoked: " (name r) ")")))}]
-    :exceeded (mapv (fn [b]
-                      {:reason/code :reason/grant-exceeded
-                       :reason/detail (breach-detail b)})
-                    (:constraint/breaches result))
+    ;; An :exceeded outcome ALWAYS yields at least one deny reason. If
+    ;; the breach detail is missing or empty, mapping over it would
+    ;; produce zero reasons — and zero reasons is an ALLOW. The outcome
+    ;; is the authority here; the detail is only description.
+    :exceeded (let [breaches (:constraint/breaches result)]
+                (if (seq breaches)
+                  (mapv (fn [b]
+                          {:reason/code :reason/grant-exceeded
+                           :reason/detail (breach-detail b)})
+                        breaches)
+                  [{:reason/code :reason/grant-exceeded
+                    :reason/detail "grant exceeded; no breach detail supplied"}]))
     ;; An outcome this translator does not know is an outcome nobody
     ;; decided the meaning of — deny rather than drop it silently.
     [{:reason/code :reason/grant-absent

--- a/components/gate/src/ai/miniforge/gate/decide.clj
+++ b/components/gate/src/ai/miniforge/gate/decide.clj
@@ -47,6 +47,11 @@
   [envelope]
   (not= :deny (:envelope/decision envelope)))
 
+;; Grant translation (Ariadne 2b)
+(defn- ^{:stratum 0} breach-detail
+  [{:constraint/keys [axis limit observed]}]
+  (str (name axis) ": " observed " exceeds " limit))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn ^{:stratum 1} gates->envelope
@@ -94,6 +99,36 @@
    :obligation/rule-id (rule-id v)
    :obligation/detail (violation-detail v)})
 
+(defn ^{:stratum 1} grant->reasons
+  "Translate an `execution-grant/authorize` result into envelope
+   reasons. `nil` means no grant was required — phase gating is not an
+   effect — and yields no reasons, which is what keeps every existing
+   `decide` caller behaving exactly as it does today.
+
+   Both non-authorized outcomes are deny-class. `:inactive` reports as
+   `:reason/grant-absent` rather than a code of its own: a revoked or
+   expired grant is precisely the case of 'no ACTIVE grant covers this
+   effect', and the detail says which."
+  [result]
+  (case (:grant/outcome result)
+    nil []
+    :authorized []
+    :absent [{:reason/code :reason/grant-absent
+              :reason/detail "no grant covers this effect"}]
+    :inactive [{:reason/code :reason/grant-absent
+                :reason/detail (str "grant is not active"
+                                    (when-let [r (:grant/revocation-reason result)]
+                                      (str " (revoked: " (name r) ")")))}]
+    :exceeded (mapv (fn [b]
+                      {:reason/code :reason/grant-exceeded
+                       :reason/detail (breach-detail b)})
+                    (:constraint/breaches result))
+    ;; An outcome this translator does not know is an outcome nobody
+    ;; decided the meaning of — deny rather than drop it silently.
+    [{:reason/code :reason/grant-absent
+      :reason/detail (str "unrecognized grant outcome: "
+                          (pr-str (:grant/outcome result)))}]))
+
 ;------------------------------------------------------------------------------ Layer 2
 
 ;; The kernel
@@ -103,12 +138,23 @@
    become deny reasons; :require-approval becomes an approval
    obligation (which the envelope derivation treats as :deny until an
    approval workflow clears it — the ratified 1c behavior change);
-   :warn/:audit become recording obligations."
-  [{:keys [blocking require-approval warnings audits unknown]} pins]
-  (env/envelope
-   (concat (map blocking->reason blocking)
-           (map unknown->reason unknown))
-   (concat (map (partial obligation :obligation/approval-required) require-approval)
-           (map (partial obligation :obligation/warn-recorded) warnings)
-           (map (partial obligation :obligation/audit-recorded) audits))
-   pins))
+   :warn/:audit become recording obligations.
+
+   The 3-arity form adds authority to policy (Ariadne 2b): pass the
+   result of `execution-grant/authorize` and a grant breach becomes a
+   deny reason alongside the rule violations, through the SAME envelope
+   derivation — there is no second decision path for authority.
+
+   The kernel stays pure: the caller resolves and checks the grant, and
+   passes the answer in. Omitting the argument is how every non-effect
+   caller (phase gating) keeps today's behavior exactly."
+  ([classified pins] (decide classified pins nil))
+  ([{:keys [blocking require-approval warnings audits unknown]} pins grant-result]
+   (env/envelope
+    (concat (map blocking->reason blocking)
+            (map unknown->reason unknown)
+            (grant->reasons grant-result))
+    (concat (map (partial obligation :obligation/approval-required) require-approval)
+            (map (partial obligation :obligation/warn-recorded) warnings)
+            (map (partial obligation :obligation/audit-recorded) audits))
+    pins)))

--- a/components/gate/src/ai/miniforge/gate/interface.clj
+++ b/components/gate/src/ai/miniforge/gate/interface.clj
@@ -127,6 +127,17 @@
   "True when an envelope's decision is not :deny."
   decide/allowed?)
 
+(def ^{:stratum 0} decide
+  "The fail-closed kernel: classified violations + pins -> envelope.
+   The 3-arity form also takes an `execution-grant/authorize` result,
+   so a grant breach denies through the same derivation (Ariadne 2b)."
+  decide/decide)
+
+(def ^{:stratum 0} grant->reasons
+  "Translate an `execution-grant/authorize` result into envelope
+   reasons; nil (no grant required) yields none."
+  decide/grant->reasons)
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn ^{:stratum 1} failed?

--- a/components/gate/test/ai/miniforge/gate/decide_test.clj
+++ b/components/gate/test/ai/miniforge/gate/decide_test.clj
@@ -40,6 +40,75 @@
 (defn- ^{:stratum 1} classify+decide [violations]
   (decide/decide (policy-pack/classify-violations violations) pins))
 
+;; ── Grant constraints as a decide() input (Ariadne 2b) ──────────────────────
+(deftest ^{:stratum 1} decide-without-grant-context-is-unchanged-test
+  ;; The regression that matters most: every existing caller passes no
+  ;; grant, and phase gating is not an effect. The 2-arity and the
+  ;; 3-arity-with-nil forms must produce exactly what today produces.
+  (doseq [violations [[] [(v :warn)] [(v :hard-halt)] [(v :require-approval)]]]
+    (let [classified (policy-pack/classify-violations violations)
+          two-arity (decide/decide classified pins)
+          explicit-nil (decide/decide classified pins nil)]
+      (is (= (:envelope/decision two-arity) (:envelope/decision explicit-nil)))
+      (is (= (:envelope/reasons two-arity) (:envelope/reasons explicit-nil)))
+      (is (= (:envelope/obligations two-arity) (:envelope/obligations explicit-nil)))))
+  (testing "an authorized grant adds nothing either"
+    (let [classified (policy-pack/classify-violations [])
+          authorized (decide/decide classified pins {:grant/outcome :authorized})]
+      (is (= :allow (:envelope/decision authorized)))
+      (is (empty? (:envelope/reasons authorized))))))
+
+(deftest ^{:stratum 1} decide-denies-on-grant-breach-test
+  (let [clean (policy-pack/classify-violations [])]
+    (testing "a breached cost ceiling denies with :reason/grant-exceeded"
+      (let [e (decide/decide clean pins
+                             {:grant/outcome :exceeded
+                              :constraint/breaches
+                              [{:constraint/axis :constraint/max-cost-usd
+                                :constraint/limit 5.0
+                                :constraint/observed 6.0}]})]
+        (is (= :deny (:envelope/decision e)))
+        (is (= [:reason/grant-exceeded] (mapv :reason/code (:envelope/reasons e))))
+        (is (re-find #"max-cost-usd" (:reason/detail (first (:envelope/reasons e)))))))
+
+    (testing "no grant for a grant-requiring effect denies with :reason/grant-absent"
+      (let [e (decide/decide clean pins {:grant/outcome :absent})]
+        (is (= :deny (:envelope/decision e)))
+        (is (= [:reason/grant-absent] (mapv :reason/code (:envelope/reasons e))))))
+
+    (testing "a revoked grant denies and names the cause"
+      (let [e (decide/decide clean pins {:grant/outcome :inactive
+                                         :grant/revocation-reason :breach/cost-exceeded})]
+        (is (= :deny (:envelope/decision e)))
+        (is (re-find #"cost-exceeded" (:reason/detail (first (:envelope/reasons e)))))))
+
+    (testing "an unrecognized outcome denies rather than passing silently"
+      (let [e (decide/decide clean pins {:grant/outcome :something-new})]
+        (is (= :deny (:envelope/decision e)))))
+
+    (testing "every breached axis is reported, not just the first"
+      (let [e (decide/decide clean pins
+                             {:grant/outcome :exceeded
+                              :constraint/breaches
+                              [{:constraint/axis :constraint/max-cost-usd
+                                :constraint/limit 5.0 :constraint/observed 6.0}
+                               {:constraint/axis :constraint/max-tokens
+                                :constraint/limit 10 :constraint/observed 99}]})]
+        (is (= 2 (count (:envelope/reasons e))))))))
+
+(deftest ^{:stratum 1} grant-breach-cannot-be-downgraded-test
+  ;; A ceiling that denies only sometimes is not a ceiling. Even
+  ;; alongside obligations that would otherwise yield
+  ;; :allow-with-obligations, a grant breach must still deny.
+  (let [with-warning (policy-pack/classify-violations [(v :warn)])
+        e (decide/decide with-warning pins
+                         {:grant/outcome :exceeded
+                          :constraint/breaches
+                          [{:constraint/axis :constraint/max-tokens
+                            :constraint/limit 10 :constraint/observed 11}]})]
+    (is (= :deny (:envelope/decision e)))
+    (is (seq (:envelope/obligations e)) "the warn obligation is still recorded")))
+
 ;------------------------------------------------------------------------------ Layer 2
 
 (deftest ^{:stratum 2} decision-table-test

--- a/components/gate/test/ai/miniforge/gate/decide_test.clj
+++ b/components/gate/test/ai/miniforge/gate/decide_test.clj
@@ -109,6 +109,33 @@
     (is (= :deny (:envelope/decision e)))
     (is (seq (:envelope/obligations e)) "the warn obligation is still recorded")))
 
+(deftest ^{:stratum 1} malformed-grant-result-still-denies-test
+  ;; grant->reasons takes plain data across a component boundary, so it
+  ;; must survive a malformed producer WITHOUT falling open. Zero reasons
+  ;; is an allow — an :exceeded outcome that yields none would be a
+  ;; fail-open in the enforcement path.
+  (let [clean (policy-pack/classify-violations [])]
+    (testing ":exceeded with no breach detail still denies"
+      (doseq [result [{:grant/outcome :exceeded}
+                      {:grant/outcome :exceeded :constraint/breaches []}
+                      {:grant/outcome :exceeded :constraint/breaches nil}]]
+        (let [e (decide/decide clean pins result)]
+          (is (= :deny (:envelope/decision e)) (pr-str result))
+          (is (= [:reason/grant-exceeded] (mapv :reason/code (:envelope/reasons e)))))))
+
+    (testing "a breach entry with a non-keyword axis denies rather than throwing"
+      (let [e (decide/decide clean pins
+                             {:grant/outcome :exceeded
+                              :constraint/breaches [{:constraint/axis nil
+                                                     :constraint/limit 5
+                                                     :constraint/observed 6}]})]
+        (is (= :deny (:envelope/decision e)))))
+
+    (testing "an inactive outcome with a non-keyword revocation reason still denies"
+      (let [e (decide/decide clean pins {:grant/outcome :inactive
+                                         :grant/revocation-reason nil})]
+        (is (= :deny (:envelope/decision e)))))))
+
 ;------------------------------------------------------------------------------ Layer 2
 
 (deftest ^{:stratum 2} decision-table-test


### PR DESCRIPTION
Implements `work/ariadne-grant-constraints-decide.spec.edn` — step 2b of the [Ariadne adoption](docs/architecture/rfc-ariadne-adoption.md), building on 2a (#1575).

**Budgets stop being plumbing.** A ceiling now lives on the grant and is checked at one site, instead of being wired per-channel where a single unwired channel cost 3h40m and $8–15.

## Why this is the fix for T3 contradiction 9

The specific two-channel asymmetry that caused the runaway is fixed, but the *class* is not, and the tree still shows it:

- `fsm.clj` `guarded-phases` is `#{:review :verify :release :implement}`, while `standard-deploy-v1.0.0.edn` sets `:on-fail` on `:provision`, `:deploy`, and `:validate` — including a `:validate → :deploy` loop. Those redirects are unmetered.
- `phase-fail-entries` returns nil for the flat form, so the structural invariants **cannot see** an unmetered redirect to complain about it.
- `:budget :tokens` and `:budget :time-seconds` are declared in schemas and EDN and read by nothing.
- `orchestrator`'s BudgetManager and `policy/core.clj`'s `check-budget` have zero production callers.

Wiring each of those individually is the mistake that produced the runaway. `authorize` is one call that every path to an effect goes through.

## What's here

- **`execution-grant/constraints.clj`** — `authorize`, the single check site. Called **twice** per effect: at `decide()` and again at commit (2c). Same function, different instants, which is how a grant that was live at decide and revoked before commit fails the second call.
- **`decision-envelope`** — `:reason/grant-exceeded` and `:reason/grant-absent`, both **deny-class**. A ceiling that denies only sometimes is not a ceiling, so neither can be downgraded to an obligation that proceeds.
- **`gate/decide.clj`** — a 3-arity taking the authorize result. A grant breach denies through the *same* envelope derivation; there is no second decision path for authority.
- **`budget->constraints`** — maps the three spellings the tree actually uses (`{:tokens :cost-usd}` in agent role-defaults, `{:max-tokens :max-cost-usd}` in orchestrator and loop, `{:budget/tokens :budget/cost-usd}` in workflow validator) onto one axis set. That three-way divergence for one concept is itself the argument for moving ceilings onto grants.

## Fail-closed, including one case the spec didn't name

nil grant, inactive grant, and unresolvable ancestry all deny. I also made a **non-numeric usage reading** a breach rather than an exception: a crash at the check site neither denies nor allows, it just takes the effect path down. Unverifiable is denied, consistent with the rest of the component.

`gate` translates grant outcomes without depending on `execution-grant` — the contract between them is plain data, and an unrecognized outcome hits the default and denies, the same rule 1c applied to unknown enforcement actions.

## Scope note worth your attention

The spec's Group 3 says "make the spend path consult it", but the spec's own `:scope` lists only `gate/decide.clj`, `gate/interface.clj`, and `execution-grant/` — `components/llm/` is not in it. I implemented the mapping (in scope) and did **not** wire the LLM spend path (out of scope, and migrating call sites is 2d's job). Flagging the contradiction rather than silently picking a side; say the word if you want the spend wiring pulled forward into this PR.

Also deliberately untouched, per the spec: the `guarded-phases` set. Applying the guarded form to every phase is real FSM work and gets its own change.

## Verification

26 tests / 150 assertions across the four affected namespaces. The regression that matters most — every existing `decide` caller passes no grant — is pinned across all four violation classes, and the pre-existing `decide_test` suite still passes untouched.

`bb poly:check` 0 errors; `bb lint:clj` 0/0; `bb lint:stratum` clean at ≤3 layers; stable-derived `bb test` plan green (7m27s).

Four sliced commits under the 200-line budget, in dependency order: reason codes → check site → tests → decide wiring. (The first is labeled `1/3`; I split the second slice after writing it and judged rewriting four commits for a label not worth the risk.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)