### PR TITLE
feat(codex): Thesium Codex consumption — codex component + consider_situation MCP tool

### DIFF
--- a/bases/mcp-context-server/resources/mcp-context-server/tool-registry.edn
+++ b/bases/mcp-context-server/resources/mcp-context-server/tool-registry.edn
@@ -68,4 +68,19 @@
      "content" {:type "string" :description "Complete file contents to write"}}}}
   :required-params
   {"path"    {:check :non-blank :msg "path is required"}
-   "content" {:check :string    :msg "content is required (string)"}}}}
+   "content" {:check :string    :msg "content is required (string)"}}}
+
+ ;; ------------------------------------------------------------------------- Thesium Codex
+ "consider_situation"
+ {:handler :consider-situation
+  :tool-def
+  {:name "consider_situation"
+   :description "Consult the Thesium Codex BEFORE acting: route your current situation to the problems worth attending to, each anchored to a failure that actually happened. Returns landings ordered strategic-first with a coverage statement. Call this when about to take actions in the world, when a process is stuck or slow, when about to trust a quality signal, when about to commit to something consequential, or when changing one side of a producer/consumer boundary."
+   :inputSchema
+   {:type "object"
+    :required ["situation"]
+    :properties
+    {"situation"  {:type "string" :description "What you are doing, phrased as a situation (e.g. \"an agent needs to act in the world\"). Substring of a situation id or title also works."}
+     "codex_path" {:type "string" :description "Codex directory (optional; defaults to MINIFORGE_CODEX_PATH)"}}}}
+  :required-params
+  {"situation" {:check :non-blank :msg "situation is required"}}}}

--- a/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/codex_tool.clj
+++ b/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/codex_tool.clj
@@ -32,10 +32,13 @@
 
 ;; Codex location
 (defn ^{:stratum 0} codex-path
-  "Codex directory: explicit param wins, else MINIFORGE_CODEX_PATH."
+  "Codex directory: explicit param wins, else MINIFORGE_CODEX_PATH.
+   A non-string param is treated as absent — this tool fails closed with a
+   codex anomaly, never a JSON-RPC error from str/trim on a number."
   [params]
-  (or (some-> (get params "codex_path") str/trim not-empty)
-      (some-> (System/getenv "MINIFORGE_CODEX_PATH") str/trim not-empty)))
+  (let [p (get params "codex_path")]
+    (or (when (string? p) (not-empty (str/trim p)))
+        (some-> (System/getenv "MINIFORGE_CODEX_PATH") str/trim not-empty))))
 
 ;; Rendering
 (defn- ^{:stratum 0} render-landing [{:keys [id type title horizon confidence open scars escalations]}]
@@ -61,9 +64,14 @@
            no-strategic-coverage? newest-scar-date]}]
   (str/join "\n"
     (concat
+      ;; horizon mix rendered in the §7.6.1 order, not map order
       [(str "coverage: " landing-count " landings, "
             unanchored-count " unanchored, newest scar " (or newest-scar-date "none")
-            ", horizon mix " (pr-str horizon-mix))]
+            ", horizon mix "
+            (str/join " · " (for [h ["strategic" "operational" "tactical"]
+                                  :let [n (get horizon-mix h)]
+                                  :when n]
+                              (str h " " n))))]
       (when no-strategic-coverage?
         ["NO STRATEGIC COVERAGE: every landing is tactical/operational. The codex has nothing strategic-horizon for this situation — that absence is a gap in the codex, not evidence the situation carries no strategic risk."]))))
 

--- a/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/codex_tool.clj
+++ b/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/codex_tool.clj
@@ -1,0 +1,109 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.mcp-context-server.codex-tool
+  "The consider_situation MCP tool — the Thesium Codex consumption surface
+   (Codex SPEC T1 §7.1) exposed to agents.
+
+   Rendering rules come from the spec, not taste: landings arrive ordered
+   strategic → operational → tactical (§7.6.1); the coverage statement leads
+   and says out loud when there is no strategic-horizon landing (§7.6.2);
+   horizon escalations — a landing whose anchoring scar cost more than the
+   landing's own horizon — are flagged inline (§7.6.3). Anomalies render as
+   anomalies; an unmatched situation is an answer, never an empty list."
+  (:require [ai.miniforge.codex.interface :as codex]
+            [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Codex location
+(defn ^{:stratum 0} codex-path
+  "Codex directory: explicit param wins, else MINIFORGE_CODEX_PATH."
+  [params]
+  (or (some-> (get params "codex_path") str/trim not-empty)
+      (some-> (System/getenv "MINIFORGE_CODEX_PATH") str/trim not-empty)))
+
+;; Rendering
+(defn- ^{:stratum 0} render-landing [{:keys [id type title horizon confidence open scars escalations]}]
+  ;; horizon, anchoring and escalation are problem-node concepts (SPEC §2.3,
+  ;; §2.6); a resolution is a terminal outcome and renders as one.
+  (let [problem? (= type "problem")]
+    (str/join "\n"
+      (concat
+        [(str "- [" (if problem? (or horizon "?") "resolution") "] " id " — " title
+              "  (confidence: " confidence ")")]
+        (when (seq escalations)
+          [(str "    ESCALATION: " (str/join ", " escalations)
+                " — the cost landed above this problem's horizon")])
+        (for [{scar-id :id :keys [date cost cost-horizon]} scars]
+          (str "    scar: " scar-id " (" date ", cost: " cost
+               (when cost-horizon (str ", cost-horizon: " cost-horizon)) ")"))
+        (when (and problem? (empty? scars))
+          ["    unanchored — reasoned, not survived"])
+        (map #(str "    open: " %) open)))))
+
+(defn- ^{:stratum 0} render-coverage
+  [{:keys [landing-count unanchored-count horizon-mix
+           no-strategic-coverage? newest-scar-date]}]
+  (str/join "\n"
+    (concat
+      [(str "coverage: " landing-count " landings, "
+            unanchored-count " unanchored, newest scar " (or newest-scar-date "none")
+            ", horizon mix " (pr-str horizon-mix))]
+      (when no-strategic-coverage?
+        ["NO STRATEGIC COVERAGE: every landing is tactical/operational. The codex has nothing strategic-horizon for this situation — that absence is a gap in the codex, not evidence the situation carries no strategic risk."]))))
+
+(defn- ^{:stratum 0} render-anomaly [{:codex/keys [anomaly reason available matches]}]
+  (str/join "\n"
+    (concat
+      [(str "codex anomaly: " (name anomaly))
+       reason]
+      (when (seq available)
+        (cons "available situations:"
+              (map (fn [[id title]] (str "- " id " — " title)) available)))
+      (when (seq matches)
+        (cons "ambiguous between:"
+              (map (fn [[id title]] (str "- " id " — " title)) matches))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} render-response [resp]
+  (if (:codex/anomaly resp)
+    (render-anomaly resp)
+    (str/join "\n"
+      (concat
+        [(str "situation: " (:situation resp) " — " (:situation-title resp))
+         (render-coverage (:coverage resp))
+         ""
+         "landings (strategic first — read top-down):"]
+        (map render-landing (:landings resp))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; MCP handler
+(defn ^{:stratum 2} handle-consider-situation
+  "MCP handler for consider_situation. Fails closed: no configured codex
+   path is an anomaly with a reason, never an empty success."
+  [params]
+  (let [text (if-let [path (codex-path params)]
+               (render-response (codex/consider path (get params "situation")))
+               (render-anomaly
+                 {:codex/anomaly :codex-unconfigured
+                  :codex/reason (str "no codex_path argument and MINIFORGE_CODEX_PATH "
+                                     "is unset — cannot consult a codex that has "
+                                     "no location")}))]
+    {:content [{:type "text" :text text}]}))

--- a/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/rpc.clj
+++ b/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/rpc.clj
@@ -1,0 +1,83 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.mcp-context-server.rpc
+  "JSON-RPC 2.0 method dispatch for the MCP context server. Split from
+   `server` (which keeps the stdin loop and lifecycle) so each namespace
+   stays within the stratified-design layer budget.
+   Babashka-compatible."
+  (:require [ai.miniforge.mcp-context-server.protocol :as protocol]
+            [ai.miniforge.mcp-context-server.tools :as tools]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Logging (stderr only — stdout is the JSON-RPC transport)
+(defn ^{:stratum 0} log-stderr
+  "Print message to stderr (stdout is reserved for JSON-RPC)."
+  [& args]
+  (binding [*out* *err*]
+    (apply println args)))
+
+;; MCP dispatch
+(defn ^{:stratum 0} handle-initialize [_params]
+  {:protocolVersion "2024-11-05"
+   :capabilities {:tools {:listChanged false}}
+   :serverInfo {:name "miniforge-context-server"
+                :version "1.0.0"}})
+
+(defn ^{:stratum 0} handle-tools-list [_params]
+  {:tools (tools/tool-definitions)})
+
+(defn ^{:stratum 0} handle-tools-call [params]
+  (let [tool-name (get params "name")
+        arguments (get params "arguments" {})]
+    (tools/handle-tool-call tool-name arguments)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} dispatch
+  "Route a JSON-RPC method to the appropriate handler."
+  [method params]
+  (case method
+    "initialize"                  (handle-initialize params)
+    "tools/list"                  (handle-tools-list params)
+    "tools/call"                  (handle-tools-call params)
+    "notifications/initialized"   nil
+    "notifications/cancelled"     nil
+    (throw (ex-info (str "Method not found: " method) {:code -32601}))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Message processing — one extracted function per message shape
+(defn ^{:stratum 2} handle-request
+  "Handle a JSON-RPC request (has id, expects response)."
+  [id method params]
+  (try
+    (when-let [result (dispatch method params)]
+      (protocol/write-response id result))
+    (catch Exception e
+      (let [code (get (ex-data e) :code -32603)]
+        (log-stderr "Error handling" method ":" (ex-message e))
+        (protocol/write-error id code (ex-message e))))))
+
+(defn ^{:stratum 2} handle-notification
+  "Handle a JSON-RPC notification (no id, no response)."
+  [method params]
+  (try
+    (dispatch method params)
+    (catch Exception e
+      (log-stderr "Notification error:" (ex-message e)))))

--- a/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/server.clj
+++ b/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/server.clj
@@ -15,75 +15,29 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.mcp-context-server.server
-  "Main MCP JSON-RPC 2.0 stdin/stdout loop.
+  "Main MCP stdin/stdout loop and lifecycle. JSON-RPC method dispatch lives
+   in `rpc`.
    Babashka-compatible."
-  (:require [ai.miniforge.mcp-context-server.context-cache :as context-cache]
+  (:require [ai.miniforge.mcp-context-server.codex-tool :as codex-tool]
+            [ai.miniforge.mcp-context-server.context-cache :as context-cache]
             [ai.miniforge.mcp-context-server.protocol :as protocol]
+            [ai.miniforge.mcp-context-server.rpc :as rpc]
             [ai.miniforge.mcp-context-server.tools :as tools]
             [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Logging (stderr only — stdout is the JSON-RPC transport)
 
-(defn log-stderr
-  "Print message to stderr (stdout is reserved for JSON-RPC)."
-  [& args]
-  (binding [*out* *err*]
-    (apply println args)))
+(defn- ^{:stratum 0} register-context-handlers!
+  "Register tool handlers in the tool handler registry."
+  []
+  (tools/register-handler! :context-read  context-cache/handle-context-read)
+  (tools/register-handler! :context-grep  context-cache/handle-context-grep)
+  (tools/register-handler! :context-glob  context-cache/handle-context-glob)
+  (tools/register-handler! :context-write context-cache/handle-context-write)
+  (tools/register-handler! :consider-situation codex-tool/handle-consider-situation))
 
-;------------------------------------------------------------------------------ Layer 1
-;; MCP dispatch
-
-(defn handle-initialize [_params]
-  {:protocolVersion "2024-11-05"
-   :capabilities {:tools {:listChanged false}}
-   :serverInfo {:name "miniforge-context-server"
-                :version "1.0.0"}})
-
-(defn handle-tools-list [_params]
-  {:tools (tools/tool-definitions)})
-
-(defn handle-tools-call [params]
-  (let [tool-name (get params "name")
-        arguments (get params "arguments" {})]
-    (tools/handle-tool-call tool-name arguments)))
-
-(defn dispatch
-  "Route a JSON-RPC method to the appropriate handler."
-  [method params]
-  (case method
-    "initialize"                  (handle-initialize params)
-    "tools/list"                  (handle-tools-list params)
-    "tools/call"                  (handle-tools-call params)
-    "notifications/initialized"   nil
-    "notifications/cancelled"     nil
-    (throw (ex-info (str "Method not found: " method) {:code -32601}))))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Message processing — one extracted function per message shape
-
-(defn handle-request
-  "Handle a JSON-RPC request (has id, expects response)."
-  [id method params]
-  (try
-    (when-let [result (dispatch method params)]
-      (protocol/write-response id result))
-    (catch Exception e
-      (let [code (get (ex-data e) :code -32603)]
-        (log-stderr "Error handling" method ":" (ex-message e))
-        (protocol/write-error id code (ex-message e))))))
-
-(defn handle-notification
-  "Handle a JSON-RPC notification (no id, no response)."
-  [method params]
-  (try
-    (dispatch method params)
-    (catch Exception e
-      (log-stderr "Notification error:" (ex-message e)))))
-
-(defn process-message
+(defn ^{:stratum 0} process-message
   "Parse and dispatch a single JSON-RPC message."
   [line]
   (if-let [msg (protocol/parse-message line)]
@@ -91,36 +45,29 @@
           method (get msg "method")
           params (get msg "params" {})]
       (if id
-        (handle-request id method params)
-        (handle-notification method params)))
-    (log-stderr "Parse error: invalid JSON")))
+        (rpc/handle-request id method params)
+        (rpc/handle-notification method params)))
+    (rpc/log-stderr "Parse error: invalid JSON")))
 
-(defn process-line
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} process-line
   "Process a single line from stdin. Skips blank lines."
   [line]
   (when-not (str/blank? line)
     (try
       (process-message line)
       (catch Exception e
-        (log-stderr "Parse error:" (ex-message e))))))
+        (rpc/log-stderr "Parse error:" (ex-message e))))))
 
 ;------------------------------------------------------------------------------ Layer 2
-;; Main loop
 
-(defn- register-context-handlers!
-  "Register context-cache tool handlers in the tool handler registry."
-  []
-  (tools/register-handler! :context-read  context-cache/handle-context-read)
-  (tools/register-handler! :context-grep  context-cache/handle-context-grep)
-  (tools/register-handler! :context-glob  context-cache/handle-context-glob)
-  (tools/register-handler! :context-write context-cache/handle-context-write))
-
-(defn run-server
+(defn ^{:stratum 2} run-server
   "Run the MCP context server loop, reading JSON-RPC messages from stdin.
 
    Lifecycle:
    1. Load context cache from artifact-dir (if present)
-   2. Register context-cache tool handlers
+   2. Register tool handlers
    3. Process JSON-RPC messages until stdin closes
    4. Flush accumulated cache misses to artifact-dir
 
@@ -131,8 +78,8 @@
      to source-root when absent"
   ([artifact-dir source-root] (run-server artifact-dir source-root nil))
   ([artifact-dir source-root workdir]
-   (log-stderr "miniforge-context MCP server started, artifact-dir:" artifact-dir
-               "source-root:" source-root "workdir:" workdir)
+   (rpc/log-stderr "miniforge-context MCP server started, artifact-dir:" artifact-dir
+                   "source-root:" source-root "workdir:" workdir)
    (context-cache/load-cache! artifact-dir source-root)
    (context-cache/set-workdir! workdir)
    (register-context-handlers!)

--- a/bases/mcp-context-server/test/ai/miniforge/mcp_context_server/codex_tool_test.clj
+++ b/bases/mcp-context-server/test/ai/miniforge/mcp_context_server/codex_tool_test.clj
@@ -1,0 +1,81 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.mcp-context-server.codex-tool-test
+  "The response-map shapes rendered here are pinned by the codex component's
+   own tests (ai.miniforge.codex.interface-test) against generator-produced
+   fixtures; these tests cover the base's rendering and fail-closed paths."
+  (:require [ai.miniforge.mcp-context-server.codex-tool :as codex-tool]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} text-of [result]
+  (-> result :content first :text))
+
+(deftest ^{:stratum 0} render-orders-and-flags
+  (let [resp {:situation "s1"
+              :situation-title "A situation"
+              :landings [{:id "p-strategic" :type "problem" :title "Big one"
+                          :horizon "strategic" :confidence "high"
+                          :open [] :scars [] :escalations []}
+                         {:id "p-op" :type "problem" :title "Runs the system"
+                          :horizon "operational" :confidence "high"
+                          :open ["still open"]
+                          :scars [{:id "scar-1" :date "2026-01" :cost "an outage"
+                                   :cost-horizon "strategic" :origin "owned"}]
+                          :escalations ["scar-1"]}]
+              :coverage {:landing-count 2 :unanchored-count 1
+                         :horizon-mix {"strategic" 1 "operational" 1}
+                         :no-strategic-coverage? false
+                         :newest-scar-date "2026-01"}}
+        text (codex-tool/render-response resp)]
+    (testing "strategic renders before operational (§7.6.1)"
+      (is (< (str/index-of text "p-strategic") (str/index-of text "p-op"))))
+    (testing "escalation and unanchored are flagged inline (§7.6.3)"
+      (is (str/includes? text "ESCALATION: scar-1"))
+      (is (str/includes? text "unanchored — reasoned, not survived")))
+    (testing "coverage line leads with counts (§7.5)"
+      (is (str/includes? text "coverage: 2 landings, 1 unanchored")))))
+
+(deftest ^{:stratum 0} render-says-when-strategic-coverage-is-absent
+  (let [resp {:situation "s1" :situation-title "t"
+              :landings [{:id "p" :type "problem" :title "t" :horizon "tactical"
+                          :confidence "high" :open [] :scars [] :escalations []}]
+              :coverage {:landing-count 1 :unanchored-count 1
+                         :horizon-mix {"tactical" 1}
+                         :no-strategic-coverage? true
+                         :newest-scar-date nil}}
+        text (codex-tool/render-response resp)]
+    (is (str/includes? text "NO STRATEGIC COVERAGE"))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} unconfigured-codex-fails-closed
+  ;; no codex_path param; MINIFORGE_CODEX_PATH is not set in the test env
+  (when-not (System/getenv "MINIFORGE_CODEX_PATH")
+    (let [text (text-of (codex-tool/handle-consider-situation
+                          {"situation" "an agent needs to act"}))]
+      (is (str/includes? text "codex anomaly: codex-unconfigured"))
+      (is (str/includes? text "MINIFORGE_CODEX_PATH")))))
+
+(deftest ^{:stratum 1} unreadable-codex-is-an-anomaly-not-an-empty-answer
+  (let [text (text-of (codex-tool/handle-consider-situation
+                        {"situation" "anything"
+                         "codex_path" "/nonexistent/codex"}))]
+    (is (str/includes? text "codex anomaly: codex-unreadable"))))

--- a/bb.edn
+++ b/bb.edn
@@ -570,6 +570,7 @@
   {:doc     "Run MCP context server (JSON-RPC 2.0 over stdin/stdout)"
    :extra-paths ["bases/mcp-context-server/src"
                  "bases/mcp-context-server/resources"
+                 "components/codex/src"
                  "components/messages/src"
                  "components/messages/resources"]
    :extra-deps {cheshire/cheshire {:mvn/version "5.13.0"}}
@@ -717,6 +718,7 @@
                  "components/context-pack/resources"
                  "bases/mcp-context-server/src"
                  "bases/mcp-context-server/resources"
+                 "components/codex/src"
                  "components/phase-software-factory/src"
                  "components/phase-software-factory/resources"
                  "components/compliance-scanner/src"

--- a/components/codex/deps.edn
+++ b/components/codex/deps.edn
@@ -1,0 +1,6 @@
+{:paths ["src"]
+ :deps {}
+ :aliases
+ {:test {:extra-paths ["test" "test-resources"]
+         :extra-deps {io.github.cognitect-labs/test-runner
+                      {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}}}

--- a/components/codex/src/ai/miniforge/codex/core.clj
+++ b/components/codex/src/ai/miniforge/codex/core.clj
@@ -1,0 +1,74 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.codex.core
+  "consider(situation) -> {landings, coverage}  (Codex SPEC T1 §7.1).
+
+   Assembles a response from the node graph (ai.miniforge.codex.node) and
+   the graph views (ai.miniforge.codex.graph). Anomalies are data: an
+   unreadable codex, an unmatched or an ambiguous situation returns a map
+   with :codex/anomaly, never an empty success — an empty answer that looks
+   like a clean answer is the exact failure the codex exists to prevent."
+  (:require [ai.miniforge.codex.graph :as graph]
+            [ai.miniforge.codex.node :as node]
+            [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} consider
+  "Route `situation-text` through the codex at `codex-dir`.
+
+   Returns {:situation id
+            :landings [...ordered strategic -> operational -> tactical]
+            :coverage {...}}
+   or a {:codex/anomaly ...} map when the codex is unreadable, the situation
+   matches nothing, or it matches ambiguously. Unmatched is an ANSWER, not
+   an empty list — silence about a missing match is false coverage."
+  [codex-dir situation-text]
+  (when (str/blank? (str situation-text))
+    (throw (IllegalArgumentException. "situation-text must be non-blank")))
+  (let [{:keys [nodes] :as loaded} (node/load-graph codex-dir)]
+    (if (:codex/anomaly loaded)
+      loaded
+      (let [matches (graph/match-situations nodes situation-text)]
+        (cond
+          (empty? matches)
+          {:codex/anomaly :situation-unmatched
+           :codex/reason (str "no situation matches '" situation-text "'")
+           :codex/available (->> (vals nodes)
+                                 (filter #(= "situation" (:type %)))
+                                 (mapv (juxt :id :title)))}
+
+          (< 1 (count matches))
+          {:codex/anomaly :situation-ambiguous
+           :codex/reason (str "'" situation-text "' matches "
+                              (count matches) " situations")
+           :codex/matches (mapv (juxt :id :title) matches)}
+
+          :else
+          (let [situation (first matches)
+                landings (->> (graph/reachable-from nodes (:id situation))
+                              (keep nodes)
+                              (filter #(#{"problem" "resolution"} (:type %)))
+                              (map #(graph/landing-view nodes %))
+                              (sort-by (fn [l] [(get graph/horizon-rank (:horizon l) 99)
+                                                (:id l)]))
+                              vec)]
+            {:situation (:id situation)
+             :situation-title (:title situation)
+             :landings landings
+             :coverage (graph/coverage-of landings)}))))))

--- a/components/codex/src/ai/miniforge/codex/core.clj
+++ b/components/codex/src/ai/miniforge/codex/core.clj
@@ -49,15 +49,20 @@
           (empty? matches)
           {:codex/anomaly :situation-unmatched
            :codex/reason (str "no situation matches '" situation-text "'")
+           ;; sorted: (vals nodes) order is map-order, and an anomaly that
+           ;; lists candidates should list them stably
            :codex/available (->> (vals nodes)
                                  (filter #(= "situation" (:type %)))
+                                 (sort-by :id)
                                  (mapv (juxt :id :title)))}
 
           (< 1 (count matches))
           {:codex/anomaly :situation-ambiguous
            :codex/reason (str "'" situation-text "' matches "
                               (count matches) " situations")
-           :codex/matches (mapv (juxt :id :title) matches)}
+           :codex/matches (->> matches
+                               (sort-by :id)
+                               (mapv (juxt :id :title)))}
 
           :else
           (let [situation (first matches)

--- a/components/codex/src/ai/miniforge/codex/graph.clj
+++ b/components/codex/src/ai/miniforge/codex/graph.clj
@@ -1,0 +1,115 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.codex.graph
+  "Walking and viewing the codex node graph: reachability over
+   routes-to/exposes edges (Codex SPEC T1 §3.2), horizon discipline
+   (§2.6, §7.6), situation matching, and the per-landing / coverage views
+   a response is assembled from."
+  (:require [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} horizon-rank
+  "Strategic outranks operational outranks tactical, and the ordering is
+   asymmetric: wrong at a lower horizon while right at a higher one can
+   succeed; the reverse cannot."
+  {"strategic" 0 "operational" 1 "tactical" 2})
+
+(defn- ^{:stratum 0} as-edge-list
+  "A frontmatter edge field is either a parsed list or an inline string
+   (situations emit `routes-to: <id>`); normalise to a list of maps."
+  [v]
+  (cond
+    (string? v) [{:target v}]
+    :else       v))
+
+(defn ^{:stratum 0} match-situations
+  "Situations whose id or title contains `text` (case-insensitive).
+   Exact id match wins outright."
+  [nodes text]
+  (let [situations (filter #(= "situation" (:type %)) (vals nodes))
+        norm (str/lower-case (str/trim text))]
+    (or (seq (filter #(= (:id %) norm) situations))
+        (seq (filter #(or (str/includes? (str/lower-case (str (:id %))) norm)
+                          (str/includes? (str/lower-case (str (:title %))) norm))
+                     situations)))))
+
+(defn ^{:stratum 0} coverage-of
+  "The response's own coverage statement (§7.5): landing count, unanchored
+   count, horizon mix, and age of the newest scar among the landings. A
+   response that reports only what is known creates false coverage."
+  [landings]
+  (let [problems (filter #(= "problem" (:type %)) landings)
+        mix (frequencies (keep :horizon problems))]
+    {:landing-count (count landings)
+     :unanchored-count (count (filter #(empty? (:scars %)) problems))
+     :horizon-mix mix
+     :no-strategic-coverage? (nil? (get mix "strategic"))
+     :newest-scar-date (some->> problems (mapcat :scars) (keep :date) sort last)}))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} edge-targets [node]
+  (concat
+    (for [r (as-edge-list (:routes-to node))]
+      (or (:target r) (:value r)))
+    (for [e (as-edge-list (:exposes node))]
+      (:value e))))
+
+(defn- ^{:stratum 1} escalated-scars
+  "Scars anchoring `problem` whose cost landed above the problem's own
+   horizon (§7.6.3) — the strongest confidence-lowering signal available."
+  [nodes problem]
+  (let [p-rank (get horizon-rank (:horizon problem))]
+    (when p-rank
+      (for [{:keys [value]} (:scars problem)
+            :let [scar (get nodes value)
+                  c-rank (get horizon-rank (:cost-horizon scar))]
+            :when (and c-rank (< c-rank p-rank))]
+        value))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} reachable-from
+  "Every node id reachable from `start` by walking routes-to + exposes."
+  [nodes start]
+  (loop [seen #{} frontier [start]]
+    (if-let [cur (peek frontier)]
+      (if (seen cur)
+        (recur seen (pop frontier))
+        (recur (conj seen cur)
+               (into (pop frontier)
+                     (when-let [n (get nodes cur)] (edge-targets n)))))
+      seen)))
+
+(defn ^{:stratum 2} landing-view
+  "The per-landing map a response carries for one problem or resolution."
+  [nodes problem]
+  (let [scars (for [{:keys [value]} (:scars problem)
+                    :let [s (get nodes value)]
+                    :when s]
+                {:id (:id s) :date (:date s) :cost (:cost s)
+                 :cost-horizon (:cost-horizon s) :origin (:origin s)})]
+    {:id (:id problem)
+     :type (:type problem)
+     :title (:title problem)
+     :horizon (:horizon problem)
+     :confidence (:confidence problem)
+     :open (mapv :value (:open problem))
+     :scars (vec scars)
+     :escalations (vec (escalated-scars nodes problem))}))

--- a/components/codex/src/ai/miniforge/codex/graph.clj
+++ b/components/codex/src/ai/miniforge/codex/graph.clj
@@ -44,7 +44,7 @@
   [nodes text]
   (let [situations (filter #(= "situation" (:type %)) (vals nodes))
         norm (str/lower-case (str/trim text))]
-    (or (seq (filter #(= (:id %) norm) situations))
+    (or (seq (filter #(= (str/lower-case (str (:id %))) norm) situations))
         (seq (filter #(or (str/includes? (str/lower-case (str (:id %))) norm)
                           (str/includes? (str/lower-case (str (:title %))) norm))
                      situations)))))

--- a/components/codex/src/ai/miniforge/codex/interface.clj
+++ b/components/codex/src/ai/miniforge/codex/interface.clj
@@ -1,0 +1,49 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.codex.interface
+  "Thesium Codex consumption surface (Codex SPEC T1 §7).
+
+   The codex stores what is dangerous, indexed by situation — not what is
+   true. `consider` routes a situation to the problems worth attending to
+   and returns them with a coverage statement, so a consumer's confidence
+   is lowered in a targeted way rather than raised.
+
+   Read-only by design: the codex is generated from data-as-source
+   elsewhere (SPEC §8.1); this component never writes it."
+  (:require [ai.miniforge.codex.core :as core]
+            [ai.miniforge.codex.node :as node]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} load-graph
+  "Read the codex node graph under `codex-dir`.
+   Returns {:nodes {id node}} or {:codex/anomaly ...} as data."
+  [codex-dir]
+  (node/load-graph codex-dir))
+
+(defn ^{:stratum 0} consider
+  "consider(situation) -> {landings, coverage}  (SPEC §7.1)
+
+   Landings are ordered strategic → operational → tactical (§7.6.1); the
+   coverage statement carries landing count, unanchored count, horizon mix
+   (including an explicit :no-strategic-coverage? flag, §7.6.2), and the
+   newest scar date (§7.5). Anomalies (unreadable codex, unmatched or
+   ambiguous situation) come back as {:codex/anomaly ...} data, never as an
+   empty success."
+  [codex-dir situation-text]
+  (core/consider codex-dir situation-text))

--- a/components/codex/src/ai/miniforge/codex/node.clj
+++ b/components/codex/src/ai/miniforge/codex/node.clj
@@ -1,0 +1,103 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.codex.node
+  "Codex node files -> node maps.
+
+   The codex is a directory of markdown nodes with structured frontmatter,
+   generated elsewhere (data-as-source, Codex SPEC T1 §8.1). This namespace
+   only parses and loads; it never writes. An unreadable codex is data
+   (:codex/anomaly), never an empty success."
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private frontmatter-re
+  ;; leading --- block; (?s) so .*? spans lines
+  #"(?s)\A---\n(.*?)\n---\n(.*)\z")
+
+(defn- ^{:stratum 0} title-of
+  "First `# ` heading in the body, or nil."
+  [body]
+  (some->> (str/split-lines body)
+           (some #(when (str/starts-with? % "# ") %))
+           (#(subs % 2))
+           str/trim))
+
+(defn- ^{:stratum 0} parse-list-item
+  "A frontmatter list item: `- value`, `- \"value\"`, or `- \"answer\": target`
+   (the quoted form is how routes-to entries are emitted)."
+  [line]
+  (let [v (str/trim (subs (str/triml line) 1))]
+    (if-let [[_ answer target] (re-matches #"^\"([^\"]*)\"\s*:\s*(.+)$" v)]
+      {:answer answer :target (str/trim target)}
+      {:value (str/replace v #"^\"|\"$" "")})))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} parse-frontmatter
+  "Parse the YAML-subset frontmatter the codex generators emit: top-level
+   `key: value` lines and two-space-indented `- item` lists. Returns
+   {:meta {...} :body \"...\"} or nil when the file has no frontmatter
+   (index files)."
+  [text]
+  (when-let [[_ fm body] (re-matches frontmatter-re text)]
+    (let [meta (reduce
+                 (fn [{:keys [meta current]} line]
+                   (cond
+                     (and current (str/starts-with? line "  - "))
+                     {:meta (update meta current (fnil conj []) (parse-list-item line))
+                      :current current}
+
+                     (and (not (str/starts-with? line " "))
+                          (str/includes? line ":"))
+                     (let [[k v] (str/split line #":" 2)
+                           k (keyword (str/trim k))
+                           v (str/trim v)]
+                       (cond
+                         ;; `key:` opens a list; following `  - ` lines append
+                         (str/blank? v) {:meta (assoc meta k []) :current k}
+                         ;; `key: []` is an inline empty list, not the string "[]"
+                         (= v "[]")     {:meta (assoc meta k []) :current nil}
+                         :else          {:meta (assoc meta k (str/replace v #"^\"|\"$" ""))
+                                         :current nil}))
+
+                     :else {:meta meta :current current}))
+                 {:meta {} :current nil}
+                 (str/split-lines fm))]
+      {:meta (:meta meta) :body body})))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} load-graph
+  "Read every node under `codex-dir`/nodes/**. Returns
+   {:nodes {id node-map}} or {:codex/anomaly :codex-unreadable ...}."
+  [codex-dir]
+  (let [nodes-dir (io/file codex-dir "nodes")]
+    (if-not (.isDirectory nodes-dir)
+      {:codex/anomaly :codex-unreadable
+       :codex/reason (str "no nodes/ directory under " codex-dir)}
+      {:nodes (into {}
+                    (comp (filter #(and (.isFile ^java.io.File %)
+                                        (str/ends-with? (.getName ^java.io.File %) ".md")))
+                          (keep (fn [f]
+                                  (let [{:keys [meta body]} (parse-frontmatter (slurp f))]
+                                    (when (:id meta)
+                                      (assoc meta :title (title-of body))))))
+                          (map (juxt :id identity)))
+                    (file-seq nodes-dir))})))

--- a/components/codex/src/ai/miniforge/codex/node.clj
+++ b/components/codex/src/ai/miniforge/codex/node.clj
@@ -86,18 +86,33 @@
 
 (defn ^{:stratum 2} load-graph
   "Read every node under `codex-dir`/nodes/**. Returns
-   {:nodes {id node-map}} or {:codex/anomaly :codex-unreadable ...}."
+   {:nodes {id node-map}} or {:codex/anomaly :codex-unreadable ...} —
+   including when a node file cannot be read mid-walk. IO failure is data
+   here, never a throw: an exception escaping this boundary would crash the
+   consumer instead of lowering its confidence."
   [codex-dir]
   (let [nodes-dir (io/file codex-dir "nodes")]
     (if-not (.isDirectory nodes-dir)
       {:codex/anomaly :codex-unreadable
        :codex/reason (str "no nodes/ directory under " codex-dir)}
-      {:nodes (into {}
-                    (comp (filter #(and (.isFile ^java.io.File %)
-                                        (str/ends-with? (.getName ^java.io.File %) ".md")))
-                          (keep (fn [f]
-                                  (let [{:keys [meta body]} (parse-frontmatter (slurp f))]
-                                    (when (:id meta)
-                                      (assoc meta :title (title-of body))))))
-                          (map (juxt :id identity)))
-                    (file-seq nodes-dir))})))
+      (try
+        {:nodes (into {}
+                      (comp (filter #(and (.isFile ^java.io.File %)
+                                          (str/ends-with? (.getName ^java.io.File %) ".md")))
+                            (keep (fn [f]
+                                    (let [{:keys [meta body]} (parse-frontmatter (slurp f))]
+                                      (when (:id meta)
+                                        (assoc meta :title (title-of body))))))
+                            (map (juxt :id identity)))
+                      (file-seq nodes-dir))}
+        ;; IOException + SecurityException, deliberately not Exception: these
+        ;; are the failures a filesystem walk can produce, and a blanket
+        ;; catch would also eat InterruptedException.
+        (catch java.io.IOException e
+          {:codex/anomaly :codex-unreadable
+           :codex/reason (str "failed reading a node under " nodes-dir ": "
+                              (ex-message e))})
+        (catch SecurityException e
+          {:codex/anomaly :codex-unreadable
+           :codex/reason (str "access denied under " nodes-dir ": "
+                              (ex-message e))})))))

--- a/components/codex/test-resources/codex-fixture/nodes/discriminators/already-failed-silently.md
+++ b/components/codex/test-resources/codex-fixture/nodes/discriminators/already-failed-silently.md
@@ -1,0 +1,29 @@
+---
+type: discriminator
+id: already-failed-silently
+peg: 3
+board: process-stuck-or-slow
+confidence: high
+origin: owned
+horizon: tactical
+routes-to:
+  - "yes": infra-vs-domain-failure
+  - "no": consuming-an-earlier-steps-output
+---
+----
+Status:: #discriminator
+Tags::[[Thesium Codex]] [[board]]
+
+----
+
+# Peg 3 · Did something already fail, but get reported as ordinary output?
+
+*A failure that is typed as content travels downstream unchallenged and surfaces as a stall far from its cause.*
+
+**Origin:: owned  ·  Horizon:: tactical**
+
+## Answers
+- **yes** → [[infra-vs-domain-failure]]
+  A timeout read as a finding, an error string read as a result. Fix the type at the boundary, not the symptom here.
+- **no** → [[consuming-an-earlier-steps-output]]
+  Nothing failed and nothing is moving — first suspect what the step was supposed to be reading.

--- a/components/codex/test-resources/codex-fixture/nodes/discriminators/consuming-an-earlier-steps-output.md
+++ b/components/codex/test-resources/codex-fixture/nodes/discriminators/consuming-an-earlier-steps-output.md
@@ -1,0 +1,30 @@
+---
+type: discriminator
+id: consuming-an-earlier-steps-output
+peg: 4
+board: process-stuck-or-slow
+confidence: high
+origin: owned
+support: 21
+horizon: tactical
+routes-to:
+  - "yes": contract-drift-is-silent
+  - "no": started-in-the-intended-environment
+---
+----
+Status:: #discriminator
+Tags::[[Thesium Codex]] [[board]]
+
+----
+
+# Peg 4 · Is the silent step consuming something an earlier step was supposed to produce?
+
+*A consumer reading a key its producer never writes gets nil, not an error — the feature no-ops forever, and from the outside a no-op loop is indistinguishable from a stall.*
+
+**Origin:: owned  ·  Horizon:: tactical**
+
+## Answers
+- **yes** → [[contract-drift-is-silent]]
+  Verify the read side against the producer's code before diagnosing anything else. The stall may be a contract mismatch wearing a stall's clothes.
+- **no** → [[started-in-the-intended-environment]]
+  It consumes nothing upstream — suspect the starting conditions.

--- a/components/codex/test-resources/codex-fixture/nodes/discriminators/is-there-progress-at-all.md
+++ b/components/codex/test-resources/codex-fixture/nodes/discriminators/is-there-progress-at-all.md
@@ -1,0 +1,29 @@
+---
+type: discriminator
+id: is-there-progress-at-all
+peg: 1
+board: process-stuck-or-slow
+confidence: high
+origin: owned
+horizon: tactical
+routes-to:
+  - "slow but moving": capacity-headroom
+  - "no progress": reports-activity-while-stuck
+---
+----
+Status:: #discriminator
+Tags::[[Thesium Codex]] [[board]]
+
+----
+
+# Peg 1 · Is there progress at all, or none?
+
+*Slow and stuck are different failures with different causes, and the instinct is to treat both as 'performance'.*
+
+**Origin:: owned  ·  Horizon:: tactical**
+
+## Answers
+- **slow but moving** → [[capacity-headroom]]
+  Something finite is binding. Find it before optimising anything.
+- **no progress** → [[reports-activity-while-stuck]]
+  Now the question is whether the process knows it is stuck.

--- a/components/codex/test-resources/codex-fixture/nodes/discriminators/reports-activity-while-stuck.md
+++ b/components/codex/test-resources/codex-fixture/nodes/discriminators/reports-activity-while-stuck.md
@@ -1,0 +1,29 @@
+---
+type: discriminator
+id: reports-activity-while-stuck
+peg: 2
+board: process-stuck-or-slow
+confidence: high
+origin: owned
+horizon: tactical
+routes-to:
+  - "yes": liveness-detection
+  - "no": already-failed-silently
+---
+----
+Status:: #discriminator
+Tags::[[Thesium Codex]] [[board]]
+
+----
+
+# Peg 2 · Is it reporting activity while making no progress?
+
+*This is where most stall diagnosis goes wrong: activity is read as health, and the monitoring agrees with the process rather than checking it.*
+
+**Origin:: owned  ·  Horizon:: tactical**
+
+## Answers
+- **yes** → [[liveness-detection]]
+  Heartbeats, spinners and keepalives are evidence the transport lives, not the work. Your liveness signal is measuring the wrong thing.
+- **no** → [[already-failed-silently]]
+  Silence could be death, or it could be a failure that was swallowed upstream.

--- a/components/codex/test-resources/codex-fixture/nodes/discriminators/started-in-the-intended-environment.md
+++ b/components/codex/test-resources/codex-fixture/nodes/discriminators/started-in-the-intended-environment.md
@@ -1,0 +1,29 @@
+---
+type: discriminator
+id: started-in-the-intended-environment
+peg: 5
+board: process-stuck-or-slow
+confidence: high
+origin: owned
+horizon: tactical
+routes-to:
+  - "no": environment-isolation
+  - "yes": liveness-detection
+---
+----
+Status:: #discriminator
+Tags::[[Thesium Codex]] [[board]]
+
+----
+
+# Peg 5 · Did the process start with the environment you intended?
+
+*Inheritance is invisible at the call site and its symptoms — exhaustion, overflow, mysterious slowness — appear nowhere near the cause.*
+
+**Origin:: owned  ·  Horizon:: tactical**
+
+## Answers
+- **no** → [[environment-isolation]]
+  It inherited more than you meant. Construct the child environment explicitly rather than filtering the parent's.
+- **yes** → [[liveness-detection]]
+  Then the problem is measurement: you cannot yet tell progress from activity, and that is the thing to fix first.

--- a/components/codex/test-resources/codex-fixture/nodes/problems/capacity-headroom.md
+++ b/components/codex/test-resources/codex-fixture/nodes/problems/capacity-headroom.md
@@ -1,0 +1,36 @@
+---
+type: problem
+id: capacity-headroom
+confidence: high
+horizon: operational
+exposes: []
+open: []
+scars:
+  - "vpc-ip-exhaustion-under-scale-test"
+---
+----
+Status:: #problem
+Tags::[[Thesium Codex]] [[problem]]
+
+----
+
+# The binding constraint is rarely the one with a dashboard
+
+**Horizon:: operational**
+
+## Forces in tension
+- capacity models cover the resources someone thought to measure
+- the unmeasured finite resource is invisible until it is exhausted
+- scale tests validate the model, not the reality outside it
+
+## Resolution
+Enumerate every finite resource in the request path, including those with no metric — addresses, file descriptors, connection-pool slots, quota ceilings. The ones without dashboards are the ones that will bind.
+
+## Exposes
+- nothing recorded yet
+
+## Still open
+- none recorded
+
+## Anchored by
+- [[vpc-ip-exhaustion-under-scale-test]]

--- a/components/codex/test-resources/codex-fixture/nodes/problems/chained-work-identity.md
+++ b/components/codex/test-resources/codex-fixture/nodes/problems/chained-work-identity.md
@@ -1,0 +1,37 @@
+---
+type: problem
+id: chained-work-identity
+confidence: high
+horizon: operational
+exposes: []
+open:
+  - "open design question: correct PR base for chained DAG tasks"
+scars:
+  - "stacked-pr-based-on-local-branch"
+---
+----
+Status:: #problem
+Tags::[[Thesium Codex]] [[problem]]
+
+----
+
+# Downstream steps can only reference what exists in the shared namespace
+
+**Horizon:: operational**
+
+## Forces in tension
+- local and shared identifiers are often textually identical
+- the producing step succeeds; only the consumer fails
+- failure lands far from the cause, usually in a later phase
+
+## Resolution
+Anything a later step will reference must be published before that step runs, and the reference must name the published thing. Resolve identity through the shared namespace even when a local one would work.
+
+## Exposes
+- nothing recorded yet
+
+## Still open
+- open design question: correct PR base for chained DAG tasks
+
+## Anchored by
+- [[stacked-pr-based-on-local-branch]]

--- a/components/codex/test-resources/codex-fixture/nodes/problems/contract-drift-is-silent.md
+++ b/components/codex/test-resources/codex-fixture/nodes/problems/contract-drift-is-silent.md
@@ -1,0 +1,39 @@
+---
+type: problem
+id: contract-drift-is-silent
+confidence: speculative
+horizon: operational
+origin: owned
+support: 31
+exposes:
+  - "chained-work-identity"
+open:
+  - "when producer and consumer live in different repos, the verification has no single place to live"
+scars: []
+---
+----
+Status:: #problem
+Tags::[[Thesium Codex]] [[problem]]
+
+----
+
+# Nothing enforces agreement between a producer and its consumers
+
+**Horizon:: operational**
+
+## Forces in tension
+- the consumer compiles against its assumption of the shape, not the producer's actual output
+- a mismatched read returns nil or a fallback, not an error — the feature no-ops forever and reads as working
+- specs and docs drift the same way code does, and direct implementers at keys that do not exist
+
+## Resolution
+Verify the read side against the producer's code — not your memory of it — every time either side changes. Prefer one shared definition of the boundary shape over two private ones, and make a failed lookup loud somewhere a human will see it.
+
+## Exposes
+- [[chained-work-identity]]
+
+## Still open
+- when producer and consumer live in different repos, the verification has no single place to live
+
+## Anchored by
+

--- a/components/codex/test-resources/codex-fixture/nodes/problems/environment-isolation.md
+++ b/components/codex/test-resources/codex-fixture/nodes/problems/environment-isolation.md
@@ -1,0 +1,36 @@
+---
+type: problem
+id: environment-isolation
+confidence: high
+horizon: tactical
+exposes: []
+open: []
+scars:
+  - "operator-env-leaked-into-subprocess"
+---
+----
+Status:: #problem
+Tags::[[Thesium Codex]] [[problem]]
+
+----
+
+# A subprocess inherits more than you intend
+
+**Horizon:: tactical**
+
+## Forces in tension
+- inheritance is the default and is invisible at the call site
+- the parent's environment grows over time; the child's assumptions do not
+- symptoms appear as resource exhaustion, far from the cause
+
+## Resolution
+Construct the child environment explicitly rather than filtering the parent's. Where the runtime offers strict or isolated config modes, use them by default and treat inheritance as the exception that must be justified.
+
+## Exposes
+- nothing recorded yet
+
+## Still open
+- none recorded
+
+## Anchored by
+- [[operator-env-leaked-into-subprocess]]

--- a/components/codex/test-resources/codex-fixture/nodes/problems/fail-closed-by-default.md
+++ b/components/codex/test-resources/codex-fixture/nodes/problems/fail-closed-by-default.md
@@ -1,0 +1,39 @@
+---
+type: problem
+id: fail-closed-by-default
+confidence: high
+horizon: operational
+exposes: []
+open:
+  - "fail-closed raises false-refusal cost; the tradeoff is real"
+scars:
+  - "fsm-swallowed-unknown-events"
+  - "autodev-governance-leak"
+---
+----
+Status:: #problem
+Tags::[[Thesium Codex]] [[problem]]
+
+----
+
+# Absence of a signal is not permission
+
+**Horizon:: operational**
+
+## Forces in tension
+- missing configuration, unknown events and empty results all look like 'nothing to do'
+- failing open is always the cheaper implementation and usually the default
+- the failure is invisible precisely because nothing happened
+
+## Resolution
+Every absence resolves to a deny with a reason code. Unknown inputs become typed anomalies rather than no-ops. 'No configuration found' is a decision the system announces, never a shrug it performs silently.
+
+## Exposes
+- nothing recorded yet
+
+## Still open
+- fail-closed raises false-refusal cost; the tradeoff is real
+
+## Anchored by
+- [[fsm-swallowed-unknown-events]]
+- [[autodev-governance-leak]]

--- a/components/codex/test-resources/codex-fixture/nodes/problems/infra-vs-domain-failure.md
+++ b/components/codex/test-resources/codex-fixture/nodes/problems/infra-vs-domain-failure.md
@@ -1,0 +1,37 @@
+---
+type: problem
+id: infra-vs-domain-failure
+confidence: high
+horizon: operational
+exposes:
+  - "fail-closed-by-default"
+open: []
+scars:
+  - "stream-idle-text-became-a-verdict"
+---
+----
+Status:: #problem
+Tags::[[Thesium Codex]] [[problem]]
+
+----
+
+# Infrastructure failure must never present as domain output
+
+**Horizon:: operational**
+
+## Forces in tension
+- both arrive on the same channel as text
+- downstream consumers cannot tell a timeout message from a finding
+- the failure is silent: it looks like the system worked and found problems
+
+## Resolution
+Normalise at the boundary where the failure occurs. Give infra failures a closed taxonomy of their own and a distinct type, so a timeout can never be read as a verdict no matter how far downstream it travels.
+
+## Exposes
+- [[fail-closed-by-default]]
+
+## Still open
+- none recorded
+
+## Anchored by
+- [[stream-idle-text-became-a-verdict]]

--- a/components/codex/test-resources/codex-fixture/nodes/problems/liveness-detection.md
+++ b/components/codex/test-resources/codex-fixture/nodes/problems/liveness-detection.md
@@ -1,0 +1,39 @@
+---
+type: problem
+id: liveness-detection
+confidence: high
+horizon: operational
+exposes: []
+open:
+  - "progress is domain-specific; there is no universal signal"
+scars:
+  - "watchdog-timeout-incoherence"
+  - "keepalive-masked-stagnation"
+---
+----
+Status:: #problem
+Tags::[[Thesium Codex]] [[problem]]
+
+----
+
+# Liveness cannot be inferred from activity
+
+**Horizon:: operational**
+
+## Forces in tension
+- bytes on a stream prove the transport is alive, not that work is progressing
+- a wall-clock timeout kills slow-but-healthy work; no timeout hangs forever
+- every watcher you add is another thing that can kill healthy work
+
+## Resolution
+Measure substantive progress — streamed content plus filesystem writes — not the presence of traffic. Record keepalives explicitly as non-substantive. Where two watchers observe one signal, declare their ordering as an invariant in the source, not in someone's head.
+
+## Exposes
+- nothing recorded yet
+
+## Still open
+- progress is domain-specific; there is no universal signal
+
+## Anchored by
+- [[watchdog-timeout-incoherence]]
+- [[keepalive-masked-stagnation]]

--- a/components/codex/test-resources/codex-fixture/nodes/scars/autodev-governance-leak.md
+++ b/components/codex/test-resources/codex-fixture/nodes/scars/autodev-governance-leak.md
@@ -1,0 +1,34 @@
+---
+type: scar
+id: autodev-governance-leak
+date: 2026
+cost: "unauthorised PR reached a repo"
+cost-horizon: strategic
+domain: Agent authority
+confidence: high
+origin: owned
+anchors:
+  - authority-outside-the-model
+  - fail-closed-by-default
+evidence:
+  - "ws/mvp-ramp/SYSTEM_BRIEFS.md (war story 2)"
+---
+----
+Status:: #scar
+Tags::[[Thesium Codex]] [[scar]] [[Agent authority]]
+
+----
+
+# Fail-open config let an agent act on a repo it was not enabled for
+
+**Cost:: unauthorised PR reached a repo  ·  2026  ·  Origin:: owned  ·  Cost-horizon:: strategic**
+
+## What happened
+An agent fixed a bug in a repository where it had not been enabled. The meta-agent caught it, but the PR had already gone out. Root cause was a configuration default that failed open when enablement was absent.
+
+## What it changed
+Absence of a grant is not permission. Every enablement check defaults to deny, and 'no configuration found' is a deny with a reason code, not a shrug.
+
+## Anchors
+- [[authority-outside-the-model]]
+- [[fail-closed-by-default]]

--- a/components/codex/test-resources/codex-fixture/nodes/scars/fsm-swallowed-unknown-events.md
+++ b/components/codex/test-resources/codex-fixture/nodes/scars/fsm-swallowed-unknown-events.md
@@ -1,0 +1,32 @@
+---
+type: scar
+id: fsm-swallowed-unknown-events
+date: 2026-06
+cost: "silent misrouting"
+cost-horizon: operational
+domain: Workflow engine
+confidence: high
+origin: owned
+anchors:
+  - fail-closed-by-default
+evidence:
+  - "code: components/fsm/src/ai/miniforge/fsm/core.clj:94,173,305 (:anomalies/fsm-unknown-event)"
+---
+----
+Status:: #scar
+Tags::[[Thesium Codex]] [[scar]] [[Workflow engine]]
+
+----
+
+# The state machine ignored events it did not recognise
+
+**Cost:: silent misrouting  ·  2026-06  ·  Origin:: owned  ·  Cost-horizon:: operational**
+
+## What happened
+clj-statecharts silently dropped state-local unknown events. Transitions that should have been impossible simply did not happen, and nothing reported it.
+
+## What it changed
+Silent downgrade is the disease. An unknown input is a typed anomaly, never a no-op — the cheapest possible failure is the one that says so.
+
+## Anchors
+- [[fail-closed-by-default]]

--- a/components/codex/test-resources/codex-fixture/nodes/scars/keepalive-masked-stagnation.md
+++ b/components/codex/test-resources/codex-fixture/nodes/scars/keepalive-masked-stagnation.md
@@ -1,0 +1,32 @@
+---
+type: scar
+id: keepalive-masked-stagnation
+date: 2026-06
+cost: "false stagnation kills"
+cost-horizon: operational
+domain: Agent runtime
+confidence: high
+origin: owned
+anchors:
+  - liveness-detection
+evidence:
+  - "code: components/llm/src/ai/miniforge/llm/progress_monitor.clj:48,141"
+---
+----
+Status:: #scar
+Tags::[[Thesium Codex]] [[scar]] [[Agent runtime]]
+
+----
+
+# Heartbeats counted as progress
+
+**Cost:: false stagnation kills  ·  2026-06  ·  Origin:: owned  ·  Cost-horizon:: operational**
+
+## What happened
+Stagnation detection treated any stream activity as progress, so spinner and keepalive blips reset the clock. Real stalls went undetected; the recorded incident reads 'Stagnation timeout: no progress for 180047ms'.
+
+## What it changed
+Liveness must be measured on substantive progress — streamed content plus filesystem writes — not on the presence of bytes. A keepalive is evidence the transport is alive, not that the work is.
+
+## Anchors
+- [[liveness-detection]]

--- a/components/codex/test-resources/codex-fixture/nodes/scars/operator-env-leaked-into-subprocess.md
+++ b/components/codex/test-resources/codex-fixture/nodes/scars/operator-env-leaked-into-subprocess.md
@@ -1,0 +1,32 @@
+---
+type: scar
+id: operator-env-leaked-into-subprocess
+date: 2026-06-07
+cost: "200k context overflow"
+cost-horizon: tactical
+domain: Agent runtime
+confidence: high
+origin: owned
+anchors:
+  - environment-isolation
+evidence:
+  - "memory: project_dogfood_findings_2026_06_07"
+---
+----
+Status:: #scar
+Tags::[[Thesium Codex]] [[scar]] [[Agent runtime]]
+
+----
+
+# The planner inherited the operator's whole environment
+
+**Cost:: 200k context overflow  ·  2026-06-07  ·  Origin:: owned  ·  Cost-horizon:: tactical**
+
+## What happened
+The planner's subprocess inherited the operator's MCP and config environment, dragging in enough context to overflow a 200k window before the planner had done anything.
+
+## What it changed
+A subprocess inherits more than you intend by default. Isolate explicitly (--strict-mcp-config, CLAUDE_CONFIG_DIR) rather than assuming a clean room.
+
+## Anchors
+- [[environment-isolation]]

--- a/components/codex/test-resources/codex-fixture/nodes/scars/stacked-pr-based-on-local-branch.md
+++ b/components/codex/test-resources/codex-fixture/nodes/scars/stacked-pr-based-on-local-branch.md
@@ -1,0 +1,33 @@
+---
+type: scar
+id: stacked-pr-based-on-local-branch
+date: 2026-06
+cost: "hard-killed release phase"
+cost-horizon: operational
+domain: PR automation
+confidence: high
+origin: owned
+anchors:
+  - chained-work-identity
+evidence:
+  - "PR #1102"
+  - "open design question: DAG task PR base convention"
+---
+----
+Status:: #scar
+Tags::[[Thesium Codex]] [[scar]] [[PR automation]]
+
+----
+
+# A dependent PR was based on a branch that existed only locally
+
+**Cost:: hard-killed release phase  ·  2026-06  ·  Origin:: owned  ·  Cost-horizon:: operational**
+
+## What happened
+Dependent DAG tasks opened PRs against the parent task's LOCAL branch rather than the pushed PR branch. The fetch failed and took the release phase down with it.
+
+## What it changed
+Anything a downstream step references must exist in the shared namespace, not the local one. 'It works on the machine that made it' is a class of bug, not an excuse.
+
+## Anchors
+- [[chained-work-identity]]

--- a/components/codex/test-resources/codex-fixture/nodes/scars/stream-idle-text-became-a-verdict.md
+++ b/components/codex/test-resources/codex-fixture/nodes/scars/stream-idle-text-became-a-verdict.md
@@ -1,0 +1,32 @@
+---
+type: scar
+id: stream-idle-text-became-a-verdict
+date: 2026-06-05
+cost: "failed gate on healthy work"
+cost-horizon: operational
+domain: Agent runtime
+confidence: high
+origin: owned
+anchors:
+  - infra-vs-domain-failure
+evidence:
+  - "code: components/agent/src/ai/miniforge/agent/result_boundary.clj:82-111 (canonical taxonomy :stream-idle / :stagnation / :hard-limit)"
+---
+----
+Status:: #scar
+Tags::[[Thesium Codex]] [[scar]] [[Agent runtime]]
+
+----
+
+# A timeout message was read as review content
+
+**Cost:: failed gate on healthy work  ·  2026-06-05  ·  Origin:: owned  ·  Cost-horizon:: operational**
+
+## What happened
+The reviewer LLM stream-idled at 360s. The timeout's text was promoted into :review/blocking-issues and failed the gate as though the reviewer had found real problems with the change.
+
+## What it changed
+Infrastructure failures must be normalised at the boundary where they occur, or they masquerade as domain output downstream. A failure and a finding are different types and must not share a channel.
+
+## Anchors
+- [[infra-vs-domain-failure]]

--- a/components/codex/test-resources/codex-fixture/nodes/scars/vpc-ip-exhaustion-under-scale-test.md
+++ b/components/codex/test-resources/codex-fixture/nodes/scars/vpc-ip-exhaustion-under-scale-test.md
@@ -1,0 +1,32 @@
+---
+type: scar
+id: vpc-ip-exhaustion-under-scale-test
+date: 2025
+cost: "cluster module redesign"
+cost-horizon: operational
+domain: Infrastructure
+confidence: high
+origin: owned
+anchors:
+  - capacity-headroom
+evidence:
+  - "career-history/2025_portfolio_review.md (Project 1)"
+---
+----
+Status:: #scar
+Tags::[[Thesium Codex]] [[scar]] [[Infrastructure]]
+
+----
+
+# The scale test ran out of addresses, not compute
+
+**Cost:: cluster module redesign  ·  2025  ·  Origin:: owned  ·  Cost-horizon:: operational**
+
+## What happened
+A Hermes scale-up test exhausted the VPC's IP space. The binding constraint was addressing, which no capacity model had accounted for, and the fix was a redesign of the cluster module.
+
+## What it changed
+Scale limits are rarely where the dashboard points. Enumerate every finite resource in the path, including the ones with no metric.
+
+## Anchors
+- [[capacity-headroom]]

--- a/components/codex/test-resources/codex-fixture/nodes/scars/watchdog-timeout-incoherence.md
+++ b/components/codex/test-resources/codex-fixture/nodes/scars/watchdog-timeout-incoherence.md
@@ -1,0 +1,35 @@
+---
+type: scar
+id: watchdog-timeout-incoherence
+date: 2026-05
+cost: "~17 hours"
+cost-horizon: operational
+domain: Agent runtime
+confidence: high
+origin: owned
+anchors:
+  - liveness-detection
+  - revocation-at-commit
+evidence:
+  - "code: components/agent/src/ai/miniforge/agent/stream_watchdog.clj:49-67 (the invariant is now written into the source: watchdog 480s >= client idle 420s + 60s margin)"
+  - "PRs #988, #989"
+---
+----
+Status:: #scar
+Tags::[[Thesium Codex]] [[scar]] [[Agent runtime]]
+
+----
+
+# Two watchers of one stream with unordered timeouts
+
+**Cost:: ~17 hours  ·  2026-05  ·  Origin:: owned  ·  Cost-horizon:: operational**
+
+## What happened
+A recurring 'stall' during retries. Every diagnosis pointed at locking. The actual cause was that the stream watchdog and the LLM client's stream-line timeout both watched the same stdout, with no ordering between them — the backstop was firing on healthy work.
+
+## What it changed
+A recurring stall is a timeout-coherence question before it is a locking question. Any two watchers of one signal need a declared ordering, or the outer one becomes a random killer.
+
+## Anchors
+- [[liveness-detection]]
+- [[revocation-at-commit]]

--- a/components/codex/test-resources/codex-fixture/nodes/situations/process-stuck-or-slow.md
+++ b/components/codex/test-resources/codex-fixture/nodes/situations/process-stuck-or-slow.md
@@ -1,0 +1,18 @@
+---
+type: situation
+id: process-stuck-or-slow
+confidence: high
+routes-to: is-there-progress-at-all
+---
+----
+Status:: #situation
+Tags::[[Thesium Codex]] [[board]]
+
+----
+
+# A long-running process is stuck or slow
+
+Enter here when something that should have finished has not, and you do not yet know whether it is dead, throttled, lying, or merely slower than you assumed. The first job is to stop guessing which.
+
+## Enter the board
+→ [[is-there-progress-at-all]]

--- a/components/codex/test/ai/miniforge/codex/interface_test.clj
+++ b/components/codex/test/ai/miniforge/codex/interface_test.clj
@@ -1,0 +1,96 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.codex.interface-test
+  "Fixtures are VERBATIM copies of files produced by the codex generators
+   (build-board-stuck-or-slow.py and friends) — the real producer's output
+   shape, never hand-invented. If the generators change their emit format,
+   refresh the fixture files from a regenerated codex rather than editing
+   them here."
+  (:require [ai.miniforge.codex.interface :as codex]
+            [clojure.java.io :as io]
+            [clojure.test :refer [deftest is testing]]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} fixture-dir
+  (-> (io/resource "codex-fixture/nodes") io/file .getParentFile .getPath))
+
+(deftest ^{:stratum 0} load-graph-anomaly-on-missing-dir
+  (let [graph (codex/load-graph "/nonexistent/codex/path")]
+    (is (= :codex-unreadable (:codex/anomaly graph)))))
+
+(def ^{:stratum 0} codex-horizon-rank {"strategic" 0 "operational" 1 "tactical" 2})
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} load-graph-reads-generated-nodes
+  (let [{:keys [nodes] :as graph} (codex/load-graph fixture-dir)]
+    (is (nil? (:codex/anomaly graph)))
+    (is (= 21 (count nodes)))
+    (testing "frontmatter fields survive parsing"
+      (let [peg (get nodes "consuming-an-earlier-steps-output")]
+        (is (= "discriminator" (:type peg)))
+        (is (= "owned" (:origin peg)))
+        (is (= "21" (:support peg)))
+        (is (= "tactical" (:horizon peg)))
+        (is (= [{:answer "yes" :target "contract-drift-is-silent"}
+                {:answer "no" :target "started-in-the-intended-environment"}]
+               (:routes-to peg)))))))
+
+(deftest ^{:stratum 1} consider-routes-a-situation-to-landings
+  (let [{:keys [situation landings coverage] :as resp}
+        (codex/consider fixture-dir "process-stuck-or-slow")]
+    (is (nil? (:codex/anomaly resp)))
+    (is (= "process-stuck-or-slow" situation))
+    (testing "every problem on the board's playable paths lands"
+      (is (= #{"capacity-headroom" "liveness-detection" "infra-vs-domain-failure"
+               "environment-isolation" "contract-drift-is-silent"
+               "chained-work-identity" "fail-closed-by-default"}
+             (set (map :id landings)))))
+    (testing "coverage statement is present and honest (SPEC §7.5, §7.6.2)"
+      (is (= 7 (:landing-count coverage)))
+      (is (= 1 (:unanchored-count coverage)))   ; contract-drift-is-silent
+      (is (true? (:no-strategic-coverage? coverage)))
+      (is (= {"operational" 6 "tactical" 1} (:horizon-mix coverage)))
+      (is (= "2026-06-07" (:newest-scar-date coverage))))))
+
+(deftest ^{:stratum 1} landings-are-horizon-ordered
+  (let [{:keys [landings]} (codex/consider fixture-dir "process-stuck-or-slow")
+        ranks (mapv #(get codex-horizon-rank (:horizon %)) landings)]
+    (is (= ranks (vec (sort ranks)))
+        "strategic → operational → tactical, §7.6.1")))
+
+(deftest ^{:stratum 1} escalations-are-flagged
+  (let [{:keys [landings]} (codex/consider fixture-dir "process-stuck-or-slow")
+        fail-closed (first (filter #(= "fail-closed-by-default" (:id %)) landings))]
+    (testing "operational problem with a strategic-cost scar (§7.6.3)"
+      (is (= ["autodev-governance-leak"] (:escalations fail-closed))))))
+
+(deftest ^{:stratum 1} substring-matches-a-situation
+  (let [resp (codex/consider fixture-dir "stuck")]
+    (is (= "process-stuck-or-slow" (:situation resp)))))
+
+(deftest ^{:stratum 1} unmatched-situation-is-an-answer-not-an-empty-list
+  (let [resp (codex/consider fixture-dir "planning a birthday party")]
+    (is (= :situation-unmatched (:codex/anomaly resp)))
+    (is (= [["process-stuck-or-slow" "A long-running process is stuck or slow"]]
+           (:codex/available resp)))))
+
+(deftest ^{:stratum 1} blank-situation-is-a-programmer-error
+  (is (thrown? IllegalArgumentException
+               (codex/consider fixture-dir "  "))))

--- a/components/codex/test/ai/miniforge/codex/interface_test.clj
+++ b/components/codex/test/ai/miniforge/codex/interface_test.clj
@@ -85,6 +85,10 @@
   (let [resp (codex/consider fixture-dir "stuck")]
     (is (= "process-stuck-or-slow" (:situation resp)))))
 
+(deftest ^{:stratum 1} exact-id-match-is-case-insensitive
+  (let [resp (codex/consider fixture-dir "Process-Stuck-Or-Slow")]
+    (is (= "process-stuck-or-slow" (:situation resp)))))
+
 (deftest ^{:stratum 1} unmatched-situation-is-an-answer-not-an-empty-list
   (let [resp (codex/consider fixture-dir "planning a birthday party")]
     (is (= :situation-unmatched (:codex/anomaly resp)))

--- a/deps.edn
+++ b/deps.edn
@@ -28,6 +28,7 @@
                        "components/progress-detector/src"
                        "components/progress-detector/resources"
                        "components/clock/src"
+                       "components/codex/src"
                        "components/coerce/src"
                        "components/response-chain/src"
                        "components/boundary/src"
@@ -222,6 +223,7 @@
                       ai.miniforge/anomaly {:local/root "components/anomaly"}
                       ai.miniforge/progress-detector {:local/root "components/progress-detector"}
                       ai.miniforge/clock {:local/root "components/clock"}
+                      ai.miniforge/codex {:local/root "components/codex"}
                       ai.miniforge/coerce {:local/root "components/coerce"}
                       ai.miniforge/response-chain {:local/root "components/response-chain"}
                       ai.miniforge/boundary {:local/root "components/boundary"}
@@ -348,6 +350,8 @@
                        "components/anomaly/test"
                        "components/progress-detector/test"
                        "components/clock/test"
+                       "components/codex/test"
+                       "components/codex/test-resources"
                        "components/coerce/test"
                        "components/response-chain/test"
                        "components/boundary/test"
@@ -483,6 +487,7 @@
                       ai.miniforge/anomaly {:local/root "components/anomaly"}
                       ai.miniforge/progress-detector {:local/root "components/progress-detector"}
                       ai.miniforge/clock {:local/root "components/clock"}
+                      ai.miniforge/codex {:local/root "components/codex"}
                       ai.miniforge/coerce {:local/root "components/coerce"}
                       ai.miniforge/response-chain {:local/root "components/response-chain"}
                       ai.miniforge/boundary {:local/root "components/boundary"}

--- a/projects/miniforge-core/deps.edn
+++ b/projects/miniforge-core/deps.edn
@@ -14,6 +14,7 @@
         ai.miniforge/algorithms {:local/root "../../components/algorithms"}
         ai.miniforge/anomaly {:local/root "../../components/anomaly"}
         ai.miniforge/clock {:local/root "../../components/clock"}
+        ai.miniforge/codex {:local/root "../../components/codex"}
         ai.miniforge/coerce {:local/root "../../components/coerce"}
         ai.miniforge/content-hash {:local/root "../../components/content-hash"}
         ai.miniforge/logging {:local/root "../../components/logging"}

--- a/projects/miniforge-tui/deps.edn
+++ b/projects/miniforge-tui/deps.edn
@@ -18,6 +18,7 @@
         ai.miniforge/algorithms {:local/root "../../components/algorithms"}
         ai.miniforge/anomaly {:local/root "../../components/anomaly"}
         ai.miniforge/clock {:local/root "../../components/clock"}
+        ai.miniforge/codex {:local/root "../../components/codex"}
         ai.miniforge/coerce {:local/root "../../components/coerce"}
         ai.miniforge/content-hash {:local/root "../../components/content-hash"}
         ai.miniforge/logging {:local/root "../../components/logging"}

--- a/projects/miniforge/deps.edn
+++ b/projects/miniforge/deps.edn
@@ -21,6 +21,7 @@
         ai.miniforge/algorithms {:local/root "../../components/algorithms"}
         ai.miniforge/anomaly {:local/root "../../components/anomaly"}
         ai.miniforge/clock {:local/root "../../components/clock"}
+        ai.miniforge/codex {:local/root "../../components/codex"}
         ai.miniforge/coerce {:local/root "../../components/coerce"}
         ai.miniforge/content-hash {:local/root "../../components/content-hash"}
         ai.miniforge/logging {:local/root "../../components/logging"}

--- a/tasks/fmt.clj
+++ b/tasks/fmt.clj
@@ -15,107 +15,43 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns fmt
   (:require
    [babashka.process :as p]
-   [clojure.string :as str]))
+   [clojure.string :as str]
+   [fmt-wrap]))
 
-(defn staged-files []
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} staged-files []
   (-> (p/sh "git" "diff" "--cached" "--name-only" "--diff-filter=ACM")
       :out
       str/split-lines
       (->> (remove str/blank?))))
 
-(defn staged-by-ext [ext]
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} staged-by-ext [ext]
   (->> (staged-files)
        (filter (fn [f] (str/ends-with? f ext)))))
 
-(defn- in-block?
-  "Track whether we're inside a fenced code block."
-  [line state]
-  (if (str/starts-with? (str/trim line) "```")
-    (not state)
-    state))
+;------------------------------------------------------------------------------ Layer 2
 
-(defn- wrap-prose-line
-  "Wrap a single prose line at `max-col`, preserving leading indent.
-   Only wraps at word boundaries. Returns a vector of lines."
-  [line max-col]
-  (let [indent (re-find #"^\s*" line)
-        prefix (if (re-find #"^\s*[-*+\d]" line)
-                 (str indent "  ")
-                 indent)]
-    (if (<= (count line) max-col)
-      [line]
-      (loop [remaining (str/trim line)
-             result []]
-        (if (<= (count (str indent remaining)) max-col)
-          (let [full (if (seq result)
-                       (str prefix remaining)
-                       (str indent remaining))]
-            (conj result full))
-          (let [target (- max-col (count (if (seq result) prefix indent)))
-                cut (or (str/last-index-of remaining " " target) target)
-                before (subs remaining 0 cut)
-                after (str/trim (subs remaining cut))
-                full (if (seq result)
-                       (str prefix before)
-                       (str indent before))]
-            (if (str/blank? after)
-              (conj result full)
-              (recur after (conj result full)))))))))
-
-(defn wrap-md-lines
-  "Wrap long prose lines in a markdown string. Skips code blocks,
-   headings, tables, and HTML. Uses 120-char limit to match .markdownlint.jsonc."
-  [content]
-  (let [max-col 120
-        ends-newline? (str/ends-with? content "\n")
-        lines (str/split-lines content)]
-    (loop [remaining lines
-           code-block? false
-           out []]
-      (if (empty? remaining)
-        (cond-> (str/join "\n" out) ends-newline? (str "\n"))
-        (let [line (first remaining)
-              trimmed (str/trim line)
-              new-block? (in-block? line code-block?)
-              skip? (or code-block?
-                        new-block?
-                        (str/starts-with? trimmed "#")
-                        (str/starts-with? trimmed "|")
-                        (str/starts-with? trimmed "<")
-                        (str/starts-with? trimmed "[")
-                        (re-find #"^\s*```" trimmed)
-                        ;; No whitespace past the limit → unbreakable (e.g. a
-                        ;; long `**File:** [text](url)` link). markdownlint
-                        ;; MD013 exempts these; wrapping them only mangles the
-                        ;; line. Mirror that exemption rather than force-break.
-                        (and (> (count line) max-col)
-                             (not (re-find #"\s" (subs line max-col)))))]
-          (if (or skip? (<= (count line) max-col))
-            (recur (rest remaining) new-block? (conj out line))
-            (recur (rest remaining) new-block?
-                   (into out (wrap-prose-line line max-col)))))))))
-
-(defn wrap-md-file!
-  "Wrap long lines in a markdown file in-place."
-  [path]
-  (let [content (slurp path)
-        wrapped (wrap-md-lines content)]
-    (when (not= content wrapped)
-      (spit path wrapped)
-      true)))
-
-(defn md-staged []
-  (let [md-files (staged-by-ext ".md")]
+(defn ^{:stratum 2} md-staged []
+  (let [md-files (->> (staged-by-ext ".md")
+                      ;; Markdown under test-resources/ or fixtures/ is DATA —
+                      ;; verbatim copies of a generator's output that tests
+                      ;; parse. Wrapping it breaks the verbatim property and
+                      ;; can split a frontmatter value across lines, corrupting
+                      ;; what the fixture exists to pin. Prose formatting is
+                      ;; for prose.
+                      (remove #(re-find #"(?i)(^|/)(test-resources|fixtures?)/" %)))]
     (if (seq md-files)
       (do
         (println "📝 Formatting" (count md-files) "Markdown file(s)...")
         ;; Wrap long prose lines before linting
         (doseq [f md-files]
-          (when (wrap-md-file! f)
+          (when (fmt-wrap/wrap-md-file! f)
             (println "  ↳ wrapped long lines in" f)))
         (let [{:keys [exit]} (apply p/sh "markdownlint" "--fix" md-files)]
           (when-not (zero? exit)

--- a/tasks/fmt_wrap.clj
+++ b/tasks/fmt_wrap.clj
@@ -1,0 +1,105 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns fmt-wrap
+  "Markdown prose-wrapping helpers for the fmt task. Split from `fmt` so
+   each namespace stays within the stratified-design layer budget."
+  (:require
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} in-block?
+  "Track whether we're inside a fenced code block."
+  [line state]
+  (if (str/starts-with? (str/trim line) "```")
+    (not state)
+    state))
+
+(defn- ^{:stratum 0} wrap-prose-line
+  "Wrap a single prose line at `max-col`, preserving leading indent.
+   Only wraps at word boundaries. Returns a vector of lines."
+  [line max-col]
+  (let [indent (re-find #"^\s*" line)
+        prefix (if (re-find #"^\s*[-*+\d]" line)
+                 (str indent "  ")
+                 indent)]
+    (if (<= (count line) max-col)
+      [line]
+      (loop [remaining (str/trim line)
+             result []]
+        (if (<= (count (str indent remaining)) max-col)
+          (let [full (if (seq result)
+                       (str prefix remaining)
+                       (str indent remaining))]
+            (conj result full))
+          (let [target (- max-col (count (if (seq result) prefix indent)))
+                cut (or (str/last-index-of remaining " " target) target)
+                before (subs remaining 0 cut)
+                after (str/trim (subs remaining cut))
+                full (if (seq result)
+                       (str prefix before)
+                       (str indent before))]
+            (if (str/blank? after)
+              (conj result full)
+              (recur after (conj result full)))))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} wrap-md-lines
+  "Wrap long prose lines in a markdown string. Skips code blocks,
+   headings, tables, and HTML. Uses 120-char limit to match .markdownlint.jsonc."
+  [content]
+  (let [max-col 120
+        ends-newline? (str/ends-with? content "\n")
+        lines (str/split-lines content)]
+    (loop [remaining lines
+           code-block? false
+           out []]
+      (if (empty? remaining)
+        (cond-> (str/join "\n" out) ends-newline? (str "\n"))
+        (let [line (first remaining)
+              trimmed (str/trim line)
+              new-block? (in-block? line code-block?)
+              skip? (or code-block?
+                        new-block?
+                        (str/starts-with? trimmed "#")
+                        (str/starts-with? trimmed "|")
+                        (str/starts-with? trimmed "<")
+                        (str/starts-with? trimmed "[")
+                        (re-find #"^\s*```" trimmed)
+                        ;; No whitespace past the limit → unbreakable (e.g. a
+                        ;; long `**File:** [text](url)` link). markdownlint
+                        ;; MD013 exempts these; wrapping them only mangles the
+                        ;; line. Mirror that exemption rather than force-break.
+                        (and (> (count line) max-col)
+                             (not (re-find #"\s" (subs line max-col)))))]
+          (if (or skip? (<= (count line) max-col))
+            (recur (rest remaining) new-block? (conj out line))
+            (recur (rest remaining) new-block?
+                   (into out (wrap-prose-line line max-col)))))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} wrap-md-file!
+  "Wrap long lines in a markdown file in-place."
+  [path]
+  (let [content (slurp path)
+        wrapped (wrap-md-lines content)]
+    (when (not= content wrapped)
+      (spit path wrapped)
+      true)))


### PR DESCRIPTION
## What

The consumption surface for the Thesium Codex (Codex SPEC T1 §7): a situation goes in, the problems worth attending to come out, each anchored to a failure that actually happened.

1. **components/codex** — reads the generated codex node graph (markdown + frontmatter, data-as-source per SPEC §8.1), walks `routes-to`/`exposes` edges from a matched situation, and returns landings with a coverage statement. Split into `node` (parse/load), `graph` (walk/views), `core` (`consider`) per the stratified-design layer budget.
2. **consider_situation MCP tool** on `mcp-context-server` — renders per spec: landings ordered strategic → operational → tactical (§7.6.1); an explicit NO STRATEGIC COVERAGE statement when every landing is tactical/operational (§7.6.2); horizon escalations (a scar whose cost landed above its problem's horizon) flagged inline (§7.6.3). Codex location: `codex_path` arg or `MINIFORGE_CODEX_PATH`.
3. Fail-closed throughout: unreadable codex, unconfigured path, unmatched or ambiguous situation are `:codex/anomaly` data with a reason — never an empty success, because an empty answer that looks clean is the exact failure the codex exists to prevent (§1.2).

## Collateral

1. `server.clj`'s JSON-RPC dispatch moved verbatim to a new `rpc` namespace (SL003 layer budget; the file was at 6 layers before this PR touched it).
2. `tasks/fmt.clj` now skips markdown under `test-resources/` and `fixtures/` — prose wrapping was splitting fixture frontmatter values across lines, corrupting the data the fixtures pin. Wrap helpers moved to `fmt-wrap` (same layer budget).

## Tests

`poly check` clean; codex brick 8 tests / 22 assertions; base 53 tests / 142 assertions incl. pre-existing; end-to-end smoke under Babashka against the live codex verified strategic-first ordering, escalation flags, and the no-strategic-coverage statement.

Fixtures are verbatim copies of the codex generators' output (fixtures-match-production-shape).

MINIFORGE_PR_BUDGET_OVERRIDE: ~560 of the reportable lines are verbatim generator-produced fixture files under test-resources/codex-fixture, and ~80 more are the verbatim rpc relocation; new logic is well under budget. A follow-up task extends the budget's exclusion patterns to cover generated fixture data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)