### PR TITLE
work: complete N7 normative references

### DIFF
--- a/docs/pull-requests/2026-08-05-codex-n7-normative-ref-gaps.md
+++ b/docs/pull-requests/2026-08-05-codex-n7-normative-ref-gaps.md
@@ -1,0 +1,50 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# work: complete N7 implementation references
+
+## Overview
+
+Adds direct normative references for every external N-series contract named by
+the bounded N7 implementation tasks.
+
+## Motivation
+
+Copilot's review of #1645 found that requiring an N10 effect path without citing
+N10 leaves implementers with incomplete traceability. The same audit found four
+analogous omissions in the N7 task DAG.
+
+## Layer
+
+Planning foundations — normative-reference metadata only.
+
+## Depends on
+
+- [miniforge#1645](https://github.com/miniforge-ai/miniforge/pull/1645) — merged
+
+## Changes in Detail
+
+- Cite N6 and N10 for canonical OPSV actuation/effect records.
+- Cite N4 for domain gate decisions.
+- Cite N4, N8, and N10 for the CLI apply path.
+- Repair stale case-sensitive N8 paths and cite the N11 runtime-adapter contract
+  for governed Kubernetes actuation.
+- Cite N7 for OPSV governance and N3 for workflow event emission.
+
+## Testing Plan
+
+- Parse every changed work spec as EDN.
+- Verify every referenced normative document exists.
+- Run the full pre-commit gate.
+
+## Deployment Plan
+
+Merge before the first N7 implementation PR.
+
+## Checklist
+
+- [x] Every explicit N-series dependency has a direct normative reference
+- [x] No task scope, constraint, or acceptance criterion changed

--- a/work/n07-opsv-cli-tui-drift.spec.edn
+++ b/work/n07-opsv-cli-tui-drift.spec.edn
@@ -16,8 +16,11 @@
           "components/opsv/src/**"]}
 
  :normative-refs
- ["specs/normative/N5-cli-tui-api.md"
-  "specs/normative/N7-Operational-Policy-Synthesis.md"]
+ ["specs/normative/N4-policy-packs.md"
+  "specs/normative/N5-cli-tui-api.md"
+  "specs/normative/N7-Operational-Policy-Synthesis.md"
+  "specs/normative/N8-observability-control-interface.md"
+  "specs/normative/N10-governed-tool-execution.md"]
 
  :spec/constraints
  ["Command names and positional SERVICE argument MUST match N5 exactly"

--- a/work/n07-opsv-contracts.spec.edn
+++ b/work/n07-opsv-contracts.spec.edn
@@ -14,7 +14,9 @@
 
  :normative-refs
  ["specs/normative/N1-architecture.md"
-  "specs/normative/N7-Operational-Policy-Synthesis.md"]
+  "specs/normative/N6-evidence-provenance.md"
+  "specs/normative/N7-Operational-Policy-Synthesis.md"
+  "specs/normative/N10-governed-tool-execution.md"]
 
  :spec/constraints
  ["Domain namespaces MUST remain pure and contain no adapter or workflow I/O"

--- a/work/n07-opsv-domain-policy.spec.edn
+++ b/work/n07-opsv-domain-policy.spec.edn
@@ -12,8 +12,9 @@
           "components/opsv/test/**"]}
 
  :normative-refs
- ["specs/normative/N7-Operational-Policy-Synthesis.md"
-  "specs/normative/N8-Observability-Control-Interface.md"
+ ["specs/normative/N4-policy-packs.md"
+  "specs/normative/N7-Operational-Policy-Synthesis.md"
+  "specs/normative/N8-observability-control-interface.md"
   "specs/normative/N10-governed-tool-execution.md"]
 
  :spec/constraints

--- a/work/n07-opsv-governed-actuation.spec.edn
+++ b/work/n07-opsv-governed-actuation.spec.edn
@@ -15,8 +15,9 @@
 
  :normative-refs
  ["specs/normative/N7-Operational-Policy-Synthesis.md"
-  "specs/normative/N8-Observability-Control-Interface.md"
-  "specs/normative/N10-governed-tool-execution.md"]
+  "specs/normative/N8-observability-control-interface.md"
+  "specs/normative/N10-governed-tool-execution.md"
+  "specs/normative/N11-delta-runtime-adapter.md"]
 
  :spec/constraints
  ["PR creation and apply MUST require real matching N10 grants at execution time"

--- a/work/n07-opsv-observability-governance.spec.edn
+++ b/work/n07-opsv-observability-governance.spec.edn
@@ -18,7 +18,8 @@
  :normative-refs
  ["specs/normative/N3-event-stream.md"
   "specs/normative/N4-policy-packs.md"
-  "specs/normative/N6-evidence-provenance.md"]
+  "specs/normative/N6-evidence-provenance.md"
+  "specs/normative/N7-Operational-Policy-Synthesis.md"]
 
  :spec/constraints
  ["Every OPSV event MUST carry the preallocated evidence bundle identifier"

--- a/work/n07-opsv-workflow.spec.edn
+++ b/work/n07-opsv-workflow.spec.edn
@@ -16,6 +16,7 @@
 
  :normative-refs
  ["specs/normative/N2-workflows.md"
+  "specs/normative/N3-event-stream.md"
   "specs/normative/N7-Operational-Policy-Synthesis.md"]
 
  :spec/constraints


### PR DESCRIPTION
## Layer
Planning foundations

## Depends on
- #1645 — merged

## What this adds
Direct normative references for every external N-series contract named by the bounded N7 implementation tasks, including case-correct N8 paths and the N11 runtime-adapter contract.

## Validation
- All changed specs parse as EDN
- Every reference resolves to an exact tracked path
- Full pre-commit gate passes

See docs/pull-requests/2026-08-05-codex-n7-normative-ref-gaps.md.