### PR TITLE
feat(codex): consultation provenance + :codex-consultation gate (SPEC §7.4.3)

### DIFF
--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.agent.implementer
   "Implementer agent implementation.
    Generates code from plans and task descriptions."
@@ -42,15 +41,263 @@
    [malli.core :as m]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Implementer-specific schemas
 
-(def CodeFile
+;; Implementer-specific schemas
+(def ^{:stratum 0} CodeFile
   [:map
    [:path [:string {:min 1}]]
    [:content [:string {:min 0}]]
    [:action [:enum :create :modify :delete]]])
 
-(def CodeArtifact
+(def ^{:stratum 0} implementer-system-prompt
+  "System prompt for the implementer agent.
+   Loaded from EDN resource for configurability."
+  (delay (prompts/load-prompt :implementer)))
+
+(def ^{:stratum 0} ^:private implementer-prompt-data
+  "Full prompt data map for the implementer agent."
+  (delay (prompts/load-prompt-data :implementer)))
+
+;; Extension → language mapping (loaded from config)
+(def ^{:stratum 0} ^:private impl-config-path "config/repo-index/implementer.edn")
+
+(def ^{:stratum 0} ^:private current-head-ref
+  "Git ref for the currently acquired promoted workspace."
+  "HEAD")
+
+;; Validation
+(defn- ^{:stratum 0} find-blank-creates
+  "Find :create files with blank content."
+  [files]
+  (filter (fn [f] (and (= :create (:action f)) (str/blank? (:content f)))) files))
+
+(defn- ^{:stratum 0} find-duplicate-paths
+  "Find file paths that appear more than once."
+  [files]
+  (->> (map :path files)
+       frequencies
+       (filter #(> (val %) 1))))
+
+;; Language detection
+(defn- ^{:stratum 0} extract-extension
+  "Extract file extension from a path."
+  [path]
+  (last (re-find #"\.(\w+)$" path)))
+
+;; Prompt formatting
+(defn ^{:stratum 0} format-repo-map
+  "Format a repo map for inclusion in the user prompt."
+  [repo-map-text]
+  (when (and repo-map-text (not (str/blank? repo-map-text)))
+    (str "\n\n## " (messages/t :prompt/repo-map-section-title) "\n\n"
+         (messages/t :prompt/repo-map-header)
+         "\n\n" repo-map-text)))
+
+(defn- ^{:stratum 0} format-file-block
+  "Format a single file as a markdown code block."
+  [{:keys [path content truncated?]}]
+  (str "\n### " path
+       (when truncated? " (truncated)")
+       "\n```\n" content "\n```"))
+
+;; Task → text conversion
+(defn- ^{:stratum 0} format-plan-section
+  "Format the plan as a markdown section."
+  [plan]
+  (str "\n\n## " (messages/t :prompt/plan-header) "\n\n"
+       (if (string? plan) plan (pr-str plan))))
+
+(defn- ^{:stratum 0} format-intent-section
+  "Format the intent as a markdown section."
+  [intent]
+  (str "\n\n## " (messages/t :prompt/intent-header) "\n\n"
+       (pr-str intent)))
+
+(defn- ^{:stratum 0} format-review-section
+  "Format review feedback as a markdown section."
+  [review-feedback]
+  (str "\n\n## " (messages/t :prompt/review-feedback-header) "\n\n"
+       (messages/t :prompt/review-feedback-intro) "\n\n"
+       (if (string? review-feedback) review-feedback (pr-str review-feedback))))
+
+(defn- ^{:stratum 0} phase-handoff-findings
+  [phase-handoff]
+  (get-in phase-handoff [:frame/body :repair/findings]))
+
+(defn- ^{:stratum 0} format-phase-handoff-detail
+  [label-key value]
+  (when value
+    (let [label (messages/t label-key)]
+      (messages/t :prompt/phase-handoff-detail-line
+                  {:label label
+                   :value value}))))
+
+(defn- ^{:stratum 0} finding-location
+  [{:finding/keys [file line]}]
+  (cond
+    (and file line)
+    (messages/t :prompt/phase-handoff-location-value {:file file :line line})
+    file
+    file))
+
+(defn- ^{:stratum 0} format-verify-section
+  "Format verify failures as a markdown section."
+  [verify-failures]
+  (str "\n\n## " (messages/t :prompt/test-failures-header) "\n\n"
+       (messages/t :prompt/test-failures-intro) "\n\n"
+       (if-let [test-results (:test-results verify-failures)]
+         (str (messages/t :prompt/test-results-label) "\n" (pr-str test-results))
+         (str (messages/t :prompt/verify-details-label) "\n" (pr-str verify-failures)))
+       (when-let [test-output (:test-output verify-failures)]
+         (str "\n\n" (messages/t :prompt/test-output-label) "\n" test-output))))
+
+(defn- ^{:stratum 0} format-prior-attempts-section
+  "Format prior attempt context as a prominent warning section."
+  [{:keys [attempt-number prior-error instruction]}]
+  (str "\n\n## ⚠️ RETRY — Attempt " attempt-number "\n\n"
+       "**Previous attempt failed:** " prior-error "\n\n"
+       "**" instruction "**\n"))
+
+;; Response parsing
+(defn- ^{:stratum 0} try-parse-edn-block
+  "Try to extract an EDN map from a fenced code block."
+  [text]
+  (when-let [match (re-find #"```(?:clojure|edn)?\s*\n([\s\S]*?)\n```" text)]
+    (let [parsed (edn/read-string (second match))]
+      (when (map? parsed) parsed))))
+
+(defn- ^{:stratum 0} try-parse-raw-edn
+  "Try to parse the entire text as EDN, returning a map or nil."
+  [text]
+  (try
+    (let [r (edn/read-string text)]
+      (when (map? r) r))
+    (catch Exception _ nil)))
+
+(defn- ^{:stratum 0} try-parse-inline-status
+  "Scan for an inline {:status :already-implemented ...} EDN map."
+  [text]
+  (when-let [match (re-find #"\{:status\s+:already-implemented[^}]*\}" text)]
+    (edn/read-string match)))
+
+(defn- ^{:stratum 0} extract-path-from-context
+  "Try to extract a file path from text immediately preceding a code block.
+   Looks for common patterns like '### path/to/file.clj' or '**path/to/file.clj**'
+   or 'File: path/to/file.clj' in the preceding lines."
+  [text block-start]
+  (let [preceding (subs text 0 block-start)
+        ;; Take last 3 lines before the code block
+        lines (take-last 3 (str/split-lines preceding))]
+    (some (fn [line]
+            (or
+             (second (re-find patterns/md-heading-file-path line))
+             (second (re-find patterns/md-delimited-file-path line))
+             (second (re-find patterns/md-label-file-path line))))
+          lines)))
+
+(defn- ^{:stratum 0} deduplicate-files
+  "Deduplicate file entries by path, keeping last occurrence."
+  [files]
+  (let [seen (atom #{})
+        deduped (reduce (fn [acc f]
+                          (if (contains? @seen (:path f))
+                            acc
+                            (do (swap! seen conj (:path f))
+                                (conj acc f))))
+                        []
+                        (reverse files))]
+    (vec (reverse deduped))))
+
+(defn- ^{:stratum 0} build-already-implemented-response
+  "Build the response map for an already-implemented task."
+  [parsed tokens cost-usd]
+  {:status :already-implemented
+   :output {:code/id (random-uuid)
+            :code/files []
+            :code/summary (:summary parsed)
+            :code/language nil
+            :code/tests-needed? false
+            :code/created-at (java.util.Date.)}
+   :summary (:summary parsed)
+   :metrics {:tokens tokens
+             :cost-usd cost-usd
+             :files-created 0
+             :skipped-reason :already-implemented}})
+
+(defn- ^{:stratum 0} repair-attempt?
+  "Return true when the implementer is handling prior review or verify feedback."
+  [input]
+  (or (:task/review-feedback input)
+      (:task/verify-failures input)))
+
+(defn- ^{:stratum 0} unverified-already-implemented-response
+  "Reject an :already-implemented claim when there is no artifact evidence on a repair attempt."
+  [input tokens]
+  (response/error
+   (messages/t :error/unverified-already-implemented)
+   {:tokens tokens
+    :data {:code :implementer/unverified-already-implemented
+           :review-feedback? (boolean (:task/review-feedback input))
+           :verify-failures? (boolean (:task/verify-failures input))}}))
+
+(defn- ^{:stratum 0} count-files-by-action
+  "Count files matching a given action in an artifact."
+  [action files]
+  (count (filter #(= action (:action %)) files)))
+
+(defn- ^{:stratum 0} code-artifact?
+  "True when the structured artifact is a code artifact payload."
+  [artifact]
+  (and (map? artifact)
+       (contains? artifact :code/files)))
+
+(def ^{:stratum 0} ^:private session-checkpoint-filename ".miniforge/session-id")
+
+(def ^{:stratum 0} ^:private implementer-disallowed-tools
+  "Native read/search tools the implementer MUST NOT call — forces it onto the
+   MCP context cache (context_read/context_grep/context_glob), the same
+   mechanism the planner and tester use. The cache is read-through +
+   write-through (a miss reads from source-root, caches the content, records
+   the miss), so context_read serves any file, not just the pre-populated set,
+   and re-reads within the session hit.
+
+   Write/Edit/MultiEdit stay allowed (the implementer's whole job) and so does
+   Bash — the implementer may legitimately need a shell for build/git steps.
+   That leaves a `cat`/`rg`-via-Bash cache-bypass open; if dogfood shows the
+   implementer evading the cache through the shell, add \"Bash\" here (the
+   planner disallows it for exactly that reason)."
+  ["Read" "Grep" "Glob" "LS" "Agent"])
+
+(defn- ^{:stratum 0} normalized-artifact-source
+  "Return a keyword artifact source for telemetry, defaulting malformed values to :none."
+  [normalized]
+  (let [source (get normalized :artifact-source)]
+    (if (keyword? source) source :none)))
+
+(defn ^{:stratum 0} code-summary
+  [artifact]
+  {:id (:code/id artifact)
+   :file-count (count (:code/files artifact))
+   :actions (frequencies (map :action (:code/files artifact)))
+   :language (:code/language artifact)
+   :tests-needed? (:code/tests-needed? artifact)
+   :dependencies-added (count (:code/dependencies-added artifact []))})
+
+(defn ^{:stratum 0} files-by-action
+  [artifact]
+  (group-by :action (:code/files artifact)))
+
+(defn ^{:stratum 0} total-lines
+  [artifact]
+  (->> (:code/files artifact)
+       (remove #(= :delete (:action %)))
+       (map :content)
+       (map #(count (str/split-lines %)))
+       (reduce + 0)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} CodeArtifact
   [:map
    [:code/id uuid?]
    [:code/files [:vector CodeFile]]
@@ -60,47 +307,202 @@
    [:code/summary {:optional true} [:string {:min 1}]]
    [:code/created-at {:optional true} inst?]])
 
-(def implementer-system-prompt
-  "System prompt for the implementer agent.
-   Loaded from EDN resource for configurability."
-  (delay (prompts/load-prompt :implementer)))
-
-(def ^:private implementer-prompt-data
-  "Full prompt data map for the implementer agent."
-  (delay (prompts/load-prompt-data :implementer)))
-
-;------------------------------------------------------------------------------ Layer 0
-;; Extension → language mapping (loaded from config)
-
-(def ^:private impl-config-path "config/repo-index/implementer.edn")
-
-(def ^:private current-head-ref
-  "Git ref for the currently acquired promoted workspace."
-  "HEAD")
-
-(defn- load-ext->language []
+(defn- ^{:stratum 1} load-ext->language []
   (if-let [res (io/resource impl-config-path)]
     (get-in (edn/read-string (slurp res)) [:repo-index/implementer :extension->language] {})
     {}))
 
-(def ^:private ext->language (delay (load-ext->language)))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Validation
-
-(defn- find-blank-creates
-  "Find :create files with blank content."
+(defn ^{:stratum 1} format-existing-files
+  "Format existing file contents for inclusion in the user prompt."
   [files]
-  (filter (fn [f] (and (= :create (:action f)) (str/blank? (:content f)))) files))
+  (when (seq files)
+    (str "\n\n## " (messages/t :prompt/existing-files-section-title) "\n\n"
+         (messages/t :prompt/existing-files-header) "\n"
+         (->> files (map format-file-block) (str/join "\n")))))
 
-(defn- find-duplicate-paths
-  "Find file paths that appear more than once."
-  [files]
-  (->> (map :path files)
-       frequencies
-       (filter #(> (val %) 1))))
+(defn- ^{:stratum 1} format-phase-handoff-finding
+  [{:finding/keys [summary group-id severity suggestion] :as finding}]
+  (let [location (finding-location finding)
+        detail-lines (keep identity
+                           [(format-phase-handoff-detail
+                             :prompt/phase-handoff-group-label group-id)
+                            (format-phase-handoff-detail
+                             :prompt/phase-handoff-severity-label severity)
+                            (format-phase-handoff-detail
+                             :prompt/phase-handoff-location-label location)
+                            (format-phase-handoff-detail
+                             :prompt/phase-handoff-suggestion-label suggestion)])
+        summary-line (messages/t :prompt/phase-handoff-finding-line
+                                 {:summary summary})]
+    (str summary-line
+         (when (seq detail-lines)
+           (str "\n" (str/join "\n" detail-lines))))))
 
-(defn validate-code-artifact
+(defn ^{:stratum 1} parse-code-response
+  "Parse the LLM response to extract code artifact.
+   Handles EDN in code blocks, plain EDN, and inline EDN maps.
+   Returns nil if no parseable map is found."
+  [response-content]
+  (try
+    (when-let [parsed (or (try-parse-edn-block response-content)
+                          (try-parse-raw-edn response-content)
+                          (try-parse-inline-status response-content))]
+      (when (map? parsed) parsed))
+    (catch Exception _
+      nil)))
+
+(defn ^{:stratum 1} extract-code-blocks
+  "Extract code blocks from markdown response and convert to file list.
+   Tries to detect file paths from markdown headings before each block.
+
+   Pathless blocks are not repo artifacts. Treating them as generated
+   filenames lets narrative snippets pass implement, verify, and review
+   without producing a releasable diff."
+  [response-content]
+  (let [pattern patterns/md-code-block
+        matcher (re-matcher pattern response-content)]
+    (loop [results [] idx 0]
+      (if (.find matcher)
+        (let [content (.group matcher 2)
+              block-start (.start matcher)
+              path (extract-path-from-context response-content block-start)]
+          (if path
+            (recur (conj results {:path path
+                                  :content (str/trim content)
+                                  :action :create})
+                   (inc idx))
+            nil))
+        (when (seq results) results)))))
+
+;; Artifact repair
+(defn- ^{:stratum 1} repair-placeholder-content
+  "Build minimal non-empty placeholder content for an otherwise blank file."
+  [path]
+  (let [comment-prefix (case (some-> path extract-extension str/lower-case)
+                         "clj" ";;"
+                         "cljc" ";;"
+                         "cljs" ";;"
+                         "edn" ";;"
+                         "js" "//"
+                         "ts" "//"
+                         "java" "//"
+                         "go" "//"
+                         "rs" "//"
+                         "swift" "//"
+                         "py" "#"
+                         "rb" "#"
+                         "sh" "#"
+                         "yml" "#"
+                         "yaml" "#"
+                         "toml" "#"
+                         nil)]
+    (if comment-prefix
+      (str comment-prefix " TODO: replace generated placeholder for " path "\n")
+      (str "TODO: replace generated placeholder for " path "\n"))))
+
+(defn- ^{:stratum 1} build-effective-system-prompt
+  "Append behavior addendum to the base system prompt."
+  [input]
+  (str @implementer-system-prompt
+       (get input :task/behavior-addendum "")))
+
+(defn- ^{:stratum 1} metadata-only-submit?
+  "True when MCP submit produced metadata but no file payload."
+  [artifact-source structured-artifact]
+  (and (= :mcp artifact-source)
+       (map? structured-artifact)
+       (not (code-artifact? structured-artifact))))
+
+(defn- ^{:stratum 1} log-implementer-rejection
+  "Emit a structured :implementer/response-rejected event when the
+   implementer can't build a success response from the LLM turn.
+   Surfaces WHY each iteration failed so the next dogfood reads the
+   reject pattern (parse-failed, unverified-already-implemented,
+   etc.) inline instead of forcing a deep-dive through the trace.
+
+   Two reject paths today; both wrap response/error. The reject
+   reason is a keyword the caller picks before invoking — keeps
+   the event taxonomy stable as new reject paths get added.
+
+   `input` is read for :repair-attempt? — that's the strongest
+   signal for distinguishing 'agent stalled mid-narration' from
+   'agent retried after rejection and still didn't ship.'"
+  [logger reason input artifact-source content tools]
+  (when logger
+    (log/warn logger :implementer :implementer/response-rejected
+              {:data {:reject/reason reason
+                      :artifact-source artifact-source
+                      :tools-called tools
+                      :content-length (count (or content ""))
+                      :repair-attempt? (boolean (repair-attempt? input))}})))
+
+(defn- ^{:stratum 1} read-session-checkpoint
+  "Read the Claude session UUID from the worktree's runtime directory.
+
+   Returns nil on any failure (missing file, permission error, garbage
+   content). Iter 24 receipt: the previous path (`.miniforge-session-id`
+   at the worktree root) got committed into git and every fresh worktree
+   inherited a stale UUID — passing `--resume <stale>` to Claude CLI
+   caused the session to die in ~5s with no output. Path is now under
+   `.miniforge/`, which is gitignored, and readers tolerate anything."
+  [working-dir]
+  (when working-dir
+    (try
+      (let [f (io/file working-dir session-checkpoint-filename)]
+        (when (.exists f)
+          (let [s (str/trim (slurp f))]
+            (when-not (str/blank? s) s))))
+      (catch Exception _ nil))))
+
+(defn- ^{:stratum 1} write-session-checkpoint! [working-dir session-id]
+  (when (and working-dir session-id)
+    (let [f (io/file working-dir session-checkpoint-filename)]
+      (io/make-parents f)
+      (spit f session-id))))
+
+(defn- ^{:stratum 1} base-ref-candidates
+  "Return candidate refs for computing the promoted task diff."
+  [context]
+  (let [base-sha (get-in context [:execution/environment-metadata :base-sha])
+        base-branch (or (get-in context [:execution/environment-metadata :base-branch])
+                        (get-in context [:execution/opts :branch])
+                        (get-in context [:execution/input :branch]))
+        resume-workspace (get-in context [:execution/opts :resume-workspace])
+        original-commit (get-in context [:execution/input :context :git-commit])
+        original-branch (get-in context [:execution/input :context :git-branch])
+        original-refs (concat (when (and original-commit
+                                         (not (str/blank? original-commit)))
+                                [original-commit])
+                              (when (and original-branch
+                                         (not (str/blank? original-branch)))
+                                [(str "refs/remotes/origin/" original-branch)
+                                 (str "origin/" original-branch)
+                                 (str "refs/heads/" original-branch)]))
+        resume-ranges (when resume-workspace
+                        (map #(str % "..." current-head-ref) original-refs))]
+    (into []
+          (distinct)
+          (cond-> (vec resume-ranges)
+            (and base-sha (not (str/blank? base-sha)))
+            (conj base-sha)
+
+            (and base-branch (not (str/blank? base-branch)))
+            (into [(str "refs/remotes/origin/" base-branch)
+                   (str "origin/" base-branch)
+                   (str "refs/heads/" base-branch)])))))
+
+(defn- ^{:stratum 1} submission-retry-prompt
+  "Submission-only retry prompt: re-feed the task + the prior (prose) output
+   and ask the implementer to deliver the actual file writes now."
+  [task-text prior-content]
+  (prompts/render-template (get @implementer-prompt-data :prompt/submission-retry-template)
+                           {:task-text task-text :prior-content prior-content}))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(def ^{:stratum 2} ^:private ext->language (delay (load-ext->language)))
+
+(defn ^{:stratum 2} validate-code-artifact
   [artifact]
   (if-not (m/validate CodeArtifact artifact)
     (schema/invalid (schema/explain CodeArtifact artifact)
@@ -119,15 +521,89 @@
         :else
         (schema/valid)))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Language detection
+(defn- ^{:stratum 2} format-phase-handoff-findings
+  [findings]
+  (if (seq findings)
+    (str/join "\n" (map format-phase-handoff-finding findings))
+    (messages/t :prompt/phase-handoff-no-findings)))
 
-(defn- extract-extension
-  "Extract file extension from a path."
-  [path]
-  (last (re-find #"\.(\w+)$" path)))
+(defn- ^{:stratum 2} ensure-required-fields
+  "Ensure a file entry has content and action, filling blank creates with a placeholder.
+  Drops entries with no path."
+  [f]
+  (when (:path f)
+    (let [file (cond-> f
+                 (nil? (:content f)) (assoc :content "")
+                 (not (:action f))   (assoc :action :create))]
+      (cond-> file
+        (and (= :create (:action file))
+             (str/blank? (:content file)))
+        (assoc :content (repair-placeholder-content (:path file)))))))
 
-(defn extract-language
+;; LLM invocation helpers
+(defn- ^{:stratum 2} build-user-prompt
+  "Build the user prompt for the implementer."
+  [task-text input]
+  (str (messages/t :prompt/implement-task-prefix) "\n\n"
+       task-text
+       (format-repo-map (:task/repo-map input))
+       (format-existing-files (:task/existing-files input))
+       "\n\n" (messages/t :prompt/output-instruction)
+       "\n\n" (messages/t :prompt/already-impl-instruction) "\n"
+       (messages/t :prompt/already-impl-template)))
+
+(defn- ^{:stratum 2} code-from-blocks
+  "Build a code artifact map from extracted markdown code blocks."
+  [content]
+  (when-let [files (extract-code-blocks content)]
+    {:code/id (random-uuid)
+     :code/files files
+     :code/tests-needed? true
+     :code/summary "Implementation from code blocks"
+     :code/created-at (java.util.Date.)}))
+
+(defn- ^{:stratum 2} invoke-implementer-session
+  "Session body for the implementer: cache files, build mcp-opts, call LLM."
+  [session llm-client user-prompt effective-system-prompt config context on-chunk
+   existing-files working-dir]
+  (when (seq existing-files)
+    (let [files-map (into {} (map (fn [f] [(:path f) (:content f)])
+                                  existing-files))]
+      (artifact-session/write-context-cache-for-session! session files-map)))
+  (artifact-session/write-cursor-permissions-for-session! session implementer-disallowed-tools)
+  (let [budget-usd (budget/resolve-cost-budget-usd :implementer config context)
+        max-turns (get @implementer-prompt-data :prompt/max-turns 10)
+        resume-id (read-session-checkpoint working-dir)
+        mcp-opts (cond-> (artifact-session/session->mcp-opts session budget-usd max-turns)
+                   true        (assoc :disallowed-tools implementer-disallowed-tools)
+                   working-dir (assoc :workdir working-dir)
+                   resume-id   (assoc :resume resume-id))
+        result (if on-chunk
+                 (llm/chat-stream llm-client user-prompt on-chunk
+                                  (merge {:system effective-system-prompt} mcp-opts))
+                 (llm/chat llm-client user-prompt
+                           (merge {:system effective-system-prompt} mcp-opts)))]
+    (when-let [new-session-id (:session-id result)]
+      (write-session-checkpoint! working-dir new-session-id))
+    result))
+
+(defn- ^{:stratum 2} collect-promoted-artifact
+  "Collect code files from the current promoted worktree/container state."
+  [context session-mode working-dir]
+  (let [base-refs (base-ref-candidates context)]
+    (if (= :capsule session-mode)
+      (when-let [exec! (:execution/execute-fn context)]
+        (file-artifacts/collect-worktree-files-via-executor
+         exec!
+         (:execution/executor context)
+         (:execution/environment-id context)
+         working-dir
+         base-refs))
+      (file-artifacts/collect-worktree-files working-dir base-refs))))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} extract-language
   "Extract the programming language from file paths or context."
   [files context]
   (let [extensions (->> files
@@ -139,124 +615,44 @@
     (or (:language context)
         (get @ext->language most-common most-common))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Prompt formatting
-
-(defn format-repo-map
-  "Format a repo map for inclusion in the user prompt."
-  [repo-map-text]
-  (when (and repo-map-text (not (str/blank? repo-map-text)))
-    (str "\n\n## " (messages/t :prompt/repo-map-section-title) "\n\n"
-         (messages/t :prompt/repo-map-header)
-         "\n\n" repo-map-text)))
-
-(defn- format-file-block
-  "Format a single file as a markdown code block."
-  [{:keys [path content truncated?]}]
-  (str "\n### " path
-       (when truncated? " (truncated)")
-       "\n```\n" content "\n```"))
-
-(defn format-existing-files
-  "Format existing file contents for inclusion in the user prompt."
-  [files]
-  (when (seq files)
-    (str "\n\n## " (messages/t :prompt/existing-files-section-title) "\n\n"
-         (messages/t :prompt/existing-files-header) "\n"
-         (->> files (map format-file-block) (str/join "\n")))))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Task → text conversion
-
-(defn- format-plan-section
-  "Format the plan as a markdown section."
-  [plan]
-  (str "\n\n## " (messages/t :prompt/plan-header) "\n\n"
-       (if (string? plan) plan (pr-str plan))))
-
-(defn- format-intent-section
-  "Format the intent as a markdown section."
-  [intent]
-  (str "\n\n## " (messages/t :prompt/intent-header) "\n\n"
-       (pr-str intent)))
-
-(defn- format-review-section
-  "Format review feedback as a markdown section."
-  [review-feedback]
-  (str "\n\n## " (messages/t :prompt/review-feedback-header) "\n\n"
-       (messages/t :prompt/review-feedback-intro) "\n\n"
-       (if (string? review-feedback) review-feedback (pr-str review-feedback))))
-
-(defn- phase-handoff-findings
-  [phase-handoff]
-  (get-in phase-handoff [:frame/body :repair/findings]))
-
-(defn- format-phase-handoff-detail
-  [label-key value]
-  (when value
-    (let [label (messages/t label-key)]
-      (messages/t :prompt/phase-handoff-detail-line
-                  {:label label
-                   :value value}))))
-
-(defn- finding-location
-  [{:finding/keys [file line]}]
-  (cond
-    (and file line)
-    (messages/t :prompt/phase-handoff-location-value {:file file :line line})
-    file
-    file))
-
-(defn- format-phase-handoff-finding
-  [{:finding/keys [summary group-id severity suggestion] :as finding}]
-  (let [location (finding-location finding)
-        detail-lines (keep identity
-                           [(format-phase-handoff-detail
-                             :prompt/phase-handoff-group-label group-id)
-                            (format-phase-handoff-detail
-                             :prompt/phase-handoff-severity-label severity)
-                            (format-phase-handoff-detail
-                             :prompt/phase-handoff-location-label location)
-                            (format-phase-handoff-detail
-                             :prompt/phase-handoff-suggestion-label suggestion)])
-        summary-line (messages/t :prompt/phase-handoff-finding-line
-                                 {:summary summary})]
-    (str summary-line
-         (when (seq detail-lines)
-           (str "\n" (str/join "\n" detail-lines))))))
-
-(defn- format-phase-handoff-findings
-  [findings]
-  (if (seq findings)
-    (str/join "\n" (map format-phase-handoff-finding findings))
-    (messages/t :prompt/phase-handoff-no-findings)))
-
-(defn- format-phase-handoff-section
+(defn- ^{:stratum 3} format-phase-handoff-section
   "Format a structured phase handoff as a prominent repair section."
   [phase-handoff]
   (str "\n\n## " (messages/t :prompt/phase-handoff-header) "\n\n"
        (messages/t :prompt/phase-handoff-intro) "\n\n"
        (format-phase-handoff-findings (phase-handoff-findings phase-handoff))))
 
-(defn- format-verify-section
-  "Format verify failures as a markdown section."
-  [verify-failures]
-  (str "\n\n## " (messages/t :prompt/test-failures-header) "\n\n"
-       (messages/t :prompt/test-failures-intro) "\n\n"
-       (if-let [test-results (:test-results verify-failures)]
-         (str (messages/t :prompt/test-results-label) "\n" (pr-str test-results))
-         (str (messages/t :prompt/verify-details-label) "\n" (pr-str verify-failures)))
-       (when-let [test-output (:test-output verify-failures)]
-         (str "\n\n" (messages/t :prompt/test-output-label) "\n" test-output))))
+(defn ^{:stratum 3} repair-code-artifact
+  "Attempt to repair a code artifact based on validation errors."
+  [artifact errors _context]
+  (let [repaired (-> artifact
+                     (update :code/id #(or % (random-uuid)))
+                     (update :code/files #(or % []))
+                     (update :code/files #(filterv some? (map ensure-required-fields %)))
+                     (update :code/files deduplicate-files))]
+    {:status :success
+     :output repaired
+     :repairs-made (when (not= artifact repaired)
+                     {:original-errors errors})}))
 
-(defn- format-prior-attempts-section
-  "Format prior attempt context as a prominent warning section."
-  [{:keys [attempt-number prior-error instruction]}]
-  (str "\n\n## ⚠️ RETRY — Attempt " attempt-number "\n\n"
-       "**Previous attempt failed:** " prior-error "\n\n"
-       "**" instruction "**\n"))
+(defn- ^{:stratum 3} collect-session-artifact
+  "Collect a file artifact from the promoted or written working tree."
+  [context session-mode working-dir pre-session-snapshot]
+  (or (collect-promoted-artifact context session-mode working-dir)
+      (if (= :capsule session-mode)
+        (when-let [exec! (:execution/execute-fn context)]
+          (file-artifacts/collect-written-files-via-executor
+           pre-session-snapshot
+           exec!
+           (:execution/executor context)
+           (:execution/environment-id context)
+           working-dir))
+        (file-artifacts/collect-written-files pre-session-snapshot
+                                              working-dir))))
 
-(defn task->text
+;------------------------------------------------------------------------------ Layer 4
+
+(defn ^{:stratum 4} task->text
   "Convert a task to text for the LLM.
    Includes plan and intent when available for richer context."
   [task]
@@ -289,206 +685,7 @@
                     (pr-str task)))
     :else (str task)))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Response parsing
-
-(defn- try-parse-edn-block
-  "Try to extract an EDN map from a fenced code block."
-  [text]
-  (when-let [match (re-find #"```(?:clojure|edn)?\s*\n([\s\S]*?)\n```" text)]
-    (let [parsed (edn/read-string (second match))]
-      (when (map? parsed) parsed))))
-
-(defn- try-parse-raw-edn
-  "Try to parse the entire text as EDN, returning a map or nil."
-  [text]
-  (try
-    (let [r (edn/read-string text)]
-      (when (map? r) r))
-    (catch Exception _ nil)))
-
-(defn- try-parse-inline-status
-  "Scan for an inline {:status :already-implemented ...} EDN map."
-  [text]
-  (when-let [match (re-find #"\{:status\s+:already-implemented[^}]*\}" text)]
-    (edn/read-string match)))
-
-(defn parse-code-response
-  "Parse the LLM response to extract code artifact.
-   Handles EDN in code blocks, plain EDN, and inline EDN maps.
-   Returns nil if no parseable map is found."
-  [response-content]
-  (try
-    (when-let [parsed (or (try-parse-edn-block response-content)
-                          (try-parse-raw-edn response-content)
-                          (try-parse-inline-status response-content))]
-      (when (map? parsed) parsed))
-    (catch Exception _
-      nil)))
-
-(defn- extract-path-from-context
-  "Try to extract a file path from text immediately preceding a code block.
-   Looks for common patterns like '### path/to/file.clj' or '**path/to/file.clj**'
-   or 'File: path/to/file.clj' in the preceding lines."
-  [text block-start]
-  (let [preceding (subs text 0 block-start)
-        ;; Take last 3 lines before the code block
-        lines (take-last 3 (str/split-lines preceding))]
-    (some (fn [line]
-            (or
-             (second (re-find patterns/md-heading-file-path line))
-             (second (re-find patterns/md-delimited-file-path line))
-             (second (re-find patterns/md-label-file-path line))))
-          lines)))
-
-(defn extract-code-blocks
-  "Extract code blocks from markdown response and convert to file list.
-   Tries to detect file paths from markdown headings before each block.
-
-   Pathless blocks are not repo artifacts. Treating them as generated
-   filenames lets narrative snippets pass implement, verify, and review
-   without producing a releasable diff."
-  [response-content]
-  (let [pattern patterns/md-code-block
-        matcher (re-matcher pattern response-content)]
-    (loop [results [] idx 0]
-      (if (.find matcher)
-        (let [content (.group matcher 2)
-              block-start (.start matcher)
-              path (extract-path-from-context response-content block-start)]
-          (if path
-            (recur (conj results {:path path
-                                  :content (str/trim content)
-                                  :action :create})
-                   (inc idx))
-            nil))
-        (when (seq results) results)))))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Artifact repair
-
-(defn- repair-placeholder-content
-  "Build minimal non-empty placeholder content for an otherwise blank file."
-  [path]
-  (let [comment-prefix (case (some-> path extract-extension str/lower-case)
-                         "clj" ";;"
-                         "cljc" ";;"
-                         "cljs" ";;"
-                         "edn" ";;"
-                         "js" "//"
-                         "ts" "//"
-                         "java" "//"
-                         "go" "//"
-                         "rs" "//"
-                         "swift" "//"
-                         "py" "#"
-                         "rb" "#"
-                         "sh" "#"
-                         "yml" "#"
-                         "yaml" "#"
-                         "toml" "#"
-                         nil)]
-    (if comment-prefix
-      (str comment-prefix " TODO: replace generated placeholder for " path "\n")
-      (str "TODO: replace generated placeholder for " path "\n"))))
-
-(defn- ensure-required-fields
-  "Ensure a file entry has content and action, filling blank creates with a placeholder.
-  Drops entries with no path."
-  [f]
-  (when (:path f)
-    (let [file (cond-> f
-                 (nil? (:content f)) (assoc :content "")
-                 (not (:action f))   (assoc :action :create))]
-      (cond-> file
-        (and (= :create (:action file))
-             (str/blank? (:content file)))
-        (assoc :content (repair-placeholder-content (:path file)))))))
-
-(defn- deduplicate-files
-  "Deduplicate file entries by path, keeping last occurrence."
-  [files]
-  (let [seen (atom #{})
-        deduped (reduce (fn [acc f]
-                          (if (contains? @seen (:path f))
-                            acc
-                            (do (swap! seen conj (:path f))
-                                (conj acc f))))
-                        []
-                        (reverse files))]
-    (vec (reverse deduped))))
-
-(defn repair-code-artifact
-  "Attempt to repair a code artifact based on validation errors."
-  [artifact errors _context]
-  (let [repaired (-> artifact
-                     (update :code/id #(or % (random-uuid)))
-                     (update :code/files #(or % []))
-                     (update :code/files #(filterv some? (map ensure-required-fields %)))
-                     (update :code/files deduplicate-files))]
-    {:status :success
-     :output repaired
-     :repairs-made (when (not= artifact repaired)
-                     {:original-errors errors})}))
-
-;------------------------------------------------------------------------------ Layer 2
-;; LLM invocation helpers
-
-(defn- build-user-prompt
-  "Build the user prompt for the implementer."
-  [task-text input]
-  (str (messages/t :prompt/implement-task-prefix) "\n\n"
-       task-text
-       (format-repo-map (:task/repo-map input))
-       (format-existing-files (:task/existing-files input))
-       "\n\n" (messages/t :prompt/output-instruction)
-       "\n\n" (messages/t :prompt/already-impl-instruction) "\n"
-       (messages/t :prompt/already-impl-template)))
-
-(defn- build-effective-system-prompt
-  "Append behavior addendum to the base system prompt."
-  [input]
-  (str @implementer-system-prompt
-       (get input :task/behavior-addendum "")))
-
-(defn- build-already-implemented-response
-  "Build the response map for an already-implemented task."
-  [parsed tokens cost-usd]
-  {:status :already-implemented
-   :output {:code/id (random-uuid)
-            :code/files []
-            :code/summary (:summary parsed)
-            :code/language nil
-            :code/tests-needed? false
-            :code/created-at (java.util.Date.)}
-   :summary (:summary parsed)
-   :metrics {:tokens tokens
-             :cost-usd cost-usd
-             :files-created 0
-             :skipped-reason :already-implemented}})
-
-(defn- repair-attempt?
-  "Return true when the implementer is handling prior review or verify feedback."
-  [input]
-  (or (:task/review-feedback input)
-      (:task/verify-failures input)))
-
-(defn- unverified-already-implemented-response
-  "Reject an :already-implemented claim when there is no artifact evidence on a repair attempt."
-  [input tokens]
-  (response/error
-   (messages/t :error/unverified-already-implemented)
-   {:tokens tokens
-    :data {:code :implementer/unverified-already-implemented
-           :review-feedback? (boolean (:task/review-feedback input))
-           :verify-failures? (boolean (:task/verify-failures input))}}))
-
-(defn- count-files-by-action
-  "Count files matching a given action in an artifact."
-  [action files]
-  (count (filter #(= action (:action %)) files)))
-
-(defn- build-code-response
+(defn- ^{:stratum 4} build-code-response
   "Build the success response for a parsed code artifact."
   [code context tokens cost-usd]
   (let [code-with-meta (-> code
@@ -505,53 +702,27 @@
                                  :tokens tokens
                                  :cost-usd cost-usd}})))
 
-(defn- code-artifact?
-  "True when the structured artifact is a code artifact payload."
-  [artifact]
-  (and (map? artifact)
-       (contains? artifact :code/files)))
+(defn- ^{:stratum 4} normalize-implementer-result
+  "Re-normalize a session's raw channels into the implementer result shape,
+   re-collecting the file artifact from what was written this turn. Used by the
+   submission-recovery turn (the main turn normalizes inline so it can also
+   surface the file artifact for its fallback log)."
+  [{:keys [llm-result artifact worktree-artifacts pre-session-snapshot session-mode]}
+   context working-dir]
+  (let [file-artifact (collect-session-artifact context session-mode working-dir
+                                                pre-session-snapshot)]
+    (result-boundary/normalize-llm-result
+     {:role :implement
+      :response llm-result
+      :worktree-artifacts worktree-artifacts
+      :artifact artifact
+      :fallback-artifact file-artifact
+      :parse-response parse-code-response
+      :derive-artifact code-from-blocks})))
 
-(defn- metadata-only-submit?
-  "True when MCP submit produced metadata but no file payload."
-  [artifact-source structured-artifact]
-  (and (= :mcp artifact-source)
-       (map? structured-artifact)
-       (not (code-artifact? structured-artifact))))
+;------------------------------------------------------------------------------ Layer 5
 
-(defn- code-from-blocks
-  "Build a code artifact map from extracted markdown code blocks."
-  [content]
-  (when-let [files (extract-code-blocks content)]
-    {:code/id (random-uuid)
-     :code/files files
-     :code/tests-needed? true
-     :code/summary "Implementation from code blocks"
-     :code/created-at (java.util.Date.)}))
-
-(defn- log-implementer-rejection
-  "Emit a structured :implementer/response-rejected event when the
-   implementer can't build a success response from the LLM turn.
-   Surfaces WHY each iteration failed so the next dogfood reads the
-   reject pattern (parse-failed, unverified-already-implemented,
-   etc.) inline instead of forcing a deep-dive through the trace.
-
-   Two reject paths today; both wrap response/error. The reject
-   reason is a keyword the caller picks before invoking — keeps
-   the event taxonomy stable as new reject paths get added.
-
-   `input` is read for :repair-attempt? — that's the strongest
-   signal for distinguishing 'agent stalled mid-narration' from
-   'agent retried after rejection and still didn't ship.'"
-  [logger reason input artifact-source content tools]
-  (when logger
-    (log/warn logger :implementer :implementer/response-rejected
-              {:data {:reject/reason reason
-                      :artifact-source artifact-source
-                      :tools-called tools
-                      :content-length (count (or content ""))
-                      :repair-attempt? (boolean (repair-attempt? input))}})))
-
-(defn- process-llm-response
+(defn- ^{:stratum 5} process-llm-response
   "Normalize structured implementer outputs from any submission channel:
    worktree metadata, MCP artifact, file fallback, or parseable stdout.
 
@@ -617,158 +788,7 @@
                                        artifact-source
                                        (assoc :artifact-source artifact-source))})))))))
 
-(def ^:private session-checkpoint-filename ".miniforge/session-id")
-
-(defn- read-session-checkpoint
-  "Read the Claude session UUID from the worktree's runtime directory.
-
-   Returns nil on any failure (missing file, permission error, garbage
-   content). Iter 24 receipt: the previous path (`.miniforge-session-id`
-   at the worktree root) got committed into git and every fresh worktree
-   inherited a stale UUID — passing `--resume <stale>` to Claude CLI
-   caused the session to die in ~5s with no output. Path is now under
-   `.miniforge/`, which is gitignored, and readers tolerate anything."
-  [working-dir]
-  (when working-dir
-    (try
-      (let [f (io/file working-dir session-checkpoint-filename)]
-        (when (.exists f)
-          (let [s (str/trim (slurp f))]
-            (when-not (str/blank? s) s))))
-      (catch Exception _ nil))))
-
-(defn- write-session-checkpoint! [working-dir session-id]
-  (when (and working-dir session-id)
-    (let [f (io/file working-dir session-checkpoint-filename)]
-      (io/make-parents f)
-      (spit f session-id))))
-
-(def ^:private implementer-disallowed-tools
-  "Native read/search tools the implementer MUST NOT call — forces it onto the
-   MCP context cache (context_read/context_grep/context_glob), the same
-   mechanism the planner and tester use. The cache is read-through +
-   write-through (a miss reads from source-root, caches the content, records
-   the miss), so context_read serves any file, not just the pre-populated set,
-   and re-reads within the session hit.
-
-   Write/Edit/MultiEdit stay allowed (the implementer's whole job) and so does
-   Bash — the implementer may legitimately need a shell for build/git steps.
-   That leaves a `cat`/`rg`-via-Bash cache-bypass open; if dogfood shows the
-   implementer evading the cache through the shell, add \"Bash\" here (the
-   planner disallows it for exactly that reason)."
-  ["Read" "Grep" "Glob" "LS" "Agent"])
-
-(defn- invoke-implementer-session
-  "Session body for the implementer: cache files, build mcp-opts, call LLM."
-  [session llm-client user-prompt effective-system-prompt config context on-chunk
-   existing-files working-dir]
-  (when (seq existing-files)
-    (let [files-map (into {} (map (fn [f] [(:path f) (:content f)])
-                                  existing-files))]
-      (artifact-session/write-context-cache-for-session! session files-map)))
-  (artifact-session/write-cursor-permissions-for-session! session implementer-disallowed-tools)
-  (let [budget-usd (budget/resolve-cost-budget-usd :implementer config context)
-        max-turns (get @implementer-prompt-data :prompt/max-turns 10)
-        resume-id (read-session-checkpoint working-dir)
-        mcp-opts (cond-> (artifact-session/session->mcp-opts session budget-usd max-turns)
-                   true        (assoc :disallowed-tools implementer-disallowed-tools)
-                   working-dir (assoc :workdir working-dir)
-                   resume-id   (assoc :resume resume-id))
-        result (if on-chunk
-                 (llm/chat-stream llm-client user-prompt on-chunk
-                                  (merge {:system effective-system-prompt} mcp-opts))
-                 (llm/chat llm-client user-prompt
-                           (merge {:system effective-system-prompt} mcp-opts)))]
-    (when-let [new-session-id (:session-id result)]
-      (write-session-checkpoint! working-dir new-session-id))
-    result))
-
-(defn- base-ref-candidates
-  "Return candidate refs for computing the promoted task diff."
-  [context]
-  (let [base-sha (get-in context [:execution/environment-metadata :base-sha])
-        base-branch (or (get-in context [:execution/environment-metadata :base-branch])
-                        (get-in context [:execution/opts :branch])
-                        (get-in context [:execution/input :branch]))
-        resume-workspace (get-in context [:execution/opts :resume-workspace])
-        original-commit (get-in context [:execution/input :context :git-commit])
-        original-branch (get-in context [:execution/input :context :git-branch])
-        original-refs (concat (when (and original-commit
-                                         (not (str/blank? original-commit)))
-                                [original-commit])
-                              (when (and original-branch
-                                         (not (str/blank? original-branch)))
-                                [(str "refs/remotes/origin/" original-branch)
-                                 (str "origin/" original-branch)
-                                 (str "refs/heads/" original-branch)]))
-        resume-ranges (when resume-workspace
-                        (map #(str % "..." current-head-ref) original-refs))]
-    (into []
-          (distinct)
-          (cond-> (vec resume-ranges)
-            (and base-sha (not (str/blank? base-sha)))
-            (conj base-sha)
-
-            (and base-branch (not (str/blank? base-branch)))
-            (into [(str "refs/remotes/origin/" base-branch)
-                   (str "origin/" base-branch)
-                   (str "refs/heads/" base-branch)])))))
-
-(defn- collect-promoted-artifact
-  "Collect code files from the current promoted worktree/container state."
-  [context session-mode working-dir]
-  (let [base-refs (base-ref-candidates context)]
-    (if (= :capsule session-mode)
-      (when-let [exec! (:execution/execute-fn context)]
-        (file-artifacts/collect-worktree-files-via-executor
-         exec!
-         (:execution/executor context)
-         (:execution/environment-id context)
-         working-dir
-         base-refs))
-      (file-artifacts/collect-worktree-files working-dir base-refs))))
-
-(defn- collect-session-artifact
-  "Collect a file artifact from the promoted or written working tree."
-  [context session-mode working-dir pre-session-snapshot]
-  (or (collect-promoted-artifact context session-mode working-dir)
-      (if (= :capsule session-mode)
-        (when-let [exec! (:execution/execute-fn context)]
-          (file-artifacts/collect-written-files-via-executor
-           pre-session-snapshot
-           exec!
-           (:execution/executor context)
-           (:execution/environment-id context)
-           working-dir))
-        (file-artifacts/collect-written-files pre-session-snapshot
-                                              working-dir))))
-
-(defn- submission-retry-prompt
-  "Submission-only retry prompt: re-feed the task + the prior (prose) output
-   and ask the implementer to deliver the actual file writes now."
-  [task-text prior-content]
-  (prompts/render-template (get @implementer-prompt-data :prompt/submission-retry-template)
-                           {:task-text task-text :prior-content prior-content}))
-
-(defn- normalize-implementer-result
-  "Re-normalize a session's raw channels into the implementer result shape,
-   re-collecting the file artifact from what was written this turn. Used by the
-   submission-recovery turn (the main turn normalizes inline so it can also
-   surface the file artifact for its fallback log)."
-  [{:keys [llm-result artifact worktree-artifacts pre-session-snapshot session-mode]}
-   context working-dir]
-  (let [file-artifact (collect-session-artifact context session-mode working-dir
-                                                pre-session-snapshot)]
-    (result-boundary/normalize-llm-result
-     {:role :implement
-      :response llm-result
-      :worktree-artifacts worktree-artifacts
-      :artifact artifact
-      :fallback-artifact file-artifact
-      :parse-response parse-code-response
-      :derive-artifact code-from-blocks})))
-
-(defn- recover-implementer-submission
+(defn- ^{:stratum 5} recover-implementer-submission
   "When the main turn produced usable analysis but NO artifact, run one short
    submission-only retry that asks the implementer to write the files now, then
    re-normalize. Returns the recovered normalized map, or nil when recovery
@@ -802,19 +822,15 @@
               (:derived-artifact recovered))
       recovered)))
 
-(defn- normalized-artifact-source
-  "Return a keyword artifact source for telemetry, defaulting malformed values to :none."
-  [normalized]
-  (let [source (get normalized :artifact-source)]
-    (if (keyword? source) source :none)))
+;------------------------------------------------------------------------------ Layer 6
 
-(defn- invoke-with-llm
+(defn- ^{:stratum 6} invoke-with-llm
   "Invoke the implementer via the LLM backend."
   [llm-client user-prompt effective-system-prompt config context on-chunk logger
    existing-files input]
   (let [working-dir (workspace/resolve-execution-workdir context "implement")
         {:keys [llm-result artifact worktree-artifacts context-misses
-                pre-session-snapshot session-mode]}
+                context-reads pre-session-snapshot session-mode]}
         (artifact-session/with-session context
           #(invoke-implementer-session % llm-client user-prompt effective-system-prompt
                                        config context on-chunk existing-files working-dir))
@@ -888,18 +904,24 @@
       ;; planner-convergence dogfood showed Claude stalling AFTER a
       ;; successful stream of edits; the old path discarded a real
       ;; artifact because the LLM response was classified as failure.
-      (if (result-boundary/usable-content? final)
-        (process-llm-response final context logger input)
-        ;; LLM call failed, no artifact (even after recovery) — preserve the
-        ;; full llm-error shape into :data so the phase-completed event carries
-        ;; :type / :stderr / :stdout / :timeout / :exit-code for post-mortem.
-        (result-boundary/error-response final
-                                        (messages/t :error/llm-failed))))))
+      (let [result (if (result-boundary/usable-content? final)
+                     (process-llm-response final context logger input)
+                     ;; LLM call failed, no artifact (even after recovery) —
+                     ;; preserve the full llm-error shape into :data so the
+                     ;; phase-completed event carries :type / :stderr /
+                     ;; :stdout / :timeout / :exit-code for post-mortem.
+                     (result-boundary/error-response final
+                                                     (messages/t :error/llm-failed)))]
+        ;; Session channel: which files the agent actually read (Codex SPEC
+        ;; §7.4.2). The phase layer turns this into consultation provenance;
+        ;; without it, "did the agent read its pinned landings" is unknowable.
+        (cond-> result
+          (seq context-reads) (assoc :context-reads context-reads))))))
 
-;------------------------------------------------------------------------------ Layer 2
+;------------------------------------------------------------------------------ Layer 7
+
 ;; Public API
-
-(defn create-implementer
+(defn ^{:stratum 7} create-implementer
   "Create an Implementer agent with optional configuration overrides.
 
    Options:
@@ -938,27 +960,6 @@
       :validate-fn validate-code-artifact
 
       :repair-fn repair-code-artifact})))
-
-(defn code-summary
-  [artifact]
-  {:id (:code/id artifact)
-   :file-count (count (:code/files artifact))
-   :actions (frequencies (map :action (:code/files artifact)))
-   :language (:code/language artifact)
-   :tests-needed? (:code/tests-needed? artifact)
-   :dependencies-added (count (:code/dependencies-added artifact []))})
-
-(defn files-by-action
-  [artifact]
-  (group-by :action (:code/files artifact)))
-
-(defn total-lines
-  [artifact]
-  (->> (:code/files artifact)
-       (remove #(= :delete (:action %)))
-       (map :content)
-       (map #(count (str/split-lines %)))
-       (reduce + 0)))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -913,10 +913,12 @@
                      (result-boundary/error-response final
                                                      (messages/t :error/llm-failed)))]
         ;; Session channel: which files the agent actually read (Codex SPEC
-        ;; §7.4.2). The phase layer turns this into consultation provenance;
-        ;; without it, "did the agent read its pinned landings" is unknowable.
+        ;; §7.4.2). The phase layer turns this into consultation provenance.
+        ;; some?, not seq: an EMPTY reads log is "known: nothing was read",
+        ;; which is a different fact from "no log surfaced" (capsule mode) —
+        ;; dropping it would turn a real unread into unknown downstream.
         (cond-> result
-          (seq context-reads) (assoc :context-reads context-reads))))))
+          (some? context-reads) (assoc :context-reads context-reads))))))
 
 ;------------------------------------------------------------------------------ Layer 7
 

--- a/components/gate/src/ai/miniforge/gate/codex_consultation.clj
+++ b/components/gate/src/ai/miniforge/gate/codex_consultation.clj
@@ -72,3 +72,6 @@
    :description "Validates the agent ran with its Thesium Codex consultation (SPEC §7.4.3)"
    :check check-codex-consultation
    :repair nil})
+
+;; Registry
+(registry/register-gate! :codex-consultation)

--- a/components/gate/src/ai/miniforge/gate/codex_consultation.clj
+++ b/components/gate/src/ai/miniforge/gate/codex_consultation.clj
@@ -1,0 +1,74 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.gate.codex-consultation
+  "Gate on Thesium Codex consultation provenance (Codex SPEC T1 §7.4.3):
+   a proposal from an agent that never saw its pinned landings is a
+   distinct object from one that did.
+
+   Reads :codex/consultation off the phase artifact (attached by the phase
+   at enter, after the agent runs). Verdicts:
+
+   1. No consultation marker, or codex unconfigured/phase unmapped — PASS
+     clean: the capability is off, and a gate that nags about an absent
+     optional capability trains people to ignore gates.
+   2. Codex CONFIGURED but the consultation was skipped (anomaly) — FAIL.
+     The operator asked for codex governance; the phase silently running
+     without it is the silent-downgrade disease this codebase treats as
+     the enemy.
+   3. Pinned but never fetched via context_read — PASS with a warning.
+     The pin is prompt-injected, so the agent saw it by construction; the
+     missing fetch is informational, and becomes meaningful only if the
+     pin ever moves to cache-only delivery."
+  (:require [ai.miniforge.gate.registry :as registry]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} check-codex-consultation
+  "Gate check fn: (artifact ctx) -> {:passed? bool :errors [..] :warnings [..]}."
+  [artifact _ctx]
+  (let [c (:codex/consultation artifact)]
+    (cond
+      (or (nil? c) (contains? #{:unconfigured :unmapped} (:status c)))
+      {:passed? true}
+
+      (= :skipped (:status c))
+      {:passed? false
+       :errors [{:type :codex-consultation-skipped
+                 :message (str "Codex is configured but this phase's consultation "
+                               "failed — the agent acted without its pinned "
+                               "landings (Codex SPEC §7.4.3)")
+                 :anomaly (:anomaly c)}]}
+
+      (and (:pinned? c) (false? (:pin-read? c)))
+      {:passed? true
+       :warnings [{:type :codex-pin-not-fetched
+                   :message (str "Pinned landings were prompt-injected but never "
+                                 "fetched via context_read; informational while "
+                                 "the pin is prompt-delivered")}]}
+
+      :else
+      {:passed? true})))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defmethod ^{:stratum 1} registry/get-gate :codex-consultation
+  [_]
+  {:name :codex-consultation
+   :description "Validates the agent ran with its Thesium Codex consultation (SPEC §7.4.3)"
+   :check check-codex-consultation
+   :repair nil})

--- a/components/gate/src/ai/miniforge/gate/interface.clj
+++ b/components/gate/src/ai/miniforge/gate/interface.clj
@@ -36,6 +36,7 @@
    [ai.miniforge.gate.pre-verify-lint]
    [ai.miniforge.gate.test]
    [ai.miniforge.gate.policy]
+   [ai.miniforge.gate.codex-consultation]
    [ai.miniforge.gate.precommit-discipline]
    [ai.miniforge.gate.behavioral]
    ;; Phase-scoped pack gates (:policy-verify / :policy-review), registered

--- a/components/gate/test/ai/miniforge/gate/codex_consultation_test.clj
+++ b/components/gate/test/ai/miniforge/gate/codex_consultation_test.clj
@@ -1,0 +1,66 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.gate.codex-consultation-test
+  (:require [ai.miniforge.gate.codex-consultation :as gate]
+            [ai.miniforge.gate.registry :as registry]
+            [clojure.test :refer [deftest is testing]]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} absent-capability-passes-clean
+  (testing "no marker at all — codex feature never ran"
+    (is (true? (:passed? (gate/check-codex-consultation {} {})))))
+  (testing "unconfigured / unmapped — capability off, no nagging"
+    (is (true? (:passed? (gate/check-codex-consultation
+                           {:codex/consultation {:status :unconfigured}} {}))))
+    (is (true? (:passed? (gate/check-codex-consultation
+                           {:codex/consultation {:status :unmapped}} {}))))))
+
+(deftest ^{:stratum 0} configured-but-skipped-fails-closed
+  (let [r (gate/check-codex-consultation
+            {:codex/consultation {:pinned? false :status :skipped
+                                  :anomaly :codex-unreadable :pin-read? nil}} {})]
+    (is (false? (:passed? r)))
+    (is (= :codex-consultation-skipped (-> r :errors first :type)))
+    (is (= :codex-unreadable (-> r :errors first :anomaly)))))
+
+(deftest ^{:stratum 0} pinned-but-unfetched-warns-only
+  (let [r (gate/check-codex-consultation
+            {:codex/consultation {:pinned? true :status :pinned
+                                  :anomaly nil :pin-read? false}} {})]
+    (is (true? (:passed? r)))
+    (is (= :codex-pin-not-fetched (-> r :warnings first :type)))))
+
+(deftest ^{:stratum 0} pinned-and-read-passes-clean
+  (let [r (gate/check-codex-consultation
+            {:codex/consultation {:pinned? true :status :pinned
+                                  :anomaly nil :pin-read? true}} {})]
+    (is (true? (:passed? r)))
+    (is (empty? (:warnings r)))))
+
+(deftest ^{:stratum 0} unknown-read-state-does-not-warn
+  ;; :pin-read? nil = the session surfaced no reads log (e.g. capsule mode);
+  ;; unknown must not be treated as unread.
+  (let [r (gate/check-codex-consultation
+            {:codex/consultation {:pinned? true :status :pinned
+                                  :anomaly nil :pin-read? nil}} {})]
+    (is (true? (:passed? r)))
+    (is (empty? (:warnings r)))))
+
+(deftest ^{:stratum 0} registered-in-the-gate-registry
+  (is (= :codex-consultation (:name (registry/get-gate :codex-consultation)))))

--- a/components/phase-software-factory/resources/config/phase/defaults.edn
+++ b/components/phase-software-factory/resources/config/phase/defaults.edn
@@ -2,7 +2,7 @@
  {;; Implementation phase defaults.
   :implement
   {:agent :implementer
-   :gates [:syntax :format :lint]
+   :gates [:syntax :format :lint :codex-consultation]
    :budget {:tokens 30000
             :iterations 8
             :time-seconds 600}
@@ -47,7 +47,7 @@
   ;; Plan phase defaults.
   :plan
   {:agent :planner
-   :gates [:plan-complete]
+   :gates [:plan-complete :codex-consultation]
    :budget {:tokens 10000
             :iterations 3
             :time-seconds 300}

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/codex_pin.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/codex_pin.clj
@@ -58,26 +58,58 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
-(defn ^{:stratum 1} pin-file
-  "The pin for `phase` as an existing-files entry {:path :content}, or nil
-   when the codex is unconfigured, the phase has no mapped situation, or
-   the consultation failed. A configured codex that cannot answer is worth
-   a warning, ALWAYS: through the logger when one is given, else stderr —
-   a nil logger must not turn the failure silent (plan has no logger)."
-  ([phase logger] (pin-file phase logger (configured-codex-dir)))
+(defn ^{:stratum 1} pin-outcome
+  "The pin attempt for `phase`, fully described:
+   {:entry {:path :content}-or-nil
+    :status :pinned | :unconfigured | :unmapped | :skipped
+    :anomaly keyword-or-nil}
+   :unconfigured (no MINIFORGE_CODEX_PATH) and :unmapped (phase not in
+   phase->situation) mean the capability is off — no noise. :skipped means a
+   CONFIGURED codex failed to answer, which always warns: through the logger
+   when one is given, else stderr — a nil logger must not turn the failure
+   silent (plan has no logger)."
+  ([phase logger] (pin-outcome phase logger (configured-codex-dir)))
   ([phase logger codex-dir]
-   (when codex-dir
-     (when-let [situation (get phase->situation phase)]
-       (let [entry (codex/pin-entry codex-dir situation pin-path)]
-         (if (:codex/anomaly entry)
-           (do (if logger
-                 (log/warn logger phase :codex/pin-skipped
-                           {:data {:anomaly (:codex/anomaly entry)
-                                   :reason  (:codex/reason entry)}})
-                 (binding [*out* *err*]
-                   (println (messages/t :codex/pin-skipped-warn
-                                        {:phase (name phase)
-                                         :anomaly (name (:codex/anomaly entry))
-                                         :reason (:codex/reason entry)}))))
-               nil)
-           entry))))))
+   (cond
+     (nil? codex-dir)
+     {:entry nil :status :unconfigured :anomaly nil}
+
+     (nil? (get phase->situation phase))
+     {:entry nil :status :unmapped :anomaly nil}
+
+     :else
+     (let [entry (codex/pin-entry codex-dir (get phase->situation phase) pin-path)]
+       (if-let [anomaly (:codex/anomaly entry)]
+         (do (if logger
+               (log/warn logger phase :codex/pin-skipped
+                         {:data {:anomaly anomaly
+                                 :reason  (:codex/reason entry)}})
+               (binding [*out* *err*]
+                 (println (messages/t :codex/pin-skipped-warn
+                                      {:phase (name phase)
+                                       :anomaly (name anomaly)
+                                       :reason (:codex/reason entry)}))))
+             {:entry nil :status :skipped :anomaly anomaly})
+         {:entry entry :status :pinned :anomaly nil})))))
+
+(defn ^{:stratum 1} consultation-summary
+  "The SPEC §7.4.3 distinct-object marker: a proposal from an agent that
+   never saw its pinned landings must be distinguishable from one that did.
+   `context-reads` is the session's recorded context_read log (§7.4.2), or
+   nil when the session did not surface one — then :pin-read? is nil
+   (unknown), not false; absence of the record is not evidence of absence
+   of the read."
+  [outcome context-reads]
+  {:pinned?   (= :pinned (:status outcome))
+   :status    (:status outcome)
+   :anomaly   (:anomaly outcome)
+   :pin-read? (when (some? context-reads)
+                (boolean (some #(= pin-path (:path %)) context-reads)))})
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} pin-file
+  "The pin for `phase` as an existing-files entry {:path :content}, or nil.
+   Thin wrapper over pin-outcome for callers that only want the entry."
+  ([phase logger] (:entry (pin-outcome phase logger)))
+  ([phase logger codex-dir] (:entry (pin-outcome phase logger codex-dir))))

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
@@ -464,10 +464,15 @@
                      (build-context-pack worktree-path files-in-scope))
         existing-files (resolve-existing-files ctx pack-ctx worktree-path files-in-scope)
         ;; Thesium Codex blackboard pin (SPEC §7.4): pinned FIRST so the
-        ;; worries render before the content they apply to.
-        codex-pin-file (codex-pin/pin-file :implement (get-in ctx [:execution/logger]))
-        existing-files (if codex-pin-file
-                         (into [codex-pin-file] (or existing-files []))
+        ;; worries render before the content they apply to. Retry iterations
+        ;; reuse :execution/cached-files which already contains the previous
+        ;; pin — drop it so the fresh consultation replaces it instead of
+        ;; rendering twice.
+        codex-outcome (codex-pin/pin-outcome :implement (get-in ctx [:execution/logger]))
+        existing-files (vec (remove #(= codex-pin/pin-path (:path %))
+                                    (or existing-files [])))
+        existing-files (if-let [pin (:entry codex-outcome)]
+                         (into [pin] existing-files)
                          existing-files)
         behavior-addendum (phase/load-guidance-addendum
                             :implement {:task {:task/intent (:intent input)}})
@@ -501,7 +506,8 @@
                        :prior-error    (or last-error (messages/t :implement/prior-error-default))
                        :instruction    (messages/t :implement/retry-instruction)}))]
     {:task task
-     :rules-manifest manifest}))
+     :rules-manifest manifest
+     :codex-outcome codex-outcome}))
 
 (defn ^{:stratum 3} leave-implement
   "Post-processing for implementation phase.
@@ -721,7 +727,7 @@
         logger (or (get-in ctx [:execution/logger])
                    (log/create-logger {:min-level :info :output :human}))
         implementer-agent (agent/create-implementer {:logger logger})
-        {:keys [task rules-manifest]} (build-implement-task ctx)
+        {:keys [task rules-manifest codex-outcome]} (build-implement-task ctx)
         ;; Cache loaded files and context pack for subsequent retries
         ctx (cond-> ctx
               (not (get-in ctx [:execution/cached-files]))
@@ -892,7 +898,17 @@
                  ;; something non-success (shouldn't happen outside no-files;
                  ;; defensive fallback).
                  :else
-                 curator-result)]
+                 curator-result)
+        ;; SPEC §7.4.3: mark the result with consultation provenance BEFORE
+        ;; enter-context stores it — gates run between enter and leave and
+        ;; read [:result :output]. Reads come from the agent result's
+        ;; :context-reads (host-mode sessions); curator-result branches drop
+        ;; that key, so read it off impl-result directly.
+        result (if (map? (:output result))
+                 (assoc-in result [:output :codex/consultation]
+                           (codex-pin/consultation-summary
+                             codex-outcome (:context-reads impl-result)))
+                 result)]
     (-> (phase/enter-context ctx :implement :implementer gates budget start-time result)
         (assoc-in [:phase :rules-manifest] rules-manifest)
         (assoc-in [:phase :watchdog-state]

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/plan.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/plan.clj
@@ -116,9 +116,9 @@
   (let [exploration-files (:exploration/files explore-result)
         ;; Thesium Codex blackboard pin (SPEC §7.4): pinned FIRST so the
         ;; worries render before the content they apply to.
-        codex-pin-file (codex-pin/pin-file :plan nil)
-        existing-files (if codex-pin-file
-                         (into [codex-pin-file] (or exploration-files []))
+        codex-outcome (codex-pin/pin-outcome :plan nil)
+        existing-files (if-let [pin (:entry codex-outcome)]
+                         (into [pin] (or exploration-files []))
                          exploration-files)
         {:keys [formatted manifest]} (kb-helpers/inject-with-manifest
                                        knowledge-store :planner (get input :tags []))
@@ -137,7 +137,8 @@
                behavior-addendum
                (assoc :task/behavior-addendum behavior-addendum))]
     {:task task
-     :rules-manifest manifest}))
+     :rules-manifest manifest
+     :codex-outcome codex-outcome}))
 
 (defn ^{:stratum 0} create-streaming-callback
   "Create a streaming callback for agent output, if event-stream is available."
@@ -204,23 +205,29 @@
    Returns {:result agent-result :rules-manifest manifest-or-nil}."
   [ctx input]
   (let [explore-result (get-in ctx [:execution/phase-results :explore :result :output])
-        {:keys [task rules-manifest]} (build-planner-task input explore-result (:knowledge-store ctx))
+        {:keys [task rules-manifest codex-outcome]} (build-planner-task input explore-result (:knowledge-store ctx))
         on-chunk (create-streaming-callback ctx)
         agent-ctx (cond-> ctx on-chunk (assoc :on-chunk on-chunk))
         planner-agent (agent/create-planner {})]
-    {:result (validate-dag-readiness
-              (try
-                (agent/invoke planner-agent task agent-ctx)
-                (catch Exception e
-                  ;; Preserve the spent-token count from the agent's failure
-                  ;; anomaly (planner tags ex-data with :tokens) into the
-                  ;; failure result's :metrics, so leave-plan still merges the
-                  ;; real cost into :execution/metrics instead of reporting $0.
-                  (let [ed   (ex-data e)
-                        toks (get ed :tokens 0)]
-                    (response/failure e {:data ed
-                                         :tokens toks
-                                         :metrics {:tokens toks}})))))
+    {:result (let [r (validate-dag-readiness
+                       (try
+                         (agent/invoke planner-agent task agent-ctx)
+                         (catch Exception e
+                           ;; Preserve the spent-token count from the agent's failure
+                           ;; anomaly (planner tags ex-data with :tokens) into the
+                           ;; failure result's :metrics, so leave-plan still merges the
+                           ;; real cost into :execution/metrics instead of reporting $0.
+                           (let [ed   (ex-data e)
+                                 toks (get ed :tokens 0)]
+                             (response/failure e {:data ed
+                                                  :tokens toks
+                                                  :metrics {:tokens toks}})))))]
+               ;; SPEC §7.4.3 consultation provenance. The planner session does
+               ;; not surface :context-reads yet, so :pin-read? is nil (unknown).
+               (if (map? (:output r))
+                 (assoc-in r [:output :codex/consultation]
+                           (codex-pin/consultation-summary codex-outcome nil))
+                 r))
      :rules-manifest rules-manifest}))
 
 ;------------------------------------------------------------------------------ Layer 2

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/codex_pin_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/codex_pin_test.clj
@@ -21,7 +21,7 @@
    (ai.miniforge.codex.render-test/pin-entry-builds-a-prompt-ready-file);
    these cover the phase-side skip conditions."
   (:require [ai.miniforge.phase-software-factory.codex-pin :as codex-pin]
-            [clojure.test :refer [deftest is]]))
+            [clojure.test :refer [deftest is testing]]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -45,3 +45,26 @@
       (is (nil? (codex-pin/pin-file :implement nil "/nonexistent/codex"))))
     (is (re-find #"WARN: codex pin skipped for implement" (str err))
         "a nil logger must not turn a configured-codex failure silent")))
+
+(deftest ^{:stratum 0} pin-outcome-states
+  (is (= {:entry nil :status :unconfigured :anomaly nil}
+         (codex-pin/pin-outcome :implement nil nil)))
+  (is (= {:entry nil :status :unmapped :anomaly nil}
+         (codex-pin/pin-outcome :verify nil "/anywhere")))
+  (is (= :skipped
+         (:status (codex-pin/pin-outcome :implement nil "/nonexistent/codex")))))
+
+(deftest ^{:stratum 0} consultation-summary-distinguishes-unknown-from-unread
+  (let [pinned {:entry {:path codex-pin/pin-path} :status :pinned :anomaly nil}]
+    (testing "nil reads log means UNKNOWN, not false — absence of the record is not absence of the read"
+      (is (nil? (:pin-read? (codex-pin/consultation-summary pinned nil)))))
+    (testing "reads log without the pin path means false"
+      (is (false? (:pin-read? (codex-pin/consultation-summary
+                                pinned [{:path "src/a.clj" :source :cache}])))))
+    (testing "reads log with the pin path means true"
+      (is (true? (:pin-read? (codex-pin/consultation-summary
+                               pinned [{:path codex-pin/pin-path :source :cache}])))))
+    (testing "skipped consultation carries its anomaly"
+      (is (= {:pinned? false :status :skipped :anomaly :codex-unreadable :pin-read? nil}
+             (codex-pin/consultation-summary
+               {:entry nil :status :skipped :anomaly :codex-unreadable} nil))))))

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
@@ -85,7 +85,7 @@
 (deftest ^{:stratum 0} default-config-test
   (testing "implement phase has correct default configuration"
     (is (= :implementer (:agent implement/default-config)))
-    (is (= [:syntax :format :lint] (:gates implement/default-config)))
+    (is (= [:syntax :format :lint :codex-consultation] (:gates implement/default-config)))
     (is (map? (:budget implement/default-config)))
     (is (= 30000 (get-in implement/default-config [:budget :tokens])))
     (is (= 8 (get-in implement/default-config [:budget :iterations])))
@@ -96,7 +96,7 @@
     (let [defaults (phase/phase-defaults :implement)]
       (is (some? defaults))
       (is (= :implementer (:agent defaults)))
-      (is (= [:syntax :format :lint] (:gates defaults))))))
+      (is (= [:syntax :format :lint :codex-consultation] (:gates defaults))))))
 
 (deftest ^{:stratum 0} base-ref-candidates-include-resume-merge-base-ranges-test
   (testing "resumed workspaces diff from the original spec base to restored HEAD"


### PR DESCRIPTION
The §7.4.3 gate: a proposal from an agent that never saw its pinned landings is a distinct object from one that did — now literally.

1. The implementer session's `:context-reads` (§7.4.2 recorded flows, shipped in [#1624](https://github.com/miniforge-ai/miniforge/pull/1624)) is threaded onto the agent result; previously it died unbound at the session destructure.
2. `build-implement-task` / `build-planner-task` return the full pin outcome (`:pinned | :unconfigured | :unmapped | :skipped` + anomaly), and the phase attaches `:codex/consultation {:pinned? :status :anomaly :pin-read?}` to `[:result :output]` before `enter-context` stores it — gates run between enter and leave and read exactly that artifact. `:pin-read?` is nil when the session surfaced no reads log: unknown, never false.
3. New `:codex-consultation` gate, default-wired into implement and plan. Absent capability passes clean (a gate that nags about an absent optional capability trains people to ignore gates). A CONFIGURED codex whose consultation failed FAILS the gate — silent downgrade is the disease. Pinned-but-never-fetched is a warning only, because the pin is prompt-injected and consultation is by construction.
4. Fixes a real defect: retry iterations reuse `:execution/cached-files` which already contains the previous pin, so the fresh pin rendered twice. The stale entry is now dropped before prepending.

Planner `:context-reads` threading is deliberately not included — the planner result assembly is deeply nested and its `:pin-read?` stays nil (unknown) until that lands; the gate treats unknown as unknown.

Gate error strings follow the gate component's existing inline-map convention (no gate catalog exists there); codex_pin prose stays in the phase catalog.

Stacked: [reviewer-pin] follows on this branch.

MINIFORGE_PR_BUDGET_OVERRIDE: functional diff ~200 lines; the remainder is stratum autofix annotation churn on baseline files (implementer.clj, implement.clj, plan.clj).

🤖 Generated with [Claude Code](https://claude.com/claude-code)