### PR TITLE
chore(workflow): remove dead #_ test block; fix stale ns docstring

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/validator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/validator.clj
@@ -18,7 +18,7 @@
 
 (ns ai.miniforge.workflow.validator
   "Validation for workflow configurations.
-   Handles schema validation (Malli) and DAG validation (cycles, reachability)."
+   Handles schema validation (Malli) and DAG structure validation (reachability, entry phase, phase references)."
   (:require
    [clojure.java.io :as io]
    [clojure.edn :as edn]

--- a/components/workflow/test/ai/miniforge/workflow/validator_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/validator_test.clj
@@ -109,28 +109,6 @@
       (is (:valid? result) "Valid DAG should pass")
       (is (empty? (:errors result)) "Valid DAG should have no errors")))
 
-  ;; Note: We no longer check for cycles as they are valid for retry/rollback patterns
-  ;; This test is commented out
-  #_(testing "Cycle detection fails validation"
-      (let [config {:workflow/id :test
-                    :workflow/version "1.0.0"
-                    :workflow/type :test
-                    :workflow/phases
-                    [{:phase/id :a
-                      :phase/name "A"
-                      :phase/agent-type :planner
-                      :phase/on-success {:transition/target :b}}
-                     {:phase/id :b
-                      :phase/name "B"
-                      :phase/agent-type :implementer
-                      :phase/on-success {:transition/target :a}}]  ; Cycle: a -> b -> a
-                    :workflow/entry-phase :a
-                    :workflow/exit-phases [:b]}
-            result (validator/validate-dag config)]
-        (is (not (:valid? result)) "Cycle should fail validation")
-        (is (some #(re-find #"cycle" %) (:errors result))
-            "Should report cycle")))
-
   (testing "Non-existent phase reference fails validation"
     (let [config {:workflow/id :test
                   :workflow/version "1.0.0"


### PR DESCRIPTION
## Summary

- Remove the `#_`-reader-macro-commented cycle-detection test from `validator_test.clj` (Dewey 008 — no dead code)
- Update the `ns` docstring in `validator.clj` to drop the stale "cycles" reference

## Motivation

Cycle detection in the workflow validator was intentionally removed when retry/rollback patterns were introduced. The test block was disabled with `#_` rather than deleted, leaving dead code. The `#_` reader macro silently discards its form — this is dead code, not a legitimate hold. The ns docstring still referenced "cycles" even though the validator no longer checks for them.

## Changes

| File/Area | Change |
|-----------|--------|
| `components/workflow/test/ai/miniforge/workflow/validator_test.clj` | Delete 22-line dead `#_`-commented cycle test block and its preceding prose comment |
| `components/workflow/src/ai/miniforge/workflow/validator.clj` | Update ns docstring: remove "cycles", accurately describe current checks (reachability, entry phase, phase references) |

## Testing

- [ ] All tests pass (`bb test`)
- [ ] Pre-commit validation passes (no `--no-verify`)
- [ ] No commented-out tests (see [guidelines](../docs/development-guidelines.md#testing-discipline))
- [ ] No giant functions (see [guidelines](../docs/development-guidelines.md#function-design))
- [ ] Functions are small and composable (target: 5-15 lines, max: 30 lines)
- [ ] New behavior has tests

## Checklist

### Required

- [x] All tests pass (`bb test`) — no logic changed, only dead code removed
- [x] Pre-commit validation passes (no `--no-verify`)
- [x] No commented-out tests
- [x] Focused PR (single concern)

### Best Practices

- [ ] Linting passes (`bb lint:clj:all`)
- [ ] README/docs updated if needed

## Related

- Dewey 008 (no-dead-code): delete obsolete code in the same change

---
_Generated by [Claude Code](https://claude.ai/code/session_013fW1Hw8LN7X1G4jX63EH78)_