### PR TITLE
fix(bb): codex-gap on the miniforge task classpaths

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -575,6 +575,8 @@
                  "components/codex-gap/resources"
                  "components/codex/src"
                  "components/codex/resources"
+                 "components/codex-gap/src"
+                 "components/codex-gap/resources"
                  "components/messages/src"
                  "components/messages/resources"]
    :requires ([ai.miniforge.codex-gap.interface :as codex-gap]
@@ -601,6 +603,8 @@
                  "bases/mcp-context-server/resources"
                  "components/codex/src"
                  "components/codex/resources"
+                 "components/codex-gap/src"
+                 "components/codex-gap/resources"
                  "components/messages/src"
                  "components/messages/resources"]
    :extra-deps {cheshire/cheshire {:mvn/version "5.13.0"}}
@@ -754,6 +758,8 @@
                  "bases/mcp-context-server/resources"
                  "components/codex/src"
                  "components/codex/resources"
+                 "components/codex-gap/src"
+                 "components/codex-gap/resources"
                  "components/phase-software-factory/src"
                  "components/phase-software-factory/resources"
                  "components/compliance-scanner/src"


### PR DESCRIPTION
My [#1634](https://github.com/miniforge-ai/miniforge/pull/1634) wiring made phase-software-factory require codex-gap, but only the codex-gap-report task listed the component on its classpath — `bb miniforge run` fails at phase-namespace load. Lazy phase loading means main.clj load checks pass; it only bites when a workflow actually runs a phase, which is why [#1640](https://github.com/miniforge-ai/miniforge/pull/1640)'s verification missed it. Found by codex-baseline shakeout run 3, ten seconds in.

Fourth instance of the uncovered-bb-classpath failure class ([#1626](https://github.com/miniforge-ai/miniforge/pull/1626), mcp-context-server additions, [#1640](https://github.com/miniforge-ai/miniforge/pull/1640), now this). The CI smoke-test task is already chipped; it should load phase interceptor namespaces too, not just task entry namespaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)