### PR TITLE
fix(workflow): thread :execution/logger into the execution context

### DIFF
--- a/components/phase-software-factory/deps.edn
+++ b/components/phase-software-factory/deps.edn
@@ -9,6 +9,7 @@
         ai.miniforge/codex {:local/root "../codex"}
         ai.miniforge/codex-gap {:local/root "../codex-gap"}
         ai.miniforge/knowledge {:local/root "../knowledge"}
+        ai.miniforge/logging {:local/root "../logging"}
         ai.miniforge/repo-index {:local/root "../repo-index"}
         ai.miniforge/context-pack {:local/root "../context-pack"}
         ai.miniforge/response {:local/root "../response"}

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/gap_wiring_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/gap_wiring_test.clj
@@ -22,6 +22,7 @@
    implement attach."
   (:require [ai.miniforge.anomaly.interface :as anomaly]
             [ai.miniforge.codex-gap.interface :as gap]
+            [ai.miniforge.logging.interface :as log]
             [ai.miniforge.phase-software-factory.gap-wiring :as gap-wiring]
             [clojure.test :refer [deftest is testing]]))
 
@@ -102,3 +103,23 @@
       (is (= :review-queue (:miss/bucket (first entries))))
       (is (= "quality-signal-might-be-lying"
              (:miss/situation (first entries)))))))
+
+(deftest ^{:stratum 0} ledger-write-failure-warns-through-the-context-logger
+  ;; The workflow runner normalizes :execution/logger at context creation
+  ;; (workflow.context), so this warn path is live in production runs —
+  ;; before that, no writer set the key and the warning vanished.
+  (let [root (str (java.nio.file.Files/createTempDirectory
+                    "gap-wiring-test-"
+                    (into-array java.nio.file.attribute.FileAttribute [])))
+        ;; occupy the run-dir path with a FILE so the ledger append fails
+        _ (spit (str root "/run-z") "occupied")
+        [logger entries] (log/collecting-logger)
+        ctx {:execution/checkpoint-root root
+             :execution/id "run-z"
+             :execution/logger logger
+             :phase {:result {:output {:review/blocking-issues ["boom"]}}}}]
+    (gap-wiring/record-phase-misses! ctx :review "/nonexistent/codex")
+    (is (= [:codex-gap/ledger-write-failed]
+           (mapv :log/event @entries))
+        "the best-effort warning must reach the ctx logger, not vanish")
+    (is (= [:warn] (mapv :log/level @entries)))))

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/gap_wiring_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/gap_wiring_test.clj
@@ -74,52 +74,61 @@
                         :anomaly/message "no movement"}}
              (gap-wiring/terminal-signal {:error err}))))))
 
-(deftest ^{:stratum 0} recording-is-a-no-op-without-a-configured-codex
-  (let [dir (str (java.nio.file.Files/createTempDirectory
-                   "gap-wiring-test-"
-                   (into-array java.nio.file.attribute.FileAttribute [])))
-        ctx {:execution/checkpoint-root dir
-             :execution/id "run-x"
-             :phase {:phase/status :failed
-                     :phase/gate-errors [{:reason/code :reason/gate-check-failed
-                                          :reason/detail "x"}]}}]
-    (gap-wiring/record-phase-misses! ctx :implement nil)
-    (is (= {:entries [] :skipped 0}
-           (gap/read-ledger (str dir "/run-x")))
-        "no codex configured -> no gap to measure -> nothing written")))
+(defn- ^{:stratum 0} temp-root
+  "Fresh temp checkpoint root for one test run."
+  []
+  (str (java.nio.file.Files/createTempDirectory
+         "gap-wiring-test-"
+         (into-array java.nio.file.attribute.FileAttribute []))))
 
-(deftest ^{:stratum 0} recording-never-throws-on-a-broken-codex-dir
-  (let [dir (str (java.nio.file.Files/createTempDirectory
-                   "gap-wiring-test-"
-                   (into-array java.nio.file.attribute.FileAttribute [])))
-        ctx {:execution/checkpoint-root dir
-             :execution/id "run-y"
-             :phase {:result {:output {:review/blocking-issues ["boom"]}}}}]
-    ;; unreadable codex: consider/load-graph return anomalies; entries
-    ;; still classify (landings-unavailable -> review queue) and record
-    (gap-wiring/record-phase-misses! ctx :review "/nonexistent/codex")
-    (let [{:keys [entries]} (gap/read-ledger (str dir "/run-y"))]
-      (is (= 1 (count entries)))
-      (is (= :review-queue (:miss/bucket (first entries))))
-      (is (= "quality-signal-might-be-lying"
-             (:miss/situation (first entries)))))))
+(defn- ^{:stratum 0} run-ctx
+  "Execution-context fragment shaped like the runner's real ctx at phase
+   leave: workflow.context/create-context sets :execution/checkpoint-root,
+   :execution/id, and :execution/logger; the phase interceptor stack sets
+   :phase. Extras merge over the base."
+  [root run-id & {:as extra}]
+  (merge {:execution/checkpoint-root root
+          :execution/id run-id}
+         extra))
 
-(deftest ^{:stratum 0} ledger-write-failure-warns-through-the-context-logger
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} recording-is-a-no-op-without-a-configured-codex
+  (testing "no codex configured → no gap to measure → nothing written"
+    (let [dir (temp-root)
+          ctx (run-ctx dir "run-x"
+                       :phase {:phase/status :failed
+                               :phase/gate-errors [{:reason/code :reason/gate-check-failed
+                                                    :reason/detail "x"}]})]
+      (gap-wiring/record-phase-misses! ctx :implement nil)
+      (is (= {:entries [] :skipped 0}
+             (gap/read-ledger (str dir "/run-x")))))))
+
+(deftest ^{:stratum 1} recording-never-throws-on-a-broken-codex-dir
+  (testing "unreadable codex → entries still classify (landings-unavailable → review queue) and record"
+    (let [dir (temp-root)
+          ctx (run-ctx dir "run-y"
+                       :phase {:result {:output {:review/blocking-issues ["boom"]}}})]
+      (gap-wiring/record-phase-misses! ctx :review "/nonexistent/codex")
+      (let [{:keys [entries]} (gap/read-ledger (str dir "/run-y"))]
+        (is (= 1 (count entries)))
+        (is (= :review-queue (:miss/bucket (first entries))))
+        (is (= "quality-signal-might-be-lying"
+               (:miss/situation (first entries))))))))
+
+(deftest ^{:stratum 1} ledger-write-failure-warns-through-the-context-logger
   ;; The workflow runner normalizes :execution/logger at context creation
   ;; (workflow.context), so this warn path is live in production runs —
   ;; before that, no writer set the key and the warning vanished.
-  (let [root (str (java.nio.file.Files/createTempDirectory
-                    "gap-wiring-test-"
-                    (into-array java.nio.file.attribute.FileAttribute [])))
-        ;; occupy the run-dir path with a FILE so the ledger append fails
-        _ (spit (str root "/run-z") "occupied")
-        [logger entries] (log/collecting-logger)
-        ctx {:execution/checkpoint-root root
-             :execution/id "run-z"
-             :execution/logger logger
-             :phase {:result {:output {:review/blocking-issues ["boom"]}}}}]
-    (gap-wiring/record-phase-misses! ctx :review "/nonexistent/codex")
-    (is (= [:codex-gap/ledger-write-failed]
-           (mapv :log/event @entries))
-        "the best-effort warning must reach the ctx logger, not vanish")
-    (is (= [:warn] (mapv :log/level @entries)))))
+  (testing "run-dir path occupied by a file (ledger append fails) → warn reaches :execution/logger"
+    (let [root (temp-root)
+          _ (spit (str root "/run-z") "occupied")
+          [logger entries] (log/collecting-logger)
+          ctx (run-ctx root "run-z"
+                       :execution/logger logger
+                       :phase {:result {:output {:review/blocking-issues ["boom"]}}})]
+      (gap-wiring/record-phase-misses! ctx :review "/nonexistent/codex")
+      (is (= [:codex-gap/ledger-write-failed]
+             (mapv :log/event @entries))
+          "the best-effort warning must reach the ctx logger, not vanish")
+      (is (= [:warn] (mapv :log/level @entries))))))

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/gap_wiring_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/gap_wiring_test.clj
@@ -83,9 +83,11 @@
 
 (defn- ^{:stratum 0} run-ctx
   "Execution-context fragment shaped like the runner's real ctx at phase
-   leave: workflow.context/create-context sets :execution/checkpoint-root,
-   :execution/id, and :execution/logger; the phase interceptor stack sets
-   :phase. Extras merge over the base."
+   leave. The base seeds only the identity keys
+   (:execution/checkpoint-root, :execution/id); tests supply the rest —
+   :execution/logger (set by workflow.context/create-context in
+   production) and :phase (set by the phase interceptor stack) — via
+   extras, which merge over the base."
   [root run-id & {:as extra}]
   (merge {:execution/checkpoint-root root
           :execution/id run-id}

--- a/components/workflow/src/ai/miniforge/workflow/context.clj
+++ b/components/workflow/src/ai/miniforge/workflow/context.clj
@@ -99,6 +99,17 @@
    :execution/response-chain   — Structured response chain (per-phase
                                  success/failure tracking)
 
+   ### Logging
+   :execution/logger           — Structured logger (logging.interface).
+                                 Always set: the caller's :logger from
+                                 opts when supplied, else a default
+                                 debug-level human-output logger.
+                                 Normalized at context creation (the one canonical
+                                 writer) — consumers guard on this key
+                                 for best-effort warning paths and must
+                                 never mint their own. Never persisted
+                                 (checkpoint-store whitelists keys).
+
    ### Supervision Support
    :execution/supervision-runtime — Runtime for workflow health supervision
    :execution/meta-coordinator    — DEPRECATED alias for
@@ -111,6 +122,7 @@
    :knowledge-store — Knowledge base store
    :event-stream   — Event stream for telemetry"
   (:require [ai.miniforge.anomaly.interface :as anomaly]
+            [ai.miniforge.logging.interface :as log]
             [ai.miniforge.response.interface :as response]
             [ai.miniforge.workflow.checkpoint-store :as checkpoint-store]
             [ai.miniforge.workflow.fsm :as fsm]
@@ -130,6 +142,13 @@
    ;; Threaded by run-chain so every step of one ETL invocation shares
    ;; it; lifecycle events read it from the context (see runner-events).
    :workflow-run/correlation-id])
+
+(defonce ^{:stratum 0} ^:private default-execution-logger
+  ;; :min-level :debug, matching runner-logger and the strictest of the
+  ;; per-reader fallbacks this default replaces (release.clj used a
+  ;; :debug fallback) — a quieter default here would silently drop
+  ;; debug entries those paths used to emit.
+  (log/create-logger {:min-level :debug :output :human}))
 
 (defn- ^{:stratum 0} monitoring-runtime-fields
   [workflow]
@@ -229,6 +248,16 @@
   [opts]
   (select-keys opts execution-passthrough-option-keys))
 
+(defn- ^{:stratum 1} execution-logger
+  "The run's structured logger: the caller's :logger from opts when
+   supplied, else the default human-output logger. This is the ONE
+   canonical writer of :execution/logger — before it existed, no writer
+   set the key at all, so every consumer guarding on it (gap-wiring's
+   ledger-failure warnings, codex-pin's consultation-skipped warning,
+   the phase loggers) silently dropped its best-effort warnings."
+  [opts]
+  (or (:logger opts) default-execution-logger))
+
 (defn ^{:stratum 1} transition-execution
   "Apply an event to the authoritative execution machine and refresh projections."
   [ctx event]
@@ -294,8 +323,9 @@
    - workflow: Workflow configuration
    - input: Input data for the workflow
    - opts: Execution options (including :llm-backend, :artifact-store,
-           callbacks, and optionally :workflow-id — the caller's run id,
-           adopted as :execution/id so one run has one identity)
+           callbacks, optionally :workflow-id — the caller's run id,
+           adopted as :execution/id so one run has one identity — and
+           optionally :logger, adopted as :execution/logger)
 
    Returns execution context map with FSM state initialized."
   [workflow input opts]
@@ -320,7 +350,8 @@
        :execution/metrics {:tokens 0 :cost-usd 0.0 :duration-ms 0}
        :execution/started-at (System/currentTimeMillis)
        :execution/opts opts
-       :execution/checkpoint-root checkpoint-root}
+       :execution/checkpoint-root checkpoint-root
+       :execution/logger (execution-logger opts)}
       (monitoring-runtime-fields workflow)
       ;; Merge opts into top-level context so :llm-backend is accessible to agents
       (passthrough-option-values opts)))))
@@ -349,7 +380,8 @@
        :execution/input (get machine-snapshot :execution/input input)
        :execution/phase-results phase-results
        :execution/opts opts
-       :execution/checkpoint-root checkpoint-root}
+       :execution/checkpoint-root checkpoint-root
+       :execution/logger (execution-logger opts)}
       (monitoring-runtime-fields workflow)
       (passthrough-option-values opts)))))
 

--- a/components/workflow/src/ai/miniforge/workflow/context.clj
+++ b/components/workflow/src/ai/miniforge/workflow/context.clj
@@ -254,7 +254,13 @@
    canonical writer of :execution/logger — before it existed, no writer
    set the key at all, so every consumer guarding on it (gap-wiring's
    ledger-failure warnings, codex-pin's consultation-skipped warning,
-   the phase loggers) silently dropped its best-effort warnings."
+   the phase loggers) silently dropped its best-effort warnings.
+
+   `or`, not `(get opts :logger default)` (rule 210 exception,
+   documented): the invariant is that the key is ALWAYS a usable
+   logger, so an opts map carrying an explicitly nil :logger must
+   still resolve to the default — `get` would adopt the nil and
+   resurrect the silent-drop bug this exists to fix."
   [opts]
   (or (:logger opts) default-execution-logger))
 

--- a/components/workflow/src/ai/miniforge/workflow/context.clj
+++ b/components/workflow/src/ai/miniforge/workflow/context.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.workflow.context
   "Execution context management.
 
@@ -118,9 +117,10 @@
             [ai.miniforge.workflow.monitoring :as monitoring]
             [ai.miniforge.agent.interface :as agent]))
 
-;------------------------------------------------------------------------------ Internal helpers
+;------------------------------------------------------------------------------ Layer 0
 
-(def execution-passthrough-option-keys
+;------------------------------------------------------------------------------ Internal helpers
+(def ^{:stratum 0} execution-passthrough-option-keys
   "Execution options that are copied onto the top-level workflow context."
   [:llm-backend :artifact-store :knowledge-store
    :on-phase-start :on-phase-complete
@@ -131,11 +131,7 @@
    ;; it; lifecycle events read it from the context (see runner-events).
    :workflow-run/correlation-id])
 
-(defn- passthrough-option-values
-  [opts]
-  (select-keys opts execution-passthrough-option-keys))
-
-(defn- monitoring-runtime-fields
+(defn- ^{:stratum 0} monitoring-runtime-fields
   [workflow]
   (let [supervisors (monitoring/create-supervisors workflow)
         supervision-runtime (agent/create-supervision-coordinator supervisors)]
@@ -144,7 +140,7 @@
      :execution/streaming-activity []
      :execution/files-written #{}}))
 
-(defn- reset-terminal-snapshot-fields
+(defn- ^{:stratum 0} reset-terminal-snapshot-fields
   [machine-snapshot workflow]
   (-> machine-snapshot
       (dissoc :execution/ended-at
@@ -155,7 +151,7 @@
              :execution/metrics {:tokens 0 :cost-usd 0.0 :duration-ms 0}
              :execution/started-at (System/currentTimeMillis))))
 
-(defn sync-machine-projections
+(defn ^{:stratum 0} sync-machine-projections
   "Project workflow fields from the authoritative machine snapshot."
   [ctx]
   (let [machine (:execution/fsm-machine ctx)
@@ -168,7 +164,72 @@
                (assoc :execution/status :completed-with-warnings))]
     ctx'))
 
-(defn transition-execution
+(defn ^{:stratum 0} active-or-last-phase
+  "Return the active phase when present, otherwise the last completed phase in
+   workflow pipeline order."
+  [ctx]
+  (let [phase-results (:execution/phase-results ctx)
+        pipeline (:workflow/pipeline (:execution/workflow ctx))
+        last-recorded-phase (some->> pipeline
+                                     (map :phase)
+                                     (filter #(contains? phase-results %))
+                                     last)]
+    (if-some [current-phase (:execution/current-phase ctx)]
+      current-phase
+      last-recorded-phase)))
+
+;------------------------------------------------------------------------------ Context operations
+(defn- ^{:stratum 0} opts-run-id
+  "Adopt the caller's run identity when opts carry one. The CLI announces a
+   run id and publishes lifecycle events under it BEFORE the pipeline
+   starts; minting a second UUID here forks the run's identity — in the
+   2026-07-21 dogfood the phase/agent events landed under the pipeline's
+   id, the lifecycle events under the CLI's, and the staleness watchdog
+   false-fired on the half without heartbeats. Accepts a uuid or a
+   uuid-shaped string; anything else returns nil (fresh uuid fallback), so
+   non-uuid session labels never break event routing."
+  [opts]
+  (let [wid (:workflow-id opts)]
+    (cond
+      (uuid? wid)   wid
+      (string? wid) (parse-uuid wid)
+      :else         nil)))
+
+(defn ^{:stratum 0} merge-metrics
+  "Merge phase metrics into execution metrics.
+   Nil-safe: treats nil values as 0 to prevent NPE from merge-with +."
+  [exec-metrics phase-metrics]
+  (merge-with (fn [a b] (+ (or a 0) (or b 0)))
+              exec-metrics
+              (select-keys phase-metrics [:tokens :cost-usd :duration-ms])))
+
+(defn- ^{:stratum 0} ->epoch-millis
+  "Coerce a :execution/started-at / :execution/ended-at value to a
+   long epoch-millis. Different writers use different
+   representations (context.clj writes Long via
+   System/currentTimeMillis; runner.clj writes java.time.Instant via
+   Instant/now), and the wall-clock stamp needs to subtract them.
+   That inconsistency is its own bug; coercing here keeps the stamp
+   from failing on either shape — specifically:
+
+     - nil started-at / ended-at → nil here, caller skips the stamp;
+     - Instant input → unguarded subtraction would
+       ClassCastException (java.time.Instant is not a Number);
+     - any unrecognised type → nil, caller skips rather than
+       producing nonsense."
+  [t]
+  (cond
+    (number? t)                          (long t)
+    (instance? java.time.Instant t)      (.toEpochMilli ^java.time.Instant t)
+    :else                                nil))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} passthrough-option-values
+  [opts]
+  (select-keys opts execution-passthrough-option-keys))
+
+(defn ^{:stratum 1} transition-execution
   "Apply an event to the authoritative execution machine and refresh projections."
   [ctx event]
   (if-let [machine (:execution/fsm-machine ctx)]
@@ -183,7 +244,7 @@
         (assoc :execution/ended-at (System/currentTimeMillis))))
     ctx))
 
-(defn transition-execution-result
+(defn ^{:stratum 1} transition-execution-result
   "Apply an event to the authoritative execution machine and refresh
    projections, returning a canonical FSM anomaly for state-local unknown
    events instead of throwing."
@@ -202,39 +263,31 @@
             (assoc :execution/ended-at (System/currentTimeMillis))))))
     ctx))
 
-(defn active-or-last-phase
-  "Return the active phase when present, otherwise the last completed phase in
-   workflow pipeline order."
+(defn- ^{:stratum 1} stamp-wall-clock-duration
+  "Overwrite :execution/metrics :duration-ms with the actual workflow
+   wall-clock (`ended-at` − `started-at`). Tokens and cost still sum
+   correctly across phases — those are independent per-phase resource
+   consumption — but :duration-ms is the user-facing 'how long did
+   this run take' answer, which under DAG parallelism and per-phase
+   summing diverges from the wall-clock the user is watching.
+
+   Pre-fix, the runner banner reported `Duration: 9.7m` for a ~50m
+   wall run because :duration-ms was sum-of-phases — an aggregate
+   that means little when phases run in parallel and even less when
+   sub-workflow duration didn't propagate. Post-fix, banner shows
+   wall-clock; sum-of-phases is recoverable from the per-phase
+   results if a future analysis ever needs it."
   [ctx]
-  (let [phase-results (:execution/phase-results ctx)
-        pipeline (:workflow/pipeline (:execution/workflow ctx))
-        last-recorded-phase (some->> pipeline
-                                     (map :phase)
-                                     (filter #(contains? phase-results %))
-                                     last)]
-    (if-some [current-phase (:execution/current-phase ctx)]
-      current-phase
-      last-recorded-phase)))
+  (let [started-at (->epoch-millis (:execution/started-at ctx))
+        ended-at   (->epoch-millis (:execution/ended-at ctx))]
+    (if (and started-at ended-at)
+      (assoc-in ctx [:execution/metrics :duration-ms]
+                (max 0 (- ended-at started-at)))
+      ctx)))
 
-;------------------------------------------------------------------------------ Context operations
+;------------------------------------------------------------------------------ Layer 2
 
-(defn- opts-run-id
-  "Adopt the caller's run identity when opts carry one. The CLI announces a
-   run id and publishes lifecycle events under it BEFORE the pipeline
-   starts; minting a second UUID here forks the run's identity — in the
-   2026-07-21 dogfood the phase/agent events landed under the pipeline's
-   id, the lifecycle events under the CLI's, and the staleness watchdog
-   false-fired on the half without heartbeats. Accepts a uuid or a
-   uuid-shaped string; anything else returns nil (fresh uuid fallback), so
-   non-uuid session labels never break event routing."
-  [opts]
-  (let [wid (:workflow-id opts)]
-    (cond
-      (uuid? wid)   wid
-      (string? wid) (parse-uuid wid)
-      :else         nil)))
-
-(defn create-context
+(defn ^{:stratum 2} create-context
   "Create initial execution context.
 
    Arguments:
@@ -272,7 +325,7 @@
       ;; Merge opts into top-level context so :llm-backend is accessible to agents
       (passthrough-option-values opts)))))
 
-(defn restore-context
+(defn ^{:stratum 2} restore-context
   "Restore execution context from a durable machine snapshot and phase checkpoints."
   [workflow input machine-snapshot phase-results opts]
   (let [execution-machine (fsm/compile-execution-machine workflow)
@@ -300,57 +353,7 @@
       (monitoring-runtime-fields workflow)
       (passthrough-option-values opts)))))
 
-(defn merge-metrics
-  "Merge phase metrics into execution metrics.
-   Nil-safe: treats nil values as 0 to prevent NPE from merge-with +."
-  [exec-metrics phase-metrics]
-  (merge-with (fn [a b] (+ (or a 0) (or b 0)))
-              exec-metrics
-              (select-keys phase-metrics [:tokens :cost-usd :duration-ms])))
-
-(defn- ->epoch-millis
-  "Coerce a :execution/started-at / :execution/ended-at value to a
-   long epoch-millis. Different writers use different
-   representations (context.clj writes Long via
-   System/currentTimeMillis; runner.clj writes java.time.Instant via
-   Instant/now), and the wall-clock stamp needs to subtract them.
-   That inconsistency is its own bug; coercing here keeps the stamp
-   from failing on either shape — specifically:
-
-     - nil started-at / ended-at → nil here, caller skips the stamp;
-     - Instant input → unguarded subtraction would
-       ClassCastException (java.time.Instant is not a Number);
-     - any unrecognised type → nil, caller skips rather than
-       producing nonsense."
-  [t]
-  (cond
-    (number? t)                          (long t)
-    (instance? java.time.Instant t)      (.toEpochMilli ^java.time.Instant t)
-    :else                                nil))
-
-(defn- stamp-wall-clock-duration
-  "Overwrite :execution/metrics :duration-ms with the actual workflow
-   wall-clock (`ended-at` − `started-at`). Tokens and cost still sum
-   correctly across phases — those are independent per-phase resource
-   consumption — but :duration-ms is the user-facing 'how long did
-   this run take' answer, which under DAG parallelism and per-phase
-   summing diverges from the wall-clock the user is watching.
-
-   Pre-fix, the runner banner reported `Duration: 9.7m` for a ~50m
-   wall run because :duration-ms was sum-of-phases — an aggregate
-   that means little when phases run in parallel and even less when
-   sub-workflow duration didn't propagate. Post-fix, banner shows
-   wall-clock; sum-of-phases is recoverable from the per-phase
-   results if a future analysis ever needs it."
-  [ctx]
-  (let [started-at (->epoch-millis (:execution/started-at ctx))
-        ended-at   (->epoch-millis (:execution/ended-at ctx))]
-    (if (and started-at ended-at)
-      (assoc-in ctx [:execution/metrics :duration-ms]
-                (max 0 (- ended-at started-at)))
-      ctx)))
-
-(defn transition-to-completed
+(defn ^{:stratum 2} transition-to-completed
   "Transition workflow to completed state using FSM. Stamps
    :execution/ended-at and overwrites :execution/metrics
    :duration-ms with the wall-clock so the runner banner reflects
@@ -363,7 +366,7 @@
       (assoc :execution/ended-at (System/currentTimeMillis))
       stamp-wall-clock-duration))
 
-(defn transition-to-failed
+(defn ^{:stratum 2} transition-to-failed
   "Transition workflow to failed state using FSM. Same wall-clock
    duration semantics as transition-to-completed — duration is
    reported even on failure so the user can see how long the run

--- a/components/workflow/test/ai/miniforge/workflow/runner_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_test.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.workflow.runner-test
   "Unit tests for the interceptor-based workflow runner.
    Tests that execute real phase pipelines (plan, implement, etc.)
@@ -34,7 +33,9 @@
    [ai.miniforge.workflow.runner-environment :as runner-environment]
    [ai.miniforge.workflow.context :as ctx]))
 
-(defn- with-stubbed-acquire-environment
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} with-stubbed-acquire-environment
   "Force `acquire-execution-environment!` to return nil for every test
    in this namespace.
 
@@ -54,26 +55,19 @@
                    (fn [& _] nil)}
     f))
 
-;; Compose phase-test-support's loader setup with the acquire-environment
-;; stub. clojure.test/use-fixtures REPLACES prior :each fixtures, so both
-;; must be registered in a single call.
-(use-fixtures :each
-  phase-test-support/with-workflow-phase-test-support
-  with-stubbed-acquire-environment)
-
-(def test-plan-phase
+(def ^{:stratum 0} test-plan-phase
   phase-test-support/runner-test-plan)
 
-(def test-implement-phase
+(def ^{:stratum 0} test-implement-phase
   phase-test-support/runner-test-implement)
 
-(def test-verify-phase
+(def ^{:stratum 0} test-verify-phase
   phase-test-support/runner-test-verify)
 
-(def test-done-phase
+(def ^{:stratum 0} test-done-phase
   phase-test-support/runner-test-done)
 
-(defn- with-temp-checkpoint-root
+(defn- ^{:stratum 0} with-temp-checkpoint-root
   [f]
   (let [root (doto (io/file (System/getProperty "java.io.tmpdir")
                             (str "mf-runner-checkpoint-test-" (random-uuid)))
@@ -87,8 +81,7 @@
 ;; ============================================================================
 ;; Context creation tests
 ;; ============================================================================
-
-(deftest create-context-test
+(deftest ^{:stratum 0} create-context-test
   (testing "create-context initializes execution state"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"}
@@ -104,7 +97,7 @@
       (is (vector? (:execution/artifacts ctx)))
       (is (number? (:execution/started-at ctx))))))
 
-(deftest create-context-preserves-source-root-test
+(deftest ^{:stratum 0} create-context-preserves-source-root-test
   (testing "create-context preserves :source-root passthrough options"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"}
@@ -112,26 +105,7 @@
           ctx (ctx/create-context workflow {:task "Test"} {:source-root source-root})]
       (is (= source-root (:source-root ctx))))))
 
-(deftest run-pipeline-persists-final-terminal-snapshot-test
-  (testing "terminal failures produced after the loop overwrite the running checkpoint"
-    (with-temp-checkpoint-root
-      (fn [checkpoint-root]
-        (let [workflow {:workflow/id :empty-test
-                        :workflow/version "1.0.0"
-                        :workflow/pipeline []}
-              result (runner/run-pipeline workflow {:task "Test"}
-                                          {:checkpoint/root checkpoint-root
-                                           :skip-lifecycle-events true})
-              checkpoint-data (checkpoint-store/load-checkpoint-data
-                               (:execution/id result)
-                               {:checkpoint/root checkpoint-root})]
-          (is (= :failed (:execution/status result)))
-          (is (= :failed (get-in checkpoint-data
-                                 [:machine-snapshot :execution/status])))
-          (is (seq (get-in checkpoint-data
-                           [:machine-snapshot :execution/errors]))))))))
-
-(deftest restore-context-can-reset-terminal-snapshot-test
+(deftest ^{:stratum 0} restore-context-can-reset-terminal-snapshot-test
   (testing "failed checkpoint snapshots can resume a trimmed workflow"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
@@ -170,11 +144,73 @@
       (is (= {:plan {:status :completed}}
              (:execution/phase-results restored))))))
 
+(deftest ^{:stratum 0} build-pipeline-empty-test
+  (testing "build-pipeline handles empty pipeline"
+    (let [workflow {:workflow/pipeline []}
+          pipeline (runner/build-pipeline workflow)]
+      (is (empty? pipeline)))))
+
+(deftest ^{:stratum 0} validate-pipeline-nil-test
+  (testing "validate-pipeline handles nil pipeline"
+    (let [workflow {}
+          result (runner/validate-pipeline workflow)]
+      (is (not (:valid? result))))))
+
+;; ============================================================================
+;; Pipeline execution tests
+;; ============================================================================
+(deftest ^{:stratum 0} run-pipeline-empty-test
+  (testing "run-pipeline fails for empty workflow"
+    (let [workflow {:workflow/pipeline []}
+          result (runner/run-pipeline workflow {} {})]
+      (is (= :failed (:execution/status result)))
+      (is (some #(= :empty-pipeline (:type %)) (:execution/errors result))))))
+
+;; ============================================================================
+;; Response chain tests
+;; ============================================================================
+(deftest ^{:stratum 0} response-chain-created-test
+  (testing "response chain is initialized in context"
+    (let [workflow {:workflow/id :test
+                    :workflow/version "1.0.0"}
+          ctx (ctx/create-context workflow {:task "Test"} {})]
+      (is (contains? ctx :execution/response-chain))
+      (is (= :test (:operation (:execution/response-chain ctx))))
+      (is (true? (:succeeded? (:execution/response-chain ctx)))))))
+
+(deftest ^{:stratum 0} context-initializes-output-nil-test
+  (testing "create-context initializes :execution/output as nil"
+    (let [workflow {:workflow/id :test
+                    :workflow/version "1.0.0"}
+          ctx (ctx/create-context workflow {:task "Test"} {})]
+      (is (contains? ctx :execution/output))
+      (is (nil? (:execution/output ctx))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} run-pipeline-persists-final-terminal-snapshot-test
+  (testing "terminal failures produced after the loop overwrite the running checkpoint"
+    (with-temp-checkpoint-root
+      (fn [checkpoint-root]
+        (let [workflow {:workflow/id :empty-test
+                        :workflow/version "1.0.0"
+                        :workflow/pipeline []}
+              result (runner/run-pipeline workflow {:task "Test"}
+                                          {:checkpoint/root checkpoint-root
+                                           :skip-lifecycle-events true})
+              checkpoint-data (checkpoint-store/load-checkpoint-data
+                               (:execution/id result)
+                               {:checkpoint/root checkpoint-root})]
+          (is (= :failed (:execution/status result)))
+          (is (= :failed (get-in checkpoint-data
+                                 [:machine-snapshot :execution/status])))
+          (is (seq (get-in checkpoint-data
+                           [:machine-snapshot :execution/errors]))))))))
+
 ;; ============================================================================
 ;; Pipeline building tests
 ;; ============================================================================
-
-(deftest build-pipeline-simple-test
+(deftest ^{:stratum 1} build-pipeline-simple-test
   (testing "build-pipeline creates interceptors from config"
     (let [workflow {:workflow/pipeline
                     [{:phase test-plan-phase}
@@ -185,13 +221,7 @@
       (is (= 3 (count pipeline)))
       (is (every? #(contains? % :enter) pipeline)))))
 
-(deftest build-pipeline-empty-test
-  (testing "build-pipeline handles empty pipeline"
-    (let [workflow {:workflow/pipeline []}
-          pipeline (runner/build-pipeline workflow)]
-      (is (empty? pipeline)))))
-
-(deftest build-pipeline-legacy-format-test
+(deftest ^{:stratum 1} build-pipeline-legacy-format-test
   (testing "build-pipeline handles legacy phase format"
     (let [workflow {:workflow/phases
                     [{:phase/id test-plan-phase}
@@ -203,8 +233,7 @@
 ;; ============================================================================
 ;; Validation tests
 ;; ============================================================================
-
-(deftest validate-pipeline-valid-test
+(deftest ^{:stratum 1} validate-pipeline-valid-test
   (testing "validate-pipeline accepts valid workflow"
     (let [workflow {:workflow/pipeline
                     [{:phase test-plan-phase}
@@ -212,24 +241,7 @@
           result (runner/validate-pipeline workflow)]
       (is (:valid? result)))))
 
-(deftest validate-pipeline-nil-test
-  (testing "validate-pipeline handles nil pipeline"
-    (let [workflow {}
-          result (runner/validate-pipeline workflow)]
-      (is (not (:valid? result))))))
-
-;; ============================================================================
-;; Pipeline execution tests
-;; ============================================================================
-
-(deftest run-pipeline-empty-test
-  (testing "run-pipeline fails for empty workflow"
-    (let [workflow {:workflow/pipeline []}
-          result (runner/run-pipeline workflow {} {})]
-      (is (= :failed (:execution/status result)))
-      (is (some #(= :empty-pipeline (:type %)) (:execution/errors result))))))
-
-(deftest run-pipeline-stopped-control-state-test
+(deftest ^{:stratum 1} run-pipeline-stopped-control-state-test
   (testing "dashboard stop request returns a failed context"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
@@ -245,7 +257,7 @@
       (is (some #(= :dashboard-stop (:type %))
                 (:execution/errors result))))))
 
-(deftest run-pipeline-done-only-test
+(deftest ^{:stratum 1} run-pipeline-done-only-test
   (testing "run-pipeline completes with just :done phase"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
@@ -254,7 +266,7 @@
       (is (= :completed (:execution/status result)))
       (is (number? (:execution/ended-at result))))))
 
-(deftest run-pipeline-ensures-supervisory-attachment-test
+(deftest ^{:stratum 1} run-pipeline-ensures-supervisory-attachment-test
   (testing "run-pipeline auto-attaches supervisory-state for event-stream callers"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
@@ -267,7 +279,7 @@
         (is (true? (supervisory/attached? stream)))
         (is (some #{:supervisory/workflow-upserted} event-types))))))
 
-(deftest run-pipeline-persists-machine-snapshot-test
+(deftest ^{:stratum 1} run-pipeline-persists-machine-snapshot-test
   (with-temp-checkpoint-root
     (fn [checkpoint-root]
       (let [workflow {:workflow/id :test
@@ -284,7 +296,7 @@
         (is (= [test-done-phase]
                (get-in checkpoint-data [:manifest :workflow/phases-completed])))))))
 
-(deftest run-pipeline-callbacks-test
+(deftest ^{:stratum 1} run-pipeline-callbacks-test
   (testing "run-pipeline invokes callbacks"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
@@ -304,7 +316,7 @@
       (is (= [test-done-phase] @started))
       (is (= [test-done-phase] @completed)))))
 
-(deftest run-pipeline-max-phases-test
+(deftest ^{:stratum 1} run-pipeline-max-phases-test
   (testing "run-pipeline completes a simple workflow within max-phases limit"
     ;; Use :done phase only since other phases require LLM infrastructure
     (let [workflow {:workflow/id :test
@@ -313,7 +325,7 @@
           result (runner/run-pipeline workflow {:task "Test"} {:max-phases 50})]
       (is (= :completed (:execution/status result))))))
 
-(deftest run-pipeline-resume-machine-snapshot-test
+(deftest ^{:stratum 1} run-pipeline-resume-machine-snapshot-test
   (testing "resume-machine-snapshot preserves the original execution id"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
@@ -327,7 +339,7 @@
       (is (= :completed (:execution/status result)))
       (is (= (:execution/id resume-ctx) (:execution/id result))))))
 
-(deftest run-pipeline-resume-from-mid-workflow-snapshot-advances-test
+(deftest ^{:stratum 1} run-pipeline-resume-from-mid-workflow-snapshot-advances-test
   ;; Regression for the dogfood-2026-05-16 silent fast-fail: resume from a
   ;; snapshot whose FSM is actually parked at an intermediate phase must
   ;; advance through the remaining phases and reach `:completed` (not just
@@ -385,8 +397,7 @@
 ;; ============================================================================
 ;; Phase result recording tests
 ;; ============================================================================
-
-(deftest phase-results-recorded-test
+(deftest ^{:stratum 1} phase-results-recorded-test
   (testing "phase results are recorded in execution context"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
@@ -397,8 +408,7 @@
 ;; ============================================================================
 ;; Metrics accumulation tests
 ;; ============================================================================
-
-(deftest metrics-accumulated-test
+(deftest ^{:stratum 1} metrics-accumulated-test
   (testing "metrics are accumulated across phases"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
@@ -408,23 +418,9 @@
       (is (contains? (:execution/metrics result) :tokens)))))
 
 ;; ============================================================================
-;; Response chain tests
-;; ============================================================================
-
-(deftest response-chain-created-test
-  (testing "response chain is initialized in context"
-    (let [workflow {:workflow/id :test
-                    :workflow/version "1.0.0"}
-          ctx (ctx/create-context workflow {:task "Test"} {})]
-      (is (contains? ctx :execution/response-chain))
-      (is (= :test (:operation (:execution/response-chain ctx))))
-      (is (true? (:succeeded? (:execution/response-chain ctx)))))))
-
-;; ============================================================================
 ;; FSM state tracking tests
 ;; ============================================================================
-
-(deftest fsm-state-tracked-test
+(deftest ^{:stratum 1} fsm-state-tracked-test
   (testing "FSM state is tracked in context"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"}
@@ -450,8 +446,7 @@
 ;; ============================================================================
 ;; Output extraction tests
 ;; ============================================================================
-
-(deftest extract-output-shape-test
+(deftest ^{:stratum 1} extract-output-shape-test
   (testing "extract-output populates :execution/output with expected shape"
     (let [;; Build a minimal context that looks like a completed pipeline
           fake-ctx {:execution/artifacts [{:type :file :path "out.txt"}]
@@ -470,7 +465,7 @@
       (is (= {:phase/status :succeeded} (:last-phase-result output)))
       (is (= :completed (:status output))))))
 
-(deftest run-pipeline-returns-execution-output-test
+(deftest ^{:stratum 1} run-pipeline-returns-execution-output-test
   (testing "run-pipeline returns context with :execution/output populated"
     (let [workflow {:workflow/id :test
                     :workflow/version "1.0.0"
@@ -486,19 +481,10 @@
         (is (contains? (:phase-results output) test-done-phase))
         (is (some? (:last-phase-result output)))))))
 
-(deftest context-initializes-output-nil-test
-  (testing "create-context initializes :execution/output as nil"
-    (let [workflow {:workflow/id :test
-                    :workflow/version "1.0.0"}
-          ctx (ctx/create-context workflow {:task "Test"} {})]
-      (is (contains? ctx :execution/output))
-      (is (nil? (:execution/output ctx))))))
-
 ;; ============================================================================
 ;; Execution environment tests
 ;; ============================================================================
-
-(deftest run-pipeline-uses-pre-acquired-executor-test
+(deftest ^{:stratum 1} run-pipeline-uses-pre-acquired-executor-test
   (testing "pre-acquired executor/environment-id in opts lands in initial context"
     (let [env-id (random-uuid)
           workflow {:workflow/id :test
@@ -512,7 +498,7 @@
       (is (= env-id (:execution/environment-id result)))
       (is (= "/tmp/worktree" (:execution/worktree-path result))))))
 
-(deftest run-pipeline-threads-acquired-default-branch-test
+(deftest ^{:stratum 1} run-pipeline-threads-acquired-default-branch-test
   (testing "the branch used to acquire a worktree is kept in execution opts"
     (let [acquire-var (resolve 'ai.miniforge.workflow.runner-environment/acquire-execution-environment!)]
       (with-redefs-fn
@@ -531,7 +517,7 @@
             (is (= {:base-branch "main"}
                    (:execution/environment-metadata result)))))))))
 
-(deftest run-pipeline-threads-resume-workspace-to-acquisition-test
+(deftest ^{:stratum 1} run-pipeline-threads-resume-workspace-to-acquisition-test
   (testing "resume workspace checkpoint reaches environment acquisition"
     (let [acquire-var (resolve 'ai.miniforge.workflow.runner-environment/acquire-execution-environment!)
           env-config-seen (atom nil)
@@ -555,7 +541,7 @@
             (is (= resume-workspace (:resume-workspace @env-config-seen)))
             (is (= :completed (:execution/status result)))))))))
 
-(deftest run-pipeline-resume-preserves-checkpoint-metadata-test
+(deftest ^{:stratum 1} run-pipeline-resume-preserves-checkpoint-metadata-test
   (testing "resume keeps checkpoint metadata when no fresh environment metadata is supplied"
     (let [acquire-var (resolve 'ai.miniforge.workflow.runner-environment/acquire-execution-environment!)
           workflow {:workflow/id :test
@@ -574,7 +560,7 @@
                                              :resume-phase-results {}})]
             (is (= metadata (:execution/environment-metadata result)))))))))
 
-(deftest run-pipeline-without-executor-skips-env-keys-test
+(deftest ^{:stratum 1} run-pipeline-without-executor-skips-env-keys-test
   (testing "when no executor in opts and acquisition yields nil, env keys are absent"
     ;; Force acquisition to return nil for deterministic test isolation.
     ;; Verifies the safe-nil path: acquisition failure → no env keys.
@@ -589,3 +575,10 @@
             (is (= :completed (:execution/status result)))
             (is (nil? (:execution/environment-id result)))
             (is (nil? (:execution/worktree-path result)))))))))
+
+;; Compose phase-test-support's loader setup with the acquire-environment
+;; stub. clojure.test/use-fixtures REPLACES prior :each fixtures, so both
+;; must be registered in a single call.
+(use-fixtures :each
+  phase-test-support/with-workflow-phase-test-support
+  with-stubbed-acquire-environment)

--- a/components/workflow/test/ai/miniforge/workflow/runner_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_test.clj
@@ -23,6 +23,7 @@
    [clojure.java.io :as io]
    [clojure.test :refer [deftest is testing use-fixtures]]
    [ai.miniforge.event-stream.interface :as es]
+   [ai.miniforge.logging.interface :as log]
    [ai.miniforge.phase.interface]
    [ai.miniforge.response.interface :as response]
    [ai.miniforge.supervisory-state.interface :as supervisory]
@@ -104,6 +105,29 @@
           source-root "/tmp/miniforge-source-root"
           ctx (ctx/create-context workflow {:task "Test"} {:source-root source-root})]
       (is (= source-root (:source-root ctx))))))
+
+(deftest ^{:stratum 0} context-normalizes-execution-logger-test
+  ;; :execution/logger is normalized at context creation — the ONE
+  ;; canonical writer. Before this, no writer set the key at all, so
+  ;; every consumer guarding on it (gap-wiring's ledger-failure
+  ;; warnings, codex-pin's consultation-skipped warning) silently
+  ;; dropped its best-effort warnings.
+  (let [workflow {:workflow/id :test
+                  :workflow/version "1.0.0"}]
+    (testing "create-context adopts the caller's :logger"
+      (let [[logger _entries] (log/collecting-logger)
+            ctx (ctx/create-context workflow {:task "Test"} {:logger logger})]
+        (is (identical? logger (:execution/logger ctx)))))
+    (testing "create-context defaults :execution/logger when opts carry none"
+      (let [ctx (ctx/create-context workflow {:task "Test"} {})]
+        (is (some? (:execution/logger ctx)))))
+    (testing "restore-context normalizes :execution/logger the same way"
+      (let [[logger _entries] (log/collecting-logger)
+            restored (ctx/restore-context workflow {:task "Test"} {} {}
+                                          {:logger logger})]
+        (is (identical? logger (:execution/logger restored))))
+      (let [restored (ctx/restore-context workflow {:task "Test"} {} {} {})]
+        (is (some? (:execution/logger restored)))))))
 
 (deftest ^{:stratum 0} restore-context-can-reset-terminal-snapshot-test
   (testing "failed checkpoint snapshots can resume a trimmed workflow"


### PR DESCRIPTION
## Problem

The workflow runner never set `:execution/logger` on the execution context. Every consumer that guards on it silently dropped its best-effort warnings:

1. `gap_wiring.clj` `record-phase-misses!` — `:codex-gap/ledger-write-failed` and `:codex-gap/recording-failed` warns only fire when `(:execution/logger ctx)` is non-nil, which it never was in production runs.
2. `codex_pin.clj` — the consultation-skipped warning path received a nil logger from `(get-in ctx [:execution/logger])` at the implement/review call sites.
3. Several readers (release, implement, phase-deployment) each minted a local fallback logger, with inconsistent min-levels.

## Fix

Normalize at context creation — one canonical writer. `create-context` and `restore-context` now set `:execution/logger` from the caller's `:logger` opt, defaulting to a debug-level human-output logger (matching `runner-logger` and the strictest per-reader fallback this replaces, so no previously-emitted debug entry is silently dropped). The key is never persisted: `checkpoint-store` whitelists persisted keys.

Also declares phase-software-factory's existing `logging` dependency in its `deps.edn` — its src already required `logging.interface`; the omission was masked by root `:dev`/`:test` flattening (known transitive-gap class).

## Commits

1. `chore(workflow)`: mechanical `stratum-lint --fix` pass on the two touched workflow files (annotation + reorder, no logic) — split out so the fix commit stays reviewable.
2. `fix(workflow)`: the logger normalization itself (~80 lines).

## Tests

1. `context-normalizes-execution-logger-test` — caller `:logger` adopted, default when absent, same for `restore-context`.
2. `ledger-write-failure-warns-through-the-context-logger` — occupies the run-dir path with a file so the ledger append fails, and asserts the `:codex-gap/ledger-write-failed` warn reaches a collecting logger via `:execution/logger`.

Component-local `clj-kondo` clean; pre-commit gate (poly check, lint, stratum, smoke, graalvm) green on both commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)