### PR TITLE
docs(specs): complete N7, fix the §11 collision in N14

### DIFF
--- a/docs/pull-requests/2026-08-10-chris-n7-and-n14-fix.md
+++ b/docs/pull-requests/2026-08-10-chris-n7-and-n14-fix.md
@@ -1,0 +1,95 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# docs: N7 completion, and a §11 collision from the N12–N15 pass
+
+## Overview
+
+Completes N7, which the sweep missed, and fixes a duplicate section number
+introduced by the previous PR.
+
+## Motivation
+
+**N7 was surveyed and then never scheduled.** It appeared in the original
+survey with 0 requirement IDs, and every subsequent wave plan omitted it. The
+final verification across all 22 normative specs surfaced it as the only
+established spec still carrying no requirement IDs and no annex. This PR closes
+that.
+
+**N14 gained a duplicate §11.** The N12–N15 pass appended a
+`## 11. Conformance Requirements` to N14, which already had
+`## 11. Conformance staging` at line 393. The appended section landed after
+§13, so the file read 10, 11, 12, 13, 11. My verification script caught it after
+merge — it should have caught it before, and would have if I had run the
+duplicate check per-file after editing rather than only on the final set.
+
+## Changes in Detail
+
+### N7
+
+- `N7.EX.*` (4), `N7.VF.*` (2), `N7.AC.*` (4) requirement IDs with four test
+  obligations, placed as §8.5 so the MCI section keeps its number.
+- Annex A.
+
+### N14
+
+- `## 11. Conformance Requirements` → `## 14.`, with its subsection. Top-level
+  sections now run 0–14 without repetition.
+
+## What N7 turns out to be
+
+N7 is the **best-served spec in the set** on the dimension that defeated every
+other extension spec reviewed in this sweep: its event family is both
+registered and emitted. The nine `opsv.*` types are in N3 §3.14's registry, and
+`event-stream/opsv.clj` emits them with tests in `phase-opsv` and
+`event-stream`. N8, N9, N10, and N14 each declared event types that were never
+registered, so none of them can be emitted conformantly.
+
+`components/opsv` implements risk, convergence, actuation, verification, and
+schema, with a simulated adapter alongside.
+
+Its gap is elsewhere and is a dependency rather than an omission: §7.3 requires
+apply actions to execute as N10-governed effects with verified rollback and
+postcondition monitoring, and N10 Annex A records that no postcondition
+component exists. N7's strongest safety requirement rests on machinery that is
+not there.
+
+## Testing Plan
+
+Specification change; no runtime code touched.
+
+- `markdownlint` clean on all four changed files.
+- No duplicate section numbers in either spec; N14's top-level sections verified
+  contiguous 0–14.
+- Verified N7's registered event types are emitted before claiming so.
+
+## Deployment Plan
+
+Documentation only. Merges to `main` with no runtime effect.
+
+## Follow-on Work
+
+1. N7.AC.2 depends on N10's postcondition monitoring, which does not exist —
+   that dependency should be tracked against N10's implementation rather than
+   N7's.
+2. `opsv.drift/detected` is registered in N3 with no producer.
+
+## Related Issues/PRs
+
+- Completes the normative spec set; follows the N1–N11, delta, and N12–N15 passes
+- Fixes a collision introduced by [#1746](https://github.com/miniforge-ai/miniforge/pull/1746)
+- Governed by: `standards/miniforge/foundations/specification-standards` (020)
+
+## Checklist
+
+- [x] Gap in my own sweep identified and closed
+- [x] Duplicate section number from the prior PR fixed
+- [x] Annex A marked informative
+- [x] No spec content extracted from implementation code (020)
+- [x] Copyright header present (810)
+- [x] `markdownlint` clean
+- [x] SPEC_INDEX updated
+- [x] PR doc created (721)

--- a/specs/SPEC_INDEX.md
+++ b/specs/SPEC_INDEX.md
@@ -6,7 +6,7 @@
 
 # miniforge Specification Index
 
-**Version:** 0.22.0-draft
+**Version:** 0.23.0-draft
 **Date:** 2026-08-10
 **Status:** Living specification during OSS development
 
@@ -610,6 +610,18 @@ Normative specs are enforced by:
 ---
 
 ## Version History
+
+- **0.23.0-draft** (2026-08-10) - N7 completion, and a fix to N14 from the previous pass.
+  **N7** was missed by the sweep entirely — it was surveyed and then not scheduled. Added
+  `N7.EX.*`, `N7.VF.*`, `N7.AC.*` requirement IDs, test obligations, and Annex A. N7 turns out to
+  be the best-served spec in the set on the dimension that defeated the others: its nine `opsv.*`
+  event types are both registered in N3 §3.14 and emitted by `event-stream/opsv.clj` with tests,
+  where every other extension spec reviewed declared types that were never registered. Its gap is
+  elsewhere — §7.3 requires apply actions to run as N10-governed effects with postcondition
+  monitoring, and N10 Annex A records that no such component exists.
+  **N14** carried two `## 11.` sections after the N12–N15 pass: the pre-existing "Conformance
+  staging" and the "Conformance Requirements" that pass appended. Renumbered to §14.
+  Per-spec bumps: N7 0.2.1→0.3.0, N14 0.2.0→0.2.1
 
 - **0.22.0-draft** (2026-08-10) - Delta-spec completion pass across all seven deltas. Metadata was
   carried three different ways — a core-style header block (N11-delta), a bulleted list under the

--- a/specs/normative/N14-shared-deliberation-workspace.md
+++ b/specs/normative/N14-shared-deliberation-workspace.md
@@ -6,7 +6,7 @@
 
 # N14 — Shared Deliberation Workspace
 
-**Version:** 0.2.0-draft
+**Version:** 0.2.1-draft
 **Date:** 2026-08-10
 **Status:** Draft (Speculative — see §0.4)
 **Conformance:** MUST, scoped per §0.4
@@ -444,7 +444,7 @@ LLM-era results (blackboard-style shared workspaces, global-workspace event loop
 collaboration) inform the design but are not incorporated as contracts; the harness exists
 to test their claims under matched budgets before adoption.
 
-## 11. Conformance Requirements
+## 14. Conformance Requirements
 
 This spec is speculative (§0.4). These IDs bind an experimental implementation
 before the N15 gate; if that gate fails, the spec demotes to informative and
@@ -459,7 +459,7 @@ these requirements withdraw with it.
 | N14.WS.5 | MUST | Detect deadlock and terminate rather than stalling silently (§7). |
 | N14.WS.6 | MUST NOT | Emit an unregistered event type — §9.1's list requires an N3 §6.1 amendment first. |
 
-### 11.1 Test Obligations
+### 14.1 Test Obligations
 
 1. Replaying the transaction log reconstructs the graph exactly.
 2. A rejected transaction leaves the graph byte-identical to its prior state.

--- a/specs/normative/N7-Operational-Policy-Synthesis.md
+++ b/specs/normative/N7-Operational-Policy-Synthesis.md
@@ -432,8 +432,6 @@ A minimal compliant OPSV implementation MUST:
 
 ---
 
----
-
 ## Annex A — Implementation Conformance Status (informative)
 
 This annex is **informative**, recording implementation state as of 2026-08-10.

--- a/specs/normative/N7-Operational-Policy-Synthesis.md
+++ b/specs/normative/N7-Operational-Policy-Synthesis.md
@@ -6,8 +6,8 @@
 
 # N7 — Operational Policy Synthesis With Verification
 
-**Version:** 0.2.1-draft
-**Date:** 2026-08-06
+**Version:** 0.3.0-draft
+**Date:** 2026-08-10
 **Status:** Complete
 **Conformance:** MUST
 **Class:** Extension spec (N7+)
@@ -385,6 +385,36 @@ Miniforge MUST implement the canonical N5 §2.3.3 commands under `fleet`:
 The TUI SHALL provide drill-down:
 Fleet → Service → OPSV Runs → (Experiment Pack, Events, Evidence, Policy Diff, Verification)
 
+## 8.5 Conformance Requirements
+
+Requirement IDs are stable identifiers for this spec's normative statements.
+IDs are never reused; a withdrawn requirement is marked withdrawn.
+
+| ID | Level | Requirement |
+|----|-------|-------------|
+| N7.EX.1 | MUST | Record an environment fingerprint for every experiment run (§3, §4). |
+| N7.EX.2 | MUST | Abort on guardrail breach and execute the declared rollback (§5). |
+| N7.EX.3 | MUST | Bound convergence by the declared iteration and budget limits (§3). |
+| N7.EX.4 | MUST | Emit the §3.14 event family of N3 for every lifecycle transition. |
+| N7.VF.1 | MUST | Evaluate verification against pre-declared criteria, not criteria chosen after the run (§6). |
+| N7.VF.2 | MUST | Link every OPSV event and artifact to its evidence bundle per N6 (§4, §7.1). |
+| N7.AC.1 | MUST | Default to `PR_ONLY` actuation; `APPLY_ALLOWED` requires the §5.4 gate (§7.2, §7.3). |
+| N7.AC.2 | MUST | Execute apply actions as N10-governed effects with verified rollback (§7.3). |
+| N7.AC.3 | MUST | Record both apply and rollback outcomes as artifacts, events, and evidence on postcondition failure (§7.3). |
+| N7.AC.4 | MUST | Include the evidence bundle reference and rollback instructions in every emitted PR body (§7.2). |
+
+### 8.5.1 Test Obligations
+
+1. A guardrail breach aborts the experiment and the rollback runs, both observable
+   on the stream (N7.EX.2).
+2. A run's environment fingerprint is sufficient to detect drift on re-run
+   (N7.EX.1).
+3. `APPLY_ALLOWED` is refused when the §5.4 gate has not passed (N7.AC.1).
+4. A failed postcondition produces both outcomes in evidence, not just the
+   rollback (N7.AC.3).
+
+---
+
 ## 9. Minimal compliant implementation (MCI)
 
 A minimal compliant OPSV implementation MUST:
@@ -399,6 +429,43 @@ A minimal compliant OPSV implementation MUST:
 - emit PRs as N10-governed actions with provenance
 - default effective actuation to `:recommend-only`
 - honor N8 emergency stop and record rollback/disposition evidence
+
+---
+
+---
+
+## Annex A — Implementation Conformance Status (informative)
+
+This annex is **informative**, recording implementation state as of 2026-08-10.
+
+### A.1 Implemented
+
+N7 is the best-served spec in the set on the dimension that has defeated the
+others: **its event family is both registered and emitted.** The nine
+`opsv.*` types of N3 §3.14 appear in N3's registry, and
+`event-stream/opsv.clj` emits them with tests in `phase-opsv` and
+`event-stream`. Every other extension spec reviewed in this pass declared event
+types that were never registered.
+
+`components/opsv` implements risk scoring, convergence, actuation, verification,
+and schema; `components/opsv-adapter-simulated` provides a simulated substrate.
+
+### A.2 Specified, Not Verified
+
+- **Guardrail abort and rollback (N7.EX.2).** `convergence.clj` references
+  guardrails, but nothing verifies that a breach triggers the declared rollback
+  end to end.
+- **Actuation gating (N7.AC.1).** `actuation.clj` exists; whether
+  `APPLY_ALLOWED` is refused absent the §5.4 gate is untested.
+- **Drift detection (§3).** No implementation — `opsv.drift/detected` is
+  registered in N3 §3.14 with no producer.
+
+### A.3 Structural
+
+§7.3 requires apply actions to execute as N10-governed effects with verified
+rollback and postcondition monitoring. N10 Annex A records that no
+postcondition-monitoring component exists, so this requirement currently
+depends on machinery that is not there.
 
 ---
 


### PR DESCRIPTION
MINIFORGE_PR_BUDGET_OVERRIDE: Spec amendment plus a section-numbering fix from the prior PR. Well below the ~10-12k threshold where Copilot declines to review. Docs-only, no runtime code.

## Overview

Completes N7, which my sweep missed, and fixes a duplicate section number the previous PR introduced.

Full detail: [`docs/pull-requests/2026-08-10-chris-n7-and-n14-fix.md`](docs/pull-requests/2026-08-10-chris-n7-and-n14-fix.md)

## Why

**N7 was surveyed and then never scheduled.** It appeared in the original survey with 0 requirement IDs, and every subsequent wave plan omitted it. The final verification across all 22 normative specs surfaced it as the only established spec still carrying no requirement IDs and no annex.

**N14 gained a duplicate §11.** The N12–N15 pass appended `## 11. Conformance Requirements` to a file that already had `## 11. Conformance staging`. The appended section landed after §13, so the file read 10, 11, 12, 13, 11. My verification caught it after merge — running the duplicate check per-file after editing, rather than only on the final set, would have caught it before.

## Changes

- **N7:** `N7.EX.*` (4), `N7.VF.*` (2), `N7.AC.*` (4) with four test obligations, placed as §8.5 so the MCI section keeps its number. Annex A added.
- **N14:** `## 11. Conformance Requirements` → `## 14.`; top-level sections now run 0–14 without repetition.

## What N7 turns out to be

N7 is the **best-served spec in the set** on the dimension that defeated every other extension spec in this sweep: its event family is both registered *and* emitted. The nine `opsv.*` types are in N3 §3.14's registry, and `event-stream/opsv.clj` emits them with tests in `phase-opsv` and `event-stream`. N8, N9, N10, and N14 each declared event types that were never registered, so none can be emitted conformantly.

`components/opsv` implements risk, convergence, actuation, verification, and schema, with a simulated adapter alongside.

Its gap is a dependency rather than an omission: §7.3 requires apply actions to execute as N10-governed effects with verified rollback and postcondition monitoring, and N10 Annex A records that no postcondition component exists. N7's strongest safety requirement rests on machinery that is not there.

## Validation

Documentation only; no runtime code touched.

- `markdownlint` clean on all four changed files
- No duplicate section numbers in either spec; N14's top-level sections verified contiguous 0–14
- Verified N7's registered event types are actually emitted before claiming so

🤖 Generated with [Claude Code](https://claude.com/claude-code)
