### PR TITLE
feat(codex): per-peg consultation telemetry (SPEC §7.7)

### DIFF
--- a/components/codex-gap/src/ai/miniforge/codex_gap/ledger.clj
+++ b/components/codex-gap/src/ai/miniforge/codex_gap/ledger.clj
@@ -39,7 +39,15 @@
 (defn ^{:stratum 0} build-entry
   "Normalize a miss into its ledger shape. `signal` is
    {:type :review-blocking|:gate-failure|:terminal-anomaly :payload ...}
-   with the payload verbatim from the producer."
+   with the payload verbatim from the producer.
+
+   The consultation's :pegs — the §7.7 per-peg record (which way each
+   presented peg answered, or that it went unanswered, and the landing
+   set that followed) — is lifted to :miss/pegs and stripped from the
+   stored consultation: one canonical location per datum. This ledger is
+   deliberately the §7.7 accrual surface — the retirement trigger
+   (T1 §4.4.1) reads answer distributions from here, no new collection
+   surface."
   [{:keys [run-id phase signal situation consultation bucket attribution]}]
   {:miss/id (random-uuid)
    :miss/at (str (java.time.Instant/now))
@@ -47,7 +55,8 @@
    :miss/phase phase
    :miss/signal signal
    :miss/situation situation
-   :miss/consultation consultation
+   :miss/consultation (dissoc consultation :pegs)
+   :miss/pegs (get consultation :pegs)
    :miss/bucket bucket
    :miss/attribution attribution})
 

--- a/components/codex-gap/test/ai/miniforge/codex_gap/interface_test.clj
+++ b/components/codex-gap/test/ai/miniforge/codex_gap/interface_test.clj
@@ -167,6 +167,29 @@
         (is (nil? (get-in entries [0 :miss/consultation :pin-read?]))
             "tri-state pin-read? survives the round trip verbatim")))))
 
+(deftest ^{:stratum 1} build-entry-lifts-pegs-out-of-the-consultation
+  ;; SPEC §7.7: the per-peg record accrues in this ledger. The writer
+  ;; normalizes — pegs live at :miss/pegs only, never duplicated inside
+  ;; the stored consultation.
+  (let [pegs [{:id "peg-a" :answer nil :landings {"yes" ["p1"] "no" ["p2"]}}]
+        e (gap/build-entry {:run-id "r" :phase :implement
+                            :signal drift-signal
+                            :situation "changing-one-side-of-a-boundary"
+                            :consultation {:status :pinned :pinned? true
+                                           :pin-read? nil :pegs pegs}
+                            :bucket :unheeded :attribution nil})]
+    (is (= pegs (:miss/pegs e)))
+    (is (= {:status :pinned :pinned? true :pin-read? nil}
+           (:miss/consultation e))
+        "one canonical location: the stored consultation drops :pegs")
+    (testing "a peg-less consultation stays nil across both keys"
+      (let [e (gap/build-entry {:run-id "r" :phase :review
+                                :signal drift-signal :situation nil
+                                :consultation nil :bucket :uncovered
+                                :attribution nil})]
+        (is (nil? (:miss/pegs e)))
+        (is (nil? (:miss/consultation e)))))))
+
 (deftest ^{:stratum 1} ledger-write-failure-is-data-not-a-throw
   (let [r (gap/record-miss! "/dev/null/not-a-dir" (gap/build-entry
                                                     {:run-id "x" :phase :implement

--- a/components/codex/resources/config/codex/messages/en-US.edn
+++ b/components/codex/resources/config/codex/messages/en-US.edn
@@ -10,7 +10,7 @@
   :render/scar-cost-horizon    ", cost-horizon: {value}"
   :render/unanchored-line      "    unanchored — reasoned, not survived"
   :render/open-line            "    open: {text}"
-  :render/coverage-line        "coverage: {landing-count} landings, {unanchored-count} unanchored, newest scar {newest-scar-date}, horizon mix {horizon-mix}"
+  :render/coverage-line        "coverage: {landing-count} landings, {unanchored-count} unanchored, newest scar {newest-scar-date}, horizon mix {horizon-mix}, retirement: {retirement}"
   :render/no-newest-scar       "none"
   :render/no-strategic-coverage "NO STRATEGIC COVERAGE: every landing is tactical/operational. The codex has nothing strategic-horizon for this situation — that absence is a gap in the codex, not evidence the situation carries no strategic risk."
 

--- a/components/codex/src/ai/miniforge/codex/core.clj
+++ b/components/codex/src/ai/miniforge/codex/core.clj
@@ -26,6 +26,7 @@
   (:require [ai.miniforge.codex.graph :as graph]
             [ai.miniforge.codex.messages :as msg]
             [ai.miniforge.codex.node :as node]
+            [ai.miniforge.codex.pegs :as pegs]
             [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -35,10 +36,16 @@
 
    Returns {:situation id
             :landings [...ordered strategic -> operational -> tactical]
+            :pegs [...id-sorted, each {:id :answers {answer [landing-ids]}}]
             :coverage {...}}
    or a {:codex/anomaly ...} map when the codex is unreadable, the situation
    matches nothing, or it matches ambiguously. Unmatched is an ANSWER, not
-   an empty list — silence about a missing match is false coverage."
+   an empty list — silence about a missing match is false coverage.
+
+   :pegs is the §7.7 telemetry basis: the discriminators this consultation
+   presents, with the landing set each answer routes to — what a recorded
+   consultation needs so the §4.4 retirement trigger has data to compute
+   over."
   [codex-dir situation-text]
   (when (str/blank? (str situation-text))
     (throw (IllegalArgumentException. "situation-text must be non-blank")))
@@ -67,7 +74,8 @@
 
           :else
           (let [situation (first matches)
-                landings (->> (graph/reachable-from nodes (:id situation))
+                reachable (graph/reachable-from nodes (:id situation))
+                landings (->> reachable
                               (keep nodes)
                               (filter #(#{"problem" "resolution"} (:type %)))
                               (map #(graph/landing-view nodes %))
@@ -77,4 +85,5 @@
             {:situation (:id situation)
              :situation-title (:title situation)
              :landings landings
+             :pegs (pegs/peg-views nodes reachable)
              :coverage (graph/coverage-of landings)}))))))

--- a/components/codex/src/ai/miniforge/codex/graph.clj
+++ b/components/codex/src/ai/miniforge/codex/graph.clj
@@ -30,9 +30,10 @@
    succeed; the reverse cannot."
   {"strategic" 0 "operational" 1 "tactical" 2})
 
-(defn- ^{:stratum 0} as-edge-list
+(defn ^{:stratum 0} as-edge-list
   "A frontmatter edge field is either a parsed list or an inline string
-   (situations emit `routes-to: <id>`); normalise to a list of maps."
+   (situations emit `routes-to: <id>`); normalise to a list of maps.
+   Public: the peg views (ai.miniforge.codex.pegs) walk routes-to too."
   [v]
   (cond
     (string? v) [{:target v}]
@@ -52,7 +53,14 @@
 (defn ^{:stratum 0} coverage-of
   "The response's own coverage statement (§7.5): landing count, unanchored
    count, horizon mix, and age of the newest scar among the landings. A
-   response that reports only what is known creates false coverage."
+   response that reports only what is known creates false coverage.
+
+   :retirement is :untriggerable while it stays true that push delivery
+   captures no peg answers: consultations record which pegs were presented
+   (§7.7) but every one goes unanswered, so the §4.4.1 answer-distribution
+   entropy trigger has nothing to compute over and every peg is de facto
+   immortal. The value flips only when an answer-capture channel exists —
+   reporting the absence here is the §7.7 MUST."
   [landings]
   (let [problems (filter #(= "problem" (:type %)) landings)
         mix (frequencies (keep :horizon problems))]
@@ -60,7 +68,8 @@
      :unanchored-count (count (filter #(empty? (:scars %)) problems))
      :horizon-mix mix
      :no-strategic-coverage? (nil? (get mix "strategic"))
-     :newest-scar-date (some->> problems (mapcat :scars) (keep :date) sort last)}))
+     :newest-scar-date (some->> problems (mapcat :scars) (keep :date) sort last)
+     :retirement :untriggerable}))
 
 ;------------------------------------------------------------------------------ Layer 1
 

--- a/components/codex/src/ai/miniforge/codex/interface.clj
+++ b/components/codex/src/ai/miniforge/codex/interface.clj
@@ -43,10 +43,12 @@
 
    Landings are ordered strategic → operational → tactical (§7.6.1); the
    coverage statement carries landing count, unanchored count, horizon mix
-   (including an explicit :no-strategic-coverage? flag, §7.6.2), and the
-   newest scar date (§7.5). Anomalies (unreadable codex, unmatched or
-   ambiguous situation) come back as {:codex/anomaly ...} data, never as an
-   empty success."
+   (including an explicit :no-strategic-coverage? flag, §7.6.2), the
+   newest scar date (§7.5), and the retirement-trigger state (§7.7).
+   :pegs carries the per-peg telemetry basis — every discriminator
+   presented, with the landing set each answer routes to (§7.7/§4.4).
+   Anomalies (unreadable codex, unmatched or ambiguous situation) come
+   back as {:codex/anomaly ...} data, never as an empty success."
   [codex-dir situation-text]
   (core/consider codex-dir situation-text))
 
@@ -61,8 +63,11 @@
 
 (defn ^{:stratum 0} pin-entry
   "Build the per-run blackboard pin (SPEC §7.4): consult the codex for
-   `situation` and return {:path pin-path :content rendered} suitable as a
-   `:task/existing-files` entry — prompt-visible AND cache-fetchable.
+   `situation` and return {:path pin-path :content rendered :pegs [..]} —
+   :path/:content suitable as a `:task/existing-files` entry
+   (prompt-visible AND cache-fetchable); :pegs is the consultation's §7.7
+   telemetry basis riding along for provenance recording, never part of
+   the pinned file itself.
 
    The pinned artifact is the consultation RESULT, ephemeral and per-run;
    the codex itself is durable and is never cached onto the blackboard
@@ -77,7 +82,8 @@
        :content (str (msg/t :pin/header)
                      "\n\n"
                      (render/render-response resp)
-                     "\n")})))
+                     "\n")
+       :pegs (:pegs resp)})))
 
 (defn ^{:stratum 0} unconfigured-anomaly
   "The anomaly returned when no codex location is configured at all.

--- a/components/codex/src/ai/miniforge/codex/pegs.clj
+++ b/components/codex/src/ai/miniforge/codex/pegs.clj
@@ -1,0 +1,57 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.codex.pegs
+  "Per-peg views of a consultation (Codex SPEC T1 §7.7).
+
+   A consultation PRESENTS every discriminator (peg) reachable from its
+   situation. Recording, per presented peg, which way it was answered and
+   the landing set behind each answer is the only data the §4.4.1
+   retirement trigger (answer-distribution entropy, routing relevance)
+   can compute over — so the consider response carries that basis."
+  (:require [ai.miniforge.codex.graph :as graph]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} answer-landings
+  "Landing ids (problems/resolutions) reachable from one answer's target,
+   sorted for stable telemetry."
+  [nodes target]
+  (->> (graph/reachable-from nodes target)
+       (keep nodes)
+       (filter #(#{"problem" "resolution"} (:type %)))
+       (map :id)
+       sort
+       vec))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} peg-views
+  "The §7.7 per-peg telemetry basis: every discriminator among `reachable`
+   (id-sorted), each with the landing set every answer routes to."
+  [nodes reachable]
+  (->> reachable
+       (keep nodes)
+       (filter #(= "discriminator" (:type %)))
+       (sort-by :id)
+       (mapv (fn [peg]
+               {:id (:id peg)
+                :answers (into {}
+                               (for [r (graph/as-edge-list (:routes-to peg))
+                                     :let [target (or (:target r) (:value r))]
+                                     :when target]
+                                 [(:answer r) (answer-landings nodes target)]))}))))

--- a/components/codex/src/ai/miniforge/codex/render.clj
+++ b/components/codex/src/ai/miniforge/codex/render.clj
@@ -59,7 +59,7 @@
 
 (defn- ^{:stratum 0} render-coverage
   [{:keys [landing-count unanchored-count horizon-mix
-           no-strategic-coverage? newest-scar-date]}]
+           no-strategic-coverage? newest-scar-date] :as coverage}]
   (str/join "\n"
     (concat
       ;; horizon mix rendered in the §7.6.1 order, not map order
@@ -71,7 +71,10 @@
                                      (for [h ["strategic" "operational" "tactical"]
                                            :let [n (get horizon-mix h)]
                                            :when n]
-                                       (str h " " n)))})]
+                                       (str h " " n)))
+               ;; a coverage map with no retirement slot predates the §7.7
+               ;; telemetry and IS the untriggerable era — same report
+               :retirement (name (get coverage :retirement :untriggerable))})]
       (when no-strategic-coverage?
         [(msg/t :render/no-strategic-coverage)]))))
 

--- a/components/codex/test/ai/miniforge/codex/interface_test.clj
+++ b/components/codex/test/ai/miniforge/codex/interface_test.clj
@@ -67,7 +67,28 @@
       (is (= 1 (:unanchored-count coverage)))   ; contract-drift-is-silent
       (is (true? (:no-strategic-coverage? coverage)))
       (is (= {"operational" 6 "tactical" 1} (:horizon-mix coverage)))
-      (is (= "2026-06-07" (:newest-scar-date coverage))))))
+      (is (= "2026-06-07" (:newest-scar-date coverage))))
+    (testing "coverage confesses the §4.4 trigger has no data yet (§7.7)"
+      (is (= :untriggerable (:retirement coverage))))))
+
+(deftest ^{:stratum 1} consider-carries-the-per-peg-telemetry-basis
+  (let [{:keys [pegs]} (codex/consider fixture-dir "process-stuck-or-slow")]
+    (testing "every discriminator on the board is a presented peg (§7.7)"
+      (is (= ["already-failed-silently" "consuming-an-earlier-steps-output"
+              "is-there-progress-at-all" "reports-activity-while-stuck"
+              "started-in-the-intended-environment"]
+             (mapv :id pegs))))
+    (testing "each answer carries the landing set that follows it — exposes edges included (§4.4.1 routing relevance)"
+      (is (= {"yes" ["fail-closed-by-default" "infra-vs-domain-failure"]
+              "no" ["chained-work-identity" "contract-drift-is-silent"
+                    "environment-isolation" "liveness-detection"]}
+             (:answers (first (filter #(= "already-failed-silently" (:id %))
+                                      pegs))))))
+    (testing "a leaf peg's branches are single landings"
+      (is (= {"no" ["environment-isolation"] "yes" ["liveness-detection"]}
+             (:answers (first (filter #(= "started-in-the-intended-environment"
+                                          (:id %))
+                                      pegs))))))))
 
 (deftest ^{:stratum 1} landings-are-horizon-ordered
   (let [{:keys [landings]} (codex/consider fixture-dir "process-stuck-or-slow")

--- a/components/codex/test/ai/miniforge/codex/render_test.clj
+++ b/components/codex/test/ai/miniforge/codex/render_test.clj
@@ -41,7 +41,8 @@
               :coverage {:landing-count 2 :unanchored-count 1
                          :horizon-mix {"strategic" 1 "operational" 1}
                          :no-strategic-coverage? false
-                         :newest-scar-date "2026-01"}}
+                         :newest-scar-date "2026-01"
+                         :retirement :untriggerable}}
         text (codex/render-response resp)]
     (testing "strategic renders before operational (§7.6.1)"
       (is (< (str/index-of text "p-strategic") (str/index-of text "p-op"))))
@@ -50,7 +51,9 @@
       (is (str/includes? text "unanchored — reasoned, not survived")))
     (testing "coverage line leads with counts and §7.6.1-ordered mix (§7.5)"
       (is (str/includes? text "coverage: 2 landings, 1 unanchored"))
-      (is (str/includes? text "strategic 1 · operational 1")))))
+      (is (str/includes? text "strategic 1 · operational 1")))
+    (testing "coverage says the §4.4 retirement trigger has no data (§7.7)"
+      (is (str/includes? text "retirement: untriggerable")))))
 
 (deftest ^{:stratum 0} render-says-when-strategic-coverage-is-absent
   (let [resp {:situation "s1" :situation-title "t"
@@ -59,7 +62,8 @@
               :coverage {:landing-count 1 :unanchored-count 1
                          :horizon-mix {"tactical" 1}
                          :no-strategic-coverage? true
-                         :newest-scar-date nil}}
+                         :newest-scar-date nil
+                         :retirement :untriggerable}}
         text (codex/render-response resp)]
     (is (str/includes? text "NO STRATEGIC COVERAGE"))))
 
@@ -71,7 +75,10 @@
     (is (= ".miniforge/codex-consider.md" (:path entry)))
     (is (str/includes? (:content entry) "Pinned at phase start"))
     (is (str/includes? (:content entry) "situation: process-stuck-or-slow"))
-    (is (str/includes? (:content entry) "coverage:"))))
+    (is (str/includes? (:content entry) "coverage:"))
+    (testing "the §7.7 telemetry basis rides the entry, outside the file body"
+      (is (= 5 (count (:pegs entry))))
+      (is (not (str/includes? (:content entry) ":pegs"))))))
 
 (deftest ^{:stratum 0} pin-entry-surfaces-anomalies-instead-of-pinning-them
   (let [entry (codex/pin-entry "/nonexistent/codex" "anything" "x.md")]

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/codex_pin.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/codex_pin.clj
@@ -77,28 +77,33 @@
   "The pin attempt for `phase`, fully described:
    {:entry {:path :content}-or-nil
     :status :pinned | :unconfigured | :unmapped | :skipped
-    :anomaly keyword-or-nil}
+    :anomaly keyword-or-nil
+    :pegs [..]-or-nil}
    :unconfigured (no MINIFORGE_CODEX_PATH) and :unmapped (phase not in
    phase->situation) mean the capability is off — no noise. :skipped means a
    CONFIGURED codex failed to answer, which always warns: through the logger
    when one is given, else stderr — a nil logger must not turn the failure
-   silent (plan has no logger)."
+   silent (plan has no logger). :pegs is the consultation's §7.7 telemetry
+   basis; it rides the outcome, never the existing-files entry."
   ([phase logger] (pin-outcome phase logger (configured-codex-dir)))
   ([phase logger codex-dir]
    (let [situation (get phase->situation phase)]
      (cond
        (nil? codex-dir)
-       {:entry nil :status :unconfigured :anomaly nil :situation situation}
+       {:entry nil :status :unconfigured :anomaly nil :situation situation
+        :pegs nil}
 
        (nil? situation)
-       {:entry nil :status :unmapped :anomaly nil :situation nil}
+       {:entry nil :status :unmapped :anomaly nil :situation nil :pegs nil}
 
        :else
        (let [entry (codex/pin-entry codex-dir situation pin-path)]
          (if-let [anomaly (:codex/anomaly entry)]
            (do (warn-skip! phase logger anomaly (:codex/reason entry))
-               {:entry nil :status :skipped :anomaly anomaly :situation situation})
-           {:entry entry :status :pinned :anomaly nil :situation situation}))))))
+               {:entry nil :status :skipped :anomaly anomaly :situation situation
+                :pegs nil})
+           {:entry (select-keys entry [:path :content]) :status :pinned
+            :anomaly nil :situation situation :pegs (:pegs entry)}))))))
 
 (defn ^{:stratum 1} landings-outcome
   "Prompt-section delivery outcome for phases with no existing-files
@@ -111,18 +116,20 @@
    (let [situation (get phase->situation phase)]
      (cond
        (nil? codex-dir)
-       {:text nil :status :unconfigured :anomaly nil :situation situation}
+       {:text nil :status :unconfigured :anomaly nil :situation situation
+        :pegs nil}
 
        (nil? situation)
-       {:text nil :status :unmapped :anomaly nil :situation nil}
+       {:text nil :status :unmapped :anomaly nil :situation nil :pegs nil}
 
        :else
        (let [resp (codex/consider codex-dir situation)]
          (if-let [anomaly (:codex/anomaly resp)]
            (do (warn-skip! phase logger anomaly (:codex/reason resp))
-               {:text nil :status :skipped :anomaly anomaly :situation situation})
+               {:text nil :status :skipped :anomaly anomaly :situation situation
+                :pegs nil})
            {:text (codex/render-response resp) :status :pinned :anomaly nil
-            :situation situation}))))))
+            :situation situation :pegs (:pegs resp)}))))))
 
 (defn ^{:stratum 1} consultation-summary
   "The SPEC §7.4.3 distinct-object marker: a proposal from an agent that
@@ -130,12 +137,26 @@
    `context-reads` is the session's recorded context_read log (§7.4.2), or
    nil when the session did not surface one — then :pin-read? is nil
    (unknown), not false; absence of the record is not evidence of absence
-   of the read."
+   of the read.
+
+   :pegs is the §7.7 per-peg record: one row per peg the consultation
+   presented — {:id peg-id
+                :answer nil
+                :landings {answer [landing-ids-that-follow]}}.
+   :answer is nil because push delivery has no answer-capture channel yet;
+   the peg went unanswered, and §7.7 says record exactly that. The
+   :landings map keeps every branch's landing set so routing relevance
+   (both branches reaching the same problem set, §4.4.1) stays computable
+   from the record alone. nil (not []) when nothing was presented."
   [outcome context-reads]
   {:pinned?   (= :pinned (:status outcome))
    :status    (:status outcome)
    :anomaly   (:anomaly outcome)
    :situation (:situation outcome)
+   :pegs      (when-let [pegs (seq (:pegs outcome))]
+                (mapv (fn [{:keys [id answers]}]
+                        {:id id :answer nil :landings answers})
+                      pegs))
    :pin-read? (when (some? context-reads)
                 (boolean (some #(= pin-path (:path %)) context-reads)))})
 

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/codex_pin_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/codex_pin_test.clj
@@ -54,9 +54,9 @@
 
 (deftest ^{:stratum 0} pin-outcome-states
   (is (= {:entry nil :status :unconfigured :anomaly nil
-          :situation "changing-one-side-of-a-boundary"}
+          :situation "changing-one-side-of-a-boundary" :pegs nil}
          (codex-pin/pin-outcome :implement nil nil)))
-  (is (= {:entry nil :status :unmapped :anomaly nil :situation nil}
+  (is (= {:entry nil :status :unmapped :anomaly nil :situation nil :pegs nil}
          (codex-pin/pin-outcome :verify nil "/anywhere")))
   (is (= :skipped
          (:status (codex-pin/pin-outcome :implement nil "/nonexistent/codex")))))
@@ -73,6 +73,21 @@
                                pinned [{:path codex-pin/pin-path :source :cache}])))))
     (testing "skipped consultation carries its anomaly"
       (is (= {:pinned? false :status :skipped :anomaly :codex-unreadable
-              :situation nil :pin-read? nil}
+              :situation nil :pegs nil :pin-read? nil}
              (codex-pin/consultation-summary
                {:entry nil :status :skipped :anomaly :codex-unreadable} nil))))))
+
+(deftest ^{:stratum 0} consultation-summary-records-per-peg-telemetry
+  ;; SPEC §7.7: per peg presented, which way it answered — push delivery
+  ;; has no answer channel, so every presented peg records unanswered
+  ;; (:answer nil) with the landing set behind each branch kept intact.
+  (let [outcome {:entry {:path codex-pin/pin-path} :status :pinned
+                 :anomaly nil :situation "process-stuck-or-slow"
+                 :pegs [{:id "peg-a"
+                         :answers {"yes" ["p1"] "no" ["p2" "p3"]}}]}]
+    (is (= [{:id "peg-a" :answer nil
+             :landings {"yes" ["p1"] "no" ["p2" "p3"]}}]
+           (:pegs (codex-pin/consultation-summary outcome nil))))
+    (testing "no pegs presented records nil, not an empty claim"
+      (is (nil? (:pegs (codex-pin/consultation-summary
+                         (assoc outcome :pegs []) nil)))))))

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/gap_wiring_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/gap_wiring_test.clj
@@ -118,6 +118,29 @@
         (is (= "quality-signal-might-be-lying"
                (:miss/situation (first entries))))))))
 
+(deftest ^{:stratum 1} per-peg-telemetry-accrues-on-recorded-misses
+  ;; SPEC §7.7: the consultation summary the phase attached (shape pinned
+  ;; by codex-pin-test) carries :pegs; recording lifts them onto the
+  ;; entry's :miss/pegs — the ledger the retirement trigger reads.
+  (testing "pegs from the phase's consultation land on the ledger entry"
+    (let [dir (temp-root)
+          pegs [{:id "peg-a" :answer nil
+                 :landings {"yes" ["p1"] "no" ["p2"]}}]
+          ctx (run-ctx dir "run-p"
+                       :phase {:result
+                               {:output
+                                {:review/blocking-issues ["boom"]
+                                 :codex/consultation
+                                 {:pinned? true :status :pinned :anomaly nil
+                                  :situation "quality-signal-might-be-lying"
+                                  :pegs pegs :pin-read? nil}}}})]
+      (gap-wiring/record-phase-misses! ctx :review "/nonexistent/codex")
+      (let [{:keys [entries]} (gap/read-ledger (str dir "/run-p"))]
+        (is (= 1 (count entries)))
+        (is (= pegs (:miss/pegs (first entries))))
+        (is (nil? (get-in (first entries) [:miss/consultation :pegs]))
+            "writer-normalized: pegs live at :miss/pegs only")))))
+
 (deftest ^{:stratum 1} ledger-write-failure-warns-through-the-context-logger
   ;; The workflow runner normalizes :execution/logger at context creation
   ;; (workflow.context), so this warn path is live in production runs —


### PR DESCRIPTION
## What

Implements Thesium Codex SPEC T1 §7.7 (per-peg consultation telemetry, feeding the §4.4 retirement test), plus the §7.5 coverage-vector confession required until the trigger has data.

1. `consider` responses now carry `:pegs` — every discriminator the consultation presents (id-sorted), each with the landing set every answer routes to (new `ai.miniforge.codex.pegs` namespace; `graph/as-edge-list` made public for it).
2. Consultation provenance (`consultation-summary`, attached to phase results as `:codex/consultation`) records one row per presented peg: which way it answered — today always unanswered (`:answer nil`; push delivery has no answer-capture channel, and §7.7 says record exactly that) — and the landing set behind each branch, so routing relevance (both branches reaching the same problem set) stays computable from the record alone.
3. The codex-gap ledger's `build-entry` is extended (not forked): it lifts the consultation's pegs to `:miss/pegs` and strips them from the stored consultation — writer-normalized, one canonical location per datum. The telemetry accrues in the ledger the gap instrument already writes; no new collection surface (§7.7).
4. The §7.5 coverage vector gains `:retirement :untriggerable`, rendered through the message catalog as `retirement: untriggerable` on the coverage line — the §4.4 trigger has no answer distribution to compute over until an answer-capture channel exists, and that absence must be visible rather than silent.

## T2 bucket drained

`:unheeded` (the attention slot, T2 §4.1.5). §7.7 telemetry is the trigger data for the §4.4 peg-retirement test; retirable pegs cut the per-consultation attention tax that §4.4 names as the cost of inert pegs — the mechanism behind delivered-but-unheeded landings.

## Testing

1. Full `poly test` over changed bricks + dependents: exit 0.
2. The five touched test namespaces plus the new assertions directly: 44 tests, 130 assertions, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)