### PR TITLE
refactor: enforce provider-backed merge readiness

### DIFF
--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge.clj
@@ -93,8 +93,7 @@
     (catch Exception e
       (dag/err :gh-exception (.getMessage e)))))
 
-(defn ^{:stratum 0} check-unresolved-threads
-  "Read GitHub's review-thread state for one pull request."
+(defn- ^{:stratum 0} read-unresolved-threads
   [worktree-path pr-number]
   (github/unresolved-review-threads worktree-path pr-number))
 
@@ -115,13 +114,23 @@
 (defn ^{:stratum 1} check-ci-status
   "Check if CI is green for a PR."
   [worktree-path pr-number]
-  (let [result (run-gh-command
-                ["gh" "pr" "checks" (str pr-number) "--fail-on-error"]
-                worktree-path)]
-    (if (dag/ok? result)
-      (dag/ok {:ci-green? true})
-      (dag/ok {:ci-green? false
-               :error (:error result)}))))
+  (dag/when-let-ok
+   [result (run-gh-command
+            ["gh" "pr" "checks" (str pr-number) "--json" "bucket"]
+            worktree-path)]
+    (let [checks (parse-gh-json (:output (:data result)))]
+      (if (and (sequential? checks) (every? #(string? (:bucket %)) checks))
+        (dag/ok {:ci-green? (boolean
+                             (and (seq checks)
+                                  (every? #{"pass" "skipping"}
+                                          (map :bucket checks))))})
+        (dag/err :invalid-ci-status-response
+                 "GitHub returned incomplete CI check state")))))
+
+(defn ^{:stratum 1} check-unresolved-threads
+  "Read GitHub's review-thread state for one pull request."
+  [worktree-path pr-number]
+  (read-unresolved-threads worktree-path pr-number))
 
 (defn ^{:stratum 1} check-review-status
   "Check if PR has required approvals."

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge.clj
@@ -23,6 +23,7 @@
   (:require
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.pr-lifecycle.github :as github]
    [ai.miniforge.pr-lifecycle.merge-orchestration :as orchestration]
    [ai.miniforge.pr-lifecycle.merge-readiness :as readiness]
    [ai.miniforge.response.interface :as response]
@@ -93,10 +94,9 @@
       (dag/err :gh-exception (.getMessage e)))))
 
 (defn ^{:stratum 0} check-unresolved-threads
-  "Check if PR has unresolved comment threads."
-  [_worktree-path _pr-number]
-  (dag/ok {:has-unresolved? false
-           :note "Thread resolution check requires GitHub API"}))
+  "Read GitHub's review-thread state for one pull request."
+  [worktree-path pr-number]
+  (github/unresolved-review-threads worktree-path pr-number))
 
 ;; Conflict-resolution dispatch (Stage 3d, spec §6.4)
 (defn- ^{:stratum 0} parse-gh-json

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge.clj
@@ -247,13 +247,13 @@
 (defn ^{:stratum 1} fetch-pr-branch
   "Read the PR head branch from GitHub."
   [worktree-path pr-number]
-  (let [result (run-gh-command
-                ["gh" "pr" "view" (str pr-number) "--json" "headRefName"] worktree-path)]
-    (if (dag/err? result)
-      result
+  (dag/when-let-ok
+   [result (run-gh-command
+            ["gh" "pr" "view" (str pr-number) "--json" "headRefName"]
+            worktree-path)]
       (if-let [branch (:headRefName (parse-gh-json (:output (:data result))))]
         (dag/ok {:branch branch})
-        (dag/err :branch-not-found "Could not determine PR branch")))))
+        (dag/err :branch-not-found "Could not determine PR branch"))))
 
 (defn- ^{:stratum 1} pr-info-from-gh
   "Fetch the fields conflict-resolution/resolve-pr-conflicts! needs
@@ -357,8 +357,11 @@
   "Attempt a governed merge or the configured branch repair."
   [worktree-path pr-number policy context]
   (orchestration/attempt-merge
-   {:check-ci check-ci-status :check-review check-review-status
-    :check-branch check-branch-status :check-threads check-unresolved-threads
+   {:evaluate-readiness
+    (partial readiness/evaluate
+             {:check-ci check-ci-status :check-review check-review-status
+              :check-branch check-branch-status
+              :check-threads check-unresolved-threads})
     :run-gh run-gh-command :merge-pr merge-pr!
     :fetch-labels fetch-pr-labels! :fetch-branch fetch-pr-branch
     :rebase-pr rebase-pr! :pr-info pr-info-from-gh :normalize-resolution normalize-resolution-outcome}

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge.clj
@@ -23,16 +23,12 @@
   (:require
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.dag-executor.interface :as dag]
-   [ai.miniforge.pr-lifecycle.conflict-resolution :as conflict-resolution]
-   [ai.miniforge.pr-lifecycle.merge-transaction :as merge-transaction]
-   [ai.miniforge.pr-lifecycle.events :as events]
-   [ai.miniforge.logging.interface :as log]
+   [ai.miniforge.pr-lifecycle.merge-orchestration :as orchestration]
+   [ai.miniforge.pr-lifecycle.merge-readiness :as readiness]
    [ai.miniforge.response.interface :as response]
    [babashka.process :as process]
    [cheshire.core :as json]
-   [clojure.string :as str])
-  (:import
-   [java.time Instant]))
+   [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -99,8 +95,6 @@
 (defn ^{:stratum 0} check-unresolved-threads
   "Check if PR has unresolved comment threads."
   [_worktree-path _pr-number]
-  ;; gh doesn't have a direct way to check this
-  ;; Would need GitHub API for accurate count
   (dag/ok {:has-unresolved? false
            :note "Thread resolution check requires GitHub API"}))
 
@@ -250,6 +244,17 @@
               (dag/err :push-failed (:error push-result))))
           (dag/err :rebase-failed (:error rebase-result)))))))
 
+(defn ^{:stratum 1} fetch-pr-branch
+  "Read the PR head branch from GitHub."
+  [worktree-path pr-number]
+  (let [result (run-gh-command
+                ["gh" "pr" "view" (str pr-number) "--json" "headRefName"] worktree-path)]
+    (if (dag/err? result)
+      result
+      (if-let [branch (:headRefName (parse-gh-json (:output (:data result))))]
+        (dag/ok {:branch branch})
+        (dag/err :branch-not-found "Could not determine PR branch")))))
+
 (defn- ^{:stratum 1} pr-info-from-gh
   "Fetch the fields conflict-resolution/resolve-pr-conflicts! needs
    from `gh pr view`: PR number, branch (headRefName), base
@@ -341,218 +346,23 @@
 ;------------------------------------------------------------------------------ Layer 2
 
 (defn ^{:stratum 2} evaluate-merge-readiness
-  "Evaluate if a PR is ready to merge according to policy.
-
-   Arguments:
-   - worktree-path: Path to git worktree
-   - pr-number: PR number
-   - policy: Merge policy map
-
-   Returns {:ready? bool :checks {...} :blocking [...]}."
+  "Evaluate every enabled merge policy check."
   [worktree-path pr-number policy]
-  (let [ci-check (when (:require-ci-green? policy)
-                   (check-ci-status worktree-path pr-number))
-        review-check (when (:require-approvals? policy)
-                       (check-review-status worktree-path pr-number
-                                            (:required-approvals policy)))
-        branch-check (when (:require-branch-up-to-date? policy)
-                       (check-branch-status worktree-path pr-number))
-        thread-check (when (:require-no-unresolved-threads? policy)
-                       (check-unresolved-threads worktree-path pr-number))
+  (readiness/evaluate
+   {:check-ci check-ci-status :check-review check-review-status
+    :check-branch check-branch-status :check-threads check-unresolved-threads}
+   worktree-path pr-number policy))
 
-        checks {:ci ci-check
-                :review review-check
-                :branch branch-check
-                :threads thread-check}
-
-        blocking (cond-> []
-                   (and ci-check (not (:ci-green? (:data ci-check))))
-                   (conj :ci-not-green)
-
-                   (and review-check (not (:approved? (:data review-check))))
-                   (conj :not-approved)
-
-                   (and branch-check (not (:up-to-date? (:data branch-check))))
-                   (conj :branch-not-up-to-date)
-
-                   (and thread-check (:has-unresolved? (:data thread-check)))
-                   (conj :unresolved-threads))]
-
-    {:ready? (empty? blocking)
-     :checks checks
-     :blocking blocking}))
-
-(defn- ^{:stratum 2} attempt-conflict-resolution!
-  "Spec §6.4 dispatch: when `branch-check` raw output classifies as
-   :conflicting AND policy enables auto-resolve AND context carries
-   `:resolve-fn`, run conflict-resolution/resolve-pr-conflicts! and
-   return its outcome (normalized into dag/ok or dag/err — see
-   normalize-resolution-outcome). Otherwise return nil so the
-   caller falls back to the existing rebase/not-ready path.
-
-   The resolve-fn comes from context (workflow side injects
-   workflow.merge-resolution/resolve-conflict! at lifecycle ctor
-   time) so pr-lifecycle stays free of a workflow dependency."
-  [worktree-path pr-number policy context branch-raw]
-  (let [resolve-fn (:resolve-fn context)
-        state      (conflict-resolution/classify-merge-state branch-raw)]
-    (when (and (= :conflicting state)
-               (:auto-resolve-conflicts? policy)
-               resolve-fn)
-      (let [pr-r (pr-info-from-gh worktree-path pr-number)]
-        (if (dag/err? pr-r)
-          pr-r
-          (normalize-resolution-outcome
-           (conflict-resolution/resolve-pr-conflicts!
-            {:worktree-path worktree-path
-             :pr            (:data pr-r)
-             :resolve-fn    resolve-fn
-             :context       context})))))))
-
-;------------------------------------------------------------------------------ Layer 3
-
-(defn ^{:stratum 3} attempt-merge
-  "Attempt to merge a PR, handling common failure cases.
-
-   Arguments:
-   - worktree-path: Path to git worktree
-   - pr-number: PR number
-   - policy: Merge policy
-   - context: Context with :dag/id :run/id :task/id :pr/id :event-bus :logger
-
-   Returns result with merge status and events."
+(defn ^{:stratum 2} attempt-merge
+  "Attempt a governed merge or the configured branch repair."
   [worktree-path pr-number policy context]
-  (let [logger (:logger context)
-        event-bus (:event-bus context)
-        {:keys [dag-id run-id task-id pr-id]} context]
-
-    (when logger
-      (log/info logger :pr-lifecycle :merge/attempting
-                {:message "Attempting PR merge"
-                 :data {:pr-number pr-number}}))
-
-    ;; First check if ready
-    (let [readiness (evaluate-merge-readiness worktree-path pr-number policy)]
-      (if (:ready? readiness)
-        ;; Ready to merge - attempt it
-        ;; Transacted (Ariadne 2d): the intent is recorded BEFORE any gh
-        ;; command, enabling auto-merge is recorded as a request accepted
-        ;; rather than a merge performed, and the merged event fires only
-        ;; against a merge GitHub actually reports — carrying GitHub's
-        ;; mergeCommit, never a SHA read from the local worktree.
-        (let [now (Instant/now)
-              run-gh (fn [args]
-                       (let [r (run-gh-command args worktree-path)]
-                         {:ok? (dag/ok? r) :output (:output (:data r))}))
-              enable! (fn []
-                        (let [r (merge-pr! worktree-path pr-number :policy policy)]
-                          {:ok? (dag/ok? r) :error (:error r)}))
-              ;; The method is known from policy; the proposal must record
-              ;; what was actually requested, not nil.
-              proposed (merge-transaction/propose!
-                        (assoc context :merge/method (:method policy))
-                        pr-number (:pr/repo context) now)
-              settled (merge-transaction/commit! context proposed pr-number
-                                                 now enable! run-gh)
-              merge-sha (merge-transaction/substantiated-sha settled)]
-          (cond
-            (= :failed (:effect/state settled))
-            (dag/err :merge-failed
-                     "Merge command failed"
-                     {:gh-error (:effect/failure settled)})
-
-            merge-sha
-            (do
-              ;; Publish merged event with the PR's labels so downstream
-              ;; watchers (label-actions M2) can match without re-querying
-              ;; GitHub. Label fetch is best-effort — missing labels
-              ;; default to #{}, never block the merge event.
-              (when event-bus
-                (events/publish! event-bus
-                                 (events/merged dag-id run-id task-id pr-id
-                                                merge-sha
-                                                (fetch-pr-labels! worktree-path pr-number))
-                                 logger))
-              (when logger
-                (log/info logger :pr-lifecycle :merge/success
-                          {:message "PR merged successfully"
-                           :data {:pr-number pr-number :merge/sha merge-sha}}))
-              (dag/ok {:merged? true
-                       :method (:method policy)
-                       :merge/sha merge-sha
-                       :effect/id (:effect/id settled)}))
-
-            :else
-            ;; Auto-merge is enabled and GitHub has not reported a merge.
-            ;; Saying {:merged? true} here is the specific lie this
-            ;; change removes; the record stays reconcilable and a later
-            ;; pass asks again.
-            (do
-              (when logger
-                (log/info logger :pr-lifecycle :merge/auto-merge-pending
-                          {:message "Auto-merge enabled; merge not yet observed"
-                           :data {:pr-number pr-number
-                                  :effect/state (:effect/state settled)}}))
-              (dag/ok {:merged? false
-                       :auto-merge/enabled? true
-                       :method (:method policy)
-                       :effect/id (:effect/id settled)}))))
-
-        ;; Not ready — branch-not-up-to-date may mean either
-        ;; CONFLICTING (Stage 3 §6.4 hook engages) or BEHIND (auto-
-        ;; rebase). Attempt conflict-resolution first; only if it
-        ;; declines (state isn't :conflicting, or policy/resolver
-        ;; absent) fall through to the rebase path.
-        (let [branch-raw (get-in (:branch (:checks readiness))
-                                 [:data :raw])
-              cr-result  (when (contains? (set (:blocking readiness))
-                                          :branch-not-up-to-date)
-                           (attempt-conflict-resolution!
-                            worktree-path pr-number policy context
-                            branch-raw))]
-          (cond
-            ;; conflict-resolution engaged — return its outcome
-            ;; (success, dag/err, or terminal anomaly) directly. The
-            ;; lifecycle's outer loop re-evaluates merge readiness
-            ;; on the next cycle once GitHub re-classifies the PR.
-            (some? cr-result)
-            cr-result
-
-            (and (contains? (set (:blocking readiness)) :branch-not-up-to-date)
-                 (:auto-rebase-on-stale? policy))
-          ;; Try to rebase
-          (do
-            (when logger
-              (log/info logger :pr-lifecycle :merge/rebasing
-                        {:message "PR is stale, attempting rebase"}))
-            (let [branch-result (run-gh-command
-                                 ["gh" "pr" "view" (str pr-number) "--json" "headRefName"]
-                                 worktree-path)
-                  branch (when (dag/ok? branch-result)
-                           ;; Parse branch name from JSON
-                           (second (re-find #"\"headRefName\":\"([^\"]+)\""
-                                            (:output (:data branch-result)))))]
-              (if branch
-                (let [rebase-result (rebase-pr! worktree-path branch)]
-                  (if (dag/ok? rebase-result)
-                    ;; Rebase succeeded - CI will run again, then we can merge
-                    (do
-                      (when event-bus
-                        (events/publish! event-bus
-                                         (events/rebase-needed dag-id run-id task-id pr-id
-                                                               (:new-sha (:data rebase-result)))
-                                         logger))
-                      (dag/ok {:merged? false
-                               :rebased? true
-                               :new-sha (:new-sha (:data rebase-result))}))
-                    rebase-result))
-                (dag/err :branch-not-found "Could not determine PR branch"))))
-
-            :else
-            ;; Can't merge and won't auto-rebase
-            (dag/err :not-ready
-                     "PR is not ready to merge"
-                     {:blocking (:blocking readiness)})))))))
+  (orchestration/attempt-merge
+   {:check-ci check-ci-status :check-review check-review-status
+    :check-branch check-branch-status :check-threads check-unresolved-threads
+    :run-gh run-gh-command :merge-pr merge-pr!
+    :fetch-labels fetch-pr-labels! :fetch-branch fetch-pr-branch
+    :rebase-pr rebase-pr! :pr-info pr-info-from-gh :normalize-resolution normalize-resolution-outcome}
+   worktree-path pr-number policy context))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
@@ -571,15 +381,5 @@
 
   ;; Rebase a PR
   (rebase-pr! "/path/to/repo" "feat/my-feature")
-
-  ;; Full merge attempt with event handling
-  (attempt-merge "/path/to/repo" 123
-                 default-merge-policy
-                 {:dag-id (random-uuid)
-                  :run-id (random-uuid)
-                  :task-id (random-uuid)
-                  :pr-id 123
-                  :logger nil
-                  :event-bus nil})
 
   :leave-this-here)

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge_orchestration.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge_orchestration.clj
@@ -1,0 +1,168 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.pr-lifecycle.merge-orchestration
+  "Application flow for readiness, conflict handling, and transacted merge."
+  (:require
+   [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.logging.interface :as log]
+   [ai.miniforge.pr-lifecycle.conflict-resolution :as conflict-resolution]
+   [ai.miniforge.pr-lifecycle.events :as events]
+   [ai.miniforge.pr-lifecycle.merge-readiness :as readiness]
+   [ai.miniforge.pr-lifecycle.merge-transaction :as transaction])
+  (:import
+   [java.time Instant]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} transact!
+  "Record merge intent, enable auto-merge, and reconcile the immediate state."
+  [operations worktree-path pr-number policy context ^Instant now]
+  (let [run-gh (fn [args]
+                 (let [result ((:run-gh operations) args worktree-path)]
+                   {:ok? (dag/ok? result)
+                    :output (:output (:data result))}))
+        enable! (fn []
+                  (let [result ((:merge-pr operations)
+                                worktree-path pr-number :policy policy)]
+                    {:ok? (dag/ok? result) :error (:error result)}))
+        proposed (transaction/propose!
+                  (assoc context :merge/method (:method policy))
+                  pr-number (:pr/repo context) now)]
+    (transaction/commit! context proposed pr-number now enable! run-gh)))
+
+(defn- ^{:stratum 0} settlement-result
+  "Translate one transaction state without overstating a pending merge."
+  [operations worktree-path pr-number policy context settled]
+  (let [logger (:logger context)
+        merge-sha (transaction/substantiated-sha settled)
+        {:keys [dag-id run-id task-id pr-id event-bus]} context]
+    (cond
+      (= :failed (:effect/state settled))
+      (dag/err :merge-failed
+               "Merge command failed"
+               {:gh-error (:effect/failure settled)})
+
+      merge-sha
+      (do
+        (when event-bus
+          (events/publish! event-bus
+                           (events/merged
+                            dag-id run-id task-id pr-id merge-sha
+                            ((:fetch-labels operations)
+                             worktree-path pr-number))
+                           logger))
+        (when logger
+          (log/info logger :pr-lifecycle :merge/success
+                    {:message "PR merged successfully"
+                     :data {:pr-number pr-number :merge/sha merge-sha}}))
+        (dag/ok {:merged? true
+                 :method (:method policy)
+                 :merge/sha merge-sha
+                 :effect/id (:effect/id settled)}))
+
+      :else
+      (do
+        (when logger
+          (log/info logger :pr-lifecycle :merge/auto-merge-pending
+                    {:message "Auto-merge enabled; merge not yet observed"
+                     :data {:pr-number pr-number
+                            :effect/state (:effect/state settled)}}))
+        (dag/ok {:merged? false
+                 :auto-merge/enabled? true
+                 :method (:method policy)
+                 :effect/id (:effect/id settled)})))))
+
+(defn- ^{:stratum 0} rebase-stale!
+  "Rebase one stale PR and publish the new head when successful."
+  [operations worktree-path pr-number context]
+  (let [logger (:logger context)
+        {:keys [dag-id run-id task-id pr-id event-bus]} context]
+    (when logger
+      (log/info logger :pr-lifecycle :merge/rebasing
+                {:message "PR is stale, attempting rebase"}))
+    (let [branch-result ((:fetch-branch operations)
+                         worktree-path pr-number)]
+      (if (dag/err? branch-result)
+        branch-result
+        (let [result ((:rebase-pr operations)
+                      worktree-path (:branch (:data branch-result)))]
+          (if (dag/err? result)
+            result
+            (let [new-sha (:new-sha (:data result))]
+              (when event-bus
+                (events/publish! event-bus
+                                 (events/rebase-needed
+                                  dag-id run-id task-id pr-id new-sha)
+                                 logger))
+              (dag/ok {:merged? false
+                       :rebased? true
+                       :new-sha new-sha}))))))))
+
+(defn- ^{:stratum 0} attempt-conflict-resolution!
+  "Run the configured conflict-resolution sub-workflow when applicable."
+  [operations worktree-path pr-number policy context branch-raw]
+  (let [resolve-fn (:resolve-fn context)
+        state (conflict-resolution/classify-merge-state branch-raw)]
+    (when (and (= :conflicting state)
+               (:auto-resolve-conflicts? policy)
+               resolve-fn)
+      (let [pr-result ((:pr-info operations) worktree-path pr-number)]
+        (if (dag/err? pr-result)
+          pr-result
+          ((:normalize-resolution operations)
+           (conflict-resolution/resolve-pr-conflicts!
+            {:worktree-path worktree-path
+             :pr (:data pr-result)
+             :resolve-fn resolve-fn
+             :context context})))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} attempt-merge
+  "Attempt a governed merge or the configured branch repair."
+  [operations worktree-path pr-number policy context]
+  (when-let [logger (:logger context)]
+    (log/info logger :pr-lifecycle :merge/attempting
+              {:message "Attempting PR merge"
+               :data {:pr-number pr-number}}))
+  (let [readiness-result (readiness/evaluate
+                          operations worktree-path pr-number policy)
+        stale? (contains? (set (:blocking readiness-result))
+                          :branch-not-up-to-date)]
+    (if (:ready? readiness-result)
+      (let [now (Instant/now)
+            settled (transact! operations worktree-path pr-number
+                                 policy context now)]
+        (settlement-result operations worktree-path pr-number
+                           policy context settled))
+      (let [branch-raw (get-in (:checks readiness-result) [:branch :data :raw])
+            conflict-result (when stale?
+                              (attempt-conflict-resolution!
+                               operations worktree-path pr-number
+                               policy context branch-raw))]
+        (cond
+          (some? conflict-result)
+          conflict-result
+
+          (and stale? (:auto-rebase-on-stale? policy))
+          (rebase-stale! operations worktree-path pr-number context)
+
+          :else
+          (dag/err :not-ready
+                   "PR is not ready to merge"
+                   {:blocking (:blocking readiness-result)}))))))

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge_orchestration.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge_orchestration.clj
@@ -22,96 +22,65 @@
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.pr-lifecycle.conflict-resolution :as conflict-resolution]
    [ai.miniforge.pr-lifecycle.events :as events]
-   [ai.miniforge.pr-lifecycle.merge-readiness :as readiness]
    [ai.miniforge.pr-lifecycle.merge-transaction :as transaction])
   (:import
    [java.time Instant]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
-(defn- ^{:stratum 0} transact!
-  "Record merge intent, enable auto-merge, and reconcile the immediate state."
-  [operations worktree-path pr-number policy context ^Instant now]
-  (let [run-gh (fn [args]
-                 (let [result ((:run-gh operations) args worktree-path)]
-                   {:ok? (dag/ok? result)
-                    :output (:output (:data result))}))
-        enable! (fn []
-                  (let [result ((:merge-pr operations)
-                                worktree-path pr-number :policy policy)]
-                    {:ok? (dag/ok? result) :error (:error result)}))
-        proposed (transaction/propose!
-                  (assoc context :merge/method (:method policy))
-                  pr-number (:pr/repo context) now)]
-    (transaction/commit! context proposed pr-number now enable! run-gh)))
+(defn- ^{:stratum 0} provider-command
+  [operations worktree-path args]
+  (let [result ((:run-gh operations) args worktree-path)]
+    {:ok? (dag/ok? result)
+     :output (:output (:data result))}))
 
-(defn- ^{:stratum 0} settlement-result
-  "Translate one transaction state without overstating a pending merge."
-  [operations worktree-path pr-number policy context settled]
-  (let [logger (:logger context)
-        merge-sha (transaction/substantiated-sha settled)
-        {:keys [dag-id run-id task-id pr-id event-bus]} context]
-    (cond
-      (= :failed (:effect/state settled))
-      (dag/err :merge-failed
-               "Merge command failed"
-               {:gh-error (:effect/failure settled)})
+(defn- ^{:stratum 0} enable-merge
+  [operations worktree-path pr-number policy]
+  (let [result ((:merge-pr operations)
+                worktree-path pr-number :policy policy)]
+    {:ok? (dag/ok? result) :error (:error result)}))
 
-      merge-sha
-      (do
-        (when event-bus
-          (events/publish! event-bus
-                           (events/merged
-                            dag-id run-id task-id pr-id merge-sha
-                            ((:fetch-labels operations)
-                             worktree-path pr-number))
-                           logger))
-        (when logger
-          (log/info logger :pr-lifecycle :merge/success
-                    {:message "PR merged successfully"
-                     :data {:pr-number pr-number :merge/sha merge-sha}}))
-        (dag/ok {:merged? true
-                 :method (:method policy)
-                 :merge/sha merge-sha
-                 :effect/id (:effect/id settled)}))
-
-      :else
-      (do
-        (when logger
-          (log/info logger :pr-lifecycle :merge/auto-merge-pending
-                    {:message "Auto-merge enabled; merge not yet observed"
-                     :data {:pr-number pr-number
-                            :effect/state (:effect/state settled)}}))
-        (dag/ok {:merged? false
-                 :auto-merge/enabled? true
-                 :method (:method policy)
-                 :effect/id (:effect/id settled)})))))
-
-(defn- ^{:stratum 0} rebase-stale!
-  "Rebase one stale PR and publish the new head when successful."
-  [operations worktree-path pr-number context]
+(defn- ^{:stratum 0} merged-result
+  [operations worktree-path pr-number policy context settled merge-sha]
   (let [logger (:logger context)
         {:keys [dag-id run-id task-id pr-id event-bus]} context]
+    (when event-bus
+      (events/publish! event-bus
+                       (events/merged
+                        dag-id run-id task-id pr-id merge-sha
+                        ((:fetch-labels operations) worktree-path pr-number))
+                       logger))
     (when logger
-      (log/info logger :pr-lifecycle :merge/rebasing
-                {:message "PR is stale, attempting rebase"}))
-    (let [branch-result ((:fetch-branch operations)
-                         worktree-path pr-number)]
-      (if (dag/err? branch-result)
-        branch-result
-        (let [result ((:rebase-pr operations)
-                      worktree-path (:branch (:data branch-result)))]
-          (if (dag/err? result)
-            result
-            (let [new-sha (:new-sha (:data result))]
-              (when event-bus
-                (events/publish! event-bus
-                                 (events/rebase-needed
-                                  dag-id run-id task-id pr-id new-sha)
-                                 logger))
-              (dag/ok {:merged? false
-                       :rebased? true
-                       :new-sha new-sha}))))))))
+      (log/info logger :pr-lifecycle :merge/success
+                {:message "PR merged successfully"
+                 :data {:pr-number pr-number :merge/sha merge-sha}}))
+    (dag/ok {:merged? true
+             :method (:method policy)
+             :merge/sha merge-sha
+             :effect/id (:effect/id settled)})))
+
+(defn- ^{:stratum 0} pending-result
+  [pr-number policy context settled]
+  (when-let [logger (:logger context)]
+    (log/info logger :pr-lifecycle :merge/auto-merge-pending
+              {:message "Auto-merge enabled; merge not yet observed"
+               :data {:pr-number pr-number
+                      :effect/state (:effect/state settled)}}))
+  (dag/ok {:merged? false
+           :auto-merge/enabled? true
+           :method (:method policy)
+           :effect/id (:effect/id settled)}))
+
+(defn- ^{:stratum 0} completed-rebase
+  [context new-sha]
+  (let [logger (:logger context)
+        {:keys [dag-id run-id task-id pr-id event-bus]} context]
+    (when event-bus
+      (events/publish! event-bus
+                       (events/rebase-needed
+                        dag-id run-id task-id pr-id new-sha)
+                       logger))
+    (dag/ok {:merged? false :rebased? true :new-sha new-sha})))
 
 (defn- ^{:stratum 0} attempt-conflict-resolution!
   "Run the configured conflict-resolution sub-workflow when applicable."
@@ -121,27 +90,67 @@
     (when (and (= :conflicting state)
                (:auto-resolve-conflicts? policy)
                resolve-fn)
-      (let [pr-result ((:pr-info operations) worktree-path pr-number)]
-        (if (dag/err? pr-result)
-          pr-result
-          ((:normalize-resolution operations)
-           (conflict-resolution/resolve-pr-conflicts!
-            {:worktree-path worktree-path
-             :pr (:data pr-result)
-             :resolve-fn resolve-fn
-             :context context})))))))
+      (dag/when-let-ok
+       [pr-result ((:pr-info operations) worktree-path pr-number)]
+        ((:normalize-resolution operations)
+         (conflict-resolution/resolve-pr-conflicts!
+          {:worktree-path worktree-path
+           :pr (:data pr-result)
+           :resolve-fn resolve-fn
+           :context context}))))))
 
 ;------------------------------------------------------------------------------ Layer 1
 
-(defn ^{:stratum 1} attempt-merge
+(defn- ^{:stratum 1} transact!
+  "Record merge intent, enable auto-merge, and reconcile the immediate state."
+  [operations worktree-path pr-number policy context ^Instant now]
+  (let [run-gh (partial provider-command operations worktree-path)
+        enable! (partial enable-merge operations worktree-path pr-number policy)
+        proposed (transaction/propose!
+                  (assoc context :merge/method (:method policy))
+                  pr-number (:pr/repo context) now)]
+    (transaction/commit! context proposed pr-number now enable! run-gh)))
+
+(defn- ^{:stratum 1} settlement-result
+  "Translate one transaction state without overstating a pending merge."
+  [operations worktree-path pr-number policy context settled]
+  (let [merge-sha (transaction/substantiated-sha settled)]
+    (cond
+      (= :failed (:effect/state settled))
+      (dag/err :merge-failed
+               "Merge command failed"
+               {:gh-error (:effect/failure settled)})
+
+      merge-sha
+      (merged-result operations worktree-path pr-number
+                     policy context settled merge-sha)
+
+      :else
+      (pending-result pr-number policy context settled))))
+
+(defn- ^{:stratum 1} rebase-stale!
+  "Rebase one stale PR and publish the new head when successful."
+  [operations worktree-path pr-number context]
+  (when-let [logger (:logger context)]
+    (log/info logger :pr-lifecycle :merge/rebasing
+              {:message "PR is stale, attempting rebase"}))
+  (dag/when-let-ok
+   [branch-result ((:fetch-branch operations) worktree-path pr-number)
+    result ((:rebase-pr operations)
+            worktree-path (:branch (:data branch-result)))]
+    (completed-rebase context (:new-sha (:data result)))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} attempt-merge
   "Attempt a governed merge or the configured branch repair."
   [operations worktree-path pr-number policy context]
   (when-let [logger (:logger context)]
     (log/info logger :pr-lifecycle :merge/attempting
               {:message "Attempting PR merge"
                :data {:pr-number pr-number}}))
-  (let [readiness-result (readiness/evaluate
-                          operations worktree-path pr-number policy)
+  (let [readiness-result ((:evaluate-readiness operations)
+                          worktree-path pr-number policy)
         stale? (contains? (set (:blocking readiness-result))
                           :branch-not-up-to-date)]
     (if (:ready? readiness-result)

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge_orchestration.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge_orchestration.clj
@@ -151,8 +151,8 @@
                :data {:pr-number pr-number}}))
   (let [readiness-result ((:evaluate-readiness operations)
                           worktree-path pr-number policy)
-        stale? (contains? (set (:blocking readiness-result))
-                          :branch-not-up-to-date)]
+        stale? (some #{:branch-not-up-to-date}
+                     (:blocking readiness-result))]
     (if (:ready? readiness-result)
       (let [now (Instant/now)
             settled (transact! operations worktree-path pr-number

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge_readiness.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge_readiness.clj
@@ -1,0 +1,60 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.pr-lifecycle.merge-readiness
+  "Pure composition of provider-backed merge-readiness checks."
+  (:require
+   [ai.miniforge.dag-executor.interface :as dag]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} evaluate
+  "Run enabled checks and return every blocking reason."
+  [{:keys [check-ci check-review check-branch check-threads]}
+   worktree-path pr-number policy]
+  (let [ci-check (when (:require-ci-green? policy)
+                   (check-ci worktree-path pr-number))
+        review-check (when (:require-approvals? policy)
+                       (check-review worktree-path pr-number
+                                     (:required-approvals policy)))
+        branch-check (when (:require-branch-up-to-date? policy)
+                       (check-branch worktree-path pr-number))
+        thread-check (when (:require-no-unresolved-threads? policy)
+                       (check-threads worktree-path pr-number))
+        checks {:ci ci-check
+                :review review-check
+                :branch branch-check
+                :threads thread-check}
+        blocking (cond-> []
+                   (and ci-check (not (:ci-green? (:data ci-check))))
+                   (conj :ci-not-green)
+
+                   (and review-check (not (:approved? (:data review-check))))
+                   (conj :not-approved)
+
+                   (and branch-check (not (:up-to-date? (:data branch-check))))
+                   (conj :branch-not-up-to-date)
+
+                   (and thread-check (dag/err? thread-check))
+                   (conj :thread-status-unavailable)
+
+                   (and (dag/ok? thread-check)
+                        (:has-unresolved? (:data thread-check)))
+                   (conj :unresolved-threads))]
+    {:ready? (empty? blocking)
+     :checks checks
+     :blocking blocking}))

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge_readiness.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge_readiness.clj
@@ -16,7 +16,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns ai.miniforge.pr-lifecycle.merge-readiness
-  "Pure composition of provider-backed merge-readiness checks."
+  "Composition and classification of provider-backed merge-readiness checks."
   (:require
    [ai.miniforge.dag-executor.interface :as dag]))
 

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge_readiness.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge_readiness.clj
@@ -38,10 +38,16 @@
 (defn- ^{:stratum 0} blocking-reasons
   [{:keys [ci review branch threads]}]
   (cond-> []
-    (and ci (not (:ci-green? (:data ci))))
+    (dag/err? ci)
+    (conj :ci-status-unavailable)
+
+    (and (dag/ok? ci) (not (:ci-green? (:data ci))))
     (conj :ci-not-green)
 
-    (and review (not (:approved? (:data review))))
+    (dag/err? review)
+    (conj :review-status-unavailable)
+
+    (and (dag/ok? review) (not (:approved? (:data review))))
     (conj :not-approved)
 
     (dag/err? branch)

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge_readiness.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge_readiness.clj
@@ -22,39 +22,47 @@
 
 ;------------------------------------------------------------------------------ Layer 0
 
-(defn ^{:stratum 0} evaluate
-  "Run enabled checks and return every blocking reason."
+(defn- ^{:stratum 0} enabled-checks
   [{:keys [check-ci check-review check-branch check-threads]}
    worktree-path pr-number policy]
-  (let [ci-check (when (:require-ci-green? policy)
-                   (check-ci worktree-path pr-number))
-        review-check (when (:require-approvals? policy)
-                       (check-review worktree-path pr-number
-                                     (:required-approvals policy)))
-        branch-check (when (:require-branch-up-to-date? policy)
-                       (check-branch worktree-path pr-number))
-        thread-check (when (:require-no-unresolved-threads? policy)
-                       (check-threads worktree-path pr-number))
-        checks {:ci ci-check
-                :review review-check
-                :branch branch-check
-                :threads thread-check}
-        blocking (cond-> []
-                   (and ci-check (not (:ci-green? (:data ci-check))))
-                   (conj :ci-not-green)
+  {:ci (when (:require-ci-green? policy)
+         (check-ci worktree-path pr-number))
+   :review (when (:require-approvals? policy)
+             (check-review worktree-path pr-number
+                           (:required-approvals policy)))
+   :branch (when (:require-branch-up-to-date? policy)
+             (check-branch worktree-path pr-number))
+   :threads (when (:require-no-unresolved-threads? policy)
+              (check-threads worktree-path pr-number))})
 
-                   (and review-check (not (:approved? (:data review-check))))
-                   (conj :not-approved)
+(defn- ^{:stratum 0} blocking-reasons
+  [{:keys [ci review branch threads]}]
+  (cond-> []
+    (and ci (not (:ci-green? (:data ci))))
+    (conj :ci-not-green)
 
-                   (and branch-check (not (:up-to-date? (:data branch-check))))
-                   (conj :branch-not-up-to-date)
+    (and review (not (:approved? (:data review))))
+    (conj :not-approved)
 
-                   (and thread-check (dag/err? thread-check))
-                   (conj :thread-status-unavailable)
+    (dag/err? branch)
+    (conj :branch-status-unavailable)
 
-                   (and (dag/ok? thread-check)
-                        (:has-unresolved? (:data thread-check)))
-                   (conj :unresolved-threads))]
+    (and (dag/ok? branch) (not (:up-to-date? (:data branch))))
+    (conj :branch-not-up-to-date)
+
+    (dag/err? threads)
+    (conj :thread-status-unavailable)
+
+    (and (dag/ok? threads) (:has-unresolved? (:data threads)))
+    (conj :unresolved-threads)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} evaluate
+  "Run enabled checks and return every blocking reason."
+  [operations worktree-path pr-number policy]
+  (let [checks (enabled-checks operations worktree-path pr-number policy)
+        blocking (blocking-reasons checks)]
     {:ready? (empty? blocking)
      :checks checks
      :blocking blocking}))

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/anomaly/normalize_resolution_shape_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/anomaly/normalize_resolution_shape_test.clj
@@ -36,7 +36,8 @@
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.pr-lifecycle.conflict-resolution :as conflict-resolution]
-   [ai.miniforge.pr-lifecycle.merge :as merge]))
+   [ai.miniforge.pr-lifecycle.merge :as merge]
+   [ai.miniforge.pr-lifecycle.merge-readiness :as readiness]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -97,8 +98,8 @@
    return the supplied terminal anomaly. Returns the attempt-merge
    result for the caller to assert on."
   [terminal-anomaly]
-  (with-redefs [merge/evaluate-merge-readiness
-                (fn [_ _ _] conflicting-readiness)
+  (with-redefs [readiness/evaluate
+                (fn [_ _ _ _] conflicting-readiness)
                 conflict-resolution/resolve-pr-conflicts!
                 (fn [_] terminal-anomaly)
                 merge/run-gh-command

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/merge_readiness_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/merge_readiness_test.clj
@@ -1,0 +1,48 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.pr-lifecycle.merge-readiness-test
+  "Behavior locks for provider-backed merge-readiness classification."
+  (:require
+   [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.pr-lifecycle.merge :as merge]
+   [ai.miniforge.pr-lifecycle.merge-readiness :as readiness]
+   [clojure.test :refer [are deftest testing]]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private passing-operations
+  {:check-ci (constantly (dag/ok {:ci-green? true}))
+   :check-review (constantly (dag/ok {:approved? true}))
+   :check-branch (constantly (dag/ok {:up-to-date? true}))
+   :check-threads (constantly (dag/ok {:has-unresolved? false}))})
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} provider-failures-are-classified-precisely
+  (testing "Every provider outage blocks with its own reason"
+    (are [operation reason]
+         (let [operations (assoc passing-operations operation
+                                 (constantly (dag/err :provider-error
+                                                      "unavailable")))
+               result (readiness/evaluate
+                       operations "/tmp" 123 merge/default-merge-policy)]
+           (= [reason] (:blocking result)))
+      :check-ci :ci-status-unavailable
+      :check-review :review-status-unavailable
+      :check-branch :branch-status-unavailable
+      :check-threads :thread-status-unavailable)))

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/merge_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/merge_test.clj
@@ -126,20 +126,15 @@
         (is (false? (:ready? result)))
         (is (some #{:unresolved-threads} (:blocking result)))))))
 
-(deftest ^{:stratum 0} evaluate-merge-readiness-thread-readback-fails-closed-test
-  (testing "Unavailable provider thread state blocks merge"
-    (with-redefs [merge/check-ci-status
-                  (fn [_ _] (dag/ok {:ci-green? true}))
-                  merge/check-review-status
-                  (fn [_ _ _] (dag/ok {:approved? true}))
-                  merge/check-branch-status
-                  (fn [_ _] (dag/ok {:up-to-date? true}))
-                  merge/check-unresolved-threads
-                  (fn [_ _] (dag/err :graphql-error "provider unavailable"))]
-      (let [result (merge/evaluate-merge-readiness
-                    "/tmp" 123 merge/default-merge-policy)]
-        (is (false? (:ready? result)))
-        (is (some #{:thread-status-unavailable} (:blocking result)))))))
+(deftest ^{:stratum 0} check-ci-status-provider-results-test
+  (testing "CI state is parsed while provider failures remain failures"
+    (let [failure (dag/err :github-error "provider unavailable")]
+      (are [run-result expected] (with-redefs [merge/run-gh-command
+                                               (constantly run-result)]
+                                   (= expected (merge/check-ci-status "/tmp" 123)))
+        failure failure
+        (dag/ok {:output "[{\"bucket\":\"fail\"}]"})
+        (dag/ok {:ci-green? false})))))
 
 (deftest ^{:stratum 0} evaluate-merge-readiness-multiple-blockers-test
   (testing "Multiple blocking conditions are all reported"

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/merge_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/merge_test.clj
@@ -24,7 +24,8 @@
    [clojure.test :refer [deftest testing is are]]
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.pr-lifecycle.conflict-resolution :as conflict-resolution]
-   [ai.miniforge.pr-lifecycle.merge :as merge]))
+   [ai.miniforge.pr-lifecycle.merge :as merge]
+   [ai.miniforge.pr-lifecycle.merge-readiness :as readiness]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -125,6 +126,21 @@
         (is (false? (:ready? result)))
         (is (some #{:unresolved-threads} (:blocking result)))))))
 
+(deftest ^{:stratum 0} evaluate-merge-readiness-thread-readback-fails-closed-test
+  (testing "Unavailable provider thread state blocks merge"
+    (with-redefs [merge/check-ci-status
+                  (fn [_ _] (dag/ok {:ci-green? true}))
+                  merge/check-review-status
+                  (fn [_ _ _] (dag/ok {:approved? true}))
+                  merge/check-branch-status
+                  (fn [_ _] (dag/ok {:up-to-date? true}))
+                  merge/check-unresolved-threads
+                  (fn [_ _] (dag/err :graphql-error "provider unavailable"))]
+      (let [result (merge/evaluate-merge-readiness
+                    "/tmp" 123 merge/default-merge-policy)]
+        (is (false? (:ready? result)))
+        (is (some #{:thread-status-unavailable} (:blocking result)))))))
+
 (deftest ^{:stratum 0} evaluate-merge-readiness-multiple-blockers-test
   (testing "Multiple blocking conditions are all reported"
     (with-redefs [merge/check-ci-status
@@ -159,8 +175,8 @@
   ;; means auto-merge was ENABLED. Until GitHub reports a merge, claiming
   ;; {:merged? true} is a claim the code cannot substantiate.
   (testing "auto-merge enabled, GitHub still OPEN"
-    (with-redefs [merge/evaluate-merge-readiness
-                  (fn [_ _ _] {:ready? true :checks {} :blocking []})
+    (with-redefs [readiness/evaluate
+                  (fn [_ _ _ _] {:ready? true :checks {} :blocking []})
                   merge/merge-pr!
                   (fn [_ _ & _] (dag/ok {:merged? true :method :squash}))
                   merge/run-gh-command
@@ -177,8 +193,8 @@
 
 (deftest ^{:stratum 0} attempt-merge-observed-merge-publishes-githubs-sha-test
   (testing "GitHub reports MERGED"
-    (with-redefs [merge/evaluate-merge-readiness
-                  (fn [_ _ _] {:ready? true :checks {} :blocking []})
+    (with-redefs [readiness/evaluate
+                  (fn [_ _ _ _] {:ready? true :checks {} :blocking []})
                   merge/merge-pr!
                   (fn [_ _ & _] (dag/ok {:merged? true :method :squash}))
                   merge/run-gh-command
@@ -197,8 +213,8 @@
 
 (deftest ^{:stratum 0} attempt-merge-not-ready-no-rebase-test
   (testing "Merge blocked without auto-rebase yields error"
-    (with-redefs [merge/evaluate-merge-readiness
-                  (fn [_ _ _] {:ready? false
+    (with-redefs [readiness/evaluate
+                  (fn [_ _ _ _] {:ready? false
                                 :checks {}
                                 :blocking [:ci-not-green]})]
       (let [policy (assoc merge/default-merge-policy :auto-rebase-on-stale? false)
@@ -264,8 +280,8 @@
           fake-success (dag/ok {:resolved? true :iterations 1
                                 :pushed-sha "fake-sha"
                                 :pr-branch "feat/x"})]
-      (with-redefs [merge/evaluate-merge-readiness
-                    (fn [_ _ _] conflicting-readiness)
+      (with-redefs [readiness/evaluate
+                    (fn [_ _ _ _] conflicting-readiness)
                     conflict-resolution/resolve-pr-conflicts!
                     (fn [_]
                       (reset! resolver-called? true)
@@ -296,8 +312,8 @@
             and attempt-merge falls through to the existing
             rebase / not-ready logic. With auto-rebase off, ends
             up as :not-ready."
-    (with-redefs [merge/evaluate-merge-readiness
-                  (fn [_ _ _] conflicting-readiness)]
+    (with-redefs [readiness/evaluate
+                  (fn [_ _ _ _] conflicting-readiness)]
       (let [policy (assoc merge/default-merge-policy
                           :auto-rebase-on-stale? false)
             context {:dag-id (random-uuid) :run-id (random-uuid)
@@ -323,8 +339,8 @@
     (let [terminal-anomaly {:anomaly/category :anomalies/dag-multi-parent-unresolvable
                             :anomaly/message  "Merge conflict could not be auto-resolved"
                             :resolution/reason :budget-exhausted}]
-      (with-redefs [merge/evaluate-merge-readiness
-                    (fn [_ _ _] conflicting-readiness)
+      (with-redefs [readiness/evaluate
+                    (fn [_ _ _ _] conflicting-readiness)
                     conflict-resolution/resolve-pr-conflicts!
                     (fn [_] terminal-anomaly)
                     merge/run-gh-command
@@ -357,8 +373,8 @@
             (e.g. for a PR known to need human attention) without
             removing the wiring globally."
     (let [resolver-called? (atom false)]
-      (with-redefs [merge/evaluate-merge-readiness
-                    (fn [_ _ _] conflicting-readiness)
+      (with-redefs [readiness/evaluate
+                    (fn [_ _ _ _] conflicting-readiness)
                     conflict-resolution/resolve-pr-conflicts!
                     (fn [_]
                       (reset! resolver-called? true)

--- a/docs/pull-requests/2026-08-07-codex-n7-merge-readiness.md
+++ b/docs/pull-requests/2026-08-07-codex-n7-merge-readiness.md
@@ -21,7 +21,8 @@ merge application flow before N7 authority enforcement is added.
   from the provider namespace into focused orchestration functions.
 - Preserve observed-merge SHA handling, auto-merge pending behavior, event
   publication, and terminal conflict anomalies.
-- Centralize repeated readiness fixtures in the merge tests.
+- Add focused readiness-classification behavior locks without repeating
+  provider fixtures.
 
 ## Standards review
 
@@ -31,14 +32,15 @@ merge application flow before N7 authority enforcement is added.
   ladders.
 - Capability maps remain declarative injection boundaries; repeated provider
   response and test-fixture maps are centralized.
-- PR budget: 593 / 600 reportable lines; every commit is at most 200.
+- PR budget: 490 / 600 reportable lines; every commit is at most 200.
 - Kondo, Polylith, stratum lint, and the changed-code standards baseline are
   clean.
 
 ## Verification
 
 - PR-lifecycle component passes in all three project compositions.
-- Merge behavior: 20 tests / 56 assertions.
+- Merge behavior: 19 tests / 54 assertions.
+- Readiness classification: 1 test / 4 assertions.
 - GitHub provider behavior: 16 tests / 48 assertions.
 - Pre-commit smoke: 339 tests / 1,285 assertions.
 - GraalVM/Babashka compatibility: 8 tests / 606 assertions.

--- a/docs/pull-requests/2026-08-07-codex-n7-merge-readiness.md
+++ b/docs/pull-requests/2026-08-07-codex-n7-merge-readiness.md
@@ -1,0 +1,51 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor: enforce provider-backed merge readiness
+
+## Summary
+
+Consumes GitHub review-thread readback in merge readiness and decomposes the
+merge application flow before N7 authority enforcement is added.
+
+## Changes
+
+- Replace the unresolved-thread placeholder with complete provider readback.
+- Reject unavailable thread state instead of treating it as clear.
+- Reject unavailable branch state without entering conflict repair or rebase.
+- Separate readiness checks from blocking-reason classification.
+- Extract transaction settlement, conflict resolution, and stale-branch repair
+  from the provider namespace into focused orchestration functions.
+- Preserve observed-merge SHA handling, auto-merge pending behavior, event
+  publication, and terminal conflict anomalies.
+- Centralize repeated readiness fixtures in the merge tests.
+
+## Standards review
+
+- Every changed namespace has at most three strata.
+- Settlement `cond` arms delegate to one named outcome function each.
+- Rebase and conflict paths use result pipelines without nested conditional
+  ladders.
+- Capability maps remain declarative injection boundaries; repeated provider
+  response and test-fixture maps are centralized.
+- PR budget: 593 / 600 reportable lines; every commit is at most 200.
+- Kondo, Polylith, stratum lint, and the changed-code standards baseline are
+  clean.
+
+## Verification
+
+- PR-lifecycle component passes in all three project compositions.
+- Merge behavior: 20 tests / 56 assertions.
+- GitHub provider behavior: 16 tests / 48 assertions.
+- Pre-commit smoke: 339 tests / 1,285 assertions.
+- GraalVM/Babashka compatibility: 8 tests / 606 assertions.
+- Standards scan matches the repository baseline: 73 findings, including six
+  manual-review findings; no new violations.
+
+## Follow-up
+
+The next N7 slice binds merge execution to an issued grant and a gate
+DecisionEnvelope, persisting both before the GitHub effect is attempted.


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# refactor: enforce provider-backed merge readiness

## Summary

Consumes GitHub review-thread readback in merge readiness and decomposes the
merge application flow before N7 authority enforcement is added.

## Changes

- Replace the unresolved-thread placeholder with complete provider readback.
- Reject unavailable thread state instead of treating it as clear.
- Reject unavailable branch state without entering conflict repair or rebase.
- Separate readiness checks from blocking-reason classification.
- Extract transaction settlement, conflict resolution, and stale-branch repair
  from the provider namespace into focused orchestration functions.
- Preserve observed-merge SHA handling, auto-merge pending behavior, event
  publication, and terminal conflict anomalies.
- Add focused readiness-classification behavior locks without repeating
  provider fixtures.

## Standards review

- Every changed namespace has at most three strata.
- Settlement `cond` arms delegate to one named outcome function each.
- Rebase and conflict paths use result pipelines without nested conditional
  ladders.
- Capability maps remain declarative injection boundaries; repeated provider
  response and test-fixture maps are centralized.
- PR budget: 490 / 600 reportable lines; every commit is at most 200.
- Kondo, Polylith, stratum lint, and the changed-code standards baseline are
  clean.

## Verification

- PR-lifecycle component passes in all three project compositions.
- Merge behavior: 19 tests / 54 assertions.
- Readiness classification: 1 test / 4 assertions.
- GitHub provider behavior: 16 tests / 48 assertions.
- Pre-commit smoke: 339 tests / 1,285 assertions.
- GraalVM/Babashka compatibility: 8 tests / 606 assertions.
- Standards scan matches the repository baseline: 73 findings, including six
  manual-review findings; no new violations.

## Follow-up

The next N7 slice binds merge execution to an issued grant and a gate
DecisionEnvelope, persisting both before the GitHub effect is attempted.
