### PR TITLE
fix(control-plane): make start-runs-discovery-test deterministic

### DIFF
--- a/components/control-plane/test/ai/miniforge/control_plane/async_test_support.clj
+++ b/components/control-plane/test/ai/miniforge/control_plane/async_test_support.clj
@@ -1,0 +1,79 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.control-plane.async-test-support
+  "Wait helpers shared by the orchestrator test namespaces.
+
+   The orchestrator runs discovery, polling, and the heartbeat watchdog on
+   background futures, so tests observe their effects from another thread.
+   These helpers block on the effect itself rather than sleeping for a
+   guessed interval, so a loaded CI runner makes them slower, not wrong."
+  (:import
+   (java.util.concurrent.locks LockSupport)))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} default-wait-timeout-ms
+  "Upper bound on any wait below. A deadlock guard, not a timing assumption:
+   the helpers return as soon as their condition holds."
+  2000)
+
+(def ^{:stratum 0} ^:private poll-park-nanos
+  "How long `wait-until` parks between polls (1ms)."
+  1000000)
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} wait-until-count
+  "Block until `(count @items-atom) >= n` or `timeout-ms` elapses.
+   Returns true if reached, false on timeout.
+
+   The watch is installed BEFORE the current value is read. The reverse
+   order drops a wakeup: an update landing between the read and the
+   add-watch is seen by neither, so the wait times out with the condition
+   already satisfied. `deliver` on a settled promise is a no-op, so the
+   two paths racing each other is harmless."
+  ([items-atom n] (wait-until-count items-atom n default-wait-timeout-ms))
+  ([items-atom n timeout-ms]
+   (let [done (promise)
+         k    (gensym "wait-count-")]
+     (add-watch items-atom k
+                (fn [_ _ _ new-val]
+                  (when (>= (count new-val) n)
+                    (deliver done :reached))))
+     (when (>= (count @items-atom) n)
+       (deliver done :immediate))
+     (let [result (deref done timeout-ms ::timeout)]
+       (remove-watch items-atom k)
+       (not= result ::timeout)))))
+
+(defn ^{:stratum 1} wait-until
+  "Block until `(pred)` returns truthy or `timeout-ms` elapses.
+   Returns true if pred satisfied, false on timeout.
+
+   Polls, so it carries the cost of a stale read for up to one park. Prefer
+   `wait-until-count`, or a promise the code under test delivers to, when
+   the condition is reachable as a watched value."
+  ([pred] (wait-until pred default-wait-timeout-ms))
+  ([pred timeout-ms]
+   (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
+     (loop []
+       (cond
+         (pred) true
+         (> (System/currentTimeMillis) deadline) false
+         :else (do (LockSupport/parkNanos poll-park-nanos)
+                   (recur)))))))

--- a/components/control-plane/test/ai/miniforge/control_plane/async_test_support.clj
+++ b/components/control-plane/test/ai/miniforge/control_plane/async_test_support.clj
@@ -32,9 +32,13 @@
    the helpers return as soon as their condition holds."
   2000)
 
-(def ^{:stratum 0} ^:private poll-park-nanos
-  "How long `wait-until` parks between polls (1ms)."
+(def ^{:stratum 0} ^:private nanos-per-ms
+  "Nanoseconds in a millisecond."
   1000000)
+
+(def ^{:stratum 0} ^:private poll-park-ms
+  "How long `wait-until` parks between polls."
+  1)
 
 ;------------------------------------------------------------------------------ Layer 1
 
@@ -67,13 +71,19 @@
 
    Polls, so it carries the cost of a stale read for up to one park. Prefer
    `wait-until-count`, or a promise the code under test delivers to, when
-   the condition is reachable as a watched value."
+   the condition is reachable as a watched value.
+
+   Deadline is on `nanoTime`, not `currentTimeMillis`: the wall clock can
+   step (NTP, a suspend/resume) and cut the wait short, which is the class
+   of failure this namespace exists to remove."
   ([pred] (wait-until pred default-wait-timeout-ms))
   ([pred timeout-ms]
-   (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
+   (let [deadline (+ (System/nanoTime) (* timeout-ms nanos-per-ms))]
      (loop []
        (cond
          (pred) true
-         (> (System/currentTimeMillis) deadline) false
-         :else (do (LockSupport/parkNanos poll-park-nanos)
+         ;; Subtract rather than compare: nanoTime's origin is arbitrary and
+         ;; the difference stays correct if the counter wraps.
+         (neg? (- deadline (System/nanoTime))) false
+         :else (do (LockSupport/parkNanos (* poll-park-ms nanos-per-ms))
                    (recur)))))))

--- a/components/control-plane/test/ai/miniforge/control_plane/orchestrator_edge_test.clj
+++ b/components/control-plane/test/ai/miniforge/control_plane/orchestrator_edge_test.clj
@@ -10,12 +10,11 @@
    [ai.miniforge.control-plane.orchestrator :as sut]
    [ai.miniforge.control-plane.registry :as registry]
    [ai.miniforge.control-plane.decision-queue :as dq]
+   [ai.miniforge.control-plane.async-test-support :as support]
    [ai.miniforge.control-plane-adapter.protocol :as adapter]
    [ai.miniforge.event-stream.interface.stream :as stream]))
 
 ;------------------------------------------------------------------------------ Layer 0
-
-(def ^{:stratum 0} ^:private default-wait-timeout-ms 2000)
 
 ;; ---------------------------------------------------------------------------
 ;; Test helpers
@@ -75,23 +74,6 @@
       (is (nil? (:event-stream orch))))))
 
 ;------------------------------------------------------------------------------ Layer 1
-
-(defn- ^{:stratum 1} wait-until-count
-  "Block until `(count @items-atom) >= n` or `timeout-ms` elapses.
-   Uses add-watch + promise — no fixed sleep. Returns true if reached, false on timeout."
-  ([items-atom n] (wait-until-count items-atom n default-wait-timeout-ms))
-  ([items-atom n timeout-ms]
-   (let [done (promise)
-         k    (gensym "wait-count-")]
-     (when (>= (count @items-atom) n)
-       (deliver done :immediate))
-     (add-watch items-atom k
-                (fn [_ _ _ new-val]
-                  (when (>= (count new-val) n)
-                    (deliver done :reached))))
-     (let [result (deref done timeout-ms ::timeout)]
-       (remove-watch items-atom k)
-       (not= result ::timeout)))))
 
 ;; ---------------------------------------------------------------------------
 ;; resolve-and-deliver!: no matching adapter for agent's vendor
@@ -427,12 +409,10 @@
       (is (contains? stopped :registry))
       (is (false? @(:running stopped))))))
 
-;------------------------------------------------------------------------------ Layer 2
-
 ;; ---------------------------------------------------------------------------
 ;; resolve-and-deliver!: emits decision-resolved event
 ;; ---------------------------------------------------------------------------
-(deftest ^{:stratum 2} resolve-and-deliver-emits-decision-resolved-event-test
+(deftest ^{:stratum 1} resolve-and-deliver-emits-decision-resolved-event-test
   (testing "resolve-and-deliver! emits :control-plane/decision-resolved event"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -453,17 +433,17 @@
           decision (sut/submit-decision-from-agent!
                     orch (:agent/id agent-rec) "Resolve event test")
           ;; Wait for submit-emitted events, then clear before resolve.
-          _ (wait-until-count published 1)
+          _ (support/wait-until-count published 1)
           _ (reset! published [])
           _ (sut/resolve-and-deliver!
              orch (:decision/id decision) "approved")]
-      (is (wait-until-count published 1)
+      (is (support/wait-until-count published 1)
           "should have published decision-resolved event"))))
 
 ;; ---------------------------------------------------------------------------
 ;; Poll pass: uses :status key from status-update (not :agent/status)
 ;; ---------------------------------------------------------------------------
-(deftest ^{:stratum 2} run-poll-pass-uses-status-key-test
+(deftest ^{:stratum 1} run-poll-pass-uses-status-key-test
   (testing "poll pass extracts new-status from :status key in status-update"
     (let [reg (registry/create-registry)
           es (stream/create-event-stream {:sinks []})
@@ -485,5 +465,5 @@
       (#'sut/run-poll-pass orch)
       ;; Agent was :initializing, poll returned :status :running
       ;; This should trigger a state-changed event
-      (is (wait-until-count published 1)
+      (is (support/wait-until-count published 1)
           "should emit state-changed when :status key differs from current"))))

--- a/components/control-plane/test/ai/miniforge/control_plane/orchestrator_supplemental_test.clj
+++ b/components/control-plane/test/ai/miniforge/control_plane/orchestrator_supplemental_test.clj
@@ -10,12 +10,11 @@
    [ai.miniforge.control-plane.orchestrator :as sut]
    [ai.miniforge.control-plane.registry :as registry]
    [ai.miniforge.control-plane.decision-queue :as dq]
+   [ai.miniforge.control-plane.async-test-support :as support]
    [ai.miniforge.control-plane-adapter.protocol :as adapter]
    [ai.miniforge.event-stream.interface.stream :as stream]))
 
 ;------------------------------------------------------------------------------ Layer 0
-
-(def ^{:stratum 0} ^:private default-wait-timeout-ms 2000)
 
 ;; ---------------------------------------------------------------------------
 ;; Test helpers
@@ -77,23 +76,6 @@
       (is (= 0 (:poll-interval-ms orch))))))
 
 ;------------------------------------------------------------------------------ Layer 1
-
-(defn- ^{:stratum 1} wait-until-count
-  "Block until `(count @items-atom) >= n` or `timeout-ms` elapses.
-   Uses add-watch + promise — no fixed sleep. Returns true if reached, false on timeout."
-  ([items-atom n] (wait-until-count items-atom n default-wait-timeout-ms))
-  ([items-atom n timeout-ms]
-   (let [done (promise)
-         k    (gensym "wait-count-")]
-     (when (>= (count @items-atom) n)
-       (deliver done :immediate))
-     (add-watch items-atom k
-                (fn [_ _ _ new-val]
-                  (when (>= (count new-val) n)
-                    (deliver done :reached))))
-     (let [result (deref done timeout-ms ::timeout)]
-       (remove-watch items-atom k)
-       (not= result ::timeout)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Discovery: adapter returns nil instead of empty seq
@@ -560,12 +542,10 @@
       (sut/resolve-and-deliver! orch (:decision/id d2) "no")
       (is (= :running (:agent/status (registry/get-agent reg (:agent/id a2))))))))
 
-;------------------------------------------------------------------------------ Layer 2
-
 ;; ---------------------------------------------------------------------------
 ;; Poll: status changes emit correct old/new values
 ;; ---------------------------------------------------------------------------
-(deftest ^{:stratum 2} run-poll-pass-status-change-event-values-test
+(deftest ^{:stratum 1} run-poll-pass-status-change-event-values-test
   (testing "poll emits state-changed with correct old and new status values"
     (let [reg (registry/create-registry)
           es (stream/create-event-stream {:sinks []})
@@ -585,13 +565,13 @@
                             :event-stream es}))]
       (#'sut/run-poll-pass orch)
       ;; Verify at least one event was published with state change
-      (is (wait-until-count published 1)
+      (is (support/wait-until-count published 1)
           "should emit event for status change"))))
 
 ;; ---------------------------------------------------------------------------
 ;; submit-decision-from-agent!: with event stream, event has correct fields
 ;; ---------------------------------------------------------------------------
-(deftest ^{:stratum 2} submit-decision-event-fields-test
+(deftest ^{:stratum 1} submit-decision-event-fields-test
   (testing "decision-created event contains agent-id and summary"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -608,7 +588,7 @@
                             :event-stream es}))
           decision (sut/submit-decision-from-agent!
                     orch (:agent/id agent-rec) "Event field test")]
-      (is (wait-until-count published 1)
+      (is (support/wait-until-count published 1)
           "should have published decision-created event")
       ;; Verify the returned decision is well-formed
       (is (= (:agent/id agent-rec) (:decision/agent-id decision))))))

--- a/components/control-plane/test/ai/miniforge/control_plane/orchestrator_test.clj
+++ b/components/control-plane/test/ai/miniforge/control_plane/orchestrator_test.clj
@@ -7,6 +7,7 @@
    [ai.miniforge.control-plane.orchestrator :as sut]
    [ai.miniforge.control-plane.registry :as registry]
    [ai.miniforge.control-plane.decision-queue :as dq]
+   [ai.miniforge.control-plane.async-test-support :as support]
    [ai.miniforge.control-plane-adapter.protocol :as adapter]
    [ai.miniforge.event-stream.interface.stream :as stream]))
 
@@ -46,8 +47,6 @@
   (let [events-atom (atom [])]
     {:stream (stream/create-event-stream {:sinks []})
      :published events-atom}))
-
-(def ^{:stratum 0} ^:private default-wait-timeout-ms 2000)
 
 (def ^{:stratum 0} test-workflow-id (java.util.UUID/fromString "00000000-0000-0000-0000-000000000001"))
 
@@ -127,36 +126,6 @@
       (is (instance? clojure.lang.Atom (:futures orch))))))
 
 ;------------------------------------------------------------------------------ Layer 1
-
-(defn- ^{:stratum 1} wait-until-count
-  "Block until `(count @items-atom) >= n` or `timeout-ms` elapses.
-   Uses add-watch + promise — no fixed sleep. Returns true if reached, false on timeout."
-  ([items-atom n] (wait-until-count items-atom n default-wait-timeout-ms))
-  ([items-atom n timeout-ms]
-   (let [done (promise)
-         k    (gensym "wait-count-")]
-     (when (>= (count @items-atom) n)
-       (deliver done :immediate))
-     (add-watch items-atom k
-                (fn [_ _ _ new-val]
-                  (when (>= (count new-val) n)
-                    (deliver done :reached))))
-     (let [result (deref done timeout-ms ::timeout)]
-       (remove-watch items-atom k)
-       (not= result ::timeout)))))
-
-(defn- ^{:stratum 1} wait-until
-  "Block until `(pred)` returns truthy or `timeout-ms` elapses.
-   Returns true if pred satisfied, false on timeout."
-  ([pred] (wait-until pred default-wait-timeout-ms))
-  ([pred timeout-ms]
-   (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
-     (loop []
-       (cond
-         (pred) true
-         (> (System/currentTimeMillis) deadline) false
-         :else (do (java.util.concurrent.locks.LockSupport/parkNanos 1000000)
-                   (recur)))))))
 
 (defn ^{:stratum 1} base-orchestrator-opts
   "Minimal valid opts for creating an orchestrator."
@@ -309,7 +278,7 @@
                   :adapters [adapter]
                   :event-stream es}))]
       (#'sut/run-discovery-pass orch)
-      (is (wait-until-count published 1)
+      (is (support/wait-until-count published 1)
           "should have published at least one event"))))
 
 (deftest ^{:stratum 2} run-discovery-pass-empty-results-test
@@ -498,7 +467,7 @@
                   :event-stream es}))]
       (#'sut/run-poll-pass orch)
       ;; Should have emitted a state-changed event since status went from :initializing to :running
-      (is (wait-until-count published 1)
+      (is (support/wait-until-count published 1)
           "should have published at least one state-changed event"))))
 
 (deftest ^{:stratum 2} run-poll-pass-no-event-when-status-unchanged-test
@@ -521,7 +490,7 @@
                   :adapters [adapter]
                   :event-stream es}))]
       (#'sut/run-poll-pass orch)
-      (wait-until-count published 1)
+      (support/wait-until-count published 1)
       (let [event-types (map :event/type @published)]
         (is (= [:control-plane/agent-heartbeat] event-types)
             "stable polls should publish heartbeat context but not a state change")))))
@@ -593,6 +562,13 @@
   (testing "start! triggers discovery loop that finds agents"
     (let [reg (registry/create-registry)
           discovered (atom [])
+          ;; The discovery pass itself delivers this: no interval, no poll,
+          ;; no watch to install too late. `start!` runs the first discovery
+          ;; pass before the loop's first sleep, so the configured intervals
+          ;; only decide when a redundant SECOND pass would run — they never
+          ;; decide whether this test passes. The timeout below is a deadlock
+          ;; guard, not a bet on how fast a loaded CI runner schedules.
+          first-discovery (promise)
           agent-info {:agent/external-id "ext-loop"
                       :agent/name "Loop Agent"
                       :agent/vendor :test-adapter}
@@ -602,23 +578,23 @@
                 (base-orchestrator-opts
                  {:registry reg
                   :adapters [adapter]
-                  :on-agent-discovered #(swap! discovered conj %)
-                  :discovery-interval-ms 50
-                  :poll-interval-ms 50}))]
-      (sut/start! orch)
-      ;; Wait for the on-agent-discovered callback to fire — not just for
-      ;; registry registration. run-discovery-pass calls register-agent!
-      ;; immediately before on-agent-discovered, so waiting on the registry
-      ;; count can observe the agent in the window before the callback runs
-      ;; and then race stop!, leaving `discovered` empty. Waiting on the
-      ;; callback's own effect makes both assertions deterministic.
-      (is (wait-until-count discovered 1)
-          "discovery callback should fire before the wait times out")
-      (sut/stop! orch)
+                  :on-agent-discovered (fn [agent-record]
+                                         (swap! discovered conj agent-record)
+                                         (deliver first-discovery agent-record))}))
+          started (sut/start! orch)
+          ;; deref establishes happens-before with everything the discovery
+          ;; thread did up to the deliver — the register-agent! and the swap!
+          ;; — so the assertions after stop! read settled state.
+          delivered (deref first-discovery support/default-wait-timeout-ms nil)]
+      (sut/stop! started)
+      (is (some? delivered)
+          "on-agent-discovered should fire on the discovery loop's first pass")
+      (is (= "ext-loop" (:agent/external-id delivered))
+          "callback should receive the agent the adapter discovered")
       (is (pos? (registry/count-agents reg))
           "discovery loop should have registered agents")
-      (is (pos? (count @discovered))
-          "on-agent-discovered should have been called"))))
+      (is (= ["ext-loop"] (mapv :agent/external-id @discovered))
+          "already-registered agents are not re-announced on later passes"))))
 
 (deftest ^{:stratum 2} stop-idempotent-test
   (testing "stop! can be called multiple times safely"
@@ -746,7 +722,7 @@
                   :event-stream es}))]
       (sut/submit-decision-from-agent!
        orch (:agent/id agent-rec) "Event decision?")
-      (is (wait-until-count published 1)
+      (is (support/wait-until-count published 1)
           "should have published a decision-created event"))))
 
 (deftest ^{:stratum 2} submit-multiple-decisions-same-agent-test
@@ -866,7 +842,7 @@
           _ (sut/resolve-and-deliver!
              orch (:decision/id decision) "approved")]
       ;; Should have events for: decision-created, decision-resolved
-      (is (wait-until-count published 2)
+      (is (support/wait-until-count published 2)
           "should have published decision-created and decision-resolved events"))))
 
 (deftest ^{:stratum 2} resolve-and-deliver-without-comment-test
@@ -961,7 +937,7 @@
 
       ;; Start orchestrator and wait for discovery to register the agent.
       (sut/start! orch)
-      (wait-until #(pos? (registry/count-agents reg)))
+      (support/wait-until #(pos? (registry/count-agents reg)))
 
       (let [agents (registry/list-agents reg)]
         (is (= 1 (count agents)) "should have discovered one agent")
@@ -1005,7 +981,7 @@
                   :discovery-interval-ms 50
                   :poll-interval-ms 50}))]
       (sut/start! orch)
-      (wait-until #(pos? (registry/count-agents reg)))
+      (support/wait-until #(pos? (registry/count-agents reg)))
 
       (let [agents (registry/list-agents reg)
             agent-id (:agent/id (first agents))
@@ -1016,7 +992,7 @@
             _ (sut/resolve-and-deliver!
                orch (:decision/id decision) "yes")]
         ;; Should have: agent-registered, possibly state-changed, decision-created, decision-resolved
-        (is (wait-until-count published 3)
+        (is (support/wait-until-count published 3)
             "should have published multiple events throughout lifecycle"))
 
       (sut/stop! orch))))

--- a/components/control-plane/test/ai/miniforge/control_plane/orchestrator_test.clj
+++ b/components/control-plane/test/ai/miniforge/control_plane/orchestrator_test.clj
@@ -593,8 +593,13 @@
           "callback should receive the agent the adapter discovered")
       (is (pos? (registry/count-agents reg))
           "discovery loop should have registered agents")
+      ;; Drive the second pass here, on this thread, now that the loop is
+      ;; stopped. Waiting for the background loop to tick again before stop!
+      ;; would put the claim below back at the mercy of the scheduler; the
+      ;; agent is registered either way, so the callback must not fire again.
+      (#'sut/run-discovery-pass started)
       (is (= ["ext-loop"] (mapv :agent/external-id @discovered))
-          "already-registered agents are not re-announced on later passes"))))
+          "an already-registered agent is not re-announced on a later pass"))))
 
 (deftest ^{:stratum 2} stop-idempotent-test
   (testing "stop! can be called multiple times safely"


### PR DESCRIPTION
## Summary

`start-runs-discovery-test` failed on [CI run 30693512654](https://github.com/miniforge-ai/miniforge/actions/runs/30693512654) — attempt 1 of #1594, a docs-only change that moved a spec file. A re-run got past it. It passes consistently locally.

The failure output names the cause:

```
FAIL in (start-runs-discovery-test) (orchestrator_test.clj:615)
  actual: (not (wait-until-count #object[clojure.lang.Atom ...
             {:status :ready, :val [#:agent{... :name "Loop Agent" ...}]}] 1))
```

The atom already held the discovered agent when the wait reported a timeout. The callback fired; the wait missed it. Registration timestamp `09:25:44.348` and failure at `09:25:46.35` — the full 2s timeout burned with the condition already satisfied.

## Root cause

`wait-until-count` read the atom's current value **before** installing its watch:

```clojure
(when (>= (count @items-atom) n)     ;; 1. read
  (deliver done :immediate))
(add-watch items-atom k ...)          ;; 2. install
```

An update landing between (1) and (2) is seen by neither path, so the promise is never delivered. This is a lost wakeup, not a slow one — widening the timeout cannot fix it, because nothing is ever going to arrive.

The racy helper was copied verbatim into all three orchestrator test namespaces, covering 14 call sites, so every atom-observing orchestrator test carried it.

## Changes

- **New `ai.miniforge.control-plane.async-test-support`** holds `wait-until-count` and `wait-until`, replacing three copies. `wait-until-count` now installs the watch before reading the value. `deliver` on a settled promise is a no-op, so the two paths racing each other is harmless.
- **`start-runs-discovery-test` no longer waits on a watched atom.** `:on-agent-discovered` delivers a promise the test derefs; the deref establishes happens-before with the `register-agent!` and `swap!` that precede it. `start!` runs its first discovery pass before the loop's first sleep, so `:discovery-interval-ms` only decides when a redundant *second* pass would run — it no longer participates in whether the test passes. The deref timeout is a deadlock guard, not a scheduling bet.
- The test also now asserts the callback received the discovered agent, and that later passes do not re-announce an already-registered one — replacing a `(pos? (count @discovered))` that the deref had made trivially true.
- `bb lint:stratum` demoted three sibling test vars from stratum 2 to 1 and dropped two now-empty Layer 2 banners: removing each file's local Layer 1 helper left those tests referencing only Layer 0 defs.

No production code changed.

## Why not the #1570 approach

[#1570](https://github.com/miniforge-ai/miniforge/pull/1570) widened a threshold against a real wall-clock race, which was right for that test — the keepalive tick genuinely runs late under load. This one is not a margin problem. The wakeup is dropped, so any timeout is equally insufficient.

## Test plan

- [x] `clj-kondo` on `components/control-plane/test` — 0 errors, 0 warnings
- [x] `bb poly:check` — no new warnings (the 5 reported are pre-existing and unrelated: config test fixtures, unused `effect-transaction`/`decision-envelope` components)
- [x] `bb lint:stratum` clean after its own autofix
- [x] `bb test` (stable-derived changed-and-affected, the same command CI runs on a PR) — green, 6m49s
- [x] **Old vs. new shape, 1500 runs each against the real orchestrator**, on a 10-core box with 40 CPU-burner threads to force scheduler jitter: old **8 lost wakeups / 1500** (0.53%, same signature as CI — callback ran, wait timed out); new **0 / 1500**
- [x] All four control-plane test namespaces (108 tests, 295 assertions) run **40x back-to-back under the same load — 40/40 clean**

🤖 Generated with [Claude Code](https://claude.com/claude-code)