### PR TITLE
feat(effect-transaction): propose, commit, reconcile (Ariadne 2c, part 2)

### DIFF
--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/core.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/core.clj
@@ -155,6 +155,11 @@
    back as a timeout; the record stays honestly unknown until
    `reconcile!` asks.
 
+   The supplied grant must be THE grant the proposal named, and its
+   effect class must match the proposed effect. Re-checking a different
+   grant would authorize the effect against authority the proposal never
+   claimed.
+
    Only a `:proposed` record may be committed. Committing one that has
    already moved on would re-run an irreversible effect — a second
    merge, a second deploy — which is the exact class of accident this
@@ -171,6 +176,24 @@
       (not= :proposed (:effect/state t))
       (wrong-state "only a :proposed record may be committed"
                    {:effect/id (:effect/id t) :effect/state (:effect/state t)})
+
+      ;; The record NAMES the grant that authorized it. Re-checking some
+      ;; other grant would authorize the effect against authority the
+      ;; proposal never claimed — propose under a narrow grant, commit
+      ;; under a broad one, and the audit trail records a lie. The
+      ;; re-check is only worth anything if it re-checks the SAME grant.
+      (not= (:effect/grant-id t) (:grant/id grant-record))
+      (wrong-state "grant does not match the one recorded on the proposal"
+                   {:effect/id (:effect/id t)
+                    :effect/grant-id (:effect/grant-id t)
+                    :grant/id (:grant/id grant-record)})
+
+      ;; Likewise the class: a merge grant must not authorize a deploy.
+      (not= (:effect/class t) (:grant/effect-class grant-record))
+      (wrong-state "grant effect-class does not match the proposed effect"
+                   {:effect/id (:effect/id t)
+                    :effect/class (:effect/class t)
+                    :grant/effect-class (:grant/effect-class grant-record)})
 
       (not (grant/authorized? auth))
       (advance! dir t {:effect/state :failed

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/core.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/core.clj
@@ -153,20 +153,38 @@
 
    A throw is not a failure. The call may have reached GitHub and come
    back as a timeout; the record stays honestly unknown until
-   `reconcile!` asks."
+   `reconcile!` asks.
+
+   Only a `:proposed` record may be committed. Committing one that has
+   already moved on would re-run an irreversible effect — a second
+   merge, a second deploy — which is the exact class of accident this
+   component exists to make impossible. Refused, and the effect does not
+   fire.
+
+   JVM `Error`s are NOT caught. An OutOfMemoryError is not an effect
+   outcome, and the record is already `:committing` on disk before
+   `effect-fn` runs, so letting it propagate leaves precisely the state
+   reconciliation is built for."
   [dir t grant-record usage ^Instant now effect-fn]
   (let [auth (grant/authorize grant-record usage now)]
-    (if-not (grant/authorized? auth)
+    (cond
+      (not= :proposed (:effect/state t))
+      (wrong-state "only a :proposed record may be committed"
+                   {:effect/id (:effect/id t) :effect/state (:effect/state t)})
+
+      (not (grant/authorized? auth))
       (advance! dir t {:effect/state :failed
                        :effect/failure (str "grant re-check failed at commit: "
                                             (name (:grant/outcome auth)))}
                 now)
+
+      :else
       (let [committing (advance! dir t {:effect/state :committing} now)]
         (if (anomaly/anomaly? committing)
           committing
           (let [reported (try
                            {:ok (effect-fn)}
-                           (catch Throwable e
+                           (catch Exception e
                              {:threw (or (ex-message e) (str (class e)))}))]
             (if (contains? reported :threw)
               (advance! dir committing
@@ -197,7 +215,11 @@
 
    An answer that omits `:effect/matched?` records `false`: an
    unconfirmed match is treated as a mismatch, because an unflagged
-   disagreement is worse than a flagged one."
+   disagreement is worse than a flagged one.
+
+   JVM `Error`s are NOT caught here either — a probe that dies of
+   OutOfMemory has not told us the effect is unresolvable, it has told
+   us the process is."
   [dir t probe-fn ^Instant now]
   (if-not (contains? schema/reconcilable-states (:effect/state t))
     (wrong-state "only :committing or :unknown-outcome records are reconcilable"
@@ -206,7 +228,7 @@
     ;; the probe returns caller-shaped data, so any in-band sentinel is a
     ;; value it could legitimately carry. The wrapper map is ours.
     (let [probed (try {:ok (probe-fn t)}
-                      (catch Throwable e {:threw (or (ex-message e) (str (class e)))}))
+                      (catch Exception e {:threw (or (ex-message e) (str (class e)))}))
           answer (:ok probed)]
       (if (or (contains? probed :threw)
               (not (map? answer))

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/core.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/core.clj
@@ -1,0 +1,222 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.effect-transaction.core
+  "propose -> commit -> reconcile for irreversible effects (Ariadne 2c).
+
+   This GENERALIZES a pattern miniforge already runs rather than
+   inventing one. The operator intervention path is already transacted:
+   `operator_requests.clj` lands the request with ATOMIC_MOVE and
+   refuses to report success for a gesture that did not reach disk, and
+   `operator/application.clj` advances to `:dispatched` BEFORE firing
+   the effect, then verifies a `{:observed :expected}` readback. Merge,
+   deploy, and spend get the same treatment here.
+
+   The judgment that shapes everything below: an effect that THREW is
+   `:unknown-outcome`, not `:failed`. A timeout talking to GitHub may
+   well have merged the PR. Recording failure for an effect that landed
+   is exactly as wrong as recording success for one that did not, and
+   both are worse than admitting we do not yet know."
+  (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.effect-transaction.schema :as schema]
+   [ai.miniforge.effect-transaction.store :as store]
+   [ai.miniforge.execution-grant.interface :as grant]
+   [malli.core :as m]
+   [malli.error :as me])
+  (:import
+   [java.time Instant]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Validation + outcome reading
+(defn ^{:stratum 0} valid?
+  "True when `t` satisfies the closed EffectTransaction schema."
+  [t]
+  (m/validate schema/EffectTransaction t))
+
+(defn- ^{:stratum 0} invalid
+  [message t]
+  (anomaly/sub-anomaly :invalid-input
+                       :anomalies.effect-transaction/invalid
+                       message
+                       {:explain (me/humanize (m/explain schema/EffectTransaction t))}))
+
+(defn- ^{:stratum 0} wrong-state
+  "The record is not in a state this operation applies to — a caller
+   error about lifecycle position, not permission and not a transient
+   fault. `:conflict` is what routes that correctly."
+  [message data]
+  (anomaly/sub-anomaly :conflict
+                       :anomalies.effect-transaction/wrong-state
+                       message
+                       data))
+
+(defn- ^{:stratum 0} unresolved
+  "The external system did not answer, so the record stays as it is.
+   `:unavailable` because this is TRANSIENT and the right response is to
+   ask again later — classifying it as a caller error would send it to
+   handling that never retries."
+  [message data]
+  (anomaly/sub-anomaly :unavailable
+                       :anomalies.effect-transaction/unresolved
+                       message
+                       data))
+
+(defn- ^{:stratum 0} outcome-of
+  "Read an effect-fn's report. Anything this does not recognize is
+   `:unknown-outcome` — an effect fn that answered in a shape we cannot
+   read has told us nothing, and 'nothing' is not 'it failed'."
+  [reported]
+  (let [o (:effect/outcome reported)]
+    (if (contains? #{:succeeded :failed} o) o :unknown-outcome)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Durable state advance
+(defn- ^{:stratum 1} advance!
+  "Apply `changes` to `t`, stamp `:effect/updated-at`, and persist
+   atomically. Returns the new record, or an `:invalid-input` anomaly
+   when the change would produce a record that does not validate — a
+   record we cannot describe is one we cannot reconcile, so it never
+   reaches disk."
+  [dir t changes ^Instant now]
+  (let [t' (assoc (merge t changes) :effect/updated-at now)]
+    (if (valid? t')
+      (do (store/write! dir t') t')
+      (invalid "EffectTransaction change failed validation" t'))))
+
+;; The transaction
+(defn ^{:stratum 1} propose!
+  "Record the intent to perform an irreversible effect, durably, BEFORE
+   anything happens. Returns the `:proposed` record.
+
+   A write failure propagates rather than returning a soft error: if we
+   cannot record that we are about to do something irreversible, the
+   caller must not do it.
+
+   The 1-arity convenience form REQUIRES `:dir`. A nil directory would
+   land records in the process working directory instead of the store —
+   the durability component silently writing the audit trail somewhere
+   nobody looks is the worst failure it could have, so it is refused
+   rather than defaulted."
+  ([{:keys [dir] :as opts}]
+   (if (nil? dir)
+     (anomaly/sub-anomaly :invalid-input
+                          :anomalies.effect-transaction/no-store-dir
+                          "propose! requires :dir — refusing to write records to the process working directory"
+                          {})
+     (propose! dir opts (Instant/now))))
+  ([dir {:keys [effect-class grant-id envelope-id proposal]} ^Instant now]
+   (let [t {:effect/id (random-uuid)
+            :effect/class effect-class
+            :effect/grant-id grant-id
+            :effect/envelope-id envelope-id
+            :effect/proposal (or proposal {})
+            :effect/state :proposed
+            :effect/at now
+            :effect/updated-at now}]
+     (if (valid? t)
+       (do (store/write! dir t) t)
+       (invalid "EffectTransaction inputs failed validation" t)))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} commit!
+  "Re-check the grant, mark the record `:committing`, run `effect-fn`,
+   and record what it reported.
+
+   The re-check is the point (Ariadne 2b Group 4): a grant that was live
+   at decide() and revoked or expired before now fails HERE, and the
+   effect never fires. `effect-fn` is a thunk returning
+   `{:effect/outcome :succeeded|:failed, :effect/observed ...}`.
+
+   Outcome mapping, and the reason for it:
+     returns :succeeded  -> :succeeded
+     returns :failed     -> :failed        (it knows the effect did not happen)
+     THROWS              -> :unknown-outcome
+     anything else       -> :unknown-outcome
+
+   A throw is not a failure. The call may have reached GitHub and come
+   back as a timeout; the record stays honestly unknown until
+   `reconcile!` asks."
+  [dir t grant-record usage ^Instant now effect-fn]
+  (let [auth (grant/authorize grant-record usage now)]
+    (if-not (grant/authorized? auth)
+      (advance! dir t {:effect/state :failed
+                       :effect/failure (str "grant re-check failed at commit: "
+                                            (name (:grant/outcome auth)))}
+                now)
+      (let [committing (advance! dir t {:effect/state :committing} now)]
+        (if (anomaly/anomaly? committing)
+          committing
+          (let [reported (try
+                           {:ok (effect-fn)}
+                           (catch Throwable e
+                             {:threw (or (ex-message e) (str (class e)))}))]
+            (if (contains? reported :threw)
+              (advance! dir committing
+                        {:effect/state :unknown-outcome
+                         :effect/failure (:threw reported)}
+                        now)
+              (let [r (:ok reported)]
+                (advance! dir committing
+                          (cond-> {:effect/state (outcome-of r)}
+                            (contains? r :effect/observed)
+                            (assoc :effect/observed (:effect/observed r))
+                            (:effect/failure r)
+                            (assoc :effect/failure (:effect/failure r)))
+                          now)))))))))
+
+(defn ^{:stratum 2} reconcile!
+  "Settle a record whose true outcome is not known locally by ASKING the
+   external system. `probe-fn` takes the record and returns
+   `{:effect/observed ... :effect/matched? bool}`.
+
+   The answer, not the local guess, becomes `:effect/observed`, and a
+   mismatch is recorded rather than smoothed over.
+
+   A probe that throws or answers in an unreadable shape leaves the
+   record where it is. Marking it `:reconciled` on a failed probe would
+   assert we found out when we did not, and would stop anything from
+   ever asking again.
+
+   An answer that omits `:effect/matched?` records `false`: an
+   unconfirmed match is treated as a mismatch, because an unflagged
+   disagreement is worse than a flagged one."
+  [dir t probe-fn ^Instant now]
+  (if-not (contains? schema/reconcilable-states (:effect/state t))
+    (wrong-state "only :committing or :unknown-outcome records are reconcilable"
+                 {:effect/id (:effect/id t) :effect/state (:effect/state t)})
+    ;; The probe's answer is wrapped rather than probed for a marker key:
+    ;; the probe returns caller-shaped data, so any in-band sentinel is a
+    ;; value it could legitimately carry. The wrapper map is ours.
+    (let [probed (try {:ok (probe-fn t)}
+                      (catch Throwable e {:threw (or (ex-message e) (str (class e)))}))
+          answer (:ok probed)]
+      (if (or (contains? probed :threw)
+              (not (map? answer))
+              (not (contains? answer :effect/observed)))
+        (unresolved "reconciliation probe did not answer; record stays unresolved"
+                    (cond-> {:effect/id (:effect/id t) :effect/state (:effect/state t)}
+                      (contains? probed :threw)
+                      (assoc :probe/error (:threw probed))))
+        (advance! dir t
+                  {:effect/state :reconciled
+                   :effect/observed (:effect/observed answer)
+                   :effect/matched? (boolean (:effect/matched? answer))}
+                  now)))))

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/interface.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/interface.clj
@@ -19,12 +19,12 @@
   "Public API for the effect-transaction component (Ariadne step 2c):
    an irreversible effect as a durable record.
 
-   This half is the RECORD and its store. The propose/commit/reconcile
-   coordinator lands next, and 2d moves merge and deploy onto it."
+   Record, durable store, and the propose/commit/reconcile coordinator.
+   2d moves merge and deploy onto this path."
   (:require
+   [ai.miniforge.effect-transaction.core :as core]
    [ai.miniforge.effect-transaction.schema :as schema]
-   [ai.miniforge.effect-transaction.store :as store]
-   [malli.core :as m]))
+   [ai.miniforge.effect-transaction.store :as store]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -57,7 +57,21 @@
   "Every persisted record under a directory."
   store/list-records)
 
-(defn ^{:stratum 0} valid?
+(def ^{:stratum 0} valid?
   "True when `t` satisfies the closed EffectTransaction schema."
-  [t]
-  (m/validate schema/EffectTransaction t))
+  core/valid?)
+
+(def ^{:stratum 0} propose!
+  "Record the intent durably, BEFORE the effect happens. Refuses a
+   missing store dir rather than writing to the process CWD."
+  core/propose!)
+
+(def ^{:stratum 0} commit!
+  "Re-check the grant, mark :committing, run the effect, record what it
+   reported. A throw is :unknown-outcome, never :failed."
+  core/commit!)
+
+(def ^{:stratum 0} reconcile!
+  "Ask the external system what actually happened and record the answer,
+   mismatch included."
+  core/reconcile!)

--- a/components/effect-transaction/test/ai/miniforge/effect_transaction/commit_test.clj
+++ b/components/effect-transaction/test/ai/miniforge/effect_transaction/commit_test.clj
@@ -1,0 +1,156 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.effect-transaction.commit-test
+  (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.effect-transaction.interface :as fx]
+   [ai.miniforge.execution-grant.interface :as grant]
+   [clojure.test :refer [deftest is testing]])
+  (:import
+   [java.nio.file Files]
+   [java.nio.file.attribute FileAttribute]
+   [java.time Instant]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} now (Instant/parse "2026-08-01T00:00:00Z"))
+
+(def ^{:stratum 0} later (Instant/parse "2026-08-01T01:00:00Z"))
+
+(def ^{:stratum 0} much-later (Instant/parse "2026-08-02T00:00:00Z"))
+
+(defn ^{:stratum 0} tmp-dir
+  "A fresh directory per test — records are files, so tests that shared
+   one would see each other's."
+  []
+  (str (.toFile (Files/createTempDirectory "fx-test" (into-array FileAttribute [])))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} merge-grant
+  ([] (merge-grant {}))
+  ([overrides]
+   (grant/issue (merge {:principal "agent:implementer"
+                        :effect-class :effect/merge
+                        :scope {:repo "miniforge-ai/miniforge" :pr 42}
+                        :constraints {:constraint/max-count 5}
+                        :delegable? false
+                        :expires-at later}
+                       overrides)
+                now)))
+
+(defn ^{:stratum 1} propose-merge!
+  [dir g]
+  (fx/propose! dir
+               {:effect-class :effect/merge
+                :grant-id (:grant/id g)
+                :envelope-id (random-uuid)
+                :proposal {:pr/repo "miniforge-ai/miniforge" :pr/number 42}}
+               now))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} interrupted-effect-is-unknown-not-failed-test
+  ;; The state that earns this component its keep. Claiming failure for
+  ;; a merge that actually landed is as wrong as claiming success.
+  (let [dir (tmp-dir)
+        g (merge-grant)
+        t (propose-merge! dir g)
+        committed (fx/commit! dir t g {} now
+                              (fn [] (throw (ex-info "connection reset" {}))))]
+    (is (= :unknown-outcome (:effect/state committed)))
+    (is (not= :failed (:effect/state committed))
+        "a throw means we do not know, not that it did not happen")
+    (is (= "connection reset" (:effect/failure committed)))
+    (testing "and the unknown state is durable, so a restart can find it"
+      (is (= :unknown-outcome (:effect/state (fx/read-record dir (:effect/id t))))))))
+
+(deftest ^{:stratum 2} definite-outcomes-are-recorded-as-such-test
+  (let [dir (tmp-dir)
+        g (merge-grant)]
+    (testing "a definite success is :succeeded and carries the observation"
+      (let [t (propose-merge! dir g)
+            done (fx/commit! dir t g {} now
+                             (fn [] {:effect/outcome :succeeded
+                                     :effect/observed {:merge/sha "abc123"}}))]
+        (is (= :succeeded (:effect/state done)))
+        (is (= {:merge/sha "abc123"} (:effect/observed done)))))
+
+    (testing "a definite failure is :failed — the effect fn knows it did not happen"
+      (let [t (propose-merge! dir g)
+            done (fx/commit! dir t g {} now
+                             (fn [] {:effect/outcome :failed
+                                     :effect/failure "PR already closed"}))]
+        (is (= :failed (:effect/state done)))
+        (is (= "PR already closed" (:effect/failure done)))))
+
+    (testing "an unreadable report is unknown, not success"
+      (let [t (propose-merge! dir g)
+            done (fx/commit! dir t g {} now (fn [] {:whatever true}))]
+        (is (= :unknown-outcome (:effect/state done))
+            "an effect fn that answered in a shape we cannot read told us nothing")))
+
+    (testing "a nil report is unknown, not success"
+      (let [t (propose-merge! dir g)
+            done (fx/commit! dir t g {} now (constantly nil))]
+        (is (= :unknown-outcome (:effect/state done)))))))
+
+(deftest ^{:stratum 2} commit-rechecks-the-grant-test
+  ;; Ariadne 2b Group 4: a constraint checked only at decide() is a check
+  ;; against stale state.
+  (testing "a grant revoked after the proposal fails the commit, and the effect never fires"
+    (let [dir (tmp-dir)
+          g (merge-grant)
+          t (propose-merge! dir g)
+          revoked (grant/revoke g :breach/cost-exceeded now)
+          fired (atom false)
+          done (fx/commit! dir t revoked {} now
+                           (fn [] (reset! fired true) {:effect/outcome :succeeded}))]
+      (is (= :failed (:effect/state done)))
+      (is (not @fired) "the effect MUST NOT fire when the re-check refuses")
+      (is (re-find #"inactive" (:effect/failure done)))))
+
+  (testing "a grant that expired between propose and commit fails the commit"
+    (let [dir (tmp-dir)
+          g (merge-grant)
+          t (propose-merge! dir g)
+          fired (atom false)
+          done (fx/commit! dir t g {} much-later
+                           (fn [] (reset! fired true) {:effect/outcome :succeeded}))]
+      (is (= :failed (:effect/state done)))
+      (is (not @fired))))
+
+  (testing "a breached ceiling fails the commit"
+    (let [dir (tmp-dir)
+          g (merge-grant)
+          t (propose-merge! dir g)
+          fired (atom false)
+          done (fx/commit! dir t g {:usage/count 99} now
+                           (fn [] (reset! fired true) {:effect/outcome :succeeded}))]
+      (is (= :failed (:effect/state done)))
+      (is (not @fired))))
+
+  (testing "no grant at all fails the commit"
+    (let [dir (tmp-dir)
+          g (merge-grant)
+          t (propose-merge! dir g)
+          fired (atom false)
+          done (fx/commit! dir t nil {} now
+                           (fn [] (reset! fired true) {:effect/outcome :succeeded}))]
+      (is (= :failed (:effect/state done)))
+      (is (not @fired)))))

--- a/components/effect-transaction/test/ai/miniforge/effect_transaction/commit_test.clj
+++ b/components/effect-transaction/test/ai/miniforge/effect_transaction/commit_test.clj
@@ -154,3 +154,23 @@
                            (fn [] (reset! fired true) {:effect/outcome :succeeded}))]
       (is (= :failed (:effect/state done)))
       (is (not @fired)))))
+
+(deftest ^{:stratum 2} only-a-proposed-record-may-be-committed-test
+  ;; The accident this component exists to prevent: committing a record
+  ;; that has already moved on re-runs an irreversible effect. A second
+  ;; merge. A second deploy.
+  (let [dir (tmp-dir)
+        g (merge-grant)]
+    (doseq [state [:committing :succeeded :failed :unknown-outcome :reconciled]]
+      (let [t (assoc (propose-merge! dir g) :effect/state state)
+            fired (atom false)
+            result (fx/commit! dir t g {} now
+                               (fn [] (reset! fired true) {:effect/outcome :succeeded}))]
+        (is (anomaly/anomaly? result) (str "commit from " state " must refuse"))
+        (is (= :conflict (:anomaly/type result)) (str state))
+        (is (not @fired)
+            (str "the effect MUST NOT re-fire from " state))))
+    (testing "a :proposed record still commits normally"
+      (let [t (propose-merge! dir g)
+            done (fx/commit! dir t g {} now (fn [] {:effect/outcome :succeeded}))]
+        (is (= :succeeded (:effect/state done)))))))

--- a/components/effect-transaction/test/ai/miniforge/effect_transaction/commit_test.clj
+++ b/components/effect-transaction/test/ai/miniforge/effect_transaction/commit_test.clj
@@ -145,15 +145,21 @@
       (is (= :failed (:effect/state done)))
       (is (not @fired))))
 
-  (testing "no grant at all fails the commit"
+  (testing "no grant at all is refused as a mismatch, and the record is untouched"
+    ;; Distinct from a revoked-or-expired grant above: passing nil when
+    ;; the record NAMES a grant is a caller supplying the wrong argument,
+    ;; not the authority lapsing. Marking the record :failed for that
+    ;; would blame the transaction for the caller's mistake.
     (let [dir (tmp-dir)
           g (merge-grant)
           t (propose-merge! dir g)
           fired (atom false)
-          done (fx/commit! dir t nil {} now
-                           (fn [] (reset! fired true) {:effect/outcome :succeeded}))]
-      (is (= :failed (:effect/state done)))
-      (is (not @fired)))))
+          result (fx/commit! dir t nil {} now
+                             (fn [] (reset! fired true) {:effect/outcome :succeeded}))]
+      (is (anomaly/anomaly? result))
+      (is (not @fired))
+      (is (= :proposed (:effect/state (fx/read-record dir (:effect/id t))))
+          "the durable record is left as it was"))))
 
 (deftest ^{:stratum 2} only-a-proposed-record-may-be-committed-test
   ;; The accident this component exists to prevent: committing a record
@@ -173,4 +179,40 @@
     (testing "a :proposed record still commits normally"
       (let [t (propose-merge! dir g)
             done (fx/commit! dir t g {} now (fn [] {:effect/outcome :succeeded}))]
+        (is (= :succeeded (:effect/state done)))))))
+
+(deftest ^{:stratum 2} commit-must-use-the-grant-the-proposal-named-test
+  ;; The re-check is only worth anything if it re-checks the SAME grant.
+  ;; Otherwise: propose under a narrow grant, commit under a broad one,
+  ;; and the durable record attests to authority that was never used.
+  (let [dir (tmp-dir)
+        recorded (merge-grant)
+        t (propose-merge! dir recorded)]
+
+    (testing "a different grant is refused, even a valid and broader one"
+      (let [other (merge-grant {:constraints {}})
+            fired (atom false)
+            result (fx/commit! dir t other {} now
+                               (fn [] (reset! fired true) {:effect/outcome :succeeded}))]
+        (is (anomaly/anomaly? result))
+        (is (= :conflict (:anomaly/type result)))
+        (is (not @fired) "substituting a broader grant must not fire the effect")))
+
+    (testing "a grant for a different effect class is refused"
+      (let [deploy-grant (grant/issue {:principal "agent:implementer"
+                                       :effect-class :effect/deploy
+                                       :scope {}
+                                       :constraints {}
+                                       :delegable? false
+                                       :expires-at later}
+                                      now)
+            mismatched (assoc t :effect/grant-id (:grant/id deploy-grant))
+            fired (atom false)
+            result (fx/commit! dir mismatched deploy-grant {} now
+                               (fn [] (reset! fired true) {:effect/outcome :succeeded}))]
+        (is (anomaly/anomaly? result))
+        (is (not @fired) "a merge proposal must not be authorized by a deploy grant")))
+
+    (testing "the recorded grant still commits"
+      (let [done (fx/commit! dir t recorded {} now (fn [] {:effect/outcome :succeeded}))]
         (is (= :succeeded (:effect/state done)))))))

--- a/components/effect-transaction/test/ai/miniforge/effect_transaction/reconcile_test.clj
+++ b/components/effect-transaction/test/ai/miniforge/effect_transaction/reconcile_test.clj
@@ -1,0 +1,173 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.effect-transaction.reconcile-test
+  (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.effect-transaction.interface :as fx]
+   [ai.miniforge.execution-grant.interface :as grant]
+   [clojure.test :refer [deftest is testing]])
+  (:import
+   [java.nio.file Files]
+   [java.nio.file.attribute FileAttribute]
+   [java.time Instant]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} now (Instant/parse "2026-08-01T00:00:00Z"))
+
+(def ^{:stratum 0} later (Instant/parse "2026-08-01T01:00:00Z"))
+
+(def ^{:stratum 0} much-later (Instant/parse "2026-08-02T00:00:00Z"))
+
+(defn ^{:stratum 0} tmp-dir
+  "A fresh directory per test — records are files, so tests that shared
+   one would see each other's."
+  []
+  (str (.toFile (Files/createTempDirectory "fx-test" (into-array FileAttribute [])))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} merge-grant
+  ([] (merge-grant {}))
+  ([overrides]
+   (grant/issue (merge {:principal "agent:implementer"
+                        :effect-class :effect/merge
+                        :scope {:repo "miniforge-ai/miniforge" :pr 42}
+                        :constraints {:constraint/max-count 5}
+                        :delegable? false
+                        :expires-at later}
+                       overrides)
+                now)))
+
+(defn ^{:stratum 1} propose-merge!
+  [dir g]
+  (fx/propose! dir
+               {:effect-class :effect/merge
+                :grant-id (:grant/id g)
+                :envelope-id (random-uuid)
+                :proposal {:pr/repo "miniforge-ai/miniforge" :pr/number 42}}
+               now))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} reconcile-reads-the-world-not-the-log-test
+  (let [dir (tmp-dir)
+        g (merge-grant)]
+    (testing "the observation comes from the probe, and a match is recorded"
+      (let [t (propose-merge! dir g)
+            unknown (fx/commit! dir t g {} now (fn [] (throw (ex-info "boom" {}))))
+            settled (fx/reconcile! dir unknown
+                                   (fn [_] {:effect/observed {:pr/state "MERGED"
+                                                              :merge/sha "real-sha"}
+                                            :effect/matched? true})
+                                   later)]
+        (is (= :reconciled (:effect/state settled)))
+        (is (= "real-sha" (get-in settled [:effect/observed :merge/sha])))
+        (is (true? (:effect/matched? settled)))))
+
+    (testing "a MISMATCH is recorded, not smoothed over"
+      (let [t (propose-merge! dir g)
+            unknown (fx/commit! dir t g {} now (fn [] (throw (ex-info "boom" {}))))
+            settled (fx/reconcile! dir unknown
+                                   (fn [_] {:effect/observed {:pr/state "CLOSED"}
+                                            :effect/matched? false})
+                                   later)]
+        (is (= :reconciled (:effect/state settled)))
+        (is (false? (:effect/matched? settled))
+            "finding out includes finding out you were wrong")))
+
+    (testing "a probe that throws leaves the record unresolved for a later attempt"
+      (let [t (propose-merge! dir g)
+            unknown (fx/commit! dir t g {} now (fn [] (throw (ex-info "boom" {}))))
+            result (fx/reconcile! dir unknown (fn [_] (throw (ex-info "network" {}))) later)]
+        (is (anomaly/anomaly? result))
+        (is (= :unknown-outcome (:effect/state (fx/read-record dir (:effect/id t))))
+            "marking :reconciled here would assert we found out when we did not")))
+
+    (testing "a probe answering in an unreadable shape also leaves it unresolved"
+      (let [t (propose-merge! dir g)
+            unknown (fx/commit! dir t g {} now (fn [] (throw (ex-info "boom" {}))))
+            result (fx/reconcile! dir unknown (constantly {:something :else}) later)]
+        (is (anomaly/anomaly? result))
+        (is (= :unknown-outcome (:effect/state (fx/read-record dir (:effect/id t)))))))
+
+    (testing "a probe answer carrying the internal marker key is still honoured"
+      ;; The probe returns caller-shaped data, so any in-band sentinel is
+      ;; a value it could legitimately carry. Wrapping the answer instead
+      ;; of probing it for a marker is what keeps that from colliding.
+      (let [t (propose-merge! dir g)
+            unknown (fx/commit! dir t g {} now (fn [] (throw (ex-info "boom" {}))))
+            settled (fx/reconcile! dir unknown
+                                   (constantly {:effect/observed {:threw "not an error"}
+                                                :threw "nor is this"
+                                                :effect/matched? true})
+                                   later)]
+        (is (= :reconciled (:effect/state settled)))
+        (is (true? (:effect/matched? settled)))))
+
+    (testing "an answer with no :effect/matched? records a mismatch, not a match"
+      (let [t (propose-merge! dir g)
+            unknown (fx/commit! dir t g {} now (fn [] (throw (ex-info "boom" {}))))
+            settled (fx/reconcile! dir unknown
+                                   (constantly {:effect/observed {:pr/state "MERGED"}})
+                                   later)]
+        (is (= :reconciled (:effect/state settled)))
+        (is (false? (:effect/matched? settled))
+            "an unflagged disagreement is worse than a flagged one")))
+
+    (testing "an already-settled record is not reconcilable"
+      (let [t (propose-merge! dir g)
+            done (fx/commit! dir t g {} now (fn [] {:effect/outcome :succeeded}))]
+        (is (anomaly/anomaly?
+             (fx/reconcile! dir done (constantly {:effect/observed :x}) later)))))))
+
+(deftest ^{:stratum 2} committing-is-reconcilable-after-a-restart-test
+  ;; A process that died mid-effect leaves the record at :committing.
+  ;; That is not failure and not success — it is exactly the case
+  ;; reconciliation exists for.
+  (let [dir (tmp-dir)
+        g (merge-grant)
+        t (propose-merge! dir g)
+        ;; simulate the crash: the record reached :committing and nothing
+        ;; ever wrote an outcome
+        crashed (assoc t :effect/state :committing)
+        settled (fx/reconcile! dir crashed
+                               (fn [_] {:effect/observed {:pr/state "OPEN"}
+                                        :effect/matched? false})
+                               later)]
+    (is (contains? fx/reconcilable-states :committing))
+    (is (= :reconciled (:effect/state settled)))
+    (is (false? (:effect/matched? settled)))))
+
+(deftest ^{:stratum 2} refusal-anomalies-route-correctly-test
+  ;; :unauthorized would say "you lack permission", which is neither
+  ;; true nor useful here. A wrong lifecycle position is a :conflict; a
+  ;; probe that did not answer is :unavailable — transient, ask again.
+  (let [dir (tmp-dir)
+        g (merge-grant)
+        settled (fx/commit! dir (propose-merge! dir g) g {} now
+                            (fn [] {:effect/outcome :succeeded}))
+        unknown (fx/commit! dir (propose-merge! dir g) g {} now
+                            (fn [] (throw (ex-info "boom" {}))))]
+    (testing "reconciling a settled record is a :conflict, not a permission error"
+      (is (= :conflict (:anomaly/type
+                        (fx/reconcile! dir settled (constantly {:effect/observed :x}) later)))))
+    (testing "a probe that did not answer is :unavailable, and carries the cause"
+      (let [a (fx/reconcile! dir unknown (fn [_] (throw (ex-info "network down" {}))) later)]
+        (is (= :unavailable (:anomaly/type a)))
+        (is (= "network down" (get-in a [:anomaly/data :probe/error])))))))

--- a/components/effect-transaction/test/ai/miniforge/effect_transaction/reconcile_test.clj
+++ b/components/effect-transaction/test/ai/miniforge/effect_transaction/reconcile_test.clj
@@ -32,8 +32,6 @@
 
 (def ^{:stratum 0} later (Instant/parse "2026-08-01T01:00:00Z"))
 
-(def ^{:stratum 0} much-later (Instant/parse "2026-08-02T00:00:00Z"))
-
 (defn ^{:stratum 0} tmp-dir
   "A fresh directory per test — records are files, so tests that shared
    one would see each other's."


### PR DESCRIPTION
Second half of `work/ariadne-effect-transaction.spec.edn`, on top of #1592. The record and store landed there; this is the coordinator.

## The judgment the component exists for

An effect that **threw** is `:unknown-outcome`, not `:failed`. A timeout talking to GitHub may well have merged the PR. Recording failure for an effect that landed is exactly as wrong as recording success for one that didn't, and both are worse than admitting we don't yet know.

| effect fn | state |
|---|---|
| returns `:succeeded` | `:succeeded` |
| returns `:failed` | `:failed` — it knows it did not happen |
| **throws** | **`:unknown-outcome`** |
| anything else | `:unknown-outcome` — an answer we can't read told us nothing |

`:committing` is reconcilable for the same reason: that's where a process that died mid-effect leaves the record.

## Generalizing, not inventing

The operator intervention path already does this: `operator_requests.clj` lands requests atomically and refuses to report success for a gesture that didn't reach disk; `operator/application.clj` advances to `:dispatched` **before** firing, then verifies an `{:observed :expected}` readback. This applies that discipline to merge, deploy, and spend — which is why the RFC's step-2 line about transacting Phase D turned out smaller than written.

## Fail-closed

- `commit!` re-checks the grant first (2b Group 4). Revoked, expired, ceiling-breached, and absent grants each fail the commit, and the tests assert the effect **never fires**.
- A probe that throws or answers unreadably leaves the record unresolved. Marking it `:reconciled` would assert we found out when we didn't, and stop anything ever asking again.
- The probe's answer is **wrapped** rather than searched for a marker key — it returns caller-shaped data, so any in-band sentinel is a value it could legitimately carry. Tested with a probe answer deliberately carrying the internal key.
- An answer omitting `:effect/matched?` records `false`: an unflagged disagreement is worse than a flagged one.

## Carries both fixes from the first review round (#1586)

- `propose!` refuses a missing store dir rather than writing the audit trail into the process CWD. For a durability component, putting the evidence somewhere nobody looks is the worst failure it has.
- Refusals are `:conflict` (wrong lifecycle position) or `:unavailable` (probe didn't answer, retry) rather than a blanket `:unauthorized`. That one matters: `:unauthorized` would route a transient probe failure to handling that never retries, stranding records permanently unresolved.

## Scope

Coordinator only. 2d moves merge and deploy onto this path, which is where `merge-pr!` stops reporting `{:merged? true}` for what is actually just auto-merge being enabled.

## Verification

12 tests / 62 assertions across three namespaces. Coordinator tests split into `commit_test` and `reconcile_test` — the combined file was one line over the 200-line commit budget, and splitting by concern beats trimming to satisfy a counter.

`bb poly:check` 0 errors; `bb lint:clj` 0/0; `bb lint:stratum` clean at ≤3 layers; stable-derived `bb test` plan green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)