### PR TITLE
refactor(policy-pack): split prompt_template.clj (rule 210)

### DIFF
--- a/components/policy-pack/src/ai/miniforge/policy_pack/prompt_template.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/prompt_template.clj
@@ -19,7 +19,8 @@
   "Pack-bundled prompt template interpolation.
 
    Templates use {{variable}} syntax. Variables are replaced with values
-   from a context map. Unknown variables are left as-is.
+   from a context map. Unknown variables are replaced with an empty
+   string (see `interpolate`).
 
    Layer 0: interpolate, default-repair-prompt/behavior-section/knowledge-section
      (delays over `template-defaults/default-template`)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/prompt_template.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/prompt_template.clj
@@ -21,21 +21,19 @@
    Templates use {{variable}} syntax. Variables are replaced with values
    from a context map. Unknown variables are left as-is.
 
-   Layer 0: interpolate, default-templates-resource
-   Layer 1: loaded-defaults (reads default-templates-resource)
-   Layer 2: default-template (looks up loaded-defaults)
-   Layer 3: default-repair-prompt/behavior-section/knowledge-section
-     (over default-template)
-   Layer 4: resolve-repair/behavior/knowledge-template (rule → pack →
-     Layer 3 default)
-   Layer 5: render-repair-prompt/behavior-section/knowledge-section
-     (interpolate over the resolved Layer 4 template)
+   Layer 0: interpolate, default-repair-prompt/behavior-section/knowledge-section
+     (delays over `template-defaults/default-template`)
+   Layer 1: resolve-repair/behavior/knowledge-template (rule → pack →
+     Layer 0 default)
+   Layer 2: render-repair-prompt/behavior-section/knowledge-section
+     (interpolate over the resolved Layer 1 template)
 
-   6 real strata — over the rule 210 budget of 3; a genuine namespace split
-   (Wave 2), not a labeling problem."
-  (:require [clojure.edn :as edn]
-            [clojure.java.io :as io]
-            [clojure.string :as str]))
+   Default-template resource loading (EDN resource → parsed map → keyed
+   lookup) lives in `ai.miniforge.policy-pack.template-defaults` — split
+   out under rule 210 (the combined namespace measured 6 real layers,
+   max 3)."
+  (:require [clojure.string :as str]
+            [ai.miniforge.policy-pack.template-defaults :as template-defaults]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -61,46 +59,22 @@
                             (get bindings s)
                             ""))))))
 
-;; Default templates (loaded from EDN resource)
-(def ^{:stratum 0} ^:private default-templates-resource
-  "Classpath resource path for default prompt templates."
-  "policy_pack/templates/defaults.edn")
+(def ^{:stratum 0} default-repair-prompt
+  "Default prompt template for LLM-based semantic repair."
+  (delay (template-defaults/default-template :repair-prompt)))
+
+(def ^{:stratum 0} default-behavior-section
+  "Default template for the behavior rules section."
+  (delay (template-defaults/default-template :behavior-section)))
+
+(def ^{:stratum 0} default-knowledge-section
+  "Default template for the reference material section."
+  (delay (template-defaults/default-template :knowledge-section)))
 
 ;------------------------------------------------------------------------------ Layer 1
 
-(def ^{:stratum 1} ^:private loaded-defaults
-  "Default templates loaded from classpath EDN resource. Delay for lazy loading."
-  (delay
-    (try
-      (when-let [resource (io/resource default-templates-resource)]
-        (edn/read-string (slurp resource)))
-      (catch Exception _ {}))))
-
-;------------------------------------------------------------------------------ Layer 2
-
-(defn- ^{:stratum 2} default-template
-  "Get a default template by key. Returns empty string if not found."
-  [k]
-  (get @loaded-defaults k ""))
-
-;------------------------------------------------------------------------------ Layer 3
-
-(def ^{:stratum 3} default-repair-prompt
-  "Default prompt template for LLM-based semantic repair."
-  (delay (default-template :repair-prompt)))
-
-(def ^{:stratum 3} default-behavior-section
-  "Default template for the behavior rules section."
-  (delay (default-template :behavior-section)))
-
-(def ^{:stratum 3} default-knowledge-section
-  "Default template for the reference material section."
-  (delay (default-template :knowledge-section)))
-
-;------------------------------------------------------------------------------ Layer 4
-
 ;; Template resolution
-(defn ^{:stratum 4} resolve-repair-template
+(defn ^{:stratum 1} resolve-repair-template
   "Resolve the repair prompt template for a violation.
 
    Priority:
@@ -118,7 +92,7 @@
   (get rule :rule/repair-prompt-template
        (get-in pack [:pack/prompt-templates :repair-prompt] @default-repair-prompt)))
 
-(defn ^{:stratum 4} resolve-behavior-template
+(defn ^{:stratum 1} resolve-behavior-template
   "Resolve the behavior section template.
 
    Priority:
@@ -133,7 +107,7 @@
   [pack]
   (get-in pack [:pack/prompt-templates :behavior-section] @default-behavior-section))
 
-(defn ^{:stratum 4} resolve-knowledge-template
+(defn ^{:stratum 1} resolve-knowledge-template
   "Resolve the knowledge section template.
 
    Priority:
@@ -148,9 +122,9 @@
   [pack]
   (get-in pack [:pack/prompt-templates :knowledge-section] @default-knowledge-section))
 
-;------------------------------------------------------------------------------ Layer 5
+;------------------------------------------------------------------------------ Layer 2
 
-(defn ^{:stratum 5} render-repair-prompt
+(defn ^{:stratum 2} render-repair-prompt
   "Render a complete repair prompt for a violation.
 
    Arguments:
@@ -171,7 +145,7 @@
     {:role    :user
      :content (interpolate template bindings)}))
 
-(defn ^{:stratum 5} render-behavior-section
+(defn ^{:stratum 2} render-behavior-section
   "Render the behavior rules section for prompt injection.
 
    Arguments:
@@ -188,7 +162,7 @@
                         (str/join "\n"))]
       (interpolate template {:behaviors numbered}))))
 
-(defn ^{:stratum 5} render-knowledge-section
+(defn ^{:stratum 2} render-knowledge-section
   "Render the reference material section for prompt injection.
 
    Arguments:

--- a/components/policy-pack/src/ai/miniforge/policy_pack/template_defaults.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/template_defaults.clj
@@ -1,0 +1,60 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.template-defaults
+  "Default prompt templates loaded from the pack's bundled EDN resource.
+
+   Layer 0: default-templates-resource (classpath resource path)
+   Layer 1: loaded-defaults (delay that reads + parses the EDN resource)
+   Layer 2: default-template (keyed lookup into the loaded defaults)
+
+   Split out of `ai.miniforge.policy-pack.prompt-template` (rule 210:
+   the parent namespace measured 6 real layers, max 3; this is the
+   resource-loading concern, kept separate from template resolution
+   and rendering)."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private default-templates-resource
+  "Classpath resource path for default prompt templates."
+  "policy_pack/templates/defaults.edn")
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} ^:private loaded-defaults
+  "Default templates loaded from classpath EDN resource. Delay for lazy loading."
+  (delay
+    (try
+      (when-let [resource (io/resource default-templates-resource)]
+        (edn/read-string (slurp resource)))
+      (catch Exception _ {}))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} default-template
+  "Get a default template by key. Returns empty string if not found."
+  [k]
+  (get @loaded-defaults k ""))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (default-template :repair-prompt)
+  (default-template :behavior-section)
+  (default-template :knowledge-section)
+  :leave-this-here)

--- a/docs/pull-requests/2026-08-09-refactor-split-policy-pack-prompt-template.md
+++ b/docs/pull-requests/2026-08-09-refactor-split-policy-pack-prompt-template.md
@@ -1,0 +1,64 @@
+<!--
+  Title: Split policy-pack/prompt_template.clj (rule 210)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(policy-pack): split prompt_template.clj (rule 210)
+
+## Overview
+
+Splits the default-template resource loading out of
+`ai.miniforge.policy-pack.prompt-template` into its own sibling
+namespace, `ai.miniforge.policy-pack.template-defaults`, resolving a
+stratum-lint SL003 finding (the combined namespace measured 6 real
+layers, over the rule 210 budget of 3).
+
+## Motivation
+
+Part of the stratum-lint rule-210 remediation program's Wave 2
+continuation. Full-repo sweep found `components/policy-pack` still has
+18 files over budget; `prompt_template.clj` (229 lines, zero fan-in
+repo-wide) is one of this batch.
+
+## Changes in Detail
+
+- New file `template_defaults.clj`: the EDN-resource-loading concern
+  (`default-templates-resource`, `loaded-defaults`, `default-template`)
+  — 3 layers, unchanged behavior.
+- `prompt_template.clj`: template resolution and rendering
+  (`interpolate`, `default-*-prompt/section`, `resolve-*-template`,
+  `render-*`) — now 3 layers instead of 6, calling
+  `template-defaults/default-template` instead of a same-file private
+  helper.
+
+This is pure code motion: no logic changed, only relocated and
+re-namespaced. `default-template` was already private
+(`defn-`) and had no callers outside this file, so no other call site
+needed updating.
+
+## Testing Plan
+
+- `stratum-lint` clean on both files (exit 0, was SL003 exit 1).
+- `bb test` (change-scope) green on the policy-pack component.
+- Confirmed no other file in the repo referenced the moved private
+  `default-template` symbol.
+
+## Deployment Plan
+
+Merges to `main` immediately; no follow-up needed for this file. 17
+more `policy-pack` files remain over budget, tracked separately.
+
+## Related Issues/PRs
+
+- Part of the stratum-lint rule-210 Wave 2 continuation (see
+  `workflow_runner.clj` splits miniforge#1662-#1667 and the
+  `compliance-scanner` split #1580 for the established convention this
+  follows).
+
+## Checklist
+
+- [x] stratum-lint clean on both resulting files
+- [x] `bb test` green (policy-pack change-scope)
+- [x] Adversarial self-review: def set unchanged, only relocated
+- [x] Zero fan-in confirmed repo-wide before starting


### PR DESCRIPTION
<!--
  Title: Split policy-pack/prompt_template.clj (rule 210)
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# refactor(policy-pack): split prompt_template.clj (rule 210)

## Overview

Splits the default-template resource loading out of
`ai.miniforge.policy-pack.prompt-template` into its own sibling
namespace, `ai.miniforge.policy-pack.template-defaults`, resolving a
stratum-lint SL003 finding (the combined namespace measured 6 real
layers, over the rule 210 budget of 3).

## Motivation

Part of the stratum-lint rule-210 remediation program's Wave 2
continuation. Full-repo sweep found `components/policy-pack` still has
18 files over budget; `prompt_template.clj` (229 lines, zero fan-in
repo-wide) is one of this batch.

## Changes in Detail

- New file `template_defaults.clj`: the EDN-resource-loading concern
  (`default-templates-resource`, `loaded-defaults`, `default-template`)
  — 3 layers, unchanged behavior.
- `prompt_template.clj`: template resolution and rendering
  (`interpolate`, `default-*-prompt/section`, `resolve-*-template`,
  `render-*`) — now 3 layers instead of 6, calling
  `template-defaults/default-template` instead of a same-file private
  helper.

This is pure code motion: no logic changed, only relocated and
re-namespaced. `default-template` was already private
(`defn-`) and had no callers outside this file, so no other call site
needed updating.

## Testing Plan

- `stratum-lint` clean on both files (exit 0, was SL003 exit 1).
- `bb test` (change-scope) green on the policy-pack component.
- Confirmed no other file in the repo referenced the moved private
  `default-template` symbol.

## Deployment Plan

Merges to `main` immediately; no follow-up needed for this file. 17
more `policy-pack` files remain over budget, tracked separately.

## Related Issues/PRs

- Part of the stratum-lint rule-210 Wave 2 continuation (see
  `workflow_runner.clj` splits miniforge#1662-#1667 and the
  `compliance-scanner` split #1580 for the established convention this
  follows).

## Checklist

- [x] stratum-lint clean on both resulting files
- [x] `bb test` green (policy-pack change-scope)
- [x] Adversarial self-review: def set unchanged, only relocated
- [x] Zero fan-in confirmed repo-wide before starting
