### PR TITLE
fix: reconcile only durable unsettled effects

### DIFF
--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/commit.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/commit.clj
@@ -81,8 +81,7 @@
 
       (not= :proposed (:effect/state t))
       (record/wrong-state (msg/t :commit/not-proposed)
-                          {:effect/id (:effect/id t)
-                           :effect/state (:effect/state t)})
+                          (record/lifecycle-position t))
 
       (= :authority/unenforced grant-record)
       (execute! dir t :unenforced now effect-fn)

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/interface.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/interface.clj
@@ -68,6 +68,6 @@
   core/commit!)
 
 (def ^{:stratum 0} reconcile!
-  "Ask the external system what actually happened and record the answer,
-   mismatch included."
+  "Reload a durable unsettled record, ask the external system what happened,
+   and record the answer, mismatch included."
   core/reconcile!)

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/reconcile.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/reconcile.clj
@@ -18,10 +18,12 @@
 (ns ai.miniforge.effect-transaction.reconcile
   "Settle unknown effect outcomes by asking the external system."
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.effect-transaction.call :as call]
    [ai.miniforge.effect-transaction.messages :as msg]
    [ai.miniforge.effect-transaction.record :as record]
-   [ai.miniforge.effect-transaction.schema :as schema])
+   [ai.miniforge.effect-transaction.schema :as schema]
+   [ai.miniforge.effect-transaction.store :as store])
   (:import
    [java.time Instant]))
 
@@ -51,9 +53,18 @@
 
 (defn ^{:stratum 2} reconcile!
   "Ask the world to settle a committing or unknown-outcome record."
-  [dir t probe-fn ^Instant now]
-  (if-not (contains? schema/reconcilable-states (:effect/state t))
-    (record/wrong-state (msg/t :reconcile/not-reconcilable)
-                        {:effect/id (:effect/id t)
-                         :effect/state (:effect/state t)})
-    (probe! dir t probe-fn now)))
+  [dir candidate probe-fn ^Instant now]
+  (let [id (:effect/id candidate)
+        t (store/read-record dir id)]
+    (cond
+      (anomaly/anomaly? t) t
+
+      (nil? t)
+      (store/not-found id)
+
+      (not (contains? schema/reconcilable-states (:effect/state t)))
+      (record/wrong-state (msg/t :reconcile/not-reconcilable)
+                          (record/lifecycle-position t))
+
+      :else
+      (probe! dir t probe-fn now))))

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/reconcile.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/reconcile.clj
@@ -52,7 +52,8 @@
 ;------------------------------------------------------------------------------ Layer 2
 
 (defn ^{:stratum 2} reconcile!
-  "Ask the world to settle a committing or unknown-outcome record."
+  "Reload a durable transaction and, when it remains unsettled, ask the world
+   to settle its committing or unknown outcome."
   [dir candidate probe-fn ^Instant now]
   (let [id (:effect/id candidate)
         t (store/read-record dir id)]

--- a/components/effect-transaction/src/ai/miniforge/effect_transaction/record.clj
+++ b/components/effect-transaction/src/ai/miniforge/effect_transaction/record.clj
@@ -35,6 +35,12 @@
   [t]
   (m/validate schema/EffectTransaction t))
 
+(defn ^{:stratum 0} lifecycle-position
+  "Identify a transaction and its current lifecycle state."
+  [t]
+  {:effect/id (:effect/id t)
+   :effect/state (:effect/state t)})
+
 (defn- ^{:stratum 0} invalid
   [message t]
   (anomaly/sub-anomaly :invalid-input

--- a/components/effect-transaction/test/ai/miniforge/effect_transaction/fixtures.clj
+++ b/components/effect-transaction/test/ai/miniforge/effect_transaction/fixtures.clj
@@ -47,6 +47,12 @@
   [count]
   {:usage/count count})
 
+(defn ^{:stratum 0} probe-answer
+  "Build the external observation returned by a reconciliation probe."
+  [observed matched?]
+  {:effect/observed observed
+   :effect/matched? matched?})
+
 (defn ^{:stratum 0} tmp-dir
   "A fresh directory for one effect-transaction test."
   []

--- a/components/effect-transaction/test/ai/miniforge/effect_transaction/reconcile_test.clj
+++ b/components/effect-transaction/test/ai/miniforge/effect_transaction/reconcile_test.clj
@@ -56,7 +56,7 @@
         stale (assoc done :effect/state :unknown-outcome)
         probes (atom 0)
         result (fx/reconcile! dir stale (fn [_] (swap! probes inc)) later)]
-    (is (anomaly/anomaly? result))
+    (is (= :conflict (:anomaly/type result)))
     (is (zero? @probes))))
 
 (deftest ^{:stratum 1} missing-durable-record-does-not-probe-test

--- a/components/effect-transaction/test/ai/miniforge/effect_transaction/reconcile_test.clj
+++ b/components/effect-transaction/test/ai/miniforge/effect_transaction/reconcile_test.clj
@@ -20,7 +20,7 @@
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.effect-transaction.fixtures :as fixture]
    [ai.miniforge.effect-transaction.interface :as fx]
-   [clojure.test :refer [deftest is testing]]))
+   [clojure.test :refer [deftest is]]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -30,125 +30,146 @@
 
 (def ^{:stratum 0} tmp-dir fixture/tmp-dir)
 
-(def ^{:stratum 0} merge-grant fixture/merge-grant)
+(def ^{:stratum 0} merge-case! fixture/merge-case!)
 
-(def ^{:stratum 0} propose-merge! fixture/propose-merge!)
+(def ^{:stratum 0} succeed! fixture/succeed!)
+
+(def ^{:stratum 0} no-usage fixture/no-usage)
+
+(def ^{:stratum 0} probe-answer fixture/probe-answer)
+
+(def ^{:stratum 0} throw-exception! fixture/throw-exception!)
 
 ;------------------------------------------------------------------------------ Layer 1
 
-(deftest ^{:stratum 1} reconcile-reads-the-world-not-the-log-test
-  (let [dir (tmp-dir)]
-    (testing "the observation comes from the probe, and a match is recorded"
-      (let [g (merge-grant)
-            t (propose-merge! dir g)
-            unknown (fx/commit! dir t g {} now (fn [] (throw (ex-info "boom" {}))))
-            settled (fx/reconcile! dir unknown
-                                   (fn [_] {:effect/observed {:pr/state "MERGED"
-                                                              :merge/sha "real-sha"}
-                                            :effect/matched? true})
-                                   later)]
-        (is (= :reconciled (:effect/state settled)))
-        (is (= "real-sha" (get-in settled [:effect/observed :merge/sha])))
-        (is (true? (:effect/matched? settled)))))
+(defn- ^{:stratum 1} unknown-case!
+  [dir]
+  (let [{g :grant t :transaction} (merge-case! dir)]
+    {:transaction t
+     :unknown (fx/commit! dir t g no-usage now
+                          (partial throw-exception! "boom"))}))
 
-    (testing "a MISMATCH is recorded, not smoothed over"
-      (let [g (merge-grant)
-            t (propose-merge! dir g)
-            unknown (fx/commit! dir t g {} now (fn [] (throw (ex-info "boom" {}))))
-            settled (fx/reconcile! dir unknown
-                                   (fn [_] {:effect/observed {:pr/state "CLOSED"}
-                                            :effect/matched? false})
-                                   later)]
-        (is (= :reconciled (:effect/state settled)))
-        (is (false? (:effect/matched? settled))
-            "finding out includes finding out you were wrong")))
+(deftest ^{:stratum 1} durable-settlement-overrides-stale-candidate-test
+  (let [dir (tmp-dir)
+        {g :grant t :transaction} (merge-case! dir)
+        done (fx/commit! dir t g no-usage now succeed!)
+        stale (assoc done :effect/state :unknown-outcome)
+        probes (atom 0)
+        result (fx/reconcile! dir stale (fn [_] (swap! probes inc)) later)]
+    (is (anomaly/anomaly? result))
+    (is (zero? @probes))))
 
-    (testing "a probe that throws leaves the record unresolved for a later attempt"
-      (let [g (merge-grant)
-            t (propose-merge! dir g)
-            unknown (fx/commit! dir t g {} now (fn [] (throw (ex-info "boom" {}))))
-            result (fx/reconcile! dir unknown (fn [_] (throw (ex-info "network" {}))) later)]
-        (is (anomaly/anomaly? result))
-        (is (= :unknown-outcome (:effect/state (fx/read-record dir (:effect/id t))))
-            "marking :reconciled here would assert we found out when we did not")))
+(deftest ^{:stratum 1} missing-durable-record-does-not-probe-test
+  (let [dir (tmp-dir)
+        probes (atom 0)
+        result (fx/reconcile! dir {:effect/id (random-uuid)}
+                              (fn [_] (swap! probes inc)) later)]
+    (is (= :conflict (:anomaly/type result)))
+    (is (zero? @probes))))
 
-    (testing "a probe answering in an unreadable shape also leaves it unresolved"
-      (let [g (merge-grant)
-            t (propose-merge! dir g)
-            unknown (fx/commit! dir t g {} now (fn [] (throw (ex-info "boom" {}))))
-            result (fx/reconcile! dir unknown (constantly {:something :else}) later)]
-        (is (anomaly/anomaly? result))
-        (is (= :unknown-outcome (:effect/state (fx/read-record dir (:effect/id t)))))))
-
-    (testing "a probe answer carrying the internal marker key is still honoured"
-      ;; The probe returns caller-shaped data, so any in-band sentinel is
-      ;; a value it could legitimately carry. Wrapping the answer instead
-      ;; of probing it for a marker is what keeps that from colliding.
-      (let [g (merge-grant)
-            t (propose-merge! dir g)
-            unknown (fx/commit! dir t g {} now (fn [] (throw (ex-info "boom" {}))))
-            settled (fx/reconcile! dir unknown
-                                   (constantly {:effect/observed {:threw "not an error"}
-                                                :threw "nor is this"
-                                                :effect/matched? true})
-                                   later)]
-        (is (= :reconciled (:effect/state settled)))
-        (is (true? (:effect/matched? settled)))))
-
-    (testing "an answer with no :effect/matched? records a mismatch, not a match"
-      (let [g (merge-grant)
-            t (propose-merge! dir g)
-            unknown (fx/commit! dir t g {} now (fn [] (throw (ex-info "boom" {}))))
-            settled (fx/reconcile! dir unknown
-                                   (constantly {:effect/observed {:pr/state "MERGED"}})
-                                   later)]
-        (is (= :reconciled (:effect/state settled)))
-        (is (false? (:effect/matched? settled))
-            "an unflagged disagreement is worse than a flagged one")))
-
-    (testing "an already-settled record is not reconcilable"
-      (let [g (merge-grant)
-            t (propose-merge! dir g)
-            done (fx/commit! dir t g {} now (fn [] {:effect/outcome :succeeded}))]
-        (is (anomaly/anomaly?
-             (fx/reconcile! dir done (constantly {:effect/observed :x}) later)))))))
+(deftest ^{:stratum 1} invalid-candidate-id-does-not-probe-test
+  (let [probes (atom 0)
+        result (fx/reconcile! (tmp-dir) {:effect/id "../outside-store"}
+                              (fn [_] (swap! probes inc)) later)]
+    (is (= :invalid-input (:anomaly/type result)))
+    (is (zero? @probes))))
 
 (deftest ^{:stratum 1} committing-is-reconcilable-after-a-restart-test
   ;; A process that died mid-effect leaves the record at :committing.
   ;; That is not failure and not success — it is exactly the case
   ;; reconciliation exists for.
   (let [dir (tmp-dir)
-        g (merge-grant)
-        t (propose-merge! dir g)]
+        {g :grant t :transaction} (merge-case! dir)]
     (is (thrown? AssertionError
-                 (fx/commit! dir t g {} now
+                 (fx/commit! dir t g no-usage now
                              (fn [] (throw (AssertionError.))))))
     (let [crashed (fx/read-record dir (:effect/id t))
           settled (fx/reconcile! dir crashed
-                                 (fn [_] {:effect/observed {:pr/state "OPEN"}
-                                          :effect/matched? false})
+                                 (fn [_] (probe-answer {:pr/state "OPEN"} false))
                                  later)]
       (is (contains? fx/reconcilable-states :committing))
       (is (= :reconciled (:effect/state settled)))
       (is (false? (:effect/matched? settled))))))
 
-(deftest ^{:stratum 1} refusal-anomalies-route-correctly-test
-  ;; :unauthorized would say "you lack permission", which is neither
-  ;; true nor useful here. A wrong lifecycle position is a :conflict; a
-  ;; probe that did not answer is :unavailable — transient, ask again.
+(deftest ^{:stratum 1} settled-record-reconciliation-is-conflict-test
+  ;; A settled lifecycle position conflicts with the request; it is not an
+  ;; authorization failure.
   (let [dir (tmp-dir)
-        settled-grant (merge-grant)
-        unknown-grant (merge-grant)
-        settled (fx/commit! dir (propose-merge! dir settled-grant)
-                            settled-grant {} now
-                            (fn [] {:effect/outcome :succeeded}))
-        unknown (fx/commit! dir (propose-merge! dir unknown-grant)
-                            unknown-grant {} now
-                            (fn [] (throw (ex-info "boom" {}))))]
-    (testing "reconciling a settled record is a :conflict, not a permission error"
-      (is (= :conflict (:anomaly/type
-                        (fx/reconcile! dir settled (constantly {:effect/observed :x}) later)))))
-    (testing "a probe that did not answer is :unavailable, and carries the cause"
-      (let [a (fx/reconcile! dir unknown (fn [_] (throw (ex-info "network down" {}))) later)]
-        (is (= :unavailable (:anomaly/type a)))
-        (is (= "network down" (get-in a [:anomaly/data :probe/error])))))))
+        {settled-grant :grant settled-t :transaction} (merge-case! dir)
+        settled (fx/commit! dir settled-t settled-grant no-usage now succeed!)
+        result (fx/reconcile! dir settled
+                              (constantly (probe-answer :unused true))
+                              later)]
+    (is (= :conflict (:anomaly/type result)))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} reconciliation-records-probe-match-test
+  (let [dir (tmp-dir)
+        {unknown :unknown} (unknown-case! dir)
+        settled (fx/reconcile! dir unknown
+                               (fn [_] (probe-answer {:pr/state "MERGED"
+                                                      :merge/sha "real-sha"}
+                                                     true))
+                               later)]
+    (is (= :reconciled (:effect/state settled)))
+    (is (= "real-sha" (get-in settled [:effect/observed :merge/sha])))
+    (is (true? (:effect/matched? settled)))))
+
+(deftest ^{:stratum 2} reconciliation-records-probe-mismatch-test
+  (let [dir (tmp-dir)
+        {unknown :unknown} (unknown-case! dir)
+        settled (fx/reconcile! dir unknown
+                               (fn [_] (probe-answer {:pr/state "CLOSED"} false))
+                               later)]
+    (is (= :reconciled (:effect/state settled)))
+    (is (false? (:effect/matched? settled))
+        "finding out includes finding out the proposal mismatched")))
+
+(deftest ^{:stratum 2} throwing-probe-leaves-record-unresolved-test
+  (let [dir (tmp-dir)
+        {t :transaction unknown :unknown} (unknown-case! dir)
+        result (fx/reconcile! dir unknown
+                              (fn [_] (throw-exception! "network"))
+                              later)]
+    (is (anomaly/anomaly? result))
+    (is (= :unknown-outcome (:effect/state (fx/read-record dir (:effect/id t))))
+        "without an answer, reconciliation must not claim knowledge")))
+
+(deftest ^{:stratum 2} unreadable-probe-answer-leaves-record-unresolved-test
+  (let [dir (tmp-dir)
+        {t :transaction unknown :unknown} (unknown-case! dir)
+        result (fx/reconcile! dir unknown (constantly {:something :else}) later)]
+    (is (anomaly/anomaly? result))
+    (is (= :unknown-outcome (:effect/state (fx/read-record dir (:effect/id t)))))))
+
+(deftest ^{:stratum 2} probe-answer-may-carry-in-band-marker-test
+  ;; Probe data is caller-shaped, so internal status must never use an in-band
+  ;; sentinel that can collide with a legitimate answer.
+  (let [dir (tmp-dir)
+        {unknown :unknown} (unknown-case! dir)
+        answer (assoc (probe-answer {:threw "not an error"} true)
+                      :threw "nor is this")
+        settled (fx/reconcile! dir unknown (constantly answer) later)]
+    (is (= :reconciled (:effect/state settled)))
+    (is (true? (:effect/matched? settled)))))
+
+(deftest ^{:stratum 2} absent-match-flag-records-mismatch-test
+  (let [dir (tmp-dir)
+        {unknown :unknown} (unknown-case! dir)
+        settled (fx/reconcile! dir unknown
+                               (constantly {:effect/observed {:pr/state "MERGED"}})
+                               later)]
+    (is (= :reconciled (:effect/state settled)))
+    (is (false? (:effect/matched? settled))
+        "an unflagged disagreement is not evidence of a match")))
+
+(deftest ^{:stratum 2} unanswered-probe-is-unavailable-test
+  ;; A silent external system is transient; callers must be able to retry.
+  (let [dir (tmp-dir)
+        {unknown :unknown} (unknown-case! dir)
+        result (fx/reconcile! dir unknown
+                              (fn [_] (throw-exception! "network down"))
+                              later)]
+    (is (= :unavailable (:anomaly/type result)))
+    (is (= "network down" (get-in result [:anomaly/data :probe/error])))))

--- a/docs/pull-requests/2026-08-07-codex-n7-effect-reconcile-durable.md
+++ b/docs/pull-requests/2026-08-07-codex-n7-effect-reconcile-durable.md
@@ -1,0 +1,70 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix: reconcile only durable unsettled effects
+
+## Overview
+
+Makes reconciliation reload the durable effect transaction before probing an
+external system. Stale caller state can no longer reopen an already-settled
+effect or cause a probe for a missing or invalid transaction identity.
+
+## Layer
+
+Application service — durable effect reconciliation orchestration.
+
+## Depends on
+
+- #1700 (durable commit authorization and single-claim fencing) — merged
+
+## Strata Affected
+
+- Reconciliation coordinator — resolve the durable record before probing.
+- Record vocabulary — centralize the lifecycle-position value shape.
+- Tests — decompose reconciliation outcomes into single-purpose cases.
+
+## Motivation
+
+Reconciliation previously trusted the lifecycle state in a caller-supplied
+record. A stale value could therefore probe an effect whose durable record had
+already settled. Durable storage must remain the authority for lifecycle
+decisions on both commit and reconciliation paths.
+
+## Changes in Detail
+
+- Reload reconciliation candidates by their validated durable effect ID.
+- Refuse missing, invalid, and already-settled durable records before probing.
+- Preserve compare-and-set recording of valid probe answers.
+- Centralize lifecycle-position maps used by commit and reconciliation.
+- Replace one multi-scenario reconciliation test with focused tests and shared
+  factories.
+
+## Testing Plan
+
+- Test durable state overriding a stale caller state without probing.
+- Test missing and invalid durable identities without probing.
+- Test matched, mismatched, unreadable, throwing, and marker-shaped answers.
+- Test restart recovery from the durable `:committing` state.
+- Run effect-transaction tests in every composing project.
+- Run Poly, Kondo, stratum lint, compliance review, and full pre-commit.
+
+## Deployment Plan
+
+Merge to `main`; this changes reconciliation lookup semantics and requires no
+record migration.
+
+## Related Issues/PRs
+
+- Completes `work/ariadne-effect-transaction-fencing.spec.edn`.
+
+## Checklist
+
+- [ ] Reconciliation reloads the durable transaction
+- [ ] Stale settled records are refused without probing
+- [ ] Missing and invalid transaction identities are refused without probing
+- [ ] Probe outcomes preserve the honest unknown/reconciled contract
+- [ ] Poly reports zero errors and zero warnings
+- [ ] Standards and pre-commit gates pass


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# fix: reconcile only durable unsettled effects

## Overview

Makes reconciliation reload the durable effect transaction before probing an
external system. Stale caller state can no longer reopen an already-settled
effect or cause a probe for a missing or invalid transaction identity.

## Layer

Application service — durable effect reconciliation orchestration.

## Depends on

- #1700 (durable commit authorization and single-claim fencing) — merged

## Strata Affected

- Reconciliation coordinator — resolve the durable record before probing.
- Record vocabulary — centralize the lifecycle-position value shape.
- Tests — decompose reconciliation outcomes into single-purpose cases.

## Motivation

Reconciliation previously trusted the lifecycle state in a caller-supplied
record. A stale value could therefore probe an effect whose durable record had
already settled. Durable storage must remain the authority for lifecycle
decisions on both commit and reconciliation paths.

## Changes in Detail

- Reload reconciliation candidates by their validated durable effect ID.
- Refuse missing, invalid, and already-settled durable records before probing.
- Preserve compare-and-set recording of valid probe answers.
- Centralize lifecycle-position maps used by commit and reconciliation.
- Replace one multi-scenario reconciliation test with focused tests and shared
  factories.

## Testing Plan

- Test durable state overriding a stale caller state without probing.
- Test missing and invalid durable identities without probing.
- Test matched, mismatched, unreadable, throwing, and marker-shaped answers.
- Test restart recovery from the durable `:committing` state.
- Run effect-transaction tests in every composing project.
- Run Poly, Kondo, stratum lint, compliance review, and full pre-commit.

## Deployment Plan

Merge to `main`; this changes reconciliation lookup semantics and requires no
record migration.

## Related Issues/PRs

- Completes `work/ariadne-effect-transaction-fencing.spec.edn`.

## Checklist

- [ ] Reconciliation reloads the durable transaction
- [ ] Stale settled records are refused without probing
- [ ] Missing and invalid transaction identities are refused without probing
- [ ] Probe outcomes preserve the honest unknown/reconciled contract
- [ ] Poly reports zero errors and zero warnings
- [ ] Standards and pre-commit gates pass
