### PR TITLE
docs(ariadne): v1.6.1 — alice and a generic licensor in the diagrams too

### DIFF
--- a/docs/architecture/ariadne/CHANGELOG.md
+++ b/docs/architecture/ariadne/CHANGELOG.md
@@ -9,6 +9,29 @@
 Bump types are defined in [VERSIONING.md](VERSIONING.md). Entries above
 PATCH state what an adopter has to do about the change.
 
+## v1.6.1 — 2026-07-29 (PATCH)
+
+Nothing to adopt. Worked examples only; no axiom, interface,
+vocabulary, or section changed.
+
+v1.6.0 scrubbed the spec's prose but not its diagrams, so the published
+unit was internally inconsistent: the spec said `alice` and
+`license:market-data` while five diagrams and one explainer
+illustration still carried a real person's name and a named commercial
+vendor. Fixed:
+
+- Example principal is `alice` throughout the diagrams and the
+  doorkeeper illustration (and its published HTML twin), matching the
+  spec.
+- The licensed-feed examples use the generic `license:market-data` and
+  "licensed-feed pattern" in the diagrams, matching the spec. The named
+  vendor stays with the product that holds that licence.
+- Diagram 5's licence tuple drops a redundant `[TTL]` annotation that
+  no longer fit the lane once the generic licensor id replaced the
+  shorter vendor name. The lane is titled "license expiry /
+  invalidation" and the panel states the TTL semantics twice more, so
+  no information was lost.
+
 ## v1.6.0 — 2026-07-28 (MINOR)
 
 First tagged and publicly published version. Ariadne moves here from

--- a/docs/architecture/ariadne/diagrams/01-core-model.svg
+++ b/docs/architecture/ariadne/diagrams/01-core-model.svg
@@ -34,14 +34,14 @@
   <rect class="zone" x="1670" y="62" width="230" height="800" rx="6"/>
   <text class="zoneT" x="1686" y="84">NON-RESIDENT AUTHORITIES</text>
 
-  <!-- tenant:chris -->
+  <!-- tenant:alice -->
   <rect class="pt" x="44" y="104" width="270" height="380" rx="8"/>
-  <text class="h" x="60" y="128">tenant:chris</text>
+  <text class="h" x="60" y="128">tenant:alice</text>
   <text class="s" x="60" y="144">personal · exactly one person</text>
   <rect class="pr" x="60" y="156" width="238" height="34" rx="6"/>
-  <text class="h" x="72" y="177" font-size="12">principal:chris</text>
+  <text class="h" x="72" y="177" font-size="12">principal:alice</text>
   <text class="s" x="176" y="177">#controller (may be several)</text>
-  <text class="s" x="60" y="212" font-weight="bold">owns (owner_tenant_id = tenant:chris)</text>
+  <text class="s" x="60" y="212" font-weight="bold">owns (owner_tenant_id = tenant:alice)</text>
   <rect class="rec" x="60" y="222" width="238" height="30" rx="4"/>
   <text class="t" x="70" y="241">evidence: resume, portfolio</text>
   <rect class="dis" x="232" y="227" width="58" height="18" rx="9"/><text class="s" x="261" y="240" text-anchor="middle">:private</text>
@@ -53,7 +53,7 @@
   <rect class="rec" x="60" y="330" width="238" height="30" rx="4"/>
   <text class="t" x="70" y="349">commissioned review (default)</text>
   <text class="s" x="60" y="382">* inherited from :confidential org sources —</text>
-  <text class="s" x="60" y="396">restriction is the imposer's, record is chris's</text>
+  <text class="s" x="60" y="396">restriction is the imposer's, record is alice's</text>
   <text class="s" x="60" y="424" font-style="italic">subject-id ≡ personal-tenant id.</text>
   <text class="s" x="60" y="438" font-style="italic">No separate user / subject layer.</text>
   <text class="s" x="60" y="452" font-style="italic">B2C = this box alone; human-owner checks</text>
@@ -113,22 +113,22 @@
   <!-- tuples -->
   <text class="s" x="680" y="196" font-weight="bold">relation tuples — object#relation@subject</text>
   <rect class="rel" x="664" y="208" width="512" height="30" rx="5"/>
-  <text class="m" x="676" y="227">tenant:acme#employee@tenant:chris</text>
+  <text class="m" x="676" y="227">tenant:acme#employee@tenant:alice</text>
   <text class="s" x="1000" y="227">employment</text>
   <rect class="rel" x="664" y="244" width="512" height="30" rx="5"/>
-  <text class="m" x="676" y="263">engagement:chris-acme#manager@principal:dana</text>
+  <text class="m" x="676" y="263">engagement:alice-acme#manager@principal:dana</text>
   <text class="s" x="1000" y="263">role scoped to engagement</text>
   <rect class="rel" x="664" y="280" width="512" height="30" rx="5"/>
-  <text class="m" x="676" y="299">tenant:chris#coach@principal:sam</text>
+  <text class="m" x="676" y="299">tenant:alice#coach@principal:sam</text>
   <text class="s" x="1000" y="299">Studio / Coach shape</text>
   <rect class="rel" x="664" y="316" width="512" height="30" rx="5"/>
-  <text class="m" x="676" y="335">assessment:A#engagement@engagement:chris-acme</text>
+  <text class="m" x="676" y="335">assessment:A#engagement@engagement:alice-acme</text>
   <text class="s" x="1000" y="335">record hangs off the engagement</text>
   <rect class="rel" x="664" y="352" width="512" height="30" rx="5"/>
   <text class="m" x="676" y="371">rubric:R#viewer@tenant:acme#employee</text>
   <text class="s" x="1000" y="371">userset: all employees</text>
   <rect class="rel" x="664" y="388" width="512" height="30" rx="5"/>
-  <text class="m" x="676" y="407">evidence:E#owner@tenant:chris</text>
+  <text class="m" x="676" y="407">evidence:E#owner@tenant:alice</text>
   <text class="s" x="1000" y="407">materialized from owner col.</text>
   <rect class="rel" x="664" y="424" width="512" height="30" rx="5"/>
   <text class="m" x="676" y="443">license:L#holder@tenant:dana · license:L#seat@tenant:alex</text>
@@ -185,7 +185,7 @@
   <!-- commissioning note -->
   <rect class="note" x="1244" y="544" width="382" height="120" rx="6"/>
   <text class="h" x="1260" y="568">Commissioning = visibility, not ownership</text>
-  <text class="t" x="1260" y="590">A review run under acme's cycle: chris keeps the record;</text>
+  <text class="t" x="1260" y="590">A review run under acme's cycle: alice keeps the record;</text>
   <text class="t" x="1260" y="606">acme holds #commissioner / #viewer relations.</text>
   <text class="t" x="1260" y="626">Official-record semantics only by explicit org policy</text>
   <text class="t" x="1260" y="642">flip at onboarding — a named opt-in, never the default.</text>
@@ -194,16 +194,16 @@
   <rect class="note" x="1244" y="680" width="382" height="160" rx="6"/>
   <text class="h" x="1260" y="704">Offboarding (§7)</text>
   <text class="t" x="1260" y="726">Delete employment + seat tuples →</text>
-  <text class="t" x="1260" y="742">· acme's relations into tenant:chris revoked</text>
-  <text class="t" x="1260" y="758">· chris's access to acme-owned intake revoked</text>
-  <text class="t" x="1260" y="774">· tenant:chris and everything it owns: untouched</text>
+  <text class="t" x="1260" y="742">· acme's relations into tenant:alice revoked</text>
+  <text class="t" x="1260" y="758">· alice's access to acme-owned intake revoked</text>
+  <text class="t" x="1260" y="774">· tenant:alice and everything it owns: untouched</text>
   <text class="t" x="1260" y="794">Entitlement gates compute, never data. Takeaway</text>
   <text class="t" x="1260" y="810">export: always available, hard policy, no off switch.</text>
 
   <!-- NON-RESIDENT -->
   <rect class="ext" x="1690" y="104" width="192" height="240" rx="8"/>
   <text class="h" x="1702" y="128">licensor</text>
-  <text class="mS" x="1702" y="146">license:eodhd</text>
+  <text class="mS" x="1702" y="146">license:market-data</text>
   <text class="s" x="1702" y="168">imposes terms on payloads</text>
   <text class="s" x="1702" y="182">that ride its feed (§12)</text>
   <text class="s" x="1702" y="204">not in the tuple store —</text>

--- a/docs/architecture/ariadne/diagrams/02-request-path.svg
+++ b/docs/architecture/ariadne/diagrams/02-request-path.svg
@@ -74,10 +74,10 @@
   <!-- context -->
   <rect class="rel" x="684" y="120" width="272" height="220" rx="8"/>
   <text class="h" x="698" y="144">InvocationContext</text>
-  <text class="m" x="698" y="170">:tenant/id      "chris"</text>
+  <text class="m" x="698" y="170">:tenant/id      "alice"</text>
   <text class="m" x="698" y="190">:workspace/id   "workspace/default"</text>
-  <text class="m" x="698" y="210">:principal/id   "chris"</text>
-  <text class="m" x="698" y="230">:subject/id     "chris"</text>
+  <text class="m" x="698" y="210">:principal/id   "alice"</text>
+  <text class="m" x="698" y="230">:subject/id     "alice"</text>
   <text class="m" x="698" y="250">:run/id         (optional, explicit)</text>
   <text class="m" x="698" y="270">:purpose (+ :purpose-basis)</text>
   <text class="m" x="698" y="290">+ relation/policy revision pins</text>

--- a/docs/architecture/ariadne/diagrams/03-ownership-provenance.svg
+++ b/docs/architecture/ariadne/diagrams/03-ownership-provenance.svg
@@ -50,11 +50,11 @@
   <text class="h" x="58" y="268">Personal drop folder / self-import</text>
   <text class="s" x="58" y="286">resume · portfolio · personal projects — no</text>
   <text class="s" x="58" y="300">employer claim exists on this route</text>
-  <rect class="rec" x="58" y="314" width="196" height="22" rx="11" fill="#d5e8d4"/><text class="own" x="156" y="329" text-anchor="middle" fill="#3a6a34">owner: tenant:chris (personal)</text>
+  <rect class="rec" x="58" y="314" width="196" height="22" rx="11" fill="#d5e8d4"/><text class="own" x="156" y="329" text-anchor="middle" fill="#3a6a34">owner: tenant:alice (personal)</text>
 
   <rect class="ext" x="44" y="374" width="312" height="120" rx="8"/>
   <text class="h" x="58" y="398">Licensed feed</text>
-  <text class="s" x="58" y="416">e.g. market data (EODHD pattern) — custodian</text>
+  <text class="s" x="58" y="416">e.g. market data (licensed-feed pattern) — custodian</text>
   <text class="s" x="58" y="430">owns the manifest; the PAYLOAD rights are the licensor's</text>
   <rect class="rec" x="58" y="444" width="150" height="22" rx="11" fill="#d5e8d4"/><text class="own" x="133" y="459" text-anchor="middle" fill="#3a6a34">custodian: intake tenant</text>
   <rect class="dis" x="218" y="444" width="124" height="22" rx="11"/><text class="s" x="280" y="459" text-anchor="middle">rights: licensed [TTL]</text>
@@ -124,7 +124,7 @@
   <rect class="note" x="854" y="494" width="292" height="120" rx="6"/>
   <text class="h" x="868" y="516">Rights inheritance (licensed sources)</text>
   <text class="t" x="868" y="538">Term-driven, not automatic: the license's</text>
-  <text class="t" x="868" y="554">derivation clause decides. EODHD pattern:</text>
+  <text class="t" x="868" y="554">derivation clause decides. licensed-feed pattern:</text>
   <text class="t" x="868" y="572">raw series → licensed [TTL] · derived</text>
   <text class="t" x="868" y="588">analytics → owned. No terms? third-party.</text>
 
@@ -145,11 +145,11 @@
   <rect class="pt" x="1214" y="272" width="320" height="220" rx="8"/>
   <text class="h" x="1228" y="296">Commissioned projections</text>
   <rect class="rec" x="1228" y="308" width="292" height="26" rx="4"/><text class="t" x="1238" y="325">review run under acme's cycle</text>
-  <rect class="rec" x="1228" y="344" width="252" height="22" rx="11" fill="#d5e8d4"/><text class="own" x="1354" y="359" text-anchor="middle" fill="#3a6a34">owner: tenant:chris (subject) — the DEFAULT</text>
+  <rect class="rec" x="1228" y="344" width="252" height="22" rx="11" fill="#d5e8d4"/><text class="own" x="1354" y="359" text-anchor="middle" fill="#3a6a34">owner: tenant:alice (subject) — the DEFAULT</text>
   <text class="s" x="1228" y="386" font-weight="bold">commissioning tenant gets relations, not ownership:</text>
   <rect class="rel" x="1228" y="396" width="292" height="24" rx="5"/><text class="m" x="1238" y="412">review:V#commissioner@tenant:acme</text>
   <rect class="rel" x="1228" y="426" width="292" height="24" rx="5"/><text class="m" x="1238" y="442">review:V#viewer@tenant:acme</text>
-  <text class="m" x="1228" y="470">review:V#engagement@engagement:chris-acme</text>
+  <text class="m" x="1228" y="470">review:V#engagement@engagement:alice-acme</text>
   <text class="s" x="1228" y="484" font-style="italic">visibility granted, property kept — bounded by the engagement</text>
 
   <rect class="dis" x="1214" y="516" width="320" height="96" rx="8"/>

--- a/docs/architecture/ariadne/diagrams/04-agent-tool-gates.svg
+++ b/docs/architecture/ariadne/diagrams/04-agent-tool-gates.svg
@@ -37,14 +37,14 @@
 
   <!-- DELEGATION -->
   <rect class="pr" x="44" y="104" width="392" height="60" rx="8"/>
-  <text class="h" x="58" y="128">principal:chris (human)</text>
+  <text class="h" x="58" y="128">principal:alice (human)</text>
   <text class="s" x="58" y="146">delegates — is never impersonated by the agent</text>
 
   <rect class="rel" x="44" y="180" width="392" height="150" rx="8"/>
   <text class="h" x="58" y="204">delegation:D — a first-class grant object</text>
-  <text class="mS" x="58" y="224">delegation:D#grantor@principal:chris</text>
+  <text class="mS" x="58" y="224">delegation:D#grantor@principal:alice</text>
   <text class="mS" x="58" y="240">delegation:D#grantee@principal:agent-a</text>
-  <text class="mS" x="58" y="256">delegation:D#basis@engagement:chris-acme</text>
+  <text class="mS" x="58" y="256">delegation:D#basis@engagement:alice-acme</text>
   <text class="mS" x="58" y="272">run:R#delegation@delegation:D</text>
   <text class="s" x="58" y="292">record: scope · purpose · argument constraints ·</text>
   <text class="s" x="58" y="306">allowed capability versions · :delegable? · TTL ·</text>

--- a/docs/architecture/ariadne/diagrams/05-revocation-rights.svg
+++ b/docs/architecture/ariadne/diagrams/05-revocation-rights.svg
@@ -31,13 +31,13 @@
   <!-- lane 1 employment -->
   <text class="h" x="44" y="116">employee offboarding</text>
   <rect class="rel" x="44" y="126" width="300" height="28" rx="5"/>
-  <text class="m" x="56" y="144">tenant:acme#employee@tenant:chris</text>
+  <text class="m" x="56" y="144">tenant:acme#employee@tenant:alice</text>
   <line class="cut" x1="330" y1="120" x2="366" y2="160"/><line class="cut" x1="366" y1="120" x2="330" y2="160"/>
   <path class="bad" d="M370,140 L420,140" marker-end="url(#aR)"/>
   <rect class="rec" x="424" y="98" width="332" height="120" rx="8"/>
-  <text class="t" x="436" y="120">· acme's relations into tenant:chris — revoked</text>
-  <text class="t" x="436" y="138">· chris's access to acme-owned intake — revoked</text>
-  <text class="t" x="436" y="156">· tenant:chris + everything it owns — untouched</text>
+  <text class="t" x="436" y="120">· acme's relations into tenant:alice — revoked</text>
+  <text class="t" x="436" y="138">· alice's access to acme-owned intake — revoked</text>
+  <text class="t" x="436" y="156">· tenant:alice + everything it owns — untouched</text>
   <text class="t" x="436" y="174">· claims persist, still carrying inherited gates</text>
   <text class="t" x="436" y="192">· path to personal = re-license, not migration</text>
   <text class="s" x="436" y="210" font-style="italic">the employer keeps its documents; neither side keeps the other's property</text>
@@ -45,7 +45,7 @@
   <!-- lane 2 agent -->
   <text class="h" x="44" y="262">agent decommission</text>
   <rect class="rel" x="44" y="272" width="300" height="28" rx="5"/>
-  <text class="mS" x="56" y="290">principal:chris#delegate@principal:agent-a</text>
+  <text class="mS" x="56" y="290">principal:alice#delegate@principal:agent-a</text>
   <line class="cut" x1="330" y1="266" x2="366" y2="306"/><line class="cut" x1="366" y1="266" x2="330" y2="306"/>
   <path class="bad" d="M370,286 L420,286" marker-end="url(#aR)"/>
   <rect class="rec" x="424" y="244" width="332" height="104" rx="8"/>
@@ -58,7 +58,7 @@
   <!-- lane 3 license -->
   <text class="h" x="44" y="392">license expiry / invalidation</text>
   <rect class="rel" x="44" y="402" width="300" height="28" rx="5"/>
-  <text class="mS" x="56" y="420">license:eodhd#beneficiary@tenant:chris [TTL]</text>
+  <text class="mS" x="56" y="420">license:market-data#beneficiary@tenant:alice</text>
   <line class="cut" x1="330" y1="396" x2="366" y2="436"/><line class="cut" x1="366" y1="396" x2="330" y2="436"/>
   <path class="bad" d="M370,416 L420,416" marker-end="url(#aR)"/>
   <rect class="rec" x="424" y="374" width="332" height="120" rx="8"/>
@@ -102,16 +102,16 @@
   <text class="h" x="1216" y="134">record:R</text>
   <text class="s" x="1216" y="152">licensed payload (raw series)</text>
   <rect class="ext" x="1470" y="110" width="180" height="60" rx="8"/>
-  <text class="h" x="1482" y="134">license:eodhd</text>
+  <text class="h" x="1482" y="134">license:market-data</text>
   <text class="s" x="1482" y="152">terms · TTL · derivation clause</text>
   <rect class="pt" x="1716" y="110" width="160" height="60" rx="8"/>
-  <text class="h" x="1728" y="134">tenant:chris</text>
+  <text class="h" x="1728" y="134">tenant:alice</text>
   <text class="s" x="1728" y="152">custodian / beneficiary</text>
   <path class="eP" d="M1384,140 L1468,140" marker-end="url(#aP)"/>
   <text class="mS" x="1426" y="132" text-anchor="middle">#rights</text>
   <path class="eP" d="M1650,140 L1714,140" marker-end="url(#aP)"/>
   <text class="mS" x="1682" y="132" text-anchor="middle">#beneficiary</text>
-  <text class="s" x="1204" y="192" font-style="italic">readability routes THROUGH the license node — check(chris, read, R) traverses #rights → #beneficiary; expired TTL = no path</text>
+  <text class="s" x="1204" y="192" font-style="italic">readability routes THROUGH the license node — check(alice, read, R) traverses #rights → #beneficiary; expired TTL = no path</text>
 
   <text class="h" x="1204" y="226">terms classes — UX projections over policy clauses (§13.1)</text>
   <rect class="pt" x="1204" y="238" width="120" height="24" rx="12"/><text class="s" x="1264" y="254" text-anchor="middle">owned</text>
@@ -121,7 +121,7 @@
 
   <rect class="note" x="1204" y="284" width="672" height="90" rx="6"/>
   <text class="h" x="1218" y="306">Derivation clause — term-driven, not automatic</text>
-  <text class="t" x="1218" y="328">EODHD pattern: raw series → licensed [TTL] · derived analytics → owned (yours).</text>
+  <text class="t" x="1218" y="328">licensed-feed pattern: raw series → licensed [TTL] · derived analytics → owned (yours).</text>
   <text class="t" x="1218" y="346">Absent explicit terms: derived keeps the third-party label — the safe default.</text>
   <text class="s" x="1218" y="364" font-style="italic">same rule as claims-over-employer-evidence: the governing agreement decides, machine-readably</text>
 
@@ -141,10 +141,10 @@
   <text class="zoneT" x="36" y="624">THE TAKEAWAY EXPORT — always available, hard policy, no off switch</text>
 
   <rect class="pt" x="44" y="650" width="240" height="120" rx="8"/>
-  <text class="h" x="58" y="674">tenant:chris — all records</text>
+  <text class="h" x="58" y="674">tenant:alice — all records</text>
   <text class="s" x="58" y="694">evidence · claims · profile · projections</text>
   <text class="s" x="58" y="710">+ org-channel intake (acme-owned)</text>
-  <text class="s" x="58" y="726">+ licensed payloads (eodhd rights)</text>
+  <text class="s" x="58" y="726">+ licensed payloads (licensed-feed rights)</text>
   <text class="s" x="58" y="742">+ scraped raw pages (third-party)</text>
 
   <path class="eB" d="M284,710 L336,710" marker-end="url(#aB)"/>

--- a/docs/architecture/ariadne/explainers/eli9-3-doorkeeper.svg
+++ b/docs/architecture/ariadne/explainers/eli9-3-doorkeeper.svg
@@ -13,7 +13,7 @@
   <rect x="70" y="116" width="216" height="110" rx="8" fill="#ffffff" stroke="#9673a6" stroke-width="1.5"/>
   <text x="82" y="138" font-size="13" font-weight="bold" fill="#4a355c">HALL PASS — robot-a</text>
   <text x="82" y="158" font-size="12" fill="#333">may: mail letters to family</text>
-  <text x="82" y="176" font-size="12" fill="#333">because: chris said so (tue)</text>
+  <text x="82" y="176" font-size="12" fill="#333">because: alice said so (tue)</text>
   <text x="82" y="194" font-size="12" fill="#333">expires: bedtime</text>
   <text x="82" y="212" font-size="12" fill="#c0392b" font-weight="bold">lending: not allowed</text>
   <text x="66" y="246" font-size="11.5" fill="#4a355c">if the "because" goes away, the pass dies too</text>

--- a/docs/architecture/ariadne/explainers/the-robot-helpers-and-the-sticker-rules.html
+++ b/docs/architecture/ariadne/explainers/the-robot-helpers-and-the-sticker-rules.html
@@ -228,7 +228,7 @@ th { background:#f0eee8; }
   <rect x="70" y="116" width="216" height="110" rx="8" fill="#ffffff" stroke="#9673a6" stroke-width="1.5"/>
   <text x="82" y="138" font-size="13" font-weight="bold" fill="#4a355c">HALL PASS — robot-a</text>
   <text x="82" y="158" font-size="12" fill="#333">may: mail letters to family</text>
-  <text x="82" y="176" font-size="12" fill="#333">because: chris said so (tue)</text>
+  <text x="82" y="176" font-size="12" fill="#333">because: alice said so (tue)</text>
   <text x="82" y="194" font-size="12" fill="#333">expires: bedtime</text>
   <text x="82" y="212" font-size="12" fill="#c0392b" font-weight="bold">lending: not allowed</text>
   <text x="66" y="246" font-size="11.5" fill="#4a355c">if the "because" goes away, the pass dies too</text>

--- a/docs/architecture/ariadne/tenancy-ownership-access.md
+++ b/docs/architecture/ariadne/tenancy-ownership-access.md
@@ -8,11 +8,11 @@ The name pairs with the Theseus engine (Thesium's), where the
 model was first distilled; the architecture itself is
 engine-agnostic and portable.
 
-**Version:** 1.6.0 — tagged `ariadne/v1.6.0`. Cite the tag, not
+**Version:** 1.6.1 — tagged `ariadne/v1.6.1`. Cite the tag, not
 `main`: see [VERSIONING.md](VERSIONING.md) for what a major/minor/patch
 bump means and how to fork against a fixed version.
 
-1.6.0 is the current and only tagged version; earlier `v1.x` numbers
+1.6.1 is the current version; earlier `v1.x` numbers
 in the history below were untagged working revisions, superseded by
 this one. See [CHANGELOG.md](CHANGELOG.md).
 

--- a/docs/architecture/rfc-ariadne-adoption.md
+++ b/docs/architecture/rfc-ariadne-adoption.md
@@ -13,7 +13,7 @@ review apart from naming and the ratification list.
 
 **Ariadne** is the tenancy/ownership/access architecture distilled
 in [`docs/architecture/ariadne/tenancy-ownership-access.md`](ariadne/tenancy-ownership-access.md),
-**adopted at tag `ariadne/v1.6.0`**: clause-set policy labels,
+**adopted at tag `ariadne/v1.6.1`**: clause-set policy labels,
 `decide()` decision envelopes,
 execution grants with lineage, transacted effects, tenants and
 Zanzibar-style relations, revocation-for-cause. It is
@@ -40,7 +40,7 @@ is analysis in support of them.
    routing eligibility; N10 and half of N12 get rewritten as
    profiles of Ariadne's six frozen interfaces.
 
-**Adopted version:** `ariadne/v1.6.0`. Adoption is pinned to a tag,
+**Adopted version:** `ariadne/v1.6.1`. Adoption is pinned to a tag,
 not to `main` — see [ariadne/VERSIONING.md](ariadne/VERSIONING.md) for
 bump semantics and the fork workflow. v1.6.0 carries the same axioms,
 interfaces, and vocabularies as the untagged v1.5 lineage this RFC was
@@ -229,6 +229,6 @@ it pays for itself before anyone believes in the rest.
 
 *Sources: as-built and target panels (miniforge #1548 + #1549
 corrections, source-verified); the contradiction register (T3);
-Ariadne v1.6.0 §§2–13; N-spec status per
+Ariadne v1.6.1 §§2–13; N-spec status per
 ROADMAP and the 2026-06-10 design review; Fleet specs N10–N12;
 governance audit 2026-07-05.*


### PR DESCRIPTION
**v1.6.0 was internally inconsistent and I shipped it that way.** The scrub covered the spec's prose but not its diagrams, so the published unit said `alice` / `license:market-data` in the text while **five diagrams and one explainer illustration still carried a real person's name and a named commercial vendor** — including the vendor that was supposed to stay private with the product holding that licence.

Fixed across `diagrams/01`–`05`, `explainers/eli9-3-doorkeeper.svg`, and its published HTML twin:

- Example principal is `alice` everywhere — tuples, invocation-context values, and prose mentions (`check(alice, read, R)`, "alice keeps the record").
- Licensed-feed examples use `license:market-data` and "licensed-feed pattern".
- Diagram 5's licence tuple drops a redundant `[TTL]`: the longer generic id pushed the string under the cut marks. The lane is titled "license expiry / invalidation" and the panel states TTL semantics twice more, so nothing was lost.

**PATCH per `VERSIONING.md`** — worked examples only; no axiom, interface, vocabulary, or section number moved, so there is nothing for an adopter to do. Spec version line, CHANGELOG, and the RFC's adopted-tag pin all updated to 1.6.1.

Verification: the three panels whose text width actually changed (1, 3, 5) are screenshot-verified; `chris`→`alice` is width-neutral at five characters each, so panels 2 and 4 are dimensionally identical. `grep` for the old names across the whole unit returns zero, excluding copyright attribution.

I'll tag `ariadne/v1.6.1` on the merge commit.

MINIFORGE_PR_BUDGET_OVERRIDE: single-purpose scrub across the diagram set; splitting would leave the published unit self-contradictory between PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)