### PR TITLE
refactor(control-plane): share the orchestrator mock adapter and base opts

### DIFF
--- a/components/control-plane/test/ai/miniforge/control_plane/orchestrator_test.clj
+++ b/components/control-plane/test/ai/miniforge/control_plane/orchestrator_test.clj
@@ -8,6 +8,8 @@
    [ai.miniforge.control-plane.registry :as registry]
    [ai.miniforge.control-plane.decision-queue :as dq]
    [ai.miniforge.control-plane.async-test-support :as support]
+   [ai.miniforge.control-plane.orchestrator-test-support
+    :refer [base-orchestrator-opts make-mock-adapter]]
    [ai.miniforge.control-plane-adapter.protocol :as adapter]
    [ai.miniforge.event-stream.interface.stream :as stream]))
 
@@ -16,39 +18,12 @@
 ;; ---------------------------------------------------------------------------
 ;; Test helpers
 ;; ---------------------------------------------------------------------------
-(defn ^{:stratum 0} make-mock-adapter
-  "Create a mock adapter implementing ControlPlaneAdapter.
-   `overrides` is a map of {:discover-agents fn, :poll-agent-status fn,
-                             :deliver-decision fn, :send-command fn, :adapter-id kw}."
-  [overrides]
-  (let [id (get overrides :adapter-id :test-adapter)]
-    (reify adapter/ControlPlaneAdapter
-      (adapter-id [_] id)
-      (discover-agents [_ config]
-        (if-let [f (:discover-agents overrides)]
-          (f config)
-          []))
-      (poll-agent-status [_ agent-record]
-        (if-let [f (:poll-agent-status overrides)]
-          (f agent-record)
-          nil))
-      (deliver-decision [_ agent-record decision]
-        (if-let [f (:deliver-decision overrides)]
-          (f agent-record decision)
-          {:delivered? true}))
-      (send-command [_ agent-record command]
-        (if-let [f (:send-command overrides)]
-          (f agent-record command)
-          {:success? true})))))
-
 (defn ^{:stratum 0} make-test-event-stream
   "Create a minimal event stream that captures published events."
   []
   (let [events-atom (atom [])]
     {:stream (stream/create-event-stream {:sinks []})
      :published events-atom}))
-
-(def ^{:stratum 0} test-workflow-id (java.util.UUID/fromString "00000000-0000-0000-0000-000000000001"))
 
 ;; ---------------------------------------------------------------------------
 ;; create-orchestrator
@@ -125,18 +100,7 @@
       (is (instance? clojure.lang.Atom (:running orch)))
       (is (instance? clojure.lang.Atom (:futures orch))))))
 
-;------------------------------------------------------------------------------ Layer 1
-
-(defn ^{:stratum 1} base-orchestrator-opts
-  "Minimal valid opts for creating an orchestrator."
-  [& [overrides]]
-  (merge {:adapters []
-          :workflow-id test-workflow-id
-          :discovery-interval-ms 50
-          :poll-interval-ms 50}
-         overrides))
-
-(deftest ^{:stratum 1} create-orchestrator-custom-opts-test
+(deftest ^{:stratum 0} create-orchestrator-custom-opts-test
   (testing "respects all provided options"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -173,7 +137,7 @@
       ((:on-agent-discovered orch) :test-agent)
       (is (= :test-agent @discovered-atom)))))
 
-(deftest ^{:stratum 1} create-orchestrator-multiple-adapters-test
+(deftest ^{:stratum 0} create-orchestrator-multiple-adapters-test
   (testing "supports multiple adapters as a vector"
     (let [a1 (make-mock-adapter {:adapter-id :adapter-1})
           a2 (make-mock-adapter {:adapter-id :adapter-2})
@@ -182,12 +146,10 @@
       (is (= :adapter-1 (adapter/adapter-id (first (:adapters orch)))))
       (is (= :adapter-2 (adapter/adapter-id (second (:adapters orch))))))))
 
-;------------------------------------------------------------------------------ Layer 2
-
 ;; ---------------------------------------------------------------------------
 ;; Discovery pass (unit-level, calling private fn via #')
 ;; ---------------------------------------------------------------------------
-(deftest ^{:stratum 2} run-discovery-pass-registers-new-agents-test
+(deftest ^{:stratum 0} run-discovery-pass-registers-new-agents-test
   (testing "discovery pass registers newly discovered agents"
     (let [reg (registry/create-registry)
           discovered (atom [])
@@ -209,7 +171,7 @@
           "on-agent-discovered callback should have been called")
       (is (= "Test Agent" (:agent/name (first @discovered)))))))
 
-(deftest ^{:stratum 2} run-discovery-pass-skips-known-agents-test
+(deftest ^{:stratum 0} run-discovery-pass-skips-known-agents-test
   (testing "discovery pass does not re-register known agents"
     (let [reg (registry/create-registry)
           discovered (atom [])
@@ -232,7 +194,7 @@
       (is (= 1 (count @discovered))
           "callback should only fire once"))))
 
-(deftest ^{:stratum 2} run-discovery-pass-handles-adapter-exception-test
+(deftest ^{:stratum 0} run-discovery-pass-handles-adapter-exception-test
   (testing "discovery pass catches exceptions from adapter"
     (let [reg (registry/create-registry)
           adapter (make-mock-adapter
@@ -243,7 +205,7 @@
       ;; Should not throw
       (is (nil? (#'sut/run-discovery-pass orch))))))
 
-(deftest ^{:stratum 2} run-discovery-pass-multiple-adapters-test
+(deftest ^{:stratum 0} run-discovery-pass-multiple-adapters-test
   (testing "discovery across multiple adapters"
     (let [reg (registry/create-registry)
           a1 (make-mock-adapter
@@ -261,7 +223,7 @@
       (#'sut/run-discovery-pass orch)
       (is (= 2 (registry/count-agents reg))))))
 
-(deftest ^{:stratum 2} run-discovery-pass-with-event-stream-test
+(deftest ^{:stratum 0} run-discovery-pass-with-event-stream-test
   (testing "discovery emits agent-registered events when stream is present"
     (let [reg (registry/create-registry)
           es (stream/create-event-stream {:sinks []})
@@ -281,7 +243,7 @@
       (is (support/wait-until-count published 1)
           "should have published at least one event"))))
 
-(deftest ^{:stratum 2} run-discovery-pass-empty-results-test
+(deftest ^{:stratum 0} run-discovery-pass-empty-results-test
   (testing "discovery pass handles adapter returning empty list"
     (let [reg (registry/create-registry)
           adapter (make-mock-adapter
@@ -293,7 +255,7 @@
       (is (zero? (registry/count-agents reg))
           "no agents should be registered when none discovered"))))
 
-(deftest ^{:stratum 2} run-discovery-pass-multiple-agents-one-adapter-test
+(deftest ^{:stratum 0} run-discovery-pass-multiple-agents-one-adapter-test
   (testing "discovery pass registers multiple agents from a single adapter"
     (let [reg (registry/create-registry)
           discovered (atom [])
@@ -313,7 +275,7 @@
       (is (= 3 (count @discovered))
           "callback should fire for each new agent"))))
 
-(deftest ^{:stratum 2} run-discovery-pass-partial-failure-test
+(deftest ^{:stratum 0} run-discovery-pass-partial-failure-test
   (testing "discovery continues with second adapter when first throws"
     (let [reg (registry/create-registry)
           failing-adapter (make-mock-adapter
@@ -334,7 +296,7 @@
 ;; ---------------------------------------------------------------------------
 ;; Poll pass
 ;; ---------------------------------------------------------------------------
-(deftest ^{:stratum 2} run-poll-pass-updates-agent-status-test
+(deftest ^{:stratum 0} run-poll-pass-updates-agent-status-test
   (testing "poll pass records heartbeat and detects status changes"
     (let [reg (registry/create-registry)
           agent-rec (registry/register-agent! reg
@@ -355,7 +317,7 @@
         (is (some? (:agent/last-heartbeat updated))
             "heartbeat should be recorded")))))
 
-(deftest ^{:stratum 2} run-poll-pass-skips-terminal-agents-test
+(deftest ^{:stratum 0} run-poll-pass-skips-terminal-agents-test
   (testing "poll pass skips agents with terminal status"
     (let [reg (registry/create-registry)
           poll-count (atom 0)
@@ -375,7 +337,7 @@
       (is (zero? @poll-count)
           "should not poll terminal agents"))))
 
-(deftest ^{:stratum 2} run-poll-pass-skips-failed-agents-test
+(deftest ^{:stratum 0} run-poll-pass-skips-failed-agents-test
   (testing "poll pass skips agents with :failed status"
     (let [reg (registry/create-registry)
           poll-count (atom 0)
@@ -395,7 +357,7 @@
       (is (zero? @poll-count)
           "should not poll failed agents"))))
 
-(deftest ^{:stratum 2} run-poll-pass-skips-terminated-agents-test
+(deftest ^{:stratum 0} run-poll-pass-skips-terminated-agents-test
   (testing "poll pass skips agents with :terminated status"
     (let [reg (registry/create-registry)
           poll-count (atom 0)
@@ -415,7 +377,7 @@
       (is (zero? @poll-count)
           "should not poll terminated agents"))))
 
-(deftest ^{:stratum 2} run-poll-pass-handles-poll-exception-test
+(deftest ^{:stratum 0} run-poll-pass-handles-poll-exception-test
   (testing "poll pass catches exceptions from adapter poll"
     (let [reg (registry/create-registry)
           _ (registry/register-agent! reg
@@ -431,7 +393,7 @@
       ;; Should not throw
       (is (nil? (#'sut/run-poll-pass orch))))))
 
-(deftest ^{:stratum 2} run-poll-pass-nil-status-update-test
+(deftest ^{:stratum 0} run-poll-pass-nil-status-update-test
   (testing "poll pass handles nil status update gracefully"
     (let [reg (registry/create-registry)
           _ (registry/register-agent! reg
@@ -446,7 +408,7 @@
       ;; Should not throw when poll returns nil
       (is (nil? (#'sut/run-poll-pass orch))))))
 
-(deftest ^{:stratum 2} run-poll-pass-with-event-stream-emits-on-status-change-test
+(deftest ^{:stratum 0} run-poll-pass-with-event-stream-emits-on-status-change-test
   (testing "poll pass emits agent-state-changed event when status changes"
     (let [reg (registry/create-registry)
           es (stream/create-event-stream {:sinks []})
@@ -470,7 +432,7 @@
       (is (support/wait-until-count published 1)
           "should have published at least one state-changed event"))))
 
-(deftest ^{:stratum 2} run-poll-pass-no-event-when-status-unchanged-test
+(deftest ^{:stratum 0} run-poll-pass-no-event-when-status-unchanged-test
   (testing "poll pass keeps heartbeats but skips state-changed when status remains the same"
     (let [reg (registry/create-registry)
           es (stream/create-event-stream {:sinks []})
@@ -495,7 +457,7 @@
         (is (= [:control-plane/agent-heartbeat] event-types)
             "stable polls should publish heartbeat context but not a state change")))))
 
-(deftest ^{:stratum 2} run-poll-pass-multiple-vendors-test
+(deftest ^{:stratum 0} run-poll-pass-multiple-vendors-test
   (testing "poll pass routes agents to correct adapters by vendor"
     (let [reg (registry/create-registry)
           poll-log (atom [])
@@ -522,7 +484,7 @@
       (is (some #(= [:vendor-1 "V1 Agent"] %) @poll-log))
       (is (some #(= [:vendor-2 "V2 Agent"] %) @poll-log)))))
 
-(deftest ^{:stratum 2} run-poll-pass-unmatched-vendor-test
+(deftest ^{:stratum 0} run-poll-pass-unmatched-vendor-test
   (testing "poll pass skips agents whose vendor has no matching adapter"
     (let [reg (registry/create-registry)
           poll-count (atom 0)
@@ -541,7 +503,7 @@
 ;; ---------------------------------------------------------------------------
 ;; start! and stop!
 ;; ---------------------------------------------------------------------------
-(deftest ^{:stratum 2} start-stop-lifecycle-test
+(deftest ^{:stratum 0} start-stop-lifecycle-test
   (testing "start! sets running to true and stop! cleans up"
     (let [adapter (make-mock-adapter {})
           orch (sut/create-orchestrator
@@ -558,7 +520,7 @@
         (is (empty? @(:futures stopped))
             "futures should be cleared after stop")))))
 
-(deftest ^{:stratum 2} start-runs-discovery-test
+(deftest ^{:stratum 0} start-runs-discovery-test
   (testing "start! triggers discovery loop that finds agents"
     (let [reg (registry/create-registry)
           discovered (atom [])
@@ -601,7 +563,7 @@
       (is (= ["ext-loop"] (mapv :agent/external-id @discovered))
           "an already-registered agent is not re-announced on a later pass"))))
 
-(deftest ^{:stratum 2} stop-idempotent-test
+(deftest ^{:stratum 0} stop-idempotent-test
   (testing "stop! can be called multiple times safely"
     (let [orch (sut/create-orchestrator (base-orchestrator-opts))]
       (sut/start! orch)
@@ -609,7 +571,7 @@
       ;; Second stop should not throw
       (is (some? (sut/stop! orch))))))
 
-(deftest ^{:stratum 2} start-returns-orchestrator-with-watchdog-test
+(deftest ^{:stratum 0} start-returns-orchestrator-with-watchdog-test
   (testing "start! returns orchestrator with :watchdog key"
     (let [orch (sut/create-orchestrator (base-orchestrator-opts))
           started (sut/start! orch)]
@@ -617,7 +579,7 @@
           "should have a watchdog after start")
       (sut/stop! started))))
 
-(deftest ^{:stratum 2} stop-clears-running-flag-immediately-test
+(deftest ^{:stratum 0} stop-clears-running-flag-immediately-test
   (testing "stop! sets running to false immediately"
     (let [orch (sut/create-orchestrator (base-orchestrator-opts))]
       (sut/start! orch)
@@ -625,7 +587,7 @@
       (sut/stop! orch)
       (is (false? @(:running orch))))))
 
-(deftest ^{:stratum 2} stop-on-never-started-orchestrator-test
+(deftest ^{:stratum 0} stop-on-never-started-orchestrator-test
   (testing "stop! on a never-started orchestrator is safe"
     (let [orch (sut/create-orchestrator (base-orchestrator-opts))]
       (is (some? (sut/stop! orch))
@@ -635,7 +597,7 @@
 ;; ---------------------------------------------------------------------------
 ;; submit-decision-from-agent!
 ;; ---------------------------------------------------------------------------
-(deftest ^{:stratum 2} submit-decision-from-agent-test
+(deftest ^{:stratum 0} submit-decision-from-agent-test
   (testing "submits a decision, transitions agent to :blocked, fires callback"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -669,7 +631,7 @@
       ;; Decision should be in the manager
       (is (some? (dq/get-decision dm (:decision/id decision)))))))
 
-(deftest ^{:stratum 2} submit-decision-with-opts-test
+(deftest ^{:stratum 0} submit-decision-with-opts-test
   (testing "submit-decision-from-agent! passes opts to create-decision"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -689,7 +651,7 @@
       (is (= :high (:decision/priority decision)))
       (is (= :choice (:decision/type decision))))))
 
-(deftest ^{:stratum 2} submit-decision-terminal-agent-test
+(deftest ^{:stratum 0} submit-decision-terminal-agent-test
   (testing "submit-decision-from-agent! handles already-terminal agent gracefully"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -708,7 +670,7 @@
       (is (some? decision)
           "decision should still be created even if transition fails"))))
 
-(deftest ^{:stratum 2} submit-decision-with-event-stream-test
+(deftest ^{:stratum 0} submit-decision-with-event-stream-test
   (testing "submit-decision-from-agent! emits decision-created event"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -730,7 +692,7 @@
       (is (support/wait-until-count published 1)
           "should have published a decision-created event"))))
 
-(deftest ^{:stratum 2} submit-multiple-decisions-same-agent-test
+(deftest ^{:stratum 0} submit-multiple-decisions-same-agent-test
   (testing "can submit multiple decisions for the same agent"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -756,7 +718,7 @@
 ;; ---------------------------------------------------------------------------
 ;; resolve-and-deliver!
 ;; ---------------------------------------------------------------------------
-(deftest ^{:stratum 2} resolve-and-deliver-test
+(deftest ^{:stratum 0} resolve-and-deliver-test
   (testing "resolves decision, delivers to agent, transitions back to :running"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -791,7 +753,7 @@
         (is (= :running (:agent/status agent))
             "agent should be transitioned back to :running")))))
 
-(deftest ^{:stratum 2} resolve-and-deliver-unknown-decision-test
+(deftest ^{:stratum 0} resolve-and-deliver-unknown-decision-test
   (testing "resolve-and-deliver! returns nil for unknown decision ID"
     (let [orch (sut/create-orchestrator (base-orchestrator-opts))
           result (sut/resolve-and-deliver!
@@ -799,7 +761,7 @@
       (is (nil? result)
           "should return nil when decision not found"))))
 
-(deftest ^{:stratum 2} resolve-and-deliver-no-adapter-test
+(deftest ^{:stratum 0} resolve-and-deliver-no-adapter-test
   (testing "resolve-and-deliver! handles missing adapter (delivery fails)"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -822,7 +784,7 @@
       (is (false? (:delivered? result))
           "delivery should be false when no adapter matches"))))
 
-(deftest ^{:stratum 2} resolve-and-deliver-with-event-stream-test
+(deftest ^{:stratum 0} resolve-and-deliver-with-event-stream-test
   (testing "resolve-and-deliver! emits decision-resolved event"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -850,7 +812,7 @@
       (is (support/wait-until-count published 2)
           "should have published decision-created and decision-resolved events"))))
 
-(deftest ^{:stratum 2} resolve-and-deliver-without-comment-test
+(deftest ^{:stratum 0} resolve-and-deliver-without-comment-test
   (testing "resolve-and-deliver! works without optional comment"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -871,7 +833,7 @@
       (is (some? (:resolved result)))
       (is (true? (:delivered? result))))))
 
-(deftest ^{:stratum 2} resolve-and-deliver-adapter-delivery-failure-test
+(deftest ^{:stratum 0} resolve-and-deliver-adapter-delivery-failure-test
   (testing "resolve-and-deliver! reports delivered? false when adapter returns failure"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -894,7 +856,7 @@
       (is (false? (:delivered? result))
           "delivered? should be false when adapter reports failure"))))
 
-(deftest ^{:stratum 2} resolve-and-deliver-resolved-data-contains-resolution-test
+(deftest ^{:stratum 0} resolve-and-deliver-resolved-data-contains-resolution-test
   (testing "the resolved decision contains the resolution value"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -918,7 +880,7 @@
 ;; ---------------------------------------------------------------------------
 ;; Integration: full lifecycle
 ;; ---------------------------------------------------------------------------
-(deftest ^{:stratum 2} full-lifecycle-integration-test
+(deftest ^{:stratum 0} full-lifecycle-integration-test
   (testing "end-to-end: create -> start -> discover -> decide -> resolve -> stop"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -963,7 +925,7 @@
       (sut/stop! orch)
       (is (false? @(:running orch))))))
 
-(deftest ^{:stratum 2} full-lifecycle-with-event-stream-integration-test
+(deftest ^{:stratum 0} full-lifecycle-with-event-stream-integration-test
   (testing "end-to-end with event stream captures all events"
     (let [reg (registry/create-registry)
           dm (dq/create-decision-manager)
@@ -1002,7 +964,7 @@
 
       (sut/stop! orch))))
 
-(deftest ^{:stratum 2} discovery-with-no-adapters-test
+(deftest ^{:stratum 0} discovery-with-no-adapters-test
   (testing "discovery pass with no adapters is a no-op"
     (let [reg (registry/create-registry)
           orch (sut/create-orchestrator
@@ -1010,7 +972,7 @@
       (#'sut/run-discovery-pass orch)
       (is (zero? (registry/count-agents reg))))))
 
-(deftest ^{:stratum 2} poll-pass-with-no-agents-test
+(deftest ^{:stratum 0} poll-pass-with-no-agents-test
   (testing "poll pass with empty registry is a no-op"
     (let [reg (registry/create-registry)
           poll-count (atom 0)
@@ -1023,7 +985,7 @@
       (is (zero? @poll-count)
           "should not call poll when registry is empty"))))
 
-(deftest ^{:stratum 2} poll-pass-with-no-adapters-test
+(deftest ^{:stratum 0} poll-pass-with-no-adapters-test
   (testing "poll pass with no adapters is safe"
     (let [reg (registry/create-registry)
           _ (registry/register-agent! reg

--- a/components/control-plane/test/ai/miniforge/control_plane/orchestrator_test_support.clj
+++ b/components/control-plane/test/ai/miniforge/control_plane/orchestrator_test_support.clj
@@ -1,0 +1,97 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.control-plane.orchestrator-test-support
+  "Mock adapter and orchestrator opts shared by the orchestrator test namespaces.
+
+   Three namespaces drive the same orchestrator through the same fake
+   adapter and the same minimal opts map. They live here so a defect in the
+   fake is fixed once rather than once per copy — the same reason the async
+   wait helpers moved to `async-test-support`."
+  (:require
+   [ai.miniforge.control-plane.registry :as registry]
+   [ai.miniforge.control-plane-adapter.protocol :as adapter]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} test-workflow-id
+  "The workflow id `base-orchestrator-opts` puts on every orchestrator it
+   builds, in place of the random one `create-orchestrator` would generate."
+  (java.util.UUID/fromString "00000000-0000-0000-0000-000000000001"))
+
+(defn ^{:stratum 0} make-mock-adapter
+  "Create a mock adapter implementing ControlPlaneAdapter.
+   `overrides` is a map of {:discover-agents fn, :poll-agent-status fn,
+                             :deliver-decision fn, :send-command fn, :adapter-id kw}.
+
+   Every protocol method not named in `overrides` answers with the benign
+   default below, so a test states only the behaviour it is about."
+  [overrides]
+  (let [id (get overrides :adapter-id :test-adapter)]
+    (reify adapter/ControlPlaneAdapter
+      (adapter-id [_] id)
+      (discover-agents [_ config]
+        (if-let [f (:discover-agents overrides)]
+          (f config)
+          []))
+      (poll-agent-status [_ agent-record]
+        (if-let [f (:poll-agent-status overrides)]
+          (f agent-record)
+          nil))
+      (deliver-decision [_ agent-record decision]
+        (if-let [f (:deliver-decision overrides)]
+          (f agent-record decision)
+          {:delivered? true}))
+      (send-command [_ agent-record command]
+        (if-let [f (:send-command overrides)]
+          (f agent-record command)
+          {:success? true})))))
+
+(defn ^{:stratum 0} base-opts
+  "Minimal valid opts for creating an orchestrator, with `overrides` merged last.
+
+   The 50ms intervals only bound how soon a *redundant* second discovery or
+   poll pass runs — `start!` runs the first pass of each before its loop
+   sleeps — so they keep a background loop from idling through a test
+   without making any assertion depend on the scheduler."
+  [& [overrides]]
+  (merge {:adapters []
+          :discovery-interval-ms 50
+          :poll-interval-ms 50}
+         overrides))
+
+(defn ^{:stratum 0} register-running-agent!
+  "Helper: register an agent and transition to :running.
+
+   Returns the record as the registry holds it after the transition, not
+   the one `register-agent!` returned, so a caller reads the post-transition
+   status rather than a stale `:initializing`."
+  [reg agent-info]
+  (let [rec (registry/register-agent! reg agent-info)]
+    (registry/transition-agent! reg (:agent/id rec) :running)
+    (registry/get-agent reg (:agent/id rec))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} base-orchestrator-opts
+  "`base-opts` with `:workflow-id` pinned. `overrides` still wins over both.
+
+   `create-orchestrator` generates a random workflow-id when opts omit one,
+   so the difference from bare `base-opts` is a stable id on every published
+   event rather than a fresh one per orchestrator."
+  [& [overrides]]
+  (base-opts (merge {:workflow-id test-workflow-id} overrides)))


### PR DESCRIPTION
## What

`make-mock-adapter` and the `base-opts` / `base-orchestrator-opts` helpers were copied verbatim into all three orchestrator test namespaces. A defect in the fake had to be fixed three times — the same failure mode that moved the async wait helpers into `async-test-support` in #1595.

This adds `ai.miniforge.control-plane.orchestrator-test-support` and adopts it in `orchestrator-test`. A follow-up PR adopts it in `orchestrator-supplemental-test` and `orchestrator-edge-test`, which still carry their own copies until then.

## Decisions worth a reviewer's attention

1. **`base-opts` and `base-orchestrator-opts` stay distinct.** `base-orchestrator-opts` is `base-opts` with `:workflow-id` pinned; `create-orchestrator` generates a random one when opts omit it, so the difference is a stable id on published events, not the presence of one. Equivalence with the old expression was checked directly, including the no-arg and `:workflow-id`-override paths.
2. **`register-running-agent!` came along**, though it was duplicated in two files rather than three. Same copy-paste, same rule (`testing/standards`: a helper used by more than one test file in a component moves to the shared file). It also keeps every deftest at one stratum, so `stratum-lint --fix` regroups nothing and the diff stays readable.
3. **Call sites are `:refer`red, not aliased.** Every call site is byte-identical to before, so the diff is the move plus the `^{:stratum n}` metadata `stratum-lint` recomputed — no test body is touched. An `orch-support/` alias would have rewritten ~90 call-site lines and forced re-indentation of every multi-line `base-opts` map, taking the change to 1048 reportable lines and past the commit budget on every slice.
4. **Namespace name.** `*_test_support.clj` follows `async_test_support.clj` (this same directory) and `workflow/phase_test_support.clj`, rather than the `fixtures.clj` the standard names as one example.

## Not in scope

`make-test-event-stream` in `orchestrator-test` is unreferenced and predates this change; left alone rather than widened into this diff.

## Verification

- `clj-kondo --lint components/control-plane/test` — clean
- `bb poly:check` — exit 0 (only pre-existing warnings 205/207, unrelated components)
- `bb lint:stratum` — clean, and idempotent on a second pass
- 108 tests / 295 assertions green across the four control-plane namespaces, both with this slice alone and with the follow-up applied
- Full `bb pre-commit` gate passed (331 tests / 1244 assertions + GraalVM compatibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)