### PR TITLE
feat(etl): wire cursor-store into pack runs — incremental packs resume instead of re-ingesting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,9 @@ work/*-local.spec.edn
 work/*-wip.edn
 .miniforge/
 .worktrees/
+
+# ETL cross-run cursor watermarks. cursor-store writes these next to the
+# pipeline EDN they belong to (<pipeline-dir>/.cursors/<pipeline>.edn), which
+# for a shipped pack is a tracked path — the watermark is per-checkout runtime
+# state and must never be committed.
+**/.cursors/

--- a/bases/etl/resources/config/etl/messages/en-US.edn
+++ b/bases/etl/resources/config/etl/messages/en-US.edn
@@ -31,6 +31,10 @@
   ;; Result emission (--out)
   :run/wrote              "  wrote: {path}"
 
+  ;; Cross-run cursors (incremental pipelines only)
+  :run/cursor-load-failed "etl run: stored cursors could not be read — {error}"
+  :run/cursor-save-failed "etl run: pipeline completed but its cursors could not be saved, so the next run would re-ingest from scratch — {error}"
+
   ;; -------- Argument validation --------
   :run/usage              "usage: etl run <pipeline.edn> --env <env.edn> [--out <result.edn|.json>] [--workbench-out <snapshot.json> --experiment-id <id> --label <label> --source-hash <sha256:...> [--baseline <snapshot.json>]]"
   :run/missing-env        "etl run: missing --env <env.edn>"

--- a/bases/etl/src/ai/miniforge/etl/cursors.clj
+++ b/bases/etl/src/ai/miniforge/etl/cursors.clj
@@ -1,0 +1,159 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.etl.cursors
+  "Cross-run watermarks for one pack execution.
+
+   `pipeline-runner` threads a cursor map through a single run and
+   reports the one that run produced; `cursor-store` persists a cursor
+   map to disk. Neither knows about the other, and a run has no memory
+   of the last one until something joins them. That is this namespace:
+   load the previous run's watermark into the context the runner reads
+   prior cursors from, write the new one back once the run has
+   succeeded.
+
+   It is its own namespace rather than a handful of helpers inside
+   `etl.runner` because the two policy questions it answers — which
+   execution modes carry a watermark, and which run outcomes may
+   advance one — belong in one stated place, and folding them into the
+   runner would push that file past its stratum budget.
+
+   Strata: mode policy and the failure constructors (0); the pair of
+   entry points `etl.runner` calls (1)."
+  {:miniforge/runtime :jvm-only}
+  (:require
+   [ai.miniforge.cursor-store.interface :as cursor-store]
+   [ai.miniforge.etl.messages :as msg]
+   [ai.miniforge.schema.interface :as schema]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private cursor-bearing-modes
+  "Execution modes whose semantics depend on a cross-run watermark.
+
+   Only `:incremental` both honours one and advances it.
+   `:full-refresh` re-reads its whole source by definition, so applying
+   a stored watermark would silently narrow it into something else.
+   `:backfill` and `:reprocess` deliberately re-read history, so the
+   watermark they end on sits behind the incremental one — persisting
+   it would drag the resume point backwards and re-ingest everything
+   between."
+  #{:incremental})
+
+(defn- ^{:stratum 0} by-stage-id
+  "Re-key a persisted cursor map onto this run's stage ids.
+
+   `cursor-store` keys by [stage-name schema-name], the identity that
+   survives between runs. `pipeline-runner` looks a stage's cursor up
+   first by the `:stage/id` it was scheduled with, which is minted
+   fresh every run. Translating here means durable identity stays in
+   the store, run identity stays in the runner, and neither has to know
+   the other's key space.
+
+   A stage name carrying more than one persisted entry is dropped
+   rather than guessed at. Two entries mean the stage's resource
+   changed between runs, so the older watermark describes a different
+   source: starting that stage fresh re-reads records, picking the
+   wrong entry skips records that were never read at all."
+  [pipeline cursors]
+  (let [name->id (into {} (map (juxt :stage/name :stage/id)) (:pipeline/stages pipeline))]
+    (reduce-kv
+     (fn [acc stage-name entries]
+       (let [id (get name->id stage-name)]
+         (if (and id (= 1 (count entries)))
+           (assoc acc id (first entries))
+           acc)))
+     {}
+     (group-by :stage/name (vals cursors)))))
+
+(defn- ^{:stratum 0} load-failure
+  "A cursor file that exists but will not parse. Nothing has executed
+   yet, so there is no run to attach."
+  [error]
+  (schema/failure :pipeline-run (msg/t :run/cursor-load-failed {:error error})))
+
+(defn- ^{:stratum 0} save-failure
+  "A watermark the run reached but could not write. `run` is kept so
+   the caller can still summarize and project what did execute."
+  [run error]
+  (schema/failure :pipeline-run
+                  (msg/t :run/cursor-save-failed {:error error})
+                  {:pipeline-run run}))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} incremental?
+  "Whether `pipeline` runs in a mode that carries a cross-run cursor.
+   A pipeline with no `:pipeline/mode` does not; `pipeline/validate-pipeline`
+   rejects it before execution either way."
+  [pipeline]
+  (contains? cursor-bearing-modes (:pipeline/mode pipeline)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} prime-context
+  "Merge the watermark left by the previous run of this pipeline into
+   `context`, keyed onto this run's stage ids (see `by-stage-id`) under
+   the key `pipeline-runner` reads prior cursors from. Returns
+   `(schema/success :context …)`; a non-incremental pipeline gets its
+   context back untouched.
+
+   A cursor file that will not parse fails the run instead of starting
+   fresh. An ingest stage with no cursor admits every record, so
+   treating a read error as `no watermark` would quietly re-ingest the
+   entire source — the exact outcome this store exists to prevent, and
+   one that reports itself as a successful run.
+
+   For an incremental pipeline the persisted file is the sole source of
+   prior cursors: a `:pipeline-run/connector-cursors` entry already in
+   `context` is replaced."
+  [logger pipeline-path pipeline context]
+  (if-not (incremental? pipeline)
+    (schema/success :context context)
+    (let [loaded (cursor-store/load-cursors logger pipeline-path)]
+      (if (schema/failed? loaded)
+        (load-failure (:error loaded))
+        (schema/success :context
+                        (assoc context
+                               :pipeline-run/connector-cursors
+                               (by-stage-id pipeline (:cursors loaded))))))))
+
+(defn ^{:stratum 2} persist-cursors!
+  "Write the watermark this run reached. Returns `result` unchanged
+   when there is nothing to write, and a run failure when the write
+   fails.
+
+   Only a wholly successful incremental run advances the watermark. A
+   run that ingested and then failed downstream is holding records that
+   were extracted and never published; advancing past them would drop
+   them for good, so a failed run leaves the previous watermark alone
+   and the next run re-reads that window.
+
+   A failed write does fail the run. The records did land, but an
+   incremental pipeline that cannot record where it got to re-ingests
+   its whole source on the next run, and every run after that —
+   reporting success here would hide the regression until someone
+   noticed the volume."
+  [logger pipeline-path pipeline result]
+  (if-not (and (incremental? pipeline) (schema/succeeded? result))
+    result
+    (let [run   (:pipeline-run result)
+          saved (cursor-store/save-cursors
+                 logger pipeline-path (:pipeline-run/connector-cursors run))]
+      (if (schema/failed? saved)
+        (save-failure run (:error saved))
+        result))))

--- a/bases/etl/src/ai/miniforge/etl/cursors.clj
+++ b/bases/etl/src/ai/miniforge/etl/cursors.clj
@@ -81,8 +81,9 @@
      (group-by :stage/name (vals cursors)))))
 
 (defn- ^{:stratum 0} load-failure
-  "A cursor file that exists but will not parse. Nothing has executed
-   yet, so there is no run to attach."
+  "A cursor file that exists but cannot be read — malformed, or an I/O
+   failure the store surfaces the same way. Nothing has executed yet,
+   so there is no run to attach."
   [error]
   (schema/failure :pipeline-run (msg/t :run/cursor-load-failed {:error error})))
 
@@ -112,11 +113,12 @@
    `(schema/success :context …)`; a non-incremental pipeline gets its
    context back untouched.
 
-   A cursor file that will not parse fails the run instead of starting
-   fresh. An ingest stage with no cursor admits every record, so
-   treating a read error as `no watermark` would quietly re-ingest the
-   entire source — the exact outcome this store exists to prevent, and
-   one that reports itself as a successful run.
+   A cursor file that exists but cannot be read — malformed, or
+   unreadable for any other reason the store reports — fails the run
+   instead of starting fresh. An ingest stage with no cursor admits
+   every record, so treating a read error as `no watermark` would
+   quietly re-ingest the entire source — the exact outcome this store
+   exists to prevent, and one that reports itself as a successful run.
 
    For an incremental pipeline the persisted file is the sole source of
    prior cursors: a `:pipeline-run/connector-cursors` entry already in

--- a/bases/etl/src/ai/miniforge/etl/cursors.clj
+++ b/bases/etl/src/ai/miniforge/etl/cursors.clj
@@ -26,16 +26,15 @@
    prior cursors from, write the new one back once the run has
    succeeded.
 
-   It is its own namespace rather than a handful of helpers inside
-   `etl.runner` because the two policy questions it answers — which
-   execution modes carry a watermark, and which run outcomes may
-   advance one — belong in one stated place, and folding them into the
-   runner would push that file past its stratum budget.
+   Its own namespace rather than helpers inside `etl.runner`: the two
+   policy questions it answers — which execution modes carry a
+   watermark, which run outcomes may advance one — belong in one stated
+   place, and folding them into the runner would push that file past
+   its stratum budget.
 
-   Strata: mode policy, key translation, and the failure constructors
-   (0); the mode predicate over that policy (1); the pair of entry
-   points `etl.runner` calls (2). Strata are per-file, so these numbers
-   say nothing about `etl.runner`'s own."
+   Strata are per-file, so the numbers here say nothing about
+   `etl.runner`'s own: policy, key translation and failure
+   constructors (0); the mode predicate (1); the entry points (2)."
   {:miniforge/runtime :jvm-only}
   (:require
    [ai.miniforge.cursor-store.interface :as cursor-store]
@@ -92,19 +91,16 @@
 (defn- ^{:stratum 1} by-stage-id
   "Re-key a persisted cursor map onto this run's stage ids.
 
-   `cursor-store` keys by [stage-name schema-name], the identity that
-   survives between runs. `pipeline-runner` looks a stage's cursor up
-   first by the `:stage/id` it was scheduled with, which is minted
-   fresh every run. Translating here means durable identity stays in
-   the store, run identity stays in the runner, and neither has to know
-   the other's key space.
+   The store keys by [stage-name schema-name] because that survives
+   between runs; `pipeline-runner` resolves a cursor by the `:stage/id`
+   it scheduled, which is minted fresh each run. Translating here keeps
+   each identity on its own side.
 
    An entry transfers only when its schema name matches the one this
    run will extract the stage under. Repointing a stage at a different
-   resource leaves its old entry in the file under the old schema, and
-   that watermark describes a different source — resuming from it would
-   skip records that were never read. A stage with no matching entry
-   starts fresh, which re-reads."
+   resource leaves its old entry under the old schema, describing a
+   different source — resuming from it would skip records that were
+   never read. No match means start fresh, which re-reads."
   [pipeline cursors]
   (reduce
    (fn [acc stage]

--- a/bases/etl/src/ai/miniforge/etl/cursors.clj
+++ b/bases/etl/src/ai/miniforge/etl/cursors.clj
@@ -32,8 +32,10 @@
    advance one — belong in one stated place, and folding them into the
    runner would push that file past its stratum budget.
 
-   Strata: mode policy and the failure constructors (0); the pair of
-   entry points `etl.runner` calls (1)."
+   Strata: mode policy, key translation, and the failure constructors
+   (0); the mode predicate over that policy (1); the pair of entry
+   points `etl.runner` calls (2). Strata are per-file, so these numbers
+   say nothing about `etl.runner`'s own."
   {:miniforge/runtime :jvm-only}
   (:require
    [ai.miniforge.cursor-store.interface :as cursor-store]
@@ -54,31 +56,21 @@
    between."
   #{:incremental})
 
-(defn- ^{:stratum 0} by-stage-id
-  "Re-key a persisted cursor map onto this run's stage ids.
+(defn- ^{:stratum 0} run-schema-name
+  "The schema name this run will extract `stage` under.
 
-   `cursor-store` keys by [stage-name schema-name], the identity that
-   survives between runs. `pipeline-runner` looks a stage's cursor up
-   first by the `:stage/id` it was scheduled with, which is minted
-   fresh every run. Translating here means durable identity stays in
-   the store, run identity stays in the runner, and neither has to know
-   the other's key space.
-
-   A stage name carrying more than one persisted entry is dropped
-   rather than guessed at. Two entries mean the stage's resource
-   changed between runs, so the older watermark describes a different
-   source: starting that stage fresh re-reads records, picking the
-   wrong entry skips records that were never read at all."
-  [pipeline cursors]
-  (let [name->id (into {} (map (juxt :stage/name :stage/id)) (:pipeline/stages pipeline))]
-    (reduce-kv
-     (fn [acc stage-name entries]
-       (let [id (get name->id stage-name)]
-         (if (and id (= 1 (count entries)))
-           (assoc acc id (first entries))
-           acc)))
-     {}
-     (group-by :stage/name (vals cursors)))))
+   Mirrors `pipeline-runner`'s own `resolve-schema-name`, which is
+   private to `run.clj`: a connector takes a resource key (\"issues\",
+   \"pulls\") where the stage config names one, and the stage name
+   otherwise. Duplicated rather than shared because reaching it would
+   mean widening pipeline-runner's interface — but the two must agree,
+   because a cursor is only valid for the resource it was read from. If
+   that fallback chain changes there, it changes here."
+  [{:stage/keys [config name]}]
+  (or (:github/resource config)
+      (:gitlab/resource config)
+      (:resource config)
+      name))
 
 (defn- ^{:stratum 0} load-failure
   "A cursor file that exists but cannot be read — malformed, or an I/O
@@ -96,6 +88,31 @@
                   {:pipeline-run run}))
 
 ;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} by-stage-id
+  "Re-key a persisted cursor map onto this run's stage ids.
+
+   `cursor-store` keys by [stage-name schema-name], the identity that
+   survives between runs. `pipeline-runner` looks a stage's cursor up
+   first by the `:stage/id` it was scheduled with, which is minted
+   fresh every run. Translating here means durable identity stays in
+   the store, run identity stays in the runner, and neither has to know
+   the other's key space.
+
+   An entry transfers only when its schema name matches the one this
+   run will extract the stage under. Repointing a stage at a different
+   resource leaves its old entry in the file under the old schema, and
+   that watermark describes a different source — resuming from it would
+   skip records that were never read. A stage with no matching entry
+   starts fresh, which re-reads."
+  [pipeline cursors]
+  (reduce
+   (fn [acc stage]
+     (if-let [entry (get cursors [(:stage/name stage) (run-schema-name stage)])]
+       (assoc acc (:stage/id stage) entry)
+       acc))
+   {}
+   (:pipeline/stages pipeline)))
 
 (defn- ^{:stratum 1} incremental?
   "Whether `pipeline` runs in a mode that carries a cross-run cursor.

--- a/bases/etl/src/ai/miniforge/etl/runner.clj
+++ b/bases/etl/src/ai/miniforge/etl/runner.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.etl.runner
   "Orchestrates one pack execution: load pipeline + env EDNs, instantiate
    connectors from the pack-declared `:env/connectors`, resolve the
@@ -30,15 +29,16 @@
    `etl.registry`."
   {:miniforge/runtime :jvm-only}
   (:require
+   [ai.miniforge.etl.cursors :as cursors]
    [ai.miniforge.etl.registry :as registry]
    [ai.miniforge.pipeline-config.interface :as pc]
    [ai.miniforge.pipeline-runner.interface :as pr-run]
    [ai.miniforge.schema.interface :as schema]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Env + pipeline assembly
 
-(defn- load-inputs
+;; Env + pipeline assembly
+(defn- ^{:stratum 0} load-inputs
   "Load pipeline + env EDNs. On success, returns
    `(schema/success :inputs {:pipeline <edn> :env-config <edn>})`;
    otherwise propagates the first `schema/failure` encountered."
@@ -52,14 +52,14 @@
           (schema/success :inputs {:pipeline   (:pipeline pipeline)
                                    :env-config (:env-config env)}))))))
 
-(defn- unsupported-types
+(defn- ^{:stratum 0} unsupported-types
   "Connector types referenced by the env that the registry can't
    construct. Returns a vector of keywords."
   [env-conn-types]
   (let [supported (set (registry/supported-types))]
     (->> (vals env-conn-types) distinct (remove supported) vec)))
 
-(defn- unsupported-types-failure
+(defn- ^{:stratum 0} unsupported-types-failure
   "Produce a `schema/failure` describing the unsupported connector
    types, listing what the runner does support for operator guidance."
   [unknown]
@@ -69,7 +69,7 @@
          (pr-str unknown)
          ". Supported: " (pr-str (registry/supported-types)))))
 
-(defn- instantiate+resolve
+(defn- ^{:stratum 0} instantiate+resolve
   "Given the loaded inputs, instantiate live connectors from the env's
    connector-type declarations and resolve the pipeline EDN against the
    env's stage overrides. Returns `{:resolved ... :connectors ...}`."
@@ -84,14 +84,28 @@
     {:resolved   (pc/resolve-pipeline pipeline res-ctx)
      :connectors (:connectors instantiated)}))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Public entry
+;; Pack-level helpers (pipeline discovery + validation)
+(defn ^{:stratum 0} list-pipelines
+  "Discover pipeline EDNs under one or more search paths. Passes through
+   to `pipeline-config/discover-pipelines`."
+  [search-paths]
+  (pc/discover-pipelines search-paths))
 
-(defn run-pack
+;------------------------------------------------------------------------------ Layer 1
+
+;; Public entry
+(defn ^{:stratum 1} run-pack
   "Execute the pipeline at `pipeline-path` using the environment at
    `env-path`. `context` is passed through to
    `pipeline-runner/execute-pipeline` (intended for event-stream, log
-   sinks, etc.).
+   sinks, etc.); its `:logger`, if any, also carries the cursor store's
+   own logging.
+
+   An `:incremental` pipeline resumes from the watermark its previous
+   run persisted and writes a new one when this run succeeds — see
+   `etl.cursors` for which modes and outcomes that covers, and note
+   that it owns `:pipeline-run/connector-cursors` in the context it
+   hands the runner.
 
    Returns the pipeline-runner result map (schema/success or
    schema/failure with `:pipeline-run`)."
@@ -105,10 +119,16 @@
              unknown (unsupported-types (pc/extract-connector-types (:env-config inputs)))]
          (if (seq unknown)
            (unsupported-types-failure unknown)
-           (let [{:keys [resolved connectors]} (instantiate+resolve inputs)]
-             (pr-run/execute-pipeline resolved connectors context))))))))
+           (let [{:keys [resolved connectors]} (instantiate+resolve inputs)
+                 logger (:logger context)
+                 primed (cursors/prime-context logger pipeline-path resolved context)]
+             (if (schema/failed? primed)
+               primed
+               (cursors/persist-cursors!
+                logger pipeline-path resolved
+                (pr-run/execute-pipeline resolved connectors (:context primed)))))))))))
 
-(defn load-run-configuration
+(defn ^{:stratum 1} load-run-configuration
   "Load the concrete pipeline/environment pair that controls one ETL run.
 
    The returned map intentionally precedes generated stage UUIDs and timestamps,
@@ -128,16 +148,7 @@
                           {:pipeline (:pipeline inputs)
                            :environment (:env-config inputs)}))))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Pack-level helpers (pipeline discovery + validation)
-
-(defn list-pipelines
-  "Discover pipeline EDNs under one or more search paths. Passes through
-   to `pipeline-config/discover-pipelines`."
-  [search-paths]
-  (pc/discover-pipelines search-paths))
-
-(defn validate-pack
+(defn ^{:stratum 1} validate-pack
   "Load + resolve the pipeline at `pipeline-path` with `env-path` without
    executing it. Surfaces any loader, env, or resolver failure."
   [pipeline-path env-path]

--- a/bases/etl/src/ai/miniforge/etl/runner.clj
+++ b/bases/etl/src/ai/miniforge/etl/runner.clj
@@ -107,8 +107,11 @@
    that it owns `:pipeline-run/connector-cursors` in the context it
    hands the runner.
 
-   Returns the pipeline-runner result map (schema/success or
-   schema/failure with `:pipeline-run`)."
+   Returns the pipeline-runner result map: schema/success, or
+   schema/failure carrying `:pipeline-run` when execution began. A
+   failure raised before that — bad inputs, an unsupported connector
+   type, an unreadable cursor file — has no run to report and leaves
+   `:pipeline-run` nil."
   ([pipeline-path env-path]
    (run-pack pipeline-path env-path {}))
   ([pipeline-path env-path context]

--- a/bases/etl/test/ai/miniforge/etl/cursors_test.clj
+++ b/bases/etl/test/ai/miniforge/etl/cursors_test.clj
@@ -1,0 +1,179 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.etl.cursors-test
+  "Cross-run cursor behaviour, exercised through `runner/run-pack`.
+
+   The packs here use the `:file` connector on both ends, so a whole
+   run is local, deterministic, and offset-based: the source file's
+   record count is the watermark, which makes `what did the second run
+   read` a directly observable fact rather than something inferred from
+   the cursor map.
+
+   Strata: pack-shaped data and single-file I/O (0); the pack builder
+   and the readers the assertions use over it (1); the tests (2). The
+   EDN builders take the stage name rather than closing over it so they
+   stay at the bottom — closing over it would push every caller up a
+   layer and the file past its budget."
+  (:require
+   [ai.miniforge.cursor-store.interface :as cursor-store]
+   [ai.miniforge.etl.runner :as runner]
+   [ai.miniforge.schema.interface :as schema]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [clojure.test :refer [deftest is testing]]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Pack-shaped data and single-file I/O.
+(def ^{:stratum 0} ^:private ingest-stage-name "Ingest Rows")
+
+(defn- ^{:stratum 0} pipeline-edn
+  [stage-name mode]
+  {:pipeline/name    "Cursor Test"
+   :pipeline/version "0.1.0"
+   :pipeline/mode    mode
+   :pipeline/stages
+   [{:stage/name            stage-name
+     :stage/family          :ingest
+     :stage/connector-ref   :conn/src
+     :stage/input-datasets  []
+     :stage/output-datasets [:ds/rows]
+     :stage/dependencies    []}
+    {:stage/name            "Publish"
+     :stage/family          :publish
+     :stage/connector-ref   :conn/sink
+     :stage/input-datasets  [:ds/rows]
+     :stage/output-datasets []
+     :stage/dependencies    [stage-name]}]
+   :pipeline/input-datasets  []
+   :pipeline/output-datasets []})
+
+(defn- ^{:stratum 0} env-edn
+  [stage-name source-path out-path]
+  {:env/name "local"
+   :env/connectors {:conn/src  {:connector/type :file}
+                    :conn/sink {:connector/type :file}}
+   :env/stages {stage-name {:file/path source-path :file/format :edn}
+                "Publish"  {:file/path out-path    :file/format :edn}}})
+
+(defn- ^{:stratum 0} rows
+  "n records, distinguishable so a re-ingest shows up as duplicates."
+  [n]
+  (mapv (fn [i] {:id i}) (range 1 (inc n))))
+
+(defn- ^{:stratum 0} write-edn!
+  [path value]
+  (io/make-parents (io/file path))
+  (spit path (pr-str value)))
+
+(defn- ^{:stratum 0} execute-pack!
+  [{:keys [pipeline-path env-path]}]
+  (runner/run-pack pipeline-path env-path))
+
+(defn- ^{:stratum 0} published
+  [{:keys [out-path]}]
+  (edn/read-string (slurp out-path)))
+
+(defn- ^{:stratum 0} cursor-file
+  [{:keys [pipeline-path]}]
+  (let [f (io/file pipeline-path)]
+    (io/file (.getParentFile f) ".cursors" (.getName f))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; The pack builder, and the readers the assertions use over it.
+(defn- ^{:stratum 1} write-pack!
+  "Materialize a runnable pack in a fresh temp directory. `record-count`
+   records land in the source file the ingest stage reads."
+  [mode record-count]
+  (let [dir           (str (System/getProperty "java.io.tmpdir")
+                           "/etl-cursors-test-" (random-uuid))
+        pipeline-path (str dir "/pipelines/pipeline.edn")
+        env-path      (str dir "/envs/local.edn")
+        source-path   (str dir "/source.edn")
+        out-path      (str dir "/out.edn")]
+    (write-edn! pipeline-path (pipeline-edn ingest-stage-name mode))
+    (write-edn! env-path (env-edn ingest-stage-name source-path out-path))
+    (write-edn! source-path (rows record-count))
+    {:pipeline-path pipeline-path
+     :env-path      env-path
+     :source-path   source-path
+     :out-path      out-path}))
+
+(defn- ^{:stratum 1} persisted-offset
+  "The offset watermark on disk, or nil when no cursor was written. The
+   schema name in the key falls back to the stage name because a file
+   stage config declares no resource."
+  [{:keys [pipeline-path]}]
+  (-> (cursor-store/load-cursors nil pipeline-path)
+      :cursors
+      (get [ingest-stage-name ingest-stage-name])
+      (get-in [:cursor :cursor/value])))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; ---------------------------------------------------------------------------
+;; run-pack — the cross-run loop end to end
+(deftest ^{:stratum 2} incremental-run-resumes-from-the-previous-runs-watermark-test
+  (testing "the second run reads only what arrived after the first"
+    (let [pack (write-pack! :incremental 3)
+          run1 (execute-pack! pack)]
+      (is (schema/succeeded? run1) (str "first run failed: " (:error run1)))
+      (is (= (rows 3) (published pack)))
+      (is (= 3 (persisted-offset pack)))
+
+      ;; Two more records arrive between runs.
+      (write-edn! (:source-path pack) (rows 5))
+      (let [run2 (execute-pack! pack)]
+        (is (schema/succeeded? run2) (str "second run failed: " (:error run2)))
+        ;; The sink appends, so a re-ingest of the whole source would
+        ;; show as 8 published records rather than 5.
+        (is (= (rows 5) (published pack))
+            "second run should publish only records 4 and 5")
+        (is (= 5 (persisted-offset pack)))))))
+
+(deftest ^{:stratum 2} incremental-run-with-no-new-records-publishes-nothing-test
+  (testing "a run that finds nothing past the watermark leaves the output alone"
+    (let [pack (write-pack! :incremental 3)]
+      (execute-pack! pack)
+      (let [run2 (execute-pack! pack)]
+        (is (schema/succeeded? run2) (str "second run failed: " (:error run2)))
+        (is (= (rows 3) (published pack)))
+        (is (= 3 (persisted-offset pack)))))))
+
+(deftest ^{:stratum 2} full-refresh-run-neither-writes-nor-honours-a-watermark-test
+  (testing "a full-refresh pack re-reads its whole source every run"
+    (let [pack (write-pack! :full-refresh 3)]
+      (is (schema/succeeded? (execute-pack! pack)))
+      (is (false? (.exists (cursor-file pack)))
+          "full-refresh must not leave a watermark behind")
+      (is (schema/succeeded? (execute-pack! pack)))
+      ;; Appending sink + full re-read == every record twice.
+      (is (= (into (rows 3) (rows 3)) (published pack))))))
+
+(deftest ^{:stratum 2} unreadable-cursor-file-fails-the-run-test
+  (testing "a cursor file that will not parse fails the run rather than re-ingesting"
+    (let [pack (write-pack! :incremental 3)]
+      (execute-pack! pack)
+      (spit (cursor-file pack) "{:this is not")
+      (let [result (execute-pack! pack)]
+        (is (schema/failed? result))
+        ;; Nothing executed, so there is no run to report on, and the
+        ;; source must not have been read a second time.
+        (is (nil? (:pipeline-run result)))
+        (is (= (rows 3) (published pack)))))))

--- a/bases/etl/test/ai/miniforge/etl/cursors_test.clj
+++ b/bases/etl/test/ai/miniforge/etl/cursors_test.clj
@@ -95,6 +95,14 @@
   (let [f (io/file pipeline-path)]
     (io/file (.getParentFile f) ".cursors" (.getName f))))
 
+(defn- ^{:stratum 0} persisted
+  "One run's cursor map for a stage, as pipeline-runner reports it —
+   keyed by stage id, which the store re-keys on save."
+  [stage-name schema-name value]
+  {(random-uuid) {:stage/name        stage-name
+                  :stage/schema-name schema-name
+                  :cursor {:cursor/type :offset :cursor/value value}}})
+
 (defn- ^{:stratum 0} run-result
   "A pipeline-runner result of the given status, shaped as
    execute-pipeline returns it — a stage failure keeps :pipeline-run."
@@ -242,10 +250,7 @@
     (let [{:keys [pipeline-path]} (write-pack! :incremental 1)
           stage-id (random-uuid)
           keyed    (stage-id-keyed pipeline-path stage-id
-                                   {(random-uuid)
-                                    {:stage/name        ingest-stage-name
-                                     :stage/schema-name ingest-stage-name
-                                     :cursor {:cursor/type :offset :cursor/value 3}}})]
+                                   (persisted ingest-stage-name ingest-stage-name 3))]
       (is (= [stage-id] (keys keyed)))
       (is (= 3 (get-in keyed [stage-id :cursor :cursor/value])))))
 
@@ -256,10 +261,7 @@
     ;; were never read; the stage starts fresh instead.
     (let [{:keys [pipeline-path]} (write-pack! :incremental 1)
           keyed (stage-id-keyed pipeline-path (random-uuid)
-                                {(random-uuid)
-                                 {:stage/name        ingest-stage-name
-                                  :stage/schema-name "issues"
-                                  :cursor {:cursor/type :offset :cursor/value 3}}}
+                                (persisted ingest-stage-name "issues" 3)
                                 {:github/resource "pulls"})]
       (is (= {} keyed))))
 
@@ -267,39 +269,23 @@
     (let [{:keys [pipeline-path]} (write-pack! :incremental 1)
           stage-id (random-uuid)
           keyed    (stage-id-keyed pipeline-path stage-id
-                                   {(random-uuid)
-                                    {:stage/name        ingest-stage-name
-                                     :stage/schema-name "pulls"
-                                     :cursor {:cursor/type :offset :cursor/value 4}}}
+                                   (persisted ingest-stage-name "pulls" 4)
                                    {:github/resource "pulls"})]
       (is (= 4 (get-in keyed [stage-id :cursor :cursor/value])))))
 
   (testing "a stage name with two persisted entries takes neither by accident"
-    ;; Two entries mean the stage's resource changed between runs, so the
-    ;; older watermark describes a different source. Starting fresh
-    ;; re-reads records; picking the wrong entry skips records that were
-    ;; never read at all.
+    ;; Neither schema matches the one this run will extract under, so
+    ;; both are left behind rather than one being picked arbitrarily.
     (let [{:keys [pipeline-path]} (write-pack! :incremental 1)
-          issues-id (random-uuid)
-          merges-id (random-uuid)
           keyed (stage-id-keyed pipeline-path (random-uuid)
-                                {issues-id
-                                 {:stage/name        ingest-stage-name
-                                  :stage/schema-name "issues"
-                                  :cursor {:cursor/type :offset :cursor/value 3}}
-                                 merges-id
-                                 {:stage/name        ingest-stage-name
-                                  :stage/schema-name "merge-requests"
-                                  :cursor {:cursor/type :offset :cursor/value 9}}})]
+                                (merge (persisted ingest-stage-name "issues" 3)
+                                       (persisted ingest-stage-name "merge-requests" 9)))]
       (is (= {} keyed))))
 
   (testing "a persisted stage that no longer exists in the pipeline is dropped"
     (let [{:keys [pipeline-path]} (write-pack! :incremental 1)
           keyed (stage-id-keyed pipeline-path (random-uuid)
-                                {(random-uuid)
-                                 {:stage/name        "Removed Stage"
-                                  :stage/schema-name "gone"
-                                  :cursor {:cursor/type :offset :cursor/value 3}}})]
+                                (persisted "Removed Stage" "gone" 3))]
       (is (= {} keyed)))))
 
 ;; ---------------------------------------------------------------------------

--- a/bases/etl/test/ai/miniforge/etl/cursors_test.clj
+++ b/bases/etl/test/ai/miniforge/etl/cursors_test.clj
@@ -139,14 +139,17 @@
 (defn- ^{:stratum 1} stage-id-keyed
   "The cursor map prime-context hands the runner, for a pipeline whose
    single stage carries `stage-id`."
-  [pipeline-path stage-id persisted]
-  (let [pipeline {:pipeline/mode   :incremental
-                  :pipeline/stages [{:stage/id   stage-id
-                                     :stage/name ingest-stage-name}]}]
-    (cursor-store/save-cursors nil pipeline-path persisted)
-    (-> (cursors/prime-context nil pipeline-path pipeline {})
-        :context
-        :pipeline-run/connector-cursors)))
+  ([pipeline-path stage-id persisted]
+   (stage-id-keyed pipeline-path stage-id persisted nil))
+  ([pipeline-path stage-id persisted stage-config]
+   (let [pipeline {:pipeline/mode   :incremental
+                   :pipeline/stages [{:stage/id     stage-id
+                                      :stage/name   ingest-stage-name
+                                      :stage/config stage-config}]}]
+     (cursor-store/save-cursors nil pipeline-path persisted)
+     (-> (cursors/prime-context nil pipeline-path pipeline {})
+         :context
+         :pipeline-run/connector-cursors))))
 
 (def ^{:stratum 1} ^:private one-cursor
   "One run's cursor map for the ingest stage, keyed by stage id as
@@ -246,7 +249,32 @@
       (is (= [stage-id] (keys keyed)))
       (is (= 3 (get-in keyed [stage-id :cursor :cursor/value])))))
 
-  (testing "a stage name with two persisted entries is dropped, not guessed at"
+  (testing "an entry whose schema no longer matches the stage is not applied"
+    ;; Repointing a stage at a different resource leaves its old entry
+    ;; in the file under the old schema. That watermark describes a
+    ;; different source, so resuming from it would skip records that
+    ;; were never read; the stage starts fresh instead.
+    (let [{:keys [pipeline-path]} (write-pack! :incremental 1)
+          keyed (stage-id-keyed pipeline-path (random-uuid)
+                                {(random-uuid)
+                                 {:stage/name        ingest-stage-name
+                                  :stage/schema-name "issues"
+                                  :cursor {:cursor/type :offset :cursor/value 3}}}
+                                {:github/resource "pulls"})]
+      (is (= {} keyed))))
+
+  (testing "an entry matching the stage's configured resource is applied"
+    (let [{:keys [pipeline-path]} (write-pack! :incremental 1)
+          stage-id (random-uuid)
+          keyed    (stage-id-keyed pipeline-path stage-id
+                                   {(random-uuid)
+                                    {:stage/name        ingest-stage-name
+                                     :stage/schema-name "pulls"
+                                     :cursor {:cursor/type :offset :cursor/value 4}}}
+                                   {:github/resource "pulls"})]
+      (is (= 4 (get-in keyed [stage-id :cursor :cursor/value])))))
+
+  (testing "a stage name with two persisted entries takes neither by accident"
     ;; Two entries mean the stage's resource changed between runs, so the
     ;; older watermark describes a different source. Starting fresh
     ;; re-reads records; picking the wrong entry skips records that were

--- a/bases/etl/test/ai/miniforge/etl/cursors_test.clj
+++ b/bases/etl/test/ai/miniforge/etl/cursors_test.clj
@@ -31,6 +31,7 @@
    layer and the file past its budget."
   (:require
    [ai.miniforge.cursor-store.interface :as cursor-store]
+   [ai.miniforge.etl.cursors :as cursors]
    [ai.miniforge.etl.runner :as runner]
    [ai.miniforge.schema.interface :as schema]
    [clojure.edn :as edn]
@@ -94,6 +95,16 @@
   (let [f (io/file pipeline-path)]
     (io/file (.getParentFile f) ".cursors" (.getName f))))
 
+(defn- ^{:stratum 0} run-result
+  "A pipeline-runner result of the given status, shaped as
+   execute-pipeline returns it — a stage failure keeps :pipeline-run."
+  [status cursors]
+  (let [run {:pipeline-run/status status
+             :pipeline-run/connector-cursors cursors}]
+    (if (= :completed status)
+      (schema/success :pipeline-run run)
+      (schema/failure :pipeline-run "stage failed" {:pipeline-run run}))))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 ;; The pack builder, and the readers the assertions use over it.
@@ -124,6 +135,26 @@
       :cursors
       (get [ingest-stage-name ingest-stage-name])
       (get-in [:cursor :cursor/value])))
+
+(defn- ^{:stratum 1} stage-id-keyed
+  "The cursor map prime-context hands the runner, for a pipeline whose
+   single stage carries `stage-id`."
+  [pipeline-path stage-id persisted]
+  (let [pipeline {:pipeline/mode   :incremental
+                  :pipeline/stages [{:stage/id   stage-id
+                                     :stage/name ingest-stage-name}]}]
+    (cursor-store/save-cursors nil pipeline-path persisted)
+    (-> (cursors/prime-context nil pipeline-path pipeline {})
+        :context
+        :pipeline-run/connector-cursors)))
+
+(def ^{:stratum 1} ^:private one-cursor
+  "One run's cursor map for the ingest stage, keyed by stage id as
+   pipeline-runner reports it."
+  {(random-uuid) {:stage/name          ingest-stage-name
+                  :stage/schema-name   ingest-stage-name
+                  :stage/connector-ref (random-uuid)
+                  :cursor {:cursor/type :offset :cursor/value 7}}})
 
 ;------------------------------------------------------------------------------ Layer 2
 
@@ -177,3 +208,101 @@
         ;; source must not have been read a second time.
         (is (nil? (:pipeline-run result)))
         (is (= (rows 3) (published pack)))))))
+
+;; ---------------------------------------------------------------------------
+;; prime-context
+(deftest ^{:stratum 2} prime-context-leaves-non-incremental-pipelines-alone-test
+  (testing "no cursor key is added for modes that do not carry a watermark"
+    (doseq [mode [:full-refresh :backfill :reprocess nil]]
+      (let [{:keys [pipeline-path]} (write-pack! :incremental 1)
+            result (cursors/prime-context nil pipeline-path
+                                          {:pipeline/mode mode}
+                                          {:auth {:token "t"}})]
+        (is (schema/succeeded? result))
+        (is (= {:auth {:token "t"}} (:context result))
+            (str "mode " mode " should not be given a watermark"))))))
+
+(deftest ^{:stratum 2} prime-context-first-run-carries-an-empty-cursor-map-test
+  (testing "no cursor file yet is a success with nothing to resume from"
+    (let [{:keys [pipeline-path]} (write-pack! :incremental 1)
+          result (cursors/prime-context nil pipeline-path
+                                        {:pipeline/mode :incremental} {})]
+      (is (schema/succeeded? result))
+      (is (= {} (:pipeline-run/connector-cursors (:context result)))))))
+
+(deftest ^{:stratum 2} prime-context-rekeys-persisted-cursors-onto-stage-ids-test
+  (testing "the persisted entry arrives under the stage id this run scheduled"
+    ;; pipeline-runner looks a stage's cursor up by the :stage/id it was
+    ;; scheduled with, which is minted fresh each run; the store keys by
+    ;; the stage name, which is not. The translation is what makes a
+    ;; loaded cursor reachable at all.
+    (let [{:keys [pipeline-path]} (write-pack! :incremental 1)
+          stage-id (random-uuid)
+          keyed    (stage-id-keyed pipeline-path stage-id
+                                   {(random-uuid)
+                                    {:stage/name        ingest-stage-name
+                                     :stage/schema-name ingest-stage-name
+                                     :cursor {:cursor/type :offset :cursor/value 3}}})]
+      (is (= [stage-id] (keys keyed)))
+      (is (= 3 (get-in keyed [stage-id :cursor :cursor/value])))))
+
+  (testing "a stage name with two persisted entries is dropped, not guessed at"
+    ;; Two entries mean the stage's resource changed between runs, so the
+    ;; older watermark describes a different source. Starting fresh
+    ;; re-reads records; picking the wrong entry skips records that were
+    ;; never read at all.
+    (let [{:keys [pipeline-path]} (write-pack! :incremental 1)
+          issues-id (random-uuid)
+          merges-id (random-uuid)
+          keyed (stage-id-keyed pipeline-path (random-uuid)
+                                {issues-id
+                                 {:stage/name        ingest-stage-name
+                                  :stage/schema-name "issues"
+                                  :cursor {:cursor/type :offset :cursor/value 3}}
+                                 merges-id
+                                 {:stage/name        ingest-stage-name
+                                  :stage/schema-name "merge-requests"
+                                  :cursor {:cursor/type :offset :cursor/value 9}}})]
+      (is (= {} keyed))))
+
+  (testing "a persisted stage that no longer exists in the pipeline is dropped"
+    (let [{:keys [pipeline-path]} (write-pack! :incremental 1)
+          keyed (stage-id-keyed pipeline-path (random-uuid)
+                                {(random-uuid)
+                                 {:stage/name        "Removed Stage"
+                                  :stage/schema-name "gone"
+                                  :cursor {:cursor/type :offset :cursor/value 3}}})]
+      (is (= {} keyed)))))
+
+;; ---------------------------------------------------------------------------
+;; persist-cursors!
+(deftest ^{:stratum 2} persist-cursors-writes-only-for-a-successful-incremental-run-test
+  (testing "a successful incremental run advances the watermark"
+    (let [pack   (write-pack! :incremental 1)
+          result (run-result :completed one-cursor)
+          out    (cursors/persist-cursors! nil (:pipeline-path pack)
+                                           {:pipeline/mode :incremental} result)]
+      (is (= result out) "the run result passes through untouched")
+      (is (= 7 (persisted-offset pack)))))
+
+  (testing "a failed run leaves the previous watermark in place"
+    ;; The stages that did complete extracted records that were never
+    ;; published; advancing past them would drop them for good.
+    (let [pack (write-pack! :incremental 1)]
+      (cursors/persist-cursors! nil (:pipeline-path pack)
+                                {:pipeline/mode :incremental}
+                                (run-result :completed one-cursor))
+      (let [later (assoc-in one-cursor
+                            [(first (keys one-cursor)) :cursor :cursor/value] 99)
+            out   (cursors/persist-cursors! nil (:pipeline-path pack)
+                                            {:pipeline/mode :incremental}
+                                            (run-result :failed later))]
+        (is (schema/failed? out))
+        (is (= 7 (persisted-offset pack))))))
+
+  (testing "a non-incremental run writes nothing at all"
+    (let [pack (write-pack! :full-refresh 1)]
+      (cursors/persist-cursors! nil (:pipeline-path pack)
+                                {:pipeline/mode :full-refresh}
+                                (run-result :completed one-cursor))
+      (is (false? (.exists (cursor-file pack)))))))

--- a/components/cursor-store/src/ai/miniforge/cursor_store/interface.clj
+++ b/components/cursor-store/src/ai/miniforge/cursor_store/interface.clj
@@ -4,12 +4,16 @@
    Cursors are stored as EDN at:
      <pipeline-dir>/.cursors/<pipeline-filename>
 
-   The on-disk map is keyed by [connector-ref schema-name] for stable
-   identity across runs (stage UUIDs are regenerated each run).
+   The on-disk map is keyed by [stage-name schema-name] — the only
+   identity a cursor entry carries that survives between runs. Both
+   `:stage/id` and `:stage/connector-ref` are freshly generated UUIDs
+   on every run (see `store/normalize-for-storage`).
    prior-cursor in pipeline-runner looks up by this composite key."
   (:require [ai.miniforge.cursor-store.store :as store]))
 
-(defn save-cursors
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} save-cursors
   "Persist connector cursors after a pipeline run.
    logger         — logger instance (or nil)
    pipeline-path  — path to the pipeline EDN file (cursor path is derived from it)
@@ -18,11 +22,11 @@
   [logger pipeline-path cursor-map]
   (store/save-cursors logger pipeline-path cursor-map))
 
-(defn load-cursors
+(defn ^{:stratum 0} load-cursors
   "Load persisted cursors for a pipeline.
    logger         — logger instance (or nil)
    pipeline-path  — path to the pipeline EDN file
-   Returns schema/success with :cursors key ({[conn-ref schema-name] → cursor-entry}).
+   Returns schema/success with :cursors key ({[stage-name schema-name] → cursor-entry}).
    Returns schema/success with empty map on first run.
    Returns schema/failure only on parse errors."
   [logger pipeline-path]

--- a/components/cursor-store/src/ai/miniforge/cursor_store/interface.clj
+++ b/components/cursor-store/src/ai/miniforge/cursor_store/interface.clj
@@ -8,7 +8,11 @@
    identity a cursor entry carries that survives between runs. Both
    `:stage/id` and `:stage/connector-ref` are freshly generated UUIDs
    on every run (see `store/normalize-for-storage`).
-   prior-cursor in pipeline-runner looks up by this composite key."
+
+   That key is this store's own; nothing downstream reads it directly.
+   `pipeline-runner`'s prior-cursor resolves a stage's cursor by the
+   `:stage/id` it was scheduled with, so a caller translates between
+   the two — `etl.cursors/by-stage-id` is the one that does today."
   (:require [ai.miniforge.cursor-store.store :as store]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -27,7 +31,8 @@
    logger         — logger instance (or nil)
    pipeline-path  — path to the pipeline EDN file
    Returns schema/success with :cursors key ({[stage-name schema-name] → cursor-entry}).
-   Returns schema/success with empty map on first run.
-   Returns schema/failure only on parse errors."
+   Returns schema/success with empty map on first run (no file yet).
+   Returns schema/failure when a file that does exist cannot be read —
+   a parse error, but equally a permissions or other I/O failure."
   [logger pipeline-path]
   (store/load-cursors logger pipeline-path))

--- a/components/cursor-store/src/ai/miniforge/cursor_store/store.clj
+++ b/components/cursor-store/src/ai/miniforge/cursor_store/store.clj
@@ -26,19 +26,31 @@
     (io/file dir ".cursors" (.getName f))))
 
 (defn- ^{:stratum 0} normalize-for-storage
-  "Re-key {stage-uuid → cursor-entry} to {[connector-ref schema-name] → cursor-entry}.
-   Entries missing connector-ref or schema-name are dropped with a warning."
+  "Re-key {stage-uuid → cursor-entry} to {[stage-name schema-name] → cursor-entry}.
+   Entries missing stage-name or schema-name are dropped with a warning.
+
+   The key has to survive between runs, which rules out both of the
+   identifiers a cursor entry carries alongside them.
+   `:stage/id` is regenerated per run. So is `:stage/connector-ref`:
+   `pipeline-config`'s `instantiate-connectors` mints a fresh
+   `UUID/randomUUID` per connector and the resolver substitutes it for
+   the pack's symbolic `:conn/…` keyword, so a resolved stage's
+   connector-ref is a different value on every run and a file keyed by
+   it would never match on reload. `:stage/name` comes verbatim from
+   the pipeline EDN — the same string an env config uses to key its
+   per-stage overrides, so the pack format already depends on it being
+   stable and unique within a pipeline."
   [logger cursor-map]
   (reduce-kv
    (fn [acc _id entry]
-     (let [cref  (:stage/connector-ref entry)
-           sname (:stage/schema-name entry)]
-       (if (and cref sname)
-         (assoc acc [cref sname] entry)
+     (let [sname  (:stage/name entry)
+           schema (:stage/schema-name entry)]
+       (if (and sname schema)
+         (assoc acc [sname schema] entry)
          (do (when logger
                (log/warn logger :cursor-store :cursor-store/entry-dropped
-                         {:message "Cursor entry dropped — missing connector-ref or schema-name"
-                          :data {:stage/name (or (:stage/name entry) "unknown")}}))
+                         {:message "Cursor entry dropped — missing stage-name or schema-name"
+                          :data {:stage/name (get entry :stage/name "unknown")}}))
              acc))))
    {}
    cursor-map))
@@ -81,7 +93,8 @@
 (defn ^{:stratum 1} save-cursors
   "Persist connector cursors to <pipeline-dir>/.cursors/<pipeline-filename>.
    cursor-map is the raw {stage-uuid → cursor-entry} map from
-   :pipeline-run/connector-cursors. Returns schema/success or schema/failure."
+   :pipeline-run/connector-cursors, re-keyed for cross-run lookup.
+   Returns schema/success or schema/failure."
   [logger pipeline-path cursor-map]
   (try
     (let [normalized (normalize-for-storage logger cursor-map)
@@ -108,7 +121,7 @@
 
 (defn ^{:stratum 1} load-cursors
   "Load persisted cursors for a pipeline. Returns schema/success with
-   :cursors key (map keyed by [connector-ref schema-name]).
+   :cursors key (map keyed by [stage-name schema-name]).
    Returns schema/success with {} on first run (no file yet).
    Returns schema/failure only on parse errors."
   [logger pipeline-path]

--- a/components/cursor-store/src/ai/miniforge/cursor_store/store.clj
+++ b/components/cursor-store/src/ai/miniforge/cursor_store/store.clj
@@ -123,7 +123,10 @@
   "Load persisted cursors for a pipeline. Returns schema/success with
    :cursors key (map keyed by [stage-name schema-name]).
    Returns schema/success with {} on first run (no file yet).
-   Returns schema/failure only on parse errors."
+   Returns schema/failure when a file that does exist cannot be read.
+   The try covers the slurp as well as the parse, so a permissions or
+   other I/O failure surfaces the same way a malformed file does —
+   callers must not treat a read failure here as impossible."
   [logger pipeline-path]
   (try
     (let [file (cursor-file pipeline-path)]

--- a/components/cursor-store/test/ai/miniforge/cursor_store/interface_test.clj
+++ b/components/cursor-store/test/ai/miniforge/cursor_store/interface_test.clj
@@ -55,12 +55,12 @@
   (testing "save then load preserves cursor data with stable key"
     (let [path      (tmp-pipeline-path)
           stage-id  (random-uuid)
-          conn-ref  :conn/gitlab
+          stage     "Ingest Issues"
           schema    "issues"
           instant   (Instant/now)
           cursor-map {stage-id {:stage/id            stage-id
-                                :stage/name          "Ingest Issues"
-                                :stage/connector-ref conn-ref
+                                :stage/name          stage
+                                :stage/connector-ref (random-uuid)
                                 :stage/schema-name   schema
                                 :cursor              {:cursor/type  :offset
                                                       :cursor/value 42}
@@ -68,7 +68,7 @@
       (is (:success? (sut/save-cursors logger path cursor-map)))
       (let [result (sut/load-cursors logger path)]
         (is (:success? result))
-        (let [loaded (get (:cursors result) [conn-ref schema])]
+        (let [loaded (get (:cursors result) [stage schema])]
           (is (some? loaded))
           (is (= :offset (get-in loaded [:cursor :cursor/type])))
           (is (= 42 (get-in loaded [:cursor :cursor/value])))
@@ -77,23 +77,29 @@
           (is (= (str instant) (:cursor/updated-at loaded))))))))
 
 (deftest ^{:stratum 1} multi-stage-round-trip-test
-  (testing "Multiple stages produce multiple entries keyed by connector/schema"
-    (let [path  (tmp-pipeline-path)
-          id-1  (random-uuid)
-          id-2  (random-uuid)
-          cursor-map {id-1 {:stage/connector-ref :conn/gitlab
-                             :stage/schema-name   "issues"
-                             :cursor              {:cursor/type :offset :cursor/value 10}
-                             :cursor/updated-at   (Instant/now)}
-                      id-2 {:stage/connector-ref :conn/gitlab
-                             :stage/schema-name   "merge-requests"
-                             :cursor              {:cursor/type :offset :cursor/value 5}
-                             :cursor/updated-at   (Instant/now)}}]
+  (testing "Two stages sharing one connector keep separate entries"
+    (let [path      (tmp-pipeline-path)
+          id-1      (random-uuid)
+          id-2      (random-uuid)
+          ;; Both stages read through the same connector, as an
+          ;; ingest-issues/ingest-merge-requests pack does.
+          conn-ref  (random-uuid)
+          cursor-map {id-1 {:stage/name          "Ingest Issues"
+                            :stage/connector-ref conn-ref
+                            :stage/schema-name   "issues"
+                            :cursor              {:cursor/type :offset :cursor/value 10}
+                            :cursor/updated-at   (Instant/now)}
+                      id-2 {:stage/name          "Ingest Merge Requests"
+                            :stage/connector-ref conn-ref
+                            :stage/schema-name   "merge-requests"
+                            :cursor              {:cursor/type :offset :cursor/value 5}
+                            :cursor/updated-at   (Instant/now)}}]
       (sut/save-cursors logger path cursor-map)
       (let [loaded (:cursors (sut/load-cursors logger path))]
         (is (= 2 (count loaded)))
-        (is (= 10 (get-in loaded [[:conn/gitlab "issues"] :cursor :cursor/value])))
-        (is (= 5 (get-in loaded [[:conn/gitlab "merge-requests"] :cursor :cursor/value])))))))
+        (is (= 10 (get-in loaded [["Ingest Issues" "issues"] :cursor :cursor/value])))
+        (is (= 5 (get-in loaded [["Ingest Merge Requests" "merge-requests"]
+                                 :cursor :cursor/value])))))))
 
 (defn- ^{:stratum 1} persisted-cursor
   "Save `cursor-value` as a timestamp watermark, then load it back.
@@ -108,7 +114,8 @@
   (let [path   (tmp-pipeline-path)
         saved  (sut/save-cursors
                 logger path
-                {(random-uuid) {:stage/connector-ref :conn/gitlab
+                {(random-uuid) {:stage/name          "Ingest Issues"
+                                :stage/connector-ref (random-uuid)
                                 :stage/schema-name   "issues"
                                 :cursor {:cursor/type  :timestamp-watermark
                                          :cursor/value cursor-value}
@@ -116,44 +123,55 @@
         loaded (sut/load-cursors logger path)]
     (is (:success? saved) (str "save-cursors failed: " (:error saved)))
     (is (:success? loaded) (str "load-cursors failed: " (:error loaded)))
-    (-> loaded :cursors (get [:conn/gitlab "issues"]) :cursor)))
+    (-> loaded :cursors (get ["Ingest Issues" "issues"]) :cursor)))
 
 ;; ---------------------------------------------------------------------------
 ;; normalization
 (deftest ^{:stratum 1} normalization-drops-incomplete-entries-test
-  (testing "Entries without connector-ref or schema-name are excluded"
-    (let [path     (tmp-pipeline-path)
-          good-id  (random-uuid)
-          bad-id   (random-uuid)
-          cursor-map {good-id {:stage/connector-ref :conn/github
-                               :stage/schema-name   "pulls"
-                               :cursor              {:cursor/type :offset :cursor/value 1}
-                               :cursor/updated-at   (Instant/now)}
-                      bad-id  {:stage/name        "No-ref stage"
-                               :cursor            {:cursor/type :offset :cursor/value 2}
-                               :cursor/updated-at (Instant/now)}}]
+  (testing "Entries without stage-name or schema-name are excluded"
+    (let [path       (tmp-pipeline-path)
+          good-id    (random-uuid)
+          no-schema  (random-uuid)
+          no-name    (random-uuid)
+          cursor-map {good-id   {:stage/name        "Ingest PRs"
+                                 :stage/schema-name "pulls"
+                                 :cursor            {:cursor/type :offset :cursor/value 1}
+                                 :cursor/updated-at (Instant/now)}
+                      no-schema {:stage/name        "No-schema stage"
+                                 :cursor            {:cursor/type :offset :cursor/value 2}
+                                 :cursor/updated-at (Instant/now)}
+                      no-name   {:stage/schema-name "orphan"
+                                 :cursor            {:cursor/type :offset :cursor/value 3}
+                                 :cursor/updated-at (Instant/now)}}]
       (sut/save-cursors logger path cursor-map)
       (let [loaded (:cursors (sut/load-cursors logger path))]
         (is (= 1 (count loaded)))
-        (is (contains? loaded [:conn/github "pulls"]))))))
+        (is (contains? loaded ["Ingest PRs" "pulls"]))))))
 
 ;; ---------------------------------------------------------------------------
 ;; idempotency — second save overwrites first
 (deftest ^{:stratum 1} overwrite-test
   (testing "Saving again overwrites prior cursor with updated value"
-    (let [path     (tmp-pipeline-path)
-          conn-ref :conn/gitlab
-          schema   "issues"
-          run1 {(random-uuid) {:stage/connector-ref conn-ref :stage/schema-name schema
-                               :cursor {:cursor/type :offset :cursor/value 10}
-                               :cursor/updated-at (Instant/now)}}
-          run2 {(random-uuid) {:stage/connector-ref conn-ref :stage/schema-name schema
-                               :cursor {:cursor/type :offset :cursor/value 20}
-                               :cursor/updated-at (Instant/now)}}]
-      (sut/save-cursors logger path run1)
-      (sut/save-cursors logger path run2)
+    ;; Every identifier a run generates differs between run1 and run2 —
+    ;; stage id and connector-ref are both fresh UUIDs each time. Only
+    ;; the pack-declared stage name and schema name carry over, which is
+    ;; why the store keys on those: anything else makes the second save
+    ;; a second entry instead of an update, and the watermark never
+    ;; advances.
+    (let [path   (tmp-pipeline-path)
+          stage  "Ingest Issues"
+          schema "issues"
+          run-of (fn [value]
+                   {(random-uuid) {:stage/name          stage
+                                   :stage/connector-ref (random-uuid)
+                                   :stage/schema-name   schema
+                                   :cursor {:cursor/type :offset :cursor/value value}
+                                   :cursor/updated-at (Instant/now)}})]
+      (sut/save-cursors logger path (run-of 10))
+      (sut/save-cursors logger path (run-of 20))
       (let [loaded (:cursors (sut/load-cursors logger path))]
-        (is (= 20 (get-in loaded [[conn-ref schema] :cursor :cursor/value])))))))
+        (is (= 1 (count loaded)))
+        (is (= 20 (get-in loaded [[stage schema] :cursor :cursor/value])))))))
 
 (deftest ^{:stratum 1} inst-tagged-cursor-file-loads-as-string-test
   (testing "a cursor file containing #inst still yields a filterable watermark"
@@ -165,14 +183,14 @@
           file (io/file (.getParentFile (io/file path))
                         ".cursors" (.getName (io/file path)))]
       (io/make-parents file)
-      (spit file (pr-str {[:conn/gitlab "issues"]
-                          {:stage/connector-ref :conn/gitlab
-                           :stage/schema-name   "issues"
+      (spit file (pr-str {["Ingest Issues" "issues"]
+                          {:stage/name        "Ingest Issues"
+                           :stage/schema-name "issues"
                            :cursor {:cursor/type  :timestamp-watermark
                                     :cursor/value (Date/from
                                                    (Instant/parse watermark-iso))}}}))
       (let [loaded (sut/load-cursors logger path)
-            cursor (get-in (:cursors loaded) [[:conn/gitlab "issues"] :cursor])]
+            cursor (get-in (:cursors loaded) [["Ingest Issues" "issues"] :cursor])]
         (is (:success? loaded) (str "load-cursors failed: " (:error loaded)))
         (is (= watermark-iso (:cursor/value cursor)))
         (is (false? (connector-http/after-cursor?

--- a/projects/data-foundry/deps.edn
+++ b/projects/data-foundry/deps.edn
@@ -32,6 +32,7 @@
         ai.miniforge/coerce                    {:local/root "../../components/coerce"}
         ai.miniforge/config                    {:local/root "../../components/config"}
         ai.miniforge/content-hash              {:local/root "../../components/content-hash"}
+        ai.miniforge/cursor-store              {:local/root "../../components/cursor-store"}
         ai.miniforge/dag-executor              {:local/root "../../components/dag-executor"}
         ai.miniforge/dag-primitives            {:local/root "../../components/dag-primitives"}
         ai.miniforge/data-quality              {:local/root "../../components/data-quality"}


### PR DESCRIPTION
## What

`cursor-store` arrived with the Data Foundry import (#474) and was never called. `save-cursors` and `load-cursors` had no callers anywhere in `components/`, `bases/`, or `projects/`; `clojure -M:poly info` showed the component belonging to no project, so its tests had never run in a CI test plan.

The consequence was that connectors had no cross-run watermark at all. `pipeline-runner` threads `:pipeline-run/connector-cursors` through a single run, but nothing persisted it at the end or reloaded it at the start — so every `mf etl run` of an incremental pack re-ingested its source from scratch. Two of the three shipped packs (`github-data`, `gitlab-data`) declare `:pipeline/mode :incremental`.

This wires it up, and fixes the identity bug that would have made the wiring inert.

## The identity bug

The store keyed its on-disk map by `[connector-ref schema-name]`, documented as "stable identity across runs". It is not. `pipeline-config`'s `instantiate-connectors` mints a fresh `UUID/randomUUID` per connector on every run ([connector_registry.clj:41](https://github.com/miniforge-ai/miniforge/blob/main/components/pipeline-config/src/ai/miniforge/pipeline_config/connector_registry.clj#L41)) and the resolver substitutes it for the pack's symbolic `:conn/…` keyword, so a resolved stage's `connector-ref` is a different value each run. A cursor file written under that key could never match on reload.

The old tests missed it because their fixtures used a literal `:conn/gitlab` keyword rather than the resolved UUID a real run produces. They now use fresh per-run identifiers throughout, so `overwrite-test` fails if the key stops being stable.

`:stage/name` is the only identity a cursor entry carries that survives — it comes verbatim from the pipeline EDN and is the same string an env config uses to key its per-stage overrides.

## The wiring

`etl.cursors` is the join between the store and the runner. `run-pack` primes the run context before executing and writes the result back after. Two policy decisions live there:

1. Only `:incremental` carries a watermark. `:full-refresh` re-reads everything by definition; `:backfill` and `:reprocess` deliberately re-read history, so a watermark from either would drag the resume point backwards.
2. Only a wholly successful run advances it. A run that ingested and then failed downstream holds records that were extracted and never published; advancing past them would drop them for good.

Failures are reported rather than absorbed. An unreadable cursor file fails the run instead of starting fresh — a stage with no cursor admits every record, so "re-ingest everything" would otherwise report itself as success. A cursor that cannot be written fails the run too: the records landed, but the pipeline can no longer say where it got to.

`by-stage-id` translates the store's durable `[stage-name schema-name]` key onto the per-run `:stage/id` that `pipeline-runner`'s `prior-cursor` looks up first, so neither side needs the other's key space. This deliberately leaves `pipeline-runner` untouched — teaching `run.clj` the store's key would have pulled in a rule-210 conversion of that file (the autofix turns it into an 8-layer namespace needing its own split), which belongs in its own PR.

## Test plan

`bases/etl/test/.../cursors_test.clj` drives `runner/run-pack` twice against a pack whose source and sink are both `:file` connectors — no network, deterministic, offset-based. The sink appends, so a re-ingest of the whole source shows up as duplicate published records rather than something inferred from the cursor map.

- Verified by mutation: removing the stage-id translation turns the resume tests red with 8 published records where 5 are expected. Reverting the key fix does the same.
- `clojure -M:poly test project:data-foundry :all` — 191 namespaces, 0 failures. `cursor-store` is now among the project's 37 bricks, so its tests run in CI for the first time.
- `poly check` reports no new warnings; warning 207 still lists only the pre-existing `decision-envelope` and `effect-transaction`, not `cursor-store`.

## Notes

- `.gitignore` now covers `**/.cursors/`. The store writes next to the pipeline EDN, which for a shipped pack is a tracked path.
- Follow-up stacked on this branch: [fix/cursor-store-merge-on-save](https://github.com/miniforge-ai/miniforge/tree/fix/cursor-store-merge-on-save) — `save-cursors` replaces the file rather than merging, which erases the watermark of any stage that reported no cursor this run.
- Related: #1605 fixed a real instant-normalization defect in this store. That fix was correct but inert until now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)