### PR TITLE
fix: return anomalies from durable effect boundaries

### DIFF
--- a/components/effect-transaction/test/ai/miniforge/effect_transaction/store_test.clj
+++ b/components/effect-transaction/test/ai/miniforge/effect_transaction/store_test.clj
@@ -186,3 +186,18 @@
     (is (= original (store/create! dir original)))
     (is (anomaly/anomaly? (store/create! dir replacement)))
     (is (= original (fx/read-record dir (:effect/id original))))))
+
+(deftest ^{:stratum 2} lifecycle-writes-propagate-store-anomalies-test
+  (let [dir (tmp-dir)
+        write-failure (anomaly/anomaly :unavailable "disk unavailable" {})]
+    (with-redefs [store/create! (fn [& _] write-failure)
+                  store/transition! (fn [& _] write-failure)]
+      (is (= write-failure
+             (effect-record/propose!
+              dir
+              {:effect-class :effect/merge
+               :grant-id (random-uuid)
+               :envelope-id (random-uuid)}
+              now)))
+      (is (= write-failure
+             (effect-record/advance! dir (record) {:effect/state :committing} now))))))

--- a/docs/pull-requests/2026-08-05-codex-standards-effect-grant-anomalies.md
+++ b/docs/pull-requests/2026-08-05-codex-standards-effect-grant-anomalies.md
@@ -1,0 +1,35 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+# fix: return anomalies from durable effect boundaries
+
+## Overview
+
+Moves effect-transaction and execution-grant persistence validation failures onto the anomaly value path.
+
+## Changes in Detail
+
+- Reject unsupported timestamps before writing.
+- Propagate persistence anomalies to callers.
+- Update focused tests for the returned anomaly contract.
+
+## Testing Plan
+
+- Focused effect-transaction and execution-grant tests
+- Normal pre-commit validation
+
+## Deployment Plan
+
+No migration or rollout is needed.
+
+## Related Issues/PRs
+
+- Base Branch: `main`
+- Depends On: none
+
+## Checklist
+
+- [x] Audit gap fixed
+- [x] Pre-commit checks passed


### PR DESCRIPTION
## Layer
Infrastructure

## Depends on
- None

## What this adds
Returns serialization and validation failures from durable effect boundaries as anomaly values before any write.

## Strata affected
- effect-transaction persistence
- execution-grant breach history

## Validation
- Normal pre-commit checks
- Focused affected-component tests