### PR TITLE
docs: complete OPSV evidence references

### DIFF
--- a/docs/pull-requests/2026-08-05-codex-n7-opsv-evidence-refs.md
+++ b/docs/pull-requests/2026-08-05-codex-n7-opsv-evidence-refs.md
@@ -1,0 +1,47 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# docs: complete OPSV evidence references
+
+## Overview
+
+Completes the N6 OPSV evidence shape with the aggregate reference fields already
+required by its immutable-finalization prose.
+
+## Motivation
+
+N6 requires finalization to preserve every accumulated event, artifact, and
+capability reference, but version 0.7.0 provided no canonical keys for those
+sets. Implementations would otherwise need undocumented extensions.
+
+## Layer
+
+Specification — normative N6 evidence contract only.
+
+## Changes in Detail
+
+- Add `:opsv/event-refs` for the complete N3 event identifier set.
+- Add `:opsv/artifact-refs` for the complete artifact identifier set.
+- Add `:opsv/capability-refs` for the complete N10 capability identifier set.
+- Advance N6 to 0.7.1-draft and record the compatibility amendment.
+
+## Testing Plan
+
+- Run Markdown formatting and repository pre-commit checks.
+- Verify the §2.8 prose and canonical map now describe the same preservation
+  contract.
+
+## Deployment Plan
+
+No deployment or migration is required; this completes a draft contract before
+its OPSV evidence implementation ships.
+
+## Checklist
+
+- [x] Event references have a canonical field
+- [x] Artifact references have a canonical aggregate field
+- [x] Capability references have a canonical field
+- [x] Existing detailed artifact and governed-effect fields remain unchanged

--- a/specs/normative/N6-evidence-provenance.md
+++ b/specs/normative/N6-evidence-provenance.md
@@ -6,8 +6,8 @@
 
 # N6 — Evidence & Provenance Standard
 
-**Version:** 0.7.0-draft
-**Date:** 2026-08-04
+**Version:** 0.7.1-draft
+**Date:** 2026-08-05
 **Status:** Draft
 **Conformance:** MUST
 
@@ -339,6 +339,10 @@ artifact, capability, and governed effect accumulated during the run.
    :node-pools [string ...]
    :image-digests {...}
    :config-hash string}
+
+  :opsv/event-refs [uuid ...]          ; Complete N3 event identifier set
+  :opsv/artifact-refs [uuid ...]       ; Complete referenced artifact set
+  :opsv/capability-refs [string ...]   ; Complete N10 capability identifier set
 
   :opsv/risk-score
   {:score double                      ; [0.0, 1.0]
@@ -1115,6 +1119,8 @@ Fleet-wide evidence will enable:
 
 **Version History:**
 
+- 0.7.1-draft (2026-08-05): Added aggregate OPSV event, artifact, and capability
+  reference fields required by the immutable-finalization contract in §2.8
 - 0.7.0-draft (2026-08-04): OPSV evidence now records preallocated bundle
   correlation, content-addressed inputs, explainable risk, per-criterion
   verification, requested/effective actuation, correlated N10 effects,


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# docs: complete OPSV evidence references

## Overview

Completes the N6 OPSV evidence shape with the aggregate reference fields already
required by its immutable-finalization prose.

## Motivation

N6 requires finalization to preserve every accumulated event, artifact, and
capability reference, but version 0.7.0 provided no canonical keys for those
sets. Implementations would otherwise need undocumented extensions.

## Layer

Specification — normative N6 evidence contract only.

## Changes in Detail

- Add `:opsv/event-refs` for the complete N3 event identifier set.
- Add `:opsv/artifact-refs` for the complete artifact identifier set.
- Add `:opsv/capability-refs` for the complete N10 capability identifier set.
- Advance N6 to 0.7.1-draft and record the compatibility amendment.

## Testing Plan

- Run Markdown formatting and repository pre-commit checks.
- Verify the §2.8 prose and canonical map now describe the same preservation
  contract.

## Deployment Plan

No deployment or migration is required; this completes a draft contract before
its OPSV evidence implementation ships.

## Checklist

- [x] Event references have a canonical field
- [x] Artifact references have a canonical aggregate field
- [x] Capability references have a canonical field
- [x] Existing detailed artifact and governed-effect fields remain unchanged
