### PR TITLE
refactor(cli): split workflow_runner/help.clj — flag table + usage rendering (rule 210)

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/help.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/help.clj
@@ -20,129 +20,52 @@
    subcommands (`workflow run/list/execute/status/cancel` and
    `chain run/list`).
 
+   The usage strings themselves live in `...help.usage`; this namespace
+   is the dispatch-facing side — flag detection, printing, and the
+   handler factories `main.clj` wires into its dispatch table.
+
    Stratification:
-   Layer 0 — pure predicates and the babashka.cli `:spec` filter that
-             strips the help-flag entry so it doesn't appear in its own
-             usage block.
-   Layer 1 — `usage-text` / `group-usage-text` compose localized
-             usage strings from a registry entry.
-   Layer 2 — `print-usage!` / `print-group-usage!` are the
-             side-effecting handlers and the `handler-with-help` /
-             `group-handler` factories the dispatch table wires in."
+   Layer 0 — the `--help` predicate and the stdout printers.
+   Layer 1 — the `handler-with-help` / `group-handler` factories the
+             dispatch table wires in."
   (:require
-   [babashka.cli :as cli]
-   [clojure.string :as str]
-   [ai.miniforge.cli.app-config :as app-config]
-   [ai.miniforge.cli.messages :as messages]
-   [ai.miniforge.cli.workflow-runner.help.registry :as registry]))
+   [ai.miniforge.cli.workflow-runner.help.registry :as registry]
+   [ai.miniforge.cli.workflow-runner.help.usage :as usage]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
-(def ^{:stratum 0} help-flag-keys
-  "Keys reserved for the help flag itself. Stripped from the usage
-   table so `--help` doesn't appear inside its own description block."
-  #{:help})
+;; Relocated public vars re-exported so existing `:require [...
+;; workflow-runner.help :as wr-help]` call sites resolve unchanged —
+;; same convention as the workflow_runner.clj split (miniforge#1667).
+(def ^{:stratum 0} usage-text usage/usage-text)
+
+(def ^{:stratum 0} group-usage-text usage/group-usage-text)
 
 (defn ^{:stratum 0} help-requested?
   "Truthy when the parsed `opts` map carries the `--help` / `-h` flag."
   [opts]
   (boolean (:help opts)))
 
-(defn- ^{:stratum 0} usage-line
-  "First-line usage banner for a subcommand."
-  [subcommand positional]
-  (let [binary (app-config/binary-name)
-        positionals (when (seq positional)
-                      (->> positional
-                           (map (fn [k] (str "<" (name k) ">")))
-                           (str/join " ")))]
-    (->> [binary subcommand positionals "[options]"]
-         (remove str/blank?)
-         (str/join " "))))
+(defn ^{:stratum 0} print-usage!
+  "Print the localized usage block for `entry` to stdout."
+  [entry]
+  (println (usage/usage-text entry)))
 
-(defn ^{:stratum 0} group-usage-text
-  "Render the localized parent-level usage block for a subcommand group."
-  [{:keys [group summary-key subcommands]}]
-  (let [usage    (messages/t :workflow-runner.help/group-usage-prefix
-                             {:line (str (app-config/binary-name)
-                                         " "
-                                         group
-                                         " <subcommand> [options]")})
-        summary  (messages/t summary-key)
-        row-text (fn [entry]
-                   (messages/t :workflow-runner.help/group-subcommand-row
-                               {:name    (:name entry)
-                                :summary (messages/t (:summary-key entry))}))
-        rows     (map row-text subcommands)]
-    (->> [(messages/t :workflow-runner.help/group-heading {:group group})
-          summary
-          ""
-          usage
-          ""
-          (messages/t :workflow-runner.help/group-subcommands-heading)
-          (str/join "\n" rows)]
-         (str/join "\n"))))
+(defn ^{:stratum 0} print-group-usage!
+  "Print the localized parent-level usage block for `group-entry`."
+  [group-entry]
+  (println (usage/group-usage-text group-entry)))
 
 ;------------------------------------------------------------------------------ Layer 1
 
-(defn- ^{:stratum 1} without-help-flag
-  "Drop the help flag from a babashka.cli `:spec` map so it doesn't
-   appear inside the flag table its presence triggered."
-  [spec]
-  (into {} (remove (fn [[k _]] (contains? help-flag-keys k))) spec))
-
-(defn ^{:stratum 1} print-group-usage!
-  "Print the localized parent-level usage block for `group-entry`."
-  [group-entry]
-  (println (group-usage-text group-entry)))
-
-;------------------------------------------------------------------------------ Layer 2
-
-(defn- ^{:stratum 2} flag-table
-  "Auto-generate the flag table from a babashka.cli `:spec`. Returns
-   nil when the (filtered) spec has no entries."
-  [spec]
-  (let [filtered (without-help-flag spec)]
-    (when (seq filtered)
-      (cli/format-opts {:spec filtered}))))
-
-(defn ^{:stratum 2} group-handler
+(defn ^{:stratum 1} group-handler
   "Return a dispatch handler that prints the group-level usage block
    for `group-entry` (e.g. `registry/workflow-group-help`)."
   [group-entry]
   (fn group-help-handler [_m]
     (print-group-usage! group-entry)))
 
-;------------------------------------------------------------------------------ Layer 3
-
-(defn ^{:stratum 3} usage-text
-  "Render the full localized usage block for a registry entry."
-  [{:keys [subcommand summary-key spec positional]}]
-  (let [usage   (messages/t :workflow-runner.help/usage-prefix
-                            {:line (usage-line subcommand positional)})
-        summary (messages/t summary-key)
-        table   (flag-table spec)]
-    (->> [(messages/t :workflow-runner.help/subcommand-heading
-                      {:subcommand subcommand})
-          summary
-          ""
-          usage
-          (when table
-            (messages/t :workflow-runner.help/options-heading))
-          table]
-         (remove nil?)
-         (str/join "\n"))))
-
-;------------------------------------------------------------------------------ Layer 4
-
-(defn ^{:stratum 4} print-usage!
-  "Print the localized usage block for `entry` to stdout."
-  [entry]
-  (println (usage-text entry)))
-
-;------------------------------------------------------------------------------ Layer 5
-
-(defn ^{:stratum 5} handler-with-help
+(defn ^{:stratum 1} handler-with-help
   "Wrap a dispatch handler `cmd-fn` so that `--help` / `-h` short-circuits
    to a localized usage block. `subcommand-key` is one of the keys in
    `registry/subcommands` (e.g. `:workflow-run`)."

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/help/flags.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/help/flags.clj
@@ -1,0 +1,52 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.workflow-runner.help.flags
+  "The `Options:` table inside a workflow-runner subcommand's `--help`
+   block, generated from the babashka.cli `:spec` the registry holds.
+
+   Stratification:
+   Layer 0 — the keys reserved for the help flag itself.
+   Layer 1 — the `:spec` filter that strips them.
+   Layer 2 — `flag-table` renders what survives the filter."
+  (:require
+   [babashka.cli :as cli]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} help-flag-keys
+  "Keys reserved for the help flag itself. Stripped from the usage
+   table so `--help` doesn't appear inside its own description block."
+  #{:help})
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} without-help-flag
+  "Drop the help flag from a babashka.cli `:spec` map so it doesn't
+   appear inside the flag table its presence triggered."
+  [spec]
+  (into {} (remove (fn [[k _]] (contains? help-flag-keys k))) spec))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} flag-table
+  "Auto-generate the flag table from a babashka.cli `:spec`. Returns
+   nil when the (filtered) spec has no entries."
+  [spec]
+  (let [filtered (without-help-flag spec)]
+    (when (seq filtered)
+      (cli/format-opts {:spec filtered}))))

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/help/usage.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/help/usage.clj
@@ -1,0 +1,90 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.workflow-runner.help.usage
+  "Localized usage blocks rendered from a registry entry: the
+   per-subcommand block behind `mf workflow run --help` and the
+   parent listing behind `mf workflow --help`.
+
+   Rendering only — the strings are returned, never printed.
+
+   Stratification:
+   Layer 0 — the usage banner line and the group-level block.
+   Layer 1 — `usage-text` composes heading, summary, banner and the
+             generated flag table into the subcommand block."
+  (:require
+   [clojure.string :as str]
+   [ai.miniforge.cli.app-config :as app-config]
+   [ai.miniforge.cli.messages :as messages]
+   [ai.miniforge.cli.workflow-runner.help.flags :as flags]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} usage-line
+  "First-line usage banner for a subcommand."
+  [subcommand positional]
+  (let [binary (app-config/binary-name)
+        positionals (when (seq positional)
+                      (->> positional
+                           (map (fn [k] (str "<" (name k) ">")))
+                           (str/join " ")))]
+    (->> [binary subcommand positionals "[options]"]
+         (remove str/blank?)
+         (str/join " "))))
+
+(defn ^{:stratum 0} group-usage-text
+  "Render the localized parent-level usage block for a subcommand group."
+  [{:keys [group summary-key subcommands]}]
+  (let [usage    (messages/t :workflow-runner.help/group-usage-prefix
+                             {:line (str (app-config/binary-name)
+                                         " "
+                                         group
+                                         " <subcommand> [options]")})
+        summary  (messages/t summary-key)
+        row-text (fn [entry]
+                   (messages/t :workflow-runner.help/group-subcommand-row
+                               {:name    (:name entry)
+                                :summary (messages/t (:summary-key entry))}))
+        rows     (map row-text subcommands)]
+    (->> [(messages/t :workflow-runner.help/group-heading {:group group})
+          summary
+          ""
+          usage
+          ""
+          (messages/t :workflow-runner.help/group-subcommands-heading)
+          (str/join "\n" rows)]
+         (str/join "\n"))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} usage-text
+  "Render the full localized usage block for a registry entry."
+  [{:keys [subcommand summary-key spec positional]}]
+  (let [usage   (messages/t :workflow-runner.help/usage-prefix
+                            {:line (usage-line subcommand positional)})
+        summary (messages/t summary-key)
+        table   (flags/flag-table spec)]
+    (->> [(messages/t :workflow-runner.help/subcommand-heading
+                      {:subcommand subcommand})
+          summary
+          ""
+          usage
+          (when table
+            (messages/t :workflow-runner.help/options-heading))
+          table]
+         (remove nil?)
+         (str/join "\n"))))


### PR DESCRIPTION
## Summary

`bases/cli/src/ai/miniforge/cli/workflow_runner/help.clj` measured **6 real strata** (stratum-lint SL003, max 3). Move-only split into the existing `workflow_runner/help/` subdirectory, alongside the sibling `help/registry.clj`:

- **`help/flags.clj`** (new, 3 layers) — the `Options:` table generated from a babashka.cli `:spec`: `help-flag-keys`, `without-help-flag`, `flag-table`.
- **`help/usage.clj`** (new, 2 layers) — the localized usage blocks rendered from a registry entry: `usage-line`, `usage-text`, `group-usage-text`. Rendering only; nothing prints.
- **`help.clj`** (2 layers, down from 6) — the dispatch-facing side that stays: `help-requested?`, `print-usage!`, `print-group-usage!`, `group-handler`, `handler-with-help`.

`usage-text` and `group-usage-text` are re-exported from `help.clj` so existing call sites resolve unchanged — same convention as the `workflow_runner.clj` split (#1667). `main.clj` only uses `group-handler` / `handler-with-help`, both unmoved.

Two commits: the new namespaces land standalone first (parent untouched, still over budget), then the flip rewrites `help.clj` SL003-clean in the same commit that deletes the moved code.

## Why

Rule 210 (per-file stratified design, ≤3 strata) — `help.clj` was the last SL003 offender in this file's own tree apart from `help/registry.clj`, which is untouched here and remains over budget (pre-existing, separate slice).

No logic changes: every moved form is verbatim. The only edits are the ns forms, headings, and `^{:stratum n}` metadata recomputed for the new files.

## Testing

- `stratum-lint` (pin `bef8657a`) plain: clean on all three files.
- `stratum-lint --fix` dry-run on copies: no stratum changes (one blank-line insertion, applied).
- `clj-kondo`: 0 errors, 0 warnings on the touched files.
- `help_test.clj` + `help/registry_test.clj`: 13 tests, 76 assertions, 0 failures — unchanged, no redef/require targets needed updating (no `with-redefs` on moved vars).
- Pre-commit gate (342 tests / 1291 assertions smoke + GraalVM compat) passed on both commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)