### PR TITLE
fix(test): isolate commit-budget gate tests from MINIFORGE_COMMIT_BUDGET_OVERRIDE

### DIFF
--- a/development/test/commit_budget_test.clj
+++ b/development/test/commit_budget_test.clj
@@ -44,6 +44,8 @@
 
 (def ^{:stratum 0} check-commit-budget! (resolve 'commit-budget/check-commit-budget!))
 
+(def ^{:stratum 0} override-rationale (resolve 'commit-budget/override-rationale))
+
 (def ^{:stratum 0} default-budget @(resolve 'commit-budget/default-budget))
 
 (defn ^{:stratum 0} ^:private unread-staged-diff
@@ -145,12 +147,21 @@
     (= "true" (str/trim out))))
 
 (defn ^{:stratum 1} ^:private gate-output
-  "Stdout from one `check-commit-budget!` run over a stubbed merge state
-   and `staged-diff`, so the gate's decision can be read without a real
-   repo or index."
-  [merging? staged-diff-fn budget]
+  "Stdout from one `check-commit-budget!` run over a stubbed merge state,
+   `staged-diff`, and override rationale, so the gate's decision can be
+   read without a real repo or index.
+
+   `override-rationale` is stubbed to `rationale` (pass nil for the
+   non-overridden path) rather than left reading the process
+   environment: this test runs inside the pre-commit hook, where a
+   developer legitimately using
+   `MINIFORGE_COMMIT_BUDGET_OVERRIDE='<why>' git commit ...` would
+   otherwise flip every gate assertion onto the override branch and
+   fail the very commit the override was meant to let through."
+  [merging? staged-diff-fn budget rationale]
   (with-redefs-fn {merge-in-progress? (constantly merging?)
-                   staged-diff        staged-diff-fn}
+                   staged-diff        staged-diff-fn
+                   override-rationale (constantly rationale)}
     #(with-out-str (check-commit-budget! budget))))
 
 (deftest ^{:stratum 1} resource-data-files-excluded-test
@@ -260,14 +271,27 @@
 
 (deftest ^{:stratum 2} merge-skips-the-budget-test
   (testing "mid-merge the gate skips without reading the index at all"
-    (let [out (gate-output true unread-staged-diff default-budget)]
+    (let [out (gate-output true unread-staged-diff default-budget nil)]
       (is (str/includes? out "skipped (merge in progress)"))
       (is (not (str/includes? out "lines OK"))))))
 
 (deftest ^{:stratum 2} non-merge-commit-still-budgeted-test
   (testing "outside a merge the gate still reports against the budget"
-    (let [out (gate-output false (constantly [in-budget-entry]) default-budget)]
+    (let [out (gate-output false (constantly [in-budget-entry]) default-budget nil)]
       (is (str/includes? out (format "%d / %d lines OK"
                                      (count (:added in-budget-entry))
                                      default-budget)))
       (is (not (str/includes? out "skipped"))))))
+
+(deftest ^{:stratum 2} override-bypasses-budget-test
+  (testing "with a rationale set the gate reports OVERRIDDEN and echoes it"
+    (let [out (gate-output false (constantly [in-budget-entry]) default-budget
+                           "generated migration")]
+      (is (str/includes? out "OVERRIDDEN"))
+      (is (str/includes? out "rationale: generated migration"))
+      (is (not (str/includes? out "lines OK")))))
+  (testing "over budget, the override still passes but warns"
+    (let [out (gate-output false (constantly [in-budget-entry]) 1
+                           "generated migration")]
+      (is (str/includes? out "OVERRIDDEN"))
+      (is (str/includes? out "budget intentionally bypassed")))))


### PR DESCRIPTION
## Problem

`development/test/commit_budget_test.clj`'s `gate-output` fixture stubs `merge-in-progress?` and `staged-diff` but leaves `override-rationale` reading the ambient process environment. Setting the documented override:

    MINIFORGE_COMMIT_BUDGET_OVERRIDE='<rationale>' git commit ...

flips `non-merge-commit-still-budgeted-test` onto the override branch during the pre-commit hook's `test:precommit` step:

    FAIL in (non-merge-commit-still-budgeted-test) (commit_budget_test.clj:270)
    actual: (not (str/includes? "📏 commit-budget: OVERRIDDEN (2 reportable lines)\n  rationale: ..." "2 / 200 lines OK"))

— failing the very commit the override was meant to let through, which makes the override mechanism unusable with the hook.

## Fix

1. Stub `override-rationale` through the same `with-redefs-fn` map as the other two collaborators, parameterized per `gate-output` call (nil = non-overridden path). Every gate assertion is now hermetic regardless of ambient environment.
2. Add `override-bypasses-budget-test` covering the previously-untested override branch: rationale echo, and the over-budget warning.

Sibling exposure checked: `merge-skips-the-budget-test` was not exposed (the merge branch returns before the rationale check) but now goes through the same parameterized stub; the linked-worktree integration test never invokes the gate.

## Verification

Test namespace run both with a clean environment and with `MINIFORGE_COMMIT_BUDGET_OVERRIDE='ambient rationale'` exported: 10 tests, 43 assertions, 0 failures in both. Full pre-commit gate chain (budget, poly check, clj-kondo, stratum-lint, smoke set, GraalVM compat) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)