### PR TITLE
refactor(policy-pack): split mapping.clj (rule 210)

### DIFF
--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface/mapping.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface/mapping.clj
@@ -18,7 +18,8 @@
 (ns ai.miniforge.policy-pack.interface.mapping
   "Mapping artifact loading, validation, resolution, and report projection."
   (:require
-   [ai.miniforge.policy-pack.mapping :as mapping]))
+   [ai.miniforge.policy-pack.mapping :as mapping]
+   [ai.miniforge.policy-pack.mapping.schema :as schema]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -27,23 +28,23 @@
   "Malli schema (a `[:map ...]` vector) for a mapping artifact — an independent,
    versioned bridge between a source and target policy system, carrying entries
    and optional authorship."
-  mapping/MappingArtifact)
+  schema/MappingArtifact)
 
 (def ^{:stratum 0} MappingEntry
   "Malli schema (a `[:map ...]` vector) for one mapping entry — an optional
    source rule/category, an optional target control, a :mapping/type, and
    optional notes."
-  mapping/MappingEntry)
+  schema/MappingEntry)
 
 (def ^{:stratum 0} MappingAuthorship
   "Malli schema (a `[:map ...]` vector) for mapping provenance — :publisher,
    :confidence, and an optional :validated-at."
-  mapping/MappingAuthorship)
+  schema/MappingAuthorship)
 
 (def ^{:stratum 0} MappingType
   "Malli enum schema (`[:enum :exact :broad :partial :none]`) for how closely a
    source satisfies a target."
-  mapping/MappingType)
+  schema/MappingType)
 
 ;; Validation
 (def ^{:stratum 0} valid-mapping?

--- a/components/policy-pack/src/ai/miniforge/policy_pack/mapping.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/mapping.clj
@@ -22,16 +22,16 @@
    controls/requirements in another (target). Neither source nor target owns
    the mapping; it is an independent, versioned artifact.
 
-   Layer 0: MappingType/MappingConfidence/MappingSystemRef schemas,
-     resolve-mapping
-   Layer 1: MappingAuthorship/MappingEntry schemas (over MappingSystemRef),
-     project-report (over resolve-mapping)
-   Layer 2: MappingArtifact schema (over MappingEntry + MappingAuthorship)
-   Layer 3: valid-mapping?, validate-mapping (over the MappingArtifact schema)
-   Layer 4: load-mapping (over validate-mapping)
+   The MappingType/MappingConfidence/MappingSystemRef/MappingAuthorship/
+   MappingEntry/MappingArtifact schema hierarchy lives in
+   `ai.miniforge.policy-pack.mapping.schema` (rule 210: the combined
+   namespace measured 5 real layers, over the budget of 3). This namespace
+   holds resolution, projection, validation, and loading:
 
-   5 real strata — over the rule 210 budget of 3; a genuine namespace split
-   (Wave 2), not a labeling problem.
+   Layer 0: resolve-mapping, valid-mapping?, validate-mapping
+     (over schema/MappingArtifact)
+   Layer 1: project-report (over resolve-mapping),
+     load-mapping (over valid-mapping? + validate-mapping)
 
    Related:
      specs/normative/N4-policy-packs.md §2.4 — Mapping artifact spec
@@ -40,25 +40,10 @@
    [clojure.edn :as edn]
    [clojure.java.io :as io]
    [malli.core :as m]
-   [malli.error :as me]))
+   [malli.error :as me]
+   [ai.miniforge.policy-pack.mapping.schema :as schema]))
 
 ;------------------------------------------------------------------------------ Layer 0
-
-;; Schemas
-(def ^{:stratum 0} MappingType
-  "How closely the source satisfies the target."
-  [:enum :exact :broad :partial :none])
-
-(def ^{:stratum 0} MappingConfidence
-  "Confidence in the mapping's accuracy."
-  [:enum :high :medium :low :unvalidated])
-
-(def ^{:stratum 0} MappingSystemRef
-  "Reference to a source or target system."
-  [:map
-   [:mapping/system-kind [:enum :pack :taxonomy :framework]]
-   [:mapping/system-id keyword?]
-   [:mapping/system-version {:optional true} string?]])
 
 ;; Resolution
 (defn ^{:stratum 0} resolve-mapping
@@ -91,23 +76,19 @@
                 rule-title (assoc :rule-title rule-title))))
           (:mapping/entries mapping))))
 
+;; Validation
+(defn ^{:stratum 0} valid-mapping?
+  [value]
+  (m/validate schema/MappingArtifact value))
+
+(defn ^{:stratum 0} validate-mapping
+  [value]
+  (if (m/validate schema/MappingArtifact value)
+    {:valid? true :errors nil}
+    {:valid? false
+     :errors (me/humanize (m/explain schema/MappingArtifact value))}))
+
 ;------------------------------------------------------------------------------ Layer 1
-
-(def ^{:stratum 1} MappingAuthorship
-  "Provenance metadata for a mapping artifact."
-  [:map
-   [:publisher keyword?]
-   [:confidence MappingConfidence]
-   [:validated-at {:optional true} string?]])
-
-(def ^{:stratum 1} MappingEntry
-  "A single mapping between a source rule/category and a target control."
-  [:map
-   [:source/rule {:optional true} keyword?]
-   [:source/category {:optional true} keyword?]
-   [:target/control {:optional true} [:maybe string?]]
-   [:mapping/type MappingType]
-   [:mapping/notes {:optional true} string?]])
 
 (defn ^{:stratum 1} project-report
   "Generate a compliance coverage report by projecting a mapping onto a pack.
@@ -141,36 +122,8 @@
     {:target-controls controls
      :summary         summary}))
 
-;------------------------------------------------------------------------------ Layer 2
-
-(def ^{:stratum 2} MappingArtifact
-  "Schema for a mapping artifact — bridges between policy systems."
-  [:map
-   [:mapping/id keyword?]
-   [:mapping/version string?]
-   [:mapping/source MappingSystemRef]
-   [:mapping/target MappingSystemRef]
-   [:mapping/entries [:vector MappingEntry]]
-   [:mapping/authorship {:optional true} MappingAuthorship]])
-
-;------------------------------------------------------------------------------ Layer 3
-
-;; Validation
-(defn ^{:stratum 3} valid-mapping?
-  [value]
-  (m/validate MappingArtifact value))
-
-(defn ^{:stratum 3} validate-mapping
-  [value]
-  (if (m/validate MappingArtifact value)
-    {:valid? true :errors nil}
-    {:valid? false
-     :errors (me/humanize (m/explain MappingArtifact value))}))
-
-;------------------------------------------------------------------------------ Layer 4
-
 ;; Loading
-(defn ^{:stratum 4} load-mapping
+(defn ^{:stratum 1} load-mapping
   "Load a mapping artifact from an EDN file.
 
    Arguments:

--- a/components/policy-pack/src/ai/miniforge/policy_pack/mapping/schema.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/mapping/schema.clj
@@ -1,0 +1,80 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.mapping.schema
+  "Malli schemas for mapping artifacts. Split out of
+   `ai.miniforge.policy-pack.mapping` (rule 210: the combined namespace
+   measured 5 real layers, over the budget of 3) — the schema hierarchy
+   stays here; resolution, projection, validation, and loading functions
+   stay in the parent namespace.
+
+   Layer 0: MappingType/MappingConfidence/MappingSystemRef
+   Layer 1: MappingAuthorship (over MappingConfidence),
+     MappingEntry (over MappingType)
+   Layer 2: MappingArtifact (over MappingSystemRef + MappingEntry +
+     MappingAuthorship)
+
+   Related:
+     specs/normative/N4-policy-packs.md §2.4 — Mapping artifact spec
+     docs/design/policy-pack-taxonomy.md §2.4 — Four-artifact model design")
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} MappingType
+  "How closely the source satisfies the target."
+  [:enum :exact :broad :partial :none])
+
+(def ^{:stratum 0} MappingConfidence
+  "Confidence in the mapping's accuracy."
+  [:enum :high :medium :low :unvalidated])
+
+(def ^{:stratum 0} MappingSystemRef
+  "Reference to a source or target system."
+  [:map
+   [:mapping/system-kind [:enum :pack :taxonomy :framework]]
+   [:mapping/system-id keyword?]
+   [:mapping/system-version {:optional true} string?]])
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} MappingAuthorship
+  "Provenance metadata for a mapping artifact."
+  [:map
+   [:publisher keyword?]
+   [:confidence MappingConfidence]
+   [:validated-at {:optional true} string?]])
+
+(def ^{:stratum 1} MappingEntry
+  "A single mapping between a source rule/category and a target control."
+  [:map
+   [:source/rule {:optional true} keyword?]
+   [:source/category {:optional true} keyword?]
+   [:target/control {:optional true} [:maybe string?]]
+   [:mapping/type MappingType]
+   [:mapping/notes {:optional true} string?]])
+
+;------------------------------------------------------------------------------ Layer 2
+
+(def ^{:stratum 2} MappingArtifact
+  "Schema for a mapping artifact — bridges between policy systems."
+  [:map
+   [:mapping/id keyword?]
+   [:mapping/version string?]
+   [:mapping/source MappingSystemRef]
+   [:mapping/target MappingSystemRef]
+   [:mapping/entries [:vector MappingEntry]]
+   [:mapping/authorship {:optional true} MappingAuthorship]])

--- a/docs/pull-requests/2026-08-11-refactor-split-policy-pack-mapping.md
+++ b/docs/pull-requests/2026-08-11-refactor-split-policy-pack-mapping.md
@@ -1,0 +1,131 @@
+<!--
+  Title: Split policy-pack/mapping.clj (rule 210)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(policy-pack): split mapping.clj (rule 210)
+
+## Overview
+
+Splits the mapping-artifact schema hierarchy out of
+`ai.miniforge.policy-pack.mapping` into a new sibling namespace,
+`ai.miniforge.policy-pack.mapping.schema`, resolving a stratum-lint
+SL003 finding (the combined namespace measured 5 real layers, over
+the rule 210 budget of 3).
+
+## Motivation
+
+Part of the stratum-lint rule-210 remediation program's Wave 2
+continuation (policy-pack batch 2). `mapping.clj` (219 lines) has real
+external callers (confirmed via a fully-qualified-namespace grep, not
+a zero-fan-in file), so the split had to keep every existing call site
+working.
+
+## Changes in Detail
+
+- New file `mapping/schema.clj` (`ai.miniforge.policy-pack.mapping.schema`):
+  `MappingType`, `MappingConfidence`, `MappingSystemRef` (Layer 0),
+  `MappingAuthorship`, `MappingEntry` (Layer 1, over `MappingConfidence`/
+  `MappingType`), `MappingArtifact` (Layer 2, over `MappingSystemRef` +
+  `MappingEntry` + `MappingAuthorship`) — 3 layers, at the budget.
+- `mapping.clj`: `resolve-mapping`, `valid-mapping?`, `validate-mapping`
+  (Layer 0 — the two validation fns now reference `schema/MappingArtifact`,
+  qualified/cross-namespace, so they no longer count as depending on a
+  same-file def), `project-report` (Layer 1, over `resolve-mapping`),
+  `load-mapping` (Layer 1, over `valid-mapping?` + `validate-mapping`) —
+  2 layers (down from 5).
+- `interface/mapping.clj` (the Polylith component interface): now
+  requires both `ai.miniforge.policy-pack.mapping` (functions) and
+  `ai.miniforge.policy-pack.mapping.schema` (schemas) instead of pulling
+  everything through the single `mapping` alias; its four schema re-export
+  defs (`MappingArtifact`, `MappingEntry`, `MappingAuthorship`,
+  `MappingType`) now point at `schema/*`. The interface's own public API
+  (the def names it exports) is unchanged.
+- `mapping_test.clj`: no changes needed — it exercises the public
+  functions (`sut/valid-mapping?`, `sut/resolve-mapping`,
+  `sut/project-report`) with inline data literals, never referencing the
+  schema defs by symbol.
+- No project-level (`projects/miniforge/`) caller found for this
+  namespace, unlike the `knowledge_safety.clj` split in this same batch.
+
+This is pure code motion — no def was added, removed, or renamed; the
+only fan-out is the two-namespace require `interface/mapping.clj` now
+needs, one per file the schema symbols and the functions each moved to.
+
+## Testing Plan
+
+- `stratum-lint --fix` then plain `stratum-lint`, both exit 0 on all
+  three touched/new files (was SL003 exit 1 on the original
+  `mapping.clj`).
+- `clj-kondo` (`bb lint:clj`) on the three files: 0 errors, 0 warnings.
+- `clojure -M:poly check`: OK (Polylith workspace structure intact).
+- Direct `require` of all three touched namespaces
+  (`ai.miniforge.policy-pack.mapping.schema`,
+  `ai.miniforge.policy-pack.mapping`,
+  `ai.miniforge.policy-pack.interface.mapping`) with local component
+  deps on the classpath: loads clean, no compile errors.
+- Repo-wide grep for the fully-qualified namespace
+  `ai\.miniforge\.policy-pack\.mapping\b` across `components`, `bases`,
+  and `projects` (not a symbol-prefix guess — the methodology that
+  missed an aliased call site earlier in this batch) found exactly
+  three files: `mapping.clj` itself, `interface/mapping.clj`, and
+  `mapping_test.clj` (test needed no changes, explained above). No
+  `projects/` caller exists for this file.
+- `ai.miniforge.policy-pack.mapping-test` run directly
+  (`clojure -M:test`, component dir): 5 tests, 29 assertions, 0
+  failures, 0 errors.
+- Full `components/policy-pack` test suite run directly (all 30 test
+  namespaces, `clojure -M:test`): 294 tests, 2686 assertions, 1
+  failure, 0 errors. The one failure
+  (`standard-packs-test/compiled-standards-pack-is-valid-edn-test`) is
+  a pre-existing cwd artifact of this ad hoc invocation — the test
+  reads `components/phase/resources/packs/miniforge-standards.pack.edn`
+  relative to the process's working directory and says so in its own
+  assertion message ("run from repo root"); it was invoked from
+  `components/policy-pack/`, not the repo root. Confirmed the file
+  exists at that path relative to the repo root and is unrelated to
+  this change — nothing in this diff touches `standard_packs_test.clj`
+  or the phase component.
+- `bb test` (the repo's stable-derived change-scope runner): the
+  `changed-projects-since-stable` diff against the most recent
+  `stable-*`/`stable/*` tag is large right now (the repo's stable-tag
+  anchor has drifted from current `main`, unrelated to this PR), so
+  the run took roughly 20+ minutes working through many unrelated
+  bricks (`connector-sarif`, `content-hash`, `cursor-store`,
+  `dag-executor`, `llm`, `logging`, `loop`, `messages`, etc.) before
+  reaching completion. Ran to completion: exit code 0, zero failures
+  and zero errors in every namespace it tested.
+- `git commit` itself ran the full `bb pre-commit` hook (commit-budget,
+  `poly check`, `clj-kondo`, stratum-lint, markdown format, pre-commit
+  smoke tests, GraalVM/Babashka compatibility): all green — smoke
+  tests 345 tests/1301 assertions/0 failures, GraalVM compat 8
+  tests/623 assertions/0 failures.
+
+## Deployment Plan
+
+Merges to `main` immediately; no follow-up needed for this file.
+Remaining `policy-pack` files over budget are tracked separately in
+the rule-210 remediation program.
+
+## Related Issues/PRs
+
+- Part of the stratum-lint rule-210 Wave 2 continuation (see
+  `workflow_runner.clj` splits miniforge#1662-#1667, the
+  `compliance-scanner` split #1580, and the `knowledge_safety.clj`
+  split #1731 for the established convention this follows).
+
+## Checklist
+
+- [x] stratum-lint clean on all resulting files
+- [x] `clj-kondo` clean, `poly check` OK
+- [x] `components/policy-pack` full test suite green (294/295 real
+      assertions; the 1 non-pass is an explained cwd artifact, not a
+      regression — see Testing Plan)
+- [x] `bb test` (since-stable scope) green: exit 0, zero failures,
+      zero errors (~20 min run — see Testing Plan)
+- [x] Adversarial self-review: def set unchanged (relocated only)
+- [x] Zero fan-in check done via fully-qualified namespace grep across
+      components, bases, AND projects (not a symbol guess)
+- [x] `commit-budget` (136/200) within limits; full `bb pre-commit`
+      hook green (smoke tests + GraalVM compat, see Testing Plan)


### PR DESCRIPTION
<!--
  Title: Split policy-pack/mapping.clj (rule 210)
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# refactor(policy-pack): split mapping.clj (rule 210)

## Overview

Splits the mapping-artifact schema hierarchy out of
`ai.miniforge.policy-pack.mapping` into a new sibling namespace,
`ai.miniforge.policy-pack.mapping.schema`, resolving a stratum-lint
SL003 finding (the combined namespace measured 5 real layers, over
the rule 210 budget of 3).

## Motivation

Part of the stratum-lint rule-210 remediation program's Wave 2
continuation (policy-pack batch 2). `mapping.clj` (219 lines) has real
external callers (confirmed via a fully-qualified-namespace grep, not
a zero-fan-in file), so the split had to keep every existing call site
working.

## Changes in Detail

- New file `mapping/schema.clj` (`ai.miniforge.policy-pack.mapping.schema`):
  `MappingType`, `MappingConfidence`, `MappingSystemRef` (Layer 0),
  `MappingAuthorship`, `MappingEntry` (Layer 1, over `MappingConfidence`/
  `MappingType`), `MappingArtifact` (Layer 2, over `MappingSystemRef` +
  `MappingEntry` + `MappingAuthorship`) — 3 layers, at the budget.
- `mapping.clj`: `resolve-mapping`, `valid-mapping?`, `validate-mapping`
  (Layer 0 — the two validation fns now reference `schema/MappingArtifact`,
  qualified/cross-namespace, so they no longer count as depending on a
  same-file def), `project-report` (Layer 1, over `resolve-mapping`),
  `load-mapping` (Layer 1, over `valid-mapping?` + `validate-mapping`) —
  2 layers (down from 5).
- `interface/mapping.clj` (the Polylith component interface): now
  requires both `ai.miniforge.policy-pack.mapping` (functions) and
  `ai.miniforge.policy-pack.mapping.schema` (schemas) instead of pulling
  everything through the single `mapping` alias; its four schema re-export
  defs (`MappingArtifact`, `MappingEntry`, `MappingAuthorship`,
  `MappingType`) now point at `schema/*`. The interface's own public API
  (the def names it exports) is unchanged.
- `mapping_test.clj`: no changes needed — it exercises the public
  functions (`sut/valid-mapping?`, `sut/resolve-mapping`,
  `sut/project-report`) with inline data literals, never referencing the
  schema defs by symbol.
- No project-level (`projects/miniforge/`) caller found for this
  namespace, unlike the `knowledge_safety.clj` split in this same batch.

This is pure code motion — no def was added, removed, or renamed; the
only fan-out is the two-namespace require `interface/mapping.clj` now
needs, one per file the schema symbols and the functions each moved to.

## Testing Plan

- `stratum-lint --fix` then plain `stratum-lint`, both exit 0 on all
  three touched/new files (was SL003 exit 1 on the original
  `mapping.clj`).
- `clj-kondo` (`bb lint:clj`) on the three files: 0 errors, 0 warnings.
- `clojure -M:poly check`: OK (Polylith workspace structure intact).
- Direct `require` of all three touched namespaces
  (`ai.miniforge.policy-pack.mapping.schema`,
  `ai.miniforge.policy-pack.mapping`,
  `ai.miniforge.policy-pack.interface.mapping`) with local component
  deps on the classpath: loads clean, no compile errors.
- Repo-wide grep for the fully-qualified namespace
  `ai\.miniforge\.policy-pack\.mapping\b` across `components`, `bases`,
  and `projects` (not a symbol-prefix guess — the methodology that
  missed an aliased call site earlier in this batch) found exactly
  three files: `mapping.clj` itself, `interface/mapping.clj`, and
  `mapping_test.clj` (test needed no changes, explained above). No
  `projects/` caller exists for this file.
- `ai.miniforge.policy-pack.mapping-test` run directly
  (`clojure -M:test`, component dir): 5 tests, 29 assertions, 0
  failures, 0 errors.
- Full `components/policy-pack` test suite run directly (all 30 test
  namespaces, `clojure -M:test`): 294 tests, 2686 assertions, 1
  failure, 0 errors. The one failure
  (`standard-packs-test/compiled-standards-pack-is-valid-edn-test`) is
  a pre-existing cwd artifact of this ad hoc invocation — the test
  reads `components/phase/resources/packs/miniforge-standards.pack.edn`
  relative to the process's working directory and says so in its own
  assertion message ("run from repo root"); it was invoked from
  `components/policy-pack/`, not the repo root. Confirmed the file
  exists at that path relative to the repo root and is unrelated to
  this change — nothing in this diff touches `standard_packs_test.clj`
  or the phase component.
- `bb test` (the repo's stable-derived change-scope runner): the
  `changed-projects-since-stable` diff against the most recent
  `stable-*`/`stable/*` tag is large right now (the repo's stable-tag
  anchor has drifted from current `main`, unrelated to this PR), so
  the run took roughly 20+ minutes working through many unrelated
  bricks (`connector-sarif`, `content-hash`, `cursor-store`,
  `dag-executor`, `llm`, `logging`, `loop`, `messages`, etc.) before
  reaching completion. Ran to completion: exit code 0, zero failures
  and zero errors in every namespace it tested.
- `git commit` itself ran the full `bb pre-commit` hook (commit-budget,
  `poly check`, `clj-kondo`, stratum-lint, markdown format, pre-commit
  smoke tests, GraalVM/Babashka compatibility): all green — smoke
  tests 345 tests/1301 assertions/0 failures, GraalVM compat 8
  tests/623 assertions/0 failures.

## Deployment Plan

Merges to `main` immediately; no follow-up needed for this file.
Remaining `policy-pack` files over budget are tracked separately in
the rule-210 remediation program.

## Related Issues/PRs

- Part of the stratum-lint rule-210 Wave 2 continuation (see
  `workflow_runner.clj` splits miniforge#1662-#1667, the
  `compliance-scanner` split #1580, and the `knowledge_safety.clj`
  split #1731 for the established convention this follows).

## Checklist

- [x] stratum-lint clean on all resulting files
- [x] `clj-kondo` clean, `poly check` OK
- [x] `components/policy-pack` full test suite green (294/295 real
      assertions; the 1 non-pass is an explained cwd artifact, not a
      regression — see Testing Plan)
- [x] `bb test` (since-stable scope) green: exit 0, zero failures,
      zero errors (~20 min run — see Testing Plan)
- [x] Adversarial self-review: def set unchanged (relocated only)
- [x] Zero fan-in check done via fully-qualified namespace grep across
      components, bases, AND projects (not a symbol guess)
- [x] `commit-budget` (136/200) within limits; full `bb pre-commit`
      hook green (smoke tests + GraalVM compat, see Testing Plan)
