### PR TITLE
feat(codex-gap): gap report — ledgers + codex → the T2 §4 vector (gap spec Task 3)

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -570,7 +570,7 @@
   ;; ──────────────────────────────────────────────────────────────────────────
 
   codex-gap-report
-  {:doc "Render the Codex gap report (T2 s4) from run ledgers. Usage: bb codex-gap-report [checkpoint-root]; codex from MINIFORGE_CODEX_PATH"
+  {:doc "Render the Codex gap report (T2 §4) from run ledgers. Usage: bb codex-gap-report [checkpoint-root]; codex from MINIFORGE_CODEX_PATH"
    :extra-paths ["components/codex-gap/src"
                  "components/codex-gap/resources"
                  "components/codex/src"
@@ -583,7 +583,7 @@
                         (str (fs/path (System/getProperty "user.home")
                                       ".miniforge" "checkpoints")))
                dirs (when (fs/directory? root)
-                      (filter fs/directory? (fs/list-dir root)))
+                      (sort (filter fs/directory? (fs/list-dir root))))
                reads (map (fn [d] (codex-gap/read-ledger (str d))) dirs)
                entries (vec (mapcat :entries reads))
                skipped (reduce + 0 (keep :skipped reads))

--- a/bb.edn
+++ b/bb.edn
@@ -569,6 +569,32 @@
   ;; MCP Context Server
   ;; ──────────────────────────────────────────────────────────────────────────
 
+  codex-gap-report
+  {:doc "Render the Codex gap report (T2 s4) from run ledgers. Usage: bb codex-gap-report [checkpoint-root]; codex from MINIFORGE_CODEX_PATH"
+   :extra-paths ["components/codex-gap/src"
+                 "components/codex-gap/resources"
+                 "components/codex/src"
+                 "components/codex/resources"
+                 "components/messages/src"
+                 "components/messages/resources"]
+   :requires ([ai.miniforge.codex-gap.interface :as codex-gap]
+              [babashka.fs :as fs])
+   :task (let [root (or (first *command-line-args*)
+                        (str (fs/path (System/getProperty "user.home")
+                                      ".miniforge" "checkpoints")))
+               dirs (when (fs/directory? root)
+                      (filter fs/directory? (fs/list-dir root)))
+               reads (map (fn [d] (codex-gap/read-ledger (str d))) dirs)
+               entries (vec (mapcat :entries reads))
+               skipped (reduce + 0 (keep :skipped reads))
+               anchoring (some-> (System/getenv "MINIFORGE_CODEX_PATH")
+                                 codex-gap/codex-anchoring-stats)]
+           (println (codex-gap/render-report
+                     (codex-gap/build-report
+                      entries {:skipped skipped
+                               :run-count (count (filter (fn [r] (seq (:entries r))) reads))
+                               :anchoring anchoring}))))}
+
   mcp-context-server
   {:doc     "Run MCP context server (JSON-RPC 2.0 over stdin/stdout)"
    :extra-paths ["bases/mcp-context-server/src"

--- a/components/codex-gap/deps.edn
+++ b/components/codex-gap/deps.edn
@@ -1,9 +1,6 @@
 {:paths ["src" "resources"]
- ;; No component deps yet: the classifier consumes codex data (landings,
- ;; problems) as arguments, and no operator prose exists in this slice —
- ;; the gap-report task adds ai.miniforge/codex + ai.miniforge/messages
- ;; when it arrives.
- :deps {}
+ :deps {ai.miniforge/codex {:local/root "../codex"}
+        ai.miniforge/messages {:local/root "../messages"}}
  :aliases
  {:test {:extra-paths ["test" "test-resources"]
          :extra-deps {io.github.cognitect-labs/test-runner

--- a/components/codex-gap/resources/config/codex-gap/messages/en-US.edn
+++ b/components/codex-gap/resources/config/codex-gap/messages/en-US.edn
@@ -1,0 +1,14 @@
+{:codex-gap/messages
+ {;; gap report rendering (T2 §4) — a VECTOR, never a scalar rollup
+  :report/header            "Codex gap report — {entry-count} misses across {run-count} run(s){skipped}"
+  :report/skipped-suffix    ", {n} unreadable ledger line(s) skipped"
+  :report/coverage          "coverage: {covered} of {total} misses carried a situation; consultation-match-rate: not instrumented"
+  :report/routing           "routing: {misrouted} of {attributed} attributed misses landed on problems the entered board cannot reach"
+  :report/anchoring         "anchoring: {problems} problems, {unanchored} unanchored, {speculative} speculative"
+  :report/anchoring-unavailable "anchoring: codex unavailable at report time"
+  :report/delivery          "delivery: {undelivered} undelivered; pin reads — {read} read, {unread} unread, {unknown} unknown"
+  :report/attention         "attention: {unheeded} misses matched a landing that was in front of the consumer"
+  :report/learning          "learning: not instrumented; {open} open harvest candidates (uncovered + queued)"
+  :report/review-queue      "review queue: {count} unresolved attribution(s) — excluded from every rate above"
+  :report/bucket-members    "  {bucket}: {ids}"
+  :report/no-members        "  (none)"}}

--- a/components/codex-gap/src/ai/miniforge/codex_gap/interface.clj
+++ b/components/codex-gap/src/ai/miniforge/codex_gap/interface.clj
@@ -27,7 +27,8 @@
    plumbing, :unheeded -> delivery form / landing actionability."
   (:require [ai.miniforge.codex-gap.attribute :as attribute]
             [ai.miniforge.codex-gap.classify :as classify]
-            [ai.miniforge.codex-gap.ledger :as ledger]))
+            [ai.miniforge.codex-gap.ledger :as ledger]
+            [ai.miniforge.codex-gap.report :as report]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -68,3 +69,20 @@
    -> problem id) from the classpath resource."
   []
   (attribute/load-gate-reason-map))
+
+(defn ^{:stratum 0} build-report
+  "Ledger entries + {:skipped :run-count :anchoring} -> the T2 §4 gap
+   VECTOR. Every slot carries its member miss ids; no scalar rollup
+   exists or may be derived."
+  [entries opts]
+  (report/build-report entries opts))
+
+(defn ^{:stratum 0} render-report
+  "The gap vector as catalog-backed text."
+  [report-map]
+  (report/render-report report-map))
+
+(defn ^{:stratum 0} codex-anchoring-stats
+  "The §4.1.3 anchoring slot from the codex graph, or nil when unreadable."
+  [codex-dir]
+  (report/codex-anchoring-stats codex-dir))

--- a/components/codex-gap/src/ai/miniforge/codex_gap/messages.clj
+++ b/components/codex-gap/src/ai/miniforge/codex_gap/messages.clj
@@ -1,0 +1,28 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.codex-gap.messages
+  "Component-level message catalog for codex-gap.
+   Delegates to the shared messages component."
+  (:require [ai.miniforge.messages.interface :as messages]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} t
+  "Look up a codex-gap message by key, with optional param substitution."
+  (messages/create-translator "config/codex-gap/messages/en-US.edn"
+                              :codex-gap/messages))

--- a/components/codex-gap/src/ai/miniforge/codex_gap/report.clj
+++ b/components/codex-gap/src/ai/miniforge/codex_gap/report.clj
@@ -1,0 +1,122 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.codex-gap.report
+  "The gap report (T2 §4): ledger entries + codex -> the gap VECTOR.
+
+   Deliberately no scalar rollup anywhere: a single codex-health number
+   would let a consumer compare and rank, which is the false comfort T1
+   §1.2 prohibits — the components stay separately visible so the absent
+   one is noticeable. Every slot links its member misses (§4.2): the
+   report IS the improvement agenda, and each bucket names its fix
+   channel. Rates whose denominators are not crisply defined in v0
+   (consultation-match, learning latency) are reported as
+   not-instrumented rather than approximated — the vector confesses."
+  (:require [ai.miniforge.codex-gap.messages :as msg]
+            [ai.miniforge.codex.interface :as codex]
+            [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} codex-anchoring-stats
+  "The §4.1.3 anchoring slot straight off the codex graph, or nil when the
+   codex is unreadable (the renderer says so rather than hiding the slot)."
+  [codex-dir]
+  (let [{:keys [nodes] :as graph} (codex/load-graph codex-dir)]
+    (when-not (:codex/anomaly graph)
+      (let [problems (filter #(= "problem" (:type %)) (vals nodes))]
+        {:problems (count problems)
+         :unanchored (count (filter #(empty? (:scars %)) problems))
+         :speculative (count (filter #(= "speculative" (:confidence %)) problems))}))))
+
+(defn ^{:stratum 0} build-report
+  "Pure: ledger entries (+ total skipped-line count and run count) and
+   optional anchoring stats -> the gap vector. Every slot carries its
+   member miss ids."
+  [entries {:keys [skipped run-count anchoring]}]
+  (let [by-bucket (group-by :miss/bucket entries)
+        ids #(mapv :miss/id (get by-bucket % []))
+        delivered (get by-bucket :unheeded [])
+        pin-reads (frequencies (map #(get-in % [:miss/consultation :pin-read?])
+                                    delivered))
+        attributed (+ (count (get by-bucket :misrouted []))
+                      (count (get by-bucket :undelivered []))
+                      (count delivered))]
+    {:entry-count (count entries)
+     :run-count (or run-count 1)
+     :skipped (or skipped 0)
+     :coverage {:covered (count (remove #(= :uncovered (:miss/bucket %)) entries))
+                :total (count entries)
+                :consultation-match-rate :not-instrumented
+                :misses (ids :uncovered)}
+     :routing {:misrouted (count (get by-bucket :misrouted []))
+               :attributed attributed
+               :misses (ids :misrouted)}
+     :anchoring (or anchoring :codex-unavailable)
+     :delivery {:undelivered (count (get by-bucket :undelivered []))
+                :pin-read {:read (get pin-reads true 0)
+                           :unread (get pin-reads false 0)
+                           :unknown (get pin-reads nil 0)}
+                :misses (ids :undelivered)}
+     :attention {:unheeded (count delivered)
+                 :misses (ids :unheeded)}
+     :learning {:status :not-instrumented
+                :open (+ (count (get by-bucket :uncovered []))
+                         (count (get by-bucket :review-queue []))
+                         (count (get by-bucket :novel [])))}
+     :review-queue {:count (count (get by-bucket :review-queue []))
+                    :misses (ids :review-queue)}}))
+
+(defn- ^{:stratum 0} members-line [bucket ids]
+  (if (seq ids)
+    (msg/t :report/bucket-members {:bucket (name bucket)
+                                   :ids (str/join ", " (map str ids))})
+    (msg/t :report/no-members)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} render-report
+  "The gap vector as catalog-backed text, one slot per line, member miss
+   ids beneath the slots that carry them."
+  [{:keys [entry-count run-count skipped coverage routing anchoring
+           delivery attention learning review-queue]}]
+  (str/join "\n"
+    [(msg/t :report/header
+            {:entry-count entry-count
+             :run-count run-count
+             :skipped (if (pos? skipped)
+                        (msg/t :report/skipped-suffix {:n skipped})
+                        "")})
+     (msg/t :report/coverage {:covered (:covered coverage)
+                              :total (:total coverage)})
+     (members-line :uncovered (:misses coverage))
+     (msg/t :report/routing {:misrouted (:misrouted routing)
+                             :attributed (:attributed routing)})
+     (members-line :misrouted (:misses routing))
+     (if (map? anchoring)
+       (msg/t :report/anchoring anchoring)
+       (msg/t :report/anchoring-unavailable))
+     (msg/t :report/delivery {:undelivered (:undelivered delivery)
+                              :read (get-in delivery [:pin-read :read])
+                              :unread (get-in delivery [:pin-read :unread])
+                              :unknown (get-in delivery [:pin-read :unknown])})
+     (members-line :undelivered (:misses delivery))
+     (msg/t :report/attention {:unheeded (:unheeded attention)})
+     (members-line :unheeded (:misses attention))
+     (msg/t :report/learning {:open (:open learning)})
+     (msg/t :report/review-queue {:count (:count review-queue)})
+     (members-line :review-queue (:misses review-queue))]))

--- a/components/codex-gap/src/ai/miniforge/codex_gap/report.clj
+++ b/components/codex-gap/src/ai/miniforge/codex_gap/report.clj
@@ -77,7 +77,10 @@
      :learning {:status :not-instrumented
                 :open (+ (count (get by-bucket :uncovered []))
                          (count (get by-bucket :review-queue []))
-                         (count (get by-bucket :novel [])))}
+                         (count (get by-bucket :novel [])))
+                :misses (vec (concat (ids :uncovered)
+                                     (ids :review-queue)
+                                     (ids :novel)))}
      :review-queue {:count (count (get by-bucket :review-queue []))
                     :misses (ids :review-queue)}}))
 
@@ -118,5 +121,6 @@
      (msg/t :report/attention {:unheeded (:unheeded attention)})
      (members-line :unheeded (:misses attention))
      (msg/t :report/learning {:open (:open learning)})
+     (members-line :learning (:misses learning))
      (msg/t :report/review-queue {:count (:count review-queue)})
      (members-line :review-queue (:misses review-queue))]))

--- a/components/codex-gap/test/ai/miniforge/codex_gap/interface_test.clj
+++ b/components/codex-gap/test/ai/miniforge/codex_gap/interface_test.clj
@@ -195,7 +195,11 @@
       (is (= 1 (get-in r [:review-queue :count]))))
     (testing "every slot links member miss ids (T2 §4.2)"
       (is (= 1 (count (get-in r [:coverage :misses]))))
-      (is (= 2 (count (get-in r [:attention :misses])))))
+      (is (= 1 (count (get-in r [:routing :misses]))))
+      (is (= 1 (count (get-in r [:delivery :misses]))))
+      (is (= 2 (count (get-in r [:attention :misses]))))
+      (is (= 2 (count (get-in r [:learning :misses]))))
+      (is (= 1 (count (get-in r [:review-queue :misses])))))
     (testing "no scalar rollup key exists"
       (is (nil? (:score r)))
       (is (nil? (:health r))))

--- a/components/codex-gap/test/ai/miniforge/codex_gap/interface_test.clj
+++ b/components/codex-gap/test/ai/miniforge/codex_gap/interface_test.clj
@@ -53,6 +53,11 @@
 (deftest ^{:stratum 0} missing-ledger-reads-as-empty-not-error
   (is (= {:entries [] :skipped 0} (gap/read-ledger "/nonexistent/run/dir"))))
 
+(deftest ^{:stratum 0} gap-report-confesses-unavailable-anchoring
+  (let [r (gap/build-report [] {})]
+    (is (= :codex-unavailable (:anchoring r)))
+    (is (re-find #"anchoring: codex unavailable" (gap/render-report r)))))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (deftest ^{:stratum 1} no-situation-classifies-uncovered-first
@@ -169,3 +174,35 @@
                                                      :consultation nil :bucket :uncovered
                                                      :attribution nil}))]
     (is (= :ledger-write-failed (:codex-gap/anomaly r)))))
+
+(deftest ^{:stratum 1} gap-report-is-a-vector-with-member-ids-and-no-scalar
+  (let [mk (fn [bucket pin-read]
+             (gap/build-entry {:run-id "r" :phase :implement
+                               :signal drift-signal
+                               :situation "s" :consultation {:status :pinned :pin-read? pin-read}
+                               :bucket bucket :attribution nil}))
+        entries [(mk :uncovered nil) (mk :misrouted nil) (mk :undelivered nil)
+                 (mk :unheeded true) (mk :unheeded nil) (mk :review-queue nil)]
+        r (gap/build-report entries {:skipped 1 :run-count 2 :anchoring
+                                     {:problems 22 :unanchored 4 :speculative 5}})]
+    (testing "slot counts"
+      (is (= {:covered 5 :total 6} (select-keys (:coverage r) [:covered :total])))
+      (is (= 1 (get-in r [:routing :misrouted])))
+      (is (= 4 (get-in r [:routing :attributed])))
+      (is (= {:read 1 :unread 0 :unknown 1} (get-in r [:delivery :pin-read])))
+      (is (= 2 (get-in r [:attention :unheeded])))
+      (is (= 2 (get-in r [:learning :open])))
+      (is (= 1 (get-in r [:review-queue :count]))))
+    (testing "every slot links member miss ids (T2 §4.2)"
+      (is (= 1 (count (get-in r [:coverage :misses]))))
+      (is (= 2 (count (get-in r [:attention :misses])))))
+    (testing "no scalar rollup key exists"
+      (is (nil? (:score r)))
+      (is (nil? (:health r))))
+    (testing "renders through the catalog with slots and members"
+      (let [text (gap/render-report r)]
+        (is (re-find #"Codex gap report — 6 misses across 2 run" text))
+        (is (re-find #"coverage: 5 of 6" text))
+        (is (re-find #"routing: 1 of 4" text))
+        (is (re-find #"anchoring: 22 problems, 4 unanchored, 5 speculative" text))
+        (is (re-find #"review queue: 1" text))))))


### PR DESCRIPTION
Task 3 of the [#1632](https://github.com/miniforge-ai/miniforge/pull/1632) spec, on merged [#1633](https://github.com/miniforge-ai/miniforge/pull/1633); wave partner of [#1634](https://github.com/miniforge-ai/miniforge/pull/1634) (independent — this reads ledgers, that writes them).

`build-report` aggregates ledger entries into the T2 §4 gap vector: coverage, routing, anchoring (straight off the codex graph, or an explicit `codex-unavailable` confession), delivery with the pin-read tri-state distribution, attention, learning, and the review-queue backlog. The load-bearing properties, each pinned by a test:

1. **Every slot links its member miss ids** (§4.2) — the report IS the improvement agenda, and an improvement PR names the bucket it drains.
2. **No scalar rollup exists** — a test asserts the absence; a single codex-health number is the false comfort T1 §1.2 prohibits.
3. **The vector confesses** — rates whose denominators aren't crisply defined in v0 (consultation-match rate, learning latency) render as "not instrumented", never approximated.

`bb codex-gap-report [checkpoint-root]` sweeps `<root>/*/codex-gap-ledger.edn`, merges, and prints; codex anchoring comes from `MINIFORGE_CODEX_PATH`. Smoke-tested against the live operator codex (anchoring: 22 problems, 4 unanchored, 5 speculative) and the empty-root path. Rendering through a new codex-gap message catalog; component deps gain codex + messages exactly as the Task 1 PR forecast.

13 tests / 46 assertions in the brick; poly check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)