### PR TITLE
docs(specs): N11 task capsule isolation spec completion (0.2.0 → 0.3.0-draft)

### DIFF
--- a/docs/pull-requests/2026-08-10-chris-n11-task-capsule-spec-complete.md
+++ b/docs/pull-requests/2026-08-10-chris-n11-task-capsule-spec-complete.md
@@ -1,0 +1,99 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# docs: N11 task capsule isolation spec completion (0.2.0 → 0.3.0-draft)
+
+## Overview
+
+Fixes a section-numbering collision, marks an implementation-mapping section
+informative, defers secrets and evidence to their owning specs, and adds
+Annex A.
+
+## Motivation
+
+**Five duplicate section numbers.** §11's subsections were numbered §10.1
+through §10.5, colliding with the TaskExecutor protocol's own §10.1–§10.5.
+Both inbound `N11 §10` references — from N11-delta-runtime-adapter — mean the
+protocol, so the protocol keeps its numbers and §11's subsections were the ones
+misnumbered.
+
+**A normative section pinned to file and line numbers.** §11 maps requirements
+to locations like `docker.clj:428–442` inside the normative body, without being
+marked informative. Those coordinates rot: the `docker.clj` it cites no longer
+exists anywhere in the tree.
+
+**Two contracts restated from their owners.** §8.1 forbade secrets being
+"logged or included in evidence records" — that is N3 §8's contract, inherited
+by N6 §7.2. §9.1's evidence keys (`:evidence/runtime-class`,
+`:evidence/image-digest`, and the rest) are not N6 artifact fields, so the
+record cannot be produced conformantly — the same shape as N10 §12.2.
+
+## Changes in Detail
+
+- **§11 renumbered** to §11.1–§11.5 and marked informative, with a note that
+  its file and line citations are a snapshot and one of them is already stale.
+- **§8.1** defers to N3 §8, keeping the one genuinely capsule-specific rule:
+  a secret's *name* and *scope* may be recorded so an auditor can see which
+  secrets a capsule was granted without seeing their values.
+- **§9.1** gated on registering its keys in N6 §3.1.1, with the interim
+  position stated — capsule execution is recorded through evidence N6 already
+  defines, correlated by workflow and task identifiers.
+
+## Annex A (informative)
+
+- **Implemented** — `components/dag-executor` provides the TaskExecutor
+  protocol with three implementations: worktree, host-guarded, Kubernetes.
+- **Specified, not implemented** — no Docker executor exists, so `:docker` is
+  unselectable among the runtime classes §5 admits. No capsule evidence record.
+  No artifact export gate, so `:export/missing-required-artifact` has no
+  producer. No network-policy enforcement.
+- **Structural** — secret teardown is stated and unverified. And §9.3's
+  prohibition on agents resolving their workspace from
+  `System/getProperty "user.dir"` in governed mode is unenforced — that is the
+  exact fallback behind the sandbox-leak defect observed in this repository
+  during this work, which makes the prohibition load-bearing rather than
+  theoretical.
+
+## Testing Plan
+
+Specification change; no runtime code touched.
+
+- `markdownlint` clean on all three changed files.
+- Verified no duplicate section numbers remain.
+- Verified both inbound `N11 §10` references mean the TaskExecutor protocol
+  before renumbering.
+- Verified `docker.clj` is absent from the tree and the other cited files
+  resolve.
+
+## Deployment Plan
+
+Documentation only. Merges to `main` with no runtime effect.
+
+## Follow-on Work
+
+1. Enforce §9.3 — reject `user.dir` workspace resolution in governed mode.
+   This is the one with a demonstrated failure behind it.
+2. Implement the artifact export gate (§9.2).
+3. Enforce the deny-by-default network policy (§8.2).
+4. Register capsule evidence keys in N6 §3.1.1, or drop the record.
+
+## Related Issues/PRs
+
+- Follows the N1–N10 completion passes
+- Depends on: N3 §8 (redaction), N6 §3.1.1 (artifact types)
+- Governed by: `standards/miniforge/foundations/specification-standards` (020)
+
+## Checklist
+
+- [x] Spec reviewed against current state before editing
+- [x] Duplicate section numbers resolved; inbound references checked first
+- [x] Implementation-mapping section marked informative
+- [x] Duplicated contracts deferred to their owners (020)
+- [x] Annex A marked informative
+- [x] Copyright header present (810)
+- [x] `markdownlint` clean
+- [x] SPEC_INDEX updated
+- [x] PR doc created (721)

--- a/specs/SPEC_INDEX.md
+++ b/specs/SPEC_INDEX.md
@@ -6,8 +6,8 @@
 
 # miniforge Specification Index
 
-**Version:** 0.18.0-draft
-**Date:** 2026-08-10
+**Version:** 0.19.0-draft
+**Date:** 2026-08-09
 **Status:** Living specification during OSS development
 
 ---
@@ -366,6 +366,13 @@ Defines:
 - Runtime specification, network, secret, resource, and evidence boundaries
 - TaskExecutor workspace persistence and phase continuity
 - OCI runtime abstraction through the indexed N11 runtime-adapter delta
+- **§11 renumbered** — its five subsections were numbered §10.1–§10.5, colliding with the
+  TaskExecutor protocol's own subsections
+- **§11 marked informative** — it maps requirements to file/line coordinates that rot; the
+  `docker.clj` it cites no longer exists
+- **Secrets deferred to N3 §8** (§8.1), keeping only the capsule-specific name/scope allowance
+- **§9.1 evidence gated on N6** — its keys are not N6 artifact fields
+- **Annex A (informative):** implementation conformance status
 
 ---
 
@@ -604,6 +611,16 @@ Normative specs are enforced by:
 
 ## Version History
 
+- **0.19.0-draft** (2026-08-10) - N11 spec-completion pass. **N11**: §11's five subsections were
+  numbered §10.1–§10.5, duplicating the TaskExecutor protocol's subsection numbers; renumbered,
+  and the two inbound `N11 §10` references both mean the protocol so are unaffected. §11 marked
+  informative — it maps requirements to file and line coordinates that rot, and the `docker.clj`
+  it cites no longer exists in the tree. §8.1's secret rules deferred to N3 §8. §9.1's evidence
+  keys are not N6 artifact fields and are now gated on registering them there, the same shape as
+  N10 §12.2. Annex A records that only three of the runtime classes §5 admits have an executor,
+  and that §9.3's prohibition on resolving the workspace from `user.dir` — the exact fallback
+  behind the sandbox-leak defect seen in this repo — is unenforced.
+  Per-spec bumps: N11 0.2→0.3
 - **0.18.0-draft** (2026-08-10) - N1 spec-completion pass. **N1**: §2's Workflow entity declared
   `:workflow/status` with the vocabulary N2 §2.2 superseded — `:pending` rather than `:queued`, and
   no `:paused`/`:blocked`. N1 was a consumer the N2 sweep missed. Added `N1.DM.*` and `N1.AR.*`

--- a/specs/SPEC_INDEX.md
+++ b/specs/SPEC_INDEX.md
@@ -7,7 +7,7 @@
 # miniforge Specification Index
 
 **Version:** 0.19.0-draft
-**Date:** 2026-08-09
+**Date:** 2026-08-10
 **Status:** Living specification during OSS development
 
 ---

--- a/specs/normative/N11-task-capsule-isolation.md
+++ b/specs/normative/N11-task-capsule-isolation.md
@@ -433,7 +433,7 @@ Secrets MUST be injected into the capsule at BOOTSTRAP time as:
 - Environment variables (`:scope :env`)
 - Files at a declared path (`:scope :file`)
 
-Secrets MUST NOT be:
+Secret **values** MUST NOT be:
 
 - Written into image layers
 - Present in any exported artifact
@@ -442,9 +442,9 @@ Secrets MUST NOT be:
 The last of these is **N3 §8's contract**, inherited here rather than restated:
 N3 §8.1 forbids emitting a credential at all, §8.2 fixes the `"[REDACTED]"`
 marker, and N6 §7.2 applies both to bundles. This section adds only the
-capsule-specific rule that a secret's *name* and *scope* MAY be recorded so an
-auditor can see which secrets a capsule was granted without seeing their
-values.
+capsule-specific rule that a secret's *name* and *scope* MAY be recorded — the
+prohibition above is on values, not on the fact that a secret was granted, so
+an auditor can see which secrets a capsule held without seeing any of them.
 
 Capsule teardown at DESTROY time MUST ensure:
 

--- a/specs/normative/N11-task-capsule-isolation.md
+++ b/specs/normative/N11-task-capsule-isolation.md
@@ -6,8 +6,8 @@
 
 # N11 — Task Capsule Isolation
 
-**Version:** 0.2.0-draft
-**Date:** 2026-04-23
+**Version:** 0.3.0-draft
+**Date:** 2026-08-10
 **Status:** Draft
 **Conformance:** MUST
 **Amends:** N2-workflows §13.4, N10-governed-tool-execution §7
@@ -437,7 +437,14 @@ Secrets MUST NOT be:
 
 - Written into image layers
 - Present in any exported artifact
-- Logged or included in evidence records (only secret *names* and *scopes* are recorded)
+- Logged, emitted on the event stream, or included in evidence records
+
+The last of these is **N3 §8's contract**, inherited here rather than restated:
+N3 §8.1 forbids emitting a credential at all, §8.2 fixes the `"[REDACTED]"`
+marker, and N6 §7.2 applies both to bundles. This section adds only the
+capsule-specific rule that a secret's *name* and *scope* MAY be recorded so an
+auditor can see which secrets a capsule was granted without seeing their
+values.
 
 Capsule teardown at DESTROY time MUST ensure:
 
@@ -467,7 +474,16 @@ for any task that requires them.
 
 ### 9.1 What Must be Recorded
 
-Each task capsule MUST produce an evidence record containing:
+Each task capsule MUST produce an evidence record. The keys below are **not
+yet N6 artifact fields** — N6 §3.1.1 enumerates artifact types and none carries
+this shape — so registering them there is a prerequisite to producing this
+record conformantly, on the same principle as N10 §12.2: N6 owns the evidence
+schema.
+
+Until then, capsule execution is recorded through the evidence N6 already
+defines, correlated by the workflow and task identifiers.
+
+*Proposed N6 artifact content. Not emittable until registered there.*
 
 ```clojure
 {:evidence/runtime-class    keyword?  ; :docker, :k8s, etc.
@@ -700,10 +716,15 @@ OSS callers MUST NOT assume cross-node capsule binding; only the per-substrate
 
 ## 11. Implementation Mapping
 
-This section maps the normative requirements above to the existing codebase and
-identifies the minimum change set.
+**This section is informative.** It maps the normative requirements above to
+the codebase as it stood when written and identifies a minimum change set. It
+carries no MUST/SHOULD of its own; where it appears to, §1–§10 govern.
 
-### 10.1 Immediate Gaps
+File and line citations below are a snapshot and rot as the tree moves — the
+`docker.clj` cited in §11.1 no longer exists at that path, for instance. Treat
+them as pointers to the shape of the change, not as current coordinates.
+
+### 11.1 Immediate Gaps
 
 | Gap | Location | Required Change |
 |-----|----------|-----------------|
@@ -715,7 +736,7 @@ identifies the minimum change set.
 | No execution mode concept | `runner.clj`, workflow spec | Add `:execution/mode #{:local :governed}` to workflow opts and runner |
 | No downgrade guard | `runner.clj:431–444` | After executor selection, check mode compatibility; fail if governed + worktree |
 
-### 10.2 `acquire-environment!` Bootstrap Extension
+### 11.2 `acquire-environment!` Bootstrap Extension
 
 The Docker executor's `acquire-environment!` currently accepts `:env`, `:workdir`,
 and `:resources`. The `:workspace` key from the runtime specification MUST be added:
@@ -731,7 +752,7 @@ and `:resources`. The `:workspace` key from the runtime specification MUST be ad
   )
 ```
 
-### 10.3 Runner Execution Mode Selection
+### 11.3 Runner Execution Mode Selection
 
 ```clojure
 (defn- acquire-execution-environment! [workflow-id {:keys [execution-mode repo-url commit] :as opts}]
@@ -749,7 +770,7 @@ and `:resources`. The `:workspace` key from the runtime specification MUST be ad
     ...))
 ```
 
-### 10.4 Phase Context Keys
+### 11.4 Phase Context Keys
 
 When a capsule environment is active, the phase context MUST carry:
 
@@ -764,7 +785,7 @@ When a capsule environment is active, the phase context MUST carry:
 The `:execution/capsule-exec-fn` key is new. Phase implementations that invoke the
 LLM client MUST use this exec-fn when present, instead of the default host exec-fn.
 
-### 10.5 What Does Not Need to Change
+### 11.5 What Does Not Need to Change
 
 The following are already conformant with this spec or are in the right direction:
 
@@ -826,6 +847,45 @@ host process) when no conformant capsule substrate is available.
 
 ---
 
+## Annex A — Implementation Conformance Status (informative)
+
+This annex is **informative**. It records where the miniforge implementation
+diverges from the contract above, as of 2026-08-10.
+
+### A.1 Implemented
+
+- **TaskExecutor protocol (§10).** `components/dag-executor` provides the
+  protocol and three implementations: `worktree.clj`, `host_guarded.clj`, and
+  `kubernetes.clj`.
+
+### A.2 Specified, Not Implemented
+
+- **Docker executor.** §11.1 cites `docker.clj` as an existing location to
+  change; no such file exists in the tree. Of the runtime classes §5 admits,
+  only worktree, host-guarded, and Kubernetes have an executor, so `:docker`
+  cannot be selected.
+- **Capsule evidence (§9.1).** The evidence keys — `:evidence/runtime-class`,
+  `:evidence/image-digest`, `:evidence/repo-commit`, and the rest — are not N6
+  artifact fields, so the record cannot be produced conformantly. Nothing
+  emits them.
+- **Artifact export gate (§9.2).** No check that `:required? true` artifacts
+  were exported before DESTROY, so `:export/missing-required-artifact` has no
+  producer.
+- **Network policy enforcement (§8.2).** The deny-by-default allow-list is
+  specified but not enforced by any executor.
+
+### A.3 Structural
+
+- **Secret teardown (§8.1)** — no verification that env vars and mounted
+  secret files are unreachable after termination. The requirement is stated
+  and unchecked, the same shape as N10 §10's safety invariants.
+- **`user.dir` prohibition (§9.3)** — §9.3 forbids agents resolving their
+  workspace from `System/getProperty "user.dir"` in governed mode. This is the
+  exact fallback behind the sandbox-leak defect observed in this repo, so the
+  prohibition is load-bearing and currently unenforced.
+
+---
+
 ## 14. References
 
 - **N2 §13.4** — Task execution isolation (amended by this spec)
@@ -847,6 +907,16 @@ host process) when no conformant capsule substrate is available.
 ---
 
 **Version History:**
+
+- 0.3.0-draft (2026-08-10): Spec-completion pass. §11's five subsections were
+  numbered §10.1–§10.5, colliding with the TaskExecutor protocol's own
+  subsections — renumbered to §11.x; the two inbound `N11 §10` references both
+  mean the protocol and are unaffected. §11 marked informative: it maps
+  requirements to file and line coordinates that rot, and the `docker.clj` it
+  cites no longer exists. §8.1's secret rules deferred to N3 §8, keeping only
+  the capsule-specific allowance that a secret's name and scope may be
+  recorded. §9.1's evidence keys are not N6 artifact fields and are now gated
+  on registering them there. Annex A records implementation divergence.
 
 - 0.2.0-draft (2026-04-23): TaskExecutor Protocol normative amendment — §10 hoists
   the TaskExecutor protocol from informative docs to normative, defining the


### PR DESCRIPTION
MINIFORGE_PR_BUDGET_OVERRIDE: Single normative spec document. A spec amendment is atomic. Well below the ~10-12k threshold where Copilot declines to review. Docs-only, no runtime code.

## Overview

Fixes a five-way section-numbering collision, marks an implementation-mapping section informative, defers secrets and evidence to their owning specs, and adds Annex A.

Full detail: [`docs/pull-requests/2026-08-10-chris-n11-task-capsule-spec-complete.md`](docs/pull-requests/2026-08-10-chris-n11-task-capsule-spec-complete.md)

## Why

**Five duplicate section numbers.** §11's subsections were numbered §10.1–§10.5, colliding with the TaskExecutor protocol's own §10.1–§10.5. Both inbound `N11 §10` references — from N11-delta-runtime-adapter — mean the protocol, so the protocol keeps its numbers and §11's were the misnumbered ones.

**A normative section pinned to file and line numbers.** §11 maps requirements to locations like `docker.clj:428–442` inside the normative body without being marked informative. Those coordinates rot: the `docker.clj` it cites no longer exists anywhere in the tree.

**Two contracts restated from their owners.** §8.1 forbade secrets being "logged or included in evidence records" — that is N3 §8's contract, inherited by N6 §7.2. §9.1's evidence keys are not N6 artifact fields, so the record cannot be produced conformantly — the same shape as N10 §12.2.

## Changes

- **§11** renumbered to §11.1–§11.5 and marked informative, with a note that its citations are a snapshot and one is already stale.
- **§8.1** defers to N3 §8, keeping the one genuinely capsule-specific rule: a secret's *name* and *scope* may be recorded, so an auditor can see which secrets a capsule held without seeing their values.
- **§9.1** gated on registering its keys in N6 §3.1.1, with the interim position stated.

## Annex A — implementation conformance status (informative)

- **Implemented** — `components/dag-executor` provides the TaskExecutor protocol with three implementations: worktree, host-guarded, Kubernetes.
- **Specified, not implemented** — no Docker executor, so `:docker` is unselectable among the runtime classes §5 admits. No capsule evidence record. No artifact export gate, so `:export/missing-required-artifact` has no producer. No network-policy enforcement.
- **Structural** — secret teardown is stated and unverified. And §9.3's prohibition on agents resolving their workspace from `System/getProperty "user.dir"` in governed mode is **unenforced** — that is the exact fallback behind the sandbox-leak defect observed in this repository during this work, which makes the prohibition load-bearing rather than theoretical.

## Validation

Documentation only; no runtime code touched.

- `markdownlint` clean on all three files
- Verified no duplicate section numbers remain
- Verified both inbound `N11 §10` references mean the TaskExecutor protocol **before** renumbering
- Verified `docker.clj` is absent from the tree and the other cited files resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)
