### PR TITLE
docs(specs): N12–N15 completion pass

### DIFF
--- a/docs/pull-requests/2026-08-10-chris-n12-n15-spec-complete.md
+++ b/docs/pull-requests/2026-08-10-chris-n12-n15-spec-complete.md
@@ -1,0 +1,106 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# docs: N12–N15 completion pass
+
+## Overview
+
+Adds conformance requirement IDs, test obligations, and implementation annexes
+to the four youngest normative specs, and gates N14's event and evidence
+declarations on the specs that own them.
+
+Grouped into one PR because all four share the same starting state — 0.1.0-draft,
+no requirement IDs, nothing implemented — and the same treatment.
+
+## Motivation
+
+**None of the four had requirement IDs.** N12 and N13 annotate conformance at
+the section level ("Conformance: MUST"), which is better than nothing but not
+citable by a test.
+
+**N14 §9.1 declared ten required event types, none registered in N3.**
+`workspace/opened`, `workspace/transaction-committed`, and eight others are
+listed as "Required event types (N3 envelope)". Under N3 §6 an implementation
+MUST NOT emit an unregistered `:event/type`, so the list could not be satisfied.
+This is the fourth spec to carry that pattern — N8, N9, and N10 each had a
+version of it.
+
+It matters more here than it did there: §9.1 also makes the event stream the
+workspace log, with the graph derived and reconstructible from it. The spec's
+central mechanism is the part that is blocked.
+
+**N14 §9.2's four N6 exports** — decision record, transaction log, graph
+snapshot, per-run accounting — are likewise absent from N6 §3.1.1.
+
+## Changes in Detail
+
+- **Requirement IDs and test obligations** on all four: `N12.CE.*` (7),
+  `N13.PI.*` (6), `N14.WS.*` (6), `N15.CH.*` (6).
+- **N14 §9.1 and §9.2** gated on N3 §6.1 and N6 §3.1.1 registration
+  respectively, with the lists retained as the proposed content of those
+  amendments.
+- **Annex A** on each.
+- Versions bumped 0.1.0 → 0.2.0-draft with histories.
+
+### Why N14's types were not simply added to N3
+
+N3's registry is the contract every consumer reads. Adding ten types for a spec
+that is explicitly speculative (§0.4) and has no implementation would
+misrepresent the stream's surface — a consumer reading the registry would see
+event types nothing will ever emit. The list stays with the spec that proposes
+it until that spec survives its gate.
+
+## Annex A — the finding worth surfacing
+
+**N15 is the one spec whose absence blocks another's disposition.** Its §8 gate
+G0 decides whether N14 is kept or demoted to informative. Until the harness
+exists, that gate cannot run, so N14 stays speculative indefinitely. Of the four,
+N15 is the one with a downstream consequence for the spec set.
+
+The others: no `context-economy` component (N12) — though `components/context-pack`
+and the MCP context server are the natural host. No violation ledger or
+cross-repo promotion (N13), which means §9's "gate as safety net" framing
+describes the current state by default rather than by design, since the
+teaching path it backs up does not exist. No deliberation workspace (N14);
+`components/workspace` is unrelated, handling workflow paths.
+
+## Testing Plan
+
+Specification change; no runtime code touched.
+
+- `markdownlint` clean on all six changed files.
+- Verified none of N14's ten event types appears in N3's registry, and none of
+  its four export types appears in N6.
+- Verified `components/workspace` is unrelated to N14's workspace model before
+  saying so.
+
+## Deployment Plan
+
+Documentation only. Merges to `main` with no runtime effect.
+
+## Follow-on Work
+
+1. Build the N15 harness — it unblocks N14's gate decision.
+2. Land N12's ladder in `components/context-pack` rather than a new component.
+3. N13's violation ledger, which is what turns the gate from the only mechanism
+   into the safety net it is described as.
+
+## Related Issues/PRs
+
+- Completes the normative spec set after the N1–N11 and delta passes
+- Depends on: N3 §6 (event registry), N3 §6.1, N6 §3.1.1 (artifact types)
+- Governed by: `standards/miniforge/foundations/specification-standards` (020)
+
+## Checklist
+
+- [x] Specs reviewed against current state before editing
+- [x] Unregistered event and evidence types gated on their owning specs (020)
+- [x] No types added to N3's registry for unimplemented, speculative specs
+- [x] Annexes marked informative
+- [x] Copyright headers present (810)
+- [x] `markdownlint` clean
+- [x] SPEC_INDEX updated
+- [x] PR doc created (721)

--- a/specs/SPEC_INDEX.md
+++ b/specs/SPEC_INDEX.md
@@ -6,7 +6,7 @@
 
 # miniforge Specification Index
 
-**Version:** 0.19.0-draft
+**Version:** 0.21.0-draft
 **Date:** 2026-08-10
 **Status:** Living specification during OSS development
 
@@ -610,6 +610,18 @@ Normative specs are enforced by:
 ---
 
 ## Version History
+
+- **0.21.0-draft** (2026-08-10) - N12–N15 completion pass. Conformance requirement IDs and test
+  obligations added to all four (`N12.CE.*`, `N13.PI.*`, `N14.WS.*`, `N15.CH.*`), plus Annex A on
+  each. **N14 §9.1** declared ten `workspace/*` types as required N3 events and none is registered
+  in N3 §6, so under N3 §6.1 none may be emitted — the same pattern found in N8, N9, and N10. Since
+  §9.1 also makes the event stream the workspace log, the spec's central mechanism is blocked on
+  that registration; the list is retained as the proposed content of an N3 amendment rather than
+  added to N3's registry, because adding ten unimplemented types would misrepresent the stream's
+  surface to every consumer. N14 §9.2's four N6 exports are gated the same way. Annex A notes that
+  N15 is the one spec whose absence blocks another's disposition: its §8 gate G0 decides whether
+  N14 is kept or demoted, and it cannot run until the harness exists.
+  Per-spec bumps: N12 0.1→0.2, N13 0.1→0.2, N14 0.1→0.2, N15 0.1→0.2
 
 - **0.19.0-draft** (2026-08-10) - N11 spec-completion pass. **N11**: §11's five subsections were
   numbered §10.1–§10.5, duplicating the TaskExecutor protocol's subsection numbers; renumbered,

--- a/specs/normative/N12-agent-context-economy.md
+++ b/specs/normative/N12-agent-context-economy.md
@@ -6,7 +6,7 @@
 
 # N12 — Agent Context Economy
 
-**Version:** 0.1.0-draft
+**Version:** 0.2.0-draft
 **Date:** 2026-06-07
 **Status:** Draft
 **Conformance:** MUST / SHOULD (staged — see §9)
@@ -292,3 +292,53 @@ bail-without-shedding when a query surface for those exact files already
 existed (§5, §6), and — looking forward — the absence of a referenceable
 codebook that would let intent and code arrive compact in the first place
 (§7).
+
+---
+
+## 11. Conformance Requirements
+
+Requirement IDs are stable identifiers for this spec's normative statements.
+Levels follow the per-section conformance annotations in §3–§8 and the staging
+in §9.
+
+| ID | Level | Requirement |
+|----|-------|-------------|
+| N12.CE.1 | MUST | Measure context size pre-flight before dispatching an agent (§3). |
+| N12.CE.2 | MUST | Detect overflow against the model's window rather than a fixed constant (§4). |
+| N12.CE.3 | MUST | Shed on the degradation ladder in the order §5 defines, never arbitrarily. |
+| N12.CE.4 | SHOULD | Pre-empt overflow rather than shedding reactively (§5). |
+| N12.CE.5 | MUST | Expose symbol handles for every shed target so the agent can re-fetch (§6). |
+| N12.CE.6 | SHOULD | Classify boundary compressibility before choosing what to shed (§8). |
+| N12.CE.7 | MUST NOT | Shed a boundary contract to make room for implementation detail (§5, §8). |
+
+### 11.1 Test Obligations
+
+1. A context exceeding the window is reduced by ladder order, and the result is
+   reproducible for the same input.
+2. Every shed element is retrievable through its symbol handle.
+3. A boundary contract survives shedding when implementation detail is present.
+
+---
+
+## Annex A — Implementation Conformance Status (informative)
+
+This annex is **informative**, recording implementation state as of 2026-08-10.
+
+### A.1 Specified, Not Implemented
+
+No `context-economy` component exists. Pre-flight measurement (N12.CE.1),
+overflow detection (N12.CE.2), and the degradation ladder (N12.CE.3) have no
+implementation, so context overflow is currently handled — if at all — by
+whatever each call site does.
+
+`components/context-pack` and the MCP context server carry adjacent machinery
+(context assembly, a context cache), which is the natural place for §3–§5 to
+land rather than a new component.
+
+---
+
+**Version History:**
+
+- 0.2.0-draft (2026-08-10): Spec-completion pass — conformance
+  requirement IDs, test obligations, and Annex A added.
+- 0.1.0-draft: Initial specification.

--- a/specs/normative/N12-agent-context-economy.md
+++ b/specs/normative/N12-agent-context-economy.md
@@ -7,7 +7,7 @@
 # N12 — Agent Context Economy
 
 **Version:** 0.2.0-draft
-**Date:** 2026-06-07
+**Date:** 2026-08-10
 **Status:** Draft
 **Conformance:** MUST / SHOULD (staged — see §9)
 

--- a/specs/normative/N13-policy-injection-and-standards-learning.md
+++ b/specs/normative/N13-policy-injection-and-standards-learning.md
@@ -6,7 +6,7 @@
 
 # N13 — Policy Injection & Standards Learning
 
-**Version:** 0.1.0-draft
+**Version:** 0.2.0-draft
 **Date:** 2026-06-09
 **Status:** Draft
 **Conformance:** MUST / SHOULD (staged — see §11)
@@ -360,3 +360,50 @@ gateable/principle (§8) is a Stage-1 task.
 - When constructing maps, construction should be key→value; move value calculations into a `let` above the map so
   construction reads simply and intent is clear.
 - `requiring-resolve` is an anti-pattern. Use proper `require`s. Genuine use cases are unicorn-rare.
+
+---
+
+## 12. Conformance Requirements
+
+| ID | Level | Requirement |
+|----|-------|-------------|
+| N13.PI.1 | MUST | Record provenance for every injected rule — origin, tier, and version (§3). |
+| N13.PI.2 | MUST | Select guidance by the §4 algorithm, not by unbounded inclusion. |
+| N13.PI.3 | MUST | Record violations in the per-repo ledger with the rule id that fired (§5). |
+| N13.PI.4 | MUST NOT | Promote a rule cross-repo without meeting the §6 promotion criteria. |
+| N13.PI.5 | MUST | Distinguish gateable rules from principle rules and gate only the former (§8). |
+| N13.PI.6 | MUST NOT | Rely on the gate as the primary teaching mechanism — it is the safety net (§9). |
+
+### 12.1 Test Obligations
+
+1. An injected rule's provenance survives into the evidence for the run that used it.
+2. A principle rule never blocks a gate.
+3. Promotion requires the §6 criteria; a rule below threshold stays local.
+
+---
+
+## Annex A — Implementation Conformance Status (informative)
+
+This annex is **informative**, recording implementation state as of 2026-08-10.
+
+### A.1 Partially Implemented
+
+The standards corpus this spec learns from exists (`standards/miniforge` as a
+submodule) and policy packs are implemented per N4, so the two tiers of §2 have
+substrate. What is absent is the flywheel: no per-repo violation ledger (§5,
+N13.PI.3), no cross-repo promotion (§6, N13.PI.4), and no provenance recorded
+for injected rules (§3, N13.PI.1).
+
+### A.2 Structural
+
+Without the ledger, §9's "gate as safety net" framing describes the current
+state by default rather than by design — the gate is the only mechanism, since
+the teaching path it is meant to back up does not exist.
+
+---
+
+**Version History:**
+
+- 0.2.0-draft (2026-08-10): Spec-completion pass — conformance
+  requirement IDs, test obligations, and Annex A added.
+- 0.1.0-draft: Initial specification.

--- a/specs/normative/N13-policy-injection-and-standards-learning.md
+++ b/specs/normative/N13-policy-injection-and-standards-learning.md
@@ -7,7 +7,7 @@
 # N13 — Policy Injection & Standards Learning
 
 **Version:** 0.2.0-draft
-**Date:** 2026-06-09
+**Date:** 2026-08-10
 **Status:** Draft
 **Conformance:** MUST / SHOULD (staged — see §11)
 

--- a/specs/normative/N14-shared-deliberation-workspace.md
+++ b/specs/normative/N14-shared-deliberation-workspace.md
@@ -7,7 +7,7 @@
 # N14 — Shared Deliberation Workspace
 
 **Version:** 0.2.0-draft
-**Date:** 2026-07-22
+**Date:** 2026-08-10
 **Status:** Draft (Speculative — see §0.4)
 **Conformance:** MUST, scoped per §0.4
 **Class:** Extension spec (N7+)

--- a/specs/normative/N14-shared-deliberation-workspace.md
+++ b/specs/normative/N14-shared-deliberation-workspace.md
@@ -6,7 +6,7 @@
 
 # N14 — Shared Deliberation Workspace
 
-**Version:** 0.1.0-draft
+**Version:** 0.2.0-draft
 **Date:** 2026-07-22
 **Status:** Draft (Speculative — see §0.4)
 **Conformance:** MUST, scoped per §0.4
@@ -342,12 +342,23 @@ Closure with open challenges records them as dissent on the affected decisions
 
 ## 9. Events and evidence
 
-### 9.1 Required event types (N3 envelope)
+### 9.1 Event types (N3 envelope)
 
 `workspace/opened`, `workspace/transaction-committed`, `workspace/transaction-rejected`,
 `workspace/activation-started`, `workspace/activation-completed`,
 `workspace/conflict-derived`, `workspace/schedule-decision`, `workspace/budget-exceeded`,
 `workspace/deadlock-detected`, `workspace/closed`.
+
+**None of these is registered in N3 §6.** Under N3 §6 an implementation MUST
+NOT emit an unregistered `:event/type`, so this list cannot be read as an
+emission requirement today. Registering them — a schema in N3 §3, a registry
+row in N3 §6, and an emission point in N3 §4.1, together per N3 §6.1 — is a
+prerequisite to implementing this section.
+
+The list is retained as the proposed content of that amendment. It is stated
+here rather than in N3 because this spec is speculative (§0.4) and N3's
+registry is the contract every consumer reads; adding ten unimplemented types
+to it would misrepresent the stream's surface.
 
 `workspace/transaction-committed` payloads carry the full operation list; the event stream
 is the workspace log (single source of truth; the materialized graph is derived state and
@@ -355,10 +366,14 @@ MUST be reconstructible from events).
 
 ### 9.2 Closure exports (N6)
 
-On close, the engine MUST export as N6 artifacts: (a) the decision record — per-goal
+On close, the engine exports four records: (a) the decision record — per-goal
 outcome, chosen alternatives, rationale links, dissent; (b) the full transaction log;
 (c) the final graph snapshot; (d) per-run accounting — activations, cost, tokens split into
 object-level vs. workspace-overhead classes (consumed by N15).
+
+None of these is an N6 §3.1.1 artifact type today, so as with §9.1 the export
+is gated on registering them there. N6 owns the evidence schema; this spec
+names the content, not a new evidence model.
 
 ## 10. Governance
 
@@ -428,6 +443,52 @@ explicit budgets, and closing rules, with control-policy search deferred to N15.
 LLM-era results (blackboard-style shared workspaces, global-workspace event loops, latent
 collaboration) inform the design but are not incorporated as contracts; the harness exists
 to test their claims under matched budgets before adoption.
+
+## 11. Conformance Requirements
+
+This spec is speculative (§0.4). These IDs bind an experimental implementation
+before the N15 gate; if that gate fails, the spec demotes to informative and
+these requirements withdraw with it.
+
+| ID | Level | Requirement |
+|----|-------|-------------|
+| N14.WS.1 | MUST | Make the event stream the workspace log, with the graph derived and reconstructible from it (§9.1). |
+| N14.WS.2 | MUST | Apply transactions atomically — a rejected transaction leaves no partial state (§3). |
+| N14.WS.3 | MUST | Derive conflicts rather than letting a writer declare its own resolution (§4). |
+| N14.WS.4 | MUST | Enforce the activation budget and terminate per §7 rather than running unbounded. |
+| N14.WS.5 | MUST | Detect deadlock and terminate rather than stalling silently (§7). |
+| N14.WS.6 | MUST NOT | Emit an unregistered event type — §9.1's list requires an N3 §6.1 amendment first. |
+
+### 11.1 Test Obligations
+
+1. Replaying the transaction log reconstructs the graph exactly.
+2. A rejected transaction leaves the graph byte-identical to its prior state.
+3. A run exceeding its budget terminates with the §7 outcome, not by hanging.
+
+---
+
+---
+
+## Annex A — Implementation Conformance Status (informative)
+
+This annex is **informative**, recording implementation state as of 2026-08-10.
+
+### A.1 Specified, Not Implemented
+
+No deliberation-workspace component exists. `components/workspace` is unrelated
+— it handles workflow workspace paths, not the shared graph of §2.
+
+None of §9.1's ten `workspace/*` event types is registered in N3 §6, so under
+N3 §6.1 none may be emitted (N14.WS.6). Since §9.1 also makes the event stream
+the workspace log (N14.WS.1), the spec's central mechanism is blocked on that
+registration.
+
+### A.2 Status
+
+This is expected rather than a defect: §0.4 declares the spec speculative,
+binding experimental implementations pre-gate, and it demotes to informative if
+N15's gate G0 fails. The annex records the position so a reader does not mistake
+the requirement set for a description of something running.
 
 ---
 

--- a/specs/normative/N15-collective-cognition-harness.md
+++ b/specs/normative/N15-collective-cognition-harness.md
@@ -6,7 +6,7 @@
 
 # N15 — Collective-Cognition Evaluation Harness
 
-**Version:** 0.1.0-draft
+**Version:** 0.2.0-draft
 **Date:** 2026-07-22
 **Status:** Draft
 **Conformance:** MUST (core protocol); workspace-conditional sections per §0.4
@@ -316,6 +316,48 @@ An MCI MUST:
 - enforce §5 comparability preconditions and replicate aggregation in `compare`
 - produce the §9 report including overhead fraction, ablation delta, and a G0 verdict
 - demonstrate absence-as-divergence with one induced crash run
+
+## 11. Conformance Requirements
+
+| ID | Level | Requirement |
+|----|-------|-------------|
+| N15.CH.1 | MUST | Register a hypothesis before running the condition that tests it (§2). |
+| N15.CH.2 | MUST | Match budgets across conditions so a result is not a spend artifact (§4). |
+| N15.CH.3 | MUST | Replicate to the §5 replication count before reporting an effect. |
+| N15.CH.4 | MUST | Record provenance sufficient to re-run a condition exactly (§5). |
+| N15.CH.5 | MUST | Score against the pre-registered metrics of §7, not metrics chosen after the fact. |
+| N15.CH.6 | MUST | Report a negative result with the same rigor as a positive one (§9). |
+
+### 11.1 Test Obligations
+
+1. A condition run twice from its recorded provenance produces the same
+   configuration.
+2. Budget parity between conditions is verifiable from the run record.
+3. A gate decision cites the pre-registered metric it was evaluated against.
+
+---
+
+---
+
+## Annex A — Implementation Conformance Status (informative)
+
+This annex is **informative**, recording implementation state as of 2026-08-10.
+
+### A.1 Specified, Not Implemented
+
+No harness component exists. The hypothesis registry (§2), budget protocol
+(§4), replication (§5), and scoring (§7) are unimplemented.
+
+`minibench` is the adjacent evaluation substrate in this workspace and is the
+natural host for §4's budget matching and §7's metrics rather than a new
+component.
+
+### A.2 Why This One Matters First
+
+N15 gates N14: §8's G0 decides whether the shared-deliberation workspace is
+kept or demoted. Until the harness exists, that gate cannot be run, so N14
+stays speculative indefinitely. Of the four specs in this group, N15 is the one
+whose absence blocks another spec's disposition.
 
 ---
 

--- a/specs/normative/N15-collective-cognition-harness.md
+++ b/specs/normative/N15-collective-cognition-harness.md
@@ -7,7 +7,7 @@
 # N15 — Collective-Cognition Evaluation Harness
 
 **Version:** 0.2.0-draft
-**Date:** 2026-07-22
+**Date:** 2026-08-10
 **Status:** Draft
 **Conformance:** MUST (core protocol); workspace-conditional sections per §0.4
 **Class:** Extension spec (N7+)


### PR DESCRIPTION
MINIFORGE_PR_BUDGET_OVERRIDE: Four specs sharing one starting state (0.1.0-draft, no requirement IDs, nothing implemented) and one treatment. Splitting yields four near-identical reviews. Well below the ~10-12k threshold where Copilot declines to review. Docs-only, no runtime code.

## Overview

Adds conformance requirement IDs, test obligations, and implementation annexes to the four youngest normative specs, and gates N14's event and evidence declarations on the specs that own them.

Full detail: [`docs/pull-requests/2026-08-10-chris-n12-n15-spec-complete.md`](docs/pull-requests/2026-08-10-chris-n12-n15-spec-complete.md)

## Why

**None of the four had requirement IDs.** N12 and N13 annotate conformance at the section level ("Conformance: MUST") — better than nothing, but not citable by a test.

**N14 §9.1 declared ten required event types, none registered in N3.** `workspace/opened`, `workspace/transaction-committed`, and eight others are listed as "Required event types (N3 envelope)". Under N3 §6 an implementation MUST NOT emit an unregistered `:event/type`, so the list could not be satisfied. This is the **fourth** spec carrying that pattern — N8, N9, and N10 each had a version.

It matters more here: §9.1 also makes the event stream the workspace log, with the graph derived and reconstructible from it. The blocked part is the spec's central mechanism.

**§9.2's four N6 exports** — decision record, transaction log, graph snapshot, per-run accounting — are likewise absent from N6 §3.1.1.

## Changes

- Requirement IDs and test obligations: `N12.CE.*` (7), `N13.PI.*` (6), `N14.WS.*` (6), `N15.CH.*` (6).
- N14 §9.1 and §9.2 gated on N3 §6.1 and N6 §3.1.1, lists retained as the proposed content of those amendments.
- Annex A on each; versions 0.1.0 → 0.2.0-draft with histories.

### Why N14's types were not simply added to N3

N3's registry is the contract every consumer reads. Adding ten types for a spec that is explicitly speculative (§0.4) with no implementation would misrepresent the stream's surface — a reader would see event types nothing will ever emit. The list stays with the spec proposing it until that spec survives its gate.

## Annex A — the finding with a downstream consequence

**N15 is the one spec whose absence blocks another's disposition.** Its §8 gate G0 decides whether N14 is kept or demoted to informative. Until the harness exists that gate cannot run, so N14 stays speculative indefinitely.

The others: no `context-economy` component (N12), though `components/context-pack` and the MCP context server are the natural host. No violation ledger or cross-repo promotion (N13) — which means §9's "gate as safety net" framing describes the current state by default rather than by design, since the teaching path it backs up does not exist. No deliberation workspace (N14); `components/workspace` is unrelated, handling workflow paths.

## Validation

Documentation only; no runtime code touched.

- `markdownlint` clean on all six changed files
- Verified none of N14's ten event types appears in N3's registry, and none of its four export types appears in N6
- Verified `components/workspace` is unrelated to N14's model before saying so

🤖 Generated with [Claude Code](https://claude.com/claude-code)
