### PR TITLE
feat(buzzword-bingo): text preparation strata for a prose slop scanner

### DIFF
--- a/components/buzzword-bingo/deps.edn
+++ b/components/buzzword-bingo/deps.edn
@@ -1,0 +1,4 @@
+{:paths ["src" "resources"]
+ :deps {}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps {}}}}

--- a/components/buzzword-bingo/deps.edn
+++ b/components/buzzword-bingo/deps.edn
@@ -1,4 +1,4 @@
-{:paths ["src" "resources"]
+{:paths ["src"]
  :deps {}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/interface.cljc
+++ b/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/interface.cljc
@@ -1,0 +1,40 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.buzzword-bingo.interface
+  "Public API for the buzzword-bingo component.
+
+   Counts marketing, corporate and generated-prose tells in a document
+   so a caller can judge whether prose is worth keeping or should be
+   written again. Host-independent throughout: the same code backs JVM
+   tools, the Babashka CLI and the Node build."
+  (:require
+   [ai.miniforge.buzzword-bingo.segment :as segment]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Text preparation
+(defn ^{:stratum 0} prose-only
+  "Return `text` with code, links, paths and quotations blanked out.
+
+   The result is the same length as `text`, so offsets into it address
+   the source. `:score-quotes?` in `opts` keeps blockquoted lines."
+  ([text] (segment/prose-only text))
+  ([text opts] (segment/prose-only text opts)))
+
+(comment
+  (prose-only "Use `robust` in code but not in prose."))

--- a/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/interface.cljc
+++ b/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/interface.cljc
@@ -18,10 +18,9 @@
 (ns ai.miniforge.buzzword-bingo.interface
   "Public API for the buzzword-bingo component.
 
-   Counts marketing, corporate and generated-prose tells in a document
-   so a caller can judge whether prose is worth keeping or should be
-   written again. Host-independent throughout: the same code backs JVM
-   tools, the Babashka CLI and the Node build."
+   Today: prepares a document for counting by blanking the regions that
+   are not authored prose. The counter that consumes it arrives with
+   the term catalog."
   (:require
    [ai.miniforge.buzzword-bingo.segment :as segment]))
 

--- a/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/phrase.cljc
+++ b/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/phrase.cljc
@@ -1,0 +1,108 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.buzzword-bingo.phrase
+  "Compile an English term or phrase into a pattern that matches it.
+
+   Handles the three things a literal search gets wrong on prose: word
+   boundaries, phrases broken across a wrapped line, and inflected
+   forms of the same word."
+  (:require
+   [ai.miniforge.buzzword-bingo.regex :as regex]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Boundary and inflection vocabulary
+(def ^{:stratum 0} ^:private whitespace-run
+  "Gap between the words of a phrase. A literal space matches any run of
+   whitespace so a phrase still matches across a wrapped line."
+  "\\s+")
+
+(def ^{:stratum 0} ^:private word-boundary "\\b")
+
+(def ^{:stratum 0} ^:private regular-suffixes
+  "Inflections of a word whose stem survives them intact."
+  "(?:s|es|ed|ing|ly)?")
+
+(def ^{:stratum 0} ^:private silent-e-suffixes
+  "Inflections of a word ending in silent `e`, which the suffix drops:
+   leverage inflects to leveraging, not leverageing."
+  "(?:e|es|ed|ing|ely)")
+
+(def ^{:stratum 0} ^:private consonant-y-suffixes
+  "Inflections of a word ending in consonant + `y`, which becomes `ie`."
+  "(?:y|ies|ied|ying)")
+
+(def ^{:stratum 0} ^:private consonant-y-pattern #"[bcdfghjklmnpqrstvwxz]y$")
+
+(def ^{:stratum 0} ^:private shortest-stemmable-word
+  "Words shorter than this keep their final letter; stripping it would
+   leave a stem matching far more than the word did."
+  3)
+
+(defn- ^{:stratum 0} without-last-character [word]
+  (subs word 0 (dec (count word))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; \b asserts a word/non-word transition, so anchoring a term that already
+;; starts or ends with punctuation would demand a character it does not have.
+(defn- ^{:stratum 1} boundary-if-word-edge [edge]
+  (if (re-find #"[a-z0-9]" edge) word-boundary ""))
+
+;; The final word of a phrase, with its inflections when stemming.
+(defn- ^{:stratum 1} final-word-source [word stem?]
+  (let [short? (< (count word) shortest-stemmable-word)]
+    (cond
+      (not stem?)
+      (regex/escape word)
+
+      (and (not short?) (str/ends-with? word "e"))
+      (str (regex/escape (without-last-character word)) silent-e-suffixes)
+
+      (and (not short?) (re-find consonant-y-pattern word))
+      (str (regex/escape (without-last-character word)) consonant-y-suffixes)
+
+      :else
+      (str (regex/escape word) regular-suffixes))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Term compilation
+;; Inflection belongs to the head of a phrase — low-hanging fruits, not
+;; low-hangings fruit — so only the final word stems.
+(defn ^{:stratum 2} term-pattern
+  "Compile literal `term` into a case-folded whole-word pattern.
+   With `:stem?` truthy it also matches inflections of the final word."
+  ([term] (term-pattern term nil))
+  ([term {:keys [stem?]}]
+   (when (str/blank? term)
+     (throw (#?(:clj IllegalArgumentException. :cljs js/Error.)
+             "term-pattern requires a non-blank term")))
+   (let [folded  (regex/ascii-lower (str/trim term))
+         words   (str/split folded #"\s+")
+         leading (map regex/escape (butlast words))
+         final   (final-word-source (last words) stem?)
+         body    (str/join whitespace-run (concat leading [final]))
+         head    (boundary-if-word-edge (subs folded 0 1))
+         tail    (boundary-if-word-edge (subs folded (dec (count folded))))]
+     (re-pattern (str head body tail)))))
+
+(comment
+  (term-pattern "low hanging fruit")
+  (term-pattern "leverage" {:stem? true}))

--- a/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/regex.cljc
+++ b/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/regex.cljc
@@ -1,0 +1,80 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.buzzword-bingo.regex
+  "Pattern primitives that behave identically on JVM, Babashka and Node.
+
+   Everything host-specific about regular expressions is confined here:
+   match positions, case folding and escaping. Patterns built on top of
+   these are matched against pre-folded lowercase text, since
+   JavaScript has no inline `(?i)`, `(?s)` or `(?m)` modifiers."
+  (:require
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Folding, escaping, match enumeration
+;; Not clojure.string/lower-case: that is not length-preserving across all of
+;; Unicode (U+0130 lowercases to two codepoints), and every line and column the
+;; scanner reports is an index into the folded string.
+(defn ^{:stratum 0} ascii-lower
+  "Lowercase the ASCII letters of `s`, leaving other codepoints untouched.
+   Preserves length, and therefore index positions."
+  [s]
+  (str/replace s #"[A-Z]" str/lower-case))
+
+(def ^{:stratum 0} ^:private metacharacter-pattern
+  "Characters escaped to match literally. Limited to the punctuation both
+   Java and JavaScript accept escaped; escaping more throws on the JVM."
+  #"[.*+?^${}()|\[\]\\]")
+
+(defn ^{:stratum 0} find-all
+  "Every non-overlapping match of `pattern` in `s`, in source order, as
+   `{:match/index i :match/text t}` where `i` is an offset into `s`."
+  [pattern s]
+  #?(:clj
+     (let [matcher (re-matcher pattern s)]
+       (loop [acc []]
+         (if (.find matcher)
+           (recur (conj acc {:match/index (.start matcher)
+                             :match/text  (.group matcher)}))
+           acc)))
+
+     :cljs
+     ;; A zero-width match leaves lastIndex where it was, so advance it by hand
+     ;; or .exec never terminates.
+     (let [re (js/RegExp. (.-source pattern) "g")]
+       (loop [acc []]
+         (if-let [m (.exec re s)]
+           (let [text (aget m 0)]
+             (when (zero? (count text))
+               (set! (.-lastIndex re) (inc (.-lastIndex re))))
+             (recur (conj acc {:match/index (.-index m)
+                               :match/text  text})))
+           acc)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} escape
+  "Escape `s` so it matches itself when embedded in a pattern."
+  [s]
+  (str/replace s metacharacter-pattern #(str "\\" %)))
+
+(comment
+  (ascii-lower "Comprehensive İ")
+  (escape "c++")
+  (find-all #"ab" "abcab"))

--- a/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/regex.cljc
+++ b/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/regex.cljc
@@ -55,9 +55,14 @@
            acc)))
 
      :cljs
+     ;; Cloned rather than reused so enumeration cannot leave lastIndex set on
+     ;; a caller's pattern; the clone keeps the original flags, since dropping
+     ;; them would make the same pattern behave differently from the JVM.
      ;; A zero-width match leaves lastIndex where it was, so advance it by hand
      ;; or .exec never terminates.
-     (let [re (js/RegExp. (.-source pattern) "g")]
+     (let [flags (.-flags pattern)
+           re    (js/RegExp. (.-source pattern)
+                             (if (str/includes? flags "g") flags (str flags "g")))]
        (loop [acc []]
          (if-let [m (.exec re s)]
            (let [text (aget m 0)]

--- a/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/segment.cljc
+++ b/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/segment.cljc
@@ -1,0 +1,91 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.buzzword-bingo.segment
+  "Blank the regions of a document that are not authored prose.
+
+   Masked characters become spaces and newlines are kept, so the mask
+   is the same length as the source and indices, lines and columns
+   derived from it still address the source correctly."
+  (:require
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Blanking
+(defn- ^{:stratum 0} blanked [match]
+  ;; A replace callback receives a bare string without capture groups and a
+  ;; [whole & groups] vector with them.
+  (let [text (if (vector? match) (first match) match)]
+    (str/replace text #"[^\n]" " ")))
+
+;; The non-prose catalog
+(def ^{:stratum 0} non-prose-patterns
+  "Regions carrying no authored prose, in application order: fenced
+   blocks precede inline code so fence backticks are already blank, and
+   link targets precede bare URLs so a markdown link is consumed whole.
+
+   Lines anchor with `(?:^|\\n)` and `[\\s\\S]` stands in for DOTALL,
+   because JavaScript has no inline regex modifiers."
+  [;; HTML and markdown comments
+   #"<!--[\s\S]*?-->"
+   ;; Fenced code, opening fence through matching closing fence
+   #"(?:^|\n)[ \t]*(`{3,}|~{3,})[^\n]*\n[\s\S]*?\n[ \t]*\1[^\n]*"
+   ;; Fenced code left unterminated at end of document
+   #"(?:^|\n)[ \t]*(?:`{3,}|~{3,})[\s\S]*$"
+   ;; Inline code spans
+   #"`[^`\n]*`"
+   ;; Markdown link and image targets, brackets included
+   #"\]\([^)\n]*\)"
+   ;; Bare URLs
+   #"(?:https?|ftp)://[^\s<>()\[\]\"']+"
+   #"www\.[^\s<>()\[\]\"']+"
+   ;; Rooted and relative filesystem paths
+   #"(?:^|\s)(?:\.{1,2}/|~/|/)[\w./~@+-]+"
+   ;; Bare paths carrying a file extension, e.g. components/foo/deps.edn
+   #"(?:^|\s)[\w.~@-]+/[\w./~@+-]*\.[A-Za-z]{1,6}\b"
+   ;; HTML tags, attributes included
+   #"</?[A-Za-z][^>\n]*>"])
+
+(def ^{:stratum 0} quotation-pattern
+  "Markdown blockquote lines — prose, but somebody else's."
+  #"(?:^|\n)[ \t]*>[^\n]*")
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} mask-pattern [text pattern]
+  (str/replace text pattern blanked))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Public masking
+(defn ^{:stratum 2} prose-only
+  "Return `text` with every non-prose region blanked to spaces.
+
+   Blockquoted lines are blanked too unless `:score-quotes?` is truthy:
+   quoting somebody else's marketing copy is not writing marketing
+   copy, and charging the author for it penalises citation."
+  ([text] (prose-only text nil))
+  ([text {:keys [score-quotes?]}]
+   (let [patterns (if score-quotes?
+                    non-prose-patterns
+                    (conj non-prose-patterns quotation-pattern))]
+     (reduce mask-pattern text patterns))))
+
+(comment
+  (prose-only "Use `robust` here.\n\n```\nrobust code\n```\n\n> a robust quote")
+  (prose-only "See https://example.com/seamless-integration for more."))

--- a/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/phrase_test.cljc
+++ b/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/phrase_test.cljc
@@ -1,0 +1,88 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.buzzword-bingo.phrase-test
+  (:require
+   [ai.miniforge.buzzword-bingo.phrase :as sut]
+   [ai.miniforge.buzzword-bingo.regex :as regex]
+   #?(:clj  [clojure.test :refer [deftest is testing]]
+      :cljs [cljs.test :refer-macros [deftest is testing]])))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Fixtures and helpers
+(defn- ^{:stratum 0} matches-of
+  "Matched text of every occurrence of `term` in `text`."
+  ([term text] (matches-of term nil text))
+  ([term opts text]
+   (mapv :match/text
+         (regex/find-all (sut/term-pattern term opts) (regex/ascii-lower text)))))
+
+(deftest ^{:stratum 0} test-term-pattern-rejects-a-blank-term
+  (testing "given a blank term → the caller is told rather than handed a pattern"
+    (is (thrown? #?(:clj Exception :cljs js/Error) (sut/term-pattern "   ")))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} stemmed
+  "Matched text of every occurrence of the stemmed `term` in `text`."
+  [term text]
+  (matches-of term {:stem? true} text))
+
+;; Boundaries and phrases
+(deftest ^{:stratum 1} test-term-pattern-matches-whole-words-only
+  (testing "given a term embedded in a longer word → no match"
+    (is (= [] (matches-of "art" "restart the cartography"))))
+
+  (testing "given the term standing alone → matched"
+    (is (= ["art"] (matches-of "art" "the art of it"))))
+
+  (testing "given a term ending in punctuation → the boundary is not demanded"
+    (is (= ["c++"] (matches-of "c++" "we use c++ here")))))
+
+(deftest ^{:stratum 1} test-term-pattern-spans-wrapped-phrases
+  (testing "given a phrase broken across a line → still matched"
+    (is (= ["low-hanging\nfruit"]
+           (matches-of "low-hanging fruit" "the low-hanging\nfruit today")))))
+
+(deftest ^{:stratum 1} test-term-pattern-folds-case
+  (testing "given capitalised source text → matched all the same"
+    (is (= ["comprehensive"] (matches-of "comprehensive" "A Comprehensive guide")))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Inflection
+(deftest ^{:stratum 2} test-term-pattern-stemming
+  (testing "given a regular word → plural, past and participle forms match"
+    (is (= ["empower" "empowers" "empowered" "empowering"]
+           (stemmed "empower" "empower empowers empowered empowering"))))
+
+  (testing "given a word ending in silent e → the e is dropped before -ing"
+    (is (= ["leverage" "leverages" "leveraged" "leveraging"]
+           (stemmed "leverage" "leverage leverages leveraged leveraging"))))
+
+  (testing "given a word ending in consonant plus y → the y becomes ie"
+    (is (= ["synergy" "synergies"] (stemmed "synergy" "synergy and synergies"))))
+
+  (testing "given a stem shared with an unrelated word → not matched"
+    (is (= [] (stemmed "leverage" "level levering lever"))))
+
+  (testing "given a word too short to stem → its final letter is kept"
+    (is (= ["be"] (stemmed "be" "to be"))))
+
+  (testing "given a phrase → only its final word inflects"
+    (is (= ["deep dives"] (stemmed "deep dive" "two deep dives")))))

--- a/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/regex_test.cljc
+++ b/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/regex_test.cljc
@@ -1,0 +1,67 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.buzzword-bingo.regex-test
+  (:require
+   [ai.miniforge.buzzword-bingo.regex :as sut]
+   #?(:clj  [clojure.test :refer [deftest is testing]]
+      :cljs [cljs.test :refer-macros [deftest is testing]])))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Fixtures and helpers
+(def ^{:stratum 0} ^:private dotted-capital-i
+  "U+0130. Lowercases to two codepoints under full Unicode rules, which
+   would shift every index derived from the folded string."
+  "İ")
+
+(defn- ^{:stratum 0} literal-matches
+  "Matched text of every occurrence of the escaped literal `s` in `text`."
+  [s text]
+  (mapv :match/text (sut/find-all (re-pattern (sut/escape s)) text)))
+
+(defn- ^{:stratum 0} match-indices [pattern text]
+  (mapv :match/index (sut/find-all pattern text)))
+
+(deftest ^{:stratum 0} test-find-all-terminates-on-a-zero-width-pattern
+  (testing "given a pattern that can match nothing → enumeration still ends"
+    (is (= 4 (count (sut/find-all #"x?" "abc"))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Case folding, escaping, enumeration
+(deftest ^{:stratum 1} test-case-folding-preserves-indices
+  (testing "given ASCII capitals → folded to lowercase"
+    (is (= "comprehensive" (sut/ascii-lower "Comprehensive"))))
+
+  (testing "given a codepoint that expands under full Unicode folding → length unchanged"
+    (is (= (count dotted-capital-i) (count (sut/ascii-lower dotted-capital-i)))))
+
+  (testing "given non-ASCII letters → left alone"
+    (is (= (str "robust " dotted-capital-i)
+           (sut/ascii-lower (str "Robust " dotted-capital-i))))))
+
+(deftest ^{:stratum 1} test-escaping-makes-metacharacters-literal
+  (testing "given a literal containing regex syntax → matched as written"
+    (is (= ["c++"] (literal-matches "c++" "we use c++ here"))))
+
+  (testing "given a dot in a literal → does not match an arbitrary character"
+    (is (= [] (literal-matches "a.b" "axb")))))
+
+(deftest ^{:stratum 1} test-find-all-reports-positions-in-source-order
+  (testing "given repeated occurrences → offsets ascend and address the source"
+    (is (= [0 12] (match-indices #"robust" "robust code robust prose")))))

--- a/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/segment_test.cljc
+++ b/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/segment_test.cljc
@@ -1,0 +1,98 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.buzzword-bingo.segment-test
+  (:require
+   [ai.miniforge.buzzword-bingo.segment :as sut]
+   [clojure.string :as str]
+   #?(:clj  [clojure.test :refer [deftest is testing]]
+      :cljs [cljs.test :refer-macros [deftest is testing]])))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Fixtures and helpers
+(def ^{:stratum 0} ^:private word-pattern #"[A-Za-z][A-Za-z'-]*")
+
+(defn- ^{:stratum 0} newline-count [text]
+  (count (filter #(= \newline %) text)))
+
+(defn- ^{:stratum 0} fenced
+  "A document with `body` inside a fenced code block."
+  [prose body]
+  (str prose "\n\n```clojure\n" body "\n```\n"))
+
+(deftest ^{:stratum 0} test-mask-leaves-ordinary-prose-untouched
+  (testing "given prose with no machine-readable regions → returned unchanged"
+    (let [text "A plain sentence about a parser, with a comma and a full stop."]
+      (is (= text (sut/prose-only text)))))
+
+  (testing "given prose punctuation resembling markup → not mistaken for code"
+    (is (str/includes? (sut/prose-only "the ratio is 3 > 2 in practice") "practice"))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} surviving-words
+  "Words still visible after masking `text`."
+  ([text] (surviving-words text nil))
+  ([text opts] (set (re-seq word-pattern (sut/prose-only text opts)))))
+
+;; The mask keeps the source addressable
+(deftest ^{:stratum 1} test-mask-is-position-preserving
+  (testing "given any document → the mask has the same length"
+    (let [text (fenced "keep this" "(def dropped 1)")]
+      (is (= (count text) (count (sut/prose-only text))))))
+
+  (testing "given a multi-line document → newlines survive masking"
+    (let [text (fenced "keep this" "(def dropped 1)")]
+      (is (= (newline-count text) (newline-count (sut/prose-only text)))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; What counts as prose
+(deftest ^{:stratum 2} test-mask-blanks-code
+  (testing "given a fenced block → its contents are dropped and prose kept"
+    (is (= #{"keep"} (surviving-words (fenced "keep" "dropped")))))
+
+  (testing "given a fence left open at end of document → the tail is dropped"
+    (is (= #{"keep"} (surviving-words "keep\n\n```\ndropped\nalso"))))
+
+  (testing "given an inline code span → only its contents are dropped"
+    (is (= #{"keep" "and"} (surviving-words "keep `dropped` and `gone`")))))
+
+(deftest ^{:stratum 2} test-mask-blanks-machine-readable-text
+  (testing "given a bare URL → its slug is not prose"
+    (is (= #{"keep"} (surviving-words "keep https://example.com/dropped-word"))))
+
+  (testing "given a markdown link → the target is dropped and the label kept"
+    (is (= #{"keep" "label"} (surviving-words "keep [label](https://example.com/dropped)"))))
+
+  (testing "given filesystem paths → both rooted and extension-bearing forms are dropped"
+    (is (= #{"keep" "and"}
+           (surviving-words "keep ./dropped/file.clj and components/dropped/deps.edn"))))
+
+  (testing "given a word pair joined by a slash → it is prose, not a path"
+    (is (= #{"input" "output" "robust"} (surviving-words "input/output robust"))))
+
+  (testing "given HTML comments and tags → both are dropped"
+    (is (= #{"keep"} (surviving-words "<!-- dropped -->keep<span class=\"dropped\">")))))
+
+(deftest ^{:stratum 2} test-mask-blanks-quotations-unless-asked
+  (testing "given a blockquote → somebody else's prose is not counted by default"
+    (is (= #{"mine"} (surviving-words "> theirs\nmine"))))
+
+  (testing "given score-quotes? → the quotation is counted too"
+    (is (= #{"theirs" "mine"} (surviving-words "> theirs\nmine" {:score-quotes? true})))))

--- a/deps.edn
+++ b/deps.edn
@@ -9,6 +9,7 @@
                        "components/config/src"
                        "components/config/resources"
                        "components/algorithms/src"
+                       "components/buzzword-bingo/src"
                        "components/content-hash/src"
                        "components/opsv/src"
                        "components/logging/src"
@@ -222,6 +223,7 @@
                       ai.miniforge/config {:local/root "components/config"}
                       ai.miniforge/lsp-mcp-bridge {:local/root "bases/lsp-mcp-bridge"}
                       ai.miniforge/algorithms {:local/root "components/algorithms"}
+                      ai.miniforge/buzzword-bingo {:local/root "components/buzzword-bingo"}
                       ai.miniforge/content-hash {:local/root "components/content-hash"}
                       ai.miniforge/opsv {:local/root "components/opsv"}
                       ai.miniforge/logging {:local/root "components/logging"}
@@ -357,6 +359,7 @@
                        "components/config/test"
                        "components/config/test-resources"
                        "components/algorithms/test"
+                       "components/buzzword-bingo/test"
                        "components/content-hash/test"
                        "components/opsv/test"
                        "components/response/test"
@@ -505,6 +508,7 @@
          :extra-deps {ai.miniforge/schema {:local/root "components/schema"}
                       ai.miniforge/config {:local/root "components/config"}
                       ai.miniforge/algorithms {:local/root "components/algorithms"}
+                      ai.miniforge/buzzword-bingo {:local/root "components/buzzword-bingo"}
                       ai.miniforge/content-hash {:local/root "components/content-hash"}
                       ai.miniforge/opsv {:local/root "components/opsv"}
                       ai.miniforge/logging {:local/root "components/logging"}

--- a/docs/pull-requests/2026-08-09-claude-buzzword-bingo-mcp-01bb19.md
+++ b/docs/pull-requests/2026-08-09-claude-buzzword-bingo-mcp-01bb19.md
@@ -1,0 +1,138 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# feat: buzzword-bingo text preparation strata
+
+## Overview
+
+First slice of a prose scanner that counts marketing, corporate and
+generated-prose tells in a document, so a caller can decide whether text is
+worth keeping or should be written again. This PR lands the three strata the
+counter will sit on: host-portable pattern primitives, term-to-pattern
+compilation, and non-prose masking.
+
+No counting yet. The lexicon, the scorer and the bingo card follow in later
+PRs, as does the MCP server, the CLI and the Node build.
+
+## Motivation
+
+Generated prose has a register, and that register is now leaking into
+everything: marketing adjectives that assert quality instead of stating
+behaviour, corporate filler, and a set of words that mark a text as machine
+written. This repository already bans that register by hand in
+`standards/miniforge` and in the author's own instructions; nothing measures
+it.
+
+A measurement makes the rule enforceable in three places at once: a model can
+check its own draft before delivering, a CI job can fail a document, and a
+human can get a number instead of an argument.
+
+The component is `.cljc` and host-independent so the same scanner can back the
+JVM tooling here, a Babashka CLI, and an npm-published Node build that any
+MCP-speaking vendor tool can call.
+
+## Changes in Detail
+
+### `components/buzzword-bingo/…/regex.cljc`
+
+Confines every host difference in regular-expression handling to one
+namespace.
+
+- `find-all` returns `{:match/index :match/text}` for each match. Neither host
+  offers this directly: `Matcher` has no ClojureScript equivalent and `re-seq`
+  reports matched text without positions.
+- `ascii-lower` folds case without the length changes full Unicode folding can
+  introduce (U+0130 lowercases to two codepoints), because every reported line
+  and column is an index into the folded string.
+- `escape` covers only the punctuation both engines accept escaped; escaping
+  more throws on the JVM.
+
+Patterns are matched against pre-folded lowercase text and spell `[\s\S]`
+rather than relying on DOTALL, since JavaScript has no inline `(?i)`, `(?s)`
+or `(?m)` modifiers.
+
+### `components/buzzword-bingo/…/phrase.cljc`
+
+Compiles a lexicon term into a pattern that matches it in real prose.
+
+- Word-boundary anchoring, applied only at edges where the term has a word
+  character, so a term like `c++` is not asked for a boundary it lacks.
+- Internal spaces match any whitespace run, so a phrase still matches when a
+  paragraph wraps mid-phrase.
+- Optional stemming of the final word only, since inflection belongs to the
+  head of a phrase. Covers regular endings plus the two spelling changes
+  English makes: dropped silent `e` (`leveraging`) and consonant + `y`
+  becoming `ie` (`synergies`). Words under three characters keep their final
+  letter.
+
+### `components/buzzword-bingo/…/segment.cljc`
+
+Blanks the regions of a document that are not authored prose, before anything
+counts words in it.
+
+- Fenced and inline code, markdown link targets, bare URLs, filesystem paths,
+  HTML comments and tags.
+- Blockquotes as well, unless `:score-quotes?` is passed. Quoting somebody
+  else's marketing copy is not writing marketing copy.
+- Masked characters become spaces and newlines survive, so the mask is the
+  same length as the source. That property is what lets a later stratum report
+  the line and column of a hit it found in the masked copy.
+
+### `components/buzzword-bingo/…/interface.cljc`
+
+Public surface for this slice: `prose-only`, exposed because a disputed score
+is nearly always a masking question, and seeing what the scanner treated as
+prose settles it.
+
+### Workspace registration
+
+`components/buzzword-bingo` added to the `:dev` and `:test` aliases.
+
+## Testing Plan
+
+- `regex-test` — case folding preserves length on a codepoint that would
+  otherwise expand, escaped metacharacters stay literal, match offsets ascend
+  in source order, and enumeration terminates on a zero-width pattern (the
+  JavaScript branch loops forever without an explicit `lastIndex` bump).
+- `phrase-test` — whole-word matching, phrases across a line break, case
+  folding, each stemming rule, no over-reach onto words sharing a stem prefix,
+  and a blank term rejected rather than compiled.
+- `segment-test` — mask length and newline count preserved, each non-prose
+  category blanked, `input/output` treated as prose rather than a path, and
+  ordinary prose returned unchanged.
+
+All run under Babashka and on the JVM through `poly test`; the test namespaces
+are `.cljc` so the ClojureScript build in a later PR can run the same
+assertions.
+
+## Deployment Plan
+
+Library code only. No entry point, no runtime behaviour change to any existing
+project. Nothing consumes the component until the following PR.
+
+## Related Issues/PRs
+
+Part of a sequence. Each depends on the one before and branches from `main`
+after it merges, rather than stacking:
+
+1. **This PR** — regex, phrase, segment strata
+2. Lexicon catalog, detection, scoring
+3. Bingo card and session accumulation
+4. Report renderers and message catalogs
+5. CLI and `bb bingo` task
+6. MCP server
+7. Stop hook and skill
+8. ClojureScript/Node build and npm packaging
+
+## Checklist
+
+- [x] `poly check` clean
+- [x] `clj-kondo` clean, no warnings
+- [x] `stratum-lint` clean, every file within the three-layer budget
+- [x] Each commit under the 200-line commit budget; whole PR under 600
+- [x] Apache header on every source file
+- [x] Adversarial self-review of the diff
+- [x] Standards gap analysis against `standards/miniforge`


### PR DESCRIPTION
## Overview

First slice of Buzzword Bingo — a scanner that counts marketing, corporate and
generated-prose tells in a document so a caller can decide whether text is
worth keeping or should be written again. This PR lands the three strata the
counter sits on. No counting yet: the lexicon, scorer and bingo card follow.

Full context, including the sequence of PRs that follow, is in
[docs/pull-requests/2026-08-09-claude-buzzword-bingo-mcp-01bb19.md](docs/pull-requests/2026-08-09-claude-buzzword-bingo-mcp-01bb19.md).

## What's here

- **`regex.cljc`** — every host difference in regular-expression handling,
  confined to one namespace. `find-all` reports match offsets (neither host
  gives this directly: `Matcher` has no ClojureScript equivalent, `re-seq`
  drops positions), `ascii-lower` folds case without the length changes full
  Unicode folding can introduce, `escape` covers only the punctuation both
  engines accept escaped.
- **`phrase.cljc`** — term to pattern. Word boundaries applied only where the
  term has a word edge, internal spaces matching any whitespace run so a
  phrase survives a wrapped line, and optional stemming of the final word,
  including English's two spelling changes (`leveraging`, `synergies`).
- **`segment.cljc`** — blanks code, link targets, URLs, paths, HTML and
  blockquotes before anything counts words. Masked characters become spaces
  and newlines survive, so the mask is the same length as the source; that is
  what lets a later stratum report line and column for a hit found in the
  masked copy.
- **`interface.cljc`** — `prose-only`, exposed because a disputed score is
  nearly always a masking question.

## Why the component is `.cljc`

The same scanner needs to back the JVM tooling here, a Babashka CLI, and an
npm-published Node build that any MCP-speaking vendor tool can call. That rules
out `Matcher`, `re-seq` positions and inline `(?i)`/`(?s)`/`(?m)` modifiers,
which is most of what `regex.cljc` exists to work around.

## Verification

- `poly check` clean, no warnings
- `clj-kondo` clean
- `stratum-lint` clean, every file within the three-layer budget
- 14 tests / 33 assertions, plus the full pre-commit suite (342 tests) on every
  commit
- Each commit under the 200-line commit budget; whole PR 314 of 600

Test namespaces are `.cljc`, so the ClojureScript build in a later PR runs the
same assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)