### PR TITLE
docs(specs): delta-spec completion pass (all seven deltas)

### DIFF
--- a/docs/pull-requests/2026-08-10-chris-delta-specs-spec-complete.md
+++ b/docs/pull-requests/2026-08-10-chris-delta-specs-spec-complete.md
@@ -1,0 +1,113 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# docs: delta-spec completion pass (all seven deltas)
+
+## Overview
+
+Normalizes metadata across the seven delta specs, adds conformance requirement
+IDs to the six that carry requirements, fixes a duplicate section number, and
+records that one delta states no requirements at all.
+
+Grouped into one PR because the defects are systemic rather than per-spec —
+each delta exhibits the same few, and fixing them one at a time would produce
+seven near-identical reviews.
+
+## Motivation
+
+**Metadata was carried three different ways.**
+
+| Convention | Specs |
+|---|---|
+| Header block, as N1–N15 use | N11-delta |
+| Bulleted list under the H1 | N5-delta-2, -3, -4, -supervisory |
+| A `## Spec metadata` section | N2-delta, N4-delta |
+
+Three of the bulleted ones also wrapped the version in backticks, so a reader
+or a script looking for the version had four shapes to match. **N4-delta
+carried no version anywhere.**
+
+I initially mis-surveyed this as "six deltas have no version header" — the
+regex matched only the header form and missed the bulleted one. The finding is
+inconsistency, not absence, and the PR is scoped to that.
+
+**No delta had conformance requirement IDs.** Every core spec now does, so a
+conformance suite can cite a delta's requirements only by quoting prose.
+
+**N5-delta-3 had two sections numbered §3.6** — the pack-management producer
+and a "Shared contract" section. Both inbound `§3.6` references (from §5 and
+the acceptance checklist) mean the producer, so the Shared contract section was
+the misnumbered one.
+
+**N4-delta contains no RFC 2119 keyword at all** — not one MUST, SHALL,
+SHOULD, or MAY — while sitting in `specs/normative/`. Standard 020 requires
+normative specs to use them. An implementation cannot conform to a document
+that states no requirements.
+
+## Changes in Detail
+
+- **Metadata normalized** to the header form on all seven, preserving Spec ID,
+  Amends, and Related where they existed. N4-delta gained a version.
+- **Requirement IDs** on the six deltas with MUSTs: `N2D.CK.*` (6),
+  `N5D1.SV.*` (7), `N5D2.SC.*` (4), `N5D3.OE.*` (5), `N5D4.AE.*` (4),
+  `N11D.RA.*` (3), each with test obligations. The ones worth naming are the
+  invariants that keep the supervisory model coherent: `N5D1.SV.3` (sole
+  emitter per entity family), `N5D1.SV.7` (terminal states never reactivate),
+  and `N5D4.AE.3` (the correlator must filter its own output out of its input,
+  or it feeds itself).
+- **N5-delta-3 §3.6 → §3.7** for the Shared contract section.
+- **Version histories** added to all seven.
+
+### N4-delta: recorded, not invented
+
+Its content is a design description — a candidate model, provenance fields, an
+approval lifecycle, compilation guarantees — written declaratively. Converting
+that prose into MUSTs is a deliberate authoring act with real consequences for
+implementers, so this PR does not do it. Inventing requirements on someone
+else's design would be worse than recording the gap.
+
+A Status subsection states that the spec is effectively informative until its
+requirements are stated, and names the two open dispositions: state the
+requirements and keep it in `normative/`, or reclassify it to `informative/`
+and let N4 carry whatever is binding. SPEC_INDEX is authoritative on scope
+(020) and should record whichever is chosen.
+
+## Testing Plan
+
+Specification change; no runtime code touched.
+
+- `markdownlint` clean on all eight changed files, except two pre-existing
+  MD040 fenced-block warnings in N5-delta-4 at lines 193 and 250. Verified
+  against the diff that both predate this change; left alone rather than
+  widening the diff.
+- No duplicate section numbers remain across any delta.
+- Verified both inbound `§3.6` references before renumbering.
+
+## Deployment Plan
+
+Documentation only. Merges to `main` with no runtime effect.
+
+## Follow-on Work
+
+1. Decide N4-delta's disposition — state its requirements or reclassify it.
+2. The `N5D1.SV.*` requirements describe invariants the supervisory-state
+   component is meant to hold; nothing tests them today.
+
+## Related Issues/PRs
+
+- Completes the delta specs after the N1–N11 core passes
+- Governed by: `standards/miniforge/foundations/specification-standards` (020)
+
+## Checklist
+
+- [x] Specs reviewed against current state before editing
+- [x] Initial mis-survey corrected before scoping the change
+- [x] Duplicate section number resolved; inbound references checked first
+- [x] No requirements invented for N4-delta — gap recorded instead
+- [x] Copyright headers present (810)
+- [x] `markdownlint` clean apart from documented pre-existing warnings
+- [x] SPEC_INDEX updated
+- [x] PR doc created (721)

--- a/docs/pull-requests/2026-08-10-chris-delta-specs-spec-complete.md
+++ b/docs/pull-requests/2026-08-10-chris-delta-specs-spec-complete.md
@@ -58,7 +58,8 @@ that states no requirements.
   emitter per entity family), `N5D1.SV.7` (terminal states never reactivate),
   and `N5D4.AE.3` (the correlator must filter its own output out of its input,
   or it feeds itself).
-- **N5-delta-3 §3.6 → §3.7** for the Shared contract section.
+- **N5-delta-3 §3.6 → §3.7** for the Shared contract section, with
+  N5-delta-4's cross-reference updated to match.
 - **Version histories** added to all seven.
 
 ### N4-delta: recorded, not invented
@@ -79,10 +80,15 @@ and let N4 carry whatever is binding. SPEC_INDEX is authoritative on scope
 
 Specification change; no runtime code touched.
 
-- `markdownlint` clean on all eight changed files, except two pre-existing
-  MD040 fenced-block warnings in N5-delta-4 at lines 193 and 250. Verified
-  against the diff that both predate this change; left alone rather than
-  widening the diff.
+- `markdownlint` clean on all eight changed files. Two pre-existing MD040
+  fenced-block warnings in N5-delta-4 were initially left alone as
+  out-of-scope, but staging the file made them blocking — the pre-commit
+  hook's markdown formatter exits non-zero when a staged file carries an
+  unfixable warning, which failed the commit twice. Both fences are now
+  labelled `text`.
+- N5-delta-4's cross-reference to N5-δ3's shared contract updated to §3.7
+  after the renumbering. I had checked inbound references *within*
+  N5-delta-3 and not across the other deltas; review caught it.
 - No duplicate section numbers remain across any delta.
 - Verified both inbound `§3.6` references before renumbering.
 

--- a/specs/SPEC_INDEX.md
+++ b/specs/SPEC_INDEX.md
@@ -6,7 +6,7 @@
 
 # miniforge Specification Index
 
-**Version:** 0.20.0-draft
+**Version:** 0.22.0-draft
 **Date:** 2026-08-10
 **Status:** Living specification during OSS development
 
@@ -611,7 +611,7 @@ Normative specs are enforced by:
 
 ## Version History
 
-- **0.20.0-draft** (2026-08-10) - Delta-spec completion pass across all seven deltas. Metadata was
+- **0.22.0-draft** (2026-08-10) - Delta-spec completion pass across all seven deltas. Metadata was
   carried three different ways — a core-style header block (N11-delta), a bulleted list under the
   H1 (the four N5 deltas), and a `## Spec metadata` section (N2-delta, N4-delta) — and
   N4-delta had no version anywhere. All normalized to the header form used by N1–N15, with Spec ID,

--- a/specs/SPEC_INDEX.md
+++ b/specs/SPEC_INDEX.md
@@ -6,7 +6,7 @@
 
 # miniforge Specification Index
 
-**Version:** 0.21.0-draft
+**Version:** 0.20.0-draft
 **Date:** 2026-08-10
 **Status:** Living specification during OSS development
 
@@ -611,6 +611,17 @@ Normative specs are enforced by:
 
 ## Version History
 
+- **0.20.0-draft** (2026-08-10) - Delta-spec completion pass across all seven deltas. Metadata was
+  carried three different ways — a core-style header block (N11-delta), a bulleted list under the
+  H1 (the four N5 deltas), and a `## Spec metadata` section (N2-delta, N4-delta) — and
+  N4-delta had no version anywhere. All normalized to the header form used by N1–N15, with Spec ID,
+  Amends and Related preserved. Conformance requirement IDs and test obligations added to the six
+  deltas carrying MUSTs: `N2D.CK.*`, `N5D1.SV.*`, `N5D2.SC.*`, `N5D3.OE.*`, `N5D4.AE.*`,
+  `N11D.RA.*`. N5-delta-3's second `§3.6` renumbered to `§3.7` — it duplicated the pack-management
+  producer's number, and both inbound references mean the producer. **N4-delta contains no RFC 2119
+  keyword at all** and so states no requirements; a Status subsection records that it is effectively
+  informative until its requirements are stated or it is reclassified, and names the two open
+  dispositions rather than choosing one.
 - **0.21.0-draft** (2026-08-10) - N12–N15 completion pass. Conformance requirement IDs and test
   obligations added to all four (`N12.CE.*`, `N13.PI.*`, `N14.WS.*`, `N15.CH.*`), plus Annex A on
   each. **N14 §9.1** declared ten `workspace/*` types as required N3 events and none is registered

--- a/specs/normative/N11-delta-runtime-adapter.md
+++ b/specs/normative/N11-delta-runtime-adapter.md
@@ -352,3 +352,24 @@ called out to ensure the user-facing story matches the contract.
 - N6 — Evidence & Provenance (image-digest pinning is N6's responsibility;
   this delta only requires that defaults are pin-friendly).
 - `docs/platform-support.md` — host platforms that miniforge supports.
+
+---
+
+## Conformance Requirements
+
+| ID | Level | Requirement |
+|----|-------|-------------|
+| N11D.RA.1 | MUST | Select the runtime adapter from the resolved runtime spec, falling through to `:worktree` (§3). |
+| N11D.RA.2 | MUST | Implement the full TaskExecutor protocol of N11 §10 for every adapter (§4). |
+| N11D.RA.3 | MUST | Fail closed when a requested runtime class has no registered adapter (§3). |
+
+### Test Obligations
+
+1. An unregistered runtime class is refused, not silently downgraded to worktree.
+
+---
+
+**Version History:**
+
+- 0.1.0-draft (2026-08-10): Spec-completion pass — `N11D.RA.*` conformance requirement IDs and test obligations added;
+  metadata already used the header form.

--- a/specs/normative/N2-delta-phase-checkpoint-and-resume.md
+++ b/specs/normative/N2-delta-phase-checkpoint-and-resume.md
@@ -6,6 +6,11 @@
 
 # Normative Spec Extension: Phase Checkpoint, Machine Snapshot & Resume
 
+**Version:** 0.2.0-draft
+**Date:** 2026-04-22
+**Status:** Draft
+**Conformance:** MUST (on any implementation that persists to disk)
+
 ## Purpose
 
 Make miniforge workflows genuinely resumable at **phase granularity** with an
@@ -37,6 +42,28 @@ Resumability also supports the dogfood iteration loop: when fixing a
 bug in one phase, engineers should not re-run earlier phases to get
 back to the broken one.
 
+## Conformance Requirements
+
+Requirement IDs are stable identifiers for this delta's normative statements.
+They extend N2's families; IDs are never reused.
+
+| ID | Level | Requirement |
+|----|-------|-------------|
+| N2D.CK.1 | MUST | Write a phase checkpoint and machine snapshot after each successful transition (§1). |
+| N2D.CK.2 | MUST | Maintain the workflow manifest atomically after each checkpoint or snapshot write (§2). |
+| N2D.CK.3 | MUST | Record `:workflow/spec-hash` at start and compare it on resume (§2, §4). |
+| N2D.CK.4 | MUST NOT | Silently resume a workflow whose spec has drifted; error and require the documented override (§4). |
+| N2D.CK.5 | MUST | Emit the checkpoint and resume events of N3 §3.21 at the points §9 defines. |
+| N2D.CK.6 | MUST | Honor the checkpoint store location and retention rules of §3 and §7. |
+
+### Test Obligations
+
+1. A crash after phase N resumes at phase N+1 with no re-execution of N.
+2. A spec edit between run and resume produces the drift error, not a resume.
+3. Every checkpoint write has a corresponding N3 §3.21 event.
+
+---
+
 ## Relationship to other specs
 
 - `N2-workflows.md` — parent spec. §1.1 principle #5 mandates
@@ -63,10 +90,6 @@ worktree from its scratch ref.
 
 - **Title:** Phase Checkpoint, Machine Snapshot & Resume
 - **Type:** Normative extension to N2
-- **Version:** 0.2.0-draft
-- **Status:** Draft
-- **Conformance:** MUST (on any implementation that persists to disk)
-- **Date:** 2026-04-22
 
 ## Definitions
 
@@ -282,3 +305,12 @@ Using the original workflow id for resumed runs preserves event-log
 continuity. All events for a given workflow — whether from the initial
 run or a resumed one — live in the same `~/.miniforge/events/<id>/`
 directory. Post-mortem readers see the full history.
+
+---
+
+**Version History:**
+
+- 0.2.0-draft (2026-08-10): Spec-completion pass — metadata moved from a bulleted `## Spec metadata` block to the
+  header form
+  used by N1–N15; `N2D.CK.*` conformance requirement IDs and test
+  obligations added.

--- a/specs/normative/N4-delta-policy-compilation-contract.md
+++ b/specs/normative/N4-delta-policy-compilation-contract.md
@@ -5,6 +5,11 @@
 -->
 # Normative Spec Extension: Policy Candidate Model and Pack Compilation Contract
 
+**Version:** 0.1.0-draft
+**Date:** 2026-08-10
+**Status:** Draft
+**Conformance:** See §Status below
+
 ## Purpose
 
 Define the OSS-stable contract for turning source policy material into reviewable, provenance-backed policy artifacts.
@@ -36,6 +41,28 @@ The stable boundary is the contract between source policy material and usable po
 - **Title:** Policy Candidate Model and Pack Compilation Contract
 - **Type:** Normative
 - **Scope:** Open-source policy origination substrate
+
+### Status: requirements unstated
+
+This spec sits in `specs/normative/` but contains **no RFC 2119 keyword** —
+not one MUST, SHALL, SHOULD, or MAY. Standard 020 requires normative specs to
+use them, and an implementation cannot conform to a document that states no
+requirements.
+
+Its content is a design description: it defines a candidate model, provenance
+fields, an approval lifecycle, and compilation guarantees in declarative prose.
+Turning that prose into requirements is a deliberate authoring act with real
+consequences for implementers, so it is not done here — inventing MUSTs on
+someone else's design would be worse than recording the gap.
+
+Until that happens this spec is **effectively informative**. Two dispositions
+are open, and one of them should be chosen rather than left implicit:
+
+1. State the requirements its content implies, keeping it in `normative/`.
+2. Reclassify it to `informative/` and let N4 carry whatever of it is binding.
+
+`specs/SPEC_INDEX.md` is authoritative on scope (020) and should record the
+choice.
 
 ## Description
 
@@ -287,3 +314,13 @@ The interesting claim is not that an LLM can turn docs into rules.
 
 The interesting claim is that miniforge policy becomes a compilable, provenance-backed artifact that can be derived from
 organizational reality and attached to repos through stable config and pack semantics.
+
+---
+
+**Version History:**
+
+- 0.1.0-draft (2026-08-10): Spec-completion pass — header metadata added — the spec previously carried no version
+  anywhere; a
+  Status subsection records that the document contains no RFC 2119 keyword
+  and is therefore effectively informative until its requirements are stated
+  or it is reclassified.

--- a/specs/normative/N5-delta-2-pr-scoring.md
+++ b/specs/normative/N5-delta-2-pr-scoring.md
@@ -6,10 +6,12 @@
 
 # N5 Delta 2 — PR Readiness / Risk / Policy Scoring
 
+**Version:** 0.1.0-draft
+**Date:** 2026-04-20
+**Status:** Draft
+**Conformance:** MUST
+
 - **Spec ID:** `N5-delta-pr-scoring-v1`
-- **Version:** `0.1.0-draft`
-- **Status:** Draft
-- **Date:** 2026-04-20
 - **Amends:** N5 — Interface Standard: CLI/TUI/API (§3.2.8 PR Fleet View, §3.2.9 PR Detail View)
 - **Amends:** N5-delta-supervisory-control-plane-v1 (§3.1 PrFleetEntry, §3.4 supervisory-state component)
 - **Related:** N3 (event stream), N4 (policy packs), N9 (external PR integration), `pr-train` readiness/risk
@@ -315,3 +317,26 @@ An implementation satisfies this delta when:
 - [ ] Absent-score and mixed-fleet scenarios render the §5.4 placeholder without errors
 - [ ] The `:pr/recommendation` derivation rules are documented alongside `pr-scoring` config so score inputs
       fully determine outputs
+
+---
+
+## Conformance Requirements
+
+| ID | Level | Requirement |
+|----|-------|-------------|
+| N5D2.SC.1 | MUST | Compute readiness and risk deterministically from recorded inputs (§2). |
+| N5D2.SC.2 | MUST NOT | Emit `:supervisory/*-upserted` from the scoring component; supervisory-state remains sole emitter (§4.1). |
+| N5D2.SC.3 | MUST | Surface score staleness rather than presenting a stale score as current (§4.1). |
+| N5D2.SC.4 | MUST | Render readiness, risk, and policy columns per N5 §3.2.8 using this delta's primitives (§5). |
+
+### Test Obligations
+
+1. Identical inputs produce identical scores across runs.
+2. No component other than supervisory-state emits a supervisory snapshot.
+
+---
+
+**Version History:**
+
+- 0.1.0-draft (2026-08-10): Spec-completion pass — metadata normalized to the header form; `N5D2.SC.*` conformance
+  requirement IDs and test obligations added.

--- a/specs/normative/N5-delta-3-observational-entities.md
+++ b/specs/normative/N5-delta-3-observational-entities.md
@@ -6,10 +6,12 @@
 
 # N5 Delta 3 — Evidence, Artifact, Task, Decision, and Pack Entities + Pack Management
 
+**Version:** 0.2.0-draft
+**Date:** 2026-04-21
+**Status:** Draft
+**Conformance:** MUST
+
 - **Spec ID:** `N5-delta-evidence-artifact-task-decision-pack-v1`
-- **Version:** `0.2.0-draft`
-- **Status:** Draft
-- **Date:** 2026-04-21
 - **Amends:** N5 — Interface Standard: CLI/TUI/API (§3.2.3 Evidence Viewer, §3.2.4 Artifact Browser,
   §3.2.5 DAG Kanban, §3.2.7 Listener/Control Panel, §3.2.11 Pack Browser)
 - **Amends:** N5-delta-supervisory-control-plane-v1 (§3.1 v1 entities, §3.4 supervisory-state component)
@@ -358,7 +360,7 @@ a compiled pack under `:pack-compile/pack-id`. Compilation MUST be deterministic
 inputs MUST produce the same pack hash — and MUST preserve a provenance link from the output
 pack to the source documents.
 
-### 3.6 Shared contract
+### 3.7 Shared contract
 
 All five producers MUST respect the N5-δ1 §3.4 coalescing window (≤ 100 ms per entity) so high-
 frequency sources (especially `:task/state-changed` in wide DAGs) do not flood the event stream.
@@ -587,3 +589,29 @@ The per-entity block is fully satisfied when all five entities meet the checklis
       machine
 
 The delta is fully satisfied when §8.1 and §8.2 are both met.
+
+---
+
+## Conformance Requirements
+
+| ID | Level | Requirement |
+|----|-------|-------------|
+| N5D3.OE.1 | MUST | Materialize all five entities through supervisory-state, not their producing components (§3). |
+| N5D3.OE.2 | MUST | Respect the ≤ 100 ms coalescing window of N5-δ1 §3.4 for every producer (§3.7). |
+| N5D3.OE.3 | MUST | Emit each entity's `:supervisory/*-upserted` type per N3 §3.19.1 (§4). |
+| N5D3.OE.4 | MUST | Render requested capabilities and require explicit consent before publishing a pack-install intent (§5). |
+| N5D3.OE.5 | MUST | Recheck authorization in the installer component; UI confirmation is not the security boundary (§3.6). |
+
+### Test Obligations
+
+1. A wide DAG's `:task/state-changed` burst produces coalesced emissions, not one per event.
+2. An unauthorized promotion is rejected by the installer even when the UI permitted it.
+
+---
+
+**Version History:**
+
+- 0.2.0-draft (2026-08-10): Spec-completion pass — metadata normalized to the header form; the second `§3.6` (Shared
+  contract) renumbered to `§3.7` — it duplicated the pack-management
+  producer's number, and both inbound `§3.6` references mean the producer;
+  `N5D3.OE.*` conformance requirement IDs and test obligations added.

--- a/specs/normative/N5-delta-4-automation-edge-correlator.md
+++ b/specs/normative/N5-delta-4-automation-edge-correlator.md
@@ -6,10 +6,12 @@
 
 # N5 Delta 4 — Automation Edge Correlator
 
+**Version:** 0.1.0-draft
+**Date:** 2026-05-17
+**Status:** Draft
+**Conformance:** MUST
+
 - **Spec ID:** `N5-delta-automation-edge-correlator-v1`
-- **Version:** `0.1.0-draft`
-- **Status:** Draft
-- **Date:** 2026-05-17
 - **Amends:** N5-delta-supervisory-control-plane-v1 (§3.1 v1 entities, §3.4 supervisory-state component)
 - **Amends:** N5-delta-evidence-artifact-task-decision-pack-v1 (entity set extended with `AutomationEdge`)
 - **Related:** N3 (event stream), N8 (observability control), N9 (external PR integration);
@@ -188,7 +190,7 @@ fields MUST produce byte-identical payloads (per N5-δ3 §3.6 shared contract).
 
 ### 2.4 Edge lifecycle — status state machine
 
-```
+```text
                            ┌─────────────┐
        trigger observed    │             │   handler workflow completes
        ────────────────►   │  :observed  │   ──────────────────────────►  :handled
@@ -245,7 +247,7 @@ the same event stream and emits `:supervisory/automation-edge-upserted` events p
 
 The component MUST follow the existing supervisory-state stratification convention:
 
-```
+```text
 components/automation-edge-correlator/
 ├── deps.edn
 ├── src/ai/miniforge/automation_edge_correlator/
@@ -594,3 +596,26 @@ The delta is satisfied when all boxes are checked.
    review comment). v1 emits separate edges keyed on trigger-event-id; the workflow appears
    as `:edge/handled-by-workflow-run-id` on each. Consumers MUST tolerate this multi-edge
    case.
+
+---
+
+## Conformance Requirements
+
+| ID | Level | Requirement |
+|----|-------|-------------|
+| N5D4.AE.1 | MUST | Emit `:supervisory/automation-edge-upserted` from the correlator and no other component (§3). |
+| N5D4.AE.2 | MUST NOT | Emit any other `:supervisory/*` snapshot type from the correlator (§3). |
+| N5D4.AE.3 | MUST | Filter its own emissions out of its input stream to avoid a feedback loop (§5). |
+| N5D4.AE.4 | MUST | Re-emit an edge for every edge reconstructed during replay (§6). |
+
+### Test Obligations
+
+1. The correlator's own output does not re-enter its input.
+2. Replay reconstructs the same edge set as the original run.
+
+---
+
+**Version History:**
+
+- 0.1.0-draft (2026-08-10): Spec-completion pass — metadata normalized to the header form; `N5D4.AE.*` conformance
+  requirement IDs and test obligations added.

--- a/specs/normative/N5-delta-4-automation-edge-correlator.md
+++ b/specs/normative/N5-delta-4-automation-edge-correlator.md
@@ -186,7 +186,7 @@ nil UUID or the DNS / URL / OID / X500 namespaces.
 
 Two observations of the same trigger event id MUST produce the same `:edge/id`. Replay of an
 event-stream prefix MUST NOT duplicate edges. Producers re-emitting an upsert with unchanged
-fields MUST produce byte-identical payloads (per N5-δ3 §3.6 shared contract).
+fields MUST produce byte-identical payloads (per N5-δ3 §3.7 shared contract).
 
 ### 2.4 Edge lifecycle — status state machine
 

--- a/specs/normative/N5-delta-supervisory-control-plane.md
+++ b/specs/normative/N5-delta-supervisory-control-plane.md
@@ -6,10 +6,12 @@
 
 # N5 Delta — Supervisory Control Plane
 
+**Version:** 0.3.0-draft
+**Date:** 2026-04-22
+**Status:** Draft
+**Conformance:** MUST
+
 - **Spec ID:** `N5-delta-supervisory-control-plane-v1`
-- **Version:** `0.3.0-draft`
-- **Status:** Draft
-- **Date:** 2026-04-22
 - **Amends:** N5 — Interface Standard: CLI/TUI/API
 - **Related:** N3 (event stream), N4 (policy packs), N6 (evidence), N8 (observability control), N9 (external PR
   integration), pr-monitor-loop-v1 (autonomous PR comment resolution)
@@ -589,3 +591,30 @@ through without error. Required keys MUST be present and correctly typed.
 1. Monitor mode MUST render at 60 columns without data loss (truncation is acceptable, absence is not)
 2. Monitor mode MUST update without user interaction when events arrive
 3. Monitor mode MUST show attention items without requiring navigation
+
+---
+
+## Conformance Requirements
+
+| ID | Level | Requirement |
+|----|-------|-------------|
+| N5D1.SV.1 | MUST | Materialize supervisory entities purely as an event-stream projection (§3.5 invariant 1). |
+| N5D1.SV.2 | MUST NOT | Peer with ephemeral in-process registries for supervisory state (§3.5 invariant 1). |
+| N5D1.SV.3 | MUST | Be the sole emitter of each entity family's snapshot event (§3.5 invariant 6). |
+| N5D1.SV.4 | MUST | Rebuild state on startup by replaying the stream, snapshots taking precedence (§3.5 invariant 3). |
+| N5D1.SV.5 | MUST | Coalesce updates within the ≤ 100 ms window per entity (§3.5 invariant 4). |
+| N5D1.SV.6 | MUST | Derive attention items inside this component and nowhere else (§3.5 invariant 5). |
+| N5D1.SV.7 | MUST NOT | Transition a terminal workflow state back to active; a retry is a new run (§3.2). |
+
+### Test Obligations
+
+1. A restart reproduces the entity table from the stream alone.
+2. No second component emits a snapshot for an entity family it does not own.
+3. Terminal states never reactivate.
+
+---
+
+**Version History:**
+
+- 0.3.0-draft (2026-08-10): Spec-completion pass — metadata normalized to the header form; `N5D1.SV.*` conformance
+  requirement IDs and test obligations added.


### PR DESCRIPTION
MINIFORGE_PR_BUDGET_OVERRIDE: Seven delta specs sharing one systemic defect set — metadata convention, missing requirement IDs, a duplicate section number. Splitting yields seven near-identical reviews. Well below the ~10-12k threshold where Copilot declines to review. Docs-only, no runtime code.

## Overview

Normalizes metadata across the seven delta specs, adds conformance requirement IDs to the six that carry requirements, fixes a duplicate section number, and records that one delta states no requirements at all.

Full detail: [`docs/pull-requests/2026-08-10-chris-delta-specs-spec-complete.md`](docs/pull-requests/2026-08-10-chris-delta-specs-spec-complete.md)

## Why

**Metadata was carried three different ways.**

| Convention | Specs |
|---|---|
| Header block, as N1–N15 use | N11-delta |
| Bulleted list under the H1 | N5-delta-2, -3, -4, -supervisory |
| A `## Spec metadata` section | N2-delta, N4-delta |

Three of the bulleted ones also backticked the version, so anything looking for it had four shapes to match. **N4-delta carried no version anywhere.**

I initially mis-surveyed this as "six deltas have no version header" — my regex matched only the header form and missed the bulleted one. The finding is inconsistency, not absence, and the PR is scoped to that.

**No delta had conformance requirement IDs**, so a suite could cite their requirements only by quoting prose.

**N5-delta-3 had two sections numbered §3.6.** Both inbound references mean the pack-management producer, so the "Shared contract" section was the misnumbered one.

**N4-delta contains no RFC 2119 keyword at all** — not one MUST, SHALL, SHOULD, or MAY — while sitting in `specs/normative/`. Nothing can conform to it.

## Changes

- Metadata normalized to the header form on all seven, preserving Spec ID / Amends / Related. N4-delta gained a version.
- Requirement IDs on the six deltas with MUSTs: `N2D.CK.*` (6), `N5D1.SV.*` (7), `N5D2.SC.*` (4), `N5D3.OE.*` (5), `N5D4.AE.*` (4), `N11D.RA.*` (3), each with test obligations. The ones worth naming are the invariants holding the supervisory model together: `N5D1.SV.3` (sole emitter per entity family), `N5D1.SV.7` (terminal states never reactivate), `N5D4.AE.3` (the correlator must filter its own output out of its input, or it feeds itself).
- N5-delta-3 `§3.6` → `§3.7` for Shared contract.
- Version histories on all seven.

### N4-delta: recorded, not invented

Its content is a declarative design description — candidate model, provenance fields, approval lifecycle, compilation guarantees. Converting that prose into MUSTs is an authoring act with real consequences for implementers, so this PR does not do it; inventing requirements on someone else's design would be worse than recording the gap.

A Status subsection states the spec is effectively informative until its requirements are stated, and names the two open dispositions — state them and keep it in `normative/`, or reclassify to `informative/` and let N4 carry what is binding. SPEC_INDEX is authoritative on scope (020) and should record the choice.

## Validation

Documentation only; no runtime code touched.

- `markdownlint` clean on all eight changed files, except two pre-existing MD040 warnings in N5-delta-4 (lines 193, 250) — verified against the diff that both predate this change, left alone rather than widening it
- No duplicate section numbers remain across any delta
- Both inbound `§3.6` references verified **before** renumbering

🤖 Generated with [Claude Code](https://claude.com/claude-code)
