### PR TITLE
docs(specs): correct the SPEC_INDEX version transition in the N3 PR doc

### DIFF
--- a/docs/pull-requests/2026-08-05-chris-n3-event-stream-spec-complete.md
+++ b/docs/pull-requests/2026-08-05-chris-n3-event-stream-spec-complete.md
@@ -155,7 +155,7 @@ contract — every row is a conformance gap to close.
 ### SPEC_INDEX
 
 N3 entry updated to list the new sections and requirement-ID families. Index
-version 0.8.0 → 0.9.0-draft with an amendment-log entry.
+version 0.9.0 → 0.10.0-draft with an amendment-log entry.
 
 ## Testing Plan
 


### PR DESCRIPTION
Follow-up to [#1641](https://github.com/miniforge-ai/miniforge/pull/1641), from a review comment that landed at merge and was stranded.

The PR doc said the index went `0.8.0 → 0.9.0-draft`. It went `0.9.0 → 0.10.0-draft` — [#1639](https://github.com/miniforge-ai/miniforge/pull/1639) had already claimed 0.9.0, so the rebase renumbered this pass to 0.10.0 and the doc line was not updated with it.

Verified against `specs/SPEC_INDEX.md` on main, which reads `**Version:** 0.10.0-draft`.

One line, documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
