### PR TITLE
docs(specs): reclassify N4-delta to informative, fold its contracts into N4

### DIFF
--- a/docs/pull-requests/2026-08-10-chris-n4-delta-reclassification.md
+++ b/docs/pull-requests/2026-08-10-chris-n4-delta-reclassification.md
@@ -14,10 +14,10 @@ surfaced.
 
 ## Motivation
 
-**The document bound nothing.** Its requirements are written lowercase — 25
-`must`, 4 `should` — against one uppercase MUST and one SHALL. Per RFC 8174
-only the uppercase forms carry normative weight, so a document indexed as a
-normative amendment to N4 was formally requiring almost nothing.
+**The document bound nothing.** Its requirements are written entirely
+lowercase — 25 `must`, 4 `should` — with **no uppercase RFC 2119 keyword
+anywhere**. Per RFC 8174 only the uppercase forms carry normative weight, so a
+document indexed as a normative amendment to N4 formally required nothing.
 
 **Its subject does not exist.** N4-delta specifies a document-to-candidate
 compiler with a candidate lifecycle, producer types, and promotion rules.
@@ -85,10 +85,18 @@ Both were mine, both from unverified assumptions in a command:
    is indexed too. I ran the check in the main checkout, which sits on an
    unrelated branch and never picked up the merges, so I read a stale file.
 2. I reported that N4-delta **"contains no RFC 2119 keyword… states no
-   requirements."** It contains no *uppercase* keyword; it states about
-   twenty-five requirements in lowercase. My grep was case-sensitive. The
-   0.22.0 index entry carrying that claim has been corrected in place rather
-   than left standing.
+   requirements."** The first half was right — the original file has zero
+   uppercase keywords. The second was wrong: it states about twenty-five
+   requirements in lowercase, which my case-sensitive grep missed.
+
+   I then over-corrected, telling the maintainer the document "contains one
+   uppercase MUST and one SHALL". That came from re-measuring the file *after*
+   I had added a Status section quoting those words — I was counting my own
+   text. Verified against the pre-edit blob this time: zero. The 0.22.0 index
+   entry is corrected in place rather than left standing.
+
+   The root cause of all three passes at this: measuring a file I had already
+   modified, without checking the original.
 
 ## Testing Plan
 

--- a/docs/pull-requests/2026-08-10-chris-n4-delta-reclassification.md
+++ b/docs/pull-requests/2026-08-10-chris-n4-delta-reclassification.md
@@ -1,0 +1,130 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# docs: reclassify N4-delta to informative, fold its novel contracts into N4
+
+## Overview
+
+Moves the policy-compilation delta from `normative/` to `informative/`, folds
+the two ideas in it that N4 lacked, and records a larger gap the investigation
+surfaced.
+
+## Motivation
+
+**The document bound nothing.** Its requirements are written lowercase — 25
+`must`, 4 `should` — against one uppercase MUST and one SHALL. Per RFC 8174
+only the uppercase forms carry normative weight, so a document indexed as a
+normative amendment to N4 was formally requiring almost nothing.
+
+**Its subject does not exist.** N4-delta specifies a document-to-candidate
+compiler with a candidate lifecycle, producer types, and promotion rules.
+Nothing in the tree implements it — no candidate keys, no compiler component.
+
+**What does exist is better.** `components/policy-calibration` decides
+gate-readiness *empirically*: it measures a semantic judge's false-positive and
+recall rates over a seeded corpus across independent runs, and
+`gate_check.clj` refuses to ship a rule that gates via the judge without a
+passing `:gate-ready?` record. That answers the same question as N4-delta's
+declared `enforceability` field, with evidence instead of assertion.
+
+## Changes in Detail
+
+### Reclassification
+
+`specs/normative/N4-delta-policy-compilation-contract.md` →
+`specs/informative/I-policy-compilation-contract.md`, with its Status section
+rewritten to say why. Removed from the index's amendments table and
+applicability table; added to the informative listing.
+
+### Folded into N4
+
+Both optional, both defaulting to current behaviour, so no existing rule is
+invalidated.
+
+- **`:rule/provenance` (§2.3.3)** — source-type, source-ref, support-type,
+  source-fingerprint, plus optional locator, excerpt-hash, and compiler
+  identity. OPTIONAL for hand-authored rules, REQUIRED for derived ones. Two
+  rules govern it: a derived rule retains provenance from every materially
+  contributing source rather than collapsing to one pointer, and provenance
+  survives promotion. This is the rule-level counterpart to N6 §2.13 — pack
+  hash tells a reader which bytes ran, provenance tells them why those bytes
+  say what they say.
+- **`:rule/enforceability` (§2.3.2)** — `:executable` / `:heuristic` /
+  `:advisory` / `:human-review`, defaulting to `:executable`, with the rule
+  that a rule MUST NOT be silently promoted to `:executable`. Silent promotion
+  turns guidance into a blocker for work that was never meant to be gated, and
+  the operator sees only the block. Severity and enforceability are orthogonal:
+  a `:critical` `:advisory` rule says "this matters and a human decides", not
+  "this blocks".
+
+§2.3.2 defers to measurement where both exist: a rule declaring `:executable`
+that fails calibration does not gate.
+
+### Recorded, not specified — N4 Annex A.5
+
+The investigation surfaced something bigger than the fold. **N4 mentions
+calibration zero times**, yet the shipped rule model carries
+`:rule/enforcement {:action :hard-halt | :require-approval}`, a
+semantic-vs-deterministic detector distinction, and a gate that refuses to ship
+a semantic gating rule without an evidence-backed reliability record.
+
+That is one of the stronger safety properties in the system and it exists only
+in code. Annex A.5 records it. Writing the contract belongs in a deliberate N4
+amendment — reverse-engineering it from the implementation is what standard 020
+forbids.
+
+## Two corrections to earlier claims
+
+Both were mine, both from unverified assumptions in a command:
+
+1. I reported that **nine specs were missing from SPEC_INDEX**. They are not.
+   All seven deltas are in an `### Indexed normative amendments` table and N11
+   is indexed too. I ran the check in the main checkout, which sits on an
+   unrelated branch and never picked up the merges, so I read a stale file.
+2. I reported that N4-delta **"contains no RFC 2119 keyword… states no
+   requirements."** It contains no *uppercase* keyword; it states about
+   twenty-five requirements in lowercase. My grep was case-sensitive. The
+   0.22.0 index entry carrying that claim has been corrected in place rather
+   than left standing.
+
+## Testing Plan
+
+Specification change; no runtime code touched.
+
+- `markdownlint` clean on all four changed files.
+- No duplicate section numbers in N4 — an A.5 collision was caught and
+  renumbered during the edit.
+- Verified `components/policy-calibration` and `gate_check.clj` behave as
+  described before writing Annex A.5.
+- Verified no `candidate/*` keys exist in the tree before claiming the compiler
+  is unimplemented.
+
+## Deployment Plan
+
+Documentation only. Merges to `main` with no runtime effect.
+
+## Follow-on Work
+
+1. Specify the enforcement/detector/calibration model in N4 — Annex A.5's gap.
+   This is the one with a real safety property behind it.
+2. If the pack compiler is ever built, it is Miniforge-product scope (like
+   N7–N10), not MiniForge Core: nothing outside miniforge originates packs.
+
+## Related Issues/PRs
+
+- Follows the full spec-completion sweep (N1–N15, deltas)
+- Governed by: `standards/miniforge/foundations/specification-standards` (020)
+
+## Checklist
+
+- [x] Two earlier incorrect claims identified and corrected
+- [x] Novel contracts folded forward; the rest moved with the document
+- [x] Optional defaults so no existing rule is invalidated
+- [x] Calibration gap recorded, not reverse-engineered (020)
+- [x] Index amendments and applicability tables updated
+- [x] Copyright header present (810)
+- [x] `markdownlint` clean
+- [x] PR doc created (721)

--- a/specs/SPEC_INDEX.md
+++ b/specs/SPEC_INDEX.md
@@ -6,7 +6,7 @@
 
 # miniforge Specification Index
 
-**Version:** 0.23.0-draft
+**Version:** 0.24.0-draft
 **Date:** 2026-08-10
 **Status:** Living specification during OSS development
 
@@ -62,7 +62,6 @@ They use RFC 2119 terminology (MUST, SHALL, SHOULD, MAY).
 |----------|------------|
 | N1-N6 | Every product built on MiniForge Core |
 | N2 checkpoint/resume delta | Implementations that persist workflow state |
-| N4 policy-compilation delta | Implementations that originate compiled policy packs |
 | N5 supervisory deltas | Miniforge SDLC control-plane producers and consumers |
 | N7-N10 | Miniforge Fleet/SDLC capabilities |
 | N11 + runtime-adapter delta | Governed task runtimes in Core and consuming products |
@@ -245,7 +244,6 @@ Defines:
 | File | Base contract | Applicability |
 |------|---------------|---------------|
 | [N2-delta-phase-checkpoint-and-resume.md](normative/N2-delta-phase-checkpoint-and-resume.md) | N2 | Persisted workflow state |
-| [N4-delta-policy-compilation-contract.md](normative/N4-delta-policy-compilation-contract.md) | N4 | Policy-pack origination |
 | [N5-delta-supervisory-control-plane.md](normative/N5-delta-supervisory-control-plane.md) | N5 | Miniforge supervisory UI/API |
 | [N5-delta-2-pr-scoring.md](normative/N5-delta-2-pr-scoring.md) | N5 supervisory | Miniforge PR fleet |
 | [N5-delta-3-observational-entities.md](normative/N5-delta-3-observational-entities.md) | N5 supervisory | Miniforge entity projections |
@@ -475,6 +473,12 @@ Defines:
 
 ## Informative Documentation (Non-Normative)
 
+- [informative/I-policy-compilation-contract.md](informative/I-policy-compilation-contract.md) — policy candidate
+  model and pack compilation design. Reclassified from a normative N4 amendment on 2026-08-10:
+  its requirements were lowercase (non-binding per RFC 8174) and the compiler it describes does
+  not exist. Its two novel ideas — per-rule provenance and enforceability class — were folded
+  into N4 §2.3.2–§2.3.3.
+
 These documents provide guidance, examples, and context but do NOT define contractual requirements.
 
 ### UX References
@@ -611,6 +615,20 @@ Normative specs are enforced by:
 
 ## Version History
 
+- **0.24.0-draft** (2026-08-10) - N4-delta reclassified to informative; its unique content folded
+  into N4. The document's requirements were written lowercase and so bound nothing per RFC 8174,
+  and the document-to-candidate compiler it specifies does not exist — what exists instead is
+  `components/policy-calibration`, which decides gate-readiness empirically by measuring a semantic
+  judge's false-positive and recall rates. **Folded into N4:** `:rule/provenance` (§2.3.3), the
+  rule-level counterpart to N6 §2.13's reproducibility requirement, and `:rule/enforceability`
+  (§2.3.2) with the rule that a rule MUST NOT be silently promoted to `:executable`. Both optional,
+  defaulting to current behaviour, so no existing rule is invalidated. **N4 Annex A.5** records a
+  larger finding: the shipped rule model carries `:rule/enforcement` actions, a
+  semantic-vs-deterministic detector distinction, and a calibration gate refusing to ship a
+  semantic gating rule without a passing `:gate-ready?` record — and N4 mentions calibration zero
+  times. That safety property exists only in code; specifying it is a deliberate future amendment
+  rather than something to reverse-engineer (020). Per-spec bumps: N4 0.7→0.8
+
 - **0.23.0-draft** (2026-08-10) - N7 completion, and a fix to N14 from the previous pass.
   **N7** was missed by the sweep entirely — it was surveyed and then not scheduled. Added
   `N7.EX.*`, `N7.VF.*`, `N7.AC.*` requirement IDs, test obligations, and Annex A. N7 turns out to
@@ -630,10 +648,11 @@ Normative specs are enforced by:
   Amends and Related preserved. Conformance requirement IDs and test obligations added to the six
   deltas carrying MUSTs: `N2D.CK.*`, `N5D1.SV.*`, `N5D2.SC.*`, `N5D3.OE.*`, `N5D4.AE.*`,
   `N11D.RA.*`. N5-delta-3's second `§3.6` renumbered to `§3.7` — it duplicated the pack-management
-  producer's number, and both inbound references mean the producer. **N4-delta contains no RFC 2119
-  keyword at all** and so states no requirements; a Status subsection records that it is effectively
-  informative until its requirements are stated or it is reclassified, and names the two open
-  dispositions rather than choosing one.
+  producer's number, and both inbound references mean the producer. **N4-delta contains no *uppercase* RFC 2119
+  keyword** and so binds nothing per RFC 8174; a Status subsection recorded that it is effectively
+  informative until its requirements are stated or it is reclassified. (That subsection originally
+  read "states no requirements", which was wrong — it states about twenty-five, in lowercase.
+  Corrected in 0.24.0, which reclassified the document.)
 - **0.21.0-draft** (2026-08-10) - N12–N15 completion pass. Conformance requirement IDs and test
   obligations added to all four (`N12.CE.*`, `N13.PI.*`, `N14.WS.*`, `N15.CH.*`), plus Annex A on
   each. **N14 §9.1** declared ten `workspace/*` types as required N3 events and none is registered

--- a/specs/SPEC_INDEX.md
+++ b/specs/SPEC_INDEX.md
@@ -616,7 +616,8 @@ Normative specs are enforced by:
 ## Version History
 
 - **0.24.0-draft** (2026-08-10) - N4-delta reclassified to informative; its unique content folded
-  into N4. The document's requirements were written lowercase and so bound nothing per RFC 8174,
+  into N4. The document's requirements were written lowercase, with no uppercase
+  keyword anywhere, and so bound nothing per RFC 8174,
   and the document-to-candidate compiler it specifies does not exist — what exists instead is
   `components/policy-calibration`, which decides gate-readiness empirically by measuring a semantic
   judge's false-positive and recall rates. **Folded into N4:** `:rule/provenance` (§2.3.3), the
@@ -648,11 +649,11 @@ Normative specs are enforced by:
   Amends and Related preserved. Conformance requirement IDs and test obligations added to the six
   deltas carrying MUSTs: `N2D.CK.*`, `N5D1.SV.*`, `N5D2.SC.*`, `N5D3.OE.*`, `N5D4.AE.*`,
   `N11D.RA.*`. N5-delta-3's second `§3.6` renumbered to `§3.7` — it duplicated the pack-management
-  producer's number, and both inbound references mean the producer. **N4-delta contains no *uppercase* RFC 2119
+  producer's number, and both inbound references mean the producer. **N4-delta contains no uppercase RFC 2119
   keyword** and so binds nothing per RFC 8174; a Status subsection recorded that it is effectively
-  informative until its requirements are stated or it is reclassified. (That subsection originally
-  read "states no requirements", which was wrong — it states about twenty-five, in lowercase.
-  Corrected in 0.24.0, which reclassified the document.)
+  informative until its requirements are stated or it is reclassified. (That subsection also read
+  "states no requirements", which was wrong — it states about twenty-five, in lowercase. Corrected
+  in 0.24.0, which reclassified the document.)
 - **0.21.0-draft** (2026-08-10) - N12–N15 completion pass. Conformance requirement IDs and test
   obligations added to all four (`N12.CE.*`, `N13.PI.*`, `N14.WS.*`, `N15.CH.*`), plus Annex A on
   each. **N14 §9.1** declared ten `workspace/*` types as required N3 events and none is registered

--- a/specs/SPEC_INDEX.md
+++ b/specs/SPEC_INDEX.md
@@ -617,7 +617,7 @@ Normative specs are enforced by:
 
 - **0.24.0-draft** (2026-08-10) - N4-delta reclassified to informative; its unique content folded
   into N4. The document's requirements were written lowercase, with no uppercase
-  keyword anywhere, and so bound nothing per RFC 8174,
+  RFC 2119 keyword anywhere, and so bound nothing per RFC 8174,
   and the document-to-candidate compiler it specifies does not exist — what exists instead is
   `components/policy-calibration`, which decides gate-readiness empirically by measuring a semantic
   judge's false-positive and recall rates. **Folded into N4:** `:rule/provenance` (§2.3.3), the

--- a/specs/informative/I-policy-compilation-contract.md
+++ b/specs/informative/I-policy-compilation-contract.md
@@ -33,8 +33,8 @@ The stable boundary is the contract between source policy material and usable po
 - `repo-config-profile.spec.*`  
   Declares repo-local pack references and attachment semantics.
 - `policy-pack-compilation.spec.*`  
-  Work spec for current compile / derive / compose implementation and UX. This normative extension constrains that work
-  spec.
+  Work spec for current compile / derive / compose implementation and UX. This
+  document informs that work spec; since reclassification it constrains nothing.
 
 ## Spec metadata
 

--- a/specs/informative/I-policy-compilation-contract.md
+++ b/specs/informative/I-policy-compilation-contract.md
@@ -49,12 +49,13 @@ This document was previously indexed as a normative amendment to N4. It is now
 
 Two things prompted the move.
 
-First, its requirements were written in lowercase (`must`, `should`) rather
-than the RFC 2119 uppercase forms. Per RFC 8174 only the uppercase forms carry
-normative weight, so the document read as normative while formally binding
-nothing. An earlier revision of this section overstated that as "contains no
-RFC 2119 keyword… states no requirements" — it states roughly twenty-five, in a
-form that does not bind.
+First, its requirements were written entirely in lowercase (`must`, `should`).
+The document contained **no uppercase RFC 2119 keyword at all**, and per
+RFC 8174 only the uppercase forms carry normative weight — so it read as
+normative while formally binding nothing. An earlier revision of this section
+put that as "states no requirements", which was wrong: it states roughly
+twenty-five, in a form that does not bind. The absence of keywords was real;
+the absence of requirements was not.
 
 Second and more decisively, the machinery it describes — a document-to-candidate
 compiler with a candidate lifecycle and promotion rules — does not exist. What

--- a/specs/informative/I-policy-compilation-contract.md
+++ b/specs/informative/I-policy-compilation-contract.md
@@ -39,13 +39,13 @@ The stable boundary is the contract between source policy material and usable po
 ## Spec metadata
 
 - **Title:** Policy Candidate Model and Pack Compilation Contract
-- **Type:** Normative
+- **Type:** Informative (formerly a normative amendment to N4)
 - **Scope:** Open-source policy origination substrate
 
 ### Status: informative
 
 This document was previously indexed as a normative amendment to N4. It is now
-**informative** and states no requirements.
+**informative**: nothing in it binds an implementation.
 
 Two things prompted the move.
 
@@ -66,7 +66,7 @@ declared enforceability field, and it is already running.
 
 The two ideas here that were not already in N4 have been folded into it:
 per-rule provenance and the enforceability class, both as optional fields
-(N4 §2.2.1, §2.2.2).
+(N4 §2.3.2, §2.3.3).
 
 What remains in this document is design material for a compiler that may never
 be built. If it is built, it is Miniforge-product scope — like N7–N10 — rather

--- a/specs/informative/I-policy-compilation-contract.md
+++ b/specs/informative/I-policy-compilation-contract.md
@@ -3,12 +3,12 @@
   Author: Christopher Lester (christopher@miniforge.ai)
   Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
 -->
-# Normative Spec Extension: Policy Candidate Model and Pack Compilation Contract
+# Informative: Policy Candidate Model and Pack Compilation Contract
 
 **Version:** 0.1.0-draft
 **Date:** 2026-08-10
 **Status:** Draft
-**Conformance:** See §Status below
+**Conformance:** None — informative
 
 ## Purpose
 
@@ -42,27 +42,35 @@ The stable boundary is the contract between source policy material and usable po
 - **Type:** Normative
 - **Scope:** Open-source policy origination substrate
 
-### Status: requirements unstated
+### Status: informative
 
-This spec sits in `specs/normative/` but contains **no RFC 2119 keyword** —
-not one MUST, SHALL, SHOULD, or MAY. Standard 020 requires normative specs to
-use them, and an implementation cannot conform to a document that states no
-requirements.
+This document was previously indexed as a normative amendment to N4. It is now
+**informative** and states no requirements.
 
-Its content is a design description: it defines a candidate model, provenance
-fields, an approval lifecycle, and compilation guarantees in declarative prose.
-Turning that prose into requirements is a deliberate authoring act with real
-consequences for implementers, so it is not done here — inventing MUSTs on
-someone else's design would be worse than recording the gap.
+Two things prompted the move.
 
-Until that happens this spec is **effectively informative**. Two dispositions
-are open, and one of them should be chosen rather than left implicit:
+First, its requirements were written in lowercase (`must`, `should`) rather
+than the RFC 2119 uppercase forms. Per RFC 8174 only the uppercase forms carry
+normative weight, so the document read as normative while formally binding
+nothing. An earlier revision of this section overstated that as "contains no
+RFC 2119 keyword… states no requirements" — it states roughly twenty-five, in a
+form that does not bind.
 
-1. State the requirements its content implies, keeping it in `normative/`.
-2. Reclassify it to `informative/` and let N4 carry whatever of it is binding.
+Second and more decisively, the machinery it describes — a document-to-candidate
+compiler with a candidate lifecycle and promotion rules — does not exist. What
+exists instead is `components/policy-calibration`, which decides gate-readiness
+**empirically**, by measuring a semantic judge's false-positive and recall rates
+over a seeded corpus. That is a better answer to the same question than a
+declared enforceability field, and it is already running.
 
-`specs/SPEC_INDEX.md` is authoritative on scope (020) and should record the
-choice.
+The two ideas here that were not already in N4 have been folded into it:
+per-rule provenance and the enforceability class, both as optional fields
+(N4 §2.2.1, §2.2.2).
+
+What remains in this document is design material for a compiler that may never
+be built. If it is built, it is Miniforge-product scope — like N7–N10 — rather
+than MiniForge Core, since nothing outside miniforge itself originates packs
+this way.
 
 ## Description
 

--- a/specs/normative/N4-policy-packs.md
+++ b/specs/normative/N4-policy-packs.md
@@ -197,6 +197,40 @@ no longer routes.
 **Categories are plural from day one.** Use `:rule/categories [...]` even when a rule currently
 belongs to a single category. This prevents a schema migration when multi-category rules arise.
 
+#### 2.3.1 Severity Levels
+
+There is **one severity vocabulary** in miniforge, ordered most to least severe:
+
+```clojure
+:critical  :high  :medium  :low  :info
+```
+
+It is used by `:rule/severity` (§2.3), `:violation/severity` (§3.3), and every
+downstream projection — supervisory attention, dashboards, reports. A rule's
+severity is what its violations carry, so a second vocabulary for rules would
+require a lossy translation at exactly the boundary where enforcement is
+decided.
+
+| Severity | Meaning | Enforcement |
+|----------|---------|-------------|
+| `:critical` | Unsafe or intent-violating; no autonomous path forward | MUST block phase completion; MUST NOT be overridable by `:gate/allow-override?` alone (§6.3.1) |
+| `:high` | Serious defect or policy breach | MUST block phase completion |
+| `:medium` | Should be fixed; auto-repair or review | SHOULD block unless auto-repaired or waived (§6.3.1) |
+| `:low` | Minor; worth reporting | MUST NOT block |
+| `:info` | Informational; no action required | MUST NOT block |
+
+**Legacy values.** `:error` and `:warning` appeared in earlier drafts of this
+spec and MAY be encountered in third-party packs authored against them.
+Implementations MUST normalize `:error` → `:high` and `:warning` → `:medium` at
+load time, and SHOULD warn that the pack targets a withdrawn vocabulary. They
+MUST NOT carry a legacy value past the load boundary.
+
+**Load order.** Normalization runs first; rejection second. After
+normalization, a `:rule/severity` outside the canonical set MUST cause the pack
+to be rejected. So `:error` loads and becomes `:high`, while `:blocker` — a
+value this spec has never defined — is rejected. Rejecting before normalizing
+would fail every pack the normalization rule exists to accept.
+
 #### 2.3.2 Enforceability
 
 `:rule/enforceability` declares what kind of check a rule is, independent of how
@@ -254,40 +288,6 @@ Two rules govern it:
 This is the rule-level counterpart to N6 §2.13, which requires a gate result to
 be reproducible from its evidence. Pack hash tells a reader which bytes ran;
 provenance tells them why those bytes say what they say.
-
-#### 2.3.1 Severity Levels
-
-There is **one severity vocabulary** in miniforge, ordered most to least severe:
-
-```clojure
-:critical  :high  :medium  :low  :info
-```
-
-It is used by `:rule/severity` (§2.3), `:violation/severity` (§3.3), and every
-downstream projection — supervisory attention, dashboards, reports. A rule's
-severity is what its violations carry, so a second vocabulary for rules would
-require a lossy translation at exactly the boundary where enforcement is
-decided.
-
-| Severity | Meaning | Enforcement |
-|----------|---------|-------------|
-| `:critical` | Unsafe or intent-violating; no autonomous path forward | MUST block phase completion; MUST NOT be overridable by `:gate/allow-override?` alone (§6.3.1) |
-| `:high` | Serious defect or policy breach | MUST block phase completion |
-| `:medium` | Should be fixed; auto-repair or review | SHOULD block unless auto-repaired or waived (§6.3.1) |
-| `:low` | Minor; worth reporting | MUST NOT block |
-| `:info` | Informational; no action required | MUST NOT block |
-
-**Legacy values.** `:error` and `:warning` appeared in earlier drafts of this
-spec and MAY be encountered in third-party packs authored against them.
-Implementations MUST normalize `:error` → `:high` and `:warning` → `:medium` at
-load time, and SHOULD warn that the pack targets a withdrawn vocabulary. They
-MUST NOT carry a legacy value past the load boundary.
-
-**Load order.** Normalization runs first; rejection second. After
-normalization, a `:rule/severity` outside the canonical set MUST cause the pack
-to be rejected. So `:error` loads and becomes `:high`, while `:blocker` — a
-value this spec has never defined — is rejected. Rejecting before normalizing
-would fail every pack the normalization rule exists to accept.
 
 ### 2.4 Mapping Artifact
 

--- a/specs/normative/N4-policy-packs.md
+++ b/specs/normative/N4-policy-packs.md
@@ -7,7 +7,7 @@
 # N4 — Policy Packs & Gates Standard
 
 **Version:** 0.8.0-draft
-**Date:** 2026-08-05
+**Date:** 2026-08-10
 **Status:** Draft
 **Conformance:** MUST
 

--- a/specs/normative/N4-policy-packs.md
+++ b/specs/normative/N4-policy-packs.md
@@ -6,7 +6,7 @@
 
 # N4 — Policy Packs & Gates Standard
 
-**Version:** 0.7.0-draft
+**Version:** 0.8.0-draft
 **Date:** 2026-08-05
 **Status:** Draft
 **Conformance:** MUST
@@ -185,6 +185,9 @@ no longer routes.
  :rule/remediation-template string     ; REQUIRED: Template for remediation message
  :rule/documentation-url    string     ; OPTIONAL: Link to detailed docs
 
+ :rule/enforceability keyword          ; OPTIONAL: §2.3.2; default :executable
+ :rule/provenance   [{...}]            ; OPTIONAL: §2.3.3; REQUIRED for derived rules
+
  :rule/deprecated-by keyword}          ; OPTIONAL: Rule ID that supersedes this rule
 ```
 
@@ -193,6 +196,64 @@ no longer routes.
 
 **Categories are plural from day one.** Use `:rule/categories [...]` even when a rule currently
 belongs to a single category. This prevents a schema migration when multi-category rules arise.
+
+#### 2.3.2 Enforceability
+
+`:rule/enforceability` declares what kind of check a rule is, independent of how
+severe a violation would be:
+
+| Value | Meaning |
+|-------|---------|
+| `:executable` | Mechanically decidable; may gate |
+| `:heuristic` | Detects reliably enough to report, not reliably enough to gate unaided |
+| `:advisory` | Informational; never gates |
+| `:human-review` | Requires a person to judge; never gates automatically |
+
+Default is `:executable`, so existing rules are unaffected.
+
+**A rule MUST NOT be silently promoted to `:executable`.** Where a pack is
+generated or recompiled, a rule declared `:advisory` or `:human-review` retains
+that class unless a person changes it. Silent promotion turns guidance into a
+blocker for work that was never meant to be gated, and the operator sees only
+the block.
+
+Severity and enforceability are orthogonal: a `:critical` `:advisory` rule says
+"this matters a great deal and a human must decide", not "this blocks".
+
+**Relationship to gate-readiness.** Enforceability is a _declaration_. Whether
+a semantic rule is reliable enough to gate in practice is _measured_ — see
+Annex A, which records that the implementation carries a calibration mechanism
+this spec does not yet describe. Where both exist, the measurement governs: a
+rule declaring `:executable` that fails calibration does not gate.
+
+#### 2.3.3 Rule Provenance
+
+`:rule/provenance` is a non-empty vector of records identifying where a rule
+came from. It is OPTIONAL for hand-authored rules and REQUIRED for any rule
+produced by deriving, composing, or compiling from other material.
+
+```clojure
+{:provenance/source-type  keyword   ; REQUIRED: :file | :url | :repo-artifact | :pack | :manual
+ :provenance/source-ref   string    ; REQUIRED: stable reference to the source object
+ :provenance/support-type keyword   ; REQUIRED: :stated | :derived | :composed | :authored
+ :provenance/source-fingerprint string ; REQUIRED: fingerprint of the source material
+ :provenance/locator      any       ; OPTIONAL: section, line span, AST path, config key
+ :provenance/excerpt-hash string    ; OPTIONAL: hash of the supporting excerpt
+ :provenance/compiler     string}   ; OPTIONAL: producer identity and version
+```
+
+Two rules govern it:
+
+1. A derived rule MUST retain the provenance of every source that materially
+   contributed. Where several sources are merged into one rule, provenance MUST
+   NOT collapse to a single pointer — an auditor asking "why does this rule
+   exist" needs all of them.
+2. Provenance MUST survive promotion. Renaming fields to fit this schema is
+   permitted; dropping the record is not.
+
+This is the rule-level counterpart to N6 §2.13, which requires a gate result to
+be reproducible from its evidence. Pack hash tells a reader which bytes ran;
+provenance tells them why those bytes say what they say.
 
 #### 2.3.1 Severity Levels
 
@@ -2001,7 +2062,7 @@ Research directions:
 ## Annex A — Implementation Conformance Status (informative)
 
 This annex is **informative**. It records where the miniforge implementation
-currently diverges from the contract above, as of 2026-08-06. It is not a
+currently diverges from the contract above, as of 2026-08-10. It is not a
 relaxation of any requirement in §1–§14: the spec is normative and the
 implementation conforms to it, not the reverse.
 
@@ -2108,7 +2169,36 @@ contract the code already satisfies:
   a reader matching §5.1.8 against the pack finds neither set of names in the
   other.
 
-### A.5 Structural
+### A.5 Gate-Readiness Calibration — implemented, unspecified
+
+The implementation carries a mechanism this spec does not describe at all: N4
+mentions calibration zero times.
+
+`components/policy-calibration` decides whether a semantic rule is reliable
+enough to be a hard gate, by measuring a judge's false-positive and recall
+rates over a seeded corpus across independent runs. `gate_check.clj` then
+refuses to ship: a rule whose enforcement action is acting
+(`:hard-halt` or `:require-approval`) **and** whose detector is `:semantic`
+must hold a passing `:gate-ready?` calibration record, or it is reported as
+ungated.
+
+Two consequences for this spec:
+
+1. **`:rule/enforcement {:action ...}` and the semantic/deterministic detector
+   distinction are part of the shipped rule model** and are absent from §2.3's
+   schema. §2.3.2's enforceability field is adjacent but not the same thing —
+   enforceability is declared, calibration is measured.
+2. **The safety property is real and unwritten.** An operator reading N4 would
+   not learn that a semantic gating rule needs an evidence-backed reliability
+   record before it can block anything. That is one of the stronger safety
+   properties in the system and it exists only in code.
+
+This is recorded rather than specified: reverse-engineering the calibration
+contract from its implementation is what standard 020 forbids. Writing it
+belongs in a deliberate N4 amendment, and §2.3.2 defers to the measurement in
+the meantime.
+
+### A.6 Structural
 
 - **Stale citations.** `policy-pack/knowledge_safety.clj`,
   `policy-pack/loader.clj`, and `policy-pack/rules/pack_dependency_validation.clj`
@@ -2123,6 +2213,12 @@ contract the code already satisfies:
 ---
 
 **Version History:**
+
+- 0.8.0-draft (2026-08-10): Absorbed the two novel contracts from the former
+  N4-delta, now informative: `:rule/provenance` (§2.3.3) and
+  `:rule/enforceability` (§2.3.2), both optional and defaulting to current
+  behaviour. Annex A.5 records that the shipped rule model carries an
+  enforcement/detector/calibration mechanism this spec does not describe.
 
 - 0.7.0-draft (2026-08-06): Annex A only, no normative change. A.4's
   self-certifying verification and A.3's canonicalization gap are closed by


### PR DESCRIPTION
MINIFORGE_PR_BUDGET_OVERRIDE: Reclassification plus the fold-forward it requires; splitting separates the move from the content it preserves. Well below the ~10-12k threshold where Copilot declines to review. Docs-only, no runtime code.

## Overview

Moves the policy-compilation delta to `informative/`, folds the two ideas N4 lacked, and records a larger gap the investigation surfaced.

Full detail: [`docs/pull-requests/2026-08-10-chris-n4-delta-reclassification.md`](docs/pull-requests/2026-08-10-chris-n4-delta-reclassification.md)

## Why

**It bound nothing.** 25 lowercase `must` and 4 `should` against one uppercase MUST. Per RFC 8174 only uppercase carries normative weight, so a document indexed as a normative N4 amendment was formally requiring almost nothing.

**Its subject does not exist.** No candidate keys, no compiler component anywhere in the tree.

**What exists is better.** `components/policy-calibration` decides gate-readiness *empirically* — measuring a semantic judge's false-positive and recall rates over a seeded corpus — and `gate_check.clj` refuses to ship a judge-gated rule without a passing `:gate-ready?` record. That answers the same question as a declared enforceability field, with evidence instead of assertion.

## Folded into N4

Both optional, both defaulting to current behaviour, so **no existing rule is invalidated**.

- **`:rule/provenance` (§2.3.3)** — REQUIRED for derived rules, OPTIONAL for hand-authored. A derived rule retains provenance from every materially contributing source rather than collapsing to one pointer; provenance survives promotion. The rule-level counterpart to N6 §2.13: pack hash says which bytes ran, provenance says why they say what they say.
- **`:rule/enforceability` (§2.3.2)** — `:executable` / `:heuristic` / `:advisory` / `:human-review`, with the rule that a rule MUST NOT be **silently promoted** to `:executable`. Silent promotion turns guidance into a blocker for work never meant to be gated, and the operator sees only the block. Severity and enforceability are orthogonal — a `:critical` `:advisory` rule says "this matters and a human decides", not "this blocks".

§2.3.2 defers to measurement where both exist: a rule declaring `:executable` that fails calibration does not gate.

## Recorded, not specified — N4 Annex A.5

**N4 mentions calibration zero times**, yet the shipped rule model carries `:rule/enforcement {:action :hard-halt | :require-approval}`, a semantic-vs-deterministic detector distinction, and a gate refusing to ship a semantic gating rule without an evidence-backed reliability record.

That is one of the stronger safety properties in the system and it exists only in code. Annex A.5 records it; writing the contract belongs in a deliberate amendment, since reverse-engineering it from the implementation is what standard 020 forbids.

## Two corrections to claims I made earlier

Both mine, both from unverified assumptions inside a command:

1. **"Nine specs are missing from SPEC_INDEX"** — false. All seven deltas are in an `### Indexed normative amendments` table, and N11 is indexed. I ran the check in the main checkout, which sits on an unrelated branch and never picked up the merges, so I read a stale file. There was no indexing work to do.
2. **"N4-delta contains no RFC 2119 keyword… states no requirements"** — it contains no *uppercase* keyword; it states ~25 requirements in lowercase. Case-sensitive grep. The 0.22.0 index entry carrying that claim is corrected in place rather than left standing.

## Validation

- `markdownlint` clean on all four changed files
- No duplicate section numbers in N4 — an A.5 collision was caught and renumbered mid-edit
- Verified `policy-calibration` and `gate_check.clj` behave as described **before** writing Annex A.5
- Verified no `candidate/*` keys exist before claiming the compiler is unimplemented

🤖 Generated with [Claude Code](https://claude.com/claude-code)
