### PR TITLE
fix(cli): close the artifact store on every exit path of run-workflow!

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -141,6 +141,15 @@
               (cond-> result
                 (some? shutdown) (assoc :event-durability shutdown))))
           (finally
+            ;; Every exit path — completion or pipeline throw — must
+            ;; release the transit store opened above; the old
+            ;; success-branch-only close leaked it on the throw path.
+            ;; close-artifact-store is nil-safe and swallows close-time
+            ;; exceptions, so one unconditional call covers all exits.
+            ;; First in the finally: the manifest and progress cleanups
+            ;; below do IO and may themselves throw, which would skip
+            ;; any close placed after them.
+            (execution/close-artifact-store artifact-store)
             ;; If we got here without marking, the pipeline threw or was
             ;; otherwise aborted before the success branch ran. Classify
             ;; as :cancelled to mirror the existing event-stream
@@ -148,12 +157,6 @@
             (lifecycle/mark-manifest-terminal! manifest-handle :cancelled)
             (lifecycle/finish-workflow-manifest! manifest-handle)
             (progress-cleanup)
-            ;; Every exit path — completion or pipeline throw — must
-            ;; release the transit store opened above; the old
-            ;; success-branch-only close leaked it on the throw path.
-            ;; close-artifact-store is nil-safe and swallows close-time
-            ;; exceptions, so one unconditional call covers all exits.
-            (execution/close-artifact-store artifact-store)
             ;; Schedule deferred GC for this workflow's scratch ref — fires
             ;; here (finally) so it runs on both normal completion and any
             ;; exception path.  The ref will be deleted on a future

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -119,7 +119,6 @@
             manifest-handle (lifecycle/start-workflow-manifest! workflow-id stream)]
         (try
           (let [result (execution/execute-workflow-pipeline run-pipeline workflow workflow-input callbacks-with-url artifact-store stream)]
-            (execution/close-artifact-store artifact-store)
             (lifecycle/mark-manifest-terminal!
              manifest-handle
              (if (phase/succeeded? result) :completed :failed))
@@ -149,6 +148,12 @@
             (lifecycle/mark-manifest-terminal! manifest-handle :cancelled)
             (lifecycle/finish-workflow-manifest! manifest-handle)
             (progress-cleanup)
+            ;; Every exit path — completion or pipeline throw — must
+            ;; release the transit store opened above; the old
+            ;; success-branch-only close leaked it on the throw path.
+            ;; close-artifact-store is nil-safe and swallows close-time
+            ;; exceptions, so one unconditional call covers all exits.
+            (execution/close-artifact-store artifact-store)
             ;; Schedule deferred GC for this workflow's scratch ref — fires
             ;; here (finally) so it runs on both normal completion and any
             ;; exception path.  The ref will be deleted on a future

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/store_lifecycle_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/store_lifecycle_test.clj
@@ -38,6 +38,7 @@
    [ai.miniforge.cli.workflow-runner.display :as display]
    [ai.miniforge.cli.workflow-runner.execution :as execution]
    [ai.miniforge.cli.workflow-runner.gc-hooks :as gc-hooks]
+   [ai.miniforge.cli.workflow-runner.lifecycle :as lifecycle]
    [ai.miniforge.cli.workflow-runner.setup :as setup]
    [clojure.test :refer [deftest is testing]]
    [slingshot.slingshot :refer [try+]]))
@@ -49,32 +50,35 @@
    as the pipeline fn, recording every store handed to
    `execution/close-artifact-store`. The `:dashboard-url` opt keeps the
    event stream nil, so the manifest and shutdown helpers no-op.
+   `extra-redefs` (var → fn) is merged over the base stubs.
    Returns {:result ... :closed [...]} on normal return,
    {:thrown ... :closed [...]} when the call throws."
-  [run-pipeline]
+  [run-pipeline & [extra-redefs]]
   (let [closed (atom [])
-        outcome (with-redefs [gc-hooks/run-gc-pass-best-effort! (fn [_repo-fn _gc-fn] nil)
-                              gc-hooks/enqueue-workflow-gc-best-effort! (fn [_enqueue-fn _wid] nil)
-                              setup/resolve-workflow-interface (fn []
-                                                                {:load-workflow (fn [_id _version] {})
-                                                                 :run-pipeline run-pipeline})
-                              setup/load-and-validate-workflow (fn [_load-fn _id _version] {})
-                              setup/create-phase-callbacks (fn [_quiet] {})
-                              context/resolve-input (fn [_opts] {})
-                              display/print-workflow-header (fn [_id _version _quiet] nil)
-                              display/print-result (fn [_result _opts] nil)
-                              execution/create-artifact-store (fn [_quiet] ::sentinel-store)
-                              execution/close-artifact-store (fn [store]
-                                                               (swap! closed conj store)
-                                                               nil)
-                              execution/execute-workflow-pipeline (fn [pipeline-fn _workflow _input _callbacks _store _stream]
-                                                                    (pipeline-fn))]
-                  (try+
-                    {:result (sut/run-workflow! "wf-store-lifecycle-test"
-                                                {:quiet true
-                                                 :dashboard-url "http://dashboard.invalid"})}
-                    (catch Object thrown
-                      {:thrown thrown})))]
+        base {#'gc-hooks/run-gc-pass-best-effort! (fn [_repo-fn _gc-fn] nil)
+              #'gc-hooks/enqueue-workflow-gc-best-effort! (fn [_enqueue-fn _wid] nil)
+              #'setup/resolve-workflow-interface (fn []
+                                                   {:load-workflow (fn [_id _version] {})
+                                                    :run-pipeline run-pipeline})
+              #'setup/load-and-validate-workflow (fn [_load-fn _id _version] {})
+              #'setup/create-phase-callbacks (fn [_quiet] {})
+              #'context/resolve-input (fn [_opts] {})
+              #'display/print-workflow-header (fn [_id _version _quiet] nil)
+              #'display/print-result (fn [_result _opts] nil)
+              #'execution/create-artifact-store (fn [_quiet] ::sentinel-store)
+              #'execution/close-artifact-store (fn [store]
+                                                 (swap! closed conj store)
+                                                 nil)
+              #'execution/execute-workflow-pipeline (fn [pipeline-fn _workflow _input _callbacks _store _stream]
+                                                      (pipeline-fn))}
+        outcome (with-redefs-fn (merge base extra-redefs)
+                  (fn []
+                    (try+
+                      {:result (sut/run-workflow! "wf-store-lifecycle-test"
+                                                  {:quiet true
+                                                   :dashboard-url "http://dashboard.invalid"})}
+                      (catch Object thrown
+                        {:thrown thrown}))))]
     (assoc outcome :closed @closed)))
 
 ;------------------------------------------------------------------------------ Layer 1
@@ -90,6 +94,20 @@
   (testing "a pipeline exception still releases the artifact store before rethrowing"
     (let [{:keys [result thrown closed]} (run-recording-closes
                                           (fn [] (throw (ex-info "pipeline exploded" {}))))]
+      (is (nil? result))
+      (is (some? thrown))
+      (is (= [::sentinel-store] closed)))))
+
+(deftest ^{:stratum 1} run-workflow!-closes-store-when-finally-cleanup-throws-test
+  (testing "a throwing manifest cleanup in the finally cannot skip the store close"
+    ;; Pins the ordering: the close sits at the top of the finally,
+    ;; before the manifest and progress cleanups, which do IO and may
+    ;; themselves throw. A close placed after them would be skipped here.
+    (let [{:keys [result thrown closed]} (run-recording-closes
+                                          (fn [] {:execution/status :completed})
+                                          {#'lifecycle/mark-manifest-terminal!
+                                           (fn [_handle _status]
+                                             (throw (ex-info "manifest IO exploded" {})))})]
       (is (nil? result))
       (is (some? thrown))
       (is (= [::sentinel-store] closed)))))

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/store_lifecycle_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/store_lifecycle_test.clj
@@ -1,0 +1,95 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.cli.workflow-runner.store-lifecycle-test
+  "Artifact-store lifecycle tests for `run-workflow!`.
+
+   `run-workflow!` opens the transit artifact store itself and nothing
+   after it returns closes the store, so every exit path — completion
+   or a pipeline throw — must release it before leaving. These tests
+   drive the real `run-workflow!` with its collaborators stubbed via
+   `with-redefs`, recording every store handed to
+   `execution/close-artifact-store` (same recording approach as
+   `execution_test.clj`'s store-lifecycle harness for
+   `execute-with-events`).
+
+   Note: `gc_integration_test.clj` documents that requiring
+   `workflow_runner.clj` hangs a test JVM via load-time background
+   threads. That predates the rule-210 namespace split; the load is
+   side-effect-free now (verified: zero new threads after `require`),
+   which is what makes these direct tests possible."
+  (:require
+   [ai.miniforge.cli.workflow-runner :as sut]
+   [ai.miniforge.cli.workflow-runner.context :as context]
+   [ai.miniforge.cli.workflow-runner.display :as display]
+   [ai.miniforge.cli.workflow-runner.execution :as execution]
+   [ai.miniforge.cli.workflow-runner.gc-hooks :as gc-hooks]
+   [ai.miniforge.cli.workflow-runner.setup :as setup]
+   [clojure.test :refer [deftest is testing]]
+   [slingshot.slingshot :refer [try+]]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} run-recording-closes
+  "Run `run-workflow!` with collaborators stubbed and `run-pipeline`
+   as the pipeline fn, recording every store handed to
+   `execution/close-artifact-store`. The `:dashboard-url` opt keeps the
+   event stream nil, so the manifest and shutdown helpers no-op.
+   Returns {:result ... :closed [...]} on normal return,
+   {:thrown ... :closed [...]} when the call throws."
+  [run-pipeline]
+  (let [closed (atom [])
+        outcome (with-redefs [gc-hooks/run-gc-pass-best-effort! (fn [_repo-fn _gc-fn] nil)
+                              gc-hooks/enqueue-workflow-gc-best-effort! (fn [_enqueue-fn _wid] nil)
+                              setup/resolve-workflow-interface (fn []
+                                                                {:load-workflow (fn [_id _version] {})
+                                                                 :run-pipeline run-pipeline})
+                              setup/load-and-validate-workflow (fn [_load-fn _id _version] {})
+                              setup/create-phase-callbacks (fn [_quiet] {})
+                              context/resolve-input (fn [_opts] {})
+                              display/print-workflow-header (fn [_id _version _quiet] nil)
+                              display/print-result (fn [_result _opts] nil)
+                              execution/create-artifact-store (fn [_quiet] ::sentinel-store)
+                              execution/close-artifact-store (fn [store]
+                                                               (swap! closed conj store)
+                                                               nil)
+                              execution/execute-workflow-pipeline (fn [pipeline-fn _workflow _input _callbacks _store _stream]
+                                                                    (pipeline-fn))]
+                  (try+
+                    {:result (sut/run-workflow! "wf-store-lifecycle-test"
+                                                {:quiet true
+                                                 :dashboard-url "http://dashboard.invalid"})}
+                    (catch Object thrown
+                      {:thrown thrown})))]
+    (assoc outcome :closed @closed)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} run-workflow!-closes-store-once-on-success-test
+  (testing "completion path releases the artifact store exactly once"
+    (let [{:keys [result closed]} (run-recording-closes
+                                   (fn [] {:execution/status :completed}))]
+      (is (= :completed (:execution/status result)))
+      (is (= [::sentinel-store] closed)))))
+
+(deftest ^{:stratum 1} run-workflow!-closes-store-when-pipeline-throws-test
+  (testing "a pipeline exception still releases the artifact store before rethrowing"
+    (let [{:keys [result thrown closed]} (run-recording-closes
+                                          (fn [] (throw (ex-info "pipeline exploded" {}))))]
+      (is (nil? result))
+      (is (some? thrown))
+      (is (= [::sentinel-store] closed)))))

--- a/docs/pull-requests/2026-08-09-fix-cli-artifact-store-leak-in-run-workflow.md
+++ b/docs/pull-requests/2026-08-09-fix-cli-artifact-store-leak-in-run-workflow.md
@@ -4,7 +4,7 @@
   Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
 -->
 
-# fix(cli): close the artifact store on every exit path of run-workflow
+# fix(cli): close the artifact store on every exit path of `run-workflow!`
 
 ## Overview
 
@@ -13,9 +13,9 @@
 on the normal-completion branch, so any pipeline throw leaked the store.
 
 This is the follow-up flagged in the "Callers — checked" section of
-`2026-08-09-fix-cli-artifact-store-leak-on-sandbox-failure.md`, which fixed
-the same leak shape in `execute-with-events` (the spec-driven path). The
-two entry points now use the same pattern.
+`2026-08-09-fix-cli-artifact-store-leak-on-sandbox-failure.md` (#1726),
+which fixed the same leak shape in `execute-with-events` (the spec-driven
+path). The two entry points now use the same pattern.
 
 ## Motivation
 
@@ -35,23 +35,26 @@ new test namespace. No component interfaces change.
 ## Changes in Detail
 
 - `run-workflow!`: the `(execution/close-artifact-store artifact-store)`
-  call moves from the pipeline-success branch into the `finally` block,
-  after `progress-cleanup` and before the GC enqueue. One unconditional
-  call rather than a per-branch duplicate: `close-artifact-store` is
-  nil-safe and swallows close-time exceptions, so a single call in
-  `finally` covers completion and the throw path without double-closing
-  or masking an in-flight exception. On the success path the close now
-  happens after `print-result` instead of before manifest marking;
-  nothing in between reads the store.
+  call moves from the pipeline-success branch to the top of the `finally`
+  block — first because the manifest and progress cleanups that follow do
+  IO and may themselves throw, which would skip a close placed after
+  them. One unconditional call rather than a per-branch duplicate:
+  `close-artifact-store` is nil-safe and swallows close-time exceptions,
+  so a single call in `finally` covers completion and the throw path
+  without double-closing or masking an in-flight exception. On the
+  success path the close now happens after `print-result` instead of
+  before manifest marking; nothing in between reads the store.
 - `bases/cli/test/ai/miniforge/cli/workflow_runner/store_lifecycle_test.clj`
   (new): drives the real `run-workflow!` with collaborators stubbed via
   `with-redefs`, recording every store handed to
   `execution/close-artifact-store` — the same recording approach as
-  `execution_test.clj`'s `execute-recording-closes` harness. Two tests:
+  `execution_test.clj`'s `execute-recording-closes` harness. Three tests:
   the success path closes the sentinel store exactly once; a throwing
-  pipeline still closes it before the rethrow propagates. A
-  `:dashboard-url` opt keeps the event stream nil so the manifest,
-  progress, and shutdown helpers take their documented nil no-op paths.
+  pipeline still closes it before the rethrow propagates; a throwing
+  manifest cleanup in the `finally` cannot skip the close (pins the
+  close-first ordering). A `:dashboard-url` opt keeps the event stream
+  nil so the manifest, progress, and shutdown helpers take their
+  documented nil no-op paths.
 
 ## Why a direct test of run-workflow! is possible now
 
@@ -88,7 +91,7 @@ sibling PR.
 
 ## Testing Plan
 
-- `clojure -M:dev:test` on the new namespace: 2 tests, 5 assertions,
+- `clojure -M:dev:test` on the new namespace: 3 tests, 8 assertions,
   green.
 - Mutation-checked rather than trusting green: reverting the source fix
   (close on the success branch only, as on main) fails

--- a/docs/pull-requests/2026-08-09-fix-cli-artifact-store-leak-in-run-workflow.md
+++ b/docs/pull-requests/2026-08-09-fix-cli-artifact-store-leak-in-run-workflow.md
@@ -1,0 +1,100 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix(cli): close the artifact store on every exit path of run-workflow
+
+## Overview
+
+`run-workflow!` now releases the workflow's transit artifact store in its
+`finally` block, once, on every exit path. Previously the close lived only
+on the normal-completion branch, so any pipeline throw leaked the store.
+
+This is the follow-up flagged in the "Callers — checked" section of
+`2026-08-09-fix-cli-artifact-store-leak-on-sandbox-failure.md`, which fixed
+the same leak shape in `execute-with-events` (the spec-driven path). The
+two entry points now use the same pattern.
+
+## Motivation
+
+`run-workflow!` opens the store with `execution/create-artifact-store`,
+hands it to `execution/execute-workflow-pipeline`, and closed it only on
+the success branch immediately after the pipeline returned. The `finally`
+block (manifest `:cancelled` fallback, progress cleanup, GC enqueue) never
+closed it, and the outer `catch Exception` rethrows without closing. Every
+pipeline exception — and every abort between store creation and the
+success branch — leaked one open transit store.
+
+## Layer
+
+CLI base only: `bases/cli/src/ai/miniforge/cli/workflow_runner.clj` plus a
+new test namespace. No component interfaces change.
+
+## Changes in Detail
+
+- `run-workflow!`: the `(execution/close-artifact-store artifact-store)`
+  call moves from the pipeline-success branch into the `finally` block,
+  after `progress-cleanup` and before the GC enqueue. One unconditional
+  call rather than a per-branch duplicate: `close-artifact-store` is
+  nil-safe and swallows close-time exceptions, so a single call in
+  `finally` covers completion and the throw path without double-closing
+  or masking an in-flight exception. On the success path the close now
+  happens after `print-result` instead of before manifest marking;
+  nothing in between reads the store.
+- `bases/cli/test/ai/miniforge/cli/workflow_runner/store_lifecycle_test.clj`
+  (new): drives the real `run-workflow!` with collaborators stubbed via
+  `with-redefs`, recording every store handed to
+  `execution/close-artifact-store` — the same recording approach as
+  `execution_test.clj`'s `execute-recording-closes` harness. Two tests:
+  the success path closes the sentinel store exactly once; a throwing
+  pipeline still closes it before the rethrow propagates. A
+  `:dashboard-url` opt keeps the event stream nil so the manifest,
+  progress, and shutdown helpers take their documented nil no-op paths.
+
+## Why a direct test of run-workflow! is possible now
+
+`gc_integration_test.clj`'s docstring records that requiring
+`workflow_runner.clj` used to start non-terminating background threads at
+namespace-load time, hanging the test JVM. That predates the rule-210
+split: the process-scoped singletons now live in `control.clj` as lazily
+initialized `defonce` atoms. Verified empirically — requiring the
+namespace in a fresh JVM creates zero new threads. The stale docstring is
+left for a follow-up rather than widening this diff.
+
+## Callers — checked
+
+`run-workflow!`'s callers (cli main, commands, chain) consume only the
+result map; none receive or touch the artifact store, so closing in
+`finally` cannot close a store still in use. `run-workflow-from-spec!`
+delegates its store's release to `execute-with-events`, fixed in the
+sibling PR.
+
+## Standards Audit
+
+- Stratified design (001/210): no stratum changes in the source file;
+  the moved call stays inside the same stratum-1 fn. Test namespace
+  layers: recording harness at 0, tests at 1 — in-namespace dependencies
+  flow downward.
+- Header rule (810): Apache header on the new test file.
+- Exception handling (211): no new catches in source; the test uses
+  slingshot `try+`/`catch Object` to observe the rethrow, matching
+  `execution_test.clj`.
+- Test fixtures match the producer's shape
+  (feedback_test_fixtures_match_production_shape): the stubbed pipeline
+  returns an `:execution/status` result like the real pipeline, and the
+  success assertion reads `:execution/status`.
+
+## Testing Plan
+
+- `clojure -M:dev:test` on the new namespace: 2 tests, 5 assertions,
+  green.
+- Mutation-checked rather than trusting green: reverting the source fix
+  (close on the success branch only, as on main) fails
+  `run-workflow!-closes-store-when-pipeline-throws-test` with an empty
+  recorded-close vector, confirming the test binds to the release
+  behavior on the throw path.
+- `bb lint:clj` on both staged files: 0 errors, 0 warnings.
+- Pre-commit hook (commit budget, structure, lint, format, smoke tests)
+  runs at commit time; full suite in CI.


### PR DESCRIPTION
## Summary

`run-workflow!` closed its transit artifact store only on the pipeline-success branch; the `finally` block (manifest :cancelled fallback, progress cleanup, GC enqueue) never closed it, so any pipeline throw leaked the open store. This PR moves the single `close-artifact-store` call into the `finally` — the call is nil-safe and swallows close-time exceptions, so one unconditional call covers completion and the throw path without double-closing or masking an in-flight exception.

Mirrors the `execute-with-events` fix for the spec-driven path; that PR's "Callers — checked" section flagged this entry point as the follow-up.

## Changes

1. `bases/cli/src/ai/miniforge/cli/workflow_runner.clj` — move the close from the success branch into the `finally`.
2. `bases/cli/test/ai/miniforge/cli/workflow_runner/store_lifecycle_test.clj` (new) — drives the real `run-workflow!` with collaborators stubbed via `with-redefs`, recording every store handed to `close-artifact-store`: success closes exactly once; a throwing pipeline still closes before the rethrow.
3. `docs/pull-requests/2026-08-09-fix-cli-artifact-store-leak-in-run-workflow.md` — PR doc.

## Testing

1. New namespace: 2 tests, 5 assertions, green.
2. Mutation-checked: reverting the src fix fails the throw-path test with an empty recorded-close vector.
3. `bb lint:clj` on both staged files: 0 errors, 0 warnings. Pre-commit checks passed at commit time.

@copilot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)