### PR TITLE
refactor: decompose GitHub conversation workflow

### DIFF
--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/fix_loop.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/fix_loop.clj
@@ -230,9 +230,9 @@
             (dag/err :push-failed (:error push-result))))
         (dag/err :commit-failed (:error stage-result))))))
 
-;; Conversation resolution
+;; Conversation follow-up
 (defn ^{:stratum 0} resolve-comment-thread
-  "Resolve a conversation thread after creating a fix PR.
+  "Reply with a fix PR link and optionally resolve the conversation thread.
 
    Arguments:
    - worktree-path: Path to git worktree
@@ -241,23 +241,24 @@
    - logger: Logger instance
 
    Options:
-   - :auto-resolve - Whether to resolve conversation (default true)
+   - :auto-resolve - Whether to resolve after replying (default true)
 
-   Returns DAG result with resolution status"
+   Returns DAG result with reply and resolution status"
   [worktree-path fix-context fix-pr-number logger & {:keys [auto-resolve]
                                                       :or {auto-resolve true}}]
   (let [comment-id (:fix/comment-id fix-context)
         parent-pr-number (:fix/parent-pr-number fix-context)]
 
-    ;; Only attempt resolution if we have the necessary metadata
+    ;; Conversation follow-up requires the original comment coordinates.
     (if (and comment-id parent-pr-number)
       (do
         (when logger
           (log/info logger :pr-lifecycle :fix/resolving-conversation
-                    {:message "Resolving conversation thread"
+                    {:message "Linking fix PR to review comment"
                      :data {:parent-pr parent-pr-number
                             :comment-id comment-id
-                            :fix-pr fix-pr-number}}))
+                            :fix-pr fix-pr-number
+                            :auto-resolve auto-resolve}}))
 
         (let [result (conversation/link-fix-pr-to-comment
                       worktree-path parent-pr-number comment-id fix-pr-number logger
@@ -270,11 +271,11 @@
                                 :reply-url (:reply-url (:data result))}})))
           result))
 
-      ;; No comment metadata - skip resolution
+      ;; No comment metadata - skip the entire conversation follow-up.
       (do
         (when (and logger (or comment-id parent-pr-number))
           (log/debug logger :pr-lifecycle :fix/skipping-resolution
-                     {:message "Skipping conversation resolution"
+                     {:message "Skipping fix PR conversation follow-up"
                       :data {:reason (cond
                                        (not comment-id) "no comment-id"
                                        (not parent-pr-number) "no parent-pr-number")}}))

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/fix_loop.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/fix_loop.clj
@@ -249,7 +249,6 @@
   (let [comment-id (:fix/comment-id fix-context)
         parent-pr-number (:fix/parent-pr-number fix-context)]
 
-    ;; Conversation follow-up requires the original comment coordinates.
     (if (and comment-id parent-pr-number)
       (do
         (when logger

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/fix_loop.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/fix_loop.clj
@@ -23,7 +23,7 @@
   (:require
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.pr-lifecycle.events :as events]
-   [ai.miniforge.pr-lifecycle.github :as github]
+   [ai.miniforge.pr-lifecycle.github-conversation :as conversation]
    [ai.miniforge.pr-lifecycle.triage :as triage]
    [ai.miniforge.loop.interface :as loop]
    [ai.miniforge.logging.interface :as log]
@@ -259,7 +259,7 @@
                             :comment-id comment-id
                             :fix-pr fix-pr-number}}))
 
-        (let [result (github/link-fix-pr-to-comment
+        (let [result (conversation/link-fix-pr-to-comment
                       worktree-path parent-pr-number comment-id fix-pr-number logger
                       :auto-resolve auto-resolve)]
           (when (dag/ok? result)

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/fix_loop.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/fix_loop.clj
@@ -373,17 +373,16 @@
                                           :attempt attempt
                                           :commit-sha (:commit-sha (:data commit-result))}}))
 
-                      ;; Try to resolve conversation thread (non-blocking)
-                      (when (and auto-resolve-comments
-                                 (:fix/comment-id fix-context))
+                      ;; Link the fix reply and optionally resolve (non-blocking).
+                      (when (:fix/comment-id fix-context)
                         (try
                           (resolve-comment-thread worktree-path fix-context pr-id logger
                                                   :auto-resolve auto-resolve-comments)
                           (catch Exception e
-                            ;; Log error but don't fail the fix loop
+                            ;; Unexpected follow-up failures do not fail the fix loop.
                             (when logger
                               (log/warn logger :pr-lifecycle :fix-loop/resolution-error
-                                        {:message "Failed to resolve conversation (non-fatal)"
+                                        {:message "Conversation follow-up failed (non-fatal)"
                                          :data {:error (.getMessage e)}})))))
 
                       ;; Publish fix-pushed event

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/fix_loop.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/fix_loop.clj
@@ -250,7 +250,7 @@
         parent-pr-number (:fix/parent-pr-number fix-context)]
 
     ;; Only attempt resolution if we have the necessary metadata
-    (if (and comment-id parent-pr-number auto-resolve)
+    (if (and comment-id parent-pr-number)
       (do
         (when logger
           (log/info logger :pr-lifecycle :fix/resolving-conversation
@@ -276,7 +276,6 @@
           (log/debug logger :pr-lifecycle :fix/skipping-resolution
                      {:message "Skipping conversation resolution"
                       :data {:reason (cond
-                                       (not auto-resolve) "auto-resolve disabled"
                                        (not comment-id) "no comment-id"
                                        (not parent-pr-number) "no parent-pr-number")}}))
         (dag/ok {:skipped true :reason "missing-metadata"})))))

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github.clj
@@ -323,17 +323,18 @@
    - worktree-path: Path to git worktree
    - thread-id: GraphQL thread ID (starts with 'PRRT_' or 'RT_')
 
-   Returns DAG result with resolution status or error"
+  Returns DAG result with resolution status or error"
   [worktree-path thread-id]
-  (let [mutation (str "mutation {
-  resolveReviewThread(input: {threadId: \"" thread-id "\"}) {
+  (let [mutation "mutation($threadId:ID!) {
+  resolveReviewThread(input: {threadId: $threadId}) {
     thread {
       id
       isResolved
     }
   }
-}")
-        result (graphql-query mutation worktree-path)]
+}"
+        result (graphql-query mutation worktree-path
+                              :variables {:threadId thread-id})]
     (if (dag/ok? result)
       (let [thread (get-in (:data result) [:data :resolveReviewThread :thread])
             is-resolved (:isResolved thread)]

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github.clj
@@ -185,20 +185,6 @@
 
 ;------------------------------------------------------------------------------ Layer 2
 
-(defn ^{:stratum 2} graphql-mutation
-  "Execute a GraphQL mutation via gh CLI.
-
-   Arguments:
-   - mutation: GraphQL mutation string
-   - worktree-path: Path to git worktree
-
-   Options:
-   - :variables - Map of GraphQL variables
-
-   Returns DAG result with parsed JSON response"
-  [mutation worktree-path & {:keys [variables]}]
-  (graphql-query mutation worktree-path :variables variables))
-
 ;; GitHub API operations
 (defn ^{:stratum 2} get-thread-id
   "Get GraphQL thread ID from a comment ID.

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github.clj
@@ -22,7 +22,6 @@
    for resolving conversation threads and posting replies to comments."
   (:require
    [ai.miniforge.dag-executor.interface :as dag]
-   [ai.miniforge.logging.interface :as log]
    [babashka.process :as process]
    [cheshire.core :as json]
    [clojure.string :as str]))
@@ -317,9 +316,7 @@
             (dag/err :json-parse-error (.getMessage e))))
         result))))
 
-;------------------------------------------------------------------------------ Layer 3
-
-(defn ^{:stratum 3} resolve-conversation
+(defn ^{:stratum 2} resolve-conversation
   "Mark a conversation thread as resolved via GraphQL.
 
    Arguments:
@@ -336,7 +333,7 @@
     }
   }
 }")
-        result (graphql-mutation mutation worktree-path)]
+        result (graphql-query mutation worktree-path)]
     (if (dag/ok? result)
       (let [thread (get-in (:data result) [:data :resolveReviewThread :thread])
             is-resolved (:isResolved thread)]
@@ -347,135 +344,6 @@
                    "Thread resolution returned false"
                    {:thread-id thread-id :thread thread})))
       result)))
-
-;------------------------------------------------------------------------------ Layer 4
-
-;; High-level conversation operations
-(defn ^{:stratum 4} link-fix-pr-to-comment
-  "Link a fix PR to a review comment and resolve the conversation.
-
-   This is the main entry point for conversation resolution after
-   creating a fix PR. It:
-   1. Posts a reply linking to the fix PR
-   2. Resolves the conversation thread (if configured)
-
-   Arguments:
-   - worktree-path: Path to git worktree
-   - pr-number: Original PR number (where comment was made)
-   - comment-id: Comment ID to reply to
-   - fix-pr-number: Fix PR number to link
-   - logger: Optional logger instance
-
-   Options:
-   - :auto-resolve - Whether to resolve conversation (default true)
-   - :message-template - Custom message template (default: 'Fixed in PR #{fix-pr-number}')
-
-   Returns DAG result with success status and actions taken"
-  [worktree-path pr-number comment-id fix-pr-number logger
-   & {:keys [auto-resolve message-template]
-      :or {auto-resolve true
-           message-template "Fixed in PR #{fix-pr-number}"}}]
-  (when logger
-    (log/info logger :pr-lifecycle :github/linking-fix-pr
-              {:message "Linking fix PR to comment"
-               :data {:pr-number pr-number
-                      :comment-id comment-id
-                      :fix-pr-number fix-pr-number}}))
-
-  (let [;; Build reply message
-        message (str/replace message-template "#{fix-pr-number}" (str "#" fix-pr-number))
-
-        ;; Step 1: Post reply
-        reply-result (reply-to-comment worktree-path pr-number comment-id message)]
-
-    (if (dag/err? reply-result)
-      ;; Reply failed - log warning but don't fail completely
-      (do
-        (when logger
-          (log/warn logger :pr-lifecycle :github/reply-failed
-                    {:message "Failed to post reply to comment"
-                     :data {:error (:error reply-result)
-                            :pr-number pr-number
-                            :comment-id comment-id}}))
-        (dag/err :reply-failed
-                 (:error reply-result)
-                 {:pr-number pr-number
-                  :comment-id comment-id
-                  :fix-pr-number fix-pr-number}))
-
-      ;; Reply succeeded
-      (do
-        (when logger
-          (log/info logger :pr-lifecycle :github/reply-posted
-                    {:message "Posted reply to comment"
-                     :data {:reply-url (:url (:data reply-result))}}))
-
-        ;; Step 2: Resolve conversation (if enabled)
-        (if-not auto-resolve
-          (dag/ok {:reply-posted true
-                   :resolved false
-                   :reply-url (:url (:data reply-result))})
-
-          ;; Try to resolve
-          (let [;; First, get thread ID from comment ID
-                thread-result (get-thread-id worktree-path pr-number comment-id)]
-
-            (if (dag/err? thread-result)
-              ;; Can't get thread ID - log warning but return success for reply
-              (do
-                (when logger
-                  (log/warn logger :pr-lifecycle :github/thread-id-failed
-                            {:message "Could not get thread ID for resolution"
-                             :data {:error (:error thread-result)
-                                    :comment-id comment-id}}))
-                (dag/ok {:reply-posted true
-                         :resolved false
-                         :resolution-error (:error thread-result)
-                         :reply-url (:url (:data reply-result))}))
-
-              ;; Got thread ID - try to resolve
-              (let [thread-id (:thread-id (:data thread-result))
-                    already-resolved (:is-resolved (:data thread-result))]
-
-                (if already-resolved
-                  ;; Already resolved
-                  (do
-                    (when logger
-                      (log/info logger :pr-lifecycle :github/already-resolved
-                                {:message "Thread already resolved"
-                                 :data {:thread-id thread-id}}))
-                    (dag/ok {:reply-posted true
-                             :resolved true
-                             :already-resolved true
-                             :thread-id thread-id
-                             :reply-url (:url (:data reply-result))}))
-
-                  ;; Try to resolve
-                  (let [resolve-result (resolve-conversation worktree-path thread-id)]
-                    (if (dag/ok? resolve-result)
-                      (do
-                        (when logger
-                          (log/info logger :pr-lifecycle :github/conversation-resolved
-                                    {:message "Conversation resolved successfully"
-                                     :data {:thread-id thread-id
-                                            :pr-number pr-number}}))
-                        (dag/ok {:reply-posted true
-                                 :resolved true
-                                 :thread-id thread-id
-                                 :reply-url (:url (:data reply-result))}))
-
-                      ;; Resolution failed - log warning but return success for reply
-                      (do
-                        (when logger
-                          (log/warn logger :pr-lifecycle :github/resolution-failed
-                                    {:message "Failed to resolve conversation"
-                                     :data {:error (:error resolve-result)
-                                            :thread-id thread-id}}))
-                        (dag/ok {:reply-posted true
-                                 :resolved false
-                                 :resolution-error (:error resolve-result)
-                                 :thread-id thread-id
-                                 :reply-url (:url (:data reply-result))})))))))))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
@@ -490,18 +358,5 @@
   ;; Resolve a conversation
   (resolve-conversation "/path/to/repo" "PRRT_kwDO...")
   ; => {:success true :data {:thread-id "PRRT_..." :resolved true}}
-
-  ;; High-level: link fix PR and resolve
-  (link-fix-pr-to-comment "/path/to/repo" 148 2780310737 150 nil)
-  ; => {:success true :data {:reply-posted true :resolved true :thread-id "PRRT_..." ...}}
-
-  ;; With custom message
-  (link-fix-pr-to-comment "/path/to/repo" 148 2780310737 150 nil
-                          :message-template "Addressed in PR #{fix-pr-number}")
-
-  ;; Disable auto-resolution
-  (link-fix-pr-to-comment "/path/to/repo" 148 2780310737 150 nil
-                          :auto-resolve false)
-  ; => {:success true :data {:reply-posted true :resolved false ...}}
 
   :leave-this-here)

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github_conversation.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github_conversation.clj
@@ -21,63 +21,37 @@
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.pr-lifecycle.github :as github]
+   [ai.miniforge.pr-lifecycle.github-conversation-resolution :as resolution]
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
-(defn- ^{:stratum 0} reply-outcome
-  "Build the shared successful-reply result shape."
-  [reply-result resolved? details]
-  (dag/ok (merge {:reply-posted true :resolved resolved?
-                  :reply-url (:url (:data reply-result))}
-                 details)))
+(defn- ^{:stratum 0} reply-failure-result
+  [pr-number comment-id fix-pr-number reply-result logger]
+  (when logger
+    (log/warn logger :pr-lifecycle :github/reply-failed
+              {:message "Failed to post reply to comment"
+               :data {:error (:error reply-result) :pr-number pr-number
+                      :comment-id comment-id}}))
+  (dag/err :reply-failed
+           (get-in reply-result [:error :message]
+                   "Failed to post reply to comment")
+           {:pr-number pr-number :comment-id comment-id
+            :fix-pr-number fix-pr-number
+            :cause (:error reply-result)}))
+
+(defn- ^{:stratum 0} continue-after-reply
+  [worktree-path pr-number comment-id reply-result auto-resolve logger]
+  (when logger
+    (log/info logger :pr-lifecycle :github/reply-posted
+              {:message "Posted reply to comment"
+               :data {:reply-url (:url (:data reply-result))}}))
+  (resolution/resolve-after-reply worktree-path pr-number comment-id
+                                  reply-result auto-resolve logger))
 
 ;------------------------------------------------------------------------------ Layer 1
 
-(defn- ^{:stratum 1} resolve-after-reply
-  "Resolve a replied-to thread when requested, preserving reply success."
-  [worktree-path pr-number comment-id reply-result auto-resolve logger]
-  (if-not auto-resolve
-    (reply-outcome reply-result false {})
-    (let [thread-result (github/get-thread-id worktree-path pr-number comment-id)]
-      (cond
-        (dag/err? thread-result)
-        (do
-          (when logger
-            (log/warn logger :pr-lifecycle :github/thread-id-failed
-                      {:message "Could not get thread ID for resolution"
-                       :data {:error (:error thread-result) :comment-id comment-id}}))
-          (reply-outcome reply-result false {:resolution-error (:error thread-result)}))
-
-        (:is-resolved (:data thread-result))
-        (let [thread-id (:thread-id (:data thread-result))]
-          (when logger
-            (log/info logger :pr-lifecycle :github/already-resolved
-                      {:message "Thread already resolved"
-                       :data {:thread-id thread-id}}))
-          (reply-outcome reply-result true {:already-resolved true :thread-id thread-id}))
-
-        :else
-        (let [thread-id (:thread-id (:data thread-result))
-              result (github/resolve-conversation worktree-path thread-id)]
-          (if (dag/ok? result)
-            (do
-              (when logger
-                (log/info logger :pr-lifecycle :github/conversation-resolved
-                          {:message "Conversation resolved successfully"
-                           :data {:thread-id thread-id :pr-number pr-number}}))
-              (reply-outcome reply-result true {:thread-id thread-id}))
-            (do
-              (when logger
-                (log/warn logger :pr-lifecycle :github/resolution-failed
-                          {:message "Failed to resolve conversation"
-                           :data {:error (:error result) :thread-id thread-id}}))
-              (reply-outcome reply-result false {:resolution-error (:error result)
-                                                 :thread-id thread-id}))))))))
-
-;------------------------------------------------------------------------------ Layer 2
-
-(defn ^{:stratum 2} link-fix-pr-to-comment
+(defn ^{:stratum 1} link-fix-pr-to-comment
   "Reply with a fix PR link and optionally resolve the review thread."
   [worktree-path pr-number comment-id fix-pr-number logger
    & {:keys [auto-resolve message-template]
@@ -86,28 +60,13 @@
   (when logger
     (log/info logger :pr-lifecycle :github/linking-fix-pr
               {:message "Linking fix PR to comment"
-               :data {:pr-number pr-number :comment-id comment-id :fix-pr-number fix-pr-number}}))
+               :data {:pr-number pr-number :comment-id comment-id
+                      :fix-pr-number fix-pr-number}}))
   (let [message (str/replace message-template "#{fix-pr-number}"
                              (str "#" fix-pr-number))
         reply-result (github/reply-to-comment worktree-path pr-number
                                               comment-id message)]
     (if (dag/err? reply-result)
-      (do
-        (when logger
-          (log/warn logger :pr-lifecycle :github/reply-failed
-                    {:message "Failed to post reply to comment"
-                     :data {:error (:error reply-result) :pr-number pr-number
-                            :comment-id comment-id}}))
-        (dag/err :reply-failed
-                 (get-in reply-result [:error :message]
-                         "Failed to post reply to comment")
-                 {:pr-number pr-number :comment-id comment-id
-                  :fix-pr-number fix-pr-number
-                  :cause (:error reply-result)}))
-      (do
-        (when logger
-          (log/info logger :pr-lifecycle :github/reply-posted
-                    {:message "Posted reply to comment"
-                     :data {:reply-url (:url (:data reply-result))}}))
-        (resolve-after-reply worktree-path pr-number comment-id
-                             reply-result auto-resolve logger)))))
+      (reply-failure-result pr-number comment-id fix-pr-number reply-result logger)
+      (continue-after-reply worktree-path pr-number comment-id reply-result
+                            auto-resolve logger))))

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github_conversation.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github_conversation.clj
@@ -1,0 +1,111 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.pr-lifecycle.github-conversation
+  "High-level reply and review-thread resolution workflows."
+  (:require
+   [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.logging.interface :as log]
+   [ai.miniforge.pr-lifecycle.github :as github]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} reply-outcome
+  "Build the shared successful-reply result shape."
+  [reply-result resolved? details]
+  (dag/ok (merge {:reply-posted true :resolved resolved?
+                  :reply-url (:url (:data reply-result))}
+                 details)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} resolve-after-reply
+  "Resolve a replied-to thread when requested, preserving reply success."
+  [worktree-path pr-number comment-id reply-result auto-resolve logger]
+  (if-not auto-resolve
+    (reply-outcome reply-result false {})
+    (let [thread-result (github/get-thread-id worktree-path pr-number comment-id)]
+      (cond
+        (dag/err? thread-result)
+        (do
+          (when logger
+            (log/warn logger :pr-lifecycle :github/thread-id-failed
+                      {:message "Could not get thread ID for resolution"
+                       :data {:error (:error thread-result) :comment-id comment-id}}))
+          (reply-outcome reply-result false {:resolution-error (:error thread-result)}))
+
+        (:is-resolved (:data thread-result))
+        (let [thread-id (:thread-id (:data thread-result))]
+          (when logger
+            (log/info logger :pr-lifecycle :github/already-resolved
+                      {:message "Thread already resolved"
+                       :data {:thread-id thread-id}}))
+          (reply-outcome reply-result true {:already-resolved true :thread-id thread-id}))
+
+        :else
+        (let [thread-id (:thread-id (:data thread-result))
+              result (github/resolve-conversation worktree-path thread-id)]
+          (if (dag/ok? result)
+            (do
+              (when logger
+                (log/info logger :pr-lifecycle :github/conversation-resolved
+                          {:message "Conversation resolved successfully"
+                           :data {:thread-id thread-id :pr-number pr-number}}))
+              (reply-outcome reply-result true {:thread-id thread-id}))
+            (do
+              (when logger
+                (log/warn logger :pr-lifecycle :github/resolution-failed
+                          {:message "Failed to resolve conversation"
+                           :data {:error (:error result) :thread-id thread-id}}))
+              (reply-outcome reply-result false {:resolution-error (:error result)
+                                                 :thread-id thread-id}))))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} link-fix-pr-to-comment
+  "Reply with a fix PR link and optionally resolve the review thread."
+  [worktree-path pr-number comment-id fix-pr-number logger
+   & {:keys [auto-resolve message-template]
+      :or {auto-resolve true
+           message-template "Fixed in PR #{fix-pr-number}"}}]
+  (when logger
+    (log/info logger :pr-lifecycle :github/linking-fix-pr
+              {:message "Linking fix PR to comment"
+               :data {:pr-number pr-number :comment-id comment-id :fix-pr-number fix-pr-number}}))
+  (let [message (str/replace message-template "#{fix-pr-number}"
+                             (str "#" fix-pr-number))
+        reply-result (github/reply-to-comment worktree-path pr-number
+                                              comment-id message)]
+    (if (dag/err? reply-result)
+      (do
+        (when logger
+          (log/warn logger :pr-lifecycle :github/reply-failed
+                    {:message "Failed to post reply to comment"
+                     :data {:error (:error reply-result) :pr-number pr-number
+                            :comment-id comment-id}}))
+        (dag/err :reply-failed
+                 (:error reply-result)
+                 {:pr-number pr-number :comment-id comment-id
+                  :fix-pr-number fix-pr-number}))
+      (do
+        (when logger
+          (log/info logger :pr-lifecycle :github/reply-posted
+                    {:message "Posted reply to comment"
+                     :data {:reply-url (:url (:data reply-result))}}))
+        (resolve-after-reply worktree-path pr-number comment-id
+                             reply-result auto-resolve logger)))))

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github_conversation.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github_conversation.clj
@@ -99,9 +99,11 @@
                      :data {:error (:error reply-result) :pr-number pr-number
                             :comment-id comment-id}}))
         (dag/err :reply-failed
-                 (:error reply-result)
+                 (get-in reply-result [:error :message]
+                         "Failed to post reply to comment")
                  {:pr-number pr-number :comment-id comment-id
-                  :fix-pr-number fix-pr-number}))
+                  :fix-pr-number fix-pr-number
+                  :cause (:error reply-result)}))
       (do
         (when logger
           (log/info logger :pr-lifecycle :github/reply-posted

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github_conversation_resolution.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github_conversation_resolution.clj
@@ -1,0 +1,91 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.pr-lifecycle.github-conversation-resolution
+  "Fail-soft review-thread resolution after a successful reply."
+  (:require
+   [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.logging.interface :as log]
+   [ai.miniforge.pr-lifecycle.github :as github]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} reply-outcome
+  [reply-result resolved? details]
+  (dag/ok (merge {:reply-posted true :resolved resolved?
+                  :reply-url (:url (:data reply-result))}
+                 details)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} thread-lookup-failure-outcome
+  [reply-result thread-result comment-id logger]
+  (when logger
+    (log/warn logger :pr-lifecycle :github/thread-id-failed
+              {:message "Could not get thread ID for resolution"
+               :data {:error (:error thread-result) :comment-id comment-id}}))
+  (reply-outcome reply-result false
+                 {:resolution-error (:error thread-result)}))
+
+(defn- ^{:stratum 1} already-resolved-outcome
+  [reply-result thread-id logger]
+  (when logger
+    (log/info logger :pr-lifecycle :github/already-resolved
+              {:message "Thread already resolved"
+               :data {:thread-id thread-id}}))
+  (reply-outcome reply-result true
+                 {:already-resolved true :thread-id thread-id}))
+
+(defn- ^{:stratum 1} resolve-open-thread
+  [worktree-path pr-number reply-result thread-id logger]
+  (let [result (github/resolve-conversation worktree-path thread-id)]
+    (if (dag/ok? result)
+      (do
+        (when logger
+          (log/info logger :pr-lifecycle :github/conversation-resolved
+                    {:message "Conversation resolved successfully"
+                     :data {:thread-id thread-id :pr-number pr-number}}))
+        (reply-outcome reply-result true {:thread-id thread-id}))
+      (do
+        (when logger
+          (log/warn logger :pr-lifecycle :github/resolution-failed
+                    {:message "Failed to resolve conversation"
+                     :data {:error (:error result) :thread-id thread-id}}))
+        (reply-outcome reply-result false
+                       {:resolution-error (:error result)
+                        :thread-id thread-id})))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} resolve-after-reply
+  "Optionally resolve a review thread without discarding reply success."
+  [worktree-path pr-number comment-id reply-result auto-resolve logger]
+  (let [thread-result (when auto-resolve
+                        (github/get-thread-id worktree-path pr-number comment-id))
+        thread-id (:thread-id (:data thread-result))]
+    (cond
+      (not auto-resolve)
+      (reply-outcome reply-result false {})
+
+      (dag/err? thread-result)
+      (thread-lookup-failure-outcome reply-result thread-result comment-id logger)
+
+      (:is-resolved (:data thread-result))
+      (already-resolved-outcome reply-result thread-id logger)
+
+      :else
+      (resolve-open-thread worktree-path pr-number reply-result thread-id logger))))

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github_conversation_resolution.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/github_conversation_resolution.clj
@@ -30,23 +30,25 @@
                   :reply-url (:url (:data reply-result))}
                  details)))
 
+(defn- ^{:stratum 0} log-event
+  [logger log-fn event message data]
+  (when logger
+    (log-fn logger :pr-lifecycle event {:message message :data data})))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn- ^{:stratum 1} thread-lookup-failure-outcome
   [reply-result thread-result comment-id logger]
-  (when logger
-    (log/warn logger :pr-lifecycle :github/thread-id-failed
-              {:message "Could not get thread ID for resolution"
-               :data {:error (:error thread-result) :comment-id comment-id}}))
+  (log-event logger log/warn :github/thread-id-failed
+             "Could not get thread ID for resolution"
+             {:error (:error thread-result) :comment-id comment-id})
   (reply-outcome reply-result false
                  {:resolution-error (:error thread-result)}))
 
 (defn- ^{:stratum 1} already-resolved-outcome
   [reply-result thread-id logger]
-  (when logger
-    (log/info logger :pr-lifecycle :github/already-resolved
-              {:message "Thread already resolved"
-               :data {:thread-id thread-id}}))
+  (log-event logger log/info :github/already-resolved
+             "Thread already resolved" {:thread-id thread-id})
   (reply-outcome reply-result true
                  {:already-resolved true :thread-id thread-id}))
 
@@ -55,16 +57,14 @@
   (let [result (github/resolve-conversation worktree-path thread-id)]
     (if (dag/ok? result)
       (do
-        (when logger
-          (log/info logger :pr-lifecycle :github/conversation-resolved
-                    {:message "Conversation resolved successfully"
-                     :data {:thread-id thread-id :pr-number pr-number}}))
+        (log-event logger log/info :github/conversation-resolved
+                   "Conversation resolved successfully"
+                   {:thread-id thread-id :pr-number pr-number})
         (reply-outcome reply-result true {:thread-id thread-id}))
       (do
-        (when logger
-          (log/warn logger :pr-lifecycle :github/resolution-failed
-                    {:message "Failed to resolve conversation"
-                     :data {:error (:error result) :thread-id thread-id}}))
+        (log-event logger log/warn :github/resolution-failed
+                   "Failed to resolve conversation"
+                   {:error (:error result) :thread-id thread-id})
         (reply-outcome reply-result false
                        {:resolution-error (:error result)
                         :thread-id thread-id})))))

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/interface.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/interface.clj
@@ -39,6 +39,7 @@
    [ai.miniforge.pr-lifecycle.review-monitor :as review]
    [ai.miniforge.pr-lifecycle.fix-loop :as fix]
    [ai.miniforge.pr-lifecycle.github :as github]
+   [ai.miniforge.pr-lifecycle.github-conversation :as conversation]
    [ai.miniforge.pr-lifecycle.listener-registry :as listener-registry]
    [ai.miniforge.pr-lifecycle.policy-eval-responder :as policy-eval-responder]
    [ai.miniforge.pr-lifecycle.resume-dispatcher :as resume-dispatcher]
@@ -365,7 +366,7 @@
    Example:
      (link-fix-pr-to-comment \"/path/to/repo\" 148 2780310737 150 logger)
      ; => {:success true :data {:reply-posted true :resolved true :thread-id \"PRRT_...\"}}"
-  github/link-fix-pr-to-comment)
+  conversation/link-fix-pr-to-comment)
 
 (def ^{:stratum 0} git-head-sha
   "Return the full HEAD SHA of `worktree-path`, or nil. Convenience

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/fix_loop_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/fix_loop_test.clj
@@ -25,7 +25,8 @@
    [clojure.test :refer [deftest testing is]]
    [clojure.string :as str]
    [ai.miniforge.dag-executor.interface :as dag]
-   [ai.miniforge.pr-lifecycle.fix-loop :as fix]))
+   [ai.miniforge.pr-lifecycle.fix-loop :as fix]
+   [ai.miniforge.pr-lifecycle.github-conversation :as conversation]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -98,13 +99,18 @@
       (is (dag/ok? result))
       (is (true? (:skipped (:data result)))))))
 
-(deftest ^{:stratum 0} resolve-comment-thread-skips-when-disabled-test
-  (testing "Skips resolution when auto-resolve is false"
-    (let [ctx {:fix/comment-id 789 :fix/parent-pr-number 123}
-          result (fix/resolve-comment-thread "/tmp" ctx 456 nil
-                                              :auto-resolve false)]
-      (is (dag/ok? result))
-      (is (true? (:skipped (:data result)))))))
+(deftest ^{:stratum 0} resolve-comment-thread-replies-when-resolution-disabled-test
+  (testing "Posts the fix link while leaving resolution disabled"
+    (let [call (atom nil)]
+      (with-redefs [conversation/link-fix-pr-to-comment
+                    (fn [& args]
+                      (reset! call args)
+                      (dag/ok {:reply-posted true :resolved false}))]
+        (let [ctx {:fix/comment-id 789 :fix/parent-pr-number 123}
+              result (fix/resolve-comment-thread "/tmp" ctx 456 nil
+                                                  :auto-resolve false)]
+          (is (dag/ok? result))
+          (is (= [:auto-resolve false] (take-last 2 @call))))))))
 
 ;------------------------------------------------------------------------------ Layer 1
 

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/fix_loop_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/fix_loop_test.clj
@@ -18,9 +18,8 @@
 (ns ai.miniforge.pr-lifecycle.fix-loop-test
   "Unit tests for fix loop context building and prompt generation.
 
-   Tests fix context creation, prompt building for each failure type,
-   and resolve-comment-thread skip logic. Does NOT test actual
-   generation or git operations."
+   Tests fix context creation, prompt building for each failure type, and
+   conversation follow-up routing. Does not execute generation or git operations."
   (:require
    [clojure.test :refer [deftest testing is]]
    [clojure.string :as str]
@@ -91,7 +90,7 @@
       (is (str/includes? prompt "Fix issues"))
       (is (str/includes? prompt "something broke")))))
 
-;------------------------------------------------------------------------------ Resolve Comment Thread (Skip Logic)
+;------------------------------------------------------------------------------ Conversation Follow-up
 (deftest ^{:stratum 0} resolve-comment-thread-skips-without-metadata-test
   (testing "Skips resolution when comment-id is missing"
     (let [ctx {:fix/comment-id nil :fix/parent-pr-number 123}
@@ -161,7 +160,7 @@
       (is (= prev (:fix/previous-fixes ctx))))))
 
 (deftest ^{:stratum 1} create-fix-context-comment-metadata-test
-  (testing "Comment metadata for conversation resolution"
+  (testing "Comment metadata for conversation follow-up"
     (let [failure {:type :review-changes
                    :summary "1 change"
                    :comment-id 456
@@ -169,3 +168,26 @@
           ctx (fix/create-fix-context test-task test-pr-info failure)]
       (is (= 456 (:fix/comment-id ctx)))
       (is (= 100 (:fix/parent-pr-number ctx))))))
+
+(deftest ^{:stratum 1} run-fix-loop-replies-when-resolution-disabled-test
+  (testing "Successful fixes still post the review reply in reply-only mode"
+    (let [follow-up-call (atom nil)
+          failure {:type :review-changes
+                   :summary "1 requested change"
+                   :comment-id 456
+                   :parent-pr-number 123}]
+      (with-redefs [fix/generate-fix
+                    (fn [& _] {:success true :artifact {} :metrics {}})
+                    fix/apply-fix-to-worktree (fn [& _] (dag/ok {}))
+                    fix/commit-fix (fn [& _] (dag/ok {:commit-sha "abc123"}))
+                    fix/resolve-comment-thread
+                    (fn [& args]
+                      (reset! follow-up-call args)
+                      (dag/ok {:reply-posted true :resolved false}))]
+        (let [result (fix/run-fix-loop
+                      test-task test-pr-info failure (fn [& _]) {}
+                      :worktree-path "/tmp"
+                      :auto-resolve-comments false)]
+          (is (:success? result))
+          (is (= [:auto-resolve false]
+                 (take-last 2 @follow-up-call))))))))

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/github_conversation_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/github_conversation_test.clj
@@ -39,7 +39,9 @@
       (let [result (conversation/link-fix-pr-to-comment
                     "/repo" 42 7 99 nil)]
         (is (dag/err? result))
-        (is (= :reply-failed (get-in result [:error :code])))))))
+        (is (= :reply-failed (get-in result [:error :code])))
+        (is (string? (get-in result [:error :message])))
+        (is (= (:error failure) (get-in result [:error :data :cause])))))))
 
 ;------------------------------------------------------------------------------ Layer 1
 

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/github_conversation_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/github_conversation_test.clj
@@ -1,0 +1,84 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.pr-lifecycle.github-conversation-test
+  "Behavior locks for the decomposed GitHub conversation workflow."
+  (:require
+   [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.pr-lifecycle.github :as github]
+   [ai.miniforge.pr-lifecycle.github-conversation :as conversation]
+   [clojure.test :refer [deftest is testing]]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} reply-success []
+  (dag/ok {:url "https://github.test/reply/1"}))
+
+(defn- ^{:stratum 0} thread-success [resolved?]
+  (dag/ok {:thread-id "PRRT_test" :is-resolved resolved?}))
+
+(deftest ^{:stratum 0} link-stops-when-reply-fails-test
+  (let [failure (dag/err :gh-command-failed "reply failed")]
+    (with-redefs [github/reply-to-comment (fn [& _] failure)
+                  github/get-thread-id
+                  (fn [& _] (throw (ex-info "must not resolve" {})))]
+      (let [result (conversation/link-fix-pr-to-comment
+                    "/repo" 42 7 99 nil)]
+        (is (dag/err? result))
+        (is (= :reply-failed (get-in result [:error :code])))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} link-can-preserve-an-unresolved-reply-test
+  (with-redefs [github/reply-to-comment (fn [& _] (reply-success))
+                github/get-thread-id
+                (fn [& _] (throw (ex-info "auto-resolution disabled" {})))]
+    (let [result (conversation/link-fix-pr-to-comment
+                  "/repo" 42 7 99 nil :auto-resolve false)]
+      (is (= {:reply-posted true
+              :resolved false
+              :reply-url "https://github.test/reply/1"}
+             (:data result))))))
+
+(deftest ^{:stratum 1} link-resolves-an-open-thread-test
+  (let [reply-message (atom nil)]
+    (with-redefs [github/reply-to-comment
+                  (fn [_ _ _ message]
+                    (reset! reply-message message)
+                    (reply-success))
+                  github/get-thread-id (fn [& _] (thread-success false))
+                  github/resolve-conversation
+                  (fn [_ thread-id]
+                    (dag/ok {:thread-id thread-id :resolved true}))]
+      (let [result (conversation/link-fix-pr-to-comment
+                    "/repo" 42 7 99 nil)]
+        (testing "the reply links the exact fix PR"
+          (is (= "Fixed in PR #99" @reply-message)))
+        (is (= {:reply-posted true
+                :resolved true
+                :reply-url "https://github.test/reply/1"
+                :thread-id "PRRT_test"}
+               (:data result)))))))
+
+(deftest ^{:stratum 1} link-does-not-resolve-an-already-resolved-thread-test
+  (with-redefs [github/reply-to-comment (fn [& _] (reply-success))
+                github/get-thread-id (fn [& _] (thread-success true))
+                github/resolve-conversation
+                (fn [& _] (throw (ex-info "already resolved" {})))]
+    (let [result (conversation/link-fix-pr-to-comment "/repo" 42 7 99 nil)]
+      (is (true? (get-in result [:data :resolved])))
+      (is (true? (get-in result [:data :already-resolved]))))))

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/github_conversation_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/github_conversation_test.clj
@@ -56,6 +56,17 @@
               :reply-url "https://github.test/reply/1"}
              (:data result))))))
 
+(deftest ^{:stratum 1} link-preserves-reply-when-thread-lookup-fails-test
+  (let [failure (dag/err :thread-not-found "review thread was not found")]
+    (with-redefs [github/reply-to-comment (fn [& _] (reply-success))
+                  github/get-thread-id (fn [& _] failure)]
+      (let [result (conversation/link-fix-pr-to-comment "/repo" 42 7 99 nil)]
+        (is (dag/ok? result))
+        (is (true? (get-in result [:data :reply-posted])))
+        (is (false? (get-in result [:data :resolved])))
+        (is (= (:error failure)
+               (get-in result [:data :resolution-error])))))))
+
 (deftest ^{:stratum 1} link-resolves-an-open-thread-test
   (let [reply-message (atom nil)]
     (with-redefs [github/reply-to-comment
@@ -84,3 +95,16 @@
     (let [result (conversation/link-fix-pr-to-comment "/repo" 42 7 99 nil)]
       (is (true? (get-in result [:data :resolved])))
       (is (true? (get-in result [:data :already-resolved]))))))
+
+(deftest ^{:stratum 1} link-preserves-reply-when-resolution-fails-test
+  (let [failure (dag/err :resolution-failed "review thread was not resolved")]
+    (with-redefs [github/reply-to-comment (fn [& _] (reply-success))
+                  github/get-thread-id (fn [& _] (thread-success false))
+                  github/resolve-conversation (fn [& _] failure)]
+      (let [result (conversation/link-fix-pr-to-comment "/repo" 42 7 99 nil)]
+        (is (dag/ok? result))
+        (is (true? (get-in result [:data :reply-posted])))
+        (is (false? (get-in result [:data :resolved])))
+        (is (= "PRRT_test" (get-in result [:data :thread-id])))
+        (is (= (:error failure)
+               (get-in result [:data :resolution-error])))))))

--- a/docs/pull-requests/2026-08-07-codex-n7-github-conversation-decomposition.md
+++ b/docs/pull-requests/2026-08-07-codex-n7-github-conversation-decomposition.md
@@ -1,0 +1,42 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor: decompose GitHub conversation workflow
+
+## Summary
+
+Extracts reply-and-resolution orchestration from the five-layer GitHub
+provider namespace before N7 merge enforcement adds provider readback.
+
+## Changes
+
+- Move the high-level fix-link workflow into a three-layer
+  `github-conversation` namespace.
+- Preserve the public PR-lifecycle API, telemetry, and result behavior.
+- Keep reply-only mode functional when automatic resolution is disabled.
+- Pass resolution identifiers as GraphQL variables.
+- Preserve provider failure messages as strings and attach structured causes.
+- Remove the unused GraphQL mutation wrapper.
+
+## Standards review
+
+- `github.clj` drops from five strata to at most three.
+- Repeated successful reply maps use one `reply-outcome` factory.
+- Provider transport and conversation orchestration remain separate concerns.
+- PR budget: 305 / 600 reportable lines; every commit is at most 200.
+- Kondo, Polylith, stratum lint, and the standards baseline are clean.
+
+## Verification
+
+- PR-lifecycle component passes in all three project compositions.
+- Conversation behavior: 4 tests / 9 assertions.
+- Pre-commit smoke: 339 tests / 1,285 assertions.
+- GraalVM/Babashka compatibility: 8 tests / 606 assertions.
+
+## Follow-up
+
+PR #1704 will rebase onto this seam and contain only provider-backed review
+thread readback and its fail-closed validation.

--- a/docs/pull-requests/2026-08-07-codex-n7-github-conversation-decomposition.md
+++ b/docs/pull-requests/2026-08-07-codex-n7-github-conversation-decomposition.md
@@ -26,13 +26,13 @@ provider namespace before N7 merge enforcement adds provider readback.
 - `github.clj` drops from five strata to at most three.
 - Repeated successful reply maps use one `reply-outcome` factory.
 - Provider transport and conversation orchestration remain separate concerns.
-- PR budget: 305 / 600 reportable lines; every commit is at most 200.
+- PR budget: 327 / 600 reportable lines; every commit is at most 200.
 - Kondo, Polylith, stratum lint, and the standards baseline are clean.
 
 ## Verification
 
 - PR-lifecycle component passes in all three project compositions.
-- Conversation behavior: 4 tests / 9 assertions.
+- Conversation behavior: 6 tests / 18 assertions.
 - Pre-commit smoke: 339 tests / 1,285 assertions.
 - GraalVM/Babashka compatibility: 8 tests / 606 assertions.
 

--- a/docs/pull-requests/2026-08-07-codex-n7-github-conversation-decomposition.md
+++ b/docs/pull-requests/2026-08-07-codex-n7-github-conversation-decomposition.md
@@ -13,8 +13,8 @@ provider namespace before N7 merge enforcement adds provider readback.
 
 ## Changes
 
-- Move the high-level fix-link workflow into a three-layer
-  `github-conversation` namespace.
+- Move the high-level fix-link workflow into focused conversation and
+  resolution namespaces, each with at most three strata.
 - Preserve the public PR-lifecycle API, telemetry, and result behavior.
 - Keep reply-only mode functional when automatic resolution is disabled.
 - Pass resolution identifiers as GraphQL variables.
@@ -24,9 +24,11 @@ provider namespace before N7 merge enforcement adds provider readback.
 ## Standards review
 
 - `github.clj` drops from five strata to at most three.
+- Reply and resolution workflows use flat conditional dispatch with one
+  concern per named function.
 - Repeated successful reply maps use one `reply-outcome` factory.
 - Provider transport and conversation orchestration remain separate concerns.
-- PR budget: 340 / 600 reportable lines; every commit is at most 200.
+- PR budget: 363 / 600 reportable lines; every commit is at most 200.
 - Kondo, Polylith, stratum lint, and the standards baseline are clean.
 
 ## Verification

--- a/docs/pull-requests/2026-08-07-codex-n7-github-conversation-decomposition.md
+++ b/docs/pull-requests/2026-08-07-codex-n7-github-conversation-decomposition.md
@@ -26,7 +26,7 @@ provider namespace before N7 merge enforcement adds provider readback.
 - `github.clj` drops from five strata to at most three.
 - Repeated successful reply maps use one `reply-outcome` factory.
 - Provider transport and conversation orchestration remain separate concerns.
-- PR budget: 327 / 600 reportable lines; every commit is at most 200.
+- PR budget: 340 / 600 reportable lines; every commit is at most 200.
 - Kondo, Polylith, stratum lint, and the standards baseline are clean.
 
 ## Verification

--- a/docs/pull-requests/2026-08-07-codex-n7-github-conversation-decomposition.md
+++ b/docs/pull-requests/2026-08-07-codex-n7-github-conversation-decomposition.md
@@ -28,7 +28,7 @@ provider namespace before N7 merge enforcement adds provider readback.
   concern per named function.
 - Repeated successful reply maps use one `reply-outcome` factory.
 - Provider transport and conversation orchestration remain separate concerns.
-- PR budget: 363 / 600 reportable lines; every commit is at most 200.
+- PR budget: 362 / 600 reportable lines; every commit is at most 200.
 - Kondo, Polylith, stratum lint, and the standards baseline are clean.
 
 ## Verification

--- a/docs/pull-requests/2026-08-07-codex-n7-github-conversation-decomposition.md
+++ b/docs/pull-requests/2026-08-07-codex-n7-github-conversation-decomposition.md
@@ -28,13 +28,14 @@ provider namespace before N7 merge enforcement adds provider readback.
   concern per named function.
 - Repeated successful reply maps use one `reply-outcome` factory.
 - Provider transport and conversation orchestration remain separate concerns.
-- PR budget: 362 / 600 reportable lines; every commit is at most 200.
+- PR budget: 396 / 600 reportable lines; every commit is at most 200.
 - Kondo, Polylith, stratum lint, and the standards baseline are clean.
 
 ## Verification
 
 - PR-lifecycle component passes in all three project compositions.
 - Conversation behavior: 6 tests / 18 assertions.
+- Fix-loop behavior: 12 tests / 33 assertions.
 - Pre-commit smoke: 339 tests / 1,285 assertions.
 - GraalVM/Babashka compatibility: 8 tests / 606 assertions.
 


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# refactor: decompose GitHub conversation workflow

## Summary

Extracts reply-and-resolution orchestration from the five-layer GitHub
provider namespace before N7 merge enforcement adds provider readback.

## Changes

- Move the high-level fix-link workflow into focused conversation and
  resolution namespaces, each with at most three strata.
- Preserve the public PR-lifecycle API, telemetry, and result behavior.
- Keep reply-only mode functional when automatic resolution is disabled.
- Pass resolution identifiers as GraphQL variables.
- Preserve provider failure messages as strings and attach structured causes.
- Remove the unused GraphQL mutation wrapper.

## Standards review

- `github.clj` drops from five strata to at most three.
- Reply and resolution workflows use flat conditional dispatch with one
  concern per named function.
- Repeated successful reply maps use one `reply-outcome` factory.
- Provider transport and conversation orchestration remain separate concerns.
- PR budget: 396 / 600 reportable lines; every commit is at most 200.
- Kondo, Polylith, stratum lint, and the standards baseline are clean.

## Verification

- PR-lifecycle component passes in all three project compositions.
- Conversation behavior: 6 tests / 18 assertions.
- Fix-loop behavior: 12 tests / 33 assertions.
- Pre-commit smoke: 339 tests / 1,285 assertions.
- GraalVM/Babashka compatibility: 8 tests / 606 assertions.

## Follow-up

PR #1704 will rebase onto this seam and contain only provider-backed review
thread readback and its fail-closed validation.
