### PR TITLE
CI load-check for bb.edn task classpaths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,17 @@ jobs:
           bb lint:clj:all 2>&1 | tee clj-kondo.log
           echo "::endgroup::"
 
+      # Guards the hand-maintained :extra-paths lists in bb.edn: loads each
+      # such task's entry namespaces in a fresh bb process (no execution).
+      # Without this, a grown require chain breaks `bb miniforge run` etc.
+      # on main with no signal (PR #1640 was the third occurrence).
+      - name: Check bb task classpaths
+        run: |
+          set -o pipefail
+          echo "::group::bb task classpath load check"
+          bb check:bb-classpaths 2>&1 | tee bb-classpaths.log
+          echo "::endgroup::"
+
       - name: Lint Markdown
         run: |
           echo "::group::Markdown Linting"
@@ -130,6 +141,7 @@ jobs:
           name: lint-logs-${{ github.sha }}
           path: |
             clj-kondo.log
+            bb-classpaths.log
             markdownlint.log
           retention-days: 7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,7 @@ jobs:
 
       - name: Lint Clojure
         run: |
+          set -o pipefail
           echo "::group::Clojure Linting"
           bb lint:clj:all 2>&1 | tee clj-kondo.log
           echo "::endgroup::"

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -841,7 +841,7 @@
             (publish-failure-event! event-stream workflow-id :interrupted
                                    (messages/t :workflow-runner/stopped {:error (ex-message e)}))
             (reset! completed? true))
-          (throw e)))
+          (throw+)))
       (finally
         (when-not @completed?
           (publish-failure-event! event-stream workflow-id :cancelled
@@ -1243,7 +1243,7 @@
         (when-not quiet
           (println (display/colorize :red (messages/t :workflow-runner/spec-execution-failed {:error (ex-message e)})))
           (flush))
-        (throw e)))))
+        (throw+)))))
 
 (defn ^{:stratum 8} run-chain!
   "Execute a chain of workflows.

--- a/bb.edn
+++ b/bb.edn
@@ -61,7 +61,7 @@
    :task (lint/stratum-staged)}
 
   check:bb-classpaths
-  {:doc  "Load-check entry namespaces of every bb.edn task with :extra-paths (catches classpath drift; load only, no task execution)"
+  {:doc  "Load-check entry namespaces of every bb.edn task declaring :extra-paths + :requires (catches classpath drift; load only, no task execution)"
    :requires ([ai.miniforge.bb-task-classpath.interface :as task-classpath])
    :task (let [exit (task-classpath/check-all! {})]
            (when-not (zero? exit)

--- a/bb.edn
+++ b/bb.edn
@@ -60,6 +60,13 @@
    :requires ([lint])
    :task (lint/stratum-staged)}
 
+  check:bb-classpaths
+  {:doc  "Load-check entry namespaces of every bb.edn task with :extra-paths (catches classpath drift; load only, no task execution)"
+   :requires ([ai.miniforge.bb-task-classpath.interface :as task-classpath])
+   :task (let [exit (task-classpath/check-all! {})]
+           (when-not (zero? exit)
+             (System/exit exit)))}
+
   fmt:md
   {:doc  "Format staged Markdown files (lint --fix)"
    :requires ([fmt])
@@ -625,6 +632,10 @@
                  "components/messages/resources"
                  "components/config/src"
                  "components/config/resources"]
+   ;; response → anomaly requires slingshot; config → governance requires
+   ;; aero (both caught by check:bb-classpaths)
+   :extra-deps {slingshot/slingshot {:mvn/version "0.12.2"}
+                aero/aero {:mvn/version "1.1.6"}}
    :requires ([ai.miniforge.lsp-mcp-bridge.main :as bridge])
    :task    (bridge/-main)}
 
@@ -638,6 +649,8 @@
                  "components/messages/resources"
                  "components/config/src"
                  "components/config/resources"]
+   ;; response → anomaly requires slingshot (caught by check:bb-classpaths)
+   :extra-deps {slingshot/slingshot {:mvn/version "0.12.2"}}
    :requires ([ai.miniforge.lsp-mcp-bridge.tasks :as tasks])
    :task    (tasks/status)}
 
@@ -651,6 +664,8 @@
                  "components/messages/resources"
                  "components/config/src"
                  "components/config/resources"]
+   ;; response → anomaly requires slingshot (caught by check:bb-classpaths)
+   :extra-deps {slingshot/slingshot {:mvn/version "0.12.2"}}
    :requires ([ai.miniforge.lsp-mcp-bridge.tasks :as tasks])
    :task    (tasks/install *command-line-args*)}
 
@@ -664,6 +679,8 @@
                  "components/messages/resources"
                  "components/config/src"
                  "components/config/resources"]
+   ;; response → anomaly requires slingshot (caught by check:bb-classpaths)
+   :extra-deps {slingshot/slingshot {:mvn/version "0.12.2"}}
    :requires ([ai.miniforge.lsp-mcp-bridge.tasks :as tasks])
    :task    (tasks/setup *command-line-args*)}
 

--- a/components/bb-task-classpath/deps.edn
+++ b/components/bb-task-classpath/deps.edn
@@ -1,0 +1,6 @@
+{:paths ["src"]
+ :deps  {}
+ :aliases
+ {:test {:extra-paths ["test"]
+         :extra-deps {io.github.cognitect-labs/test-runner
+                      {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}}}

--- a/components/bb-task-classpath/src/ai/miniforge/bb_task_classpath/core.clj
+++ b/components/bb-task-classpath/src/ai/miniforge/bb_task_classpath/core.clj
@@ -1,0 +1,98 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.bb-task-classpath.core
+  "Load-check the entry namespaces of bb.edn tasks that carry
+   :extra-paths.
+
+   A task's :extra-paths list is a hand-maintained classpath: when an
+   entry namespace's require chain grows a component the list doesn't
+   cover, the task breaks at namespace load on main with no CI signal
+   (third occurrence: PR #1640, after #1626 and the mcp-context-server
+   additions). This check reconstructs each such task's classpath in a
+   fresh Babashka process and requires its entry namespaces — load
+   only, no task execution.
+
+   Layer 0: pure spec extraction + child-program generation
+   Layer 1: subprocess execution and reporting"
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.java.shell :as shell]
+            [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; ── Layer 0 ──────────────────────────────────────────────────────────
+(defn ^{:stratum 0} check-specs
+  "One check spec per task declaring both :extra-paths and :requires.
+   Root :paths/:deps are merged in because bb puts them on every
+   task's classpath. Sorted by task name for stable output."
+  [bb-edn]
+  (->> (:tasks bb-edn)
+       (filter (fn [[task-name task]]
+                 (and (symbol? task-name)
+                      (map? task)
+                      (seq (:extra-paths task))
+                      (seq (:requires task)))))
+       (map (fn [[task-name task]]
+              {:task       task-name
+               :paths      (vec (concat (:paths bb-edn) (:extra-paths task)))
+               :deps       (merge {} (:deps bb-edn) (:extra-deps task))
+               :namespaces (mapv first (:requires task))}))
+       (sort-by (comp str :task))
+       vec))
+
+(defn ^{:stratum 0} load-program
+  "Program for a fresh bb process: reconstruct the task's classpath,
+   then require its entry namespaces. The path separator is resolved
+   in the child so the program is portable across platforms."
+  [{:keys [paths deps namespaces]}]
+  (->> [(list 'babashka.deps/add-deps (list 'quote {:deps deps}))
+        (list 'babashka.classpath/add-classpath
+              (list 'clojure.string/join
+                    '(System/getProperty "path.separator")
+                    paths))
+        (cons 'require (map (fn [n] (list 'quote n)) namespaces))]
+       (map pr-str)
+       (str/join " ")))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; ── Layer 1 ──────────────────────────────────────────────────────────
+(defn- ^{:stratum 1} check-task!
+  [repo-root spec]
+  (let [{:keys [exit out err]} (shell/with-sh-dir repo-root
+                                 (shell/sh "bb" "-e" (load-program spec)))]
+    (assoc spec :exit exit :out out :err err)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} check-all!
+  "Load-check every bb.edn task with :extra-paths. Prints one line per
+   task (plus captured output on failure) and returns a process exit
+   code: 0 when every entry namespace loads, 1 otherwise."
+  [{:keys [repo-root bb-edn-path]
+    :or   {repo-root "." bb-edn-path "bb.edn"}}]
+  (let [bb-edn  (edn/read-string (slurp (io/file repo-root bb-edn-path)))
+        results (mapv (partial check-task! repo-root) (check-specs bb-edn))]
+    (doseq [{:keys [task exit out err]} results]
+      (if (zero? exit)
+        (println "✓" task)
+        (do (println "✗" task "— entry namespaces failed to load (exit" (str exit ")"))
+            (doseq [s [out err] :when (not (str/blank? s))]
+              (println s)))))
+    (if (every? (comp zero? :exit) results) 0 1)))

--- a/components/bb-task-classpath/src/ai/miniforge/bb_task_classpath/core.clj
+++ b/components/bb-task-classpath/src/ai/miniforge/bb_task_classpath/core.clj
@@ -36,7 +36,6 @@
 
 ;------------------------------------------------------------------------------ Layer 0
 
-;; ── Layer 0 ──────────────────────────────────────────────────────────
 (defn ^{:stratum 0} check-specs
   "One check spec per task declaring both :extra-paths and :requires.
    Root :paths/:deps are merged in because bb puts them on every
@@ -72,7 +71,6 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
-;; ── Layer 1 ──────────────────────────────────────────────────────────
 (defn- ^{:stratum 1} check-task!
   [repo-root spec]
   (let [{:keys [exit out err]} (shell/with-sh-dir repo-root

--- a/components/bb-task-classpath/src/ai/miniforge/bb_task_classpath/core.clj
+++ b/components/bb-task-classpath/src/ai/miniforge/bb_task_classpath/core.clj
@@ -80,9 +80,11 @@
 ;------------------------------------------------------------------------------ Layer 2
 
 (defn ^{:stratum 2} check-all!
-  "Load-check every bb.edn task with :extra-paths. Prints one line per
-   task (plus captured output on failure) and returns a process exit
-   code: 0 when every entry namespace loads, 1 otherwise."
+  "Load-check every bb.edn task declaring both :extra-paths and
+   :requires (a task relying solely on root :requires has no entry
+   namespaces of its own to check). Prints one line per task (plus
+   captured output on failure) and returns a process exit code: 0 when
+   every entry namespace loads, 1 otherwise."
   [{:keys [repo-root bb-edn-path]
     :or   {repo-root "." bb-edn-path "bb.edn"}}]
   (let [bb-edn  (edn/read-string (slurp (io/file repo-root bb-edn-path)))

--- a/components/bb-task-classpath/src/ai/miniforge/bb_task_classpath/interface.clj
+++ b/components/bb-task-classpath/src/ai/miniforge/bb_task_classpath/interface.clj
@@ -1,0 +1,34 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.bb-task-classpath.interface
+  "Public API for the bb.edn task-classpath load check."
+  (:require [ai.miniforge.bb-task-classpath.core :as core]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} check-specs
+  [bb-edn]
+  (core/check-specs bb-edn))
+
+(defn ^{:stratum 0} load-program
+  [spec]
+  (core/load-program spec))
+
+(defn ^{:stratum 0} check-all!
+  [opts]
+  (core/check-all! opts))

--- a/components/bb-task-classpath/test/ai/miniforge/bb_task_classpath/core_test.clj
+++ b/components/bb-task-classpath/test/ai/miniforge/bb_task_classpath/core_test.clj
@@ -1,0 +1,78 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.bb-task-classpath.core-test
+  (:require [ai.miniforge.bb-task-classpath.core :as sut]
+            [clojure.test :refer [deftest is testing]]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Mirrors the real bb.edn shape: top-level :requires/:init keyword
+;; entries alongside symbol-keyed tasks, root :paths/:deps, and a task
+;; carrying :extra-paths + :extra-deps + :requires.
+(def ^{:stratum 0} sample-bb-edn
+  '{:paths ["tasks"]
+    :deps  {ai.miniforge/bb-utils {:local/root "projects/bb-utils"}}
+    :tasks
+    {:requires ([babashka.fs :as fs])
+     :init     (do)
+     lint:clj  {:requires ([lint])
+                :task (lint/clj-staged)}
+     mcp-context-server
+     {:extra-paths ["bases/mcp-context-server/src"
+                    "components/codex/src"]
+      :extra-deps  {cheshire/cheshire {:mvn/version "5.13.0"}}
+      :requires    ([ai.miniforge.mcp-context-server.main :as mcp])
+      :task        (apply mcp/-main *command-line-args*)}
+     extract:artifact
+     {:extra-paths ["components/evidence-bundle/src"]
+      :requires    ([ai.miniforge.evidence-bundle.extraction-bulk :as eb]
+                    [babashka.fs :as fs])
+      :task        (eb/extract-artifact-from-file nil)}}})
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} check-specs-test
+  (let [specs (sut/check-specs sample-bb-edn)]
+    (testing "only tasks with both :extra-paths and :requires are checked"
+      (is (= '[extract:artifact mcp-context-server] (mapv :task specs))))
+    (testing "root paths precede the task's extra paths"
+      (is (= ["tasks" "bases/mcp-context-server/src" "components/codex/src"]
+             (:paths (second specs)))))
+    (testing "root deps merge with the task's extra deps"
+      (is (= '{ai.miniforge/bb-utils {:local/root "projects/bb-utils"}
+               cheshire/cheshire {:mvn/version "5.13.0"}}
+             (:deps (second specs)))))
+    (testing "entry namespaces come from each libspec head"
+      (is (= '[ai.miniforge.evidence-bundle.extraction-bulk babashka.fs]
+             (:namespaces (first specs)))))))
+
+(deftest ^{:stratum 1} load-program-test
+  (let [spec  (second (sut/check-specs sample-bb-edn))
+        forms (read-string (str "[" (sut/load-program spec) "]"))]
+    (testing "adds the merged deps first"
+      (is (= (list 'babashka.deps/add-deps (list 'quote {:deps (:deps spec)}))
+             (first forms))))
+    (testing "adds the full path list with the child's path separator"
+      (is (= (list 'babashka.classpath/add-classpath
+                   (list 'clojure.string/join
+                         '(System/getProperty "path.separator")
+                         (:paths spec)))
+             (second forms))))
+    (testing "requires every entry namespace"
+      (is (= '(require (quote ai.miniforge.mcp-context-server.main))
+             (nth forms 2))))))

--- a/deps.edn
+++ b/deps.edn
@@ -213,7 +213,8 @@
                        "components/bb-generate-icon/src"
                        "components/bb-r2/src"
                        "components/bb-data-plane-http/src"
-                       "components/bb-etl-runner/src"]
+                       "components/bb-etl-runner/src"
+                       "components/bb-task-classpath/src"]
          :extra-deps {ai.miniforge/schema {:local/root "components/schema"}
                       ai.miniforge/config {:local/root "components/config"}
                       ai.miniforge/lsp-mcp-bridge {:local/root "bases/lsp-mcp-bridge"}
@@ -486,7 +487,8 @@
                        "components/bb-generate-icon/test"
                        "components/bb-r2/test"
                        "components/bb-data-plane-http/test"
-                       "components/bb-etl-runner/test"]
+                       "components/bb-etl-runner/test"
+                       "components/bb-task-classpath/test"]
          :extra-deps {ai.miniforge/schema {:local/root "components/schema"}
                       ai.miniforge/config {:local/root "components/config"}
                       ai.miniforge/algorithms {:local/root "components/algorithms"}

--- a/projects/bb-utils/deps.edn
+++ b/projects/bb-utils/deps.edn
@@ -20,7 +20,8 @@
         ai.miniforge/bb-generate-icon  {:local/root "../../components/bb-generate-icon"}
         ai.miniforge/bb-r2             {:local/root "../../components/bb-r2"}
         ai.miniforge/bb-data-plane-http {:local/root "../../components/bb-data-plane-http"}
-        ai.miniforge/bb-etl-runner     {:local/root "../../components/bb-etl-runner"}}
+        ai.miniforge/bb-etl-runner     {:local/root "../../components/bb-etl-runner"}
+        ai.miniforge/bb-task-classpath {:local/root "../../components/bb-task-classpath"}}
 
  :aliases
  {:test {:extra-paths ["../../components/bb-paths/test"
@@ -33,7 +34,8 @@
                        "../../components/bb-generate-icon/test"
                        "../../components/bb-r2/test"
                        "../../components/bb-data-plane-http/test"
-                       "../../components/bb-etl-runner/test"]
+                       "../../components/bb-etl-runner/test"
+                       "../../components/bb-task-classpath/test"]
          :extra-deps {io.github.cognitect-labs/test-runner
                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
          :main-opts ["-m" "cognitect.test-runner"]}}}

--- a/tasks/lint.clj
+++ b/tasks/lint.clj
@@ -46,7 +46,10 @@
                                      "clj-kondo" "--lint" "bases" "components" "development/src")]
     (when-not (str/blank? out) (println out))
     (when-not (str/blank? err) (binding [*out* *err*] (println err)))
-    (when-not (zero? exit)
+    ;; Same policy as clj-staged: warnings (exit 2) pass, errors and
+    ;; unexpected exits fail. Moot while CI's tee pipe masked this exit;
+    ;; pipefail made it live, and repo-wide warnings must not gate CI.
+    (when-not (contains? #{0 2} exit)
       (println "❌ Linting failed with exit code:" exit)
       (System/exit exit))))
 

--- a/workspace.edn
+++ b/workspace.edn
@@ -99,4 +99,5 @@
                                           "bb-generate-icon"
                                           "bb-platform"
                                           "bb-r2"
+                                          "bb-task-classpath"
                                           "bb-test-runner"]}}}


### PR DESCRIPTION
## Why

bb.edn task `:extra-paths` lists are hand-maintained classpaths with no CI coverage. When a component's require chain grows, `bb miniforge run` (or another task) breaks at namespace load on main with no signal. Third known occurrence: #1640 (supervisory-state → policy-clause → decision-envelope → effect-transaction → execution-grant), after #1626 and the earlier mcp-context-server additions.

## What

1. New `bb-task-classpath` component: extracts a check spec for every bb.edn task carrying `:extra-paths` + `:requires` (root `:paths`/`:deps` merged, since bb puts them on every task classpath), then loads that task's entry namespaces in a fresh Babashka subprocess via `add-deps`/`add-classpath`. Load only — no task execution.
2. `bb check:bb-classpaths` task wrapping it; wired into the CI lint job (with `set -o pipefail`, log uploaded with the other lint logs).
3. Unit tests over the pure spec-extraction and program-generation layers.

## Found and fixed by the check itself

First local run failed 4 of 8 tasks — live drift on main today:

1. `lsp:status` / `lsp:install` / `lsp:setup` / `lsp-mcp-bridge`: missing `slingshot` (response → anomaly now requires it).
2. `lsp-mcp-bridge` additionally: missing `aero` (config → governance).

Both fixed via `:extra-deps` on those tasks. All 8 checked tasks now load clean.

## Verification

1. `bb check:bb-classpaths` — 8/8 ✓ locally.
2. Failure path verified: doctored bb.edn with a bogus entry namespace → ✗ line, captured error, exit 1.
3. Component unit tests pass; clj-kondo clean; `poly check` clean (component registered as `:necessary` in the bb-utils aggregator per existing convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)