### PR TITLE
feat(phase-deployment): a deployment is granted, gated, and recorded (Ariadne 2d, deploy half)

### DIFF
--- a/components/phase-deployment/deps.edn
+++ b/components/phase-deployment/deps.edn
@@ -1,5 +1,7 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/anomaly {:local/root "../anomaly"}
+ :deps {ai.miniforge/effect-transaction {:local/root "../effect-transaction"}
+        ai.miniforge/execution-grant {:local/root "../execution-grant"}
+        ai.miniforge/anomaly {:local/root "../anomaly"}
         ai.miniforge/messages {:local/root "../messages"}
         ai.miniforge/phase {:local/root "../phase"}
         ai.miniforge/gate {:local/root "../gate"}

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_authority.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_authority.clj
@@ -1,0 +1,123 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.phase-deployment.deploy-authority
+  "Authority for one exact Kubernetes deployment (Ariadne step 2d).
+
+   Mirrors `pr-lifecycle.merge-authority`: issue a narrow runtime-owned
+   grant, authorize the concrete scope, and decide. The runtime is the
+   principal — a phase may request a deployment, it cannot mint the
+   authority to perform one.
+
+   The preflight basis here is deployment's own: the provider dry-run
+   plus the existing `check-resource-count` and `check-gke-node-limit`.
+   Those checks already existed and were never consulted before an
+   apply; wiring them as the issuance basis is why this component reuses
+   rather than reinvents them."
+  (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.execution-grant.interface :as grant]
+   [ai.miniforge.gate.interface :as gate]
+   [ai.miniforge.phase-deployment.policy :as policy])
+  (:import
+   [java.time Instant]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} allow-decisions
+  "Envelope decisions that permit the apply. `:allow-with-obligations`
+   is included: obligations are recorded, not blocking."
+  #{:allow :allow-with-obligations})
+
+(def ^{:stratum 0} empty-classification
+  "No policy-pack violations to classify — deployment's preflight is its
+   own dry-run plus the resource checks, folded in as the grant basis."
+  {:blocking [] :require-approval [] :warnings [] :audits [] :unknown []})
+
+(def ^{:stratum 0} unpinned-policy
+  {:pins/pack-revision nil :pins/rule-ids [] :pins/event-watermark nil})
+
+(defn ^{:stratum 0} breach-dir
+  [context]
+  (or (:grant-breach-dir context)
+      (str (System/getProperty "user.home") "/.miniforge/grants")))
+
+(defn ^{:stratum 0} preflight
+  "Run the deployment checks that must precede a mutation, over the
+   provider's dry-run render.
+
+   Returns `{:preflight/result :allow|:deny :preflight/violations [...]
+   :preflight/rendered s}`. A dry-run that did not render is `:deny` —
+   we cannot show the apply is safe, and unverifiable is denied."
+  [rendered check-context]
+  (if (clojure.string/blank? (str rendered))
+    {:preflight/result :deny
+     :preflight/violations []
+     :preflight/rendered nil}
+    (let [violations (remove nil?
+                             [(policy/check-resource-count rendered check-context)
+                              (policy/check-gke-node-limit rendered check-context)])]
+      {:preflight/result (if (seq violations) :deny :allow)
+       :preflight/violations (vec violations)
+       :preflight/rendered rendered})))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} permitted?
+  "True only when the grant check and the DecisionEnvelope both allow."
+  [{:authority/keys [authorization envelope]}]
+  (and (grant/authorized? authorization)
+       (contains? allow-decisions (:envelope/decision envelope))))
+
+(defn ^{:stratum 1} prepare
+  "Issue, authorize, and decide authority for a preflight-approved
+   deployment. Returns an authority record, or the issuer's anomaly when
+   authority cannot be established at all."
+  [context effect-id deploy-config preflight-result ^Instant now]
+  (let [{:keys [kustomize-dir namespace context-name default-context
+                deployment-name]} deploy-config
+        request {:workflow-run/id (:run-id context)
+                 :workflow-run/status :running
+                 :effect/id effect-id
+                 :effect/class :effect/deploy
+                 :effect/preflight
+                 {:preflight/type :preflight/deploy-policy-and-dry-run
+                  :preflight/result preflight-result}
+                 :kustomize-dir kustomize-dir
+                 :context context-name
+                 :default-context default-context
+                 :namespace namespace
+                 :deployment-name deployment-name}
+        grant-record (grant/issue-for-effect (breach-dir context) request now)]
+    (if (anomaly/anomaly? grant-record)
+      grant-record
+      (let [scope {:effect/id effect-id
+                   :workflow-run/id (:run-id context)
+                   :kustomize-dir kustomize-dir
+                   :context (or context-name default-context)
+                   :namespace namespace
+                   :deployment-name deployment-name}
+            authorization (grant/authorize grant-record
+                                           {:effect/scope scope :usage/count 1}
+                                           now)
+            envelope (gate/decide empty-classification unpinned-policy
+                                  authorization)]
+        {:effect/id effect-id
+         :effect/proposal scope
+         :authority/grant grant-record
+         :authority/authorization authorization
+         :authority/envelope envelope}))))

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_governed.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_governed.clj
@@ -1,0 +1,136 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.phase-deployment.deploy-governed
+  "Granted, gated, and durably transacted Kubernetes application
+   (Ariadne step 2d, deployment half).
+
+   `enter-deploy` previously went config -> rollback capture ->
+   `kustomize-apply!` with no policy gate at all, while
+   `check-resource-count` and `check-gke-node-limit` sat in
+   `policy.clj` uncalled. This is the seam that makes the mutation
+   conditional: dry-run, check, issue authority, record durably, and
+   only then apply.
+
+   The provider is injected. A governance seam whose tests need a real
+   cluster is a seam nobody tests."
+  (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.effect-transaction.interface :as fx]
+   [ai.miniforge.phase-deployment.deploy-authority :as authority])
+  (:import
+   [java.time Instant]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} store-dir
+  "Effect store location. Never relative to the process working
+   directory — a durable record written where nobody looks is not one."
+  [context]
+  (or (:effect-store-dir context)
+      (str (System/getProperty "user.home") "/.miniforge/effects")))
+
+(defn- ^{:stratum 0} refusal
+  [code detail]
+  {:deploy/status :failed
+   :deploy/stage :authority
+   :deploy/rollback-info nil
+   :deploy/failure detail
+   :deploy/refusal code})
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} propose!
+  "Record correlated authority and intent BEFORE any mutation. The
+   proposal carries the dry-run render, so the record says what was
+   about to change rather than only that something was."
+  [context auth rendered now]
+  (fx/propose! (store-dir context)
+               {:effect-id (:effect/id auth)
+                :effect-class :effect/deploy
+                :grant-id (get-in auth [:authority/grant :grant/id])
+                :envelope-id (get-in auth [:authority/envelope :envelope/id])
+                :proposal (assoc (:effect/proposal auth)
+                                 :deploy/dry-run rendered)}
+               now))
+
+(defn- ^{:stratum 1} commit!
+  "Apply, then ask the provider what it observes.
+
+   A failed apply is a definite `:failed` — the provider told us it did
+   not take. Anything else defers to the observation, and an
+   unobservable result stays `:accepted`, which the coordinator records
+   as unknown rather than as success."
+  [context t auth now apply! observe!]
+  (fx/commit! (store-dir context) t (:authority/grant auth) {:usage/count 1} now
+              (fn []
+                (let [applied (apply!)]
+                  (if (:deploy/failed? applied)
+                    {:effect/outcome :failed
+                     :effect/failure (str (:deploy/failure applied))
+                     :effect/observed (:deploy/rollback-info applied)}
+                    (let [observed (observe!)]
+                      (if (:provider/matched? observed)
+                        {:effect/outcome :succeeded
+                         :effect/observed (:provider/observed observed)}
+                        {:effect/outcome :accepted
+                         :effect/observed (:provider/observed observed)})))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} transact!
+  "Dry-run, check, authorize, record, and only then mutate.
+
+   `provider` supplies `:dry-run!`, `:apply!`, `:observe!`, and
+   `:rollback-info!`. Returns the deploy outcome map the flow already
+   speaks, so the refusal paths look like every other failure to the
+   caller — except that no kubectl mutation ran."
+  [context deploy-config provider ^Instant now]
+  (let [rendered ((:dry-run! provider) deploy-config)
+        pre (authority/preflight rendered (:policy-context context {}))]
+    (if (= :deny (:preflight/result pre))
+      (refusal :deploy/preflight-denied
+               (str "deployment preflight denied: "
+                    (pr-str (:preflight/violations pre))))
+      (let [rollback-info ((:rollback-info! provider) deploy-config)
+            auth (authority/prepare context (random-uuid) deploy-config
+                                    (:preflight/result pre) now)]
+        (cond
+          (anomaly/anomaly? auth)
+          (refusal :deploy/authority-unavailable (:anomaly/message auth))
+
+          (not (authority/permitted? auth))
+          (refusal :deploy/authority-denied
+                   (str "deploy authority denied: "
+                        (get-in auth [:authority/envelope :envelope/decision])))
+
+          :else
+          (let [proposed (propose! context auth (:preflight/rendered pre) now)]
+            (if (anomaly/anomaly? proposed)
+              (refusal :deploy/proposal-failed (:anomaly/message proposed))
+              (let [committed (commit! context proposed auth now
+                                       #((:apply! provider) deploy-config)
+                                       #((:observe! provider) deploy-config))]
+                {:deploy/status (case (:effect/state committed)
+                                  :succeeded :success
+                                  :failed :failed
+                                  :pending)
+                 :deploy/stage :apply
+                 :deploy/rollback-info rollback-info
+                 :deploy/effect-id (:effect/id proposed)
+                 :deploy/rendered-yaml (:preflight/rendered pre)
+                 :deploy/observed (:effect/observed committed)}))))))))

--- a/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_governed.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase_deployment/deploy_governed.clj
@@ -45,9 +45,12 @@
       (str (System/getProperty "user.home") "/.miniforge/effects")))
 
 (defn- ^{:stratum 0} refusal
-  [code detail]
+  "A refusal names the stage it happened at. Hard-coding one stage
+   makes a preflight denial read as an authority failure, which sends
+   whoever is debugging it to the wrong place."
+  [stage code detail]
   {:deploy/status :failed
-   :deploy/stage :authority
+   :deploy/stage stage
    :deploy/rollback-info nil
    :deploy/failure detail
    :deploy/refusal code})
@@ -103,7 +106,7 @@
   (let [rendered ((:dry-run! provider) deploy-config)
         pre (authority/preflight rendered (:policy-context context {}))]
     (if (= :deny (:preflight/result pre))
-      (refusal :deploy/preflight-denied
+      (refusal :preflight :deploy/preflight-denied
                (str "deployment preflight denied: "
                     (pr-str (:preflight/violations pre))))
       (let [rollback-info ((:rollback-info! provider) deploy-config)
@@ -111,17 +114,17 @@
                                     (:preflight/result pre) now)]
         (cond
           (anomaly/anomaly? auth)
-          (refusal :deploy/authority-unavailable (:anomaly/message auth))
+          (refusal :authority :deploy/authority-unavailable (:anomaly/message auth))
 
           (not (authority/permitted? auth))
-          (refusal :deploy/authority-denied
+          (refusal :authority :deploy/authority-denied
                    (str "deploy authority denied: "
                         (get-in auth [:authority/envelope :envelope/decision])))
 
           :else
           (let [proposed (propose! context auth (:preflight/rendered pre) now)]
             (if (anomaly/anomaly? proposed)
-              (refusal :deploy/proposal-failed (:anomaly/message proposed))
+              (refusal :proposal :deploy/proposal-failed (:anomaly/message proposed))
               (let [committed (commit! context proposed auth now
                                        #((:apply! provider) deploy-config)
                                        #((:observe! provider) deploy-config))]

--- a/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_governed_test.clj
+++ b/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_governed_test.clj
@@ -1,0 +1,164 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.phase-deployment.deploy-governed-test
+  "The seam between a deployment request and a live kubectl apply.
+
+   Every assertion about refusal is really one assertion: `:apply!` was
+   never called. A governance seam is only worth its complexity if the
+   mutation genuinely does not happen."
+  (:require
+   [ai.miniforge.phase-deployment.deploy-authority :as authority]
+   [ai.miniforge.phase-deployment.deploy-governed :as governed]
+   [clojure.test :refer [deftest is testing]])
+  (:import
+   [java.nio.file Files]
+   [java.nio.file.attribute FileAttribute]
+   [java.time Instant]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} now (Instant/parse "2026-08-01T00:00:00Z"))
+
+(def ^{:stratum 0} clean-preview
+  "A Pulumi-shaped preview that creates nothing, so both resource checks
+   pass and the preflight is allow-class."
+  "{\"steps\":[]}")
+
+(defn- ^{:stratum 0} tmp []
+  (str (.toFile (Files/createTempDirectory "deploy" (into-array FileAttribute [])))))
+
+(def ^{:stratum 0} deploy-config
+  {:kustomize-dir "/repo/k8s/overlays/prod"
+   :namespace "prod"
+   :context-name "gke-prod"
+   :default-context "gke-default"
+   :deployment-name "api"})
+
+(defn- ^{:stratum 0} recording-provider
+  "Records every provider call. The assertions are about absence."
+  [calls & {:keys [rendered apply-failed?]
+            :or {rendered clean-preview apply-failed? false}}]
+  {:dry-run! (fn [_] (swap! calls conj :dry-run!) rendered)
+   :rollback-info! (fn [_] (swap! calls conj :rollback-info!)
+                     {:deployment/replicas 3})
+   :apply! (fn [_] (swap! calls conj :apply!)
+             {:deploy/failed? apply-failed?
+              :deploy/failure (when apply-failed? "apply exploded")})
+   :observe! (fn [_] (swap! calls conj :observe!)
+               {:provider/matched? true
+                :provider/observed {:deployment/ready? true}})})
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} context
+  ([] (context {}))
+  ([overrides]
+   (merge {:run-id (random-uuid)
+           :effect-store-dir (tmp)
+           :grant-breach-dir (tmp)
+           :policy-context {}}
+          overrides)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(deftest ^{:stratum 2} no-authority-means-no-kubectl-mutation-test
+  ;; The headline criterion: "A deploy without an active :effect/deploy
+  ;; grant runs no kubectl mutation."
+  (testing "a context with no workflow run cannot bind deploy scope"
+    (let [calls (atom [])
+          result (governed/transact! (dissoc (context) :run-id)
+                                     deploy-config
+                                     (recording-provider calls)
+                                     now)]
+      (is (= :failed (:deploy/status result)))
+      (is (= :deploy/authority-unavailable (:deploy/refusal result)))
+      (is (not (some #{:apply!} @calls))
+          (str "no kubectl mutation may run without authority, saw: "
+               (pr-str @calls))))))
+
+(deftest ^{:stratum 2} a-denied-preflight-runs-no-mutation-test
+  ;; check-resource-count and check-gke-node-limit existed in policy.clj
+  ;; and were never consulted before an apply. Now a violation stops it.
+  (testing "a preview that creates more than the limit denies the apply"
+    (let [creates (apply str (repeat 25 "{\"op\":\"create\",\"type\":\"gcp:Node\"},"))
+          preview (str "{\"steps\":[" (subs creates 0 (dec (count creates))) "]}")
+          calls (atom [])
+          result (governed/transact! (context) deploy-config
+                                     (recording-provider calls :rendered preview)
+                                     now)]
+      (is (= :failed (:deploy/status result)))
+      (is (= :deploy/preflight-denied (:deploy/refusal result)))
+      (is (not (some #{:apply!} @calls))
+          (str "a denied preflight must not reach kubectl, saw: " (pr-str @calls)))))
+
+  (testing "a dry-run that rendered nothing is denied, not waved through"
+    (let [calls (atom [])
+          result (governed/transact! (context) deploy-config
+                                     (recording-provider calls :rendered "")
+                                     now)]
+      (is (= :deploy/preflight-denied (:deploy/refusal result))
+          "we cannot show an unrendered apply is safe")
+      (is (not (some #{:apply!} @calls))))))
+
+(deftest ^{:stratum 2} an-authorized-deploy-applies-and-records-test
+  ;; A guard that refuses everything is an outage. The allowed path has
+  ;; to work, and has to leave evidence.
+  (let [calls (atom [])
+        ctx (context)
+        result (governed/transact! ctx deploy-config
+                                   (recording-provider calls) now)]
+    (is (some #{:apply!} @calls) "an authorized deploy should reach the provider")
+    (is (= :success (:deploy/status result)))
+    (is (some? (:deploy/effect-id result)) "the effect id is reported")
+    (testing "the dry-run ran BEFORE the apply"
+      (is (< (.indexOf ^java.util.List @calls :dry-run!)
+             (.indexOf ^java.util.List @calls :apply!))))
+    (testing "a durable record exists in the effect store"
+      (is (some #(.endsWith (.getName ^java.io.File %) ".edn")
+                (file-seq (java.io.File. ^String (:effect-store-dir ctx))))))))
+
+(deftest ^{:stratum 2} rollback-evidence-survives-a-failed-apply-test
+  ;; The old store-apply-failure discarded :evidence/rollback-info,
+  ;; losing the undo artifact exactly when the apply failed.
+  (let [calls (atom [])
+        result (governed/transact! (context) deploy-config
+                                   (recording-provider calls :apply-failed? true)
+                                   now)]
+    (is (= :failed (:deploy/status result)))
+    (is (some? (:deploy/rollback-info result))
+        "rollback evidence must survive the failure path, not only success")))
+
+(deftest ^{:stratum 2} a-denied-envelope-runs-no-mutation-test
+  ;; Distinct from authority-UNAVAILABLE. Here authority resolves fine
+  ;; and the envelope says no. Without this the permitted? guard is
+  ;; untested: removing it fails nothing, because every other refusal
+  ;; path short-circuits earlier.
+  (let [calls (atom [])
+        denied {:effect/id (random-uuid)
+                :effect/proposal {}
+                :authority/grant {:grant/id (random-uuid)}
+                :authority/authorization {:grant/outcome :exceeded}
+                :authority/envelope {:envelope/id (random-uuid)
+                                     :envelope/decision :deny}}]
+    (with-redefs [authority/prepare (fn [& _] denied)]
+      (let [result (governed/transact! (context) deploy-config
+                                       (recording-provider calls) now)]
+        (is (= :deploy/authority-denied (:deploy/refusal result)))
+        (is (not (some #{:apply!} @calls))
+            (str "a denied envelope must not reach kubectl, saw: "
+                 (pr-str @calls)))))))

--- a/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_governed_test.clj
+++ b/components/phase-deployment/test/ai/miniforge/phase_deployment/deploy_governed_test.clj
@@ -87,6 +87,7 @@
                                      now)]
       (is (= :failed (:deploy/status result)))
       (is (= :deploy/authority-unavailable (:deploy/refusal result)))
+      (is (= :authority (:deploy/stage result)))
       (is (not (some #{:apply!} @calls))
           (str "no kubectl mutation may run without authority, saw: "
                (pr-str @calls))))))
@@ -103,6 +104,8 @@
                                      now)]
       (is (= :failed (:deploy/status result)))
       (is (= :deploy/preflight-denied (:deploy/refusal result)))
+      (is (= :preflight (:deploy/stage result))
+          "a preflight denial must not report as an authority failure")
       (is (not (some #{:apply!} @calls))
           (str "a denied preflight must not reach kubectl, saw: " (pr-str @calls)))))
 


### PR DESCRIPTION
Implements `work/ariadne-deploy-grant-enforcement.spec.edn` — the last unbuilt piece of Ariadne step 2.

## What was there

`enter-deploy` went config → rollback capture → `kustomize-apply!` with **no policy gate at all**, while `check-resource-count` and `check-gke-node-limit` sat in `policy.clj` and were never called by anything. A cluster mutation with an unconsulted policy module next to it.

## What's here

`deploy-authority` mirrors `merge-authority`: issue a narrow runtime-owned `:effect/deploy` grant, authorize the concrete scope, decide. The runtime is the principal — a phase may *request* a deployment, it cannot mint the authority to perform one.

The preflight basis is deployment's own: the provider dry-run plus those two existing checks, **reused rather than reinvented**, which is what the spec asked for.

`deploy-governed` composes it — dry-run, check, authorize, record durably, and only then apply:

- the proposal carries the **dry-run render**, so the record says what was about to change rather than only that something was
- **rollback evidence is returned on the failure path too**; the old `store-apply-failure` discarded it precisely when the apply failed, losing the undo artifact at the one moment it mattered
- a failed apply is a definite `:failed`; anything unobservable stays `:accepted`, which the coordinator records as unknown rather than as success
- an **unrendered dry-run is denied** — we cannot show an apply is safe without seeing what it does

The provider is injected. A governance seam whose tests need a real cluster is a seam nobody tests.

## The test that earns its keep

Every refusal assertion is really one assertion: `:apply!` was never called.

Worth flagging the process here, because it repeated a lesson from the merge half. My first five tests all passed — and then I mutated the source and found that **removing the `permitted?` guard failed nothing**, because every other refusal path short-circuits earlier. The guard was untested. The denied-envelope test exists specifically to cover it, and I re-ran the mutation afterwards to confirm it now fails. Verified by mutation both before and after.

## Verification

5 tests / 17 assertions. `bb poly:check` 0 errors; `bb lint:clj` 0/0; `bb lint:stratum` clean at ≤3 layers.

Three sliced commits: authority → governed composition → tests.

## Not in this PR

`enter-deploy` still calls `flow/execute!` directly — wiring the governed path into the live phase is a separate change so the seam lands reviewable on its own, exactly as the merge half did before `merge_orchestration` adopted it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)