### PR TITLE
refactor(cli): split workflow_runner/sandbox.clj — clone target (rule 210)

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/sandbox.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/sandbox.clj
@@ -24,7 +24,8 @@
    `ai.miniforge.cli.workflow-runner.sandbox-clone-target`.
 
    Stratification (intra-namespace):
-   Layer 0 — `sandbox-release-fn`, `prepare-sandbox` (no in-ns deps).
+   Layer 0 — `sandbox-release-fn`, the `infer-branch` / `infer-repo-url`
+             re-exports, `prepare-sandbox` (no in-ns deps).
    Layer 1 — `setup-sandbox-context` (composes Layer 0)."
   (:require
    [ai.miniforge.cli.runtime-env :as runtime-env]

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/sandbox.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/sandbox.clj
@@ -20,17 +20,16 @@
    the host's container runtime is auto-selected (Podman first, Docker
    second), with MINIFORGE_RUNTIME as the explicit override.
 
+   The repo/branch the container checks out is resolved by
+   `ai.miniforge.cli.workflow-runner.sandbox-clone-target`.
+
    Stratification (intra-namespace):
-   Layer 0 — `sandbox-release-fn`, `git-remote-url`, `infer-branch`
-             (no in-ns deps).
-   Layer 1 — `infer-repo-url` (composes `git-remote-url`).
-   Layer 2 — `prepare-sandbox` (composes Layer 1).
-   Layer 3 — `setup-sandbox-context` (composes Layer 2)."
+   Layer 0 — `sandbox-release-fn`, `prepare-sandbox` (no in-ns deps).
+   Layer 1 — `setup-sandbox-context` (composes Layer 0)."
   (:require
-   [clojure.string :as str]
-   [babashka.process :as p]
    [ai.miniforge.cli.runtime-env :as runtime-env]
    [ai.miniforge.cli.workflow-runner.display :as display]
+   [ai.miniforge.cli.workflow-runner.sandbox-clone-target :as clone-target]
    [ai.miniforge.dag-executor.interface :as dag]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -42,39 +41,15 @@
       (dag/release-environment! executor environment-id)
       (catch Exception _ nil))))
 
-(defn- ^{:stratum 0} git-remote-url
-  "Get git remote origin URL from a directory. Returns nil on failure."
-  [dir]
-  (try
-    (let [result (p/shell {:out :string :err :string :continue true :dir dir}
-                          "git" "remote" "get-url" "origin")]
-      (when (zero? (:exit result))
-        (str/trim (:out result))))
-    (catch Exception _ nil)))
+;; Relocated public vars re-exported so existing `:require [...
+;; workflow-runner.sandbox :as sandbox]` call sites resolve unchanged —
+;; same convention as the workflow-runner split (miniforge#1667).
+(def ^{:stratum 0} infer-branch clone-target/infer-branch)
 
-(defn ^{:stratum 0} infer-branch [spec enriched-spec]
-  (or (:spec/branch spec)
-      (get-in enriched-spec [:spec/context :git-branch])
-      "main"))
+(def ^{:stratum 0} infer-repo-url clone-target/infer-repo-url)
 
-;------------------------------------------------------------------------------ Layer 1
-
-;; Composes Layer 0.
-(defn ^{:stratum 1} infer-repo-url [spec enriched-spec]
-  (or (:spec/repo-url spec)
-      (get-in enriched-spec [:spec/context :repo-url])
-      ;; If spec came from a file in a different repo, use that repo's remote.
-      ;; :spec/source-dir is set by the run command from the spec file's parent.
-      (when-let [source-dir (:spec/source-dir spec)]
-        (git-remote-url source-dir))
-      ;; Final fallback: cwd's repo
-      (git-remote-url ".")))
-
-;------------------------------------------------------------------------------ Layer 2
-
-;; Sandbox preparation — composes Layer 1 (`infer-repo-url`) plus
-;; Layer 0 (`infer-branch`).
-(defn ^{:stratum 2} prepare-sandbox [spec enriched-spec]
+;; Sandbox preparation — expressed in the clone-target vocabulary.
+(defn ^{:stratum 0} prepare-sandbox [spec enriched-spec]
   (let [prep-result (dag/prepare-runtime-executor!
                      (runtime-env/selection-config {:image-type :clojure}))]
     (if-not (dag/ok? prep-result)
@@ -86,18 +61,18 @@
         (if-not (dag/ok? env-result)
           env-result
           (let [env-id (:environment-id (dag/unwrap env-result))
-                repo-url (infer-repo-url spec enriched-spec)
-                branch (infer-branch spec enriched-spec)]
+                repo-url (clone-target/infer-repo-url spec enriched-spec)
+                branch (clone-target/infer-branch spec enriched-spec)]
             (when repo-url
               (dag/clone-and-checkout! executor env-id repo-url branch {}))
             (dag/ok {:executor executor
                      :environment-id env-id
                      :sandbox-workdir "/workspace"})))))))
 
-;------------------------------------------------------------------------------ Layer 3
+;------------------------------------------------------------------------------ Layer 1
 
-;; Composes Layer 2.
-(defn ^{:stratum 3} setup-sandbox-context [base-context sandbox? spec enriched-spec quiet]
+;; Composes Layer 0.
+(defn ^{:stratum 1} setup-sandbox-context [base-context sandbox? spec enriched-spec quiet]
   (if-not sandbox?
     [base-context nil]
     (do

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/sandbox_clone_target.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/sandbox_clone_target.clj
@@ -1,0 +1,58 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.workflow-runner.sandbox-clone-target
+  "Which repository and branch a sandbox container should check out.
+   Resolves the clone target from the work spec, then the enriched spec's
+   context, then the git remote of the spec's source directory, then the
+   current working directory's remote. Split out of
+   `ai.miniforge.cli.workflow-runner.sandbox` (rule 210: the parent
+   namespace measured 4 real layers, max 3)."
+  (:require
+   [clojure.string :as str]
+   [babashka.process :as p]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; No in-namespace dependencies.
+(defn- ^{:stratum 0} git-remote-url
+  "Get git remote origin URL from a directory. Returns nil on failure."
+  [dir]
+  (try
+    (let [result (p/shell {:out :string :err :string :continue true :dir dir}
+                          "git" "remote" "get-url" "origin")]
+      (when (zero? (:exit result))
+        (str/trim (:out result))))
+    (catch Exception _ nil)))
+
+(defn ^{:stratum 0} infer-branch [spec enriched-spec]
+  (or (:spec/branch spec)
+      (get-in enriched-spec [:spec/context :git-branch])
+      "main"))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Composes Layer 0.
+(defn ^{:stratum 1} infer-repo-url [spec enriched-spec]
+  (or (:spec/repo-url spec)
+      (get-in enriched-spec [:spec/context :repo-url])
+      ;; If spec came from a file in a different repo, use that repo's remote.
+      ;; :spec/source-dir is set by the run command from the spec file's parent.
+      (when-let [source-dir (:spec/source-dir spec)]
+        (git-remote-url source-dir))
+      ;; Final fallback: cwd's repo
+      (git-remote-url ".")))


### PR DESCRIPTION
## Summary

`bases/cli/src/ai/miniforge/cli/workflow_runner/sandbox.clj` measured 4 real strata; the per-file budget (rule 210, stratum-lint SL003) is 3. The clone-target vocabulary — which repository URL and which branch a sandbox container should check out — moves to a sibling namespace, `ai.miniforge.cli.workflow-runner.sandbox-clone-target`.

Split shape:

- `sandbox-clone-target.clj` (new): `git-remote-url` (private, Layer 0), `infer-branch` (Layer 0), `infer-repo-url` (Layer 1) — 2 real strata.
- `sandbox.clj`: `sandbox-release-fn`, the two re-exports, `prepare-sandbox` (Layer 0); `setup-sandbox-context` (Layer 1) — 2 real strata. `prepare-sandbox` now has no in-namespace dependencies, so it drops from Layer 2 to Layer 0.

`infer-branch` and `infer-repo-url` are re-exported as `(def name clone-target/name)` because `workflow_runner.clj` calls both directly — same convention as the workflow_runner split (#1667) and the dag-orchestrator split (#1485). Everything moved is verbatim; no behavior change.

Commit 1 adds the new namespace standalone (unused, parent untouched); commit 2 is the flip, SL003-clean in the same commit.

## Why

SL003 layer budget: 4 real strata, max 3. Rule 210 says a file wanting a fourth band is the signal to split the namespace, not to flatten real strata.

## Testing

- stratum-lint (pinned sha `bef8657a`) plain pass and `--fix` dry-run on copies: both files clean, no fixer-suggested restratification.
- `clj-kondo`: 0 errors, 0 warnings on both files.
- `clojure -M:dev:test` over `workflow-runner.kanban-test`, `manifest-wiring-test`, `runner-control-wiring-test`, `alias-test`: 30 tests, 60 assertions, 0 failures, 0 errors.
- REPL smoke: `ai.miniforge.cli.workflow-runner` loads and both re-exported vars resolve.
- No test namespace references any moved var, so no redef targets needed updating.
- Pre-commit gate (smoke + GraalVM/bb compatibility, 607 assertions) passed on both commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)