### PR TITLE
feat(execution-grant): revocation for cause and breach history (Ariadne 2e)

### DIFF
--- a/components/execution-grant/src/ai/miniforge/execution_grant/breach.clj
+++ b/components/execution-grant/src/ai/miniforge/execution_grant/breach.clj
@@ -1,0 +1,91 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.execution-grant.breach
+  "Breach history: what a principal blew through, and whether we caught
+   it or merely noticed (Ariadne step 2e, §13.5).
+
+   THE HONEST HALF. Gates prevent what they can; logbooks catch the
+   rest. Some conditions cannot be checked before the fact — a cost that
+   only materializes mid-stream, an effect whose true outcome arrives
+   later. Those are found by reconciliation, after the effect. A
+   governance product that reports those as PREVENTED is claiming a
+   capability it does not have, so every breach records which it was.
+
+   Append-only by construction: one file per breach, never rewritten.
+   A history you can edit is a history that stops being evidence."
+  (:require
+   [ai.miniforge.execution-grant.core :as core]
+   [ai.miniforge.execution-grant.schema :as schema]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [malli.core :as m])
+  (:import
+   [java.io File]
+   [java.nio.file Files StandardCopyOption]
+   [java.time Instant]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Durable, append-only
+(defn- ^{:stratum 0} ->wire [b] (update b :breach/at #(.toString ^Instant %)))
+
+(defn- ^{:stratum 0} <-wire [m] (update m :breach/at #(Instant/parse %)))
+
+(defn ^{:stratum 0} valid?
+  "True when `b` satisfies the closed Breach schema."
+  [b]
+  (m/validate schema/Breach b))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} history
+  "Every recorded breach under `dir`, optionally narrowed to one
+   principal. Missing directory reads as empty, not as an error — a
+   principal with no history is the normal case."
+  ([dir] (history dir nil))
+  ([dir principal]
+   (let [^File d (io/file dir)
+         xform (comp (filter #(.endsWith (.getName ^File %) ".edn"))
+                     (map #(<-wire (edn/read-string (slurp % :encoding "UTF-8"))))
+                     (filter #(or (nil? principal)
+                                  (= principal (:breach/principal %)))))]
+     (if-not (.isDirectory d)
+       []
+       (into [] xform (.listFiles d))))))
+
+(defn ^{:stratum 1} record!
+  "Append one breach to `dir`. One file per breach, written atomically
+   and never rewritten — the append-only property is structural rather
+   than a rule someone has to remember.
+
+   A malformed breach throws rather than persisting: a history entry
+   nobody can read is worse than a loud failure at the moment of
+   writing, because the alternative is discovering the gap during an
+   audit."
+  [dir b]
+  (when-not (valid? b)
+    (throw (ex-info "breach record failed validation" {:breach b})))
+  (let [^File target (io/file dir (str (:breach/id b) ".edn"))
+        _ (io/make-parents target)
+        ^File tmp (io/file (.getParentFile target) (str (.getName target) ".tmp"))]
+    (spit tmp (pr-str (->wire b)) :encoding "UTF-8")
+    (Files/move (.toPath tmp) (.toPath target)
+                (into-array java.nio.file.CopyOption
+                            [StandardCopyOption/ATOMIC_MOVE
+                             StandardCopyOption/REPLACE_EXISTING]))
+    b))

--- a/components/execution-grant/src/ai/miniforge/execution_grant/breach.clj
+++ b/components/execution-grant/src/ai/miniforge/execution_grant/breach.clj
@@ -36,12 +36,27 @@
   (:import
    [java.io File]
    [java.nio.file Files StandardCopyOption]
-   [java.time Instant]))
+   [java.time Instant]
+   [java.util Date]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
 ;; Durable, append-only
-(defn- ^{:stratum 0} ->wire [b] (update b :breach/at #(.toString ^Instant %)))
+(defn- ^{:stratum 0} ->iso
+  "Timestamp -> ISO-8601, by actual type rather than by type hint.
+
+   `:breach/at` is validated with `inst?`, and `inst?` admits
+   `java.util.Date` as well as `java.time.Instant`. A Date's `.toString`
+   is not ISO-8601, so persisting one would write a value `Instant/parse`
+   cannot read back — corrupting the history at the moment of recording
+   it. Same defect effect-transaction's store carried; fixed there and
+   not swept here until review caught it."
+  ^String [v]
+  (cond
+    (instance? Instant v) (.toString ^Instant v)
+    (instance? Date v) (.toString (.toInstant ^Date v))
+    :else (throw (ex-info "breach timestamp is not a supported instant type"
+                          {:value v :type (some-> v class .getName)}))))
 
 (defn- ^{:stratum 0} <-wire [m] (update m :breach/at #(Instant/parse %)))
 
@@ -51,6 +66,8 @@
   (m/validate schema/Breach b))
 
 ;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} ->wire [b] (update b :breach/at ->iso))
 
 (defn ^{:stratum 1} history
   "Every recorded breach under `dir`, optionally narrowed to one
@@ -67,7 +84,9 @@
        []
        (into [] xform (.listFiles d))))))
 
-(defn ^{:stratum 1} record!
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} record!
   "Append one breach to `dir`. One file per breach, written atomically
    and never rewritten — the append-only property is structural rather
    than a rule someone has to remember.
@@ -89,7 +108,12 @@
         _ (when (.exists target)
             (throw (ex-info "breach id already recorded; history is append-only"
                             {:breach/id (:breach/id b) :path (str target)})))
-        ^File tmp (io/file (.getParentFile target) (str (.getName target) ".tmp"))]
+        ;; Unique per attempt. A deterministic <id>.edn.tmp lets two
+        ;; writers of the same id trample each other before the move,
+        ;; and leaves a lingering partial that reads like evidence
+        ;; during manual inspection.
+        ^File tmp (io/file (.getParentFile target)
+                           (str (.getName target) "." (random-uuid) ".tmp"))]
     (spit tmp (pr-str (->wire b)) :encoding "UTF-8")
     ;; ATOMIC_MOVE WITHOUT REPLACE_EXISTING. Append-only has to be
     ;; enforced by the filesystem, not asserted in a docstring: with

--- a/components/execution-grant/src/ai/miniforge/execution_grant/breach.clj
+++ b/components/execution-grant/src/ai/miniforge/execution_grant/breach.clj
@@ -100,28 +100,26 @@
     (throw (ex-info "breach record failed validation" {:breach b})))
   (let [^File target (io/file dir (str (:breach/id b) ".edn"))
         _ (io/make-parents target)
-        ;; Checked explicitly rather than left to the move. ATOMIC_MOVE
-        ;; without REPLACE_EXISTING is documented as implementation-
-        ;; specific when the target exists, and on POSIX it lowers to
-        ;; rename(2), which overwrites silently. Append-only cannot rest
-        ;; on a guarantee the platform does not actually make.
-        _ (when (.exists target)
-            (throw (ex-info "breach id already recorded; history is append-only"
-                            {:breach/id (:breach/id b) :path (str target)})))
         ;; Unique per attempt. A deterministic <id>.edn.tmp lets two
-        ;; writers of the same id trample each other before the move,
-        ;; and leaves a lingering partial that reads like evidence
-        ;; during manual inspection.
+        ;; writers of the same id trample each other's partial before it
+        ;; is published, and leaves a lingering file that reads like
+        ;; evidence during manual inspection.
         ^File tmp (io/file (.getParentFile target)
                            (str (.getName target) "." (random-uuid) ".tmp"))]
     (spit tmp (pr-str (->wire b)) :encoding "UTF-8")
-    ;; ATOMIC_MOVE WITHOUT REPLACE_EXISTING. Append-only has to be
-    ;; enforced by the filesystem, not asserted in a docstring: with
-    ;; REPLACE_EXISTING a reused :breach/id would silently overwrite an
-    ;; earlier breach, which is precisely the edit this record exists to
-    ;; make impossible. The move throws FileAlreadyExistsException
-    ;; instead, and the caller learns rather than losing evidence.
-    (Files/move (.toPath tmp) (.toPath target)
-                (into-array java.nio.file.CopyOption
-                            [StandardCopyOption/ATOMIC_MOVE]))
+    ;; Write the temp in full, then hard-link it into place.
+    ;; `createLink` is atomic AND exclusive: it throws
+    ;; FileAlreadyExistsException when the target exists, in ONE
+    ;; operation, so there is no window between checking and creating.
+    ;;
+    ;; Both obvious alternatives fail. `Files/move` with ATOMIC_MOVE
+    ;; lowers to rename(2) on POSIX, which overwrites silently. An
+    ;; `(.exists target)` pre-check is TOCTOU — two writers of the same
+    ;; id both pass it and the second rename wins. Append-only has to be
+    ;; one indivisible operation or it is not a guarantee, only a hope
+    ;; with good intentions.
+    (try
+      (Files/createLink (.toPath target) (.toPath tmp))
+      (finally
+        (.delete tmp)))
     b))

--- a/components/execution-grant/src/ai/miniforge/execution_grant/breach.clj
+++ b/components/execution-grant/src/ai/miniforge/execution_grant/breach.clj
@@ -29,7 +29,6 @@
    Append-only by construction: one file per breach, never rewritten.
    A history you can edit is a history that stops being evidence."
   (:require
-   [ai.miniforge.execution-grant.core :as core]
    [ai.miniforge.execution-grant.schema :as schema]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
@@ -82,10 +81,23 @@
     (throw (ex-info "breach record failed validation" {:breach b})))
   (let [^File target (io/file dir (str (:breach/id b) ".edn"))
         _ (io/make-parents target)
+        ;; Checked explicitly rather than left to the move. ATOMIC_MOVE
+        ;; without REPLACE_EXISTING is documented as implementation-
+        ;; specific when the target exists, and on POSIX it lowers to
+        ;; rename(2), which overwrites silently. Append-only cannot rest
+        ;; on a guarantee the platform does not actually make.
+        _ (when (.exists target)
+            (throw (ex-info "breach id already recorded; history is append-only"
+                            {:breach/id (:breach/id b) :path (str target)})))
         ^File tmp (io/file (.getParentFile target) (str (.getName target) ".tmp"))]
     (spit tmp (pr-str (->wire b)) :encoding "UTF-8")
+    ;; ATOMIC_MOVE WITHOUT REPLACE_EXISTING. Append-only has to be
+    ;; enforced by the filesystem, not asserted in a docstring: with
+    ;; REPLACE_EXISTING a reused :breach/id would silently overwrite an
+    ;; earlier breach, which is precisely the edit this record exists to
+    ;; make impossible. The move throws FileAlreadyExistsException
+    ;; instead, and the caller learns rather than losing evidence.
     (Files/move (.toPath tmp) (.toPath target)
                 (into-array java.nio.file.CopyOption
-                            [StandardCopyOption/ATOMIC_MOVE
-                             StandardCopyOption/REPLACE_EXISTING]))
+                            [StandardCopyOption/ATOMIC_MOVE]))
     b))

--- a/components/execution-grant/src/ai/miniforge/execution_grant/eligibility.clj
+++ b/components/execution-grant/src/ai/miniforge/execution_grant/eligibility.clj
@@ -1,0 +1,105 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.execution-grant.eligibility
+  "What a principal's breach history permits them to be granted next
+   (Ariadne step 2e, §13.5), and the revocation that writes to it.
+
+   The rule here is a POLICY CHOICE, not a derivation. It is stated
+   plainly in `permitted-ceiling` so it can be argued with rather than
+   absorbed by whoever reads the code next."
+  (:require
+   [ai.miniforge.execution-grant.breach :as breach]
+   [ai.miniforge.execution-grant.core :as core]
+   [ai.miniforge.execution-grant.schema :as schema])
+  (:import
+   [java.time Instant]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} permitted-ceiling
+  "The highest ceiling this principal may now be granted on `axis` for
+   `effect-class`, or nil for unbounded (no relevant history).
+
+   DAY-ONE RULE, and a policy choice rather than a derivation: a
+   principal who blew through a limit may not be handed that limit
+   again. The cap becomes the lowest limit they breached. Strictly
+   smaller ceilings stay available, so the path back is narrower
+   authority rather than a permanent ban.
+
+   What it deliberately does NOT do is decay with time or forgive after
+   N clean runs. Both are reasonable; both need a decision this spec
+   does not own, and guessing one here would bury it."
+  [dir principal effect-class axis]
+  (let [limits (into []
+                     (comp (filter #(and (= effect-class (:breach/effect-class %))
+                                         (= axis (:breach/axis %))))
+                           (map :breach/limit))
+                     (breach/history dir principal))]
+    (when (seq limits) (apply min limits))))
+
+(defn ^{:stratum 0} revoke-for-cause!
+  "End a grant BECAUSE of a breach, and remember it.
+
+   Two effects that must not drift apart: the grant carries the cause on
+   `:grant/revocation-reason`, and the history carries the numbers —
+   which axis, what limit, what was observed, and whether a gate
+   prevented it or reconciliation merely found it.
+
+   Revocation is transitive over lineage (2a's `active?` walks
+   ancestors), so ending a parent ends everything cut from it. That is
+   what makes a delegated inner orchestrator containable rather than
+   merely instructed.
+
+   The breach is recorded FIRST. If the history write fails the caller
+   must learn the breach went unrecorded, rather than discover a revoked
+   grant with no reason behind it."
+  [dir grant {:keys [axis limit observed detection]} ^Instant now]
+  (let [b {:breach/id (random-uuid)
+           :breach/principal (:grant/principal grant)
+           :breach/grant-id (:grant/id grant)
+           :breach/effect-class (:grant/effect-class grant)
+           :breach/axis axis
+           :breach/limit limit
+           :breach/observed observed
+           :breach/detection detection
+           :breach/at now}
+        reason (case axis
+                 :constraint/max-cost-usd :breach/cost-exceeded
+                 :constraint/max-tokens :breach/token-exceeded
+                 :constraint/max-count :breach/count-exceeded
+                 :breach/scope-violation)]
+    (breach/record! dir b)
+    (core/revoke grant reason now)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} eligible?
+  "May this principal be granted `effect-class` at `constraints`?
+
+   False when any requested ceiling reaches or exceeds one they have
+   already breached. An unbounded request (axis absent) against a
+   principal WITH history on that axis is also refused — asking for no
+   limit after breaching a limit is the widest request there is, not an
+   abstention."
+  [dir principal effect-class constraints]
+  (every? (fn [axis]
+            (if-let [cap (permitted-ceiling dir principal effect-class axis)]
+              (let [requested (get constraints axis)]
+                (and (some? requested) (number? requested) (< requested cap)))
+              true))
+          schema/constraint-axes))

--- a/components/execution-grant/src/ai/miniforge/execution_grant/interface.clj
+++ b/components/execution-grant/src/ai/miniforge/execution_grant/interface.clj
@@ -25,6 +25,8 @@
    liveness over lineage."
   (:require
    [ai.miniforge.execution-grant.attenuation :as attenuation]
+   [ai.miniforge.execution-grant.breach :as breach]
+   [ai.miniforge.execution-grant.eligibility :as eligibility]
    [ai.miniforge.execution-grant.constraints :as constraints]
    [ai.miniforge.execution-grant.core :as core]
    [ai.miniforge.execution-grant.lineage :as lineage]
@@ -108,3 +110,34 @@
 (def ^{:stratum 0} budget->constraints
   "Translate a legacy budget map into `:grant/constraints`."
   constraints/budget->constraints)
+
+(def ^{:stratum 0} Breach
+  "Closed Malli schema for a recorded breach."
+  schema/Breach)
+
+(def ^{:stratum 0} detections
+  "How a breach came to light: :prevented (a gate refused first) or
+   :detected (reconciliation found it after the effect)."
+  schema/detections)
+
+(def ^{:stratum 0} record-breach!
+  "Append one breach to the history. One file per breach, never
+   rewritten — append-only by construction."
+  breach/record!)
+
+(def ^{:stratum 0} breach-history
+  "Every recorded breach, optionally narrowed to one principal."
+  breach/history)
+
+(def ^{:stratum 0} permitted-ceiling
+  "The highest ceiling a principal may now be granted on an axis, or nil
+   for unbounded."
+  eligibility/permitted-ceiling)
+
+(def ^{:stratum 0} eligible?
+  "May this principal be granted this effect class at these ceilings?"
+  eligibility/eligible?)
+
+(def ^{:stratum 0} revoke-for-cause!
+  "Revoke a grant AND record the breach that caused it."
+  eligibility/revoke-for-cause!)

--- a/components/execution-grant/src/ai/miniforge/execution_grant/schema.clj
+++ b/components/execution-grant/src/ai/miniforge/execution_grant/schema.clj
@@ -83,6 +83,15 @@
    `delegate` checks."
   [:map-of :keyword any?])
 
+(def ^{:stratum 0} detections
+  "How a breach came to light (Ariadne 2e).
+
+   `:prevented` — a gate refused before the effect happened.
+   `:detected`  — reconciliation found it afterwards; the effect already
+                  occurred. Recording this as `:prevented` would claim a
+                  gate that does not exist."
+  [:prevented :detected])
+
 ;------------------------------------------------------------------------------ Layer 1
 
 ;; The grant
@@ -111,3 +120,16 @@
    [:grant/expires-at inst?]
    [:grant/revoked-at [:maybe inst?]]
    [:grant/revocation-reason [:maybe (into [:enum] revocation-reasons)]]])
+
+(def ^{:stratum 1} Breach
+  "CLOSED record of one ceiling a principal exceeded (Ariadne 2e)."
+  [:map {:closed true}
+   [:breach/id :uuid]
+   [:breach/principal :string]
+   [:breach/grant-id :uuid]
+   [:breach/effect-class (into [:enum] effect-classes)]
+   [:breach/axis (into [:enum] constraint-axes)]
+   [:breach/limit number?]
+   [:breach/observed number?]
+   [:breach/detection (into [:enum] detections)]
+   [:breach/at inst?]])

--- a/components/execution-grant/test/ai/miniforge/execution_grant/breach_test.clj
+++ b/components/execution-grant/test/ai/miniforge/execution_grant/breach_test.clj
@@ -1,0 +1,129 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.execution-grant.breach-test
+  (:require
+   [ai.miniforge.execution-grant.interface :as grant]
+   [clojure.test :refer [deftest is testing]])
+  (:import
+   [java.nio.file Files]
+   [java.nio.file.attribute FileAttribute]
+   [java.time Instant]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} now (Instant/parse "2026-08-01T00:00:00Z"))
+
+(def ^{:stratum 0} later (Instant/parse "2026-08-01T01:00:00Z"))
+
+(def ^{:stratum 0} much-later (Instant/parse "2026-08-02T00:00:00Z"))
+
+(defn ^{:stratum 0} tmp-dir []
+  (str (.toFile (Files/createTempDirectory "breach" (into-array FileAttribute [])))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} spend-grant
+  ([] (spend-grant {}))
+  ([overrides]
+   (grant/issue (merge {:principal "agent:implementer"
+                        :effect-class :effect/spend
+                        :scope {}
+                        :constraints {:constraint/max-cost-usd 5.0}
+                        :delegable? true
+                        :expires-at much-later}
+                       overrides)
+                now)))
+
+(deftest ^{:stratum 1} malformed-breach-is-refused-test
+  (let [dir (tmp-dir)]
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (grant/record-breach! dir {:breach/id (random-uuid)})))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} revoke-for-cause-ends-the-grant-and-remembers-test
+  (let [dir (tmp-dir)
+        g (spend-grant)
+        revoked (grant/revoke-for-cause! dir g
+                                         {:axis :constraint/max-cost-usd
+                                          :limit 5.0 :observed 9.0
+                                          :detection :detected}
+                                         later)]
+    (testing "the grant carries the cause"
+      (is (grant/revoked? revoked))
+      (is (= :breach/cost-exceeded (:grant/revocation-reason revoked)))
+      (is (not (grant/active? revoked later))))
+    (testing "the history carries the numbers"
+      (let [[b :as all] (grant/breach-history dir "agent:implementer")]
+        (is (= 1 (count all)))
+        (is (= 5.0 (:breach/limit b)))
+        (is (= 9.0 (:breach/observed b)))
+        (is (= :constraint/max-cost-usd (:breach/axis b)))
+        (is (= later (:breach/at b)))))))
+
+(deftest ^{:stratum 2} prevented-and-detected-stay-distinguishable-test
+  ;; A governance product that reports a breach it merely NOTICED as one
+  ;; it PREVENTED is claiming a gate it does not have.
+  (let [dir (tmp-dir)]
+    (grant/revoke-for-cause! dir (spend-grant)
+                             {:axis :constraint/max-cost-usd :limit 5.0
+                              :observed 6.0 :detection :prevented} later)
+    (grant/revoke-for-cause! dir (spend-grant {:principal "agent:other"})
+                             {:axis :constraint/max-cost-usd :limit 5.0
+                              :observed 7.0 :detection :detected} later)
+    (let [all (grant/breach-history dir)]
+      (is (= #{:prevented :detected} (set (map :breach/detection all)))))))
+
+(deftest ^{:stratum 2} history-is-append-only-and-per-principal-test
+  (let [dir (tmp-dir)]
+    (dotimes [_ 3]
+      (grant/revoke-for-cause! dir (spend-grant)
+                               {:axis :constraint/max-cost-usd :limit 5.0
+                                :observed 6.0 :detection :detected} later))
+    (grant/revoke-for-cause! dir (spend-grant {:principal "agent:other"})
+                             {:axis :constraint/max-cost-usd :limit 5.0
+                              :observed 6.0 :detection :detected} later)
+    (testing "every breach is kept — later ones never overwrite earlier"
+      (is (= 4 (count (grant/breach-history dir)))))
+    (testing "history narrows by principal"
+      (is (= 3 (count (grant/breach-history dir "agent:implementer"))))
+      (is (= 1 (count (grant/breach-history dir "agent:other")))))
+    (testing "a principal with no history reads empty, not an error"
+      (is (= [] (grant/breach-history dir "agent:never-breached")))
+      (is (= [] (grant/breach-history (str dir "/nope")))))))
+
+(deftest ^{:stratum 2} a-breacher-cannot-immediately-re-obtain-the-ceiling-test
+  (let [dir (tmp-dir)
+        p "agent:implementer"]
+    (testing "with no history, anything is eligible"
+      (is (grant/eligible? dir p :effect/spend {:constraint/max-cost-usd 100.0})))
+    (grant/revoke-for-cause! dir (spend-grant)
+                             {:axis :constraint/max-cost-usd :limit 5.0
+                              :observed 9.0 :detection :detected} later)
+    (testing "the breached ceiling is refused, and so is anything above it"
+      (is (not (grant/eligible? dir p :effect/spend {:constraint/max-cost-usd 5.0})))
+      (is (not (grant/eligible? dir p :effect/spend {:constraint/max-cost-usd 50.0}))))
+    (testing "a strictly smaller ceiling is still available — narrower, not banned"
+      (is (grant/eligible? dir p :effect/spend {:constraint/max-cost-usd 1.0})))
+    (testing "asking for NO limit after breaching one is the widest request, not an abstention"
+      (is (not (grant/eligible? dir p :effect/spend {}))))
+    (testing "the cap is per effect class"
+      (is (grant/eligible? dir p :effect/merge {:constraint/max-cost-usd 50.0})))
+    (testing "and per principal"
+      (is (grant/eligible? dir "agent:clean" :effect/spend {:constraint/max-cost-usd 50.0})))
+    (is (= 5.0 (grant/permitted-ceiling dir p :effect/spend :constraint/max-cost-usd)))))

--- a/components/execution-grant/test/ai/miniforge/execution_grant/breach_test.clj
+++ b/components/execution-grant/test/ai/miniforge/execution_grant/breach_test.clj
@@ -54,6 +54,26 @@
     (is (thrown? clojure.lang.ExceptionInfo
                  (grant/record-breach! dir {:breach/id (random-uuid)})))))
 
+(deftest ^{:stratum 1} a-reused-breach-id-cannot-overwrite-history-test
+  ;; Append-only must be enforced by the filesystem, not asserted in a
+  ;; docstring. A reused id silently replacing an earlier breach is the
+  ;; exact edit this record exists to make impossible.
+  (let [dir (tmp-dir)
+        b {:breach/id (random-uuid)
+           :breach/principal "agent:x"
+           :breach/grant-id (random-uuid)
+           :breach/effect-class :effect/spend
+           :breach/axis :constraint/max-cost-usd
+           :breach/limit 5.0
+           :breach/observed 9.0
+           :breach/detection :detected
+           :breach/at now}]
+    (grant/record-breach! dir b)
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (grant/record-breach! dir (assoc b :breach/observed 1.0))))
+    (testing "the original survives untouched"
+      (is (= 9.0 (:breach/observed (first (grant/breach-history dir "agent:x"))))))))
+
 ;------------------------------------------------------------------------------ Layer 2
 
 (deftest ^{:stratum 2} revoke-for-cause-ends-the-grant-and-remembers-test

--- a/components/execution-grant/test/ai/miniforge/execution_grant/breach_test.clj
+++ b/components/execution-grant/test/ai/miniforge/execution_grant/breach_test.clj
@@ -69,7 +69,7 @@
            :breach/detection :detected
            :breach/at now}]
     (grant/record-breach! dir b)
-    (is (thrown? clojure.lang.ExceptionInfo
+    (is (thrown? java.nio.file.FileAlreadyExistsException
                  (grant/record-breach! dir (assoc b :breach/observed 1.0))))
     (testing "the original survives untouched"
       (is (= 9.0 (:breach/observed (first (grant/breach-history dir "agent:x"))))))))

--- a/components/execution-grant/test/ai/miniforge/execution_grant/breach_test.clj
+++ b/components/execution-grant/test/ai/miniforge/execution_grant/breach_test.clj
@@ -74,6 +74,36 @@
     (testing "the original survives untouched"
       (is (= 9.0 (:breach/observed (first (grant/breach-history dir "agent:x"))))))))
 
+(deftest ^{:stratum 1} both-inst-types-round-trip-test
+  ;; inst? admits java.util.Date as well as Instant, so a breach the
+  ;; schema ACCEPTS can arrive holding either. A Date's .toString is not
+  ;; ISO-8601 and would corrupt the history at the moment of recording.
+  (let [dir (tmp-dir)
+        base {:breach/principal "agent:x"
+              :breach/grant-id (random-uuid)
+              :breach/effect-class :effect/spend
+              :breach/axis :constraint/max-cost-usd
+              :breach/limit 5.0 :breach/observed 9.0
+              :breach/detection :detected}
+        as-date (assoc base :breach/id (random-uuid)
+                       :breach/at (java.util.Date/from now))
+        as-instant (assoc base :breach/id (random-uuid) :breach/at now)]
+    (grant/record-breach! dir as-date)
+    (grant/record-breach! dir as-instant)
+    (is (= [now now] (mapv :breach/at (grant/breach-history dir "agent:x")))
+        "a Date normalizes to the same instant on the way out"))
+  (testing "an unsupported timestamp throws rather than corrupting the history"
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (grant/record-breach! (tmp-dir)
+                                       {:breach/id (random-uuid)
+                                        :breach/principal "p"
+                                        :breach/grant-id (random-uuid)
+                                        :breach/effect-class :effect/spend
+                                        :breach/axis :constraint/max-cost-usd
+                                        :breach/limit 1.0 :breach/observed 2.0
+                                        :breach/detection :detected
+                                        :breach/at "nope"})))))
+
 ;------------------------------------------------------------------------------ Layer 2
 
 (deftest ^{:stratum 2} revoke-for-cause-ends-the-grant-and-remembers-test


### PR DESCRIPTION
Implements `work/ariadne-revocation-for-cause.spec.edn` — step 2e of the [Ariadne adoption](docs/architecture/rfc-ariadne-adoption.md).

A ceiling that can be re-passed is not a ceiling. This makes a breach end the grant, and makes the ending remembered.

## The honest half

Gates prevent what they can; logbooks catch the rest. Some conditions cannot be checked before the fact — a cost that materializes mid-stream, an effect whose true outcome arrives later. Those are found by reconciliation, *after* the effect.

So every breach records **which it was**: `:prevented` (a gate refused first) or `:detected` (we merely noticed). A governance product that reports the second as the first is claiming a gate it does not have.

## Append-only by construction

One file per breach, written atomically, never rewritten. The property is structural rather than a rule someone has to remember — a history you can edit is a history that stops being evidence.

## The eligibility rule is a policy choice, and says so

`permitted-ceiling` states its rule in the docstring rather than burying it: a principal who blew through a limit may not be handed that limit again; the cap becomes the lowest limit they breached. Strictly smaller ceilings stay available, so the path back is **narrower authority, not a permanent ban**.

It deliberately does **not** decay with time or forgive after N clean runs. Both are reasonable. Both need a decision this spec does not own, and quietly picking one would bury it.

One consequence worth naming: asking for **no** limit after breaching one is refused. That is the widest request there is, not an abstention.

## Revocation keeps two records in step

`revoke-for-cause!` writes the cause onto the grant and the numbers into the history — axis, limit, observed, detection. The breach is recorded **first**, so a failed history write cannot leave a revoked grant with no reason behind it.

Revocation is transitive over lineage (2a's `active?` walks ancestors), which is what makes a delegated inner orchestrator containable rather than merely instructed.

## Scope

The eligibility predicate is built and tested but has **no production caller** — grant *issuance* is its only intended call site, and nothing issues grants yet. That gap is specced in `work/ariadne-grant-issuance.spec.edn`, opened alongside this in the 2d PR.

Per the spec's own scope note, `connector-retry`'s circuit breaker is not revived or extended here: it is an unconsumed HTTP breaker, and reusing it for authority would be the wrong seam.

## Verification

21 tests / 108 assertions across the grant component. `bb poly:check` 0 errors; `bb lint:clj` 0/0; `bb lint:stratum` clean at ≤3 layers.

The `Breach` schema lives in `schema.clj` with the component's other schemas — keeping it in `breach.clj` pushed that file to four strata, and `schema.clj` was the right home rather than a workaround.

Three sliced commits: history → eligibility and revocation → tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)