### PR TITLE
refactor(compliance-scanner): split classify.clj to fit the 3-layer budget

### DIFF
--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/classify.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/classify.clj
@@ -20,29 +20,16 @@
 
    Classification is pack-driven: uses :auto-fixable-default and
    :exclude-contexts metadata enriched onto violations during scan.
+   Exclusion-context matching lives in `classify-exclusion` (rule 210: a
+   fourth real layer here is the signal to split it).
 
-   Layer 0: Context exclusion matching
-   Layer 1: Top-level classify-violations entry point"
-  (:require [ai.miniforge.compliance-scanner.messages :as msg]
-            [clojure.string :as str]))
+   Layer 0: Semantic-strategy predicate
+   Layer 1: Single-violation classification
+   Layer 2: Top-level classify-violations entry point"
+  (:require [ai.miniforge.compliance-scanner.classify-exclusion :as exclusion]
+            [ai.miniforge.compliance-scanner.messages :as msg]))
 
 ;------------------------------------------------------------------------------ Layer 0
-
-;; Context exclusion matching
-(defn- ^{:stratum 0} has-path-exclusion?
-  "Return true if the violation's file path matches a :path-contains exclusion."
-  [violation ctx-rule]
-  (when-let [p (get ctx-rule :path-contains)]
-    (str/includes? (get violation :file "") p)))
-
-(defn- ^{:stratum 0} has-content-exclusion?
-  "Return true if the violation's :current text matches a :current-contains exclusion."
-  [violation ctx-rule]
-  (when-let [cs (get ctx-rule :current-contains)]
-    (let [current (get violation :current "")]
-      (if (vector? cs)
-        (boolean (some #(str/includes? current %) cs))
-        (str/includes? current cs)))))
 
 (defn- ^{:stratum 0} semantic-strategy?
   "Return true if the violation has a :semantic remediation strategy."
@@ -52,23 +39,14 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
-(defn- ^{:stratum 1} matches-exclude-context?
-  "Return true if a violation matches an exclusion context rule.
-   Exclusion contexts are declared in MDC remediation config."
-  [violation ctx-rule]
-  (or (has-path-exclusion? violation ctx-rule)
-      (has-content-exclusion? violation ctx-rule)))
-
-;------------------------------------------------------------------------------ Layer 2
-
-(defn- ^{:stratum 2} classify-one
+(defn- ^{:stratum 1} classify-one
   "Classify a single violation using pack-enriched metadata.
    Uses :auto-fixable-default and :exclude-contexts from the pack rule.
    Violations with :semantic remediation strategy are always not auto-fixable."
   [violation]
   (let [auto-default (get violation :auto-fixable-default true)
         excludes     (get violation :exclude-contexts [])
-        excluded?    (boolean (some #(matches-exclude-context? violation %) excludes))
+        excluded?    (boolean (some #(exclusion/matches-exclude-context? violation %) excludes))
         semantic?    (semantic-strategy? violation)]
     (assoc violation
            :auto-fixable? (and auto-default (not excluded?) (not semantic?))
@@ -79,10 +57,10 @@
                             :else        (str (get violation :rule/title "Manual review")
                                               " — manual review required")))))
 
-;------------------------------------------------------------------------------ Layer 3
+;------------------------------------------------------------------------------ Layer 2
 
 ;; Top-level entry point
-(defn ^{:stratum 3} classify-violations
+(defn ^{:stratum 2} classify-violations
   "Add :auto-fixable? and :rationale to each violation.
    Returns updated violation list."
   [violations]

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/classify_exclusion.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/classify_exclusion.clj
@@ -1,0 +1,51 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.compliance-scanner.classify-exclusion
+  "Exclusion-context matching, split out of `classify` (rule 210: pulling
+   this out keeps `classify` itself at 3 real layers instead of 4).
+
+   Layer 0: Path/content exclusion predicates
+   Layer 1: Combined exclude-context match"
+  (:require [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Context exclusion matching
+(defn- ^{:stratum 0} has-path-exclusion?
+  "Return true if the violation's file path matches a :path-contains exclusion."
+  [violation ctx-rule]
+  (when-let [p (get ctx-rule :path-contains)]
+    (str/includes? (get violation :file "") p)))
+
+(defn- ^{:stratum 0} has-content-exclusion?
+  "Return true if the violation's :current text matches a :current-contains exclusion."
+  [violation ctx-rule]
+  (when-let [cs (get ctx-rule :current-contains)]
+    (let [current (get violation :current "")]
+      (if (vector? cs)
+        (boolean (some #(str/includes? current %) cs))
+        (str/includes? current cs)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} matches-exclude-context?
+  "Return true if a violation matches an exclusion context rule.
+   Exclusion contexts are declared in MDC remediation config."
+  [violation ctx-rule]
+  (or (has-path-exclusion? violation ctx-rule)
+      (has-content-exclusion? violation ctx-rule)))


### PR DESCRIPTION
## Summary

Part of a docs-accuracy sweep (see #1581) that expanded into real
Wave-2 namespace splits once it turned out several Wave-1-fixed files
were also over rule 210's 3-layer budget (SL003), which independently
blocks the pre-commit gate regardless of docstring content.

\`classify.clj\`'s real per-file reference graph is 4 distinct layers
after Wave 1's autofix (#1461). Extracts exclusion-context matching
(\`has-path-exclusion?\`, \`has-content-exclusion?\`,
\`matches-exclude-context?\`) into \`classify-exclusion.clj\`, a
self-contained 2-layer namespace; \`classify.clj\` itself drops to 3
real layers.

## Verification

- \`stratum-lint\` (plain + \`--fix\` dry-run against a scratch copy): 0
  findings, both files.
- \`clj-kondo\`: 0 warnings.
- \`classify-test\`: 7 tests, 14 assertions, unmodified, all passing.
- No public-API change -- \`interface.clj\` (this component's only
  external boundary) requires \`classify\` unchanged; \`classify-
  violations\` stays in its original namespace.

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>