### PR TITLE
feat(mcp): record every context_read resolution (Codex SPEC §7.4.2)

### DIFF
--- a/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/context_cache.clj
+++ b/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/context_cache.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.mcp-context-server.context-cache
   "Read-through context cache for MCP file exploration tools.
 
@@ -32,20 +31,13 @@
             [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Pure helpers
 
-(def ^:private chars-per-token
+;; Pure helpers
+(def ^{:stratum 0} ^:private chars-per-token
   "Approximate characters per token for estimation."
   4)
 
-(defn estimate-tokens
-  "Estimate token count from a string (~4 chars per token)."
-  [s]
-  (if (string? s)
-    (int (Math/ceil (/ (count s) chars-per-token)))
-    0))
-
-(defn apply-offset-limit
+(defn ^{:stratum 0} apply-offset-limit
   "Apply line-based offset and limit to content string.
    offset is 0-based line index; limit is max lines to return."
   [content offset limit]
@@ -55,7 +47,7 @@
         limited (if limit (take limit sliced) sliced)]
     (str/join "\n" limited)))
 
-(defn glob-matches?
+(defn ^{:stratum 0} glob-matches?
   "Check if a path matches a glob pattern.
    Supports * (single segment) and ** (any depth)."
   [pattern path]
@@ -69,7 +61,7 @@
         regex (re-pattern (str "^" regex-str "$"))]
     (boolean (re-matches regex path))))
 
-(defn grep-file
+(defn ^{:stratum 0} grep-file
   "Search a file's content for a regex pattern.
    Returns vector of {:path :line-number :text} for matching lines."
   [path content pattern-str]
@@ -84,7 +76,7 @@
            vec))
     (catch Exception _e [])))
 
-(defn format-grep-results
+(defn ^{:stratum 0} format-grep-results
   "Format grep results as path:line:text lines."
   [results]
   (->> results
@@ -92,13 +84,153 @@
               (str path ":" line-number ":" text)))
        (str/join "\n")))
 
-;------------------------------------------------------------------------------ Layer 0
-;; Shell fallbacks
+;; Stateful cache operations
+;; Cache atom holding :files (path → content), :mtimes (path → epoch-ms of the
+;; file when its content was cached, for write-invalidation), :misses
+;; (recorded cache misses), and :reads (every context_read resolution, hit or
+;; miss — the recorded-flows half of the Codex SPEC §7.4 blackboard contract:
+;; whether an agent consulted a pinned artifact must be an answerable
+;; question).
+(defonce ^{:stratum 0} cache-state
+  (atom {:files {} :mtimes {} :misses [] :reads []
+         :source-root nil :artifact-dir nil :workdir nil}))
 
-(declare source-root)
-(declare file-mtime)
+(def ^{:stratum 0} ^:private persistent-cache-relpath ".miniforge/context-cache.edn")
 
-(defn shell-grep
+(defn- ^{:stratum 0} read-cache-edn
+  "Read {:files .. :mtimes ..} from an EDN cache file, or nil on missing/bad."
+  [path]
+  (let [f (and path (io/file path))]
+    (when (and f (.exists f))
+      (try (edn/read-string (slurp f))
+           (catch Exception _ nil)))))
+
+;; MCP response helpers
+(defn- ^{:stratum 0} text-response
+  "Wrap a string in the MCP tool response shape."
+  [text]
+  {:content [{:type "text" :text text}]})
+
+(defn- ^{:stratum 0} error-response
+  "Wrap an error message in the MCP tool error shape."
+  [text]
+  {:content [{:type "text" :text text}] :isError true})
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} estimate-tokens
+  "Estimate token count from a string (~4 chars per token)."
+  [s]
+  (if (string? s)
+    (int (Math/ceil (/ (count s) chars-per-token)))
+    0))
+
+(defn ^{:stratum 1} reset-state!
+  "Reset cache state. Intended for test isolation."
+  []
+  (reset! cache-state {:files {} :mtimes {} :misses [] :reads []
+                       :source-root nil :artifact-dir nil :workdir nil}))
+
+(defn ^{:stratum 1} set-workdir!
+  "Set the write target for context_write — the agent's worktree, distinct from
+   `:source-root` (the read reference). Reads resolve against source-root;
+   writes land in the worktree where the run collects the diff. Agent-agnostic:
+   every backend's context server is launched with the same command, so this
+   applies to Claude/Codex/Cursor alike."
+  [workdir]
+  (swap! cache-state assoc :workdir workdir))
+
+(defn- ^{:stratum 1} source-root
+  []
+  (or (:source-root @cache-state) "."))
+
+(defn- ^{:stratum 1} persistent-cache-path
+  "Worktree-resident cross-phase cache file, or nil when there's no
+   source-root. Under .miniforge/ (gitignored) so it rides workspace
+   persistence into containers across phases."
+  [source-root]
+  (when-not (str/blank? source-root)
+    (str source-root "/" persistent-cache-relpath)))
+
+(defn ^{:stratum 1} flush-misses!
+  "Write accumulated cache misses to context-misses.edn in artifact-dir."
+  [artifact-dir]
+  (let [misses (:misses @cache-state)]
+    (when (seq misses)
+      (let [path (str artifact-dir "/context-misses.edn")]
+        (spit path (pr-str misses))
+        (binding [*out* *err*]
+          (println (msg/t :cache/misses-written {:count (count misses) :path path})))))))
+
+(defn ^{:stratum 1} flush-reads!
+  "Write every recorded context_read resolution to context-reads.edn in
+   artifact-dir — the recorded flows a §7.4.3 gate condition reads."
+  [artifact-dir]
+  (let [reads (:reads @cache-state)]
+    (when (seq reads)
+      (spit (str artifact-dir "/context-reads.edn") (pr-str reads)))))
+
+;; `handle-submit` (the artifact.edn metadata channel) removed: the artifact is
+;; the worktree/container diff (promotion); the curator derives the summary.
+;; Models ignored the opt-in submit tool anyway. See artifact_session/mcp-tools.
+(defn- ^{:stratum 1} record-miss!
+  "Record a cache miss for meta-loop learning."
+  [tool-name params tokens]
+  (swap! cache-state update :misses conj
+         (merge {:tool tool-name
+                 :tokens tokens
+                 :timestamp (str (java.time.Instant/now))}
+                params)))
+
+(defn- ^{:stratum 1} record-read!
+  "Record every context_read resolution — hit AND miss. `source` is
+   :cache | :filesystem | :refresh | :absent. Misses track what the
+   pre-load lacked; reads answer the different question of what the agent
+   actually consulted (Codex SPEC §7.4.2)."
+  [path source]
+  (swap! cache-state update :reads conj
+         {:path path
+          :source source
+          :timestamp (str (java.time.Instant/now))}))
+
+(defn- ^{:stratum 1} cache-get
+  "Get cached content for a path, or nil if not cached."
+  [path]
+  (get-in @cache-state [:files path]))
+
+(defn- ^{:stratum 1} cached-files
+  "Return the current files map from the cache."
+  []
+  (:files @cache-state))
+
+(defn- ^{:stratum 1} grep-response
+  "Build MCP response from grep results. Returns formatted matches or
+   a no-matches message when empty."
+  [results]
+  (text-response
+    (if (seq results)
+      (format-grep-results results)
+      (msg/t :context/no-grep-matches))))
+
+;; Grep helpers: file selection and fallback
+(defn ^{:stratum 1} filter-cached-files
+  "Select which cached files to search based on path or glob filter.
+   Returns a {path → content} map."
+  [files target-path glob-filter]
+  (cond
+    target-path  (select-keys files [target-path])
+    glob-filter  (into {} (filter (fn [[p _]] (glob-matches? glob-filter p))) files)
+    :else        files))
+
+(defn- ^{:stratum 1} search-cached-files
+  "Grep across a map of {path → content} for a pattern.
+   Returns a flat vector of grep result maps."
+  [files-map pattern-str]
+  (into [] (mapcat (fn [[path content]] (grep-file path content pattern-str))) files-map))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} shell-grep
   "Fall back to ripgrep for files not in cache.
    Returns vector of {:path :line-number :text} or nil."
   [pattern-str path-or-glob]
@@ -119,7 +251,7 @@
              vec)))
     (catch Exception _e nil)))
 
-(defn shell-glob
+(defn ^{:stratum 2} shell-glob
   "Fall back to filesystem glob by walking source-root.
    Returns vector of relative file paths or nil."
   [pattern]
@@ -144,46 +276,38 @@
         matches))
     (catch Exception _e nil)))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Stateful cache operations
-
-;; Cache atom holding :files (path → content), :mtimes (path → epoch-ms of the
-;; file when its content was cached, for write-invalidation), and :misses
-;; (recorded cache misses).
-(defonce cache-state
-  (atom {:files {} :mtimes {} :misses [] :source-root nil :artifact-dir nil :workdir nil}))
-
-(defn reset-state!
-  "Reset cache state. Intended for test isolation."
-  []
-  (reset! cache-state {:files {} :mtimes {} :misses [] :source-root nil :artifact-dir nil :workdir nil}))
-
-(defn set-workdir!
-  "Set the write target for context_write — the agent's worktree, distinct from
-   `:source-root` (the read reference). Reads resolve against source-root;
-   writes land in the worktree where the run collects the diff. Agent-agnostic:
-   every backend's context server is launched with the same command, so this
-   applies to Claude/Codex/Cursor alike."
-  [workdir]
-  (swap! cache-state assoc :workdir workdir))
-
-(defn- source-root
-  []
-  (or (:source-root @cache-state) "."))
-
-(defn- write-root
+(defn- ^{:stratum 2} write-root
   "Root for context_write: the worktree (`:workdir`) when set, else source-root."
   []
   (or (:workdir @cache-state) (source-root)))
 
-(defn- resolve-source-path
+(defn- ^{:stratum 2} resolve-source-path
   [path]
   (let [f (io/file path)]
     (if (.isAbsolute f)
       (.getPath f)
       (.getPath (io/file (source-root) path)))))
 
-(defn- resolve-write-path
+(defn ^{:stratum 2} save-cache!
+  "Persist the accumulated in-memory cache (pre-populated + read-through
+   additions, with mtimes) to the worktree-resident cross-phase cache file so
+   the NEXT phase's server loads it. No-ops without a source-root or when
+   nothing is cached. Best-effort: a write failure is logged, not thrown."
+  []
+  (let [{:keys [source-root files mtimes]} @cache-state]
+    (when-let [path (and (seq files) (persistent-cache-path source-root))]
+      (try
+        (io/make-parents path)
+        (spit path (pr-str {:files files :mtimes mtimes}))
+        (binding [*out* *err*]
+          (println (msg/t :cache/saved {:count (count files) :path path})))
+        (catch Exception e
+          (binding [*out* *err*]
+            (println (msg/t :cache/save-failed {:error (ex-message e)}))))))))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn- ^{:stratum 3} resolve-write-path
   "Resolve a write path against write-root (the worktree)."
   [path]
   (let [f (io/file path)]
@@ -191,25 +315,42 @@
       (.getPath f)
       (.getPath (io/file (write-root) path)))))
 
-(def ^:private persistent-cache-relpath ".miniforge/context-cache.edn")
-
-(defn- persistent-cache-path
-  "Worktree-resident cross-phase cache file, or nil when there's no
-   source-root. Under .miniforge/ (gitignored) so it rides workspace
-   persistence into containers across phases."
-  [source-root]
-  (when-not (str/blank? source-root)
-    (str source-root "/" persistent-cache-relpath)))
-
-(defn- read-cache-edn
-  "Read {:files .. :mtimes ..} from an EDN cache file, or nil on missing/bad."
+(defn- ^{:stratum 3} file-mtime
+  "Last-modified epoch-ms of the resolved source file, or nil if absent."
   [path]
-  (let [f (and path (io/file path))]
-    (when (and f (.exists f))
-      (try (edn/read-string (slurp f))
-           (catch Exception _ nil)))))
+  (let [f (io/file (resolve-source-path path))]
+    (when (.exists f)
+      (.lastModified f))))
 
-(defn load-cache!
+;; Glob helpers
+(defn- ^{:stratum 3} glob-with-union
+  "Match cached paths, union with filesystem glob, record misses for
+   files found only on disk. Returns a sequence of matched paths."
+  [pattern]
+  (let [files         (cached-files)
+        cache-matches (sort (filter #(glob-matches? pattern %) (keys files)))
+        fs-matches    (or (shell-glob pattern) [])
+        cache-set     (set cache-matches)
+        new-from-fs   (remove cache-set fs-matches)]
+    (when (seq new-from-fs)
+      (record-miss! "context_glob"
+                    {:pattern pattern :fs-only-count (count new-from-fs)}
+                    0))
+    (concat cache-matches new-from-fs)))
+
+(defn- ^{:stratum 3} within-write-root?
+  "True when the resolved target canonicalizes to a path inside write-root.
+   Blocks absolute paths and `..` traversal that would let an MCP client
+   overwrite files outside the worktree."
+  [target]
+  (let [root-c   (.getCanonicalPath (io/file (write-root)))
+        target-c (.getCanonicalPath (io/file target))]
+    (or (= target-c root-c)
+        (str/starts-with? target-c (str root-c java.io.File/separator)))))
+
+;------------------------------------------------------------------------------ Layer 4
+
+(defn ^{:stratum 4} load-cache!
   "Load the context cache from two sources (freshest wins):
 
    1. the cross-phase PERSISTENT cache at <source-root>/.miniforge/
@@ -239,59 +380,7 @@
        (binding [*out* *err*]
          (println (msg/t :cache/load-failed {:error (ex-message e)})))))))
 
-(defn save-cache!
-  "Persist the accumulated in-memory cache (pre-populated + read-through
-   additions, with mtimes) to the worktree-resident cross-phase cache file so
-   the NEXT phase's server loads it. No-ops without a source-root or when
-   nothing is cached. Best-effort: a write failure is logged, not thrown."
-  []
-  (let [{:keys [source-root files mtimes]} @cache-state]
-    (when-let [path (and (seq files) (persistent-cache-path source-root))]
-      (try
-        (io/make-parents path)
-        (spit path (pr-str {:files files :mtimes mtimes}))
-        (binding [*out* *err*]
-          (println (msg/t :cache/saved {:count (count files) :path path})))
-        (catch Exception e
-          (binding [*out* *err*]
-            (println (msg/t :cache/save-failed {:error (ex-message e)}))))))))
-
-(defn flush-misses!
-  "Write accumulated cache misses to context-misses.edn in artifact-dir."
-  [artifact-dir]
-  (let [misses (:misses @cache-state)]
-    (when (seq misses)
-      (let [path (str artifact-dir "/context-misses.edn")]
-        (spit path (pr-str misses))
-        (binding [*out* *err*]
-          (println (msg/t :cache/misses-written {:count (count misses) :path path})))))))
-
-;; `handle-submit` (the artifact.edn metadata channel) removed: the artifact is
-;; the worktree/container diff (promotion); the curator derives the summary.
-;; Models ignored the opt-in submit tool anyway. See artifact_session/mcp-tools.
-
-(defn- record-miss!
-  "Record a cache miss for meta-loop learning."
-  [tool-name params tokens]
-  (swap! cache-state update :misses conj
-         (merge {:tool tool-name
-                 :tokens tokens
-                 :timestamp (str (java.time.Instant/now))}
-                params)))
-
-(defn- cache-get
-  "Get cached content for a path, or nil if not cached."
-  [path]
-  (get-in @cache-state [:files path]))
-
-(defn- file-mtime
-  "Last-modified epoch-ms of the resolved source file, or nil if absent."
-  [path]
-  (let [f (io/file (resolve-source-path path))]
-    (when (.exists f)
-      (.lastModified f))))
-
-(defn- cache-put!
+(defn- ^{:stratum 4} cache-put!
   "Store content in the cache for a path, stamping the file's current mtime so
    `cache-stale?` can later detect on-disk changes (write-invalidation)."
   [path content]
@@ -299,7 +388,7 @@
                           (assoc-in [:files path] content)
                           (assoc-in [:mtimes path] (file-mtime path)))))
 
-(defn- cache-stale?
+(defn- ^{:stratum 4} cache-stale?
   "True only when the cached entry can be PROVEN out of date: we recorded an
    mtime for it, the file still exists, and it was modified after we cached.
    When there's no recorded mtime or no on-disk file, staleness cannot be
@@ -312,145 +401,7 @@
         disk   (file-mtime path)]
     (boolean (and cached disk (> disk cached)))))
 
-(defn- cached-files
-  "Return the current files map from the cache."
-  []
-  (:files @cache-state))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Read-through cache: resolve content from cache or filesystem
-
-(defn- read-through
-  "Resolve file content. Fresh cache hit returns instantly. A miss — or a
-   cached entry whose file changed on disk since it was cached — reads from
-   disk, re-caches (with the new mtime), and returns the current content.
-   Records a miss only on a GENUINE miss (never cached), not on a
-   staleness-driven refresh. Returns content string or nil."
-  [path]
-  (let [cached (cache-get path)]
-    (if (and cached (not (cache-stale? path)))
-      cached
-      (try
-        (let [content (slurp (resolve-source-path path))]
-          (cache-put! path content)
-          (when (nil? cached)
-            (record-miss! "context_read" {:path path} (estimate-tokens content)))
-          content)
-        (catch Exception _ nil)))))
-
-;------------------------------------------------------------------------------ Layer 1
-;; MCP response helpers
-
-(defn- text-response
-  "Wrap a string in the MCP tool response shape."
-  [text]
-  {:content [{:type "text" :text text}]})
-
-(defn- error-response
-  "Wrap an error message in the MCP tool error shape."
-  [text]
-  {:content [{:type "text" :text text}] :isError true})
-
-(defn- grep-response
-  "Build MCP response from grep results. Returns formatted matches or
-   a no-matches message when empty."
-  [results]
-  (text-response
-    (if (seq results)
-      (format-grep-results results)
-      (msg/t :context/no-grep-matches))))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Grep helpers: file selection and fallback
-
-(defn filter-cached-files
-  "Select which cached files to search based on path or glob filter.
-   Returns a {path → content} map."
-  [files target-path glob-filter]
-  (cond
-    target-path  (select-keys files [target-path])
-    glob-filter  (into {} (filter (fn [[p _]] (glob-matches? glob-filter p))) files)
-    :else        files))
-
-(defn- search-cached-files
-  "Grep across a map of {path → content} for a pattern.
-   Returns a flat vector of grep result maps."
-  [files-map pattern-str]
-  (into [] (mapcat (fn [[path content]] (grep-file path content pattern-str))) files-map))
-
-(defn- cache-new-files!
-  "Cache files discovered by shell grep that aren't already cached.
-   Records a miss for each newly cached file."
-  [results pattern-str known-files]
-  (doseq [path (distinct (map :path results))
-          :when (not (contains? known-files path))]
-    (try
-      (let [content (slurp (resolve-source-path path))]
-        (cache-put! path content)
-        (record-miss! "context_grep" {:path path :pattern pattern-str}
-                      (estimate-tokens content)))
-      (catch Exception _ nil))))
-
-(defn- grep-with-fallback
-  "Search cached files first. On cache miss, fall back to ripgrep,
-   cache any newly discovered files, and record misses."
-  [pattern-str target-path glob-filter]
-  (let [files         (cached-files)
-        searchable    (filter-cached-files files target-path glob-filter)
-        cache-results (search-cached-files searchable pattern-str)]
-    (if (seq cache-results)
-      cache-results
-      (let [rg-results (or (shell-grep pattern-str (or target-path glob-filter)) [])]
-        (if (seq rg-results)
-          (do (cache-new-files! rg-results pattern-str files)
-              rg-results)
-          (do (record-miss! "context_grep"
-                            {:pattern pattern-str :path target-path
-                             :glob glob-filter :hit false}
-                            0)
-              []))))))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Glob helpers
-
-(defn- glob-with-union
-  "Match cached paths, union with filesystem glob, record misses for
-   files found only on disk. Returns a sequence of matched paths."
-  [pattern]
-  (let [files         (cached-files)
-        cache-matches (sort (filter #(glob-matches? pattern %) (keys files)))
-        fs-matches    (or (shell-glob pattern) [])
-        cache-set     (set cache-matches)
-        new-from-fs   (remove cache-set fs-matches)]
-    (when (seq new-from-fs)
-      (record-miss! "context_glob"
-                    {:pattern pattern :fs-only-count (count new-from-fs)}
-                    0))
-    (concat cache-matches new-from-fs)))
-
-;------------------------------------------------------------------------------ Layer 2
-;; Tool handler functions (compose Layer 0 + Layer 1)
-
-(defn handle-context-read
-  "Handler for context_read MCP tool."
-  [params]
-  (let [path    (get params "path")
-        offset  (get params "offset")
-        limit   (get params "limit")
-        content (read-through path)]
-    (if content
-      (text-response (apply-offset-limit content offset limit))
-      (error-response (msg/t :context/read-error {:path path})))))
-
-(defn handle-context-grep
-  "Handler for context_grep MCP tool."
-  [params]
-  (grep-response
-    (grep-with-fallback (get params "pattern")
-                        (get params "path")
-                        (get params "glob"))))
-
-(defn handle-context-glob
+(defn ^{:stratum 4} handle-context-glob
   "Handler for context_glob MCP tool."
   [params]
   (let [matches (glob-with-union (get params "pattern"))]
@@ -459,17 +410,7 @@
         (str/join "\n" matches)
         (msg/t :context/no-glob-matches)))))
 
-(defn- within-write-root?
-  "True when the resolved target canonicalizes to a path inside write-root.
-   Blocks absolute paths and `..` traversal that would let an MCP client
-   overwrite files outside the worktree."
-  [target]
-  (let [root-c   (.getCanonicalPath (io/file (write-root)))
-        target-c (.getCanonicalPath (io/file target))]
-    (or (= target-c root-c)
-        (str/starts-with? target-c (str root-c java.io.File/separator)))))
-
-(defn handle-context-write
+(defn ^{:stratum 4} handle-context-write
   "Handler for the context_write MCP tool. Writes the full file content to the
    worktree (write-root) and refreshes the cache so a later context_read returns
    the new content. Agent-agnostic edit path — works for any MCP client and,
@@ -502,3 +443,89 @@
         (catch Exception e
           (error-response (msg/t :context/write-failed
                                  {:path path :error (ex-message e)})))))))
+
+;------------------------------------------------------------------------------ Layer 5
+
+;; Read-through cache: resolve content from cache or filesystem
+(defn- ^{:stratum 5} read-through
+  "Resolve file content. Fresh cache hit returns instantly. A miss — or a
+   cached entry whose file changed on disk since it was cached — reads from
+   disk, re-caches (with the new mtime), and returns the current content.
+   Records a miss only on a GENUINE miss (never cached), not on a
+   staleness-driven refresh. Returns content string or nil."
+  [path]
+  (let [cached (cache-get path)]
+    (if (and cached (not (cache-stale? path)))
+      (do (record-read! path :cache)
+          cached)
+      (try
+        (let [content (slurp (resolve-source-path path))]
+          (cache-put! path content)
+          (when (nil? cached)
+            (record-miss! "context_read" {:path path} (estimate-tokens content)))
+          (record-read! path (if cached :refresh :filesystem))
+          content)
+        (catch Exception _
+          (record-read! path :absent)
+          nil)))))
+
+(defn- ^{:stratum 5} cache-new-files!
+  "Cache files discovered by shell grep that aren't already cached.
+   Records a miss for each newly cached file."
+  [results pattern-str known-files]
+  (doseq [path (distinct (map :path results))
+          :when (not (contains? known-files path))]
+    (try
+      (let [content (slurp (resolve-source-path path))]
+        (cache-put! path content)
+        (record-miss! "context_grep" {:path path :pattern pattern-str}
+                      (estimate-tokens content)))
+      (catch Exception _ nil))))
+
+;------------------------------------------------------------------------------ Layer 6
+
+(defn- ^{:stratum 6} grep-with-fallback
+  "Search cached files first. On cache miss, fall back to ripgrep,
+   cache any newly discovered files, and record misses."
+  [pattern-str target-path glob-filter]
+  (let [files         (cached-files)
+        searchable    (filter-cached-files files target-path glob-filter)
+        cache-results (search-cached-files searchable pattern-str)]
+    (if (seq cache-results)
+      cache-results
+      (let [rg-results (or (shell-grep pattern-str (or target-path glob-filter)) [])]
+        (if (seq rg-results)
+          (do (cache-new-files! rg-results pattern-str files)
+              rg-results)
+          (do (record-miss! "context_grep"
+                            {:pattern pattern-str :path target-path
+                             :glob glob-filter :hit false}
+                            0)
+              []))))))
+
+;; Tool handler functions (compose Layer 0 + Layer 1)
+(defn ^{:stratum 6} handle-context-read
+  "Handler for context_read MCP tool."
+  [params]
+  (let [path    (get params "path")
+        offset  (get params "offset")
+        limit   (get params "limit")
+        content (read-through path)]
+    (if content
+      (text-response (apply-offset-limit content offset limit))
+      (error-response (msg/t :context/read-error {:path path})))))
+
+;------------------------------------------------------------------------------ Layer 7
+
+(defn ^{:stratum 7} handle-context-grep
+  "Handler for context_grep MCP tool."
+  [params]
+  (grep-response
+    (grep-with-fallback (get params "pattern")
+                        (get params "path")
+                        (get params "glob"))))
+
+;; Shell fallbacks
+(declare source-root)
+
+(declare file-mtime)

--- a/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/context_cache.clj
+++ b/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/context_cache.clj
@@ -524,8 +524,3 @@
     (grep-with-fallback (get params "pattern")
                         (get params "path")
                         (get params "glob"))))
-
-;; Shell fallbacks
-(declare source-root)
-
-(declare file-mtime)

--- a/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/server.clj
+++ b/bases/mcp-context-server/src/ai/miniforge/mcp_context_server/server.clj
@@ -91,6 +91,7 @@
            (recur))))
      (finally
        (context-cache/flush-misses! artifact-dir)
+       (context-cache/flush-reads! artifact-dir)
        ;; Persist the accumulated cache (incl. read-through additions) to the
        ;; worktree so the next phase loads it — cross-phase write-through.
        (context-cache/save-cache!)))))

--- a/bases/mcp-context-server/test/ai/miniforge/mcp_context_server/context_cache_test.clj
+++ b/bases/mcp-context-server/test/ai/miniforge/mcp_context_server/context_cache_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.mcp-context-server.context-cache-test
   "Unit tests for context cache pure helpers and tool handlers."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
@@ -24,15 +23,13 @@
             [ai.miniforge.mcp-context-server.context-cache :as cache]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Test fixtures
 
-(defn with-clean-cache [f]
+;; Test fixtures
+(defn ^{:stratum 0} with-clean-cache [f]
   (cache/reset-state!)
   (try (f) (finally (cache/reset-state!))))
 
-(use-fixtures :each with-clean-cache)
-
-(defn with-temp-dir [f]
+(defn ^{:stratum 0} with-temp-dir [f]
   (let [dir (str (java.nio.file.Files/createTempDirectory
                    "ctx-cache-test-"
                    (into-array java.nio.file.attribute.FileAttribute [])))]
@@ -42,10 +39,8 @@
         (doseq [file (reverse (file-seq (io/file dir)))]
           (.delete ^java.io.File file))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Pure helper tests
-
-(deftest estimate-tokens-test
+(deftest ^{:stratum 0} estimate-tokens-test
   (testing "estimates ~4 chars per token"
     (is (= 3 (cache/estimate-tokens "hello world!")))
     (is (= 1 (cache/estimate-tokens "abc"))))
@@ -55,7 +50,7 @@
     (is (= 0 (cache/estimate-tokens nil)))
     (is (= 0 (cache/estimate-tokens 42)))))
 
-(deftest apply-offset-limit-test
+(deftest ^{:stratum 0} apply-offset-limit-test
   (let [content "line0\nline1\nline2\nline3\nline4"]
 
     (testing "no offset or limit returns all lines"
@@ -73,7 +68,7 @@
     (testing "nil content returns empty"
       (is (= "" (cache/apply-offset-limit nil nil nil))))))
 
-(deftest glob-matches?-test
+(deftest ^{:stratum 0} glob-matches?-test
   (testing "single star matches one segment"
     (is (cache/glob-matches? "src/*.clj" "src/core.clj"))
     (is (not (cache/glob-matches? "src/*.clj" "src/nested/core.clj"))))
@@ -89,7 +84,7 @@
   (testing "dots are literal"
     (is (not (cache/glob-matches? "src/*.clj" "src/corexclj")))))
 
-(deftest grep-file-test
+(deftest ^{:stratum 0} grep-file-test
   (let [content "(ns core)\n\n(defn greet [name]\n  (str \"Hello, \" name))"]
 
     (testing "finds matching lines with line numbers"
@@ -104,30 +99,103 @@
     (testing "returns empty on invalid regex"
       (is (empty? (cache/grep-file "src/core.clj" content "[invalid"))))))
 
-(deftest format-grep-results-test
+(deftest ^{:stratum 0} format-grep-results-test
   (testing "formats as path:line:text"
     (is (= "a.clj:1:hello\nb.clj:5:world"
            (cache/format-grep-results
              [{:path "a.clj" :line-number 1 :text "hello"}
               {:path "b.clj" :line-number 5 :text "world"}])))))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Tool handler tests
-
-(deftest handle-context-read-cache-hit-test
+(deftest ^{:stratum 0} handle-context-read-cache-hit-test
   (testing "returns cached content"
     (swap! cache/cache-state assoc-in [:files "src/core.clj"] "(ns core)\n(defn hello [])")
     (let [result (cache/handle-context-read {"path" "src/core.clj"})]
       (is (= "(ns core)\n(defn hello [])" (get-in result [:content 0 :text])))
       (is (not (:isError result))))))
 
-(deftest handle-context-read-offset-limit-test
+(deftest ^{:stratum 0} handle-context-read-offset-limit-test
   (testing "applies offset and limit on cache hit"
     (swap! cache/cache-state assoc-in [:files "src/core.clj"] "line0\nline1\nline2\nline3")
     (let [result (cache/handle-context-read {"path" "src/core.clj" "offset" 1 "limit" 2})]
       (is (= "line1\nline2" (get-in result [:content 0 :text]))))))
 
-(deftest handle-context-read-cache-miss-test
+(deftest ^{:stratum 0} handle-context-read-nonexistent-test
+  (testing "returns error for nonexistent file"
+    (let [result (cache/handle-context-read {"path" "/nonexistent/path.clj"})]
+      (is (:isError result))
+      (is (re-find #"Error reading" (get-in result [:content 0 :text]))))))
+
+(deftest ^{:stratum 0} handle-context-grep-cache-hit-test
+  (testing "finds pattern in cached files"
+    (swap! cache/cache-state assoc-in [:files "src/alpha.clj"]
+           "(ns alpha)\n\n(defn greet [name]\n  (str name))")
+    (swap! cache/cache-state assoc-in [:files "src/beta.clj"]
+           "(ns beta)\n\n(defn process [x]\n  (inc x))")
+    (let [result (cache/handle-context-grep {"pattern" "defn greet"})]
+      (is (re-find #"alpha\.clj" (get-in result [:content 0 :text])))
+      (is (re-find #"defn greet" (get-in result [:content 0 :text]))))))
+
+(deftest ^{:stratum 0} handle-context-grep-specific-file-test
+  (testing "path restricts search to one file"
+    (swap! cache/cache-state assoc-in [:files "src/alpha.clj"]
+           "(defn greet [name] name)")
+    (swap! cache/cache-state assoc-in [:files "src/beta.clj"]
+           "(defn greet [user] user)")
+    (let [result (cache/handle-context-grep {"pattern" "defn" "path" "src/beta.clj"})]
+      (is (re-find #"beta\.clj" (get-in result [:content 0 :text])))
+      (is (not (re-find #"alpha\.clj" (get-in result [:content 0 :text])))))))
+
+(deftest ^{:stratum 0} handle-context-grep-glob-filter-test
+  (testing "glob filter restricts search"
+    (swap! cache/cache-state assoc-in [:files "src/core.clj"] "(defn foo [])")
+    (swap! cache/cache-state assoc-in [:files "test/core_test.clj"] "(deftest foo-test)")
+    (let [result (cache/handle-context-grep {"pattern" "def" "glob" "test/*.clj"})]
+      (is (re-find #"core_test\.clj" (get-in result [:content 0 :text])))
+      (is (not (re-find #"src/" (get-in result [:content 0 :text])))))))
+
+(deftest ^{:stratum 0} handle-context-grep-no-match-test
+  (testing "returns no matches message"
+    (swap! cache/cache-state assoc-in [:files "src/core.clj"] "(ns core)")
+    (let [result (cache/handle-context-grep {"pattern" "zzz_nonexistent_zzz"})]
+      (is (re-find #"[Nn]o matches" (get-in result [:content 0 :text]))))))
+
+(deftest ^{:stratum 0} handle-context-glob-cached-paths-test
+  (testing "matches cached file paths"
+    (swap! cache/cache-state assoc-in [:files "src/alpha.clj"] "a")
+    (swap! cache/cache-state assoc-in [:files "src/beta.clj"] "b")
+    (swap! cache/cache-state assoc-in [:files "test/alpha_test.clj"] "t")
+    (let [result (cache/handle-context-glob {"pattern" "src/*.clj"})
+          text (get-in result [:content 0 :text])]
+      (is (re-find #"alpha\.clj" text))
+      (is (re-find #"beta\.clj" text))
+      (is (not (re-find #"test/" text))))))
+
+(deftest ^{:stratum 0} handle-context-glob-no-match-test
+  (testing "returns no files matched message"
+    (let [result (cache/handle-context-glob {"pattern" "nonexistent/**/*.xyz"})]
+      (is (re-find #"[Nn]o files matched" (get-in result [:content 0 :text]))))))
+
+;------------------------------------------------------------------------------ Write-invalidation + cross-phase persistence (Fable #4)
+(defn- ^{:stratum 0} read-text [result]
+  (get-in result [:content 0 :text]))
+
+(deftest ^{:stratum 0} save-cache-noop-without-source-root-test
+  (testing "save-cache! is a safe no-op when there's no source-root"
+    (cache/reset-state!)
+    (swap! cache/cache-state assoc :files {"x" "y"})
+    (is (nil? (cache/save-cache!)) "no throw, nothing to persist without a worktree")))
+
+(deftest ^{:stratum 0} handle-context-write-rejects-bad-input-test
+  (cache/reset-state!)
+  (is (:isError (cache/handle-context-write {"path" "" "content" "x"}))
+      "blank path rejected")
+  (is (:isError (cache/handle-context-write {"path" "f" "content" nil}))
+      "nil content rejected"))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} handle-context-read-cache-miss-test
   (testing "falls back to filesystem and records miss"
     (with-temp-dir
       (fn [dir]
@@ -141,66 +209,8 @@
             (is (= 1 (count (:misses @cache/cache-state))))
             (is (= "context_read" (:tool (first (:misses @cache/cache-state)))))))))))
 
-(deftest handle-context-read-nonexistent-test
-  (testing "returns error for nonexistent file"
-    (let [result (cache/handle-context-read {"path" "/nonexistent/path.clj"})]
-      (is (:isError result))
-      (is (re-find #"Error reading" (get-in result [:content 0 :text]))))))
-
-(deftest handle-context-grep-cache-hit-test
-  (testing "finds pattern in cached files"
-    (swap! cache/cache-state assoc-in [:files "src/alpha.clj"]
-           "(ns alpha)\n\n(defn greet [name]\n  (str name))")
-    (swap! cache/cache-state assoc-in [:files "src/beta.clj"]
-           "(ns beta)\n\n(defn process [x]\n  (inc x))")
-    (let [result (cache/handle-context-grep {"pattern" "defn greet"})]
-      (is (re-find #"alpha\.clj" (get-in result [:content 0 :text])))
-      (is (re-find #"defn greet" (get-in result [:content 0 :text]))))))
-
-(deftest handle-context-grep-specific-file-test
-  (testing "path restricts search to one file"
-    (swap! cache/cache-state assoc-in [:files "src/alpha.clj"]
-           "(defn greet [name] name)")
-    (swap! cache/cache-state assoc-in [:files "src/beta.clj"]
-           "(defn greet [user] user)")
-    (let [result (cache/handle-context-grep {"pattern" "defn" "path" "src/beta.clj"})]
-      (is (re-find #"beta\.clj" (get-in result [:content 0 :text])))
-      (is (not (re-find #"alpha\.clj" (get-in result [:content 0 :text])))))))
-
-(deftest handle-context-grep-glob-filter-test
-  (testing "glob filter restricts search"
-    (swap! cache/cache-state assoc-in [:files "src/core.clj"] "(defn foo [])")
-    (swap! cache/cache-state assoc-in [:files "test/core_test.clj"] "(deftest foo-test)")
-    (let [result (cache/handle-context-grep {"pattern" "def" "glob" "test/*.clj"})]
-      (is (re-find #"core_test\.clj" (get-in result [:content 0 :text])))
-      (is (not (re-find #"src/" (get-in result [:content 0 :text])))))))
-
-(deftest handle-context-grep-no-match-test
-  (testing "returns no matches message"
-    (swap! cache/cache-state assoc-in [:files "src/core.clj"] "(ns core)")
-    (let [result (cache/handle-context-grep {"pattern" "zzz_nonexistent_zzz"})]
-      (is (re-find #"[Nn]o matches" (get-in result [:content 0 :text]))))))
-
-(deftest handle-context-glob-cached-paths-test
-  (testing "matches cached file paths"
-    (swap! cache/cache-state assoc-in [:files "src/alpha.clj"] "a")
-    (swap! cache/cache-state assoc-in [:files "src/beta.clj"] "b")
-    (swap! cache/cache-state assoc-in [:files "test/alpha_test.clj"] "t")
-    (let [result (cache/handle-context-glob {"pattern" "src/*.clj"})
-          text (get-in result [:content 0 :text])]
-      (is (re-find #"alpha\.clj" text))
-      (is (re-find #"beta\.clj" text))
-      (is (not (re-find #"test/" text))))))
-
-(deftest handle-context-glob-no-match-test
-  (testing "returns no files matched message"
-    (let [result (cache/handle-context-glob {"pattern" "nonexistent/**/*.xyz"})]
-      (is (re-find #"[Nn]o files matched" (get-in result [:content 0 :text]))))))
-
-;------------------------------------------------------------------------------ Layer 2
 ;; Lifecycle tests
-
-(deftest load-cache-roundtrip-test
+(deftest ^{:stratum 1} load-cache-roundtrip-test
   (testing "load-cache! reads context-cache.edn and populates atom"
     (with-temp-dir
       (fn [dir]
@@ -214,8 +224,7 @@
 ;; The submit/artifact.edn tests were removed with the submit tool — the
 ;; artifact is now the worktree/container diff (promotion), not an agent
 ;; metadata channel.
-
-(deftest handle-context-read-source-root-fallback-test
+(deftest ^{:stratum 1} handle-context-read-source-root-fallback-test
   (testing "relative file reads resolve from source-root when cache is empty"
     (with-temp-dir
       (fn [dir]
@@ -229,7 +238,7 @@
             (is (= "(ns demo.core)"
                    (get-in @cache/cache-state [:files "components/demo/core.clj"])))))))))
 
-(deftest handle-context-glob-source-root-fallback-test
+(deftest ^{:stratum 1} handle-context-glob-source-root-fallback-test
   (testing "relative glob fallback searches from source-root"
     (with-temp-dir
       (fn [dir]
@@ -241,7 +250,7 @@
             (is (re-find #"components/alpha/src/demo/core\.clj"
                          (get-in result [:content 0 :text])))))))))
 
-(deftest handle-context-glob-source-root-fallback-prunes-git-test
+(deftest ^{:stratum 1} handle-context-glob-source-root-fallback-prunes-git-test
   (testing "filesystem glob fallback ignores .git contents"
     (with-temp-dir
       (fn [dir]
@@ -256,7 +265,7 @@
             (is (re-find #"components/alpha/src/demo/core\.clj" text))
             (is (not (re-find #"\.git/objects/aa/hidden\.clj" text)))))))))
 
-(deftest flush-misses-roundtrip-test
+(deftest ^{:stratum 1} flush-misses-roundtrip-test
   (testing "flush-misses! writes misses to context-misses.edn"
     (with-temp-dir
       (fn [dir]
@@ -269,19 +278,14 @@
           (is (= "context_read" (:tool (first misses))))
           (is (= "src/x.clj" (:path (first misses)))))))))
 
-(deftest flush-misses-noop-when-empty-test
+(deftest ^{:stratum 1} flush-misses-noop-when-empty-test
   (testing "flush-misses! does not write file when no misses"
     (with-temp-dir
       (fn [dir]
         (cache/flush-misses! dir)
         (is (not (.exists (io/file (str dir "/context-misses.edn")))))))))
 
-;------------------------------------------------------------------------------ Write-invalidation + cross-phase persistence (Fable #4)
-
-(defn- read-text [result]
-  (get-in result [:content 0 :text]))
-
-(deftest read-through-invalidates-on-disk-change-test
+(deftest ^{:stratum 1} read-through-invalidates-on-disk-change-test
   (testing "a cached read is re-read when the file changes on disk — no stale
             content after a write (the safety guard for forcing write-heavy
             agents onto context_read, and for cross-phase persistence)"
@@ -299,7 +303,7 @@
           (is (= "V2" (read-text (cache/handle-context-read {"path" "src/a.clj"})))
               "second read returns fresh V2, not the stale cached V1"))))))
 
-(deftest save-cache-persists-across-phases-test
+(deftest ^{:stratum 1} save-cache-persists-across-phases-test
   (testing "save-cache! writes the accumulated cache to <source-root>/.miniforge,
             and a fresh load (next phase) picks it up"
     (with-temp-dir
@@ -320,16 +324,8 @@
           (is (contains? (:mtimes @cache/cache-state) "src/b.clj")
               "its mtime is restored so staleness is still detectable"))))))
 
-(deftest save-cache-noop-without-source-root-test
-  (testing "save-cache! is a safe no-op when there's no source-root"
-    (cache/reset-state!)
-    (swap! cache/cache-state assoc :files {"x" "y"})
-    (is (nil? (cache/save-cache!)) "no throw, nothing to persist without a worktree")))
-
-;------------------------------------------------------------------------------ Layer 3
 ;; context_write handler
-
-(deftest handle-context-write-writes-to-workdir-and-caches-test
+(deftest ^{:stratum 1} handle-context-write-writes-to-workdir-and-caches-test
   (with-temp-dir
     (fn [dir]
       (cache/reset-state!)
@@ -342,7 +338,7 @@
           (let [read-resp (cache/handle-context-read {"path" "src/new.clj"})]
             (is (= "(ns new)" (-> read-resp :content first :text)))))))))
 
-(deftest handle-context-write-overwrites-existing-test
+(deftest ^{:stratum 1} handle-context-write-overwrites-existing-test
   (with-temp-dir
     (fn [dir]
       (cache/reset-state!)
@@ -354,14 +350,7 @@
         (is (= "(ns a-v2)" (-> (cache/handle-context-read {"path" "a.clj"}) :content first :text))
             "an existing file is edited and the cache reflects it")))))
 
-(deftest handle-context-write-rejects-bad-input-test
-  (cache/reset-state!)
-  (is (:isError (cache/handle-context-write {"path" "" "content" "x"}))
-      "blank path rejected")
-  (is (:isError (cache/handle-context-write {"path" "f" "content" nil}))
-      "nil content rejected"))
-
-(deftest handle-context-write-rejects-path-escapes-test
+(deftest ^{:stratum 1} handle-context-write-rejects-path-escapes-test
   (with-temp-dir
     (fn [dir]
       (cache/reset-state!)
@@ -374,3 +363,28 @@
         (is (:isError (cache/handle-context-write
                        {"path" "/tmp/abs-escape.clj" "content" "x"})))
         (is (not (.exists (io/file "/tmp/abs-escape.clj"))))))))
+
+(deftest ^{:stratum 1} context-reads-are-recorded-hits-and-misses-test
+  (cache/reset-state!)
+  ;; A virtual pin path: present in the cache, no file on disk. cache-stale?
+  ;; never fires for it, so it resolves as a :cache hit forever — the pin
+  ;; primitive the Codex SPEC §7.4 blackboard pin relies on.
+  (swap! cache/cache-state assoc-in
+         [:files ".miniforge/codex-consider.md"] "pinned landings")
+  (cache/handle-context-read {"path" ".miniforge/codex-consider.md"})
+  (cache/handle-context-read {"path" "no/such/file.txt"})
+  (let [reads (:reads @cache/cache-state)]
+    (is (= [{:path ".miniforge/codex-consider.md" :source :cache}
+            {:path "no/such/file.txt" :source :absent}]
+           (mapv #(select-keys % [:path :source]) reads))
+        "every resolution recorded, hit and miss (§7.4.2)")
+    (is (every? :timestamp reads)))
+  (testing "flush writes context-reads.edn"
+    (with-temp-dir
+      (fn [dir]
+        (cache/flush-reads! dir)
+        (let [f (io/file (str dir "/context-reads.edn"))]
+          (is (.exists f))
+          (is (= 2 (count (edn/read-string (slurp f))))))))))
+
+(use-fixtures :each with-clean-cache)


### PR DESCRIPTION
Slice B of [#1622](https://github.com/miniforge-ai/miniforge/pull/1622), decomposed per the size gate. Independent of slice A ([#1623](https://github.com/miniforge-ai/miniforge/pull/1623)); slice C (the phase-start pin + session surfacing of the reads file) lands after both.

The context cache records every `context_read` resolution — cache hit, staleness refresh, filesystem miss, absent — and flushes `context-reads.edn` beside `context-misses.edn` on server exit. Misses track what the pre-load lacked; reads answer the different question of what the agent actually consulted (Codex SPEC §7.4.2). Once the phase-start pin lands, "did this agent read its pinned landings" becomes answerable and gateable (§7.4.3).

The added test also pins the virtual-path property the pin relies on: a cached path with no on-disk file resolves as a :cache hit forever, because staleness invalidation only fires for paths that exist on disk.

MINIFORGE_PR_BUDGET_OVERRIDE: 413 of the reportable lines are the stratum autofix annotation rewrite of context_cache.clj, a pre-existing strata-violations-baseline entry the commit hook fully annotates on any touch; the functional diff is ~60 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)