### PR TITLE
feat(buzzword-bingo): term catalog, detection and scoring

### DIFF
--- a/components/buzzword-bingo/deps.edn
+++ b/components/buzzword-bingo/deps.edn
@@ -1,4 +1,4 @@
-{:paths ["src"]
+{:paths ["src" "resources"]
  :deps {}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/buzzword-bingo/resources/config/buzzword-bingo/lexicon.edn
+++ b/components/buzzword-bingo/resources/config/buzzword-bingo/lexicon.edn
@@ -1,0 +1,135 @@
+;; Buzzword Bingo lexicon — the terms the scanner counts.
+;;
+;; Entries are data, not prose: `:entry/term` is the literal being
+;; matched and `:entry/label` names a pattern that has no single literal
+;; form. Neither is display copy, so neither belongs in a message
+;; catalog. Anything the tool says *about* a hit is localized.
+;;
+;; Fields
+;;   :entry/term     literal to match, lowercase, spaces match any whitespace run
+;;   :entry/pattern  raw pattern source, for entries with no single literal form
+;;   :entry/label    name of a :entry/pattern entry, shown where a term would be
+;;   :entry/category key into :lexicon/categories, supplies the default weight
+;;   :entry/weight   per-entry override, for terms that are worse than their category
+;;   :entry/stem?    also match the s/es/d/ed/ing/ly inflections of the last word
+;;
+;; Patterns are matched against lowercase text with non-prose regions
+;; already blanked, and must avoid inline modifiers — see the regex
+;; namespace for why.
+
+{:lexicon/version "2026-08-09"
+
+ :lexicon/categories
+ {:marketing {:category/weight 3}
+  :ai-tell   {:category/weight 3}
+  :corporate {:category/weight 2}
+  :hedge     {:category/weight 1}
+  :filler    {:category/weight 1}}
+
+ :lexicon/entries
+ [;; ---------------------------------------------------------------- marketing
+  ;; Selling adjectives. A claim about how good the thing is, in place
+  ;; of a statement of what it does.
+  {:entry/term "comprehensive"    :entry/category :marketing}
+  {:entry/term "robust"           :entry/category :marketing}
+  {:entry/term "powerful"         :entry/category :marketing}
+  {:entry/term "seamless"         :entry/category :marketing :entry/stem? true}
+  {:entry/term "elegant"          :entry/category :marketing :entry/stem? true}
+  {:entry/term "surgical"         :entry/category :marketing}
+  {:entry/term "load-bearing"     :entry/category :marketing}
+  {:entry/term "the real deal"    :entry/category :marketing}
+  {:entry/term "cutting-edge"     :entry/category :marketing}
+  {:entry/term "state-of-the-art" :entry/category :marketing}
+  {:entry/term "best-in-class"    :entry/category :marketing}
+  {:entry/term "world-class"      :entry/category :marketing}
+  {:entry/term "industry-leading" :entry/category :marketing}
+  {:entry/term "game-changing"    :entry/category :marketing}
+  {:entry/term "game changer"     :entry/category :marketing}
+  {:entry/term "revolutionary"    :entry/category :marketing}
+  {:entry/term "next-generation"  :entry/category :marketing}
+  {:entry/term "enterprise-grade" :entry/category :marketing}
+  {:entry/term "battle-tested"    :entry/category :marketing}
+  {:entry/term "blazing fast"     :entry/category :marketing}
+  {:entry/term "blazingly fast"   :entry/category :marketing}
+  {:entry/term "lightning fast"   :entry/category :marketing}
+  {:entry/term "rock-solid"       :entry/category :marketing}
+  {:entry/term "turnkey"          :entry/category :marketing}
+  {:entry/term "unparalleled"     :entry/category :marketing}
+  {:entry/term "unmatched"        :entry/category :marketing}
+  {:entry/term "first-class"      :entry/category :marketing}
+  {:entry/term "delightful"       :entry/category :marketing}
+  {:entry/term "effortless"       :entry/category :marketing :entry/stem? true}
+  {:entry/term "frictionless"     :entry/category :marketing}
+  {:entry/term "supercharge"      :entry/category :marketing :entry/stem? true}
+  {:entry/term "transformative"   :entry/category :marketing}
+
+  ;; ------------------------------------------------------------------ ai-tell
+  ;; Register that marks generated text. Weighted above the category
+  ;; default where the word is close to a fingerprint on its own.
+  {:entry/term "delve"                 :entry/category :ai-tell :entry/weight 5 :entry/stem? true}
+  {:entry/term "tapestry"              :entry/category :ai-tell :entry/weight 5}
+  {:entry/term "a testament to"        :entry/category :ai-tell :entry/weight 5}
+  {:entry/term "ever-evolving"         :entry/category :ai-tell :entry/weight 5}
+  {:entry/term "in the realm of"       :entry/category :ai-tell :entry/weight 4}
+  {:entry/term "navigate the complexities" :entry/category :ai-tell :entry/weight 4}
+  {:entry/term "harness the power"     :entry/category :ai-tell :entry/weight 4}
+  {:entry/term "unlock the potential"  :entry/category :ai-tell :entry/weight 4}
+  {:entry/term "paves the way"         :entry/category :ai-tell}
+  {:entry/term "sheds light on"        :entry/category :ai-tell}
+  {:entry/term "fast-paced"            :entry/category :ai-tell}
+  {:entry/term "multifaceted"          :entry/category :ai-tell}
+  {:entry/term "myriad"                :entry/category :ai-tell}
+  {:entry/term "plethora"              :entry/category :ai-tell}
+  {:entry/term "nuanced"               :entry/category :ai-tell}
+  {:entry/term "intricate"             :entry/category :ai-tell}
+  {:entry/term "meticulous"            :entry/category :ai-tell :entry/stem? true}
+  {:entry/term "pivotal"               :entry/category :ai-tell}
+  {:entry/term "quintessential"        :entry/category :ai-tell}
+  {:entry/term "cornerstone"           :entry/category :ai-tell}
+  {:entry/term "hallmark"              :entry/category :ai-tell}
+  {:entry/term "underscore"            :entry/category :ai-tell :entry/stem? true}
+  {:entry/term "bolster"               :entry/category :ai-tell :entry/stem? true}
+  {:entry/term "garner"                :entry/category :ai-tell :entry/stem? true}
+  {:entry/term "spearhead"             :entry/category :ai-tell :entry/stem? true}
+  {:entry/term "showcase"              :entry/category :ai-tell :entry/stem? true}
+  {:entry/term "empower"               :entry/category :ai-tell :entry/stem? true}
+  {:entry/term "it's important to note" :entry/category :ai-tell}
+  {:entry/term "it's worth noting"     :entry/category :ai-tell}
+  {:entry/term "in conclusion"         :entry/category :ai-tell}
+  {:entry/term "at the end of the day" :entry/category :ai-tell}
+  {:entry/term "that being said"       :entry/category :ai-tell}
+
+  ;; ---------------------------------------------------------------- corporate
+  {:entry/term "synergy"           :entry/category :corporate :entry/stem? true}
+  {:entry/term "leverage"          :entry/category :corporate :entry/stem? true}
+  {:entry/term "holistic"          :entry/category :corporate}
+  {:entry/term "paradigm"          :entry/category :corporate}
+  {:entry/term "low-hanging fruit" :entry/category :corporate}
+  {:entry/term "move the needle"   :entry/category :corporate}
+  {:entry/term "circle back"       :entry/category :corporate}
+  {:entry/term "deep dive"         :entry/category :corporate}
+  {:entry/term "north star"        :entry/category :corporate}
+  {:entry/term "force multiplier"  :entry/category :corporate}
+  {:entry/term "mission-critical"  :entry/category :corporate}
+  {:entry/term "thought leadership" :entry/category :corporate}
+  {:entry/term "actionable insights" :entry/category :corporate}
+  {:entry/term "table stakes"      :entry/category :corporate}
+  {:entry/term "operationalize"    :entry/category :corporate :entry/stem? true}
+  {:entry/term "incentivize"       :entry/category :corporate :entry/stem? true}
+
+  ;; -------------------------------------------------------------------- hedge
+  {:entry/term "arguably"          :entry/category :hedge}
+  {:entry/term "essentially"       :entry/category :hedge}
+  {:entry/term "fundamentally"     :entry/category :hedge}
+  {:entry/term "in many ways"      :entry/category :hedge}
+  {:entry/term "to some extent"    :entry/category :hedge}
+  {:entry/term "generally speaking" :entry/category :hedge}
+
+  ;; ------------------------------------------------------------------- filler
+  {:entry/term "very"              :entry/category :filler}
+  {:entry/term "really"            :entry/category :filler}
+  {:entry/term "actually"          :entry/category :filler}
+  {:entry/term "truly"             :entry/category :filler}
+  {:entry/term "literally"         :entry/category :filler}
+  {:entry/term "incredibly"        :entry/category :filler}
+  {:entry/term "extremely"         :entry/category :filler}]}

--- a/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/detect.cljc
+++ b/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/detect.cljc
@@ -75,18 +75,24 @@
   "Locate every lexicon hit in `text`.
 
    Returns `{:scan/hits [...] :scan/word-count n :scan/lexicon-version v}`
-   with hits ordered by position. `:entries` in `opts` replaces the
-   catalog; remaining options pass through to masking."
+   with hits ordered by position.
+
+   `:entries` in `opts` replaces the catalog, in which case the version
+   stamp is whatever `:lexicon-version` says and nil otherwise — the
+   stamp exists so a score traces back to the catalog that produced it,
+   and naming the shipped version over somebody else's catalog would
+   defeat that. Remaining options pass through to masking."
   ([text] (scan text nil))
   ([text opts]
    (let [entries (get opts :entries lexicon/entries)
+         shipped? (identical? entries lexicon/entries)
          folded  (regex/ascii-lower (segment/prose-only text opts))
          starts  (locate/line-starts text)
          raw     (sort-by hit-order (mapcat (partial entry-hits folded) entries))
          kept    (:kept (reduce keep-outermost {:kept [] :furthest-end -1} raw))]
      {:scan/hits            (mapv (partial locate/place text starts) kept)
       :scan/word-count      (word-count folded)
-      :scan/lexicon-version lexicon/version})))
+      :scan/lexicon-version (get opts :lexicon-version (when shipped? lexicon/version))})))
 
 (comment
   (scan "This robust and comprehensive solution will delve into synergy.")

--- a/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/detect.cljc
+++ b/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/detect.cljc
@@ -1,0 +1,93 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.buzzword-bingo.detect
+  "Find every catalog term in a document.
+
+   Matching runs over a masked, case-folded copy so code and links
+   cannot score; positions and context come from the source."
+  (:require
+   [ai.miniforge.buzzword-bingo.lexicon :as lexicon]
+   [ai.miniforge.buzzword-bingo.locate :as locate]
+   [ai.miniforge.buzzword-bingo.regex :as regex]
+   [ai.miniforge.buzzword-bingo.segment :as segment]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Raw hits
+(def ^{:stratum 0} ^:private word-pattern
+  "A prose word: alphanumeric with internal apostrophes and hyphens."
+  #"[a-z0-9][a-z0-9'’-]*")
+
+(defn- ^{:stratum 0} hit-of [entry {:match/keys [index text]}]
+  {:hit/id       (:entry/id entry)
+   :hit/term     (:entry/display entry)
+   :hit/matched  text
+   :hit/category (:entry/category entry)
+   :hit/weight   (:entry/effective-weight entry)
+   :hit/index    index
+   :hit/length   (count text)})
+
+;; Earliest first, longest first at equal position — the order keep-outermost
+;; relies on.
+(defn- ^{:stratum 0} hit-order [hit]
+  [(:hit/index hit) (- (:hit/length hit))])
+
+;; Entries overlap by design (`deep dive` contains `dive`) and counting both
+;; charges a document twice for one phrase. Every kept hit starts at or before
+;; the candidate, so a candidate ending no later than the furthest end so far
+;; is contained in one of them.
+(defn- ^{:stratum 0} keep-outermost [{:keys [kept furthest-end]} hit]
+  (let [end (+ (:hit/index hit) (:hit/length hit))]
+    (if (<= end furthest-end)
+      {:kept kept :furthest-end furthest-end}
+      {:kept (conj kept hit) :furthest-end end})))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Counting and matching
+(defn ^{:stratum 1} word-count
+  "Count prose words in already-masked, already-folded text."
+  [folded]
+  (count (regex/find-all word-pattern folded)))
+
+(defn- ^{:stratum 1} entry-hits [folded entry]
+  (map (partial hit-of entry) (regex/find-all (:entry/regex entry) folded)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Scanning
+(defn ^{:stratum 2} scan
+  "Locate every lexicon hit in `text`.
+
+   Returns `{:scan/hits [...] :scan/word-count n :scan/lexicon-version v}`
+   with hits ordered by position. `:entries` in `opts` replaces the
+   catalog; remaining options pass through to masking."
+  ([text] (scan text nil))
+  ([text opts]
+   (let [entries (get opts :entries lexicon/entries)
+         folded  (regex/ascii-lower (segment/prose-only text opts))
+         starts  (locate/line-starts text)
+         raw     (sort-by hit-order (mapcat (partial entry-hits folded) entries))
+         kept    (:kept (reduce keep-outermost {:kept [] :furthest-end -1} raw))]
+     {:scan/hits            (mapv (partial locate/place text starts) kept)
+      :scan/word-count      (word-count folded)
+      :scan/lexicon-version lexicon/version})))
+
+(comment
+  (scan "This robust and comprehensive solution will delve into synergy.")
+  (:scan/word-count (scan "one two three")))

--- a/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/entry.cljc
+++ b/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/entry.cljc
@@ -29,11 +29,18 @@
 ;------------------------------------------------------------------------------ Layer 0
 
 ;; Reading one entry
-(defn- ^{:stratum 0} slug [s]
-  (-> (regex/ascii-lower s)
-      (str/replace #"[^a-z0-9]+" "-")
-      (str/replace #"^-" "")
-      (str/replace #"-$" "")))
+;; A display name with no ASCII alphanumerics at all slugs to the empty
+;; string. Two such entries would share the blank id and silently merge in the
+;; per-term tallies, which group on it, so the catalog is refused instead.
+(defn- ^{:stratum 0} slug-id [s]
+  (let [slug (-> (regex/ascii-lower s)
+                 (str/replace #"[^a-z0-9]+" "-")
+                 (str/replace #"^-" "")
+                 (str/replace #"-$" ""))]
+    (when (str/blank? slug)
+      (throw (#?(:clj IllegalArgumentException. :cljs js/Error.)
+              (str "Lexicon entry has no identifier-forming characters: " (pr-str s)))))
+    (keyword slug)))
 
 ;; An entry supplies either a literal term or raw pattern source; the raw form
 ;; exists for shapes with no single literal, such as a variable middle.
@@ -66,7 +73,7 @@
         weight  (get entry :entry/weight
                      (weight-for categories (get entry :entry/category)))]
     (assoc entry
-           :entry/id (keyword (slug display))
+           :entry/id (slug-id display)
            :entry/display display
            :entry/effective-weight weight
            :entry/regex (entry-pattern entry))))

--- a/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/entry.cljc
+++ b/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/entry.cljc
@@ -1,0 +1,87 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.buzzword-bingo.entry
+  "Turn an authored catalog entry into one the scanner can match with.
+
+   An authored entry carries a term or a raw pattern and a category; a
+   compiled one adds a stable id, a display name, the weight in force
+   and the compiled pattern."
+  (:require
+   [ai.miniforge.buzzword-bingo.phrase :as phrase]
+   [ai.miniforge.buzzword-bingo.regex :as regex]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Reading one entry
+(defn- ^{:stratum 0} slug [s]
+  (-> (regex/ascii-lower s)
+      (str/replace #"[^a-z0-9]+" "-")
+      (str/replace #"^-" "")
+      (str/replace #"-$" "")))
+
+;; An entry supplies either a literal term or raw pattern source; the raw form
+;; exists for shapes with no single literal, such as a variable middle.
+(defn- ^{:stratum 0} entry-pattern [{:entry/keys [term pattern stem?]}]
+  (if pattern
+    (re-pattern pattern)
+    (phrase/term-pattern term {:stem? stem?})))
+
+;; A catalog is authored, not received at runtime, so a bad entry is a
+;; programmer error caught at load rather than data to be handled.
+(defn- ^{:stratum 0} weight-for [categories category]
+  (let [defaults (get categories category)]
+    (when-not defaults
+      (throw (#?(:clj IllegalArgumentException. :cljs js/Error.)
+              (str "Unknown lexicon category: " category))))
+    (get defaults :category/weight)))
+
+(defn- ^{:stratum 0} display-for [entry]
+  (let [display (or (:entry/label entry) (:entry/term entry))]
+    (when (str/blank? display)
+      (throw (#?(:clj IllegalArgumentException. :cljs js/Error.)
+              (str "Lexicon entry needs a term or a label: " (pr-str entry)))))
+    display))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Compilation
+(defn- ^{:stratum 1} compile-one [categories entry]
+  (let [display (display-for entry)
+        weight  (get entry :entry/weight
+                     (weight-for categories (get entry :entry/category)))]
+    (assoc entry
+           :entry/id (keyword (slug display))
+           :entry/display display
+           :entry/effective-weight weight
+           :entry/regex (entry-pattern entry))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Compiling a catalog
+(defn ^{:stratum 2} compile-all
+  "Compile `raw-entries` against `categories`.
+
+   Public so a caller can supply a project-local catalog in the shape
+   of the shipped one and get entries the scanner accepts."
+  [categories raw-entries]
+  (mapv (partial compile-one categories) raw-entries))
+
+(comment
+  (compile-all {:mild {:category/weight 1}}
+               [{:entry/term "low-hanging fruit" :entry/category :mild}]))

--- a/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/inline.clj
+++ b/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/inline.clj
@@ -20,7 +20,7 @@
    ClojureScript, which has no runtime classpath. Expansion always runs
    on the JVM, for both targets.
 
-   Build tools that cache macro expansion do not know this read a file,
+   Build tools that cache macro expansion do not know this macro reads a file,
    so a consuming namespace belongs in shadow-cljs `:cache-blockers`."
   (:require
    [clojure.edn :as edn]

--- a/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/inline.clj
+++ b/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/inline.clj
@@ -1,0 +1,47 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.buzzword-bingo.inline
+  "Compile-time EDN inlining, so configuration survives the trip to
+   ClojureScript, which has no runtime classpath. Expansion always runs
+   on the JVM, for both targets.
+
+   Build tools that cache macro expansion do not know this read a file,
+   so a consuming namespace belongs in shadow-cljs `:cache-blockers`."
+  (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Resource reading
+(defn- ^{:stratum 0} read-edn-resource [path]
+  (if-let [url (io/resource path)]
+    (edn/read-string (slurp url))
+    (throw (IllegalArgumentException.
+            (str "EDN resource not found on classpath: " path)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Macro surface
+(defmacro ^{:stratum 1} edn-resource
+  "Emit the parsed EDN classpath resource at `path` as a literal."
+  [path]
+  (read-edn-resource path))
+
+(comment
+  (macroexpand '(edn-resource "config/buzzword-bingo/lexicon.edn")))

--- a/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/interface.cljc
+++ b/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/interface.cljc
@@ -18,15 +18,39 @@
 (ns ai.miniforge.buzzword-bingo.interface
   "Public API for the buzzword-bingo component.
 
-   Today: prepares a document for counting by blanking the regions that
-   are not authored prose. The counter that consumes it arrives with
-   the term catalog."
+   Counts marketing, corporate and generated-prose tells in a document
+   and grades the result, so a caller can decide whether prose is worth
+   keeping or should be written again."
   (:require
+   [ai.miniforge.buzzword-bingo.detect :as detect]
+   [ai.miniforge.buzzword-bingo.lexicon :as lexicon]
+   [ai.miniforge.buzzword-bingo.score :as score]
    [ai.miniforge.buzzword-bingo.segment :as segment]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
-;; Text preparation
+;; Catalog
+(defn ^{:stratum 0} entries
+  "Every compiled lexicon entry."
+  []
+  lexicon/entries)
+
+(defn ^{:stratum 0} categories
+  "Category key → attributes, including the category's default weight."
+  []
+  lexicon/categories)
+
+(defn ^{:stratum 0} lexicon-version
+  "Version stamp of the catalog backing this build."
+  []
+  lexicon/version)
+
+(defn ^{:stratum 0} default-thresholds
+  "Grade boundaries applied when a caller supplies none."
+  []
+  score/default-thresholds)
+
+;; Scanning
 (defn ^{:stratum 0} prose-only
   "Return `text` with code, links, paths and quotations blanked out.
 
@@ -35,5 +59,19 @@
   ([text] (segment/prose-only text))
   ([text opts] (segment/prose-only text opts)))
 
+(defn ^{:stratum 0} scan
+  "Scan `text` for lexicon terms and grade the result.
+
+   Returns hits with position and context, per-category and per-term
+   tallies, a weighted rate per thousand words, and a grade of
+   `:clean`, `:suspect` or `:slop`.
+
+   Options: `:entries` replaces the catalog, `:thresholds` replaces the
+   grade boundaries, `:score-quotes?` counts blockquoted lines."
+  ([text] (scan text nil))
+  ([text opts] (score/summarize (detect/scan text opts) opts)))
+
 (comment
-  (prose-only "Use `robust` in code but not in prose."))
+  (prose-only "Use `robust` in code but not in prose.")
+  (scan "A robust, comprehensive, seamless solution.")
+  (:score/grade (scan "Plain sentence about a file parser.")))

--- a/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/lexicon.cljc
+++ b/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/lexicon.cljc
@@ -1,0 +1,57 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.buzzword-bingo.lexicon
+  "The shipped catalog of counted terms.
+
+   Canonical form is EDN on disk so it reviews as data. It is inlined
+   at compile time rather than read at runtime so one namespace serves
+   both a JVM classpath and a bundled Node script."
+  (:require
+   [ai.miniforge.buzzword-bingo.entry :as entry]
+   #?(:clj [ai.miniforge.buzzword-bingo.inline :as inline]))
+  #?(:cljs (:require-macros [ai.miniforge.buzzword-bingo.inline :as inline])))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Catalog source
+;; The macro needs a literal path, so it cannot come from a named constant.
+(def ^{:stratum 0} ^:private source
+  (inline/edn-resource "config/buzzword-bingo/lexicon.edn"))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Published catalog
+(def ^{:stratum 1} categories
+  "Category key → attributes, including the category's default weight."
+  (get source :lexicon/categories))
+
+(def ^{:stratum 1} version
+  "Catalog version stamp, reported with every scan so a score traces
+   back to the catalog that produced it."
+  (get source :lexicon/version))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Compiled entries
+(def ^{:stratum 2} entries
+  "Every catalog entry, compiled and ready to match."
+  (entry/compile-all categories (get source :lexicon/entries)))
+
+(comment
+  (count entries)
+  (first entries))

--- a/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/locate.cljc
+++ b/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/locate.cljc
@@ -1,0 +1,75 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.buzzword-bingo.locate
+  "Turn a character offset into somewhere a human can look.
+
+   Matching happens on a masked copy of a document; reporting has to
+   name a place in the original. Both strings have the same length by
+   construction, so one offset serves for both."
+  (:require
+   [ai.miniforge.buzzword-bingo.regex :as regex]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Offsets
+(def ^{:stratum 0} ^:private newline-pattern #"\n")
+
+(def ^{:stratum 0} ^:private snippet-radius
+  "Characters of surrounding source quoted on either side of a hit."
+  40)
+
+;; Linear in lines per lookup, which is well inside budget for documents and
+;; chat turns; revisit before running this over a whole repository in one pass.
+(defn- ^{:stratum 0} position-of [starts index]
+  (let [line (count (take-while #(<= % index) starts))]
+    {:hit/line   line
+     :hit/column (inc (- index (nth starts (dec line))))}))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Lines and quotations
+(defn ^{:stratum 1} line-starts
+  "Character offset at which each line of `text` begins."
+  [text]
+  (into [0] (map #(inc (:match/index %))) (regex/find-all newline-pattern text)))
+
+(defn- ^{:stratum 1} snippet [text index length]
+  (let [from (max 0 (- index snippet-radius))
+        to   (min (count text) (+ index length snippet-radius))]
+    (-> (subs text from to)
+        (str/replace #"\s+" " ")
+        str/trim)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Placing a hit
+(defn ^{:stratum 2} place
+  "Attach one-based line and column, and surrounding source, to `hit`.
+
+   `starts` comes from `line-starts` over the same `text`; it is passed
+   in rather than recomputed so a scan pays for it once."
+  [text starts hit]
+  (merge hit
+         (position-of starts (:hit/index hit))
+         {:hit/context (snippet text (:hit/index hit) (:hit/length hit))}))
+
+(comment
+  (line-starts "one\ntwo\nthree")
+  (place "a robust claim" (line-starts "a robust claim")
+         {:hit/index 2 :hit/length 6}))

--- a/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/score.cljc
+++ b/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/score.cljc
@@ -1,0 +1,97 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.buzzword-bingo.score
+  "Turn hits into a number a gate can act on.
+
+   A raw count is not comparable across documents, so the reported
+   figure is a rate per thousand words, weighted by how damning each
+   term is."
+  (:require
+   [ai.miniforge.buzzword-bingo.tally :as tally]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Constants and arithmetic
+;; Worked cases behind the numbers, at the smoothing below: one marketing
+;; adjective in 500 words scores 5, two score 10, five score 25; a single
+;; filler word in a ten-word reply scores 9, a single marketing adjective in
+;; the same reply scores 27. Catching the last of those is the point of the
+;; tool, so a short text is not exempt — only a light one is.
+(def ^{:stratum 0} default-thresholds
+  "Grade boundaries in weighted hits per thousand words. Calibrated by
+   hand against generated and hand-written prose, not derived — a
+   working number, tuned as evidence arrives."
+  {:threshold/suspect 10.0
+   :threshold/slop    25.0})
+
+(def ^{:stratum 0} ^:private density-smoothing-words
+  "Words added to every rate's denominator. Without it a two-sentence
+   reply with one buzzword outscores a long document with twenty."
+  100)
+
+(def ^{:stratum 0} ^:private per-thousand 1000)
+
+;; Truncating after adding a half rounds half up for non-negatives on both
+;; hosts, avoiding a rounding function ClojureScript does not share.
+(defn- ^{:stratum 0} round-hundredths [x]
+  (/ (long (+ 0.5 (* x 100))) 100.0))
+
+(defn- ^{:stratum 0} grade-for [value thresholds]
+  (cond
+    (>= value (get thresholds :threshold/slop))    :slop
+    (>= value (get thresholds :threshold/suspect)) :suspect
+    :else                                          :clean))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Rates
+(defn- ^{:stratum 1} rate [total word-count]
+  (round-hundredths
+   (/ (* per-thousand (double total))
+      (+ word-count density-smoothing-words))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Summary
+(defn ^{:stratum 2} summarize
+  "Score a scan result, returning it augmented with `:score/*` keys:
+   counts, per-thousand-word rates, per-category and per-term tallies,
+   and a grade of `:clean`, `:suspect` or `:slop`.
+
+   `:thresholds` in `opts` replaces the default grade boundaries."
+  ([scan] (summarize scan nil))
+  ([scan opts]
+   (let [thresholds (get opts :thresholds default-thresholds)
+         hits       (get scan :scan/hits)
+         words      (get scan :scan/word-count 0)
+         weighted   (tally/weight-of hits)
+         value      (rate weighted words)]
+     (merge scan
+            {:score/hit-count   (count hits)
+             :score/weighted    weighted
+             :score/density     (rate (count hits) words)
+             :score/value       value
+             :score/grade       (grade-for value thresholds)
+             :score/thresholds  thresholds
+             :score/by-category (tally/by-category hits)
+             :score/by-term     (tally/by-term hits)}))))
+
+(comment
+  (summarize {:scan/hits [{:hit/id :robust :hit/term "robust"
+                           :hit/category :marketing :hit/weight 3}]
+              :scan/word-count 40}))

--- a/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/score.cljc
+++ b/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/score.cljc
@@ -73,10 +73,12 @@
    counts, per-thousand-word rates, per-category and per-term tallies,
    and a grade of `:clean`, `:suspect` or `:slop`.
 
-   `:thresholds` in `opts` replaces the default grade boundaries."
+   `:thresholds` in `opts` overrides grade boundaries; it is merged
+   over the defaults, so supplying one boundary leaves the other in
+   place rather than comparing against nothing."
   ([scan] (summarize scan nil))
   ([scan opts]
-   (let [thresholds (get opts :thresholds default-thresholds)
+   (let [thresholds (merge default-thresholds (:thresholds opts))
          hits       (get scan :scan/hits)
          words      (get scan :scan/word-count 0)
          weighted   (tally/weight-of hits)

--- a/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/tally.cljc
+++ b/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/tally.cljc
@@ -1,0 +1,69 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.buzzword-bingo.tally
+  "Break a list of hits down by category and by term.
+
+   A single score says whether prose needs rewriting; these say which
+   words to reach for first.")
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Weight
+(defn ^{:stratum 0} weight-of
+  "Total weight of `hits`."
+  [hits]
+  (reduce + 0 (map :hit/weight hits)))
+
+;; Term breaks the count tie so the report is stable across runs.
+(defn- ^{:stratum 0} descending-count [tally]
+  [(- (:tally/count tally)) (str (:tally/term tally))])
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Grouped counts
+(defn- ^{:stratum 1} category-tally [hits]
+  {:tally/count    (count hits)
+   :tally/weighted (weight-of hits)})
+
+(defn- ^{:stratum 1} term-tally [[term-id hits]]
+  (let [head (first hits)]
+    {:tally/id       term-id
+     :tally/term     (:hit/term head)
+     :tally/category (:hit/category head)
+     :tally/count    (count hits)
+     :tally/weighted (weight-of hits)}))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Published breakdowns
+(defn ^{:stratum 2} by-category
+  "Category key → count and weight, for every category present in `hits`."
+  [hits]
+  (update-vals (group-by :hit/category hits) category-tally))
+
+(defn ^{:stratum 2} by-term
+  "Per-term tallies for `hits`, heaviest first."
+  [hits]
+  (->> (group-by :hit/id hits)
+       (map term-tally)
+       (sort-by descending-count)
+       vec))
+
+(comment
+  (by-category [{:hit/id :robust :hit/term "robust"
+                 :hit/category :marketing :hit/weight 3}]))

--- a/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/tally.cljc
+++ b/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/tally.cljc
@@ -51,10 +51,14 @@
 ;------------------------------------------------------------------------------ Layer 2
 
 ;; Published breakdowns
+;; Written with a transducer rather than update-vals so the namespace carries
+;; no floor on the Clojure or ClojureScript version a consumer builds against.
 (defn ^{:stratum 2} by-category
   "Category key → count and weight, for every category present in `hits`."
   [hits]
-  (update-vals (group-by :hit/category hits) category-tally))
+  (into {}
+        (map (fn [[category grouped]] [category (category-tally grouped)]))
+        (group-by :hit/category hits)))
 
 (defn ^{:stratum 2} by-term
   "Per-term tallies for `hits`, heaviest first."

--- a/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/detect_test.cljc
+++ b/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/detect_test.cljc
@@ -1,0 +1,89 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.buzzword-bingo.detect-test
+  (:require
+   [ai.miniforge.buzzword-bingo.detect :as sut]
+   [ai.miniforge.buzzword-bingo.entry :as entry]
+   [ai.miniforge.buzzword-bingo.lexicon :as lexicon]
+   #?(:clj  [clojure.test :refer [deftest is testing]]
+      :cljs [cljs.test :refer-macros [deftest is testing]])))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Fixtures and helpers
+;; Detection is exercised against a catalog defined here rather than the
+;; shipped one, so editing the lexicon cannot break these assertions. The
+;; entries still come from the real compiler, so they carry the shape a scan
+;; receives in production.
+(defn- ^{:stratum 0} scan-with
+  "Scan `text` against a single-category catalog built from `terms`."
+  [terms text]
+  (let [categories {:probe {:category/weight 2}}
+        raw        (mapv (fn [term] {:entry/term term :entry/category :probe}) terms)]
+    (sut/scan text {:entries (entry/compile-all categories raw)})))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} hit-terms [terms text]
+  (mapv :hit/term (:scan/hits (scan-with terms text))))
+
+(defn- ^{:stratum 1} hit-positions [terms text]
+  (mapv (juxt :hit/line :hit/column) (:scan/hits (scan-with terms text))))
+
+(deftest ^{:stratum 1} test-word-count-covers-prose-only
+  (testing "given a document with code → only prose words are counted"
+    (is (= 3 (:scan/word-count (scan-with ["robust"] "one two three\n\n```\nignored code here\n```")))))
+
+  (testing "given a scan → the catalog version is stamped on the result"
+    (is (= lexicon/version (:scan/lexicon-version (scan-with ["robust"] "text"))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Where a hit is
+(deftest ^{:stratum 2} test-hits-are-reported-at-their-source-position
+  (testing "given a hit on a later line → line and column are one-based and address the source"
+    (is (= [[3 7]] (hit-positions ["robust"] "first\nsecond\nthird robust here"))))
+
+  (testing "given a hit after a masked region → the mask has not shifted its position"
+    (is (= [[1 26]] (hit-positions ["robust"] "see `code here` and then robust"))))
+
+  (testing "given a hit → surrounding source is quoted for context"
+    (is (= "a robust claim"
+           (:hit/context (first (:scan/hits (scan-with ["robust"] "a robust claim"))))))))
+
+(deftest ^{:stratum 2} test-hits-are-ordered-by-position
+  (testing "given several terms out of catalog order → hits ascend through the document"
+    (is (= ["second" "first"] (hit-terms ["first" "second"] "the second, then the first")))))
+
+;; What counts as a hit
+(deftest ^{:stratum 2} test-overlapping-terms-are-counted-once
+  (testing "given a term contained in a longer one → only the longer is charged"
+    (is (= ["deep dive"] (hit-terms ["deep dive" "dive"] "a deep dive here"))))
+
+  (testing "given the shorter term standing alone → it is charged"
+    (is (= ["dive"] (hit-terms ["deep dive" "dive"] "a dive here"))))
+
+  (testing "given two terms that merely overlap → both are charged"
+    (is (= ["one two" "two three"] (hit-terms ["one two" "two three"] "one two three")))))
+
+(deftest ^{:stratum 2} test-non-prose-is-not-counted
+  (testing "given a term inside a code span → it is not a hit"
+    (is (= [] (hit-terms ["robust"] "the `robust` parser"))))
+
+  (testing "given a term inside a URL → it is not a hit"
+    (is (= [] (hit-terms ["seamless"] "see https://example.com/seamless now")))))

--- a/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/detect_test.cljc
+++ b/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/detect_test.cljc
@@ -49,8 +49,16 @@
   (testing "given a document with code → only prose words are counted"
     (is (= 3 (:scan/word-count (scan-with ["robust"] "one two three\n\n```\nignored code here\n```")))))
 
-  (testing "given a scan → the catalog version is stamped on the result"
-    (is (= lexicon/version (:scan/lexicon-version (scan-with ["robust"] "text"))))))
+  (testing "given the shipped catalog → its version is stamped on the result"
+    (is (= lexicon/version (:scan/lexicon-version (sut/scan "text")))))
+
+  (testing "given a caller's own catalog → no shipped version is claimed for it"
+    (is (nil? (:scan/lexicon-version (scan-with ["robust"] "text")))))
+
+  (testing "given a caller's own catalog and version → that version is stamped"
+    (is (= "probe-1"
+           (:scan/lexicon-version
+            (sut/scan "text" {:entries [] :lexicon-version "probe-1"}))))))
 
 ;------------------------------------------------------------------------------ Layer 2
 

--- a/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/entry_test.cljc
+++ b/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/entry_test.cljc
@@ -67,4 +67,9 @@
 
   (testing "given neither a term nor a label → the catalog is refused at load"
     (is (thrown? #?(:clj Exception :cljs js/Error)
-                 (compiled {:entry/category :mild})))))
+                 (compiled {:entry/category :mild}))))
+
+  (testing "given a term with no identifier-forming characters → refused rather
+            than given a blank id that would merge it with the next such entry"
+    (is (thrown? #?(:clj Exception :cljs js/Error)
+                 (compiled {:entry/term "!!!" :entry/category :mild})))))

--- a/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/entry_test.cljc
+++ b/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/entry_test.cljc
@@ -1,0 +1,70 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.buzzword-bingo.entry-test
+  (:require
+   [ai.miniforge.buzzword-bingo.entry :as sut]
+   #?(:clj  [clojure.test :refer [deftest is testing]]
+      :cljs [cljs.test :refer-macros [deftest is testing]])))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Fixtures and helpers
+(def ^{:stratum 0} ^:private test-categories
+  {:loud {:category/weight 4}
+   :mild {:category/weight 1}})
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} compiled
+  "Compile `raw-entries` against the test category table."
+  [& raw-entries]
+  (sut/compile-all test-categories raw-entries))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Compilation contract
+(deftest ^{:stratum 2} test-entry-identity-is-derived-from-its-display-name
+  (testing "given a multi-word term → the id is its slug"
+    (is (= [:low-hanging-fruit]
+           (mapv :entry/id (compiled {:entry/term "low-hanging fruit"
+                                      :entry/category :mild})))))
+
+  (testing "given a raw pattern entry → the label supplies the id"
+    (is (= [:not-only-but-also]
+           (mapv :entry/id (compiled {:entry/pattern  "not only[\\s\\S]{0,40}?but also"
+                                      :entry/label    "not only but also"
+                                      :entry/category :mild}))))))
+
+(deftest ^{:stratum 2} test-entry-weight-falls-back-to-its-category
+  (testing "given no per-entry weight → the category default applies"
+    (is (= 4 (:entry/effective-weight
+              (first (compiled {:entry/term "loud" :entry/category :loud}))))))
+
+  (testing "given a per-entry weight → it overrides the category"
+    (is (= 9 (:entry/effective-weight
+              (first (compiled {:entry/term "loud" :entry/category :loud
+                                :entry/weight 9})))))))
+
+(deftest ^{:stratum 2} test-compilation-rejects-unusable-entries
+  (testing "given an unknown category → the catalog is refused at load"
+    (is (thrown? #?(:clj Exception :cljs js/Error)
+                 (compiled {:entry/term "x" :entry/category :nonexistent}))))
+
+  (testing "given neither a term nor a label → the catalog is refused at load"
+    (is (thrown? #?(:clj Exception :cljs js/Error)
+                 (compiled {:entry/category :mild})))))

--- a/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/interface_test.cljc
+++ b/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/interface_test.cljc
@@ -1,0 +1,72 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.buzzword-bingo.interface-test
+  (:require
+   [ai.miniforge.buzzword-bingo.interface :as sut]
+   #?(:clj  [clojure.test :refer [deftest is testing]]
+      :cljs [cljs.test :refer-macros [deftest is testing]])))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Fixtures and helpers
+(def ^{:stratum 0} ^:private plain-report
+  "Prose of the kind the scanner should leave alone: what changed, and
+   what it means, with no claim about how good any of it is."
+  (str "The loop condition used the wrong comparison, so the last index "
+       "was skipped. The fix changes it and the two failing tests pass."))
+
+(def ^{:stratum 0} ^:private generated-pitch
+  "The register the scanner exists to catch."
+  (str "Our comprehensive platform delivers a seamless, robust experience "
+       "that empowers teams in todays fast-paced landscape. This "
+       "game-changing solution is a testament to best-in-class engineering."))
+
+(defn- ^{:stratum 0} graded [text]
+  (:score/grade (sut/scan text)))
+
+(deftest ^{:stratum 0} test-catalog-is-reachable-through-the-interface
+  (testing "given the shipped build → entries, categories and a version are exposed"
+    (is (seq (sut/entries)))
+    (is (contains? (sut/categories) :marketing))
+    (is (string? (sut/lexicon-version)))
+    (is (contains? (sut/default-thresholds) :threshold/slop))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; End to end through the shipped catalog
+(deftest ^{:stratum 1} test-scan-separates-plain-prose-from-generated-pitch
+  (testing "given a plain change report → clean, with nothing flagged"
+    (is (= :clean (graded plain-report)))
+    (is (empty? (:scan/hits (sut/scan plain-report)))))
+
+  (testing "given generated marketing prose → slop"
+    (is (= :slop (graded generated-pitch))))
+
+  (testing "given a hit → it carries the position and context needed to fix it"
+    (let [hit (first (:scan/hits (sut/scan generated-pitch)))]
+      (is (every? hit [:hit/term :hit/category :hit/weight :hit/line :hit/column :hit/context])))))
+
+(deftest ^{:stratum 1} test-scan-ignores-what-is-not-prose
+  (testing "given a buzzword only inside code → nothing is charged"
+    (is (= :clean (graded (str plain-report "\n\n```\n(def robust-comprehensive 1)\n```")))))
+
+  (testing "given caller thresholds → the grade moves with them"
+    (is (= :suspect (:score/grade
+                     (sut/scan generated-pitch
+                               {:thresholds {:threshold/suspect 1.0
+                                             :threshold/slop    1e6}}))))))

--- a/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/interface_test.cljc
+++ b/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/interface_test.cljc
@@ -33,7 +33,7 @@
 (def ^{:stratum 0} ^:private generated-pitch
   "The register the scanner exists to catch."
   (str "Our comprehensive platform delivers a seamless, robust experience "
-       "that empowers teams in todays fast-paced landscape. This "
+       "that empowers teams in today's fast-paced landscape. This "
        "game-changing solution is a testament to best-in-class engineering."))
 
 (defn- ^{:stratum 0} graded [text]

--- a/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/lexicon_test.cljc
+++ b/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/lexicon_test.cljc
@@ -1,0 +1,43 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.buzzword-bingo.lexicon-test
+  (:require
+   [ai.miniforge.buzzword-bingo.lexicon :as sut]
+   #?(:clj  [clojure.test :refer [deftest is testing]]
+      :cljs [cljs.test :refer-macros [deftest is testing]])))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; The shipped catalog
+;; Guards the EDN a human edits by hand. A malformed entry throws at load, so
+;; reaching these assertions at all proves the catalog compiled.
+(deftest ^{:stratum 0} test-shipped-catalog-is-well-formed
+  (testing "given the shipped catalog → every entry carries a usable pattern"
+    (is (every? :entry/regex sut/entries)))
+
+  (testing "given the shipped catalog → every weight is positive"
+    (is (every? #(pos? (:entry/effective-weight %)) sut/entries)))
+
+  (testing "given the shipped catalog → ids are unique, so tallies cannot collide"
+    (is (= (count sut/entries) (count (set (map :entry/id sut/entries))))))
+
+  (testing "given the shipped catalog → every entry names a declared category"
+    (is (every? #(contains? sut/categories (:entry/category %)) sut/entries)))
+
+  (testing "given the shipped catalog → it declares a version to stamp scans with"
+    (is (string? sut/version))))

--- a/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/score_test.cljc
+++ b/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/score_test.cljc
@@ -1,0 +1,88 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.buzzword-bingo.score-test
+  (:require
+   [ai.miniforge.buzzword-bingo.score :as sut]
+   #?(:clj  [clojure.test :refer [deftest is testing]]
+      :cljs [cljs.test :refer-macros [deftest is testing]])))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Fixtures and helpers
+;; Mirrors the shape detect/scan emits: hits carry an id, display term,
+;; category and weight, and the scan carries the prose word count.
+(defn- ^{:stratum 0} hit
+  [term category weight]
+  {:hit/id       (keyword term)
+   :hit/term     term
+   :hit/category category
+   :hit/weight   weight})
+
+(defn- ^{:stratum 0} scan-of
+  [word-count & hits]
+  {:scan/hits (vec hits) :scan/word-count word-count})
+
+(defn- ^{:stratum 0} graded
+  ([scan] (graded scan nil))
+  ([scan opts] (:score/grade (sut/summarize scan opts))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Rates and grades
+(deftest ^{:stratum 1} test-grade-follows-the-weighted-rate
+  (testing "given prose with no hits → clean"
+    (is (= :clean (graded (scan-of 500)))))
+
+  (testing "given a dense run of heavy terms → slop"
+    (is (= :slop (graded (apply scan-of 100 (repeat 10 (hit "robust" :marketing 3)))))))
+
+  (testing "given caller thresholds → they replace the defaults"
+    (is (= :slop (graded (scan-of 400 (hit "robust" :marketing 3))
+                         {:thresholds {:threshold/suspect 1.0 :threshold/slop 2.0}})))))
+
+(deftest ^{:stratum 1} test-short-texts-are-damped-but-not-exempt
+  (testing "given a lone filler word in a short reply → clean, not a false alarm"
+    (is (= :clean (graded (scan-of 10 (hit "very" :filler 1))))))
+
+  (testing "given a marketing adjective in the same short reply → flagged"
+    (is (= :slop (graded (scan-of 10 (hit "robust" :marketing 3))))))
+
+  (testing "given one hit → smoothing keeps a short text below a saturated long one"
+    (let [short-reply (sut/summarize (scan-of 10 (hit "robust" :marketing 3)))
+          long-doc    (sut/summarize (apply scan-of 1000 (repeat 30 (hit "robust" :marketing 3))))]
+      (is (< (:score/value short-reply) (:score/value long-doc))))))
+
+;; Tallies
+(deftest ^{:stratum 1} test-tallies-break-the-score-down
+  (testing "given hits across categories → each category reports count and weight"
+    (let [scored (sut/summarize (scan-of 200
+                                         (hit "robust" :marketing 3)
+                                         (hit "delve" :ai-tell 5)
+                                         (hit "synergy" :corporate 2)))]
+      (is (= {:marketing {:tally/count 1 :tally/weighted 3}
+              :ai-tell   {:tally/count 1 :tally/weighted 5}
+              :corporate {:tally/count 1 :tally/weighted 2}}
+             (:score/by-category scored)))
+      (is (= 10 (:score/weighted scored)))))
+
+  (testing "given a repeated term → the per-term tally leads, heaviest first"
+    (let [scored (sut/summarize (apply scan-of 200
+                                       (hit "delve" :ai-tell 5)
+                                       (repeat 3 (hit "robust" :marketing 3))))]
+      (is (= ["robust" "delve"] (mapv :tally/term (:score/by-term scored))))
+      (is (= 3 (:tally/count (first (:score/by-term scored))))))))

--- a/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/score_test.cljc
+++ b/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/score_test.cljc
@@ -53,7 +53,12 @@
 
   (testing "given caller thresholds → they replace the defaults"
     (is (= :slop (graded (scan-of 400 (hit "robust" :marketing 3))
-                         {:thresholds {:threshold/suspect 1.0 :threshold/slop 2.0}})))))
+                         {:thresholds {:threshold/suspect 1.0 :threshold/slop 2.0}}))))
+
+  (testing "given only one boundary → the other keeps its default rather than
+            being compared against nothing"
+    (is (= :suspect (graded (scan-of 400 (hit "robust" :marketing 3))
+                            {:thresholds {:threshold/suspect 1.0}})))))
 
 (deftest ^{:stratum 1} test-short-texts-are-damped-but-not-exempt
   (testing "given a lone filler word in a short reply → clean, not a false alarm"

--- a/deps.edn
+++ b/deps.edn
@@ -10,6 +10,7 @@
                        "components/config/resources"
                        "components/algorithms/src"
                        "components/buzzword-bingo/src"
+                       "components/buzzword-bingo/resources"
                        "components/content-hash/src"
                        "components/opsv/src"
                        "components/logging/src"

--- a/docs/pull-requests/2026-08-09-feat-buzzword-bingo-lexicon.md
+++ b/docs/pull-requests/2026-08-09-feat-buzzword-bingo-lexicon.md
@@ -44,7 +44,7 @@ Reading the EDN during macro expansion — which runs on the JVM for both target
 — keeps the catalog canonical as reviewable data on disk while emitting it as a
 literal into the compiled output.
 
-Build tools that cache macro expansion do not know this macro read a file, so
+Build tools that cache macro expansion do not know this macro reads a file, so
 the consuming namespace needs listing under shadow-cljs `:cache-blockers` when
 that build arrives.
 

--- a/docs/pull-requests/2026-08-09-feat-buzzword-bingo-lexicon.md
+++ b/docs/pull-requests/2026-08-09-feat-buzzword-bingo-lexicon.md
@@ -1,0 +1,178 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# feat: buzzword-bingo catalog, detection and scoring
+
+## Overview
+
+Second slice of Buzzword Bingo. #1716 landed the strata that prepare a document
+for counting; this one does the counting. After it, `scan` takes prose and
+returns hits with positions, per-category and per-term tallies, a rate, and a
+grade of `:clean`, `:suspect` or `:slop`.
+
+That is the whole gate. Everything after this PR is a surface onto it: the
+bingo card, the CLI, the MCP server, the Stop hook and the npm build.
+
+## Motivation
+
+Generated prose has a register — marketing adjectives that assert quality
+instead of stating behaviour, corporate filler, and words that mark a text as
+machine-written. This repository bans that register by hand in
+`standards/miniforge` and in the author's own instructions. Nothing measured
+it, so enforcement was argument rather than evidence.
+
+## Changes in Detail
+
+### `entry.cljc` — compiling an authored entry
+
+An authored entry carries a term (or raw pattern source) and a category. The
+scanner needs a stable id, a display name, the weight in force and a compiled
+pattern. A catalog is authored rather than received at runtime, so an unknown
+category or an entry with neither term nor label throws at load rather than
+being handled as data.
+
+`compile-all` is public so a caller can supply a project-local catalog in the
+same shape and get entries the scanner accepts.
+
+### `inline.clj` — compile-time EDN
+
+ClojureScript has no runtime classpath, so `io/resource` is unavailable there.
+Reading the EDN during macro expansion — which runs on the JVM for both targets
+— keeps the catalog canonical as reviewable data on disk while emitting it as a
+literal into the compiled output.
+
+Build tools that cache macro expansion do not know this macro read a file, so
+the consuming namespace needs listing under shadow-cljs `:cache-blockers` when
+that build arrives.
+
+### `lexicon.edn` — the catalog
+
+Around ninety terms across five categories, weighted by how damning each is:
+
+| Category | Default weight | What it covers |
+|---|---|---|
+| `:marketing` | 3 | Selling adjectives — a claim about how good a thing is, in place of what it does |
+| `:ai-tell` | 3 | Register that marks generated text |
+| `:corporate` | 2 | Business jargon |
+| `:hedge` | 1 | Qualifiers that soften without informing |
+| `:filler` | 1 | Intensifiers |
+
+Weights are not uniform inside a category. `delve`, `tapestry`,
+`a testament to` and `ever-evolving` carry 5, because each is close to a
+fingerprint on its own.
+
+EDN so a disagreement about a word is a one-line data change, not a code
+change. Terms and pattern labels name the thing being detected rather than
+being display copy, so they stay out of the message catalogs.
+
+### `locate.cljc` and `detect.cljc` — finding hits
+
+Matching runs over the masked, case-folded copy so code and links cannot score;
+every reported line, column and quoted snippet comes from the source. Both
+strings have the same length by construction, so one offset addresses both.
+
+Overlapping entries are counted once. `deep dive` contains `dive`, and charging
+a document for both double-counts one phrase. Hits sort earliest-first and
+longest-first at equal position, so every kept hit starts at or before the
+candidate; a candidate ending no later than the furthest end so far is
+contained in one of them and is dropped. Partial overlaps are kept — those are
+two phrases, not one counted twice.
+
+### `tally.cljc` and `score.cljc` — grading
+
+A raw count is not comparable across documents, so the figure is weighted hits
+per thousand words. Every rate carries 100 smoothing words in the denominator:
+without it a two-sentence reply with one buzzword outscores a long document
+with twenty.
+
+The smoothing damps a short text without exempting it. A lone filler word in a
+ten-word reply scores 9 and stays clean; a marketing adjective in the same
+reply scores 27 and is flagged. Catching that second case is the point of the
+tool.
+
+Per-category and per-term tallies come alongside the score, because a number
+says whether to rewrite and the tallies say which words to reach for first.
+
+## Calibration
+
+Thresholds of 10 (suspect) and 25 (slop) are set by hand, not derived. The
+evidence they are set against:
+
+| Sample | Score | Grade |
+|---|---|---|
+| `readme.md` | 3.58 | clean |
+| `agents.md` | 0.81 | clean |
+| `CONTRIBUTING.md` | 0.00 | clean |
+| `ROADMAP.md` | 2.51 | clean |
+| `standards/miniforge/foundations/simple-made-easy.mdc` | 0.00 | clean |
+| A plain change report | 0.00 | clean |
+| Prose with mild drift (`robust`, `leverages`, `actually`, `circle back`) | 62.02 | slop |
+| A generated marketing paragraph | 280.00 | slop |
+
+Masking is what keeps the repository documents clean — they are full of code
+blocks and paths. Treat the numbers the way this repository treats its
+review-size budgets: a working figure, tuned as evidence arrives.
+
+## Testing Plan
+
+29 tests, 75 assertions, run on the JVM through `poly test` and under Babashka.
+
+- `entry-test` — id derivation from term and from label, weight falling back to
+  category and being overridden per entry, and both load-time rejections.
+- `lexicon-test` — invariants over the shipped catalog: every entry compiles to
+  a pattern, weights positive, ids unique so tallies cannot collide, every
+  category declared. Reaching the assertions at all proves the EDN compiled.
+- `detect-test` — line and column against the source, position unshifted by
+  masking, context quoted, hits ordered by position, containment counted once,
+  partial overlap counted twice, code and URLs not counted, word count over
+  prose only.
+- `score-test` — grade at each boundary, caller thresholds replacing defaults,
+  short-text damping in both directions, category and term tallies.
+- `interface-test` — end to end through the shipped catalog: a plain change
+  report clean with nothing flagged, a generated pitch slop, buzzwords in code
+  not charged, hits carrying everything needed to act on them.
+
+### Cross-host verification
+
+The component compiles to a Node script with `cljs.main --target node`, and the
+same `.cljc` test namespaces pass under `cljs.test`. Babashka and Node produce
+byte-identical output on the same input — same grade, same value to two
+decimals, same hits with the same line and column, same tallies.
+
+Recorded for whoever compiles a Polylith component to ClojureScript next:
+`interface` is a reserved JavaScript keyword, so Closure munges the namespace
+to `interface$` and warns. Harmless, and it will fire for every component.
+
+## Deployment Plan
+
+Library code. No entry point and no runtime behaviour change to any existing
+project; nothing consumes `scan` until the CLI arrives.
+
+## Related Issues/PRs
+
+Sequence, each branching from `main` after the previous merges:
+
+1. #1716 — regex, phrase, segment strata (merged)
+2. **This PR** — catalog, detection, scoring
+3. Bingo card and session accumulation
+4. Report renderers and message catalogs
+5. CLI and `bb bingo` task
+6. MCP server
+7. Stop hook and skill
+8. ClojureScript/Node build and npm packaging
+
+## Checklist
+
+- [x] `poly check` clean, no warnings
+- [x] `clj-kondo` clean
+- [x] `stratum-lint` clean; four namespaces split to stay inside the three-layer
+      budget (`entry` from `lexicon`, `locate` from `detect`, `tally` from
+      `score`)
+- [x] Each commit under the 200-line commit budget; whole PR 499 of 600
+- [x] Apache header on every source file
+- [x] Adversarial self-review of the diff
+- [x] Standards gap analysis against `standards/miniforge`
+- [x] Calibrated against real documents, not only synthetic samples


### PR DESCRIPTION
## Overview

Second slice of Buzzword Bingo. #1716 landed the strata that prepare a document
for counting; this one does the counting. After it, `scan` takes prose and
returns hits with positions, per-category and per-term tallies, a rate, and a
grade of `:clean`, `:suspect` or `:slop`.

That is the whole gate. Everything after this PR is a surface onto it — bingo
card, CLI, MCP server, Stop hook, npm build.

Full detail in [the PR document](docs/pull-requests/2026-08-09-feat-buzzword-bingo-lexicon.md).

## What's here

- **`entry.cljc`** — compiles an authored entry (term or raw pattern, plus
  category) into one the scanner can match with: stable id, display name,
  effective weight, compiled pattern. A catalog is authored rather than
  received at runtime, so an unknown category or a term-less entry throws at
  load rather than being handled as data.
- **`inline.clj`** — reads the catalog EDN during macro expansion, which runs
  on the JVM for both targets. ClojureScript has no runtime classpath, so this
  is what lets the catalog stay canonical as reviewable data on disk while
  still reaching a bundled Node script.
- **`lexicon.edn`** — ~90 terms across marketing, ai-tell, corporate, hedge and
  filler, weighted by how damning each is. `delve`, `tapestry`, `a testament
  to` and `ever-evolving` carry 5 rather than the category default, because
  each is close to a fingerprint on its own.
- **`locate.cljc` / `detect.cljc`** — hits with line, column and quoted
  context. Overlapping entries counted once: `deep dive` contains `dive`, and
  charging for both double-counts one phrase. Partial overlaps still count
  twice, because those are two phrases.
- **`tally.cljc` / `score.cljc`** — weighted hits per thousand words with 100
  smoothing words in the denominator, so a two-sentence reply with one buzzword
  does not outscore a long document with twenty.

## Calibration

Thresholds (10 suspect, 25 slop) are set by hand against evidence, not derived:

| Sample | Score | Grade |
|---|---|---|
| `readme.md` | 3.58 | clean |
| `agents.md` | 0.81 | clean |
| `CONTRIBUTING.md` | 0.00 | clean |
| `ROADMAP.md` | 2.51 | clean |
| A plain change report | 0.00 | clean |
| Prose with mild drift | 62.02 | slop |
| A generated marketing paragraph | 280.00 | slop |

Masking is what keeps the repo documents clean — they are full of code and
paths. The smoothing damps short texts without exempting them: a lone filler
word in a ten-word reply scores 9 and stays clean, a marketing adjective in the
same reply scores 27 and is flagged. Catching that second case is the point.

## Verification

- `poly check` clean, `clj-kondo` clean, `stratum-lint` clean
- 29 tests / 75 assertions, plus the full pre-commit suite on every commit
- Compiled to Node with `cljs.main`; the same `.cljc` tests pass under
  `cljs.test`, and Babashka and Node produce byte-identical output on the same
  input — same grade, same value, same hits at the same line and column
- Each commit under the 200-line commit budget; whole PR 499 of 600

`stratum-lint` forced four namespace splits to stay inside the three-layer
budget: `entry` out of `lexicon`, `locate` out of `detect`, `tally` out of
`score`. Each split is a real seam rather than a concession — compiling an
entry, placing an offset in a source file, and breaking hits down are separate
jobs from holding a catalog, matching, and grading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)