### PR TITLE
fix(cli): normalize the runner's sandbox-failure result to :execution/*

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/execution.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/execution.clj
@@ -45,6 +45,19 @@
       (artifact/close-store artifact-store)
       (catch Exception _))))
 
+(defn- ^{:stratum 0} sandbox-failure-result
+  "Workflow result for a sandbox that never came up.
+
+   Speaks the same `:execution/*` vocabulary as the pipeline's own
+   results, so `phase/succeeded?`, `display/print-result` and
+   `lifecycle/publish-completion-event` classify and render it like any
+   other workflow failure instead of seeing a statusless map."
+  [sandbox-error]
+  (let [error (:error sandbox-error)]
+    {:execution/status :failed
+     :execution/errors [{:type :sandbox-setup-failed
+                         :message (or (:message error) (str error))}]}))
+
 (defn ^{:stratum 0} execute-workflow-pipeline [run-pipeline workflow input callbacks artifact-store event-stream]
   (-> callbacks
       (cond-> artifact-store (assoc :artifact-store artifact-store))
@@ -58,9 +71,7 @@
   (let [completed? (atom false)]
     (try+
       (if-let [sandbox-error (:sandbox-error context)]
-        (let [result {:success? false
-                      :errors [{:type :sandbox-setup-failed
-                                :message (str (:error sandbox-error))}]}]
+        (let [result (sandbox-failure-result sandbox-error)]
           (lifecycle/publish-completion-event event-stream workflow-id result)
           (reset! completed? true)
           (display/print-result result opts)

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/lifecycle.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/lifecycle.clj
@@ -41,10 +41,10 @@
    aren't maps at all) fall back to their printed form. With no errors
    at all, report the execution status."
   [result]
-  (let [status (get result :execution/status :unknown)]
-    (if-let [first-error (first (:execution/errors result))]
-      (or (:message first-error) (str first-error))
-      (str "Workflow ended with status: " (name status)))))
+  (if-let [first-error (first (:execution/errors result))]
+    (or (:message first-error) (str first-error))
+    (str "Workflow ended with status: "
+         (name (get result :execution/status :unknown)))))
 
 (defn ^{:stratum 0} publish-failure-event!
   "Publish a workflow failure event, swallowing exceptions."

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/lifecycle.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/lifecycle.clj
@@ -35,12 +35,15 @@
 
 (defn- ^{:stratum 0} failure-message
   "Build a meaningful failure message from a workflow result.
-   Falls back to execution status when no explicit errors exist."
+
+   Error entries are canonically maps carrying `:message`, so read that
+   rather than printing the whole entry; entries without one (or that
+   aren't maps at all) fall back to their printed form. With no errors
+   at all, report the execution status."
   [result]
-  (let [errors (:execution/errors result)
-        status (get result :execution/status :unknown)]
-    (if (seq errors)
-      (str (first errors))
+  (let [status (get result :execution/status :unknown)]
+    (if-let [first-error (first (:execution/errors result))]
+      (or (:message first-error) (str first-error))
       (str "Workflow ended with status: " (name status)))))
 
 (defn ^{:stratum 0} publish-failure-event!

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/execution_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/execution_test.clj
@@ -1,0 +1,117 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.workflow-runner.execution-test
+  "Tests for the sandbox-setup-failure branch of `execute-with-events`.
+
+   The branch short-circuits the pipeline and synthesises its own
+   workflow result. That result has to speak the same `:execution/*`
+   vocabulary the pipeline emits, otherwise every downstream consumer
+   (`phase/succeeded?`, the completion event, the pretty summary) reads
+   a statusless, errorless map and reports the run as neither failed nor
+   explained."
+  (:require
+   [ai.miniforge.cli.workflow-runner.execution :as sut]
+   [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.event-stream.interface :as es]
+   [ai.miniforge.phase.interface :as phase]
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private sandbox-error-message
+  "Message carried by the fixture sandbox failure."
+  "container runtime unreachable")
+
+(defn- ^{:stratum 0} run-sandbox-failure
+  "Drive `execute-with-events` down the sandbox-failure branch against a
+   real event stream. Returns
+   `{:result <workflow result> :events [...] :out <printed summary>}`."
+  [context opts]
+  (let [stream (es/create-event-stream {:sinks []})
+        captured (atom [])
+        result (atom nil)]
+    (es/subscribe! stream :execution-test (fn [event] (swap! captured conj event)))
+    (let [out (with-out-str
+                (reset! result (sut/execute-with-events
+                                {:run-pipeline (fn [& _]
+                                                 (throw (ex-info "pipeline must not run" {})))
+                                 :context context
+                                 :event-stream stream
+                                 :workflow-id (random-uuid)
+                                 :opts opts})))]
+      {:result @result :events @captured :out out})))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} sandbox-error-context
+  "Context as `sandbox/setup-sandbox-context` builds it when
+   `prepare-sandbox` returns a non-ok result: the dag error result
+   itself, stashed under `:sandbox-error`."
+  ([] (sandbox-error-context (dag/err :sandbox-prep-failed sandbox-error-message)))
+  ([sandbox-error] {:sandbox-error sandbox-error}))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} sandbox-failure-result-uses-canonical-execution-keys
+  (testing "the synthesised result is a canonical failed workflow result"
+    (let [{:keys [result]} (run-sandbox-failure (sandbox-error-context) {:quiet true})]
+      (is (= :failed (:execution/status result)))
+      (is (= [{:type :sandbox-setup-failed :message sandbox-error-message}]
+             (:execution/errors result)))
+      (is (not (contains? result :success?))
+          "the runner-local :success?/:errors shape is gone — consumers
+           read :execution/status and :execution/errors")
+      (is (not (contains? result :errors))))))
+
+(deftest ^{:stratum 2} sandbox-failure-result-is-a-failure-to-phase-predicates
+  (testing "phase/succeeded? classifies the sandbox failure as a failure"
+    (let [{:keys [result]} (run-sandbox-failure (sandbox-error-context) {:quiet true})]
+      (is (false? (phase/succeeded? result)))
+      (is (true? (phase/failed? result))
+          "a statusless map is merely not-succeeded; :execution/status
+           :failed makes the failure positively detectable"))))
+
+(deftest ^{:stratum 2} sandbox-failure-falls-back-to-printing-an-unshaped-error
+  ;; Deliberately NOT the producer's shape: every `dag/err` path carries
+  ;; a map `:error` with a `:message`. This pins the defensive fallback
+  ;; that keeps the pre-existing printed form if that ever stops holding.
+  (testing "a sandbox error without a nested :message still yields a message"
+    (let [sandbox-error {:ok? false :error :runtime-missing}
+          {:keys [result]} (run-sandbox-failure (sandbox-error-context sandbox-error)
+                                                {:quiet true})]
+      (is (= [{:type :sandbox-setup-failed :message ":runtime-missing"}]
+             (:execution/errors result))))))
+
+(deftest ^{:stratum 2} sandbox-failure-publishes-a-workflow-failed-event
+  (testing "the completion event is a failure carrying the sandbox message"
+    (let [{:keys [events]} (run-sandbox-failure (sandbox-error-context) {:quiet true})
+          failed (filterv #(= :workflow/failed (:event/type %)) events)]
+      (is (= 1 (count events))
+          "exactly one completion event; the finally must not add a
+           cancellation event on top of it")
+      (is (= 1 (count failed)))
+      (is (= sandbox-error-message (:workflow/failure-reason (first failed)))
+          "the sandbox message reaches the event, not
+           'Workflow ended with status: unknown'"))))
+
+(deftest ^{:stratum 2} sandbox-failure-prints-the-error-in-the-pretty-summary
+  (testing "the pretty summary lists the sandbox error"
+    (let [{:keys [out]} (run-sandbox-failure (sandbox-error-context) {:output :pretty})]
+      (is (str/includes? out sandbox-error-message)
+          "errors only render when they arrive under :execution/errors"))))

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/kanban_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/kanban_test.clj
@@ -48,11 +48,25 @@
 ;; failure-message
 ;; ============================================================================
 (deftest ^{:stratum 0} failure-message-with-errors-test
-  (testing "uses first error entry when errors exist"
+  (testing "reports the first error's :message, not the printed entry"
     (let [result {:execution/errors [{:type :gate-failed :message "lint failed"}]
                   :execution/status :failed}
           msg (#'lifecycle/failure-message result)]
-      (is (str/includes? msg "lint failed")))))
+      (is (= "lint failed" msg)))))
+
+(deftest ^{:stratum 0} failure-message-with-messageless-map-error-test
+  (testing "a map entry carrying no :message falls back to its printed form"
+    (let [result {:execution/errors [{:type :gate-failed}]
+                  :execution/status :failed}
+          msg (#'lifecycle/failure-message result)]
+      (is (= (str {:type :gate-failed}) msg)))))
+
+(deftest ^{:stratum 0} failure-message-with-non-map-error-test
+  (testing "a plain-string entry is used as-is"
+    (let [result {:execution/errors ["compile failed"]
+                  :execution/status :failed}
+          msg (#'lifecycle/failure-message result)]
+      (is (= "compile failed" msg)))))
 
 (deftest ^{:stratum 0} failure-message-without-errors-test
   (testing "includes execution status when no errors"

--- a/docs/pull-requests/2026-08-09-fix-runner-failure-shapes.md
+++ b/docs/pull-requests/2026-08-09-fix-runner-failure-shapes.md
@@ -1,0 +1,141 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix(cli): normalize the sandbox-setup failure result to `:execution/*`
+
+## Overview
+
+Two related shape defects in the CLI workflow-runner execution path, both
+flagged by Copilot on PR #1666 and deferred there because that PR was
+move-only. This one changes behavior.
+
+1. `execute-with-events`' sandbox-setup-failure branch returned
+   `{:success? false :errors [...]}` — a vocabulary nothing downstream
+   reads. It now returns `{:execution/status :failed :execution/errors
+   [...]}`.
+2. `lifecycle/failure-message` stringified the whole first error entry. It
+   now reads that entry's `:message`, printing the entry only when it has
+   none.
+
+## Motivation
+
+Every consumer of a workflow result speaks `:execution/*`:
+
+- `phase/succeeded?` / `phase/failed?` scan `[:status :execution/status
+  :step/status :chain/status]`.
+- `display/print-result` → `format-compact-summary` destructures
+  `{:execution/keys [status metrics errors]}`.
+- `lifecycle/publish-completion-event` reads `:execution/errors` and
+  derives the event message from the result.
+- `pr-lifecycle`'s `fix-succeeded?` tests `(not= :failed (get result
+  :execution/status))`.
+
+Against the old sandbox map every one of those read a key that was not
+there. Traced on the pre-change code:
+
+| Consumer | Old behavior | New behavior |
+|---|---|---|
+| `phase/succeeded?` | `false` (status nil ≠ `:completed`) — right answer for the wrong reason | `false` |
+| `phase/failed?` | `false` — the failure was not positively detectable | `true` |
+| `publish-completion-event` | `workflow/failed` with reason `"Workflow ended with status: unknown"`, `:errors [{:type :unknown-failure …}]` | reason is the sandbox error's message; `:errors` is the real entry |
+| `display/print-result` (`:pretty`) | failure banner, then **no error lines at all** — `:execution/errors` was nil | failure banner plus the sandbox error |
+| `pr-lifecycle/fix-succeeded?` | **`true`** — nil status is not `:failed`, so a sandbox that never came up counted as a successful fix and the bot replied "Fixed in latest push" on the review comments | `false` |
+
+The last row is the one with user-visible consequences, and it is the
+`(:key m default)` idiom the repo has been bitten by before: a producer
+changing (or never adopting) a shape silently flips a consumer's default.
+
+`failure-message`'s `(str (first errors))` is the same class of defect one
+level down. Error entries are canonically maps —
+`workflow/execution.clj` builds `{:type :phase-error :phase … :message …
+:data … :anomaly …}` — so the event message was the printed map rather
+than the sentence inside it.
+
+## Layer
+
+`bases/cli` only, plus its tests. No component or contract changes.
+
+## Changes in Detail
+
+- `workflow_runner/execution.clj`: new private Layer 0
+  `sandbox-failure-result`, building `{:execution/status :failed
+  :execution/errors [{:type :sandbox-setup-failed :message …}]}`.
+  `execute-with-events` calls it instead of inlining the old map.
+- The message is now `(or (:message (:error sandbox-error)) (str (:error
+  sandbox-error)))`. `:sandbox-error` holds a `dag/err` result, whose
+  `:error` is `{:code … :message …}`, so the old `(str (:error …))`
+  embedded a printed map inside the message string — the same defect as
+  (2), in the producer. The `str` form is kept as the fallback, so any
+  non-map error stringifies exactly as it does today.
+- `workflow_runner/lifecycle.clj`: `failure-message` prefers `(:message
+  first-error)`, falls back to `(str first-error)`, and keeps the
+  status-only sentence when there are no errors. Keyword lookup on a
+  non-map returns nil, so string entries take the fallback without a
+  `map?` guard.
+
+### Checked, not changed
+
+- Every other `:success?` / `(:errors …)` reader in `bases/cli` was
+  grepped. The hits are unrelated producers: `web/github.clj`'s
+  `sh-success?` over shell results, `commands/scan.clj` and
+  `commands/policy.clj` over pack-compile results, `setup.clj` and
+  `commands/run.clj` over spec *validation* results. No reader of the
+  runner's result map used either key.
+- `execute-with-events` still does not `close-artifact-store` on the
+  sandbox-failure branch, unlike the pipeline branch. Pre-existing, out of
+  scope here, left alone deliberately.
+- `display/compact-error-lines` prints each entry with `str`, so a map
+  entry renders as a map. That is already how canonical pipeline errors
+  render; not touched.
+
+## Testing Plan
+
+- New `bases/cli/test/.../workflow_runner/execution_test.clj` — 5 tests
+  driving `execute-with-events` down the sandbox branch against a real
+  event stream: canonical result keys, `phase/succeeded?`/`failed?`
+  classification, the published `workflow/failed` event's
+  `:workflow/failure-reason`, the `:pretty` summary containing the error,
+  and the non-map fallback.
+- `kanban_test`'s three `failure-message` tests deliberately re-pinned
+  from the stringify behavior to exact-message equality, plus two new
+  cases: a map entry with no `:message`, and a plain-string entry.
+- Non-vacuous: stashing the two source edits and re-running gives 9
+  assertion failures across the new tests, each naming the old behavior
+  (`"{:type :gate-failed, :message \"lint failed\"}"`, `"Workflow ended
+  with status: unknown"`, `:execution/errors` nil, `:success?` present).
+- Green: `execution-test`, `kanban-test`, `manifest-wiring-test`,
+  `runner-control-wiring-test`, `display-test`, `operator-wiring-test`
+  (59 tests / 115 assertions) and `pr-lifecycle.responder-test` (12 / 51),
+  the consumer whose `fix-succeeded?` verdict flips.
+- Pre-commit suite (342 tests / 1291 assertions + GraalVM compatibility)
+  green.
+
+## Standards Audit
+
+- Stratified design (001/210): `sandbox-failure-result` has no
+  in-namespace dependencies and sits at stratum 0; the test namespace's
+  strata were placed by `stratum-lint --fix`.
+- Testing (400): the sandbox context is built by a factory that mirrors
+  `sandbox/setup-sandbox-context`'s real output, via the producer's own
+  `dag/err` constructor. The one fixture that is *not* the producer shape
+  is the fallback test, commented to say so and why.
+- Localization (007-adjacent): no new user-facing strings; messages come
+  from data already in the error result.
+
+## Deployment Plan
+
+Ships with the CLI. No migration, no config.
+
+## Related Issues/PRs
+
+- PR #1666 — the move-only split that surfaced both warts.
+
+## Checklist
+
+- [x] Both consumers traced against the pre-change code, not assumed
+- [x] Other readers of the old keys grepped
+- [x] New tests shown to fail without the source change
+- [x] Affected namespaces run green


### PR DESCRIPTION
## Summary

**This is a behavior change**, not a refactor. Two shape defects in the CLI workflow-runner execution path, both flagged by Copilot on #1666 and deferred there because that PR was move-only.

1. `execute-with-events`' sandbox-setup-failure branch returned `{:success? false :errors [...]}` — a vocabulary nothing downstream reads. It now returns `{:execution/status :failed :execution/errors [{:type :sandbox-setup-failed :message ...}]}`.
2. `lifecycle/failure-message` stringified the whole first entry of `:execution/errors`. It now reads that entry's `:message`, printing the entry only when it has none (or isn't a map).

### What actually changes, traced against the pre-change code

| Consumer | Before | After |
|---|---|---|
| `phase/succeeded?` | `false` (nil status ≠ `:completed`) — right answer for the wrong reason | `false` |
| `phase/failed?` | `false` — the failure was not positively detectable | `true` |
| `lifecycle/publish-completion-event` | `workflow/failed` with reason `"Workflow ended with status: unknown"` and `:errors [{:type :unknown-failure ...}]` | reason is the sandbox error's message; `:errors` is the real entry |
| `display/print-result` (`:pretty`) | failure banner, then **no error lines at all** (`:execution/errors` was nil) | failure banner plus the sandbox error |
| `pr-lifecycle`'s `fix-succeeded?` | **`true`** — its `(not= :failed (get result :execution/status))` passes on a nil status, so a sandbox that never came up counted as a successful fix and the bot replied "Fixed in latest push" on the review comments | `false` |

The last row is the one with user-visible consequences, and it is the `(:key m default)` idiom this repo has been bitten by before.

A third, smaller change in the same producer: the message was `(str (:error sandbox-error))`, and `:sandbox-error` holds a `dag/err` whose `:error` is `{:code ... :message ...}` — so the old code embedded a printed map inside the message string, the same defect as (2) one level up. It now prefers the nested `:message`, keeping `str` as the fallback so any non-map error stringifies exactly as today.

### Checked, not changed

- Grepped every other `:success?` / `(:errors ...)` reader in `bases/cli` before changing the producer. All hits are unrelated producers (`web/github.clj`'s `sh-success?`, `commands/scan.clj` and `commands/policy.clj` over pack-compile results, `setup.clj` / `commands/run.clj` over spec *validation* results). No reader of the runner's result map used either key.
- `execute-with-events` still doesn't `close-artifact-store` on the sandbox-failure branch, unlike the pipeline branch. Pre-existing, left alone.
- `display/compact-error-lines` prints each entry with `str`, so a map entry renders as a map — already how canonical pipeline errors render. Not touched.

## Testing

- New `bases/cli/test/.../workflow_runner/execution_test.clj` — 5 tests driving `execute-with-events` down the sandbox branch against a real event stream: canonical result keys, `phase/succeeded?` / `failed?` classification, the published `workflow/failed` event's `:workflow/failure-reason`, the `:pretty` summary containing the error, and the non-map fallback.
- `kanban_test`'s `failure-message` tests deliberately re-pinned from the stringify behavior to exact-message equality, plus two new cases (map entry with no `:message`; plain-string entry).
- Non-vacuous: stashing the two source edits and re-running gives 9 assertion failures across the new tests, each naming the old behavior (`"{:type :gate-failed, :message \"lint failed\"}"`, `"Workflow ended with status: unknown"`, `:execution/errors` nil, `:success?` present).
- Green: `execution-test`, `kanban-test`, `manifest-wiring-test`, `runner-control-wiring-test`, `display-test`, `operator-wiring-test` — 59 tests / 115 assertions. Plus `pr-lifecycle.responder-test` (12 / 51), the consumer whose `fix-succeeded?` verdict flips.
- Pre-commit suite green on both commits (342 tests / 1291 assertions, plus GraalVM compatibility).
- PR doc: `docs/pull-requests/2026-08-09-fix-runner-failure-shapes.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
