### PR TITLE
feat: add exact deployment preflight operations

### DIFF
--- a/components/phase-deployment/resources/config/phase/deploy-messages/en-US.edn
+++ b/components/phase-deployment/resources/config/phase/deploy-messages/en-US.edn
@@ -65,6 +65,8 @@
   "Command failed with exit code {exit-code}"
   :shell/execution-failed
   "Execution failed: {error}"
+  :shell/unknown-command-failure
+  "Unknown command failure"
   :shell/kustomize-build-failed
   "kustomize build failed: {error}"
   :shell/kubectl-apply-failed

--- a/components/phase-deployment/resources/config/phase/deploy-messages/en-US.edn
+++ b/components/phase-deployment/resources/config/phase/deploy-messages/en-US.edn
@@ -10,6 +10,7 @@
 
   :deploy/starting               "Starting application deployment"
   :deploy/invalid-config         "Deploy configuration invalid: {error}"
+  :deploy/context-unavailable    "Kubernetes current context unavailable"
   :deploy/applied                "Manifests applied to cluster"
   :deploy/rollout-failed         "Deployment rollout failed"
   :deploy/complete               "Application deployment complete"

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_provider.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_provider.clj
@@ -84,7 +84,18 @@
      :ready? (boolean (and (seq statuses) (every? :ready statuses)))
      :images (mapv :image (get-in pod [:spec :containers] []))}))
 
-(defn ^{:stratum 0} target!
+(defn- ^{:stratum 0} target-failure
+  [kubectl-result]
+  (schema/failure
+   :target
+   (or (not-empty (:stderr kubectl-result))
+       (:error kubectl-result)
+       (msg/t :deploy/context-unavailable))
+   {:kubectl-result kubectl-result}))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} target!
   "Resolve a context-free target to kubectl's configured current context."
   [{:keys [context] :as deploy-config}]
   (if context
@@ -92,13 +103,11 @@
     (let [result (shell/kubectl! "config" :extra-args ["current-context"])
           current-context (some-> (:stdout result) str/trim not-empty)]
       (cond
-        (schema/failed? result) result
+        (schema/failed? result) (target-failure result)
         (nil? current-context) (schema/failure
                                 :target (msg/t :deploy/context-unavailable))
         :else (schema/success :target
                               (assoc deploy-config :context current-context))))))
-
-;------------------------------------------------------------------------------ Layer 1
 
 (defn ^{:stratum 1} rollback-info!
   "Read the pre-effect deployment state used to recover a partial mutation."

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_provider.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_provider.clj
@@ -19,8 +19,10 @@
   "Kubernetes reads, mutation, and reconciliation probes."
   (:require
    [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.phase-deployment.messages :as msg]
    [ai.miniforge.phase-deployment.shell :as shell]
-   [ai.miniforge.schema.interface :as schema]))
+   [ai.miniforge.schema.interface :as schema]
+   [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -35,6 +37,23 @@
   [{:keys [kustomize-dir namespace context]}]
   (shell/kustomize-apply! kustomize-dir
                           :namespace namespace :context context))
+
+(defn ^{:stratum 0} render!
+  "Render one Kustomize target without contacting Kubernetes."
+  [{:keys [kustomize-dir]}]
+  (shell/kustomize-build! kustomize-dir))
+
+(defn ^{:stratum 0} apply-rendered!
+  "Apply exactly the manifest bytes recorded by the caller."
+  [{:keys [namespace context]} rendered-yaml]
+  (shell/kubectl-apply! rendered-yaml
+                        :namespace namespace :context context))
+
+(defn ^{:stratum 0} dry-run!
+  "Ask the API server to validate exactly the manifest bytes to be applied."
+  [{:keys [namespace context]} rendered-yaml]
+  (shell/kubectl-apply! rendered-yaml :namespace namespace :context context
+                        :server-dry-run? true))
 
 (def ^{:stratum 0} PodState
   [:map
@@ -64,6 +83,20 @@
      :phase (get-in pod [:status :phase])
      :ready? (boolean (and (seq statuses) (every? :ready statuses)))
      :images (mapv :image (get-in pod [:spec :containers] []))}))
+
+(defn ^{:stratum 0} target!
+  "Resolve a context-free target to kubectl's configured current context."
+  [{:keys [context] :as deploy-config}]
+  (if context
+    (schema/success :target deploy-config)
+    (let [result (shell/kubectl! "config" :extra-args ["current-context"])
+          current-context (some-> (:stdout result) str/trim not-empty)]
+      (cond
+        (schema/failed? result) result
+        (nil? current-context) (schema/failure
+                                :target (msg/t :deploy/context-unavailable))
+        :else (schema/success :target
+                              (assoc deploy-config :context current-context))))))
 
 ;------------------------------------------------------------------------------ Layer 1
 

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_provider.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_provider.clj
@@ -104,8 +104,7 @@
           current-context (some-> (:stdout result) str/trim not-empty)]
       (cond
         (schema/failed? result) (target-failure result)
-        (nil? current-context) (schema/failure
-                                :target (msg/t :deploy/context-unavailable))
+        (nil? current-context) (target-failure result)
         :else (schema/success :target
                               (assoc deploy-config :context current-context))))))
 

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/shell.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/shell.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.phase-deployment.shell
   "Public deployment shell API.
 
@@ -28,22 +27,31 @@
             [ai.miniforge.phase-deployment.shell.pulumi :as pulumi]))
 
 ;------------------------------------------------------------------------------ Layer 0
+
 ;; Public API
+(def ^{:stratum 0} sh-with-timeout exec/sh-with-timeout)
 
-(def sh-with-timeout exec/sh-with-timeout)
-(def classify-error exec/classify-error)
+(def ^{:stratum 0} classify-error exec/classify-error)
 
-(def pulumi! pulumi/pulumi!)
-(def pulumi-preview! pulumi/pulumi-preview!)
-(def pulumi-up! pulumi/pulumi-up!)
-(def pulumi-outputs! pulumi/pulumi-outputs!)
+(def ^{:stratum 0} pulumi! pulumi/pulumi!)
 
-(def kubectl! kubectl/kubectl!)
-(def kubectl-rollout-status! kubectl/kubectl-rollout-status!)
-(def kubectl-get-pods! kubectl/kubectl-get-pods!)
+(def ^{:stratum 0} pulumi-preview! pulumi/pulumi-preview!)
 
-(def kustomize-build! kustomize/kustomize-build!)
-(def kustomize-apply! kustomize/kustomize-apply!)
+(def ^{:stratum 0} pulumi-up! pulumi/pulumi-up!)
+
+(def ^{:stratum 0} pulumi-outputs! pulumi/pulumi-outputs!)
+
+(def ^{:stratum 0} kubectl! kubectl/kubectl!)
+
+(def ^{:stratum 0} kubectl-rollout-status! kubectl/kubectl-rollout-status!)
+
+(def ^{:stratum 0} kubectl-get-pods! kubectl/kubectl-get-pods!)
+
+(def ^{:stratum 0} kustomize-build! kustomize/kustomize-build!)
+
+(def ^{:stratum 0} kubectl-apply! kustomize/kubectl-apply!)
+
+(def ^{:stratum 0} kustomize-apply! kustomize/kustomize-apply!)
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/shell/kustomize.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/shell/kustomize.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.phase-deployment.shell.kustomize
   "Kustomize CLI wrappers for deployment phases."
   (:require [ai.miniforge.phase-deployment.messages :as msg]
@@ -24,9 +23,9 @@
             [ai.miniforge.schema.interface :as schema]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Kustomize wrappers
 
-(def KustomizeApplyResult
+;; Kustomize wrappers
+(def ^{:stratum 0} KustomizeApplyResult
   [:map
    [:success? :boolean]
    [:rendered-yaml [:maybe :string]]
@@ -35,19 +34,30 @@
    [:error {:optional true} any?]
    [:anomaly {:optional true} map?]])
 
-(defn- validate-result!
-  [result]
-  (schema/validate KustomizeApplyResult result))
-
-(defn kustomize-build!
+(defn ^{:stratum 0} kustomize-build!
   [kustomize-dir & {:keys [timeout-ms] :or {timeout-ms (get timeouts/timeouts :kustomize-build-ms 60000)}}]
   (exec/sh-with-timeout "kustomize" ["build" kustomize-dir] :timeout-ms timeout-ms))
 
-(defn kustomize-apply!
+(defn ^{:stratum 0} kubectl-apply!
+  "Apply the supplied manifest bytes without rebuilding their source."
+  [rendered-yaml & {:keys [namespace context server-dry-run?]}]
+  (let [apply-args (cond-> ["apply" "-f" "-"]
+                     namespace (into ["--namespace" namespace])
+                     context (into ["--context" context])
+                     server-dry-run? (into ["--dry-run=server" "-o" "yaml"]))]
+    (exec/sh-with-timeout "kubectl" apply-args
+                          :in rendered-yaml
+                          :timeout-ms (get timeouts/timeouts
+                                           :kustomize-apply-ms 120000))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} kustomize-apply!
   [kustomize-dir & {:keys [namespace context dry-run?]}]
   (let [build-result (kustomize-build! kustomize-dir)]
     (if (schema/failed? build-result)
-      (validate-result!
+      (schema/validate-anomaly
+       KustomizeApplyResult
        (schema/failure :rendered-yaml
                        (msg/t :shell/kustomize-build-failed
                               {:error (get build-result :stderr "")})
@@ -62,11 +72,13 @@
                                                 :in rendered-yaml
                                                 :timeout-ms (get timeouts/timeouts :kustomize-apply-ms 120000))]
         (if (schema/succeeded? apply-result)
-          (validate-result!
+          (schema/validate-anomaly
+           KustomizeApplyResult
            (schema/success :rendered-yaml rendered-yaml
                            {:build-result build-result
                             :apply-result apply-result}))
-          (validate-result!
+          (schema/validate-anomaly
+           KustomizeApplyResult
            (schema/failure :rendered-yaml
                            (get apply-result
                                 :stderr

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/shell/kustomize.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/shell/kustomize.clj
@@ -20,7 +20,8 @@
   (:require [ai.miniforge.phase-deployment.messages :as msg]
             [ai.miniforge.phase-deployment.shell.exec :as exec]
             [ai.miniforge.phase-deployment.shell.timeouts :as timeouts]
-            [ai.miniforge.schema.interface :as schema]))
+            [ai.miniforge.schema.interface :as schema]
+            [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -50,6 +51,14 @@
                           :timeout-ms (get timeouts/timeouts
                                            :kustomize-apply-ms 120000))))
 
+(defn- ^{:stratum 0} failure-detail
+  [command-result]
+  (let [error (:error command-result)]
+    (or (not-empty (:stderr command-result))
+        (when-not (and (string? error) (str/blank? error)) error)
+        (not-empty (get-in command-result [:anomaly :anomaly/message]))
+        (msg/t :shell/unknown-command-failure))))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn ^{:stratum 1} kustomize-apply!
@@ -60,7 +69,7 @@
        KustomizeApplyResult
        (schema/failure :rendered-yaml
                        (msg/t :shell/kustomize-build-failed
-                              {:error (get build-result :stderr "")})
+                              {:error (failure-detail build-result)})
                        {:build-result build-result
                         :apply-result nil}))
       (let [rendered-yaml (:stdout build-result)
@@ -80,9 +89,7 @@
           (schema/validate-anomaly
            KustomizeApplyResult
            (schema/failure :rendered-yaml
-                           (get apply-result
-                                :stderr
-                                (msg/t :shell/kubectl-apply-failed))
+                           (failure-detail apply-result)
                            {:build-result build-result
                             :apply-result apply-result})))))))
 

--- a/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_test.clj
+++ b/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_test.clj
@@ -18,6 +18,8 @@
 (ns ai.miniforge.phase-deployment.deploy-test
   (:require [ai.miniforge.phase-deployment.deploy-config :as config]
             [ai.miniforge.phase-deployment.deploy-provider :as provider]
+            [ai.miniforge.phase-deployment.shell :as shell]
+            [ai.miniforge.schema.interface :as schema]
             [clojure.test :refer [deftest is testing]]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -58,3 +60,18 @@
       (is (= ["svc:v1" "sidecar:v1"]
              (get-in pod-state [:pods 0 :images])))
       (is (every? false? (mapv :ready? (subvec (:pods pod-state) 1)))))))
+
+(deftest ^{:stratum 0} context-free-target-is-bound-once-test
+  (let [calls (atom 0)]
+    (with-redefs [shell/kubectl!
+                  (fn [& _]
+                    (swap! calls inc)
+                    (schema/success :stdout "configured-cluster\n"))]
+      (let [resolved (:target (provider/target!
+                               {:context nil :namespace "production"}))]
+        (is (= "configured-cluster" (:context resolved)))
+        (is (= 1 @calls))))))
+
+(deftest ^{:stratum 0} absent-current-context-fails-closed-test
+  (with-redefs [shell/kubectl! (fn [& _] (schema/success :stdout "\n"))]
+    (is (schema/failed? (provider/target! {:context nil})))))

--- a/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_test.clj
+++ b/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_test.clj
@@ -73,8 +73,11 @@
         (is (= 1 @calls))))))
 
 (deftest ^{:stratum 0} absent-current-context-fails-closed-test
-  (with-redefs [shell/kubectl! (fn [& _] (schema/success :stdout "\n"))]
-    (is (schema/failed? (provider/target! {:context nil})))))
+  (let [kubectl-result (schema/success :stdout "\n")]
+    (with-redefs [shell/kubectl! (fn [& _] kubectl-result)]
+      (let [result (provider/target! {:context nil})]
+        (is (schema/failed? result))
+        (is (= kubectl-result (:kubectl-result result)))))))
 
 (deftest ^{:stratum 0} current-context-shell-failure-keeps-target-contract-test
   (let [kubectl-result (schema/failure :stdout "kubectl unavailable")]

--- a/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_test.clj
+++ b/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_test.clj
@@ -75,3 +75,11 @@
 (deftest ^{:stratum 0} absent-current-context-fails-closed-test
   (with-redefs [shell/kubectl! (fn [& _] (schema/success :stdout "\n"))]
     (is (schema/failed? (provider/target! {:context nil})))))
+
+(deftest ^{:stratum 0} current-context-shell-failure-keeps-target-contract-test
+  (let [kubectl-result (schema/failure :stdout "kubectl unavailable")]
+    (with-redefs [shell/kubectl! (fn [& _] kubectl-result)]
+      (let [result (provider/target! {:context nil})]
+        (is (schema/failed? result))
+        (is (contains? result :target))
+        (is (= kubectl-result (:kubectl-result result)))))))

--- a/components/phase-deployment/test/ai/miniforge/phase_deployment/shell/kustomize_test.clj
+++ b/components/phase-deployment/test/ai/miniforge/phase_deployment/shell/kustomize_test.clj
@@ -26,6 +26,10 @@
 
 (def ^{:stratum 0} manifest-bytes "apiVersion: apps/v1\nkind: Deployment\n")
 
+(defn ^{:stratum 0} blank-stderr-failure
+  [message]
+  (schema/failure :stdout message {:stderr ""}))
+
 (defn ^{:stratum 0} recording-shell
   [calls]
   (fn [command args & {:as options}]
@@ -54,3 +58,19 @@
         (is (= ["apply" "-f" "-" "--namespace" "production"
                 "--context" "cluster-1"]
                (:args apply-call)))))))
+
+(deftest ^{:stratum 1} blank-stderr-retains-command-error-test
+  (testing "build failures retain the structured command error"
+    (let [result (with-redefs [kustomize/kustomize-build!
+                               (fn [& _] (blank-stderr-failure "build broke"))]
+                   (kustomize/kustomize-apply! "/deployment"))]
+      (is (schema/failed? result))
+      (is (re-find #"build broke" (:error result)))))
+  (testing "apply failures retain the structured command error"
+    (let [result (with-redefs [kustomize/kustomize-build!
+                               (fn [& _] (schema/success :stdout manifest-bytes))
+                               exec/sh-with-timeout
+                               (fn [& _] (blank-stderr-failure "apply broke"))]
+                   (kustomize/kustomize-apply! "/deployment"))]
+      (is (schema/failed? result))
+      (is (= "apply broke" (:error result))))))

--- a/components/phase-deployment/test/ai/miniforge/phase_deployment/shell/kustomize_test.clj
+++ b/components/phase-deployment/test/ai/miniforge/phase_deployment/shell/kustomize_test.clj
@@ -1,0 +1,56 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.phase-deployment.shell.kustomize-test
+  (:require
+   [ai.miniforge.phase-deployment.shell.exec :as exec]
+   [ai.miniforge.phase-deployment.shell.kustomize :as kustomize]
+   [ai.miniforge.schema.interface :as schema]
+   [clojure.test :refer [deftest is testing]]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} manifest-bytes "apiVersion: apps/v1\nkind: Deployment\n")
+
+(defn ^{:stratum 0} recording-shell
+  [calls]
+  (fn [command args & {:as options}]
+    (swap! calls conj {:command command :args args :options options})
+    (schema/success :stdout "accepted")))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} server-dry-run-and-apply-use-identical-input-test
+  (let [calls (atom [])]
+    (with-redefs [exec/sh-with-timeout (recording-shell calls)]
+      (kustomize/kubectl-apply! manifest-bytes
+                                 :namespace "production"
+                                 :context "cluster-1"
+                                 :server-dry-run? true)
+      (kustomize/kubectl-apply! manifest-bytes
+                                 :namespace "production"
+                                 :context "cluster-1"))
+    (let [[dry-run apply-call] @calls]
+      (is (= [manifest-bytes manifest-bytes]
+             (mapv #(get-in % [:options :in]) @calls)))
+      (is (= ["apply" "-f" "-" "--namespace" "production"
+              "--context" "cluster-1" "--dry-run=server" "-o" "yaml"]
+             (:args dry-run)))
+      (testing "the real mutation cannot inherit the dry-run flag"
+        (is (= ["apply" "-f" "-" "--namespace" "production"
+                "--context" "cluster-1"]
+               (:args apply-call)))))))

--- a/docs/pull-requests/2026-08-07-codex-n7-deploy-provider-preflight.md
+++ b/docs/pull-requests/2026-08-07-codex-n7-deploy-provider-preflight.md
@@ -1,0 +1,55 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# feat: add exact deployment preflight operations
+
+## Overview
+
+Adds the provider operations needed to govern Kubernetes deployment without
+changing the active deploy flow yet.
+
+## Motivation
+
+N7 must persist an exact target and provider dry-run before mutation. Rebuilding
+or resolving the current Kubernetes context again at commit would let the
+authorized proposal differ from the bytes or cluster actually mutated.
+
+## Layer
+
+Kubernetes provider adapter.
+
+## Depends on
+
+- #1712 — deployment flow decomposition (merged)
+
+## Changes in Detail
+
+- Resolve a context-free target to kubectl's configured current context once.
+- Expose separate render, server-dry-run, and apply-rendered provider calls.
+- Pass identical rendered manifest bytes to dry-run and real apply.
+- Preserve the existing combined apply operation until enforcement replaces it.
+
+## Testing Plan
+
+- Phase-deployment component tests.
+- Staged Kondo and stratum lint with zero findings.
+- Polylith structure check with zero errors and warnings.
+- Full pre-commit smoke and compatibility suites.
+
+## Deployment Plan
+
+Merge before the deployment grant-enforcement PR. This adds provider seams but
+does not change production deployment behavior.
+
+## Related Issues/PRs
+
+Prerequisite adapter slice for `work/ariadne-deploy-grant-enforcement.spec.edn`.
+
+## Checklist
+
+- [x] Current context becomes an exact target value.
+- [x] Server dry-run and apply consume identical manifest bytes.
+- [x] Existing deploy behavior remains independently usable.

--- a/docs/pull-requests/2026-08-07-codex-n7-deploy-provider-preflight.md
+++ b/docs/pull-requests/2026-08-07-codex-n7-deploy-provider-preflight.md
@@ -30,6 +30,7 @@ Kubernetes provider adapter.
 - Resolve a context-free target to kubectl's configured current context once.
 - Expose separate render, server-dry-run, and apply-rendered provider calls.
 - Pass identical rendered manifest bytes to dry-run and real apply.
+- Preserve structured command diagnostics when a shell returns blank stderr.
 - Preserve the existing combined apply operation until enforcement replaces it.
 
 ## Testing Plan


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# feat: add exact deployment preflight operations

## Overview

Adds the provider operations needed to govern Kubernetes deployment without
changing the active deploy flow yet.

## Motivation

N7 must persist an exact target and provider dry-run before mutation. Rebuilding
or resolving the current Kubernetes context again at commit would let the
authorized proposal differ from the bytes or cluster actually mutated.

## Layer

Kubernetes provider adapter.

## Depends on

- #1712 — deployment flow decomposition (merged)

## Changes in Detail

- Resolve a context-free target to kubectl's configured current context once.
- Expose separate render, server-dry-run, and apply-rendered provider calls.
- Pass identical rendered manifest bytes to dry-run and real apply.
- Preserve the existing combined apply operation until enforcement replaces it.

## Testing Plan

- Phase-deployment component tests.
- Staged Kondo and stratum lint with zero findings.
- Polylith structure check with zero errors and warnings.
- Full pre-commit smoke and compatibility suites.

## Deployment Plan

Merge before the deployment grant-enforcement PR. This adds provider seams but
does not change production deployment behavior.

## Related Issues/PRs

Prerequisite adapter slice for `work/ariadne-deploy-grant-enforcement.spec.edn`.

## Checklist

- [x] Current context becomes an exact target value.
- [x] Server dry-run and apply consume identical manifest bytes.
- [x] Existing deploy behavior remains independently usable.
