### PR TITLE
test(cli): correct stale docstring claim in gc_integration_test.clj

### DIFF
--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/gc_integration_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/gc_integration_test.clj
@@ -30,12 +30,20 @@
       in the `finally` clause of both functions, so it fires on *both* normal
       completion and exception-path exit.
 
-   ## Why workflow_runner.clj is not loaded here
+   ## Why these tests exercise gc-hooks rather than workflow_runner.clj
 
-   `workflow_runner.clj` starts JVM background threads at namespace-load time
-   that never terminate in a test JVM, causing a 30-minute hang.  These tests
-   therefore verify the *lifecycle wiring pattern* directly via `gc-hooks`,
-   using the same DI approach that `workflow_runner.clj` employs internally:
+   These are deliberately *pattern-level* tests: they verify the lifecycle
+   wiring shape directly via `gc-hooks` with mock collaborators, rather than
+   driving `run-workflow!` end-to-end.  Loading `workflow_runner.clj` is not
+   the obstacle — since the rule-210 namespace split, the process-scoped
+   singletons (meta-loop context, operator-event consumer) live in
+   `workflow_runner/control.clj` as lazily initialized `defonce` atoms, and
+   requiring `ai.miniforge.cli.workflow-runner` in a fresh JVM starts no
+   background threads (sibling tests such as `runner_control_wiring_test.clj`
+   and `preflight_test.clj` require it directly).  An earlier revision of this
+   docstring claimed namespace load hung a test JVM; that predates the split
+   and no longer applies.  The gc-hooks-level approach stays because it tests
+   the wiring contract without a full workflow harness:
 
      ;; Pattern in workflow_runner.clj (simplified):
      (run-gc-pass-best-effort!)   ; at entry of run-workflow!

--- a/docs/pull-requests/2026-08-09-test-gc-integration-docstring-stale-claim.md
+++ b/docs/pull-requests/2026-08-09-test-gc-integration-docstring-stale-claim.md
@@ -1,0 +1,54 @@
+# test(cli): correct stale docstring claim in gc_integration_test.clj
+
+## Overview
+
+Docs-only change. The namespace docstring of
+`bases/cli/test/ai/miniforge/cli/workflow_runner/gc_integration_test.clj`
+claimed that requiring `ai.miniforge.cli.workflow-runner` starts JVM
+background threads at namespace-load time that hang a test JVM for
+~30 minutes, and that this is why the tests exercise `gc-hooks` directly
+instead of the runner namespace. That claim is stale.
+
+## Motivation
+
+After the rule-210 namespace split of `workflow_runner.clj`, the
+process-scoped singletons (meta-loop context, operator-event consumer)
+live in `bases/cli/src/ai/miniforge/cli/workflow_runner/control.clj` as
+lazily initialized `defonce` atoms (`meta-loop-ctx`,
+`operator-consumer-handle`, both `(atom nil)` initialized on first
+governed workflow start). Requiring the runner namespace in a fresh JVM
+creates no threads. Verified 2026-08-09; sibling tests in the same
+directory (`runner_control_wiring_test.clj`, `preflight_test.clj`)
+require `ai.miniforge.cli.workflow-runner` directly and pass.
+
+A docstring that gives a false reason for a test's design invites the
+wrong fix later — someone "modernizing" the test to load the runner
+would conclude the whole file is obsolete, or someone hitting an
+unrelated hang would chase a load-time-thread ghost.
+
+## Changes in Detail
+
+One section of the namespace docstring rewritten. The old section
+("Why workflow_runner.clj is not loaded here") asserted namespace load
+was unsafe. The new section ("Why these tests exercise gc-hooks rather
+than workflow_runner.clj") states:
+
+1. The tests are deliberately pattern-level: they verify the lifecycle
+   wiring shape via `gc-hooks` with mock collaborators.
+2. Loading `workflow_runner.clj` is not the obstacle — the singletons
+   moved to `control.clj` and are lazy; sibling tests require the
+   runner namespace directly.
+3. The earlier hang claim predates the split and no longer applies.
+
+No test bodies changed. The tests remain valid as pattern-level tests
+of the gc-hooks wiring: the `defn-` wrappers in `workflow_runner.clj`
+(`enqueue-workflow-gc-best-effort!`, `run-gc-pass-best-effort!` at
+Layer 0) still call through the `gc-hooks` vars, and the entry/finally
+wiring points the docstring describes still exist in
+`run-workflow!` and `run-workflow-from-spec!`.
+
+## Verification
+
+1. `clj-kondo` / stratum-lint pre-commit hooks on commit.
+2. `bases/cli` test namespace loads and the file's tests pass
+   (docstring-only edit; no behavior change possible).


### PR DESCRIPTION
## Overview

Docs-only. The namespace docstring of `bases/cli/test/ai/miniforge/cli/workflow_runner/gc_integration_test.clj` claimed that requiring `ai.miniforge.cli.workflow-runner` starts JVM background threads at namespace-load time that hang a test JVM for ~30 minutes, and that this is why the tests exercise `gc-hooks` directly. Stale since the rule-210 namespace split.

## Current reality

1. The process-scoped singletons (meta-loop context, operator-event consumer) live in `workflow_runner/control.clj` as lazily initialized `defonce` atoms — `(atom nil)`, initialized on first governed workflow start.
2. Requiring the runner namespace in a fresh JVM creates no threads. Sibling tests in the same directory (`runner_control_wiring_test.clj`, `preflight_test.clj`) require it directly and pass.

## Change

One docstring section rewritten: the tests are deliberately pattern-level over `gc-hooks` with mock collaborators; loading the runner namespace is not the obstacle, and the old hang claim predates the split. No test bodies changed — the wiring points the docstring describes (`defn-` wrappers at Layer 0, entry/finally calls in `run-workflow!` and `run-workflow-from-spec!`) still exist and were re-verified.

PR doc: `docs/pull-requests/2026-08-09-test-gc-integration-docstring-stale-claim.md`

## Verification

Namespace loads and runs clean: 7 tests, 9 assertions, 0 failures. Full pre-commit suite (345 tests / 1301 assertions + GraalVM compat) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)