### PR TITLE
refactor(policy-pack): split mdc_compiler.clj — extract rule-config, final slice (6/6)

### DIFF
--- a/components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler.clj
@@ -24,28 +24,26 @@
 
    Designed to be called by the ETL task (bb standards:pack) at build time.
 
-   Slice 5/6 of a rule 210 split train (SL003: this namespace measured
-   9 real layers, max 3 — same approach as the dag-orchestrator split,
-   miniforge#1485, and the workflow-runner split, miniforge#1662).
-   Slices 1-2 (miniforge#1729/#1732) moved the frontmatter grammar out;
-   slice 3 (miniforge#1733) moved the text-condensation chain out;
-   slice 4 (miniforge#1740) moved the Dewey-range chain out. This slice
-   moves agent-behavior extraction (`extract-agent-behavior-section`,
-   `extract-first-paragraph`, `condense-to-length`,
-   `extract-agent-behavior`) to `mdc-compiler.agent-behavior`. The file
-   stays at 4 real layers — `mdc->rule` sits atop TWO independent
-   chains, and moving only one (this slice) still leaves the other
-   (`build-remediation-config`'s rule-config chain) setting the depth.
-   The final slice (rule-config builders) removes that last chain and
-   brings the file to budget.
+   Final slice (6/6) of a rule 210 split train (SL003: this namespace
+   originally measured 9 real layers, max 3 — same approach as the
+   dag-orchestrator split, miniforge#1485, and the workflow-runner
+   split, miniforge#1662). Slices 1-2 (miniforge#1729/#1732) moved the
+   frontmatter grammar out; slice 3 (miniforge#1733) moved the
+   text-condensation chain out; slice 4 (miniforge#1740) moved the
+   Dewey-range chain out; slice 5 (miniforge#1742) moved agent-behavior
+   extraction out. This slice moves the remaining rule-config builders
+   (`build-exclude-context`, `build-detection-config`,
+   `valid-enforcement-actions`, `build-remediation-config`) to
+   `mdc-compiler.rule-config` — the second of the two independent
+   chains feeding `mdc->rule`. With both chains moved, this namespace
+   is now within budget at 3 real layers.
 
    Layer 0: Parsing/config primitives — group-dotted-keys,
-     build-exclude-context, build-detection-config, slug->rule-id/title,
-     format-pack-version, validate-no-duplicate-slugs, parse-mdc,
-     export-canonical-taxonomy, build-categories
-   Layer 1: build-remediation-config
-   Layer 2: mdc->rule
-   Layer 3: compile-standards-pack
+     slug->rule-id/title, normalize-globs, format-pack-version,
+     validate-no-duplicate-slugs, parse-mdc, export-canonical-taxonomy,
+     build-categories
+   Layer 1: mdc->rule
+   Layer 2: compile-standards-pack
 
    Related:
      work/designs/mdc-to-pack-field-mapping.edn — authoritative field mapping spec
@@ -55,7 +53,7 @@
    [ai.miniforge.policy-pack.mdc-compiler.agent-behavior :as agent-behavior]
    [ai.miniforge.policy-pack.mdc-compiler.dewey :as dewey]
    [ai.miniforge.policy-pack.mdc-compiler.frontmatter :as frontmatter]
-   [ai.miniforge.policy-pack.schema-types :as schema-types]
+   [ai.miniforge.policy-pack.mdc-compiler.rule-config :as rule-config]
    [ai.miniforge.policy-pack.schema-validation :as schema-validation]
    [clojure.java.io :as io]
    [clojure.string :as str]))
@@ -77,40 +75,6 @@
        (assoc acc k v)))
    {}
    fm))
-
-(defn- ^{:stratum 0} build-exclude-context
-  "Convert path/current exclude lists from MDC remediation config into
-   ExcludeContext maps for the RuleRemediation schema."
-  [remediation-map]
-  (let [path-contains    (get remediation-map "excludePathContains")
-        current-contains (get remediation-map "excludeCurrentContains")]
-    (cond-> []
-      (seq path-contains)
-      (into (mapv (fn [p] {:path-contains p}) path-contains))
-
-      (seq current-contains)
-      (conj {:current-contains (vec current-contains)}))))
-
-(defn- ^{:stratum 0} build-detection-config
-  "Build :rule/detection map from grouped frontmatter detection block.
-   Returns {:type :content-scan ...} when detection config is present,
-   {:type :custom} otherwise."
-  [detection-map]
-  (if (and detection-map (get detection-map "pattern"))
-    (cond-> {:type    :content-scan
-             :pattern (get detection-map "pattern")
-             :mode    (keyword (get detection-map "mode" "positive"))}
-      (get detection-map "emailPattern")
-      (assoc :email-pattern (get detection-map "emailPattern")))
-    {:type :custom}))
-
-(def ^{:stratum 0} ^:private valid-enforcement-actions
-  "Enforcement actions a rule may opt into via frontmatter `enforcement.action`,
-   derived from the ONE canonical source (`schema-types/enforcement-actions`) so the
-   compiler can never accept an action the rule schema rejects. `:hard-halt`
-   makes a pack-derived gate BLOCK; the rest are non-blocking. An unrecognized
-   value falls back to the alwaysApply default — a typo can't produce garbage."
-  (set schema-types/enforcement-actions))
 
 ;; Field mapping transforms
 ;; ── Filename slug → rule ID ─────────────────────────────────────────────────
@@ -229,32 +193,8 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
-(defn- ^{:stratum 1} build-remediation-config
-  "Build :rule/remediation map from grouped frontmatter remediation block.
-   Returns nil if no remediation config is present."
-  [remediation-map]
-  (when (and remediation-map (get remediation-map "strategy"))
-    (let [excludes (build-exclude-context remediation-map)]
-      (cond-> {:strategy (keyword (get remediation-map "strategy"))}
-        (get remediation-map "type")
-        (assoc :type (keyword (get remediation-map "type")))
-
-        (get remediation-map "replacement")
-        (assoc :replacement (get remediation-map "replacement"))
-
-        (get remediation-map "template")
-        (assoc :template (get remediation-map "template"))
-
-        (some? (get remediation-map "autoFixable"))
-        (assoc :auto-fixable-default (boolean (get remediation-map "autoFixable")))
-
-        (seq excludes)
-        (assoc :exclude-contexts excludes)))))
-
-;------------------------------------------------------------------------------ Layer 2
-
 ;; Rule compilation
-(defn ^{:stratum 2} mdc->rule
+(defn ^{:stratum 1} mdc->rule
   "Compile a single MDC file into a policy-pack rule map.
 
    Implements the field mapping from the design spec
@@ -288,8 +228,8 @@
                          (seq globs) (assoc :file-globs globs))
 
           ;; ── Detection & remediation ─────────────────────────────────────
-          detection    (build-detection-config (get fm "detection"))
-          remediation  (build-remediation-config (get fm "remediation"))
+          detection    (rule-config/build-detection-config (get fm "detection"))
+          remediation  (rule-config/build-remediation-config (get fm "remediation"))
 
           ;; ── Content extraction ──────────────────────────────────────────
           body-trimmed    (when-not (str/blank? body) (str/trim body))
@@ -305,7 +245,7 @@
           fm-action      (some-> enforcement-fm (get "action") str str/trim
                                  not-empty keyword)
           action         (cond
-                           (contains? valid-enforcement-actions fm-action) fm-action
+                           (contains? rule-config/valid-enforcement-actions fm-action) fm-action
                            always-apply :warn
                            :else :audit)
           ;; A rule that opts into blocking is at least :high (canonical scale).
@@ -346,9 +286,9 @@
       (merge (schema-validation/failure :rule (.getMessage e))
              {:filename filename}))))
 
-;------------------------------------------------------------------------------ Layer 3
+;------------------------------------------------------------------------------ Layer 2
 
-(defn ^{:stratum 3} compile-standards-pack
+(defn ^{:stratum 2} compile-standards-pack
   "Compile all .mdc files from a standards directory into a pack manifest.
 
    Discovers all .mdc files recursively, compiles each via mdc->rule,

--- a/components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler/rule_config.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler/rule_config.clj
@@ -1,0 +1,93 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.mdc-compiler.rule-config
+  "Rule-level config builders: detection config, remediation config
+   (and its exclude-context lists), and the canonical set of
+   frontmatter-opt-in enforcement actions. Split out of
+   `ai.miniforge.policy-pack.mdc-compiler` (rule 210: slice 6/6, the
+   final slice of the split train started in
+   `mdc-compiler.frontmatter-values`/`mdc-compiler.frontmatter`/
+   `mdc-compiler.condense`/`mdc-compiler.dewey`/`mdc-compiler.agent-behavior`,
+   miniforge#1729/#1732/#1733/#1740/#1742 — same approach as the
+   dag-orchestrator split, miniforge#1485, and the workflow-runner
+   split, miniforge#1662). This was the second of the two independent
+   chains feeding `mdc->rule`; removing it (the agent-behavior chain
+   having already moved in slice 5) brings the parent namespace to
+   budget."
+  (:require
+   [ai.miniforge.policy-pack.schema-types :as schema-types]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} build-exclude-context
+  "Convert path/current exclude lists from MDC remediation config into
+   ExcludeContext maps for the RuleRemediation schema."
+  [remediation-map]
+  (let [path-contains    (get remediation-map "excludePathContains")
+        current-contains (get remediation-map "excludeCurrentContains")]
+    (cond-> []
+      (seq path-contains)
+      (into (mapv (fn [p] {:path-contains p}) path-contains))
+
+      (seq current-contains)
+      (conj {:current-contains (vec current-contains)}))))
+
+(defn ^{:stratum 0} build-detection-config
+  "Build :rule/detection map from grouped frontmatter detection block.
+   Returns {:type :content-scan ...} when detection config is present,
+   {:type :custom} otherwise."
+  [detection-map]
+  (if (and detection-map (get detection-map "pattern"))
+    (cond-> {:type    :content-scan
+             :pattern (get detection-map "pattern")
+             :mode    (keyword (get detection-map "mode" "positive"))}
+      (get detection-map "emailPattern")
+      (assoc :email-pattern (get detection-map "emailPattern")))
+    {:type :custom}))
+
+(def ^{:stratum 0} valid-enforcement-actions
+  "Enforcement actions a rule may opt into via frontmatter `enforcement.action`,
+   derived from the ONE canonical source (`schema-types/enforcement-actions`) so the
+   compiler can never accept an action the rule schema rejects. `:hard-halt`
+   makes a pack-derived gate BLOCK; the rest are non-blocking. An unrecognized
+   value falls back to the alwaysApply default — a typo can't produce garbage."
+  (set schema-types/enforcement-actions))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} build-remediation-config
+  "Build :rule/remediation map from grouped frontmatter remediation block.
+   Returns nil if no remediation config is present."
+  [remediation-map]
+  (when (and remediation-map (get remediation-map "strategy"))
+    (let [excludes (build-exclude-context remediation-map)]
+      (cond-> {:strategy (keyword (get remediation-map "strategy"))}
+        (get remediation-map "type")
+        (assoc :type (keyword (get remediation-map "type")))
+
+        (get remediation-map "replacement")
+        (assoc :replacement (get remediation-map "replacement"))
+
+        (get remediation-map "template")
+        (assoc :template (get remediation-map "template"))
+
+        (some? (get remediation-map "autoFixable"))
+        (assoc :auto-fixable-default (boolean (get remediation-map "autoFixable")))
+
+        (seq excludes)
+        (assoc :exclude-contexts excludes)))))

--- a/docs/pull-requests/2026-08-09-refactor-split-policy-pack-mdc-compiler-6.md
+++ b/docs/pull-requests/2026-08-09-refactor-split-policy-pack-mdc-compiler-6.md
@@ -1,0 +1,117 @@
+<!--
+  Title: Split policy-pack mdc_compiler.clj — extract rule-config, final slice (6/6)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(policy-pack): split mdc_compiler.clj — extract rule-config, final slice (6/6)
+
+## Overview
+
+Final slice (6/6) of the split train for
+`components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler.clj`
+(rule 210, SL003 — originally 9 real layers, max 3; slices 1-5 were
+`#1729`/`#1732`/`#1733`/`#1740`/`#1742`). This slice extracts
+`ai.miniforge.policy-pack.mdc-compiler.rule-config`: the rule-level
+config builders — `build-exclude-context`, `build-detection-config`,
+`valid-enforcement-actions`, `build-remediation-config`.
+
+## Motivation
+
+Re-confirmed zero external fan-in on all four moved items and rebased
+onto latest `origin/main` before starting.
+
+This was the second of the two independent chains feeding `mdc->rule`
+(slice 5 moved the agent-behavior chain; this slice moves the
+rule-config chain). With both gone, `mdc_compiler.clj` drops from 4 to
+**3 real layers — within the rule 210 budget.** stratum-lint is clean
+on this file with no `MINIFORGE_STRATUM_BUDGET_MODE` override needed
+for the first time in this train.
+
+A repo-wide sweep confirms the target and every sibling file this
+train created are clean:
+
+```text
+$ stratum-lint components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler.clj \
+                components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler/
+(0 findings)
+```
+
+(A component-wide sweep of all of `policy-pack` turns up several
+*other* files over budget — `compiler.clj`, `detection.clj`,
+`external.clj`, `intent.clj`, `loader.clj`, `mapping.clj`,
+`registry.clj`, `repair.clj`, `rules/pack_dependency_validation.clj`,
+`taxonomy.clj` — all out of scope for this train, which was
+`mdc_compiler.clj`-only.)
+
+## Changes in Detail
+
+- New file `mdc_compiler/rule_config.clj`: the rule-config builders, 2
+  real layers (0-1), stratum-lint clean on its own.
+- `mdc_compiler.clj`: the four items removed; `mdc->rule` now calls
+  `rule-config/build-detection-config`, `rule-config/build-remediation-config`,
+  and `rule-config/valid-enforcement-actions`. Ran `stratum-lint --fix`
+  to renumber headings/`:stratum` metadata and rewrote the namespace
+  docstring's layer summary to reflect the completed train.
+- No test file changes: none of the four extracted items had direct
+  test coverage in `mdc_compiler_test.clj` (exercised only indirectly
+  through `mdc->rule`, whose tests are unaffected).
+
+## Testing Plan
+
+1. `clj-kondo` clean on both touched files.
+2. stratum-lint: `rule_config.clj` passes SL003 outright;
+   `mdc_compiler.clj` **passes SL003 outright too** — 3 real layers,
+   within budget. First clean commit in this train, no
+   `MINIFORGE_STRATUM_BUDGET_MODE` override.
+3. `ai.miniforge.policy-pack.mdc-compiler-test`: 26 tests / 159
+   assertions, 0 failures, 0 errors — unchanged from main.
+4. `ai.miniforge.policy-pack.taxonomy-test` (exercises the slice-4
+   `export-canonical-taxonomy` delegating var, untouched by this
+   slice): 10 tests / 39 assertions, 0 failures, 0 errors.
+5. `ai.miniforge.policy-pack.interface-test`: 14 tests / 69 assertions,
+   0 failures, 0 errors.
+6. Full pre-commit suite (`poly:check`, lint, smoke tests, GraalVM)
+   passed on both commits.
+7. Adversarial self-review: diffed the full top-level `defn`/`def` set
+   before and after — exactly 4 relocated, 0 added/removed/altered in
+   behavior; `mdc->rule`'s body is unchanged except for the three
+   qualified calls.
+
+PR size: reportable lines checked per-commit (63 for the new file, 97
+for the removal commit), both under the 200-line commit budget;
+combined well under the 600-line PR budget.
+
+## Deployment Plan
+
+Merges to `main`, completing the 6-PR split train.
+`components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler.clj`
+and every namespace this train created
+(`mdc-compiler.frontmatter-values`, `mdc-compiler.frontmatter`,
+`mdc-compiler.condense`, `mdc-compiler.dewey`,
+`mdc-compiler.agent-behavior`, `mdc-compiler.rule-config`) are within
+the rule 210 3-layer budget.
+
+## Related Issues/PRs
+
+- Slice 1: [#1729](https://github.com/miniforge-ai/miniforge/pull/1729)
+- Slice 2: [#1732](https://github.com/miniforge-ai/miniforge/pull/1732)
+- Slice 3: [#1733](https://github.com/miniforge-ai/miniforge/pull/1733)
+- Slice 4: [#1740](https://github.com/miniforge-ai/miniforge/pull/1740)
+- Slice 5: [#1742](https://github.com/miniforge-ai/miniforge/pull/1742)
+- Precedent: [dag-orchestrator split, #1485](https://github.com/miniforge-ai/miniforge/pull/1485)
+- Precedent: [workflow-runner split, #1662](https://github.com/miniforge-ai/miniforge/pull/1662)
+- Part of the stratum-lint rule-210 remediation program (Wave 2)
+
+## Checklist
+
+- [x] Fan-in re-verified with the corrected namespace-symbol grep
+      pattern for all four moved items — none found
+- [x] Branch rebased onto latest `origin/main`
+- [x] Pure code motion — no behavior change, no logic altered
+- [x] `clj-kondo` clean
+- [x] Tests green (mdc-compiler 26/26, taxonomy 10/10, interface 14/14)
+- [x] Commit-diff budgets checked (63 and 97, both ≤200); PR total
+      well under 600
+- [x] stratum-lint clean on `mdc_compiler.clj` with NO budget-mode
+      override — train complete


### PR DESCRIPTION
<!--
  Title: Split policy-pack mdc_compiler.clj — extract rule-config, final slice (6/6)
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# refactor(policy-pack): split mdc_compiler.clj — extract rule-config, final slice (6/6)

## Overview

Final slice (6/6) of the split train for
`components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler.clj`
(rule 210, SL003 — originally 9 real layers, max 3; slices 1-5 were
`#1729`/`#1732`/`#1733`/`#1740`/`#1742`). This slice extracts
`ai.miniforge.policy-pack.mdc-compiler.rule-config`: the rule-level
config builders — `build-exclude-context`, `build-detection-config`,
`valid-enforcement-actions`, `build-remediation-config`.

## Motivation

Re-confirmed zero external fan-in on all four moved items and rebased
onto latest `origin/main` before starting.

This was the second of the two independent chains feeding `mdc->rule`
(slice 5 moved the agent-behavior chain; this slice moves the
rule-config chain). With both gone, `mdc_compiler.clj` drops from 4 to
**3 real layers — within the rule 210 budget.** stratum-lint is clean
on this file with no `MINIFORGE_STRATUM_BUDGET_MODE` override needed
for the first time in this train.

A repo-wide sweep confirms the target and every sibling file this
train created are clean:

```text
$ stratum-lint components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler.clj \
                components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler/
(0 findings)
```

(A component-wide sweep of all of `policy-pack` turns up several
*other* files over budget — `compiler.clj`, `detection.clj`,
`external.clj`, `intent.clj`, `loader.clj`, `mapping.clj`,
`registry.clj`, `repair.clj`, `rules/pack_dependency_validation.clj`,
`taxonomy.clj` — all out of scope for this train, which was
`mdc_compiler.clj`-only.)

## Changes in Detail

- New file `mdc_compiler/rule_config.clj`: the rule-config builders, 2
  real layers (0-1), stratum-lint clean on its own.
- `mdc_compiler.clj`: the four items removed; `mdc->rule` now calls
  `rule-config/build-detection-config`, `rule-config/build-remediation-config`,
  and `rule-config/valid-enforcement-actions`. Ran `stratum-lint --fix`
  to renumber headings/`:stratum` metadata and rewrote the namespace
  docstring's layer summary to reflect the completed train.
- No test file changes: none of the four extracted items had direct
  test coverage in `mdc_compiler_test.clj` (exercised only indirectly
  through `mdc->rule`, whose tests are unaffected).

## Testing Plan

1. `clj-kondo` clean on both touched files.
2. stratum-lint: `rule_config.clj` passes SL003 outright;
   `mdc_compiler.clj` **passes SL003 outright too** — 3 real layers,
   within budget. First clean commit in this train, no
   `MINIFORGE_STRATUM_BUDGET_MODE` override.
3. `ai.miniforge.policy-pack.mdc-compiler-test`: 26 tests / 159
   assertions, 0 failures, 0 errors — unchanged from main.
4. `ai.miniforge.policy-pack.taxonomy-test` (exercises the slice-4
   `export-canonical-taxonomy` delegating var, untouched by this
   slice): 10 tests / 39 assertions, 0 failures, 0 errors.
5. `ai.miniforge.policy-pack.interface-test`: 14 tests / 69 assertions,
   0 failures, 0 errors.
6. Full pre-commit suite (`poly:check`, lint, smoke tests, GraalVM)
   passed on both commits.
7. Adversarial self-review: diffed the full top-level `defn`/`def` set
   before and after — exactly 4 relocated, 0 added/removed/altered in
   behavior; `mdc->rule`'s body is unchanged except for the three
   qualified calls.

PR size: reportable lines checked per-commit (63 for the new file, 97
for the removal commit), both under the 200-line commit budget;
combined well under the 600-line PR budget.

## Deployment Plan

Merges to `main`, completing the 6-PR split train.
`components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler.clj`
and every namespace this train created
(`mdc-compiler.frontmatter-values`, `mdc-compiler.frontmatter`,
`mdc-compiler.condense`, `mdc-compiler.dewey`,
`mdc-compiler.agent-behavior`, `mdc-compiler.rule-config`) are within
the rule 210 3-layer budget.

## Related Issues/PRs

- Slice 1: [#1729](https://github.com/miniforge-ai/miniforge/pull/1729)
- Slice 2: [#1732](https://github.com/miniforge-ai/miniforge/pull/1732)
- Slice 3: [#1733](https://github.com/miniforge-ai/miniforge/pull/1733)
- Slice 4: [#1740](https://github.com/miniforge-ai/miniforge/pull/1740)
- Slice 5: [#1742](https://github.com/miniforge-ai/miniforge/pull/1742)
- Precedent: [dag-orchestrator split, #1485](https://github.com/miniforge-ai/miniforge/pull/1485)
- Precedent: [workflow-runner split, #1662](https://github.com/miniforge-ai/miniforge/pull/1662)
- Part of the stratum-lint rule-210 remediation program (Wave 2)

## Checklist

- [x] Fan-in re-verified with the corrected namespace-symbol grep
      pattern for all four moved items — none found
- [x] Branch rebased onto latest `origin/main`
- [x] Pure code motion — no behavior change, no logic altered
- [x] `clj-kondo` clean
- [x] Tests green (mdc-compiler 26/26, taxonomy 10/10, interface 14/14)
- [x] Commit-diff budgets checked (63 and 97, both ≤200); PR total
      well under 600
- [x] stratum-lint clean on `mdc_compiler.clj` with NO budget-mode
      override — train complete
