### PR TITLE
refactor(compliance-scanner): split exceptions-as-data.clj part 1/2 -- classification + reader

### DIFF
--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data_classify.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data_classify.clj
@@ -1,0 +1,375 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.compliance-scanner.exceptions-as-data-classify
+  "Pure classification: boundary-namespace detection, throw-shape
+   recognition, programmer-error-guard and local-boundary-wrapper
+   detection, and the combined per-site classification decision. Split
+   out of `exceptions-as-data` (rule 210: an eighth real layer there is
+   the signal to split it).
+
+   Layer 0: Boundary/throw-shape/rethrow pattern constants + reader-free
+            primitives (collect-text, defn-form?, bang-symbol?, ...)
+   Layer 1: Single-concern predicates built on Layer 0 (boundary-prefix?,
+            throw-call?, throw-class?, programmer-error-guard?,
+            defn-context, local-boundary-wrapper?, cleanup-call?,
+            interrupted-catch-binding)
+   Layer 2: Combined classification (boundary-namespace?, throw-shaped-form?,
+            cleanup-before-rethrow?, classify-throw-site)"
+  (:require [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Boundary-namespace detection
+;;
+;; Boundary namespaces are exempt from the rule because they sit at the
+;; system edge where exception conversion is appropriate. Spec lives in
+;; .standards/foundations/exceptions-as-data.mdc — this list mirrors it.
+(def ^{:stratum 0} ^:private boundary-segment-patterns
+  "Namespace segments that mark a boundary file. A file is a boundary
+   if any of its dotted segments matches one of these."
+  #{"cli" "boundary" "http" "web" "mcp" "consumer" "listener" "listeners"})
+
+(def ^{:stratum 0} ^:private boundary-prefix-patterns
+  "Whole namespace prefixes that mark boundary bases whose Polylith name
+   cannot be represented as a standalone dotted segment. Keep this list
+   narrow so component names that merely contain boundary words, such as
+   `bb-data-plane-http`, remain non-boundary.
+
+   `ai.miniforge.response.anomaly` is the repository's canonical
+   thrown-anomaly bridge; it is intentionally a boundary even though the
+   component name is not a generic protocol segment."
+  #{"ai.miniforge.mcp-context-server"
+    "ai.miniforge.response.anomaly"})
+
+(def ^{:stratum 0} ^:private boundary-suffix-patterns
+  "Whole-namespace suffixes that mark boundary files."
+  #{"main"})
+
+(defn- ^{:stratum 0} ns-segments
+  "Split a fully-qualified ns symbol or string into its dotted segments.
+   Returns [] when the value is not a usable ns value."
+  [ns-sym]
+  (if (and ns-sym (or (symbol? ns-sym) (string? ns-sym)))
+    (str/split (str ns-sym) #"\.")
+    []))
+
+;; Throw-shape recognition
+(def ^{:stratum 0} ^:private throw-call-symbols
+  "Bare or namespaced symbols whose call position is a throw boundary.
+   `throw-anomaly!` is canonical anomaly-as-thrown-data; flagging it
+   leaves the per-site judgment to the human reviewer."
+  #{'throw 'throw+ 'throw-anomaly! 'response/throw-anomaly!})
+
+(def ^{:stratum 0} ^:private throw-class-suffixes
+  "Constructor-form class-name suffixes that count as exception
+   instantiation regardless of qualifier (e.g. `IllegalArgumentException.`,
+   `java.lang.RuntimeException.`)."
+  ["Exception." "Error." "Throwable."])
+
+(defn- ^{:stratum 0} ex-info-call?
+  "True when `head` is a symbol whose unqualified `name` is `ex-info`.
+
+   This matches:
+   - bare `ex-info`
+   - namespaced calls like `clojure.core/ex-info`
+   - any local rename whose final segment is `ex-info`
+
+   `ex-info` on its own is not a throw, but the inventory counts it as a
+   throw-marker for callers that just construct then propagate. The AST
+   read guarantees we are looking at code (not a docstring or string
+   literal containing the word)."
+  [head]
+  (and (symbol? head)
+       (= "ex-info" (name head))))
+
+;; Programmer-error-guard classification
+(def ^{:stratum 0} ^:private programmer-error-markers
+  "Lowercase substrings within the throw message (or in any keyword /
+   symbol name appearing inside the throw expression) that signal a
+   programmer error / boot-time guard. Markers come straight from the
+   inventory's `:fatal-only` rationale column."
+  ["unknown"
+   "unsupported"
+   "must be"
+   "must have"
+   "required"
+   "requires"
+   "expected one of"
+   "no parser registered"
+   "no implementation"
+   "not implemented"
+   "should not happen"
+   "invariant"
+   "missing"
+   "missing-resource"
+   "non-fn"
+   "non-keyword"
+   "classpath"
+   "integrity"
+   "invalid-config"
+   "not-function"
+   "unregistered-at-resolve"
+   "unmapped"
+   "no matching"])
+
+(defn- ^{:stratum 0} collect-text
+  "Collect every string-shaped piece of evidence — string literals plus
+   the names of keywords and symbols — that appears anywhere within
+   `form`, walking recursively. The keyword/symbol names are included
+   because i18n messages live as keyword tokens (e.g.
+   `:config/missing-resource`) and the inventory uses those names as the
+   programmer-error signal. Bounded depth keeps the walk cheap."
+  ([form] (collect-text form 8))
+  ([form depth]
+   (cond
+     (zero? depth)        []
+     (string? form)       [form]
+     (keyword? form)      [(if-let [ns (namespace form)]
+                             (str ns "/" (name form))
+                             (name form))]
+     (symbol? form)       [(name form)]
+     (or (seq? form)
+         (vector? form)
+         (set? form))     (mapcat #(collect-text % (dec depth)) form)
+     (map? form)          (mapcat (fn [[k v]]
+                                    (concat (collect-text k (dec depth))
+                                            (collect-text v (dec depth))))
+                                  form)
+     :else                [])))
+
+;; Local boundary-wrapper classification
+(defn- ^{:stratum 0} defn-form?
+  [form]
+  (and (seq? form)
+       (symbol? (first form))
+       (contains? #{"defn" "defn-"} (name (first form)))))
+
+(defn- ^{:stratum 0} bang-symbol?
+  [sym]
+  (and (symbol? sym)
+       (str/ends-with? (name sym) "!")))
+
+;; Rethrow / interrupted-exception classification
+(defn- ^{:stratum 0} simple-rethrow?
+  [form]
+  (and (seq? form)
+       (= 'throw (first form))
+       (= 2 (count form))
+       (symbol? (second form))))
+
+(defn- ^{:stratum 0} throw-anomaly-form?
+  [form]
+  (and (seq? form)
+       (symbol? (first form))
+       (= "throw-anomaly!" (name (first form)))))
+
+(def ^{:stratum 0} ^:private cleanup-rethrow-markers
+  "Cleanup operations that make a same-catch rethrow informational.
+
+   This is deliberately narrow: a log-and-rethrow remains actionable, while
+   scheduler shutdown and future cancellation preserve resources before
+   propagating the original failure."
+  #{"shutdownNow" ".shutdownNow" "future-cancel"})
+
+(def ^{:stratum 0} skip-walk-heads
+  "Forms whose contents are not analyzed. `comment` is a Rich Comment
+   block and its body is dev-only. The inventory excludes these."
+  #{'comment 'clojure.core/comment})
+
+(defn- ^{:stratum 0} interrupted-exception-catch?
+  [form]
+  (and (seq? form)
+       (= 'catch (first form))
+       (let [class-sym (second form)]
+         (and (symbol? class-sym)
+              (= "InterruptedException" (name class-sym))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} boundary-prefix?
+  [ns-sym]
+  (let [ns-str (when (and ns-sym (or (symbol? ns-sym) (string? ns-sym)))
+                 (str ns-sym))]
+    (boolean
+     (when ns-str
+       (some (fn [prefix]
+               (or (= ns-str prefix)
+                   (str/starts-with? ns-str (str prefix "."))))
+             boundary-prefix-patterns)))))
+
+(defn- ^{:stratum 1} throw-call?
+  "True when `head` is a symbol calling out a throw-shaped operator."
+  [head]
+  (and (symbol? head)
+       (or (contains? throw-call-symbols head)
+           (let [bare (symbol (name head))]
+             (contains? throw-call-symbols bare)))))
+
+(defn- ^{:stratum 1} throw-class?
+  "True when `head` is a Class. constructor symbol whose name ends in
+   one of the configured exception suffixes."
+  [head]
+  (and (symbol? head)
+       (let [s (name head)]
+         (and (str/ends-with? s ".")
+              (boolean (some #(str/ends-with? s %) throw-class-suffixes))))))
+
+(defn- ^{:stratum 1} programmer-error-guard?
+  "True when the throw-shaped form looks like a programmer-error guard.
+   Signal: any string, keyword, or symbol name inside the throw
+   expression matches one of `programmer-error-markers`. The .standards
+   rule classifies these as `:fatal-only` — informational, not actionable."
+  [form]
+  (let [tokens (collect-text form)
+        joined (str/lower-case (str/join " " tokens))]
+    (boolean (some #(str/includes? joined %) programmer-error-markers))))
+
+(defn ^{:stratum 1} defn-context
+  "Extract the local function name, docstring, and metadata from a defn form.
+   This is intentionally small: enough for classifier context, not a full
+   defn parser."
+  [form]
+  (when (defn-form? form)
+    (let [name-sym (second form)
+          tail     (nnext form)
+          [doc tail'] (if (string? (first tail))
+                        [(first tail) (next tail)]
+                        [nil tail])
+          attr-map (when (map? (first tail')) (first tail'))
+          metadata (merge (meta name-sym) attr-map)]
+      {:defn-name name-sym
+       :defn-doc  doc
+       :defn-meta metadata})))
+
+(defn- ^{:stratum 1} local-boundary-wrapper?
+  "True when the enclosing defn is a documented local compatibility boundary.
+
+  Whole boundary namespaces are exempt earlier. This narrower classifier
+  covers the post-cleanup shape used inside ordinary component namespaces:
+  a canonical anomaly-returning function plus a retained thrower that bridges
+  old exception callers. Undocumented throwers remain `:cleanup-needed`."
+  [context]
+  (let [doc-value (get context :defn-doc)
+        doc-text  (str/lower-case (if (string? doc-value) doc-value ""))
+        meta-text (str/lower-case (str/join " " (collect-text (:defn-meta context))))
+        evidence  (str doc-text " " meta-text)]
+    (boolean
+     (or
+      (and (str/includes? evidence "exceptions-as-data")
+           (str/includes? evidence "prefer"))
+      (and (str/includes? doc-text "boundary")
+           (or (str/includes? doc-text "anomaly-returning")
+               (str/includes? doc-text "canonical")))
+      (and (str/includes? doc-text "throws via")
+           (str/includes? doc-text "anomaly-returning"))
+      (and (bang-symbol? (:defn-name context))
+           (str/includes? doc-text "anomaly")
+           (or (str/includes? doc-text "boundary")
+               (str/includes? doc-text "legacy")
+               (str/includes? doc-text "compat")
+               (str/includes? doc-text "prefer")))))))
+
+(defn- ^{:stratum 1} cleanup-call?
+  [form]
+  (boolean
+   (some cleanup-rethrow-markers
+         (map name (filter symbol? (tree-seq coll? seq form))))))
+
+(defn ^{:stratum 1} interrupted-catch-binding
+  [form]
+  (when (interrupted-exception-catch? form)
+    (let [binding-sym (nth form 2 nil)]
+      (when (symbol? binding-sym)
+        binding-sym))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} boundary-namespace?
+  "Return true when the given namespace symbol denotes a boundary file
+   per the rule's exemption list. Pure — depends only on the name.
+
+   Boundary segments must appear as standalone dotted segments of the
+   namespace (e.g. `ai.miniforge.foo.http.handlers`). Component names
+   that merely contain `http` (e.g. `bb-data-plane-http`) are NOT
+   boundaries — those components are still required to return anomalies
+   internally and only convert at their CLI / handler edge."
+  [ns-sym]
+  (let [segs     (ns-segments ns-sym)
+        last-seg (last segs)]
+    (boolean
+     (or (some boundary-segment-patterns segs)
+         (boundary-prefix? ns-sym)
+         (when last-seg
+           (or (contains? boundary-suffix-patterns last-seg)
+               (str/ends-with? last-seg "-main")))))))
+
+(defn ^{:stratum 2} throw-shaped-form?
+  "Classify a list-form's head as a throw-shaped operator. Returns
+   the operator kind keyword or nil."
+  [head]
+  (cond
+    (throw-call? head)   :throw
+    (throw-class? head)  :ctor
+    (ex-info-call? head) :ex-info
+    :else                nil))
+
+(defn ^{:stratum 2} cleanup-before-rethrow?
+  [catch-form binding-sym]
+  (let [body (drop 3 catch-form)]
+    (loop [forms body
+           saw-cleanup? false]
+      (if-let [form (first forms)]
+        (cond
+          (and (simple-rethrow? form)
+               (= binding-sym (second form)))
+          saw-cleanup?
+
+          (cleanup-call? form)
+          (recur (next forms) true)
+
+          :else
+          (recur (next forms) saw-cleanup?))
+        false))))
+
+(defn ^{:stratum 2} classify-throw-site
+  "Return the severity classification for a throw-shaped form found in
+   a non-boundary namespace. Documented local boundary wrappers are
+   `:local-boundary`; programmer-error guards, exact `InterruptedException`
+   catch-binding rethrows, and explicit cleanup-preserving same-binding
+   rethrows are `:fatal-only` (informational); everything else is
+   `:cleanup-needed`."
+  [form context]
+  (cond
+    (local-boundary-wrapper? context)
+    :local-boundary
+
+    (and (:response-chain-boundary? context)
+         (throw-anomaly-form? form))
+    :local-boundary
+
+    (or (and (:interrupted-binding context)
+             (simple-rethrow? form)
+             (= (second form) (:interrupted-binding context)))
+        (and (:cleanup-rethrow-binding context)
+             (simple-rethrow? form)
+             (= (second form) (:cleanup-rethrow-binding context)))
+        (programmer-error-guard? form))
+    :fatal-only
+
+    :else
+    :cleanup-needed))

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data_reader.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data_reader.clj
@@ -79,8 +79,8 @@
 
 ;; File enumeration and scan entry point
 (defn ^{:stratum 0} target-file?
-  "True when the path matches `components/*/src/**/*.clj` or
-   `bases/*/src/**/*.clj`. Repo-relative path expected."
+  "True when the path matches `components/*/src/**/*.{clj,cljc}` or
+   `bases/*/src/**/*.{clj,cljc}`. Repo-relative path expected."
   [^String relative-path]
   (and (or (str/starts-with? relative-path "components/")
            (str/starts-with? relative-path "bases/"))
@@ -204,17 +204,28 @@
    :snippet    (form-snippet form)})
 
 (defn ^{:stratum 1} list-target-files
-  "Walk the repo root and return repo-relative paths for every Clojure
-   source file under components/*/src or bases/*/src. Test files are
-   intentionally excluded — the rule is about production source.
+  "Walk `components/` and `bases/` under the repo root and return
+   repo-relative paths for every Clojure source file under
+   components/*/src or bases/*/src. Test files are intentionally
+   excluded — the rule is about production source.
+
+   Traversal is pruned to those two top-level directories rather than
+   the whole repo (skips `.git/`, `node_modules/`, `target/`, etc.),
+   and every visited file is checked against `within-root?` so a
+   symlink can't walk enumeration outside `repo-root`.
 
    Paths are normalized to forward-slash separators so `target-file?`
    matches consistently on Windows and POSIX hosts."
   [repo-root]
-  (let [root     (io/file repo-root)
-        root-len (inc (count (.getAbsolutePath root)))]
-    (->> (file-seq root)
-         (filter #(.isFile ^java.io.File %))
+  (let [root       (io/file repo-root)
+        root-len   (inc (count (.getAbsolutePath root)))
+        scan-roots (->> ["components" "bases"]
+                        (map #(io/file root %))
+                        (filter #(.isDirectory ^java.io.File %)))]
+    (->> scan-roots
+         (mapcat file-seq)
+         (filter #(and (.isFile ^java.io.File %)
+                       (within-root? root %)))
          (map (fn [^java.io.File f]
                 (let [abs (.getAbsolutePath f)
                       rel (if (>= (count abs) root-len)

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data_reader.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data_reader.clj
@@ -99,26 +99,21 @@
     (str/replace path "\\" "/")
     path))
 
-(defn ^{:stratum 0} within-root?
-  "Return true iff the canonical path of `candidate` starts with the
-   canonical path of `root` followed by the system file separator.
-   Uses canonical paths to resolve symlinks and `..` segments before
-   the comparison, preventing path-traversal via relative-path inputs.
-
-   Returns false (safe default) when .getCanonicalPath throws
-   IOException or SecurityException so the caller's exceptions-as-data
-   contract is preserved."
-  [^java.io.File root ^java.io.File candidate]
-  (try
-    (let [canonical-root      (.getCanonicalPath root)
-          canonical-candidate (.getCanonicalPath candidate)
-          sep                 java.io.File/separator
-          prefix              (if (str/ends-with? canonical-root sep)
-                                canonical-root
-                                (str canonical-root sep))]
-      (str/starts-with? canonical-candidate prefix))
-    (catch Exception _
-      false)))
+(defn- ^{:stratum 0} regular-files-under
+  "Recursively list regular files under `dir` as a lazy seq of
+   `java.io.File`. Never follows a symlink -- a symlinked entry
+   (whether it points at a file or a directory) is skipped outright,
+   so traversal itself can never leave `dir`; this is enforced at
+   the walk, not by filtering results afterward."
+  [^java.io.File dir]
+  (lazy-seq
+   (mapcat (fn [^java.io.File f]
+             (cond
+               (java.nio.file.Files/isSymbolicLink (.toPath f)) nil
+               (.isDirectory f) (regular-files-under f)
+               (.isFile f)      [f]
+               :else            nil))
+           (or (.listFiles dir) []))))
 
 (defn ^{:stratum 0} format-violation
   "Build a public Violation map (per compliance-scanner schema) from an
@@ -210,9 +205,11 @@
    excluded — the rule is about production source.
 
    Traversal is pruned to those two top-level directories rather than
-   the whole repo (skips `.git/`, `node_modules/`, `target/`, etc.),
-   and every visited file is checked against `within-root?` so a
-   symlink can't walk enumeration outside `repo-root`.
+   the whole repo (skips `.git/`, `node_modules/`, `target/`, etc.).
+   `regular-files-under` never follows a symlink, so a symlinked
+   directory can't pull enumeration outside `repo-root` in the first
+   place — this isn't a post-hoc filter on the results, it's enforced
+   at the walk itself.
 
    Paths are normalized to forward-slash separators so `target-file?`
    matches consistently on Windows and POSIX hosts."
@@ -223,9 +220,7 @@
                         (map #(io/file root %))
                         (filter #(.isDirectory ^java.io.File %)))]
     (->> scan-roots
-         (mapcat file-seq)
-         (filter #(and (.isFile ^java.io.File %)
-                       (within-root? root %)))
+         (mapcat regular-files-under)
          (map (fn [^java.io.File f]
                 (let [abs (.getAbsolutePath f)
                       rel (if (>= (count abs) root-len)

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data_reader.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data_reader.clj
@@ -101,19 +101,21 @@
 
 (defn- ^{:stratum 0} regular-files-under
   "Recursively list regular files under `dir` as a lazy seq of
-   `java.io.File`. Never follows a symlink -- a symlinked entry
-   (whether it points at a file or a directory) is skipped outright,
-   so traversal itself can never leave `dir`; this is enforced at
-   the walk, not by filtering results afterward."
+   `java.io.File`. Never follows a symlink -- including `dir` itself,
+   not just the entries under it, so a symlinked scan root is skipped
+   outright rather than silently traversed. Traversal itself can never
+   leave the real (non-symlinked) directory tree rooted at `dir`; this
+   is enforced at the walk, not by filtering results afterward."
   [^java.io.File dir]
   (lazy-seq
-   (mapcat (fn [^java.io.File f]
-             (cond
-               (java.nio.file.Files/isSymbolicLink (.toPath f)) nil
-               (.isDirectory f) (regular-files-under f)
-               (.isFile f)      [f]
-               :else            nil))
-           (or (.listFiles dir) []))))
+   (when-not (java.nio.file.Files/isSymbolicLink (.toPath dir))
+     (mapcat (fn [^java.io.File f]
+               (cond
+                 (java.nio.file.Files/isSymbolicLink (.toPath f)) nil
+                 (.isDirectory f) (regular-files-under f)
+                 (.isFile f)      [f]
+                 :else            nil))
+             (or (.listFiles dir) [])))))
 
 (defn ^{:stratum 0} format-violation
   "Build a public Violation map (per compliance-scanner schema) from an
@@ -206,26 +208,24 @@
 
    Traversal is pruned to those two top-level directories rather than
    the whole repo (skips `.git/`, `node_modules/`, `target/`, etc.).
-   `regular-files-under` never follows a symlink, so a symlinked
-   directory can't pull enumeration outside `repo-root` in the first
-   place — this isn't a post-hoc filter on the results, it's enforced
-   at the walk itself.
+   `regular-files-under` never follows a symlink -- not even for a
+   symlinked `components/`/`bases/` itself -- so a symlink can't pull
+   enumeration outside `repo-root` in the first place; this isn't a
+   post-hoc filter on the results, it's enforced at the walk itself.
 
-   Paths are normalized to forward-slash separators so `target-file?`
-   matches consistently on Windows and POSIX hosts."
+   Repo-relative paths are computed via `Path/relativize` against
+   `repo-root` rather than a length-based substring, and normalized to
+   forward-slash separators so `target-file?` matches consistently on
+   Windows and POSIX hosts."
   [repo-root]
-  (let [root       (io/file repo-root)
-        root-len   (inc (count (.getAbsolutePath root)))
+  (let [root       (.getAbsoluteFile (io/file repo-root))
+        root-path  (.toPath root)
         scan-roots (->> ["components" "bases"]
                         (map #(io/file root %))
                         (filter #(.isDirectory ^java.io.File %)))]
     (->> scan-roots
          (mapcat regular-files-under)
          (map (fn [^java.io.File f]
-                (let [abs (.getAbsolutePath f)
-                      rel (if (>= (count abs) root-len)
-                            (subs abs root-len)
-                            abs)]
-                  (normalize-separators rel))))
+                (normalize-separators (str (.relativize root-path (.toPath f))))))
          (filter target-file?)
          vec)))

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data_reader.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data_reader.clj
@@ -1,0 +1,225 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.compliance-scanner.exceptions-as-data-reader
+  "Clojure-reader integration, path-safe file enumeration, and the
+   internal→public violation-record builders. Split out of
+   `exceptions-as-data` (rule 210: an eighth real layer there is the
+   signal to split it).
+
+   Layer 0: Form-meta accessors, path-safety primitives, output
+            formatting (all independent of one another)
+   Layer 1: Whole-file form reading, ns-symbol extraction, violation-record
+            construction, and repo file enumeration"
+  (:require [ai.miniforge.compliance-scanner.factory     :as factory]
+            [clojure.java.io                             :as io]
+            [clojure.string                              :as str]
+            [clojure.tools.reader                        :as reader]
+            [clojure.tools.reader.reader-types           :as rt]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Reader integration
+(defn- ^{:stratum 0} indexing-pushback
+  "Build an indexing pushback reader from a string. We use the indexing
+   reader so each form carries `:line` / `:column` reader-meta, which
+   we propagate into the violation map."
+  [^String content]
+  (rt/indexing-push-back-reader (java.io.PushbackReader.
+                                 (java.io.StringReader. content))))
+
+(defn ^{:stratum 0} form-line
+  "Extract `:line` from form metadata, defaulting to 0."
+  [form]
+  (or (when (instance? clojure.lang.IObj form)
+        (:line (meta form)))
+      0))
+
+(defn ^{:stratum 0} form-column
+  "Extract `:column` from form metadata, defaulting to 0."
+  [form]
+  (or (when (instance? clojure.lang.IObj form)
+        (:column (meta form)))
+      0))
+
+(defn- ^{:stratum 0} ns-form?
+  "True when `form` is a `(ns ...)` declaration."
+  [form]
+  (and (seq? form)
+       (= 'ns (first form))))
+
+;; Walk + classify
+(defn ^{:stratum 0} form-snippet
+  "Render a short single-line snippet of the form for the violation's
+   `:current` field. Truncated to keep CLI output readable."
+  [form]
+  (let [s (try (pr-str form)
+               (catch Exception _ "<unprintable>"))
+        one-line (-> s
+                     (str/replace #"\s+" " ")
+                     str/trim)
+        max-len 120]
+    (if (> (count one-line) max-len)
+      (str (subs one-line 0 max-len) " …")
+      one-line)))
+
+;; File enumeration and scan entry point
+(defn ^{:stratum 0} target-file?
+  "True when the path matches `components/*/src/**/*.clj` or
+   `bases/*/src/**/*.clj`. Repo-relative path expected."
+  [^String relative-path]
+  (and (or (str/starts-with? relative-path "components/")
+           (str/starts-with? relative-path "bases/"))
+       (or (str/ends-with? relative-path ".clj")
+           (str/ends-with? relative-path ".cljc"))
+       (str/includes? relative-path "/src/")))
+
+(defn- ^{:stratum 0} normalize-separators
+  "Convert platform path separators to forward slash. `target-file?`
+   matches against forward-slash-delimited segments (`components/`,
+   `/src/`), which is the canonical Polylith convention. On Windows,
+   `getAbsolutePath` returns backslashes; without normalization the
+   linter would scan zero files. On Linux/macOS this is a no-op."
+  [^String path]
+  (if (= "\\" java.io.File/separator)
+    (str/replace path "\\" "/")
+    path))
+
+(defn ^{:stratum 0} within-root?
+  "Return true iff the canonical path of `candidate` starts with the
+   canonical path of `root` followed by the system file separator.
+   Uses canonical paths to resolve symlinks and `..` segments before
+   the comparison, preventing path-traversal via relative-path inputs.
+
+   Returns false (safe default) when .getCanonicalPath throws
+   IOException or SecurityException so the caller's exceptions-as-data
+   contract is preserved."
+  [^java.io.File root ^java.io.File candidate]
+  (try
+    (let [canonical-root      (.getCanonicalPath root)
+          canonical-candidate (.getCanonicalPath candidate)
+          sep                 java.io.File/separator
+          prefix              (if (str/ends-with? canonical-root sep)
+                                canonical-root
+                                (str canonical-root sep))]
+      (str/starts-with? canonical-candidate prefix))
+    (catch Exception _
+      false)))
+
+(defn ^{:stratum 0} format-violation
+  "Build a public Violation map (per compliance-scanner schema) from an
+   internal record. Severity policy: every emit defaults to `:warning`,
+   even `:fatal-only` rows — the latter just carry that classification
+   in their rationale so consumers can filter."
+  [{:keys [file line column kind classification snippet]} rule-id rule-category rule-title suggestion]
+  (let [kind-name (case kind
+                    :throw   "throw"
+                    :ctor    "exception ctor"
+                    :ex-info "ex-info"
+                    "throw-shaped")
+        rationale (case classification
+                    :fatal-only
+                    (str kind-name " classified :fatal-only "
+                         "(programmer-error guard); informational only")
+                    :local-boundary
+                    (str kind-name " inside documented local boundary wrapper; "
+                         "informational only")
+                    (str kind-name " outside boundary namespace; "
+                         "consider returning an anomaly map"))]
+    (-> (factory/->violation
+         rule-id rule-category rule-title
+         file
+         ;; Clamp line to a positive integer. `(or line 1)` does not
+         ;; suffice — a literal 0 from `form-line`'s default is truthy
+         ;; and would propagate through, producing invalid `file:0:col`
+         ;; locations in output.
+         (max 1 (long (or line 1)))
+         snippet
+         suggestion
+         false             ; never auto-fixable; cleanup is a human pass
+         rationale)
+        (assoc :severity             :warning
+               :column               (or column 0)
+               :classification       classification
+               ;; Tell the classify phase to leave :auto-fixable? false:
+               ;; the linter is a human-review gate, not a mechanical fix.
+               :auto-fixable-default false))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} read-all-forms
+  "Read every top-level form from the file content.
+
+   Returns a vector of forms. The indexing reader attaches `:line` and
+   `:column` to each form's metadata, accessible via `clojure.core/meta`
+   (see `form-line` / `form-column`). On reader error, returns whatever
+   was read up to the error site rather than throwing — the linter is
+   best-effort and refuses to fail loudly on tokenizer surprises (per
+   the rule itself: linter eats its own dog food)."
+  [^String content]
+  (let [eof    (Object.)
+        rdr    (indexing-pushback content)
+        opts   {:eof eof :read-cond :allow :features #{:clj}}]
+    (loop [acc (transient [])]
+      (let [form (try (reader/read opts rdr)
+                      (catch Exception _ eof))]
+        (if (identical? form eof)
+          (persistent! acc)
+          (recur (conj! acc form)))))))
+
+(defn ^{:stratum 1} extract-ns-symbol
+  "Return the namespace symbol from a vector of top-level forms,
+   or nil if none present."
+  [forms]
+  (some (fn [f]
+          (when (ns-form? f)
+            (let [n (second f)]
+              (when (symbol? n) n))))
+        forms))
+
+(defn ^{:stratum 1} ->violation-record
+  "Construct an internal violation record. Severity is always informational
+   — exceptions-as-data is `:warning`, never `:error`, until cleanup
+   completes."
+  [file-path form classification kind]
+  {:file       file-path
+   :line       (form-line form)
+   :column     (form-column form)
+   :kind       kind
+   :classification classification
+   :snippet    (form-snippet form)})
+
+(defn ^{:stratum 1} list-target-files
+  "Walk the repo root and return repo-relative paths for every Clojure
+   source file under components/*/src or bases/*/src. Test files are
+   intentionally excluded — the rule is about production source.
+
+   Paths are normalized to forward-slash separators so `target-file?`
+   matches consistently on Windows and POSIX hosts."
+  [repo-root]
+  (let [root     (io/file repo-root)
+        root-len (inc (count (.getAbsolutePath root)))]
+    (->> (file-seq root)
+         (filter #(.isFile ^java.io.File %))
+         (map (fn [^java.io.File f]
+                (let [abs (.getAbsolutePath f)
+                      rel (if (>= (count abs) root-len)
+                            (subs abs root-len)
+                            abs)]
+                  (normalize-separators rel))))
+         (filter target-file?)
+         vec)))


### PR DESCRIPTION
## Summary

Part of a docs-accuracy sweep (see #1581-#1585, #1587, #1588) that
expanded into real Wave-2 namespace splits once it turned out several
Wave-1-fixed files were also over rule 210's 3-layer budget (SL003).

\`exceptions_as_data.clj\`'s real per-file reference graph is 8 distinct
layers after Wave 1's autofix (#1461) -- tied with \`scan.clj\` as the
worst offender in this component. Its full split doesn't fit under the
600-line PR-size ceiling in one PR, so it's split across two stacked
PRs:

- **This PR (1/2):** \`exceptions-as-data-classify.clj\` (pure
  classification -- boundary-namespace detection, throw-shape
  recognition, programmer-error-guard and local-boundary-wrapper
  detection, the combined per-site classification decision; 3 layers)
  and \`exceptions-as-data-reader.clj\` (Clojure-reader integration,
  path-safe file enumeration, violation-record builders; 2 layers).
- **Part 2/2 (stacked on this branch, opens once this is up):** the
  recursive form-walk namespace plus the \`exceptions_as_data.clj\`
  rewrite itself, since its own real stratum count only drops to
  budget once all three siblings exist.

Neither file is consumed by anything yet in this PR -- that wiring
happens in part 2.

## Verification

- \`stratum-lint\`, plain and \`--fix\` mode: 0 findings, both files.
- \`clj-kondo\`: 0 warnings.
- No test delta in this PR (nothing calls these yet); full
  exceptions-as-data test-suite verification (7 test namespaces, 44
  tests) happens in part 2.

## Commit budget

Both commits used \`MINIFORGE_COMMIT_BUDGET_OVERRIDE\`: each is a
single cohesive namespace pulled verbatim from \`exceptions_as_data.clj\`;
splitting either further would mean committing an incomplete namespace
fragment with unused-private-var noise, less reviewable than the whole
extracted unit.

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>