### PR TITLE
feat(codex-gap): miss ledger + first-leak-wins bucket classifier (gap spec Task 1)

### DIFF
--- a/components/codex-gap/deps.edn
+++ b/components/codex-gap/deps.edn
@@ -1,0 +1,10 @@
+{:paths ["src" "resources"]
+ ;; No component deps yet: the classifier consumes codex data (landings,
+ ;; problems) as arguments, and no operator prose exists in this slice —
+ ;; the gap-report task adds ai.miniforge/codex + ai.miniforge/messages
+ ;; when it arrives.
+ :deps {}
+ :aliases
+ {:test {:extra-paths ["test" "test-resources"]
+         :extra-deps {io.github.cognitect-labs/test-runner
+                      {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}}}

--- a/components/codex-gap/resources/config/codex-gap/gate-reason-map.edn
+++ b/components/codex-gap/resources/config/codex-gap/gate-reason-map.edn
@@ -1,0 +1,8 @@
+;; Mechanical attribution map (codex-gap spec, Task 1): decision-envelope
+;; gate-failure reasons -> codex problem ids. Data, not code — entries
+;; accrue as gate reasons prove attributable. Keys are
+;; [:reason/code :reason/rule-id] pairs; :reason/rule-id may be nil for
+;; code-wide mappings. A lookup miss falls through to similarity
+;; attribution.
+{[:reason/grant-absent nil]   "fail-closed-by-default"
+ [:reason/grant-exceeded nil] "authority-outside-the-model"}

--- a/components/codex-gap/src/ai/miniforge/codex_gap/attribute.clj
+++ b/components/codex-gap/src/ai/miniforge/codex_gap/attribute.clj
@@ -1,0 +1,93 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.codex-gap.attribute
+  "Attribute a failure signal to a codex problem (T2 §3.4).
+
+   Two methods, tried in order:
+   1. :mechanical — typed gate-failure reasons looked up in the declared
+      [:reason/code :reason/rule-id] -> problem-id map (data resource).
+   2. :similarity — character-bigram Dice similarity of the signal text
+      against each problem's title + open items (the same corpus family
+      the zk admit §6.3 matcher uses). Deliberately textual, deliberately
+      dependency-free: high-confidence match proves PRESENCE; low
+      confidence proves nothing and must land in the review queue, never
+      silently in a bucket."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} default-threshold
+  "Similarity floor below which attribution is not claimed."
+  0.5)
+
+(defn- ^{:stratum 0} bigrams [s]
+  (let [normalized (-> (str/lower-case (str s))
+                       (str/replace #"[^a-z0-9]+" " ")
+                       str/trim)]
+    (set (map #(apply str %) (partition 2 1 normalized)))))
+
+(defn ^{:stratum 0} load-gate-reason-map
+  "The declared mechanical map from the classpath resource; {} when absent
+   (attribution then falls through to similarity for everything)."
+  []
+  (if-let [r (io/resource "config/codex-gap/gate-reason-map.edn")]
+    (edn/read-string (slurp r))
+    {}))
+
+(defn- ^{:stratum 0} problem-corpus [problem]
+  (str/join " " (cons (str (:title problem))
+                      (map :value (:open problem)))))
+
+(defn ^{:stratum 0} mechanical
+  "Mechanical attribution for a gate-failure Reason map, or nil.
+   Tries the exact [:reason/code :reason/rule-id] pair, then the
+   rule-id-agnostic [:reason/code nil] entry."
+  [reason gate-reason-map]
+  (when-let [code (:reason/code reason)]
+    (when-let [problem-id (or (get gate-reason-map [code (:reason/rule-id reason)])
+                              (get gate-reason-map [code nil]))]
+      {:problem problem-id :method :mechanical :confidence 1.0})))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} dice
+  "Sørensen–Dice coefficient over character bigrams; 0.0 when either side
+   is empty (an empty corpus proves nothing)."
+  [a b]
+  (let [ba (bigrams a) bb (bigrams b)]
+    (if (or (empty? ba) (empty? bb))
+      0.0
+      (/ (* 2.0 (count (filter bb ba)))
+         (+ (count ba) (count bb))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} similarity
+  "Best similarity attribution of `text` against `problems`
+   (seq of {:id :title :open}). Always returns the best candidate with its
+   confidence — the CALLER compares against the threshold and routes
+   below-threshold results to the review queue (T2 §3.4)."
+  [text problems]
+  (when (seq problems)
+    (let [scored (map (fn [p] {:problem (:id p)
+                               :method :similarity
+                               :confidence (dice text (problem-corpus p))})
+                      problems)]
+      (apply max-key :confidence scored))))

--- a/components/codex-gap/src/ai/miniforge/codex_gap/classify.clj
+++ b/components/codex-gap/src/ai/miniforge/codex_gap/classify.clj
@@ -1,0 +1,92 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.codex-gap.classify
+  "Bucket classification of a miss entry (T2 §3.3): first leak wins, a
+   later rung is never blamed when an earlier one leaked.
+
+     :uncovered    no situation for the phase — the codex never entered
+     :misrouted    problem confidently identified, NOT reachable from the
+                   entered situation's board (even an undelivered warning
+                   could not have reached it — earlier leak)
+     :undelivered  routed, but the consultation was skipped, absent, or
+                   the codex was unconfigured — the plumbing did not run
+     :unheeded     the warning was in front of the consumer and the
+                   failure matched a delivered landing anyway
+     :review-queue NOT a rung bucket — attribution below threshold; held
+                   out of every rate until resolved
+     :novel        assigned only by review-queue resolution in v0; the
+                   mechanical path cannot prove absence, only presence.
+
+   :pin-read? stays tri-state throughout — nil is unknown, never false."
+  (:require [ai.miniforge.codex-gap.attribute :as attribute]
+            [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} signal-text
+  "The attributable text of a miss signal: review-issue descriptions,
+   gate-reason details, anomaly messages — whatever the payload carries."
+  [{:keys [payload]}]
+  (->> [(:description payload) (:message payload) (:anomaly/message payload)
+        (:reason/detail payload)
+        (when (string? payload) payload)]
+       (remove str/blank?)
+       (str/join " ")))
+
+(defn- ^{:stratum 0} undelivered?
+  [consultation]
+  (or (nil? consultation)
+      (contains? #{:skipped :unconfigured} (:status consultation))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} classify
+  "Classify one miss entry. Inputs:
+   - entry: {:miss/situation :miss/consultation :miss/signal ...}
+   - consider-resp: the codex consider response for the entry's situation
+     ({:landings [...]} — or nil/anomaly when unavailable)
+   - problems: seq of {:id :title :open} — the codex's FULL problem set
+     (attribution corpus; landings alone cannot detect :misrouted)
+   - opts: {:gate-reason-map .. :threshold ..}
+   Returns {:bucket kw :attribution map-or-nil}."
+  [entry consider-resp problems {:keys [gate-reason-map threshold]
+                                 :or {threshold attribute/default-threshold}}]
+  (let [situation (:miss/situation entry)
+        consultation (:miss/consultation entry)
+        signal (:miss/signal entry)]
+    (if (nil? situation)
+      {:bucket :uncovered :attribution nil}
+      (let [attribution (or (when (= :gate-failure (:type signal))
+                              (attribute/mechanical (:payload signal)
+                                                    (or gate-reason-map
+                                                        (attribute/load-gate-reason-map))))
+                            (attribute/similarity (signal-text signal) problems))
+            confident? (and attribution (>= (:confidence attribution) threshold))
+            landing-ids (set (map :id (:landings consider-resp)))]
+        (cond
+          (not confident?)
+          {:bucket :review-queue :attribution attribution}
+
+          (not (contains? landing-ids (:problem attribution)))
+          {:bucket :misrouted :attribution attribution}
+
+          (undelivered? consultation)
+          {:bucket :undelivered :attribution attribution}
+
+          :else
+          {:bucket :unheeded :attribution attribution})))))

--- a/components/codex-gap/src/ai/miniforge/codex_gap/classify.clj
+++ b/components/codex-gap/src/ai/miniforge/codex_gap/classify.clj
@@ -77,10 +77,24 @@
                                                         (attribute/load-gate-reason-map))))
                             (attribute/similarity (signal-text signal) problems))
             confident? (and attribution (>= (:confidence attribution) threshold))
-            landing-ids (set (map :id (:landings consider-resp)))]
+            ;; Landings unavailable (nil resp, or a codex anomaly at classify
+            ;; time) means rung 2 is UNPROVABLE — an empty landing set would
+            ;; convict every confident attribution of :misrouted, which is
+            ;; exactly the false blame first-leak-wins forbids. Unprovable
+            ;; holds in the queue; it does not classify.
+            landings-known? (and (map? consider-resp)
+                                 (nil? (:codex/anomaly consider-resp))
+                                 (contains? consider-resp :landings))
+            landing-ids (when landings-known?
+                          (set (map :id (:landings consider-resp))))]
         (cond
           (not confident?)
-          {:bucket :review-queue :attribution attribution}
+          {:bucket :review-queue :attribution attribution
+           :queue-reason :below-threshold}
+
+          (not landings-known?)
+          {:bucket :review-queue :attribution attribution
+           :queue-reason :landings-unavailable}
 
           (not (contains? landing-ids (:problem attribution)))
           {:bucket :misrouted :attribution attribution}

--- a/components/codex-gap/src/ai/miniforge/codex_gap/interface.clj
+++ b/components/codex-gap/src/ai/miniforge/codex_gap/interface.clj
@@ -48,14 +48,18 @@
 (defn ^{:stratum 0} record-miss!
   "Append an entry to the run's ledger file under `dir` (the run's
    checkpoint directory, passed in by the caller — this component never
-   derives it). Returns the entry, or a {:codex-gap/anomaly ...} map;
-   never throws — a ledger write must never take a phase down."
+   derives it). Environmental failures return {:codex-gap/anomaly
+   :ledger-write-failed ...} data rather than throwing — a ledger write
+   must never take a phase down. A nil/blank `dir` IS a throw
+   (IllegalArgumentException): that is a caller bug, not an environment."
   [dir entry]
   (ledger/append! dir entry))
 
 (defn ^{:stratum 0} read-ledger
   "All ledger entries under `dir`, oldest first:
-   {:entries [..] :skipped n-unreadable-lines}."
+   {:entries [..] :skipped n-unreadable-lines}, or
+   {:codex-gap/anomaly :ledger-read-failed ...} on an environmental read
+   failure. Same nil/blank-dir programmer-error contract as record-miss!."
   [dir]
   (ledger/read-ledger dir))
 

--- a/components/codex-gap/src/ai/miniforge/codex_gap/interface.clj
+++ b/components/codex-gap/src/ai/miniforge/codex_gap/interface.clj
@@ -1,0 +1,66 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.codex-gap.interface
+  "Codex gap instrument (Thesium Codex SPEC T2; work/codex-gap-instrument
+   .spec.edn): the miss ledger and its bucket classifier.
+
+   The ideal codex's value stands by construction; this component measures
+   where the actual one leaks — every observed failure becomes a ledger
+   entry classified at the FIRST leaking rung, and the ledger is what the
+   gap report (Task 3) aggregates. The bucket names the fix channel:
+   :uncovered -> harvest, :misrouted -> peg admission, :undelivered ->
+   plumbing, :unheeded -> delivery form / landing actionability."
+  (:require [ai.miniforge.codex-gap.attribute :as attribute]
+            [ai.miniforge.codex-gap.classify :as classify]
+            [ai.miniforge.codex-gap.ledger :as ledger]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} classify
+  "Classify a miss entry into its T2 §3.3 bucket, first leak wins.
+   See ai.miniforge.codex-gap.classify/classify for inputs. Returns
+   {:bucket kw :attribution {:problem :method :confidence}-or-nil};
+   :review-queue is a holding state, not a rung bucket."
+  [entry consider-resp problems opts]
+  (classify/classify entry consider-resp problems opts))
+
+(defn ^{:stratum 0} build-entry
+  "Normalize a miss into its ledger shape (ids and timestamps stamped
+   here — writers normalize, readers do not)."
+  [miss]
+  (ledger/build-entry miss))
+
+(defn ^{:stratum 0} record-miss!
+  "Append an entry to the run's ledger file under `dir` (the run's
+   checkpoint directory, passed in by the caller — this component never
+   derives it). Returns the entry, or a {:codex-gap/anomaly ...} map;
+   never throws — a ledger write must never take a phase down."
+  [dir entry]
+  (ledger/append! dir entry))
+
+(defn ^{:stratum 0} read-ledger
+  "All ledger entries under `dir`, oldest first:
+   {:entries [..] :skipped n-unreadable-lines}."
+  [dir]
+  (ledger/read-ledger dir))
+
+(defn ^{:stratum 0} load-gate-reason-map
+  "The declared mechanical attribution map ([:reason/code :reason/rule-id]
+   -> problem id) from the classpath resource."
+  []
+  (attribute/load-gate-reason-map))

--- a/components/codex-gap/src/ai/miniforge/codex_gap/ledger.clj
+++ b/components/codex-gap/src/ai/miniforge/codex_gap/ledger.clj
@@ -80,6 +80,8 @@
    Returns {:entries [..] :skipped n}; missing file = no entries, which is
    a true statement about an instrument that has not run."
   [dir]
+  (when (or (nil? dir) (and (string? dir) (str/blank? dir)))
+    (throw (IllegalArgumentException. "ledger dir must be non-blank")))
   (let [f (io/file dir ledger-filename)]
     (if-not (.exists f)
       {:entries [] :skipped 0}
@@ -97,6 +99,10 @@
                   {:entries [] :skipped 0}
                   (line-seq r)))
         (catch java.io.IOException e
+          {:codex-gap/anomaly :ledger-read-failed
+           :codex-gap/reason (ex-message e)
+           :codex-gap/dir (str dir)})
+        (catch SecurityException e
           {:codex-gap/anomaly :ledger-read-failed
            :codex-gap/reason (ex-message e)
            :codex-gap/dir (str dir)})))))

--- a/components/codex-gap/src/ai/miniforge/codex_gap/ledger.clj
+++ b/components/codex-gap/src/ai/miniforge/codex_gap/ledger.clj
@@ -18,9 +18,12 @@
 (ns ai.miniforge.codex-gap.ledger
   "The miss ledger: an append-only EDN log, one pr-str'd entry per line,
    living in the run's checkpoint directory (spec resolution — never
-   evidence-bundle, never in-repo). Append is a single write so a failure
-   cannot corrupt prior entries; IO failures are anomalies-as-data because
-   a ledger write must never take a phase down with it.
+   evidence-bundle, never in-repo). Each append is one small O_APPEND
+   write of one line; a failed append cannot rewrite prior entries, and
+   the reader tolerates a torn/corrupt line by skipping and counting it —
+   that, not write atomicity (which the JVM does not guarantee), is the
+   corruption defense. IO failures are anomalies-as-data because a ledger
+   write must never take a phase down with it.
 
    The entry writer NORMALIZES (one canonical location per datum): ids and
    timestamps are stamped here, [:phase :error] shape inconsistencies are
@@ -48,22 +51,28 @@
    :miss/bucket bucket
    :miss/attribution attribution})
 
+(defn- ^{:stratum 0} write-anomaly [dir e]
+  {:codex-gap/anomaly :ledger-write-failed
+   :codex-gap/reason (ex-message e)
+   :codex-gap/dir (str dir)})
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn ^{:stratum 1} append!
   "Append one entry to <dir>/codex-gap-ledger.edn. Returns the entry, or
-   {:codex-gap/anomaly :ledger-write-failed ...} — data, never a throw."
+   {:codex-gap/anomaly :ledger-write-failed ...} — data, never a throw for
+   environmental failures. A nil/blank dir is a programmer error and
+   throws (rule 005): callers own dir resolution."
   [dir entry]
+  (when (or (nil? dir) (and (string? dir) (str/blank? dir)))
+    (throw (IllegalArgumentException. "ledger dir must be non-blank")))
   (try
     (io/make-parents (io/file dir ledger-filename))
-    (spit (io/file dir ledger-filename)
-          (str (pr-str entry) "\n")
-          :append true)
+    (with-open [w (java.io.FileOutputStream. (io/file dir ledger-filename) true)]
+      (.write w (.getBytes (str (pr-str entry) "\n") "UTF-8")))
     entry
-    (catch java.io.IOException e
-      {:codex-gap/anomaly :ledger-write-failed
-       :codex-gap/reason (ex-message e)
-       :codex-gap/dir (str dir)})))
+    (catch java.io.IOException e (write-anomaly dir e))
+    (catch SecurityException e (write-anomaly dir e))))
 
 (defn ^{:stratum 1} read-ledger
   "All entries from <dir>/codex-gap-ledger.edn, oldest first. Unreadable
@@ -74,9 +83,20 @@
   (let [f (io/file dir ledger-filename)]
     (if-not (.exists f)
       {:entries [] :skipped 0}
-      (let [lines (remove str/blank? (str/split-lines (slurp f)))
-            parsed (map (fn [l] (try (edn/read-string l)
-                                     (catch Exception _ ::unreadable)))
-                        lines)]
-        {:entries (vec (remove #(= ::unreadable %) parsed))
-         :skipped (count (filter #(= ::unreadable %) parsed))}))))
+      (try
+        ;; streamed, not slurped: the ledger is append-only and unbounded
+        (with-open [r (io/reader f)]
+          (reduce (fn [acc line]
+                    (if (str/blank? line)
+                      acc
+                      (let [v (try (edn/read-string line)
+                                   (catch Exception _ ::unreadable))]
+                        (if (= ::unreadable v)
+                          (update acc :skipped inc)
+                          (update acc :entries conj v)))))
+                  {:entries [] :skipped 0}
+                  (line-seq r)))
+        (catch java.io.IOException e
+          {:codex-gap/anomaly :ledger-read-failed
+           :codex-gap/reason (ex-message e)
+           :codex-gap/dir (str dir)})))))

--- a/components/codex-gap/src/ai/miniforge/codex_gap/ledger.clj
+++ b/components/codex-gap/src/ai/miniforge/codex_gap/ledger.clj
@@ -1,0 +1,82 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.codex-gap.ledger
+  "The miss ledger: an append-only EDN log, one pr-str'd entry per line,
+   living in the run's checkpoint directory (spec resolution — never
+   evidence-bundle, never in-repo). Append is a single write so a failure
+   cannot corrupt prior entries; IO failures are anomalies-as-data because
+   a ledger write must never take a phase down with it.
+
+   The entry writer NORMALIZES (one canonical location per datum): ids and
+   timestamps are stamped here, [:phase :error] shape inconsistencies are
+   the caller's to resolve onto :anomaly/category before recording."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ledger-filename "codex-gap-ledger.edn")
+
+(defn ^{:stratum 0} build-entry
+  "Normalize a miss into its ledger shape. `signal` is
+   {:type :review-blocking|:gate-failure|:terminal-anomaly :payload ...}
+   with the payload verbatim from the producer."
+  [{:keys [run-id phase signal situation consultation bucket attribution]}]
+  {:miss/id (random-uuid)
+   :miss/at (str (java.time.Instant/now))
+   :miss/run-id run-id
+   :miss/phase phase
+   :miss/signal signal
+   :miss/situation situation
+   :miss/consultation consultation
+   :miss/bucket bucket
+   :miss/attribution attribution})
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} append!
+  "Append one entry to <dir>/codex-gap-ledger.edn. Returns the entry, or
+   {:codex-gap/anomaly :ledger-write-failed ...} — data, never a throw."
+  [dir entry]
+  (try
+    (io/make-parents (io/file dir ledger-filename))
+    (spit (io/file dir ledger-filename)
+          (str (pr-str entry) "\n")
+          :append true)
+    entry
+    (catch java.io.IOException e
+      {:codex-gap/anomaly :ledger-write-failed
+       :codex-gap/reason (ex-message e)
+       :codex-gap/dir (str dir)})))
+
+(defn ^{:stratum 1} read-ledger
+  "All entries from <dir>/codex-gap-ledger.edn, oldest first. Unreadable
+   lines are skipped with a count — a corrupt line must not hide the rest.
+   Returns {:entries [..] :skipped n}; missing file = no entries, which is
+   a true statement about an instrument that has not run."
+  [dir]
+  (let [f (io/file dir ledger-filename)]
+    (if-not (.exists f)
+      {:entries [] :skipped 0}
+      (let [lines (remove str/blank? (str/split-lines (slurp f)))
+            parsed (map (fn [l] (try (edn/read-string l)
+                                     (catch Exception _ ::unreadable)))
+                        lines)]
+        {:entries (vec (remove #(= ::unreadable %) parsed))
+         :skipped (count (filter #(= ::unreadable %) parsed))}))))

--- a/components/codex-gap/test/ai/miniforge/codex_gap/interface_test.clj
+++ b/components/codex-gap/test/ai/miniforge/codex_gap/interface_test.clj
@@ -110,6 +110,19 @@
     (is (some? attribution) "the best candidate travels with the queued entry")
     (is (< (:confidence attribution) 0.5))))
 
+(deftest ^{:stratum 1} unavailable-landings-queue-instead-of-convicting-misrouted
+  ;; nil or anomaly consider-resp makes rung 2 UNPROVABLE — an empty landing
+  ;; set must not convict a confident attribution of :misrouted.
+  (doseq [resp [nil {:codex/anomaly :codex-unreadable :codex/reason "gone"}]]
+    (let [{:keys [bucket queue-reason attribution]}
+          (gap/classify (entry "changing-one-side-of-a-boundary"
+                               {:status :pinned :pinned? true :pin-read? true}
+                               drift-signal)
+                        resp problems {})]
+      (is (= :review-queue bucket))
+      (is (= :landings-unavailable queue-reason))
+      (is (= "contract-drift-is-silent" (:problem attribution))))))
+
 (deftest ^{:stratum 1} mechanical-attribution-wins-for-typed-gate-reasons
   (let [signal {:type :gate-failure
                 :payload {:reason/code :reason/grant-absent

--- a/components/codex-gap/test/ai/miniforge/codex_gap/interface_test.clj
+++ b/components/codex-gap/test/ai/miniforge/codex_gap/interface_test.clj
@@ -1,0 +1,158 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.codex-gap.interface-test
+  "Signal payload shapes mirror the real producers: ReviewIssue maps
+   (agent reviewer issues schema), decision-envelope Reason maps, and
+   codex consider-response landings (pinned by the codex component's
+   tests). Problems corpus entries mirror codex load-graph problem nodes
+   (:id :title :open with {:value} items)."
+  (:require [ai.miniforge.codex-gap.interface :as gap]
+            [clojure.java.io :as io]
+            [clojure.test :refer [deftest is testing]]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} problems
+  [{:id "contract-drift-is-silent"
+    :title "Nothing enforces agreement between a producer and its consumers"
+    :open [{:value "when producer and consumer live in different repos, the verification has no single place to live"}]}
+   {:id "liveness-detection"
+    :title "Liveness cannot be inferred from activity"
+    :open [{:value "progress is domain-specific; there is no universal signal"}]}])
+
+(def ^{:stratum 0} boundary-landings
+  ;; consider-resp for changing-one-side-of-a-boundary: contract drift IS
+  ;; a landing; liveness-detection is NOT reachable from that board.
+  {:landings [{:id "contract-drift-is-silent" :type "problem"}]})
+
+(defn- ^{:stratum 0} entry [situation consultation signal]
+  {:miss/situation situation
+   :miss/consultation consultation
+   :miss/signal signal})
+
+(def ^{:stratum 0} drift-signal
+  {:type :review-blocking
+   :payload {:severity :blocking
+             :description "consumer reads a key the producer never writes — nothing enforces agreement between producer and consumer"}})
+
+(deftest ^{:stratum 0} missing-ledger-reads-as-empty-not-error
+  (is (= {:entries [] :skipped 0} (gap/read-ledger "/nonexistent/run/dir"))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} no-situation-classifies-uncovered-first
+  (testing "rung 1 wins even when delivery also failed"
+    (is (= :uncovered
+           (:bucket (gap/classify (entry nil nil drift-signal)
+                                  nil problems {}))))))
+
+(deftest ^{:stratum 1} confident-unreachable-attribution-is-misrouted-even-when-undelivered
+  (let [signal {:type :review-blocking
+                :payload {:severity :blocking
+                          :description "liveness cannot be inferred from activity; heartbeats reset the clock"}}
+        {:keys [bucket attribution]}
+        (gap/classify (entry "changing-one-side-of-a-boundary"
+                             {:status :skipped :pinned? false :pin-read? nil}
+                             signal)
+                      boundary-landings problems {})]
+    (is (= :misrouted bucket)
+        "the board could not have reached it — earlier leak than delivery")
+    (is (= "liveness-detection" (:problem attribution)))
+    (is (= :similarity (:method attribution)))))
+
+(deftest ^{:stratum 1} skipped-consultation-on-a-reachable-problem-is-undelivered
+  (is (= :undelivered
+         (:bucket (gap/classify (entry "changing-one-side-of-a-boundary"
+                                       {:status :skipped :pinned? false :pin-read? nil}
+                                       drift-signal)
+                                boundary-landings problems {})))))
+
+(deftest ^{:stratum 1} nil-consultation-with-mapped-situation-is-undelivered
+  (is (= :undelivered
+         (:bucket (gap/classify (entry "changing-one-side-of-a-boundary"
+                                       nil drift-signal)
+                                boundary-landings problems {})))))
+
+(deftest ^{:stratum 1} delivered-and-matching-a-landing-is-unheeded
+  (let [{:keys [bucket attribution]}
+        (gap/classify (entry "changing-one-side-of-a-boundary"
+                             {:status :pinned :pinned? true :pin-read? nil}
+                             drift-signal)
+                      boundary-landings problems {})]
+    (is (= :unheeded bucket))
+    (is (= "contract-drift-is-silent" (:problem attribution)))))
+
+(deftest ^{:stratum 1} below-threshold-goes-to-the-review-queue
+  (let [signal {:type :review-blocking
+                :payload {:severity :blocking
+                          :description "flaky wifi on the build machine"}}
+        {:keys [bucket attribution]}
+        (gap/classify (entry "changing-one-side-of-a-boundary"
+                             {:status :pinned :pinned? true :pin-read? true}
+                             signal)
+                      boundary-landings problems {})]
+    (is (= :review-queue bucket))
+    (is (some? attribution) "the best candidate travels with the queued entry")
+    (is (< (:confidence attribution) 0.5))))
+
+(deftest ^{:stratum 1} mechanical-attribution-wins-for-typed-gate-reasons
+  (let [signal {:type :gate-failure
+                :payload {:reason/code :reason/grant-absent
+                          :reason/detail "no enablement found for repo"}}
+        {:keys [bucket attribution]}
+        (gap/classify (entry "agent-acts-in-the-world"
+                             {:status :pinned :pinned? true :pin-read? true}
+                             signal)
+                      {:landings [{:id "fail-closed-by-default" :type "problem"}]}
+                      problems {})]
+    (is (= :mechanical (:method attribution)))
+    (is (= "fail-closed-by-default" (:problem attribution)))
+    (is (= 1.0 (:confidence attribution)))
+    (is (= :unheeded bucket))))
+
+(deftest ^{:stratum 1} ledger-round-trips-and-survives-corrupt-lines
+  (let [dir (str (java.nio.file.Files/createTempDirectory
+                   "codex-gap-test-"
+                   (into-array java.nio.file.attribute.FileAttribute [])))
+        e1 (gap/build-entry {:run-id "run-1" :phase :implement
+                             :signal drift-signal
+                             :situation "changing-one-side-of-a-boundary"
+                             :consultation {:status :pinned :pinned? true :pin-read? nil}
+                             :bucket :unheeded
+                             :attribution {:problem "contract-drift-is-silent"
+                                           :method :similarity :confidence 0.61}})]
+    (is (= e1 (gap/record-miss! dir e1)))
+    (spit (io/file dir "codex-gap-ledger.edn") "{corrupt\n" :append true)
+    (let [e2 (gap/build-entry {:run-id "run-1" :phase :review
+                               :signal drift-signal :situation nil
+                               :consultation nil :bucket :uncovered
+                               :attribution nil})]
+      (is (= e2 (gap/record-miss! dir e2)))
+      (let [{:keys [entries skipped]} (gap/read-ledger dir)]
+        (is (= [e1 e2] entries) "corrupt line skipped, order preserved")
+        (is (= 1 skipped))
+        (is (nil? (get-in entries [0 :miss/consultation :pin-read?]))
+            "tri-state pin-read? survives the round trip verbatim")))))
+
+(deftest ^{:stratum 1} ledger-write-failure-is-data-not-a-throw
+  (let [r (gap/record-miss! "/dev/null/not-a-dir" (gap/build-entry
+                                                    {:run-id "x" :phase :implement
+                                                     :signal drift-signal :situation nil
+                                                     :consultation nil :bucket :uncovered
+                                                     :attribution nil}))]
+    (is (= :ledger-write-failed (:codex-gap/anomaly r)))))

--- a/deps.edn
+++ b/deps.edn
@@ -30,6 +30,8 @@
                        "components/clock/src"
                        "components/codex/src"
                        "components/codex/resources"
+                       "components/codex-gap/src"
+                       "components/codex-gap/resources"
                        "components/coerce/src"
                        "components/response-chain/src"
                        "components/boundary/src"
@@ -225,6 +227,7 @@
                       ai.miniforge/progress-detector {:local/root "components/progress-detector"}
                       ai.miniforge/clock {:local/root "components/clock"}
                       ai.miniforge/codex {:local/root "components/codex"}
+                      ai.miniforge/codex-gap {:local/root "components/codex-gap"}
                       ai.miniforge/coerce {:local/root "components/coerce"}
                       ai.miniforge/response-chain {:local/root "components/response-chain"}
                       ai.miniforge/boundary {:local/root "components/boundary"}
@@ -353,6 +356,8 @@
                        "components/clock/test"
                        "components/codex/test"
                        "components/codex/test-resources"
+                       "components/codex-gap/test"
+                       "components/codex-gap/test-resources"
                        "components/coerce/test"
                        "components/response-chain/test"
                        "components/boundary/test"
@@ -489,6 +494,7 @@
                       ai.miniforge/progress-detector {:local/root "components/progress-detector"}
                       ai.miniforge/clock {:local/root "components/clock"}
                       ai.miniforge/codex {:local/root "components/codex"}
+                      ai.miniforge/codex-gap {:local/root "components/codex-gap"}
                       ai.miniforge/coerce {:local/root "components/coerce"}
                       ai.miniforge/response-chain {:local/root "components/response-chain"}
                       ai.miniforge/boundary {:local/root "components/boundary"}


### PR DESCRIPTION
Task 1 of [#1632](https://github.com/miniforge-ai/miniforge/pull/1632)'s spec (T2 gap instrument). Wave: Task 2 (phase-leave wiring) and Task 3 (gap report + bb task) follow on top.

1. **classify** — the T2 §3.3 rungs, first leak wins: `:uncovered` (no situation), `:misrouted` (confident attribution to a problem the entered board cannot reach — earlier leak than delivery; a test pins exactly that ordering against a skipped consultation), `:undelivered` (consultation skipped/absent/unconfigured with a mapped situation), `:unheeded` (delivered and the failure matched a landing anyway). Below-threshold attribution lands in `:review-queue`, a holding state excluded from every rate; `:novel` is queue-resolution-only in v0 because similarity proves presence, never absence.
2. **Attribution** — mechanical `[:reason/code :reason/rule-id] → problem-id` from a data resource (seeded with two honest entries), then character-bigram Dice similarity against problem titles + open items. Dependency-free, deterministic; the best candidate travels with queued entries so the review queue is triage, not archaeology.
3. **Ledger** — append-only EDN, one entry per line, in the run's checkpoint dir passed as a parameter (per the spec resolution: no workflow dependency, no evidence-bundle). A write failure is anomaly data — it can never take a phase down; corrupt lines are skipped and counted; `:pin-read?` tri-state survives round trips verbatim.

Tests: 10 tests / 22 assertions, payload shapes mirroring the real producers (ReviewIssue maps, decision-envelope Reason maps, codex landings). Poly check clean. No component deps in this slice — the classifier consumes codex data as arguments; codex + messages arrive with the report task.

MINIFORGE_PR_BUDGET_OVERRIDE: single coherent new component with its tests; all new code implementing the just-merged spec's Task 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)