### PR TITLE
feat(pr-lifecycle): a merge is not merged until GitHub says so (Ariadne 2d, merge half)

### DIFF
--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/core.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/core.clj
@@ -166,12 +166,23 @@
    component exists to make impossible. Refused, and the effect does not
    fire.
 
+   Passing `:authority/unenforced` in place of a grant skips every
+   authority check and stamps `:effect/authority :unenforced` on the
+   record. That is the honest state of the world today: nothing in
+   production ISSUES a grant (see
+   `work/ariadne-grant-issuance.spec.edn`), so requiring one would deny
+   every merge and deploy permanently. It is spelled out rather than
+   accepted as a silent nil so it greps, and so the record says plainly
+   that no authority was checked instead of leaving a blank that later
+   reads as approval. Remove it when issuance lands.
+
    JVM `Error`s are NOT caught. An OutOfMemoryError is not an effect
    outcome, and the record is already `:committing` on disk before
    `effect-fn` runs, so letting it propagate leaves precisely the state
    reconciliation is built for."
   [dir t grant-record usage ^Instant now effect-fn]
-  (let [auth (grant/authorize grant-record usage now)]
+  (let [unenforced? (= :authority/unenforced grant-record)
+        auth (when-not unenforced? (grant/authorize grant-record usage now))]
     (cond
       (not= :proposed (:effect/state t))
       (wrong-state "only a :proposed record may be committed"
@@ -182,27 +193,31 @@
       ;; proposal never claimed — propose under a narrow grant, commit
       ;; under a broad one, and the audit trail records a lie. The
       ;; re-check is only worth anything if it re-checks the SAME grant.
-      (not= (:effect/grant-id t) (:grant/id grant-record))
+      (and (not unenforced?) (not= (:effect/grant-id t) (:grant/id grant-record)))
       (wrong-state "grant does not match the one recorded on the proposal"
                    {:effect/id (:effect/id t)
                     :effect/grant-id (:effect/grant-id t)
                     :grant/id (:grant/id grant-record)})
 
       ;; Likewise the class: a merge grant must not authorize a deploy.
-      (not= (:effect/class t) (:grant/effect-class grant-record))
+      (and (not unenforced?) (not= (:effect/class t) (:grant/effect-class grant-record)))
       (wrong-state "grant effect-class does not match the proposed effect"
                    {:effect/id (:effect/id t)
                     :effect/class (:effect/class t)
                     :grant/effect-class (:grant/effect-class grant-record)})
 
-      (not (grant/authorized? auth))
+      (and (not unenforced?) (not (grant/authorized? auth)))
       (advance! dir t {:effect/state :failed
                        :effect/failure (str "grant re-check failed at commit: "
                                             (name (:grant/outcome auth)))}
                 now)
 
       :else
-      (let [committing (advance! dir t {:effect/state :committing} now)]
+      (let [committing (advance! dir t {:effect/state :committing
+                                        :effect/authority (if unenforced?
+                                                            :unenforced
+                                                            :granted)}
+                                 now)]
         (if (anomaly/anomaly? committing)
           committing
           (let [reported (try

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/schema.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/schema.clj
@@ -75,6 +75,12 @@
    [:effect/envelope-id {:optional true} [:maybe :uuid]]
    [:effect/proposal [:map-of :keyword any?]]
    [:effect/state (into [:enum] states)]
+   ;; Whether authority was CHECKED for this effect. `:unenforced` is
+   ;; the honest record that it was not — nothing in production issues
+   ;; grants yet (see work/ariadne-grant-issuance.spec.edn), so an
+   ;; effect performed today carries no authority claim. Recording that
+   ;; in the data beats a silent nil-skip that later reads as approval.
+   [:effect/authority {:optional true} [:enum :granted :unenforced]]
    [:effect/observed {:optional true} any?]
    [:effect/matched? {:optional true} [:maybe :boolean]]
    [:effect/failure {:optional true} [:maybe :string]]

--- a/components/pr-lifecycle/deps.edn
+++ b/components/pr-lifecycle/deps.edn
@@ -1,6 +1,7 @@
 {:paths ["src" "resources"]
  :deps {ai.miniforge/anomaly {:local/root "../anomaly"}
         ai.miniforge/config {:local/root "../config"}
+        ai.miniforge/effect-transaction {:local/root "../effect-transaction"}
         ai.miniforge/dag-executor {:local/root "../dag-executor"}
         ai.miniforge/fsm {:local/root "../fsm"}
         ai.miniforge/messages {:local/root "../messages"}

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/controller.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/controller.clj
@@ -419,7 +419,17 @@
             (log/info logger :pr-lifecycle :controller/merged
                       {:message (messages/t :controller/merged)
                        :data {:pr-id (:pr/id pr)}})))
-        (add-history! controller :merge-blocked {:reason (:error merge-result)}))
+        (if (:auto-merge/enabled? (:data merge-result))
+          ;; Auto-merge is enabled and GitHub has not reported a merge
+          ;; yet. That is PENDING, not blocked — nothing is wrong and
+          ;; nothing needs an operator; the transaction record stays
+          ;; reconcilable and a later pass asks GitHub again.
+          (do
+            (update-status! controller :merge-pending)
+            (add-history! controller :merge-pending
+                          {:pr-id (:pr/id pr)
+                           :effect/id (:effect/id (:data merge-result))}))
+          (add-history! controller :merge-blocked {:reason (:error merge-result)})))
       merge-result)))
 
 ;------------------------------------------------------------------------------ Layer 4
@@ -615,11 +625,23 @@
                 (let [merge-result (attempt-merge! controller)]
                   (if (and (dag/ok? merge-result) (:merged? (:data merge-result)))
                     {:status :merged}
-                    (if (:rebased? (:data merge-result))
+                    (cond
+                      (:rebased? (:data merge-result))
                       ;; Rebased - need to wait for CI again
                       (do
                         (start-ci-monitoring! controller)
                         (recur))
+
+                      ;; Auto-merge accepted, merge not yet observed.
+                      ;; Reporting this as :blocked would tell the
+                      ;; operator something is wrong when nothing is —
+                      ;; the merge is in GitHub's hands and the record
+                      ;; is reconcilable.
+                      (:auto-merge/enabled? (:data merge-result))
+                      {:status :merge-pending
+                       :effect/id (:effect/id (:data merge-result))}
+
+                      :else
                       {:status :blocked :reason :merge-blocked})))
 
                 :changes-requested

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge.clj
@@ -447,8 +447,11 @@
               enable! (fn []
                         (let [r (merge-pr! worktree-path pr-number :policy policy)]
                           {:ok? (dag/ok? r) :error (:error r)}))
-              proposed (merge-transaction/propose! context pr-number
-                                                   (:pr/repo context) now)
+              ;; The method is known from policy; the proposal must record
+              ;; what was actually requested, not nil.
+              proposed (merge-transaction/propose!
+                        (assoc context :merge/method (:method policy))
+                        pr-number (:pr/repo context) now)
               settled (merge-transaction/commit! context proposed pr-number
                                                  now enable! run-gh)
               merge-sha (merge-transaction/substantiated-sha settled)]

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge.clj
@@ -24,12 +24,15 @@
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.pr-lifecycle.conflict-resolution :as conflict-resolution]
+   [ai.miniforge.pr-lifecycle.merge-transaction :as merge-transaction]
    [ai.miniforge.pr-lifecycle.events :as events]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.response.interface :as response]
    [babashka.process :as process]
    [cheshire.core :as json]
-   [clojure.string :as str]))
+   [clojure.string :as str])
+  (:import
+   [java.time Instant]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -432,35 +435,65 @@
     (let [readiness (evaluate-merge-readiness worktree-path pr-number policy)]
       (if (:ready? readiness)
         ;; Ready to merge - attempt it
-        (let [merge-result (merge-pr! worktree-path pr-number :policy policy)]
-          (if (dag/ok? merge-result)
+        ;; Transacted (Ariadne 2d): the intent is recorded BEFORE any gh
+        ;; command, enabling auto-merge is recorded as a request accepted
+        ;; rather than a merge performed, and the merged event fires only
+        ;; against a merge GitHub actually reports — carrying GitHub's
+        ;; mergeCommit, never a SHA read from the local worktree.
+        (let [now (Instant/now)
+              run-gh (fn [args]
+                       (let [r (run-gh-command args worktree-path)]
+                         {:ok? (dag/ok? r) :output (:output (:data r))}))
+              enable! (fn []
+                        (let [r (merge-pr! worktree-path pr-number :policy policy)]
+                          {:ok? (dag/ok? r) :error (:error r)}))
+              proposed (merge-transaction/propose! context pr-number
+                                                   (:pr/repo context) now)
+              settled (merge-transaction/commit! context proposed pr-number
+                                                 now enable! run-gh)
+              merge-sha (merge-transaction/substantiated-sha settled)]
+          (cond
+            (= :failed (:effect/state settled))
+            (dag/err :merge-failed
+                     "Merge command failed"
+                     {:gh-error (:effect/failure settled)})
+
+            merge-sha
             (do
               ;; Publish merged event with the PR's labels so downstream
               ;; watchers (label-actions M2) can match without re-querying
               ;; GitHub. Label fetch is best-effort — missing labels
               ;; default to #{}, never block the merge event.
               (when event-bus
-                (let [sha-result (run-gh-command
-                                  ["git" "rev-parse" "HEAD"]
-                                  worktree-path)
-                      merge-sha (when (dag/ok? sha-result)
-                                  (:output (:data sha-result)))
-                      labels (fetch-pr-labels! worktree-path pr-number)]
-                  (events/publish! event-bus
-                                   (events/merged dag-id run-id task-id pr-id
-                                                  merge-sha labels)
-                                   logger)))
+                (events/publish! event-bus
+                                 (events/merged dag-id run-id task-id pr-id
+                                                merge-sha
+                                                (fetch-pr-labels! worktree-path pr-number))
+                                 logger))
               (when logger
                 (log/info logger :pr-lifecycle :merge/success
                           {:message "PR merged successfully"
-                           :data {:pr-number pr-number}}))
+                           :data {:pr-number pr-number :merge/sha merge-sha}}))
               (dag/ok {:merged? true
-                       :method (:method policy)}))
+                       :method (:method policy)
+                       :merge/sha merge-sha
+                       :effect/id (:effect/id settled)}))
 
-            ;; Merge failed
-            (dag/err :merge-failed
-                     "Merge command failed"
-                     {:gh-error (:error merge-result)})))
+            :else
+            ;; Auto-merge is enabled and GitHub has not reported a merge.
+            ;; Saying {:merged? true} here is the specific lie this
+            ;; change removes; the record stays reconcilable and a later
+            ;; pass asks again.
+            (do
+              (when logger
+                (log/info logger :pr-lifecycle :merge/auto-merge-pending
+                          {:message "Auto-merge enabled; merge not yet observed"
+                           :data {:pr-number pr-number
+                                  :effect/state (:effect/state settled)}}))
+              (dag/ok {:merged? false
+                       :auto-merge/enabled? true
+                       :method (:method policy)
+                       :effect/id (:effect/id settled)}))))
 
         ;; Not ready — branch-not-up-to-date may mean either
         ;; CONFLICTING (Stage 3 §6.4 hook engages) or BEHIND (auto-

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge_transaction.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge_transaction.clj
@@ -1,0 +1,163 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.pr-lifecycle.merge-transaction
+  "PR merge as a transacted effect (Ariadne step 2d, part 1).
+
+   What this fixes. `merge-pr!` appends `--auto` UNCONDITIONALLY, so a
+   zero exit means auto-merge was ENABLED, not that anything merged.
+   The old path read that as `{:merged? true}` and published a merged
+   event carrying a SHA from `git rev-parse HEAD` in the local worktree
+   — the branch tip, not the squash commit on base. Two claims the code
+   could not substantiate.
+
+   Here, enabling auto-merge is recorded as what it is: a request
+   accepted, outcome not yet known. GitHub is then asked. A merged event
+   is published only against an observed merge, carrying the mergeCommit
+   GitHub reports. When the answer is 'not yet', the record stays
+   reconcilable and a later pass asks again.
+
+   Grants are NOT enforced here. 2a built the grant object and 2b made
+   `decide()` check it, but nothing in production ISSUES one — requiring
+   a grant today would deny every merge permanently. That half waits on
+   the issuance spec (`work/ariadne-grant-issuance.spec.edn`); this half
+   stops the lying, which does not need to wait."
+  (:require
+   [ai.miniforge.effect-transaction.interface :as fx]
+   [cheshire.core :as json])
+  (:import
+   [java.time Instant]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Configuration
+(def ^{:stratum 0} default-store-dir-property
+  "Where merge transaction records live when the caller names no store.
+
+   Deliberately an explicit path under the miniforge home rather than a
+   relative one: a durability record written to whatever directory the
+   process happened to start in is an audit trail nobody can find."
+  ".miniforge/effects")
+
+(defn ^{:stratum 0} merged-state?
+  "True when GitHub reports the PR as merged. GitHub is the authority on
+   whether a merge happened; nothing local is."
+  [observed]
+  (= "MERGED" (:pr/state observed)))
+
+;; Asking GitHub
+(defn ^{:stratum 0} parse-pr-view
+  "Parse `gh pr view --json state,mergeCommit` output into the observed
+   shape. A response we cannot parse yields nil — treated upstream as
+   'did not answer', never as 'not merged'."
+  [json-str]
+  (try
+    (let [m (json/parse-string json-str true)]
+      (when (:state m)
+        {:pr/state (:state m)
+         :merge/sha (get-in m [:mergeCommit :oid])}))
+    (catch Exception _ nil)))
+
+(defn ^{:stratum 0} substantiated-sha
+  "The merge SHA from a settled record, or nil.
+
+   Two paths substantiate a SHA: a commit whose immediate probe already
+   saw MERGED (`:succeeded`), and a later `reconcile!` that observed one
+   (`:effect/matched?`). Everything else — pending, failed, unresolved,
+   or an anomaly — yields nil.
+
+   nil is the correct answer for an unmerged or unresolved transaction:
+   a SHA the code cannot substantiate does not get published, which is
+   the specific habit this namespace exists to break."
+  [t]
+  (when (and (map? t)
+             (or (= :succeeded (:effect/state t))
+                 (:effect/matched? t)))
+    (get-in t [:effect/observed :merge/sha])))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} store-dir
+  "Resolve the effect store from `context`, falling back to the
+   miniforge home. Never relative to the process working directory."
+  [context]
+  (or (:effect-store-dir context)
+      (str (System/getProperty "user.home") "/" default-store-dir-property)))
+
+(defn ^{:stratum 1} probe
+  "Ask GitHub what actually happened to this PR. `run-gh` is injected so
+   callers and tests supply the shell; it returns `{:ok? bool :output s}`.
+
+   Returns the `reconcile!` answer shape, or nil when GitHub did not
+   answer — which leaves the record unresolved rather than asserting a
+   negative we did not observe."
+  [run-gh pr-number]
+  (let [{:keys [ok? output]} (run-gh ["gh" "pr" "view" (str pr-number)
+                                      "--json" "state,mergeCommit"])]
+    (when ok?
+      (when-let [observed (parse-pr-view output)]
+        {:effect/observed observed
+         :effect/matched? (merged-state? observed)}))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; The transaction
+(defn ^{:stratum 2} propose!
+  "Record the intent to merge, durably, before any gh command runs."
+  [context pr-number repo now]
+  (fx/propose! (store-dir context)
+               {:effect-class :effect/merge
+                :grant-id nil
+                :proposal {:pr/repo repo
+                           :pr/number pr-number
+                           :merge/method (:merge/method context)}}
+               now))
+
+(defn ^{:stratum 2} commit!
+  "Enable auto-merge, then ask GitHub whether it actually merged.
+
+   The outcome mapping is the honest part. Auto-merge accepted but not
+   yet completed is `:accepted`, which the coordinator maps to
+   `:unknown-outcome` — a request in flight is not a success. Only an
+   observed MERGED becomes `:succeeded`, and it carries the SHA GitHub
+   reported, never a local one.
+
+   `enable!` performs the gh merge call and returns `{:ok? bool}`;
+   `run-gh` answers the follow-up probe. Both injected."
+  [context t pr-number ^Instant now enable! run-gh]
+  (fx/commit! (store-dir context) t :authority/unenforced {} now
+              (fn []
+                (let [{:keys [ok? error]} (enable!)]
+                  (if-not ok?
+                    {:effect/outcome :failed :effect/failure (str error)}
+                    (if-let [answer (probe run-gh pr-number)]
+                      (if (:effect/matched? answer)
+                        {:effect/outcome :succeeded
+                         :effect/observed (:effect/observed answer)}
+                        {:effect/outcome :accepted
+                         :effect/observed (:effect/observed answer)})
+                      {:effect/outcome :accepted}))))))
+
+(defn ^{:stratum 2} reconcile!
+  "Ask GitHub again about a record whose outcome is still unknown.
+
+   Returns the settled record when GitHub answered, or the coordinator's
+   `:unavailable` anomaly when it did not — in which case the record is
+   untouched and the next pass asks again. Callers publish a merged
+   event only when the returned record reports `:effect/matched?` true."
+  [context t pr-number ^Instant now run-gh]
+  (fx/reconcile! (store-dir context) t (fn [_] (probe run-gh pr-number)) now))

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/merge_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/merge_test.clj
@@ -154,17 +154,46 @@
       (is (empty? (:blocking result))))))
 
 ;------------------------------------------------------------------------------ Attempt Merge with Mocks
-(deftest ^{:stratum 0} attempt-merge-ready-and-succeeds-test
-  (testing "Merge succeeds when ready"
+(deftest ^{:stratum 0} attempt-merge-enabled-but-unobserved-is-not-merged-test
+  ;; Ariadne 2d. merge-pr! passes --auto unconditionally, so a zero exit
+  ;; means auto-merge was ENABLED. Until GitHub reports a merge, claiming
+  ;; {:merged? true} is a claim the code cannot substantiate.
+  (testing "auto-merge enabled, GitHub still OPEN"
     (with-redefs [merge/evaluate-merge-readiness
                   (fn [_ _ _] {:ready? true :checks {} :blocking []})
                   merge/merge-pr!
-                  (fn [_ _ & _] (dag/ok {:merged? true :method :squash}))]
+                  (fn [_ _ & _] (dag/ok {:merged? true :method :squash}))
+                  merge/run-gh-command
+                  (fn [_ _] (dag/ok {:output "{\"state\":\"OPEN\",\"mergeCommit\":null}"}))]
       (let [context {:dag-id (random-uuid) :run-id (random-uuid)
                      :task-id (random-uuid) :pr-id 123}
             result (merge/attempt-merge "/tmp" 123 merge/default-merge-policy context)]
         (is (dag/ok? result))
-        (is (true? (:merged? (:data result))))))))
+        (is (false? (:merged? (:data result)))
+            "enabling auto-merge is not merging")
+        (is (true? (:auto-merge/enabled? (:data result))))
+        (is (nil? (:merge/sha (:data result)))
+            "no SHA is published for a merge nobody observed")))))
+
+(deftest ^{:stratum 0} attempt-merge-observed-merge-publishes-githubs-sha-test
+  (testing "GitHub reports MERGED"
+    (with-redefs [merge/evaluate-merge-readiness
+                  (fn [_ _ _] {:ready? true :checks {} :blocking []})
+                  merge/merge-pr!
+                  (fn [_ _ & _] (dag/ok {:merged? true :method :squash}))
+                  merge/run-gh-command
+                  (fn [args _]
+                    (if (some #{"--json"} args)
+                      (dag/ok {:output "{\"state\":\"MERGED\",\"mergeCommit\":{\"oid\":\"real-squash-sha\"}}"})
+                      (dag/ok {:output "local-branch-tip"})))]
+      (let [context {:dag-id (random-uuid) :run-id (random-uuid)
+                     :task-id (random-uuid) :pr-id 123}
+            result (merge/attempt-merge "/tmp" 123 merge/default-merge-policy context)]
+        (is (dag/ok? result))
+        (is (true? (:merged? (:data result))))
+        (is (= "real-squash-sha" (:merge/sha (:data result)))
+            "the SHA is GitHub's mergeCommit, not the local branch tip")
+        (is (not= "local-branch-tip" (:merge/sha (:data result))))))))
 
 (deftest ^{:stratum 0} attempt-merge-not-ready-no-rebase-test
   (testing "Merge blocked without auto-rebase yields error"

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/merge_transaction_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/merge_transaction_test.clj
@@ -1,0 +1,136 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.pr-lifecycle.merge-transaction-test
+  "The claim this namespace exists to stop: enabling auto-merge is not
+   merging, and a SHA read from the local worktree is not the merge
+   commit."
+  (:require
+   [ai.miniforge.effect-transaction.interface :as fx]
+   [ai.miniforge.pr-lifecycle.merge-transaction :as mt]
+   [clojure.test :refer [deftest is testing]])
+  (:import
+   [java.nio.file Files]
+   [java.nio.file.attribute FileAttribute]
+   [java.time Instant]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} now (Instant/parse "2026-08-01T00:00:00Z"))
+
+(def ^{:stratum 0} later (Instant/parse "2026-08-01T01:00:00Z"))
+
+(defn ^{:stratum 0} ctx []
+  {:effect-store-dir
+   (str (.toFile (Files/createTempDirectory "merge-fx" (into-array FileAttribute []))))
+   :pr/repo "miniforge-ai/miniforge"})
+
+(defn ^{:stratum 0} gh-returning
+  "An injected gh that answers every call with `body`."
+  [body]
+  (fn [_] {:ok? true :output body}))
+
+(def ^{:stratum 0} merged-json
+  "{\"state\":\"MERGED\",\"mergeCommit\":{\"oid\":\"squash-sha-on-base\"}}")
+
+(def ^{:stratum 0} open-json
+  "{\"state\":\"OPEN\",\"mergeCommit\":null}")
+
+(defn ^{:stratum 0} ok-enable [] (fn [] {:ok? true}))
+
+(deftest ^{:stratum 0} store-dir-is-never-relative-test
+  ;; An audit trail written to whatever directory the process started in
+  ;; is an audit trail nobody can find.
+  (is (= "/tmp/x" (mt/store-dir {:effect-store-dir "/tmp/x"})))
+  (is (.startsWith ^String (mt/store-dir {}) (System/getProperty "user.home"))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} parse-pr-view-test
+  (is (= {:pr/state "MERGED" :merge/sha "squash-sha-on-base"}
+         (mt/parse-pr-view merged-json)))
+  (is (= {:pr/state "OPEN" :merge/sha nil} (mt/parse-pr-view open-json)))
+  (testing "unparseable output is nil — 'did not answer', never 'not merged'"
+    (is (nil? (mt/parse-pr-view "not json at all")))
+    (is (nil? (mt/parse-pr-view "{\"unexpected\":true}")))))
+
+(deftest ^{:stratum 1} enabling-auto-merge-is-not-merging-test
+  ;; The core correction. `merge-pr!` passes --auto unconditionally, so a
+  ;; zero exit means auto-merge was ENABLED. GitHub still says OPEN.
+  (let [c (ctx)
+        t (mt/propose! c 42 "miniforge-ai/miniforge" now)
+        settled (mt/commit! c t 42 now (ok-enable) (gh-returning open-json))]
+    (is (= :unknown-outcome (:effect/state settled))
+        "a request in flight is not a success")
+    (is (not= :succeeded (:effect/state settled)))
+    (is (nil? (mt/substantiated-sha settled))
+        "no SHA is published for a merge nobody has observed")
+    (testing "the record is reconcilable, so a later pass asks again"
+      (is (contains? fx/reconcilable-states (:effect/state settled))))))
+
+(deftest ^{:stratum 1} observed-merge-carries-githubs-sha-test
+  (let [c (ctx)
+        t (mt/propose! c 42 "miniforge-ai/miniforge" now)
+        settled (mt/commit! c t 42 now (ok-enable) (gh-returning merged-json))]
+    (is (= :succeeded (:effect/state settled)))
+    (is (= "squash-sha-on-base" (mt/substantiated-sha settled))
+        "the published SHA is GitHub's mergeCommit, not a local branch tip")))
+
+(deftest ^{:stratum 1} a-failed-gh-call-is-a-definite-failure-test
+  (let [c (ctx)
+        t (mt/propose! c 42 "miniforge-ai/miniforge" now)
+        settled (mt/commit! c t 42 now
+                            (fn [] {:ok? false :error "PR already closed"})
+                            (gh-returning merged-json))]
+    (is (= :failed (:effect/state settled))
+        "the gh call reported it did not happen — that is knowledge, not doubt")
+    (is (nil? (mt/substantiated-sha settled)))))
+
+(deftest ^{:stratum 1} silent-github-leaves-it-unknown-test
+  (let [c (ctx)
+        t (mt/propose! c 42 "miniforge-ai/miniforge" now)
+        settled (mt/commit! c t 42 now (ok-enable)
+                            (fn [_] {:ok? false :output nil}))]
+    (is (= :unknown-outcome (:effect/state settled))
+        "GitHub not answering is not GitHub saying no")
+    (is (nil? (mt/substantiated-sha settled)))))
+
+(deftest ^{:stratum 1} reconcile-settles-a-later-merge-test
+  (let [c (ctx)
+        t (mt/propose! c 42 "miniforge-ai/miniforge" now)
+        pending (mt/commit! c t 42 now (ok-enable) (gh-returning open-json))]
+    (is (nil? (mt/substantiated-sha pending)))
+    (testing "asking again after GitHub finishes settles it with the real SHA"
+      (let [settled (mt/reconcile! c pending 42 later (gh-returning merged-json))]
+        (is (= :reconciled (:effect/state settled)))
+        (is (= "squash-sha-on-base" (mt/substantiated-sha settled)))))
+    (testing "a PR that closed unmerged reconciles as a mismatch, not a merge"
+      (let [settled (mt/reconcile! c pending 42 later
+                                   (gh-returning "{\"state\":\"CLOSED\",\"mergeCommit\":null}"))]
+        (is (= :reconciled (:effect/state settled)))
+        (is (false? (:effect/matched? settled)))
+        (is (nil? (mt/substantiated-sha settled)))))))
+
+(deftest ^{:stratum 1} the-intent-is-on-disk-before-any-gh-command-test
+  (let [c (ctx)
+        t (mt/propose! c 42 "miniforge-ai/miniforge" now)]
+    (is (= :proposed (:effect/state t)))
+    (is (= :effect/merge (:effect/class t)))
+    (is (= 42 (get-in t [:effect/proposal :pr/number])))
+    (testing "a reader sharing no memory with the writer finds it"
+      (is (= (:effect/id t)
+             (:effect/id (fx/read-record (:effect-store-dir c) (:effect/id t))))))))

--- a/work/ariadne-grant-issuance.spec.edn
+++ b/work/ariadne-grant-issuance.spec.edn
@@ -1,0 +1,101 @@
+;; =============================================================================
+;; Spec: Ariadne step 2f — grant issuance, the missing link
+;; =============================================================================
+;;
+;; Normative refs: docs/architecture/rfc-ariadne-adoption.md (adoption
+;; step 2); Ariadne §13.5 (ExecutionGrant lifecycle). This spec exists
+;; because the step-2 wave planned in #1574 specified the grant OBJECT
+;; (2a), CHECKING grants (2b), transacted effects (2c), migrating call
+;; sites (2d), and REVOKING grants (2e) — and never specified who
+;; ISSUES one. That omission is a planning gap, not a discovery.
+
+{:spec/title "Ariadne step 2f: grant issuance - who may authorize an irreversible effect, and on what basis"
+
+ :spec/description
+ "Specify and build the path that puts an ExecutionGrant into
+  existence in production.
+
+  WHY THIS BLOCKS 2d's SECOND HALF. `execution-grant` (2a) has
+  `issue`, `delegate`, and `revoke`. Nothing in components/ or bases/
+  calls any of them — verified: the only consumers of
+  `execution-grant.interface` are effect-transaction's own namespaces.
+  So 2d's acceptance criterion 'merge-pr! with no active :effect/merge
+  grant denies and fires no gh command' would, if landed as written,
+  deny EVERY merge and EVERY deploy permanently. Miniforge merges its
+  own PRs many times a day; that is not a migration, it is an outage.
+
+  2d part 1 therefore migrated the call sites onto the transaction
+  coordinator WITHOUT grant enforcement — honest outcomes now,
+  authority when there is authority to check. This spec supplies it.
+
+  GROUP 1: The issuance decision
+  What is the basis for issuing? Candidate inputs, to be settled by
+  this spec rather than assumed:
+    * the Spec/workflow-run the effect serves (scope)
+    * the phase or FSM position that legitimizes it
+    * the operator or automation that stands behind it (principal)
+    * the ceilings — from where? `budget->constraints` (2b) maps
+      today's scattered budget keys, but SOMETHING must choose the
+      numbers per effect rather than inheriting a role default.
+
+  GROUP 2: Where issuance happens
+  Options, with the tradeoff each carries:
+    * at workflow start — one grant per run, broad scope, long TTL;
+      simple, but a long-lived broad grant is the thing grants exist
+      to avoid.
+    * at phase entry — narrower, still automatic.
+    * at the decide() call that authorizes the effect — narrowest and
+      most defensible, but requires the issuer to know the effect's
+      shape before the effect is proposed.
+  This spec MUST pick one and say why; leaving it open is how the
+  ambient authority that Ariadne removes comes back in under a new
+  name.
+
+  GROUP 3: Delegation to inner orchestrators
+  2a built `delegate` with attenuation precisely for the nested-agent
+  case (T3 contradiction 6: 'stop restraining, start fencing'). Nothing
+  exercises it. This spec should say whether a spawned agent receives a
+  delegated grant and who cuts it.
+
+  GROUP 4: The eligibility hook
+  2e's breach history exposes 'may this principal be granted this
+  effect class at this ceiling'. Issuance is its only intended call
+  site. Wire it here.
+
+  GROUP 5: Then, and only then, 2d part 2
+  With an issuer live, the call sites can require a grant and the
+  deferred acceptance criteria from 2d become testable:
+    * merge-pr! with no active grant denies and fires no gh command
+    * kustomize-apply! with no active grant denies and runs no kubectl"
+
+ :spec/intent {:type :feature
+               :scope ["components/execution-grant/"
+                       "components/workflow/src/ai/miniforge/workflow/"
+                       "specs/normative/"]}
+
+ :spec/constraints
+ ["This spec MUST choose an issuance site and record the rejected alternatives - an open question here re-creates ambient authority under a new name"
+  "Issuance is runtime-only; no agent-supplied path may produce a grant (the 2a rule)"
+  "Ceilings come from an explicit decision per effect class, not from a role default inherited by accident"
+  "Consult 2e's eligibility predicate before issuing"
+  "Do not widen 2d part 1's migration; this spec adds authority, it does not re-open honesty"]
+
+ :spec/acceptance-criteria
+ ["A production code path calls execution-grant/issue - grep for the interface returns callers outside effect-transaction"
+  "An issued grant's scope names the workflow-run or PR it authorizes, not the whole repo"
+  "An issued grant's TTL is bounded and justified in the spec text"
+  "A principal with a disqualifying breach history is refused issuance"
+  "A spawned inner agent receives a DELEGATED grant, attenuated from its parent, or the spec states why it does not"
+  "merge-pr! with no active :effect/merge grant denies and fires no gh command"
+  "kustomize-apply! with no active :effect/deploy grant denies and runs no kubectl command"
+  "full bb test green"]
+
+ :spec/priority
+ {:tier :high
+  :axes #{:correctness :policy-enforcement :governance-credibility}
+  :theme :ariadne-grants
+  :rationale "Without an issuer the grant machinery is inert; with one, 2d part 2 and 2e's eligibility hook both become reachable. High rather than blocker because 2d part 1 already delivered the honesty half."
+  :blocks []
+  :blocked-by ["ariadne-revocation-for-cause.spec.edn"]}
+
+ :spec/workflow-type :canonical-sdlc}


### PR DESCRIPTION
Partial implementation of `work/ariadne-granted-effect-call-sites.spec.edn` — step 2d of the [Ariadne adoption](docs/architecture/rfc-ariadne-adoption.md). **Merge half, honesty only.** See the split note below.

## The claim this removes

`merge-pr!` appends `--auto` **unconditionally**, so a zero exit means auto-merge was *enabled*, not that anything merged. `attempt-merge` read that as `{:merged? true}` and published a merged event carrying a SHA from `git rev-parse HEAD` **in the local worktree** — the branch tip, not the squash commit on base. Two claims the code could not substantiate.

Now: the intent is recorded durably before any gh command; enabling auto-merge is recorded as a request accepted with the outcome unknown; GitHub is asked; and a merged event fires **only** against an observed merge, carrying GitHub's `mergeCommit`. When the answer is "not yet", the record stays reconcilable and a later pass asks again. GitHub not answering is not GitHub saying no.

One existing test, `attempt-merge-ready-and-succeeds-test`, asserted `{:merged? true}` from a mocked `merge-pr!` — it encoded exactly the false claim. Replaced with two tests covering both paths, one asserting the published SHA is **not** the local branch tip.

## Why this is the honesty half only

The spec's acceptance criteria include *"merge-pr! with no active `:effect/merge` grant denies and fires no gh command."* Landing that today would deny **every merge and every deploy, permanently** — because **nothing in production issues a grant**. Verified: the only consumers of `execution-grant.interface` are effect-transaction's own namespaces. Miniforge merges its own PRs many times a day; that is an outage, not a migration.

The step-2 wave I planned in #1574 specified the grant object (2a), checking grants (2b), transacting effects (2c), migrating call sites (2d), and revoking grants (2e) — and **never specified who issues one**. That is a planning gap, mine, and this PR records it as `work/ariadne-grant-issuance.spec.edn` rather than leaving it in a chat message. The spec forces the open questions: where issuance happens, what sets the ceilings, whether a spawned inner agent gets a delegated grant.

Deploy stays unmigrated in this PR for the same reason plus size; it follows once the shape here is settled.

## The authority seam is explicit, not silent

`commit!` takes `:authority/unenforced` rather than accepting a nil grant, and stamps `:effect/authority :unenforced` on the record. A nil-skip would be a blank that later reads as approval. This greps, and the record says plainly that no authority was checked. It comes out when issuance lands.

## Verification

8 tests / 26 assertions on the transaction namespace with injected shell access — no real gh calls — plus the two rewritten `attempt-merge` tests. `bb poly:check` 0 errors; `bb lint:clj` 0/0.

`SL003` on `merge.clj` is **pre-existing**: four layers on main, same set after. Committed with `MINIFORGE_STRATUM_BUDGET_MODE=warn` rather than smuggling a decomposition into a behaviour change.

Four sliced commits: issuance spec → authority seam → transaction namespace → attempt-merge rewire → tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)