### PR TITLE
refactor(policy-pack): split mdc_compiler.clj — extract agent-behavior (5/6)

### DIFF
--- a/components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler.clj
@@ -24,33 +24,26 @@
 
    Designed to be called by the ETL task (bb standards:pack) at build time.
 
-   Slice 4/6 of a rule 210 split train (SL003: this namespace measured
+   Slice 5/6 of a rule 210 split train (SL003: this namespace measured
    9 real layers, max 3 — same approach as the dag-orchestrator split,
    miniforge#1485, and the workflow-runner split, miniforge#1662).
    Slices 1-2 (miniforge#1729/#1732) moved the frontmatter grammar out;
-   slice 3 (miniforge#1733) moved the text-condensation chain out. This
-   slice moves the Dewey-range table and its lookups (`find-dewey-range`,
-   `dewey->phases`/`category-id`/`category-label`, the N4 taxonomy
-   export) to `mdc-compiler.dewey` — the chain that was the bottleneck
-   after slice 3. `export-canonical-taxonomy` is re-exported here as a
-   thin delegating var (not just moved) because
-   `ai.miniforge.policy-pack.interface` and this component's
-   `taxonomy_test.clj` reference `mdc-compiler/export-canonical-taxonomy`
-   directly — real external fan-in the original zero-fan-in check
-   (which only grepped the underscored file-path spelling, not the
-   hyphenated namespace symbol actually used in `:require` forms)
-   missed. The file now measures 4 real layers; the surviving critical
-   path runs through two independent branches feeding `mdc->rule` —
-   `build-remediation-config`'s rule-config chain and (after slice 5)
-   `extract-agent-behavior`'s chain — both must move before the parent
-   drops to budget.
+   slice 3 (miniforge#1733) moved the text-condensation chain out;
+   slice 4 (miniforge#1740) moved the Dewey-range chain out. This slice
+   moves agent-behavior extraction (`extract-agent-behavior-section`,
+   `extract-first-paragraph`, `condense-to-length`,
+   `extract-agent-behavior`) to `mdc-compiler.agent-behavior`. The file
+   stays at 4 real layers — `mdc->rule` sits atop TWO independent
+   chains, and moving only one (this slice) still leaves the other
+   (`build-remediation-config`'s rule-config chain) setting the depth.
+   The final slice (rule-config builders) removes that last chain and
+   brings the file to budget.
 
    Layer 0: Parsing/config primitives — group-dotted-keys,
      build-exclude-context, build-detection-config, slug->rule-id/title,
-     agent-behavior paragraph/section helpers, format-pack-version,
-     validate-no-duplicate-slugs, parse-mdc, condense-to-length,
+     format-pack-version, validate-no-duplicate-slugs, parse-mdc,
      export-canonical-taxonomy, build-categories
-   Layer 1: build-remediation-config, extract-agent-behavior
+   Layer 1: build-remediation-config
    Layer 2: mdc->rule
    Layer 3: compile-standards-pack
 
@@ -59,7 +52,7 @@
      components/policy-pack/src/.../schema.clj  — Rule schema (target format)
      .standards/                                 — source .mdc files (input)"
   (:require
-   [ai.miniforge.policy-pack.mdc-compiler.condense :as condense]
+   [ai.miniforge.policy-pack.mdc-compiler.agent-behavior :as agent-behavior]
    [ai.miniforge.policy-pack.mdc-compiler.dewey :as dewey]
    [ai.miniforge.policy-pack.mdc-compiler.frontmatter :as frontmatter]
    [ai.miniforge.policy-pack.schema-types :as schema-types]
@@ -146,58 +139,6 @@
        (map str/capitalize)
        (str/join " ")))
 
-;; ── Agent behavior extraction ───────────────────────────────────────────────
-(def ^{:stratum 0} ^:private behavior-condensation-target 500)
-
-(defn- ^{:stratum 0} extract-agent-behavior-section
-  "Extract content from a \"## Agent behavior\" section in the MDC body.
-
-   Scans for a heading matching /^## Agent behavior/i, extracts everything
-   from that heading to the next ## heading or end-of-file, strips the
-   heading line itself.
-
-   Returns the section content string, or nil if no such heading exists."
-  [body]
-  (let [lines (str/split-lines body)
-        heading-idx (first
-                     (keep-indexed
-                      (fn [i line]
-                        (when (re-matches #"(?i)^##\s+Agent\s+behavior\s*$"
-                                          (str/trim line))
-                          i))
-                      lines))]
-    (when heading-idx
-      (let [after-heading (drop (inc heading-idx) lines)
-            section-lines (take-while
-                           (fn [line]
-                             (not (re-matches #"^##\s+.*" (str/trim line))))
-                           after-heading)
-            content (str/trim (str/join "\n" section-lines))]
-        (when-not (str/blank? content)
-          content)))))
-
-(defn- ^{:stratum 0} extract-first-paragraph
-  "Extract the first non-heading paragraph from the MDC body.
-
-   Skips any leading # headings and blank lines, then takes text
-   until the next blank line.
-
-   Returns the paragraph string, or nil."
-  [body]
-  (let [lines (str/split-lines body)
-        content-lines (drop-while
-                       (fn [line]
-                         (let [trimmed (str/trim line)]
-                           (or (str/blank? trimmed)
-                               (str/starts-with? trimmed "#"))))
-                       lines)
-        paragraph-lines (take-while
-                         (fn [line] (not (str/blank? (str/trim line))))
-                         content-lines)
-        content (str/trim (str/join "\n" paragraph-lines))]
-    (when-not (str/blank? content)
-      content)))
-
 ;; ── Globs normalization ─────────────────────────────────────────────────────
 (defn- ^{:stratum 0} normalize-globs
   "Normalize the globs frontmatter value to a vector of strings.
@@ -240,19 +181,6 @@
   (let [{:keys [frontmatter body]} (frontmatter/split-frontmatter content)]
     {:frontmatter (frontmatter/parse-frontmatter frontmatter)
      :body        body}))
-
-(defn- ^{:stratum 0} condense-to-length
-  "Condense text to approximately target-length characters.
-   Bullet lists (including numbered): keeps first 3 bullets.
-   Prose: keeps complete sentences."
-  [text target-length]
-  (if (<= (count text) target-length)
-    text
-    (let [lines   (str/split-lines text)
-          bullets (filterv condense/bullet-line? lines)]
-      (if (>= (count bullets) 2)
-        (condense/condense-bullets lines target-length)
-        (condense/condense-prose text target-length)))))
 
 ;; Canonical taxonomy export — re-exported here (not just from `dewey`)
 ;; because `ai.miniforge.policy-pack.interface` and
@@ -323,27 +251,6 @@
         (seq excludes)
         (assoc :exclude-contexts excludes)))))
 
-(defn ^{:stratum 1} extract-agent-behavior
-  "Extract a concise agent behavior directive from an MDC body.
-
-   Priority 1: If the body contains a '## Agent behavior' section,
-               extract and condense its content.
-   Priority 2: If no such section, use the first non-heading paragraph.
-
-   Result is condensed to ~500 chars for prompt injection.
-
-   Arguments:
-   - body - MDC body text (everything after frontmatter)
-
-   Returns:
-   - Behavior string, or nil if no meaningful content."
-  [body]
-  (when-not (str/blank? body)
-    (let [section (extract-agent-behavior-section body)
-          content (or section (extract-first-paragraph body))]
-      (when content
-        (condense-to-length content behavior-condensation-target)))))
-
 ;------------------------------------------------------------------------------ Layer 2
 
 ;; Rule compilation
@@ -386,7 +293,7 @@
 
           ;; ── Content extraction ──────────────────────────────────────────
           body-trimmed    (when-not (str/blank? body) (str/trim body))
-          agent-behavior  (extract-agent-behavior body)
+          agent-behavior  (agent-behavior/extract-agent-behavior body)
 
           ;; ── Build rule map ──────────────────────────────────────────────
           ;; Enforcement action: a rule MAY opt into a stronger action via
@@ -540,11 +447,11 @@
   (slug->rule-id "pre-commit-discipline.mdc")   ;; => :std/pre-commit-discipline
 
   ;; ── Agent behavior extraction ───────────────────────────────────────────
-  (extract-agent-behavior
+  (agent-behavior/extract-agent-behavior
    "# Title\n\nSome intro text.\n\n## Agent behavior\n\n- Do this first.\n- Then do that.")
   ;; => "- Do this first.\n- Then do that."
 
-  (extract-agent-behavior
+  (agent-behavior/extract-agent-behavior
    "# Title\n\nFirst paragraph used as fallback.\n\nSecond paragraph ignored.")
   ;; => "First paragraph used as fallback."
 

--- a/components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler/agent_behavior.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler/agent_behavior.clj
@@ -1,0 +1,122 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.mdc-compiler.agent-behavior
+  "Extraction of a concise agent-behavior directive from an MDC body:
+   prefers a '## Agent behavior' section, falls back to the first
+   non-heading paragraph, condensed to a prompt-injection-friendly
+   length via `mdc-compiler.condense`. Split out of
+   `ai.miniforge.policy-pack.mdc-compiler` (rule 210: slice 5/6 of the
+   same split train as `mdc-compiler.frontmatter-values`/
+   `mdc-compiler.frontmatter`/`mdc-compiler.condense`/`mdc-compiler.dewey`,
+   miniforge#1729/#1732/#1733/#1740 — same approach as the
+   dag-orchestrator split, miniforge#1485, and the workflow-runner
+   split, miniforge#1662). One of two independent chains feeding
+   `mdc->rule` (the other being the rule-config builders, slice 6);
+   both must move before the parent namespace drops to budget."
+  (:require
+   [ai.miniforge.policy-pack.mdc-compiler.condense :as condense]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private behavior-condensation-target 500)
+
+(defn- ^{:stratum 0} extract-agent-behavior-section
+  "Extract content from a \"## Agent behavior\" section in the MDC body.
+
+   Scans for a heading matching /^## Agent behavior/i, extracts everything
+   from that heading to the next ## heading or end-of-file, strips the
+   heading line itself.
+
+   Returns the section content string, or nil if no such heading exists."
+  [body]
+  (let [lines (str/split-lines body)
+        heading-idx (first
+                     (keep-indexed
+                      (fn [i line]
+                        (when (re-matches #"(?i)^##\s+Agent\s+behavior\s*$"
+                                          (str/trim line))
+                          i))
+                      lines))]
+    (when heading-idx
+      (let [after-heading (drop (inc heading-idx) lines)
+            section-lines (take-while
+                           (fn [line]
+                             (not (re-matches #"^##\s+.*" (str/trim line))))
+                           after-heading)
+            content (str/trim (str/join "\n" section-lines))]
+        (when-not (str/blank? content)
+          content)))))
+
+(defn- ^{:stratum 0} extract-first-paragraph
+  "Extract the first non-heading paragraph from the MDC body.
+
+   Skips any leading # headings and blank lines, then takes text
+   until the next blank line.
+
+   Returns the paragraph string, or nil."
+  [body]
+  (let [lines (str/split-lines body)
+        content-lines (drop-while
+                       (fn [line]
+                         (let [trimmed (str/trim line)]
+                           (or (str/blank? trimmed)
+                               (str/starts-with? trimmed "#"))))
+                       lines)
+        paragraph-lines (take-while
+                         (fn [line] (not (str/blank? (str/trim line))))
+                         content-lines)
+        content (str/trim (str/join "\n" paragraph-lines))]
+    (when-not (str/blank? content)
+      content)))
+
+(defn- ^{:stratum 0} condense-to-length
+  "Condense text to approximately target-length characters.
+   Bullet lists (including numbered): keeps first 3 bullets.
+   Prose: keeps complete sentences."
+  [text target-length]
+  (if (<= (count text) target-length)
+    text
+    (let [lines   (str/split-lines text)
+          bullets (filterv condense/bullet-line? lines)]
+      (if (>= (count bullets) 2)
+        (condense/condense-bullets lines target-length)
+        (condense/condense-prose text target-length)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} extract-agent-behavior
+  "Extract a concise agent behavior directive from an MDC body.
+
+   Priority 1: If the body contains a '## Agent behavior' section,
+               extract and condense its content.
+   Priority 2: If no such section, use the first non-heading paragraph.
+
+   Result is condensed to ~500 chars for prompt injection.
+
+   Arguments:
+   - body - MDC body text (everything after frontmatter)
+
+   Returns:
+   - Behavior string, or nil if no meaningful content."
+  [body]
+  (when-not (str/blank? body)
+    (let [section (extract-agent-behavior-section body)
+          content (or section (extract-first-paragraph body))]
+      (when content
+        (condense-to-length content behavior-condensation-target)))))

--- a/components/policy-pack/test/ai/miniforge/policy_pack/mdc_compiler_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/mdc_compiler_test.clj
@@ -32,6 +32,7 @@
    [clojure.test :refer [deftest testing is are]]
    [clojure.string :as str]
    [ai.miniforge.policy-pack.mdc-compiler :as sut]
+   [ai.miniforge.policy-pack.mdc-compiler.agent-behavior :as agent-behavior]
    [ai.miniforge.policy-pack.mdc-compiler.dewey :as dewey]
    [ai.miniforge.policy-pack.mdc-compiler.frontmatter :as frontmatter]))
 
@@ -175,34 +176,34 @@
   (testing "priority 1: extracts ## Agent behavior section"
     (let [body "# Title\n\nIntro.\n\n## Agent behavior\n\n- Do this first.\n- Then do that.\n\n## Next section"]
       (is (= "- Do this first.\n- Then do that."
-             (sut/extract-agent-behavior body)))))
+             (agent-behavior/extract-agent-behavior body)))))
 
   (testing "priority 2: falls back to first non-heading paragraph"
     (let [body "# Title\n\nFirst paragraph used as fallback.\n\nSecond paragraph ignored."]
       (is (= "First paragraph used as fallback."
-             (sut/extract-agent-behavior body)))))
+             (agent-behavior/extract-agent-behavior body)))))
 
   (testing "returns nil for nil body"
-    (is (nil? (sut/extract-agent-behavior nil))))
+    (is (nil? (agent-behavior/extract-agent-behavior nil))))
 
   (testing "returns nil for blank body"
-    (is (nil? (sut/extract-agent-behavior ""))))
+    (is (nil? (agent-behavior/extract-agent-behavior ""))))
 
   (testing "returns nil for whitespace-only body"
-    (is (nil? (sut/extract-agent-behavior "   \n  "))))
+    (is (nil? (agent-behavior/extract-agent-behavior "   \n  "))))
 
   (testing "returns nil for body with only headings"
-    (is (nil? (sut/extract-agent-behavior "# Heading only\n## Sub heading"))))
+    (is (nil? (agent-behavior/extract-agent-behavior "# Heading only\n## Sub heading"))))
 
   (testing "condenses long behavior sections to ~500 chars"
     (let [long-body (str "## Agent behavior\n\n"
                          (str/join ". " (repeat 100 "Do something important"))
                          ".")]
-      (is (<= (count (sut/extract-agent-behavior long-body)) 510))))  ;; allow small slack
+      (is (<= (count (agent-behavior/extract-agent-behavior long-body)) 510))))  ;; allow small slack
 
   (testing "preserves bullet lists when condensing"
     (let [body "## Agent behavior\n\n- First bullet.\n- Second bullet.\n- Third bullet.\n- Fourth bullet."
-          result (sut/extract-agent-behavior body)]
+          result (agent-behavior/extract-agent-behavior body)]
       ;; Should preserve first 3 bullets when condensing
       (is (str/includes? result "First bullet"))
       (is (str/includes? result "Second bullet"))
@@ -219,7 +220,7 @@
                     "3. Third numbered step that should survive.\n"
                     "4. Fourth numbered step.\n"
                     "5. Fifth numbered step.")
-          result (sut/extract-agent-behavior body)]
+          result (agent-behavior/extract-agent-behavior body)]
       (is (str/includes? result "First numbered step")
           "first numbered item must be preserved")
       (is (str/includes? result "Second numbered step")
@@ -240,7 +241,7 @@
                             "target so the trimming path is exercised."))
           body (str "## Agent behavior\n\n"
                     (str/join "\n" (map step (range 1 6))))
-          result (str/trim (sut/extract-agent-behavior body))]
+          result (str/trim (agent-behavior/extract-agent-behavior body))]
       (is (> (count (str/join "\n" (map step (range 1 4)))) 500)
           "fixture must actually overflow, else the trim branch isn't tested")
       (is (<= (count result) 510) "still condensed to ~500 chars")

--- a/docs/pull-requests/2026-08-09-refactor-split-policy-pack-mdc-compiler-5.md
+++ b/docs/pull-requests/2026-08-09-refactor-split-policy-pack-mdc-compiler-5.md
@@ -1,0 +1,103 @@
+<!--
+  Title: Split policy-pack mdc_compiler.clj — extract agent-behavior (5/6)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(policy-pack): split mdc_compiler.clj — extract agent-behavior (5/6)
+
+## Overview
+
+Slice 5 of the 6-PR split train for
+`components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler.clj`
+(rule 210, SL003 — 9 real layers, max 3; slices 1-4 were
+`#1729`/`#1732`/`#1733`/`#1740`). This slice extracts
+`ai.miniforge.policy-pack.mdc-compiler.agent-behavior`: the
+agent-behavior extraction chain — `behavior-condensation-target`,
+`extract-agent-behavior-section`, `extract-first-paragraph`,
+`condense-to-length`, `extract-agent-behavior`.
+
+## Motivation
+
+Re-confirmed zero external fan-in on all five moved items (grepped for
+`mdc-compiler/<fn-name>` across the repo, the corrected pattern from
+slice 4) and rebased onto latest `origin/main` before starting.
+
+**Notable finding**: the file stays at 4 real layers after this
+slice, unchanged from slice 4. `mdc->rule` sits atop two independent
+chains — this slice's agent-behavior chain, and
+`build-remediation-config`'s rule-config chain. Moving only one still
+leaves the other setting `mdc->rule`'s depth, so the SL003 count
+doesn't move until the final slice removes both. This mirrors the
+slice 1→2 pattern (moving a chain that isn't the sole bottleneck still
+reduces line count and internal complexity even when the layer number
+doesn't drop) — expected, not a regression.
+
+## Changes in Detail
+
+- New file `mdc_compiler/agent_behavior.clj`: the agent-behavior chain,
+  2 real layers (0-1), stratum-lint clean on its own.
+- `mdc_compiler.clj`: the five items removed; `mdc->rule` now calls
+  `agent-behavior/extract-agent-behavior`. Ran `stratum-lint --fix`
+  (no rewrite needed — the remaining defs' `:stratum` metadata was
+  already correct after the removal) and updated the namespace
+  docstring's layer summary — the file stays at 4 real layers; the
+  final slice (rule-config builders) is what actually collapses it to
+  budget.
+- `mdc_compiler_test.clj`: added a require for the new
+  `agent-behavior` namespace; `extract-agent-behavior-test`'s 10 call
+  sites now call `agent-behavior/extract-agent-behavior` instead of
+  `sut/extract-agent-behavior`.
+
+The parent namespace stays over budget (4 real layers) until the
+remaining slice lands; the removal commit used
+`MINIFORGE_STRATUM_BUDGET_MODE=warn`, same convention as prior slices.
+
+## Testing Plan
+
+1. `clj-kondo` clean on all touched files.
+2. stratum-lint: `agent_behavior.clj` passes SL003 outright;
+   `mdc_compiler.clj` intentionally still over budget (4 layers,
+   unchanged) — expected, see Motivation above.
+3. `ai.miniforge.policy-pack.mdc-compiler-test`: 26 tests / 159
+   assertions, 0 failures, 0 errors — unchanged from main.
+4. Full pre-commit suite (`poly:check`, lint, smoke tests, GraalVM)
+   passed on both commits.
+5. Adversarial self-review: diffed the full top-level `defn`/`def` set
+   before and after — exactly 5 relocated, 0 added/removed/altered in
+   behavior; `mdc->rule`'s body is unchanged except for the one
+   qualified call.
+
+PR size: reportable lines checked per-commit (88 for the new file, 134
+for the removal commit), both under the 200-line commit budget;
+combined well under the 600-line PR budget.
+
+## Deployment Plan
+
+Merges to `main` as part of the ongoing 6-PR train. The final slice
+rebases onto the updated `main` after this one merges and is expected
+to bring `mdc_compiler.clj` (and the whole component) within the
+rule-210 budget.
+
+## Related Issues/PRs
+
+- Slice 1: [#1729](https://github.com/miniforge-ai/miniforge/pull/1729)
+- Slice 2: [#1732](https://github.com/miniforge-ai/miniforge/pull/1732)
+- Slice 3: [#1733](https://github.com/miniforge-ai/miniforge/pull/1733)
+- Slice 4: [#1740](https://github.com/miniforge-ai/miniforge/pull/1740)
+- Precedent: [dag-orchestrator split, #1485](https://github.com/miniforge-ai/miniforge/pull/1485)
+- Precedent: [workflow-runner split, #1662](https://github.com/miniforge-ai/miniforge/pull/1662)
+- Part of the stratum-lint rule-210 remediation program (Wave 2)
+
+## Checklist
+
+- [x] Fan-in re-verified with the corrected namespace-symbol grep
+      pattern for all five moved items — none found
+- [x] Branch rebased onto latest `origin/main`
+- [x] Pure code motion — no behavior change, no logic altered
+- [x] `clj-kondo` clean
+- [x] Tests green (26/26, 159 assertions)
+- [x] Commit-diff budgets checked (88 and 134, both ≤200); PR total
+      well under 600
+- [x] `MINIFORGE_STRATUM_BUDGET_MODE=warn` used + documented for the
+      expected intermediate over-budget state


### PR DESCRIPTION
<!--
  Title: Split policy-pack mdc_compiler.clj — extract agent-behavior (5/6)
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# refactor(policy-pack): split mdc_compiler.clj — extract agent-behavior (5/6)

## Overview

Slice 5 of the 6-PR split train for
`components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler.clj`
(rule 210, SL003 — 9 real layers, max 3; slices 1-4 were
`#1729`/`#1732`/`#1733`/`#1740`). This slice extracts
`ai.miniforge.policy-pack.mdc-compiler.agent-behavior`: the
agent-behavior extraction chain — `behavior-condensation-target`,
`extract-agent-behavior-section`, `extract-first-paragraph`,
`condense-to-length`, `extract-agent-behavior`.

## Motivation

Re-confirmed zero external fan-in on all five moved items (grepped for
`mdc-compiler/<fn-name>` across the repo, the corrected pattern from
slice 4) and rebased onto latest `origin/main` before starting.

**Notable finding**: the file stays at 4 real layers after this
slice, unchanged from slice 4. `mdc->rule` sits atop two independent
chains — this slice's agent-behavior chain, and
`build-remediation-config`'s rule-config chain. Moving only one still
leaves the other setting `mdc->rule`'s depth, so the SL003 count
doesn't move until the final slice removes both. This mirrors the
slice 1→2 pattern (moving a chain that isn't the sole bottleneck still
reduces line count and internal complexity even when the layer number
doesn't drop) — expected, not a regression.

## Changes in Detail

- New file `mdc_compiler/agent_behavior.clj`: the agent-behavior chain,
  2 real layers (0-1), stratum-lint clean on its own.
- `mdc_compiler.clj`: the five items removed; `mdc->rule` now calls
  `agent-behavior/extract-agent-behavior`. Ran `stratum-lint --fix`
  (no rewrite needed — the remaining defs' `:stratum` metadata was
  already correct after the removal) and updated the namespace
  docstring's layer summary — the file stays at 4 real layers; the
  final slice (rule-config builders) is what actually collapses it to
  budget.
- `mdc_compiler_test.clj`: added a require for the new
  `agent-behavior` namespace; `extract-agent-behavior-test`'s 10 call
  sites now call `agent-behavior/extract-agent-behavior` instead of
  `sut/extract-agent-behavior`.

The parent namespace stays over budget (4 real layers) until the
remaining slice lands; the removal commit used
`MINIFORGE_STRATUM_BUDGET_MODE=warn`, same convention as prior slices.

## Testing Plan

1. `clj-kondo` clean on all touched files.
2. stratum-lint: `agent_behavior.clj` passes SL003 outright;
   `mdc_compiler.clj` intentionally still over budget (4 layers,
   unchanged) — expected, see Motivation above.
3. `ai.miniforge.policy-pack.mdc-compiler-test`: 26 tests / 159
   assertions, 0 failures, 0 errors — unchanged from main.
4. Full pre-commit suite (`poly:check`, lint, smoke tests, GraalVM)
   passed on both commits.
5. Adversarial self-review: diffed the full top-level `defn`/`def` set
   before and after — exactly 5 relocated, 0 added/removed/altered in
   behavior; `mdc->rule`'s body is unchanged except for the one
   qualified call.

PR size: reportable lines checked per-commit (88 for the new file, 134
for the removal commit), both under the 200-line commit budget;
combined well under the 600-line PR budget.

## Deployment Plan

Merges to `main` as part of the ongoing 6-PR train. The final slice
rebases onto the updated `main` after this one merges and is expected
to bring `mdc_compiler.clj` (and the whole component) within the
rule-210 budget.

## Related Issues/PRs

- Slice 1: [#1729](https://github.com/miniforge-ai/miniforge/pull/1729)
- Slice 2: [#1732](https://github.com/miniforge-ai/miniforge/pull/1732)
- Slice 3: [#1733](https://github.com/miniforge-ai/miniforge/pull/1733)
- Slice 4: [#1740](https://github.com/miniforge-ai/miniforge/pull/1740)
- Precedent: [dag-orchestrator split, #1485](https://github.com/miniforge-ai/miniforge/pull/1485)
- Precedent: [workflow-runner split, #1662](https://github.com/miniforge-ai/miniforge/pull/1662)
- Part of the stratum-lint rule-210 remediation program (Wave 2)

## Checklist

- [x] Fan-in re-verified with the corrected namespace-symbol grep
      pattern for all five moved items — none found
- [x] Branch rebased onto latest `origin/main`
- [x] Pure code motion — no behavior change, no logic altered
- [x] `clj-kondo` clean
- [x] Tests green (26/26, 159 assertions)
- [x] Commit-diff budgets checked (88 and 134, both ≤200); PR total
      well under 600
- [x] `MINIFORGE_STRATUM_BUDGET_MODE=warn` used + documented for the
      expected intermediate over-budget state
