### PR TITLE
feat: enforce grants on PR merge

### DIFF
--- a/components/pr-lifecycle/deps.edn
+++ b/components/pr-lifecycle/deps.edn
@@ -2,6 +2,8 @@
  :deps {ai.miniforge/anomaly {:local/root "../anomaly"}
         ai.miniforge/config {:local/root "../config"}
         ai.miniforge/effect-transaction {:local/root "../effect-transaction"}
+        ai.miniforge/execution-grant {:local/root "../execution-grant"}
+        ai.miniforge/gate {:local/root "../gate"}
         ai.miniforge/dag-executor {:local/root "../dag-executor"}
         ai.miniforge/fsm {:local/root "../fsm"}
         ai.miniforge/messages {:local/root "../messages"}

--- a/components/pr-lifecycle/resources/config/pr-lifecycle/messages/en-US.edn
+++ b/components/pr-lifecycle/resources/config/pr-lifecycle/messages/en-US.edn
@@ -22,6 +22,20 @@
   "Attempting to merge PR"
   :controller/merged
   "PR merged successfully"
+  :merge/repository-unavailable
+  "Could not identify the pull request repository"
+  :merge/authority-unavailable
+  "Could not establish merge authority"
+  :merge/authority-denied
+  "Merge authority was denied"
+  :merge/proposal-failed
+  "Could not record the governed merge proposal"
+  :merge/commit-refused
+  "Merge authority changed before commit"
+  :merge/command-failed
+  "Merge command failed"
+  :merge/not-ready
+  "PR is not ready to merge"
   :controller/lifecycle-starting
   "Starting PR lifecycle"
   :controller/pr-creation-failed

--- a/components/pr-lifecycle/resources/config/pr-lifecycle/messages/en-US.edn
+++ b/components/pr-lifecycle/resources/config/pr-lifecycle/messages/en-US.edn
@@ -34,6 +34,8 @@
   "Merge authority changed before commit"
   :merge/command-failed
   "Merge command failed"
+  :merge/outcome-unknown
+  "The merge outcome is unknown"
   :merge/not-ready
   "PR is not ready to merge"
   :controller/lifecycle-starting

--- a/components/pr-lifecycle/resources/config/pr-lifecycle/messages/system.edn
+++ b/components/pr-lifecycle/resources/config/pr-lifecycle/messages/system.edn
@@ -1,5 +1,15 @@
 {:pr-lifecycle/system
  {;; WorklistEntry schema validation failure (operator tooling, not user UI)
+  :merge/success
+  "PR merged successfully"
+  :merge/auto-merge-pending
+  "Auto-merge enabled; merge not yet observed"
+  :merge/rebasing
+  "PR is stale, attempting rebase"
+  :merge/attempting
+  "Attempting PR merge"
+
+  ;; WorklistEntry schema validation failure (operator tooling, not user UI)
   :worklist/validation-failed
   "WorklistEntry schema validation failed"
 

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge.clj
@@ -26,6 +26,7 @@
    [ai.miniforge.pr-lifecycle.github :as github]
    [ai.miniforge.pr-lifecycle.merge-orchestration :as orchestration]
    [ai.miniforge.pr-lifecycle.merge-readiness :as readiness]
+   [ai.miniforge.pr-lifecycle.messages :as messages]
    [ai.miniforge.response.interface :as response]
    [babashka.process :as process]
    [cheshire.core :as json]
@@ -97,6 +98,11 @@
   [worktree-path pr-number]
   (github/unresolved-review-threads worktree-path pr-number))
 
+(defn- ^{:stratum 0} repository-name?
+  [value]
+  (and (string? value)
+       (re-matches #"[^/\s]+/[^/\s]+" value)))
+
 ;; Conflict-resolution dispatch (Stage 3d, spec §6.4)
 (defn- ^{:stratum 0} parse-gh-json
   "Parse `gh --json` output as JSON via Cheshire. Returns the parsed
@@ -159,6 +165,20 @@
         (dag/ok {:up-to-date? clean?
                  :raw output}))
       result)))
+
+(defn ^{:stratum 1} read-repository
+  "Read the exact GitHub owner/repository bound to the worktree."
+  [worktree-path]
+  (dag/when-let-ok
+   [result (run-gh-command
+            ["gh" "repo" "view" "--json" "nameWithOwner"
+             "--jq" ".nameWithOwner"]
+            worktree-path)]
+    (let [repo (:output (:data result))]
+      (if (repository-name? repo)
+        (dag/ok {:pr/repo repo})
+        (dag/err :repository-unavailable
+                 (messages/t :merge/repository-unavailable))))))
 
 ;; Merge execution
 (defn ^{:stratum 1} merge-pr!
@@ -371,7 +391,7 @@
              {:check-ci check-ci-status :check-review check-review-status
               :check-branch check-branch-status
               :check-threads check-unresolved-threads})
-    :run-gh run-gh-command :merge-pr merge-pr!
+    :run-gh run-gh-command :merge-pr merge-pr! :read-repository read-repository
     :fetch-labels fetch-pr-labels! :fetch-branch fetch-pr-branch
     :rebase-pr rebase-pr! :pr-info pr-info-from-gh :normalize-resolution normalize-resolution-outcome}
    worktree-path pr-number policy context))

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge_authority.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge_authority.clj
@@ -1,0 +1,103 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.pr-lifecycle.merge-authority
+  "Runtime authority preparation for one exact pull-request merge."
+  (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.execution-grant.interface :as grant]
+   [ai.miniforge.gate.interface :as gate])
+  (:import
+   [java.time Instant]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} default-breach-dir-property
+  ".miniforge/grant-breaches")
+
+(def ^{:stratum 0} empty-classification
+  {:blocking []
+   :require-approval []
+   :warnings []
+   :audits []
+   :unknown []})
+
+(def ^{:stratum 0} unpinned-policy
+  {:pins/pack-revision nil
+   :pins/rule-ids []
+   :pins/event-watermark nil})
+
+(def ^{:stratum 0} allow-decisions
+  #{:allow :allow-with-obligations})
+
+(defn- ^{:stratum 0} effect-scope
+  [request merge-method]
+  (-> (dissoc request :workflow-run/status :effect/class :effect/preflight)
+      (assoc :merge/method merge-method)))
+
+(defn ^{:stratum 0} request
+  "Build the closed, runtime-attested request for one merge effect."
+  [context effect-id repo pr-number]
+  {:workflow-run/id (:run-id context)
+   :workflow-run/status :running
+   :effect/id effect-id
+   :effect/class :effect/merge
+   :effect/preflight {:preflight/type :preflight/merge-readiness
+                      :preflight/result :allow}
+   :pr/repo repo
+   :pr/number pr-number})
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} breach-dir
+  [context]
+  (or (:grant-breach-dir context)
+      (str (System/getProperty "user.home") "/" default-breach-dir-property)))
+
+(defn ^{:stratum 1} permitted?
+  "True only when both the grant check and DecisionEnvelope allow the effect."
+  [{:authority/keys [authorization envelope]}]
+  (and (grant/authorized? authorization)
+       (contains? allow-decisions (:envelope/decision envelope))))
+
+(defn- ^{:stratum 1} authority-record
+  [request merge-method grant-record authorization envelope]
+  {:effect/id (:effect/id request)
+   :effect/proposal (effect-scope request merge-method)
+   :authority/grant grant-record
+   :authority/authorization authorization
+   :authority/envelope envelope})
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} prepare
+  "Issue, authorize, and decide authority for a preflight-approved merge."
+  [context effect-id repo pr-number merge-method ^Instant now]
+  (let [request (request context effect-id repo pr-number)
+        grant-record (grant/issue-for-effect (breach-dir context) request now)]
+    (if (anomaly/anomaly? grant-record)
+      grant-record
+      (let [scope (effect-scope request merge-method)
+            authorization (grant/authorize grant-record
+                                           {:effect/scope scope
+                                            :usage/count 1}
+                                           now)
+            envelope (gate/decide empty-classification
+                                  unpinned-policy
+                                  authorization)]
+        (authority-record request merge-method grant-record
+                          authorization envelope)))))

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge_governed.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge_governed.clj
@@ -1,0 +1,91 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.pr-lifecycle.merge-governed
+  "Granted, gated, and durably transacted GitHub merge execution."
+  (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.pr-lifecycle.merge-authority :as authority]
+   [ai.miniforge.pr-lifecycle.merge-transaction :as transaction]
+   [ai.miniforge.pr-lifecycle.messages :as messages])
+  (:import
+   [java.time Instant]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} provider-command
+  [operations worktree-path args]
+  (let [result ((:run-gh operations) args worktree-path)]
+    {:ok? (dag/ok? result)
+     :output (:output (:data result))}))
+
+(defn- ^{:stratum 0} enable-merge
+  [operations worktree-path pr-number policy]
+  (let [result ((:merge-pr operations)
+                worktree-path pr-number :policy policy)]
+    {:ok? (dag/ok? result) :error (:error result)}))
+
+(defn- ^{:stratum 0} propose-authority!
+  [context prepared now]
+  (if (anomaly/anomaly? prepared)
+    prepared
+    (transaction/propose! context prepared now)))
+
+(defn- ^{:stratum 0} commit-authority!
+  [context proposed prepared pr-number now enable! run-gh]
+  (let [committed (transaction/commit!
+                   context proposed (:authority/grant prepared)
+                   pr-number now enable! run-gh)]
+    (if (anomaly/anomaly? committed)
+      (dag/err :merge-commit-refused
+               (messages/t :merge/commit-refused)
+               {:commit/result committed})
+      (dag/ok committed))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} transact!
+  "Prepare authority, durably propose, then commit an allowed merge."
+  [operations worktree-path pr-number repo policy context ^Instant now]
+  (let [run-gh (partial provider-command operations worktree-path)
+        enable! (partial enable-merge operations worktree-path pr-number policy)
+        prepared (authority/prepare context (random-uuid) repo pr-number
+                                    (:method policy) now)
+        proposed (propose-authority! context prepared now)]
+    (cond
+      (anomaly/anomaly? prepared)
+      (dag/err :merge-authority-unavailable
+               (messages/t :merge/authority-unavailable)
+               {:authority/result prepared})
+
+      (anomaly/anomaly? proposed)
+      (dag/err :merge-proposal-failed
+               (messages/t :merge/proposal-failed)
+               {:proposal/result proposed})
+
+      (not (authority/permitted? prepared))
+      (dag/err :merge-authority-denied
+               (messages/t :merge/authority-denied)
+               {:effect/id (:effect/id proposed)
+                :envelope/decision (get-in prepared
+                                           [:authority/envelope
+                                            :envelope/decision])})
+
+      :else
+      (commit-authority! context proposed prepared pr-number now
+                         enable! run-gh))))

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge_orchestration.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge_orchestration.clj
@@ -22,54 +22,13 @@
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.pr-lifecycle.conflict-resolution :as conflict-resolution]
    [ai.miniforge.pr-lifecycle.events :as events]
-   [ai.miniforge.pr-lifecycle.merge-transaction :as transaction])
+   [ai.miniforge.pr-lifecycle.merge-governed :as governed]
+   [ai.miniforge.pr-lifecycle.merge-outcome :as outcome]
+   [ai.miniforge.pr-lifecycle.messages :as messages])
   (:import
    [java.time Instant]))
 
 ;------------------------------------------------------------------------------ Layer 0
-
-(defn- ^{:stratum 0} provider-command
-  [operations worktree-path args]
-  (let [result ((:run-gh operations) args worktree-path)]
-    {:ok? (dag/ok? result)
-     :output (:output (:data result))}))
-
-(defn- ^{:stratum 0} enable-merge
-  [operations worktree-path pr-number policy]
-  (let [result ((:merge-pr operations)
-                worktree-path pr-number :policy policy)]
-    {:ok? (dag/ok? result) :error (:error result)}))
-
-(defn- ^{:stratum 0} merged-result
-  [operations worktree-path pr-number policy context settled merge-sha]
-  (let [logger (:logger context)
-        {:keys [dag-id run-id task-id pr-id event-bus]} context]
-    (when event-bus
-      (events/publish! event-bus
-                       (events/merged
-                        dag-id run-id task-id pr-id merge-sha
-                        ((:fetch-labels operations) worktree-path pr-number))
-                       logger))
-    (when logger
-      (log/info logger :pr-lifecycle :merge/success
-                {:message "PR merged successfully"
-                 :data {:pr-number pr-number :merge/sha merge-sha}}))
-    (dag/ok {:merged? true
-             :method (:method policy)
-             :merge/sha merge-sha
-             :effect/id (:effect/id settled)})))
-
-(defn- ^{:stratum 0} pending-result
-  [pr-number policy context settled]
-  (when-let [logger (:logger context)]
-    (log/info logger :pr-lifecycle :merge/auto-merge-pending
-              {:message "Auto-merge enabled; merge not yet observed"
-               :data {:pr-number pr-number
-                      :effect/state (:effect/state settled)}}))
-  (dag/ok {:merged? false
-           :auto-merge/enabled? true
-           :method (:method policy)
-           :effect/id (:effect/id settled)}))
 
 (defn- ^{:stratum 0} completed-rebase
   [context new-sha]
@@ -99,41 +58,25 @@
            :resolve-fn resolve-fn
            :context context}))))))
 
+(defn- ^{:stratum 0} merge-ready!
+  [operations worktree-path pr-number policy context]
+  (dag/when-let-ok
+   [repository-result ((:read-repository operations) worktree-path)
+    transaction-result (governed/transact!
+                        operations worktree-path pr-number
+                        (:pr/repo (:data repository-result))
+                        policy context (Instant/now))]
+    (outcome/settlement-result operations worktree-path pr-number policy context
+                               (:data transaction-result))))
+
 ;------------------------------------------------------------------------------ Layer 1
-
-(defn- ^{:stratum 1} transact!
-  "Record merge intent, enable auto-merge, and reconcile the immediate state."
-  [operations worktree-path pr-number policy context ^Instant now]
-  (let [run-gh (partial provider-command operations worktree-path)
-        enable! (partial enable-merge operations worktree-path pr-number policy)
-        proposed (transaction/propose!
-                  (assoc context :merge/method (:method policy))
-                  pr-number (:pr/repo context) now)]
-    (transaction/commit! context proposed pr-number now enable! run-gh)))
-
-(defn- ^{:stratum 1} settlement-result
-  "Translate one transaction state without overstating a pending merge."
-  [operations worktree-path pr-number policy context settled]
-  (let [merge-sha (transaction/substantiated-sha settled)]
-    (cond
-      (= :failed (:effect/state settled))
-      (dag/err :merge-failed
-               "Merge command failed"
-               {:gh-error (:effect/failure settled)})
-
-      merge-sha
-      (merged-result operations worktree-path pr-number
-                     policy context settled merge-sha)
-
-      :else
-      (pending-result pr-number policy context settled))))
 
 (defn- ^{:stratum 1} rebase-stale!
   "Rebase one stale PR and publish the new head when successful."
   [operations worktree-path pr-number context]
   (when-let [logger (:logger context)]
     (log/info logger :pr-lifecycle :merge/rebasing
-              {:message "PR is stale, attempting rebase"}))
+              {:message (messages/system-t :merge/rebasing)}))
   (dag/when-let-ok
    [branch-result ((:fetch-branch operations) worktree-path pr-number)
     result ((:rebase-pr operations)
@@ -147,18 +90,14 @@
   [operations worktree-path pr-number policy context]
   (when-let [logger (:logger context)]
     (log/info logger :pr-lifecycle :merge/attempting
-              {:message "Attempting PR merge"
+              {:message (messages/system-t :merge/attempting)
                :data {:pr-number pr-number}}))
   (let [readiness-result ((:evaluate-readiness operations)
                           worktree-path pr-number policy)
         stale? (some #{:branch-not-up-to-date}
                      (:blocking readiness-result))]
     (if (:ready? readiness-result)
-      (let [now (Instant/now)
-            settled (transact! operations worktree-path pr-number
-                                 policy context now)]
-        (settlement-result operations worktree-path pr-number
-                           policy context settled))
+      (merge-ready! operations worktree-path pr-number policy context)
       (let [branch-raw (get-in (:checks readiness-result) [:branch :data :raw])
             conflict-result (when stale?
                               (attempt-conflict-resolution!
@@ -173,5 +112,5 @@
 
           :else
           (dag/err :not-ready
-                   "PR is not ready to merge"
+                   (messages/t :merge/not-ready)
                    {:blocking (:blocking readiness-result)}))))))

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge_outcome.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge_outcome.clj
@@ -1,0 +1,77 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.pr-lifecycle.merge-outcome
+  "Honest result and event translation for governed merge transactions."
+  (:require
+   [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.logging.interface :as log]
+   [ai.miniforge.pr-lifecycle.events :as events]
+   [ai.miniforge.pr-lifecycle.merge-transaction :as transaction]
+   [ai.miniforge.pr-lifecycle.messages :as messages]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} merged-result
+  [operations worktree-path pr-number policy context settled merge-sha]
+  (let [logger (:logger context)
+        {:keys [dag-id run-id task-id pr-id event-bus]} context]
+    (when event-bus
+      (events/publish! event-bus
+                       (events/merged
+                        dag-id run-id task-id pr-id merge-sha
+                        ((:fetch-labels operations) worktree-path pr-number))
+                       logger))
+    (when logger
+      (log/info logger :pr-lifecycle :merge/success
+                {:message (messages/system-t :merge/success)
+                 :data {:pr-number pr-number :merge/sha merge-sha}}))
+    (dag/ok {:merged? true
+             :method (:method policy)
+             :merge/sha merge-sha
+             :effect/id (:effect/id settled)})))
+
+(defn- ^{:stratum 0} pending-result
+  [pr-number policy context settled]
+  (when-let [logger (:logger context)]
+    (log/info logger :pr-lifecycle :merge/auto-merge-pending
+              {:message (messages/system-t :merge/auto-merge-pending)
+               :data {:pr-number pr-number
+                      :effect/state (:effect/state settled)}}))
+  (dag/ok {:merged? false
+           :auto-merge/enabled? true
+           :method (:method policy)
+           :effect/id (:effect/id settled)}))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} settlement-result
+  "Translate one transaction state without overstating a pending merge."
+  [operations worktree-path pr-number policy context settled]
+  (let [merge-sha (transaction/substantiated-sha settled)]
+    (cond
+      (= :failed (:effect/state settled))
+      (dag/err :merge-failed
+               (messages/t :merge/command-failed)
+               {:gh-error (:effect/failure settled)})
+
+      merge-sha
+      (merged-result operations worktree-path pr-number
+                     policy context settled merge-sha)
+
+      :else
+      (pending-result pr-number policy context settled))))

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge_outcome.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge_outcome.clj
@@ -57,6 +57,14 @@
            :method (:method policy)
            :effect/id (:effect/id settled)}))
 
+(defn- ^{:stratum 0} uncertain-result
+  [settled]
+  (dag/err :merge-outcome-unknown
+           (messages/t :merge/outcome-unknown)
+           {:effect/id (:effect/id settled)
+            :effect/state (:effect/state settled)
+            :effect/failure (:effect/failure settled)}))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn ^{:stratum 1} settlement-result
@@ -72,6 +80,9 @@
       merge-sha
       (merged-result operations worktree-path pr-number
                      policy context settled merge-sha)
+
+      (:effect/failure settled)
+      (uncertain-result settled)
 
       :else
       (pending-result pr-number policy context settled))))

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge_transaction.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge_transaction.clj
@@ -137,21 +137,19 @@
 
    `enable!` performs the gh merge call and returns `{:ok? bool}`;
    `run-gh` answers the follow-up probe. Both injected."
-  ([context t pr-number ^Instant now enable! run-gh]
-   (commit! context t :authority/unenforced pr-number now enable! run-gh))
-  ([context t grant-record pr-number ^Instant now enable! run-gh]
-   (fx/commit! (store-dir context) t grant-record {} now
-               (fn []
-                 (let [{:keys [ok? error]} (enable!)]
-                   (if-not ok?
-                     {:effect/outcome :failed :effect/failure (str error)}
-                     (if-let [answer (probe run-gh pr-number)]
-                       (if (:effect/matched? answer)
-                         {:effect/outcome :succeeded
-                          :effect/observed (:effect/observed answer)}
-                         {:effect/outcome :accepted
-                          :effect/observed (:effect/observed answer)})
-                       {:effect/outcome :accepted})))))))
+  [context t grant-record pr-number ^Instant now enable! run-gh]
+  (fx/commit! (store-dir context) t grant-record {} now
+              (fn []
+                (let [{:keys [ok? error]} (enable!)]
+                  (if-not ok?
+                    {:effect/outcome :failed :effect/failure (str error)}
+                    (if-let [answer (probe run-gh pr-number)]
+                      (if (:effect/matched? answer)
+                        {:effect/outcome :succeeded
+                         :effect/observed (:effect/observed answer)}
+                        {:effect/outcome :accepted
+                         :effect/observed (:effect/observed answer)})
+                      {:effect/outcome :accepted}))))))
 
 (defn ^{:stratum 2} reconcile!
   "Ask GitHub again about a record whose outcome is still unknown.

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge_transaction.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge_transaction.clj
@@ -31,11 +31,10 @@
    GitHub reports. When the answer is 'not yet', the record stays
    reconcilable and a later pass asks again.
 
-   Grants are NOT enforced here. 2a built the grant object and 2b made
-   `decide()` check it, but nothing in production ISSUES one — requiring
-   a grant today would deny every merge permanently. That half waits on
-   the issuance spec (`work/ariadne-grant-issuance.spec.edn`); this half
-   stops the lying, which does not need to wait."
+   The caller supplies the runtime-issued grant and allowing envelope.
+   Their identifiers are durable on the proposal, and the effect
+   transaction rechecks the grant against that durable scope before the
+   provider command can run."
   (:require
    [ai.miniforge.effect-transaction.interface :as fx]
    [cheshire.core :as json])
@@ -117,14 +116,14 @@
 
 ;; The transaction
 (defn ^{:stratum 2} propose!
-  "Record the intent to merge, durably, before any gh command runs."
-  [context pr-number repo now]
+  "Record correlated merge authority and intent before any gh command runs."
+  [context authority now]
   (fx/propose! (store-dir context)
-               {:effect-class :effect/merge
-                :grant-id nil
-                :proposal {:pr/repo repo
-                           :pr/number pr-number
-                           :merge/method (:merge/method context)}}
+               {:effect-id (:effect/id authority)
+                :effect-class :effect/merge
+                :grant-id (get-in authority [:authority/grant :grant/id])
+                :envelope-id (get-in authority [:authority/envelope :envelope/id])
+                :proposal (:effect/proposal authority)}
                now))
 
 (defn ^{:stratum 2} commit!
@@ -138,19 +137,21 @@
 
    `enable!` performs the gh merge call and returns `{:ok? bool}`;
    `run-gh` answers the follow-up probe. Both injected."
-  [context t pr-number ^Instant now enable! run-gh]
-  (fx/commit! (store-dir context) t :authority/unenforced {} now
-              (fn []
-                (let [{:keys [ok? error]} (enable!)]
-                  (if-not ok?
-                    {:effect/outcome :failed :effect/failure (str error)}
-                    (if-let [answer (probe run-gh pr-number)]
-                      (if (:effect/matched? answer)
-                        {:effect/outcome :succeeded
-                         :effect/observed (:effect/observed answer)}
-                        {:effect/outcome :accepted
-                         :effect/observed (:effect/observed answer)})
-                      {:effect/outcome :accepted}))))))
+  ([context t pr-number ^Instant now enable! run-gh]
+   (commit! context t :authority/unenforced pr-number now enable! run-gh))
+  ([context t grant-record pr-number ^Instant now enable! run-gh]
+   (fx/commit! (store-dir context) t grant-record {} now
+               (fn []
+                 (let [{:keys [ok? error]} (enable!)]
+                   (if-not ok?
+                     {:effect/outcome :failed :effect/failure (str error)}
+                     (if-let [answer (probe run-gh pr-number)]
+                       (if (:effect/matched? answer)
+                         {:effect/outcome :succeeded
+                          :effect/observed (:effect/observed answer)}
+                         {:effect/outcome :accepted
+                          :effect/observed (:effect/observed answer)})
+                       {:effect/outcome :accepted})))))))
 
 (defn ^{:stratum 2} reconcile!
   "Ask GitHub again about a record whose outcome is still unknown.

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/messages.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/messages.clj
@@ -26,3 +26,8 @@
   "Look up a PR lifecycle message by key, with optional param substitution."
   (messages/create-translator "config/pr-lifecycle/messages/en-US.edn"
                               :pr-lifecycle/messages))
+
+(def ^{:stratum 0} system-t
+  "Look up developer-facing PR lifecycle prose by key."
+  (messages/create-translator "config/pr-lifecycle/messages/system.edn"
+                              :pr-lifecycle/system))

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/merge_authority_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/merge_authority_test.clj
@@ -1,0 +1,147 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.pr-lifecycle.merge-authority-test
+  "Provider-effect tests for granted and denied pull-request merges."
+  (:require
+   [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.effect-transaction.interface :as fx]
+   [ai.miniforge.execution-grant.interface :as grant]
+   [ai.miniforge.pr-lifecycle.merge :as merge]
+   [ai.miniforge.pr-lifecycle.merge-readiness :as readiness]
+   [clojure.test :refer [deftest is testing]])
+  (:import
+   [java.nio.file Files]
+   [java.nio.file.attribute FileAttribute]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} merge-context
+  []
+  {:dag-id (random-uuid)
+   :run-id (random-uuid)
+   :task-id (random-uuid)
+   :pr-id 123
+   :effect-store-dir
+   (str (.toFile (Files/createTempDirectory
+                  "merge-effects" (into-array FileAttribute []))))
+   :grant-breach-dir
+   (str (.toFile (Files/createTempDirectory
+                  "merge-grants" (into-array FileAttribute []))))})
+
+(defn- ^{:stratum 0} ready-result
+  [& _]
+  {:ready? true :checks {} :blocking []})
+
+(defn- ^{:stratum 0} issued-merge-grant
+  [request now scope-overrides expires-at]
+  (grant/issue
+   {:principal "runtime:test"
+    :effect-class :effect/merge
+    :scope (merge (select-keys request
+                               [:effect/id :workflow-run/id :pr/repo :pr/number])
+                  scope-overrides)
+    :constraints {:constraint/max-count 1}
+    :delegable? false
+    :expires-at expires-at}
+   now))
+
+(defn- ^{:stratum 0} repository-result
+  [_]
+  (dag/ok {:pr/repo "miniforge-ai/miniforge"}))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} attempt-with-issuer
+  [issuer]
+  (let [merge-calls (atom 0)
+        context (merge-context)]
+    (with-redefs [readiness/evaluate ready-result
+                  merge/read-repository repository-result
+                  grant/issue-for-effect issuer
+                  merge/merge-pr!
+                  (fn [_ _ & _]
+                    (swap! merge-calls inc)
+                    (dag/ok {:merged? true :method :squash}))]
+      {:result (merge/attempt-merge "/tmp" 123
+                                   merge/default-merge-policy context)
+       :merge-calls @merge-calls})))
+
+(deftest ^{:stratum 1} governed-merge-records-authority-before-provider-test
+  (let [context (merge-context)
+        at-command (atom nil)]
+    (with-redefs [readiness/evaluate ready-result
+                  merge/read-repository repository-result
+                  merge/merge-pr!
+                  (fn [_ _ & _]
+                    (reset! at-command
+                            (first (fx/list-records
+                                    (:effect-store-dir context))))
+                    (dag/ok {:merged? true :method :squash}))
+                  merge/run-gh-command
+                  (fn [_ _]
+                    (dag/ok {:output "{\"state\":\"MERGED\",\"mergeCommit\":{\"oid\":\"real-squash-sha\"}}"}))]
+      (let [result (merge/attempt-merge "/tmp" 123
+                                       merge/default-merge-policy context)]
+        (is (dag/ok? result))
+        (is (= "real-squash-sha" (get-in result [:data :merge/sha])))
+        (is (= :committing (:effect/state @at-command)))
+        (is (uuid? (:effect/grant-id @at-command)))
+        (is (uuid? (:effect/envelope-id @at-command)))
+        (is (= :granted
+               (:effect/authority
+                (first (fx/list-records (:effect-store-dir context))))))))))
+
+(deftest ^{:stratum 1} pending-auto-merge-is-not-completed-test
+  (with-redefs [readiness/evaluate ready-result
+                merge/read-repository repository-result
+                merge/merge-pr!
+                (fn [_ _ & _] (dag/ok {:merged? true :method :squash}))
+                merge/run-gh-command
+                (fn [_ _]
+                  (dag/ok {:output "{\"state\":\"OPEN\",\"mergeCommit\":null}"}))]
+    (let [result (merge/attempt-merge "/tmp" 123
+                                     merge/default-merge-policy
+                                     (merge-context))]
+      (is (dag/ok? result))
+      (is (false? (get-in result [:data :merged?])))
+      (is (true? (get-in result [:data :auto-merge/enabled?])))
+      (is (nil? (get-in result [:data :merge/sha]))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} denied-authority-never-invokes-merge-test
+  (testing "an absent grant denies before the provider mutation"
+    (let [{:keys [result merge-calls]} (attempt-with-issuer
+                                        (fn [_ _ _] nil))]
+      (is (dag/err? result))
+      (is (zero? merge-calls))))
+  (testing "a mismatched grant denies before the provider mutation"
+    (let [issuer (fn [_ request now]
+                   (issued-merge-grant request now
+                                       {:pr/repo "other/repository"}
+                                       (.plusSeconds now 60)))
+          {:keys [result merge-calls]} (attempt-with-issuer issuer)]
+      (is (dag/err? result))
+      (is (zero? merge-calls))))
+  (testing "an expired grant denies before the provider mutation"
+    (let [issuer (fn [_ request now]
+                   (issued-merge-grant request now {}
+                                       (.minusSeconds now 1)))
+          {:keys [result merge-calls]} (attempt-with-issuer issuer)]
+      (is (dag/err? result))
+      (is (zero? merge-calls)))))

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/merge_authority_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/merge_authority_test.clj
@@ -100,8 +100,16 @@
         (is (dag/ok? result))
         (is (= "real-squash-sha" (get-in result [:data :merge/sha])))
         (is (= :committing (:effect/state @at-command)))
+        (is (= :granted (:effect/authority @at-command)))
         (is (uuid? (:effect/grant-id @at-command)))
         (is (uuid? (:effect/envelope-id @at-command)))
+        (is (= (:effect/id @at-command)
+               (get-in @at-command [:effect/proposal :effect/id])))
+        (is (= (:run-id context)
+               (get-in @at-command [:effect/proposal :workflow-run/id])))
+        (is (= "miniforge-ai/miniforge"
+               (get-in @at-command [:effect/proposal :pr/repo])))
+        (is (= 123 (get-in @at-command [:effect/proposal :pr/number])))
         (is (= :granted
                (:effect/authority
                 (first (fx/list-records (:effect-store-dir context))))))))))
@@ -129,6 +137,7 @@
     (let [{:keys [result merge-calls]} (attempt-with-issuer
                                         (fn [_ _ _] nil))]
       (is (dag/err? result))
+      (is (= :merge-authority-denied (get-in result [:error :code])))
       (is (zero? merge-calls))))
   (testing "a mismatched grant denies before the provider mutation"
     (let [issuer (fn [_ request now]
@@ -137,6 +146,7 @@
                                        (.plusSeconds now 60)))
           {:keys [result merge-calls]} (attempt-with-issuer issuer)]
       (is (dag/err? result))
+      (is (= :merge-authority-denied (get-in result [:error :code])))
       (is (zero? merge-calls))))
   (testing "an expired grant denies before the provider mutation"
     (let [issuer (fn [_ request now]
@@ -144,4 +154,5 @@
                                        (.minusSeconds now 1)))
           {:keys [result merge-calls]} (attempt-with-issuer issuer)]
       (is (dag/err? result))
+      (is (= :merge-authority-denied (get-in result [:error :code])))
       (is (zero? merge-calls)))))

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/merge_authority_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/merge_authority_test.clj
@@ -130,6 +130,22 @@
       (is (true? (get-in result [:data :auto-merge/enabled?])))
       (is (nil? (get-in result [:data :merge/sha]))))))
 
+(deftest ^{:stratum 1} uncertain-merge-does-not-claim-auto-merge-test
+  (with-redefs [readiness/evaluate ready-result
+                merge/read-repository repository-result
+                merge/merge-pr!
+                (fn [_ _ & _] (throw (ex-info "provider disconnected" {})))]
+    (let [result (merge/attempt-merge "/tmp" 123
+                                     merge/default-merge-policy
+                                     (merge-context))]
+      (is (dag/err? result))
+      (is (= :merge-outcome-unknown (get-in result [:error :code])))
+      (is (= :unknown-outcome
+             (get-in result [:error :data :effect/state])))
+      (is (= "provider disconnected"
+             (get-in result [:error :data :effect/failure])))
+      (is (nil? (get-in result [:data :auto-merge/enabled?]))))))
+
 ;------------------------------------------------------------------------------ Layer 2
 
 (deftest ^{:stratum 2} denied-authority-never-invokes-merge-test

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/merge_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/merge_test.clj
@@ -164,48 +164,6 @@
       (is (true? (:ready? result)))
       (is (empty? (:blocking result))))))
 
-;------------------------------------------------------------------------------ Attempt Merge with Mocks
-(deftest ^{:stratum 0} attempt-merge-enabled-but-unobserved-is-not-merged-test
-  ;; Ariadne 2d. merge-pr! passes --auto unconditionally, so a zero exit
-  ;; means auto-merge was ENABLED. Until GitHub reports a merge, claiming
-  ;; {:merged? true} is a claim the code cannot substantiate.
-  (testing "auto-merge enabled, GitHub still OPEN"
-    (with-redefs [readiness/evaluate
-                  (fn [_ _ _ _] {:ready? true :checks {} :blocking []})
-                  merge/merge-pr!
-                  (fn [_ _ & _] (dag/ok {:merged? true :method :squash}))
-                  merge/run-gh-command
-                  (fn [_ _] (dag/ok {:output "{\"state\":\"OPEN\",\"mergeCommit\":null}"}))]
-      (let [context {:dag-id (random-uuid) :run-id (random-uuid)
-                     :task-id (random-uuid) :pr-id 123}
-            result (merge/attempt-merge "/tmp" 123 merge/default-merge-policy context)]
-        (is (dag/ok? result))
-        (is (false? (:merged? (:data result)))
-            "enabling auto-merge is not merging")
-        (is (true? (:auto-merge/enabled? (:data result))))
-        (is (nil? (:merge/sha (:data result)))
-            "no SHA is published for a merge nobody observed")))))
-
-(deftest ^{:stratum 0} attempt-merge-observed-merge-publishes-githubs-sha-test
-  (testing "GitHub reports MERGED"
-    (with-redefs [readiness/evaluate
-                  (fn [_ _ _ _] {:ready? true :checks {} :blocking []})
-                  merge/merge-pr!
-                  (fn [_ _ & _] (dag/ok {:merged? true :method :squash}))
-                  merge/run-gh-command
-                  (fn [args _]
-                    (if (some #{"--json"} args)
-                      (dag/ok {:output "{\"state\":\"MERGED\",\"mergeCommit\":{\"oid\":\"real-squash-sha\"}}"})
-                      (dag/ok {:output "local-branch-tip"})))]
-      (let [context {:dag-id (random-uuid) :run-id (random-uuid)
-                     :task-id (random-uuid) :pr-id 123}
-            result (merge/attempt-merge "/tmp" 123 merge/default-merge-policy context)]
-        (is (dag/ok? result))
-        (is (true? (:merged? (:data result))))
-        (is (= "real-squash-sha" (:merge/sha (:data result)))
-            "the SHA is GitHub's mergeCommit, not the local branch tip")
-        (is (not= "local-branch-tip" (:merge/sha (:data result))))))))
-
 (deftest ^{:stratum 0} attempt-merge-not-ready-no-rebase-test
   (testing "Merge blocked without auto-rebase yields error"
     (with-redefs [readiness/evaluate

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/merge_transaction_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/merge_transaction_test.clj
@@ -21,6 +21,7 @@
    commit."
   (:require
    [ai.miniforge.effect-transaction.interface :as fx]
+   [ai.miniforge.pr-lifecycle.merge-authority :as authority]
    [ai.miniforge.pr-lifecycle.merge-transaction :as mt]
    [clojure.test :refer [deftest is testing]])
   (:import
@@ -35,8 +36,11 @@
 (def ^{:stratum 0} later (Instant/parse "2026-08-01T01:00:00Z"))
 
 (defn ^{:stratum 0} ctx []
-  {:effect-store-dir
+  {:run-id (random-uuid)
+   :effect-store-dir
    (str (.toFile (Files/createTempDirectory "merge-fx" (into-array FileAttribute []))))
+   :grant-breach-dir
+   (str (.toFile (Files/createTempDirectory "merge-grants" (into-array FileAttribute []))))
    :pr/repo "miniforge-ai/miniforge"})
 
 (defn ^{:stratum 0} gh-returning
@@ -60,6 +64,14 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
+(defn ^{:stratum 1} merge-case! []
+  (let [context (ctx)
+        prepared (authority/prepare context (random-uuid)
+                                    (:pr/repo context) 42 :squash now)]
+    {:context context
+     :authority prepared
+     :transaction (mt/propose! context prepared now)}))
+
 (deftest ^{:stratum 1} parse-pr-view-test
   (is (= {:pr/state "MERGED" :merge/sha "squash-sha-on-base"}
          (mt/parse-pr-view merged-json)))
@@ -68,12 +80,14 @@
     (is (nil? (mt/parse-pr-view "not json at all")))
     (is (nil? (mt/parse-pr-view "{\"unexpected\":true}")))))
 
-(deftest ^{:stratum 1} enabling-auto-merge-is-not-merging-test
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} enabling-auto-merge-is-not-merging-test
   ;; The core correction. `merge-pr!` passes --auto unconditionally, so a
   ;; zero exit means auto-merge was ENABLED. GitHub still says OPEN.
-  (let [c (ctx)
-        t (mt/propose! c 42 "miniforge-ai/miniforge" now)
-        settled (mt/commit! c t 42 now (ok-enable) (gh-returning open-json))]
+  (let [{:keys [context authority transaction]} (merge-case!)
+        settled (mt/commit! context transaction (:authority/grant authority)
+                            42 now (ok-enable) (gh-returning open-json))]
     (is (= :unknown-outcome (:effect/state settled))
         "a request in flight is not a success")
     (is (not= :succeeded (:effect/state settled)))
@@ -82,62 +96,59 @@
     (testing "the record is reconcilable, so a later pass asks again"
       (is (contains? fx/reconcilable-states (:effect/state settled))))))
 
-(deftest ^{:stratum 1} observed-merge-carries-githubs-sha-test
-  (let [c (ctx)
-        t (mt/propose! c 42 "miniforge-ai/miniforge" now)
-        settled (mt/commit! c t 42 now (ok-enable) (gh-returning merged-json))]
+(deftest ^{:stratum 2} observed-merge-carries-githubs-sha-test
+  (let [{:keys [context authority transaction]} (merge-case!)
+        settled (mt/commit! context transaction (:authority/grant authority)
+                            42 now (ok-enable) (gh-returning merged-json))]
     (is (= :succeeded (:effect/state settled)))
     (is (= "squash-sha-on-base" (mt/substantiated-sha settled))
         "the published SHA is GitHub's mergeCommit, not a local branch tip")))
 
-(deftest ^{:stratum 1} a-failed-gh-call-is-a-definite-failure-test
-  (let [c (ctx)
-        t (mt/propose! c 42 "miniforge-ai/miniforge" now)
-        settled (mt/commit! c t 42 now
+(deftest ^{:stratum 2} a-failed-gh-call-is-a-definite-failure-test
+  (let [{:keys [context authority transaction]} (merge-case!)
+        settled (mt/commit! context transaction (:authority/grant authority) 42 now
                             (fn [] {:ok? false :error "PR already closed"})
                             (gh-returning merged-json))]
     (is (= :failed (:effect/state settled))
         "the gh call reported it did not happen — that is knowledge, not doubt")
     (is (nil? (mt/substantiated-sha settled)))))
 
-(deftest ^{:stratum 1} silent-github-leaves-it-unknown-test
-  (let [c (ctx)
-        t (mt/propose! c 42 "miniforge-ai/miniforge" now)
-        settled (mt/commit! c t 42 now (ok-enable)
+(deftest ^{:stratum 2} silent-github-leaves-it-unknown-test
+  (let [{:keys [context authority transaction]} (merge-case!)
+        settled (mt/commit! context transaction (:authority/grant authority)
+                            42 now (ok-enable)
                             (fn [_] {:ok? false :output nil}))]
     (is (= :unknown-outcome (:effect/state settled))
         "GitHub not answering is not GitHub saying no")
     (is (nil? (mt/substantiated-sha settled)))))
 
-(deftest ^{:stratum 1} the-intent-is-on-disk-before-any-gh-command-test
-  (let [c (ctx)
-        t (mt/propose! c 42 "miniforge-ai/miniforge" now)]
-    (is (= :proposed (:effect/state t)))
-    (is (= :effect/merge (:effect/class t)))
-    (is (= 42 (get-in t [:effect/proposal :pr/number])))
+(deftest ^{:stratum 2} the-intent-is-on-disk-before-any-gh-command-test
+  (let [{:keys [context authority transaction]} (merge-case!)]
+    (is (= :proposed (:effect/state transaction)))
+    (is (= :effect/merge (:effect/class transaction)))
+    (is (= 42 (get-in transaction [:effect/proposal :pr/number])))
+    (is (= (get-in authority [:authority/grant :grant/id])
+           (:effect/grant-id transaction)))
+    (is (= (get-in authority [:authority/envelope :envelope/id])
+           (:effect/envelope-id transaction)))
     (testing "a reader sharing no memory with the writer finds it"
-      (is (= (:effect/id t)
-             (:effect/id (fx/read-record (:effect-store-dir c) (:effect/id t))))))))
-
-;; Strata are per-file: the imported commit boundary does not add a local layer.
-(defn- ^{:stratum 1} pending-merge!
-  []
-  (let [c (ctx)
-        t (mt/propose! c 42 "miniforge-ai/miniforge" now)]
-    {:context c
-     :pending (mt/commit! c t 42 now (ok-enable) (gh-returning open-json))}))
-
-;------------------------------------------------------------------------------ Layer 2
+      (is (= (:effect/id transaction)
+             (:effect/id (fx/read-record (:effect-store-dir context)
+                                         (:effect/id transaction))))))))
 
 (deftest ^{:stratum 2} reconcile-settles-a-later-merge-test
   (testing "asking again after GitHub finishes settles it with the real SHA"
-    (let [{:keys [context pending]} (pending-merge!)]
+    (let [{:keys [context authority transaction]} (merge-case!)
+          pending (mt/commit! context transaction (:authority/grant authority)
+                              42 now (ok-enable) (gh-returning open-json))]
       (is (nil? (mt/substantiated-sha pending)))
       (let [settled (mt/reconcile! context pending 42 later (gh-returning merged-json))]
         (is (= :reconciled (:effect/state settled)))
         (is (= "squash-sha-on-base" (mt/substantiated-sha settled))))))
   (testing "a PR that closed unmerged reconciles as a mismatch, not a merge"
-    (let [{:keys [context pending]} (pending-merge!)
+    (let [{:keys [context authority transaction]} (merge-case!)
+          pending (mt/commit! context transaction (:authority/grant authority)
+                              42 now (ok-enable) (gh-returning open-json))
           settled (mt/reconcile! context pending 42 later
                                  (gh-returning "{\"state\":\"CLOSED\",\"mergeCommit\":null}"))]
       (is (= :reconciled (:effect/state settled)))

--- a/docs/pull-requests/2026-08-07-codex-n7-merge-grant-enforcement.md
+++ b/docs/pull-requests/2026-08-07-codex-n7-merge-grant-enforcement.md
@@ -1,0 +1,50 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# feat: enforce grants on PR merge
+
+## Overview
+
+Requires a runtime-issued merge grant and an allowing DecisionEnvelope before
+the PR lifecycle can invoke `gh pr merge`.
+
+## Motivation
+
+Merge transactions were durable but still committed through
+`:authority/unenforced`, leaving an ambient-authority escape hatch in N7.
+
+## Changes in Detail
+
+- Resolve the exact GitHub repository and preallocate the effect identifier.
+- Issue and authorize a merge-scoped grant after provider-backed readiness.
+- Derive one DecisionEnvelope through the gate kernel.
+- Persist effect, grant, envelope, workflow, repository, and PR bindings before
+  the provider effect.
+- Recheck the grant from durable proposal scope at commit time.
+- Separate authority, transaction, outcome, and orchestration namespaces.
+- Deny absent, expired, or mismatched grants without a merge command.
+
+## Testing Plan
+
+- Staged Kondo and stratum lint: zero findings.
+- Polylith structure check: zero errors and warnings.
+- PR lifecycle: all tests green, including denial and pre-effect durability.
+- Pre-commit smoke and GraalVM/Babashka compatibility: green per commit.
+
+## Deployment Plan
+
+No migration is required. Existing unresolved transactions remain
+reconcilable; new merges require runtime authority.
+
+## Related Issues/PRs
+
+Implements `work/ariadne-merge-grant-enforcement.spec.edn` after #1706.
+
+## Checklist
+
+- [x] Provider reads, decisions, and effects are separated.
+- [x] No final merge path uses `:authority/unenforced`.
+- [x] Every changed implementation namespace has at most three strata.

--- a/docs/pull-requests/2026-08-07-codex-n7-merge-grant-enforcement.md
+++ b/docs/pull-requests/2026-08-07-codex-n7-merge-grant-enforcement.md
@@ -26,6 +26,7 @@ Merge transactions were durable but still committed through
 - Recheck the grant from durable proposal scope at commit time.
 - Separate authority, transaction, outcome, and orchestration namespaces.
 - Deny absent, expired, or mismatched grants without a merge command.
+- Preserve provider-exception diagnostics without claiming auto-merge succeeded.
 
 ## Testing Plan
 


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# feat: enforce grants on PR merge

## Overview

Requires a runtime-issued merge grant and an allowing DecisionEnvelope before
the PR lifecycle can invoke `gh pr merge`.

## Motivation

Merge transactions were durable but still committed through
`:authority/unenforced`, leaving an ambient-authority escape hatch in N7.

## Changes in Detail

- Resolve the exact GitHub repository and preallocate the effect identifier.
- Issue and authorize a merge-scoped grant after provider-backed readiness.
- Derive one DecisionEnvelope through the gate kernel.
- Persist effect, grant, envelope, workflow, repository, and PR bindings before
  the provider effect.
- Recheck the grant from durable proposal scope at commit time.
- Separate authority, transaction, outcome, and orchestration namespaces.
- Deny absent, expired, or mismatched grants without a merge command.

## Testing Plan

- Staged Kondo and stratum lint: zero findings.
- Polylith structure check: zero errors and warnings.
- PR lifecycle: all tests green, including denial and pre-effect durability.
- Pre-commit smoke and GraalVM/Babashka compatibility: green per commit.

## Deployment Plan

No migration is required. Existing unresolved transactions remain
reconcilable; new merges require runtime authority.

## Related Issues/PRs

Implements `work/ariadne-merge-grant-enforcement.spec.edn` after #1706.

## Checklist

- [x] Provider reads, decisions, and effects are separated.
- [x] No final merge path uses `:authority/unenforced`.
- [x] Every changed implementation namespace has at most three strata.
