### PR TITLE
docs(specs): close N4 Annex A's signature items

### DIFF
--- a/docs/pull-requests/2026-08-06-claude-n4-annex-a-close-signature-items.md
+++ b/docs/pull-requests/2026-08-06-claude-n4-annex-a-close-signature-items.md
@@ -1,0 +1,54 @@
+# docs(specs): close N4 Annex A's signature items
+
+## Overview
+
+Annex A of N4 still reports pack signature verification as self-certifying and
+the canonical serialization as partial. Both were closed by
+[#1669](https://github.com/miniforge-ai/miniforge/pull/1669). This updates the
+annex to match, and names what actually remains.
+
+Informative annex only. No normative change.
+
+## Motivation
+
+PR #1658 (which introduced Annex A) and #1669 (which fixed what A.4 described)
+were open at the same time; #1658 landed first, so the annex reached `main`
+describing a vulnerability that was fixed hours later. A conformance annex that
+reports a closed security gap as open is worse than no annex — it is the
+document a reader consults to decide whether the implementation can be trusted.
+
+## Changes in Detail
+
+- **A.4** — self-certifying verification marked closed, with what replaced it
+  (identifier resolved against a configured trust-root store, shipped empty so
+  a deployment that configures nothing trusts nothing). Records the two
+  adjacent defects closed with it, and states what is still open: §8.2 steps 4
+  and 5, and that §5.1.8's gate rules carry no `:custom-fn`, so the verifier
+  has no caller outside its component. Correct, not yet reachable.
+- **A.3** — canonicalization rewritten for what `policy-pack/canonical-edn`
+  and `canonical-order` now do, replacing the "partial on determinism" note.
+- **Annex preamble** — a closed row says so and names the change rather than
+  being deleted; the annex is the record of what the gap was, not only of what
+  remains. Date moved to 2026-08-06.
+- **Version history** — one entry for this annex-only revision.
+
+## Testing Plan
+
+Documentation change to a single markdown file. `bb commit-budget` and the
+pre-commit gate cover it; CI runs the workspace checks.
+
+## Deployment Plan
+
+None — informative spec text.
+
+## Related Issues/PRs
+
+- [#1669](https://github.com/miniforge-ai/miniforge/pull/1669) — the implementation change this records
+- [#1658](https://github.com/miniforge-ai/miniforge/pull/1658) — N4 0.7.0-draft, which introduced Annex A
+
+## Checklist
+
+- [x] A.4 reads as closed and names what remains
+- [x] A.3 describes the current implementation
+- [x] No normative text touched
+- [x] Version history entry

--- a/docs/pull-requests/2026-08-06-claude-n4-annex-a-close-signature-items.md
+++ b/docs/pull-requests/2026-08-06-claude-n4-annex-a-close-signature-items.md
@@ -23,9 +23,10 @@ document a reader consults to decide whether the implementation can be trusted.
   (identifier resolved against a configured trust-root store, shipped empty so
   a deployment that configures nothing trusts nothing). Records the two
   adjacent defects closed with it, and states what is still open: §8.2 steps 4
-  and 5, and that the shipped pack's `:trust/*` rules carry no `:custom-fn`,
-  so the verifier has no caller outside its component. Correct, not yet
-  reachable.
+  and 5, and that the shipped pack's `:trust/*` rules bind to `:semantic`
+  (LLM-as-judge) rather than to a `:custom-fn` over the verifier. They run;
+  they just never call `verify-signature`, which has no caller outside its
+  component.
 - **A.4, second entry** — a divergence the review surfaced: §5.1.8 names the
   pack-trust rules `require-signature-verification` /
   `enforce-publisher-allowlist` / `enforce-minimum-trust-level`, while the
@@ -38,6 +39,12 @@ document a reader consults to decide whether the implementation can be trusted.
   being deleted; the annex is the record of what the gap was, not only of what
   remains. Date moved to 2026-08-06.
 - **Version history** — one entry for this annex-only revision.
+
+A first draft of A.4 said the `:trust/*` rules "do not run" because they carry
+no `:custom-fn`. Review corrected it: `compiler/resolve-detector` binds a
+`:custom` rule with no `:custom-fn` to `:semantic`, so they run under the
+LLM judge. The gap is narrower and more specific than "unwired" — a model
+judging whether a pack looks signed is not a signature check.
 
 ## Testing Plan
 

--- a/docs/pull-requests/2026-08-06-claude-n4-annex-a-close-signature-items.md
+++ b/docs/pull-requests/2026-08-06-claude-n4-annex-a-close-signature-items.md
@@ -41,8 +41,8 @@ document a reader consults to decide whether the implementation can be trusted.
 
 ## Testing Plan
 
-Documentation change to a single markdown file. `bb commit-budget` and the
-pre-commit gate cover it; CI runs the workspace checks.
+Two markdown files, no code: the N4 annex and this write-up. `bb commit-budget`
+and the pre-commit gate cover them; CI runs the workspace checks.
 
 ## Deployment Plan
 

--- a/docs/pull-requests/2026-08-06-claude-n4-annex-a-close-signature-items.md
+++ b/docs/pull-requests/2026-08-06-claude-n4-annex-a-close-signature-items.md
@@ -23,8 +23,15 @@ document a reader consults to decide whether the implementation can be trusted.
   (identifier resolved against a configured trust-root store, shipped empty so
   a deployment that configures nothing trusts nothing). Records the two
   adjacent defects closed with it, and states what is still open: §8.2 steps 4
-  and 5, and that §5.1.8's gate rules carry no `:custom-fn`, so the verifier
-  has no caller outside its component. Correct, not yet reachable.
+  and 5, and that the shipped pack's `:trust/*` rules carry no `:custom-fn`,
+  so the verifier has no caller outside its component. Correct, not yet
+  reachable.
+- **A.4, second entry** — a divergence the review surfaced: §5.1.8 names the
+  pack-trust rules `require-signature-verification` /
+  `enforce-publisher-allowlist` / `enforce-minimum-trust-level`, while the
+  shipped pack declares `:trust/require-signature` /
+  `:trust/publisher-allowlist` / `:trust/minimum-trust-level`. §1.1 makes rule
+  IDs the durable anchor, so the two should agree.
 - **A.3** — canonicalization rewritten for what `policy-pack/canonical-edn`
   and `canonical-order` now do, replacing the "partial on determinism" note.
 - **Annex preamble** — a closed row says so and names the change rather than

--- a/specs/normative/N4-policy-packs.md
+++ b/specs/normative/N4-policy-packs.md
@@ -2084,10 +2084,18 @@ contract the code already satisfies:
   **Still open.** §8.2 steps 4 and 5 — checking the signature timestamp
   against a key validity window, and confirming the publisher is permitted for
   the pack (§5.1.8) — are unimplemented. So is the gate that would call any of
-  this: §5.1.8's `require-signature-verification` and
-  `enforce-publisher-allowlist` are declared with `:rule/detection
-  {:type :custom}` and no `:custom-fn`, so `verify-signature` has no caller
-  outside its component. The verifier is correct; it is not yet reachable.
+  this. The shipped `miniforge/pack-trust` pack declares its three rules —
+  `:trust/require-signature`, `:trust/publisher-allowlist`, and
+  `:trust/minimum-trust-level` — with `:rule/detection {:type :custom}` and no
+  `:custom-fn`, so none of them runs and `verify-signature` has no caller
+  outside its own component. The verifier is correct; it is not yet reachable.
+
+- **Pack-trust rule naming (§5.1.8).** §5.1.8 lists that pack's rules as
+  `require-signature-verification`, `enforce-publisher-allowlist`, and
+  `enforce-minimum-trust-level`. The shipped pack uses the `:trust/*` IDs
+  above. Since §1.1 makes rule IDs the durable anchor, the two should agree —
+  a reader matching §5.1.8 against the pack finds neither set of names in the
+  other.
 
 ### A.5 Structural
 
@@ -2108,7 +2116,9 @@ contract the code already satisfies:
 - 0.7.0-draft (2026-08-06): Annex A only, no normative change. A.4's
   self-certifying verification and A.3's canonicalization gap are closed by
   PR #1669 and now read as closed, naming what remains: §8.2 steps 4 and 5,
-  and the §5.1.8 gate that would call the verifier at all.
+  and the §5.1.8 gate that would call the verifier at all. Records a new
+  divergence — §5.1.8's rule names and the shipped pack's `:trust/*` rule IDs
+  do not match.
 - 0.7.0-draft (2026-08-05): Spec-completion pass.
   **Contract fixes:** one severity vocabulary — §2.3.1 rewritten from
   `:error`/`:warning`/`:info` to the canonical `:critical :high :medium :low

--- a/specs/normative/N4-policy-packs.md
+++ b/specs/normative/N4-policy-packs.md
@@ -2092,9 +2092,9 @@ contract the code already satisfies:
   `:custom-fn`. Per `policy-pack/compiler/resolve-detector`, a `:custom` rule
   with no `:custom-fn` binds to `:semantic`, the LLM-as-judge mechanism. The
   rules therefore do compile and do run; what they do not do is call
-  `verify-signature`. That fn has no caller anywhere in the workspace and is
-  not among the names `policy-pack.interface.registry` exports, so no code
-  outside the component can reach it at all.
+  `verify-signature`. Its only callers are the policy-pack component's own
+  tests, and it is not among the names `policy-pack.interface.registry`
+  exports, so no production code outside the component can reach it at all.
 
   A model judging whether a pack looks signed is not a signature check.
   `:trust/require-signature` in particular asserts a cryptographic property

--- a/specs/normative/N4-policy-packs.md
+++ b/specs/normative/N4-policy-packs.md
@@ -2083,12 +2083,21 @@ contract the code already satisfies:
 
   **Still open.** §8.2 steps 4 and 5 — checking the signature timestamp
   against a key validity window, and confirming the publisher is permitted for
-  the pack (§5.1.8) — are unimplemented. So is the gate that would call any of
-  this. The shipped `miniforge/pack-trust` pack declares its three rules —
+  the pack (§5.1.8) — are unimplemented.
+
+  So is the path from the pack-trust gate to the verifier. The shipped
+  `miniforge/pack-trust` pack declares its three rules —
   `:trust/require-signature`, `:trust/publisher-allowlist`, and
   `:trust/minimum-trust-level` — with `:rule/detection {:type :custom}` and no
-  `:custom-fn`, so none of them runs and `verify-signature` has no caller
-  outside its own component. The verifier is correct; it is not yet reachable.
+  `:custom-fn`. Per `policy-pack/compiler/resolve-detector`, a `:custom` rule
+  with no `:custom-fn` binds to `:semantic`, the LLM-as-judge mechanism. The
+  rules therefore do compile and do run; what they do not do is call
+  `verify-signature`, which has no caller outside its own component.
+
+  A model judging whether a pack looks signed is not a signature check.
+  `:trust/require-signature` in particular asserts a cryptographic property
+  and should bind to a `:custom-fn` over the verifier, not to `:semantic`.
+  Until it does, the verifier is correct and unreached.
 
 - **Pack-trust rule naming (§5.1.8).** §5.1.8 lists that pack's rules as
   `require-signature-verification`, `enforce-publisher-allowlist`, and

--- a/specs/normative/N4-policy-packs.md
+++ b/specs/normative/N4-policy-packs.md
@@ -2092,7 +2092,9 @@ contract the code already satisfies:
   `:custom-fn`. Per `policy-pack/compiler/resolve-detector`, a `:custom` rule
   with no `:custom-fn` binds to `:semantic`, the LLM-as-judge mechanism. The
   rules therefore do compile and do run; what they do not do is call
-  `verify-signature`, which has no caller outside its own component.
+  `verify-signature`. That fn has no caller anywhere in the workspace and is
+  not among the names `policy-pack.interface.registry` exports, so no code
+  outside the component can reach it at all.
 
   A model judging whether a pack looks signed is not a signature check.
   `:trust/require-signature` in particular asserts a cryptographic property

--- a/specs/normative/N4-policy-packs.md
+++ b/specs/normative/N4-policy-packs.md
@@ -2001,11 +2001,13 @@ Research directions:
 ## Annex A — Implementation Conformance Status (informative)
 
 This annex is **informative**. It records where the miniforge implementation
-currently diverges from the contract above, as of 2026-08-05. It is not a
+currently diverges from the contract above, as of 2026-08-06. It is not a
 relaxation of any requirement in §1–§14: the spec is normative and the
 implementation conforms to it, not the reverse.
 
-Each row is work, not an exemption.
+Each row is work, not an exemption. A row that has been closed says so and
+names the change, rather than being deleted — the annex is the record of what
+the gap was, not only of what remains.
 
 ### A.1 Type Divergences
 
@@ -2043,45 +2045,49 @@ vocabulary was the outlier, and this revision withdraws it.
 Recorded because they were previously unspecified and this revision writes the
 contract the code already satisfies:
 
-- **Signature canonicalization (§8.1.1).** `policy-pack/crypto/pack-signable-bytes`
-  already dissocs the signature fields, sorts keys via `(into (sorted-map) …)`,
-  and serializes `pr-str` as UTF-8 — the broad shape §8.1.1 now specifies.
+- **Signature canonicalization (§8.1.1).** `policy-pack/canonical-edn` renders
+  the §8.1.1 rules directly rather than deferring to `pr-str`: recursive map
+  key ordering, sets as sorted vectors, sequences in declared order, instants
+  as millisecond-precision UTC, and single-space separation, with the
+  comparator in `policy-pack/canonical-order`. A value with no EDN reader form
+  — a live `:rule/check-fn` rather than the symbol §8.1.1 requires — throws
+  rather than serializing an identity hash.
 
-  **Partial on determinism.** Two §8.1.1 rendering rules are unimplemented,
-  and both are reachable today:
-
-  - _Recursive map ordering._ `(into (sorted-map) …)` orders the top-level map
-    only. Nested maps — `:pack/metadata`, each rule map — keep the host's
-    ordering, which is insertion order for small maps and hash order above the
-    array-map threshold.
-  - _Set normalization._ `pr-str` renders a set in iteration order. §8.1.1
-    requires sets to render as a sorted vector, because set iteration order is
-    not defined.
-
-  Either can make the same pack serialize to different bytes on different runs
-  or different hosts, so a signature valid on one machine fails on another.
-  This is a signature interoperability bug, not merely an unimplemented
-  requirement, and it is why §8.1.1 states the rendering rather than deferring
-  to `pr-str`.
+  The earlier `(pr-str (into (sorted-map) …))` sorted the top level only, left
+  sets in iteration order, and printed a `java.time.Instant` with an identity
+  hash, so the same pack could serialize to different bytes across runs. That
+  interoperability bug is closed (PR #1669); signatures produced against the
+  old bytes do not verify, and none could reliably have.
 - **Legacy severity normalization (§2.3.1).** `schema/normalize-severity`
   already exists for `:major` → `:high` and `:minor` → `:low`; §2.3.1 adds
   `:error` → `:high` and `:warning` → `:medium` on the same seam.
 
 ### A.4 Security
 
-- **Self-certifying signature verification.**
-  `policy-pack/registry.clj`'s `verify-signature` reads the verification key
-  from the pack being verified — `pub-key-str (:pack/signed-by pack)`, base64
-  decoded and passed straight to `verify-ed25519`. §8.2.1 forbids this, and
-  §8.1 now types `:pack/signed-by` as a key identifier rather than a key.
+- **Self-certifying signature verification — closed (PR #1669).**
+  `verify-signature` previously read the verification key from the pack being
+  verified, so an attacker could modify a pack, sign it with their own key,
+  write that public key into `:pack/signed-by`, and pass.
 
-  As implemented, signature verification establishes only that the pack was
-  signed by whoever holds the key the pack itself names. An attacker who
-  modifies a pack signs it with their own key, writes that public key into
-  `:pack/signed-by`, and verification passes. There is no configured trust
-  root to resolve against.
+  It now resolves `:pack/signed-by` as a key identifier against a configured
+  trust-root store and fails when it resolves to nothing (§8.2.1). The store
+  loads from `config/policy-pack/trust-roots.edn` on the classpath overlaid
+  with `~/.miniforge/config.edn` under `[:policy-pack :trust-roots]`; the
+  shipped resource is empty, so a deployment that configures nothing trusts
+  nothing.
 
-  This is the highest-priority item in this annex.
+  Two adjacent defects closed with it: `verify-ed25519` could not decode the
+  RFC 8032 raw public-key encoding at all (it read the bytes big-endian and
+  took x as always even), and the canonical serialization was not
+  reproducible — see A.3.
+
+  **Still open.** §8.2 steps 4 and 5 — checking the signature timestamp
+  against a key validity window, and confirming the publisher is permitted for
+  the pack (§5.1.8) — are unimplemented. So is the gate that would call any of
+  this: §5.1.8's `require-signature-verification` and
+  `enforce-publisher-allowlist` are declared with `:rule/detection
+  {:type :custom}` and no `:custom-fn`, so `verify-signature` has no caller
+  outside its component. The verifier is correct; it is not yet reachable.
 
 ### A.5 Structural
 
@@ -2099,6 +2105,10 @@ contract the code already satisfies:
 
 **Version History:**
 
+- 0.7.0-draft (2026-08-06): Annex A only, no normative change. A.4's
+  self-certifying verification and A.3's canonicalization gap are closed by
+  PR #1669 and now read as closed, naming what remains: §8.2 steps 4 and 5,
+  and the §5.1.8 gate that would call the verifier at all.
 - 0.7.0-draft (2026-08-05): Spec-completion pass.
   **Contract fixes:** one severity vocabulary — §2.3.1 rewritten from
   `:error`/`:warning`/`:info` to the canonical `:critical :high :medium :low


### PR DESCRIPTION
Follow-up to #1669, which that PR named as owed once #1658 landed.

Annex A of N4 still reports pack signature verification as self-certifying (A.4) and the canonical serialization as partial (A.3). #1669 closed both. #1658 introduced the annex and landed first, so `main` carries an annex describing a vulnerability that was fixed hours later — and that annex is the document a reader consults to decide whether the implementation can be trusted.

Informative annex only. No normative text touched.

## Changes

- **A.4** reads as closed and says what replaced it: `:pack/signed-by` resolved as a key identifier against a configured trust-root store that ships empty, so a deployment that configures nothing trusts nothing. Records the two adjacent defects closed with it (RFC 8032 raw key decoding, non-reproducible canonical bytes).

  It also names what is **still open**, which #1669 did not close:
  - §8.2 steps 4 and 5 — signature timestamp against a key validity window, and publisher permitted for the pack (§5.1.8).
  - The gate that would call any of it. §5.1.8's `require-signature-verification` and `enforce-publisher-allowlist` are declared with `:rule/detection {:type :custom}` and no `:custom-fn`, so `verify-signature` has no caller outside its component. The verifier is correct; it is not yet reachable.

- **A.3** describes what `policy-pack/canonical-edn` and `canonical-order` now do, replacing the "partial on determinism" note.

- **Annex preamble** — a closed row says so and names the change rather than being deleted. The annex is the record of what the gap was, not only of what remains. Date to 2026-08-06.

- **Version history** — one entry for this annex-only revision.

Full write-up: [docs/pull-requests/2026-08-06-claude-n4-annex-a-close-signature-items.md](docs/pull-requests/2026-08-06-claude-n4-annex-a-close-signature-items.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
