### PR TITLE
refactor(evidence-bundle): stratum-lint annotations for chain_evidence.clj

### DIFF
--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/chain_evidence.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/chain_evidence.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.evidence-bundle.chain-evidence
   "Chain-level evidence aggregation.
 
@@ -24,9 +23,9 @@
   (:require [ai.miniforge.phase.interface :as phase]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Step Summarization
 
-(defn summarize-step
+;; Step Summarization
+(defn ^{:stratum 0} summarize-step
   "Create a summary of a single chain step for inclusion in chain evidence.
 
    Arguments:
@@ -46,10 +45,8 @@
    :step/status (:step/status step-result)
    :step/has-output? (some? (:step/output step-result))})
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Metrics Aggregation
-
-(defn aggregate-metrics
+(defn ^{:stratum 0} aggregate-metrics
   "Aggregate timing and count metrics across chain steps.
 
    Arguments:
@@ -70,22 +67,24 @@
      :failed-steps failed
      :steps-with-output with-output}))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Chain Evidence Creation
-
-(defn derive-chain-status
+(defn ^{:stratum 0} derive-chain-status
   "Derive chain evidence status from the chain result."
   [chain-result]
   (if (phase/succeeded? chain-result)
     :completed
     :failed))
 
-(defn build-step-summaries
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} build-step-summaries
   "Build step summaries from chain step results."
   [step-results]
   (vec (map-indexed (fn [idx sr] (summarize-step sr idx)) step-results)))
 
-(defn create-chain-evidence
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} create-chain-evidence
   "Create a chain-level evidence record from chain execution results.
 
    Arguments:

--- a/components/evidence-bundle/test/ai/miniforge/evidence_bundle/chain_evidence_test.clj
+++ b/components/evidence-bundle/test/ai/miniforge/evidence_bundle/chain_evidence_test.clj
@@ -15,22 +15,22 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.evidence-bundle.chain-evidence-test
   "Tests for chain-level evidence aggregation."
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.evidence-bundle.interface :as evidence]))
 
-;------------------------------------------------------------------------------ Test Data
+;------------------------------------------------------------------------------ Layer 0
 
-(def test-chain-def
+;------------------------------------------------------------------------------ Test Data
+(def ^{:stratum 0} test-chain-def
   {:chain/id :test-chain
    :chain/version "1.0.0"
    :chain/steps [{:step/id :plan :step/workflow-id :planning}
                  {:step/id :implement :step/workflow-id :implementation}]})
 
-(def test-chain-result
+(def ^{:stratum 0} test-chain-result
   {:chain/id :test-chain
    :chain/status :completed
    :chain/duration-ms 5000
@@ -43,7 +43,7 @@
                          :step/status :completed
                          :step/output nil}]})
 
-(def test-failed-chain-result
+(def ^{:stratum 0} test-failed-chain-result
   {:chain/id :test-chain
    :chain/status :failed
    :chain/duration-ms 2000
@@ -56,37 +56,8 @@
                          :step/status :failed
                          :step/output nil}]})
 
-;------------------------------------------------------------------------------ create-chain-evidence Tests
-
-(deftest create-chain-evidence-success-test
-  (testing "Creates evidence with all required fields for successful chain"
-    (let [ev (evidence/create-chain-evidence test-chain-def test-chain-result)]
-      (is (uuid? (:chain-evidence/id ev)))
-      (is (= :test-chain (:chain-evidence/chain-id ev)))
-      (is (= "1.0.0" (:chain-evidence/chain-version ev)))
-      (is (= 2 (:chain-evidence/step-count ev)))
-      (is (= :completed (:chain-evidence/status ev)))
-      (is (= 5000 (:chain-evidence/duration-ms ev)))
-      (is (= 2 (count (:chain-evidence/step-summaries ev))))
-      (is (inst? (:chain-evidence/created-at ev))))))
-
-(deftest create-chain-evidence-failed-test
-  (testing "Creates evidence with :failed status for failed chain"
-    (let [ev (evidence/create-chain-evidence test-chain-def test-failed-chain-result)]
-      (is (= :failed (:chain-evidence/status ev)))
-      (is (= 2000 (:chain-evidence/duration-ms ev))))))
-
-(deftest create-chain-evidence-step-bundles-test
-  (testing "Includes step-bundles when provided in opts"
-    (let [bundle-ids [#uuid "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
-                      #uuid "11111111-2222-3333-4444-555555555555"]
-          ev (evidence/create-chain-evidence test-chain-def test-chain-result
-                                             {:step-bundles bundle-ids})]
-      (is (= bundle-ids (:chain-evidence/step-bundles ev))))))
-
 ;------------------------------------------------------------------------------ summarize-step Tests
-
-(deftest summarize-step-with-output-test
+(deftest ^{:stratum 0} summarize-step-with-output-test
   (testing "Step with output has :step/has-output? true"
     (let [step-result {:step/id :plan
                        :step/workflow-id :planning
@@ -99,7 +70,7 @@
       (is (= :completed (:step/status summary)))
       (is (true? (:step/has-output? summary))))))
 
-(deftest summarize-step-without-output-test
+(deftest ^{:stratum 0} summarize-step-without-output-test
   (testing "Step without output has :step/has-output? false"
     (let [step-result {:step/id :implement
                        :step/workflow-id :implementation
@@ -109,8 +80,7 @@
       (is (false? (:step/has-output? summary))))))
 
 ;------------------------------------------------------------------------------ aggregate-metrics Tests
-
-(deftest aggregate-metrics-mixed-test
+(deftest ^{:stratum 0} aggregate-metrics-mixed-test
   (testing "Correctly counts completed, failed, and output steps"
     (let [step-results [{:step/id :a :step/status :completed :step/output {:x 1}}
                         {:step/id :b :step/status :completed :step/output nil}
@@ -120,3 +90,32 @@
       (is (= 2 (:completed-steps metrics)))
       (is (= 1 (:failed-steps metrics)))
       (is (= 1 (:steps-with-output metrics))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;------------------------------------------------------------------------------ create-chain-evidence Tests
+(deftest ^{:stratum 1} create-chain-evidence-success-test
+  (testing "Creates evidence with all required fields for successful chain"
+    (let [ev (evidence/create-chain-evidence test-chain-def test-chain-result)]
+      (is (uuid? (:chain-evidence/id ev)))
+      (is (= :test-chain (:chain-evidence/chain-id ev)))
+      (is (= "1.0.0" (:chain-evidence/chain-version ev)))
+      (is (= 2 (:chain-evidence/step-count ev)))
+      (is (= :completed (:chain-evidence/status ev)))
+      (is (= 5000 (:chain-evidence/duration-ms ev)))
+      (is (= 2 (count (:chain-evidence/step-summaries ev))))
+      (is (inst? (:chain-evidence/created-at ev))))))
+
+(deftest ^{:stratum 1} create-chain-evidence-failed-test
+  (testing "Creates evidence with :failed status for failed chain"
+    (let [ev (evidence/create-chain-evidence test-chain-def test-failed-chain-result)]
+      (is (= :failed (:chain-evidence/status ev)))
+      (is (= 2000 (:chain-evidence/duration-ms ev))))))
+
+(deftest ^{:stratum 1} create-chain-evidence-step-bundles-test
+  (testing "Includes step-bundles when provided in opts"
+    (let [bundle-ids [#uuid "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+                      #uuid "11111111-2222-3333-4444-555555555555"]
+          ev (evidence/create-chain-evidence test-chain-def test-chain-result
+                                             {:step-bundles bundle-ids})]
+      (is (= bundle-ids (:chain-evidence/step-bundles ev))))))


### PR DESCRIPTION
Split out of #1531 per user direction. Mechanical `stratum-lint --fix` pass over `chain_evidence.clj` + `chain_evidence_test.clj` (previously unannotated). Both pass within the 3-layer SL003 budget, no split needed. Full pre-commit suite passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>