### PR TITLE
fix(cursor-store): normalize cursor instants by type — a Date watermark silently disabled incremental ingest

### DIFF
--- a/components/coerce/src/ai/miniforge/coerce/instant.clj
+++ b/components/coerce/src/ai/miniforge/coerce/instant.clj
@@ -1,0 +1,59 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.coerce.instant
+  "Instant normalization for values crossing a serialization boundary.
+
+   Replaces the Instant-only postwalk that grew up independently in
+   cursor-store, workflow's checkpoint-store, and the etl base — each
+   of which matched `java.time.Instant` and silently let a
+   `java.util.Date` past."
+  (:require [clojure.walk :as walk])
+  (:import [java.time Instant]
+           [java.util Date]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} ->iso
+  "Instant -> ISO-8601 string, dispatched on the ACTUAL type.
+   Anything that is not an instant is returned unchanged.
+
+   `clojure.core/inst?` admits BOTH `java.time.Instant` and
+   `java.util.Date`, so a normalizer that tests only
+   `(instance? Instant x)` lets a Date past. That is the harder
+   failure to notice: a Date has a print form (`#inst`) that survives
+   an EDN round-trip, so nothing throws, the file stays valid EDN, and
+   the value simply arrives at the reader as a Date where a string was
+   expected.
+
+   Passing non-instants through is what separates this from the strict
+   `->iso` helpers in effect-transaction and knowledge. Those guard a
+   single key that is always supposed to hold a timestamp, so they can
+   throw on anything else. This one is applied to every value in a
+   payload, most of which legitimately are not timestamps."
+  [v]
+  (cond
+    (instance? Instant v) (.toString ^Instant v)
+    (instance? Date v)    (.toString (.toInstant ^Date v))
+    :else                 v))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} stringify-instants
+  "Walk `v`, replacing every instant with its ISO-8601 string."
+  [v]
+  (walk/postwalk ->iso v))

--- a/components/coerce/src/ai/miniforge/coerce/interface.clj
+++ b/components/coerce/src/ai/miniforge/coerce/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.coerce.interface
   "Tiny safe-coercion helpers shared across the OSS components.
 
@@ -25,12 +24,17 @@
 
    pattern that grew up across compliance-scanner, pr-sync, tui-views,
    web-dashboard, workflow-security-compliance, policy-pack,
-   connector-sarif, and the cli base.")
+   connector-sarif, and the cli base — and the duplicated
+   Instant-only instant walker that grew up across cursor-store,
+   workflow's checkpoint-store, and the etl base."
+  (:require [clojure.walk :as walk])
+  (:import [java.time Instant]
+           [java.util Date]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; No in-namespace dependencies.
 
-(defn safe-parse-int
+;; No in-namespace dependencies.
+(defn ^{:stratum 0} safe-parse-int
   "Parse `s` as a 32-bit integer. Returns `default` when `s` is nil,
    non-string, non-numeric, or out of range. The default `default` is
    `nil` so callers can pattern-match on the parsed-or-not distinction;
@@ -47,7 +51,7 @@
      (try (Integer/parseInt ^String s)
           (catch NumberFormatException _ default)))))
 
-(defn safe-parse-long
+(defn ^{:stratum 0} safe-parse-long
   "Parse `s` as a 64-bit integer. Returns `default` when `s` is nil,
    non-string, non-numeric, or out of range. See [[safe-parse-int]] for
    the rationale on the up-front nil check and narrowed catch."
@@ -58,7 +62,7 @@
      (try (Long/parseLong ^String s)
           (catch NumberFormatException _ default)))))
 
-(defn safe-parse-double
+(defn ^{:stratum 0} safe-parse-double
   "Parse `s` as a double. Returns `default` when `s` is nil, non-string,
    or non-numeric. See [[safe-parse-int]] for the rationale on the
    up-front nil check and narrowed catch."
@@ -68,3 +72,29 @@
      default
      (try (Double/parseDouble ^String s)
           (catch NumberFormatException _ default)))))
+
+(defn ^{:stratum 0} stringify-instants
+  "Walk `v`, replacing every instant with its ISO-8601 string.
+   Non-instant values are returned unchanged.
+
+   Dispatches on the ACTUAL type. `clojure.core/inst?` admits BOTH
+   `java.time.Instant` and `java.util.Date`, so a walker that tests
+   only `(instance? Instant x)` lets a Date past untouched. That is
+   the harder failure to notice, because a Date has a print form
+   (`#inst`) that survives an EDN round-trip: nothing throws, the
+   file is valid EDN, and the value simply arrives at the reader as
+   a Date where the reader expected a string. Connector cursor
+   watermarks were being silently dropped exactly that way.
+
+   Unlike the strict `->iso` helpers at single-key write boundaries
+   (effect-transaction, knowledge), this cannot throw on unrecognized
+   input — it walks whole payloads in which most values are
+   legitimately not timestamps."
+  [v]
+  (walk/postwalk
+   (fn [x]
+     (cond
+       (instance? Instant x) (.toString ^Instant x)
+       (instance? Date x)    (.toString (.toInstant ^Date x))
+       :else                 x))
+   v))

--- a/components/coerce/src/ai/miniforge/coerce/interface.clj
+++ b/components/coerce/src/ai/miniforge/coerce/interface.clj
@@ -26,10 +26,15 @@
    web-dashboard, workflow-security-compliance, policy-pack,
    connector-sarif, and the cli base — and the duplicated
    Instant-only instant walker that grew up across cursor-store,
-   workflow's checkpoint-store, and the etl base."
-  (:require [clojure.walk :as walk])
-  (:import [java.time Instant]
-           [java.util Date]))
+   workflow's checkpoint-store, and the etl base.
+
+   NOTE: `safe-parse-int` / `-long` / `-double` are implemented here
+   rather than passed through to an implementation namespace, which
+   predates this file's current form and does not match the
+   interface.clj rule in `languages/clojure.mdc`. New additions do not
+   follow them — see `stringify-instants` below. Migrating the three
+   parsers is left to its own change."
+  (:require [ai.miniforge.coerce.instant :as instant]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -77,24 +82,11 @@
   "Walk `v`, replacing every instant with its ISO-8601 string.
    Non-instant values are returned unchanged.
 
-   Dispatches on the ACTUAL type. `clojure.core/inst?` admits BOTH
+   Normalizes by ACTUAL type. `clojure.core/inst?` admits BOTH
    `java.time.Instant` and `java.util.Date`, so a walker that tests
-   only `(instance? Instant x)` lets a Date past untouched. That is
-   the harder failure to notice, because a Date has a print form
-   (`#inst`) that survives an EDN round-trip: nothing throws, the
-   file is valid EDN, and the value simply arrives at the reader as
-   a Date where the reader expected a string. Connector cursor
-   watermarks were being silently dropped exactly that way.
-
-   Unlike the strict `->iso` helpers at single-key write boundaries
-   (effect-transaction, knowledge), this cannot throw on unrecognized
-   input — it walks whole payloads in which most values are
-   legitimately not timestamps."
+   only `(instance? Instant x)` lets a Date past untouched — and a
+   Date is the harder failure to notice, because its `#inst` print
+   form survives an EDN round-trip without anything throwing. Use
+   this at any boundary where instants are serialized."
   [v]
-  (walk/postwalk
-   (fn [x]
-     (cond
-       (instance? Instant x) (.toString ^Instant x)
-       (instance? Date x)    (.toString (.toInstant ^Date x))
-       :else                 x))
-   v))
+  (instant/stringify-instants v))

--- a/components/coerce/test/ai/miniforge/coerce/interface_test.clj
+++ b/components/coerce/test/ai/miniforge/coerce/interface_test.clj
@@ -15,12 +15,15 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.coerce.interface-test
   (:require [clojure.test :refer [deftest testing is]]
-            [ai.miniforge.coerce.interface :as sut]))
+            [ai.miniforge.coerce.interface :as sut])
+  (:import [java.time Instant]
+           [java.util Date]))
 
-(deftest safe-parse-int-test
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} safe-parse-int-test
   (testing "valid numeric strings parse to ints"
     (is (= 0       (sut/safe-parse-int "0")))
     (is (= 42      (sut/safe-parse-int "42")))
@@ -37,7 +40,7 @@
   (testing "overflow returns the default rather than throwing"
     (is (= -1  (sut/safe-parse-int "99999999999999999999" -1)))))
 
-(deftest safe-parse-long-test
+(deftest ^{:stratum 0} safe-parse-long-test
   (testing "valid input"
     (is (= 9999999999 (sut/safe-parse-long "9999999999"))))
 
@@ -45,10 +48,38 @@
     (is (nil? (sut/safe-parse-long "x")))
     (is (= 0  (sut/safe-parse-long "x" 0)))))
 
-(deftest safe-parse-double-test
+(deftest ^{:stratum 0} safe-parse-double-test
   (testing "valid input"
     (is (= 3.14 (sut/safe-parse-double "3.14"))))
 
   (testing "invalid input returns default"
     (is (nil?  (sut/safe-parse-double "x")))
     (is (= 0.0 (sut/safe-parse-double "x" 0.0)))))
+
+(def ^{:stratum 0} ^:private iso "2024-01-15T10:00:00.123Z")
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} stringify-instants-test
+  (testing "both types clojure.core/inst? admits normalize to the same string"
+    (let [instant (Instant/parse iso)
+          date    (Date/from instant)]
+      (is (inst? instant))
+      (is (inst? date))
+      (is (= iso (sut/stringify-instants instant)))
+      (is (= iso (sut/stringify-instants date)))))
+
+  (testing "millisecond precision survives a Date"
+    (is (= iso (sut/stringify-instants (Date/from (Instant/parse iso))))))
+
+  (testing "normalizes at any depth, in maps and in sequences"
+    (let [date (Date/from (Instant/parse iso))]
+      (is (= {:a {:b [iso]}}
+             (sut/stringify-instants {:a {:b [date]}})))
+      (is (= #{iso} (sut/stringify-instants #{date})))
+      (is (= {iso :as-a-key}
+             (sut/stringify-instants {date :as-a-key})))))
+
+  (testing "non-instant values pass through untouched"
+    (is (= {:n 1 :s "x" :k :kw :nil nil :v [true 2.5]}
+           (sut/stringify-instants {:n 1 :s "x" :k :kw :nil nil :v [true 2.5]})))))

--- a/components/cursor-store/deps.edn
+++ b/components/cursor-store/deps.edn
@@ -1,5 +1,10 @@
 {:paths ["src" "resources"]
  :deps {ai.miniforge/schema   {:local/root "../schema"}
-        ai.miniforge/logging  {:local/root "../logging"}}
+        ai.miniforge/logging  {:local/root "../logging"}
+        ai.miniforge/coerce   {:local/root "../coerce"}}
  :aliases {:test {:extra-paths ["test"]
-                  :extra-deps {}}}}
+                  ;; Test-only: the round-trip test asserts that what this
+                  ;; store persists is a value connector-http can actually
+                  ;; filter with. Nothing in src depends on connector-http.
+                  :extra-deps {ai.miniforge/connector-http
+                               {:local/root "../connector-http"}}}}}

--- a/components/cursor-store/src/ai/miniforge/cursor_store/store.clj
+++ b/components/cursor-store/src/ai/miniforge/cursor_store/store.clj
@@ -44,9 +44,18 @@
    cursor-map))
 
 (defn- ^{:stratum 0} read-edn
-  "Parse an EDN string."
+  "Parse an EDN string, normalizing instants exactly as the write side
+   does.
+
+   EDN's `#inst` reader produces a `java.util.Date`, so a cursor file
+   containing `#inst \"…\"` loads a Date no matter how careful the
+   writer was — a hand-edited file is enough, and `#inst` is the
+   obvious thing for a human to type. Reading through the same
+   normalizer makes the store's guarantee a property of the store
+   rather than of whoever last wrote the file: a timestamp read out of
+   here is an ISO-8601 string."
   [s]
-  (edn/read-string s))
+  (coerce/stringify-instants (edn/read-string s)))
 
 (defn- ^{:stratum 0} write-edn
   "Render a value to a pretty-printed EDN string, with every instant

--- a/components/cursor-store/src/ai/miniforge/cursor_store/store.clj
+++ b/components/cursor-store/src/ai/miniforge/cursor_store/store.clj
@@ -3,22 +3,21 @@
 
    Stratification (intra-namespace):
    Layer 0 — no in-ns deps: cursor-file, normalize-for-storage,
-             stringify-instants, read-edn.
-   Layer 1 — write-edn (composes Layer 0's stringify-instants).
-   Layer 2 — public I/O (save-cursors, load-cursors). Both at L2 to
+             read-edn, write-edn.
+   Layer 1 — public I/O (save-cursors, load-cursors). Both at L1 to
              keep the persistence API at one stratum."
   (:require [clojure.edn :as edn]
             [clojure.java.io :as io]
             [clojure.pprint :as pp]
-            [clojure.walk :as walk]
+            [ai.miniforge.coerce.interface :as coerce]
             [ai.miniforge.logging.interface :as log]
             [ai.miniforge.schema.interface :as schema])
-  (:import [java.io StringWriter]
-           [java.time Instant]))
+  (:import [java.io StringWriter]))
 
-;;------------------------------------------------------------------------------ Layer 0 — pure helpers
+;------------------------------------------------------------------------------ Layer 0
 
-(defn- cursor-file
+;; Pure helpers.
+(defn- ^{:stratum 0} cursor-file
   "Derive cursor EDN file from a pipeline file path.
    <pipeline-dir>/.cursors/<pipeline-filename>"
   [pipeline-path]
@@ -26,7 +25,7 @@
         dir (or (.getParentFile f) (io/file "."))]
     (io/file dir ".cursors" (.getName f))))
 
-(defn- normalize-for-storage
+(defn- ^{:stratum 0} normalize-for-storage
   "Re-key {stage-uuid → cursor-entry} to {[connector-ref schema-name] → cursor-entry}.
    Entries missing connector-ref or schema-name are dropped with a warning."
   [logger cursor-map]
@@ -44,31 +43,33 @@
    {}
    cursor-map))
 
-(defn- stringify-instants
-  "Convert all java.time.Instant values to ISO-8601 strings.
-   Clojure's pprint emits #object[java.time.Instant ...] which is not valid EDN;
-   storing as a plain string keeps the file fully EDN-readable.
-   :cursor/updated-at is audit metadata — it is not used in cursor lookup logic."
-  [v]
-  (walk/postwalk (fn [x] (if (instance? Instant x) (str x) x)) v))
-
-(defn- read-edn
+(defn- ^{:stratum 0} read-edn
   "Parse an EDN string."
   [s]
   (edn/read-string s))
 
-;;------------------------------------------------------------------------------ Layer 1 — composes Layer 0
+(defn- ^{:stratum 0} write-edn
+  "Render a value to a pretty-printed EDN string, with every instant
+   normalized to an ISO-8601 string first.
 
-(defn- write-edn
-  "Render a value to a pretty-printed EDN string."
+   Both halves of that matter. pprint emits
+   `#object[java.time.Instant ...]` for an Instant, which is not
+   readable EDN at all. A `java.util.Date` is the quieter problem: it
+   pprints as `#inst` and reads back as a Date, so the file is valid
+   and nothing fails — but `connector-http`'s `parse-timestamp`
+   requires a string, returns nil for a Date, and `after-cursor?`
+   then falls through to its no-watermark branch and re-ingests
+   every record. Normalizing by type is what keeps a persisted
+   cursor readable by the connector that has to honour it."
   [v]
   (let [sw (StringWriter.)]
-    (pp/pprint (stringify-instants v) sw)
+    (pp/pprint (coerce/stringify-instants v) sw)
     (str sw)))
 
-;;------------------------------------------------------------------------------ Layer 2 — public I/O
+;------------------------------------------------------------------------------ Layer 1
 
-(defn save-cursors
+;; Public I/O.
+(defn ^{:stratum 1} save-cursors
   "Persist connector cursors to <pipeline-dir>/.cursors/<pipeline-filename>.
    cursor-map is the raw {stage-uuid → cursor-entry} map from
    :pipeline-run/connector-cursors. Returns schema/success or schema/failure."
@@ -96,7 +97,7 @@
                     :data {:path pipeline-path :error (.getMessage e)}}))
       (schema/failure :cursors (.getMessage e)))))
 
-(defn load-cursors
+(defn ^{:stratum 1} load-cursors
   "Load persisted cursors for a pipeline. Returns schema/success with
    :cursors key (map keyed by [connector-ref schema-name]).
    Returns schema/success with {} on first run (no file yet).

--- a/components/cursor-store/test/ai/miniforge/cursor_store/interface_test.clj
+++ b/components/cursor-store/test/ai/miniforge/cursor_store/interface_test.clj
@@ -15,25 +15,34 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.cursor-store.interface-test
   (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.connector-http.interface :as connector-http]
             [ai.miniforge.cursor-store.interface :as sut]
             [ai.miniforge.logging.interface :as log])
-  (:import [java.time Instant]))
+  (:import [java.time Instant]
+           [java.util Date]))
 
-(defn- tmp-pipeline-path []
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} tmp-pipeline-path []
   (str (System/getProperty "java.io.tmpdir")
        "/cursor-store-test-"
        (random-uuid)
        "/pipelines/pipeline.edn"))
 
-(def ^:private logger (log/create-logger {:min-level :debug :output :human}))
+(def ^{:stratum 0} ^:private logger (log/create-logger {:min-level :debug :output :human}))
+
+(def ^{:stratum 0} ^:private watermark-iso "2024-01-15T10:00:00Z")
+
+(defn- ^{:stratum 0} record-timestamp [record]
+  (or (:updated_at record) (:created_at record)))
+
+;------------------------------------------------------------------------------ Layer 1
 
 ;; ---------------------------------------------------------------------------
 ;; load-cursors
-
-(deftest load-cursors-first-run-test
+(deftest ^{:stratum 1} load-cursors-first-run-test
   (testing "Returns empty map when no cursor file exists yet"
     (let [result (sut/load-cursors logger (tmp-pipeline-path))]
       (is (:success? result))
@@ -41,8 +50,7 @@
 
 ;; ---------------------------------------------------------------------------
 ;; round-trip
-
-(deftest round-trip-test
+(deftest ^{:stratum 1} round-trip-test
   (testing "save then load preserves cursor data with stable key"
     (let [path      (tmp-pipeline-path)
           stage-id  (random-uuid)
@@ -67,7 +75,7 @@
           (is (string? (:cursor/updated-at loaded)))
           (is (= (str instant) (:cursor/updated-at loaded))))))))
 
-(deftest multi-stage-round-trip-test
+(deftest ^{:stratum 1} multi-stage-round-trip-test
   (testing "Multiple stages produce multiple entries keyed by connector/schema"
     (let [path  (tmp-pipeline-path)
           id-1  (random-uuid)
@@ -86,10 +94,24 @@
         (is (= 10 (get-in loaded [[:conn/gitlab "issues"] :cursor :cursor/value])))
         (is (= 5 (get-in loaded [[:conn/gitlab "merge-requests"] :cursor :cursor/value])))))))
 
+(defn- ^{:stratum 1} persisted-cursor
+  "Save `cursor-value` as a timestamp watermark, then load it back."
+  [cursor-value]
+  (let [path (tmp-pipeline-path)]
+    (sut/save-cursors logger path
+                      {(random-uuid) {:stage/connector-ref :conn/gitlab
+                                      :stage/schema-name   "issues"
+                                      :cursor {:cursor/type  :timestamp-watermark
+                                               :cursor/value cursor-value}
+                                      :cursor/updated-at (Instant/now)}})
+    (-> (sut/load-cursors logger path)
+        :cursors
+        (get [:conn/gitlab "issues"])
+        :cursor)))
+
 ;; ---------------------------------------------------------------------------
 ;; normalization
-
-(deftest normalization-drops-incomplete-entries-test
+(deftest ^{:stratum 1} normalization-drops-incomplete-entries-test
   (testing "Entries without connector-ref or schema-name are excluded"
     (let [path     (tmp-pipeline-path)
           good-id  (random-uuid)
@@ -108,8 +130,7 @@
 
 ;; ---------------------------------------------------------------------------
 ;; idempotency — second save overwrites first
-
-(deftest overwrite-test
+(deftest ^{:stratum 1} overwrite-test
   (testing "Saving again overwrites prior cursor with updated value"
     (let [path     (tmp-pipeline-path)
           conn-ref :conn/gitlab
@@ -124,3 +145,39 @@
       (sut/save-cursors logger path run2)
       (let [loaded (:cursors (sut/load-cursors logger path))]
         (is (= 20 (get-in loaded [[conn-ref schema] :cursor :cursor/value])))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; ---------------------------------------------------------------------------
+;; instant normalization — a persisted watermark the consumer can honour
+;;
+;; `clojure.core/inst?` admits java.util.Date as readily as
+;; java.time.Instant, and a Date has a print form (#inst) that survives
+;; the EDN round-trip intact — so a Date-valued watermark used to reach
+;; disk and come back unchanged with nothing throwing anywhere. The
+;; damage was downstream and silent: connector-http's parse-timestamp
+;; requires a string, returned nil for the Date, and after-cursor? fell
+;; through to its no-watermark branch — admitting EVERY record and
+;; re-ingesting the whole source on every run.
+;;
+;; Asserting the serialized shape alone would not have caught that. The
+;; filtering assertions below are the ones that fail on the unfixed
+;; store.
+(deftest ^{:stratum 2} date-watermark-round-trip-test
+  (testing "a java.util.Date watermark persists as an ISO-8601 string"
+    (let [cursor (persisted-cursor (Date/from (Instant/parse watermark-iso)))]
+      (is (string? (:cursor/value cursor)))
+      (is (= watermark-iso (:cursor/value cursor)))))
+
+  (testing "the loaded cursor actually filters — records at or before it are excluded"
+    (let [cursor (persisted-cursor (Date/from (Instant/parse watermark-iso)))]
+      (is (false? (connector-http/after-cursor?
+                   record-timestamp cursor {:updated_at "2024-01-14T00:00:00Z"})))
+      (is (false? (connector-http/after-cursor?
+                   record-timestamp cursor {:updated_at watermark-iso})))
+      (is (true? (connector-http/after-cursor?
+                  record-timestamp cursor {:updated_at "2024-01-16T00:00:00Z"})))))
+
+  (testing "an Instant watermark is indistinguishable once persisted"
+    (is (= (:cursor/value (persisted-cursor (Instant/parse watermark-iso)))
+           (:cursor/value (persisted-cursor (Date/from (Instant/parse watermark-iso))))))))

--- a/components/cursor-store/test/ai/miniforge/cursor_store/interface_test.clj
+++ b/components/cursor-store/test/ai/miniforge/cursor_store/interface_test.clj
@@ -16,7 +16,8 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns ai.miniforge.cursor-store.interface-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer [deftest is testing]]
             [ai.miniforge.connector-http.interface :as connector-http]
             [ai.miniforge.cursor-store.interface :as sut]
             [ai.miniforge.logging.interface :as log])
@@ -153,6 +154,31 @@
       (sut/save-cursors logger path run2)
       (let [loaded (:cursors (sut/load-cursors logger path))]
         (is (= 20 (get-in loaded [[conn-ref schema] :cursor :cursor/value])))))))
+
+(deftest ^{:stratum 1} inst-tagged-cursor-file-loads-as-string-test
+  (testing "a cursor file containing #inst still yields a filterable watermark"
+    ;; `#inst` is the obvious literal for a human editing a cursor file by
+    ;; hand, and EDN's reader turns it into a java.util.Date — which
+    ;; parse-timestamp rejects. The read path normalizes, so the store's
+    ;; guarantee holds regardless of who wrote the file.
+    (let [path (tmp-pipeline-path)
+          file (io/file (.getParentFile (io/file path))
+                        ".cursors" (.getName (io/file path)))]
+      (io/make-parents file)
+      (spit file (pr-str {[:conn/gitlab "issues"]
+                          {:stage/connector-ref :conn/gitlab
+                           :stage/schema-name   "issues"
+                           :cursor {:cursor/type  :timestamp-watermark
+                                    :cursor/value (Date/from
+                                                   (Instant/parse watermark-iso))}}}))
+      (let [loaded (sut/load-cursors logger path)
+            cursor (get-in (:cursors loaded) [[:conn/gitlab "issues"] :cursor])]
+        (is (:success? loaded) (str "load-cursors failed: " (:error loaded)))
+        (is (= watermark-iso (:cursor/value cursor)))
+        (is (false? (connector-http/after-cursor?
+                     record-timestamp cursor {:updated_at "2024-01-14T00:00:00Z"})))
+        (is (true? (connector-http/after-cursor?
+                    record-timestamp cursor {:updated_at "2024-01-16T00:00:00Z"})))))))
 
 ;------------------------------------------------------------------------------ Layer 2
 

--- a/components/cursor-store/test/ai/miniforge/cursor_store/interface_test.clj
+++ b/components/cursor-store/test/ai/miniforge/cursor_store/interface_test.clj
@@ -95,19 +95,27 @@
         (is (= 5 (get-in loaded [[:conn/gitlab "merge-requests"] :cursor :cursor/value])))))))
 
 (defn- ^{:stratum 1} persisted-cursor
-  "Save `cursor-value` as a timestamp watermark, then load it back."
+  "Save `cursor-value` as a timestamp watermark, then load it back.
+
+   Both I/O results are asserted here. `save-cursors` and
+   `load-cursors` report failure as a `schema/failure` map rather than
+   throwing, so an unchecked write or read error would reach the
+   caller as a nil cursor and fail some later assertion with a
+   misleading `(not (string? nil))` instead of naming the real
+   problem."
   [cursor-value]
-  (let [path (tmp-pipeline-path)]
-    (sut/save-cursors logger path
-                      {(random-uuid) {:stage/connector-ref :conn/gitlab
-                                      :stage/schema-name   "issues"
-                                      :cursor {:cursor/type  :timestamp-watermark
-                                               :cursor/value cursor-value}
-                                      :cursor/updated-at (Instant/now)}})
-    (-> (sut/load-cursors logger path)
-        :cursors
-        (get [:conn/gitlab "issues"])
-        :cursor)))
+  (let [path   (tmp-pipeline-path)
+        saved  (sut/save-cursors
+                logger path
+                {(random-uuid) {:stage/connector-ref :conn/gitlab
+                                :stage/schema-name   "issues"
+                                :cursor {:cursor/type  :timestamp-watermark
+                                         :cursor/value cursor-value}
+                                :cursor/updated-at (Instant/now)}})
+        loaded (sut/load-cursors logger path)]
+    (is (:success? saved) (str "save-cursors failed: " (:error saved)))
+    (is (:success? loaded) (str "load-cursors failed: " (:error loaded)))
+    (-> loaded :cursors (get [:conn/gitlab "issues"]) :cursor)))
 
 ;; ---------------------------------------------------------------------------
 ;; normalization


### PR DESCRIPTION
## The defect

Found during the `inst?` sweep in #1602, which listed it as adjacent
and deliberately out of scope there. This is the fix.

`cursor-store/store.clj` `stringify-instants` walked for
`java.time.Instant` only:

```clojure
(walk/postwalk (fn [x] (if (instance? Instant x) (str x) x)) v)
```

`clojure.core/inst?` admits `java.util.Date` just as readily. A Date
passed through untouched and **survived the round trip** — `pprint`
emits `#inst`, `edn/read-string` reads it back as a Date. Valid EDN,
nothing thrown, no log line.

The damage is one component downstream:

| step | file | behavior with a Date cursor |
|---|---|---|
| persist | `cursor_store/store.clj` | writes `#inst "…"` |
| load | same | reads back a `java.util.Date` |
| parse | `connector_http/cursors.clj` `parse-timestamp` | requires `string?` → returns **nil** |
| filter | same, `after-cursor?` | `if-let` on nil → falls to the `true` branch |

`after-cursor?`'s `true` branch means *no prior watermark — admit
everything*. Every record is treated as new: the timestamp watermark
is silently disabled and the connector re-ingests the entire source.
No error, no warning.

Reproduced against the unfixed source before the fix was restored:

```
FAIL in (date-watermark-round-trip-test)
expected: (false? (after-cursor? ts-fn cursor {:updated_at "2024-01-14T00:00:00Z"}))
  actual: (not (false? true))
```

A record dated a year before the watermark reported as after it.

## Blast radius — stated accurately

**This is not currently firing in production, and the reason is worse
than the bug.** `save-cursors` / `load-cursors` have **no callers
anywhere** in `components/`, `bases/`, or `projects/` — I grepped for
all three names. `cursor-store` came in with the Data Foundry import
(#474) and was never wired up. `poly info` confirms it: the component
belongs to no project.

So today:

- `pipeline-runner` threads `:pipeline-run/connector-cursors` **within
  a single run**, in memory. No EDN round trip, so this defect cannot
  touch it.
- **Cross-run** cursor persistence — the entire reason `cursor-store`
  exists — is not connected. Connectors already re-ingest from scratch
  on every run, because nothing reloads a watermark at all.

What this PR buys is that the store is correct *before* something
wires it in, rather than the first integration shipping with a
watermark that silently does nothing. It does not, on its own, change
any current run's behavior. I'd rather say that than let a severity
claim stand that the code doesn't support.

Two consequences worth a reviewer's attention, both pre-existing and
neither fixed here:

1. **The new tests do not run in CI.** `bb test` / `bb test:all` are
   Polylith project-scoped, and `cursor-store` is in no project, so
   `ai.miniforge.cursor-store.interface-test` — the whole file, not
   just my additions — has never been in a CI test plan. It runs under
   `clojure -M:dev:test` (the root `:test` alias carries the path),
   which is how the failures above were demonstrated. Adding
   `cursor-store` to `data-foundry` purely to get it into a test plan
   would earn a poly warning 207 for an unused component, so I left
   the call to whoever wires the component up. The `coerce` tests here
   **do** run in CI — that component is in every project.
2. `after-cursor?` would fail the same way on an in-memory Date cursor,
   with no persistence involved — `parse-timestamp` requires a string
   either way. Not reachable today: its only callers are
   `connector-gitlab` and `connector-github`, both HTTP/JSON sources
   whose timestamps are strings by construction. Worth knowing before
   a non-JSON source starts using these helpers.

## The fix

Normalization moves to a shared `coerce/stringify-instants` that
dispatches on the actual type — the same shape as the two reference
implementations, `effect-transaction/store.clj` `->iso` (#1592) and
`knowledge/zettel.clj` `->iso` (#1602):

```clojure
(cond
  (instance? Instant v) (.toString ^Instant v)
  (instance? Date v)    (.toString (.toInstant ^Date v))
  :else                 v)
```

One deliberate difference from the references: this one does **not**
throw on unrecognized input. Those helpers run at single-key write
boundaries where every value is supposed to be a timestamp. This walks
whole payloads in which most values legitimately are not, so `:else`
has to be identity. The docstring says so, and says why.

`coerce` is the home because its stated purpose is already "replaces
the duplicated \<X\> pattern that grew up across N components" — the
same story with a different pattern. Two more copies of the
Instant-only walk exist; they adopt this one in the stacked PRs below.

**Both sides of the boundary normalize.** `read-edn` runs loaded EDN
through the same helper, so `#inst` in a cursor file — the obvious
literal for a human editing one by hand — cannot reintroduce a Date.
The guarantee "a timestamp out of this store is an ISO-8601 string" is
a property of the store, not of whoever last wrote the file.

## Tests

Every new assertion was confirmed to **fail against the unfixed
source**, then pass with it restored.

`coerce` — Instant and Date both `inst?`, both normalize to the same
ISO-8601 string, millisecond precision intact, at any depth (nested
maps, vectors, sets, map keys), non-instants untouched.

`cursor-store` — the behavioral ones. Asserting the serialized shape
alone would not have caught this defect, because the serialized shape
never failed. So the tests assert the **filtering**: a Date watermark
persists as a parseable string, and `connector-http/after-cursor?`
then excludes records before and at the watermark and admits the one
after. A second test writes an `#inst`-tagged file directly and
asserts the same. A test-only dep on `connector-http` makes that
end-to-end; nothing in `src` depends on it.

## Review round

- Copilot: `persisted-cursor` swallowed the `save-cursors` /
  `load-cursors` results — neither throws, both return a
  `schema/failure` map, so an I/O error surfaced as
  `(not (string? nil))` several assertions later. Both results are now
  bound and asserted.
- Copilot: `load-cursors` returned raw EDN, so an `#inst` in the file
  still yielded a Date. Fixed as described above. The upgrade-safety
  framing Copilot gave does not apply — nothing has ever written a
  cursor file — but the symmetry argument does.
- Self-review against `languages/clojure.mdc` caught two gaps in my
  own diff: I had put the walker's implementation directly in
  `interface.clj` (rule marked CRITICAL: interfaces hold thin
  pass-throughs only), cloning the shape of the three `safe-parse-*`
  fns already there — which is exactly how drift replicates. The
  implementation now lives in `coerce/instant.clj`. The postwalk
  callback was also a four-line anonymous `cond`; it is now the named
  `instant/->iso`, and `stringify-instants` reads as
  `(walk/postwalk ->iso v)`. The three pre-existing parsers are left
  alone — their migration is its own change — but the ns docstring now
  names the violation so the next reader does not clone it.

## Stacked on this

- #1606 — the etl base's copy
- #1607 — the checkpoint store's copy

## Gates

- `bb lint:clj` — 0 errors, 0 warnings
- `bb lint:stratum` — clean, no findings
- `bb poly:check` — only pre-existing warnings 205 and 207, identical to the baseline on `main`
- `bb commit-budget` — every commit inside 200
- `bb pre-commit` — ALL PASSED on each commit (331 tests / 1244 assertions smoke, GraalVM 8 / 562)
- `bb test` — stable-derived plan passed, 7m07s
- cursor-store + coerce, run directly — 10 tests / 52 assertions, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)