### PR TITLE
fix(evidence-bundle): EvidenceCollector implements WorkflowObserver, split to fit budget

### DIFF
--- a/components/evidence-bundle/IMPLEMENTATION_SUMMARY.md
+++ b/components/evidence-bundle/IMPLEMENTATION_SUMMARY.md
@@ -6,7 +6,9 @@
 
 ## Overview
 
-The evidence-bundle component implements the N6 Evidence & Provenance Standard, providing comprehensive audit trails for autonomous workflow execution. This component enables traceability, compliance, and semantic intent validation for all workflows.
+The evidence-bundle component implements the N6 Evidence & Provenance Standard, providing comprehensive audit trails for
+autonomous workflow execution. This component enables traceability, compliance, and semantic intent validation for all
+workflows.
 
 ## Implementation Status
 
@@ -242,7 +244,7 @@ The implementation follows established patterns from recent PRs:
 
 ```clojure
 (def wf (-> (workflow/create-workflow)
-            (integration/create-and-attach-evidence-collector artifact-store)))
+            (integration-factory/create-and-attach-evidence-collector artifact-store)))
 ;; Bundle created automatically on workflow completion
 ```
 
@@ -270,7 +272,7 @@ The implementation follows established patterns from recent PRs:
 
 ## File Structure
 
-```
+```text
 components/evidence-bundle/
 ├── deps.edn                                           # Component dependencies
 ├── README.md                                          # Component documentation
@@ -375,4 +377,5 @@ The evidence-bundle component is **complete and ready for integration**. It prov
 4. **Debugging**: Phase evidence linked to event streams
 5. **Trust**: Policy checks and semantic validation results
 
-The component is fully conformant with the N6 Evidence & Provenance Standard (sections 2-7) and follows all established development patterns and guidelines.
+The component is fully conformant with the N6 Evidence & Provenance Standard (sections 2-7) and follows all established
+development patterns and guidelines.

--- a/components/evidence-bundle/README.md
+++ b/components/evidence-bundle/README.md
@@ -1,6 +1,7 @@
 # Evidence Bundle Component
 
-The evidence-bundle component provides comprehensive audit trails for autonomous workflow execution, implementing the N6 Evidence & Provenance Standard.
+The evidence-bundle component provides comprehensive audit trails for autonomous workflow execution, implementing the N6
+Evidence & Provenance Standard.
 
 ## Purpose
 
@@ -16,7 +17,7 @@ Evidence bundles make autonomous workflows **credible** by providing:
 
 The component follows the established protocol extraction pattern:
 
-```
+```text
 evidence-bundle/
 ├── src/ai/miniforge/evidence_bundle/
 │   ├── interface.clj                          # Public API
@@ -104,12 +105,12 @@ Protocol for semantic intent validation:
 ### Automatic Evidence Collection
 
 ```clojure
-(require '[ai.miniforge.evidence-bundle.workflow-integration :as integration]
+(require '[ai.miniforge.evidence-bundle.workflow-integration-factory :as integration-factory]
          '[ai.miniforge.workflow.interface :as workflow])
 
 ;; Attach evidence collector to workflow
 (def wf (-> (workflow/create-workflow)
-            (integration/create-and-attach-evidence-collector artifact-store)
+            (integration-factory/create-and-attach-evidence-collector artifact-store)
             (workflow/start spec context)))
 
 ;; Evidence bundle created automatically on workflow completion

--- a/components/evidence-bundle/resources/examples/basic_usage.clj
+++ b/components/evidence-bundle/resources/examples/basic_usage.clj
@@ -167,6 +167,7 @@
 
 (comment
   (require '[ai.miniforge.evidence-bundle.workflow-integration :as integration]
+           '[ai.miniforge.evidence-bundle.workflow-integration-factory :as integration-factory]
            '[ai.miniforge.workflow.interface :as workflow])
 
   (def artifact-store (artifact/create-transit-store))
@@ -174,7 +175,7 @@
   ;; Method 1: Manual setup
   (def evidence-mgr (evidence/create-evidence-manager
                      {:artifact-store artifact-store}))
-  (def collector (integration/create-evidence-collector
+  (def collector (integration-factory/create-evidence-collector
                   {:evidence-manager evidence-mgr
                    :artifact-store artifact-store}))
 
@@ -183,7 +184,7 @@
 
   ;; Method 2: Convenience function
   (def wf2 (-> (workflow/create-workflow)
-               (integration/create-and-attach-evidence-collector artifact-store)))
+               (integration-factory/create-and-attach-evidence-collector artifact-store)))
 
   ;; Now run workflow - evidence bundle created automatically on completion
   (def example-spec {:spec/title "Example workflow"})

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/workflow_integration.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/workflow_integration.clj
@@ -15,59 +15,26 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.evidence-bundle.workflow-integration
   "Integration hooks for automatic evidence collection in workflows.
-   Provides WorkflowObserver implementation for evidence bundle generation."
+   Provides the WorkflowObserver implementation for evidence bundle
+   generation. Collector construction and the create+attach convenience
+   composite live in `workflow-integration-factory` (rule 210: adding
+   the WorkflowObserver implementation here is one real layer deeper
+   than a bare Object record, and that extra hop is the signal to
+   split it).
+
+   Layer 0: Workflow completion handler + attach-to-workflow
+   Layer 1: EvidenceCollector record (WorkflowObserver impl)"
   (:require
    [ai.miniforge.evidence-bundle.interface :as evidence]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.workflow.interface :as workflow]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Observer Record
 
-(defrecord EvidenceCollector [evidence-manager artifact-store logger]
-  ;; Implement WorkflowObserver protocol if it exists in workflow component
-  ;; This enables automatic evidence collection on workflow completion
-
-  Object
-  (toString [_] "EvidenceCollector"))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Observer Factory
-
-(defn create-evidence-collector
-  "Create an evidence collector for workflow integration.
-
-   The evidence collector acts as a workflow observer that automatically
-   creates evidence bundles when workflows complete (success or failure).
-
-   Options:
-   - :evidence-manager - Evidence bundle manager (required)
-   - :artifact-store - Artifact store for provenance (required)
-   - :logger - Optional logger instance
-
-   Example:
-     (def collector (create-evidence-collector
-                     {:evidence-manager mgr
-                      :artifact-store store}))
-     (workflow/add-observer workflow collector)"
-  [opts]
-  (let [{:keys [evidence-manager artifact-store logger]} opts]
-    (when-not evidence-manager
-      (throw (ex-info "evidence-manager required" {:opts opts})))
-    (when-not artifact-store
-      (throw (ex-info "artifact-store required" {:opts opts})))
-    (->EvidenceCollector
-     evidence-manager
-     artifact-store
-     (or logger (log/create-logger {:min-level :info})))))
-
-;------------------------------------------------------------------------------ Layer 2
 ;; Workflow Completion Handler
-
-(defn on-workflow-complete
+(defn ^{:stratum 0} on-workflow-complete
   "Handle workflow completion event.
    Automatically creates evidence bundle for the completed workflow.
 
@@ -102,10 +69,8 @@
                          :trace (vec (.getStackTrace e))}})
       nil)))
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Integration Utilities
-
-(defn attach-to-workflow
+(defn ^{:stratum 0} attach-to-workflow
   "Attach evidence collector to a workflow instance.
 
    This is a convenience function that adds the evidence collector
@@ -125,54 +90,25 @@
   (workflow/add-observer workflow-instance collector)
   workflow-instance)
 
-(defn create-and-attach-evidence-collector
-  "Create evidence collector and attach to workflow in one step.
+;------------------------------------------------------------------------------ Layer 1
 
-   This is the simplest way to enable automatic evidence collection.
+;; Observer Record
+;;
+;; Implements WorkflowObserver so attaching this record via
+;; workflow/add-observer doesn't throw IllegalArgumentException the
+;; first time the workflow engine invokes any observer callback.
+;; on-workflow-complete delegates to the free fn above (defined first
+;; in this namespace so the delegating call resolves); the collector
+;; only cares about workflow completion, so the other four callbacks
+;; are no-ops.
+(defrecord ^{:stratum 1} EvidenceCollector [evidence-manager artifact-store logger]
+  workflow/WorkflowObserver
+  (on-phase-start [_ _workflow-id _phase _context] nil)
+  (on-phase-complete [_ _workflow-id _phase _result] nil)
+  (on-phase-error [_ _workflow-id _phase _error] nil)
+  (on-workflow-complete [this workflow-id final-state]
+    (on-workflow-complete this workflow-id final-state))
+  (on-rollback [_ _workflow-id _from-phase _to-phase _reason] nil)
 
-   Arguments:
-   - workflow: Workflow instance
-   - artifact-store: Artifact store instance
-
-   Returns the workflow instance (for chaining).
-
-   Example:
-     (-> (workflow/create-workflow)
-         (create-and-attach-evidence-collector artifact-store)
-         (workflow/start spec context))"
-  [workflow artifact-store]
-  (let [evidence-manager (evidence/create-evidence-manager
-                          {:artifact-store artifact-store})
-        collector (create-evidence-collector
-                   {:evidence-manager evidence-manager
-                    :artifact-store artifact-store})]
-    (attach-to-workflow workflow collector)))
-
-;------------------------------------------------------------------------------ Rich Comment
-
-(comment
-  (require '[ai.miniforge.artifact.interface :as artifact])
-
-  ;; Create artifact store
-  (def artifact-store (artifact/create-transit-store))
-
-  ;; Create evidence manager
-  (def evidence-mgr (evidence/create-evidence-manager
-                     {:artifact-store artifact-store}))
-
-  ;; Create evidence collector
-  (def collector (create-evidence-collector
-                  {:evidence-manager evidence-mgr
-                   :artifact-store artifact-store}))
-
-  ;; Attach to workflow
-  (def wf (-> (workflow/create-workflow)
-              (attach-to-workflow collector)))
-
-  ;; Or use the convenience function
-  (def wf2 (-> (workflow/create-workflow)
-               (create-and-attach-evidence-collector artifact-store)))
-
-  ;; Now evidence bundles will be created automatically on workflow completion
-
-  :end)
+  Object
+  (toString [_] "EvidenceCollector"))

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/workflow_integration_factory.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/workflow_integration_factory.clj
@@ -1,0 +1,114 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.evidence-bundle.workflow-integration-factory
+  "Construction and attachment helpers for `workflow-integration`'s
+   EvidenceCollector, split out of `workflow-integration` (rule 210:
+   the WorkflowObserver implementation there added one real layer, and
+   this factory/composite pair would have tipped the combined file
+   over the 3-layer budget).
+
+   Layer 0: Collector factory
+   Layer 1: Create+attach convenience composite"
+  (:require
+   [ai.miniforge.evidence-bundle.interface :as evidence]
+   [ai.miniforge.evidence-bundle.workflow-integration :as workflow-integration]
+   [ai.miniforge.logging.interface :as log]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Observer Factory
+(defn ^{:stratum 0} create-evidence-collector
+  "Create an evidence collector for workflow integration.
+
+   The evidence collector acts as a workflow observer that automatically
+   creates evidence bundles when workflows complete (success or failure).
+
+   Options:
+   - :evidence-manager - Evidence bundle manager (required)
+   - :artifact-store - Artifact store for provenance (required)
+   - :logger - Optional logger instance
+
+   Example:
+     (def collector (create-evidence-collector
+                     {:evidence-manager mgr
+                      :artifact-store store}))
+     (workflow/add-observer workflow collector)"
+  [opts]
+  (let [{:keys [evidence-manager artifact-store logger]} opts]
+    (when-not evidence-manager
+      (throw (ex-info "evidence-manager required" {:opts opts})))
+    (when-not artifact-store
+      (throw (ex-info "artifact-store required" {:opts opts})))
+    (workflow-integration/->EvidenceCollector
+     evidence-manager
+     artifact-store
+     (or logger (log/create-logger {:min-level :info})))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} create-and-attach-evidence-collector
+  "Create evidence collector and attach to workflow in one step.
+
+   This is the simplest way to enable automatic evidence collection.
+
+   Arguments:
+   - workflow: Workflow instance
+   - artifact-store: Artifact store instance
+
+   Returns the workflow instance (for chaining).
+
+   Example:
+     (-> (workflow/create-workflow)
+         (create-and-attach-evidence-collector artifact-store)
+         (workflow/start spec context))"
+  [workflow artifact-store]
+  (let [evidence-manager (evidence/create-evidence-manager
+                          {:artifact-store artifact-store})
+        collector (create-evidence-collector
+                   {:evidence-manager evidence-manager
+                    :artifact-store artifact-store})]
+    (workflow-integration/attach-to-workflow workflow collector)))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (require '[ai.miniforge.artifact.interface :as artifact]
+           '[ai.miniforge.workflow.interface :as workflow])
+
+  ;; Create artifact store
+  (def artifact-store (artifact/create-transit-store))
+
+  ;; Create evidence manager
+  (def evidence-mgr (evidence/create-evidence-manager
+                     {:artifact-store artifact-store}))
+
+  ;; Create evidence collector
+  (def collector (create-evidence-collector
+                  {:evidence-manager evidence-mgr
+                   :artifact-store artifact-store}))
+
+  ;; Attach to workflow
+  (def wf (-> (workflow/create-workflow)
+              (workflow-integration/attach-to-workflow collector)))
+
+  ;; Or use the convenience function
+  (def wf2 (-> (workflow/create-workflow)
+               (create-and-attach-evidence-collector artifact-store)))
+
+  ;; Now evidence bundles will be created automatically on workflow completion
+
+  :end)


### PR DESCRIPTION
## Summary

Split out of #1531 per user direction (that PR was closed -- old
whole-component Wave-1 convention, over both the size and structural
budget against current main; the remainder is being re-opened as
per-file PRs).

- `EvidenceCollector` (in `workflow_integration.clj`) is attached to
  workflows via `workflow/add-observer`, and the workflow engine
  invokes `WorkflowObserver` protocol methods on every observer. The
  record only implemented `Object` -- attaching it would throw
  `IllegalArgumentException` (no protocol method impl) the first time
  the engine called any observer callback, silently breaking automatic
  evidence collection. Now implements `workflow/WorkflowObserver`
  directly; `on-workflow-complete` delegates to the existing free fn,
  the other four callbacks are no-ops (unused by this collector).
- That fix added one real same-file dependency hop (the record now
  depends on the free fn), pushing the file from 3 layers to 4 and
  tripping SL003. Split at the natural seam: `workflow_integration.clj`
  keeps the observer core (handler + attach-to-workflow + the record)
  at 2 layers; `workflow_integration_factory.clj` takes construction
  and composition (`create-evidence-collector`,
  `create-and-attach-evidence-collector`) at 2 layers of its own.

Nothing outside this component referenced `workflow-integration`
directly (confirmed by repo-wide grep), so no other call sites needed
updating.

## Verification

- Both files lint clean (`clj-kondo`, `stratum-lint`).
- `satisfies?` confirms the record implements `WorkflowObserver`; all
  five methods callable without throwing.
- `on-workflow-complete` via the protocol produces the same log event
  and return value as calling the free function directly -- no
  infinite recursion, no double dispatch.
- Full pre-commit suite (poly check, clj-kondo, stratum-lint, smoke
  tests, GraalVM/Babashka compatibility) passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>