### PR TITLE
refactor(compliance-scanner): split comments.clj to fit the 3-layer budget

### DIFF
--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/comments.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/comments.clj
@@ -21,84 +21,21 @@
 
    Pure functions only. Consumers (e.g., `connector-github`) take the
    structured comment maps emitted here and post them via the provider's
-   review-comment API.
+   review-comment API. Severity inference and payload/body-rendering
+   primitives live in `comments-payload` (rule 210: a fourth real layer
+   here is the signal to split it).
 
-   Layer 0: payload helpers
-   Layer 1: comment-record builders
-   Layer 2: bulk renderer + severity inference"
-  (:require [clojure.edn :as edn]
-            [clojure.string :as str]))
+   Layer 0: single-violation payload + comment-body builders
+   Layer 1: single-comment builder
+   Layer 2: bulk comment renderer"
+  (:require [ai.miniforge.compliance-scanner.comments-payload :as payload]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
-;; Severity inference
-(defn- ^{:stratum 0} infer-severity
-  "Map a classified Violation to a :violation/severity keyword.
+;; Re-export: round-trip payload parser lives in `comments-payload`.
+(def ^{:stratum 0} extract-payload payload/extract-payload)
 
-   Heuristic: violations whose `:rule/category` matches
-   security/safety/critical → :error. Everything else → :warning,
-   regardless of auto-fixability. Callers may override by providing
-   `:severity-override` on the violation map."
-  [violation]
-  (or (:severity-override violation)
-      (let [category      (some-> (:rule/category violation) str/lower-case)
-            critical-cat? (and category
-                               (or (str/includes? category "security")
-                                   (str/includes? category "safety")
-                                   (str/includes? category "critical")))]
-        (if critical-cat? :error :warning))))
-
-;; Payload construction
-(defn- ^{:stratum 0} rationale-text
-  "Return a violation rationale when it is a string; otherwise return empty text."
-  [violation]
-  (let [rationale (get violation :rationale)]
-    (if (string? rationale) rationale "")))
-
-;; Body rendering
-(defn- ^{:stratum 0} pr-edn
-  "Pretty-print an EDN value for embedding in a comment body. Stable
-   key ordering keeps comment diffs minimal across re-renders."
-  [v]
-  (if (map? v)
-    (let [ordered-keys [:violation/rule-id
-                        :violation/severity
-                        :violation/auto-fixable?
-                        :violation/suggested-fix
-                        :violation/rationale
-                        :violation/pack-id
-                        :violation/pack-version]
-          present      (filter #(contains? v %) ordered-keys)
-          extras       (sort (remove (set ordered-keys) (keys v)))
-          all-keys     (concat present extras)
-          lines        (for [k all-keys]
-                         (str " " (pr-str k) " " (pr-str (get v k))))]
-      (str "{" (str/triml (str/join "\n" lines)) "}"))
-    (pr-str v)))
-
-;; Parser (round-trip helper)
-(defn ^{:stratum 0} extract-payload
-  "Extract a `:comment/payload` map from a comment body produced by
-   `render-body`. Returns nil if no payload block is found.
-
-   Used by the Comment Response Agent's bot-comment-table parser
-   (per `pr-monitoring-workflow.md` Bot Comment Handling) to recover
-   the structured payload from a posted comment."
-  [body]
-  (when (string? body)
-    (let [block-re #"(?s)```edn\s*:comment/payload\s*(\{.*?\})\s*```"]
-      (when-let [[_ edn-str] (re-find block-re body)]
-        (try
-          ;; clojure.edn/read-string is strictly EDN — no reader macros,
-          ;; no #=, no eval. Comment bodies are untrusted input once
-          ;; posted/retrieved from a PR. {:default identity} swallows
-          ;; unknown tagged literals safely.
-          (edn/read-string {:default (fn [_tag value] value)} edn-str)
-          (catch Exception _ nil))))))
-
-;------------------------------------------------------------------------------ Layer 1
-
-(defn ^{:stratum 1} violation->payload
+(defn ^{:stratum 0} violation->payload
   "Build the :comment/payload map for a single classified Violation.
 
    Arguments:
@@ -116,33 +53,33 @@
       :violation/pack-version  string}"
   [violation pack-info]
   {:violation/rule-id        (:rule/id violation)
-   :violation/severity       (infer-severity violation)
+   :violation/severity       (payload/infer-severity violation)
    :violation/auto-fixable?  (boolean (:auto-fixable? violation))
    :violation/suggested-fix  (:suggested violation)
-   :violation/rationale      (rationale-text violation)
+   :violation/rationale      (payload/rationale-text violation)
    :violation/pack-id        (:pack/id pack-info)
    :violation/pack-version   (:pack/version pack-info)})
 
-(defn- ^{:stratum 1} render-body
+(defn- ^{:stratum 0} render-body
   "Build the human-readable comment body with the embedded EDN payload
    block."
-  [violation payload]
+  [violation payload-map]
   (str "**" (or (:rule/title violation) (name (:rule/id violation))) "**\n"
        "\n"
-       (when-let [r (not-empty (:violation/rationale payload))]
+       (when-let [r (not-empty (:violation/rationale payload-map))]
          (str r "\n\n"))
        (when-let [s (:suggested violation)]
          (str "Suggested fix:\n```\n" s "\n```\n\n"))
        "```edn\n"
        ":comment/payload\n"
-       (pr-edn payload) "\n"
+       (payload/pr-edn payload-map) "\n"
        "```\n"
        "<sub>Posted by `miniforge-policy-evaluator[bot]` — see N13 §2.3</sub>"))
 
-;------------------------------------------------------------------------------ Layer 2
+;------------------------------------------------------------------------------ Layer 1
 
 ;; Single-comment builder
-(defn ^{:stratum 2} violation->comment
+(defn ^{:stratum 1} violation->comment
   "Render a single classified Violation to the comment record per
    N13 §2.3.
 
@@ -158,18 +95,18 @@
       :comment/body    string  ; markdown w/ embedded :comment/payload EDN
       :comment/payload {:violation/...}}"
   [violation pack-info]
-  (let [payload (violation->payload violation pack-info)
-        body    (render-body violation payload)]
+  (let [payload-map (violation->payload violation pack-info)
+        body        (render-body violation payload-map)]
     {:comment/author  "miniforge-policy-evaluator[bot]"
      :comment/path    (:file violation)
      :comment/line    (:line violation)
      :comment/body    body
-     :comment/payload payload}))
+     :comment/payload payload-map}))
 
-;------------------------------------------------------------------------------ Layer 3
+;------------------------------------------------------------------------------ Layer 2
 
 ;; Bulk renderer
-(defn ^{:stratum 3} violations->comments
+(defn ^{:stratum 2} violations->comments
   "Render a vector of classified Violations to a vector of comment
    records.
 

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/comments.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/comments.clj
@@ -32,8 +32,17 @@
 
 ;------------------------------------------------------------------------------ Layer 0
 
-;; Re-export: round-trip payload parser lives in `comments-payload`.
-(def ^{:stratum 0} extract-payload payload/extract-payload)
+;; Re-export: round-trip payload parser lives in `comments-payload`. A
+;; real `defn` delegate rather than `def`-aliasing the Var, so the
+;; docstring and the name shown in stack traces / REPL doc stay
+;; `comments/extract-payload`, not `comments-payload/extract-payload`.
+(defn ^{:stratum 0} extract-payload
+  "Extract a `:comment/payload` map from a comment body produced by
+   `violation->payload`/`render-body`. Returns nil if no payload block
+   is found. See `comments-payload/extract-payload` for the full
+   contract."
+  [body]
+  (payload/extract-payload body))
 
 (defn ^{:stratum 0} violation->payload
   "Build the :comment/payload map for a single classified Violation.

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/comments_payload.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/comments_payload.clj
@@ -1,0 +1,94 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.compliance-scanner.comments-payload
+  "Severity inference + payload/body-rendering primitives, split out of
+   `comments` (rule 210: a fourth real layer there is the signal to split
+   it). Every def here is independent of the others — no same-file
+   reference edges — so they all sit at a single real stratum.
+
+   Layer 0: Severity inference, rationale text, EDN payload rendering,
+            and payload round-trip parsing"
+  (:require [clojure.edn :as edn]
+            [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Severity inference
+(defn ^{:stratum 0} infer-severity
+  "Map a classified Violation to a :violation/severity keyword.
+
+   Heuristic: violations whose `:rule/category` matches
+   security/safety/critical → :error. Everything else → :warning,
+   regardless of auto-fixability. Callers may override by providing
+   `:severity-override` on the violation map."
+  [violation]
+  (or (:severity-override violation)
+      (let [category      (some-> (:rule/category violation) str/lower-case)
+            critical-cat? (and category
+                               (or (str/includes? category "security")
+                                   (str/includes? category "safety")
+                                   (str/includes? category "critical")))]
+        (if critical-cat? :error :warning))))
+
+;; Payload construction
+(defn ^{:stratum 0} rationale-text
+  "Return a violation rationale when it is a string; otherwise return empty text."
+  [violation]
+  (let [rationale (get violation :rationale)]
+    (if (string? rationale) rationale "")))
+
+;; Body rendering
+(defn ^{:stratum 0} pr-edn
+  "Pretty-print an EDN value for embedding in a comment body. Stable
+   key ordering keeps comment diffs minimal across re-renders."
+  [v]
+  (if (map? v)
+    (let [ordered-keys [:violation/rule-id
+                        :violation/severity
+                        :violation/auto-fixable?
+                        :violation/suggested-fix
+                        :violation/rationale
+                        :violation/pack-id
+                        :violation/pack-version]
+          present      (filter #(contains? v %) ordered-keys)
+          extras       (sort (remove (set ordered-keys) (keys v)))
+          all-keys     (concat present extras)
+          lines        (for [k all-keys]
+                         (str " " (pr-str k) " " (pr-str (get v k))))]
+      (str "{" (str/triml (str/join "\n" lines)) "}"))
+    (pr-str v)))
+
+;; Parser (round-trip helper)
+(defn ^{:stratum 0} extract-payload
+  "Extract a `:comment/payload` map from a comment body produced by
+   `render-body`. Returns nil if no payload block is found.
+
+   Used by the Comment Response Agent's bot-comment-table parser
+   (per `pr-monitoring-workflow.md` Bot Comment Handling) to recover
+   the structured payload from a posted comment."
+  [body]
+  (when (string? body)
+    (let [block-re #"(?s)```edn\s*:comment/payload\s*(\{.*?\})\s*```"]
+      (when-let [[_ edn-str] (re-find block-re body)]
+        (try
+          ;; clojure.edn/read-string is strictly EDN — no reader macros,
+          ;; no #=, no eval. Comment bodies are untrusted input once
+          ;; posted/retrieved from a PR. {:default identity} swallows
+          ;; unknown tagged literals safely.
+          (edn/read-string {:default (fn [_tag value] value)} edn-str)
+          (catch Exception _ nil))))))


### PR DESCRIPTION
## Summary

Part of a docs-accuracy sweep (see #1581, #1582) that expanded into
real Wave-2 namespace splits once it turned out several Wave-1-fixed
files were also over rule 210's 3-layer budget (SL003), which
independently blocks the pre-commit gate regardless of docstring
content.

\`comments.clj\`'s real per-file reference graph is 4 distinct layers
after Wave 1's autofix (#1461). Extracts severity inference and
payload/body-rendering primitives (\`infer-severity\`, \`rationale-text\`,
\`pr-edn\`, \`extract-payload\`) into \`comments-payload.clj\`, a
single-stratum namespace (no internal reference edges); \`comments.clj\`
itself drops to 3 real layers. \`extract-payload\` is re-exported from
\`comments.clj\` since \`comments-test\` calls it there directly -- it's
still logically part of \`comments\`' public round-trip contract, just
implemented elsewhere.

## Verification

- \`stratum-lint\` (plain + \`--fix\` dry-run): 0 findings, both files.
- \`clj-kondo\`: 0 warnings.
- \`comments-test\`: 11 tests, 44 assertions, unmodified, all passing.
- No public-API change.

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>