### PR TITLE
refactor: decompose the OPSV phase model

### DIFF
--- a/components/phase-opsv/src/ai/miniforge/phase_opsv/confidence.clj
+++ b/components/phase-opsv/src/ai/miniforge/phase_opsv/confidence.clj
@@ -1,0 +1,27 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.phase-opsv.confidence
+  "Classify bounded OPSV convergence confidence.")
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} level
+  [score threshold]
+  (if (and (number? score) (number? threshold) (>= score threshold))
+    :high
+    :low))

--- a/components/phase-opsv/src/ai/miniforge/phase_opsv/flow.clj
+++ b/components/phase-opsv/src/ai/miniforge/phase_opsv/flow.clj
@@ -1,0 +1,27 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.phase-opsv.flow
+  "Anomaly-preserving continuation for deterministic OPSV phase values."
+  (:require
+   [ai.miniforge.anomaly.interface :as anomaly]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} continue
+  [value transform]
+  (if (anomaly/anomaly? value) value (transform value)))

--- a/components/phase-opsv/src/ai/miniforge/phase_opsv/model.clj
+++ b/components/phase-opsv/src/ai/miniforge/phase_opsv/model.clj
@@ -39,102 +39,106 @@
   [ctx key]
   (get-in ctx [:execution/input key]))
 
-;------------------------------------------------------------------------------ Layer 1
-
-(defn- ^{:stratum 1} adapter-value
+(defn- ^{:stratum 0} adapter-value
   [ctx]
   (or (get-in ctx [:execution/opts :opsv/adapter])
-      (input-value ctx :opsv/adapter)))
+      (get-in ctx [:execution/input :opsv/adapter])))
 
-(defn ^{:stratum 1} plan
+(defn- ^{:stratum 0} converged-output
+  [executed]
+  (let [config (get-in executed [:opsv/experiment-pack
+                                 :experiment-pack/convergence])
+        initial-state {:steps (:opsv/ramp-steps executed) :history []}
+        result (opsv/converge config initial-state
+                              evaluation/convergence-step
+                              evaluation/convergence-evaluation)]
+    (if (anomaly/anomaly? result)
+      result
+      (assoc executed :opsv/convergence-result result))))
+
+(defn- ^{:stratum 0} synthesized-output
+  [ctx converged]
+  (let [proposal (policy/operational-policy
+                  ctx (:opsv/convergence-result converged))
+        validated (opsv/validate-operational-policy proposal)]
+    (if (anomaly/anomaly? validated)
+      validated
+      (assoc converged
+             :opsv/operational-policy validated
+             :opsv/policy-hash (content-hash/content-hash validated)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} planned-output
+  [ctx discovery]
+  (let [pack (:opsv/experiment-pack discovery)
+        risk-result (opsv/assess-risk
+                     (risk/factors pack
+                                   (input-value ctx :opsv/service-criticality))
+                     (input-value ctx :opsv/risk-thresholds))
+        pack-hash (opsv/experiment-pack-hash pack)]
+    (cond
+      (anomaly/anomaly? risk-result) risk-result
+      (anomaly/anomaly? pack-hash) pack-hash
+      :else (assoc discovery :opsv/risk-result risk-result
+                   :opsv/experiment-pack-hash pack-hash))))
+
+(defn ^{:stratum 1} discover
   [ctx]
-  (flow/continue
-   (phase-output ctx :opsv/discover)
-   (fn [discovery]
-     (let [pack (:opsv/experiment-pack discovery)
-           risk-result (opsv/assess-risk
-                        (risk/factors
-                         pack (input-value ctx :opsv/service-criticality))
-                        (input-value ctx :opsv/risk-thresholds))
-           pack-hash (opsv/experiment-pack-hash pack)]
-       (cond
-         (anomaly/anomaly? risk-result) risk-result
-         (anomaly/anomaly? pack-hash) pack-hash
-         :else (assoc discovery
-                      :opsv/risk-result risk-result
-                      :opsv/experiment-pack-hash pack-hash))))))
+  (let [pack (opsv/validate-experiment-pack
+              (input-value ctx :opsv/experiment-pack))
+        runtime-adapter (adapter-value ctx)
+        invalid-adapter (adapter/adapter-anomaly runtime-adapter)]
+    (cond
+      (anomaly/anomaly? pack) pack
+      invalid-adapter invalid-adapter
+      :else
+      (let [drivers (port/discover-signals
+                     runtime-adapter (:experiment-pack/targets pack))]
+        (if (anomaly/anomaly? drivers)
+          drivers
+          {:opsv/experiment-pack pack
+           :opsv/candidate-drivers drivers})))))
+
+(defn- ^{:stratum 1} executed-output
+  [ctx planned]
+  (let [runtime-adapter (adapter-value ctx)
+        invalid-adapter (adapter/adapter-anomaly runtime-adapter)]
+    (if invalid-adapter
+      invalid-adapter
+      (let [ramp (port/run-guarded-ramp
+                  runtime-adapter (:opsv/experiment-pack planned))
+            invalid-ramp (adapter/ramp-shape-anomaly ramp)]
+        (cond
+          (anomaly/anomaly? ramp) ramp
+          invalid-ramp invalid-ramp
+          :else (assoc planned
+                       :opsv/environment-fingerprint
+                       (:environment-fingerprint ramp)
+                       :opsv/ramp-steps (:steps ramp)))))))
 
 (defn ^{:stratum 1} converge
   [ctx]
-  (flow/continue
-   (phase-output ctx :opsv/execute)
-   (fn [executed]
-     (let [config (get-in executed
-                          [:opsv/experiment-pack
-                           :experiment-pack/convergence])
-           initial-state {:steps (:opsv/ramp-steps executed) :history []}
-           result (opsv/converge config initial-state
-                                 evaluation/convergence-step
-                                 evaluation/convergence-evaluation)]
-       (if (anomaly/anomaly? result)
-         result
-         (assoc executed :opsv/convergence-result result))))))
+  (flow/continue (phase-output ctx :opsv/execute) converged-output))
+
+(defn ^{:stratum 1} synthesize
+  [ctx]
+  (flow/continue (phase-output ctx :opsv/converge)
+                 (partial synthesized-output ctx)))
 
 (defn ^{:stratum 1} verify
   [ctx]
   (flow/continue (phase-output ctx :opsv/synthesize)
                  (partial verification/output ctx)))
 
-(defn ^{:stratum 1} synthesize
-  [ctx]
-  (flow/continue
-   (phase-output ctx :opsv/converge)
-   (fn [converged]
-     (let [proposal (policy/operational-policy
-                     ctx (:opsv/convergence-result converged))
-           validated (opsv/validate-operational-policy proposal)]
-       (if (anomaly/anomaly? validated)
-         validated
-         (assoc converged
-                :opsv/operational-policy validated
-                :opsv/policy-hash (content-hash/content-hash validated)))))))
-
 ;------------------------------------------------------------------------------ Layer 2
 
-(defn ^{:stratum 2} discover
+(defn ^{:stratum 2} plan
   [ctx]
-  (let [pack (opsv/validate-experiment-pack
-              (input-value ctx :opsv/experiment-pack))
-        invalid-adapter (adapter/adapter-anomaly
-                         (adapter-value ctx))]
-    (cond
-      (anomaly/anomaly? pack) pack
-      invalid-adapter invalid-adapter
-      :else
-      (let [adapter (adapter-value ctx)
-            drivers (port/discover-signals
-                     adapter (:experiment-pack/targets pack))]
-        (if (anomaly/anomaly? drivers)
-          drivers
-          {:opsv/experiment-pack pack
-           :opsv/candidate-drivers drivers})))))
+  (flow/continue (phase-output ctx :opsv/discover)
+                 (partial planned-output ctx)))
 
 (defn ^{:stratum 2} execute
   [ctx]
-  (flow/continue
-   (phase-output ctx :opsv/plan)
-   (fn [planned]
-     (if-let [invalid (adapter/adapter-anomaly
-                       (adapter-value ctx))]
-       invalid
-       (let [adapter (adapter-value ctx)
-             ramp (port/run-guarded-ramp
-                   adapter (:opsv/experiment-pack planned))
-             invalid-ramp (adapter/ramp-shape-anomaly ramp)]
-         (cond
-           (anomaly/anomaly? ramp) ramp
-           invalid-ramp invalid-ramp
-           :else (merge planned
-                        {:opsv/environment-fingerprint
-                         (:environment-fingerprint ramp)
-                         :opsv/ramp-steps (:steps ramp)})))))))
+  (flow/continue (phase-output ctx :opsv/plan)
+                 (partial executed-output ctx)))

--- a/components/phase-opsv/src/ai/miniforge/phase_opsv/model.clj
+++ b/components/phase-opsv/src/ai/miniforge/phase_opsv/model.clj
@@ -23,8 +23,11 @@
    [ai.miniforge.opsv.interface :as opsv]
    [ai.miniforge.phase-opsv.adapter :as adapter]
    [ai.miniforge.phase-opsv.evaluation :as evaluation]
+   [ai.miniforge.phase-opsv.flow :as flow]
+   [ai.miniforge.phase-opsv.policy :as policy]
    [ai.miniforge.phase-opsv.protocol :as port]
-   [ai.miniforge.phase-opsv.risk :as risk]))
+   [ai.miniforge.phase-opsv.risk :as risk]
+   [ai.miniforge.phase-opsv.verification :as verification]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -36,23 +39,6 @@
   [ctx key]
   (get-in ctx [:execution/input key]))
 
-(defn- ^{:stratum 0} preserve-anomaly
-  [value continue]
-  (if (anomaly/anomaly? value)
-    value
-    (continue value)))
-
-(defn- ^{:stratum 0} verification-criteria
-  [pack]
-  (let [declared (:experiment-pack/success-criteria pack)]
-    (if (contains? declared :criteria)
-      (:criteria declared)
-      (->> declared
-           (sort-by (comp str key))
-           (mapv (fn [[criterion-id expected]]
-                   {:criterion/id (name criterion-id)
-                    :criterion/expected expected}))))))
-
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn- ^{:stratum 1} adapter-value
@@ -60,36 +46,9 @@
   (or (get-in ctx [:execution/opts :opsv/adapter])
       (input-value ctx :opsv/adapter)))
 
-(defn- ^{:stratum 1} operational-policy
-  [ctx convergence]
-  (let [pack (input-value ctx :opsv/experiment-pack)
-        targets (:experiment-pack/targets pack)
-        evidence-refs (input-value ctx :opsv/evidence-refs)
-        selected-step (get-in convergence [:state :selected-step])
-        metrics (:step/metrics selected-step)]
-    {:operational-policy/id (str (:experiment-pack/id pack) "-policy")
-     :operational-policy/version "1.0.0"
-     :operational-policy/target-services (:services targets)
-     :operational-policy/target-envs (:environments targets)
-     :operational-policy/scaling
-     {:hpa {:api-version "autoscaling/v2"
-            :metric :cpu
-            :target-utilization (:hpa-target-utilization metrics)
-            :min-replicas (:min-replicas metrics)
-            :max-replicas (:max-replicas metrics)}
-      :keda {:trigger :backlog
-             :target (:keda-backlog-target metrics)}}
-     :operational-policy/resources
-     {:cpu-request-millicores (:cpu-request-millicores metrics)}
-     :operational-policy/guardrails (:experiment-pack/guardrails pack)
-     :operational-policy/verification-summary
-     {:passed? false :confidence :pending :caveats []}
-     :operational-policy/rollback-plan {:strategy :restore-previous-policy}
-     :operational-policy/evidence-refs evidence-refs}))
-
 (defn ^{:stratum 1} plan
   [ctx]
-  (preserve-anomaly
+  (flow/continue
    (phase-output ctx :opsv/discover)
    (fn [discovery]
      (let [pack (:opsv/experiment-pack discovery)
@@ -107,7 +66,7 @@
 
 (defn ^{:stratum 1} converge
   [ctx]
-  (preserve-anomaly
+  (flow/continue
    (phase-output ctx :opsv/execute)
    (fn [executed]
      (let [config (get-in executed
@@ -123,36 +82,22 @@
 
 (defn ^{:stratum 1} verify
   [ctx]
-  (preserve-anomaly
-   (phase-output ctx :opsv/synthesize)
-   (fn [synthesized]
-     (let [pack (:opsv/experiment-pack synthesized)
-           criteria (verification-criteria pack)
-           convergence (:opsv/convergence-result synthesized)
-           observations (get-in convergence [:state :selected-step :step/observations])
-           confidence-score (get-in convergence [:evaluation :confidence])
-           confidence-threshold (get-in pack [:experiment-pack/convergence
-                                              :confidence-threshold])
-           confidence (if (>= confidence-score confidence-threshold) :high :low)
-           verification (opsv/verify-policy criteria observations
-                                            evaluation/criterion-evaluation
-                                            confidence [])]
-       (if (anomaly/anomaly? verification)
-         verification
-         (let [summary (select-keys verification
-                                    [:passed? :confidence :caveats])
-               policy (assoc (:opsv/operational-policy synthesized)
-                             :operational-policy/verification-summary summary)
-               validated (opsv/validate-operational-policy policy)]
-           (if (anomaly/anomaly? validated)
-             validated
-             (assoc synthesized
-                    :opsv/verification-result verification
-                    :opsv/operational-policy validated
-                    :opsv/policy-hash (content-hash/content-hash validated)
-                    :opsv/metric-snapshot-artifact-refs
-                    (input-value ctx
-                                 :opsv/metric-snapshot-artifact-refs)))))))))
+  (flow/continue (phase-output ctx :opsv/synthesize)
+                 (partial verification/output ctx)))
+
+(defn ^{:stratum 1} synthesize
+  [ctx]
+  (flow/continue
+   (phase-output ctx :opsv/converge)
+   (fn [converged]
+     (let [proposal (policy/operational-policy
+                     ctx (:opsv/convergence-result converged))
+           validated (opsv/validate-operational-policy proposal)]
+       (if (anomaly/anomaly? validated)
+         validated
+         (assoc converged
+                :opsv/operational-policy validated
+                :opsv/policy-hash (content-hash/content-hash validated)))))))
 
 ;------------------------------------------------------------------------------ Layer 2
 
@@ -176,7 +121,7 @@
 
 (defn ^{:stratum 2} execute
   [ctx]
-  (preserve-anomaly
+  (flow/continue
    (phase-output ctx :opsv/plan)
    (fn [planned]
      (if-let [invalid (adapter/adapter-anomaly
@@ -193,17 +138,3 @@
                         {:opsv/environment-fingerprint
                          (:environment-fingerprint ramp)
                          :opsv/ramp-steps (:steps ramp)})))))))
-
-(defn ^{:stratum 2} synthesize
-  [ctx]
-  (preserve-anomaly
-   (phase-output ctx :opsv/converge)
-   (fn [converged]
-     (let [proposal (operational-policy
-                     ctx (:opsv/convergence-result converged))
-           validated (opsv/validate-operational-policy proposal)]
-       (if (anomaly/anomaly? validated)
-         validated
-         (assoc converged
-                :opsv/operational-policy validated
-                :opsv/policy-hash (content-hash/content-hash validated)))))))

--- a/components/phase-opsv/src/ai/miniforge/phase_opsv/policy.clj
+++ b/components/phase-opsv/src/ai/miniforge/phase_opsv/policy.clj
@@ -1,0 +1,48 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.phase-opsv.policy
+  "Construct an operational policy proposal from converged OPSV evidence.")
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} operational-policy
+  [ctx convergence]
+  (let [pack (get-in ctx [:execution/input :opsv/experiment-pack])
+        targets (:experiment-pack/targets pack)
+        evidence-refs (get-in ctx [:execution/input :opsv/evidence-refs])
+        selected-step (get-in convergence [:state :selected-step])
+        metrics (:step/metrics selected-step)]
+    {:operational-policy/id (str (:experiment-pack/id pack) "-policy")
+     :operational-policy/version "1.0.0"
+     :operational-policy/target-services (:services targets)
+     :operational-policy/target-envs (:environments targets)
+     :operational-policy/scaling
+     {:hpa {:api-version "autoscaling/v2"
+            :metric :cpu
+            :target-utilization (:hpa-target-utilization metrics)
+            :min-replicas (:min-replicas metrics)
+            :max-replicas (:max-replicas metrics)}
+      :keda {:trigger :backlog
+             :target (:keda-backlog-target metrics)}}
+     :operational-policy/resources
+     {:cpu-request-millicores (:cpu-request-millicores metrics)}
+     :operational-policy/guardrails (:experiment-pack/guardrails pack)
+     :operational-policy/verification-summary
+     {:passed? false :confidence :pending :caveats []}
+     :operational-policy/rollback-plan {:strategy :restore-previous-policy}
+     :operational-policy/evidence-refs evidence-refs}))

--- a/components/phase-opsv/src/ai/miniforge/phase_opsv/verification.clj
+++ b/components/phase-opsv/src/ai/miniforge/phase_opsv/verification.clj
@@ -1,0 +1,78 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.phase-opsv.verification
+  "Verify and attach OPSV operational policy evidence."
+  (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.content-hash.interface :as content-hash]
+   [ai.miniforge.opsv.interface :as opsv]
+   [ai.miniforge.phase-opsv.confidence :as confidence]
+   [ai.miniforge.phase-opsv.evaluation :as evaluation]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} criteria
+  [pack]
+  (let [declared (:experiment-pack/success-criteria pack)]
+    (if (contains? declared :criteria)
+      (:criteria declared)
+      (->> declared
+           (sort-by (comp str key))
+           (mapv (fn [[criterion-id expected]]
+                   {:criterion/id (name criterion-id)
+                    :criterion/expected expected}))))))
+
+(defn- ^{:stratum 0} attach-verification
+  [ctx synthesized verification]
+  (let [summary (select-keys verification [:passed? :confidence :caveats])
+        policy (assoc (:opsv/operational-policy synthesized)
+                      :operational-policy/verification-summary summary)
+        validated (opsv/validate-operational-policy policy)]
+    (if (anomaly/anomaly? validated)
+      validated
+      (assoc synthesized
+             :opsv/verification-result verification
+             :opsv/operational-policy validated
+             :opsv/policy-hash (content-hash/content-hash validated)
+             :opsv/metric-snapshot-artifact-refs
+             (get-in ctx [:execution/input
+                          :opsv/metric-snapshot-artifact-refs])))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} verify-policy
+  [pack convergence]
+  (let [observations (get-in convergence [:state :selected-step
+                                          :step/observations])
+        score (get-in convergence [:evaluation :confidence])
+        threshold (get-in pack [:experiment-pack/convergence
+                                :confidence-threshold])
+        confidence-level (confidence/level score threshold)]
+    (opsv/verify-policy (criteria pack) observations
+                        evaluation/criterion-evaluation confidence-level [])))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} output
+  [ctx synthesized]
+  (let [pack (:opsv/experiment-pack synthesized)
+        convergence (:opsv/convergence-result synthesized)
+        verification (verify-policy pack convergence)]
+    (if (anomaly/anomaly? verification)
+      verification
+      (attach-verification ctx synthesized verification))))

--- a/components/phase-opsv/test/ai/miniforge/phase_opsv/confidence_test.clj
+++ b/components/phase-opsv/test/ai/miniforge/phase_opsv/confidence_test.clj
@@ -1,0 +1,32 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.phase-opsv.confidence-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.phase-opsv.confidence :as confidence]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} test-confidence-level
+  (testing "numeric values use the inclusive threshold"
+    (is (= :high (confidence/level 0.8 0.8)))
+    (is (= :low (confidence/level 0.79 0.8))))
+  (testing "missing or non-numeric values degrade safely"
+    (is (= :low (confidence/level nil 0.8)))
+    (is (= :low (confidence/level 0.8 nil)))
+    (is (= :low (confidence/level :unknown 0.8)))))

--- a/components/phase-opsv/test/ai/miniforge/phase_opsv/test_support.clj
+++ b/components/phase-opsv/test/ai/miniforge/phase_opsv/test_support.clj
@@ -81,9 +81,9 @@
 (defn ^{:stratum 1} execution-context
   [adapter]
   {:execution/id #uuid "00000000-0000-0000-0000-000000000700"
+   :execution/opts {:opsv/adapter adapter}
    :execution/input
-   {:opsv/adapter adapter
-    :opsv/experiment-pack (:experiment-pack fixture)
+   {:opsv/experiment-pack (:experiment-pack fixture)
     :opsv/evidence-bundle-id evidence-id
     :opsv/evidence-refs [artifact-id]
     :opsv/gate-results (:gate-results fixture)

--- a/docs/pull-requests/2026-08-05-codex-n7-opsv-model-decomposition.md
+++ b/docs/pull-requests/2026-08-05-codex-n7-opsv-model-decomposition.md
@@ -37,9 +37,11 @@ Application transformation structure.
 
 ## Testing Plan
 
-- Run phase-OPSV tests in every composed project.
-- Run Poly structure, Clojure lint, stratum lint, and pre-commit gates.
-- Run the full Miniforge project test suite before merge.
+- Phase-OPSV tests pass in both composed projects (6 tests, 37 assertions).
+- All four commits passed Poly structure, staged Clojure lint, stratum lint,
+  smoke tests, and GraalVM compatibility gates.
+- The full Miniforge project test suite passes across all 87 bricks.
+- The Miniforge CLI uberjar builds successfully.
 
 ## Deployment Plan
 
@@ -48,10 +50,10 @@ outputs, anomaly behavior, and the default recommend-only posture.
 
 ## Checklist
 
-- [ ] Every implementation namespace uses at most three computed strata.
-- [ ] The seven public phase transformations preserve their contracts.
-- [ ] Runtime adapter precedence remains backward compatible.
-- [ ] No policy or verification map shape is duplicated in orchestration.
+- [x] Every implementation namespace uses at most three computed strata.
+- [x] The seven public phase transformations preserve their contracts.
+- [x] Runtime adapter precedence remains backward compatible.
+- [x] No policy or verification map shape is duplicated in orchestration.
 
 ## Follow-up
 

--- a/docs/pull-requests/2026-08-05-codex-n7-opsv-model-decomposition.md
+++ b/docs/pull-requests/2026-08-05-codex-n7-opsv-model-decomposition.md
@@ -1,0 +1,58 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor: decompose the OPSV phase model
+
+## Overview
+
+Decompose the OPSV application transformations into focused, stratified
+namespaces before adding domain event projection.
+
+## Motivation
+
+The phase model mixed anomaly continuation, policy construction, and
+verification inside long orchestration functions. Although the transformations
+were deterministic, that shape obscured the seven-step value flow and made
+future event projection harder to review safely.
+
+## Layer
+
+Application transformation structure.
+
+## Depends on
+
+- PR #1657 (OPSV lifecycle and workflow) — merged
+
+## Changes in Detail
+
+- Extract anomaly-preserving continuation into a focused leaf namespace.
+- Extract operational policy construction from phase orchestration.
+- Extract verification criteria, evaluation, and result attachment.
+- Centralize bounded confidence classification with nil/type-safe fallback.
+- Replace nested anonymous phase bodies with named transformation helpers.
+- Keep runtime adapter resolution opts-first with the existing input fallback.
+
+## Testing Plan
+
+- Run phase-OPSV tests in every composed project.
+- Run Poly structure, Clojure lint, stratum lint, and pre-commit gates.
+- Run the full Miniforge project test suite before merge.
+
+## Deployment Plan
+
+No deployment action is required. This refactor preserves phase inputs,
+outputs, anomaly behavior, and the default recommend-only posture.
+
+## Checklist
+
+- [ ] Every implementation namespace uses at most three computed strata.
+- [ ] The seven public phase transformations preserve their contracts.
+- [ ] Runtime adapter precedence remains backward compatible.
+- [ ] No policy or verification map shape is duplicated in orchestration.
+
+## Follow-up
+
+The next dependent PR projects and persists the required N3 OPSV events.


### PR DESCRIPTION
## Overview\n\nDecompose the OPSV application transformations into focused, stratified namespaces before adding N3 event projection.\n\n## Changes\n\n- extract anomaly-preserving continuation into a leaf namespace\n- extract the canonical operational-policy constructor\n- extract verification criteria, evaluation, and result attachment\n- centralize bounded confidence classification with nil/type-safe degradation\n- replace nested anonymous phase bodies with named value transformations\n- preserve runtime adapter precedence: execution opts first, legacy input fallback second\n\n## Miniforge standards audit\n\n- one application-transformation stratum; no domain or infrastructure dependency inversion\n- every changed implementation namespace has at most three computed strata\n- public phase functions are thin orchestration over named helpers\n- operational policy and verification maps each have one canonical construction site\n- no duplicated maps, raw operational messages, exception control flow, or mutable state\n- full diff reviewed adversarially after rebasing onto current main\n\n## Validation\n\n- PR budget: 331 / 600 reportable lines\n- changed-file clj-kondo: 0 errors, 0 warnings\n- changed-file stratum lint: 0 findings\n- Poly check: clean apart from four known repository baseline warnings\n- phase-opsv in miniforge: 6 tests, 37 assertions\n- phase-opsv in miniforge-tui: 6 tests, 37 assertions\n- pre-commit smoke: 339 tests, 1285 assertions\n- GraalVM compatibility: 8 tests, 602 assertions\n- full miniforge project: all 87 bricks pass\n- Miniforge CLI uberjar builds successfully\n\n## Dependency\n\nDepends on merged PR #1657. The next dependent slice adds and persists the required N3 OPSV events.