### PR TITLE
refactor(cli): split workflow_runner/display.clj — extract display namespaces (rule 210, 1/2)

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/display_ansi.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/display_ansi.clj
@@ -1,0 +1,41 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.workflow-runner.display-ansi
+  "ANSI escape-code styling for workflow-runner terminal output."
+  (:require
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ansi-codes
+  {:reset "\u001b[0m"
+   :bold "\u001b[1m"
+   :cyan "\u001b[36m"
+   :green "\u001b[32m"
+   :yellow "\u001b[33m"
+   :red "\u001b[31m"})
+
+(defn ^{:stratum 0} strip-ansi
+  "Remove ANSI escape codes from a string."
+  [s]
+  (str/replace s #"\u001b\[[0-9;]*m" ""))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} colorize [color text]
+  (str (get ansi-codes color "") text (:reset ansi-codes)))

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/display_demo_line.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/display_demo_line.clj
@@ -1,0 +1,76 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.workflow-runner.display-demo-line
+  "Plain-text (ANSI-stripped) event lines for demo and test output."
+  (:require
+   [ai.miniforge.cli.workflow-runner.display-ansi :as ansi]
+   [ai.miniforge.cli.workflow-runner.display-event-line :as event-line]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} demo-defaults
+  "Fill in '?' defaults for nil event params so format-event-line produces
+   visible placeholders instead of empty strings."
+  [event]
+  (let [evt (:event/type event)]
+    (cond-> event
+      (and (#{:workflow/phase-started :workflow/phase-completed} evt)
+           (nil? (or (:workflow/phase event) (:phase event))))
+      (assoc :workflow/phase "?")
+
+      (and (#{:agent/started :agent/completed :agent/failed :agent/status} evt)
+           (nil? (or (:agent/id event) (:agent event))))
+      (assoc :agent/id "?")
+
+      (and (#{:gate/started :gate/passed :gate/failed} evt)
+           (nil? (or (:gate/id event) (:gate event))))
+      (assoc :gate/id "?")
+
+      (and (#{:tool/invoked :tool/completed} evt)
+           (nil? (:tool/id event)))
+      (assoc :tool/id "?")
+
+      (and (= :workflow/milestone-reached evt)
+           (nil? (:message event)))
+      (assoc :message "?")
+
+      (and (= :workflow/failed evt)
+           (nil? (:workflow/failure-reason event)))
+      (assoc :workflow/failure-reason "unknown"))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} format-demo-line
+  "Format a plain-text (no ANSI) progress line for demo/test output.
+   Delegates to format-event-line with nil-defaulted params, then strips ANSI.
+   Uses '?' for nil values and 'unknown' for missing failure reasons."
+  [event]
+  (let [evt (:event/type event)
+        patched (demo-defaults event)
+        base (event-line/format-event-line patched)]
+    (when base
+      (let [stripped (ansi/strip-ansi base)]
+        (case evt
+          ;; Append (?) when duration is missing
+          :workflow/completed (if (nil? (:workflow/duration-ms event))
+                                (str stripped " (?)")
+                                stripped)
+          :workflow/phase-completed (if (nil? (:phase/duration-ms event))
+                                      (str stripped " (?)")
+                                      stripped)
+          stripped)))))

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/display_error_help.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/display_error_help.clj
@@ -1,0 +1,57 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.workflow-runner.display-error-help
+  "Operator-facing help output for workflow load and runtime failures."
+  (:require
+   [ai.miniforge.cli.messages :as messages]
+   [ai.miniforge.cli.workflow-runner.display-ansi :as ansi]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} print-error-header
+  "Print error header with message, details, and cause."
+  [msg data cause]
+  (println (ansi/colorize :red (str "\n" (messages/t :workflow-runner/load-failed))))
+  (println (messages/t :workflow-runner/error {:message msg}))
+  (when data
+    (println (messages/t :workflow-runner/details {:details (pr-str data)})))
+  (when cause
+    (println (messages/t :workflow-runner/cause {:cause (ex-message cause)})))
+  (println (ansi/colorize :yellow (str "\n" (messages/t :workflow-runner/possible-causes))))
+  (println (messages/t :workflow-runner/cause-missing-dep))
+  (println (messages/t :workflow-runner/cause-compile))
+  (println (messages/t :workflow-runner/cause-cycle)))
+
+(defn ^{:stratum 0} print-namespace-resolution-help
+  "Print help for namespace resolution errors."
+  []
+  (println (ansi/colorize :cyan (str "\n" (messages/t :workflow-runner/namespace-help-header))))
+  (println (messages/t :workflow-runner/namespace-help-dep))
+  (println (messages/t :workflow-runner/namespace-help-build)))
+
+(defn ^{:stratum 0} print-babashka-fallback-help
+  "Print help for Babashka compatibility issues."
+  []
+  (println (ansi/colorize :cyan (str "\n" (messages/t :workflow-runner/bb-help-header))))
+  (println (messages/t :workflow-runner/bb-help-command)))
+
+(defn ^{:stratum 0} print-general-debugging-help
+  "Print general debugging tips."
+  []
+  (println (ansi/colorize :cyan (str "\n" (messages/t :workflow-runner/debug-header))))
+  (println (messages/t :workflow-runner/debug-command)))

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/display_event_line.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/display_event_line.clj
@@ -1,0 +1,141 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.workflow-runner.display-event-line
+  "Colorized one-line rendering of workflow lifecycle events."
+  (:require
+   [clojure.string :as str]
+   [ai.miniforge.cli.messages :as messages]
+   [ai.miniforge.cli.workflow-runner.display-ansi :as ansi]
+   [ai.miniforge.cli.workflow-runner.display-format :as fmt]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} dependency-kind-label
+  [event]
+  (messages/t (keyword "workflow-runner.dependency-kind"
+                       (name (or (:dependency/kind event) :environment)))))
+
+(defn- ^{:stratum 0} dependency-status-label
+  [event]
+  (messages/t (keyword "workflow-runner.dependency-status"
+                       (name (or (:dependency/status event) :healthy)))))
+
+(defn- ^{:stratum 0} dependency-display-name
+  [event]
+  (or (some-> (:dependency/vendor event) fmt/humanize-keyword str/capitalize)
+      (let [dependency-id (:dependency/id event)]
+        (cond
+          (keyword? dependency-id) (str/capitalize (fmt/humanize-keyword dependency-id))
+          (string? dependency-id) dependency-id
+          dependency-id (str dependency-id)
+          :else nil))
+      "?"))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} dependency-event-line
+  [event message-key color]
+  (ansi/colorize color
+                 (messages/t message-key
+                             {:dependency (dependency-display-name event)
+                              :kind (dependency-kind-label event)
+                              :status (dependency-status-label event)})))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} format-event-line
+  "Format a concise progress line for a lifecycle event. Returns nil for unknown events."
+  [event]
+  (let [evt (:event/type event)
+        phase (or (:workflow/phase event) (:phase event))
+        gate (or (:gate/id event) (:gate event))
+        agent (or (:agent/id event) (:agent event))
+        tool-id (:tool/id event)]
+    (case evt
+      :workflow/started (ansi/colorize :cyan (messages/t :workflow-runner/start))
+      :workflow/completed (str (ansi/colorize :green (messages/t :workflow-runner/completed))
+                               (when-let [d (:workflow/duration-ms event)]
+                                 (str " (" (fmt/format-duration d) ")")))
+      :workflow/failed (str (ansi/colorize :red (messages/t :workflow-runner/failed))
+                            (when-let [r (:workflow/failure-reason event)]
+                              (str ": " r)))
+      :workflow/phase-started (ansi/colorize :yellow (messages/t :workflow-runner/phase-started
+                                                                 {:phase phase}))
+      :workflow/phase-completed (let [outcome (or (:phase/outcome event) :completed)
+                                      color   (case outcome
+                                                :failure    :red
+                                                :blocked    :red
+                                                :skipped    :yellow
+                                                :redirected :yellow
+                                                :green)
+                                      symbol  (case outcome
+                                                :failure    "✗"
+                                                :blocked    "⊘"
+                                                :skipped    "○"
+                                                :redirected "↻"
+                                                "✓")]
+                                  (str (ansi/colorize color (messages/t :workflow-runner/phase-completed
+                                                                        {:symbol symbol
+                                                                         :phase phase
+                                                                         :outcome (name outcome)}))
+                                       (when-let [d (:phase/duration-ms event)]
+                                         (str " (" (fmt/format-duration d) ")"))))
+      :workflow/milestone-reached (ansi/colorize :green (messages/t :workflow-runner/milestone
+                                                                    {:message (:message event)}))
+      :workspace/persisted (ansi/colorize :cyan (messages/t :workflow-runner/workspace-persisted
+                                                            {:phase       (some-> (:workspace/phase event) name)
+                                                             :bundle-path (or (:workspace/bundle-path event)
+                                                                              (:workspace/commit-sha event)
+                                                                              "(no archive path)")}))
+      :agent/started (ansi/colorize :cyan (messages/t :workflow-runner/agent-started
+                                                      {:agent agent}))
+      :agent/completed (ansi/colorize :green (messages/t :workflow-runner/agent-completed
+                                                         {:agent agent}))
+      :agent/failed (ansi/colorize :red (messages/t :workflow-runner/agent-failed
+                                                    {:agent agent}))
+      :agent/status (ansi/colorize :cyan (messages/t :workflow-runner/agent-status
+                                                     {:agent agent
+                                                      :status (or (:message event)
+                                                                  (:status/type event)
+                                                                  (messages/t :workflow-runner/default-status))}))
+      :tool/invoked (ansi/colorize :yellow (messages/t :workflow-runner/tool-invoked
+                                                       {:tool-id tool-id}))
+      :tool/completed (ansi/colorize :green (messages/t :workflow-runner/tool-completed
+                                                        {:tool-id tool-id}))
+      :gate/started (ansi/colorize :yellow (messages/t :workflow-runner/gate-started
+                                                       {:gate gate}))
+      :gate/passed (ansi/colorize :green (messages/t :workflow-runner/gate-passed
+                                                     {:gate gate}))
+      :gate/failed (ansi/colorize :red (messages/t :workflow-runner/gate-failed
+                                                   {:gate gate}))
+      :dependency/health-updated
+      (dependency-event-line event
+                             :workflow-runner/dependency-health-updated
+                             (case (:dependency/status event)
+                               (:operator-action-required :misconfigured :unavailable) :red
+                               :degraded :yellow
+                               :green))
+      :dependency/recovered
+      (dependency-event-line event
+                             :workflow-runner/dependency-recovered
+                             :green)
+      :chain/completed (str (ansi/colorize :green (messages/t :workflow-runner/chain-step-completed
+                                                              {:chain-id (name (get event :chain/id :unknown))}))
+                            (when-let [d (:chain/duration-ms event)]
+                              (str " (" (fmt/format-duration d) ")")))
+      nil)))

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/display_format.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/display_format.clj
@@ -1,0 +1,33 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.workflow-runner.display-format
+  "Scalar value to display-string conversions shared by the display namespaces."
+  (:require
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} format-duration [ms]
+  (cond
+    (< ms 1000) (str ms "ms")
+    (< ms 60000) (format "%.1fs" (/ ms 1000.0))
+    :else (format "%.1fm" (/ ms 60000.0))))
+
+(defn ^{:stratum 0} humanize-keyword
+  [kw]
+  (some-> kw name (str/replace "-" " ")))

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/display_print.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/display_print.clj
@@ -1,0 +1,74 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.workflow-runner.display-print
+  "Printing of workflow header, summary, and final result to stdout."
+  (:require
+   [clojure.pprint]
+   [cheshire.core :as json]
+   [ai.miniforge.cli.app-config :as app-config]
+   [ai.miniforge.cli.messages :as messages]
+   [ai.miniforge.cli.workflow-runner.display-ansi :as ansi]
+   [ai.miniforge.cli.workflow-runner.display-format :as fmt]
+   [ai.miniforge.cli.workflow-runner.display-summary :as summary]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} print-workflow-header [workflow-id version quiet?]
+  (when-not quiet?
+    (println (ansi/colorize :cyan (str "\n" (apply str (repeat 65 "━")))))
+    (println (ansi/colorize :bold (messages/t :workflow-runner/header
+                                              {:display-name (app-config/display-name)})))
+    (println (ansi/colorize :cyan (messages/t :workflow-runner/workflow
+                                              {:workflow-id (name workflow-id)})))
+    (println (ansi/colorize :cyan (messages/t :workflow-runner/version
+                                              {:version version})))
+    (println (ansi/colorize :cyan (str (apply str (repeat 65 "━")) "\n")))
+    (flush)))
+
+(defn ^{:stratum 0} print-workflow-summary [result]
+  (let [{:execution/keys [status metrics errors]} result
+        success? (= status :completed)]
+    (println (if success?
+               (ansi/colorize :green (messages/t :workflow-runner/summary-success))
+               (ansi/colorize :red (messages/t :workflow-runner/summary-failure))))
+    (when metrics
+      (println (messages/t :workflow-runner/metrics
+                           {:tokens (:tokens metrics 0)
+                            :cost (format "%.4f" (:cost-usd metrics 0.0))
+                            :duration (fmt/format-duration (:duration-ms metrics 0))})))
+    (when (seq errors)
+      (println (ansi/colorize :red (str "\n" (messages/t :workflow-runner/errors))))
+      (doseq [err errors]
+        (println (str "  • " err))))))
+
+(defn ^{:stratum 0} print-pretty-result
+  "Print a compact human-readable summary of the workflow result.
+   Full EDN dump is available via --output edn."
+  [result]
+  (println (summary/format-compact-summary result)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} print-result [result {:keys [output quiet]}]
+  (when-not quiet
+    (case output
+      :json   (println (json/generate-string result {:pretty true}))
+      :pretty (print-pretty-result result)
+      :edn    (clojure.pprint/pprint result)
+      (clojure.pprint/pprint result)))
+  (flush))

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/display_progress.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/display_progress.clj
@@ -1,0 +1,43 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.workflow-runner.display-progress
+  "Live progress printing driven by an event-stream subscription."
+  (:require
+   [ai.miniforge.cli.workflow-runner.display-event-line :as event-line]
+   [ai.miniforge.event-stream.interface :as es]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} start-progress!
+  "Subscribe to lifecycle events and print concise progress lines.
+   Returns a cleanup function."
+  [event-stream quiet?]
+  (if (or quiet? (nil? event-stream))
+    (fn [] nil)
+    (let [sub-id (keyword (str "progress-" (random-uuid)))
+          last-line (atom nil)]
+      (es/subscribe! event-stream sub-id
+                     (fn [event]
+                       (when-let [line (event-line/format-event-line event)]
+                         ;; Deduplicate back-to-back duplicates from layered emitters.
+                         (when-not (= line @last-line)
+                           (reset! last-line line)
+                           (println line)
+                           (flush)))))
+      (fn []
+        (es/unsubscribe! event-stream sub-id)))))

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/display_result_facts.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/display_result_facts.clj
@@ -1,0 +1,97 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.workflow-runner.display-result-facts
+  "Pure readers that pull display facts out of a workflow execution result.")
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} phase-summary-outcome
+  [phase-result]
+  (let [status (get phase-result :status :unknown)]
+    (case status
+      :success :completed
+      :completed :completed
+      :already-implemented :completed
+      :done :completed
+      :error :failure
+      :failed :failure
+      :failure :failure
+      status)))
+
+(defn- ^{:stratum 0} phase-summary-duration-ms
+  [phase-result]
+  (or (:duration-ms phase-result)
+      (get-in phase-result [:metrics :duration-ms])
+      (get-in phase-result [:phase/metrics :duration-ms])))
+
+(defn- ^{:stratum 0} workflow-phase-result-entries
+  [result]
+  (when (map? result)
+    (seq (:execution/phase-results result))))
+
+(defn ^{:stratum 0} extract-failed-tasks
+  "Read failed DAG task ids from the canonical workflow DAG result.
+
+  Returns a vec of task-id strings, or nil when the workflow result does not
+  carry `[:execution/dag-result :failed-task-ids]`."
+  [result]
+  (when-let [ids (seq (get-in result [:execution/dag-result :failed-task-ids]))]
+    (not-empty (vec (map #(if (keyword? %) (name %) (str %)) ids)))))
+
+(defn- ^{:stratum 0} pr-info-url
+  [pr-info]
+  (or (:pr-url pr-info)
+      (:pr/url pr-info)))
+
+(defn- ^{:stratum 0} workflow-pr-infos
+  [result]
+  (concat (get result :execution/dag-pr-infos [])
+          (when-let [pr-info (:workflow/pr-info result)]
+            [pr-info])))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} phase-result-summary-entry
+  [[phase-id phase-result]]
+  (when (map? phase-result)
+    {:phase       phase-id
+     :outcome     (phase-summary-outcome phase-result)
+     :duration-ms (phase-summary-duration-ms phase-result)}))
+
+(defn ^{:stratum 1} extract-pr-urls
+  "Extract PR URLs from workflow-owned PR info.
+
+  Reads the canonical workflow context producers for PR info:
+  `:execution/dag-pr-infos` for DAG runs and `:workflow/pr-info` for the
+  release phase's single-PR path. Returns a vec of URL strings, or nil."
+  [result]
+  (when (map? result)
+    (let [all (distinct (keep pr-info-url (workflow-pr-infos result)))]
+      (not-empty (vec all)))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} extract-phase-summaries
+  "Extract phase summaries from canonical workflow execution results.
+
+  Reads only `:execution/phase-results`, the workflow context's documented
+  phase-result authority. Returns a vec of
+  {:phase :outcome :duration-ms} maps, or nil when no phase breakdown is found."
+  [result]
+  (when-let [entries (workflow-phase-result-entries result)]
+    (not-empty (vec (keep phase-result-summary-entry entries)))))

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/display_summary.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/display_summary.clj
@@ -53,7 +53,8 @@
   - Events directory pointer
   - '--output edn' hint
 
-  All user-facing strings go through messages/t."
+  Localizable text goes through messages/t; structural characters
+  (separators, newlines, bullets) are emitted directly."
   ([result] (format-compact-summary result nil))
   ([result _workflow-id]
    (str/join "\n" (compact-summary-lines result))))

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/display_summary.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/display_summary.clj
@@ -1,0 +1,59 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.workflow-runner.display-summary
+  "Assembly of the compact multi-line workflow summary."
+  (:require
+   [clojure.string :as str]
+   [ai.miniforge.cli.workflow-runner.display-ansi :as ansi]
+   [ai.miniforge.cli.workflow-runner.display-summary-lines :as lines]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} compact-summary-lines
+  [result]
+  (let [{:execution/keys [status metrics errors]} result
+        success? (= status :completed)
+        hr       (apply str (repeat 65 "━"))]
+    (concat [(ansi/colorize :cyan (str "\n" hr))
+             (lines/status-line success?)]
+            (lines/phase-lines result)
+            (lines/failed-task-lines result)
+            (lines/pr-lines result)
+            (lines/metrics-lines metrics)
+            (lines/error-lines success? errors)
+            (lines/footer-lines hr))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} format-compact-summary
+  "Build a compact multi-line string summarising a workflow result.
+
+  Lines included:
+  - Status (success/failure, colorized)
+  - Phase table (when phase data present)
+  - Failed task IDs (when present)
+  - PR URLs (when present)
+  - Metrics line (when metrics present)
+  - Error list (on failure only)
+  - Events directory pointer
+  - '--output edn' hint
+
+  All user-facing strings go through messages/t."
+  ([result] (format-compact-summary result nil))
+  ([result _workflow-id]
+   (str/join "\n" (compact-summary-lines result))))

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/display_summary_lines.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/display_summary_lines.clj
@@ -1,0 +1,102 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.workflow-runner.display-summary-lines
+  "The individual lines that make up a compact workflow summary."
+  (:require
+   [clojure.string :as str]
+   [ai.miniforge.cli.app-config :as app-config]
+   [ai.miniforge.cli.messages :as messages]
+   [ai.miniforge.cli.workflow-runner.display-ansi :as ansi]
+   [ai.miniforge.cli.workflow-runner.display-format :as fmt]
+   [ai.miniforge.cli.workflow-runner.display-result-facts :as facts]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} phase-outcome-symbol
+  "Return a display symbol for a phase outcome keyword."
+  [outcome]
+  (case outcome
+    :failure "✗"
+    :failed  "✗"
+    :error   "✗"
+    :skipped "○"
+    "✓"))
+
+(defn ^{:stratum 0} failed-task-lines
+  [result]
+  (when-let [task-ids (facts/extract-failed-tasks result)]
+    [(messages/t :workflow-runner/compact-failed-tasks
+                 {:task-ids (str/join ", " task-ids)})]))
+
+(defn ^{:stratum 0} metrics-lines
+  [metrics]
+  (when metrics
+    [(messages/t :workflow-runner/metrics
+                 {:tokens   (get metrics :tokens 0)
+                  :cost     (format "%.4f" (get metrics :cost-usd 0.0))
+                  :duration (fmt/format-duration (get metrics :duration-ms 0))})]))
+
+(defn ^{:stratum 0} status-line
+  [success?]
+  (if success?
+    (ansi/colorize :green (messages/t :workflow-runner/summary-success))
+    (ansi/colorize :red   (messages/t :workflow-runner/summary-failure))))
+
+(defn ^{:stratum 0} pr-lines
+  [result]
+  (when-let [urls (facts/extract-pr-urls result)]
+    [(messages/t :workflow-runner/compact-prs-created
+                 {:urls (str/join "  " urls)})]))
+
+(defn ^{:stratum 0} error-lines
+  [success? errors]
+  (when (and (not success?) (seq errors))
+    (into [(ansi/colorize :red (str "\n" (messages/t :workflow-runner/errors)))]
+          (map #(str "  • " %) errors))))
+
+(defn ^{:stratum 0} footer-lines
+  [hr]
+  [(ansi/colorize :cyan (str hr "\n"))
+   (messages/t :workflow-runner/compact-events-pointer
+               {:events-dir (app-config/events-dir)})
+   (messages/t :workflow-runner/compact-full-hint)])
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} format-phase-line
+  "Format a single phase summary line using message catalog."
+  [{:keys [phase outcome duration-ms]}]
+  (let [symbol (phase-outcome-symbol outcome)
+        phase-str (cond
+                    (nil? phase)     "?"
+                    (keyword? phase) (name phase)
+                    :else            (str phase))]
+    (if duration-ms
+      (messages/t :workflow-runner/compact-phase-line
+                  {:symbol   symbol
+                   :phase    phase-str
+                   :duration (fmt/format-duration duration-ms)})
+      (messages/t :workflow-runner/compact-phase-no-dur
+                  {:symbol symbol
+                   :phase  phase-str}))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} phase-lines
+  [result]
+  (map format-phase-line (or (facts/extract-phase-summaries result) [])))

--- a/docs/pull-requests/2026-08-09-refactor-split-wr-display-1.md
+++ b/docs/pull-requests/2026-08-09-refactor-split-wr-display-1.md
@@ -1,0 +1,102 @@
+# refactor(cli): split workflow_runner/display.clj — extract display namespaces (rule 210, 1/2)
+
+## Overview
+
+`bases/cli/src/ai/miniforge/cli/workflow_runner/display.clj` carries 8 real
+strata against the rule-210 budget of 3 — the worst SL003 offender left in
+`workflow_runner/`. This is PR 1 of 2 that splits it into ten sibling
+namespaces, each a named vocabulary of ≤3 strata.
+
+**PR 1 (this one) — extraction.** Create the ten new namespaces containing the
+moved code. `display.clj` is not touched; the new namespaces are standalone and
+nothing requires them yet.
+
+**PR 2 (follow-up) — the flip.** Rewrite `display.clj` to require the new
+namespaces, delete the moved definitions, and re-export the public vars its
+callers use.
+
+## Motivation
+
+Two constraints force the two-PR shape:
+
+- **SL003 is a staged-file gate.** The pre-commit stratum-lint run only sees
+  files in the commit. Because this PR never stages `display.clj`, its existing
+  8-stratum violation is not re-reported, and no budget override is needed.
+- **600-reportable-line PR budget.** Extraction plus flip in one PR would carry
+  both the new files and the rewrite of `display.clj` in one diff. Split in two,
+  each half stays inside the budget.
+
+## Changes in Detail
+
+New files under `bases/cli/src/ai/miniforge/cli/workflow_runner/`:
+
+| Namespace (`…workflow-runner.`) | Vocabulary | Strata |
+|---|---|---|
+| `display-ansi` | ANSI escape-code styling | 2 |
+| `display-format` | scalar → display-string conversions | 1 |
+| `display-event-line` | colorized lifecycle-event lines | 3 |
+| `display-demo-line` | plain-text (ANSI-stripped) event lines | 2 |
+| `display-progress` | live progress via event-stream subscription | 1 |
+| `display-result-facts` | pure readers over a workflow result | 3 |
+| `display-summary-lines` | individual compact-summary lines | 3 |
+| `display-summary` | compact-summary assembly | 2 |
+| `display-print` | header / summary / result printing | 2 |
+| `display-error-help` | operator-facing failure help | 1 |
+
+Dependency graph among the new namespaces (one-way, no cycles):
+
+```text
+display-ansi ────┬─> display-event-line ─┬─> display-demo-line
+display-format ──┘                       └─> display-progress
+                 ├─> display-error-help
+                 └─> display-summary-lines ─> display-summary ─> display-print
+display-result-facts ──> display-summary-lines
+```
+
+Definitions moved verbatim except for:
+
+- `strip-ansi` and `humanize-keyword` change from `defn-` to `defn` — they are
+  now consumed across a namespace boundary.
+- The `compact-*` line builders in `display-summary-lines` become public and
+  drop the `compact-` prefix (`compact-status-line` → `status-line`, and so on);
+  the namespace name now carries that qualifier, so `lines/status-line` reads
+  without stutter.
+
+## Testing Plan
+
+- `stratum-lint` (pin `bef8657`), plain and `--fix` on copies, over all ten new
+  files: clean, and `--fix` proposes **zero** changes — the hand-written
+  `^{:stratum n}` metadata and `Layer N` headings match the strata computed from
+  each file's reference graph, and every file is within the 3-stratum budget.
+- `clj-kondo`: 0 errors, 0 warnings.
+- Behavioural equivalence harness: 152 paired comparisons of every moved public
+  function against its `display.clj` original — ANSI codes, `colorize` over 7
+  colors, `format-duration` at each boundary, `format-event-line` and
+  `format-demo-line` over 40 event shapes, the four extractors, compact-summary
+  assembly, all print functions captured via `with-out-str`, and
+  `start-progress!` driven over a real event stream. **0 mismatches.**
+- `display-test` + `display-output-test`: 74 tests, 168 assertions, 0 failures,
+  0 errors. Neither namespace changes in this PR; the run proves the new files
+  do not interfere.
+
+## Deployment Plan
+
+No behaviour change and no runtime effect: the new namespaces are not required
+by anything until PR 2. Ships with the ordinary merge to `main`.
+
+## Related Issues/PRs
+
+- Follow-up: PR 2 rewires `display.clj` and deletes the moved code.
+- Rules: `standards/miniforge/languages/clojure` (210),
+  `standards/miniforge/foundations/stratified-design` (001).
+
+## Checklist
+
+- [x] Ten new namespaces created, each ≤3 strata
+- [x] Apache header on every new file
+- [x] `^{:stratum n}` metadata agrees with `Layer N` headings
+- [x] stratum-lint plain + `--fix` dry run clean
+- [x] clj-kondo clean
+- [x] Behavioural equivalence verified against `display.clj`
+- [x] `display-test` / `display-output-test` green
+- [ ] PR 2: flip `display.clj` to require + re-export, delete moved code


### PR DESCRIPTION
## The two-PR plan

`bases/cli/src/ai/miniforge/cli/workflow_runner/display.clj` (502 lines) carries
**8 real strata** against the rule-210 budget of 3 — the worst remaining SL003
offender in `workflow_runner/`. It is split into ten sibling namespaces over two
PRs:

- **PR 1 — this one: extraction.** Create the ten new namespaces holding the
  moved code. `display.clj` is **not touched**; the new namespaces are
  standalone and nothing requires them yet.
- **PR 2 — the flip.** Rewrite `display.clj` to require the new namespaces,
  delete the moved definitions, and re-export the public vars its callers use
  (`colorize`, `print-result`, `print-workflow-header`, `start-progress!`,
  `format-duration`, `ansi-codes`, `format-event-line`, `format-demo-line`,
  `format-compact-summary`, `print-pretty-result`, `print-workflow-summary`,
  the three `extract-*` readers, and the four error-help printers).

## Why phase 1 leaves display.clj untouched

Two gates force the split:

- **SL003 is a staged-file gate.** Pre-commit stratum-lint only inspects files
  in the commit. Because no commit here stages `display.clj`, its existing
  8-stratum violation is never re-reported, so no budget override is needed and
  no `warn` mode is used.
- **600-reportable-line PR budget.** Extraction plus flip in one PR would carry
  both the new files and the `display.clj` rewrite. Split in two, each half
  stays inside the budget without an override. This PR is 460 reportable lines
  across three commits of 125 / 182 / 153, each under the 200 commit ceiling.

## The split

| Namespace (`ai.miniforge.cli.workflow-runner.`) | Vocabulary | Strata |
|---|---|---|
| `display-ansi` | ANSI escape-code styling | 2 |
| `display-format` | scalar to display-string conversions | 1 |
| `display-event-line` | colorized lifecycle-event lines | 3 |
| `display-demo-line` | plain-text (ANSI-stripped) event lines | 2 |
| `display-progress` | live progress via event-stream subscription | 1 |
| `display-result-facts` | pure readers over a workflow result | 3 |
| `display-summary-lines` | individual compact-summary lines | 3 |
| `display-summary` | compact-summary assembly | 2 |
| `display-print` | header / summary / result printing | 2 |
| `display-error-help` | operator-facing failure help | 1 |

One-way dependency graph among them, no cycles:

```text
display-ansi ────┬─> display-event-line ─┬─> display-demo-line
display-format ──┘                       └─> display-progress
                 ├─> display-error-help
                 └─> display-summary-lines ─> display-summary ─> display-print
display-result-facts ──> display-summary-lines
```

All 41 definitions in `display.clj` are accounted for exactly once across the
ten files, verbatim except:

- `strip-ansi` and `humanize-keyword` change from `defn-` to `defn` — they are
  now consumed across a namespace boundary.
- The seven `compact-*` line builders in `display-summary-lines` become public
  and drop the `compact-` prefix (`compact-status-line` -> `status-line`, and so
  on); the namespace name carries that qualifier, so `lines/status-line` reads
  without stutter.

## Testing

- **stratum-lint** (pin `bef8657`) plain over all ten files: clean. `--fix` on
  copies proposes **zero** changes, so the hand-written `^{:stratum n}` metadata
  and `Layer N` headings match the strata computed from each file's reference
  graph, and every file is inside the 3-stratum budget.
- **clj-kondo**: 0 errors, 0 warnings. (No unused-namespace warnings — every
  `:require` in the new files is used by a sibling; the files themselves being
  unrequired is not something clj-kondo flags.)
- **Behavioural equivalence harness**: 152 paired comparisons of every moved
  public function against its `display.clj` original — `ansi-codes`, `colorize`
  over 7 colors, `format-duration` at each boundary, `format-event-line` and
  `format-demo-line` over 40 event shapes (including all five phase outcomes and
  all five dependency statuses), the four extractors, compact-summary assembly,
  every print function captured via `with-out-str`, and `start-progress!` driven
  over a real event stream. **0 mismatches.**
- **`display-test` + `display-output-test`**: 74 tests, 168 assertions, 0
  failures, 0 errors. Neither test namespace changes here; the run proves the
  new files do not interfere.
- **Full `bb pre-commit`** green on each of the three commits.

## Notes for review

- Duplicated `(repeat 65 "━")` now appears in two namespaces (`display-print`
  and `display-summary`) where it previously appeared twice in one file. Left
  as-is to keep this PR a pure move; naming it is a follow-up.
- `MINIFORGE_COMMIT_BUDGET_OVERRIDE` cannot be used with the pre-commit hook in
  this repo: `development/test/commit_budget_test.clj`
  (`non-merge-commit-still-budgeted-test`) reads the ambient env var, so the
  override makes the hook's own smoke tests fail. Worked around by splitting
  into three sub-200-line commits; flagged as a separate defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
