### PR TITLE
refactor: align OPSV governed effects with Ariadne

### DIFF
--- a/components/event-stream/src/ai/miniforge/event_stream/schema/opsv.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/schema/opsv.clj
@@ -46,9 +46,9 @@
 
 (def ^{:stratum 0} GovernedEffect
   [:map {:closed true}
-   [:evidence/intent-id :uuid]
-   [:evidence/oir-id :uuid]
-   [:evidence/capability-id :string]])
+   [:evidence/effect-id :uuid]
+   [:evidence/grant-id :uuid]
+   [:evidence/envelope-id :uuid]])
 
 (def ^{:stratum 0} EnvironmentFingerprint
   [:map {:closed true}

--- a/components/event-stream/test/ai/miniforge/event_stream/opsv_schema_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/opsv_schema_test.clj
@@ -63,9 +63,9 @@
     {:opsv/requested-actuation-mode :pr-only
      :opsv/effective-actuation-mode :pr-only
      :opsv/governed-effects
-     [{:evidence/intent-id #uuid "00000000-0000-0000-0000-000000000005"
-       :evidence/oir-id #uuid "00000000-0000-0000-0000-000000000006"
-       :evidence/capability-id "grant-1"}]
+     [{:evidence/effect-id #uuid "00000000-0000-0000-0000-000000000005"
+       :evidence/grant-id #uuid "00000000-0000-0000-0000-000000000006"
+       :evidence/envelope-id #uuid "00000000-0000-0000-0000-000000000007"}]
      :opsv/pr-refs ["https://example.test/pr/1"] :opsv/apply-refs []}]
    [opsv-schema/DriftDetected :opsv.drift/detected
     {:opsv/signal :latency :opsv/deviation {:ratio 1.2}

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/opsv_assembly.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/opsv_assembly.clj
@@ -23,7 +23,7 @@
 ;------------------------------------------------------------------------------ Layer 0
 
 (def ^{:stratum 0} ^:private reference-keys
-  [:opsv/event-refs :opsv/artifact-refs :opsv/capability-refs])
+  [:opsv/event-refs :opsv/artifact-refs :opsv/grant-refs])
 
 (defn ^{:stratum 0} create-store
   "Create an in-memory store for run-scoped OPSV assembly records."
@@ -51,7 +51,7 @@
                     :opsv.assembly/status :assembling
                     :opsv/event-refs #{}
                     :opsv/artifact-refs #{}
-                    :opsv/capability-refs #{}
+                    :opsv/grant-refs #{}
                     :opsv/governed-effects #{}}
           [old-state _new-state]
           (swap-vals! store #(if (contains? % bundle-id)

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/opsv_finalization.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/opsv_finalization.clj
@@ -56,7 +56,7 @@
 (def ^{:stratum 0} ^:private reference-paths
   [[:opsv/event-refs]
    [:opsv/artifact-refs]
-   [:opsv/capability-refs]
+   [:opsv/grant-refs]
    [:opsv/actuation :pr-refs]
    [:opsv/actuation :apply-refs]
    [:opsv/actuation :postcondition-artifact-refs]
@@ -67,9 +67,9 @@
 
 (defn- ^{:stratum 0} governed-effect-sort-key
   [effect]
-  [(str (:evidence/intent-id effect))
-   (str (:evidence/oir-id effect))
-   (:evidence/capability-id effect)])
+  [(str (:evidence/effect-id effect))
+   (str (:evidence/grant-id effect))
+   (str (:evidence/envelope-id effect))])
 
 ;------------------------------------------------------------------------------ Layer 1
 
@@ -86,18 +86,18 @@
   [record evidence available-artifact-ids]
   (let [event-refs (reference-set (:opsv/event-refs evidence))
         artifact-refs (reference-set (:opsv/artifact-refs evidence))
-        capability-refs (reference-set (:opsv/capability-refs evidence))
+        grant-refs (reference-set (:opsv/grant-refs evidence))
         available-artifact-refs (reference-set available-artifact-ids)
         effects (reference-set (get-in evidence [:opsv/actuation
                                                  :governed-effects]))
-        effect-capabilities (set (map :evidence/capability-id effects))]
+        effect-grants (set (map :evidence/grant-id effects))]
     (cond-> []
       (not= (:opsv/event-refs record) event-refs)
       (conj {:code :event-reference-mismatch})
       (not= (:opsv/artifact-refs record) artifact-refs)
       (conj {:code :artifact-reference-mismatch})
-      (not= (:opsv/capability-refs record) capability-refs)
-      (conj {:code :capability-reference-mismatch})
+      (not= (:opsv/grant-refs record) grant-refs)
+      (conj {:code :grant-reference-mismatch})
       (not= (:opsv/governed-effects record) effects)
       (conj {:code :governed-effect-mismatch})
       (not (cset/subset? (detailed-artifact-refs evidence) artifact-refs))
@@ -107,7 +107,7 @@
              :missing (vec (sort (cset/difference
                                   artifact-refs
                                   available-artifact-refs)))})
-      (not (cset/subset? effect-capabilities capability-refs))
+      (not (cset/subset? effect-grants grant-refs))
       (conj {:code :uncorrelated-governed-effect}))))
 
 ;------------------------------------------------------------------------------ Layer 2

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/schema/opsv.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/schema/opsv.clj
@@ -50,9 +50,9 @@
 
 (def ^{:stratum 0} GovernedEffect
   [:map {:closed true}
-   [:evidence/intent-id uuid?]
-   [:evidence/oir-id uuid?]
-   [:evidence/capability-id string?]])
+   [:evidence/effect-id uuid?]
+   [:evidence/grant-id uuid?]
+   [:evidence/envelope-id uuid?]])
 
 (def ^{:stratum 0} RollbackResult
   [:map {:closed true}
@@ -107,8 +107,8 @@
     [:and [:vector {:min 1} uuid?] [:fn unique-values?]]]
    [:opsv/artifact-refs
     [:and [:vector {:min 1} uuid?] [:fn unique-values?]]]
-   [:opsv/capability-refs
-    [:and [:vector string?] [:fn unique-values?]]]
+   [:opsv/grant-refs
+    [:and [:vector uuid?] [:fn unique-values?]]]
    [:opsv/risk-score RiskResult]
    [:opsv/convergence-iterations [:int {:min 0}]]
    [:opsv/policy-proposals [:vector PolicyProposal]]

--- a/components/evidence-bundle/test/ai/miniforge/evidence_bundle/opsv_assembly_test.clj
+++ b/components/evidence-bundle/test/ai/miniforge/evidence_bundle/opsv_assembly_test.clj
@@ -92,7 +92,7 @@
                 :missing)))))
 
 (deftest ^{:stratum 1} finalize-rejects-uncorrelated-governed-effect
-  (let [uncorrelated (assoc f/opsv-evidence :opsv/capability-refs [])
+  (let [uncorrelated (assoc f/opsv-evidence :opsv/grant-refs [])
         [store bundle-id] (accumulated-store
                            uncorrelated)
         result (evidence/finalize-opsv-evidence!
@@ -114,8 +114,8 @@
   (doseq [[expected-code change]
           [[:artifact-reference-mismatch
             #(update % :opsv/artifact-refs pop)]
-           [:capability-reference-mismatch
-            #(assoc % :opsv/capability-refs [])]
+           [:grant-reference-mismatch
+            #(assoc % :opsv/grant-refs [])]
            [:governed-effect-mismatch
             #(assoc-in % [:opsv/actuation :governed-effects] [])]]]
     (let [[store bundle-id] (accumulated-store f/opsv-evidence)
@@ -138,7 +138,7 @@
 (deftest ^{:stratum 1} finalize-rejects-duplicate-aggregate-references
   (doseq [reference-key [:opsv/event-refs
                          :opsv/artifact-refs
-                         :opsv/capability-refs]]
+                         :opsv/grant-refs]]
     (let [duplicate-evidence
           (update f/opsv-evidence reference-key #(conj % (first %)))
           [store bundle-id]
@@ -178,18 +178,17 @@
     (is (contains? (error-codes result) :referenced-artifact-not-found))))
 
 (deftest ^{:stratum 1} finalization-canonicalizes-reference-order
-  (let [second-capability-id "grant-2"
+  (let [second-grant-id #uuid "00000000-0000-0000-0000-000000000113"
         second-effect (assoc f/governed-effect
-                             :evidence/capability-id second-capability-id)
+                             :evidence/grant-id second-grant-id)
         evidence-value (-> f/opsv-evidence
-                           (update :opsv/capability-refs
-                                   conj second-capability-id)
+                           (update :opsv/grant-refs conj second-grant-id)
                            (update-in [:opsv/actuation :governed-effects]
                                       conj second-effect))
         reordered (-> evidence-value
                       (update :opsv/event-refs #(vec (reverse %)))
                       (update :opsv/artifact-refs #(vec (reverse %)))
-                      (update :opsv/capability-refs #(vec (reverse %)))
+                      (update :opsv/grant-refs #(vec (reverse %)))
                       (update-in [:opsv/actuation :governed-effects]
                                  #(vec (reverse %))))
         finalize (fn [input]

--- a/components/evidence-bundle/test/ai/miniforge/evidence_bundle/opsv_test_fixtures.clj
+++ b/components/evidence-bundle/test/ai/miniforge/evidence_bundle/opsv_test_fixtures.clj
@@ -41,14 +41,17 @@
 (def ^{:stratum 0} diff-artifact-id
   #uuid "00000000-0000-0000-0000-000000000108")
 
-(def ^{:stratum 0} intent-id
+(def ^{:stratum 0} effect-id
   #uuid "00000000-0000-0000-0000-000000000109")
 
-(def ^{:stratum 0} oir-id
+(def ^{:stratum 0} grant-id
   #uuid "00000000-0000-0000-0000-000000000110")
 
-(def ^{:stratum 0} canonical-bundle-id
+(def ^{:stratum 0} envelope-id
   #uuid "00000000-0000-0000-0000-000000000111")
+
+(def ^{:stratum 0} canonical-bundle-id
+  #uuid "00000000-0000-0000-0000-000000000112")
 
 ;------------------------------------------------------------------------------ Layer 1
 
@@ -57,9 +60,9 @@
    diff-artifact-id])
 
 (def ^{:stratum 1} governed-effect
-  {:evidence/intent-id intent-id
-   :evidence/oir-id oir-id
-   :evidence/capability-id "grant-1"})
+  {:evidence/effect-id effect-id
+   :evidence/grant-id grant-id
+   :evidence/envelope-id envelope-id})
 
 (def ^{:stratum 1} base-bundle
   {:evidence-bundle/workflow-id workflow-id
@@ -84,7 +87,7 @@
     :image-digests {"catalog" "sha256:image"} :config-hash "sha256:cfg"}
    :opsv/event-refs event-ids
    :opsv/artifact-refs artifact-ids
-   :opsv/capability-refs ["grant-1"]
+   :opsv/grant-refs [grant-id]
    :opsv/risk-score {:score 0.2 :level :low :factors []}
    :opsv/convergence-iterations 2
    :opsv/policy-proposals

--- a/components/opsv/src/ai/miniforge/opsv/schema.clj
+++ b/components/opsv/src/ai/miniforge/opsv/schema.clj
@@ -112,9 +112,9 @@
 
 (def ^{:stratum 0} GovernedEffect
   [:map {:closed true}
-   [:evidence/intent-id :uuid]
-   [:evidence/oir-id :uuid]
-   [:evidence/capability-id :string]])
+   [:evidence/effect-id :uuid]
+   [:evidence/grant-id :uuid]
+   [:evidence/envelope-id :uuid]])
 
 (def ^{:stratum 0} ConvergenceEvaluation
   [:map {:closed true}

--- a/components/opsv/test/ai/miniforge/opsv/interface_test.clj
+++ b/components/opsv/test/ai/miniforge/opsv/interface_test.clj
@@ -86,9 +86,9 @@
   {:requested-actuation-mode :pr-only
    :effective-actuation-mode :pr-only
    :governed-effects
-   [{:evidence/intent-id #uuid "00000000-0000-0000-0000-000000000002"
-     :evidence/oir-id #uuid "00000000-0000-0000-0000-000000000003"
-     :evidence/capability-id "grant-123"}]
+   [{:evidence/effect-id #uuid "00000000-0000-0000-0000-000000000002"
+     :evidence/grant-id #uuid "00000000-0000-0000-0000-000000000003"
+     :evidence/envelope-id #uuid "00000000-0000-0000-0000-000000000004"}]
    :pr-refs ["https://example.test/pr/1"]
    :apply-refs []
    :postcondition-artifact-refs []
@@ -183,9 +183,9 @@
   (is (= (assoc valid-actuation :effective-actuation-mode :none)
          (opsv/validate-actuation
           (assoc valid-actuation :effective-actuation-mode :none))))
-  (doseq [field [:evidence/intent-id
-                 :evidence/oir-id
-                 :evidence/capability-id]]
+  (doseq [field [:evidence/effect-id
+                 :evidence/grant-id
+                 :evidence/envelope-id]]
     (is (invalid? (opsv/validate-actuation
                    (update valid-actuation :governed-effects
                            #(mapv (fn [effect] (dissoc effect field)) %))))

--- a/docs/pull-requests/2026-08-06-codex-n7-opsv-ariadne-evidence.md
+++ b/docs/pull-requests/2026-08-06-codex-n7-opsv-ariadne-evidence.md
@@ -33,7 +33,7 @@ Normative governed-effect and evidence contracts.
 - Establish the Ariadne adoption profile in N10 and make it authoritative over
   the retained legacy design material.
 - Correlate each governed effect by effect transaction, execution grant, and
-  allow decision envelope UUID.
+  allowing decision envelope UUID.
 - Replace aggregate capability references with execution-grant references.
 - Synchronize the closed OPSV, N3 event, and N6 evidence schemas and fixtures.
 - Make production grant issuance an explicit prerequisite for N7 actuation.

--- a/docs/pull-requests/2026-08-06-codex-n7-opsv-ariadne-evidence.md
+++ b/docs/pull-requests/2026-08-06-codex-n7-opsv-ariadne-evidence.md
@@ -1,0 +1,80 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor: align OPSV governed effects with Ariadne
+
+## Overview
+
+Replace OPSV's stale N10 intent/OIR/capability evidence with the accepted
+Ariadne runtime identities: EffectTransaction, ExecutionGrant, and
+DecisionEnvelope.
+
+## Motivation
+
+N7's actuation contract still referred to execution objects that the accepted
+Ariadne adoption RFC superseded and that production code does not implement.
+Building against those fields would either create a second authority model or
+encourage fabricated identifiers. This change makes the evidence contract
+truthful before external mutation is added.
+
+## Layer
+
+Normative governed-effect and evidence contracts.
+
+## Depends on
+
+- PR #1680 (deterministic OPSV staging adapter) — merged
+
+## Changes in Detail
+
+- Establish the Ariadne adoption profile in N10 and make it authoritative over
+  the retained legacy design material.
+- Correlate each governed effect by effect transaction, execution grant, and
+  allow decision envelope UUID.
+- Replace aggregate capability references with execution-grant references.
+- Synchronize the closed OPSV, N3 event, and N6 evidence schemas and fixtures.
+- Make production grant issuance an explicit prerequisite for N7 actuation.
+
+## Standards Audit
+
+- The spec and all three closed runtime schemas use one correlation vocabulary;
+  there is no compatibility shim or duplicated legacy/current map shape.
+- Evidence finalization derives grant correlation from governed effects and
+  reports a domain-specific mismatch value.
+- Changed functions remain small, value-oriented, and in their existing strata;
+  no namespace or component dependency is added.
+- The compliance scanner reports no finding in a changed file. Its 79 findings
+  are the existing repository baseline.
+- clj-kondo and computed-stratum checks are clean. Polylith reports only the
+  four existing workspace warnings.
+
+## Testing Plan
+
+- Focused OPSV/event/evidence tests: 23 tests, 175 assertions.
+- Full `evidence-bundle` brick tests across three projects: green.
+- Full `opsv` brick tests across two projects: green.
+- Full `event-stream` brick tests across four projects: green.
+- Pre-commit smoke: 339 tests, 1,285 assertions.
+- GraalVM/Babashka compatibility: 8 tests, 606 assertions.
+- Miniforge CLI uberjar builds successfully.
+
+## Deployment Plan
+
+No deployment action is required. This is a contract migration; OPSV remains
+recommend-only and emits no external effects.
+
+## Checklist
+
+- [x] N3, N6, N7, and N10 agree on Ariadne effect correlation.
+- [x] Runtime schemas reject the superseded evidence keys.
+- [x] Evidence finalization requires every effect's grant to be referenced.
+- [x] The actuation work item forbids unenforced authority.
+- [x] Grant issuance is named as a prerequisite rather than simulated in OPSV.
+
+## Follow-up
+
+Implement the Ariadne grant-issuance prerequisite, then build OPSV PR and apply
+effects on the real grant and effect-transaction path.

--- a/specs/normative/N10-governed-tool-execution.md
+++ b/specs/normative/N10-governed-tool-execution.md
@@ -59,11 +59,11 @@ rechecked at commit, and the runtime decision that allowed it:
 
 ### 1.2 What This Specification Defines
 
-- Operational intent representation (§2)
+- Operational intent and IR design input (§2, informative legacy material)
 - Action classification and tool-declared risk (§3)
 - Verification pipeline (§4)
 - Validation requirements (§5)
-- Capability model and lifecycle (§6)
+- Capability model and lifecycle design input (§6, informative legacy material)
 - Execution capsule isolation (§7)
 - Crown jewel protection (§8)
 - Postcondition monitoring (§9)

--- a/specs/normative/N10-governed-tool-execution.md
+++ b/specs/normative/N10-governed-tool-execution.md
@@ -39,6 +39,13 @@ NOT implement a parallel capability broker. Sections that retain the older
 intent/OIR/capability vocabulary describe design inputs only; where they conflict
 with this profile, this profile governs.
 
+For avoidance of doubt, every `REQUIRED` or `OPTIONAL` annotation and every
+`MUST` or `MUST NOT` statement that depends on the legacy Intent, Operational
+IR, Capability, or Capability Broker objects is informative only and has no
+independent conformance force. Implementations MUST express the underlying
+safety requirement through the adopted Ariadne contracts. Requirements that do
+not depend on those superseded objects remain normative.
+
 Governed-effect evidence MUST correlate the durable transaction, the grant
 rechecked at commit, and the runtime decision that allowed it:
 

--- a/specs/normative/N10-governed-tool-execution.md
+++ b/specs/normative/N10-governed-tool-execution.md
@@ -843,6 +843,13 @@ Validation and environment adapters (§5.3) register through the tool registry:
 All governed execution operations MUST emit events to the event stream (N3) and
 produce evidence for evidence bundles (N6).
 
+> **Ariadne profile:** Rows whose event, trigger, or data depends on Intent,
+> Operational IR, Capability, or Capability Broker are informative legacy
+> placeholders, despite this section's heading. Implementations MUST NOT emit
+> them as unregistered N3 event types. Conformant domain events correlate the
+> DecisionEnvelope, ExecutionGrant, and EffectTransaction identifiers; a new
+> lifecycle event type requires an N3 registry amendment.
+
 | Event | Trigger | Data |
 |-------|---------|------|
 | `:intent/created` | Agent expresses intent | Intent structure |

--- a/specs/normative/N10-governed-tool-execution.md
+++ b/specs/normative/N10-governed-tool-execution.md
@@ -39,12 +39,14 @@ NOT implement a parallel capability broker. Sections that retain the older
 intent/OIR/capability vocabulary describe design inputs only; where they conflict
 with this profile, this profile governs.
 
-For avoidance of doubt, every `REQUIRED` or `OPTIONAL` annotation and every
-`MUST` or `MUST NOT` statement that depends on the legacy Intent, Operational
-IR, Capability, or Capability Broker objects is informative only and has no
+The following legacy material is explicitly informative: §2 and §6 in full;
+the Intent-, Operational-IR-, Capability-, and Capability-Broker-dependent
+clauses in §§3–5, §§7–10, §12, and §§13.2–13.4; and their architecture and
+glossary references in §§14–17. Within that material, every `REQUIRED` or
+`OPTIONAL` field annotation and every `MUST` or `MUST NOT` statement has no
 independent conformance force. Implementations MUST express the underlying
-safety requirement through the adopted Ariadne contracts. Requirements that do
-not depend on those superseded objects remain normative.
+safety requirement through the adopted Ariadne contracts. All other clauses
+remain normative.
 
 Governed-effect evidence MUST correlate the durable transaction, the grant
 rechecked at commit, and the runtime decision that allowed it:
@@ -91,7 +93,7 @@ rechecked at commit, and the runtime decision that allowed it:
 
 ---
 
-## 2. Operational Intent
+## 2. Operational Intent (Informative Legacy Design Input)
 
 ### 2.1 Intent Model
 
@@ -477,7 +479,7 @@ audit ledger (N6).
 
 ---
 
-## 6. Capability Model
+## 6. Capability Model (Informative Legacy Design Input)
 
 ### 6.1 Capability Structure
 
@@ -904,7 +906,7 @@ Governed execution produces a sub-bundle within the workflow's evidence bundle:
 | N10.VL.2 | MUST | Class C and above MUST undergo provider dry-run |
 | N10.VL.3 | SHOULD | Implementations SHOULD support the ValidationAdapter interface for extended strategies |
 
-### 13.4 Capabilities
+### 13.4 Capabilities (Informative Legacy Design Input)
 
 | ID | Level | Requirement |
 |----|-------|-------------|

--- a/specs/normative/N10-governed-tool-execution.md
+++ b/specs/normative/N10-governed-tool-execution.md
@@ -6,8 +6,8 @@
 
 # N10 — Governed Tool Execution
 
-**Version:** 0.2.0-draft
-**Date:** 2026-03-08
+**Version:** 0.3.0-draft
+**Date:** 2026-08-06
 **Status:** Draft
 **Conformance:** MUST
 
@@ -26,10 +26,29 @@ operations such as:
 - large-scale unintended infrastructure changes
 - credential leakage or privilege escalation
 
-The core model: agents express **operational intent**, which is verified, classified,
-policy-evaluated, and executed inside **isolated capsules** with **ephemeral capabilities**.
+The core model: agents request effects, while the runtime decides through an
+Ariadne DecisionEnvelope and executes only under a bounded ExecutionGrant and a
+durable EffectTransaction.
 
-### 1.1 What This Specification Defines
+### 1.1 Ariadne adoption profile
+
+The accepted Ariadne adoption RFC supersedes this document's older Operational
+IR and capability objects. Miniforge implementations MUST use the runtime-owned
+`DecisionEnvelope`, `ExecutionGrant`, and `EffectTransaction` contracts and MUST
+NOT implement a parallel capability broker. Sections that retain the older
+intent/OIR/capability vocabulary describe design inputs only; where they conflict
+with this profile, this profile governs.
+
+Governed-effect evidence MUST correlate the durable transaction, the grant
+rechecked at commit, and the runtime decision that allowed it:
+
+```clojure
+{:evidence/effect-id uuid
+ :evidence/grant-id uuid
+ :evidence/envelope-id uuid}
+```
+
+### 1.2 What This Specification Defines
 
 - Operational intent representation (§2)
 - Action classification and tool-declared risk (§3)
@@ -44,14 +63,14 @@ policy-evaluated, and executed inside **isolated capsules** with **ephemeral cap
 - Audit integration (§12)
 - Conformance requirements (§13)
 
-### 1.2 What This Specification Does Not Define
+### 1.3 What This Specification Does Not Define
 
 - Fleet governance and trust scoring (future N12 enterprise extension)
 - Specific diagnostic or incident workflows (informative: I-INCIDENT-DIAGNOSTICS)
 - Extended validation strategies beyond static analysis and provider dry-run
   (informative: I-VALIDATION-STRATEGIES)
 
-### 1.3 Design Principles
+### 1.4 Design Principles
 
 1. **Intent over command** — agents declare what they want to achieve, not which
    commands to run
@@ -838,17 +857,16 @@ produce evidence for evidence bundles (N6).
 Governed execution produces a sub-bundle within the workflow's evidence bundle:
 
 ```clojure
-{:evidence/type           :governed-execution
- :evidence/intent-id      uuid
- :evidence/oir-id         uuid
- :evidence/action-class   keyword
- :evidence/policy-result  map
- :evidence/validation     map
- :evidence/capability-id  string
- :evidence/capsule-result map
- :evidence/postconditions [map]
- :evidence/duration-ms    long
- :evidence/timestamp      inst}
+{:evidence/type            :governed-execution
+ :evidence/effect-id       uuid
+ :evidence/grant-id        uuid
+ :evidence/envelope-id     uuid
+ :evidence/action-class    keyword
+ :evidence/validation      map
+ :evidence/effect-result   map
+ :evidence/postconditions  [map]
+ :evidence/duration-ms     long
+ :evidence/timestamp       inst}
 ```
 
 ---
@@ -1033,6 +1051,9 @@ Audit Ledger (N3 events + N6 evidence bundles)
 
 **Version History:**
 
+- 0.3.0-draft (2026-08-06): Applied the accepted Ariadne adoption profile;
+  DecisionEnvelope, ExecutionGrant, and EffectTransaction supersede the
+  parallel intent/OIR/capability execution objects
 - 0.2.0-draft (2026-03-08): Reliability Nines amendments — Operational Semantics with
   timeout/retry/circuit-breaker/concurrency/fallback (§3.4), Tool Health Tracking (§3.5),
   Tool Response Validation (§7.4), unified autonomy model back-reference (§14),

--- a/specs/normative/N3-event-stream.md
+++ b/specs/normative/N3-event-stream.md
@@ -6,10 +6,13 @@
 
 # N3 — Event Stream & Observability Contract
 
-**Version:** 0.10.0-draft
-**Date:** 2026-08-05
+**Version:** 0.10.1-draft
+**Date:** 2026-08-06
 **Status:** Draft
 **Conformance:** MUST
+
+_v0.10.1 aligns OPSV governed-effect correlation with the accepted Ariadne
+runtime contracts._
 
 _v0.10.0 closes the spec's structural gaps: a canonical event-type registry
 (§6), schema evolution and consumer compatibility rules (§7), sensitive-data
@@ -1344,10 +1347,10 @@ event types:
  :opsv/evidence-bundle-id uuid
  :opsv/requested-actuation-mode keyword ; :recommend-only, :pr-only, :apply-allowed
  :opsv/effective-actuation-mode keyword ; :none, :recommend-only, :pr-only, :apply-allowed
- :opsv/governed-effects              ; Correlates each N10 intent, OIR, and capability
- [{:evidence/intent-id uuid
-   :evidence/oir-id uuid
-   :evidence/capability-id string}]
+ :opsv/governed-effects              ; Correlates the Ariadne effect, grant, and decision
+ [{:evidence/effect-id uuid
+   :evidence/grant-id uuid
+   :evidence/envelope-id uuid}]
  :opsv/pr-refs [string ...]          ; PR URLs if PR_ONLY
  :opsv/apply-refs [string ...]       ; Applied resource refs if APPLY_ALLOWED
  :message "OPSV actuation emitted: {effective-actuation-mode}"}
@@ -3279,6 +3282,8 @@ resolution is an N3 amendment per §6.1, not silent acceptance.
 
 **Version History:**
 
+- 0.10.1-draft (2026-08-06): Replaced stale OPSV intent/OIR/capability
+  correlation with Ariadne effect, execution-grant, and decision-envelope IDs
 - 0.10.0-draft (2026-08-05): Spec-completion pass.
   **New normative sections:** event type registry (§6), schema evolution and
   consumer compatibility (§7), sensitive data and redaction (§8), emission

--- a/specs/normative/N6-evidence-provenance.md
+++ b/specs/normative/N6-evidence-provenance.md
@@ -6,8 +6,8 @@
 
 # N6 — Evidence & Provenance Standard
 
-**Version:** 0.7.1-draft
-**Date:** 2026-08-05
+**Version:** 0.7.2-draft
+**Date:** 2026-08-06
 **Status:** Draft
 **Conformance:** MUST
 
@@ -327,7 +327,7 @@ The workflow MUST allocate the evidence bundle identifier before emitting its
 first OPSV event and accumulate material in a run-scoped assembly record. At
 terminal disposition it MUST publish one immutable bundle whose identifier is
 the preallocated value. Finalization MUST preserve references to every event,
-artifact, capability, and governed effect accumulated during the run.
+artifact, execution grant, and governed effect accumulated during the run.
 
 ```clojure
 {:evidence/opsv
@@ -342,7 +342,7 @@ artifact, capability, and governed effect accumulated during the run.
 
   :opsv/event-refs [uuid ...]          ; Complete N3 event identifier set
   :opsv/artifact-refs [uuid ...]       ; Complete referenced artifact set
-  :opsv/capability-refs [string ...]   ; Complete N10 capability identifier set
+  :opsv/grant-refs [uuid ...]          ; Complete Ariadne ExecutionGrant identifier set
 
   :opsv/risk-score
   {:score double                      ; [0.0, 1.0]
@@ -374,10 +374,10 @@ artifact, capability, and governed effect accumulated during the run.
   :opsv/actuation
   {:requested-actuation-mode keyword  ; :recommend-only, :pr-only, :apply-allowed
    :effective-actuation-mode keyword  ; :none, :recommend-only, :pr-only, :apply-allowed
-   :governed-effects                   ; One correlated record per N10 effect
-   [{:evidence/intent-id uuid
-     :evidence/oir-id uuid
-     :evidence/capability-id string}]
+   :governed-effects                   ; One correlated Ariadne transaction per effect
+   [{:evidence/effect-id uuid
+     :evidence/grant-id uuid
+     :evidence/envelope-id uuid}]
    :pr-refs [string ...]              ; PR URLs if PR_ONLY
    :apply-refs [string ...]           ; Applied resource refs if APPLY_ALLOWED
    :postcondition-artifact-refs [uuid ...]
@@ -1119,6 +1119,8 @@ Fleet-wide evidence will enable:
 
 **Version History:**
 
+- 0.7.2-draft (2026-08-06): Replaced stale OPSV capability references with
+  Ariadne effect, execution-grant, and decision-envelope correlation
 - 0.7.1-draft (2026-08-05): Added aggregate OPSV event, artifact, and capability
   reference fields required by the immutable-finalization contract in §2.8
 - 0.7.0-draft (2026-08-04): OPSV evidence now records preallocated bundle

--- a/specs/normative/N7-Operational-Policy-Synthesis.md
+++ b/specs/normative/N7-Operational-Policy-Synthesis.md
@@ -6,8 +6,8 @@
 
 # N7 — Operational Policy Synthesis With Verification
 
-**Version:** 0.2.0-draft
-**Date:** 2026-08-04
+**Version:** 0.2.1-draft
+**Date:** 2026-08-06
 **Status:** Complete
 **Conformance:** MUST
 **Class:** Extension spec (N7+)
@@ -39,8 +39,9 @@ OPSV is an extension of existing Miniforge normative contracts:
 - **N6**: defines evidence bundle requirements for experiment provenance, reproducibility, and
           verification artifacts. Now landed in N6 §2.8 (OPSV Evidence) and §3.1.1 (artifact types).
 - **N8**: supplies emergency-stop and safe-mode behavior for active OPSV runs (§3.1.4, §3.4).
-- **N10**: governs PR creation and direct apply as external effects, including capability,
-           rollback verification, postconditions, audit events, and evidence (§§4–6, §9, §12).
+- **N10/Ariadne**: govern PR creation and direct apply as external effects using
+  DecisionEnvelopes, ExecutionGrants, EffectTransactions, rollback verification,
+  postconditions, audit events, and evidence.
 
 ### 0.3 Non-goals
 
@@ -302,7 +303,7 @@ If any gate fails, OPSV MUST produce remediation guidance as machine-readable ou
 - All OPSV runs MUST support a global emergency stop.
 
 An N8 emergency stop or safe-mode entry MUST prevent new OPSV effects, abort
-active experiments at the next safe boundary, revoke their mutation capabilities,
+active experiments at the next safe boundary, revoke their mutation grants,
 invoke verified rollback through the separately authorized recovery path, and
 record the disposition in N3/N6. Safe mode MUST set effective actuation to
 `:none` per N8's A0 posture.
@@ -311,14 +312,14 @@ record the disposition in N3/N6. Safe mode MUST set effective actuation to
 
 Before any external mutation, OPSV MUST compute an effective actuation decision
 from the requested mode, verification result, N4 gate results, N8 safe-mode
-state, and current N10 capability. The decision MAY reduce autonomy but MUST NOT
+state, and current Ariadne ExecutionGrant. The decision MAY reduce autonomy but MUST NOT
 promote beyond the requested mode.
 
 - `:none` emits only disposition evidence and is required when N8 forbids execution.
 - `:recommend-only` never produces an external mutation.
-- `:pr-only` requires authority for the PR-creation effect.
+- `:pr-only` requires a matching active grant for the PR-creation effect.
 - `:apply-allowed` requires successful verification, all gates, a valid scoped
-  capability at execution time, a verified rollback, and configured postconditions.
+  ExecutionGrant at execution time, a verified rollback, and configured postconditions.
 
 The decision and every authority/effect reference MUST be recorded in N6 evidence.
 
@@ -361,7 +362,7 @@ All changes MUST be emitted as artifacts with provenance per N6:
 
 - at least one PR per target repo or a coordinated patch set
 - included evidence bundle link/reference and rollback instructions in PR body
-- N10 capability and governed-action references for the provider mutation
+- Ariadne grant, decision-envelope, and effect-transaction references for the provider mutation
 
 ### 7.3 Apply emission (optional, gated)
 
@@ -403,6 +404,9 @@ A minimal compliant OPSV implementation MUST:
 
 **Version History:**
 
+- 0.2.1-draft (2026-08-06): Replaced stale N10 intent/OIR/capability
+  correlation with the adopted Ariadne DecisionEnvelope, ExecutionGrant, and
+  EffectTransaction contracts
 - 0.2.0-draft (2026-08-04): Reconciled canonical schemas, events, evidence,
   requested/effective actuation, verification blocking, N8 safe mode, and N10 effects
 - 0.1.0-draft (2026-02-01): Initial OPSV extension specification

--- a/work/n07-opsv-governed-actuation.spec.edn
+++ b/work/n07-opsv-governed-actuation.spec.edn
@@ -1,7 +1,7 @@
 {:spec/title "Implement governed OPSV PR, Kubernetes apply, and rollback effects"
 
  :spec/description
- "Add provider and Kubernetes adapter protocols plus N10-backed PR creation and
+ "Add provider and Kubernetes adapter protocols plus Ariadne-backed PR creation and
   direct apply. Direct apply uses the resolved OCI/Kubernetes command surface,
   verified rollback, postcondition monitoring, and effect reconciliation. N8
   emergency stop revokes new mutation, stops load at a safe boundary, and invokes
@@ -17,10 +17,12 @@
  ["specs/normative/N7-Operational-Policy-Synthesis.md"
   "specs/normative/N8-observability-control-interface.md"
   "specs/normative/N10-governed-tool-execution.md"
-  "specs/normative/N11-delta-runtime-adapter.md"]
+  "specs/normative/N11-delta-runtime-adapter.md"
+  "docs/architecture/rfc-ariadne-adoption.md"]
 
  :spec/constraints
- ["PR creation and apply MUST require real matching N10 grants at execution time"
+ ["PR creation and apply MUST require a real matching ExecutionGrant at execution time"
+  "Every effect MUST correlate its EffectTransaction, ExecutionGrant, and allow DecisionEnvelope"
   "OPSV MUST NOT use :authority/unenforced"
   "Runtime differences MUST remain registry data and MUST NOT branch on :runtime/kind"
   "Direct apply MUST have verified rollback and configured postconditions"
@@ -40,7 +42,8 @@
   :rationale "External mutations are the highest-risk N7 stratum and must reuse settled N8/N10 authority."
   :blocks ["n07-opsv-cli-tui-drift.spec.edn"]
   :blocked-by ["n07-opsv-domain-policy.spec.edn"
-               "n07-opsv-workflow.spec.edn"]}
+               "n07-opsv-workflow.spec.edn"
+               "ariadne-grant-issuance.spec.edn"]}
 
  :dag/id :n07-opsv-governed-actuation
  :spec/workflow-type :canonical-sdlc}

--- a/work/n07-opsv-governed-actuation.spec.edn
+++ b/work/n07-opsv-governed-actuation.spec.edn
@@ -22,7 +22,7 @@
 
  :spec/constraints
  ["PR creation and apply MUST require a real matching ExecutionGrant at execution time"
-  "Every effect MUST correlate its EffectTransaction, ExecutionGrant, and allow DecisionEnvelope"
+  "Every effect MUST record the IDs of its EffectTransaction, ExecutionGrant, and allowing DecisionEnvelope"
   "OPSV MUST NOT use :authority/unenforced"
   "Runtime differences MUST remain registry data and MUST NOT branch on :runtime/kind"
   "Direct apply MUST have verified rollback and configured postconditions"


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# refactor: align OPSV governed effects with Ariadne

## Overview

Replace OPSV's stale N10 intent/OIR/capability evidence with the accepted
Ariadne runtime identities: EffectTransaction, ExecutionGrant, and
DecisionEnvelope.

## Motivation

N7's actuation contract still referred to execution objects that the accepted
Ariadne adoption RFC superseded and that production code does not implement.
Building against those fields would either create a second authority model or
encourage fabricated identifiers. This change makes the evidence contract
truthful before external mutation is added.

## Layer

Normative governed-effect and evidence contracts.

## Depends on

- PR #1680 (deterministic OPSV staging adapter) — merged

## Changes in Detail

- Establish the Ariadne adoption profile in N10 and make it authoritative over
  the retained legacy design material.
- Correlate each governed effect by effect transaction, execution grant, and
  allowing decision envelope UUID.
- Replace aggregate capability references with execution-grant references.
- Synchronize the closed OPSV, N3 event, and N6 evidence schemas and fixtures.
- Make production grant issuance an explicit prerequisite for N7 actuation.

## Standards Audit

- The spec and all three closed runtime schemas use one correlation vocabulary;
  there is no compatibility shim or duplicated legacy/current map shape.
- Evidence finalization derives grant correlation from governed effects and
  reports a domain-specific mismatch value.
- Changed functions remain small, value-oriented, and in their existing strata;
  no namespace or component dependency is added.
- The compliance scanner reports no finding in a changed file. Its 79 findings
  are the existing repository baseline.
- clj-kondo and computed-stratum checks are clean. Polylith reports only the
  four existing workspace warnings.

## Testing Plan

- Focused OPSV/event/evidence tests: 23 tests, 175 assertions.
- Full `evidence-bundle` brick tests across three projects: green.
- Full `opsv` brick tests across two projects: green.
- Full `event-stream` brick tests across four projects: green.
- Pre-commit smoke: 339 tests, 1,285 assertions.
- GraalVM/Babashka compatibility: 8 tests, 606 assertions.
- Miniforge CLI uberjar builds successfully.

## Deployment Plan

No deployment action is required. This is a contract migration; OPSV remains
recommend-only and emits no external effects.

## Checklist

- [x] N3, N6, N7, and N10 agree on Ariadne effect correlation.
- [x] Runtime schemas reject the superseded evidence keys.
- [x] Evidence finalization requires every effect's grant to be referenced.
- [x] The actuation work item forbids unenforced authority.
- [x] Grant issuance is named as a prerequisite rather than simulated in OPSV.

## Follow-up

Implement the Ariadne grant-issuance prerequisite, then build OPSV PR and apply
effects on the real grant and effect-transaction path.
