### PR TITLE
work: Ariadne step-3 spec wave (tenants, owners, attested contracts)

### DIFF
--- a/work/QUEUE.md
+++ b/work/QUEUE.md
@@ -139,6 +139,44 @@ Discover scaling + budget signals via governed experiments, synthesize
 | high | ○ | operational-policy-synthesis | `n07-opsv-governed-actuation.spec.edn` — Implement governed OPSV PR, Kubernetes apply, and rollback effects | correctness+scale |
 | medium | ○ | operational-policy-synthesis | `workflow-policy-convergence.spec.edn` — Converge workflow-selection policy from governed outcomes | governance+workfloworchestration+reliability |
 
+## Theme — Ariadne adoption - step 3: tenants, owners, and attested contracts (`ariadne-tenancy`, status: in-flight)
+
+Step 3 of the ratified Ariadne adoption order. Identity stops being
+   implicit: tenants and principals become objects, every record is born
+   owned, the commissioning relationship becomes a relation rather than
+   containment, and the cross-language contracts gain a content hash and
+   an attestation.
+
+   The move is the same one steps 1 and 2 made twice already — take
+   something currently carried by convention and good behaviour, and
+   carry it by representation instead. Step 1 did it for verdicts, step
+   2 for authority, step 3 does it for identity and for the contracts
+   themselves.
+
+   ONE LESSON CARRIED FORWARD DELIBERATELY. The step-2 wave specified the
+   grant object, checking grants, transacting effects, migrating call
+   sites, and revoking grants — and never specified WHO ISSUES ONE. That
+   gap only surfaced at the call-site migration, where enforcing the
+   spec as written would have denied every merge and deploy permanently.
+   Step 3's equivalent gap is 'who establishes operator identity', and it
+   is spec 3a rather than a discovery. Nothing here is unblocked by
+   accident.
+
+   The RFC's own note that N12's authn half is 'thin' is taken at face
+   value: 3a names the credential->principal dependency and builds a
+   config-backed resolver behind the same seam, so the real one is a
+   drop-in rather than a second migration.
+
+**Informative spec:** `docs/architecture/rfc-ariadne-adoption.md`
+
+| tier | r | theme | spec | axes |
+|---|---|---|---|---|
+| blocker | ● | ariadne-tenancy | `ariadne-identity-boundary.spec.edn` — Ariadne step 3a: Tenant and Principal, and the boundary that establishes one | correctness+scale+governancecredibility |
+| high | ● | ariadne-tenancy | `ariadne-attested-contracts.spec.edn` — Ariadne step 3e: content-addressed, attested contracts | correctness+observation+governancecredibility |
+| blocker | ○ | ariadne-tenancy | `ariadne-owned-records.spec.edn` — Ariadne step 3c: every record is born owned | correctness+scale+governancecredibility |
+| blocker | ○ | ariadne-tenancy | `ariadne-run-identity-threading.spec.edn` — Ariadne step 3b: thread the acting identity through the run hierarchy | correctness+scale+governancecredibility |
+| high | ○ | ariadne-tenancy | `ariadne-engagement.spec.edn` — Ariadne step 3d: engagement as a relation, not containment | correctness+scale+governancecredibility |
+
 ## Theme — unassigned (`unassigned`, status: planned)
 
 (no theme description)

--- a/work/ariadne-attested-contracts.spec.edn
+++ b/work/ariadne-attested-contracts.spec.edn
@@ -1,0 +1,90 @@
+;; =============================================================================
+;; Spec: Ariadne step 3e — contracts that can prove what they are
+;; =============================================================================
+;;
+;; Normative refs: docs/architecture/rfc-ariadne-adoption.md (adoption
+;; step 3, "contracts attested"; T3 contradiction 2, "entity contract is
+;; convention"); Ariadne §13.6 (registry discipline: versioned,
+;; content-addressed, attested).
+
+{:spec/title "Ariadne step 3e: content-addressed, attested contracts"
+
+ :spec/description
+ "Give the three cross-language contract families a content hash and an
+  attestation, so a consumer can verify the contract it compiled against
+  is the contract the producer emitted.
+
+  WHAT EXISTS TODAY. `contracts/` holds three families — event-stream,
+  operator-events, supervisory-entities — and the last carries a
+  `:supervisory/schema-version` integer plus a vendored golden corpus.
+  That version is real discipline and it already caught a live drift
+  (miniforge-control #197 rejected a version mismatch fail-closed). But
+  a version number is an ASSERTION. It says 'I am v2'; it cannot show
+  that the bytes are the v2 the producer meant. Two producers can both
+  claim v2 and disagree.
+
+  T3 recorded contradiction 2 as 'entity contract is convention' and
+  step 1 marked it half-resolved: the contract became versioned and
+  gated, not attested. This closes the other half.
+
+  GROUP 1: Content addressing
+  Each contract family gets a manifest carrying a content hash over its
+  canonical shape definitions and its golden corpus. Same inputs, same
+  hash, on any machine — the repo already has a content-hash component
+  with instant-normalization fixed (#1744), which is the property this
+  depends on.
+
+  GROUP 2: Attestation
+  The manifest records WHO produced it and WHEN, signed by the runtime
+  the way DecisionEnvelopes are. An attestation an agent could forge is
+  a picture of an attestation; the label plane stays model-unwritable
+  (§13.4), same rule as everywhere else.
+
+  GROUP 3: Consumers verify, and fail closed
+  A consumer that vendors a corpus records the hash it vendored. On
+  mismatch it REJECTS, exactly as the schema-version check already
+  does — the fail-closed behaviour is proven, this widens what it
+  covers from a declared integer to the actual bytes.
+
+  GROUP 4: The generator is the only writer
+  Hashes and attestations are produced by the fixture generator, never
+  hand-edited. A hand-editable attestation is a comment.
+
+  WHY THIS BELONGS TO STEP 3 rather than step 1. The RFC groups it with
+  tenants and owners because both are the same move: turning something
+  currently carried by convention and good behaviour into something
+  carried by representation. Ownership makes 'whose is this' checkable;
+  attestation makes 'is this the contract you think' checkable."
+
+ :spec/intent {:type :feature
+               :scope ["contracts/"
+                       "components/supervisory-state/src/"
+                       "tasks/"]}
+
+ :spec/constraints
+ ["Content hash is deterministic across machines - same inputs, same hash"
+  "Attestation records producer and time, runtime-written, never agent-supplied"
+  "A consumer hash mismatch REJECTS, matching the existing fail-closed version behaviour"
+  "Hashes and attestations are generator-written only; a hand-edited manifest is invalid"
+  "The existing :supervisory/schema-version gate keeps working - this widens it, replaces nothing"
+  "Stratified design, max 3 layers per file"]
+
+ :spec/acceptance-criteria
+ ["Each contract family's manifest carries a content hash over its shapes and corpus"
+  "Regenerating with unchanged inputs produces an identical hash"
+  "Changing one shape definition changes the hash"
+  "The manifest records producer identity and generation time"
+  "A consumer verifying against a mismatched hash rejects rather than warning"
+  "A hand-edited manifest fails verification"
+  "The existing schema-version mismatch behaviour is unchanged - a regression test pins it"
+  "full bb test green"]
+
+ :spec/priority
+ {:tier :high
+  :axes #{:correctness :governance-credibility :observation}
+  :theme :ariadne-tenancy
+  :rationale "Closes the unresolved half of T3 contradiction 2; independent of the ownership slices, so it can run in parallel with them."
+  :blocks []
+  :blocked-by []}
+
+ :spec/workflow-type :canonical-sdlc}

--- a/work/ariadne-engagement.spec.edn
+++ b/work/ariadne-engagement.spec.edn
@@ -1,0 +1,85 @@
+;; =============================================================================
+;; Spec: Ariadne step 3d — the engagement, or who commissioned this work
+;; =============================================================================
+;;
+;; Normative refs: docs/architecture/rfc-ariadne-adoption.md (adoption
+;; step 3; the mapping table's Engagement row); Ariadne §2-§4. Prior
+;; art: thesium-career ADR 008, where employment became a relation
+;; rather than containment — the same shape as this.
+
+{:spec/title "Ariadne step 3d: engagement as a relation, not containment"
+
+ :spec/description
+ "Model the commissioning relationship: which tenant asked for work to
+  be done on which repository or fleet, and under what terms.
+
+  WHY A RELATION AND NOT A FIELD. The tempting model is that a repo
+  BELONGS to a tenant and runs inherit from it. That model breaks the
+  moment two tenants have a legitimate interest in the same repository —
+  a customer org that owns the code and an operator org running the
+  agents on it. Career hit this exactly: employment could not be
+  containment, because a person is not inside their employer. It had to
+  be a relation, and the same is true here.
+
+  So: an Engagement is an object connecting a commissioning tenant to a
+  target, and a run cites the engagement it was commissioned under.
+  Ownership (3c) still says who OWNS the artifact; the engagement says
+  who ASKED. Those answer different questions and conflating them loses
+  both.
+
+  GROUP 1: The object
+  `:engagement/id`, `:engagement/commissioning-tenant-id`,
+  `:engagement/target` (a repo or fleet reference),
+  `:engagement/status` [:enum :active :suspended :ended],
+  `:engagement/started-at`, `:engagement/ended-at`.
+
+  GROUP 2: Runs cite their engagement
+  A workflow run carries `:workflow-run/engagement-id`. A run with no
+  engagement is a run nobody commissioned, which during
+  single-operator use is the overwhelmingly common case — so this slice
+  creates a default local engagement rather than making the field
+  optional. An optional field here would be filled in by nobody and
+  would answer the question 'who asked' with silence.
+
+  GROUP 3: Ended engagements do not retroactively unown anything
+  Ending an engagement stops NEW work being commissioned under it. It
+  does not orphan the records already created, and it does not delete
+  them. The takeaway-export right the RFC names depends on those records
+  remaining attributable after the relationship ends; an engagement that
+  erased its history on termination would defeat the point.
+
+  DELIBERATELY NOT HERE: entitlements, quotas, or any access check
+  driven by engagement status. Those are Fleet re-scope (step 4)
+  territory and are explicitly the thing the RFC says to delete-and-
+  redesign rather than extend."
+
+ :spec/intent {:type :feature
+               :scope ["components/tenancy/"
+                       "components/workflow/src/"]}
+
+ :spec/constraints
+ ["Engagement is a relation object, never a containment field on a repo"
+  "A workflow run cites an engagement id; the field is required, defaulted locally, never optional"
+  "Ending an engagement does not orphan, unown, or delete existing records"
+  "Ownership and engagement stay distinct - one says who owns, the other who asked"
+  "No access decision is driven by engagement status in this slice"
+  "Stratified design, max 3 layers per file"]
+
+ :spec/acceptance-criteria
+ ["Engagement validates its documented shape and rejects extra keys"
+  "A workflow run carries an engagement id"
+  "Local single-operator use creates and reuses a default engagement rather than leaving the field empty"
+  "Two tenants can hold engagements against the same target simultaneously"
+  "Ending an engagement leaves prior records readable and still attributed"
+  "A test asserts ownership and engagement can name different tenants for one run"
+  "full bb test green"]
+
+ :spec/priority
+ {:tier :high
+  :axes #{:scale :governance-credibility :correctness}
+  :theme :ariadne-tenancy
+  :rationale "Multi-operator and the Fleet data story both need the commissioning relation; nothing earlier in step 3 depends on it."
+  :blocks []
+  :blocked-by ["ariadne-owned-records.spec.edn"]}
+
+ :spec/workflow-type :canonical-sdlc}

--- a/work/ariadne-identity-boundary.spec.edn
+++ b/work/ariadne-identity-boundary.spec.edn
@@ -59,8 +59,8 @@
   Stating it here so the next wave does not discover it the way step 2
   discovered issuance.
 
-  DELIBERATELY NOT HERE: engagements (3d), owner stamping (3b), context
-  threading (3c). This is the vocabulary and its source, nothing that
+  DELIBERATELY NOT HERE: engagements (3d), context threading (3b), owner
+  stamping (3c). This is the vocabulary and its source, nothing that
   consumes them."
 
  :spec/intent {:type :feature

--- a/work/ariadne-identity-boundary.spec.edn
+++ b/work/ariadne-identity-boundary.spec.edn
@@ -1,0 +1,97 @@
+;; =============================================================================
+;; Spec: Ariadne step 3a — Tenant, Principal, and where identity comes from
+;; =============================================================================
+;;
+;; Normative refs: docs/architecture/rfc-ariadne-adoption.md (adoption
+;; step 3, "Tenants + owners on the run hierarchy"); Ariadne §2-§4
+;; (tenants, principals, the #controller relation); T3's tenancy-ABSENT
+;; note.
+
+{:spec/title "Ariadne step 3a: Tenant and Principal, and the boundary that establishes one"
+
+ :spec/description
+ "Create component `tenancy`: the identity objects every later step-3
+  slice stamps onto records, AND the boundary that decides who the
+  operator actually is.
+
+  WHY THOSE TWO THINGS TOGETHER. The step-2 wave specified the grant
+  object, checking grants, transacting effects, migrating call sites,
+  and revoking grants — and never specified WHO ISSUES ONE. The result
+  was a call-site migration that would have denied every merge and
+  deploy permanently, and a spec written after the fact to fill the
+  hole. Ownership has exactly the same shape of gap: a record cannot be
+  born owned if nothing establishes an owner. So the object and its
+  source land together, deliberately.
+
+  GROUP 1: The objects
+  A CLOSED Tenant and a CLOSED Principal, following the DecisionEnvelope
+  and ExecutionGrant precedent — unknown keys rejected, because an
+  identity nobody can describe is an identity nobody can audit.
+
+    :tenant/id, :tenant/kind [:enum :operator :customer-org :service],
+    :tenant/display-name, :tenant/created-at
+
+    :principal/id, :principal/tenant-id, :principal/kind
+    [:enum :human :agent-instance :service], :principal/display-name
+
+  A principal ALWAYS belongs to exactly one tenant. An agent instance is
+  a principal, not a tenant: it acts, it does not own.
+
+  GROUP 2: Where an operator identity comes from
+  Today there is none — single-operator is implicit, and 'the process
+  that is running' stands in for 'who asked'. This slice makes that
+  explicit rather than pretending otherwise:
+
+    * A config-backed local operator tenant, resolved once at process
+      boundary (CLI, MCP server, daemon start).
+    * The resolution is a named function with a stated failure mode, not
+      a default sprinkled through call sites. A missing operator
+      identity is an ERROR at boundary, not an anonymous fallback that
+      later reads as a real owner.
+
+  GROUP 3: The authn dependency is NAMED, not assumed
+  Real multi-operator needs credential->principal mapping, which the RFC
+  puts in the authn layer (N12, 'thin'). That does NOT exist and this
+  spec does NOT build it. What this spec does is make the seam explicit:
+  one resolution point, one shape, so the authn-backed resolver is a
+  drop-in later rather than a rewrite of every record-birth site.
+
+  Stating it here so the next wave does not discover it the way step 2
+  discovered issuance.
+
+  DELIBERATELY NOT HERE: engagements (3d), owner stamping (3b), context
+  threading (3c). This is the vocabulary and its source, nothing that
+  consumes them."
+
+ :spec/intent {:type :feature
+               :scope ["components/tenancy/"
+                       "projects/*/deps.edn"]}
+
+ :spec/constraints
+ ["Closed schemas - m/validate rejects unknown keys; a test proves it"
+  "A principal belongs to exactly one tenant; an orphan principal is invalid"
+  "Operator resolution is ONE named function with a stated failure mode"
+  "A missing operator identity is an error at the boundary, never an anonymous fallback"
+  "No record-birth site is modified in this slice"
+  "Stratified design, max 3 layers per file"
+  "New component MUST be added to all four projects' deps.edn or poly check fails"]
+
+ :spec/acceptance-criteria
+ ["Tenant and Principal schemas validate their documented shape and reject extra keys"
+  "A principal with no tenant fails validation"
+  "Operator resolution returns a tenant and principal from configuration"
+  "Operator resolution with no configured identity returns an error, not a default tenant"
+  "The resolver's return shape is identical whether config-backed or (future) authn-backed - a test pins the shape"
+  "poly check reports 0 errors"
+  "full bb test green"]
+
+ :spec/priority
+ {:tier :blocker
+  :axes #{:correctness :governance-credibility :scale}
+  :theme :ariadne-tenancy
+  :rationale "Every later step-3 slice stamps an owner; nothing can stamp one until something establishes who the owner is."
+  :blocks ["ariadne-owned-records.spec.edn"
+           "ariadne-run-identity-threading.spec.edn"]
+  :blocked-by []}
+
+ :spec/workflow-type :canonical-sdlc}

--- a/work/ariadne-owned-records.spec.edn
+++ b/work/ariadne-owned-records.spec.edn
@@ -1,0 +1,90 @@
+;; =============================================================================
+;; Spec: Ariadne step 3c — every record is born owned
+;; =============================================================================
+;;
+;; Normative refs: docs/architecture/rfc-ariadne-adoption.md (adoption
+;; step 3, "Owner on every record"); Ariadne §2-§4. Prior art:
+;; thesium-career ADR 008 migration M4, "every record born owned +
+;; backfilled", and its finding that a derived-identity shortcut had to
+;; be deleted rather than kept alongside.
+
+{:spec/title "Ariadne step 3c: every record is born owned"
+
+ :spec/description
+ "Stamp an owner on every record at the moment it is created, and make
+  an unowned record unrepresentable rather than merely discouraged.
+
+  THE RULE, from the RFC's mapping table: execution artifacts belong to
+  the LAUNCHING tenant; domain outputs belong to the REPO OWNER's
+  tenant. Those are different tenants in the multi-operator case and
+  identical in today's single-operator one, which is exactly why the
+  distinction has to be drawn now — while it is invisible and cheap —
+  rather than after the first customer org exists.
+
+  GROUP 1: Ownership on the canonical entities
+  `:owner/tenant-id` and `:owner/principal-id` on workflow runs, specs,
+  tasks, agent sessions, PR records, evidence bundles, and effect
+  transactions. Required, not optional. An optional owner is an owner
+  nobody fills in.
+
+  GROUP 2: Stamped at birth, from the acting context
+  Ownership is written where the record is created, from 3b's acting
+  context. Never assigned later, never inferred from a neighbouring
+  record, never derived from an id shape. The career migration
+  specifically had to DELETE a derived run identity that looked like a
+  reasonable shortcut and turned out to be a second, disagreeing source
+  of truth.
+
+  GROUP 3: Backfill is explicit and dated
+  Records that predate this change get a one-time backfill to the local
+  operator tenant, marked `:owner/backfilled? true`. Not because the
+  provenance is real, but because pretending it is real is worse: a
+  reader must be able to tell an asserted owner from an observed one.
+
+  GROUP 4: The negative test is the point
+  A record created without an acting context does not get a default
+  owner — it fails. The whole value of ownership is that its absence is
+  impossible, and a fallback owner converts an impossible state into a
+  plausible-looking wrong one.
+
+  DELIBERATELY NOT HERE: access decisions. Nothing in this slice CHECKS
+  an owner. Ownership has to exist and be trustworthy before anything
+  gates on it, and gating on a half-populated owner field is how a
+  governance layer earns a reputation for being wrong."
+
+ :spec/intent {:type :feature
+               :scope ["components/tenancy/"
+                       "components/workflow/src/"
+                       "components/supervisory-state/src/"
+                       "components/effect-transaction/src/"
+                       "components/evidence-bundle/src/"]}
+
+ :spec/constraints
+ ["Owner fields are REQUIRED on the listed entities, not optional"
+  "Ownership is written at record creation from the acting context, never assigned later"
+  "No owner is inferred from a neighbouring record or from an id shape"
+  "Backfilled ownership is marked as backfilled and is distinguishable from observed ownership"
+  "A record created with no acting context FAILS - there is no default owner"
+  "Nothing in this slice reads an owner to make an access decision"
+  "Stratified design, max 3 layers per file"]
+
+ :spec/acceptance-criteria
+ ["A workflow run created through the normal path carries owner tenant and principal"
+  "A spec, task, agent session, PR record, evidence bundle, and effect transaction each carry an owner"
+  "Creating any of those without an acting context fails rather than defaulting"
+  "An execution artifact is owned by the launching tenant"
+  "A domain output is owned by the repo owner's tenant, and a test proves the two can differ"
+  "Backfilled records are marked :owner/backfilled? true and are queryable as such"
+  "No code path assigns ownership after creation - a test asserts the setter does not exist"
+  "full bb test green"]
+
+ :spec/priority
+ {:tier :blocker
+  :axes #{:correctness :governance-credibility :scale}
+  :theme :ariadne-tenancy
+  :rationale "This is what step 3 is for; engagements and attested contracts both assume records already know who owns them."
+  :blocks ["ariadne-engagement.spec.edn"]
+  :blocked-by ["ariadne-identity-boundary.spec.edn"
+               "ariadne-run-identity-threading.spec.edn"]}
+
+ :spec/workflow-type :canonical-sdlc}

--- a/work/ariadne-run-identity-threading.spec.edn
+++ b/work/ariadne-run-identity-threading.spec.edn
@@ -1,0 +1,91 @@
+;; =============================================================================
+;; Spec: Ariadne step 3b — carry the acting identity through the run
+;; =============================================================================
+;;
+;; Normative refs: docs/architecture/rfc-ariadne-adoption.md (adoption
+;; step 3); Ariadne §2-§4. Prior art: thesium-career ADR 008 migration
+;; M2, which threaded a subject context CLI -> spine -> stores and found
+;; that the threading, not the schema, was the whole job.
+
+{:spec/title "Ariadne step 3b: thread the acting identity through the run hierarchy"
+
+ :spec/description
+ "Carry tenant and principal from the process boundary down through
+  workflow run -> phase -> task -> agent, so that any code about to
+  create a record can answer 'on whose behalf' without guessing.
+
+  WHY THIS IS ITS OWN SLICE, AND THE BIGGEST ONE. The run hierarchy is
+  already threaded with ids — `:task/id` appears in 244 places,
+  `:agent/id` in 115, `:workflow-run/id` in 38. Every one of those is a
+  place that knows WHAT is running and not WHO it is running for. Adding
+  an owner field to a schema is an afternoon; making the identity
+  actually available at the point a record is born is the work.
+
+  The career migration of exactly this shape (ADR 008 M2) found the same
+  thing: the schema change was small and the context threading was the
+  migration.
+
+  GROUP 1: The acting context
+  A closed `:acting/context` carried alongside the existing execution
+  context: `:acting/tenant-id`, `:acting/principal-id`, and
+  `:acting/established-at`. Not a bare tenant id — the principal is what
+  distinguishes 'the operator asked' from 'an agent instance did it',
+  and both stamp differently.
+
+  GROUP 2: One entry point per boundary
+  Every process boundary (CLI command, MCP tool call, daemon start,
+  scheduled trigger) resolves identity ONCE via 3a's resolver and puts
+  it on the context. Downstream code reads; it never re-resolves. A
+  second resolution site is a second answer, and two answers about who
+  acted is worse than none.
+
+  GROUP 3: Absence is loud
+  Code that requires an acting context and does not find one FAILS. It
+  does not substitute a default tenant, and it does not proceed
+  unowned. An unowned record created during the migration is
+  indistinguishable, later, from one that was legitimately anonymous —
+  and there is no such thing as legitimately anonymous here.
+
+  GROUP 4: Propagation across the agent boundary
+  A spawned agent inherits the acting context of the run that spawned
+  it, as a principal in its own right (`:principal/kind
+  :agent-instance`) whose tenant is the spawning tenant. This is the
+  representational half of the fence-not-restrain reframing: the inner
+  agent acts under a named identity inside the boundary rather than
+  under the ambient authority of the process.
+
+  DELIBERATELY NOT HERE: stamping owners onto records (3c). This slice
+  makes the answer AVAILABLE; the next one writes it down."
+
+ :spec/intent {:type :feature
+               :scope ["components/tenancy/"
+                       "components/workflow/src/"
+                       "components/agent/src/"
+                       "bases/"]}
+
+ :spec/constraints
+ ["Identity is resolved ONCE per boundary; downstream reads, never re-resolves"
+  "Code requiring an acting context fails when absent - no default tenant, no unowned proceed"
+  "A spawned agent inherits the spawning tenant and gets its own agent-instance principal"
+  "The acting context rides alongside the existing execution context, not merged into it"
+  "No record schema changes in this slice"
+  "Stratified design, max 3 layers per file"]
+
+ :spec/acceptance-criteria
+ ["A CLI-initiated run carries an acting context reachable at phase, task, and agent scope"
+  "An MCP-initiated run carries the same shape"
+  "Code that requires an acting context and finds none returns an error naming the missing identity"
+  "No call site resolves identity a second time - a test asserts the resolver is called once per run"
+  "A spawned agent's principal is :agent-instance and its tenant matches the spawning run's tenant"
+  "Existing runs without an acting context fail loudly rather than proceeding unowned"
+  "full bb test green"]
+
+ :spec/priority
+ {:tier :blocker
+  :axes #{:correctness :scale :governance-credibility}
+  :theme :ariadne-tenancy
+  :rationale "Owner stamping has nothing to stamp until the identity reaches the place records are created; this is the bulk of the step-3 migration."
+  :blocks ["ariadne-owned-records.spec.edn"]
+  :blocked-by ["ariadne-identity-boundary.spec.edn"]}
+
+ :spec/workflow-type :canonical-sdlc}

--- a/work/themes.edn
+++ b/work/themes.edn
@@ -199,6 +199,53 @@
    schema-version check). T3 contradictions 1, 2, 4, and 5 are
    recorded resolved in the T3 register (#1560)."}
 
+ :ariadne-tenancy
+ {:theme/id :ariadne-tenancy
+  :theme/title "Ariadne adoption - step 3: tenants, owners, and attested contracts"
+  :theme/description
+  "Step 3 of the ratified Ariadne adoption order. Identity stops being
+   implicit: tenants and principals become objects, every record is born
+   owned, the commissioning relationship becomes a relation rather than
+   containment, and the cross-language contracts gain a content hash and
+   an attestation.
+
+   The move is the same one steps 1 and 2 made twice already — take
+   something currently carried by convention and good behaviour, and
+   carry it by representation instead. Step 1 did it for verdicts, step
+   2 for authority, step 3 does it for identity and for the contracts
+   themselves.
+
+   ONE LESSON CARRIED FORWARD DELIBERATELY. The step-2 wave specified the
+   grant object, checking grants, transacting effects, migrating call
+   sites, and revoking grants — and never specified WHO ISSUES ONE. That
+   gap only surfaced at the call-site migration, where enforcing the
+   spec as written would have denied every merge and deploy permanently.
+   Step 3's equivalent gap is 'who establishes operator identity', and it
+   is spec 3a rather than a discovery. Nothing here is unblocked by
+   accident.
+
+   The RFC's own note that N12's authn half is 'thin' is taken at face
+   value: 3a names the credential->principal dependency and builds a
+   config-backed resolver behind the same seam, so the real one is a
+   drop-in rather than a second migration."
+  :theme/informative-spec "docs/architecture/rfc-ariadne-adoption.md"
+  :theme/normative-refs
+  [{:doc "docs/architecture/rfc-ariadne-adoption.md" :section "Suggested adoption order, step 3"
+    :relation :primary}
+   {:doc "docs/architecture/ariadne.md" :section "sections 2-4 (tenants, principals, relations) and 13.6 (registry discipline)"
+    :relation :primary}
+   {:doc "docs/architecture/diagrams/README.md" :section "T3 contradiction register, #2 and the tenancy-ABSENT note"
+    :relation :supporting}]
+  :theme/completion-criteria
+  ["a tenant and a principal are objects, and one named boundary function establishes them"
+   "no record can be created without an owner - absence fails rather than defaulting"
+   "execution artifacts and domain outputs can be owned by different tenants, and a test proves it"
+   "commissioning is a relation: two tenants can hold engagements against one target"
+   "a consumer can verify the contract bytes it compiled against, not merely a version integer (T3 #2 fully resolved)"]
+  :theme/status :in-flight
+  :theme/owner :christopher
+  :theme/started #inst "2026-08-01"}
+
  :ariadne-grants
  {:theme/id :ariadne-grants
   :theme/title "Ariadne adoption - step 2: grants on the irreversible effects"


### PR DESCRIPTION
Implementation plan for **step 3** of the ratified [Ariadne adoption order](docs/architecture/rfc-ariadne-adoption.md), following step 1 (#1555–#1559) and step 2 (#1575–#1752).

Adds theme `:ariadne-tenancy` and five specs.

## What step 3 is

The same move steps 1 and 2 made twice: take something carried by convention and good behaviour, and carry it by **representation** instead. Step 1 did it for verdicts, step 2 for authority, step 3 does it for identity — and for the contracts themselves.

Today `:task/id` appears in **244 places** and `:tenant/` in **zero**. Every one of those knows *what* is running and none knows *who for*.

| | spec | what it settles |
|---|---|---|
| 3a | `ariadne-identity-boundary` | Tenant and Principal objects **and** the one named function that establishes an operator |
| 3b | `ariadne-run-identity-threading` | carry tenant + principal to the places records are born |
| 3c | `ariadne-owned-records` | every record born owned; absence fails |
| 3d | `ariadne-engagement` | commissioning as a relation, not containment |
| 3e | `ariadne-attested-contracts` | content hash + attestation over the three contract families |

3a and 3e are independently ready; 3b/3c/3d chain.

## The lesson from step 2, carried forward deliberately

My step-2 wave specified the grant object, checking grants, transacting effects, migrating call sites, and revoking grants — and **never specified who issues one**. That gap surfaced only at the call-site migration, where enforcing the spec as written would have denied every merge and deploy permanently, and it needed a spec written after the fact to fill.

Ownership has exactly the same shape of hole: a record cannot be born owned if nothing establishes an owner. So **"who establishes operator identity" is spec 3a**, not a discovery. The RFC calls N12's authn half "thin"; taken at face value, 3a names the credential→principal dependency and builds a config-backed resolver behind the same seam, so the real one is a drop-in rather than a second migration.

## Three judgments worth arguing with

**No default owner.** A record created without an acting context fails rather than defaulting. A fallback owner converts an impossible state into a plausible-looking wrong one, and the whole value of ownership is that its absence is impossible. Career's ADR 008 had to *delete* a derived run identity that looked like a reasonable shortcut and turned out to be a second, disagreeing source of truth — 3c forbids that move up front.

**Engagement is a relation.** The tempting model is that a repo belongs to a tenant and runs inherit from it. That breaks the moment a customer org owns the code and an operator org runs agents on it. Career hit this exactly: a person is not inside their employer, so employment could not be containment. Ownership says who *owns*; engagement says who *asked*.

**A version integer is an assertion.** `:supervisory/schema-version` is real discipline and already caught live drift — miniforge-control #197 rejected a mismatch fail-closed. But it says "I am v2"; it cannot show the bytes are the v2 the producer meant, and two producers can both claim v2 and disagree. 3e closes the half of T3 contradiction 2 that step 1 left at half-resolved.

## Nothing here gates on identity

3c explicitly does not read an owner to make an access decision, and 3d explicitly drives nothing from engagement status. Ownership has to exist and be trustworthy before anything gates on it; gating on a half-populated owner field is how a governance layer earns a reputation for being wrong. Entitlements and quotas are step-4 territory, which the RFC says to delete-and-redesign rather than extend.

## Note on a pre-existing dangling reference

`ariadne-deploy-grant-enforcement.spec.edn` names two now-archived specs in its `:blocked-by`. That predates this PR and is cosmetic — both blockers are satisfied — but it will need clearing when that spec is archived after `enter-deploy` is wired.

`bb work:queue` regenerated; three sliced commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)