### PR TITLE
refactor(evidence-bundle): stratum-lint annotations for scanner.clj

### DIFF
--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/scanner.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/scanner.clj
@@ -15,11 +15,12 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.evidence-bundle.scanner
   "Sensitive-data scanner for assembled evidence bundles.")
 
-(def ^:private sensitive-patterns
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private sensitive-patterns
   [{:finding/type :email
     :finding/pattern #"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}"}
    {:finding/type :ssn
@@ -27,16 +28,18 @@
    {:finding/type :aws-access-key
     :finding/pattern #"\bAKIA[0-9A-Z]{16}\b"}])
 
-(def ^:private pii-finding-types
+(def ^{:stratum 0} ^:private pii-finding-types
   #{:email :ssn})
 
-(defn- bundle-text
+(defn- ^{:stratum 0} bundle-text
   [bundle]
   (binding [*print-length* 1000
             *print-level* 20]
     (pr-str bundle)))
 
-(defn scan-artifact
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} scan-artifact
   "Scan an evidence bundle and return sensitive-data findings.
 
    The scanner reports finding types only; matched secret values are not
@@ -50,7 +53,7 @@
                 {:finding/type type}))
             sensitive-patterns))}))
 
-(defn compliance-metadata
+(defn ^{:stratum 1} compliance-metadata
   "Convert scan results into evidence compliance metadata."
   [scan-result]
   (let [findings (:scan/findings scan-result)

--- a/components/evidence-bundle/test/ai/miniforge/evidence_bundle/scanner_test.clj
+++ b/components/evidence-bundle/test/ai/miniforge/evidence_bundle/scanner_test.clj
@@ -15,13 +15,14 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.evidence-bundle.scanner-test
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.evidence-bundle.scanner :as scanner]))
 
-(deftest scan-artifact-reports-finding-types-only
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} scan-artifact-reports-finding-types-only
   (testing "sensitive values are detected but not copied into evidence"
     (let [result (scanner/scan-artifact
                   {:evidence/intent
@@ -32,13 +33,13 @@
               :compliance/sensitive-findings [{:finding/type :email}]}
              metadata)))))
 
-(deftest compliance-metadata-is-empty-without-findings
+(deftest ^{:stratum 0} compliance-metadata-is-empty-without-findings
   (testing "absence of findings does not overwrite caller-provided compliance flags"
     (is (= {} (scanner/compliance-metadata (scanner/scan-artifact
                                             {:evidence/intent
                                              {:intent/description "No sensitive data"}}))))))
 
-(deftest compliance-metadata-keeps-secrets-separate-from-pii
+(deftest ^{:stratum 0} compliance-metadata-keeps-secrets-separate-from-pii
   (testing "secret findings do not imply personal information"
     (let [result (scanner/scan-artifact
                   {:evidence/intent


### PR DESCRIPTION
Split out of #1531 per user direction. Mechanical `stratum-lint --fix` pass over `scanner.clj` + `scanner_test.clj` (previously unannotated, no Layer headings at all). Both pass within the 3-layer SL003 budget. Full pre-commit suite passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>