### PR TITLE
fix(cli): resolve CLI paths portably in the workflow runner

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/paths.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/paths.clj
@@ -26,7 +26,10 @@
   (:require
    [babashka.fs :as fs]
    [clojure.string :as str]
-   [ai.miniforge.response.interface :as response]))
+   [ai.miniforge.response.interface :as response])
+  (:import
+   (java.io File)
+   (java.util.regex Pattern)))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -58,9 +61,9 @@
   [cmd]
   (boolean (re-find #"[\\/]" (or cmd ""))))
 
-(defn- ^{:stratum 0} path-entries
-  []
-  (str/split (or (System/getenv "PATH") "") #":"))
+(defn- ^{:stratum 0} split-path-entries
+  [raw-path]
+  (str/split (or raw-path "") (re-pattern (Pattern/quote File/pathSeparator))))
 
 ;------------------------------------------------------------------------------ Layer 1
 
@@ -71,11 +74,9 @@
              fs/path
              fs/absolutize))))
 
-(defn- ^{:stratum 1} matching-command-path
-  [entry cmd]
-  (let [candidate (fs/path entry cmd)]
-    (when (executable-file? candidate)
-      (str candidate))))
+(defn- ^{:stratum 1} path-entries
+  []
+  (split-path-entries (System/getenv "PATH")))
 
 (defn- ^{:stratum 1} source-dir-under-root?
   [source-dir source-root]
@@ -108,20 +109,6 @@
 
 ;------------------------------------------------------------------------------ Layer 2
 
-(defn ^{:stratum 2} resolve-cli-command-path
-  "Absolute path of `cmd` when it resolves to an executable: a direct
-   path is normalized in place; a bare command is looked up via
-   `fs/which` and then, as a fallback, by scanning PATH entries."
-  [cmd]
-  (cond
-    (str/blank? cmd) nil
-    (direct-command-path? cmd)
-    (normalize-command-path cmd)
-
-    :else
-    (or (some-> cmd fs/which str normalize-command-path)
-        (some #(matching-command-path % cmd) (path-entries)))))
-
 (defn ^{:stratum 2} assert-source-dir-alignment!
   [spec context]
   (let [source-dir (:spec/source-dir spec)
@@ -133,3 +120,19 @@
                                {:source-dir source-dir
                                 :source-root source-root
                                 :worktree-path (:worktree-path context)}))))
+
+(defn ^{:stratum 2} resolve-cli-command-path
+  "Absolute path of `cmd` when it resolves to an executable: a direct
+   path is normalized in place; a bare command is looked up via
+   `fs/which` and then, as a fallback, by scanning PATH entries. Every
+   branch goes through `normalize-command-path`, so a relative PATH
+   entry still yields an absolute result."
+  [cmd]
+  (cond
+    (str/blank? cmd) nil
+    (direct-command-path? cmd)
+    (normalize-command-path cmd)
+
+    :else
+    (or (some-> cmd fs/which str normalize-command-path)
+        (some #(normalize-command-path (fs/path % cmd)) (path-entries)))))

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/paths_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/paths_test.clj
@@ -31,8 +31,6 @@
    delimiter here: `;` on POSIX, `:` on Windows."
   (if (= ";" File/pathSeparator) ":" ";"))
 
-(def ^{:stratum 0} ^:private executable-permissions "rwxr-xr-x")
-
 (defn- ^{:stratum 0} join-path-entries
   [entries]
   (str/join File/pathSeparator entries))
@@ -41,18 +39,15 @@
   [dir]
   (str (fs/relativize (fs/cwd) dir)))
 
-;------------------------------------------------------------------------------ Layer 1
+(defn- ^{:stratum 0} mark-executable!
+  "POSIX permission bits do not exist on Windows, where `File/setExecutable`
+   is the only way to set the bit this test's subject reads."
+  [path]
+  (if (fs/windows?)
+    (.setExecutable ^java.io.File (fs/file path) true)
+    (fs/set-posix-file-permissions path "rwxr-xr-x")))
 
-(defn- ^{:stratum 1} temp-executable
-  "Creates an executable file with a name no real PATH lookup can resolve, so
-   `fs/which` misses and the PATH scan fallback is the code path under test."
-  []
-  (let [dir (fs/create-temp-dir {:prefix "mf-paths-"})
-        cmd (str "mf-fake-cli-" (random-uuid))
-        exe (fs/path dir cmd)]
-    (spit (fs/file exe) "#!/bin/sh\nexit 0\n")
-    (fs/set-posix-file-permissions exe executable-permissions)
-    {:dir (str dir) :cmd cmd}))
+;------------------------------------------------------------------------------ Layer 1
 
 (deftest ^{:stratum 1} test-path-splitting-honours-the-platform-separator
   (testing "given a PATH joined with the platform separator → one entry per element"
@@ -65,14 +60,29 @@
   (testing "given an unset PATH → the empty entry, never a nil deref"
     (is (= [""] (#'sut/split-path-entries nil)))))
 
+(defn- ^{:stratum 1} temp-executable
+  "Creates an empty executable file with a name no real PATH lookup can
+   resolve, so `fs/which` misses and the PATH scan fallback is the code path
+   under test. The file is never run — only its executable bit is read."
+  []
+  (let [dir (fs/create-temp-dir {:prefix "mf-paths-"})
+        cmd (str "mf-fake-cli-" (random-uuid))
+        exe (fs/path dir cmd)]
+    (spit (fs/file exe) "")
+    (mark-executable! exe)
+    {:dir (str dir) :cmd cmd}))
+
 ;------------------------------------------------------------------------------ Layer 2
 
 (deftest ^{:stratum 2} test-path-scan-fallback-returns-an-absolute-path
   (testing "given a relative PATH entry → the resolved command path is absolute"
-    (let [{:keys [dir cmd]} (temp-executable)
-          resolved (with-redefs-fn {#'sut/path-entries (fn [] [(relative-entry dir)])}
-                     (fn [] (sut/resolve-cli-command-path cmd)))]
-      (is (some? resolved))
-      (is (fs/absolute? resolved))
-      (is (= (str (fs/canonicalize (fs/path dir cmd)))
-             (str (fs/canonicalize resolved)))))))
+    (let [{:keys [dir cmd]} (temp-executable)]
+      (try
+        (let [resolved (with-redefs-fn {#'sut/path-entries (fn [] [(relative-entry dir)])}
+                         (fn [] (sut/resolve-cli-command-path cmd)))]
+          (is (some? resolved))
+          (is (fs/absolute? resolved))
+          (is (= (str (fs/canonicalize (fs/path dir cmd)))
+                 (str (fs/canonicalize resolved)))))
+        (finally
+          (fs/delete-tree dir))))))

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/paths_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/paths_test.clj
@@ -1,0 +1,78 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.workflow-runner.paths-test
+  (:require
+   [babashka.fs :as fs]
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.cli.workflow-runner.paths :as sut])
+  (:import
+   (java.io File)))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private foreign-separator
+  "The PATH separator of the *other* platform family, which must never act as a
+   delimiter here: `;` on POSIX, `:` on Windows."
+  (if (= ";" File/pathSeparator) ":" ";"))
+
+(def ^{:stratum 0} ^:private executable-permissions "rwxr-xr-x")
+
+(defn- ^{:stratum 0} join-path-entries
+  [entries]
+  (str/join File/pathSeparator entries))
+
+(defn- ^{:stratum 0} relative-entry
+  [dir]
+  (str (fs/relativize (fs/cwd) dir)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} temp-executable
+  "Creates an executable file with a name no real PATH lookup can resolve, so
+   `fs/which` misses and the PATH scan fallback is the code path under test."
+  []
+  (let [dir (fs/create-temp-dir {:prefix "mf-paths-"})
+        cmd (str "mf-fake-cli-" (random-uuid))
+        exe (fs/path dir cmd)]
+    (spit (fs/file exe) "#!/bin/sh\nexit 0\n")
+    (fs/set-posix-file-permissions exe executable-permissions)
+    {:dir (str dir) :cmd cmd}))
+
+(deftest ^{:stratum 1} test-path-splitting-honours-the-platform-separator
+  (testing "given a PATH joined with the platform separator → one entry per element"
+    (is (= ["/usr/local/bin" "/usr/bin" "/bin"]
+           (#'sut/split-path-entries
+            (join-path-entries ["/usr/local/bin" "/usr/bin" "/bin"])))))
+  (testing "given an entry containing the other platform's separator → kept whole"
+    (let [entry (str "/opt/tools" foreign-separator "extra")]
+      (is (= [entry] (#'sut/split-path-entries entry)))))
+  (testing "given an unset PATH → the empty entry, never a nil deref"
+    (is (= [""] (#'sut/split-path-entries nil)))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} test-path-scan-fallback-returns-an-absolute-path
+  (testing "given a relative PATH entry → the resolved command path is absolute"
+    (let [{:keys [dir cmd]} (temp-executable)
+          resolved (with-redefs-fn {#'sut/path-entries (fn [] [(relative-entry dir)])}
+                     (fn [] (sut/resolve-cli-command-path cmd)))]
+      (is (some? resolved))
+      (is (fs/absolute? resolved))
+      (is (= (str (fs/canonicalize (fs/path dir cmd)))
+             (str (fs/canonicalize resolved)))))))

--- a/docs/pull-requests/2026-08-09-fix-paths-portability.md
+++ b/docs/pull-requests/2026-08-09-fix-paths-portability.md
@@ -1,0 +1,74 @@
+# fix(cli): platform PATH separator and absolute PATH-scan results
+
+## Overview
+
+Two portability defects in `ai.miniforge.cli.workflow-runner.paths`, both
+flagged by Copilot on #1662 and deferred there because that PR was a
+move-only namespace split.
+
+## Motivation
+
+1. `path-entries` split `$PATH` on a hard-coded `":"`. On Windows the
+   separator is `";"`, so the whole PATH parsed as a single bogus entry
+   and the CLI-resolution fallback silently found nothing.
+2. `resolve-cli-command-path` documents an absolute-path contract, but
+   the PATH-scan fallback returned `entry/cmd` verbatim. A relative
+   entry in `$PATH` (`.`, `bin`, `../tools`) therefore produced a
+   relative result, which breaks once the runner executes the command
+   from a worktree with a different working directory than the JVM.
+
+## Changes in Detail
+
+- `split-path-entries` (Layer 0) splits a raw PATH string on
+  `(Pattern/quote File/pathSeparator)`; `path-entries` (Layer 1) is now
+  just the environment read. The split becoming a pure function is what
+  makes the separator behaviour testable without mutating the JVM
+  environment.
+- `matching-command-path` is gone. The PATH scan in
+  `resolve-cli-command-path` now goes through `normalize-command-path`,
+  the same function the direct-path and `fs/which` branches already
+  used, so every branch absolutizes and the docstring's contract holds
+  everywhere. Removing the helper also keeps the file inside the
+  3-layer budget (SL003) — routing `matching-command-path` through
+  `normalize-command-path` at the same stratum would have pushed the
+  namespace to 4 layers.
+- Docstring updated to state the absolutize guarantee explicitly.
+
+Behaviour note: results are absolutized, not canonicalized, matching
+what the `fs/which` branch already did — symlinks are preserved.
+
+## Testing Plan
+
+New `bases/cli/test/ai/miniforge/cli/workflow_runner/paths_test.clj`:
+
+- `test-path-splitting-honours-the-platform-separator` — entries joined
+  with `File/pathSeparator` split apart; an entry containing the *other*
+  platform's separator stays whole; a nil PATH does not NPE.
+- `test-path-scan-fallback-returns-an-absolute-path` — an executable in
+  a temp dir reached via a relative PATH entry resolves to an absolute
+  path pointing at that executable.
+
+Run: `clojure -M:dev:test` over `paths-test` and `preflight-test`.
+`paths-test` is 2 tests / 6 assertions, green. `preflight-test` has one
+pre-existing unrelated failure on main (the codex generic-path
+assertion, being fixed separately).
+
+Regression check: reverting the absolutize fix makes
+`test-path-scan-fallback-returns-an-absolute-path` fail as expected.
+The separator test cannot fail on a POSIX runner — `File/pathSeparator`
+*is* `":"` there — so on Linux CI it pins intent rather than catching a
+revert; it becomes a live regression detector on Windows.
+
+## Deployment Plan
+
+No migration. Internal helper, no public API or wire-format change.
+
+## Related Issues/PRs
+
+- #1662 — the move-only split that surfaced both comments.
+
+## Checklist
+
+- [x] `bb lint:clj` clean
+- [x] `bb lint:stratum` clean (3 layers)
+- [x] New tests green, targeted regression verified

--- a/docs/pull-requests/2026-08-09-fix-paths-portability.md
+++ b/docs/pull-requests/2026-08-09-fix-paths-portability.md
@@ -53,6 +53,10 @@ Run: `clojure -M:dev:test` over `paths-test` and `preflight-test`.
 pre-existing unrelated failure on main (the codex generic-path
 assertion, being fixed separately).
 
+The temp fixture sets the executable bit through `File/setExecutable` on
+Windows and POSIX permission bits elsewhere, and deletes its temp dir in
+a `finally` (both raised in review).
+
 Regression check: reverting the absolutize fix makes
 `test-path-scan-fallback-returns-an-absolute-path` fail as expected.
 The separator test cannot fail on a POSIX runner — `File/pathSeparator`


### PR DESCRIPTION
## Summary

Two portability defects in `ai.miniforge.cli.workflow-runner.paths`, both flagged by Copilot on #1662 and deferred there because that PR was a move-only namespace split.

1. **PATH separator was hard-coded to `":"`.** On Windows the separator is `";"`, so the whole PATH parsed as one bogus entry and the CLI-resolution fallback silently found nothing. Splitting now uses `(Pattern/quote File/pathSeparator)`.
2. **The PATH-scan fallback could return a relative path**, contradicting `resolve-cli-command-path`'s documented absolute-path contract. A relative entry in `$PATH` (`.`, `bin`, `../tools`) produced a relative result, which breaks once the runner executes the command from a worktree whose working directory differs from the JVM's.

### Changes

- `split-path-entries` (Layer 0) does the pure split; `path-entries` (Layer 1) is now only the environment read. Making the split pure is what allows testing the separator without mutating the JVM environment.
- `matching-command-path` is removed. The PATH scan in `resolve-cli-command-path` now goes through `normalize-command-path` — the same function the direct-path and `fs/which` branches already used — so every branch absolutizes. Removing the helper also keeps the namespace inside the 3-layer budget: calling `normalize-command-path` from `matching-command-path` at the same stratum pushed the file to 4 layers and tripped SL003.
- Docstring updated to state the absolutize guarantee.

Results are absolutized, not canonicalized, matching what the `fs/which` branch already did — symlinks are preserved.

## Testing

New `bases/cli/test/ai/miniforge/cli/workflow_runner/paths_test.clj` (2 tests, 6 assertions, green):

- `test-path-splitting-honours-the-platform-separator` — entries joined with `File/pathSeparator` split apart; an entry containing the *other* platform's separator stays whole; a nil PATH does not NPE.
- `test-path-scan-fallback-returns-an-absolute-path` — an executable in a temp dir reached via a relative PATH entry resolves to an absolute path pointing at that executable.

Regression check: reverting the absolutize fix makes `test-path-scan-fallback-returns-an-absolute-path` fail as expected. The separator test cannot fail on a POSIX runner — `File/pathSeparator` *is* `":"` there — so on Linux CI it pins intent rather than catching a revert; it becomes a live regression detector on Windows.

`preflight-test` was run alongside and has one pre-existing failure on main (the codex generic-path assertion), unrelated to this change and being fixed separately. Full `bb pre-commit` passed: lint, stratum lint, poly check, 342-test smoke suite, GraalVM compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
