### PR TITLE
refactor(cli): split workflow_runner/help/registry.clj — flag specs vs. subcommand registry (rule 210)

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/help/flag_specs.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/help/flag_specs.clj
@@ -19,8 +19,10 @@
   "The babashka.cli `:spec` each workflow-runner subcommand accepts —
    one def per subcommand, every one carrying the `--help`/`-h` flag.
 
-   Pure data. `help/registry.clj` binds these to subcommand keys; the
-   flag vocabulary they are written in lives in `help/flags.clj`.
+   Each def is a literal spec map with the shared help flag merged in;
+   nothing here computes anything else. `help/registry.clj` binds them
+   to subcommand keys, and the flag vocabulary they are written in
+   lives in `help/flags.clj`.
 
    Stratification:
    Layer 0 — one flag spec per subcommand."

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/help/flag_specs.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/help/flag_specs.clj
@@ -1,0 +1,73 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.workflow-runner.help.flag-specs
+  "The babashka.cli `:spec` each workflow-runner subcommand accepts —
+   one def per subcommand, every one carrying the `--help`/`-h` flag.
+
+   Pure data. `help/registry.clj` binds these to subcommand keys; the
+   flag vocabulary they are written in lives in `help/flags.clj`.
+
+   Stratification:
+   Layer 0 — one flag spec per subcommand."
+  (:require
+   [ai.miniforge.cli.workflow-runner.help.flags :as flags]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} workflow-run-flag-spec
+  (flags/with-help-flag
+    {:version       {:coerce :string  :alias :v :default "latest"}
+     :input         {:alias :i}
+     :input-json    {}
+     :output        {:coerce :keyword :alias :o :default :pretty}
+     :quiet         {:coerce :boolean :alias :q}
+     :dashboard-url {:coerce :string  :alias :d}}))
+
+(def ^{:stratum 0} workflow-list-flag-spec
+  (flags/with-help-flag {}))
+
+(def ^{:stratum 0} workflow-execute-flag-spec
+  (flags/with-help-flag
+    {:worktree       {:alias :w}
+     :backend        {:coerce :keyword :alias :b}
+     :execution-mode {:coerce :keyword :alias :m}
+     :quiet          {:coerce :boolean :alias :q}}))
+
+(def ^{:stratum 0} workflow-status-flag-spec
+  (flags/with-help-flag {}))
+
+(def ^{:stratum 0} workflow-inspect-flag-spec
+  (flags/with-help-flag {}))
+
+(def ^{:stratum 0} workflow-cancel-flag-spec
+  (flags/with-help-flag {}))
+
+(def ^{:stratum 0} workflow-gc-scratch-flag-spec
+  (flags/with-help-flag
+    {:max-age-days {:coerce :int :alias :a :default 7}
+     :repo-path    {:coerce :string :alias :r}}))
+
+(def ^{:stratum 0} chain-run-flag-spec
+  (flags/with-help-flag
+    {:version    {:coerce :string :alias :v :default "latest"}
+     :spec       {:alias :s}
+     :input-json {}
+     :quiet      {:coerce :boolean :alias :q}}))
+
+(def ^{:stratum 0} chain-list-flag-spec
+  (flags/with-help-flag {}))

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/help/flags.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/help/flags.clj
@@ -16,17 +16,23 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns ai.miniforge.cli.workflow-runner.help.flags
-  "The `Options:` table inside a workflow-runner subcommand's `--help`
-   block, generated from the babashka.cli `:spec` the registry holds.
+  "The `--help`/`-h` flag every workflow-runner subcommand carries: what
+   it is, how a babashka.cli `:spec` gains it, and how it is stripped
+   back out to render the `Options:` table inside the `--help` block.
 
    Stratification:
-   Layer 0 — the keys reserved for the help flag itself.
-   Layer 1 — the `:spec` filter that strips them.
+   Layer 0 — the help flag itself: its spec and its reserved keys.
+   Layer 1 — adding it to a `:spec`, and the filter that strips it.
    Layer 2 — `flag-table` renders what survives the filter."
   (:require
    [babashka.cli :as cli]))
 
 ;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private help-flag-spec
+  "The `--help`/`-h` boolean flag added to every workflow-runner
+   subcommand spec. Single definition keeps the alias consistent."
+  {:coerce :boolean :alias :h})
 
 (def ^{:stratum 0} help-flag-keys
   "Keys reserved for the help flag itself. Stripped from the usage
@@ -34,6 +40,11 @@
   #{:help})
 
 ;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} with-help-flag
+  "Return `spec` with the `--help`/`-h` boolean flag merged in. Idempotent."
+  [spec]
+  (assoc spec :help help-flag-spec))
 
 (defn- ^{:stratum 1} without-help-flag
   "Drop the help flag from a babashka.cli `:spec` map so it doesn't

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/help/registry.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/help/registry.clj
@@ -16,8 +16,10 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns ai.miniforge.cli.workflow-runner.help.registry
-  "Pure data registry of every workflow-runner CLI subcommand
-   (`workflow run/list/execute/status/cancel` and `chain run/list`).
+  "Registry of every workflow-runner CLI subcommand (`workflow
+   run/list/execute/status/cancel` and `chain run/list`). The
+   `subcommands` map is pure data; the rest of this namespace is
+   lookups and derivations over it.
 
    The registry is the single source of truth for:
    - the babashka.cli `:spec` (defined in `help/flag_specs.clj`) wired

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/help/registry.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/help/registry.clj
@@ -27,18 +27,14 @@
    - the parent-level (`workflow --help` / `chain --help`) listing.
 
    Stratification:
-   Layer 0 — flag-spec data + the `with-help-flag` helper.
-   Layer 1 — the `subcommands` map + per-group ordering.
-   Layer 2 — group-listing inputs derived from Layer 1."
+   Layer 0 — the `subcommands` map + per-group display ordering.
+   Layer 1 — lookups and row derivations over that map.
+   Layer 2 — the parent-level group-listing inputs."
   (:require
-   [clojure.string :as str]))
+   [clojure.string :as str]
+   [ai.miniforge.cli.workflow-runner.help.flag-specs :as flag-specs]))
 
 ;------------------------------------------------------------------------------ Layer 0
-
-(def ^{:stratum 0} ^:private help-flag-spec
-  "The `--help`/`-h` boolean flag added to every workflow-runner
-   subcommand spec. Single definition keeps the alias consistent."
-  {:coerce :boolean :alias :h})
 
 (def ^{:stratum 0} workflow-subcommand-keys
   "Display order for `mf workflow --help`."
@@ -52,129 +48,75 @@
 (defn- ^{:stratum 0} subcommand-leaf [entry]
   (-> (:subcommand entry) (str/split #"\s+") last))
 
-;------------------------------------------------------------------------------ Layer 1
-
-(defn ^{:stratum 1} with-help-flag
-  "Return `spec` with the `--help`/`-h` boolean flag merged in. Idempotent."
-  [spec]
-  (assoc spec :help help-flag-spec))
-
-;------------------------------------------------------------------------------ Layer 2
-
-(def ^{:stratum 2} workflow-run-flag-spec
-  (with-help-flag
-    {:version       {:coerce :string  :alias :v :default "latest"}
-     :input         {:alias :i}
-     :input-json    {}
-     :output        {:coerce :keyword :alias :o :default :pretty}
-     :quiet         {:coerce :boolean :alias :q}
-     :dashboard-url {:coerce :string  :alias :d}}))
-
-(def ^{:stratum 2} workflow-list-flag-spec
-  (with-help-flag {}))
-
-(def ^{:stratum 2} workflow-execute-flag-spec
-  (with-help-flag
-    {:worktree       {:alias :w}
-     :backend        {:coerce :keyword :alias :b}
-     :execution-mode {:coerce :keyword :alias :m}
-     :quiet          {:coerce :boolean :alias :q}}))
-
-(def ^{:stratum 2} workflow-status-flag-spec
-  (with-help-flag {}))
-
-(def ^{:stratum 2} workflow-inspect-flag-spec
-  (with-help-flag {}))
-
-(def ^{:stratum 2} workflow-cancel-flag-spec
-  (with-help-flag {}))
-
-(def ^{:stratum 2} workflow-gc-scratch-flag-spec
-  (with-help-flag
-    {:max-age-days {:coerce :int :alias :a :default 7}
-     :repo-path    {:coerce :string :alias :r}}))
-
-(def ^{:stratum 2} chain-run-flag-spec
-  (with-help-flag
-    {:version    {:coerce :string :alias :v :default "latest"}
-     :spec       {:alias :s}
-     :input-json {}
-     :quiet      {:coerce :boolean :alias :q}}))
-
-(def ^{:stratum 2} chain-list-flag-spec
-  (with-help-flag {}))
-
-;------------------------------------------------------------------------------ Layer 3
-
-(def ^{:stratum 3} subcommands
+(def ^{:stratum 0} subcommands
   "Keyword-addressable registry of every workflow-runner subcommand.
    Each value is the input shape consumed by the help renderer."
   {:workflow-run     {:subcommand  "workflow run"
                       :summary-key :workflow-runner.help/workflow-run-summary
-                      :spec        workflow-run-flag-spec
+                      :spec        flag-specs/workflow-run-flag-spec
                       :positional  [:workflow-id]}
    :workflow-list    {:subcommand  "workflow list"
                       :summary-key :workflow-runner.help/workflow-list-summary
-                      :spec        workflow-list-flag-spec
+                      :spec        flag-specs/workflow-list-flag-spec
                       :positional  []}
    :workflow-execute {:subcommand  "workflow execute"
                       :summary-key :workflow-runner.help/workflow-execute-summary
-                      :spec        workflow-execute-flag-spec
+                      :spec        flag-specs/workflow-execute-flag-spec
                       :positional  [:spec]}
    :workflow-status  {:subcommand  "workflow status"
                       :summary-key :workflow-runner.help/workflow-status-summary
-                      :spec        workflow-status-flag-spec
+                      :spec        flag-specs/workflow-status-flag-spec
                       :positional  [:id]}
    :workflow-inspect {:subcommand  "workflow inspect"
                       :summary-key :workflow-runner.help/workflow-inspect-summary
-                      :spec        workflow-inspect-flag-spec
+                      :spec        flag-specs/workflow-inspect-flag-spec
                       :positional  [:path]}
    :workflow-cancel  {:subcommand  "workflow cancel"
                       :summary-key :workflow-runner.help/workflow-cancel-summary
-                      :spec        workflow-cancel-flag-spec
+                      :spec        flag-specs/workflow-cancel-flag-spec
                       :positional  [:id]}
    :workflow-gc-scratch {:subcommand  "workflow gc-scratch"
                          :summary-key :workflow-runner.help/workflow-gc-scratch-summary
-                         :spec        workflow-gc-scratch-flag-spec
+                         :spec        flag-specs/workflow-gc-scratch-flag-spec
                          :positional  []}
    :chain-run        {:subcommand  "chain run"
                       :summary-key :workflow-runner.help/chain-run-summary
-                      :spec        chain-run-flag-spec
+                      :spec        flag-specs/chain-run-flag-spec
                       :positional  [:chain-id]}
    :chain-list       {:subcommand  "chain list"
                       :summary-key :workflow-runner.help/chain-list-summary
-                      :spec        chain-list-flag-spec
+                      :spec        flag-specs/chain-list-flag-spec
                       :positional  []}})
 
-;------------------------------------------------------------------------------ Layer 4
+;------------------------------------------------------------------------------ Layer 1
 
-(defn ^{:stratum 4} spec-for
+(defn ^{:stratum 1} spec-for
   "Look up the babashka.cli `:spec` for a subcommand by key."
   [subcommand-key]
   (:spec (get subcommands subcommand-key)))
 
-(defn ^{:stratum 4} entry-for
+(defn ^{:stratum 1} entry-for
   "Look up the full registry entry for `subcommand-key`. Returns nil
    when unknown — callers may treat that as a programming error."
   [subcommand-key]
   (get subcommands subcommand-key))
 
-(defn- ^{:stratum 4} group-subcommand-rows [entry-keys]
+(defn- ^{:stratum 1} group-subcommand-rows [entry-keys]
   (map (fn [entry-key]
          (let [entry (get subcommands entry-key)]
            {:name        (subcommand-leaf entry)
             :summary-key (:summary-key entry)}))
        entry-keys))
 
-;------------------------------------------------------------------------------ Layer 5
+;------------------------------------------------------------------------------ Layer 2
 
-(def ^{:stratum 5} workflow-group-help
+(def ^{:stratum 2} workflow-group-help
   "Input shape for the `workflow` parent's `--help` listing."
   {:group       "workflow"
    :summary-key :workflow-runner.help/workflow-summary
    :subcommands (group-subcommand-rows workflow-subcommand-keys)})
 
-(def ^{:stratum 5} chain-group-help
+(def ^{:stratum 2} chain-group-help
   "Input shape for the `chain` parent's `--help` listing."
   {:group       "chain"
    :summary-key :workflow-runner.help/chain-summary

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/help/registry.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/help/registry.clj
@@ -20,8 +20,8 @@
    (`workflow run/list/execute/status/cancel` and `chain run/list`).
 
    The registry is the single source of truth for:
-   - the babashka.cli `:spec` (flag definitions) wired into the
-     `main.clj` dispatch table,
+   - the babashka.cli `:spec` (defined in `help/flag_specs.clj`) wired
+     into the `main.clj` dispatch table,
    - the per-subcommand `--help` usage block rendered by
      `ai.miniforge.cli.workflow-runner.help/usage-text`, and
    - the parent-level (`workflow --help` / `chain --help`) listing.

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/help/registry.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/help/registry.clj
@@ -17,9 +17,9 @@
 ;; limitations under the License.
 (ns ai.miniforge.cli.workflow-runner.help.registry
   "Registry of every workflow-runner CLI subcommand (`workflow
-   run/list/execute/status/cancel` and `chain run/list`). The
-   `subcommands` map is pure data; the rest of this namespace is
-   lookups and derivations over it.
+   run/list/execute/status/inspect/cancel/gc-scratch` and `chain
+   run/list`). The `subcommands` map is pure data; the rest of this
+   namespace is lookups and derivations over it.
 
    The registry is the single source of truth for:
    - the babashka.cli `:spec` (defined in `help/flag_specs.clj`) wired

--- a/docs/pull-requests/2026-08-09-refactor-split-wr-help-registry.md
+++ b/docs/pull-requests/2026-08-09-refactor-split-wr-help-registry.md
@@ -74,7 +74,7 @@ grep over `bases/`, `components/`, `projects/`).
 - `help_test.clj` + `help/registry_test.clj`: 13 tests, 76 assertions,
   0 failures, 0 errors. No `with-redefs` targets moved, so no test edits.
 - Pre-commit gate (342 tests / 1291 assertions smoke + GraalVM compat) passed on
-  both commits.
+  every commit in the branch.
 
 ## Deployment Plan
 

--- a/docs/pull-requests/2026-08-09-refactor-split-wr-help-registry.md
+++ b/docs/pull-requests/2026-08-09-refactor-split-wr-help-registry.md
@@ -1,0 +1,100 @@
+# refactor(cli): split workflow_runner/help/registry.clj — flag specs vs. subcommand registry (rule 210)
+
+## Overview
+
+`bases/cli/src/ai/miniforge/cli/workflow_runner/help/registry.clj` measured 6
+real strata against the rule-210 budget of 3 (stratum-lint SL003). Move-only
+split into two namespaces along the seam the file already had: the flag-spec
+data that describes *what flags a subcommand takes*, and the registry that binds
+those specs to subcommand keys and derives the parent-level `--help` listings.
+
+| Namespace | Vocabulary | Strata |
+|---|---|---|
+| `…help.flags` (existing) | the `--help`/`-h` flag: its definition, adding it to a `:spec`, stripping it, rendering the `Options:` table | 3 |
+| `…help.flag-specs` (new) | one babashka.cli `:spec` per workflow-runner subcommand | 1 |
+| `…help.registry` (rewritten) | the `subcommands` map, lookups over it, group-listing inputs | 3 (was 6) |
+
+Dependency direction (one-way, no cycles):
+
+```text
+help.flags ──> help.flag-specs ──> help.registry ──> help.clj / main.clj
+      └──────> help.usage
+```
+
+## Motivation
+
+Rule 210 (`standards/miniforge/languages/clojure`, per-file stratified design):
+a file wanting a fourth band is the signal to split the namespace. `registry.clj`
+wanted six. It was the last SL003 offender left in the `workflow_runner/help/`
+tree after #1719 extracted `help/flags.clj` and `help/usage.clj`.
+
+This also closes a finding deferred from #1719: `help-flag-keys` (in
+`help/flags.clj`) and `help-flag-spec` (in `registry.clj`) were two halves of one
+idea — what the `--help` flag *is*. They now sit together at Layer 0 of
+`help/flags.clj`, alongside the two operations over it (`with-help-flag` adds it,
+`without-help-flag` strips it). `flags.clj` stays inside the 3-stratum budget,
+and `help-flag-spec` stays private — moving `with-help-flag` with it meant the
+API surface did not have to widen.
+
+## Changes in Detail
+
+**`help/flag_specs.clj` (new, 1 stratum).** The nine `*-flag-spec` defs, moved
+verbatim apart from `with-help-flag` becoming `flags/with-help-flag`. Because
+every def now references only a var in another namespace, they are all leaves of
+this file's reference graph and sit at a single Layer 0.
+
+**`help/flags.clj` (3 strata, unchanged count).** Gains `help-flag-spec`
+(Layer 0, still `^:private`) and `with-help-flag` (Layer 1), both moved verbatim
+from `registry.clj`. Namespace docstring updated to cover both concerns.
+
+**`help/registry.clj` (3 strata, down from 6).** Keeps its whole public surface:
+`subcommands`, `spec-for`, `entry-for`, `workflow-subcommand-keys`,
+`chain-subcommand-keys`, `workflow-group-help`, `chain-group-help`. Relative
+order of the surviving forms is unchanged; only the `Layer N` headings and
+`^{:stratum n}` metadata are recomputed:
+
+- Layer 0 — `workflow-subcommand-keys`, `chain-subcommand-keys`,
+  `subcommand-leaf`, `subcommands`
+- Layer 1 — `spec-for`, `entry-for`, `group-subcommand-rows`
+- Layer 2 — `workflow-group-help`, `chain-group-help`
+
+No re-exports were needed. `with-help-flag` and `help-flag-spec` are the only
+vars that left the namespace, and neither had a caller outside it (verified by
+grep over `bases/`, `components/`, `projects/`).
+
+## Testing Plan
+
+- `stratum-lint` (pin `bef8657a`) plain: clean on all three files.
+- `stratum-lint --fix` dry run on scratch copies: zero changes to any of the
+  three, so the hand-written headings and metadata match the strata the linter
+  computes from each file's reference graph. (`--fix` behaviour on these files
+  was itself sanity-checked against a deliberately mis-tagged probe copy, which
+  it correctly collapsed.)
+- `clj-kondo`: 0 errors, 0 warnings on the touched files.
+- `help_test.clj` + `help/registry_test.clj`: 13 tests, 76 assertions,
+  0 failures, 0 errors. No `with-redefs` targets moved, so no test edits.
+- Pre-commit gate (342 tests / 1291 assertions smoke + GraalVM compat) passed on
+  both commits.
+
+## Deployment Plan
+
+No behaviour change — every moved form is verbatim. Ships with the ordinary
+merge to `main`.
+
+## Related Issues/PRs
+
+- #1719 split `workflow_runner/help.clj` into `help/flags.clj` + `help/usage.clj`
+  and deferred both this file and the `help-flag-spec` reunification.
+- Same wave: #1662–#1667, #1720, #1721, #1724.
+- Rules: `standards/miniforge/languages/clojure` (210),
+  `standards/miniforge/foundations/stratified-design` (001).
+
+## Checklist
+
+- [x] `registry.clj` down to 3 strata, public surface intact
+- [x] `flag_specs.clj` created with the Apache header
+- [x] `help-flag-spec` reunited with `help-flag-keys`; `flags.clj` still ≤3 strata
+- [x] `^{:stratum n}` metadata agrees with `Layer N` headings
+- [x] stratum-lint plain + `--fix` dry run clean
+- [x] clj-kondo clean
+- [x] `help_test` / `help/registry_test` green


### PR DESCRIPTION
## Summary

`bases/cli/src/ai/miniforge/cli/workflow_runner/help/registry.clj` measured **6 real strata** (stratum-lint SL003, max 3). Move-only split along the seam the file already had — the flag-spec data, and the registry that binds it to subcommand keys.

| Namespace | Vocabulary | Strata |
|---|---|---|
| `…help.flags` (existing) | the `--help`/`-h` flag: its definition, adding it to a `:spec`, stripping it, rendering the `Options:` table | 3 (unchanged) |
| `…help.flag-specs` (new) | one babashka.cli `:spec` per workflow-runner subcommand | 1 |
| `…help.registry` (rewritten) | the `subcommands` map, lookups over it, group-listing inputs | 3 (was 6) |

Dependency direction, one-way and acyclic:

```text
help.flags ──> help.flag-specs ──> help.registry ──> help.clj / main.clj
      └──────> help.usage
```

`registry.clj` keeps its whole public surface — `subcommands`, `spec-for`, `entry-for`, `workflow-subcommand-keys`, `chain-subcommand-keys`, `workflow-group-help`, `chain-group-help`. Relative order of the surviving forms is unchanged; only the `Layer N` headings and `^{:stratum n}` metadata are recomputed:

- Layer 0 — `workflow-subcommand-keys`, `chain-subcommand-keys`, `subcommand-leaf`, `subcommands`
- Layer 1 — `spec-for`, `entry-for`, `group-subcommand-rows`
- Layer 2 — `workflow-group-help`, `chain-group-help`

**No re-exports were needed.** `with-help-flag` and `help-flag-spec` are the only vars that left the namespace, and grep over `bases/`, `components/`, `projects/` shows neither had a caller outside it.

Three commits: the new namespace lands standalone first (parent untouched, still over budget), then the flip rewrites `registry.clj` SL003-clean in the same commit that deletes the moved code, then the PR doc.

## Why

Rule 210 (`standards/miniforge/languages/clojure`, per-file stratified design) — a file wanting a fourth band is the signal to split. This one wanted six. It was the last SL003 offender in the `workflow_runner/help/` tree after #1719 extracted `help/flags.clj` and `help/usage.clj`, and was explicitly deferred there.

This also closes the other finding deferred from #1719: `help-flag-keys` (in `help/flags.clj`) and `help-flag-spec` (in `registry.clj`) were two halves of one idea — what the `--help` flag *is*. **The reunification happened.** Both now sit at Layer 0 of `help/flags.clj`, alongside the two operations over the flag: `with-help-flag` adds it, `without-help-flag` strips it. `flags.clj` stays at 3 strata. `with-help-flag` moved along with the spec so that `help-flag-spec` could stay `^:private` — moving the spec alone would have forced it public.

No logic changes: every moved form is verbatim. The only edits are ns forms, headings, `^{:stratum n}` metadata, and qualifying the nine `:spec` references with the `flag-specs/` alias.

## Testing

- `stratum-lint` (pin `bef8657a`) plain: clean on all three files.
- `stratum-lint --fix` dry run on scratch copies: **zero** changes to any of the three — the hand-written headings and metadata match the strata computed from each file's reference graph. `--fix` behaviour on these files was itself sanity-checked against a deliberately mis-tagged probe copy, which it correctly collapsed back.
- `clj-kondo`: 0 errors, 0 warnings on the touched files.
- `help_test.clj` + `help/registry_test.clj`: 13 tests, 76 assertions, 0 failures, 0 errors. No `with-redefs` targets moved, so no test edits were needed.
- Rendered-output smoke: `group-usage-text` for the `workflow` group, `usage-text` for `workflow run`, and `spec-for` over all nine subcommand keys all render/resolve as before.
- Pre-commit gate (342 tests / 1291 assertions smoke + GraalVM compat) passed on all three commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
