### PR TITLE
fix: harden execution-grant breach history

### DIFF
--- a/components/execution-grant/deps.edn
+++ b/components/execution-grant/deps.edn
@@ -1,5 +1,6 @@
-{:paths ["src"]
+{:paths ["src" "resources"]
  :deps {ai.miniforge/anomaly {:local/root "../anomaly"}
+        ai.miniforge/messages {:local/root "../messages"}
         metosin/malli {:mvn/version "0.16.4"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/execution-grant/resources/config/execution-grant/messages/system.edn
+++ b/components/execution-grant/resources/config/execution-grant/messages/system.edn
@@ -1,0 +1,21 @@
+;; Title: Miniforge.ai
+;; Author: Christopher Lester (christopher@miniforge.ai)
+;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+
+{:execution-grant/messages
+ {:grant/input-invalid "ExecutionGrant inputs failed validation"
+  :grant/parent-invalid "Cannot delegate from a value that is not a valid ExecutionGrant"
+  :grant/parent-not-delegable "Parent grant is not delegable"
+  :grant/parent-inactive "Parent grant is revoked or expired"
+  :grant/delegated-invalid "Delegated ExecutionGrant inputs failed validation"
+  :grant/delegation-widened "Delegated grant is broader than its parent"
+  :grant/revoke-invalid "Cannot revoke a value that is not a valid ExecutionGrant"
+  :grant/revocation-invalid "Revocation produced an invalid ExecutionGrant"
+  :attenuation/effect-class "A delegated grant cannot change effect class"
+  :attenuation/scope "Child scope drops or changes a binding the parent set"
+  :attenuation/expiry "Child expiry outlives the parent's"
+  :attenuation/ceiling "Child raises a ceiling above the parent, or drops a bound the parent set"
+  :breach/invalid "Breach record failed validation"
+  :breach/read-failed "Breach history record could not be read"
+  :breach/write-failed "Breach history record could not be persisted"
+  :breach/id-conflict "Breach history already contains this breach id"}}

--- a/components/execution-grant/resources/config/execution-grant/messages/system.edn
+++ b/components/execution-grant/resources/config/execution-grant/messages/system.edn
@@ -3,19 +3,7 @@
 ;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
 
 {:execution-grant/messages
- {:grant/input-invalid "ExecutionGrant inputs failed validation"
-  :grant/parent-invalid "Cannot delegate from a value that is not a valid ExecutionGrant"
-  :grant/parent-not-delegable "Parent grant is not delegable"
-  :grant/parent-inactive "Parent grant is revoked or expired"
-  :grant/delegated-invalid "Delegated ExecutionGrant inputs failed validation"
-  :grant/delegation-widened "Delegated grant is broader than its parent"
-  :grant/revoke-invalid "Cannot revoke a value that is not a valid ExecutionGrant"
-  :grant/revocation-invalid "Revocation produced an invalid ExecutionGrant"
-  :attenuation/effect-class "A delegated grant cannot change effect class"
-  :attenuation/scope "Child scope drops or changes a binding the parent set"
-  :attenuation/expiry "Child expiry outlives the parent's"
-  :attenuation/ceiling "Child raises a ceiling above the parent, or drops a bound the parent set"
-  :breach/invalid "Breach record failed validation"
+ {:breach/invalid "Breach record failed validation"
   :breach/read-failed "Breach history record could not be read"
   :breach/write-failed "Breach history record could not be persisted"
   :breach/id-conflict "Breach history already contains this breach id"}}

--- a/components/execution-grant/src/ai/miniforge/execution_grant/breach.clj
+++ b/components/execution-grant/src/ai/miniforge/execution_grant/breach.clj
@@ -16,110 +16,16 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns ai.miniforge.execution-grant.breach
-  "Breach history: what a principal blew through, and whether we caught
-   it or merely noticed (Ariadne step 2e, §13.5).
-
-   THE HONEST HALF. Gates prevent what they can; logbooks catch the
-   rest. Some conditions cannot be checked before the fact — a cost that
-   only materializes mid-stream, an effect whose true outcome arrives
-   later. Those are found by reconciliation, after the effect. A
-   governance product that reports those as PREVENTED is claiming a
-   capability it does not have, so every breach records which it was.
-
-   Append-only by construction: one file per breach, never rewritten.
-   A history you can edit is a history that stops being evidence."
+  "Breach-history API for execution grants."
   (:require
-   [ai.miniforge.execution-grant.schema :as schema]
-   [clojure.edn :as edn]
-   [clojure.java.io :as io]
-   [malli.core :as m])
-  (:import
-   [java.io File]
-   [java.nio.file Files StandardCopyOption]
-   [java.time Instant]
-   [java.util Date]))
+   [ai.miniforge.execution-grant.breach.store :as store]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
-;; Durable, append-only
-(defn- ^{:stratum 0} ->iso
-  "Timestamp -> ISO-8601, by actual type rather than by type hint.
+(def ^{:stratum 0} history
+  "Every recorded breach, optionally narrowed to one principal."
+  store/history)
 
-   `:breach/at` is validated with `inst?`, and `inst?` admits
-   `java.util.Date` as well as `java.time.Instant`. A Date's `.toString`
-   is not ISO-8601, so persisting one would write a value `Instant/parse`
-   cannot read back — corrupting the history at the moment of recording
-   it. Same defect effect-transaction's store carried; fixed there and
-   not swept here until review caught it."
-  ^String [v]
-  (cond
-    (instance? Instant v) (.toString ^Instant v)
-    (instance? Date v) (.toString (.toInstant ^Date v))
-    :else (throw (ex-info "breach timestamp is not a supported instant type"
-                          {:value v :type (some-> v class .getName)}))))
-
-(defn- ^{:stratum 0} <-wire [m] (update m :breach/at #(Instant/parse %)))
-
-(defn ^{:stratum 0} valid?
-  "True when `b` satisfies the closed Breach schema."
-  [b]
-  (m/validate schema/Breach b))
-
-;------------------------------------------------------------------------------ Layer 1
-
-(defn- ^{:stratum 1} ->wire [b] (update b :breach/at ->iso))
-
-(defn ^{:stratum 1} history
-  "Every recorded breach under `dir`, optionally narrowed to one
-   principal. Missing directory reads as empty, not as an error — a
-   principal with no history is the normal case."
-  ([dir] (history dir nil))
-  ([dir principal]
-   (let [^File d (io/file dir)
-         xform (comp (filter #(.endsWith (.getName ^File %) ".edn"))
-                     (map #(<-wire (edn/read-string (slurp % :encoding "UTF-8"))))
-                     (filter #(or (nil? principal)
-                                  (= principal (:breach/principal %)))))]
-     (if-not (.isDirectory d)
-       []
-       (into [] xform (.listFiles d))))))
-
-;------------------------------------------------------------------------------ Layer 2
-
-(defn ^{:stratum 2} record!
-  "Append one breach to `dir`. One file per breach, written atomically
-   and never rewritten — the append-only property is structural rather
-   than a rule someone has to remember.
-
-   A malformed breach throws rather than persisting: a history entry
-   nobody can read is worse than a loud failure at the moment of
-   writing, because the alternative is discovering the gap during an
-   audit."
-  [dir b]
-  (when-not (valid? b)
-    (throw (ex-info "breach record failed validation" {:breach b})))
-  (let [^File target (io/file dir (str (:breach/id b) ".edn"))
-        _ (io/make-parents target)
-        ;; Unique per attempt. A deterministic <id>.edn.tmp lets two
-        ;; writers of the same id trample each other's partial before it
-        ;; is published, and leaves a lingering file that reads like
-        ;; evidence during manual inspection.
-        ^File tmp (io/file (.getParentFile target)
-                           (str (.getName target) "." (random-uuid) ".tmp"))]
-    (spit tmp (pr-str (->wire b)) :encoding "UTF-8")
-    ;; Write the temp in full, then hard-link it into place.
-    ;; `createLink` is atomic AND exclusive: it throws
-    ;; FileAlreadyExistsException when the target exists, in ONE
-    ;; operation, so there is no window between checking and creating.
-    ;;
-    ;; Both obvious alternatives fail. `Files/move` with ATOMIC_MOVE
-    ;; lowers to rename(2) on POSIX, which overwrites silently. An
-    ;; `(.exists target)` pre-check is TOCTOU — two writers of the same
-    ;; id both pass it and the second rename wins. Append-only has to be
-    ;; one indivisible operation or it is not a guarantee, only a hope
-    ;; with good intentions.
-    (try
-      (Files/createLink (.toPath target) (.toPath tmp))
-      (finally
-        (.delete tmp)))
-    b))
+(def ^{:stratum 0} record!
+  "Append one breach without replacing an existing breach id."
+  store/record!)

--- a/components/execution-grant/src/ai/miniforge/execution_grant/breach/store.clj
+++ b/components/execution-grant/src/ai/miniforge/execution_grant/breach/store.clj
@@ -1,0 +1,151 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.execution-grant.breach.store
+  "Append-only filesystem storage for execution-grant breaches.
+
+   One complete EDN file is published per breach. An exclusive hard
+   link makes reusing an id unable to replace the original evidence."
+  (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.execution-grant.messages :as msg]
+   [ai.miniforge.execution-grant.schema :as schema]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [malli.core :as m])
+  (:import
+   [java.io File]
+   [java.nio.file FileAlreadyExistsException Files]
+   [java.time Instant]
+   [java.util Date]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} ->iso
+  ^String [value]
+  (if (instance? Instant value)
+    (.toString ^Instant value)
+    (.toString (.toInstant ^Date value))))
+
+(defn- ^{:stratum 0} breach-file?
+  [^File file]
+  (.endsWith (.getName file) ".edn"))
+
+(defn- ^{:stratum 0} principal-breach?
+  [principal breach]
+  (or (nil? principal)
+      (= principal (:breach/principal breach))))
+
+(defn- ^{:stratum 0} anomaly-value
+  [value]
+  (when (anomaly/anomaly? value) value))
+
+(defn- ^{:stratum 0} invalid-record
+  [breach]
+  (anomaly/sub-anomaly :invalid-input
+                       :anomalies.execution-grant/invalid-breach
+                       (msg/t :breach/invalid)
+                       {:breach breach}))
+
+(defn- ^{:stratum 0} read-failure
+  [^File file ex]
+  (anomaly/sub-anomaly :fault
+                       :anomalies.execution-grant/breach-read-failed
+                       (msg/t :breach/read-failed)
+                       {:breach/path (.getPath file)
+                        :exception/message (some-> ex ex-message)}))
+
+(defn- ^{:stratum 0} invalid-stored-record
+  [^File file value]
+  (anomaly/sub-anomaly :fault
+                       :anomalies.execution-grant/breach-read-failed
+                       (msg/t :breach/read-failed)
+                       {:breach/path (.getPath file)
+                        :breach/value value}))
+
+(defn- ^{:stratum 0} write-failure
+  [^File target ex]
+  (anomaly/sub-anomaly :fault
+                       :anomalies.execution-grant/breach-write-failed
+                       (msg/t :breach/write-failed)
+                       {:breach/path (.getPath target)
+                        :exception/message (ex-message ex)}))
+
+(defn- ^{:stratum 0} id-conflict
+  [breach]
+  (anomaly/sub-anomaly :conflict
+                       :anomalies.execution-grant/breach-id-conflict
+                       (msg/t :breach/id-conflict)
+                       {:breach/id (:breach/id breach)}))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} breach-files
+  [^File dir]
+  (cond
+    (not (.exists dir)) []
+    (not (.isDirectory dir)) (read-failure dir nil)
+    :else (if-let [files (.listFiles dir)]
+            (filterv breach-file? files)
+            (read-failure dir nil))))
+
+(defn- ^{:stratum 1} read-record
+  [^File file]
+  (try
+    (let [wire-record (edn/read-string (slurp file :encoding "UTF-8"))
+          record (update wire-record :breach/at #(Instant/parse %))]
+      (if (m/validate schema/Breach record)
+        record
+        (invalid-stored-record file record)))
+    (catch Exception ex
+      (read-failure file ex))))
+
+(defn- ^{:stratum 1} persist!
+  [^File target breach]
+  (let [tmp-name (str (.getName target) "." (random-uuid) ".tmp")
+        ^File tmp (io/file (.getParentFile target) tmp-name)]
+    (try
+      (io/make-parents target)
+      (spit tmp (pr-str (update breach :breach/at ->iso)) :encoding "UTF-8")
+      (Files/createLink (.toPath target) (.toPath tmp))
+      breach
+      (catch FileAlreadyExistsException _
+        (id-conflict breach))
+      (catch Exception ex
+        (write-failure target ex))
+      (finally
+        (.delete tmp)))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} history
+  "Read breach history, failing closed on inaccessible or corrupt evidence."
+  ([dir] (history dir nil))
+  ([dir principal]
+   (let [files (breach-files (io/file dir))]
+     (if (anomaly/anomaly? files)
+       files
+       (let [records (mapv read-record files)]
+         (or (some anomaly-value records)
+             (filterv (partial principal-breach? principal) records)))))))
+
+(defn ^{:stratum 2} record!
+  "Publish one complete breach record without replacing existing evidence."
+  [dir breach]
+  (if (m/validate schema/Breach breach)
+    (persist! (io/file dir (str (:breach/id breach) ".edn")) breach)
+    (invalid-record breach)))

--- a/components/execution-grant/src/ai/miniforge/execution_grant/breach/store.clj
+++ b/components/execution-grant/src/ai/miniforge/execution_grant/breach/store.clj
@@ -96,12 +96,15 @@
 
 (defn- ^{:stratum 1} breach-files
   [^File dir]
-  (cond
-    (not (.exists dir)) []
-    (not (.isDirectory dir)) (read-failure dir nil)
-    :else (if-let [files (.listFiles dir)]
-            (filterv breach-file? files)
-            (read-failure dir nil))))
+  (try
+    (cond
+      (not (.exists dir)) []
+      (not (.isDirectory dir)) (read-failure dir nil)
+      :else (if-let [files (.listFiles dir)]
+              (filterv breach-file? files)
+              (read-failure dir nil)))
+    (catch Exception ex
+      (read-failure dir ex))))
 
 (defn- ^{:stratum 1} read-record
   [^File file]

--- a/components/execution-grant/src/ai/miniforge/execution_grant/eligibility.clj
+++ b/components/execution-grant/src/ai/miniforge/execution_grant/eligibility.clj
@@ -16,90 +16,38 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns ai.miniforge.execution-grant.eligibility
-  "What a principal's breach history permits them to be granted next
-   (Ariadne step 2e, §13.5), and the revocation that writes to it.
-
-   The rule here is a POLICY CHOICE, not a derivation. It is stated
-   plainly in `permitted-ceiling` so it can be argued with rather than
-   absorbed by whoever reads the code next."
+  "Whether breach history permits a principal's requested ceilings."
   (:require
-   [ai.miniforge.execution-grant.breach :as breach]
-   [ai.miniforge.execution-grant.core :as core]
-   [ai.miniforge.execution-grant.schema :as schema])
-  (:import
-   [java.time Instant]))
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.execution-grant.eligibility.ceiling :as ceiling]
+   [ai.miniforge.execution-grant.schema :as schema]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
-(defn ^{:stratum 0} permitted-ceiling
-  "The highest ceiling this principal may now be granted on `axis` for
-   `effect-class`, or nil for unbounded (no relevant history).
-
-   DAY-ONE RULE, and a policy choice rather than a derivation: a
-   principal who blew through a limit may not be handed that limit
-   again. The cap becomes the lowest limit they breached. Strictly
-   smaller ceilings stay available, so the path back is narrower
-   authority rather than a permanent ban.
-
-   What it deliberately does NOT do is decay with time or forgive after
-   N clean runs. Both are reasonable; both need a decision this spec
-   does not own, and guessing one here would bury it."
-  [dir principal effect-class axis]
-  (let [limits (into []
-                     (comp (filter #(and (= effect-class (:breach/effect-class %))
-                                         (= axis (:breach/axis %))))
-                           (map :breach/limit))
-                     (breach/history dir principal))]
-    (when (seq limits) (apply min limits))))
-
-(defn ^{:stratum 0} revoke-for-cause!
-  "End a grant BECAUSE of a breach, and remember it.
-
-   Two effects that must not drift apart: the grant carries the cause on
-   `:grant/revocation-reason`, and the history carries the numbers —
-   which axis, what limit, what was observed, and whether a gate
-   prevented it or reconciliation merely found it.
-
-   Revocation is transitive over lineage (2a's `active?` walks
-   ancestors), so ending a parent ends everything cut from it. That is
-   what makes a delegated inner orchestrator containable rather than
-   merely instructed.
-
-   The breach is recorded FIRST. If the history write fails the caller
-   must learn the breach went unrecorded, rather than discover a revoked
-   grant with no reason behind it."
-  [dir grant {:keys [axis limit observed detection]} ^Instant now]
-  (let [b {:breach/id (random-uuid)
-           :breach/principal (:grant/principal grant)
-           :breach/grant-id (:grant/id grant)
-           :breach/effect-class (:grant/effect-class grant)
-           :breach/axis axis
-           :breach/limit limit
-           :breach/observed observed
-           :breach/detection detection
-           :breach/at now}
-        reason (case axis
-                 :constraint/max-cost-usd :breach/cost-exceeded
-                 :constraint/max-tokens :breach/token-exceeded
-                 :constraint/max-count :breach/count-exceeded
-                 :breach/scope-violation)]
-    (breach/record! dir b)
-    (core/revoke grant reason now)))
+(def ^{:stratum 0} permitted-ceiling
+  "The highest ceiling breach history permits for one authority axis."
+  ceiling/permitted-ceiling)
 
 ;------------------------------------------------------------------------------ Layer 1
 
-(defn ^{:stratum 1} eligible?
+(defn- ^{:stratum 1} axis-eligible?
+  [dir principal effect-class constraints axis]
+  (let [cap (permitted-ceiling dir principal effect-class axis)
+        requested (get constraints axis)]
+    (cond
+      (anomaly/anomaly? cap) false
+      (nil? cap) true
+      :else (and (some? requested) (number? requested) (< requested cap)))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} eligible?
   "May this principal be granted `effect-class` at `constraints`?
 
-   False when any requested ceiling reaches or exceeds one they have
-   already breached. An unbounded request (axis absent) against a
-   principal WITH history on that axis is also refused — asking for no
-   limit after breaching a limit is the widest request there is, not an
-   abstention."
+   False when a request reaches or exceeds a previously breached
+   ceiling. An absent ceiling is the widest request and is refused
+   once history establishes a bound. Unreadable history also refuses
+   issuance rather than presenting a principal as clean."
   [dir principal effect-class constraints]
-  (every? (fn [axis]
-            (if-let [cap (permitted-ceiling dir principal effect-class axis)]
-              (let [requested (get constraints axis)]
-                (and (some? requested) (number? requested) (< requested cap)))
-              true))
+  (every? #(axis-eligible? dir principal effect-class constraints %)
           schema/constraint-axes))

--- a/components/execution-grant/src/ai/miniforge/execution_grant/eligibility/ceiling.clj
+++ b/components/execution-grant/src/ai/miniforge/execution_grant/eligibility/ceiling.clj
@@ -1,0 +1,55 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.execution-grant.eligibility.ceiling
+  "Ceilings a principal's breach history permits them to receive."
+  (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.execution-grant.breach :as breach]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} breach-for-axis?
+  [effect-class axis record]
+  (and (= effect-class (:breach/effect-class record))
+       (= axis (:breach/axis record))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} minimum-relevant-limit
+  [records effect-class axis]
+  (let [limits (into []
+                     (comp (filter (partial breach-for-axis? effect-class axis))
+                           (map :breach/limit))
+                     records)]
+    (when (seq limits) (apply min limits))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} permitted-ceiling
+  "The highest ceiling this principal may now receive on `axis`.
+
+   No relevant breach means unbounded authority is still eligible.
+   Otherwise the lowest breached limit becomes an exclusive ceiling:
+   recovery is possible through narrower authority, not an immediate
+   restoration of the same bound. Storage anomalies pass through so
+   issuance can fail closed."
+  [dir principal effect-class axis]
+  (let [records (breach/history dir principal)]
+    (if (anomaly/anomaly? records)
+      records
+      (minimum-relevant-limit records effect-class axis))))

--- a/components/execution-grant/src/ai/miniforge/execution_grant/interface.clj
+++ b/components/execution-grant/src/ai/miniforge/execution_grant/interface.clj
@@ -144,5 +144,5 @@
 
 (def ^{:stratum 0} revoke-for-cause!
   "Revoke a grant AND record the breach that caused it, or return the
-   persistence anomaly without revoking."
+   recording anomaly without revoking."
   revocation/revoke-for-cause!)

--- a/components/execution-grant/src/ai/miniforge/execution_grant/interface.clj
+++ b/components/execution-grant/src/ai/miniforge/execution_grant/interface.clj
@@ -29,6 +29,7 @@
    [ai.miniforge.execution-grant.attenuation :as attenuation]
    [ai.miniforge.execution-grant.breach :as breach]
    [ai.miniforge.execution-grant.eligibility :as eligibility]
+   [ai.miniforge.execution-grant.revocation :as revocation]
    [ai.miniforge.execution-grant.constraints :as constraints]
    [ai.miniforge.execution-grant.core :as core]
    [ai.miniforge.execution-grant.lineage :as lineage]
@@ -123,12 +124,13 @@
   schema/detections)
 
 (def ^{:stratum 0} record-breach!
-  "Append one breach to the history. One file per breach, never
-   rewritten — append-only by construction."
+  "Append one breach to the history, or return an anomaly. One file per
+   breach, never rewritten — append-only by construction."
   breach/record!)
 
 (def ^{:stratum 0} breach-history
-  "Every recorded breach, optionally narrowed to one principal."
+  "Every recorded breach, optionally narrowed to one principal. Returns
+   an anomaly rather than treating unreadable history as empty."
   breach/history)
 
 (def ^{:stratum 0} permitted-ceiling
@@ -141,5 +143,6 @@
   eligibility/eligible?)
 
 (def ^{:stratum 0} revoke-for-cause!
-  "Revoke a grant AND record the breach that caused it."
-  eligibility/revoke-for-cause!)
+  "Revoke a grant AND record the breach that caused it, or return the
+   persistence anomaly without revoking."
+  revocation/revoke-for-cause!)

--- a/components/execution-grant/src/ai/miniforge/execution_grant/messages.clj
+++ b/components/execution-grant/src/ai/miniforge/execution_grant/messages.clj
@@ -1,0 +1,29 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.execution-grant.messages
+  "Developer-facing messages for the execution-grant component."
+  (:require
+   [ai.miniforge.messages.interface :as messages]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} t
+  "Translate an execution-grant system message."
+  (messages/create-translator
+   "config/execution-grant/messages/system.edn"
+   :execution-grant/messages))

--- a/components/execution-grant/src/ai/miniforge/execution_grant/revocation.clj
+++ b/components/execution-grant/src/ai/miniforge/execution_grant/revocation.clj
@@ -1,0 +1,63 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.execution-grant.revocation
+  "For-cause grant revocation backed by durable breach evidence."
+  (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.execution-grant.breach :as breach]
+   [ai.miniforge.execution-grant.core :as core])
+  (:import
+   [java.time Instant]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} breach-record
+  [grant {:keys [axis limit observed detection]} ^Instant now]
+  {:breach/id (random-uuid)
+   :breach/principal (:grant/principal grant)
+   :breach/grant-id (:grant/id grant)
+   :breach/effect-class (:grant/effect-class grant)
+   :breach/axis axis
+   :breach/limit limit
+   :breach/observed observed
+   :breach/detection detection
+   :breach/at now})
+
+(defn- ^{:stratum 0} revocation-reason
+  [axis]
+  (case axis
+    :constraint/max-cost-usd :breach/cost-exceeded
+    :constraint/max-tokens :breach/token-exceeded
+    :constraint/max-count :breach/count-exceeded
+    :breach/scope-violation))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} revoke-for-cause!
+  "Persist the breach, then revoke its grant with the matching cause.
+
+   A persistence failure returns unchanged and leaves the grant live;
+   callers never receive an apparently complete revocation with its
+   governing evidence missing."
+  [dir grant observation ^Instant now]
+  (let [record (breach-record grant observation now)
+        reason (revocation-reason (:axis observation))
+        recorded (breach/record! dir record)]
+    (if (anomaly/anomaly? recorded)
+      recorded
+      (core/revoke grant reason now))))

--- a/components/execution-grant/src/ai/miniforge/execution_grant/revocation.clj
+++ b/components/execution-grant/src/ai/miniforge/execution_grant/revocation.clj
@@ -51,7 +51,7 @@
 (defn ^{:stratum 1} revoke-for-cause!
   "Persist the breach, then revoke its grant with the matching cause.
 
-   A persistence failure returns its anomaly unchanged and leaves the
+   A recording failure returns its anomaly unchanged and leaves the
    grant live; callers never receive an apparently complete revocation
    with its governing evidence missing."
   [dir grant observation ^Instant now]

--- a/components/execution-grant/src/ai/miniforge/execution_grant/revocation.clj
+++ b/components/execution-grant/src/ai/miniforge/execution_grant/revocation.clj
@@ -51,9 +51,9 @@
 (defn ^{:stratum 1} revoke-for-cause!
   "Persist the breach, then revoke its grant with the matching cause.
 
-   A persistence failure returns unchanged and leaves the grant live;
-   callers never receive an apparently complete revocation with its
-   governing evidence missing."
+   A persistence failure returns its anomaly unchanged and leaves the
+   grant live; callers never receive an apparently complete revocation
+   with its governing evidence missing."
   [dir grant observation ^Instant now]
   (let [record (breach-record grant observation now)
         reason (revocation-reason (:axis observation))

--- a/components/execution-grant/test/ai/miniforge/execution_grant/breach_test.clj
+++ b/components/execution-grant/test/ai/miniforge/execution_grant/breach_test.clj
@@ -122,18 +122,18 @@
 (deftest ^{:stratum 2} storage-failures-are-returned-as-data-test
   (let [dir (tmp-dir)
         blocking-file (io/file dir "not-a-directory")
-        grant (spend-grant)]
+        g (spend-grant)]
     (spit blocking-file "occupied" :encoding "UTF-8")
     (is (= :fault
            (:anomaly/type
             (grant/record-breach! blocking-file (breach-record)))))
     (is (anomaly/anomaly?
-         (grant/revoke-for-cause! blocking-file grant
+         (grant/revoke-for-cause! blocking-file g
                                   (breach-observation) later)))
     (is (anomaly/anomaly? (grant/breach-history blocking-file)))
     (is (false? (grant/eligible? blocking-file "agent:x" :effect/spend
                                 {:constraint/max-cost-usd 1.0})))
-    (is (grant/active? grant later))))
+    (is (grant/active? g later))))
 
 (deftest ^{:stratum 2} revoke-for-cause-ends-the-grant-and-remembers-test
   (let [dir (tmp-dir)

--- a/components/execution-grant/test/ai/miniforge/execution_grant/breach_test.clj
+++ b/components/execution-grant/test/ai/miniforge/execution_grant/breach_test.clj
@@ -114,10 +114,11 @@
     (is (= [now now] (mapv :breach/at (grant/breach-history dir "agent:x")))
         "a Date normalizes to the same instant on the way out"))
   (testing "an unsupported timestamp is data and never corrupts history"
-    (is (= :invalid-input
-           (:anomaly/type
-            (grant/record-breach! (tmp-dir)
-                                  (breach-record {:breach/at "nope"})))))))
+    (doseq [unsupported ["nope" (java.util.GregorianCalendar.)]]
+      (is (= :invalid-input
+             (:anomaly/type
+              (grant/record-breach! (tmp-dir)
+                                    (breach-record {:breach/at unsupported}))))))))
 
 (deftest ^{:stratum 2} storage-failures-are-returned-as-data-test
   (let [dir (tmp-dir)

--- a/components/execution-grant/test/ai/miniforge/execution_grant/breach_test.clj
+++ b/components/execution-grant/test/ai/miniforge/execution_grant/breach_test.clj
@@ -17,7 +17,9 @@
 ;; limitations under the License.
 (ns ai.miniforge.execution-grant.breach-test
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.execution-grant.interface :as grant]
+   [clojure.java.io :as io]
    [clojure.test :refer [deftest is testing]])
   (:import
    [java.nio.file Files]
@@ -32,12 +34,21 @@
 
 (def ^{:stratum 0} much-later (Instant/parse "2026-08-02T00:00:00Z"))
 
-(defn ^{:stratum 0} tmp-dir []
+(defn- ^{:stratum 0} tmp-dir []
   (str (.toFile (Files/createTempDirectory "breach" (into-array FileAttribute [])))))
+
+(defn- ^{:stratum 0} breach-observation
+  ([] (breach-observation {}))
+  ([overrides]
+   (merge {:axis :constraint/max-cost-usd
+           :limit 5.0
+           :observed 9.0
+           :detection :detected}
+          overrides)))
 
 ;------------------------------------------------------------------------------ Layer 1
 
-(defn ^{:stratum 1} spend-grant
+(defn- ^{:stratum 1} spend-grant
   ([] (spend-grant {}))
   ([overrides]
    (grant/issue (merge {:principal "agent:implementer"
@@ -49,17 +60,10 @@
                        overrides)
                 now)))
 
-(deftest ^{:stratum 1} malformed-breach-is-refused-test
-  (let [dir (tmp-dir)]
-    (is (thrown? clojure.lang.ExceptionInfo
-                 (grant/record-breach! dir {:breach/id (random-uuid)})))))
-
-(deftest ^{:stratum 1} a-reused-breach-id-cannot-overwrite-history-test
-  ;; Append-only must be enforced by the filesystem, not asserted in a
-  ;; docstring. A reused id silently replacing an earlier breach is the
-  ;; exact edit this record exists to make impossible.
-  (let [dir (tmp-dir)
-        b {:breach/id (random-uuid)
+(defn- ^{:stratum 1} breach-record
+  ([] (breach-record {}))
+  ([overrides]
+   (merge {:breach/id (random-uuid)
            :breach/principal "agent:x"
            :breach/grant-id (random-uuid)
            :breach/effect-class :effect/spend
@@ -67,52 +71,75 @@
            :breach/limit 5.0
            :breach/observed 9.0
            :breach/detection :detected
-           :breach/at now}]
+           :breach/at now}
+          overrides)))
+
+(deftest ^{:stratum 1} malformed-breach-is-refused-test
+  (let [dir (tmp-dir)]
+    (is (anomaly/anomaly?
+         (grant/record-breach! dir {:breach/id (random-uuid)})))))
+
+(deftest ^{:stratum 1} unreadable-history-fails-eligibility-closed-test
+  (doseq [body ["{}" "{"]]
+    (let [dir (tmp-dir)]
+      (spit (io/file dir "corrupt.edn") body :encoding "UTF-8")
+      (is (anomaly/anomaly? (grant/breach-history dir)))
+      (is (false? (grant/eligible? dir "agent:x" :effect/spend
+                                  {:constraint/max-cost-usd 1.0}))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} a-reused-breach-id-cannot-overwrite-history-test
+  ;; Append-only must be enforced by the filesystem, not asserted in a
+  ;; docstring. A reused id silently replacing an earlier breach is the
+  ;; exact edit this record exists to make impossible.
+  (let [dir (tmp-dir)
+        b (breach-record)]
     (grant/record-breach! dir b)
-    (is (thrown? java.nio.file.FileAlreadyExistsException
-                 (grant/record-breach! dir (assoc b :breach/observed 1.0))))
+    (is (= :conflict
+           (:anomaly/type
+            (grant/record-breach! dir (assoc b :breach/observed 1.0)))))
     (testing "the original survives untouched"
       (is (= 9.0 (:breach/observed (first (grant/breach-history dir "agent:x"))))))))
 
-(deftest ^{:stratum 1} both-inst-types-round-trip-test
+(deftest ^{:stratum 2} both-inst-types-round-trip-test
   ;; inst? admits java.util.Date as well as Instant, so a breach the
   ;; schema ACCEPTS can arrive holding either. A Date's .toString is not
   ;; ISO-8601 and would corrupt the history at the moment of recording.
   (let [dir (tmp-dir)
-        base {:breach/principal "agent:x"
-              :breach/grant-id (random-uuid)
-              :breach/effect-class :effect/spend
-              :breach/axis :constraint/max-cost-usd
-              :breach/limit 5.0 :breach/observed 9.0
-              :breach/detection :detected}
-        as-date (assoc base :breach/id (random-uuid)
-                       :breach/at (java.util.Date/from now))
-        as-instant (assoc base :breach/id (random-uuid) :breach/at now)]
+        as-date (breach-record {:breach/at (java.util.Date/from now)})
+        as-instant (breach-record)]
     (grant/record-breach! dir as-date)
     (grant/record-breach! dir as-instant)
     (is (= [now now] (mapv :breach/at (grant/breach-history dir "agent:x")))
         "a Date normalizes to the same instant on the way out"))
-  (testing "an unsupported timestamp throws rather than corrupting the history"
-    (is (thrown? clojure.lang.ExceptionInfo
-                 (grant/record-breach! (tmp-dir)
-                                       {:breach/id (random-uuid)
-                                        :breach/principal "p"
-                                        :breach/grant-id (random-uuid)
-                                        :breach/effect-class :effect/spend
-                                        :breach/axis :constraint/max-cost-usd
-                                        :breach/limit 1.0 :breach/observed 2.0
-                                        :breach/detection :detected
-                                        :breach/at "nope"})))))
+  (testing "an unsupported timestamp is data and never corrupts history"
+    (is (= :invalid-input
+           (:anomaly/type
+            (grant/record-breach! (tmp-dir)
+                                  (breach-record {:breach/at "nope"})))))))
 
-;------------------------------------------------------------------------------ Layer 2
+(deftest ^{:stratum 2} storage-failures-are-returned-as-data-test
+  (let [dir (tmp-dir)
+        blocking-file (io/file dir "not-a-directory")
+        grant (spend-grant)]
+    (spit blocking-file "occupied" :encoding "UTF-8")
+    (is (= :fault
+           (:anomaly/type
+            (grant/record-breach! blocking-file (breach-record)))))
+    (is (anomaly/anomaly?
+         (grant/revoke-for-cause! blocking-file grant
+                                  (breach-observation) later)))
+    (is (anomaly/anomaly? (grant/breach-history blocking-file)))
+    (is (false? (grant/eligible? blocking-file "agent:x" :effect/spend
+                                {:constraint/max-cost-usd 1.0})))
+    (is (grant/active? grant later))))
 
 (deftest ^{:stratum 2} revoke-for-cause-ends-the-grant-and-remembers-test
   (let [dir (tmp-dir)
         g (spend-grant)
         revoked (grant/revoke-for-cause! dir g
-                                         {:axis :constraint/max-cost-usd
-                                          :limit 5.0 :observed 9.0
-                                          :detection :detected}
+                                         (breach-observation)
                                          later)]
     (testing "the grant carries the cause"
       (is (grant/revoked? revoked))
@@ -131,11 +158,10 @@
   ;; it PREVENTED is claiming a gate it does not have.
   (let [dir (tmp-dir)]
     (grant/revoke-for-cause! dir (spend-grant)
-                             {:axis :constraint/max-cost-usd :limit 5.0
-                              :observed 6.0 :detection :prevented} later)
+                             (breach-observation {:observed 6.0
+                                                  :detection :prevented}) later)
     (grant/revoke-for-cause! dir (spend-grant {:principal "agent:other"})
-                             {:axis :constraint/max-cost-usd :limit 5.0
-                              :observed 7.0 :detection :detected} later)
+                             (breach-observation {:observed 7.0}) later)
     (let [all (grant/breach-history dir)]
       (is (= #{:prevented :detected} (set (map :breach/detection all)))))))
 
@@ -143,11 +169,9 @@
   (let [dir (tmp-dir)]
     (dotimes [_ 3]
       (grant/revoke-for-cause! dir (spend-grant)
-                               {:axis :constraint/max-cost-usd :limit 5.0
-                                :observed 6.0 :detection :detected} later))
+                               (breach-observation {:observed 6.0}) later))
     (grant/revoke-for-cause! dir (spend-grant {:principal "agent:other"})
-                             {:axis :constraint/max-cost-usd :limit 5.0
-                              :observed 6.0 :detection :detected} later)
+                             (breach-observation {:observed 6.0}) later)
     (testing "every breach is kept — later ones never overwrite earlier"
       (is (= 4 (count (grant/breach-history dir)))))
     (testing "history narrows by principal"
@@ -163,8 +187,7 @@
     (testing "with no history, anything is eligible"
       (is (grant/eligible? dir p :effect/spend {:constraint/max-cost-usd 100.0})))
     (grant/revoke-for-cause! dir (spend-grant)
-                             {:axis :constraint/max-cost-usd :limit 5.0
-                              :observed 9.0 :detection :detected} later)
+                             (breach-observation) later)
     (testing "the breached ceiling is refused, and so is anything above it"
       (is (not (grant/eligible? dir p :effect/spend {:constraint/max-cost-usd 5.0})))
       (is (not (grant/eligible? dir p :effect/spend {:constraint/max-cost-usd 50.0}))))

--- a/docs/pull-requests/2026-08-06-codex-execution-grant-breach-standards.md
+++ b/docs/pull-requests/2026-08-06-codex-execution-grant-breach-standards.md
@@ -1,0 +1,86 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix: harden execution-grant breach history
+
+## Overview
+
+Bring breach persistence, eligibility, and for-cause revocation into compliance
+with exception, component, function, test-data, and stratified-design standards
+before production grant issuance is enabled.
+
+## Motivation
+
+The existing breach module threw on invalid input and filesystem conflicts,
+treated unreadable history as a clean principal, and combined record encoding,
+filesystem storage, ceiling policy, eligibility, and revocation in one deep
+call chain. Its tests also repeated full breach and observation maps.
+
+Those defects are authority defects: a corrupt audit store must not make a
+principal eligible, and a failed evidence write must not masquerade as a
+complete for-cause revocation.
+
+## Layer
+
+Execution-grant domain policy and internal infrastructure hardening.
+
+## Changes in Detail
+
+- Return anomalies for invalid records, duplicate ids, and filesystem failures.
+- Fail eligibility closed when breach history is inaccessible or corrupt.
+- Preserve append-only evidence with exclusive hard-link publication.
+- Record breach evidence before revoking and leave the grant live if recording
+  fails.
+- Separate breach API/storage, ceiling policy, eligibility, and revocation.
+- Centralize breach, observation, and grant factories in tests.
+- Move emitted failure text into the component message catalog.
+
+## Architecture
+
+The breach namespace is a thin component-internal API over the append-only
+store. The store contains only filesystem discovery, individual record I/O, and
+the two public storage operations. Ceiling derivation is separate from the
+boolean issuance predicate, while for-cause revocation owns its two-effect
+ordering explicitly. Every implementation namespace has at most three inferred
+layers.
+
+## Failure Semantics
+
+- Missing history directory is the normal empty-history case.
+- Existing non-directory, unreadable directory, malformed EDN, and invalid
+  stored records return `:fault` anomalies.
+- Reusing a breach id returns `:conflict` and preserves the original record.
+- Invalid caller input returns `:invalid-input` without touching storage.
+- Eligibility returns false for every breach-store anomaly.
+
+## Testing Plan
+
+- Focused execution-grant tests in every composed product.
+- Full five-project stable-derived test plan.
+- Poly check, kondo, inferred-stratum lint, standards scan, smoke tests, Graal
+  compatibility, and PR budget.
+
+## Standards Review
+
+- Exceptions as data: both execution-grant scanner findings are removed.
+- Component design: filesystem concerns are isolated behind the breach API.
+- Function design: policy functions no longer construct repeated maps inline.
+- Data design: one fixture factory per canonical breach/test input shape.
+- Stratified design: the former six- and five-layer namespaces are decomposed;
+  staged lint validates the resulting dependency depth.
+- Failure design: no read or write failure widens authority.
+
+## Checklist
+
+- [x] Commit budgets pass without overrides.
+- [x] Focused execution-grant tests pass in all four composed products.
+- [x] Poly, kondo, stratum, smoke, and Graal gates pass.
+- [x] Adversarial failure-path and changed-code review is clean.
+
+## Related Work
+
+- `work/ariadne-grant-issuance.spec.edn`
+- Follow-up: delegation and attenuation standards remediation.


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# fix: harden execution-grant breach history

## Overview

Bring breach persistence, eligibility, and for-cause revocation into compliance
with exception, component, function, test-data, and stratified-design standards
before production grant issuance is enabled.

## Motivation

The existing breach module threw on invalid input and filesystem conflicts,
treated unreadable history as a clean principal, and combined record encoding,
filesystem storage, ceiling policy, eligibility, and revocation in one deep
call chain. Its tests also repeated full breach and observation maps.

Those defects are authority defects: a corrupt audit store must not make a
principal eligible, and a failed evidence write must not masquerade as a
complete for-cause revocation.

## Layer

Execution-grant domain policy and internal infrastructure hardening.

## Changes in Detail

- Return anomalies for invalid records, duplicate ids, and filesystem failures.
- Fail eligibility closed when breach history is inaccessible or corrupt.
- Preserve append-only evidence with exclusive hard-link publication.
- Record breach evidence before revoking and leave the grant live if recording
  fails.
- Separate breach API/storage, ceiling policy, eligibility, and revocation.
- Centralize breach, observation, and grant factories in tests.
- Move emitted failure text into the component message catalog.

## Architecture

The breach namespace is a thin component-internal API over the append-only
store. The store contains only filesystem discovery, individual record I/O, and
the two public storage operations. Ceiling derivation is separate from the
boolean issuance predicate, while for-cause revocation owns its two-effect
ordering explicitly. Every implementation namespace has at most three inferred
layers.

## Failure Semantics

- Missing history directory is the normal empty-history case.
- Existing non-directory, unreadable directory, malformed EDN, and invalid
  stored records return `:fault` anomalies.
- Reusing a breach id returns `:conflict` and preserves the original record.
- Invalid caller input returns `:invalid-input` without touching storage.
- Eligibility returns false for every breach-store anomaly.

## Testing Plan

- Focused execution-grant tests in every composed product.
- Full five-project stable-derived test plan.
- Poly check, kondo, inferred-stratum lint, standards scan, smoke tests, Graal
  compatibility, and PR budget.

## Standards Review

- Exceptions as data: both execution-grant scanner findings are removed.
- Component design: filesystem concerns are isolated behind the breach API.
- Function design: policy functions no longer construct repeated maps inline.
- Data design: one fixture factory per canonical breach/test input shape.
- Stratified design: the former six- and five-layer namespaces are decomposed;
  staged lint validates the resulting dependency depth.
- Failure design: no read or write failure widens authority.

## Checklist

- [x] Commit budgets pass without overrides.
- [x] Focused execution-grant tests pass in all four composed products.
- [x] Poly, kondo, stratum, smoke, and Graal gates pass.
- [x] Adversarial failure-path and changed-code review is clean.

## Related Work

- `work/ariadne-grant-issuance.spec.edn`
- Follow-up: delegation and attenuation standards remediation.
