### PR TITLE
feat: project OPSV lifecycle events

### DIFF
--- a/components/event-stream/deps.edn
+++ b/components/event-stream/deps.edn
@@ -7,6 +7,7 @@
         ai.miniforge/schema {:local/root "../schema"}
         cheshire/cheshire {:mvn/version "5.13.0"}
         com.cognitect/transit-clj {:mvn/version "1.0.333"}
+        metosin/malli {:mvn/version "0.16.4"}
         slingshot/slingshot {:mvn/version "0.12.2"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {io.github.cognitect-labs/test-runner

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/opsv.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/opsv.clj
@@ -18,6 +18,7 @@
 (ns ai.miniforge.event-stream.interface.opsv
   "Public schemas and constructors for the N3 OPSV event family."
   (:require
+   [malli.core :as m]
    [ai.miniforge.event-stream.opsv :as opsv]
    [ai.miniforge.event-stream.schema.opsv :as schema]))
 
@@ -90,3 +91,16 @@
 (def ^{:stratum 0} drift-detected
   "Construct a drift-detected event."
   opsv/drift-detected)
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} OPSVEvent
+  (into [:or] [ExperimentPlanned ExperimentStarted LoadStep GuardrailAbort
+               ConvergenceIteration PolicyProposed VerificationResult
+               ActuationEmitted DriftDetected]))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} explain-invalid-event
+  [event]
+  (m/explain OPSVEvent event))

--- a/components/phase-opsv/deps.edn
+++ b/components/phase-opsv/deps.edn
@@ -2,6 +2,7 @@
  :deps {ai.miniforge/anomaly {:local/root "../anomaly"}
         ai.miniforge/content-hash {:local/root "../content-hash"}
         ai.miniforge/evidence-bundle {:local/root "../evidence-bundle"}
+        ai.miniforge/event-stream {:local/root "../event-stream"}
         ai.miniforge/messages {:local/root "../messages"}
         ai.miniforge/opsv {:local/root "../opsv"}
         ai.miniforge/phase {:local/root "../phase"}}

--- a/components/phase-opsv/resources/config/phase-opsv/messages/system.edn
+++ b/components/phase-opsv/resources/config/phase-opsv/messages/system.edn
@@ -5,4 +5,5 @@
   :adapter/missing-fingerprint "The OPSV adapter returned no environment fingerprint."
   :evidence/assembly-mismatch "The OPSV evidence identifier has no matching workflow assembly."
   :evidence/accumulation-failed "The OPSV event reference could not be added to evidence."
+  :event/invalid "The projected OPSV event does not satisfy its N3 schema."
   :event/publication-failed "The OPSV event stream rejected a domain event."}}

--- a/components/phase-opsv/resources/config/phase-opsv/messages/system.edn
+++ b/components/phase-opsv/resources/config/phase-opsv/messages/system.edn
@@ -3,4 +3,6 @@
   :adapter/invalid-result "The OPSV adapter returned an invalid result shape."
   :adapter/empty-ramp "The OPSV adapter returned no guarded ramp observations."
   :adapter/missing-fingerprint "The OPSV adapter returned no environment fingerprint."
-  :evidence/assembly-mismatch "The OPSV evidence identifier has no matching workflow assembly."}}
+  :evidence/assembly-mismatch "The OPSV evidence identifier has no matching workflow assembly."
+  :evidence/accumulation-failed "The OPSV event reference could not be added to evidence."
+  :event/publication-failed "The OPSV event stream rejected a domain event."}}

--- a/components/phase-opsv/src/ai/miniforge/phase_opsv/event_projection.clj
+++ b/components/phase-opsv/src/ai/miniforge/phase_opsv/event_projection.clj
@@ -1,0 +1,114 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.phase-opsv.event-projection
+  "Construct N3 events for successful OPSV phase outputs."
+  (:require
+   [ai.miniforge.event-stream.interface :as event-stream]
+   [ai.miniforge.phase-opsv.confidence :as confidence]
+   [ai.miniforge.phase-opsv.load-events :as load-events]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} policy-confidence
+  [output]
+  (confidence/level
+   (get-in output [:opsv/convergence-result :evaluation :confidence])
+   (get-in output [:opsv/experiment-pack
+                   :experiment-pack/convergence
+                   :confidence-threshold])))
+
+(defn- ^{:stratum 0} convergence-event
+  [stream workflow-id evidence-id index step]
+  (event-stream/convergence-iteration
+   stream workflow-id evidence-id
+   {:opsv/iteration-id (str (inc index))
+    :opsv/params (:step/intended-load step)
+    :opsv/observed-metrics-summary (:step/metrics step)}))
+
+(defn- ^{:stratum 0} planned-events
+  [stream workflow-id evidence-id output]
+  [(event-stream/experiment-planned
+    stream workflow-id evidence-id
+    {:opsv/experiment-pack-hash (:opsv/experiment-pack-hash output)
+     :opsv/targets (get-in output [:opsv/experiment-pack
+                                   :experiment-pack/targets])
+     :opsv/risk-score (:opsv/risk-result output)})])
+
+(defn- ^{:stratum 0} execution-events
+  [stream workflow-id evidence-id output]
+  (let [started (event-stream/experiment-started
+                 stream workflow-id evidence-id
+                 {:opsv/experiment-pack-hash
+                  (:opsv/experiment-pack-hash output)
+                  :opsv/environment-fingerprint
+                  (:opsv/environment-fingerprint output)})]
+    (into [started]
+          (load-events/project stream workflow-id evidence-id
+                               (:opsv/ramp-steps output)))))
+
+(defn- ^{:stratum 0} verification-events
+  [stream workflow-id evidence-id output]
+  (let [verification (:opsv/verification-result output)]
+    [(event-stream/verification-result
+      stream workflow-id evidence-id
+      {:opsv/passed? (:passed? verification)
+       :opsv/criteria-evaluation (:criteria-evaluation verification)
+       :opsv/confidence (:confidence verification)
+       :opsv/caveats (:caveats verification)})]))
+
+(defn- ^{:stratum 0} actuation-events
+  [stream workflow-id evidence-id output]
+  (let [actuation (:opsv/actuation-record output)]
+    [(event-stream/actuation-emitted
+      stream workflow-id evidence-id
+      {:opsv/requested-actuation-mode (:requested-actuation-mode actuation)
+       :opsv/effective-actuation-mode (:effective-actuation-mode actuation)
+       :opsv/governed-effects (:governed-effects actuation)
+       :opsv/pr-refs (:pr-refs actuation)
+       :opsv/apply-refs (:apply-refs actuation)})]))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} convergence-events
+  [stream workflow-id evidence-id output]
+  (let [history (get-in output [:opsv/convergence-result :state :history])]
+    (map-indexed (partial convergence-event stream workflow-id evidence-id)
+                 history)))
+
+(defn- ^{:stratum 1} policy-events
+  [stream workflow-id evidence-id ctx output]
+  [(event-stream/policy-proposed
+    stream workflow-id evidence-id
+    {:opsv/policy-hash (:opsv/policy-hash output)
+     :opsv/diff-artifact-refs
+     (get-in ctx [:execution/input :opsv/policy-diff-artifact-refs] [])
+     :opsv/confidence (policy-confidence output)})])
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} phase-events
+  [stream workflow-id evidence-id ctx phase-key output]
+  (case phase-key
+    :opsv/discover []
+    :opsv/plan (planned-events stream workflow-id evidence-id output)
+    :opsv/execute (execution-events stream workflow-id evidence-id output)
+    :opsv/converge (convergence-events stream workflow-id evidence-id output)
+    :opsv/synthesize (policy-events stream workflow-id evidence-id ctx output)
+    :opsv/verify (verification-events stream workflow-id evidence-id output)
+    :opsv/actuate (actuation-events stream workflow-id evidence-id output)
+    []))

--- a/components/phase-opsv/src/ai/miniforge/phase_opsv/events.clj
+++ b/components/phase-opsv/src/ai/miniforge/phase_opsv/events.clj
@@ -18,9 +18,11 @@
 (ns ai.miniforge.phase-opsv.events
   "Publish projected N3 events at successful OPSV phase boundaries."
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.evidence-bundle.interface :as evidence]
    [ai.miniforge.event-stream.interface :as event-stream]
-   [ai.miniforge.phase-opsv.event-projection :as projection]))
+   [ai.miniforge.phase-opsv.event-projection :as projection]
+   [ai.miniforge.phase-opsv.messages :as msg]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -38,17 +40,48 @@
   [ctx]
   (get-in ctx [:execution/input :opsv/evidence-bundle-id]))
 
+(defn- ^{:stratum 0} publication-anomaly
+  [event published]
+  (cond
+    (anomaly/anomaly? published) published
+    (anomaly/any-anomaly? published)
+    (anomaly/anomaly :unavailable
+                     (msg/ts :event/publication-failed)
+                     {:event/id (:event/id event)
+                      :event/type (:event/type event)
+                      :event-stream/result published})
+    (= (:event/id event) (:event/id published)) nil
+    :else (anomaly/anomaly
+           :conflict
+           (msg/ts :event/publication-failed)
+           {:event/id (:event/id event)
+            :event/type (:event/type event)
+            :event-stream/result published})))
+
+(defn- ^{:stratum 0} evidence-anomaly
+  [event assembly]
+  (cond
+    (anomaly/anomaly? assembly) assembly
+    (anomaly/any-anomaly? assembly)
+    (anomaly/anomaly :fault
+                     (msg/ts :evidence/accumulation-failed)
+                     {:event/id (:event/id event)
+                      :event/type (:event/type event)
+                      :evidence/result assembly})))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn- ^{:stratum 1} publish-event!
   [ctx stream-value event]
   (let [published (event-stream/publish! stream-value event)
         store (:opsv/evidence-assembly-store ctx)
-        published? (= (:event/id event) (:event/id published))]
-    (when (and published? store)
-      (evidence/accumulate-opsv-evidence!
-       store (evidence-id ctx)
-       {:opsv/event-refs [(:event/id event)]}))))
+        failure (publication-anomaly event published)]
+    (cond
+      failure failure
+      store (let [assembly (evidence/accumulate-opsv-evidence!
+                            store (evidence-id ctx)
+                            {:opsv/event-refs [(:event/id event)]})]
+              (evidence-anomaly event assembly)))))
 
 ;------------------------------------------------------------------------------ Layer 2
 
@@ -58,4 +91,9 @@
     (let [events (projection/phase-events
                   stream-value (workflow-id ctx) (evidence-id ctx)
                   ctx phase-key output)]
-      (run! (partial publish-event! ctx stream-value) events))))
+      (reduce (fn [result event]
+                (if (anomaly/anomaly? result)
+                  (reduced result)
+                  (publish-event! ctx stream-value event)))
+              nil
+              events))))

--- a/components/phase-opsv/src/ai/miniforge/phase_opsv/events.clj
+++ b/components/phase-opsv/src/ai/miniforge/phase_opsv/events.clj
@@ -45,6 +45,12 @@
   [event published]
   (cond
     (anomaly/anomaly? published) published
+    (:rejected? published)
+    (anomaly/anomaly :unavailable
+                     (msg/ts :event/publication-failed)
+                     {:event/id (:event/id event)
+                      :event/type (:event/type event)
+                      :event-stream/result published})
     (anomaly/any-anomaly? published)
     (anomaly/anomaly :unavailable
                      (msg/ts :event/publication-failed)

--- a/components/phase-opsv/src/ai/miniforge/phase_opsv/events.clj
+++ b/components/phase-opsv/src/ai/miniforge/phase_opsv/events.clj
@@ -1,0 +1,61 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.phase-opsv.events
+  "Publish projected N3 events at successful OPSV phase boundaries."
+  (:require
+   [ai.miniforge.evidence-bundle.interface :as evidence]
+   [ai.miniforge.event-stream.interface :as event-stream]
+   [ai.miniforge.phase-opsv.event-projection :as projection]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} stream
+  [ctx]
+  (or (:event-stream ctx)
+      (:execution/event-stream ctx)
+      (get-in ctx [:execution/opts :event-stream])))
+
+(defn- ^{:stratum 0} workflow-id
+  [ctx]
+  (or (:execution/id ctx) (:workflow/id ctx) (:workflow-id ctx)))
+
+(defn- ^{:stratum 0} evidence-id
+  [ctx]
+  (get-in ctx [:execution/input :opsv/evidence-bundle-id]))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} publish-event!
+  [ctx stream-value event]
+  (let [published (event-stream/publish! stream-value event)
+        store (:opsv/evidence-assembly-store ctx)
+        published? (= (:event/id event) (:event/id published))]
+    (when (and published? store)
+      (evidence/accumulate-opsv-evidence!
+       store (evidence-id ctx)
+       {:opsv/event-refs [(:event/id event)]}))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} emit-phase-events!
+  [ctx phase-key output]
+  (when-let [stream-value (stream ctx)]
+    (let [events (projection/phase-events
+                  stream-value (workflow-id ctx) (evidence-id ctx)
+                  ctx phase-key output)]
+      (run! (partial publish-event! ctx stream-value) events))))

--- a/components/phase-opsv/src/ai/miniforge/phase_opsv/events.clj
+++ b/components/phase-opsv/src/ai/miniforge/phase_opsv/events.clj
@@ -21,6 +21,7 @@
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.evidence-bundle.interface :as evidence]
    [ai.miniforge.event-stream.interface :as event-stream]
+   [ai.miniforge.event-stream.interface.opsv :as opsv-event]
    [ai.miniforge.phase-opsv.event-projection :as projection]
    [ai.miniforge.phase-opsv.messages :as msg]))
 
@@ -69,6 +70,12 @@
                       :event/type (:event/type event)
                       :evidence/result assembly})))
 
+(defn- ^{:stratum 0} validation-anomaly
+  [event]
+  (when-let [explanation (opsv-event/explain-invalid-event event)]
+    (anomaly/validation-anomaly
+     (msg/ts :event/invalid) :opsv/event event explanation)))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn- ^{:stratum 1} publish-event!
@@ -94,6 +101,8 @@
       (reduce (fn [result event]
                 (if (anomaly/anomaly? result)
                   (reduced result)
-                  (publish-event! ctx stream-value event)))
+                  (if-let [invalid (validation-anomaly event)]
+                    (reduced invalid)
+                    (publish-event! ctx stream-value event))))
               nil
               events))))

--- a/components/phase-opsv/src/ai/miniforge/phase_opsv/lifecycle.clj
+++ b/components/phase-opsv/src/ai/miniforge/phase_opsv/lifecycle.clj
@@ -43,19 +43,28 @@
           (not runtime-supplied?)
           (assoc-in [:execution/opts :opsv/adapter] adapter))))))
 
-(defn- ^{:stratum 0} leave-phase
+(defn- ^{:stratum 0} result-after-publication
+  [ctx phase-key result]
+  (if-not (phase/result-succeeded? result)
+    result
+    (let [published (events/emit-phase-events! ctx phase-key (:output result))]
+      (if (anomaly/anomaly? published)
+        (lifecycle-result/phase-result published)
+        result))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} leave-phase
   [ctx]
   (let [phase-key (get-in ctx [:phase :name])
-        result (get-in ctx [:phase :result])
+        result (result-after-publication
+                ctx phase-key (get-in ctx [:phase :result]))
+        completed-ctx (assoc-in ctx [:phase :result] result)
         success? (phase/result-succeeded? result)
         end-time (System/currentTimeMillis)
         duration-ms (- end-time (get-in ctx [:phase :started-at]))]
-    (when success?
-      (events/emit-phase-events! ctx phase-key (:output result)))
-    (lifecycle-result/complete-phase ctx phase-key success? end-time
+    (lifecycle-result/complete-phase completed-ctx phase-key success? end-time
                                      duration-ms)))
-
-;------------------------------------------------------------------------------ Layer 1
 
 (defn- ^{:stratum 1} enter-phase
   [phase-key transform config ctx]

--- a/components/phase-opsv/src/ai/miniforge/phase_opsv/lifecycle.clj
+++ b/components/phase-opsv/src/ai/miniforge/phase_opsv/lifecycle.clj
@@ -21,6 +21,7 @@
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.phase-opsv.evidence-runtime :as evidence-runtime]
+   [ai.miniforge.phase-opsv.events :as events]
    [ai.miniforge.phase-opsv.lifecycle-result :as lifecycle-result]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -49,6 +50,8 @@
         success? (phase/result-succeeded? result)
         end-time (System/currentTimeMillis)
         duration-ms (- end-time (get-in ctx [:phase :started-at]))]
+    (when success?
+      (events/emit-phase-events! ctx phase-key (:output result)))
     (lifecycle-result/complete-phase ctx phase-key success? end-time
                                      duration-ms)))
 

--- a/components/phase-opsv/src/ai/miniforge/phase_opsv/load_events.clj
+++ b/components/phase-opsv/src/ai/miniforge/phase_opsv/load_events.clj
@@ -37,7 +37,7 @@
      stream workflow-id evidence-id
      {:opsv/trigger (get abort-data :trigger :guardrail)
       :opsv/threshold (get abort-data :threshold {})
-      :opsv/observed (get abort-data :observed (:step/observations step))
+      :opsv/observed (or (:observed abort-data) (:step/observations step) {})
       :opsv/rollback-action (get abort-data :rollback-action
                                  :restore-previous-policy)})))
 

--- a/components/phase-opsv/src/ai/miniforge/phase_opsv/load_events.clj
+++ b/components/phase-opsv/src/ai/miniforge/phase_opsv/load_events.clj
@@ -1,0 +1,58 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.phase-opsv.load-events
+  "Construct N3 events for guarded OPSV load steps."
+  (:require
+   [ai.miniforge.event-stream.interface :as event-stream]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} load-step-event
+  [stream workflow-id evidence-id step]
+  (event-stream/load-step
+   stream workflow-id evidence-id
+   {:opsv/step-id (:step/id step)
+    :opsv/intended-load (:step/intended-load step)
+    :opsv/observed-load (:step/observed-load step)}))
+
+(defn- ^{:stratum 0} guardrail-abort-event
+  [stream workflow-id evidence-id step]
+  (let [abort-data (:step/guardrail-abort step)]
+    (event-stream/guardrail-abort
+     stream workflow-id evidence-id
+     {:opsv/trigger (get abort-data :trigger :guardrail)
+      :opsv/threshold (get abort-data :threshold {})
+      :opsv/observed (get abort-data :observed (:step/observations step))
+      :opsv/rollback-action (get abort-data :rollback-action
+                                 :restore-previous-policy)})))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} events-for-step
+  [stream workflow-id evidence-id step]
+  (let [load-event (load-step-event stream workflow-id evidence-id step)
+        abort? (true? (get-in step [:step/metrics :guardrail-abort?]))]
+    (cond-> [load-event]
+      abort? (conj (guardrail-abort-event stream workflow-id evidence-id
+                                          step)))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} project
+  [stream workflow-id evidence-id steps]
+  (mapcat (partial events-for-step stream workflow-id evidence-id) steps))

--- a/components/phase-opsv/test/ai/miniforge/phase_opsv/events_test.clj
+++ b/components/phase-opsv/test/ai/miniforge/phase_opsv/events_test.clj
@@ -18,8 +18,11 @@
 (ns ai.miniforge.phase-opsv.events-test
   (:require
    [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.evidence-bundle.interface :as evidence]
    [ai.miniforge.event-stream.interface :as event-stream]
-   [ai.miniforge.phase-opsv.events :as events]))
+   [ai.miniforge.phase-opsv.events :as events]
+   [ai.miniforge.phase-opsv.lifecycle :as lifecycle]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -29,7 +32,22 @@
    :execution/input {:opsv/evidence-bundle-id (random-uuid)}
    :event-stream stream})
 
+(def ^{:stratum 0} ^:private planned-output
+  {:opsv/experiment-pack-hash "pack-hash"
+   :opsv/experiment-pack {:experiment-pack/targets
+                          {:services ["catalog"]
+                           :environments ["staging"]}}
+   :opsv/risk-result {:score 0.1 :level :low :factors []}})
+
 ;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} leave-planned-phase
+  [ctx]
+  (let [leave (:leave (lifecycle/interceptor {} :opsv/plan identity))]
+    (leave (assoc ctx :phase
+                  {:name :opsv/plan
+                   :started-at (System/currentTimeMillis)
+                   :result {:status :success :output planned-output}}))))
 
 (deftest ^{:stratum 1} test-policy-confidence-degrades-safely
   (let [stream (event-stream/create-event-stream)]
@@ -72,3 +90,28 @@
         (is (= (:observed abort) (:opsv/observed abort-event)))
         (is (= (:rollback-action abort)
                (:opsv/rollback-action abort-event)))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} test-publication-rejection-fails-the-phase
+  (let [stream (event-stream/create-event-stream)
+        ctx (event-context stream)
+        workflow-id (:execution/id ctx)
+        _ (event-stream/quiesce! stream {:workflow-id workflow-id})
+        completed (leave-planned-phase ctx)]
+    (is (= :failed (get-in completed [:phase :status])))
+    (is (anomaly/anomaly? (get-in completed [:phase :result :output])))
+    (is (empty? (event-stream/get-events stream)))
+    (is (not-any? #{:opsv/plan}
+                  (get-in completed [:execution :phases-completed])))))
+
+(deftest ^{:stratum 2} test-evidence-accumulation-failure-fails-the-phase
+  (let [stream (event-stream/create-event-stream)
+        ctx (assoc (event-context stream)
+                   :opsv/evidence-assembly-store
+                   (evidence/create-opsv-assembly-store))
+        completed (leave-planned-phase ctx)]
+    (is (= :failed (get-in completed [:phase :status])))
+    (is (anomaly/anomaly? (get-in completed [:phase :result :output])))
+    (is (= [:opsv.experiment/planned]
+           (mapv :event/type (event-stream/get-events stream))))))

--- a/components/phase-opsv/test/ai/miniforge/phase_opsv/events_test.clj
+++ b/components/phase-opsv/test/ai/miniforge/phase_opsv/events_test.clj
@@ -63,7 +63,6 @@
   (let [stream (event-stream/create-event-stream)
         abort {:trigger :tail-latency
                :threshold {:milliseconds 500}
-               :observed {:milliseconds 650}
                :rollback-action :restore-previous-policy}]
     (events/emit-phase-events!
      (event-context stream)
@@ -87,9 +86,17 @@
       (testing "the canonical abort evidence is preserved"
         (is (= (:trigger abort) (:opsv/trigger abort-event)))
         (is (= (:threshold abort) (:opsv/threshold abort-event)))
-        (is (= (:observed abort) (:opsv/observed abort-event)))
+        (is (= {} (:opsv/observed abort-event)))
         (is (= (:rollback-action abort)
                (:opsv/rollback-action abort-event)))))))
+
+(deftest ^{:stratum 1} test-invalid-projection-is-not-published
+  (let [stream (event-stream/create-event-stream)
+        result (events/emit-phase-events!
+                (event-context stream) :opsv/plan
+                (dissoc planned-output :opsv/experiment-pack-hash))]
+    (is (anomaly/anomaly? result))
+    (is (empty? (event-stream/get-events stream)))))
 
 ;------------------------------------------------------------------------------ Layer 2
 

--- a/components/phase-opsv/test/ai/miniforge/phase_opsv/events_test.clj
+++ b/components/phase-opsv/test/ai/miniforge/phase_opsv/events_test.clj
@@ -108,6 +108,7 @@
         completed (leave-planned-phase ctx)]
     (is (= :failed (get-in completed [:phase :status])))
     (is (anomaly/anomaly? (get-in completed [:phase :result :output])))
+    (is (= :unavailable (get-in completed [:phase :result :output :anomaly/type])))
     (is (empty? (event-stream/get-events stream)))
     (is (not-any? #{:opsv/plan}
                   (get-in completed [:execution :phases-completed])))))

--- a/components/phase-opsv/test/ai/miniforge/phase_opsv/events_test.clj
+++ b/components/phase-opsv/test/ai/miniforge/phase_opsv/events_test.clj
@@ -1,0 +1,74 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.phase-opsv.events-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.event-stream.interface :as event-stream]
+   [ai.miniforge.phase-opsv.events :as events]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} event-context
+  [stream]
+  {:execution/id (random-uuid)
+   :execution/input {:opsv/evidence-bundle-id (random-uuid)}
+   :event-stream stream})
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} test-policy-confidence-degrades-safely
+  (let [stream (event-stream/create-event-stream)]
+    (events/emit-phase-events!
+     (event-context stream)
+     :opsv/synthesize
+     {:opsv/policy-hash "policy-hash"
+      :opsv/experiment-pack {:experiment-pack/convergence {}}
+      :opsv/convergence-result {:evaluation {:confidence 0.9}}})
+    (is (= :low (:opsv/confidence (first (event-stream/get-events stream)))))))
+
+(deftest ^{:stratum 1} test-guardrail-abort-projection
+  (let [stream (event-stream/create-event-stream)
+        abort {:trigger :tail-latency
+               :threshold {:milliseconds 500}
+               :observed {:milliseconds 650}
+               :rollback-action :restore-previous-policy}]
+    (events/emit-phase-events!
+     (event-context stream)
+     :opsv/execute
+     {:opsv/experiment-pack-hash "pack-hash"
+      :opsv/environment-fingerprint
+      {:cluster "staging-1" :node-pools []
+       :image-digests {} :config-hash "config-hash"}
+      :opsv/ramp-steps
+      [{:step/id "1"
+        :step/intended-load {:requests-per-second 50}
+        :step/observed-load {:requests-per-second 48}
+        :step/metrics {:guardrail-abort? true}
+        :step/guardrail-abort abort}]})
+    (let [published (event-stream/get-events stream)
+          abort-event (last published)]
+      (testing "the load observation precedes the abort"
+        (is (= [:opsv.experiment/started :opsv/load-step
+                :opsv.guardrail/abort]
+               (mapv :event/type published))))
+      (testing "the canonical abort evidence is preserved"
+        (is (= (:trigger abort) (:opsv/trigger abort-event)))
+        (is (= (:threshold abort) (:opsv/threshold abort-event)))
+        (is (= (:observed abort) (:opsv/observed abort-event)))
+        (is (= (:rollback-action abort)
+               (:opsv/rollback-action abort-event)))))))

--- a/docs/pull-requests/2026-08-06-codex-n7-opsv-event-projection.md
+++ b/docs/pull-requests/2026-08-06-codex-n7-opsv-event-projection.md
@@ -1,0 +1,76 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# feat: project OPSV lifecycle events
+
+## Overview
+
+Project the required N3 OPSV domain events at successful phase boundaries and
+persist their identifiers in the durable evidence assembly.
+
+## Motivation
+
+The OPSV lifecycle executed end to end but exposed only generic workflow
+telemetry. N7 requires domain-specific event records that carry the evidence
+bundle identity, retain the complete risk result, and survive checkpointing.
+
+## Layer
+
+OPSV application event projection and publication.
+
+## Depends on
+
+- PR #1675 (OPSV model decomposition) — merged
+- PR #1677 (project integration registration) — merged
+
+## Changes in Detail
+
+- Construct the planned, started, load-step, convergence, policy,
+  verification, and actuation event records from phase outputs.
+- Publish events only after successful phase transformations.
+- Accumulate published event IDs in the canonical evidence assembly.
+- Reuse the shared bounded confidence classifier rather than duplicate its
+  threshold logic.
+- Exercise the registered project integration path with exact event
+  cardinalities, evidence linkage, checkpoint restoration, and side-effect
+  freedom assertions.
+
+## Standards Audit
+
+- Event construction, publication, and phase orchestration remain separate.
+- Every changed implementation namespace has at most three computed strata.
+- Each event payload is assembled once; no repeated policy or evidence maps
+  are embedded across phase functions.
+- Event publication failures are not swallowed or converted to false success.
+- Runtime objects remain outside checkpointed execution input.
+- Default actuation remains `:recommend-only` with no governed effects.
+
+## Testing Plan
+
+- Phase-OPSV tests pass in both composed projects.
+- Registered OPSV project integration verifies lifecycle and domain events.
+- The full Miniforge project suite passes across all composed bricks.
+- Poly, clj-kondo, stratum lint, pre-commit smoke, GraalVM compatibility, and
+  CLI build gates pass.
+
+## Deployment Plan
+
+No deployment action is required. The change adds deterministic event records
+to the existing successful workflow path and preserves the current actuation
+posture.
+
+## Checklist
+
+- [x] All required N3 event types are projected exactly once per boundary.
+- [x] The planned event retains the full risk result record.
+- [x] Domain event IDs are durable evidence references.
+- [x] No runtime adapter or evidence-store object is checkpointed.
+- [x] Guardrail aborts and missing confidence thresholds are covered.
+
+## Follow-up
+
+Add the deterministic simulated OPSV adapter as the next independently
+reviewable N7 slice.

--- a/docs/pull-requests/2026-08-06-codex-n7-opsv-event-projection.md
+++ b/docs/pull-requests/2026-08-06-codex-n7-opsv-event-projection.md
@@ -54,7 +54,7 @@ OPSV application event projection and publication.
 
 - Phase-OPSV tests pass in both composed projects: 10 tests and 50 assertions
   per project, including fail-closed publication and evidence regressions.
-- Project integration passes: 310 tests and 1,098 assertions, including exact
+- Project integration passes: 310 tests and 1,099 assertions, including exact
   OPSV event cardinalities and durable evidence references.
 - The full Miniforge project suite passes across all 87 composed bricks.
 - Poly reports only the four known repository baseline warnings.
@@ -71,7 +71,7 @@ posture.
 
 ## Checklist
 
-- [x] All required N3 event types are projected exactly once per boundary.
+- [x] Required N3 event types have deterministic phase-boundary cardinalities.
 - [x] The planned event retains the full risk result record.
 - [x] Domain event IDs are durable evidence references.
 - [x] No runtime adapter or evidence-store object is checkpointed.

--- a/docs/pull-requests/2026-08-06-codex-n7-opsv-event-projection.md
+++ b/docs/pull-requests/2026-08-06-codex-n7-opsv-event-projection.md
@@ -45,16 +45,23 @@ OPSV application event projection and publication.
 - Each event payload is assembled once; no repeated policy or evidence maps
   are embedded across phase functions.
 - Event publication failures are not swallowed or converted to false success.
+- Legacy evidence failures are normalized to canonical anomalies at the
+  component boundary, preserving the original failure as diagnostic data.
 - Runtime objects remain outside checkpointed execution input.
 - Default actuation remains `:recommend-only` with no governed effects.
 
 ## Testing Plan
 
-- Phase-OPSV tests pass in both composed projects.
-- Registered OPSV project integration verifies lifecycle and domain events.
-- The full Miniforge project suite passes across all composed bricks.
-- Poly, clj-kondo, stratum lint, pre-commit smoke, GraalVM compatibility, and
-  CLI build gates pass.
+- Phase-OPSV tests pass in both composed projects: 10 tests and 50 assertions
+  per project, including fail-closed publication and evidence regressions.
+- Project integration passes: 310 tests and 1,098 assertions, including exact
+  OPSV event cardinalities and durable evidence references.
+- The full Miniforge project suite passes across all 87 composed bricks.
+- Poly reports only the four known repository baseline warnings.
+- Changed-file clj-kondo and stratum lint report no findings.
+- Pre-commit smoke passes 339 tests and 1,285 assertions; GraalVM compatibility
+  passes 8 tests and 602 assertions.
+- The Miniforge CLI uberjar builds successfully.
 
 ## Deployment Plan
 

--- a/projects/miniforge/test/ai/miniforge/workflow/opsv_lifecycle_integration_test.clj
+++ b/projects/miniforge/test/ai/miniforge/workflow/opsv_lifecycle_integration_test.clj
@@ -123,6 +123,7 @@
                   lifecycle-events phase-key :workflow/phase-completed)))))
     (testing "successful boundaries emit the required N3 OPSV events"
       (is (= support/expected-domain-type-counts domain-type-counts))
+      (is (every? support/valid-domain-event? domain-events))
       (is (= (:opsv/risk-result (support/phase-output result :opsv/plan))
              (:opsv/risk-score planned-event)))
       (is (number? (get-in planned-event [:opsv/risk-score :score])))

--- a/projects/miniforge/test/ai/miniforge/workflow/opsv_lifecycle_integration_test.clj
+++ b/projects/miniforge/test/ai/miniforge/workflow/opsv_lifecycle_integration_test.clj
@@ -17,87 +17,64 @@
 ;; limitations under the License.
 (ns ai.miniforge.workflow.opsv-lifecycle-integration-test
   (:require
-   [clojure.edn :as edn]
-   [clojure.java.io :as io]
-   [clojure.test :refer [deftest is]]
+   [clojure.test :refer [deftest is testing]]
    [ai.miniforge.evidence-bundle.interface :as evidence]
+   [ai.miniforge.event-stream.interface :as event-stream]
    [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.phase-opsv.interface :as opsv]
-   [ai.miniforge.phase-opsv.protocol :as port]
-   [ai.miniforge.workflow.interface :as workflow])
-  (:import
-   [org.apache.commons.io FileUtils]))
+   [ai.miniforge.workflow.interface :as workflow]
+   [ai.miniforge.workflow.opsv-lifecycle-support :as support]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
-(def ^{:stratum 0} ^:private fixture
-  (let [resource-path "opsv/application-fixture.edn"
-        project-relative (io/file "../../components/phase-opsv/test-resources"
-                                  resource-path)
-        source (or (io/resource resource-path)
-                   (when (.isFile project-relative) project-relative))]
-    (when-not source
-      (throw (ex-info "OPSV application fixture not found"
-                      {:fixture/path resource-path})))
-    (-> source slurp edn/read-string)))
+(defn- ^{:stratum 0} run-opsv-scenario
+  [checkpoint-root]
+  (let [workflow-config (:workflow
+                         (workflow/load-workflow
+                          :opsv "1.0.0" {:skip-cache? true}))
+        stream (event-stream/create-event-stream)
+        result (workflow/run-pipeline workflow-config
+                                      (support/workflow-input)
+                                      (support/workflow-options
+                                       stream checkpoint-root))
+        events (event-stream/get-events stream)
+        lifecycle-events (filter
+                          (partial support/event-type-in?
+                                   support/lifecycle-event-types)
+                          events)
+        domain-events (filter
+                       (partial support/event-type-in?
+                                support/domain-event-types)
+                       events)
+        evidence-id (:opsv/evidence-bundle-id (first domain-events))]
+    {:result result
+     :lifecycle-events lifecycle-events
+     :domain-events domain-events
+     :domain-type-counts (frequencies (map :event/type domain-events))
+     :planned-event (support/event-of-type
+                     domain-events :opsv.experiment/planned)
+     :evidence-id evidence-id
+     :evidence-store (:opsv/evidence-assembly-store result)
+     :checkpoint (workflow/load-checkpoint-data
+                  (:execution/id result)
+                  {:checkpoint/root checkpoint-root})}))
 
-(def ^{:stratum 0} ^:private artifact-id
-  #uuid "00000000-0000-0000-0000-000000000799")
-
-(def ^{:stratum 0} ^:private expected-pipeline
-  (conj (mapv #(hash-map :phase %) opsv/phase-keys) {:phase :done}))
-
-(defn- ^{:stratum 0} with-temp-checkpoint-root
-  [f]
-  (let [root (doto (io/file (System/getProperty "java.io.tmpdir")
-                            (str "opsv-lifecycle-" (random-uuid)))
-               .mkdirs)]
-    (try
-      (f (.getAbsolutePath root))
-      (finally (FileUtils/deleteDirectory root)))))
-
-;------------------------------------------------------------------------------ Layer 1
-
-(defn- ^{:stratum 1} test-adapter
-  []
-  (reify port/OPSVAdapter
-    (discover-signals [_ _targets]
-      [{:driver :cpu} {:driver :backlog}])
-    (run-guarded-ramp [_ _pack]
-      {:environment-fingerprint
-       {:cluster "staging-1"
-        :node-pools ["general"]
-        :image-digests {"catalog" "sha256:abc"}
-        :config-hash "config-1"}
-       :steps (:ramp-steps fixture)})))
-
-(defn- ^{:stratum 1} workflow-input
-  []
-  {:opsv/experiment-pack (:experiment-pack fixture)
-   :opsv/evidence-refs [artifact-id]
-   :opsv/risk-thresholds {:medium 0.3 :high 0.6 :critical 0.85}
-   :opsv/metric-snapshot-artifact-refs [artifact-id]
-   :opsv/policy-diff-artifact-refs [artifact-id]})
-
-(deftest ^{:stratum 1} test-exact-opsv-workflow-resource
+(deftest ^{:stratum 0} test-opsv-workflow-loads-exact-versioned-pipeline
   (let [loaded (workflow/load-workflow :opsv "1.0.0" {:skip-cache? true})]
     (is (= :resource (:source loaded)))
     (is (true? (get-in loaded [:validation :valid?])))
-    (is (= expected-pipeline (get-in loaded [:workflow :workflow/pipeline])))))
+    (is (= support/expected-pipeline
+           (get-in loaded [:workflow :workflow/pipeline])))))
 
-;------------------------------------------------------------------------------ Layer 2
-
-(deftest ^{:stratum 2} test-runtime-adapter-authority
-  (let [legacy-adapter (test-adapter)
-        runtime-adapter (test-adapter)
+(deftest ^{:stratum 0} test-opsv-interceptor-isolates-runtime-adapter
+  (let [legacy-adapter (support/test-adapter)
+        runtime-adapter (support/test-adapter)
         interceptor (phase/get-phase-interceptor
                      {:phase :opsv/discover :agent :opsv-test-agent})
         enter (:enter interceptor)
-        context {:execution/id (random-uuid)
-                 :execution/input (assoc (workflow-input)
-                                         :opsv/adapter legacy-adapter)}
-        migrated (enter context)
-        preferred (enter (assoc context :execution/opts
+        migrated (enter (support/legacy-adapter-context legacy-adapter))
+        preferred (enter (assoc (support/legacy-adapter-context legacy-adapter)
+                                :execution/opts
                                 {:opsv/adapter runtime-adapter}))]
     (is (= :opsv-test-agent (get-in migrated [:phase :agent])))
     (is (identical? legacy-adapter
@@ -107,43 +84,55 @@
     (is (not (contains? (:execution/input migrated) :opsv/adapter)))
     (is (not (contains? (:execution/input preferred) :opsv/adapter)))))
 
-(deftest ^{:stratum 2} test-evidence-runtime-restores-from-durable-input
+(deftest ^{:stratum 0} test-opsv-evidence-runtime-restores-from-durable-input
   (let [workflow-id (random-uuid)
+        runtime-adapter (support/test-adapter)
+        context (-> (support/legacy-adapter-context runtime-adapter)
+                    (assoc :execution/id workflow-id)
+                    (update :execution/input dissoc :opsv/adapter)
+                    (assoc :execution/opts {:opsv/adapter runtime-adapter}))
         interceptor (phase/get-phase-interceptor {:phase :opsv/discover})
-        entered ((:enter interceptor)
-                 {:execution/id workflow-id
-                  :execution/input
-                  {:opsv/experiment-pack (:experiment-pack fixture)}
-                  :execution/opts {:opsv/adapter (test-adapter)}})
+        entered ((:enter interceptor) context)
         checkpointed ((:leave interceptor) entered)
         resumed (dissoc checkpointed :opsv/evidence-assembly-store)
         restored ((:enter interceptor) resumed)
         bundle-id (get-in restored
                           [:execution/input :opsv/evidence-bundle-id])]
-    (is (= (get-in checkpointed
-                   [:execution/input :opsv/evidence-assembly])
+    (is (= (get-in checkpointed [:execution/input :opsv/evidence-assembly])
            (evidence/get-opsv-assembly
             (:opsv/evidence-assembly-store restored) bundle-id)))))
 
-(deftest ^{:stratum 2} test-opsv-lifecycle-checkpoint
-  (with-temp-checkpoint-root
-    (fn [checkpoint-root]
-      (let [config (:workflow
-                    (workflow/load-workflow
-                     :opsv "1.0.0" {:skip-cache? true}))
-            result (workflow/run-pipeline
-                    config (workflow-input)
-                    {:opsv/adapter (test-adapter)
-                     :checkpoint/root checkpoint-root})
-            checkpoint (workflow/load-checkpoint-data
-                        (:execution/id result)
-                        {:checkpoint/root checkpoint-root})
-            checkpoint-input (get-in checkpoint
-                                     [:machine-snapshot :execution/input])]
-        (is (= :completed (:execution/status result)))
-        (is (= (set (conj opsv/phase-keys :done))
-               (set (keys (:execution/phase-results result)))))
-        (is (map? (:opsv/evidence-assembly checkpoint-input)))
-        (is (not (contains? checkpoint-input :opsv/adapter)))
-        (is (not (contains? checkpoint-input
-                            :opsv/evidence-assembly-store)))))))
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} test-opsv-run-emits-lifecycle-and-domain-events
+  (let [{:keys [result lifecycle-events domain-events domain-type-counts
+                planned-event evidence-id evidence-store checkpoint]}
+        (support/with-temp-checkpoint-root run-opsv-scenario)
+        assembly (evidence/get-opsv-assembly evidence-store evidence-id)
+        checkpoint-input (get-in checkpoint [:machine-snapshot :execution/input])
+        actuation (:opsv/actuation-record
+                   (support/phase-output result :opsv/actuate))]
+    (testing "the shared runner executes all registered phases"
+      (is (= :completed (:execution/status result)))
+      (is (= (set (conj opsv/phase-keys :done))
+             (set (keys (:execution/phase-results result)))))
+      (doseq [phase-key opsv/phase-keys]
+        (is (= 1 (support/lifecycle-event-count
+                  lifecycle-events phase-key :workflow/phase-started)))
+        (is (= 1 (support/lifecycle-event-count
+                  lifecycle-events phase-key :workflow/phase-completed)))))
+    (testing "successful boundaries emit the required N3 OPSV events"
+      (is (= support/expected-domain-type-counts domain-type-counts))
+      (is (= (:opsv/risk-result (support/phase-output result :opsv/plan))
+             (:opsv/risk-score planned-event)))
+      (is (number? (get-in planned-event [:opsv/risk-score :score])))
+      (is (uuid? evidence-id))
+      (is (every? #(= evidence-id (:opsv/evidence-bundle-id %)) domain-events))
+      (is (= :assembling (:opsv.assembly/status assembly)))
+      (is (= (set (map :event/id domain-events)) (:opsv/event-refs assembly)))
+      (is (= assembly (:opsv/evidence-assembly checkpoint-input)))
+      (is (not (contains? checkpoint-input :opsv/evidence-assembly-store)))
+      (is (not (contains? checkpoint-input :opsv/adapter))))
+    (testing "the default posture remains side-effect free"
+      (is (= :recommend-only (:effective-actuation-mode actuation)))
+      (is (= [] (:governed-effects actuation))))))

--- a/projects/miniforge/test/ai/miniforge/workflow/opsv_lifecycle_integration_test.clj
+++ b/projects/miniforge/test/ai/miniforge/workflow/opsv_lifecycle_integration_test.clj
@@ -105,7 +105,8 @@
   (let [{:keys [result lifecycle-events domain-events domain-type-counts
                 planned-event evidence-id evidence-store checkpoint]}
         (support/with-temp-checkpoint-root run-opsv-scenario)
-        assembly (evidence/get-opsv-assembly evidence-store evidence-id)
+        assembly (when (and evidence-store evidence-id)
+                   (evidence/get-opsv-assembly evidence-store evidence-id))
         checkpoint-input (get-in checkpoint [:machine-snapshot :execution/input])
         actuation (:opsv/actuation-record
                    (support/phase-output result :opsv/actuate))]

--- a/projects/miniforge/test/ai/miniforge/workflow/opsv_lifecycle_integration_test.clj
+++ b/projects/miniforge/test/ai/miniforge/workflow/opsv_lifecycle_integration_test.clj
@@ -42,10 +42,7 @@
                           (partial support/event-type-in?
                                    support/lifecycle-event-types)
                           events)
-        domain-events (filter
-                       (partial support/event-type-in?
-                                support/domain-event-types)
-                       events)
+        domain-events (filter support/opsv-domain-event? events)
         evidence-id (:opsv/evidence-bundle-id (first domain-events))]
     {:result result
      :lifecycle-events lifecycle-events

--- a/projects/miniforge/test/ai/miniforge/workflow/opsv_lifecycle_support.clj
+++ b/projects/miniforge/test/ai/miniforge/workflow/opsv_lifecycle_support.clj
@@ -1,0 +1,128 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.workflow.opsv-lifecycle-support
+  (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [ai.miniforge.phase-opsv.interface :as opsv]
+   [ai.miniforge.phase-opsv.protocol :as port])
+  (:import
+   [org.apache.commons.io FileUtils]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} lifecycle-event-types
+  #{:workflow/phase-started :workflow/phase-completed})
+
+(def ^{:stratum 0} domain-event-types
+  #{:opsv.experiment/planned
+    :opsv.experiment/started
+    :opsv/load-step
+    :opsv.convergence/iteration
+    :opsv.policy/proposed
+    :opsv.verification/result
+    :opsv.actuation/emitted})
+
+(def ^{:stratum 0} expected-domain-type-counts
+  {:opsv.experiment/planned 1
+   :opsv.experiment/started 1
+   :opsv/load-step 2
+   :opsv.convergence/iteration 2
+   :opsv.policy/proposed 1
+   :opsv.verification/result 1
+   :opsv.actuation/emitted 1})
+
+(def ^{:stratum 0} expected-pipeline
+  (conj (mapv #(hash-map :phase %) opsv/phase-keys) {:phase :done}))
+
+(def ^{:stratum 0} ^:private artifact-id
+  #uuid "00000000-0000-0000-0000-000000000799")
+
+(def ^{:stratum 0} ^:private fixture
+  (-> "opsv/application-fixture.edn" io/resource slurp edn/read-string))
+
+(def ^{:stratum 0} ^:private environment-fingerprint
+  {:cluster "staging-1"
+   :node-pools ["general"]
+   :image-digests {"catalog" "sha256:abc"}
+   :config-hash "config-1"})
+
+(defn ^{:stratum 0} event-type-in?
+  [event-types event]
+  (contains? event-types (:event/type event)))
+
+(defn ^{:stratum 0} event-of-type
+  [events event-type]
+  (first (filter #(= event-type (:event/type %)) events)))
+
+(defn ^{:stratum 0} phase-output
+  [result phase-key]
+  (get-in result [:execution/phase-results phase-key :result :output]))
+
+(defn ^{:stratum 0} lifecycle-event-count
+  [events phase-key event-type]
+  (count (filter #(and (= event-type (:event/type %))
+                       (= phase-key (:workflow/phase %)))
+                 events)))
+
+(defn ^{:stratum 0} with-temp-checkpoint-root
+  [f]
+  (let [root (doto (io/file (System/getProperty "java.io.tmpdir")
+                            (str "opsv-lifecycle-" (random-uuid)))
+               .mkdirs)]
+    (try
+      (f (.getAbsolutePath root))
+      (finally
+        (FileUtils/deleteDirectory root)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} test-adapter
+  []
+  (reify port/OPSVAdapter
+    (discover-signals [_ _targets]
+      [{:driver :cpu} {:driver :backlog}])
+    (run-guarded-ramp [_ _pack]
+      {:environment-fingerprint environment-fingerprint
+       :steps (:ramp-steps fixture)})))
+
+(defn ^{:stratum 1} workflow-input
+  []
+  {:opsv/experiment-pack
+   (assoc (:experiment-pack fixture)
+          :experiment-pack/actuation-intent
+          :recommend-only)
+   :opsv/evidence-refs [artifact-id]
+   :opsv/risk-thresholds {:medium 0.3 :high 0.6 :critical 0.85}
+   :opsv/metric-snapshot-artifact-refs [artifact-id]
+   :opsv/policy-diff-artifact-refs [artifact-id]})
+
+(defn ^{:stratum 1} legacy-adapter-context
+  [adapter]
+  {:execution/id (random-uuid)
+   :execution/input
+   {:opsv/adapter adapter
+    :opsv/experiment-pack (:experiment-pack fixture)}})
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} workflow-options
+  [stream checkpoint-root]
+  {:event-stream stream
+   :opsv/adapter (test-adapter)
+   :checkpoint/root checkpoint-root})

--- a/projects/miniforge/test/ai/miniforge/workflow/opsv_lifecycle_support.clj
+++ b/projects/miniforge/test/ai/miniforge/workflow/opsv_lifecycle_support.clj
@@ -19,6 +19,8 @@
   (:require
    [clojure.edn :as edn]
    [clojure.java.io :as io]
+   [malli.core :as m]
+   [ai.miniforge.event-stream.interface.opsv :as opsv-event]
    [ai.miniforge.phase-opsv.interface :as opsv]
    [ai.miniforge.phase-opsv.protocol :as port])
   (:import
@@ -46,6 +48,15 @@
    :opsv.policy/proposed 1
    :opsv.verification/result 1
    :opsv.actuation/emitted 1})
+
+(def ^{:stratum 0} ^:private domain-event-schemas
+  {:opsv.experiment/planned opsv-event/ExperimentPlanned
+   :opsv.experiment/started opsv-event/ExperimentStarted
+   :opsv/load-step opsv-event/LoadStep
+   :opsv.convergence/iteration opsv-event/ConvergenceIteration
+   :opsv.policy/proposed opsv-event/PolicyProposed
+   :opsv.verification/result opsv-event/VerificationResult
+   :opsv.actuation/emitted opsv-event/ActuationEmitted})
 
 (def ^{:stratum 0} expected-pipeline
   (conj (mapv #(hash-map :phase %) opsv/phase-keys) {:phase :done}))
@@ -99,6 +110,11 @@
         (FileUtils/deleteDirectory root)))))
 
 ;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} valid-domain-event?
+  [event]
+  (when-let [schema (get domain-event-schemas (:event/type event))]
+    (m/validate schema event)))
 
 (defn ^{:stratum 1} test-adapter
   []

--- a/projects/miniforge/test/ai/miniforge/workflow/opsv_lifecycle_support.clj
+++ b/projects/miniforge/test/ai/miniforge/workflow/opsv_lifecycle_support.clj
@@ -102,7 +102,7 @@
     (try
       (f (.getAbsolutePath root))
       (finally
-        (FileUtils/deleteDirectory root)))))
+        (FileUtils/deleteQuietly root)))))
 
 ;------------------------------------------------------------------------------ Layer 1
 

--- a/projects/miniforge/test/ai/miniforge/workflow/opsv_lifecycle_support.clj
+++ b/projects/miniforge/test/ai/miniforge/workflow/opsv_lifecycle_support.clj
@@ -19,6 +19,7 @@
   (:require
    [clojure.edn :as edn]
    [clojure.java.io :as io]
+   [clojure.string :as str]
    [malli.core :as m]
    [ai.miniforge.event-stream.interface.opsv :as opsv-event]
    [ai.miniforge.phase-opsv.interface :as opsv]
@@ -30,15 +31,6 @@
 
 (def ^{:stratum 0} lifecycle-event-types
   #{:workflow/phase-started :workflow/phase-completed})
-
-(def ^{:stratum 0} domain-event-types
-  #{:opsv.experiment/planned
-    :opsv.experiment/started
-    :opsv/load-step
-    :opsv.convergence/iteration
-    :opsv.policy/proposed
-    :opsv.verification/result
-    :opsv.actuation/emitted})
 
 (def ^{:stratum 0} expected-domain-type-counts
   {:opsv.experiment/planned 1
@@ -53,10 +45,12 @@
   {:opsv.experiment/planned opsv-event/ExperimentPlanned
    :opsv.experiment/started opsv-event/ExperimentStarted
    :opsv/load-step opsv-event/LoadStep
+   :opsv.guardrail/abort opsv-event/GuardrailAbort
    :opsv.convergence/iteration opsv-event/ConvergenceIteration
    :opsv.policy/proposed opsv-event/PolicyProposed
    :opsv.verification/result opsv-event/VerificationResult
-   :opsv.actuation/emitted opsv-event/ActuationEmitted})
+   :opsv.actuation/emitted opsv-event/ActuationEmitted
+   :opsv.drift/detected opsv-event/DriftDetected})
 
 (def ^{:stratum 0} expected-pipeline
   (conj (mapv #(hash-map :phase %) opsv/phase-keys) {:phase :done}))
@@ -66,10 +60,7 @@
 
 (def ^{:stratum 0} ^:private fixture
   (let [resource-path "opsv/application-fixture.edn"
-        project-relative (io/file "../../components/phase-opsv/test-resources"
-                                  resource-path)
-        source (or (io/resource resource-path)
-                   (when (.isFile project-relative) project-relative))]
+        source (io/resource resource-path)]
     (when-not source
       (throw (ex-info "OPSV application fixture not found"
                       {:fixture/path resource-path})))
@@ -84,6 +75,10 @@
 (defn ^{:stratum 0} event-type-in?
   [event-types event]
   (contains? event-types (:event/type event)))
+
+(defn ^{:stratum 0} opsv-domain-event?
+  [event]
+  (some-> event :event/type namespace (str/starts-with? "opsv")))
 
 (defn ^{:stratum 0} event-of-type
   [events event-type]

--- a/projects/miniforge/test/ai/miniforge/workflow/opsv_lifecycle_support.clj
+++ b/projects/miniforge/test/ai/miniforge/workflow/opsv_lifecycle_support.clj
@@ -54,7 +54,15 @@
   #uuid "00000000-0000-0000-0000-000000000799")
 
 (def ^{:stratum 0} ^:private fixture
-  (-> "opsv/application-fixture.edn" io/resource slurp edn/read-string))
+  (let [resource-path "opsv/application-fixture.edn"
+        project-relative (io/file "../../components/phase-opsv/test-resources"
+                                  resource-path)
+        source (or (io/resource resource-path)
+                   (when (.isFile project-relative) project-relative))]
+    (when-not source
+      (throw (ex-info "OPSV application fixture not found"
+                      {:fixture/path resource-path})))
+    (-> source slurp edn/read-string)))
 
 (def ^{:stratum 0} ^:private environment-fingerprint
   {:cluster "staging-1"


### PR DESCRIPTION
## Overview

Project the required N3 OPSV domain events at successful phase boundaries and persist their published identifiers in the durable evidence assembly.

## Changes

- construct planned, started, load-step, convergence, policy, verification, actuation, and guardrail-abort records from canonical phase outputs
- publish events only for successful transformations and accumulate their IDs in the preallocated OPSV evidence assembly
- fail the phase if event publication is rejected or evidence accumulation fails
- normalize the evidence component's legacy anomaly at the component boundary while preserving its diagnostic data
- validate every emitted OPSV domain event against its exported N3 schema

## Standards audit

- event construction, publication, and phase orchestration are separate focused namespaces
- every changed implementation namespace stays within three computed strata
- event payload maps are assembled once; policy, confidence, and evidence shapes are not duplicated
- confidence classification reuses the shared bounded classifier
- side-effect failures use canonical anomalies as data and cannot produce false phase success
- runtime adapters and mutable stores remain outside durable checkpoint input
- default actuation remains `:recommend-only` with zero governed effects

## Validation

- PR budget: 594 / 600 reportable lines
- phase-OPSV in Miniforge: 10 tests, 50 assertions
- phase-OPSV in Miniforge TUI: 10 tests, 50 assertions
- direct OPSV project integration: 4 tests, 38 assertions
- full project integration: 310 tests, 1,099 assertions
- full Miniforge suite: all 87 composed bricks passed
- changed-file clj-kondo: 0 errors, 0 warnings
- changed-file stratum lint: 0 findings
- Poly: only four known repository baseline warnings
- pre-commit smoke: 339 tests, 1,285 assertions
- GraalVM compatibility: 8 tests, 602 assertions
- Miniforge CLI uberjar built successfully

## Follow-up

The next N7 slice adds the deterministic simulated adapter and staging MCI without expanding this application event layer.
