### PR TITLE
refactor(evidence-bundle): stratum-lint annotations for hash_test.clj + outcome_anomaly_shape_test.clj

### DIFF
--- a/components/evidence-bundle/test/ai/miniforge/evidence_bundle/hash_test.clj
+++ b/components/evidence-bundle/test/ai/miniforge/evidence_bundle/hash_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.evidence-bundle.hash-test
   "Tests for SHA-256 content hashing."
   (:require
@@ -23,16 +22,16 @@
    [ai.miniforge.evidence-bundle.interface :as evidence]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Content Hash Tests
 
-(deftest content-hash-deterministic-test
+;; Content Hash Tests
+(deftest ^{:stratum 0} content-hash-deterministic-test
   (testing "Returns consistent hash for same input"
     (let [content {:type :terraform-plan :body "resource aws_instance"}
           hash-1 (evidence/content-hash content)
           hash-2 (evidence/content-hash content)]
       (is (= hash-1 hash-2)))))
 
-(deftest content-hash-uniqueness-test
+(deftest ^{:stratum 0} content-hash-uniqueness-test
   (testing "Returns different hash for different input"
     (let [content-a {:type :terraform-plan :body "resource aws_instance"}
           content-b {:type :terraform-plan :body "resource aws_s3_bucket"}
@@ -40,7 +39,7 @@
           hash-b (evidence/content-hash content-b)]
       (is (not= hash-a hash-b)))))
 
-(deftest content-hash-format-test
+(deftest ^{:stratum 0} content-hash-format-test
   (testing "Hash is a 64-char hex string (SHA-256)"
     (let [content {:foo "bar"}
           h (evidence/content-hash content)]
@@ -48,13 +47,13 @@
       (is (= 64 (count h)))
       (is (re-matches #"[0-9a-f]{64}" h)))))
 
-(deftest content-hash-string-input-test
+(deftest ^{:stratum 0} content-hash-string-input-test
   (testing "Handles string content"
     (let [h (evidence/content-hash "hello world")]
       (is (= 64 (count h)))
       (is (re-matches #"[0-9a-f]{64}" h)))))
 
-(deftest content-hash-nil-input-test
+(deftest ^{:stratum 0} content-hash-nil-input-test
   (testing "Handles nil content"
     (let [h (evidence/content-hash nil)]
       (is (= 64 (count h)))

--- a/components/evidence-bundle/test/ai/miniforge/evidence_bundle/outcome_anomaly_shape_test.clj
+++ b/components/evidence-bundle/test/ai/miniforge/evidence_bundle/outcome_anomaly_shape_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.evidence-bundle.outcome-anomaly-shape-test
   "Lock the dual-shape anomaly detection in `build-outcome-evidence`
    after the W2 anomaly convergence flip.
@@ -33,9 +32,9 @@
    [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Fixtures + factories
 
-(defn- workflow-state-with-error [error]
+;; Fixtures + factories
+(defn- ^{:stratum 0} workflow-state-with-error [error]
   {:workflow/id (random-uuid)
    :workflow/status :failed
    :workflow/spec {}
@@ -44,9 +43,9 @@
    :workflow/error error})
 
 ;------------------------------------------------------------------------------ Layer 1
-;; Canonical anomaly shape (post-W2 producers)
 
-(deftest canonical-anomaly-at-error-info-routes-through-outcome
+;; Canonical anomaly shape (post-W2 producers)
+(deftest ^{:stratum 1} canonical-anomaly-at-error-info-routes-through-outcome
   (testing "a canonical anomaly map as :workflow/error is detected"
     (let [a       (anomaly/anomaly :fault "Compilation error" {})
           outcome (collector/build-outcome-evidence
@@ -54,7 +53,7 @@
       (is (false? (:outcome/success outcome)))
       (is (= "Compilation error" (:outcome/error-message outcome))))))
 
-(deftest canonical-anomaly-nested-under-anomaly-routes-through-outcome
+(deftest ^{:stratum 1} canonical-anomaly-nested-under-anomaly-routes-through-outcome
   (testing "a canonical anomaly under {:anomaly a} is also detected"
     (let [a       (anomaly/anomaly :timeout "agent timed out" {})
           outcome (collector/build-outcome-evidence
@@ -63,8 +62,7 @@
       (is (= "agent timed out" (:outcome/error-message outcome))))))
 
 ;; Legacy anomaly shape (pre-W2 producers)
-
-(deftest legacy-anomaly-at-error-info-still-detected
+(deftest ^{:stratum 1} legacy-anomaly-at-error-info-still-detected
   (testing "a legacy :anomaly/category map as :workflow/error is detected"
     (let [a       (response/make-anomaly :anomalies/fault "boom")
           outcome (collector/build-outcome-evidence
@@ -72,7 +70,7 @@
       (is (false? (:outcome/success outcome)))
       (is (= "boom" (:outcome/error-message outcome))))))
 
-(deftest legacy-anomaly-nested-under-anomaly-still-detected
+(deftest ^{:stratum 1} legacy-anomaly-nested-under-anomaly-still-detected
   (testing "a legacy anomaly under {:anomaly a} is still detected"
     (let [a       (response/make-anomaly :anomalies/timeout "slow")
           outcome (collector/build-outcome-evidence
@@ -81,8 +79,7 @@
       (is (= "slow" (:outcome/error-message outcome))))))
 
 ;; Non-anomaly fallback (legacy shape error map)
-
-(deftest non-anomaly-error-falls-back-to-legacy-shape
+(deftest ^{:stratum 1} non-anomaly-error-falls-back-to-legacy-shape
   (testing "a plain error map (no :anomaly/type, no :anomaly/category)
             is preserved via the legacy non-anomaly fall-through"
     (let [outcome (collector/build-outcome-evidence


### PR DESCRIPTION
Split out of #1531 per user direction. Mechanical `stratum-lint --fix` pass over two small, unrelated test files (bundled -- each is too small to justify its own PR): content-hash-integration tests and outcome-anomaly-shape tests. Previously unannotated; both pass within the 3-layer SL003 budget. Full pre-commit suite passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>