### PR TITLE
docs(specs): N1 architecture spec completion (0.7.0 → 0.8.0-draft)

### DIFF
--- a/docs/pull-requests/2026-08-10-chris-n1-architecture-spec-complete.md
+++ b/docs/pull-requests/2026-08-10-chris-n1-architecture-spec-complete.md
@@ -1,0 +1,92 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# docs: N1 architecture spec completion (0.7.0 → 0.8.0-draft)
+
+## Overview
+
+Aligns N1's Workflow entity with N2's canonical status vocabulary, adds
+requirement IDs for the domain model and layering, and adds Annex A.
+
+## Motivation
+
+**N1 was a consumer the N2 sweep missed.** §2's Workflow entity declared
+`:workflow/status` as `:pending, :running, :completed, :failed, :cancelled` —
+the vocabulary N2 §2.2 superseded. It named `:pending` rather than `:queued`
+and omitted `:paused` and `:blocked` entirely.
+
+When I unified the vocabulary in N2 I swept N5 and N2-delta, and reported that
+as the lesson from the N4 severity unification. N1 still slipped, which says
+the sweep needs to be a search across all specs rather than a list of the
+consumers I happened to think of.
+
+**N1 had requirement IDs for everything except its own subject.** Six families
+existed — `N1.AU.*`, `N1.CP.*`, `N1.EV.*`, `N1.RI.*`, `N1.RL.*`, `N1.SI.*` —
+all added by later amendments for capabilities layered onto N1. The domain
+model of §2 and the three-layer architecture and component boundaries of
+§3–§4, which are what N1 is *for*, had none.
+
+## Changes in Detail
+
+- **§2** `:workflow/status` now defers to N2 §2.2's canonical vocabulary.
+- **§8.4** adds `N1.DM.*` (5 requirements) and `N1.AR.*` (6 requirements).
+  The ones worth naming: N1.DM.3 requires the status projection to stay within
+  N2 §2.2's set with no synonym reachable; N1.AR.2 requires that no agent-layer
+  component depend on a control-plane component, which Polylith does not check.
+- **§8.5** adds six test obligations, three of which are static checks the
+  repository can run continuously.
+
+## Annex A (informative)
+
+The useful split here is between architectural requirements that have a static
+check and those that do not.
+
+**Enforced:** interface-only access (`poly check` in pre-commit), stratum
+direction (`bb lint:stratum`), component isolation (123 Polylith components).
+These are the requirements that have not drifted — which is the point.
+
+**Not enforced:** layer direction, because Polylith enforces *interface*
+boundaries rather than *layer* direction, so a legal interface call can still
+invert §3's layering. And status-vocabulary conformance, which is how
+`:executing` — a value in no spec — reached both the implementation and N5's
+documented CLI filter.
+
+## Testing Plan
+
+Specification change; no runtime code touched.
+
+- `markdownlint` clean on all three changed files.
+- No duplicate section numbers; 45 requirement IDs across eight families.
+- Verified the other `:pending` occurrences in N1 belong to `:phase/status` and
+  `:gate/status`, which are separate vocabularies N2 §2.2 does not govern.
+
+## Deployment Plan
+
+Documentation only. Merges to `main` with no runtime effect.
+
+## Follow-on Work
+
+1. Add a static check for layer direction (N1.AR.2) — the gap Polylith leaves.
+2. Add a check that `:workflow/status` values stay within N2 §2.2's set
+   (N1.DM.3), which would have caught `:executing`.
+3. Apply boundary schema validation uniformly (N1.DM.2).
+
+## Related Issues/PRs
+
+- Follows the N2–N10 completion passes
+- Depends on: N2 §2.2 (canonical status vocabulary)
+- Governed by: `standards/miniforge/foundations/specification-standards` (020)
+
+## Checklist
+
+- [x] Spec reviewed against current state before editing
+- [x] Cross-spec vocabulary divergence resolved
+- [x] Annex A marked informative
+- [x] No spec content extracted from implementation code (020)
+- [x] Copyright header present (810)
+- [x] `markdownlint` clean
+- [x] SPEC_INDEX updated
+- [x] PR doc created (721)

--- a/specs/SPEC_INDEX.md
+++ b/specs/SPEC_INDEX.md
@@ -6,7 +6,7 @@
 
 # miniforge Specification Index
 
-**Version:** 0.17.0-draft
+**Version:** 0.18.0-draft
 **Date:** 2026-08-09
 **Status:** Living specification during OSS development
 
@@ -91,6 +91,12 @@ Defines:
 - **Unified Autonomy Model:** A0-A5 levels with cross-spec mapping (§5.6)
 - **Trust Boundary Validation:** 5 named boundaries with architectural invariants (§5.7)
 - **Evaluation Pipeline:** Golden sets, replay mode, shadow mode, canary deployment (§3.3.3)
+- **Status vocabulary aligned with N2 §2.2** — §2's Workflow entity still carried the
+  superseded `:pending`-based set
+- **Conformance requirement IDs** for the domain model (`N1.DM.*`) and architecture
+  (`N1.AR.*`), the two families N1's own subject matter lacked, plus test obligations (§8.4–§8.5)
+- **Annex A (informative):** which architectural requirements have a static check — interface
+  boundaries and stratum direction do; layer direction and status conformance do not
 
 ### N2 — Workflow Execution Model ✅
 
@@ -597,6 +603,15 @@ Normative specs are enforced by:
 ---
 
 ## Version History
+
+- **0.18.0-draft** (2026-08-10) - N1 spec-completion pass. **N1**: §2's Workflow entity declared
+  `:workflow/status` with the vocabulary N2 §2.2 superseded — `:pending` rather than `:queued`, and
+  no `:paused`/`:blocked`. N1 was a consumer the N2 sweep missed. Added `N1.DM.*` and `N1.AR.*`
+  requirement IDs — the domain model and layering are N1's own subject and had no IDs, while six
+  families existed for capabilities later amendments added. Annex A separates the architectural
+  requirements that have a static check (`poly check` for interfaces, `bb lint:stratum` for stratum
+  direction) from those that do not (layer direction, status-vocabulary conformance) — the latter
+  being how `:executing` reached the implementation unchallenged. Per-spec bumps: N1 0.7→0.8
 
 - **0.17.0-draft** (2026-08-06) - N10 spec-completion pass. **N10**: §12.1 required governed
   execution to emit events to N3 directly above a note saying implementations MUST NOT emit them,

--- a/specs/SPEC_INDEX.md
+++ b/specs/SPEC_INDEX.md
@@ -7,7 +7,7 @@
 # miniforge Specification Index
 
 **Version:** 0.18.0-draft
-**Date:** 2026-08-09
+**Date:** 2026-08-10
 **Status:** Living specification during OSS development
 
 ---

--- a/specs/normative/N1-architecture.md
+++ b/specs/normative/N1-architecture.md
@@ -6,8 +6,8 @@
 
 # N1 — Core Architecture & Concepts
 
-**Version:** 0.7.0-draft
-**Date:** 2026-08-04
+**Version:** 0.8.0-draft
+**Date:** 2026-08-10
 **Status:** Draft
 **Conformance:** MUST
 
@@ -47,7 +47,9 @@ A **workflow** is the top-level unit of autonomous execution.
 ```clojure
 {:workflow/id uuid                  ; REQUIRED: Unique workflow identifier
  :workflow/type keyword             ; REQUIRED: :infrastructure-change, :feature, :refactor
- :workflow/status keyword           ; REQUIRED derived projection: :pending, :running, :completed, :failed, :cancelled
+ :workflow/status keyword           ; REQUIRED derived projection of N2 §2.2's
+                                   ;   canonical vocabulary: :queued :running :paused
+                                   ;   :blocked :completed :failed :cancelled
 
  :workflow/machine                  ; REQUIRED: authoritative execution-machine state
  {:machine/id keyword               ; Compiled machine identity
@@ -2564,6 +2566,59 @@ Implementations MUST demonstrate:
 3. **Evidence bundle portability** - Can read evidence from other instances
 4. **Policy pack compatibility** - Can use community policy packs
 
+### 8.4 Conformance Requirements
+
+N1 already carries requirement IDs for the capabilities added by later
+amendments — `N1.AU.*` (autonomy), `N1.CP.*` (capability), `N1.EV.*`
+(evaluation), `N1.RI.*` (repository intelligence), `N1.RL.*` (reliability), and
+`N1.SI.*` (semantic intent). This section adds the two families the spec's own
+subject matter needs and previously lacked: the domain model of §2 and the
+layering of §3–§4.
+
+IDs are never reused; a withdrawn requirement is marked withdrawn, not deleted.
+
+#### Domain model
+
+| ID | Level | Requirement |
+|----|-------|-------------|
+| N1.DM.1 | MUST | Represent every §2 entity with the required keys its schema declares. |
+| N1.DM.2 | MUST | Validate domain entities at boundaries against those schemas (§8.1). |
+| N1.DM.3 | MUST | Derive `:workflow/status` from the execution machine, using N2 §2.2's vocabulary and no synonym (§2). |
+| N1.DM.4 | MUST | Treat every entity identifier as opaque — no consumer parses meaning out of an id (§2). |
+| N1.DM.5 | MUST NOT | Introduce an entity in an extension spec that duplicates a §2 concept rather than specializing it (§2, standard 020). |
+
+#### Architecture and boundaries
+
+| ID | Level | Requirement |
+|----|-------|-------------|
+| N1.AR.1 | MUST | Keep the three layers of §3 distinct: control plane, agent layer, execution layer. |
+| N1.AR.2 | MUST NOT | Let an agent-layer component depend on a control-plane component (§3). |
+| N1.AR.3 | MUST | Expose each Polylith component only through its `interface` namespace (§4). |
+| N1.AR.4 | MUST NOT | Reference another component's implementation namespace directly (§4). |
+| N1.AR.5 | MUST | Keep components independently testable — a component's tests MUST NOT require the workflow engine (§4, §8.3). |
+| N1.AR.6 | MUST | Tag every namespace with its stratum, and keep dependencies flowing one way through the strata (§3, §4). |
+
+### 8.5 Test Obligations
+
+A conformance suite MUST cover, at minimum:
+
+1. **Schema validation at boundaries** — an invalid entity is rejected at the
+   boundary rather than propagating (N1.DM.1, N1.DM.2).
+2. **Status projection** — `:workflow/status` derived from the machine is a
+   member of N2 §2.2's set at every transition, with no synonym reachable
+   (N1.DM.3).
+3. **Interface-only access** — a static check that no component references
+   another's implementation namespace (N1.AR.3, N1.AR.4).
+4. **Layer direction** — a static check that no agent-layer namespace depends
+   on a control-plane namespace (N1.AR.2).
+5. **Stratum direction** — the stratum linter passes with no downward
+   dependency (N1.AR.6).
+6. **Component isolation** — each component's tests pass with only that
+   component and its declared dependencies on the classpath (N1.AR.5).
+
+Obligations 3 through 5 are static checks the repository can run continuously;
+they are the ones that catch architectural drift before it reaches review.
+
 ---
 
 ## 9. Rationale & Design Notes
@@ -2711,6 +2766,45 @@ conformance checklist.
 
 ---
 
+## Annex A — Implementation Conformance Status (informative)
+
+This annex is **informative**. It records where the miniforge implementation
+diverges from the contract above, as of 2026-08-10.
+
+### A.1 Implemented and Enforced
+
+- **Interface-only access (N1.AR.3, N1.AR.4)** — `poly check` runs in
+  `bb pre-commit` and enforces Polylith component boundaries continuously.
+- **Stratum direction (N1.AR.6)** — `bb lint:stratum` runs in pre-commit,
+  backed by the `stratum-lint` tool.
+- **Component isolation (N1.AR.5)** — the workspace holds 123 components under
+  Polylith, tested independently.
+
+These three are the architectural requirements already covered by a static
+check, which is why they are the ones that have not drifted.
+
+### A.2 Specified, Not Enforced
+
+- **Layer direction (N1.AR.2).** Nothing checks that an agent-layer component
+  does not depend on a control-plane component. Polylith enforces _interface_
+  boundaries, not _layer_ direction, so a legal interface call can still invert
+  the layering of §3.
+- **Status projection (N1.DM.3).** No check that `:workflow/status` stays
+  within N2 §2.2's vocabulary. This is how `:executing` — a value in no spec —
+  reached the implementation and N5's documented CLI filter; see N2 Annex A.
+- **Boundary schema validation (N1.DM.2).** Applied unevenly across entities
+  rather than at every boundary.
+
+### A.3 Structural
+
+- **The reliability, autonomy, and evaluation requirement families**
+  (`N1.RL.*`, `N1.AU.*`, `N1.EV.*`) largely describe capabilities whose
+  implementation status is recorded in the annexes of the specs that consume
+  them — N3 for reliability events, N10 for autonomy gating. N1 states the
+  model; the gaps surface downstream.
+
+---
+
 ## 12. References
 
 - RFC 2119: Key words for use in RFCs to Indicate Requirement Levels
@@ -2793,6 +2887,17 @@ conformance checklist.
 ---
 
 **Version History:**
+
+- 0.8.0-draft (2026-08-10): Spec-completion pass. §2's Workflow entity still
+  declared `:workflow/status` as `:pending, :running, :completed, :failed,
+  :cancelled` — the vocabulary N2 §2.2 superseded, missing `:paused` and
+  `:blocked` and naming `:pending` rather than `:queued`. N1 is a consumer the
+  N2 sweep missed; it now defers to N2 §2.2. Added the two requirement-ID
+  families N1's own subject matter lacked: `N1.DM.*` for the domain model and
+  `N1.AR.*` for layering and component boundaries, plus test obligations
+  (§8.4–§8.5). Annex A records which architectural requirements have a static
+  check — interface boundaries and stratum direction do; layer direction and
+  status-vocabulary conformance do not.
 
 - 0.7.0-draft (2026-08-04): Clarified OPSV requested actuation as intent rather
   than authority; added rollback and required-instrumentation fields to the N7

--- a/specs/normative/N1-architecture.md
+++ b/specs/normative/N1-architecture.md
@@ -2591,7 +2591,7 @@ IDs are never reused; a withdrawn requirement is marked withdrawn, not deleted.
 
 | ID | Level | Requirement |
 |----|-------|-------------|
-| N1.AR.1 | MUST | Keep the three layers of §3 distinct: control plane, agent layer, execution layer. |
+| N1.AR.1 | MUST | Keep the three layers of §3 distinct: control plane (§3.1), agent layer (§3.2), learning layer (§3.3). |
 | N1.AR.2 | MUST NOT | Let an agent-layer component depend on a control-plane component (§3). |
 | N1.AR.3 | MUST | Expose each Polylith component only through its `interface` namespace (§4). |
 | N1.AR.4 | MUST NOT | Reference another component's implementation namespace directly (§4). |


### PR DESCRIPTION
MINIFORGE_PR_BUDGET_OVERRIDE: Single normative spec document. A spec amendment is atomic. Well below the ~10-12k threshold where Copilot declines to review. Docs-only, no runtime code.

## Overview

Aligns N1's Workflow entity with N2's canonical status vocabulary, adds requirement IDs for the domain model and layering, and adds Annex A.

Full detail: [`docs/pull-requests/2026-08-10-chris-n1-architecture-spec-complete.md`](docs/pull-requests/2026-08-10-chris-n1-architecture-spec-complete.md)

## Why

**N1 was a consumer the N2 sweep missed.** §2's Workflow entity declared `:workflow/status` as `:pending, :running, :completed, :failed, :cancelled` — the vocabulary N2 §2.2 superseded, naming `:pending` rather than `:queued` and omitting `:paused` and `:blocked`.

When I unified the vocabulary in N2 I swept N5 and N2-delta, and reported that as the lesson learned from the N4 severity unification. N1 still slipped. The lesson holds one level up: the sweep needs to be a search across all specs, not a list of the consumers I happened to think of.

**N1 had requirement IDs for everything except its own subject.** Six families existed — `N1.AU.*`, `N1.CP.*`, `N1.EV.*`, `N1.RI.*`, `N1.RL.*`, `N1.SI.*` — all added by later amendments for capabilities layered onto N1. The domain model of §2 and the architecture of §3–§4, which are what N1 is *for*, had none.

## Changes

- **§2** `:workflow/status` defers to N2 §2.2.
- **§8.4** adds `N1.DM.*` (5) and `N1.AR.*` (6). The two worth naming: N1.DM.3 requires the status projection to stay within N2 §2.2's set with no synonym reachable; N1.AR.2 requires that no agent-layer component depend on a control-plane component — which Polylith does not check.
- **§8.5** adds six test obligations, three of them static checks the repo can run continuously.

## Annex A — implementation conformance status (informative)

The useful split is between architectural requirements that have a static check and those that do not.

**Enforced:** interface-only access (`poly check` in pre-commit), stratum direction (`bb lint:stratum`), component isolation (123 Polylith components). These are the requirements that have not drifted — which is the point.

**Not enforced:** layer direction, because Polylith checks *interface* boundaries rather than *layer* direction, so a legal interface call can still invert §3's layering. And status-vocabulary conformance — which is precisely how `:executing`, a value in no spec, reached both the implementation and N5's documented CLI filter.

## Validation

Documentation only; no runtime code touched.

- `markdownlint` clean on all three files
- No duplicate section numbers; 45 requirement IDs across eight families
- Verified N1's other `:pending` occurrences belong to `:phase/status` and `:gate/status`, separate vocabularies N2 §2.2 does not govern

🤖 Generated with [Claude Code](https://claude.com/claude-code)
