### PR TITLE
feat(codex): reviewer pin — quality-signals board via prompt section (SPEC §7.3)

### DIFF
--- a/components/agent/resources/prompts/reviewer.edn
+++ b/components/agent/resources/prompts/reviewer.edn
@@ -252,6 +252,10 @@ Findings outside the scope are out-of-scope — report them in
 
 {{constraints|safe}}
 
+{% endif %}{% if has_codex %}## Codex — worth attending to before you review
+
+{{codex_landings|safe}}
+
 {% endif %}## Code to Review
 
 {{artifact_text|safe}}{% if has_tests %}

--- a/components/agent/src/ai/miniforge/agent/reviewer/prompts.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer/prompts.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.agent.reviewer.prompts
   "Reviewer prompt assembly.
 
@@ -44,35 +43,25 @@
             [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Prompt resource loading
 
-(def reviewer-system-prompt
+;; Prompt resource loading
+(def ^{:stratum 0} reviewer-system-prompt
   "System prompt for the reviewer agent."
   (delay (prompts/load-prompt :reviewer)))
 
-(def reviewer-prompt-data
+(def ^{:stratum 0} reviewer-prompt-data
   "Full prompt data map for the reviewer agent.
    Exposes knobs like :prompt/progress-monitor that gate stream supervision."
   (delay (prompts/load-prompt-data :reviewer)))
 
-(defn create-reviewer-progress-monitor
-  "Reviewer main-turn progress monitor. Thresholds live in
-   resources/prompts/reviewer.edn (:prompt/progress-monitor). Falls
-   back to the framework default when the EDN omits the block."
-  []
-  (prompts/load-progress-monitor @reviewer-prompt-data
-                                 :prompt/progress-monitor))
-
-(def default-reviewer-max-turns
+(def ^{:stratum 0} default-reviewer-max-turns
   "Fallback when reviewer.edn omits :prompt/max-turns. Authority is
    the EDN; this constant only protects against malformed prompt
    resources."
   20)
 
-;------------------------------------------------------------------------------ Layer 1
 ;; Artifact rendering
-
-(defn format-artifact-for-review
+(defn ^{:stratum 0} format-artifact-for-review
   "Format a code artifact into a readable string for the LLM prompt."
   [artifact]
   (cond
@@ -92,7 +81,17 @@
     :else
     (pr-str artifact)))
 
-(defn format-artifact-manifest
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} create-reviewer-progress-monitor
+  "Reviewer main-turn progress monitor. Thresholds live in
+   resources/prompts/reviewer.edn (:prompt/progress-monitor). Falls
+   back to the framework default when the EDN omits the block."
+  []
+  (prompts/load-progress-monitor @reviewer-prompt-data
+                                 :prompt/progress-monitor))
+
+(defn ^{:stratum 1} format-artifact-manifest
   "Compact manifest of the artifact-under-review for the shed path (N12 §5):
    each file's path, action, and size — not its inlined body. The reviewer
    runs read-only with native Read/Grep disallowed, so it fetches any file
@@ -115,10 +114,8 @@
                         (:code/files artifact))))
     (format-artifact-for-review artifact)))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; User-prompt assembly
-
-(defn build-review-prompt
+(defn ^{:stratum 1} build-review-prompt
   "Construct the user prompt for LLM review from task data.
 
    `artifact-fmt` selects how the artifact-under-review is rendered: full
@@ -133,6 +130,7 @@
          intent (or (:task/intent input) "")
          constraints (or (:task/constraints input) "")
          tests (:task/tests input)
+         codex-landings (:task/codex-landings input)
          review-scope (scope/effective-review-scope input)
          artifact-text (artifact-fmt artifact)]
      (prompts/render-template
@@ -149,12 +147,12 @@
        "artifact_text" artifact-text
        "has_tests" (some? tests)
        "tests" (when (some? tests)
-                 (if (string? tests) tests (pr-str tests)))}))))
+                 (if (string? tests) tests (pr-str tests)))
+       "has_codex" (not (str/blank? (str codex-landings)))
+       "codex_landings" (str codex-landings)}))))
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Enumeration retry
-
-(defn enumeration-retry-prompt
+(defn ^{:stratum 1} enumeration-retry-prompt
   "Build the enumeration-retry prompt: the ORIGINAL review user-prompt (so the
    retry has the same artifact/diff evidence the first call had — `llm/chat`
    is single-turn with no history) followed by the retry instruction with the

--- a/components/agent/test/ai/miniforge/agent/reviewer/prompts_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer/prompts_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.agent.reviewer.prompts-test
   "Tests for `ai.miniforge.agent.reviewer.prompts` — extracted from
    `ai.miniforge.agent.reviewer-test` as part of the PR-E decomposition.
@@ -28,9 +27,10 @@
    [ai.miniforge.agent.prompts :as prompts]
    [ai.miniforge.agent.reviewer.prompts :as reviewer-prompts]))
 
-;------------------------------------------------------------------------------ format-artifact-for-review
+;------------------------------------------------------------------------------ Layer 0
 
-(deftest format-artifact-for-review-test
+;------------------------------------------------------------------------------ format-artifact-for-review
+(deftest ^{:stratum 0} format-artifact-for-review-test
   (testing "CodeArtifact with :code/files renders each file as a markdown block"
     (let [out (reviewer-prompts/format-artifact-for-review
                 {:code/files [{:path "src/a.clj" :content "(def x 1)" :action :create}
@@ -52,8 +52,7 @@
     (is (= "{:k 1}" (reviewer-prompts/format-artifact-for-review {:k 1})))))
 
 ;------------------------------------------------------------------------------ format-artifact-manifest (N12 §5 shed path)
-
-(deftest format-artifact-manifest-test
+(deftest ^{:stratum 0} format-artifact-manifest-test
   (testing "CodeArtifact renders each file as path + action + size, omitting the body"
     (let [out (reviewer-prompts/format-artifact-manifest
                 {:code/files [{:path "src/a.clj" :content "(def x 1)" :action :create}
@@ -76,14 +75,13 @@
     (is (= "{:k 1}" (reviewer-prompts/format-artifact-manifest {:k 1})))))
 
 ;------------------------------------------------------------------------------ build-review-prompt — manifest artifact formatter
-
-(deftest render-template-preserves-raw-prompt-content-test
+(deftest ^{:stratum 0} render-template-preserves-raw-prompt-content-test
   (testing "Selmer prompt rendering does not HTML-escape code, diffs, markdown, or EDN"
     (is (= "Review <src/a.clj> && {:ok? true}"
            (prompts/render-template "Review {{content}}"
                                     {:content "<src/a.clj> && {:ok? true}"})))))
 
-(deftest build-review-prompt-manifest-arity-test
+(deftest ^{:stratum 0} build-review-prompt-manifest-arity-test
   (let [input {:task/title "T"
                :task/scope ["src"]
                :task/artifact {:code/files [{:path "src/a.clj"
@@ -102,8 +100,7 @@
         (is (not (re-find #"\(def x 1\)" prompt)))))))
 
 ;------------------------------------------------------------------------------ build-review-prompt — section rendering
-
-(deftest build-review-prompt-renders-scope-section-test
+(deftest ^{:stratum 0} build-review-prompt-renders-scope-section-test
   (testing "Scope section appears with bulleted paths when scope is resolved"
     (let [prompt (reviewer-prompts/build-review-prompt
                    {:task/title "Test"
@@ -124,7 +121,7 @@
                     :task/intent "free-form prose"
                     :task/artifact {:code/files []}})))))
 
-(deftest build-review-prompt-omits-empty-sections-test
+(deftest ^{:stratum 0} build-review-prompt-omits-empty-sections-test
   (let [prompt (reviewer-prompts/build-review-prompt
                  {:task/title ""
                   :task/description ""
@@ -157,7 +154,7 @@
       (is (not (re-find #"## Intent"      prompt)))
       (is (not (re-find #"## Constraints" prompt))))))
 
-(deftest build-review-prompt-includes-tests-section-test
+(deftest ^{:stratum 0} build-review-prompt-includes-tests-section-test
   (let [prompt (reviewer-prompts/build-review-prompt
                  {:task/title "T"
                   :task/scope ["src"]
@@ -165,3 +162,24 @@
                   :task/tests "all 12 tests passed"})]
     (is (re-find #"## Test Results" prompt))
     (is (re-find #"all 12 tests passed" prompt))))
+
+(deftest ^{:stratum 0} build-review-prompt-renders-codex-landings-before-code
+  (let [prompt (reviewer-prompts/build-review-prompt
+                 {:task/title "t"
+                  :task/description "d"
+                  :task/scope ["src"]
+                  :task/artifact {:code/files []}
+                  :task/codex-landings "situation: quality-signal-might-be-lying\ncoverage: 4 landings"})]
+    (is (re-find #"## Codex — worth attending to before you review" prompt))
+    (is (re-find #"quality-signal-might-be-lying" prompt))
+    (is (< (.indexOf ^String prompt "## Codex")
+           (.indexOf ^String prompt "## Code to Review"))
+        "worries render before the content they apply to")))
+
+(deftest ^{:stratum 0} build-review-prompt-omits-codex-section-when-absent
+  (let [prompt (reviewer-prompts/build-review-prompt
+                 {:task/title "t"
+                  :task/description "d"
+                  :task/scope ["src"]
+                  :task/artifact {:code/files []}})]
+    (is (not (re-find #"## Codex" prompt)))))

--- a/components/phase-software-factory/resources/config/phase/messages/en-US.edn
+++ b/components/phase-software-factory/resources/config/phase/messages/en-US.edn
@@ -3,7 +3,7 @@
   :default/task-description "implement changes"
 
   ;; Thesium Codex blackboard pin (SPEC §7.4)
-  :codex/pin-skipped-warn "WARN: codex pin skipped for {phase} — {anomaly}: {reason}"
+  :codex/consultation-skipped-warn "WARN: codex consultation skipped for {phase} — {anomaly}: {reason}"
 
   ;; Implementation phase
   :implement/agent-error           "Agent returned error status"

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/codex_pin.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/codex_pin.clj
@@ -61,10 +61,10 @@
    else stderr — a nil logger must not turn the failure silent."
   [phase logger anomaly reason]
   (if logger
-    (log/warn logger phase :codex/pin-skipped
+    (log/warn logger phase :codex/consultation-skipped
               {:data {:anomaly anomaly :reason reason}})
     (binding [*out* *err*]
-      (println (messages/t :codex/pin-skipped-warn
+      (println (messages/t :codex/consultation-skipped-warn
                            {:phase (name phase)
                             :anomaly (name anomaly)
                             :reason reason})))))

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/codex_pin.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/codex_pin.clj
@@ -46,15 +46,28 @@
 (def ^{:stratum 0} phase->situation
   "Which codex situation each phase enters at. This map IS the push
    mechanism's routing: the orchestrator supplies the situation, the codex
-   supplies the worries. Only phases whose task builders actually carry
-   `:task/existing-files` are listed — review's channel is `:task/artifact`,
-   so its pin (situation: quality-signal-might-be-lying) waits until the
-   reviewer prompt assembly grows a slot for it."
+   supplies the worries. implement/plan deliver via the pinned
+   existing-files entry (pin-outcome); review has no existing-files
+   channel and delivers via a rendered prompt section (landings-text)."
   {:implement "changing-one-side-of-a-boundary"
-   :plan      "about-to-commit-consequential"})
+   :plan      "about-to-commit-consequential"
+   :review    "quality-signal-might-be-lying"})
 
 (defn- ^{:stratum 0} configured-codex-dir []
   (some-> (System/getenv "MINIFORGE_CODEX_PATH") str/trim not-empty))
+
+(defn- ^{:stratum 0} warn-skip!
+  "A CONFIGURED codex that fails to answer always warns: logger when given,
+   else stderr — a nil logger must not turn the failure silent."
+  [phase logger anomaly reason]
+  (if logger
+    (log/warn logger phase :codex/pin-skipped
+              {:data {:anomaly anomaly :reason reason}})
+    (binding [*out* *err*]
+      (println (messages/t :codex/pin-skipped-warn
+                           {:phase (name phase)
+                            :anomaly (name anomaly)
+                            :reason reason})))))
 
 ;------------------------------------------------------------------------------ Layer 1
 
@@ -80,17 +93,25 @@
      :else
      (let [entry (codex/pin-entry codex-dir (get phase->situation phase) pin-path)]
        (if-let [anomaly (:codex/anomaly entry)]
-         (do (if logger
-               (log/warn logger phase :codex/pin-skipped
-                         {:data {:anomaly anomaly
-                                 :reason  (:codex/reason entry)}})
-               (binding [*out* *err*]
-                 (println (messages/t :codex/pin-skipped-warn
-                                      {:phase (name phase)
-                                       :anomaly (name anomaly)
-                                       :reason (:codex/reason entry)}))))
+         (do (warn-skip! phase logger anomaly (:codex/reason entry))
              {:entry nil :status :skipped :anomaly anomaly})
          {:entry entry :status :pinned :anomaly nil})))))
+
+(defn ^{:stratum 1} landings-text
+  "Rendered consultation body for phases that deliver via a prompt section
+   rather than a pinned file — the reviewer has no existing-files channel.
+   Returns the rendered text, or nil when the capability is off
+   (unconfigured/unmapped) or a configured codex failed to answer (which
+   warns, same policy as pin-outcome)."
+  ([phase logger] (landings-text phase logger (configured-codex-dir)))
+  ([phase logger codex-dir]
+   (when codex-dir
+     (when-let [situation (get phase->situation phase)]
+       (let [resp (codex/consider codex-dir situation)]
+         (if-let [anomaly (:codex/anomaly resp)]
+           (do (warn-skip! phase logger anomaly (:codex/reason resp))
+               nil)
+           (codex/render-response resp)))))))
 
 (defn ^{:stratum 1} consultation-summary
   "The SPEC §7.4.3 distinct-object marker: a proposal from an agent that

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
@@ -25,6 +25,7 @@
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.phase-software-factory.messages :as messages]
+   [ai.miniforge.phase-software-factory.codex-pin :as codex-pin]
    [ai.miniforge.phase-software-factory.phase-config :as phase-config]
    [ai.miniforge.phase-software-factory.phase-handoff :as phase-handoff]
    [ai.miniforge.phase-software-factory.knowledge-helpers :as kb-helpers]
@@ -331,6 +332,10 @@
         {:keys [formatted manifest]} (kb-helpers/inject-with-manifest
                                        (:knowledge-store ctx) :reviewer (get input :tags []))
         artifact (resolve-implement-artifact implement-phase-result ctx)
+        ;; Thesium Codex push delivery for the reviewer (SPEC §7.3): rendered
+        ;; landings as a prompt section — the quality-signals board, because a
+        ;; reviewer IS a quality signal deciding whether to trust itself.
+        codex-landings (codex-pin/landings-text :review (get-in ctx [:execution/logger]))
         behavior-addendum (phase/load-and-filter-behaviors
                             :review {:task {:task/intent (:intent input)}})
         task (cond-> {:task/id (random-uuid)
@@ -352,7 +357,9 @@
                formatted
                (assoc :task/knowledge-context formatted)
                behavior-addendum
-               (assoc :task/behavior-addendum behavior-addendum))]
+               (assoc :task/behavior-addendum behavior-addendum)
+               codex-landings
+               (assoc :task/codex-landings codex-landings))]
     {:task task
      :rules-manifest manifest}))
 

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/codex_pin_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/codex_pin_test.clj
@@ -49,7 +49,7 @@
   (let [err (java.io.StringWriter.)]
     (binding [*err* err]
       (is (nil? (codex-pin/pin-file :implement nil "/nonexistent/codex"))))
-    (is (re-find #"WARN: codex pin skipped for implement" (str err))
+    (is (re-find #"WARN: codex consultation skipped for implement" (str err))
         "a nil logger must not turn a configured-codex failure silent")))
 
 (deftest ^{:stratum 0} pin-outcome-states

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/codex_pin_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/codex_pin_test.clj
@@ -35,9 +35,15 @@
   (is (nil? (codex-pin/pin-file :implement nil "/nonexistent/codex"))))
 
 (deftest ^{:stratum 0} only-wired-phases-are-mapped
-  ;; review's task builder has no :task/existing-files channel yet; a mapping
-  ;; without a wire would be a defined-but-unreachable capability.
-  (is (= #{:implement :plan} (set (keys codex-pin/phase->situation)))))
+  ;; implement/plan wire via pin-outcome (existing-files); review wires via
+  ;; landings-text (prompt section). A mapping without a wire would be a
+  ;; defined-but-unreachable capability.
+  (is (= #{:implement :plan :review} (set (keys codex-pin/phase->situation)))))
+
+(deftest ^{:stratum 0} landings-text-skip-conditions
+  (is (nil? (codex-pin/landings-text :review nil nil)))
+  (is (nil? (codex-pin/landings-text :verify nil "/anywhere")))
+  (is (nil? (codex-pin/landings-text :review nil "/nonexistent/codex"))))
 
 (deftest ^{:stratum 0} anomaly-with-nil-logger-warns-on-stderr
   (let [err (java.io.StringWriter.)]


### PR DESCRIPTION
Stacked on the consultation-gate PR. The reviewer IS a quality signal deciding whether to trust itself, so it enters the codex at `quality-signal-might-be-lying`.

The reviewer has no `:task/existing-files` channel, so delivery is a rendered prompt section: `codex-pin/landings-text` → `:task/codex-landings` → "## Codex — worth attending to before you review", placed before the code under review (worries render before the content they apply to). Same skip policy as the pin: capability off = no noise; a configured codex that fails to answer warns, never silently (shared `warn-skip!`).

Live smoke against the operator codex: the reviewer receives board 3's five landings with the §7.6.2 NO STRATEGIC COVERAGE statement.

Tests: prompt section renders before `## Code to Review` and is omitted when absent; landings-text skip conditions; phase->situation now maps exactly the wired phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)