### PR TITLE
refactor: add provider-backed merge thread readback

### DIFF
--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github.clj
@@ -64,6 +64,32 @@
    Renders as nothing in PR Markdown."
   "<!-- miniforge:policy-eval -->")
 
+(def ^{:stratum 0} ^:private review-threads-query
+  "Paginated provider readback for pull-request review threads."
+  "query($owner:String!,$repo:String!,$pr:Int!,$cursor:String) {
+  repository(owner:$owner, name:$repo) {
+    pullRequest(number:$pr) {
+      reviewThreads(first:100, after:$cursor) {
+        nodes { id isResolved }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}")
+
+(defn- ^{:stratum 0} valid-review-thread-page?
+  "True when GitHub returned the complete page shape needed to decide."
+  [threads]
+  (let [nodes (:nodes threads)
+        page-info (:pageInfo threads)]
+    (and (map? threads)
+         (vector? nodes)
+         (every? #(and (string? (:id %))
+                       (boolean? (:isResolved %)))
+                 nodes)
+         (map? page-info)
+         (boolean? (:hasNextPage page-info)))))
+
 (defn- ^{:stratum 0} run-gh-with-stdin
   "Run a `gh` command piping `stdin-body` over stdin. Returns the
    same DAG-shaped result as `run-gh-command`. Used for `gh api ...
@@ -148,6 +174,24 @@
           (dag/err :json-parse-error (.getMessage e))))
       result)))
 
+(defn- ^{:stratum 1} repository-coordinates
+  "Read the GitHub owner and repository name from the origin remote."
+  [worktree-path]
+  (let [result (run-gh-command
+                ["git" "config" "--get" "remote.origin.url"]
+                worktree-path)]
+    (if (dag/err? result)
+      result
+      (let [remote-url (str/trim (or (:output (:data result)) ""))
+            parts (re-find #"github\.com[:/]([^/]+)/([^/]+)$" remote-url)
+            owner (nth parts 1 nil)
+            repo (some-> (nth parts 2 nil)
+                         (str/replace #"\.git$" ""))]
+        (if (and owner (seq repo))
+          (dag/ok {:owner owner :repo repo})
+          (dag/err :invalid-remote
+                   (str "Could not parse owner/repo from remote URL: " remote-url)))))))
+
 (defn ^{:stratum 1} reply-to-comment
   "Post a reply to a review comment thread.
 
@@ -198,22 +242,13 @@
    - pr-number: Pull request number
    - comment-id: REST API comment ID (integer)
 
-   Returns DAG result with :thread-id or error"
+  Returns DAG result with :thread-id or error"
   [worktree-path pr-number comment-id]
-  (let [;; First get repo owner/name from git remote
-        remote-result (run-gh-command ["git" "config" "--get" "remote.origin.url"] worktree-path)]
-    (if (dag/err? remote-result)
-      remote-result
-      (let [remote-url (str/trim (:output (:data remote-result)))
-            ;; Parse owner/repo from URL (supports both SSH and HTTPS)
-            ;; git@github.com:owner/repo.git or https://github.com/owner/repo.git
-            parts (re-find #"github\.com[:/]([^/]+)/([^/.]+)" remote-url)
-            owner (nth parts 1 nil)
-            repo (nth parts 2 nil)]
-        (if-not (and owner repo)
-          (dag/err :invalid-remote
-                   (str "Could not parse owner/repo from remote URL: " remote-url))
-          (let [query (str "query {
+  (let [repository-result (repository-coordinates worktree-path)]
+    (if (dag/err? repository-result)
+      repository-result
+      (let [{:keys [owner repo]} (:data repository-result)
+            query (str "query {
   repository(owner: \"" owner "\", name: \"" repo "\") {
     pullRequest(number: " pr-number ") {
       reviewThreads(first: 100) {
@@ -230,23 +265,21 @@
     }
   }
 }")
-                result (graphql-query query worktree-path)]
-            (if (dag/ok? result)
-              (let [threads (get-in (:data result) [:data :repository :pullRequest :reviewThreads :nodes])
-                    ;; Find thread containing our comment ID
-                    matching-thread (some (fn [thread]
-                                            (when (some #(= (:databaseId %) comment-id)
-                                                        (get-in thread [:comments :nodes]))
-                                              thread))
-                                          threads)]
-                (if matching-thread
-                  (dag/ok {:thread-id (:id matching-thread)
-                           :is-resolved (:isResolved matching-thread)})
-                  (dag/err :thread-not-found
-                           "Could not find thread containing comment ID"
-                           {:comment-id comment-id
-                            :pr-number pr-number})))
-              result)))))))
+            result (graphql-query query worktree-path)]
+        (if (dag/ok? result)
+          (let [threads (get-in (:data result) [:data :repository :pullRequest :reviewThreads :nodes])
+                matching-thread (some (fn [thread]
+                                        (when (some #(= (:databaseId %) comment-id)
+                                                    (get-in thread [:comments :nodes]))
+                                          thread))
+                                      threads)]
+            (if matching-thread
+              (dag/ok {:thread-id (:id matching-thread)
+                       :is-resolved (:isResolved matching-thread)})
+              (dag/err :thread-not-found
+                       "Could not find thread containing comment ID"
+                       {:comment-id comment-id :pr-number pr-number})))
+          result)))))
 
 (defn ^{:stratum 2} post-review!
   "Post a single PR review batching multiple inline comments.
@@ -331,6 +364,39 @@
                    "Thread resolution returned false"
                    {:thread-id thread-id :thread thread})))
       result)))
+
+(defn ^{:stratum 2} unresolved-review-threads
+  "Read every review-thread page and report whether any thread is unresolved."
+  [worktree-path pr-number]
+  (let [repository-result (repository-coordinates worktree-path)]
+    (if (dag/err? repository-result)
+      repository-result
+      (let [{:keys [owner repo]} (:data repository-result)]
+        (loop [cursor nil
+               unresolved-count 0]
+          (let [variables (cond-> {:owner owner :repo repo :pr pr-number}
+                            cursor (assoc :cursor cursor))
+                result (graphql-query review-threads-query worktree-path
+                                      :variables variables)]
+            (if (dag/err? result)
+              result
+              (let [threads (get-in (:data result)
+                                    [:data :repository :pullRequest :reviewThreads])
+                    page-info (:pageInfo threads)]
+                (if-not (valid-review-thread-page? threads)
+                  (dag/err :invalid-review-thread-response
+                           "GitHub returned incomplete review thread state")
+                  (let [total (+ unresolved-count
+                                 (count (remove :isResolved (:nodes threads))))]
+                    (if (:hasNextPage page-info)
+                      (let [next-cursor (:endCursor page-info)]
+                        (if (or (not (string? next-cursor))
+                                (str/blank? next-cursor))
+                          (dag/err :invalid-pagination
+                                   "GitHub review thread page omitted its next cursor")
+                          (recur next-cursor total)))
+                      (dag/ok {:has-unresolved? (pos? total)
+                               :unresolved-count total}))))))))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github.clj
@@ -209,15 +209,15 @@
                 worktree-path)]
     (if (dag/err? result)
       result
-      (let [remote-url (str/trim (or (:output (:data result)) ""))
-            parts (re-find #"github\.com[:/]([^/]+)/([^/]+)$" remote-url)
+      (let [remote-url (str/trim (get (:data result) :output ""))
+            parts (re-find #"github\.com(?::\d+)?[:/]([^/]+)/([^/]+)/?$" remote-url)
             owner (nth parts 1 nil)
             repo (some-> (nth parts 2 nil)
                          (str/replace #"\.git$" ""))]
         (if (and owner (seq repo))
           (dag/ok {:owner owner :repo repo})
           (dag/err :invalid-remote
-                   (str "Could not parse owner/repo from remote URL: " remote-url)))))))
+                   "Could not parse GitHub owner/repository from origin remote"))))))
 
 (defn- ^{:stratum 1} review-comment-root-id
   "Resolve a review reply to its thread's root REST comment ID."

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github.clj
@@ -77,6 +77,19 @@
   }
 }")
 
+(def ^{:stratum 0} ^:private review-thread-roots-query
+  "Paginated review-thread roots used to locate a REST review comment."
+  "query($owner:String!,$repo:String!,$pr:Int!,$cursor:String) {
+  repository(owner:$owner, name:$repo) {
+    pullRequest(number:$pr) {
+      reviewThreads(first:100, after:$cursor) {
+        nodes { id isResolved comments(first:1) { nodes { databaseId } } }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}")
+
 (defn- ^{:stratum 0} valid-review-thread-page?
   "True when GitHub returned the complete page shape needed to decide."
   [threads]
@@ -89,6 +102,13 @@
                  nodes)
          (map? page-info)
          (boolean? (:hasNextPage page-info)))))
+
+(defn- ^{:stratum 0} valid-next-cursor?
+  "True when pagination can advance without repeating a page."
+  [cursor seen-cursors]
+  (and (string? cursor)
+       (not (str/blank? cursor))
+       (not (contains? seen-cursors cursor))))
 
 (defn- ^{:stratum 0} run-gh-with-stdin
   "Run a `gh` command piping `stdin-body` over stdin. Returns the
@@ -144,6 +164,13 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
+(defn- ^{:stratum 1} valid-review-thread-root-page?
+  "True when every thread exposes its integer root comment ID."
+  [threads]
+  (and (valid-review-thread-page? threads)
+       (every? #(integer? (get-in % [:comments :nodes 0 :databaseId]))
+               (:nodes threads))))
+
 (defn ^{:stratum 1} graphql-query
   "Execute a GraphQL query via gh CLI.
 
@@ -191,6 +218,27 @@
           (dag/ok {:owner owner :repo repo})
           (dag/err :invalid-remote
                    (str "Could not parse owner/repo from remote URL: " remote-url)))))))
+
+(defn- ^{:stratum 1} review-comment-root-id
+  "Resolve a review reply to its thread's root REST comment ID."
+  [worktree-path owner repo comment-id]
+  (let [result (run-gh-command
+                ["gh" "api" (str "repos/" owner "/" repo
+                                  "/pulls/comments/" comment-id)]
+                worktree-path)]
+    (if (dag/err? result)
+      result
+      (try
+        (let [comment (json/parse-string (get (:data result) :output "") true)
+              root-id (if-some [reply-to-id (:in_reply_to_id comment)]
+                        reply-to-id
+                        (:id comment))]
+          (if (integer? root-id)
+            (dag/ok root-id)
+            (dag/err :invalid-review-comment-response
+                     "GitHub returned a review comment without an integer ID")))
+        (catch Exception e
+          (dag/err :json-parse-error (.getMessage e)))))))
 
 (defn ^{:stratum 1} reply-to-comment
   "Post a reply to a review comment thread.
@@ -248,38 +296,44 @@
     (if (dag/err? repository-result)
       repository-result
       (let [{:keys [owner repo]} (:data repository-result)
-            query (str "query {
-  repository(owner: \"" owner "\", name: \"" repo "\") {
-    pullRequest(number: " pr-number ") {
-      reviewThreads(first: 100) {
-        nodes {
-          id
-          isResolved
-          comments(first: 10) {
-            nodes {
-              databaseId
-            }
-          }
-        }
-      }
-    }
-  }
-}")
-            result (graphql-query query worktree-path)]
-        (if (dag/ok? result)
-          (let [threads (get-in (:data result) [:data :repository :pullRequest :reviewThreads :nodes])
-                matching-thread (some (fn [thread]
-                                        (when (some #(= (:databaseId %) comment-id)
-                                                    (get-in thread [:comments :nodes]))
-                                          thread))
-                                      threads)]
-            (if matching-thread
-              (dag/ok {:thread-id (:id matching-thread)
-                       :is-resolved (:isResolved matching-thread)})
-              (dag/err :thread-not-found
-                       "Could not find thread containing comment ID"
-                       {:comment-id comment-id :pr-number pr-number})))
-          result)))))
+            root-result (review-comment-root-id worktree-path owner repo comment-id)]
+        (if (dag/err? root-result)
+          root-result
+          (loop [cursor nil
+                 seen-cursors #{}]
+            (let [variables (cond-> {:owner owner :repo repo :pr pr-number}
+                              cursor (assoc :cursor cursor))
+                  result (graphql-query review-thread-roots-query worktree-path
+                                        :variables variables)]
+              (if (dag/err? result)
+                result
+                (let [threads (get-in (:data result)
+                                      [:data :repository :pullRequest :reviewThreads])
+                      matching-thread
+                      (some #(when (= (:data root-result)
+                                      (get-in % [:comments :nodes 0 :databaseId]))
+                               %)
+                            (:nodes threads))]
+                  (cond
+                    (not (valid-review-thread-root-page? threads))
+                    (dag/err :invalid-review-thread-response
+                             "GitHub returned incomplete review thread state")
+
+                    matching-thread
+                    (dag/ok {:thread-id (:id matching-thread)
+                             :is-resolved (:isResolved matching-thread)})
+
+                    (:hasNextPage (:pageInfo threads))
+                    (let [next-cursor (:endCursor (:pageInfo threads))]
+                      (if-not (valid-next-cursor? next-cursor seen-cursors)
+                        (dag/err :invalid-pagination
+                                 "GitHub returned an invalid review thread cursor")
+                        (recur next-cursor (conj seen-cursors next-cursor))))
+
+                    :else
+                    (dag/err :thread-not-found
+                             "Could not find thread containing comment ID"
+                             {:comment-id comment-id :pr-number pr-number})))))))))))
 
 (defn ^{:stratum 2} post-review!
   "Post a single PR review batching multiple inline comments.
@@ -391,9 +445,7 @@
                                  (count (remove :isResolved (:nodes threads))))]
                     (if (:hasNextPage page-info)
                       (let [next-cursor (:endCursor page-info)]
-                        (if (or (not (string? next-cursor))
-                                (str/blank? next-cursor)
-                                (contains? seen-cursors next-cursor))
+                        (if-not (valid-next-cursor? next-cursor seen-cursors)
                           (dag/err :invalid-pagination
                                    "GitHub returned an invalid review thread cursor")
                           (recur next-cursor

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github.clj
@@ -22,6 +22,7 @@
    for resolving conversation threads and posting replies to comments."
   (:require
    [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.pr-lifecycle.github-review-threads :as review-threads]
    [babashka.process :as process]
    [cheshire.core :as json]
    [clojure.string :as str]))
@@ -63,52 +64,6 @@
    under a personal access token, so we tag the body instead).
    Renders as nothing in PR Markdown."
   "<!-- miniforge:policy-eval -->")
-
-(def ^{:stratum 0} ^:private review-threads-query
-  "Paginated provider readback for pull-request review threads."
-  "query($owner:String!,$repo:String!,$pr:Int!,$cursor:String) {
-  repository(owner:$owner, name:$repo) {
-    pullRequest(number:$pr) {
-      reviewThreads(first:100, after:$cursor) {
-        nodes { id isResolved }
-        pageInfo { hasNextPage endCursor }
-      }
-    }
-  }
-}")
-
-(def ^{:stratum 0} ^:private review-thread-roots-query
-  "Paginated review-thread roots used to locate a REST review comment."
-  "query($owner:String!,$repo:String!,$pr:Int!,$cursor:String) {
-  repository(owner:$owner, name:$repo) {
-    pullRequest(number:$pr) {
-      reviewThreads(first:100, after:$cursor) {
-        nodes { id isResolved comments(first:1) { nodes { databaseId } } }
-        pageInfo { hasNextPage endCursor }
-      }
-    }
-  }
-}")
-
-(defn- ^{:stratum 0} valid-review-thread-page?
-  "True when GitHub returned the complete page shape needed to decide."
-  [threads]
-  (let [nodes (:nodes threads)
-        page-info (:pageInfo threads)]
-    (and (map? threads)
-         (vector? nodes)
-         (every? #(and (string? (:id %))
-                       (boolean? (:isResolved %)))
-                 nodes)
-         (map? page-info)
-         (boolean? (:hasNextPage page-info)))))
-
-(defn- ^{:stratum 0} valid-next-cursor?
-  "True when pagination can advance without repeating a page."
-  [cursor seen-cursors]
-  (and (string? cursor)
-       (not (str/blank? cursor))
-       (not (contains? seen-cursors cursor))))
 
 (defn- ^{:stratum 0} run-gh-with-stdin
   "Run a `gh` command piping `stdin-body` over stdin. Returns the
@@ -164,13 +119,6 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
-(defn- ^{:stratum 1} valid-review-thread-root-page?
-  "True when every thread exposes its integer root comment ID."
-  [threads]
-  (and (valid-review-thread-page? threads)
-       (every? #(integer? (get-in % [:comments :nodes 0 :databaseId]))
-               (:nodes threads))))
-
 (defn ^{:stratum 1} graphql-query
   "Execute a GraphQL query via gh CLI.
 
@@ -200,45 +148,6 @@
         (catch Exception e
           (dag/err :json-parse-error (.getMessage e))))
       result)))
-
-(defn- ^{:stratum 1} repository-coordinates
-  "Read the GitHub owner and repository name from the origin remote."
-  [worktree-path]
-  (let [result (run-gh-command
-                ["git" "config" "--get" "remote.origin.url"]
-                worktree-path)]
-    (if (dag/err? result)
-      result
-      (let [remote-url (str/trim (get (:data result) :output ""))
-            parts (re-find #"github\.com(?::\d+)?[:/]([^/]+)/([^/]+)/?$" remote-url)
-            owner (nth parts 1 nil)
-            repo (some-> (nth parts 2 nil)
-                         (str/replace #"\.git$" ""))]
-        (if (and owner (seq repo))
-          (dag/ok {:owner owner :repo repo})
-          (dag/err :invalid-remote
-                   "Could not parse GitHub owner/repository from origin remote"))))))
-
-(defn- ^{:stratum 1} review-comment-root-id
-  "Resolve a review reply to its thread's root REST comment ID."
-  [worktree-path owner repo comment-id]
-  (let [result (run-gh-command
-                ["gh" "api" (str "repos/" owner "/" repo
-                                  "/pulls/comments/" comment-id)]
-                worktree-path)]
-    (if (dag/err? result)
-      result
-      (try
-        (let [comment (json/parse-string (get (:data result) :output "") true)
-              root-id (if-some [reply-to-id (:in_reply_to_id comment)]
-                        reply-to-id
-                        (:id comment))]
-          (if (integer? root-id)
-            (dag/ok root-id)
-            (dag/err :invalid-review-comment-response
-                     "GitHub returned a review comment without an integer ID")))
-        (catch Exception e
-          (dag/err :json-parse-error (.getMessage e)))))))
 
 (defn ^{:stratum 1} reply-to-comment
   "Post a reply to a review comment thread.
@@ -277,63 +186,11 @@
 
 ;------------------------------------------------------------------------------ Layer 2
 
-;; GitHub API operations
 (defn ^{:stratum 2} get-thread-id
-  "Get GraphQL thread ID from a comment ID.
-
-   GitHub review comments have both a REST API comment ID and a
-   GraphQL thread ID. This function fetches the thread ID needed
-   for resolving conversations.
-
-   Arguments:
-   - worktree-path: Path to git worktree
-   - pr-number: Pull request number
-   - comment-id: REST API comment ID (integer)
-
-  Returns DAG result with :thread-id or error"
+  "Resolve a REST review comment or reply to its GraphQL review thread."
   [worktree-path pr-number comment-id]
-  (let [repository-result (repository-coordinates worktree-path)]
-    (if (dag/err? repository-result)
-      repository-result
-      (let [{:keys [owner repo]} (:data repository-result)
-            root-result (review-comment-root-id worktree-path owner repo comment-id)]
-        (if (dag/err? root-result)
-          root-result
-          (loop [cursor nil
-                 seen-cursors #{}]
-            (let [variables (cond-> {:owner owner :repo repo :pr pr-number}
-                              cursor (assoc :cursor cursor))
-                  result (graphql-query review-thread-roots-query worktree-path
-                                        :variables variables)]
-              (if (dag/err? result)
-                result
-                (let [threads (get-in (:data result)
-                                      [:data :repository :pullRequest :reviewThreads])
-                      matching-thread
-                      (some #(when (= (:data root-result)
-                                      (get-in % [:comments :nodes 0 :databaseId]))
-                               %)
-                            (:nodes threads))]
-                  (cond
-                    (not (valid-review-thread-root-page? threads))
-                    (dag/err :invalid-review-thread-response
-                             "GitHub returned incomplete review thread state")
-
-                    matching-thread
-                    (dag/ok {:thread-id (:id matching-thread)
-                             :is-resolved (:isResolved matching-thread)})
-
-                    (:hasNextPage (:pageInfo threads))
-                    (let [next-cursor (:endCursor (:pageInfo threads))]
-                      (if-not (valid-next-cursor? next-cursor seen-cursors)
-                        (dag/err :invalid-pagination
-                                 "GitHub returned an invalid review thread cursor")
-                        (recur next-cursor (conj seen-cursors next-cursor))))
-
-                    :else
-                    (dag/err :thread-not-found
-                             "Could not find thread containing comment ID"
-                             {:comment-id comment-id :pr-number pr-number})))))))))))
+  (review-threads/get-thread-id run-gh-command graphql-query
+                                worktree-path pr-number comment-id))
 
 (defn ^{:stratum 2} post-review!
   "Post a single PR review batching multiple inline comments.
@@ -420,45 +277,15 @@
       result)))
 
 (defn ^{:stratum 2} unresolved-review-threads
-  "Read every review-thread page and report whether any thread is unresolved."
+  "Read all provider pages and summarize unresolved review threads."
   [worktree-path pr-number]
-  (let [repository-result (repository-coordinates worktree-path)]
-    (if (dag/err? repository-result)
-      repository-result
-      (let [{:keys [owner repo]} (:data repository-result)]
-        (loop [cursor nil
-               seen-cursors #{}
-               unresolved-count 0]
-          (let [variables (cond-> {:owner owner :repo repo :pr pr-number}
-                            cursor (assoc :cursor cursor))
-                result (graphql-query review-threads-query worktree-path
-                                      :variables variables)]
-            (if (dag/err? result)
-              result
-              (let [threads (get-in (:data result)
-                                    [:data :repository :pullRequest :reviewThreads])
-                    page-info (:pageInfo threads)]
-                (if-not (valid-review-thread-page? threads)
-                  (dag/err :invalid-review-thread-response
-                           "GitHub returned incomplete review thread state")
-                  (let [total (+ unresolved-count
-                                 (count (remove :isResolved (:nodes threads))))]
-                    (if (:hasNextPage page-info)
-                      (let [next-cursor (:endCursor page-info)]
-                        (if-not (valid-next-cursor? next-cursor seen-cursors)
-                          (dag/err :invalid-pagination
-                                   "GitHub returned an invalid review thread cursor")
-                          (recur next-cursor
-                                 (conj seen-cursors next-cursor)
-                                 total)))
-                      (dag/ok {:has-unresolved? (pos? total)
-                               :unresolved-count total}))))))))))))
+  (review-threads/unresolved-review-threads
+   run-gh-command graphql-query worktree-path pr-number))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
-  ;; Get thread ID from comment
+  ;; Resolve a review comment to its thread.
   (get-thread-id "/path/to/repo" 148 2780310737)
-  ; => {:success true :data {:thread-id "PRRT_..." :is-resolved false ...}}
 
   ;; Reply to a comment
   (reply-to-comment "/path/to/repo" 148 2780310737 "Fixed in PR #150")

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github.clj
@@ -373,6 +373,7 @@
       repository-result
       (let [{:keys [owner repo]} (:data repository-result)]
         (loop [cursor nil
+               seen-cursors #{}
                unresolved-count 0]
           (let [variables (cond-> {:owner owner :repo repo :pr pr-number}
                             cursor (assoc :cursor cursor))
@@ -391,10 +392,13 @@
                     (if (:hasNextPage page-info)
                       (let [next-cursor (:endCursor page-info)]
                         (if (or (not (string? next-cursor))
-                                (str/blank? next-cursor))
+                                (str/blank? next-cursor)
+                                (contains? seen-cursors next-cursor))
                           (dag/err :invalid-pagination
-                                   "GitHub review thread page omitted its next cursor")
-                          (recur next-cursor total)))
+                                   "GitHub returned an invalid review thread cursor")
+                          (recur next-cursor
+                                 (conj seen-cursors next-cursor)
+                                 total)))
                       (dag/ok {:has-unresolved? (pos? total)
                                :unresolved-count total}))))))))))))
 

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github_review_thread_pages.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github_review_thread_pages.clj
@@ -74,7 +74,7 @@
   [unresolved-count nodes]
   (let [page-count (count (remove :isResolved nodes))
         total (+ unresolved-count page-count)]
-    #:page{:done? false :state total}))
+    [false total nil]))
 
 (defn- ^{:stratum 0} finish-unresolved
   [unresolved-count]
@@ -82,16 +82,11 @@
     (dag/ok {:has-unresolved? has-unresolved?
              :unresolved-count unresolved-count})))
 
-(defn- ^{:stratum 0} select-root
-  [root-id state nodes]
-  (let [matching-thread (some #(when (= root-id
-                                       (get-in % [:comments :nodes 0 :databaseId]))
-                                 %)
-                              nodes)
-        found? (some? matching-thread)]
-    #:page{:done? found?
-           :state state
-           :value matching-thread}))
+(defn- ^{:stratum 0} matching-root
+  [root-id nodes]
+  (first (filter #(= root-id
+                     (get-in % [:comments :nodes 0 :databaseId]))
+                 nodes)))
 
 (defn- ^{:stratum 0} finish-missing-root
   [comment-id pr-number _]
@@ -100,6 +95,12 @@
            {:comment-id comment-id :pr-number pr-number}))
 
 ;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} select-root
+  [root-id state nodes]
+  (let [matching-thread (matching-root root-id nodes)
+        found? (some? matching-thread)]
+    [found? state matching-thread]))
 
 (defn ^{:stratum 1} unresolved-pagination
   "Describe full review-thread pagination without embedding behavior anonymously."
@@ -156,12 +157,11 @@
        [page-result (read-page graphql-query worktree-path owner repo pr-number
                                cursor query valid-page?)]
         (let [threads (:data page-result)
-              selection (select-page state (:nodes threads))
+              [done? next-state value] (select-page state (:nodes threads))
               page-info (:pageInfo threads)
-              next-cursor (:endCursor page-info)
-              next-state (:page/state selection)]
+              next-cursor (:endCursor page-info)]
           (cond
-            (:page/done? selection) (dag/ok (:page/value selection))
+            done? (dag/ok value)
             (not (:hasNextPage page-info)) (finish next-state)
             (not (valid-next-cursor? next-cursor seen-cursors))
             (dag/err :invalid-pagination

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github_review_thread_pages.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github_review_thread_pages.clj
@@ -1,0 +1,171 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.pr-lifecycle.github-review-thread-pages
+  "Validated, cycle-safe pagination for GitHub review-thread readback."
+  (:require
+   [ai.miniforge.dag-executor.interface :as dag]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private review-threads-query
+  "query($owner:String!,$repo:String!,$pr:Int!,$cursor:String) {
+  repository(owner:$owner, name:$repo) {
+    pullRequest(number:$pr) {
+      reviewThreads(first:100, after:$cursor) {
+        nodes { id isResolved }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}")
+
+(def ^{:stratum 0} ^:private review-thread-roots-query
+  "query($owner:String!,$repo:String!,$pr:Int!,$cursor:String) {
+  repository(owner:$owner, name:$repo) {
+    pullRequest(number:$pr) {
+      reviewThreads(first:100, after:$cursor) {
+        nodes { id isResolved comments(first:1) { nodes { databaseId } } }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}")
+
+(defn- ^{:stratum 0} valid-review-thread-page?
+  [threads]
+  (let [nodes (:nodes threads)
+        page-info (:pageInfo threads)]
+    (and (map? threads)
+         (vector? nodes)
+         (every? #(and (string? (:id %))
+                       (boolean? (:isResolved %)))
+                 nodes)
+         (map? page-info)
+         (boolean? (:hasNextPage page-info)))))
+
+(defn- ^{:stratum 0} valid-next-cursor?
+  [cursor seen-cursors]
+  (and (string? cursor)
+       (not (str/blank? cursor))
+       (not (contains? seen-cursors cursor))))
+
+(defn- ^{:stratum 0} page-variables
+  [owner repo pr-number cursor]
+  (cond-> {:owner owner :repo repo :pr pr-number}
+    cursor (assoc :cursor cursor)))
+
+(defn- ^{:stratum 0} select-unresolved
+  [unresolved-count nodes]
+  (let [page-count (count (remove :isResolved nodes))
+        total (+ unresolved-count page-count)]
+    #:page{:done? false :state total}))
+
+(defn- ^{:stratum 0} finish-unresolved
+  [unresolved-count]
+  (let [has-unresolved? (pos? unresolved-count)]
+    (dag/ok {:has-unresolved? has-unresolved?
+             :unresolved-count unresolved-count})))
+
+(defn- ^{:stratum 0} select-root
+  [root-id state nodes]
+  (let [matching-thread (some #(when (= root-id
+                                       (get-in % [:comments :nodes 0 :databaseId]))
+                                 %)
+                              nodes)
+        found? (some? matching-thread)]
+    #:page{:done? found?
+           :state state
+           :value matching-thread}))
+
+(defn- ^{:stratum 0} finish-missing-root
+  [comment-id pr-number _]
+  (dag/err :thread-not-found
+           "Could not find thread containing comment ID"
+           {:comment-id comment-id :pr-number pr-number}))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} unresolved-pagination
+  "Describe full review-thread pagination without embedding behavior anonymously."
+  []
+  #:pagination{:query review-threads-query
+               :valid-page? valid-review-thread-page?
+               :select-page select-unresolved
+               :initial-state 0
+               :finish finish-unresolved})
+
+(defn- ^{:stratum 1} valid-review-thread-root-page?
+  [threads]
+  (and (valid-review-thread-page? threads)
+       (every? #(integer? (get-in % [:comments :nodes 0 :databaseId]))
+               (:nodes threads))))
+
+(defn- ^{:stratum 1} read-page
+  [graphql-query worktree-path owner repo pr-number cursor query valid-page?]
+  (let [variables (page-variables owner repo pr-number cursor)]
+    (dag/when-let-ok
+     [result (graphql-query query worktree-path :variables variables)]
+      (let [threads (get-in (:data result)
+                            [:data :repository :pullRequest :reviewThreads])]
+        (if (valid-page? threads)
+          (dag/ok threads)
+          (dag/err :invalid-review-thread-response
+                   "GitHub returned incomplete review thread state"))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} root-pagination
+  "Describe early-exit pagination for one review-comment root."
+  [comment-id pr-number root-id]
+  (let [select-page (partial select-root root-id)
+        finish (partial finish-missing-root comment-id pr-number)]
+    #:pagination{:query review-thread-roots-query
+                 :valid-page? valid-review-thread-root-page?
+                 :select-page select-page
+                 :initial-state nil
+                 :finish finish}))
+
+(defn ^{:stratum 2} paginate
+  "Apply a named pagination description with validation and cycle rejection."
+  [graphql-query worktree-path owner repo pr-number pagination]
+  (let [query (:pagination/query pagination)
+        valid-page? (:pagination/valid-page? pagination)
+        select-page (:pagination/select-page pagination)
+        initial-state (:pagination/initial-state pagination)
+        finish (:pagination/finish pagination)]
+    (loop [cursor nil
+           seen-cursors #{}
+           state initial-state]
+      (dag/when-let-ok
+       [page-result (read-page graphql-query worktree-path owner repo pr-number
+                               cursor query valid-page?)]
+        (let [threads (:data page-result)
+              selection (select-page state (:nodes threads))
+              page-info (:pageInfo threads)
+              next-cursor (:endCursor page-info)
+              next-state (:page/state selection)]
+          (cond
+            (:page/done? selection) (dag/ok (:page/value selection))
+            (not (:hasNextPage page-info)) (finish next-state)
+            (not (valid-next-cursor? next-cursor seen-cursors))
+            (dag/err :invalid-pagination
+                     "GitHub returned an invalid review thread cursor")
+            :else (recur next-cursor
+                         (conj seen-cursors next-cursor)
+                         next-state)))))))

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github_review_threads.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github_review_threads.clj
@@ -1,0 +1,97 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.pr-lifecycle.github-review-threads
+  "GitHub repository discovery and review-thread provider readback."
+  (:require
+   [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.pr-lifecycle.github-review-thread-pages :as pages]
+   [cheshire.core :as json]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} repository-coordinates
+  [run-command worktree-path]
+  (dag/when-let-ok
+   [result (run-command
+            ["git" "config" "--get" "remote.origin.url"] worktree-path)]
+    (let [remote-url (str/trim (get (:data result) :output ""))
+          parts (re-find #"github\.com(?::\d+)?[:/]([^/]+)/([^/]+)/?$" remote-url)
+          owner (nth parts 1 nil)
+          repo (some-> (nth parts 2 nil) (str/replace #"\.git$" ""))]
+      (if (and owner (seq repo))
+        (dag/ok {:owner owner :repo repo})
+        (dag/err :invalid-remote
+                 "Could not parse GitHub owner/repository from origin remote")))))
+
+(defn- ^{:stratum 0} review-comment-root-id
+  [run-command worktree-path owner repo comment-id]
+  (dag/when-let-ok
+   [result (run-command
+            ["gh" "api" (str "repos/" owner "/" repo
+                              "/pulls/comments/" comment-id)]
+            worktree-path)]
+    (try
+      (let [comment (json/parse-string (get (:data result) :output "") true)
+            root-id (if-some [reply-to-id (:in_reply_to_id comment)]
+                      reply-to-id
+                      (:id comment))]
+        (if (integer? root-id)
+          (dag/ok root-id)
+          (dag/err :invalid-review-comment-response
+                   "GitHub returned a review comment without an integer ID")))
+      (catch Exception e
+        (dag/err :json-parse-error (.getMessage e))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} get-thread-id
+  "Resolve a REST review comment or reply to its GraphQL review thread."
+  [run-command graphql-query worktree-path pr-number comment-id]
+  (dag/when-let-ok
+   [repository-result (repository-coordinates run-command worktree-path)
+    root-result (review-comment-root-id
+                 run-command
+                 worktree-path
+                 (:owner (:data repository-result))
+                 (:repo (:data repository-result))
+                 comment-id)
+    thread-result (pages/paginate
+                   graphql-query
+                   worktree-path
+                   (:owner (:data repository-result))
+                   (:repo (:data repository-result))
+                   pr-number
+                   (pages/root-pagination
+                    comment-id pr-number (:data root-result)))]
+    (let [thread (:data thread-result)]
+      (dag/ok {:thread-id (:id thread)
+               :is-resolved (:isResolved thread)}))))
+
+(defn ^{:stratum 1} unresolved-review-threads
+  "Read all provider pages and summarize unresolved review threads."
+  [run-command graphql-query worktree-path pr-number]
+  (dag/when-let-ok
+   [repository-result (repository-coordinates run-command worktree-path)]
+    (pages/paginate
+     graphql-query
+     worktree-path
+     (:owner (:data repository-result))
+     (:repo (:data repository-result))
+     pr-number
+     (pages/unresolved-pagination))))

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github_review_threads.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github_review_threads.clj
@@ -25,42 +25,52 @@
 
 ;------------------------------------------------------------------------------ Layer 0
 
-(defn- ^{:stratum 0} repository-coordinates
+(defn- ^{:stratum 0} parse-repository-coordinates
+  [output]
+  (let [remote-url (str/trim output)
+        parts (re-find #"github\.com(?::\d+)?[:/]([^/]+)/([^/]+)/?$" remote-url)
+        owner (nth parts 1 nil)
+        repo (some-> (nth parts 2 nil) (str/replace #"\.git$" ""))]
+    (if (and owner (seq repo))
+      (dag/ok {:owner owner :repo repo})
+      (dag/err :invalid-remote
+               "Could not parse GitHub owner/repository from origin remote"))))
+
+(defn- ^{:stratum 0} parse-review-comment-root-id
+  [output]
+  (try
+    (let [comment (json/parse-string output true)
+          root-id (if-some [reply-to-id (:in_reply_to_id comment)]
+                    reply-to-id
+                    (:id comment))]
+      (if (integer? root-id)
+        (dag/ok root-id)
+        (dag/err :invalid-review-comment-response
+                 "GitHub returned a review comment without an integer ID")))
+    (catch Exception e
+      (dag/err :json-parse-error (.getMessage e)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} repository-coordinates
   [run-command worktree-path]
   (dag/when-let-ok
    [result (run-command
             ["git" "config" "--get" "remote.origin.url"] worktree-path)]
-    (let [remote-url (str/trim (get (:data result) :output ""))
-          parts (re-find #"github\.com(?::\d+)?[:/]([^/]+)/([^/]+)/?$" remote-url)
-          owner (nth parts 1 nil)
-          repo (some-> (nth parts 2 nil) (str/replace #"\.git$" ""))]
-      (if (and owner (seq repo))
-        (dag/ok {:owner owner :repo repo})
-        (dag/err :invalid-remote
-                 "Could not parse GitHub owner/repository from origin remote")))))
+    (parse-repository-coordinates (get (:data result) :output ""))))
 
-(defn- ^{:stratum 0} review-comment-root-id
+(defn- ^{:stratum 1} review-comment-root-id
   [run-command worktree-path owner repo comment-id]
   (dag/when-let-ok
    [result (run-command
             ["gh" "api" (str "repos/" owner "/" repo
                               "/pulls/comments/" comment-id)]
             worktree-path)]
-    (try
-      (let [comment (json/parse-string (get (:data result) :output "") true)
-            root-id (if-some [reply-to-id (:in_reply_to_id comment)]
-                      reply-to-id
-                      (:id comment))]
-        (if (integer? root-id)
-          (dag/ok root-id)
-          (dag/err :invalid-review-comment-response
-                   "GitHub returned a review comment without an integer ID")))
-      (catch Exception e
-        (dag/err :json-parse-error (.getMessage e))))))
+    (parse-review-comment-root-id (get (:data result) :output ""))))
 
-;------------------------------------------------------------------------------ Layer 1
+;------------------------------------------------------------------------------ Layer 2
 
-(defn ^{:stratum 1} get-thread-id
+(defn ^{:stratum 2} get-thread-id
   "Resolve a REST review comment or reply to its GraphQL review thread."
   [run-command graphql-query worktree-path pr-number comment-id]
   (dag/when-let-ok
@@ -83,7 +93,7 @@
       (dag/ok {:thread-id (:id thread)
                :is-resolved (:isResolved thread)}))))
 
-(defn ^{:stratum 1} unresolved-review-threads
+(defn ^{:stratum 2} unresolved-review-threads
   "Read all provider pages and summarize unresolved review threads."
   [run-command graphql-query worktree-path pr-number]
   (dag/when-let-ok

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/github_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/github_test.clj
@@ -56,6 +56,15 @@
 (def ^{:stratum 0} ^:private flat-shape
   [{:path "src/baz.clj" :line 1 :body "flat-shape body"}])
 
+(def ^{:stratum 0} ^:private github-origin-result
+  (dag/ok {:output "git@github.com:miniforge-ai/miniforge.git"}))
+
+(defn- ^{:stratum 0} review-thread-node
+  [id root-id resolved?]
+  {:id id
+   :isResolved resolved?
+   :comments {:nodes [{:databaseId root-id}]}})
+
 (defn- ^{:stratum 0} review-thread-page
   "Build one GraphQL response page without duplicating provider maps."
   [nodes has-next? end-cursor]
@@ -68,23 +77,6 @@
         :pageInfo {:hasNextPage has-next?
                    :endCursor end-cursor}}}}}}))
 
-(deftest ^{:stratum 0} unresolved-review-threads-rejects-incomplete-readback
-  (with-redefs [github/run-gh-command
-                (fn [_ _] (dag/ok {:output "git@github.com:miniforge-ai/miniforge.git"}))
-                github/graphql-query
-                (fn [& _]
-                  (dag/ok {:data {:repository {:pullRequest nil}}}))]
-    (let [result (github/unresolved-review-threads "/repo" 1703)]
-      (is (dag/err? result))
-      (is (= :invalid-review-thread-response (get-in result [:error :code]))))))
-
-(deftest ^{:stratum 0} unresolved-review-threads-propagates-provider-failure
-  (let [failure (dag/err :graphql-error "provider unavailable")]
-    (with-redefs [github/run-gh-command
-                  (fn [_ _] (dag/ok {:output "git@github.com:miniforge-ai/miniforge.git"}))
-                  github/graphql-query (fn [& _] failure)]
-      (is (= failure (github/unresolved-review-threads "/repo" 1703))))))
-
 (deftest ^{:stratum 0} invalid-remote-error-redacts-credentials
   (with-redefs [github/run-gh-command
                 (fn [_ _]
@@ -95,6 +87,23 @@
                               "secret-token"))))))
 
 ;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} unresolved-review-threads-rejects-incomplete-readback
+  (with-redefs [github/run-gh-command
+                (fn [_ _] github-origin-result)
+                github/graphql-query
+                (fn [& _]
+                  (dag/ok {:data {:repository {:pullRequest nil}}}))]
+    (let [result (github/unresolved-review-threads "/repo" 1703)]
+      (is (dag/err? result))
+      (is (= :invalid-review-thread-response (get-in result [:error :code]))))))
+
+(deftest ^{:stratum 1} unresolved-review-threads-propagates-provider-failure
+  (let [failure (dag/err :graphql-error "provider unavailable")]
+    (with-redefs [github/run-gh-command
+                  (fn [_ _] github-origin-result)
+                  github/graphql-query (fn [& _] failure)]
+      (is (= failure (github/unresolved-review-threads "/repo" 1703))))))
 
 ;; ── tests ────────────────────────────────────────────────────────────
 (deftest ^{:stratum 1} unresolved-review-threads-paginates
@@ -121,7 +130,7 @@
 
 (deftest ^{:stratum 1} unresolved-review-threads-rejects-missing-page-cursor
   (with-redefs [github/run-gh-command
-                (fn [_ _] (dag/ok {:output "git@github.com:miniforge-ai/miniforge.git"}))
+                (fn [_ _] github-origin-result)
                 github/graphql-query
                 (fn [& _]
                   (review-thread-page [] true nil))]
@@ -131,7 +140,7 @@
 
 (deftest ^{:stratum 1} unresolved-review-threads-rejects-repeated-page-cursor
   (with-redefs [github/run-gh-command
-                (fn [_ _] (dag/ok {:output "git@github.com:miniforge-ai/miniforge.git"}))
+                (fn [_ _] github-origin-result)
                 github/graphql-query
                 (fn [& _]
                   (review-thread-page [] true "same-page"))]
@@ -141,16 +150,14 @@
 
 (deftest ^{:stratum 1} get-thread-id-follows-reply-root-and-paginates
   (let [requests (atom [])
-        thread (fn [id root-id resolved?]
-                 {:id id
-                  :isResolved resolved?
-                  :comments {:nodes [{:databaseId root-id}]}})
-        pages [(review-thread-page [(thread "other" 1 true)] true "next-page")
-               (review-thread-page [(thread "target" 10 false)] false nil)]]
+        pages [(review-thread-page
+                [(review-thread-node "other" 1 true)] true "next-page")
+               (review-thread-page
+                [(review-thread-node "target" 10 false)] false nil)]]
     (with-redefs [github/run-gh-command
                   (fn [args _]
-                    (if (= ["git" "config" "--get" "remote.origin.url"] args)
-                      (dag/ok {:output "git@github.com:miniforge-ai/miniforge.git"})
+                  (if (= ["git" "config" "--get" "remote.origin.url"] args)
+                      github-origin-result
                       (dag/ok {:output (json/generate-string
                                         {:id 99 :in_reply_to_id 10})})))
                   github/graphql-query
@@ -166,14 +173,13 @@
   (with-redefs [github/run-gh-command
                 (fn [args _]
                   (if (= "git" (first args))
-                    (dag/ok {:output "git@github.com:miniforge-ai/miniforge.git"})
+                    github-origin-result
                     (dag/ok {:output (json/generate-string
                                       {:id 10 :in_reply_to_id nil})})))
                 github/graphql-query
                 (fn [& _]
                   (review-thread-page
-                   [{:id "target" :isResolved true
-                     :comments {:nodes [{:databaseId 10}]}}]
+                   [(review-thread-node "target" 10 true)]
                    false nil))]
     (is (= {:thread-id "target" :is-resolved true}
            (:data (github/get-thread-id "/repo" 1704 10))))))

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/github_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/github_test.clj
@@ -16,7 +16,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns ai.miniforge.pr-lifecycle.github-test
-  "Tests for the github.clj batched-review posting (N13 §2.2)."
+  "Tests for GitHub provider readback and batched-review posting."
   (:require [babashka.process :as process]
             [cheshire.core :as json]
             [clojure.string :as str]
@@ -56,9 +56,70 @@
 (def ^{:stratum 0} ^:private flat-shape
   [{:path "src/baz.clj" :line 1 :body "flat-shape body"}])
 
+(defn- ^{:stratum 0} review-thread-page
+  "Build one GraphQL response page without duplicating provider maps."
+  [nodes has-next? end-cursor]
+  (dag/ok
+   {:data
+    {:repository
+     {:pullRequest
+      {:reviewThreads
+       {:nodes nodes
+        :pageInfo {:hasNextPage has-next?
+                   :endCursor end-cursor}}}}}}))
+
+(deftest ^{:stratum 0} unresolved-review-threads-rejects-incomplete-readback
+  (with-redefs [github/run-gh-command
+                (fn [_ _] (dag/ok {:output "git@github.com:miniforge-ai/miniforge.git"}))
+                github/graphql-query
+                (fn [& _]
+                  (dag/ok {:data {:repository {:pullRequest nil}}}))]
+    (let [result (github/unresolved-review-threads "/repo" 1703)]
+      (is (dag/err? result))
+      (is (= :invalid-review-thread-response (get-in result [:error :code]))))))
+
+(deftest ^{:stratum 0} unresolved-review-threads-propagates-provider-failure
+  (let [failure (dag/err :graphql-error "provider unavailable")]
+    (with-redefs [github/run-gh-command
+                  (fn [_ _] (dag/ok {:output "git@github.com:miniforge-ai/miniforge.git"}))
+                  github/graphql-query (fn [& _] failure)]
+      (is (= failure (github/unresolved-review-threads "/repo" 1703))))))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 ;; ── tests ────────────────────────────────────────────────────────────
+(deftest ^{:stratum 1} unresolved-review-threads-paginates
+  (let [requests (atom [])
+        pages [(review-thread-page [{:id "resolved" :isResolved true}]
+                                   true "next-page")
+               (review-thread-page [{:id "open" :isResolved false}]
+                                   false nil)]]
+    (with-redefs [github/run-gh-command
+                  (fn [_ _]
+                    (dag/ok {:output "https://github.com/acme/repo.with-dots.git"}))
+                  github/graphql-query
+                  (fn [_ _ & {:keys [variables]}]
+                    (let [index (count @requests)]
+                      (swap! requests conj variables)
+                      (nth pages index)))]
+      (let [result (github/unresolved-review-threads "/repo" 1703)]
+        (is (dag/ok? result))
+        (is (= {:has-unresolved? true :unresolved-count 1}
+               (:data result)))
+        (is (= [nil "next-page"] (mapv :cursor @requests)))
+        (is (= {:owner "acme" :repo "repo.with-dots" :pr 1703}
+               (first @requests)))))))
+
+(deftest ^{:stratum 1} unresolved-review-threads-rejects-missing-page-cursor
+  (with-redefs [github/run-gh-command
+                (fn [_ _] (dag/ok {:output "git@github.com:miniforge-ai/miniforge.git"}))
+                github/graphql-query
+                (fn [& _]
+                  (review-thread-page [] true nil))]
+    (let [result (github/unresolved-review-threads "/repo" 1703)]
+      (is (dag/err? result))
+      (is (= :invalid-pagination (get-in result [:error :code]))))))
+
 (deftest ^{:stratum 1} post-review-uses-create-review-endpoint-via-stdin
   (testing "post-review! shells out to the right gh api endpoint with --input -"
     (let [calls (atom [])

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/github_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/github_test.clj
@@ -85,6 +85,15 @@
                   github/graphql-query (fn [& _] failure)]
       (is (= failure (github/unresolved-review-threads "/repo" 1703))))))
 
+(deftest ^{:stratum 0} invalid-remote-error-redacts-credentials
+  (with-redefs [github/run-gh-command
+                (fn [_ _]
+                  (dag/ok {:output "https://secret-token@other.example/repo.git"}))]
+    (let [result (github/unresolved-review-threads "/repo" 1704)]
+      (is (dag/err? result))
+      (is (not (str/includes? (get-in result [:error :message])
+                              "secret-token"))))))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 ;; ── tests ────────────────────────────────────────────────────────────
@@ -96,7 +105,7 @@
                                    false nil)]]
     (with-redefs [github/run-gh-command
                   (fn [_ _]
-                    (dag/ok {:output "https://github.com/acme/repo.with-dots.git"}))
+                    (dag/ok {:output "ssh://git@github.com:443/acme/repo.with-dots.git/"}))
                   github/graphql-query
                   (fn [_ _ & {:keys [variables]}]
                     (let [index (count @requests)]

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/github_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/github_test.clj
@@ -120,6 +120,16 @@
       (is (dag/err? result))
       (is (= :invalid-pagination (get-in result [:error :code]))))))
 
+(deftest ^{:stratum 1} unresolved-review-threads-rejects-repeated-page-cursor
+  (with-redefs [github/run-gh-command
+                (fn [_ _] (dag/ok {:output "git@github.com:miniforge-ai/miniforge.git"}))
+                github/graphql-query
+                (fn [& _]
+                  (review-thread-page [] true "same-page"))]
+    (let [result (github/unresolved-review-threads "/repo" 1703)]
+      (is (dag/err? result))
+      (is (= :invalid-pagination (get-in result [:error :code]))))))
+
 (deftest ^{:stratum 1} post-review-uses-create-review-endpoint-via-stdin
   (testing "post-review! shells out to the right gh api endpoint with --input -"
     (let [calls (atom [])

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/github_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/github_test.clj
@@ -130,6 +130,45 @@
       (is (dag/err? result))
       (is (= :invalid-pagination (get-in result [:error :code]))))))
 
+(deftest ^{:stratum 1} get-thread-id-follows-reply-root-and-paginates
+  (let [requests (atom [])
+        thread (fn [id root-id resolved?]
+                 {:id id
+                  :isResolved resolved?
+                  :comments {:nodes [{:databaseId root-id}]}})
+        pages [(review-thread-page [(thread "other" 1 true)] true "next-page")
+               (review-thread-page [(thread "target" 10 false)] false nil)]]
+    (with-redefs [github/run-gh-command
+                  (fn [args _]
+                    (if (= ["git" "config" "--get" "remote.origin.url"] args)
+                      (dag/ok {:output "git@github.com:miniforge-ai/miniforge.git"})
+                      (dag/ok {:output (json/generate-string
+                                        {:id 99 :in_reply_to_id 10})})))
+                  github/graphql-query
+                  (fn [_ _ & {:keys [variables]}]
+                    (let [index (count @requests)]
+                      (swap! requests conj variables)
+                      (nth pages index)))]
+      (let [result (github/get-thread-id "/repo" 1704 99)]
+        (is (= {:thread-id "target" :is-resolved false} (:data result)))
+        (is (= [nil "next-page"] (mapv :cursor @requests)))))))
+
+(deftest ^{:stratum 1} get-thread-id-uses-original-comment-id
+  (with-redefs [github/run-gh-command
+                (fn [args _]
+                  (if (= "git" (first args))
+                    (dag/ok {:output "git@github.com:miniforge-ai/miniforge.git"})
+                    (dag/ok {:output (json/generate-string
+                                      {:id 10 :in_reply_to_id nil})})))
+                github/graphql-query
+                (fn [& _]
+                  (review-thread-page
+                   [{:id "target" :isResolved true
+                     :comments {:nodes [{:databaseId 10}]}}]
+                   false nil))]
+    (is (= {:thread-id "target" :is-resolved true}
+           (:data (github/get-thread-id "/repo" 1704 10))))))
+
 (deftest ^{:stratum 1} post-review-uses-create-review-endpoint-via-stdin
   (testing "post-review! shells out to the right gh api endpoint with --input -"
     (let [calls (atom [])

--- a/docs/pull-requests/2026-08-07-codex-n7-merge-thread-readback.md
+++ b/docs/pull-requests/2026-08-07-codex-n7-merge-thread-readback.md
@@ -1,0 +1,50 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor: add provider-backed merge thread readback
+
+## Summary
+
+Adds the GitHub provider read required for N7 merge enforcement. Review-thread
+state is fully paginated, validated, and reported through the existing
+PR-lifecycle provider API.
+
+## Changes
+
+- Read every GitHub review-thread page and report the exact unresolved count.
+- Resolve a REST review comment or reply through its root comment and paginate
+  thread roots until the corresponding GraphQL thread is found.
+- Reject incomplete provider shapes and missing or repeated page cursors.
+- Parse SSH and HTTPS GitHub remotes with optional ports, trailing slashes, and
+  dotted repository names without exposing invalid remote values in errors.
+- Decompose page mechanics and readback orchestration into focused namespaces
+  while preserving the public `github.clj` API.
+
+## Standards review
+
+- Provider transport, response parsing, pagination, and API delegation are
+  separate concerns with downward-only dependencies.
+- Each changed namespace has at most three strata and each function has one
+  primary responsibility.
+- Shared response builders remove repeated provider maps from the tests.
+- PR budget: 391 / 600 reportable lines; every commit is at most 200.
+- Kondo, Polylith, stratum lint, and the changed-code standards baseline are
+  clean.
+
+## Verification
+
+- PR-lifecycle component passes in all three project compositions.
+- GitHub provider behavior: 16 tests / 48 assertions.
+- Pre-commit smoke: 339 tests / 1,285 assertions.
+- GraalVM/Babashka compatibility: 8 tests / 606 assertions.
+- Standards scan matches the repository baseline: 73 findings, including six
+  manual-review findings; no new violations.
+
+## Follow-up
+
+The next N7 PR consumes `unresolved-review-threads` from merge readiness while
+decomposing the existing merge control flow. Grant and DecisionEnvelope
+enforcement follows that structural seam.

--- a/docs/pull-requests/2026-08-07-codex-n7-merge-thread-readback.md
+++ b/docs/pull-requests/2026-08-07-codex-n7-merge-thread-readback.md
@@ -30,7 +30,7 @@ PR-lifecycle provider API.
 - Each changed namespace has at most three strata and each function has one
   primary responsibility.
 - Shared response builders remove repeated provider maps from the tests.
-- PR budget: 391 / 600 reportable lines; every commit is at most 200.
+- PR budget: 389 / 600 reportable lines; every commit is at most 200.
 - Kondo, Polylith, stratum lint, and the changed-code standards baseline are
   clean.
 


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# refactor: add provider-backed merge thread readback

## Summary

Adds the GitHub provider read required for N7 merge enforcement. Review-thread
state is fully paginated, validated, and reported through the existing
PR-lifecycle provider API.

## Changes

- Read every GitHub review-thread page and report the exact unresolved count.
- Resolve a REST review comment or reply through its root comment and paginate
  thread roots until the corresponding GraphQL thread is found.
- Reject incomplete provider shapes and missing or repeated page cursors.
- Parse SSH and HTTPS GitHub remotes with optional ports, trailing slashes, and
  dotted repository names without exposing invalid remote values in errors.
- Decompose page mechanics and readback orchestration into focused namespaces
  while preserving the public `github.clj` API.

## Standards review

- Provider transport, response parsing, pagination, and API delegation are
  separate concerns with downward-only dependencies.
- Each changed namespace has at most three strata and each function has one
  primary responsibility.
- Shared response builders remove repeated provider maps from the tests.
- PR budget: 389 / 600 reportable lines; every commit is at most 200.
- Kondo, Polylith, stratum lint, and the changed-code standards baseline are
  clean.

## Verification

- PR-lifecycle component passes in all three project compositions.
- GitHub provider behavior: 16 tests / 48 assertions.
- Pre-commit smoke: 339 tests / 1,285 assertions.
- GraalVM/Babashka compatibility: 8 tests / 606 assertions.
- Standards scan matches the repository baseline: 73 findings, including six
  manual-review findings; no new violations.

## Follow-up

The next N7 PR consumes `unresolved-review-threads` from merge readiness while
decomposing the existing merge control flow. Grant and DecisionEnvelope
enforcement follows that structural seam.
