### PR TITLE
refactor(policy-pack): split intent.clj (rule 210)

### DIFF
--- a/components/policy-pack/src/ai/miniforge/policy_pack/intent.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/intent.clj
@@ -23,11 +23,11 @@
      parse-terraform-plan-counts, parse-k8s-diff-counts
    Layer 1: intent-violation (over intent-constraints)
    Layer 2: intent-matches? (over intent-violation)
-   Layer 3: semantic-intent-check (over intent-matches? + the plan/diff
-     count parsers)
 
-   4 real strata — over the rule 210 budget of 3; a genuine namespace split
-   (Wave 2), not a labeling problem.
+   The full semantic check that composes `infer-intent` and
+   `intent-matches?` into one pass/fail result is a 4th layer, split
+   out to `ai.miniforge.policy-pack.intent.check` (rule 210: this
+   namespace measured 4 real layers, over the budget of 3).
 
    Intent Types:
      :import   → Creates: 0, Updates: 0, Destroys: 0 (state-only)
@@ -176,25 +176,6 @@
           {:passed? true}
           {:passed? false :violations violations})))))
 
-;------------------------------------------------------------------------------ Layer 3
-
-(defn ^{:stratum 3} semantic-intent-check
-  "Full semantic intent validation check function per N4 §4.
-
-   Arguments:
-   - declared-intent — Keyword from intent-types
-   - counts          — {:creates int :updates int :destroys int}
-
-   Returns:
-   - {:passed? bool :violations [...] :inferred-intent keyword :metadata {...}}"
-  [declared-intent counts]
-  (let [inferred (infer-intent counts)
-        result   (intent-matches? declared-intent counts)]
-    (assoc result
-           :inferred-intent inferred
-           :metadata {:declared declared-intent
-                      :counts   counts})))
-
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   ;; Infer intent from counts
@@ -211,8 +192,6 @@
   (intent-matches? :create {:creates 3 :updates 1 :destroys 0})
   ;; => {:passed? true}
 
-  ;; Full check
-  (semantic-intent-check :import {:creates 0 :updates 0 :destroys 0})
-  ;; => {:passed? true :inferred-intent :refactor :metadata {...}}
+  ;; Full check lives in ai.miniforge.policy-pack.intent.check
 
   :leave-this-here)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/intent/check.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/intent/check.clj
@@ -1,0 +1,53 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.intent.check
+  "Full semantic intent check (N4 §4) — composes
+   `ai.miniforge.policy-pack.intent/infer-intent` and
+   `ai.miniforge.policy-pack.intent/intent-matches?` into a single
+   pass/fail result with metadata. Split out of
+   `ai.miniforge.policy-pack.intent` (rule 210: the combined namespace
+   measured 4 real layers, over the budget of 3); intent classification
+   and the constraint-violation chain stay in the parent namespace."
+  (:require
+   [ai.miniforge.policy-pack.intent :as intent]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} semantic-intent-check
+  "Full semantic intent validation check function per N4 §4.
+
+   Arguments:
+   - declared-intent — Keyword from intent/intent-types
+   - counts          — {:creates int :updates int :destroys int}
+
+   Returns:
+   - {:passed? bool :violations [...] :inferred-intent keyword :metadata {...}}"
+  [declared-intent counts]
+  (let [inferred (intent/infer-intent counts)
+        result   (intent/intent-matches? declared-intent counts)]
+    (assoc result
+           :inferred-intent inferred
+           :metadata {:declared declared-intent
+                      :counts   counts})))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (semantic-intent-check :import {:creates 0 :updates 0 :destroys 0})
+  ;; => {:passed? true :inferred-intent :refactor :metadata {...}}
+
+  :leave-this-here)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface/intent.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface/intent.clj
@@ -18,7 +18,8 @@
 (ns ai.miniforge.policy-pack.interface.intent
   "Semantic intent validation — declared intent vs actual resource changes."
   (:require
-   [ai.miniforge.policy-pack.intent :as intent]))
+   [ai.miniforge.policy-pack.intent :as intent]
+   [ai.miniforge.policy-pack.intent.check :as intent-check]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -43,7 +44,7 @@
   "Full semantic intent check (N4 §4).
    (semantic-intent-check declared-intent counts) returns
    {:passed? bool :violations [...] :inferred-intent keyword :metadata {...}}."
-  intent/semantic-intent-check)
+  intent-check/semantic-intent-check)
 
 (def ^{:stratum 0} parse-terraform-plan-counts
   "Parse terraform plan output into resource change counts.

--- a/components/policy-pack/test/ai/miniforge/policy_pack/intent_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/intent_test.clj
@@ -25,7 +25,8 @@
    - Kubernetes diff parsing"
   (:require
    [clojure.test :refer [deftest testing is]]
-   [ai.miniforge.policy-pack.intent :as sut]))
+   [ai.miniforge.policy-pack.intent :as sut]
+   [ai.miniforge.policy-pack.intent.check :as check]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -112,13 +113,13 @@
 ;; ============================================================================
 (deftest ^{:stratum 0} semantic-intent-check-test
   (testing "returns inferred intent and metadata"
-    (let [result (sut/semantic-intent-check :import {:creates 0 :updates 0 :destroys 0})]
+    (let [result (check/semantic-intent-check :import {:creates 0 :updates 0 :destroys 0})]
       (is (true? (:passed? result)))
       (is (= :refactor (:inferred-intent result)))
       (is (= :import (get-in result [:metadata :declared])))))
 
   (testing "failing check includes violations"
-    (let [result (sut/semantic-intent-check :import {:creates 3 :updates 0 :destroys 0})]
+    (let [result (check/semantic-intent-check :import {:creates 3 :updates 0 :destroys 0})]
       (is (false? (:passed? result)))
       (is (seq (:violations result)))
       (is (= :create (:inferred-intent result))))))

--- a/docs/pull-requests/2026-08-11-refactor-split-policy-pack-intent.md
+++ b/docs/pull-requests/2026-08-11-refactor-split-policy-pack-intent.md
@@ -1,0 +1,101 @@
+<!--
+  Title: Split policy-pack/intent.clj (rule 210)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(policy-pack): split intent.clj (rule 210)
+
+## Overview
+
+Splits the full semantic-intent check out of
+`ai.miniforge.policy-pack.intent` into a new sibling namespace,
+`ai.miniforge.policy-pack.intent.check`, resolving a stratum-lint
+SL003 finding (the combined namespace measured 4 real layers, over
+the rule 210 budget of 3).
+
+## Motivation
+
+Part of the stratum-lint rule-210 remediation program, policy-pack
+Wave 2 batch 2. `intent.clj` (218 lines) has real fan-in — three
+files repo-wide reference `ai.miniforge.policy-pack.intent`
+(its own test, its `interface/intent.clj` re-export, and itself) — so
+this is a real split, not a zero-fan-in cleanup.
+
+## Changes in Detail
+
+- New file `intent/check.clj` (namespace
+  `ai.miniforge.policy-pack.intent.check`): `semantic-intent-check`,
+  moved verbatim — 1 layer. It requires `ai.miniforge.policy-pack.intent`
+  and calls `intent/infer-intent` + `intent/intent-matches?`
+  cross-namespace, so it no longer stacks on top of the parent's own
+  layers.
+- `intent.clj`: keeps `intent-types`, `infer-intent`,
+  `intent-constraints`, `violation-message-fmt`,
+  `parse-terraform-plan-counts`, `parse-k8s-diff-counts` (Layer 0),
+  `intent-violation` (Layer 1), and `intent-matches?` (Layer 2) — now
+  3 layers (down from 4). Docstring updated to point at the new
+  namespace instead of describing a Layer 3 that no longer lives here.
+- `interface/intent.clj`: added a require for
+  `ai.miniforge.policy-pack.intent.check`; the `semantic-intent-check`
+  pass-through def now points at `intent-check/semantic-intent-check`
+  instead of `intent/semantic-intent-check`. No public def added,
+  removed, or renamed — the interface's surface is unchanged.
+- `intent_test.clj`: added a require for
+  `ai.miniforge.policy-pack.intent.check`; the two
+  `semantic-intent-check-test` assertions call `check/semantic-intent-check`
+  instead of `sut/semantic-intent-check`. No other test changed.
+
+Pure code motion — no logic changes. The moved function body is
+byte-identical; only its namespace and the two call sites that invoke
+it directly (test + interface) changed.
+
+## Testing Plan
+
+- `stratum-lint --fix` then plain `stratum-lint` clean (exit 0) on all
+  three touched/new source files — was SL003 exit 1 on the original
+  `intent.clj`.
+- Repo-wide grep for the fully-qualified namespace
+  (`ai\.miniforge\.policy-pack\.intent\b`, not a guessed symbol/alias
+  prefix — a prior mistake in this program missed aliased callers)
+  across `components`, `bases`, and `projects` found exactly the three
+  files already listed above; no caller in `projects/miniforge/test/`
+  references this namespace, so there was no project-level integration
+  test to update.
+- `bb test` (change-scope) ran green, but its "changed since stable
+  tag" detection did not pick up this uncommitted worktree diff at all
+  (it ran unrelated `workflow`/`workspace` component tests, zero
+  `policy-pack` tests) — not sufficient on its own to validate this
+  change.
+- Directly verified instead: `clojure -M:dev:test -e "(require
+  'ai.miniforge.policy-pack.intent-test) (clojure.test/run-tests
+  'ai.miniforge.policy-pack.intent-test)"` → 9 tests, 33 assertions, 0
+  failures, 0 errors.
+- Also directly required `ai.miniforge.policy-pack.intent.check` and
+  `ai.miniforge.policy-pack.interface.intent` and called
+  `semantic-intent-check` through both the new namespace and the
+  unchanged interface facade to confirm identical return values.
+
+## Deployment Plan
+
+Merges to `main` immediately; no follow-up needed for this file.
+
+## Related Issues/PRs
+
+- Part of the stratum-lint rule-210 Wave 2 continuation (see
+  `workflow_runner.clj` splits miniforge#1662-#1667,
+  `knowledge_safety.clj` split #1731, and the `compliance-scanner`
+  split #1580 for the established convention this follows).
+
+## Checklist
+
+- [x] stratum-lint clean on all resulting files
+- [x] `bb test` green (change-scope; did not cover this brick, see
+      Testing Plan) plus a direct `clojure -M:dev:test` run of
+      `intent-test` (9 tests / 33 assertions / 0 failures)
+- [x] Adversarial self-review: def set unchanged (relocated only), no
+      logic changes
+- [x] Fan-in confirmed via fully-qualified namespace grep across
+      components, bases, and projects — three callers, all updated
+- [x] `tasks/pr_budget.clj` / `tasks/commit_budget.clj` ceilings not
+      approached (diff is ~90 lines across 4 files)

--- a/docs/pull-requests/2026-08-11-refactor-split-policy-pack-intent.md
+++ b/docs/pull-requests/2026-08-11-refactor-split-policy-pack-intent.md
@@ -17,10 +17,14 @@ the rule 210 budget of 3).
 ## Motivation
 
 Part of the stratum-lint rule-210 remediation program, policy-pack
-Wave 2 batch 2. `intent.clj` (218 lines) has real fan-in — three
-files repo-wide reference `ai.miniforge.policy-pack.intent`
-(its own test, its `interface/intent.clj` re-export, and itself) — so
-this is a real split, not a zero-fan-in cleanup.
+Wave 2 batch 2. `intent.clj` (218 lines) has real fan-in — before
+this split, three files repo-wide referenced
+`ai.miniforge.policy-pack.intent` (its own test, its
+`interface/intent.clj` re-export, and itself) — so this is a real
+split, not a zero-fan-in cleanup. The split itself adds a 4th
+reference: the new `intent/check.clj` now also requires
+`ai.miniforge.policy-pack.intent` to call `infer-intent` and
+`intent-matches?`.
 
 ## Changes in Detail
 
@@ -58,10 +62,12 @@ it directly (test + interface) changed.
 - Repo-wide grep for the fully-qualified namespace
   (`ai\.miniforge\.policy-pack\.intent\b`, not a guessed symbol/alias
   prefix — a prior mistake in this program missed aliased callers)
-  across `components`, `bases`, and `projects` found exactly the three
-  files already listed above; no caller in `projects/miniforge/test/`
+  across `components`, `bases`, and `projects`, run before starting
+  this split, found exactly the three pre-existing files listed in
+  Motivation above; no caller in `projects/miniforge/test/`
   references this namespace, so there was no project-level integration
-  test to update.
+  test to update. (The new `intent/check.clj` created by this split
+  is itself a 4th, expected reference — not a missed caller.)
 - `bb test` (change-scope) ran green, but its "changed since stable
   tag" detection did not pick up this uncommitted worktree diff at all
   (it ran unrelated `workflow`/`workspace` component tests, zero


### PR DESCRIPTION
## Overview

Splits the full semantic-intent check out of `ai.miniforge.policy-pack.intent` into a new sibling namespace, `ai.miniforge.policy-pack.intent.check`, resolving a stratum-lint SL003 finding (the combined namespace measured 4 real layers, over the rule 210 budget of 3).

Part of the stratum-lint rule-210 remediation program, policy-pack Wave 2 batch 2. Full PR doc: `docs/pull-requests/2026-08-11-refactor-split-policy-pack-intent.md`.

## Changes

- New file `intent/check.clj` (ns `ai.miniforge.policy-pack.intent.check`): `semantic-intent-check`, moved verbatim — 1 layer, calls `intent/infer-intent` + `intent/intent-matches?` cross-namespace.
- `intent.clj`: down to 3 layers (0-2) — `intent-types`, `infer-intent`, `intent-constraints`, `violation-message-fmt`, the two plan/diff parsers (L0), `intent-violation` (L1), `intent-matches?` (L2).
- `interface/intent.clj`: added a require for the new namespace; `semantic-intent-check` pass-through now points there. Public surface unchanged.
- `intent_test.clj`: `semantic-intent-check-test` calls updated to the new namespace.

Pure code motion, no logic changes.

## Fan-in / callers

Fully-qualified-namespace grep (`ai\.miniforge\.policy-pack\.intent\b`) across `components`, `bases`, `projects` found exactly 3 files — the target itself, `interface/intent.clj`, and `intent_test.clj` — all updated. No caller in `projects/miniforge/test/`.

## Testing

- `stratum-lint --fix` then plain `stratum-lint` clean (exit 0) on all touched/new files.
- `bb test` (change-scope) ran green but its "since stable tag" detection did not pick up this brick at all (ran unrelated workflow/workspace tests, zero policy-pack tests) — not sufficient alone.
- Directly verified: `clojure -M:dev:test -e "(require 'ai.miniforge.policy-pack.intent-test) (clojure.test/run-tests 'ai.miniforge.policy-pack.intent-test)"` → 9 tests, 33 assertions, 0 failures, 0 errors.
- Pre-commit hook (poly:check, lint:clj, lint:stratum, fmt:md, `test:precommit` 345 tests/1301 assertions, `test:graalvm` 8 tests/623 assertions) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
