### PR TITLE
fix(operator): make retries reachable through the ownership gate

### DIFF
--- a/components/operator/src/ai/miniforge/operator/application.clj
+++ b/components/operator/src/ai/miniforge/operator/application.clj
@@ -24,6 +24,16 @@
    publishing every transition through the consumer's canonical
    state-changed emitter.
 
+   This namespace is the facade: it owns the process-scoped registries
+   (live runners, degradation manager, resume launcher, policy
+   evaluator), the ownership predicate a consumer uses to claim an
+   event, and the `apply-intervention!` hook that dispatches an approved
+   intervention to its verb applier. The verb appliers live in
+   [[ai.miniforge.operator.application.verbs]] and the lifecycle
+   primitives they compose in [[ai.miniforge.operator.application.core]]
+   — split out so no single namespace exceeds the three-layer budget
+   (rule 210).
+
    Application mapping (Phase D design decision 5, v1):
 
    | intervention                       | mechanism                          |
@@ -36,11 +46,11 @@
    | :waive / :request-replan           | not yet applied — fail loudly      |
 
    **Process-lifetime honesty:** control-state is in-process, so
-   interventions act only on workflows registered by a live runner in
-   THIS process. Anything else fails visibly with a localized reason
-   and a typed `:failure/code` — rather than pretending. The
-   not-yet-applied verbs fail the same way: a red chip with a stable
-   code beats silently-parked hope.
+   control-state interventions act only on workflows registered by a
+   live runner in THIS process. Anything else fails visibly with a
+   localized reason and a typed `:failure/code` — rather than
+   pretending. The not-yet-applied verbs fail the same way: a red chip
+   with a stable code beats silently-parked hope.
 
    `:waive` stays unapplied on purpose. N5-delta-1 §6 Waiver records
    have a schema (`schema/Waiver`) and a TUI surface that derives
@@ -58,12 +68,10 @@
    re-evaluation by finding a PolicyEvaluation in the materialized
    entity table that was not there before the publish."
   (:require
-   [ai.miniforge.event-stream.interface :as es]
-   [ai.miniforge.operator.consumer :as consumer]
+   [ai.miniforge.operator.application.core :as core]
+   [ai.miniforge.operator.application.verbs :as verbs]
    [ai.miniforge.operator.intervention :as intervention]
-   [ai.miniforge.operator.mechanism :as mechanism]
-   [ai.miniforge.operator.messages :as messages]
-   [ai.miniforge.reliability.interface :as reliability]))
+   [ai.miniforge.operator.messages :as messages]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -93,59 +101,22 @@
   ;; a PR fetcher — both adapter-owned.
   (atom nil))
 
-(def ^{:stratum 0} ^:private failure-message-key-by-code
-  {:application-error :application/application-error
-   :control-state-readback-mismatch :application/control-state-readback-mismatch
-   :missing-phase :application/missing-phase
-   :no-degradation-manager :application/no-degradation-manager
-   :invalid-policy-evaluation :application/invalid-policy-evaluation
-   :no-live-runner :application/no-live-runner
-   :no-policy-evaluator :application/no-policy-evaluator
-   :no-resume-context :application/no-resume-context
-   :no-resume-launcher :application/no-resume-launcher
-   :not-implemented :application/not-implemented
-   :policy-evaluation-readback-mismatch :application/policy-evaluation-readback-mismatch
-   :resume-not-dispatched :application/resume-not-dispatched
-   :resume-readback-mismatch :application/resume-readback-mismatch
-   :safe-mode-readback-mismatch :application/safe-mode-readback-mismatch
-   :unknown-phase :application/unknown-phase
-   :unresolved-workflow-type :application/unresolved-workflow-type})
-
-(def ^{:stratum 0} ^:private expected-degradation-mode-by-verb
-  {:force-safe-mode :safe-mode
-   :exit-safe-mode :nominal})
-
-(defn- ^{:stratum 0} intervention-justification
-  [interv]
-  (if-some [justification (:intervention/justification interv)]
-    justification
-    (messages/t :application/default-justification)))
-
-(defn- ^{:stratum 0} transition-succeeded?
-  [result]
-  (true? (:success? result)))
-
-;; ── Mechanisms ─────────────────────────────────────────────────────────────
-(defn- ^{:stratum 0} control-state-effect!
-  "Flip the control-state flag for `verb` and return the readback the
-   verification step asserts."
-  [control-state verb]
-  (case verb
-    :pause  (do (es/pause! control-state)
-                {:verb :pause :observed (boolean (es/paused? control-state))
-                 :expected true})
-    :resume (do (es/resume! control-state)
-                {:verb :resume :observed (boolean (es/paused? control-state))
-                 :expected false})
-    :cancel (do (es/cancel! control-state)
-                {:verb :cancel :observed (boolean (es/cancelled? control-state))
-                 :expected true})))
-
-(defn- ^{:stratum 0} resume-events-dir
-  [launcher]
-  (or (:events-dir launcher) (es/default-events-dir)))
+(def ^{:stratum 0} ^:private resume-ownership-verbs
+  "Retry verbs whose ownership cannot hinge on a live runner. Their
+   canonical target type is `:workflow`, but a retry restarts a run
+   whose original runner is gone by definition — the live runner it
+   would gate on is exactly the thing it will never have. So they are
+   process-global for ownership: whichever consumer sees one claims it,
+   and the application layer either dispatches through the registered
+   resume launcher or fails `:no-resume-launcher` — a visible red chip,
+   never a silent park."
+  #{:retry :retry-from-phase})
 
 ;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} live-runner?
+  [workflow-id]
+  (contains? @live-runners (str workflow-id)))
 
 (defn ^{:stratum 1} register-runner!
   "Register a live runner's control handles for `workflow-id`.
@@ -222,10 +193,6 @@
   (swap! live-runners dissoc (str workflow-id))
   nil)
 
-(defn ^{:stratum 1} live-runner?
-  [workflow-id]
-  (contains? @live-runners (str workflow-id)))
-
 (defn ^{:stratum 1} live-intervention-stream
   "Return the registered event stream for a workflow-targeted
    intervention, or nil for process-global and unowned targets."
@@ -236,172 +203,8 @@
     (:event-stream
      (get @live-runners (str (:intervention/target-id event))))))
 
-(defn- ^{:stratum 1} failure-message
-  [reason-code]
-  (messages/t (get failure-message-key-by-code
-                   reason-code
-                   :application/unknown-failure)))
-
-;; Lifecycle publication helpers
-(defn- ^{:stratum 1} advance!
-  "Apply lifecycle `step-fn` to `interv`, publish the transition, and
-   return the updated intervention. Returns nil when the lifecycle step
-   itself is rejected."
-  [stream interv step-fn & step-args]
-  (let [result (apply step-fn interv step-args)]
-    (if (transition-succeeded? result)
-      (let [updated (:intervention result)]
-        (consumer/publish-state-changed! stream updated)
-        updated)
-      nil)))
-
-(defn- ^{:stratum 1} safe-mode-effect!
-  "Move the degradation manager for `verb` and return the readback the
-   verification step asserts."
-  [manager verb interv]
-  (let [justification (intervention-justification interv)]
-    (case verb
-      :force-safe-mode
-      (reliability/enter-safe-mode! manager :manual justification)
-      :exit-safe-mode
-      (reliability/exit-safe-mode! manager
-                                   justification
-                                   (:intervention/requested-by interv)))
-    {:verb verb
-     :observed (reliability/degradation-mode manager)
-     :expected (get expected-degradation-mode-by-verb verb)}))
-
-;------------------------------------------------------------------------------ Layer 2
-
-(defn ^{:stratum 2} live-intervention-target?
-  "True when this process may claim `event` for application. Workflow
-   targets must belong to a registered live runner; process-global
-   intervention targets may be claimed by whichever serialized consumer
-   sees them first."
-  [event]
-  (if-not (intervention/valid-type? (:intervention/type event))
-    true
-    (let [canonical-target-type
-          (intervention/intervention-target-type (:intervention/type event))
-          declared-target-type (:intervention/target-type event)]
-      (or (and declared-target-type
-               (not= canonical-target-type declared-target-type))
-          (not= :workflow canonical-target-type)
-          (live-runner? (:intervention/target-id event))))))
-
-(defn- ^{:stratum 2} fail!
-  [stream interv reason-code]
-  (let [with-failure-code (assoc-in interv
-                                    [:intervention/details :failure/code]
-                                    reason-code)]
-    (when-let [failed (advance! stream
-                                with-failure-code
-                                intervention/fail
-                                (failure-message reason-code))]
-      failed)))
-
-(defn- ^{:stratum 2} apply-no-effect-verb!
-  "Verbs whose whole effect IS the supervisory record (Phase D mapping:
-   `supervisory-state only`). Dispatch → applied → verified with no
-   machine touch."
-  [stream dispatched verb]
-  (when-let [applied (advance! stream dispatched intervention/apply-result)]
-    (advance! stream applied intervention/verify {:verb verb})))
-
-;------------------------------------------------------------------------------ Layer 3
-
-(defn- ^{:stratum 3} verify-readback!
-  "Shared tail for every readback-verified mechanism: verify `applied`
-   when the mechanism's observable matches what the verb asked for, else
-   fail with `mismatch-code`. Returns nil when the lifecycle step is
-   itself rejected."
-  [stream applied readback mismatch-code]
-  (if (= (:observed readback) (:expected readback))
-    (advance! stream applied intervention/verify readback)
-    (fail! stream applied mismatch-code)))
-
-;------------------------------------------------------------------------------ Layer 4
-
-(defn- ^{:stratum 4} apply-control-verb!
-  [stream dispatched entry verb]
-  (let [readback (control-state-effect! (:control-state entry) verb)]
-    (when-let [applied (advance! stream dispatched intervention/apply-result)]
-      (verify-readback! stream applied readback
-                        :control-state-readback-mismatch))))
-
-(defn- ^{:stratum 4} apply-safe-mode-verb!
-  [stream dispatched manager verb interv]
-  (if manager
-    (let [readback (safe-mode-effect! manager verb interv)]
-      (when-let [applied (advance! stream dispatched intervention/apply-result)]
-        (verify-readback! stream applied readback
-                          :safe-mode-readback-mismatch)))
-    (fail! stream dispatched :no-degradation-manager)))
-
-(defn- ^{:stratum 4} dispatch-resume!
-  "Hand `plan` to the launcher, then read the run it reports back
-   through the resume machinery itself. The readback is deliberately
-   the resume component's view rather than the launcher's return value:
-   a launcher naming a run it never started must not buy a `verified`
-   chip."
-  [stream dispatched launcher events-dir verb plan]
-  (let [run-id (mechanism/launched-run-id ((:launch! launcher) plan))]
-    (if-not run-id
-      (fail! stream dispatched :resume-not-dispatched)
-      (let [readback {:verb verb
-                      :resume/run-id run-id
-                      :resume/from-phase (:resume/from-phase plan)
-                      :observed (mechanism/resume-observable? events-dir run-id)
-                      :expected true}]
-        (when-let [applied (advance! stream dispatched
-                                     intervention/apply-result readback)]
-          (verify-readback! stream applied readback
-                            :resume-readback-mismatch))))))
-
-(defn- ^{:stratum 4} apply-re-evaluate-verb!
-  "Run the registered evaluator, publish its verdict as a gate event,
-   and read the materialized entity table back.
-
-   `verified` means a PolicyEvaluation that did not exist before the
-   publish exists after it — a new immutable record per N5-delta-1
-   §12.2, not a mutation of the evaluation being re-run."
-  [stream dispatched evaluate interv]
-  (if-not evaluate
-    (fail! stream dispatched :no-policy-evaluator)
-    (let [evaluation (evaluate (mechanism/evaluation-request interv))]
-      ;; Validate BEFORE publishing: a nil/garbage result would otherwise
-      ;; coerce to `passed? false`, mint a bogus :gate/failed record, and
-      ;; verify — a verdict we never received. Fail typed, publish nothing.
-      (if-not (mechanism/valid-evaluation? evaluation)
-        (fail! stream dispatched :invalid-policy-evaluation)
-        (let [readback (mechanism/record-policy-evaluation! stream interv evaluation)]
-          (when-let [applied (advance! stream dispatched
-                                       intervention/apply-result readback)]
-            (verify-readback! stream applied readback
-                              :policy-evaluation-readback-mismatch)))))))
-
-;------------------------------------------------------------------------------ Layer 5
-
-(defn- ^{:stratum 5} apply-resume-verb!
-  "Rebuild resume state for a retry, then dispatch it.
-
-   Every rejection is typed and lands before the launcher runs — a
-   request naming a phase the run never reached must not be guessed
-   into a plan and started."
-  [stream dispatched launcher verb interv]
-  (if-not launcher
-    (fail! stream dispatched :no-resume-launcher)
-    (let [events-dir (resume-events-dir launcher)
-          prepared (mechanism/prepare-resume events-dir interv verb)]
-      (if-let [failure-code (:failure/code prepared)]
-        (fail! stream dispatched failure-code)
-        (dispatch-resume! stream dispatched launcher events-dir verb
-                          (:resume/plan prepared))))))
-
-;------------------------------------------------------------------------------ Layer 6
-
 ;; The applier hook
-(defn ^{:stratum 6} apply-intervention!
+(defn ^{:stratum 1} apply-intervention!
   "Apply one `:approved` intervention. This is the `:apply!` hook the
    operator-event consumer invokes (Phase D D-3, mechanisms extended in
    D-3b).
@@ -413,45 +216,65 @@
   [stream interv]
   (let [verb (:intervention/type interv)
         entry (get @live-runners (str (:intervention/target-id interv)))]
-    (if-let [dispatched (advance! stream interv intervention/dispatch)]
+    (if-let [dispatched (core/advance! stream interv intervention/dispatch)]
       (try
         (case verb
           (:pause :resume :cancel)
           (if entry
-            (apply-control-verb! stream dispatched entry verb)
-            (fail! stream dispatched :no-live-runner))
+            (verbs/apply-control-verb! stream dispatched entry verb)
+            (core/fail! stream dispatched :no-live-runner))
 
           (:acknowledge :request-human-review)
-          (apply-no-effect-verb! stream dispatched verb)
+          (verbs/apply-no-effect-verb! stream dispatched verb)
 
           (:force-safe-mode :exit-safe-mode)
-          (apply-safe-mode-verb! stream
-                                 dispatched
-                                 @process-degradation-manager
-                                 verb
-                                 interv)
+          (verbs/apply-safe-mode-verb! stream
+                                       dispatched
+                                       @process-degradation-manager
+                                       verb
+                                       interv)
 
           (:retry :retry-from-phase)
-          (apply-resume-verb! stream
-                              dispatched
-                              @process-resume-launcher
-                              verb
-                              interv)
+          (verbs/apply-resume-verb! stream
+                                    dispatched
+                                    @process-resume-launcher
+                                    verb
+                                    interv)
 
           :re-evaluate
-          (apply-re-evaluate-verb! stream
-                                   dispatched
-                                   @process-policy-evaluator
-                                   interv)
+          (verbs/apply-re-evaluate-verb! stream
+                                         dispatched
+                                         @process-policy-evaluator
+                                         interv)
 
           ;; :waive — N5-delta-1 §6 Waiver records have a schema and a
           ;; TUI surface but no store: no event, no entity table, no
           ;; emitter. :request-replan — deferred to D-7 (phase-redirect
           ;; semantics). Loud, typed failure per the honesty doctrine
           ;; rather than a mechanism invented here.
-          (fail! stream dispatched :not-implemented))
+          (core/fail! stream dispatched :not-implemented))
         (catch Exception _e
           ;; A throwing mechanism must not abort the consumer's pass —
           ;; the failure IS the outcome, recorded on the lifecycle.
-          (fail! stream dispatched :application-error)))
+          (core/fail! stream dispatched :application-error)))
       nil)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} live-intervention-target?
+  "True when this process may claim `event` for application. Workflow
+   targets must belong to a registered live runner; process-global
+   intervention targets — and retry verbs, whose runner is gone by
+   definition (see [[resume-ownership-verbs]]) — may be claimed by
+   whichever serialized consumer sees them first."
+  [event]
+  (if-not (intervention/valid-type? (:intervention/type event))
+    true
+    (let [verb (:intervention/type event)
+          canonical-target-type (intervention/intervention-target-type verb)
+          declared-target-type (:intervention/target-type event)]
+      (or (and declared-target-type
+               (not= canonical-target-type declared-target-type))
+          (contains? resume-ownership-verbs verb)
+          (not= :workflow canonical-target-type)
+          (live-runner? (:intervention/target-id event))))))

--- a/components/operator/src/ai/miniforge/operator/application/core.clj
+++ b/components/operator/src/ai/miniforge/operator/application/core.clj
@@ -1,0 +1,143 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.operator.application.core
+  "Lifecycle primitives shared by the intervention appliers — the bottom
+   stratum of the D-3/D-3b application layer, split out of
+   `application` so neither that namespace nor
+   [[ai.miniforge.operator.application.verbs]] carries more than three
+   real layers (rule 210).
+
+   Two kinds of thing live here: the lifecycle publishers
+   ([[advance!]], [[fail!]]) that turn a lifecycle step into a published
+   state transition, and the raw mechanism effects ([[control-state-effect!]],
+   [[safe-mode-effect!]]) that flip a runner flag or move the
+   degradation manager and hand back the readback the verification step
+   asserts. The appliers in `verbs` compose these; `application` calls
+   [[advance!]] / [[fail!]] for the dispatch step and the terminal
+   failure paths."
+  (:require
+   [ai.miniforge.event-stream.interface :as es]
+   [ai.miniforge.operator.consumer :as consumer]
+   [ai.miniforge.operator.intervention :as intervention]
+   [ai.miniforge.operator.messages :as messages]
+   [ai.miniforge.reliability.interface :as reliability]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private failure-message-key-by-code
+  {:application-error :application/application-error
+   :control-state-readback-mismatch :application/control-state-readback-mismatch
+   :missing-phase :application/missing-phase
+   :no-degradation-manager :application/no-degradation-manager
+   :invalid-policy-evaluation :application/invalid-policy-evaluation
+   :no-live-runner :application/no-live-runner
+   :no-policy-evaluator :application/no-policy-evaluator
+   :no-resume-context :application/no-resume-context
+   :no-resume-launcher :application/no-resume-launcher
+   :not-implemented :application/not-implemented
+   :policy-evaluation-readback-mismatch :application/policy-evaluation-readback-mismatch
+   :resume-not-dispatched :application/resume-not-dispatched
+   :resume-readback-mismatch :application/resume-readback-mismatch
+   :safe-mode-readback-mismatch :application/safe-mode-readback-mismatch
+   :unknown-phase :application/unknown-phase
+   :unresolved-workflow-type :application/unresolved-workflow-type})
+
+(def ^{:stratum 0} ^:private expected-degradation-mode-by-verb
+  {:force-safe-mode :safe-mode
+   :exit-safe-mode :nominal})
+
+(defn- ^{:stratum 0} intervention-justification
+  [interv]
+  (if-some [justification (:intervention/justification interv)]
+    justification
+    (messages/t :application/default-justification)))
+
+(defn- ^{:stratum 0} transition-succeeded?
+  [result]
+  (true? (:success? result)))
+
+(defn ^{:stratum 0} control-state-effect!
+  "Flip the control-state flag for `verb` and return the readback the
+   verification step asserts."
+  [control-state verb]
+  (case verb
+    :pause  (do (es/pause! control-state)
+                {:verb :pause :observed (boolean (es/paused? control-state))
+                 :expected true})
+    :resume (do (es/resume! control-state)
+                {:verb :resume :observed (boolean (es/paused? control-state))
+                 :expected false})
+    :cancel (do (es/cancel! control-state)
+                {:verb :cancel :observed (boolean (es/cancelled? control-state))
+                 :expected true})))
+
+(defn ^{:stratum 0} resume-events-dir
+  [launcher]
+  (or (:events-dir launcher) (es/default-events-dir)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} failure-message
+  [reason-code]
+  (messages/t (get failure-message-key-by-code
+                   reason-code
+                   :application/unknown-failure)))
+
+(defn ^{:stratum 1} advance!
+  "Apply lifecycle `step-fn` to `interv`, publish the transition, and
+   return the updated intervention. Returns nil when the lifecycle step
+   itself is rejected."
+  [stream interv step-fn & step-args]
+  (let [result (apply step-fn interv step-args)]
+    (if (transition-succeeded? result)
+      (let [updated (:intervention result)]
+        (consumer/publish-state-changed! stream updated)
+        updated)
+      nil)))
+
+(defn ^{:stratum 1} safe-mode-effect!
+  "Move the degradation manager for `verb` and return the readback the
+   verification step asserts."
+  [manager verb interv]
+  (let [justification (intervention-justification interv)]
+    (case verb
+      :force-safe-mode
+      (reliability/enter-safe-mode! manager :manual justification)
+      :exit-safe-mode
+      (reliability/exit-safe-mode! manager
+                                   justification
+                                   (:intervention/requested-by interv)))
+    {:verb verb
+     :observed (reliability/degradation-mode manager)
+     :expected (get expected-degradation-mode-by-verb verb)}))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} fail!
+  "Stamp `reason-code` onto the intervention's failure details and
+   publish the `:failed` transition. Returns the failed intervention, or
+   nil when the lifecycle step is itself rejected."
+  [stream interv reason-code]
+  (let [with-failure-code (assoc-in interv
+                                    [:intervention/details :failure/code]
+                                    reason-code)]
+    (when-let [failed (advance! stream
+                                with-failure-code
+                                intervention/fail
+                                (failure-message reason-code))]
+      failed)))

--- a/components/operator/src/ai/miniforge/operator/application/verbs.clj
+++ b/components/operator/src/ai/miniforge/operator/application/verbs.clj
@@ -1,0 +1,133 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.operator.application.verbs
+  "The per-verb appliers of the D-3/D-3b application layer, split out of
+   `application` so no namespace in it carries more than three real
+   layers (rule 210).
+
+   Each `apply-*-verb!` takes an already-`:dispatched` intervention plus
+   the handle its mechanism needs (a control-state, the degradation
+   manager, the resume launcher, the policy evaluator — all supplied by
+   `application` from its process-scoped registry, never reached for
+   here), advances it to `:applied`, and verifies by readback through
+   [[verify-readback!]]. The lifecycle publishers and raw effects they
+   compose live one stratum down in
+   [[ai.miniforge.operator.application.core]]. `application`'s
+   `apply-intervention!` dispatches to these by verb."
+  (:require
+   [ai.miniforge.operator.application.core :as core]
+   [ai.miniforge.operator.intervention :as intervention]
+   [ai.miniforge.operator.mechanism :as mechanism]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} verify-readback!
+  "Shared tail for every readback-verified mechanism: verify `applied`
+   when the mechanism's observable matches what the verb asked for, else
+   fail with `mismatch-code`. Returns nil when the lifecycle step is
+   itself rejected."
+  [stream applied readback mismatch-code]
+  (if (= (:observed readback) (:expected readback))
+    (core/advance! stream applied intervention/verify readback)
+    (core/fail! stream applied mismatch-code)))
+
+(defn ^{:stratum 0} apply-no-effect-verb!
+  "Verbs whose whole effect IS the supervisory record (Phase D mapping:
+   `supervisory-state only`). Dispatch → applied → verified with no
+   machine touch."
+  [stream dispatched verb]
+  (when-let [applied (core/advance! stream dispatched intervention/apply-result)]
+    (core/advance! stream applied intervention/verify {:verb verb})))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} apply-control-verb!
+  [stream dispatched entry verb]
+  (let [readback (core/control-state-effect! (:control-state entry) verb)]
+    (when-let [applied (core/advance! stream dispatched intervention/apply-result)]
+      (verify-readback! stream applied readback
+                        :control-state-readback-mismatch))))
+
+(defn ^{:stratum 1} apply-safe-mode-verb!
+  [stream dispatched manager verb interv]
+  (if manager
+    (let [readback (core/safe-mode-effect! manager verb interv)]
+      (when-let [applied (core/advance! stream dispatched intervention/apply-result)]
+        (verify-readback! stream applied readback
+                          :safe-mode-readback-mismatch)))
+    (core/fail! stream dispatched :no-degradation-manager)))
+
+(defn- ^{:stratum 1} dispatch-resume!
+  "Hand `plan` to the launcher, then read the run it reports back
+   through the resume machinery itself. The readback is deliberately
+   the resume component's view rather than the launcher's return value:
+   a launcher naming a run it never started must not buy a `verified`
+   chip."
+  [stream dispatched launcher events-dir verb plan]
+  (let [run-id (mechanism/launched-run-id ((:launch! launcher) plan))]
+    (if-not run-id
+      (core/fail! stream dispatched :resume-not-dispatched)
+      (let [readback {:verb verb
+                      :resume/run-id run-id
+                      :resume/from-phase (:resume/from-phase plan)
+                      :observed (mechanism/resume-observable? events-dir run-id)
+                      :expected true}]
+        (when-let [applied (core/advance! stream dispatched
+                                          intervention/apply-result readback)]
+          (verify-readback! stream applied readback
+                            :resume-readback-mismatch))))))
+
+(defn ^{:stratum 1} apply-re-evaluate-verb!
+  "Run the registered evaluator, publish its verdict as a gate event,
+   and read the materialized entity table back.
+
+   `verified` means a PolicyEvaluation that did not exist before the
+   publish exists after it — a new immutable record per N5-delta-1
+   §12.2, not a mutation of the evaluation being re-run."
+  [stream dispatched evaluate interv]
+  (if-not evaluate
+    (core/fail! stream dispatched :no-policy-evaluator)
+    (let [evaluation (evaluate (mechanism/evaluation-request interv))]
+      ;; Validate BEFORE publishing: a nil/garbage result would otherwise
+      ;; coerce to `passed? false`, mint a bogus :gate/failed record, and
+      ;; verify — a verdict we never received. Fail typed, publish nothing.
+      (if-not (mechanism/valid-evaluation? evaluation)
+        (core/fail! stream dispatched :invalid-policy-evaluation)
+        (let [readback (mechanism/record-policy-evaluation! stream interv evaluation)]
+          (when-let [applied (core/advance! stream dispatched
+                                            intervention/apply-result readback)]
+            (verify-readback! stream applied readback
+                              :policy-evaluation-readback-mismatch)))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} apply-resume-verb!
+  "Rebuild resume state for a retry, then dispatch it.
+
+   Every rejection is typed and lands before the launcher runs — a
+   request naming a phase the run never reached must not be guessed
+   into a plan and started."
+  [stream dispatched launcher verb interv]
+  (if-not launcher
+    (core/fail! stream dispatched :no-resume-launcher)
+    (let [events-dir (core/resume-events-dir launcher)
+          prepared (mechanism/prepare-resume events-dir interv verb)]
+      (if-let [failure-code (:failure/code prepared)]
+        (core/fail! stream dispatched failure-code)
+        (dispatch-resume! stream dispatched launcher events-dir verb
+                          (:resume/plan prepared))))))

--- a/components/operator/src/ai/miniforge/operator/mechanism.clj
+++ b/components/operator/src/ai/miniforge/operator/mechanism.clj
@@ -178,19 +178,38 @@
     (if-let [ns (namespace pack)] (str ns "/" (name pack)) (name pack))
     :else (str pack)))
 
-(defn ^{:stratum 0} valid-evaluation?
-  "A usable evaluator result: a map carrying a boolean
-   `:evaluation/passed?`. Anything else — nil, a non-map, or a map
-   whose verdict is missing or non-boolean — is NOT an evaluation and
-   must never be published as one. Without this check a nil/garbage
-   result coerces to `passed? false` and mints a bogus `:gate/failed`
-   PolicyEvaluation, breaking the \"never publishes a verdict it did
-   not receive\" guarantee."
-  [evaluation]
-  (and (map? evaluation)
-       (boolean? (:evaluation/passed? evaluation))))
+(defn- ^{:stratum 0} evaluation-list-field-ok?
+  "A `:evaluation/violations` / `:evaluation/packs-applied` field is
+   usable when it is absent or sequential. `evaluation-gate-event`
+   `(vec violations)`s and `pack-ids` `(mapv pack-id …)`s these, which
+   throw on a non-seqable scalar (a number, a keyword) — a throw the
+   application layer only catches as the generic `:application-error`,
+   losing the specific `:invalid-policy-evaluation` this predicate
+   exists to surface. Rejecting the shape here keeps the failure typed
+   and lands it before any gate event is published."
+  [v]
+  (or (nil? v) (sequential? v)))
 
 ;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} valid-evaluation?
+  "A usable evaluator result: a map carrying a boolean
+   `:evaluation/passed?`, with `:evaluation/violations` and
+   `:evaluation/packs-applied` each absent or sequential. Anything
+   else — nil, a non-map, a map whose verdict is missing or
+   non-boolean, or one whose violation/pack fields are a non-seqable
+   scalar — is NOT an evaluation and must never be published as one.
+   Without the verdict check a nil/garbage result coerces to
+   `passed? false` and mints a bogus `:gate/failed` PolicyEvaluation,
+   breaking the \"never publishes a verdict it did not receive\"
+   guarantee; without the list-field checks a scalar there throws deep
+   in `evaluation-gate-event` and surfaces as `:application-error`
+   rather than `:invalid-policy-evaluation`."
+  [evaluation]
+  (and (map? evaluation)
+       (boolean? (:evaluation/passed? evaluation))
+       (evaluation-list-field-ok? (:evaluation/violations evaluation))
+       (evaluation-list-field-ok? (:evaluation/packs-applied evaluation))))
 
 (defn ^{:stratum 1} requested-phase
   "The phase an intervention's `:intervention/details` targets, as a
@@ -237,9 +256,35 @@
            :resume/intervention-id (:intervention/id interv)}
     from-phase (assoc :resume/from-phase from-phase)))
 
-(defn- ^{:stratum 1} pack-ids
-  [packs]
-  (mapv pack-id (or packs [])))
+(defn ^{:stratum 1} evaluation-gate-event
+  "The `:gate/passed` / `:gate/failed` event that materializes a new
+   PolicyEvaluation for `interv`'s target.
+
+   Going through a gate event rather than writing a
+   `:supervisory/policy-evaluated` snapshot keeps the producer/
+   materializer direction intact: producers emit gate outcomes,
+   `supervisory-state` derives the record. Its `:policy-eval/id` is this
+   event's `:event/id`, so every re-evaluation is a fresh, immutable
+   record per N5-delta-1 §12.2 — never a mutation of a prior one.
+
+   The pack coercion is `mapv pack-id` inline rather than a `pack-ids`
+   helper: threading it through one more stratum-1 function would push
+   `record-policy-evaluation!` to a fourth layer and over the file's
+   budget for no readability gain."
+  [stream interv evaluation]
+  (let [passed? (true? (:evaluation/passed? evaluation))
+        target-id (str (:intervention/target-id interv))]
+    (-> (es/create-envelope stream
+                            (if passed? :gate/passed :gate/failed)
+                            nil
+                            (messages/t :application/policy-re-evaluated
+                                        {:target target-id
+                                         :result (if passed? "pass" "fail")}))
+        (assoc :gate/id re-evaluation-gate-id
+               :gate/target-type :pr
+               :gate/target-id target-id
+               :gate/packs (mapv pack-id (or (:evaluation/packs-applied evaluation) []))
+               :gate/violations (vec (:evaluation/violations evaluation))))))
 
 ;------------------------------------------------------------------------------ Layer 2
 
@@ -275,34 +320,7 @@
               {:resume/plan (resume-plan interv context workflow-identity
                                          from-phase)})))))))
 
-(defn ^{:stratum 2} evaluation-gate-event
-  "The `:gate/passed` / `:gate/failed` event that materializes a new
-   PolicyEvaluation for `interv`'s target.
-
-   Going through a gate event rather than writing a
-   `:supervisory/policy-evaluated` snapshot keeps the producer/
-   materializer direction intact: producers emit gate outcomes,
-   `supervisory-state` derives the record. Its `:policy-eval/id` is this
-   event's `:event/id`, so every re-evaluation is a fresh, immutable
-   record per N5-delta-1 §12.2 — never a mutation of a prior one."
-  [stream interv evaluation]
-  (let [passed? (true? (:evaluation/passed? evaluation))
-        target-id (str (:intervention/target-id interv))]
-    (-> (es/create-envelope stream
-                            (if passed? :gate/passed :gate/failed)
-                            nil
-                            (messages/t :application/policy-re-evaluated
-                                        {:target target-id
-                                         :result (if passed? "pass" "fail")}))
-        (assoc :gate/id re-evaluation-gate-id
-               :gate/target-type :pr
-               :gate/target-id target-id
-               :gate/packs (pack-ids (:evaluation/packs-applied evaluation))
-               :gate/violations (vec (:evaluation/violations evaluation))))))
-
-;------------------------------------------------------------------------------ Layer 3
-
-(defn ^{:stratum 3} record-policy-evaluation!
+(defn ^{:stratum 2} record-policy-evaluation!
   "Publish the evaluator's verdict and read the entity table back.
    Caller MUST gate on [[valid-evaluation?]] first — this fn assumes a
    well-formed evaluation and does not re-check.

--- a/components/operator/test/ai/miniforge/operator/application_test.clj
+++ b/components/operator/test/ai/miniforge/operator/application_test.clj
@@ -212,6 +212,19 @@
                :intervention/target-id (random-uuid)}))
       "mismatched known targets must not be deferred as unowned"))
 
+(deftest ^{:stratum 0} retry-verbs-are-owned-without-a-live-runner
+  ;; The consumer wires this predicate as `:accept?`. A retry's canonical
+  ;; target type is `:workflow`, but the run it restarts has no live
+  ;; runner by definition — gating retries on one deferred them on every
+  ;; pass forever, never reaching the launcher-missing failure. They must
+  ;; be claimable regardless of runner registration.
+  (doseq [verb [:retry :retry-from-phase]]
+    (is (true? (application/live-intervention-target?
+                {:intervention/type verb
+                 :intervention/target-type :workflow
+                 :intervention/target-id (random-uuid)}))
+        (str verb " must be owned even with no live runner for its target"))))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn- ^{:stratum 1} stage-golden!
@@ -558,6 +571,62 @@
               "the fixture's `phase` detail survives the wire round-trip")
           (is (= [:approved :dispatched :applied :verified]
                  (state-trail stream))))))))
+
+(deftest ^{:stratum 2} retry-passes-the-production-ownership-gate
+  ;; Regression: the runner wires `:accept? live-intervention-target?`,
+  ;; but every other consume-pass! test omits `:accept?` and so runs the
+  ;; accept-everything default — the ownership gate the runner actually
+  ;; uses was never exercised in the consume path. A retry's runner is
+  ;; gone by definition, so the gate deferred it on every pass and it
+  ;; never reached the launcher. Drive the real gate here.
+  (testing "with the launcher registered the retry is claimed and verified"
+    (let [events-dir (temp-events-dir)
+          stream (memory-stream)
+          resumed-id (random-uuid)
+          captured (atom nil)]
+      (stage-golden! events-dir "retry-from-phase.transit.json")
+      (stage-workflow-history!
+       events-dir golden-pause-target-id
+       [(workflow-event (parse-uuid golden-pause-target-id) :workflow/started
+                        {:workflow/spec {:workflow-type :canonical-sdlc}})
+        (workflow-event (parse-uuid golden-pause-target-id) :workflow/phase-completed
+                        {:workflow/phase :explore :phase/outcome :success})
+        (workflow-event (parse-uuid golden-pause-target-id) :workflow/phase-completed
+                        {:workflow/phase :implement :phase/outcome :failure})])
+      (stage-two-phase-run! events-dir resumed-id)
+      (with-resume-launcher
+        (assoc (recording-launcher captured resumed-id) :events-dir events-dir)
+        (fn []
+          (is (= {:routed 1 :skipped 0 :anomalies 0}
+                 (consumer/consume-pass!
+                  {:events-dir events-dir
+                   :stream stream
+                   :apply! application/apply-intervention!
+                   :accept? application/live-intervention-target?}))
+              "the ownership gate must claim the retry, not defer it")
+          (is (= [:approved :dispatched :applied :verified]
+                 (state-trail stream)))))))
+  (testing "with no launcher the retry is still claimed and fails typed, never parks"
+    (let [events-dir (temp-events-dir)
+          stream (memory-stream)]
+      (stage-golden! events-dir "retry-from-phase.transit.json")
+      (with-resume-launcher
+        nil
+        (fn []
+          (is (= {:routed 1 :skipped 0 :anomalies 0}
+                 (consumer/consume-pass!
+                  {:events-dir events-dir
+                   :stream stream
+                   :apply! application/apply-intervention!
+                   :accept? application/live-intervention-target?}))
+              "a launcher-less retry is claimed and resolved, not parked forever")
+          (is (= :no-resume-launcher
+                 (get-in (last (filterv #(= consumer/state-changed-event-type
+                                            (:event/type %))
+                                        (es/get-events stream)))
+                         [:intervention/details :failure/code]))
+              "the claimed retry ends in a typed failure, a visible red chip")
+          (is (= [:approved :dispatched :failed] (state-trail stream))))))))
 
 (deftest ^{:stratum 2} re-evaluate-without-an-evaluator-fails-typed
   (with-policy-evaluator

--- a/components/operator/test/ai/miniforge/operator/mechanism_test.clj
+++ b/components/operator/test/ai/miniforge/operator/mechanism_test.clj
@@ -118,6 +118,34 @@
   (vals (:policy-evals (supervisory/apply-events supervisory/empty-table
                                                  (es/get-events stream)))))
 
+(deftest ^{:stratum 0} valid-evaluation-requires-a-verdict-and-seqable-lists
+  (testing "a well-formed verdict, with or without list fields, is valid"
+    (is (true? (mechanism/valid-evaluation? {:evaluation/passed? true})))
+    (is (true? (mechanism/valid-evaluation?
+                {:evaluation/passed? false
+                 :evaluation/packs-applied ["core"]
+                 :evaluation/violations [{:rule-id :r}]})))
+    (is (true? (mechanism/valid-evaluation?
+                {:evaluation/passed? true
+                 :evaluation/violations '()
+                 :evaluation/packs-applied nil}))
+        "absent (nil) list fields are fine — the gate builder defaults them"))
+  (testing "a missing or non-boolean verdict is not an evaluation"
+    (is (false? (mechanism/valid-evaluation? nil)))
+    (is (false? (mechanism/valid-evaluation? :not-a-map)))
+    (is (false? (mechanism/valid-evaluation? {})))
+    (is (false? (mechanism/valid-evaluation? {:evaluation/passed? "true"}))))
+  (testing "a non-seqable violations / packs field is rejected here, not as a throw later"
+    ;; `(vec :kw)` / `(vec 3)` throw; caught downstream they degrade to
+    ;; the generic `:application-error`. Reject the shape so the failure
+    ;; stays the specific `:invalid-policy-evaluation`.
+    (is (false? (mechanism/valid-evaluation?
+                 {:evaluation/passed? true :evaluation/violations 3})))
+    (is (false? (mechanism/valid-evaluation?
+                 {:evaluation/passed? true :evaluation/violations :nope})))
+    (is (false? (mechanism/valid-evaluation?
+                 {:evaluation/passed? true :evaluation/packs-applied :core})))))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (deftest ^{:stratum 1} plain-retry-keeps-the-fsm-snapshot

--- a/components/operator/test/ai/miniforge/operator/mechanism_test.clj
+++ b/components/operator/test/ai/miniforge/operator/mechanism_test.clj
@@ -118,7 +118,7 @@
   (vals (:policy-evals (supervisory/apply-events supervisory/empty-table
                                                  (es/get-events stream)))))
 
-(deftest ^{:stratum 0} valid-evaluation-requires-a-verdict-and-seqable-lists
+(deftest ^{:stratum 0} valid-evaluation-requires-a-verdict-and-sequential-lists
   (testing "a well-formed verdict, with or without list fields, is valid"
     (is (true? (mechanism/valid-evaluation? {:evaluation/passed? true})))
     (is (true? (mechanism/valid-evaluation?
@@ -135,10 +135,12 @@
     (is (false? (mechanism/valid-evaluation? :not-a-map)))
     (is (false? (mechanism/valid-evaluation? {})))
     (is (false? (mechanism/valid-evaluation? {:evaluation/passed? "true"}))))
-  (testing "a non-seqable violations / packs field is rejected here, not as a throw later"
-    ;; `(vec :kw)` / `(vec 3)` throw; caught downstream they degrade to
-    ;; the generic `:application-error`. Reject the shape so the failure
-    ;; stays the specific `:invalid-policy-evaluation`.
+  (testing "a non-sequential violations / packs field is rejected here, not as a throw later"
+    ;; The predicate requires `sequential?` (nil or a list/vector/seq),
+    ;; so a set is rejected too even though it is seqable. The scalars
+    ;; below (`(vec :kw)` / `(vec 3)`) throw downstream and degrade to the
+    ;; generic `:application-error`; rejecting the shape here keeps the
+    ;; failure the specific `:invalid-policy-evaluation`.
     (is (false? (mechanism/valid-evaluation?
                  {:evaluation/passed? true :evaluation/violations 3})))
     (is (false? (mechanism/valid-evaluation?


### PR DESCRIPTION
## The bug (HIGH)

The workflow runner wires `application/live-intervention-target?` as the operator consumer's `:accept?` predicate. A retry's canonical target type is `:workflow`, so the gate required a **live runner** for the target workflow — but a retry, by definition, restarts a run whose original runner is already gone. The gate therefore returned false for every retry, and `consume-operator-dir!` deferred the event without advancing either cursor. So a retry was re-read and re-rejected on every pass, forever: no dispatch, no failure, no red chip. A silent park — the exact failure the honesty doctrine forbids.

## The fix

`:retry` / `:retry-from-phase` are process-global for ownership: whichever consumer sees one claims it, and the application layer then either dispatches through the registered resume launcher or fails `:no-resume-launcher` (a visible failure), never parks. This mirrors how safe-mode (`:degradation`) targets are already claimed "by whichever serialized consumer sees them first."

## Why the tests missed it

Every `consume-pass!` test omitted `:accept?`, so they ran the accept-everything default — the gate the runner actually uses was never exercised in the consume path. Added `retry-passes-the-production-ownership-gate`, which drives a retry through `consume-pass!` with `:accept? live-intervention-target?`:

- with a launcher registered → claimed, `verified`;
- with **no** launcher → claimed, `failed` `:no-resume-launcher` (`[:approved :dispatched :failed]`), proving it no longer parks.

Plus a unit test that both retry verbs are owned with no live runner.

## Also: `valid-evaluation?` tightened

Require `:evaluation/violations` and `:evaluation/packs-applied` to be absent or sequential. A non-seqable scalar there throws in `evaluation-gate-event`, which the application layer catches only as the generic `:application-error` — losing the specific `:invalid-policy-evaluation`. Rejecting the shape in the predicate keeps the failure typed and lands it before any gate event publishes.

## Stratum split (rule 210)

Editing these files re-triggers the layer-budget check on two pre-existing over-budget namespaces, so this PR also splits them (verbatim moves, no behaviour change):

- `application.clj` (7 layers) → facade + `application.core` (lifecycle publishers `advance!`/`fail!` + raw effects) + `application.verbs` (per-verb appliers). The operator interface re-exports only from the facade, so no caller moves.
- `mechanism.clj` (4 → 3) → the trivial `pack-ids` helper inlined into `evaluation-gate-event`, dropping `record-policy-evaluation!` off a fourth layer.

The commit carries `MINIFORGE_COMMIT_BUDGET_OVERRIDE` (echoed in CI): the diff is large only because the split moves code verbatim; net new logic is the ~140-line fix.

## Verification

- Operator application/mechanism/consumer/interface tests: 82 tests, 312 assertions, 0 failures.
- `stratum-lint` and `clj-kondo` clean on all four files.
- All namespaces load under Babashka (the runtime the consumer runs in).
- Full pre-commit (`test:precommit` + `test:graalvm`) green.

Found by the one-pass adversarial review of the merged D-3b work (#1455).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
