### PR TITLE
feat(gate): stale-references — contract drift becomes a deterministic gate

### DIFF
--- a/components/gate/resources/config/gate/messages/en-US.edn
+++ b/components/gate/resources/config/gate/messages/en-US.edn
@@ -13,7 +13,15 @@
 
   ;; Stale-references gate — no worktree available
   :stale-references/no-worktree
-  "No worktree path on the execution context — stale-reference check skipped"
+  "No worktree path on the execution context — stale-references check skipped"
+
+  ;; Stale-references gate — git missing or worktree is not a repo
+  :stale-references/git-unavailable
+  "git unavailable or the worktree is not a git repository — stale-references check skipped"
+
+  ;; Stale-references gate — changed files carried no readable content
+  :stale-references/no-content
+  "Changed files carried no readable after-content — stale-references check skipped"
 
   ;; Review-approved gate — verdict not approved (carries the decision read)
   :review/not-approved

--- a/components/gate/resources/config/gate/messages/en-US.edn
+++ b/components/gate/resources/config/gate/messages/en-US.edn
@@ -3,7 +3,19 @@
 ;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
 
 {:gate/messages
- {;; Review-approved gate — verdict not approved (carries the decision read)
+ {;; Stale-references gate — registry description
+  :stale-references/description
+  "Fails when a removed keyword or def'd name is still referenced elsewhere in the repo (contract drift)"
+
+  ;; Stale-references gate — stale token found
+  :stale-references/stale
+  "'{token}' was removed by this change but is still referenced by: {files}"
+
+  ;; Stale-references gate — no worktree available
+  :stale-references/no-worktree
+  "No worktree path on the execution context — stale-reference check skipped"
+
+  ;; Review-approved gate — verdict not approved (carries the decision read)
   :review/not-approved
   "Review not approved (decision={decision})"
 

--- a/components/gate/src/ai/miniforge/gate/interface.clj
+++ b/components/gate/src/ai/miniforge/gate/interface.clj
@@ -38,6 +38,7 @@
    [ai.miniforge.gate.test]
    [ai.miniforge.gate.policy]
    [ai.miniforge.gate.codex-consultation]
+   [ai.miniforge.gate.stale-references]
    [ai.miniforge.gate.precommit-discipline]
    [ai.miniforge.gate.behavioral]
    [ai.miniforge.gate.opsv]

--- a/components/gate/src/ai/miniforge/gate/stale_references.clj
+++ b/components/gate/src/ai/miniforge/gate/stale_references.clj
@@ -1,0 +1,175 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.gate.stale-references
+  "Deterministic contract-drift gate: when a change removes a keyword or
+   a def'd name from a file, every remaining reference to it elsewhere
+   in the repo is a silently-broken consumer.
+
+   This gate is a Thesium Codex peg migrated into a mechanism (SPEC
+   §4.4.2.a/§4.5 — the best outcome a peg can have). It enforces the
+   problem node `contract-drift-is-silent` (situation
+   changing-one-side-of-a-boundary; scars knight-capital-flag-reuse,
+   round-format-drift): the trap bench measured eight of eight
+   implementer runs renaming a producer and missing an untested
+   consumer, with the prose warning delivered and read. Prose did not
+   change the outcome; this gate does not rely on prose.
+
+   Mechanics: for each changed file, the before-content comes from
+   `git show HEAD:<path>` in the worktree (implement runs on uncommitted
+   work, so HEAD is the pre-change state). Candidate tokens are keywords
+   and def'd names present in a before and absent from EVERY changed
+   file's after-content. Each candidate is then searched repo-wide
+   (`git grep -F`); any hit outside the changed set is a stale
+   reference and fails the gate with the token and its files.
+
+   Fail-open guards, each surfaced as a warning: no worktree path, no
+   changed-file content, git unavailable. The gate never guesses."
+  (:require [ai.miniforge.gate.messages :as messages]
+            [ai.miniforge.gate.registry :as registry]
+            [clojure.java.shell :as shell]
+            [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} min-token-length
+  "Tokens shorter than this are too collision-prone to grep for."
+  4)
+
+(def ^{:stratum 0} max-tokens
+  "Upper bound of removed tokens checked per run — a mass refactor
+   should fail on its first few stale tokens, not grep for hundreds."
+  24)
+
+(def ^{:stratum 0} max-files-per-token
+  "Upper bound of stale files reported per token."
+  8)
+
+(def ^{:stratum 0} keyword-pattern
+  "Clojure keyword literals, namespaced or bare."
+  #"(?<![\w:]):[A-Za-z][A-Za-z0-9*+!?_<>=./-]*")
+
+(def ^{:stratum 0} def-name-pattern
+  "Names bound by def/defn/defn-/defmacro/defmulti at any nesting."
+  #"\(def(?:n-?|macro|multi)?\s+(?:\^\S+\s+|\^\{[^}]*\}\s+)*([A-Za-z][A-Za-z0-9*+!?_<>=<-]*[A-Za-z0-9*+!?_<>=-])")
+
+(defn- ^{:stratum 0} git
+  "Trimmed stdout of a git command in `dir`, or nil on any failure."
+  [dir & args]
+  ;; Plain try, class-only catch at an absolute boundary (std 211 ex. a):
+  ;; a missing git binary must degrade to the gate's fail-open warning.
+  (try
+    (let [{:keys [exit out]} (apply shell/sh "git" "-C" (str dir) args)]
+      (when (zero? exit) (str out)))
+    (catch Exception _ nil)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} content-tokens
+  "The keyword literals and def'd names in `content`. Public for tests."
+  [content]
+  ;; keyword-pattern has no capture group, so re-seq yields the match
+  ;; strings directly; def-name-pattern captures the bound name.
+  (into (set (re-seq keyword-pattern (str content)))
+        (map second (re-seq def-name-pattern (str content)))))
+
+(defn- ^{:stratum 1} before-content
+  "The pre-change content of `path`, or nil when the file is new."
+  [worktree path]
+  (git worktree "show" (str "HEAD:" path)))
+
+(defn- ^{:stratum 1} stale-files
+  "Repo files outside `changed-paths` still referencing `token`."
+  [worktree changed-paths token]
+  ;; -e makes the token an explicit pattern — a token can never be
+  ;; parsed as an option or pathspec regardless of its first character.
+  (when-let [out (git worktree "grep" "-I" "-l" "-F" "-e" token "--")]
+    (->> (str/split-lines out)
+         (remove str/blank?)
+         (remove (set changed-paths))
+         (take max-files-per-token)
+         vec)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} removed-tokens
+  "Tokens present in some before-content and absent from every
+   after-content, longest first (a rename's long form is the real
+   contract; its fragments are noise). Public for tests."
+  [befores afters]
+  (let [before-tokens (reduce into #{} (map content-tokens befores))
+        after-blob (str/join "\n" (map str afters))]
+    (->> before-tokens
+         (remove #(< (count %) min-token-length))
+         (remove #(str/includes? after-blob %))
+         (sort-by (comp - count))
+         (take max-tokens)
+         vec)))
+
+;------------------------------------------------------------------------------ Layer 3
+
+(defn ^{:stratum 3} check-stale-references
+  "Gate check (see ns docstring). `artifact` is the implement phase
+   output; changed files ride on :code/files ({:path :content :action})
+   with :code/file-paths as the path fallback."
+  [artifact ctx]
+  (let [worktree (get ctx :execution/worktree-path)
+        files (:code/files artifact)
+        paths (or (seq (keep :path files)) (:code/file-paths artifact))]
+    (cond
+      (empty? paths)
+      {:passed? true}
+
+      (nil? worktree)
+      {:passed? true
+       :warnings [{:type :stale-references-skipped
+                   :message (messages/t :stale-references/no-worktree)}]}
+
+      :else
+      (let [befores (keep #(before-content worktree %) paths)
+            afters (if (seq files)
+                     (map :content files)
+                     (keep #(try (slurp (str worktree "/" %))
+                                 (catch Exception _ nil))
+                           paths))
+            removed (removed-tokens befores afters)
+            stale (into []
+                        (keep (fn [token]
+                                (let [hits (stale-files worktree paths token)]
+                                  (when (seq hits)
+                                    {:type :stale-reference
+                                     :token token
+                                     :files hits
+                                     :message (messages/t :stale-references/stale
+                                                          {:token token
+                                                           :files (str/join ", " hits)})}))))
+                        removed)]
+        (if (seq stale)
+          {:passed? false :errors stale}
+          {:passed? true})))))
+
+;------------------------------------------------------------------------------ Layer 4
+
+(defmethod ^{:stratum 4} registry/get-gate :stale-references
+  [_]
+  {:name :stale-references
+   :description (messages/t :stale-references/description)
+   :check check-stale-references
+   :repair nil})
+
+;; Registry
+(registry/register-gate! :stale-references)

--- a/components/gate/src/ai/miniforge/gate/stale_references.clj
+++ b/components/gate/src/ai/miniforge/gate/stale_references.clj
@@ -77,6 +77,17 @@
       (when (zero? exit) (str out)))
     (catch Exception _ nil)))
 
+(defn ^{:stratum 0} token-present?
+  "Whole-token occurrence of `token` in `blob` — boundary-anchored so
+   :skip is not counted present because :skipped survives. Public for
+   tests."
+  [blob token]
+  (boolean
+   (re-find (re-pattern (str "(?<![\\w:*+!?<>=./-])"
+                             (java.util.regex.Pattern/quote token)
+                             "(?![\\w*+!?<>=./-])"))
+            (str blob))))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn ^{:stratum 1} content-tokens
@@ -107,15 +118,15 @@
 ;------------------------------------------------------------------------------ Layer 2
 
 (defn ^{:stratum 2} removed-tokens
-  "Tokens present in some before-content and absent from every
-   after-content, longest first (a rename's long form is the real
-   contract; its fragments are noise). Public for tests."
+  "Tokens present in some before-content and absent (as whole tokens)
+   from every after-content, longest first (a rename's long form is the
+   real contract; its fragments are noise). Public for tests."
   [befores afters]
   (let [before-tokens (reduce into #{} (map content-tokens befores))
         after-blob (str/join "\n" (map str afters))]
     (->> before-tokens
          (remove #(< (count %) min-token-length))
-         (remove #(str/includes? after-blob %))
+         (remove #(token-present? after-blob %))
          (sort-by (comp - count))
          (take max-tokens)
          vec)))
@@ -125,11 +136,36 @@
 (defn ^{:stratum 3} check-stale-references
   "Gate check (see ns docstring). `artifact` is the implement phase
    output; changed files ride on :code/files ({:path :content :action})
-   with :code/file-paths as the path fallback."
+   with :code/file-paths as the path fallback.
+
+   `befores`/`afters`/`stale` are computed up front, unconditionally --
+   each is nil-safe on its own (a nil `worktree` or empty `paths` just
+   flows through as empty results) and the work is cheap, so guarding
+   each behind its own nesting level bought nothing but extra
+   conditional depth."
   [artifact ctx]
   (let [worktree (get ctx :execution/worktree-path)
         files (:code/files artifact)
-        paths (or (seq (keep :path files)) (:code/file-paths artifact))]
+        paths (or (seq (keep :path files)) (:code/file-paths artifact))
+        git-ok? (and worktree (some? (git worktree "rev-parse" "--git-dir")))
+        befores (when (and git-ok? (seq paths)) (keep #(before-content worktree %) paths))
+        afters (when (seq paths)
+                 (if (seq files)
+                   (keep :content files)
+                   (keep #(try (slurp (str worktree "/" %))
+                               (catch Exception _ nil))
+                         paths)))
+        stale (into []
+                    (keep (fn [token]
+                            (let [hits (stale-files worktree paths token)]
+                              (when (seq hits)
+                                {:type :stale-reference
+                                 :token token
+                                 :files hits
+                                 :message (messages/t :stale-references/stale
+                                                      {:token token
+                                                       :files (str/join ", " hits)})}))))
+                    (removed-tokens befores afters))]
     (cond
       (empty? paths)
       {:passed? true}
@@ -139,28 +175,21 @@
        :warnings [{:type :stale-references-skipped
                    :message (messages/t :stale-references/no-worktree)}]}
 
+      (not git-ok?)
+      {:passed? true
+       :warnings [{:type :stale-references-skipped
+                   :message (messages/t :stale-references/git-unavailable)}]}
+
+      (empty? afters)
+      {:passed? true
+       :warnings [{:type :stale-references-skipped
+                   :message (messages/t :stale-references/no-content)}]}
+
+      (seq stale)
+      {:passed? false :errors stale}
+
       :else
-      (let [befores (keep #(before-content worktree %) paths)
-            afters (if (seq files)
-                     (map :content files)
-                     (keep #(try (slurp (str worktree "/" %))
-                                 (catch Exception _ nil))
-                           paths))
-            removed (removed-tokens befores afters)
-            stale (into []
-                        (keep (fn [token]
-                                (let [hits (stale-files worktree paths token)]
-                                  (when (seq hits)
-                                    {:type :stale-reference
-                                     :token token
-                                     :files hits
-                                     :message (messages/t :stale-references/stale
-                                                          {:token token
-                                                           :files (str/join ", " hits)})}))))
-                        removed)]
-        (if (seq stale)
-          {:passed? false :errors stale}
-          {:passed? true})))))
+      {:passed? true})))
 
 ;------------------------------------------------------------------------------ Layer 4
 

--- a/components/gate/test/ai/miniforge/gate/stale_references_test.clj
+++ b/components/gate/test/ai/miniforge/gate/stale_references_test.clj
@@ -1,0 +1,114 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.gate.stale-references-test
+  "Tests for the contract-drift gate: token extraction, removal
+   semantics, and the end-to-end check against a real temp git repo —
+   the trap-bench shape (producer renamed, untested consumer stale) is
+   the fixture, per feedback: fixtures match the real producer's output."
+  (:require [clojure.java.shell :as shell]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.gate.stale-references :as stale])
+  (:import (java.nio.file Files)
+           (java.nio.file.attribute FileAttribute)))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} temp-git-repo
+  "Init a git repo with `files` ({path content}) committed at HEAD.
+   Returns the repo dir as a string."
+  [files]
+  (let [dir (str (Files/createTempDirectory "stale-ref-test" (make-array FileAttribute 0)))]
+    (shell/sh "git" "-C" dir "init" "-q")
+    (shell/sh "git" "-C" dir "config" "user.email" "test@test")
+    (shell/sh "git" "-C" dir "config" "user.name" "test")
+    (doseq [[path content] files]
+      (let [f (java.io.File. dir path)]
+        (.mkdirs (.getParentFile f))
+        (spit f content)))
+    (shell/sh "git" "-C" dir "add" "-A")
+    (shell/sh "git" "-C" dir "commit" "-q" "-m" "base")
+    dir))
+
+(deftest ^{:stratum 0} content-tokens-extracts-keywords-and-def-names
+  (let [tokens (stale/content-tokens
+                "(defn read-ledger [x]\n  {:entries [] :skipped 0 :a 1})\n(def ^{:stratum 0} ledger-filename \"f\")")]
+    (is (contains? tokens ":skipped"))
+    (is (contains? tokens ":entries"))
+    (is (contains? tokens "read-ledger"))
+    (is (contains? tokens "ledger-filename"))
+    (is (contains? tokens ":a")
+        "extraction keeps short tokens; removed-tokens filters length")))
+
+(deftest ^{:stratum 0} removed-tokens-semantics
+  (testing "a token absent from every after-content is removed"
+    (is (= [":skipped"]
+           (stale/removed-tokens ["{:entries [] :skipped 0}"]
+                                 ["{:entries [] :torn-lines 0}"]))))
+  (testing "a token that MOVED to another changed file is not removed"
+    (is (= []
+           (stale/removed-tokens ["{:skipped 0}"]
+                                 ["{}" "(get m :skipped)"]))))
+  (testing "short tokens are filtered"
+    (is (= []
+           (stale/removed-tokens ["{:a 1}"] ["{}"])))))
+
+(deftest ^{:stratum 0} check-guards
+  (testing "no changed files -> pass, no warnings"
+    (is (= {:passed? true}
+           (stale/check-stale-references {} {:execution/worktree-path "/tmp"}))))
+  (testing "no worktree -> fail-open with a warning"
+    (let [r (stale/check-stale-references
+             {:code/files [{:path "a.clj" :content "x" :action :modify}]} {})]
+      (is (true? (:passed? r)))
+      (is (= :stale-references-skipped (-> r :warnings first :type))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} check-fails-on-stale-consumer
+  (testing "the trap-bench shape: producer renames a key, an uncommitted
+            consumer elsewhere still reads the old one"
+    (let [producer "src/producer.clj"
+          consumer "tasks/report.clj"
+          dir (temp-git-repo
+               {producer "(ns producer)\n(defn read-ledger [] {:entries [] :skipped 0})"
+                consumer "(ns report)\n(defn skipped-count [r] (get r :skipped 0))"})
+          new-producer "(ns producer)\n(defn read-ledger [] {:entries [] :torn-lines 0})"
+          _ (spit (str dir "/" producer) new-producer)
+          result (stale/check-stale-references
+                  {:code/files [{:path producer :content new-producer :action :modify}]}
+                  {:execution/worktree-path dir})]
+      (is (false? (:passed? result)))
+      (is (= [":skipped"] (mapv :token (:errors result))))
+      (is (= [[consumer]] (mapv :files (:errors result)))))))
+
+(deftest ^{:stratum 1} check-passes-when-consumers-updated
+  (let [producer "src/producer.clj"
+        consumer "tasks/report.clj"
+        dir (temp-git-repo
+             {producer "(ns producer)\n(defn read-ledger [] {:skipped 0})"
+              consumer "(ns report)\n(get {} :skipped)"})
+        new-producer "(ns producer)\n(defn read-ledger [] {:torn-lines 0})"
+        new-consumer "(ns report)\n(get {} :torn-lines)"
+        _ (spit (str dir "/" producer) new-producer)
+        _ (spit (str dir "/" consumer) new-consumer)
+        result (stale/check-stale-references
+                {:code/files [{:path producer :content new-producer :action :modify}
+                              {:path consumer :content new-consumer :action :modify}]}
+                {:execution/worktree-path dir})]
+    (is (true? (:passed? result)))))

--- a/components/gate/test/ai/miniforge/gate/stale_references_test.clj
+++ b/components/gate/test/ai/miniforge/gate/stale_references_test.clj
@@ -64,11 +64,24 @@
     (is (= []
            (stale/removed-tokens ["{:skipped 0}"]
                                  ["{}" "(get m :skipped)"]))))
+  (testing "boundary-anchored presence: :skip is removed even though
+            :skipped survives in the after-content"
+    (is (= [":skip"]
+           (stale/removed-tokens ["{:skip 1 :skipped 0}"]
+                                 ["{:skipped 0}"]))))
   (testing "short tokens are filtered"
     (is (= []
            (stale/removed-tokens ["{:a 1}"] ["{}"])))))
 
-(deftest ^{:stratum 0} check-guards
+(deftest ^{:stratum 0} token-present?-boundaries
+  (is (true? (stale/token-present? "(get r :skipped 0)" ":skipped")))
+  (is (false? (stale/token-present? "(get r :skipped 0)" ":skip")))
+  (is (false? (stale/token-present? "read-ledger-fast" "read-ledger")))
+  (is (true? (stale/token-present? "(read-ledger x)" "read-ledger"))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(deftest ^{:stratum 1} check-guards
   (testing "no changed files -> pass, no warnings"
     (is (= {:passed? true}
            (stale/check-stale-references {} {:execution/worktree-path "/tmp"}))))
@@ -76,9 +89,23 @@
     (let [r (stale/check-stale-references
              {:code/files [{:path "a.clj" :content "x" :action :modify}]} {})]
       (is (true? (:passed? r)))
-      (is (= :stale-references-skipped (-> r :warnings first :type))))))
-
-;------------------------------------------------------------------------------ Layer 1
+      (is (= :stale-references-skipped (-> r :warnings first :type)))))
+  (testing "worktree is not a git repo -> fail-open with the
+            git-unavailable warning"
+    (let [dir (str (Files/createTempDirectory "stale-ref-nogit" (make-array FileAttribute 0)))
+          r (stale/check-stale-references
+             {:code/files [{:path "a.clj" :content "x" :action :modify}]}
+             {:execution/worktree-path dir})]
+      (is (true? (:passed? r)))
+      (is (str/includes? (-> r :warnings first :message) "git unavailable"))))
+  (testing "no readable after-content -> fail-open with the no-content
+            warning"
+    (let [dir (temp-git-repo {"a.clj" "(ns a)"})
+          r (stale/check-stale-references
+             {:code/file-paths ["missing.clj"]}
+             {:execution/worktree-path dir})]
+      (is (true? (:passed? r)))
+      (is (str/includes? (-> r :warnings first :message) "no readable after-content")))))
 
 (deftest ^{:stratum 1} check-fails-on-stale-consumer
   (testing "the trap-bench shape: producer renames a key, an uncommitted

--- a/components/phase-software-factory/resources/config/phase/defaults.edn
+++ b/components/phase-software-factory/resources/config/phase/defaults.edn
@@ -2,7 +2,7 @@
  {;; Implementation phase defaults.
   :implement
   {:agent :implementer
-   :gates [:syntax :format :lint :codex-consultation]
+   :gates [:syntax :format :lint :codex-consultation :stale-references]
    :budget {:tokens 30000
             :iterations 8
             :time-seconds 600}

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/implement_test.clj
@@ -81,11 +81,11 @@
     (response/error (or (:message err) "Implementation failed")
                     {:data (or (:data err) {})})))
 
-;------------------------------------------------------------------------------ Layer 0: Defaults Tests
+;; Defaults Tests
 (deftest ^{:stratum 0} default-config-test
   (testing "implement phase has correct default configuration"
     (is (= :implementer (:agent implement/default-config)))
-    (is (= [:syntax :format :lint :codex-consultation] (:gates implement/default-config)))
+    (is (= [:syntax :format :lint :codex-consultation :stale-references] (:gates implement/default-config)))
     (is (map? (:budget implement/default-config)))
     (is (= 30000 (get-in implement/default-config [:budget :tokens])))
     (is (= 8 (get-in implement/default-config [:budget :iterations])))
@@ -96,7 +96,7 @@
     (let [defaults (phase/phase-defaults :implement)]
       (is (some? defaults))
       (is (= :implementer (:agent defaults)))
-      (is (= [:syntax :format :lint :codex-consultation] (:gates defaults))))))
+      (is (= [:syntax :format :lint :codex-consultation :stale-references] (:gates defaults))))))
 
 (deftest ^{:stratum 0} base-ref-candidates-include-resume-merge-base-ranges-test
   (testing "resumed workspaces diff from the original spec base to restored HEAD"
@@ -139,7 +139,7 @@
   (response/error "No files written to environment"
                   {:data {:code :curator/no-files-written}}))
 
-;------------------------------------------------------------------------------ Layer 3: Capsule File Loading
+;; Capsule File Loading
 (deftest ^{:stratum 0} load-files-from-capsule-reads-via-execute-fn-test
   (testing "load-files-from-capsule reads files via execute-fn"
     (let [execute-fn (fn [_executor _env-id cmd _opts]
@@ -770,7 +770,7 @@
                (get-in result [:phase :result :error :message]))
             "Error message should be preserved")))))
 
-;------------------------------------------------------------------------------ Layer 2: Interceptor Leave Tests
+;; Interceptor Leave Tests
 (deftest ^{:stratum 2} leave-implement-records-metrics-test
   (testing "leave-implement records duration and token metrics"
     (with-redefs [agent/create-implementer (fn [_] {:type :mock-implementer})


### PR DESCRIPTION
## What

The trap bench (#1750) measured the codex's contract-drift landing changing nothing: eight of eight implementer runs (both arms plus test runs) renamed a producer-side key, updated component and tests, and missed the untested bb.edn consumer — with the warning delivered and read. Per the operator directive and SPEC §4.4.2.a (a peg's best outcome is being replaced by a mechanism), the worry becomes a gate:

1. `:stale-references` extracts keyword literals and def'd names that the change REMOVES (before-content = `git show HEAD:<path>` in the worktree — implement runs on uncommitted work), where removed means absent from every changed file's after-content (a token that moved between changed files is not removed).
2. Each removed token is searched repo-wide (`git grep -I -l -F -e <token> --`); any hit outside the changed set fails the gate with the token and the stale files — the exact evidence an implementer needs to finish the rename.
3. Fail-open guards with warnings: no worktree path, no changed content, git unavailable. Caps: 24 tokens per run, 8 files per token, minimum token length 4.
4. Default-on at implement (`defaults.edn`). Deliberately NOT in `policy-gates` yet: a fresh detector needs calibration data before it becomes un-droppable; promotion is the follow-up once false-positive rates are observed. Note canonical-sdlc v2's implement `:gates` override therefore drops it today — promotion to `policy-gates` is the switch that turns it on there.
5. Gate ns documents the codex receipt chain (SPEC §4.5): problem `contract-drift-is-silent`, scars knight-capital-flag-reuse and round-format-drift.

## Verification

Unit tests cover token extraction, removal semantics (including the moved-token case), and end-to-end checks against a real temp git repo built in the trap-bench shape (producer renamed, uncommitted consumer stale → fail with the right token and file; consumers updated → pass; guards). Full `bb test` green.

T2 §6.2: this drains the `:unheeded` bucket by removing the attention rung from the loop entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)