### PR TITLE
docs(specs): N8 observability control interface spec completion (0.3.0 → 0.4.0-draft)

### DIFF
--- a/docs/pull-requests/2026-08-06-chris-n8-observability-control-spec-complete.md
+++ b/docs/pull-requests/2026-08-06-chris-n8-observability-control-spec-complete.md
@@ -1,0 +1,110 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# docs: N8 observability control interface spec completion (0.3.0 → 0.4.0-draft)
+
+## Overview
+
+Removes N8's parallel models for redaction, retention, and event schemas —
+all three are owned by N3 — and adds conformance requirement IDs. Adds Annex A.
+
+## Motivation
+
+**Four vocabularies for two concerns.** N3 §8 defines redaction: what may never
+be emitted, the `"[REDACTED]"` marker, truncation, and three field classes.
+N3 §4.3 defines retention: four classes with minimums. N8 §5 carried its own
+of each — privacy levels `metadata-only | redacted | full`, a
+`:redaction/patterns` regex table, a `:redaction/field-rules` vocabulary of
+`:include | :redact | :exclude`, and a `:retention/policies` schema with its
+own day counts.
+
+The practical consequence: an operator configuring redaction through N8 had no
+way to know whether N3 §8.1's MUST NOT still applied. It does, unconditionally,
+and it is not configurable — but nothing in N8 said so.
+
+**A function in a config map.** §5.2 specified `:redaction/custom-fn function`.
+`foundations/config-as-data` (dewey 007) is `alwaysApply` with hard-halt
+enforcement. A function cannot be serialized, diffed, reviewed, or audited,
+which defeats the purpose of a redaction policy an auditor needs to inspect.
+
+**Stale duplicated schemas.** §10.1 reproduced N3 §3.15's `listener/*` and
+`control-action/*` schemas with a fixed `:workflow/id`. Since N3 now streams
+six scopes and those families take an inherited scope carrying `:scope/type`,
+the reproduced copies were unusable on the five non-workflow scopes.
+
+**No requirement IDs.**
+
+## Changes in Detail
+
+- **§5 rewritten.** Defers redaction to N3 §8 and retention to N3 §4.3, and
+  names the withdrawn models explicitly so a reader meeting one in code knows
+  it is a defect. §5.1 keeps what is genuinely listener-specific: which
+  principal sees which field class, with `:restricted` suppressed per-recipient
+  at delivery rather than per-event at emission.
+- **§5.2** states redaction patterns are EDN configuration with a schema, and
+  that deployment patterns apply *in addition to* N3 §8.1's set, never instead
+  of it. `:redaction/custom-fn` withdrawn.
+- **§5.3** adds one constraint N3 does not: control-action events are `:audit`
+  class and MUST NOT be retained for less than the one-year floor. A control
+  action is the record of a human overriding the machine.
+- **§10.1** replaced by a reference table, with the inherited-scope property
+  called out since it is what the reproduced schemas got wrong.
+- **§12.4–§12.5** requirement IDs (`N8.CAP.*`, `N8.CTL.*`, `N8.PRV.*`) and six
+  test obligations.
+- **§13 MCI** no longer cites the withdrawn `metadata-only` privacy level.
+
+## Annex A (informative)
+
+- **Implemented** — listener capability enforcement and `include-payloads`
+  filtering in `event-stream/listeners.clj`; control-action evidence in
+  `evidence-bundle/collector.clj`.
+- **Specified, not implemented** — no redaction configuration exists anywhere
+  in the tree; the only match for "redaction" is a `progress-detector` test.
+  This is the third spec in a row to record that gap (N3 Annex A, N6 Annex A),
+  which is a signal about where implementation effort should go. Also missing:
+  per-recipient `:restricted` suppression, and `:scope/type` on listener
+  events.
+- **Structural** — no retention floor for control-action events.
+
+## Testing Plan
+
+Specification change; no runtime code touched.
+
+- `markdownlint` clean on all three changed files.
+- Code blocks brace-balanced; no duplicate section numbers.
+- Verified the withdrawn vocabularies survive only where their withdrawal is
+  documented.
+
+## Deployment Plan
+
+Documentation only. Merges to `main` with no runtime effect.
+
+## Follow-on Work
+
+1. Implement redaction — now recorded as a gap by N3, N6, and N8.
+2. Per-recipient `:restricted` suppression by RBAC role.
+3. Emit `:scope/type` on listener and control-action events.
+4. Enforce the audit retention floor for control actions.
+
+## Related Issues/PRs
+
+- Follows N3/N4/N5/N6 completion passes
+- Depends on: N3 §8 (redaction), N3 §4.3 (retention), N3 §3.15 (event schemas),
+  N3 §2.3 (scopes)
+- Governed by: `standards/miniforge/foundations/specification-standards` (020),
+  `standards/miniforge/foundations/config-as-data` (007)
+
+## Checklist
+
+- [x] Spec reviewed against current state before editing
+- [x] Duplicated contracts replaced by references (020)
+- [x] Config-as-data violation removed (007)
+- [x] Annex A marked informative
+- [x] No spec content extracted from implementation code (020)
+- [x] Copyright header present (810)
+- [x] `markdownlint` clean
+- [x] SPEC_INDEX updated
+- [x] PR doc created (721)

--- a/specs/SPEC_INDEX.md
+++ b/specs/SPEC_INDEX.md
@@ -273,7 +273,6 @@ Defines:
 - Listener capability model: OBSERVE, ADVISE, CONTROL levels with RBAC
 - Control action surface: pause, resume, rollback, quarantine, approve, emergency-stop
 - Advisory annotation system: non-blocking recommendations and warnings
-- Privacy and redaction: metadata-only, redacted, full privacy levels
 - OpenTelemetry interoperability: GenAI span mapping, OTLP export
 - Cost and volume controls: sampling rules, aggregation boundaries
 - Fleet and enterprise extensions: multi-tenancy, pattern detection

--- a/specs/SPEC_INDEX.md
+++ b/specs/SPEC_INDEX.md
@@ -7,8 +7,7 @@
 # miniforge Specification Index
 
 **Version:** 0.15.0-draft
-**Version:** 0.14.0-draft
-**Date:** 2026-08-06
+**Date:** 2026-08-09
 **Status:** Living specification during OSS development
 
 ---

--- a/specs/SPEC_INDEX.md
+++ b/specs/SPEC_INDEX.md
@@ -6,6 +6,7 @@
 
 # miniforge Specification Index
 
+**Version:** 0.15.0-draft
 **Version:** 0.14.0-draft
 **Date:** 2026-08-06
 **Status:** Living specification during OSS development
@@ -278,6 +279,16 @@ Defines:
 - Fleet and enterprise extensions: multi-tenancy, pattern detection
 - CLI/TUI extensions: listener commands, control palette, approval queue
 - **Safe-mode posture:** Triggers, behavior, exit protocol for system-wide autonomy demotion (§3.4)
+- **Redaction and retention deferred to N3** (§5) — the parallel privacy-level,
+  pattern-table, field-rule and retention-policy models are withdrawn
+- **Per-listener content visibility (§5.1):** N3 §8.4 field classes by RBAC role;
+  `:restricted` suppressed per-recipient at delivery
+- **Redaction patterns are EDN configuration**, never a function (§5.2, dewey 007)
+- **Event schemas referenced, not restated** (§10.1) — the reproduced copies carried a
+  fixed `:workflow/id` and were unusable on N3's five non-workflow scopes
+- **Conformance requirement IDs** (`N8.CAP.*`, `N8.CTL.*`, `N8.PRV.*`) and test
+  obligations (§12.4–§12.5)
+- **Annex A (informative):** implementation conformance status
 
 ### N9 — External PR Integration 🆕
 
@@ -575,6 +586,15 @@ Normative specs are enforced by:
 
 ## Version History
 
+- **0.15.0-draft** (2026-08-06) - N8 spec-completion pass. **N8**: §5 carried a parallel model for
+  concerns N3 owns — privacy levels, a regex pattern table, a field-rule vocabulary, and its own
+  retention schema — so an operator configuring redaction there could not tell whether N3 §8.1's
+  MUST NOT still applied. All withdrawn; §5 now defines only which principal sees which field
+  class. `:redaction/custom-fn function` withdrawn as a config-as-data violation (dewey 007).
+  §10.1 reproduced N3 §3.15's event schemas with a fixed `:workflow/id`, unusable on the five
+  non-workflow scopes N3 streams; now a reference table. Conformance requirement IDs and test
+  obligations (§12.4–§12.5). Annex A notes that no redaction configuration exists anywhere in the
+  tree — the third spec in a row to record that gap. Per-spec bumps: N8 0.3→0.4
 - **0.14.0-draft** (2026-08-06) - N2 spec-completion pass. **N2**: the workflow status
   vocabulary was spelled three ways — N2 said `:pending`, N5-delta-supervisory §3.2 said
   `:queued`, and N5 §2.3.2's CLI filter plus the implementation said `:executing`, so a filter

--- a/specs/normative/N8-observability-control-interface.md
+++ b/specs/normative/N8-observability-control-interface.md
@@ -6,7 +6,7 @@
 
 # N8 — Observability Control Interface
 
-**Version:** 0.3.0-draft
+**Version:** 0.4.0-draft
 **Date:** 2026-03-08
 **Status:** Draft
 **Conformance:** MUST
@@ -512,52 +512,67 @@ Annotations MUST emit events per N3:
 
 ## 5. Privacy and Redaction
 
-### 5.1 Privacy Levels
+**N3 owns redaction and retention.** N3 §8 defines what may never be emitted,
+the `"[REDACTED]"` marker, truncation, and the three field classes; N3 §4.3
+defines the four retention classes and their minimums. This section defines
+only what is specific to *listeners* — which principal sees which class — and
+MUST NOT restate or vary those contracts.
 
-Event payloads MUST support configurable privacy levels:
+Earlier revisions of this section carried a parallel model: privacy levels
+`metadata-only | redacted | full`, a `:redaction/patterns` regex table, a
+`:redaction/field-rules` vocabulary of `:include | :redact | :exclude`, and a
+`:retention/policies` schema with its own day counts. All are withdrawn. Four
+overlapping vocabularies for two concerns meant an operator configuring
+redaction here had no way to know whether N3 §8's MUST NOT still applied — it
+does, unconditionally, and it is not configurable.
 
-| Level          | Content Included                              |
-| -------------- | --------------------------------------------- |
-| `metadata-only`| Event envelope only, no prompt/response content|
-| `redacted`     | Content with sensitive patterns removed       |
-| `full`         | Complete content (encrypted at rest)          |
+### 5.1 Per-Listener Content Visibility
 
-### 5.2 Redaction Requirements
+What a listener receives is determined by N3 §8.4's field classes and the
+principal's RBAC role (§2.3):
 
-Implementations MUST provide redaction hooks at emission time:
+| Field class | Delivered to |
+|-------------|--------------|
+| `:public` | Every attached listener |
+| `:payload` | Listeners that have not set `include-payloads=false` (N3 §5.3.4) |
+| `:restricted` | Only principals whose RBAC role permits that class |
 
-```clojure
-{:redaction/patterns
- [{:pattern regex                     ; Pattern to match
-   :replacement string                ; Replacement text
-   :applies-to [keyword ...]}]        ; Event fields to scan
+`:restricted` suppression is **per-recipient at delivery**, not per-event at
+emission (N3 §8.4): two listeners on one stream may be entitled to different
+views of the same event.
 
- :redaction/field-rules
- {:prompt-content keyword             ; :include | :redact | :exclude
-  :response-content keyword
-  :tool-args keyword
-  :tool-results keyword}
+A deployment MAY configure a listener type's default — for instance that
+`:fleet` listeners default to `include-payloads=false`. It MUST NOT configure
+away N3 §8.1: no configuration, listener type, or RBAC role causes a
+never-emitted value to be emitted, because that value was never in the event
+(N3 §8.1 redacts at construction).
 
- :redaction/custom-fn function}       ; Custom redaction function
-```
+### 5.2 Redaction Configuration
 
-### 5.3 Retention Policies
+Redaction patterns are **configuration, not code**. Per
+`standards/miniforge/foundations/config-as-data` (dewey 007), the pattern set
+lives in an EDN resource with a schema; implementations MUST NOT accept a
+function as a configuration value.
 
-Implementations MUST support configurable retention:
+An earlier revision specified `:redaction/custom-fn function`. That is
+withdrawn — a function in a config map cannot be serialized, diffed, reviewed,
+or audited, which defeats the purpose of a redaction policy an auditor needs to
+inspect.
 
-```clojure
-{:retention/policies
- [{:event-types [keyword ...]         ; Which events this applies to
-   :privacy-level keyword             ; Which privacy level
-   :retention-days int                ; Days to retain
-   :archive-after-days int            ; Days before archiving
-   :delete-after-days int}]           ; Days before deletion
+Where a deployment needs a detection rule beyond N3 §8.1's set, it adds a
+pattern to that configuration. Implementations MUST apply deployment patterns
+in addition to N3 §8.1's excluded set, never instead of it.
 
- :retention/compliance
- {:audit-events-min-days int          ; Minimum for audit events
-  :control-actions-min-days int       ; Minimum for control actions
-  :evidence-bundles-min-days int}}    ; Minimum for evidence
-```
+### 5.3 Retention
+
+Listener-visible events take the retention class N3 §4.3.1 assigns their event
+type. This spec adds one constraint:
+
+`control-action/requested`, `control-action/executed`, and
+`control-action/approval-required` are `:audit` class (N3 §6). A deployment MAY
+retain them longer than the one-year floor; it MUST NOT retain them for less.
+A control action is the record of a human overriding the machine, and it is the
+first thing an audit asks for.
 
 ---
 
@@ -761,63 +776,31 @@ The TUI MUST provide:
 
 ### 10.1 Additional Event Types
 
-OCI adds these event types to N3:
+OCI's listener and control-action event types are defined by **N3 §3.15**,
+which owns every event wire contract (standard 020). They are listed here for
+navigation only; their schemas are not reproduced.
 
-#### listener/attached
+| Event type | Defined in |
+|------------|------------|
+| `listener/attached` | N3 §3.15 |
+| `listener/detached` | N3 §3.15 |
+| `listener/overflow` | N3 §3.15 |
+| `control-action/requested` | N3 §3.15 |
+| `control-action/executed` | N3 §3.15 |
+| `control-action/approval-required` | N3 §3.15 |
+| `annotation/created` | N3 §3.15 |
 
-```clojure
-{:event/type :listener/attached
- :listener/id uuid
- :listener/type keyword
- :listener/capability keyword
- :workflow/id uuid
- :message "Listener attached: {type} with {capability} capability"}
-```
+Two properties of that family matter to implementers of this spec:
 
-#### listener/detached
+- These events take an **inherited scope** (N3 §2.3): `listener/*` takes the
+  scope of the stream it annotates, and `control-action/*` and
+  `annotation/created` take the scope of their target. Each carries
+  `:scope/type` naming which scope it resolved to. An earlier revision of this
+  section reproduced these schemas with a fixed `:workflow/id`, which made them
+  unusable on the five non-workflow scopes N3 §5.3.1 now streams.
+- `control-action/*` is `:audit` retention class (§5.3).
 
-```clojure
-{:event/type :listener/detached
- :listener/id uuid
- :workflow/id uuid
- :listener/reason keyword             ; :disconnect | :timeout | :revoked
- :message "Listener detached: {reason}"}
-```
-
-#### control-action/requested
-
-```clojure
-{:event/type :control-action/requested
- :action/id uuid
- :action/type keyword
- :action/target {...}
- :action/requester {...}
- :workflow/id uuid
- :message "Control action requested: {type}"}
-```
-
-#### control-action/executed
-
-```clojure
-{:event/type :control-action/executed
- :action/id uuid
- :action/type keyword
- :action/result {:status keyword :error {...}}
- :workflow/id uuid
- :message "Control action executed: {type} - {status}"}
-```
-
-#### control-action/approval-required
-
-```clojure
-{:event/type :control-action/approval-required
- :action/id uuid
- :action/type keyword
- :approval/required-approvers int
- :approval/timeout-at inst
- :workflow/id uuid
- :message "Approval required for {type}: {required} approvers needed"}
-```
+The remaining event types below are specific to this spec and are defined here.
 
 #### checkpoint/reached
 
@@ -930,6 +913,65 @@ Conformance tests MUST verify:
 2. Privacy levels control content inclusion
 3. Retention policies are enforced
 
+### 12.4 Conformance Requirements
+
+Requirement IDs are stable identifiers for the normative statements of this
+spec. IDs are never reused; a withdrawn requirement is marked withdrawn, not
+deleted.
+
+#### Capability model
+
+| ID | Level | Requirement |
+|----|-------|-------------|
+| N8.CAP.1 | MUST | Enforce the three capability levels of §2 — OBSERVE, ADVISE, CONTROL. |
+| N8.CAP.2 | MUST NOT | Let an OBSERVE listener emit an annotation or request a control action (§2). |
+| N8.CAP.3 | MUST NOT | Let an ADVISE listener request a control action (§2). |
+| N8.CAP.4 | MUST | Resolve every listener to a principal and RBAC role (§2.3). |
+| N8.CAP.5 | MUST | Reject a declared capability the principal's role does not permit, with HTTP 403 (§2.3, N3 §5.3.3). |
+
+#### Control actions
+
+| ID | Level | Requirement |
+|----|-------|-------------|
+| N8.CTL.1 | MUST | Emit `control-action/requested` and `control-action/executed` per N3 §3.15 for every action. |
+| N8.CTL.2 | MUST | Require approval for High and Critical actions where configured (§3). |
+| N8.CTL.3 | MUST | Record every control action in the evidence bundle (N6 §2.1, §11). |
+| N8.CTL.4 | MUST NOT | Modify workflow state when an action fails (§12.2). |
+| N8.CTL.5 | MUST | Carry `:scope/type` and the matching scope key on every control-action event (N3 §2.3). |
+| N8.CTL.6 | MUST | Treat control-action events as `:audit` retention class (§5.3, N3 §4.3.1). |
+
+#### Privacy
+
+| ID | Level | Requirement |
+|----|-------|-------------|
+| N8.PRV.1 | MUST | Deliver fields by N3 §8.4's class and the principal's role (§5.1). |
+| N8.PRV.2 | MUST | Suppress `:restricted` fields per-recipient at delivery, not per-event at emission (§5.1). |
+| N8.PRV.3 | MUST NOT | Allow any configuration, listener type, or role to cause a N3 §8.1 excluded value to be emitted (§5.1). |
+| N8.PRV.4 | MUST | Hold redaction patterns as EDN configuration with a schema (§5.2, dewey 007). |
+| N8.PRV.5 | MUST NOT | Accept a function as a redaction configuration value (§5.2). |
+| N8.PRV.6 | MUST | Apply deployment patterns in addition to N3 §8.1's excluded set, never instead of it (§5.2). |
+
+### 12.5 Test Obligations
+
+A conformance suite MUST cover, at minimum:
+
+1. **Capability enforcement** — an OBSERVE listener's annotation attempt and a
+   ADVISE listener's control-action attempt are both rejected
+   (N8.CAP.2, N8.CAP.3).
+2. **Non-workflow scope** — a listener attached to a pack or repository stream
+   receives `listener/attached` carrying that scope's key, not `:workflow/id`
+   (N8.CTL.5, N3 §2.3).
+3. **Per-recipient suppression** — two listeners with different roles on one
+   stream receive the same event with different `:restricted` fields present
+   (N8.PRV.2).
+4. **Redaction is not configurable away** — no combination of listener type,
+   role, and deployment configuration causes a N3 §8.1 value to appear
+   (N8.PRV.3).
+5. **Config shape** — the redaction configuration round-trips through EDN and
+   is rejected if it carries a function (N8.PRV.4, N8.PRV.5).
+6. **Audit retention** — control-action events survive the one-year floor and
+   are not expired by a shorter deployment policy (N8.CTL.6).
+
 ---
 
 ## 13. Minimal Compliant Implementation (MCI)
@@ -940,7 +982,7 @@ A minimal compliant OCI implementation MUST:
 2. Support at least: pause, resume, cancel control actions
 3. Emit all required event types (§10.1)
 4. Record control actions in evidence bundles
-5. Support metadata-only privacy level
+5. Deliver `:public` fields to every listener and honor `include-payloads=false` (§5.1)
 6. Provide CLI commands for listener attachment
 
 A minimal compliant implementation MAY defer:
@@ -950,6 +992,41 @@ A minimal compliant implementation MAY defer:
 - OTel export
 - Enterprise multi-tenancy
 - Pattern detection
+
+---
+
+## Annex A — Implementation Conformance Status (informative)
+
+This annex is **informative**. It records where the miniforge implementation
+diverges from the contract above, as of 2026-08-06. It is not a relaxation of
+any requirement in §0–§14.
+
+### A.1 Implemented
+
+- **Listener capability and filtering.** `event-stream/listeners.clj`
+  implements listener registration, capability checks, and `include-payloads`
+  filtering (N8.CAP.1–N8.CAP.3, N8.PRV.1 partially).
+- **Control action evidence.** `evidence-bundle/collector.clj` records
+  control actions (N8.CTL.3).
+
+### A.2 Specified, Not Implemented
+
+- **Redaction (§5.2).** No redaction configuration exists anywhere in the
+  tree — the only match for "redaction" is a test in `progress-detector`. N3
+  §8's excluded-value set is therefore unenforced on this surface, as it is on
+  the evidence surface (N6 Annex A). This is the same gap seen from three
+  specs now, which is a signal about where implementation effort should go
+  (N8.PRV.3–N8.PRV.6).
+- **Per-recipient `:restricted` suppression (§5.1).** Filtering is
+  per-subscription, not per-recipient by role (N8.PRV.2).
+- **Inherited scope on listener events (§10.1).** Listener events carry
+  `:workflow/id`; `:scope/type` is not emitted, so the five non-workflow
+  scopes of N3 §2.3 cannot be observed (N8.CTL.5).
+
+### A.3 Structural
+
+- **Audit retention (§5.3)** is unenforced — there is no retention floor for
+  control-action events (N8.CTL.6).
 
 ---
 
@@ -967,6 +1044,21 @@ A minimal compliant implementation MAY defer:
 ---
 
 **Version History:**
+
+- 0.4.0-draft (2026-08-06): Spec-completion pass. §5 carried a parallel model
+  for concerns N3 owns — privacy levels `metadata-only | redacted | full`, a
+  `:redaction/patterns` regex table, a `:redaction/field-rules` vocabulary, and
+  a `:retention/policies` schema with its own day counts. All withdrawn: N3 §8
+  owns redaction and N3 §4.3 owns retention, and four overlapping vocabularies
+  meant an operator configuring redaction here could not tell whether N3 §8.1's
+  MUST NOT still applied. §5 now defines only what is listener-specific — which
+  principal sees which field class. `:redaction/custom-fn function` withdrawn
+  as a config-as-data violation (dewey 007): a function in a config map cannot
+  be serialized, diffed, or audited. §10.1 reproduced N3 §3.15's event schemas
+  with a fixed `:workflow/id`, which made them unusable on the five
+  non-workflow scopes N3 §5.3.1 streams; now a reference table. §12.4–§12.5
+  conformance requirement IDs and test obligations. Annex A records
+  implementation divergence.
 
 - 0.3.0-draft (2026-04-23): Control-action surface extensions — Checkpoint Control
   (§3.1.5: request/approve/reject) for governed pause-points in Workflow Packs and

--- a/specs/normative/N8-observability-control-interface.md
+++ b/specs/normative/N8-observability-control-interface.md
@@ -534,7 +534,7 @@ principal's RBAC role (§2.3):
 | Field class | Delivered to |
 |-------------|--------------|
 | `:public` | Every attached listener |
-| `:payload` | Listeners that have not set `include-payloads=false` (N3 §5.3.4) |
+| `:payload` | Listeners whose `:include-payloads?` is true (§2.1); on the wire this is N3 §5.3.4's `include-payloads` query parameter |
 | `:restricted` | Only principals whose RBAC role permits that class |
 
 `:restricted` suppression is **per-recipient at delivery**, not per-event at
@@ -542,7 +542,7 @@ emission (N3 §8.4): two listeners on one stream may be entitled to different
 views of the same event.
 
 A deployment MAY configure a listener type's default — for instance that
-`:fleet` listeners default to `include-payloads=false`. It MUST NOT configure
+`:fleet` listeners default to `:include-payloads? false`. It MUST NOT configure
 away N3 §8.1: no configuration, listener type, or RBAC role causes a
 never-emitted value to be emitted, because that value was never in the event
 (N3 §8.1 redacts at construction).
@@ -986,7 +986,7 @@ A minimal compliant OCI implementation MUST:
 2. Support at least: pause, resume, cancel control actions
 3. Emit all required event types (§10.1)
 4. Record control actions in evidence bundles
-5. Deliver `:public` fields to every listener and honor `include-payloads=false` (§5.1)
+5. Deliver `:public` fields to every listener and honor `:include-payloads?` (§5.1)
 6. Provide CLI commands for listener attachment
 
 A minimal compliant implementation MAY defer:

--- a/specs/normative/N8-observability-control-interface.md
+++ b/specs/normative/N8-observability-control-interface.md
@@ -7,7 +7,7 @@
 # N8 — Observability Control Interface
 
 **Version:** 0.4.0-draft
-**Date:** 2026-03-08
+**Date:** 2026-08-06
 **Status:** Draft
 **Conformance:** MUST
 
@@ -909,9 +909,13 @@ Conformance tests MUST verify:
 
 Conformance tests MUST verify:
 
-1. Redaction patterns are applied before emission
-2. Privacy levels control content inclusion
-3. Retention policies are enforced
+1. N3 §8.1's excluded values never appear, under any combination of listener
+   type, RBAC role, and deployment configuration (§5.1)
+2. Field delivery follows N3 §8.4's classes and the principal's role, with
+   `:restricted` suppressed per-recipient rather than per-event (§5.1)
+3. Deployment redaction patterns apply in addition to N3 §8.1's set, and the
+   configuration is EDN carrying no function (§5.2)
+4. Control-action events survive the `:audit` one-year floor (§5.3)
 
 ### 12.4 Conformance Requirements
 


### PR DESCRIPTION
MINIFORGE_PR_BUDGET_OVERRIDE: Single normative spec document. A spec amendment is atomic — slicing yields intermediate PRs where the document contradicts itself. Well below the ~10-12k threshold where Copilot declines to review. Docs-only, no runtime code.

## Overview

Removes N8's parallel models for redaction, retention, and event schemas — all three owned by N3 — and adds conformance requirement IDs.

Full detail: [`docs/pull-requests/2026-08-06-chris-n8-observability-control-spec-complete.md`](docs/pull-requests/2026-08-06-chris-n8-observability-control-spec-complete.md)

## Why

**Four vocabularies for two concerns.** N3 §8 owns redaction — what may never be emitted, the `"[REDACTED]"` marker, truncation, three field classes. N3 §4.3 owns retention — four classes with minimums. N8 §5 carried its own of each: privacy levels `metadata-only | redacted | full`, a `:redaction/patterns` regex table, a `:redaction/field-rules` vocabulary of `:include | :redact | :exclude`, and a `:retention/policies` schema with its own day counts.

The practical consequence: an operator configuring redaction through N8 had no way to know whether N3 §8.1's MUST NOT still applied. It does, unconditionally, and it is not configurable — but nothing in N8 said so.

**A function in a config map.** §5.2 specified `:redaction/custom-fn function`. `foundations/config-as-data` (dewey 007) is `alwaysApply` with hard-halt enforcement. A function cannot be serialized, diffed, reviewed, or audited — which defeats the purpose of a redaction policy an auditor needs to inspect.

**Stale duplicated schemas.** §10.1 reproduced N3 §3.15's `listener/*` and `control-action/*` schemas with a fixed `:workflow/id`. Since N3 now streams six scopes and those families take an *inherited* scope carrying `:scope/type`, the reproduced copies were unusable on the five non-workflow scopes.

## Changes

- **§5** defers redaction to N3 §8 and retention to N3 §4.3, naming the withdrawn models explicitly so a reader meeting one in code knows it is a defect. §5.1 keeps what is genuinely listener-specific: which principal sees which field class, `:restricted` suppressed per-recipient at delivery rather than per-event at emission.
- **§5.2** redaction patterns are EDN configuration with a schema; deployment patterns apply *in addition to* N3 §8.1's set, never instead of it.
- **§5.3** adds the one constraint N3 does not: control-action events are `:audit` class and MUST NOT be retained below the one-year floor. A control action is the record of a human overriding the machine.
- **§10.1** replaced by a reference table, with the inherited-scope property called out since it is what the reproduced schemas got wrong.
- **§12.4–§12.5** requirement IDs (`N8.CAP.*`, `N8.CTL.*`, `N8.PRV.*`) + 6 test obligations.
- **§13 MCI** no longer cites the withdrawn `metadata-only` privacy level.

## Annex A — implementation conformance status (informative)

- **Implemented** — listener capability enforcement and `include-payloads` filtering (`event-stream/listeners.clj`); control-action evidence (`evidence-bundle/collector.clj`).
- **Specified, not implemented** — **no redaction configuration exists anywhere in the tree**; the only match for "redaction" is a `progress-detector` test. This is the third spec in a row to record that gap (N3 Annex A, N6 Annex A), which is a signal about where implementation effort should go. Also missing: per-recipient `:restricted` suppression, and `:scope/type` on listener events.
- **Structural** — no retention floor for control-action events.

## Validation

Documentation only; no runtime code touched.

- `markdownlint` clean on all three files
- Code blocks brace-balanced; no duplicate section numbers
- Verified the withdrawn vocabularies survive only where their withdrawal is documented
- `bb pre-commit` passed on both commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)
