### PR TITLE
feat: add deterministic OPSV staging adapter

### DIFF
--- a/components/opsv-adapter-simulated/deps.edn
+++ b/components/opsv-adapter-simulated/deps.edn
@@ -1,0 +1,5 @@
+{:paths ["src"]
+ :deps {ai.miniforge/phase-opsv {:local/root "../phase-opsv"}}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps {io.github.cognitect-labs/test-runner
+                               {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}}}

--- a/components/opsv-adapter-simulated/src/ai/miniforge/opsv_adapter_simulated/core.clj
+++ b/components/opsv-adapter-simulated/src/ai/miniforge/opsv_adapter_simulated/core.clj
@@ -1,0 +1,30 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.opsv-adapter-simulated.core
+  "Deterministic, side-effect-free OPSV adapter for staging scenarios."
+  (:require
+   [ai.miniforge.phase-opsv.interface :as opsv]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} create-adapter
+  "Create an adapter that deterministically replays an immutable scenario."
+  [scenario]
+  (opsv/functional-adapter
+   (constantly (:opsv/candidate-drivers scenario))
+   (constantly (:opsv/ramp-result scenario))))

--- a/components/opsv-adapter-simulated/src/ai/miniforge/opsv_adapter_simulated/interface.clj
+++ b/components/opsv-adapter-simulated/src/ai/miniforge/opsv_adapter_simulated/interface.clj
@@ -1,0 +1,25 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.opsv-adapter-simulated.interface
+  "Public factory for the deterministic OPSV staging adapter."
+  (:require
+   [ai.miniforge.opsv-adapter-simulated.core :as core]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} create-adapter core/create-adapter)

--- a/components/opsv-adapter-simulated/test/ai/miniforge/opsv_adapter_simulated/interface_test.clj
+++ b/components/opsv-adapter-simulated/test/ai/miniforge/opsv_adapter_simulated/interface_test.clj
@@ -1,0 +1,44 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.opsv-adapter-simulated.interface-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.opsv-adapter-simulated.interface :as sut]
+   [ai.miniforge.phase-opsv.interface :as opsv]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private scenario
+  {:opsv/candidate-drivers [{:driver :cpu} {:driver :backlog}]
+   :opsv/ramp-result
+   {:environment-fingerprint {:cluster "staging"}
+    :steps [{:step/id "one"}]}})
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} test-adapter-replays-scenario-values
+  (let [adapter (sut/create-adapter scenario)]
+    (testing "discovery is deterministic and implements the public port"
+      (is (satisfies? opsv/OPSVAdapter adapter))
+      (is (= (:opsv/candidate-drivers scenario)
+             (opsv/discover-signals adapter {:services ["catalog"]}))))
+    (testing "guarded load replay is stable across calls"
+      (is (= (:opsv/ramp-result scenario)
+             (opsv/run-guarded-ramp adapter {:experiment-pack/id "pack"})))
+      (is (= (opsv/run-guarded-ramp adapter {})
+             (opsv/run-guarded-ramp adapter {}))))))

--- a/components/phase-opsv/src/ai/miniforge/phase_opsv/interface.clj
+++ b/components/phase-opsv/src/ai/miniforge/phase_opsv/interface.clj
@@ -50,3 +50,14 @@
   [ctx]
   (actuation/actuate
    ctx (get-in ctx [:execution/phase-results :opsv/verify :result :output])))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} functional-adapter
+  "Build an OPSV adapter from pure discovery and guarded-ramp functions."
+  [discover-fn guarded-ramp-fn]
+  (reify protocol/OPSVAdapter
+    (discover-signals [_ targets]
+      (discover-fn targets))
+    (run-guarded-ramp [_ experiment-pack]
+      (guarded-ramp-fn experiment-pack))))

--- a/components/phase-opsv/test-resources/opsv/application-fixture.edn
+++ b/components/phase-opsv/test-resources/opsv/application-fixture.edn
@@ -31,8 +31,16 @@
   {:gate/id :actuation :gate/passed? true :gate/type :opsv}
   {:gate/id :evidence-completeness :gate/passed? true :gate/type :opsv}]
 
- :ramp-steps
- [{:step/id "1"
+ :opsv/candidate-drivers [{:driver :cpu} {:driver :backlog}]
+
+ :opsv/ramp-result
+ {:environment-fingerprint
+  {:cluster "staging-1"
+   :node-pools ["general"]
+   :image-digests {"catalog" "sha256:abc"}
+   :config-hash "config-1"}
+  :steps
+  [{:step/id "1"
    :step/intended-load {:requests-per-second 50}
    :step/observed-load {:requests-per-second 50}
    :step/observations
@@ -65,4 +73,4 @@
     :min-replicas 2
     :max-replicas 8
     :keda-backlog-target 100
-    :cpu-request-millicores 250}}]}
+    :cpu-request-millicores 250}}]}}

--- a/components/phase-opsv/test/ai/miniforge/phase_opsv/test_support.clj
+++ b/components/phase-opsv/test/ai/miniforge/phase_opsv/test_support.clj
@@ -76,7 +76,7 @@
 ;------------------------------------------------------------------------------ Layer 1
 
 (def ^{:stratum 1} ramp-steps
-  (:ramp-steps fixture))
+  (get-in fixture [:opsv/ramp-result :steps]))
 
 (defn ^{:stratum 1} execution-context
   [adapter]

--- a/deps.edn
+++ b/deps.edn
@@ -56,6 +56,7 @@
                        "components/phase-software-factory/resources"
                        "components/phase-opsv/src"
                        "components/phase-opsv/resources"
+                       "components/opsv-adapter-simulated/src"
                        "components/gate/src"
                        "components/workflow/src"
                        "components/workflow/resources"
@@ -251,6 +252,7 @@
                       ai.miniforge/phase {:local/root "components/phase"}
                       ai.miniforge/phase-software-factory {:local/root "components/phase-software-factory"}
                       ai.miniforge/phase-opsv {:local/root "components/phase-opsv"}
+                      ai.miniforge/opsv-adapter-simulated {:local/root "components/opsv-adapter-simulated"}
                       ai.miniforge/gate {:local/root "components/gate"}
                       ai.miniforge/workflow {:local/root "components/workflow"}
                       ai.miniforge/workflow-financial-etl {:local/root "components/workflow-financial-etl"}
@@ -383,6 +385,7 @@
                        "components/phase-software-factory/test"
                        "components/phase-opsv/test"
                        "components/phase-opsv/test-resources"
+                       "components/opsv-adapter-simulated/test"
                        "components/gate/test"
                        "components/workflow/test"
                        "components/workflow/test-resources"
@@ -527,6 +530,7 @@
                       ai.miniforge/phase {:local/root "components/phase"}
                       ai.miniforge/phase-software-factory {:local/root "components/phase-software-factory"}
                       ai.miniforge/phase-opsv {:local/root "components/phase-opsv"}
+                      ai.miniforge/opsv-adapter-simulated {:local/root "components/opsv-adapter-simulated"}
                       ai.miniforge/gate {:local/root "components/gate"}
                       ai.miniforge/workflow {:local/root "components/workflow"}
                       ai.miniforge/workflow-financial-etl {:local/root "components/workflow-financial-etl"}

--- a/docs/pull-requests/2026-08-06-codex-n7-opsv-simulated-adapter.md
+++ b/docs/pull-requests/2026-08-06-codex-n7-opsv-simulated-adapter.md
@@ -1,0 +1,76 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# feat: add deterministic OPSV staging adapter
+
+## Overview
+
+Add a side-effect-free simulated adapter and use it to prove the N7 staging
+MCI discovers CPU and backlog signals and synthesizes an interoperable scaling
+proposal.
+
+## Motivation
+
+The registered OPSV workflow had an inline project test double. N7 calls for a
+deterministic staging adapter that exercises guarded ramp data without live
+infrastructure and demonstrates the required HPA/KEDA proposal end to end.
+
+## Layer
+
+OPSV staging adapter and project integration composition.
+
+## Depends on
+
+- PR #1678 (OPSV event projection) — merged
+
+## Changes in Detail
+
+- Add a public functional constructor for the existing OPSV adapter port.
+- Add a focused `opsv-adapter-simulated` Polylith component that replays
+  immutable scenario values.
+- Move candidate drivers, the environment fingerprint, and ramp observations
+  into one application fixture instead of duplicating maps in test support.
+- Compose the simulated component into the Miniforge staging integration run.
+- Assert staging targeting, CPU and backlog discovery, `autoscaling/v2` HPA,
+  backlog KEDA, recommend-only mode, and zero governed effects.
+
+## Standards Audit
+
+- Cross-component calls use public interface namespaces only.
+- The adapter owns no mutable state and has no external-effect path.
+- Scenario maps are assembled once in EDN and passed as values.
+- The adapter constructor has one responsibility and no nested control flow.
+- Changed namespaces satisfy clj-kondo and computed-stratum checks.
+- The project-only integration dependency is declared in Polylith's
+  `:necessary` set; no new workspace warning is introduced.
+
+## Testing Plan
+
+- Simulated adapter component: 1 test, 4 assertions.
+- Phase OPSV suites: 11 tests, 53 assertions.
+- OPSV project integration: 4 tests, 42 assertions.
+- Pre-commit smoke: 339 tests, 1,285 assertions.
+- GraalVM/Babashka compatibility: 8 tests, 606 assertions.
+- Polylith reports only the four existing repository baseline warnings.
+- Miniforge CLI uberjar builds successfully.
+
+## Deployment Plan
+
+No deployment action is required. The adapter is deterministic staging
+infrastructure and the workflow remains recommend-only with no external
+effects.
+
+## Checklist
+
+- [x] Staging execution requires no live infrastructure.
+- [x] Discovery returns both CPU and backlog candidate drivers.
+- [x] Guarded ramp observations flow through the seven-phase workflow.
+- [x] Synthesis produces HPA/KEDA-compatible scaling recommendations.
+- [x] Effective actuation remains recommend-only with zero effects.
+
+## Follow-up
+
+Implement the separately governed N7 actuation slice.

--- a/projects/miniforge/deps.edn
+++ b/projects/miniforge/deps.edn
@@ -9,6 +9,7 @@
         ai.miniforge/workflow-financial-etl {:local/root "../../components/workflow-financial-etl"}
         ai.miniforge/phase-software-factory {:local/root "../../components/phase-software-factory"}
         ai.miniforge/phase-opsv {:local/root "../../components/phase-opsv"}
+        ai.miniforge/opsv-adapter-simulated {:local/root "../../components/opsv-adapter-simulated"}
         ai.miniforge/workflow-opsv {:local/root "../../components/workflow-opsv"}
         ;; Deployment pack: Pulumi/Kustomize orchestration with policy gates and evidence
         ai.miniforge/phase-deployment {:local/root "../../components/phase-deployment"}

--- a/projects/miniforge/test/ai/miniforge/workflow/opsv_lifecycle_integration_test.clj
+++ b/projects/miniforge/test/ai/miniforge/workflow/opsv_lifecycle_integration_test.clj
@@ -108,6 +108,9 @@
         assembly (when (and evidence-store evidence-id)
                    (evidence/get-opsv-assembly evidence-store evidence-id))
         checkpoint-input (get-in checkpoint [:machine-snapshot :execution/input])
+        discovery (support/phase-output result :opsv/discover)
+        policy (:opsv/operational-policy
+                (support/phase-output result :opsv/synthesize))
         actuation (:opsv/actuation-record
                    (support/phase-output result :opsv/actuate))]
     (testing "the shared runner executes all registered phases"
@@ -132,6 +135,16 @@
       (is (= assembly (:opsv/evidence-assembly checkpoint-input)))
       (is (not (contains? checkpoint-input :opsv/evidence-assembly-store)))
       (is (not (contains? checkpoint-input :opsv/adapter))))
+    (testing "the staging adapter yields interoperable scaling recommendations"
+      (is (= #{:cpu :backlog}
+             (set (map :driver (:opsv/candidate-drivers discovery)))))
+      (is (= ["staging"] (:operational-policy/target-envs policy)))
+      (is (= {:api-version "autoscaling/v2" :metric :cpu}
+             (select-keys
+              (get-in policy [:operational-policy/scaling :hpa])
+              [:api-version :metric])))
+      (is (= :backlog
+             (get-in policy [:operational-policy/scaling :keda :trigger]))))
     (testing "the default posture remains side-effect free"
       (is (= :recommend-only (:effective-actuation-mode actuation)))
       (is (= [] (:governed-effects actuation))))))

--- a/projects/miniforge/test/ai/miniforge/workflow/opsv_lifecycle_support.clj
+++ b/projects/miniforge/test/ai/miniforge/workflow/opsv_lifecycle_support.clj
@@ -22,8 +22,8 @@
    [clojure.string :as str]
    [malli.core :as m]
    [ai.miniforge.event-stream.interface.opsv :as opsv-event]
-   [ai.miniforge.phase-opsv.interface :as opsv]
-   [ai.miniforge.phase-opsv.protocol :as port])
+   [ai.miniforge.opsv-adapter-simulated.interface :as simulated]
+   [ai.miniforge.phase-opsv.interface :as opsv])
   (:import
    [org.apache.commons.io FileUtils]))
 
@@ -66,12 +66,6 @@
                       {:fixture/path resource-path})))
     (-> source slurp edn/read-string)))
 
-(def ^{:stratum 0} ^:private environment-fingerprint
-  {:cluster "staging-1"
-   :node-pools ["general"]
-   :image-digests {"catalog" "sha256:abc"}
-   :config-hash "config-1"})
-
 (defn ^{:stratum 0} event-type-in?
   [event-types event]
   (contains? event-types (:event/type event)))
@@ -113,12 +107,7 @@
 
 (defn ^{:stratum 1} test-adapter
   []
-  (reify port/OPSVAdapter
-    (discover-signals [_ _targets]
-      [{:driver :cpu} {:driver :backlog}])
-    (run-guarded-ramp [_ _pack]
-      {:environment-fingerprint environment-fingerprint
-       :steps (:ramp-steps fixture)})))
+  (simulated/create-adapter fixture))
 
 (defn ^{:stratum 1} workflow-input
   []

--- a/workspace.edn
+++ b/workspace.edn
@@ -48,6 +48,9 @@
                                           "governance-provenance"
                                           "knowledge-pack"
                                           "observer" "orchestrator"
+                                          ;; Deterministic staging MCI adapter, consumed by the
+                                          ;; project integration suite rather than a runtime base.
+                                          "opsv-adapter-simulated"
                                           "phase-opsv"
                                           "phase-software-factory"
                                           "phase-deployment"


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# feat: add deterministic OPSV staging adapter

## Overview

Add a side-effect-free simulated adapter and use it to prove the N7 staging
MCI discovers CPU and backlog signals and synthesizes an interoperable scaling
proposal.

## Motivation

The registered OPSV workflow had an inline project test double. N7 calls for a
deterministic staging adapter that exercises guarded ramp data without live
infrastructure and demonstrates the required HPA/KEDA proposal end to end.

## Layer

OPSV staging adapter and project integration composition.

## Depends on

- PR #1678 (OPSV event projection) — merged

## Changes in Detail

- Add a public functional constructor for the existing OPSV adapter port.
- Add a focused `opsv-adapter-simulated` Polylith component that replays
  immutable scenario values.
- Move candidate drivers, the environment fingerprint, and ramp observations
  into one application fixture instead of duplicating maps in test support.
- Compose the simulated component into the Miniforge staging integration run.
- Assert staging targeting, CPU and backlog discovery, `autoscaling/v2` HPA,
  backlog KEDA, recommend-only mode, and zero governed effects.

## Standards Audit

- Cross-component calls use public interface namespaces only.
- The adapter owns no mutable state and has no external-effect path.
- Scenario maps are assembled once in EDN and passed as values.
- The adapter constructor has one responsibility and no nested control flow.
- Changed namespaces satisfy clj-kondo and computed-stratum checks.
- The project-only integration dependency is declared in Polylith's
  `:necessary` set; no new workspace warning is introduced.

## Testing Plan

- Simulated adapter component: 1 test, 4 assertions.
- Phase OPSV suites: 11 tests, 53 assertions.
- OPSV project integration: 4 tests, 42 assertions.
- Pre-commit smoke: 339 tests, 1,285 assertions.
- GraalVM/Babashka compatibility: 8 tests, 606 assertions.
- Polylith reports only the four existing repository baseline warnings.
- Miniforge CLI uberjar builds successfully.

## Deployment Plan

No deployment action is required. The adapter is deterministic staging
infrastructure and the workflow remains recommend-only with no external
effects.

## Checklist

- [x] Staging execution requires no live infrastructure.
- [x] Discovery returns both CPU and backlog candidate drivers.
- [x] Guarded ramp observations flow through the seven-phase workflow.
- [x] Synthesis produces HPA/KEDA-compatible scaling recommendations.
- [x] Effective actuation remains recommend-only with zero effects.

## Follow-up

Implement the separately governed N7 actuation slice.
