### PR TITLE
fix(bench): isolate the bench sandbox from the checkout it was launched from

### DIFF
--- a/DOGFOODING.md
+++ b/DOGFOODING.md
@@ -81,6 +81,39 @@ bb miniforge run <spec-path>
 When `gh` is authenticated but `GITHUB_TOKEN` is not exported, the wrapper
 passes `GITHUB_TOKEN=$(gh auth token)` into the Miniforge process.
 
+## Bench Runs
+
+A bench (an A/B experiment over repeated dogfood runs) points `origin` at a
+throwaway local mirror so a completed run cannot open a real PR. Provision
+the sandbox with:
+
+```bash
+bb bench:provision /path/to/launching/checkout
+```
+
+This clones to `~/.miniforge/bench/repo`, creates the bare mirror
+`~/.miniforge/bench/origin.git`, and redirects only the clone's `origin`.
+Override the root with `MINIFORGE_BENCH_ROOT`.
+
+Do **not** use `git worktree add` for a bench sandbox. A linked worktree
+owns HEAD, the index, and the working tree — `.git/config` and every other
+ref live in the shared common dir. Inside a linked worktree,
+`git remote set-url origin` rewrites the *launching* checkout's origin and
+`git fetch origin main` rewrites the *launching* checkout's
+`refs/remotes/origin/main`. On 2026-08-06 that left the live checkout
+pointing at the bench mirror with `origin/main` force-updated backwards to
+the mirror's stale head; branches cut from `origin/main` afterwards were
+based on a stale commit and pushed to the mirror instead of GitHub.
+
+A bench runner should gate on the guard before it touches anything:
+
+```bash
+bb bench:verify ~/.miniforge/bench/repo /path/to/launching/checkout
+```
+
+It exits non-zero when the bench shares a git common dir with the
+launching checkout.
+
 ## Resume, Do Not Restart
 
 When a dogfood run stops, do not re-run the same spec from scratch if a

--- a/bb.edn
+++ b/bb.edn
@@ -552,6 +552,11 @@
   ;; Dogfooding - Miniforge working on itself
   ;; ──────────────────────────────────────────────────────────────────────────
 
+  bench:provision
+  {:doc "Provision an isolated bench sandbox (usage: bb bench:provision [source-dir] [ref] [branch])"
+   :requires ([bench])
+   :task (apply bench/provision *command-line-args*)}
+
   bench:verify
   {:doc "Fail-closed check that a bench sandbox owns its own remotes and refs (usage: bb bench:verify [bench-repo-dir] [source-dir])"
    :requires ([bench])

--- a/bb.edn
+++ b/bb.edn
@@ -552,6 +552,11 @@
   ;; Dogfooding - Miniforge working on itself
   ;; ──────────────────────────────────────────────────────────────────────────
 
+  bench:verify
+  {:doc "Fail-closed check that a bench sandbox owns its own remotes and refs (usage: bb bench:verify [bench-repo-dir] [source-dir])"
+   :requires ([bench])
+   :task (apply bench/verify *command-line-args*)}
+
   dogfood:check
   {:doc "Check dogfooding prerequisites"
    :requires ([dogfood])

--- a/deps.edn
+++ b/deps.edn
@@ -349,6 +349,10 @@
                      ai.miniforge/bb-etl-runner    {:local/root "components/bb-etl-runner"}}}
 
   :test {:extra-paths ["development/test"
+                       ;; bb task namespaces, so their tests can `require`
+                       ;; them instead of `load-file` (which cannot resolve
+                       ;; a task ns that requires a sibling task ns).
+                       "tasks"
                        "components/schema/test"
                        "components/config/test"
                        "components/algorithms/test"

--- a/development/test/bench_test.clj
+++ b/development/test/bench_test.clj
@@ -129,6 +129,22 @@
           (delete-tree! root)
           (delete-tree! source))))))
 
+(deftest ^{:stratum 2} provision-stops-at-the-first-failed-step-test
+  (testing "a failed step leaves no mirror behind for a later step to inherit"
+    (let [root (temp-dir)
+          source (init-launching-repo! (temp-dir))
+          bench-root (str (File. root "bench"))]
+      (try
+        (let [result (sut/provision! {:source source
+                                      :root bench-root
+                                      :ref "no-such-ref"})]
+          (is (= :checkout (get-in result [:anomaly/data :step])))
+          (is (not (.exists (File. (str (File. bench-root "origin.git")))))
+              "steps after the failure must not have run"))
+        (finally
+          (delete-tree! root)
+          (delete-tree! source))))))
+
 (deftest ^{:stratum 2} linked-worktree-is-reported-unisolated-test
   (testing "the shape the 2026-08-06 bench actually had is rejected"
     (let [source (init-launching-repo! (temp-dir))

--- a/development/test/bench_test.clj
+++ b/development/test/bench_test.clj
@@ -1,0 +1,150 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns bench-test
+  "Pins the isolation contract of the bench/dogfood sandbox.
+
+   The 2026-08-06 incident: the bench sandbox was a linked `git worktree`
+   of the live checkout, so redirecting the bench's origin at a local bare
+   mirror redirected the live checkout's origin too, and the bench's
+   `git fetch origin main` force-updated the live checkout's `origin/main`
+   backwards to the mirror's stale head. These tests run real git against
+   throwaway repos — the leak is a property of how git shares a common
+   dir, so a mocked git would not observe it."
+  (:require
+   [bench :as sut]
+   [bench-git :as git]
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]])
+  (:import
+   [java.io File]
+   [java.nio.file Files]
+   [java.nio.file.attribute FileAttribute]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} launching-origin
+  "Obviously synthetic — `.invalid` is reserved and can never resolve, so a
+   test that accidentally reaches the network fails loudly instead of
+   touching a real remote."
+  "https://example.invalid/launching-origin.git")
+
+(defn- ^{:stratum 0} temp-dir []
+  (str (Files/createTempDirectory "miniforge-bench-test" (make-array FileAttribute 0))))
+
+(defn- ^{:stratum 0} delete-tree! [path]
+  (let [f (File. (str path))]
+    (when (.exists f)
+      (when (.isDirectory f)
+        (doseq [child (.listFiles f)] (delete-tree! child)))
+      (.delete f))))
+
+(defn- ^{:stratum 0} heads [dir]
+  (->> (:out (git/git dir "for-each-ref" "--format=%(refname)" "refs/heads"))
+       str str/split-lines (remove str/blank?) set))
+
+(deftest ^{:stratum 0} qualified-branch-ref-prefixes-exactly-once-test
+  (testing "every accepted spelling normalizes to one refs/heads/ prefix"
+    (is (= "refs/heads/main" (sut/qualified-branch-ref "main")))
+    (is (= "refs/heads/main" (sut/qualified-branch-ref "refs/heads/main")))
+    (is (= "refs/heads/main" (sut/qualified-branch-ref "heads/main")))
+    (is (= "refs/heads/main" (sut/qualified-branch-ref "refs/heads/heads/main"))
+        "the doubled prefix found in the bench mirror collapses to one"))
+  (testing "an interior heads/ segment is part of the branch name, not a prefix"
+    (is (= "refs/heads/feature/heads-up" (sut/qualified-branch-ref "feature/heads-up")))
+    (is (= "refs/heads/fix/heads/nested" (sut/qualified-branch-ref "refs/heads/fix/heads/nested"))))
+  (testing "a name that is nothing but prefixes has no ref, rather than an empty one"
+    (is (nil? (sut/qualified-branch-ref "refs/heads/")))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} init-launching-repo!
+  "A stand-in for the checkout an operator launches the bench from: one
+   commit, and an `origin` that must survive the run untouched."
+  [dir]
+  (git/git dir "init" "--quiet" "-b" "main")
+  (git/git dir "config" "user.email" "bench-test@example.invalid")
+  (git/git dir "config" "user.name" "Bench Test")
+  (git/git dir "config" "commit.gpgsign" "false")
+  (spit (str (File. (str dir) "seed.txt")) "seed\n")
+  (git/git dir "add" "seed.txt")
+  (git/git dir "commit" "--quiet" "-m" "seed")
+  (git/git dir "remote" "add" "origin" launching-origin)
+  dir)
+
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} provision-leaves-launching-origin-unchanged-test
+  (testing "a provisioned bench never rewrites the launching checkout's origin"
+    (let [root (temp-dir)
+          source (init-launching-repo! (temp-dir))]
+      (try
+        (let [report (sut/provision! {:source source :root (str (File. root "bench"))})]
+          (is (= launching-origin (git/remote-url source "origin"))
+              "the regression: the launching checkout's origin is untouched")
+          (is (= launching-origin (:source-origin report)))
+          (is (= (:mirror-dir report) (git/remote-url (:repo-dir report) "origin"))
+              "only the bench points at the throwaway mirror")
+          (is (:isolated? report))
+          (is (false? (:linked-worktree? report)))
+          (is (false? (:shares-source-git-dir? report))))
+        (finally
+          (delete-tree! root)
+          (delete-tree! source))))))
+
+(deftest ^{:stratum 2} provision-seeds-mirror-without-doubled-prefix-test
+  (testing "the mirror carries exactly the qualified branch it was told to"
+    (let [root (temp-dir)
+          source (init-launching-repo! (temp-dir))]
+      (try
+        (let [report (sut/provision! {:source source :root (str (File. root "bench"))})]
+          (is (= #{"refs/heads/main"} (heads (:mirror-dir report)))))
+        (finally
+          (delete-tree! root)
+          (delete-tree! source))))))
+
+(deftest ^{:stratum 2} provision-refuses-to-clobber-an-existing-bench-test
+  (testing "an in-flight bench keeps its worktrees and task branches"
+    (let [root (temp-dir)
+          source (init-launching-repo! (temp-dir))
+          bench-root (str (File. root "bench"))]
+      (try
+        (sut/provision! {:source source :root bench-root})
+        (is (= :conflict (:anomaly/type (sut/provision! {:source source :root bench-root}))))
+        (finally
+          (delete-tree! root)
+          (delete-tree! source))))))
+
+(deftest ^{:stratum 2} linked-worktree-is-reported-unisolated-test
+  (testing "the shape the 2026-08-06 bench actually had is rejected"
+    (let [source (init-launching-repo! (temp-dir))
+          parent (temp-dir)
+          leaky (str (File. parent "leaky-bench"))]
+      (try
+        (git/git source "worktree" "add" "--quiet" "--detach" leaky)
+        (let [report (sut/isolation-report leaky source)]
+          (is (false? (:isolated? report)))
+          (is (true? (:linked-worktree? report)))
+          (is (true? (:shares-source-git-dir? report))))
+        (testing "and the leak it guards against is real: set-url inside the
+                  worktree rewrites the launching checkout's origin"
+          (git/git leaky "remote" "set-url" "origin" "https://example.invalid/bench-mirror.git")
+          (is (not= launching-origin (git/remote-url source "origin"))))
+        (finally
+          (git/git source "worktree" "remove" "--force" leaky)
+          (delete-tree! parent)
+          (delete-tree! source))))))

--- a/docs/pull-requests/2026-08-06-bench-sandbox-isolation.md
+++ b/docs/pull-requests/2026-08-06-bench-sandbox-isolation.md
@@ -1,0 +1,125 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix: isolate the bench sandbox from the checkout it was launched from
+
+## Overview
+
+Provision the bench/dogfood sandbox as an independent clone, and add a
+fail-closed guard that refuses a bench sharing a git common dir with the
+launching checkout.
+
+## Motivation
+
+On 2026-08-06 a bench run left the live miniforge checkout with
+`remote.origin.url` pointing at `~/.miniforge/bench/origin.git` and
+`refs/remotes/origin/main` force-updated *backwards* to that mirror's
+stale head. Branches cut from `origin/main` afterwards were based on a
+stale commit, and their pushes went to the local mirror, so the PRs never
+appeared on GitHub.
+
+The bench sandbox at `~/.miniforge/bench/repo` was a linked `git worktree`
+of the live checkout:
+
+```text
+$ git -C ~/.miniforge/bench/repo rev-parse --git-dir --git-common-dir
+/Users/chris/ws/miniforge.ai/miniforge/.git/worktrees/repo
+/Users/chris/ws/miniforge.ai/miniforge/.git
+```
+
+A linked worktree owns HEAD, the index, and the working tree. `.git/config`
+and every other ref live in the shared common dir. So the bench's
+deliberate `git remote set-url origin <mirror>` — intended to stop a
+completed run opening a real PR — rewrote the launching checkout's origin,
+and its `git fetch origin main` rewrote the launching checkout's
+remote-tracking ref. Neither is recoverable by re-running the bench; both
+are silent.
+
+This is the same class as the known workflow-runtime sandbox leak: an
+isolation mechanism that isolates less than the caller assumes.
+
+## Layer
+
+Development tooling (`tasks/`), not a runtime brick.
+
+## Changes in Detail
+
+- `bench-git` — total git plumbing. A failing git call, or a `dir` that
+  does not exist, comes back as a value; `bench/verify` is routinely
+  handed a path an operator typed.
+- `bench/isolation-report` — compares the bench's per-worktree git dir
+  against its common dir, and its common dir against the launching
+  checkout's. Either overlap means `set-url`/`fetch` inside the bench
+  mutates the other checkout.
+- `bb bench:verify` — fail-closed CLI gate over that report, for a runner
+  to call before it touches anything.
+- `bb bench:provision` — clones the launching checkout, inits the bare
+  mirror, and redirects only the clone's origin. Captures the launching
+  checkout's `remote.origin.url` before the work and re-checks it after;
+  a mismatch fails the provision. Refuses an existing `<root>/repo`,
+  since a bench in flight keeps its worktrees and task branches there.
+- `qualified-branch-ref` — normalizes a push destination to exactly one
+  `refs/heads/` prefix. Git DWIMs an unqualified destination, so one
+  already carrying a partial `heads/...` prefix expands to
+  `refs/heads/heads/...`.
+
+## On the malformed `refs/heads/heads/main`
+
+Reported as a suspected refspec bug in the run's push path. It is not.
+The ref lives in the **live checkout** and predates the bench:
+
+```text
+$ git reflog show refs/heads/heads/main --date=iso | tail -1
+93c56dafa refs/heads/heads/main@{2026-05-19 19:31:14 -0700}: branch: Created from origin/main
+```
+
+Nine reflog entries follow over two days, all `pull --ff-only` and
+`reset: moving to origin/main` — a branch literally named `heads/main`
+that someone checked out and worked on. No committed code in this repo
+constructs a branch name by stripping only `refs/`, and no source file
+runs `git pull --ff-only` at all. The bench mirror acquired the junk ref
+because it was cloned from the bench worktree, which shares `refs/heads`
+with the live checkout.
+
+Two things follow. The generic fix is in this PR: refspecs are fully
+qualified via `qualified-branch-ref`, and the mirror is seeded by explicit
+push rather than by mirroring every ref, so junk refs in a source can no
+longer reach a bench mirror. The specific cleanup is a one-line ref
+deletion in the live checkout, left to the operator because a bench run
+was in flight:
+
+```bash
+git -C /path/to/checkout branch -D heads/main
+```
+
+## Testing
+
+`development/test/bench_test.clj` runs real git against throwaway repos.
+The leak is a property of how git shares a common dir between linked
+worktrees, so a mocked git cannot observe it — the last test creates a
+linked worktree, runs `remote set-url` inside it, and shows the launching
+checkout's origin change.
+
+- Provisioning leaves the launching checkout's `remote.origin.url`
+  byte-identical (the regression the incident was missing).
+- The seeded mirror carries exactly `refs/heads/main`.
+- `qualified-branch-ref` collapses `heads/main` and
+  `refs/heads/heads/main` to `refs/heads/main`, and leaves
+  `feature/heads-up` intact.
+- Provisioning refuses to clobber an existing bench.
+
+Verified against the real leaky bench, which `bb bench:verify` rejects
+with exit 1, and against a freshly provisioned one, which it accepts.
+
+## Follow-ups
+
+- The `eval/codex-traps/` bench harness is untracked on disk and was not
+  modified — a run was in flight against it. It needs a `bb bench:verify`
+  gate at startup and should be committed.
+- The worktree executor (`dag-executor`) gives task runs the same
+  filesystem-only isolation. Nothing in a task run sets remotes today, but
+  an agent that ran `git remote set-url` or `git fetch origin` inside its
+  task worktree would reach the host checkout the same way.

--- a/tasks/bench.clj
+++ b/tasks/bench.clj
@@ -41,6 +41,11 @@
   "Working clone the bench runs in, under the bench root."
   "repo")
 
+(def ^{:stratum 0} mirror-dir-name
+  "Bare mirror the bench's origin points at, under the bench root. Exists
+   so a completed run's push lands here instead of on GitHub."
+  "origin.git")
+
 (def ^{:stratum 0} default-bench-root
   "Bench sandbox root. Sits beside the other miniforge run state so a
    bench survives reboots for post-mortem — the same rationale as the
@@ -48,7 +53,39 @@
   (or (System/getenv "MINIFORGE_BENCH_ROOT")
       (str (System/getProperty "user.home") "/.miniforge/bench")))
 
-;; Composes the Layer 0 constants and the `bench-git` plumbing.
+(defn ^{:stratum 0} anomaly
+  "Anomaly-shaped failure value (std 005 §Anomaly shape). Local because
+   the bb task classpath carries `bb-utils` only, not the
+   `ai.miniforge.anomaly` component."
+  [type message data]
+  {:anomaly/type type
+   :anomaly/message message
+   :anomaly/data data
+   :anomaly/at (java.time.Instant/now)})
+
+(defn ^{:stratum 0} anomaly?
+  [x]
+  (boolean (and (map? x) (contains? x :anomaly/type))))
+
+(defn ^{:stratum 0} qualified-branch-ref
+  "Normalize `branch` to exactly one `refs/heads/` prefix, or nil when
+   nothing but prefixes remain.
+
+   Git DWIMs an unqualified push destination, so a destination already
+   carrying a partial `heads/...` prefix expands to `refs/heads/heads/...`
+   — which then makes `git ls-remote origin main` resolve ambiguously
+   against the real `refs/heads/main`. Every refspec this namespace builds
+   goes through here. Only leading `refs/` and `heads/` segments are
+   stripped; `feature/heads-up` keeps its interior intact."
+  [branch]
+  (let [stripped (loop [s (str/trim (str branch))]
+                   (cond
+                     (str/starts-with? s "refs/") (recur (subs s (count "refs/")))
+                     (str/starts-with? s "heads/") (recur (subs s (count "heads/")))
+                     :else s))]
+    (when-not (str/blank? stripped)
+      (str "refs/heads/" stripped))))
+
 (defn ^{:stratum 0} isolation-report
   "Whether `bench-dir` can safely own its own remotes and refs.
 
@@ -70,8 +107,80 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
-;; Composes Layer 1. Absolute CLI boundary (std 005) — the only layer that
-;; prints and exits.
+;; Composes Layer 0.
+(defn ^{:stratum 1} provision!
+  "Provision a bench sandbox under `:root` from the checkout at `:source`.
+
+   Clones `:source` to `<root>/repo` at `:ref`, creates the throwaway bare
+   mirror `<root>/origin.git`, pushes the pinned commit to it as a fully
+   qualified `refs/heads/<branch>`, and points only the clone's origin at
+   the mirror. Seeding by explicit push rather than by mirroring every ref
+   also stops junk refs in the source propagating into the bench.
+
+   The launching checkout is read from and never written to: its
+   `remote.origin.url` is captured before the work and re-checked after,
+   and a mismatch fails the provision.
+
+   Refuses outright when `<root>/repo` exists — a bench in flight keeps
+   its worktrees and task branches there, so removing a previous bench is
+   the operator's call, not a flag on this function.
+
+   Returns the provisioning report, or an anomaly."
+  [{:keys [source root ref branch]
+    :or {root default-bench-root ref "HEAD" branch "main"}}]
+  (let [source (git/absolute-path "." source)
+        repo-dir (str (File. (str root) repo-dir-name))
+        mirror-dir (str (File. (str root) mirror-dir-name))
+        origin-before (git/remote-url source "origin")
+        target-ref (qualified-branch-ref branch)]
+    (cond
+      (nil? target-ref)
+      (anomaly :invalid-input "branch name is empty once ref prefixes are stripped"
+               {:branch branch})
+
+      (.exists (File. repo-dir))
+      (anomaly :conflict "bench repo already exists; remove it to re-provision"
+               {:repo-dir repo-dir})
+
+      (nil? (git/git-dirs source))
+      (anomaly :invalid-input "bench source is not a git checkout" {:source source})
+
+      :else
+      (do
+        (.mkdirs (File. (str root)))
+        (let [steps [[:clone (git/git "." "clone" "--quiet" "--no-checkout" source repo-dir)]
+                     [:checkout (git/git repo-dir "checkout" "--quiet" "--detach" ref)]
+                     [:init-mirror (git/git "." "init" "--quiet" "--bare" mirror-dir)]
+                     [:seed-mirror (git/git repo-dir "push" "--quiet" mirror-dir
+                                            (str "HEAD:" target-ref))]
+                     [:mirror-head (git/git mirror-dir "symbolic-ref" "HEAD" target-ref)]
+                     [:redirect-origin (git/git repo-dir "remote" "set-url" "origin" mirror-dir)]]
+              failed (first (remove #(zero? (:exit (second %))) steps))
+              origin-after (git/remote-url source "origin")
+              report (isolation-report repo-dir source)]
+          (cond
+            failed
+            (anomaly :fault (str "bench provisioning failed at " (name (first failed)))
+                     {:step (first failed)
+                      :exit (:exit (second failed))
+                      :err (str/trim (str (:err (second failed))))})
+
+            (not= origin-before origin-after)
+            (anomaly :fault "bench provisioning mutated the launching checkout's origin"
+                     {:before origin-before :after origin-after})
+
+            (not (:isolated? report))
+            (anomaly :fault "bench repo is not isolated from the launching checkout" report)
+
+            :else
+            (assoc report
+                   :repo-dir repo-dir
+                   :mirror-dir mirror-dir
+                   :target-ref target-ref
+                   :source-origin origin-after
+                   :bench-origin (git/remote-url repo-dir "origin"))))))))
+
+;; Absolute CLI boundary (std 005) — the only fns that print and exit.
 (defn ^{:stratum 1} verify
   "Fail-closed guard for a bench runner. Exits non-zero unless the bench
    repo owns its own config and refs.
@@ -95,3 +204,26 @@
           (println "❌ shares a git common dir with" (:source-dir report)))
         (println "   provision the bench as a clone of the launching checkout instead")
         (System/exit 1)))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Composes Layer 1.
+(defn ^{:stratum 2} provision
+  "Provision an isolated bench sandbox.
+   Usage: bb bench:provision [source-dir] [ref] [branch]"
+  [& args]
+  (let [[source ref branch] (map #(some-> % str/trim not-empty) args)
+        report (provision! (cond-> {:source (or source ".")}
+                             ref (assoc :ref ref)
+                             branch (assoc :branch branch)))]
+    (if (anomaly? report)
+      (do
+        (println "❌" (:anomaly/message report))
+        (println "  " (pr-str (:anomaly/data report)))
+        (System/exit 1))
+      (do
+        (println "✅ bench provisioned")
+        (println "  repo:" (:repo-dir report))
+        (println "  mirror:" (:mirror-dir report))
+        (println "  bench origin:" (:bench-origin report))
+        (println "  launching checkout origin (unchanged):" (:source-origin report))))))

--- a/tasks/bench.clj
+++ b/tasks/bench.clj
@@ -27,7 +27,8 @@
    checkout. See DOGFOODING.md §Bench Runs for the 2026-08-06 incident
    that shape produced.
 
-   Per std 005 only the Layer 2 bb-task entry point prints and exits."
+   Per std 005 only the bb-task entry points — `verify` and `provision` —
+   print and exit; everything below them returns an anomaly as data."
   (:require
    [bench-git :as git]
    [clojure.string :as str])
@@ -138,9 +139,9 @@
       (anomaly :invalid-input "branch name is empty once ref prefixes are stripped"
                {:branch branch})
 
-      (.exists (File. repo-dir))
-      (anomaly :conflict "bench repo already exists; remove it to re-provision"
-               {:repo-dir repo-dir})
+      (some #(.exists (File. ^String %)) [repo-dir mirror-dir])
+      (anomaly :conflict "bench root already populated; remove it to re-provision"
+               {:repo-dir repo-dir :mirror-dir mirror-dir})
 
       (nil? (git/git-dirs source))
       (anomaly :invalid-input "bench source is not a git checkout" {:source source})
@@ -148,14 +149,22 @@
       :else
       (do
         (.mkdirs (File. (str root)))
-        (let [steps [[:clone (git/git "." "clone" "--quiet" "--no-checkout" source repo-dir)]
-                     [:checkout (git/git repo-dir "checkout" "--quiet" "--detach" ref)]
-                     [:init-mirror (git/git "." "init" "--quiet" "--bare" mirror-dir)]
-                     [:seed-mirror (git/git repo-dir "push" "--quiet" mirror-dir
-                                            (str "HEAD:" target-ref))]
-                     [:mirror-head (git/git mirror-dir "symbolic-ref" "HEAD" target-ref)]
-                     [:redirect-origin (git/git repo-dir "remote" "set-url" "origin" mirror-dir)]]
-              failed (first (remove #(zero? (:exit (second %))) steps))
+        ;; Thunks, not results: a vector of `(git ...)` calls would run every
+        ;; step before anything inspected an exit code, so a failed clone
+        ;; would still init a mirror and leave partial state behind.
+        (let [steps [[:clone #(git/git "." "clone" "--quiet" "--no-checkout" source repo-dir)]
+                     [:checkout #(git/git repo-dir "checkout" "--quiet" "--detach" ref)]
+                     [:init-mirror #(git/git "." "init" "--quiet" "--bare" mirror-dir)]
+                     [:seed-mirror #(git/git repo-dir "push" "--quiet" mirror-dir
+                                             (str "HEAD:" target-ref))]
+                     [:mirror-head #(git/git mirror-dir "symbolic-ref" "HEAD" target-ref)]
+                     [:redirect-origin #(git/git repo-dir "remote" "set-url" "origin" mirror-dir)]]
+              failed (reduce (fn [_ [step run-step!]]
+                               (let [r (run-step!)]
+                                 (when-not (zero? (:exit r))
+                                   (reduced [step r]))))
+                             nil
+                             steps)
               origin-after (git/remote-url source "origin")
               report (isolation-report repo-dir source)]
           (cond

--- a/tasks/bench.clj
+++ b/tasks/bench.clj
@@ -1,0 +1,97 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns bench
+  "Whether the bench/dogfood sandbox is actually isolated from the
+   checkout it was launched from.
+
+   A bench points `origin` at a throwaway local mirror so a completed run
+   cannot open a real PR. A linked `git worktree` is not a safe place to
+   do that: it owns HEAD, the index, and the working tree, while
+   `.git/config` and every other ref live in the shared common dir — so
+   `remote set-url` and `fetch` inside it rewrite the *launching*
+   checkout. See DOGFOODING.md §Bench Runs for the 2026-08-06 incident
+   that shape produced.
+
+   Per std 005 only the Layer 2 bb-task entry point prints and exits."
+  (:require
+   [bench-git :as git]
+   [clojure.string :as str])
+  (:import
+   [java.io File]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; No in-namespace dependencies.
+(def ^{:stratum 0} repo-dir-name
+  "Working clone the bench runs in, under the bench root."
+  "repo")
+
+(def ^{:stratum 0} default-bench-root
+  "Bench sandbox root. Sits beside the other miniforge run state so a
+   bench survives reboots for post-mortem — the same rationale as the
+   worktree executor's `~/.miniforge/worktrees` default."
+  (or (System/getenv "MINIFORGE_BENCH_ROOT")
+      (str (System/getProperty "user.home") "/.miniforge/bench")))
+
+;; Composes the Layer 0 constants and the `bench-git` plumbing.
+(defn ^{:stratum 0} isolation-report
+  "Whether `bench-dir` can safely own its own remotes and refs.
+
+   `:isolated?` is false when `bench-dir` is a linked worktree, or when it
+   shares a git common dir with `source-dir` — in either case a
+   `remote set-url` or `fetch` inside it mutates the other checkout.
+   `source-dir` may be nil to check `bench-dir` on its own."
+  [bench-dir source-dir]
+  (let [bench (git/git-dirs bench-dir)
+        source (when source-dir (git/git-dirs source-dir))
+        linked? (boolean (and bench (not= (:git-dir bench) (:common-dir bench))))
+        shared? (boolean (and bench source (= (:common-dir bench) (:common-dir source))))]
+    {:bench-dir (str bench-dir)
+     :source-dir (some-> source-dir str)
+     :git-dirs bench
+     :linked-worktree? linked?
+     :shares-source-git-dir? shared?
+     :isolated? (boolean (and bench (not linked?) (not shared?)))}))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Composes Layer 1. Absolute CLI boundary (std 005) — the only layer that
+;; prints and exits.
+(defn ^{:stratum 1} verify
+  "Fail-closed guard for a bench runner. Exits non-zero unless the bench
+   repo owns its own config and refs.
+   Usage: bb bench:verify [bench-repo-dir] [source-dir]"
+  [& args]
+  (let [[bench-dir source-dir] (map #(some-> % str/trim not-empty) args)
+        bench-dir (or bench-dir (str (File. default-bench-root repo-dir-name)))
+        report (isolation-report bench-dir source-dir)]
+    (println "bench-repo:" (:bench-dir report))
+    (println "  git-dir:" (get-in report [:git-dirs :git-dir]))
+    (println "  common-dir:" (get-in report [:git-dirs :common-dir]))
+    (println "  origin:" (git/remote-url bench-dir "origin"))
+    (if (:isolated? report)
+      (println "✅ isolated — remotes and refs are its own")
+      (do
+        (when-not (:git-dirs report)
+          (println "❌ not a git checkout"))
+        (when (:linked-worktree? report)
+          (println "❌ linked worktree — set-url/fetch here rewrites the parent checkout"))
+        (when (:shares-source-git-dir? report)
+          (println "❌ shares a git common dir with" (:source-dir report)))
+        (println "   provision the bench as a clone of the launching checkout instead")
+        (System/exit 1)))))

--- a/tasks/bench_git.clj
+++ b/tasks/bench_git.clj
@@ -1,0 +1,77 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns bench-git
+  "Git plumbing the bench tasks read the world through. Every fn here is
+   total: a failing git call, or a `dir` that does not exist, comes back
+   as a value rather than a throw, because `bench/verify` is routinely
+   handed a path an operator typed."
+  (:require
+   [babashka.process :as p]
+   [clojure.string :as str])
+  (:import
+   [java.io File]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; No in-namespace dependencies.
+(defn ^{:stratum 0} git
+  "Run git with `args` in `dir`. Returns the process result map. A `dir`
+   that does not exist makes the process launch itself fail, which is
+   reported as a non-zero exit like any other git failure."
+  [dir & args]
+  (try
+    (apply p/sh {:dir dir :out :string :err :string :continue true} "git" args)
+    (catch Exception e
+      {:exit 127 :out "" :err (.getMessage e)})))
+
+(defn ^{:stratum 0} absolute-path
+  "Canonical absolute path of `path`, resolved against `dir` when it is
+   relative. `git rev-parse --git-common-dir` returns a bare `.git` for
+   the primary worktree and an absolute path for linked ones, so both
+   shapes have to normalize before they can be compared."
+  [dir path]
+  (let [f (File. (str path))]
+    (.getCanonicalPath (if (.isAbsolute f) f (File. (str dir) (str path))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Composes Layer 0.
+(defn ^{:stratum 1} git-out
+  "Trimmed stdout of a git command, or nil when it failed or said nothing."
+  [dir & args]
+  (let [{:keys [exit out]} (apply git dir args)]
+    (when (zero? exit)
+      (not-empty (str/trim (str out))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Composes Layer 1.
+(defn ^{:stratum 2} remote-url
+  "Configured URL of `remote` in `dir`, or nil when unset."
+  [dir remote]
+  (git-out dir "remote" "get-url" remote))
+
+(defn ^{:stratum 2} git-dirs
+  "The `:git-dir` (per-worktree) and `:common-dir` (shared) of `dir`, both
+   canonical. They are equal for a standalone clone and differ for a
+   linked worktree. Returns nil when `dir` is not a git checkout."
+  [dir]
+  (when-let [git-dir (git-out dir "rev-parse" "--absolute-git-dir")]
+    {:git-dir (absolute-path dir git-dir)
+     :common-dir (absolute-path dir (or (git-out dir "rev-parse" "--git-common-dir")
+                                        git-dir))}))

--- a/tasks/bench_git.clj
+++ b/tasks/bench_git.clj
@@ -43,10 +43,17 @@
   "Canonical absolute path of `path`, resolved against `dir` when it is
    relative. `git rev-parse --git-common-dir` returns a bare `.git` for
    the primary worktree and an absolute path for linked ones, so both
-   shapes have to normalize before they can be compared."
+   shapes have to normalize before they can be compared.
+
+   `getCanonicalPath` resolves symlinks and so can throw on IO or security
+   failures; the uncanonicalized absolute path is a usable fallback and
+   keeps this fn total."
   [dir path]
-  (let [f (File. (str path))]
-    (.getCanonicalPath (if (.isAbsolute f) f (File. (str dir) (str path))))))
+  (let [f (File. (str path))
+        resolved (if (.isAbsolute f) f (File. (str dir) (str path)))]
+    (try
+      (.getCanonicalPath resolved)
+      (catch Exception _ (.getAbsolutePath resolved)))))
 
 ;------------------------------------------------------------------------------ Layer 1
 


### PR DESCRIPTION
## Overview

Provision the bench/dogfood sandbox as an independent clone, and add a fail-closed guard that refuses a bench sharing a git common dir with the launching checkout.

Full write-up: [docs/pull-requests/2026-08-06-bench-sandbox-isolation.md](docs/pull-requests/2026-08-06-bench-sandbox-isolation.md)

## The defect

On 2026-08-06 a bench run left the live miniforge checkout with `remote.origin.url` pointing at `~/.miniforge/bench/origin.git` and `refs/remotes/origin/main` force-updated **backwards** to that mirror's stale head. Branches cut from `origin/main` afterwards were based on a stale commit and pushed to the local mirror, so the PRs never appeared on GitHub.

Root cause: `~/.miniforge/bench/repo` was a linked `git worktree` of the live checkout.

```
$ git -C ~/.miniforge/bench/repo rev-parse --git-dir --git-common-dir
/Users/chris/ws/miniforge.ai/miniforge/.git/worktrees/repo
/Users/chris/ws/miniforge.ai/miniforge/.git
```

A linked worktree owns HEAD, the index, and the working tree. `.git/config` and every other ref live in the shared common dir. So the bench's deliberate `git remote set-url origin <mirror>` — intended to stop a completed run opening a real PR — rewrote the launching checkout's origin, and its `git fetch origin main` rewrote the launching checkout's remote-tracking ref. Same class as the known workflow-runtime sandbox leak: an isolation mechanism that isolates less than the caller assumes.

## Changes

- `bb bench:provision` — clones the launching checkout, inits the bare mirror, redirects only the clone's origin. Captures the launching checkout's `remote.origin.url` before the work and re-checks after; a mismatch fails the provision. Refuses an existing `<root>/repo`.
- `bb bench:verify` — fail-closed gate comparing the bench's per-worktree git dir against its common dir, and its common dir against the launching checkout's.
- `qualified-branch-ref` — normalizes push destinations to exactly one `refs/heads/` prefix; the mirror is seeded by explicit push rather than by mirroring every ref.
- `DOGFOODING.md` §Bench Runs — the correct procedure and the failure mode.

## Correction on `refs/heads/heads/main`

Reported as a suspected refspec bug in the run's push path. It is not. The ref lives in the live checkout and predates the bench:

```
93c56dafa refs/heads/heads/main@{2026-05-19 19:31:14 -0700}: branch: Created from origin/main
```

Nine reflog entries follow over two days, all `pull --ff-only` and `reset: moving to origin/main` — a branch literally named `heads/main` that someone checked out and worked on. No committed code constructs a branch name by stripping only `refs/`, and no source file runs `git pull --ff-only`. The bench mirror acquired it because it was cloned from the bench worktree, which shares `refs/heads` with the live checkout. The generic fix (qualified refspecs, explicit-push seeding) is in this PR; deleting the stray ref is left to the operator because a bench run was in flight.

## Testing

`development/test/bench_test.clj` runs real git against throwaway repos — the leak is a property of how git shares a common dir, so a mocked git cannot observe it. The last test creates a linked worktree, runs `set-url` inside it, and shows the launching checkout's origin change.

Verified against the real leaky bench (`bb bench:verify` exits 1) and a freshly provisioned one (exits 0). Pre-commit suite green on all five commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)