### PR TITLE
refactor(cli): split workflow_runner/context.clj — git checkout state (rule 210)

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/context.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/context.clj
@@ -16,15 +16,15 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns ai.miniforge.cli.workflow-runner.context
-  "Workflow input resolution and runtime context creation."
+  "Workflow input resolution and runtime context creation. Git checkout
+   state lives in `ai.miniforge.cli.workflow-runner.context-git`."
   (:require
    [clojure.edn :as edn]
-   [clojure.java.shell :as shell]
-   [clojure.string :as str]
    [babashka.fs :as fs]
    [cheshire.core :as json]
    [ai.miniforge.cli.config :as config]
    [ai.miniforge.cli.worktree :as worktree]
+   [ai.miniforge.cli.workflow-runner.context-git :as git]
    [ai.miniforge.cli.workflow-runner.display :as display]
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.llm.interface :as llm]
@@ -57,12 +57,6 @@
         (response/throw-anomaly! :anomalies/fault
                                 (str "Failed to parse input JSON: " (ex-message e))
                                 {:input s})))))
-
-(defn- ^{:stratum 0} resolve-git-field
-  [dir & args]
-  (let [{:keys [exit out]} (apply shell/sh (concat ["git"] args [:dir dir]))]
-    (when (zero? exit)
-      (some-> out str/trim not-empty))))
 
 (defn- ^{:stratum 0} execution-worktree-path
   [execution-opts]
@@ -141,45 +135,10 @@
     input (read-input-file input)
     :else {}))
 
-(defn- ^{:stratum 1} resolve-git-bool
-  [dir & args]
-  (boolean (apply resolve-git-field dir args)))
-
-(defn ^{:stratum 1} get-git-info
-  ([] (get-git-info nil))
-  ([start-path]
-   (try
-     (when-let [root (worktree/worktree-root start-path)]
-       (let [branch (resolve-git-field root "rev-parse" "--abbrev-ref" "HEAD")
-             commit (resolve-git-field root "rev-parse" "--short" "HEAD")]
-         (when (and branch commit)
-           {:git-branch branch
-            :git-commit commit})))
-     (catch Exception _ nil))))
-
-;------------------------------------------------------------------------------ Layer 2
-
-(defn ^{:stratum 2} get-git-state
-  ([] (get-git-state nil))
-  ([start-path]
-   (try
-     (when-let [root (worktree/worktree-root start-path)]
-       (let [branch (resolve-git-field root "rev-parse" "--abbrev-ref" "HEAD")
-             commit (resolve-git-field root "rev-parse" "--short" "HEAD")
-             upstream (resolve-git-field root "rev-parse" "--abbrev-ref" "--symbolic-full-name" "@{upstream}")
-             dirty? (resolve-git-bool root "status" "--porcelain")]
-         (when (and branch commit)
-           {:git-branch branch
-            :git-commit commit
-            :git-upstream upstream
-            :git-dirty? dirty?
-            :git-detached? (= "HEAD" branch)})))
-     (catch Exception _ nil))))
-
 ;; Context decoration
-(defn ^{:stratum 2} decorate-spec-with-runtime-context [spec {:keys [iteration parent-task-id] :or {iteration 1}}]
+(defn ^{:stratum 1} decorate-spec-with-runtime-context [spec {:keys [iteration parent-task-id] :or {iteration 1}}]
   (let [cwd (or (worktree/worktree-root) (str (fs/cwd)))
-        git-info (get-git-info cwd)
+        git-info (git/get-git-info cwd)
         files-in-scope (get-files-in-scope (:spec/intent spec))]
     (assoc spec
            :spec/context
@@ -194,10 +153,8 @@
                     :iteration iteration}
              parent-task-id (assoc :parent-task-id parent-task-id)))))
 
-;------------------------------------------------------------------------------ Layer 3
-
 ;; Workflow context assembly
-(defn ^{:stratum 3} create-workflow-context [{:keys [callbacks artifact-store event-stream workflow-id
+(defn ^{:stratum 1} create-workflow-context [{:keys [callbacks artifact-store event-stream workflow-id
                                        workflow-type workflow-version llm-client quiet
                                        spec-title control-state skip-lifecycle-events
                                        execution-opts source-dir
@@ -205,7 +162,7 @@
   (let [on-chunk (es/create-streaming-callback event-stream workflow-id :agent
                                                {:print? (not quiet) :quiet? quiet})
         source-root (source-root-path source-dir)
-        git-info (get-git-state source-root)
+        git-info (git/get-git-state source-root)
         worktree-path (or (execution-worktree-path execution-opts)
                           (worktree/worktree-root)
                           (System/getProperty "user.dir"))]

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/context_git.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/context_git.clj
@@ -1,0 +1,74 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.workflow-runner.context-git
+  "Git checkout state for a workflow run: single-field `git` queries,
+   the branch/commit pair stamped into a spec's runtime context, and
+   the fuller upstream/dirty/detached snapshot stamped into a workflow
+   context. Split out of `ai.miniforge.cli.workflow-runner.context`
+   (rule 210: the parent namespace measured 4 real layers, max 3; this
+   probe chain was its whole depth — same approach as the
+   workflow-runner split, miniforge#1662-#1667)."
+  (:require
+   [clojure.java.shell :as shell]
+   [clojure.string :as str]
+   [ai.miniforge.cli.worktree :as worktree]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} resolve-git-field
+  [dir & args]
+  (let [{:keys [exit out]} (apply shell/sh (concat ["git"] args [:dir dir]))]
+    (when (zero? exit)
+      (some-> out str/trim not-empty))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} resolve-git-bool
+  [dir & args]
+  (boolean (apply resolve-git-field dir args)))
+
+(defn ^{:stratum 1} get-git-info
+  ([] (get-git-info nil))
+  ([start-path]
+   (try
+     (when-let [root (worktree/worktree-root start-path)]
+       (let [branch (resolve-git-field root "rev-parse" "--abbrev-ref" "HEAD")
+             commit (resolve-git-field root "rev-parse" "--short" "HEAD")]
+         (when (and branch commit)
+           {:git-branch branch
+            :git-commit commit})))
+     (catch Exception _ nil))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} get-git-state
+  ([] (get-git-state nil))
+  ([start-path]
+   (try
+     (when-let [root (worktree/worktree-root start-path)]
+       (let [branch (resolve-git-field root "rev-parse" "--abbrev-ref" "HEAD")
+             commit (resolve-git-field root "rev-parse" "--short" "HEAD")
+             upstream (resolve-git-field root "rev-parse" "--abbrev-ref" "--symbolic-full-name" "@{upstream}")
+             dirty? (resolve-git-bool root "status" "--porcelain")]
+         (when (and branch commit)
+           {:git-branch branch
+            :git-commit commit
+            :git-upstream upstream
+            :git-dirty? dirty?
+            :git-detached? (= "HEAD" branch)})))
+     (catch Exception _ nil))))


### PR DESCRIPTION
## Summary

`bases/cli/src/ai/miniforge/cli/workflow_runner/context.clj` (231 lines) measured **4 real strata** — stratum-lint SL003, max 3. The git checkout probe was the whole of that depth: `resolve-git-field` (L0) → `resolve-git-bool` / `get-git-info` (L1) → `get-git-state` (L2), a three-deep spine under a file whose other work is flat.

That spine moves, move-only, to a sibling namespace `ai.miniforge.cli.workflow-runner.context-git` — "git checkout state for a workflow run": single-field `git` queries, the branch/commit pair stamped into a spec's runtime context, and the fuller upstream/dirty/detached snapshot stamped into a workflow context.

Result: `context.clj` measures **2** real strata, `context_git.clj` measures **3**. Both SL003 clean.

Two commits, per the split precedent (#1662–#1667): commit 1 adds the new namespace standalone (parent untouched, still over budget); commit 2 is the flip (parent requires it, moved defs deleted, SL003-clean in that commit).

## Why

Rule 210 (`standards/miniforge/languages/clojure.mdc`) caps a namespace at 3 labeled strata; a file wanting a fourth band is the signal to split, not to flatten. `stratum-lint` SL003 enforces it and the pre-commit gate fails on it.

## Public interface

Unchanged. `context.clj` is required by `workflow_runner.clj`, `chain.clj`, `main/commands/plan_executor.clj`, `main/commands/resume.clj`, `context_test.clj`, `runner_control_wiring_test.clj` and `resume_test.clj`. Every one of those uses `resolve-input`, `create-llm-client`, `decorate-spec-with-runtime-context`, `spec->workflow-input` or `create-workflow-context` — all of which stay put. The moved vars had no external callers, so there are no re-export shims and no `with-redefs` target changes.

## Testing

- `stratum-lint` (pin `bef8657a`) plain pass on both files: clean.
- `stratum-lint --fix` dry-run on copies of both files: no diff, so the hand-written strata match what the reference graph computes (plain lint does not catch too-shallow hand strata).
- `clj-kondo` on both touched files: 0 errors, 0 warnings.
- `context-test`, `runner-control-wiring-test`, `kanban-test`, `resume-test`: 23 tests, 73 assertions, 0 failures, 0 errors.
- Pre-commit gate (smoke + GraalVM/bb compatibility) passed on both commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)