### PR TITLE
refactor(governance-provenance): apply Clojure/code-quality standards (dewey 002, 210)

### DIFF
--- a/components/governance-provenance/src/ai/miniforge/governance_provenance/core.clj
+++ b/components/governance-provenance/src/ai/miniforge/governance_provenance/core.clj
@@ -40,6 +40,14 @@
   [rule]
   (some? (:rule/id rule)))
 
+(defn ^{:stratum 0} prepend-incident-node
+  [incident-id path]
+  (update path :path/nodes #(into [(str "incident:" incident-id)] %)))
+
+(defn ^{:stratum 0} pr-for-commit
+  [prs-by-commit commit]
+  (first (get prs-by-commit (:commit/sha commit))))
+
 (defn ^{:stratum 0} commit-projection
   [incident-id revision subject facts commit pr]
   (let [commit-n (model/commit-node commit)
@@ -89,28 +97,9 @@
        (every? valid-mapping? (or specification-mappings []))
        (every? valid-rule-reference? (or policy-rules []))))
 
-(defn ^{:stratum 1} coverage
-  [location-facts mappings rules]
-  (let [location-count (count location-facts)
-        symbol-count (count (filter #(get-in % [:location :symbol :symbol/id]) location-facts))
-        range-count (count (filter :blob-sha location-facts))
-        commit-count (count (set (map :commit/sha (mapcat :commits location-facts))))
-        pr-count (count (set (map (juxt :pull-request/number :pull-request/contains-commit)
-                                  (mapcat :pull-requests location-facts))))
-        mapped? (some (fn [{:keys [location]}]
-                        (some #(mapping-matches? (:path location) %) mappings))
-                      location-facts)]
-    {:coverage/locations {:requested location-count :immutable-ranges range-count}
-     :coverage/symbols {:status (cond (= symbol-count location-count) :provided
-                                      (zero? symbol-count) :none
-                                      :else :partial)
-                        :resolved symbol-count :requested location-count}
-     :coverage/pull-requests {:status :local-merge-history
-                              :resolved pr-count :candidate-commits commit-count}
-     :coverage/specifications (cond (empty? mappings) :not-provided
-                                    mapped? :mapped
-                                    :else :unresolved)
-     :coverage/policy-rules (if (seq rules) :evaluated :not-provided)}))
+(defn- ^{:stratum 1} location-mapped?
+  [{:keys [location]} mappings]
+  (some #(mapping-matches? (:path location) %) mappings))
 
 (defn ^{:stratum 1} governance-projection
   [subject path mappings rules policy-context]
@@ -163,30 +152,51 @@
 
 ;------------------------------------------------------------------------------ Layer 2
 
+(defn ^{:stratum 2} coverage
+  [location-facts mappings rules]
+  (let [location-count (count location-facts)
+        symbol-count (count (filter #(get-in % [:location :symbol :symbol/id]) location-facts))
+        range-count (count (filter :blob-sha location-facts))
+        commit-count (count (set (map :commit/sha (mapcat :commits location-facts))))
+        pr-count (count (set (map (juxt :pull-request/number :pull-request/contains-commit)
+                                  (mapcat :pull-requests location-facts))))
+        mapped? (some #(location-mapped? % mappings) location-facts)
+        symbol-status (cond (= symbol-count location-count) :provided
+                            (zero? symbol-count) :none
+                            :else :partial)
+        spec-status (cond (empty? mappings) :not-provided
+                          mapped? :mapped
+                          :else :unresolved)
+        policy-status (if (seq rules) :evaluated :not-provided)]
+    {:coverage/locations {:requested location-count :immutable-ranges range-count}
+     :coverage/symbols {:status symbol-status :resolved symbol-count :requested location-count}
+     :coverage/pull-requests {:status :local-merge-history
+                              :resolved pr-count :candidate-commits commit-count}
+     :coverage/specifications spec-status
+     :coverage/policy-rules policy-status}))
+
 (defn ^{:stratum 2} project-location
   [incident-id revision facts mappings rules policy-context]
-  (if-let [subject (model/subject-node revision facts)]
-    (let [range-n (model/range-node revision facts)
-          incident-edge (model/edge (str "incident:" incident-id) :implicates
-                                    (:node/id subject) :asserted
-                                    [{:evidence/type :operator-selected-location}])
-          range-edge (when (and range-n (not= (:node/id range-n) (:node/id subject)))
-                       (model/edge (:node/id subject) :cites (:node/id range-n) :asserted
-                                   [{:evidence/type :operator-selected-location}]))
-          governance (governance-projection subject (get-in facts [:location :path])
-                                            mappings rules policy-context)
-          prs-by-commit (group-by :pull-request/contains-commit (:pull-requests facts))
-          commits (mapv #(commit-projection incident-id revision subject facts %
-                                            (first (get prs-by-commit (:commit/sha %))))
-                        (:commits facts))
-          paths (mapv #(update % :path/nodes (fn [nodes]
-                                              (into [(str "incident:" incident-id)] nodes)))
-                      (mapcat :paths commits))]
-      {:nodes (into (cond-> [subject] range-n (conj range-n))
-                    (concat (:nodes governance) (mapcat :nodes commits)))
-       :edges (into (cond-> [incident-edge] range-edge (conj range-edge))
-                    (concat (:edges governance) (mapcat :edges commits)))
-       :claims (vec (mapcat :claims commits))
-       :paths paths
-       :gaps (location-gaps facts mappings rules policy-context)})
-    (assoc (empty-projection) :gaps (location-gaps facts mappings rules policy-context))))
+  (let [gaps (location-gaps facts mappings rules policy-context)]
+    (if-let [subject (model/subject-node revision facts)]
+      (let [range-n (model/range-node revision facts)
+            incident-edge (model/edge (str "incident:" incident-id) :implicates
+                                      (:node/id subject) :asserted
+                                      [{:evidence/type :operator-selected-location}])
+            range-edge (when (and range-n (not= (:node/id range-n) (:node/id subject)))
+                         (model/edge (:node/id subject) :cites (:node/id range-n) :asserted
+                                     [{:evidence/type :operator-selected-location}]))
+            governance (governance-projection subject (get-in facts [:location :path])
+                                              mappings rules policy-context)
+            prs-by-commit (group-by :pull-request/contains-commit (:pull-requests facts))
+            commits (mapv #(commit-projection incident-id revision subject facts %
+                                              (pr-for-commit prs-by-commit %))
+                          (:commits facts))
+            paths (mapv #(prepend-incident-node incident-id %) (mapcat :paths commits))
+            nodes (into (cond-> [subject] range-n (conj range-n))
+                        (concat (:nodes governance) (mapcat :nodes commits)))
+            edges (into (cond-> [incident-edge] range-edge (conj range-edge))
+                        (concat (:edges governance) (mapcat :edges commits)))
+            claims (vec (mapcat :claims commits))]
+        {:nodes nodes :edges edges :claims claims :paths paths :gaps gaps})
+      (assoc (empty-projection) :gaps gaps))))

--- a/components/governance-provenance/src/ai/miniforge/governance_provenance/core.clj
+++ b/components/governance-provenance/src/ai/miniforge/governance_provenance/core.clj
@@ -48,24 +48,6 @@
   [prs-by-commit commit]
   (first (get prs-by-commit (:commit/sha commit))))
 
-(defn ^{:stratum 0} commit-projection
-  [incident-id revision subject facts commit pr]
-  (let [commit-n (model/commit-node commit)
-        claim (model/attribution-claim incident-id subject commit)
-        evidence (model/blame-evidence revision subject facts commit)
-        pr-n (some-> pr model/pull-request-node)
-        nodes (cond-> [commit-n claim evidence] pr-n (conj pr-n))
-        edges (cond-> [(model/edge (:node/id subject) :changed-by (:node/id commit-n) :derived
-                                   [{:evidence/ref (:node/id evidence)}])
-                        (model/edge (:node/id evidence) :supports (:node/id claim) :derived
-                                   [{:evidence/type :git-blame}])]
-                pr-n (conj (model/edge (:node/id commit-n) :contained-in (:node/id pr-n) :derived
-                                       [{:evidence/type :local-merge-ancestry
-                                         :evidence/ref (:pull-request/merge-commit pr)}])))
-        path (cond-> [(:node/id subject) (:node/id commit-n)] pr-n (conj (:node/id pr-n)))]
-    {:nodes nodes :edges edges :claims [claim]
-     :paths [{:path/type :incident-change-candidate :path/nodes path}]}))
-
 ;; mapping/file-globs and policy-pack rule globs are always `/`-delimited
 ;; (per governance-provenance.git/valid-location?, which treats `\` as a
 ;; separator too); without normalizing here a Windows-style path would
@@ -81,6 +63,50 @@
   (policy/filter-applicable-rules
    rules (assoc (or policy-context {})
                 :artifact {:artifact/path (str/replace path "\\" "/")})))
+
+(defn ^{:stratum 0} commit-projection
+  [incident-id revision subject facts commit pr]
+  (let [commit-n (model/commit-node commit)
+        claim (model/attribution-claim incident-id subject commit)
+        evidence (model/blame-evidence revision subject facts commit)
+        pr-n (some-> pr model/pull-request-node)
+        nodes (cond-> [commit-n claim evidence] pr-n (conj pr-n))
+        changed-by-edge (model/edge1 (:node/id subject) :changed-by (:node/id commit-n) :derived
+                               {:evidence/ref (:node/id evidence)})
+        supports-edge (model/edge1 (:node/id evidence) :supports (:node/id claim) :derived
+                             {:evidence/type :git-blame})
+        contained-in-edge (when pr-n
+                            (model/edge1 (:node/id commit-n) :contained-in (:node/id pr-n) :derived
+                                   {:evidence/type :local-merge-ancestry
+                                    :evidence/ref (:pull-request/merge-commit pr)}))
+        edges (cond-> [changed-by-edge supports-edge] contained-in-edge (conj contained-in-edge))
+        path (cond-> [(:node/id subject) (:node/id commit-n)] pr-n (conj (:node/id pr-n)))]
+    {:nodes nodes :edges edges :claims [claim]
+     :paths [{:path/type :incident-change-candidate :path/nodes path}]}))
+
+(defn ^{:stratum 0} spec-governance-edge
+  [subject mapping spec]
+  (model/edge1 (:node/id subject) :governed-by (:node/id spec) :derived
+         {:evidence/type :specification-mapping :evidence/ref (:mapping/id mapping)}))
+
+(defn ^{:stratum 0} rule-governance-edge
+  [subject rule rule-n]
+  (model/edge1 (:node/id subject) :governed-by (:node/id rule-n) :derived
+         {:evidence/type :policy-applicability :evidence/ref (str (:rule/id rule))}))
+
+(defn ^{:stratum 0} location-implicates-edge
+  [incident-id subject]
+  (model/edge1 (str "incident:" incident-id) :implicates (:node/id subject) :asserted
+         {:evidence/type :operator-selected-location}))
+
+(defn ^{:stratum 0} location-cites-edge
+  "Edge from `subject` to `range-n`, or nil when there's no range or the
+   range and subject are already the same node (a symbol subject has no
+   independent range to cite)."
+  [subject range-n]
+  (when (and range-n (not= (:node/id range-n) (:node/id subject)))
+    (model/edge1 (:node/id subject) :cites (:node/id range-n) :asserted
+           {:evidence/type :operator-selected-location})))
 
 ;------------------------------------------------------------------------------ Layer 1
 
@@ -100,24 +126,6 @@
 (defn- ^{:stratum 1} location-mapped?
   [{:keys [location]} mappings]
   (some #(mapping-matches? (:path location) %) mappings))
-
-(defn ^{:stratum 1} governance-projection
-  [subject path mappings rules policy-context]
-  (let [matched-mappings (filterv #(mapping-matches? path %) mappings)
-        matched-rules (applicable-rules path rules policy-context)
-        specs (mapv model/specification-node matched-mappings)
-        rule-nodes (mapv model/rule-node matched-rules)
-        spec-edges (mapv (fn [mapping spec]
-                           (model/edge (:node/id subject) :governed-by (:node/id spec) :derived
-                                       [{:evidence/type :specification-mapping
-                                         :evidence/ref (:mapping/id mapping)}]))
-                         matched-mappings specs)
-        rule-edges (mapv (fn [rule rule-n]
-                           (model/edge (:node/id subject) :governed-by (:node/id rule-n) :derived
-                                       [{:evidence/type :policy-applicability
-                                         :evidence/ref (str (:rule/id rule))}]))
-                         matched-rules rule-nodes)]
-    {:nodes (into specs rule-nodes) :edges (into spec-edges rule-edges)}))
 
 (defn ^{:stratum 1} location-gaps
   [facts mappings rules policy-context]
@@ -150,6 +158,23 @@
                   :when (not (contains? pr-commits (:commit/sha commit)))]
               {:gap/type :pull-request-unresolved :gap/commit (:commit/sha commit)})))))
 
+(defn ^{:stratum 1} governance-projection
+  [subject path mappings rules policy-context]
+  (let [matched-mappings (filterv #(mapping-matches? path %) mappings)
+        matched-rules (applicable-rules path rules policy-context)
+        specs (mapv model/specification-node matched-mappings)
+        rule-nodes (mapv model/rule-node matched-rules)
+        spec-edges (mapv #(spec-governance-edge subject %1 %2) matched-mappings specs)
+        rule-edges (mapv #(rule-governance-edge subject %1 %2) matched-rules rule-nodes)]
+    {:nodes (into specs rule-nodes) :edges (into spec-edges rule-edges)}))
+
+(defn ^{:stratum 1} location-commit-projections
+  [incident-id revision subject facts]
+  (let [prs-by-commit (group-by :pull-request/contains-commit (:pull-requests facts))]
+    (mapv #(commit-projection incident-id revision subject facts %
+                              (pr-for-commit prs-by-commit %))
+          (:commits facts))))
+
 ;------------------------------------------------------------------------------ Layer 2
 
 (defn ^{:stratum 2} coverage
@@ -180,22 +205,15 @@
   (let [gaps (location-gaps facts mappings rules policy-context)]
     (if-let [subject (model/subject-node revision facts)]
       (let [range-n (model/range-node revision facts)
-            incident-edge (model/edge (str "incident:" incident-id) :implicates
-                                      (:node/id subject) :asserted
-                                      [{:evidence/type :operator-selected-location}])
-            range-edge (when (and range-n (not= (:node/id range-n) (:node/id subject)))
-                         (model/edge (:node/id subject) :cites (:node/id range-n) :asserted
-                                     [{:evidence/type :operator-selected-location}]))
+            implicates-edge (location-implicates-edge incident-id subject)
+            cites-edge (location-cites-edge subject range-n)
             governance (governance-projection subject (get-in facts [:location :path])
                                               mappings rules policy-context)
-            prs-by-commit (group-by :pull-request/contains-commit (:pull-requests facts))
-            commits (mapv #(commit-projection incident-id revision subject facts %
-                                              (pr-for-commit prs-by-commit %))
-                          (:commits facts))
+            commits (location-commit-projections incident-id revision subject facts)
             paths (mapv #(prepend-incident-node incident-id %) (mapcat :paths commits))
             nodes (into (cond-> [subject] range-n (conj range-n))
                         (concat (:nodes governance) (mapcat :nodes commits)))
-            edges (into (cond-> [incident-edge] range-edge (conj range-edge))
+            edges (into (cond-> [implicates-edge] cites-edge (conj cites-edge))
                         (concat (:edges governance) (mapcat :edges commits)))
             claims (vec (mapcat :claims commits))]
         {:nodes nodes :edges edges :claims claims :paths paths :gaps gaps})

--- a/components/governance-provenance/src/ai/miniforge/governance_provenance/dossier.clj
+++ b/components/governance-provenance/src/ai/miniforge/governance_provenance/dossier.clj
@@ -25,41 +25,77 @@
 
 ;------------------------------------------------------------------------------ Layer 0
 
-(defn ^{:stratum 0} build-dossier
+(defn ^{:stratum 0} invalid-request-error
+  []
+  {:success? false
+   :error {:error/type :invalid-incident-dossier-request
+           :error/detail "repository/root, incident/id, and a safe positive line range are required"}})
+
+(defn ^{:stratum 0} incident-node
+  [incident-id revision incident]
+  (model/node (str "incident:" incident-id) :incident revision
+              {:source/type (:incident/source incident) :source/ref incident-id}
+              incident))
+
+(defn ^{:stratum 0} project-locations
+  [incident-id revision location-facts mappings rules policy-context]
+  (mapv #(core/project-location incident-id revision % mappings rules policy-context)
+        location-facts))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} collect-or-error
+  "Collect facts, or -- when the request itself fails validation -- an
+   error map in the same :success? shape as collect-facts, so callers
+   only ever need one failure check."
+  [request repository locations git-exec]
+  (if-not (core/valid-request? request)
+    (invalid-request-error)
+    (git-collect/collect-facts (:repository/root repository) (:repository/revision repository)
+                               locations git-exec)))
+
+(defn ^{:stratum 1} assemble-dossier
+  "Build the success-shaped dossier map from collected facts and
+   per-location projections. Every value is precomputed above the map
+   so the map itself reads as data, not code."
+  [repository incident facts projections mappings rules clock]
+  (let [revision (:repository/revision facts)
+        incident-id (str (:incident/id incident))
+        incident-n (incident-node incident-id revision incident)
+        gaps (vec (distinct (mapcat :gaps projections)))
+        status (if (seq gaps) :partial :complete)
+        nodes (model/unique-by :node/id (into [incident-n] (mapcat :nodes projections)))
+        edges (model/unique-edges (mapcat :edges projections))
+        claims (model/unique-by :node/id (mapcat :claims projections))
+        paths (vec (mapcat :paths projections))
+        coverage (core/coverage (:location-facts facts) mappings rules)]
+    {:success? true
+     :dossier/schema-version "0.1"
+     :dossier/status status
+     :dossier/observed-at (clock)
+     :dossier/repository {:repository/root (:repository/root repository)
+                          :repository/revision revision}
+     :dossier/incident incident
+     :dossier/nodes nodes
+     :dossier/edges edges
+     :dossier/claims claims
+     :dossier/paths paths
+     :dossier/coverage coverage
+     :dossier/gaps gaps}))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} build-dossier
   [{:keys [repository incident locations specification-mappings policy-rules policy-context]
     :as request}
    {:keys [git-exec clock] :or {git-exec git/shell-exec clock #(java.time.Instant/now)}}]
-  (if-not (core/valid-request? request)
-    {:success? false
-     :error {:error/type :invalid-incident-dossier-request
-             :error/detail "repository/root, incident/id, and a safe positive line range are required"}}
-    (let [facts (git-collect/collect-facts (:repository/root repository)
-                                          (:repository/revision repository)
-                                          locations git-exec)]
-      (if-not (:success? facts)
-        facts
-        (let [revision (:repository/revision facts)
-              incident-id (str (:incident/id incident))
-              incident-n (model/node (str "incident:" incident-id) :incident revision
-                                     {:source/type (:incident/source incident)
-                                      :source/ref incident-id} incident)
-              mappings (vec (or specification-mappings []))
-              rules (vec (or policy-rules []))
-              projections (mapv #(core/project-location incident-id revision % mappings rules
-                                                        policy-context)
-                                (:location-facts facts))
-              gaps (vec (distinct (mapcat :gaps projections)))]
-          {:success? true
-           :dossier/schema-version "0.1"
-           :dossier/status (if (seq gaps) :partial :complete)
-           :dossier/observed-at (clock)
-           :dossier/repository {:repository/root (:repository/root repository)
-                                :repository/revision revision}
-           :dossier/incident incident
-           :dossier/nodes (model/unique-by :node/id
-                                           (into [incident-n] (mapcat :nodes projections)))
-           :dossier/edges (model/unique-edges (mapcat :edges projections))
-           :dossier/claims (model/unique-by :node/id (mapcat :claims projections))
-           :dossier/paths (vec (mapcat :paths projections))
-           :dossier/coverage (core/coverage (:location-facts facts) mappings rules)
-           :dossier/gaps gaps})))))
+  (let [facts (collect-or-error request repository locations git-exec)]
+    (if-not (:success? facts)
+      facts
+      (let [mappings (vec (or specification-mappings []))
+            rules (vec (or policy-rules []))
+            revision (:repository/revision facts)
+            incident-id (str (:incident/id incident))
+            projections (project-locations incident-id revision (:location-facts facts)
+                                           mappings rules policy-context)]
+        (assemble-dossier repository incident facts projections mappings rules clock)))))

--- a/components/governance-provenance/src/ai/miniforge/governance_provenance/model.clj
+++ b/components/governance-provenance/src/ai/miniforge/governance_provenance/model.clj
@@ -55,6 +55,14 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
+(defn ^{:stratum 1} edge1
+  "Build an edge whose :edge/basis is a single evidence entry -- the
+   common case across every caller in this component, where an edge
+   always carries exactly one evidence map. Callers stop repeating the
+   `[{...}]` vector-wrapping at every call site."
+  [from type to status evidence]
+  (edge from type to status [evidence]))
+
 (defn ^{:stratum 1} range-node
   [revision {:keys [location blob-sha]}]
   (when blob-sha


### PR DESCRIPTION
## Summary

Follow-up to #1642's review: the merged component's functions didn't
hold to `languages/clojure` (210) and `foundations/code-quality` (002)
-- flagged after merge, fixed here rather than left as debt.

- `dossier.clj`'s `build-dossier` was one function doing validate +
  collect + project + assemble, two levels of nested `if-not`/`let`
  (standards cap nesting at one level), and its whole result map built
  from ~6 non-trivial computed expressions embedded directly as map
  values instead of precomputed `let` bindings. Split into
  `invalid-request-error` / `incident-node` / `project-locations`
  (Layer 0, single concern each), `collect-or-error` (Layer 1, absorbs
  the request-validation branch so the top-level function only checks
  one failure shape), `assemble-dossier` (Layer 1, builds the success
  map from precomputed bindings), `build-dossier` (Layer 2, one level
  of conditional, orchestration only).

- `core.clj`'s `coverage` embedded three computed values (two `cond`,
  one `if`) directly as map literal values -- extracted to
  `symbol-status`/`spec-status`/`policy-status` bindings above the map.
  `project-location` nested an anonymous fn inside another
  (`#(update % :path/nodes (fn [nodes] ...))`), embedded a dense
  `(first (get prs-by-commit ...))` lookup inline in a callback, called
  `location-gaps` twice (once per `if-let` branch), and built
  `:nodes`/`:edges` as multi-form `into`/`cond->`/`concat`/`mapcat`
  expressions directly in the return map. Extracted
  `prepend-incident-node` and `pr-for-commit` as named Layer-0 helpers,
  hoisted `gaps` above the `if-let`, precomputed `nodes`/`edges`/`claims`
  as `let` bindings.

## Validation

- No behavior change -- same 8 tests, 40 assertions, all passing
  unmodified.
- `clj-kondo`: 0 errors, 0 warnings on both files.
- `stratum-lint`: clean, 3 layers on both files (matching the
  pre-existing budget -- no new SL003 debt).
- `bb pre-commit`: 338 smoke tests / 1,281 assertions and 8 GraalVM
  tests / 587 assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)