### PR TITLE
spec: reconcile N7 operational policy contracts

### DIFF
--- a/docs/pull-requests/2026-08-04-codex-n7-contract-reconciliation.md
+++ b/docs/pull-requests/2026-08-04-codex-n7-contract-reconciliation.md
@@ -1,0 +1,61 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# spec: reconcile N7 operational policy contracts
+
+## Overview
+
+Makes N7 a current, internally consistent implementation contract before OPSV
+code is introduced. It aligns the extension with the live N1/N3/N6 wire
+contracts and the later N8/N10 governance model.
+
+## Motivation
+
+The original N7 predates governed effect grants, emergency-stop semantics, and
+the repository's current extension catalog. It also cites the wrong N3 section,
+uses event names that differ from N3, and treats `APPLY_ALLOWED` as both intent
+and authority. Implementing those contradictions would produce unsafe or
+nonconforming behavior.
+
+## Layer
+
+Foundations — normative contracts only.
+
+## Depends on
+
+- [miniforge#1638](https://github.com/miniforge-ai/miniforge/pull/1638) — merged
+
+## Changes in Detail
+
+- Reconcile N7 phases, event names, evidence correlation, and cross-references.
+- Define direct apply as a requested intent that still requires N10 execution
+  authority and transactional rollback behavior.
+- Integrate N8 emergency stop and safe-mode behavior.
+- Make failed verification a hard block for direct mutation.
+- Repair the specification catalog and README extension guidance.
+
+## Test plan
+
+- Validate every N7 cross-reference and duplicated wire contract against its
+  owning core spec.
+- Run Markdown formatting and the full pre-commit gate.
+- Adversarially trace recommend-only, PR-only, direct-apply, verification
+  failure, guardrail abort, and emergency-stop paths.
+
+## Deployment Plan
+
+Merge before replacing the stale N7 work specs or implementing OPSV components.
+
+## Related Issues/PRs
+
+- [miniforge-ai/miniforge-standards#96](https://github.com/miniforge-ai/miniforge-standards/pull/96)
+
+## Checklist
+
+- [ ] Core and extension contracts agree
+- [ ] Unsafe override paths are eliminated
+- [ ] Specification catalog is complete
+- [ ] Repository checks pass

--- a/docs/pull-requests/2026-08-04-codex-n7-contract-reconciliation.md
+++ b/docs/pull-requests/2026-08-04-codex-n7-contract-reconciliation.md
@@ -45,6 +45,11 @@ Foundations — normative contracts only.
 - Adversarially trace recommend-only, PR-only, direct-apply, verification
   failure, guardrail abort, and emergency-stop paths.
 
+`bb pre-commit` passes for every commit slice (338 smoke tests / 1,281
+assertions and 8 GraalVM/Babashka compatibility tests / 572 assertions).
+Local-link validation reports no missing targets, and every file under
+`specs/normative/` appears in `SPEC_INDEX.md`.
+
 ## Deployment Plan
 
 Merge before replacing the stale N7 work specs or implementing OPSV components.
@@ -55,7 +60,7 @@ Merge before replacing the stale N7 work specs or implementing OPSV components.
 
 ## Checklist
 
-- [ ] Core and extension contracts agree
-- [ ] Unsafe override paths are eliminated
-- [ ] Specification catalog is complete
-- [ ] Repository checks pass
+- [x] Core and extension contracts agree
+- [x] Unsafe override paths are eliminated
+- [x] Specification catalog is complete
+- [x] Repository checks pass

--- a/specs/README.md
+++ b/specs/README.md
@@ -12,14 +12,12 @@ This directory contains the **canonical specifications** for the miniforge ecosy
 
 The miniforge ecosystem comprises three products built on a shared kernel:
 
-- **MiniForge Core** — the governed workflow engine (kernel/runtime). Normative specs N1-N6 define its contract:
-  architecture, workflow execution, event stream, policy packs, interface standards, and evidence/provenance. Any
-  product built on the engine must conform to these six specs.
+- **MiniForge Core** — the governed workflow engine (kernel/runtime). Normative specs N1-N6 plus applicable indexed
+  amendments define its contract. Any product built on the engine must conform to that applicable set.
 - **Miniforge** — the autonomous software factory (SDLC product). Consumes MiniForge Core and adds SDLC-specific
-  capabilities defined in N5 and N7-N10 (fleet mode, observability control, external PR integration, governed tool
-  execution).
+  amendments and N7+ capabilities assigned by [SPEC_INDEX.md](SPEC_INDEX.md).
 - **Data Foundry** — a generic ETL product built on MiniForge Core. Consumes the same N1-N6 engine contract with
-  ETL-specific workflow packs and policy configurations.
+  ETL-specific workflow packs, policy configurations, and only the amendments whose scope applies.
 
 ## Entry Point
 
@@ -39,36 +37,34 @@ specs/
 │   ├── N3-event-stream.md    # ✅ Complete
 │   ├── N4-policy-packs.md
 │   ├── N5-cli-tui-api.md
-│   └── N6-evidence-provenance.md  # ✅ Complete
+│   ├── N6-evidence-provenance.md  # ✅ Complete
+│   ├── N7-... through N15-...     # Indexed extension specs
+│   └── N*-delta-*.md              # Indexed amendments to a named base spec
 ├── informative/               # Guidance & references (non-normative)
-│   ├── software-factory-vision.md
-│   ├── oss-paid-roadmap.md
 │   ├── ux-tui-mockups.md
-│   └── ai-ux-flows.md
-├── examples/                  # Reference implementations
-│   ├── workflows/
-│   ├── evidence/
-│   └── policy-packs/
+│   ├── ai-ux-flows.md
+│   └── I-*.md                  # Informative contract and design notes
 └── deprecated/                # Superseded documents (historical reference)
     ├── AGENT_STATUS_STREAMING.md  → Superseded by N3
     ├── BUILD_PLAN_REVISED.md      → Content extracted to N2, N3, N6
-    ├── OSS_PAID_ROADMAP.md        → Superseded by informative/oss-paid-roadmap.md
+    ├── OSS_PAID_ROADMAP.md        → Superseded; current strategy is private
     └── ...
 ```
 
 ## Normative vs. Informative
 
-### Normative Specifications (N1-N6) — MiniForge Core Contract
+### Normative Specifications
 
-**Normative specs N1-N6** define the **contractual requirements** for MiniForge Core — the shared engine that both
-  Miniforge (SDLC) and Data Foundry consume.
+**Core specs N1-N6** define the universal MiniForge Core contract. Indexed deltas amend a named base spec, and N7+
+extensions define scoped product or capability contracts. The applicability table in [SPEC_INDEX.md](SPEC_INDEX.md) is
+authoritative.
 
 - Use RFC 2119 keywords: MUST, SHALL, SHOULD, MAY
 - Breaking changes require version bump
 - Implementations MUST conform to pass conformance tests
 - Changes require careful review
 
-**Current normative specs:**
+**Core normative specs:**
 
 1. **N1 - Core Architecture** (Draft) - Conceptual model, layering, Polylith boundaries
 2. **N2 - Workflow Execution** (Draft) - Phase graph, inner loop, gate contract
@@ -84,14 +80,14 @@ specs/
 - Use descriptive language (no MUST/SHALL)
 - Can change without version bumps
 - Inform normative specs but don't constrain them
-- Include UX mockups, guides, roadmaps, vision documents
+- Include UX mockups and design/contract notes
 
 ## Rules to Prevent Spec Explosion
 
-1. **No new normative spec files** - Only amend N1-N6
-2. **Every new concept must land in N1** - Or it's not real
-3. **Every new runtime datum must land in N3 or N6** - Or it's unobservable
-4. **Every UX feature must point to a contract** - Or it's just a mock
+1. **Amend the owning spec by default** - Do not duplicate a contract
+2. **Index every delta and extension** - Unindexed normative files are invalid
+3. **Name scope and relationships** - Deltas name their base; extensions relate to N1-N6
+4. **Centralize wire contracts** - Events/evidence/UX live in N3/N6/N5
 5. **Roadmaps never contain contracts** - They link to specs
 
 ## For Implementers
@@ -99,34 +95,30 @@ specs/
 **To implement miniforge:**
 
 1. Read [SPEC_INDEX.md](SPEC_INDEX.md) for overview
-2. Study normative specs N1-N6 (start with N3, N6)
+2. Study N1-N6 and every amendment/extension applicable to the target product
 3. Refer to informative docs for guidance
-4. Use examples for reference implementations
-5. Pass conformance tests
+4. Pass conformance tests
 
 **To propose changes:**
 
-1. Check if concept belongs in existing N1-N6
-2. If new concept → amend N1 first
-3. If new runtime data → amend N3 or N6
-4. If new UX feature → link to contract in N3/N5/N6
-5. Update examples to demonstrate change
+1. Check whether an indexed spec already owns the capability
+2. Amend the owner unless a separately scoped delta/extension is approved
+3. Add event/evidence/UX wire contracts to N3/N6/N5
+4. Update `SPEC_INDEX.md` with scope and applicability
 
 ## For AI Agents (Claude, Codex, etc.)
 
 **When building miniforge:**
 
 1. **Always start with SPEC_INDEX.md** - It's your entry point
-2. **Normative specs (N1-N6) are authoritative** - These define MUST/SHALL
+2. **The indexed applicable normative set is authoritative** - Core plus scoped amendments/extensions define MUST/SHALL
 3. **Ignore deprecated/ directory** - Content superseded, use normative specs
 4. **Informative docs provide context** - But don't define requirements
-5. **Examples show conformance** - Use them as patterns
 
 **If confused about a requirement:**
 
 - Check N3 (events) or N6 (evidence) first - most implementation details live there
 - Cross-reference: normative specs link to each other
-- Check examples/ for concrete demonstrations
 
 ## Conformance Testing
 
@@ -137,7 +129,8 @@ Normative specs are enforced by:
 - **CLI contract tests** - Command interface stability
 - **Integration tests** - End-to-end workflow execution
 
-See `miniforge/tests/` for conformance test suite.
+Conformance tests live alongside the Polylith components and project integrations
+that implement each contract.
 
 ---
 
@@ -147,7 +140,7 @@ See `miniforge/tests/` for conformance test suite.
 
 **Understanding the product?**
 → [SPEC_INDEX.md](SPEC_INDEX.md) (1-paragraph summary)
-→ [informative/software-factory-vision.md](informative/software-factory-vision.md)
+→ [N1 - Core Architecture](normative/N1-architecture.md)
 
 **Building agents?**
 → [N3 - Event Stream](normative/N3-event-stream.md) (emit events)
@@ -160,16 +153,15 @@ See `miniforge/tests/` for conformance test suite.
 
 **Building policy packs?**
 → [N4 - Policy Packs](normative/N4-policy-packs.md)
-→ [examples/policy-packs/](examples/policy-packs/)
 
 **Understanding workflow execution?**
 → [N2 - Workflow Execution](normative/N2-workflows.md)
 → [N6 - Evidence & Provenance](normative/N6-evidence-provenance.md) (semantic validation)
 
 **OSS vs Paid split?**
-→ [informative/oss-paid-roadmap.md](informative/oss-paid-roadmap.md)
+→ [SPEC_INDEX.md](SPEC_INDEX.md) (applicability table)
 
 ---
 
-**Version:** 0.1.0-draft
-**Last Updated:** 2026-01-23
+**Version:** 0.2.0-draft
+**Last Updated:** 2026-08-04

--- a/specs/README.md
+++ b/specs/README.md
@@ -66,12 +66,12 @@ authoritative.
 
 **Core normative specs:**
 
-1. **N1 - Core Architecture** (Draft) - Conceptual model, layering, Polylith boundaries
-2. **N2 - Workflow Execution** (Draft) - Phase graph, inner loop, gate contract
-3. **N3 - Event Stream** (Draft) ✅ - Event protocol, streaming API, observability
-4. **N4 - Policy Packs** (Draft) - Policy pack standard, gate execution
-5. **N5 - CLI/TUI/API** (Draft) - User interface contract, command taxonomy
-6. **N6 - Evidence & Provenance** (Draft) ✅ - Evidence bundles, artifact provenance, semantic validation
+1. **N1 - Core Architecture** - Conceptual model, layering, Polylith boundaries
+2. **N2 - Workflow Execution** - Phase graph, inner loop, gate contract
+3. **N3 - Event Stream** - Event protocol, streaming API, observability
+4. **N4 - Policy Packs** - Policy pack standard, gate execution
+5. **N5 - CLI/TUI/API** - User interface contract, command taxonomy
+6. **N6 - Evidence & Provenance** - Evidence bundles, artifact provenance, semantic validation
 
 ### Informative Documentation
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -43,7 +43,7 @@ specs/
 ├── informative/               # Guidance & references (non-normative)
 │   ├── ux-tui-mockups.md
 │   ├── ai-ux-flows.md
-│   └── I-*.md                  # Informative contract and design notes
+│   └── *.md                    # Informative contract, design, and system notes
 └── deprecated/                # Superseded documents (historical reference)
     ├── AGENT_STATUS_STREAMING.md  → Superseded by N3
     ├── BUILD_PLAN_REVISED.md      → Content extracted to N2, N3, N6

--- a/specs/SPEC_INDEX.md
+++ b/specs/SPEC_INDEX.md
@@ -391,7 +391,6 @@ These documents provide guidance, examples, and context but do NOT define contra
 
 - [informative/CONFIG-SYSTEM.md](informative/CONFIG-SYSTEM.md) - Configuration precedence and ownership
 - [informative/tool-registry.md](informative/tool-registry.md) - Tool registry guidance
-- [informative/I-PHASE-HANDOFF-ENVELOPES.md](informative/I-PHASE-HANDOFF-ENVELOPES.md) - Phase handoff envelopes
 - [Workflow supervision architecture](informative/I-WORKFLOW-SUPERVISION-MACHINE-ARCHITECTURE.md) - Design note
 
 > Product strategy documents (pricing, roadmap, competitive positioning) are maintained

--- a/specs/SPEC_INDEX.md
+++ b/specs/SPEC_INDEX.md
@@ -392,9 +392,7 @@ These documents provide guidance, examples, and context but do NOT define contra
 - [informative/CONFIG-SYSTEM.md](informative/CONFIG-SYSTEM.md) - Configuration precedence and ownership
 - [informative/tool-registry.md](informative/tool-registry.md) - Tool registry guidance
 - [informative/I-PHASE-HANDOFF-ENVELOPES.md](informative/I-PHASE-HANDOFF-ENVELOPES.md) - Phase handoff envelopes
--
-  [informative/I-WORKFLOW-SUPERVISION-MACHINE-ARCHITECTURE.md](informative/I-WORKFLOW-SUPERVISION-MACHINE-ARCHITECTURE.m
-  d) - Workflow supervision design
+- [Workflow supervision architecture](informative/I-WORKFLOW-SUPERVISION-MACHINE-ARCHITECTURE.md) - Design note
 
 > Product strategy documents (pricing, roadmap, competitive positioning) are maintained
 > in the private [miniforge-fleet](https://github.com/miniforge-ai/miniforge-fleet) repository.

--- a/specs/SPEC_INDEX.md
+++ b/specs/SPEC_INDEX.md
@@ -6,7 +6,7 @@
 
 # miniforge Specification Index
 
-**Version:** 0.8.0-draft
+**Version:** 0.9.0-draft
 **Date:** 2026-08-04
 **Status:** Living specification during OSS development
 
@@ -16,12 +16,12 @@
 
 These specifications define three products built on a shared kernel:
 
-- **MiniForge Core** (N1-N6) — the governed workflow engine. These six core specs define the engine contract that all
-  products must conform to.
-- **Miniforge** (N1-N10) — the autonomous software factory for SDLC. Consumes Core plus extension specs N7-N10 for fleet
-  operations, observability control, external PR integration, and governed tool execution.
-- **Data Foundry** (N1-N6) — a generic ETL product. Consumes the same Core engine contract with domain-specific workflow
-  packs and policy configurations.
+- **MiniForge Core** (N1-N6 plus applicable indexed amendments) — the governed workflow engine contract shared by all
+  products.
+- **Miniforge** — the autonomous software factory for SDLC. Consumes Core plus the Miniforge-scoped extensions and
+  amendments in the applicability table below.
+- **Data Foundry** — a generic ETL product. Consumes Core plus only the indexed amendments that declare applicability to
+  its workflow/runtime capabilities.
 
 ---
 
@@ -53,9 +53,22 @@ They use RFC 2119 terminology (MUST, SHALL, SHOULD, MAY).
   and evidence. These define the shared engine consumed by all products (Miniforge SDLC, Data Foundry, and any future
   product).
 
-**Extension specs (N7+) — product-specific capabilities.** Cross-cutting capabilities that extend core specs. Currently
-  these are Miniforge SDLC concerns (Fleet Mode, Control Interface, PR Integration, Governed Tool Execution); Data
-  Foundry does not consume N7-N10.
+**Amendments and extension specs — scoped capabilities.** Indexed delta specs amend a named base contract. N7+ specs
+  define product or capability extensions. Applicability is explicit rather than inferred from the filename alone.
+
+### Applicability
+
+| Spec set | Applies to |
+|----------|------------|
+| N1-N6 | Every product built on MiniForge Core |
+| N2 checkpoint/resume delta | Implementations that persist workflow state |
+| N4 policy-compilation delta | Implementations that originate compiled policy packs |
+| N5 supervisory deltas | Miniforge SDLC control-plane producers and consumers |
+| N7-N10 | Miniforge Fleet/SDLC capabilities |
+| N11 + runtime-adapter delta | Governed task runtimes in Core and consuming products |
+| N12-N13 | Miniforge agent context and policy-guidance runtime |
+| N14 | Experimental Miniforge deliberation runs, scoped by N14 §0.4 |
+| N15 | minibench/workbench evaluation protocol and N14 promotion gates |
 
 ### N1 — Core Architecture & Concepts ✅
 
@@ -162,6 +175,18 @@ Defines:
 - **Reliability evidence:** SLI measurements, failure class, workflow tier, degradation mode in outcome (§2.6)
 - **Evaluation artifacts:** Golden set and eval-run-result artifact types (§3.1.1)
 
+### Indexed normative amendments
+
+| File | Base contract | Applicability |
+|------|---------------|---------------|
+| [N2-delta-phase-checkpoint-and-resume.md](normative/N2-delta-phase-checkpoint-and-resume.md) | N2 | Persisted workflow state |
+| [N4-delta-policy-compilation-contract.md](normative/N4-delta-policy-compilation-contract.md) | N4 | Policy-pack origination |
+| [N5-delta-supervisory-control-plane.md](normative/N5-delta-supervisory-control-plane.md) | N5 | Miniforge supervisory UI/API |
+| [N5-delta-2-pr-scoring.md](normative/N5-delta-2-pr-scoring.md) | N5 supervisory | Miniforge PR fleet |
+| [N5-delta-3-observational-entities.md](normative/N5-delta-3-observational-entities.md) | N5 supervisory | Miniforge entity projections |
+| [N5-delta-4-automation-edge-correlator.md](normative/N5-delta-4-automation-edge-correlator.md) | N5 supervisory | Miniforge automation causality |
+| [N11-delta-runtime-adapter.md](normative/N11-delta-runtime-adapter.md) | N11 | Governed task runtimes |
+
 ### N7 — Operational Policy Synthesis With Verification ✅
 
 **File:** [normative/N7-Operational-Policy-Synthesis.md](normative/N7-Operational-Policy-Synthesis.md)
@@ -175,7 +200,7 @@ Defines:
 - OPSV workflow family: DISCOVER → PLAN → EXECUTE → CONVERGE → SYNTHESIZE → VERIFY → ACTUATE
 - Verification requirements: pass/fail semantics, success criteria evaluation
 - Fleet Mode integration: per-service policy state, experiment governance
-- Risk scoring and actuation modes (RECOMMEND_ONLY, PR_ONLY, APPLY_ALLOWED)
+- Risk scoring plus requested/effective actuation decisions (RECOMMEND_ONLY, PR_ONLY, APPLY_ALLOWED)
 
 ### N8 — Observability Control Interface 🆕
 
@@ -236,6 +261,23 @@ Defines:
 - Audit integration: full event stream (N3) and evidence bundle (N6) linkage
 - **Tool operational semantics:** Timeout, retry, circuit-breaker, concurrency, fallback (§3.4–§3.5)
 - **Tool response validation:** Schema validation and injection sanitization at capsule boundary (§7.4)
+
+---
+
+### N11 — Task Capsule Isolation 🆕
+
+**File:** [normative/N11-task-capsule-isolation.md](normative/N11-task-capsule-isolation.md)
+**Status:** Draft
+**Purpose:** Make the per-task capsule the primary governed execution boundary
+
+Defines:
+
+- Full enclosure of the agent process, tools, filesystem writes, and emitted artifacts
+- Capsule lifecycle: bootstrap, execute, export, destroy
+- Local vs governed execution modes with no silent downgrade
+- Runtime specification, network, secret, resource, and evidence boundaries
+- TaskExecutor workspace persistence and phase continuity
+- OCI runtime abstraction through the indexed N11 runtime-adapter delta
 
 ---
 
@@ -345,16 +387,14 @@ These documents provide guidance, examples, and context but do NOT define contra
 - [informative/ux-tui-mockups.md](informative/ux-tui-mockups.md) - Visual design for CLI/TUI (informs N5)
 - [informative/ai-ux-flows.md](informative/ai-ux-flows.md) - AI-powered features (informs N3, N5)
 
-### Guides (How-To)
+### Design and Contract Notes
 
-- [informative/getting-started.md](informative/getting-started.md) - First workflow guide
-- [informative/authoring-policies.md](informative/authoring-policies.md) - Policy pack development
-- [informative/writing-workflows.md](informative/writing-workflows.md) - Workflow spec authoring
-- [informative/building-scanners.md](informative/building-scanners.md) - Scanner development
-
-### Vision & Positioning
-
-- [informative/operational-modes.md](informative/operational-modes.md) - OSS vs Paid operational differences
+- [informative/CONFIG-SYSTEM.md](informative/CONFIG-SYSTEM.md) - Configuration precedence and ownership
+- [informative/tool-registry.md](informative/tool-registry.md) - Tool registry guidance
+- [informative/I-PHASE-HANDOFF-ENVELOPES.md](informative/I-PHASE-HANDOFF-ENVELOPES.md) - Phase handoff envelopes
+-
+  [informative/I-WORKFLOW-SUPERVISION-MACHINE-ARCHITECTURE.md](informative/I-WORKFLOW-SUPERVISION-MACHINE-ARCHITECTURE.m
+  d) - Workflow supervision design
 
 > Product strategy documents (pricing, roadmap, competitive positioning) are maintained
 > in the private [miniforge-fleet](https://github.com/miniforge-ai/miniforge-fleet) repository.
@@ -362,11 +402,6 @@ These documents provide guidance, examples, and context but do NOT define contra
 ### Future Workflows
 
 - [informative/pr-monitoring-workflow.md](informative/pr-monitoring-workflow.md) - PR monitoring and conflict resolution
-
-### Demo Scripts
-
-- [informative/yc-mvp-demo-script.md](informative/yc-mvp-demo-script.md) -
-  YC-ready MVP demo narrative, flow, and implementation breakdown
 
 ### Architecture & Internals
 
@@ -388,33 +423,6 @@ These documents provide guidance, examples, and context but do NOT define contra
 - [informative/I-INCIDENT-DIAGNOSTICS.md](informative/I-INCIDENT-DIAGNOSTICS.md) -
   Autonomous incident diagnostics and response workflow patterns
 
-### Roadmaps (Experimental/Future)
-
-- [informative/learning-meta-loop.md](informative/learning-meta-loop.md) - Future learning system (post-OSS)
-
----
-
-## Examples (Reference Implementations)
-
-Concrete examples that demonstrate compliance with normative specs.
-
-### Workflow Examples
-
-- [examples/workflows/rds-import.edn](examples/workflows/rds-import.edn) - Import existing RDS to Terraform
-- [examples/workflows/k8s-deployment.edn](examples/workflows/k8s-deployment.edn) - Deploy to Kubernetes
-- [examples/workflows/vpc-network-changes.edn](examples/workflows/vpc-network-changes.edn) - Network infrastructure
-
-### Evidence Bundle Examples
-
-- [examples/evidence/rds-import-bundle.edn](examples/evidence/rds-import-bundle.edn) - Complete evidence bundle
-- [examples/evidence/semantic-validation.edn](examples/evidence/semantic-validation.edn) - Intent validation example
-
-### Policy Pack Examples
-
-- [examples/policy-packs/terraform-aws/](examples/policy-packs/terraform-aws/) - Terraform AWS safety checks
-- [examples/policy-packs/kubernetes/](examples/policy-packs/kubernetes/) - K8s manifest validation
-- [examples/policy-packs/foundations/](examples/policy-packs/foundations/) - General code quality
-
 ---
 
 ## Deprecated Documents
@@ -433,7 +441,7 @@ Documents superseded by normative specs. Retained for reference during migration
 
 ### Language Rules
 
-**Normative specs (N1-N10):**
+**Indexed normative specs:**
 
 - MUST use RFC 2119 keywords: MUST, SHALL, SHOULD, MAY, MUST NOT, SHALL NOT
 - MUST define versioning and compatibility expectations
@@ -447,11 +455,17 @@ Documents superseded by normative specs. Retained for reference during migration
 
 ### Amendment Process
 
-**To add a new concept:**
+**To add or amend a contract:**
 
-1. It MUST land in N1 (glossary + concept model) first
-2. Runtime data MUST land in N3 (events) or N6 (evidence/artifacts)
-3. UX features MUST point to a contract in N3/N5/N6
+1. Universal concepts MUST land in N1
+2. Amendment/extension-local concepts MUST specialize an N1 concept
+3. Event and evidence wire contracts MUST be added to N3 or N6
+4. UX contracts MUST be added to or reference N3, N5, or N6
+
+**Delta amendments:**
+
+A separate delta MUST name its base spec and scope and appear in this index.
+It inherits the base spec's applicability unless this index narrows it.
 
 **Extension specs (N7+):**
 
@@ -465,12 +479,11 @@ They MUST:
 
 **Rules to prevent spec explosion:**
 
-1. **Core specs (N1-N6)** define fundamental contracts
-2. **Extension specs (N7+)** define cross-cutting capabilities
-3. **Every new concept must land in N1** or it's not real
-4. **Every new runtime datum must land in N3 or N6** or it's unobservable
-5. **Every UX feature must point to a contract** or it's just a mock
-6. **Roadmaps never contain contracts** - they link to specs
+1. **Core specs (N1-N6)** define universal contracts
+2. **Indexed deltas** amend a named contract without duplicating it
+3. **Extension specs (N7+)** define scoped product/capability requirements
+4. **Wire contracts stay centralized** in N3/N5/N6
+5. **Roadmaps never contain contracts** - they link to specs
 
 ### Conformance
 

--- a/specs/SPEC_INDEX.md
+++ b/specs/SPEC_INDEX.md
@@ -516,6 +516,9 @@ Normative specs are enforced by:
 
 ## Version History
 
+- **0.9.0-draft** (2026-08-04) - Indexed every normative amendment and extension with explicit
+  product applicability; reconciled N7 requested/effective actuation, OPSV event/evidence
+  correlation, and N8/N10 governance semantics
 - **0.8.0-draft** (2026-07-23) - Added N14 (Shared Deliberation Workspace) and N15 (Collective-Cognition
   Evaluation Harness). N14 is a speculative spec: conformance binds experimental implementations pre-gate and
   the spec demotes to Informative as a recorded negative result if N15 Gate G0 fails. N15's core protocol

--- a/specs/normative/N1-architecture.md
+++ b/specs/normative/N1-architecture.md
@@ -788,6 +788,7 @@ with provenance per N6.
   :confidence keyword
   :caveats [string ...]}
 
+ :operational-policy/rollback-plan {...} ; N10-governed rollback action
  :operational-policy/evidence-refs [uuid ...]} ; N6 evidence artifacts
 ```
 
@@ -816,7 +817,8 @@ Experiment Packs are specializations of Packs (§2.10.3).
  :experiment-pack/success-criteria {...}
  :experiment-pack/guardrails {...}
  :experiment-pack/convergence {...}
- :experiment-pack/actuation-intent keyword} ; :recommend-only, :pr-only, :apply-allowed
+ :experiment-pack/actuation-intent keyword  ; :recommend-only, :pr-only, :apply-allowed
+ :experiment-pack/required-instrumentation [...]}
 ```
 
 Experiment Packs SHALL be hash-addressed and recorded in the event stream and evidence bundle.
@@ -825,13 +827,16 @@ See N7 for detailed Experiment Pack specification.
 ### 2.13 Actuation Mode (N7)
 
 An **Actuation Mode** governs whether OPSV workflows produce recommendations, PRs, or
-direct changes:
+request direct changes:
 
 - **RECOMMEND_ONLY**: produce policy proposals and evidence; no changes emitted.
 - **PR_ONLY**: produce changes as PRs against declared repos.
-- **APPLY_ALLOWED**: apply changes directly when permitted by policy packs and gates.
+- **APPLY_ALLOWED**: request direct apply eligibility when permitted by policy packs and gates.
 
-`APPLY_ALLOWED` MUST be disabled by default. See N7 §1.4.
+An Actuation Mode expresses intent and MUST NOT be treated as an authority grant.
+PR creation and direct apply require a valid N10 capability at execution time;
+the effective mode may be less autonomous than requested. `APPLY_ALLOWED` MUST
+be disabled by default. See N7 §1.4 and §5.4.
 
 ### 2.14 Verification (N7)
 
@@ -2721,12 +2726,14 @@ conformance checklist.
 - N7 (Operational Policy Synthesis): Defines OPSV workflow, Experiment Packs, Operational Policies
 - N8 (Observability Control Interface): Defines Listeners, Capability Levels, Control Actions
 - N9 (External PR Integration): Defines PR Work Items, Providers, PR Trains, Readiness
+- N10 (Governed Tool Execution): Defines bounded capabilities, governed actions, rollback, and postconditions
 
 ---
 
 ## 13. Glossary
 
-- **Actuation Mode** - Governance mode for OPSV outputs: RECOMMEND_ONLY, PR_ONLY, or APPLY_ALLOWED (N7)
+- **Actuation Mode** - Requested OPSV output intent: RECOMMEND_ONLY, PR_ONLY, or APPLY_ALLOWED; authority is evaluated
+  separately (N7)
 - **Advisory Annotation** - Non-blocking message attached to a workflow or event by a Listener (N8)
 - **Agent** - Autonomous software entity that executes workflow phases
 - **Artifact** - Work product created during workflow execution

--- a/specs/normative/N1-architecture.md
+++ b/specs/normative/N1-architecture.md
@@ -829,9 +829,9 @@ See N7 for detailed Experiment Pack specification.
 An **Actuation Mode** governs whether OPSV workflows produce recommendations, PRs, or
 request direct changes:
 
-- **RECOMMEND_ONLY**: produce policy proposals and evidence; no changes emitted.
-- **PR_ONLY**: produce changes as PRs against declared repos.
-- **APPLY_ALLOWED**: request direct apply eligibility when permitted by policy packs and gates.
+- **RECOMMEND_ONLY** (`:recommend-only`): produce policy proposals and evidence; no changes emitted.
+- **PR_ONLY** (`:pr-only`): produce changes as PRs against declared repos.
+- **APPLY_ALLOWED** (`:apply-allowed`): request direct apply eligibility when permitted by policy packs and gates.
 
 An Actuation Mode expresses intent and MUST NOT be treated as an authority grant.
 PR creation and direct apply require a valid N10 capability at execution time;

--- a/specs/normative/N1-architecture.md
+++ b/specs/normative/N1-architecture.md
@@ -6,8 +6,8 @@
 
 # N1 — Core Architecture & Concepts
 
-**Version:** 0.6.0-draft
-**Date:** 2026-04-22
+**Version:** 0.7.0-draft
+**Date:** 2026-08-04
 **Status:** Draft
 **Conformance:** MUST
 
@@ -2794,6 +2794,9 @@ conformance checklist.
 
 **Version History:**
 
+- 0.7.0-draft (2026-08-04): Clarified OPSV requested actuation as intent rather
+  than authority; added rollback and required-instrumentation fields to the N7
+  specializations and linked governed effects to N10
 - 0.6.0-draft (2026-04-23): Pack interchange and tool registry amendments — Pack Signature
   Format (§2.10.4.1) defining detached-signature wire format and verification API so
   signed packs are portable between OSS implementations; Pack Bundle Format (§2.10.6)

--- a/specs/normative/N3-event-stream.md
+++ b/specs/normative/N3-event-stream.md
@@ -1089,7 +1089,13 @@ event types:
  :opsv/evidence-bundle-id uuid
  :opsv/experiment-pack-hash string   ; Experiment Pack content hash
  :opsv/targets {:services [...] :environments [...]}
- :opsv/risk-score {:score double :level keyword :factors [...]}
+ :opsv/risk-score
+ {:score double                      ; [0.0, 1.0]
+  :level keyword                     ; :low, :medium, :high, :critical
+  :factors [{:factor keyword
+             :input any
+             :contribution double
+             :rationale string}]}
  :message "OPSV experiment planned: {experiment-pack-hash}"}
 ```
 

--- a/specs/normative/N3-event-stream.md
+++ b/specs/normative/N3-event-stream.md
@@ -1179,7 +1179,7 @@ event types:
    :evidence/capability-id string}]
  :opsv/pr-refs [string ...]          ; PR URLs if PR_ONLY
  :opsv/apply-refs [string ...]       ; Applied resource refs if APPLY_ALLOWED
- :message "OPSV actuation emitted: {effective-mode}"}
+ :message "OPSV actuation emitted: {effective-actuation-mode}"}
 ```
 
 #### opsv.drift/detected

--- a/specs/normative/N3-event-stream.md
+++ b/specs/normative/N3-event-stream.md
@@ -1173,8 +1173,10 @@ event types:
  :opsv/evidence-bundle-id uuid
  :opsv/requested-actuation-mode keyword
  :opsv/effective-actuation-mode keyword ; :none or no more autonomous than requested
- :opsv/capability-refs [string ...]
- :opsv/governed-action-refs [uuid ...]
+ :opsv/governed-effects              ; Correlates each N10 intent, OIR, and capability
+ [{:evidence/intent-id uuid
+   :evidence/oir-id uuid
+   :evidence/capability-id string}]
  :opsv/pr-refs [string ...]          ; PR URLs if PR_ONLY
  :opsv/apply-refs [string ...]       ; Applied resource refs if APPLY_ALLOWED
  :message "OPSV actuation emitted: {effective-mode}"}

--- a/specs/normative/N3-event-stream.md
+++ b/specs/normative/N3-event-stream.md
@@ -1087,9 +1087,10 @@ event types:
 ```clojure
 {:event/type :opsv.experiment/planned
  :workflow/id uuid
+ :opsv/evidence-bundle-id uuid
  :opsv/pack-hash string              ; Experiment Pack content hash
  :opsv/targets {:services [...] :environments [...]}
- :opsv/risk-score {:level keyword :factors [...]}
+ :opsv/risk-score {:score double :level keyword :factors [...]}
  :message "OPSV experiment planned: {pack-hash}"}
 ```
 
@@ -1098,6 +1099,7 @@ event types:
 ```clojure
 {:event/type :opsv.experiment/started
  :workflow/id uuid
+ :opsv/evidence-bundle-id uuid
  :opsv/pack-hash string
  :opsv/environment-fingerprint {...} ; Cluster, node pool, image digests, config
  :message "OPSV experiment started in {environment}"}
@@ -1108,6 +1110,7 @@ event types:
 ```clojure
 {:event/type :opsv/load-step
  :workflow/id uuid
+ :opsv/evidence-bundle-id uuid
  :opsv/step-id string
  :opsv/intended-load {...}
  :opsv/observed-load {...}
@@ -1119,6 +1122,7 @@ event types:
 ```clojure
 {:event/type :opsv.guardrail/abort
  :workflow/id uuid
+ :opsv/evidence-bundle-id uuid
  :opsv/trigger keyword               ; Abort trigger type
  :opsv/threshold {...}
  :opsv/observed {...}
@@ -1131,6 +1135,7 @@ event types:
 ```clojure
 {:event/type :opsv.convergence/iteration
  :workflow/id uuid
+ :opsv/evidence-bundle-id uuid
  :opsv/iteration-id string
  :opsv/params {...}
  :opsv/observed-metrics-summary {...}
@@ -1142,6 +1147,7 @@ event types:
 ```clojure
 {:event/type :opsv.policy/proposed
  :workflow/id uuid
+ :opsv/evidence-bundle-id uuid
  :opsv/policy-hash string
  :opsv/diff-refs [uuid ...]          ; N6 artifact references
  :opsv/confidence keyword
@@ -1153,9 +1159,9 @@ event types:
 ```clojure
 {:event/type :opsv.verification/result
  :workflow/id uuid
+ :opsv/evidence-bundle-id uuid
  :opsv/passed? boolean
  :opsv/criteria-evaluation [...]
- :opsv/evidence-bundle-id uuid
  :message "OPSV verification {passed?}: {summary}"}
 ```
 
@@ -1164,24 +1170,32 @@ event types:
 ```clojure
 {:event/type :opsv.actuation/emitted
  :workflow/id uuid
- :opsv/actuation-mode keyword        ; :pr-only or :apply-allowed
+ :opsv/evidence-bundle-id uuid
+ :opsv/requested-actuation-mode keyword
+ :opsv/effective-actuation-mode keyword ; :none or no more autonomous than requested
+ :opsv/capability-refs [string ...]
+ :opsv/governed-action-refs [uuid ...]
  :opsv/pr-refs [string ...]          ; PR URLs if PR_ONLY
  :opsv/apply-refs [string ...]       ; Applied resource refs if APPLY_ALLOWED
- :message "OPSV actuation emitted: {mode}"}
+ :message "OPSV actuation emitted: {effective-mode}"}
 ```
 
 #### opsv.drift/detected
 
 ```clojure
 {:event/type :opsv.drift/detected
- :workflow/id uuid                   ; OPTIONAL: may be nil if detected by monitoring
+ :workflow/id uuid                   ; Originating OPSV workflow for the monitored policy
+ :opsv/evidence-bundle-id uuid
  :opsv/signal keyword
  :opsv/deviation {...}
  :opsv/suggested-rerun? boolean
  :message "OPSV drift detected: {signal}"}
 ```
 
-All OPSV events MUST link to the corresponding evidence bundle id per N6.
+All OPSV events MUST include `:opsv/evidence-bundle-id`. The OPSV workflow
+MUST allocate that identifier before `:opsv.experiment/planned` and finalize
+the corresponding bundle per N6. Drift events reference the originating
+workflow and bundle for the monitored policy.
 
 ### 3.15 Observability Control Interface Events (N8)
 

--- a/specs/normative/N3-event-stream.md
+++ b/specs/normative/N3-event-stream.md
@@ -1106,7 +1106,11 @@ event types:
  :workflow/id uuid
  :opsv/evidence-bundle-id uuid
  :opsv/experiment-pack-hash string
- :opsv/environment-fingerprint {...} ; Cluster, node pool, image digests, config
+ :opsv/environment-fingerprint
+ {:cluster string
+  :node-pools [string ...]
+  :image-digests {...}
+  :config-hash string}
  :message "OPSV experiment started in {environment-fingerprint}"}
 ```
 
@@ -1166,7 +1170,14 @@ event types:
  :workflow/id uuid
  :opsv/evidence-bundle-id uuid
  :opsv/passed? boolean
- :opsv/criteria-evaluation [...]
+ :opsv/criteria-evaluation
+ [{:criterion/id string
+   :criterion/passed? boolean
+   :criterion/observed any
+   :criterion/expected any
+   :criterion/reason-code keyword}]
+ :opsv/confidence keyword
+ :opsv/caveats [string ...]
  :message "OPSV verification {passed?}: {summary}"}
 ```
 
@@ -2247,8 +2258,8 @@ Event stream will extend to:
 **Version History:**
 
 - 0.9.0-draft (2026-08-04): OPSV events now share a preallocated evidence-bundle
-  identifier, canonical Experiment Pack hash key, requested/effective actuation
-  modes, and correlated N10 governed-effect records
+  identifier, canonical Experiment Pack/environment/verification/risk shapes,
+  requested/effective actuation modes, and correlated N10 governed-effect records
 - 0.8.0-draft (2026-04-23): Per-workflow streaming wire-contract amendments — §5.3
   expanded from a one-line SSE sketch to a complete contract for the per-workflow
   stream: authentication via bearer token (with browser-friendly query-param

--- a/specs/normative/N3-event-stream.md
+++ b/specs/normative/N3-event-stream.md
@@ -1178,7 +1178,7 @@ event types:
    :criterion/reason-code keyword}]
  :opsv/confidence keyword
  :opsv/caveats [string ...]
- :message "OPSV verification {passed?}: {summary}"}
+ :message "OPSV verification passed: {passed?}"}
 ```
 
 #### opsv.actuation/emitted

--- a/specs/normative/N3-event-stream.md
+++ b/specs/normative/N3-event-stream.md
@@ -1088,10 +1088,10 @@ event types:
 {:event/type :opsv.experiment/planned
  :workflow/id uuid
  :opsv/evidence-bundle-id uuid
- :opsv/pack-hash string              ; Experiment Pack content hash
+ :opsv/experiment-pack-hash string   ; Experiment Pack content hash
  :opsv/targets {:services [...] :environments [...]}
  :opsv/risk-score {:score double :level keyword :factors [...]}
- :message "OPSV experiment planned: {pack-hash}"}
+ :message "OPSV experiment planned: {experiment-pack-hash}"}
 ```
 
 #### opsv.experiment/started
@@ -1100,9 +1100,9 @@ event types:
 {:event/type :opsv.experiment/started
  :workflow/id uuid
  :opsv/evidence-bundle-id uuid
- :opsv/pack-hash string
+ :opsv/experiment-pack-hash string
  :opsv/environment-fingerprint {...} ; Cluster, node pool, image digests, config
- :message "OPSV experiment started in {environment}"}
+ :message "OPSV experiment started in {environment-fingerprint}"}
 ```
 
 #### opsv/load-step
@@ -1114,7 +1114,7 @@ event types:
  :opsv/step-id string
  :opsv/intended-load {...}
  :opsv/observed-load {...}
- :message "OPSV load step {step-id}: {intended} → {observed}"}
+ :message "OPSV load step {step-id}: {intended-load} → {observed-load}"}
 ```
 
 #### opsv.guardrail/abort

--- a/specs/normative/N3-event-stream.md
+++ b/specs/normative/N3-event-stream.md
@@ -1158,7 +1158,7 @@ event types:
  :workflow/id uuid
  :opsv/evidence-bundle-id uuid
  :opsv/policy-hash string
- :opsv/diff-refs [uuid ...]          ; N6 artifact references
+ :opsv/diff-artifact-refs [uuid ...] ; N6 artifact references
  :opsv/confidence keyword
  :message "OPSV policy proposed: {policy-hash}"}
 ```

--- a/specs/normative/N3-event-stream.md
+++ b/specs/normative/N3-event-stream.md
@@ -1171,8 +1171,8 @@ event types:
 {:event/type :opsv.actuation/emitted
  :workflow/id uuid
  :opsv/evidence-bundle-id uuid
- :opsv/requested-actuation-mode keyword
- :opsv/effective-actuation-mode keyword ; :none or no more autonomous than requested
+ :opsv/requested-actuation-mode keyword ; :recommend-only, :pr-only, :apply-allowed
+ :opsv/effective-actuation-mode keyword ; :none, :recommend-only, :pr-only, :apply-allowed
  :opsv/governed-effects              ; Correlates each N10 intent, OIR, and capability
  [{:evidence/intent-id uuid
    :evidence/oir-id uuid

--- a/specs/normative/N3-event-stream.md
+++ b/specs/normative/N3-event-stream.md
@@ -6,14 +6,13 @@
 
 # N3 — Event Stream & Observability Contract
 
-**Version:** 0.8.0-draft
-**Date:** 2026-04-17
+**Version:** 0.9.0-draft
+**Date:** 2026-08-04
 **Status:** Draft
 **Conformance:** MUST
 
-_v0.7.0 adds §3.19 supervisory snapshot event family
-(`:supervisory/*-upserted`) as the consumer-facing surface for canonical
-supervisory entities defined in N5-delta-supervisory-control-plane §3._
+_v0.9.0 reconciles the §3.14 OPSV event family with N6 evidence correlation
+and N10 governed-effect identifiers._
 
 ---
 
@@ -2232,15 +2231,18 @@ Event stream will extend to:
 - N2 (Workflow Execution): Workflow engine emits lifecycle events
 - N5 (CLI/TUI/API): UI consumes event stream via subscription API
 - N6 (Evidence & Provenance): Evidence bundles reference event streams
-- N7 (Operational Policy Synthesis): OPSV event types (§3.13)
-- N8 (Observability Control Interface): Listener/control action event types (§3.14)
-- N9 (External PR Integration): Provider/PR/train event types (§3.15)
+- N7 (Operational Policy Synthesis): OPSV event types (§3.14)
+- N8 (Observability Control Interface): Listener/control action event types (§3.15)
+- N9 (External PR Integration): Provider/PR/train event types (§3.16)
 - I-DAG-ORCHESTRATION: DAG executor with PR lifecycle (Section 12: PR Lifecycle Events)
 
 ---
 
 **Version History:**
 
+- 0.9.0-draft (2026-08-04): OPSV events now share a preallocated evidence-bundle
+  identifier, canonical Experiment Pack hash key, requested/effective actuation
+  modes, and correlated N10 governed-effect records
 - 0.8.0-draft (2026-04-23): Per-workflow streaming wire-contract amendments — §5.3
   expanded from a one-line SSE sketch to a complete contract for the per-workflow
   stream: authentication via bearer token (with browser-friendly query-param
@@ -2249,6 +2251,8 @@ Event stream will extend to:
   buffer-overflow behavior, SSE wire format (event/id/data/retry + heartbeats),
   optional WebSocket wire format, rate limiting. Cross-workflow aggregation
   endpoints remain out of OSS scope
+- 0.7.0-draft (2026-04-17): Added the §3.19 supervisory snapshot event family
+  (`:supervisory/*-upserted`) for canonical N5 supervisory entities
 - 0.6.0-draft (2026-03-08): Reliability Nines amendments — `:failure/class` enum on all
   failure events, reliability metric events (§3.17), repository intelligence events (§3.18)
 - 0.5.0-draft (2026-02-16): Added pack lifecycle, Pack Run, capability denial, and chain

--- a/specs/normative/N3-event-stream.md
+++ b/specs/normative/N3-event-stream.md
@@ -1178,7 +1178,7 @@ event types:
    :criterion/reason-code keyword}]
  :opsv/confidence keyword
  :opsv/caveats [string ...]
- :message "OPSV verification passed: {passed?}"}
+ :message "OPSV verification result: {passed?}"}
 ```
 
 #### opsv.actuation/emitted

--- a/specs/normative/N6-evidence-provenance.md
+++ b/specs/normative/N6-evidence-provenance.md
@@ -6,8 +6,8 @@
 
 # N6 — Evidence & Provenance Standard
 
-**Version:** 0.6.0-draft
-**Date:** 2026-03-08
+**Version:** 0.7.0-draft
+**Date:** 2026-08-04
 **Status:** Draft
 **Conformance:** MUST
 
@@ -1100,6 +1100,9 @@ Fleet-wide evidence will enable:
 
 **Version History:**
 
+- 0.7.0-draft (2026-08-04): OPSV evidence now records preallocated bundle
+  correlation, content-addressed inputs, requested/effective actuation,
+  correlated N10 effects, postconditions, rollback, and diff/metric artifacts
 - 0.6.0-draft (2026-04-23): External-PR artifact amendment — `:pr-context-pack`
   artifact type registered in §3.1.1 with full content schema. PR Context Packs are
   the normalized PR snapshot that reviewer, meta, and governance workflow packs

--- a/specs/normative/N6-evidence-provenance.md
+++ b/specs/normative/N6-evidence-provenance.md
@@ -354,7 +354,7 @@ preserve every referenced event, artifact, capability, and governed effect.
 
   :opsv/actuation
   {:requested-mode keyword            ; :recommend-only, :pr-only, :apply-allowed
-   :effective-mode keyword            ; :none or never more autonomous than requested
+   :effective-mode keyword            ; :none, :recommend-only, :pr-only, :apply-allowed
    :governed-effects                   ; One correlated record per N10 effect
    [{:evidence/intent-id uuid
      :evidence/oir-id uuid

--- a/specs/normative/N6-evidence-provenance.md
+++ b/specs/normative/N6-evidence-provenance.md
@@ -381,7 +381,7 @@ artifact, capability, and governed effect accumulated during the run.
               :artifact-refs [uuid ...]}}
 
   :opsv/metric-query-artifact-refs [uuid ...]
-  :opsv/metric-snapshots [uuid ...]   ; Links to :opsv-metric-snapshot artifacts
+  :opsv/metric-snapshot-artifact-refs [uuid ...]
   :opsv/diff-artifact-refs [uuid ...]}}
 ```
 

--- a/specs/normative/N6-evidence-provenance.md
+++ b/specs/normative/N6-evidence-provenance.md
@@ -324,8 +324,10 @@ For tasks reaching `:merged` terminal state:
 For Operational Policy Synthesis workflows (see N7), evidence bundles MUST include:
 
 The workflow MUST allocate the evidence bundle identifier before emitting its
-first OPSV event and update the bundle throughout the run. Finalization MUST
-preserve every referenced event, artifact, capability, and governed effect.
+first OPSV event and accumulate material in a run-scoped assembly record. At
+terminal disposition it MUST publish one immutable bundle whose identifier is
+the preallocated value. Finalization MUST preserve references to every event,
+artifact, capability, and governed effect accumulated during the run.
 
 ```clojure
 {:evidence/opsv

--- a/specs/normative/N6-evidence-provenance.md
+++ b/specs/normative/N6-evidence-provenance.md
@@ -355,8 +355,10 @@ preserve every referenced event, artifact, capability, and governed effect.
   :opsv/actuation
   {:requested-mode keyword            ; :recommend-only, :pr-only, :apply-allowed
    :effective-mode keyword            ; :none or never more autonomous than requested
-   :capability-refs [string ...]       ; N10 bounded-authority references
-   :governed-action-refs [uuid ...]    ; N10 action/audit references
+   :governed-effects                   ; One correlated record per N10 effect
+   [{:evidence/intent-id uuid
+     :evidence/oir-id uuid
+     :evidence/capability-id string}]
    :pr-refs [string ...]              ; PR URLs if PR_ONLY
    :apply-refs [string ...]           ; Applied resource refs if APPLY_ALLOWED
    :postcondition-artifact-refs [uuid ...]

--- a/specs/normative/N6-evidence-provenance.md
+++ b/specs/normative/N6-evidence-provenance.md
@@ -323,14 +323,20 @@ For tasks reaching `:merged` terminal state:
 
 For Operational Policy Synthesis workflows (see N7), evidence bundles MUST include:
 
+The workflow MUST allocate the evidence bundle identifier before emitting its
+first OPSV event and update the bundle throughout the run. Finalization MUST
+preserve every referenced event, artifact, capability, and governed effect.
+
 ```clojure
 {:evidence/opsv
  {:opsv/experiment-pack-hash string   ; Content hash of Experiment Pack used
   :opsv/experiment-pack-id string
+  :opsv/experiment-pack-artifact-id uuid ; Content-addressed pack artifact
   :opsv/environment-fingerprint       ; Cluster, node pool, image digests, config
   {:cluster string
    :node-pools [string ...]
-   :image-digests {...}}
+   :image-digests {...}
+   :config-hash string}
 
   :opsv/convergence-iterations long   ; Number of convergence iterations
   :opsv/policy-proposals              ; Proposed operational policies
@@ -347,11 +353,19 @@ For Operational Policy Synthesis workflows (see N7), evidence bundles MUST inclu
    :caveats [string ...]}
 
   :opsv/actuation
-  {:mode keyword                      ; :recommend-only, :pr-only, :apply-allowed
+  {:requested-mode keyword            ; :recommend-only, :pr-only, :apply-allowed
+   :effective-mode keyword            ; :none or never more autonomous than requested
+   :capability-refs [string ...]       ; N10 bounded-authority references
+   :governed-action-refs [uuid ...]    ; N10 action/audit references
    :pr-refs [string ...]              ; PR URLs if PR_ONLY
-   :apply-refs [string ...]}          ; Applied resource refs if APPLY_ALLOWED
+   :apply-refs [string ...]           ; Applied resource refs if APPLY_ALLOWED
+   :postcondition-artifact-refs [uuid ...]
+   :rollback {:status keyword         ; :not-required, :not-triggered, :succeeded, :failed
+              :artifact-refs [uuid ...]}}
 
-  :opsv/metric-snapshots [uuid ...]}} ; Links to :opsv-metric-snapshot artifacts
+  :opsv/metric-query-artifact-refs [uuid ...]
+  :opsv/metric-snapshots [uuid ...]   ; Links to :opsv-metric-snapshot artifacts
+  :opsv/diff-artifact-refs [uuid ...]}}
 ```
 
 ### 2.9 Control Action Evidence (N8)

--- a/specs/normative/N6-evidence-provenance.md
+++ b/specs/normative/N6-evidence-provenance.md
@@ -353,8 +353,8 @@ preserve every referenced event, artifact, capability, and governed effect.
    :caveats [string ...]}
 
   :opsv/actuation
-  {:requested-mode keyword            ; :recommend-only, :pr-only, :apply-allowed
-   :effective-mode keyword            ; :none, :recommend-only, :pr-only, :apply-allowed
+  {:requested-actuation-mode keyword  ; :recommend-only, :pr-only, :apply-allowed
+   :effective-actuation-mode keyword  ; :none, :recommend-only, :pr-only, :apply-allowed
    :governed-effects                   ; One correlated record per N10 effect
    [{:evidence/intent-id uuid
      :evidence/oir-id uuid

--- a/specs/normative/N6-evidence-provenance.md
+++ b/specs/normative/N6-evidence-provenance.md
@@ -338,6 +338,14 @@ preserve every referenced event, artifact, capability, and governed effect.
    :image-digests {...}
    :config-hash string}
 
+  :opsv/risk-score
+  {:score double                      ; [0.0, 1.0]
+   :level keyword                     ; :low, :medium, :high, :critical
+   :factors [{:factor keyword
+              :input any
+              :contribution double
+              :rationale string}]}
+
   :opsv/convergence-iterations long   ; Number of convergence iterations
   :opsv/policy-proposals              ; Proposed operational policies
   [{:policy-hash string
@@ -348,7 +356,12 @@ preserve every referenced event, artifact, capability, and governed effect.
 
   :opsv/verification
   {:passed? boolean
-   :criteria-evaluation [...]         ; Per-criterion results
+   :criteria-evaluation
+   [{:criterion/id string
+     :criterion/passed? boolean
+     :criterion/observed any
+     :criterion/expected any
+     :criterion/reason-code keyword}]
    :confidence keyword
    :caveats [string ...]}
 
@@ -1101,8 +1114,9 @@ Fleet-wide evidence will enable:
 **Version History:**
 
 - 0.7.0-draft (2026-08-04): OPSV evidence now records preallocated bundle
-  correlation, content-addressed inputs, requested/effective actuation,
-  correlated N10 effects, postconditions, rollback, and diff/metric artifacts
+  correlation, content-addressed inputs, explainable risk, per-criterion
+  verification, requested/effective actuation, correlated N10 effects,
+  postconditions, rollback, and diff/metric artifacts
 - 0.6.0-draft (2026-04-23): External-PR artifact amendment — `:pr-context-pack`
   artifact type registered in §3.1.1 with full content schema. PR Context Packs are
   the normalized PR snapshot that reviewer, meta, and governance workflow packs

--- a/specs/normative/N7-Operational-Policy-Synthesis.md
+++ b/specs/normative/N7-Operational-Policy-Synthesis.md
@@ -6,7 +6,7 @@
 
 # N7 — Operational Policy Synthesis With Verification
 
-**Version:** 0.2.0
+**Version:** 0.2.0-draft
 **Date:** 2026-08-04
 **Status:** Complete
 **Conformance:** MUST
@@ -398,3 +398,11 @@ A minimal compliant OPSV implementation MUST:
 - emit PRs as N10-governed actions with provenance
 - default effective actuation to `:recommend-only`
 - honor N8 emergency stop and record rollback/disposition evidence
+
+---
+
+**Version History:**
+
+- 0.2.0-draft (2026-08-04): Reconciled canonical schemas, events, evidence,
+  requested/effective actuation, verification blocking, N8 safe mode, and N10 effects
+- 0.1.0-draft (2026-02-01): Initial OPSV extension specification

--- a/specs/normative/N7-Operational-Policy-Synthesis.md
+++ b/specs/normative/N7-Operational-Policy-Synthesis.md
@@ -87,9 +87,9 @@ Experiment Packs SHALL be hash-addressed and recorded in the event stream and ev
 
 OPSV MUST support these requested actuation modes:
 
-- **RECOMMEND_ONLY**: produce policy proposals and evidence; no changes are emitted.
-- **PR_ONLY**: produce changes as PRs (or patch sets) against declared repos.
-- **APPLY_ALLOWED**: request direct apply eligibility; it does not grant execution authority.
+- **RECOMMEND_ONLY** (`:recommend-only`): produce policy proposals and evidence; no changes are emitted.
+- **PR_ONLY** (`:pr-only`): produce changes as PRs (or patch sets) against declared repos.
+- **APPLY_ALLOWED** (`:apply-allowed`): request direct apply eligibility; it does not grant execution authority.
 
 `APPLY_ALLOWED` MUST be disabled by default.
 

--- a/specs/normative/N7-Operational-Policy-Synthesis.md
+++ b/specs/normative/N7-Operational-Policy-Synthesis.md
@@ -201,7 +201,7 @@ CONVERGE MUST be expressed as a bounded loop with:
 
 ### 4.1 Experiment Pack schema (normative fields)
 
-An Experiment Pack MUST use the N1 §2.12 namespaced keys:
+An Experiment Pack MUST use the N1 §2.12 namespaced top-level keys:
 
 ```clojure
 {:experiment-pack/id string
@@ -227,7 +227,7 @@ and stop conditions. Actuation intent MUST be `:recommend-only`, `:pr-only`, or
 
 ### 4.2 Operational Policy Proposal schema (normative fields)
 
-A proposal MUST use the N1 §2.11 namespaced keys:
+A proposal MUST use the N1 §2.11 namespaced top-level keys:
 
 ```clojure
 {:operational-policy/id string

--- a/specs/normative/N7-Operational-Policy-Synthesis.md
+++ b/specs/normative/N7-Operational-Policy-Synthesis.md
@@ -121,6 +121,7 @@ An OPSV run MUST produce:
 - **Evidence Bundle** per N6, including:
   - Experiment Pack hash and content
   - environment fingerprint (cluster, node pool, image digests, config)
+  - normalized risk score and explainable factor records
   - metric queries and snapshots used for conclusions
   - artifacts emitted and diffs
 - **Remediation Artifacts** depending on actuation mode (none, PRs, or applied changes)
@@ -256,7 +257,7 @@ OPSV SHALL emit these event types with required minimal payloads:
 - `:opsv.guardrail/abort` (trigger, threshold, observed, rollback action)
 - `:opsv.convergence/iteration` (iteration id, params, observed metrics summary)
 - `:opsv.policy/proposed` (policy hash, diff refs, confidence)
-- `:opsv.verification/result` (pass/fail, criteria evaluation)
+- `:opsv.verification/result` (pass/fail, criteria evaluation, confidence, caveats)
 - `:opsv.actuation/emitted` (requested/effective mode and correlated N10 effect records)
 - `:opsv.drift/detected` (signal, deviation, suggested re-run)
 

--- a/specs/normative/N7-Operational-Policy-Synthesis.md
+++ b/specs/normative/N7-Operational-Policy-Synthesis.md
@@ -250,8 +250,8 @@ plan MUST identify a concrete N10-governed rollback action.
 
 OPSV SHALL emit these event types with required minimal payloads:
 
-- `:opsv.experiment/planned` (pack hash, targets, risk score)
-- `:opsv.experiment/started` (pack hash, environment fingerprint)
+- `:opsv.experiment/planned` (Experiment Pack hash, targets, risk score)
+- `:opsv.experiment/started` (Experiment Pack hash, environment fingerprint)
 - `:opsv/load-step` (step id, intended load, observed load)
 - `:opsv.guardrail/abort` (trigger, threshold, observed, rollback action)
 - `:opsv.convergence/iteration` (iteration id, params, observed metrics summary)

--- a/specs/normative/N7-Operational-Policy-Synthesis.md
+++ b/specs/normative/N7-Operational-Policy-Synthesis.md
@@ -257,7 +257,7 @@ OPSV SHALL emit these event types with required minimal payloads:
 - `:opsv.convergence/iteration` (iteration id, params, observed metrics summary)
 - `:opsv.policy/proposed` (policy hash, diff refs, confidence)
 - `:opsv.verification/result` (pass/fail, criteria evaluation)
-- `:opsv.actuation/emitted` (requested/effective mode and governed-action references)
+- `:opsv.actuation/emitted` (requested/effective mode and correlated N10 effect records)
 - `:opsv.drift/detected` (signal, deviation, suggested re-run)
 
 Every event MUST include `:opsv/evidence-bundle-id` for the preallocated OPSV
@@ -395,5 +395,5 @@ A minimal compliant OPSV implementation MUST:
 - produce explainable risk and per-criterion verification results
 - emit the §4.3 events and a complete N6 §2.8 evidence bundle
 - emit PRs as N10-governed actions with provenance
-- default effective actuation to `RECOMMEND_ONLY`
+- default effective actuation to `:recommend-only`
 - honor N8 emergency stop and record rollback/disposition evidence

--- a/specs/normative/N7-Operational-Policy-Synthesis.md
+++ b/specs/normative/N7-Operational-Policy-Synthesis.md
@@ -256,7 +256,7 @@ OPSV SHALL emit these event types with required minimal payloads:
 - `:opsv/load-step` (step id, intended load, observed load)
 - `:opsv.guardrail/abort` (trigger, threshold, observed, rollback action)
 - `:opsv.convergence/iteration` (iteration id, params, observed metrics summary)
-- `:opsv.policy/proposed` (policy hash, diff refs, confidence)
+- `:opsv.policy/proposed` (policy hash, diff artifact refs, confidence)
 - `:opsv.verification/result` (pass/fail, criteria evaluation, confidence, caveats)
 - `:opsv.actuation/emitted` (requested/effective mode and correlated N10 effect records)
 - `:opsv.drift/detected` (signal, deviation, suggested re-run)

--- a/specs/normative/N7-Operational-Policy-Synthesis.md
+++ b/specs/normative/N7-Operational-Policy-Synthesis.md
@@ -6,6 +6,12 @@
 
 # N7 — Operational Policy Synthesis With Verification
 
+**Version:** 0.2.0
+**Date:** 2026-08-04
+**Status:** Complete
+**Conformance:** MUST
+**Class:** Extension spec (N7+)
+
 ## 0. Status and scope
 
 ### 0.1 Purpose
@@ -15,23 +21,26 @@ This specification defines the normative requirements for **Operational Policy S
 performance bottlenecks via governed experiments, synthesizes operational policies, verifies
 them against explicit acceptance criteria, and emits fixes as auditable artifacts.
 
-### 0.2 Relationship to N1–N6
+### 0.2 Relationship to core and later extensions
 
 OPSV is an extension of existing Miniforge normative contracts:
 
 - **N1**: introduces new *concepts* (Experiment Pack, Operational Policy, Actuation Mode,
           Verification) as specializations of Workflow/Policy Pack/Artifact/Evidence.
-          Now landed in N1 §2.11–§2.14 and §12 (glossary).
-- **N2**: defines a new workflow family (`opsv.*`) and convergence loops as instances of the
-          validate→feedback→repair→re-validate pattern.
+          Now landed in N1 §2.11–§2.14 and §13 (glossary).
+- **N2**: supplies the phase lifecycle, gate, and bounded-loop contracts that the `opsv.*`
+          workflow family specializes in this specification.
 - **N3**: adds required event types for experiments and verification.
-          Now landed in N3 §3.13 (OPSV Events).
+          Now landed in N3 §3.14 (OPSV Events).
 - **N4**: defines new gates and policy-pack controls for experiment governance, safety, and actuation.
           Now landed in N4 §5.1.5 (OPSV Gates Pack).
 - **N5**: defines Fleet Mode command surfaces and navigation primitives for experiments and policy diffs.
           Now landed in N5 §2.3.3 (OPSV Commands) and §3.2.6 (OPSV Drill-Down View).
 - **N6**: defines evidence bundle requirements for experiment provenance, reproducibility, and
           verification artifacts. Now landed in N6 §2.8 (OPSV Evidence) and §3.1.1 (artifact types).
+- **N8**: supplies emergency-stop and safe-mode behavior for active OPSV runs (§3.1.4, §3.4).
+- **N10**: governs PR creation and direct apply as external effects, including capability,
+           rollback verification, postconditions, audit events, and evidence (§§4–6, §9, §12).
 
 ### 0.3 Non-goals
 
@@ -74,15 +83,19 @@ Experiment Packs SHALL be hash-addressed and recorded in the event stream and ev
 **Verification** is the process of executing an Experiment Pack (or a verification subset) against a candidate Operational
  Policy and producing an evidence bundle showing whether success criteria are satisfied.
 
-### 1.4 Actuation Mode
+### 1.4 Requested Actuation Mode
 
-OPSV MUST support these actuation modes:
+OPSV MUST support these requested actuation modes:
 
 - **RECOMMEND_ONLY**: produce policy proposals and evidence; no changes are emitted.
 - **PR_ONLY**: produce changes as PRs (or patch sets) against declared repos.
-- **APPLY_ALLOWED**: apply changes directly only when explicitly permitted by policy packs and gates.
+- **APPLY_ALLOWED**: request direct apply eligibility; it does not grant execution authority.
 
 `APPLY_ALLOWED` MUST be disabled by default.
+
+A requested mode is intent, not permission. The effective actuation decision MUST be
+derived under §5.4. PR creation and direct apply remain governed N10 effects and require
+valid authority at execution time.
 
 ## 2. System model
 
@@ -187,64 +200,68 @@ CONVERGE MUST be expressed as a bounded loop with:
 
 ### 4.1 Experiment Pack schema (normative fields)
 
-An Experiment Pack MUST include:
+An Experiment Pack MUST use the N1 §2.12 namespaced keys:
 
-- `id`: stable identifier
-- `version`: semantic version or monotonic revision
-- `targets`:
-  - `services`: selectors (repo and/or runtime)
-  - `environments`: selectors (cluster/namespace)
-- `workload`:
-  - `profile`: step/ramp/spike definitions
-  - `mix`: request classes and weights (if applicable)
-  - `warmup_seconds`, `cooldown_seconds`
-- `success_criteria`:
-  - latency thresholds (p95/p99) and measurement window
-  - error rate threshold and window
-  - stability criteria (max oscillation, max pod churn)
-  - optional cost ceiling or resource ceiling
-- `guardrails`:
-  - abort triggers with thresholds (error budget burn, saturation, tail latency)
-  - blast radius limits (max replicas delta, max node delta, namespaces)
-  - time windows
-- `convergence`:
-  - search space definition (candidate signals, thresholds, min/max)
-  - iteration limits and stop conditions
-- `actuation_intent`: one of `RECOMMEND_ONLY | PR_ONLY | APPLY_ALLOWED`
-- `required_instrumentation`: list of metrics/traces/log signals that MUST be present
+```clojure
+{:experiment-pack/id string
+ :experiment-pack/version string
+ :experiment-pack/targets {:services [...] :environments [...]}
+ :experiment-pack/workload
+ {:profile keyword
+  :mix [...]
+  :warmup-seconds long
+  :cooldown-seconds long}
+ :experiment-pack/success-criteria {...}
+ :experiment-pack/guardrails {...}
+ :experiment-pack/convergence {...}
+ :experiment-pack/actuation-intent keyword
+ :experiment-pack/required-instrumentation [...]}
+```
+
+Success criteria MUST cover latency/error windows and stability, with optional
+cost/resource ceilings. Guardrails MUST cover abort thresholds, blast radius,
+and time windows. Convergence MUST define the search space, iteration limit,
+and stop conditions. Actuation intent MUST be `:recommend-only`, `:pr-only`, or
+`:apply-allowed`.
 
 ### 4.2 Operational Policy Proposal schema (normative fields)
 
-A proposal MUST include:
+A proposal MUST use the N1 §2.11 namespaced keys:
 
-- `policy_id`, `policy_version`
-- `target_services`, `target_envs`
-- `scaling`:
-  - chosen driver(s)
-  - thresholds and behaviors
-  - min/max bounds
-- `resources`:
-  - requests/limits recommendation or settings
-- `guardrails` (if emitted)
-- `verification_summary`: pass/fail plus confidence score and known caveats
-- `rollback_plan`: explicit rollback action
-- `evidence_refs`: pointers to evidence bundle elements per N6
+```clojure
+{:operational-policy/id string
+ :operational-policy/version string
+ :operational-policy/target-services [string ...]
+ :operational-policy/target-envs [string ...]
+ :operational-policy/scaling {...}
+ :operational-policy/resources {...}
+ :operational-policy/guardrails {...}
+ :operational-policy/verification-summary
+ {:passed? boolean :confidence keyword :caveats [string ...]}
+ :operational-policy/rollback-plan {...}
+ :operational-policy/evidence-refs [uuid ...]}
+```
+
+Scaling MUST include chosen drivers, thresholds, behaviors, and min/max bounds.
+Resources MUST contain requests/limits recommendations or settings. The rollback
+plan MUST identify a concrete N10-governed rollback action.
 
 ### 4.3 Event stream additions (N3 extension)
 
 OPSV SHALL emit these event types with required minimal payloads:
 
-- `opsv.experiment_planned` (pack hash, targets, risk score)
-- `opsv.experiment_started` (pack hash, environment fingerprint)
-- `opsv.load_step` (step id, intended load, observed load)
-- `opsv.guardrail_abort` (trigger, threshold, observed, rollback action)
-- `opsv.convergence_iteration` (iteration id, params, observed metrics summary)
-- `opsv.policy_proposed` (policy hash, diff refs, confidence)
-- `opsv.verification_result` (pass/fail, criteria evaluation)
-- `opsv.actuation_emitted` (PR refs or apply refs)
-- `opsv.drift_detected` (signal, deviation, suggested re-run)
+- `:opsv.experiment/planned` (pack hash, targets, risk score)
+- `:opsv.experiment/started` (pack hash, environment fingerprint)
+- `:opsv/load-step` (step id, intended load, observed load)
+- `:opsv.guardrail/abort` (trigger, threshold, observed, rollback action)
+- `:opsv.convergence/iteration` (iteration id, params, observed metrics summary)
+- `:opsv.policy/proposed` (policy hash, diff refs, confidence)
+- `:opsv.verification/result` (pass/fail, criteria evaluation)
+- `:opsv.actuation/emitted` (requested/effective mode and governed-action references)
+- `:opsv.drift/detected` (signal, deviation, suggested re-run)
 
-All events MUST link to the corresponding evidence bundle id per N6.
+Every event MUST include `:opsv/evidence-bundle-id` for the preallocated OPSV
+evidence bundle per N6 §2.8.
 
 ## 5. Governance and safety (N4 extension)
 
@@ -259,6 +276,11 @@ OPSV MUST compute a risk score for each run using at least:
 
 Risk score MUST determine required gates and approvals.
 
+The risk result MUST contain a normalized score in `[0.0, 1.0]`, a level in
+`:low`, `:medium`, `:high`, or `:critical`, and explainable factor records containing
+the input, contribution, and rationale. Policy packs map score/level thresholds
+to approvals; implementations MUST NOT hide approval selection in an opaque model.
+
 ### 5.2 Gates
 
 Policy packs SHALL define gates for:
@@ -267,7 +289,7 @@ Policy packs SHALL define gates for:
 - **Environment Gate**: targets are allowed and within time windows.
 - **Blast Radius Gate**: max changes bounded.
 - **Abort Gate**: abort triggers configured.
-- **Actuation Gate**: PR-only vs apply allowed; apply requires explicit allowlist.
+- **Actuation Gate**: requested vs effective mode; apply requires an explicit allowlist.
 - **Evidence Completeness Gate**: evidence bundle contains required fields before actuation.
 
 If any gate fails, OPSV MUST produce remediation guidance as machine-readable output and human-readable summary.
@@ -277,6 +299,27 @@ If any gate fails, OPSV MUST produce remediation guidance as machine-readable ou
 - `APPLY_ALLOWED` MUST be disabled by default.
 - Production targets MUST require explicit allowlisting in policy packs.
 - All OPSV runs MUST support a global emergency stop.
+
+An N8 emergency stop or safe-mode entry MUST prevent new OPSV effects, abort
+active experiments at the next safe boundary, revoke their mutation capabilities,
+invoke verified rollback through the separately authorized recovery path, and
+record the disposition in N3/N6. Safe mode MUST set effective actuation to
+`:none` per N8's A0 posture.
+
+### 5.4 Effective actuation decision
+
+Before any external mutation, OPSV MUST compute an effective actuation decision
+from the requested mode, verification result, N4 gate results, N8 safe-mode
+state, and current N10 capability. The decision MAY reduce autonomy but MUST NOT
+promote beyond the requested mode.
+
+- `:none` emits only disposition evidence and is required when N8 forbids execution.
+- `:recommend-only` never produces an external mutation.
+- `:pr-only` requires authority for the PR-creation effect.
+- `:apply-allowed` requires successful verification, all gates, a valid scoped
+  capability at execution time, a verified rollback, and configured postconditions.
+
+The decision and every authority/effect reference MUST be recorded in N6 evidence.
 
 ## 6. Verification requirements
 
@@ -296,7 +339,9 @@ Verification MUST evaluate each success criterion and produce:
 - overall pass/fail
 - confidence/caveat fields (e.g., variance high, dependency noise)
 
-Verification failure MUST block actuation unless a policy pack explicitly allows “force apply” with elevated approval gates.
+Verification failure MUST block direct apply and MUST NOT be overridden by a
+policy pack. `PR_ONLY` MAY emit a failed candidate for review only when the PR
+is marked ineligible for merge and includes the failed criteria and evidence.
 
 ## 7. Emission and remediation
 
@@ -315,15 +360,18 @@ All changes MUST be emitted as artifacts with provenance per N6:
 
 - at least one PR per target repo or a coordinated patch set
 - included evidence bundle link/reference and rollback instructions in PR body
+- N10 capability and governed-action references for the provider mutation
 
 ### 7.3 Apply emission (optional, gated)
 
-`APPLY_ALLOWED` MAY apply changes directly only when all gates pass and the policy pack
- allows it; apply actions MUST be recorded as artifacts and events.
+`APPLY_ALLOWED` MAY apply changes directly only when §5.4 succeeds. Apply actions
+MUST execute as N10-governed effects with verified rollback and postcondition
+monitoring. A failed postcondition MUST trigger the declared rollback and record
+both the apply and rollback outcomes as artifacts, events, and evidence.
 
 ## 8. CLI/TUI extensions (N5 extension)
 
-Miniforge SHOULD add commands under `fleet` (exact naming may be refined, but contracts MUST exist):
+Miniforge MUST implement the canonical N5 §2.3.3 commands under `fleet`:
 
 - `fleet opsv plan …` → generate Experiment Packs and risk/gate status
 - `fleet opsv run …` → execute and converge
@@ -340,8 +388,12 @@ Fleet → Service → OPSV Runs → (Experiment Pack, Events, Evidence, Policy D
 A minimal compliant OPSV implementation MUST:
 
 - support staging-only operation
+- execute all seven §3.1 phases through the shared N2 workflow lifecycle
 - discover at least two candidate scaling drivers (e.g., CPU and a backlog/concurrency proxy if available)
 - run step/ramp experiments with abort guardrails
 - synthesize an HPA/KEDA-compatible policy proposal
-- produce verification pass/fail and evidence bundle
-- emit PRs with provenance
+- produce explainable risk and per-criterion verification results
+- emit the §4.3 events and a complete N6 §2.8 evidence bundle
+- emit PRs as N10-governed actions with provenance
+- default effective actuation to `RECOMMEND_ONLY`
+- honor N8 emergency stop and record rollback/disposition evidence


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# spec: reconcile N7 operational policy contracts

## Overview

Makes N7 a current, internally consistent implementation contract before OPSV
code is introduced. It aligns the extension with the live N1/N3/N6 wire
contracts and the later N8/N10 governance model.

## Motivation

The original N7 predates governed effect grants, emergency-stop semantics, and
the repository's current extension catalog. It also cites the wrong N3 section,
uses event names that differ from N3, and treats `APPLY_ALLOWED` as both intent
and authority. Implementing those contradictions would produce unsafe or
nonconforming behavior.

## Layer

Foundations — normative contracts only.

## Depends on

- [miniforge#1638](https://github.com/miniforge-ai/miniforge/pull/1638) — merged

## Changes in Detail

- Reconcile N7 phases, event names, evidence correlation, and cross-references.
- Define direct apply as a requested intent that still requires N10 execution
  authority and transactional rollback behavior.
- Integrate N8 emergency stop and safe-mode behavior.
- Make failed verification a hard block for direct mutation.
- Repair the specification catalog and README extension guidance.

## Test plan

- Validate every N7 cross-reference and duplicated wire contract against its
  owning core spec.
- Run Markdown formatting and the full pre-commit gate.
- Adversarially trace recommend-only, PR-only, direct-apply, verification
  failure, guardrail abort, and emergency-stop paths.

`bb pre-commit` passes for every commit slice (338 smoke tests / 1,281
assertions and 8 GraalVM/Babashka compatibility tests / 572 assertions).
Local-link validation reports no missing targets, and every file under
`specs/normative/` appears in `SPEC_INDEX.md`.

## Deployment Plan

Merge before replacing the stale N7 work specs or implementing OPSV components.

## Related Issues/PRs

- [miniforge-ai/miniforge-standards#96](https://github.com/miniforge-ai/miniforge-standards/pull/96)

## Checklist

- [x] Core and extension contracts agree
- [x] Unsafe override paths are eliminated
- [x] Specification catalog is complete
- [x] Repository checks pass
