### PR TITLE
refactor(policy-pack): split mdc_compiler.clj — extract frontmatter (2/6)

### DIFF
--- a/components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler.clj
@@ -24,24 +24,27 @@
 
    Designed to be called by the ETL task (bb standards:pack) at build time.
 
-   Slice 1/6 of a rule 210 split train (SL003: this namespace measured
+   Slice 2/6 of a rule 210 split train (SL003: this namespace measured
    9 real layers, max 3 — same approach as the dag-orchestrator split,
-   miniforge#1485, and the workflow-runner split, miniforge#1662):
-   quote-stripping and the frontmatter scalar-value grammar moved to
-   `ai.miniforge.policy-pack.mdc-compiler.frontmatter-values`. This
-   file now measures 7 real layers; further slices land in subsequent
-   PRs until it's within budget.
+   miniforge#1485, and the workflow-runner split, miniforge#1662).
+   Slice 1 (miniforge#1729) moved the frontmatter scalar-value grammar
+   to `mdc-compiler.frontmatter-values`; this slice moves the
+   remaining frontmatter line-grammar (splitting, key/value and list
+   parsing) to `mdc-compiler.frontmatter`. The file still measures 7
+   real layers — the frontmatter chain was never the sole bottleneck;
+   the surviving critical path is now condense-to-length →
+   extract-agent-behavior → mdc->rule → compile-standards-pack, which
+   the next slices target directly.
 
-   Layer 0: Parsing/config primitives — split-frontmatter,
-     group-dotted-keys, build-exclude-context, build-detection-config,
-     dewey-ranges, default-phases, slug->rule-id/title, agent-behavior
-     paragraph/bullet helpers, format-pack-version, validate-no-duplicate-slugs,
-     parse-list-item, parse-kv-line
+   Layer 0: Parsing/config primitives — group-dotted-keys,
+     build-exclude-context, build-detection-config, dewey-ranges,
+     default-phases, slug->rule-id/title, agent-behavior
+     paragraph/bullet helpers, format-pack-version,
+     validate-no-duplicate-slugs, parse-mdc
    Layer 1: build-remediation-config, find-dewey-range, bullet-line?,
-     condense-prose, export-canonical-taxonomy, process-frontmatter-line
-   Layer 2: dewey->phases/category-id/category-label, condense-bullets,
-     parse-frontmatter
-   Layer 3: condense-to-length, build-categories, parse-mdc
+     condense-prose, export-canonical-taxonomy
+   Layer 2: dewey->phases/category-id/category-label, condense-bullets
+   Layer 3: condense-to-length, build-categories
    Layer 4: extract-agent-behavior
    Layer 5: mdc->rule
    Layer 6: compile-standards-pack
@@ -52,37 +55,13 @@
      .standards/                                 — source .mdc files (input)"
   (:require
    [ai.miniforge.coerce.interface :as coerce]
-   [ai.miniforge.policy-pack.mdc-compiler.frontmatter-values :as frontmatter-values]
+   [ai.miniforge.policy-pack.mdc-compiler.frontmatter :as frontmatter]
    [ai.miniforge.policy-pack.schema-types :as schema-types]
    [ai.miniforge.policy-pack.schema-validation :as schema-validation]
    [clojure.java.io :as io]
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-
-;; MDC parsing — frontmatter and body extraction
-(defn ^{:stratum 0} split-frontmatter
-  "Split MDC content into frontmatter string and body string.
-
-   Expects --- delimited YAML frontmatter at the top of the file.
-
-   Arguments:
-   - content - Full .mdc file content
-
-   Returns:
-   - {:frontmatter <string> :body <string>}"
-  [content]
-  (let [trimmed (str/trim (str content))]
-    (if (str/starts-with? trimmed "---")
-      (let [after-open (subs trimmed 3)
-            close-idx (str/index-of after-open "---")]
-        (if close-idx
-          {:frontmatter (str/trim (subs after-open 0 close-idx))
-           :body        (str/trim (subs after-open (+ close-idx 3)))}
-          {:frontmatter ""
-           :body        trimmed}))
-      {:frontmatter ""
-       :body        trimmed})))
 
 ;; Detection and remediation config builders
 (defn- ^{:stratum 0} group-dotted-keys
@@ -292,21 +271,18 @@
             (str/join ", " (map first duplicates))
             ". Rule IDs must be unique across all subdirectories.")])))
 
-(defn- ^{:stratum 0} parse-list-item
-  "Parse a '- <value>' frontmatter list line to its string value."
-  [trimmed]
-  (frontmatter-values/strip-quotes (str/trim (subs trimmed 2))))
+(defn ^{:stratum 0} parse-mdc
+  "Parse an MDC file into its structured components.
 
-(defn- ^{:stratum 0} parse-kv-line
-  "Parse a 'key: value' frontmatter line.
-   Returns [new-current-key updated-acc]."
-  [trimmed acc]
-  (let [idx (str/index-of trimmed ":")
-        k   (str/trim (subs trimmed 0 idx))
-        v   (str/trim (subs trimmed (inc idx)))]
-    (if (str/blank? v)
-      [k (assoc acc k [])]
-      [nil (assoc acc k (frontmatter-values/parse-frontmatter-value v))])))
+   Arguments:
+   - content - Full .mdc file content string
+
+   Returns:
+   - {:frontmatter {string-key value} :body string}"
+  [content]
+  (let [{:keys [frontmatter body]} (frontmatter/split-frontmatter content)]
+    {:frontmatter (frontmatter/parse-frontmatter frontmatter)
+     :body        body}))
 
 ;------------------------------------------------------------------------------ Layer 1
 
@@ -385,21 +361,6 @@
             :alias/target (keyword "mf.cat" id)})
          dewey-ranges)})
 
-(defn- ^{:stratum 1} process-frontmatter-line
-  "Process one frontmatter line. Returns [current-key acc]."
-  [trimmed current-key acc]
-  (cond
-    (str/blank? trimmed)
-    [current-key acc]
-
-    (and current-key (str/starts-with? trimmed "- "))
-    [current-key (update acc current-key (fnil conj []) (parse-list-item trimmed))]
-
-    (str/includes? trimmed ":")
-    (parse-kv-line trimmed acc)
-
-    :else [current-key acc]))
-
 ;------------------------------------------------------------------------------ Layer 2
 
 (defn ^{:stratum 2} dewey->phases
@@ -453,28 +414,6 @@
       result
       (keep-whole-sentences result target-length))))
 
-(defn- ^{:stratum 2} parse-frontmatter
-  "Parse YAML-like frontmatter text into a string-keyed map.
-
-   Handles simple key: value pairs, inline arrays [a, b], and
-   multi-line list items (- value) under a key.
-
-   Arguments:
-   - frontmatter-str - Raw text between --- delimiters
-
-   Returns:
-   - Map of {string-key parsed-value}, or empty map."
-  [frontmatter-str]
-  (if (str/blank? frontmatter-str)
-    {}
-    (loop [[line & remaining] (str/split-lines frontmatter-str)
-           current-key nil
-           acc {}]
-      (if (nil? line)
-        acc
-        (let [[current-key' acc'] (process-frontmatter-line (str/trim line) current-key acc)]
-          (recur remaining current-key' acc'))))))
-
 ;------------------------------------------------------------------------------ Layer 3
 
 (defn- ^{:stratum 3} condense-to-length
@@ -514,19 +453,6 @@
                  :category/rules (mapv :rule/id cat-rules)}))
          (sort-by :category/id)
          vec)))
-
-(defn ^{:stratum 3} parse-mdc
-  "Parse an MDC file into its structured components.
-
-   Arguments:
-   - content - Full .mdc file content string
-
-   Returns:
-   - {:frontmatter {string-key value} :body string}"
-  [content]
-  (let [{:keys [frontmatter body]} (split-frontmatter content)]
-    {:frontmatter (parse-frontmatter frontmatter)
-     :body        body}))
 
 ;------------------------------------------------------------------------------ Layer 4
 

--- a/components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler/frontmatter.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler/frontmatter.clj
@@ -1,0 +1,112 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.mdc-compiler.frontmatter
+  "MDC frontmatter line-grammar: splitting a file into frontmatter/body,
+   and parsing the frontmatter block's lines (key: value, multi-line
+   `- item` lists) into a string-keyed map. Split out of
+   `ai.miniforge.policy-pack.mdc-compiler` (rule 210: slice 2/6 of the
+   same split train as
+   `ai.miniforge.policy-pack.mdc-compiler.frontmatter-values`, miniforge#1729
+   — same approach as the dag-orchestrator split, miniforge#1485, and
+   the workflow-runner split, miniforge#1662)."
+  (:require
+   [ai.miniforge.policy-pack.mdc-compiler.frontmatter-values :as frontmatter-values]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; MDC parsing — frontmatter and body extraction
+(defn ^{:stratum 0} split-frontmatter
+  "Split MDC content into frontmatter string and body string.
+
+   Expects --- delimited YAML frontmatter at the top of the file.
+
+   Arguments:
+   - content - Full .mdc file content
+
+   Returns:
+   - {:frontmatter <string> :body <string>}"
+  [content]
+  (let [trimmed (str/trim (str content))]
+    (if (str/starts-with? trimmed "---")
+      (let [after-open (subs trimmed 3)
+            close-idx (str/index-of after-open "---")]
+        (if close-idx
+          {:frontmatter (str/trim (subs after-open 0 close-idx))
+           :body        (str/trim (subs after-open (+ close-idx 3)))}
+          {:frontmatter ""
+           :body        trimmed}))
+      {:frontmatter ""
+       :body        trimmed})))
+
+(defn- ^{:stratum 0} parse-list-item
+  "Parse a '- <value>' frontmatter list line to its string value."
+  [trimmed]
+  (frontmatter-values/strip-quotes (str/trim (subs trimmed 2))))
+
+(defn- ^{:stratum 0} parse-kv-line
+  "Parse a 'key: value' frontmatter line.
+   Returns [new-current-key updated-acc]."
+  [trimmed acc]
+  (let [idx (str/index-of trimmed ":")
+        k   (str/trim (subs trimmed 0 idx))
+        v   (str/trim (subs trimmed (inc idx)))]
+    (if (str/blank? v)
+      [k (assoc acc k [])]
+      [nil (assoc acc k (frontmatter-values/parse-frontmatter-value v))])))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} process-frontmatter-line
+  "Process one frontmatter line. Returns [current-key acc]."
+  [trimmed current-key acc]
+  (cond
+    (str/blank? trimmed)
+    [current-key acc]
+
+    (and current-key (str/starts-with? trimmed "- "))
+    [current-key (update acc current-key (fnil conj []) (parse-list-item trimmed))]
+
+    (str/includes? trimmed ":")
+    (parse-kv-line trimmed acc)
+
+    :else [current-key acc]))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} parse-frontmatter
+  "Parse YAML-like frontmatter text into a string-keyed map.
+
+   Handles simple key: value pairs, inline arrays [a, b], and
+   multi-line list items (- value) under a key.
+
+   Arguments:
+   - frontmatter-str - Raw text between --- delimiters
+
+   Returns:
+   - Map of {string-key parsed-value}, or empty map."
+  [frontmatter-str]
+  (if (str/blank? frontmatter-str)
+    {}
+    (loop [[line & remaining] (str/split-lines frontmatter-str)
+           current-key nil
+           acc {}]
+      (if (nil? line)
+        acc
+        (let [[current-key' acc'] (process-frontmatter-line (str/trim line) current-key acc)]
+          (recur remaining current-key' acc'))))))

--- a/components/policy-pack/test/ai/miniforge/policy_pack/mdc_compiler_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/mdc_compiler_test.clj
@@ -31,7 +31,8 @@
   (:require
    [clojure.test :refer [deftest testing is are]]
    [clojure.string :as str]
-   [ai.miniforge.policy-pack.mdc-compiler :as sut]))
+   [ai.miniforge.policy-pack.mdc-compiler :as sut]
+   [ai.miniforge.policy-pack.mdc-compiler.frontmatter :as frontmatter]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -43,30 +44,30 @@
 ;; ============================================================================
 (deftest ^{:stratum 0} split-frontmatter-test
   (testing "splits frontmatter and body at --- delimiters"
-    (let [result (sut/split-frontmatter "---\nkey: value\n---\nBody text")]
+    (let [result (frontmatter/split-frontmatter "---\nkey: value\n---\nBody text")]
       (is (= "key: value" (:frontmatter result)))
       (is (= "Body text" (:body result)))))
 
   (testing "handles missing frontmatter (no --- prefix)"
-    (let [result (sut/split-frontmatter "Just body text")]
+    (let [result (frontmatter/split-frontmatter "Just body text")]
       (is (= "" (:frontmatter result)))
       (is (= "Just body text" (:body result)))))
 
   (testing "handles missing closing ---"
-    (let [result (sut/split-frontmatter "---\nkey: value\nno closing")]
+    (let [result (frontmatter/split-frontmatter "---\nkey: value\nno closing")]
       (is (= "" (:frontmatter result)))))
 
   (testing "handles empty frontmatter"
-    (let [result (sut/split-frontmatter "---\n---\nBody only")]
+    (let [result (frontmatter/split-frontmatter "---\n---\nBody only")]
       (is (= "" (:frontmatter result)))
       (is (= "Body only" (:body result)))))
 
   (testing "handles empty content"
-    (let [result (sut/split-frontmatter "")]
+    (let [result (frontmatter/split-frontmatter "")]
       (is (= "" (:frontmatter result)))))
 
   (testing "handles nil content gracefully"
-    (let [result (sut/split-frontmatter nil)]
+    (let [result (frontmatter/split-frontmatter nil)]
       (is (= "" (:frontmatter result))))))
 
 ;; ============================================================================

--- a/docs/pull-requests/2026-08-09-refactor-split-policy-pack-mdc-compiler-2.md
+++ b/docs/pull-requests/2026-08-09-refactor-split-policy-pack-mdc-compiler-2.md
@@ -1,0 +1,101 @@
+<!--
+  Title: Split policy-pack mdc_compiler.clj — extract frontmatter (2/6)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(policy-pack): split mdc_compiler.clj — extract frontmatter (2/6)
+
+## Overview
+
+Slice 2 of the 6-PR split train for
+`components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler.clj`
+(rule 210, SL003 — 9 real layers, max 3; slice 1 was #1729). This
+slice extracts `ai.miniforge.policy-pack.mdc-compiler.frontmatter`:
+the frontmatter line-grammar — `split-frontmatter`, `parse-list-item`,
+`parse-kv-line`, `process-frontmatter-line`, `parse-frontmatter` —
+which requires slice 1's `frontmatter-values` for `strip-quotes` and
+`parse-frontmatter-value`.
+
+## Motivation
+
+Re-confirmed zero fan-in on `mdc-compiler` before starting (no other
+namespace requires it repo-wide), and re-verified the branch was
+rebased onto the latest `origin/main` (which now includes #1729)
+before making changes.
+
+## Changes in Detail
+
+- New file `mdc_compiler/frontmatter.clj`: the frontmatter
+  line-grammar functions, 3 real layers (0-2), stratum-lint clean on
+  its own.
+- `mdc_compiler.clj`: the five functions removed; `parse-mdc` now
+  calls `frontmatter/split-frontmatter` and
+  `frontmatter/parse-frontmatter`. Ran `stratum-lint --fix` to
+  renumber headings/`:stratum` metadata and updated the namespace
+  docstring's layer summary.
+- **Notable finding**: the file still measures 7 real layers after
+  this slice, unchanged from slice 1. The frontmatter chain was never
+  the sole bottleneck — `parse-mdc`'s stratum dropped to 0 (all its
+  remaining dependencies are now external), but the file's overall
+  layer count is set by an independent chain:
+  `condense-to-length → extract-agent-behavior → mdc->rule →
+  compile-standards-pack`. Slices 3-4 (the condense/agent-behavior
+  extraction) target that chain directly and are expected to bring
+  the real layer count down.
+- `mdc_compiler_test.clj`: added a require for the new
+  `frontmatter` namespace; `split-frontmatter-test`'s 6 call sites
+  now call `frontmatter/split-frontmatter` instead of
+  `sut/split-frontmatter`. No other test changes needed —
+  `parse-list-item`/`parse-kv-line`/`process-frontmatter-line`/
+  `parse-frontmatter` had no direct test coverage (exercised only
+  indirectly through `parse-mdc`, whose tests are unaffected).
+
+The parent namespace stays over budget (7 real layers) until the
+remaining slices land; the commit removing the functions used
+`MINIFORGE_STRATUM_BUDGET_MODE=warn` to get past the pre-commit gate's
+plain-lint check on the intermediate state, same convention as #1662
+and #1729.
+
+## Testing Plan
+
+1. `clj-kondo` clean on all three touched files.
+2. stratum-lint: `frontmatter.clj` passes SL003 outright;
+   `mdc_compiler.clj` intentionally still over budget (7 layers,
+   unchanged from slice 1) — expected, see Motivation above.
+3. `ai.miniforge.policy-pack.mdc-compiler-test`: 26 tests / 159
+   assertions, 0 failures, 0 errors — unchanged from main.
+4. Full pre-commit suite (`poly:check`, lint, smoke tests, GraalVM)
+   passed on both commits.
+5. Adversarial self-review: diffed the full top-level `defn`/`def` set
+   before and after — exactly 5 relocated, 0 added/removed/altered in
+   behavior; `parse-mdc`'s body is unchanged except for the two
+   qualified calls, every other def's body is byte-identical.
+
+PR size: reportable lines were checked per-commit (74 for the new
+file, 132 for the removal/test-update commit), both under the
+200-line commit budget; combined well under the 600-line PR budget.
+
+## Deployment Plan
+
+Merges to `main` as part of the ongoing 6-PR train. The next slice
+rebases onto the updated `main` after this one merges.
+
+## Related Issues/PRs
+
+- Slice 1: [#1729](https://github.com/miniforge-ai/miniforge/pull/1729)
+- Precedent: [dag-orchestrator split, #1485](https://github.com/miniforge-ai/miniforge/pull/1485)
+- Precedent: [workflow-runner split, #1662](https://github.com/miniforge-ai/miniforge/pull/1662)
+- Part of the stratum-lint rule-210 remediation program (Wave 2)
+
+## Checklist
+
+- [x] Zero fan-in re-confirmed before starting
+- [x] Branch rebased onto latest `origin/main` (includes #1729)
+- [x] Pure code motion — no behavior change, no logic altered
+- [x] `clj-kondo` clean
+- [x] Tests green (26/26, 159 assertions)
+- [x] Commit-diff budgets checked (74 and 132, both ≤200); PR total
+      well under 600
+- [x] `MINIFORGE_STRATUM_BUDGET_MODE=warn` used + documented for the
+      expected intermediate over-budget state


### PR DESCRIPTION
<!--
  Title: Split policy-pack mdc_compiler.clj — extract frontmatter (2/6)
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# refactor(policy-pack): split mdc_compiler.clj — extract frontmatter (2/6)

## Overview

Slice 2 of the 6-PR split train for
`components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler.clj`
(rule 210, SL003 — 9 real layers, max 3; slice 1 was #1729). This
slice extracts `ai.miniforge.policy-pack.mdc-compiler.frontmatter`:
the frontmatter line-grammar — `split-frontmatter`, `parse-list-item`,
`parse-kv-line`, `process-frontmatter-line`, `parse-frontmatter` —
which requires slice 1's `frontmatter-values` for `strip-quotes` and
`parse-frontmatter-value`.

## Motivation

Re-confirmed zero fan-in on `mdc-compiler` before starting (no other
namespace requires it repo-wide), and re-verified the branch was
rebased onto the latest `origin/main` (which now includes #1729)
before making changes.

## Changes in Detail

- New file `mdc_compiler/frontmatter.clj`: the frontmatter
  line-grammar functions, 3 real layers (0-2), stratum-lint clean on
  its own.
- `mdc_compiler.clj`: the five functions removed; `parse-mdc` now
  calls `frontmatter/split-frontmatter` and
  `frontmatter/parse-frontmatter`. Ran `stratum-lint --fix` to
  renumber headings/`:stratum` metadata and updated the namespace
  docstring's layer summary.
- **Notable finding**: the file still measures 7 real layers after
  this slice, unchanged from slice 1. The frontmatter chain was never
  the sole bottleneck — `parse-mdc`'s stratum dropped to 0 (all its
  remaining dependencies are now external), but the file's overall
  layer count is set by an independent chain:
  `condense-to-length → extract-agent-behavior → mdc->rule →
  compile-standards-pack`. Slices 3-4 (the condense/agent-behavior
  extraction) target that chain directly and are expected to bring
  the real layer count down.
- `mdc_compiler_test.clj`: added a require for the new
  `frontmatter` namespace; `split-frontmatter-test`'s 6 call sites
  now call `frontmatter/split-frontmatter` instead of
  `sut/split-frontmatter`. No other test changes needed —
  `parse-list-item`/`parse-kv-line`/`process-frontmatter-line`/
  `parse-frontmatter` had no direct test coverage (exercised only
  indirectly through `parse-mdc`, whose tests are unaffected).

The parent namespace stays over budget (7 real layers) until the
remaining slices land; the commit removing the functions used
`MINIFORGE_STRATUM_BUDGET_MODE=warn` to get past the pre-commit gate's
plain-lint check on the intermediate state, same convention as #1662
and #1729.

## Testing Plan

1. `clj-kondo` clean on all three touched files.
2. stratum-lint: `frontmatter.clj` passes SL003 outright;
   `mdc_compiler.clj` intentionally still over budget (7 layers,
   unchanged from slice 1) — expected, see Motivation above.
3. `ai.miniforge.policy-pack.mdc-compiler-test`: 26 tests / 159
   assertions, 0 failures, 0 errors — unchanged from main.
4. Full pre-commit suite (`poly:check`, lint, smoke tests, GraalVM)
   passed on both commits.
5. Adversarial self-review: diffed the full top-level `defn`/`def` set
   before and after — exactly 5 relocated, 0 added/removed/altered in
   behavior; `parse-mdc`'s body is unchanged except for the two
   qualified calls, every other def's body is byte-identical.

PR size: reportable lines were checked per-commit (74 for the new
file, 132 for the removal/test-update commit), both under the
200-line commit budget; combined well under the 600-line PR budget.

## Deployment Plan

Merges to `main` as part of the ongoing 6-PR train. The next slice
rebases onto the updated `main` after this one merges.

## Related Issues/PRs

- Slice 1: [#1729](https://github.com/miniforge-ai/miniforge/pull/1729)
- Precedent: [dag-orchestrator split, #1485](https://github.com/miniforge-ai/miniforge/pull/1485)
- Precedent: [workflow-runner split, #1662](https://github.com/miniforge-ai/miniforge/pull/1662)
- Part of the stratum-lint rule-210 remediation program (Wave 2)

## Checklist

- [x] Zero fan-in re-confirmed before starting
- [x] Branch rebased onto latest `origin/main` (includes #1729)
- [x] Pure code motion — no behavior change, no logic altered
- [x] `clj-kondo` clean
- [x] Tests green (26/26, 159 assertions)
- [x] Commit-diff budgets checked (74 and 132, both ≤200); PR total
      well under 600
- [x] `MINIFORGE_STRATUM_BUDGET_MODE=warn` used + documented for the
      expected intermediate over-budget state
