### PR TITLE
fix(lint): skip the stratum-lint pre-commit gate on merge commits

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -136,7 +136,14 @@ Two related, previously-missing gates, added 2026-07-26:
   for the override and dilutes its signal for the cases it exists for.
   `bb pr-budget` still covers the whole PR diff in CI, and is not
   affected: it diffs merge-base..head, so content the branch merged in
-  from the base is already excluded.
+  from the base is already excluded. The same exemption covers the
+  stratum-lint gate (`lint/stratum-staged`, added 2026-08-10, sharing
+  `commit-budget/merge-in-progress?`): a merge stages files from the
+  merged-in branch the merging author never touched, and a file
+  legitimately mid-way through its own namespace-split wave on main
+  (still SL003 there by design) was blocking unrelated merges,
+  forcing `MINIFORGE_STRATUM_BUDGET_MODE=warn`. Incoming files were
+  stratum-linted on their own PRs; CI lints the PR's own diff.
 - **Adversarial self-review before every push**, not just for PRs that
   trip the size gate. Read the actual diff like a skeptical reviewer,
   not the tool's own "this should be safe" framing.

--- a/development/test/lint_test.clj
+++ b/development/test/lint_test.clj
@@ -1,0 +1,74 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns lint-test
+  "Pins `lint/stratum-staged`'s merge-commit skip. Mid-merge the staged
+   set includes every file arriving from the merged-in branch — files
+   the merging author did not touch, already stratum-linted on their
+   own PRs, and possibly mid-way through a namespace split on main
+   (legitimately SL003 there). The gate must skip before listing the
+   staged files at all, and must keep dispatching normally outside a
+   merge. Merge *detection* is pinned by `commit-budget-test` against a
+   real linked-worktree merge; this namespace pins the gate's use of it."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [commit-budget]
+            [lint]
+            [stratum]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} ^:private unlisted-staged-by-ext
+  "A `staged-by-ext` stand-in that fails if anything calls it.
+
+   Mid-merge the gate has to return before listing staged files, not
+   merely ignore the listing: an incoming file must never be read,
+   autofixed, or re-staged by a gate that has declined to judge the
+   merge. Throwing also means a lost skip surfaces here as this error
+   rather than as a real `bb -Sdeps` linter run inside the test suite."
+  [_ext]
+  (throw (ex-info "staged-by-ext called while a merge was in progress" {})))
+
+(def ^{:stratum 0} ^:private staged-clj-file
+  "One fully-staged .clj file — the ordinary, non-merge commit."
+  "components/codex/src/ai/miniforge/codex/core.clj")
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} merge-skips-stratum-lint-test
+  (testing "mid-merge the gate skips before listing staged files at all"
+    (let [out (with-redefs [commit-budget/merge-in-progress? (constantly true)
+                            lint/staged-by-ext unlisted-staged-by-ext]
+                (with-out-str (lint/stratum-staged)))]
+      (is (str/includes? out "skipped (merge in progress)"))
+      (is (not (str/includes? out "Stratum-linting"))))))
+
+(deftest ^{:stratum 1} non-merge-commit-still-stratum-linted-test
+  (testing "outside a merge, fully-staged files still reach autofix"
+    (let [calls (atom [])]
+      (with-redefs [commit-budget/merge-in-progress? (constantly false)
+                    lint/staged-by-ext (fn [ext]
+                                         (if (= ext ".clj") [staged-clj-file] []))
+                    lint/unstaged-files (constantly #{})
+                    stratum/autofix-and-restage! (fn [files]
+                                                   (swap! calls conj [:autofix files]))
+                    stratum/lint-only-and-fail! (fn [files]
+                                                  (swap! calls conj [:lint-only files]))]
+        (let [out (with-out-str (lint/stratum-staged))]
+          (is (str/includes? out "Stratum-linting 1 Clojure file(s)"))
+          (is (not (str/includes? out "skipped")))
+          (is (= [[:autofix [staged-clj-file]]] @calls)))))))

--- a/docs/pull-requests/2026-08-10-fix-stratum-staged-skips-merge-commits.md
+++ b/docs/pull-requests/2026-08-10-fix-stratum-staged-skips-merge-commits.md
@@ -1,0 +1,94 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix: skip the stratum-lint gate on merge commits
+
+## Overview
+
+`lint/stratum-staged` (the `lint:stratum` pre-commit gate) now detects a
+merge in progress and skips, printing one line saying so. Same exemption
+`bb commit-budget` gained on 2026-08-07, sharing its
+`commit-budget/merge-in-progress?` detector.
+
+## Motivation
+
+The gate lints every staged `.clj`/`.cljc` file. On a merge commit the
+staged set includes every file arriving from the merged-in branch —
+files the merging author did not touch, already stratum-linted on the
+PRs that introduced them.
+
+Concrete failure on 2026-08-10: merging `origin/main` into a feature
+branch staged
+`components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler.clj`,
+which is mid-way through its own 6-PR namespace split on main (#1729 is
+1/6) and legitimately still SL003 there. The gate blocked the merge and
+required `MINIFORGE_STRATUM_BUDGET_MODE=warn` to proceed — training the
+same override reflex the commit-budget fix was written to prevent.
+
+Skipping entirely (rather than restricting to files differing from both
+parents) matches the commit-budget precedent: a merge is not the merging
+author's change, and a partial lint of a merge would still autofix and
+re-stage files mid-way through their own split waves.
+
+## Layer
+
+Development-tool tasks (`tasks/lint.clj`, `tasks/stratum.clj` docstring),
+a new test namespace, the smoke-test registry, and the operator-facing
+description in `agents.md`.
+
+## Changes in Detail
+
+- `lint/stratum-staged`: returns on a merge in progress *before*
+  listing staged files, so no incoming file is read, autofixed, or
+  re-staged. Detection is `commit-budget/merge-in-progress?` — one
+  canonical detector rather than a copy; it already handles the
+  linked-worktree case (`git rev-parse -q --verify MERGE_HEAD`, not a
+  `.git/MERGE_HEAD` path stat) and is pinned e2e by
+  `commit-budget-test` against a real linked-worktree merge.
+- `stratum/budget-mode-env` docstring: records that merge commits never
+  reach the post-fix budget check, so warn mode is not needed for them.
+- `development/test/lint_test.clj` (new): pins the skip and the
+  non-merge dispatch. Requires the task namespaces directly (`tasks` is
+  on the `:test` classpath) instead of `load-file`, which cannot
+  resolve `lint`'s sibling-namespace requires.
+- `resources/precommit-smoke-tests.edn`: adds `lint-test` to the smoke
+  set. Pure `with-redefs` — no subprocess, no filesystem.
+- `agents.md`: extends the 2026-08-07 merge-exemption entry to cover
+  the stratum gate.
+
+## Standards Audit
+
+- Stratified design (001/210): `stratum-staged` stays at stratum 2; the
+  skip adds no in-file dependency (`commit-budget` is an external
+  namespace). Test file carries its own Layer headings, helpers at 0,
+  tests at 1.
+- One canonical location per datum: merge detection stays in
+  `commit-budget`; `lint` requires it rather than duplicating the
+  subprocess call.
+- Testing (400): the merge-state fixture already exists in
+  `commit-budget-test`; this namespace deliberately does not build a
+  second scratch repo to re-pin the same detector.
+
+## Testing Plan
+
+- `lint-test` + `commit-budget-test` — 11 tests, 43 assertions, green
+  under the smoke runner's own aliases (`clojure -M:test:dev`).
+- Mutation-checked rather than trusting green:
+  - Replacing the merge check with `false` (skip lost) errors
+    `merge-skips-stratum-lint-test` — its `staged-by-ext` stub throws
+    if the gate lists files mid-merge.
+  - Replacing it with `true` (gate always skips) fails
+    `non-merge-commit-still-stratum-linted-test` on all three
+    assertions.
+- `bb lint:stratum` in this worktree (no merge): normal path, green —
+  the `commit-budget` require also loads under babashka, not just the
+  JVM test runner.
+- End-to-end both directions in a detached scratch worktree of this
+  repo with a real `--no-commit` merge in progress (54 staged `.clj`
+  files): the pre-fix gate reproduces the original failure verbatim
+  (SL003 on `mdc_compiler.clj`, exit 1); with the fixed task files
+  copied in, the gate prints the skip line and exits 0. Worktree
+  removed afterwards.

--- a/resources/precommit-smoke-tests.edn
+++ b/resources/precommit-smoke-tests.edn
@@ -60,4 +60,9 @@
   ;; repo under java.io.tmpdir (hermetic — its own config scopes, no
   ;; hooks, deleted after) because the detection it pins only
   ;; reproduces against real merge state.
-  "commit-budget-test"]}
+  "commit-budget-test"
+  ;; Pins the stratum-lint gate's merge-commit skip (same exemption,
+  ;; sharing commit-budget's merge detection) and that non-merge
+  ;; commits still dispatch to autofix. Pure with-redefs — no
+  ;; subprocess, no filesystem.
+  "lint-test"]}

--- a/tasks/lint.clj
+++ b/tasks/lint.clj
@@ -19,6 +19,7 @@
   (:require
    [babashka.process :as p]
    [clojure.string :as str]
+   [commit-budget]
    [stratum]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -98,16 +99,28 @@
    working-tree file, and re-staging it whole would silently include
    work-in-progress the developer deliberately left unstaged. Mechanics
    live in the `stratum` namespace (rule 210: this dispatcher plus that
-   namespace's own chain would be 4 real layers in one file)."
+   namespace's own chain would be 4 real layers in one file).
+
+   Mid-merge, returns before touching the index at all — the same
+   exemption `bb commit-budget` applies, via the same
+   `commit-budget/merge-in-progress?`. A merge commit's staged set
+   includes every file arriving from the merged-in branch, which the
+   merging author did not touch and which was already gated on the PR
+   that introduced it; a file legitimately mid-way through its own
+   namespace-split wave on main (SL003 there by design) must not block
+   an unrelated merge. Skipping before the file listing keeps the skip
+   total: no incoming file is read, autofixed, or re-staged."
   []
-  (let [files (->> (concat (staged-by-ext ".clj")
-                           (staged-by-ext ".cljc"))
-                   (remove (fn [f] (str/starts-with? f ".clj-kondo/"))))]
-    (if (seq files)
-      (let [dirty (unstaged-files)
-            unsafe (filter dirty files)
-            safe (remove dirty files)]
-        (println "🔍 Stratum-linting" (count files) "Clojure file(s)...")
-        (when (seq unsafe) (stratum/lint-only-and-fail! unsafe))
-        (when (seq safe) (stratum/autofix-and-restage! safe)))
-      (println "✓ No Clojure files to stratum-lint"))))
+  (if (commit-budget/merge-in-progress?)
+    (println "🔍 stratum-lint: skipped (merge in progress) — incoming files were gated on their own PRs.")
+    (let [files (->> (concat (staged-by-ext ".clj")
+                             (staged-by-ext ".cljc"))
+                     (remove (fn [f] (str/starts-with? f ".clj-kondo/"))))]
+      (if (seq files)
+        (let [dirty (unstaged-files)
+              unsafe (filter dirty files)
+              safe (remove dirty files)]
+          (println "🔍 Stratum-linting" (count files) "Clojure file(s)...")
+          (when (seq unsafe) (stratum/lint-only-and-fail! unsafe))
+          (when (seq safe) (stratum/autofix-and-restage! safe)))
+        (println "✓ No Clojure files to stratum-lint")))))

--- a/tasks/stratum.clj
+++ b/tasks/stratum.clj
@@ -58,7 +58,10 @@
    continues. Blocking is the default — every rule 210 violation gets
    real enforcement, not a decorative print — with an explicit opt-out
    for a team mid-way through clearing a backlog of pre-existing
-   over-budget files."
+   over-budget files. Not needed for merge commits: `lint/stratum-staged`
+   skips mid-merge entirely (same exemption as `bb commit-budget`), so
+   an over-budget file arriving from the merged-in branch never reaches
+   this check."
   "MINIFORGE_STRATUM_BUDGET_MODE")
 
 ;------------------------------------------------------------------------------ Layer 1


### PR DESCRIPTION
## Overview

`lint/stratum-staged` (the `lint:stratum` pre-commit gate) now detects a merge in progress and skips, printing one line saying so — the same exemption `bb commit-budget` gained on 2026-08-07, sharing its `commit-budget/merge-in-progress?` detector (linked-worktree-safe: `git rev-parse -q --verify MERGE_HEAD`, not a `.git/MERGE_HEAD` path stat).

## Motivation

On a merge commit the staged set includes every file arriving from the merged-in branch — files the merging author did not touch, already stratum-linted on the PRs that introduced them. Concrete failure on 2026-08-10: merging `origin/main` into a feature branch staged `components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler.clj`, mid-way through its own 6-PR namespace split on main (#1729 is 1/6) and legitimately still SL003 there; the gate blocked the merge and required `MINIFORGE_STRATUM_BUDGET_MODE=warn` — training the same override reflex the commit-budget fix exists to prevent.

## Changes

- `lint/stratum-staged`: returns on a merge in progress before listing staged files, so no incoming file is read, autofixed, or re-staged. One canonical detector — `lint` requires `commit-budget` rather than duplicating the subprocess call.
- `stratum/budget-mode-env` docstring: records that merges never reach the post-fix budget check.
- `development/test/lint_test.clj` (new, added to the pre-commit smoke set): pins the skip and the non-merge dispatch. Pure `with-redefs`, no subprocess.
- `agents.md`: extends the 2026-08-07 merge-exemption entry to cover the stratum gate.

## Testing

- `lint-test` + `commit-budget-test`: 11 tests, 43 assertions, green under the smoke runner's aliases.
- Mutation-checked: skip lost (`if false`) errors `merge-skips-stratum-lint-test` via its throwing `staged-by-ext` stub; gate-always-skips (`if true`) fails `non-merge-commit-still-stratum-linted-test`.
- End-to-end both directions in a detached scratch worktree with a real `--no-commit` merge (54 staged `.clj` files): pre-fix gate reproduces the original SL003 failure verbatim, exit 1; fixed gate prints the skip line, exit 0.

PR doc: `docs/pull-requests/2026-08-10-fix-stratum-staged-skips-merge-commits.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)