### PR TITLE
feat(agent): surface :context-misses/:context-reads in capsule sessions

### DIFF
--- a/components/agent/src/ai/miniforge/agent/artifact_session.clj
+++ b/components/agent/src/ai/miniforge/agent/artifact_session.clj
@@ -362,8 +362,16 @@
 
 (def ^{:stratum 0} ^:private capsule-output-boundary
   "Sentinel line separating the concatenated session-output files in the
-   single `read-capsule-session-outputs` executor round-trip. Never appears
-   in the EDN the MCP server writes (paths and keywords, not file bodies)."
+   single `read-capsule-session-outputs` executor round-trip.
+
+   Collision assumption: the first two segments (context-misses.edn,
+   context-reads.edn) are written by our own MCP server and contain
+   record maps (paths, keywords, timestamps), so this sentinel is not
+   expected to occur in them — a pathological workspace path containing
+   it would corrupt the split. The artifact segment CAN contain arbitrary
+   agent-authored strings, which is why it is deliberately placed LAST in
+   the cat chain: the bounded `str/split` keeps any embedded occurrence
+   inside the final segment intact."
   "===MINIFORGE-SESSION-OUTPUT-BOUNDARY===")
 
 (defn- ^{:stratum 0} read-role-entry
@@ -927,6 +935,12 @@
    /dev/null and the `;` chain continues), which parse to nil. Malformed
    segments emit the same parse WARNs as the host-mode readers.
 
+   The artifact segment is deliberately LAST in the chain: its content is
+   agent-authored and may contain arbitrary strings, and the bounded
+   split keeps an embedded boundary occurrence inside that final segment
+   rather than corrupting the earlier server-written segments — see
+   `capsule-output-boundary` for the collision assumption.
+
    Returns: {:artifact <map-or-nil>
              :context-misses <vector-or-nil>
              :context-reads <vector-or-nil>}"
@@ -935,16 +949,16 @@
         misses-path (str dir "/context-misses.edn")
         reads-path  (str dir "/context-reads.edn")
         sep         (str "; echo; echo " capsule-output-boundary "; ")
-        cmd         (str "cat " (:artifact-path session) " 2>/dev/null"
+        cmd         (str "cat " (file-artifacts/shell-quote misses-path) " 2>/dev/null"
                          sep
-                         "cat " misses-path " 2>/dev/null"
+                         "cat " (file-artifacts/shell-quote reads-path) " 2>/dev/null"
                          sep
-                         "cat " reads-path " 2>/dev/null")
+                         "cat " (file-artifacts/shell-quote (:artifact-path session)) " 2>/dev/null")
         result      ((:exec! session) (:executor session) (:environment-id session)
                      cmd {:workdir (:workdir session)})
         stdout      (get-in result [:data :stdout] "")
         boundary-re (re-pattern (java.util.regex.Pattern/quote capsule-output-boundary))
-        [artifact-part misses-part reads-part] (mapv str/trim (str/split stdout boundary-re 3))]
+        [misses-part reads-part artifact-part] (mapv str/trim (str/split stdout boundary-re 3))]
     {:artifact       (when (seq artifact-part)
                        (parse-edn-content artifact-part
                                           (comp parse-uuid-strings edn/read-string)

--- a/components/agent/src/ai/miniforge/agent/artifact_session.clj
+++ b/components/agent/src/ai/miniforge/agent/artifact_session.clj
@@ -360,6 +360,12 @@
    scan and the no-artifact-found diagnostic."
   [:plan :implement :verify :review :release])
 
+(def ^{:stratum 0} ^:private capsule-output-boundary
+  "Sentinel line separating the concatenated session-output files in the
+   single `read-capsule-session-outputs` executor round-trip. Never appears
+   in the EDN the MCP server writes (paths and keywords, not file bodies)."
+  "===MINIFORGE-SESSION-OUTPUT-BOUNDARY===")
+
 (defn- ^{:stratum 0} read-role-entry
   "Read the worktree artifact for `role` via `read-role-artifact` and
    return a `[role artifact]` map entry, or nil if the role file was
@@ -906,6 +912,51 @@
                            :warn/capsule-worktree-artifact-parse
                            path)))))
 
+(defn ^{:stratum 3} read-capsule-session-outputs
+  "Read artifact.edn, context-misses.edn, and context-reads.edn from a
+   capsule session in a SINGLE executor round-trip.
+
+   The three files are concatenated by one `cat` chain with
+   `capsule-output-boundary` sentinel lines between them, then split back
+   apart here. This is how capsule sessions surface `:context-misses` and
+   `:context-reads` (Codex SPEC §7.4.2 recorded flows) without adding
+   per-file executor round-trips — the batched read costs the same one
+   exec call the artifact read already paid.
+
+   Missing files contribute empty segments (`cat` failures are sent to
+   /dev/null and the `;` chain continues), which parse to nil. Malformed
+   segments emit the same parse WARNs as the host-mode readers.
+
+   Returns: {:artifact <map-or-nil>
+             :context-misses <vector-or-nil>
+             :context-reads <vector-or-nil>}"
+  [session]
+  (let [dir         (:dir session)
+        misses-path (str dir "/context-misses.edn")
+        reads-path  (str dir "/context-reads.edn")
+        sep         (str "; echo; echo " capsule-output-boundary "; ")
+        cmd         (str "cat " (:artifact-path session) " 2>/dev/null"
+                         sep
+                         "cat " misses-path " 2>/dev/null"
+                         sep
+                         "cat " reads-path " 2>/dev/null")
+        result      ((:exec! session) (:executor session) (:environment-id session)
+                     cmd {:workdir (:workdir session)})
+        stdout      (get-in result [:data :stdout] "")
+        boundary-re (re-pattern (java.util.regex.Pattern/quote capsule-output-boundary))
+        [artifact-part misses-part reads-part] (mapv str/trim (str/split stdout boundary-re 3))]
+    {:artifact       (when (seq artifact-part)
+                       (parse-edn-content artifact-part
+                                          (comp parse-uuid-strings edn/read-string)
+                                          :warn/artifact-parse
+                                          (:artifact-path session)))
+     :context-misses (when (seq misses-part)
+                       (parse-edn-content misses-part edn/read-string
+                                          :warn/context-misses-parse misses-path))
+     :context-reads  (when (seq reads-part)
+                       (parse-edn-content reads-part edn/read-string
+                                          :warn/context-reads-parse reads-path))}))
+
 (defmacro ^{:stratum 3} with-capsule-artifact-session
   "Execute body with a capsule-aware artifact session (N11 §6.3).
    Like with-artifact-session but session files live inside the task capsule.
@@ -1017,11 +1068,10 @@
    'did this agent consult its pinned codex landings' an answerable
    question (Codex SPEC §7.4.2).
 
-   HOST MODE ONLY, same as `read-context-misses`: in capsule mode the
-   server writes the file inside the container and surfacing it needs an
-   executor round-trip (the same trade-off already accepted for capsule
-   worktree artifacts). Until that lands, capsule sessions return nil here
-   — absent data, not evidence the agent read nothing.
+   Reads the host-local session directory, same as `read-context-misses`.
+   Capsule sessions surface the same file through
+   `read-capsule-session-outputs`, which batches it into the artifact
+   read's single executor round-trip.
 
    Returns: vector of read records, or nil if no reads file."
   [session]
@@ -1063,6 +1113,16 @@
         (run session cleanup-session!)))))
 
 ;------------------------------------------------------------------------------ Layer 5
+
+(defn ^{:stratum 5} read-host-session-outputs
+  "Read artifact + context-misses + context-reads from a host session's
+   local directory. Host-mode counterpart of `read-capsule-session-outputs`
+   — same return shape, plain filesystem reads instead of an executor
+   round-trip."
+  [session]
+  {:artifact       (read-artifact session)
+   :context-misses (read-context-misses session)
+   :context-reads  (read-context-reads session)})
 
 (defmacro ^{:stratum 5} with-artifact-session
   "Execute body with an artifact session, returning the artifact if found.
@@ -1109,6 +1169,12 @@
   "Execute body-fn with session, read artifacts, and clean up.
    Shared lifecycle for both host and capsule sessions.
 
+   `read-outputs-fn` is the mode-specific session-outputs reader
+   (`read-host-session-outputs` or `read-capsule-session-outputs`) and
+   must return {:artifact :context-misses :context-reads}. Both modes
+   surface all three — the capsule reader batches them into one executor
+   round-trip rather than dropping the context files.
+
    `:worktree-artifacts` is a map from role keyword to parsed artifact,
    read from <workdir>/.miniforge/<role>.edn. Container-promotion pattern —
    agents write their artifact into the worktree and the runtime picks it
@@ -1138,7 +1204,7 @@
    is the machine-readable signal that no artifact was produced. Callers
    that key on phase output MUST treat this combination as a workflow fault
    - no artifact means the implementing agent did not deliver work product."
-  [session body-fn read-artifact-fn cleanup-fn mode]
+  [session body-fn read-outputs-fn cleanup-fn mode]
   (try
     (let [result              (body-fn session)
           workdir             (:workdir session)
@@ -1146,7 +1212,7 @@
           worktree-artifacts  (if (:explicit-workdir? session)
                                 (collect-worktree-artifacts read-role-artifact workdir)
                                 {})
-          artifact            (read-artifact-fn session)
+          {:keys [artifact context-misses context-reads]} (read-outputs-fn session)
           ;; Track whether any .miniforge/<role>.edn files existed on disk,
           ;; independent of parse success. A file that exists but contains
           ;; malformed EDN returns nil from read-role-artifact (and emits
@@ -1190,8 +1256,8 @@
       {:llm-result           result
        :artifact             artifact
        :worktree-artifacts   worktree-artifacts
-       :context-misses       (when (= :host mode) (read-context-misses session))
-       :context-reads        (when (= :host mode) (read-context-reads session))
+       :context-misses       context-misses
+       :context-reads        context-reads
        :pre-session-snapshot (:pre-session-snapshot session)
        :session-mode         mode})
     (finally
@@ -1212,7 +1278,8 @@
    - body-fn - (fn [session] ...) that receives the session and returns LLM result
 
    Returns normalized map:
-   {:llm-result :artifact :context-misses :pre-session-snapshot :session-mode}"
+   {:llm-result :artifact :worktree-artifacts :context-misses :context-reads
+    :pre-session-snapshot :session-mode}"
   [context body-fn]
     (if (governed? context)
       (let [executor (:execution/executor context)
@@ -1221,14 +1288,14 @@
             exec!    (or (:execution/execute-fn context) (missing-execute-fn!))
             session  (-> (create-capsule-session! executor env-id workdir exec!)
                        write-capsule-mcp-config!)]
-      (run-session session body-fn read-capsule-artifact cleanup-capsule-session! :capsule))
+      (run-session session body-fn read-capsule-session-outputs cleanup-capsule-session! :capsule))
     (let [workdir (:execution/worktree-path context)
           session (-> (if workdir
                         (create-session! {:workdir workdir
                                           :source-root (:source-root context)})
                         (create-session! {:source-root (:source-root context)}))
                       write-mcp-config!)]
-      (run-session session body-fn read-artifact cleanup-session! :host))))
+      (run-session session body-fn read-host-session-outputs cleanup-session! :host))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/agent/src/ai/miniforge/agent/artifact_session.clj
+++ b/components/agent/src/ai/miniforge/agent/artifact_session.clj
@@ -957,7 +957,12 @@
         result      ((:exec! session) (:executor session) (:environment-id session)
                      cmd {:workdir (:workdir session)})
         stdout      (get-in result [:data :stdout] "")
-        boundary-re (re-pattern (java.util.regex.Pattern/quote capsule-output-boundary))
+        ;; Full-line anchor: the echoed sentinel always stands alone on its
+        ;; own line, so a boundary substring embedded mid-line in EDN
+        ;; content never splits a segment.
+        boundary-re (re-pattern (str "(?m)^"
+                                     (java.util.regex.Pattern/quote capsule-output-boundary)
+                                     "$"))
         [misses-part reads-part artifact-part] (mapv str/trim (str/split stdout boundary-re 3))]
     {:artifact       (when (seq artifact-part)
                        (parse-edn-content artifact-part

--- a/components/agent/src/ai/miniforge/agent/file_artifacts.clj
+++ b/components/agent/src/ai/miniforge/agent/file_artifacts.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.agent.file-artifacts
   "Fallback artifact collection from files written in the working tree."
   (:require
@@ -27,84 +26,51 @@
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Porcelain parsing and artifact shaping
 
-(def ^:private artifact-manifest-name
+;; Porcelain parsing and artifact shaping
+(def ^{:stratum 0} ^:private artifact-manifest-name
   "Optional metadata manifest written by the agent."
   "miniforge-artifact.edn")
 
-(def ^:private failed-exit-code
+(def ^{:stratum 0} ^:private failed-exit-code
   "Default process exit code for missing executor status."
   1)
 
-(def ^:private empty-changed-paths
+(def ^{:stratum 0} ^:private empty-changed-paths
   {:create #{} :modify #{} :delete #{}})
 
-(defn- shell-quote
-  "Quote a value for a POSIX shell command string."
+(defn ^{:stratum 0} shell-quote
+  "Quote a value for a POSIX shell command string.
+
+   Public so sibling namespaces that build executor command strings
+   (e.g. artifact-session's capsule reads) quote paths the same way."
   [value]
   (str "'" (str/replace (str value) #"'" "'\"'\"'") "'"))
 
-(defn- valid-base-ref?
+(defn- ^{:stratum 0} valid-base-ref?
   "True when `base-ref` can be used as a git diff base candidate."
   [base-ref]
   (and (string? base-ref) (not (str/blank? base-ref))))
 
-(defn- successful-exec?
-  "True when executor result reports success and a zero exit code."
-  [result]
-  (let [exit-code (get-in result [:data :exit-code] failed-exit-code)]
-    (and (:ok? result)
-         (zero? exit-code))))
-
-(defn- normalize-base-refs
+(defn- ^{:stratum 0} normalize-base-refs
   [base-refs]
   (if (sequential? base-refs)
     base-refs
     [base-refs]))
 
-(defn- tracked-addition?
+(defn- ^{:stratum 0} tracked-addition?
   "Return true when the porcelain status indicates a newly added tracked file."
   [status]
   (or (= \A (nth status 0))
       (= \A (nth status 1))))
 
-(defn- deleted?
+(defn- ^{:stratum 0} deleted?
   "Return true when the porcelain status indicates deletion."
   [status]
   (or (= \D (nth status 0))
       (= \D (nth status 1))))
 
-(defn- modified?
-  "Return true when the porcelain status indicates a tracked file change."
-  [status]
-  (or (= \M (nth status 0))
-      (= \M (nth status 1))
-      (= \R (nth status 0))
-      (= \R (nth status 1))
-      (= \C (nth status 0))
-      (= \C (nth status 1))
-      (= \T (nth status 0))
-      (= \T (nth status 1))
-      (tracked-addition? status)))
-
-(defn- porcelain-entry
-  "Parse a single git status --porcelain=v1 line."
-  [line]
-  (when (>= (count line) 3)
-    (let [status (subs line 0 2)
-          raw-path (subs line 3)
-          path (if (str/includes? raw-path " -> ")
-                 (second (str/split raw-path #" -> " 2))
-                 raw-path)]
-      (cond
-        (= status "??") {:bucket :untracked :path path}
-        (deleted? status) {:bucket :deleted :path path}
-        (tracked-addition? status) {:bucket :added :path path}
-        (modified? status) {:bucket :modified :path path}
-        :else nil))))
-
-(defn- name-status-entries
+(defn- ^{:stratum 0} name-status-entries
   "Parse one `git diff --name-status` line into action/path entries."
   [line]
   (let [[status old-path new-path] (str/split line #"\t")
@@ -119,7 +85,7 @@
       \T [{:action :modify :path old-path}]
       [])))
 
-(defn empty-snapshot
+(defn ^{:stratum 0} empty-snapshot
   "Return an empty working tree snapshot."
   []
   {:untracked #{}
@@ -127,34 +93,85 @@
    :deleted #{}
    :added #{}})
 
-(defn- add-entry
+(defn- ^{:stratum 0} add-entry
   "Add a parsed porcelain entry into the snapshot."
   [snapshot {:keys [bucket path]}]
   (update snapshot bucket conj path))
 
-(defn- manifest-path
-  "Return the manifest file path for a working dir."
-  [working-dir]
-  (str (io/file working-dir artifact-manifest-name)))
-
-(defn- read-manifest
-  "Read optional artifact metadata from the working directory."
-  [working-dir]
-  (let [path (manifest-path working-dir)
-        file (io/file path)]
-    (when (.exists file)
-      (-> (slurp file)
-          edn/read-string
-          (select-keys [:code/summary :code/tests-needed?])))))
-
-(defn- file-entry
+(defn- ^{:stratum 0} file-entry
   "Build a synthetic artifact entry for a written file."
   [working-dir action path]
   {:path path
    :content (if (= :delete action) "" (slurp (io/file working-dir path)))
    :action action})
 
-(defn- changed-paths
+(defn- ^{:stratum 0} add-diff-entry
+  "Add a parsed name-status entry into changed path sets."
+  [changed {:keys [action path]}]
+  (if (and action path)
+    (update changed action conj path)
+    changed))
+
+(defn- ^{:stratum 0} merge-changed
+  "Union changed path maps."
+  [& changeds]
+  (apply merge-with set/union changeds))
+
+(defn- ^{:stratum 0} has-changed-paths?
+  "True when a diff changed-path map contains at least one path."
+  [changed]
+  (boolean (some seq (vals changed))))
+
+(defn- ^{:stratum 0} safe-resolve
+  "Resolve `path` under `working-dir` defensively. Returns a regular-file
+   `java.io.File` when:
+   - `path` is non-blank
+   - the canonical target stays inside `working-dir` (rejects absolute
+     paths, `..` escapes, and symlinks pointing outside)
+   - the target exists and is a regular file (not a directory)
+   Returns nil otherwise. Paths come from agent-produced artifacts, so
+   this is a real boundary check, not paranoia."
+  [working-dir path]
+  (try
+    (when (and (string? path) (not (str/blank? path)))
+      (let [base   (.getCanonicalFile (io/file working-dir))
+            target (.getCanonicalFile (io/file working-dir path))]
+        (when (and (.exists target)
+                   (.isFile target)
+                   (.startsWith (.toPath target) (.toPath base)))
+          target)))
+    (catch java.io.IOException _ nil)
+    (catch SecurityException _ nil)
+    (catch IllegalArgumentException _ nil)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} successful-exec?
+  "True when executor result reports success and a zero exit code."
+  [result]
+  (let [exit-code (get-in result [:data :exit-code] failed-exit-code)]
+    (and (:ok? result)
+         (zero? exit-code))))
+
+(defn- ^{:stratum 1} modified?
+  "Return true when the porcelain status indicates a tracked file change."
+  [status]
+  (or (= \M (nth status 0))
+      (= \M (nth status 1))
+      (= \R (nth status 0))
+      (= \R (nth status 1))
+      (= \C (nth status 0))
+      (= \C (nth status 1))
+      (= \T (nth status 0))
+      (= \T (nth status 1))
+      (tracked-addition? status)))
+
+(defn- ^{:stratum 1} manifest-path
+  "Return the manifest file path for a working dir."
+  [working-dir]
+  (str (io/file working-dir artifact-manifest-name)))
+
+(defn- ^{:stratum 1} changed-paths
   "Compute created/modified/deleted paths attributable to the current session."
   [pre post]
   (let [dirty-before (apply set/union (map #(get pre % #{})
@@ -171,24 +188,7 @@
      :modify (disj modified artifact-manifest-name)
      :delete (disj deleted artifact-manifest-name)}))
 
-(defn- add-diff-entry
-  "Add a parsed name-status entry into changed path sets."
-  [changed {:keys [action path]}]
-  (if (and action path)
-    (update changed action conj path)
-    changed))
-
-(defn- merge-changed
-  "Union changed path maps."
-  [& changeds]
-  (apply merge-with set/union changeds))
-
-(defn- has-changed-paths?
-  "True when a diff changed-path map contains at least one path."
-  [changed]
-  (boolean (some seq (vals changed))))
-
-(defn- snapshot->changed-paths
+(defn- ^{:stratum 1} snapshot->changed-paths
   "Convert a current dirty snapshot into changed path sets."
   [snapshot]
   {:create (disj (set/union (:untracked snapshot #{})
@@ -197,7 +197,7 @@
    :modify (disj (:modified snapshot #{}) artifact-manifest-name)
    :delete (disj (:deleted snapshot #{}) artifact-manifest-name)})
 
-(defn- diff-against-ref
+(defn- ^{:stratum 1} diff-against-ref
   "Return changed paths between `base-ref` and the current working tree."
   [working-dir base-ref]
   (when (and working-dir (valid-base-ref? base-ref))
@@ -208,7 +208,55 @@
                 empty-changed-paths
                 (mapcat name-status-entries (str/split-lines out)))))))
 
-(defn- first-diff-against-ref
+(defn- ^{:stratum 1} read-rehydrated-file
+  "Read one rehydration entry. Returns the file map or nil for any
+   failure (path traversal, missing/non-regular file, permissions,
+   read errors). Skipping unreadable paths is preferable to bubbling
+   an exception that fails the entire review phase."
+  [working-dir path action]
+  (if (= :delete action)
+    {:path path :content "" :action :delete}
+    (when-let [file (safe-resolve working-dir path)]
+      (try
+        {:path path :content (slurp file) :action action}
+        (catch java.io.IOException _ nil)
+        (catch SecurityException _ nil)))))
+
+(defn- ^{:stratum 1} read-file-via-executor
+  "Read a file's content from the capsule. Returns empty string on failure."
+  [exec! executor env-id working-dir path]
+  (let [r (exec! executor env-id (str "cat " (shell-quote path)) {:workdir working-dir})]
+    (get-in r [:data :stdout] "")))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn- ^{:stratum 2} porcelain-entry
+  "Parse a single git status --porcelain=v1 line."
+  [line]
+  (when (>= (count line) 3)
+    (let [status (subs line 0 2)
+          raw-path (subs line 3)
+          path (if (str/includes? raw-path " -> ")
+                 (second (str/split raw-path #" -> " 2))
+                 raw-path)]
+      (cond
+        (= status "??") {:bucket :untracked :path path}
+        (deleted? status) {:bucket :deleted :path path}
+        (tracked-addition? status) {:bucket :added :path path}
+        (modified? status) {:bucket :modified :path path}
+        :else nil))))
+
+(defn- ^{:stratum 2} read-manifest
+  "Read optional artifact metadata from the working directory."
+  [working-dir]
+  (let [path (manifest-path working-dir)
+        file (io/file path)]
+    (when (.exists file)
+      (-> (slurp file)
+          edn/read-string
+          (select-keys [:code/summary :code/tests-needed?])))))
+
+(defn- ^{:stratum 2} first-diff-against-ref
   "Try base refs in order and return the first non-empty successful diff."
   [working-dir base-refs]
   (loop [[base-ref & remaining] (filter valid-base-ref? base-refs)
@@ -221,7 +269,55 @@
         (recur remaining empty-diff))
       empty-diff)))
 
-(defn- worktree-changed-paths
+(defn- ^{:stratum 2} rehydration-entry
+  "Build one `:code/files` entry for `path` under `working-dir`,
+   honoring the action recorded in `action-by-path` (defaulting to
+   `:modify`). Named so callers can pass it via `partial` instead of
+   hoisting the closure into an inline `fn`."
+  [working-dir action-by-path path]
+  (read-rehydrated-file working-dir
+                        path
+                        (get action-by-path path :modify)))
+
+(defn- ^{:stratum 2} read-manifest-via-executor
+  "Read the artifact manifest from the capsule, if present."
+  [exec! executor env-id working-dir]
+  (let [r (exec! executor env-id
+                 (str "cat " (shell-quote artifact-manifest-name))
+                 {:workdir working-dir})]
+    (when (successful-exec? r)
+      (try (-> (get-in r [:data :stdout])
+               edn/read-string
+               (select-keys [:code/summary :code/tests-needed?]))
+           (catch Exception _ nil)))))
+
+(defn- ^{:stratum 2} changed-path->file-entry
+  "Build a file entry map for a changed path, reading content via executor."
+  [exec! executor env-id working-dir action path]
+  {:path path
+   :content (if (= :delete action)
+              ""
+              (read-file-via-executor exec! executor env-id working-dir path))
+   :action action})
+
+(defn- ^{:stratum 2} diff-against-ref-via-executor
+  "Return changed paths between `base-ref` and the capsule working tree."
+  [exec! executor env-id working-dir base-ref]
+  (when (valid-base-ref? base-ref)
+    (let [result (exec! executor env-id
+                        (str "git diff --name-status "
+                             (shell-quote base-ref)
+                             " --")
+                        {:workdir working-dir})]
+      (when (successful-exec? result)
+        (reduce add-diff-entry
+                empty-changed-paths
+                (mapcat name-status-entries
+                        (str/split-lines (get-in result [:data :stdout] ""))))))))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn- ^{:stratum 3} worktree-changed-paths
   "Merge committed task diff and current dirty snapshot paths."
   [working-dir base-refs snapshot]
   (merge-changed
@@ -229,7 +325,7 @@
        empty-changed-paths)
    (snapshot->changed-paths snapshot)))
 
-(defn- synthetic-artifact
+(defn- ^{:stratum 3} synthetic-artifact
   "Build a synthetic code artifact from written file sets."
   [working-dir changed]
   (let [files (->> [[:create (:create changed)]
@@ -246,10 +342,8 @@
               :code/tests-needed? true}
              (read-manifest working-dir)))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Working tree snapshot and fallback artifact collection
-
-(defn snapshot-working-dir
+(defn ^{:stratum 3} snapshot-working-dir
   "Capture the current git dirty state for a working directory.
 
    Returns sets of paths relative to working-dir. Paths already staged
@@ -281,7 +375,7 @@
                         :exit exit
                         :stderr err}))))
 
-(defn snapshot-via-executor
+(defn ^{:stratum 3} snapshot-via-executor
   "Capture git dirty state inside a capsule via the executor.
 
    Like snapshot-working-dir but runs git status through the executor
@@ -296,98 +390,7 @@
               (keep porcelain-entry (str/split-lines (get-in result [:data :stdout] ""))))
       (empty-snapshot))))
 
-(defn collect-written-files
-  "Collect files written during the agent session into a synthetic code artifact.
-
-   Uses the pre-session snapshot to exclude files that were already dirty before
-   the session started.
-
-   `snapshot-working-dir` is anomaly-returning; we treat any anomaly
-   the same way we treat a thrown exception — return nil so a broken
-   working tree never aborts the review phase. The `try/catch` covers
-   non-anomaly throws from downstream IO (e.g. `synthetic-artifact`
-   reading file content)."
-  [pre-snapshot working-dir]
-  (when pre-snapshot
-    (try
-      (let [snap (snapshot-working-dir working-dir)]
-        (when-not (anomaly/anomaly? snap)
-          (->> snap
-               (changed-paths pre-snapshot)
-               (synthetic-artifact working-dir))))
-      (catch Exception _
-        nil))))
-
-(defn collect-worktree-files
-  "Collect the promoted worktree artifact.
-
-   Unlike `collect-written-files`, this is not limited to the current
-   LLM session. It compares the current worktree against the task base
-   ref when one is known, then merges in untracked dirty files. This is
-   the environment-promotion path: previously committed repair work is
-   still part of the artifact even when the current session only touched
-   one follow-up file or wrote nothing new."
-  ([working-dir]
-   (collect-worktree-files working-dir nil))
-  ([working-dir base-refs]
-   (when working-dir
-     (try
-       (let [snap (snapshot-working-dir working-dir)]
-         (when-not (anomaly/anomaly? snap)
-           (synthetic-artifact working-dir
-                               (worktree-changed-paths working-dir
-                                                       base-refs
-                                                       snap))))
-       (catch Exception _
-         nil)))))
-
-(defn- safe-resolve
-  "Resolve `path` under `working-dir` defensively. Returns a regular-file
-   `java.io.File` when:
-   - `path` is non-blank
-   - the canonical target stays inside `working-dir` (rejects absolute
-     paths, `..` escapes, and symlinks pointing outside)
-   - the target exists and is a regular file (not a directory)
-   Returns nil otherwise. Paths come from agent-produced artifacts, so
-   this is a real boundary check, not paranoia."
-  [working-dir path]
-  (try
-    (when (and (string? path) (not (str/blank? path)))
-      (let [base   (.getCanonicalFile (io/file working-dir))
-            target (.getCanonicalFile (io/file working-dir path))]
-        (when (and (.exists target)
-                   (.isFile target)
-                   (.startsWith (.toPath target) (.toPath base)))
-          target)))
-    (catch java.io.IOException _ nil)
-    (catch SecurityException _ nil)
-    (catch IllegalArgumentException _ nil)))
-
-(defn- read-rehydrated-file
-  "Read one rehydration entry. Returns the file map or nil for any
-   failure (path traversal, missing/non-regular file, permissions,
-   read errors). Skipping unreadable paths is preferable to bubbling
-   an exception that fails the entire review phase."
-  [working-dir path action]
-  (if (= :delete action)
-    {:path path :content "" :action :delete}
-    (when-let [file (safe-resolve working-dir path)]
-      (try
-        {:path path :content (slurp file) :action action}
-        (catch java.io.IOException _ nil)
-        (catch SecurityException _ nil)))))
-
-(defn- rehydration-entry
-  "Build one `:code/files` entry for `path` under `working-dir`,
-   honoring the action recorded in `action-by-path` (defaulting to
-   `:modify`). Named so callers can pass it via `partial` instead of
-   hoisting the closure into an inline `fn`."
-  [working-dir action-by-path path]
-  (read-rehydrated-file working-dir
-                        path
-                        (get action-by-path path :modify)))
-
-(defn rehydrate-files
+(defn ^{:stratum 3} rehydrate-files
   "Read file content from `working-dir` for each path in `paths`,
    producing the `:code/files` vector callers expect.
 
@@ -423,34 +426,7 @@
             (keep (partial rehydration-entry working-dir action-by-path))
             vec)))))
 
-(defn- read-file-via-executor
-  "Read a file's content from the capsule. Returns empty string on failure."
-  [exec! executor env-id working-dir path]
-  (let [r (exec! executor env-id (str "cat " (shell-quote path)) {:workdir working-dir})]
-    (get-in r [:data :stdout] "")))
-
-(defn- read-manifest-via-executor
-  "Read the artifact manifest from the capsule, if present."
-  [exec! executor env-id working-dir]
-  (let [r (exec! executor env-id
-                 (str "cat " (shell-quote artifact-manifest-name))
-                 {:workdir working-dir})]
-    (when (successful-exec? r)
-      (try (-> (get-in r [:data :stdout])
-               edn/read-string
-               (select-keys [:code/summary :code/tests-needed?]))
-           (catch Exception _ nil)))))
-
-(defn- changed-path->file-entry
-  "Build a file entry map for a changed path, reading content via executor."
-  [exec! executor env-id working-dir action path]
-  {:path path
-   :content (if (= :delete action)
-              ""
-              (read-file-via-executor exec! executor env-id working-dir path))
-   :action action})
-
-(defn- changed-paths->file-entries
+(defn- ^{:stratum 3} changed-paths->file-entries
   "Convert changed-paths result to a flat vector of file entry maps."
   [changed exec! executor env-id working-dir]
   (->> [[:create (:create changed)]
@@ -461,22 +437,7 @@
                       (sort paths))))
        vec))
 
-(defn- diff-against-ref-via-executor
-  "Return changed paths between `base-ref` and the capsule working tree."
-  [exec! executor env-id working-dir base-ref]
-  (when (valid-base-ref? base-ref)
-    (let [result (exec! executor env-id
-                        (str "git diff --name-status "
-                             (shell-quote base-ref)
-                             " --")
-                        {:workdir working-dir})]
-      (when (successful-exec? result)
-        (reduce add-diff-entry
-                empty-changed-paths
-                (mapcat name-status-entries
-                        (str/split-lines (get-in result [:data :stdout] ""))))))))
-
-(defn- first-diff-against-ref-via-executor
+(defn- ^{:stratum 3} first-diff-against-ref-via-executor
   "Try base refs in order inside the capsule."
   [exec! executor env-id working-dir base-refs]
   (loop [[base-ref & remaining] (filter valid-base-ref? base-refs)
@@ -490,7 +451,54 @@
         (recur remaining empty-diff))
       empty-diff)))
 
-(defn- worktree-changed-paths-via-executor
+;------------------------------------------------------------------------------ Layer 4
+
+(defn ^{:stratum 4} collect-written-files
+  "Collect files written during the agent session into a synthetic code artifact.
+
+   Uses the pre-session snapshot to exclude files that were already dirty before
+   the session started.
+
+   `snapshot-working-dir` is anomaly-returning; we treat any anomaly
+   the same way we treat a thrown exception — return nil so a broken
+   working tree never aborts the review phase. The `try/catch` covers
+   non-anomaly throws from downstream IO (e.g. `synthetic-artifact`
+   reading file content)."
+  [pre-snapshot working-dir]
+  (when pre-snapshot
+    (try
+      (let [snap (snapshot-working-dir working-dir)]
+        (when-not (anomaly/anomaly? snap)
+          (->> snap
+               (changed-paths pre-snapshot)
+               (synthetic-artifact working-dir))))
+      (catch Exception _
+        nil))))
+
+(defn ^{:stratum 4} collect-worktree-files
+  "Collect the promoted worktree artifact.
+
+   Unlike `collect-written-files`, this is not limited to the current
+   LLM session. It compares the current worktree against the task base
+   ref when one is known, then merges in untracked dirty files. This is
+   the environment-promotion path: previously committed repair work is
+   still part of the artifact even when the current session only touched
+   one follow-up file or wrote nothing new."
+  ([working-dir]
+   (collect-worktree-files working-dir nil))
+  ([working-dir base-refs]
+   (when working-dir
+     (try
+       (let [snap (snapshot-working-dir working-dir)]
+         (when-not (anomaly/anomaly? snap)
+           (synthetic-artifact working-dir
+                               (worktree-changed-paths working-dir
+                                                       base-refs
+                                                       snap))))
+       (catch Exception _
+         nil)))))
+
+(defn- ^{:stratum 4} worktree-changed-paths-via-executor
   "Merge committed task diff and current dirty snapshot paths in a capsule."
   [exec! executor env-id working-dir base-refs snapshot]
   (merge-changed
@@ -499,7 +507,7 @@
        empty-changed-paths)
    (snapshot->changed-paths snapshot)))
 
-(defn- worktree-artifact-via-executor
+(defn- ^{:stratum 4} worktree-artifact-via-executor
   [exec! executor env-id working-dir changed]
   (let [files (changed-paths->file-entries changed exec! executor env-id working-dir)]
     (when (seq files)
@@ -509,7 +517,7 @@
               :code/tests-needed? true}
              (read-manifest-via-executor exec! executor env-id working-dir)))))
 
-(defn collect-written-files-via-executor
+(defn ^{:stratum 4} collect-written-files-via-executor
   "Like collect-written-files but runs git status inside a capsule via executor.
    Reads file contents from the capsule for the synthetic artifact."
   [pre-snapshot exec! executor env-id working-dir]
@@ -527,7 +535,9 @@
       (catch Exception _
         nil))))
 
-(defn collect-worktree-files-via-executor
+;------------------------------------------------------------------------------ Layer 5
+
+(defn ^{:stratum 5} collect-worktree-files-via-executor
   "Like collect-worktree-files but reads git state and content in a capsule."
   ([exec! executor env-id working-dir]
    (collect-worktree-files-via-executor exec! executor env-id working-dir nil))

--- a/components/agent/test/ai/miniforge/agent/artifact_session_capsule_test.clj
+++ b/components/agent/test/ai/miniforge/agent/artifact_session_capsule_test.clj
@@ -64,9 +64,11 @@
     (result/ok {:stdout "" :stderr "" :exit-code 0})))
 
 (def ^{:stratum 0} ^:private capsule-boundary
-  "Mirror of the private boundary sentinel in artifact-session's batched
-   session-outputs read (misses, reads, artifact — artifact last)."
-  "===MINIFORGE-SESSION-OUTPUT-BOUNDARY===")
+  "The production boundary sentinel for the batched session-outputs read
+   (misses, reads, artifact — artifact last), resolved from
+   artifact-session's private var so the mock always frames stdout with
+   the real boundary (white-box access, same pattern as run-session*)."
+  @(ns-resolve 'ai.miniforge.agent.artifact-session 'capsule-output-boundary))
 
 (def ^{:stratum 0} ^:private artifact-edn-stdout
   "{:code/id \"a1b2c3d4-e5f6-7890-abcd-ef1234567890\" :code/description \"test\"}")

--- a/components/agent/test/ai/miniforge/agent/artifact_session_capsule_test.clj
+++ b/components/agent/test/ai/miniforge/agent/artifact_session_capsule_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.agent.artifact-session-capsule-test
   "Tests for capsule-aware artifact sessions (N11 §6.3-6.4).
    Verifies with-session dispatches correctly between host and capsule modes."
@@ -26,15 +25,16 @@
    [ai.miniforge.agent.artifact-session :as session]
    [ai.miniforge.dag-executor.result :as result]))
 
-;------------------------------------------------------------------------------ helpers
+;------------------------------------------------------------------------------ Layer 0
 
-(defn- delete-dir!
+;------------------------------------------------------------------------------ helpers
+(defn- ^{:stratum 0} delete-dir!
   "Recursively delete a directory tree."
   [path]
   (doseq [^java.io.File f (reverse (file-seq (io/file path)))]
     (.delete f)))
 
-(defn- local-cat-exec!
+(defn- ^{:stratum 0} local-cat-exec!
   "Stub exec! that reads 'cat <path>' from the local filesystem.
    All other commands (mkdir, rm, git status, etc.) succeed with empty output.
    Used for tests that need a real workdir on disk without a live executor."
@@ -49,51 +49,30 @@
     {:ok? true :data {:exit-code 0 :stdout "" :stderr ""}}))
 
 ;; run-session is private; accessed via ns-resolve for white-box testing.
-(def ^:private run-session*
+(def ^{:stratum 0} ^:private run-session*
   @(ns-resolve 'ai.miniforge.agent.artifact-session 'run-session))
 
-;------------------------------------------------------------------------------ Layer 0
 ;; Mock executor infrastructure
-
-(def ^:private capsule-workdir
+(def ^{:stratum 0} ^:private capsule-workdir
   "/workspace")
 
-(def ^:private capsule-session-dir
-  (str capsule-workdir "/.miniforge-session"))
-
-(def ^:private capsule-cleanup-command
-  (str "rm -rf " capsule-session-dir))
-
-(defn- mock-execute!
+(defn- ^{:stratum 0} mock-execute!
   "Mock executor that records commands and returns success."
   [log]
   (fn [_executor _env-id command & [_opts]]
     (swap! log conj command)
     (result/ok {:stdout "" :stderr "" :exit-code 0})))
 
-(defn- mock-execute-with-artifact!
-  "Mock executor that records commands and returns artifact EDN for cat commands."
-  [log]
-  (fn [_executor _env-id command & [_opts]]
-    (swap! log conj command)
-    (cond
-      (and (string? command) (str/starts-with? command "cat ") (str/includes? command "artifact.edn"))
-      (result/ok {:stdout "{:code/id \"a1b2c3d4-e5f6-7890-abcd-ef1234567890\" :code/description \"test\"}"
-                  :stderr ""
-                  :exit-code 0})
+(def ^{:stratum 0} ^:private capsule-boundary
+  "Mirror of the private boundary sentinel in artifact-session's batched
+   session-outputs read (misses, reads, artifact — artifact last)."
+  "===MINIFORGE-SESSION-OUTPUT-BOUNDARY===")
 
-      (and (string? command) (str/starts-with? command "cat ") (str/includes? command "implement.edn"))
-      (result/ok {:stdout "{:status :already-implemented :summary \"already there\"}"
-                  :stderr ""
-                  :exit-code 0})
+(def ^{:stratum 0} ^:private artifact-edn-stdout
+  "{:code/id \"a1b2c3d4-e5f6-7890-abcd-ef1234567890\" :code/description \"test\"}")
 
-      :else
-      (result/ok {:stdout "" :stderr "" :exit-code 0}))))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; with-session dispatch tests
-
-(deftest with-session-local-mode-test
+(deftest ^{:stratum 0} with-session-local-mode-test
   (testing "local mode uses host session (same shape as with-artifact-session)"
     (let [context {:execution/mode :local}
           result (session/with-session context
@@ -106,7 +85,7 @@
       (is (= :host (:session-mode result)))
       (is (nil? (:artifact result))))))
 
-(deftest with-session-missing-mode-defaults-to-host-test
+(deftest ^{:stratum 0} with-session-missing-mode-defaults-to-host-test
   (testing "missing :execution/mode falls through to host"
     (let [result (session/with-session {}
                    (fn [session]
@@ -114,7 +93,139 @@
                      :ok))]
       (is (= :host (:session-mode result))))))
 
-(deftest with-session-governed-mode-test
+;; Context cache dispatch tests
+(deftest ^{:stratum 0} write-context-cache-for-session-host-test
+  (testing "host session uses spit-based write"
+    (let [s (session/create-session!)]
+      (try
+        (session/write-context-cache-for-session! s {"src/foo.clj" "(ns foo)"})
+        (is (.exists (java.io.File. (str (:dir s) "/context-cache.edn"))))
+        (finally
+          (session/cleanup-session! s))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} ^:private capsule-session-dir
+  (str capsule-workdir "/.miniforge-session"))
+
+(defn- ^{:stratum 1} mock-execute-with-artifact!
+  "Mock executor that records commands and returns artifact EDN for cat
+   commands. The batched session-outputs read (the only command naming
+   context-misses.edn) gets boundary-framed stdout with the artifact in
+   the final segment; plain role-file cats get bare EDN."
+  [log]
+  (fn [_executor _env-id command & [_opts]]
+    (swap! log conj command)
+    (cond
+      (and (string? command) (str/includes? command "context-misses.edn"))
+      (result/ok {:stdout (str "\n" capsule-boundary "\n"
+                               "\n" capsule-boundary "\n"
+                               artifact-edn-stdout "\n")
+                  :stderr ""
+                  :exit-code 0})
+
+      (and (string? command) (str/starts-with? command "cat ") (str/includes? command "artifact.edn"))
+      (result/ok {:stdout artifact-edn-stdout
+                  :stderr ""
+                  :exit-code 0})
+
+      (and (string? command) (str/starts-with? command "cat ") (str/includes? command "implement.edn"))
+      (result/ok {:stdout "{:status :already-implemented :summary \"already there\"}"
+                  :stderr ""
+                  :exit-code 0})
+
+      :else
+      (result/ok {:stdout "" :stderr "" :exit-code 0}))))
+
+(deftest ^{:stratum 1} write-context-cache-for-session-capsule-test
+  (testing "capsule session uses executor-based write"
+    (let [log (atom [])
+          s {:dir "/workspace/.miniforge-session"
+             :capsule? true
+             :exec! (mock-execute! log)
+             :executor :mock
+             :environment-id "env-test"
+             :workdir capsule-workdir}]
+      (session/write-context-cache-for-session! s {"src/foo.clj" "(ns foo)"})
+      (is (some #(.contains (str %) "context-cache.edn") @log)))))
+
+;; :explicit-workdir? flag and WARN suppression (artifact-warning-suppression PR)
+(deftest ^{:stratum 1} create-capsule-session-sets-explicit-workdir-test
+  (testing "create-capsule-session! always sets :explicit-workdir? true"
+    ;; The 4-arity form accepts an inject execute-fn, so the test never
+    ;; touches requiring-resolve or a live Docker executor.
+    (let [dir (str (System/getProperty "java.io.tmpdir") "/caps-test-" (random-uuid))]
+      (.mkdirs (io/file dir))
+      (try
+        (let [s (session/create-capsule-session! ::stub "env-1" dir local-cat-exec!)]
+          (is (true? (:explicit-workdir? s))
+              ":explicit-workdir? must be true so run-session scans worktree artifacts")
+          (is (= dir (:workdir s)))
+          (is (true? (:capsule? s))))
+        (finally
+          (delete-dir! dir))))))
+
+(deftest ^{:stratum 1} capsule-worktree-artifact-suppresses-warn-test
+  (testing "no WARN when .miniforge/plan.edn exists in capsule workdir (no MCP artifact)"
+    (let [dir       (str (System/getProperty "java.io.tmpdir") "/caps-warn-" (random-uuid))
+          plan-file (io/file dir ".miniforge" "plan.edn")]
+      (.mkdirs (.getParentFile plan-file))
+      ;; Write a minimal parseable plan artifact to the capsule workdir
+      (spit plan-file "{:plan/summary \"stub\" :plan/tasks []}")
+      (try
+        (let [session {:workdir           dir
+                       :explicit-workdir? true
+                       :capsule?          true
+                       ;; artifact-path does NOT exist → read-capsule-artifact returns nil
+                       :artifact-path     (str dir "/.miniforge-session/artifact.edn")
+                       :exec!             local-cat-exec!
+                       :executor          ::stub
+                       :environment-id    "env-1"}
+              err    (java.io.StringWriter.)
+              result (binding [*err* err]
+                       (run-session* session
+                                     (constantly :ok)
+                                     session/read-capsule-session-outputs
+                                     (constantly nil)   ; cleanup noop
+                                     :capsule))]
+          (is (not (str/includes? (str err) "WARN: no artifact found"))
+              "WARN must be suppressed when worktree artifact covers the missing MCP file")
+          (is (contains? (:worktree-artifacts result) :plan)
+              "worktree-artifacts must include :plan from .miniforge/plan.edn"))
+        (finally
+          (delete-dir! dir))))))
+
+(deftest ^{:stratum 1} capsule-warn-fires-when-both-sources-absent-test
+  (testing "WARN fires when both MCP artifact and all worktree artifacts are absent"
+    (let [dir     (str (System/getProperty "java.io.tmpdir") "/caps-nowarn-" (random-uuid))]
+      (.mkdirs (io/file dir))
+      (try
+        (let [session {:workdir           dir
+                       :explicit-workdir? true
+                       :capsule?          true
+                       :artifact-path     (str dir "/.miniforge-session/artifact.edn")
+                       :exec!             local-cat-exec!
+                       :executor          ::stub
+                       :environment-id    "env-2"}
+              err    (java.io.StringWriter.)]
+          (binding [*err* err]
+            (run-session* session
+                          (constantly :ok)
+                          session/read-capsule-session-outputs
+                          (constantly nil)
+                          :capsule))
+          ;; Both sources absent → WARN must have been written
+          (is (str/includes? (str err) "WARN: no artifact found")
+              "WARN must fire when both MCP and worktree artifacts are absent"))
+        (finally
+          (delete-dir! dir))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(def ^{:stratum 2} ^:private capsule-cleanup-command
+  (str "rm -rf " capsule-session-dir))
+
+(deftest ^{:stratum 2} with-session-governed-mode-test
   (testing "governed mode with executor uses capsule session"
     (let [log (atom [])
           exec! (mock-execute! log)
@@ -136,7 +247,7 @@
       ;; Should have executed mkdir, config writes, and cleanup
       (is (pos? (count @log))))))
 
-(deftest with-session-governed-reads-artifact-test
+(deftest ^{:stratum 2} with-session-governed-reads-artifact-test
   (testing "governed mode reads and parses artifact from capsule"
     (let [log (atom [])
           exec! (mock-execute-with-artifact! log)
@@ -150,7 +261,35 @@
       (is (some? (:artifact result)))
       (is (uuid? (:code/id (:artifact result)))))))
 
-(deftest with-session-governed-cleanup-on-exception-test
+;; UUID parsing in capsule artifact
+(deftest ^{:stratum 2} read-capsule-artifact-parses-uuids-test
+  (testing "UUID strings are converted to java.util.UUID"
+    (let [log (atom [])
+          s {:artifact-path "/workspace/.miniforge-session/artifact.edn"
+             :capsule? true
+             :exec! (mock-execute-with-artifact! log)
+             :executor :mock
+             :environment-id "env-uuid"
+             :workdir capsule-workdir}
+          artifact (session/read-capsule-artifact s)]
+      (is (some? artifact))
+      (is (uuid? (:code/id artifact))))))
+
+(deftest ^{:stratum 2} read-capsule-worktree-artifact-test
+  (testing "reads .miniforge/<role>.edn from inside the capsule worktree"
+    (let [log (atom [])
+          s {:capsule? true
+             :exec! (mock-execute-with-artifact! log)
+             :executor :mock
+             :environment-id "env-role"
+             :workdir capsule-workdir}
+          artifact (session/read-capsule-worktree-artifact s :implement)]
+      (is (= :already-implemented (:status artifact)))
+      (is (= "already there" (:summary artifact))))))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(deftest ^{:stratum 3} with-session-governed-cleanup-on-exception-test
   (testing "capsule session cleans up even on exception"
     (let [log (atom [])
           exec! (mock-execute! log)
@@ -164,131 +303,6 @@
               (fn [_session]
                 (throw (ex-info "test error" {}))))))
       (is (some #(= capsule-cleanup-command %) @log)))))
-
-;------------------------------------------------------------------------------ Layer 2
-;; Context cache dispatch tests
-
-(deftest write-context-cache-for-session-host-test
-  (testing "host session uses spit-based write"
-    (let [s (session/create-session!)]
-      (try
-        (session/write-context-cache-for-session! s {"src/foo.clj" "(ns foo)"})
-        (is (.exists (java.io.File. (str (:dir s) "/context-cache.edn"))))
-        (finally
-          (session/cleanup-session! s))))))
-
-(deftest write-context-cache-for-session-capsule-test
-  (testing "capsule session uses executor-based write"
-    (let [log (atom [])
-          s {:dir "/workspace/.miniforge-session"
-             :capsule? true
-             :exec! (mock-execute! log)
-             :executor :mock
-             :environment-id "env-test"
-             :workdir capsule-workdir}]
-      (session/write-context-cache-for-session! s {"src/foo.clj" "(ns foo)"})
-      (is (some #(.contains (str %) "context-cache.edn") @log)))))
-
-;------------------------------------------------------------------------------ Layer 3
-;; UUID parsing in capsule artifact
-
-(deftest read-capsule-artifact-parses-uuids-test
-  (testing "UUID strings are converted to java.util.UUID"
-    (let [log (atom [])
-          s {:artifact-path "/workspace/.miniforge-session/artifact.edn"
-             :capsule? true
-             :exec! (mock-execute-with-artifact! log)
-             :executor :mock
-             :environment-id "env-uuid"
-             :workdir capsule-workdir}
-          artifact (session/read-capsule-artifact s)]
-      (is (some? artifact))
-      (is (uuid? (:code/id artifact))))))
-
-(deftest read-capsule-worktree-artifact-test
-  (testing "reads .miniforge/<role>.edn from inside the capsule worktree"
-    (let [log (atom [])
-          s {:capsule? true
-             :exec! (mock-execute-with-artifact! log)
-             :executor :mock
-             :environment-id "env-role"
-             :workdir capsule-workdir}
-          artifact (session/read-capsule-worktree-artifact s :implement)]
-      (is (= :already-implemented (:status artifact)))
-      (is (= "already there" (:summary artifact))))))
-
-;------------------------------------------------------------------------------ Layer 4
-;; :explicit-workdir? flag and WARN suppression (artifact-warning-suppression PR)
-
-(deftest create-capsule-session-sets-explicit-workdir-test
-  (testing "create-capsule-session! always sets :explicit-workdir? true"
-    ;; The 4-arity form accepts an inject execute-fn, so the test never
-    ;; touches requiring-resolve or a live Docker executor.
-    (let [dir (str (System/getProperty "java.io.tmpdir") "/caps-test-" (random-uuid))]
-      (.mkdirs (io/file dir))
-      (try
-        (let [s (session/create-capsule-session! ::stub "env-1" dir local-cat-exec!)]
-          (is (true? (:explicit-workdir? s))
-              ":explicit-workdir? must be true so run-session scans worktree artifacts")
-          (is (= dir (:workdir s)))
-          (is (true? (:capsule? s))))
-        (finally
-          (delete-dir! dir))))))
-
-(deftest capsule-worktree-artifact-suppresses-warn-test
-  (testing "no WARN when .miniforge/plan.edn exists in capsule workdir (no MCP artifact)"
-    (let [dir       (str (System/getProperty "java.io.tmpdir") "/caps-warn-" (random-uuid))
-          plan-file (io/file dir ".miniforge" "plan.edn")]
-      (.mkdirs (.getParentFile plan-file))
-      ;; Write a minimal parseable plan artifact to the capsule workdir
-      (spit plan-file "{:plan/summary \"stub\" :plan/tasks []}")
-      (try
-        (let [session {:workdir           dir
-                       :explicit-workdir? true
-                       :capsule?          true
-                       ;; artifact-path does NOT exist → read-capsule-artifact returns nil
-                       :artifact-path     (str dir "/.miniforge-session/artifact.edn")
-                       :exec!             local-cat-exec!
-                       :executor          ::stub
-                       :environment-id    "env-1"}
-              err    (java.io.StringWriter.)
-              result (binding [*err* err]
-                       (run-session* session
-                                     (constantly :ok)
-                                     session/read-capsule-artifact
-                                     (constantly nil)   ; cleanup noop
-                                     :capsule))]
-          (is (not (str/includes? (str err) "WARN: no artifact found"))
-              "WARN must be suppressed when worktree artifact covers the missing MCP file")
-          (is (contains? (:worktree-artifacts result) :plan)
-              "worktree-artifacts must include :plan from .miniforge/plan.edn"))
-        (finally
-          (delete-dir! dir))))))
-
-(deftest capsule-warn-fires-when-both-sources-absent-test
-  (testing "WARN fires when both MCP artifact and all worktree artifacts are absent"
-    (let [dir     (str (System/getProperty "java.io.tmpdir") "/caps-nowarn-" (random-uuid))]
-      (.mkdirs (io/file dir))
-      (try
-        (let [session {:workdir           dir
-                       :explicit-workdir? true
-                       :capsule?          true
-                       :artifact-path     (str dir "/.miniforge-session/artifact.edn")
-                       :exec!             local-cat-exec!
-                       :executor          ::stub
-                       :environment-id    "env-2"}
-              err    (java.io.StringWriter.)]
-          (binding [*err* err]
-            (run-session* session
-                          (constantly :ok)
-                          session/read-capsule-artifact
-                          (constantly nil)
-                          :capsule))
-          ;; Both sources absent → WARN must have been written
-          (is (str/includes? (str err) "WARN: no artifact found")
-              "WARN must fire when both MCP and worktree artifacts are absent"))
-        (finally
-          (delete-dir! dir))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/agent/test/ai/miniforge/agent/artifact_session_test.clj
+++ b/components/agent/test/ai/miniforge/agent/artifact_session_test.clj
@@ -409,6 +409,43 @@
       (session/cleanup-session! s)
       (is (not (.exists (io/file (:dir s))))))))
 
+;------------------------------------------------------------------------------ Layer 3.6
+;; Capsule session-outputs surfacing (Codex SPEC §7.4.2 recorded flows)
+;;
+;; Capsule sessions must surface :context-misses and :context-reads like host
+;; sessions do. The reader batches artifact.edn + context-misses.edn +
+;; context-reads.edn into ONE executor round-trip — these tests pin both the
+;; parsing and the round-trip count.
+(def ^{:stratum 0} ^:private capsule-boundary
+  "Mirror of the private boundary sentinel in artifact-session. The cat-chain
+   command embeds it verbatim, so tests reproduce the stdout it yields."
+  "===MINIFORGE-SESSION-OUTPUT-BOUNDARY===")
+
+(defn- ^{:stratum 0} outputs-read?
+  "True when `cmd` is the batched session-outputs read (the only command
+   that references the context files)."
+  [cmd]
+  (str/includes? cmd "context-misses.edn"))
+
+(defn- ^{:stratum 0} context-miss-record
+  "Fixture matching the real producer (`record-miss!` in the
+   mcp-context-server context-cache): the base {:tool :tokens :timestamp}
+   map merged with the tool params, which carry :path."
+  [path]
+  {:tool      "context_read"
+   :tokens    120
+   :timestamp "2026-08-02T12:00:00Z"
+   :path      path})
+
+(defn- ^{:stratum 0} context-read-record
+  "Fixture matching the real producer (`record-read!` in the
+   mcp-context-server context-cache): {:path :source :timestamp}, where
+   :source is :cache | :filesystem | :refresh | :absent."
+  [path source]
+  {:path      path
+   :source    source
+   :timestamp "2026-08-02T12:00:00Z"})
+
 (deftest ^{:stratum 0} with-readonly-session-test
   (testing "runs body-fn with a configured session and returns its result
             directly (no artifact-promotion map), for read-only agents"
@@ -484,6 +521,25 @@
         (finally
           (doseq [^java.io.File f (reverse (file-seq (io/file wt)))]
             (.delete f)))))))
+
+(defn- ^{:stratum 1} capsule-outputs-stdout
+  "Assemble the stdout the batched cat chain produces for the given
+   artifact/misses/reads segments. Empty string = missing file (cat wrote
+   nothing; the echoed boundary lines remain)."
+  [artifact misses reads]
+  (str artifact "\n" capsule-boundary "\n"
+       misses "\n" capsule-boundary "\n"
+       reads "\n"))
+
+(defn- ^{:stratum 1} capsule-exec-stub
+  "Executor stub for capsule-session tests. Returns `outputs-stdout` for the
+   batched session-outputs read and empty stdout for everything else
+   (mkdir, config writes, snapshot, role-file cats, cleanup). Records every
+   command in `calls`."
+  [calls outputs-stdout]
+  (fn [_executor _env-id cmd _opts]
+    (swap! calls conj cmd)
+    {:data {:stdout (if (outputs-read? cmd) outputs-stdout "")}}))
 
 ;------------------------------------------------------------------------------ Layer 2
 
@@ -717,6 +773,90 @@
         (finally
           (doseq [^java.io.File f (reverse (file-seq (io/file wt)))]
             (.delete f)))))))
+
+(deftest ^{:stratum 2} read-capsule-session-outputs-test
+  (testing "parses all three session files from a single executor round-trip"
+    (let [calls   (atom [])
+          stdout  (capsule-outputs-stdout
+                   (pr-str (code-artifact))
+                   (pr-str [(context-miss-record "src/a.clj")])
+                   (pr-str [(context-read-record "src/a.clj" :cache)]))
+          session {:dir            "/workspace/.miniforge-session"
+                   :artifact-path  "/workspace/.miniforge-session/artifact.edn"
+                   :workdir        "/workspace"
+                   :executor       :fake-executor
+                   :environment-id "env-1"
+                   :exec!          (capsule-exec-stub calls stdout)}
+          result  (session/read-capsule-session-outputs session)]
+      (is (= 1 (count @calls))
+          "all three files must ride one executor round-trip, not three")
+      (is (str/includes? (first @calls) "artifact.edn"))
+      (is (str/includes? (first @calls) "context-misses.edn"))
+      (is (str/includes? (first @calls) "context-reads.edn"))
+      (is (= (java.util.UUID/fromString default-uuid-str)
+             (get-in result [:artifact :code/id]))
+          "artifact segment must go through parse-uuid-strings like host mode")
+      (is (= [(context-miss-record "src/a.clj")] (:context-misses result)))
+      (is (= [(context-read-record "src/a.clj" :cache)] (:context-reads result)))))
+
+  (testing "missing files yield nils, not errors"
+    (let [calls   (atom [])
+          session {:dir            "/workspace/.miniforge-session"
+                   :artifact-path  "/workspace/.miniforge-session/artifact.edn"
+                   :workdir        "/workspace"
+                   :executor       :fake-executor
+                   :environment-id "env-1"
+                   :exec!          (capsule-exec-stub calls (capsule-outputs-stdout "" "" ""))}
+          result  (session/read-capsule-session-outputs session)]
+      (is (nil? (:artifact result)))
+      (is (nil? (:context-misses result)))
+      (is (nil? (:context-reads result)))))
+
+  (testing "malformed segment emits parse WARN and yields nil for that file only"
+    (let [calls   (atom [])
+          stdout  (capsule-outputs-stdout
+                   ""
+                   "{{{not edn"
+                   (pr-str [(context-read-record "b.clj" :filesystem)]))
+          session {:dir            "/workspace/.miniforge-session"
+                   :artifact-path  "/workspace/.miniforge-session/artifact.edn"
+                   :workdir        "/workspace"
+                   :executor       :fake-executor
+                   :environment-id "env-1"
+                   :exec!          (capsule-exec-stub calls stdout)}
+          err     (java.io.StringWriter.)
+          result  (binding [*err* err]
+                    (session/read-capsule-session-outputs session))]
+      (is (nil? (:context-misses result)))
+      (is (= [(context-read-record "b.clj" :filesystem)] (:context-reads result))
+          "a malformed sibling segment must not poison the others")
+      (is (str/includes? (str err) "WARN")))))
+
+(deftest ^{:stratum 2} with-session-capsule-surfaces-context-files-test
+  (testing "governed with-session returns :context-misses and :context-reads"
+    ;; The regression this pins: capsule run-session used to gate both keys
+    ;; on :host mode, silently dropping the recorded flows the MCP server
+    ;; wrote inside the container.
+    (let [calls  (atom [])
+          stdout (capsule-outputs-stdout
+                  (pr-str (code-artifact))
+                  (pr-str [(context-miss-record "src/x.clj")])
+                  (pr-str [(context-read-record "src/x.clj" :absent)]))
+          ctx    {:execution/mode           :governed
+                  :execution/executor       :fake-executor
+                  :execution/environment-id "env-1"
+                  :execution/execute-fn     (capsule-exec-stub calls stdout)}
+          result (session/with-session ctx (constantly :llm-done))]
+      (is (= :capsule (:session-mode result)))
+      (is (= :llm-done (:llm-result result)))
+      (is (= (java.util.UUID/fromString default-uuid-str)
+             (get-in result [:artifact :code/id])))
+      (is (= [(context-miss-record "src/x.clj")] (:context-misses result))
+          "capsule sessions must surface context misses")
+      (is (= [(context-read-record "src/x.clj" :absent)] (:context-reads result))
+          "capsule sessions must surface recorded context reads (SPEC §7.4.2)")
+      (is (= 1 (count (filter outputs-read? @calls)))
+          "context files must not add executor round-trips beyond the batched read"))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/agent/test/ai/miniforge/agent/artifact_session_test.clj
+++ b/components/agent/test/ai/miniforge/agent/artifact_session_test.clj
@@ -524,12 +524,14 @@
 
 (defn- ^{:stratum 1} capsule-outputs-stdout
   "Assemble the stdout the batched cat chain produces for the given
-   artifact/misses/reads segments. Empty string = missing file (cat wrote
+   misses/reads/artifact segments (chain order: the agent-authored
+   artifact rides last so an embedded boundary cannot corrupt the
+   server-written segments). Empty string = missing file (cat wrote
    nothing; the echoed boundary lines remain)."
-  [artifact misses reads]
-  (str artifact "\n" capsule-boundary "\n"
-       misses "\n" capsule-boundary "\n"
-       reads "\n"))
+  [misses reads artifact]
+  (str misses "\n" capsule-boundary "\n"
+       reads "\n" capsule-boundary "\n"
+       artifact "\n"))
 
 (defn- ^{:stratum 1} capsule-exec-stub
   "Executor stub for capsule-session tests. Returns `outputs-stdout` for the
@@ -778,9 +780,9 @@
   (testing "parses all three session files from a single executor round-trip"
     (let [calls   (atom [])
           stdout  (capsule-outputs-stdout
-                   (pr-str (code-artifact))
                    (pr-str [(context-miss-record "src/a.clj")])
-                   (pr-str [(context-read-record "src/a.clj" :cache)]))
+                   (pr-str [(context-read-record "src/a.clj" :cache)])
+                   (pr-str (code-artifact)))
           session {:dir            "/workspace/.miniforge-session"
                    :artifact-path  "/workspace/.miniforge-session/artifact.edn"
                    :workdir        "/workspace"
@@ -815,9 +817,9 @@
   (testing "malformed segment emits parse WARN and yields nil for that file only"
     (let [calls   (atom [])
           stdout  (capsule-outputs-stdout
-                   ""
                    "{{{not edn"
-                   (pr-str [(context-read-record "b.clj" :filesystem)]))
+                   (pr-str [(context-read-record "b.clj" :filesystem)])
+                   "")
           session {:dir            "/workspace/.miniforge-session"
                    :artifact-path  "/workspace/.miniforge-session/artifact.edn"
                    :workdir        "/workspace"
@@ -830,7 +832,29 @@
       (is (nil? (:context-misses result)))
       (is (= [(context-read-record "b.clj" :filesystem)] (:context-reads result))
           "a malformed sibling segment must not poison the others")
-      (is (str/includes? (str err) "WARN")))))
+      (is (str/includes? (str err) "WARN"))))
+
+  (testing "artifact containing the boundary string parses intact"
+    ;; The artifact segment is agent-authored and rides LAST in the cat
+    ;; chain; the bounded split must keep an embedded boundary occurrence
+    ;; inside that final segment instead of corrupting the split.
+    (let [calls    (atom [])
+          summary  (str "mentions " capsule-boundary " inline")
+          stdout   (capsule-outputs-stdout
+                    (pr-str [(context-miss-record "src/a.clj")])
+                    ""
+                    (pr-str (code-artifact :code/summary summary)))
+          session  {:dir            "/workspace/.miniforge-session"
+                    :artifact-path  "/workspace/.miniforge-session/artifact.edn"
+                    :workdir        "/workspace"
+                    :executor       :fake-executor
+                    :environment-id "env-1"
+                    :exec!          (capsule-exec-stub calls stdout)}
+          result   (session/read-capsule-session-outputs session)]
+      (is (= summary (get-in result [:artifact :code/summary]))
+          "bounded split keeps the embedded boundary inside the final segment")
+      (is (= [(context-miss-record "src/a.clj")] (:context-misses result))
+          "server-written segments stay intact"))))
 
 (deftest ^{:stratum 2} with-session-capsule-surfaces-context-files-test
   (testing "governed with-session returns :context-misses and :context-reads"
@@ -839,9 +863,9 @@
     ;; wrote inside the container.
     (let [calls  (atom [])
           stdout (capsule-outputs-stdout
-                  (pr-str (code-artifact))
                   (pr-str [(context-miss-record "src/x.clj")])
-                  (pr-str [(context-read-record "src/x.clj" :absent)]))
+                  (pr-str [(context-read-record "src/x.clj" :absent)])
+                  (pr-str (code-artifact)))
           ctx    {:execution/mode           :governed
                   :execution/executor       :fake-executor
                   :execution/environment-id "env-1"

--- a/components/agent/test/ai/miniforge/agent/artifact_session_test.clj
+++ b/components/agent/test/ai/miniforge/agent/artifact_session_test.clj
@@ -417,9 +417,10 @@
 ;; context-reads.edn into ONE executor round-trip — these tests pin both the
 ;; parsing and the round-trip count.
 (def ^{:stratum 0} ^:private capsule-boundary
-  "Mirror of the private boundary sentinel in artifact-session. The cat-chain
-   command embeds it verbatim, so tests reproduce the stdout it yields."
-  "===MINIFORGE-SESSION-OUTPUT-BOUNDARY===")
+  "The production boundary sentinel, resolved from artifact-session's
+   private var so these tests always exercise the real split boundary
+   (white-box access, same pattern as run-session in the capsule tests)."
+  @(ns-resolve 'ai.miniforge.agent.artifact-session 'capsule-output-boundary))
 
 (defn- ^{:stratum 0} outputs-read?
   "True when `cmd` is the batched session-outputs read (the only command

--- a/components/agent/test/ai/miniforge/agent/artifact_session_test.clj
+++ b/components/agent/test/ai/miniforge/agent/artifact_session_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.agent.artifact-session-test
   (:require [clojure.test :as test :refer [deftest testing is]]
             [clojure.java.io :as io]
@@ -24,37 +23,15 @@
             [ai.miniforge.agent.artifact-session :as session]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Test fixtures and factories
 
-(def ^:private default-uuid-str
+;; Test fixtures and factories
+(def ^{:stratum 0} ^:private default-uuid-str
   "Stable UUID literal used across artifact fixtures. Real values are random;
    tests pin a constant so assertions can compare against a known UUID."
   "550e8400-e29b-41d4-a716-446655440000")
 
-(defn- code-artifact
-  "Factory for code-artifact EDN maps written to a session's `:artifact-path`.
-   Defaults exercise the parser's UUID/instant coercion paths; pass any
-   subset of overrides to vary individual fields per test."
-  [& {:as overrides}]
-  (merge {:code/id           default-uuid-str
-          :code/summary      "test artifact"
-          :code/created-at   "2026-02-28T12:00:00Z"}
-         overrides))
-
-(defn- plan-artifact
-  "Factory for plan-artifact EDN maps written to `.miniforge/plan.edn` in
-   the worktree. Defaults yield an empty task vector; override `:plan/tasks`
-   to exercise nested-vector UUID parsing."
-  [& {:as overrides}]
-  (merge {:plan/id    default-uuid-str
-          :plan/name  "t"
-          :plan/tasks []}
-         overrides))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; Session lifecycle tests
-
-(deftest create-session-test
+(deftest ^{:stratum 0} create-session-test
   (testing "creates temp dir and returns session map"
     (let [s (session/create-session!)]
       (try
@@ -88,7 +65,7 @@
         (finally
           (session/cleanup-session! s))))))
 
-(deftest validate-session-test
+(deftest ^{:stratum 0} validate-session-test
   (testing "valid session passes"
     (let [result (session/validate-session {:dir "/tmp/x"
                                             :mcp-config-path "/tmp/x/mcp-config.json"
@@ -110,10 +87,8 @@
     (let [result (session/validate-session {})]
       (is (not (:valid? result))))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; MCP config generation tests
-
-(deftest write-mcp-config-test
+(deftest ^{:stratum 0} write-mcp-config-test
   (testing "writes valid JSON with mcpServers.artifact.command and --artifact-dir"
     (let [s (session/create-session!)]
       (try
@@ -143,24 +118,7 @@
         (finally
           (session/cleanup-session! s))))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Artifact reading tests
-
-(deftest read-artifact-valid-edn-test
-  (testing "reads and parses valid artifact EDN"
-    (let [s (session/create-session!)
-          artifact (code-artifact)]
-      (try
-        (spit (:artifact-path s) (pr-str artifact))
-        (let [result (session/read-artifact s)]
-          (is (map? result))
-          (is (instance? java.util.UUID (:code/id result)))
-          (is (= "test artifact" (:code/summary result)))
-          (is (instance? java.util.Date (:code/created-at result))))
-        (finally
-          (session/cleanup-session! s))))))
-
-(deftest read-artifact-missing-file-test
+(deftest ^{:stratum 0} read-artifact-missing-file-test
   (testing "returns nil when file does not exist"
     (let [s (session/create-session!)]
       (try
@@ -182,7 +140,7 @@
         (finally
           (session/cleanup-session! s))))))
 
-(deftest read-artifact-invalid-edn-test
+(deftest ^{:stratum 0} read-artifact-invalid-edn-test
   (testing "returns nil for invalid EDN (no throw)"
     (let [s (session/create-session!)]
       (try
@@ -193,8 +151,7 @@
 
 ;------------------------------------------------------------------------------ Layer 2.1
 ;; Worktree artifact tests — container-promotion submission path
-
-(defn- make-worktree-with-plan [plan-edn-str]
+(defn- ^{:stratum 0} make-worktree-with-plan [plan-edn-str]
   (let [wt (io/file (System/getProperty "java.io.tmpdir")
                     (str "mf-wt-test-" (random-uuid)))
         _  (.mkdirs (io/file wt ".miniforge"))]
@@ -202,7 +159,350 @@
       (spit (io/file wt ".miniforge" "plan.edn") plan-edn-str))
     (.getPath wt)))
 
-(deftest read-worktree-artifact-reads-plan-edn-test
+(deftest ^{:stratum 0} read-worktree-artifact-nil-args-test
+  (testing "returns nil for nil workdir or nil role (no throw)"
+    (is (nil? (session/read-worktree-artifact nil :plan)))
+    (is (nil? (session/read-worktree-artifact "/tmp" nil)))
+    (is (nil? (session/read-worktree-artifact nil nil)))))
+
+;------------------------------------------------------------------------------ Layer 1.5
+;; Multi-backend MCP config tests
+;;
+;; These tests use isolated temp directories to avoid conflicts with
+;; concurrent test runs that also call write-mcp-config! (e.g. workflow tests).
+(deftest ^{:stratum 0} write-mcp-config-tracks-cleanup-files-test
+  (testing "session has :mcp-cleanup-files after write-mcp-config!"
+    (let [s (-> (session/create-session!) session/write-mcp-config!)]
+      (try
+        (is (vector? (:mcp-cleanup-files s)))
+        (is (= 3 (count (:mcp-cleanup-files s))))
+        (is (some #(str/ends-with? % "config.toml") (:mcp-cleanup-files s)))
+        (is (some #(str/ends-with? % "mcp.json") (:mcp-cleanup-files s)))
+        (is (some #(str/ends-with? % "cli.json") (:mcp-cleanup-files s)))
+        (finally
+          (session/cleanup-session! s))))))
+
+(deftest ^{:stratum 0} write-codex-mcp-config-test
+  (testing "writes .codex/config.toml tracked in cleanup files"
+    (let [s (-> (session/create-session!) session/write-mcp-config!)
+          codex-file (first (filter #(str/ends-with? % "config.toml")
+                                    (:mcp-cleanup-files s)))]
+      (try
+        ;; Verify the codex path is tracked for cleanup
+        (is (some? codex-file))
+        (is (str/ends-with? codex-file "config.toml"))
+        ;; Verify the artifact block is marked required so Codex fails
+        ;; loudly if our MCP server can't initialize, instead of silently
+        ;; running without it.
+        (let [content (slurp codex-file)]
+          (is (str/includes? content "[mcp_servers.artifact]"))
+          (is (str/includes? content "default_tools_approval_mode = \"approve\""))
+          (is (str/includes? content "required = true")))
+        (finally
+          (session/cleanup-session! s))))))
+
+(deftest ^{:stratum 0} write-cursor-mcp-config-test
+  (testing "writes .cursor/mcp.json tracked in cleanup files"
+    (let [s (-> (session/create-session!) session/write-mcp-config!)
+          cursor-file (first (filter #(str/ends-with? % "mcp.json")
+                                     (:mcp-cleanup-files s)))]
+      (try
+        ;; Verify the cursor path is tracked for cleanup
+        (is (some? cursor-file))
+        (is (str/ends-with? cursor-file "mcp.json"))
+        (finally
+          (session/cleanup-session! s))))))
+
+(deftest ^{:stratum 0} cursor-permission-allow-test
+  (testing "mcp-tools translate to Mcp(...) + Write(**) rules"
+    (let [allow (session/cursor-permission-allow session/mcp-tools nil)]
+      (is (some #(= "Mcp(context:context_read)" %) allow))
+      (is (some #(= "Write(**)" %) allow))
+      (testing "Write/Edit/MultiEdit collapse to a single Write(**) rule"
+        (is (= 1 (count (filter #(= "Write(**)" %) allow)))))))
+  (testing "default-deny: disallowing all write tools drops the write rule"
+    (let [allow (session/cursor-permission-allow session/mcp-tools ["Write" "Edit" "MultiEdit"])]
+      (is (not (some #(= "Write(**)" %) allow)))
+      (is (some #(str/starts-with? % "Mcp(") allow))))
+  (testing "disallowing ANY write tool drops Write(**) (Cursor can't distinguish)"
+    (doseq [blocked [["Write"] ["Edit"] ["MultiEdit"]]]
+      (let [allow (session/cursor-permission-allow session/mcp-tools blocked)]
+        (is (not (some #(= "Write(**)" %) allow))
+            (str "Write(**) should be dropped when disallowing " blocked))))))
+
+(deftest ^{:stratum 0} write-cursor-permissions-test
+  (testing "writes .cursor/cli.json with allow + secret-deny baseline"
+    (let [tmp (io/file (System/getProperty "java.io.tmpdir")
+                       (str "cursor-perms-" (random-uuid)))]
+      (try
+        (.mkdirs tmp)
+        (let [path   (session/write-cursor-permissions! (str tmp) session/mcp-tools nil)
+              config (json/parse-string (slurp path))]
+          (is (str/ends-with? path "cli.json"))
+          (is (contains? (set (get-in config ["permissions" "allow"])) "Write(**)"))
+          (is (= (set session/cursor-permission-deny)
+                 (set (get-in config ["permissions" "deny"])))))
+        (finally
+          (doseq [f (reverse (file-seq tmp))] (.delete ^java.io.File f)))))))
+
+(deftest ^{:stratum 0} write-cursor-permissions-narrows-on-rewrite-test
+  (testing "rewriting with a narrower disallow set shrinks the allowlist"
+    (let [tmp (io/file (System/getProperty "java.io.tmpdir")
+                       (str "cursor-perms-narrow-" (random-uuid)))]
+      (try
+        (.mkdirs tmp)
+        ;; First write: full allow (no disallow) includes Write(**).
+        (session/write-cursor-permissions! (str tmp) session/mcp-tools nil)
+        (let [path (str (io/file tmp ".cursor" "cli.json"))]
+          (is (some #(= "Write(**)" %)
+                    (get-in (json/parse-string (slurp path)) ["permissions" "allow"])))
+          ;; Rewrite disallowing Write: managed Write(**) is stripped, MCP stays.
+          (session/write-cursor-permissions! (str tmp) session/mcp-tools ["Write" "Edit" "MultiEdit"])
+          (let [allow (get-in (json/parse-string (slurp path)) ["permissions" "allow"])]
+            (is (not (some #(= "Write(**)" %) allow)))
+            (is (some #(str/starts-with? % "Mcp(") allow))))
+        (finally
+          (doseq [f (reverse (file-seq tmp))] (.delete ^java.io.File f)))))))
+
+(deftest ^{:stratum 0} write-cursor-permissions-for-session-test
+  (testing "no-op for capsule sessions"
+    (is (nil? (session/write-cursor-permissions-for-session!
+               {:capsule? true :config-root "/tmp/should-not-write"} ["Write"]))))
+  (testing "host session writes to its config-root"
+    (let [tmp (io/file (System/getProperty "java.io.tmpdir")
+                       (str "cursor-perms-session-" (random-uuid)))]
+      (try
+        (.mkdirs tmp)
+        (let [path (session/write-cursor-permissions-for-session!
+                    {:config-root (str tmp) :mcp-allowed-tools session/mcp-tools}
+                    ["Write" "Edit" "MultiEdit"])
+              allow (get-in (json/parse-string (slurp path)) ["permissions" "allow"])]
+          (is (str/ends-with? path "cli.json"))
+          (is (not (some #(= "Write(**)" %) allow))))
+        (finally
+          (doseq [f (reverse (file-seq tmp))] (.delete ^java.io.File f)))))))
+
+(deftest ^{:stratum 0} cleanup-cursor-permissions-restores-original-test
+  (testing "cleanup restores a pre-existing cli.json byte-for-byte"
+    (let [tmp (io/file (System/getProperty "java.io.tmpdir")
+                       (str "cursor-perms-restore-" (random-uuid)))
+          dir (io/file tmp ".cursor")
+          cli (io/file dir "cli.json")
+          cleanup-fn @#'session/cleanup-cursor-permissions!]
+      (try
+        (.mkdirs dir)
+        ;; A user rule that is byte-identical to a managed rule — the case the
+        ;; old string-stripping cleanup could not preserve.
+        (let [original (json/generate-string {"permissions" {"allow" ["Shell(git)" "Write(**)"]}})]
+          (spit cli original)
+          (session/backup-cursor-permissions! (str tmp))
+          (session/write-cursor-permissions! (str tmp) session/mcp-tools ["Write" "Edit" "MultiEdit"])
+          (is (not= original (slurp cli)) "writer mutates the live file")
+          (cleanup-fn (str cli))
+          (is (= original (slurp cli)) "cleanup restores the exact original")
+          (is (not (.exists (io/file dir (str "cli.json" @#'session/cursor-permissions-backup-suffix))))
+              "backup file is removed after restore"))
+        (finally
+          (doseq [f (reverse (file-seq tmp))] (.delete ^java.io.File f)))))))
+
+(deftest ^{:stratum 0} cleanup-cursor-permissions-deletes-generated-test
+  (testing "cleanup deletes the file when miniforge created it (no prior file)"
+    (let [tmp (io/file (System/getProperty "java.io.tmpdir")
+                       (str "cursor-perms-del-" (random-uuid)))
+          cli (io/file tmp ".cursor" "cli.json")
+          cleanup-fn @#'session/cleanup-cursor-permissions!]
+      (try
+        (.mkdirs tmp)
+        (session/backup-cursor-permissions! (str tmp)) ; no-op: nothing to back up
+        (session/write-cursor-permissions! (str tmp) session/mcp-tools nil)
+        (is (.exists cli))
+        (cleanup-fn (str cli))
+        (is (not (.exists cli)) "generated file is deleted, leaving no stray config")
+        (finally
+          (doseq [f (reverse (file-seq tmp))] (.delete ^java.io.File f)))))))
+
+(deftest ^{:stratum 0} cleanup-codex-config-test
+  (testing "cleanup removes artifact block but preserves other config"
+    (let [tmp (io/file (System/getProperty "java.io.tmpdir")
+                       (str "codex-test-" (random-uuid)))
+          config-file (io/file tmp "config.toml")
+          cleanup-fn  @#'session/cleanup-codex-mcp-config!]
+      (try
+        (.mkdirs tmp)
+        ;; Write a config with an existing section + an artifact block
+        (spit config-file (str "[some_other_section]\nkey = \"value\"\n\n"
+                               "[mcp_servers.artifact]\n"
+                               "command = \"bb\"\n"
+                               "args = [\"miniforge\",\"mcp-serve\"]\n"))
+        (is (str/includes? (slurp config-file) "[mcp_servers.artifact]"))
+        ;; Cleanup should remove artifact block but preserve the rest
+        (cleanup-fn (str config-file))
+        (let [content (slurp config-file)]
+          (is (not (str/includes? content "[mcp_servers.artifact]")))
+          (is (str/includes? content "[some_other_section]")))
+        (finally
+          (doseq [f (reverse (file-seq tmp))]
+            (.delete ^java.io.File f)))))))
+
+(deftest ^{:stratum 0} cleanup-codex-config-removes-nested-artifact-tables-test
+  (testing "cleanup removes nested artifact tool tables as part of the same subtree"
+    (let [tmp (io/file (System/getProperty "java.io.tmpdir")
+                       (str "codex-nested-test-" (random-uuid)))
+          config-file (io/file tmp "config.toml")
+          cleanup-fn  @#'session/cleanup-codex-mcp-config!]
+      (try
+        (.mkdirs tmp)
+        (spit config-file (str "sandbox_mode = \"workspace-write\"\n"
+                               "\n"
+                               "[mcp_servers.artifact]\n"
+                               "command = \"bb\"\n"
+                               "args = [\"miniforge\",\"mcp-serve\"]\n"
+                               "\n"
+                               "[mcp_servers.artifact.tools.context_read]\n"
+                               "approval_mode = \"approve\"\n"
+                               "\n"
+                               "[sandbox_workspace_write]\n"
+                               "network_access = true\n"))
+        (cleanup-fn (str config-file))
+        (let [content (slurp config-file)]
+          (is (not (str/includes? content "[mcp_servers.artifact]")))
+          (is (not (str/includes? content "[mcp_servers.artifact.tools.context_read]")))
+          (is (str/includes? content "sandbox_mode = \"workspace-write\""))
+          (is (str/includes? content "[sandbox_workspace_write]")))
+        (finally
+          (doseq [f (reverse (file-seq tmp))]
+            (.delete ^java.io.File f)))))))
+
+(deftest ^{:stratum 0} cleanup-cursor-config-test
+  (testing "cleanup removes artifact entry but preserves other servers"
+    (let [tmp (io/file (System/getProperty "java.io.tmpdir")
+                       (str "cursor-test-" (random-uuid)))
+          config-file (io/file tmp "mcp.json")
+          cleanup-fn  @#'session/cleanup-cursor-mcp-config!]
+      (try
+        (.mkdirs tmp)
+        ;; Write a JSON config with an existing server + artifact
+        (spit config-file (json/generate-string
+                            {"mcpServers" {"other" {"command" "other-cmd"}
+                                           "artifact" {"command" "bb"
+                                                       "args" ["miniforge" "mcp-serve"]}}}))
+        (let [config (json/parse-string (slurp config-file))]
+          (is (contains? (get config "mcpServers") "artifact")))
+        ;; Cleanup should remove artifact but preserve other
+        (cleanup-fn (str config-file))
+        (let [config (json/parse-string (slurp config-file))]
+          (is (not (contains? (get config "mcpServers") "artifact")))
+          (is (= "other-cmd" (get-in config ["mcpServers" "other" "command"]))))
+        (finally
+          (doseq [f (reverse (file-seq tmp))]
+            (.delete ^java.io.File f)))))))
+
+;; Cleanup and macro tests
+(deftest ^{:stratum 0} cleanup-session-test
+  (testing "removes temp dir and all files"
+    (let [s (session/create-session!)]
+      (session/write-mcp-config! s)
+      (spit (:artifact-path s) "{:test true}")
+      (is (.exists (io/file (:dir s))))
+      (is (.exists (io/file (:mcp-config-path s))))
+      (is (.exists (io/file (:artifact-path s))))
+      (session/cleanup-session! s)
+      (is (not (.exists (io/file (:dir s))))))))
+
+(deftest ^{:stratum 0} with-readonly-session-test
+  (testing "runs body-fn with a configured session and returns its result
+            directly (no artifact-promotion map), for read-only agents"
+    (let [ran (atom false)
+          result (session/with-readonly-session
+                  {}
+                  (fn [s]
+                    (reset! ran true)
+                    (is (:mcp-config-path s) "session has an mcp-config path")
+                    (is (:mcp-allowed-tools s) "session carries the MCP tool allowlist")
+                    :review-result))]
+      (is @ran "body-fn ran")
+      (is (= :review-result result)
+          "returns the body-fn value directly, not a normalized artifact map"))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} code-artifact
+  "Factory for code-artifact EDN maps written to a session's `:artifact-path`.
+   Defaults exercise the parser's UUID/instant coercion paths; pass any
+   subset of overrides to vary individual fields per test."
+  [& {:as overrides}]
+  (merge {:code/id           default-uuid-str
+          :code/summary      "test artifact"
+          :code/created-at   "2026-02-28T12:00:00Z"}
+         overrides))
+
+(defn- ^{:stratum 1} plan-artifact
+  "Factory for plan-artifact EDN maps written to `.miniforge/plan.edn` in
+   the worktree. Defaults yield an empty task vector; override `:plan/tasks`
+   to exercise nested-vector UUID parsing."
+  [& {:as overrides}]
+  (merge {:plan/id    default-uuid-str
+          :plan/name  "t"
+          :plan/tasks []}
+         overrides))
+
+(deftest ^{:stratum 1} read-worktree-artifact-missing-file-test
+  (testing "returns nil when .miniforge/<role>.edn is absent"
+    (let [wt (make-worktree-with-plan nil)]
+      (try
+        (is (nil? (session/read-worktree-artifact wt :plan)))
+        (finally
+          (io/delete-file (io/file wt ".miniforge") true)
+          (io/delete-file (io/file wt) true))))))
+
+(deftest ^{:stratum 1} read-worktree-artifact-invalid-edn-test
+  (testing "returns nil for unparseable file (no throw)"
+    (let [wt (make-worktree-with-plan "{{{ not edn")]
+      (try
+        (is (nil? (session/read-worktree-artifact wt :plan)))
+        (finally
+          (io/delete-file (io/file wt ".miniforge" "plan.edn") true)
+          (io/delete-file (io/file wt ".miniforge") true)
+          (io/delete-file (io/file wt) true))))))
+
+(deftest ^{:stratum 1} with-session-no-artifact-warn-suppressed-when-parse-failed-test
+  (testing "no-artifact WARN is suppressed when worktree file exists but fails to parse"
+    ;; If the agent wrote plan.edn but it contains malformed EDN, the parse
+    ;; warning (:warn/worktree-artifact-parse) is the correct diagnostic.
+    ;; :warn/no-artifact-found must NOT also fire — the file DID exist.
+    (let [wt  (make-worktree-with-plan "{{{invalid edn not parseable")
+          err (java.io.StringWriter.)
+          ctx {:execution/worktree-path wt}]
+      (try
+        (binding [*err* err]
+          (session/with-session ctx (constantly :bad-edn)))
+        (let [stderr (str err)]
+          (is (str/includes? stderr "failed to parse worktree artifact")
+              "parse WARN must still fire to alert on the malformed file")
+          (is (not (str/includes? stderr "no artifact found after session"))
+              "no-artifact WARN must be suppressed when the file existed — parse WARN covers it"))
+        (finally
+          (doseq [^java.io.File f (reverse (file-seq (io/file wt)))]
+            (.delete f)))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Artifact reading tests
+(deftest ^{:stratum 2} read-artifact-valid-edn-test
+  (testing "reads and parses valid artifact EDN"
+    (let [s (session/create-session!)
+          artifact (code-artifact)]
+      (try
+        (spit (:artifact-path s) (pr-str artifact))
+        (let [result (session/read-artifact s)]
+          (is (map? result))
+          (is (instance? java.util.UUID (:code/id result)))
+          (is (= "test artifact" (:code/summary result)))
+          (is (instance? java.util.Date (:code/created-at result))))
+        (finally
+          (session/cleanup-session! s))))))
+
+(deftest ^{:stratum 2} read-worktree-artifact-reads-plan-edn-test
   (testing "reads .miniforge/<role>.edn from the worktree"
     (let [wt (make-worktree-with-plan (pr-str (plan-artifact)))]
       (try
@@ -216,35 +516,9 @@
           (io/delete-file (io/file wt ".miniforge") true)
           (io/delete-file (io/file wt) true))))))
 
-(deftest read-worktree-artifact-missing-file-test
-  (testing "returns nil when .miniforge/<role>.edn is absent"
-    (let [wt (make-worktree-with-plan nil)]
-      (try
-        (is (nil? (session/read-worktree-artifact wt :plan)))
-        (finally
-          (io/delete-file (io/file wt ".miniforge") true)
-          (io/delete-file (io/file wt) true))))))
-
-(deftest read-worktree-artifact-nil-args-test
-  (testing "returns nil for nil workdir or nil role (no throw)"
-    (is (nil? (session/read-worktree-artifact nil :plan)))
-    (is (nil? (session/read-worktree-artifact "/tmp" nil)))
-    (is (nil? (session/read-worktree-artifact nil nil)))))
-
-(deftest read-worktree-artifact-invalid-edn-test
-  (testing "returns nil for unparseable file (no throw)"
-    (let [wt (make-worktree-with-plan "{{{ not edn")]
-      (try
-        (is (nil? (session/read-worktree-artifact wt :plan)))
-        (finally
-          (io/delete-file (io/file wt ".miniforge" "plan.edn") true)
-          (io/delete-file (io/file wt ".miniforge") true)
-          (io/delete-file (io/file wt) true))))))
-
 ;------------------------------------------------------------------------------ Layer 2.5
 ;; UUID/instant parsing tests (via read-artifact round-trip)
-
-(deftest parse-uuid-strings-test
+(deftest ^{:stratum 2} parse-uuid-strings-test
   (testing "UUID string keys converted to java.util.UUID"
     (let [s (session/create-session!)
           artifact (code-artifact :code/summary "test")]
@@ -278,7 +552,7 @@
         (finally
           (session/cleanup-session! s))))))
 
-(deftest parse-uuid-strings-nested-vectors-test
+(deftest ^{:stratum 2} parse-uuid-strings-nested-vectors-test
   (testing "handles vector of maps with :task/id"
     (let [s (session/create-session!)
           uuid1 "550e8400-e29b-41d4-a716-446655440001"
@@ -298,253 +572,7 @@
         (finally
           (session/cleanup-session! s))))))
 
-;------------------------------------------------------------------------------ Layer 1.5
-;; Multi-backend MCP config tests
-;;
-;; These tests use isolated temp directories to avoid conflicts with
-;; concurrent test runs that also call write-mcp-config! (e.g. workflow tests).
-
-(deftest write-mcp-config-tracks-cleanup-files-test
-  (testing "session has :mcp-cleanup-files after write-mcp-config!"
-    (let [s (-> (session/create-session!) session/write-mcp-config!)]
-      (try
-        (is (vector? (:mcp-cleanup-files s)))
-        (is (= 3 (count (:mcp-cleanup-files s))))
-        (is (some #(str/ends-with? % "config.toml") (:mcp-cleanup-files s)))
-        (is (some #(str/ends-with? % "mcp.json") (:mcp-cleanup-files s)))
-        (is (some #(str/ends-with? % "cli.json") (:mcp-cleanup-files s)))
-        (finally
-          (session/cleanup-session! s))))))
-
-(deftest write-codex-mcp-config-test
-  (testing "writes .codex/config.toml tracked in cleanup files"
-    (let [s (-> (session/create-session!) session/write-mcp-config!)
-          codex-file (first (filter #(str/ends-with? % "config.toml")
-                                    (:mcp-cleanup-files s)))]
-      (try
-        ;; Verify the codex path is tracked for cleanup
-        (is (some? codex-file))
-        (is (str/ends-with? codex-file "config.toml"))
-        ;; Verify the artifact block is marked required so Codex fails
-        ;; loudly if our MCP server can't initialize, instead of silently
-        ;; running without it.
-        (let [content (slurp codex-file)]
-          (is (str/includes? content "[mcp_servers.artifact]"))
-          (is (str/includes? content "default_tools_approval_mode = \"approve\""))
-          (is (str/includes? content "required = true")))
-        (finally
-          (session/cleanup-session! s))))))
-
-(deftest write-cursor-mcp-config-test
-  (testing "writes .cursor/mcp.json tracked in cleanup files"
-    (let [s (-> (session/create-session!) session/write-mcp-config!)
-          cursor-file (first (filter #(str/ends-with? % "mcp.json")
-                                     (:mcp-cleanup-files s)))]
-      (try
-        ;; Verify the cursor path is tracked for cleanup
-        (is (some? cursor-file))
-        (is (str/ends-with? cursor-file "mcp.json"))
-        (finally
-          (session/cleanup-session! s))))))
-
-(deftest cursor-permission-allow-test
-  (testing "mcp-tools translate to Mcp(...) + Write(**) rules"
-    (let [allow (session/cursor-permission-allow session/mcp-tools nil)]
-      (is (some #(= "Mcp(context:context_read)" %) allow))
-      (is (some #(= "Write(**)" %) allow))
-      (testing "Write/Edit/MultiEdit collapse to a single Write(**) rule"
-        (is (= 1 (count (filter #(= "Write(**)" %) allow)))))))
-  (testing "default-deny: disallowing all write tools drops the write rule"
-    (let [allow (session/cursor-permission-allow session/mcp-tools ["Write" "Edit" "MultiEdit"])]
-      (is (not (some #(= "Write(**)" %) allow)))
-      (is (some #(str/starts-with? % "Mcp(") allow))))
-  (testing "disallowing ANY write tool drops Write(**) (Cursor can't distinguish)"
-    (doseq [blocked [["Write"] ["Edit"] ["MultiEdit"]]]
-      (let [allow (session/cursor-permission-allow session/mcp-tools blocked)]
-        (is (not (some #(= "Write(**)" %) allow))
-            (str "Write(**) should be dropped when disallowing " blocked))))))
-
-(deftest write-cursor-permissions-test
-  (testing "writes .cursor/cli.json with allow + secret-deny baseline"
-    (let [tmp (io/file (System/getProperty "java.io.tmpdir")
-                       (str "cursor-perms-" (random-uuid)))]
-      (try
-        (.mkdirs tmp)
-        (let [path   (session/write-cursor-permissions! (str tmp) session/mcp-tools nil)
-              config (json/parse-string (slurp path))]
-          (is (str/ends-with? path "cli.json"))
-          (is (contains? (set (get-in config ["permissions" "allow"])) "Write(**)"))
-          (is (= (set session/cursor-permission-deny)
-                 (set (get-in config ["permissions" "deny"])))))
-        (finally
-          (doseq [f (reverse (file-seq tmp))] (.delete ^java.io.File f)))))))
-
-(deftest write-cursor-permissions-narrows-on-rewrite-test
-  (testing "rewriting with a narrower disallow set shrinks the allowlist"
-    (let [tmp (io/file (System/getProperty "java.io.tmpdir")
-                       (str "cursor-perms-narrow-" (random-uuid)))]
-      (try
-        (.mkdirs tmp)
-        ;; First write: full allow (no disallow) includes Write(**).
-        (session/write-cursor-permissions! (str tmp) session/mcp-tools nil)
-        (let [path (str (io/file tmp ".cursor" "cli.json"))]
-          (is (some #(= "Write(**)" %)
-                    (get-in (json/parse-string (slurp path)) ["permissions" "allow"])))
-          ;; Rewrite disallowing Write: managed Write(**) is stripped, MCP stays.
-          (session/write-cursor-permissions! (str tmp) session/mcp-tools ["Write" "Edit" "MultiEdit"])
-          (let [allow (get-in (json/parse-string (slurp path)) ["permissions" "allow"])]
-            (is (not (some #(= "Write(**)" %) allow)))
-            (is (some #(str/starts-with? % "Mcp(") allow))))
-        (finally
-          (doseq [f (reverse (file-seq tmp))] (.delete ^java.io.File f)))))))
-
-(deftest write-cursor-permissions-for-session-test
-  (testing "no-op for capsule sessions"
-    (is (nil? (session/write-cursor-permissions-for-session!
-               {:capsule? true :config-root "/tmp/should-not-write"} ["Write"]))))
-  (testing "host session writes to its config-root"
-    (let [tmp (io/file (System/getProperty "java.io.tmpdir")
-                       (str "cursor-perms-session-" (random-uuid)))]
-      (try
-        (.mkdirs tmp)
-        (let [path (session/write-cursor-permissions-for-session!
-                    {:config-root (str tmp) :mcp-allowed-tools session/mcp-tools}
-                    ["Write" "Edit" "MultiEdit"])
-              allow (get-in (json/parse-string (slurp path)) ["permissions" "allow"])]
-          (is (str/ends-with? path "cli.json"))
-          (is (not (some #(= "Write(**)" %) allow))))
-        (finally
-          (doseq [f (reverse (file-seq tmp))] (.delete ^java.io.File f)))))))
-
-(deftest cleanup-cursor-permissions-restores-original-test
-  (testing "cleanup restores a pre-existing cli.json byte-for-byte"
-    (let [tmp (io/file (System/getProperty "java.io.tmpdir")
-                       (str "cursor-perms-restore-" (random-uuid)))
-          dir (io/file tmp ".cursor")
-          cli (io/file dir "cli.json")
-          cleanup-fn @#'session/cleanup-cursor-permissions!]
-      (try
-        (.mkdirs dir)
-        ;; A user rule that is byte-identical to a managed rule — the case the
-        ;; old string-stripping cleanup could not preserve.
-        (let [original (json/generate-string {"permissions" {"allow" ["Shell(git)" "Write(**)"]}})]
-          (spit cli original)
-          (session/backup-cursor-permissions! (str tmp))
-          (session/write-cursor-permissions! (str tmp) session/mcp-tools ["Write" "Edit" "MultiEdit"])
-          (is (not= original (slurp cli)) "writer mutates the live file")
-          (cleanup-fn (str cli))
-          (is (= original (slurp cli)) "cleanup restores the exact original")
-          (is (not (.exists (io/file dir (str "cli.json" @#'session/cursor-permissions-backup-suffix))))
-              "backup file is removed after restore"))
-        (finally
-          (doseq [f (reverse (file-seq tmp))] (.delete ^java.io.File f)))))))
-
-(deftest cleanup-cursor-permissions-deletes-generated-test
-  (testing "cleanup deletes the file when miniforge created it (no prior file)"
-    (let [tmp (io/file (System/getProperty "java.io.tmpdir")
-                       (str "cursor-perms-del-" (random-uuid)))
-          cli (io/file tmp ".cursor" "cli.json")
-          cleanup-fn @#'session/cleanup-cursor-permissions!]
-      (try
-        (.mkdirs tmp)
-        (session/backup-cursor-permissions! (str tmp)) ; no-op: nothing to back up
-        (session/write-cursor-permissions! (str tmp) session/mcp-tools nil)
-        (is (.exists cli))
-        (cleanup-fn (str cli))
-        (is (not (.exists cli)) "generated file is deleted, leaving no stray config")
-        (finally
-          (doseq [f (reverse (file-seq tmp))] (.delete ^java.io.File f)))))))
-
-(deftest cleanup-codex-config-test
-  (testing "cleanup removes artifact block but preserves other config"
-    (let [tmp (io/file (System/getProperty "java.io.tmpdir")
-                       (str "codex-test-" (random-uuid)))
-          config-file (io/file tmp "config.toml")
-          cleanup-fn  @#'session/cleanup-codex-mcp-config!]
-      (try
-        (.mkdirs tmp)
-        ;; Write a config with an existing section + an artifact block
-        (spit config-file (str "[some_other_section]\nkey = \"value\"\n\n"
-                               "[mcp_servers.artifact]\n"
-                               "command = \"bb\"\n"
-                               "args = [\"miniforge\",\"mcp-serve\"]\n"))
-        (is (str/includes? (slurp config-file) "[mcp_servers.artifact]"))
-        ;; Cleanup should remove artifact block but preserve the rest
-        (cleanup-fn (str config-file))
-        (let [content (slurp config-file)]
-          (is (not (str/includes? content "[mcp_servers.artifact]")))
-          (is (str/includes? content "[some_other_section]")))
-        (finally
-          (doseq [f (reverse (file-seq tmp))]
-            (.delete ^java.io.File f)))))))
-
-(deftest cleanup-codex-config-removes-nested-artifact-tables-test
-  (testing "cleanup removes nested artifact tool tables as part of the same subtree"
-    (let [tmp (io/file (System/getProperty "java.io.tmpdir")
-                       (str "codex-nested-test-" (random-uuid)))
-          config-file (io/file tmp "config.toml")
-          cleanup-fn  @#'session/cleanup-codex-mcp-config!]
-      (try
-        (.mkdirs tmp)
-        (spit config-file (str "sandbox_mode = \"workspace-write\"\n"
-                               "\n"
-                               "[mcp_servers.artifact]\n"
-                               "command = \"bb\"\n"
-                               "args = [\"miniforge\",\"mcp-serve\"]\n"
-                               "\n"
-                               "[mcp_servers.artifact.tools.context_read]\n"
-                               "approval_mode = \"approve\"\n"
-                               "\n"
-                               "[sandbox_workspace_write]\n"
-                               "network_access = true\n"))
-        (cleanup-fn (str config-file))
-        (let [content (slurp config-file)]
-          (is (not (str/includes? content "[mcp_servers.artifact]")))
-          (is (not (str/includes? content "[mcp_servers.artifact.tools.context_read]")))
-          (is (str/includes? content "sandbox_mode = \"workspace-write\""))
-          (is (str/includes? content "[sandbox_workspace_write]")))
-        (finally
-          (doseq [f (reverse (file-seq tmp))]
-            (.delete ^java.io.File f)))))))
-
-(deftest cleanup-cursor-config-test
-  (testing "cleanup removes artifact entry but preserves other servers"
-    (let [tmp (io/file (System/getProperty "java.io.tmpdir")
-                       (str "cursor-test-" (random-uuid)))
-          config-file (io/file tmp "mcp.json")
-          cleanup-fn  @#'session/cleanup-cursor-mcp-config!]
-      (try
-        (.mkdirs tmp)
-        ;; Write a JSON config with an existing server + artifact
-        (spit config-file (json/generate-string
-                            {"mcpServers" {"other" {"command" "other-cmd"}
-                                           "artifact" {"command" "bb"
-                                                       "args" ["miniforge" "mcp-serve"]}}}))
-        (let [config (json/parse-string (slurp config-file))]
-          (is (contains? (get config "mcpServers") "artifact")))
-        ;; Cleanup should remove artifact but preserve other
-        (cleanup-fn (str config-file))
-        (let [config (json/parse-string (slurp config-file))]
-          (is (not (contains? (get config "mcpServers") "artifact")))
-          (is (= "other-cmd" (get-in config ["mcpServers" "other" "command"]))))
-        (finally
-          (doseq [f (reverse (file-seq tmp))]
-            (.delete ^java.io.File f)))))))
-;------------------------------------------------------------------------------ Layer 3
-;; Cleanup and macro tests
-
-(deftest cleanup-session-test
-  (testing "removes temp dir and all files"
-    (let [s (session/create-session!)]
-      (session/write-mcp-config! s)
-      (spit (:artifact-path s) "{:test true}")
-      (is (.exists (io/file (:dir s))))
-      (is (.exists (io/file (:mcp-config-path s))))
-      (is (.exists (io/file (:artifact-path s))))
-      (session/cleanup-session! s)
-      (is (not (.exists (io/file (:dir s))))))))
-
-(deftest with-artifact-session-test
+(deftest ^{:stratum 2} with-artifact-session-test
   (testing "returns {:llm-result ... :artifact ...} and cleans up"
     (let [captured-dir (atom nil)
           result (session/with-artifact-session [sess]
@@ -592,8 +620,7 @@
 ;;
 ;; run-session is private; these tests drive it through with-session, which
 ;; is the public, production-path entry that selects host vs. capsule mode.
-
-(deftest with-session-warn-when-both-sources-absent-test
+(deftest ^{:stratum 2} with-session-warn-when-both-sources-absent-test
   (testing "suppresses WARN when no explicit workdir was provided"
     ;; Without an explicit workdir, the worktree-artifact scan is intentionally
     ;; skipped. Its empty result should not be diagnosed as a failed artifact
@@ -658,7 +685,7 @@
       (is (not (str/includes? (str err) "WARN"))
           "WARN must be suppressed when MCP artifact is present"))))
 
-(deftest with-session-no-warn-when-mcp-artifact-present-test
+(deftest ^{:stratum 2} with-session-no-warn-when-mcp-artifact-present-test
   (testing "no WARN emitted when MCP artifact file is written"
     ;; Explicit cross-check: MCP artifact present, worktree absent.
     ;; Verifies the WARN gate checks mcp-artifact before firing.
@@ -671,27 +698,7 @@
       (is (not (str/includes? (str err) "WARN"))
           "no WARN when MCP artifact is present and worktree is absent"))))
 
-(deftest with-session-no-artifact-warn-suppressed-when-parse-failed-test
-  (testing "no-artifact WARN is suppressed when worktree file exists but fails to parse"
-    ;; If the agent wrote plan.edn but it contains malformed EDN, the parse
-    ;; warning (:warn/worktree-artifact-parse) is the correct diagnostic.
-    ;; :warn/no-artifact-found must NOT also fire — the file DID exist.
-    (let [wt  (make-worktree-with-plan "{{{invalid edn not parseable")
-          err (java.io.StringWriter.)
-          ctx {:execution/worktree-path wt}]
-      (try
-        (binding [*err* err]
-          (session/with-session ctx (constantly :bad-edn)))
-        (let [stderr (str err)]
-          (is (str/includes? stderr "failed to parse worktree artifact")
-              "parse WARN must still fire to alert on the malformed file")
-          (is (not (str/includes? stderr "no artifact found after session"))
-              "no-artifact WARN must be suppressed when the file existed — parse WARN covers it"))
-        (finally
-          (doseq [^java.io.File f (reverse (file-seq (io/file wt)))]
-            (.delete f)))))))
-
-(deftest with-session-emits-mcp-skipped-info-when-worktree-only-test
+(deftest ^{:stratum 2} with-session-emits-mcp-skipped-info-when-worktree-only-test
   (testing "INFO message emitted when worktree artifact found but MCP not submitted"
     ;; Normal Write-based submission: agent wrote .miniforge/plan.edn, skipped
     ;; MCP submit_artifact. Should surface a diagnostic INFO (not a WARN) so
@@ -715,18 +722,3 @@
 (comment
   (test/run-tests 'ai.miniforge.agent.artifact-session-test)
   :leave-this-here)
-
-(deftest with-readonly-session-test
-  (testing "runs body-fn with a configured session and returns its result
-            directly (no artifact-promotion map), for read-only agents"
-    (let [ran (atom false)
-          result (session/with-readonly-session
-                  {}
-                  (fn [s]
-                    (reset! ran true)
-                    (is (:mcp-config-path s) "session has an mcp-config path")
-                    (is (:mcp-allowed-tools s) "session carries the MCP tool allowlist")
-                    :review-result))]
-      (is @ran "body-fn ran")
-      (is (= :review-result result)
-          "returns the body-fn value directly, not a normalized artifact map"))))


### PR DESCRIPTION
## Summary

Re-stack of #1625 onto `codex/phase-start-pin` (#1628) after #1622 was decomposed into slices — same commits, cherry-picked; all three Copilot review rounds from #1625 are already addressed in this history.

Capsule (governed) `run-session` dropped `:context-misses` and `:context-reads` — the MCP context server writes both files inside the container, but the session result gated them on `:host` mode. The recorded-flows surface (Codex SPEC §7.4.2) went dark in exactly the mode the gates run in. Raised by Copilot on #1622.

## Changes

1. `run-session` takes one mode-specific session-outputs reader returning `{:artifact :context-misses :context-reads}`.
2. `read-capsule-session-outputs` batches all three files into the ONE executor round-trip the artifact read already paid: a single `cat` chain with shell-quoted paths and sentinel boundary lines, split back apart host-side. The agent-authored artifact segment rides last so an embedded boundary occurrence cannot corrupt the server-written segments (collision test included). No per-file round-trips added.
3. `read-host-session-outputs` composes the existing local readers; host behavior unchanged.
4. `file-artifacts/shell-quote` promoted from private to public for the cross-namespace reuse.
5. Capsule white-box tests migrated to the new `run-session` contract; fixtures mirror the real `record-miss!`/`record-read!` output shapes.
6. Also carries the `mcp-tools-test` expectation fix for `consider_situation` — #1628 adds the tool to `mcp-tools` but its extended test still expects the old set, so its Test job will be red until this lands.
7. Remaining churn is mechanical stratum-lint `--fix` annotation/regroup of previously-unannotated files, isolated in its own commits.

## Notes

1. Stacked on #1628 (`codex/phase-start-pin`); retargets to main automatically when it merges. Supersedes #1625.
2. SL003 (layer budget) on `artifact_session.clj` and `file_artifacts.clj` pre-exists; no layers added.

MINIFORGE_PR_BUDGET_OVERRIDE: The substantive change is ~170 reportable lines (source + new tests). The rest is mechanical stratum-lint --fix annotation/regroup of previously-unannotated test/source files, forced by the pre-commit gate on any commit staging those files; moved lines double-count as add+delete. Mechanical churn is isolated in its own commits for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
