### PR TITLE
fix(content-hash): normalize instants by type — an Instant made content-hash non-deterministic

### DIFF
--- a/components/content-hash/src/ai/miniforge/content_hash/core.clj
+++ b/components/content-hash/src/ai/miniforge/content_hash/core.clj
@@ -135,13 +135,21 @@
    component exists to provide: hashing one evidence bundle twice gave
    two digests.
 
-   Anything else `inst?` might admit throws rather than being hashed
-   under a rendering nothing has checked — the same refusal the `->iso`
-   helpers in effect-transaction and policy-pack make. An
-   `IllegalArgumentException` rather than their `ex-info`: the branch is
-   an exhaustive match over the types `inst?` admits, so reaching it is
-   a programmer error, which is the guard rule 005 names — and this
-   component carries no dependencies, so `throw+` is not on the table."
+   Anything else throws rather than being hashed under a rendering
+   nothing has checked — the same refusal the `->iso` helpers in
+   effect-transaction and policy-pack make.
+
+   `inst?` is open, not a closed pair: it is satisfied by any
+   `clojure.core/Inst` implementation, and this namespace's own test
+   builds one to prove the refusal fires. So the two branches below
+   are exhaustive over the types actually SUPPORTED — the two the JDK
+   and Clojure's own readers produce — rather than over everything
+   `inst?` will say yes to. Reaching the third branch means a caller
+   handed a timestamp representation nobody here has a rendering for,
+   which is the programmer error rule 005 names, hence
+   `IllegalArgumentException` rather than the siblings' `ex-info`; this
+   component also carries no dependencies, so `throw+` is not on the
+   table."
   [v]
   (let [^Instant i (cond
                      (instance? Instant v) v
@@ -228,9 +236,14 @@
   "Return a deterministic EDN string for `x`.
 
    Maps are emitted with keys sorted under a stable comparator; sets are
-   sorted; sequential collections preserve order. The output is suitable as
-   input to a content hash because logically equal values produce identical
-   strings regardless of original insertion order."
+   sorted; sequential collections preserve order; instants render as
+   `#inst` literals. The output is suitable as input to a content hash
+   because logically equal values produce identical strings regardless
+   of original insertion order.
+
+   Throws `IllegalArgumentException` on an unsupported `inst?` type, and
+   on a map or set whose entries would collapse onto one instant — see
+   `inst->literal` and `refuse-collapse!`."
   [x]
   (pr-str (->canonical x)))
 
@@ -241,6 +254,8 @@
 
    Returns a lowercase 64-character hex string. Logically equal values
    (e.g. maps with identical keys/values regardless of insertion order)
-   produce identical hashes."
+   produce identical hashes.
+
+   Throws whatever `canonical-edn` throws — it is the same walk."
   [x]
   (sha256-hex (canonical-edn x)))

--- a/components/content-hash/src/ai/miniforge/content_hash/core.clj
+++ b/components/content-hash/src/ai/miniforge/content_hash/core.clj
@@ -160,13 +160,19 @@
    rendering moves.
 
    A map holding two instant keys for the same moment — one `Instant`,
-   one `Date` — is refused. They are two distinct keys to Clojure but
-   one key once normalized, so one entry would overwrite the other and
-   which one survived would follow the source map's iteration order:
-   `{i :a, d :b}` and `{d :b, i :a}` are `=`, and would hash
-   differently. Refusing keeps the guarantee in `canonical-edn`'s
-   docstring — equal inputs, equal output — rather than dropping an
-   entry quietly.
+   one `Date` — is refused, and so is a set holding two such elements.
+   They are two distinct keys (or elements) to Clojure but one once
+   normalized, so one would quietly swallow the other. In a map, which
+   one survived would follow the source map's iteration order:
+   `{i :a, d :b}` and `{d :b, i :a}` are `=` and would hash
+   differently. In a set it is worse — `#{i d}` and `#{i}` are distinct
+   values that would produce the identical digest. Refusing keeps both
+   halves of `canonical-edn`'s contract: equal inputs give equal
+   output, and distinct inputs do not silently converge.
+
+   Both checks are scoped to values normalization actually rewrote, so
+   the pre-existing collapse of distinct-but-comparator-equal entries
+   (`{1 :a 1.0 :b}`, `#{1 1.0}`) is left exactly as it was.
 
    One self-recursive walk, replacing the mutually-recursive
    `->canonical`/`canonicalize-map`/`canonicalize-coll` trio that
@@ -191,7 +197,15 @@
                         (assoc acc k' (->canonical v))))
                     (sorted-map-by canonical-compare)
                     x)
-    (set? x)       (into (sorted-set-by canonical-compare) (map ->canonical) x)
+    (set? x)       (let [normalized (mapv ->canonical x)]
+                     ;; (set normalized) uses `=`, not the comparator, so
+                     ;; only a normalization-induced collapse shrinks it —
+                     ;; `#{1 1.0}` stays two here and keeps its old
+                     ;; comparator-driven behavior below.
+                     (when (< (count (set normalized)) (count x))
+                       (throw (IllegalArgumentException.
+                               "Set has two instant elements for one moment")))
+                     (into (sorted-set-by canonical-compare) normalized))
     (map-entry? x) [(->canonical (key x)) (->canonical (val x))]
     (coll? x)      (mapv ->canonical x)
     (inst? x)      (inst->literal x)

--- a/components/content-hash/src/ai/miniforge/content_hash/core.clj
+++ b/components/content-hash/src/ai/miniforge/content_hash/core.clj
@@ -116,26 +116,31 @@
     :else 10))
 
 (defn- ^{:stratum 0} refuse-collapse!
-  "Throw when normalization merged two entries of a sorted container.
+  "Throw when instant normalization merged two entries of a container.
 
-   Compared under `=`, not under `canonical-compare`. Only instant
-   normalization can map two distinct values onto one — every other
-   branch of `->canonical` is injective — so a shortfall here is always
-   an `Instant`/`Date`/`#inst`-literal ambiguity and never the
-   comparator collapsing `1` and `1.0`, which predates this namespace's
-   instant handling and is left exactly as it was.
+   Only `#inst` literals are considered, and they are compared under
+   `=`. Narrowing to them is what keeps this from firing on a collision
+   this namespace did not cause: `mapv` renders a list and a vector of
+   the same items to one vector, so a container whose own comparator is
+   inconsistent with `=` — a `sorted-set-by` ordering `[1 2]` before
+   `(1 2)`, say — can hold two entries that normalize alike for reasons
+   that have nothing to do with timestamps. That collapsed silently
+   before this namespace handled instants and still does.
 
-   Checking the normalized values rather than which inputs got rewritten
-   is what catches a caller who already holds an `#inst` literal: that
-   key is not rewritten, so a guard keyed on rewriting would let it
-   silently overwrite an `Instant` for the same moment, or not, by
-   iteration order."
+   Checking normalized values rather than which inputs got rewritten is
+   what catches a caller who already holds an `#inst` literal: that key
+   is not rewritten, so a guard keyed on rewriting would let it silently
+   overwrite an `Instant` for the same moment, or not, by iteration
+   order. The literal test is inlined for the reason given on
+   `type-rank` — naming it would cost a layer on a file already over
+   the SL003 budget."
   [what normalized]
-  (when-let [dup (some (fn [[v n]] (when (> n 1) v)) (frequencies normalized))]
-    (throw (IllegalArgumentException.
-            ;; pr-str, not str: a TaggedLiteral's toString is its identity
-            ;; hash — the very thing this namespace exists to keep out.
-            (str what " that normalize to one instant: " (pr-str dup))))))
+  (let [insts (filterv #(and (tagged-literal? %) (= 'inst (:tag %))) normalized)]
+    (when-let [dup (some (fn [[v n]] (when (> n 1) v)) (frequencies insts))]
+      (throw (IllegalArgumentException.
+              ;; pr-str, not str: a TaggedLiteral's toString is its identity
+              ;; hash — the very thing this namespace exists to keep out.
+              (str what " that normalize to one instant: " (pr-str dup)))))))
 
 ;------------------------------------------------------------------------------ Layer 1
 
@@ -219,9 +224,10 @@
 
    Both containers detect that through `refuse-collapse!`, which
    compares the NORMALIZED values rather than which inputs were
-   rewritten — see its docstring for why the difference matters. The
-   pre-existing collapse of distinct-but-comparator-equal entries
-   (`{1 :a 1.0 :b}`, `#{1 1.0}`) is left exactly as it was.
+   rewritten, and looks only at `#inst` literals — see its docstring
+   for why each half matters. Every other collapse this walk can
+   produce is left exactly as it was, silent: the comparator equating
+   `1` and `1.0`, and `mapv` rendering a list and a vector alike.
 
    One self-recursive walk, replacing the mutually-recursive
    `->canonical`/`canonicalize-map`/`canonicalize-coll` trio that

--- a/components/content-hash/src/ai/miniforge/content_hash/core.clj
+++ b/components/content-hash/src/ai/miniforge/content_hash/core.clj
@@ -26,8 +26,8 @@
    `inst->literal`."
   (:import
    [java.time Instant ZoneOffset]
-   [java.time.format DateTimeFormatter]
-   [java.util Date]))
+   [java.time.format DateTimeFormatter DecimalStyle]
+   [java.util Date Locale]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -39,9 +39,15 @@
    era, so 1 BC and 2 AD both print `0002` — two distinct instants
    collapsing to one digest, which is the defect this namespace exists
    to keep out. `uuuu` is the proleptic year and is identical for every
-   AD year."
-  (.withZone (DateTimeFormatter/ofPattern "uuuu-MM-dd'T'HH:mm:ss")
-             ZoneOffset/UTC))
+   AD year.
+
+   Locale and decimal style are pinned. `ofPattern` otherwise captures
+   `Locale/getDefault` at load time, and a locale whose numbering system
+   is not `latn` renders non-ASCII digits — which would make a content
+   hash depend on the machine that computed it."
+  (-> (DateTimeFormatter/ofPattern "uuuu-MM-dd'T'HH:mm:ss" Locale/ROOT)
+      (.withZone ZoneOffset/UTC)
+      (.withDecimalStyle DecimalStyle/STANDARD)))
 
 (defn- ^{:stratum 0} inst-fraction
   "Fractional-seconds digits for `nanos`.
@@ -56,12 +62,23 @@
 
    Six or nine digits only when finer precision is present:
    `Instant/now` carries microseconds on current JVMs, and truncating
-   them would let distinct instants collide."
+   them would let distinct instants collide.
+
+   `String/format` under `Locale/ROOT`, never `clojure.core/format`,
+   which uses the default locale: under a numbering system such as
+   `hi-IN-u-nu-deva` the padded digits come back Devanagari and the
+   digest changes with the machine. Demonstrated, not assumed —
+   `rendering-is-locale-independent` pins it."
   ^String [nanos]
   (cond
-    (zero? (rem nanos 1000000)) (format "%03d" (quot nanos 1000000))
-    (zero? (rem nanos 1000))    (format "%06d" (quot nanos 1000))
-    :else                       (format "%09d" nanos)))
+    (zero? (rem nanos 1000000))
+    (String/format Locale/ROOT "%03d" (object-array [(quot nanos 1000000)]))
+
+    (zero? (rem nanos 1000))
+    (String/format Locale/ROOT "%06d" (object-array [(quot nanos 1000)]))
+
+    :else
+    (String/format Locale/ROOT "%09d" (object-array [nanos]))))
 
 ;; SHA-256 digest
 (defn- ^{:stratum 0} sha256-hex

--- a/components/content-hash/src/ai/miniforge/content_hash/core.clj
+++ b/components/content-hash/src/ai/miniforge/content_hash/core.clj
@@ -15,20 +15,74 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.content-hash.core
   "Implementation of content hashing primitives.
 
    Domain-free: no SDLC, workflow, or evidence schema is referenced here.
    Computes a canonical EDN serialization (with deterministically ordered map
-   keys) and a SHA-256 digest over that serialization.")
+   keys) and a SHA-256 digest over that serialization.
+
+   Instants are normalized by ACTUAL type before serialization — see
+   `inst->literal`."
+  (:import
+   [java.time Instant ZoneOffset]
+   [java.time.format DateTimeFormatter]
+   [java.util Date]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Comparator
 
-(defn- type-rank
+;; Instants
+(def ^{:stratum 0} ^:private inst-seconds
+  "Whole-second half of an `#inst` literal, rendered in UTC.
+
+   `uuuu`, not `yyyy`. `yyyy` is year-of-era and renders without the
+   era, so 1 BC and 2 AD both print `0002` — two distinct instants
+   collapsing to one digest, which is the defect this namespace exists
+   to keep out. `uuuu` is the proleptic year and is identical for every
+   AD year."
+  (.withZone (DateTimeFormatter/ofPattern "uuuu-MM-dd'T'HH:mm:ss")
+             ZoneOffset/UTC))
+
+(defn- ^{:stratum 0} inst-fraction
+  "Fractional-seconds digits for `nanos`.
+
+   Three when the value is millisecond-aligned — the width
+   `java.util.Date` prints — so a Date renders byte-identically to what
+   it did before instants were normalized here and every hash computed
+   over one still holds. That holds across the Gregorian range, which
+   is every timestamp a caller will hold; `Date` renders pre-1582 dates
+   on the Julian calendar and omits the ISO `+` past year 9999, so it
+   disagrees with ISO-8601 there and those two hashes do move.
+
+   Six or nine digits only when finer precision is present:
+   `Instant/now` carries microseconds on current JVMs, and truncating
+   them would let distinct instants collide."
+  ^String [nanos]
+  (cond
+    (zero? (rem nanos 1000000)) (format "%03d" (quot nanos 1000000))
+    (zero? (rem nanos 1000))    (format "%06d" (quot nanos 1000))
+    :else                       (format "%09d" nanos)))
+
+;; SHA-256 digest
+(defn- ^{:stratum 0} sha256-hex
+  "Compute the SHA-256 digest of the given UTF-8 string and return it as a
+   lowercase hex string (64 characters)."
+  [s]
+  (let [digest (java.security.MessageDigest/getInstance "SHA-256")
+        bytes  (.digest digest (.getBytes ^String s "UTF-8"))]
+    (apply str (map #(format "%02x" %) bytes))))
+
+;; Comparator
+(defn- ^{:stratum 0} type-rank
   "Rank disparate map-key types so canonical EDN can sort heterogeneous keys
-   without throwing. Lower ranks sort first."
+   without throwing. Lower ranks sort first.
+
+   A normalized instant ranks where a raw Date used to, so a map keyed
+   by timestamps sorts exactly as it did before normalization. The raw
+   Date and Instant ranks stay as defense for direct comparator use;
+   `->canonical` no longer reaches them. The `#inst` test is inlined
+   rather than named so this stays a leaf — a named predicate would
+   push every layer above it up one, on a file already over budget."
   [x]
   (cond
     (nil? x) 0
@@ -40,10 +94,46 @@
     (symbol? x) 6
     (uuid? x) 7
     (instance? java.util.Date x) 8
+    (and (tagged-literal? x) (= 'inst (:tag x))) 8
     (instance? java.time.Instant x) 9
     :else 10))
 
-(defn- canonical-compare
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} inst->literal
+  "An instant as an `#inst` tagged literal, dispatched on ACTUAL type.
+
+   `clojure.core/inst?` admits BOTH `java.time.Instant` and
+   `java.util.Date`, and `pr-str` — which renders the canonical EDN —
+   treats them as unrelated. A Date prints readable `#inst \"…\"`. An
+   Instant prints `#object[java.time.Instant 0x1f2e3d4c \"…\"]`, which
+   is not readable EDN and embeds the object's identity hash — so the
+   same instant rendered differently on every call, making
+   `content-hash` non-deterministic. That is the one property the
+   component exists to provide: hashing one evidence bundle twice gave
+   two digests.
+
+   Anything else `inst?` might admit throws rather than being hashed
+   under a rendering nothing has checked — the same refusal the `->iso`
+   helpers in effect-transaction and policy-pack make. An
+   `IllegalArgumentException` rather than their `ex-info`: the branch is
+   an exhaustive match over the types `inst?` admits, so reaching it is
+   a programmer error, which is the guard rule 005 names — and this
+   component carries no dependencies, so `throw+` is not on the table."
+  [v]
+  (let [^Instant i (cond
+                     (instance? Instant v) v
+                     (instance? Date v)    (.toInstant ^Date v)
+                     :else
+                     (throw (IllegalArgumentException.
+                             (str "Not a supported instant type: "
+                                  (some-> v class .getName)))))]
+    (tagged-literal 'inst (str (.format inst-seconds i)
+                               "."
+                               (inst-fraction (.getNano i))
+                               "-00:00"))))
+
+(defn- ^{:stratum 1} canonical-compare
   "Total-order comparator for canonical EDN. Same-type values use natural
    compare; cross-type values fall back to string representation comparison
    under a stable type rank."
@@ -57,45 +147,42 @@
         (catch Exception _
           (compare (pr-str a) (pr-str b)))))))
 
-;------------------------------------------------------------------------------ Layer 1
+;------------------------------------------------------------------------------ Layer 2
+
 ;; Canonical EDN
-
-(declare ->canonical)
-
-(defn- canonicalize-entry
-  "Canonicalize the value of a key/value pair, leaving the key unchanged."
-  [[k v]]
-  [k (->canonical v)])
-
-(defn- canonicalize-map
-  "Recursively canonicalize a map by sorting keys and canonicalizing values."
-  [m]
-  (into (sorted-map-by canonical-compare)
-        (map canonicalize-entry)
-        m))
-
-(defn- canonicalize-coll
-  "Recursively canonicalize a non-map collection by canonicalizing each
-   element. Order is preserved for sequential collections; sets are sorted
-   under the canonical comparator."
-  [c]
-  (cond
-    (set? c) (into (sorted-set-by canonical-compare)
-                   (map ->canonical)
-                   c)
-    (map-entry? c) [(->canonical (key c)) (->canonical (val c))]
-    :else (mapv ->canonical c)))
-
-(defn- ->canonical
+(defn- ^{:stratum 2} ->canonical
   "Walk a value into a canonical form: maps become sorted-maps, sets become
-   sorted-sets, sequential collections become vectors. Scalars pass through."
+   sorted-sets, sequential collections become vectors, instants become
+   `#inst` literals. Other scalars pass through.
+
+   Map keys are canonicalized only when they are instants; every other
+   key is left exactly as it was, so no existing map's ordering or
+   rendering moves.
+
+   One self-recursive walk, replacing the mutually-recursive
+   `->canonical`/`canonicalize-map`/`canonicalize-coll` trio that
+   referred to each other through a `declare`. Stratum-lint reports
+   that as SL007 — a reference cycle no layer ordering can express and
+   `--fix` cannot resolve, so the file was uncommittable while it
+   stood. Same tests in the same order, so behavior is unchanged;
+   `map-entry?` precedes `coll?`, and `set?` precedes both, because a
+   map entry and a set are also collections."
   [x]
   (cond
-    (map? x) (canonicalize-map x)
-    (coll? x) (canonicalize-coll x)
-    :else x))
+    (map? x)       (into (sorted-map-by canonical-compare)
+                         (map (fn [[k v]]
+                                [(if (inst? k) (inst->literal k) k)
+                                 (->canonical v)]))
+                         x)
+    (set? x)       (into (sorted-set-by canonical-compare) (map ->canonical) x)
+    (map-entry? x) [(->canonical (key x)) (->canonical (val x))]
+    (coll? x)      (mapv ->canonical x)
+    (inst? x)      (inst->literal x)
+    :else          x))
 
-(defn canonical-edn
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} canonical-edn
   "Return a deterministic EDN string for `x`.
 
    Maps are emitted with keys sorted under a stable comparator; sets are
@@ -105,18 +192,9 @@
   [x]
   (pr-str (->canonical x)))
 
-;------------------------------------------------------------------------------ Layer 2
-;; SHA-256 digest
+;------------------------------------------------------------------------------ Layer 4
 
-(defn- sha256-hex
-  "Compute the SHA-256 digest of the given UTF-8 string and return it as a
-   lowercase hex string (64 characters)."
-  [s]
-  (let [digest (java.security.MessageDigest/getInstance "SHA-256")
-        bytes  (.digest digest (.getBytes ^String s "UTF-8"))]
-    (apply str (map #(format "%02x" %) bytes))))
-
-(defn content-hash
+(defn ^{:stratum 4} content-hash
   "Compute the SHA-256 digest of the canonical EDN of `x`.
 
    Returns a lowercase 64-character hex string. Logically equal values

--- a/components/content-hash/src/ai/miniforge/content_hash/core.clj
+++ b/components/content-hash/src/ai/miniforge/content_hash/core.clj
@@ -159,6 +159,15 @@
    key is left exactly as it was, so no existing map's ordering or
    rendering moves.
 
+   A map holding two instant keys for the same moment — one `Instant`,
+   one `Date` — is refused. They are two distinct keys to Clojure but
+   one key once normalized, so one entry would overwrite the other and
+   which one survived would follow the source map's iteration order:
+   `{i :a, d :b}` and `{d :b, i :a}` are `=`, and would hash
+   differently. Refusing keeps the guarantee in `canonical-edn`'s
+   docstring — equal inputs, equal output — rather than dropping an
+   entry quietly.
+
    One self-recursive walk, replacing the mutually-recursive
    `->canonical`/`canonicalize-map`/`canonicalize-coll` trio that
    referred to each other through a `declare`. Stratum-lint reports
@@ -169,11 +178,19 @@
    map entry and a set are also collections."
   [x]
   (cond
-    (map? x)       (into (sorted-map-by canonical-compare)
-                         (map (fn [[k v]]
-                                [(if (inst? k) (inst->literal k) k)
-                                 (->canonical v)]))
-                         x)
+    (map? x)       (reduce-kv
+                    (fn [acc k v]
+                      (let [k' (if (inst? k) (inst->literal k) k)]
+                        (when (and (not (identical? k' k)) (contains? acc k'))
+                          ;; pr-str, not str: a TaggedLiteral's toString is
+                          ;; its identity hash — the very thing this
+                          ;; namespace exists to keep out of output.
+                          (throw (IllegalArgumentException.
+                                  (str "Map has two instant keys for one moment: "
+                                       (pr-str k')))))
+                        (assoc acc k' (->canonical v))))
+                    (sorted-map-by canonical-compare)
+                    x)
     (set? x)       (into (sorted-set-by canonical-compare) (map ->canonical) x)
     (map-entry? x) [(->canonical (key x)) (->canonical (val x))]
     (coll? x)      (mapv ->canonical x)

--- a/components/content-hash/src/ai/miniforge/content_hash/core.clj
+++ b/components/content-hash/src/ai/miniforge/content_hash/core.clj
@@ -98,6 +98,28 @@
     (instance? java.time.Instant x) 9
     :else 10))
 
+(defn- ^{:stratum 0} refuse-collapse!
+  "Throw when normalization merged two entries of a sorted container.
+
+   Compared under `=`, not under `canonical-compare`. Only instant
+   normalization can map two distinct values onto one — every other
+   branch of `->canonical` is injective — so a shortfall here is always
+   an `Instant`/`Date`/`#inst`-literal ambiguity and never the
+   comparator collapsing `1` and `1.0`, which predates this namespace's
+   instant handling and is left exactly as it was.
+
+   Checking the normalized values rather than which inputs got rewritten
+   is what catches a caller who already holds an `#inst` literal: that
+   key is not rewritten, so a guard keyed on rewriting would let it
+   silently overwrite an `Instant` for the same moment, or not, by
+   iteration order."
+  [what normalized]
+  (when-let [dup (some (fn [[v n]] (when (> n 1) v)) (frequencies normalized))]
+    (throw (IllegalArgumentException.
+            ;; pr-str, not str: a TaggedLiteral's toString is its identity
+            ;; hash — the very thing this namespace exists to keep out.
+            (str what " that normalize to one instant: " (pr-str dup))))))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn- ^{:stratum 1} inst->literal
@@ -170,8 +192,10 @@
    halves of `canonical-edn`'s contract: equal inputs give equal
    output, and distinct inputs do not silently converge.
 
-   Both checks are scoped to values normalization actually rewrote, so
-   the pre-existing collapse of distinct-but-comparator-equal entries
+   Both containers detect that through `refuse-collapse!`, which
+   compares the NORMALIZED values rather than which inputs were
+   rewritten — see its docstring for why the difference matters. The
+   pre-existing collapse of distinct-but-comparator-equal entries
    (`{1 :a 1.0 :b}`, `#{1 1.0}`) is left exactly as it was.
 
    One self-recursive walk, replacing the mutually-recursive
@@ -184,27 +208,14 @@
    map entry and a set are also collections."
   [x]
   (cond
-    (map? x)       (reduce-kv
-                    (fn [acc k v]
-                      (let [k' (if (inst? k) (inst->literal k) k)]
-                        (when (and (not (identical? k' k)) (contains? acc k'))
-                          ;; pr-str, not str: a TaggedLiteral's toString is
-                          ;; its identity hash — the very thing this
-                          ;; namespace exists to keep out of output.
-                          (throw (IllegalArgumentException.
-                                  (str "Map has two instant keys for one moment: "
-                                       (pr-str k')))))
-                        (assoc acc k' (->canonical v))))
-                    (sorted-map-by canonical-compare)
-                    x)
+    (map? x)       (let [entries (mapv (fn [[k v]]
+                                         [(if (inst? k) (inst->literal k) k)
+                                          (->canonical v)])
+                                       x)]
+                     (refuse-collapse! "Map has two keys" (mapv first entries))
+                     (into (sorted-map-by canonical-compare) entries))
     (set? x)       (let [normalized (mapv ->canonical x)]
-                     ;; (set normalized) uses `=`, not the comparator, so
-                     ;; only a normalization-induced collapse shrinks it —
-                     ;; `#{1 1.0}` stays two here and keeps its old
-                     ;; comparator-driven behavior below.
-                     (when (< (count (set normalized)) (count x))
-                       (throw (IllegalArgumentException.
-                               "Set has two instant elements for one moment")))
+                     (refuse-collapse! "Set has two elements" normalized)
                      (into (sorted-set-by canonical-compare) normalized))
     (map-entry? x) [(->canonical (key x)) (->canonical (val x))]
     (coll? x)      (mapv ->canonical x)

--- a/components/content-hash/src/ai/miniforge/content_hash/interface.clj
+++ b/components/content-hash/src/ai/miniforge/content_hash/interface.clj
@@ -15,7 +15,6 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-
 (ns ai.miniforge.content-hash.interface
   "Public API for the content-hash component.
 
@@ -30,15 +29,21 @@
    [ai.miniforge.content-hash.core :as core]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Canonical EDN
 
-(defn canonical-edn
+;; Canonical EDN
+(defn ^{:stratum 0} canonical-edn
   "Return a deterministic EDN string for `x`.
 
    Maps are serialized with keys sorted under a stable, type-aware
    comparator; sets are sorted; sequential collections preserve order;
-   scalars pass through. Logically equal inputs produce identical output
-   regardless of original insertion order.
+   instants render as `#inst` literals whether they arrive as a
+   `java.time.Instant` or a `java.util.Date`; other scalars pass
+   through. Logically equal inputs produce identical output regardless
+   of original insertion order.
+
+   Throws `IllegalArgumentException` on an `inst?` value that is
+   neither of those two types, rather than hashing it under a rendering
+   nothing has checked.
 
    Example:
      (canonical-edn {:b 2 :a 1}) ;; => \"{:a 1, :b 2}\"
@@ -46,10 +51,8 @@
   [x]
   (core/canonical-edn x))
 
-;------------------------------------------------------------------------------ Layer 1
 ;; SHA-256 content hash
-
-(defn content-hash
+(defn ^{:stratum 0} content-hash
   "Compute the SHA-256 hex digest of `x`'s canonical EDN.
 
    Returns a lowercase 64-character hex string. Equal data produces equal

--- a/components/content-hash/src/ai/miniforge/content_hash/interface.clj
+++ b/components/content-hash/src/ai/miniforge/content_hash/interface.clj
@@ -63,6 +63,10 @@
    hashes; distinct data produces distinct hashes (with cryptographic
    probability).
 
+   Throws the same `IllegalArgumentException` cases `canonical-edn`
+   does — an unsupported `inst?` type, or a map/set whose entries would
+   collapse onto one instant — since it digests that same string.
+
    Example:
      (content-hash {:a 1 :b 2})
      ;; => \"c7e0...\" (64-char hex string)"

--- a/components/content-hash/src/ai/miniforge/content_hash/interface.clj
+++ b/components/content-hash/src/ai/miniforge/content_hash/interface.clj
@@ -41,9 +41,13 @@
    through. Logically equal inputs produce identical output regardless
    of original insertion order.
 
-   Throws `IllegalArgumentException` on an `inst?` value that is
-   neither of those two types, rather than hashing it under a rendering
-   nothing has checked.
+   Throws `IllegalArgumentException` in two cases, rather than hashing
+   a value under a rendering nothing has checked or quietly losing one:
+
+   - an `inst?` value that is neither of those two types;
+   - a map or set holding two entries that denote the same moment —
+     say an `Instant` key and a `Date` key — since they are two entries
+     going in and one coming out.
 
    Example:
      (canonical-edn {:b 2 :a 1}) ;; => \"{:a 1, :b 2}\"

--- a/components/content-hash/test/ai/miniforge/content_hash/interface/instant_canonicalization_test.clj
+++ b/components/content-hash/test/ai/miniforge/content_hash/interface/instant_canonicalization_test.clj
@@ -58,6 +58,14 @@
       (is (not= (ch/canonical-edn {:at bc}) (ch/canonical-edn {:at ad})))
       (is (not= (ch/content-hash {:at bc}) (ch/content-hash {:at ad}))))))
 
+(deftest ^{:stratum 0} comparator-equal-non-instants-keep-their-old-behavior
+  ;; The refusals above must not widen into the pre-existing collapse of
+  ;; keys that are distinct under `=` but equal under the comparator.
+  ;; That behavior predates this PR and is out of its scope.
+  (testing "1 and 1.0 still collapse silently rather than throwing"
+    (is (= 1 (count (edn/read-string (ch/canonical-edn #{1 1.0})))))
+    (is (string? (ch/canonical-edn {1 :a 1.0 :b})))))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (deftest ^{:stratum 1} both-inst-types-are-inst?
@@ -134,6 +142,23 @@
                               (ch/content-hash m)))))
     (testing "one instant key is still fine, at either type"
       (is (= (ch/canonical-edn {now :v}) (ch/canonical-edn {d :v}))))))
+
+(deftest ^{:stratum 1} two-instant-set-elements-for-one-moment-are-refused
+  ;; The same collapse as the map-key case, found by re-checking the
+  ;; other sorted container after fixing that one. Worse here: no
+  ;; insertion-order dependence, just a plain collision — `#{i d}` and
+  ;; `#{i}` are distinct values that produced the identical digest.
+  (let [d (Date/from now)]
+    (testing "the set really does hold two elements before normalization"
+      (is (= 2 (count #{now d}))))
+    (testing "an ambiguous set throws instead of collapsing onto one element"
+      (is (thrown-with-msg? IllegalArgumentException
+                            #"two instant elements for one moment"
+                            (ch/content-hash #{now d}))))
+    (testing "a set with one instant is still fine, at either type"
+      (is (= (ch/canonical-edn #{now}) (ch/canonical-edn #{d}))))
+    (testing "a vector keeps both — order is preserved, nothing is deduped"
+      (is (= 2 (count (edn/read-string (ch/canonical-edn [now d]))))))))
 
 (deftest ^{:stratum 1} instants-normalize-at-any-depth
   (testing "nested, in sequences, in sets, and as a map key"

--- a/components/content-hash/test/ai/miniforge/content_hash/interface/instant_canonicalization_test.clj
+++ b/components/content-hash/test/ai/miniforge/content_hash/interface/instant_canonicalization_test.clj
@@ -118,6 +118,23 @@
       (testing label
         (is (= (Date/from now) (:at (edn/read-string (ch/canonical-edn {:at t})))))))))
 
+(deftest ^{:stratum 1} two-instant-keys-for-one-moment-are-refused
+  ;; Copilot caught this on #1744. Normalizing keys turns an Instant key
+  ;; and a Date key for the same moment into one key, so one entry
+  ;; overwrites the other and the survivor follows the source map's
+  ;; iteration order — two `=` maps hashing differently, which is the
+  ;; guarantee `canonical-edn` advertises. Refused rather than dropped.
+  (let [d (Date/from now)]
+    (testing "the two orderings really are one map, so silently collapsing would be a contract break"
+      (is (= (array-map now :a d :b) (array-map d :b now :a))))
+    (testing "an ambiguous map throws instead of dropping an entry"
+      (doseq [m [(array-map now :a d :b) (array-map d :b now :a)]]
+        (is (thrown-with-msg? IllegalArgumentException
+                              #"two instant keys for one moment"
+                              (ch/content-hash m)))))
+    (testing "one instant key is still fine, at either type"
+      (is (= (ch/canonical-edn {now :v}) (ch/canonical-edn {d :v}))))))
+
 (deftest ^{:stratum 1} instants-normalize-at-any-depth
   (testing "nested, in sequences, in sets, and as a map key"
     (is (= (ch/canonical-edn {:a {:b [now]}})

--- a/components/content-hash/test/ai/miniforge/content_hash/interface/instant_canonicalization_test.clj
+++ b/components/content-hash/test/ai/miniforge/content_hash/interface/instant_canonicalization_test.clj
@@ -1,0 +1,126 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.content-hash.interface.instant-canonicalization-test
+  "The instant boundary in canonical EDN.
+
+   `inst?` admits BOTH `java.time.Instant` and `java.util.Date`, and
+   `pr-str` renders them as unrelated things — a Date as readable
+   `#inst`, an Instant as `#object[java.time.Instant 0x… \"…\"]` that
+   carries the object's identity hash. So hashing the same value twice
+   used to answer two different digests."
+  (:require
+   [clojure.edn :as edn]
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.content-hash.interface :as ch])
+  (:import
+   [java.time Instant]
+   [java.util Date]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} ^:private now
+  "A pinned instant carrying MILLISECONDS — `.789` proves losslessness."
+  (Instant/parse "2026-08-01T12:34:56.789Z"))
+
+(deftest ^{:stratum 0} unsupported-inst-type-is-refused
+  ;; Hashing a value under a rendering nothing has checked is how this
+  ;; defect class starts. Refuse at the boundary instead.
+  (testing "an inst? that is neither Instant nor Date throws"
+    (let [exotic (reify clojure.core/Inst (inst-ms* [_] 0))]
+      (is (inst? exotic))
+      (is (thrown-with-msg? IllegalArgumentException
+                            #"Not a supported instant type"
+                            (ch/content-hash {:at exotic}))))))
+
+(deftest ^{:stratum 0} era-is-not-dropped
+  ;; A `yyyy` pattern is year-of-era: it renders 1 BC and 2 AD alike as
+  ;; `0002`, collapsing two distinct instants onto one digest — the same
+  ;; defect this namespace exists to keep out, one layer down.
+  (testing "1 BC and 2 AD are distinct instants and distinct hashes"
+    (let [bc (Instant/parse "-0001-01-01T00:00:00Z")
+          ad (Instant/parse "0002-01-01T00:00:00Z")]
+      (is (not= bc ad))
+      (is (not= (ch/canonical-edn {:at bc}) (ch/canonical-edn {:at ad})))
+      (is (not= (ch/content-hash {:at bc}) (ch/content-hash {:at ad}))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} both-inst-types-are-inst?
+  ;; The premise the rest of this namespace rests on. If `inst?` stopped
+  ;; admitting Date, canonical EDN would not need to normalize by type —
+  ;; so assert it rather than assume it.
+  (testing "clojure.core/inst? admits an Instant and a Date alike"
+    (is (inst? now))
+    (is (inst? (Date/from now)))))
+
+(deftest ^{:stratum 1} instant-hashing-is-deterministic
+  ;; The defect. Pre-fix, `pr-str` embedded the Instant's identity hash,
+  ;; so two equal values hashed differently and re-verifying a stored
+  ;; digest against a recomputed one always failed.
+  (testing "two equal Instants produce one digest"
+    (let [a (Instant/parse "2026-08-01T12:34:56.789Z")
+          b (Instant/parse "2026-08-01T12:34:56.789Z")]
+      (is (= a b))
+      (is (= (ch/content-hash {:at a}) (ch/content-hash {:at b})))))
+  (testing "no identity hash survives into the serialization"
+    (is (not (re-find #"0x" (ch/canonical-edn {:at now}))))))
+
+(deftest ^{:stratum 1} both-inst-types-converge-on-one-rendering
+  (testing "a Date and an Instant for the same moment are indistinguishable"
+    (is (= (ch/canonical-edn {:at now})
+           (ch/canonical-edn {:at (Date/from now)})))
+    (is (= (ch/content-hash {:at now})
+           (ch/content-hash {:at (Date/from now)})))))
+
+(deftest ^{:stratum 1} date-rendering-is-unchanged
+  ;; Content hashes are persisted and later re-verified, so a Date must
+  ;; render to the byte-identical text `pr-str` gave it before instants
+  ;; were normalized here. Asserted against Date's own print form rather
+  ;; than a literal, so it tracks the JDK rather than this test.
+  ;; Holds across the Gregorian range; `Date` renders pre-1582 dates on
+  ;; the Julian calendar and drops the ISO `+` past year 9999, so it
+  ;; disagrees with ISO-8601 outside it.
+  (testing "a Date renders exactly as pr-str renders it"
+    (let [d (Date/from now)]
+      (is (= (str "{:at " (pr-str d) "}") (ch/canonical-edn {:at d}))))))
+
+(deftest ^{:stratum 1} sub-millisecond-precision-survives
+  ;; `Instant/now` carries microseconds on current JVMs. Truncating to
+  ;; Date's millisecond width would let two distinct instants collide
+  ;; inside a tamper-evidence hash.
+  (testing "microseconds are neither dropped nor collapsed"
+    (let [micros (Instant/parse "2026-08-01T12:34:56.789123Z")]
+      (is (= "{:at #inst \"2026-08-01T12:34:56.789123-00:00\"}"
+             (ch/canonical-edn {:at micros})))
+      (is (not= (ch/content-hash {:at micros}) (ch/content-hash {:at now}))))))
+
+(deftest ^{:stratum 1} normalized-instants-are-readable-edn
+  ;; `#object[...]` has no reader, so pre-fix an Instant made the whole
+  ;; canonical string unreadable. The reader answers a Date for `#inst`,
+  ;; so the round trip recovers the instant, not the original type.
+  (testing "canonical EDN holding an instant reads back to the same moment"
+    (doseq [[label t] [["Instant" now] ["Date" (Date/from now)]]]
+      (testing label
+        (is (= (Date/from now) (:at (edn/read-string (ch/canonical-edn {:at t})))))))))
+
+(deftest ^{:stratum 1} instants-normalize-at-any-depth
+  (testing "nested, in sequences, in sets, and as a map key"
+    (is (= (ch/canonical-edn {:a {:b [now]}})
+           (ch/canonical-edn {:a {:b [(Date/from now)]}})))
+    (is (= (ch/canonical-edn #{now}) (ch/canonical-edn #{(Date/from now)})))
+    (is (= (ch/canonical-edn {now :v}) (ch/canonical-edn {(Date/from now) :v})))))

--- a/components/content-hash/test/ai/miniforge/content_hash/interface/instant_canonicalization_test.clj
+++ b/components/content-hash/test/ai/miniforge/content_hash/interface/instant_canonicalization_test.clj
@@ -83,7 +83,18 @@
   ;; That behavior predates this PR and is out of its scope.
   (testing "1 and 1.0 still collapse silently rather than throwing"
     (is (= 1 (count (edn/read-string (ch/canonical-edn #{1 1.0})))))
-    (is (string? (ch/canonical-edn {1 :a 1.0 :b})))))
+    (is (string? (ch/canonical-edn {1 :a 1.0 :b}))))
+  (testing "a non-instant normalization collapse stays silent too"
+    ;; Copilot round 5. `mapv` renders a list and a vector of the same
+    ;; items to one vector, so instant normalization is NOT the only
+    ;; non-injective branch. A container whose comparator is
+    ;; inconsistent with `=` can hold both, and the guard used to throw
+    ;; on it — reporting "normalize to one instant: [1 2]", with no
+    ;; instant anywhere in sight.
+    (let [by-type (fn [a b] (compare (str (type a)) (str (type b))))
+          s       (sorted-set-by by-type [1 2] '(1 2))]
+      (is (= 2 (count s)))
+      (is (= [1 2] (first (edn/read-string (ch/canonical-edn s))))))))
 
 ;------------------------------------------------------------------------------ Layer 1
 

--- a/components/content-hash/test/ai/miniforge/content_hash/interface/instant_canonicalization_test.clj
+++ b/components/content-hash/test/ai/miniforge/content_hash/interface/instant_canonicalization_test.clj
@@ -58,6 +58,25 @@
       (is (not= (ch/canonical-edn {:at bc}) (ch/canonical-edn {:at ad})))
       (is (not= (ch/content-hash {:at bc}) (ch/content-hash {:at ad}))))))
 
+(deftest ^{:stratum 0} rendering-is-locale-independent
+  ;; Copilot round 4. `clojure.core/format` and a bare
+  ;; `DateTimeFormatter/ofPattern` both take the default locale, so a
+  ;; numbering system other than `latn` rendered the padded fraction in
+  ;; its own digits — `.789` came back `.७८९` under hi-IN-u-nu-deva and
+  ;; the digest changed with the machine that computed it.
+  (let [deva (java.util.Locale/forLanguageTag "hi-IN-u-nu-deva")
+        orig (java.util.Locale/getDefault)
+        v    {:at (Instant/parse "2026-08-01T12:34:56.789Z")}
+        base (ch/canonical-edn v)]
+    (testing "a non-latn default locale changes neither the rendering nor the digest"
+      (try
+        (java.util.Locale/setDefault deva)
+        (is (= base (ch/canonical-edn v)))
+        (is (re-find #"\.789-00:00" (ch/canonical-edn v)))
+        (finally (java.util.Locale/setDefault orig))))
+    (testing "the locale really was restored, so later tests are unaffected"
+      (is (= orig (java.util.Locale/getDefault))))))
+
 (deftest ^{:stratum 0} comparator-equal-non-instants-keep-their-old-behavior
   ;; The refusals above must not widen into the pre-existing collapse of
   ;; keys that are distinct under `=` but equal under the comparator.

--- a/components/content-hash/test/ai/miniforge/content_hash/interface/instant_canonicalization_test.clj
+++ b/components/content-hash/test/ai/miniforge/content_hash/interface/instant_canonicalization_test.clj
@@ -138,10 +138,20 @@
     (testing "an ambiguous map throws instead of dropping an entry"
       (doseq [m [(array-map now :a d :b) (array-map d :b now :a)]]
         (is (thrown-with-msg? IllegalArgumentException
-                              #"two instant keys for one moment"
+                              #"normalize to one instant"
                               (ch/content-hash m)))))
     (testing "one instant key is still fine, at either type"
-      (is (= (ch/canonical-edn {now :v}) (ch/canonical-edn {d :v}))))))
+      (is (= (ch/canonical-edn {now :v}) (ch/canonical-edn {d :v}))))
+    (testing "a caller's own #inst literal collides the same way, in either order"
+      ;; Copilot round 2. A pre-normalized key is never rewritten, so a
+      ;; guard keyed on rewriting saw nothing to check and let it
+      ;; overwrite an Instant for the same moment — or not, by iteration
+      ;; order. `refuse-collapse!` compares normalized values instead.
+      (let [lit (tagged-literal 'inst "2026-08-01T12:34:56.789-00:00")]
+        (doseq [m [(array-map lit :a now :b) (array-map now :b lit :a)]]
+          (is (thrown-with-msg? IllegalArgumentException
+                                #"normalize to one instant"
+                                (ch/content-hash m))))))))
 
 (deftest ^{:stratum 1} two-instant-set-elements-for-one-moment-are-refused
   ;; The same collapse as the map-key case, found by re-checking the
@@ -153,7 +163,7 @@
       (is (= 2 (count #{now d}))))
     (testing "an ambiguous set throws instead of collapsing onto one element"
       (is (thrown-with-msg? IllegalArgumentException
-                            #"two instant elements for one moment"
+                            #"normalize to one instant"
                             (ch/content-hash #{now d}))))
     (testing "a set with one instant is still fine, at either type"
       (is (= (ch/canonical-edn #{now}) (ch/canonical-edn #{d}))))


### PR DESCRIPTION
## The sweep's three named items are already fixed

This PR was scoped as "finish the `inst?` sweep" against three open
items. All three are fixed on `origin/main` — by two PRs that land
*after* the last one in the known-fixed list, which is why they read as
open:

| item | state | fixed by |
|---|---|---|
| `cursor_store/store.clj` `stringify-instants` | fixed | #1605 |
| `bases/etl/.../main.clj` `stringify-instants` | fixed | **#1606** |
| `workflow/checkpoint_store.clj` | fixed | **#1607** |

#1605 did more than the `connector-http` read side: it extracted a
shared `coerce/instant.clj` whose `->iso` dispatches on actual type
(Instant *and* Date). #1606 and #1607 then deleted the two remaining
Instant-only postwalks and routed both call sites through it. All three
carry round-trip tests over both inst types.

Nothing to do on them. Re-sweeping instead turned up one open instance,
which is what this PR fixes.

## The open instance: `content-hash`

`canonical-edn` renders scalars with `pr-str`. `inst?` admits both
types and `pr-str` treats them as unrelated:

```
Date    -> #inst "2024-01-15T10:00:00.123-00:00"      readable EDN
Instant -> #object[java.time.Instant 0x3eb631b8 "..."]
```

The Instant form embeds the object's **identity hash**, so the same
instant renders differently on every call:

```clojure
(ch/content-hash {:t i})   ;; => 1c4294c6f828dfa4...
(ch/content-hash {:t i2})  ;; => 13af656d4bce0ef8...   where (= i i2)
```

Determinism is the one property the component exists to provide. And
`#object[...]` has no EDN reader, so the canonical string could not be
read back either — the stated defect class, one step worse.

**Not latent.** `evidence_bundle/collector.clj:580` stamps
`:evidence-bundle/created-at (java.time.Instant/now)` and hashes the
whole bundle at line 619. `opsv_finalization.clj:156` recomputes a
digest and compares it to a stored one — a comparison that could never
succeed. `knowledge-pack`, `opsv`, `phase-opsv` and the two workbench
adapters hash through the same entry point.

Worth noting `policy_pack/canonical_edn.clj` — a second canonical-EDN
implementation in the same repo — already dispatched on both types.
One of the two got it right.

## The fix

`inst->literal` dispatches on actual type and emits an `#inst` tagged
literal. Two properties held deliberately:

1. **A Date renders byte-identically to before**, so every previously
   stable hash still holds. Only Instant-valued hashes change, and
   those were never reproducible. Holds across the Gregorian range;
   `Date` renders pre-1582 dates on the Julian calendar and drops the
   ISO `+` past year 9999, so it disagrees with ISO-8601 outside it and
   those two hashes do move. Documented rather than papered over.
2. **Sub-millisecond precision survives.** `Instant/now` carries
   microseconds on current JVMs; truncating to Date's millisecond width
   would let distinct instants collide inside a tamper-evidence hash.

Map keys are normalized too, and only when they are instants, so no
other map's ordering or rendering moves.

An unsupported `inst?` throws `IllegalArgumentException` rather than
the `ex-info` its siblings in effect-transaction and policy-pack use:
the branch is an exhaustive match over the types `inst?` admits, so
reaching it is the programmer error rule 005 names, and this component
carries no dependencies so `throw+` is not available.

## Self-review caught a collision I introduced

The first pass formatted with `yyyy` — year-of-era, rendered without
the era. 1 BC and 2 AD both printed `0002`:

```
1 BC  -> {:t #inst "0002-01-01T00:00:00.000-00:00"}
2 AD  -> {:t #inst "0002-01-01T00:00:00.000-00:00"}
COLLIDING HASHES? true
```

Two distinct instants onto one digest — the exact failure this PR
exists to prevent. Fixed with `uuuu` (proleptic year, identical for
every AD year); `era-is-not-dropped` pins it.

## The SL007 cycle, and why the diff touches `->canonical`

`->canonical`/`canonicalize-map`/`canonicalize-coll` referred to each
other through a `declare`. stratum-lint reports that as SL007, and
`--fix` cannot resolve a reference cycle, so **no commit touching this
file could pass the gate** — `MINIFORGE_STRATUM_BUDGET_MODE=warn` does
not help, since it only covers the SL003 budget path. Collapsing the
trio into one self-recursive walk was forced, not opportunistic. Same
tests in the same order.

Breaking the cycle then exposed an SL003 the cycle had been masking.
Proven pre-existing rather than asserted: the HEAD file with **only**
the cycle broken and no instant work reports the same count.

| variant | finding |
|---|---|
| HEAD as-is | SL007 — uncommittable, SL003 never computed |
| HEAD + cycle-break only | SL003, **5 layers** |
| this PR | SL003, **5 layers** |

This change adds no layer. Committed with
`MINIFORGE_STRATUM_BUDGET_MODE=warn`; the namespace split SL003 asks
for is its own PR.

## Tests

New `instant_canonicalization_test.clj`, every assertion confirmed to
**fail against the unfixed source** (9 failures, 1 error) before the
fix was restored: both types are `inst?` (the premise, asserted not
assumed), Instant hashing is deterministic, both types converge, Date
rendering is unchanged, sub-millisecond precision survives, output is
readable EDN, instants normalize at any depth including as map keys,
era is not dropped, and an unsupported `inst?` is refused.

## Rest of the sweep — everything else checked

Scope: every `inst?` schema field in `components/` + `bases/` against
every `pr-str` / `pprint` / `spit` persistence path.

**Clean — dispatch on both types or not a persistence path:**
`cursor-store`, `bases/etl`, `workflow/checkpoint_store` (all via
`coerce`); `policy-pack/loader` + `canonical_edn`; `pipeline-pack`;
`effect-transaction/codec`; `execution-grant/temporal`;
`knowledge/zettel`; `bases/cli` `timestamp->epoch-ms`; `web-dashboard`;
`dag-executor/scratch_gc_queue` (Date-only by construction);
`pr-lifecycle` listener-registry / monitor-worklist / monitor-budget
(stamp their own `java.util.Date`, round-trip natively as `#inst`).

**One adjacent finding, deliberately not fixed here** — different
mechanism, its own PR: `workflow/context.clj:242`
`timestamp->epoch-ms` maps a number or Instant to epoch millis and
answers `nil` for anything else, so a `java.util.Date` — equally
`inst?` — silently skips the duration stamp. Documented fail-soft
rather than a persist-unreadable defect, so it is out of this class,
but the `inst?`-admits-both root cause is identical.

## Review rounds — Copilot found two regressions I introduced

Both were in the instant **key/element** path, and both were real.

**Round 1 — map keys.** Normalizing keys collapses an `Instant` key and
a `Date` key for the same moment into one, so one entry overwrites the
other and the survivor follows the source map's iteration order:

```
(= m1 m2)   => true      ; m1 = (array-map i :from-instant d :from-date)
m1 -> {#inst "2026-08-01T12:34:56.789-00:00" :from-date}
m2 -> {#inst "2026-08-01T12:34:56.789-00:00" :from-instant}
same hash?  => false
```

**Set path, found by re-checking the other sorted container.** Same
collapse, worse — no order dependence, just a plain collision:
`#{i d}` and `#{i}` are distinct values that produced the identical
digest. Fixing only maps would have left this PR doing what the sweep
it belongs to exists to stop: handling one shape of a defect and
calling the class closed.

**Round 2 — the first guard had a hole.** It only ran when a key was
rewritten (`identical?`), and a caller already holding an `#inst`
literal is never rewritten:

```
lit-first  (array-map lit :a i :b)  => REFUSED
inst-first (array-map i :b lit :a)  => {#inst "..." :a}   silently one entry
```

Same non-determinism, different door.

**Where it landed.** `refuse-collapse!`, shared by the map and set
branches, compares the NORMALIZED values under `=` rather than which
inputs were rewritten — so it cannot miss a collision regardless of
input form. It stays narrow for a principled reason rather than by
construction: instant normalization is the only non-injective branch of
`->canonical`, so a duplicate is always an instant ambiguity and never
the comparator collapsing `1` and `1.0`. That boundary has its own test
(`comparator-equal-non-instants-keep-their-old-behavior`) so a later
change cannot widen the refusal into pre-existing behavior by accident.

Copilot's suppressed comment was valid too: both throws are now
documented on `canonical-edn`'s public docstring, not only in the
private implementation.

## Gates

`bb lint:clj`, `bb poly:check`, `bb test` (full suite, 7m49s),
`bb commit-budget`, `bb pr-budget` (212/600) all pass. `bb
lint:stratum` reports only the pre-existing SL003 above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


