### PR TITLE
refactor(policy-pack): split mdc_to_pack_mapping_test.clj — extract dewey (1/7)

### DIFF
--- a/components/policy-pack/test/ai/miniforge/policy_pack/mdc_to_pack_mapping_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/mdc_to_pack_mapping_test.clj
@@ -29,6 +29,7 @@
    Once the ETL task (bb standards:pack) is implemented, these tests serve
    as the authoritative acceptance suite."
   (:require
+   [ai.miniforge.policy-pack.mdc-to-pack-mapping-test.dewey :as dewey]
    [clojure.test :refer [deftest testing is are]]
    [clojure.string :as str]
    [clojure.set :as set]))
@@ -58,28 +59,6 @@
    Format: 'Engineering standard (<category>): <title>'"
   [category title]
   (str "Engineering standard (" category "): " title))
-
-(defn ^{:stratum 0} parse-dewey
-  "Parse dewey string to integer. Returns -1 on failure (outside all ranges)."
-  [dewey-str]
-  (try
-    (Integer/parseInt (str dewey-str))
-    (catch Exception _ -1)))
-
-(def ^{:stratum 0} dewey-range-to-phases
-  "Dewey range → phase set mapping from Section 2 of the design."
-  [[0 99]    #{:plan :implement :review :verify :release}
-   [100 199] #{:implement :review}
-   [200 299] #{:implement :review}
-   [300 399] #{:plan :implement :review}
-   [400 499] #{:implement :verify}
-   [500 599] #{:implement :review}
-   [600 699] #{:implement :review}
-   [700 799] #{:plan :implement :review :verify :release}
-   [800 899] #{:implement :review}
-   [900 999] #{}])
-
-(def ^{:stratum 0} default-phases #{:implement :review})
 
 (defn ^{:stratum 0} normalize-globs
   "Wrap string globs in a vector; pass vectors through; nil → nil."
@@ -172,8 +151,6 @@
    "meta/rule-format.mdc"                   :std/rule-format
    "index.mdc"                              :std/index})
 
-(def ^{:stratum 0} all-phases #{:plan :implement :review :verify :release})
-
 (deftest ^{:stratum 0} pack-metadata-test
   (testing "Output pack has required identity fields"
     (let [template {:pack/id          "miniforge/standards"
@@ -230,11 +207,6 @@
     (if (and desc (not (str/blank? desc)))
       desc
       (title-from-slug (slug-from-filename filepath)))))
-
-(def ^{:stratum 1} dewey-ranges
-  "Parsed vector of [low high phases] triples."
-  (->> (partition 2 dewey-range-to-phases)
-       (mapv (fn [[[lo hi] phases]] [lo hi phases]))))
 
 (deftest ^{:stratum 1} slug-from-filename-test
   (testing "Strips .mdc extension from filename only"
@@ -421,16 +393,16 @@
       (is (= inventory-ids category-rules)
           "Pack categories should reference exactly the inventory rule IDs"))))
 
-;------------------------------------------------------------------------------ Layer 2
+(defn ^{:stratum 1} build-applies-to
+  "Build :rule/applies-to from dewey + optional globs."
+  [dewey-str globs]
+  (let [phases (dewey/dewey-to-phases dewey-str)
+        base   {:phases phases}]
+    (if-let [g (normalize-globs globs)]
+      (assoc base :file-globs g)
+      base)))
 
-(defn ^{:stratum 2} dewey-to-phases
-  "Look up phases for a dewey code (string). Falls back to default."
-  [dewey-str]
-  (let [code (parse-dewey dewey-str)]
-    (or (some (fn [[lo hi phases]]
-                (when (<= lo code hi) phases))
-              dewey-ranges)
-        default-phases)))
+;------------------------------------------------------------------------------ Layer 2
 
 ;; ===========================================================================
 ;; Section 1: Rule ID Derivation Tests
@@ -473,127 +445,7 @@
     (is (= "Code Quality" (derive-title {"description" ""} "foundations/code-quality.mdc")))
     (is (= "Code Quality" (derive-title {"description" "  "} "foundations/code-quality.mdc")))))
 
-;; ===========================================================================
-;; Section 19: Dewey Range Completeness and Non-Overlap Tests
-;; ===========================================================================
-(deftest ^{:stratum 2} dewey-ranges-non-overlapping-test
-  (testing "Dewey ranges do not overlap"
-    (let [ranges (mapv (fn [[lo hi _]] [lo hi]) dewey-ranges)
-          sorted (sort-by first ranges)]
-      (doseq [[[_ hi1] [lo2 _]] (partition 2 1 sorted)]
-        (is (< hi1 lo2)
-            (str "Ranges overlap: ..." hi1 "] and [" lo2 "..."))))))
-
-(deftest ^{:stratum 2} dewey-ranges-cover-0-to-999-test
-  (testing "Dewey ranges cover all codes from 0 to 999"
-    (let [covered (set (for [[lo hi _] dewey-ranges
-                             code (range lo (inc hi))]
-                         code))
-          full-range (set (range 0 1000))]
-      (is (= full-range covered)
-          (str "Uncovered codes: " (set/difference full-range covered))))))
-
-;------------------------------------------------------------------------------ Layer 3
-
-(defn ^{:stratum 3} build-applies-to
-  "Build :rule/applies-to from dewey + optional globs."
-  [dewey-str globs]
-  (let [phases (dewey-to-phases dewey-str)
-        base   {:phases phases}]
-    (if-let [g (normalize-globs globs)]
-      (assoc base :file-globs g)
-      base)))
-
-;; ===========================================================================
-;; Section 4: Dewey-to-Phases Mapping Tests
-;; ===========================================================================
-(deftest ^{:stratum 3} dewey-to-phases-test
-  (testing "Foundations (0-99) → all phases"
-    (is (= all-phases (dewey-to-phases "001")))
-    (is (= all-phases (dewey-to-phases "000")))
-    (is (= all-phases (dewey-to-phases "099"))))
-
-  (testing "Tools (100-199) → implement + review"
-    (is (= #{:implement :review} (dewey-to-phases "100")))
-    (is (= #{:implement :review} (dewey-to-phases "150"))))
-
-  (testing "Languages (200-299) → implement + review"
-    (is (= #{:implement :review} (dewey-to-phases "210")))
-    (is (= #{:implement :review} (dewey-to-phases "200"))))
-
-  (testing "Frameworks (300-399) → plan + implement + review"
-    (is (= #{:plan :implement :review} (dewey-to-phases "300")))
-    (is (= #{:plan :implement :review} (dewey-to-phases "350"))))
-
-  (testing "Testing (400-499) → implement + verify"
-    (is (= #{:implement :verify} (dewey-to-phases "400")))
-    (is (= #{:implement :verify} (dewey-to-phases "450"))))
-
-  (testing "Operations (500-599) → implement + review"
-    (is (= #{:implement :review} (dewey-to-phases "500")))
-    (is (= #{:implement :review} (dewey-to-phases "550"))))
-
-  (testing "Documentation (600-699) → implement + review"
-    (is (= #{:implement :review} (dewey-to-phases "600"))))
-
-  (testing "Workflows (700-799) → all phases"
-    (is (= all-phases (dewey-to-phases "700")))
-    (is (= all-phases (dewey-to-phases "715"))))
-
-  (testing "Project-specific (800-899) → implement + review"
-    (is (= #{:implement :review} (dewey-to-phases "800"))))
-
-  (testing "Meta (900-999) → empty set (never injected)"
-    (is (= #{} (dewey-to-phases "900")))
-    (is (= #{} (dewey-to-phases "999"))))
-
-  (testing "Boundary values at range transitions"
-    ;; End of foundations → start of tools
-    (is (= all-phases (dewey-to-phases "99")))
-    (is (= #{:implement :review} (dewey-to-phases "100")))
-    ;; End of tools → start of languages
-    (is (= #{:implement :review} (dewey-to-phases "199")))
-    (is (= #{:implement :review} (dewey-to-phases "200"))))
-
-  (testing "Dewey range coverage is contiguous from 0-999"
-    (doseq [code (range 0 1000)]
-      (is (set? (dewey-to-phases (str code)))
-          (str "No phase set for dewey code " code)))))
-
-(deftest ^{:stratum 3} dewey-default-phases-test
-  (testing "Unparseable dewey defaults to implement + review"
-    (is (= default-phases (dewey-to-phases "")))))
-
-(deftest ^{:stratum 3} dewey-missing-defaults-to-000-test
-  (testing "Missing dewey frontmatter defaults to '000' (foundation phases)"
-    ;; Per edge case: "Missing dewey frontmatter" → default to '000'
-    (is (= all-phases (dewey-to-phases "000")))))
-
-;; ===========================================================================
-;; Section 20: Phase Injection Equivalence Tests
-;; ===========================================================================
-(deftest ^{:stratum 3} phase-injection-role-equivalence-test
-  (testing "Foundation rules reach all agent roles"
-    (is (= all-phases (dewey-to-phases "001"))))
-
-  (testing "Workflow rules reach all agent roles"
-    (is (= all-phases (dewey-to-phases "715"))))
-
-  (testing "Language rules reach implementer and reviewer only"
-    (is (= #{:implement :review} (dewey-to-phases "210"))))
-
-  (testing "Framework rules include planner (architecture awareness)"
-    (is (contains? (dewey-to-phases "300") :plan)))
-
-  (testing "Testing rules reach implementer and verifier"
-    (is (= #{:implement :verify} (dewey-to-phases "400"))))
-
-  (testing "Meta rules reach no agents"
-    (is (empty? (dewey-to-phases "900")))))
-
-;------------------------------------------------------------------------------ Layer 4
-
-(defn ^{:stratum 4} compile-rule
+(defn ^{:stratum 2} compile-rule
   "Compile a single MDC file representation into a pack rule map.
    This is the reference implementation of the spec's field mapping."
   [{:keys [filepath frontmatter body]}]
@@ -622,7 +474,7 @@
 ;; ===========================================================================
 ;; Section 6: Applies-To (Phases + Globs) Tests
 ;; ===========================================================================
-(deftest ^{:stratum 4} applies-to-test
+(deftest ^{:stratum 2} applies-to-test
   (testing "Dewey-only → phases from dewey, no globs"
     (is (= {:phases #{:plan :implement :review :verify :release}}
            (build-applies-to "001" nil))))
@@ -640,12 +492,12 @@
             :file-globs [".cursor/rules/**/*.mdc"]}
            (build-applies-to "900" [".cursor/rules/**/*.mdc"])))))
 
-;------------------------------------------------------------------------------ Layer 5
+;------------------------------------------------------------------------------ Layer 3
 
 ;; ===========================================================================
 ;; Section 7: Constant/Default Fields Tests
 ;; ===========================================================================
-(deftest ^{:stratum 5} constant-fields-test
+(deftest ^{:stratum 3} constant-fields-test
   (testing "Non-alwaysApply severity is :low"
     (let [rule (compile-rule {:filepath "test.mdc"
                               :frontmatter {"dewey" "001"}
@@ -678,7 +530,7 @@
 ;; ===========================================================================
 ;; Section 8: Knowledge Content Tests
 ;; ===========================================================================
-(deftest ^{:stratum 5} knowledge-content-test
+(deftest ^{:stratum 3} knowledge-content-test
   (testing "Body text preserved as :rule/knowledge-content"
     (let [body "# Heading\n\nSome content here."
           rule (compile-rule {:filepath "test.mdc"
@@ -713,7 +565,7 @@
 ;; ===========================================================================
 ;; Section 10: Worked Example A — Foundation alwaysApply Rule
 ;; ===========================================================================
-(deftest ^{:stratum 5} worked-example-a-stratified-design-test
+(deftest ^{:stratum 3} worked-example-a-stratified-design-test
   (let [rule (compile-rule
               {:filepath    "foundations/stratified-design.mdc"
                :frontmatter {"dewey"       "001"
@@ -742,7 +594,7 @@
       (is (true? (:rule/always-inject? rule))))
 
     (testing ":rule/applies-to has all phases for dewey 001"
-      (is (= {:phases all-phases}
+      (is (= {:phases dewey/all-phases}
              (:rule/applies-to rule))))
 
     (testing ":rule/detection is {:type :custom}"
@@ -760,7 +612,7 @@
 ;; ===========================================================================
 ;; Section 11: Worked Example B — Language Rule with Globs
 ;; ===========================================================================
-(deftest ^{:stratum 5} worked-example-b-clojure-test
+(deftest ^{:stratum 3} worked-example-b-clojure-test
   (let [globs ["components/**/src/**/*.clj"
                "components/**/src/**/*.cljc"
                "bases/**/src/**/*.clj"
@@ -799,7 +651,7 @@
 ;; ===========================================================================
 ;; Section 12: Worked Example C — Meta Rule (Not Injected)
 ;; ===========================================================================
-(deftest ^{:stratum 5} worked-example-c-meta-rule-test
+(deftest ^{:stratum 3} worked-example-c-meta-rule-test
   (let [rule (compile-rule
               {:filepath    "meta/rule-format.mdc"
                :frontmatter {"dewey"       "900"
@@ -824,7 +676,7 @@
 ;; ===========================================================================
 ;; Section 13: Worked Example D — Testing Rule (alwaysApply)
 ;; ===========================================================================
-(deftest ^{:stratum 5} worked-example-d-testing-rule-test
+(deftest ^{:stratum 3} worked-example-d-testing-rule-test
   (let [rule (compile-rule
               {:filepath    "testing/standards.mdc"
                :frontmatter {"dewey"       "400"
@@ -850,23 +702,23 @@
 ;; ===========================================================================
 ;; Section 14: Edge Case Tests
 ;; ===========================================================================
-(deftest ^{:stratum 5} edge-case-missing-dewey-test
+(deftest ^{:stratum 3} edge-case-missing-dewey-test
   (testing "Missing dewey → default to '000', phases all"
     (let [rule (compile-rule {:filepath "test.mdc"
                               :frontmatter {}
                               :body "content"})]
       (is (= "000" (:rule/category rule)))
-      (is (= all-phases
+      (is (= dewey/all-phases
              (get-in rule [:rule/applies-to :phases]))))))
 
-(deftest ^{:stratum 5} edge-case-missing-description-test
+(deftest ^{:stratum 3} edge-case-missing-description-test
   (testing "Missing description → title derived from slug"
     (let [rule (compile-rule {:filepath "foundations/code-quality.mdc"
                               :frontmatter {"dewey" "001"}
                               :body "content"})]
       (is (= "Code Quality" (:rule/title rule))))))
 
-(deftest ^{:stratum 5} edge-case-empty-body-test
+(deftest ^{:stratum 3} edge-case-empty-body-test
   (testing "Empty body → knowledge-content omitted, rule still valid"
     (let [rule (compile-rule {:filepath "stub.mdc"
                               :frontmatter {"dewey" "001"
@@ -876,7 +728,7 @@
       (is (= :std/stub (:rule/id rule)))
       (is (= "Stub rule" (:rule/title rule))))))
 
-(deftest ^{:stratum 5} edge-case-always-apply-meta-test
+(deftest ^{:stratum 3} edge-case-always-apply-meta-test
   (testing "alwaysApply: true + dewey 900 → always-inject true but empty phases"
     (let [rule (compile-rule {:filepath "meta/weird.mdc"
                               :frontmatter {"dewey"       "900"
@@ -886,7 +738,7 @@
       (is (true? (:rule/always-inject? rule)))
       (is (= #{} (get-in rule [:rule/applies-to :phases]))))))
 
-(deftest ^{:stratum 5} edge-case-globs-string-instead-of-list-test
+(deftest ^{:stratum 3} edge-case-globs-string-instead-of-list-test
   (testing "String globs normalized to vector"
     (let [rule (compile-rule {:filepath "test.mdc"
                               :frontmatter {"dewey" "210"
@@ -894,7 +746,7 @@
                               :body "content"})]
       (is (= ["*.clj"] (get-in rule [:rule/applies-to :file-globs]))))))
 
-(deftest ^{:stratum 5} edge-case-index-mdc-test
+(deftest ^{:stratum 3} edge-case-index-mdc-test
   (testing "index.mdc compiled like any other file, ID :std/index"
     (let [rule (compile-rule {:filepath "index.mdc"
                               :frontmatter {"dewey" "000"
@@ -902,11 +754,11 @@
                                             "alwaysApply" false}
                               :body "# Rules Catalog"})]
       (is (= :std/index (:rule/id rule)))
-      (is (= all-phases (get-in rule [:rule/applies-to :phases])))
+      (is (= dewey/all-phases (get-in rule [:rule/applies-to :phases])))
       ;; alwaysApply false → always-inject? omitted
       (is (not (contains? rule :rule/always-inject?))))))
 
-(deftest ^{:stratum 5} all-rule-schema-fields-produced-test
+(deftest ^{:stratum 3} all-rule-schema-fields-produced-test
   (testing "Compiled rule produces all required schema fields"
     (let [rule (compile-rule {:filepath "test/example.mdc"
                               :frontmatter {"dewey"       "210"
@@ -920,7 +772,7 @@
       (is (set/subset? required-keys (set (keys rule)))
           (str "Missing required keys: " (set/difference required-keys (set (keys rule))))))))
 
-(deftest ^{:stratum 5} optional-fields-conditionally-present-test
+(deftest ^{:stratum 3} optional-fields-conditionally-present-test
   (testing ":rule/always-inject? present only when alwaysApply is true"
     (let [rule-with    (compile-rule {:filepath "a.mdc" :frontmatter {"alwaysApply" true} :body "x"})
           rule-without (compile-rule {:filepath "b.mdc" :frontmatter {} :body "x"})]
@@ -936,7 +788,7 @@
 ;; ===========================================================================
 ;; Section 18: Schema Compatibility Tests
 ;; ===========================================================================
-(deftest ^{:stratum 5} compiled-rule-matches-schema-shape-test
+(deftest ^{:stratum 3} compiled-rule-matches-schema-shape-test
   (testing "Compiled rule has correct value types for schema fields"
     (let [rule (compile-rule {:filepath "foundations/stratified-design.mdc"
                               :frontmatter {"dewey" "001"
@@ -969,7 +821,7 @@
       (is (boolean? (:rule/always-inject? rule)))
       (is (string? (:rule/knowledge-content rule))))))
 
-(deftest ^{:stratum 5} always-inject-does-not-override-phases-test
+(deftest ^{:stratum 3} always-inject-does-not-override-phases-test
   (testing "alwaysApply controls injection, phases control which roles"
     (let [rule (compile-rule {:filepath "testing/standards.mdc"
                               :frontmatter {"dewey" "400"

--- a/components/policy-pack/test/ai/miniforge/policy_pack/mdc_to_pack_mapping_test/dewey.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/mdc_to_pack_mapping_test/dewey.clj
@@ -1,0 +1,80 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.mdc-to-pack-mapping-test.dewey
+  "Dewey-code → phase-set mapping, part of the reference implementation
+   for the MDC-to-Pack Rule Field Mapping acceptance spec (Section 2 and
+   Section 4 of work/designs/mdc-to-pack-field-mapping.edn).
+
+   Split out of `ai.miniforge.policy-pack.mdc-to-pack-mapping-test`
+   (rule 210: slice 1/7 of a stratum-lint SL003 split train — that
+   namespace measured 6 real layers, max 3. Same approach as the
+   mdc_compiler.clj split train, miniforge#1729-#1743). This was the
+   deepest same-file chain in the parent namespace:
+   `dewey-range-to-phases` fed `dewey-ranges`, which fed
+   `dewey-to-phases`, which in turn fed `build-applies-to` and
+   `compile-rule`. Moving it to its own namespace lets every downstream
+   consumer reach it as a cross-namespace call, which does not count
+   toward the caller's own layer budget.
+
+   Layer 0: parse-dewey, dewey-range-to-phases, default-phases, all-phases
+   Layer 1: dewey-ranges
+   Layer 2: dewey-to-phases")
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} parse-dewey
+  "Parse dewey string to integer. Returns -1 on failure (outside all ranges)."
+  [dewey-str]
+  (try
+    (Integer/parseInt (str dewey-str))
+    (catch Exception _ -1)))
+
+(def ^{:stratum 0} dewey-range-to-phases
+  "Dewey range → phase set mapping from Section 2 of the design."
+  [[0 99]    #{:plan :implement :review :verify :release}
+   [100 199] #{:implement :review}
+   [200 299] #{:implement :review}
+   [300 399] #{:plan :implement :review}
+   [400 499] #{:implement :verify}
+   [500 599] #{:implement :review}
+   [600 699] #{:implement :review}
+   [700 799] #{:plan :implement :review :verify :release}
+   [800 899] #{:implement :review}
+   [900 999] #{}])
+
+(def ^{:stratum 0} default-phases #{:implement :review})
+
+(def ^{:stratum 0} all-phases #{:plan :implement :review :verify :release})
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} dewey-ranges
+  "Parsed vector of [low high phases] triples."
+  (->> (partition 2 dewey-range-to-phases)
+       (mapv (fn [[[lo hi] phases]] [lo hi phases]))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} dewey-to-phases
+  "Look up phases for a dewey code (string). Falls back to default."
+  [dewey-str]
+  (let [code (parse-dewey dewey-str)]
+    (or (some (fn [[lo hi phases]]
+                (when (<= lo code hi) phases))
+              dewey-ranges)
+        default-phases)))

--- a/components/policy-pack/test/ai/miniforge/policy_pack/mdc_to_pack_mapping_test/dewey_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/mdc_to_pack_mapping_test/dewey_test.clj
@@ -1,0 +1,138 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.mdc-to-pack-mapping-test.dewey-test
+  "Acceptance tests for the Dewey-code → phase-set mapping (Sections 4,
+   19, and 20 of work/designs/mdc-to-pack-field-mapping.edn).
+
+   Split out of `ai.miniforge.policy-pack.mdc-to-pack-mapping-test`
+   (rule 210 split train, slice 1/7). Assertions are unchanged from the
+   parent namespace — only the deftest forms and their dependency on
+   `mdc-to-pack-mapping-test.dewey` moved."
+  (:require
+   [ai.miniforge.policy-pack.mdc-to-pack-mapping-test.dewey :as dewey]
+   [clojure.set :as set]
+   [clojure.test :refer [deftest is testing]]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; ===========================================================================
+;; Section 4: Dewey-to-Phases Mapping Tests
+;; ===========================================================================
+(deftest ^{:stratum 0} dewey-to-phases-test
+  (testing "Foundations (0-99) → all phases"
+    (is (= dewey/all-phases (dewey/dewey-to-phases "001")))
+    (is (= dewey/all-phases (dewey/dewey-to-phases "000")))
+    (is (= dewey/all-phases (dewey/dewey-to-phases "099"))))
+
+  (testing "Tools (100-199) → implement + review"
+    (is (= #{:implement :review} (dewey/dewey-to-phases "100")))
+    (is (= #{:implement :review} (dewey/dewey-to-phases "150"))))
+
+  (testing "Languages (200-299) → implement + review"
+    (is (= #{:implement :review} (dewey/dewey-to-phases "210")))
+    (is (= #{:implement :review} (dewey/dewey-to-phases "200"))))
+
+  (testing "Frameworks (300-399) → plan + implement + review"
+    (is (= #{:plan :implement :review} (dewey/dewey-to-phases "300")))
+    (is (= #{:plan :implement :review} (dewey/dewey-to-phases "350"))))
+
+  (testing "Testing (400-499) → implement + verify"
+    (is (= #{:implement :verify} (dewey/dewey-to-phases "400")))
+    (is (= #{:implement :verify} (dewey/dewey-to-phases "450"))))
+
+  (testing "Operations (500-599) → implement + review"
+    (is (= #{:implement :review} (dewey/dewey-to-phases "500")))
+    (is (= #{:implement :review} (dewey/dewey-to-phases "550"))))
+
+  (testing "Documentation (600-699) → implement + review"
+    (is (= #{:implement :review} (dewey/dewey-to-phases "600"))))
+
+  (testing "Workflows (700-799) → all phases"
+    (is (= dewey/all-phases (dewey/dewey-to-phases "700")))
+    (is (= dewey/all-phases (dewey/dewey-to-phases "715"))))
+
+  (testing "Project-specific (800-899) → implement + review"
+    (is (= #{:implement :review} (dewey/dewey-to-phases "800"))))
+
+  (testing "Meta (900-999) → empty set (never injected)"
+    (is (= #{} (dewey/dewey-to-phases "900")))
+    (is (= #{} (dewey/dewey-to-phases "999"))))
+
+  (testing "Boundary values at range transitions"
+    ;; End of foundations → start of tools
+    (is (= dewey/all-phases (dewey/dewey-to-phases "99")))
+    (is (= #{:implement :review} (dewey/dewey-to-phases "100")))
+    ;; End of tools → start of languages
+    (is (= #{:implement :review} (dewey/dewey-to-phases "199")))
+    (is (= #{:implement :review} (dewey/dewey-to-phases "200"))))
+
+  (testing "Dewey range coverage is contiguous from 0-999"
+    (doseq [code (range 0 1000)]
+      (is (set? (dewey/dewey-to-phases (str code)))
+          (str "No phase set for dewey code " code)))))
+
+(deftest ^{:stratum 0} dewey-default-phases-test
+  (testing "Unparseable dewey defaults to implement + review"
+    (is (= dewey/default-phases (dewey/dewey-to-phases "")))))
+
+(deftest ^{:stratum 0} dewey-missing-defaults-to-000-test
+  (testing "Missing dewey frontmatter defaults to '000' (foundation phases)"
+    ;; Per edge case: "Missing dewey frontmatter" → default to '000'
+    (is (= dewey/all-phases (dewey/dewey-to-phases "000")))))
+
+;; ===========================================================================
+;; Section 19: Dewey Range Completeness and Non-Overlap Tests
+;; ===========================================================================
+(deftest ^{:stratum 0} dewey-ranges-non-overlapping-test
+  (testing "Dewey ranges do not overlap"
+    (let [ranges (mapv (fn [[lo hi _]] [lo hi]) dewey/dewey-ranges)
+          sorted (sort-by first ranges)]
+      (doseq [[[_ hi1] [lo2 _]] (partition 2 1 sorted)]
+        (is (< hi1 lo2)
+            (str "Ranges overlap: ..." hi1 "] and [" lo2 "..."))))))
+
+(deftest ^{:stratum 0} dewey-ranges-cover-0-to-999-test
+  (testing "Dewey ranges cover all codes from 0 to 999"
+    (let [covered (set (for [[lo hi _] dewey/dewey-ranges
+                             code (range lo (inc hi))]
+                         code))
+          full-range (set (range 0 1000))]
+      (is (= full-range covered)
+          (str "Uncovered codes: " (set/difference full-range covered))))))
+
+;; ===========================================================================
+;; Section 20: Phase Injection Equivalence Tests
+;; ===========================================================================
+(deftest ^{:stratum 0} phase-injection-role-equivalence-test
+  (testing "Foundation rules reach all agent roles"
+    (is (= dewey/all-phases (dewey/dewey-to-phases "001"))))
+
+  (testing "Workflow rules reach all agent roles"
+    (is (= dewey/all-phases (dewey/dewey-to-phases "715"))))
+
+  (testing "Language rules reach implementer and reviewer only"
+    (is (= #{:implement :review} (dewey/dewey-to-phases "210"))))
+
+  (testing "Framework rules include planner (architecture awareness)"
+    (is (contains? (dewey/dewey-to-phases "300") :plan)))
+
+  (testing "Testing rules reach implementer and verifier"
+    (is (= #{:implement :verify} (dewey/dewey-to-phases "400"))))
+
+  (testing "Meta rules reach no agents"
+    (is (empty? (dewey/dewey-to-phases "900")))))

--- a/docs/pull-requests/2026-08-11-refactor-split-policy-pack-mdc-to-pack-mapping-test-1.md
+++ b/docs/pull-requests/2026-08-11-refactor-split-policy-pack-mdc-to-pack-mapping-test-1.md
@@ -1,0 +1,112 @@
+<!--
+  Title: Split policy-pack mdc_to_pack_mapping_test.clj — extract dewey (1/7)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(policy-pack): split mdc_to_pack_mapping_test.clj — extract dewey (1/7)
+
+## Overview
+
+`components/policy-pack/test/ai/miniforge/policy_pack/mdc_to_pack_mapping_test.clj`
+trips stratum-lint SL003: 6 distinct layers, max 3 (rule 210,
+`standards/miniforge`). This is a test file (989 lines, the largest in
+the current Wave 2 batch) with an embedded reference implementation of
+the MDC-to-Pack field-mapping spec — it requires nothing from
+production `mdc_compiler.clj`, so the same layering discipline that
+split that source file (miniforge#1729-#1743) applies here to its own
+helper chain and `deftest` groups.
+
+This is slice 1 of a planned 7-PR split, one cohesive concern per
+namespace, each new file within the 3-layer budget, mechanical moves
+only — same convention as the `mdc_compiler.clj` and `knowledge_safety.clj`
+trains.
+
+This slice extracts `ai.miniforge.policy-pack.mdc-to-pack-mapping-test.dewey`:
+the dewey-code → phase-set chain (`parse-dewey`, `dewey-range-to-phases`,
+`default-phases`, `all-phases`, `dewey-ranges`, `dewey-to-phases`) — the
+deepest same-file dependency chain in the parent namespace, feeding
+`build-applies-to` and then `compile-rule`.
+
+## Motivation
+
+Confirmed zero fan-in repo-wide before starting
+(`grep -rlE "ai\.miniforge\.policy-pack\.mdc-to-pack-mapping-test\b"`
+across `components`/`bases`/`projects` matches only the file's own `ns`
+form and its `(comment ...)` block) — no other namespace requires this
+test namespace, so the split is a pure internal reorganization.
+
+## Changes in Detail
+
+- New file `mdc_to_pack_mapping_test/dewey.clj`: `parse-dewey`,
+  `dewey-range-to-phases`, `default-phases`, `all-phases` (layer 0),
+  `dewey-ranges` (layer 1), `dewey-to-phases` (layer 2) — moved
+  verbatim, 3 real layers, stratum-lint clean.
+- New file `mdc_to_pack_mapping_test/dewey_test.clj`: the six
+  `deftest` forms that exercise this chain (`dewey-to-phases-test`,
+  `dewey-default-phases-test`, `dewey-missing-defaults-to-000-test`,
+  `dewey-ranges-non-overlapping-test`, `dewey-ranges-cover-0-to-999-test`,
+  `phase-injection-role-equivalence-test`) — assertions unchanged,
+  only the call sites now go through the `dewey` alias.
+- `mdc_to_pack_mapping_test.clj`: the six functions and six tests
+  removed; `build-applies-to` and the three remaining call sites that
+  used the bare `all-phases` symbol (`worked-example-a-stratified-design-test`,
+  `edge-case-missing-dewey-test`, `edge-case-index-mdc-test`) now call
+  `dewey/dewey-to-phases` / `dewey/all-phases` across the namespace
+  boundary. Ran `stratum-lint --fix` to renumber the remaining defs'
+  `;--- Layer N` headings and `^{:stratum n}` metadata (6 → 4 real
+  layers).
+
+The parent namespace stays over budget (4 real layers) until the
+remaining slices land; the commit removing the dewey chain used
+`MINIFORGE_STRATUM_BUDGET_MODE=warn` to get past the pre-commit gate's
+plain-lint check on this intermediate state, same convention as
+miniforge#1729. The final slice in this train brings it to 3 layers
+(or removes the file entirely, once every `deftest` has moved to a
+sibling namespace — this file has no production entry point to keep,
+unlike `mdc_compiler.clj`).
+
+## Testing Plan
+
+1. `clj-kondo` clean on all three touched/new files.
+2. stratum-lint: `dewey.clj` and `dewey_test.clj` pass SL003 outright;
+   `mdc_to_pack_mapping_test.clj` intentionally still over budget (4
+   layers) until the rest of the train lands — expected and tracked,
+   not a defect.
+3. Test/assertion count verified unchanged before and after, across
+   both namespaces combined: 39 tests / 1213 assertions, 0 failures —
+   identical to the pre-split baseline (single namespace, 39/1213).
+4. Full pre-commit suite (`poly:check`, lint, stratum-lint, smoke
+   tests, GraalVM) passed on both commits.
+5. Adversarial self-review: diffed the full top-level `defn`/`def`/
+   `deftest` set before and after — exactly 6 functions/defs and 6
+   deftest forms relocated, 0 added/removed/altered in behavior; every
+   other def's body is byte-identical, only its `:stratum` tag,
+   heading section, or (for the three cross-file call sites) the
+   `dewey/` qualification changed.
+
+PR size: 314 reportable lines (350 raw insertions / 180 raw deletions
+across 3 files, two commits of 133 and 164 reportable lines each),
+under the 600-line budget — no override needed.
+
+## Deployment Plan
+
+Merges to `main` as part of an ongoing 7-PR train. Each subsequent PR
+rebases onto the updated `main` after the prior one merges.
+
+## Related Issues/PRs
+
+- Precedent: [mdc_compiler.clj split train, miniforge#1729-#1743](https://github.com/miniforge-ai/miniforge/pull/1743)
+- Precedent: [knowledge_safety.clj split, miniforge#1731](https://github.com/miniforge-ai/miniforge/pull/1731)
+- Precedent: [workflow-runner split, miniforge#1662](https://github.com/miniforge-ai/miniforge/pull/1662)
+- Part of the stratum-lint rule-210 remediation program (Wave 2, policy-pack batch 2)
+
+## Checklist
+
+- [x] Zero fan-in confirmed via repo-wide grep before starting
+- [x] Pure code motion — no behavior change, no assertions altered
+- [x] `clj-kondo` clean
+- [x] Tests green (39/39 tests, 1213/1213 assertions, matches baseline)
+- [x] PR-diff and commit-diff budgets checked (314/600 PR, both commits ≤200)
+- [x] `MINIFORGE_STRATUM_BUDGET_MODE=warn` used + documented for the
+      expected intermediate over-budget state


### PR DESCRIPTION
<!--
  Title: Split policy-pack mdc_to_pack_mapping_test.clj — extract dewey (1/7)
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# refactor(policy-pack): split mdc_to_pack_mapping_test.clj — extract dewey (1/7)

## Overview

`components/policy-pack/test/ai/miniforge/policy_pack/mdc_to_pack_mapping_test.clj`
trips stratum-lint SL003: 6 distinct layers, max 3 (rule 210,
`standards/miniforge`). This is a test file (989 lines, the largest in
the current Wave 2 batch) with an embedded reference implementation of
the MDC-to-Pack field-mapping spec — it requires nothing from
production `mdc_compiler.clj`, so the same layering discipline that
split that source file (miniforge#1729-#1743) applies here to its own
helper chain and `deftest` groups.

This is slice 1 of a planned 7-PR split, one cohesive concern per
namespace, each new file within the 3-layer budget, mechanical moves
only — same convention as the `mdc_compiler.clj` and `knowledge_safety.clj`
trains.

This slice extracts `ai.miniforge.policy-pack.mdc-to-pack-mapping-test.dewey`:
the dewey-code → phase-set chain (`parse-dewey`, `dewey-range-to-phases`,
`default-phases`, `all-phases`, `dewey-ranges`, `dewey-to-phases`) — the
deepest same-file dependency chain in the parent namespace, feeding
`build-applies-to` and then `compile-rule`.

## Motivation

Confirmed zero fan-in repo-wide before starting
(`grep -rlE "ai\.miniforge\.policy-pack\.mdc-to-pack-mapping-test\b"`
across `components`/`bases`/`projects` matches only the file's own `ns`
form and its `(comment ...)` block) — no other namespace requires this
test namespace, so the split is a pure internal reorganization.

## Changes in Detail

- New file `mdc_to_pack_mapping_test/dewey.clj`: `parse-dewey`,
  `dewey-range-to-phases`, `default-phases`, `all-phases` (layer 0),
  `dewey-ranges` (layer 1), `dewey-to-phases` (layer 2) — moved
  verbatim, 3 real layers, stratum-lint clean.
- New file `mdc_to_pack_mapping_test/dewey_test.clj`: the six
  `deftest` forms that exercise this chain (`dewey-to-phases-test`,
  `dewey-default-phases-test`, `dewey-missing-defaults-to-000-test`,
  `dewey-ranges-non-overlapping-test`, `dewey-ranges-cover-0-to-999-test`,
  `phase-injection-role-equivalence-test`) — assertions unchanged,
  only the call sites now go through the `dewey` alias.
- `mdc_to_pack_mapping_test.clj`: the six functions and six tests
  removed; `build-applies-to` and the three remaining call sites that
  used the bare `all-phases` symbol (`worked-example-a-stratified-design-test`,
  `edge-case-missing-dewey-test`, `edge-case-index-mdc-test`) now call
  `dewey/dewey-to-phases` / `dewey/all-phases` across the namespace
  boundary. Ran `stratum-lint --fix` to renumber the remaining defs'
  `;--- Layer N` headings and `^{:stratum n}` metadata (6 → 4 real
  layers).

The parent namespace stays over budget (4 real layers) until the
remaining slices land; the commit removing the dewey chain used
`MINIFORGE_STRATUM_BUDGET_MODE=warn` to get past the pre-commit gate's
plain-lint check on this intermediate state, same convention as
miniforge#1729. The final slice in this train brings it to 3 layers
(or removes the file entirely, once every `deftest` has moved to a
sibling namespace — this file has no production entry point to keep,
unlike `mdc_compiler.clj`).

## Testing Plan

1. `clj-kondo` clean on all three touched/new files.
2. stratum-lint: `dewey.clj` and `dewey_test.clj` pass SL003 outright;
   `mdc_to_pack_mapping_test.clj` intentionally still over budget (4
   layers) until the rest of the train lands — expected and tracked,
   not a defect.
3. Test/assertion count verified unchanged before and after, across
   both namespaces combined: 39 tests / 1213 assertions, 0 failures —
   identical to the pre-split baseline (single namespace, 39/1213).
4. Full pre-commit suite (`poly:check`, lint, stratum-lint, smoke
   tests, GraalVM) passed on both commits.
5. Adversarial self-review: diffed the full top-level `defn`/`def`/
   `deftest` set before and after — exactly 6 functions/defs and 6
   deftest forms relocated, 0 added/removed/altered in behavior; every
   other def's body is byte-identical, only its `:stratum` tag,
   heading section, or (for the three cross-file call sites) the
   `dewey/` qualification changed.

PR size: 314 reportable lines (350 raw insertions / 180 raw deletions
across 3 files, two commits of 133 and 164 reportable lines each),
under the 600-line budget — no override needed.

## Deployment Plan

Merges to `main` as part of an ongoing 7-PR train. Each subsequent PR
rebases onto the updated `main` after the prior one merges.

## Related Issues/PRs

- Precedent: [mdc_compiler.clj split train, miniforge#1729-#1743](https://github.com/miniforge-ai/miniforge/pull/1743)
- Precedent: [knowledge_safety.clj split, miniforge#1731](https://github.com/miniforge-ai/miniforge/pull/1731)
- Precedent: [workflow-runner split, miniforge#1662](https://github.com/miniforge-ai/miniforge/pull/1662)
- Part of the stratum-lint rule-210 remediation program (Wave 2, policy-pack batch 2)

## Checklist

- [x] Zero fan-in confirmed via repo-wide grep before starting
- [x] Pure code motion — no behavior change, no assertions altered
- [x] `clj-kondo` clean
- [x] Tests green (39/39 tests, 1213/1213 assertions, matches baseline)
- [x] PR-diff and commit-diff budgets checked (314/600 PR, both commits ≤200)
- [x] `MINIFORGE_STRATUM_BUDGET_MODE=warn` used + documented for the
      expected intermediate over-budget state