### PR TITLE
feat(codex): release-phase consultation — every agent-bearing phase carries the pin

### DIFF
--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/codex_pin.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/codex_pin.clj
@@ -51,7 +51,12 @@
    channel and delivers via a rendered prompt section (landings-text)."
   {:implement "changing-one-side-of-a-boundary"
    :plan      "about-to-commit-consequential"
-   :review    "quality-signal-might-be-lying"})
+   :review    "quality-signal-might-be-lying"
+   ;; Release IS the consequential commitment (branch, push, PR) — the
+   ;; same situation plan enters at, consulted again at the moment the
+   ;; commitment actually happens. Delivered via the releaser's behavior
+   ;; addendum (no existing-files channel, same reasoning as review).
+   :release   "about-to-commit-consequential"})
 
 (defn ^{:stratum 0} configured-codex-dir
   "MINIFORGE_CODEX_PATH, trimmed, or nil — nil means the capability is off."

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
@@ -32,6 +32,8 @@
             [ai.miniforge.agent.interface :as agent]
             [ai.miniforge.logging.interface :as log]
             [ai.miniforge.phase.interface :as phase]
+            [ai.miniforge.phase-software-factory.codex-pin :as codex-pin]
+            [ai.miniforge.phase-software-factory.gap-wiring :as gap-wiring]
             [ai.miniforge.phase-software-factory.messages :as messages]
             [ai.miniforge.phase-software-factory.phase-config :as phase-config]
             [ai.miniforge.phase-software-factory.phase-terminal :as phase-terminal]
@@ -277,8 +279,19 @@
   [ctx config logger]
   (let [on-chunk (phase/create-streaming-callback ctx :release)
         input (get-in ctx [:execution/input])
-        behavior-addendum (phase/load-and-filter-behaviors
-                            :release {:task {:task/intent (:intent input)}})]
+        ;; Codex consultation for the release situation, delivered through
+        ;; the same addendum channel as the compiled standards pack — the
+        ;; releaser has no existing-files channel (SPEC T1 s7.4). The
+        ;; outcome rides on the exec-context so enter-release can attach
+        ;; provenance without consulting twice.
+        codex-outcome (codex-pin/landings-outcome :release logger)
+        pack-addendum (phase/load-and-filter-behaviors
+                        :release {:task {:task/intent (:intent input)}})
+        behavior-addendum (let [t (:text codex-outcome)]
+                            (cond
+                              (and pack-addendum t) (str pack-addendum "\n\n" t)
+                              t t
+                              :else pack-addendum))]
     (cond-> {;; Preserve the original precedence — explicit ctx worktree paths
              ;; win over config; the blessed resolver is the LAST resort,
              ;; adding the opts key + the governed-fail / CWD decision (no
@@ -313,7 +326,8 @@
              ;; Resolve and inject GitHub token for capsule gh CLI auth
              :github-token (resolve-github-token ctx)}
       on-chunk (assoc :on-chunk on-chunk)
-      behavior-addendum (assoc :task/behavior-addendum behavior-addendum))))
+      behavior-addendum (assoc :task/behavior-addendum behavior-addendum)
+      codex-outcome (assoc :codex/outcome codex-outcome))))
 
 (defn ^{:stratum 1} leave-release
   "Post-processing for release phase.
@@ -326,6 +340,10 @@
    bypasses `:on-fail` and lands on `:failed` because the curator's
    empty-diff signal means the implementer has nothing left to do."
   [ctx]
+  ;; Gap-instrument miss recording (T2 s3): best-effort, opt-in, and it
+  ;; must never change the outcome it measures. Consultation provenance
+  ;; was attached at enter, so it is visible here.
+  (gap-wiring/record-phase-misses! ctx :release)
   (let [start-time (get-in ctx [:phase :started-at])
         end-time (System/currentTimeMillis)
         duration-ms (if start-time (- end-time start-time) 0)
@@ -604,7 +622,15 @@
                    (response/failure e)))
 
         ;; Emit agent-completed telemetry event for release executor
-        _ (phase/emit-agent-completed! ctx :release :releaser result)]
+        _ (phase/emit-agent-completed! ctx :release :releaser result)
+        ;; SPEC s7.4.3: consultation provenance onto the durable result —
+        ;; the gap instrument reads it at leave (same marker implement and
+        ;; plan carry). Release has no recorded context-reads channel.
+        result (if (map? (:output result))
+                 (assoc-in result [:output :codex/consultation]
+                           (codex-pin/consultation-summary
+                             (:codex/outcome exec-context) nil))
+                 result)]
 
     (-> (phase/enter-context ctx :release :releaser gates budget start-time result)
         ;; Single derived projection of the canonical pr-info onto ctx-level

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
@@ -42,6 +42,16 @@
 
 ;------------------------------------------------------------------------------ Layer 0
 
+(defn ^{:stratum 0} attach-consultation
+  "Record `codex-outcome`'s summary onto `result`, on both success and
+   failure -- :output starts nil on response/failure, so a failed
+   release that consulted must not be ledgered as one that never did."
+  [result codex-outcome]
+  (cond-> result
+    (map? result)
+    (assoc-in [:output :codex/consultation]
+              (codex-pin/consultation-summary codex-outcome nil))))
+
 ;; Defaults
 (def ^{:stratum 0} default-config
   "Phase defaults loaded from config/phase/defaults.edn."
@@ -327,7 +337,9 @@
              :github-token (resolve-github-token ctx)}
       on-chunk (assoc :on-chunk on-chunk)
       behavior-addendum (assoc :task/behavior-addendum behavior-addendum)
-      codex-outcome (assoc :codex/outcome codex-outcome))))
+      ;; :text already rode into the behavior addendum; the summary only
+      ;; needs the status fields — don't ship the rendered prose twice.
+      codex-outcome (assoc :codex/outcome (dissoc codex-outcome :text)))))
 
 (defn ^{:stratum 1} leave-release
   "Post-processing for release phase.
@@ -626,11 +638,7 @@
         ;; SPEC s7.4.3: consultation provenance onto the durable result —
         ;; the gap instrument reads it at leave (same marker implement and
         ;; plan carry). Release has no recorded context-reads channel.
-        result (if (map? (:output result))
-                 (assoc-in result [:output :codex/consultation]
-                           (codex-pin/consultation-summary
-                             (:codex/outcome exec-context) nil))
-                 result)]
+        result (attach-consultation result (:codex/outcome exec-context))]
 
     (-> (phase/enter-context ctx :release :releaser gates budget start-time result)
         ;; Single derived projection of the canonical pr-info onto ctx-level

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/codex_pin_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/codex_pin_test.clj
@@ -36,9 +36,11 @@
 
 (deftest ^{:stratum 0} only-wired-phases-are-mapped
   ;; implement/plan wire via pin-outcome (existing-files); review wires via
-  ;; landings-text (prompt section). A mapping without a wire would be a
-  ;; defined-but-unreachable capability.
-  (is (= #{:implement :plan :review} (set (keys codex-pin/phase->situation)))))
+  ;; landings-text (prompt section); release wires via landings-outcome
+  ;; through the releaser's behavior addendum. A mapping without a wire
+  ;; would be a defined-but-unreachable capability.
+  (is (= #{:implement :plan :review :release}
+         (set (keys codex-pin/phase->situation)))))
 
 (deftest ^{:stratum 0} landings-text-skip-conditions
   (is (nil? (codex-pin/landings-text :review nil nil)))

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/release_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/release_test.clj
@@ -82,7 +82,7 @@
    :summary        "Implemented feature: Add feature (2 files)"
    :metrics        {:tokens 1500 :duration-ms 3200}})
 
-;------------------------------------------------------------------------------ Layer 0: Defaults Tests
+;; Defaults Tests
 (deftest ^{:stratum 0} default-config-test
   (testing "release phase has correct default configuration"
     (is (= :releaser (:agent release/default-config)))
@@ -92,6 +92,17 @@
     (is (= 2 (get-in release/default-config [:budget :iterations])))
     (is (= 180 (get-in release/default-config [:budget :time-seconds])))))
 
+(deftest ^{:stratum 0} attach-consultation-test
+  (testing "output starting nil (response/failure shape) still gets the consultation"
+    (let [result (release/attach-consultation {:success? false :output nil} {:pegs []})]
+      (is (some? (get-in result [:output :codex/consultation])))))
+  (testing "output already a map keeps its other keys"
+    (let [result (release/attach-consultation {:output {:pr-url "x"}} {:pegs []})]
+      (is (= "x" (get-in result [:output :pr-url])))
+      (is (some? (get-in result [:output :codex/consultation])))))
+  (testing "a non-map result passes through unchanged"
+    (is (nil? (release/attach-consultation nil {:pegs []})))))
+
 (deftest ^{:stratum 0} phase-defaults-registration-test
   (testing "release phase defaults are registered"
     (let [defaults (phase/phase-defaults :release)]
@@ -99,7 +110,7 @@
       (is (= :releaser (:agent defaults)))
       (is (= [:release-ready] (:gates defaults))))))
 
-;------------------------------------------------------------------------------ Layer 1: Diagnostic-emission regression tests
+;; Diagnostic-emission regression tests
 ;;
 ;; These tests pin the observability behavior added 2026-05-04. The
 ;; production fix for the dogfood release-phase silent fail is two-part:
@@ -125,7 +136,7 @@
   [entries-atom]
   (into #{} (keep :log/event) @entries-atom))
 
-;------------------------------------------------------------------------------ Layer 0: Boundary-commit rehydration regression
+;; Boundary-commit rehydration regression
 ;;
 ;; Stage-3 dogfood (2026-05-07): plan/implement/verify/review all green,
 ;; files committed on the task branch by the implement-phase boundary,
@@ -745,7 +756,7 @@
             (is (= "release chunk" (:chunk/delta (first chunk-events))))
             (is (= :release (:agent/id (first chunk-events)))))))))))
 
-;------------------------------------------------------------------------------ Layer 2: Interceptor Leave Tests
+;; Interceptor Leave Tests
 (deftest ^{:stratum 3} leave-release-records-metrics-test
   (testing "leave-release records duration and completion"
     (with-test-worktree


### PR DESCRIPTION
Closes the last agent-bearing phase without codex consultation, per the trap-bench finding (#1750) and the operator directive that every agent needs the warning surface, not just plan.

1. :release joins phase->situation at "about-to-commit-consequential" (the same situation plan enters — release is the moment the commitment happens).
2. Delivery rides the releaser's behavior addendum beside the compiled standards pack (release has no existing-files channel; same reasoning as review's prompt section). One consultation per phase — the outcome rides the exec-context so provenance attaches without consulting twice.
3. :codex/consultation provenance attached to the durable result at enter; gap-wiring record-phase-misses! at leave-release — release misses now enter the ledger with a situation instead of classifying :uncovered.
4. Explore, verify, and observe build no agent prompt; they stay unmapped by design (documented in the lockstep test).

T2 §6.2: drains :undelivered for the release phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)