### PR TITLE
docs(specs): N10 governed tool execution spec completion (0.3.1 → 0.4.0-draft)

### DIFF
--- a/docs/pull-requests/2026-08-06-chris-n10-governed-tool-execution-spec-complete.md
+++ b/docs/pull-requests/2026-08-06-chris-n10-governed-tool-execution-spec-complete.md
@@ -1,0 +1,95 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# docs: N10 governed tool execution spec completion (0.3.1 → 0.4.0-draft)
+
+## Overview
+
+Resolves a requirement satisfiable in neither direction, makes an unregistered
+evidence type conditional on its owning spec, and adds Annex A.
+
+N10 already carried 30 conformance requirement IDs, so this is a consistency
+pass rather than a rebuild.
+
+## Motivation
+
+**§12.1 required and forbade the same thing.** It opened with "All governed
+execution operations MUST emit events to the event stream (N3)" and immediately
+followed with a note saying "Implementations MUST NOT emit them as unregistered
+N3 event types". None of the fifteen types in its table is registered in
+N3 §6 — verified for `capsule/*`, `postcondition/*`, `rollback/*`, and
+`verification/*`. An implementation could satisfy neither reading.
+
+**§12.2 specified an evidence type N6 does not define.**
+`:evidence/type :governed-execution` is absent from N6 §3.1.1's artifact-type
+list, so producing it conformantly is impossible.
+
+## Changes in Detail
+
+- **§12.1** reframed. The table is marked informative and retained as a record
+  of intended observation points. The conformant path is stated: governed
+  execution is observed through DecisionEnvelope, ExecutionGrant, and
+  EffectTransaction identifiers on registered event types, and adding any row
+  to the emitted surface is an N3 amendment first — registry entry, schema, and
+  emission point together, per N3 §6.1.
+- **§12.2** split into what is required now and what is proposed. Recording
+  governed execution in the evidence bundle is a MUST, discharged today by the
+  correlation set (`:effect-id`, `:grant-id`, `:envelope-id`) on evidence N6
+  already defines. The richer `:governed-execution` artifact is marked not yet
+  producible and retained as the proposed content of an N6 §3.1.1 amendment.
+- **Redaction** pointed at N3 §8 as inherited by N6 §7.2, rather than left
+  implicit in the table's "Capability (redacted)".
+
+## Annex A (informative)
+
+The finding worth surfacing: **§10's ten safety invariants have no enforcement
+point.** No execution-capsule, crown-jewel, or postcondition component exists.
+SI-8 (no execution beyond capability TTL), SI-9 (no credential persistence
+beyond capsule lifetime), and SI-10 (revocation terminates execution within
+5 seconds) are stated as guarantees and are currently assertions. SI-10 is the
+one an operator is most likely to assume true.
+
+`components/execution-grant` exists, so the identity §12.2 correlates on is
+real.
+
+## Testing Plan
+
+Specification change; no runtime code touched.
+
+- `markdownlint` clean on all three changed files.
+- Verified none of the §12.1 event types appears in N3's §6 registry, and that
+  `governed-execution` appears nowhere in N6.
+
+## Deployment Plan
+
+Documentation only. Merges to `main` with no runtime effect.
+
+## Follow-on Work
+
+1. Decide whether the governed-execution lifecycle warrants registered N3 event
+   types; if so, amend N3 §3/§4.1/§6 together.
+2. Register `:governed-execution` in N6 §3.1.1 if that evidence is wanted.
+3. Implement an enforcement point for the §10 safety invariants — SI-10's
+   revocation bound first, since it is time-bounded and testable.
+
+## Related Issues/PRs
+
+- Follows the N3/N4/N5/N6 completion passes; N2, N8, N9 in review
+- Depends on: N3 §6 (event registry), N3 §6.1 (registry maintenance),
+  N6 §3.1.1 (artifact types), N3 §8 (redaction)
+- Governed by: `standards/miniforge/foundations/specification-standards` (020)
+
+## Checklist
+
+- [x] Spec reviewed against current state before editing
+- [x] Unsatisfiable requirement resolved
+- [x] Cross-spec gaps gated on the owning spec rather than duplicated (020)
+- [x] Annex A marked informative
+- [x] No spec content extracted from implementation code (020)
+- [x] Copyright header present (810)
+- [x] `markdownlint` clean
+- [x] SPEC_INDEX updated
+- [x] PR doc created (721)

--- a/specs/SPEC_INDEX.md
+++ b/specs/SPEC_INDEX.md
@@ -6,6 +6,7 @@
 
 # miniforge Specification Index
 
+**Version:** 0.17.0-draft
 **Version:** 0.16.0-draft
 **Date:** 2026-08-09
 **Status:** Living specification during OSS development
@@ -338,6 +339,11 @@ Defines:
 - Audit integration: full event stream (N3) and evidence bundle (N6) linkage
 - **Tool operational semantics:** Timeout, retry, circuit-breaker, concurrency, fallback (§3.4–§3.5)
 - **Tool response validation:** Schema validation and injection sanitization at capsule boundary (§7.4)
+- **Audit events reframed (§12.1):** none of the fifteen types is registered in N3 §6, so the
+  table is informative; adding a row is an N3 amendment first
+- **Evidence type gated on N6 (§12.2):** `:governed-execution` is not an N6 §3.1.1 artifact type
+- **Annex A (informative):** implementation conformance status — §10's ten safety invariants
+  have no enforcement point
 
 ---
 
@@ -593,6 +599,15 @@ Normative specs are enforced by:
 
 ## Version History
 
+- **0.17.0-draft** (2026-08-06) - N10 spec-completion pass. **N10**: §12.1 required governed
+  execution to emit events to N3 directly above a note saying implementations MUST NOT emit them,
+  since none of the fifteen types is registered in N3 §6 — a requirement satisfiable in neither
+  direction. The table is now informative and the conformant path is correlation identifiers on
+  registered types, with N3 §6.1 amendment as the route to emitting any of them. §12.2's
+  `:governed-execution` evidence shape is not an N6 §3.1.1 artifact type and is gated on
+  registering it there. Annex A records that §10's ten safety invariants — including SI-10's
+  five-second revocation bound — have no enforcement point, because no capsule, postcondition, or
+  crown-jewel component exists. Per-spec bumps: N10 0.3.1→0.4.0
 - **0.16.0-draft** (2026-08-06) - N9 spec-completion pass. **N9**: §7.1 restated a PR-only scope
   rule superseded by N3 §2.3's six-scope table, and §7.2 reproduced N3 §3.16's event schemas —
   both now reference N3. §14 required breaking changes to be "supported in parallel for at least

--- a/specs/SPEC_INDEX.md
+++ b/specs/SPEC_INDEX.md
@@ -7,7 +7,6 @@
 # miniforge Specification Index
 
 **Version:** 0.17.0-draft
-**Version:** 0.16.0-draft
 **Date:** 2026-08-09
 **Status:** Living specification during OSS development
 

--- a/specs/normative/N10-governed-tool-execution.md
+++ b/specs/normative/N10-governed-tool-execution.md
@@ -884,14 +884,22 @@ _Informative. Not an emission list; see above._
 
 ### 12.2 Evidence Bundle Integration
 
-Governed execution contributes a record to the workflow's evidence bundle. The
-shape below is not yet an N6 artifact type: N6 §3.1.1 enumerates artifact
-types, and `:governed-execution` is absent from it. Registering it there is a
-prerequisite to producing it, on the same principle as §12.1 — N6 owns the
-evidence schema, so a new evidence type is an N6 amendment first.
+Governed execution MUST be recorded in the workflow's evidence bundle. What it
+records today is the correlation set — `:effect-id`, `:grant-id`,
+`:envelope-id` — carried on the evidence N6 already defines, which is what
+makes a governed execution traceable from its bundle.
+
+The richer artifact below is **not yet producible**. N6 §3.1.1 enumerates
+artifact types and `:governed-execution` is absent from it, so emitting it
+would be non-conformant. Registering it in N6 §3.1.1 is a prerequisite, on the
+same principle as §12.1: N6 owns the evidence schema, so a new artifact type is
+an N6 amendment first. The shape is retained as the proposed content of that
+amendment, not as a requirement of this spec.
 
 Redaction of any credential-bearing field follows N3 §8 as inherited by N6
 §7.2; this spec does not define a separate redaction rule.
+
+_Proposed N6 §3.1.1 artifact type. Not emittable until registered there._
 
 ```clojure
 {:evidence/type            :governed-execution

--- a/specs/normative/N10-governed-tool-execution.md
+++ b/specs/normative/N10-governed-tool-execution.md
@@ -6,7 +6,7 @@
 
 # N10 — Governed Tool Execution
 
-**Version:** 0.3.1-draft
+**Version:** 0.4.0-draft
 **Date:** 2026-08-06
 **Status:** Draft
 **Conformance:** MUST
@@ -841,20 +841,31 @@ Validation and environment adapters (§5.3) register through the tool registry:
 
 ## 12. Audit Integration
 
-### 12.1 Required Audit Events
+### 12.1 Audit Events
 
-All governed execution operations MUST emit events to the event stream (N3) and
-produce evidence for evidence bundles (N6).
+All governed execution operations MUST be observable on the event stream (N3)
+and MUST produce evidence for evidence bundles (N6).
 
-> **Ariadne profile:** Rows whose event, trigger, or data depends on Intent,
-> Operational IR, Capability, or Capability Broker are informative legacy
-> placeholders, despite this section's heading. Implementations MUST NOT emit
-> them as unregistered N3 event types. Conformant domain events correlate the
-> DecisionEnvelope, ExecutionGrant, and EffectTransaction identifiers; a new
-> lifecycle event type requires an N3 registry amendment.
+**None of the event types in the table below is registered in N3 §6.** Under
+N3 §6 an implementation MUST NOT emit an unregistered `:event/type`, so the
+table cannot be read as a list of events to emit. It is retained as an
+informative record of the intended observation points, and this section states
+the conformant path explicitly:
 
-| Event | Trigger | Data |
-|-------|---------|------|
+- Governed execution is observed today through the DecisionEnvelope,
+  ExecutionGrant, and EffectTransaction identifiers carried on registered
+  event types, correlated per §12.2.
+- Adding any row below to the emitted surface is an **N3 amendment first**: the
+  type must appear in N3 §6's registry, with a schema in N3 §3 and an emission
+  point in N3 §4.1, before an implementation emits it (N3 §6.1).
+
+The previous framing — "MUST emit events" immediately above a note saying
+implementations MUST NOT emit them — could not be satisfied either way.
+
+_Informative. Not an emission list; see above._
+
+| Event (unregistered) | Trigger | Data |
+|----------------------|---------|------|
 | `:intent/created` | Agent expresses intent | Intent structure |
 | `:intent/compiled` | OIR generated from intent | OIR structure |
 | `:verification/started` | Verification pipeline begins | OIR ID, verifiers |
@@ -873,7 +884,14 @@ produce evidence for evidence bundles (N6).
 
 ### 12.2 Evidence Bundle Integration
 
-Governed execution produces a sub-bundle within the workflow's evidence bundle:
+Governed execution contributes a record to the workflow's evidence bundle. The
+shape below is not yet an N6 artifact type: N6 §3.1.1 enumerates artifact
+types, and `:governed-execution` is absent from it. Registering it there is a
+prerequisite to producing it, on the same principle as §12.1 — N6 owns the
+evidence schema, so a new evidence type is an N6 amendment first.
+
+Redaction of any credential-bearing field follows N3 §8 as inherited by N6
+§7.2; this spec does not define a separate redaction rule.
 
 ```clojure
 {:evidence/type            :governed-execution
@@ -1044,6 +1062,42 @@ Audit Ledger (N3 events + N6 evidence bundles)
 
 ---
 
+## Annex A — Implementation Conformance Status (informative)
+
+This annex is **informative**. It records where the miniforge implementation
+diverges from the contract above, as of 2026-08-06.
+
+### A.1 Implemented
+
+- **ExecutionGrant** — `components/execution-grant` exists and carries the
+  grant identity §12.2 correlates on.
+
+### A.2 Specified, Not Implemented
+
+- **Execution capsules (§7).** No capsule component exists. SI-8 (no execution
+  beyond capability TTL), SI-9 (no credential persistence beyond capsule
+  lifetime), and SI-10 (revocation terminates execution within 5 seconds) have
+  no enforcement point, and SI-10 is the invariant most likely to be assumed
+  true by an operator.
+- **Crown jewel protection (§8).** No component.
+- **Postcondition monitoring (§9).** No component, so `:postcondition/*`
+  observation points have neither an emitter nor a registered event type.
+- **Audit event types (§12.1).** None of the fifteen types is registered in
+  N3 §6, so none may be emitted. Governed execution is currently observable
+  only through correlation identifiers on other event types.
+- **`:governed-execution` evidence (§12.2).** Not an N6 §3.1.1 artifact type,
+  so it cannot be produced conformantly.
+
+### A.3 Structural
+
+- **Safety invariants are unenforced.** §10 requires violation of any invariant
+  to halt execution immediately. With no capsule, no postcondition monitor, and
+  no crown-jewel component, SI-1 through SI-10 are stated but not checked
+  anywhere. This is the widest gap in the spec set: the invariants read as
+  guarantees and are currently assertions.
+
+---
+
 ## 17. Glossary
 
 - **Action Class** — Risk category (A-E) assigned to a tool verb by the tool
@@ -1069,6 +1123,18 @@ Audit Ledger (N3 events + N6 evidence bundles)
 ---
 
 **Version History:**
+
+- 0.4.0-draft (2026-08-06): Spec-completion pass. §12.1 said governed execution
+  MUST emit events to N3 directly above a note saying implementations MUST NOT
+  emit them, because none of the fifteen types is registered in N3 §6 — a
+  requirement satisfiable in neither direction. Reframed: the table is
+  informative, the conformant path is correlation identifiers on registered
+  types, and adding a row is an N3 amendment first (N3 §6.1). §12.2's
+  `:governed-execution` evidence shape is likewise not an N6 §3.1.1 artifact
+  type; registering it there is a prerequisite to producing it. Redaction
+  pointed at N3 §8 rather than left implicit. Annex A records that §10's ten
+  safety invariants have no enforcement point — no capsule, postcondition, or
+  crown-jewel component exists.
 
 - 0.3.1-draft (2026-08-06): Required commit-time ExecutionGrant scope
   enforcement against the durable effect proposal


### PR DESCRIPTION
MINIFORGE_PR_BUDGET_OVERRIDE: Single normative spec document. A spec amendment is atomic. Well below the ~10-12k threshold where Copilot declines to review. Docs-only, no runtime code.

## Overview

Resolves a requirement satisfiable in neither direction, gates an unregistered evidence type on its owning spec, and adds Annex A. N10 already carried 30 conformance requirement IDs, so this is a consistency pass rather than a rebuild.

Full detail: [`docs/pull-requests/2026-08-06-chris-n10-governed-tool-execution-spec-complete.md`](docs/pull-requests/2026-08-06-chris-n10-governed-tool-execution-spec-complete.md)

## Why

**§12.1 required and forbade the same thing.** It opened with "All governed execution operations MUST emit events to the event stream (N3)" and immediately followed with a note: "Implementations MUST NOT emit them as unregistered N3 event types." None of the fifteen types in its table is registered in N3 §6 — verified for `capsule/*`, `postcondition/*`, `rollback/*`, and `verification/*`. An implementation could satisfy neither reading.

**§12.2 specified an evidence type N6 does not define.** `:evidence/type :governed-execution` is absent from N6 §3.1.1's artifact-type list, so producing it conformantly is impossible.

## Changes

- **§12.1** reframed. The table is marked informative and kept as a record of intended observation points. The conformant path is stated: governed execution is observed through DecisionEnvelope, ExecutionGrant, and EffectTransaction identifiers on registered event types, and adding any row to the emitted surface is an N3 amendment first — registry entry, schema, and emission point together, per N3 §6.1.
- **§12.2** gates `:governed-execution` on registering it in N6 §3.1.1, on the same principle.
- **Redaction** pointed at N3 §8 as inherited by N6 §7.2, rather than left implicit in the table's "Capability (redacted)".

## Annex A — implementation conformance status (informative)

The finding worth surfacing: **§10's ten safety invariants have no enforcement point.** No execution-capsule, crown-jewel, or postcondition component exists. SI-8 (no execution beyond capability TTL), SI-9 (no credential persistence beyond capsule lifetime), and SI-10 (revocation terminates execution within 5 seconds) are stated as guarantees and are currently assertions. SI-10 is the one an operator is most likely to assume true.

`components/execution-grant` does exist, so the identity §12.2 correlates on is real.

## Validation

Documentation only; no runtime code touched.

- `markdownlint` clean on all three files
- Verified none of §12.1's event types appears in N3's §6 registry, and that `governed-execution` appears nowhere in N6
- `bb pre-commit` passed on both commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)
