### PR TITLE
feat(codex-gap): record misses at phase leave (gap spec Task 2)

### DIFF
--- a/components/phase-software-factory/deps.edn
+++ b/components/phase-software-factory/deps.edn
@@ -7,6 +7,7 @@
         ai.miniforge/schema {:local/root "../schema"}
         ai.miniforge/agent {:local/root "../agent"}
         ai.miniforge/codex {:local/root "../codex"}
+        ai.miniforge/codex-gap {:local/root "../codex-gap"}
         ai.miniforge/knowledge {:local/root "../knowledge"}
         ai.miniforge/repo-index {:local/root "../repo-index"}
         ai.miniforge/context-pack {:local/root "../context-pack"}

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/codex_pin.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/codex_pin.clj
@@ -53,7 +53,9 @@
    :plan      "about-to-commit-consequential"
    :review    "quality-signal-might-be-lying"})
 
-(defn- ^{:stratum 0} configured-codex-dir []
+(defn ^{:stratum 0} configured-codex-dir
+  "MINIFORGE_CODEX_PATH, trimmed, or nil — nil means the capability is off."
+  []
   (some-> (System/getenv "MINIFORGE_CODEX_PATH") str/trim not-empty))
 
 (defn- ^{:stratum 0} warn-skip!
@@ -83,35 +85,44 @@
    silent (plan has no logger)."
   ([phase logger] (pin-outcome phase logger (configured-codex-dir)))
   ([phase logger codex-dir]
-   (cond
-     (nil? codex-dir)
-     {:entry nil :status :unconfigured :anomaly nil}
+   (let [situation (get phase->situation phase)]
+     (cond
+       (nil? codex-dir)
+       {:entry nil :status :unconfigured :anomaly nil :situation situation}
 
-     (nil? (get phase->situation phase))
-     {:entry nil :status :unmapped :anomaly nil}
+       (nil? situation)
+       {:entry nil :status :unmapped :anomaly nil :situation nil}
 
-     :else
-     (let [entry (codex/pin-entry codex-dir (get phase->situation phase) pin-path)]
-       (if-let [anomaly (:codex/anomaly entry)]
-         (do (warn-skip! phase logger anomaly (:codex/reason entry))
-             {:entry nil :status :skipped :anomaly anomaly})
-         {:entry entry :status :pinned :anomaly nil})))))
+       :else
+       (let [entry (codex/pin-entry codex-dir situation pin-path)]
+         (if-let [anomaly (:codex/anomaly entry)]
+           (do (warn-skip! phase logger anomaly (:codex/reason entry))
+               {:entry nil :status :skipped :anomaly anomaly :situation situation})
+           {:entry entry :status :pinned :anomaly nil :situation situation}))))))
 
-(defn ^{:stratum 1} landings-text
-  "Rendered consultation body for phases that deliver via a prompt section
-   rather than a pinned file — the reviewer has no existing-files channel.
-   Returns the rendered text, or nil when the capability is off
-   (unconfigured/unmapped) or a configured codex failed to answer (which
-   warns, same policy as pin-outcome)."
-  ([phase logger] (landings-text phase logger (configured-codex-dir)))
+(defn ^{:stratum 1} landings-outcome
+  "Prompt-section delivery outcome for phases with no existing-files
+   channel (the reviewer): {:text rendered-or-nil :status :anomaly
+   :situation} — same status vocabulary as pin-outcome, with :pinned
+   meaning DELIVERED (the section is the pin's prompt-only analog), so
+   consultation-summary works on either outcome unchanged."
+  ([phase logger] (landings-outcome phase logger (configured-codex-dir)))
   ([phase logger codex-dir]
-   (when codex-dir
-     (when-let [situation (get phase->situation phase)]
+   (let [situation (get phase->situation phase)]
+     (cond
+       (nil? codex-dir)
+       {:text nil :status :unconfigured :anomaly nil :situation situation}
+
+       (nil? situation)
+       {:text nil :status :unmapped :anomaly nil :situation nil}
+
+       :else
        (let [resp (codex/consider codex-dir situation)]
          (if-let [anomaly (:codex/anomaly resp)]
            (do (warn-skip! phase logger anomaly (:codex/reason resp))
-               nil)
-           (codex/render-response resp)))))))
+               {:text nil :status :skipped :anomaly anomaly :situation situation})
+           {:text (codex/render-response resp) :status :pinned :anomaly nil
+            :situation situation}))))))
 
 (defn ^{:stratum 1} consultation-summary
   "The SPEC §7.4.3 distinct-object marker: a proposal from an agent that
@@ -124,10 +135,17 @@
   {:pinned?   (= :pinned (:status outcome))
    :status    (:status outcome)
    :anomaly   (:anomaly outcome)
+   :situation (:situation outcome)
    :pin-read? (when (some? context-reads)
                 (boolean (some #(= pin-path (:path %)) context-reads)))})
 
 ;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} landings-text
+  "Rendered consultation body, or nil. Thin wrapper over landings-outcome
+   for callers that only want the text."
+  ([phase logger] (:text (landings-outcome phase logger)))
+  ([phase logger codex-dir] (:text (landings-outcome phase logger codex-dir))))
 
 (defn ^{:stratum 2} pin-file
   "The pin for `phase` as an existing-files entry {:path :content}, or nil.

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/gap_wiring.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/gap_wiring.clj
@@ -1,0 +1,147 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.phase-software-factory.gap-wiring
+  "Miss-ledger recording at phase leave (gap-instrument spec Task 2, T2
+   §3). Collects the phase's failure signals — review blocking issues
+   (map-shaped :review/issues preferred, string fallback), gate failures
+   (decision-envelope Reason maps off the NAMESPACED [:phase :phase/...]
+   keys), and terminal anomalies (normalized onto :anomaly/category at
+   this writer) — classifies each against the live codex, and appends to
+   the run's ledger.
+
+   Recording is opt-in by construction (no MINIFORGE_CODEX_PATH -> no-op:
+   without a codex there is no gap to measure) and best-effort by
+   contract: a recording failure logs and continues, because the
+   instrument must never change the outcome it measures."
+  (:require [ai.miniforge.codex-gap.interface :as gap]
+            [ai.miniforge.codex.interface :as codex]
+            [ai.miniforge.logging.interface :as log]
+            [ai.miniforge.phase-software-factory.codex-pin :as codex-pin]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Signal extraction — pure over ctx fragments, public for tests
+(defn ^{:stratum 0} review-signals
+  "Blocking review findings as miss signals. Prefers the map-shaped
+   :review/issues (severity/file/description); falls back to the
+   :review/blocking-issues string vector, which is all the gate-only and
+   parse-failure paths populate."
+  [output]
+  (let [issues (seq (filter #(= :blocking (:severity %)) (:review/issues output)))]
+    (if issues
+      (map (fn [i] {:type :review-blocking :payload i}) issues)
+      (map (fn [s] {:type :review-blocking :payload s})
+           (:review/blocking-issues output)))))
+
+(defn ^{:stratum 0} gate-signals
+  "Gate failures as miss signals, one per decision-envelope Reason map.
+   Reads the NAMESPACED keys: bare [:phase :status] is clobbered at leave."
+  [phase-map]
+  (when (= :failed (:phase/status phase-map))
+    (map (fn [r] {:type :gate-failure :payload r})
+         (:phase/gate-errors phase-map))))
+
+(defn ^{:stratum 0} terminal-signal
+  "The phase's terminal anomaly as a miss signal, normalized here (the
+   writer) onto :anomaly/category — [:phase :error] shapes are
+   inconsistent across producers (sub-anomaly records vs hand-rolled
+   maps), and readers must not each re-solve that."
+  [phase-map]
+  (when-let [err (:error phase-map)]
+    {:type :terminal-anomaly
+     :payload {:anomaly/category (or (:anomaly/category err)
+                                     (get-in err [:anomaly :category]))
+               :anomaly/message (or (:anomaly/message err) (:message err))}}))
+
+(defn- ^{:stratum 0} ledger-dir
+  "The run's checkpoint dir, or nil when identity/root are absent (e.g.
+   bare unit-test ctxs) — recording skips rather than inventing a path."
+  [ctx]
+  (let [root (:execution/checkpoint-root ctx)
+        run-id (:execution/id ctx)]
+    (when (and root run-id)
+      (str (java.io.File. (str root) (str run-id))))))
+
+(defn- ^{:stratum 0} codex-problems
+  "Attribution corpus: every problem node's {:id :title :open}."
+  [codex-dir]
+  (let [{:keys [nodes] :as graph} (codex/load-graph codex-dir)]
+    (when-not (:codex/anomaly graph)
+      (->> (vals nodes)
+           (filter #(= "problem" (:type %)))
+           (map #(select-keys % [:id :title :open]))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} phase-signals
+  "All miss signals visible on ctx at leave for `_phase`."
+  [ctx _phase]
+  (let [phase-map (get ctx :phase)
+        output (get-in phase-map [:result :output])]
+    (concat (review-signals output)
+            (gate-signals phase-map)
+            (when-let [t (terminal-signal phase-map)] [t]))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} record-phase-misses!
+  "Classify and append every failure signal of the phase at leave.
+   No-op without a configured codex or a resolvable run dir. Never
+   affects the phase: environmental failures come back as data from the
+   ledger, and anything unexpected logs and continues — except an
+   interrupt, which must keep flying (cooperative cancellation)."
+  ([ctx phase] (record-phase-misses! ctx phase (codex-pin/configured-codex-dir)))
+  ([ctx phase codex-dir]
+   (let [logger (:execution/logger ctx)
+         dir (ledger-dir ctx)]
+     (when (and codex-dir dir)
+       (try
+         (let [phase-map (get ctx :phase)
+               consultation (get-in phase-map [:result :output :codex/consultation])
+               situation (or (:situation consultation)
+                             (get codex-pin/phase->situation phase))
+               consider-resp (when situation (codex/consider codex-dir situation))
+               problems (codex-problems codex-dir)]
+           (doseq [signal (phase-signals ctx phase)]
+             (let [{:keys [bucket attribution queue-reason]}
+                   (gap/classify {:miss/situation situation
+                                  :miss/consultation consultation
+                                  :miss/signal signal}
+                                 consider-resp problems {})
+                   entry (gap/build-entry {:run-id (:execution/id ctx)
+                                           :phase phase
+                                           :signal signal
+                                           :situation situation
+                                           :consultation consultation
+                                           :bucket bucket
+                                           :attribution (cond-> attribution
+                                                          queue-reason
+                                                          (assoc :queue-reason queue-reason))})
+                   written (gap/record-miss! dir entry)]
+               (when (and logger (:codex-gap/anomaly written))
+                 (log/warn logger phase :codex-gap/ledger-write-failed
+                           {:data written})))))
+         (catch InterruptedException e (throw e))
+         ;; Boundary catch, deliberate and narrow in effect: the instrument
+         ;; must never change the outcome it measures, so an unexpected
+         ;; classification bug logs and the phase proceeds. Interrupts are
+         ;; rethrown above — this must not eat cooperative cancellation.
+         (catch Exception e
+           (when logger
+             (log/warn logger phase :codex-gap/recording-failed
+                       {:data {:error (ex-message e)}}))))))))

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/gap_wiring.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/gap_wiring.clj
@@ -59,13 +59,17 @@
 (defn ^{:stratum 0} terminal-signal
   "The phase's terminal anomaly as a miss signal, normalized here (the
    writer) onto :anomaly/category — [:phase :error] shapes are
-   inconsistent across producers (sub-anomaly records vs hand-rolled
-   maps), and readers must not each re-solve that."
+   inconsistent across producers (anomaly/sub-anomaly maps carrying
+   :anomaly/subtype + :anomaly/type vs hand-rolled maps carrying
+   :anomaly/category), and readers must not each re-solve that. The
+   sub-anomaly :anomaly/subtype IS the domain category (the :anomalies.*
+   vocabulary) and maps first; its generic :anomaly/type is the fallback."
   [phase-map]
   (when-let [err (:error phase-map)]
     {:type :terminal-anomaly
      :payload {:anomaly/category (or (:anomaly/category err)
-                                     (get-in err [:anomaly :category]))
+                                     (:anomaly/subtype err)
+                                     (:anomaly/type err))
                :anomaly/message (or (:anomaly/message err) (:message err))}}))
 
 (defn- ^{:stratum 0} ledger-dir

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
@@ -27,6 +27,7 @@
    [ai.miniforge.phase-software-factory.messages :as messages]
    [ai.miniforge.phase-software-factory.phase-config :as phase-config]
    [ai.miniforge.phase-software-factory.codex-pin :as codex-pin]
+   [ai.miniforge.phase-software-factory.gap-wiring :as gap-wiring]
    [ai.miniforge.phase-software-factory.knowledge-helpers :as kb-helpers]
    [ai.miniforge.agent.interface :as agent]
    [ai.miniforge.agent.interface.protocols.messaging :as messaging]
@@ -514,6 +515,9 @@
 
    Records metrics, captures code artifacts."
   [ctx]
+  ;; Gap-instrument miss recording (T2 s3): best-effort, opt-in, and it
+  ;; must never change the outcome it measures.
+  (gap-wiring/record-phase-misses! ctx :implement)
   (let [start-time (get-in ctx [:phase :started-at])
         end-time (System/currentTimeMillis)
         duration-ms (if start-time (- end-time start-time) 0)

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/plan.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/plan.clj
@@ -24,6 +24,7 @@
   (:require [ai.miniforge.phase.interface :as phase]
             [ai.miniforge.phase-software-factory.phase-config :as phase-config]
             [ai.miniforge.phase-software-factory.codex-pin :as codex-pin]
+            [ai.miniforge.phase-software-factory.gap-wiring :as gap-wiring]
             [ai.miniforge.phase-software-factory.knowledge-helpers :as kb-helpers]
             [ai.miniforge.phase-software-factory.phase-terminal :as phase-terminal]
             [ai.miniforge.agent.interface :as agent]
@@ -150,6 +151,9 @@
 
    Records metrics and updates execution state."
   [ctx]
+  ;; Gap-instrument miss recording (T2 s3): best-effort, opt-in, and it
+  ;; must never change the outcome it measures.
+  (gap-wiring/record-phase-misses! ctx :plan)
   (let [start-time (get-in ctx [:phase :started-at])
         end-time (System/currentTimeMillis)
         duration-ms (- end-time start-time)

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
@@ -26,6 +26,7 @@
    [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.phase-software-factory.messages :as messages]
    [ai.miniforge.phase-software-factory.codex-pin :as codex-pin]
+   [ai.miniforge.phase-software-factory.gap-wiring :as gap-wiring]
    [ai.miniforge.phase-software-factory.phase-config :as phase-config]
    [ai.miniforge.phase-software-factory.phase-handoff :as phase-handoff]
    [ai.miniforge.phase-software-factory.knowledge-helpers :as kb-helpers]
@@ -335,7 +336,8 @@
         ;; Thesium Codex push delivery for the reviewer (SPEC §7.3): rendered
         ;; landings as a prompt section — the quality-signals board, because a
         ;; reviewer IS a quality signal deciding whether to trust itself.
-        codex-landings (codex-pin/landings-text :review (get-in ctx [:execution/logger]))
+        codex-outcome (codex-pin/landings-outcome :review (get-in ctx [:execution/logger]))
+        codex-landings (:text codex-outcome)
         behavior-addendum (phase/load-and-filter-behaviors
                             :review {:task {:task/intent (:intent input)}})
         task (cond-> {:task/id (random-uuid)
@@ -361,7 +363,8 @@
                codex-landings
                (assoc :task/codex-landings codex-landings))]
     {:task task
-     :rules-manifest manifest}))
+     :rules-manifest manifest
+     :codex-outcome codex-outcome}))
 
 (defn ^{:stratum 2} leave-review
   "Post-processing for review phase.
@@ -383,6 +386,9 @@
    The cycle count persists at [:execution :review-warning-only-cycles]
    across phase re-entries, like fingerprints."
   [ctx]
+  ;; Gap-instrument miss recording (T2 s3): best-effort, opt-in, and it
+  ;; must never change the outcome it measures.
+  (gap-wiring/record-phase-misses! ctx :review)
   (let [end-time    (System/currentTimeMillis)
         duration-ms (- end-time (get-in ctx [:phase :started-at]))
         result      (get-in ctx [:phase :result])
@@ -449,7 +455,7 @@
         _ (phase/emit-phase-started! ctx :review)
         reviewer-agent (agent/create-reviewer
                         (select-keys ctx [:llm-backend]))
-        {:keys [task rules-manifest]} (build-review-task ctx)
+        {:keys [task rules-manifest codex-outcome]} (build-review-task ctx)
         on-chunk (create-streaming-callback ctx :review)
         agent-ctx (cond-> ctx on-chunk (assoc :on-chunk on-chunk))
 
@@ -462,7 +468,16 @@
                    (response/failure e)))
 
         ;; Emit agent-completed telemetry event
-        _ (phase/emit-agent-completed! agent-ctx :review :reviewer result)]
+        _ (phase/emit-agent-completed! agent-ctx :review :reviewer result)
+
+        ;; SPEC §7.4.3 consultation provenance, prompt-section flavor. The
+        ;; reviewer session surfaces no reads log, so :pin-read? is nil
+        ;; (unknown). Attached before enter-context stores the result so
+        ;; gates and the gap ledger can see it.
+        result (if (map? (:output result))
+                 (assoc-in result [:output :codex/consultation]
+                           (codex-pin/consultation-summary codex-outcome nil))
+                 result)]
 
     (-> (phase/enter-context ctx :review :reviewer gates budget start-time result)
         (assoc-in [:phase :rules-manifest] rules-manifest))))

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/codex_pin_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/codex_pin_test.clj
@@ -53,9 +53,10 @@
         "a nil logger must not turn a configured-codex failure silent")))
 
 (deftest ^{:stratum 0} pin-outcome-states
-  (is (= {:entry nil :status :unconfigured :anomaly nil}
+  (is (= {:entry nil :status :unconfigured :anomaly nil
+          :situation "changing-one-side-of-a-boundary"}
          (codex-pin/pin-outcome :implement nil nil)))
-  (is (= {:entry nil :status :unmapped :anomaly nil}
+  (is (= {:entry nil :status :unmapped :anomaly nil :situation nil}
          (codex-pin/pin-outcome :verify nil "/anywhere")))
   (is (= :skipped
          (:status (codex-pin/pin-outcome :implement nil "/nonexistent/codex")))))
@@ -71,6 +72,7 @@
       (is (true? (:pin-read? (codex-pin/consultation-summary
                                pinned [{:path codex-pin/pin-path :source :cache}])))))
     (testing "skipped consultation carries its anomaly"
-      (is (= {:pinned? false :status :skipped :anomaly :codex-unreadable :pin-read? nil}
+      (is (= {:pinned? false :status :skipped :anomaly :codex-unreadable
+              :situation nil :pin-read? nil}
              (codex-pin/consultation-summary
                {:entry nil :status :skipped :anomaly :codex-unreadable} nil))))))

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/gap_wiring_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/gap_wiring_test.clj
@@ -1,0 +1,96 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.phase-software-factory.gap-wiring-test
+  "Signal fragments mirror the real producers' shapes: ReviewIssue maps,
+   decision-envelope Reason maps, the namespaced [:phase :phase/...] keys
+   the gate runner writes, and the [:phase :error] variants review/
+   implement attach."
+  (:require [ai.miniforge.codex-gap.interface :as gap]
+            [ai.miniforge.phase-software-factory.gap-wiring :as gap-wiring]
+            [clojure.test :refer [deftest is testing]]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} review-signals-prefer-maps-and-fall-back-to-strings
+  (testing "map-shaped issues win"
+    (is (= [{:type :review-blocking
+             :payload {:severity :blocking :description "d" :file "f.clj"}}]
+           (gap-wiring/review-signals
+             {:review/issues [{:severity :blocking :description "d" :file "f.clj"}
+                              {:severity :warning :description "w"}]
+              :review/blocking-issues ["d"]}))))
+  (testing "string fallback when no map-shaped issues exist"
+    (is (= [{:type :review-blocking :payload "gate says no"}]
+           (gap-wiring/review-signals
+             {:review/blocking-issues ["gate says no"]})))))
+
+(deftest ^{:stratum 0} gate-signals-read-the-namespaced-keys-only
+  (is (= [{:type :gate-failure
+           :payload {:reason/code :reason/gate-check-failed :reason/detail "x"}}]
+         (gap-wiring/gate-signals
+           {:phase/status :failed
+            :phase/gate-errors [{:reason/code :reason/gate-check-failed
+                                 :reason/detail "x"}]
+            ;; the bare key is leave-clobbered and must be ignored
+            :status :completed})))
+  (is (nil? (gap-wiring/gate-signals {:phase/status :completed
+                                      :phase/gate-errors []}))))
+
+(deftest ^{:stratum 0} terminal-signal-normalizes-onto-anomaly-category
+  (testing "hand-rolled review anomaly map"
+    (is (= {:type :terminal-anomaly
+            :payload {:anomaly/category :anomalies.review/needs-decomposition
+                      :anomaly/message "m"}}
+           (gap-wiring/terminal-signal
+             {:error {:message "m"
+                      :anomaly/category :anomalies.review/needs-decomposition
+                      :anomaly/message "m"}}))))
+  (testing "implement's plain error map (no category)"
+    (is (= {:type :terminal-anomaly
+            :payload {:anomaly/category nil :anomaly/message "agent failed"}}
+           (gap-wiring/terminal-signal {:error {:message "agent failed"}})))))
+
+(deftest ^{:stratum 0} recording-is-a-no-op-without-a-configured-codex
+  (let [dir (str (java.nio.file.Files/createTempDirectory
+                   "gap-wiring-test-"
+                   (into-array java.nio.file.attribute.FileAttribute [])))
+        ctx {:execution/checkpoint-root dir
+             :execution/id "run-x"
+             :phase {:phase/status :failed
+                     :phase/gate-errors [{:reason/code :reason/gate-check-failed
+                                          :reason/detail "x"}]}}]
+    (gap-wiring/record-phase-misses! ctx :implement nil)
+    (is (= {:entries [] :skipped 0}
+           (gap/read-ledger (str dir "/run-x")))
+        "no codex configured -> no gap to measure -> nothing written")))
+
+(deftest ^{:stratum 0} recording-never-throws-on-a-broken-codex-dir
+  (let [dir (str (java.nio.file.Files/createTempDirectory
+                   "gap-wiring-test-"
+                   (into-array java.nio.file.attribute.FileAttribute [])))
+        ctx {:execution/checkpoint-root dir
+             :execution/id "run-y"
+             :phase {:result {:output {:review/blocking-issues ["boom"]}}}}]
+    ;; unreadable codex: consider/load-graph return anomalies; entries
+    ;; still classify (landings-unavailable -> review queue) and record
+    (gap-wiring/record-phase-misses! ctx :review "/nonexistent/codex")
+    (let [{:keys [entries]} (gap/read-ledger (str dir "/run-y"))]
+      (is (= 1 (count entries)))
+      (is (= :review-queue (:miss/bucket (first entries))))
+      (is (= "quality-signal-might-be-lying"
+             (:miss/situation (first entries)))))))

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/gap_wiring_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/gap_wiring_test.clj
@@ -20,7 +20,8 @@
    decision-envelope Reason maps, the namespaced [:phase :phase/...] keys
    the gate runner writes, and the [:phase :error] variants review/
    implement attach."
-  (:require [ai.miniforge.codex-gap.interface :as gap]
+  (:require [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.codex-gap.interface :as gap]
             [ai.miniforge.phase-software-factory.gap-wiring :as gap-wiring]
             [clojure.test :refer [deftest is testing]]))
 
@@ -63,7 +64,14 @@
   (testing "implement's plain error map (no category)"
     (is (= {:type :terminal-anomaly
             :payload {:anomaly/category nil :anomaly/message "agent failed"}}
-           (gap-wiring/terminal-signal {:error {:message "agent failed"}})))))
+           (gap-wiring/terminal-signal {:error {:message "agent failed"}}))))
+  (testing "the canonical anomaly/sub-anomaly shape (review stagnation path)"
+    (let [err (anomaly/sub-anomaly :exhausted :anomalies.review/stagnation
+                                   "no movement" {:review/fingerprint-history []})]
+      (is (= {:type :terminal-anomaly
+              :payload {:anomaly/category :anomalies.review/stagnation
+                        :anomaly/message "no movement"}}
+             (gap-wiring/terminal-signal {:error err}))))))
 
 (deftest ^{:stratum 0} recording-is-a-no-op-without-a-configured-codex
   (let [dir (str (java.nio.file.Files/createTempDirectory

--- a/projects/miniforge-core/deps.edn
+++ b/projects/miniforge-core/deps.edn
@@ -15,6 +15,7 @@
         ai.miniforge/anomaly {:local/root "../../components/anomaly"}
         ai.miniforge/clock {:local/root "../../components/clock"}
         ai.miniforge/codex {:local/root "../../components/codex"}
+        ai.miniforge/codex-gap {:local/root "../../components/codex-gap"}
         ai.miniforge/coerce {:local/root "../../components/coerce"}
         ai.miniforge/content-hash {:local/root "../../components/content-hash"}
         ai.miniforge/logging {:local/root "../../components/logging"}

--- a/projects/miniforge-tui/deps.edn
+++ b/projects/miniforge-tui/deps.edn
@@ -19,6 +19,7 @@
         ai.miniforge/anomaly {:local/root "../../components/anomaly"}
         ai.miniforge/clock {:local/root "../../components/clock"}
         ai.miniforge/codex {:local/root "../../components/codex"}
+        ai.miniforge/codex-gap {:local/root "../../components/codex-gap"}
         ai.miniforge/coerce {:local/root "../../components/coerce"}
         ai.miniforge/content-hash {:local/root "../../components/content-hash"}
         ai.miniforge/logging {:local/root "../../components/logging"}

--- a/projects/miniforge/deps.edn
+++ b/projects/miniforge/deps.edn
@@ -22,6 +22,7 @@
         ai.miniforge/anomaly {:local/root "../../components/anomaly"}
         ai.miniforge/clock {:local/root "../../components/clock"}
         ai.miniforge/codex {:local/root "../../components/codex"}
+        ai.miniforge/codex-gap {:local/root "../../components/codex-gap"}
         ai.miniforge/coerce {:local/root "../../components/coerce"}
         ai.miniforge/content-hash {:local/root "../../components/content-hash"}
         ai.miniforge/logging {:local/root "../../components/logging"}


### PR DESCRIPTION
Task 2 of the [#1632](https://github.com/miniforge-ai/miniforge/pull/1632) spec, on merged [#1633](https://github.com/miniforge-ai/miniforge/pull/1633). Task 3 (gap report) runs as a parallel wave PR.

Every failure signal at implement/plan/review leave becomes a classified miss-ledger entry in the run's checkpoint dir:

1. **Signals** — review findings (map-shaped `:review/issues` preferred, string `:review/blocking-issues` fallback — the gate-only and parse-failure paths populate only strings), gate failures read off the NAMESPACED `[:phase :phase/status]` + `[:phase :phase/gate-errors]` (decision-envelope Reason maps; the bare `:status` is leave-clobbered), terminal anomalies normalized onto `:anomaly/category` at the writer.
2. **Opt-in + harmless** — no `MINIFORGE_CODEX_PATH` means no-op (no codex, no gap to measure); ledger anomalies log; an unexpected classification bug logs and continues; interrupts are rethrown so the boundary catch cannot eat cooperative cancellation. The instrument never changes the outcome it measures.
3. **Consultation carries `:situation`** (pin-outcome, landings-outcome, consultation-summary widened) so entries need no re-derivation — and the reviewer now attaches consultation provenance via a status-returning `landings-outcome`, closing the structural trap where every review miss classified `:undelivered`.

Tests: signal extraction against real producer shapes (incl. the bare-vs-namespaced key trap pinned in a test), no-op-without-codex, and broken-codex-dir recording (entries land in `:review-queue` with `:landings-unavailable`, nothing throws). 22 tests / 68 assertions across the touched bricks; poly check clean.

MINIFORGE_PR_BUDGET_OVERRIDE: baseline-file stratum annotation churn dominates (implement.clj, plan.clj, review.clj); functional diff ~230 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)