### PR TITLE
fix(cli): send the preflight prompt the way the backend expects

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/preflight_probe.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/preflight_probe.clj
@@ -67,13 +67,22 @@
   (into [cmd-path "-p" (support/backend-preflight-prompt)]
         (support/claude-preflight-args)))
 
-(defn- ^{:stratum 0} generic-preflight-command
+(defn- ^{:stratum 0} generic-preflight-invocation
+  "Build `{:args :stdin}` for a non-Claude backend's health probe the
+   same way the llm brick builds them for a real call: the backend's
+   declared `:prompt-via` goes into the request so `:args-fn` shapes
+   argv for that mode, and a `:stdin` backend (codex, whose argv ends
+   in the `-` placeholder) gets the prompt piped in rather than left
+   out entirely. The caller prepends the resolved CLI path."
   [llm-client]
   (let [{:keys [backend model]} (:config llm-client)
-        {:keys [cmd args-fn]} (get llm/backends backend)
-        request (cond-> {:prompt (support/backend-preflight-prompt)}
+        {:keys [args-fn] :as backend-config} (get llm/backends backend)
+        prompt (support/backend-preflight-prompt)
+        prompt-via (llm/backend-prompt-via backend-config)
+        request (cond-> {:prompt prompt :prompt-via prompt-via}
                   model (assoc :model model))]
-    (into [cmd] (args-fn request))))
+    {:args (vec (args-fn request))
+     :stdin (when (= :stdin prompt-via) prompt)}))
 
 ;------------------------------------------------------------------------------ Layer 1
 
@@ -81,10 +90,12 @@
   [llm-client cmd-path workdir]
   (let [{:keys [backend]} (:config llm-client)
         backend-config (get llm/backends backend)
-        full-cmd (into [cmd-path] (rest (generic-preflight-command llm-client)))
+        {:keys [args stdin]} (generic-preflight-invocation llm-client)
+        full-cmd (into [cmd-path] args)
         {:keys [out err exit timeout-ms]} (process/run-cli-command full-cmd
                                                                    (support/backend-preflight-timeout-ms)
-                                                                   :workdir workdir)
+                                                                   :workdir workdir
+                                                                   :stdin stdin)
         content (support/decoded-preflight-content backend-config out)]
     (cond
       timeout-ms

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/process.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/process.clj
@@ -86,6 +86,9 @@
 
 (defn ^{:stratum 2} run-cli-command
   [cmd timeout-ms & {:keys [workdir stdin]}]
+  (when (and (some? stdin) (not (string? stdin)))
+    (throw (ex-info "run-cli-command :stdin must be a string"
+                    {:stdin-type (type stdin)})))
   (let [^Process process (start-cli-process cmd workdir)
         in-future (stream-writer (.getOutputStream process) stdin)
         out-future (stream-reader (.getInputStream process))

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/process.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/process.clj
@@ -37,6 +37,24 @@
     (with-open [stream stream]
       (slurp stream))))
 
+(defn- ^{:stratum 0} stream-writer
+  "Feed `input` to the process stdin and close it, off-thread: a child
+   that never drains stdin would otherwise block the caller on a full
+   pipe buffer past the command timeout. A nil/empty `input` just
+   closes the stream, which is what a prompt-in-argv backend wants.
+
+   A write failure is ignored, matching `await-stream`: it means the
+   child exited or was destroyed before reading, and that outcome
+   already reaches the caller as an exit code, stderr, or a timeout."
+  [^java.io.OutputStream stream ^String input]
+  (future
+    (try
+      (with-open [out stream]
+        (when (seq input)
+          (.write out (.getBytes input "UTF-8"))
+          (.flush out)))
+      (catch Exception _ nil))))
+
 (defn- ^{:stratum 0} destroy-cli-process!
   [^Process process]
   (try
@@ -67,15 +85,16 @@
 ;------------------------------------------------------------------------------ Layer 2
 
 (defn ^{:stratum 2} run-cli-command
-  [cmd timeout-ms & {:keys [workdir]}]
+  [cmd timeout-ms & {:keys [workdir stdin]}]
   (let [^Process process (start-cli-process cmd workdir)
-        _ (.close (.getOutputStream process))
+        in-future (stream-writer (.getOutputStream process) stdin)
         out-future (stream-reader (.getInputStream process))
         err-future (stream-reader (.getErrorStream process))
         completed? (.waitFor process timeout-ms java.util.concurrent.TimeUnit/MILLISECONDS)]
     (if-not completed?
       (do
         (destroy-cli-process! process)
+        (future-cancel in-future)
         (future-cancel out-future)
         (future-cancel err-future)
         {:out ""

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/preflight_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/preflight_test.clj
@@ -162,16 +162,15 @@
 (deftest ^{:stratum 0} run-backend-preflight-exercises-generic-cli-success-path-test
   (testing "non-Claude CLI backends decode streamed CLI output and accept the canonical ok payload"
     (let [llm-client (llm/create-client {:backend :codex})
-          seen-cmd (atom nil)
-          seen-timeout (atom nil)
-          seen-workdir (atom nil)
+          seen (atom nil)
           output (with-out-str
                    (with-redefs-fn {#'paths/resolve-cli-command-path (fn [_] "/Users/chris/.local/bin/codex")
                                     #'probe/read-cli-version (fn [_] {:success true :version "1.2.3"})
-                                    #'process/run-cli-command (fn [cmd timeout-ms & {:keys [workdir]}]
-                                                            (reset! seen-cmd cmd)
-                                                            (reset! seen-timeout timeout-ms)
-                                                            (reset! seen-workdir workdir)
+                                    #'process/run-cli-command (fn [cmd timeout-ms & {:keys [workdir stdin]}]
+                                                            (reset! seen {:cmd cmd
+                                                                          :timeout-ms timeout-ms
+                                                                          :workdir workdir
+                                                                          :stdin stdin})
                                                             {:out "{\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\",\"text\":\"{\\\"ok\\\":true}\"}}\n{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}"
                                                              :err ""
                                                              :exit 0})}
@@ -179,15 +178,42 @@
                        (#'preflight/run-backend-preflight!
                         false
                         llm-client
-                        {:worktree-path "/tmp/runtime-worktree"}))))]
+                        {:worktree-path "/tmp/runtime-worktree"}))))
+          {:keys [cmd timeout-ms workdir stdin]} @seen]
       (is (str/includes? output "Backend: codex"))
       (is (str/includes? output "Backend Path: /Users/chris/.local/bin/codex"))
       (is (str/includes? output "Backend Version: 1.2.3"))
-      (is (= "/Users/chris/.local/bin/codex" (first @seen-cmd)))
-      (is (= ["exec" "--json"] (take 2 (rest @seen-cmd))))
-      (is (= "Reply with exactly {\"ok\":true}" (last @seen-cmd)))
-      (is (= 30000 @seen-timeout))
-      (is (= "/tmp/runtime-worktree" @seen-workdir)))))
+      (is (= "/Users/chris/.local/bin/codex" (first cmd)))
+      (is (= ["exec" "--json"] (take 2 (rest cmd))))
+      (is (= 30000 timeout-ms))
+      (is (= "/tmp/runtime-worktree" workdir))
+      (testing "codex takes its prompt on stdin, so argv ends in the `-` placeholder"
+        (is (= "-" (last cmd)))
+        (is (not-any? #{"Reply with exactly {\"ok\":true}"} cmd)))
+      (testing "and the probe actually pipes that prompt in"
+        (is (= "Reply with exactly {\"ok\":true}" stdin))))))
+
+(deftest ^{:stratum 0} run-backend-preflight-keeps-argv-backend-prompt-in-argv-test
+  (testing "a backend declaring :prompt-via :argv still carries the prompt as an argument, with no stdin"
+    (let [llm-client (llm/create-client {:backend :opencode})
+          seen (atom nil)
+          output (with-out-str
+                   (with-redefs-fn {#'paths/resolve-cli-command-path (fn [_] "/opt/homebrew/bin/opencode")
+                                    #'probe/read-cli-version (fn [_] {:success true :version "0.4.1"})
+                                    #'process/run-cli-command (fn [cmd _timeout-ms & {:keys [stdin]}]
+                                                            (reset! seen {:cmd cmd :stdin stdin})
+                                                            {:out "{\"ok\":true}"
+                                                             :err ""
+                                                             :exit 0})}
+                     (fn []
+                       (#'preflight/run-backend-preflight!
+                        false
+                        llm-client
+                        {:worktree-path "/tmp/runtime-worktree"}))))
+          {:keys [cmd stdin]} @seen]
+      (is (str/includes? output "Backend: opencode"))
+      (is (= ["/opt/homebrew/bin/opencode" "run" "Reply with exactly {\"ok\":true}"] cmd))
+      (is (nil? stdin)))))
 
 ;------------------------------------------------------------------------------ Layer 1
 
@@ -196,6 +222,19 @@
     (let [result (#'process/run-cli-command [(shell-path) "-lc" "printf ok; printf warn >&2"] 5000)]
       (is (= "ok" (:out result)))
       (is (= "warn" (:err result)))
+      (is (= 0 (:exit result))))))
+
+(deftest ^{:stratum 1} run-cli-command-pipes-stdin-to-the-child-test
+  (testing "the :stdin option reaches the subprocess"
+    (let [result (#'process/run-cli-command [(shell-path) "-lc" "cat"] 5000
+                                            :stdin "prompt-on-stdin")]
+      (is (= "prompt-on-stdin" (:out result)))
+      (is (= 0 (:exit result))))))
+
+(deftest ^{:stratum 1} run-cli-command-closes-stdin-without-input-test
+  (testing "omitting :stdin still closes the stream so a reading child sees EOF"
+    (let [result (#'process/run-cli-command [(shell-path) "-lc" "cat"] 5000)]
+      (is (= "" (:out result)))
       (is (= 0 (:exit result))))))
 
 (deftest ^{:stratum 1} run-cli-command-times-out-fast-test

--- a/components/llm/src/ai/miniforge/llm/interface.clj
+++ b/components/llm/src/ai/miniforge/llm/interface.clj
@@ -34,6 +34,25 @@
   "Available CLI backends."
   impl/backends)
 
+(defn ^{:stratum 0} backend-prompt-via
+  "Given a backend entry from `backends`, return how its CLI expects the
+   user prompt: `:argv` (prompt is an argument, supplied by the entry's
+   `:args-fn`) or `:stdin` (argv carries a placeholder such as codex's
+   `-` and the prompt must be piped to the process). A backend that
+   declares nothing gets `:argv`.
+
+   Callers building a backend command themselves must pass the result
+   into `:args-fn` as `:prompt-via` and honor it when starting the
+   process. Not doing so is how the CLI preflight probe came to send
+   codex an empty prompt: `codex-args` saw no `:prompt-via`, defaulted
+   to stdin, emitted the `-` placeholder, and the prompt went nowhere.
+
+   The impl's own `resolve-prompt-via` answers the same question for
+   the in-brick call path; `backend-prompt-via-matches-impl-test` pins
+   the two together."
+  [backend-config]
+  (get backend-config :prompt-via :argv))
+
 ;; Re-export protocol for public API
 (def ^{:stratum 0} LLMClient
   "Protocol clients implement for LLM interaction; the public extensibility

--- a/components/llm/test/ai/miniforge/llm/interface_test.clj
+++ b/components/llm/test/ai/miniforge/llm/interface_test.clj
@@ -923,6 +923,26 @@
     (is (= :argv (:prompt-via (get impl/backends :opencode))))
     (is (= :argv (:prompt-via (get impl/backends :echo))))))
 
+(deftest ^{:stratum 0} backend-prompt-via-test
+  (testing "reads the declared delivery mode for callers building a backend command themselves"
+    (is (= :stdin (llm/backend-prompt-via (get llm/backends :codex))))
+    (is (= :argv (llm/backend-prompt-via (get llm/backends :opencode)))))
+
+  (testing "an undeclared mode falls back to argv"
+    (is (= :argv (llm/backend-prompt-via {:cmd "some-cli"})))))
+
+(deftest ^{:stratum 0} backend-prompt-via-matches-impl-test
+  (testing "the public accessor and the in-brick resolver cannot drift apart"
+    (let [resolve-prompt-via (var-get (ns-resolve 'ai.miniforge.llm.protocols.impl.llm-client
+                                                  'resolve-prompt-via))]
+      (doseq [[backend-key backend-config] impl/backends]
+        (is (= (resolve-prompt-via backend-config)
+               (llm/backend-prompt-via backend-config))
+            (str "prompt delivery disagrees for " backend-key)))
+      (is (= (resolve-prompt-via {:cmd "some-cli"})
+             (llm/backend-prompt-via {:cmd "some-cli"}))
+          "an undeclared mode must fall back the same way on both sides"))))
+
 ;; default-exec-fn / stream-exec-fn — :stdin opt is piped to the subprocess
 ;;
 ;; Use `cat` as the subprocess: stdin is echoed verbatim to stdout, so we

--- a/docs/pull-requests/2026-08-09-fix-codex-preflight-prompt.md
+++ b/docs/pull-requests/2026-08-09-fix-codex-preflight-prompt.md
@@ -1,0 +1,105 @@
+# fix(cli): deliver the backend preflight prompt the way the backend expects
+
+## Overview
+
+The CLI's backend preflight probe built a codex command whose argv ended
+in `-` — codex's "prompt arrives on stdin" placeholder — and then ran it
+with stdin closed immediately. Codex therefore received an empty prompt
+on every preflight, and the probe's verdict said nothing about whether
+the backend could actually answer.
+
+## Motivation
+
+`components/llm` moved codex to stdin prompt delivery in #1024
+(`:prompt-via :stdin` in `llm/backends.edn`, `codex-args` defaulting to
+`:stdin` and appending `-`). Real execution in the llm brick handles both
+halves of that contract: `resolve-prompt-via` reads the backend's declared
+mode, passes it into `:args-fn` so argv is shaped for it, and pipes the
+prompt through the exec layer's `:stdin` option.
+
+The CLI preflight probe reads the same `llm/backends` map and calls the
+same `:args-fn`, but did neither. It passed no `:prompt-via`, so
+`codex-args` fell through to its `:stdin` default and dropped the prompt
+from argv; and `process/run-cli-command` closed the child's stdin before
+the process could read anything.
+
+`ai.miniforge.cli.workflow-runner.preflight-test/run-backend-preflight-exercises-generic-cli-success-path-test`
+failed on main asserting the prompt was the last argv element. That
+assertion was stale, but the reason it was stale is a production defect,
+not a test-only drift.
+
+## Changes in Detail
+
+### `components/llm`
+
+- New `llm/backend-prompt-via` on the interface: the public accessor for a
+  backend's declared prompt-delivery mode, so a caller building a backend
+  command need not restate the `:argv` fallback from memory. The impl keeps
+  its private `resolve-prompt-via` for the in-brick path; a new test asserts
+  the two agree across every backend and on an undeclared map, so they
+  cannot drift.
+
+  The accessor is a separate defn rather than a re-export of the impl's
+  private fn because publishing that var means editing
+  `protocols/impl/llm_client.clj`, which fails the pre-commit stratum gate
+  on a pre-existing SL003 (11 distinct layers, max 3) that also reproduces
+  on untouched `origin/main`. Splitting that namespace is its own change,
+  not this one.
+
+### `bases/cli`
+
+- `process/run-cli-command` accepts a `:stdin` option. The string is written
+  to the child's stdin on a background thread and the stream is then closed;
+  a nil/empty value just closes it, preserving the previous behavior for
+  argv backends. Off-thread so a child that never drains stdin cannot block
+  the caller past the command timeout.
+- `preflight-probe/generic-preflight-command` becomes
+  `generic-preflight-invocation`, returning `{:args :stdin}`. It threads the
+  backend's declared `:prompt-via` into the `:args-fn` request and returns
+  the prompt as stdin when the backend expects it there.
+
+The Claude probe is unchanged: it does not go through `:args-fn`, and its
+direct `-p <prompt>` form is a valid claude CLI invocation.
+
+## Testing Plan
+
+- `run-backend-preflight-exercises-generic-cli-success-path-test` now pins
+  both halves of the codex contract: argv ends in `-` and carries no prompt
+  text, and the probe pipes the prompt via `:stdin`.
+- New `run-backend-preflight-keeps-argv-backend-prompt-in-argv-test` covers
+  the `:prompt-via :argv` side (opencode): prompt in argv, no stdin.
+- New `run-cli-command-pipes-stdin-to-the-child-test` and
+  `run-cli-command-closes-stdin-without-input-test` exercise the subprocess
+  layer against a real `cat`.
+- New `backend-prompt-via-test` and `backend-prompt-via-matches-impl-test`
+  in the llm interface tests pin the accessor, its `:argv` fallback, and its
+  agreement with the impl's resolver.
+
+Run:
+
+```zsh
+clojure -M:dev:test -e "(require 'clojure.test 'ai.miniforge.cli.workflow-runner.preflight-test) (clojure.test/run-tests 'ai.miniforge.cli.workflow-runner.preflight-test)"
+clojure -M:dev:test -e "(require 'clojure.test 'ai.miniforge.llm.interface-test 'ai.miniforge.llm.args-fn-test) (clojure.test/run-tests 'ai.miniforge.llm.interface-test 'ai.miniforge.llm.args-fn-test)"
+```
+
+Both green: 15 tests / 49 assertions and 90 tests / 368 assertions, 0
+failures, 0 errors.
+
+## Deployment Plan
+
+No migration or configuration change. The preflight probe starts sending a
+real prompt to codex; a codex install that was silently "passing" preflight
+on an empty prompt may now fail preflight, which is the intended
+fail-closed behavior.
+
+## Related Issues/PRs
+
+- #1024 `fix(llm): send codex prompts via stdin` — introduced the contract
+  the preflight probe did not follow.
+
+## Checklist
+
+- [x] Preflight namespace tests pass
+- [x] llm interface + args-fn tests pass
+- [x] No other caller of `llm/backends` `:args-fn` outside the llm brick
+- [x] Apache 2.0 headers unchanged on all touched sources


### PR DESCRIPTION
## Summary

The CLI backend preflight probe built a codex command whose argv ended in `-` — codex's "prompt arrives on stdin" placeholder — and then ran it with stdin closed immediately. Codex received an empty prompt on every preflight, so the probe's verdict said nothing about whether the backend could actually answer.

The failing test on `main` (`preflight-test/run-backend-preflight-exercises-generic-cli-success-path-test`, asserting the prompt was the last argv element) was stale, but the reason it was stale is a production defect, not test drift.

**Root cause.** `components/llm` moved codex to stdin delivery in #1024 (`:prompt-via :stdin` in `llm/backends.edn`, `codex-args` defaulting to `:stdin` and appending `-`). The llm brick honors both halves of that contract on the real call path: `resolve-prompt-via` reads the declared mode, passes it into `:args-fn` so argv is shaped for it, and pipes the prompt through the exec layer's `:stdin` option. The CLI preflight probe reads the same `llm/backends` map and calls the same `:args-fn`, but did neither — it passed no `:prompt-via`, so `codex-args` fell through to its `:stdin` default and dropped the prompt from argv, and `process/run-cli-command` closed the child's stdin before it could read anything.

**Fix.** Mirror the real call path.

- `process/run-cli-command` accepts a `:stdin` option: written to the child's stdin on a background thread, then closed. A nil/empty value just closes it, preserving previous behavior for argv backends. Off-thread so a child that never drains stdin cannot block the caller past the command timeout.
- `preflight-probe/generic-preflight-command` becomes `generic-preflight-invocation`, returning `{:args :stdin}`: it threads the backend's declared `:prompt-via` into the `:args-fn` request and returns the prompt as stdin when the backend expects it there.
- New `llm/backend-prompt-via` is the public accessor for that mode, so a caller building a backend command need not restate the `:argv` fallback from memory. It is a separate defn rather than a re-export of the impl's private `resolve-prompt-via` because publishing that var means editing `protocols/impl/llm_client.clj`, which fails the pre-commit stratum gate on a pre-existing SL003 (11 distinct layers, max 3) that reproduces on untouched `origin/main`. A test asserts the two agree across every backend and on an undeclared map, so they cannot drift.

The Claude probe is unchanged: it does not go through `:args-fn`, and its direct `-p <prompt>` form is a valid claude CLI invocation.

Behavior note: a codex install that was silently "passing" preflight on an empty prompt may now fail preflight. That is the intended fail-closed outcome.

Full write-up: `docs/pull-requests/2026-08-09-fix-codex-preflight-prompt.md`

## Testing

```zsh
clojure -M:dev:test -e "(require 'clojure.test 'ai.miniforge.cli.workflow-runner.preflight-test 'ai.miniforge.llm.interface-test 'ai.miniforge.llm.args-fn-test) (clojure.test/run-tests 'ai.miniforge.cli.workflow-runner.preflight-test 'ai.miniforge.llm.interface-test 'ai.miniforge.llm.args-fn-test)"
```

106 tests, 428 assertions, 0 failures, 0 errors. `bb pre-commit` passed (342 tests / 1291 assertions smoke set, plus GraalVM compatibility).

Tests added or changed:

- `run-backend-preflight-exercises-generic-cli-success-path-test` now pins both halves of the codex contract: argv ends in `-` and carries no prompt text, and the probe pipes the prompt via `:stdin`.
- `run-backend-preflight-keeps-argv-backend-prompt-in-argv-test` covers the `:prompt-via :argv` side (opencode): prompt in argv, no stdin.
- `run-cli-command-pipes-stdin-to-the-child-test` and `run-cli-command-closes-stdin-without-input-test` exercise the subprocess layer against a real `cat`.
- `backend-prompt-via-test` and `backend-prompt-via-matches-impl-test` pin the new accessor, its `:argv` fallback, and its agreement with the impl resolver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
