### PR TITLE
refactor(policy-pack): split builtin_detectors.clj (rule 210)

### DIFF
--- a/components/policy-pack/src/ai/miniforge/policy_pack/builtin_detectors.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/builtin_detectors.clj
@@ -16,75 +16,25 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns ai.miniforge.policy-pack.builtin-detectors
-  "Built-in :custom detectors, registered at namespace load. These exist so a
-   rule's policy parameters stay DATA — read from the rule's
-   `:rule/detection :detector-config` — instead of being encoded in a regex.
-   The rule reaches the detector via `:policy-pack/rule` in context (threaded in
-   by `detection/run-resolved-custom`)."
+  "Built-in :custom detectors, registered at namespace load. Each detector's
+   own logic lives in its own sibling namespace under `builtin-detectors.*`
+   (rule 210: registering more than one detector's worth of layers in this
+   file would exceed the 3-layer budget); this namespace only wires the
+   registration symbol — the one `pack.edn` `:custom-fn` data refers to — to
+   the sibling's implementation. The rule reaches the detector via
+   `:policy-pack/rule` in context (threaded in by
+   `detection/run-resolved-custom`)."
   (:require
-   [ai.miniforge.policy-pack.detection :as detection]))
+   [ai.miniforge.policy-pack.detection :as detection]
+   [ai.miniforge.policy-pack.builtin-detectors.approved-instance-types :as approved-instance-types]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
-;; Approved EC2 instance types
-(def ^{:stratum 0} ^:private default-approved-instance-families
-  "Fallback approved EC2 instance-type families, used only when a rule supplies
-   no :approved-families in its :detector-config."
-  ["t3" "t4g" "m5" "m6i" "c5" "c6i" "r5" "r6i"])
-
-(defn- ^{:stratum 0} instance-type-literals
-  "String literals assigned to instance_type in Terraform content, e.g.
-   `instance_type = \"t3.micro\"` -> \"t3.micro\". The capture is `*`, not `+`, so
-   an empty literal (`instance_type = \"\"`) is captured (and later flagged as a
-   non-family) rather than ignored. Variable references (`instance_type = var.x`)
-   carry no literal and are not evaluated here — the same limitation the prior
-   regex had."
-  [content]
-  (map second (re-seq #"instance_type\s*=\s*\"([^\"]*)\"" (str content))))
-
-(defn- ^{:stratum 0} approved?
-  "True when `literal` has a `family.size` shape whose family is approved. A
-   dotless/placeholder literal (\"t3\", \"\") has no family and is never approved
-   — matching the prior regex, which required a `family.` prefix."
-  [approved-set literal]
-  (boolean (when-let [[_ fam] (re-matches #"([^.]+)\..+" literal)]
-             (contains? approved-set fam))))
-
-;------------------------------------------------------------------------------ Layer 1
-
-(defn- ^{:stratum 1} approved-families
-  "The approved-family set for this rule. A configured `:approved-families` must
-   be a sequential collection of strings; anything else is a misconfigured pack
-   and throws (surfaced as a :custom-error by `run-resolved-custom`) rather than
-   silently coercing — e.g. a bare string would `set` into a char-set."
-  [context]
-  (let [configured (get-in context [:policy-pack/rule :rule/detection :detector-config :approved-families])]
-    (when (and configured (not (and (sequential? configured) (every? string? configured))))
-      (throw (ex-info "approved-families must be a sequential collection of strings"
-                      {:approved-families configured})))
-    (set (or configured default-approved-instance-families))))
-
-;------------------------------------------------------------------------------ Layer 2
-
-(defn ^{:stratum 2} check-approved-instance-types
-  "Flag EC2 `instance_type` literals whose family is not approved. The approved
-   families come from the rule's `:detector-config :approved-families` (data),
-   falling back to `default-approved-instance-families`."
-  [artifact context]
-  (let [approved  (approved-families context)
-        offenders (remove #(approved? approved %)
-                          (instance-type-literals (:artifact/content artifact)))]
-    (when (seq offenders)
-      {:matches  (vec offenders)
-       :message  (get-in context [:policy-pack/rule :rule/enforcement :message])})))
-
-;------------------------------------------------------------------------------ Layer 3
-
 ;; Registration (load-time side effect — see ns docstring)
-(defn- ^{:stratum 3} register!
+(defn- ^{:stratum 0} register!
   []
   (detection/register-custom-fn!
    'ai.miniforge.policy-pack.builtin-detectors/check-approved-instance-types
-   check-approved-instance-types))
+   approved-instance-types/check-approved-instance-types))
 
 (register!)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/builtin_detectors/approved_instance_types.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/builtin_detectors/approved_instance_types.clj
@@ -1,0 +1,78 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.builtin-detectors.approved-instance-types
+  "The `:custom` detector for EC2 `instance_type` family approval. Split out
+   of `ai.miniforge.policy-pack.builtin-detectors` (rule 210: the parent
+   namespace measured 4 real layers, max 3; this detector's own logic is
+   layer-coherent on its own). The rule's policy parameters stay DATA — read
+   from the rule's `:rule/detection :detector-config` — instead of being
+   encoded in a regex.")
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Approved EC2 instance types
+(def ^{:stratum 0} ^:private default-approved-instance-families
+  "Fallback approved EC2 instance-type families, used only when a rule supplies
+   no :approved-families in its :detector-config."
+  ["t3" "t4g" "m5" "m6i" "c5" "c6i" "r5" "r6i"])
+
+(defn- ^{:stratum 0} instance-type-literals
+  "String literals assigned to instance_type in Terraform content, e.g.
+   `instance_type = \"t3.micro\"` -> \"t3.micro\". The capture is `*`, not `+`, so
+   an empty literal (`instance_type = \"\"`) is captured (and later flagged as a
+   non-family) rather than ignored. Variable references (`instance_type = var.x`)
+   carry no literal and are not evaluated here — the same limitation the prior
+   regex had."
+  [content]
+  (map second (re-seq #"instance_type\s*=\s*\"([^\"]*)\"" (str content))))
+
+(defn- ^{:stratum 0} approved?
+  "True when `literal` has a `family.size` shape whose family is approved. A
+   dotless/placeholder literal (\"t3\", \"\") has no family and is never approved
+   — matching the prior regex, which required a `family.` prefix."
+  [approved-set literal]
+  (boolean (when-let [[_ fam] (re-matches #"([^.]+)\..+" literal)]
+             (contains? approved-set fam))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} approved-families
+  "The approved-family set for this rule. A configured `:approved-families` must
+   be a sequential collection of strings; anything else is a misconfigured pack
+   and throws (surfaced as a :custom-error by `run-resolved-custom`) rather than
+   silently coercing — e.g. a bare string would `set` into a char-set."
+  [context]
+  (let [configured (get-in context [:policy-pack/rule :rule/detection :detector-config :approved-families])]
+    (when (and configured (not (and (sequential? configured) (every? string? configured))))
+      (throw (ex-info "approved-families must be a sequential collection of strings"
+                      {:approved-families configured})))
+    (set (or configured default-approved-instance-families))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} check-approved-instance-types
+  "Flag EC2 `instance_type` literals whose family is not approved. The approved
+   families come from the rule's `:detector-config :approved-families` (data),
+   falling back to `default-approved-instance-families`."
+  [artifact context]
+  (let [approved  (approved-families context)
+        offenders (remove #(approved? approved %)
+                          (instance-type-literals (:artifact/content artifact)))]
+    (when (seq offenders)
+      {:matches  (vec offenders)
+       :message  (get-in context [:policy-pack/rule :rule/enforcement :message])})))

--- a/docs/pull-requests/2026-08-09-refactor-split-policy-pack-builtin-detectors.md
+++ b/docs/pull-requests/2026-08-09-refactor-split-policy-pack-builtin-detectors.md
@@ -1,0 +1,70 @@
+<!--
+  Title: Split policy-pack/builtin_detectors.clj (rule 210)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(policy-pack): split builtin_detectors.clj (rule 210)
+
+## Overview
+
+Splits the EC2 `instance_type` approval detector out of
+`ai.miniforge.policy-pack.builtin-detectors` into its own sibling
+namespace, `ai.miniforge.policy-pack.builtin-detectors.approved-instance-types`,
+resolving a stratum-lint SL003 finding (the combined namespace
+measured 4 real layers, over the rule 210 budget of 3).
+
+## Motivation
+
+Part of the stratum-lint rule-210 remediation program's Wave 2
+continuation (per-file namespace splits for components whose Wave 1
+fix was a heading-only relabeling, not a real split). Full-repo sweep
+found `components/policy-pack` still has 18 files over budget;
+`builtin_detectors.clj` was picked first as the smallest (90 lines,
+zero fan-in repo-wide — nothing else requires this namespace directly,
+so the split carries no call-site risk outside its own registration
+wiring).
+
+## Changes in Detail
+
+- New file `builtin_detectors/approved_instance_types.clj`: the
+  detector's own logic (`default-approved-instance-families`,
+  `instance-type-literals`, `approved?`, `approved-families`,
+  `check-approved-instance-types`) — 3 layers, unchanged behavior.
+- `builtin_detectors.clj`: now only the load-time registration wiring
+  (1 layer). The registration KEY stays the original fully-qualified
+  symbol (`ai.miniforge.policy-pack.builtin-detectors/check-approved-instance-types`)
+  since `resources/policy_pack/packs/terraform-aws-1.0.0.pack.edn`
+  references it as data (`:custom-fn`) — only the registered
+  implementation moves, the data-facing name does not.
+
+This is pure code motion: no logic changed, only relocated and
+re-namespaced.
+
+## Testing Plan
+
+- `stratum-lint` clean on both files (exit 0, was SL003 exit 1).
+- `bb test` (change-scope) green on the policy-pack component.
+- Existing `builtin_detectors_test.clj` unchanged and passing — it
+  exercises the detector through the real `detection/detect-custom`
+  path (registry lookup), not by calling the moved function directly,
+  so it is agnostic to which namespace implements it.
+
+## Deployment Plan
+
+Merges to `main` immediately; no follow-up needed for this file. 17
+more `policy-pack` files remain over budget, tracked separately.
+
+## Related Issues/PRs
+
+- Part of the stratum-lint rule-210 Wave 2 continuation (see
+  `workflow_runner.clj` splits miniforge#1662-#1667 and the
+  `compliance-scanner` split #1580 for the established convention this
+  follows).
+
+## Checklist
+
+- [x] stratum-lint clean on both resulting files
+- [x] `bb test` green (policy-pack change-scope)
+- [x] Adversarial self-review: def set unchanged, only relocated
+- [x] Zero fan-in confirmed repo-wide before starting


### PR DESCRIPTION
<!--
  Title: Split policy-pack/builtin_detectors.clj (rule 210)
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# refactor(policy-pack): split builtin_detectors.clj (rule 210)

## Overview

Splits the EC2 `instance_type` approval detector out of
`ai.miniforge.policy-pack.builtin-detectors` into its own sibling
namespace, `ai.miniforge.policy-pack.builtin-detectors.approved-instance-types`,
resolving a stratum-lint SL003 finding (the combined namespace
measured 4 real layers, over the rule 210 budget of 3).

## Motivation

Part of the stratum-lint rule-210 remediation program's Wave 2
continuation (per-file namespace splits for components whose Wave 1
fix was a heading-only relabeling, not a real split). Full-repo sweep
found `components/policy-pack` still has 18 files over budget;
`builtin_detectors.clj` was picked first as the smallest (90 lines,
zero fan-in repo-wide — nothing else requires this namespace directly,
so the split carries no call-site risk outside its own registration
wiring).

## Changes in Detail

- New file `builtin_detectors/approved_instance_types.clj`: the
  detector's own logic (`default-approved-instance-families`,
  `instance-type-literals`, `approved?`, `approved-families`,
  `check-approved-instance-types`) — 3 layers, unchanged behavior.
- `builtin_detectors.clj`: now only the load-time registration wiring
  (1 layer). The registration KEY stays the original fully-qualified
  symbol (`ai.miniforge.policy-pack.builtin-detectors/check-approved-instance-types`)
  since `resources/policy_pack/packs/terraform-aws-1.0.0.pack.edn`
  references it as data (`:custom-fn`) — only the registered
  implementation moves, the data-facing name does not.

This is pure code motion: no logic changed, only relocated and
re-namespaced.

## Testing Plan

- `stratum-lint` clean on both files (exit 0, was SL003 exit 1).
- `bb test` (change-scope) green on the policy-pack component.
- Existing `builtin_detectors_test.clj` unchanged and passing — it
  exercises the detector through the real `detection/detect-custom`
  path (registry lookup), not by calling the moved function directly,
  so it is agnostic to which namespace implements it.

## Deployment Plan

Merges to `main` immediately; no follow-up needed for this file. 17
more `policy-pack` files remain over budget, tracked separately.

## Related Issues/PRs

- Part of the stratum-lint rule-210 Wave 2 continuation (see
  `workflow_runner.clj` splits miniforge#1662-#1667 and the
  `compliance-scanner` split #1580 for the established convention this
  follows).

## Checklist

- [x] stratum-lint clean on both resulting files
- [x] `bb test` green (policy-pack change-scope)
- [x] Adversarial self-review: def set unchanged, only relocated
- [x] Zero fan-in confirmed repo-wide before starting
