### PR TITLE
feat: add canonical OPSV events

### DIFF
--- a/components/event-stream/resources/config/event-stream/event-type-registry.edn
+++ b/components/event-stream/resources/config/event-stream/event-type-registry.edn
@@ -382,4 +382,25 @@
  {:constructor "repo-index-coverage-changed"
   :event-type  :repo-index/coverage-changed
   :json-string "repo-index/coverage-changed"
-  :browser?    false}]
+  :browser?    false}
+
+ ;; ── Operational Policy Synthesis events (N3 §3.14) ────────────────
+
+ {:constructor "experiment-planned" :event-type :opsv.experiment/planned
+  :json-string "opsv.experiment/planned" :browser? false}
+ {:constructor "experiment-started" :event-type :opsv.experiment/started
+  :json-string "opsv.experiment/started" :browser? false}
+ {:constructor "load-step" :event-type :opsv/load-step
+  :json-string "opsv/load-step" :browser? false}
+ {:constructor "guardrail-abort" :event-type :opsv.guardrail/abort
+  :json-string "opsv.guardrail/abort" :browser? false}
+ {:constructor "convergence-iteration" :event-type :opsv.convergence/iteration
+  :json-string "opsv.convergence/iteration" :browser? false}
+ {:constructor "policy-proposed" :event-type :opsv.policy/proposed
+  :json-string "opsv.policy/proposed" :browser? false}
+ {:constructor "verification-result" :event-type :opsv.verification/result
+  :json-string "opsv.verification/result" :browser? false}
+ {:constructor "actuation-emitted" :event-type :opsv.actuation/emitted
+  :json-string "opsv.actuation/emitted" :browser? false}
+ {:constructor "drift-detected" :event-type :opsv.drift/detected
+  :json-string "opsv.drift/detected" :browser? false}]

--- a/components/event-stream/src/ai/miniforge/event_stream/event_type_registry.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/event_type_registry.clj
@@ -75,7 +75,7 @@
 
 ;; Derived views
 (def ^{:stratum 1} browser-handled-events
-  "The 6 event types currently handled in `handleWorkflowEvent` in app.js.
+  "Event types currently handled in `handleWorkflowEvent` in app.js.
    All strings confirmed correct — no mismatches."
   (->> event-type-registry
        (filter :browser?)

--- a/components/event-stream/src/ai/miniforge/event_stream/event_type_registry.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/event_type_registry.clj
@@ -30,7 +30,7 @@
      4.  Whether the browser `handleWorkflowEvent` switch in `app.js` handles
          that string
      5.  The constructor-name → serialised-string naming asymmetries that
-         would trip up a developer reading only `interface/events.clj`
+         would trip up a developer reading only one `interface.*` API group
 
    ## Audit verdict (2026-08-05)
 
@@ -61,7 +61,7 @@
    data here.
 
    Columns:
-     :constructor  — var name in `interface/events.clj` / `core.clj`
+     :constructor  — var name exposed by an `interface.*` API group
      :event-type   — Clojure keyword set on `:event/type`
      :json-string  — string the browser receives in `event['event/type']`
      :browser?     — true iff `handleWorkflowEvent` in `app.js` has a case."

--- a/components/event-stream/src/ai/miniforge/event_stream/event_type_registry.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/event_type_registry.clj
@@ -64,7 +64,7 @@
      :constructor  — var name in `interface/events.clj` / `core.clj`
      :event-type   — Clojure keyword set on `:event/type`
      :json-string  — string the browser receives in `event['event/type']`
-     :browser?     — true iff `handleWorkflowEvent` in `app.js` has a case"
+     :browser?     — true iff `handleWorkflowEvent` in `app.js` has a case."
   data/event-type-registry)
 
 (def ^{:stratum 0} audit-summary

--- a/components/event-stream/src/ai/miniforge/event_stream/event_type_registry.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/event_type_registry.clj
@@ -21,7 +21,7 @@
    This namespace is the single source of truth for the event-type naming audit
    (Tasks 1–7).  It documents:
 
-     1.  Every constructor defined in `interface/events.clj`
+     1.  Every constructor exposed by the `interface.*` API groups
      2.  The `:event/type` keyword each constructor places in the envelope
          (see `event-stream.core/create-envelope`)
      3.  The JSON string that keyword serialises to when transmitted over
@@ -32,11 +32,11 @@
      5.  The constructor-name → serialised-string naming asymmetries that
          would trip up a developer reading only `interface/events.clj`
 
-   ## Audit verdict (2026-03-28)
+   ## Audit verdict (2026-08-05)
 
    * NO mismatches: every browser `case` string exactly matches the server keyword.
-   * LARGE coverage gap: only 6 of 45 server-side event types are handled in
-     the browser switch; the remaining 39 silently fall through to `default: break`.
+   * LARGE coverage gap: only 6 server-side event types are handled in the
+     browser switch; all other registered types fall through to `default: break`.
    * NAMING ASYMMETRIES: 13 constructors use a function name whose implied
      namespace differs from the actual `:event/type` namespace.  See
      `naming-asymmetries` below.
@@ -46,19 +46,13 @@
    file to add or modify event types.  This namespace loads it and
    derives the computed views below."
   (:require
-   [clojure.edn :as edn]
-   [clojure.java.io :as io]
+   [ai.miniforge.event-stream.event-type-registry.audit :as audit]
+   [ai.miniforge.event-stream.event-type-registry.data :as data]
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
-;; Registry — loaded from EDN resource
-(def ^{:stratum 0} ^:private registry-resource-path
-  "config/event-stream/event-type-registry.edn")
-
-;------------------------------------------------------------------------------ Layer 1
-
-(def ^{:stratum 1} event-type-registry
+(def ^{:stratum 0} event-type-registry
   "Complete mapping from constructor symbol name (as string) to serialised
    JSON event-type string, grouped by originating namespace.
 
@@ -71,14 +65,16 @@
      :event-type   — Clojure keyword set on `:event/type`
      :json-string  — string the browser receives in `event['event/type']`
      :browser?     — true iff `handleWorkflowEvent` in `app.js` has a case"
-  (-> (io/resource registry-resource-path)
-      slurp
-      edn/read-string))
+  data/event-type-registry)
 
-;------------------------------------------------------------------------------ Layer 2
+(def ^{:stratum 0} audit-summary
+  "Machine-readable registry/browser audit summary."
+  audit/audit-summary)
+
+;------------------------------------------------------------------------------ Layer 1
 
 ;; Derived views
-(def ^{:stratum 2} browser-handled-events
+(def ^{:stratum 1} browser-handled-events
   "The 6 event types currently handled in `handleWorkflowEvent` in app.js.
    All strings confirmed correct — no mismatches."
   (->> event-type-registry
@@ -87,7 +83,7 @@
 
 ;; => ["workflow/started" "workflow/phase-started" "workflow/phase-completed"
 ;;     "workflow/completed" "workflow/failed" "agent/chunk"]
-(def ^{:stratum 2} browser-unhandled-events
+(def ^{:stratum 1} browser-unhandled-events
   "Event types emitted server-side that the browser switch silently ignores.
    These are the gap items for Tasks 1–7."
   (->> event-type-registry
@@ -107,7 +103,7 @@
 ;;   cp-agent-state-changed     → "control-plane/agent-state-changed" (prefix cp → control-plane)
 ;;   cp-decision-created        → "control-plane/decision-created"  (prefix cp → control-plane)
 ;;   cp-decision-resolved       → "control-plane/decision-resolved" (prefix cp → control-plane)
-(def ^{:stratum 2} naming-asymmetries
+(def ^{:stratum 1} naming-asymmetries
   "13 constructors whose function name does not predict the namespace portion
    of the serialised event-type string.  A developer reading only
    `interface/events.clj` would guess the wrong browser case string.
@@ -119,39 +115,6 @@
                {:constructor    constructor
                 :json-string    json-string
                 :asymmetry-note asymmetry-note}))))
-
-;------------------------------------------------------------------------------ Layer 3
-
-;; Audit summary (machine-readable)
-(def ^{:stratum 3} audit-summary
-  {:audit/date          "2026-05-24"
-   :audit/source-server "components/event-stream/src/ai/miniforge/event_stream/interface/events.clj"
-   :audit/source-browser "components/web-dashboard/resources/public/js/app.js"
-   :audit/browser-switch "handleWorkflowEvent"
-
-   :total-server-events      (count event-type-registry)
-   :browser-handled-count    (count browser-handled-events)
-   :browser-unhandled-count  (count browser-unhandled-events)
-   :naming-asymmetry-count   (count naming-asymmetries)
-
-   ;; Verdict
-   :string-mismatches []
-   ;; ^ NONE: every browser case string exactly matches a server-emitted value.
-   ;; The 6 handled events are a correct, strict subset of server events.
-
-   :coverage-gaps browser-unhandled-events
-   ;; ^ Events silently ignored by the browser. Adding cases for these
-   ;;   is the primary work of Tasks 1–7.
-
-   :asymmetries naming-asymmetries
-   ;; ^ When adding browser cases, use the :json-string column above,
-   ;;   NOT a mechanical transformation of the constructor name.
-
-   :serialisation-rule
-   "Clojure namespaced keyword :ns/name serialises (Cheshire/jsonista) to
-    the plain string \"ns/name\" — no leading colon.  The browser reads
-    event['event/type'] (key has a literal slash) and compares against these
-    plain strings."})
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/event-stream/src/ai/miniforge/event_stream/event_type_registry/audit.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/event_type_registry/audit.clj
@@ -1,0 +1,47 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.event-stream.event-type-registry.audit
+  "Machine-readable audit summary derived from registry data."
+  (:require
+   [ai.miniforge.event-stream.event-type-registry.data :as data]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} audit-summary
+  (let [registry data/event-type-registry
+        handled (filter :browser? registry)
+        unhandled (remove :browser? registry)
+        asymmetries (filter :asymmetry? registry)]
+    {:audit/date "2026-08-05"
+     :audit/source-server
+     "components/event-stream/src/ai/miniforge/event_stream/interface/*.clj"
+     :audit/source-browser
+     "components/web-dashboard/resources/public/js/app.js"
+     :audit/browser-switch "handleWorkflowEvent"
+     :total-server-events (count registry)
+     :browser-handled-count (count handled)
+     :browser-unhandled-count (count unhandled)
+     :naming-asymmetry-count (count asymmetries)
+     :string-mismatches []
+     :coverage-gaps (mapv :json-string unhandled)
+     :asymmetries
+     (mapv #(select-keys % [:constructor :json-string :asymmetry-note])
+           asymmetries)
+     :serialisation-rule
+     (str "Clojure namespaced keywords serialize as ns/name without a leading "
+          "colon; browser comparisons use those plain strings.")}))

--- a/components/event-stream/src/ai/miniforge/event_stream/event_type_registry/data.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/event_type_registry/data.clj
@@ -1,0 +1,34 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.event-stream.event-type-registry.data
+  "Loading boundary for the authoritative event-type registry resource."
+  (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private registry-resource-path
+  "config/event-stream/event-type-registry.edn")
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} event-type-registry
+  (-> (io/resource registry-resource-path)
+      slurp
+      edn/read-string))

--- a/components/event-stream/src/ai/miniforge/event_stream/event_type_registry/data.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/event_type_registry/data.clj
@@ -29,6 +29,7 @@
 ;------------------------------------------------------------------------------ Layer 1
 
 (def ^{:stratum 1} event-type-registry
-  (-> (io/resource registry-resource-path)
-      slurp
-      edn/read-string))
+  (if-let [resource (io/resource registry-resource-path)]
+    (-> resource slurp edn/read-string)
+    (throw (ex-info "Event type registry resource not found"
+                    {:resource-path registry-resource-path}))))

--- a/components/event-stream/src/ai/miniforge/event_stream/interface.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface.clj
@@ -26,6 +26,7 @@
    [ai.miniforge.event-stream.interface.control-state :as control-state]
    [ai.miniforge.event-stream.interface.events :as events]
    [ai.miniforge.event-stream.interface.listeners :as listeners]
+   [ai.miniforge.event-stream.interface.opsv :as opsv]
    [ai.miniforge.event-stream.interface.stream :as stream]
    [ai.miniforge.event-stream.digest :as digest]
    [ai.miniforge.event-stream.heartbeat :as heartbeat]
@@ -200,6 +201,24 @@
 
 ;; ────────────────────────────────────────────────────────────────────────────
 ;; Event constructors
+(def ^{:stratum 0} experiment-planned opsv/experiment-planned)
+
+(def ^{:stratum 0} experiment-started opsv/experiment-started)
+
+(def ^{:stratum 0} load-step opsv/load-step)
+
+(def ^{:stratum 0} guardrail-abort opsv/guardrail-abort)
+
+(def ^{:stratum 0} convergence-iteration opsv/convergence-iteration)
+
+(def ^{:stratum 0} policy-proposed opsv/policy-proposed)
+
+(def ^{:stratum 0} verification-result opsv/verification-result)
+
+(def ^{:stratum 0} actuation-emitted opsv/actuation-emitted)
+
+(def ^{:stratum 0} drift-detected opsv/drift-detected)
+
 (def ^{:stratum 0} workflow-started
   "Build and return a :workflow/started event envelope map. Multi-arity
    for the legacy 2/3-arg call shape; the opts arity may carry

--- a/components/event-stream/src/ai/miniforge/event_stream/interface.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface.clj
@@ -201,23 +201,41 @@
 
 ;; ────────────────────────────────────────────────────────────────────────────
 ;; Event constructors
-(def ^{:stratum 0} experiment-planned opsv/experiment-planned)
+(def ^{:stratum 0} experiment-planned
+  "Construct an N3 :opsv.experiment/planned event."
+  opsv/experiment-planned)
 
-(def ^{:stratum 0} experiment-started opsv/experiment-started)
+(def ^{:stratum 0} experiment-started
+  "Construct an N3 :opsv.experiment/started event."
+  opsv/experiment-started)
 
-(def ^{:stratum 0} load-step opsv/load-step)
+(def ^{:stratum 0} load-step
+  "Construct an N3 :opsv/load-step event."
+  opsv/load-step)
 
-(def ^{:stratum 0} guardrail-abort opsv/guardrail-abort)
+(def ^{:stratum 0} guardrail-abort
+  "Construct an N3 :opsv.guardrail/abort event."
+  opsv/guardrail-abort)
 
-(def ^{:stratum 0} convergence-iteration opsv/convergence-iteration)
+(def ^{:stratum 0} convergence-iteration
+  "Construct an N3 :opsv.convergence/iteration event."
+  opsv/convergence-iteration)
 
-(def ^{:stratum 0} policy-proposed opsv/policy-proposed)
+(def ^{:stratum 0} policy-proposed
+  "Construct an N3 :opsv.policy/proposed event."
+  opsv/policy-proposed)
 
-(def ^{:stratum 0} verification-result opsv/verification-result)
+(def ^{:stratum 0} verification-result
+  "Construct an N3 :opsv.verification/result event."
+  opsv/verification-result)
 
-(def ^{:stratum 0} actuation-emitted opsv/actuation-emitted)
+(def ^{:stratum 0} actuation-emitted
+  "Construct an N3 :opsv.actuation/emitted event."
+  opsv/actuation-emitted)
 
-(def ^{:stratum 0} drift-detected opsv/drift-detected)
+(def ^{:stratum 0} drift-detected
+  "Construct an N3 :opsv.drift/detected event."
+  opsv/drift-detected)
 
 (def ^{:stratum 0} workflow-started
   "Build and return a :workflow/started event envelope map. Multi-arity

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/opsv.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/opsv.clj
@@ -1,0 +1,60 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.event-stream.interface.opsv
+  "Public schemas and constructors for the N3 OPSV event family."
+  (:require
+   [ai.miniforge.event-stream.opsv :as opsv]
+   [ai.miniforge.event-stream.schema.opsv :as schema]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ExperimentPlanned schema/ExperimentPlanned)
+
+(def ^{:stratum 0} ExperimentStarted schema/ExperimentStarted)
+
+(def ^{:stratum 0} LoadStep schema/LoadStep)
+
+(def ^{:stratum 0} GuardrailAbort schema/GuardrailAbort)
+
+(def ^{:stratum 0} ConvergenceIteration schema/ConvergenceIteration)
+
+(def ^{:stratum 0} PolicyProposed schema/PolicyProposed)
+
+(def ^{:stratum 0} VerificationResult schema/VerificationResult)
+
+(def ^{:stratum 0} ActuationEmitted schema/ActuationEmitted)
+
+(def ^{:stratum 0} DriftDetected schema/DriftDetected)
+
+(def ^{:stratum 0} experiment-planned opsv/experiment-planned)
+
+(def ^{:stratum 0} experiment-started opsv/experiment-started)
+
+(def ^{:stratum 0} load-step opsv/load-step)
+
+(def ^{:stratum 0} guardrail-abort opsv/guardrail-abort)
+
+(def ^{:stratum 0} convergence-iteration opsv/convergence-iteration)
+
+(def ^{:stratum 0} policy-proposed opsv/policy-proposed)
+
+(def ^{:stratum 0} verification-result opsv/verification-result)
+
+(def ^{:stratum 0} actuation-emitted opsv/actuation-emitted)
+
+(def ^{:stratum 0} drift-detected opsv/drift-detected)

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/opsv.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/opsv.clj
@@ -23,38 +23,70 @@
 
 ;------------------------------------------------------------------------------ Layer 0
 
-(def ^{:stratum 0} ExperimentPlanned schema/ExperimentPlanned)
+(def ^{:stratum 0} ExperimentPlanned
+  "Schema for :opsv.experiment/planned."
+  schema/ExperimentPlanned)
 
-(def ^{:stratum 0} ExperimentStarted schema/ExperimentStarted)
+(def ^{:stratum 0} ExperimentStarted
+  "Schema for :opsv.experiment/started."
+  schema/ExperimentStarted)
 
-(def ^{:stratum 0} LoadStep schema/LoadStep)
+(def ^{:stratum 0} LoadStep "Schema for :opsv/load-step." schema/LoadStep)
 
-(def ^{:stratum 0} GuardrailAbort schema/GuardrailAbort)
+(def ^{:stratum 0} GuardrailAbort
+  "Schema for :opsv.guardrail/abort."
+  schema/GuardrailAbort)
 
-(def ^{:stratum 0} ConvergenceIteration schema/ConvergenceIteration)
+(def ^{:stratum 0} ConvergenceIteration
+  "Schema for :opsv.convergence/iteration."
+  schema/ConvergenceIteration)
 
-(def ^{:stratum 0} PolicyProposed schema/PolicyProposed)
+(def ^{:stratum 0} PolicyProposed
+  "Schema for :opsv.policy/proposed."
+  schema/PolicyProposed)
 
-(def ^{:stratum 0} VerificationResult schema/VerificationResult)
+(def ^{:stratum 0} VerificationResult
+  "Schema for :opsv.verification/result."
+  schema/VerificationResult)
 
-(def ^{:stratum 0} ActuationEmitted schema/ActuationEmitted)
+(def ^{:stratum 0} ActuationEmitted
+  "Schema for :opsv.actuation/emitted."
+  schema/ActuationEmitted)
 
-(def ^{:stratum 0} DriftDetected schema/DriftDetected)
+(def ^{:stratum 0} DriftDetected
+  "Schema for :opsv.drift/detected."
+  schema/DriftDetected)
 
-(def ^{:stratum 0} experiment-planned opsv/experiment-planned)
+(def ^{:stratum 0} experiment-planned
+  "Construct an experiment-planned event."
+  opsv/experiment-planned)
 
-(def ^{:stratum 0} experiment-started opsv/experiment-started)
+(def ^{:stratum 0} experiment-started
+  "Construct an experiment-started event."
+  opsv/experiment-started)
 
-(def ^{:stratum 0} load-step opsv/load-step)
+(def ^{:stratum 0} load-step "Construct a load-step event." opsv/load-step)
 
-(def ^{:stratum 0} guardrail-abort opsv/guardrail-abort)
+(def ^{:stratum 0} guardrail-abort
+  "Construct a guardrail-abort event."
+  opsv/guardrail-abort)
 
-(def ^{:stratum 0} convergence-iteration opsv/convergence-iteration)
+(def ^{:stratum 0} convergence-iteration
+  "Construct a convergence-iteration event."
+  opsv/convergence-iteration)
 
-(def ^{:stratum 0} policy-proposed opsv/policy-proposed)
+(def ^{:stratum 0} policy-proposed
+  "Construct a policy-proposed event."
+  opsv/policy-proposed)
 
-(def ^{:stratum 0} verification-result opsv/verification-result)
+(def ^{:stratum 0} verification-result
+  "Construct a verification-result event."
+  opsv/verification-result)
 
-(def ^{:stratum 0} actuation-emitted opsv/actuation-emitted)
+(def ^{:stratum 0} actuation-emitted
+  "Construct an actuation-emitted event."
+  opsv/actuation-emitted)
 
-(def ^{:stratum 0} drift-detected opsv/drift-detected)
+(def ^{:stratum 0} drift-detected
+  "Construct a drift-detected event."
+  opsv/drift-detected)

--- a/components/event-stream/src/ai/miniforge/event_stream/opsv.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/opsv.clj
@@ -45,6 +45,8 @@
 
 (defn ^{:stratum 2} experiment-started
   [stream workflow-id evidence-id data]
+  ;; N3 section 3.14 deliberately includes the complete fingerprint value in
+  ;; this canonical message as well as in the structured internal payload.
   (opsv-event stream workflow-id evidence-id :opsv.experiment/started
               [:opsv/experiment-pack-hash :opsv/environment-fingerprint]
               (str "OPSV experiment started in "
@@ -53,6 +55,8 @@
 
 (defn ^{:stratum 2} load-step
   [stream workflow-id evidence-id data]
+  ;; N3 section 3.14 deliberately includes both load values in the canonical
+  ;; message; consumers that need structure should still use the payload keys.
   (opsv-event stream workflow-id evidence-id :opsv/load-step
               [:opsv/step-id :opsv/intended-load :opsv/observed-load]
               (str "OPSV load step " (:opsv/step-id data) ": "

--- a/components/event-stream/src/ai/miniforge/event_stream/opsv.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/opsv.clj
@@ -27,7 +27,7 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
-(defn ^{:stratum 1} opsv-event
+(defn- ^{:stratum 1} opsv-event
   [stream workflow-id evidence-id event-type payload-keys message data]
   (merge (select-keys data payload-keys)
          (core/create-envelope stream event-type workflow-id message

--- a/components/event-stream/src/ai/miniforge/event_stream/opsv.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/opsv.clj
@@ -1,0 +1,108 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.event-stream.opsv
+  "N3 OPSV event constructors with preallocated N6 bundle correlation."
+  (:require
+   [ai.miniforge.event-stream.core :as core]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private identity-keys
+  [:org/id :workspace/id :repo/id :auth/context])
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} opsv-event
+  [stream workflow-id evidence-id event-type payload-keys message data]
+  (merge (select-keys data payload-keys)
+         (core/create-envelope stream event-type workflow-id message
+                               (select-keys data identity-keys))
+         {:opsv/evidence-bundle-id evidence-id}))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} experiment-planned
+  [stream workflow-id evidence-id data]
+  (opsv-event stream workflow-id evidence-id :opsv.experiment/planned
+              [:opsv/experiment-pack-hash :opsv/targets :opsv/risk-score]
+              (str "OPSV experiment planned: " (:opsv/experiment-pack-hash data))
+              data))
+
+(defn ^{:stratum 2} experiment-started
+  [stream workflow-id evidence-id data]
+  (opsv-event stream workflow-id evidence-id :opsv.experiment/started
+              [:opsv/experiment-pack-hash :opsv/environment-fingerprint]
+              (str "OPSV experiment started in "
+                   (pr-str (:opsv/environment-fingerprint data)))
+              data))
+
+(defn ^{:stratum 2} load-step
+  [stream workflow-id evidence-id data]
+  (opsv-event stream workflow-id evidence-id :opsv/load-step
+              [:opsv/step-id :opsv/intended-load :opsv/observed-load]
+              (str "OPSV load step " (:opsv/step-id data) ": "
+                   (pr-str (:opsv/intended-load data)) " → "
+                   (pr-str (:opsv/observed-load data)))
+              data))
+
+(defn ^{:stratum 2} guardrail-abort
+  [stream workflow-id evidence-id data]
+  (opsv-event stream workflow-id evidence-id :opsv.guardrail/abort
+              [:opsv/trigger :opsv/threshold :opsv/observed
+               :opsv/rollback-action]
+              (str "OPSV guardrail abort: " (:opsv/trigger data))
+              data))
+
+(defn ^{:stratum 2} convergence-iteration
+  [stream workflow-id evidence-id data]
+  (opsv-event stream workflow-id evidence-id :opsv.convergence/iteration
+              [:opsv/iteration-id :opsv/params
+               :opsv/observed-metrics-summary]
+              (str "OPSV convergence iteration " (:opsv/iteration-id data))
+              data))
+
+(defn ^{:stratum 2} policy-proposed
+  [stream workflow-id evidence-id data]
+  (opsv-event stream workflow-id evidence-id :opsv.policy/proposed
+              [:opsv/policy-hash :opsv/diff-artifact-refs :opsv/confidence]
+              (str "OPSV policy proposed: " (:opsv/policy-hash data))
+              data))
+
+(defn ^{:stratum 2} verification-result
+  [stream workflow-id evidence-id data]
+  (opsv-event stream workflow-id evidence-id :opsv.verification/result
+              [:opsv/passed? :opsv/criteria-evaluation
+               :opsv/confidence :opsv/caveats]
+              (str "OPSV verification result: " (:opsv/passed? data))
+              data))
+
+(defn ^{:stratum 2} actuation-emitted
+  [stream workflow-id evidence-id data]
+  (opsv-event stream workflow-id evidence-id :opsv.actuation/emitted
+              [:opsv/requested-actuation-mode :opsv/effective-actuation-mode
+               :opsv/governed-effects :opsv/pr-refs :opsv/apply-refs]
+              (str "OPSV actuation emitted: "
+                   (:opsv/effective-actuation-mode data))
+              data))
+
+(defn ^{:stratum 2} drift-detected
+  [stream workflow-id evidence-id data]
+  (opsv-event stream workflow-id evidence-id :opsv.drift/detected
+              [:opsv/signal :opsv/deviation :opsv/suggested-rerun?]
+              (str "OPSV drift detected: " (:opsv/signal data))
+              data))

--- a/components/event-stream/src/ai/miniforge/event_stream/schema/opsv.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/schema/opsv.clj
@@ -16,7 +16,9 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns ai.miniforge.event-stream.schema.opsv
-  "Canonical N3 section 3.14 OPSV event schemas.")
+  "Canonical N3 section 3.14 OPSV event schemas."
+  (:require
+   [ai.miniforge.event-stream.schema :as event-schema]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -62,10 +64,6 @@
    [:event/sequence-number :int]
    [:workflow/id :uuid]
    [:opsv/evidence-bundle-id :uuid]
-   [:org/id {:optional true} :uuid]
-   [:workspace/id {:optional true} :uuid]
-   [:repo/id {:optional true} :string]
-   [:auth/context {:optional true} :map]
    [:message :string]])
 
 ;------------------------------------------------------------------------------ Layer 1
@@ -78,8 +76,9 @@
 
 (defn ^{:stratum 1} opsv-event-schema
   [event-type payload-entries]
-  (into [:map [:event/type [:= event-type]]]
-        (concat payload-entries envelope-entries)))
+  (event-schema/with-identity
+   (into [:map [:event/type [:= event-type]]]
+         (concat payload-entries envelope-entries))))
 
 ;------------------------------------------------------------------------------ Layer 2
 

--- a/components/event-stream/src/ai/miniforge/event_stream/schema/opsv.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/schema/opsv.clj
@@ -1,0 +1,152 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.event-stream.schema.opsv
+  "Canonical N3 section 3.14 OPSV event schemas.")
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} KeywordMap [:map-of :keyword any?])
+
+(def ^{:stratum 0} Targets
+  [:map {:closed true}
+   [:services [:vector :string]]
+   [:environments [:vector :string]]])
+
+(def ^{:stratum 0} RiskFactor
+  [:map {:closed true}
+   [:factor :keyword]
+   [:input any?]
+   [:contribution [:double {:min 0.0 :max 1.0}]]
+   [:rationale :string]])
+
+(def ^{:stratum 0} CriterionResult
+  [:map {:closed true}
+   [:criterion/id :string]
+   [:criterion/passed? :boolean]
+   [:criterion/observed any?]
+   [:criterion/expected any?]
+   [:criterion/reason-code :keyword]])
+
+(def ^{:stratum 0} GovernedEffect
+  [:map {:closed true}
+   [:evidence/intent-id :uuid]
+   [:evidence/oir-id :uuid]
+   [:evidence/capability-id :string]])
+
+(def ^{:stratum 0} EnvironmentFingerprint
+  [:map {:closed true}
+   [:cluster :string]
+   [:node-pools [:vector :string]]
+   [:image-digests [:map-of :string :string]]
+   [:config-hash :string]])
+
+(def ^{:stratum 0} ^:private envelope-entries
+  [[:event/id :uuid]
+   [:event/timestamp inst?]
+   [:event/version :string]
+   [:event/sequence-number :int]
+   [:workflow/id :uuid]
+   [:opsv/evidence-bundle-id :uuid]
+   [:org/id {:optional true} :uuid]
+   [:workspace/id {:optional true} :uuid]
+   [:repo/id {:optional true} :string]
+   [:auth/context {:optional true} :map]
+   [:message :string]])
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} RiskResult
+  [:map {:closed true}
+   [:score [:double {:min 0.0 :max 1.0}]]
+   [:level [:enum :low :medium :high :critical]]
+   [:factors [:vector RiskFactor]]])
+
+(defn ^{:stratum 1} opsv-event-schema
+  [event-type payload-entries]
+  (into [:map [:event/type [:= event-type]]]
+        (concat payload-entries envelope-entries)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(def ^{:stratum 2} ExperimentPlanned
+  (opsv-event-schema
+   :opsv.experiment/planned
+   [[:opsv/experiment-pack-hash :string]
+    [:opsv/targets Targets]
+    [:opsv/risk-score RiskResult]]))
+
+(def ^{:stratum 2} ExperimentStarted
+  (opsv-event-schema
+   :opsv.experiment/started
+   [[:opsv/experiment-pack-hash :string]
+    [:opsv/environment-fingerprint EnvironmentFingerprint]]))
+
+(def ^{:stratum 2} LoadStep
+  (opsv-event-schema
+   :opsv/load-step
+   [[:opsv/step-id :string]
+    [:opsv/intended-load KeywordMap]
+    [:opsv/observed-load KeywordMap]]))
+
+(def ^{:stratum 2} GuardrailAbort
+  (opsv-event-schema
+   :opsv.guardrail/abort
+   [[:opsv/trigger :keyword]
+    [:opsv/threshold KeywordMap]
+    [:opsv/observed KeywordMap]
+    [:opsv/rollback-action :keyword]]))
+
+(def ^{:stratum 2} ConvergenceIteration
+  (opsv-event-schema
+   :opsv.convergence/iteration
+   [[:opsv/iteration-id :string]
+    [:opsv/params KeywordMap]
+    [:opsv/observed-metrics-summary KeywordMap]]))
+
+(def ^{:stratum 2} PolicyProposed
+  (opsv-event-schema
+   :opsv.policy/proposed
+   [[:opsv/policy-hash :string]
+    [:opsv/diff-artifact-refs [:vector :uuid]]
+    [:opsv/confidence :keyword]]))
+
+(def ^{:stratum 2} VerificationResult
+  (opsv-event-schema
+   :opsv.verification/result
+   [[:opsv/passed? :boolean]
+    [:opsv/criteria-evaluation [:vector CriterionResult]]
+    [:opsv/confidence :keyword]
+    [:opsv/caveats [:vector :string]]]))
+
+(def ^{:stratum 2} ActuationEmitted
+  (opsv-event-schema
+   :opsv.actuation/emitted
+   [[:opsv/requested-actuation-mode
+     [:enum :recommend-only :pr-only :apply-allowed]]
+    [:opsv/effective-actuation-mode
+     [:enum :none :recommend-only :pr-only :apply-allowed]]
+    [:opsv/governed-effects [:vector GovernedEffect]]
+    [:opsv/pr-refs [:vector :string]]
+    [:opsv/apply-refs [:vector :string]]]))
+
+(def ^{:stratum 2} DriftDetected
+  (opsv-event-schema
+   :opsv.drift/detected
+   [[:opsv/signal :keyword]
+    [:opsv/deviation KeywordMap]
+    [:opsv/suggested-rerun? :boolean]]))

--- a/components/event-stream/src/ai/miniforge/event_stream/schema/opsv.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/schema/opsv.clj
@@ -58,13 +58,13 @@
    [:config-hash :string]])
 
 (def ^{:stratum 0} ^:private envelope-entries
-  [[:event/id :uuid]
+  [[:event/id uuid?]
    [:event/timestamp inst?]
-   [:event/version :string]
-   [:event/sequence-number :int]
-   [:workflow/id :uuid]
-   [:opsv/evidence-bundle-id :uuid]
-   [:message :string]])
+   [:event/version string?]
+   [:event/sequence-number int?]
+   [:workflow/id uuid?]
+   [:opsv/evidence-bundle-id uuid?]
+   [:message string?]])
 
 ;------------------------------------------------------------------------------ Layer 1
 

--- a/components/event-stream/src/ai/miniforge/event_stream/schema/opsv.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/schema/opsv.clj
@@ -20,7 +20,7 @@
 
 ;------------------------------------------------------------------------------ Layer 0
 
-(def ^{:stratum 0} KeywordMap [:map-of :keyword any?])
+(def ^{:stratum 0} KeywordMap [:map-of :keyword :any])
 
 (def ^{:stratum 0} Targets
   [:map {:closed true}
@@ -30,7 +30,7 @@
 (def ^{:stratum 0} RiskFactor
   [:map {:closed true}
    [:factor :keyword]
-   [:input any?]
+   [:input :any]
    [:contribution [:double {:min 0.0 :max 1.0}]]
    [:rationale :string]])
 
@@ -38,8 +38,8 @@
   [:map {:closed true}
    [:criterion/id :string]
    [:criterion/passed? :boolean]
-   [:criterion/observed any?]
-   [:criterion/expected any?]
+   [:criterion/observed :any]
+   [:criterion/expected :any]
    [:criterion/reason-code :keyword]])
 
 (def ^{:stratum 0} GovernedEffect

--- a/components/event-stream/test/ai/miniforge/event_stream/opsv_event_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/opsv_event_test.clj
@@ -1,0 +1,95 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.event-stream.opsv-event-test
+  (:require
+   [ai.miniforge.event-stream.interface :as event-stream]
+   [ai.miniforge.event-stream.interface.opsv :as opsv]
+   [clojure.test :refer [deftest is]]
+   [malli.core :as m]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} workflow-id
+  #uuid "00000000-0000-0000-0000-000000000010")
+
+(def ^{:stratum 0} evidence-id
+  #uuid "00000000-0000-0000-0000-000000000011")
+
+(def ^{:stratum 0} constructor-cases
+  [[event-stream/experiment-planned opsv/ExperimentPlanned
+    :opsv.experiment/planned
+    {:opsv/experiment-pack-hash "pack"
+     :opsv/targets {:services ["catalog"] :environments ["staging"]}
+     :opsv/risk-score {:score 0.1 :level :low :factors []}}]
+   [event-stream/experiment-started opsv/ExperimentStarted
+    :opsv.experiment/started
+    {:opsv/experiment-pack-hash "pack"
+     :opsv/environment-fingerprint
+     {:cluster "test" :node-pools [] :image-digests {} :config-hash "cfg"}}]
+   [event-stream/load-step opsv/LoadStep :opsv/load-step
+    {:opsv/step-id "1" :opsv/intended-load {:rps 5}
+     :opsv/observed-load {:rps 5}}]
+   [event-stream/guardrail-abort opsv/GuardrailAbort :opsv.guardrail/abort
+    {:opsv/trigger :errors :opsv/threshold {:max 1}
+     :opsv/observed {:value 2} :opsv/rollback-action :restore}]
+   [event-stream/convergence-iteration opsv/ConvergenceIteration
+    :opsv.convergence/iteration
+    {:opsv/iteration-id "1" :opsv/params {:replicas 2}
+     :opsv/observed-metrics-summary {:latency 100}}]
+   [event-stream/policy-proposed opsv/PolicyProposed :opsv.policy/proposed
+    {:opsv/policy-hash "policy" :opsv/diff-artifact-refs []
+     :opsv/confidence :high}]
+   [event-stream/verification-result opsv/VerificationResult
+    :opsv.verification/result
+    {:opsv/passed? true :opsv/criteria-evaluation []
+     :opsv/confidence :high :opsv/caveats []}]
+   [event-stream/actuation-emitted opsv/ActuationEmitted
+    :opsv.actuation/emitted
+    {:opsv/requested-actuation-mode :recommend-only
+     :opsv/effective-actuation-mode :recommend-only
+     :opsv/governed-effects [] :opsv/pr-refs [] :opsv/apply-refs []}]
+   [event-stream/drift-detected opsv/DriftDetected :opsv.drift/detected
+    {:opsv/signal :latency :opsv/deviation {:ratio 1.1}
+     :opsv/suggested-rerun? true}]])
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} test-all-opsv-constructors-emit-canonical-events
+  (let [stream (event-stream/create-event-stream)]
+    (doseq [[constructor schema event-type payload] constructor-cases]
+      (let [event (constructor stream workflow-id evidence-id payload)]
+        (is (= event-type (:event/type event)))
+        (is (= workflow-id (:workflow/id event)))
+        (is (= evidence-id (:opsv/evidence-bundle-id event)))
+        (is (not-empty (:message event)))
+        (is (m/validate schema event) (str event-type " validates"))))))
+
+(deftest ^{:stratum 1} test-opsv-constructor-propagates-identity-without-overrides
+  (let [stream (event-stream/create-event-stream)
+        org-id #uuid "00000000-0000-0000-0000-000000000012"
+        event (event-stream/drift-detected
+               stream workflow-id evidence-id
+               {:opsv/signal :latency
+                :opsv/deviation {}
+                :opsv/suggested-rerun? false
+                :org/id org-id
+                :event/type :wrong
+                :opsv/evidence-bundle-id (random-uuid)})]
+    (is (= org-id (:org/id event)))
+    (is (= :opsv.drift/detected (:event/type event)))
+    (is (= evidence-id (:opsv/evidence-bundle-id event)))))

--- a/components/event-stream/test/ai/miniforge/event_stream/opsv_schema_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/opsv_schema_test.clj
@@ -1,0 +1,93 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.event-stream.opsv-schema-test
+  (:require
+   [ai.miniforge.event-stream.schema.opsv :as opsv-schema]
+   [clojure.test :refer [deftest is]]
+   [malli.core :as m]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} evidence-id
+  #uuid "00000000-0000-0000-0000-000000000001")
+
+(def ^{:stratum 0} event-cases
+  [[opsv-schema/ExperimentPlanned :opsv.experiment/planned
+    {:opsv/experiment-pack-hash "pack-hash"
+     :opsv/targets {:services ["catalog"] :environments ["staging"]}
+     :opsv/risk-score
+     {:score 0.2 :level :low
+      :factors [{:factor :blast-radius :input 1 :contribution 0.2
+                 :rationale "One service"}]}}]
+   [opsv-schema/ExperimentStarted :opsv.experiment/started
+    {:opsv/experiment-pack-hash "pack-hash"
+     :opsv/environment-fingerprint
+     {:cluster "test" :node-pools ["workers"]
+      :image-digests {"catalog" "sha256:abc"} :config-hash "config"}}]
+   [opsv-schema/LoadStep :opsv/load-step
+    {:opsv/step-id "step-1" :opsv/intended-load {:rps 100}
+     :opsv/observed-load {:rps 98}}]
+   [opsv-schema/GuardrailAbort :opsv.guardrail/abort
+    {:opsv/trigger :error-rate :opsv/threshold {:max 0.05}
+     :opsv/observed {:value 0.08} :opsv/rollback-action :restore}]
+   [opsv-schema/ConvergenceIteration :opsv.convergence/iteration
+    {:opsv/iteration-id "iteration-1" :opsv/params {:replicas 4}
+     :opsv/observed-metrics-summary {:latency-p95 180}}]
+   [opsv-schema/PolicyProposed :opsv.policy/proposed
+    {:opsv/policy-hash "policy-hash"
+     :opsv/diff-artifact-refs [#uuid "00000000-0000-0000-0000-000000000004"]
+     :opsv/confidence :high}]
+   [opsv-schema/VerificationResult :opsv.verification/result
+    {:opsv/passed? true
+     :opsv/criteria-evaluation
+     [{:criterion/id "latency" :criterion/passed? true
+       :criterion/observed 180 :criterion/expected 200
+       :criterion/reason-code :within-threshold}]
+     :opsv/confidence :high :opsv/caveats []}]
+   [opsv-schema/ActuationEmitted :opsv.actuation/emitted
+    {:opsv/requested-actuation-mode :pr-only
+     :opsv/effective-actuation-mode :pr-only
+     :opsv/governed-effects
+     [{:evidence/intent-id #uuid "00000000-0000-0000-0000-000000000005"
+       :evidence/oir-id #uuid "00000000-0000-0000-0000-000000000006"
+       :evidence/capability-id "grant-1"}]
+     :opsv/pr-refs ["https://example.test/pr/1"] :opsv/apply-refs []}]
+   [opsv-schema/DriftDetected :opsv.drift/detected
+    {:opsv/signal :latency :opsv/deviation {:ratio 1.2}
+     :opsv/suggested-rerun? true}]])
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} event-base
+  {:event/id #uuid "00000000-0000-0000-0000-000000000002"
+   :event/timestamp #inst "2026-08-05T00:00:00.000-00:00"
+   :event/version "1.0"
+   :event/sequence-number 0
+   :workflow/id #uuid "00000000-0000-0000-0000-000000000003"
+   :opsv/evidence-bundle-id evidence-id
+   :message "OPSV event"})
+
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} test-all-canonical-opsv-event-schemas
+  (doseq [[schema event-type payload] event-cases]
+    (let [event (merge event-base payload {:event/type event-type})]
+      (is (m/validate schema event) (str event-type " validates"))
+      (is (not (m/validate schema
+                           (dissoc event :opsv/evidence-bundle-id)))
+          (str event-type " requires preallocated evidence id")))))

--- a/components/event-stream/test/ai/miniforge/event_stream/opsv_schema_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/opsv_schema_test.clj
@@ -75,7 +75,7 @@
 
 (def ^{:stratum 1} event-base
   {:event/id #uuid "00000000-0000-0000-0000-000000000002"
-   :event/timestamp #inst "2026-08-05T00:00:00.000-00:00"
+   :event/timestamp #inst "2026-08-05T00:00:00.000Z"
    :event/version "1.0"
    :event/sequence-number 0
    :workflow/id #uuid "00000000-0000-0000-0000-000000000003"

--- a/docs/pull-requests/2026-08-05-codex-n7-opsv-events.md
+++ b/docs/pull-requests/2026-08-05-codex-n7-opsv-events.md
@@ -1,0 +1,61 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# feat: add canonical OPSV events
+
+## Overview
+
+Implements the complete nine-event N3 OPSV family as decomposed schemas and
+public constructors, with every event correlated to its preallocated N6 evidence
+bundle identifier.
+
+## Motivation
+
+OPSV workflow and evidence assembly require one canonical durable event surface
+before execution phases can be wired safely.
+
+## Layer
+
+Infrastructure — event contracts and pure envelope constructors.
+
+## Depends on
+
+- #1650 — merged
+
+## Changes in Detail
+
+- Add exact schemas for all nine N3 section 3.14 event types.
+- Add public constructors that preserve workflow, evidence, and tenant identity.
+- Register all serialized event names in the authoritative registry.
+- Decompose OPSV schemas and public API into focused namespaces.
+- Refresh stale registry source/date/count documentation found during audit.
+
+## Testing Plan
+
+- Validate every canonical event and required preallocated evidence identifier.
+- Validate every constructor against its corresponding schema.
+- Run the complete event-stream brick suite in every composed project.
+- Run pre-commit and the event-stream brick in every project composition.
+- Confirm kondo and stratum lint are clean for every changed Clojure file.
+
+## Deployment Plan
+
+No migration is required; this adds new event types and constructors.
+
+## Checklist
+
+- [x] Nine schemas match N3 section 3.14
+- [x] Nine constructors preserve N6 correlation
+- [x] Event registry includes all serialized names
+- [x] New focused tests: 3 tests, 66 assertions, 0 failures/errors
+- [x] Full event-stream brick suite passes in all project compositions
+- [x] Pre-commit suite passes
+- [x] Changed Clojure files have zero kondo or stratum findings
+
+The whole event-stream component scan continues to report eleven pre-existing
+`SL003` namespace-depth findings outside this diff. This PR removes the finding
+that modifying the registry would otherwise have introduced by extracting its
+data-loading and audit-summary responsibilities.


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# feat: add canonical OPSV events

## Overview

Implements the complete nine-event N3 OPSV family as decomposed schemas and
public constructors, with every event correlated to its preallocated N6 evidence
bundle identifier.

## Motivation

OPSV workflow and evidence assembly require one canonical durable event surface
before execution phases can be wired safely.

## Layer

Infrastructure — event contracts and pure envelope constructors.

## Depends on

- #1650 — merged

## Changes in Detail

- Add exact schemas for all nine N3 section 3.14 event types.
- Add public constructors that preserve workflow, evidence, and tenant identity.
- Register all serialized event names in the authoritative registry.
- Decompose OPSV schemas and public API into focused namespaces.
- Refresh stale registry source/date/count documentation found during audit.

## Testing Plan

- Validate every canonical event and required preallocated evidence identifier.
- Validate every constructor against its corresponding schema.
- Run the complete event-stream brick suite in every composed project.
- Run pre-commit and the event-stream brick in every project composition.
- Confirm kondo and stratum lint are clean for every changed Clojure file.

## Deployment Plan

No migration is required; this adds new event types and constructors.

## Checklist

- [x] Nine schemas match N3 section 3.14
- [x] Nine constructors preserve N6 correlation
- [x] Event registry includes all serialized names
- [x] New focused tests: 3 tests, 66 assertions, 0 failures/errors
- [x] Full event-stream brick suite passes in all project compositions
- [x] Pre-commit suite passes
- [x] Changed Clojure files have zero kondo or stratum findings

The whole event-stream component scan continues to report eleven pre-existing
`SL003` namespace-depth findings outside this diff. This PR removes the finding
that modifying the registry would otherwise have introduced by extracting its
data-loading and audit-summary responsibilities.
