### PR TITLE
fix(cli): close the artifact store on every exit path of execute-with-events

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/execution.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/execution.clj
@@ -68,7 +68,6 @@
         (let [result (execute-workflow-pipeline run-pipeline workflow workflow-input context artifact-store event-stream)]
           (lifecycle/publish-completion-event event-stream workflow-id result)
           (reset! completed? true)
-          (close-artifact-store artifact-store)
           (display/print-result result opts)
           result))
       (catch Object _
@@ -82,6 +81,10 @@
         (when-not @completed?
           (lifecycle/publish-failure-event! event-stream workflow-id :cancelled
                                             (messages/t :workflow-runner/cancelled)))
+        ;; Every exit path — completion, sandbox-setup failure, throw —
+        ;; must release the transit store the caller opened before
+        ;; sandbox setup; per-branch closes leaked it on the failure paths.
+        (close-artifact-store artifact-store)
         (when sandbox-cleanup
           (sandbox-cleanup)
           (when-not (:quiet opts)

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/execution_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/execution_test.clj
@@ -1,0 +1,92 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.workflow-runner.execution-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [slingshot.slingshot :refer [try+]]
+   [ai.miniforge.artifact.interface :as artifact]
+   [ai.miniforge.cli.workflow-runner.display :as display]
+   [ai.miniforge.cli.workflow-runner.execution :as execution]
+   [ai.miniforge.cli.workflow-runner.lifecycle :as lifecycle]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} execute-recording-closes
+  "Run `execute-with-events` with `overrides` merged over a minimal input,
+   recording every store handed to `artifact/close-store`. Returns
+   {:result ... :closed [...]} on normal return, {:thrown ... :closed [...]}
+   when the call throws."
+  [overrides]
+  (let [closed (atom [])
+        base {:run-pipeline (fn [_workflow _input _callbacks] {:success? true})
+              :workflow {}
+              :workflow-input {}
+              :context {}
+              :artifact-store ::sentinel-store
+              :event-stream nil
+              :workflow-id "wf-execution-test"
+              :sandbox-cleanup nil
+              :opts {:quiet true}}
+        outcome (with-redefs-fn {#'artifact/close-store (fn [store]
+                                                          (swap! closed conj store)
+                                                          nil)
+                                 #'lifecycle/publish-completion-event (fn [_stream _id _result] nil)
+                                 #'lifecycle/publish-failure-event! (fn [_stream _id _type _msg] nil)
+                                 #'display/print-result (fn [_result _opts] nil)}
+                  (fn []
+                    (try+
+                      {:result (execution/execute-with-events (merge base overrides))}
+                      (catch Object thrown
+                        {:thrown thrown}))))]
+    (assoc outcome :closed @closed)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} run-sandbox-failure
+  "Drive `execute-with-events` down the sandbox-setup-failure branch.
+   The pipeline stub throws — that branch must never reach it."
+  []
+  (execute-recording-closes
+   {:context {:sandbox-error {:error "container boot failed"}}
+    :run-pipeline (fn [_workflow _input _callbacks]
+                    (throw (ex-info "pipeline must not run after sandbox failure" {})))}))
+
+(deftest ^{:stratum 1} execute-with-events-closes-store-once-on-success-test
+  (testing "completion path releases the artifact store exactly once"
+    (let [{:keys [result closed]} (execute-recording-closes {})]
+      (is (true? (:success? result)))
+      (is (= [::sentinel-store] closed)))))
+
+(deftest ^{:stratum 1} execute-with-events-closes-store-when-pipeline-throws-test
+  (testing "a pipeline exception still releases the artifact store before rethrowing"
+    (let [{:keys [result thrown closed]} (execute-recording-closes
+                                          {:run-pipeline (fn [_workflow _input _callbacks]
+                                                           (throw (ex-info "pipeline exploded" {})))})]
+      (is (nil? result))
+      (is (some? thrown))
+      (is (= [::sentinel-store] closed)))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} execute-with-events-closes-store-on-sandbox-failure-test
+  (testing "sandbox-setup failure reports the error and releases the artifact store"
+    (let [{:keys [result thrown closed]} (run-sandbox-failure)]
+      (is (nil? thrown))
+      (is (false? (:success? result)))
+      (is (= :sandbox-setup-failed (get-in result [:errors 0 :type])))
+      (is (= [::sentinel-store] closed)))))

--- a/docs/pull-requests/2026-08-09-fix-cli-artifact-store-leak-on-sandbox-failure.md
+++ b/docs/pull-requests/2026-08-09-fix-cli-artifact-store-leak-on-sandbox-failure.md
@@ -87,12 +87,13 @@ task rather than widening this diff.
 
 ## Testing Plan
 
-- `clojure -M:dev:test` on the new namespace: 3 tests, 9 assertions,
-  green.
+- `clojure -M:dev:test` on the merged namespace (this branch's 3
+  store-lifecycle tests plus #1723's 5 result-shape tests): 8 tests,
+  20 assertions, green.
 - Mutation-checked rather than trusting green: deleting the `finally`
-  close fails all three tests (each asserts the recorded close vector),
-  confirming the tests bind to the release behavior, not incidental
-  output.
+  close fails all three store-lifecycle tests (each asserts the
+  recorded close vector), confirming they bind to the release behavior,
+  not incidental output.
 - `bb lint:clj` on both staged files: 0 errors, 0 warnings.
 - Pre-commit hook (commit budget, structure, lint, format, smoke tests)
   runs at commit time; full suite in CI.

--- a/docs/pull-requests/2026-08-09-fix-cli-artifact-store-leak-on-sandbox-failure.md
+++ b/docs/pull-requests/2026-08-09-fix-cli-artifact-store-leak-on-sandbox-failure.md
@@ -1,0 +1,93 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix(cli): close the artifact store on every exit path of execute-with-events
+
+## Overview
+
+`execute-with-events` now releases the workflow's transit artifact store in
+its `finally` block, once, on every exit path. Previously the close lived
+only on the normal-completion branch, so two paths leaked the store.
+
+## Motivation
+
+`run-workflow-from-spec!` opens the store with
+`execution/create-artifact-store` *before* `sandbox/setup-sandbox-context`
+runs, then hands it to `execute-with-events`. Inside, only the pipeline
+branch closed it after publishing the completion event. Two paths never
+did:
+
+- The sandbox-setup-failure branch (`:sandbox-error` set in context):
+  published the failure result and returned with the store still open.
+  Every failed container sandbox setup leaked one open transit store.
+- The `catch Object` path: published the failure event and rethrew via
+  `throw+` without closing. The caller does not close it either — the
+  store's lifecycle ends inside `execute-with-events` or not at all.
+
+## Layer
+
+CLI base only: `bases/cli/src/ai/miniforge/cli/workflow_runner/execution.clj`
+plus its (new) test namespace. No component interfaces change.
+
+## Changes in Detail
+
+- `execute-with-events`: the `(close-artifact-store artifact-store)` call
+  moves from the pipeline-success branch into the `finally` block, after
+  the not-completed `:cancelled` publish and before `sandbox-cleanup`.
+  One unconditional call rather than a per-branch duplicate with a
+  closed-twice guard: `close-artifact-store` is already nil-safe and
+  swallows close-time exceptions, so a single call in `finally` covers
+  completion, sandbox-setup failure, and the rethrow path without ever
+  double-closing or masking an in-flight exception.
+- `bases/cli/test/ai/miniforge/cli/workflow_runner/execution_test.clj`
+  (new namespace — none existed for this file): an
+  `execute-recording-closes` harness runs `execute-with-events` with a
+  sentinel store, stubbing `artifact/close-store` to record what it
+  receives and silencing the lifecycle/display side effects. Three tests:
+  sandbox-failure branch closes the store and reports
+  `:sandbox-setup-failed` without invoking the pipeline; a throwing
+  pipeline still closes the store before the rethrow propagates; the
+  success path closes exactly once (guards against a duplicate close
+  reappearing alongside the `finally`).
+
+## Callers — checked
+
+`run-workflow-from-spec!` is the only caller. Nothing after
+`execute-with-events` returns touches the store (`spec-kanban` moves and
+the meta-loop trigger consume only the result), so closing in `finally`
+cannot close a store still in use.
+
+`run-workflow!` (the non-spec entry point in `workflow_runner.clj`) has
+the same leak shape on its own throw path — its `finally` never closes
+the store it opened. Out of scope for this PR; flagged as a follow-up
+task rather than widening this diff.
+
+## Standards Audit
+
+- Stratified design (001/210): no stratum changes; `close-artifact-store`
+  (stratum 0) was already below `execute-with-events` (stratum 1). Test
+  namespace layers: harness at 0, sandbox helper and direct tests at 1,
+  sandbox-branch test at 2 — in-namespace dependencies flow downward.
+- Header rule (810): Apache header on the new test file.
+- Exception handling (211): no new catches; the test uses slingshot
+  `try+`/`catch Object` to observe the rethrow, matching sibling tests.
+- Test fixtures match the producer's shape
+  (feedback_test_fixtures_match_production_shape): the sandbox-error
+  context uses the same `{:sandbox-error {:error ...}}` shape
+  `setup-sandbox-context` produces and the same `:errors` vector shape
+  the branch itself constructs.
+
+## Testing Plan
+
+- `clojure -M:dev:test` on the new namespace: 3 tests, 9 assertions,
+  green.
+- Mutation-checked rather than trusting green: deleting the `finally`
+  close fails all three tests (each asserts the recorded close vector),
+  confirming the tests bind to the release behavior, not incidental
+  output.
+- `bb lint:clj` on both staged files: 0 errors, 0 warnings.
+- Pre-commit hook (commit budget, structure, lint, format, smoke tests)
+  runs at commit time; full suite in CI.


### PR DESCRIPTION
## Summary

`execute-with-events` closed the workflow's transit artifact store only on the pipeline-success branch. The sandbox-setup-failure branch (`:sandbox-error` in context) and the `catch Object`/`throw+` path both returned with the store open, and the caller never closes it — every failed container sandbox setup leaked one open store.

The single `close-artifact-store` call moves into the `finally` block. It is nil-safe and swallows close-time exceptions, so one unconditional call covers completion, sandbox failure, and rethrow without double-closing or masking an in-flight exception.

## Tests

An `execute-recording-closes` harness in `execution_test.clj` stubs `artifact/close-store` to record what it receives and pins all three paths — sandbox failure closes without running the pipeline, a throwing pipeline closes before the rethrow propagates, success closes exactly once. Mutation-checked: deleting the `finally` close fails all three.

This branch created `execution_test.clj`, then #1723 landed its own file of that name on main (sandbox-failure result-shape tests) first. The merge commit keeps #1723's tests verbatim and adds the store-lifecycle tests beside them, assertions updated to #1723's `:execution/*` result vocabulary. Combined namespace: 8 tests, 20 assertions, green.

PR doc: `docs/pull-requests/2026-08-09-fix-cli-artifact-store-leak-on-sandbox-failure.md`

Known adjacent issue, out of scope: `run-workflow!` has the same leak shape on its throw path; flagged as a follow-up task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)