### PR TITLE
fix: enforce execution-grant scope

### DIFF
--- a/components/decision-envelope/src/ai/miniforge/decision_envelope/core.clj
+++ b/components/decision-envelope/src/ai/miniforge/decision_envelope/core.clj
@@ -40,7 +40,7 @@
     :reason/unknown-severity
     :reason/missing-artifact
     :reason/gate-check-failed
-    ;; A ceiling that denies only sometimes is not a ceiling. Both grant
+    ;; A ceiling that denies only sometimes is not a ceiling. Grant
     ;; reasons are deny-class, so an effect over budget or lacking
     ;; authority cannot be downgraded to an obligation and proceed.
     :reason/grant-exceeded

--- a/components/decision-envelope/src/ai/miniforge/decision_envelope/core.clj
+++ b/components/decision-envelope/src/ai/miniforge/decision_envelope/core.clj
@@ -44,6 +44,7 @@
     ;; reasons are deny-class, so an effect over budget or lacking
     ;; authority cannot be downgraded to an obligation and proceed.
     :reason/grant-exceeded
+    :reason/grant-scope-mismatch
     :reason/grant-absent})
 
 (def ^{:stratum 0} ^:private obligation-only-types

--- a/components/decision-envelope/src/ai/miniforge/decision_envelope/schema.clj
+++ b/components/decision-envelope/src/ai/miniforge/decision_envelope/schema.clj
@@ -46,6 +46,7 @@
    ;; Ariadne 2b — authority, not policy: the action may be legal and
    ;; still be beyond what this principal was granted.
    :reason/grant-exceeded
+   :reason/grant-scope-mismatch
    :reason/grant-absent])
 
 (def ^{:stratum 0} obligation-types

--- a/components/decision-envelope/test/ai/miniforge/decision_envelope/interface_test.clj
+++ b/components/decision-envelope/test/ai/miniforge/decision_envelope/interface_test.clj
@@ -32,7 +32,8 @@
   (testing "deny-class reasons force :deny"
     (doseq [code [:reason/rule-violation :reason/unknown-enforcement
                   :reason/unknown-severity :reason/missing-artifact
-                  :reason/gate-check-failed]]
+                  :reason/gate-check-failed :reason/grant-exceeded
+                  :reason/grant-scope-mismatch :reason/grant-absent]]
       (is (= :deny (env/derive-decision [{:reason/code code :reason/detail "x"}] []))
           (str code))))
   (testing "approval obligation denies until a workflow clears it"

--- a/components/effect-transaction/test/ai/miniforge/effect_transaction/commit_test.clj
+++ b/components/effect-transaction/test/ai/miniforge/effect_transaction/commit_test.clj
@@ -37,6 +37,8 @@
 
 (def ^{:stratum 0} propose-merge! fixture/propose-merge!)
 
+(def ^{:stratum 0} record-success! fixture/record-success!)
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (deftest ^{:stratum 1} interrupted-effect-is-unknown-not-failed-test
@@ -94,7 +96,7 @@
           revoked (grant/revoke g :breach/cost-exceeded now)
           fired (atom false)
           done (fx/commit! dir t revoked {} now
-                           (fn [] (reset! fired true) {:effect/outcome :succeeded}))]
+                           (partial record-success! fired))]
       (is (= :failed (:effect/state done)))
       (is (not @fired) "the effect MUST NOT fire when the re-check refuses")
       (is (re-find #"inactive" (:effect/failure done)))))
@@ -105,7 +107,7 @@
           t (propose-merge! dir g)
           fired (atom false)
           done (fx/commit! dir t g {} much-later
-                           (fn [] (reset! fired true) {:effect/outcome :succeeded}))]
+                           (partial record-success! fired))]
       (is (= :failed (:effect/state done)))
       (is (not @fired))))
 
@@ -115,7 +117,7 @@
           t (propose-merge! dir g)
           fired (atom false)
           done (fx/commit! dir t g {:usage/count 99} now
-                           (fn [] (reset! fired true) {:effect/outcome :succeeded}))]
+                           (partial record-success! fired))]
       (is (= :failed (:effect/state done)))
       (is (not @fired))))
 
@@ -129,7 +131,7 @@
           t (propose-merge! dir g)
           fired (atom false)
           result (fx/commit! dir t nil {} now
-                             (fn [] (reset! fired true) {:effect/outcome :succeeded}))]
+                             (partial record-success! fired))]
       (is (anomaly/anomaly? result))
       (is (not @fired))
       (is (= :proposed (:effect/state (fx/read-record dir (:effect/id t))))
@@ -152,7 +154,7 @@
       (let [t (assoc (propose-merge! dir g) :effect/state state)
             fired (atom false)
             result (fx/commit! dir t g {} now
-                               (fn [] (reset! fired true) {:effect/outcome :succeeded}))]
+                               (partial record-success! fired))]
         (is (anomaly/anomaly? result) (str "commit from " state " must refuse"))
         (is (= :conflict (:anomaly/type result)) (str state))
         (is (not @fired)
@@ -174,7 +176,7 @@
       (let [other (merge-grant {:constraints {}})
             fired (atom false)
             result (fx/commit! dir t other {} now
-                               (fn [] (reset! fired true) {:effect/outcome :succeeded}))]
+                               (partial record-success! fired))]
         (is (anomaly/anomaly? result))
         (is (= :conflict (:anomaly/type result)))
         (is (not @fired) "substituting a broader grant must not fire the effect")))
@@ -190,10 +192,23 @@
             mismatched (assoc t :effect/grant-id (:grant/id deploy-grant))
             fired (atom false)
             result (fx/commit! dir mismatched deploy-grant {} now
-                               (fn [] (reset! fired true) {:effect/outcome :succeeded}))]
+                               (partial record-success! fired))]
         (is (anomaly/anomaly? result))
         (is (not @fired) "a merge proposal must not be authorized by a deploy grant")))
 
     (testing "the recorded grant still commits"
       (let [done (fx/commit! dir t recorded {} now (fn [] {:effect/outcome :succeeded}))]
         (is (= :succeeded (:effect/state done)))))))
+
+(deftest ^{:stratum 1} commit-enforces-grant-scope-test
+  (testing "durable proposal scope overrides a caller-supplied scope"
+    (let [dir (tmp-dir)
+          g (merge-grant {:scope (assoc fixture/merge-proposal :pr/number 43)})
+          t (propose-merge! dir g)
+          fired (atom false)
+          usage {:effect/scope (:grant/scope g)}
+          result (fx/commit! dir t g usage now
+                             (partial record-success! fired))]
+      (is (= :failed (:effect/state result)))
+      (is (re-find #"scope-mismatch" (:effect/failure result)))
+      (is (not @fired)))))

--- a/components/effect-transaction/test/ai/miniforge/effect_transaction/fixtures.clj
+++ b/components/effect-transaction/test/ai/miniforge/effect_transaction/fixtures.clj
@@ -41,6 +41,12 @@
   []
   (str (.toFile (Files/createTempDirectory "fx-test" (into-array FileAttribute [])))))
 
+(defn ^{:stratum 0} record-success!
+  "Record that a test effect fired and report definite success."
+  [fired]
+  (reset! fired true)
+  {:effect/outcome :succeeded})
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn ^{:stratum 1} merge-grant

--- a/components/execution-grant/src/ai/miniforge/execution_grant/constraints.clj
+++ b/components/execution-grant/src/ai/miniforge/execution_grant/constraints.clj
@@ -34,6 +34,7 @@
    Everything fails CLOSED. A nil grant, an inactive grant, and an
    unresolvable ancestry all deny; absence is not silence (§13.7)."
   (:require
+   [ai.miniforge.execution-grant.attenuation :as attenuation]
    [ai.miniforge.execution-grant.lineage :as lineage]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -70,6 +71,19 @@
   "True when `authorize` returned `:authorized`."
   [result]
   (= :authorized (:grant/outcome result)))
+
+(defn- ^{:stratum 0} within-scope?
+  "True when `effect-scope` carries every binding the grant requires.
+   The existing attenuation relation is the authority: an effect may
+   add narrower bindings, but may not drop or change a grant binding.
+   An empty grant scope is deliberately unbounded; every non-empty
+   scope requires a map so malformed effect data denies, not throws."
+  [grant effect-scope]
+  (let [grant-scope (:grant/scope grant)]
+    (and (map? grant-scope)
+         (or (empty? grant-scope)
+             (and (map? effect-scope)
+                  (not (attenuation/scope-widened? grant-scope effect-scope)))))))
 
 ;------------------------------------------------------------------------------ Layer 1
 
@@ -129,6 +143,9 @@
       :grant/revocation-reason r}                    - revoked, expired,
                                                        or unverifiable
                                                        ancestry
+     {:grant/outcome :scope-mismatch :grant/id id
+      :grant/scope required :effect/scope actual}    - effect is outside
+                                                       the grant scope
      {:grant/outcome :exceeded :grant/id id
       :constraint/breaches [...]}                    - over a ceiling
 
@@ -143,12 +160,19 @@
      (let [active? (if lookup
                      (lineage/active? grant now lookup)
                      (lineage/active? grant now))
+           effect-scope (:effect/scope usage)
            over (when active? (breaches grant usage))]
        (cond
          (not active?)
          {:grant/outcome :inactive
           :grant/id (:grant/id grant)
           :grant/revocation-reason (:grant/revocation-reason grant)}
+
+         (not (within-scope? grant effect-scope))
+         {:grant/outcome :scope-mismatch
+          :grant/id (:grant/id grant)
+          :grant/scope (:grant/scope grant)
+          :effect/scope effect-scope}
 
          (seq over)
          {:grant/outcome :exceeded

--- a/components/execution-grant/src/ai/miniforge/execution_grant/constraints.clj
+++ b/components/execution-grant/src/ai/miniforge/execution_grant/constraints.clj
@@ -72,7 +72,7 @@
   [result]
   (= :authorized (:grant/outcome result)))
 
-(defn- ^{:stratum 0} within-scope?
+(defn- ^{:stratum 0} effect-within-grant-scope?
   "True when `effect-scope` carries every binding the grant requires.
    The existing attenuation relation is the authority: an effect may
    add narrower bindings, but may not drop or change a grant binding.
@@ -168,7 +168,7 @@
           :grant/id (:grant/id grant)
           :grant/revocation-reason (:grant/revocation-reason grant)}
 
-         (not (within-scope? grant effect-scope))
+         (not (effect-within-grant-scope? grant effect-scope))
          {:grant/outcome :scope-mismatch
           :grant/id (:grant/id grant)
           :grant/scope (:grant/scope grant)

--- a/components/execution-grant/src/ai/miniforge/execution_grant/core.clj
+++ b/components/execution-grant/src/ai/miniforge/execution_grant/core.clj
@@ -66,13 +66,13 @@
   "Build a grant map from caller-supplied bounds plus runtime-owned
    identity. `:grant/id` and `:grant/issued-at` are minted here and
    never accepted from a caller; a fresh grant is never born revoked."
-  [{:keys [principal effect-class scope constraints parent-id delegable? expires-at]}
+  [{:keys [principal effect-class parent-id delegable? expires-at] :as opts}
    ^Instant now]
   {:grant/id (random-uuid)
    :grant/principal principal
    :grant/effect-class effect-class
-   :grant/scope (or scope {})
-   :grant/constraints (or constraints {})
+   :grant/scope (get opts :scope {})
+   :grant/constraints (get opts :constraints {})
    :grant/parent-id parent-id
    :grant/delegable? (boolean delegable?)
    :grant/issued-at now

--- a/components/execution-grant/src/ai/miniforge/execution_grant/interface.clj
+++ b/components/execution-grant/src/ai/miniforge/execution_grant/interface.clj
@@ -19,10 +19,11 @@
   "Public API for the execution-grant component (Ariadne step 2a):
    bounded authority to perform an irreversible effect.
 
-   Nothing consults grants yet — `decide()` gains them in step 2b and
-   the effect call sites in 2d. This component owns the object and its
-   rules: issuance, attenuated delegation, revocation as a state, and
-   liveness over lineage."
+   `decide()` and effect-transaction both consult grants. Production
+   call sites still await the runtime issuer before they can remove
+   their explicit unenforced-authority marker. This component owns the
+   object and its rules: issuance, attenuated delegation, revocation as
+   a state, scope and ceiling authorization, and liveness over lineage."
   (:require
    [ai.miniforge.execution-grant.attenuation :as attenuation]
    [ai.miniforge.execution-grant.breach :as breach]

--- a/components/execution-grant/src/ai/miniforge/execution_grant/interface.clj
+++ b/components/execution-grant/src/ai/miniforge/execution_grant/interface.clj
@@ -19,11 +19,12 @@
   "Public API for the execution-grant component (Ariadne step 2a):
    bounded authority to perform an irreversible effect.
 
-   `decide()` and effect-transaction both consult grants. Production
-   call sites still await the runtime issuer before they can remove
-   their explicit unenforced-authority marker. This component owns the
-   object and its rules: issuance, attenuated delegation, revocation as
-   a state, scope and ceiling authorization, and liveness over lineage."
+   Decision gating consumes authorization results, and
+   effect-transaction rechecks grants at commit. Production call sites
+   still await the runtime issuer before they can remove their explicit
+   unenforced-authority marker. This component owns the object and its
+   rules: issuance, attenuated delegation, revocation as a state, scope
+   and ceiling authorization, and liveness over lineage."
   (:require
    [ai.miniforge.execution-grant.attenuation :as attenuation]
    [ai.miniforge.execution-grant.breach :as breach]

--- a/components/execution-grant/test/ai/miniforge/execution_grant/constraints_test.clj
+++ b/components/execution-grant/test/ai/miniforge/execution_grant/constraints_test.clj
@@ -30,14 +30,21 @@
 
 (def ^{:stratum 0} much-later (Instant/parse "2026-08-01T00:00:00Z"))
 
+(def ^{:stratum 0} effect-scope {:workflow/run-id "run-1"})
+
 ;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} usage
+  "Usage readings for the effect named by `effect-scope`."
+  ([] (usage {}))
+  ([readings] (assoc readings :effect/scope effect-scope)))
 
 (defn ^{:stratum 1} spend-grant
   ([] (spend-grant {}))
   ([overrides]
    (grant/issue (merge {:principal "agent:implementer"
                         :effect-class :effect/spend
-                        :scope {:workflow-run "run-1"}
+                        :scope effect-scope
                         :constraints {:constraint/max-cost-usd 5.0
                                       :constraint/max-tokens 100000}
                         :delegable? true
@@ -101,7 +108,8 @@
       ;; else in this component.
       (is (= [:constraint/max-cost-usd]
              (mapv :constraint/axis (grant/breaches g {:usage/cost-usd "lots"}))))
-      (is (= :exceeded (:grant/outcome (grant/authorize g {:usage/tokens :unknown} now)))))))
+      (is (= :exceeded (:grant/outcome
+                        (grant/authorize g (usage {:usage/tokens :unknown}) now)))))))
 
 (deftest ^{:stratum 2} authorize-fails-closed-test
   (testing "no grant at all is :absent — absence is not silence"
@@ -109,34 +117,54 @@
 
   (testing "a revoked grant is :inactive and carries the cause"
     (let [r (grant/revoke (spend-grant) :breach/cost-exceeded now)
-          result (grant/authorize r {} now)]
+          result (grant/authorize r (usage) now)]
       (is (= :inactive (:grant/outcome result)))
       (is (= :breach/cost-exceeded (:grant/revocation-reason result)))))
 
   (testing "an expired grant is :inactive even with a clean revocation stamp"
     (let [g (spend-grant)]
       (is (nil? (:grant/revoked-at g)))
-      (is (= :inactive (:grant/outcome (grant/authorize g {} much-later))))))
+      (is (= :inactive (:grant/outcome (grant/authorize g (usage) much-later))))))
 
   (testing "a delegated grant with no lookup is NOT authorized"
     (let [parent (spend-grant)
           child (grant/delegate parent
                                 {:principal "agent:sub"
-                                 :scope {:workflow-run "run-1"}
+                                 :scope effect-scope
                                  :constraints {:constraint/max-cost-usd 1.0
                                                :constraint/max-tokens 10}
                                  :expires-at later}
                                 now)]
-      (is (= :inactive (:grant/outcome (grant/authorize child {} now)))
+      (is (= :inactive (:grant/outcome (grant/authorize child (usage) now)))
           "an unverified grant must never read as a live one")
       (is (grant/authorized?
-           (grant/authorize child {} now
+           (grant/authorize child (usage) now
                             (fn [id] (when (= id (:grant/id parent)) parent)))))))
 
   (testing "within ceilings on a live grant is :authorized"
     (is (grant/authorized? (grant/authorize (spend-grant)
-                                            {:usage/cost-usd 1.0}
+                                            (usage {:usage/cost-usd 1.0})
                                             now)))))
+
+(deftest ^{:stratum 2} authorize-enforces-scope-test
+  (let [g (spend-grant)]
+    (testing "an absent effect scope fails closed"
+      (is (= :scope-mismatch (:grant/outcome (grant/authorize g {} now)))))
+    (testing "a changed grant binding is outside the grant scope"
+      (is (= :scope-mismatch
+             (:grant/outcome
+              (grant/authorize g
+                               {:effect/scope {:workflow/run-id "run-2"}}
+                               now)))))
+    (testing "a malformed persisted scope denies rather than becoming unbounded"
+      (let [malformed (assoc g :grant/scope nil)]
+        (is (= :scope-mismatch
+               (:grant/outcome (grant/authorize malformed (usage) now))))))
+    (testing "extra effect bindings narrow rather than widen"
+      (is (grant/authorized?
+           (grant/authorize g
+                            {:effect/scope (assoc effect-scope :phase :release)}
+                            now))))))
 
 (deftest ^{:stratum 2} ceiling-holds-on-every-path-test
   ;; The two-channel lesson (T3 contradiction 9): the 3h40m runaway
@@ -145,7 +173,7 @@
   ;; enforced by the same call no matter which path reaches the effect,
   ;; so there is no second path to forget to wire.
   (let [g (spend-grant)
-        over {:usage/cost-usd 6.0}
+        over (usage {:usage/cost-usd 6.0})
         path-a (grant/authorize g over now)
         path-b (grant/authorize g over now (constantly nil))]
     (is (= :exceeded (:grant/outcome path-a)))
@@ -156,22 +184,24 @@
 (deftest ^{:stratum 2} recheck-at-commit-catches-what-decide-could-not-test
   (testing "a grant revoked between decide and commit fails the commit"
     (let [g (spend-grant)
-          at-decide (grant/authorize g {:usage/cost-usd 1.0} now)
+          at-decide (grant/authorize g (usage {:usage/cost-usd 1.0}) now)
           revoked (grant/revoke g :breach/cost-exceeded now)
-          at-commit (grant/authorize revoked {:usage/cost-usd 1.0} now)]
+          at-commit (grant/authorize revoked (usage {:usage/cost-usd 1.0}) now)]
       (is (grant/authorized? at-decide))
       (is (not (grant/authorized? at-commit)))
       (is (= :inactive (:grant/outcome at-commit)))))
 
   (testing "a grant that expires between decide and commit fails the commit"
     (let [g (spend-grant)]
-      (is (grant/authorized? (grant/authorize g {} now)))
-      (is (not (grant/authorized? (grant/authorize g {} much-later))))))
+      (is (grant/authorized? (grant/authorize g (usage) now)))
+      (is (not (grant/authorized? (grant/authorize g (usage) much-later))))))
 
   (testing "usage that grew past the ceiling between the two calls fails the second"
     (let [g (spend-grant)]
-      (is (grant/authorized? (grant/authorize g {:usage/cost-usd 4.0} now)))
-      (is (= :exceeded (:grant/outcome (grant/authorize g {:usage/cost-usd 5.5} now)))))))
+      (is (grant/authorized? (grant/authorize g (usage {:usage/cost-usd 4.0}) now)))
+      (is (= :exceeded
+             (:grant/outcome
+              (grant/authorize g (usage {:usage/cost-usd 5.5}) now)))))))
 
 (deftest ^{:stratum 2} malformed-ceiling-is-a-breach-test
   ;; A persisted grant could carry a non-numeric ceiling. The check site
@@ -194,4 +224,6 @@
     (is (= [:constraint/max-cost-usd]
            (mapv :constraint/axis (grant/breaches g {:usage/cost-usd 1.0})))
         "but the check site must still deny rather than throw")
-    (is (= :exceeded (:grant/outcome (grant/authorize g {:usage/cost-usd 1.0} now))))))
+    (is (= :exceeded
+           (:grant/outcome
+            (grant/authorize g (usage {:usage/cost-usd 1.0}) now))))))

--- a/components/execution-grant/test/ai/miniforge/execution_grant/interface_test.clj
+++ b/components/execution-grant/test/ai/miniforge/execution_grant/interface_test.clj
@@ -84,7 +84,10 @@
   (testing "an unknown effect class is refused, not coerced"
     (is (anomaly/anomaly? (root {:effect-class :effect/launch-missiles}))))
   (testing "a missing expiry is refused — an unbounded grant is not a grant"
-    (is (anomaly/anomaly? (root {:expires-at nil})))))
+    (is (anomaly/anomaly? (root {:expires-at nil}))))
+  (testing "explicit nil bounds are refused rather than silently broadened"
+    (is (anomaly/anomaly? (root {:scope nil})))
+    (is (anomaly/anomaly? (root {:constraints nil})))))
 
 (deftest ^{:stratum 2} delegation-attenuates-test
   (let [parent (root)]

--- a/components/execution-grant/test/ai/miniforge/execution_grant/interface_test.clj
+++ b/components/execution-grant/test/ai/miniforge/execution_grant/interface_test.clj
@@ -32,6 +32,8 @@
 
 (def ^{:stratum 0} much-later (Instant/parse "2026-08-01T00:00:00Z"))
 
+(def ^{:stratum 0} repo-scope {:pr/repo "miniforge-ai/miniforge"})
+
 (defn ^{:stratum 0} lookup-of
   "An `id -> grant` resolver over the given grants."
   [& grants]
@@ -40,13 +42,15 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
+(def ^{:stratum 1} pr-scope (assoc repo-scope :pr/number 42))
+
 (defn ^{:stratum 1} root
   "A delegable root merge grant, bounded on every axis."
   ([] (root {}))
   ([overrides]
    (grant/issue (merge {:principal "operator:chris"
                         :effect-class :effect/merge
-                        :scope {:repo "miniforge-ai/miniforge"}
+                        :scope repo-scope
                         :constraints {:constraint/max-cost-usd 10.0
                                       :constraint/max-tokens 100000
                                       :constraint/max-count 5}
@@ -87,7 +91,7 @@
     (testing "a narrower child is issued and names its parent"
       (let [child (grant/delegate parent
                                   {:principal "agent:implementer"
-                                   :scope {:repo "miniforge-ai/miniforge" :pr 42}
+                                   :scope pr-scope
                                    :constraints {:constraint/max-cost-usd 2.0
                                                  :constraint/max-tokens 1000
                                                  :constraint/max-count 1}
@@ -100,7 +104,7 @@
     (testing "raising a ceiling is refused, naming the axis"
       (let [refused (grant/delegate parent
                                     {:principal "agent:x"
-                                     :scope {:repo "miniforge-ai/miniforge"}
+                                     :scope repo-scope
                                      :constraints {:constraint/max-cost-usd 999.0}
                                      :expires-at later}
                                     now)]
@@ -111,7 +115,7 @@
     (testing "OMITTING a ceiling the parent set is refused — absent means unbounded"
       (let [refused (grant/delegate parent
                                     {:principal "agent:x"
-                                     :scope {:repo "miniforge-ai/miniforge"}
+                                     :scope repo-scope
                                      :constraints {:constraint/max-cost-usd 1.0}
                                      :expires-at later}
                                     now)]
@@ -131,7 +135,7 @@
       (is (anomaly/anomaly?
            (grant/delegate parent
                            {:principal "agent:x"
-                            :scope {:repo "miniforge-ai/miniforge"}
+                            :scope repo-scope
                             :constraints (:grant/constraints parent)
                             :expires-at (Instant/parse "2026-12-01T00:00:00Z")}
                            now))))
@@ -140,7 +144,7 @@
       (let [child (grant/delegate parent
                                   {:principal "agent:x"
                                    :effect-class :effect/deploy
-                                   :scope {:repo "miniforge-ai/miniforge"}
+                                   :scope repo-scope
                                    :constraints (:grant/constraints parent)
                                    :expires-at later}
                                   now)]
@@ -152,22 +156,23 @@
     ;; scope may legitimately hold. Presence must be tested with
     ;; `contains?`, or a child could drop exactly this key undetected.
     (let [sentinel :ai.miniforge.execution-grant.attenuation/absent
-          parent (root {:scope {:repo "miniforge-ai/miniforge" :marker sentinel}})]
+          parent (root {:scope (assoc repo-scope :marker sentinel)})]
       (is (anomaly/anomaly?
            (grant/delegate parent
                            {:principal "agent:x"
-                            :scope {:repo "miniforge-ai/miniforge"}
+                            :scope repo-scope
                             :constraints (:grant/constraints parent)
                             :expires-at later}
                            now))
           "dropping a key whose value equals the sentinel is still a widening")))
 
   (testing "a key bound to nil must still be carried by the child"
-    (let [parent (root {:scope {:repo "miniforge-ai/miniforge" :branch nil}})]
+    (let [scope-with-nil (assoc repo-scope :branch nil)
+          parent (root {:scope scope-with-nil})]
       (is (anomaly/anomaly?
            (grant/delegate parent
                            {:principal "agent:x"
-                            :scope {:repo "miniforge-ai/miniforge"}
+                            :scope repo-scope
                             :constraints (:grant/constraints parent)
                             :expires-at later}
                            now))
@@ -175,7 +180,7 @@
       (is (grant/valid?
            (grant/delegate parent
                            {:principal "agent:x"
-                            :scope {:repo "miniforge-ai/miniforge" :branch nil}
+                            :scope scope-with-nil
                             :constraints (:grant/constraints parent)
                             :expires-at later}
                            now))
@@ -193,7 +198,7 @@
   (testing "a refused delegation from a valid parent is :unauthorized"
     (let [a (grant/delegate (root {:delegable? false})
                             {:principal "agent:x"
-                             :scope {:repo "miniforge-ai/miniforge"}
+                             :scope repo-scope
                              :constraints {:constraint/max-cost-usd 1.0
                                            :constraint/max-tokens 10
                                            :constraint/max-count 1}
@@ -207,7 +212,7 @@
       (is (anomaly/anomaly?
            (grant/delegate parent
                            {:principal "agent:x"
-                            :scope {:repo "miniforge-ai/miniforge"}
+                            :scope repo-scope
                             :constraints (:grant/constraints parent)
                             :expires-at later}
                            now)))))
@@ -217,7 +222,7 @@
       (is (anomaly/anomaly?
            (grant/delegate parent
                            {:principal "agent:x"
-                            :scope {:repo "miniforge-ai/miniforge"}
+                            :scope repo-scope
                             :constraints (:grant/constraints parent)
                             :expires-at later}
                            now)))))
@@ -227,7 +232,7 @@
       (is (anomaly/anomaly?
            (grant/delegate parent
                            {:principal "agent:x"
-                            :scope {:repo "miniforge-ai/miniforge"}
+                            :scope repo-scope
                             :constraints (:grant/constraints parent)
                             :expires-at later}
                            much-later))))))
@@ -250,7 +255,7 @@
   (let [parent (root)
         child (grant/delegate parent
                               {:principal "agent:implementer"
-                               :scope {:repo "miniforge-ai/miniforge" :pr 42}
+                               :scope pr-scope
                                :constraints {:constraint/max-cost-usd 2.0
                                              :constraint/max-tokens 1000
                                              :constraint/max-count 1}

--- a/components/gate/resources/config/gate/messages/en-US.edn
+++ b/components/gate/resources/config/gate/messages/en-US.edn
@@ -1,3 +1,7 @@
+;; Title: Miniforge.ai
+;; Author: Christopher Lester (christopher@miniforge.ai)
+;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+
 {:gate/messages
  {;; Review-approved gate — verdict not approved (carries the decision read)
   :review/not-approved
@@ -58,6 +62,9 @@
   ;; Policy-pack gate — pack compilation failed before evaluation.
   :policy-pack/compile-error
   "Policy pack compilation failed: {message}"
+
+  :decide/grant-scope-mismatch
+  "Effect is outside the grant scope"
 
   :opsv/instrumentation-description "Validates required OPSV signals"
   :opsv/instrumentation-failed "Required instrumentation is unavailable or unreliable"

--- a/components/gate/resources/config/gate/messages/en-US.edn
+++ b/components/gate/resources/config/gate/messages/en-US.edn
@@ -63,9 +63,6 @@
   :policy-pack/compile-error
   "Policy pack compilation failed: {message}"
 
-  :decide/grant-scope-mismatch
-  "Effect is outside the grant scope"
-
   :opsv/instrumentation-description "Validates required OPSV signals"
   :opsv/instrumentation-failed "Required instrumentation is unavailable or unreliable"
   :opsv/instrumentation-remediation "Configure and verify every required signal before execution"

--- a/components/gate/resources/config/gate/messages/system.edn
+++ b/components/gate/resources/config/gate/messages/system.edn
@@ -1,0 +1,16 @@
+;; Title: Miniforge.ai
+;; Author: Christopher Lester (christopher@miniforge.ai)
+;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+
+{:gate/system
+ {:decide/policy-rule-violated "policy rule violated"
+  :decide/missing-artifact "gates configured but no artifact was produced"
+  :decide/check-failed "check failed"
+  :decide/gate-failed "gate {gate} failed: {message}"
+  :decide/breach "{axis}: {observed} exceeds {limit}"
+  :decide/grant-absent "no grant covers this effect"
+  :decide/grant-inactive "grant is not active"
+  :decide/grant-inactive-revoked "grant is not active (revoked: {reason})"
+  :decide/grant-scope-mismatch "Effect is outside the grant scope"
+  :decide/grant-exceeded-no-detail "grant exceeded; no breach detail supplied"
+  :decide/unrecognized-grant-outcome "unrecognized grant outcome: {outcome}"}}

--- a/components/gate/src/ai/miniforge/gate/decide.clj
+++ b/components/gate/src/ai/miniforge/gate/decide.clj
@@ -24,14 +24,17 @@
    pass."
   (:require
    [ai.miniforge.decision-envelope.interface :as env]
-   [ai.miniforge.gate.messages :as msg]))
+   [ai.miniforge.gate.grant :as grant]
+   [ai.miniforge.gate.messages :as msg]
+   [ai.miniforge.gate.reason :as reason]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
-;; Translation helpers
 (defn- ^{:stratum 0} violation-detail
   [v]
-  (str (or (:message v) (:current v) "policy rule violated")))
+  (str (or (:message v)
+           (:current v)
+           (msg/system-t :decide/policy-rule-violated))))
 
 (defn- ^{:stratum 0} rule-id
   [v]
@@ -40,49 +43,24 @@
 (defn ^{:stratum 0} missing-artifact-reason
   "The nil-artifact-fails-the-gate discipline as a reason (wired by 1d)."
   []
-  {:reason/code :reason/missing-artifact
-   :reason/detail "gates configured but no artifact was produced"})
+  (reason/create :reason/missing-artifact
+                 (msg/system-t :decide/missing-artifact)))
 
 (defn ^{:stratum 0} allowed?
   "True when the envelope's decision is not :deny."
   [envelope]
   (not= :deny (:envelope/decision envelope)))
 
-;; Grant translation (Ariadne 2b)
-(defn- ^{:stratum 0} breach-detail
-  "Render one breach. `axis` is printed defensively rather than
-   `name`-d: this translator takes plain data, and a malformed entry
-   must still produce a deny reason instead of throwing on its way to
-   describing one."
-  [{:constraint/keys [axis limit observed]}]
-  (str (if (keyword? axis) (name axis) (pr-str axis))
-       ": " observed " exceeds " limit))
+(defn- ^{:stratum 0} mechanical-failure-reason
+  [result]
+  (let [gate (name (get result :gate :unknown))
+        error (first (:errors result))
+        detail (or (:message error) (msg/system-t :decide/check-failed))]
+    (reason/create :reason/gate-check-failed
+                   (msg/system-t :decide/gate-failed
+                                 {:gate gate :message detail}))))
 
 ;------------------------------------------------------------------------------ Layer 1
-
-(defn ^{:stratum 1} gates->envelope
-  "Phase-level envelope from a `check-gates` result (Ariadne 1d): ONE
-   envelope per gated transition. Policy-gate results already carry an
-   envelope — their reasons and obligations merge in; a mechanical gate
-   failure contributes a :reason/gate-check-failed; a nil artifact with
-   gates configured contributes :reason/missing-artifact. Pins come
-   from the first policy envelope present (nil pins otherwise)."
-  [{:keys [results]} artifact-nil?]
-  (let [gate-envs (keep :envelope results)
-        mech-failures (remove :envelope (remove :passed? results))
-        pins (or (:envelope/pins (first gate-envs))
-                 {:pins/pack-revision nil :pins/rule-ids [] :pins/event-watermark nil})]
-    (env/envelope
-     (concat (mapcat :envelope/reasons gate-envs)
-             (map (fn [r]
-                    {:reason/code :reason/gate-check-failed
-                     :reason/detail (str "gate " (name (get r :gate :unknown))
-                                         " failed: "
-                                         (or (:message (first (:errors r))) "check failed"))})
-                  mech-failures)
-             (when artifact-nil? [(missing-artifact-reason)]))
-     (mapcat :envelope/obligations gate-envs)
-     pins)))
 
 ;; Reason/obligation translation
 (defn- ^{:stratum 1} unknown->reason
@@ -105,45 +83,26 @@
    :obligation/rule-id (rule-id v)
    :obligation/detail (violation-detail v)})
 
-(defn ^{:stratum 1} grant->reasons
-  "Translate an `execution-grant/authorize` result into envelope
-   reasons. `nil` means no grant was required — phase gating is not an
-   effect — and yields no reasons, which is what keeps every existing
-   `decide` caller behaving exactly as it does today.
-
-   Every non-authorized outcome is deny-class. `:inactive` reports as
-   `:reason/grant-absent` rather than a code of its own: a revoked or
-   expired grant is precisely the case of 'no ACTIVE grant covers this
-   effect', and the detail says which."
-  [result]
-  (case (:grant/outcome result)
-    nil []
-    :authorized []
-    :absent [{:reason/code :reason/grant-absent
-              :reason/detail "no grant covers this effect"}]
-    :inactive [{:reason/code :reason/grant-absent
-                :reason/detail (str "grant is not active"
-                                    (when-let [r (:grant/revocation-reason result)]
-                                      (str " (revoked: " (name r) ")")))}]
-    :scope-mismatch [{:reason/code :reason/grant-scope-mismatch
-                      :reason/detail (msg/t :decide/grant-scope-mismatch)}]
-    ;; An :exceeded outcome ALWAYS yields at least one deny reason. If
-    ;; the breach detail is missing or empty, mapping over it would
-    ;; produce zero reasons — and zero reasons is an ALLOW. The outcome
-    ;; is the authority here; the detail is only description.
-    :exceeded (let [breaches (:constraint/breaches result)]
-                (if (seq breaches)
-                  (mapv (fn [b]
-                          {:reason/code :reason/grant-exceeded
-                           :reason/detail (breach-detail b)})
-                        breaches)
-                  [{:reason/code :reason/grant-exceeded
-                    :reason/detail "grant exceeded; no breach detail supplied"}]))
-    ;; An outcome this translator does not know is an outcome nobody
-    ;; decided the meaning of — deny rather than drop it silently.
-    [{:reason/code :reason/grant-absent
-      :reason/detail (str "unrecognized grant outcome: "
-                          (pr-str (:grant/outcome result)))}]))
+(defn ^{:stratum 1} gates->envelope
+  "Phase-level envelope from a `check-gates` result (Ariadne 1d): ONE
+   envelope per gated transition. Policy-gate results already carry an
+   envelope — their reasons and obligations merge in; a mechanical gate
+   failure contributes a :reason/gate-check-failed; a nil artifact with
+   gates configured contributes :reason/missing-artifact. Pins come
+   from the first policy envelope present (nil pins otherwise)."
+  [{:keys [results]} artifact-nil?]
+  (let [gate-envs (keep :envelope results)
+        mech-failures (remove :envelope (remove :passed? results))
+        pins (or (:envelope/pins (first gate-envs))
+                 {:pins/pack-revision nil
+                  :pins/rule-ids []
+                  :pins/event-watermark nil})]
+    (env/envelope
+     (concat (mapcat :envelope/reasons gate-envs)
+             (map mechanical-failure-reason mech-failures)
+             (when artifact-nil? [(missing-artifact-reason)]))
+     (mapcat :envelope/obligations gate-envs)
+     pins)))
 
 ;------------------------------------------------------------------------------ Layer 2
 
@@ -169,7 +128,7 @@
    (env/envelope
     (concat (map blocking->reason blocking)
             (map unknown->reason unknown)
-            (grant->reasons grant-result))
+            (grant/reasons grant-result))
     (concat (map (partial obligation :obligation/approval-required) require-approval)
             (map (partial obligation :obligation/warn-recorded) warnings)
             (map (partial obligation :obligation/audit-recorded) audits))

--- a/components/gate/src/ai/miniforge/gate/decide.clj
+++ b/components/gate/src/ai/miniforge/gate/decide.clj
@@ -23,7 +23,8 @@
    obligations, with NO branch that lets an unclassifiable violation
    pass."
   (:require
-   [ai.miniforge.decision-envelope.interface :as env]))
+   [ai.miniforge.decision-envelope.interface :as env]
+   [ai.miniforge.gate.messages :as msg]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -75,7 +76,7 @@
      (concat (mapcat :envelope/reasons gate-envs)
              (map (fn [r]
                     {:reason/code :reason/gate-check-failed
-                     :reason/detail (str "gate " (name (or (:gate r) :unknown))
+                     :reason/detail (str "gate " (name (get r :gate :unknown))
                                          " failed: "
                                          (or (:message (first (:errors r))) "check failed"))})
                   mech-failures)
@@ -110,7 +111,7 @@
    effect — and yields no reasons, which is what keeps every existing
    `decide` caller behaving exactly as it does today.
 
-   Both non-authorized outcomes are deny-class. `:inactive` reports as
+   Every non-authorized outcome is deny-class. `:inactive` reports as
    `:reason/grant-absent` rather than a code of its own: a revoked or
    expired grant is precisely the case of 'no ACTIVE grant covers this
    effect', and the detail says which."
@@ -124,6 +125,8 @@
                 :reason/detail (str "grant is not active"
                                     (when-let [r (:grant/revocation-reason result)]
                                       (str " (revoked: " (name r) ")")))}]
+    :scope-mismatch [{:reason/code :reason/grant-scope-mismatch
+                      :reason/detail (msg/t :decide/grant-scope-mismatch)}]
     ;; An :exceeded outcome ALWAYS yields at least one deny reason. If
     ;; the breach detail is missing or empty, mapping over it would
     ;; produce zero reasons — and zero reasons is an ALLOW. The outcome

--- a/components/gate/src/ai/miniforge/gate/grant.clj
+++ b/components/gate/src/ai/miniforge/gate/grant.clj
@@ -1,0 +1,78 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.gate.grant
+  "Translate ExecutionGrant authorization results into envelope reasons."
+  (:require
+   [ai.miniforge.gate.messages :as msg]
+   [ai.miniforge.gate.reason :as reason]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} render-label
+  "Render nominal identifiers without trusting boundary data."
+  [value]
+  (if (or (keyword? value) (symbol? value) (string? value))
+    (name value)
+    (pr-str value)))
+
+(defn- ^{:stratum 0} unrecognized-reasons
+  [result]
+  (let [outcome (pr-str (:grant/outcome result))]
+    [(reason/create :reason/grant-absent
+                    (msg/system-t :decide/unrecognized-grant-outcome
+                                  {:outcome outcome}))]))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} inactive-reasons
+  [result]
+  (let [revocation-reason (:grant/revocation-reason result)
+        detail (if revocation-reason
+                 (msg/system-t :decide/grant-inactive-revoked
+                               {:reason (render-label revocation-reason)})
+                 (msg/system-t :decide/grant-inactive))]
+    [(reason/create :reason/grant-absent detail)]))
+
+(defn- ^{:stratum 1} breach-reason
+  [{:constraint/keys [axis limit observed]}]
+  (reason/create :reason/grant-exceeded
+                 (msg/system-t :decide/breach
+                               {:axis (render-label axis)
+                                :observed observed
+                                :limit limit})))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} reasons
+  "Translate an authorization result into deny-class envelope reasons.
+   Nil means no grant was required; every unrecognized outcome fails closed."
+  [result]
+  (case (:grant/outcome result)
+    nil []
+    :authorized []
+    :absent [(reason/create :reason/grant-absent
+                            (msg/system-t :decide/grant-absent))]
+    :inactive (inactive-reasons result)
+    :scope-mismatch [(reason/create :reason/grant-scope-mismatch
+                                    (msg/system-t :decide/grant-scope-mismatch))]
+    :exceeded (let [breaches (:constraint/breaches result)]
+                (if (seq breaches)
+                  (mapv breach-reason breaches)
+                  [(reason/create :reason/grant-exceeded
+                                  (msg/system-t :decide/grant-exceeded-no-detail))]))
+    (unrecognized-reasons result)))

--- a/components/gate/src/ai/miniforge/gate/interface.clj
+++ b/components/gate/src/ai/miniforge/gate/interface.clj
@@ -29,6 +29,7 @@
      (repair-gate :lint artifact errors ctx)"
   (:require
    [ai.miniforge.gate.decide :as decide]
+   [ai.miniforge.gate.grant :as grant]
    ;; Require implementations for side effects
    [ai.miniforge.gate.syntax]
    [ai.miniforge.gate.lint]
@@ -138,7 +139,7 @@
 (def ^{:stratum 0} grant->reasons
   "Translate an `execution-grant/authorize` result into envelope
    reasons; nil (no grant required) yields none."
-  decide/grant->reasons)
+  grant/reasons)
 
 ;------------------------------------------------------------------------------ Layer 1
 

--- a/components/gate/src/ai/miniforge/gate/reason.clj
+++ b/components/gate/src/ai/miniforge/gate/reason.clj
@@ -15,19 +15,13 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-(ns ai.miniforge.gate.messages
-  "Component-level message catalog for gate.
-   Delegates to the shared messages component."
-  (:require [ai.miniforge.messages.interface :as messages]))
+(ns ai.miniforge.gate.reason
+  "DecisionEnvelope reason construction shared by gate translators.")
 
 ;------------------------------------------------------------------------------ Layer 0
 
-(def ^{:stratum 0} t
-  "Look up a gate message by key, with optional param substitution."
-  (messages/create-translator "config/gate/messages/en-US.edn"
-                              :gate/messages))
-
-(def ^{:stratum 0} system-t
-  "Look up developer-facing gate prose by key."
-  (messages/create-translator "config/gate/messages/system.edn"
-                              :gate/system))
+(defn ^{:stratum 0} create
+  "Create the shared DecisionEnvelope reason shape used by gate translators."
+  [code detail]
+  {:reason/code code
+   :reason/detail detail})

--- a/components/gate/test/ai/miniforge/gate/decide_test.clj
+++ b/components/gate/test/ai/miniforge/gate/decide_test.clj
@@ -137,10 +137,12 @@
                                                      :constraint/observed 6}]})]
         (is (= :deny (:envelope/decision e)))))
 
-    (testing "an inactive outcome with a non-keyword revocation reason still denies"
-      (let [e (decide/decide clean pins {:grant/outcome :inactive
-                                         :grant/revocation-reason nil})]
-        (is (= :deny (:envelope/decision e)))))))
+    (testing "an inactive outcome with malformed revocation data still denies"
+      (doseq [revocation-reason [42 {:malformed true}]]
+        (let [e (decide/decide clean pins
+                               {:grant/outcome :inactive
+                                :grant/revocation-reason revocation-reason})]
+          (is (= :deny (:envelope/decision e)) (pr-str revocation-reason)))))))
 
 ;------------------------------------------------------------------------------ Layer 2
 

--- a/components/gate/test/ai/miniforge/gate/decide_test.clj
+++ b/components/gate/test/ai/miniforge/gate/decide_test.clj
@@ -82,6 +82,12 @@
         (is (= :deny (:envelope/decision e)))
         (is (re-find #"cost-exceeded" (:reason/detail (first (:envelope/reasons e)))))))
 
+    (testing "an effect outside the grant scope has its own deny reason"
+      (let [e (decide/decide clean pins {:grant/outcome :scope-mismatch})]
+        (is (= :deny (:envelope/decision e)))
+        (is (= [:reason/grant-scope-mismatch]
+               (mapv :reason/code (:envelope/reasons e))))))
+
     (testing "an unrecognized outcome denies rather than passing silently"
       (let [e (decide/decide clean pins {:grant/outcome :something-new})]
         (is (= :deny (:envelope/decision e)))))

--- a/docs/pull-requests/2026-08-06-codex-ariadne-grant-scope.md
+++ b/docs/pull-requests/2026-08-06-codex-ariadne-grant-scope.md
@@ -1,0 +1,94 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix: enforce execution-grant scope
+
+## Overview
+
+Make an ExecutionGrant's scope part of authorization and bind commit-time
+authorization to the durable effect proposal before production issuance is
+enabled.
+
+## Motivation
+
+The grant record currently carries `:grant/scope`, but authorization checks only
+liveness and numeric ceilings. A grant scoped to one PR can therefore authorize
+another. Issuing production grants on this foundation would preserve ambient
+authority behind a structured record.
+
+## Layer
+
+Authority contract and its EffectTransaction application adapter. These land
+atomically because enabling the pure check alone denies every existing scoped
+transaction, while adapting commit without the check enforces nothing.
+
+## Depends on
+
+- PR #1681 (Ariadne governed-effect evidence contract) — merged
+- PR #1683 (EffectTransaction standards remediation) — merged
+
+## Changes in Detail
+
+- Compare the proposed effect against grant scope at every authorization check.
+- Translate scope mismatches into an explicit deny-class reason.
+- Derive commit-time scope from the durable effect proposal, ignoring a
+  caller-supplied scope map.
+- Replace duplicated multi-form effect callbacks with one named test fixture.
+- Replace duplicated gate reason maps with one constructor, decompose
+  multi-step translation callbacks, and move developer prose to the system
+  catalog.
+- Split grant-result translation from the decision kernel after stratum lint
+  exposed five real layers in the original namespace.
+
+## Architecture
+
+`scope-widened?` remains the one containment primitive. Delegation and effect
+authorization use it in the same direction: the candidate must carry every
+binding established by its authority. The grant component remains pure and
+does not depend on transaction storage. EffectTransaction is the application
+boundary that adapts its durable proposal into that pure authorization input.
+
+The easy design would authorize a caller-supplied scope alongside the durable
+proposal. The simpler design has one canonical authority: immutable proposal
+data persisted by EffectTransaction. Scope policy remains pure in
+execution-grant; filesystem state remains confined to the transaction store.
+
+## Testing Plan
+
+- Execution-grant schema, delegation, scope, expiry, revocation, and ceilings.
+- EffectTransaction success, failure, interruption, scope refusal, and
+  reconciliation paths.
+- Gate translation and DecisionEnvelope worst-wins derivation.
+- `bb pre-commit`, `bb review`, Polylith checks, and affected builds.
+
+Exact-head validation completed with zero kondo warnings, clean stratum lint,
+the focused gate suite in all composed projects, and the full five-project
+stable-derived suite (12m20s). `bb review` remains at the known repository
+baseline of 78 findings and reports no branch-introduced violation.
+
+## Deployment Plan
+
+No deployment action is required. Production call sites still use the explicit
+`:authority/unenforced` path until the dependent issuance slice lands.
+
+## Security Considerations
+
+This closes grant reuse and prevents callers from substituting a matching scope
+map for a different durable proposal. Production issuance remains blocked until
+the separate issuer slice chooses principals, ceilings, eligibility, and TTLs.
+
+## Checklist
+
+- [x] Non-empty grant scope fails closed when effect scope is absent.
+- [x] Mismatched effect scope produces an explicit deny envelope.
+- [x] Commit uses durable proposal scope and never invokes a refused effect.
+- [x] Focused and full checks are green.
+- [x] Adversarial standards pass is clean.
+
+## Related Issues/PRs
+
+- `work/ariadne-grant-issuance.spec.edn`
+- `work/n07-opsv-governed-actuation.spec.edn`

--- a/specs/normative/N10-governed-tool-execution.md
+++ b/specs/normative/N10-governed-tool-execution.md
@@ -6,7 +6,7 @@
 
 # N10 — Governed Tool Execution
 
-**Version:** 0.3.0-draft
+**Version:** 0.3.1-draft
 **Date:** 2026-08-06
 **Status:** Draft
 **Conformance:** MUST
@@ -56,6 +56,9 @@ rechecked at commit, and the runtime decision that allowed it:
  :evidence/grant-id uuid
  :evidence/envelope-id uuid}
 ```
+
+At commit, the durable proposed effect MUST satisfy the grant's recorded scope.
+A parallel caller-supplied scope MUST NOT override the durable proposal.
 
 ### 1.2 What This Specification Defines
 
@@ -1067,6 +1070,8 @@ Audit Ledger (N3 events + N6 evidence bundles)
 
 **Version History:**
 
+- 0.3.1-draft (2026-08-06): Required commit-time ExecutionGrant scope
+  enforcement against the durable effect proposal
 - 0.3.0-draft (2026-08-06): Applied the accepted Ariadne adoption profile;
   DecisionEnvelope, ExecutionGrant, and EffectTransaction supersede the
   parallel intent/OIR/capability execution objects

--- a/work/QUEUE.md
+++ b/work/QUEUE.md
@@ -108,8 +108,9 @@ Step 2 of the ratified Ariadne adoption order: authority stops being
 
 | tier | r | theme | spec | axes |
 |---|---|---|---|---|
-| high | ● | ariadne-grants | `ariadne-grant-issuance.spec.edn` — Ariadne step 2f: grant issuance - who may authorize an irreversible effect, and on what basis | correctness+policyenforcement+governancecredibility |
+| blocker | ● | ariadne-grants | `ariadne-grant-scope-enforcement.spec.edn` — Enforce ExecutionGrant scope against durable effect proposals | correctness+policyenforcement+governancecredibility |
 | high | ● | ariadne-grants | `ariadne-granted-effect-call-sites.spec.edn` — Ariadne step 2d: migrate merge and deploy onto the granted, transacted path | correctness+observation+governancecredibility |
+| high | ○ | ariadne-grants | `ariadne-grant-issuance.spec.edn` — Ariadne step 2f: grant issuance - who may authorize an irreversible effect, and on what basis | correctness+policyenforcement+governancecredibility |
 
 ## Theme — Polylith compliance (`polylith-compliance`, status: in-flight)
 

--- a/work/ariadne-grant-issuance.spec.edn
+++ b/work/ariadne-grant-issuance.spec.edn
@@ -96,6 +96,7 @@
   :theme :ariadne-grants
   :rationale "Without an issuer the grant machinery is inert; with one, 2d part 2 and 2e's eligibility hook both become reachable. High rather than blocker because 2d part 1 already delivered the honesty half."
   :blocks []
-  :blocked-by ["ariadne-revocation-for-cause.spec.edn"]}
+  :blocked-by ["ariadne-revocation-for-cause.spec.edn"
+               "ariadne-grant-scope-enforcement.spec.edn"]}
 
  :spec/workflow-type :canonical-sdlc}

--- a/work/ariadne-grant-scope-enforcement.spec.edn
+++ b/work/ariadne-grant-scope-enforcement.spec.edn
@@ -1,0 +1,63 @@
+;; =============================================================================
+;; Spec: Ariadne grant scope enforcement
+;; =============================================================================
+;;
+;; Normative refs: Ariadne §13.5 (scoped, attenuated grants and
+;; commit-time recheck); N10 §1.1 (bounded ExecutionGrant authority).
+
+{:spec/title "Enforce ExecutionGrant scope against durable effect proposals"
+
+ :spec/description
+ "Close an authority gap before production grant issuance is enabled.
+
+  ExecutionGrant records carry :grant/scope but authorize currently
+  checks only liveness and numeric ceilings. A grant for one PR can therefore
+  authorize another. Authorization must compare the proposed effect with the
+  grant's scope using the same containment rule used for delegation. A
+  non-empty grant scope with absent or mismatched effect scope fails closed.
+
+  EffectTransaction commit must supply :effect/scope from its durable
+  :effect/proposal. It must ignore any parallel caller-supplied scope so a
+  caller cannot present one effect for authorization while committing another."
+
+ :spec/intent
+ {:type :bugfix
+  :scope ["components/execution-grant/**"
+          "components/decision-envelope/**"
+          "components/gate/**"
+          "components/effect-transaction/**"
+          "specs/normative/N10-governed-tool-execution.md"]}
+
+ :normative-refs
+ ["docs/architecture/ariadne/tenancy-ownership-access.md §13.3, §13.5"
+  "specs/normative/N10-governed-tool-execution.md §1.1"]
+
+ :spec/constraints
+ ["Reuse execution-grant's existing scope containment primitive; do not duplicate its map comparison"
+  "Authorization remains pure and fail-closed"
+  "Commit-time scope comes from the durable effect proposal, not a parallel caller-supplied map"
+  "A refused scope recheck records failure and never invokes the effect"
+  "No duplicated proposal or grant fixture maps across transaction tests"
+  "Unknown authorization outcomes remain deny-class"
+  "Stratified design, max three layers per implementation namespace"]
+
+ :spec/acceptance-criteria
+ ["A non-empty grant scope with absent effect scope returns :scope-mismatch"
+  "An effect for another workflow run returns :scope-mismatch"
+  "An effect scope carrying every grant binding plus narrower bindings authorizes"
+  "EffectTransaction commit authorizes the durable proposal rather than caller-supplied scope"
+  "A mismatched durable proposal fails without invoking the effect"
+  "Interrupted effects and reconciliation behavior remain unchanged"
+  "Gate translation turns :scope-mismatch into a deny DecisionEnvelope"
+  "poly check reports no new errors or warnings"
+  "full bb test is green"]
+
+ :spec/priority
+ {:tier :blocker
+  :axes #{:correctness :policy-enforcement :governance-credibility}
+  :theme :ariadne-grants
+  :rationale "Production issuance would otherwise mint grants whose recorded scope is not enforced."
+  :blocks ["ariadne-grant-issuance.spec.edn"]
+  :blocked-by []}
+
+ :spec/workflow-type :canonical-sdlc}

--- a/work/ariadne-grant-scope-enforcement.spec.edn
+++ b/work/ariadne-grant-scope-enforcement.spec.edn
@@ -10,8 +10,8 @@
  :spec/description
  "Close an authority gap before production grant issuance is enabled.
 
-  ExecutionGrant records carry :grant/scope but authorize currently
-  checks only liveness and numeric ceilings. A grant for one PR can therefore
+  ExecutionGrant records carry :grant/scope but authorization currently checks
+  only liveness and numeric ceilings. A grant for one PR can therefore
   authorize another. Authorization must compare the proposed effect with the
   grant's scope using the same containment rule used for delegation. A
   non-empty grant scope with absent or mismatched effect scope fails closed.


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# fix: enforce execution-grant scope

## Overview

Make an ExecutionGrant's scope part of authorization and bind commit-time
authorization to the durable effect proposal before production issuance is
enabled.

## Motivation

The grant record currently carries `:grant/scope`, but authorization checks only
liveness and numeric ceilings. A grant scoped to one PR can therefore authorize
another. Issuing production grants on this foundation would preserve ambient
authority behind a structured record.

## Layer

Authority contract and its EffectTransaction application adapter. These land
atomically because enabling the pure check alone denies every existing scoped
transaction, while adapting commit without the check enforces nothing.

## Depends on

- PR #1681 (Ariadne governed-effect evidence contract) — merged
- PR #1683 (EffectTransaction standards remediation) — merged

## Changes in Detail

- Compare the proposed effect against grant scope at every authorization check.
- Translate scope mismatches into an explicit deny-class reason.
- Derive commit-time scope from the durable effect proposal, ignoring a
  caller-supplied scope map.
- Replace duplicated multi-form effect callbacks with one named test fixture.
- Replace duplicated gate reason maps with one constructor, decompose
  multi-step translation callbacks, and move developer prose to the system
  catalog.
- Split grant-result translation from the decision kernel after stratum lint
  exposed five real layers in the original namespace.

## Architecture

`scope-widened?` remains the one containment primitive. Delegation and effect
authorization use it in the same direction: the candidate must carry every
binding established by its authority. The grant component remains pure and
does not depend on transaction storage. EffectTransaction is the application
boundary that adapts its durable proposal into that pure authorization input.

The easy design would authorize a caller-supplied scope alongside the durable
proposal. The simpler design has one canonical authority: immutable proposal
data persisted by EffectTransaction. Scope policy remains pure in
execution-grant; filesystem state remains confined to the transaction store.

## Testing Plan

- Execution-grant schema, delegation, scope, expiry, revocation, and ceilings.
- EffectTransaction success, failure, interruption, scope refusal, and
  reconciliation paths.
- Gate translation and DecisionEnvelope worst-wins derivation.
- `bb pre-commit`, `bb review`, Polylith checks, and affected builds.

Exact-head validation completed with zero kondo warnings, clean stratum lint,
the focused gate suite in all composed projects, and the full five-project
stable-derived suite (12m20s). `bb review` remains at the known repository
baseline of 78 findings and reports no branch-introduced violation.

## Deployment Plan

No deployment action is required. Production call sites still use the explicit
`:authority/unenforced` path until the dependent issuance slice lands.

## Security Considerations

This closes grant reuse and prevents callers from substituting a matching scope
map for a different durable proposal. Production issuance remains blocked until
the separate issuer slice chooses principals, ceilings, eligibility, and TTLs.

## Checklist

- [x] Non-empty grant scope fails closed when effect scope is absent.
- [x] Mismatched effect scope produces an explicit deny envelope.
- [x] Commit uses durable proposal scope and never invokes a refused effect.
- [x] Focused and full checks are green.
- [x] Adversarial standards pass is clean.

## Related Issues/PRs

- `work/ariadne-grant-issuance.spec.edn`
- `work/n07-opsv-governed-actuation.spec.edn`
