### PR TITLE
fix(codex-gap): close the delivery-record gaps the first dogfood chunk exposed

### DIFF
--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
@@ -282,6 +282,18 @@
                :code/file-actions (mapv :action files)
                :code/file-count (count files))))))
 
+(defn ^{:stratum 0} preserve-consultation
+  "Carry :codex/consultation from the full phase result onto the
+   lightweight success result. The gap instrument (T2 s3.2) and the gap
+   report read consultation provenance from the durable phase record;
+   replacing the result wholesale at leave destroyed it, leaving
+   successful DAG-task implements with no evidence delivery happened.
+   Public for tests."
+  [lightweight result]
+  (if-let [consultation (get-in result [:output :codex/consultation])]
+    (assoc-in lightweight [:output :codex/consultation] consultation)
+    lightweight))
+
 (defn- ^{:stratum 0} ensure-valid-metrics
   "Phase-input boundary validation for the agent result's `:metrics`. The
    response builders guarantee non-nil numeric `:tokens`/`:duration-ms`, but a
@@ -686,7 +698,8 @@
 
             ;; On success: store lightweight result — code is in the environment, not here
             (= :completed phase-status)
-            (-> (assoc-in [:phase :result] (phase/success env-id summary))
+            (-> (assoc-in [:phase :result]
+                          (preserve-consultation (phase/success env-id summary) result))
                 (assoc-in [:phase :artifact]
                           (cond-> (lightweight-curated-artifact curated-artifact)
                             degraded-handoff?

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/verify.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/verify.clj
@@ -25,6 +25,7 @@
   (:require [ai.miniforge.anomaly.interface :as anomaly]
             [ai.miniforge.phase.interface :as phase]
             [ai.miniforge.workspace.interface :as workspace]
+            [ai.miniforge.phase-software-factory.gap-wiring :as gap-wiring]
             [ai.miniforge.phase-software-factory.phase-config :as phase-config]
             [ai.miniforge.phase-software-factory.messages :as messages]
             [ai.miniforge.phase-software-factory.phase-terminal :as phase-terminal]
@@ -321,6 +322,14 @@
 
                    :else
                    updated-ctx)]
+    ;; Gap-instrument miss recording (T2 s3): best-effort, opt-in, and it
+    ;; must never change the outcome it measures. On next-ctx, not ctx:
+    ;; gate failures sit on the untouched NAMESPACED [:phase :phase/...]
+    ;; keys either way, but the run-tests-error shape only gains its
+    ;; [:phase :error] map in attach-verify-error above. Verify has no
+    ;; static situation mapping, so its misses classify :uncovered —
+    ;; honest: no codex board addresses a failing-verify loop yet.
+    (gap-wiring/record-phase-misses! next-ctx :verify)
     (phase/emit-phase-completed! next-ctx :verify
       (merge {:outcome     (phase/outcome result (= :completed phase-status))
               :duration-ms duration-ms

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
@@ -215,6 +215,14 @@
 (defn- ^{:stratum 0} backend-timeout? [result]
   (#'implement/backend-timeout-in-result? result))
 
+(deftest ^{:stratum 0} preserve-consultation-no-consultation-unchanged-test
+  (testing "no consultation on the full result -> lightweight result
+            untouched (no empty :output key invented)"
+    (let [lightweight {:status :success :environment-id :env}]
+      (is (identical? lightweight
+                      (implement/preserve-consultation
+                       lightweight {:output {:code/summary "done"}}))))))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn ^{:stratum 1} create-base-context
@@ -517,6 +525,33 @@
         (is (nil? (get-in final-result [:phase :result :output]))
             "Result should NOT contain serialized :output / :code/files")))))
 
+(deftest ^{:stratum 2} leave-implement-preserves-codex-consultation-test
+  (testing "the lightweight success result keeps :codex/consultation — the
+            gap instrument reads delivery provenance from the durable
+            record, and the wholesale result replacement was destroying it
+            (every successful DAG-task implement looked undelivered)"
+    (with-redefs [agent/create-implementer (fn [_] {:type :mock-implementer})
+                  agent/invoke (fn [_ _ _]
+                                (response/success nil {:tokens 800 :duration-ms 1500}))
+                  agent/curate-implement-output mock-curator-success]
+      (let [consultation {:pinned? true :status :delivered
+                          :situation "changing-one-side-of-a-boundary"}
+            ctx (-> (create-base-context)
+                    (assoc :execution/environment-id (random-uuid))
+                    (assoc :phase-config {:phase :implement}))
+            interceptor (phase/get-phase-interceptor {:phase :implement})
+            enter-result (-> ((:enter interceptor) ctx)
+                             (assoc-in [:phase :result :output :codex/consultation]
+                                       consultation)
+                             (assoc-in [:phase :result :output :code/summary] "done"))
+            final-result ((:leave interceptor) enter-result)]
+        (is (= :completed (get-in final-result [:phase :status])))
+        (is (= consultation
+               (get-in final-result [:phase :result :output :codex/consultation]))
+            "consultation provenance survives the lightweight replacement")
+        (is (nil? (get-in final-result [:phase :result :output :code/summary]))
+            "everything else in :output is still dropped")))))
+
 (deftest ^{:stratum 2} leave-implement-tolerates-nil-tokens-metrics-test
   (testing "an agent result with an EXPLICIT nil :tokens (file-artifact fallback
             path) does not NPE in leave — tokens coerce to 0, verdict survives"
@@ -789,8 +824,11 @@
         (is (= ["src/core.clj"] (get-in final-result [:phase :artifact :code/file-paths])))
         (is (= :success (get-in final-result [:phase :result :status]))
             "The persisted phase result stays lightweight")
-        (is (nil? (get-in final-result [:phase :result :output]))
-            "Serialized code does not go back into the environment-model result")
+        (is (= [:codex/consultation]
+               (keys (get-in final-result [:phase :result :output])))
+            "Serialized code does not go back into the environment-model
+             result — only consultation provenance survives (gap instrument
+             reads it from the durable record)")
         (is (nil? (get-in final-result [:phase :artifact :code/files]))
             "Serialized code should not be persisted on the outer phase artifact")))))
 

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/verify_failure_modes_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/verify_failure_modes_test.clj
@@ -25,6 +25,7 @@
    [clojure.string :as str]
    [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.phase.loader :as loader]
+   [ai.miniforge.phase-software-factory.gap-wiring :as gap-wiring]
    [ai.miniforge.phase-software-factory.messages :as messages]
    [ai.miniforge.phase-software-factory.verify :as verify]))
 
@@ -172,6 +173,23 @@
             (is (str/ends-with? message suffix))
             (is (= (+ (count prefix) 1 preview-limit (count suffix))
                    (count message)))))))))
+
+(deftest ^{:stratum 1} leave-verify-records-gap-misses-test
+  (testing "leave-verify feeds the gap instrument before any result
+            rewriting — verify failures were the dominant unrecorded
+            signal in the first dogfood chunk (every failing run died at
+            verify with an empty ledger)"
+    (let [calls (atom [])]
+      (with-redefs [gap-wiring/record-phase-misses!
+                    (fn [ctx phase & _more]
+                      (swap! calls conj [phase (get-in ctx [:phase :error :message])]))]
+        (verify/leave-verify
+         (make-leave-ctx {:status :error
+                          :error {:message "Tests failed: 3 assertions"}}
+                         :implement)))
+      (is (= [[:verify "Tests failed: 3 assertions"]] @calls)
+          "recorder called once, tagged :verify, AFTER attach-verify-error
+           so the run-tests-error shape is visible as a terminal signal"))))
 
 (deftest ^{:stratum 1} leave-verify-normal-failure-emits-repair-requested-verdict-test
   (testing "Phase 3: normal verify failure with :on-fail configured sets

--- a/components/phase/src/ai/miniforge/phase/registry.clj
+++ b/components/phase/src/ai/miniforge/phase/registry.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.phase.registry
   "Phase interceptor registry using multimethods.
 
@@ -27,16 +26,83 @@
   (:require [malli.core :as m]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Schemas
 
-(def Budget
+;; Schemas
+(def ^{:stratum 0} Budget
   "Budget configuration schema"
   [:map
    [:tokens {:optional true} pos-int?]
    [:iterations {:optional true} pos-int?]
    [:time-seconds {:optional true} pos-int?]])
 
-(def PhaseConfig
+(def ^{:stratum 0} Interceptor
+  "Interceptor schema (Pedestal-style)"
+  [:map
+   [:name keyword?]
+   [:enter {:optional true} fn?]
+   [:leave {:optional true} fn?]
+   [:error {:optional true} fn?]])
+
+;; Defaults registry (atom for extensibility)
+(defonce ^{:stratum 0} defaults-registry (atom {}))
+
+(def ^{:stratum 0} policy-gates
+  "Governance gates a phase-config override must never drop from the phase-type
+   default. A workflow's per-phase `:gates` may add or trim mechanical gates
+   (syntax, lint, coverage, …) freely, but silently losing policy enforcement is
+   the one merge outcome a governance system cannot allow: the shallow
+   `(merge defaults config)` let a workflow that declared `:gates [...]` at
+   verify/review replace the default vector wholesale, dropping
+   `:policy-verify`/`:policy-review` with no signal (e.g. quick-fix-v2's verify).
+   `merge-with-defaults` re-adds any of these the default enforced but the
+   override omitted. Extend this set when a new governance gate ships.
+
+   :codex-consultation is governance, not mechanics: it asserts delivery
+   provenance for the codex warning surface, and the canonical-sdlc v2
+   implement `:gates` override was silently dropping it — exactly the
+   footgun this set exists to close."
+  #{:policy-verify :policy-review :policy-pack :codex-consultation})
+
+;; Phase status predicates
+;;
+;; Accept either a bare keyword (:completed, :failed, etc.) or a map with
+;; a status key (:status, :execution/status, :step/status, :chain/status).
+(def ^{:stratum 0} already-done-statuses
+  "Statuses indicating work is already complete — neutral outcome."
+  #{:already-satisfied :already-implemented})
+
+(def ^{:stratum 0} status-keys
+  "Keys to try when extracting status from a map, in priority order."
+  [:status :execution/status :step/status :chain/status])
+
+(def ^{:stratum 0} ^:private inner-failure-statuses
+  #{:error :failed :failure})
+
+(defn- ^{:stratum 0} result-status
+  [m]
+  (get-in m [:result :status]))
+
+(defn ^{:stratum 0} determine-phase-status
+  "Determine phase status from agent result status, iteration count, and budget.
+
+   Arguments:
+   - agent-status: The :status from the agent result (:success, :error, etc.)
+   - iterations: Current iteration count
+   - max-iterations: Maximum allowed iterations
+
+   Returns: :completed, :retrying, or :failed"
+  [agent-status iterations max-iterations]
+  (cond
+    (= :success agent-status) :completed
+    (and (= :error agent-status)
+         (< iterations max-iterations)) :retrying
+    (= :error agent-status) :failed
+    (not= :success agent-status) :failed
+    :else :completed))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} PhaseConfig
   "Phase configuration schema"
   [:map
    [:phase keyword?]
@@ -50,21 +116,8 @@
    [:model-hint {:optional true} keyword?]
    [:require-model {:optional true} keyword?]])
 
-(def Interceptor
-  "Interceptor schema (Pedestal-style)"
-  [:map
-   [:name keyword?]
-   [:enter {:optional true} fn?]
-   [:leave {:optional true} fn?]
-   [:error {:optional true} fn?]])
-
-;; Defaults registry (atom for extensibility)
-(defonce defaults-registry (atom {}))
-
-;------------------------------------------------------------------------------ Layer 1
 ;; Multimethod registry
-
-(defmulti get-phase-interceptor
+(defmulti ^{:stratum 1} get-phase-interceptor
   "Get interceptor for a phase configuration.
 
    Dispatches on :phase keyword.
@@ -76,17 +129,15 @@
      Interceptor map with :name, :enter, :leave, :error"
   :phase)
 
-(defmethod get-phase-interceptor :default
+(defmethod ^{:stratum 1} get-phase-interceptor :default
   [{:keys [phase]}]
   (throw (ex-info (str "Unknown phase type: " phase
                        ". Available: " (keys @defaults-registry))
                   {:phase phase
                    :available (keys @defaults-registry)})))
 
-;------------------------------------------------------------------------------ Layer 2
 ;; Registry management
-
-(defn register-phase-defaults!
+(defn ^{:stratum 1} register-phase-defaults!
   "Register default configuration for a phase type.
 
    Arguments:
@@ -95,7 +146,7 @@
   [phase-kw defaults]
   (swap! defaults-registry assoc phase-kw defaults))
 
-(defn phase-defaults
+(defn ^{:stratum 1} phase-defaults
   "Get default configuration for a phase type.
 
    Arguments:
@@ -106,7 +157,7 @@
   [phase-kw]
   (get @defaults-registry phase-kw))
 
-(defn list-phases
+(defn ^{:stratum 1} list-phases
   "List all registered phase types.
 
    Returns:
@@ -114,19 +165,7 @@
   []
   (set (keys @defaults-registry)))
 
-(def policy-gates
-  "Governance gates a phase-config override must never drop from the phase-type
-   default. A workflow's per-phase `:gates` may add or trim mechanical gates
-   (syntax, lint, coverage, …) freely, but silently losing policy enforcement is
-   the one merge outcome a governance system cannot allow: the shallow
-   `(merge defaults config)` let a workflow that declared `:gates [...]` at
-   verify/review replace the default vector wholesale, dropping
-   `:policy-verify`/`:policy-review` with no signal (e.g. quick-fix-v2's verify).
-   `merge-with-defaults` re-adds any of these the default enforced but the
-   override omitted. Extend this set when a new governance gate ships."
-  #{:policy-verify :policy-review :policy-pack})
-
-(defn merge-gates
+(defn ^{:stratum 1} merge-gates
   "Merge an override `:gates` vector over the phase-type default's. The result is
    the override's gates in declared order, followed by any policy gate (see
    `policy-gates`) the default enforced that the override dropped — so an
@@ -139,7 +178,24 @@
                               default-gates)]
     (into (vec override-gates) preserved)))
 
-(defn merge-with-defaults
+(defn ^{:stratum 1} valid-interceptor?
+  "Check if interceptor is valid against schema."
+  [interceptor]
+  (m/validate Interceptor interceptor))
+
+(defn- ^{:stratum 1} outer-status
+  [m]
+  (when m (some m status-keys)))
+
+(defn- ^{:stratum 1} failure-status
+  [m]
+  (let [status (result-status m)]
+    (when (contains? inner-failure-statuses status)
+      :failed)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} merge-with-defaults
   "Merge user config with phase defaults.
 
    Shallow-merges `config` over the phase-type defaults, with one exception for
@@ -161,53 +217,19 @@
       (assoc merged :gates (merge-gates (:gates defaults) (:gates config)))
       merged)))
 
-(defn valid-config?
+(defn ^{:stratum 2} valid-config?
   "Check if phase config is valid against schema."
   [config]
   (m/validate PhaseConfig config))
 
-(defn valid-interceptor?
-  "Check if interceptor is valid against schema."
-  [interceptor]
-  (m/validate Interceptor interceptor))
-
-;------------------------------------------------------------------------------ Layer 3
-;; Phase status predicates
-;;
-;; Accept either a bare keyword (:completed, :failed, etc.) or a map with
-;; a status key (:status, :execution/status, :step/status, :chain/status).
-
-(def already-done-statuses
-  "Statuses indicating work is already complete — neutral outcome."
-  #{:already-satisfied :already-implemented})
-
-(def status-keys
-  "Keys to try when extracting status from a map, in priority order."
-  [:status :execution/status :step/status :chain/status])
-
-(def ^:private inner-failure-statuses
-  #{:error :failed :failure})
-
-(defn- result-status
-  [m]
-  (get-in m [:result :status]))
-
-(defn- outer-status
-  [m]
-  (when m (some m status-keys)))
-
-(defn- failure-status
-  [m]
-  (let [status (result-status m)]
-    (when (contains? inner-failure-statuses status)
-      :failed)))
-
-(defn- completed-with-inner-failure?
+(defn- ^{:stratum 2} completed-with-inner-failure?
   [m]
   (and (= :completed (outer-status m))
        (failure-status m)))
 
-(defn extract-status
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} extract-status
   "Extract a normalized phase status keyword from a map.
 
    Inner agent failures take precedence over an outer interceptor status of
@@ -218,19 +240,21 @@
       :failed
       status)))
 
-(defn succeeded?
+;------------------------------------------------------------------------------ Layer 4
+
+(defn ^{:stratum 4} succeeded?
   "Check if a result map indicates success.
    Looks for :status, :execution/status, :step/status, or :chain/status."
   [m]
   (= :completed (extract-status m)))
 
-(defn already-done?
+(defn ^{:stratum 4} already-done?
   "Check if a result map indicates work was already complete.
    This is a neutral outcome — not a failure."
   [m]
   (contains? already-done-statuses (extract-status m)))
 
-(defn succeeded-or-done?
+(defn ^{:stratum 4} succeeded-or-done?
   "Check if a result map indicates success or already-done (neutral).
    Use this for event emission and outcome reporting."
   [m]
@@ -238,33 +262,15 @@
     (or (= :completed s)
         (contains? already-done-statuses s))))
 
-(defn failed?
+(defn ^{:stratum 4} failed?
   "Check if a result map indicates failure."
   [m]
   (= :failed (extract-status m)))
 
-(defn retrying?
+(defn ^{:stratum 4} retrying?
   "Check if a result map indicates retry."
   [m]
   (= :retrying (extract-status m)))
-
-(defn determine-phase-status
-  "Determine phase status from agent result status, iteration count, and budget.
-
-   Arguments:
-   - agent-status: The :status from the agent result (:success, :error, etc.)
-   - iterations: Current iteration count
-   - max-iterations: Maximum allowed iterations
-
-   Returns: :completed, :retrying, or :failed"
-  [agent-status iterations max-iterations]
-  (cond
-    (= :success agent-status) :completed
-    (and (= :error agent-status)
-         (< iterations max-iterations)) :retrying
-    (= :error agent-status) :failed
-    (not= :success agent-status) :failed
-    :else :completed))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/phase/test/ai/miniforge/phase/registry_test.clj
+++ b/components/phase/test/ai/miniforge/phase/registry_test.clj
@@ -15,29 +15,38 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.phase.registry-test
   (:require [clojure.test :refer [deftest is testing]]
             [ai.miniforge.phase.registry :as registry]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; merge-gates
 
-(deftest merge-gates-preserves-dropped-policy-gate-test
+;; merge-gates
+(deftest ^{:stratum 0} merge-gates-preserves-dropped-policy-gate-test
   (testing "an override that drops a policy gate gets it re-added (appended)"
     (is (= [:tests-pass :policy-verify]
            (registry/merge-gates
             [:pre-verify-lint :tests-pass :coverage :policy-verify]
             [:tests-pass])))))
 
-(deftest merge-gates-keeps-order-and-no-duplicate-test
+(deftest ^{:stratum 0} merge-gates-preserves-codex-consultation-gate-test
+  (testing "the canonical-sdlc v2 implement override shape cannot drop
+            :codex-consultation — governance gate, re-added like policy-*
+            (this exact override silently disabled the gate in every
+            canonical-sdlc run before the fix)"
+    (is (= [:syntax :lint :no-secrets :codex-consultation]
+           (registry/merge-gates
+            [:syntax :format :lint :codex-consultation]
+            [:syntax :lint :no-secrets])))))
+
+(deftest ^{:stratum 0} merge-gates-keeps-order-and-no-duplicate-test
   (testing "an override that keeps the policy gate is returned as-is (no dup)"
     (is (= [:tests-pass :policy-verify]
            (registry/merge-gates
             [:pre-verify-lint :tests-pass :coverage :policy-verify]
             [:tests-pass :policy-verify])))))
 
-(deftest merge-gates-mechanical-only-default-unchanged-test
+(deftest ^{:stratum 0} merge-gates-mechanical-only-default-unchanged-test
   (testing "no policy gate in the default → override is returned verbatim
             (mechanical trim/add is the author's choice)"
     (is (= [:syntax :lint :no-secrets]
@@ -45,17 +54,30 @@
             [:syntax :format :lint]
             [:syntax :lint :no-secrets])))))
 
-(deftest merge-gates-empty-override-still-restores-policy-test
+(deftest ^{:stratum 0} merge-gates-empty-override-still-restores-policy-test
   (testing "an explicitly empty override cannot disable a default policy gate"
     (is (= [:policy-review]
            (registry/merge-gates
             [:review-approved :quality-check :policy-review]
             [])))))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; merge-with-defaults
+(def ^{:stratum 0} ^:private verify-like-phase :registry-test/verify-like)
 
-(def ^:private verify-like-phase :registry-test/verify-like)
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} merge-with-defaults-no-gates-override-keeps-defaults-test
+  (testing "a config without :gates keeps the full default gate vector"
+    (is (= [:pre-verify-lint :tests-pass :coverage :policy-verify]
+           (:gates (registry/merge-with-defaults
+                    {:phase verify-like-phase :budget {:tokens 5}}))))))
+
+(deftest ^{:stratum 1} merge-with-defaults-override-cannot-drop-policy-gate-test
+  (testing "a :gates override that omits :policy-verify still enforces it —
+            the quick-fix-v2 footgun (verify :gates [:tests-pass]) is closed"
+    (is (= [:tests-pass :policy-verify]
+           (:gates (registry/merge-with-defaults
+                    {:phase verify-like-phase :gates [:tests-pass]}))))))
 
 (registry/register-phase-defaults!
  verify-like-phase
@@ -63,16 +85,3 @@
   :agent nil
   :gates [:pre-verify-lint :tests-pass :coverage :policy-verify]
   :budget {:tokens 0 :iterations 3 :time-seconds 300}})
-
-(deftest merge-with-defaults-no-gates-override-keeps-defaults-test
-  (testing "a config without :gates keeps the full default gate vector"
-    (is (= [:pre-verify-lint :tests-pass :coverage :policy-verify]
-           (:gates (registry/merge-with-defaults
-                    {:phase verify-like-phase :budget {:tokens 5}}))))))
-
-(deftest merge-with-defaults-override-cannot-drop-policy-gate-test
-  (testing "a :gates override that omits :policy-verify still enforces it —
-            the quick-fix-v2 footgun (verify :gates [:tests-pass]) is closed"
-    (is (= [:tests-pass :policy-verify]
-           (:gates (registry/merge-with-defaults
-                    {:phase verify-like-phase :gates [:tests-pass]}))))))

--- a/components/workflow/src/ai/miniforge/workflow/dag_sub_workflow.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_sub_workflow.clj
@@ -203,6 +203,12 @@
                     :quiet (boolean (get-in context [:execution/opts :quiet]))
                     :create-pr? true}]
      (cond-> base-opts
+       ;; Child runs checkpoint under the parent's root, not whatever the
+       ;; merged config resolves in the child process — one run tree, one
+       ;; root, so per-run tooling (gap ledger aggregation, bench arm
+       ;; partitioning) sees parent and DAG children together.
+       (:execution/checkpoint-root context)
+       (assoc :checkpoint/root (:execution/checkpoint-root context))
        (:llm-backend context)      (assoc :llm-backend (:llm-backend context))
        (:event-stream context)     (assoc :event-stream (:event-stream context))
        (get-in context [:execution/opts :event-stream])

--- a/components/workflow/test/ai/miniforge/workflow/dag_resilience_execution_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/dag_resilience_execution_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.workflow.dag-resilience-execution-test
   "Tests for DAG execution pausing on rate limits and plan->dag-tasks dependency handling."
   (:require
@@ -29,21 +28,19 @@
    [java.time Instant]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Test fixtures
 
-(defn ok-result [task-id]
+;; Test fixtures
+(defn ^{:stratum 0} ok-result [task-id]
   (dag/ok {:task-id task-id :status :implemented}))
 
-(defn rate-limit-err [message]
+(defn ^{:stratum 0} rate-limit-err [message]
   (dag/err :task-execution-failed message {:task-id :test}))
 
-(defn generic-err [message]
+(defn ^{:stratum 0} generic-err [message]
   (dag/err :task-execution-failed message {:task-id :test}))
 
-;------------------------------------------------------------------------------ Layer 4
 ;; DAG orchestrator integration — pause on rate limit
-
-(deftest test-dag-execution-pauses-on-rate-limit
+(deftest ^{:stratum 0} test-dag-execution-pauses-on-rate-limit
   (testing "DAG execution returns paused result when all tasks hit rate limits"
     (let [fixed-now (Instant/parse "2026-05-09T17:00:00Z")
           [logger _] (log/collecting-logger)
@@ -75,7 +72,7 @@
             (is (string? (:pause-reason result)))
             (is (= [] (:completed-task-ids result)))))))))
 
-(deftest test-dag-execution-partial-rate-limit
+(deftest ^{:stratum 0} test-dag-execution-partial-rate-limit
   (testing "DAG pauses when some tasks succeed and others hit rate limits"
     (let [[logger _] (log/collecting-logger)
           task-a (random-uuid)
@@ -114,7 +111,7 @@
           (is (contains? #{task-a task-b}
                          (first (:completed-task-ids result)))))))))
 
-(deftest test-dag-execution-pre-completed-ids
+(deftest ^{:stratum 0} test-dag-execution-pre-completed-ids
   (testing "DAG skips tasks in pre-completed-ids set"
     (let [[logger _] (log/collecting-logger)
           task-a (random-uuid)
@@ -146,7 +143,6 @@
           ;; Both count as completed (1 pre-completed + 1 executed)
           (is (= 2 (:tasks-completed result))))))))
 
-;------------------------------------------------------------------------------ Layer 5
 ;; Regression: phantom dependency detection and unreached task reporting
 ;;
 ;; Bug: Planner generates dependency UUIDs referencing non-existent tasks.
@@ -154,8 +150,7 @@
 ;; and never fail (nothing actually failed). The loop exits on
 ;; (empty? ready-tasks) and silently drops them — reporting success
 ;; with 0 failures despite tasks never running.
-
-(deftest test-plan->dag-tasks-drops-phantom-deps
+(deftest ^{:stratum 0} test-plan->dag-tasks-drops-phantom-deps
   (testing "dependencies referencing non-existent task IDs are dropped"
     (let [task-a (random-uuid)
           task-b (random-uuid)
@@ -176,7 +171,7 @@
           ;; Task A has no deps
           (is (empty? (:task/deps (first dag-tasks)))))))))
 
-(deftest test-plan->dag-tasks-drops-string-phantom-deps
+(deftest ^{:stratum 0} test-plan->dag-tasks-drops-string-phantom-deps
   (testing "string UUID dependencies to non-existent tasks are also dropped"
     (let [task-a (random-uuid)
           task-b (random-uuid)
@@ -195,7 +190,7 @@
           ;; task-a string should resolve; phantom string should be dropped
           (is (= #{task-a} (:task/deps (second dag-tasks)))))))))
 
-(deftest test-plan->dag-tasks-all-deps-valid
+(deftest ^{:stratum 0} test-plan->dag-tasks-all-deps-valid
   (testing "valid dependencies are preserved unchanged"
     (let [task-a (random-uuid)
           task-b (random-uuid)
@@ -214,7 +209,7 @@
           task-c-dag (first (filter #(= task-c (:task/id %)) dag-tasks))]
       (is (= #{task-a task-b} (:task/deps task-c-dag))))))
 
-(deftest test-plan->dag-tasks-keyword-task-ids
+(deftest ^{:stratum 0} test-plan->dag-tasks-keyword-task-ids
   (testing "keyword task IDs are preserved and dependencies resolve against them"
     (let [plan {:plan/id (random-uuid)
                 :plan/tasks [{:task/id :task-a
@@ -231,7 +226,7 @@
       ;; Dependency resolved correctly
       (is (= #{id-a} (:task/deps (second dag-tasks)))))))
 
-(deftest test-plan->dag-tasks-keyword-deps-resolve
+(deftest ^{:stratum 0} test-plan->dag-tasks-keyword-deps-resolve
   (testing "keyword dependencies resolve to the correct normalized task IDs"
     (let [plan {:plan/id (random-uuid)
                 :plan/tasks [{:task/id :alpha
@@ -248,7 +243,7 @@
           gamma-task (first (filter #(= "Gamma" (:task/description %)) dag-tasks))]
       (is (= #{(ids "Alpha") (ids "Beta")} (:task/deps gamma-task))))))
 
-(deftest test-plan->dag-tasks-mixed-id-types
+(deftest ^{:stratum 0} test-plan->dag-tasks-mixed-id-types
   (testing "plan with mixed UUID and keyword IDs preserves both consistently"
     (let [uuid-id (random-uuid)
           plan {:plan/id (random-uuid)
@@ -266,7 +261,7 @@
       ;; Dependency on UUID task resolves
       (is (= #{uuid-id} (:task/deps (second dag-tasks)))))))
 
-(deftest test-plan->dag-tasks-string-non-uuid-ids
+(deftest ^{:stratum 0} test-plan->dag-tasks-string-non-uuid-ids
   (testing "non-UUID string task IDs are preserved and dependencies resolve against them"
     (let [plan {:plan/id (random-uuid)
                 :plan/tasks [{:task/id "build-fixtures"
@@ -282,7 +277,7 @@
       (is (= "run-tests" id-test))
       (is (= #{id-build} (:task/deps (second dag-tasks)))))))
 
-(deftest test-phantom-deps-caused-stuck-tasks-before-fix
+(deftest ^{:stratum 0} test-phantom-deps-caused-stuck-tasks-before-fix
   (testing "regression: phantom deps no longer cause silently stuck tasks"
     (let [[logger _] (log/collecting-logger)
           task-a (random-uuid)
@@ -322,7 +317,7 @@
           (is (= 0 (:tasks-failed result)))
           (is (= #{task-a task-b task-c} @executed-tasks)))))))
 
-(deftest test-unreached-tasks-reported-in-result
+(deftest ^{:stratum 0} test-unreached-tasks-reported-in-result
   (testing "tasks stuck due to failed deps are reported as unreached"
     (let [[logger _] (log/collecting-logger)
           task-a (random-uuid)
@@ -361,7 +356,7 @@
           ;; No tasks unreached — all accounted for via propagation
           (is (= 0 (or (:tasks-unreached result) 0))))))))
 
-(deftest test-all-tasks-accounted-for
+(deftest ^{:stratum 0} test-all-tasks-accounted-for
   (testing "completed + failed + unreached = total (no silent data loss)"
     (let [[logger _] (log/collecting-logger)
           task-ids (repeatedly 6 random-uuid)
@@ -404,7 +399,7 @@
           (is (= total accounted)
               "Every task must be accounted for — no silent drops"))))))
 
-(deftest test-sub-workflow-strips-release-phase
+(deftest ^{:stratum 0} test-sub-workflow-strips-release-phase
   (testing "sub-workflow pipeline excludes :explore, :plan, and :release phases"
     (let [task-def {:task/id (random-uuid)
                     :task/description "Test task"}
@@ -430,10 +425,20 @@
           phase-names (mapv :phase (:workflow/pipeline sub-wf))]
       (is (= [:implement :release :done] phase-names)))))
 
-(deftest test-task-sub-opts-inherits-parent-quiet-setting
+(deftest ^{:stratum 0} test-task-sub-opts-inherits-parent-quiet-setting
   (testing "DAG sub-workflows inherit parent quiet=false so nested agent output stays visible"
     (let [opts (#'dag-orch/task-sub-opts {:execution/opts {:quiet false}})]
       (is (false? (:quiet opts)))))
   (testing "DAG sub-workflows still honor explicit quiet=true from parent opts"
     (let [opts (#'dag-orch/task-sub-opts {:execution/opts {:quiet true}})]
       (is (true? (:quiet opts))))))
+
+(deftest ^{:stratum 0} test-task-sub-opts-inherits-parent-checkpoint-root
+  (testing "DAG sub-workflows checkpoint under the parent's root so one run
+            is one tree (gap-ledger aggregation, bench arm partitioning)"
+    (let [opts (#'dag-orch/task-sub-opts
+                {:execution/checkpoint-root "/tmp/ckpt-root"})]
+      (is (= "/tmp/ckpt-root" (:checkpoint/root opts)))))
+  (testing "no parent root -> key absent, child resolves its own default"
+    (let [opts (#'dag-orch/task-sub-opts {})]
+      (is (not (contains? opts :checkpoint/root))))))


### PR DESCRIPTION
## What

Chunk 1 of the codex baseline/treated dogfood matrix (T2 s5.4, six runs of the resume-FSM spec) produced zero gap-ledger entries and no consultation evidence on any durable record. Survey of the DAG task execution path found four distinct causes; this PR fixes all of them. Per T2 s6.2, the buckets drained are :undelivered (gate, checkpoint tree) and the instrument's own blind spots (verify recording, provenance destruction).

1. **Gate silently dropped** — `canonical-sdlc-v2.0.0.edn` overrides implement `:gates`, and `merge-gates` only re-added `#{:policy-verify :policy-review :policy-pack}`. The `:codex-consultation` gate (#1630) therefore never ran in canonical-sdlc pipelines. It now sits in `policy-gates`, so overrides cannot drop it.
2. **Provenance destroyed at leave** — on success, `leave-implement` replaced the phase result wholesale with the lightweight `(phase/success env-id summary)`, discarding `:codex/consultation`. Every successful implement looked undelivered. `preserve-consultation` carries it (and only it) onto the lightweight result.
3. **Verify had no gap wiring** — and verify failures were the dominant signal in every failing chunk-1 run. `record-phase-misses!` now runs at `leave-verify`, on `next-ctx` so both the gate-failure shape (namespaced `:phase/gate-errors`) and the run-tests-error shape (`[:phase :error]`, attached by `attach-verify-error`) are visible. Verify misses classify `:uncovered` — no codex board addresses a failing-verify loop yet; that is the honest bucket and the harvest signal.
4. **Split checkpoint trees** — DAG task sub-workflows resolved their own checkpoint root from child-process config. `task-sub-opts` now passes the parent's `:execution/checkpoint-root` as `:checkpoint/root`, so one run is one tree for ledger aggregation and bench arm partitioning.

## Verification

1. `bb test` (changed-and-affected) green; pre-commit smoke + GraalVM checks green on all three commits.
2. New tests: gate preservation through the exact canonical-sdlc override shape; consultation survival through the lightweight replacement (and that nothing else survives); recorder invocation at leave-verify after error attachment; checkpoint-root passthrough both ways.
3. End-to-end verification is the next step in the dogfood matrix: rerun the treated chunk-1 arm and confirm non-empty ledgers plus consultation on inner implement records.

## Notes

1. One existing assertion narrowed: implement's lightweight result may now carry exactly `[:codex/consultation]` in `:output`. An `:unconfigured` consultation is preserved deliberately — explicit "codex off" provenance beats absence, and the baseline arm relies on it.
2. SL003 layer-count findings on `implement.clj`/`verify.clj`/`registry.clj` are pre-existing over-budget files (committed under the documented `MINIFORGE_STRATUM_BUDGET_MODE=warn` opt-out); no new layers added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)