### PR TITLE
docs(specs): N6 evidence & provenance spec completion (0.7.2 → 0.8.0-draft)

### DIFF
--- a/docs/pull-requests/2026-08-06-chris-n6-evidence-provenance-spec-complete.md
+++ b/docs/pull-requests/2026-08-06-chris-n6-evidence-provenance-spec-complete.md
@@ -1,0 +1,168 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# docs: N6 evidence & provenance spec completion (0.7.2 → 0.8.0-draft)
+
+## Overview
+
+Supplies the sealing mechanism behind the immutability N6 already claimed, the
+event-linkage and gate-evidence schemas other specs already depend on, and
+conformance requirement IDs. Adds Annex A recording implementation divergence.
+
+## Motivation
+
+**Immutability was asserted, never mechanised.** §1.1 principle 3 says bundles
+MUST NOT be modified after creation. §7.3 says "prevent tampering — immutable
+storage, content hashing". §9.1 requires implementations to *validate*
+immutability. None of it said how: no hash over the bundle, no canonical
+serialization, no verification procedure, no rule about what to do when
+verification fails. An audit record whose integrity cannot be checked is not
+audit evidence. The implementation had meanwhile invented an
+`:evidence/content-hash` field that the spec never mentioned.
+
+**N4 §5.5 places four obligations on N6 that the bundle did not carry.** A gate
+result MUST be reproducible from its evidence: the gate binding and resolved
+rule set, every violation including waived ones, each pack's content hash, and
+any waiver with its justification. The bundle schema recorded none of these. No
+gate result in the system is currently reproducible from its evidence.
+
+**Two redaction markers for one concept.** N3 §8.2 specifies `"[REDACTED]"`.
+N6 §7.2 specified `[REDACTED:<type>]`. An auditor grepping for redactions finds
+only some of them. §7.2 also permitted "redact **or** flag", where N3 §8.1 is a
+MUST NOT on the value existing at all.
+
+**The compliance key list disagreed with itself.** §2.1's bundle structure and
+§7.1's required set diverged in both directions: §7.1 required
+`:compliance/created-at` and `:compliance/retention-policy`, which §2.1 did not
+list; §2.1 had `:compliance/auditor-notes`, which §7.1 did not.
+
+**§5.1 required linking to the event stream** "via event sequence ranges" with
+no schema for the link — and since N3 now sequences per scope across six
+scopes, a bare range is ambiguous.
+
+**§8 restated N5's interface contracts.** "Implementations MUST provide CLI
+command `miniforge evidence show`" duplicates N5 §2.3.5; the TUI list
+duplicates N5 §3.2.3. Standard 020: reference, don't duplicate.
+
+## Changes in Detail
+
+### New normative sections
+
+- **§2.14 Bundle sealing and integrity.** Seal at creation after scanning and
+  redaction; SHA-256 over a canonical serialization excluding the hash and
+  signature; `validate-bundle` recomputes and compares; a mismatch is reported
+  as tampered, never repaired or re-sealed; corrections are issued as a new
+  bundle referencing the prior one, never an in-place edit. The canonical-form
+  requirement is the part that makes the hash meaningful — without it two
+  readers hash the same bundle differently.
+- **§2.12 Event stream linkage.** `:evidence/event-links` carrying N3 scope
+  type, scope id, and an inclusive sequence range, with one link per scope when
+  work spans scopes, and a prohibition on expiring events inside a retained
+  bundle's range.
+- **§2.13 Gate execution evidence.** Discharges N4 §5.5. Records binding,
+  per-pack exact resolved version and content hash, all violations including
+  waived, and waivers. States the three rules implementations get wrong: a
+  version range is not a resolved version; waived violations stay in the list;
+  a waiver without a reason is invalid, not merely incomplete.
+- **§7.4 Retention.** Bundles inherit N3 §4.3.1's `:audit` floor. A bundle's
+  retention is a floor on its cited events and referenced artifacts — a bundle
+  whose artifacts have been collected fails §9.1 and cannot satisfy §7.3's
+  chain of custody.
+- **§9.4–§9.5 Conformance requirement IDs and test obligations.** `N6.EB.*`,
+  `N6.PR.*`, `N6.EL.*`, `N6.GE.*`, `N6.SD.*`, `N6.PS.*`, plus seven test
+  obligations.
+
+### Contract fixes
+
+- §7.2 now inherits N3 §8 whole — excluded values, `"[REDACTED]"` marker,
+  truncation — instead of defining a variant. "Redact or flag" replaced by
+  redact-then-flag. Added: a bundle MUST NOT seal until scanning and redaction
+  complete, since sealing first would either break the seal or preserve the
+  secret inside a tamper-evident record.
+- §2.1 and §7.1 reconciled into one key list, with a note that a §7.1 key
+  missing from §2.1 is a defect in this spec rather than a choice.
+- §8.1–§8.2 replaced by a statement of what any presenting surface MUST be able
+  to show, referencing N5 for the surfaces themselves. Adds seal status to that
+  list: a bundle whose hash does not verify MUST be shown as tampered.
+- SOCII → SOC 2 (§1.1, §7.3).
+
+### Annex A (informative)
+
+- **Partially implemented** — `collector.clj:619` sets `:evidence/content-hash`,
+  a field the spec had never defined. Missing: canonical serialization,
+  `:evidence/sealed-at`, and any recompute-and-compare in `validate-bundle`.
+- **Specified, not implemented** — `scanner.clj` detects email, SSN, and AWS
+  keys but performs no redaction; `[REDACTED]` appears nowhere in the
+  component, so detect-and-flag leaves the secret in the bundle. No gate
+  evidence, no event links, no retention floor.
+- **Structural** — nothing prevents a sealed bundle from being modified in
+  place.
+
+### SPEC_INDEX
+
+N6 entry updated; index 0.12.0 → 0.13.0-draft with an amendment-log entry.
+
+## Testing Plan
+
+Specification change; no runtime code touched.
+
+- `markdownlint` clean on all three changed files.
+- Code blocks verified brace-balanced.
+- No duplicate section numbers; top-level sections ascending 1–13.
+- Internal `§N.N` references resolved against defined headings; the five
+  apparent misses are cross-spec references to N3, N4, and N5, verified by hand.
+- Verified the withdrawn `[REDACTED:<type>]` marker survives only in the two
+  places that document its withdrawal.
+
+Self-review caught one defect mid-edit: I first numbered the new subsections
+§2.4–§2.6, which collided with the existing Semantic Validation, Policy Check,
+and Outcome Evidence sections. Renumbered to §2.12–§2.14 and relocated to the
+end of §2.
+
+§9.5's test obligations describe tests that do not exist yet — follow-on work.
+
+## Deployment Plan
+
+Documentation only. Merges to `main` with no runtime effect.
+
+## Follow-on Work
+
+Tracked by Annex A. The redaction gap is the one worth doing first: the scanner
+already detects secrets and then stores them.
+
+1. Redact on detection in `evidence-bundle/scanner.clj`, and widen the pattern
+   set to private keys, connection strings, and payment card numbers.
+2. Implement sealing: canonical serialization, `:evidence/sealed-at`, and
+   recompute-and-compare in `validate-bundle`.
+3. Record gate execution evidence so gate results become reproducible per
+   N4 §5.5.
+4. Populate `:evidence/event-links`.
+5. Enforce a retention floor for bundles and their artifacts.
+
+## Related Issues/PRs
+
+- Follows: [#1641](https://github.com/miniforge-ai/miniforge/pull/1641) (N3),
+  [#1658](https://github.com/miniforge-ai/miniforge/pull/1658) (N4),
+  [#1668](https://github.com/miniforge-ai/miniforge/pull/1668) (N5)
+- Depends on: N3 §8 (redaction), N3 §4.3 (retention classes), N3 §2.3 (scopes),
+  N4 §5.5 (gate evidence obligations), N4 §6.3.1 (waiver)
+- Governed by: `standards/miniforge/foundations/specification-standards` (020)
+
+## Checklist
+
+- [x] Spec reviewed against current state before editing
+- [x] Internal contradictions identified and fixed
+- [x] Cross-spec obligations from N3/N4/N5 discharged
+- [x] New sections use RFC 2119 keywords (020)
+- [x] Annex A marked informative — carries no new requirements
+- [x] No spec content extracted from implementation code (020 critical rule)
+- [x] N5's interface contracts referenced, not duplicated (020)
+- [x] Copyright header present (810)
+- [x] `markdownlint` clean
+- [x] Code blocks brace-balanced; no duplicate section numbers
+- [x] Internal section references resolve
+- [x] SPEC_INDEX updated (020: index is authoritative)
+- [x] PR doc created (721)

--- a/specs/SPEC_INDEX.md
+++ b/specs/SPEC_INDEX.md
@@ -7,7 +7,7 @@
 # miniforge Specification Index
 
 **Version:** 0.13.0-draft
-**Date:** 2026-08-05
+**Date:** 2026-08-06
 **Status:** Living specification during OSS development
 
 ---
@@ -221,7 +221,7 @@ Defines:
 - **Conformance requirement IDs** (`N6.EB.*`, `N6.PR.*`, `N6.EL.*`, `N6.GE.*`, `N6.SD.*`,
   `N6.PS.*`) and test obligations (§9.4–§9.5)
 - **Annex A (informative):** implementation conformance status
-- Compliance metadata: sensitive data handling, audit requirements (SOCII/FedRAMP)
+- Compliance metadata: sensitive data handling, audit requirements (SOC 2/FedRAMP)
 - **Reliability evidence:** SLI measurements, failure class, workflow tier, degradation mode in outcome (§2.6)
 - **Evaluation artifacts:** Golden set and eval-run-result artifact types (§3.1.1)
 

--- a/specs/SPEC_INDEX.md
+++ b/specs/SPEC_INDEX.md
@@ -6,7 +6,7 @@
 
 # miniforge Specification Index
 
-**Version:** 0.12.0-draft
+**Version:** 0.13.0-draft
 **Date:** 2026-08-05
 **Status:** Living specification during OSS development
 
@@ -211,6 +211,16 @@ Defines:
 - Semantic intent validation rules with Terraform/Kubernetes specifics
 - Queryable provenance API: trace artifact chains, find intent mismatches
 - Pack Run evidence: pack identity, capabilities, connector actions, metrics snapshots, report artifacts
+- **Bundle sealing and integrity (§2.14):** canonical-serialization hash, seal-at-creation,
+  tamper reporting — the mechanism behind the immutability the spec already asserted
+- **Event stream linkage (§2.12):** scope-aware sequence ranges per N3 §2.3
+- **Gate execution evidence (§2.13):** binding, exact resolved pack versions, content hashes,
+  waivers — discharging the obligations N4 §5.5 places on this spec
+- **Retention (§7.4):** `:audit` floor per N3 §4.3.1; bundles outlive neither their events nor artifacts
+- **Redaction inherited from N3 §8** rather than a second `[REDACTED:<type>]` marker (§7.2)
+- **Conformance requirement IDs** (`N6.EB.*`, `N6.PR.*`, `N6.EL.*`, `N6.GE.*`, `N6.SD.*`,
+  `N6.PS.*`) and test obligations (§9.4–§9.5)
+- **Annex A (informative):** implementation conformance status
 - Compliance metadata: sensitive data handling, audit requirements (SOCII/FedRAMP)
 - **Reliability evidence:** SLI measurements, failure class, workflow tier, degradation mode in outcome (§2.6)
 - **Evaluation artifacts:** Golden set and eval-run-result artifact types (§3.1.1)
@@ -556,6 +566,15 @@ Normative specs are enforced by:
 
 ## Version History
 
+- **0.13.0-draft** (2026-08-06) - N6 spec-completion pass. **N6**: bundle sealing and integrity
+  (§2.14) — the spec asserted immutability in three places without a mechanism a reader could
+  check; event stream linkage schema (§2.12); gate execution evidence (§2.13) discharging the four
+  obligations N4 §5.5 places on N6, none of which the bundle recorded; retention (§7.4);
+  conformance requirement IDs and test obligations (§9.4–§9.5). Contract fixes: §7.2's
+  `[REDACTED:<type>]` marker against N3 §8.2's `[REDACTED]`, and its "redact **or** flag" against
+  N3 §8.1's MUST NOT; §2.1 and §7.1 compliance keys disagreeing in both directions; §8.1–§8.2
+  restating N5's CLI/TUI contracts. Annex A records implementation divergence — notably that the
+  scanner detects secrets but never redacts them. Per-spec bumps: N6 0.7.2→0.8.0
 - **0.12.0-draft** (2026-08-05) - N5 spec-completion pass. **N5**: localization contract (§9)
   applying dewey 050 to the console surface — the spec defining the largest prose surface in the
   system had none; CLI output contract with stdout/stderr separation, an exit-code taxonomy that

--- a/specs/normative/N6-evidence-provenance.md
+++ b/specs/normative/N6-evidence-provenance.md
@@ -1119,7 +1119,7 @@ withdrawn requirement is marked withdrawn, not deleted.
 | ID | Level | Requirement |
 |----|-------|-------------|
 | N6.EB.1 | MUST | Create a bundle at workflow completion, including for failed and cancelled workflows (§5.1). |
-| N6.EB.2 | MUST | Include every §7.1 compliance key, as listed in §2.1 (§2.1, §7.1). |
+| N6.EB.2 | MUST | Include every compliance key §7.1 marks required (§2.1, §7.1). |
 | N6.EB.3 | MUST | Seal the bundle at creation: set `:evidence/sealed-at` and `:evidence/content-hash` (§2.14). |
 | N6.EB.4 | MUST | Compute the seal hash over a canonical serialization, excluding hash and signature (§2.14). |
 | N6.EB.5 | MUST NOT | Modify a bundle after sealing, including to add auditor notes (§2.14). |

--- a/specs/normative/N6-evidence-provenance.md
+++ b/specs/normative/N6-evidence-provenance.md
@@ -101,8 +101,10 @@ contracts that make autonomous workflows credible to platform and security teams
  :compliance/retention-policy keyword ; OPTIONAL: see §7.4
  :compliance/auditor-notes string   ; OPTIONAL
 
+ ;; Event Stream Linkage (§2.12)
+ :evidence/event-links [...]        ; REQUIRED: one per scope
+
  ;; Seal (§2.14)
- :evidence/event-links [...]        ; REQUIRED: one per scope, see §2.12
  :evidence/content-hash string      ; REQUIRED: SHA-256 over the canonical form,
                                    ;   excluding this key and :evidence/signature (§2.14)
  :evidence/sealed-at inst           ; REQUIRED

--- a/specs/normative/N6-evidence-provenance.md
+++ b/specs/normative/N6-evidence-provenance.md
@@ -103,7 +103,8 @@ contracts that make autonomous workflows credible to platform and security teams
 
  ;; Seal (§2.14)
  :evidence/event-links [...]        ; REQUIRED: one per scope, see §2.12
- :evidence/content-hash string      ; REQUIRED: SHA-256 over the sealed bundle
+ :evidence/content-hash string      ; REQUIRED: SHA-256 over the canonical form,
+                                   ;   excluding this key and :evidence/signature (§2.14)
  :evidence/sealed-at inst           ; REQUIRED
  :evidence/signature string}        ; OPTIONAL
 ```

--- a/specs/normative/N6-evidence-provenance.md
+++ b/specs/normative/N6-evidence-provenance.md
@@ -6,10 +6,16 @@
 
 # N6 — Evidence & Provenance Standard
 
-**Version:** 0.7.2-draft
+**Version:** 0.8.0-draft
 **Date:** 2026-08-06
 **Status:** Draft
 **Conformance:** MUST
+
+_v0.8.0 supplies the sealing mechanism behind the immutability the spec already
+claimed (§2.14), the event-stream linkage schema (§2.12), gate-execution
+evidence per N4 §5.5 (§2.13), retention (§7.4), and conformance requirement IDs
+(§9.4–§9.5); and inherits N3 §8's redaction contract rather than defining a
+second marker._
 
 ---
 
@@ -29,7 +35,7 @@ contracts that make autonomous workflows credible to platform and security teams
 2. **Semantic validation** - Declared intent MUST be verifiable against actual behavior
 3. **Immutable records** - Evidence bundles MUST NOT be modified after creation
 4. **Queryable history** - Users MUST be able to query "What was the intent for this artifact?"
-5. **Compliance-ready** - Evidence format MUST support SOCII, FedRAMP audit requirements
+5. **Compliance-ready** - Evidence format MUST support SOC 2 and FedRAMP audit requirements
 
 ---
 
@@ -85,11 +91,26 @@ contracts that make autonomous workflows credible to platform and security teams
  ;; Outcome
  :evidence/outcome {...}
 
+ ;; Gate Evidence (N4 §5.5)
+ :evidence/gate-executions [...]    ; REQUIRED when any gate ran; see §2.13
+
  ;; Compliance Metadata
+ :compliance/created-at inst        ; REQUIRED
+ :compliance/sensitive-data boolean ; REQUIRED
+ :compliance/pii-handling keyword   ; REQUIRED: :none, :redacted, :encrypted
+ :compliance/retention-policy keyword ; OPTIONAL: see §7.4
  :compliance/auditor-notes string   ; OPTIONAL
- :compliance/sensitive-data boolean
- :compliance/pii-handling keyword}  ; :none, :redacted, :encrypted
+
+ ;; Seal (§2.14)
+ :evidence/event-links {...}        ; REQUIRED: see §2.12
+ :evidence/content-hash string      ; REQUIRED: SHA-256 over the sealed bundle
+ :evidence/sealed-at inst           ; REQUIRED
+ :evidence/signature string}        ; OPTIONAL
 ```
+
+The compliance keys here and the required set in §7.1 are one list. A key
+required by §7.1 that does not appear in this structure is a defect in this
+spec, not a choice for implementations.
 
 ### 2.2 Intent Evidence
 
@@ -518,6 +539,93 @@ When a pack renders a report, the output MUST be a Report Artifact:
 Report Artifacts enable provenance tracing from rendered output back to input data
 and template.
 
+### 2.12 Event Stream Linkage
+
+§5.1 requires a bundle to link to the event stream. This is that link:
+
+```clojure
+{:event-links/scope-type keyword   ; REQUIRED: N3 §2.3 scope — usually :workflow
+ :event-links/scope-id any         ; REQUIRED: the scope key's value
+ :event-links/from-sequence long   ; REQUIRED: first event covered, inclusive
+ :event-links/to-sequence long     ; REQUIRED: last event covered, inclusive
+ :event-links/event-count long}    ; REQUIRED: events in range at seal time
+```
+
+A sequence range is only meaningful within one N3 scope, because N3 §2.2
+sequences per scope. A bundle covering work that spans scopes MUST record one
+link per scope rather than a single range.
+
+Implementations MUST NOT expire an event inside a sealed bundle's range while
+the bundle is retained. N3 §4.3.2 forbids expiring from the middle of a
+sequence; a bundle whose cited events have been collected cannot be replayed,
+which defeats the audit trail it exists to provide.
+
+### 2.13 Gate Execution Evidence
+
+N4 §5.5 requires that a gate result be reproducible from its evidence. For each
+gate execution the bundle MUST record:
+
+```clojure
+{:gate-execution/gate-id keyword
+ :gate-execution/phase keyword
+ :gate-execution/outcome keyword          ; :passed | :failed | :waived
+ :gate-execution/binding {...}            ; the gate binding per N4 §5.4
+ :gate-execution/packs
+ [{:pack/id string
+   :pack/version string                   ; REQUIRED: exact resolved version
+   :pack/content-hash string}]            ; REQUIRED: the bytes that ran
+ :gate-execution/violations [...]         ; REQUIRED: all of them, including waived
+ :gate-execution/waivers
+ [{:waiver/id uuid
+   :waiver/evaluation-id uuid
+   :waiver/violations [keyword]
+   :waiver/actor string
+   :waiver/reason string
+   :waiver/timestamp inst}]}
+```
+
+Three rules follow from N4 §5.5 and are restated because they are the ones
+implementations get wrong:
+
+1. A **version range** is not a resolved version. Recording `"^2.0"` does not
+   satisfy this section; recording `"2.1.3"` does.
+2. Waived violations stay in `:gate-execution/violations`. A waiver records
+   that a violation was accepted, never that it was absent.
+3. A waiver with no `:waiver/reason` is not a waiver (N4 §6.3.1). A bundle
+   carrying one is invalid, not merely incomplete.
+
+### 2.14 Bundle Sealing and Integrity
+
+§1.1 principle 3 requires bundles to be immutable and §9.1 requires
+implementations to verify it. This section supplies the mechanism; without one,
+"immutable" is an assertion an auditor cannot check.
+
+**Sealing.** At creation, after all evidence is assembled and after scanning and
+redaction (§7.2), implementations MUST:
+
+1. Set `:compliance/created-at` and `:evidence/sealed-at`.
+2. Compute a SHA-256 over the canonical serialization of the bundle with
+   `:evidence/content-hash` and `:evidence/signature` absent, and store it in
+   `:evidence/content-hash`.
+3. Optionally sign that hash and store the signature in
+   `:evidence/signature`.
+
+**Canonical serialization.** The hash MUST be computed over a canonical form:
+map keys sorted, no insignificant whitespace, and a stable representation for
+each scalar type. Without a canonical form two readers hash the same bundle to
+different values and the check is worthless.
+
+**Verification.** `validate-bundle` (§8.3) MUST recompute the hash and compare.
+A bundle whose recomputed hash differs from `:evidence/content-hash` MUST be
+reported as tampered — not repaired, not re-sealed.
+
+**After sealing** a bundle MUST NOT be modified. Corrections are made by
+issuing a new bundle that references the prior one; implementations MUST NOT
+edit a sealed bundle in place, including to add auditor notes. Storage SHOULD
+enforce this (write-once or equivalent) rather than relying on callers.
+
+An unsealed bundle MUST NOT be exported (§8.3) or presented as evidence.
+
 ---
 
 ## 3. Artifact Provenance Schema
@@ -860,19 +968,57 @@ Evidence bundles MUST include:
 
 ### 7.2 Sensitive Data Handling
 
-Implementations MUST:
+**N3 §8 owns the redaction contract.** Evidence bundles inherit it rather than
+defining a second one: the excluded-value set of N3 §8.1, the marker of §8.2,
+and the truncation rules of §8.3 apply unchanged to bundle content.
 
-1. **Scan artifacts for sensitive data** - Before storing
-2. **Detect patterns**:
-   - AWS access keys (20-char uppercase alphanumeric)
-   - Passwords in plaintext
-   - SSNs, credit cards
-3. **Redact or flag** - Replace with `[REDACTED:<type>]` or mark bundle as sensitive
-4. **Record in metadata** - Set `compliance/sensitive-data` flag
+In particular the marker is `"[REDACTED]"`, exactly as on the stream. An
+earlier revision of this section specified `[REDACTED:<type>]`; that variant is
+withdrawn. Two markers for one concept means an auditor grepping for redactions
+finds some of them, and a redaction an auditor cannot find is not a redaction.
+
+Beyond inheriting N3 §8, implementations MUST:
+
+1. **Scan artifacts before storing.** Detection is a bundle-side obligation
+   because an artifact may carry a secret that never crossed the event stream.
+2. **Detect, at minimum**: cloud provider access keys, plaintext passwords and
+   connection strings carrying a secret, private keys, SSNs, and payment card
+   numbers.
+3. **Redact, then flag.** Redaction is not optional when a secret is found —
+   §8.1 of N3 is a MUST NOT, not a preference. Marking the bundle sensitive
+   records that a secret was present; it does not license storing it.
+4. **Record in metadata.** Set `:compliance/sensitive-data` and, where
+   redaction occurred, `:compliance/pii-handling :redacted`.
+
+A bundle MUST NOT be sealed (§2.14) until scanning and redaction have completed.
+Sealing a bundle and redacting afterwards would either break the seal or leave
+the secret inside a record that claims to be tamper-evident.
+
+### 7.4 Retention
+
+`:compliance/retention-policy` is optional on a bundle; a retention _floor_ is
+not optional on an implementation.
+
+An evidence bundle is the durable record of a workflow, so it inherits the
+`:audit` class of N3 §4.3.1: **minimum one year**, or the deployment's stated
+policy if longer. Implementations MUST document their actual retention.
+
+Two constraints follow from the rest of this spec:
+
+- A bundle MUST NOT outlive the events it cites (§2.12) — or rather, the events
+  MUST NOT be expired first. Retention of a bundle is a floor on the retention
+  of its event range.
+- Artifacts referenced by a retained bundle MUST be retained with it. A bundle
+  whose artifact references dangle fails §9.1's validity check and cannot
+  satisfy §7.3's chain of custody.
+
+Deleting a bundle before its floor is a compliance failure, not a storage
+optimization. Where regulation requires erasure of specific content, that is
+handled by redaction at seal time (§7.2), not by destroying the record.
 
 ### 7.3 Audit Trail Requirements
 
-For SOCII/FedRAMP compliance, implementations MUST:
+For SOC 2 / FedRAMP compliance, implementations MUST:
 
 1. **Record all evidence bundle accesses** - Who, when, why
 2. **Prevent tampering** - Immutable storage, content hashing
@@ -883,31 +1029,27 @@ For SOCII/FedRAMP compliance, implementations MUST:
 
 ## 8. Evidence Bundle Presentation
 
-### 8.1 CLI Evidence View
+**N5 owns the interface surface.** The CLI command, the TUI view, and their
+key bindings are specified in N5 §2.3.5 and N5 §3.2.3; this section states what
+those surfaces MUST be able to show, not how they look. Restating N5's command
+taxonomy here would create a second source of truth that drifts.
 
-Implementations MUST provide CLI command:
+### 8.1 Minimum Presented Content
 
-```bash
-miniforge evidence show <workflow-id>
-```
+Whatever surface presents a bundle MUST be able to show:
 
-Displaying (at minimum):
-
-- Intent summary
-- Artifacts per phase
-- Policy validation results
+- Intent summary — type, description, constraints
+- Artifacts per phase, with provenance navigable from each (§4.1.1)
+- Policy validation results, including waived violations marked as waived
 - Semantic validation results
+- Gate executions with their resolved pack versions and hashes (§2.13)
 - Outcome
+- Seal status: whether `:evidence/content-hash` verifies (§2.14)
 
-### 8.2 TUI Evidence Browser
-
-Implementations MUST provide TUI view with:
-
-1. **Intent panel** - Type, description, constraints
-2. **Phase tree** - Expandable phases with artifacts
-3. **Validation results** - Policy checks, semantic validation
-4. **Artifact viewer** - View artifact content (with syntax highlighting)
-5. **Provenance trace** - Navigate artifact chain
+Seal status is not decoration. A presented bundle whose hash does not verify
+MUST be shown as tampered rather than rendered as ordinary evidence, on every
+surface. Per N5 §6.2 the same applies to waived gates: never rendered as
+passing.
 
 ### 8.3 Programmatic Access
 
@@ -955,6 +1097,93 @@ Conformance tests MUST verify:
 2. **No false positives** - Valid workflows pass validation
 3. **Terraform parsing accuracy** - Correctly categorizes all change types
 4. **Kubernetes parsing accuracy** - Correctly detects resource changes
+
+### 9.4 Conformance Requirements
+
+Requirement IDs are stable identifiers for the normative statements of this
+spec, so a conformance suite can cite what it tests. IDs are never reused; a
+withdrawn requirement is marked withdrawn, not deleted.
+
+#### Bundle structure and sealing
+
+| ID | Level | Requirement |
+|----|-------|-------------|
+| N6.EB.1 | MUST | Create a bundle at workflow completion, including for failed and cancelled workflows (§5.1). |
+| N6.EB.2 | MUST | Include every §7.1 compliance key, as listed in §2.1 (§2.1, §7.1). |
+| N6.EB.3 | MUST | Seal the bundle at creation: set `:evidence/sealed-at` and `:evidence/content-hash` (§2.14). |
+| N6.EB.4 | MUST | Compute the seal hash over a canonical serialization, excluding hash and signature (§2.14). |
+| N6.EB.5 | MUST NOT | Modify a bundle after sealing, including to add auditor notes (§2.14). |
+| N6.EB.6 | MUST | Report a bundle whose recomputed hash differs as tampered, never repair or re-seal it (§2.14, §9.1). |
+| N6.EB.7 | MUST NOT | Export or present an unsealed bundle as evidence (§2.14, §8.3). |
+| N6.EB.8 | MUST | Seal only after scanning and redaction have completed (§7.2). |
+
+#### Provenance
+
+| ID | Level | Requirement |
+|----|-------|-------------|
+| N6.PR.1 | MUST | Link every artifact to its originating workflow and intent (§1.1, §3.2). |
+| N6.PR.2 | MUST | Record content hashes for all artifacts and verify them on read (§3.1, §9.1). |
+| N6.PR.3 | MUST | Support the query operations of §4.1 and the API of §4.2. |
+| N6.PR.4 | MUST | Keep artifact references resolvable for as long as the bundle is retained (§7.4). |
+
+#### Event linkage
+
+| ID | Level | Requirement |
+|----|-------|-------------|
+| N6.EL.1 | MUST | Record `:evidence/event-links` with an N3 scope type, scope id, and sequence range (§2.12). |
+| N6.EL.2 | MUST | Record one link per scope when the work spans scopes (§2.12). |
+| N6.EL.3 | MUST NOT | Expire an event inside a retained bundle's cited range (§2.12, N3 §4.3.2). |
+
+#### Gate evidence
+
+| ID | Level | Requirement |
+|----|-------|-------------|
+| N6.GE.1 | MUST | Record the gate binding and resolved rule set for every gate execution (§2.13, N4 §5.5). |
+| N6.GE.2 | MUST | Record each pack's exact resolved version — a range does not satisfy this (§2.13). |
+| N6.GE.3 | MUST | Record each pack's content hash (§2.13). |
+| N6.GE.4 | MUST | Retain waived violations in the violations list, marked waived (§2.13). |
+| N6.GE.5 | MUST | Reject a waiver with no `:waiver/reason` as invalid (§2.13, N4 §6.3.1). |
+
+#### Sensitive data and retention
+
+| ID | Level | Requirement |
+|----|-------|-------------|
+| N6.SD.1 | MUST | Apply N3 §8's excluded-value set, marker, and truncation rules to bundle content (§7.2). |
+| N6.SD.2 | MUST | Use the marker `"[REDACTED]"` (§7.2). |
+| N6.SD.3 | MUST | Scan artifacts before storing, independently of the event stream (§7.2). |
+| N6.SD.4 | MUST | Redact on detection; flagging alone does not satisfy N3 §8.1 (§7.2). |
+| N6.SD.5 | MUST | Retain bundles for at least the `:audit` floor of N3 §4.3.1 (§7.4). |
+
+#### Presentation
+
+| ID | Level | Requirement |
+|----|-------|-------------|
+| N6.PS.1 | MUST | Be able to present every item in §8.1 on whichever surface renders a bundle. |
+| N6.PS.2 | MUST | Show a bundle whose seal does not verify as tampered (§8.1). |
+| N6.PS.3 | MUST NOT | Render a waived gate as passing (§8.1, N5 §6.2). |
+
+### 9.5 Test Obligations
+
+A conformance suite MUST cover, at minimum:
+
+1. **Seal round-trip** — a sealed bundle verifies; the same bundle
+   re-serialized in a different key order still verifies (N6.EB.4).
+2. **Tamper detection** — mutating any field of a sealed bundle causes
+   verification to fail and the bundle to be reported tampered, not repaired
+   (N6.EB.5, N6.EB.6).
+3. **Failure and cancellation** — a failed workflow and a cancelled workflow
+   each produce a sealed bundle (N6.EB.1).
+4. **Gate reproducibility** — the recorded pack versions and hashes are
+   sufficient to re-resolve and re-run the gate and obtain the same outcome
+   (N6.GE.1–N6.GE.3).
+5. **Waiver visibility** — a waived violation appears in the violations list
+   marked waived, and no surface renders its gate as passing (N6.GE.4,
+   N6.PS.3).
+6. **Redaction** — a workflow whose artifact contains a secret produces a
+   bundle with `"[REDACTED]"` and no occurrence of the secret, and the bundle
+   seals only after that substitution (N6.SD.2, N6.SD.4, N6.EB.8).
+7. **Event-link integrity** — every sequence in a bundle's cited range is
+   retrievable for as long as the bundle is retained (N6.EL.3).
 
 ---
 
@@ -1109,7 +1338,12 @@ Fleet-wide evidence will enable:
 - RFC 2119: Key words for use in RFCs to Indicate Requirement Levels
 - N2 (Workflow Execution): Workflows produce evidence bundles
 - N3 (Event Stream): Evidence bundles link to event streams via sequence ranges
-- N4 (Policy Packs): Policy check results stored in evidence
+- N3 §2.3 (scopes) and §4.3 (retention) constrain §2.12 and §7.4; N3 §8 owns the
+  redaction contract inherited by §7.2
+- N4 (Policy Packs): Policy check results stored in evidence; §5.5 imposes the
+  gate-evidence obligations of §2.13; §6.3.1 defines the waiver
+- N5 (CLI/TUI/API): §2.3.5 and §3.2.3 own the surfaces that present bundles (§8)
+- N5-delta-supervisory-control-plane §3.1: Waiver shape recorded in §2.13
 - N7 (Operational Policy Synthesis): OPSV evidence requirements (§2.8)
 - N8 (Observability Control Interface): Control action and annotation evidence (§2.9)
 - N9 (External PR Integration): External PR evidence artifacts (§2.10, §3.1.1)
@@ -1117,8 +1351,64 @@ Fleet-wide evidence will enable:
 
 ---
 
+## Annex A — Implementation Conformance Status (informative)
+
+This annex is **informative**. It records where the miniforge implementation
+diverges from the contract above, as of 2026-08-06. It is not a relaxation of
+any requirement in §1–§13.
+
+### A.1 Partially Implemented
+
+- **Bundle hash (§2.14).** `evidence-bundle/collector.clj:619` already sets
+  `:evidence/content-hash` over the assembled bundle. Until this revision the
+  field was not in the spec at all, so the implementation had invented it. What
+  is missing is the rest of the mechanism: no canonical serialization is
+  specified or implemented, so two readers can hash the same bundle
+  differently; there is no `:evidence/sealed-at`; and `validate-bundle` does not
+  recompute and compare (N6.EB.3, N6.EB.4, N6.EB.6).
+
+### A.2 Specified, Not Implemented
+
+- **Redaction (§7.2).** `evidence-bundle/scanner.clj` detects email addresses,
+  SSNs, and AWS access keys and records findings, but performs no redaction —
+  the string `[REDACTED]` appears nowhere in the component. N3 §8.1 is a
+  MUST NOT on emission, so detect-and-flag leaves the secret in the bundle
+  (N6.SD.4). The detection set is also narrower than §7.2 requires: no private
+  keys, no connection strings, no payment card numbers.
+- **Gate execution evidence (§2.13).** No waiver, gate binding, or resolved
+  pack version is recorded anywhere in the component. All five N6.GE
+  requirements are unmet, which means no gate result in the system is currently
+  reproducible from its evidence as N4 §5.5 requires.
+- **Event stream linkage (§2.12).** No `:evidence/event-links`. §5.1 has always
+  required linking to the event stream; nothing implements it.
+- **Retention (§7.4).** No retention floor is enforced for bundles or their
+  artifacts.
+
+### A.3 Structural
+
+- **Immutability is unenforced.** Nothing prevents a sealed bundle from being
+  modified in place; §2.14's write-once expectation has no storage-level
+  backing (N6.EB.5).
+
 **Version History:**
 
+- 0.8.0-draft (2026-08-06): Spec-completion pass.
+  **New normative sections:** bundle sealing and integrity (§2.14) — the spec
+  asserted immutability in §1.1, §7.3, and §9.1 without ever saying how a
+  reader verifies it; event stream linkage schema (§2.12), scope-aware per N3
+  §2.3; gate execution evidence (§2.13) discharging the four obligations N4
+  §5.5 places on this spec — binding, resolved versions, content hashes,
+  waivers — none of which the bundle previously recorded; retention (§7.4);
+  conformance requirement IDs and test obligations (§9.4–§9.5).
+  **Contract fixes:** §7.2 specified the marker `[REDACTED:<type>]` against N3
+  §8.2's `[REDACTED]` — withdrawn in favour of inheriting N3 §8 whole, since two
+  markers means an auditor grepping for redactions finds only some of them;
+  §7.2 also permitted "redact **or** flag" where N3 §8.1 is a MUST NOT;
+  §2.1's compliance keys and §7.1's required set disagreed in both directions
+  and are now one list; §8.1–§8.2 restated N5's CLI and TUI contracts and now
+  reference them, stating only what a surface MUST be able to show; SOCII →
+  SOC 2.
+  Annex A records implementation divergence.
 - 0.7.2-draft (2026-08-06): Replaced stale OPSV capability references with
   Ariadne effect, execution-grant, and decision-envelope correlation
 - 0.7.1-draft (2026-08-05): Added aggregate OPSV event, artifact, and capability

--- a/specs/normative/N6-evidence-provenance.md
+++ b/specs/normative/N6-evidence-provenance.md
@@ -111,9 +111,11 @@ contracts that make autonomous workflows credible to platform and security teams
  :evidence/signature string}        ; OPTIONAL
 ```
 
-The compliance keys here and the required set in §7.1 are one list. A key
-required by §7.1 that does not appear in this structure is a defect in this
-spec, not a choice for implementations.
+§7.1 defines the **required** compliance keys; this structure additionally
+shows the optional ones (`:compliance/retention-policy`,
+`:compliance/auditor-notes`). Every key §7.1 marks required MUST appear here —
+a required key missing from this structure is a defect in this spec, not a
+choice for implementations.
 
 ### 2.2 Intent Evidence
 
@@ -974,8 +976,9 @@ Evidence bundles MUST include:
 ### 7.2 Sensitive Data Handling
 
 **N3 §8 owns the redaction contract.** Evidence bundles inherit it rather than
-defining a second one: the excluded-value set of N3 §8.1, the marker of §8.2,
-and the truncation rules of §8.3 apply unchanged to bundle content.
+defining a second one: the excluded-value set of N3 §8.1, the marker of N3
+§8.2, and the truncation rules of N3 §8.3 apply unchanged to bundle content.
+(N6 has its own §8.2 and §8.3, so these references are qualified throughout.)
 
 In particular the marker is `"[REDACTED]"`, exactly as on the stream. An
 earlier revision of this section specified `[REDACTED:<type>]`; that variant is
@@ -1050,6 +1053,8 @@ Whatever surface presents a bundle MUST be able to show:
 - Gate executions with their resolved pack versions and hashes (§2.13)
 - Outcome
 - Seal status: whether `:evidence/content-hash` verifies (§2.14)
+
+### 8.2 Seal and Waiver Presentation
 
 Seal status is not decoration. A presented bundle whose hash does not verify
 MUST be shown as tampered rather than rendered as ordinary evidence, on every

--- a/specs/normative/N6-evidence-provenance.md
+++ b/specs/normative/N6-evidence-provenance.md
@@ -102,7 +102,7 @@ contracts that make autonomous workflows credible to platform and security teams
  :compliance/auditor-notes string   ; OPTIONAL
 
  ;; Seal (§2.14)
- :evidence/event-links {...}        ; REQUIRED: see §2.12
+ :evidence/event-links [...]        ; REQUIRED: one per scope, see §2.12
  :evidence/content-hash string      ; REQUIRED: SHA-256 over the sealed bundle
  :evidence/sealed-at inst           ; REQUIRED
  :evidence/signature string}        ; OPTIONAL
@@ -541,7 +541,9 @@ and template.
 
 ### 2.12 Event Stream Linkage
 
-§5.1 requires a bundle to link to the event stream. This is that link:
+§5.1 requires a bundle to link to the event stream. `:evidence/event-links` is
+a **vector** of links, one per scope covered — never a single map, because a
+bundle may span scopes. Each element:
 
 ```clojure
 {:event-links/scope-type keyword   ; REQUIRED: N3 §2.3 scope — usually :workflow
@@ -552,8 +554,8 @@ and template.
 ```
 
 A sequence range is only meaningful within one N3 scope, because N3 §2.2
-sequences per scope. A bundle covering work that spans scopes MUST record one
-link per scope rather than a single range.
+sequences per scope. A bundle covering work in a single scope carries a
+one-element vector; one spanning scopes carries one element per scope.
 
 Implementations MUST NOT expire an event inside a sealed bundle's range while
 the bundle is retained. N3 §4.3.2 forbids expiring from the middle of a
@@ -994,6 +996,15 @@ A bundle MUST NOT be sealed (§2.14) until scanning and redaction have completed
 Sealing a bundle and redacting afterwards would either break the seal or leave
 the secret inside a record that claims to be tamper-evident.
 
+### 7.3 Audit Trail Requirements
+
+For SOC 2 / FedRAMP compliance, implementations MUST:
+
+1. **Record all evidence bundle accesses** - Who, when, why
+2. **Prevent tampering** - Immutable storage, content hashing
+3. **Support export** - Evidence bundles exportable for auditors
+4. **Maintain chain of custody** - From intent to outcome
+
 ### 7.4 Retention
 
 `:compliance/retention-policy` is optional on a bundle; a retention _floor_ is
@@ -1015,15 +1026,6 @@ Two constraints follow from the rest of this spec:
 Deleting a bundle before its floor is a compliance failure, not a storage
 optimization. Where regulation requires erasure of specific content, that is
 handled by redaction at seal time (§7.2), not by destroying the record.
-
-### 7.3 Audit Trail Requirements
-
-For SOC 2 / FedRAMP compliance, implementations MUST:
-
-1. **Record all evidence bundle accesses** - Who, when, why
-2. **Prevent tampering** - Immutable storage, content hashing
-3. **Support export** - Evidence bundles exportable for auditors
-4. **Maintain chain of custody** - From intent to outcome
 
 ---
 


### PR DESCRIPTION
MINIFORGE_PR_BUDGET_OVERRIDE: Single normative spec document. A spec amendment is atomic — slicing yields intermediate PRs where the document contradicts itself (requirement IDs citing sections not yet added, renumbered subsections referenced before they move). At ~500 raw changed lines this is far below the ~10-12k threshold where Copilot declines to review, so automated review coverage is unaffected. Docs-only, no runtime code.

## Overview

Supplies the sealing mechanism behind the immutability N6 already claimed, the event-linkage and gate-evidence schemas other specs already depend on, and conformance requirement IDs.

Full detail: [`docs/pull-requests/2026-08-06-chris-n6-evidence-provenance-spec-complete.md`](docs/pull-requests/2026-08-06-chris-n6-evidence-provenance-spec-complete.md)

## Why

**Immutability was asserted, never mechanised.** §1.1 principle 3 says bundles MUST NOT be modified after creation. §7.3 says "prevent tampering — immutable storage, content hashing". §9.1 requires implementations to *validate* immutability. Nothing said how: no hash over the bundle, no canonical serialization, no verification procedure, no rule for what happens when verification fails. An audit record whose integrity cannot be checked is not audit evidence. The implementation had meanwhile invented an `:evidence/content-hash` the spec never mentioned.

**N4 §5.5 places four obligations on N6 that the bundle did not carry.** A gate result MUST be reproducible from its evidence — binding and resolved rule set, every violation including waived, each pack's content hash, any waiver with justification. The schema recorded none of them, so no gate result in the system is currently reproducible from its evidence.

**Two redaction markers for one concept.** N3 §8.2 says `"[REDACTED]"`; N6 §7.2 said `[REDACTED:<type>]`. An auditor grepping for redactions finds only some of them. §7.2 also permitted "redact **or** flag" where N3 §8.1 is a MUST NOT on the value existing at all.

**The compliance key list disagreed with itself** — §2.1 and §7.1 diverged in both directions.

**§5.1 required event-stream linkage** with no schema, and N3 now sequences per scope across six scopes, so a bare range is ambiguous.

**§8 restated N5's CLI and TUI contracts** rather than referencing them (standard 020).

## New normative sections

| § | Adds |
|---|------|
| 2.14 | Bundle sealing — canonical-serialization hash, seal after redaction, recompute-and-compare, tamper reporting, corrections as new bundles |
| 2.12 | Event stream linkage — scope type, scope id, inclusive range, one link per scope |
| 2.13 | Gate execution evidence — binding, exact resolved versions, content hashes, waivers |
| 7.4 | Retention — `:audit` floor; a bundle's retention is a floor on its events and artifacts |
| 9.4–9.5 | Requirement IDs (`N6.EB.*`, `N6.PR.*`, `N6.EL.*`, `N6.GE.*`, `N6.SD.*`, `N6.PS.*`) + 7 test obligations |

Three rules in §2.13 are restated because they are the ones implementations get wrong: a version *range* is not a resolved version; waived violations stay in the violations list; a waiver with no reason is invalid, not merely incomplete.

## Contract fixes

- §7.2 inherits N3 §8 whole. Redact-then-flag, not redact-or-flag. A bundle MUST NOT seal until redaction completes — sealing first would either break the seal or preserve the secret inside a tamper-evident record.
- §2.1 and §7.1 reconciled into one key list.
- §8.1–§8.2 now state what any presenting surface MUST be able to show, referencing N5 §2.3.5 and §3.2.3 for the surfaces. Seal status added to that list.
- SOCII → SOC 2.

## Annex A — implementation conformance status (informative)

- **Partially implemented** — `collector.clj:619` sets `:evidence/content-hash`, a field the spec never defined. Missing: canonical serialization, `:evidence/sealed-at`, and any recompute-and-compare in `validate-bundle`.
- **Specified, not implemented** — `scanner.clj` detects email, SSN, and AWS keys but performs **no redaction**; `[REDACTED]` appears nowhere in the component, so detect-and-flag leaves the secret in the bundle. No gate evidence, no event links, no retention floor.
- **Structural** — nothing prevents a sealed bundle being modified in place.

## Validation

Documentation only; no runtime code touched.

- `markdownlint` clean on all three files
- Code blocks brace-balanced; no duplicate section numbers; top-level sections ascending 1–13
- Internal `§N.N` references resolved against defined headings (five apparent misses are cross-spec refs to N3/N4/N5, verified by hand)
- Verified the withdrawn `[REDACTED:<type>]` marker survives only where its withdrawal is documented
- `bb pre-commit` passed on both commits

Self-review caught one defect mid-edit: I first numbered the new subsections §2.4–§2.6, colliding with the existing Semantic Validation, Policy Check, and Outcome Evidence sections. Renumbered to §2.12–§2.14.

## Note on the size budgets

The spec commit used `MINIFORGE_COMMIT_BUDGET_OVERRIDE` (323 reportable lines vs the 200 gate), rationale in the commit message. SPEC_INDEX and the PR doc went in a separate commit that passed normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
