### PR TITLE
fix(commit-budget): skip the budget on merge commits

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -126,6 +126,17 @@ Two related, previously-missing gates, added 2026-07-26:
   human number, two orders of magnitude below the ~10-12k raw lines
   where Copilot's own review actually broke down (below). Treat 600 as
   calibrated-not-fixed, the same as the commit-level 200.
+- **Merge commits are exempt from `bb commit-budget`** (added
+  2026-08-07). A merge's staged diff carries every line arriving from
+  the merged-in branch, which the merging author did not write and
+  which was already budgeted on the PR that introduced it — a routine
+  `git merge github/main` to pick up an unrelated merged PR was failing
+  the gate on 491 lines of someone else's reviewed code. Requiring
+  `MINIFORGE_COMMIT_BUDGET_OVERRIDE` for that trains people to reach
+  for the override and dilutes its signal for the cases it exists for.
+  `bb pr-budget` still covers the whole PR diff in CI, and is not
+  affected: it diffs merge-base..head, so content the branch merged in
+  from the base is already excluded.
 - **Adversarial self-review before every push**, not just for PRs that
   trip the size gate. Read the actual diff like a skeptical reviewer,
   not the tool's own "this should be safe" framing.

--- a/development/test/commit_budget_test.clj
+++ b/development/test/commit_budget_test.clj
@@ -20,8 +20,15 @@
    files count toward the commit-size budget and which are treated
    as bulk data. The gate runs on every commit; a silent widening
    (real code stops counting) or narrowing (fixture data starts
-   blocking commits) of the exclusion set should fail here first."
-  (:require [clojure.test :refer [deftest is testing]]))
+   blocking commits) of the exclusion set should fail here first.
+
+   Also pins the merge-commit skip: mid-merge the staged diff carries
+   the merged-in branch's lines, which are not the merging author's
+   change and were budgeted on their own PRs."
+  (:require [babashka.process :as p]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]))
 
 (load-file "tasks/commit_budget.clj")
 
@@ -31,7 +38,123 @@
 
 (def ^{:stratum 0} file-reportable-count (resolve 'commit-budget/file-reportable-count))
 
+(def ^{:stratum 0} merge-in-progress? (resolve 'commit-budget/merge-in-progress?))
+
+(def ^{:stratum 0} staged-diff (resolve 'commit-budget/staged-diff))
+
+(def ^{:stratum 0} check-commit-budget! (resolve 'commit-budget/check-commit-budget!))
+
+(def ^{:stratum 0} default-budget @(resolve 'commit-budget/default-budget))
+
+(def ^{:stratum 0} ^:private merged-in-entry
+  "A staged file the size of a branch merged in from main — the shape
+   that made a routine `git merge github/main` reach for
+   MINIFORGE_COMMIT_BUDGET_OVERRIDE (491 reportable lines, all from
+   `components/execution-grant/**`, on 2026-08-07)."
+  {:path    "components/execution-grant/src/grant.clj"
+   :added   (repeat 500 "(def incoming 1)")
+   :deleted []})
+
+(def ^{:stratum 0} ^:private headroom-budget
+  "A budget `merged-in-entry` cannot exceed. Passed instead of
+   `default-budget` so that losing the merge skip surfaces as a failed
+   assertion rather than as the gate's own `System/exit 1`, which would
+   end the smoke run mid-suite and take every later namespace's result
+   with it."
+  10000)
+
+(def ^{:stratum 0} ^:private in-budget-entry
+  "One small staged file — the ordinary, non-merge commit."
+  {:path    "components/codex/src/core.clj"
+   :added   ["(def a 1)" "(def b 2)"]
+   :deleted []})
+
+(defn ^{:stratum 0} ^:private delete-tree!
+  "Recursively delete `f`. Depth-first via `file-seq` reversed, so
+   children go before their parents."
+  [f]
+  (doseq [child (reverse (file-seq (io/file f)))]
+    (.delete child)))
+
+(defn ^{:stratum 0} ^:private hermetic-git-env
+  "The process environment with every `GIT_*` variable dropped, then the
+   scratch repo's own config scopes and commit identity put back.
+
+   Dropping them is what makes the scratch repo actually separate. This
+   test runs inside the pre-commit hook, and git exports `GIT_DIR` and
+   `GIT_INDEX_FILE` to its hooks — inherited, those aim the fixture's
+   commands at the real repository no matter what `:dir` says (`git
+   add` fails with \"this operation must be run in a work tree\"; a
+   command that didn't fail would be operating on the live checkout).
+   Clearing the whole prefix also takes the developer's
+   `GIT_CONFIG_*`, and pointing both config scopes at an empty file
+   keeps their `core.hooksPath`, `commit.gpgsign` and `user.*` out. It
+   is a real empty file rather than /dev/null so this holds on Windows
+   too."
+  [empty-config]
+  (let [cfg (str empty-config)]
+    (->> (System/getenv)
+         (remove (fn [[k _]] (str/starts-with? k "GIT_")))
+         (into {})
+         (merge {"GIT_CONFIG_GLOBAL"   cfg
+                 "GIT_CONFIG_SYSTEM"   cfg
+                 "GIT_AUTHOR_NAME"     "budget-test"
+                 "GIT_AUTHOR_EMAIL"    "budget-test@example.invalid"
+                 "GIT_COMMITTER_NAME"  "budget-test"
+                 "GIT_COMMITTER_EMAIL" "budget-test@example.invalid"}))))
+
+(def ^{:stratum 0} ^:private merge-probe
+  "A bb program that prints `merge-in-progress?` for its own working
+   directory. `pr-str` on the path so a Windows path's backslashes
+   survive as a Clojure string literal."
+  (format "(load-file %s) (print (commit-budget/merge-in-progress?))"
+          (pr-str (.getAbsolutePath (io/file "tasks/commit_budget.clj")))))
+
 ;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} ^:private git!
+  "Run git in `dir` under `hermetic-git-env` and return the result.
+   Throws on a non-zero exit — a fixture that has quietly stopped
+   building what the test claims should say so, not leave the
+   assertions running against nothing."
+  [dir empty-config & args]
+  (let [{:keys [exit err] :as res}
+        (apply p/sh {:dir dir :out :string :err :string
+                     :env (hermetic-git-env empty-config)}
+               "git" args)]
+    (when-not (zero? exit)
+      (throw (ex-info "git fixture command failed"
+                      {:args args :dir (str dir) :exit exit :err err})))
+    res))
+
+(defn ^{:stratum 1} ^:private merge-in-progress-at?
+  "Run the production `merge-in-progress?` with `dir` as its working
+   directory, in its own process under `hermetic-git-env`.
+
+   A subprocess rather than a direct call because the function answers
+   for the git context of the process it runs in — which is the point,
+   and which in-process would be this test runner's, i.e. the real
+   repository under the pre-commit hook. Going out to a process is also
+   the only way to exercise the zero-arity form the hook actually
+   calls, instead of a dir-taking variant that would exist only here."
+  [dir empty-config]
+  (let [{:keys [out err exit]}
+        (p/sh {:dir dir :out :string :err :string
+               :env (hermetic-git-env empty-config)}
+              "bb" "-e" merge-probe)]
+    (when-not (zero? exit)
+      (throw (ex-info "merge probe failed"
+                      {:dir (str dir) :exit exit :err err})))
+    (= "true" (str/trim out))))
+
+(defn ^{:stratum 1} ^:private gate-output
+  "Stdout from one `check-commit-budget!` run over a stubbed merge state
+   and staged diff, so the gate's decision can be read without a real
+   repo or index."
+  [merging? entries budget]
+  (with-redefs-fn {merge-in-progress? (constantly merging?)
+                   staged-diff        (constantly entries)}
+    #(with-out-str (check-commit-budget! budget))))
 
 (deftest ^{:stratum 1} resource-data-files-excluded-test
   (testing "data extensions under resources/ and messages/, nested or top-level"
@@ -93,3 +216,61 @@
                {:path    "components/codex/src/note.md"
                 :added   ["# Note 001" "generated body line"]
                 :deleted []})))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Integration scenario — the one test here that touches the filesystem
+;; and spawns git, because MERGE_HEAD detection only reproduces against
+;; real merge state. Confined to its own scratch repo under
+;; java.io.tmpdir and deleted afterwards; it never reads or writes the
+;; checkout it runs from.
+(deftest ^{:stratum 2} merge-detected-in-linked-worktree-test
+  (testing "a merge left in progress is detected, and only in the worktree doing it"
+    (let [tmp  (.toFile (java.nio.file.Files/createTempDirectory
+                         "commit-budget-merge"
+                         (into-array java.nio.file.attribute.FileAttribute [])))
+          cfg  (io/file tmp "gitconfig")
+          repo (io/file tmp "repo")
+          ;; The merge happens in a LINKED worktree, where `.git` is a
+          ;; file and MERGE_HEAD lives under `.git/worktrees/<name>/`.
+          ;; A detector that stats `.git/MERGE_HEAD` passes in the main
+          ;; checkout and fails here — and here is where this repo works.
+          wt   (io/file tmp "wt")]
+      (try
+        (spit cfg "")
+        (.mkdirs repo)
+        (git! repo cfg "init" "-q" "-b" "main" ".")
+        (spit (io/file repo "base.txt") "base\n")
+        (git! repo cfg "add" "-A")
+        (git! repo cfg "commit" "-qm" "base")
+        (git! repo cfg "branch" "feature")
+        (spit (io/file repo "from-main.txt") "main\n")
+        (git! repo cfg "add" "-A")
+        (git! repo cfg "commit" "-qm" "main work")
+        (git! repo cfg "worktree" "add" "-q" (str wt) "feature")
+        (spit (io/file wt "from-feature.txt") "feature\n")
+        (git! wt cfg "add" "-A")
+        (git! wt cfg "commit" "-qm" "feature work")
+        ;; --no-commit is the non-conflicting way to leave MERGE_HEAD
+        ;; set; a conflicted merge reaches the same state by a noisier
+        ;; route. Both are how `git commit` — and so this gate — ends up
+        ;; running mid-merge at all: a clean auto-committed merge fires
+        ;; `pre-merge-commit`, not `pre-commit`.
+        (git! wt cfg "merge" "--no-commit" "--no-ff" "main")
+        (is (true? (merge-in-progress-at? wt cfg)))
+        (is (false? (merge-in-progress-at? repo cfg)))
+        (finally (delete-tree! tmp))))))
+
+(deftest ^{:stratum 2} merge-skips-the-budget-test
+  (testing "mid-merge the gate skips without weighing the staged diff at all"
+    (let [out (gate-output true [merged-in-entry] headroom-budget)]
+      (is (str/includes? out "skipped (merge in progress)"))
+      (is (not (str/includes? out "lines OK"))))))
+
+(deftest ^{:stratum 2} non-merge-commit-still-budgeted-test
+  (testing "outside a merge the gate still reports against the budget"
+    (let [out (gate-output false [in-budget-entry] default-budget)]
+      (is (str/includes? out (format "%d / %d lines OK"
+                                     (count (:added in-budget-entry))
+                                     default-budget)))
+      (is (not (str/includes? out "skipped"))))))

--- a/development/test/commit_budget_test.clj
+++ b/development/test/commit_budget_test.clj
@@ -46,22 +46,19 @@
 
 (def ^{:stratum 0} default-budget @(resolve 'commit-budget/default-budget))
 
-(def ^{:stratum 0} ^:private merged-in-entry
-  "A staged file the size of a branch merged in from main — the shape
-   that made a routine `git merge github/main` reach for
-   MINIFORGE_COMMIT_BUDGET_OVERRIDE (491 reportable lines, all from
-   `components/execution-grant/**`, on 2026-08-07)."
-  {:path    "components/execution-grant/src/grant.clj"
-   :added   (repeat 500 "(def incoming 1)")
-   :deleted []})
+(defn ^{:stratum 0} ^:private unread-staged-diff
+  "A `staged-diff` stand-in that fails if anything calls it.
 
-(def ^{:stratum 0} ^:private headroom-budget
-  "A budget `merged-in-entry` cannot exceed. Passed instead of
-   `default-budget` so that losing the merge skip surfaces as a failed
-   assertion rather than as the gate's own `System/exit 1`, which would
-   end the smoke run mid-suite and take every later namespace's result
-   with it."
-  10000)
+   Mid-merge the gate has to return before reading the index at all,
+   not merely ignore what it read: a large merge's diff should never be
+   fetched or parsed, and `staged-diff` failing closed on a git error
+   must not be able to block a merge the gate already declined to
+   judge. Throwing also means a lost merge skip surfaces here as this
+   error rather than as the gate's own `System/exit 1`, which would end
+   the smoke run mid-suite and take every later namespace's result with
+   it."
+  []
+  (throw (ex-info "staged-diff called while a merge was in progress" {})))
 
 (def ^{:stratum 0} ^:private in-budget-entry
   "One small staged file — the ordinary, non-merge commit."
@@ -149,11 +146,11 @@
 
 (defn ^{:stratum 1} ^:private gate-output
   "Stdout from one `check-commit-budget!` run over a stubbed merge state
-   and staged diff, so the gate's decision can be read without a real
+   and `staged-diff`, so the gate's decision can be read without a real
    repo or index."
-  [merging? entries budget]
+  [merging? staged-diff-fn budget]
   (with-redefs-fn {merge-in-progress? (constantly merging?)
-                   staged-diff        (constantly entries)}
+                   staged-diff        staged-diff-fn}
     #(with-out-str (check-commit-budget! budget))))
 
 (deftest ^{:stratum 1} resource-data-files-excluded-test
@@ -262,14 +259,14 @@
         (finally (delete-tree! tmp))))))
 
 (deftest ^{:stratum 2} merge-skips-the-budget-test
-  (testing "mid-merge the gate skips without weighing the staged diff at all"
-    (let [out (gate-output true [merged-in-entry] headroom-budget)]
+  (testing "mid-merge the gate skips without reading the index at all"
+    (let [out (gate-output true unread-staged-diff default-budget)]
       (is (str/includes? out "skipped (merge in progress)"))
       (is (not (str/includes? out "lines OK"))))))
 
 (deftest ^{:stratum 2} non-merge-commit-still-budgeted-test
   (testing "outside a merge the gate still reports against the budget"
-    (let [out (gate-output false [in-budget-entry] default-budget)]
+    (let [out (gate-output false (constantly [in-budget-entry]) default-budget)]
       (is (str/includes? out (format "%d / %d lines OK"
                                      (count (:added in-budget-entry))
                                      default-budget)))

--- a/docs/pull-requests/2026-08-07-fix-commit-budget-skips-merge-commits.md
+++ b/docs/pull-requests/2026-08-07-fix-commit-budget-skips-merge-commits.md
@@ -1,0 +1,108 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix: skip the commit budget on merge commits
+
+## Overview
+
+`bb commit-budget` now detects a merge in progress and skips the check,
+printing one line saying so.
+
+## Motivation
+
+The gate counts the full staged diff. On a merge commit that diff includes
+every line arriving from the merged-in branch — content the merging author
+did not write.
+
+On 2026-08-07, merging `github/main` into a feature branch to pick up an
+unrelated squash-merged PR produced a 491-reportable-line failure, all of it
+`components/execution-grant/**`: another author's work, already reviewed and
+merged on its own PR. The merge itself contributed no new code.
+
+A merge commit's size is not a reviewability signal about the merging
+author's change. Forcing `MINIFORGE_COMMIT_BUDGET_OVERRIDE` on routine
+merges trains people to reach for the override and dilutes its signal for
+the cases it exists for.
+
+## Layer
+
+Development-tool task (`tasks/commit_budget.clj`), plus its test and the
+operator-facing description in `agents.md`.
+
+## Changes in Detail
+
+- `commit-budget/merge-in-progress?`: asks `git rev-parse -q --verify
+  MERGE_HEAD` rather than stat-ing `.git/MERGE_HEAD`. In a linked worktree
+  `.git` is a file pointing at `…/.git/worktrees/<name>/`, where the merge
+  state actually lives, so the path check finds nothing — and nearly all
+  work in this repo happens in worktrees. Takes no arguments: it answers
+  for whatever repository git itself would act on, which under the hook is
+  the exported `GIT_DIR` and is the same repository `staged-diff` reads.
+- `check-commit-budget!`: a merge in progress is the first branch of the
+  decision `cond`, ahead of the override and size branches, so no override
+  is needed and none is consumed.
+- `agents.md`: records the exemption and that `pr-budget` is unaffected.
+- `resources/precommit-smoke-tests.edn`: the entry's comment claimed "no
+  subprocess"; the merge test spawns git, so the comment now says so.
+
+## `pr-budget` — checked, not affected
+
+`pr-budget` diffs `merge-base(base, head)..head` (three-dot). When a branch
+merges the base in, the base tip becomes an ancestor of head, so the
+merge-base moves up to it and the incoming content falls out of the diff.
+
+Confirmed against both merge-containing PRs in recent history rather than
+assumed:
+
+- PR #1697 — head is itself `Merge remote-tracking branch 'github/main'`.
+  `base.sha` equals the merge commit's second parent; the three-dot diff is
+  10 files, the branch's own.
+- PR #1693 — five merge commits, two of them from `github/main`. Three-dot
+  diff is 7 files.
+
+The failure mode would be a `base.sha` older than what the branch merged in;
+in both cases `base.sha` equals the merge-base, so GitHub is not reporting a
+stale base here. Reproduced both directions in a scratch repo: with the
+current base tip the merged-in file is absent from the diff, with a
+deliberately stale base it appears.
+
+## Standards Audit
+
+- Stratified design (001/210): `merge-in-progress?` has no in-namespace
+  dependencies and sits at stratum 0 beside `override-rationale`, which is
+  likewise external-state-reading with no in-namespace deps.
+- Testing (400): magic numbers extracted to named fixtures at Layer 0;
+  the git-spawning scenario is the only filesystem test and is isolated in
+  its own Layer 2 section.
+- Exception handling (211) does not apply by glob (`components|bases|
+  projects/**/src`); the single `ex-info` throw is a test-fixture failure
+  boundary.
+
+## Testing Plan
+
+- `commit-budget-test` — 9 tests, 38 assertions, green.
+- Mutation-checked both new tests rather than trusting green:
+  - Replacing `git rev-parse` with a `.git/MERGE_HEAD` stat fails
+    `merge-detected-in-linked-worktree-test`.
+  - Deleting the merge branch from the `cond` fails
+    `merge-skips-the-budget-test`.
+  - Both fail as named assertions and the suite still completes. An earlier
+    draft passed `default-budget` to the second test, which made the
+    regression exit the test JVM mid-run and take every later namespace's
+    result with it; it now passes a budget the fixture cannot exceed.
+- Run under a simulated hook environment (`GIT_DIR` and `GIT_INDEX_FILE`
+  exported) as well as a clean one. The first draft passed clean and failed
+  under the hook: the fixture's git commands inherited `GIT_DIR` and aimed
+  at the real repository regardless of their `:dir`. `git add -A` failed
+  with "this operation must be run in a work tree" and `git!`'s
+  throw-on-non-zero surfaced it; a command that had not failed would have
+  been operating on the live checkout. The fixture now runs with every
+  `GIT_*` variable stripped from the environment. This is also why
+  `merge-in-progress?` gained no dir-taking arity — an ambient `GIT_DIR`
+  outranks a subprocess `:dir`, so such an arity would have answered about
+  the wrong repository under the hook, which is the only place the gate
+  runs. The test drives the zero-arity form in its own process instead.
+- End-to-end: `bb commit-budget` run inside a real merge in this worktree.

--- a/docs/pull-requests/2026-08-07-fix-commit-budget-skips-merge-commits.md
+++ b/docs/pull-requests/2026-08-07-fix-commit-budget-skips-merge-commits.md
@@ -41,9 +41,12 @@ operator-facing description in `agents.md`.
   work in this repo happens in worktrees. Takes no arguments: it answers
   for whatever repository git itself would act on, which under the hook is
   the exported `GIT_DIR` and is the same repository `staged-diff` reads.
-- `check-commit-budget!`: a merge in progress is the first branch of the
-  decision `cond`, ahead of the override and size branches, so no override
-  is needed and none is consumed.
+- `check-commit-budget!`: returns on a merge in progress *before* calling
+  `staged-diff`, ahead of the override and size branches, so no override is
+  needed and none is consumed. Returning ahead of the diff rather than as a
+  `cond` branch below it is what makes the skip total — a large merge's
+  diff is neither fetched nor parsed, and `staged-diff` failing closed on a
+  git error cannot block a merge the gate has already declined to judge.
 - `agents.md`: records the exemption and that `pr-budget` is unaffected.
 - `resources/precommit-smoke-tests.edn`: the entry's comment claimed "no
   subprocess"; the merge test spawns git, so the comment now says so.
@@ -84,15 +87,16 @@ deliberately stale base it appears.
 ## Testing Plan
 
 - `commit-budget-test` — 9 tests, 38 assertions, green.
-- Mutation-checked both new tests rather than trusting green:
+- Mutation-checked the new tests rather than trusting green:
   - Replacing `git rev-parse` with a `.git/MERGE_HEAD` stat fails
     `merge-detected-in-linked-worktree-test`.
-  - Deleting the merge branch from the `cond` fails
-    `merge-skips-the-budget-test`.
-  - Both fail as named assertions and the suite still completes. An earlier
-    draft passed `default-budget` to the second test, which made the
-    regression exit the test JVM mid-run and take every later namespace's
-    result with it; it now passes a budget the fixture cannot exceed.
+  - Demoting the skip to a `cond` branch below `staged-diff` fails
+    `merge-skips-the-budget-test`, whose `staged-diff` stub throws if
+    anything calls it mid-merge.
+  - Both surface as a named failure or error and the suite still completes.
+    An earlier draft asserted only on output with a stubbed-but-callable
+    diff; losing the skip then exited the test JVM mid-run and took every
+    later namespace's result with it.
 - Run under a simulated hook environment (`GIT_DIR` and `GIT_INDEX_FILE`
   exported) as well as a clean one. The first draft passed clean and failed
   under the hook: the fixture's git commands inherited `GIT_DIR` and aimed

--- a/resources/precommit-smoke-tests.edn
+++ b/resources/precommit-smoke-tests.edn
@@ -52,8 +52,12 @@
   "ai.miniforge.workflow.phase-transitions-test"
   "ai.miniforge.phase.interface-test"
   ;; Pins the commit-budget gate's path-exclusion set (which staged
-  ;; files count toward the 200-line ceiling). The gate itself runs in
-  ;; this same pre-commit chain — a drifted exclusion regex should fail
-  ;; here, not by silently blocking (or waving through) commits. Pure
-  ;; regex assertions, no subprocess, sub-second.
+  ;; files count toward the 200-line ceiling) and its merge-commit
+  ;; skip. The gate itself runs in this same pre-commit chain — a
+  ;; drifted exclusion regex, or a lost merge skip, should fail here
+  ;; rather than by silently blocking (or waving through) commits.
+  ;; Mostly regex assertions; the merge case builds a throwaway git
+  ;; repo under java.io.tmpdir (hermetic — its own config scopes, no
+  ;; hooks, deleted after) because the detection it pins only
+  ;; reproduces against real merge state.
   "commit-budget-test"]}

--- a/tasks/commit_budget.clj
+++ b/tasks/commit_budget.clj
@@ -283,66 +283,70 @@
    `bb pre-commit` `:depends` chain (a `(System/exit 0)` here would
    terminate the JVM before lint/fmt/test got to run).
 
-   - Mid-merge, skips the check. A merge commit's staged diff carries
-     every line arriving from the merged-in branch, which the merging
-     author did not write and which was already budgeted on the PR
-     that introduced it; its size is not a reviewability signal about
-     this commit. `bb pr-budget` still covers the whole PR diff in CI.
-     Without this, a routine `git merge github/main` forces
-     `MINIFORGE_COMMIT_BUDGET_OVERRIDE`, which trains people to reach
-     for the override and dilutes it for the cases it exists for.
+   - Mid-merge, returns before reading the index at all. A merge
+     commit's staged diff carries every line arriving from the
+     merged-in branch, which the merging author did not write and which
+     was already budgeted on the PR that introduced it; its size is not
+     a reviewability signal about this commit. `bb pr-budget` still
+     covers the whole PR diff in CI. Without this, a routine `git merge
+     github/main` forces `MINIFORGE_COMMIT_BUDGET_OVERRIDE`, which
+     trains people to reach for the override and dilutes it for the
+     cases it exists for. Returning ahead of `staged-diff` rather than
+     as a `cond` branch below it is what makes the skip total: the diff
+     of a large merge is neither fetched nor parsed, and `staged-diff`
+     failing closed on a git error can't block a merge this gate has
+     already declined to judge.
    - With no staged content, returns silently (lets git itself emit
      the 'nothing to commit' message).
    - With `MINIFORGE_COMMIT_BUDGET_OVERRIDE` set, succeeds and echoes
      the rationale.
    - Otherwise prints a per-file breakdown and the verdict."
   [budget]
-  (let [entries    (staged-diff)
-        annotated  (reportable-changes entries)
-        total      (total-lines annotated)
-        rationale  (override-rationale)]
-    (cond
-      (merge-in-progress?)
-      (println "📏 commit-budget: skipped (merge in progress) — incoming lines were budgeted on their own PRs; bb pr-budget covers the full PR diff in CI.")
+  (if (merge-in-progress?)
+    (println "📏 commit-budget: skipped (merge in progress) — incoming lines were budgeted on their own PRs; bb pr-budget covers the full PR diff in CI.")
+    (let [entries    (staged-diff)
+          annotated  (reportable-changes entries)
+          total      (total-lines annotated)
+          rationale  (override-rationale)]
+      (cond
+        (empty? entries)
+        nil   ; truly silent — let git handle the 'nothing to commit' messaging
 
-      (empty? entries)
-      nil   ; truly silent — let git handle the 'nothing to commit' messaging
+        rationale
+        (do (println (format "📏 commit-budget: OVERRIDDEN (%d reportable lines)" total))
+            (println (str "  rationale: " rationale))
+            (when (> total budget)
+              (println (format "  WARNING: %d > %d — budget intentionally bypassed."
+                               total budget)))
+            (print-report! annotated total))
 
-      rationale
-      (do (println (format "📏 commit-budget: OVERRIDDEN (%d reportable lines)" total))
-          (println (str "  rationale: " rationale))
-          (when (> total budget)
-            (println (format "  WARNING: %d > %d — budget intentionally bypassed."
-                             total budget)))
-          (print-report! annotated total))
+        (<= total budget)
+        (println (format "📏 commit-budget: %d / %d lines OK" total budget))
 
-      (<= total budget)
-      (println (format "📏 commit-budget: %d / %d lines OK" total budget))
-
-      :else
-      (do (println "")
-          (println "════════════════════════════════════════════════════════════════")
-          (println (format "❌ COMMIT BUDGET EXCEEDED: %d > %d lines" total budget))
-          (println "════════════════════════════════════════════════════════════════")
-          (println "")
-          (print-report! annotated total)
-          (println "")
-          (println "Why this exists:")
-          (println "  Reviewer defect-detection drops sharply past ~200 LOC.")
-          (println "  Slicing a large change into a stack of small commits keeps")
-          (println "  each one reviewable; the agent that merges first is still on")
-          (println "  the way to the same destination.")
-          (println "")
-          (println "How to proceed:")
-          (println "  • Slice the work: stage only the files for the first PR,")
-          (println "    commit, then continue with the next slice.")
-          (println "  • Genuine exception (lockfile rev, generated migration):")
-          (println "    MINIFORGE_COMMIT_BUDGET_OVERRIDE='<rationale>' git commit ...")
-          (println "    The rationale is echoed at commit time and in CI logs.")
-          (println "    (It is not written into the commit message itself —")
-          (println "     repeat it in your -m '...' if you want it in the trail.)")
-          (println "")
-          (System/exit 1)))))
+        :else
+        (do (println "")
+            (println "════════════════════════════════════════════════════════════════")
+            (println (format "❌ COMMIT BUDGET EXCEEDED: %d > %d lines" total budget))
+            (println "════════════════════════════════════════════════════════════════")
+            (println "")
+            (print-report! annotated total)
+            (println "")
+            (println "Why this exists:")
+            (println "  Reviewer defect-detection drops sharply past ~200 LOC.")
+            (println "  Slicing a large change into a stack of small commits keeps")
+            (println "  each one reviewable; the agent that merges first is still on")
+            (println "  the way to the same destination.")
+            (println "")
+            (println "How to proceed:")
+            (println "  • Slice the work: stage only the files for the first PR,")
+            (println "    commit, then continue with the next slice.")
+            (println "  • Genuine exception (lockfile rev, generated migration):")
+            (println "    MINIFORGE_COMMIT_BUDGET_OVERRIDE='<rationale>' git commit ...")
+            (println "    The rationale is echoed at commit time and in CI logs.")
+            (println "    (It is not written into the commit message itself —")
+            (println "     repeat it in your -m '...' if you want it in the trail.)")
+            (println "")
+            (System/exit 1))))))
 
 ;------------------------------------------------------------------------------ Layer 5
 

--- a/tasks/commit_budget.clj
+++ b/tasks/commit_budget.clj
@@ -32,6 +32,8 @@
      and per-function commentary don't represent review effort and
      shouldn't push a small change over budget.
 
+   Merge commits are skipped outright — see `check-commit-budget!`.
+
    Default: 200 lines. Override via env var
    `MINIFORGE_COMMIT_BUDGET_OVERRIDE=\"<rationale>\"` (the rationale is
    echoed to stdout so the override is auditable in CI logs)."
@@ -125,6 +127,24 @@
   (some-> (System/getenv "MINIFORGE_COMMIT_BUDGET_OVERRIDE")
           str/trim
           not-empty))
+
+(defn ^{:stratum 0} merge-in-progress?
+  "True when git is part-way through a merge, i.e. `MERGE_HEAD`
+   resolves.
+
+   Asks git instead of probing `.git/MERGE_HEAD` as a path: in a linked
+   worktree `.git` is a *file* pointing at `…/.git/worktrees/<name>`,
+   where the merge state actually lives, so the literal path finds
+   nothing. Nearly all work in this repo happens in worktrees, so the
+   path check would be wrong in the common case.
+
+   Answers for whichever repository git itself would act on — the
+   `GIT_DIR` the pre-commit hook exports when there is one, discovery
+   from the working directory otherwise. That is the same repository
+   `staged-diff` reads, which is what makes the two agree."
+  []
+  (zero? (:exit (p/sh {:out :string :err :string}
+                      "git" "rev-parse" "-q" "--verify" "MERGE_HEAD"))))
 
 ;; report (composes Layer 1)
 (defn ^{:stratum 0} print-report!
@@ -263,6 +283,14 @@
    `bb pre-commit` `:depends` chain (a `(System/exit 0)` here would
    terminate the JVM before lint/fmt/test got to run).
 
+   - Mid-merge, skips the check. A merge commit's staged diff carries
+     every line arriving from the merged-in branch, which the merging
+     author did not write and which was already budgeted on the PR
+     that introduced it; its size is not a reviewability signal about
+     this commit. `bb pr-budget` still covers the whole PR diff in CI.
+     Without this, a routine `git merge github/main` forces
+     `MINIFORGE_COMMIT_BUDGET_OVERRIDE`, which trains people to reach
+     for the override and dilutes it for the cases it exists for.
    - With no staged content, returns silently (lets git itself emit
      the 'nothing to commit' message).
    - With `MINIFORGE_COMMIT_BUDGET_OVERRIDE` set, succeeds and echoes
@@ -274,6 +302,9 @@
         total      (total-lines annotated)
         rationale  (override-rationale)]
     (cond
+      (merge-in-progress?)
+      (println "📏 commit-budget: skipped (merge in progress) — incoming lines were budgeted on their own PRs; bb pr-budget covers the full PR diff in CI.")
+
       (empty? entries)
       nil   ; truly silent — let git handle the 'nothing to commit' messaging
 


### PR DESCRIPTION
## Problem

`bb commit-budget` counts the full staged diff. On a merge commit that
includes every line arriving from the merged-in branch — content the
merging author did not write, and that was already budgeted on the PR
which introduced it.

On 2026-08-07 merging `github/main` into a feature branch to pick up an
unrelated squash-merged PR failed on 491 reportable lines, all of it
`components/execution-grant/**`: another author's reviewed, merged work.
The merge itself contributed no new code.

A merge commit's size is not a reviewability signal about the merging
author's change. Forcing `MINIFORGE_COMMIT_BUDGET_OVERRIDE` on routine
merges trains people to reach for the override and dilutes its signal for
the cases it exists for.

## Fix

`commit-budget` detects a merge in progress and skips, printing one line
saying so. Detection asks `git rev-parse -q --verify MERGE_HEAD` rather
than stat-ing `.git/MERGE_HEAD` — in a linked worktree `.git` is a *file*
pointing at `.git/worktrees/<name>/`, where the merge state actually
lives, so the path check finds nothing, and nearly all work in this repo
happens in worktrees.

## Demonstrated on this PR's own merge

This branch merges `github/main` (19 commits, 20 files, 1,783 insertions).
Same staged merge, both versions of the gate:

- pre-fix: `❌ COMMIT BUDGET EXCEEDED: 1135 > 200 lines`
- post-fix: `📏 commit-budget: skipped (merge in progress) — …`

The merge commit here was made through the real pre-commit hook with no
override set.

## `pr-budget` — checked, not assumed

`pr-budget` diffs `merge-base(base, head)..head`. When a branch merges the
base in, the base tip becomes an ancestor of head, the merge-base moves up
to it, and the incoming content falls out of the diff. Confirmed three ways:

- Both merge-containing PRs in recent history: #1697 (head is itself
  `Merge github/main`; `base.sha` equals the merge commit's second parent,
  three-dot diff is the branch's own 10 files) and #1693 (five merge
  commits, three-dot diff 7 files).
- Reproduced both directions in a scratch repo — with the current base tip
  the merged-in file is absent, with a deliberately stale base it appears.
  The failure mode would need GitHub to report a `base.sha` older than what
  the branch merged in; in both real PRs `base.sha` equals the merge-base.
- On this branch: `bb pr-budget` reports 187 / 600, my change only, not the
  1,783 lines merged in.

No change to `pr-budget`.

## Tests

Three added to `commit-budget-test`, mutation-checked rather than trusted
green:

- Replacing `git rev-parse` with a `.git/MERGE_HEAD` stat fails the
  linked-worktree detection test.
- Deleting the merge branch from the `cond` fails the skip test.
- Both fail as named assertions and the suite still completes — an earlier
  draft let the regression exit the test JVM mid-run and take every later
  namespace's result with it.

The fixture strips every `GIT_*` variable from its environment. Without
that it passed standalone and failed under the hook, which exports
`GIT_DIR` and `GIT_INDEX_FILE`: the fixture's git commands inherited them
and aimed at the real repository regardless of `:dir`. That is also why
`merge-in-progress?` takes no repo-dir argument — an ambient `GIT_DIR`
outranks a subprocess `:dir`, so such an argument would answer about the
wrong repository under the hook, the only place the gate runs.

## Note on SL003

Committed with `MINIFORGE_STRATUM_BUDGET_MODE=warn`.
`tasks/commit_budget.clj` already used 6 layers (max 3) on `main` before
this change, which adds none — verified by linting the pristine
`github/main` copy. The namespace split is separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)