### PR TITLE
feat: add canonical OPSV contracts

### DIFF
--- a/components/opsv/deps.edn
+++ b/components/opsv/deps.edn
@@ -1,0 +1,7 @@
+{:paths ["src"]
+ :deps {ai.miniforge/anomaly {:local/root "../anomaly"}
+        ai.miniforge/content-hash {:local/root "../content-hash"}
+        metosin/malli {:mvn/version "0.16.4"}}
+ :aliases
+ {:test {:extra-paths ["test"]
+         :extra-deps {}}}}

--- a/components/opsv/src/ai/miniforge/opsv/core.clj
+++ b/components/opsv/src/ai/miniforge/opsv/core.clj
@@ -1,0 +1,29 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.opsv.core
+  "Trusted canonical hashing implementation for validated OPSV domain values."
+  (:require
+   [ai.miniforge.content-hash.interface :as content-hash]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Validated content identity
+(defn ^{:stratum 0} experiment-pack-hash-impl
+  "Hash a validated Experiment Pack. The interface owns validation."
+  [pack]
+  (content-hash/content-hash pack))

--- a/components/opsv/src/ai/miniforge/opsv/interface.clj
+++ b/components/opsv/src/ai/miniforge/opsv/interface.clj
@@ -27,33 +27,61 @@
 ;------------------------------------------------------------------------------ Layer 0
 
 ;; Contract and vocabulary re-exports
-(def ^{:stratum 0} requested-actuation-modes schema/requested-actuation-modes)
+(def ^{:stratum 0} requested-actuation-modes
+  "Canonical N7 intent modes, ordered from least to most autonomous."
+  schema/requested-actuation-modes)
 
-(def ^{:stratum 0} effective-actuation-modes schema/effective-actuation-modes)
+(def ^{:stratum 0} effective-actuation-modes
+  "Canonical N7 effective modes, including the N8-safe :none posture."
+  schema/effective-actuation-modes)
 
-(def ^{:stratum 0} risk-levels schema/risk-levels)
+(def ^{:stratum 0} risk-levels
+  "Canonical N7 explainable-risk levels."
+  schema/risk-levels)
 
-(def ^{:stratum 0} rollback-statuses schema/rollback-statuses)
+(def ^{:stratum 0} rollback-statuses
+  "Canonical N6 OPSV rollback dispositions."
+  schema/rollback-statuses)
 
-(def ^{:stratum 0} ExperimentPack schema/ExperimentPack)
+(def ^{:stratum 0} ExperimentPack
+  "Closed Malli schema for an N1/N7 Experiment Pack."
+  schema/ExperimentPack)
 
-(def ^{:stratum 0} OperationalPolicy schema/OperationalPolicy)
+(def ^{:stratum 0} OperationalPolicy
+  "Closed Malli schema for an N1/N7 Operational Policy Proposal."
+  schema/OperationalPolicy)
 
-(def ^{:stratum 0} VerificationSummary schema/VerificationSummary)
+(def ^{:stratum 0} VerificationSummary
+  "Closed Malli schema for an Operational Policy verification summary."
+  schema/VerificationSummary)
 
-(def ^{:stratum 0} RiskFactor schema/RiskFactor)
+(def ^{:stratum 0} RiskFactor
+  "Closed Malli schema for one explainable risk contribution."
+  schema/RiskFactor)
 
-(def ^{:stratum 0} RiskResult schema/RiskResult)
+(def ^{:stratum 0} RiskResult
+  "Closed Malli schema for normalized explainable OPSV risk."
+  schema/RiskResult)
 
-(def ^{:stratum 0} CriterionResult schema/CriterionResult)
+(def ^{:stratum 0} CriterionResult
+  "Closed Malli schema for one verification criterion result."
+  schema/CriterionResult)
 
-(def ^{:stratum 0} VerificationResult schema/VerificationResult)
+(def ^{:stratum 0} VerificationResult
+  "Closed Malli schema for per-criterion OPSV verification."
+  schema/VerificationResult)
 
-(def ^{:stratum 0} GovernedEffect schema/GovernedEffect)
+(def ^{:stratum 0} GovernedEffect
+  "Closed Malli schema correlating an N10 intent, OIR, and capability."
+  schema/GovernedEffect)
 
-(def ^{:stratum 0} RollbackResult schema/RollbackResult)
+(def ^{:stratum 0} RollbackResult
+  "Closed Malli schema for the OPSV rollback disposition and evidence."
+  schema/RollbackResult)
 
-(def ^{:stratum 0} ActuationRecord schema/ActuationRecord)
+(def ^{:stratum 0} ActuationRecord
+  "Closed Malli schema for requested/effective actuation and effects."
+  schema/ActuationRecord)
 
 (def ^{:stratum 0} ^:private invalid-domain-value-message
   "Stable programmer-facing message for OPSV contract violations."
@@ -73,26 +101,31 @@
 
 ;; Public validation boundary
 (defn ^{:stratum 1} validate-experiment-pack
+  "Return the pack unchanged when valid, otherwise an :invalid-input anomaly."
   [value]
   (validation-result invalid-domain-value-message
                      :opsv/experiment-pack schema/ExperimentPack value))
 
 (defn ^{:stratum 1} validate-operational-policy
+  "Return the policy unchanged when valid, otherwise an :invalid-input anomaly."
   [value]
   (validation-result invalid-domain-value-message
                      :opsv/operational-policy schema/OperationalPolicy value))
 
 (defn ^{:stratum 1} validate-risk
+  "Return the risk result unchanged when valid, otherwise an anomaly."
   [value]
   (validation-result invalid-domain-value-message
                      :opsv/risk-result schema/RiskResult value))
 
 (defn ^{:stratum 1} validate-verification
+  "Return the verification unchanged when valid, otherwise an anomaly."
   [value]
   (validation-result invalid-domain-value-message
                      :opsv/verification-result schema/VerificationResult value))
 
 (defn ^{:stratum 1} validate-actuation
+  "Return the actuation record unchanged when valid, otherwise an anomaly."
   [value]
   (validation-result invalid-domain-value-message
                      :opsv/actuation-record schema/ActuationRecord value))
@@ -101,6 +134,7 @@
 
 ;; Canonical content identity
 (defn ^{:stratum 2} experiment-pack-hash
+  "Return a canonical SHA-256 hash for a valid pack, or a validation anomaly."
   [pack]
   (let [validated (validate-experiment-pack pack)]
     (if (anomaly/anomaly? validated)

--- a/components/opsv/src/ai/miniforge/opsv/interface.clj
+++ b/components/opsv/src/ai/miniforge/opsv/interface.clj
@@ -1,0 +1,108 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.opsv.interface
+  "Public API for canonical OPSV contracts and Experiment Pack hashing."
+  (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.opsv.core :as core]
+   [ai.miniforge.opsv.schema :as schema]
+   [malli.core :as m]
+   [malli.error :as me]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Contract and vocabulary re-exports
+(def ^{:stratum 0} requested-actuation-modes schema/requested-actuation-modes)
+
+(def ^{:stratum 0} effective-actuation-modes schema/effective-actuation-modes)
+
+(def ^{:stratum 0} risk-levels schema/risk-levels)
+
+(def ^{:stratum 0} rollback-statuses schema/rollback-statuses)
+
+(def ^{:stratum 0} ExperimentPack schema/ExperimentPack)
+
+(def ^{:stratum 0} OperationalPolicy schema/OperationalPolicy)
+
+(def ^{:stratum 0} VerificationSummary schema/VerificationSummary)
+
+(def ^{:stratum 0} RiskFactor schema/RiskFactor)
+
+(def ^{:stratum 0} RiskResult schema/RiskResult)
+
+(def ^{:stratum 0} CriterionResult schema/CriterionResult)
+
+(def ^{:stratum 0} VerificationResult schema/VerificationResult)
+
+(def ^{:stratum 0} GovernedEffect schema/GovernedEffect)
+
+(def ^{:stratum 0} RollbackResult schema/RollbackResult)
+
+(def ^{:stratum 0} ActuationRecord schema/ActuationRecord)
+
+(def ^{:stratum 0} ^:private invalid-domain-value-message
+  "Stable programmer-facing message for OPSV contract violations."
+  "Invalid OPSV domain value")
+
+(defn- ^{:stratum 0} validation-result
+  [message schema-name contract value]
+  (if-let [explanation (m/explain contract value)]
+    (anomaly/validation-anomaly
+     message
+     schema-name
+     value
+     (me/humanize explanation))
+    value))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Public validation boundary
+(defn ^{:stratum 1} validate-experiment-pack
+  [value]
+  (validation-result invalid-domain-value-message
+                     :opsv/experiment-pack schema/ExperimentPack value))
+
+(defn ^{:stratum 1} validate-operational-policy
+  [value]
+  (validation-result invalid-domain-value-message
+                     :opsv/operational-policy schema/OperationalPolicy value))
+
+(defn ^{:stratum 1} validate-risk
+  [value]
+  (validation-result invalid-domain-value-message
+                     :opsv/risk-result schema/RiskResult value))
+
+(defn ^{:stratum 1} validate-verification
+  [value]
+  (validation-result invalid-domain-value-message
+                     :opsv/verification-result schema/VerificationResult value))
+
+(defn ^{:stratum 1} validate-actuation
+  [value]
+  (validation-result invalid-domain-value-message
+                     :opsv/actuation-record schema/ActuationRecord value))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Canonical content identity
+(defn ^{:stratum 2} experiment-pack-hash
+  [pack]
+  (let [validated (validate-experiment-pack pack)]
+    (if (anomaly/anomaly? validated)
+      validated
+      (core/experiment-pack-hash-impl validated))))

--- a/components/opsv/src/ai/miniforge/opsv/schema.clj
+++ b/components/opsv/src/ai/miniforge/opsv/schema.clj
@@ -1,0 +1,141 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.opsv.schema
+  "Closed domain contracts for N7 Operational Policy Synthesis.")
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Vocabularies and structural values
+(def ^{:stratum 0} requested-actuation-modes
+  [:recommend-only :pr-only :apply-allowed])
+
+(def ^{:stratum 0} effective-actuation-modes
+  [:none :recommend-only :pr-only :apply-allowed])
+
+(def ^{:stratum 0} risk-levels
+  [:low :medium :high :critical])
+
+(def ^{:stratum 0} rollback-statuses
+  [:not-required :not-triggered :succeeded :failed])
+
+(def ^{:stratum 0} KeywordMap
+  "Extensible, namespaced detail whose keys remain data rather than contract fields."
+  [:map-of :keyword any?])
+
+(def ^{:stratum 0} Targets
+  [:map {:closed true}
+   [:services [:vector any?]]
+   [:environments [:vector any?]]])
+
+(def ^{:stratum 0} Workload
+  [:map {:closed true}
+   [:profile :keyword]
+   [:mix [:vector any?]]
+   [:warmup-seconds [:int {:min 0}]]
+   [:cooldown-seconds [:int {:min 0}]]])
+
+(def ^{:stratum 0} VerificationSummary
+  [:map {:closed true}
+   [:passed? :boolean]
+   [:confidence :keyword]
+   [:caveats [:vector :string]]])
+
+(def ^{:stratum 0} RiskFactor
+  [:map {:closed true}
+   [:factor :keyword]
+   [:input any?]
+   [:contribution :double]
+   [:rationale :string]])
+
+(def ^{:stratum 0} CriterionResult
+  [:map {:closed true}
+   [:criterion/id :string]
+   [:criterion/passed? :boolean]
+   [:criterion/observed any?]
+   [:criterion/expected any?]
+   [:criterion/reason-code :keyword]])
+
+(def ^{:stratum 0} GovernedEffect
+  [:map {:closed true}
+   [:evidence/intent-id :uuid]
+   [:evidence/oir-id :uuid]
+   [:evidence/capability-id :string]])
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} RollbackResult
+  [:map {:closed true}
+   [:status (into [:enum] rollback-statuses)]
+   [:artifact-refs [:vector :uuid]]])
+
+;; Canonical N1/N6/N7 records
+(def ^{:stratum 1} ExperimentPack
+  "N1 section 2.12 and N7 section 4.1 Experiment Pack."
+  [:map {:closed true}
+   [:experiment-pack/id :string]
+   [:experiment-pack/version :string]
+   [:experiment-pack/targets Targets]
+   [:experiment-pack/workload Workload]
+   [:experiment-pack/success-criteria KeywordMap]
+   [:experiment-pack/guardrails KeywordMap]
+   [:experiment-pack/convergence KeywordMap]
+   [:experiment-pack/actuation-intent
+    (into [:enum] requested-actuation-modes)]
+   [:experiment-pack/required-instrumentation [:vector any?]]])
+
+(def ^{:stratum 1} OperationalPolicy
+  "N1 section 2.11 and N7 section 4.2 Operational Policy Proposal."
+  [:map {:closed true}
+   [:operational-policy/id :string]
+   [:operational-policy/version :string]
+   [:operational-policy/target-services [:vector :string]]
+   [:operational-policy/target-envs [:vector :string]]
+   [:operational-policy/scaling KeywordMap]
+   [:operational-policy/resources KeywordMap]
+   [:operational-policy/guardrails KeywordMap]
+   [:operational-policy/verification-summary VerificationSummary]
+   [:operational-policy/rollback-plan KeywordMap]
+   [:operational-policy/evidence-refs [:vector :uuid]]])
+
+(def ^{:stratum 1} RiskResult
+  "Normalized, explainable N7 risk result using the N6 evidence shape."
+  [:map {:closed true}
+   [:score [:double {:min 0.0 :max 1.0}]]
+   [:level (into [:enum] risk-levels)]
+   [:factors [:vector RiskFactor]]])
+
+(def ^{:stratum 1} VerificationResult
+  "Per-criterion N7 verification result using the N6 evidence shape."
+  [:map {:closed true}
+   [:passed? :boolean]
+   [:criteria-evaluation [:vector CriterionResult]]
+   [:confidence :keyword]
+   [:caveats [:vector :string]]])
+
+;------------------------------------------------------------------------------ Layer 2
+
+(def ^{:stratum 2} ActuationRecord
+  "Requested/effective actuation and correlated governed N10 effects."
+  [:map {:closed true}
+   [:requested-actuation-mode (into [:enum] requested-actuation-modes)]
+   [:effective-actuation-mode (into [:enum] effective-actuation-modes)]
+   [:governed-effects [:vector GovernedEffect]]
+   [:pr-refs [:vector :string]]
+   [:apply-refs [:vector :string]]
+   [:postcondition-artifact-refs [:vector :uuid]]
+   [:rollback RollbackResult]])

--- a/components/opsv/src/ai/miniforge/opsv/schema.clj
+++ b/components/opsv/src/ai/miniforge/opsv/schema.clj
@@ -34,7 +34,7 @@
   [:not-required :not-triggered :succeeded :failed])
 
 (def ^{:stratum 0} KeywordMap
-  "Extensible, namespaced detail whose keys remain data rather than contract fields."
+  "Extensible keyword-keyed detail whose entries remain domain data."
   [:map-of :keyword any?])
 
 (def ^{:stratum 0} Targets

--- a/components/opsv/src/ai/miniforge/opsv/schema.clj
+++ b/components/opsv/src/ai/miniforge/opsv/schema.clj
@@ -39,8 +39,8 @@
 
 (def ^{:stratum 0} Targets
   [:map {:closed true}
-   [:services [:vector any?]]
-   [:environments [:vector any?]]])
+   [:services [:vector :string]]
+   [:environments [:vector :string]]])
 
 (def ^{:stratum 0} Workload
   [:map {:closed true}
@@ -96,7 +96,7 @@
    [:experiment-pack/convergence KeywordMap]
    [:experiment-pack/actuation-intent
     (into [:enum] requested-actuation-modes)]
-   [:experiment-pack/required-instrumentation [:vector any?]]])
+   [:experiment-pack/required-instrumentation [:vector :keyword]]])
 
 (def ^{:stratum 1} OperationalPolicy
   "N1 section 2.11 and N7 section 4.2 Operational Policy Proposal."

--- a/components/opsv/test/ai/miniforge/opsv/interface_test.clj
+++ b/components/opsv/test/ai/miniforge/opsv/interface_test.clj
@@ -1,0 +1,183 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.opsv.interface-test
+  (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.opsv.interface :as opsv]
+   [clojure.test :refer [deftest is testing]]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Canonical fixtures
+(def ^{:stratum 0} valid-pack
+  {:experiment-pack/id "catalog-ramp"
+   :experiment-pack/version "1.0.0"
+   :experiment-pack/targets
+   {:services ["catalog"]
+    :environments ["staging"]}
+   :experiment-pack/workload
+   {:profile :ramp
+    :mix [{:request :read :weight 1.0}]
+    :warmup-seconds 30
+    :cooldown-seconds 30}
+   :experiment-pack/success-criteria
+   {:latency-p95-ms 200 :error-rate 0.01 :stable-seconds 60}
+   :experiment-pack/guardrails
+   {:abort-error-rate 0.05 :max-replicas 20 :window :staging}
+   :experiment-pack/convergence
+   {:search-space {:min 2 :max 20} :iteration-limit 8 :stop :stable}
+   :experiment-pack/actuation-intent :recommend-only
+   :experiment-pack/required-instrumentation [:cpu :backlog]})
+
+(def ^{:stratum 0} valid-policy
+  {:operational-policy/id "catalog-scaling"
+   :operational-policy/version "1.0.0"
+   :operational-policy/target-services ["catalog"]
+   :operational-policy/target-envs ["staging"]
+   :operational-policy/scaling
+   {:drivers [:cpu :backlog] :thresholds {:cpu 0.7} :min 2 :max 20}
+   :operational-policy/resources {:requests {:cpu "500m"}}
+   :operational-policy/guardrails {:max-replicas 20}
+   :operational-policy/verification-summary
+   {:passed? true :confidence :high :caveats []}
+   :operational-policy/rollback-plan {:action :restore-manifest}
+   :operational-policy/evidence-refs [(random-uuid)]})
+
+(def ^{:stratum 0} valid-risk
+  {:score 0.35
+   :level :medium
+   :factors [{:factor :environment
+              :input :staging
+              :contribution 0.1
+              :rationale "Staging is isolated"}]})
+
+(def ^{:stratum 0} valid-verification
+  {:passed? true
+   :criteria-evaluation
+   [{:criterion/id "latency-p95"
+     :criterion/passed? true
+     :criterion/observed 175
+     :criterion/expected 200
+     :criterion/reason-code :within-threshold}]
+   :confidence :high
+   :caveats []})
+
+(def ^{:stratum 0} valid-actuation
+  {:requested-actuation-mode :pr-only
+   :effective-actuation-mode :pr-only
+   :governed-effects
+   [{:evidence/intent-id (random-uuid)
+     :evidence/oir-id (random-uuid)
+     :evidence/capability-id "grant-123"}]
+   :pr-refs ["https://example.test/pr/1"]
+   :apply-refs []
+   :postcondition-artifact-refs []
+   :rollback {:status :not-triggered :artifact-refs []}})
+
+(defn ^{:stratum 0} invalid?
+  [value]
+  (anomaly/anomaly? value))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Contract validation
+(deftest ^{:stratum 1} test-required-experiment-pack-contract
+  (is (= valid-pack (opsv/validate-experiment-pack valid-pack)))
+  (testing "given a missing top-level field → validation returns an anomaly"
+    (doseq [field (keys valid-pack)]
+      (is (invalid? (opsv/validate-experiment-pack (dissoc valid-pack field)))
+          (str "missing " field))))
+  (testing "given a missing target or workload field → validation returns an anomaly"
+    (doseq [[path field] [[[:experiment-pack/targets] :services]
+                          [[:experiment-pack/targets] :environments]
+                          [[:experiment-pack/workload] :profile]
+                          [[:experiment-pack/workload] :mix]
+                          [[:experiment-pack/workload] :warmup-seconds]
+                          [[:experiment-pack/workload] :cooldown-seconds]]]
+      (is (invalid? (opsv/validate-experiment-pack
+                     (update-in valid-pack path dissoc field)))
+          (str "missing " field))))
+  (testing "given an unknown key or mode → validation returns an anomaly"
+    (is (invalid? (opsv/validate-experiment-pack
+                   (assoc valid-pack :experiment-pack/unknown true))))
+    (is (invalid? (opsv/validate-experiment-pack
+                   (assoc valid-pack :experiment-pack/actuation-intent :apply))))))
+
+(deftest ^{:stratum 1} test-required-operational-policy-contract
+  (is (= valid-policy (opsv/validate-operational-policy valid-policy)))
+  (doseq [field [:operational-policy/rollback-plan
+                 :operational-policy/verification-summary
+                 :operational-policy/evidence-refs]]
+    (is (invalid? (opsv/validate-operational-policy (dissoc valid-policy field)))
+        (str "missing " field))))
+
+(deftest ^{:stratum 1} test-explainable-risk-contract
+  (is (= valid-risk (opsv/validate-risk valid-risk)))
+  (doseq [score [-0.01 1.01]]
+    (is (invalid? (opsv/validate-risk (assoc valid-risk :score score)))))
+  (doseq [field [:input :contribution :rationale]]
+    (is (invalid? (opsv/validate-risk
+                   (update valid-risk :factors
+                           #(mapv (fn [factor] (dissoc factor field)) %))))
+        (str "factor missing " field))))
+
+(deftest ^{:stratum 1} test-per-criterion-verification-contract
+  (is (= valid-verification (opsv/validate-verification valid-verification)))
+  (is (invalid? (opsv/validate-verification
+                 (update-in valid-verification [:criteria-evaluation 0]
+                            dissoc :criterion/reason-code)))))
+
+(deftest ^{:stratum 1} test-correlated-actuation-contract
+  (is (= valid-actuation (opsv/validate-actuation valid-actuation)))
+  (doseq [mode [:none :apply :automatic]]
+    (is (invalid? (opsv/validate-actuation
+                   (assoc valid-actuation :requested-actuation-mode mode)))))
+  (is (= (assoc valid-actuation :effective-actuation-mode :none)
+         (opsv/validate-actuation
+          (assoc valid-actuation :effective-actuation-mode :none))))
+  (doseq [field [:evidence/intent-id
+                 :evidence/oir-id
+                 :evidence/capability-id]]
+    (is (invalid? (opsv/validate-actuation
+                   (update valid-actuation :governed-effects
+                           #(mapv (fn [effect] (dissoc effect field)) %))))
+        (str "effect missing " field))))
+
+(deftest ^{:stratum 1} test-closed-top-level-contracts
+  (doseq [[validate value] [[opsv/validate-experiment-pack valid-pack]
+                            [opsv/validate-operational-policy valid-policy]
+                            [opsv/validate-risk valid-risk]
+                            [opsv/validate-verification valid-verification]
+                            [opsv/validate-actuation valid-actuation]]]
+    (is (invalid? (validate (assoc value :opsv/unknown true))))))
+
+(deftest ^{:stratum 1} test-typed-validation-anomaly
+  (let [result (opsv/validate-experiment-pack
+                (dissoc valid-pack :experiment-pack/id))]
+    (is (= :invalid-input (:anomaly/type result)))
+    (is (= :opsv/experiment-pack
+           (get-in result [:anomaly/data :anomaly/schema])))))
+
+;; Validated content identity
+(deftest ^{:stratum 1} test-canonical-experiment-pack-hash
+  (let [reordered (into (array-map) (reverse (seq valid-pack)))]
+    (is (= (opsv/experiment-pack-hash valid-pack)
+           (opsv/experiment-pack-hash reordered)))
+    (is (re-matches #"[0-9a-f]{64}" (opsv/experiment-pack-hash valid-pack))))
+  (is (invalid? (opsv/experiment-pack-hash
+                 (dissoc valid-pack :experiment-pack/id)))))

--- a/components/opsv/test/ai/miniforge/opsv/interface_test.clj
+++ b/components/opsv/test/ai/miniforge/opsv/interface_test.clj
@@ -144,9 +144,22 @@
 
 (deftest ^{:stratum 1} test-correlated-actuation-contract
   (is (= valid-actuation (opsv/validate-actuation valid-actuation)))
+  (doseq [mode opsv/requested-actuation-modes]
+    (is (= mode
+           (:requested-actuation-mode
+            (opsv/validate-actuation
+             (assoc valid-actuation :requested-actuation-mode mode))))))
+  (doseq [mode opsv/effective-actuation-modes]
+    (is (= mode
+           (:effective-actuation-mode
+            (opsv/validate-actuation
+             (assoc valid-actuation :effective-actuation-mode mode))))))
   (doseq [mode [:none :apply :automatic]]
     (is (invalid? (opsv/validate-actuation
                    (assoc valid-actuation :requested-actuation-mode mode)))))
+  (doseq [mode [:apply :automatic]]
+    (is (invalid? (opsv/validate-actuation
+                   (assoc valid-actuation :effective-actuation-mode mode)))))
   (is (= (assoc valid-actuation :effective-actuation-mode :none)
          (opsv/validate-actuation
           (assoc valid-actuation :effective-actuation-mode :none))))

--- a/components/opsv/test/ai/miniforge/opsv/interface_test.clj
+++ b/components/opsv/test/ai/miniforge/opsv/interface_test.clj
@@ -117,13 +117,20 @@
     (is (invalid? (opsv/validate-experiment-pack
                    (assoc valid-pack :experiment-pack/unknown true))))
     (is (invalid? (opsv/validate-experiment-pack
-                   (assoc valid-pack :experiment-pack/actuation-intent :apply))))))
+                   (assoc valid-pack :experiment-pack/actuation-intent :apply)))))
+  (testing "given invalid target or instrumentation identifiers → validation returns an anomaly"
+    (is (invalid? (opsv/validate-experiment-pack
+                   (assoc-in valid-pack
+                             [:experiment-pack/targets :services 0]
+                             :catalog))))
+    (is (invalid? (opsv/validate-experiment-pack
+                   (assoc-in valid-pack
+                             [:experiment-pack/required-instrumentation 0]
+                             "cpu"))))))
 
 (deftest ^{:stratum 1} test-required-operational-policy-contract
   (is (= valid-policy (opsv/validate-operational-policy valid-policy)))
-  (doseq [field [:operational-policy/rollback-plan
-                 :operational-policy/verification-summary
-                 :operational-policy/evidence-refs]]
+  (doseq [field (keys valid-policy)]
     (is (invalid? (opsv/validate-operational-policy (dissoc valid-policy field)))
         (str "missing " field))))
 
@@ -189,8 +196,12 @@
 
 ;; Validated content identity
 (deftest ^{:stratum 1} test-canonical-experiment-pack-hash
-  (let [reordered (into (array-map) (reverse (seq valid-pack)))]
-    (is (= (opsv/experiment-pack-hash valid-pack)
+  (let [ordered (into (sorted-map) valid-pack)
+        reordered (into (sorted-map-by
+                         (fn [left right]
+                           (compare (str right) (str left))))
+                        valid-pack)]
+    (is (= (opsv/experiment-pack-hash ordered)
            (opsv/experiment-pack-hash reordered)))
     (is (re-matches #"[0-9a-f]{64}" (opsv/experiment-pack-hash valid-pack))))
   (is (invalid? (opsv/experiment-pack-hash

--- a/components/opsv/test/ai/miniforge/opsv/interface_test.clj
+++ b/components/opsv/test/ai/miniforge/opsv/interface_test.clj
@@ -56,7 +56,8 @@
    :operational-policy/verification-summary
    {:passed? true :confidence :high :caveats []}
    :operational-policy/rollback-plan {:action :restore-manifest}
-   :operational-policy/evidence-refs [(random-uuid)]})
+   :operational-policy/evidence-refs
+   [#uuid "00000000-0000-0000-0000-000000000001"]})
 
 (def ^{:stratum 0} valid-risk
   {:score 0.35
@@ -81,8 +82,8 @@
   {:requested-actuation-mode :pr-only
    :effective-actuation-mode :pr-only
    :governed-effects
-   [{:evidence/intent-id (random-uuid)
-     :evidence/oir-id (random-uuid)
+   [{:evidence/intent-id #uuid "00000000-0000-0000-0000-000000000002"
+     :evidence/oir-id #uuid "00000000-0000-0000-0000-000000000003"
      :evidence/capability-id "grant-123"}]
    :pr-refs ["https://example.test/pr/1"]
    :apply-refs []

--- a/deps.edn
+++ b/deps.edn
@@ -10,6 +10,7 @@
                        "components/config/resources"
                        "components/algorithms/src"
                        "components/content-hash/src"
+                       "components/opsv/src"
                        "components/logging/src"
                        "components/logging/resources"
                        "components/llm/src"
@@ -216,6 +217,7 @@
                       ai.miniforge/lsp-mcp-bridge {:local/root "bases/lsp-mcp-bridge"}
                       ai.miniforge/algorithms {:local/root "components/algorithms"}
                       ai.miniforge/content-hash {:local/root "components/content-hash"}
+                      ai.miniforge/opsv {:local/root "components/opsv"}
                       ai.miniforge/logging {:local/root "components/logging"}
                       ai.miniforge/llm {:local/root "components/llm"}
                       ai.miniforge/tool {:local/root "components/tool"}
@@ -341,6 +343,7 @@
                        "components/config/test"
                        "components/algorithms/test"
                        "components/content-hash/test"
+                       "components/opsv/test"
                        "components/response/test"
                        "components/fsm/test"
                        "components/logging/test"
@@ -483,6 +486,7 @@
                       ai.miniforge/config {:local/root "components/config"}
                       ai.miniforge/algorithms {:local/root "components/algorithms"}
                       ai.miniforge/content-hash {:local/root "components/content-hash"}
+                      ai.miniforge/opsv {:local/root "components/opsv"}
                       ai.miniforge/logging {:local/root "components/logging"}
                       ai.miniforge/llm {:local/root "components/llm"}
                       ai.miniforge/tool {:local/root "components/tool"}
@@ -583,6 +587,8 @@
                               "components/algorithms/test"
                               "components/content-hash/src"
                               "components/content-hash/test"
+                              "components/opsv/src"
+                              "components/opsv/test"
                               "components/logging/src"
                               "components/logging/test"
                               "components/llm/src"
@@ -634,6 +640,7 @@
                 :extra-deps {ai.miniforge/schema {:local/root "components/schema"}
                              ai.miniforge/algorithms {:local/root "components/algorithms"}
                              ai.miniforge/content-hash {:local/root "components/content-hash"}
+                             ai.miniforge/opsv {:local/root "components/opsv"}
                              ai.miniforge/logging {:local/root "components/logging"}
                              ai.miniforge/llm {:local/root "components/llm"}
                              ai.miniforge/tool {:local/root "components/tool"}

--- a/docs/pull-requests/2026-08-05-codex-n7-opsv-contracts.md
+++ b/docs/pull-requests/2026-08-05-codex-n7-opsv-contracts.md
@@ -23,7 +23,7 @@ Foundations — domain contracts and pure hashing composition.
 
 ## Depends on
 
-- #1647 — pending merge
+- #1647 — merged
 
 ## Changes in Detail
 

--- a/docs/pull-requests/2026-08-05-codex-n7-opsv-contracts.md
+++ b/docs/pull-requests/2026-08-05-codex-n7-opsv-contracts.md
@@ -41,7 +41,7 @@ Foundations — domain contracts and pure hashing composition.
 - Run Polylith structure, Clojure lint, stratum lint, and the full pre-commit gate.
 - Verify all acceptance criteria from `work/n07-opsv-contracts.spec.edn`.
 
-Focused result: 8 tests, 48 assertions, 0 failures, 0 errors. The repository
+Focused result: 8 tests, 57 assertions, 0 failures, 0 errors. The repository
 pre-commit gate also passes, including Polylith structure, staged clj-kondo,
 stratum lint, smoke tests, and GraalVM/Babashka compatibility.
 

--- a/docs/pull-requests/2026-08-05-codex-n7-opsv-contracts.md
+++ b/docs/pull-requests/2026-08-05-codex-n7-opsv-contracts.md
@@ -1,0 +1,59 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# feat: add canonical OPSV contracts
+
+## Overview
+
+Adds the pure OPSV foundation component: closed N1/N7 domain schemas, canonical
+N6 actuation records, typed validation anomalies, and deterministic Experiment
+Pack hashing.
+
+## Motivation
+
+Every later OPSV producer and consumer needs one validated representation before
+risk, convergence, workflow, evidence, or actuation behavior can be implemented.
+
+## Layer
+
+Foundations — domain contracts and pure hashing composition.
+
+## Depends on
+
+- #1647 — pending merge
+
+## Changes in Detail
+
+- Define closed Experiment Pack and Operational Policy top-level contracts.
+- Define explainable risk, per-criterion verification, and requested/effective
+  actuation contracts using the reconciled N6 record shapes.
+- Return canonical `:invalid-input` anomaly data for validation failures.
+- Hash only validated Experiment Packs through the shared canonical EDN hasher.
+- Compose the component into the Miniforge project and root development,
+  testing, and conformance aliases.
+
+## Testing Plan
+
+- Run focused OPSV component tests.
+- Run Polylith structure, Clojure lint, stratum lint, and the full pre-commit gate.
+- Verify all acceptance criteria from `work/n07-opsv-contracts.spec.edn`.
+
+Focused result: 8 tests, 48 assertions, 0 failures, 0 errors. The repository
+pre-commit gate also passes, including Polylith structure, staged clj-kondo,
+stratum lint, smoke tests, and GraalVM/Babashka compatibility.
+
+## Deployment Plan
+
+Merge as the first N7 implementation stratum. No runtime behavior changes until
+later domain and workflow PRs consume the new interface.
+
+## Checklist
+
+- [x] Required fields and closed-key behavior tested
+- [x] Risk bounds and factor explanations tested
+- [x] Actuation modes and governed-effect correlations tested
+- [x] Canonical hash equivalence tested
+- [x] Full pre-commit gate passes

--- a/projects/miniforge/deps.edn
+++ b/projects/miniforge/deps.edn
@@ -25,6 +25,9 @@
         ai.miniforge/codex-gap {:local/root "../../components/codex-gap"}
         ai.miniforge/coerce {:local/root "../../components/coerce"}
         ai.miniforge/content-hash {:local/root "../../components/content-hash"}
+        ;; Foundation for the N7 implementation DAG. Polylith warning 207 is
+        ;; expected until the workflow stratum consumes this interface.
+        ai.miniforge/opsv {:local/root "../../components/opsv"}
         ai.miniforge/logging {:local/root "../../components/logging"}
         ai.miniforge/llm {:local/root "../../components/llm"}
         ai.miniforge/tool {:local/root "../../components/tool"}

--- a/work/n07-opsv-contracts.spec.edn
+++ b/work/n07-opsv-contracts.spec.edn
@@ -9,7 +9,8 @@
 
  :spec/intent
  {:type :feature
-  :scope ["components/opsv/**"
+  :scope ["deps.edn"
+          "components/opsv/**"
           "projects/miniforge/deps.edn"]}
 
  :normative-refs


### PR DESCRIPTION
## Layer
Foundations

## Depends on
- #1647 — merged

## What this adds
- Closed N1/N6/N7 Experiment Pack, Operational Policy, risk, verification, and actuation schemas
- Typed :invalid-input anomalies at the Polylith interface boundary
- Deterministic validated Experiment Pack hashing
- Miniforge and root dev/test/conformance composition

## Validation
- Focused: 8 tests, 57 assertions, 0 failures
- Polylith structure passes (expected warning 207 until the workflow consumes OPSV)
- Staged clj-kondo and stratum lint pass
- Full pre-commit smoke and GraalVM compatibility pass
- PR budget: 377 / 600 reportable lines

See docs/pull-requests/2026-08-05-codex-n7-opsv-contracts.md.