### PR TITLE
refactor(cli): split workflow_runner.clj — extract paths + spec-kanban (rule 210, 1/6)

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -18,7 +18,6 @@
 (ns ai.miniforge.cli.workflow-runner
   (:require
    [ai.miniforge.anomaly.interface :as anomaly]
-   [babashka.fs :as fs]
    [clojure.string :as str]
    [clojure.edn :as edn]
    [cheshire.core :as json]
@@ -37,6 +36,8 @@
    [ai.miniforge.cli.workflow-runner.display :as display]
    [ai.miniforge.cli.workflow-runner.context :as context]
    [ai.miniforge.cli.workflow-runner.control :as control]
+   [ai.miniforge.cli.workflow-runner.paths :as paths]
+   [ai.miniforge.cli.workflow-runner.spec-kanban :as spec-kanban]
    [ai.miniforge.cli.workflow-runner.sandbox :as sandbox]
    [ai.miniforge.cli.workflow-runner.dashboard :as dashboard]
    [ai.miniforge.phase.interface :as phase]
@@ -47,19 +48,6 @@
    [ai.miniforge.cli.workflow-runner.gc-hooks :as gc-hooks]))
 
 ;------------------------------------------------------------------------------ Layer 0
-
-;; Work spec kanban lifecycle
-(def ^{:stratum 0} ^:private work-dirs
-  "Kanban folder structure under work/."
-  {:in-progress "work/in-progress"
-   :done        "work/done"
-   :failed      "work/failed"})
-
-(defn- ^{:stratum 0} work-spec?
-  "True when the spec provenance points to a file under work/."
-  [provenance]
-  (when-let [source (:source-file provenance)]
-    (str/starts-with? (str source) "work/")))
 
 ;; Meta-loop context — process-scoped, accumulates metrics across workflows
 (defn- ^{:stratum 0} trigger-meta-loop-after-workflow!
@@ -122,23 +110,6 @@
   []
   (gc-hooks/run-gc-pass-best-effort! worktree/worktree-root gc-queue/run-deferred-gc!))
 
-;; Source-root and execution-context validation helpers
-(defn- ^{:stratum 0} valid-source-root?
-  [source-root]
-  (and source-root
-       (fs/exists? source-root)
-       (fs/exists? (fs/path source-root ".git"))))
-
-(defn- ^{:stratum 0} normalize-path
-  [path]
-  (when path
-    (let [resolved (-> path
-                       fs/path
-                       fs/absolutize)]
-      (str (if (fs/exists? resolved)
-             (fs/canonicalize resolved)
-             (.normalize resolved))))))
-
 (defn- ^{:stratum 0} print-colored-lines!
   [quiet lines]
   (when-not quiet
@@ -168,22 +139,6 @@
     (resource-config/merged-resource-config "config/cli/workflow-runner.edn"
                                             :workflow-runner
                                             {})))
-
-(defn- ^{:stratum 0} executable-file?
-  [path]
-  (let [file (some-> path fs/file)]
-    (and file
-         (fs/exists? file)
-         (not (fs/directory? file))
-         (fs/executable? file))))
-
-(defn- ^{:stratum 0} direct-command-path?
-  [cmd]
-  (boolean (re-find #"[\\/]" (or cmd ""))))
-
-(defn- ^{:stratum 0} path-entries
-  []
-  (str/split (or (System/getenv "PATH") "") #":"))
 
 (defn- ^{:stratum 0} cli-process-env
   []
@@ -450,49 +405,25 @@
       (println (display/colorize :red (messages/t :workflow-runner/list-chains-failed {:error (ex-message e)})))
       (throw e))))
 
+(defn- ^{:stratum 0} assert-runtime-alignment!
+  [spec context]
+  (paths/assert-valid-source-root! context)
+  (paths/assert-execution-worktree! context)
+  (paths/assert-source-dir-alignment! spec context))
+
+(defn- ^{:stratum 0} backend-stamp
+  [llm-client]
+  (when-let [backend (llm/client-backend llm-client)]
+    (let [backend-config (get llm/backends backend)
+          cmd (:cmd backend-config)
+          cmd-path (when (:requires-cli? backend-config)
+                     (paths/resolve-cli-command-path cmd))]
+      {:backend backend
+       :backend-config backend-config
+       :cmd cmd
+       :cmd-path cmd-path})))
+
 ;------------------------------------------------------------------------------ Layer 1
-
-(defn- ^{:stratum 1} move-spec!
-  "Move a work spec file to the target kanban folder.
-   No-op if the spec isn't under work/ or the file doesn't exist."
-  [provenance target-key]
-  (when (work-spec? provenance)
-    (let [source (str (:source-file provenance))
-          target-dir (get work-dirs target-key)]
-      (when (and target-dir (fs/exists? source))
-        (fs/create-dirs target-dir)
-        (let [target (str target-dir "/" (fs/file-name source))]
-          (fs/move source target {:replace-existing true})
-          target)))))
-
-(defn- ^{:stratum 1} source-dir-under-root?
-  [source-dir source-root]
-  (let [source-dir-path (some-> source-dir normalize-path fs/path)
-        source-root-path (some-> source-root normalize-path fs/path)]
-    (or (nil? source-dir-path)
-        (nil? source-root-path)
-        (.startsWith source-dir-path source-root-path))))
-
-(defn- ^{:stratum 1} assert-valid-source-root!
-  [context]
-  (let [source-root (:source-root context)]
-    (when-not (valid-source-root? source-root)
-      (response/throw-anomaly! :anomalies/incorrect
-                               (str "Invalid workflow source root: " source-root)
-                               {:source-root source-root
-                                :worktree-path (:worktree-path context)}))))
-
-(defn- ^{:stratum 1} assert-execution-worktree!
-  [context]
-  (let [expected (normalize-path (get-in context [:execution/opts :worktree-path]))
-        actual (normalize-path (:worktree-path context))]
-    (when (and expected actual (not= expected actual))
-      (response/throw-anomaly! :anomalies/incorrect
-                               (str "Execution worktree mismatch: expected "
-                                    expected " but runtime is using " actual)
-                               {:expected-worktree expected
-                                :actual-worktree actual
-                                :source-root (:source-root context)}))))
 
 (defn- ^{:stratum 1} print-runtime-provenance!
   [quiet context]
@@ -500,19 +431,6 @@
 
 (defn- ^{:stratum 1} backend-preflight-config []
   (:backend-preflight @workflow-runner-config))
-
-(defn- ^{:stratum 1} normalize-command-path
-  [path]
-  (when (executable-file? path)
-    (str (-> path
-             fs/path
-             fs/absolutize))))
-
-(defn- ^{:stratum 1} matching-command-path
-  [entry cmd]
-  (let [candidate (fs/path entry cmd)]
-    (when (executable-file? candidate)
-      (str candidate))))
 
 (defn- ^{:stratum 1} start-cli-process
   [cmd workdir]
@@ -710,35 +628,13 @@
          (sort-by (juxt :workflow/id :workflow/version))
          format-workflow-listing)))
 
+(defn- ^{:stratum 1} cli-required-backend-stamp
+  [llm-client]
+  (when-let [stamp (backend-stamp llm-client)]
+    (when (:requires-cli? (:backend-config stamp))
+      stamp)))
+
 ;------------------------------------------------------------------------------ Layer 2
-
-(defn ^{:stratum 2} move-spec-to-in-progress!
-  "Move a work spec to in-progress when execution starts.
-   Returns updated provenance with new source-file path,
-   or the original provenance if the move was a no-op."
-  [provenance]
-  (if-let [new-path (move-spec! provenance :in-progress)]
-    (assoc provenance :source-file new-path)
-    provenance))
-
-(defn ^{:stratum 2} move-spec-on-completion!
-  "Move a work spec to done or failed based on workflow result."
-  [provenance result]
-  (if (phase/succeeded? result)
-    (move-spec! provenance :done)
-    (move-spec! provenance :failed)))
-
-(defn- ^{:stratum 2} assert-source-dir-alignment!
-  [spec context]
-  (let [source-dir (:spec/source-dir spec)
-        source-root (:source-root context)]
-    (when-not (source-dir-under-root? source-dir source-root)
-      (response/throw-anomaly! :anomalies/incorrect
-                               (str "Spec source directory is outside the workflow source root: "
-                                    source-dir)
-                               {:source-dir source-dir
-                                :source-root source-root
-                                :worktree-path (:worktree-path context)}))))
 
 (defn- ^{:stratum 2} backend-preflight-prompt []
   (:prompt (backend-preflight-config)))
@@ -751,12 +647,6 @@
 
 (defn- ^{:stratum 2} claude-preflight-args []
   (:claude-args (backend-preflight-config)))
-
-(defn- ^{:stratum 2} portable-command-path
-  [cmd]
-  (some-> cmd
-          fs/which
-          normalize-command-path))
 
 (defn- ^{:stratum 2} run-cli-command
   [cmd timeout-ms & {:keys [workdir]}]
@@ -937,23 +827,6 @@
 
 ;------------------------------------------------------------------------------ Layer 3
 
-(defn- ^{:stratum 3} assert-runtime-alignment!
-  [spec context]
-  (assert-valid-source-root! context)
-  (assert-execution-worktree! context)
-  (assert-source-dir-alignment! spec context))
-
-(defn- ^{:stratum 3} resolve-cli-command-path
-  [cmd]
-  (cond
-    (str/blank? cmd) nil
-    (direct-command-path? cmd)
-    (normalize-command-path cmd)
-
-    :else
-    (or (portable-command-path cmd)
-        (some #(matching-command-path % cmd) (path-entries)))))
-
 (defn- ^{:stratum 3} read-cli-version
   [cmd-path]
   (let [{:keys [out err exit timeout-ms]} (run-cli-command [cmd-path "--version"] (backend-version-timeout-ms))]
@@ -1000,18 +873,6 @@
     (into [cmd] (args-fn request))))
 
 ;------------------------------------------------------------------------------ Layer 4
-
-(defn- ^{:stratum 4} backend-stamp
-  [llm-client]
-  (when-let [backend (llm/client-backend llm-client)]
-    (let [backend-config (get llm/backends backend)
-          cmd (:cmd backend-config)
-          cmd-path (when (:requires-cli? backend-config)
-                     (resolve-cli-command-path cmd))]
-      {:backend backend
-       :backend-config backend-config
-       :cmd cmd
-       :cmd-path cmd-path})))
 
 (defn- ^{:stratum 4} run-generic-backend-preflight
   [llm-client cmd-path workdir]
@@ -1113,12 +974,6 @@
 
 ;------------------------------------------------------------------------------ Layer 5
 
-(defn- ^{:stratum 5} cli-required-backend-stamp
-  [llm-client]
-  (when-let [stamp (backend-stamp llm-client)]
-    (when (:requires-cli? (:backend-config stamp))
-      stamp)))
-
 (defn- ^{:stratum 5} run-backend-probe
   [llm-client {:keys [backend cmd-path]} workdir]
   (if (= backend :claude)
@@ -1217,7 +1072,7 @@
         (assert-runtime-alignment! spec context)
         (print-runtime-provenance! quiet context)
         (run-backend-preflight! quiet llm-client context)
-        (let [provenance (move-spec-to-in-progress! (:spec/provenance enriched-spec))
+        (let [provenance (spec-kanban/move-spec-to-in-progress! (:spec/provenance enriched-spec))
               result (execute-with-events {:run-pipeline run-pipeline
                                            :workflow workflow
                                            :workflow-input workflow-input
@@ -1228,7 +1083,7 @@
                                            :sandbox-cleanup sandbox-cleanup
                                            :opts opts})
               outcome-status (if (phase/succeeded? result) :completed :failed)]
-          (move-spec-on-completion! provenance result)
+          (spec-kanban/move-spec-on-completion! provenance result)
           ;; Trigger meta-loop learning cycle in background
           (trigger-meta-loop-after-workflow! workflow-id outcome-status nil)
           result)

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/paths.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/paths.clj
@@ -1,0 +1,135 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.workflow-runner.paths
+  "Filesystem path vocabulary for the workflow runner: normalization,
+   executable/command-path resolution, and the runtime-path assertions
+   that keep a run's source root, worktree, and spec source dir
+   aligned. Split out of `ai.miniforge.cli.workflow-runner` (rule 210:
+   the parent namespace measured 10 real layers, max 3; each concern
+   moves to its own layer-coherent file — same approach as the
+   dag-orchestrator split, miniforge#1485)."
+  (:require
+   [babashka.fs :as fs]
+   [clojure.string :as str]
+   [ai.miniforge.response.interface :as response]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} valid-source-root?
+  [source-root]
+  (and source-root
+       (fs/exists? source-root)
+       (fs/exists? (fs/path source-root ".git"))))
+
+(defn- ^{:stratum 0} normalize-path
+  [path]
+  (when path
+    (let [resolved (-> path
+                       fs/path
+                       fs/absolutize)]
+      (str (if (fs/exists? resolved)
+             (fs/canonicalize resolved)
+             (.normalize resolved))))))
+
+(defn- ^{:stratum 0} executable-file?
+  [path]
+  (let [file (some-> path fs/file)]
+    (and file
+         (fs/exists? file)
+         (not (fs/directory? file))
+         (fs/executable? file))))
+
+(defn- ^{:stratum 0} direct-command-path?
+  [cmd]
+  (boolean (re-find #"[\\/]" (or cmd ""))))
+
+(defn- ^{:stratum 0} path-entries
+  []
+  (str/split (or (System/getenv "PATH") "") #":"))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} normalize-command-path
+  [path]
+  (when (executable-file? path)
+    (str (-> path
+             fs/path
+             fs/absolutize))))
+
+(defn- ^{:stratum 1} matching-command-path
+  [entry cmd]
+  (let [candidate (fs/path entry cmd)]
+    (when (executable-file? candidate)
+      (str candidate))))
+
+(defn- ^{:stratum 1} source-dir-under-root?
+  [source-dir source-root]
+  (let [source-dir-path (some-> source-dir normalize-path fs/path)
+        source-root-path (some-> source-root normalize-path fs/path)]
+    (or (nil? source-dir-path)
+        (nil? source-root-path)
+        (.startsWith source-dir-path source-root-path))))
+
+(defn ^{:stratum 1} assert-valid-source-root!
+  [context]
+  (let [source-root (:source-root context)]
+    (when-not (valid-source-root? source-root)
+      (response/throw-anomaly! :anomalies/incorrect
+                               (str "Invalid workflow source root: " source-root)
+                               {:source-root source-root
+                                :worktree-path (:worktree-path context)}))))
+
+(defn ^{:stratum 1} assert-execution-worktree!
+  [context]
+  (let [expected (normalize-path (get-in context [:execution/opts :worktree-path]))
+        actual (normalize-path (:worktree-path context))]
+    (when (and expected actual (not= expected actual))
+      (response/throw-anomaly! :anomalies/incorrect
+                               (str "Execution worktree mismatch: expected "
+                                    expected " but runtime is using " actual)
+                               {:expected-worktree expected
+                                :actual-worktree actual
+                                :source-root (:source-root context)}))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} resolve-cli-command-path
+  "Absolute path of `cmd` when it resolves to an executable: a direct
+   path is normalized in place; a bare command is looked up via
+   `fs/which` and then, as a fallback, by scanning PATH entries."
+  [cmd]
+  (cond
+    (str/blank? cmd) nil
+    (direct-command-path? cmd)
+    (normalize-command-path cmd)
+
+    :else
+    (or (some-> cmd fs/which str normalize-command-path)
+        (some #(matching-command-path % cmd) (path-entries)))))
+
+(defn ^{:stratum 2} assert-source-dir-alignment!
+  [spec context]
+  (let [source-dir (:spec/source-dir spec)
+        source-root (:source-root context)]
+    (when-not (source-dir-under-root? source-dir source-root)
+      (response/throw-anomaly! :anomalies/incorrect
+                               (str "Spec source directory is outside the workflow source root: "
+                                    source-dir)
+                               {:source-dir source-dir
+                                :source-root source-root
+                                :worktree-path (:worktree-path context)}))))

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/spec_kanban.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/spec_kanban.clj
@@ -1,0 +1,74 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.workflow-runner.spec-kanban
+  "Work-spec kanban lifecycle: specs that live under `work/` move
+   through in-progress/done/failed folders as their workflow runs.
+   Split out of `ai.miniforge.cli.workflow-runner` (rule 210: the
+   parent namespace measured 10 real layers, max 3; each concern moves
+   to its own layer-coherent file)."
+  (:require
+   [babashka.fs :as fs]
+   [clojure.string :as str]
+   [ai.miniforge.phase.interface :as phase]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private work-dirs
+  "Kanban folder structure under work/."
+  {:in-progress "work/in-progress"
+   :done        "work/done"
+   :failed      "work/failed"})
+
+(defn- ^{:stratum 0} work-spec?
+  "True when the spec provenance points to a file under work/."
+  [provenance]
+  (when-let [source (:source-file provenance)]
+    (str/starts-with? (str source) "work/")))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} move-spec!
+  "Move a work spec file to the target kanban folder.
+   No-op if the spec isn't under work/ or the file doesn't exist."
+  [provenance target-key]
+  (when (work-spec? provenance)
+    (let [source (str (:source-file provenance))
+          target-dir (get work-dirs target-key)]
+      (when (and target-dir (fs/exists? source))
+        (fs/create-dirs target-dir)
+        (let [target (str target-dir "/" (fs/file-name source))]
+          (fs/move source target {:replace-existing true})
+          target)))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} move-spec-to-in-progress!
+  "Move a work spec to in-progress when execution starts.
+   Returns updated provenance with new source-file path,
+   or the original provenance if the move was a no-op."
+  [provenance]
+  (if-let [new-path (move-spec! provenance :in-progress)]
+    (assoc provenance :source-file new-path)
+    provenance))
+
+(defn ^{:stratum 2} move-spec-on-completion!
+  "Move a work spec to done or failed based on workflow result."
+  [provenance result]
+  (if (phase/succeeded? result)
+    (move-spec! provenance :done)
+    (move-spec! provenance :failed)))

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/kanban_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/kanban_test.clj
@@ -21,7 +21,8 @@
    [clojure.test :refer [deftest testing is use-fixtures]]
    [clojure.string :as str]
    [babashka.fs :as fs]
-   [ai.miniforge.cli.workflow-runner :as sut]))
+   [ai.miniforge.cli.workflow-runner :as sut]
+   [ai.miniforge.cli.workflow-runner.spec-kanban :as kanban]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -41,7 +42,7 @@
 (deftest ^{:stratum 0} move-spec-to-in-progress-non-work-spec-test
   (testing "non-work spec provenance is returned unchanged"
     (let [provenance {:source-file "/tmp/not-a-work-spec.edn"}]
-      (is (= provenance (sut/move-spec-to-in-progress! provenance))))))
+      (is (= provenance (kanban/move-spec-to-in-progress! provenance))))))
 
 ;; ============================================================================
 ;; failure-message
@@ -81,10 +82,10 @@
   "Redirect kanban dirs and work-spec? predicate to use the temp test dir."
   [& body]
   `(let [prefix# (str *test-dir* "/work/")]
-     (with-redefs [sut/work-dirs {:in-progress (str *test-dir* "/work/in-progress")
+     (with-redefs [kanban/work-dirs {:in-progress (str *test-dir* "/work/in-progress")
                                   :done (str *test-dir* "/work/done")
                                   :failed (str *test-dir* "/work/failed")}
-                   sut/work-spec? (fn [provenance#]
+                   kanban/work-spec? (fn [provenance#]
                                     (when-let [src# (:source-file provenance#)]
                                       (str/starts-with? (str src#) prefix#)))]
        ~@body)))
@@ -99,7 +100,7 @@
     (let [spec-path (create-work-spec! "test.spec.edn")
           provenance {:source-file spec-path}]
       (with-test-kanban
-        (let [updated (sut/move-spec-to-in-progress! provenance)]
+        (let [updated (kanban/move-spec-to-in-progress! provenance)]
           (is (= (str *test-dir* "/work/in-progress/test.spec.edn")
                  (:source-file updated)))
           (is (fs/exists? (:source-file updated)))
@@ -110,9 +111,9 @@
     (let [spec-path (create-work-spec! "lifecycle.spec.edn")
           provenance {:source-file spec-path}]
       (with-test-kanban
-        (let [updated (sut/move-spec-to-in-progress! provenance)]
+        (let [updated (kanban/move-spec-to-in-progress! provenance)]
           ;; Simulate successful completion
-          (sut/move-spec-on-completion! updated {:execution/status :completed})
+          (kanban/move-spec-on-completion! updated {:execution/status :completed})
           (is (fs/exists? (str *test-dir* "/work/done/lifecycle.spec.edn")))
           (is (not (fs/exists? (:source-file updated)))))))))
 
@@ -121,8 +122,8 @@
     (let [spec-path (create-work-spec! "broken.spec.edn")
           provenance {:source-file spec-path}]
       (with-test-kanban
-        (let [updated (sut/move-spec-to-in-progress! provenance)]
-          (sut/move-spec-on-completion! updated {:execution/status :failed})
+        (let [updated (kanban/move-spec-to-in-progress! provenance)]
+          (kanban/move-spec-on-completion! updated {:execution/status :failed})
           (is (fs/exists? (str *test-dir* "/work/failed/broken.spec.edn")))
           (is (not (fs/exists? (:source-file updated)))))))))
 

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/preflight_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/preflight_test.clj
@@ -22,7 +22,8 @@
    [clojure.test :refer [deftest is testing]]
    [slingshot.slingshot :refer [try+]]
    [ai.miniforge.llm.interface :as llm]
-   [ai.miniforge.cli.workflow-runner :as sut]))
+   [ai.miniforge.cli.workflow-runner :as sut]
+   [ai.miniforge.cli.workflow-runner.paths :as paths]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -68,7 +69,7 @@
     (let [llm-client (llm/mock-client {:output "{\"ok\":true}"})
           preflight-client (atom nil)
           output (with-out-str
-                   (with-redefs-fn {#'sut/resolve-cli-command-path (fn [_] "/Users/chris/.local/bin/claude")
+                   (with-redefs-fn {#'paths/resolve-cli-command-path (fn [_] "/Users/chris/.local/bin/claude")
                                     #'sut/read-cli-version (fn [_] {:success true :version "2.1.126"})
                                     #'sut/run-claude-backend-preflight (fn [cmd-path workdir]
                                                                          (is (= "/Users/chris/.local/bin/claude" cmd-path))
@@ -93,7 +94,7 @@
   (testing "backend preflight carries the resolved path and version when the probe fails"
     (let [llm-client (llm/mock-client {:output "{\"ok\":true}"})]
       (try+
-        (with-redefs-fn {#'sut/resolve-cli-command-path (fn [_] "/opt/homebrew/bin/claude")
+        (with-redefs-fn {#'paths/resolve-cli-command-path (fn [_] "/opt/homebrew/bin/claude")
                          #'sut/read-cli-version (fn [_] {:success true :version "2.1.89"})
                          #'sut/run-claude-backend-preflight (fn [_cmd-path _workdir]
                                                               {:success false
@@ -117,7 +118,7 @@
   (testing "Claude preflight accepts success envelopes whose result field contains the canonical payload"
     (let [llm-client (llm/mock-client {:output "{\"ok\":true}"})
           output (with-out-str
-                   (with-redefs-fn {#'sut/resolve-cli-command-path (fn [_] "/opt/homebrew/bin/claude")
+                   (with-redefs-fn {#'paths/resolve-cli-command-path (fn [_] "/opt/homebrew/bin/claude")
                                     #'sut/read-cli-version (fn [_] {:success true :version "2.1.118 (Claude Code)"})
                                     #'sut/run-cli-command (fn [_cmd _timeout-ms & _]
                                                             {:out "{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"{\\\"ok\\\":true}\"}"
@@ -136,7 +137,7 @@
   (testing "Claude preflight rejects wrapped payloads when the outer result envelope is not successful"
     (let [llm-client (llm/mock-client {:output "{\"ok\":true}"})]
       (try+
-        (with-redefs-fn {#'sut/resolve-cli-command-path (fn [_] "/opt/homebrew/bin/claude")
+        (with-redefs-fn {#'paths/resolve-cli-command-path (fn [_] "/opt/homebrew/bin/claude")
                          #'sut/read-cli-version (fn [_] {:success true :version "2.1.118 (Claude Code)"})
                          #'sut/run-cli-command (fn [_cmd _timeout-ms & _]
                                                  {:out "{\"type\":\"result\",\"subtype\":\"error\",\"is_error\":true,\"result\":\"{\\\"ok\\\":true}\"}"
@@ -161,7 +162,7 @@
           seen-timeout (atom nil)
           seen-workdir (atom nil)
           output (with-out-str
-                   (with-redefs-fn {#'sut/resolve-cli-command-path (fn [_] "/Users/chris/.local/bin/codex")
+                   (with-redefs-fn {#'paths/resolve-cli-command-path (fn [_] "/Users/chris/.local/bin/codex")
                                     #'sut/read-cli-version (fn [_] {:success true :version "1.2.3"})
                                     #'sut/run-cli-command (fn [cmd timeout-ms & {:keys [workdir]}]
                                                             (reset! seen-cmd cmd)


### PR DESCRIPTION
## Summary

`bases/cli/src/ai/miniforge/cli/workflow_runner.clj` (~1300 lines) trips stratum-lint SL003: 10 distinct real layers, max 3 (rule 210, standards/miniforge). This is slice 1 of a 6-PR split following the dag_orchestrator precedent (#1485): one concern per namespace, each new file within the 3-layer budget, mechanical moves only.

1. `workflow-runner.paths` — path normalization, executable/command-path resolution, and the runtime-path assertions (source root / execution worktree / spec source dir).
2. `workflow-runner.spec-kanban` — work-spec kanban lifecycle (in-progress/done/failed moves).

Only non-move change: `portable-command-path` folded into `resolve-cli-command-path` (same `fs/which` + normalize composition inlined) so the new file fits the 3-layer budget.

The parent namespace stays over budget until the remaining slices land (commits use `MINIFORGE_STRATUM_BUDGET_MODE=warn`); the final slice brings it to 3 layers.

## Testing

1. `clj-kondo` clean on all touched files.
2. stratum-lint: both new files pass SL003.
3. workflow-runner test namespaces (kanban, preflight, alias, manifest-wiring, runner-control-wiring): 42 tests, 1 pre-existing failure also present on unmodified main (codex preflight prompt test — flagged separately), 0 new failures.
4. Full pre-commit suite (poly:check, lint, smoke tests, graalvm) passed.

PR size: 254+/188- raw, under the 600-reportable-line budget (no override needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
