### PR TITLE
feat(codex): blackboard pin at phase start + recorded context reads (SPEC §7.3/§7.4)

### DIFF
--- a/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/codex_tool.clj
+++ b/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/codex_tool.clj
@@ -16,21 +16,19 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns ai.miniforge.mcp-context-server.codex-tool
-  "The consider_situation MCP tool — the Thesium Codex consumption surface
-   (Codex SPEC T1 §7.1) exposed to agents.
+  "The consider_situation MCP tool — the PULL side of the Thesium Codex
+   consumption surface (Codex SPEC T1 §7.1). Rendering lives in the codex
+   component (ai.miniforge.codex.render) so this tool's output and the
+   phase-start blackboard pin (§7.4, the PUSH side) are byte-identical.
 
-   Rendering rules come from the spec, not taste: landings arrive ordered
-   strategic → operational → tactical (§7.6.1); the coverage statement leads
-   and says out loud when there is no strategic-horizon landing (§7.6.2);
-   horizon escalations — a landing whose anchoring scar cost more than the
-   landing's own horizon — are flagged inline (§7.6.3). Anomalies render as
-   anomalies; an unmatched situation is an answer, never an empty list."
+   Fails closed: no configured codex path, an unreadable codex, or an
+   unmatched situation renders as an anomaly with a reason — never an
+   empty success."
   (:require [ai.miniforge.codex.interface :as codex]
             [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
-;; Codex location
 (defn ^{:stratum 0} codex-path
   "Codex directory: explicit param wins, else MINIFORGE_CODEX_PATH.
    A non-string param is treated as absent — this tool fails closed with a
@@ -40,76 +38,14 @@
     (or (when (string? p) (not-empty (str/trim p)))
         (some-> (System/getenv "MINIFORGE_CODEX_PATH") str/trim not-empty))))
 
-;; Rendering
-(defn- ^{:stratum 0} render-landing [{:keys [id type title horizon confidence open scars escalations]}]
-  ;; horizon, anchoring and escalation are problem-node concepts (SPEC §2.3,
-  ;; §2.6); a resolution is a terminal outcome and renders as one.
-  (let [problem? (= type "problem")]
-    (str/join "\n"
-      (concat
-        [(str "- [" (if problem? (or horizon "?") "resolution") "] " id " — " title
-              "  (confidence: " confidence ")")]
-        (when (seq escalations)
-          [(str "    ESCALATION: " (str/join ", " escalations)
-                " — the cost landed above this problem's horizon")])
-        (for [{scar-id :id :keys [date cost cost-horizon]} scars]
-          (str "    scar: " scar-id " (" date ", cost: " cost
-               (when cost-horizon (str ", cost-horizon: " cost-horizon)) ")"))
-        (when (and problem? (empty? scars))
-          ["    unanchored — reasoned, not survived"])
-        (map #(str "    open: " %) open)))))
-
-(defn- ^{:stratum 0} render-coverage
-  [{:keys [landing-count unanchored-count horizon-mix
-           no-strategic-coverage? newest-scar-date]}]
-  (str/join "\n"
-    (concat
-      ;; horizon mix rendered in the §7.6.1 order, not map order
-      [(str "coverage: " landing-count " landings, "
-            unanchored-count " unanchored, newest scar " (or newest-scar-date "none")
-            ", horizon mix "
-            (str/join " · " (for [h ["strategic" "operational" "tactical"]
-                                  :let [n (get horizon-mix h)]
-                                  :when n]
-                              (str h " " n))))]
-      (when no-strategic-coverage?
-        ["NO STRATEGIC COVERAGE: every landing is tactical/operational. The codex has nothing strategic-horizon for this situation — that absence is a gap in the codex, not evidence the situation carries no strategic risk."]))))
-
-(defn- ^{:stratum 0} render-anomaly [{:codex/keys [anomaly reason available matches]}]
-  (str/join "\n"
-    (concat
-      [(str "codex anomaly: " (name anomaly))
-       reason]
-      (when (seq available)
-        (cons "available situations:"
-              (map (fn [[id title]] (str "- " id " — " title)) available)))
-      (when (seq matches)
-        (cons "ambiguous between:"
-              (map (fn [[id title]] (str "- " id " — " title)) matches))))))
-
 ;------------------------------------------------------------------------------ Layer 1
 
-(defn ^{:stratum 1} render-response [resp]
-  (if (:codex/anomaly resp)
-    (render-anomaly resp)
-    (str/join "\n"
-      (concat
-        [(str "situation: " (:situation resp) " — " (:situation-title resp))
-         (render-coverage (:coverage resp))
-         ""
-         "landings (strategic first — read top-down):"]
-        (map render-landing (:landings resp))))))
-
-;------------------------------------------------------------------------------ Layer 2
-
-;; MCP handler
-(defn ^{:stratum 2} handle-consider-situation
-  "MCP handler for consider_situation. Fails closed: no configured codex
-   path is an anomaly with a reason, never an empty success."
+(defn ^{:stratum 1} handle-consider-situation
+  "MCP handler for consider_situation."
   [params]
   (let [text (if-let [path (codex-path params)]
-               (render-response (codex/consider path (get params "situation")))
-               (render-anomaly
+               (codex/render-response (codex/consider path (get params "situation")))
+               (codex/render-response
                  {:codex/anomaly :codex-unconfigured
                   :codex/reason (str "no codex_path argument and MINIFORGE_CODEX_PATH "
                                      "is unset — cannot consult a codex that has "

--- a/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/context_cache.clj
+++ b/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/context_cache.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.mcp-context-server.context-cache
   "Read-through context cache for MCP file exploration tools.
 
@@ -32,20 +31,13 @@
             [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Pure helpers
 
-(def ^:private chars-per-token
+;; Pure helpers
+(def ^{:stratum 0} ^:private chars-per-token
   "Approximate characters per token for estimation."
   4)
 
-(defn estimate-tokens
-  "Estimate token count from a string (~4 chars per token)."
-  [s]
-  (if (string? s)
-    (int (Math/ceil (/ (count s) chars-per-token)))
-    0))
-
-(defn apply-offset-limit
+(defn ^{:stratum 0} apply-offset-limit
   "Apply line-based offset and limit to content string.
    offset is 0-based line index; limit is max lines to return."
   [content offset limit]
@@ -55,7 +47,7 @@
         limited (if limit (take limit sliced) sliced)]
     (str/join "\n" limited)))
 
-(defn glob-matches?
+(defn ^{:stratum 0} glob-matches?
   "Check if a path matches a glob pattern.
    Supports * (single segment) and ** (any depth)."
   [pattern path]
@@ -69,7 +61,7 @@
         regex (re-pattern (str "^" regex-str "$"))]
     (boolean (re-matches regex path))))
 
-(defn grep-file
+(defn ^{:stratum 0} grep-file
   "Search a file's content for a regex pattern.
    Returns vector of {:path :line-number :text} for matching lines."
   [path content pattern-str]
@@ -84,7 +76,7 @@
            vec))
     (catch Exception _e [])))
 
-(defn format-grep-results
+(defn ^{:stratum 0} format-grep-results
   "Format grep results as path:line:text lines."
   [results]
   (->> results
@@ -92,13 +84,153 @@
               (str path ":" line-number ":" text)))
        (str/join "\n")))
 
-;------------------------------------------------------------------------------ Layer 0
-;; Shell fallbacks
+;; Stateful cache operations
+;; Cache atom holding :files (path → content), :mtimes (path → epoch-ms of the
+;; file when its content was cached, for write-invalidation), :misses
+;; (recorded cache misses), and :reads (every context_read resolution, hit or
+;; miss — the recorded-flows half of the Codex SPEC §7.4 blackboard contract:
+;; whether an agent consulted a pinned artifact must be an answerable
+;; question).
+(defonce ^{:stratum 0} cache-state
+  (atom {:files {} :mtimes {} :misses [] :reads []
+         :source-root nil :artifact-dir nil :workdir nil}))
 
-(declare source-root)
-(declare file-mtime)
+(def ^{:stratum 0} ^:private persistent-cache-relpath ".miniforge/context-cache.edn")
 
-(defn shell-grep
+(defn- ^{:stratum 0} read-cache-edn
+  "Read {:files .. :mtimes ..} from an EDN cache file, or nil on missing/bad."
+  [path]
+  (let [f (and path (io/file path))]
+    (when (and f (.exists f))
+      (try (edn/read-string (slurp f))
+           (catch Exception _ nil)))))
+
+;; MCP response helpers
+(defn- ^{:stratum 0} text-response
+  "Wrap a string in the MCP tool response shape."
+  [text]
+  {:content [{:type "text" :text text}]})
+
+(defn- ^{:stratum 0} error-response
+  "Wrap an error message in the MCP tool error shape."
+  [text]
+  {:content [{:type "text" :text text}] :isError true})
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} estimate-tokens
+  "Estimate token count from a string (~4 chars per token)."
+  [s]
+  (if (string? s)
+    (int (Math/ceil (/ (count s) chars-per-token)))
+    0))
+
+(defn ^{:stratum 1} reset-state!
+  "Reset cache state. Intended for test isolation."
+  []
+  (reset! cache-state {:files {} :mtimes {} :misses [] :reads []
+                       :source-root nil :artifact-dir nil :workdir nil}))
+
+(defn ^{:stratum 1} set-workdir!
+  "Set the write target for context_write — the agent's worktree, distinct from
+   `:source-root` (the read reference). Reads resolve against source-root;
+   writes land in the worktree where the run collects the diff. Agent-agnostic:
+   every backend's context server is launched with the same command, so this
+   applies to Claude/Codex/Cursor alike."
+  [workdir]
+  (swap! cache-state assoc :workdir workdir))
+
+(defn- ^{:stratum 1} source-root
+  []
+  (or (:source-root @cache-state) "."))
+
+(defn- ^{:stratum 1} persistent-cache-path
+  "Worktree-resident cross-phase cache file, or nil when there's no
+   source-root. Under .miniforge/ (gitignored) so it rides workspace
+   persistence into containers across phases."
+  [source-root]
+  (when-not (str/blank? source-root)
+    (str source-root "/" persistent-cache-relpath)))
+
+(defn ^{:stratum 1} flush-misses!
+  "Write accumulated cache misses to context-misses.edn in artifact-dir."
+  [artifact-dir]
+  (let [misses (:misses @cache-state)]
+    (when (seq misses)
+      (let [path (str artifact-dir "/context-misses.edn")]
+        (spit path (pr-str misses))
+        (binding [*out* *err*]
+          (println (msg/t :cache/misses-written {:count (count misses) :path path})))))))
+
+(defn ^{:stratum 1} flush-reads!
+  "Write every recorded context_read resolution to context-reads.edn in
+   artifact-dir — the recorded flows a §7.4.3 gate condition reads."
+  [artifact-dir]
+  (let [reads (:reads @cache-state)]
+    (when (seq reads)
+      (spit (str artifact-dir "/context-reads.edn") (pr-str reads)))))
+
+;; `handle-submit` (the artifact.edn metadata channel) removed: the artifact is
+;; the worktree/container diff (promotion); the curator derives the summary.
+;; Models ignored the opt-in submit tool anyway. See artifact_session/mcp-tools.
+(defn- ^{:stratum 1} record-miss!
+  "Record a cache miss for meta-loop learning."
+  [tool-name params tokens]
+  (swap! cache-state update :misses conj
+         (merge {:tool tool-name
+                 :tokens tokens
+                 :timestamp (str (java.time.Instant/now))}
+                params)))
+
+(defn- ^{:stratum 1} record-read!
+  "Record every context_read resolution — hit AND miss. `source` is
+   :cache | :filesystem | :refresh | :absent. Misses track what the
+   pre-load lacked; reads answer the different question of what the agent
+   actually consulted (Codex SPEC §7.4.2)."
+  [path source]
+  (swap! cache-state update :reads conj
+         {:path path
+          :source source
+          :timestamp (str (java.time.Instant/now))}))
+
+(defn- ^{:stratum 1} cache-get
+  "Get cached content for a path, or nil if not cached."
+  [path]
+  (get-in @cache-state [:files path]))
+
+(defn- ^{:stratum 1} cached-files
+  "Return the current files map from the cache."
+  []
+  (:files @cache-state))
+
+(defn- ^{:stratum 1} grep-response
+  "Build MCP response from grep results. Returns formatted matches or
+   a no-matches message when empty."
+  [results]
+  (text-response
+    (if (seq results)
+      (format-grep-results results)
+      (msg/t :context/no-grep-matches))))
+
+;; Grep helpers: file selection and fallback
+(defn ^{:stratum 1} filter-cached-files
+  "Select which cached files to search based on path or glob filter.
+   Returns a {path → content} map."
+  [files target-path glob-filter]
+  (cond
+    target-path  (select-keys files [target-path])
+    glob-filter  (into {} (filter (fn [[p _]] (glob-matches? glob-filter p))) files)
+    :else        files))
+
+(defn- ^{:stratum 1} search-cached-files
+  "Grep across a map of {path → content} for a pattern.
+   Returns a flat vector of grep result maps."
+  [files-map pattern-str]
+  (into [] (mapcat (fn [[path content]] (grep-file path content pattern-str))) files-map))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} shell-grep
   "Fall back to ripgrep for files not in cache.
    Returns vector of {:path :line-number :text} or nil."
   [pattern-str path-or-glob]
@@ -119,7 +251,7 @@
              vec)))
     (catch Exception _e nil)))
 
-(defn shell-glob
+(defn ^{:stratum 2} shell-glob
   "Fall back to filesystem glob by walking source-root.
    Returns vector of relative file paths or nil."
   [pattern]
@@ -144,46 +276,38 @@
         matches))
     (catch Exception _e nil)))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Stateful cache operations
-
-;; Cache atom holding :files (path → content), :mtimes (path → epoch-ms of the
-;; file when its content was cached, for write-invalidation), and :misses
-;; (recorded cache misses).
-(defonce cache-state
-  (atom {:files {} :mtimes {} :misses [] :source-root nil :artifact-dir nil :workdir nil}))
-
-(defn reset-state!
-  "Reset cache state. Intended for test isolation."
-  []
-  (reset! cache-state {:files {} :mtimes {} :misses [] :source-root nil :artifact-dir nil :workdir nil}))
-
-(defn set-workdir!
-  "Set the write target for context_write — the agent's worktree, distinct from
-   `:source-root` (the read reference). Reads resolve against source-root;
-   writes land in the worktree where the run collects the diff. Agent-agnostic:
-   every backend's context server is launched with the same command, so this
-   applies to Claude/Codex/Cursor alike."
-  [workdir]
-  (swap! cache-state assoc :workdir workdir))
-
-(defn- source-root
-  []
-  (or (:source-root @cache-state) "."))
-
-(defn- write-root
+(defn- ^{:stratum 2} write-root
   "Root for context_write: the worktree (`:workdir`) when set, else source-root."
   []
   (or (:workdir @cache-state) (source-root)))
 
-(defn- resolve-source-path
+(defn- ^{:stratum 2} resolve-source-path
   [path]
   (let [f (io/file path)]
     (if (.isAbsolute f)
       (.getPath f)
       (.getPath (io/file (source-root) path)))))
 
-(defn- resolve-write-path
+(defn ^{:stratum 2} save-cache!
+  "Persist the accumulated in-memory cache (pre-populated + read-through
+   additions, with mtimes) to the worktree-resident cross-phase cache file so
+   the NEXT phase's server loads it. No-ops without a source-root or when
+   nothing is cached. Best-effort: a write failure is logged, not thrown."
+  []
+  (let [{:keys [source-root files mtimes]} @cache-state]
+    (when-let [path (and (seq files) (persistent-cache-path source-root))]
+      (try
+        (io/make-parents path)
+        (spit path (pr-str {:files files :mtimes mtimes}))
+        (binding [*out* *err*]
+          (println (msg/t :cache/saved {:count (count files) :path path})))
+        (catch Exception e
+          (binding [*out* *err*]
+            (println (msg/t :cache/save-failed {:error (ex-message e)}))))))))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn- ^{:stratum 3} resolve-write-path
   "Resolve a write path against write-root (the worktree)."
   [path]
   (let [f (io/file path)]
@@ -191,25 +315,42 @@
       (.getPath f)
       (.getPath (io/file (write-root) path)))))
 
-(def ^:private persistent-cache-relpath ".miniforge/context-cache.edn")
-
-(defn- persistent-cache-path
-  "Worktree-resident cross-phase cache file, or nil when there's no
-   source-root. Under .miniforge/ (gitignored) so it rides workspace
-   persistence into containers across phases."
-  [source-root]
-  (when-not (str/blank? source-root)
-    (str source-root "/" persistent-cache-relpath)))
-
-(defn- read-cache-edn
-  "Read {:files .. :mtimes ..} from an EDN cache file, or nil on missing/bad."
+(defn- ^{:stratum 3} file-mtime
+  "Last-modified epoch-ms of the resolved source file, or nil if absent."
   [path]
-  (let [f (and path (io/file path))]
-    (when (and f (.exists f))
-      (try (edn/read-string (slurp f))
-           (catch Exception _ nil)))))
+  (let [f (io/file (resolve-source-path path))]
+    (when (.exists f)
+      (.lastModified f))))
 
-(defn load-cache!
+;; Glob helpers
+(defn- ^{:stratum 3} glob-with-union
+  "Match cached paths, union with filesystem glob, record misses for
+   files found only on disk. Returns a sequence of matched paths."
+  [pattern]
+  (let [files         (cached-files)
+        cache-matches (sort (filter #(glob-matches? pattern %) (keys files)))
+        fs-matches    (or (shell-glob pattern) [])
+        cache-set     (set cache-matches)
+        new-from-fs   (remove cache-set fs-matches)]
+    (when (seq new-from-fs)
+      (record-miss! "context_glob"
+                    {:pattern pattern :fs-only-count (count new-from-fs)}
+                    0))
+    (concat cache-matches new-from-fs)))
+
+(defn- ^{:stratum 3} within-write-root?
+  "True when the resolved target canonicalizes to a path inside write-root.
+   Blocks absolute paths and `..` traversal that would let an MCP client
+   overwrite files outside the worktree."
+  [target]
+  (let [root-c   (.getCanonicalPath (io/file (write-root)))
+        target-c (.getCanonicalPath (io/file target))]
+    (or (= target-c root-c)
+        (str/starts-with? target-c (str root-c java.io.File/separator)))))
+
+;------------------------------------------------------------------------------ Layer 4
+
+(defn ^{:stratum 4} load-cache!
   "Load the context cache from two sources (freshest wins):
 
    1. the cross-phase PERSISTENT cache at <source-root>/.miniforge/
@@ -239,59 +380,7 @@
        (binding [*out* *err*]
          (println (msg/t :cache/load-failed {:error (ex-message e)})))))))
 
-(defn save-cache!
-  "Persist the accumulated in-memory cache (pre-populated + read-through
-   additions, with mtimes) to the worktree-resident cross-phase cache file so
-   the NEXT phase's server loads it. No-ops without a source-root or when
-   nothing is cached. Best-effort: a write failure is logged, not thrown."
-  []
-  (let [{:keys [source-root files mtimes]} @cache-state]
-    (when-let [path (and (seq files) (persistent-cache-path source-root))]
-      (try
-        (io/make-parents path)
-        (spit path (pr-str {:files files :mtimes mtimes}))
-        (binding [*out* *err*]
-          (println (msg/t :cache/saved {:count (count files) :path path})))
-        (catch Exception e
-          (binding [*out* *err*]
-            (println (msg/t :cache/save-failed {:error (ex-message e)}))))))))
-
-(defn flush-misses!
-  "Write accumulated cache misses to context-misses.edn in artifact-dir."
-  [artifact-dir]
-  (let [misses (:misses @cache-state)]
-    (when (seq misses)
-      (let [path (str artifact-dir "/context-misses.edn")]
-        (spit path (pr-str misses))
-        (binding [*out* *err*]
-          (println (msg/t :cache/misses-written {:count (count misses) :path path})))))))
-
-;; `handle-submit` (the artifact.edn metadata channel) removed: the artifact is
-;; the worktree/container diff (promotion); the curator derives the summary.
-;; Models ignored the opt-in submit tool anyway. See artifact_session/mcp-tools.
-
-(defn- record-miss!
-  "Record a cache miss for meta-loop learning."
-  [tool-name params tokens]
-  (swap! cache-state update :misses conj
-         (merge {:tool tool-name
-                 :tokens tokens
-                 :timestamp (str (java.time.Instant/now))}
-                params)))
-
-(defn- cache-get
-  "Get cached content for a path, or nil if not cached."
-  [path]
-  (get-in @cache-state [:files path]))
-
-(defn- file-mtime
-  "Last-modified epoch-ms of the resolved source file, or nil if absent."
-  [path]
-  (let [f (io/file (resolve-source-path path))]
-    (when (.exists f)
-      (.lastModified f))))
-
-(defn- cache-put!
+(defn- ^{:stratum 4} cache-put!
   "Store content in the cache for a path, stamping the file's current mtime so
    `cache-stale?` can later detect on-disk changes (write-invalidation)."
   [path content]
@@ -299,7 +388,7 @@
                           (assoc-in [:files path] content)
                           (assoc-in [:mtimes path] (file-mtime path)))))
 
-(defn- cache-stale?
+(defn- ^{:stratum 4} cache-stale?
   "True only when the cached entry can be PROVEN out of date: we recorded an
    mtime for it, the file still exists, and it was modified after we cached.
    When there's no recorded mtime or no on-disk file, staleness cannot be
@@ -312,145 +401,7 @@
         disk   (file-mtime path)]
     (boolean (and cached disk (> disk cached)))))
 
-(defn- cached-files
-  "Return the current files map from the cache."
-  []
-  (:files @cache-state))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Read-through cache: resolve content from cache or filesystem
-
-(defn- read-through
-  "Resolve file content. Fresh cache hit returns instantly. A miss — or a
-   cached entry whose file changed on disk since it was cached — reads from
-   disk, re-caches (with the new mtime), and returns the current content.
-   Records a miss only on a GENUINE miss (never cached), not on a
-   staleness-driven refresh. Returns content string or nil."
-  [path]
-  (let [cached (cache-get path)]
-    (if (and cached (not (cache-stale? path)))
-      cached
-      (try
-        (let [content (slurp (resolve-source-path path))]
-          (cache-put! path content)
-          (when (nil? cached)
-            (record-miss! "context_read" {:path path} (estimate-tokens content)))
-          content)
-        (catch Exception _ nil)))))
-
-;------------------------------------------------------------------------------ Layer 1
-;; MCP response helpers
-
-(defn- text-response
-  "Wrap a string in the MCP tool response shape."
-  [text]
-  {:content [{:type "text" :text text}]})
-
-(defn- error-response
-  "Wrap an error message in the MCP tool error shape."
-  [text]
-  {:content [{:type "text" :text text}] :isError true})
-
-(defn- grep-response
-  "Build MCP response from grep results. Returns formatted matches or
-   a no-matches message when empty."
-  [results]
-  (text-response
-    (if (seq results)
-      (format-grep-results results)
-      (msg/t :context/no-grep-matches))))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Grep helpers: file selection and fallback
-
-(defn filter-cached-files
-  "Select which cached files to search based on path or glob filter.
-   Returns a {path → content} map."
-  [files target-path glob-filter]
-  (cond
-    target-path  (select-keys files [target-path])
-    glob-filter  (into {} (filter (fn [[p _]] (glob-matches? glob-filter p))) files)
-    :else        files))
-
-(defn- search-cached-files
-  "Grep across a map of {path → content} for a pattern.
-   Returns a flat vector of grep result maps."
-  [files-map pattern-str]
-  (into [] (mapcat (fn [[path content]] (grep-file path content pattern-str))) files-map))
-
-(defn- cache-new-files!
-  "Cache files discovered by shell grep that aren't already cached.
-   Records a miss for each newly cached file."
-  [results pattern-str known-files]
-  (doseq [path (distinct (map :path results))
-          :when (not (contains? known-files path))]
-    (try
-      (let [content (slurp (resolve-source-path path))]
-        (cache-put! path content)
-        (record-miss! "context_grep" {:path path :pattern pattern-str}
-                      (estimate-tokens content)))
-      (catch Exception _ nil))))
-
-(defn- grep-with-fallback
-  "Search cached files first. On cache miss, fall back to ripgrep,
-   cache any newly discovered files, and record misses."
-  [pattern-str target-path glob-filter]
-  (let [files         (cached-files)
-        searchable    (filter-cached-files files target-path glob-filter)
-        cache-results (search-cached-files searchable pattern-str)]
-    (if (seq cache-results)
-      cache-results
-      (let [rg-results (or (shell-grep pattern-str (or target-path glob-filter)) [])]
-        (if (seq rg-results)
-          (do (cache-new-files! rg-results pattern-str files)
-              rg-results)
-          (do (record-miss! "context_grep"
-                            {:pattern pattern-str :path target-path
-                             :glob glob-filter :hit false}
-                            0)
-              []))))))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Glob helpers
-
-(defn- glob-with-union
-  "Match cached paths, union with filesystem glob, record misses for
-   files found only on disk. Returns a sequence of matched paths."
-  [pattern]
-  (let [files         (cached-files)
-        cache-matches (sort (filter #(glob-matches? pattern %) (keys files)))
-        fs-matches    (or (shell-glob pattern) [])
-        cache-set     (set cache-matches)
-        new-from-fs   (remove cache-set fs-matches)]
-    (when (seq new-from-fs)
-      (record-miss! "context_glob"
-                    {:pattern pattern :fs-only-count (count new-from-fs)}
-                    0))
-    (concat cache-matches new-from-fs)))
-
-;------------------------------------------------------------------------------ Layer 2
-;; Tool handler functions (compose Layer 0 + Layer 1)
-
-(defn handle-context-read
-  "Handler for context_read MCP tool."
-  [params]
-  (let [path    (get params "path")
-        offset  (get params "offset")
-        limit   (get params "limit")
-        content (read-through path)]
-    (if content
-      (text-response (apply-offset-limit content offset limit))
-      (error-response (msg/t :context/read-error {:path path})))))
-
-(defn handle-context-grep
-  "Handler for context_grep MCP tool."
-  [params]
-  (grep-response
-    (grep-with-fallback (get params "pattern")
-                        (get params "path")
-                        (get params "glob"))))
-
-(defn handle-context-glob
+(defn ^{:stratum 4} handle-context-glob
   "Handler for context_glob MCP tool."
   [params]
   (let [matches (glob-with-union (get params "pattern"))]
@@ -459,17 +410,7 @@
         (str/join "\n" matches)
         (msg/t :context/no-glob-matches)))))
 
-(defn- within-write-root?
-  "True when the resolved target canonicalizes to a path inside write-root.
-   Blocks absolute paths and `..` traversal that would let an MCP client
-   overwrite files outside the worktree."
-  [target]
-  (let [root-c   (.getCanonicalPath (io/file (write-root)))
-        target-c (.getCanonicalPath (io/file target))]
-    (or (= target-c root-c)
-        (str/starts-with? target-c (str root-c java.io.File/separator)))))
-
-(defn handle-context-write
+(defn ^{:stratum 4} handle-context-write
   "Handler for the context_write MCP tool. Writes the full file content to the
    worktree (write-root) and refreshes the cache so a later context_read returns
    the new content. Agent-agnostic edit path — works for any MCP client and,
@@ -502,3 +443,89 @@
         (catch Exception e
           (error-response (msg/t :context/write-failed
                                  {:path path :error (ex-message e)})))))))
+
+;------------------------------------------------------------------------------ Layer 5
+
+;; Read-through cache: resolve content from cache or filesystem
+(defn- ^{:stratum 5} read-through
+  "Resolve file content. Fresh cache hit returns instantly. A miss — or a
+   cached entry whose file changed on disk since it was cached — reads from
+   disk, re-caches (with the new mtime), and returns the current content.
+   Records a miss only on a GENUINE miss (never cached), not on a
+   staleness-driven refresh. Returns content string or nil."
+  [path]
+  (let [cached (cache-get path)]
+    (if (and cached (not (cache-stale? path)))
+      (do (record-read! path :cache)
+          cached)
+      (try
+        (let [content (slurp (resolve-source-path path))]
+          (cache-put! path content)
+          (when (nil? cached)
+            (record-miss! "context_read" {:path path} (estimate-tokens content)))
+          (record-read! path (if cached :refresh :filesystem))
+          content)
+        (catch Exception _
+          (record-read! path :absent)
+          nil)))))
+
+(defn- ^{:stratum 5} cache-new-files!
+  "Cache files discovered by shell grep that aren't already cached.
+   Records a miss for each newly cached file."
+  [results pattern-str known-files]
+  (doseq [path (distinct (map :path results))
+          :when (not (contains? known-files path))]
+    (try
+      (let [content (slurp (resolve-source-path path))]
+        (cache-put! path content)
+        (record-miss! "context_grep" {:path path :pattern pattern-str}
+                      (estimate-tokens content)))
+      (catch Exception _ nil))))
+
+;------------------------------------------------------------------------------ Layer 6
+
+(defn- ^{:stratum 6} grep-with-fallback
+  "Search cached files first. On cache miss, fall back to ripgrep,
+   cache any newly discovered files, and record misses."
+  [pattern-str target-path glob-filter]
+  (let [files         (cached-files)
+        searchable    (filter-cached-files files target-path glob-filter)
+        cache-results (search-cached-files searchable pattern-str)]
+    (if (seq cache-results)
+      cache-results
+      (let [rg-results (or (shell-grep pattern-str (or target-path glob-filter)) [])]
+        (if (seq rg-results)
+          (do (cache-new-files! rg-results pattern-str files)
+              rg-results)
+          (do (record-miss! "context_grep"
+                            {:pattern pattern-str :path target-path
+                             :glob glob-filter :hit false}
+                            0)
+              []))))))
+
+;; Tool handler functions (compose Layer 0 + Layer 1)
+(defn ^{:stratum 6} handle-context-read
+  "Handler for context_read MCP tool."
+  [params]
+  (let [path    (get params "path")
+        offset  (get params "offset")
+        limit   (get params "limit")
+        content (read-through path)]
+    (if content
+      (text-response (apply-offset-limit content offset limit))
+      (error-response (msg/t :context/read-error {:path path})))))
+
+;------------------------------------------------------------------------------ Layer 7
+
+(defn ^{:stratum 7} handle-context-grep
+  "Handler for context_grep MCP tool."
+  [params]
+  (grep-response
+    (grep-with-fallback (get params "pattern")
+                        (get params "path")
+                        (get params "glob"))))
+
+;; Shell fallbacks
+(declare source-root)
+
+(declare file-mtime)

--- a/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/server.clj
+++ b/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/server.clj
@@ -91,6 +91,7 @@
            (recur))))
      (finally
        (context-cache/flush-misses! artifact-dir)
+       (context-cache/flush-reads! artifact-dir)
        ;; Persist the accumulated cache (incl. read-through additions) to the
        ;; worktree so the next phase loads it — cross-phase write-through.
        (context-cache/save-cache!)))))

--- a/bases/mcp-context-server/test/ai/miniforge/mcp_context_server/codex_tool_test.clj
+++ b/bases/mcp-context-server/test/ai/miniforge/mcp_context_server/codex_tool_test.clj
@@ -16,53 +16,17 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns ai.miniforge.mcp-context-server.codex-tool-test
-  "The response-map shapes rendered here are pinned by the codex component's
-   own tests (ai.miniforge.codex.interface-test) against generator-produced
-   fixtures; these tests cover the base's rendering and fail-closed paths."
+  "Rendering itself is pinned by the codex component's tests
+   (ai.miniforge.codex.render-test) — these cover the tool's fail-closed
+   paths and param handling only."
   (:require [ai.miniforge.mcp-context-server.codex-tool :as codex-tool]
             [clojure.string :as str]
-            [clojure.test :refer [deftest is testing]]))
+            [clojure.test :refer [deftest is]]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
 (defn- ^{:stratum 0} text-of [result]
   (-> result :content first :text))
-
-(deftest ^{:stratum 0} render-orders-and-flags
-  (let [resp {:situation "s1"
-              :situation-title "A situation"
-              :landings [{:id "p-strategic" :type "problem" :title "Big one"
-                          :horizon "strategic" :confidence "high"
-                          :open [] :scars [] :escalations []}
-                         {:id "p-op" :type "problem" :title "Runs the system"
-                          :horizon "operational" :confidence "high"
-                          :open ["still open"]
-                          :scars [{:id "scar-1" :date "2026-01" :cost "an outage"
-                                   :cost-horizon "strategic" :origin "owned"}]
-                          :escalations ["scar-1"]}]
-              :coverage {:landing-count 2 :unanchored-count 1
-                         :horizon-mix {"strategic" 1 "operational" 1}
-                         :no-strategic-coverage? false
-                         :newest-scar-date "2026-01"}}
-        text (codex-tool/render-response resp)]
-    (testing "strategic renders before operational (§7.6.1)"
-      (is (< (str/index-of text "p-strategic") (str/index-of text "p-op"))))
-    (testing "escalation and unanchored are flagged inline (§7.6.3)"
-      (is (str/includes? text "ESCALATION: scar-1"))
-      (is (str/includes? text "unanchored — reasoned, not survived")))
-    (testing "coverage line leads with counts (§7.5)"
-      (is (str/includes? text "coverage: 2 landings, 1 unanchored")))))
-
-(deftest ^{:stratum 0} render-says-when-strategic-coverage-is-absent
-  (let [resp {:situation "s1" :situation-title "t"
-              :landings [{:id "p" :type "problem" :title "t" :horizon "tactical"
-                          :confidence "high" :open [] :scars [] :escalations []}]
-              :coverage {:landing-count 1 :unanchored-count 1
-                         :horizon-mix {"tactical" 1}
-                         :no-strategic-coverage? true
-                         :newest-scar-date nil}}
-        text (codex-tool/render-response resp)]
-    (is (str/includes? text "NO STRATEGIC COVERAGE"))))
 
 ;------------------------------------------------------------------------------ Layer 1
 
@@ -73,6 +37,12 @@
                           {"situation" "an agent needs to act"}))]
       (is (str/includes? text "codex anomaly: codex-unconfigured"))
       (is (str/includes? text "MINIFORGE_CODEX_PATH")))))
+
+(deftest ^{:stratum 1} non-string-codex-path-is-treated-as-absent
+  (when-not (System/getenv "MINIFORGE_CODEX_PATH")
+    (let [text (text-of (codex-tool/handle-consider-situation
+                          {"situation" "anything" "codex_path" 42}))]
+      (is (str/includes? text "codex anomaly: codex-unconfigured")))))
 
 (deftest ^{:stratum 1} unreadable-codex-is-an-anomaly-not-an-empty-answer
   (let [text (text-of (codex-tool/handle-consider-situation

--- a/bases/mcp-context-server/test/ai/miniforge/mcp_context_server/context_cache_test.clj
+++ b/bases/mcp-context-server/test/ai/miniforge/mcp_context_server/context_cache_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.mcp-context-server.context-cache-test
   "Unit tests for context cache pure helpers and tool handlers."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
@@ -24,15 +23,13 @@
             [ai.miniforge.mcp-context-server.context-cache :as cache]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Test fixtures
 
-(defn with-clean-cache [f]
+;; Test fixtures
+(defn ^{:stratum 0} with-clean-cache [f]
   (cache/reset-state!)
   (try (f) (finally (cache/reset-state!))))
 
-(use-fixtures :each with-clean-cache)
-
-(defn with-temp-dir [f]
+(defn ^{:stratum 0} with-temp-dir [f]
   (let [dir (str (java.nio.file.Files/createTempDirectory
                    "ctx-cache-test-"
                    (into-array java.nio.file.attribute.FileAttribute [])))]
@@ -42,10 +39,8 @@
         (doseq [file (reverse (file-seq (io/file dir)))]
           (.delete ^java.io.File file))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Pure helper tests
-
-(deftest estimate-tokens-test
+(deftest ^{:stratum 0} estimate-tokens-test
   (testing "estimates ~4 chars per token"
     (is (= 3 (cache/estimate-tokens "hello world!")))
     (is (= 1 (cache/estimate-tokens "abc"))))
@@ -55,7 +50,7 @@
     (is (= 0 (cache/estimate-tokens nil)))
     (is (= 0 (cache/estimate-tokens 42)))))
 
-(deftest apply-offset-limit-test
+(deftest ^{:stratum 0} apply-offset-limit-test
   (let [content "line0\nline1\nline2\nline3\nline4"]
 
     (testing "no offset or limit returns all lines"
@@ -73,7 +68,7 @@
     (testing "nil content returns empty"
       (is (= "" (cache/apply-offset-limit nil nil nil))))))
 
-(deftest glob-matches?-test
+(deftest ^{:stratum 0} glob-matches?-test
   (testing "single star matches one segment"
     (is (cache/glob-matches? "src/*.clj" "src/core.clj"))
     (is (not (cache/glob-matches? "src/*.clj" "src/nested/core.clj"))))
@@ -89,7 +84,7 @@
   (testing "dots are literal"
     (is (not (cache/glob-matches? "src/*.clj" "src/corexclj")))))
 
-(deftest grep-file-test
+(deftest ^{:stratum 0} grep-file-test
   (let [content "(ns core)\n\n(defn greet [name]\n  (str \"Hello, \" name))"]
 
     (testing "finds matching lines with line numbers"
@@ -104,30 +99,103 @@
     (testing "returns empty on invalid regex"
       (is (empty? (cache/grep-file "src/core.clj" content "[invalid"))))))
 
-(deftest format-grep-results-test
+(deftest ^{:stratum 0} format-grep-results-test
   (testing "formats as path:line:text"
     (is (= "a.clj:1:hello\nb.clj:5:world"
            (cache/format-grep-results
              [{:path "a.clj" :line-number 1 :text "hello"}
               {:path "b.clj" :line-number 5 :text "world"}])))))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Tool handler tests
-
-(deftest handle-context-read-cache-hit-test
+(deftest ^{:stratum 0} handle-context-read-cache-hit-test
   (testing "returns cached content"
     (swap! cache/cache-state assoc-in [:files "src/core.clj"] "(ns core)\n(defn hello [])")
     (let [result (cache/handle-context-read {"path" "src/core.clj"})]
       (is (= "(ns core)\n(defn hello [])" (get-in result [:content 0 :text])))
       (is (not (:isError result))))))
 
-(deftest handle-context-read-offset-limit-test
+(deftest ^{:stratum 0} handle-context-read-offset-limit-test
   (testing "applies offset and limit on cache hit"
     (swap! cache/cache-state assoc-in [:files "src/core.clj"] "line0\nline1\nline2\nline3")
     (let [result (cache/handle-context-read {"path" "src/core.clj" "offset" 1 "limit" 2})]
       (is (= "line1\nline2" (get-in result [:content 0 :text]))))))
 
-(deftest handle-context-read-cache-miss-test
+(deftest ^{:stratum 0} handle-context-read-nonexistent-test
+  (testing "returns error for nonexistent file"
+    (let [result (cache/handle-context-read {"path" "/nonexistent/path.clj"})]
+      (is (:isError result))
+      (is (re-find #"Error reading" (get-in result [:content 0 :text]))))))
+
+(deftest ^{:stratum 0} handle-context-grep-cache-hit-test
+  (testing "finds pattern in cached files"
+    (swap! cache/cache-state assoc-in [:files "src/alpha.clj"]
+           "(ns alpha)\n\n(defn greet [name]\n  (str name))")
+    (swap! cache/cache-state assoc-in [:files "src/beta.clj"]
+           "(ns beta)\n\n(defn process [x]\n  (inc x))")
+    (let [result (cache/handle-context-grep {"pattern" "defn greet"})]
+      (is (re-find #"alpha\.clj" (get-in result [:content 0 :text])))
+      (is (re-find #"defn greet" (get-in result [:content 0 :text]))))))
+
+(deftest ^{:stratum 0} handle-context-grep-specific-file-test
+  (testing "path restricts search to one file"
+    (swap! cache/cache-state assoc-in [:files "src/alpha.clj"]
+           "(defn greet [name] name)")
+    (swap! cache/cache-state assoc-in [:files "src/beta.clj"]
+           "(defn greet [user] user)")
+    (let [result (cache/handle-context-grep {"pattern" "defn" "path" "src/beta.clj"})]
+      (is (re-find #"beta\.clj" (get-in result [:content 0 :text])))
+      (is (not (re-find #"alpha\.clj" (get-in result [:content 0 :text])))))))
+
+(deftest ^{:stratum 0} handle-context-grep-glob-filter-test
+  (testing "glob filter restricts search"
+    (swap! cache/cache-state assoc-in [:files "src/core.clj"] "(defn foo [])")
+    (swap! cache/cache-state assoc-in [:files "test/core_test.clj"] "(deftest foo-test)")
+    (let [result (cache/handle-context-grep {"pattern" "def" "glob" "test/*.clj"})]
+      (is (re-find #"core_test\.clj" (get-in result [:content 0 :text])))
+      (is (not (re-find #"src/" (get-in result [:content 0 :text])))))))
+
+(deftest ^{:stratum 0} handle-context-grep-no-match-test
+  (testing "returns no matches message"
+    (swap! cache/cache-state assoc-in [:files "src/core.clj"] "(ns core)")
+    (let [result (cache/handle-context-grep {"pattern" "zzz_nonexistent_zzz"})]
+      (is (re-find #"[Nn]o matches" (get-in result [:content 0 :text]))))))
+
+(deftest ^{:stratum 0} handle-context-glob-cached-paths-test
+  (testing "matches cached file paths"
+    (swap! cache/cache-state assoc-in [:files "src/alpha.clj"] "a")
+    (swap! cache/cache-state assoc-in [:files "src/beta.clj"] "b")
+    (swap! cache/cache-state assoc-in [:files "test/alpha_test.clj"] "t")
+    (let [result (cache/handle-context-glob {"pattern" "src/*.clj"})
+          text (get-in result [:content 0 :text])]
+      (is (re-find #"alpha\.clj" text))
+      (is (re-find #"beta\.clj" text))
+      (is (not (re-find #"test/" text))))))
+
+(deftest ^{:stratum 0} handle-context-glob-no-match-test
+  (testing "returns no files matched message"
+    (let [result (cache/handle-context-glob {"pattern" "nonexistent/**/*.xyz"})]
+      (is (re-find #"[Nn]o files matched" (get-in result [:content 0 :text]))))))
+
+;------------------------------------------------------------------------------ Write-invalidation + cross-phase persistence (Fable #4)
+(defn- ^{:stratum 0} read-text [result]
+  (get-in result [:content 0 :text]))
+
+(deftest ^{:stratum 0} save-cache-noop-without-source-root-test
+  (testing "save-cache! is a safe no-op when there's no source-root"
+    (cache/reset-state!)
+    (swap! cache/cache-state assoc :files {"x" "y"})
+    (is (nil? (cache/save-cache!)) "no throw, nothing to persist without a worktree")))
+
+(deftest ^{:stratum 0} handle-context-write-rejects-bad-input-test
+  (cache/reset-state!)
+  (is (:isError (cache/handle-context-write {"path" "" "content" "x"}))
+      "blank path rejected")
+  (is (:isError (cache/handle-context-write {"path" "f" "content" nil}))
+      "nil content rejected"))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} handle-context-read-cache-miss-test
   (testing "falls back to filesystem and records miss"
     (with-temp-dir
       (fn [dir]
@@ -141,66 +209,8 @@
             (is (= 1 (count (:misses @cache/cache-state))))
             (is (= "context_read" (:tool (first (:misses @cache/cache-state)))))))))))
 
-(deftest handle-context-read-nonexistent-test
-  (testing "returns error for nonexistent file"
-    (let [result (cache/handle-context-read {"path" "/nonexistent/path.clj"})]
-      (is (:isError result))
-      (is (re-find #"Error reading" (get-in result [:content 0 :text]))))))
-
-(deftest handle-context-grep-cache-hit-test
-  (testing "finds pattern in cached files"
-    (swap! cache/cache-state assoc-in [:files "src/alpha.clj"]
-           "(ns alpha)\n\n(defn greet [name]\n  (str name))")
-    (swap! cache/cache-state assoc-in [:files "src/beta.clj"]
-           "(ns beta)\n\n(defn process [x]\n  (inc x))")
-    (let [result (cache/handle-context-grep {"pattern" "defn greet"})]
-      (is (re-find #"alpha\.clj" (get-in result [:content 0 :text])))
-      (is (re-find #"defn greet" (get-in result [:content 0 :text]))))))
-
-(deftest handle-context-grep-specific-file-test
-  (testing "path restricts search to one file"
-    (swap! cache/cache-state assoc-in [:files "src/alpha.clj"]
-           "(defn greet [name] name)")
-    (swap! cache/cache-state assoc-in [:files "src/beta.clj"]
-           "(defn greet [user] user)")
-    (let [result (cache/handle-context-grep {"pattern" "defn" "path" "src/beta.clj"})]
-      (is (re-find #"beta\.clj" (get-in result [:content 0 :text])))
-      (is (not (re-find #"alpha\.clj" (get-in result [:content 0 :text])))))))
-
-(deftest handle-context-grep-glob-filter-test
-  (testing "glob filter restricts search"
-    (swap! cache/cache-state assoc-in [:files "src/core.clj"] "(defn foo [])")
-    (swap! cache/cache-state assoc-in [:files "test/core_test.clj"] "(deftest foo-test)")
-    (let [result (cache/handle-context-grep {"pattern" "def" "glob" "test/*.clj"})]
-      (is (re-find #"core_test\.clj" (get-in result [:content 0 :text])))
-      (is (not (re-find #"src/" (get-in result [:content 0 :text])))))))
-
-(deftest handle-context-grep-no-match-test
-  (testing "returns no matches message"
-    (swap! cache/cache-state assoc-in [:files "src/core.clj"] "(ns core)")
-    (let [result (cache/handle-context-grep {"pattern" "zzz_nonexistent_zzz"})]
-      (is (re-find #"[Nn]o matches" (get-in result [:content 0 :text]))))))
-
-(deftest handle-context-glob-cached-paths-test
-  (testing "matches cached file paths"
-    (swap! cache/cache-state assoc-in [:files "src/alpha.clj"] "a")
-    (swap! cache/cache-state assoc-in [:files "src/beta.clj"] "b")
-    (swap! cache/cache-state assoc-in [:files "test/alpha_test.clj"] "t")
-    (let [result (cache/handle-context-glob {"pattern" "src/*.clj"})
-          text (get-in result [:content 0 :text])]
-      (is (re-find #"alpha\.clj" text))
-      (is (re-find #"beta\.clj" text))
-      (is (not (re-find #"test/" text))))))
-
-(deftest handle-context-glob-no-match-test
-  (testing "returns no files matched message"
-    (let [result (cache/handle-context-glob {"pattern" "nonexistent/**/*.xyz"})]
-      (is (re-find #"[Nn]o files matched" (get-in result [:content 0 :text]))))))
-
-;------------------------------------------------------------------------------ Layer 2
 ;; Lifecycle tests
-
-(deftest load-cache-roundtrip-test
+(deftest ^{:stratum 1} load-cache-roundtrip-test
   (testing "load-cache! reads context-cache.edn and populates atom"
     (with-temp-dir
       (fn [dir]
@@ -214,8 +224,7 @@
 ;; The submit/artifact.edn tests were removed with the submit tool — the
 ;; artifact is now the worktree/container diff (promotion), not an agent
 ;; metadata channel.
-
-(deftest handle-context-read-source-root-fallback-test
+(deftest ^{:stratum 1} handle-context-read-source-root-fallback-test
   (testing "relative file reads resolve from source-root when cache is empty"
     (with-temp-dir
       (fn [dir]
@@ -229,7 +238,7 @@
             (is (= "(ns demo.core)"
                    (get-in @cache/cache-state [:files "components/demo/core.clj"])))))))))
 
-(deftest handle-context-glob-source-root-fallback-test
+(deftest ^{:stratum 1} handle-context-glob-source-root-fallback-test
   (testing "relative glob fallback searches from source-root"
     (with-temp-dir
       (fn [dir]
@@ -241,7 +250,7 @@
             (is (re-find #"components/alpha/src/demo/core\.clj"
                          (get-in result [:content 0 :text])))))))))
 
-(deftest handle-context-glob-source-root-fallback-prunes-git-test
+(deftest ^{:stratum 1} handle-context-glob-source-root-fallback-prunes-git-test
   (testing "filesystem glob fallback ignores .git contents"
     (with-temp-dir
       (fn [dir]
@@ -256,7 +265,7 @@
             (is (re-find #"components/alpha/src/demo/core\.clj" text))
             (is (not (re-find #"\.git/objects/aa/hidden\.clj" text)))))))))
 
-(deftest flush-misses-roundtrip-test
+(deftest ^{:stratum 1} flush-misses-roundtrip-test
   (testing "flush-misses! writes misses to context-misses.edn"
     (with-temp-dir
       (fn [dir]
@@ -269,19 +278,14 @@
           (is (= "context_read" (:tool (first misses))))
           (is (= "src/x.clj" (:path (first misses)))))))))
 
-(deftest flush-misses-noop-when-empty-test
+(deftest ^{:stratum 1} flush-misses-noop-when-empty-test
   (testing "flush-misses! does not write file when no misses"
     (with-temp-dir
       (fn [dir]
         (cache/flush-misses! dir)
         (is (not (.exists (io/file (str dir "/context-misses.edn")))))))))
 
-;------------------------------------------------------------------------------ Write-invalidation + cross-phase persistence (Fable #4)
-
-(defn- read-text [result]
-  (get-in result [:content 0 :text]))
-
-(deftest read-through-invalidates-on-disk-change-test
+(deftest ^{:stratum 1} read-through-invalidates-on-disk-change-test
   (testing "a cached read is re-read when the file changes on disk — no stale
             content after a write (the safety guard for forcing write-heavy
             agents onto context_read, and for cross-phase persistence)"
@@ -299,7 +303,7 @@
           (is (= "V2" (read-text (cache/handle-context-read {"path" "src/a.clj"})))
               "second read returns fresh V2, not the stale cached V1"))))))
 
-(deftest save-cache-persists-across-phases-test
+(deftest ^{:stratum 1} save-cache-persists-across-phases-test
   (testing "save-cache! writes the accumulated cache to <source-root>/.miniforge,
             and a fresh load (next phase) picks it up"
     (with-temp-dir
@@ -320,16 +324,8 @@
           (is (contains? (:mtimes @cache/cache-state) "src/b.clj")
               "its mtime is restored so staleness is still detectable"))))))
 
-(deftest save-cache-noop-without-source-root-test
-  (testing "save-cache! is a safe no-op when there's no source-root"
-    (cache/reset-state!)
-    (swap! cache/cache-state assoc :files {"x" "y"})
-    (is (nil? (cache/save-cache!)) "no throw, nothing to persist without a worktree")))
-
-;------------------------------------------------------------------------------ Layer 3
 ;; context_write handler
-
-(deftest handle-context-write-writes-to-workdir-and-caches-test
+(deftest ^{:stratum 1} handle-context-write-writes-to-workdir-and-caches-test
   (with-temp-dir
     (fn [dir]
       (cache/reset-state!)
@@ -342,7 +338,7 @@
           (let [read-resp (cache/handle-context-read {"path" "src/new.clj"})]
             (is (= "(ns new)" (-> read-resp :content first :text)))))))))
 
-(deftest handle-context-write-overwrites-existing-test
+(deftest ^{:stratum 1} handle-context-write-overwrites-existing-test
   (with-temp-dir
     (fn [dir]
       (cache/reset-state!)
@@ -354,14 +350,7 @@
         (is (= "(ns a-v2)" (-> (cache/handle-context-read {"path" "a.clj"}) :content first :text))
             "an existing file is edited and the cache reflects it")))))
 
-(deftest handle-context-write-rejects-bad-input-test
-  (cache/reset-state!)
-  (is (:isError (cache/handle-context-write {"path" "" "content" "x"}))
-      "blank path rejected")
-  (is (:isError (cache/handle-context-write {"path" "f" "content" nil}))
-      "nil content rejected"))
-
-(deftest handle-context-write-rejects-path-escapes-test
+(deftest ^{:stratum 1} handle-context-write-rejects-path-escapes-test
   (with-temp-dir
     (fn [dir]
       (cache/reset-state!)
@@ -374,3 +363,28 @@
         (is (:isError (cache/handle-context-write
                        {"path" "/tmp/abs-escape.clj" "content" "x"})))
         (is (not (.exists (io/file "/tmp/abs-escape.clj"))))))))
+
+(deftest ^{:stratum 1} context-reads-are-recorded-hits-and-misses-test
+  (cache/reset-state!)
+  ;; A virtual pin path: present in the cache, no file on disk. cache-stale?
+  ;; never fires for it, so it resolves as a :cache hit forever — the pin
+  ;; primitive the Codex SPEC §7.4 blackboard pin relies on.
+  (swap! cache/cache-state assoc-in
+         [:files ".miniforge/codex-consider.md"] "pinned landings")
+  (cache/handle-context-read {"path" ".miniforge/codex-consider.md"})
+  (cache/handle-context-read {"path" "no/such/file.txt"})
+  (let [reads (:reads @cache/cache-state)]
+    (is (= [{:path ".miniforge/codex-consider.md" :source :cache}
+            {:path "no/such/file.txt" :source :absent}]
+           (mapv #(select-keys % [:path :source]) reads))
+        "every resolution recorded, hit and miss (§7.4.2)")
+    (is (every? :timestamp reads)))
+  (testing "flush writes context-reads.edn"
+    (with-temp-dir
+      (fn [dir]
+        (cache/flush-reads! dir)
+        (let [f (io/file (str dir "/context-reads.edn"))]
+          (is (.exists f))
+          (is (= 2 (count (edn/read-string (slurp f))))))))))
+
+(use-fixtures :each with-clean-cache)

--- a/components/agent/src/ai/miniforge/agent/artifact_session.clj
+++ b/components/agent/src/ai/miniforge/agent/artifact_session.clj
@@ -1017,6 +1017,12 @@
    'did this agent consult its pinned codex landings' an answerable
    question (Codex SPEC §7.4.2).
 
+   HOST MODE ONLY, same as `read-context-misses`: in capsule mode the
+   server writes the file inside the container and surfacing it needs an
+   executor round-trip (the same trade-off already accepted for capsule
+   worktree artifacts). Until that lands, capsule sessions return nil here
+   — absent data, not evidence the agent read nothing.
+
    Returns: vector of read records, or nil if no reads file."
   [session]
   (let [path (str (:dir session) "/context-reads.edn")

--- a/components/agent/src/ai/miniforge/agent/artifact_session.clj
+++ b/components/agent/src/ai/miniforge/agent/artifact_session.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.agent.artifact-session
   "MCP artifact session management.
 
@@ -40,16 +39,16 @@
    [java.nio.file.attribute FileAttribute]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Schema & session lifecycle
 
-(def Session
+;; Schema & session lifecycle
+(def ^{:stratum 0} Session
   "Schema for an artifact session map."
   [:map
    [:dir [:string {:min 1}]]
    [:mcp-config-path [:string {:min 1}]]
    [:artifact-path [:string {:min 1}]]])
 
-(def ^:private system-message-templates
+(def ^{:stratum 0} ^:private system-message-templates
   "System-localized stderr message templates for artifact-session I/O."
   {:warn/worktree-artifact-parse
    "WARN: failed to parse worktree artifact at %s — %s"
@@ -66,20 +65,13 @@
    :warn/context-misses-parse
    "WARN: failed to parse context misses at %s — %s"
 
+   :warn/context-reads-parse
+   "WARN: failed to parse context reads at %s — %s"
+
    :info/mcp-artifact-skipped
    "INFO: MCP artifact not submitted — worktree-promotion succeeded (workdir: %s)"})
 
-(defn validate-session
-  "Validate a session map against the Session schema.
-
-   Returns {:valid? true} or {:valid? false :errors ...}."
-  [session]
-  (if (m/validate Session session)
-    {:valid? true}
-    {:valid? false
-     :errors (m/explain Session session)}))
-
-(defn command-on-path?
+(defn ^{:stratum 0} command-on-path?
   "Check if a command exists on PATH."
   [cmd]
   (try
@@ -87,7 +79,7 @@
       (zero? (.waitFor proc)))
     (catch Exception _ false)))
 
-(defn- find-bb-root
+(defn- ^{:stratum 0} find-bb-root
   "Find the nearest ancestor directory containing bb.edn."
   []
   (loop [dir (.getCanonicalFile (io/file (System/getProperty "user.dir")))]
@@ -97,99 +89,18 @@
         (nil? (.getParentFile dir)) nil
         :else (recur (.getParentFile dir))))))
 
-(defn resolve-miniforge-command
-  "Resolve the miniforge command to use for spawning subprocesses.
-
-   Resolution order:
-   1. MINIFORGE_CMD env var (explicit override, e.g. \"/usr/local/bin/mf\")
-   2. [\"bb\" \"--config\" <root>/bb.edn \"--deps-root\" <root> \"miniforge\"]
-      (dev mode — location-independent bb.edn task)
-   3. \"miniforge\" on PATH (installed binary)
-   4. [\"bb\" \"miniforge\"] as a final fallback"
-  []
-  (let [bb-root (find-bb-root)]
-    (cond
-      ;; 1. Explicit override
-      (System/getenv "MINIFORGE_CMD")
-      [(System/getenv "MINIFORGE_CMD")]
-
-      ;; 2. Prefer the current workspace in development and tests.
-      bb-root
-      ["bb" "--config" (str bb-root "/bb.edn") "--deps-root" bb-root "miniforge"]
-
-      ;; 3. Installed binary on PATH
-      (command-on-path? "miniforge")
-      ["miniforge"]
-
-      ;; 4. Last-resort fallback
-      :else
-      ["bb" "miniforge"])))
-
-(defn- emit-system-message!
-  "Render a system-scoped stderr message from a shared template."
-  [message-key & args]
-  (binding [*out* *err*]
-    (println (apply format (get system-message-templates message-key) args))))
-
-(defn- artifact-filename
+(defn- ^{:stratum 0} artifact-filename
   "Canonical filename for a role artifact in .miniforge/."
   [role]
   (str (name role) ".edn"))
 
-(defn- worktree-artifact-file
-  "Resolve the canonical .miniforge artifact file for a role."
-  [workdir role]
-  (io/file workdir ".miniforge" (artifact-filename role)))
-
-(defn- parse-edn-content
-  "Parse EDN content with a transform, logging failures as system messages."
-  [content transform warning-key path]
-  (try
-    (-> content
-        transform)
-    (catch Exception e
-      (emit-system-message! warning-key path (ex-message e))
-      nil)))
-
-(defn- parse-edn-file
-  "Read and parse an EDN file with a transform, logging failures consistently."
-  [f transform warning-key]
-  (parse-edn-content (slurp f) transform warning-key (.getPath f)))
-
-(def ^:private codex-artifact-table-pattern
+(def ^{:stratum 0} ^:private codex-artifact-table-pattern
   #"^\[mcp_servers\.artifact(?:\..+)?\]\s*$")
 
-(def ^:private toml-table-pattern
+(def ^{:stratum 0} ^:private toml-table-pattern
   #"^\[[^]]+\]\s*$")
 
-(defn- strip-codex-artifact-config
-  "Remove the full mcp_servers.artifact subtree from a Codex TOML config.
-
-   This strips both the root server block and any nested tables such as
-   [mcp_servers.artifact.tools.context_read], which newer Codex builds treat
-   as invalid if the parent server definition has already been removed."
-  [content]
-  (let [lines (str/split-lines content)]
-    (loop [remaining lines
-           cleaned []
-           skipping? false]
-      (if-let [line (first remaining)]
-        (let [trimmed (str/trim line)]
-          (cond
-            (re-matches codex-artifact-table-pattern trimmed)
-            (recur (rest remaining) cleaned true)
-
-            (and skipping? (re-matches toml-table-pattern trimmed))
-            (recur remaining cleaned false)
-
-            skipping?
-            (recur (rest remaining) cleaned true)
-
-            :else
-            (recur (rest remaining) (conj cleaned line) false)))
-        (str/join "\n" cleaned)))))
-
-(defn create-session!
+(defn ^{:stratum 0} create-session!
   "Create a new artifact session with a temporary directory.
 
    Optionally accepts a workdir override (e.g., a git worktree path) for
@@ -230,10 +141,313 @@
                                 (file-artifacts/empty-snapshot)
                                 snap))})))
 
-;------------------------------------------------------------------------------ Layer 1
-;; MCP server command
+(defn ^{:stratum 0} write-cursor-mcp-config!
+  "Write or update .cursor/mcp.json with mcpServers.artifact entry.
 
-(defn server-command
+   If the file exists, merges into existing JSON. Creates .cursor/ dir if needed.
+
+   Returns the path to the config file."
+  [config-root server-cmd]
+  (let [{:keys [command args]} server-cmd
+        root (or config-root (System/getProperty "user.dir"))
+        dir (io/file root ".cursor")
+        config-file (io/file dir "mcp.json")
+        entry {"command" command "args" args}
+        existing (when (.exists config-file)
+                   (try (json/parse-string (slurp config-file))
+                        (catch Exception _ {})))
+        config (assoc-in (or existing {}) ["mcpServers" "artifact"] entry)]
+    (.mkdirs dir)
+    (spit config-file (json/generate-string config {:pretty true}))
+    (str config-file)))
+
+(defn- ^{:stratum 0} mcp-tool->cursor-permission
+  "Translate one agent-agnostic `mcp-tools` entry into a Cursor permission
+   rule string (https://cursor.com/docs/cli/reference/permissions).
+
+     {:mcp/server S :mcp/tool T} -> \"Mcp(S:T)\"
+     :Write / :Edit / :MultiEdit -> \"Write(**)\"  (Cursor models all edits
+                                                    as writes; no Edit primitive)
+
+   Returns nil for entries with no Cursor analog."
+  [tool]
+  (cond
+    (map? tool)
+    (format "Mcp(%s:%s)" (name (:mcp/server tool)) (name (:mcp/tool tool)))
+
+    (#{:Write :Edit :MultiEdit} tool)
+    "Write(**)"
+
+    :else nil))
+
+(def ^{:stratum 0} cursor-permission-deny
+  "Hard denials applied regardless of the allowlist. Deny takes precedence
+   over allow in Cursor, so these block secret writes even when Write(**) is
+   allowed. Globs follow Cursor's documented Write(pathOrGlob) form."
+  ["Write(**/.env*)" "Write(**/*.key)" "Write(**/*.pem)"])
+
+(def ^{:stratum 0} ^:private cursor-write-tools
+  "Native tools that Cursor collapses into the single Write(**) permission.
+   Cursor cannot express a partial write restriction, so disallowing any one
+   of these drops the whole write permission."
+  #{:Write :Edit :MultiEdit})
+
+(def ^{:stratum 0} ^:private cursor-permissions-backup-suffix
+  "Suffix for the pre-session .cursor/cli.json snapshot used to restore the
+   user's exact file on cleanup."
+  ".mf-bak")
+
+(def ^{:stratum 0} mcp-tools
+  "Tools the inner agent is auto-approved to call, as generic data.
+
+   Each backend adapter (claude, codex, cursor-agent, …) translates
+   this into the allowlist / approval shape its CLI expects. Keep
+   agent-CLI-agnostic — the structured form is the source of truth.
+
+   Two entry shapes:
+   - `{:mcp/server :mcp/tool}` — a tool exposed by an MCP server
+   - plain keyword — a native tool from the agent CLI (e.g. `:Write`,
+     needed for plan.edn / code container-promotion writes)
+
+   Example wire formats per backend:
+     claude  → --allowedTools \"mcp__context__context_read,Write,...\"
+     cursor  → --approve-mcps  (blanket approve; no names needed)
+     codex   → (currently unused; codex uses its own MCP config)
+
+   Iter-10 failure — bare names like `context_read` were passed to
+   --allowedTools without the `mcp__<server>__` prefix, so every MCP
+   call got permission-denied. Iter-15 follow-on — `Write` wasn't in
+   the allowlist at all, so the planner's `.miniforge/plan.edn`
+   Write was silently denied (model then narrated 'let me try Edit'
+   and stalled). 2026-05-04 follow-on — `Edit` / `MultiEdit` were
+   never added either; the implementer in the
+   event-log-tool-visibility dogfood spent five repair iters
+   producing patch text the CLI refused to apply, then a sixth
+   iter discovered Write worked while Edit did not. Both issues trace
+   back to keeping the structured form honest and adapters translating
+   at the CLI boundary."
+  ;; No `:submit` — the artifact is the worktree/container diff (promotion),
+  ;; the definitive channel. Models trained to their native tools ignore an
+  ;; opt-in submit tool anyway (84:0 in dogfood), and a submit-without-files
+  ;; turn is exactly the empty-disk failure we want to eliminate. Files are
+  ;; the def; the curator derives the summary from the diff.
+  [{:mcp/server :context :mcp/tool :context_read}
+   {:mcp/server :context :mcp/tool :context_grep}
+   {:mcp/server :context :mcp/tool :context_glob}
+   ;; Thesium Codex pull surface (SPEC §7.1). Push delivery is the
+   ;; phase-start pin (phase-software-factory codex-pin); this lets an
+   ;; agent RE-consult mid-run for a different situation.
+   {:mcp/server :context :mcp/tool :consider_situation}
+   ;; Agent-agnostic edit path: writes to the worktree + refreshes the cache,
+   ;; needs no prior native Read. The reliable way to modify EXISTING files
+   ;; across Claude/Codex/Cursor (native Write/Edit require a prior Read, which
+   ;; the implementer disallows to force the cache).
+   {:mcp/server :context :mcp/tool :context_write}
+   ;; Native write tools: implementer needs all three patch shapes.
+   ;; `Write` for full-file rewrites (planner's plan.edn, implementer
+   ;; new files, releaser PR drafts). `Edit` for single-region patches.
+   ;; `MultiEdit` for batched edits within one file. Roles that shouldn't
+   ;; modify files filter via :disallowed-tools separately.
+   :Write
+   :Edit
+   :MultiEdit])
+
+(defn ^{:stratum 0} write-context-cache!
+  "Write context cache EDN to the session directory.
+
+   The MCP artifact server loads this on startup and uses it as
+   a read-through cache for context_read/context_grep/context_glob tools.
+
+   Arguments:
+   - session - Session map from create-session!
+   - files   - Map of {relative-path content-string}
+
+   Returns: session (for threading)"
+  [session files]
+  (when (seq files)
+    (let [path (str (:dir session) "/context-cache.edn")]
+      (spit path (pr-str {:files files}))))
+  session)
+
+(defn ^{:stratum 0} write-capsule-context-cache!
+  "Write context cache EDN inside the capsule via executor.
+   Capsule variant of write-context-cache! for governed mode."
+  [session files]
+  (when (seq files)
+    (let [path    (str (:dir session) "/context-cache.edn")
+          content (pr-str {:files files})]
+      ((:exec! session) (:executor session) (:environment-id session)
+                        (str "cat > " path " << 'CACHEEOF'\n" content "\nCACHEEOF")
+                        {:workdir (:workdir session)})))
+  session)
+
+;; Artifact reading
+(defn ^{:stratum 0} uuid-str?
+  "Check if a value is a UUID-shaped string."
+  [v]
+  (and (string? v)
+       (re-matches #"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}" v)))
+
+(defn ^{:stratum 0} instant-str?
+  "Check if a value looks like an ISO instant string."
+  [v]
+  (and (string? v)
+       (re-matches #"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.*" v)))
+
+(defn ^{:stratum 0} key-ends-with?
+  "Check if a namespaced keyword ends with the given suffix."
+  [k suffix]
+  (and (keyword? k)
+       (str/ends-with? (name k) suffix)))
+
+(defn ^{:stratum 0} cleanup-cursor-mcp-config!
+  "Remove artifact key from .cursor/mcp.json.
+   Deletes the file if mcpServers becomes empty."
+  [path]
+  (let [f (io/file path)]
+    (when (.exists f)
+      (try
+        (let [config (json/parse-string (slurp f))
+              servers (dissoc (get config "mcpServers" {}) "artifact")
+              config' (if (empty? servers)
+                        (dissoc config "mcpServers")
+                        (assoc config "mcpServers" servers))]
+          (if (empty? config')
+            (.delete f)
+            (spit f (json/generate-string config' {:pretty true}))))
+        (catch Exception _ nil)))))
+
+;------------------------------------------------------------------------------ Layer 2.5
+;; Capsule-aware session lifecycle (N11 §6.3-6.4)
+(defn- ^{:stratum 0} missing-execute-fn!
+  []
+  (throw (ex-info "Capsule artifact sessions require :execution/execute-fn"
+                  {:missing :execution/execute-fn
+                   :component :agent/artifact-session})))
+
+(defn ^{:stratum 0} cleanup-capsule-session!
+  "Remove the session directory inside the capsule."
+  [session]
+  (try
+    ((:exec! session) (:executor session) (:environment-id session)
+                      (str "rm -rf " (:dir session)) {:workdir (:workdir session)})
+    (catch Exception _ nil)))
+
+;------------------------------------------------------------------------------ Layer 2.75
+;; Session → MCP opts
+(defn ^{:stratum 0} session->mcp-opts
+  "Build the base MCP options map from a session for LLM chat calls.
+   Callers merge role-specific keys (e.g. :model, :disallowed-tools, :workdir)."
+  [session budget-usd max-turns]
+  {:mcp-config        (:mcp-config-path session)
+   :mcp-allowed-tools (:mcp-allowed-tools session)
+   :supervision       (:supervision session)
+   :budget-usd        budget-usd
+   :max-turns         max-turns})
+
+;; Unified session dispatch (N11 §6.3)
+(defn ^{:stratum 0} governed?
+  "True when the execution context requires governed (capsule) mode.
+   Checks :execution/mode is :governed and executor + environment-id are present."
+  [context]
+  (and (= :governed (:execution/mode context))
+       (some? (:execution/executor context))
+       (some? (:execution/environment-id context))))
+
+(def ^{:stratum 0} ^:private worktree-roles
+  "Roles whose `.miniforge/<role>.edn` files `run-session` probes for
+   worktree-promoted artifacts. Single source of truth for both the
+   scan and the no-artifact-found diagnostic."
+  [:plan :implement :verify :review :release])
+
+(defn- ^{:stratum 0} read-role-entry
+  "Read the worktree artifact for `role` via `read-role-artifact` and
+   return a `[role artifact]` map entry, or nil if the role file was
+   absent (so callers can use `keep` to drop misses)."
+  [read-role-artifact role]
+  (when-let [a (read-role-artifact role)]
+    [role a]))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} validate-session
+  "Validate a session map against the Session schema.
+
+   Returns {:valid? true} or {:valid? false :errors ...}."
+  [session]
+  (if (m/validate Session session)
+    {:valid? true}
+    {:valid? false
+     :errors (m/explain Session session)}))
+
+(defn ^{:stratum 1} resolve-miniforge-command
+  "Resolve the miniforge command to use for spawning subprocesses.
+
+   Resolution order:
+   1. MINIFORGE_CMD env var (explicit override, e.g. \"/usr/local/bin/mf\")
+   2. [\"bb\" \"--config\" <root>/bb.edn \"--deps-root\" <root> \"miniforge\"]
+      (dev mode — location-independent bb.edn task)
+   3. \"miniforge\" on PATH (installed binary)
+   4. [\"bb\" \"miniforge\"] as a final fallback"
+  []
+  (let [bb-root (find-bb-root)]
+    (cond
+      ;; 1. Explicit override
+      (System/getenv "MINIFORGE_CMD")
+      [(System/getenv "MINIFORGE_CMD")]
+
+      ;; 2. Prefer the current workspace in development and tests.
+      bb-root
+      ["bb" "--config" (str bb-root "/bb.edn") "--deps-root" bb-root "miniforge"]
+
+      ;; 3. Installed binary on PATH
+      (command-on-path? "miniforge")
+      ["miniforge"]
+
+      ;; 4. Last-resort fallback
+      :else
+      ["bb" "miniforge"])))
+
+(defn- ^{:stratum 1} emit-system-message!
+  "Render a system-scoped stderr message from a shared template."
+  [message-key & args]
+  (binding [*out* *err*]
+    (println (apply format (get system-message-templates message-key) args))))
+
+(defn- ^{:stratum 1} worktree-artifact-file
+  "Resolve the canonical .miniforge artifact file for a role."
+  [workdir role]
+  (io/file workdir ".miniforge" (artifact-filename role)))
+
+(defn- ^{:stratum 1} strip-codex-artifact-config
+  "Remove the full mcp_servers.artifact subtree from a Codex TOML config.
+
+   This strips both the root server block and any nested tables such as
+   [mcp_servers.artifact.tools.context_read], which newer Codex builds treat
+   as invalid if the parent server definition has already been removed."
+  [content]
+  (let [lines (str/split-lines content)]
+    (loop [remaining lines
+           cleaned []
+           skipping? false]
+      (if-let [line (first remaining)]
+        (let [trimmed (str/trim line)]
+          (cond
+            (re-matches codex-artifact-table-pattern trimmed)
+            (recur (rest remaining) cleaned true)
+
+            (and skipping? (re-matches toml-table-pattern trimmed))
+            (recur remaining cleaned false)
+
+            skipping?
+            (recur (rest remaining) cleaned true)
+
+            :else
+            (recur (rest remaining) (conj cleaned line) false)))
+        (str/join "\n" cleaned)))))
+
+;; MCP server command
+(defn ^{:stratum 1} server-command
   "Build the MCP context server command for a given session directory.
 
    Returns {:command <string> :args [<string> ...]} suitable for MCP config JSON.
@@ -273,10 +487,189 @@
       :else
       {:command "miniforge" :args (into ["context-server"] mcp-args)}))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; MCP config generation
+(defn ^{:stratum 1} cursor-permission-allow
+  "Cursor `allow` rules for a session: the auto-approved `mcp-tools`, minus
+   any native tool the role disallows, translated to Cursor rule strings.
 
-(defn write-codex-mcp-config!
+   Default-deny: Cursor sees only this allowlist, so shell, arbitrary file
+   reads, and other MCP servers are denied by omission — no wildcard needed.
+
+   Cursor maps Write/Edit/MultiEdit onto one Write(**) rule, so disallowing
+   ANY of them drops Write(**) entirely (a finer-grained Claude distinction
+   like 'Edit-but-not-Write' cannot be represented here)."
+  [allowed-tools disallowed-tools]
+  (let [disallowed     (set (map name disallowed-tools))
+        write-blocked? (some #(contains? disallowed (name %)) cursor-write-tools)
+        keep?          (fn [tool]
+                         (cond
+                           (map? tool)               true
+                           (cursor-write-tools tool) (not write-blocked?)
+                           :else                     (not (contains? disallowed (name tool)))))]
+    (->> allowed-tools
+         (filter keep?)
+         (keep mcp-tool->cursor-permission)
+         distinct
+         vec)))
+
+(defn ^{:stratum 1} backup-cursor-permissions!
+  "Snapshot a pre-existing .cursor/cli.json once, before miniforge mutates
+   it, so cleanup can restore it byte-for-byte.
+
+   No-op when the file is absent (cleanup then just deletes the file we
+   generate) or when a snapshot already exists (so mid-session rewrites never
+   clobber the original). Returns the backup path or nil."
+  [config-root]
+  (let [root        (or config-root (System/getProperty "user.dir"))
+        config-file (io/file root ".cursor" "cli.json")
+        backup-file (io/file root ".cursor" (str "cli.json" cursor-permissions-backup-suffix))]
+    (when (and (.exists config-file) (not (.exists backup-file)))
+      (io/copy config-file backup-file)
+      (str backup-file))))
+
+(defn ^{:stratum 1} write-context-cache-for-session!
+  "Write context cache to the appropriate location based on session type.
+   Dispatches to capsule or host variant based on :capsule? flag."
+  [session files]
+  (if (:capsule? session)
+    (write-capsule-context-cache! session files)
+    (write-context-cache! session files)))
+
+(defn ^{:stratum 1} parse-uuid-strings
+  "Convert string UUIDs and ISO instant strings in an artifact map.
+   The MCP server writes UUIDs and instants as strings since it runs in babashka.
+
+   Pattern-based detection:
+   - Any key ending in `/id` with a UUID-shaped string → java.util.UUID
+   - Any key ending in `/created-at` with an ISO instant string → java.util.Date
+   - Any vector of maps containing `:task/id` → recurse into those maps"
+  [m]
+  (cond
+    (map? m)
+    (into {}
+          (map (fn [[k v]]
+                 [k (cond
+                      ;; Any key ending in /id with a UUID string
+                      (and (key-ends-with? k "id") (uuid-str? v))
+                      (java.util.UUID/fromString v)
+
+                      ;; Any key ending in /created-at with an instant string
+                      (and (key-ends-with? k "created-at") (instant-str? v))
+                      (try (java.util.Date/from (java.time.Instant/parse v))
+                           (catch Exception _ (java.util.Date.)))
+
+                      ;; Vector of maps that may contain nested UUIDs/instants
+                      (and (vector? v) (seq v) (map? (first v)))
+                      (mapv (fn [item]
+                              (parse-uuid-strings item))
+                            v)
+
+                      :else v)]))
+          m)
+
+    :else m))
+
+(defn ^{:stratum 1} cleanup-cursor-permissions!
+  "Restore .cursor/cli.json to its exact pre-session contents.
+
+   If `backup-cursor-permissions!` captured a snapshot (the file pre-existed),
+   move it back over our generated file; otherwise delete the file miniforge
+   created. Fully non-destructive — user/project rules are byte-preserved
+   regardless of any overlap with managed rules."
+  [path]
+  (try
+    (let [config-file (io/file path)
+          backup-file (io/file (str path cursor-permissions-backup-suffix))]
+      (cond
+        (.exists backup-file)
+        (do (io/copy backup-file config-file)
+            (.delete backup-file))
+
+        (.exists config-file)
+        (.delete config-file)))
+    (catch Exception _ nil)))
+
+(defn ^{:stratum 1} create-capsule-session!
+  "Create an artifact session inside a task capsule.
+   Session directory is created inside the capsule's workspace via executor.
+   Returns session map with capsule-relative paths and resolved exec! fn.
+
+   Three-arity form fails with a configuration error because agent must not
+   reach upward into dag-executor. Four-arity form accepts the execute-fn
+   injected by workflow."
+  ([executor env-id workdir]
+   (create-capsule-session! executor env-id workdir (missing-execute-fn!)))
+  ([executor env-id workdir execute-fn]
+   (let [exec!       execute-fn
+         session-dir (str workdir "/.miniforge-session")
+         _           (exec! executor env-id (str "mkdir -p " session-dir) {:workdir workdir})]
+     {:dir               session-dir
+      :mcp-config-path   (str session-dir "/mcp-config.json")
+      :artifact-path     (str session-dir "/artifact.edn")
+      :capsule?          true
+      :explicit-workdir? true
+      :exec!             exec!
+      :executor          executor
+      :environment-id    env-id
+      :workdir           workdir
+      :pre-session-snapshot (try
+                              (file-artifacts/snapshot-via-executor
+                               exec! executor env-id workdir)
+                              (catch Exception _
+                                (file-artifacts/empty-snapshot)))})))
+
+(defn ^{:stratum 1} write-capsule-mcp-config!
+  "Write MCP config and Claude settings inside the capsule.
+   The server command resolves to capsule-local bb/miniforge binary."
+  [session]
+  (let [exec!       (:exec! session)
+        executor    (:executor session)
+        env-id      (:environment-id session)
+        session-dir (:dir session)
+        ;; Inside the capsule, bb and miniforge are available directly
+        srv-cmd     {:command "bb" :args ["miniforge" "mcp-context-server"
+                                          "--artifact-dir" session-dir]}
+        mcp-config  (json/generate-string
+                     {"mcpServers" {"context" {"command" (:command srv-cmd)
+                                               "args"    (:args srv-cmd)}}}
+                     {:pretty true})
+        hook-cmd    "bb miniforge hook-eval"
+        settings    (json/generate-string
+                     {"hooks" {"PreToolUse" [{"type" "command" "command" hook-cmd}]}}
+                     {:pretty true})]
+    ;; Write configs inside capsule
+    (exec! executor env-id (str "cat > " (:mcp-config-path session) " << 'MCPEOF'\n" mcp-config "\nMCPEOF")
+           {:workdir (:workdir session)})
+    (exec! executor env-id (str "cat > " session-dir "/claude-settings.json << 'SETTINGSEOF'\n" settings "\nSETTINGSEOF")
+           {:workdir (:workdir session)})
+    (assoc session
+           :mcp-allowed-tools mcp-tools
+           :supervision {:hook-eval-cmd hook-cmd
+                         :settings-path (str session-dir "/claude-settings.json")
+                         :policy :workspace-write})))
+
+(defn- ^{:stratum 1} collect-worktree-artifacts
+  "Build the `:worktree-artifacts` map by probing every role file under
+   `workdir`/.miniforge/. Returns nil when `workdir` is absent so callers
+   can distinguish 'no worktree was threaded through' from 'worktree had
+   no role files'."
+  [read-role-artifact workdir]
+  (when workdir
+    (into {} (keep #(read-role-entry read-role-artifact %)) worktree-roles)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- ^{:stratum 2} parse-edn-content
+  "Parse EDN content with a transform, logging failures as system messages."
+  [content transform warning-key path]
+  (try
+    (-> content
+        transform)
+    (catch Exception e
+      (emit-system-message! warning-key path (ex-message e))
+      nil)))
+
+;; MCP config generation
+(defn ^{:stratum 2} write-codex-mcp-config!
   "Write or update .codex/config.toml with [mcp_servers.artifact] block.
 
    If the file exists and already has an [mcp_servers.artifact] block,
@@ -310,82 +703,7 @@
       (spit config-file block))
     (str config-file)))
 
-(defn write-cursor-mcp-config!
-  "Write or update .cursor/mcp.json with mcpServers.artifact entry.
-
-   If the file exists, merges into existing JSON. Creates .cursor/ dir if needed.
-
-   Returns the path to the config file."
-  [config-root server-cmd]
-  (let [{:keys [command args]} server-cmd
-        root (or config-root (System/getProperty "user.dir"))
-        dir (io/file root ".cursor")
-        config-file (io/file dir "mcp.json")
-        entry {"command" command "args" args}
-        existing (when (.exists config-file)
-                   (try (json/parse-string (slurp config-file))
-                        (catch Exception _ {})))
-        config (assoc-in (or existing {}) ["mcpServers" "artifact"] entry)]
-    (.mkdirs dir)
-    (spit config-file (json/generate-string config {:pretty true}))
-    (str config-file)))
-
-(defn- mcp-tool->cursor-permission
-  "Translate one agent-agnostic `mcp-tools` entry into a Cursor permission
-   rule string (https://cursor.com/docs/cli/reference/permissions).
-
-     {:mcp/server S :mcp/tool T} -> \"Mcp(S:T)\"
-     :Write / :Edit / :MultiEdit -> \"Write(**)\"  (Cursor models all edits
-                                                    as writes; no Edit primitive)
-
-   Returns nil for entries with no Cursor analog."
-  [tool]
-  (cond
-    (map? tool)
-    (format "Mcp(%s:%s)" (name (:mcp/server tool)) (name (:mcp/tool tool)))
-
-    (#{:Write :Edit :MultiEdit} tool)
-    "Write(**)"
-
-    :else nil))
-
-(def cursor-permission-deny
-  "Hard denials applied regardless of the allowlist. Deny takes precedence
-   over allow in Cursor, so these block secret writes even when Write(**) is
-   allowed. Globs follow Cursor's documented Write(pathOrGlob) form."
-  ["Write(**/.env*)" "Write(**/*.key)" "Write(**/*.pem)"])
-
-(def ^:private cursor-write-tools
-  "Native tools that Cursor collapses into the single Write(**) permission.
-   Cursor cannot express a partial write restriction, so disallowing any one
-   of these drops the whole write permission."
-  #{:Write :Edit :MultiEdit})
-
-(defn cursor-permission-allow
-  "Cursor `allow` rules for a session: the auto-approved `mcp-tools`, minus
-   any native tool the role disallows, translated to Cursor rule strings.
-
-   Default-deny: Cursor sees only this allowlist, so shell, arbitrary file
-   reads, and other MCP servers are denied by omission — no wildcard needed.
-
-   Cursor maps Write/Edit/MultiEdit onto one Write(**) rule, so disallowing
-   ANY of them drops Write(**) entirely (a finer-grained Claude distinction
-   like 'Edit-but-not-Write' cannot be represented here)."
-  [allowed-tools disallowed-tools]
-  (let [disallowed     (set (map name disallowed-tools))
-        write-blocked? (some #(contains? disallowed (name %)) cursor-write-tools)
-        keep?          (fn [tool]
-                         (cond
-                           (map? tool)               true
-                           (cursor-write-tools tool) (not write-blocked?)
-                           :else                     (not (contains? disallowed (name tool)))))]
-    (->> allowed-tools
-         (filter keep?)
-         (keep mcp-tool->cursor-permission)
-         distinct
-         vec)))
-
-(defn write-cursor-permissions!
+(defn ^{:stratum 2} write-cursor-permissions!
   "Write .cursor/cli.json with a default-deny permission allowlist.
 
    `allowed-tools` is the agent-agnostic auto-approve set (`mcp-tools`);
@@ -418,39 +736,7 @@
     (spit config-file (json/generate-string config {:pretty true}))
     (str config-file)))
 
-(def ^:private cursor-permissions-backup-suffix
-  "Suffix for the pre-session .cursor/cli.json snapshot used to restore the
-   user's exact file on cleanup."
-  ".mf-bak")
-
-(defn backup-cursor-permissions!
-  "Snapshot a pre-existing .cursor/cli.json once, before miniforge mutates
-   it, so cleanup can restore it byte-for-byte.
-
-   No-op when the file is absent (cleanup then just deletes the file we
-   generate) or when a snapshot already exists (so mid-session rewrites never
-   clobber the original). Returns the backup path or nil."
-  [config-root]
-  (let [root        (or config-root (System/getProperty "user.dir"))
-        config-file (io/file root ".cursor" "cli.json")
-        backup-file (io/file root ".cursor" (str "cli.json" cursor-permissions-backup-suffix))]
-    (when (and (.exists config-file) (not (.exists backup-file)))
-      (io/copy config-file backup-file)
-      (str backup-file))))
-
-(defn write-cursor-permissions-for-session!
-  "Rewrite the session's .cursor/cli.json allowlist with a role's
-   `disallowed-tools` applied (e.g. a reviewer that must not Write).
-
-   No-op for capsule sessions — Cursor configs are host-only. Returns the
-   path, or nil when skipped."
-  [session disallowed-tools]
-  (when-not (:capsule? session)
-    (write-cursor-permissions! (:config-root session)
-                               (:mcp-allowed-tools session)
-                               disallowed-tools)))
-
-(defn write-claude-settings!
+(defn ^{:stratum 2} write-claude-settings!
   "Write Claude CLI settings JSON with PreToolUse hook for supervision.
 
    The hook invokes `bb miniforge hook-eval` which reads the tool request
@@ -468,58 +754,100 @@
     (spit path (json/generate-string settings {:pretty true}))
     path))
 
-(def mcp-tools
-  "Tools the inner agent is auto-approved to call, as generic data.
+;; High-level session helpers
+(defn ^{:stratum 2} cleanup-codex-mcp-config!
+  "Remove [mcp_servers.artifact] block from .codex/config.toml.
+   Deletes the file if it becomes empty."
+  [path]
+  (let [f (io/file path)]
+    (when (.exists f)
+      (let [cleaned (-> (slurp f) strip-codex-artifact-config str/trim)]
+        (if (str/blank? cleaned)
+          (.delete f)
+          (spit f (str cleaned "\n")))))))
 
-   Each backend adapter (claude, codex, cursor-agent, …) translates
-   this into the allowlist / approval shape its CLI expects. Keep
-   agent-CLI-agnostic — the structured form is the source of truth.
+(defn ^{:stratum 2} read-capsule-artifact
+  "Read artifact EDN from inside the capsule via executor.
+   Applies parse-uuid-strings to match host read-artifact behavior."
+  [session]
+  (let [exec!    (:exec! session)
+        result   (exec! (:executor session) (:environment-id session)
+                        (str "cat " (:artifact-path session)) {:workdir (:workdir session)})
+        content  (get-in result [:data :stdout] "")]
+    (when (seq content)
+      (try
+        (-> content
+            clojure.edn/read-string
+            parse-uuid-strings)
+        (catch Exception _ nil)))))
 
-   Two entry shapes:
-   - `{:mcp/server :mcp/tool}` — a tool exposed by an MCP server
-   - plain keyword — a native tool from the agent CLI (e.g. `:Write`,
-     needed for plan.edn / code container-promotion writes)
+(defn- ^{:stratum 2} any-worktree-files-exist?
+  "Check if any .miniforge/<role>.edn file exists under workdir without parsing.
 
-   Example wire formats per backend:
-     claude  → --allowedTools \"mcp__context__context_read,Write,...\"
-     cursor  → --approve-mcps  (blanket approve; no names needed)
-     codex   → (currently unused; codex uses its own MCP config)
+   Used in host-mode sessions to distinguish 'truly no files' from 'files existed
+   but all failed to parse'. A parse failure emits :warn/worktree-artifact-parse and
+   returns nil from read-role-artifact, which causes collect-worktree-artifacts to
+   yield an empty map indistinguishable from the no-files case. This function
+   inspects the filesystem directly so run-session can suppress the redundant
+   :warn/no-artifact-found message when files were present but malformed.
 
-   Iter-10 failure — bare names like `context_read` were passed to
-   --allowedTools without the `mcp__<server>__` prefix, so every MCP
-   call got permission-denied. Iter-15 follow-on — `Write` wasn't in
-   the allowlist at all, so the planner's `.miniforge/plan.edn`
-   Write was silently denied (model then narrated 'let me try Edit'
-   and stalled). 2026-05-04 follow-on — `Edit` / `MultiEdit` were
-   never added either; the implementer in the
-   event-log-tool-visibility dogfood spent five repair iters
-   producing patch text the CLI refused to apply, then a sixth
-   iter discovered Write worked while Edit did not. Both issues trace
-   back to keeping the structured form honest and adapters translating
-   at the CLI boundary."
-  ;; No `:submit` — the artifact is the worktree/container diff (promotion),
-  ;; the definitive channel. Models trained to their native tools ignore an
-  ;; opt-in submit tool anyway (84:0 in dogfood), and a submit-without-files
-  ;; turn is exactly the empty-disk failure we want to eliminate. Files are
-  ;; the def; the curator derives the summary from the diff.
-  [{:mcp/server :context :mcp/tool :context_read}
-   {:mcp/server :context :mcp/tool :context_grep}
-   {:mcp/server :context :mcp/tool :context_glob}
-   ;; Agent-agnostic edit path: writes to the worktree + refreshes the cache,
-   ;; needs no prior native Read. The reliable way to modify EXISTING files
-   ;; across Claude/Codex/Cursor (native Write/Edit require a prior Read, which
-   ;; the implementer disallows to force the cache).
-   {:mcp/server :context :mcp/tool :context_write}
-   ;; Native write tools: implementer needs all three patch shapes.
-   ;; `Write` for full-file rewrites (planner's plan.edn, implementer
-   ;; new files, releaser PR drafts). `Edit` for single-region patches.
-   ;; `MultiEdit` for batched edits within one file. Roles that shouldn't
-   ;; modify files filter via :disallowed-tools separately.
-   :Write
-   :Edit
-   :MultiEdit])
+   Not used in capsule mode — the executor would require an additional exec call
+   per role to check existence, which is deferred to a future iteration."
+  [workdir]
+  (boolean
+   (when workdir
+     (some #(.exists (worktree-artifact-file workdir %))
+           worktree-roles))))
 
-(defn write-mcp-config!
+(defn- ^{:stratum 2} emit-no-artifact-warning!
+  "Emit `:warn/no-artifact-found` after an explicit worktree scan confirms
+   both the MCP path and the worktree role files came up empty. Separate fn
+   so `run-session` reads as a sequence of named steps and the diagnostic
+   stays testable.
+
+   AUDIT NOTE (2026-05-21): An audit of bases/cli/src, components/workflow/src,
+   and components/phase-software-factory/src confirmed that no code re-renders
+   this WARN at ERROR level in terminal output. The message is emitted to stderr
+   via `emit-system-message!` at WARN severity and is passed through as-is by
+   the CLI rendering pipeline (workflow_runner/display.clj applies no
+   artifact-specific coloring or severity amplification). The plan phase
+   delegates artifact handling entirely to `agent/invoke` → `with-session` →
+   `run-session`; there is no redundant artifact-presence check at the phase
+   layer.
+
+   However, because this message goes to stderr it may be perceived as a
+   terminal-level error by users even though it is diagnostic WARN output.
+   If the cause is not actionable by the user (e.g. the agent simply used the
+   Write-based worktree submission path instead of the MCP submit_artifact
+   tool), callers SHOULD suppress this warning — see the `any-file-existed?`
+   and `(seq worktree-artifacts)` guards in `run-session` for the suppression
+   logic already in place."
+  [session workdir]
+  (emit-system-message! :warn/no-artifact-found
+                        (:artifact-path session)
+                        (str (or workdir "<no-workdir>") "/.miniforge/")
+                        (str/join ", " (map name worktree-roles))))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn- ^{:stratum 3} parse-edn-file
+  "Read and parse an EDN file with a transform, logging failures consistently."
+  [f transform warning-key]
+  (parse-edn-content (slurp f) transform warning-key (.getPath f)))
+
+(defn ^{:stratum 3} write-cursor-permissions-for-session!
+  "Rewrite the session's .cursor/cli.json allowlist with a role's
+   `disallowed-tools` applied (e.g. a reviewer that must not Write).
+
+   No-op for capsule sessions — Cursor configs are host-only. Returns the
+   path, or nil when skipped."
+  [session disallowed-tools]
+  (when-not (:capsule? session)
+    (write-cursor-permissions! (:config-root session)
+                               (:mcp-allowed-tools session)
+                               disallowed-tools)))
+
+(defn ^{:stratum 3} write-mcp-config!
   "Write session config files for all supported CLI backends.
 
    Writes config files:
@@ -561,121 +889,7 @@
                          :task-context (:task-context session)
                          :phase (:phase session)})))
 
-(defn write-context-cache!
-  "Write context cache EDN to the session directory.
-
-   The MCP artifact server loads this on startup and uses it as
-   a read-through cache for context_read/context_grep/context_glob tools.
-
-   Arguments:
-   - session - Session map from create-session!
-   - files   - Map of {relative-path content-string}
-
-   Returns: session (for threading)"
-  [session files]
-  (when (seq files)
-    (let [path (str (:dir session) "/context-cache.edn")]
-      (spit path (pr-str {:files files}))))
-  session)
-
-(defn write-capsule-context-cache!
-  "Write context cache EDN inside the capsule via executor.
-   Capsule variant of write-context-cache! for governed mode."
-  [session files]
-  (when (seq files)
-    (let [path    (str (:dir session) "/context-cache.edn")
-          content (pr-str {:files files})]
-      ((:exec! session) (:executor session) (:environment-id session)
-                        (str "cat > " path " << 'CACHEEOF'\n" content "\nCACHEEOF")
-                        {:workdir (:workdir session)})))
-  session)
-
-(defn write-context-cache-for-session!
-  "Write context cache to the appropriate location based on session type.
-   Dispatches to capsule or host variant based on :capsule? flag."
-  [session files]
-  (if (:capsule? session)
-    (write-capsule-context-cache! session files)
-    (write-context-cache! session files)))
-
-;------------------------------------------------------------------------------ Layer 2
-;; Artifact reading
-
-(defn uuid-str?
-  "Check if a value is a UUID-shaped string."
-  [v]
-  (and (string? v)
-       (re-matches #"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}" v)))
-
-(defn instant-str?
-  "Check if a value looks like an ISO instant string."
-  [v]
-  (and (string? v)
-       (re-matches #"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.*" v)))
-
-(defn key-ends-with?
-  "Check if a namespaced keyword ends with the given suffix."
-  [k suffix]
-  (and (keyword? k)
-       (str/ends-with? (name k) suffix)))
-
-(defn parse-uuid-strings
-  "Convert string UUIDs and ISO instant strings in an artifact map.
-   The MCP server writes UUIDs and instants as strings since it runs in babashka.
-
-   Pattern-based detection:
-   - Any key ending in `/id` with a UUID-shaped string → java.util.UUID
-   - Any key ending in `/created-at` with an ISO instant string → java.util.Date
-   - Any vector of maps containing `:task/id` → recurse into those maps"
-  [m]
-  (cond
-    (map? m)
-    (into {}
-          (map (fn [[k v]]
-                 [k (cond
-                      ;; Any key ending in /id with a UUID string
-                      (and (key-ends-with? k "id") (uuid-str? v))
-                      (java.util.UUID/fromString v)
-
-                      ;; Any key ending in /created-at with an instant string
-                      (and (key-ends-with? k "created-at") (instant-str? v))
-                      (try (java.util.Date/from (java.time.Instant/parse v))
-                           (catch Exception _ (java.util.Date.)))
-
-                      ;; Vector of maps that may contain nested UUIDs/instants
-                      (and (vector? v) (seq v) (map? (first v)))
-                      (mapv (fn [item]
-                              (parse-uuid-strings item))
-                            v)
-
-                      :else v)]))
-          m)
-
-    :else m))
-
-(defn read-worktree-artifact
-  "Read a role artifact from <workdir>/.miniforge/<role>.edn if present.
-
-   Container-promotion pattern: an agent submits its phase artifact by
-   writing a file into the worktree, and the runtime reads that file
-   after the LLM invocation. This lives alongside the MCP-based
-   artifact path (`read-artifact`) — the caller decides precedence.
-
-   Arguments:
-   - workdir — absolute path to the worktree (may be nil)
-   - role    — keyword or string naming the artifact (e.g. :plan → plan.edn)
-
-   Returns: parsed artifact map with UUID types, or nil (missing,
-   unreadable, or parse failure — all logged to stderr, never thrown)."
-  [workdir role]
-  (when (and workdir role)
-    (let [f (worktree-artifact-file workdir role)]
-      (when (.exists f)
-        (parse-edn-file f
-                        (comp parse-uuid-strings edn/read-string)
-                        :warn/worktree-artifact-parse)))))
-
-(defn read-capsule-worktree-artifact
+(defn ^{:stratum 3} read-capsule-worktree-artifact
   "Read a role artifact from <workdir>/.miniforge/<role>.edn inside a capsule.
 
   Returns the parsed artifact map or nil. Missing files and parse failures are
@@ -692,184 +906,7 @@
                            :warn/capsule-worktree-artifact-parse
                            path)))))
 
-(defn read-artifact
-  "Read the artifact EDN file from a session directory.
-
-   The MCP artifact is now an optional submission channel. A missing file
-   is not an error on its own — the worktree-promoted path
-   (.miniforge/<role>.edn) is the primary channel and is checked separately
-   by run-session. Returns nil silently when the file is absent so callers
-   (result-boundary/normalize-llm-result) can handle nil gracefully.
-
-   Arguments:
-   - session - Session map from create-session!
-
-   Returns:
-   - Parsed artifact map with proper UUID types, or nil if not found.
-     Parse failures (malformed EDN) are still logged via :warn/artifact-parse."
-  [session]
-  (let [f (io/file (:artifact-path session))]
-    (when (.exists f)
-      (parse-edn-file f
-                      (comp parse-uuid-strings edn/read-string)
-                      :warn/artifact-parse))))
-
-(defn read-context-misses
-  "Read context cache misses from the session directory.
-
-   The MCP server writes context-misses.edn on exit with records of
-   every cache miss (files the agent needed but weren't pre-loaded).
-
-   Returns: vector of miss records, or nil if no misses file."
-  [session]
-  (let [path (str (:dir session) "/context-misses.edn")
-        f (io/file path)]
-    (when (.exists f)
-      (parse-edn-file f edn/read-string :warn/context-misses-parse))))
-
-;------------------------------------------------------------------------------ Layer 3
-;; High-level session helpers
-
-(defn cleanup-codex-mcp-config!
-  "Remove [mcp_servers.artifact] block from .codex/config.toml.
-   Deletes the file if it becomes empty."
-  [path]
-  (let [f (io/file path)]
-    (when (.exists f)
-      (let [cleaned (-> (slurp f) strip-codex-artifact-config str/trim)]
-        (if (str/blank? cleaned)
-          (.delete f)
-          (spit f (str cleaned "\n")))))))
-
-(defn cleanup-cursor-mcp-config!
-  "Remove artifact key from .cursor/mcp.json.
-   Deletes the file if mcpServers becomes empty."
-  [path]
-  (let [f (io/file path)]
-    (when (.exists f)
-      (try
-        (let [config (json/parse-string (slurp f))
-              servers (dissoc (get config "mcpServers" {}) "artifact")
-              config' (if (empty? servers)
-                        (dissoc config "mcpServers")
-                        (assoc config "mcpServers" servers))]
-          (if (empty? config')
-            (.delete f)
-            (spit f (json/generate-string config' {:pretty true}))))
-        (catch Exception _ nil)))))
-
-(defn cleanup-cursor-permissions!
-  "Restore .cursor/cli.json to its exact pre-session contents.
-
-   If `backup-cursor-permissions!` captured a snapshot (the file pre-existed),
-   move it back over our generated file; otherwise delete the file miniforge
-   created. Fully non-destructive — user/project rules are byte-preserved
-   regardless of any overlap with managed rules."
-  [path]
-  (try
-    (let [config-file (io/file path)
-          backup-file (io/file (str path cursor-permissions-backup-suffix))]
-      (cond
-        (.exists backup-file)
-        (do (io/copy backup-file config-file)
-            (.delete backup-file))
-
-        (.exists config-file)
-        (.delete config-file)))
-    (catch Exception _ nil)))
-
-;------------------------------------------------------------------------------ Layer 2.5
-;; Capsule-aware session lifecycle (N11 §6.3-6.4)
-
-(defn- missing-execute-fn!
-  []
-  (throw (ex-info "Capsule artifact sessions require :execution/execute-fn"
-                  {:missing :execution/execute-fn
-                   :component :agent/artifact-session})))
-
-(defn create-capsule-session!
-  "Create an artifact session inside a task capsule.
-   Session directory is created inside the capsule's workspace via executor.
-   Returns session map with capsule-relative paths and resolved exec! fn.
-
-   Three-arity form fails with a configuration error because agent must not
-   reach upward into dag-executor. Four-arity form accepts the execute-fn
-   injected by workflow."
-  ([executor env-id workdir]
-   (create-capsule-session! executor env-id workdir (missing-execute-fn!)))
-  ([executor env-id workdir execute-fn]
-   (let [exec!       execute-fn
-         session-dir (str workdir "/.miniforge-session")
-         _           (exec! executor env-id (str "mkdir -p " session-dir) {:workdir workdir})]
-     {:dir               session-dir
-      :mcp-config-path   (str session-dir "/mcp-config.json")
-      :artifact-path     (str session-dir "/artifact.edn")
-      :capsule?          true
-      :explicit-workdir? true
-      :exec!             exec!
-      :executor          executor
-      :environment-id    env-id
-      :workdir           workdir
-      :pre-session-snapshot (try
-                              (file-artifacts/snapshot-via-executor
-                               exec! executor env-id workdir)
-                              (catch Exception _
-                                (file-artifacts/empty-snapshot)))})))
-
-(defn write-capsule-mcp-config!
-  "Write MCP config and Claude settings inside the capsule.
-   The server command resolves to capsule-local bb/miniforge binary."
-  [session]
-  (let [exec!       (:exec! session)
-        executor    (:executor session)
-        env-id      (:environment-id session)
-        session-dir (:dir session)
-        ;; Inside the capsule, bb and miniforge are available directly
-        srv-cmd     {:command "bb" :args ["miniforge" "mcp-context-server"
-                                          "--artifact-dir" session-dir]}
-        mcp-config  (json/generate-string
-                     {"mcpServers" {"context" {"command" (:command srv-cmd)
-                                               "args"    (:args srv-cmd)}}}
-                     {:pretty true})
-        hook-cmd    "bb miniforge hook-eval"
-        settings    (json/generate-string
-                     {"hooks" {"PreToolUse" [{"type" "command" "command" hook-cmd}]}}
-                     {:pretty true})]
-    ;; Write configs inside capsule
-    (exec! executor env-id (str "cat > " (:mcp-config-path session) " << 'MCPEOF'\n" mcp-config "\nMCPEOF")
-           {:workdir (:workdir session)})
-    (exec! executor env-id (str "cat > " session-dir "/claude-settings.json << 'SETTINGSEOF'\n" settings "\nSETTINGSEOF")
-           {:workdir (:workdir session)})
-    (assoc session
-           :mcp-allowed-tools mcp-tools
-           :supervision {:hook-eval-cmd hook-cmd
-                         :settings-path (str session-dir "/claude-settings.json")
-                         :policy :workspace-write})))
-
-(defn read-capsule-artifact
-  "Read artifact EDN from inside the capsule via executor.
-   Applies parse-uuid-strings to match host read-artifact behavior."
-  [session]
-  (let [exec!    (:exec! session)
-        result   (exec! (:executor session) (:environment-id session)
-                        (str "cat " (:artifact-path session)) {:workdir (:workdir session)})
-        content  (get-in result [:data :stdout] "")]
-    (when (seq content)
-      (try
-        (-> content
-            clojure.edn/read-string
-            parse-uuid-strings)
-        (catch Exception _ nil)))))
-
-(defn cleanup-capsule-session!
-  "Remove the session directory inside the capsule."
-  [session]
-  (try
-    ((:exec! session) (:executor session) (:environment-id session)
-                      (str "rm -rf " (:dir session)) {:workdir (:workdir session)})
-    (catch Exception _ nil)))
-
-(defmacro with-capsule-artifact-session
+(defmacro ^{:stratum 3} with-capsule-artifact-session
   "Execute body with a capsule-aware artifact session (N11 §6.3).
    Like with-artifact-session but session files live inside the task capsule.
    Binding form: [session executor env-id workdir execute-fn]."
@@ -889,7 +926,7 @@
          (finally
            (cleanup-capsule-session! session#))))))
 
-(defn cleanup-session!
+(defn ^{:stratum 3} cleanup-session!
   "Delete the temporary session directory and clean up injected configs.
 
    Removes the [mcp_servers.artifact] block from .codex/config.toml and the
@@ -913,7 +950,115 @@
         (.delete ^java.io.File f)))
     (catch Exception _ nil)))
 
-(defmacro with-artifact-session
+;------------------------------------------------------------------------------ Layer 4
+
+(defn ^{:stratum 4} read-worktree-artifact
+  "Read a role artifact from <workdir>/.miniforge/<role>.edn if present.
+
+   Container-promotion pattern: an agent submits its phase artifact by
+   writing a file into the worktree, and the runtime reads that file
+   after the LLM invocation. This lives alongside the MCP-based
+   artifact path (`read-artifact`) — the caller decides precedence.
+
+   Arguments:
+   - workdir — absolute path to the worktree (may be nil)
+   - role    — keyword or string naming the artifact (e.g. :plan → plan.edn)
+
+   Returns: parsed artifact map with UUID types, or nil (missing,
+   unreadable, or parse failure — all logged to stderr, never thrown)."
+  [workdir role]
+  (when (and workdir role)
+    (let [f (worktree-artifact-file workdir role)]
+      (when (.exists f)
+        (parse-edn-file f
+                        (comp parse-uuid-strings edn/read-string)
+                        :warn/worktree-artifact-parse)))))
+
+(defn ^{:stratum 4} read-artifact
+  "Read the artifact EDN file from a session directory.
+
+   The MCP artifact is now an optional submission channel. A missing file
+   is not an error on its own — the worktree-promoted path
+   (.miniforge/<role>.edn) is the primary channel and is checked separately
+   by run-session. Returns nil silently when the file is absent so callers
+   (result-boundary/normalize-llm-result) can handle nil gracefully.
+
+   Arguments:
+   - session - Session map from create-session!
+
+   Returns:
+   - Parsed artifact map with proper UUID types, or nil if not found.
+     Parse failures (malformed EDN) are still logged via :warn/artifact-parse."
+  [session]
+  (let [f (io/file (:artifact-path session))]
+    (when (.exists f)
+      (parse-edn-file f
+                      (comp parse-uuid-strings edn/read-string)
+                      :warn/artifact-parse))))
+
+(defn ^{:stratum 4} read-context-misses
+  "Read context cache misses from the session directory.
+
+   The MCP server writes context-misses.edn on exit with records of
+   every cache miss (files the agent needed but weren't pre-loaded).
+
+   Returns: vector of miss records, or nil if no misses file."
+  [session]
+  (let [path (str (:dir session) "/context-misses.edn")
+        f (io/file path)]
+    (when (.exists f)
+      (parse-edn-file f edn/read-string :warn/context-misses-parse))))
+
+(defn ^{:stratum 4} read-context-reads
+  "Read recorded context_read resolutions from the session directory.
+
+   The MCP server writes context-reads.edn on exit with a record of every
+   context_read the agent made, hit or miss — the recorded flows that make
+   'did this agent consult its pinned codex landings' an answerable
+   question (Codex SPEC §7.4.2).
+
+   Returns: vector of read records, or nil if no reads file."
+  [session]
+  (let [path (str (:dir session) "/context-reads.edn")
+        f (io/file path)]
+    (when (.exists f)
+      (parse-edn-file f edn/read-string :warn/context-reads-parse))))
+
+(defn ^{:stratum 4} with-readonly-session
+  "Like `with-session`, but for READ-ONLY agents (e.g. the reviewer) that
+   consume the MCP context cache but produce NO worktree artifact.
+
+   Sets up the session + MCP config (host or governed/capsule, mirroring
+   `with-session`), runs `body-fn`, and cleans up — but skips the artifact
+   read + the nothing-found WARN that `run-session` does, since a reviewer
+   has no work product to promote. Returns the `body-fn` result directly
+   (the LLM result), not a normalized artifact map.
+
+   Use when an agent needs cached reads (context_read/grep/glob) for
+   exploration but does not write files."
+  [context body-fn]
+  (let [run (fn [session cleanup-fn]
+              (try (body-fn session)
+                   (finally (cleanup-fn session))))]
+    (if (governed? context)
+      (let [executor (:execution/executor context)
+            env-id   (:execution/environment-id context)
+            workdir  (or (:execution/worktree-path context) "/workspace")
+            exec!    (or (:execution/execute-fn context) (missing-execute-fn!))
+            session  (-> (create-capsule-session! executor env-id workdir exec!)
+                         write-capsule-mcp-config!)]
+        (run session cleanup-capsule-session!))
+      (let [workdir (:execution/worktree-path context)
+            session (-> (if workdir
+                          (create-session! {:workdir workdir
+                                            :source-root (:source-root context)})
+                          (create-session! {:source-root (:source-root context)}))
+                        write-mcp-config!)]
+        (run session cleanup-session!)))))
+
+;------------------------------------------------------------------------------ Layer 5
+
+(defmacro ^{:stratum 5} with-artifact-session
   "Execute body with an artifact session, returning the artifact if found.
 
    Binds `session` in the body. After body completes, reads the artifact
@@ -942,37 +1087,7 @@
        (finally
          (cleanup-session! session#)))))
 
-;------------------------------------------------------------------------------ Layer 2.75
-;; Session → MCP opts
-
-(defn session->mcp-opts
-  "Build the base MCP options map from a session for LLM chat calls.
-   Callers merge role-specific keys (e.g. :model, :disallowed-tools, :workdir)."
-  [session budget-usd max-turns]
-  {:mcp-config        (:mcp-config-path session)
-   :mcp-allowed-tools (:mcp-allowed-tools session)
-   :supervision       (:supervision session)
-   :budget-usd        budget-usd
-   :max-turns         max-turns})
-
-;------------------------------------------------------------------------------ Layer 3
-;; Unified session dispatch (N11 §6.3)
-
-(defn governed?
-  "True when the execution context requires governed (capsule) mode.
-   Checks :execution/mode is :governed and executor + environment-id are present."
-  [context]
-  (and (= :governed (:execution/mode context))
-       (some? (:execution/executor context))
-       (some? (:execution/environment-id context))))
-
-(def ^:private worktree-roles
-  "Roles whose `.miniforge/<role>.edn` files `run-session` probes for
-   worktree-promoted artifacts. Single source of truth for both the
-   scan and the no-artifact-found diagnostic."
-  [:plan :implement :verify :review :release])
-
-(defn- role-reader-for-mode
+(defn- ^{:stratum 5} role-reader-for-mode
   "Return a 1-arg fn from role keyword to parsed worktree artifact, picked
    by execution mode. Capsule mode reads through the executor; host mode
    reads directly from `workdir`; an unknown mode yields a no-op reader."
@@ -982,71 +1097,9 @@
     :host    #(read-worktree-artifact workdir %)
     (constantly nil)))
 
-(defn- read-role-entry
-  "Read the worktree artifact for `role` via `read-role-artifact` and
-   return a `[role artifact]` map entry, or nil if the role file was
-   absent (so callers can use `keep` to drop misses)."
-  [read-role-artifact role]
-  (when-let [a (read-role-artifact role)]
-    [role a]))
+;------------------------------------------------------------------------------ Layer 6
 
-(defn- collect-worktree-artifacts
-  "Build the `:worktree-artifacts` map by probing every role file under
-   `workdir`/.miniforge/. Returns nil when `workdir` is absent so callers
-   can distinguish 'no worktree was threaded through' from 'worktree had
-   no role files'."
-  [read-role-artifact workdir]
-  (when workdir
-    (into {} (keep #(read-role-entry read-role-artifact %)) worktree-roles)))
-
-(defn- any-worktree-files-exist?
-  "Check if any .miniforge/<role>.edn file exists under workdir without parsing.
-
-   Used in host-mode sessions to distinguish 'truly no files' from 'files existed
-   but all failed to parse'. A parse failure emits :warn/worktree-artifact-parse and
-   returns nil from read-role-artifact, which causes collect-worktree-artifacts to
-   yield an empty map indistinguishable from the no-files case. This function
-   inspects the filesystem directly so run-session can suppress the redundant
-   :warn/no-artifact-found message when files were present but malformed.
-
-   Not used in capsule mode — the executor would require an additional exec call
-   per role to check existence, which is deferred to a future iteration."
-  [workdir]
-  (boolean
-   (when workdir
-     (some #(.exists (worktree-artifact-file workdir %))
-           worktree-roles))))
-
-(defn- emit-no-artifact-warning!
-  "Emit `:warn/no-artifact-found` after an explicit worktree scan confirms
-   both the MCP path and the worktree role files came up empty. Separate fn
-   so `run-session` reads as a sequence of named steps and the diagnostic
-   stays testable.
-
-   AUDIT NOTE (2026-05-21): An audit of bases/cli/src, components/workflow/src,
-   and components/phase-software-factory/src confirmed that no code re-renders
-   this WARN at ERROR level in terminal output. The message is emitted to stderr
-   via `emit-system-message!` at WARN severity and is passed through as-is by
-   the CLI rendering pipeline (workflow_runner/display.clj applies no
-   artifact-specific coloring or severity amplification). The plan phase
-   delegates artifact handling entirely to `agent/invoke` → `with-session` →
-   `run-session`; there is no redundant artifact-presence check at the phase
-   layer.
-
-   However, because this message goes to stderr it may be perceived as a
-   terminal-level error by users even though it is diagnostic WARN output.
-   If the cause is not actionable by the user (e.g. the agent simply used the
-   Write-based worktree submission path instead of the MCP submit_artifact
-   tool), callers SHOULD suppress this warning — see the `any-file-existed?`
-   and `(seq worktree-artifacts)` guards in `run-session` for the suppression
-   logic already in place."
-  [session workdir]
-  (emit-system-message! :warn/no-artifact-found
-                        (:artifact-path session)
-                        (str (or workdir "<no-workdir>") "/.miniforge/")
-                        (str/join ", " (map name worktree-roles))))
-
-(defn- run-session
+(defn- ^{:stratum 6} run-session
   "Execute body-fn with session, read artifacts, and clean up.
    Shared lifecycle for both host and capsule sessions.
 
@@ -1132,12 +1185,15 @@
        :artifact             artifact
        :worktree-artifacts   worktree-artifacts
        :context-misses       (when (= :host mode) (read-context-misses session))
+       :context-reads        (when (= :host mode) (read-context-reads session))
        :pre-session-snapshot (:pre-session-snapshot session)
        :session-mode         mode})
     (finally
       (cleanup-fn session))))
 
-(defn with-session
+;------------------------------------------------------------------------------ Layer 7
+
+(defn ^{:stratum 7} with-session
   "Execute body-fn with the appropriate artifact session for the execution mode.
 
    In governed mode (context has :execution/executor, :execution/environment-id,
@@ -1167,38 +1223,6 @@
                         (create-session! {:source-root (:source-root context)}))
                       write-mcp-config!)]
       (run-session session body-fn read-artifact cleanup-session! :host))))
-
-(defn with-readonly-session
-  "Like `with-session`, but for READ-ONLY agents (e.g. the reviewer) that
-   consume the MCP context cache but produce NO worktree artifact.
-
-   Sets up the session + MCP config (host or governed/capsule, mirroring
-   `with-session`), runs `body-fn`, and cleans up — but skips the artifact
-   read + the nothing-found WARN that `run-session` does, since a reviewer
-   has no work product to promote. Returns the `body-fn` result directly
-   (the LLM result), not a normalized artifact map.
-
-   Use when an agent needs cached reads (context_read/grep/glob) for
-   exploration but does not write files."
-  [context body-fn]
-  (let [run (fn [session cleanup-fn]
-              (try (body-fn session)
-                   (finally (cleanup-fn session))))]
-    (if (governed? context)
-      (let [executor (:execution/executor context)
-            env-id   (:execution/environment-id context)
-            workdir  (or (:execution/worktree-path context) "/workspace")
-            exec!    (or (:execution/execute-fn context) (missing-execute-fn!))
-            session  (-> (create-capsule-session! executor env-id workdir exec!)
-                         write-capsule-mcp-config!)]
-        (run session cleanup-capsule-session!))
-      (let [workdir (:execution/worktree-path context)
-            session (-> (if workdir
-                          (create-session! {:workdir workdir
-                                            :source-root (:source-root context)})
-                          (create-session! {:source-root (:source-root context)}))
-                        write-mcp-config!)]
-        (run session cleanup-session!)))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/codex/src/ai/miniforge/codex/interface.clj
+++ b/components/codex/src/ai/miniforge/codex/interface.clj
@@ -26,7 +26,8 @@
    Read-only by design: the codex is generated from data-as-source
    elsewhere (SPEC §8.1); this component never writes it."
   (:require [ai.miniforge.codex.core :as core]
-            [ai.miniforge.codex.node :as node]))
+            [ai.miniforge.codex.node :as node]
+            [ai.miniforge.codex.render :as render]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -47,3 +48,31 @@
    empty success."
   [codex-dir situation-text]
   (core/consider codex-dir situation-text))
+
+(defn ^{:stratum 0} render-response
+  "Render a `consider` response (or anomaly) as the canonical text form.
+   Used by both the consider_situation MCP tool (pull) and the phase-start
+   blackboard pin (push, SPEC §7.4) so the two forms are identical."
+  [resp]
+  (render/render-response resp))
+
+(defn ^{:stratum 0} pin-entry
+  "Build the per-run blackboard pin (SPEC §7.4): consult the codex for
+   `situation` and return {:path pin-path :content rendered} suitable as a
+   `:task/existing-files` entry — prompt-visible AND cache-fetchable.
+
+   The pinned artifact is the consultation RESULT, ephemeral and per-run;
+   the codex itself is durable and is never cached onto the blackboard
+   (§7.4.1). On any anomaly the anomaly map comes back instead, so the
+   caller decides whether to pin nothing or pin the anomaly — a silent
+   default here would be false coverage."
+  [codex-dir situation pin-path]
+  (let [resp (core/consider codex-dir situation)]
+    (if (:codex/anomaly resp)
+      resp
+      {:path pin-path
+       :content (str "<!-- Pinned at phase start (Codex SPEC T1 §7.4): the "
+                     "Thesium Codex consultation for this phase's situation. "
+                     "Per-run artifact — read it before acting. -->\n\n"
+                     (render/render-response resp)
+                     "\n")})))

--- a/components/codex/src/ai/miniforge/codex/render.clj
+++ b/components/codex/src/ai/miniforge/codex/render.clj
@@ -1,0 +1,90 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.codex.render
+  "Text rendering of a `consider` response. Lives in the component — not the
+   MCP base — so the pulled form (consider_situation tool) and the pushed
+   form (the phase-start blackboard pin, SPEC §7.4) are byte-identical.
+
+   Rendering rules come from the spec, not taste: landings arrive ordered
+   strategic → operational → tactical (§7.6.1); the coverage statement leads
+   and says out loud when there is no strategic-horizon landing (§7.6.2);
+   horizon escalations — a landing whose anchoring scar cost more than the
+   landing's own horizon — are flagged inline (§7.6.3). Anomalies render as
+   anomalies; an unmatched situation is an answer, never an empty list."
+  (:require [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} render-landing [{:keys [id type title horizon confidence open scars escalations]}]
+  ;; horizon, anchoring and escalation are problem-node concepts (SPEC §2.3,
+  ;; §2.6); a resolution is a terminal outcome and renders as one.
+  (let [problem? (= type "problem")]
+    (str/join "\n"
+      (concat
+        [(str "- [" (if problem? (or horizon "?") "resolution") "] " id " — " title
+              "  (confidence: " confidence ")")]
+        (when (seq escalations)
+          [(str "    ESCALATION: " (str/join ", " escalations)
+                " — the cost landed above this problem's horizon")])
+        (for [{scar-id :id :keys [date cost cost-horizon]} scars]
+          (str "    scar: " scar-id " (" date ", cost: " cost
+               (when cost-horizon (str ", cost-horizon: " cost-horizon)) ")"))
+        (when (and problem? (empty? scars))
+          ["    unanchored — reasoned, not survived"])
+        (map #(str "    open: " %) open)))))
+
+(defn- ^{:stratum 0} render-coverage
+  [{:keys [landing-count unanchored-count horizon-mix
+           no-strategic-coverage? newest-scar-date]}]
+  (str/join "\n"
+    (concat
+      ;; horizon mix rendered in the §7.6.1 order, not map order
+      [(str "coverage: " landing-count " landings, "
+            unanchored-count " unanchored, newest scar " (or newest-scar-date "none")
+            ", horizon mix "
+            (str/join " · " (for [h ["strategic" "operational" "tactical"]
+                                  :let [n (get horizon-mix h)]
+                                  :when n]
+                              (str h " " n))))]
+      (when no-strategic-coverage?
+        ["NO STRATEGIC COVERAGE: every landing is tactical/operational. The codex has nothing strategic-horizon for this situation — that absence is a gap in the codex, not evidence the situation carries no strategic risk."]))))
+
+(defn ^{:stratum 0} render-anomaly [{:codex/keys [anomaly reason available matches]}]
+  (str/join "\n"
+    (concat
+      [(str "codex anomaly: " (name anomaly))
+       reason]
+      (when (seq available)
+        (cons "available situations:"
+              (map (fn [[id title]] (str "- " id " — " title)) available)))
+      (when (seq matches)
+        (cons "ambiguous between:"
+              (map (fn [[id title]] (str "- " id " — " title)) matches))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} render-response [resp]
+  (if (:codex/anomaly resp)
+    (render-anomaly resp)
+    (str/join "\n"
+      (concat
+        [(str "situation: " (:situation resp) " — " (:situation-title resp))
+         (render-coverage (:coverage resp))
+         ""
+         "landings (strategic first — read top-down):"]
+        (map render-landing (:landings resp))))))

--- a/components/codex/test/ai/miniforge/codex/render_test.clj
+++ b/components/codex/test/ai/miniforge/codex/render_test.clj
@@ -1,0 +1,79 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.codex.render-test
+  "The response-map shapes here are pinned by interface-test against
+   generator-produced fixtures; these tests cover the text rendering rules
+   (SPEC §7.5, §7.6)."
+  (:require [ai.miniforge.codex.interface :as codex]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} render-orders-and-flags
+  (let [resp {:situation "s1"
+              :situation-title "A situation"
+              :landings [{:id "p-strategic" :type "problem" :title "Big one"
+                          :horizon "strategic" :confidence "high"
+                          :open [] :scars [] :escalations []}
+                         {:id "p-op" :type "problem" :title "Runs the system"
+                          :horizon "operational" :confidence "high"
+                          :open ["still open"]
+                          :scars [{:id "scar-1" :date "2026-01" :cost "an outage"
+                                   :cost-horizon "strategic" :origin "owned"}]
+                          :escalations ["scar-1"]}]
+              :coverage {:landing-count 2 :unanchored-count 1
+                         :horizon-mix {"strategic" 1 "operational" 1}
+                         :no-strategic-coverage? false
+                         :newest-scar-date "2026-01"}}
+        text (codex/render-response resp)]
+    (testing "strategic renders before operational (§7.6.1)"
+      (is (< (str/index-of text "p-strategic") (str/index-of text "p-op"))))
+    (testing "escalation and unanchored are flagged inline (§7.6.3)"
+      (is (str/includes? text "ESCALATION: scar-1"))
+      (is (str/includes? text "unanchored — reasoned, not survived")))
+    (testing "coverage line leads with counts and §7.6.1-ordered mix (§7.5)"
+      (is (str/includes? text "coverage: 2 landings, 1 unanchored"))
+      (is (str/includes? text "strategic 1 · operational 1")))))
+
+(deftest ^{:stratum 0} render-says-when-strategic-coverage-is-absent
+  (let [resp {:situation "s1" :situation-title "t"
+              :landings [{:id "p" :type "problem" :title "t" :horizon "tactical"
+                          :confidence "high" :open [] :scars [] :escalations []}]
+              :coverage {:landing-count 1 :unanchored-count 1
+                         :horizon-mix {"tactical" 1}
+                         :no-strategic-coverage? true
+                         :newest-scar-date nil}}
+        text (codex/render-response resp)]
+    (is (str/includes? text "NO STRATEGIC COVERAGE"))))
+
+(deftest ^{:stratum 0} pin-entry-builds-a-prompt-ready-file
+  (let [fixture-dir (-> (io/resource "codex-fixture/nodes")
+                        io/file .getParentFile .getPath)
+        entry (codex/pin-entry fixture-dir "process-stuck-or-slow"
+                               ".miniforge/codex-consider.md")]
+    (is (= ".miniforge/codex-consider.md" (:path entry)))
+    (is (str/includes? (:content entry) "Pinned at phase start"))
+    (is (str/includes? (:content entry) "situation: process-stuck-or-slow"))
+    (is (str/includes? (:content entry) "coverage:"))))
+
+(deftest ^{:stratum 0} pin-entry-surfaces-anomalies-instead-of-pinning-them
+  (let [entry (codex/pin-entry "/nonexistent/codex" "anything" "x.md")]
+    (is (= :codex-unreadable (:codex/anomaly entry)))
+    (is (nil? (:path entry)))))

--- a/components/phase-software-factory/deps.edn
+++ b/components/phase-software-factory/deps.edn
@@ -6,6 +6,7 @@
         ai.miniforge/phase {:local/root "../phase"}
         ai.miniforge/schema {:local/root "../schema"}
         ai.miniforge/agent {:local/root "../agent"}
+        ai.miniforge/codex {:local/root "../codex"}
         ai.miniforge/knowledge {:local/root "../knowledge"}
         ai.miniforge/repo-index {:local/root "../repo-index"}
         ai.miniforge/context-pack {:local/root "../context-pack"}

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/codex_pin.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/codex_pin.clj
@@ -1,0 +1,76 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.phase-software-factory.codex-pin
+  "The Thesium Codex blackboard pin — PUSH delivery (Codex SPEC T1 §7.3/§7.4).
+
+   Agents are not relied on to pull: a confident agent does not ask what it
+   is missing, and warnings are needed precisely when confidence is
+   unwarranted. So at phase start the orchestrator consults the codex for
+   the phase's situation and pins the result as a synthetic
+   `:task/existing-files` entry — the one channel that is both
+   prompt-visible and MCP-cache-fetchable. The pin is the consultation
+   RESULT, ephemeral and per-run; the codex itself is never cached onto the
+   blackboard (§7.4.1).
+
+   No configured codex (MINIFORGE_CODEX_PATH unset) means the capability is
+   off: no pin, no noise. A configured codex that fails to answer is logged
+   as a warning — that is a gap the operator should see."
+  (:require [ai.miniforge.codex.interface :as codex]
+            [ai.miniforge.logging.interface :as log]
+            [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} pin-path
+  "Virtual path of the pinned artifact. It never exists on disk, which is
+   what makes it stable in the MCP context cache: staleness invalidation
+   only fires for paths with an on-disk file."
+  ".miniforge/codex-consider.md")
+
+(def ^{:stratum 0} phase->situation
+  "Which codex situation each phase enters at. This map IS the push
+   mechanism's routing: the orchestrator supplies the situation, the codex
+   supplies the worries. Only phases whose task builders actually carry
+   `:task/existing-files` are listed — review's channel is `:task/artifact`,
+   so its pin (situation: quality-signal-might-be-lying) waits until the
+   reviewer prompt assembly grows a slot for it."
+  {:implement "changing-one-side-of-a-boundary"
+   :plan      "about-to-commit-consequential"})
+
+(defn- ^{:stratum 0} configured-codex-dir []
+  (some-> (System/getenv "MINIFORGE_CODEX_PATH") str/trim not-empty))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} pin-file
+  "The pin for `phase` as an existing-files entry {:path :content}, or nil
+   when the codex is unconfigured, the phase has no mapped situation, or
+   the consultation failed (logged as :codex/pin-skipped when a logger is
+   given — a configured codex that cannot answer is worth a warning)."
+  ([phase logger] (pin-file phase logger (configured-codex-dir)))
+  ([phase logger codex-dir]
+   (when codex-dir
+     (when-let [situation (get phase->situation phase)]
+       (let [entry (codex/pin-entry codex-dir situation pin-path)]
+         (if (:codex/anomaly entry)
+           (do (when logger
+                 (log/warn logger phase :codex/pin-skipped
+                           {:data {:anomaly (:codex/anomaly entry)
+                                   :reason  (:codex/reason entry)}}))
+               nil)
+           entry))))))

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/codex_pin.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/codex_pin.clj
@@ -60,17 +60,22 @@
 (defn ^{:stratum 1} pin-file
   "The pin for `phase` as an existing-files entry {:path :content}, or nil
    when the codex is unconfigured, the phase has no mapped situation, or
-   the consultation failed (logged as :codex/pin-skipped when a logger is
-   given — a configured codex that cannot answer is worth a warning)."
+   the consultation failed. A configured codex that cannot answer is worth
+   a warning, ALWAYS: through the logger when one is given, else stderr —
+   a nil logger must not turn the failure silent (plan has no logger)."
   ([phase logger] (pin-file phase logger (configured-codex-dir)))
   ([phase logger codex-dir]
    (when codex-dir
      (when-let [situation (get phase->situation phase)]
        (let [entry (codex/pin-entry codex-dir situation pin-path)]
          (if (:codex/anomaly entry)
-           (do (when logger
+           (do (if logger
                  (log/warn logger phase :codex/pin-skipped
                            {:data {:anomaly (:codex/anomaly entry)
-                                   :reason  (:codex/reason entry)}}))
+                                   :reason  (:codex/reason entry)}})
+                 (binding [*out* *err*]
+                   (println "WARN: codex pin skipped for" (name phase) "—"
+                            (name (:codex/anomaly entry)) ":"
+                            (:codex/reason entry))))
                nil)
            entry))))))

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
@@ -26,6 +26,7 @@
    [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.phase-software-factory.messages :as messages]
    [ai.miniforge.phase-software-factory.phase-config :as phase-config]
+   [ai.miniforge.phase-software-factory.codex-pin :as codex-pin]
    [ai.miniforge.phase-software-factory.knowledge-helpers :as kb-helpers]
    [ai.miniforge.agent.interface :as agent]
    [ai.miniforge.agent.interface.protocols.messaging :as messaging]
@@ -462,6 +463,12 @@
         pack-ctx (or (get-in ctx [:execution/pack-context])
                      (build-context-pack worktree-path files-in-scope))
         existing-files (resolve-existing-files ctx pack-ctx worktree-path files-in-scope)
+        ;; Thesium Codex blackboard pin (SPEC §7.4): pinned FIRST so the
+        ;; worries render before the content they apply to.
+        codex-pin (codex-pin/pin-file :implement (get-in ctx [:execution/logger]))
+        existing-files (if codex-pin
+                         (into [codex-pin] (or existing-files []))
+                         existing-files)
         behavior-addendum (phase/load-guidance-addendum
                             :implement {:task {:task/intent (:intent input)}})
         review-feedback (resolve-review-feedback ctx)

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/plan.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/plan.clj
@@ -23,6 +23,7 @@
    Default gates: [:plan-complete]"
   (:require [ai.miniforge.phase.interface :as phase]
             [ai.miniforge.phase-software-factory.phase-config :as phase-config]
+            [ai.miniforge.phase-software-factory.codex-pin :as codex-pin]
             [ai.miniforge.phase-software-factory.knowledge-helpers :as kb-helpers]
             [ai.miniforge.phase-software-factory.phase-terminal :as phase-terminal]
             [ai.miniforge.agent.interface :as agent]
@@ -112,7 +113,13 @@
 
    Returns {:task task-map :rules-manifest manifest-or-nil}."
   [input explore-result knowledge-store]
-  (let [existing-files (:exploration/files explore-result)
+  (let [exploration-files (:exploration/files explore-result)
+        ;; Thesium Codex blackboard pin (SPEC §7.4): pinned FIRST so the
+        ;; worries render before the content they apply to.
+        codex-pin (codex-pin/pin-file :plan nil)
+        existing-files (if codex-pin
+                         (into [codex-pin] (or exploration-files []))
+                         exploration-files)
         {:keys [formatted manifest]} (kb-helpers/inject-with-manifest
                                        knowledge-store :planner (get input :tags []))
         behavior-addendum (phase/load-guidance-addendum

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/codex_pin_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/codex_pin_test.clj
@@ -1,0 +1,40 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.phase-software-factory.codex-pin-test
+  "The happy path (a real codex producing a pin) is covered by the codex
+   component's own tests against generator-produced fixtures
+   (ai.miniforge.codex.render-test/pin-entry-builds-a-prompt-ready-file);
+   these cover the phase-side skip conditions."
+  (:require [ai.miniforge.phase-software-factory.codex-pin :as codex-pin]
+            [clojure.test :refer [deftest is]]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} no-configured-codex-means-no-pin-and-no-noise
+  (is (nil? (codex-pin/pin-file :implement nil nil))))
+
+(deftest ^{:stratum 0} unmapped-phase-gets-no-pin
+  (is (nil? (codex-pin/pin-file :verify nil "/anywhere"))))
+
+(deftest ^{:stratum 0} anomaly-skips-the-pin-rather-than-pinning-garbage
+  (is (nil? (codex-pin/pin-file :implement nil "/nonexistent/codex"))))
+
+(deftest ^{:stratum 0} only-wired-phases-are-mapped
+  ;; review's task builder has no :task/existing-files channel yet; a mapping
+  ;; without a wire would be a defined-but-unreachable capability.
+  (is (= #{:implement :plan} (set (keys codex-pin/phase->situation)))))

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/codex_pin_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/codex_pin_test.clj
@@ -38,3 +38,10 @@
   ;; review's task builder has no :task/existing-files channel yet; a mapping
   ;; without a wire would be a defined-but-unreachable capability.
   (is (= #{:implement :plan} (set (keys codex-pin/phase->situation)))))
+
+(deftest ^{:stratum 0} anomaly-with-nil-logger-warns-on-stderr
+  (let [err (java.io.StringWriter.)]
+    (binding [*err* err]
+      (is (nil? (codex-pin/pin-file :implement nil "/nonexistent/codex"))))
+    (is (re-find #"WARN: codex pin skipped for implement" (str err))
+        "a nil logger must not turn a configured-codex failure silent")))


### PR DESCRIPTION
## What

The push half of the Thesium Codex consumption surface. [#1620](https://github.com/miniforge-ai/miniforge/pull/1620) shipped pull (the `consider_situation` tool); this ships push, because agents must not be relied on to pull: a confident agent does not ask what it is missing, and warnings are needed precisely when confidence is unwarranted (SPEC §7.3).

1. **Phase-start pin (§7.4).** `build-implement-task` and `build-planner-task` consult the codex for the phase's situation (implement → `changing-one-side-of-a-boundary`, plan → `about-to-commit-consequential`) and pin the rendered result FIRST in `:task/existing-files` — the one channel that is both prompt-visible and MCP-cache-fetchable. The pin lives at the virtual path `.miniforge/codex-consider.md`: no on-disk file, so cache staleness never invalidates it, and `save-cache!` carries it across phases. The pinned artifact is the consultation result, per-run; the codex itself is never cached onto the blackboard (§7.4.1).
2. **Recorded reads (§7.4.2).** The context cache now records every `context_read` resolution — hit and miss — and flushes `context-reads.edn` beside `context-misses.edn`; sessions surface `:context-reads`. "Did this agent consult its pinned landings" is now an answerable question, ready to become a gate condition (§7.4.3, not yet gated).
3. **Rendering moved into the component** (`ai.miniforge.codex.render`) so the pulled form and the pushed form are byte-identical; `codex/pin-entry` builds the pin. `consider_situation` joins the agent tool allowlist for mid-run re-consultation.

## Scope notes

1. Review phase is deliberately NOT wired: its task builder has no `:task/existing-files` channel, and a mapping without a wire is a defined-but-unreachable capability. Its situation (`quality-signal-might-be-lying`) waits for a reviewer prompt slot.
2. Unconfigured codex (`MINIFORGE_CODEX_PATH` unset) = no pin, no noise. A configured codex that fails to answer logs `:codex/pin-skipped`.
3. Committed with `MINIFORGE_STRATUM_BUDGET_MODE=warn`: `implement.clj`, `plan.clj`, `artifact_session.clj`, `context_cache.clj` are pre-existing entries in `docs/standards/strata-violations-baseline.md`; their namespace splits are the rule-210 backlog, not this change.

## Tests

49 tests / 121 assertions across codex, base, and phase bricks; poly check clean; end-to-end smoke against the live codex shows the implement pin rendering board 5's landings with the §7.6.2 no-strategic-coverage statement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)