### PR TITLE
refactor(policy-pack): split mdc_compiler.clj — extract dewey (4/6)

### DIFF
--- a/components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler.clj
@@ -24,41 +24,43 @@
 
    Designed to be called by the ETL task (bb standards:pack) at build time.
 
-   Slice 3/6 of a rule 210 split train (SL003: this namespace measured
+   Slice 4/6 of a rule 210 split train (SL003: this namespace measured
    9 real layers, max 3 — same approach as the dag-orchestrator split,
    miniforge#1485, and the workflow-runner split, miniforge#1662).
-   Slice 1 (miniforge#1729) moved the frontmatter scalar-value grammar
-   to `mdc-compiler.frontmatter-values`; slice 2 (miniforge#1732) moved
-   the frontmatter line-grammar to `mdc-compiler.frontmatter`. This
-   slice moves the text-condensation chain (whole-sentence truncation,
-   bullet detection, prose/bullet condensation) to
-   `mdc-compiler.condense` — the chain that was the real bottleneck:
-   `condense-to-length` alone accounted for 4 of the file's 7 real
-   layers. The file now measures 5 real layers; the surviving
-   critical path is the Dewey-range chain (`find-dewey-range` →
-   `dewey->phases`/`category-id`/`category-label` →
-   `build-categories`/`mdc->rule` → `compile-standards-pack`), which
-   the remaining slices (Dewey-range extraction, then rule-config
-   builders) target directly.
+   Slices 1-2 (miniforge#1729/#1732) moved the frontmatter grammar out;
+   slice 3 (miniforge#1733) moved the text-condensation chain out. This
+   slice moves the Dewey-range table and its lookups (`find-dewey-range`,
+   `dewey->phases`/`category-id`/`category-label`, the N4 taxonomy
+   export) to `mdc-compiler.dewey` — the chain that was the bottleneck
+   after slice 3. `export-canonical-taxonomy` is re-exported here as a
+   thin delegating var (not just moved) because
+   `ai.miniforge.policy-pack.interface` and this component's
+   `taxonomy_test.clj` reference `mdc-compiler/export-canonical-taxonomy`
+   directly — real external fan-in the original zero-fan-in check
+   (which only grepped the underscored file-path spelling, not the
+   hyphenated namespace symbol actually used in `:require` forms)
+   missed. The file now measures 4 real layers; the surviving critical
+   path runs through two independent branches feeding `mdc->rule` —
+   `build-remediation-config`'s rule-config chain and (after slice 5)
+   `extract-agent-behavior`'s chain — both must move before the parent
+   drops to budget.
 
    Layer 0: Parsing/config primitives — group-dotted-keys,
-     build-exclude-context, build-detection-config, dewey-ranges,
-     default-phases, slug->rule-id/title, agent-behavior
-     paragraph/section helpers, format-pack-version,
-     validate-no-duplicate-slugs, parse-mdc, condense-to-length
-   Layer 1: build-remediation-config, find-dewey-range,
-     export-canonical-taxonomy, extract-agent-behavior
-   Layer 2: dewey->phases/category-id/category-label
-   Layer 3: build-categories, mdc->rule
-   Layer 4: compile-standards-pack
+     build-exclude-context, build-detection-config, slug->rule-id/title,
+     agent-behavior paragraph/section helpers, format-pack-version,
+     validate-no-duplicate-slugs, parse-mdc, condense-to-length,
+     export-canonical-taxonomy, build-categories
+   Layer 1: build-remediation-config, extract-agent-behavior
+   Layer 2: mdc->rule
+   Layer 3: compile-standards-pack
 
    Related:
      work/designs/mdc-to-pack-field-mapping.edn — authoritative field mapping spec
      components/policy-pack/src/.../schema.clj  — Rule schema (target format)
      .standards/                                 — source .mdc files (input)"
   (:require
-   [ai.miniforge.coerce.interface :as coerce]
    [ai.miniforge.policy-pack.mdc-compiler.condense :as condense]
+   [ai.miniforge.policy-pack.mdc-compiler.dewey :as dewey]
    [ai.miniforge.policy-pack.mdc-compiler.frontmatter :as frontmatter]
    [ai.miniforge.policy-pack.schema-types :as schema-types]
    [ai.miniforge.policy-pack.schema-validation :as schema-validation]
@@ -118,28 +120,6 @@
   (set schema-types/enforcement-actions))
 
 ;; Field mapping transforms
-;; ── Dewey code → phases ─────────────────────────────────────────────────────
-;;
-;; This table lives ONLY in the compiler. After compilation, phases are plain
-;; keyword sets on the rule map. The runtime product never sees Dewey codes.
-(def ^{:stratum 0} ^:private dewey-ranges
-  "Dewey ranges with category metadata and applicable phase sets.
-   Each entry: {:lo <int> :hi <int> :id <string> :label <string> :phases <set>}"
-  [{:lo 0   :hi 99  :id "foundations"   :label "Foundations & Core Principles"     :phases #{:plan :implement :review :verify :release}}
-   {:lo 100 :hi 199 :id "tools"         :label "Development Environment & Tools"   :phases #{:implement :review}}
-   {:lo 200 :hi 299 :id "languages"     :label "Languages"                         :phases #{:implement :review}}
-   {:lo 300 :hi 399 :id "frameworks"    :label "Frameworks & Platforms"             :phases #{:plan :implement :review}}
-   {:lo 400 :hi 499 :id "testing"       :label "Testing & Quality"                 :phases #{:implement :verify}}
-   {:lo 500 :hi 599 :id "operations"    :label "Operations & Infrastructure"       :phases #{:implement :review}}
-   {:lo 600 :hi 699 :id "documentation" :label "Documentation"                     :phases #{:implement :review}}
-   {:lo 700 :hi 799 :id "workflows"     :label "Workflows & Processes"             :phases #{:plan :implement :review :verify :release}}
-   {:lo 800 :hi 899 :id "project"       :label "Project-Specific"                  :phases #{:implement :review}}
-   {:lo 900 :hi 999 :id "meta"          :label "Meta & Templates"                  :phases #{}}])
-
-(def ^{:stratum 0} ^:private default-phases
-  "Fallback phases when Dewey code is outside defined ranges or unparseable."
-  #{:implement :review})
-
 ;; ── Filename slug → rule ID ─────────────────────────────────────────────────
 (defn ^{:stratum 0} slug->rule-id
   "Convert an MDC filename to a namespaced rule ID keyword.
@@ -274,6 +254,39 @@
         (condense/condense-bullets lines target-length)
         (condense/condense-prose text target-length)))))
 
+;; Canonical taxonomy export — re-exported here (not just from `dewey`)
+;; because `ai.miniforge.policy-pack.interface` and
+;; `taxonomy_test.clj` require this namespace directly and reference
+;; `mdc-compiler/export-canonical-taxonomy` by name; moving the
+;; definition without this delegating var would be a public-API break
+;; disguised as an internal reorganization.
+(def ^{:stratum 0} export-canonical-taxonomy dewey/export-canonical-taxonomy)
+
+;; ── Category builder ────────────────────────────────────────────────────────
+(defn- ^{:stratum 0} build-categories
+  "Build PackCategory entries from compiled rules.
+
+   Groups rules by Dewey-range-derived category and produces
+   {:category/id :category/name :category/rules} entries.
+
+   Arguments:
+   - rules - Vector of compiled rule maps
+
+   Returns:
+   - Sorted vector of PackCategory maps."
+  [rules]
+  (let [by-cat (group-by (fn [rule]
+                           (dewey/dewey->category-id (:rule/category rule)))
+                         rules)]
+    (->> by-cat
+         (map (fn [[cat-id cat-rules]]
+                {:category/id    cat-id
+                 :category/name  (dewey/dewey->category-label
+                                  (:rule/category (first cat-rules)))
+                 :category/rules (mapv :rule/id cat-rules)}))
+         (sort-by :category/id)
+         vec)))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn- ^{:stratum 1} build-remediation-config
@@ -298,48 +311,6 @@
         (seq excludes)
         (assoc :exclude-contexts excludes)))))
 
-(defn- ^{:stratum 1} find-dewey-range
-  "Find the dewey-ranges entry for a given Dewey code string.
-   Returns the matching range map, or nil."
-  [dewey-str]
-  (when-let [code (coerce/safe-parse-int (str/trim (str dewey-str)))]
-    (some (fn [{:keys [lo hi] :as entry}]
-            (when (and (<= lo code) (<= code hi))
-              entry))
-          dewey-ranges)))
-
-;; Canonical taxonomy export
-(defn ^{:stratum 1} export-canonical-taxonomy
-  "Export the compiler's dewey-ranges as a first-class Taxonomy artifact.
-
-   This bridges the compiler's internal category table to the N4 four-artifact
-   model. The exported taxonomy is the authoritative source of truth; the
-   bundled EDN resource at resources/taxonomies/miniforge-dewey-1.0.0.edn
-   should match this output.
-
-   Returns:
-   - A valid Taxonomy map per taxonomy/Taxonomy schema."
-  []
-  {:taxonomy/id      :miniforge/dewey
-   :taxonomy/version "1.0.0"
-   :taxonomy/title   "Miniforge Dewey Taxonomy"
-   :taxonomy/description
-   "Dewey-decimal-inspired category tree for miniforge engineering standards.
-    Ten top-level ranges (000-999) covering foundations, tools, languages,
-    frameworks, testing, operations, documentation, workflows, project, and meta."
-   :taxonomy/categories
-   (mapv (fn [{:keys [lo id label]}]
-           {:category/id    (keyword "mf.cat" id)
-            :category/code  (format "%03d-%03d" lo (+ lo 99))
-            :category/title label
-            :category/order lo})
-         dewey-ranges)
-   :taxonomy/aliases
-   (mapv (fn [{:keys [id]}]
-           {:alias/name   (keyword id)
-            :alias/target (keyword "mf.cat" id)})
-         dewey-ranges)})
-
 (defn ^{:stratum 1} extract-agent-behavior
   "Extract a concise agent behavior directive from an MDC body.
 
@@ -363,74 +334,8 @@
 
 ;------------------------------------------------------------------------------ Layer 2
 
-(defn ^{:stratum 2} dewey->phases
-  "Map a Dewey code string to a set of applicable workflow phases.
-
-   Arguments:
-   - dewey-str - Dewey code string, e.g. \"001\", \"210\", \"900\"
-
-   Returns:
-   - Set of phase keywords, e.g. #{:plan :implement :review}"
-  [dewey-str]
-  (if-let [entry (find-dewey-range dewey-str)]
-    (:phases entry)
-    default-phases))
-
-(defn ^{:stratum 2} dewey->category-id
-  "Map a Dewey code to its category ID string.
-
-   Arguments:
-   - dewey-str - Dewey code string
-
-   Returns:
-   - Category ID string (e.g. \"foundations\", \"languages\"), or \"other\"."
-  [dewey-str]
-  (if-let [entry (find-dewey-range dewey-str)]
-    (:id entry)
-    "other"))
-
-(defn ^{:stratum 2} dewey->category-label
-  "Map a Dewey code to its human-readable category label.
-
-   Arguments:
-   - dewey-str - Dewey code string
-
-   Returns:
-   - Category label string, or \"Other\"."
-  [dewey-str]
-  (if-let [entry (find-dewey-range dewey-str)]
-    (:label entry)
-    "Other"))
-
-;------------------------------------------------------------------------------ Layer 3
-
-;; ── Category builder ────────────────────────────────────────────────────────
-(defn- ^{:stratum 3} build-categories
-  "Build PackCategory entries from compiled rules.
-
-   Groups rules by Dewey-range-derived category and produces
-   {:category/id :category/name :category/rules} entries.
-
-   Arguments:
-   - rules - Vector of compiled rule maps
-
-   Returns:
-   - Sorted vector of PackCategory maps."
-  [rules]
-  (let [by-cat (group-by (fn [rule]
-                           (dewey->category-id (:rule/category rule)))
-                         rules)]
-    (->> by-cat
-         (map (fn [[cat-id cat-rules]]
-                {:category/id    cat-id
-                 :category/name  (dewey->category-label
-                                  (:rule/category (first cat-rules)))
-                 :category/rules (mapv :rule/id cat-rules)}))
-         (sort-by :category/id)
-         vec)))
-
 ;; Rule compilation
-(defn ^{:stratum 3} mdc->rule
+(defn ^{:stratum 2} mdc->rule
   "Compile a single MDC file into a policy-pack rule map.
 
    Implements the field mapping from the design spec
@@ -458,7 +363,7 @@
           always-apply (true? (get fm "alwaysApply"))
 
           ;; ── Applicability ───────────────────────────────────────────────
-          phases       (dewey->phases dewey)
+          phases       (dewey/dewey->phases dewey)
           globs        (normalize-globs (get fm "globs"))
           applies-to   (cond-> {:phases phases}
                          (seq globs) (assoc :file-globs globs))
@@ -522,9 +427,9 @@
       (merge (schema-validation/failure :rule (.getMessage e))
              {:filename filename}))))
 
-;------------------------------------------------------------------------------ Layer 4
+;------------------------------------------------------------------------------ Layer 3
 
-(defn ^{:stratum 4} compile-standards-pack
+(defn ^{:stratum 3} compile-standards-pack
   "Compile all .mdc files from a standards directory into a pack manifest.
 
    Discovers all .mdc files recursively, compiles each via mdc->rule,
@@ -612,10 +517,10 @@
   ;;     :body "# Body here"}
 
   ;; ── Dewey → phases ──────────────────────────────────────────────────────
-  (dewey->phases "001")  ;; => #{:plan :implement :review :verify :release}
-  (dewey->phases "210")  ;; => #{:implement :review}
-  (dewey->phases "900")  ;; => #{}
-  (dewey->phases "xyz")  ;; => #{:implement :review}  (default fallback)
+  (dewey/dewey->phases "001")  ;; => #{:plan :implement :review :verify :release}
+  (dewey/dewey->phases "210")  ;; => #{:implement :review}
+  (dewey/dewey->phases "900")  ;; => #{}
+  (dewey/dewey->phases "xyz")  ;; => #{:implement :review}  (default fallback)
 
   ;; ── Slug → rule ID ──────────────────────────────────────────────────────
   (slug->rule-id "stratified-design.mdc")       ;; => :std/stratified-design

--- a/components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler.clj
@@ -260,7 +260,19 @@
 ;; `mdc-compiler/export-canonical-taxonomy` by name; moving the
 ;; definition without this delegating var would be a public-API break
 ;; disguised as an internal reorganization.
-(def ^{:stratum 0} export-canonical-taxonomy dewey/export-canonical-taxonomy)
+(def ^{:stratum 0} export-canonical-taxonomy
+  "Export the compiler's dewey-ranges as a first-class Taxonomy artifact.
+
+   This bridges the compiler's internal category table to the N4 four-artifact
+   model. The exported taxonomy is the authoritative source of truth; the
+   bundled EDN resource at resources/taxonomies/miniforge-dewey-1.0.0.edn
+   should match this output.
+
+   Returns:
+   - A valid Taxonomy map per taxonomy/Taxonomy schema.
+
+   Delegates to ai.miniforge.policy-pack.mdc-compiler.dewey/export-canonical-taxonomy."
+  dewey/export-canonical-taxonomy)
 
 ;; ── Category builder ────────────────────────────────────────────────────────
 (defn- ^{:stratum 0} build-categories

--- a/components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler/dewey.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler/dewey.clj
@@ -1,0 +1,140 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.mdc-compiler.dewey
+  "Dewey-decimal-inspired category table and its lookups: range
+   definitions, phase/category/label mapping, and the N4 taxonomy
+   export. This table lives ONLY here — after compilation, phases are
+   plain keyword sets on the rule map, and the runtime product never
+   sees Dewey codes. Split out of `ai.miniforge.policy-pack.mdc-compiler`
+   (rule 210: slice 4/6 of the same split train as
+   `mdc-compiler.frontmatter-values`/`mdc-compiler.frontmatter`/
+   `mdc-compiler.condense`, miniforge#1729/#1732/#1733 — same approach
+   as the dag-orchestrator split, miniforge#1485, and the
+   workflow-runner split, miniforge#1662). This chain was the parent
+   namespace's bottleneck after slice 3: `find-dewey-range` fed
+   `dewey->phases`/`category-id`/`category-label`, which in turn fed
+   `build-categories`/`mdc->rule` and then `compile-standards-pack`."
+  (:require
+   [ai.miniforge.coerce.interface :as coerce]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; ── Dewey code → phases ─────────────────────────────────────────────────────
+(def ^{:stratum 0} ^:private dewey-ranges
+  "Dewey ranges with category metadata and applicable phase sets.
+   Each entry: {:lo <int> :hi <int> :id <string> :label <string> :phases <set>}"
+  [{:lo 0   :hi 99  :id "foundations"   :label "Foundations & Core Principles"     :phases #{:plan :implement :review :verify :release}}
+   {:lo 100 :hi 199 :id "tools"         :label "Development Environment & Tools"   :phases #{:implement :review}}
+   {:lo 200 :hi 299 :id "languages"     :label "Languages"                         :phases #{:implement :review}}
+   {:lo 300 :hi 399 :id "frameworks"    :label "Frameworks & Platforms"             :phases #{:plan :implement :review}}
+   {:lo 400 :hi 499 :id "testing"       :label "Testing & Quality"                 :phases #{:implement :verify}}
+   {:lo 500 :hi 599 :id "operations"    :label "Operations & Infrastructure"       :phases #{:implement :review}}
+   {:lo 600 :hi 699 :id "documentation" :label "Documentation"                     :phases #{:implement :review}}
+   {:lo 700 :hi 799 :id "workflows"     :label "Workflows & Processes"             :phases #{:plan :implement :review :verify :release}}
+   {:lo 800 :hi 899 :id "project"       :label "Project-Specific"                  :phases #{:implement :review}}
+   {:lo 900 :hi 999 :id "meta"          :label "Meta & Templates"                  :phases #{}}])
+
+(def ^{:stratum 0} ^:private default-phases
+  "Fallback phases when Dewey code is outside defined ranges or unparseable."
+  #{:implement :review})
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} find-dewey-range
+  "Find the dewey-ranges entry for a given Dewey code string.
+   Returns the matching range map, or nil."
+  [dewey-str]
+  (when-let [code (coerce/safe-parse-int (str/trim (str dewey-str)))]
+    (some (fn [{:keys [lo hi] :as entry}]
+            (when (and (<= lo code) (<= code hi))
+              entry))
+          dewey-ranges)))
+
+;; Canonical taxonomy export
+(defn ^{:stratum 1} export-canonical-taxonomy
+  "Export the compiler's dewey-ranges as a first-class Taxonomy artifact.
+
+   This bridges the compiler's internal category table to the N4 four-artifact
+   model. The exported taxonomy is the authoritative source of truth; the
+   bundled EDN resource at resources/taxonomies/miniforge-dewey-1.0.0.edn
+   should match this output.
+
+   Returns:
+   - A valid Taxonomy map per taxonomy/Taxonomy schema."
+  []
+  {:taxonomy/id      :miniforge/dewey
+   :taxonomy/version "1.0.0"
+   :taxonomy/title   "Miniforge Dewey Taxonomy"
+   :taxonomy/description
+   "Dewey-decimal-inspired category tree for miniforge engineering standards.
+    Ten top-level ranges (000-999) covering foundations, tools, languages,
+    frameworks, testing, operations, documentation, workflows, project, and meta."
+   :taxonomy/categories
+   (mapv (fn [{:keys [lo id label]}]
+           {:category/id    (keyword "mf.cat" id)
+            :category/code  (format "%03d-%03d" lo (+ lo 99))
+            :category/title label
+            :category/order lo})
+         dewey-ranges)
+   :taxonomy/aliases
+   (mapv (fn [{:keys [id]}]
+           {:alias/name   (keyword id)
+            :alias/target (keyword "mf.cat" id)})
+         dewey-ranges)})
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} dewey->phases
+  "Map a Dewey code string to a set of applicable workflow phases.
+
+   Arguments:
+   - dewey-str - Dewey code string, e.g. \"001\", \"210\", \"900\"
+
+   Returns:
+   - Set of phase keywords, e.g. #{:plan :implement :review}"
+  [dewey-str]
+  (if-let [entry (find-dewey-range dewey-str)]
+    (:phases entry)
+    default-phases))
+
+(defn ^{:stratum 2} dewey->category-id
+  "Map a Dewey code to its category ID string.
+
+   Arguments:
+   - dewey-str - Dewey code string
+
+   Returns:
+   - Category ID string (e.g. \"foundations\", \"languages\"), or \"other\"."
+  [dewey-str]
+  (if-let [entry (find-dewey-range dewey-str)]
+    (:id entry)
+    "other"))
+
+(defn ^{:stratum 2} dewey->category-label
+  "Map a Dewey code to its human-readable category label.
+
+   Arguments:
+   - dewey-str - Dewey code string
+
+   Returns:
+   - Category label string, or \"Other\"."
+  [dewey-str]
+  (if-let [entry (find-dewey-range dewey-str)]
+    (:label entry)
+    "Other"))

--- a/components/policy-pack/test/ai/miniforge/policy_pack/mdc_compiler_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/mdc_compiler_test.clj
@@ -126,8 +126,8 @@
 ;; ============================================================================
 (deftest ^{:stratum 0} dewey->category-id-test
   (testing "maps dewey codes to category IDs"
-    (are [dewey expected]
-         (= expected (dewey/dewey->category-id dewey))
+    (are [dewey-code expected]
+         (= expected (dewey/dewey->category-id dewey-code))
       "001" "foundations"
       "100" "tools"
       "210" "languages"

--- a/components/policy-pack/test/ai/miniforge/policy_pack/mdc_compiler_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/mdc_compiler_test.clj
@@ -32,6 +32,7 @@
    [clojure.test :refer [deftest testing is are]]
    [clojure.string :as str]
    [ai.miniforge.policy-pack.mdc-compiler :as sut]
+   [ai.miniforge.policy-pack.mdc-compiler.dewey :as dewey]
    [ai.miniforge.policy-pack.mdc-compiler.frontmatter :as frontmatter]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -126,7 +127,7 @@
 (deftest ^{:stratum 0} dewey->category-id-test
   (testing "maps dewey codes to category IDs"
     (are [dewey expected]
-         (= expected (sut/dewey->category-id dewey))
+         (= expected (dewey/dewey->category-id dewey))
       "001" "foundations"
       "100" "tools"
       "210" "languages"
@@ -139,17 +140,17 @@
       "900" "meta"))
 
   (testing "unknown dewey returns 'other'"
-    (is (= "other" (sut/dewey->category-id "xyz")))
-    (is (= "other" (sut/dewey->category-id "")))))
+    (is (= "other" (dewey/dewey->category-id "xyz")))
+    (is (= "other" (dewey/dewey->category-id "")))))
 
 (deftest ^{:stratum 0} dewey->category-label-test
   (testing "maps dewey codes to human labels"
-    (is (= "Foundations & Core Principles" (sut/dewey->category-label "001")))
-    (is (= "Languages" (sut/dewey->category-label "210")))
-    (is (= "Workflows & Processes" (sut/dewey->category-label "715"))))
+    (is (= "Foundations & Core Principles" (dewey/dewey->category-label "001")))
+    (is (= "Languages" (dewey/dewey->category-label "210")))
+    (is (= "Workflows & Processes" (dewey/dewey->category-label "715"))))
 
   (testing "unknown dewey returns 'Other'"
-    (is (= "Other" (sut/dewey->category-label "xyz")))))
+    (is (= "Other" (dewey/dewey->category-label "xyz")))))
 
 ;; ============================================================================
 ;; Slug → rule ID tests
@@ -524,46 +525,46 @@
 
 (deftest ^{:stratum 1} dewey->phases-test
   (testing "foundations (0-99) → all phases"
-    (is (= all-phases (sut/dewey->phases "001")))
-    (is (= all-phases (sut/dewey->phases "000")))
-    (is (= all-phases (sut/dewey->phases "099"))))
+    (is (= all-phases (dewey/dewey->phases "001")))
+    (is (= all-phases (dewey/dewey->phases "000")))
+    (is (= all-phases (dewey/dewey->phases "099"))))
 
   (testing "tools (100-199) → implement + review"
-    (is (= #{:implement :review} (sut/dewey->phases "100"))))
+    (is (= #{:implement :review} (dewey/dewey->phases "100"))))
 
   (testing "languages (200-299) → implement + review"
-    (is (= #{:implement :review} (sut/dewey->phases "210"))))
+    (is (= #{:implement :review} (dewey/dewey->phases "210"))))
 
   (testing "frameworks (300-399) → plan + implement + review"
-    (is (= #{:plan :implement :review} (sut/dewey->phases "300"))))
+    (is (= #{:plan :implement :review} (dewey/dewey->phases "300"))))
 
   (testing "testing (400-499) → implement + verify"
-    (is (= #{:implement :verify} (sut/dewey->phases "400"))))
+    (is (= #{:implement :verify} (dewey/dewey->phases "400"))))
 
   (testing "operations (500-599) → implement + review"
-    (is (= #{:implement :review} (sut/dewey->phases "500"))))
+    (is (= #{:implement :review} (dewey/dewey->phases "500"))))
 
   (testing "documentation (600-699) → implement + review"
-    (is (= #{:implement :review} (sut/dewey->phases "600"))))
+    (is (= #{:implement :review} (dewey/dewey->phases "600"))))
 
   (testing "workflows (700-799) → all phases"
-    (is (= all-phases (sut/dewey->phases "715"))))
+    (is (= all-phases (dewey/dewey->phases "715"))))
 
   (testing "project (800-899) → implement + review"
-    (is (= #{:implement :review} (sut/dewey->phases "800"))))
+    (is (= #{:implement :review} (dewey/dewey->phases "800"))))
 
   (testing "meta (900-999) → empty set (never injected)"
-    (is (= #{} (sut/dewey->phases "900")))
-    (is (= #{} (sut/dewey->phases "999"))))
+    (is (= #{} (dewey/dewey->phases "900")))
+    (is (= #{} (dewey/dewey->phases "999"))))
 
   (testing "boundary values: end of one range, start of next"
-    (is (= all-phases (sut/dewey->phases "99")))
-    (is (= #{:implement :review} (sut/dewey->phases "100"))))
+    (is (= all-phases (dewey/dewey->phases "99")))
+    (is (= #{:implement :review} (dewey/dewey->phases "100"))))
 
   (testing "unparseable dewey falls back to default phases"
-    (is (= #{:implement :review} (sut/dewey->phases "xyz")))
-    (is (= #{:implement :review} (sut/dewey->phases "")))
-    (is (= #{:implement :review} (sut/dewey->phases nil)))))
+    (is (= #{:implement :review} (dewey/dewey->phases "xyz")))
+    (is (= #{:implement :review} (dewey/dewey->phases "")))
+    (is (= #{:implement :review} (dewey/dewey->phases nil)))))
 
 ;; ============================================================================
 ;; mdc->rule compilation tests

--- a/docs/pull-requests/2026-08-09-refactor-split-policy-pack-mdc-compiler-4.md
+++ b/docs/pull-requests/2026-08-09-refactor-split-policy-pack-mdc-compiler-4.md
@@ -1,0 +1,129 @@
+<!--
+  Title: Split policy-pack mdc_compiler.clj — extract dewey (4/6)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(policy-pack): split mdc_compiler.clj — extract dewey (4/6)
+
+## Overview
+
+Slice 4 of the 6-PR split train for
+`components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler.clj`
+(rule 210, SL003 — 9 real layers, max 3; slices 1-3 were
+`#1729`/`#1732`/`#1733`). This slice extracts
+`ai.miniforge.policy-pack.mdc-compiler.dewey`: the Dewey-range table
+and its lookups — `dewey-ranges`, `default-phases`, `find-dewey-range`,
+`export-canonical-taxonomy`, `dewey->phases`, `dewey->category-id`,
+`dewey->category-label`.
+
+## Motivation
+
+**Important correction to this train's fan-in check.** Slices 1-3
+stated "zero fan-in" based on
+`grep -rl "policy[-_]pack\.mdc_compiler\b"` — a pattern built for the
+underscored file-path spelling (`mdc_compiler`), not the hyphenated
+namespace symbol (`mdc-compiler`) Clojure actually uses in `:require`
+forms. Re-checking with the correct pattern
+(`grep -rl "ai\.miniforge\.policy-pack\.mdc-compiler\b"`) found real
+fan-in: `ai.miniforge.policy-pack.interface` requires `mdc-compiler`
+and re-exports `compile-standards-pack` and `export-canonical-taxonomy`
+by name, and this component's `taxonomy_test.clj` calls
+`mdc-compiler/export-canonical-taxonomy` directly. `compile-standards-pack`
+was never planned to move (it's the file's own top-level orchestrator),
+so this didn't affect slices 1-3. `export-canonical-taxonomy` **is**
+part of this slice's Dewey-range group, so it needed handling here.
+
+Fix: `export-canonical-taxonomy` is re-exported from `mdc_compiler.clj`
+as a thin delegating var —
+`(def export-canonical-taxonomy dewey/export-canonical-taxonomy)` —
+rather than only existing in the new `dewey` namespace. This keeps
+`mdc-compiler`'s public surface unchanged, matching the "no public-API
+changes" guarantee from the compliance-scanner precedent
+(miniforge#1580). Verified `interface.clj` still resolves and returns
+the correct taxonomy through the delegate, and `taxonomy_test.clj`
+passes unchanged.
+
+No other function in this slice, or in slices 5-6's planned groups,
+has external fan-in — re-verified the corrected grep pattern against
+every remaining function name before proceeding.
+
+## Changes in Detail
+
+- New file `mdc_compiler/dewey.clj`: the Dewey-range table and lookups,
+  3 real layers (0-2), stratum-lint clean on its own.
+- `mdc_compiler.clj`: the six standalone functions/defs removed;
+  `export-canonical-taxonomy` becomes a delegating var (see Motivation);
+  `build-categories` and `mdc->rule` now call `dewey/dewey->category-id`,
+  `dewey/dewey->category-label`, and `dewey/dewey->phases`. Ran
+  `stratum-lint --fix` to renumber headings/`:stratum` metadata and
+  updated the namespace docstring's layer summary — dropped from 5 to
+  4 real layers. The surviving critical path runs through two
+  independent branches feeding `mdc->rule`
+  (`build-remediation-config`'s rule-config chain, and
+  `extract-agent-behavior`'s chain) — both need to move before the
+  file drops to budget, which slices 5-6 target.
+- `mdc_compiler_test.clj`: `sut/dewey->phases`,
+  `sut/dewey->category-id`, and `sut/dewey->category-label` call sites
+  now go through the new `dewey` namespace directly.
+
+The parent namespace stays over budget (4 real layers) until the
+remaining slices land; the removal commit used
+`MINIFORGE_STRATUM_BUDGET_MODE=warn`, same convention as prior slices.
+
+## Testing Plan
+
+1. `clj-kondo` clean on all touched files.
+2. stratum-lint: `dewey.clj` passes SL003 outright; `mdc_compiler.clj`
+   intentionally still over budget (4 layers, down from 5) — expected,
+   see Motivation above.
+3. `ai.miniforge.policy-pack.mdc-compiler-test`: 26 tests / 159
+   assertions, 0 failures, 0 errors.
+4. `ai.miniforge.policy-pack.taxonomy-test` (exercises
+   `export-canonical-taxonomy` through the `mdc-compiler` alias
+   directly, exactly the fan-in path this PR had to preserve): 10
+   tests / 39 assertions, 0 failures, 0 errors.
+5. `ai.miniforge.policy-pack.interface-test`: 14 tests / 69 assertions,
+   0 failures, 0 errors.
+6. Full pre-commit suite (`poly:check`, lint, smoke tests, GraalVM)
+   passed on both commits.
+7. Adversarial self-review: diffed the full top-level `defn`/`def` set
+   before and after — six defs relocated, one (`export-canonical-taxonomy`)
+   turned into a delegating var with identical return value (verified
+   via `interface.clj`'s live call, byte-identical output), 0 other
+   behavior changes.
+
+PR size: reportable lines checked per-commit (100 for the new file,
+188 for the removal commit, 51 for the test-update commit), all under
+the 200-line commit budget; combined well under the 600-line PR budget.
+
+## Deployment Plan
+
+Merges to `main` as part of the ongoing 6-PR train. The next slice
+rebases onto the updated `main` after this one merges.
+
+## Related Issues/PRs
+
+- Slice 1: [#1729](https://github.com/miniforge-ai/miniforge/pull/1729)
+- Slice 2: [#1732](https://github.com/miniforge-ai/miniforge/pull/1732)
+- Slice 3: [#1733](https://github.com/miniforge-ai/miniforge/pull/1733)
+- Precedent (no-public-API-changes guarantee): [compliance-scanner split, #1580](https://github.com/miniforge-ai/miniforge/pull/1580)
+- Precedent: [dag-orchestrator split, #1485](https://github.com/miniforge-ai/miniforge/pull/1485)
+- Precedent: [workflow-runner split, #1662](https://github.com/miniforge-ai/miniforge/pull/1662)
+- Part of the stratum-lint rule-210 remediation program (Wave 2)
+
+## Checklist
+
+- [x] Fan-in re-verified with the correct namespace-symbol grep
+      pattern (not just file-path spelling) — found and handled real
+      external fan-in on `export-canonical-taxonomy`
+- [x] Branch rebased onto latest `origin/main`
+- [x] Pure code motion for six of seven moved items; one
+      (`export-canonical-taxonomy`) deliberately kept as a delegating
+      var to preserve the public API — documented and verified
+- [x] `clj-kondo` clean
+- [x] Tests green (mdc-compiler 26/26, taxonomy 10/10, interface 14/14)
+- [x] Commit-diff budgets checked (100/188/51, all ≤200); PR total
+      well under 600
+- [x] `MINIFORGE_STRATUM_BUDGET_MODE=warn` used + documented for the
+      expected intermediate over-budget state


### PR DESCRIPTION
<!--
  Title: Split policy-pack mdc_compiler.clj — extract dewey (4/6)
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# refactor(policy-pack): split mdc_compiler.clj — extract dewey (4/6)

## Overview

Slice 4 of the 6-PR split train for
`components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler.clj`
(rule 210, SL003 — 9 real layers, max 3; slices 1-3 were
`#1729`/`#1732`/`#1733`). This slice extracts
`ai.miniforge.policy-pack.mdc-compiler.dewey`: the Dewey-range table
and its lookups — `dewey-ranges`, `default-phases`, `find-dewey-range`,
`export-canonical-taxonomy`, `dewey->phases`, `dewey->category-id`,
`dewey->category-label`.

## Motivation

**Important correction to this train's fan-in check.** Slices 1-3
stated "zero fan-in" based on
`grep -rl "policy[-_]pack\.mdc_compiler\b"` — a pattern built for the
underscored file-path spelling (`mdc_compiler`), not the hyphenated
namespace symbol (`mdc-compiler`) Clojure actually uses in `:require`
forms. Re-checking with the correct pattern
(`grep -rl "ai\.miniforge\.policy-pack\.mdc-compiler\b"`) found real
fan-in: `ai.miniforge.policy-pack.interface` requires `mdc-compiler`
and re-exports `compile-standards-pack` and `export-canonical-taxonomy`
by name, and this component's `taxonomy_test.clj` calls
`mdc-compiler/export-canonical-taxonomy` directly. `compile-standards-pack`
was never planned to move (it's the file's own top-level orchestrator),
so this didn't affect slices 1-3. `export-canonical-taxonomy` **is**
part of this slice's Dewey-range group, so it needed handling here.

Fix: `export-canonical-taxonomy` is re-exported from `mdc_compiler.clj`
as a thin delegating var —
`(def export-canonical-taxonomy dewey/export-canonical-taxonomy)` —
rather than only existing in the new `dewey` namespace. This keeps
`mdc-compiler`'s public surface unchanged, matching the "no public-API
changes" guarantee from the compliance-scanner precedent
(miniforge#1580). Verified `interface.clj` still resolves and returns
the correct taxonomy through the delegate, and `taxonomy_test.clj`
passes unchanged.

No other function in this slice, or in slices 5-6's planned groups,
has external fan-in — re-verified the corrected grep pattern against
every remaining function name before proceeding.

## Changes in Detail

- New file `mdc_compiler/dewey.clj`: the Dewey-range table and lookups,
  3 real layers (0-2), stratum-lint clean on its own.
- `mdc_compiler.clj`: the six standalone functions/defs removed;
  `export-canonical-taxonomy` becomes a delegating var (see Motivation);
  `build-categories` and `mdc->rule` now call `dewey/dewey->category-id`,
  `dewey/dewey->category-label`, and `dewey/dewey->phases`. Ran
  `stratum-lint --fix` to renumber headings/`:stratum` metadata and
  updated the namespace docstring's layer summary — dropped from 5 to
  4 real layers. The surviving critical path runs through two
  independent branches feeding `mdc->rule`
  (`build-remediation-config`'s rule-config chain, and
  `extract-agent-behavior`'s chain) — both need to move before the
  file drops to budget, which slices 5-6 target.
- `mdc_compiler_test.clj`: `sut/dewey->phases`,
  `sut/dewey->category-id`, and `sut/dewey->category-label` call sites
  now go through the new `dewey` namespace directly.

The parent namespace stays over budget (4 real layers) until the
remaining slices land; the removal commit used
`MINIFORGE_STRATUM_BUDGET_MODE=warn`, same convention as prior slices.

## Testing Plan

1. `clj-kondo` clean on all touched files.
2. stratum-lint: `dewey.clj` passes SL003 outright; `mdc_compiler.clj`
   intentionally still over budget (4 layers, down from 5) — expected,
   see Motivation above.
3. `ai.miniforge.policy-pack.mdc-compiler-test`: 26 tests / 159
   assertions, 0 failures, 0 errors.
4. `ai.miniforge.policy-pack.taxonomy-test` (exercises
   `export-canonical-taxonomy` through the `mdc-compiler` alias
   directly, exactly the fan-in path this PR had to preserve): 10
   tests / 39 assertions, 0 failures, 0 errors.
5. `ai.miniforge.policy-pack.interface-test`: 14 tests / 69 assertions,
   0 failures, 0 errors.
6. Full pre-commit suite (`poly:check`, lint, smoke tests, GraalVM)
   passed on both commits.
7. Adversarial self-review: diffed the full top-level `defn`/`def` set
   before and after — six defs relocated, one (`export-canonical-taxonomy`)
   turned into a delegating var with identical return value (verified
   via `interface.clj`'s live call, byte-identical output), 0 other
   behavior changes.

PR size: reportable lines checked per-commit (100 for the new file,
188 for the removal commit, 51 for the test-update commit), all under
the 200-line commit budget; combined well under the 600-line PR budget.

## Deployment Plan

Merges to `main` as part of the ongoing 6-PR train. The next slice
rebases onto the updated `main` after this one merges.

## Related Issues/PRs

- Slice 1: [#1729](https://github.com/miniforge-ai/miniforge/pull/1729)
- Slice 2: [#1732](https://github.com/miniforge-ai/miniforge/pull/1732)
- Slice 3: [#1733](https://github.com/miniforge-ai/miniforge/pull/1733)
- Precedent (no-public-API-changes guarantee): [compliance-scanner split, #1580](https://github.com/miniforge-ai/miniforge/pull/1580)
- Precedent: [dag-orchestrator split, #1485](https://github.com/miniforge-ai/miniforge/pull/1485)
- Precedent: [workflow-runner split, #1662](https://github.com/miniforge-ai/miniforge/pull/1662)
- Part of the stratum-lint rule-210 remediation program (Wave 2)

## Checklist

- [x] Fan-in re-verified with the correct namespace-symbol grep
      pattern (not just file-path spelling) — found and handled real
      external fan-in on `export-canonical-taxonomy`
- [x] Branch rebased onto latest `origin/main`
- [x] Pure code motion for six of seven moved items; one
      (`export-canonical-taxonomy`) deliberately kept as a delegating
      var to preserve the public API — documented and verified
- [x] `clj-kondo` clean
- [x] Tests green (mdc-compiler 26/26, taxonomy 10/10, interface 14/14)
- [x] Commit-diff budgets checked (100/188/51, all ≤200); PR total
      well under 600
- [x] `MINIFORGE_STRATUM_BUDGET_MODE=warn` used + documented for the
      expected intermediate over-budget state
