### PR TITLE
fix(bb.edn): complete classpath for extract:artifact task

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -513,7 +513,10 @@
 
   extract:artifact
   {:doc "Extract files from a code artifact EDN file and write them to disk"
-   :extra-paths ["components/evidence-bundle/src"]
+   :extra-paths ["components/evidence-bundle/src"
+                 "components/response/src"
+                 "components/messages/src"]
+   :extra-deps {slingshot/slingshot {:mvn/version "0.12.2"}}
    :requires ([ai.miniforge.evidence-bundle.extraction-bulk :as extraction-bulk])
    :task (if-let [artifact-file (first *command-line-args*)]
            (let [result (extraction-bulk/extract-artifact-from-file artifact-file)]


### PR DESCRIPTION
## Summary
- `bb extract:artifact` fails on unmodified main: `extraction.clj` requires `ai.miniforge.response.interface`, which was not on the task's `:extra-paths`, so babashka throws `FileNotFoundException` at namespace load before the task body runs.
- Traced the full transitive chain: `response.interface` → `response.messages` → `ai.miniforge.messages.interface` (component `messages`), and `response.interface` → `response.anomaly` → `slingshot.slingshot` (a maven dep, not bundled with babashka).
- Added `components/response/src` and `components/messages/src` to `:extra-paths`, and `slingshot/slingshot {:mvn/version "0.12.2"}` to `:extra-deps` (version matches every other deps.edn pin of slingshot in the repo).

## Test plan
- [x] `bb extract:artifact` (no args) prints the usage message and exits 1 — no longer throws.
- [x] `bb extract:artifact <artifact-file>` against a real `:code/files` artifact EDN successfully creates the target file.
- [x] Pre-commit hooks (poly check, stratum-lint, smoke tests, GraalVM/bb compatibility) all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)