### PR TITLE
fix: authorize and claim durable effects once

### DIFF
--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/authorization.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/authorization.clj
@@ -1,0 +1,60 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.effect-transaction.authorization
+  "Authorization derived exclusively from a durable effect proposal."
+  (:require
+   [ai.miniforge.effect-transaction.messages :as msg]
+   [ai.miniforge.effect-transaction.record :as record]
+   [ai.miniforge.execution-grant.interface :as grant])
+  (:import
+   [java.time Instant]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} effect-scope
+  [t]
+  (assoc (:effect/proposal t) :effect/id (:effect/id t)))
+
+(defn- ^{:stratum 0} grant-conflict
+  "Return a conflict when a grant is not the authority named by `t`."
+  [t grant-record]
+  (cond
+    (not= (:effect/grant-id t) (:grant/id grant-record))
+    (record/wrong-state (msg/t :grant/id-mismatch)
+                        {:effect/id (:effect/id t)
+                         :effect/grant-id (:effect/grant-id t)
+                         :grant/id (:grant/id grant-record)})
+
+    (not= (:effect/class t) (:grant/effect-class grant-record))
+    (record/wrong-state (msg/t :grant/effect-class-mismatch)
+                        {:effect/id (:effect/id t)
+                         :effect/class (:effect/class t)
+                         :grant/effect-class (:grant/effect-class grant-record)})
+
+    :else nil))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} evaluate
+  "Check the named grant against durable scope and a one-operation usage."
+  [t grant-record ^Instant now]
+  (or (grant-conflict t grant-record)
+      (grant/authorize grant-record
+                       {:effect/scope (effect-scope t)
+                        :usage/count 1}
+                       now)))

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/commit.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/commit.clj
@@ -19,37 +19,16 @@
   "Commit authorization and effect execution for durable proposals."
   (:require
    [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.effect-transaction.authorization :as authorization]
    [ai.miniforge.effect-transaction.call :as call]
    [ai.miniforge.effect-transaction.messages :as msg]
    [ai.miniforge.effect-transaction.record :as record]
+   [ai.miniforge.effect-transaction.store :as store]
    [ai.miniforge.execution-grant.interface :as grant])
   (:import
    [java.time Instant]))
 
 ;------------------------------------------------------------------------------ Layer 0
-
-(defn- ^{:stratum 0} authorization-context
-  "Attach the durable proposal as the effect scope being authorized."
-  [t usage]
-  (assoc usage :effect/scope (:effect/proposal t)))
-
-(defn- ^{:stratum 0} grant-conflict
-  "Return a conflict when a grant is not the authority named by `t`."
-  [t grant-record]
-  (cond
-    (not= (:effect/grant-id t) (:grant/id grant-record))
-    (record/wrong-state (msg/t :grant/id-mismatch)
-                      {:effect/id (:effect/id t)
-                       :effect/grant-id (:effect/grant-id t)
-                       :grant/id (:grant/id grant-record)})
-
-    (not= (:effect/class t) (:grant/effect-class grant-record))
-    (record/wrong-state (msg/t :grant/effect-class-mismatch)
-                      {:effect/id (:effect/id t)
-                       :effect/class (:effect/class t)
-                       :grant/effect-class (:grant/effect-class grant-record)})
-
-    :else nil))
 
 (defn- ^{:stratum 0} execute!
   "Persist the authority result, then perform and record the effect."
@@ -75,31 +54,38 @@
 
 (defn- ^{:stratum 1} authorized-commit!
   "Authorize the durable proposal, then execute or record refusal."
-  [dir t grant-record usage ^Instant now effect-fn]
-  (let [context (authorization-context t usage)
-        auth (grant/authorize grant-record context now)]
-    (if (grant/authorized? auth)
-      (execute! dir t :granted now effect-fn)
-      (deny! dir t auth now))))
+  [dir t grant-record ^Instant now effect-fn]
+  (let [auth (authorization/evaluate t grant-record now)]
+    (cond
+      (anomaly/anomaly? auth) auth
+      (grant/authorized? auth) (execute! dir t :granted now effect-fn)
+      :else (deny! dir t auth now))))
 
 ;------------------------------------------------------------------------------ Layer 2
 
 (defn ^{:stratum 2} commit!
   "Commit a proposed effect under its recorded grant.
 
-   The durable proposal, not caller usage, supplies authorization scope.
+   The durable proposal, not caller usage, supplies authorization scope and
+   the one-operation usage count.
    Exceptions from the effect become `:unknown-outcome`; JVM Errors
    propagate after the `:committing` record is durable."
-  [dir t grant-record usage ^Instant now effect-fn]
-  (cond
-    (not= :proposed (:effect/state t))
-    (record/wrong-state (msg/t :commit/not-proposed)
-                      {:effect/id (:effect/id t)
-                       :effect/state (:effect/state t)})
+  [dir candidate grant-record _usage ^Instant now effect-fn]
+  (let [id (:effect/id candidate)
+        t (store/read-record dir id)]
+    (cond
+      (anomaly/anomaly? t) t
 
-    (= :authority/unenforced grant-record)
-    (execute! dir t :unenforced now effect-fn)
+      (nil? t)
+      (store/not-found id)
 
-    :else
-    (or (grant-conflict t grant-record)
-        (authorized-commit! dir t grant-record usage now effect-fn))))
+      (not= :proposed (:effect/state t))
+      (record/wrong-state (msg/t :commit/not-proposed)
+                          {:effect/id (:effect/id t)
+                           :effect/state (:effect/state t)})
+
+      (= :authority/unenforced grant-record)
+      (execute! dir t :unenforced now effect-fn)
+
+      :else
+      (authorized-commit! dir t grant-record now effect-fn))))

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/commit.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/commit.clj
@@ -71,21 +71,23 @@
    Exceptions from the effect become `:unknown-outcome`; JVM Errors
    propagate after the `:committing` record is durable."
   [dir candidate grant-record _usage ^Instant now effect-fn]
-  (let [id (:effect/id candidate)
-        t (store/read-record dir id)]
-    (cond
-      (anomaly/anomaly? t) t
+  (let [id (:effect/id candidate)]
+    (if (nil? id)
+      (record/invalid (msg/t :record/input-invalid) candidate)
+      (let [t (store/read-record dir id)]
+        (cond
+          (anomaly/anomaly? t) t
 
-      (nil? t)
-      (store/not-found id)
+          (nil? t)
+          (store/not-found id)
 
-      (not= :proposed (:effect/state t))
-      (record/wrong-state (msg/t :commit/not-proposed)
-                          {:effect/id (:effect/id t)
-                           :effect/state (:effect/state t)})
+          (not= :proposed (:effect/state t))
+          (record/wrong-state (msg/t :commit/not-proposed)
+                              {:effect/id (:effect/id t)
+                               :effect/state (:effect/state t)})
 
-      (= :authority/unenforced grant-record)
-      (execute! dir t :unenforced now effect-fn)
+          (= :authority/unenforced grant-record)
+          (execute! dir t :unenforced now effect-fn)
 
-      :else
-      (authorized-commit! dir t grant-record now effect-fn))))
+          :else
+          (authorized-commit! dir t grant-record now effect-fn))))))

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/commit.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/commit.clj
@@ -71,23 +71,21 @@
    Exceptions from the effect become `:unknown-outcome`; JVM Errors
    propagate after the `:committing` record is durable."
   [dir candidate grant-record _usage ^Instant now effect-fn]
-  (let [id (:effect/id candidate)]
-    (if (nil? id)
-      (record/invalid (msg/t :record/input-invalid) candidate)
-      (let [t (store/read-record dir id)]
-        (cond
-          (anomaly/anomaly? t) t
+  (let [id (:effect/id candidate)
+        t (store/read-record dir id)]
+    (cond
+      (anomaly/anomaly? t) t
 
-          (nil? t)
-          (store/not-found id)
+      (nil? t)
+      (store/not-found id)
 
-          (not= :proposed (:effect/state t))
-          (record/wrong-state (msg/t :commit/not-proposed)
-                              {:effect/id (:effect/id t)
-                               :effect/state (:effect/state t)})
+      (not= :proposed (:effect/state t))
+      (record/wrong-state (msg/t :commit/not-proposed)
+                          {:effect/id (:effect/id t)
+                           :effect/state (:effect/state t)})
 
-          (= :authority/unenforced grant-record)
-          (execute! dir t :unenforced now effect-fn)
+      (= :authority/unenforced grant-record)
+      (execute! dir t :unenforced now effect-fn)
 
-          :else
-          (authorized-commit! dir t grant-record now effect-fn))))))
+      :else
+      (authorized-commit! dir t grant-record now effect-fn))))

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/interface.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/interface.clj
@@ -45,7 +45,7 @@
   schema/EffectTransaction)
 
 (def ^{:stratum 0} read-record
-  "Read one persisted record by id, nil, or a storage anomaly."
+  "Read one persisted record by UUID, nil, or an input/storage anomaly."
   store/read-record)
 
 (def ^{:stratum 0} list-records

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/interface.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/interface.clj
@@ -61,9 +61,10 @@
   core/propose!)
 
 (def ^{:stratum 0} commit!
-  "Re-check the grant, mark :committing, run the effect, record what it
-   reported. An Exception is :unknown-outcome, never :failed; a JVM Error
-   propagates after the durable claim."
+  "Reload the durable proposal, authorize its scope and one-operation count,
+   atomically mark :committing, run the effect, and record what it reported.
+   Caller usage is ignored. An Exception is :unknown-outcome, never :failed;
+   a JVM Error propagates after the durable claim."
   core/commit!)
 
 (def ^{:stratum 0} reconcile!

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/record.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/record.clj
@@ -35,7 +35,8 @@
   [t]
   (m/validate schema/EffectTransaction t))
 
-(defn- ^{:stratum 0} invalid
+(defn ^{:stratum 0} invalid
+  "Return the canonical schema-validation anomaly for effect input."
   [message t]
   (anomaly/sub-anomaly :invalid-input
                        :anomalies.effect-transaction/invalid

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/record.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/record.clj
@@ -35,8 +35,7 @@
   [t]
   (m/validate schema/EffectTransaction t))
 
-(defn ^{:stratum 0} invalid
-  "Return the canonical schema-validation anomaly for effect input."
+(defn- ^{:stratum 0} invalid
   [message t]
   (anomaly/sub-anomaly :invalid-input
                        :anomalies.effect-transaction/invalid

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/store.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/store.clj
@@ -26,6 +26,13 @@
 
 (def ^{:stratum 0} record-file persistence/record-file)
 
+(defn- ^{:stratum 0} invalid-id
+  [id]
+  (anomaly/sub-anomaly :invalid-input
+                       :anomalies.effect-transaction/invalid
+                       (msg/t :record/input-invalid)
+                       {:effect/id id}))
+
 (defn ^{:stratum 0} not-found
   "Return a conflict for a transaction absent from the durable store."
   [id]
@@ -57,17 +64,20 @@
   [dir record]
   (persistence/create! dir record))
 
-(defn ^{:stratum 0} read-record
-  "Read one record by id, nil when absent, or an anomaly on corruption."
-  [dir id]
-  (persistence/read-record dir id))
-
 (defn ^{:stratum 0} list-records
   "Read every complete transaction record under `dir`."
   [dir]
   (persistence/list-records dir))
 
 ;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} read-record
+  "Read one record by UUID, nil when absent, or an anomaly on invalid input
+   or corruption."
+  [dir id]
+  (if (uuid? id)
+    (persistence/read-record dir id)
+    (invalid-id id)))
 
 (defn- ^{:stratum 1} transition-under-lock
   [dir expected replacement]

--- a/components/effect-transaction/test/ai/miniforge/effect_transaction/commit_test.clj
+++ b/components/effect-transaction/test/ai/miniforge/effect_transaction/commit_test.clj
@@ -100,86 +100,82 @@
             done (fx/commit! dir t g no-usage now (constantly nil))]
         (is (= :unknown-outcome (:effect/state done)))))))
 
-(deftest ^{:stratum 1} commit-rechecks-the-grant-test
-  ;; Ariadne 2b Group 4: a constraint checked only at decide() is a check
-  ;; against stale state.
-  (testing "a grant revoked after the proposal fails the commit, and the effect never fires"
-    (let [dir (tmp-dir)
-          {g :grant t :transaction} (merge-case! dir)
-          revoked (grant/revoke g :breach/cost-exceeded now)
-          fired (atom false)
-          done (fx/commit! dir t revoked no-usage now
+(deftest ^{:stratum 1} revoked-grant-recheck-denies-effect-test
+  ;; A constraint checked only at decide time is a check against stale state.
+  (let [dir (tmp-dir)
+        {g :grant t :transaction} (merge-case! dir)
+        revoked (grant/revoke g :breach/cost-exceeded now)
+        fired (atom false)
+        done (fx/commit! dir t revoked no-usage now
+                         (partial record-success! fired))]
+    (is (= :failed (:effect/state done)))
+    (is (not @fired) "the effect MUST NOT fire when the re-check refuses")
+    (is (re-find #"inactive" (:effect/failure done)))))
+
+(deftest ^{:stratum 1} expired-grant-recheck-denies-effect-test
+  (let [dir (tmp-dir)
+        {g :grant t :transaction} (merge-case! dir)
+        fired (atom false)
+        done (fx/commit! dir t g no-usage much-later
+                         (partial record-success! fired))]
+    (is (= :failed (:effect/state done)))
+    (is (not @fired))))
+
+(deftest ^{:stratum 1} caller-cannot-fabricate-breached-usage-test
+  (let [dir (tmp-dir)
+        {g :grant t :transaction} (merge-case! dir)
+        fired (atom false)
+        done (fx/commit! dir t g (claimed-usage 99) now
+                         (partial record-success! fired))]
+    (is (= :succeeded (:effect/state done)))
+    (is @fired)))
+
+(deftest ^{:stratum 1} caller-zero-cannot-bypass-derived-count-test
+  (let [dir (tmp-dir)
+        {g :grant t :transaction}
+        (merge-case! dir {:constraints {:constraint/max-count 0}})
+        fired (atom false)
+        done (fx/commit! dir t g (claimed-usage 0) now
+                         (partial record-success! fired))]
+    (is (= :failed (:effect/state done)))
+    (is (not @fired))))
+
+(deftest ^{:stratum 1} missing-grant-leaves-proposal-untouched-test
+  ;; A missing argument is a caller conflict, not an authority lapse that
+  ;; should permanently fail the durable transaction.
+  (let [dir (tmp-dir)
+        {t :transaction} (merge-case! dir)
+        fired (atom false)
+        result (fx/commit! dir t nil no-usage now
                            (partial record-success! fired))]
-      (is (= :failed (:effect/state done)))
-      (is (not @fired) "the effect MUST NOT fire when the re-check refuses")
-      (is (re-find #"inactive" (:effect/failure done)))))
+    (is (anomaly/anomaly? result))
+    (is (not @fired))
+    (is (= :proposed (:effect/state (fx/read-record dir (:effect/id t)))))))
 
-  (testing "a grant that expired between propose and commit fails the commit"
-    (let [dir (tmp-dir)
-          {g :grant t :transaction} (merge-case! dir)
-          fired (atom false)
-          done (fx/commit! dir t g no-usage much-later
-                           (partial record-success! fired))]
-      (is (= :failed (:effect/state done)))
-      (is (not @fired))))
-
-  (testing "caller-supplied usage cannot fabricate a breached ceiling"
-    (let [dir (tmp-dir)
-          {g :grant t :transaction} (merge-case! dir)
-          fired (atom false)
-          done (fx/commit! dir t g (claimed-usage 99) now
-                           (partial record-success! fired))]
-      (is (= :succeeded (:effect/state done)))
-      (is @fired)))
-
-  (testing "caller-supplied zero cannot bypass the derived operation count"
-    (let [dir (tmp-dir)
-          {g :grant t :transaction}
-          (merge-case! dir {:constraints {:constraint/max-count 0}})
-          fired (atom false)
-          done (fx/commit! dir t g (claimed-usage 0) now
-                           (partial record-success! fired))]
-      (is (= :failed (:effect/state done)))
-      (is (not @fired))))
-
-  (testing "no grant at all is refused as a mismatch, and the record is untouched"
-    ;; Distinct from a revoked-or-expired grant above: passing nil when
-    ;; the record NAMES a grant is a caller supplying the wrong argument,
-    ;; not the authority lapsing. Marking the record :failed for that
-    ;; would blame the transaction for the caller's mistake.
-    (let [dir (tmp-dir)
-          {t :transaction} (merge-case! dir)
-          fired (atom false)
-          result (fx/commit! dir t nil no-usage now
-                             (partial record-success! fired))]
-      (is (anomaly/anomaly? result))
-      (is (not @fired))
-      (is (= :proposed (:effect/state (fx/read-record dir (:effect/id t))))
-          "the durable record is left as it was"))))
-
-(deftest ^{:stratum 1} only-a-proposed-record-may-be-committed-test
+(deftest ^{:stratum 1} falsey-proposals-retain-empty-default-test
   (let [dir (tmp-dir)]
-    (testing "falsey proposals retain the empty-map default"
-      (doseq [proposal [nil false]]
-        (let [g (merge-grant)
-              t (propose-merge! dir g proposal)]
-          (is (= {} (:effect/proposal t))))))
+    (doseq [proposal [nil false]]
+      (let [g (merge-grant)
+            t (propose-merge! dir g proposal)]
+        (is (= {} (:effect/proposal t)))))))
 
-    (testing "replaying the stale proposal cannot re-fire the effect"
-      (let [{g :grant t :transaction} (merge-case! dir)
-            calls (atom 0)
-            effect! (partial count-success! calls)
-            first-result (fx/commit! dir t g no-usage now effect!)
-            replay-result (fx/commit! dir t g no-usage now effect!)]
-        (is (= :succeeded (:effect/state first-result)))
-        (is (anomaly/anomaly? replay-result))
-        (is (= 1 @calls))))
+(deftest ^{:stratum 1} stale-proposal-replay-does-not-refire-test
+  (let [dir (tmp-dir)
+        {g :grant t :transaction} (merge-case! dir)
+        calls (atom 0)
+        effect! (partial count-success! calls)
+        first-result (fx/commit! dir t g no-usage now effect!)
+        replay-result (fx/commit! dir t g no-usage now effect!)]
+    (is (= :succeeded (:effect/state first-result)))
+    (is (anomaly/anomaly? replay-result))
+    (is (= 1 @calls))))
 
-    (testing "caller state cannot replace the durable proposal state"
-      (let [{g :grant t :transaction} (merge-case! dir)
-            forged (assoc t :effect/state :succeeded)
-            done (fx/commit! dir forged g no-usage now succeed!)]
-        (is (= :succeeded (:effect/state done)))))))
+(deftest ^{:stratum 1} caller-state-cannot-replace-durable-state-test
+  (let [dir (tmp-dir)
+        {g :grant t :transaction} (merge-case! dir)
+        forged (assoc t :effect/state :succeeded)
+        done (fx/commit! dir forged g no-usage now succeed!)]
+    (is (= :succeeded (:effect/state done)))))
 
 (deftest ^{:stratum 1} proposal-preserves-preallocated-id-without-replacement-test
   (let [dir (tmp-dir)

--- a/components/effect-transaction/test/ai/miniforge/effect_transaction/commit_test.clj
+++ b/components/effect-transaction/test/ai/miniforge/effect_transaction/commit_test.clj
@@ -51,6 +51,10 @@
 
 (def ^{:stratum 0} concurrency-timeout-ms fixture/concurrency-timeout-ms)
 
+(def ^{:stratum 0} no-usage fixture/no-usage)
+
+(def ^{:stratum 0} claimed-usage fixture/claimed-usage)
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (deftest ^{:stratum 1} interrupted-effect-is-unknown-not-failed-test
@@ -58,7 +62,7 @@
   ;; a merge that actually landed is as wrong as claiming success.
   (let [dir (tmp-dir)
         {g :grant t :transaction} (merge-case! dir)
-        committed (fx/commit! dir t g {} now
+        committed (fx/commit! dir t g no-usage now
                               (partial throw-exception! "connection reset"))]
     (is (= :unknown-outcome (:effect/state committed)))
     (is (not= :failed (:effect/state committed))
@@ -71,7 +75,7 @@
   (let [dir (tmp-dir)]
     (testing "a definite success is :succeeded and carries the observation"
       (let [{g :grant t :transaction} (merge-case! dir)
-            done (fx/commit! dir t g {} now
+            done (fx/commit! dir t g no-usage now
                              (fn [] {:effect/outcome :succeeded
                                      :effect/observed {:merge/sha "abc123"}}))]
         (is (= :succeeded (:effect/state done)))
@@ -79,7 +83,7 @@
 
     (testing "a definite failure is :failed — the effect fn knows it did not happen"
       (let [{g :grant t :transaction} (merge-case! dir)
-            done (fx/commit! dir t g {} now
+            done (fx/commit! dir t g no-usage now
                              (fn [] {:effect/outcome :failed
                                      :effect/failure "PR already closed"}))]
         (is (= :failed (:effect/state done)))
@@ -87,13 +91,13 @@
 
     (testing "an unreadable report is unknown, not success"
       (let [{g :grant t :transaction} (merge-case! dir)
-            done (fx/commit! dir t g {} now (fn [] {:whatever true}))]
+            done (fx/commit! dir t g no-usage now (fn [] {:whatever true}))]
         (is (= :unknown-outcome (:effect/state done))
             "an effect fn that answered in a shape we cannot read told us nothing")))
 
     (testing "a nil report is unknown, not success"
       (let [{g :grant t :transaction} (merge-case! dir)
-            done (fx/commit! dir t g {} now (constantly nil))]
+            done (fx/commit! dir t g no-usage now (constantly nil))]
         (is (= :unknown-outcome (:effect/state done)))))))
 
 (deftest ^{:stratum 1} commit-rechecks-the-grant-test
@@ -104,7 +108,7 @@
           {g :grant t :transaction} (merge-case! dir)
           revoked (grant/revoke g :breach/cost-exceeded now)
           fired (atom false)
-          done (fx/commit! dir t revoked {} now
+          done (fx/commit! dir t revoked no-usage now
                            (partial record-success! fired))]
       (is (= :failed (:effect/state done)))
       (is (not @fired) "the effect MUST NOT fire when the re-check refuses")
@@ -114,7 +118,7 @@
     (let [dir (tmp-dir)
           {g :grant t :transaction} (merge-case! dir)
           fired (atom false)
-          done (fx/commit! dir t g {} much-later
+          done (fx/commit! dir t g no-usage much-later
                            (partial record-success! fired))]
       (is (= :failed (:effect/state done)))
       (is (not @fired))))
@@ -123,7 +127,7 @@
     (let [dir (tmp-dir)
           {g :grant t :transaction} (merge-case! dir)
           fired (atom false)
-          done (fx/commit! dir t g {:usage/count 99} now
+          done (fx/commit! dir t g (claimed-usage 99) now
                            (partial record-success! fired))]
       (is (= :succeeded (:effect/state done)))
       (is @fired)))
@@ -133,7 +137,7 @@
           {g :grant t :transaction}
           (merge-case! dir {:constraints {:constraint/max-count 0}})
           fired (atom false)
-          done (fx/commit! dir t g {:usage/count 0} now
+          done (fx/commit! dir t g (claimed-usage 0) now
                            (partial record-success! fired))]
       (is (= :failed (:effect/state done)))
       (is (not @fired))))
@@ -146,7 +150,7 @@
     (let [dir (tmp-dir)
           {t :transaction} (merge-case! dir)
           fired (atom false)
-          result (fx/commit! dir t nil {} now
+          result (fx/commit! dir t nil no-usage now
                              (partial record-success! fired))]
       (is (anomaly/anomaly? result))
       (is (not @fired))
@@ -165,8 +169,8 @@
       (let [{g :grant t :transaction} (merge-case! dir)
             calls (atom 0)
             effect! (partial count-success! calls)
-            first-result (fx/commit! dir t g {} now effect!)
-            replay-result (fx/commit! dir t g {} now effect!)]
+            first-result (fx/commit! dir t g no-usage now effect!)
+            replay-result (fx/commit! dir t g no-usage now effect!)]
         (is (= :succeeded (:effect/state first-result)))
         (is (anomaly/anomaly? replay-result))
         (is (= 1 @calls))))
@@ -174,7 +178,7 @@
     (testing "caller state cannot replace the durable proposal state"
       (let [{g :grant t :transaction} (merge-case! dir)
             forged (assoc t :effect/state :succeeded)
-            done (fx/commit! dir forged g {} now succeed!)]
+            done (fx/commit! dir forged g no-usage now succeed!)]
         (is (= :succeeded (:effect/state done)))))))
 
 (deftest ^{:stratum 1} proposal-preserves-preallocated-id-without-replacement-test
@@ -197,7 +201,7 @@
     (testing "a different grant is refused, even a valid and broader one"
       (let [other (merge-grant {:constraints {}})
             fired (atom false)
-            result (fx/commit! dir t other {} now
+            result (fx/commit! dir t other no-usage now
                                (partial record-success! fired))]
         (is (anomaly/anomaly? result))
         (is (= :conflict (:anomaly/type result)))
@@ -207,13 +211,13 @@
       (let [deploy-grant (merge-grant {:effect-class :effect/deploy})
             mismatched (propose-merge! dir deploy-grant)
             fired (atom false)
-            result (fx/commit! dir mismatched deploy-grant {} now
+            result (fx/commit! dir mismatched deploy-grant no-usage now
                                (partial record-success! fired))]
         (is (anomaly/anomaly? result))
         (is (not @fired) "a merge proposal must not be authorized by a deploy grant")))
 
     (testing "the recorded grant still commits"
-      (let [done (fx/commit! dir t recorded {} now succeed!)]
+      (let [done (fx/commit! dir t recorded no-usage now succeed!)]
         (is (= :succeeded (:effect/state done)))))))
 
 (deftest ^{:stratum 1} concurrent-commit-invokes-the-effect-once-test
@@ -223,11 +227,11 @@
         entered (promise)
         release (promise)
         first-result (future
-                       (fx/commit! dir t g {} now
+                       (fx/commit! dir t g no-usage now
                                    (partial block-and-count-success!
                                             calls entered release)))]
     (is (= true (deref entered concurrency-timeout-ms :timeout)))
-    (let [second-result (fx/commit! dir t g {} now
+    (let [second-result (fx/commit! dir t g no-usage now
                                     (partial count-success! calls))]
       (deliver release true)
       (is (= :succeeded
@@ -239,7 +243,7 @@
   (let [dir (tmp-dir)
         {g :grant t :transaction} (merge-case! dir)]
     (is (thrown? AssertionError
-                 (fx/commit! dir t g {} now
+                 (fx/commit! dir t g no-usage now
                              (fn [] (throw (AssertionError.))))))
     (is (= :committing
            (:effect/state (fx/read-record dir (:effect/id t)))))))
@@ -263,7 +267,7 @@
           {g :grant t :transaction} (merge-case! dir)
           other-effect-grant (assoc-in g [:grant/scope :effect/id] (random-uuid))
           fired (atom false)
-          result (fx/commit! dir t other-effect-grant {} now
+          result (fx/commit! dir t other-effect-grant no-usage now
                              (partial record-success! fired))]
       (is (= :failed (:effect/state result)))
       (is (not @fired)))))

--- a/components/effect-transaction/test/ai/miniforge/effect_transaction/commit_test.clj
+++ b/components/effect-transaction/test/ai/miniforge/effect_transaction/commit_test.clj
@@ -37,7 +37,19 @@
 
 (def ^{:stratum 0} propose-merge! fixture/propose-merge!)
 
+(def ^{:stratum 0} merge-case! fixture/merge-case!)
+
 (def ^{:stratum 0} record-success! fixture/record-success!)
+
+(def ^{:stratum 0} succeed! fixture/succeed!)
+
+(def ^{:stratum 0} throw-exception! fixture/throw-exception!)
+
+(def ^{:stratum 0} count-success! fixture/count-success!)
+
+(def ^{:stratum 0} block-and-count-success! fixture/block-and-count-success!)
+
+(def ^{:stratum 0} concurrency-timeout-ms fixture/concurrency-timeout-ms)
 
 ;------------------------------------------------------------------------------ Layer 1
 
@@ -45,10 +57,9 @@
   ;; The state that earns this component its keep. Claiming failure for
   ;; a merge that actually landed is as wrong as claiming success.
   (let [dir (tmp-dir)
-        g (merge-grant)
-        t (propose-merge! dir g)
+        {g :grant t :transaction} (merge-case! dir)
         committed (fx/commit! dir t g {} now
-                              (fn [] (throw (ex-info "connection reset" {}))))]
+                              (partial throw-exception! "connection reset"))]
     (is (= :unknown-outcome (:effect/state committed)))
     (is (not= :failed (:effect/state committed))
         "a throw means we do not know, not that it did not happen")
@@ -57,10 +68,9 @@
       (is (= :unknown-outcome (:effect/state (fx/read-record dir (:effect/id t))))))))
 
 (deftest ^{:stratum 1} definite-outcomes-are-recorded-as-such-test
-  (let [dir (tmp-dir)
-        g (merge-grant)]
+  (let [dir (tmp-dir)]
     (testing "a definite success is :succeeded and carries the observation"
-      (let [t (propose-merge! dir g)
+      (let [{g :grant t :transaction} (merge-case! dir)
             done (fx/commit! dir t g {} now
                              (fn [] {:effect/outcome :succeeded
                                      :effect/observed {:merge/sha "abc123"}}))]
@@ -68,7 +78,7 @@
         (is (= {:merge/sha "abc123"} (:effect/observed done)))))
 
     (testing "a definite failure is :failed — the effect fn knows it did not happen"
-      (let [t (propose-merge! dir g)
+      (let [{g :grant t :transaction} (merge-case! dir)
             done (fx/commit! dir t g {} now
                              (fn [] {:effect/outcome :failed
                                      :effect/failure "PR already closed"}))]
@@ -76,13 +86,13 @@
         (is (= "PR already closed" (:effect/failure done)))))
 
     (testing "an unreadable report is unknown, not success"
-      (let [t (propose-merge! dir g)
+      (let [{g :grant t :transaction} (merge-case! dir)
             done (fx/commit! dir t g {} now (fn [] {:whatever true}))]
         (is (= :unknown-outcome (:effect/state done))
             "an effect fn that answered in a shape we cannot read told us nothing")))
 
     (testing "a nil report is unknown, not success"
-      (let [t (propose-merge! dir g)
+      (let [{g :grant t :transaction} (merge-case! dir)
             done (fx/commit! dir t g {} now (constantly nil))]
         (is (= :unknown-outcome (:effect/state done)))))))
 
@@ -91,8 +101,7 @@
   ;; against stale state.
   (testing "a grant revoked after the proposal fails the commit, and the effect never fires"
     (let [dir (tmp-dir)
-          g (merge-grant)
-          t (propose-merge! dir g)
+          {g :grant t :transaction} (merge-case! dir)
           revoked (grant/revoke g :breach/cost-exceeded now)
           fired (atom false)
           done (fx/commit! dir t revoked {} now
@@ -103,20 +112,28 @@
 
   (testing "a grant that expired between propose and commit fails the commit"
     (let [dir (tmp-dir)
-          g (merge-grant)
-          t (propose-merge! dir g)
+          {g :grant t :transaction} (merge-case! dir)
           fired (atom false)
           done (fx/commit! dir t g {} much-later
                            (partial record-success! fired))]
       (is (= :failed (:effect/state done)))
       (is (not @fired))))
 
-  (testing "a breached ceiling fails the commit"
+  (testing "caller-supplied usage cannot fabricate a breached ceiling"
     (let [dir (tmp-dir)
-          g (merge-grant)
-          t (propose-merge! dir g)
+          {g :grant t :transaction} (merge-case! dir)
           fired (atom false)
           done (fx/commit! dir t g {:usage/count 99} now
+                           (partial record-success! fired))]
+      (is (= :succeeded (:effect/state done)))
+      (is @fired)))
+
+  (testing "caller-supplied zero cannot bypass the derived operation count"
+    (let [dir (tmp-dir)
+          {g :grant t :transaction}
+          (merge-case! dir {:constraints {:constraint/max-count 0}})
+          fired (atom false)
+          done (fx/commit! dir t g {:usage/count 0} now
                            (partial record-success! fired))]
       (is (= :failed (:effect/state done)))
       (is (not @fired))))
@@ -127,8 +144,7 @@
     ;; not the authority lapsing. Marking the record :failed for that
     ;; would blame the transaction for the caller's mistake.
     (let [dir (tmp-dir)
-          g (merge-grant)
-          t (propose-merge! dir g)
+          {t :transaction} (merge-case! dir)
           fired (atom false)
           result (fx/commit! dir t nil {} now
                              (partial record-success! fired))]
@@ -138,39 +154,45 @@
           "the durable record is left as it was"))))
 
 (deftest ^{:stratum 1} only-a-proposed-record-may-be-committed-test
-  ;; The accident this component exists to prevent: committing a record
-  ;; that has already moved on re-runs an irreversible effect. A second
-  ;; merge. A second deploy.
-  (let [dir (tmp-dir)
-        g (merge-grant)]
+  (let [dir (tmp-dir)]
     (testing "falsey proposals retain the empty-map default"
       (doseq [proposal [nil false]]
-        (is (= {} (:effect/proposal
-                   (fx/propose! dir {:effect-class :effect/merge
-                                     :grant-id (:grant/id g)
-                                     :proposal proposal}
-                                now))))))
-    (doseq [state [:committing :succeeded :failed :unknown-outcome :reconciled]]
-      (let [t (assoc (propose-merge! dir g) :effect/state state)
-            fired (atom false)
-            result (fx/commit! dir t g {} now
-                               (partial record-success! fired))]
-        (is (anomaly/anomaly? result) (str "commit from " state " must refuse"))
-        (is (= :conflict (:anomaly/type result)) (str state))
-        (is (not @fired)
-            (str "the effect MUST NOT re-fire from " state))))
-    (testing "a :proposed record still commits normally"
-      (let [t (propose-merge! dir g)
-            done (fx/commit! dir t g {} now (fn [] {:effect/outcome :succeeded}))]
+        (let [g (merge-grant)
+              t (propose-merge! dir g proposal)]
+          (is (= {} (:effect/proposal t))))))
+
+    (testing "replaying the stale proposal cannot re-fire the effect"
+      (let [{g :grant t :transaction} (merge-case! dir)
+            calls (atom 0)
+            effect! (partial count-success! calls)
+            first-result (fx/commit! dir t g {} now effect!)
+            replay-result (fx/commit! dir t g {} now effect!)]
+        (is (= :succeeded (:effect/state first-result)))
+        (is (anomaly/anomaly? replay-result))
+        (is (= 1 @calls))))
+
+    (testing "caller state cannot replace the durable proposal state"
+      (let [{g :grant t :transaction} (merge-case! dir)
+            forged (assoc t :effect/state :succeeded)
+            done (fx/commit! dir forged g {} now succeed!)]
         (is (= :succeeded (:effect/state done)))))))
+
+(deftest ^{:stratum 1} proposal-preserves-preallocated-id-without-replacement-test
+  (let [dir (tmp-dir)
+        g (merge-grant)
+        id (get-in g [:grant/scope :effect/id])
+        original (propose-merge! dir g)
+        duplicate (propose-merge! dir g {:pr/number 99})]
+    (is (= id (:effect/id original)))
+    (is (anomaly/anomaly? duplicate))
+    (is (= original (fx/read-record dir id)))))
 
 (deftest ^{:stratum 1} commit-must-use-the-grant-the-proposal-named-test
   ;; The re-check is only worth anything if it re-checks the SAME grant.
   ;; Otherwise: propose under a narrow grant, commit under a broad one,
   ;; and the durable record attests to authority that was never used.
   (let [dir (tmp-dir)
-        recorded (merge-grant)
-        t (propose-merge! dir recorded)]
+        {recorded :grant t :transaction} (merge-case! dir)]
 
     (testing "a different grant is refused, even a valid and broader one"
       (let [other (merge-grant {:constraints {}})
@@ -182,14 +204,8 @@
         (is (not @fired) "substituting a broader grant must not fire the effect")))
 
     (testing "a grant for a different effect class is refused"
-      (let [deploy-grant (grant/issue {:principal "agent:implementer"
-                                       :effect-class :effect/deploy
-                                       :scope {}
-                                       :constraints {}
-                                       :delegable? false
-                                       :expires-at later}
-                                      now)
-            mismatched (assoc t :effect/grant-id (:grant/id deploy-grant))
+      (let [deploy-grant (merge-grant {:effect-class :effect/deploy})
+            mismatched (propose-merge! dir deploy-grant)
             fired (atom false)
             result (fx/commit! dir mismatched deploy-grant {} now
                                (partial record-success! fired))]
@@ -197,18 +213,57 @@
         (is (not @fired) "a merge proposal must not be authorized by a deploy grant")))
 
     (testing "the recorded grant still commits"
-      (let [done (fx/commit! dir t recorded {} now (fn [] {:effect/outcome :succeeded}))]
+      (let [done (fx/commit! dir t recorded {} now succeed!)]
         (is (= :succeeded (:effect/state done)))))))
+
+(deftest ^{:stratum 1} concurrent-commit-invokes-the-effect-once-test
+  (let [dir (tmp-dir)
+        {g :grant t :transaction} (merge-case! dir)
+        calls (atom 0)
+        entered (promise)
+        release (promise)
+        first-result (future
+                       (fx/commit! dir t g {} now
+                                   (partial block-and-count-success!
+                                            calls entered release)))]
+    (is (= true (deref entered concurrency-timeout-ms :timeout)))
+    (let [second-result (fx/commit! dir t g {} now
+                                    (partial count-success! calls))]
+      (deliver release true)
+      (is (= :succeeded
+             (:effect/state (deref first-result concurrency-timeout-ms :timeout))))
+      (is (anomaly/anomaly? second-result))
+      (is (= 1 @calls)))))
+
+(deftest ^{:stratum 1} process-failure-after-claim-leaves-committing-test
+  (let [dir (tmp-dir)
+        {g :grant t :transaction} (merge-case! dir)]
+    (is (thrown? AssertionError
+                 (fx/commit! dir t g {} now
+                             (fn [] (throw (AssertionError.))))))
+    (is (= :committing
+           (:effect/state (fx/read-record dir (:effect/id t)))))))
 
 (deftest ^{:stratum 1} commit-enforces-grant-scope-test
   (testing "durable proposal scope overrides a caller-supplied scope"
     (let [dir (tmp-dir)
-          g (merge-grant {:scope (assoc fixture/merge-proposal :pr/number 43)})
-          t (propose-merge! dir g)
+          {g :grant t :transaction}
+          (merge-case! dir {:scope (assoc fixture/merge-proposal :pr/number 43)})
+          forged (assoc t :effect/proposal (:grant/scope g))
           fired (atom false)
           usage {:effect/scope (:grant/scope g)}
-          result (fx/commit! dir t g usage now
+          result (fx/commit! dir forged g usage now
                              (partial record-success! fired))]
       (is (= :failed (:effect/state result)))
       (is (re-find #"scope-mismatch" (:effect/failure result)))
+      (is (not @fired))))
+
+  (testing "a grant bound to another durable effect ID is refused"
+    (let [dir (tmp-dir)
+          {g :grant t :transaction} (merge-case! dir)
+          other-effect-grant (assoc-in g [:grant/scope :effect/id] (random-uuid))
+          fired (atom false)
+          result (fx/commit! dir t other-effect-grant {} now
+                             (partial record-success! fired))]
+      (is (= :failed (:effect/state result)))
       (is (not @fired)))))

--- a/components/effect-transaction/test/ai/miniforge/effect_transaction/commit_test.clj
+++ b/components/effect-transaction/test/ai/miniforge/effect_transaction/commit_test.clj
@@ -155,6 +155,15 @@
     (is (not @fired))
     (is (= :proposed (:effect/state (fx/read-record dir (:effect/id t)))))))
 
+(deftest ^{:stratum 1} missing-effect-id-is-invalid-input-test
+  (let [dir (tmp-dir)
+        fired (atom false)
+        result (fx/commit! dir {} :authority/unenforced no-usage now
+                           (partial record-success! fired))]
+    (is (= :invalid-input (:anomaly/type result)))
+    (is (not @fired))
+    (is (empty? (fx/list-records dir)))))
+
 (deftest ^{:stratum 1} falsey-proposals-retain-empty-default-test
   (let [dir (tmp-dir)]
     (doseq [proposal [nil false]]

--- a/components/effect-transaction/test/ai/miniforge/effect_transaction/commit_test.clj
+++ b/components/effect-transaction/test/ai/miniforge/effect_transaction/commit_test.clj
@@ -155,14 +155,15 @@
     (is (not @fired))
     (is (= :proposed (:effect/state (fx/read-record dir (:effect/id t)))))))
 
-(deftest ^{:stratum 1} missing-effect-id-is-invalid-input-test
-  (let [dir (tmp-dir)
-        fired (atom false)
-        result (fx/commit! dir {} :authority/unenforced no-usage now
-                           (partial record-success! fired))]
-    (is (= :invalid-input (:anomaly/type result)))
-    (is (not @fired))
-    (is (empty? (fx/list-records dir)))))
+(deftest ^{:stratum 1} invalid-effect-id-is-invalid-input-test
+  (doseq [id [nil "../outside-store"]]
+    (let [dir (tmp-dir)
+          fired (atom false)
+          result (fx/commit! dir {:effect/id id} :authority/unenforced
+                             no-usage now (partial record-success! fired))]
+      (is (= :invalid-input (:anomaly/type result)))
+      (is (not @fired))
+      (is (empty? (fx/list-records dir))))))
 
 (deftest ^{:stratum 1} falsey-proposals-retain-empty-default-test
   (let [dir (tmp-dir)]

--- a/components/effect-transaction/test/ai/miniforge/effect_transaction/commit_test.clj
+++ b/components/effect-transaction/test/ai/miniforge/effect_transaction/commit_test.clj
@@ -21,7 +21,7 @@
    [ai.miniforge.effect-transaction.fixtures :as fixture]
    [ai.miniforge.effect-transaction.interface :as fx]
    [ai.miniforge.execution-grant.interface :as grant]
-   [clojure.test :refer [deftest is testing]]))
+   [clojure.test :refer [deftest is]]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -68,37 +68,40 @@
     (is (not= :failed (:effect/state committed))
         "a throw means we do not know, not that it did not happen")
     (is (= "connection reset" (:effect/failure committed)))
-    (testing "and the unknown state is durable, so a restart can find it"
-      (is (= :unknown-outcome (:effect/state (fx/read-record dir (:effect/id t))))))))
+    (is (= :unknown-outcome
+           (:effect/state (fx/read-record dir (:effect/id t))))
+        "the unknown state is durable for a fresh reader")))
 
-(deftest ^{:stratum 1} definite-outcomes-are-recorded-as-such-test
-  (let [dir (tmp-dir)]
-    (testing "a definite success is :succeeded and carries the observation"
-      (let [{g :grant t :transaction} (merge-case! dir)
-            done (fx/commit! dir t g no-usage now
-                             (fn [] {:effect/outcome :succeeded
-                                     :effect/observed {:merge/sha "abc123"}}))]
-        (is (= :succeeded (:effect/state done)))
-        (is (= {:merge/sha "abc123"} (:effect/observed done)))))
+(deftest ^{:stratum 1} definite-success-records-observation-test
+  (let [dir (tmp-dir)
+        {g :grant t :transaction} (merge-case! dir)
+        done (fx/commit! dir t g no-usage now
+                         (fn [] {:effect/outcome :succeeded
+                                 :effect/observed {:merge/sha "abc123"}}))]
+    (is (= :succeeded (:effect/state done)))
+    (is (= {:merge/sha "abc123"} (:effect/observed done)))))
 
-    (testing "a definite failure is :failed — the effect fn knows it did not happen"
-      (let [{g :grant t :transaction} (merge-case! dir)
-            done (fx/commit! dir t g no-usage now
-                             (fn [] {:effect/outcome :failed
-                                     :effect/failure "PR already closed"}))]
-        (is (= :failed (:effect/state done)))
-        (is (= "PR already closed" (:effect/failure done)))))
+(deftest ^{:stratum 1} definite-failure-records-reason-test
+  (let [dir (tmp-dir)
+        {g :grant t :transaction} (merge-case! dir)
+        done (fx/commit! dir t g no-usage now
+                         (fn [] {:effect/outcome :failed
+                                 :effect/failure "PR already closed"}))]
+    (is (= :failed (:effect/state done)))
+    (is (= "PR already closed" (:effect/failure done)))))
 
-    (testing "an unreadable report is unknown, not success"
-      (let [{g :grant t :transaction} (merge-case! dir)
-            done (fx/commit! dir t g no-usage now (fn [] {:whatever true}))]
-        (is (= :unknown-outcome (:effect/state done))
-            "an effect fn that answered in a shape we cannot read told us nothing")))
+(deftest ^{:stratum 1} unreadable-effect-report-is-unknown-test
+  (let [dir (tmp-dir)
+        {g :grant t :transaction} (merge-case! dir)
+        done (fx/commit! dir t g no-usage now (fn [] {:whatever true}))]
+    (is (= :unknown-outcome (:effect/state done))
+        "an unreadable report supplies no outcome knowledge")))
 
-    (testing "a nil report is unknown, not success"
-      (let [{g :grant t :transaction} (merge-case! dir)
-            done (fx/commit! dir t g no-usage now (constantly nil))]
-        (is (= :unknown-outcome (:effect/state done)))))))
+(deftest ^{:stratum 1} nil-effect-report-is-unknown-test
+  (let [dir (tmp-dir)
+        {g :grant t :transaction} (merge-case! dir)
+        done (fx/commit! dir t g no-usage now (constantly nil))]
+    (is (= :unknown-outcome (:effect/state done)))))
 
 (deftest ^{:stratum 1} revoked-grant-recheck-denies-effect-test
   ;; A constraint checked only at decide time is a check against stale state.
@@ -187,34 +190,35 @@
     (is (anomaly/anomaly? duplicate))
     (is (= original (fx/read-record dir id)))))
 
-(deftest ^{:stratum 1} commit-must-use-the-grant-the-proposal-named-test
+(deftest ^{:stratum 1} substituted-broader-grant-is-refused-test
   ;; The re-check is only worth anything if it re-checks the SAME grant.
   ;; Otherwise: propose under a narrow grant, commit under a broad one,
   ;; and the durable record attests to authority that was never used.
   (let [dir (tmp-dir)
-        {recorded :grant t :transaction} (merge-case! dir)]
+        {t :transaction} (merge-case! dir)
+        other (merge-grant {:constraints {}})
+        fired (atom false)
+        result (fx/commit! dir t other no-usage now
+                           (partial record-success! fired))]
+    (is (anomaly/anomaly? result))
+    (is (= :conflict (:anomaly/type result)))
+    (is (not @fired) "substituting a broader grant must not fire the effect")))
 
-    (testing "a different grant is refused, even a valid and broader one"
-      (let [other (merge-grant {:constraints {}})
-            fired (atom false)
-            result (fx/commit! dir t other no-usage now
-                               (partial record-success! fired))]
-        (is (anomaly/anomaly? result))
-        (is (= :conflict (:anomaly/type result)))
-        (is (not @fired) "substituting a broader grant must not fire the effect")))
+(deftest ^{:stratum 1} different-effect-class-grant-is-refused-test
+  (let [dir (tmp-dir)
+        deploy-grant (merge-grant {:effect-class :effect/deploy})
+        mismatched (propose-merge! dir deploy-grant)
+        fired (atom false)
+        result (fx/commit! dir mismatched deploy-grant no-usage now
+                           (partial record-success! fired))]
+    (is (anomaly/anomaly? result))
+    (is (not @fired) "a merge proposal must not use a deploy grant")))
 
-    (testing "a grant for a different effect class is refused"
-      (let [deploy-grant (merge-grant {:effect-class :effect/deploy})
-            mismatched (propose-merge! dir deploy-grant)
-            fired (atom false)
-            result (fx/commit! dir mismatched deploy-grant no-usage now
-                               (partial record-success! fired))]
-        (is (anomaly/anomaly? result))
-        (is (not @fired) "a merge proposal must not be authorized by a deploy grant")))
-
-    (testing "the recorded grant still commits"
-      (let [done (fx/commit! dir t recorded no-usage now succeed!)]
-        (is (= :succeeded (:effect/state done)))))))
+(deftest ^{:stratum 1} proposal-recorded-grant-commits-test
+  (let [dir (tmp-dir)
+        {g :grant t :transaction} (merge-case! dir)
+        done (fx/commit! dir t g no-usage now succeed!)]
+    (is (= :succeeded (:effect/state done)))))
 
 (deftest ^{:stratum 1} concurrent-commit-invokes-the-effect-once-test
   (let [dir (tmp-dir)
@@ -244,26 +248,25 @@
     (is (= :committing
            (:effect/state (fx/read-record dir (:effect/id t)))))))
 
-(deftest ^{:stratum 1} commit-enforces-grant-scope-test
-  (testing "durable proposal scope overrides a caller-supplied scope"
-    (let [dir (tmp-dir)
-          {g :grant t :transaction}
-          (merge-case! dir {:scope (assoc fixture/merge-proposal :pr/number 43)})
-          forged (assoc t :effect/proposal (:grant/scope g))
-          fired (atom false)
-          usage {:effect/scope (:grant/scope g)}
-          result (fx/commit! dir forged g usage now
-                             (partial record-success! fired))]
-      (is (= :failed (:effect/state result)))
-      (is (re-find #"scope-mismatch" (:effect/failure result)))
-      (is (not @fired))))
+(deftest ^{:stratum 1} durable-scope-overrides-caller-context-test
+  (let [dir (tmp-dir)
+        {g :grant t :transaction}
+        (merge-case! dir {:scope (assoc fixture/merge-proposal :pr/number 43)})
+        forged (assoc t :effect/proposal (:grant/scope g))
+        fired (atom false)
+        usage {:effect/scope (:grant/scope g)}
+        result (fx/commit! dir forged g usage now
+                           (partial record-success! fired))]
+    (is (= :failed (:effect/state result)))
+    (is (re-find #"scope-mismatch" (:effect/failure result)))
+    (is (not @fired))))
 
-  (testing "a grant bound to another durable effect ID is refused"
-    (let [dir (tmp-dir)
-          {g :grant t :transaction} (merge-case! dir)
-          other-effect-grant (assoc-in g [:grant/scope :effect/id] (random-uuid))
-          fired (atom false)
-          result (fx/commit! dir t other-effect-grant no-usage now
-                             (partial record-success! fired))]
-      (is (= :failed (:effect/state result)))
-      (is (not @fired)))))
+(deftest ^{:stratum 1} grant-bound-to-another-effect-is-refused-test
+  (let [dir (tmp-dir)
+        {g :grant t :transaction} (merge-case! dir)
+        other-effect-grant (assoc-in g [:grant/scope :effect/id] (random-uuid))
+        fired (atom false)
+        result (fx/commit! dir t other-effect-grant no-usage now
+                           (partial record-success! fired))]
+    (is (= :failed (:effect/state result)))
+    (is (not @fired))))

--- a/components/effect-transaction/test/ai/miniforge/effect_transaction/fixtures.clj
+++ b/components/effect-transaction/test/ai/miniforge/effect_transaction/fixtures.clj
@@ -32,6 +32,8 @@
 
 (def ^{:stratum 0} much-later (Instant/parse "2026-08-02T00:00:00Z"))
 
+(def ^{:stratum 0} concurrency-timeout-ms 5000)
+
 (def ^{:stratum 0} merge-proposal
   {:pr/repo "miniforge-ai/miniforge"
    :pr/number 42})
@@ -41,33 +43,69 @@
   []
   (str (.toFile (Files/createTempDirectory "fx-test" (into-array FileAttribute [])))))
 
-(defn ^{:stratum 0} record-success!
+(defn ^{:stratum 0} succeed!
+  []
+  {:effect/outcome :succeeded})
+
+(defn ^{:stratum 0} throw-exception!
+  [message]
+  (throw (ex-info message {})))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} record-success!
   "Record that a test effect fired and report definite success."
   [fired]
   (reset! fired true)
-  {:effect/outcome :succeeded})
+  (succeed!))
 
-;------------------------------------------------------------------------------ Layer 1
+(defn ^{:stratum 1} count-success!
+  [calls]
+  (swap! calls inc)
+  (succeed!))
+
+(defn ^{:stratum 1} block-and-count-success!
+  [calls entered release]
+  (swap! calls inc)
+  (deliver entered true)
+  @release
+  (succeed!))
 
 (defn ^{:stratum 1} merge-grant
   "A merge grant matching the canonical test proposal."
   ([] (merge-grant {}))
   ([overrides]
-   (grant/issue (merge {:principal "agent:implementer"
-                        :effect-class :effect/merge
-                        :scope merge-proposal
-                        :constraints {:constraint/max-count 5}
-                        :delegable? false
-                        :expires-at later}
-                       overrides)
-                now)))
+   (let [effect-id (get overrides :effect-id (random-uuid))
+         scope (assoc (get overrides :scope merge-proposal)
+                      :effect/id effect-id)
+         grant-overrides (dissoc overrides :effect-id :scope)]
+     (grant/issue (merge {:principal "agent:implementer"
+                          :effect-class :effect/merge
+                          :scope scope
+                          :constraints {:constraint/max-count 1}
+                          :delegable? false
+                          :expires-at later}
+                         grant-overrides)
+                  now))))
 
 (defn ^{:stratum 1} propose-merge!
   "Persist the effect that `merge-grant` authorizes."
-  [dir g]
-  (fx/propose! dir
-               {:effect-class :effect/merge
-                :grant-id (:grant/id g)
-                :envelope-id (random-uuid)
-                :proposal merge-proposal}
-               now))
+  ([dir g] (propose-merge! dir g merge-proposal))
+  ([dir g proposal]
+   (fx/propose! dir
+                {:effect-id (get-in g [:grant/scope :effect/id])
+                 :effect-class :effect/merge
+                 :grant-id (:grant/id g)
+                 :envelope-id (random-uuid)
+                 :proposal proposal}
+                now)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} merge-case!
+  "Create one grant and its exactly bound durable proposal."
+  ([dir] (merge-case! dir {}))
+  ([dir grant-overrides]
+   (let [g (merge-grant grant-overrides)]
+     {:grant g
+      :transaction (propose-merge! dir g)})))

--- a/components/effect-transaction/test/ai/miniforge/effect_transaction/fixtures.clj
+++ b/components/effect-transaction/test/ai/miniforge/effect_transaction/fixtures.clj
@@ -38,6 +38,15 @@
   {:pr/repo "miniforge-ai/miniforge"
    :pr/number 42})
 
+(def ^{:stratum 0} no-usage
+  "Caller usage is intentionally absent at the fenced commit boundary."
+  {})
+
+(defn ^{:stratum 0} claimed-usage
+  "Build an untrusted caller usage claim for fencing tests."
+  [count]
+  {:usage/count count})
+
 (defn ^{:stratum 0} tmp-dir
   "A fresh directory for one effect-transaction test."
   []

--- a/components/effect-transaction/test/ai/miniforge/effect_transaction/reconcile_test.clj
+++ b/components/effect-transaction/test/ai/miniforge/effect_transaction/reconcile_test.clj
@@ -37,10 +37,10 @@
 ;------------------------------------------------------------------------------ Layer 1
 
 (deftest ^{:stratum 1} reconcile-reads-the-world-not-the-log-test
-  (let [dir (tmp-dir)
-        g (merge-grant)]
+  (let [dir (tmp-dir)]
     (testing "the observation comes from the probe, and a match is recorded"
-      (let [t (propose-merge! dir g)
+      (let [g (merge-grant)
+            t (propose-merge! dir g)
             unknown (fx/commit! dir t g {} now (fn [] (throw (ex-info "boom" {}))))
             settled (fx/reconcile! dir unknown
                                    (fn [_] {:effect/observed {:pr/state "MERGED"
@@ -52,7 +52,8 @@
         (is (true? (:effect/matched? settled)))))
 
     (testing "a MISMATCH is recorded, not smoothed over"
-      (let [t (propose-merge! dir g)
+      (let [g (merge-grant)
+            t (propose-merge! dir g)
             unknown (fx/commit! dir t g {} now (fn [] (throw (ex-info "boom" {}))))
             settled (fx/reconcile! dir unknown
                                    (fn [_] {:effect/observed {:pr/state "CLOSED"}
@@ -63,7 +64,8 @@
             "finding out includes finding out you were wrong")))
 
     (testing "a probe that throws leaves the record unresolved for a later attempt"
-      (let [t (propose-merge! dir g)
+      (let [g (merge-grant)
+            t (propose-merge! dir g)
             unknown (fx/commit! dir t g {} now (fn [] (throw (ex-info "boom" {}))))
             result (fx/reconcile! dir unknown (fn [_] (throw (ex-info "network" {}))) later)]
         (is (anomaly/anomaly? result))
@@ -71,7 +73,8 @@
             "marking :reconciled here would assert we found out when we did not")))
 
     (testing "a probe answering in an unreadable shape also leaves it unresolved"
-      (let [t (propose-merge! dir g)
+      (let [g (merge-grant)
+            t (propose-merge! dir g)
             unknown (fx/commit! dir t g {} now (fn [] (throw (ex-info "boom" {}))))
             result (fx/reconcile! dir unknown (constantly {:something :else}) later)]
         (is (anomaly/anomaly? result))
@@ -81,7 +84,8 @@
       ;; The probe returns caller-shaped data, so any in-band sentinel is
       ;; a value it could legitimately carry. Wrapping the answer instead
       ;; of probing it for a marker is what keeps that from colliding.
-      (let [t (propose-merge! dir g)
+      (let [g (merge-grant)
+            t (propose-merge! dir g)
             unknown (fx/commit! dir t g {} now (fn [] (throw (ex-info "boom" {}))))
             settled (fx/reconcile! dir unknown
                                    (constantly {:effect/observed {:threw "not an error"}
@@ -92,7 +96,8 @@
         (is (true? (:effect/matched? settled)))))
 
     (testing "an answer with no :effect/matched? records a mismatch, not a match"
-      (let [t (propose-merge! dir g)
+      (let [g (merge-grant)
+            t (propose-merge! dir g)
             unknown (fx/commit! dir t g {} now (fn [] (throw (ex-info "boom" {}))))
             settled (fx/reconcile! dir unknown
                                    (constantly {:effect/observed {:pr/state "MERGED"}})
@@ -102,7 +107,8 @@
             "an unflagged disagreement is worse than a flagged one")))
 
     (testing "an already-settled record is not reconcilable"
-      (let [t (propose-merge! dir g)
+      (let [g (merge-grant)
+            t (propose-merge! dir g)
             done (fx/commit! dir t g {} now (fn [] {:effect/outcome :succeeded}))]
         (is (anomaly/anomaly?
              (fx/reconcile! dir done (constantly {:effect/observed :x}) later)))))))
@@ -131,10 +137,13 @@
   ;; true nor useful here. A wrong lifecycle position is a :conflict; a
   ;; probe that did not answer is :unavailable — transient, ask again.
   (let [dir (tmp-dir)
-        g (merge-grant)
-        settled (fx/commit! dir (propose-merge! dir g) g {} now
+        settled-grant (merge-grant)
+        unknown-grant (merge-grant)
+        settled (fx/commit! dir (propose-merge! dir settled-grant)
+                            settled-grant {} now
                             (fn [] {:effect/outcome :succeeded}))
-        unknown (fx/commit! dir (propose-merge! dir g) g {} now
+        unknown (fx/commit! dir (propose-merge! dir unknown-grant)
+                            unknown-grant {} now
                             (fn [] (throw (ex-info "boom" {}))))]
     (testing "reconciling a settled record is a :conflict, not a permission error"
       (is (= :conflict (:anomaly/type

--- a/docs/pull-requests/2026-08-07-codex-n7-effect-commit-fencing.md
+++ b/docs/pull-requests/2026-08-07-codex-n7-effect-commit-fencing.md
@@ -1,0 +1,72 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix: authorize and claim durable effects once
+
+## Overview
+
+Makes commit authorization depend only on the durable proposal and claims that
+proposal atomically before invoking an irreversible effect. A stale caller
+value, fabricated usage, substituted grant, or concurrent process therefore
+cannot invoke the same effect again.
+
+## Layer
+
+Application service — effect commit authorization and claim orchestration.
+
+## Depends on
+
+- #1699 (durable effect identity, create-only persistence, and lifecycle
+  compare-and-set) — merged
+
+## Strata Affected
+
+- Authorization evaluator — derive scope and usage from durable effect data.
+- Commit coordinator — reload and claim the durable proposal before invocation.
+- Tests — shared grant/proposal factories and deterministic claim coverage.
+
+## Motivation
+
+`:constraint/max-count 1` is not a replay fence when a caller can repeatedly
+present stale proposal data or choose its own usage count. The durable effect
+identity and an atomic lifecycle claim must decide whether invocation is still
+permitted.
+
+## Changes in Detail
+
+- Reload the durable transaction before commit authorization.
+- Authorize the durable proposal plus its effect ID with `:usage/count 1`.
+- Ignore caller-provided scope, state, and usage claims.
+- Require the grant identity and effect class recorded by the proposal.
+- Atomically claim `:proposed` as `:committing` before invoking the effect.
+- Keep JVM failures visible while leaving the durable claim reconcilable.
+
+## Testing Plan
+
+- Test stale-map replay and caller context spoofing.
+- Test substituted grant and effect-class refusal.
+- Test concurrent commit at-most-once behavior.
+- Test a process-level failure after claim leaves `:committing` durable.
+- Run effect-transaction tests in every composing project.
+- Run Poly, kondo, stratum lint, compliance review, and full pre-commit.
+
+## Deployment Plan
+
+Merge to `main`; existing effect records remain readable and require no data
+migration.
+
+## Related Issues/PRs
+
+- Precedes durable reconciliation reload in the N7 transaction-fencing spec.
+
+## Checklist
+
+- [ ] Commit authorization ignores caller scope, state, and usage count
+- [ ] The recorded grant identity and effect class are enforced
+- [ ] Concurrent and stale commits invoke at most once
+- [ ] Claimed transactions remain reconcilable after process death
+- [ ] Poly reports zero errors and warnings
+- [ ] Standards and pre-commit gates pass


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# fix: authorize and claim durable effects once

## Overview

Makes commit authorization depend only on the durable proposal and claims that
proposal atomically before invoking an irreversible effect. A stale caller
value, fabricated usage, substituted grant, or concurrent process therefore
cannot invoke the same effect again.

## Layer

Application service — effect commit authorization and claim orchestration.

## Depends on

- #1699 (durable effect identity, create-only persistence, and lifecycle
  compare-and-set) — merged

## Strata Affected

- Authorization evaluator — derive scope and usage from durable effect data.
- Commit coordinator — reload and claim the durable proposal before invocation.
- Tests — shared grant/proposal factories and deterministic claim coverage.

## Motivation

`:constraint/max-count 1` is not a replay fence when a caller can repeatedly
present stale proposal data or choose its own usage count. The durable effect
identity and an atomic lifecycle claim must decide whether invocation is still
permitted.

## Changes in Detail

- Reload the durable transaction before commit authorization.
- Authorize the durable proposal plus its effect ID with `:usage/count 1`.
- Ignore caller-provided scope, state, and usage claims.
- Require the grant identity and effect class recorded by the proposal.
- Atomically claim `:proposed` as `:committing` before invoking the effect.
- Keep JVM failures visible while leaving the durable claim reconcilable.

## Testing Plan

- Test stale-map replay and caller context spoofing.
- Test substituted grant and effect-class refusal.
- Test concurrent commit at-most-once behavior.
- Test a process-level failure after claim leaves `:committing` durable.
- Run effect-transaction tests in every composing project.
- Run Poly, kondo, stratum lint, compliance review, and full pre-commit.

## Deployment Plan

Merge to `main`; existing effect records remain readable and require no data
migration.

## Related Issues/PRs

- Precedes durable reconciliation reload in the N7 transaction-fencing spec.

## Checklist

- [ ] Commit authorization ignores caller scope, state, and usage count
- [ ] The recorded grant identity and effect class are enforced
- [ ] Concurrent and stale commits invoke at most once
- [ ] Claimed transactions remain reconcilable after process death
- [ ] Poly reports zero errors and warnings
- [ ] Standards and pre-commit gates pass
