### PR TITLE
fix: fence durable effect persistence

### DIFF
--- a/components/effect-transaction/resources/config/effect-transaction/messages/system.edn
+++ b/components/effect-transaction/resources/config/effect-transaction/messages/system.edn
@@ -8,7 +8,13 @@
   :grant/recheck-failed "Grant re-check failed at commit: {outcome}"
   :record/change-invalid "EffectTransaction change failed validation"
   :record/input-invalid "EffectTransaction inputs failed validation"
+  :record/not-found "EffectTransaction does not exist in the durable store"
+  :record/transition-conflict "EffectTransaction changed before its durable transition could be claimed"
   :proposal/no-store "propose! requires :dir — refusing to write records to the process working directory"
+  :proposal/id-conflict "EffectTransaction identity is already durable and cannot be replaced"
+  :store/read-failed "EffectTransaction durable record could not be read"
+  :store/write-failed "EffectTransaction durable record could not be written"
+  :store/lock-conflict "EffectTransaction durable record is being changed by another process"
   :commit/not-proposed "Only a :proposed record may be committed"
   :reconcile/not-reconcilable "Only :committing or :unknown-outcome records are reconcilable"
   :reconcile/no-answer "Reconciliation probe did not answer; record stays unresolved"}}

--- a/components/effect-transaction/resources/config/effect-transaction/messages/system.edn
+++ b/components/effect-transaction/resources/config/effect-transaction/messages/system.edn
@@ -7,6 +7,7 @@
   :grant/effect-class-mismatch "Grant effect class does not match the proposed effect"
   :grant/recheck-failed "Grant re-check failed at commit: {outcome}"
   :record/change-invalid "EffectTransaction change failed validation"
+  :record/id-immutable "EffectTransaction identity cannot change during a lifecycle transition"
   :record/input-invalid "EffectTransaction inputs failed validation"
   :record/not-found "EffectTransaction does not exist in the durable store"
   :record/transition-conflict "EffectTransaction changed before its durable transition could be claimed"

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/codec.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/codec.clj
@@ -1,0 +1,59 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.effect-transaction.codec
+  "Translate validated effect transactions across the EDN storage boundary."
+  (:import
+   [java.time Instant]
+   [java.util Date]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private instant-keys
+  [:effect/at :effect/updated-at])
+
+(defn- ^{:stratum 0} ->iso
+  ^String [v]
+  (if (instance? Instant v)
+    (.toString ^Instant v)
+    (.toString (.toInstant ^Date v))))
+
+(defn- ^{:stratum 0} decode-instant-key
+  [record k]
+  (if-let [v (get record k)]
+    (assoc record k (Instant/parse v))
+    record))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} encode-instant-key
+  [record k]
+  (if (some? (get record k))
+    (assoc record k (->iso (get record k)))
+    record))
+
+(defn ^{:stratum 1} <-wire
+  "EDN map -> transaction record."
+  [record]
+  (reduce decode-instant-key record instant-keys))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} ->wire
+  "Record -> EDN-safe map."
+  [record]
+  (reduce encode-instant-key record instant-keys))

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/interface.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/interface.clj
@@ -44,13 +44,8 @@
   "Closed Malli schema for a transaction record."
   schema/EffectTransaction)
 
-(def ^{:stratum 0} write!
-  "Persist a record atomically. Throws if the write cannot complete —
-   a caller MUST treat that as 'do not attempt the effect'."
-  store/write!)
-
 (def ^{:stratum 0} read-record
-  "Read one persisted record by id, or nil."
+  "Read one persisted record by id, nil, or a storage anomaly."
   store/read-record)
 
 (def ^{:stratum 0} list-records
@@ -62,13 +57,13 @@
   core/valid?)
 
 (def ^{:stratum 0} propose!
-  "Record the intent durably, BEFORE the effect happens. Refuses a
-   missing store dir rather than writing to the process CWD."
+  "Create a durable proposal without replacing an existing effect ID."
   core/propose!)
 
 (def ^{:stratum 0} commit!
   "Re-check the grant, mark :committing, run the effect, record what it
-   reported. A throw is :unknown-outcome, never :failed."
+   reported. An Exception is :unknown-outcome, never :failed; a JVM Error
+   propagates after the durable claim."
   core/commit!)
 
 (def ^{:stratum 0} reconcile!

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/interface.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/interface.clj
@@ -49,7 +49,7 @@
   store/read-record)
 
 (def ^{:stratum 0} list-records
-  "Every persisted record under a directory."
+  "Every persisted record under a directory, or a storage anomaly."
   store/list-records)
 
 (def ^{:stratum 0} valid?

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/persistence.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/persistence.clj
@@ -140,6 +140,15 @@
         (lock-conflict id)
         (write-failure file ex)))))
 
+(defn- ^{:stratum 1} list-files
+  [^File directory]
+  (try
+    (if (.isDirectory directory)
+      (or (.listFiles directory) (read-failure directory nil))
+      [])
+    (catch Exception ex
+      (read-failure directory ex))))
+
 ;------------------------------------------------------------------------------ Layer 2
 
 (defn ^{:stratum 2} create!
@@ -174,12 +183,10 @@
 (defn ^{:stratum 2} list-records
   [dir]
   (let [^File directory (io/file dir)
-        files (.listFiles directory)
+        files (list-files directory)
         xform (comp (filter #(.endsWith (.getName ^File %) ".edn"))
                     (map read-file))]
-    (cond
-      (not (.isDirectory directory)) []
-      (nil? files) (read-failure directory nil)
-      :else
+    (if (anomaly/anomaly? files)
+      files
       (let [records (into [] xform files)]
         (or (some anomaly-value records) records)))))

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/persistence.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/persistence.clj
@@ -120,11 +120,25 @@
       (finally
         (.delete tmp)))))
 
-(defn- ^{:stratum 1} attempt-locked-call
-  [^FileChannel channel id thunk]
-  (if-let [lock (.tryLock channel)]
-    (call-with-lock lock thunk)
-    (lock-conflict id)))
+(defn- ^{:stratum 1} open-channel
+  [^File file options]
+  (try
+    (io/make-parents file)
+    (FileChannel/open (.toPath file) options)
+    (catch Exception ex
+      (write-failure file ex))))
+
+(defn- ^{:stratum 1} attempt-lock
+  [^FileChannel channel ^File file id]
+  (try
+    (or (.tryLock channel) (lock-conflict id))
+    (catch Exception ex
+      ;; Babashka does not expose OverlappingFileLockException as a
+      ;; resolvable class, so keep this JVM/BB-compatible boundary check.
+      (if (= "java.nio.channels.OverlappingFileLockException"
+             (.getName (class ex)))
+        (lock-conflict id)
+        (write-failure file ex)))))
 
 ;------------------------------------------------------------------------------ Layer 2
 
@@ -141,18 +155,15 @@
   (let [^File file (lock-file dir id)
         options (into-array StandardOpenOption
                             [StandardOpenOption/CREATE
-                             StandardOpenOption/WRITE])]
-    (try
-      (io/make-parents file)
-      (with-open [^FileChannel channel (FileChannel/open (.toPath file) options)]
-        (attempt-locked-call channel id thunk))
-      (catch Exception ex
-        ;; Babashka does not expose OverlappingFileLockException as a
-        ;; resolvable class, so keep this JVM/BB-compatible boundary check.
-        (if (= "java.nio.channels.OverlappingFileLockException"
-               (.getName (class ex)))
-          (lock-conflict id)
-          (write-failure file ex))))))
+                             StandardOpenOption/WRITE])
+        opened (open-channel file options)]
+    (if (anomaly/anomaly? opened)
+      opened
+      (with-open [^FileChannel channel opened]
+        (let [lock (attempt-lock channel file id)]
+          (if (anomaly/anomaly? lock)
+            lock
+            (call-with-lock lock thunk)))))))
 
 (defn ^{:stratum 2} read-record
   [dir id]

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/persistence.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/persistence.clj
@@ -1,0 +1,172 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.effect-transaction.persistence
+  "Atomic filesystem publication and per-transaction locking."
+  (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.effect-transaction.codec :as codec]
+   [ai.miniforge.effect-transaction.messages :as msg]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io])
+  (:import
+   [java.io File]
+   [java.nio.channels FileChannel]
+   [java.nio.file FileAlreadyExistsException Files StandardCopyOption StandardOpenOption]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} record-file
+  ^File [dir id]
+  (io/file dir (str id ".edn")))
+
+(defn- ^{:stratum 0} lock-file
+  ^File [dir id]
+  (io/file dir (str id ".lock")))
+
+(defn- ^{:stratum 0} temp-file
+  ^File [^File target]
+  (io/file (.getParentFile target)
+           (str (.getName target) "." (random-uuid) ".tmp")))
+
+(defn- ^{:stratum 0} read-failure
+  [^File file ex]
+  (anomaly/sub-anomaly :fault
+                       :anomalies.effect-transaction/read-failed
+                       (msg/t :store/read-failed)
+                       {:effect/path (.getPath file)
+                        :exception/message (some-> ex ex-message)}))
+
+(defn- ^{:stratum 0} write-failure
+  [^File file ex]
+  (anomaly/sub-anomaly :fault
+                       :anomalies.effect-transaction/write-failed
+                       (msg/t :store/write-failed)
+                       {:effect/path (.getPath file)
+                        :exception/message (some-> ex ex-message)}))
+
+(defn- ^{:stratum 0} id-conflict
+  [record]
+  (anomaly/sub-anomaly :conflict
+                       :anomalies.effect-transaction/id-conflict
+                       (msg/t :proposal/id-conflict)
+                       {:effect/id (:effect/id record)}))
+
+(defn- ^{:stratum 0} lock-conflict
+  [id]
+  (anomaly/sub-anomaly :conflict
+                       :anomalies.effect-transaction/lock-conflict
+                       (msg/t :store/lock-conflict)
+                       {:effect/id id}))
+
+(defn- ^{:stratum 0} anomaly-value
+  [value]
+  (when (anomaly/anomaly? value) value))
+
+(defn- ^{:stratum 0} link-target!
+  [^File tmp ^File target]
+  (Files/createLink (.toPath target) (.toPath tmp)))
+
+(defn- ^{:stratum 0} move-target!
+  [^File tmp ^File target]
+  (Files/move (.toPath tmp)
+              (.toPath target)
+              (into-array java.nio.file.CopyOption
+                          [StandardCopyOption/ATOMIC_MOVE
+                           StandardCopyOption/REPLACE_EXISTING])))
+
+(defn- ^{:stratum 0} call-with-lock
+  [lock thunk]
+  (try
+    (thunk)
+    (finally
+      (.release lock))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} read-file
+  [^File file]
+  (try
+    (codec/<-wire (edn/read-string (slurp file :encoding "UTF-8")))
+    (catch Exception ex
+      (read-failure file ex))))
+
+(defn- ^{:stratum 1} persist!
+  [^File target record publish!]
+  (let [^File tmp (temp-file target)]
+    (try
+      (io/make-parents target)
+      (spit tmp (pr-str (codec/->wire record)) :encoding "UTF-8")
+      (publish! tmp target)
+      record
+      (catch FileAlreadyExistsException _
+        (id-conflict record))
+      (catch Exception ex
+        (write-failure target ex))
+      (finally
+        (.delete tmp)))))
+
+(defn- ^{:stratum 1} attempt-locked-call
+  [^FileChannel channel id thunk]
+  (if-let [lock (.tryLock channel)]
+    (call-with-lock lock thunk)
+    (lock-conflict id)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} create!
+  [dir record]
+  (persist! (record-file dir (:effect/id record)) record link-target!))
+
+(defn ^{:stratum 2} replace!
+  [dir record]
+  (persist! (record-file dir (:effect/id record)) record move-target!))
+
+(defn ^{:stratum 2} with-record-lock
+  [dir id thunk]
+  (let [^File file (lock-file dir id)
+        options (into-array StandardOpenOption
+                            [StandardOpenOption/CREATE
+                             StandardOpenOption/WRITE])]
+    (try
+      (io/make-parents file)
+      (with-open [^FileChannel channel (FileChannel/open (.toPath file) options)]
+        (attempt-locked-call channel id thunk))
+      (catch Exception ex
+        (if (= "java.nio.channels.OverlappingFileLockException"
+               (.getName (class ex)))
+          (lock-conflict id)
+          (write-failure file ex))))))
+
+(defn ^{:stratum 2} read-record
+  [dir id]
+  (let [^File file (record-file dir id)]
+    (when (.exists file)
+      (read-file file))))
+
+(defn ^{:stratum 2} list-records
+  [dir]
+  (let [^File directory (io/file dir)
+        files (.listFiles directory)
+        xform (comp (filter #(.endsWith (.getName ^File %) ".edn"))
+                    (map read-file))]
+    (cond
+      (not (.isDirectory directory)) []
+      (nil? files) (read-failure directory nil)
+      :else
+      (let [records (into [] xform files)]
+        (or (some anomaly-value records) records)))))

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/persistence.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/persistence.clj
@@ -147,6 +147,8 @@
       (with-open [^FileChannel channel (FileChannel/open (.toPath file) options)]
         (attempt-locked-call channel id thunk))
       (catch Exception ex
+        ;; Babashka does not expose OverlappingFileLockException as a
+        ;; resolvable class, so keep this JVM/BB-compatible boundary check.
         (if (= "java.nio.channels.OverlappingFileLockException"
                (.getName (class ex)))
           (lock-conflict id)

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/record.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/record.clj
@@ -25,7 +25,8 @@
    [malli.core :as m]
    [malli.error :as me])
   (:import
-   [java.time Instant]))
+   [java.time Instant]
+   [java.util Date]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -57,17 +58,21 @@
                        message
                        data))
 
-;------------------------------------------------------------------------------ Layer 1
+(defn- ^{:stratum 0} normalize-instant
+  [value]
+  (if (instance? Date value)
+    (.toInstant ^Date value)
+    value))
 
-(defn ^{:stratum 1} not-found
-  "Return a conflict for a transaction absent from the durable store."
-  [id]
-  (wrong-state (msg/t :record/not-found) {:effect/id id}))
+(def ^{:stratum 0} not-found store/not-found)
+
+;------------------------------------------------------------------------------ Layer 1
 
 (defn ^{:stratum 1} advance!
   "Compare-and-set `changes` against the exact durable value of `t`."
   [dir t changes ^Instant now]
-  (let [t' (assoc (merge t changes) :effect/updated-at now)]
+  (let [t' (assoc (merge t changes)
+                  :effect/updated-at (normalize-instant now))]
     (if (valid? t')
       (store/transition! dir t t')
       (invalid (msg/t :record/change-invalid) t'))))
@@ -82,14 +87,15 @@
                           {})
      (propose! dir opts (Instant/now))))
   ([dir {:keys [effect-id effect-class grant-id envelope-id proposal]} ^Instant now]
-   (let [t {:effect/id (if (some? effect-id) effect-id (random-uuid))
+   (let [at (normalize-instant now)
+         t {:effect/id (if (some? effect-id) effect-id (random-uuid))
             :effect/class effect-class
             :effect/grant-id grant-id
             :effect/envelope-id envelope-id
             :effect/proposal (if proposal proposal {})
             :effect/state :proposed
-            :effect/at now
-            :effect/updated-at now}]
+            :effect/at at
+            :effect/updated-at at}]
      (if (valid? t)
        (store/create! dir t)
        (invalid (msg/t :record/input-invalid) t)))))

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/record.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/record.clj
@@ -59,12 +59,17 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
+(defn ^{:stratum 1} not-found
+  "Return a conflict for a transaction absent from the durable store."
+  [id]
+  (wrong-state (msg/t :record/not-found) {:effect/id id}))
+
 (defn ^{:stratum 1} advance!
-  "Apply `changes` to `t`, validate, and persist the new record atomically."
+  "Compare-and-set `changes` against the exact durable value of `t`."
   [dir t changes ^Instant now]
   (let [t' (assoc (merge t changes) :effect/updated-at now)]
     (if (valid? t')
-      (do (store/write! dir t') t')
+      (store/transition! dir t t')
       (invalid (msg/t :record/change-invalid) t'))))
 
 (defn ^{:stratum 1} propose!
@@ -76,8 +81,8 @@
                           (msg/t :proposal/no-store)
                           {})
      (propose! dir opts (Instant/now))))
-  ([dir {:keys [effect-class grant-id envelope-id proposal]} ^Instant now]
-   (let [t {:effect/id (random-uuid)
+  ([dir {:keys [effect-id effect-class grant-id envelope-id proposal]} ^Instant now]
+   (let [t {:effect/id (if (some? effect-id) effect-id (random-uuid))
             :effect/class effect-class
             :effect/grant-id grant-id
             :effect/envelope-id envelope-id
@@ -86,5 +91,5 @@
             :effect/at now
             :effect/updated-at now}]
      (if (valid? t)
-       (do (store/write! dir t) t)
+       (store/create! dir t)
        (invalid (msg/t :record/input-invalid) t)))))

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/record.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/record.clj
@@ -64,8 +64,6 @@
     (.toInstant ^Date value)
     value))
 
-(def ^{:stratum 0} not-found store/not-found)
-
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn ^{:stratum 1} advance!

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/record.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/record.clj
@@ -72,9 +72,7 @@
   "Compare-and-set `changes` against the exact durable value of `t`."
   [dir t changes ^Instant now]
   (if (not= (:effect/id t) (get changes :effect/id (:effect/id t)))
-    (wrong-state (msg/t :record/id-immutable)
-                 {:effect/id (:effect/id t)
-                  :effect/requested-id (:effect/id changes)})
+    (store/identity-conflict t changes)
     (let [t' (assoc (merge t changes)
                     :effect/updated-at (normalize-instant now))]
       (if (valid? t')

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/record.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/record.clj
@@ -71,11 +71,15 @@
 (defn ^{:stratum 1} advance!
   "Compare-and-set `changes` against the exact durable value of `t`."
   [dir t changes ^Instant now]
-  (let [t' (assoc (merge t changes)
-                  :effect/updated-at (normalize-instant now))]
-    (if (valid? t')
-      (store/transition! dir t t')
-      (invalid (msg/t :record/change-invalid) t'))))
+  (if (not= (:effect/id t) (get changes :effect/id (:effect/id t)))
+    (wrong-state (msg/t :record/id-immutable)
+                 {:effect/id (:effect/id t)
+                  :effect/requested-id (:effect/id changes)})
+    (let [t' (assoc (merge t changes)
+                    :effect/updated-at (normalize-instant now))]
+      (if (valid? t')
+        (store/transition! dir t t')
+        (invalid (msg/t :record/change-invalid) t')))))
 
 (defn ^{:stratum 1} propose!
   "Record an irreversible effect durably before anything happens."

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/store.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/store.clj
@@ -43,6 +43,15 @@
                         :effect/expected-state (:effect/state expected)
                         :effect/current-state (:effect/state current)}))
 
+(defn ^{:stratum 0} identity-conflict
+  "Return a conflict when a transition attempts to replace record identity."
+  [expected replacement]
+  (anomaly/sub-anomaly :conflict
+                       :anomalies.effect-transaction/wrong-state
+                       (msg/t :record/id-immutable)
+                       {:effect/id (:effect/id expected)
+                        :effect/requested-id (:effect/id replacement)}))
+
 (defn ^{:stratum 0} create!
   "Publish one complete proposal without replacing an existing effect ID."
   [dir record]
@@ -74,6 +83,8 @@
 (defn ^{:stratum 2} transition!
   "Replace `expected` only when it is still the exact durable record."
   [dir expected replacement]
-  (let [id (:effect/id expected)]
-    (persistence/with-record-lock
-     dir id (partial transition-under-lock dir expected replacement))))
+  (if (not= (:effect/id expected) (:effect/id replacement))
+    (identity-conflict expected replacement)
+    (let [id (:effect/id expected)]
+      (persistence/with-record-lock
+       dir id (partial transition-under-lock dir expected replacement)))))

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/store.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/store.clj
@@ -26,6 +26,14 @@
 
 (def ^{:stratum 0} record-file persistence/record-file)
 
+(defn ^{:stratum 0} not-found
+  "Return a conflict for a transaction absent from the durable store."
+  [id]
+  (anomaly/sub-anomaly :conflict
+                       :anomalies.effect-transaction/not-found
+                       (msg/t :record/not-found)
+                       {:effect/id id}))
+
 (defn- ^{:stratum 0} transition-conflict
   [expected current]
   (anomaly/sub-anomaly :conflict
@@ -57,6 +65,7 @@
   (let [current (persistence/read-record dir (:effect/id expected))]
     (cond
       (anomaly/anomaly? current) current
+      (nil? current) (not-found (:effect/id expected))
       (not= expected current) (transition-conflict expected current)
       :else (persistence/replace! dir replacement))))
 

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/store.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/store.clj
@@ -16,130 +16,55 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns ai.miniforge.effect-transaction.store
-  "Durable storage for EffectTransactions (Ariadne step 2c).
-
-   Records land with the same atomic discipline the operator
-   intervention path already uses (`operator_requests.clj`
-   `write-event-file!`): write a sibling `.tmp`, then `Files/move` with
-   ATOMIC_MOVE. A reader can never observe a half-written record, and
-   the `.tmp` suffix keeps partials out of the `.edn` listing.
-
-   The rule that discipline exists to enforce: a transaction that did
-   not reach disk MUST NOT report a committed effect. If we cannot
-   record that we are about to do something irreversible, we do not do
-   it — otherwise the first thing a crash destroys is the evidence that
-   the effect was ever attempted."
+  "Create-only transaction storage and exact-value lifecycle transitions."
   (:require
-   [clojure.edn :as edn]
-   [clojure.java.io :as io])
-  (:import
-   [java.io File]
-   [java.nio.file Files StandardCopyOption]
-   [java.time Instant]
-   [java.util Date]))
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.effect-transaction.messages :as msg]
+   [ai.miniforge.effect-transaction.persistence :as persistence]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
-;; Wire form
-(def ^{:stratum 0} instant-keys
-  "Record keys holding an Instant. EDN has no reader for
-   `java.time.Instant`, so these cross the disk boundary as ISO-8601
-   strings and are parsed back on read — explicit, rather than relying
-   on a print form that does not round-trip."
-  [:effect/at :effect/updated-at])
+(def ^{:stratum 0} record-file persistence/record-file)
 
-(defn ^{:stratum 0} record-file
-  "Path for one record: `{dir}/{id}.edn`."
-  ^File [dir id]
-  (io/file dir (str id ".edn")))
+(defn- ^{:stratum 0} transition-conflict
+  [expected current]
+  (anomaly/sub-anomaly :conflict
+                       :anomalies.effect-transaction/transition-conflict
+                       (msg/t :record/transition-conflict)
+                       {:effect/id (:effect/id expected)
+                        :effect/expected-state (:effect/state expected)
+                        :effect/current-state (:effect/state current)}))
 
-(defn ^{:stratum 0} ->iso
-  "Timestamp -> ISO-8601 string, by actual type rather than by type hint.
+(defn ^{:stratum 0} create!
+  "Publish one complete proposal without replacing an existing effect ID."
+  [dir record]
+  (persistence/create! dir record))
 
-   The schema says `inst?`, and `inst?` admits BOTH `java.time.Instant`
-   and `java.util.Date` — so a record the schema accepts can arrive here
-   holding either. Both are normalized; anything else throws.
+(defn ^{:stratum 0} read-record
+  "Read one record by id, nil when absent, or an anomaly on corruption."
+  [dir id]
+  (persistence/read-record dir id))
 
-   Throwing is the right answer for a store: persisting a value that
-   cannot be read back turns a durable record into a landmine that only
-   goes off later, when someone is trying to reconcile an effect they
-   already performed.
-
-   Strings are NOT waved through. A string that happens not to parse
-   would persist fine and only fail on the way back out — which is the
-   landmine this is meant to prevent, just relocated."
-  ^String [v]
-  (cond
-    (instance? Instant v) (.toString ^Instant v)
-    (instance? Date v) (.toString (.toInstant ^Date v))
-    :else (throw (ex-info "EffectTransaction timestamp is not a supported instant type"
-                          {:value v :type (some-> v class .getName)}))))
+(defn ^{:stratum 0} list-records
+  "Read every complete transaction record under `dir`."
+  [dir]
+  (persistence/list-records dir))
 
 ;------------------------------------------------------------------------------ Layer 1
 
-(defn ^{:stratum 1} ->wire
-  "Record -> EDN-safe map (timestamps to ISO-8601 strings)."
-  [record]
-  (reduce (fn [acc k]
-            (if (some? (get acc k))
-              (assoc acc k (->iso (get acc k)))
-              acc))
-          record
-          instant-keys))
-
-(defn ^{:stratum 1} <-wire
-  "EDN map -> record (ISO-8601 strings back to Instants). Reading is
-   deliberately strict: a stored value that will not parse is corruption
-   and must surface, not be silently carried forward as a string."
-  [m]
-  (reduce (fn [acc k]
-            (if-let [v (get acc k)]
-              (assoc acc k (Instant/parse v))
-              acc))
-          m
-          instant-keys))
+(defn- ^{:stratum 1} transition-under-lock
+  [dir expected replacement]
+  (let [current (persistence/read-record dir (:effect/id expected))]
+    (cond
+      (anomaly/anomaly? current) current
+      (not= expected current) (transition-conflict expected current)
+      :else (persistence/replace! dir replacement))))
 
 ;------------------------------------------------------------------------------ Layer 2
 
-;; Atomic write
-(defn ^{:stratum 2} write!
-  "Persist `record` under `dir` atomically. Returns the target File.
-
-   Throws if the write cannot complete — callers MUST treat that as
-   'the effect did not happen and must not be attempted', never as a
-   soft failure to log past."
-  ^File [dir record]
-  (let [^File target (record-file dir (:effect/id record))
-        _ (io/make-parents target)
-        ^File tmp (io/file (.getParentFile target) (str (.getName target) ".tmp"))]
-    (spit tmp (pr-str (->wire record)) :encoding "UTF-8")
-    (Files/move (.toPath tmp)
-                (.toPath target)
-                (into-array java.nio.file.CopyOption
-                            [StandardCopyOption/ATOMIC_MOVE
-                             StandardCopyOption/REPLACE_EXISTING]))
-    target))
-
-(defn ^{:stratum 2} read-record
-  "Read one record by id, or nil when absent."
-  [dir id]
-  (let [^File f (record-file dir id)]
-    (when (.exists f)
-      (<-wire (edn/read-string (slurp f :encoding "UTF-8"))))))
-
-;; Listing
-(defn ^{:stratum 2} list-records
-  "Every persisted record under `dir`. `.tmp` files are skipped by the
-   `.edn` suffix filter — a partial write is never mistaken for a
-   record."
-  [dir]
-  (let [^File d (io/file dir)
-        ;; Bound rather than inlined: as an inline `(comp ...)` argument
-        ;; this read as a 2-arity `into` to two reviewers running, which
-        ;; is reason enough to name it even though the 3-arity form was
-        ;; correct.
-        xform (comp (filter #(.endsWith (.getName ^File %) ".edn"))
-                    (map #(<-wire (edn/read-string (slurp % :encoding "UTF-8")))))]
-    (if-not (.isDirectory d)
-      []
-      (into [] xform (.listFiles d)))))
+(defn ^{:stratum 2} transition!
+  "Replace `expected` only when it is still the exact durable record."
+  [dir expected replacement]
+  (let [id (:effect/id expected)]
+    (persistence/with-record-lock
+     dir id (partial transition-under-lock dir expected replacement))))

--- a/components/effect-transaction/test/ai/miniforge/effect_transaction/reconcile_test.clj
+++ b/components/effect-transaction/test/ai/miniforge/effect_transaction/reconcile_test.clj
@@ -113,17 +113,18 @@
   ;; reconciliation exists for.
   (let [dir (tmp-dir)
         g (merge-grant)
-        t (propose-merge! dir g)
-        ;; simulate the crash: the record reached :committing and nothing
-        ;; ever wrote an outcome
-        crashed (assoc t :effect/state :committing)
-        settled (fx/reconcile! dir crashed
-                               (fn [_] {:effect/observed {:pr/state "OPEN"}
-                                        :effect/matched? false})
-                               later)]
-    (is (contains? fx/reconcilable-states :committing))
-    (is (= :reconciled (:effect/state settled)))
-    (is (false? (:effect/matched? settled)))))
+        t (propose-merge! dir g)]
+    (is (thrown? AssertionError
+                 (fx/commit! dir t g {} now
+                             (fn [] (throw (AssertionError.))))))
+    (let [crashed (fx/read-record dir (:effect/id t))
+          settled (fx/reconcile! dir crashed
+                                 (fn [_] {:effect/observed {:pr/state "OPEN"}
+                                          :effect/matched? false})
+                                 later)]
+      (is (contains? fx/reconcilable-states :committing))
+      (is (= :reconciled (:effect/state settled)))
+      (is (false? (:effect/matched? settled))))))
 
 (deftest ^{:stratum 1} refusal-anomalies-route-correctly-test
   ;; :unauthorized would say "you lack permission", which is neither

--- a/components/effect-transaction/test/ai/miniforge/effect_transaction/store_test.clj
+++ b/components/effect-transaction/test/ai/miniforge/effect_transaction/store_test.clj
@@ -57,6 +57,19 @@
     (spit (store/record-file dir id) "{:effect/id" :encoding "UTF-8")
     (is (anomaly/anomaly? (fx/read-record dir id)))))
 
+(deftest ^{:stratum 1} proposal-normalizes-schema-valid-date-test
+  (let [dir (tmp-dir)
+        id (random-uuid)
+        t (fx/propose! dir {:effect-id id
+                            :effect-class :effect/merge
+                            :grant-id (random-uuid)
+                            :envelope-id (random-uuid)}
+                       (Date/from now))
+        committing (assoc t :effect/state :committing)]
+    (is (= id (:effect/id t)))
+    (is (instance? Instant (:effect/at t)))
+    (is (= committing (store/transition! dir t committing)))))
+
 ;------------------------------------------------------------------------------ Layer 2
 
 (deftest ^{:stratum 2} schema-is-closed-test
@@ -108,7 +121,13 @@
     (testing "a stale expected value cannot replace the durable record"
       (let [result (store/transition! dir t (assoc t :effect/state :succeeded))]
         (is (anomaly/anomaly? result))
-        (is (= :committing (:effect/state (fx/read-record dir (:effect/id t)))))))))
+        (is (= :committing (:effect/state (fx/read-record dir (:effect/id t)))))))
+    (testing "a missing durable value is reported as not found"
+      (let [missing (record)
+            result (store/transition! dir missing
+                                      (assoc missing :effect/state :committing))]
+        (is (= :anomalies.effect-transaction/not-found
+               (:anomaly/subtype result)))))))
 
 (deftest ^{:stratum 2} both-inst-types-round-trip-test
   ;; The schema says `inst?`, and `inst?` admits java.util.Date as well

--- a/components/effect-transaction/test/ai/miniforge/effect_transaction/store_test.clj
+++ b/components/effect-transaction/test/ai/miniforge/effect_transaction/store_test.clj
@@ -22,6 +22,8 @@
   (:require
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.effect-transaction.interface :as fx]
+   [ai.miniforge.effect-transaction.persistence :as persistence]
+   [ai.miniforge.effect-transaction.record :as effect-record]
    [ai.miniforge.effect-transaction.store :as store]
    [clojure.test :refer [deftest is testing]])
   (:import
@@ -56,6 +58,15 @@
         id (random-uuid)]
     (spit (store/record-file dir id) "{:effect/id" :encoding "UTF-8")
     (is (anomaly/anomaly? (fx/read-record dir id)))))
+
+(deftest ^{:stratum 1} lock-does-not-reclassify-application-errors-test
+  (let [dir (tmp-dir)
+        id (random-uuid)]
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (persistence/with-record-lock
+                  dir id #(throw (ex-info "application failure" {})))))
+    (is (= :released
+           (persistence/with-record-lock dir id (constantly :released))))))
 
 (deftest ^{:stratum 1} proposal-normalizes-schema-valid-date-test
   (let [dir (tmp-dir)
@@ -127,7 +138,15 @@
             result (store/transition! dir missing
                                       (assoc missing :effect/state :committing))]
         (is (= :anomalies.effect-transaction/not-found
-               (:anomaly/subtype result)))))))
+               (:anomaly/subtype result)))))
+    (testing "a lifecycle change cannot replace the durable identity"
+      (let [other-id (random-uuid)
+            result (effect-record/advance! dir committing
+                                           {:effect/id other-id}
+                                           now)]
+        (is (anomaly/anomaly? result))
+        (is (= committing (fx/read-record dir (:effect/id t))))
+        (is (nil? (fx/read-record dir other-id)))))))
 
 (deftest ^{:stratum 2} both-inst-types-round-trip-test
   ;; The schema says `inst?`, and `inst?` admits java.util.Date as well

--- a/components/effect-transaction/test/ai/miniforge/effect_transaction/store_test.clj
+++ b/components/effect-transaction/test/ai/miniforge/effect_transaction/store_test.clj
@@ -20,7 +20,9 @@
    with the writer. That is what makes 'the record exists before the
    effect' a claim rather than a hope."
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.effect-transaction.interface :as fx]
+   [ai.miniforge.effect-transaction.store :as store]
    [clojure.test :refer [deftest is testing]])
   (:import
    [java.nio.file Files]
@@ -49,6 +51,12 @@
            :effect/updated-at now}
           overrides)))
 
+(deftest ^{:stratum 1} corrupt-record-is-returned-as-data-test
+  (let [dir (tmp-dir)
+        id (random-uuid)]
+    (spit (store/record-file dir id) "{:effect/id" :encoding "UTF-8")
+    (is (anomaly/anomaly? (fx/read-record dir id)))))
+
 ;------------------------------------------------------------------------------ Layer 2
 
 (deftest ^{:stratum 2} schema-is-closed-test
@@ -68,7 +76,7 @@
 (deftest ^{:stratum 2} record-survives-to-a-fresh-reader-test
   (let [dir (tmp-dir)
         t (record)]
-    (fx/write! dir t)
+    (store/create! dir t)
     (testing "a reader sharing no memory with the writer finds it whole"
       (let [from-disk (fx/read-record dir (:effect/id t))]
         (is (= (:effect/id t) (:effect/id from-disk)))
@@ -81,7 +89,7 @@
 
 (deftest ^{:stratum 2} listing-skips-partials-and-missing-dirs-test
   (let [dir (tmp-dir)]
-    (dotimes [_ 3] (fx/write! dir (record)))
+    (dotimes [_ 3] (store/create! dir (record)))
     (is (= 3 (count (fx/list-records dir))))
     (testing "a .tmp partial is never mistaken for a record"
       (spit (str dir "/half-written.edn.tmp") "{:effect/id ")
@@ -89,15 +97,18 @@
     (testing "listing a directory that does not exist is empty, not an error"
       (is (= [] (fx/list-records (str dir "/nope")))))))
 
-(deftest ^{:stratum 2} rewrite-replaces-in-place-test
-  ;; State advances rewrite the same record; the store must replace
-  ;; rather than accumulate, or a reader could find two truths.
+(deftest ^{:stratum 2} compare-and-set-replaces-the-exact-record-test
   (let [dir (tmp-dir)
-        t (record)]
-    (fx/write! dir t)
-    (fx/write! dir (assoc t :effect/state :committing))
+        t (record)
+        committing (assoc t :effect/state :committing)]
+    (store/create! dir t)
+    (is (= committing (store/transition! dir t committing)))
     (is (= 1 (count (fx/list-records dir))))
-    (is (= :committing (:effect/state (fx/read-record dir (:effect/id t)))))))
+    (is (= :committing (:effect/state (fx/read-record dir (:effect/id t)))))
+    (testing "a stale expected value cannot replace the durable record"
+      (let [result (store/transition! dir t (assoc t :effect/state :succeeded))]
+        (is (anomaly/anomaly? result))
+        (is (= :committing (:effect/state (fx/read-record dir (:effect/id t)))))))))
 
 (deftest ^{:stratum 2} both-inst-types-round-trip-test
   ;; The schema says `inst?`, and `inst?` admits java.util.Date as well
@@ -108,20 +119,16 @@
         as-date (record {:effect/at (Date/from now)})
         as-instant (record {:effect/at now})]
     (is (fx/valid? as-date) "a Date is a valid :effect/at per the schema")
-    (fx/write! dir as-date)
-    (fx/write! dir as-instant)
+    (store/create! dir as-date)
+    (store/create! dir as-instant)
     (is (= now (:effect/at (fx/read-record dir (:effect/id as-date))))
         "a Date normalizes to the same instant on the way out")
     (is (= now (:effect/at (fx/read-record dir (:effect/id as-instant)))))))
 
-(deftest ^{:stratum 2} unsupported-timestamp-throws-rather-than-persisting-test
-  ;; Persisting a value that cannot be read back turns a durable record
-  ;; into a landmine that only goes off later, when someone is trying to
-  ;; reconcile an effect they already performed.
-  (let [dir (tmp-dir)]
-    (testing "a number is refused"
-      (is (thrown? clojure.lang.ExceptionInfo
-                   (fx/write! dir (record {:effect/updated-at 12345})))))
-    (testing "a string is refused too — it would persist and fail only on READ"
-      (is (thrown? clojure.lang.ExceptionInfo
-                   (fx/write! dir (record {:effect/at "not-a-timestamp-at-all"})))))))
+(deftest ^{:stratum 2} duplicate-id-does-not-replace-the-first-record-test
+  (let [dir (tmp-dir)
+        original (record)
+        replacement (assoc original :effect/proposal {:pr/number 99})]
+    (is (= original (store/create! dir original)))
+    (is (anomaly/anomaly? (store/create! dir replacement)))
+    (is (= original (fx/read-record dir (:effect/id original))))))

--- a/components/effect-transaction/test/ai/miniforge/effect_transaction/store_test.clj
+++ b/components/effect-transaction/test/ai/miniforge/effect_transaction/store_test.clj
@@ -147,6 +147,14 @@
                                       (assoc missing :effect/state :committing))]
         (is (= :anomalies.effect-transaction/not-found
                (:anomaly/subtype result)))))
+    (testing "the store itself refuses to write under a replacement identity"
+      (let [other-id (random-uuid)
+            result (store/transition! dir committing
+                                      (assoc committing :effect/id other-id))]
+        (is (= :anomalies.effect-transaction/wrong-state
+               (:anomaly/subtype result)))
+        (is (= committing (fx/read-record dir (:effect/id t))))
+        (is (nil? (fx/read-record dir other-id)))))
     (testing "a lifecycle change cannot replace the durable identity"
       (let [other-id (random-uuid)
             result (effect-record/advance! dir committing

--- a/components/effect-transaction/test/ai/miniforge/effect_transaction/store_test.clj
+++ b/components/effect-transaction/test/ai/miniforge/effect_transaction/store_test.clj
@@ -25,6 +25,7 @@
    [ai.miniforge.effect-transaction.persistence :as persistence]
    [ai.miniforge.effect-transaction.record :as effect-record]
    [ai.miniforge.effect-transaction.store :as store]
+   [clojure.java.io :as io]
    [clojure.test :refer [deftest is testing]])
   (:import
    [java.nio.file Files]
@@ -38,6 +39,13 @@
 
 (defn ^{:stratum 0} tmp-dir []
   (str (.toFile (Files/createTempDirectory "fx-store-test" (into-array FileAttribute [])))))
+
+(deftest ^{:stratum 0} directory-listing-failure-is-returned-as-data-test
+  (let [denied (proxy [java.io.File] ["denied"]
+                 (isDirectory [] true)
+                 (listFiles [] (throw (SecurityException. "denied"))))]
+    (with-redefs [io/file (constantly denied)]
+      (is (anomaly/anomaly? (persistence/list-records "denied"))))))
 
 ;------------------------------------------------------------------------------ Layer 1
 

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/merge_transaction_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/merge_transaction_test.clj
@@ -60,13 +60,6 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
-(defn ^{:stratum 1} pending-merge
-  []
-  (let [c (ctx)
-        t (mt/propose! c 42 "miniforge-ai/miniforge" now)]
-    {:context c
-     :pending (mt/commit! c t 42 now (ok-enable) (gh-returning open-json))}))
-
 (deftest ^{:stratum 1} parse-pr-view-test
   (is (= {:pr/state "MERGED" :merge/sha "squash-sha-on-base"}
          (mt/parse-pr-view merged-json)))
@@ -126,17 +119,25 @@
       (is (= (:effect/id t)
              (:effect/id (fx/read-record (:effect-store-dir c) (:effect/id t))))))))
 
+;; Strata are per-file: the imported commit boundary does not add a local layer.
+(defn- ^{:stratum 1} pending-merge!
+  []
+  (let [c (ctx)
+        t (mt/propose! c 42 "miniforge-ai/miniforge" now)]
+    {:context c
+     :pending (mt/commit! c t 42 now (ok-enable) (gh-returning open-json))}))
+
 ;------------------------------------------------------------------------------ Layer 2
 
 (deftest ^{:stratum 2} reconcile-settles-a-later-merge-test
   (testing "asking again after GitHub finishes settles it with the real SHA"
-    (let [{:keys [context pending]} (pending-merge)]
+    (let [{:keys [context pending]} (pending-merge!)]
       (is (nil? (mt/substantiated-sha pending)))
       (let [settled (mt/reconcile! context pending 42 later (gh-returning merged-json))]
         (is (= :reconciled (:effect/state settled)))
         (is (= "squash-sha-on-base" (mt/substantiated-sha settled))))))
   (testing "a PR that closed unmerged reconciles as a mismatch, not a merge"
-    (let [{:keys [context pending]} (pending-merge)
+    (let [{:keys [context pending]} (pending-merge!)
           settled (mt/reconcile! context pending 42 later
                                  (gh-returning "{\"state\":\"CLOSED\",\"mergeCommit\":null}"))]
       (is (= :reconciled (:effect/state settled)))

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/merge_transaction_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/merge_transaction_test.clj
@@ -60,6 +60,13 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
+(defn ^{:stratum 1} pending-merge
+  []
+  (let [c (ctx)
+        t (mt/propose! c 42 "miniforge-ai/miniforge" now)]
+    {:context c
+     :pending (mt/commit! c t 42 now (ok-enable) (gh-returning open-json))}))
+
 (deftest ^{:stratum 1} parse-pr-view-test
   (is (= {:pr/state "MERGED" :merge/sha "squash-sha-on-base"}
          (mt/parse-pr-view merged-json)))
@@ -109,22 +116,6 @@
         "GitHub not answering is not GitHub saying no")
     (is (nil? (mt/substantiated-sha settled)))))
 
-(deftest ^{:stratum 1} reconcile-settles-a-later-merge-test
-  (let [c (ctx)
-        t (mt/propose! c 42 "miniforge-ai/miniforge" now)
-        pending (mt/commit! c t 42 now (ok-enable) (gh-returning open-json))]
-    (is (nil? (mt/substantiated-sha pending)))
-    (testing "asking again after GitHub finishes settles it with the real SHA"
-      (let [settled (mt/reconcile! c pending 42 later (gh-returning merged-json))]
-        (is (= :reconciled (:effect/state settled)))
-        (is (= "squash-sha-on-base" (mt/substantiated-sha settled)))))
-    (testing "a PR that closed unmerged reconciles as a mismatch, not a merge"
-      (let [settled (mt/reconcile! c pending 42 later
-                                   (gh-returning "{\"state\":\"CLOSED\",\"mergeCommit\":null}"))]
-        (is (= :reconciled (:effect/state settled)))
-        (is (false? (:effect/matched? settled)))
-        (is (nil? (mt/substantiated-sha settled)))))))
-
 (deftest ^{:stratum 1} the-intent-is-on-disk-before-any-gh-command-test
   (let [c (ctx)
         t (mt/propose! c 42 "miniforge-ai/miniforge" now)]
@@ -134,3 +125,20 @@
     (testing "a reader sharing no memory with the writer finds it"
       (is (= (:effect/id t)
              (:effect/id (fx/read-record (:effect-store-dir c) (:effect/id t))))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} reconcile-settles-a-later-merge-test
+  (testing "asking again after GitHub finishes settles it with the real SHA"
+    (let [{:keys [context pending]} (pending-merge)]
+      (is (nil? (mt/substantiated-sha pending)))
+      (let [settled (mt/reconcile! context pending 42 later (gh-returning merged-json))]
+        (is (= :reconciled (:effect/state settled)))
+        (is (= "squash-sha-on-base" (mt/substantiated-sha settled))))))
+  (testing "a PR that closed unmerged reconciles as a mismatch, not a merge"
+    (let [{:keys [context pending]} (pending-merge)
+          settled (mt/reconcile! context pending 42 later
+                                 (gh-returning "{\"state\":\"CLOSED\",\"mergeCommit\":null}"))]
+      (is (= :reconciled (:effect/state settled)))
+      (is (false? (:effect/matched? settled)))
+      (is (nil? (mt/substantiated-sha settled))))))

--- a/docs/pull-requests/2026-08-07-codex-n7-effect-persistence-fencing.md
+++ b/docs/pull-requests/2026-08-07-codex-n7-effect-persistence-fencing.md
@@ -1,0 +1,70 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix: fence durable effect persistence
+
+## Overview
+
+Makes effect proposal publication create-only and lifecycle transitions atomic.
+Concurrent processes coordinate below effect orchestration through a durable,
+exact-record compare-and-set boundary.
+
+## Layer
+
+Foundations — durable effect identity and lifecycle persistence.
+
+## Depends on
+
+- #1697 (N7 grant issuance contract reconciliation) — merged
+- #1698 (zero-warning Polylith baseline) — merged
+
+## Strata Affected
+
+- Persistence — immutable publication, atomic replacement, and per-effect lock.
+- Store — transaction-level create and compare-and-set transitions.
+- Record — caller-preallocated identity and exact lifecycle advancement.
+- Tests — create-only, stale-transition, and storage-failure coverage.
+
+## Motivation
+
+A grant cannot be fenced to one irreversible effect if a duplicate proposal can
+replace the first record or two processes can both advance the same stale value.
+The storage boundary must make those operations indivisible before commit-time
+authorization and execution rely on them.
+
+## Changes in Detail
+
+- Persist caller-preallocated effect IDs with create-only publication.
+- Refuse duplicate IDs without replacing the original proposal.
+- Serialize per-effect transitions and compare the exact durable record.
+- Return read, write, and lock failures as localized anomaly values.
+- Remove the public raw-write escape hatch.
+
+## Testing Plan
+
+- Test duplicate proposal refusal without replacement.
+- Test stale compare-and-set refusal.
+- Test corrupted records and storage failures remain data-valued.
+- Run effect-transaction tests in every composing project.
+- Run Poly, Kondo, stratum lint, standards review, and full pre-commit.
+
+## Deployment Plan
+
+Merge to `main`; existing records remain readable and require no migration.
+
+## Related Issues/PRs
+
+- Prepares the follow-up commit-authorization and reconciliation fencing PR.
+- Blocks the N7 merge and deployment grant-enforcement work specs.
+
+## Checklist
+
+- [x] Proposal identity is caller-preallocated and create-only
+- [x] Duplicate IDs preserve the original transaction
+- [x] Lifecycle transitions use exact durable compare-and-set
+- [x] Storage failures are returned as anomaly values
+- [x] Poly reports zero errors and warnings
+- [x] Standards and pre-commit gates pass


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# fix: fence durable effect persistence

## Overview

Makes effect proposal publication create-only and lifecycle transitions atomic.
Concurrent processes coordinate below effect orchestration through a durable,
exact-record compare-and-set boundary.

## Layer

Foundations — durable effect identity and lifecycle persistence.

## Depends on

- #1697 (N7 grant issuance contract reconciliation) — merged
- #1698 (zero-warning Polylith baseline) — merged

## Strata Affected

- Persistence — immutable publication, atomic replacement, and per-effect lock.
- Store — transaction-level create and compare-and-set transitions.
- Record — caller-preallocated identity and exact lifecycle advancement.
- Tests — create-only, stale-transition, and storage-failure coverage.

## Motivation

A grant cannot be fenced to one irreversible effect if a duplicate proposal can
replace the first record or two processes can both advance the same stale value.
The storage boundary must make those operations indivisible before commit-time
authorization and execution rely on them.

## Changes in Detail

- Persist caller-preallocated effect IDs with create-only publication.
- Refuse duplicate IDs without replacing the original proposal.
- Serialize per-effect transitions and compare the exact durable record.
- Return read, write, and lock failures as localized anomaly values.
- Remove the public raw-write escape hatch.

## Testing Plan

- Test duplicate proposal refusal without replacement.
- Test stale compare-and-set refusal.
- Test corrupted records and storage failures remain data-valued.
- Run effect-transaction tests in every composing project.
- Run Poly, Kondo, stratum lint, standards review, and full pre-commit.

## Deployment Plan

Merge to `main`; existing records remain readable and require no migration.

## Related Issues/PRs

- Prepares the follow-up commit-authorization and reconciliation fencing PR.
- Blocks the N7 merge and deployment grant-enforcement work specs.

## Checklist

- [x] Proposal identity is caller-preallocated and create-only
- [x] Duplicate IDs preserve the original transaction
- [x] Lifecycle transitions use exact durable compare-and-set
- [x] Storage failures are returned as anomaly values
- [x] Poly reports zero errors and warnings
- [x] Standards and pre-commit gates pass
