### PR TITLE
fix(ci): alert when CI fails on a push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ name: CI
 # would otherwise needlessly re-trigger the expensive jobs below.
 # All output is captured in log files and uploaded as artifacts for debugging.
 # Logs are retained for 7 days and can be downloaded from the Actions UI.
+#
+# A failed push run on main additionally opens (or updates) a `ci-main-red`
+# tracking issue -- see the `main-status` job at the bottom of this file, and
+# docs/development/ci-debugging.md.
 
 on:
   push:
@@ -375,3 +379,113 @@ jobs:
           name: miniforge-cli-${{ github.sha }}
           path: dist/miniforge.jar
           retention-days: 7
+
+  # Alerting for a red `main`. Until this existed, a failing push run
+  # produced no signal at all: the Test job was red across six consecutive
+  # merges (runs 30734048427 through 30735684110), for two independent
+  # reasons, and the second went unnoticed until someone looked by hand.
+  #
+  # The channel is a GitHub issue because there is no chat webhook secret on
+  # this repo or the org -- only the CI-bot app credentials. Repo watchers
+  # already get notified on issue creation, and the push author is mentioned
+  # in the body.
+  #
+  # No checkout and no toolchain setup, deliberately: the alerter has to
+  # survive the failure it reports. A bb- or Clojure-based alerter would be
+  # taken out by exactly the deps/toolchain breakage it exists to announce.
+  # `gh` is preinstalled on GitHub-hosted runners.
+  main-status:
+    name: Alert on main status
+    runs-on: ubuntu-latest
+    needs: [structure, lint, test, test-windows, build]
+    # Push-to-main only: PR failures are already visible on the PR itself.
+    # `!cancelled()` keeps a manual cancellation from being reported as
+    # breakage. Green runs are included so the tracking issue gets closed.
+    if: ${{ !cancelled() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    permissions:
+      issues: write
+      actions: read
+    # Serializes alert jobs across overlapping main runs so two failures
+    # landing together cannot each decide no issue exists and file one.
+    concurrency:
+      group: main-status-alert
+      cancel-in-progress: false
+    steps:
+      - name: Open, update, or close the red-main tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # No checkout, so gh cannot infer the repo from a git remote.
+          GH_REPO: ${{ github.repository }}
+          JOB_RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          set -euo pipefail
+
+          label='ci-main-red'
+          body_file="${RUNNER_TEMP}/main-status-body.md"
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+          # Any failed dependency means red, whatever else happened. A run
+          # with no failure but a non-success result (cancelled, skipped) is
+          # not evidence that main is healthy, so it is left alone.
+          outcome=green
+          for result in ${JOB_RESULTS}; do
+            case "${result}" in
+              success) ;;
+              failure) outcome=red; break ;;
+              *)       outcome=inconclusive ;;
+            esac
+          done
+
+          # Reuse an open tracking issue instead of filing one per run.
+          # Queried through the REST list endpoint rather than `gh issue
+          # list --search`: the search index is eventually consistent, so a
+          # freshly created issue can be invisible to the next run's lookup.
+          # `/issues` also returns pull requests -- filter them out.
+          issue=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/issues?state=open&labels=${label}&per_page=100" \
+            --jq 'map(select(.pull_request == null)) | .[0].number // empty')
+
+          if [ "${outcome}" = 'green' ]; then
+            if [ -n "${issue}" ]; then
+              gh issue close "${issue}" \
+                --comment "\`main\` is green again as of ${GITHUB_SHA}. Run: ${run_url}"
+            fi
+            exit 0
+          fi
+
+          if [ "${outcome}" != 'red' ]; then
+            echo "Inconclusive run (${JOB_RESULTS}); not alerting."
+            exit 0
+          fi
+
+          # Best-effort detail. Losing it must not lose the alert.
+          failed_jobs=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs?per_page=100" \
+            --jq '[.jobs[] | select(.conclusion == "failure") | .name] | join(", ")' \
+            || true)
+
+          cat > "${body_file}" <<EOF
+          CI failed on a push to \`main\`.
+
+          - Run: ${run_url}
+          - Commit: ${GITHUB_SHA}
+          - Pushed by: @${GITHUB_ACTOR}
+          - Failed jobs: ${failed_jobs:-unknown, see the run}
+
+          One issue is reused for every consecutive red run on \`main\`; each
+          further failure lands here as a comment. It closes automatically on
+          the next fully green \`main\` push.
+          EOF
+
+          if [ -n "${issue}" ]; then
+            gh issue comment "${issue}" --body-file "${body_file}"
+          else
+            # Idempotent: the label survives from earlier breaks.
+            gh label create "${label}" \
+              --color b60205 \
+              --description 'CI is failing on main' >/dev/null 2>&1 || true
+            gh issue create \
+              --title 'CI is red on main' \
+              --label "${label}" \
+              --body-file "${body_file}"
+          fi

--- a/docs/development/ci-debugging.md
+++ b/docs/development/ci-debugging.md
@@ -136,6 +136,42 @@ the actual arity mismatch errors.
 
 **Solution**: Download compile.log and build-cli.log to see exact compilation errors
 
+## Alerting on a red `main`
+
+Pull request failures are visible on the PR. Failures on a push to `main` are
+not visible anywhere unless someone looks, so the `main-status` job in
+`ci.yml` reports them.
+
+On a push to `main`:
+
+- **Any job failed** — the job opens an issue titled "CI is red on main",
+  labelled `ci-main-red`, containing the run URL, the commit, the pusher, and
+  the names of the failed jobs. If such an issue is already open, the failure
+  is added to it as a comment instead. One issue covers a whole red streak.
+- **Every job succeeded** — the open `ci-main-red` issue, if any, is closed
+  with a comment naming the commit that fixed it.
+- **Anything else** (a cancelled run, a job skipped for an unrelated reason,
+  with no outright failure) — nothing happens, and an open issue stays open.
+  An inconclusive run is not evidence that `main` is healthy.
+
+Pull request runs never trigger it.
+
+To find the current state:
+
+```bash
+gh issue list --repo miniforge-ai/miniforge --label ci-main-red --state open
+```
+
+Closing the issue by hand is safe — the next red run reopens the alert as a
+new issue. Do not remove the `ci-main-red` label from an open issue that is
+still tracking a real failure: the label is how the job finds it, and without
+it the next failure files a duplicate.
+
+The job runs no checkout and installs no toolchain. That is deliberate: it has
+to survive the failure it reports, so it depends on nothing but `gh`, which is
+preinstalled on GitHub-hosted runners. Keep it that way — an alerter that
+needs `bb` cannot report a broken `bb`.
+
 ## Log Retention
 
 - **Retention period**: 7 days

--- a/docs/pull-requests/2026-08-02-fix-ci-alert-on-red-main.md
+++ b/docs/pull-requests/2026-08-02-fix-ci-alert-on-red-main.md
@@ -1,0 +1,174 @@
+<!--
+  Title: Alert when CI fails on a push to main
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix(ci): alert when main goes red
+
+## Overview
+
+Adds a `main-status` job to `.github/workflows/ci.yml`. On a push to `main`,
+it opens (or comments on) a tracking issue when any CI job failed, and closes
+that issue on the next fully green run. Push events on `main` only — pull
+request runs are unaffected.
+
+## Motivation
+
+`ci.yml` had no `failure()` handler and no notification step anywhere.
+Verified 2026-08-02: no `notify`, `slack`, `issues.create`, or `failure()`
+appeared in the file, and none of the other workflows (`bump-standards.yml`,
+`notify-website.yml`, `pr-size.yml`, `refresh-cost-table.yml`, `release.yml`)
+covered CI outcomes.
+
+Consequence: `main`'s Test job was red across at least six consecutive merges
+(runs `30734048427` through `30735684110`) and produced zero signal. It was
+red for two independent reasons, and the second had gone entirely unnoticed.
+Both were fixed in [#1616](https://github.com/miniforge-ai/miniforge/pull/1616)
+(commit `f624b6f`), but the reason nobody knew was left unaddressed. This PR
+addresses it.
+
+### Why an issue and not a chat message
+
+There is no chat webhook configured. Checked before choosing: repository
+secrets are `HOMEBREW_APP_ID` and `HOMEBREW_APP_PRIVATE_KEY`; the organization
+secrets visible to this repo are `CI_BOT_WRITE_APPID`, `CI_BOT_WRITE_PEM`,
+`MINIFORGE_CI_BOT_APPID`, and `MINIFORGE_CI_BOT_KEY`. No Slack or Discord
+webhook exists at either level.
+
+A GitHub issue needs no new secret, reaches every repo watcher through the
+notification path they already use, and gives the failure a place to live
+until it is fixed. If a webhook is added later, it slots into the same job as
+an extra step.
+
+### Why this and not carrying "previously failing" tests into PR runs
+
+PR CI runs `bb test` (`scripts/test-since-stable.bb`, changed-and-affected)
+while main pushes run `bb test:all`, so namespaces outside a PR's affected set
+never run on that PR. That selection behaved correctly in this incident — none
+of the six PRs touched the affected components.
+
+Carrying a "previously failing" set forward into PR runs is the other option
+on the table, but it needs persisted state and still does nothing about a
+first break going unseen. Alerting is the higher-value change to make first.
+Test selection is deliberately untouched here.
+
+## Changes in Detail
+
+### `.github/workflows/ci.yml`
+
+One new job, `main-status`:
+
+- `needs: [structure, lint, test, test-windows, build]` — every job in the
+  workflow, so a failure anywhere is caught.
+- `if: !cancelled() && github.event_name == 'push' && github.ref ==
+  'refs/heads/main'`. PR failures are already visible on the PR itself, so
+  they are excluded. `!cancelled()` keeps a manual cancellation from being
+  reported as breakage. Green runs are included so the issue can be closed.
+- `permissions: {issues: write, actions: read}` — narrower than a workflow
+  default would be, and job-scoped. The rest of the workflow keeps
+  `contents: read`.
+- `concurrency: {group: main-status-alert, cancel-in-progress: false}` —
+  serializes alert jobs across overlapping main runs, so two failures landing
+  close together cannot each conclude that no issue exists and file one.
+
+The step itself decides an outcome from `join(needs.*.result, ' ')`:
+
+| Results | Outcome | Action |
+|---|---|---|
+| any `failure` | red | comment on the open tracking issue, or create it |
+| all `success` | green | close the open tracking issue, if any |
+| anything else (`cancelled`, `skipped`, no failure) | inconclusive | nothing |
+
+The inconclusive branch matters: a run with no failure but a non-success
+result is not evidence that `main` is healthy, so it must not close the issue.
+
+### Deduplication
+
+Open issues are found through `GET /repos/{repo}/issues?state=open&labels=ci-main-red`,
+not `gh issue list --search`. The search index is eventually consistent, so a
+freshly created issue can be invisible to the next run's lookup, which is
+exactly the case that would produce a duplicate. `/issues` also returns pull
+requests, hence the `.pull_request == null` filter.
+
+The `ci-main-red` label does not exist in the repo yet; the job creates it on
+first use, idempotently (`|| true`), rather than requiring an out-of-band repo
+change that would not appear in this diff.
+
+### No checkout, no toolchain
+
+The job deliberately has no `actions/checkout` and no Java/Clojure/bb setup.
+The alerter has to survive the failure it reports: a bb- or Clojure-based
+alerter would be taken out by exactly the deps or toolchain breakage it exists
+to announce. `gh` is preinstalled on GitHub-hosted runners, so the step needs
+nothing but `GH_TOKEN` and `GH_REPO`.
+
+This is why `workflows/bb-over-shell` (dewey 740) does not apply: the rule
+scopes to `bb.edn` and `scripts/**/*.sh` for build, launch, package, lint,
+test, and dev-loop tasks, and its "bb is genuinely unavailable" exception is
+the operative condition here.
+
+### `docs/development/ci-debugging.md`
+
+New "Alerting on a red `main`" section describing what the issue is, when it
+opens and closes, and how to silence it.
+
+## Testing Plan
+
+The step script was extracted from the parsed YAML and exercised against a
+stub `gh` across every branch:
+
+1. red, no open issue → creates the label, then the issue.
+2. red, open issue → comments on it, creates nothing.
+3. green, open issue → closes it.
+4. green, no open issue → no calls beyond the lookup.
+5. inconclusive (`cancelled` present, no `failure`) → no write calls; the open
+   issue is left open.
+6. red with the jobs API failing → still files the issue, with
+   `Failed jobs: unknown, see the run`.
+
+All six behaved as specified. The YAML was parsed to confirm the heredoc
+terminator lands at column 0 after block-scalar de-indentation.
+
+On this PR the job should report as skipped — `github.event_name` is
+`pull_request` — which is also the check that the `if` expression parses.
+Live confirmation of the green path comes on the first push to `main` after
+merge.
+
+## Deployment Plan
+
+Merging is the deployment. The first `main` push after merge exercises the
+green path (lookup, no issue, exit 0). The red path stays untested against the
+real API until `main` next breaks, which is the intended trigger.
+
+Rollback is deleting the job; nothing else in the workflow depends on it.
+
+## Security Considerations
+
+No untrusted input reaches the shell. The step interpolates only
+`github.token`, `github.repository`, and `join(needs.*.result, ' ')` — all
+GitHub-controlled. `GITHUB_ACTOR` and `GITHUB_SHA` are read from the runner
+environment and written into a markdown file, never executed. No commit
+message, PR title, or issue body is interpolated, so the workflow-injection
+class described in
+<https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/>
+does not arise.
+
+`permissions` is set at job level and grants `issues: write` and
+`actions: read` only.
+
+## Related Issues/PRs
+
+- [#1616](https://github.com/miniforge-ai/miniforge/pull/1616) — fixed the two
+  failures that went unnoticed; this PR fixes the not-knowing.
+
+## Checklist
+
+- [x] Alert restricted to `main` pushes, not PRs
+- [x] Deduplicated — one open issue reused, further failures become comments
+- [x] Issue closes automatically when `main` goes green
+- [x] Checked for an existing Slack/webhook secret before choosing the channel
+- [x] `set -o pipefail` on the Run tests step left untouched
+- [x] Test selection left untouched
+- [x] All script branches exercised against a stub `gh`
+- [x] `docs/development/ci-debugging.md` updated


### PR DESCRIPTION
Adds a `main-status` job to `.github/workflows/ci.yml`. On a push to `main` it opens (or comments on) a `ci-main-red` tracking issue when any CI job failed, and closes that issue on the next fully green run. Pull request runs are unaffected.

## Motivation

`ci.yml` had no `failure()` handler and no notification step, and no other workflow covered CI outcomes. `main`'s Test job was consequently red across six consecutive merges (runs `30734048427` through `30735684110`) and produced zero signal — it was red for two independent reasons, and the second went entirely unnoticed until someone looked by hand. #1616 fixed both failures; this fixes the not-knowing.

## Behaviour

| Job results | Outcome | Action |
|---|---|---|
| any `failure` | red | comment on the open tracking issue, or create it |
| all `success` | green | close the open tracking issue, if any |
| anything else (`cancelled`, `skipped`, no failure) | inconclusive | nothing |

The inconclusive branch matters: a run with no failure but a non-success result is not evidence that `main` is healthy, so it must not close the issue.

## Decisions

**Issue, not chat.** No webhook secret exists at either level — repo secrets are `HOMEBREW_APP_ID` / `HOMEBREW_APP_PRIVATE_KEY`, org secrets visible here are the four CI-bot app credentials. An issue needs no new secret and reaches watchers through a path they already have. A webhook, if one is added later, slots into the same job as an extra step.

**Dedupe reads the REST list endpoint,** `GET /issues?state=open&labels=ci-main-red`, not `gh issue list --search`. The search index is eventually consistent, so a freshly filed issue can be invisible to the next run's lookup — exactly the case that produces a duplicate. A job-level `concurrency` group serializes overlapping alert jobs for the same reason. The `ci-main-red` label does not exist yet; the job creates it idempotently rather than requiring an out-of-band repo change invisible to this diff.

**No checkout, no toolchain.** The alerter has to survive the failure it reports; a bb- or Clojure-based one would be taken out by exactly the deps/toolchain breakage it exists to announce. That is the "bb is genuinely unavailable" exception in `workflows/bb-over-shell` (dewey 740), which otherwise scopes to `bb.edn` and `scripts/**/*.sh`.

**Not in scope.** Test selection is untouched. Carrying a "previously failing" set into PR runs was the other candidate, but it needs persisted state and still does nothing about a first break going unseen. The Run tests step's `set -o pipefail` is untouched.

## Testing

The step script was extracted from the parsed YAML and exercised against a stub `gh` across every branch:

1. red, no open issue → creates the label, then the issue
2. red, open issue → comments, creates nothing
3. green, open issue → closes it
4. green, no open issue → no calls beyond the lookup
5. inconclusive (`cancelled` present, no `failure`) → no write calls, issue left open
6. red with the jobs API failing → still files, with `Failed jobs: unknown, see the run`

All six behaved as specified. YAML parses; `needs` was asserted to cover every other job in the workflow. On this PR the job should report as **skipped** (`github.event_name` is `pull_request`), which is also the check that the `if` expression parses. The green path gets live confirmation on the first push to `main` after merge; the red path stays untested against the real API until `main` next breaks.

## Security

No untrusted input reaches the shell. The step interpolates only `github.token`, `github.repository`, and `join(needs.*.result, ' ')` — all GitHub-controlled. `GITHUB_ACTOR` and `GITHUB_SHA` are read from the runner environment and written into a markdown file, never executed. No commit message, PR title, or issue body is interpolated. `permissions` is job-scoped to `issues: write` and `actions: read`.

## Docs

- `docs/development/ci-debugging.md` — new "Alerting on a red `main`" section
- `docs/pull-requests/2026-08-02-fix-ci-alert-on-red-main.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)