### PR TITLE
fix(pipeline-runner): guard against DAG deadlock in run-pipeline-dag

### DIFF
--- a/components/pipeline-runner/src/ai/miniforge/pipeline_runner/run.clj
+++ b/components/pipeline-runner/src/ai/miniforge/pipeline_runner/run.clj
@@ -361,16 +361,35 @@
 
 (defn- run-pipeline-dag
   "Loop over the DAG until all stages reach a terminal state.
-   Returns {:stage-runs [...] :cursors {...} :failed? bool}."
+   Returns {:stage-runs [...] :cursors {:} :failed? bool}.
+
+   Guards against DAG deadlock: when the run is not yet terminal but no task
+   is ready to execute — which happens when (first (dag/ready-tasks @run-atom))
+   returns nil and the silent failed transitions leave state unchanged — the
+   loop would spin forever. Detecting an empty ready-set before calling
+   step-pipeline lets us skip remaining pending tasks and surface the deadlock
+   as a normal pipeline failure."
   [run-atom stage-map connectors context]
   (loop [stage-outputs {}
          stage-runs    []
          cursors       {}
          sm            stage-map]
-    (if (dag/all-terminal? @run-atom)
+    (cond
+      (dag/all-terminal? @run-atom)
       {:stage-runs stage-runs
        :cursors    cursors
        :failed?    (seq (:run/failed @run-atom))}
+
+      ;; DAG deadlock: non-terminal run with no ready tasks.
+      ;; Skip any remaining pending tasks and return as a failed run so the
+      ;; caller receives a deterministic failure instead of an infinite loop.
+      (empty? (dag/ready-tasks @run-atom))
+      (do (skip-remaining-tasks! run-atom)
+          {:stage-runs stage-runs
+           :cursors    cursors
+           :failed?    true})
+
+      :else
       (let [[outputs' runs' cursors' sm']
             (step-pipeline run-atom sm connectors context stage-outputs stage-runs cursors)]
         (recur outputs' runs' cursors' sm')))))

--- a/components/pipeline-runner/src/ai/miniforge/pipeline_runner/run.clj
+++ b/components/pipeline-runner/src/ai/miniforge/pipeline_runner/run.clj
@@ -361,7 +361,7 @@
 
 (defn- run-pipeline-dag
   "Loop over the DAG until all stages reach a terminal state.
-   Returns {:stage-runs [...] :cursors {:} :failed? bool}.
+   Returns {:stage-runs [...] :cursors {...} :failed? bool}.
 
    Guards against DAG deadlock: when the run is not yet terminal but no task
    is ready to execute — which happens when (first (dag/ready-tasks @run-atom))
@@ -378,7 +378,7 @@
       (dag/all-terminal? @run-atom)
       {:stage-runs stage-runs
        :cursors    cursors
-       :failed?    (seq (:run/failed @run-atom))}
+       :failed?    (boolean (seq (:run/failed @run-atom)))}
 
       ;; DAG deadlock: non-terminal run with no ready tasks.
       ;; Skip any remaining pending tasks and return as a failed run so the


### PR DESCRIPTION
## Summary

`run-pipeline-dag` looped until `dag/all-terminal?` returned true, but had no exit path for a non-terminal DAG with an empty ready-set. When a stage failed and its dependents were never unblocked, the loop spun forever — a live-lock with no recovery.

Added a `cond` branch: when `(empty? (dag/ready-tasks @run-atom))` and the run is not yet terminal, call `skip-remaining-tasks!` and return `{:failed? true}`. This mirrors the intent of a failed stage propagating failure through the rest of the pipeline without hanging the executor.

## Motivation

Any pipeline where a stage fails and the failure is not cleanly propagated to all downstream dependents would wedge the executor thread indefinitely. The guard ensures the loop always terminates, either successfully or with a failure signal that callers can act on.

## Changes

| File | Change |
|------|--------|
| `components/pipeline-runner/src/ai/miniforge/pipeline_runner/run.clj` | Convert `if` to `cond`; add deadlock-guard arm with `skip-remaining-tasks!` call and updated docstring |

## Testing

- Existing pipeline-runner tests pass.
- Deadlock scenario: a pipeline with a failing first stage and a dependent second stage now terminates with `{:failed? true}` instead of spinning.

## Checklist

- [x] `bb poly:check` passes
- [x] No new dependencies introduced
- [x] Docstring updated to describe the guard

## Related

No open issues. Surfaced by daily health sweep 2026-08-08.

---
_Generated by [Claude Code](https://claude.ai/code/session_0188mrLBxAEH8e5i14rzzQxd)_