### PR TITLE
refactor: decompose effect transaction coordination

### DIFF
--- a/components/effect-transaction/deps.edn
+++ b/components/effect-transaction/deps.edn
@@ -1,6 +1,7 @@
-{:paths ["src"]
+{:paths ["src" "resources"]
  :deps {ai.miniforge/anomaly {:local/root "../anomaly"}
         ai.miniforge/execution-grant {:local/root "../execution-grant"}
+        ai.miniforge/messages {:local/root "../messages"}
         metosin/malli {:mvn/version "0.16.4"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/effect-transaction/resources/config/effect-transaction/messages/system.edn
+++ b/components/effect-transaction/resources/config/effect-transaction/messages/system.edn
@@ -1,0 +1,14 @@
+;; Title: Miniforge.ai
+;; Author: Christopher Lester (christopher@miniforge.ai)
+;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+
+{:effect-transaction/messages
+ {:grant/id-mismatch "Grant does not match the one recorded on the proposal"
+  :grant/effect-class-mismatch "Grant effect class does not match the proposed effect"
+  :grant/recheck-failed "Grant re-check failed at commit: {outcome}"
+  :record/change-invalid "EffectTransaction change failed validation"
+  :record/input-invalid "EffectTransaction inputs failed validation"
+  :proposal/no-store "propose! requires :dir — refusing to write records to the process working directory"
+  :commit/not-proposed "Only a :proposed record may be committed"
+  :reconcile/not-reconcilable "Only :committing or :unknown-outcome records are reconcilable"
+  :reconcile/no-answer "Reconciliation probe did not answer; record stays unresolved"}}

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/call.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/call.clj
@@ -1,0 +1,73 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.effect-transaction.call
+  "Convert effect and probe calls into honest outcome data.")
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} result
+  "Call `thunk`; preserve an Exception as data and let JVM Errors propagate."
+  [thunk]
+  (try
+    {:call/report (thunk)}
+    (catch Exception e
+      {:call/error (or (ex-message e) (str (class e)))})))
+
+(defn- ^{:stratum 0} outcome-of
+  "Return a definite reported outcome, or `:unknown-outcome`."
+  [reported]
+  (let [outcome (:effect/outcome reported)]
+    (if (contains? #{:succeeded :failed} outcome)
+      outcome
+      :unknown-outcome)))
+
+(defn ^{:stratum 0} probe-answered?
+  "True when a wrapped probe produced the reconciliation shape."
+  [called]
+  (let [answer (:call/report called)]
+    (and (not (contains? called :call/error))
+         (map? answer)
+         (contains? answer :effect/observed))))
+
+(defn ^{:stratum 0} probe-error-data
+  "Diagnostic data for a probe that did not answer."
+  [t called]
+  (cond-> {:effect/id (:effect/id t) :effect/state (:effect/state t)}
+    (contains? called :call/error)
+    (assoc :probe/error (:call/error called))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} effect-changes
+  "Transaction changes justified by one effect report."
+  [report]
+  (cond-> {:effect/state (outcome-of report)}
+    (contains? report :effect/observed)
+    (assoc :effect/observed (:effect/observed report))
+    (:effect/failure report)
+    (assoc :effect/failure (:effect/failure report))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} changes
+  "Transaction changes for a wrapped effect call."
+  [called]
+  (if-let [message (:call/error called)]
+    {:effect/state :unknown-outcome
+     :effect/failure message}
+    (effect-changes (:call/report called))))

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/commit.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/commit.clj
@@ -1,0 +1,105 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.effect-transaction.commit
+  "Commit authorization and effect execution for durable proposals."
+  (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.effect-transaction.call :as call]
+   [ai.miniforge.effect-transaction.messages :as msg]
+   [ai.miniforge.effect-transaction.record :as record]
+   [ai.miniforge.execution-grant.interface :as grant])
+  (:import
+   [java.time Instant]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} authorization-context
+  "Attach the durable proposal as the effect scope being authorized."
+  [t usage]
+  (assoc usage :effect/scope (:effect/proposal t)))
+
+(defn- ^{:stratum 0} grant-conflict
+  "Return a conflict when a grant is not the authority named by `t`."
+  [t grant-record]
+  (cond
+    (not= (:effect/grant-id t) (:grant/id grant-record))
+    (record/wrong-state (msg/t :grant/id-mismatch)
+                      {:effect/id (:effect/id t)
+                       :effect/grant-id (:effect/grant-id t)
+                       :grant/id (:grant/id grant-record)})
+
+    (not= (:effect/class t) (:grant/effect-class grant-record))
+    (record/wrong-state (msg/t :grant/effect-class-mismatch)
+                      {:effect/id (:effect/id t)
+                       :effect/class (:effect/class t)
+                       :grant/effect-class (:grant/effect-class grant-record)})
+
+    :else nil))
+
+(defn- ^{:stratum 0} execute!
+  "Persist the authority result, then perform and record the effect."
+  [dir t authority ^Instant now effect-fn]
+  (let [committing (record/advance! dir t
+                                    {:effect/state :committing
+                                     :effect/authority authority}
+                                    now)]
+    (if (anomaly/anomaly? committing)
+      committing
+      (record/advance! dir committing
+                       (call/changes (call/result effect-fn))
+                       now))))
+
+(defn- ^{:stratum 0} deny!
+  "Record a failed commit-time grant recheck without firing the effect."
+  [dir t auth ^Instant now]
+  (let [failure (msg/t :grant/recheck-failed
+                       {:outcome (name (:grant/outcome auth))})]
+    (record/advance! dir t {:effect/state :failed :effect/failure failure} now)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} authorized-commit!
+  "Authorize the durable proposal, then execute or record refusal."
+  [dir t grant-record usage ^Instant now effect-fn]
+  (let [context (authorization-context t usage)
+        auth (grant/authorize grant-record context now)]
+    (if (grant/authorized? auth)
+      (execute! dir t :granted now effect-fn)
+      (deny! dir t auth now))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} commit!
+  "Commit a proposed effect under its recorded grant.
+
+   The durable proposal, not caller usage, supplies authorization scope.
+   Exceptions from the effect become `:unknown-outcome`; JVM Errors
+   propagate after the `:committing` record is durable."
+  [dir t grant-record usage ^Instant now effect-fn]
+  (cond
+    (not= :proposed (:effect/state t))
+    (record/wrong-state (msg/t :commit/not-proposed)
+                      {:effect/id (:effect/id t)
+                       :effect/state (:effect/state t)})
+
+    (= :authority/unenforced grant-record)
+    (execute! dir t :unenforced now effect-fn)
+
+    :else
+    (or (grant-conflict t grant-record)
+        (authorized-commit! dir t grant-record usage now effect-fn))))

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/core.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/core.clj
@@ -16,26 +16,14 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns ai.miniforge.effect-transaction.core
-  "propose -> commit -> reconcile for irreversible effects (Ariadne 2c).
-
-   This GENERALIZES a pattern miniforge already runs rather than
-   inventing one. The operator intervention path is already transacted:
-   `operator_requests.clj` lands the request with ATOMIC_MOVE and
-   refuses to report success for a gesture that did not reach disk, and
-   `operator/application.clj` advances to `:dispatched` BEFORE firing
-   the effect, then verifies a `{:observed :expected}` readback. Merge,
-   deploy, and spend get the same treatment here.
-
-   The judgment that shapes everything below: an effect that THREW is
-   `:unknown-outcome`, not `:failed`. A timeout talking to GitHub may
-   well have merged the PR. Recording failure for an effect that landed
-   is exactly as wrong as recording success for one that did not, and
-   both are worse than admitting we do not yet know."
+  "Durable record lifecycle and coordinator facade for effects."
   (:require
    [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.effect-transaction.commit :as commit]
+   [ai.miniforge.effect-transaction.messages :as msg]
+   [ai.miniforge.effect-transaction.reconcile :as reconcile]
    [ai.miniforge.effect-transaction.schema :as schema]
    [ai.miniforge.effect-transaction.store :as store]
-   [ai.miniforge.execution-grant.interface :as grant]
    [malli.core :as m]
    [malli.error :as me])
   (:import
@@ -43,7 +31,6 @@
 
 ;------------------------------------------------------------------------------ Layer 0
 
-;; Validation + outcome reading
 (defn ^{:stratum 0} valid?
   "True when `t` satisfies the closed EffectTransaction schema."
   [t]
@@ -56,227 +43,34 @@
                        message
                        {:explain (me/humanize (m/explain schema/EffectTransaction t))}))
 
-(defn- ^{:stratum 0} wrong-state
-  "The record is not in a state this operation applies to — a caller
-   error about lifecycle position, not permission and not a transient
-   fault. `:conflict` is what routes that correctly."
-  [message data]
-  (anomaly/sub-anomaly :conflict
-                       :anomalies.effect-transaction/wrong-state
-                       message
-                       data))
+(def ^{:stratum 0} commit!
+  "Authorize and execute a durable proposal, recording an honest outcome."
+  commit/commit!)
 
-(defn- ^{:stratum 0} unresolved
-  "The external system did not answer, so the record stays as it is.
-   `:unavailable` because this is TRANSIENT and the right response is to
-   ask again later — classifying it as a caller error would send it to
-   handling that never retries."
-  [message data]
-  (anomaly/sub-anomaly :unavailable
-                       :anomalies.effect-transaction/unresolved
-                       message
-                       data))
-
-(defn- ^{:stratum 0} outcome-of
-  "Read an effect-fn's report. Anything this does not recognize is
-   `:unknown-outcome` — an effect fn that answered in a shape we cannot
-   read has told us nothing, and 'nothing' is not 'it failed'."
-  [reported]
-  (let [o (:effect/outcome reported)]
-    (if (contains? #{:succeeded :failed} o) o :unknown-outcome)))
+(def ^{:stratum 0} reconcile!
+  "Ask the external system to settle an unknown effect outcome."
+  reconcile/reconcile!)
 
 ;------------------------------------------------------------------------------ Layer 1
 
-;; Durable state advance
-(defn- ^{:stratum 1} advance!
-  "Apply `changes` to `t`, stamp `:effect/updated-at`, and persist
-   atomically. Returns the new record, or an `:invalid-input` anomaly
-   when the change would produce a record that does not validate — a
-   record we cannot describe is one we cannot reconcile, so it never
-   reaches disk."
-  [dir t changes ^Instant now]
-  (let [t' (assoc (merge t changes) :effect/updated-at now)]
-    (if (valid? t')
-      (do (store/write! dir t') t')
-      (invalid "EffectTransaction change failed validation" t'))))
-
-;; The transaction
 (defn ^{:stratum 1} propose!
-  "Record the intent to perform an irreversible effect, durably, BEFORE
-   anything happens. Returns the `:proposed` record.
-
-   A write failure propagates rather than returning a soft error: if we
-   cannot record that we are about to do something irreversible, the
-   caller must not do it.
-
-   The 1-arity convenience form REQUIRES `:dir`. A nil directory would
-   land records in the process working directory instead of the store —
-   the durability component silently writing the audit trail somewhere
-   nobody looks is the worst failure it could have, so it is refused
-   rather than defaulted."
+  "Record an irreversible effect durably before anything happens."
   ([{:keys [dir] :as opts}]
    (if (nil? dir)
      (anomaly/sub-anomaly :invalid-input
                           :anomalies.effect-transaction/no-store-dir
-                          "propose! requires :dir — refusing to write records to the process working directory"
+                          (msg/t :proposal/no-store)
                           {})
      (propose! dir opts (Instant/now))))
-  ([dir {:keys [effect-class grant-id envelope-id proposal]} ^Instant now]
+  ([dir {:keys [effect-class grant-id envelope-id] :as opts} ^Instant now]
    (let [t {:effect/id (random-uuid)
             :effect/class effect-class
             :effect/grant-id grant-id
             :effect/envelope-id envelope-id
-            :effect/proposal (or proposal {})
+            :effect/proposal (get opts :proposal {})
             :effect/state :proposed
             :effect/at now
             :effect/updated-at now}]
      (if (valid? t)
        (do (store/write! dir t) t)
-       (invalid "EffectTransaction inputs failed validation" t)))))
-
-;------------------------------------------------------------------------------ Layer 2
-
-(defn ^{:stratum 2} commit!
-  "Re-check the grant, mark the record `:committing`, run `effect-fn`,
-   and record what it reported.
-
-   The re-check is the point (Ariadne 2b Group 4): a grant that was live
-   at decide() and revoked or expired before now fails HERE, and the
-   effect never fires. `effect-fn` is a thunk returning
-   `{:effect/outcome :succeeded|:failed, :effect/observed ...}`.
-
-   Outcome mapping, and the reason for it:
-     returns :succeeded  -> :succeeded
-     returns :failed     -> :failed        (it knows the effect did not happen)
-     THROWS              -> :unknown-outcome
-     anything else       -> :unknown-outcome
-
-   A throw is not a failure. The call may have reached GitHub and come
-   back as a timeout; the record stays honestly unknown until
-   `reconcile!` asks.
-
-   The supplied grant must be THE grant the proposal named, and its
-   effect class must match the proposed effect. Re-checking a different
-   grant would authorize the effect against authority the proposal never
-   claimed.
-
-   Only a `:proposed` record may be committed. Committing one that has
-   already moved on would re-run an irreversible effect — a second
-   merge, a second deploy — which is the exact class of accident this
-   component exists to make impossible. Refused, and the effect does not
-   fire.
-
-   Passing `:authority/unenforced` in place of a grant skips every
-   authority check and stamps `:effect/authority :unenforced` on the
-   record. That is the honest state of the world today: nothing in
-   production ISSUES a grant (see
-   `work/ariadne-grant-issuance.spec.edn`), so requiring one would deny
-   every merge and deploy permanently. It is spelled out rather than
-   accepted as a silent nil so it greps, and so the record says plainly
-   that no authority was checked instead of leaving a blank that later
-   reads as approval. Remove it when issuance lands.
-
-   JVM `Error`s are NOT caught. An OutOfMemoryError is not an effect
-   outcome, and the record is already `:committing` on disk before
-   `effect-fn` runs, so letting it propagate leaves precisely the state
-   reconciliation is built for."
-  [dir t grant-record usage ^Instant now effect-fn]
-  (let [unenforced? (= :authority/unenforced grant-record)
-        auth (when-not unenforced? (grant/authorize grant-record usage now))]
-    (cond
-      (not= :proposed (:effect/state t))
-      (wrong-state "only a :proposed record may be committed"
-                   {:effect/id (:effect/id t) :effect/state (:effect/state t)})
-
-      ;; The record NAMES the grant that authorized it. Re-checking some
-      ;; other grant would authorize the effect against authority the
-      ;; proposal never claimed — propose under a narrow grant, commit
-      ;; under a broad one, and the audit trail records a lie. The
-      ;; re-check is only worth anything if it re-checks the SAME grant.
-      (and (not unenforced?) (not= (:effect/grant-id t) (:grant/id grant-record)))
-      (wrong-state "grant does not match the one recorded on the proposal"
-                   {:effect/id (:effect/id t)
-                    :effect/grant-id (:effect/grant-id t)
-                    :grant/id (:grant/id grant-record)})
-
-      ;; Likewise the class: a merge grant must not authorize a deploy.
-      (and (not unenforced?) (not= (:effect/class t) (:grant/effect-class grant-record)))
-      (wrong-state "grant effect-class does not match the proposed effect"
-                   {:effect/id (:effect/id t)
-                    :effect/class (:effect/class t)
-                    :grant/effect-class (:grant/effect-class grant-record)})
-
-      (and (not unenforced?) (not (grant/authorized? auth)))
-      (advance! dir t {:effect/state :failed
-                       :effect/failure (str "grant re-check failed at commit: "
-                                            (name (:grant/outcome auth)))}
-                now)
-
-      :else
-      (let [committing (advance! dir t {:effect/state :committing
-                                        :effect/authority (if unenforced?
-                                                            :unenforced
-                                                            :granted)}
-                                 now)]
-        (if (anomaly/anomaly? committing)
-          committing
-          (let [reported (try
-                           {:ok (effect-fn)}
-                           (catch Exception e
-                             {:threw (or (ex-message e) (str (class e)))}))]
-            (if (contains? reported :threw)
-              (advance! dir committing
-                        {:effect/state :unknown-outcome
-                         :effect/failure (:threw reported)}
-                        now)
-              (let [r (:ok reported)]
-                (advance! dir committing
-                          (cond-> {:effect/state (outcome-of r)}
-                            (contains? r :effect/observed)
-                            (assoc :effect/observed (:effect/observed r))
-                            (:effect/failure r)
-                            (assoc :effect/failure (:effect/failure r)))
-                          now)))))))))
-
-(defn ^{:stratum 2} reconcile!
-  "Settle a record whose true outcome is not known locally by ASKING the
-   external system. `probe-fn` takes the record and returns
-   `{:effect/observed ... :effect/matched? bool}`.
-
-   The answer, not the local guess, becomes `:effect/observed`, and a
-   mismatch is recorded rather than smoothed over.
-
-   A probe that throws or answers in an unreadable shape leaves the
-   record where it is. Marking it `:reconciled` on a failed probe would
-   assert we found out when we did not, and would stop anything from
-   ever asking again.
-
-   An answer that omits `:effect/matched?` records `false`: an
-   unconfirmed match is treated as a mismatch, because an unflagged
-   disagreement is worse than a flagged one.
-
-   JVM `Error`s are NOT caught here either — a probe that dies of
-   OutOfMemory has not told us the effect is unresolvable, it has told
-   us the process is."
-  [dir t probe-fn ^Instant now]
-  (if-not (contains? schema/reconcilable-states (:effect/state t))
-    (wrong-state "only :committing or :unknown-outcome records are reconcilable"
-                 {:effect/id (:effect/id t) :effect/state (:effect/state t)})
-    ;; The probe's answer is wrapped rather than probed for a marker key:
-    ;; the probe returns caller-shaped data, so any in-band sentinel is a
-    ;; value it could legitimately carry. The wrapper map is ours.
-    (let [probed (try {:ok (probe-fn t)}
-                      (catch Exception e {:threw (or (ex-message e) (str (class e)))}))
-          answer (:ok probed)]
-      (if (or (contains? probed :threw)
-              (not (map? answer))
-              (not (contains? answer :effect/observed)))
-        (unresolved "reconciliation probe did not answer; record stays unresolved"
-                    (cond-> {:effect/id (:effect/id t) :effect/state (:effect/state t)}
-                      (contains? probed :threw)
-                      (assoc :probe/error (:threw probed))))
-        (advance! dir t
-                  {:effect/state :reconciled
-                   :effect/observed (:effect/observed answer)
-                   :effect/matched? (boolean (:effect/matched? answer))}
-                  now)))))
+       (invalid (msg/t :record/input-invalid) t)))))

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/core.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/core.clj
@@ -16,32 +16,25 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns ai.miniforge.effect-transaction.core
-  "Durable record lifecycle and coordinator facade for effects."
+  "propose -> commit -> reconcile facade for irreversible effects.
+
+   A proposed effect is durable before execution. An effect call that
+   throws has an unknown outcome, never a fabricated failure, and must
+   be reconciled by asking the external system what actually happened."
   (:require
-   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.effect-transaction.commit :as commit]
-   [ai.miniforge.effect-transaction.messages :as msg]
    [ai.miniforge.effect-transaction.reconcile :as reconcile]
-   [ai.miniforge.effect-transaction.schema :as schema]
-   [ai.miniforge.effect-transaction.store :as store]
-   [malli.core :as m]
-   [malli.error :as me])
-  (:import
-   [java.time Instant]))
+   [ai.miniforge.effect-transaction.record :as record]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
-(defn ^{:stratum 0} valid?
+(def ^{:stratum 0} valid?
   "True when `t` satisfies the closed EffectTransaction schema."
-  [t]
-  (m/validate schema/EffectTransaction t))
+  record/valid?)
 
-(defn- ^{:stratum 0} invalid
-  [message t]
-  (anomaly/sub-anomaly :invalid-input
-                       :anomalies.effect-transaction/invalid
-                       message
-                       {:explain (me/humanize (m/explain schema/EffectTransaction t))}))
+(def ^{:stratum 0} propose!
+  "Record the intent durably before an irreversible effect happens."
+  record/propose!)
 
 (def ^{:stratum 0} commit!
   "Authorize and execute a durable proposal, recording an honest outcome."
@@ -50,27 +43,3 @@
 (def ^{:stratum 0} reconcile!
   "Ask the external system to settle an unknown effect outcome."
   reconcile/reconcile!)
-
-;------------------------------------------------------------------------------ Layer 1
-
-(defn ^{:stratum 1} propose!
-  "Record an irreversible effect durably before anything happens."
-  ([{:keys [dir] :as opts}]
-   (if (nil? dir)
-     (anomaly/sub-anomaly :invalid-input
-                          :anomalies.effect-transaction/no-store-dir
-                          (msg/t :proposal/no-store)
-                          {})
-     (propose! dir opts (Instant/now))))
-  ([dir {:keys [effect-class grant-id envelope-id] :as opts} ^Instant now]
-   (let [t {:effect/id (random-uuid)
-            :effect/class effect-class
-            :effect/grant-id grant-id
-            :effect/envelope-id envelope-id
-            :effect/proposal (get opts :proposal {})
-            :effect/state :proposed
-            :effect/at now
-            :effect/updated-at now}]
-     (if (valid? t)
-       (do (store/write! dir t) t)
-       (invalid (msg/t :record/input-invalid) t)))))

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/messages.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/messages.clj
@@ -1,0 +1,29 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.effect-transaction.messages
+  "Developer-facing messages for the effect-transaction component."
+  (:require
+   [ai.miniforge.messages.interface :as messages]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} t
+  "Translate an effect-transaction system message."
+  (messages/create-translator
+   "config/effect-transaction/messages/system.edn"
+   :effect-transaction/messages))

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/reconcile.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/reconcile.clj
@@ -1,0 +1,59 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.effect-transaction.reconcile
+  "Settle unknown effect outcomes by asking the external system."
+  (:require
+   [ai.miniforge.effect-transaction.call :as call]
+   [ai.miniforge.effect-transaction.messages :as msg]
+   [ai.miniforge.effect-transaction.record :as record]
+   [ai.miniforge.effect-transaction.schema :as schema])
+  (:import
+   [java.time Instant]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} record-answer!
+  "Persist the external system's answer to a reconciliation probe."
+  [dir t answer ^Instant now]
+  (record/advance! dir t
+                   {:effect/state :reconciled
+                    :effect/observed (:effect/observed answer)
+                    :effect/matched? (boolean (:effect/matched? answer))}
+                   now))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} probe!
+  "Probe the external system and preserve an unresolved record on silence."
+  [dir t probe-fn ^Instant now]
+  (let [called (call/result (partial probe-fn t))]
+    (if (call/probe-answered? called)
+      (record-answer! dir t (:call/report called) now)
+      (record/unresolved (msg/t :reconcile/no-answer)
+                         (call/probe-error-data t called)))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} reconcile!
+  "Ask the world to settle a committing or unknown-outcome record."
+  [dir t probe-fn ^Instant now]
+  (if-not (contains? schema/reconcilable-states (:effect/state t))
+    (record/wrong-state (msg/t :reconcile/not-reconcilable)
+                        {:effect/id (:effect/id t)
+                         :effect/state (:effect/state t)})
+    (probe! dir t probe-fn now)))

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/record.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/record.clj
@@ -76,12 +76,12 @@
                           (msg/t :proposal/no-store)
                           {})
      (propose! dir opts (Instant/now))))
-  ([dir {:keys [effect-class grant-id envelope-id] :as opts} ^Instant now]
+  ([dir {:keys [effect-class grant-id envelope-id proposal]} ^Instant now]
    (let [t {:effect/id (random-uuid)
             :effect/class effect-class
             :effect/grant-id grant-id
             :effect/envelope-id envelope-id
-            :effect/proposal (get opts :proposal {})
+            :effect/proposal (if proposal proposal {})
             :effect/state :proposed
             :effect/at now
             :effect/updated-at now}]

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/record.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/record.clj
@@ -1,0 +1,90 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.effect-transaction.record
+  "Validation and durable lifecycle changes for effect transactions."
+  (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.effect-transaction.messages :as msg]
+   [ai.miniforge.effect-transaction.schema :as schema]
+   [ai.miniforge.effect-transaction.store :as store]
+   [malli.core :as m]
+   [malli.error :as me])
+  (:import
+   [java.time Instant]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} valid?
+  "True when `t` satisfies the closed EffectTransaction schema."
+  [t]
+  (m/validate schema/EffectTransaction t))
+
+(defn- ^{:stratum 0} invalid
+  [message t]
+  (anomaly/sub-anomaly :invalid-input
+                       :anomalies.effect-transaction/invalid
+                       message
+                       {:explain (me/humanize (m/explain schema/EffectTransaction t))}))
+
+(defn ^{:stratum 0} wrong-state
+  "Return a lifecycle-position conflict for an internal coordinator."
+  [message data]
+  (anomaly/sub-anomaly :conflict
+                       :anomalies.effect-transaction/wrong-state
+                       message
+                       data))
+
+(defn ^{:stratum 0} unresolved
+  "Return a transient unavailable result without changing the record."
+  [message data]
+  (anomaly/sub-anomaly :unavailable
+                       :anomalies.effect-transaction/unresolved
+                       message
+                       data))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} advance!
+  "Apply `changes` to `t`, validate, and persist the new record atomically."
+  [dir t changes ^Instant now]
+  (let [t' (assoc (merge t changes) :effect/updated-at now)]
+    (if (valid? t')
+      (do (store/write! dir t') t')
+      (invalid (msg/t :record/change-invalid) t'))))
+
+(defn ^{:stratum 1} propose!
+  "Record an irreversible effect durably before anything happens."
+  ([{:keys [dir] :as opts}]
+   (if (nil? dir)
+     (anomaly/sub-anomaly :invalid-input
+                          :anomalies.effect-transaction/no-store-dir
+                          (msg/t :proposal/no-store)
+                          {})
+     (propose! dir opts (Instant/now))))
+  ([dir {:keys [effect-class grant-id envelope-id] :as opts} ^Instant now]
+   (let [t {:effect/id (random-uuid)
+            :effect/class effect-class
+            :effect/grant-id grant-id
+            :effect/envelope-id envelope-id
+            :effect/proposal (get opts :proposal {})
+            :effect/state :proposed
+            :effect/at now
+            :effect/updated-at now}]
+     (if (valid? t)
+       (do (store/write! dir t) t)
+       (invalid (msg/t :record/input-invalid) t)))))

--- a/components/effect-transaction/test/ai/miniforge/effect_transaction/commit_test.clj
+++ b/components/effect-transaction/test/ai/miniforge/effect_transaction/commit_test.clj
@@ -141,6 +141,13 @@
   ;; merge. A second deploy.
   (let [dir (tmp-dir)
         g (merge-grant)]
+    (testing "falsey proposals retain the empty-map default"
+      (doseq [proposal [nil false]]
+        (is (= {} (:effect/proposal
+                   (fx/propose! dir {:effect-class :effect/merge
+                                     :grant-id (:grant/id g)
+                                     :proposal proposal}
+                                now))))))
     (doseq [state [:committing :succeeded :failed :unknown-outcome :reconciled]]
       (let [t (assoc (propose-merge! dir g) :effect/state state)
             fired (atom false)

--- a/components/effect-transaction/test/ai/miniforge/effect_transaction/commit_test.clj
+++ b/components/effect-transaction/test/ai/miniforge/effect_transaction/commit_test.clj
@@ -18,54 +18,28 @@
 (ns ai.miniforge.effect-transaction.commit-test
   (:require
    [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.effect-transaction.fixtures :as fixture]
    [ai.miniforge.effect-transaction.interface :as fx]
    [ai.miniforge.execution-grant.interface :as grant]
-   [clojure.test :refer [deftest is testing]])
-  (:import
-   [java.nio.file Files]
-   [java.nio.file.attribute FileAttribute]
-   [java.time Instant]))
+   [clojure.test :refer [deftest is testing]]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
-(def ^{:stratum 0} now (Instant/parse "2026-08-01T00:00:00Z"))
+(def ^{:stratum 0} now fixture/now)
 
-(def ^{:stratum 0} later (Instant/parse "2026-08-01T01:00:00Z"))
+(def ^{:stratum 0} later fixture/later)
 
-(def ^{:stratum 0} much-later (Instant/parse "2026-08-02T00:00:00Z"))
+(def ^{:stratum 0} much-later fixture/much-later)
 
-(defn ^{:stratum 0} tmp-dir
-  "A fresh directory per test — records are files, so tests that shared
-   one would see each other's."
-  []
-  (str (.toFile (Files/createTempDirectory "fx-test" (into-array FileAttribute [])))))
+(def ^{:stratum 0} tmp-dir fixture/tmp-dir)
+
+(def ^{:stratum 0} merge-grant fixture/merge-grant)
+
+(def ^{:stratum 0} propose-merge! fixture/propose-merge!)
 
 ;------------------------------------------------------------------------------ Layer 1
 
-(defn ^{:stratum 1} merge-grant
-  ([] (merge-grant {}))
-  ([overrides]
-   (grant/issue (merge {:principal "agent:implementer"
-                        :effect-class :effect/merge
-                        :scope {:repo "miniforge-ai/miniforge" :pr 42}
-                        :constraints {:constraint/max-count 5}
-                        :delegable? false
-                        :expires-at later}
-                       overrides)
-                now)))
-
-(defn ^{:stratum 1} propose-merge!
-  [dir g]
-  (fx/propose! dir
-               {:effect-class :effect/merge
-                :grant-id (:grant/id g)
-                :envelope-id (random-uuid)
-                :proposal {:pr/repo "miniforge-ai/miniforge" :pr/number 42}}
-               now))
-
-;------------------------------------------------------------------------------ Layer 2
-
-(deftest ^{:stratum 2} interrupted-effect-is-unknown-not-failed-test
+(deftest ^{:stratum 1} interrupted-effect-is-unknown-not-failed-test
   ;; The state that earns this component its keep. Claiming failure for
   ;; a merge that actually landed is as wrong as claiming success.
   (let [dir (tmp-dir)
@@ -80,7 +54,7 @@
     (testing "and the unknown state is durable, so a restart can find it"
       (is (= :unknown-outcome (:effect/state (fx/read-record dir (:effect/id t))))))))
 
-(deftest ^{:stratum 2} definite-outcomes-are-recorded-as-such-test
+(deftest ^{:stratum 1} definite-outcomes-are-recorded-as-such-test
   (let [dir (tmp-dir)
         g (merge-grant)]
     (testing "a definite success is :succeeded and carries the observation"
@@ -110,7 +84,7 @@
             done (fx/commit! dir t g {} now (constantly nil))]
         (is (= :unknown-outcome (:effect/state done)))))))
 
-(deftest ^{:stratum 2} commit-rechecks-the-grant-test
+(deftest ^{:stratum 1} commit-rechecks-the-grant-test
   ;; Ariadne 2b Group 4: a constraint checked only at decide() is a check
   ;; against stale state.
   (testing "a grant revoked after the proposal fails the commit, and the effect never fires"
@@ -161,7 +135,7 @@
       (is (= :proposed (:effect/state (fx/read-record dir (:effect/id t))))
           "the durable record is left as it was"))))
 
-(deftest ^{:stratum 2} only-a-proposed-record-may-be-committed-test
+(deftest ^{:stratum 1} only-a-proposed-record-may-be-committed-test
   ;; The accident this component exists to prevent: committing a record
   ;; that has already moved on re-runs an irreversible effect. A second
   ;; merge. A second deploy.
@@ -181,7 +155,7 @@
             done (fx/commit! dir t g {} now (fn [] {:effect/outcome :succeeded}))]
         (is (= :succeeded (:effect/state done)))))))
 
-(deftest ^{:stratum 2} commit-must-use-the-grant-the-proposal-named-test
+(deftest ^{:stratum 1} commit-must-use-the-grant-the-proposal-named-test
   ;; The re-check is only worth anything if it re-checks the SAME grant.
   ;; Otherwise: propose under a narrow grant, commit under a broad one,
   ;; and the durable record attests to authority that was never used.

--- a/components/effect-transaction/test/ai/miniforge/effect_transaction/fixtures.clj
+++ b/components/effect-transaction/test/ai/miniforge/effect_transaction/fixtures.clj
@@ -1,0 +1,67 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.effect-transaction.fixtures
+  (:require
+   [ai.miniforge.effect-transaction.interface :as fx]
+   [ai.miniforge.execution-grant.interface :as grant])
+  (:import
+   [java.nio.file Files]
+   [java.nio.file.attribute FileAttribute]
+   [java.time Instant]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} now (Instant/parse "2026-08-01T00:00:00Z"))
+
+(def ^{:stratum 0} later (Instant/parse "2026-08-01T01:00:00Z"))
+
+(def ^{:stratum 0} much-later (Instant/parse "2026-08-02T00:00:00Z"))
+
+(def ^{:stratum 0} merge-proposal
+  {:pr/repo "miniforge-ai/miniforge"
+   :pr/number 42})
+
+(defn ^{:stratum 0} tmp-dir
+  "A fresh directory for one effect-transaction test."
+  []
+  (str (.toFile (Files/createTempDirectory "fx-test" (into-array FileAttribute [])))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} merge-grant
+  "A merge grant matching the canonical test proposal."
+  ([] (merge-grant {}))
+  ([overrides]
+   (grant/issue (merge {:principal "agent:implementer"
+                        :effect-class :effect/merge
+                        :scope merge-proposal
+                        :constraints {:constraint/max-count 5}
+                        :delegable? false
+                        :expires-at later}
+                       overrides)
+                now)))
+
+(defn ^{:stratum 1} propose-merge!
+  "Persist the effect that `merge-grant` authorizes."
+  [dir g]
+  (fx/propose! dir
+               {:effect-class :effect/merge
+                :grant-id (:grant/id g)
+                :envelope-id (random-uuid)
+                :proposal merge-proposal}
+               now))

--- a/components/effect-transaction/test/ai/miniforge/effect_transaction/reconcile_test.clj
+++ b/components/effect-transaction/test/ai/miniforge/effect_transaction/reconcile_test.clj
@@ -18,52 +18,25 @@
 (ns ai.miniforge.effect-transaction.reconcile-test
   (:require
    [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.effect-transaction.fixtures :as fixture]
    [ai.miniforge.effect-transaction.interface :as fx]
-   [ai.miniforge.execution-grant.interface :as grant]
-   [clojure.test :refer [deftest is testing]])
-  (:import
-   [java.nio.file Files]
-   [java.nio.file.attribute FileAttribute]
-   [java.time Instant]))
+   [clojure.test :refer [deftest is testing]]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
-(def ^{:stratum 0} now (Instant/parse "2026-08-01T00:00:00Z"))
+(def ^{:stratum 0} now fixture/now)
 
-(def ^{:stratum 0} later (Instant/parse "2026-08-01T01:00:00Z"))
+(def ^{:stratum 0} later fixture/later)
 
-(defn ^{:stratum 0} tmp-dir
-  "A fresh directory per test — records are files, so tests that shared
-   one would see each other's."
-  []
-  (str (.toFile (Files/createTempDirectory "fx-test" (into-array FileAttribute [])))))
+(def ^{:stratum 0} tmp-dir fixture/tmp-dir)
+
+(def ^{:stratum 0} merge-grant fixture/merge-grant)
+
+(def ^{:stratum 0} propose-merge! fixture/propose-merge!)
 
 ;------------------------------------------------------------------------------ Layer 1
 
-(defn ^{:stratum 1} merge-grant
-  ([] (merge-grant {}))
-  ([overrides]
-   (grant/issue (merge {:principal "agent:implementer"
-                        :effect-class :effect/merge
-                        :scope {:repo "miniforge-ai/miniforge" :pr 42}
-                        :constraints {:constraint/max-count 5}
-                        :delegable? false
-                        :expires-at later}
-                       overrides)
-                now)))
-
-(defn ^{:stratum 1} propose-merge!
-  [dir g]
-  (fx/propose! dir
-               {:effect-class :effect/merge
-                :grant-id (:grant/id g)
-                :envelope-id (random-uuid)
-                :proposal {:pr/repo "miniforge-ai/miniforge" :pr/number 42}}
-               now))
-
-;------------------------------------------------------------------------------ Layer 2
-
-(deftest ^{:stratum 2} reconcile-reads-the-world-not-the-log-test
+(deftest ^{:stratum 1} reconcile-reads-the-world-not-the-log-test
   (let [dir (tmp-dir)
         g (merge-grant)]
     (testing "the observation comes from the probe, and a match is recorded"
@@ -134,7 +107,7 @@
         (is (anomaly/anomaly?
              (fx/reconcile! dir done (constantly {:effect/observed :x}) later)))))))
 
-(deftest ^{:stratum 2} committing-is-reconcilable-after-a-restart-test
+(deftest ^{:stratum 1} committing-is-reconcilable-after-a-restart-test
   ;; A process that died mid-effect leaves the record at :committing.
   ;; That is not failure and not success — it is exactly the case
   ;; reconciliation exists for.
@@ -152,7 +125,7 @@
     (is (= :reconciled (:effect/state settled)))
     (is (false? (:effect/matched? settled)))))
 
-(deftest ^{:stratum 2} refusal-anomalies-route-correctly-test
+(deftest ^{:stratum 1} refusal-anomalies-route-correctly-test
   ;; :unauthorized would say "you lack permission", which is neither
   ;; true nor useful here. A wrong lifecycle position is a :conflict; a
   ;; probe that did not answer is :unavailable — transient, ask again.

--- a/docs/pull-requests/2026-08-06-codex-effect-transaction-design.md
+++ b/docs/pull-requests/2026-08-06-codex-effect-transaction-design.md
@@ -1,0 +1,75 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor: decompose effect transaction coordination
+
+## Overview
+
+Bring EffectTransaction into compliance with component, function, message, and
+stratified-design standards before extending its authority contract.
+
+## Motivation
+
+The coordinator mixed durable record changes, call outcome interpretation,
+grant authorization, execution, and reconciliation in one namespace. Its
+declared three strata concealed eight inferred dependency layers. Commit and
+reconciliation tests also duplicated proposal and grant maps that had already
+drifted to different key vocabularies.
+
+## Layer
+
+Behavior-preserving internal component design.
+
+## Changes in Detail
+
+- Make `core` a thin public facade.
+- Separate durable records, wrapped calls, commit authorization, and
+  reconciliation into focused namespaces with at most three strata each.
+- Move developer-facing messages into the component message catalog.
+- Centralize the canonical merge proposal and grant fixtures shared by commit
+  and reconciliation tests.
+
+## Architecture
+
+`record` owns validation and atomic state advance. `call` converts injected
+effect and probe calls into honest data. `commit` coordinates authorization and
+effect execution. `reconcile` asks the external system to settle unknown
+outcomes. None of those responsibilities is duplicated by the facade.
+
+The durable proposal is adapted into grant authorization context in `commit`.
+The current grant implementation does not inspect that scope yet; the dependent
+grant-scope PR activates the contract and supplies its refusal tests.
+
+## Testing Plan
+
+- EffectTransaction tests across every consuming project.
+- Full stable-derived test plan across all five projects.
+- Poly check, kondo, stratum lint, compatibility tests, and PR budget.
+
+## Standards Review
+
+- Inferred strata: no namespace exceeds three layers.
+- Function design: each coordinator stage has one responsibility and named data
+  transitions replace the former nested control flow.
+- Component design: all new namespaces remain internal to EffectTransaction;
+  the public interface is unchanged.
+- Data design: one canonical proposal/grant fixture replaces duplicated maps.
+- Exceptions-as-data scan: the existing store throws remain intentional at the
+  durability boundary; failure to persist the audit record must stop the
+  irreversible effect.
+
+## Checklist
+
+- [x] Focused EffectTransaction tests pass in all four consuming projects.
+- [x] Full five-project test plan passes.
+- [x] Poly, kondo, stratum, compatibility, and pre-commit checks pass.
+- [x] PR budget passes at 591/600 reportable lines without override.
+- [x] Adversarial standards pass is clean for changed code.
+
+## Related Work
+
+- `work/ariadne-grant-scope-enforcement.spec.edn`
+- `work/ariadne-grant-issuance.spec.edn`


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# refactor: decompose effect transaction coordination

## Overview

Bring EffectTransaction into compliance with component, function, message, and
stratified-design standards before extending its authority contract.

## Motivation

The coordinator mixed durable record changes, call outcome interpretation,
grant authorization, execution, and reconciliation in one namespace. Its
declared three strata concealed eight inferred dependency layers. Commit and
reconciliation tests also duplicated proposal and grant maps that had already
drifted to different key vocabularies.

## Layer

Behavior-preserving internal component design.

## Changes in Detail

- Make `core` a thin public facade.
- Separate durable records, wrapped calls, commit authorization, and
  reconciliation into focused namespaces with at most three strata each.
- Move developer-facing messages into the component message catalog.
- Centralize the canonical merge proposal and grant fixtures shared by commit
  and reconciliation tests.

## Architecture

`record` owns validation and atomic state advance. `call` converts injected
effect and probe calls into honest data. `commit` coordinates authorization and
effect execution. `reconcile` asks the external system to settle unknown
outcomes. None of those responsibilities is duplicated by the facade.

The durable proposal is adapted into grant authorization context in `commit`.
The current grant implementation does not inspect that scope yet; the dependent
grant-scope PR activates the contract and supplies its refusal tests.

## Testing Plan

- EffectTransaction tests across every consuming project.
- Full stable-derived test plan across all five projects.
- Poly check, kondo, stratum lint, compatibility tests, and PR budget.

## Standards Review

- Inferred strata: no namespace exceeds three layers.
- Function design: each coordinator stage has one responsibility and named data
  transitions replace the former nested control flow.
- Component design: all new namespaces remain internal to EffectTransaction;
  the public interface is unchanged.
- Data design: one canonical proposal/grant fixture replaces duplicated maps.
- Exceptions-as-data scan: the existing store throws remain intentional at the
  durability boundary; failure to persist the audit record must stop the
  irreversible effect.

## Checklist

- [x] Focused EffectTransaction tests pass in all four consuming projects.
- [x] Full five-project test plan passes.
- [x] Poly, kondo, stratum, compatibility, and pre-commit checks pass.
- [x] PR budget passes at 591/600 reportable lines without override.
- [x] Adversarial standards pass is clean for changed code.

## Related Work

- `work/ariadne-grant-scope-enforcement.spec.edn`
- `work/ariadne-grant-issuance.spec.edn`
