### PR TITLE
refactor(compliance-scanner): split scan.clj part 1/2 -- detection primitives

### DIFF
--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/scan_content.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/scan_content.clj
@@ -1,0 +1,126 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.compliance-scanner.scan-content
+  "Per-file content-scan detection, split out of `scan` (rule 210: an
+   eighth real layer there is the signal to split it). Regex matching
+   against a single file's content — the leaf-level detection primitives
+   for :content-scan rules.
+
+   Layer 0: Header/pattern presence + positive-match line finder
+   Layer 1: Positive/negative rule scanning for one file
+   Layer 2: Per-file scan dispatch by :detect-mode"
+  (:require [ai.miniforge.compliance-scanner.factory  :as factory]
+            [ai.miniforge.compliance-scanner.messages :as msg]
+            [clojure.string                           :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Per-file detection helpers
+(defn- ^{:stratum 0} header-present?
+  "Return true if the first 10 lines of content contain both
+   the name pattern and the email pattern."
+  [content name-pattern email-pattern]
+  (let [first-10 (->> (str/split-lines content)
+                      (take 10)
+                      (str/join "\n"))]
+    (and (re-find name-pattern first-10)
+         (re-find email-pattern first-10))))
+
+(defn- ^{:stratum 0} pattern-present?
+  "Return true if pattern appears anywhere in content.
+   Generic negative-mode check (not header-specific)."
+  [content pattern]
+  (boolean (re-find pattern content)))
+
+(defn ^{:stratum 0} positive-matches
+  "Find all lines in content matching pattern.
+   Returns seq of {:line int :text string :match string}."
+  [pattern content]
+  (->> (str/split-lines content)
+       (map-indexed (fn [idx line]
+                      (let [m (re-find pattern line)]
+                        {:line  (inc idx)
+                         :text  line
+                         :match (if (string? m) m (first m))})))
+       (filter :match)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} violations-for-positive-rule
+  "Scan a single file with a positive-match rule (pattern = violation).
+   Returns vector of Violation maps (without :auto-fixable? / :rationale —
+   those are added by classify)."
+  [rule-cfg file-path content]
+  (let [rule-id  (get rule-cfg :rule/id)
+        rule-cat (get rule-cfg :rule/category)
+        title    (get rule-cfg :title)
+        pattern  (get rule-cfg :pattern)
+        suggest  (get rule-cfg :suggest-fn)
+        matches  (positive-matches pattern content)]
+    (mapv (fn [{:keys [line match]}]
+            (factory/->violation
+             rule-id
+             rule-cat
+             title
+             file-path
+             line
+             match
+             (suggest match)
+             false          ; classify phase fills this in
+             ""))           ; classify phase fills this in
+          matches)))
+
+(defn- ^{:stratum 1} violations-for-negative-rule
+  "Scan a single file with a negative-match rule (absence of pattern = violation).
+   Returns a vector of 0 or 1 Violation maps."
+  [rule-cfg file-path content]
+  (let [rule-id  (get rule-cfg :rule/id)
+        rule-cat (get rule-cfg :rule/category)
+        title    (get rule-cfg :title)
+        pattern  (get rule-cfg :pattern)
+        suggest  (get rule-cfg :suggest-fn)
+        ep       (get rule-cfg :email-pattern)
+        present? (if ep
+                   (header-present? content pattern ep)
+                   (pattern-present? content pattern))
+        absence-msg (if ep
+                      (msg/t :scan/missing-header)
+                      (str "(missing: " title ")"))]
+    (if present?
+      []
+      [(factory/->violation
+        rule-id
+        rule-cat
+        title
+        file-path
+        1
+        absence-msg
+        (suggest nil)
+        false
+        "")])))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} scan-file
+  "Dispatch to the appropriate scanner for a rule config.
+   Returns vector of raw (pre-classify) Violation maps."
+  [rule-cfg file-path content]
+  (case (get rule-cfg :detect-mode :positive)
+    :positive (violations-for-positive-rule rule-cfg file-path content)
+    :negative (violations-for-negative-rule rule-cfg file-path content)
+    []))

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/scan_diff_plan.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/scan_diff_plan.clj
@@ -1,0 +1,183 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.compliance-scanner.scan-diff-plan
+  "Diff/plan/exceptions-as-data detection, split out of `scan` (rule 210:
+   an eighth real layer there is the signal to split it). These are the
+   scanner's non-content-scan detection types — they don't flow through
+   pack-rule detection configs.
+
+   Layer 0: Safe git-ref validation, plan-rule scanning, diff-rule
+            scanning, exceptions-as-data selector
+   Layer 1: Git diff retrieval, bulk diff/plan-rule scanning, and the
+            exceptions-as-data dispatch"
+  (:require
+   [ai.miniforge.compliance-scanner.exceptions-as-data :as exc-data]
+   [ai.miniforge.compliance-scanner.factory            :as factory]
+   [ai.miniforge.compliance-scanner.scan-content        :as scan-content]
+   [ai.miniforge.policy-pack.interface                  :as policy-pack]
+   [clojure.java.io                                     :as io]
+   [clojure.string                                      :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} safe-git-ref?
+  "Return true iff ref contains only characters valid in a git ref argument.
+   Rejects empty strings, nil, and any value starting with '-' (which git
+   could interpret as an option flag)."
+  [ref]
+  (boolean (and (string? ref)
+                (seq ref)
+                (not (str/starts-with? ref "-"))
+                (re-matches #"[a-zA-Z0-9/_.\-~^@{}]+" ref))))
+
+(defn- ^{:stratum 0} scan-plan-rule
+  "Scan plan output for violations using a plan-output rule.
+   Uses the policy-pack detect-violation dispatcher for resource-level analysis.
+   Returns vector of Violation maps."
+  [rule-cfg plan-output]
+  (let [rule-id  (:rule/id rule-cfg)
+        rule-cat (:rule/category rule-cfg)
+        title    (:rule/title rule-cfg)
+        ;; Build rule and artifact maps for the detection dispatcher
+        rule-map {:rule/id         rule-id
+                  :rule/detection  (get rule-cfg :rule/detection)
+                  :rule/applies-to (get rule-cfg :rule/applies-to {})
+                  :rule/enforcement {:action :warn :message title}}
+        artifact {:artifact/content plan-output}
+        context  {:terraform-plan plan-output}
+        result   (policy-pack/detect-violation rule-map artifact context)]
+    (if result
+      (let [resources (:resource-violations result [])]
+        (if (seq resources)
+          (mapv (fn [{:keys [resource action line]}]
+                  (factory/->violation
+                   rule-id rule-cat title
+                   (str resource)
+                   0
+                   (str action " " resource " — " (str/trim (or line "")))
+                   nil false ""))
+                resources)
+          [(factory/->violation
+            rule-id rule-cat title
+            "<plan-output>" 0
+            (:message result)
+            nil false "")]))
+      [])))
+
+;; Built-in Clojure-AST linters
+;;
+;; These linters do not flow through pack-rule detection configs because
+;; their analysis is structural, not regex-driven. They are first-class
+;; rules of the scanner and run alongside content/diff/plan rules.
+(defn ^{:stratum 0} exceptions-as-data-selected?
+  "True when the rules selector resolves the exceptions-as-data linter on.
+   Defaults on for `:all` / `:always-apply`; opts in for explicit selectors."
+  [opts]
+  (let [raw       (get opts :rules :always-apply)
+        requested (if (string? raw) (keyword (subs raw 1)) raw)]
+    (cond
+      (contains? #{:all :always-apply} requested) true
+      (= exc-data/rule-id requested)              true
+      (and (set? requested)
+           (contains? requested exc-data/rule-id)) true
+      :else false)))
+
+(defn- ^{:stratum 0} scan-diff-rule
+  "Scan a git diff for violations using a diff-analysis rule.
+   Returns vector of Violation maps."
+  [rule-cfg diff-content]
+  (let [rule-id  (:rule/id rule-cfg)
+        rule-cat (:rule/category rule-cfg)
+        title    (:rule/title rule-cfg)
+        pattern  (re-pattern (get-in rule-cfg [:rule/detection :pattern]))
+        matches  (scan-content/positive-matches pattern diff-content)]
+    (mapv (fn [{:keys [line match]}]
+            (factory/->violation
+             rule-id rule-cat title
+             "<diff>"     ; file is the entire diff
+             line match
+             nil          ; no suggestion for diff violations
+             false ""))
+          matches)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} git-diff
+  "Run git diff and return the output string."
+  [repo-path since-ref]
+  (when (safe-git-ref? since-ref)
+    (try
+      (let [pb (ProcessBuilder. ^java.util.List
+                ["git" "diff" (str since-ref "..HEAD")])
+            _  (.directory pb (io/file repo-path))
+            proc (.start pb)
+            out  (slurp (.getInputStream proc))]
+        (.waitFor proc)
+        (when-not (str/blank? out) out))
+      (catch Exception _ nil))))
+
+(defn ^{:stratum 1} git-diff-name-only
+  "Run git diff --name-only and return set of changed file paths."
+  [repo-path since-ref]
+  (when (safe-git-ref? since-ref)
+    (try
+      (let [pb (ProcessBuilder. ^java.util.List
+                ["git" "diff" "--name-only" (str since-ref "..HEAD")])
+            _  (.directory pb (io/file repo-path))
+            proc (.start pb)
+            out  (slurp (.getInputStream proc))]
+        (.waitFor proc)
+        (when-not (str/blank? out)
+          (set (str/split-lines (str/trim out)))))
+      (catch Exception _ nil))))
+
+(defn ^{:stratum 1} run-exceptions-as-data
+  "Run the AST-based exceptions-as-data linter against the repo. Returns
+   a vector of actionable Violation maps when selected, or nil when the
+   rule selector leaves the linter off. Returned rows are already in the
+   canonical scanner shape.
+
+   The raw exceptions-as-data scanner preserves `:fatal-only` and
+   `:local-boundary` records for audit counts, but the top-level compliance
+   review treats only `:cleanup-needed` rows as standards debt.
+   Programmer-error guards and documented local boundary wrappers are explicit
+   rule carve-outs and should not inflate `bb review` totals.
+
+   When `changed-files` is non-nil (incremental mode via `:since`), the
+   linter restricts its file walk to the changed set — matching the
+   behavior of content rules so `bb review --since` stays fast."
+  [repo-path changed-files opts]
+  (when (exceptions-as-data-selected? opts)
+    (filterv #(= :cleanup-needed (:classification %))
+             (:violations (exc-data/scan-repo repo-path changed-files)))))
+
+(defn ^{:stratum 1} scan-plan-rules
+  "Scan plan-output rules against terraform plan output."
+  [plan-rules plan-output]
+  (when plan-output
+    (->> plan-rules
+         (mapcat #(scan-plan-rule % plan-output))
+         vec)))
+
+(defn ^{:stratum 1} scan-diff-rules
+  "Scan diff-analysis rules against a git diff."
+  [diff-rules diff-content]
+  (when diff-content
+    (->> diff-rules
+         (mapcat #(scan-diff-rule % diff-content))
+         vec)))

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/scan_diff_plan.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/scan_diff_plan.clj
@@ -89,7 +89,10 @@
    Defaults on for `:all` / `:always-apply`; opts in for explicit selectors."
   [opts]
   (let [raw       (get opts :rules :always-apply)
-        requested (if (string? raw) (keyword (subs raw 1)) raw)]
+        requested (if (string? raw)
+                    (let [trimmed (cond-> raw (str/starts-with? raw ":") (subs 1))]
+                      (if (str/blank? trimmed) :always-apply (keyword trimmed)))
+                    raw)]
     (cond
       (contains? #{:all :always-apply} requested) true
       (= exc-data/rule-id requested)              true

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/scan_pack_config.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/scan_pack_config.clj
@@ -1,0 +1,134 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.compliance-scanner.scan-pack-config
+  "Pack-driven detection config conversion, split out of `scan` (rule 210:
+   an eighth real layer there is the signal to split it). Converts
+   compiled policy-pack rules into the detection config format `scan`
+   dispatches on, and filters pack rules by the :rules selector. Rule/
+   category selector matching lives in `scan-rule-selector`.
+
+   Layer 0: Glob matching, suggest-fn building, scannable-types,
+            violation enrichment
+   Layer 1: Pack-rule filtering by the :rules option + detection config
+            conversion"
+  (:require [ai.miniforge.compliance-scanner.scan-rule-selector :as rule-selector]
+            [clojure.string :as str])
+  (:import [java.nio.file FileSystems Paths]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Pack-driven detection config
+(defn- ^{:stratum 0} globs->file-pred
+  "Convert a vector of glob patterns into a file-path predicate function.
+   Uses java.nio.file.PathMatcher for standard glob matching."
+  [globs]
+  (let [fs       (FileSystems/getDefault)
+        matchers (mapv #(.getPathMatcher fs (str "glob:" %)) globs)]
+    (fn [path]
+      (let [p (Paths/get path (into-array String []))]
+        (boolean (some #(.matches ^java.nio.file.PathMatcher % p) matchers))))))
+
+(defn- ^{:stratum 0} build-suggest-fn
+  "Build a suggest function from pack detection and remediation config.
+   Uses str/replace-first with $1/$2/$3 group references for mechanical fixes."
+  [detection remediation]
+  (let [replacement (get remediation :replacement)
+        pattern-str (get detection :pattern)]
+    (cond
+      replacement
+      (let [pat (re-pattern pattern-str)]
+        (fn [matched-text]
+          (when (and matched-text pat replacement)
+            (str/replace-first matched-text pat replacement))))
+
+      (= :prepend (get remediation :type))
+      (constantly nil)
+
+      :else
+      (constantly nil))))
+
+(def ^{:stratum 0} ^:private scannable-types
+  "Detection types the compliance scanner can process."
+  #{:content-scan :diff-analysis :plan-output})
+
+(defn ^{:stratum 0} enrich-violation
+  "Attach remediation metadata from the pack rule to a violation map.
+   Downstream classify and execute phases use these fields."
+  [violation remediation]
+  (cond-> violation
+    (get remediation :type)
+    (assoc :remediation-type (get remediation :type))
+
+    (get remediation :template)
+    (assoc :remediation-template (get remediation :template))
+
+    (some? (get remediation :auto-fixable-default))
+    (assoc :auto-fixable-default (get remediation :auto-fixable-default))
+
+    (get remediation :exclude-contexts)
+    (assoc :exclude-contexts (get remediation :exclude-contexts))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} pack-rule->detection-config
+  "Convert a compiled pack rule into the detection config format used by scan-file.
+   Returns nil for rules without :content-scan detection."
+  [rule]
+  (let [detection   (get rule :rule/detection)
+        remediation (get rule :rule/remediation)
+        globs       (get-in rule [:rule/applies-to :file-globs])]
+    (when (= :content-scan (get detection :type))
+      (cond->
+        {:rule/id       (get rule :rule/id)
+         :rule/category (get rule :rule/category)
+         :title         (get rule :rule/title)
+         :pattern       (re-pattern (get detection :pattern))
+         :file-pred     (globs->file-pred (or globs ["**/*"]))
+         :suggest-fn    (build-suggest-fn detection remediation)
+         :detect-mode   (get detection :mode :positive)}
+
+        (get detection :email-pattern)
+        (assoc :email-pattern (re-pattern (get detection :email-pattern)))
+
+        remediation
+        (assoc :remediation remediation)))))
+
+(defn ^{:stratum 1} filter-pack-rules
+  "Filter compiled pack rules by the :rules option.
+
+   Supported selectors:
+   - :all / :always-apply — all rules with scannable detection types
+   - keyword — single rule ID match
+   - set of keywords — matches rule IDs OR category IDs
+     e.g. #{:std/clojure :mf.cat/workflows}
+
+   Only rules with scannable detection types (content-scan, diff-analysis,
+   plan-output) pass through."
+  [pack-rules opts]
+  (let [raw       (get opts :rules :always-apply)
+        requested (if (string? raw) (keyword (subs raw 1)) raw)
+        scannable (filter #(contains? scannable-types
+                                      (get-in % [:rule/detection :type]))
+                          pack-rules)]
+    (cond
+      (contains? #{:all :always-apply} requested) scannable
+      (keyword? requested)  (filter #(= requested (:rule/id %)) scannable)
+      (set? requested)      (filter (fn [rule]
+                                      (some #(rule-selector/rule-matches-selector? rule %) requested))
+                                    scannable)
+      :else                 scannable)))

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/scan_pack_config.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/scan_pack_config.clj
@@ -121,7 +121,10 @@
    plan-output) pass through."
   [pack-rules opts]
   (let [raw       (get opts :rules :always-apply)
-        requested (if (string? raw) (keyword (subs raw 1)) raw)
+        requested (if (string? raw)
+                    (let [trimmed (cond-> raw (str/starts-with? raw ":") (subs 1))]
+                      (if (str/blank? trimmed) :always-apply (keyword trimmed)))
+                    raw)
         scannable (filter #(contains? scannable-types
                                       (get-in % [:rule/detection :type]))
                           pack-rules)]

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/scan_rule_selector.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/scan_rule_selector.clj
@@ -1,0 +1,65 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.compliance-scanner.scan-rule-selector
+  "Rule/category selector matching, split out of `scan` (rule 210: an
+   eighth real layer there is the signal to split it). Used by
+   `scan-pack-config/filter-pack-rules` to resolve a `:rules` option
+   set of keywords against each pack rule's ID or Dewey category.
+
+   Layer 0: Dewey category-range table
+   Layer 1: Category-range matching
+   Layer 2: Rule-ID-or-category selector matching")
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private category-dewey-ranges
+  "Category keyword name to Dewey code range [lo hi].
+   Static data — no runtime dependency on taxonomy component."
+  {"foundations"   [0 99]
+   "tools"         [100 199]
+   "languages"     [200 299]
+   "frameworks"    [300 399]
+   "testing"       [400 499]
+   "operations"    [500 599]
+   "documentation" [600 699]
+   "workflows"     [700 799]
+   "project"       [800 899]
+   "meta"          [900 999]})
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} category-matches?
+  "Check if a rule's Dewey category falls in a category selector's range.
+   Uses static range lookup — no cross-layer dependency."
+  [rule cat-kw]
+  (let [cat-name (name cat-kw)
+        rule-cat (:rule/category rule)]
+    (or (= cat-name rule-cat)
+        (when-let [[lo hi] (get category-dewey-ranges cat-name)]
+          (try
+            (let [code (Integer/parseInt (str rule-cat))]
+              (and (<= lo code) (<= code hi)))
+            (catch Exception _ false))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} rule-matches-selector?
+  "Check if a rule matches a selector element (keyword — rule ID or category ID)."
+  [rule selector-kw]
+  (or (= selector-kw (:rule/id rule))
+      (category-matches? rule selector-kw)))


### PR DESCRIPTION
## Summary

Part of a docs-accuracy sweep (see #1581-#1585, #1587) that expanded
into real Wave-2 namespace splits once it turned out several
Wave-1-fixed files were also over rule 210's 3-layer budget (SL003).

\`scan.clj\`'s real per-file reference graph is 8 distinct layers after
Wave 1's autofix (#1461) -- the worst offender in this component,
tied with \`exceptions_as_data.clj\`. Its full split doesn't fit under
the 600-line PR-size ceiling in one PR, so it's split across two
stacked PRs:

- **This PR (1/2):** the detection-primitive layer --
  \`scan-rule-selector.clj\` (rule/category selector matching, 3
  layers), \`scan-content.clj\` (per-file content-scan detection, 3
  layers), \`scan-pack-config.clj\` (pack-driven detection-config
  conversion, 2 layers), \`scan-diff-plan.clj\` (diff/plan/
  exceptions-as-data detection, 2 layers).
- **Part 2/2 (stacked on this branch, opens once this is up):** the
  orchestration layer -- \`scan-content-rules.clj\` plus the \`scan.clj\`
  rewrite itself, since \`scan.clj\`'s own real stratum count only drops
  to budget once all five siblings exist.

None of these four files are consumed by anything yet in this PR --
that wiring happens in part 2. Each is independently verified.

## Verification

- \`stratum-lint\`, plain and \`--fix\` mode: 0 findings, all four files.
- \`clj-kondo\`: 0 warnings.
- No behavior change possible yet (nothing calls these), so no test
  delta in this PR; the full \`scan-test\`/\`multi-detection-test\`
  verification happens in part 2 once \`scan.clj\` actually requires
  these.

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>