### PR TITLE
refactor(cli): split workflow_runner.clj — extract process + provenance (rule 210, 2/6)

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -37,6 +37,8 @@
    [ai.miniforge.cli.workflow-runner.context :as context]
    [ai.miniforge.cli.workflow-runner.control :as control]
    [ai.miniforge.cli.workflow-runner.paths :as paths]
+   [ai.miniforge.cli.workflow-runner.process :as process]
+   [ai.miniforge.cli.workflow-runner.provenance :as provenance]
    [ai.miniforge.cli.workflow-runner.spec-kanban :as spec-kanban]
    [ai.miniforge.cli.workflow-runner.sandbox :as sandbox]
    [ai.miniforge.cli.workflow-runner.dashboard :as dashboard]
@@ -110,59 +112,11 @@
   []
   (gc-hooks/run-gc-pass-best-effort! worktree/worktree-root gc-queue/run-deferred-gc!))
 
-(defn- ^{:stratum 0} print-colored-lines!
-  [quiet lines]
-  (when-not quiet
-    (doseq [[color line] lines]
-      (println (display/colorize color line)))))
-
-(defn- ^{:stratum 0} runtime-provenance-lines
-  [context]
-  (concat
-   [[:cyan (messages/t :workflow-runner/runtime-source
-                       {:path (:source-root context)})]
-    [:cyan (messages/t :workflow-runner/runtime-worktree
-                       {:path (:worktree-path context)})]]
-   (when-let [branch (:git-branch context)]
-     [[:cyan (messages/t :workflow-runner/runtime-branch {:branch branch})]])
-   (when-let [commit (:git-commit context)]
-     [[:cyan (messages/t :workflow-runner/runtime-commit {:commit commit})]])
-   (when-let [upstream (:git-upstream context)]
-     [[:cyan (messages/t :workflow-runner/runtime-upstream {:upstream upstream})]])
-   (when (:git-detached? context)
-     [[:yellow (messages/t :workflow-runner/runtime-detached-warning)]])
-   (when (:git-dirty? context)
-     [[:yellow (messages/t :workflow-runner/runtime-dirty-warning)]])))
-
 (def ^{:stratum 0} ^:private workflow-runner-config
   (delay
     (resource-config/merged-resource-config "config/cli/workflow-runner.edn"
                                             :workflow-runner
                                             {})))
-
-(defn- ^{:stratum 0} cli-process-env
-  []
-  (when (System/getenv "CLAUDECODE")
-    (into {} (remove (fn [[k _]] (= k "CLAUDECODE"))) (System/getenv))))
-
-(defn- ^{:stratum 0} stream-reader
-  [stream]
-  (future
-    (with-open [stream stream]
-      (slurp stream))))
-
-(defn- ^{:stratum 0} destroy-cli-process!
-  [^Process process]
-  (try
-    (.destroyForcibly process)
-    (.waitFor process 1000 java.util.concurrent.TimeUnit/MILLISECONDS)
-    (catch Exception _ nil)))
-
-(defn- ^{:stratum 0} await-stream
-  [stream-future]
-  (try
-    @stream-future
-    (catch Exception _ "")))
 
 (defn- ^{:stratum 0} success-response
   [output]
@@ -187,16 +141,6 @@
 (defn- ^{:stratum 0} with-backend-version
   [stamp version]
   (assoc stamp :cmd-version version))
-
-(defn- ^{:stratum 0} backend-provenance-lines
-  [{:keys [backend cmd-path cmd-version]}]
-  (concat
-   [[:cyan (messages/t :workflow-runner/backend-label
-                       {:backend (name backend)})]]
-   (when cmd-path
-     [[:cyan (messages/t :workflow-runner/backend-path {:path cmd-path})]])
-   (when cmd-version
-     [[:cyan (messages/t :workflow-runner/backend-version {:version cmd-version})]])))
 
 (defn- ^{:stratum 0} parse-preflight-payload
   [content]
@@ -425,24 +369,8 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
-(defn- ^{:stratum 1} print-runtime-provenance!
-  [quiet context]
-  (print-colored-lines! quiet (runtime-provenance-lines context)))
-
 (defn- ^{:stratum 1} backend-preflight-config []
   (:backend-preflight @workflow-runner-config))
-
-(defn- ^{:stratum 1} start-cli-process
-  [cmd workdir]
-  (let [builder (ProcessBuilder. ^java.util.List cmd)]
-    (when-let [process-env (cli-process-env)]
-      (let [env (.environment builder)]
-        (.clear env)
-        (doseq [[k v] process-env]
-          (.put env k v))))
-    (when workdir
-      (.directory builder (java.io.File. workdir)))
-    (.start builder)))
 
 (defn- ^{:stratum 1} response-summary
   [response]
@@ -450,12 +378,6 @@
    (select-keys response [:success :error :anomaly :exit-code])
    (select-keys (response-output response)
                 [:content :exit-code :version])))
-
-(defn- ^{:stratum 1} print-backend-provenance!
-  [quiet {:keys [backend cmd-path cmd-version]}]
-  (print-colored-lines! quiet (backend-provenance-lines {:backend backend
-                                                         :cmd-path cmd-path
-                                                         :cmd-version cmd-version})))
 
 (defn- ^{:stratum 1} normalized-preflight-content
   [content]
@@ -648,27 +570,6 @@
 (defn- ^{:stratum 2} claude-preflight-args []
   (:claude-args (backend-preflight-config)))
 
-(defn- ^{:stratum 2} run-cli-command
-  [cmd timeout-ms & {:keys [workdir]}]
-  (let [^Process process (start-cli-process cmd workdir)
-        _ (.close (.getOutputStream process))
-        out-future (stream-reader (.getInputStream process))
-        err-future (stream-reader (.getErrorStream process))
-        completed? (.waitFor process timeout-ms java.util.concurrent.TimeUnit/MILLISECONDS)]
-    (if-not completed?
-      (do
-        (destroy-cli-process! process)
-        (future-cancel out-future)
-        (future-cancel err-future)
-        {:out ""
-         :err (messages/t :workflow-runner/cli-process-timeout
-                          {:timeout-ms timeout-ms})
-         :exit -1
-         :timeout-ms timeout-ms})
-      {:out (await-stream out-future)
-       :err (await-stream err-future)
-       :exit (.exitValue process)})))
-
 (defn- ^{:stratum 2} preflight-success?
   [content]
   (= {:ok true} (parse-preflight-payload (normalized-preflight-content content))))
@@ -829,7 +730,7 @@
 
 (defn- ^{:stratum 3} read-cli-version
   [cmd-path]
-  (let [{:keys [out err exit timeout-ms]} (run-cli-command [cmd-path "--version"] (backend-version-timeout-ms))]
+  (let [{:keys [out err exit timeout-ms]} (process/run-cli-command [cmd-path "--version"] (backend-version-timeout-ms))]
     (cond
       timeout-ms
       (failure-response :anomalies/unavailable
@@ -879,7 +780,7 @@
   (let [{:keys [backend]} (:config llm-client)
         backend-config (get llm/backends backend)
         full-cmd (into [cmd-path] (rest (generic-preflight-command llm-client)))
-        {:keys [out err exit timeout-ms]} (run-cli-command full-cmd
+        {:keys [out err exit timeout-ms]} (process/run-cli-command full-cmd
                                                            (backend-preflight-timeout-ms)
                                                            :workdir workdir)
         content (decoded-preflight-content backend-config out)]
@@ -921,7 +822,7 @@
 
 (defn- ^{:stratum 4} run-claude-backend-preflight
   [cmd-path workdir]
-  (let [{:keys [out err exit timeout-ms]} (run-cli-command (claude-preflight-command cmd-path)
+  (let [{:keys [out err exit timeout-ms]} (process/run-cli-command (claude-preflight-command cmd-path)
                                                            (backend-preflight-timeout-ms)
                                                            :workdir workdir)
         trimmed (some-> out str/trim)
@@ -997,7 +898,7 @@
     (let [stamp (-> stamp
                     ensure-cli-command-path!
                     versioned-backend-stamp)]
-      (print-backend-provenance! quiet stamp)
+      (provenance/print-backend-provenance! quiet stamp)
       (verify-backend-probe! llm-client stamp (:worktree-path context)))))
 
 ;------------------------------------------------------------------------------ Layer 8
@@ -1070,7 +971,7 @@
           (display/print-workflow-header (keyword (str "adhoc-" (hash spec))) "adhoc" quiet))
         (dashboard/print-dashboard-status! quiet)
         (assert-runtime-alignment! spec context)
-        (print-runtime-provenance! quiet context)
+        (provenance/print-runtime-provenance! quiet context)
         (run-backend-preflight! quiet llm-client context)
         (let [provenance (spec-kanban/move-spec-to-in-progress! (:spec/provenance enriched-spec))
               result (execute-with-events {:run-pipeline run-pipeline

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/process.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/process.clj
@@ -1,0 +1,88 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.workflow-runner.process
+  "Subprocess primitives for backend CLI probes: environment scrubbing,
+   stream capture, and bounded-timeout command execution. Split out of
+   `ai.miniforge.cli.workflow-runner` (rule 210: the parent namespace
+   measured 10 real layers, max 3; each concern moves to its own
+   layer-coherent file)."
+  (:require
+   [ai.miniforge.cli.messages :as messages]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} cli-process-env
+  []
+  (when (System/getenv "CLAUDECODE")
+    (into {} (remove (fn [[k _]] (= k "CLAUDECODE"))) (System/getenv))))
+
+(defn- ^{:stratum 0} stream-reader
+  [stream]
+  (future
+    (with-open [stream stream]
+      (slurp stream))))
+
+(defn- ^{:stratum 0} destroy-cli-process!
+  [^Process process]
+  (try
+    (.destroyForcibly process)
+    (.waitFor process 1000 java.util.concurrent.TimeUnit/MILLISECONDS)
+    (catch Exception _ nil)))
+
+(defn- ^{:stratum 0} await-stream
+  [stream-future]
+  (try
+    @stream-future
+    (catch Exception _ "")))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} start-cli-process
+  [cmd workdir]
+  (let [builder (ProcessBuilder. ^java.util.List cmd)]
+    (when-let [process-env (cli-process-env)]
+      (let [env (.environment builder)]
+        (.clear env)
+        (doseq [[k v] process-env]
+          (.put env k v))))
+    (when workdir
+      (.directory builder (java.io.File. workdir)))
+    (.start builder)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} run-cli-command
+  [cmd timeout-ms & {:keys [workdir]}]
+  (let [^Process process (start-cli-process cmd workdir)
+        _ (.close (.getOutputStream process))
+        out-future (stream-reader (.getInputStream process))
+        err-future (stream-reader (.getErrorStream process))
+        completed? (.waitFor process timeout-ms java.util.concurrent.TimeUnit/MILLISECONDS)]
+    (if-not completed?
+      (do
+        (destroy-cli-process! process)
+        (future-cancel out-future)
+        (future-cancel err-future)
+        {:out ""
+         :err (messages/t :workflow-runner/cli-process-timeout
+                          {:timeout-ms timeout-ms})
+         :exit -1
+         :timeout-ms timeout-ms})
+      {:out (await-stream out-future)
+       :err (await-stream err-future)
+       :exit (.exitValue process)})))

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/provenance.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/provenance.clj
@@ -1,0 +1,74 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.workflow-runner.provenance
+  "Startup provenance banners: where the runtime is executing from
+   (source root, worktree, git state) and which backend CLI it resolved
+   (path, version). Split out of `ai.miniforge.cli.workflow-runner`
+   (rule 210: the parent namespace measured 10 real layers, max 3; each
+   concern moves to its own layer-coherent file)."
+  (:require
+   [ai.miniforge.cli.messages :as messages]
+   [ai.miniforge.cli.workflow-runner.display :as display]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} print-colored-lines!
+  [quiet lines]
+  (when-not quiet
+    (doseq [[color line] lines]
+      (println (display/colorize color line)))))
+
+(defn- ^{:stratum 0} runtime-provenance-lines
+  [context]
+  (concat
+   [[:cyan (messages/t :workflow-runner/runtime-source
+                       {:path (:source-root context)})]
+    [:cyan (messages/t :workflow-runner/runtime-worktree
+                       {:path (:worktree-path context)})]]
+   (when-let [branch (:git-branch context)]
+     [[:cyan (messages/t :workflow-runner/runtime-branch {:branch branch})]])
+   (when-let [commit (:git-commit context)]
+     [[:cyan (messages/t :workflow-runner/runtime-commit {:commit commit})]])
+   (when-let [upstream (:git-upstream context)]
+     [[:cyan (messages/t :workflow-runner/runtime-upstream {:upstream upstream})]])
+   (when (:git-detached? context)
+     [[:yellow (messages/t :workflow-runner/runtime-detached-warning)]])
+   (when (:git-dirty? context)
+     [[:yellow (messages/t :workflow-runner/runtime-dirty-warning)]])))
+
+(defn- ^{:stratum 0} backend-provenance-lines
+  [{:keys [backend cmd-path cmd-version]}]
+  (concat
+   [[:cyan (messages/t :workflow-runner/backend-label
+                       {:backend (name backend)})]]
+   (when cmd-path
+     [[:cyan (messages/t :workflow-runner/backend-path {:path cmd-path})]])
+   (when cmd-version
+     [[:cyan (messages/t :workflow-runner/backend-version {:version cmd-version})]])))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} print-runtime-provenance!
+  [quiet context]
+  (print-colored-lines! quiet (runtime-provenance-lines context)))
+
+(defn ^{:stratum 1} print-backend-provenance!
+  [quiet {:keys [backend cmd-path cmd-version]}]
+  (print-colored-lines! quiet (backend-provenance-lines {:backend backend
+                                                         :cmd-path cmd-path
+                                                         :cmd-version cmd-version})))

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/preflight_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/preflight_test.clj
@@ -23,7 +23,9 @@
    [slingshot.slingshot :refer [try+]]
    [ai.miniforge.llm.interface :as llm]
    [ai.miniforge.cli.workflow-runner :as sut]
-   [ai.miniforge.cli.workflow-runner.paths :as paths]))
+   [ai.miniforge.cli.workflow-runner.paths :as paths]
+   [ai.miniforge.cli.workflow-runner.process :as process]
+   [ai.miniforge.cli.workflow-runner.provenance :as provenance]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -39,7 +41,7 @@
 (deftest ^{:stratum 0} await-stream-waits-for-reader-completion-test
   (testing "stream join waits for a completed reader instead of dropping late output"
     (let [started-at (System/currentTimeMillis)
-          result (#'sut/await-stream (future
+          result (#'process/await-stream (future
                                        (Thread/sleep 1100)
                                        "late-output"))
           elapsed-ms (- (System/currentTimeMillis) started-at)]
@@ -49,7 +51,7 @@
 (deftest ^{:stratum 0} print-runtime-provenance-includes-startup-warnings-test
   (testing "startup provenance prints upstream and source checkout warnings"
     (let [output (with-out-str
-                   (#'sut/print-runtime-provenance!
+                   (#'provenance/print-runtime-provenance!
                     false
                     {:source-root "/tmp/source-root"
                      :worktree-path "/tmp/runtime-worktree"
@@ -120,7 +122,7 @@
           output (with-out-str
                    (with-redefs-fn {#'paths/resolve-cli-command-path (fn [_] "/opt/homebrew/bin/claude")
                                     #'sut/read-cli-version (fn [_] {:success true :version "2.1.118 (Claude Code)"})
-                                    #'sut/run-cli-command (fn [_cmd _timeout-ms & _]
+                                    #'process/run-cli-command (fn [_cmd _timeout-ms & _]
                                                             {:out "{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"{\\\"ok\\\":true}\"}"
                                                              :err ""
                                                              :exit 0})}
@@ -139,7 +141,7 @@
       (try+
         (with-redefs-fn {#'paths/resolve-cli-command-path (fn [_] "/opt/homebrew/bin/claude")
                          #'sut/read-cli-version (fn [_] {:success true :version "2.1.118 (Claude Code)"})
-                         #'sut/run-cli-command (fn [_cmd _timeout-ms & _]
+                         #'process/run-cli-command (fn [_cmd _timeout-ms & _]
                                                  {:out "{\"type\":\"result\",\"subtype\":\"error\",\"is_error\":true,\"result\":\"{\\\"ok\\\":true}\"}"
                                                   :err ""
                                                   :exit 0})}
@@ -164,7 +166,7 @@
           output (with-out-str
                    (with-redefs-fn {#'paths/resolve-cli-command-path (fn [_] "/Users/chris/.local/bin/codex")
                                     #'sut/read-cli-version (fn [_] {:success true :version "1.2.3"})
-                                    #'sut/run-cli-command (fn [cmd timeout-ms & {:keys [workdir]}]
+                                    #'process/run-cli-command (fn [cmd timeout-ms & {:keys [workdir]}]
                                                             (reset! seen-cmd cmd)
                                                             (reset! seen-timeout timeout-ms)
                                                             (reset! seen-workdir workdir)
@@ -189,14 +191,14 @@
 
 (deftest ^{:stratum 1} run-cli-command-captures-short-lived-process-output-test
   (testing "probe helper captures stdout, stderr, and exit code for short-lived commands"
-    (let [result (#'sut/run-cli-command [(shell-path) "-lc" "printf ok; printf warn >&2"] 5000)]
+    (let [result (#'process/run-cli-command [(shell-path) "-lc" "printf ok; printf warn >&2"] 5000)]
       (is (= "ok" (:out result)))
       (is (= "warn" (:err result)))
       (is (= 0 (:exit result))))))
 
 (deftest ^{:stratum 1} run-cli-command-times-out-fast-test
   (testing "probe helper returns a timeout result instead of hanging the caller"
-    (let [result (#'sut/run-cli-command [(shell-path) "-lc" "sleep 1"] 10)]
+    (let [result (#'process/run-cli-command [(shell-path) "-lc" "sleep 1"] 10)]
       (is (= -1 (:exit result)))
       (is (= 10 (:timeout-ms result)))
       (is (str/includes? (:err result) "10")))))


### PR DESCRIPTION
## Summary

Slice 2 of the workflow_runner.clj SL003 split (stacked on #1662; see that PR for the full plan).

1. `workflow-runner.process` — subprocess primitives for backend CLI probes: env scrubbing, stream capture, bounded-timeout `run-cli-command`.
2. `workflow-runner.provenance` — startup provenance banners (runtime source/worktree/git state, backend path/version).

Pure moves, no logic changes. `preflight_test` redef/require targets updated.

## Testing

1. `clj-kondo` clean; both new files pass stratum-lint SL003.
2. kanban/preflight/manifest-wiring test namespaces: only the pre-existing codex preflight failure (present on main), 0 new failures.
3. Full pre-commit suite passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)