### PR TITLE
docs(compliance-scanner): fix stale Layer count in interface.clj docstring

### DIFF
--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/interface.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/interface.clj
@@ -21,7 +21,8 @@
    Thin pass-throughs only — no implementation logic here.
 
    Layer 0: Schema/factory re-exports + single-phase entry points
-            (scan, classify, plan, write-report!, execute!, comment renderers)
+            (scan, classify, plan, write-report!, write-work-spec!,
+            execute!, comment renderers)
    Layer 1: Composite entry points (write-delta-report!, pr-review,
             compliance-run!)"
   (:require [ai.miniforge.compliance-scanner.schema             :as schema]

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/interface.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/interface.clj
@@ -20,9 +20,10 @@
 
    Thin pass-throughs only — no implementation logic here.
 
-   Layer 0: Schema re-exports
-   Layer 1: Phase entry points
-   Layer 2: Convenience run! orchestrator"
+   Layer 0: Schema/factory re-exports + single-phase entry points
+            (scan, classify, plan, write-report!, execute!, comment renderers)
+   Layer 1: Composite entry points (write-delta-report!, pr-review,
+            compliance-run!)"
   (:require [ai.miniforge.compliance-scanner.schema             :as schema]
             [ai.miniforge.compliance-scanner.factory            :as factory]
             [ai.miniforge.compliance-scanner.scan               :as scan]


### PR DESCRIPTION
## Summary

Part of a docs-accuracy sweep: cross-check every Wave 1-fixed
component's namespace docstring \`Layer N:\` prose summary against the
file's real current stratum-lint layer count, fix any mismatch.

\`interface.clj\`'s real stratification collapsed to 2 layers after
Wave 1's autofix (#1461) -- \`compliance-run!\` folded into Layer 1
alongside \`pr-review\`, no real Layer 2 remains. The docstring still
described the old 3-layer shape. Corrected.

## Verification

- \`clj-kondo\`: 0 warnings.
- Pre-commit smoke suite: 331 tests, 1244 assertions, 0 failures.
- Docs-only change, no behavior impact.

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>