### PR TITLE
fix(workflow): normalize checkpoint instants by type, not by Instant check

### DIFF
--- a/components/workflow/deps.edn
+++ b/components/workflow/deps.edn
@@ -1,6 +1,7 @@
 {:paths ["src" "resources"]
  :deps {ai.miniforge/config {:local/root "../config"}
         ai.miniforge/clock {:local/root "../clock"}
+        ai.miniforge/coerce {:local/root "../coerce"}
         ai.miniforge/schema {:local/root "../schema"}
         ai.miniforge/logging {:local/root "../logging"}
         ai.miniforge/messages {:local/root "../messages"}

--- a/components/workflow/src/ai/miniforge/workflow/checkpoint_store.clj
+++ b/components/workflow/src/ai/miniforge/workflow/checkpoint_store.clj
@@ -101,9 +101,18 @@
   (str (fs/path checkpoint-root (str workflow-run-id))))
 
 (defn- ^{:stratum 0} read-edn-file
+  "Read a checkpoint EDN file, normalizing instants the same way the
+   write side does.
+
+   Checkpoints already on disk were written before this normalization
+   existed, so a `java.util.Date` in one of them was persisted as
+   `#inst` — and EDN's reader hands that back as a Date, which is
+   exactly the mixed-type restore this file is trying to stop. Reading
+   through the same normalizer makes the guarantee a property of the
+   store rather than of whichever version wrote the file."
   [path]
   (when (fs/exists? path)
-    (edn/read-string (slurp path))))
+    (coerce/stringify-instants (edn/read-string (slurp path)))))
 
 (defn ^{:stratum 0} ordered-phase-ids
   "Phase ids in workflow pipeline order, filtered to checkpointed phases."

--- a/components/workflow/src/ai/miniforge/workflow/checkpoint_store.clj
+++ b/components/workflow/src/ai/miniforge/workflow/checkpoint_store.clj
@@ -16,7 +16,20 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns ai.miniforge.workflow.checkpoint-store
-  "Durable execution-machine snapshots and phase checkpoints."
+  "Durable execution-machine snapshots and phase checkpoints.
+
+   Strata, bottom-up: filenames, key lists and path normalization (0);
+   the per-run paths, the atomic write, and the snapshot/phase-record
+   builders (1); `resolve-checkpoint-root` and `phase-checkpoint-path`
+   (2); `build-manifest` and `load-checkpoint-data` (3);
+   `persist-execution-state!`, which drives all of it (4).
+
+   Five, two over the budget — SL003 fires here and fired identically
+   before this file carried any stratum metadata. The chain is real
+   (persist → manifest → per-phase path → atomic write → path
+   normalization), so closing it means splitting the namespace along
+   the path-resolution / record-building / persistence seam, not
+   renumbering what is here."
   (:require
    [ai.miniforge.coerce.interface :as coerce]
    [ai.miniforge.config.interface :as config]

--- a/components/workflow/src/ai/miniforge/workflow/checkpoint_store.clj
+++ b/components/workflow/src/ai/miniforge/workflow/checkpoint_store.clj
@@ -15,53 +15,43 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.workflow.checkpoint-store
   "Durable execution-machine snapshots and phase checkpoints."
   (:require
+   [ai.miniforge.coerce.interface :as coerce]
    [ai.miniforge.config.interface :as config]
    [ai.miniforge.workflow.schemas :as schemas]
    [babashka.fs :as fs]
-   [clojure.edn :as edn]
-   [clojure.walk :as walk]))
+   [clojure.edn :as edn]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Constants and path resolution
 
-(def checkpoint-root-option-key
+;; Constants and path resolution
+(def ^{:stratum 0} checkpoint-root-option-key
   "Execution option key for overriding the checkpoint root."
   :checkpoint/root)
 
-(def machine-snapshot-filename
+(def ^{:stratum 0} machine-snapshot-filename
   "Filename for the authoritative execution-machine snapshot."
   "machine-snapshot.edn")
 
-(def manifest-filename
+(def ^{:stratum 0} manifest-filename
   "Filename for the durable workflow checkpoint manifest."
   "manifest.edn")
 
-(def phase-checkpoints-directory-name
+(def ^{:stratum 0} phase-checkpoints-directory-name
   "Directory name for per-phase checkpoint files."
   "phases")
 
-(def temp-file-suffix
+(def ^{:stratum 0} temp-file-suffix
   "Temporary suffix used for atomic checkpoint writes."
   ".tmp")
 
-(defn- current-checkpoint-timestamp
+(defn- ^{:stratum 0} current-checkpoint-timestamp
   []
   (str (java.time.Instant/now)))
 
-(defn- serialize-checkpoint-value
-  [value]
-  (walk/postwalk
-   (fn [node]
-     (if (instance? java.time.Instant node)
-       (str node)
-       node))
-   value))
-
-(def persisted-execution-keys
+(def ^{:stratum 0} persisted-execution-keys
   "Serializable execution fields kept in the durable machine snapshot."
   [:execution/id
    :execution/workflow-id
@@ -88,61 +78,57 @@
    :execution/mode
    :execution/completed-with-warnings?])
 
-(defn- normalize-checkpoint-root
+(defn- ^{:stratum 0} normalize-checkpoint-root
   [checkpoint-root]
   (some-> checkpoint-root fs/expand-home str))
 
-(defn default-checkpoint-root
+(defn ^{:stratum 0} workflow-checkpoint-dir
+  "Directory for one workflow run's durable checkpoint state."
+  [checkpoint-root workflow-run-id]
+  (str (fs/path checkpoint-root (str workflow-run-id))))
+
+(defn- ^{:stratum 0} read-edn-file
+  [path]
+  (when (fs/exists? path)
+    (edn/read-string (slurp path))))
+
+(defn ^{:stratum 0} ordered-phase-ids
+  "Phase ids in workflow pipeline order, filtered to checkpointed phases."
+  [ctx]
+  (let [phase-results (:execution/phase-results ctx)
+        pipeline-phase-ids (map :phase (get-in ctx [:execution/workflow :workflow/pipeline]))
+        ordered-phase-ids (filter #(contains? phase-results %) pipeline-phase-ids)
+        remaining-phase-ids (remove (set ordered-phase-ids) (keys phase-results))]
+    (vec (concat ordered-phase-ids remaining-phase-ids))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} default-checkpoint-root
   "Default durable checkpoint root from merged config."
   []
   (normalize-checkpoint-root
    (or (get-in (config/load-merged-config) [:workflow :checkpoint-root])
        (str (config/miniforge-home) "/checkpoints"))))
 
-(defn resolve-checkpoint-root
-  "Resolve checkpoint root from context/opts/config."
-  ([]
-   (default-checkpoint-root))
-  ([m]
-   (normalize-checkpoint-root
-    (or (:execution/checkpoint-root m)
-        (get m checkpoint-root-option-key)
-        (get-in m [:execution/opts checkpoint-root-option-key])
-        (default-checkpoint-root)))))
-
-(defn workflow-checkpoint-dir
-  "Directory for one workflow run's durable checkpoint state."
-  [checkpoint-root workflow-run-id]
-  (str (fs/path checkpoint-root (str workflow-run-id))))
-
-(defn machine-snapshot-path
+(defn ^{:stratum 1} machine-snapshot-path
   "Path to the authoritative machine snapshot for a workflow run."
   [checkpoint-root workflow-run-id]
   (str (fs/path (workflow-checkpoint-dir checkpoint-root workflow-run-id)
                 machine-snapshot-filename)))
 
-(defn manifest-path
+(defn ^{:stratum 1} manifest-path
   "Path to the manifest for a workflow run."
   [checkpoint-root workflow-run-id]
   (str (fs/path (workflow-checkpoint-dir checkpoint-root workflow-run-id)
                 manifest-filename)))
 
-(defn phase-checkpoints-dir
+(defn ^{:stratum 1} phase-checkpoints-dir
   "Directory that stores per-phase checkpoint files."
   [checkpoint-root workflow-run-id]
   (str (fs/path (workflow-checkpoint-dir checkpoint-root workflow-run-id)
                 phase-checkpoints-directory-name)))
 
-(defn phase-checkpoint-path
-  "Path to a persisted phase checkpoint."
-  [checkpoint-root workflow-run-id phase-name]
-  (str (fs/path (phase-checkpoints-dir checkpoint-root workflow-run-id)
-                (str (name phase-name) ".edn"))))
-
-;------------------------------------------------------------------------------ Layer 0.5
-;; Serialization helpers
-
-(defn- write-edn-atomically!
+(defn- ^{:stratum 1} write-edn-atomically!
   [target-path data]
   (let [target (fs/file target-path)
         temp-path (str target-path temp-file-suffix)]
@@ -153,37 +139,30 @@
     (fs/move temp-path target-path)
     target-path))
 
-(defn- read-edn-file
-  [path]
-  (when (fs/exists? path)
-    (edn/read-string (slurp path))))
-
-(defn ordered-phase-ids
-  "Phase ids in workflow pipeline order, filtered to checkpointed phases."
-  [ctx]
-  (let [phase-results (:execution/phase-results ctx)
-        pipeline-phase-ids (map :phase (get-in ctx [:execution/workflow :workflow/pipeline]))
-        ordered-phase-ids (filter #(contains? phase-results %) pipeline-phase-ids)
-        remaining-phase-ids (remove (set ordered-phase-ids) (keys phase-results))]
-    (vec (concat ordered-phase-ids remaining-phase-ids))))
-
-(defn active-or-last-phase
+(defn ^{:stratum 1} active-or-last-phase
   "Current phase when present, otherwise the last checkpointed phase."
   [ctx]
   (or (:execution/current-phase ctx)
       (last (ordered-phase-ids ctx))))
 
-(defn build-machine-snapshot
-  "Build the durable machine snapshot for an execution context."
+(defn ^{:stratum 1} build-machine-snapshot
+  "Build the durable machine snapshot for an execution context.
+
+   Timestamps are normalized by type on the way out. Writers of
+   :execution/started-at / :execution/ended-at disagree today
+   (context.clj writes epoch millis, runner.clj an Instant), and
+   `inst?` admits a Date as readily as an Instant — so without
+   normalization a restore hands its reader an Instant-derived string
+   from one writer and a live Date from another for the same key."
   [ctx]
   (-> (select-keys ctx persisted-execution-keys)
-      serialize-checkpoint-value))
+      coerce/stringify-instants))
 
-(defn build-phase-checkpoint
+(defn ^{:stratum 1} build-phase-checkpoint
   "Build a durable per-phase checkpoint record."
   [ctx phase-name phase-result]
   (let [checkpointed-at (current-checkpoint-timestamp)]
-    (serialize-checkpoint-value
+    (coerce/stringify-instants
      {:workflow/id (:execution/id ctx)
       :workflow/workflow-id (:execution/workflow-id ctx)
       :workflow/workflow-version (:execution/workflow-version ctx)
@@ -191,7 +170,28 @@
       :workflow/checkpointed-at checkpointed-at
       :phase/result phase-result})))
 
-(defn build-manifest
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} resolve-checkpoint-root
+  "Resolve checkpoint root from context/opts/config."
+  ([]
+   (default-checkpoint-root))
+  ([m]
+   (normalize-checkpoint-root
+    (or (:execution/checkpoint-root m)
+        (get m checkpoint-root-option-key)
+        (get-in m [:execution/opts checkpoint-root-option-key])
+        (default-checkpoint-root)))))
+
+(defn ^{:stratum 2} phase-checkpoint-path
+  "Path to a persisted phase checkpoint."
+  [checkpoint-root workflow-run-id phase-name]
+  (str (fs/path (phase-checkpoints-dir checkpoint-root workflow-run-id)
+                (str (name phase-name) ".edn"))))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} build-manifest
   "Build the durable checkpoint manifest for an execution context."
   ([ctx checkpoint-root]
    (build-manifest ctx checkpoint-root nil))
@@ -212,7 +212,7 @@
                                                                   phase-id)]))
                                    current-phase-ids)
          phase-paths (merge existing-phase-paths current-phase-paths)]
-     (serialize-checkpoint-value
+     (coerce/stringify-instants
       {:workflow/id workflow-run-id
        :workflow/workflow-id (:execution/workflow-id ctx)
        :workflow/workflow-version (:execution/workflow-version ctx)
@@ -222,10 +222,36 @@
        :workflow/phase-checkpoints phase-paths
        :workflow/last-checkpoint-at (current-checkpoint-timestamp)}))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Persistence and restore inputs
+(defn ^{:stratum 3} load-checkpoint-data
+  "Load durable checkpoint data for a workflow run, if present."
+  ([workflow-run-id]
+   (load-checkpoint-data workflow-run-id {}))
+  ([workflow-run-id opts]
+   (try
+     (let [checkpoint-root (resolve-checkpoint-root opts)
+           manifest-path' (manifest-path checkpoint-root workflow-run-id)
+           manifest (read-edn-file manifest-path')
+           snapshot-path' (or (:workflow/machine-snapshot-path manifest)
+                              (machine-snapshot-path checkpoint-root workflow-run-id))
+           machine-snapshot (read-edn-file snapshot-path')
+           phase-paths (or (:workflow/phase-checkpoints manifest) {})
+           phase-results (into {}
+                               (keep (fn [[phase-id path]]
+                                       (when-let [checkpoint (read-edn-file path)]
+                                         [phase-id (:phase/result checkpoint)])))
+                               phase-paths)]
+       (when machine-snapshot
+         {:checkpoint/root checkpoint-root
+          :manifest manifest
+          :machine-snapshot machine-snapshot
+          :phase-results phase-results}))
+     (catch Exception _
+       nil))))
 
-(defn persist-execution-state!
+;------------------------------------------------------------------------------ Layer 4
+
+;; Persistence and restore inputs
+(defn ^{:stratum 4} persist-execution-state!
   "Persist a machine snapshot, manifest, and current phase checkpoint."
   [ctx]
   (when-let [workflow-run-id (:execution/id ctx)]
@@ -254,29 +280,3 @@
          :checkpoint/manifest-path manifest-path'}
         (catch Exception _
           nil)))))
-
-(defn load-checkpoint-data
-  "Load durable checkpoint data for a workflow run, if present."
-  ([workflow-run-id]
-   (load-checkpoint-data workflow-run-id {}))
-  ([workflow-run-id opts]
-   (try
-     (let [checkpoint-root (resolve-checkpoint-root opts)
-           manifest-path' (manifest-path checkpoint-root workflow-run-id)
-           manifest (read-edn-file manifest-path')
-           snapshot-path' (or (:workflow/machine-snapshot-path manifest)
-                              (machine-snapshot-path checkpoint-root workflow-run-id))
-           machine-snapshot (read-edn-file snapshot-path')
-           phase-paths (or (:workflow/phase-checkpoints manifest) {})
-           phase-results (into {}
-                               (keep (fn [[phase-id path]]
-                                       (when-let [checkpoint (read-edn-file path)]
-                                         [phase-id (:phase/result checkpoint)])))
-                               phase-paths)]
-       (when machine-snapshot
-         {:checkpoint/root checkpoint-root
-          :manifest manifest
-          :machine-snapshot machine-snapshot
-          :phase-results phase-results}))
-     (catch Exception _
-       nil))))

--- a/components/workflow/test/ai/miniforge/workflow/checkpoint_store_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/checkpoint_store_test.clj
@@ -210,3 +210,29 @@
         (is (= handoff
                (get-in checkpoint-data
                        [:phase-results :review :phase/handoff])))))))
+
+(deftest ^{:stratum 1} inst-tagged-checkpoint-loads-as-string-test
+  (testing "a checkpoint written before normalization restores as a string"
+    ;; Checkpoints already on disk predate the write-side normalization, so
+    ;; a Date in one of them was persisted as `#inst` — and EDN's reader
+    ;; hands that back as a Date, which is the mixed-type restore this
+    ;; change exists to stop. Written here by hand because the current
+    ;; write path can no longer produce it.
+    (with-temp-checkpoint-root
+      (fn [checkpoint-root]
+        (let [run-id (random-uuid)
+              snapshot-path (checkpoint-store/machine-snapshot-path
+                             checkpoint-root run-id)]
+          (io/make-parents snapshot-path)
+          ;; :started-at as the old writer left it (#inst), :ended-at as the
+          ;; new writer produces it — the mixed file an upgrade actually meets.
+          (spit snapshot-path
+                (pr-str {:execution/id run-id
+                         :execution/started-at (java.util.Date/from instant-stamp)
+                         :execution/ended-at (str instant-stamp)}))
+          (let [snapshot (:machine-snapshot
+                          (checkpoint-store/load-checkpoint-data
+                           run-id {:checkpoint/root checkpoint-root}))]
+            (is (string? (:execution/started-at snapshot)))
+            (is (= (:execution/ended-at snapshot)
+                   (:execution/started-at snapshot)))))))))

--- a/components/workflow/test/ai/miniforge/workflow/checkpoint_store_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/checkpoint_store_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.workflow.checkpoint-store-test
   (:require
    [clojure.java.io :as io]
@@ -24,7 +23,9 @@
    [ai.miniforge.workflow.context :as ctx]
    [ai.miniforge.workflow.interface :as workflow]))
 
-(defn- with-temp-checkpoint-root
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} with-temp-checkpoint-root
   [f]
   (let [root (doto (io/file (System/getProperty "java.io.tmpdir")
                             (str "mf-checkpoint-test-" (random-uuid)))
@@ -35,7 +36,41 @@
         (doseq [file (reverse (file-seq root))]
           (.delete ^java.io.File file))))))
 
-(deftest persist-and-load-checkpoint-data-test
+(def ^{:stratum 0} ^:private instant-stamp
+  "One instant, written twice — once as an Instant, once as the Date
+   `clojure.core/inst?` admits just as readily — so the snapshot can be
+   asserted to type them the same way on the way back out."
+  (java.time.Instant/parse "2026-04-24T00:00:00.123Z"))
+
+(deftest ^{:stratum 0} load-checkpoint-data-validates-at-interface-boundary-test
+  (testing "invalid checkpoint payloads are rejected at the public interface"
+    (with-redefs [checkpoint-store/load-checkpoint-data
+                  (fn [_workflow-run-id _opts]
+                    {:checkpoint/root "/tmp/checkpoints"
+                     :manifest {:workflow/id (random-uuid)
+                                :workflow/workflow-id :canonical-sdlc
+                                :workflow/workflow-version "1.0.0"
+                                :workflow/phases-completed [:plan]
+                                :workflow/machine-snapshot-path "/tmp/checkpoints/run/machine-snapshot.edn"
+                                :workflow/phase-checkpoints {:plan "/tmp/checkpoints/run/phases/plan.edn"}
+                                :workflow/last-checkpoint-at "2026-04-24T00:00:00Z"}
+                     :machine-snapshot {:execution/id (random-uuid)
+                                        :execution/workflow-id :canonical-sdlc
+                                        :execution/workflow-version "1.0.0"
+                                        :execution/status :running
+                                        :execution/fsm-state {:_state :running}
+                                        :execution/response-chain {}
+                                        :execution/errors []
+                                        :execution/artifacts []
+                                        :execution/metrics {}}
+                     :phase-results {:plan :invalid-phase-result}})]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"Invalid checkpoint data"
+                            (workflow/load-checkpoint-data (random-uuid) {}))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} persist-and-load-checkpoint-data-test
   (with-temp-checkpoint-root
     (fn [checkpoint-root]
       (let [workflow {:workflow/id :test
@@ -52,7 +87,9 @@
                                       :artifacts [{:artifact/id "art-1"}]
                                       :pause-reason :rate-limit})
                               (assoc :execution/current-phase :done
-                                     :execution/started-at (java.time.Instant/now)
+                                     :execution/started-at instant-stamp
+                                     :execution/ended-at (java.util.Date/from
+                                                          instant-stamp)
                                      :execution/output
                                      {:status :running
                                       :finished-at (java.time.Instant/now)}))
@@ -78,11 +115,21 @@
                                [:machine-snapshot
                                 :execution/output
                                 :finished-at]))))
+        (testing "a Date is typed the same as an Instant across a restore"
+          ;; Pre-fix the walker matched java.time.Instant only, so a Date
+          ;; kept its #inst print form and came back a Date — leaving
+          ;; :execution/started-at a String and :execution/ended-at a Date
+          ;; on the same restored snapshot, decided by which writer stamped
+          ;; them.
+          (is (string? (get-in checkpoint-data
+                               [:machine-snapshot :execution/ended-at])))
+          (is (= (get-in checkpoint-data [:machine-snapshot :execution/started-at])
+                 (get-in checkpoint-data [:machine-snapshot :execution/ended-at]))))
         (testing "manifest tracks checkpointed phases"
           (is (= [:done]
                  (get-in checkpoint-data [:manifest :workflow/phases-completed]))))))))
 
-(deftest persist-execution-state-validates-before-saving-test
+(deftest ^{:stratum 1} persist-execution-state-validates-before-saving-test
   (with-temp-checkpoint-root
     (fn [checkpoint-root]
       (let [workflow {:workflow/id :test
@@ -95,7 +142,7 @@
                               #"Invalid checkpoint data"
                               (checkpoint-store/persist-execution-state! invalid-ctx)))))))
 
-(deftest persist-execution-state-preserves-existing-phase-checkpoints-test
+(deftest ^{:stratum 1} persist-execution-state-preserves-existing-phase-checkpoints-test
   (testing "a resumed partial pipeline does not shrink the checkpoint manifest"
     (with-temp-checkpoint-root
       (fn [checkpoint-root]
@@ -137,7 +184,7 @@
             (is (= {:status :failed}
                    (get-in checkpoint-data [:phase-results :release])))))))))
 
-(deftest persist-execution-state-preserves-phase-handoffs-test
+(deftest ^{:stratum 1} persist-execution-state-preserves-phase-handoffs-test
   (with-temp-checkpoint-root
     (fn [checkpoint-root]
       (let [handoff {:frame/kind :repair-request
@@ -163,29 +210,3 @@
         (is (= handoff
                (get-in checkpoint-data
                        [:phase-results :review :phase/handoff])))))))
-
-(deftest load-checkpoint-data-validates-at-interface-boundary-test
-  (testing "invalid checkpoint payloads are rejected at the public interface"
-    (with-redefs [checkpoint-store/load-checkpoint-data
-                  (fn [_workflow-run-id _opts]
-                    {:checkpoint/root "/tmp/checkpoints"
-                     :manifest {:workflow/id (random-uuid)
-                                :workflow/workflow-id :canonical-sdlc
-                                :workflow/workflow-version "1.0.0"
-                                :workflow/phases-completed [:plan]
-                                :workflow/machine-snapshot-path "/tmp/checkpoints/run/machine-snapshot.edn"
-                                :workflow/phase-checkpoints {:plan "/tmp/checkpoints/run/phases/plan.edn"}
-                                :workflow/last-checkpoint-at "2026-04-24T00:00:00Z"}
-                     :machine-snapshot {:execution/id (random-uuid)
-                                        :execution/workflow-id :canonical-sdlc
-                                        :execution/workflow-version "1.0.0"
-                                        :execution/status :running
-                                        :execution/fsm-state {:_state :running}
-                                        :execution/response-chain {}
-                                        :execution/errors []
-                                        :execution/artifacts []
-                                        :execution/metrics {}}
-                     :phase-results {:plan :invalid-phase-result}})]
-      (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                            #"Invalid checkpoint data"
-                            (workflow/load-checkpoint-data (random-uuid) {}))))))


### PR DESCRIPTION
Last of three in the `inst?` sweep. #1605 and #1606 are merged; this
rebases onto them.

Third and last copy of the Instant-only postwalk found in the #1602
sweep.

## What was wrong

`serialize-checkpoint-value` matched `java.time.Instant` only, so a
`java.util.Date` — which `clojure.core/inst?` admits equally — kept its
`#inst` print form through `pr-str` and came back from
`edn/read-string` as a Date. The result was **asymmetric typing across
a restore**: `:execution/started-at` arriving as a String and
`:execution/ended-at` as a Date on the same snapshot, decided by which
writer stamped them. The two writers genuinely disagree today —
`context.clj` writes epoch millis via `System/currentTimeMillis`,
`runner.clj` writes an `Instant`.

## Severity — stated plainly

This is a **consistency** defect, not corruption, and unlike the
cursor-store case in #1605 nothing observable is currently broken by
it. I traced every consumer of a restored checkpoint timestamp:
`context/->epoch-millis` is the only one, it handles `number?` and
`Instant` and returns nil for everything else, so a String and a Date
both already produced nil after a restore. The wall-clock duration
stamp behaves identically before and after this change. (The one other
`.toInstant` in the component, `dag_resilience.clj:123`, parses
rate-limit text and never touches a checkpoint.)

What changes is that a reader can now rely on one type. The reason to
fix it in the same sweep rather than leave it: the next person to add
an `Instant/parse` on the read side would write code that works for
one writer and throws for the other, with nothing in the file to warn
them.

## The change

- `serialize-checkpoint-value` is gone; the three call sites use
  `coerce/stringify-instants` (#1605) directly. A one-line private
  delegate would have added a hop for nothing.
- `build-machine-snapshot`'s docstring now records why normalization
  is there at all, including the writer disagreement above.
- Removed a stranded `Layer 0.5 / Serialization helpers` banner the
  stratum autofix left sitting mid-Layer-1 after it reordered the file.
- Second commit documents the file's actual stratum map. Copilot found
  the equivalent drift on the etl base in #1606 — prose describing a
  layering the file no longer had once the autofix assigned real
  metadata. This file had no layer prose at all, which is the same
  problem one step earlier: SL003 is visible in CI with nothing in the
  file explaining it.

## Tests

Extends the existing round-trip test rather than adding a parallel
one: the same instant goes in twice, once as an `Instant`
(`:execution/started-at`) and once as the `Date` `inst?` admits just
as readily (`:execution/ended-at`). Both must come back as the same
string. Confirmed to fail against the unfixed source:

```
expected: (string? (get-in checkpoint-data [:machine-snapshot :execution/ended-at]))
  actual: (not (string? #inst "2026-04-24T00:00:00.123-00:00"))
```

## Notes for review

**Stratum.** Committed with `MINIFORGE_STRATUM_BUDGET_MODE=warn`.
`checkpoint_store.clj` reports SL003 (5 distinct layers, max 3).
Linting the unmodified HEAD file returns the identical finding. This
PR adds no layer; it removes a stale banner and documents the rest.
The chain is real (persist → manifest → per-phase path → atomic write
→ path normalization), so closing SL003 means splitting the namespace,
not renumbering — out of scope for a normalizer swap.

**Why the sweep is three PRs.** The local `bb commit-budget` caps a
commit at 200 reportable lines. The main commit here measures 249, of
which ~174 are the repo's own stratum autofix mechanically
re-annotating and reordering a file that has never carried stratum
metadata. Verified by running the same autofix against the unmodified
HEAD copy: it produces the identical rewrite, so that cost is incurred
by touching the file at all. The substantive diff is ~26 lines.

| file | reportable | of which mechanical |
|---|---|---|
| `checkpoint_store.clj` | 174 | ~148 |
| `checkpoint_store_test.clj` | 74 | ~55 |
| `deps.edn` | 1 | 0 |

Slicing further is not possible — the churn is per-file and
indivisible. So this commit used `MINIFORGE_COMMIT_BUDGET_OVERRIDE`
with that rationale, while #1605 and #1606 both fit the budget on
their own. For the record, CI's `bb pr-budget` runs a **600**-line
ceiling and needed no override; the override was for the stricter
local commit gate only.

## Gates

- `bb lint:clj` — 0 errors, 0 warnings
- `bb lint:stratum` — pre-existing SL003 only (above)
- `bb poly:check` — only pre-existing warnings 205 and 207
- `bb commit-budget` — 249 (overridden, rationale above) and 13
- CI `bb pr-budget` — 249 / 600 OK
- `bb pre-commit` — ALL PASSED on each commit (331 tests / 1244 assertions smoke, GraalVM 8 / 562)
- `bb test` — stable-derived plan passed
- workflow suites, run directly post-rebase — 39 tests / 113 assertions across checkpoint-store, runner, context-duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)