### PR TITLE
fix: get main green — two independent breaks in the Test job

### DIFF
--- a/components/release-executor/src/ai/miniforge/release_executor/core.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/core.clj
@@ -200,6 +200,20 @@
   (when (and body (not (str/blank? body)))
     (str header body "\n\n")))
 
+(defn- ^{:stratum 0} usable-worktree-path?
+  "True when `v` is a non-blank string.
+
+   `:worktree-path` is contractually a String: `workspace/core.clj`, the
+   single blessed execution-workdir resolver, only reads a context path
+   that satisfies `string?`. Callers that hand over a
+   `java.nio.file.Path` — what `babashka.fs` returns — reached
+   `clojure.string/blank?` here and died on its `CharSequence` cast, so a
+   wrong-typed path crashed validation instead of failing it. Anything
+   non-string is unusable, and falls through to the normal
+   `:missing-worktree-path` branch."
+  [v]
+  (and (string? v) (not (str/blank? v))))
+
 (defn- ^{:stratum 0} pr-body-needs-update?
   "True when the post-create PR body should be overwritten."
   [release-meta]
@@ -285,13 +299,13 @@
     ;; A blank :worktree-path is NOT present — babashka.process treats
     ;; :dir "" as the current working directory, which would run host git/gh
     ;; against whatever repo the process happens to sit in.
-    (and (not (str/blank? (:worktree-path state)))
+    (and (usable-worktree-path? (:worktree-path state))
          (nil? (:executor state))
          (nil? (:environment-id state)))
     (assoc state :host-mode? true)
 
     ;; Sandbox-mode guards — same order/messages as before
-    (str/blank? (:worktree-path state))
+    (not (usable-worktree-path? (:worktree-path state)))
     (fail state :missing-worktree-path (msg/t :exec/missing-worktree-path))
 
     (not (:executor state))

--- a/components/release-executor/test/ai/miniforge/release_executor/git_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/git_test.clj
@@ -300,7 +300,20 @@
   (testing "a blank :worktree-path is not host-mode (babashka :dir \"\" = cwd)"
     (let [r (core/step-validate-inputs {:worktree-path "  " :create-pr? true})]
       (is (not (:host-mode? r)))
-      (is (core/failed? r)))))
+      (is (core/failed? r))))
+  ;; A java.nio.file.Path — what babashka.fs returns — used to reach
+  ;; clojure.string/blank? and throw ClassCastException on the CharSequence
+  ;; cast, so validation crashed instead of failing. :worktree-path is
+  ;; contractually a String (workspace/core.clj accepts only string?), so a
+  ;; Path is rejected the same way a missing one is.
+  (testing "a non-string :worktree-path fails validation rather than throwing"
+    (let [r (core/step-validate-inputs
+             {:worktree-path (java.nio.file.Path/of "/tmp/wt" (into-array String []))
+              :create-pr? true})]
+      (is (not (:host-mode? r)))
+      (is (core/failed? r))
+      (is (= :missing-worktree-path (:type (:failure r)))
+          "reports the typed missing-worktree-path failure"))))
 
 ;------------------------------------------------------------------------------ Layer 1
 

--- a/projects/miniforge/test/ai/miniforge/release_executor/artifact_validation_integration_test.clj
+++ b/projects/miniforge/test/ai/miniforge/release_executor/artifact_validation_integration_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.release-executor.artifact-validation-integration-test
   "Project-level integration tests for artifact validation in the release executor.
 
@@ -23,17 +22,19 @@
   Exercises the release-executor component through its public interface."
   (:require
    [clojure.test :refer [deftest testing is use-fixtures]]
+   [clojure.string :as str]
    [babashka.fs :as fs]
    [babashka.process :as process]
    [ai.miniforge.release-executor.interface :as release-executor]
    [ai.miniforge.dag-executor.protocols.executor :as executor-proto]
    [ai.miniforge.logging.interface :as log]))
 
+;------------------------------------------------------------------------------ Layer 0
+
 ;------------------------------------------------------------------------------ Fixtures
+(def ^{:stratum 0} ^:dynamic *temp-dir* nil)
 
-(def ^:dynamic *temp-dir* nil)
-
-(defn temp-dir-fixture [f]
+(defn ^{:stratum 0} temp-dir-fixture [f]
   (let [dir (fs/create-temp-dir {:prefix "artifact-val-test-"})]
     (process/shell {:dir (str dir)} "git init")
     (process/shell {:dir (str dir)} "git config user.email" "test@example.com")
@@ -48,17 +49,14 @@
       (try (f)
            (finally (fs/delete-tree dir))))))
 
-(use-fixtures :each temp-dir-fixture)
-
 ;------------------------------------------------------------------------------ Helpers
-
-(defn make-workflow-state [artifacts]
+(defn ^{:stratum 0} make-workflow-state [artifacts]
   {:workflow/id (random-uuid)
    :workflow/phase :release
    :workflow/spec {:spec/description "test"}
    :workflow/artifacts artifacts})
 
-(defn make-stub-executor
+(defn ^{:stratum 0} make-stub-executor
   "Create a stub executor that runs shell commands in the temp dir.
    Satisfies the TaskExecutor protocol so the release pipeline passes
    input validation and can execute git operations on the test repo."
@@ -72,8 +70,14 @@
     (execute! [_ _env-id command opts]
       (try
         (let [workdir (or (:workdir opts) (str worktree-dir))
+              ;; TaskExecutor/execute! takes "string or vector"; sandbox.clj
+              ;; uses both forms. Join vectors the way the real worktree
+              ;; executor does (dag_executor/protocols/impl/worktree.clj's
+              ;; execute-command) — passing the vector straight to `sh -c`
+              ;; would run its .toString, i.e. `sh: [git: command not found`.
+              cmd-str (if (string? command) command (str/join " " command))
               result (process/shell {:dir workdir :out :string :err :string :continue true}
-                                    "sh" "-c" command)]
+                                    "sh" "-c" cmd-str)]
           {:ok? true :data {:exit-code (:exit result)
                             :stdout (or (:out result) "")
                             :stderr (or (:err result) "")}})
@@ -90,16 +94,23 @@
     (persist-workspace! [_ _env-id _opts]
       {:ok? true :data {:persisted? true}})))
 
-(defn make-context []
-  {:worktree-path *temp-dir*
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} make-context []
+  ;; `fs/create-temp-dir` returns a java.nio.file.Path; the release context's
+  ;; :worktree-path is contractually a String (see workspace/core.clj, the
+  ;; blessed execution-workdir resolver). Coerce at this boundary, as the
+  ;; other helpers here already do for :dir and :workdir.
+  {:worktree-path (str *temp-dir*)
    :create-pr? false
    :executor (make-stub-executor *temp-dir*)
    :environment-id "test-env-001"
    :logger (log/create-logger {:min-level :warn})})
 
-;------------------------------------------------------------------------------ Tests
+;------------------------------------------------------------------------------ Layer 2
 
-(deftest nil-artifacts-rejected-test
+;------------------------------------------------------------------------------ Tests
+(deftest ^{:stratum 2} nil-artifacts-rejected-test
   (testing "release executor pipeline fails with nil artifact content"
     (let [state (make-workflow-state [{:artifact/type :code
                                        :artifact/content nil}])
@@ -117,7 +128,7 @@
       (is (seq (:errors result))
           "Should have downstream pipeline errors"))))
 
-(deftest empty-files-rejected-test
+(deftest ^{:stratum 2} empty-files-rejected-test
   (testing "release executor pipeline fails with zero-file artifacts"
     (let [state (make-workflow-state [{:artifact/type :code
                                        :artifact/content {:code/id (random-uuid)
@@ -135,7 +146,7 @@
       (is (seq (:errors result))
           "Should have downstream pipeline errors"))))
 
-(deftest valid-artifacts-pass-validation-test
+(deftest ^{:stratum 2} valid-artifacts-pass-validation-test
   (testing "release executor passes validation for valid artifacts with files"
     (let [state (make-workflow-state
                  [{:artifact/type :code
@@ -152,7 +163,7 @@
       (is (not (contains? (set (map :type (:errors result))) :no-files-to-write))
           "Should not fail with no-files-to-write for valid artifact"))))
 
-(deftest mixed-nil-and-valid-artifacts-test
+(deftest ^{:stratum 2} mixed-nil-and-valid-artifacts-test
   (testing "release executor filters out nil artifacts and processes valid ones"
     (let [state (make-workflow-state
                  [{:artifact/type :code
@@ -168,3 +179,5 @@
           "Should not fail with no-code-artifacts — nil was filtered, valid remained")
       (is (not (contains? (set (map :type (:errors result))) :no-code-files))
           "Should not fail with no-code-files — valid artifact has files"))))
+
+(use-fixtures :each temp-dir-fixture)

--- a/projects/miniforge/test/ai/miniforge/web_dashboard/fleet_onboarding_integration_test.clj
+++ b/projects/miniforge/test/ai/miniforge/web_dashboard/fleet_onboarding_integration_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.web-dashboard.fleet-onboarding-integration-test
   (:require
    [clojure.test :refer [deftest is testing]]
@@ -23,10 +22,13 @@
    [ai.miniforge.pr-train.interface :as pr-train]
    [ai.miniforge.repo-dag.interface :as repo-dag]
    [ai.miniforge.web-dashboard.server :as server]
+   [ai.miniforge.web-dashboard.server.auth :as auth]
    [ai.miniforge.web-dashboard.state.core :as state-core]
    [ai.miniforge.web-dashboard.state.trains :as trains]))
 
-(defn temp-config-path
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} temp-config-path
   []
   (let [dir (.toFile (java.nio.file.Files/createTempDirectory
                       "fleet-e2e-config"
@@ -34,13 +36,29 @@
     (.deleteOnExit dir)
     (str (.getAbsolutePath dir) "/config.edn")))
 
-(defn arg-value
+(defn ^{:stratum 0} arg-value
   [args flag]
   (some (fn [[a b]]
           (when (= a flag) b))
         (partition 2 1 args)))
 
-(defn fake-run-gh
+(defn ^{:stratum 0} body-stream
+  [content]
+  (java.io.ByteArrayInputStream. (.getBytes (str content) "UTF-8")))
+
+(defn ^{:stratum 0} route-json
+  [handler method uri query-string cookie]
+  (let [response (handler {:uri uri
+                           :request-method method
+                           :query-string query-string
+                           :headers (cond-> {} cookie (assoc "cookie" cookie))
+                           :params {}})]
+    {:status (:status response)
+     :json (json/parse-string (:body response) true)}))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} fake-run-gh
   [& args]
   (let [[cmd subcmd] args]
     (cond
@@ -83,29 +101,46 @@
        :out ""
        :err (str "Unexpected gh call: " args)})))
 
-(defn route-json
-  [handler method uri query-string]
-  (let [response (handler {:uri uri
-                           :request-method method
-                           :query-string query-string
-                           :params {}})]
-    {:status (:status response)
-     :json (json/parse-string (:body response) true)}))
+(defn ^{:stratum 1} login-cookie
+  "Drive the login flow against `handler` and return the session cookie.
 
-(deftest fleet-onboarding-route-flow-integration-test
+   The fleet routes below POST, and issue #1460 made every mutating
+   request require an authenticated operator session even when
+   browse-auth is disabled — so these calls need a real session, not
+   just a bare request map. Mirrors the helper in the component's own
+   control-gate test."
+  [handler]
+  (-> (handler {:uri "/login"
+                :request-method :post
+                :headers {"content-type" "application/x-www-form-urlencoded"}
+                :body (body-stream "username=alice&password=wonderland&return-to=%2F")})
+      (get-in [:headers "Set-Cookie"])))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} fleet-onboarding-route-flow-integration-test
   (testing "discover repos + sync PRs through server routes"
     (let [config-path (temp-config-path)
           pr-manager (pr-train/create-manager)
           dag-manager (repo-dag/create-manager)
-          state (state-core/create-state {:pr-train-manager pr-manager
-                                          :repo-dag-manager dag-manager})]
+          ;; Configuring a user turns `auth/enabled?` on, so the read-only
+          ;; GET below needs the session cookie too — not just the POSTs
+          ;; that the #1460 control gate covers.
+          state (state-core/create-state
+                 {:pr-train-manager pr-manager
+                  :repo-dag-manager dag-manager
+                  :auth (auth/build-auth-state
+                         {:users [{:username "alice"
+                                   :password "wonderland"
+                                   :role :operator}]})})]
       (with-redefs-fn {#'trains/default-fleet-config-path config-path
                        #'trains/run-gh fake-run-gh}
         (fn []
           (let [handler (server/create-handler state)
-                discover-res (route-json handler :post "/api/fleet/repos/discover" "owner=acme")
-                repos-res (route-json handler :get "/api/fleet/repos" nil)
-                sync-res (route-json handler :post "/api/fleet/prs/sync" nil)
+                cookie (login-cookie handler)
+                discover-res (route-json handler :post "/api/fleet/repos/discover" "owner=acme" cookie)
+                repos-res (route-json handler :get "/api/fleet/repos" nil cookie)
+                sync-res (route-json handler :post "/api/fleet/prs/sync" nil cookie)
                 trains-list (vec (pr-train/list-trains pr-manager))
                 dag-list (vec (repo-dag/get-all-dags dag-manager))
                 train (first trains-list)


### PR DESCRIPTION
## Summary

`main`'s `Test` job has been red for at least six merges (runs 30734048427 → 30735684110). It is red for **two independent reasons**, both in that one job — `Structure`, `Lint`, and `Test (Windows)` all pass. Fixing either alone leaves `main` red.

Neither break was caused by the PRs in that range. Both predate it.

## Break 1 — `ClassCastException` in release-executor input validation

Four tests in `artifact-validation-integration-test` errored at `string.clj:294`:

```
java.lang.ClassCastException: class sun.nio.fs.UnixPath cannot be cast to
class java.lang.CharSequence
```

`clojure.string/blank?` is hinted `^CharSequence`, so `string.clj:294` is its `(.length s)`. `core.clj:288` called it directly on `:worktree-path`, and the test fixture passed a `java.nio.file.Path` from `fs/create-temp-dir`.

The two sides of this disagreed. `workspace/core.clj:43` — described in its own docstring as the single blessed execution-workdir resolver — reads a context path only when it satisfies `string?`, so String is the contract, and every other caller in the repo honors it. But `git.clj` defensively `(str worktree-path)`s at every consumer, which makes the component look Path-tolerant right up until validation.

- Extract `usable-worktree-path?` (`string?` + non-blank) and use it for both the host-mode branch and the guard, so a wrong-typed path fails as `:missing-worktree-path` rather than throwing. A crash becomes a typed failure; nothing that previously succeeded changes behavior.
- Coerce in the fixture at the interface boundary, as its sibling helpers already do for `:dir` and `:workdir`.
- Regression test pinning the non-string case.

Also fixed fixture drift found once the crash was gone: the stub executor passed vector commands straight to `sh -c`, running their `.toString` (`sh: [git: command not found`). `TaskExecutor/execute!` contracts for "string or vector" and `sandbox.clj` uses both forms. The stub now joins vectors the way the real worktree executor does. The tests had been asserting against a bogus failure path rather than the git-no-remote one their own comments describe.

## Break 2 — a stale test, not a bug

All 19 failures in `fleet-onboarding-route-flow-integration-test` cascade from a single `401`. Issue #1460 deliberately gated mutating requests behind an authenticated operator session even when browse-auth is disabled — a no-auth dashboard refuses mutations while read-only views stay open. This test predates that gate and still POSTed `/api/fleet/repos/discover` and `/api/fleet/prs/sync` from bare request maps.

**The 401 is correct behavior.** The test was stale. It now configures an operator user and drives the login flow for a session cookie, following the helper shape in the component's own `control_gate_test.clj`. Configuring a user also turns `auth/enabled?` on, which brings the browse gate into play, so the read-only GET carries the cookie too.

## Verification

- `bb test:all` green end to end: exit 0, zero `FAIL`/`ERROR` lines, no `❌`. The miniforge project goes 304 tests / 1045 assertions / 0 failures — previously 19 failures plus 4 errors.
- release-executor component suite: 102 tests / 305 assertions clean.
- Target namespace goes from 4 assertions / 4 errors to 13 assertions / 0 errors (the crash was aborting before the later assertions ran).
- Pre-commit clean on both commits, including GraalVM compatibility.

## Two things reviewers should weigh

**`MINIFORGE_STRATUM_BUDGET_MODE=warn` on the first commit.** The `SL003` finding on `core.clj` (over its layer budget, needs a namespace split) blocked the commit, but it pre-exists on `main` — verified against a pristine worktree at `origin/main`, where it reports at line 800 versus 814 here. Splitting that namespace is well outside a bug fix and would blow the PR-size gate. `tasks/stratum.clj` documents this env var as the opt-out for exactly this case, so this is the tool's own mode toggle rather than a hook bypass — but it is a judgment call worth a look.

**The CI gap is real but is not test selection.** PR CI runs `bb test` (changed-and-affected) and `main` runs `bb test:all`, so this namespace was never selected on a PR. That selection behaved correctly — none of those six PRs touched release-executor. The actual defect is that `ci.yml` has no `failure()` handler and no alerting anywhere, so six consecutive red `main` runs produced zero signal, and the redness was in fact broader than anyone had noticed. I'd fix the alerting before the selection logic. Not addressed here; this PR is scoped to getting `main` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)