### PR TITLE
fix: propagate missing event registry anomalies

### DIFF
--- a/components/event-stream/src/ai/miniforge/event_stream/event_type_registry.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/event_type_registry.clj
@@ -72,27 +72,28 @@
   "Machine-readable registry/browser audit summary."
   audit/audit-summary)
 
-;------------------------------------------------------------------------------ Layer 1
-
 ;; Derived views
-(def ^{:stratum 1} browser-handled-events
+(defn ^{:stratum 0} browser-handled-events-for
   "Event types currently handled in `handleWorkflowEvent` in app.js.
-   All strings confirmed correct — no mismatches."
-  (if (anomaly/anomaly? event-type-registry)
-    event-type-registry
-    (->> event-type-registry
+   All strings confirmed correct — no mismatches. Returns an upstream
+   registry anomaly unchanged."
+  [registry]
+  (if (anomaly/anomaly? registry)
+    registry
+    (->> registry
          (filter :browser?)
          (mapv :json-string))))
 
 ;; => ["workflow/started" "workflow/phase-started" "workflow/phase-completed"
 ;;     "workflow/completed" "workflow/failed" "agent/chunk"]
-(def ^{:stratum 1} browser-unhandled-events
+(defn ^{:stratum 0} browser-unhandled-events-for
   "Event types emitted server-side that the browser switch silently ignores.
    These are the gap items for Tasks 1–7. Returns the registry anomaly
    when the backing resource cannot be loaded."
-  (if (anomaly/anomaly? event-type-registry)
-    event-type-registry
-    (->> event-type-registry
+  [registry]
+  (if (anomaly/anomaly? registry)
+    registry
+    (->> registry
          (remove :browser?)
          (mapv :json-string))))
 
@@ -109,21 +110,33 @@
 ;;   cp-agent-state-changed     → "control-plane/agent-state-changed" (prefix cp → control-plane)
 ;;   cp-decision-created        → "control-plane/decision-created"  (prefix cp → control-plane)
 ;;   cp-decision-resolved       → "control-plane/decision-resolved" (prefix cp → control-plane)
-(def ^{:stratum 1} naming-asymmetries
+(defn ^{:stratum 0} naming-asymmetries-for
   "13 constructors whose function name does not predict the namespace portion
    of the serialised event-type string.  A developer reading only
    `interface/events.clj` would guess the wrong browser case string.
 
    Format: [constructor → json-string (note)]. Returns the registry
    anomaly when the backing resource cannot be loaded."
-  (if (anomaly/anomaly? event-type-registry)
-    event-type-registry
-    (->> event-type-registry
+  [registry]
+  (if (anomaly/anomaly? registry)
+    registry
+    (->> registry
          (filter :asymmetry?)
          (mapv (fn [{:keys [constructor json-string asymmetry-note]}]
                  {:constructor    constructor
                   :json-string    json-string
                   :asymmetry-note asymmetry-note})))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} browser-handled-events
+  (browser-handled-events-for event-type-registry))
+
+(def ^{:stratum 1} browser-unhandled-events
+  (browser-unhandled-events-for event-type-registry))
+
+(def ^{:stratum 1} naming-asymmetries
+  (naming-asymmetries-for event-type-registry))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/event-stream/src/ai/miniforge/event_stream/event_type_registry.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/event_type_registry.clj
@@ -46,6 +46,7 @@
    file to add or modify event types.  This namespace loads it and
    derives the computed views below."
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.event-stream.event-type-registry.audit :as audit]
    [ai.miniforge.event-stream.event-type-registry.data :as data]
    [clojure.string :as str]))
@@ -77,18 +78,22 @@
 (def ^{:stratum 1} browser-handled-events
   "Event types currently handled in `handleWorkflowEvent` in app.js.
    All strings confirmed correct — no mismatches."
-  (->> event-type-registry
-       (filter :browser?)
-       (mapv :json-string)))
+  (if (anomaly/anomaly? event-type-registry)
+    event-type-registry
+    (->> event-type-registry
+         (filter :browser?)
+         (mapv :json-string))))
 
 ;; => ["workflow/started" "workflow/phase-started" "workflow/phase-completed"
 ;;     "workflow/completed" "workflow/failed" "agent/chunk"]
 (def ^{:stratum 1} browser-unhandled-events
   "Event types emitted server-side that the browser switch silently ignores.
    These are the gap items for Tasks 1–7."
-  (->> event-type-registry
-       (remove :browser?)
-       (mapv :json-string)))
+  (if (anomaly/anomaly? event-type-registry)
+    event-type-registry
+    (->> event-type-registry
+         (remove :browser?)
+         (mapv :json-string))))
 
 ;; Asymmetries at a glance:
 ;;
@@ -109,12 +114,14 @@
    `interface/events.clj` would guess the wrong browser case string.
 
    Format: [constructor → json-string (note)]"
-  (->> event-type-registry
-       (filter :asymmetry?)
-       (mapv (fn [{:keys [constructor json-string asymmetry-note]}]
-               {:constructor    constructor
-                :json-string    json-string
-                :asymmetry-note asymmetry-note}))))
+  (if (anomaly/anomaly? event-type-registry)
+    event-type-registry
+    (->> event-type-registry
+         (filter :asymmetry?)
+         (mapv (fn [{:keys [constructor json-string asymmetry-note]}]
+                 {:constructor    constructor
+                  :json-string    json-string
+                  :asymmetry-note asymmetry-note})))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/event-stream/src/ai/miniforge/event_stream/event_type_registry.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/event_type_registry.clj
@@ -88,7 +88,8 @@
 ;;     "workflow/completed" "workflow/failed" "agent/chunk"]
 (def ^{:stratum 1} browser-unhandled-events
   "Event types emitted server-side that the browser switch silently ignores.
-   These are the gap items for Tasks 1–7."
+   These are the gap items for Tasks 1–7. Returns the registry anomaly
+   when the backing resource cannot be loaded."
   (if (anomaly/anomaly? event-type-registry)
     event-type-registry
     (->> event-type-registry
@@ -113,7 +114,8 @@
    of the serialised event-type string.  A developer reading only
    `interface/events.clj` would guess the wrong browser case string.
 
-   Format: [constructor → json-string (note)]"
+   Format: [constructor → json-string (note)]. Returns the registry
+   anomaly when the backing resource cannot be loaded."
   (if (anomaly/anomaly? event-type-registry)
     event-type-registry
     (->> event-type-registry

--- a/components/event-stream/src/ai/miniforge/event_stream/event_type_registry/audit.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/event_type_registry/audit.clj
@@ -18,30 +18,33 @@
 (ns ai.miniforge.event-stream.event-type-registry.audit
   "Machine-readable audit summary derived from registry data."
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.event-stream.event-type-registry.data :as data]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
 (def ^{:stratum 0} audit-summary
-  (let [registry data/event-type-registry
-        handled (filter :browser? registry)
-        unhandled (remove :browser? registry)
-        asymmetries (filter :asymmetry? registry)]
-    {:audit/date "2026-08-05"
-     :audit/source-server
-     "components/event-stream/src/ai/miniforge/event_stream/interface/*.clj"
-     :audit/source-browser
-     "components/web-dashboard/resources/public/js/app.js"
-     :audit/browser-switch "handleWorkflowEvent"
-     :total-server-events (count registry)
-     :browser-handled-count (count handled)
-     :browser-unhandled-count (count unhandled)
-     :naming-asymmetry-count (count asymmetries)
-     :string-mismatches []
-     :coverage-gaps (mapv :json-string unhandled)
-     :asymmetries
-     (mapv #(select-keys % [:constructor :json-string :asymmetry-note])
-           asymmetries)
-     :serialisation-rule
-     (str "Clojure namespaced keywords serialize as ns/name without a leading "
-          "colon; browser comparisons use those plain strings.")}))
+  (let [registry data/event-type-registry]
+    (if (anomaly/anomaly? registry)
+      registry
+      (let [handled (filter :browser? registry)
+            unhandled (remove :browser? registry)
+            asymmetries (filter :asymmetry? registry)]
+        {:audit/date "2026-08-05"
+         :audit/source-server
+         "components/event-stream/src/ai/miniforge/event_stream/interface/*.clj"
+         :audit/source-browser
+         "components/web-dashboard/resources/public/js/app.js"
+         :audit/browser-switch "handleWorkflowEvent"
+         :total-server-events (count registry)
+         :browser-handled-count (count handled)
+         :browser-unhandled-count (count unhandled)
+         :naming-asymmetry-count (count asymmetries)
+         :string-mismatches []
+         :coverage-gaps (mapv :json-string unhandled)
+         :asymmetries
+         (mapv #(select-keys % [:constructor :json-string :asymmetry-note])
+               asymmetries)
+         :serialisation-rule
+         (str "Clojure namespaced keywords serialize as ns/name without a leading "
+              "colon; browser comparisons use those plain strings.")}))))

--- a/components/event-stream/src/ai/miniforge/event_stream/event_type_registry/audit.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/event_type_registry/audit.clj
@@ -23,28 +23,34 @@
 
 ;------------------------------------------------------------------------------ Layer 0
 
-(def ^{:stratum 0} audit-summary
-  (let [registry data/event-type-registry]
-    (if (anomaly/anomaly? registry)
-      registry
-      (let [handled (filter :browser? registry)
-            unhandled (remove :browser? registry)
-            asymmetries (filter :asymmetry? registry)]
-        {:audit/date "2026-08-05"
-         :audit/source-server
-         "components/event-stream/src/ai/miniforge/event_stream/interface/*.clj"
-         :audit/source-browser
-         "components/web-dashboard/resources/public/js/app.js"
-         :audit/browser-switch "handleWorkflowEvent"
-         :total-server-events (count registry)
-         :browser-handled-count (count handled)
-         :browser-unhandled-count (count unhandled)
-         :naming-asymmetry-count (count asymmetries)
-         :string-mismatches []
-         :coverage-gaps (mapv :json-string unhandled)
-         :asymmetries
-         (mapv #(select-keys % [:constructor :json-string :asymmetry-note])
-               asymmetries)
-         :serialisation-rule
-         (str "Clojure namespaced keywords serialize as ns/name without a leading "
-              "colon; browser comparisons use those plain strings.")}))))
+(defn ^{:stratum 0} audit-summary-for
+  "Derive the audit summary or preserve an upstream registry anomaly."
+  [registry]
+  (if (anomaly/anomaly? registry)
+    registry
+    (let [handled (filter :browser? registry)
+          unhandled (remove :browser? registry)
+          asymmetries (filter :asymmetry? registry)]
+      {:audit/date "2026-08-05"
+       :audit/source-server
+       "components/event-stream/src/ai/miniforge/event_stream/interface/*.clj"
+       :audit/source-browser
+       "components/web-dashboard/resources/public/js/app.js"
+       :audit/browser-switch "handleWorkflowEvent"
+       :total-server-events (count registry)
+       :browser-handled-count (count handled)
+       :browser-unhandled-count (count unhandled)
+       :naming-asymmetry-count (count asymmetries)
+       :string-mismatches []
+       :coverage-gaps (mapv :json-string unhandled)
+       :asymmetries
+       (mapv #(select-keys % [:constructor :json-string :asymmetry-note])
+             asymmetries)
+       :serialisation-rule
+       (str "Clojure namespaced keywords serialize as ns/name without a leading "
+            "colon; browser comparisons use those plain strings.")})))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} audit-summary
+  (audit-summary-for data/event-type-registry))

--- a/components/event-stream/src/ai/miniforge/event_stream/event_type_registry/data.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/event_type_registry/data.clj
@@ -29,10 +29,17 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
-(def ^{:stratum 1} event-type-registry
+(defn ^{:stratum 1} load-event-type-registry
+  "Load the registry resource, returning a :not-found anomaly when absent."
+  []
   (if-let [resource (io/resource registry-resource-path)]
     (-> resource slurp edn/read-string)
     (anomaly/anomaly
      :not-found
      "Event type registry resource not found"
      {:resource-path registry-resource-path})))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(def ^{:stratum 2} event-type-registry
+  (load-event-type-registry))

--- a/components/event-stream/src/ai/miniforge/event_stream/event_type_registry/data.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/event_type_registry/data.clj
@@ -18,6 +18,7 @@
 (ns ai.miniforge.event-stream.event-type-registry.data
   "Loading boundary for the authoritative event-type registry resource."
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [clojure.edn :as edn]
    [clojure.java.io :as io]))
 
@@ -31,5 +32,7 @@
 (def ^{:stratum 1} event-type-registry
   (if-let [resource (io/resource registry-resource-path)]
     (-> resource slurp edn/read-string)
-    (throw (ex-info "Event type registry resource not found"
-                    {:resource-path registry-resource-path}))))
+    (anomaly/anomaly
+     :not-found
+     "Event type registry resource not found"
+     {:resource-path registry-resource-path})))

--- a/components/event-stream/test/ai/miniforge/event_stream/event_type_registry_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/event_type_registry_test.clj
@@ -18,8 +18,12 @@
 (ns ai.miniforge.event-stream.event-type-registry-test
   "Tests for event type registry integrity and derived views."
   (:require
+   [clojure.java.io :as io]
    [clojure.test :refer [deftest testing is]]
-   [ai.miniforge.event-stream.event-type-registry :as registry]))
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.event-stream.event-type-registry :as registry]
+   [ai.miniforge.event-stream.event-type-registry.audit :as audit]
+   [ai.miniforge.event-stream.event-type-registry.data :as data]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -124,3 +128,16 @@
 
   (testing "no string mismatches reported"
     (is (empty? (:string-mismatches registry/audit-summary)))))
+
+(deftest ^{:stratum 0} missing-registry-resource-propagates-as-anomaly-test
+  (let [missing-registry (with-redefs [io/resource (constantly nil)]
+                           (data/load-event-type-registry))]
+    (is (anomaly/anomaly? missing-registry))
+    (is (= :not-found (:anomaly/type missing-registry)))
+    (is (= missing-registry (audit/audit-summary-for missing-registry)))
+    (is (= missing-registry
+           (registry/browser-handled-events-for missing-registry)))
+    (is (= missing-registry
+           (registry/browser-unhandled-events-for missing-registry)))
+    (is (= missing-registry
+           (registry/naming-asymmetries-for missing-registry)))))

--- a/docs/pull-requests/2026-08-05-codex-standards-event-registry-anomalies.md
+++ b/docs/pull-requests/2026-08-05-codex-standards-event-registry-anomalies.md
@@ -1,0 +1,34 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+# fix: propagate missing event registry anomalies
+
+## Overview
+
+Makes a missing event-type registry resource an explicit `:not-found` anomaly.
+
+## Changes in Detail
+
+- Return an anomaly at the resource loading boundary.
+- Preserve that anomaly in derived registry views and audit output.
+
+## Testing Plan
+
+- Event-stream tests
+- Normal pre-commit validation
+
+## Deployment Plan
+
+No migration or rollout is needed.
+
+## Related Issues/PRs
+
+- Base Branch: `main`
+- Depends On: none
+
+## Checklist
+
+- [x] Audit gap fixed
+- [x] Pre-commit checks passed


### PR DESCRIPTION
## Layer
Infrastructure

## Depends on
- None

## What this adds
Represents a missing event registry resource as `:not-found` and preserves it through derived views.

## Strata affected
- event-stream registry loading and audit

## Validation
- Normal pre-commit checks
- Event-stream tests