### PR TITLE
fix(policy-pack): resolve pack signatures against configured trust roots (N4 §8.2.1)

### DIFF
--- a/components/policy-pack/deps.edn
+++ b/components/policy-pack/deps.edn
@@ -5,6 +5,7 @@
         ai.miniforge/algorithms {:local/root "../algorithms"}
         ai.miniforge/config {:local/root "../config"}
         ai.miniforge/knowledge {:local/root "../knowledge"}
+        ai.miniforge/messages {:local/root "../messages"}
         ai.miniforge/response {:local/root "../response"}
         ai.miniforge/schema {:local/root "../schema"}
         metosin/malli {:mvn/version "0.16.4"}}

--- a/components/policy-pack/resources/config/policy-pack/messages/system.edn
+++ b/components/policy-pack/resources/config/policy-pack/messages/system.edn
@@ -17,10 +17,13 @@
   "Trusted public key is not a 32-byte raw Ed25519 key"
 
   :crypto/undecodable-signature
-  "Pack signature is not valid base64"
+  "Pack signature is not a readable base64 string"
 
   :crypto/invalid-signature
   "Pack signature does not verify against the trusted public key"
+
+  :crypto/verification-error
+  "Ed25519 verification failed without an error message"
 
   :trust-roots/invalid-public-key
   "must be base64 of a raw {bytes}-byte Ed25519 public key"

--- a/components/policy-pack/resources/config/policy-pack/messages/system.edn
+++ b/components/policy-pack/resources/config/policy-pack/messages/system.edn
@@ -1,0 +1,29 @@
+{:policy-pack/system
+ {;; Signature verification outcomes (N4 §8.2) and trust-root config
+  ;; diagnostics (§8.2.1). Operator-facing: they explain why a pack was
+  ;; refused or why a trust root would not load, and they reach logs and
+  ;; evidence rather than a product surface, so they live in the system
+  ;; locale.
+  :verify/unsigned
+  "Pack is not signed"
+
+  :verify/missing-key-id
+  "Pack carries a signature but no :pack/signed-by key identifier"
+
+  :verify/untrusted-key-id
+  "Pack signer is not in the configured trust roots"
+
+  :crypto/bad-public-key-length
+  "Trusted public key is not a 32-byte raw Ed25519 key"
+
+  :crypto/undecodable-signature
+  "Pack signature is not valid base64"
+
+  :trust-roots/invalid-public-key
+  "must be base64 of a raw {bytes}-byte Ed25519 public key"
+
+  :trust-roots/invalid-entry
+  "Invalid policy pack trust root: {key-id}"
+
+  :trust-roots/invalid-config
+  "Invalid policy pack trust-root config: {source}"}}

--- a/components/policy-pack/resources/config/policy-pack/messages/system.edn
+++ b/components/policy-pack/resources/config/policy-pack/messages/system.edn
@@ -19,6 +19,9 @@
   :crypto/undecodable-signature
   "Pack signature is not valid base64"
 
+  :crypto/invalid-signature
+  "Pack signature does not verify against the trusted public key"
+
   :trust-roots/invalid-public-key
   "must be base64 of a raw {bytes}-byte Ed25519 public key"
 

--- a/components/policy-pack/resources/config/policy-pack/trust-roots.edn
+++ b/components/policy-pack/resources/config/policy-pack/trust-roots.edn
@@ -1,0 +1,32 @@
+;; Trusted publisher keys for policy pack signature verification (N4 §8.2.1).
+;;
+;; Verification resolves a pack's :pack/signed-by identifier against this
+;; store. A pack never supplies its own key: one that did would be
+;; self-certifying, since an attacker could re-sign a modified pack and
+;; nominate their own key to verify it.
+;;
+;; This file ships EMPTY on purpose. Verification is fail-closed, so with no
+;; entries no signed pack verifies. Publisher keys are a deployment concern
+;; and are configured out-of-band, in ~/.miniforge/config.edn:
+;;
+;;   {:policy-pack
+;;    {:trust-roots
+;;     {:trust-roots/publishers
+;;      [{:trust-root/key-id     "acme-publisher-2026"
+;;        :trust-root/public-key "kK1r...=="}]}}}
+;;
+;; Operator entries layer on top of this file; a shared :trust-root/key-id
+;; takes the operator's entry.
+;;
+;; :trust-root/key-id     — the identifier a pack names in :pack/signed-by.
+;;                          Opaque; a fingerprint works as well as a name.
+;; :trust-root/public-key — base64 of the RAW 32-byte Ed25519 public key
+;;                          (RFC 8032 §5.1.5), not a PEM or DER wrapper.
+;;                          From a PEM public key, the raw key is the final
+;;                          32 bytes of the DER SubjectPublicKeyInfo:
+;;                            openssl pkey -pubin -in pub.pem -outform DER \
+;;                              | tail -c 32 | base64
+;;
+;; Adding a key here means every pack it signs is trusted to run. Record who
+;; holds it and why it was added.
+{:trust-roots/publishers []}

--- a/components/policy-pack/src/ai/miniforge/policy_pack/canonical_edn.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/canonical_edn.clj
@@ -1,0 +1,97 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.canonical-edn
+  "Canonical pack serialization (N4 §8.1.1) — the exact bytes a signature is
+   computed over and the pack content hash of §5.5 digests.
+
+   Layer 0: Rendering constants
+   Layer 1: Canonical rendering
+   Layer 2: Pack signable bytes"
+  (:require
+   [ai.miniforge.policy-pack.canonical-order :as order]
+   [clojure.string :as str])
+  (:import
+   [java.time Instant ZoneOffset]
+   [java.time.format DateTimeFormatter]
+   [java.util Date]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private iso-millis
+  ;; Fixed pattern, not Instant/toString, which varies precision with value.
+  (.withZone (DateTimeFormatter/ofPattern "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+             ZoneOffset/UTC))
+
+(def ^{:stratum 0} ^:private unrenderable-prefix
+  "Print prefix of a value with no EDN reader form."
+  "#object[")
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} canonical-edn
+  "Render a value as canonical EDN per N4 §8.1.1: maps key-ordered at every
+   depth, sets as sorted vectors, sequences in declared order, instants as
+   millisecond-precision UTC, single spaces between entries.
+
+   Throws on a value with no EDN reader form — a live `:rule/check-fn`
+   rather than the symbol §8.1.1 requires. Its print form carries an
+   identity hash, so the bytes would differ on every run."
+  ^String [v]
+  (let [cmp (partial order/canonical-compare canonical-edn)]
+    (cond
+      (map? v)
+      (str "{"
+           (str/join " "
+                     (map (fn [[k value]]
+                            (str (canonical-edn k) " " (canonical-edn value)))
+                          (sort-by key cmp v)))
+           "}")
+
+      (set? v)
+      (str "[" (str/join " " (map canonical-edn (sort cmp v))) "]")
+
+      (vector? v)
+      (str "[" (str/join " " (map canonical-edn v)) "]")
+
+      (sequential? v)
+      (str "(" (str/join " " (map canonical-edn v)) ")")
+
+      (instance? Instant v)
+      (str "#inst \"" (.format iso-millis ^Instant v) "\"")
+
+      (instance? Date v)
+      (str "#inst \"" (.format iso-millis (.toInstant ^Date v)) "\"")
+
+      :else
+      (let [printed (pr-str v)]
+        (if (str/starts-with? printed unrenderable-prefix)
+          (throw (ex-info "Pack value has no EDN reader form and cannot be signed"
+                          {:policy-pack/value-type (some-> v class .getName)}))
+          printed)))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} pack-signable-bytes
+  "Signable bytes of a pack manifest (N4 §8.1.1): signature fields stripped,
+   remainder rendered as canonical EDN in UTF-8. Ed25519 signs these
+   directly; the §5.5 pack content hash digests the same bytes."
+  [pack]
+  (-> pack
+      (dissoc :pack/signature :pack/signed-by :pack/signed-at)
+      canonical-edn
+      (.getBytes "UTF-8")))

--- a/components/policy-pack/src/ai/miniforge/policy_pack/canonical_order.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/canonical_order.clj
@@ -1,0 +1,91 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.canonical-order
+  "Value ordering for canonical pack serialization (N4 §8.1.1).
+
+   Ordering is separate from rendering, and `canonical-compare` takes its
+   renderer as an argument, so the two do not depend on each other.
+
+   Layer 0: Byte and type comparison
+   Layer 1: Identifier comparison
+   Layer 2: The canonical comparator")
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} compare-utf8
+  ;; Not String/compareTo, which compares UTF-16 code units and orders
+  ;; supplementary characters differently from their UTF-8 bytes.
+  [^String a ^String b]
+  (let [xs (.getBytes a "UTF-8")
+        ys (.getBytes b "UTF-8")
+        n  (min (alength xs) (alength ys))]
+    (loop [i 0]
+      (if (= i n)
+        (compare (alength xs) (alength ys))
+        (let [d (compare (Byte/toUnsignedInt (aget xs i))
+                         (Byte/toUnsignedInt (aget ys i)))]
+          (if (zero? d) (recur (inc i)) d))))))
+
+(defn ^{:stratum 0} ^:private type-rank
+  ;; §8.1.1 pins the ordering of keys; ranking by type gives a set of
+  ;; anything else a total order too.
+  [v]
+  (cond
+    (nil? v)     0
+    (boolean? v) 1
+    (number? v)  2
+    (char? v)    3
+    (string? v)  4
+    (keyword? v) 5
+    (symbol? v)  6
+    :else        7))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} ^:private compare-identifiers
+  ;; Namespace then name, an absent namespace sorting before any present one.
+  [a b]
+  (let [ns-a (namespace a)
+        ns-b (namespace b)]
+    (if (not= (some? ns-a) (some? ns-b))
+      (if ns-a 1 -1)
+      (let [ns-order (compare-utf8 (or ns-a "") (or ns-b ""))]
+        (if (zero? ns-order)
+          (compare-utf8 (name a) (name b))
+          ns-order)))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} canonical-compare
+  "Order two values for canonical rendering (N4 §8.1.1). `render` breaks the
+   ties the spec leaves equal — collections and other tagged values — and is
+   an argument so that ordering does not depend on rendering."
+  [render a b]
+  (let [rank (compare (type-rank a) (type-rank b))
+        primary
+        (if-not (zero? rank)
+          rank
+          (cond
+            (or (keyword? a) (symbol? a))           (compare-identifiers a b)
+            (string? a)                             (compare-utf8 a b)
+            (nil? a)                                0
+            (or (number? a) (boolean? a) (char? a)) (compare a b)
+            :else                                   (compare-utf8 (render a) (render b))))]
+    (if (and (zero? primary) (not= a b))
+      (compare-utf8 (render a) (render b))
+      primary)))

--- a/components/policy-pack/src/ai/miniforge/policy_pack/crypto.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/crypto.clj
@@ -73,7 +73,9 @@
 
    Returns:
    - {:verified? true} on success
-   - {:verified? false :reason string} on failure or missing Java 15+ support"
+   - {:verified? false :reason string} on every failure, a signature that
+     simply does not verify included, so a caller always has something to
+     log"
   [content-bytes sig-bytes ^bytes pub-key-bytes]
   (try
     (if (or (nil? pub-key-bytes)
@@ -94,6 +96,8 @@
             verifier   (doto (java.security.Signature/getInstance "Ed25519")
                          (.initVerify public-key)
                          (.update ^bytes content-bytes))]
-        {:verified? (.verify verifier sig-bytes)}))
+        (if (.verify verifier sig-bytes)
+          {:verified? true}
+          {:verified? false :reason (t :crypto/invalid-signature)})))
     (catch Exception e
       {:verified? false :reason (.getMessage e)})))

--- a/components/policy-pack/src/ai/miniforge/policy_pack/crypto.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/crypto.clj
@@ -100,4 +100,6 @@
           {:verified? true}
           {:verified? false :reason (t :crypto/invalid-signature)})))
     (catch Exception e
-      {:verified? false :reason (.getMessage e)})))
+      ;; .getMessage is nil for some exceptions (a bare NPE among them), and
+      ;; a nil reason is the one thing this fn promises never to return.
+      {:verified? false :reason (or (.getMessage e) (t :crypto/verification-error))})))

--- a/components/policy-pack/src/ai/miniforge/policy_pack/crypto.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/crypto.clj
@@ -16,56 +16,84 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns ai.miniforge.policy-pack.crypto
-  "Cryptographic signature verification for policy packs.
+  "Ed25519 signature verification for policy packs. The bytes it verifies
+   come from `policy-pack.canonical-edn` (N4 §8.1.1).
 
    Uses reflection for all Ed25519 class references to avoid direct
    imports of Java 15+ classes (EdECPublicKeySpec, NamedParameterSpec)
    that are not available in GraalVM/Babashka native-image.
 
-   Layer 0: Ed25519 signature verification
-   Layer 1: Pack content hashing
-
-   Note: If byte-level parsing expands beyond signature verification,
-   consider adopting gloss for structured binary codec work.")
+   Layer 0: Key-encoding constants
+   Layer 1: Raw public-key decoding
+   Layer 2: Signature verification"
+  (:require
+   [ai.miniforge.messages.interface :as messages]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
+(def ^{:stratum 0} ^:private t
+  (messages/create-translator "config/policy-pack/messages/system.edn"
+                              :policy-pack/system))
+
+(def ^{:stratum 0} ed25519-public-key-bytes
+  "Length of a raw Ed25519 public key, per RFC 8032 §5.1.5."
+  32)
+
+(def ^{:stratum 0} ^:private x-odd-bit
+  "Bit carrying the sign of x in the final byte of a raw Ed25519 key."
+  0x80)
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} raw-ed25519-point
+  "Decode a raw 32-byte Ed25519 public key into `[x-odd? y]`.
+
+   RFC 8032 §5.1.2 stores y LITTLE-endian with the sign of x in the top bit
+   of the final byte. Reading the bytes as one big-endian magnitude rejects
+   every standards-generated key; taking x as always-even rejects half."
+  [^bytes pub-key-bytes]
+  (let [little-endian (aclone pub-key-bytes)
+        last-index    (dec ed25519-public-key-bytes)
+        top-byte      (Byte/toUnsignedInt (aget little-endian last-index))
+        x-odd?        (pos? (bit-and top-byte x-odd-bit))]
+    (aset-byte little-endian last-index
+               (unchecked-byte (bit-and top-byte (bit-not x-odd-bit))))
+    [x-odd? (java.math.BigInteger. 1 (byte-array (reverse (seq little-endian))))]))
+
+;------------------------------------------------------------------------------ Layer 2
+
 ;; Ed25519 verification via reflection
-(defn ^{:stratum 0} verify-ed25519
+(defn ^{:stratum 2} verify-ed25519
   "Verify an Ed25519 signature against content bytes.
 
    Arguments:
    - content-bytes — byte array of the signable content
    - sig-bytes     — byte array of the signature
-   - pub-key-bytes — byte array of the public key
+   - pub-key-bytes — raw 32-byte Ed25519 public key, per RFC 8032 §5.1.5
 
    Returns:
    - {:verified? true} on success
    - {:verified? false :reason string} on failure or missing Java 15+ support"
-  [content-bytes sig-bytes pub-key-bytes]
+  [content-bytes sig-bytes ^bytes pub-key-bytes]
   (try
-    (let [named-spec (Class/forName "java.security.spec.NamedParameterSpec")
-          edec-point (Class/forName "java.security.spec.EdECPoint")
-          edec-spec  (Class/forName "java.security.spec.EdECPublicKeySpec")
-          param      (.getConstructor named-spec (into-array Class [String]))
-          ed-param   (.newInstance param (into-array Object ["Ed25519"]))
-          point-ctor (.getConstructor edec-point (into-array Class [Boolean/TYPE java.math.BigInteger]))
-          point      (.newInstance point-ctor (into-array Object [false (java.math.BigInteger. 1 ^bytes pub-key-bytes)]))
-          spec-ctor  (.getConstructor edec-spec (into-array Class [named-spec edec-point]))
-          key-spec   (.newInstance spec-ctor (into-array Object [ed-param point]))
-          kf         (java.security.KeyFactory/getInstance "EdDSA")
-          public-key (.generatePublic kf key-spec)
-          verifier   (doto (java.security.Signature/getInstance "Ed25519")
-                       (.initVerify public-key)
-                       (.update ^bytes content-bytes))]
-      {:verified? (.verify verifier sig-bytes)})
+    (if (or (nil? pub-key-bytes)
+            (not= ed25519-public-key-bytes (alength pub-key-bytes)))
+      {:verified? false :reason (t :crypto/bad-public-key-length)}
+      (let [named-spec (Class/forName "java.security.spec.NamedParameterSpec")
+            edec-point (Class/forName "java.security.spec.EdECPoint")
+            edec-spec  (Class/forName "java.security.spec.EdECPublicKeySpec")
+            param      (.getConstructor named-spec (into-array Class [String]))
+            ed-param   (.newInstance param (into-array Object ["Ed25519"]))
+            point-ctor (.getConstructor edec-point (into-array Class [Boolean/TYPE java.math.BigInteger]))
+            [x-odd? y] (raw-ed25519-point pub-key-bytes)
+            point      (.newInstance point-ctor (into-array Object [x-odd? y]))
+            spec-ctor  (.getConstructor edec-spec (into-array Class [named-spec edec-point]))
+            key-spec   (.newInstance spec-ctor (into-array Object [ed-param point]))
+            kf         (java.security.KeyFactory/getInstance "EdDSA")
+            public-key (.generatePublic kf key-spec)
+            verifier   (doto (java.security.Signature/getInstance "Ed25519")
+                         (.initVerify public-key)
+                         (.update ^bytes content-bytes))]
+        {:verified? (.verify verifier sig-bytes)}))
     (catch Exception e
       {:verified? false :reason (.getMessage e)})))
-
-;; Pack content hashing
-(defn ^{:stratum 0} pack-signable-bytes
-  "Compute the signable byte representation of a pack manifest.
-   Strips signature fields and serializes the remainder as sorted EDN."
-  [pack]
-  (let [signable (dissoc pack :pack/signature :pack/signed-by :pack/signed-at)]
-    (.getBytes (pr-str (into (sorted-map) signable)) "UTF-8")))

--- a/components/policy-pack/src/ai/miniforge/policy_pack/registry.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/registry.clj
@@ -98,9 +98,11 @@
 
   (verify-signature [this pack]
     "Verify pack signature against the configured trust roots (N4 §8.2).
-     Returns {:verified? bool :signer string :timestamp inst}, where
-     :signer is the identifier the pack CLAIMS — it is verified only when
-     :verified? is true.")
+     Returns {:verified? bool :reason string}, plus :signer and :timestamp
+     when the pack carries a signature — an unsigned pack has neither, and
+     reporting a signer for one would imply something signed it. :signer is
+     the identifier the pack CLAIMS; it is verified only when :verified? is
+     true.")
 
   ;; Composition
   (resolve-pack [this pack-id]

--- a/components/policy-pack/src/ai/miniforge/policy_pack/registry.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/registry.clj
@@ -30,12 +30,20 @@
    (Wave 2), not a labeling problem."
   (:require
    [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.messages.interface :as messages]
+   [ai.miniforge.policy-pack.canonical-edn :as canonical-edn]
    [ai.miniforge.policy-pack.crypto :as crypto]
    [ai.miniforge.policy-pack.schema :as schema]
+   [ai.miniforge.policy-pack.trust-roots :as trust-roots]
+   [ai.miniforge.policy-pack.trust-roots-config :as trust-roots-config]
    [ai.miniforge.response.interface :as response]
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private t
+  (messages/create-translator "config/policy-pack/messages/system.edn"
+                              :policy-pack/system))
 
 ;; Protocol definition
 (defprotocol ^{:stratum 0} PolicyPackRegistry
@@ -89,8 +97,10 @@
      Returns {:valid? bool :errors [...]}.")
 
   (verify-signature [this pack]
-    "Verify pack signature (paid feature).
-     Returns {:verified? bool :signer string :timestamp inst}.")
+    "Verify pack signature against the configured trust roots (N4 §8.2).
+     Returns {:verified? bool :signer string :timestamp inst}, where
+     :signer is the identifier the pack CLAIMS — it is verified only when
+     :verified? is true.")
 
   ;; Composition
   (resolve-pack [this pack-id]
@@ -134,6 +144,17 @@
       (boolean (re-matches (re-pattern regex-pattern) path))
       (catch Exception _
         false))))
+
+(defn ^{:stratum 0} decode-signature
+  "Base64 pack signature to bytes; nil when the field is not a string or not
+   base64. A pack reaching verification has not necessarily been through
+   schema validation, so the type check belongs here."
+  [sig-str]
+  (when (string? sig-str)
+    (try
+      (.decode (java.util.Base64/getDecoder) ^String sig-str)
+      (catch IllegalArgumentException _
+        nil))))
 
 (defn ^{:stratum 0} dedupe-by-id
   "Remove duplicate rules, keeping the last occurrence (later pack wins)."
@@ -196,8 +217,9 @@
 
 ;------------------------------------------------------------------------------ Layer 3
 
-;; In-memory registry implementation
-(defrecord ^{:stratum 3} InMemoryPackRegistry [state]
+;; In-memory registry implementation. `trust-roots` (N4 §8.2.1) sits outside
+;; `state` because it is fixed configuration, not state a caller mutates.
+(defrecord ^{:stratum 3} InMemoryPackRegistry [state trust-roots]
   PolicyPackRegistry
 
   (register-pack [_this pack]
@@ -295,18 +317,29 @@
     (schema/validate-pack pack))
 
   (verify-signature [_this pack]
-    (if-let [sig-str (:pack/signature pack)]
-      (let [decoder       (java.util.Base64/getDecoder)
-            content-bytes (crypto/pack-signable-bytes pack)
-            sig-bytes     (.decode decoder ^String sig-str)
-            pub-key-str   (:pack/signed-by pack)
-            pub-bytes     (when pub-key-str (.decode decoder ^String pub-key-str))
-            result        (crypto/verify-ed25519 content-bytes sig-bytes pub-bytes)]
-        (assoc result
-               :signer    pub-key-str
-               :timestamp (:pack/signed-at pack)))
-      {:verified? false
-       :reason "Pack is not signed"}))
+    ;; N4 §8.2: the key comes from the trust roots, resolved by the
+    ;; identifier the pack names — never from the pack itself.
+    (let [key-id  (:pack/signed-by pack)
+          sig-str (:pack/signature pack)
+          claimed {:signer key-id :timestamp (:pack/signed-at pack)}]
+      (cond
+        (nil? sig-str)
+        {:verified? false :reason (t :verify/unsigned)}
+
+        (not (and (string? key-id) (seq key-id)))
+        (assoc claimed :verified? false :reason (t :verify/missing-key-id))
+
+        :else
+        (if-let [pub-bytes (trust-roots/resolve-key trust-roots key-id)]
+          (if-let [sig-bytes (decode-signature sig-str)]
+            (merge claimed
+                   (crypto/verify-ed25519 (canonical-edn/pack-signable-bytes pack)
+                                          sig-bytes
+                                          pub-bytes))
+            (assoc claimed :verified? false
+                   :reason (t :crypto/undecodable-signature)))
+          (assoc claimed :verified? false
+                 :reason (t :verify/untrusted-key-id))))))
 
   (resolve-pack [this pack-id]
     (when-let [pack (get-pack this pack-id)]
@@ -341,15 +374,21 @@
   "Create an in-memory policy pack registry.
 
    Options:
-   - :logger - Logger instance for structured logging
+   - :logger      - Logger instance for structured logging
+   - :trust-roots - Trusted-publisher store for signature verification
+                    (see policy-pack.trust-roots). Defaults to the
+                    configured store, which ships empty — with nothing
+                    configured, no signed pack verifies.
 
    Example:
      (create-registry)
      (create-registry {:logger my-logger})"
   ([]
    (create-registry {}))
-  ([_opts]
-   (->InMemoryPackRegistry (atom {:packs {}}))))
+  ([opts]
+   (->InMemoryPackRegistry (atom {:packs {}})
+                           (or (:trust-roots opts)
+                               (trust-roots-config/load-trust-roots)))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/policy-pack/src/ai/miniforge/policy_pack/schema.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/schema.clj
@@ -128,7 +128,11 @@
    [:pack/homepage {:optional true} string?]
    [:pack/repository {:optional true} string?]
 
-   ;; Signing (paid feature)
+   ;; Signing (N4 §8.1). :pack/signature is base64 Ed25519 over the pack's
+   ;; canonical serialization (§8.1.1). :pack/signed-by is a key IDENTIFIER
+   ;; — a key id or fingerprint the verifier resolves through its configured
+   ;; trust roots (§8.2.1) — never the public key itself, which would let a
+   ;; pack nominate the key that verifies it.
    [:pack/signature {:optional true} string?]
    [:pack/signed-by {:optional true} string?]
    [:pack/signed-at {:optional true} inst?]

--- a/components/policy-pack/src/ai/miniforge/policy_pack/trust_roots.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/trust_roots.clj
@@ -1,0 +1,120 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.trust-roots
+  "The trusted-publisher store for pack signature verification (N4 §8.2.1),
+   as a value. `policy-pack.trust-roots-config` loads one from configuration.
+
+   A pack names a key identifier in :pack/signed-by; the key material is
+   resolved here, never taken from the pack itself.
+
+   Layer 0: Schema and key decoding
+   Layer 1: Entry validation and lookup
+   Layer 2: Store construction"
+  (:require
+   [ai.miniforge.messages.interface :as messages]
+   [ai.miniforge.policy-pack.crypto :as crypto]
+   [ai.miniforge.policy-pack.schema-validation :as schema-validation]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private t
+  (messages/create-translator "config/policy-pack/messages/system.edn"
+                              :policy-pack/system))
+
+(def ^{:stratum 0} TrustRoot
+  "One trusted publisher key. No algorithm field: N4 §8.1 fixes Ed25519 for
+   the pack format, so a per-key algorithm would contradict it."
+  [:map
+   [:trust-root/key-id
+    {:description "Identifier a pack names in :pack/signed-by."}
+    [:string {:min 1}]]
+   [:trust-root/public-key
+    {:description "Base64 of the raw 32-byte Ed25519 public key."}
+    [:string {:min 1}]]])
+
+(defn ^{:stratum 0} decode-public-key
+  "Base64 raw Ed25519 public key to bytes; nil if not base64 or not 32 bytes."
+  [^String base64-key]
+  (try
+    (let [decoded (.decode (java.util.Base64/getDecoder) base64-key)]
+      (when (= crypto/ed25519-public-key-bytes (alength decoded))
+        decoded))
+    (catch IllegalArgumentException _
+      nil)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} validate-entry
+  "Check one entry's shape and key material. {:valid? bool :errors map-or-nil}."
+  [entry]
+  (let [{:keys [valid? errors]} (schema-validation/validate TrustRoot entry)]
+    (cond
+      (not valid?)
+      {:valid? false :errors errors}
+
+      (nil? (decode-public-key (:trust-root/public-key entry)))
+      {:valid? false
+       :errors {:trust-root/public-key
+                [(t :trust-roots/invalid-public-key
+                    {:bytes crypto/ed25519-public-key-bytes})]}}
+
+      :else
+      {:valid? true :errors nil})))
+
+(defn ^{:stratum 1} resolve-key
+  "Resolve a :pack/signed-by identifier to its trusted public key bytes.
+
+   Nil — the fail-closed answer — covers a pack with no identifier, an
+   unknown publisher, and the empty default store alike."
+  [store key-id]
+  (when (and (string? key-id) (seq key-id))
+    (some-> (get store key-id)
+            :trust-root/public-key
+            decode-public-key)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} ->store
+  "Build a key-identifier→entry store from publisher collections, later
+   collections winning a shared identifier.
+
+   Throws on a malformed entry rather than dropping it: a trust root that
+   silently disappears reads at the gate as an untrusted publisher, sending
+   the operator hunting through packs for a fault in their config."
+  [& publisher-colls]
+  (reduce (fn [store entry]
+            (let [{:keys [valid? errors]} (validate-entry entry)
+                  key-id (:trust-root/key-id entry)]
+              (when-not valid?
+                (throw (ex-info (t :trust-roots/invalid-entry {:key-id key-id})
+                                {:policy-pack/trust-root-errors errors
+                                 :policy-pack/key-id key-id})))
+              (assoc store key-id entry)))
+          {}
+          (apply concat publisher-colls)))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (def store (->store [{:trust-root/key-id "acme-publisher-2026"
+                        :trust-root/public-key "5Q1r...=="}]))
+
+  (resolve-key store "acme-publisher-2026")
+  (resolve-key store "unknown-publisher")
+  ;; => nil
+
+  :leave-this-here)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/trust_roots.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/trust_roots.clj
@@ -48,14 +48,18 @@
     [:string {:min 1}]]])
 
 (defn ^{:stratum 0} decode-public-key
-  "Base64 raw Ed25519 public key to bytes; nil if not base64 or not 32 bytes."
-  [^String base64-key]
-  (try
-    (let [decoded (.decode (java.util.Base64/getDecoder) base64-key)]
-      (when (= crypto/ed25519-public-key-bytes (alength decoded))
-        decoded))
-    (catch IllegalArgumentException _
-      nil)))
+  "Base64 raw Ed25519 public key to bytes; nil when the value is not a
+   string, not base64, or not 32 bytes. `resolve-key` reaches this with
+   whatever a caller-supplied store holds, so the type check is here rather
+   than left to the schema."
+  [base64-key]
+  (when (string? base64-key)
+    (try
+      (let [decoded (.decode (java.util.Base64/getDecoder) ^String base64-key)]
+        (when (= crypto/ed25519-public-key-bytes (alength decoded))
+          decoded))
+      (catch IllegalArgumentException _
+        nil))))
 
 ;------------------------------------------------------------------------------ Layer 1
 

--- a/components/policy-pack/src/ai/miniforge/policy_pack/trust_roots_config.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/trust_roots_config.clj
@@ -1,0 +1,87 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.trust-roots-config
+  "Loads the trusted-publisher store (N4 §8.2.1) from configuration.
+
+   Two sources, merged by identifier with the operator's entry winning:
+   the shipped classpath resource, which ships empty so a deployment that
+   configures nothing trusts nothing, and ~/.miniforge/config.edn — the
+   out-of-band, auditable store §8.2.1 asks for.
+
+   Layer 0: Config paths and schema
+   Layer 1: Loading"
+  (:require
+   [ai.miniforge.config.interface :as config]
+   [ai.miniforge.messages.interface :as messages]
+   [ai.miniforge.policy-pack.schema-validation :as schema-validation]
+   [ai.miniforge.policy-pack.trust-roots :as trust-roots]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private t
+  (messages/create-translator "config/policy-pack/messages/system.edn"
+                              :policy-pack/system))
+
+(def ^{:stratum 0} trust-roots-resource
+  "Classpath path of the shipped trust-root defaults."
+  "config/policy-pack/trust-roots.edn")
+
+(def ^{:stratum 0} user-config-path
+  "Key path into ~/.miniforge/config.edn holding operator trust roots."
+  [:policy-pack :trust-roots])
+
+(def ^{:stratum 0} TrustRootConfig
+  "The trust-root config file and the user-config block under
+   `user-config-path`. An empty publisher vector trusts nobody."
+  [:map
+   [:trust-roots/publishers [:vector trust-roots/TrustRoot]]])
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} load-trust-roots
+  "Load the configured store: shipped defaults overlaid with the operator's
+   entries. The 1-arity takes an already-loaded user config, for tests and
+   for callers whose config is not at the default path.
+
+   Throws when either source is malformed — trusting the wrong set of
+   publishers is not a condition to fail open on, and config-as-data (007)
+   puts that check at load rather than at each verification."
+  ([]
+   (load-trust-roots (config/load-user-config)))
+  ([user-config]
+   (let [shipped  (config/load-config-resource trust-roots-resource
+                                               [:trust-roots/publishers])
+         operator (get-in user-config user-config-path)]
+     (doseq [[source cfg] [[trust-roots-resource shipped]
+                           [user-config-path operator]]
+             :when (some? cfg)]
+       (let [{:keys [valid? errors]} (schema-validation/validate TrustRootConfig cfg)]
+         (when-not valid?
+           (throw (ex-info (t :trust-roots/invalid-config {:source source})
+                           {:policy-pack/config-source source
+                            :policy-pack/config-errors errors})))))
+     (trust-roots/->store (:trust-roots/publishers shipped)
+                          (:trust-roots/publishers operator)))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; The shipped store trusts nobody
+  (load-trust-roots)
+  ;; => {}
+
+  :leave-this-here)

--- a/components/policy-pack/test/ai/miniforge/policy_pack/anomaly/registry_anomaly_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/anomaly/registry_anomaly_test.clj
@@ -30,7 +30,9 @@
 ;------------------------------------------------------------------------------ Layer 0
 
 (defn- ^{:stratum 0} new-registry []
-  (registry/->InMemoryPackRegistry (atom {:packs {}})))
+  ;; Empty trust roots: none of these paths verify a signature, and an
+  ;; empty store keeps the fixture off the operator's configured one.
+  (registry/->InMemoryPackRegistry (atom {:packs {}}) {}))
 
 ;------------------------------------------------------------------------------ Layer 1
 

--- a/components/policy-pack/test/ai/miniforge/policy_pack/canonical_edn_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/canonical_edn_test.clj
@@ -1,0 +1,181 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.canonical-edn-test
+  "Tests for canonical pack serialization (N4 §8.1.1).
+
+   Canonicalization is only useful if two runs produce identical bytes, so
+   most of these build the same value two ways and compare."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.policy-pack.canonical-edn :as sut])
+  (:import
+   [java.time Instant]
+   [java.util Date]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} signable-string
+  [pack]
+  (String. ^bytes (sut/pack-signable-bytes pack) "UTF-8"))
+
+(def ^{:stratum 0} ^:private array-map-threshold
+  "Above this many entries Clojure switches a map literal from an array map,
+   which preserves insertion order, to a hash map, which does not. Nested
+   maps of this size are where unsorted serialization stops being
+   reproducible."
+  9)
+
+;; ============================================================================
+;; Map key ordering
+;; ============================================================================
+(deftest ^{:stratum 0} map-key-ordering-test
+  (testing "top-level keys order by namespace then name"
+    (is (= "{:a 1 :b 2 :zz/a 3 :zz/b 4}"
+           (sut/canonical-edn {:zz/b 4 :b 2 :zz/a 3 :a 1}))))
+
+  (testing "an absent namespace sorts before any present one"
+    (is (= "{:zebra 1 :a/aardvark 2}"
+           (sut/canonical-edn {:a/aardvark 2 :zebra 1}))))
+
+  (testing "insertion order does not reach the output"
+    (is (= (sut/canonical-edn {:a 1 :b 2 :c 3})
+           (sut/canonical-edn {:c 3 :b 2 :a 1})))))
+
+;; ============================================================================
+;; Collections
+;; ============================================================================
+(deftest ^{:stratum 0} collection-rendering-test
+  (testing "sets render as a sorted vector"
+    (is (= "[:a :b :c]" (sut/canonical-edn #{:c :a :b}))))
+
+  (testing "set iteration order does not reach the output"
+    (is (= (sut/canonical-edn (into #{} [:implement :review :plan]))
+           (sut/canonical-edn (into #{} [:plan :implement :review])))))
+
+  (testing "a set above the array-set threshold still sorts"
+    (let [ks (map #(keyword (str "k" %)) (range 32))]
+      (is (= (sut/canonical-edn (into #{} ks))
+             (sut/canonical-edn (into #{} (reverse ks)))))))
+
+  (testing "vectors keep their declared order — sequence order is data"
+    (is (= "[3 1 2]" (sut/canonical-edn [3 1 2]))))
+
+  (testing "lists keep their declared order and their list form"
+    (is (= "(3 1 2)" (sut/canonical-edn '(3 1 2)))))
+
+  (testing "empty collections render empty"
+    (is (= "{}" (sut/canonical-edn {})))
+    (is (= "[]" (sut/canonical-edn [])))
+    (is (= "[]" (sut/canonical-edn #{}))))
+
+  (testing "a set of mixed types is ordered by type, not left to chance"
+    (is (= (sut/canonical-edn #{1 "a" :b 'c nil true})
+           (sut/canonical-edn #{'c true nil :b "a" 1})))))
+
+;; ============================================================================
+;; Scalars
+;; ============================================================================
+(deftest ^{:stratum 0} scalar-rendering-test
+  (testing "instants render as UTC with millisecond precision"
+    (is (= "#inst \"2026-01-23T00:00:00.000Z\""
+           (sut/canonical-edn (Instant/parse "2026-01-23T00:00:00Z"))))
+    (is (= "#inst \"2026-01-23T04:05:06.789Z\""
+           (sut/canonical-edn (Instant/parse "2026-01-23T04:05:06.789Z")))))
+
+  (testing "a Date renders identically to the Instant it denotes"
+    (let [instant (Instant/parse "2026-01-23T04:05:06.789Z")]
+      (is (= (sut/canonical-edn instant)
+             (sut/canonical-edn (Date/from instant))))))
+
+  (testing "sub-millisecond precision is truncated, not rounded up"
+    (is (= "#inst \"2026-01-23T04:05:06.789Z\""
+           (sut/canonical-edn (Instant/parse "2026-01-23T04:05:06.789999Z")))))
+
+  (testing "strings, keywords, symbols and numbers keep their EDN form"
+    (is (= "\"acl = \\\"public-read\\\"\""
+           (sut/canonical-edn "acl = \"public-read\"")))
+    (is (= ":rule/id" (sut/canonical-edn :rule/id)))
+    (is (= "some.ns/check" (sut/canonical-edn 'some.ns/check)))
+    (is (= "42" (sut/canonical-edn 42)))
+    (is (= "nil" (sut/canonical-edn nil))))
+
+  (testing "a value with no EDN reader form cannot be signed"
+    ;; A live :rule/check-fn prints with an identity hash, so signing it
+    ;; yields bytes that differ on every run.
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (sut/canonical-edn {:rule/check-fn (fn [_ _] nil)})))))
+
+;; ============================================================================
+;; Whitespace
+;; ============================================================================
+(deftest ^{:stratum 0} whitespace-test
+  (testing "one space separates key from value and entry from entry"
+    (is (= "{:a 1 :b 2}" (sut/canonical-edn {:a 1 :b 2}))))
+
+  (testing "no newlines, indentation, or trailing space"
+    (let [rendered (sut/canonical-edn {:pack/rules [{:rule/id :a}
+                                                    {:rule/id :b}]})]
+      (is (not (re-find #"[\n\r\t]" rendered)))
+      (is (not (re-find #" \}" rendered))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} recursive-map-ordering-test
+  (testing "nested maps are ordered too, not only the top level"
+    (is (= "{:pack/metadata {:a 1 :z 2}}"
+           (sut/canonical-edn {:pack/metadata {:z 2 :a 1}}))))
+
+  (testing "nesting above the array-map threshold serializes reproducibly"
+    ;; Below the threshold a map literal keeps insertion order and an
+    ;; unsorted renderer looks correct; above it, host hash order decides.
+    (let [ks       (map #(keyword (str "k" %)) (range (inc array-map-threshold)))
+          forward  (into {} (map-indexed (fn [i k] [k i]) ks))
+          backward (into {} (reverse (map-indexed (fn [i k] [k i]) ks)))]
+      (is (= (sut/canonical-edn {:pack/metadata forward})
+             (sut/canonical-edn {:pack/metadata backward})))))
+
+  (testing "maps inside vectors are ordered"
+    (is (= "{:pack/rules [{:rule/id :a :rule/severity :high}]}"
+           (sut/canonical-edn
+            {:pack/rules [{:rule/severity :high :rule/id :a}]})))))
+
+;; ============================================================================
+;; Signable bytes
+;; ============================================================================
+(deftest ^{:stratum 1} pack-signable-bytes-test
+  (let [pack {:pack/id "acme/security"
+              :pack/version "2026.08.05"
+              :pack/rules [{:rule/id :a :rule/applies-to {:phases #{:review :implement}}}]}]
+
+    (testing "signature fields are excluded from the signed payload"
+      (is (= (signable-string pack)
+             (signable-string (assoc pack
+                                     :pack/signature "sig"
+                                     :pack/signed-by "acme-2026"
+                                     :pack/signed-at (Instant/now))))))
+
+    (testing "content changes change the payload"
+      (is (not= (signable-string pack)
+                (signable-string (assoc pack :pack/version "2026.08.06")))))
+
+    (testing "the payload is UTF-8 of the canonical rendering"
+      (is (= (sut/canonical-edn pack) (signable-string pack))))
+
+    (testing "non-ASCII content encodes as UTF-8"
+      (is (= (alength (.getBytes "{:pack/author \"Ω\"}" "UTF-8"))
+             (alength (sut/pack-signable-bytes {:pack/author "Ω"})))))))

--- a/components/policy-pack/test/ai/miniforge/policy_pack/crypto_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/crypto_test.clj
@@ -1,0 +1,57 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.crypto-test
+  "Tests for Ed25519 public-key decoding and verification guards."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.policy-pack.crypto :as sut]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; ============================================================================
+;; Ed25519 key decoding
+;; ============================================================================
+(deftest ^{:stratum 0} raw-ed25519-point-test
+  (testing "the sign of x comes from the top bit of the final byte"
+    (let [even-key (byte-array (concat (repeat 31 (byte 0)) [(unchecked-byte 0x7f)]))
+          odd-key  (byte-array (concat (repeat 31 (byte 0)) [(unchecked-byte 0xff)]))]
+      (is (false? (first (sut/raw-ed25519-point even-key))))
+      (is (true? (first (sut/raw-ed25519-point odd-key))))
+
+      (testing "and that bit is cleared from y rather than left in it"
+        (is (= (second (sut/raw-ed25519-point even-key))
+               (second (sut/raw-ed25519-point odd-key)))))))
+
+  (testing "y is read little-endian"
+    ;; 0x01 in the FIRST byte is the least significant byte of y.
+    (let [key-bytes (byte-array (concat [(byte 1)] (repeat 31 (byte 0))))]
+      (is (= (biginteger 1) (second (sut/raw-ed25519-point key-bytes))))))
+
+  (testing "the caller's array is not mutated"
+    (let [key-bytes (byte-array (concat (repeat 31 (byte 0)) [(unchecked-byte 0xff)]))]
+      (sut/raw-ed25519-point key-bytes)
+      (is (= (unchecked-byte 0xff) (aget key-bytes 31))))))
+
+(deftest ^{:stratum 0} verify-ed25519-key-length-test
+  (let [content (.getBytes "payload" "UTF-8")
+        sig     (byte-array 64)]
+    (testing "a nil public key fails closed"
+      (is (not (:verified? (sut/verify-ed25519 content sig nil)))))
+
+    (testing "a public key of the wrong length fails closed"
+      (is (not (:verified? (sut/verify-ed25519 content sig (byte-array 16))))))))

--- a/components/policy-pack/test/ai/miniforge/policy_pack/crypto_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/crypto_test.clj
@@ -54,4 +54,13 @@
       (is (not (:verified? (sut/verify-ed25519 content sig nil)))))
 
     (testing "a public key of the wrong length fails closed"
-      (is (not (:verified? (sut/verify-ed25519 content sig (byte-array 16))))))))
+      (is (not (:verified? (sut/verify-ed25519 content sig (byte-array 16))))))
+
+    (testing "an exception with no message still yields a reason"
+      ;; .getMessage is nil for some exceptions, and a nil reason is the one
+      ;; thing this fn promises never to return.
+      (let [result (with-redefs [sut/raw-ed25519-point
+                                 (fn [_] (throw (NullPointerException.)))]
+                     (sut/verify-ed25519 content sig (byte-array 32)))]
+        (is (not (:verified? result)))
+        (is (string? (:reason result)))))))

--- a/components/policy-pack/test/ai/miniforge/policy_pack/registry_signature_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/registry_signature_test.clj
@@ -211,14 +211,24 @@
         (is (= "Pack carries a signature but no :pack/signed-by key identifier"
                (:reason result)))))
 
-    (testing "a well-formed but wrong signature fails"
+    (testing "a well-formed but wrong signature fails, with a reason to log"
       (let [other  (fixtures/sign-pack (assoc unsigned-pack :pack/version "2026.08.06")
                                        publisher
                                        "acme-publisher-2026")
             result (sut/verify-signature registry
                                          (assoc pack :pack/signature
                                                 (:pack/signature other)))]
-        (is (not (:verified? result)))))))
+        (is (not (:verified? result)))
+        (is (= "Pack signature does not verify against the trusted public key"
+               (:reason result)))))
+
+    (testing "every failure path carries a reason"
+      (is (every? (comp string? :reason)
+                  [(sut/verify-signature registry unsigned-pack)
+                   (sut/verify-signature registry (dissoc pack :pack/signed-by))
+                   (sut/verify-signature registry (assoc pack :pack/signature "not base64!"))
+                   (sut/verify-signature registry (assoc pack :pack/signed-by "who-is-this"))
+                   (sut/verify-signature registry (assoc pack :pack/author "mallory"))])))))
 
 (defn- ^{:stratum 1} keypair-of-each-parity
   "Draw keypairs until one of each x parity is in hand, or the limit runs out."

--- a/components/policy-pack/test/ai/miniforge/policy_pack/registry_signature_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/registry_signature_test.clj
@@ -196,14 +196,14 @@
       (let [result (sut/verify-signature registry
                                          (assoc pack :pack/signature "not base64!"))]
         (is (not (:verified? result)))
-        (is (= "Pack signature is not valid base64" (:reason result)))))
+        (is (= "Pack signature is not a readable base64 string" (:reason result)))))
 
     (testing "a signature that is not a string fails rather than throwing"
       ;; Verification runs on packs that have not necessarily been through
       ;; schema validation.
       (let [result (sut/verify-signature registry (assoc pack :pack/signature 42))]
         (is (not (:verified? result)))
-        (is (= "Pack signature is not valid base64" (:reason result)))))
+        (is (= "Pack signature is not a readable base64 string" (:reason result)))))
 
     (testing "a key identifier that is not a string fails"
       (let [result (sut/verify-signature registry (assoc pack :pack/signed-by 42))]

--- a/components/policy-pack/test/ai/miniforge/policy_pack/registry_signature_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/registry_signature_test.clj
@@ -172,10 +172,19 @@
         registry  (registry-trusting "acme-publisher-2026" publisher)
         pack      (fixtures/sign-pack unsigned-pack publisher "acme-publisher-2026")]
 
-    (testing "an unsigned pack is reported as unsigned"
+    (testing "an unsigned pack is reported as unsigned, with no claimed signer"
       (let [result (sut/verify-signature registry unsigned-pack)]
         (is (not (:verified? result)))
-        (is (= "Pack is not signed" (:reason result)))))
+        (is (= "Pack is not signed" (:reason result)))
+        (is (not (contains? result :signer)))
+        (is (not (contains? result :timestamp)))))
+
+    (testing "a signed pack reports its claimed signer and timestamp"
+      (let [result (sut/verify-signature
+                    registry
+                    (assoc pack :pack/signed-at #inst "2026-08-05T00:00:00.000Z"))]
+        (is (= "acme-publisher-2026" (:signer result)))
+        (is (= #inst "2026-08-05T00:00:00.000Z" (:timestamp result)))))
 
     (testing "a signature with no key identifier fails"
       (let [result (sut/verify-signature registry (dissoc pack :pack/signed-by))]

--- a/components/policy-pack/test/ai/miniforge/policy_pack/registry_signature_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/registry_signature_test.clj
@@ -1,0 +1,239 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.registry-signature-test
+  "Tests for pack signature verification against configured trust roots
+   (N4 §8.2).
+
+   The case that motivates the whole store is `self-certifying-pack-test`:
+   a pack that carries its own verification key must fail, however
+   internally consistent its signature is."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.policy-pack.registry :as sut]
+   [ai.miniforge.policy-pack.signing-fixtures :as fixtures]
+   [ai.miniforge.policy-pack.trust-roots :as trust-roots]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private unsigned-pack
+  {:pack/id "acme/security"
+   :pack/name "Acme Security"
+   :pack/version "2026.08.05"
+   :pack/description "A pack under signature test"
+   :pack/author "acme"
+   :pack/categories [{:category/id "300"
+                      :category/name "Infrastructure"
+                      :category/rules [:no-public-buckets]}]
+   :pack/rules [{:rule/id :no-public-buckets
+                 :rule/title "No public buckets"
+                 :rule/description "Buckets must not be world-readable"
+                 :rule/severity :critical
+                 :rule/category "300"
+                 :rule/applies-to {:phases #{:implement :review}}
+                 :rule/detection {:type :content-scan :pattern "acl = \"public-read\""}
+                 :rule/enforcement {:action :hard-halt :message "Public bucket"}}]
+   :pack/created-at #inst "2026-08-01T00:00:00.000Z"
+   :pack/updated-at #inst "2026-08-04T00:00:00.000Z"})
+
+(defn- ^{:stratum 0} registry-trusting
+  "A registry whose trust roots hold exactly the given identifier→keypair
+   pairs."
+  [& id+keypairs]
+  (sut/create-registry
+   {:trust-roots (trust-roots/->store
+                  (mapv (fn [[key-id keypair]]
+                          {:trust-root/key-id key-id
+                           :trust-root/public-key (:public-key-base64 keypair)})
+                        (partition 2 id+keypairs)))}))
+
+;; ============================================================================
+;; Key encoding
+;; ============================================================================
+(def ^{:stratum 0} ^:private parity-draw-limit
+  "Keypairs to draw looking for one of each x parity. Each draw is an
+   independent coin flip, so missing a parity in this many is ~1e-19."
+  64)
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; ============================================================================
+;; The trusted path
+;; ============================================================================
+(deftest ^{:stratum 1} trusted-signature-verifies-test
+  (let [publisher (fixtures/generate-keypair)
+        registry  (registry-trusting "acme-publisher-2026" publisher)
+        pack      (fixtures/sign-pack unsigned-pack publisher "acme-publisher-2026")
+        result    (sut/verify-signature registry pack)]
+
+    (testing "a pack signed by a trusted publisher verifies"
+      (is (:verified? result)))
+
+    (testing "the result reports the resolved signer"
+      (is (= "acme-publisher-2026" (:signer result))))))
+
+(deftest ^{:stratum 1} trusted-signature-covers-content-test
+  (let [publisher (fixtures/generate-keypair)
+        registry  (registry-trusting "acme-publisher-2026" publisher)
+        pack      (fixtures/sign-pack unsigned-pack publisher "acme-publisher-2026")]
+
+    (testing "editing a rule after signing invalidates the signature"
+      (is (not (:verified?
+                (sut/verify-signature
+                 registry
+                 (assoc-in pack [:pack/rules 0 :rule/enforcement :action] :warn))))))
+
+    (testing "editing pack metadata after signing invalidates the signature"
+      (is (not (:verified?
+                (sut/verify-signature
+                 registry
+                 (assoc pack :pack/author "mallory"))))))))
+
+;; ============================================================================
+;; Untrusted paths
+;; ============================================================================
+(deftest ^{:stratum 1} unknown-key-identifier-test
+  (let [publisher (fixtures/generate-keypair)
+        registry  (registry-trusting "acme-publisher-2026" publisher)
+        pack      (fixtures/sign-pack unsigned-pack publisher "who-is-this")
+        result    (sut/verify-signature registry pack)]
+
+    (testing "a signer identifier absent from the trust roots fails"
+      (is (not (:verified? result))))
+
+    (testing "the failure names the unresolved signer, not a crypto fault"
+      (is (= "who-is-this" (:signer result)))
+      (is (= "Pack signer is not in the configured trust roots" (:reason result))))))
+
+(deftest ^{:stratum 1} untrusted-signer-test
+  (let [publisher (fixtures/generate-keypair)
+        attacker  (fixtures/generate-keypair)
+        registry  (registry-trusting "acme-publisher-2026" publisher)
+        ;; Internally consistent: the attacker re-signed the pack they
+        ;; modified, then claimed the publisher's identifier.
+        pack      (fixtures/sign-pack (assoc unsigned-pack :pack/author "mallory")
+                                      attacker
+                                      "acme-publisher-2026")]
+
+    (testing "a pack re-signed with an untrusted key fails under a trusted identifier"
+      (is (not (:verified? (sut/verify-signature registry pack)))))))
+
+(deftest ^{:stratum 1} self-certifying-pack-test
+  (let [publisher (fixtures/generate-keypair)
+        attacker  (fixtures/generate-keypair)
+        registry  (registry-trusting "acme-publisher-2026" publisher)
+        ;; The pre-§8.2.1 attack: modify the pack, sign it with your own
+        ;; key, and write that public key into :pack/signed-by. Verification
+        ;; used to decode the field as key material and pass.
+        pack      (fixtures/sign-pack (assoc unsigned-pack :pack/author "mallory")
+                                      attacker
+                                      (:public-key-base64 attacker))
+        result    (sut/verify-signature registry pack)]
+
+    (testing "a pack that supplies its own verification key fails"
+      (is (not (:verified? result))))
+
+    (testing "the field is treated as an identifier, so it resolves to nothing"
+      (is (= "Pack signer is not in the configured trust roots" (:reason result))))
+
+    (testing "the signature is genuinely self-consistent — only trust rejects it"
+      (is (:verified?
+           (sut/verify-signature (registry-trusting (:public-key-base64 attacker)
+                                                    attacker)
+                                 pack))))))
+
+(deftest ^{:stratum 1} empty-trust-roots-test
+  (let [publisher (fixtures/generate-keypair)
+        registry  (sut/create-registry {:trust-roots {}})
+        pack      (fixtures/sign-pack unsigned-pack publisher "acme-publisher-2026")]
+
+    (testing "with nothing configured, no signed pack verifies"
+      (is (not (:verified? (sut/verify-signature registry pack)))))))
+
+;; ============================================================================
+;; Malformed signature fields
+;; ============================================================================
+(deftest ^{:stratum 1} malformed-signature-fields-test
+  (let [publisher (fixtures/generate-keypair)
+        registry  (registry-trusting "acme-publisher-2026" publisher)
+        pack      (fixtures/sign-pack unsigned-pack publisher "acme-publisher-2026")]
+
+    (testing "an unsigned pack is reported as unsigned"
+      (let [result (sut/verify-signature registry unsigned-pack)]
+        (is (not (:verified? result)))
+        (is (= "Pack is not signed" (:reason result)))))
+
+    (testing "a signature with no key identifier fails"
+      (let [result (sut/verify-signature registry (dissoc pack :pack/signed-by))]
+        (is (not (:verified? result)))
+        (is (= "Pack carries a signature but no :pack/signed-by key identifier"
+               (:reason result)))))
+
+    (testing "a signature that is not base64 fails rather than throwing"
+      (let [result (sut/verify-signature registry
+                                         (assoc pack :pack/signature "not base64!"))]
+        (is (not (:verified? result)))
+        (is (= "Pack signature is not valid base64" (:reason result)))))
+
+    (testing "a signature that is not a string fails rather than throwing"
+      ;; Verification runs on packs that have not necessarily been through
+      ;; schema validation.
+      (let [result (sut/verify-signature registry (assoc pack :pack/signature 42))]
+        (is (not (:verified? result)))
+        (is (= "Pack signature is not valid base64" (:reason result)))))
+
+    (testing "a key identifier that is not a string fails"
+      (let [result (sut/verify-signature registry (assoc pack :pack/signed-by 42))]
+        (is (not (:verified? result)))
+        (is (= "Pack carries a signature but no :pack/signed-by key identifier"
+               (:reason result)))))
+
+    (testing "a well-formed but wrong signature fails"
+      (let [other  (fixtures/sign-pack (assoc unsigned-pack :pack/version "2026.08.06")
+                                       publisher
+                                       "acme-publisher-2026")
+            result (sut/verify-signature registry
+                                         (assoc pack :pack/signature
+                                                (:pack/signature other)))]
+        (is (not (:verified? result)))))))
+
+(defn- ^{:stratum 1} keypair-of-each-parity
+  "Draw keypairs until one of each x parity is in hand, or the limit runs out."
+  []
+  (reduce (fn [found _]
+            (if (= 2 (count found))
+              (reduced found)
+              (let [keypair (fixtures/generate-keypair)]
+                (update found (:x-odd? keypair) #(or % keypair)))))
+          {}
+          (range parity-draw-limit)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} both-x-parities-verify-test
+  ;; The raw encoding carries the sign of x in the top bit of the last byte.
+  ;; Taking x as always-even rejects about half of all real keys, so one
+  ;; generated keypair is not enough to cover the decoder.
+  (let [by-parity (keypair-of-each-parity)]
+    (testing "both parities occur within the draw limit"
+      (is (= #{true false} (set (keys by-parity)))))
+
+    (doseq [[x-odd? publisher] by-parity]
+      (testing (str "a key with x-odd? " x-odd? " verifies")
+        (let [registry (registry-trusting "publisher" publisher)
+              pack     (fixtures/sign-pack unsigned-pack publisher "publisher")]
+          (is (:verified? (sut/verify-signature registry pack))))))))

--- a/components/policy-pack/test/ai/miniforge/policy_pack/signing_fixtures.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/signing_fixtures.clj
@@ -1,0 +1,68 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.signing-fixtures
+  "Ed25519 key generation and pack signing for signature tests.
+
+   Real keys, real signatures: a test that stubs the crypto cannot tell a
+   verifier that resolves the right key from one that accepts whatever the
+   pack hands it. Keys are generated per run rather than checked in, so the
+   suite covers both x parities of the Ed25519 public key encoding."
+  (:require
+   [ai.miniforge.policy-pack.canonical-edn :as canonical-edn]
+   [ai.miniforge.policy-pack.crypto :as crypto])
+  (:import
+   [java.security KeyPairGenerator Signature]
+   [java.util Base64]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private x-odd-bit
+  "Bit carrying the sign of x in the final byte of a raw Ed25519 key."
+  0x80)
+
+(defn ^{:stratum 0} sign-pack
+  "Sign a pack's canonical bytes (N4 §8.1.1) with `keypair`, returning the
+   pack carrying :pack/signature and the given :pack/signed-by identifier."
+  [pack keypair key-id]
+  (let [signer (doto (Signature/getInstance "Ed25519")
+                 (.initSign (:private keypair))
+                 (.update ^bytes (canonical-edn/pack-signable-bytes pack)))]
+    (assoc pack
+           :pack/signature (.encodeToString (Base64/getEncoder) (.sign signer))
+           :pack/signed-by key-id)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} generate-keypair
+  "Generate an Ed25519 keypair.
+
+   Returns {:private PrivateKey :public-key-base64 string :x-odd? bool},
+   where the base64 holds the raw 32-byte public key a trust root carries —
+   the trailing bytes of the X.509 SubjectPublicKeyInfo encoding — and
+   :x-odd? reports the parity the raw encoding stores in its final bit."
+  []
+  (let [pair     (.generateKeyPair (KeyPairGenerator/getInstance "Ed25519"))
+        encoded  ^bytes (.getEncoded (.getPublic pair))
+        raw      (java.util.Arrays/copyOfRange encoded
+                                               (- (alength encoded)
+                                                  crypto/ed25519-public-key-bytes)
+                                               (alength encoded))
+        top-byte (aget raw (dec crypto/ed25519-public-key-bytes))]
+    {:private (.getPrivate pair)
+     :public-key-base64 (.encodeToString (Base64/getEncoder) raw)
+     :x-odd? (pos? (bit-and top-byte x-odd-bit))}))

--- a/components/policy-pack/test/ai/miniforge/policy_pack/trust_roots_config_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/trust_roots_config_test.clj
@@ -1,0 +1,63 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.trust-roots-config-test
+  "Tests for loading the trust-root store from configuration (N4 §8.2.1)."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.policy-pack.signing-fixtures :as fixtures]
+   [ai.miniforge.policy-pack.trust-roots :as trust-roots]
+   [ai.miniforge.policy-pack.trust-roots-config :as sut]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} entry
+  [key-id public-key-base64]
+  {:trust-root/key-id key-id
+   :trust-root/public-key public-key-base64})
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; ============================================================================
+;; Configured store
+;; ============================================================================
+(deftest ^{:stratum 1} load-trust-roots-test
+  (let [alice (fixtures/generate-keypair)]
+    (testing "the shipped resource trusts nobody"
+      (is (= {} (sut/load-trust-roots nil))))
+
+    (testing "operator entries layer on top of the shipped resource"
+      (let [store (sut/load-trust-roots
+                   {:policy-pack
+                    {:trust-roots
+                     {:trust-roots/publishers
+                      [(entry "alice" (:public-key-base64 alice))]}}})]
+        (is (= 32 (alength (trust-roots/resolve-key store "alice"))))))
+
+    (testing "a user config with no trust-roots block leaves the store empty"
+      (is (= {} (sut/load-trust-roots {:llm {:backend :claude}}))))
+
+    (testing "a non-map trust-roots block throws"
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (sut/load-trust-roots {:policy-pack {:trust-roots [:not :a :map]}}))))
+
+    (testing "a malformed operator entry throws"
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (sut/load-trust-roots
+                    {:policy-pack
+                     {:trust-roots
+                      {:trust-roots/publishers [(entry "alice" "not base64!")]}}}))))))

--- a/components/policy-pack/test/ai/miniforge/policy_pack/trust_roots_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/trust_roots_test.clj
@@ -41,7 +41,11 @@
       (is (nil? (sut/decode-public-key "not base64!"))))
 
     (testing "base64 of the wrong length decodes to nil"
-      (is (nil? (sut/decode-public-key "c2hvcnQ="))))))
+      (is (nil? (sut/decode-public-key "c2hvcnQ="))))
+
+    (testing "a nil or non-string key decodes to nil rather than throwing"
+      (is (nil? (sut/decode-public-key nil)))
+      (is (nil? (sut/decode-public-key 42))))))
 
 ;------------------------------------------------------------------------------ Layer 1
 
@@ -112,4 +116,10 @@
       (is (nil? (sut/resolve-key store ""))))
 
     (testing "an empty store resolves nothing — the fail-closed default"
-      (is (nil? (sut/resolve-key {} "alice"))))))
+      (is (nil? (sut/resolve-key {} "alice"))))
+
+    (testing "a hand-built store holding a non-string key resolves to nothing"
+      ;; create-registry accepts an injected store, so resolution cannot
+      ;; assume every entry came through ->store's validation.
+      (is (nil? (sut/resolve-key {"alice" {:trust-root/public-key 42}} "alice")))
+      (is (nil? (sut/resolve-key {"alice" {}} "alice"))))))

--- a/components/policy-pack/test/ai/miniforge/policy_pack/trust_roots_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/trust_roots_test.clj
@@ -1,0 +1,115 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.trust-roots-test
+  "Tests for the configured trusted-publisher store (N4 §8.2.1).
+
+   Covers entry validation, store construction and precedence, identifier
+   resolution, and the shipped-plus-operator config chain."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.policy-pack.signing-fixtures :as fixtures]
+   [ai.miniforge.policy-pack.trust-roots :as sut]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} entry
+  [key-id public-key-base64]
+  {:trust-root/key-id key-id
+   :trust-root/public-key public-key-base64})
+
+(deftest ^{:stratum 0} decode-public-key-test
+  (let [{:keys [public-key-base64]} (fixtures/generate-keypair)]
+    (testing "a raw Ed25519 key decodes to 32 bytes"
+      (is (= 32 (alength (sut/decode-public-key public-key-base64)))))
+
+    (testing "non-base64 decodes to nil rather than throwing"
+      (is (nil? (sut/decode-public-key "not base64!"))))
+
+    (testing "base64 of the wrong length decodes to nil"
+      (is (nil? (sut/decode-public-key "c2hvcnQ="))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; ============================================================================
+;; Entry validation
+;; ============================================================================
+(deftest ^{:stratum 1} validate-entry-test
+  (let [{:keys [public-key-base64]} (fixtures/generate-keypair)]
+    (testing "a well-formed entry validates"
+      (is (:valid? (sut/validate-entry (entry "acme-2026" public-key-base64)))))
+
+    (testing "an entry missing the key identifier fails"
+      (is (not (:valid? (sut/validate-entry
+                         {:trust-root/public-key public-key-base64})))))
+
+    (testing "an entry missing the public key fails"
+      (is (not (:valid? (sut/validate-entry {:trust-root/key-id "acme-2026"})))))
+
+    (testing "a blank key identifier fails"
+      (is (not (:valid? (sut/validate-entry (entry "" public-key-base64))))))
+
+    (testing "a public key that is not base64 fails"
+      (is (not (:valid? (sut/validate-entry (entry "acme-2026" "not base64!"))))))
+
+    (testing "a base64 public key of the wrong length fails"
+      (is (not (:valid? (sut/validate-entry (entry "acme-2026" "c2hvcnQ="))))))
+
+    (testing "the key-material failure names the field and the expected length"
+      (is (= {:trust-root/public-key
+              ["must be base64 of a raw 32-byte Ed25519 public key"]}
+             (:errors (sut/validate-entry (entry "acme-2026" "c2hvcnQ="))))))))
+
+;; ============================================================================
+;; Store construction and lookup
+;; ============================================================================
+(deftest ^{:stratum 1} ->store-test
+  (let [alice (fixtures/generate-keypair)
+        bob   (fixtures/generate-keypair)]
+    (testing "entries are keyed by identifier"
+      (let [store (sut/->store [(entry "alice" (:public-key-base64 alice))
+                                (entry "bob" (:public-key-base64 bob))])]
+        (is (= #{"alice" "bob"} (set (keys store))))))
+
+    (testing "a later collection wins on a shared identifier"
+      (let [store (sut/->store [(entry "alice" (:public-key-base64 alice))]
+                               [(entry "alice" (:public-key-base64 bob))])]
+        (is (= (:public-key-base64 bob)
+               (get-in store ["alice" :trust-root/public-key])))))
+
+    (testing "no publishers yields an empty store"
+      (is (= {} (sut/->store [] nil))))
+
+    (testing "a malformed entry throws rather than being dropped"
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (sut/->store [(entry "alice" "not base64!")]))))))
+
+(deftest ^{:stratum 1} resolve-key-test
+  (let [alice (fixtures/generate-keypair)
+        store (sut/->store [(entry "alice" (:public-key-base64 alice))])]
+    (testing "a configured identifier resolves to its key bytes"
+      (is (= 32 (alength (sut/resolve-key store "alice")))))
+
+    (testing "an unknown identifier resolves to nothing"
+      (is (nil? (sut/resolve-key store "mallory"))))
+
+    (testing "an absent or blank identifier resolves to nothing"
+      (is (nil? (sut/resolve-key store nil)))
+      (is (nil? (sut/resolve-key store ""))))
+
+    (testing "an empty store resolves nothing — the fail-closed default"
+      (is (nil? (sut/resolve-key {} "alice"))))))

--- a/docs/pull-requests/2026-08-05-claude-n4-pack-trust-roots.md
+++ b/docs/pull-requests/2026-08-05-claude-n4-pack-trust-roots.md
@@ -1,0 +1,194 @@
+# fix(policy-pack): resolve pack signatures against configured trust roots
+
+MINIFORGE_PR_BUDGET_OVERRIDE: security fix; non-test change is 370 reportable
+lines, within dewey 722's 400-line limit for meaningful change. The remainder
+is the test coverage the fix needs — a signature verifier is not reviewable
+without tests that sign real packs with real Ed25519 keys.
+
+## Overview
+
+Policy pack signature verification took its verification key from the pack
+being verified. `registry/verify-signature` read `:pack/signed-by`, base64
+decoded it, and passed the result to `verify-ed25519`. Verification therefore
+established only that the pack was signed by whoever holds the key the pack
+itself names.
+
+This adds a configured trust-root store, resolves `:pack/signed-by` against it
+as a key identifier, and fails when it resolves to nothing. It also implements
+the canonical serialization the signature is computed over, which was not
+reproducible across runs.
+
+## Motivation
+
+N4 §8.2.1 (0.7.0-draft, [#1658](https://github.com/miniforge-ai/miniforge/pull/1658)):
+
+> Implementations MUST maintain an explicit set of trusted publisher keys, and
+> MUST NOT accept a key supplied by the pack being verified. A pack that
+> carries its own verification key is self-certifying and establishes nothing.
+
+N4 Annex A.4 records the implementation gap and calls it the highest-priority
+item in that annex. §8.1 types `:pack/signed-by` as a key identifier.
+
+Two further defects surfaced while building the fix, both of which had to be
+addressed for the trust-root store to be usable:
+
+1. **`pack-signable-bytes` was not reproducible.** `(pr-str (into (sorted-map)
+   signable))` sorts only the top-level map, renders sets in iteration order,
+   and prints a `java.time.Instant` as `#object[java.time.Instant 0x… "…"]`
+   with an identity hash. The same pack serialized to different bytes across
+   runs, so a signature valid on one machine failed on another. N4 Annex A.3
+   records the first two; the `Instant` case is the same class of defect.
+
+2. **`verify-ed25519` could not decode a standard Ed25519 public key.** It read
+   the key bytes as one big-endian magnitude and hardcoded `x-odd? = false`.
+   RFC 8032 §5.1.2 stores y little-endian with the sign of x in the top bit of
+   the final byte. Measured against the old decoder over 200 generated
+   keypairs: the standard raw encoding verified 0 of 200; feeding it a
+   big-endian y instead verified 94 of 200 — exactly the 94 whose x was even,
+   and none of the 106 whose x was odd. A trust root holding real publisher
+   keys is unusable against that decoder.
+
+## Changes in Detail
+
+### Trust-root store — `policy_pack/trust_roots{,_config}.clj` (new)
+
+`trust_roots` is the store as a value — schema, key decoding, entry
+validation, lookup, construction. `trust_roots_config` loads one from two
+sources, merged by identifier with the operator's entry winning:
+
+1. `config/policy-pack/trust-roots.edn` on the classpath — **ships empty**, so
+   a deployment that configures nothing trusts nothing.
+2. `~/.miniforge/config.edn` under `[:policy-pack :trust-roots]` — the
+   out-of-band, auditable store §8.2.1 asks for.
+
+Both sources validate against the `TrustRootConfig` Malli schema at load, and
+each entry's public key must base64-decode to exactly 32 bytes. A malformed
+entry throws rather than being dropped: a trust root that silently disappears
+reads at the gate as an untrusted publisher.
+
+Entries carry `:trust-root/key-id` and `:trust-root/public-key` only. No
+per-key algorithm field — §8.1 fixes Ed25519 for the pack format.
+
+### Verification — `policy_pack/registry.clj`
+
+`verify-signature` now resolves `:pack/signed-by` through the store and fails
+when it resolves to nothing. Distinct outcomes: unsigned, signature present
+with no key identifier, identifier not in the trust roots, signature not
+base64, signature invalid. `:signer` remains the identifier the pack *claims*
+— verified only when `:verified? true`, which the protocol docstring now says.
+
+`InMemoryPackRegistry` gains a `trust-roots` field, outside `state` because it
+is fixed configuration. `create-registry` takes `:trust-roots` for injection
+and otherwise loads the configured store.
+
+### Canonical serialization — `policy_pack/canonical_{order,edn}.clj` (new)
+
+`pack-signable-bytes` renders N4 §8.1.1 rather than deferring to `pr-str`:
+maps key-ordered at every depth, sets as sorted vectors, sequences in declared
+order, instants as millisecond-precision UTC, single spaces between entries,
+key comparison byte-wise over UTF-8 with an absent namespace sorting first.
+
+A value with no EDN reader form now throws instead of serializing an identity
+hash — a pack carrying a live `:rule/check-fn` rather than the symbol §8.1.1
+requires cannot produce a signature that verifies, and failing loudly beats
+failing mysteriously.
+
+`verify-ed25519` decodes the RFC 8032 raw encoding and rejects a key that is
+not 32 bytes. `crypto` keeps only the Ed25519 concern; the serialization moved
+out to keep each namespace within rule 210's layer budget. `canonical-compare`
+takes its renderer as an argument so ordering and rendering are not mutually
+recursive — which is also what makes them stratifiable.
+
+### Schema — `policy_pack/schema.clj`
+
+`:pack/signed-by` field docs record that it is a key identifier resolved
+through the trust roots, never key material. The type is unchanged (`string?`).
+
+### Localization
+
+Verification and trust-root diagnostics go through a new system-locale
+catalog, `config/policy-pack/messages/system.edn`. Adds a `messages` component
+dependency to policy-pack.
+
+## Testing Plan
+
+New: `crypto_test`, `trust_roots_test`, `registry_signature_test`, and a
+`signing_fixtures` helper that generates real Ed25519 keypairs and signs packs
+over the canonical bytes. Stubbed crypto cannot distinguish a verifier that
+resolves the right key from one that accepts whatever the pack hands it.
+
+The three cases the fix exists for:
+
+| Case | Expected |
+|---|---|
+| Pack signed by a trusted key | verifies |
+| `:pack/signed-by` names an unknown identifier | fails, unresolved signer |
+| Pack re-signed with an untrusted key, internally consistent | fails |
+
+`self-certifying-pack-test` reproduces the original attack: modify the pack,
+sign it with the attacker's key, write that public key into `:pack/signed-by`.
+It fails, and the same pack verifies against a store that trusts that key —
+so the signature is genuinely self-consistent and only trust rejects it.
+
+Canonicalization tests build the same value two ways and compare bytes,
+including nested maps above the array-map threshold where host hash order
+takes over. `both-x-parities-verify-test` draws keypairs until it holds one of
+each x parity, because one keypair covers the decoder only half the time.
+
+Run:
+
+- policy-pack: 294 tests, 2677 assertions, 0 failures, 0 errors
+- policy-pack + its 8 reverse dependencies: 1353 tests, 6417 assertions, 0
+  failures, 0 errors
+- `bb poly:check` clean; `bb lint:clj:all` 0 errors, no policy-pack findings
+- `bb lint:stratum` clean on every file this PR adds. `registry.clj` still
+  reports SL003 (5 layers, max 3) — verified to report the same at
+  `bade0222f` before this change, is documented as a Wave 2 split in its own
+  namespace docstring, and appears in `work/stratum-lint-baseline-2026-07-24`.
+  This PR adds one Layer 0 function to it and no new stratum, so the commits
+  touching it were made with the documented
+  `MINIFORGE_STRATUM_BUDGET_MODE=warn` opt-out.
+- `bb test:graalvm` passes; `canonical-edn` verified under Babashka directly
+  (the graalvm suite does not cover policy-pack namespaces)
+
+## Deployment Plan
+
+Ships with the trust-root resource empty. Signature verification is fail-closed
+from this commit: until an operator configures a publisher key, every signed
+pack reports `:verified? false`. Nothing regresses, because verification was
+not previously reachable — see below.
+
+## Breaking Changes
+
+Signatures produced against the old `pack-signable-bytes` no longer verify.
+The old bytes were not reproducible, so no signature depended on them.
+
+## Not in this change
+
+- **No production caller.** `verify-signature` has no caller outside the
+  component. §5.1.8's `require-signature-verification` and
+  `enforce-publisher-allowlist` rules are declared with
+  `:rule/detection {:type :custom}` and no `:custom-fn`, so nothing runs them.
+  Wiring the pack-trust gate is separate work.
+- **§8.2 steps 4 and 5** — key validity windows and per-pack publisher
+  permission — remain unimplemented. §8.2.1 puts key distribution and rotation
+  out of scope, and a validity field nothing enforced would be worse than none.
+- **N4 Annex A** still records A.4 and the A.3 canonicalization gap as open.
+  The annex lives on the unmerged #1658 branch; editing it from here would
+  conflict. It should be updated when #1658 lands.
+
+## Related Issues/PRs
+
+- [#1658](https://github.com/miniforge-ai/miniforge/pull/1658) — N4 0.7.0-draft, the spec text this implements
+- N4 §8.1, §8.1.1, §8.2, §8.2.1, Annex A.3, Annex A.4
+
+## Checklist
+
+- [x] Trust-root store loaded from config, not inline code (dewey 007)
+- [x] Malli schema on the config file, validated at load
+- [x] `verify-signature` resolves an identifier and fails closed
+- [x] `:pack/signed-by` field docs corrected
+- [x] Tests for trusted, unknown-identifier, and re-signed packs
+- [x] `pack-signable-bytes` implements §8.1.1 rendering
+- [x] Diagnostics routed through a message catalog (dewey 050)
+- [x] `bb poly:check`, `bb lint:clj:all`, `bb test:graalvm`

--- a/docs/pull-requests/2026-08-05-claude-n4-pack-trust-roots.md
+++ b/docs/pull-requests/2026-08-05-claude-n4-pack-trust-roots.md
@@ -167,6 +167,10 @@ Three Copilot rounds, all findings real and fixed:
    no: the one verification outcome an operator would read as blank. Added
    `:crypto/invalid-signature` and a test that every failure path carries a
    reason.
+4. Two follow-ons from (3): the catch-all used `(.getMessage e)`, which is nil
+   for some exceptions, and `:crypto/undecodable-signature` said "not valid
+   base64" while `decode-signature` also rejects a non-string. Both fixed, with
+   a test that forces the nil-message path.
 
 ## Deployment Plan
 

--- a/docs/pull-requests/2026-08-05-claude-n4-pack-trust-roots.md
+++ b/docs/pull-requests/2026-08-05-claude-n4-pack-trust-roots.md
@@ -151,6 +151,23 @@ Run:
 - `bb test:graalvm` passes; `canonical-edn` verified under Babashka directly
   (the graalvm suite does not cover policy-pack namespaces)
 
+## Review rounds
+
+Three Copilot rounds, all findings real and fixed:
+
+1. `decode-public-key` threw an NPE on a nil or non-string key. Reachable —
+   `create-registry` accepts an injected store, so `resolve-key` sees whatever
+   a caller holds, not only entries `->store` validated. A fail-closed path
+   should not throw.
+2. The protocol docstring promised `:signer` and `:timestamp` unconditionally
+   while the unsigned branch omits both. The behaviour is right — reporting a
+   signer for an unsigned pack would imply something signed it — so the
+   docstring moved to match and the tests now assert both presence and absence.
+3. `verify-ed25519` returned a bare `{:verified? false}` when `.verify` said
+   no: the one verification outcome an operator would read as blank. Added
+   `:crypto/invalid-signature` and a test that every failure path carries a
+   reason.
+
 ## Deployment Plan
 
 Ships with the trust-root resource empty. Signature verification is fail-closed


### PR DESCRIPTION
MINIFORGE_PR_BUDGET_OVERRIDE: security fix; non-test change is 370 reportable lines, within dewey 722's 400-line limit for meaningful change. The remainder is test coverage — a signature verifier is not reviewable without tests that sign real packs with real Ed25519 keys.

## What was wrong

`registry/verify-signature` took its verification key from the pack being verified:

```clojure
pub-key-str   (:pack/signed-by pack)
pub-bytes     (when pub-key-str (.decode decoder ^String pub-key-str))
result        (crypto/verify-ed25519 content-bytes sig-bytes pub-bytes)
```

Verification therefore established only that the pack was signed by whoever holds the key the pack itself names. An attacker modifies a pack, signs it with their own key, writes that public key into `:pack/signed-by`, and verification passes. There was no configured trust root.

N4 §8.2.1 (0.7.0-draft, #1658) forbids this; §8.1 types `:pack/signed-by` as a key identifier. Annex A.4 records it as the highest-priority item in that annex.

## What this does

- **Trust-root store.** `trust_roots` holds the store as a value; `trust_roots_config` loads one from `config/policy-pack/trust-roots.edn` on the classpath overlaid with `~/.miniforge/config.edn` under `[:policy-pack :trust-roots]`. The shipped resource **ships empty**, so a deployment that configures nothing trusts nothing.
- **`verify-signature`** resolves `:pack/signed-by` through that store and fails when it resolves to nothing. `:signer` remains the identifier the pack *claims* — verified only when `:verified?` is true.
- **`:pack/signed-by` field docs** record that it is a key identifier, never key material.

## Two defects found on the way, both required for the store to work

1. **`pack-signable-bytes` was not reproducible.** `(pr-str (into (sorted-map) signable))` sorts only the top-level map, renders sets in iteration order, and prints a `java.time.Instant` with an identity hash. The same pack serialized to different bytes across runs. Now implements the §8.1.1 rendering.

2. **`verify-ed25519` could not decode a standard Ed25519 public key.** It read the bytes as one big-endian magnitude with `x-odd?` hardcoded false; RFC 8032 §5.1.2 stores y little-endian with the sign of x in the top bit of the final byte. Measured against the old decoder over 200 generated keypairs: the standard raw encoding verified **0 of 200**; a big-endian y verified **94 of 200** — exactly the 94 whose x was even.

## Tests

The three cases the fix exists for, plus the regression for the original attack:

| Case | Expected |
|---|---|
| Pack signed by a trusted key | verifies |
| `:pack/signed-by` names an unknown identifier | fails |
| Pack re-signed with an untrusted key, internally consistent | fails |
| Pack supplies its own public key in `:pack/signed-by` | fails |

`self-certifying-pack-test` also asserts that the same pack **does** verify against a store that trusts the attacker's key — so the signature is genuinely self-consistent and only the trust check rejects it.

Run:

- policy-pack: 294 tests, 2677 assertions, 0 failures, 0 errors
- policy-pack + its 8 reverse dependencies: 1353 tests, 6417 assertions, 0 failures, 0 errors
- `bb pre-commit` green on every commit; `bb test:graalvm` passes; `canonical-edn` verified under Babashka directly

`registry.clj` still reports SL003 (5 layers, max 3). Verified to report the same at `bade0222f` before this change, documented as a Wave 2 split in its own namespace docstring, and present in `work/stratum-lint-baseline-2026-07-24`. This PR adds one Layer 0 function to it and no new stratum, so its commit used the documented `MINIFORGE_STRATUM_BUDGET_MODE=warn` opt-out. Every file this PR adds is stratum-clean.

## Not in this change

- **No production caller.** `verify-signature` has none outside the component. §5.1.8's `require-signature-verification` and `enforce-publisher-allowlist` are declared with `:rule/detection {:type :custom}` and no `:custom-fn`, so nothing runs them. Wiring the pack-trust gate is separate work.
- **§8.2 steps 4 and 5** — key validity windows and per-pack publisher permission — remain unimplemented. §8.2.1 puts key distribution and rotation out of scope, and a validity field nothing enforced would be worse than none.
- **N4 Annex A** still records A.4 and the A.3 canonicalization gap as open. The annex lives on the unmerged #1658 branch; editing it from here would conflict. It should be updated when #1658 lands.

## Breaking

Signatures produced against the old `pack-signable-bytes` no longer verify. Those bytes were not reproducible, so no signature depended on them.

Full write-up: [docs/pull-requests/2026-08-05-claude-n4-pack-trust-roots.md](docs/pull-requests/2026-08-05-claude-n4-pack-trust-roots.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
