### PR TITLE
refactor(policy-pack): split detection.clj — extract detection.matching (1/N)

### DIFF
--- a/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
@@ -31,8 +31,10 @@
    Layer 4: detect-violation (unified per-type dispatcher, over Layer 3)
    Layer 5: check-rules (over detect-violation)
 
-   6 real strata — over the rule 210 budget of 3; a genuine namespace split
-   (Wave 2), not a labeling problem.
+   Pattern-matching and terraform-plan-parsing primitives moved to the
+   sibling `detection.matching` namespace (rule 210 split, Wave 2); layer
+   count in the docstring above is stale pending the next commit's
+   `stratum-lint --fix` renumbering.
 
    Supports detection types:
    - :content-scan - Regex against artifact content
@@ -46,74 +48,13 @@
   (:require
    [ai.miniforge.policy-pack.ast :as ast]
    [ai.miniforge.policy-pack.capability :as capability]
+   [ai.miniforge.policy-pack.detection.matching :as matching]
    [ai.miniforge.policy-pack.schema-validation :as schema]
    [ai.miniforge.policy-clause.interface :as clause]
    [clojure.data :as data]
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-
-;; Pattern matching utilities
-(defn ^{:stratum 0} ensure-pattern
-  "Convert string or regex to compiled pattern."
-  [p]
-  (cond
-    (instance? java.util.regex.Pattern p) p
-    (string? p) (re-pattern p)
-    :else nil))
-
-(defn ^{:stratum 0} extract-patterns
-  "Extract pattern(s) from detection config.
-   Returns vector of patterns."
-  [detection]
-  (let [{:keys [pattern patterns]} detection]
-    (cond
-      (seq patterns) patterns
-      pattern [pattern]
-      :else [])))
-
-;; Plan output detection
-(defn ^{:stratum 0} parse-plan-resources
-  "Parse terraform plan output to extract resource changes.
-   Returns vector of {:action :resource :details}."
-  [plan-output]
-  (when plan-output
-    (let [;; Match lines like:
-          ;; "# aws_route.main will be destroyed"
-          ;; "# aws_subnet.private[0] must be replaced"
-          ;; "# aws_vpc.main will be created"
-          ;; "  -/+ aws_route.main (tainted)"
-          action-patterns
-          [{:pattern #"#\s+(\S+)\s+will be (created|destroyed|updated)"
-            :extractor (fn [[_ resource action]]
-                         {:resource resource
-                          :action (case action
-                                    "created" :create
-                                    "destroyed" :destroy
-                                    "updated" :update
-                                    (keyword action))})}
-           {:pattern #"#\s+(\S+)\s+must be (replaced)"
-            :extractor (fn [[_ resource _action]]
-                         {:resource resource
-                          :action :replace})}
-           {:pattern #"^\s*(-/\+|~|\+|-)\s+(\S+)"
-            :extractor (fn [[_ symbol resource]]
-                         {:resource resource
-                          :action (case symbol
-                                    "-/+" :replace
-                                    "~" :update
-                                    "+" :create
-                                    "-" :destroy
-                                    :unknown)})}]]
-      (->> (str/split-lines plan-output)
-           (mapcat (fn [line]
-                     (keep (fn [{:keys [pattern extractor]}]
-                             (when-let [match (re-find pattern line)]
-                               (assoc (extractor match)
-                                      :line line)))
-                           action-patterns)))
-           (distinct)
-           vec))))
 
 ;; State comparison detection
 (defn ^{:stratum 0} detect-state-comparison
@@ -344,58 +285,8 @@ depending on ambient namespace loading or raw var resolution."}
    :message (:message violation)
    :severity (:rule/severity rule)})
 
-;------------------------------------------------------------------------------ Layer 1
-
-(defn ^{:stratum 1} find-matches
-  "Find all matches of a pattern in content.
-   Returns vector of {:match string :line int :column int :context string}."
-  [pattern content context-lines]
-  (when-let [pat (ensure-pattern pattern)]
-    (let [lines (str/split-lines content)
-          context-lines (or context-lines 2)]
-      (->> lines
-           (map-indexed vector)
-           (keep (fn [[idx line]]
-                   (when-let [match (re-find pat line)]
-                     (let [match-str (if (string? match) match (first match))
-                           start (max 0 (- idx context-lines))
-                           end (min (count lines) (+ idx context-lines 1))
-                           context-vec (subvec (vec lines) start end)]
-                       {:match match-str
-                        :line (inc idx)  ; 1-indexed
-                        :column (when-let [idx (str/index-of line match-str)]
-                                  (inc idx))
-                        :context (str/join "\n" context-vec)}))))
-           vec))))
-
-;; Content scan detection
-(defn ^{:stratum 1} any-pattern-matches-multiline?
-  "Like `any-pattern-matches?` but matches each pattern against the WHOLE content
-   rather than line-by-line, for rules whose pattern must span lines (e.g. a k8s
-   `resources:` block followed by `limits:`). Returns a one-element matches vec
-   (with the match's `:line`/`:column` and a bounded `:context` — never the whole
-   file, to avoid payload bloat and leaking unrelated content) on the first hit,
-   or nil."
-  [patterns content]
-  (some (fn [p]
-          (when-let [pat (ensure-pattern p)]
-            (let [matcher (re-matcher pat content)]
-              (when (.find matcher)
-                (let [start     (.start matcher)
-                      match-str (.group matcher)
-                      before    (subs content 0 start)
-                      last-nl   (str/last-index-of before "\n")
-                      match-cap (if (> (count match-str) 200)
-                                  (str (subs match-str 0 200) "…")
-                                  match-str)]
-                  [{:match   match-str
-                    :line    (inc (count (re-seq #"\n" before)))
-                    :column  (inc (- start (if last-nl (inc last-nl) 0)))
-                    :context match-cap}])))))
-        patterns))
-
 ;; AST analysis detection (tree-sitter CLI)
-(defn ^{:stratum 1} detect-ast-analysis
+(defn ^{:stratum 0} detect-ast-analysis
   "Detect violations by structural pattern matching via tree-sitter.
 
    Requires the tree-sitter CLI to be available on PATH.
@@ -411,7 +302,7 @@ depending on ambient namespace loading or raw var resolution."}
   [rule artifact context]
   (when (ast/tree-sitter-available?)
     (let [detection (:rule/detection rule)
-          query     (or (:query detection) (first (extract-patterns detection)))
+          query     (or (:query detection) (first (matching/extract-patterns detection)))
           content   (:artifact/content artifact)
           path      (:artifact/path artifact "")
           lang      (ast/detect-language path (:lang context))]
@@ -425,20 +316,127 @@ depending on ambient namespace loading or raw var resolution."}
              :artifact-path path
              :message       (get-in rule [:rule/enforcement :message])}))))))
 
-(defn ^{:stratum 1} plan-resource-counts
-  "Aggregate resource change counts from terraform plan output.
-   Returns {:creates int :updates int :destroys int}."
-  [plan-output]
-  (let [resources (parse-plan-resources plan-output)]
-    (reduce (fn [acc {:keys [action]}]
-              (case action
-                :create  (update acc :creates inc)
-                :destroy (update acc :destroys inc)
-                :update  (update acc :updates inc)
-                :replace (-> acc (update :creates inc) (update :destroys inc))
-                acc))
-            {:creates 0 :updates 0 :destroys 0}
-            resources)))
+(defn ^{:stratum 0} detect-content-scan
+  "Detect violations by scanning artifact content.
+
+   Looks for pattern matches in the artifact's content field.
+
+   Arguments:
+   - rule - Rule with :rule/detection config
+   - artifact - Artifact with :artifact/content
+   - context - Execution context (unused for content-scan)
+
+   Honors `:rule/detection :mode`:
+   - `:positive` (default) — a pattern MATCH is a violation.
+   - `:negative` — the ABSENCE of any pattern match is a violation (the rule
+     requires the pattern to be present, e.g. a copyright header or a k8s
+     resource limit). Applicability (file-globs, phases) scopes which artifacts
+     a negative rule can flag, so a missing pattern only fires on relevant files.
+
+   Honors `:rule/detection :multiline?`: when true the patterns are matched
+   against the whole content instead of line-by-line, so a pattern that spans
+   lines (`resources:\\n  limits:`) can match. Line-oriented patterns keep the
+   default per-line behavior.
+
+   Returns:
+   - Violation map if detected, nil otherwise"
+  [rule artifact _context]
+  (let [detection (:rule/detection rule)
+        content (:artifact/content artifact)
+        patterns (matching/extract-patterns detection)
+        context-lines (:context-lines detection 2)
+        mode (:mode detection :positive)
+        violation (fn [matches]
+                    {:type :content-scan
+                     :rule-id (:rule/id rule)
+                     :matches (vec matches)
+                     :artifact-path (:artifact/path artifact)
+                     :message (get-in rule [:rule/enforcement :message])})]
+    (when (and content (seq patterns))
+      (let [matches (if (:multiline? detection)
+                      (matching/any-pattern-matches-multiline? patterns content)
+                      (matching/any-pattern-matches? patterns content context-lines))]
+        (if (= :negative mode)
+          (when-not matches (violation nil))
+          (when matches (violation matches)))))))
+
+;; Diff analysis detection
+(defn ^{:stratum 0} detect-diff-analysis
+  "Detect violations by analyzing git diff.
+
+   Looks for pattern matches in:
+   - The artifact's diff field (if present)
+   - The context's diff field
+
+   Useful for detecting removed lines, changed patterns, etc.
+
+   Arguments:
+   - rule - Rule with :rule/detection config
+   - artifact - Artifact with optional :artifact/diff
+   - context - Context with optional :diff
+
+   Returns:
+   - Violation map if detected, nil otherwise"
+  [rule artifact context]
+  (let [detection (:rule/detection rule)
+        ;; Diff can be on artifact or in context
+        diff (or (:artifact/diff artifact)
+                 (:diff context))
+        patterns (matching/extract-patterns detection)
+        context-lines (:context-lines detection 3)]
+    (when (and diff (seq patterns))
+      (when-let [matches (matching/any-pattern-matches? patterns diff context-lines)]
+        {:type :diff-analysis
+         :rule-id (:rule/id rule)
+         :matches matches
+         :artifact-path (:artifact/path artifact)
+         :message (get-in rule [:rule/enforcement :message])}))))
+
+(defn ^{:stratum 0} detect-plan-output
+  "Detect violations by analyzing terraform plan output.
+
+   Parses plan output and checks for:
+   - Resource patterns matching replace/destroy actions
+   - Specific patterns in plan text
+
+   Arguments:
+   - rule - Rule with :rule/detection config
+   - artifact - Artifact (may contain plan output)
+   - context - Context with :terraform-plan
+
+   Returns:
+   - Violation map if detected, nil otherwise"
+  [rule artifact context]
+  (let [detection (:rule/detection rule)
+        plan-output (or (:terraform-plan context)
+                        (:artifact/content artifact))
+        patterns (matching/extract-patterns detection)
+        resource-patterns (get-in rule [:rule/applies-to :resource-patterns])]
+    (when plan-output
+      ;; Two detection modes:
+      ;; 1. Pattern match against raw plan text
+      ;; 2. Parse plan and check resource changes
+      (let [pattern-matches (when (seq patterns)
+                              (matching/any-pattern-matches? patterns plan-output 2))
+            ;; Parse resources and check for concerning actions
+            parsed (matching/parse-plan-resources plan-output)
+            resource-violations
+            (when (and (seq resource-patterns) (seq parsed))
+              (->> parsed
+                   (filter (fn [{:keys [resource action]}]
+                             (and (#{:replace :destroy} action)
+                                  (some (fn [rp]
+                                          (re-find (matching/ensure-pattern rp) resource))
+                                        resource-patterns))))
+                   seq))]
+        (when (or pattern-matches resource-violations)
+          {:type :plan-output
+           :rule-id (:rule/id rule)
+           :matches (or pattern-matches [])
+           :resource-violations (vec resource-violations)
+           :message (get-in rule [:rule/enforcement :message])})))))
+
+;------------------------------------------------------------------------------ Layer 1
 
 (defn- ^{:stratum 1} variadic-accepts-arity?
   [arity f]
@@ -504,17 +502,6 @@ depending on ambient namespace loading or raw var resolution."}
 
 ;------------------------------------------------------------------------------ Layer 2
 
-(defn ^{:stratum 2} any-pattern-matches?
-  "Check if any of the patterns match the content.
-   Returns the first matching pattern's matches, or nil."
-  [patterns content context-lines]
-  (when (seq patterns)
-    (some (fn [p]
-            (let [matches (find-matches p content context-lines)]
-              (when (seq matches)
-                matches)))
-          patterns)))
-
 (defn- ^{:stratum 2} detector-predicate?
   "True when `f` is a custom detector fn. On the JVM its 2-arity shape is verified
    by reflection; under babashka/SCI (whose fn classes expose no reflectable
@@ -567,149 +554,8 @@ depending on ambient namespace loading or raw var resolution."}
    :location (violation-location violation)
    :remediation (get-in rule [:rule/enforcement :remediation])})
 
-;------------------------------------------------------------------------------ Layer 3
-
-(defn ^{:stratum 3} detect-content-scan
-  "Detect violations by scanning artifact content.
-
-   Looks for pattern matches in the artifact's content field.
-
-   Arguments:
-   - rule - Rule with :rule/detection config
-   - artifact - Artifact with :artifact/content
-   - context - Execution context (unused for content-scan)
-
-   Honors `:rule/detection :mode`:
-   - `:positive` (default) — a pattern MATCH is a violation.
-   - `:negative` — the ABSENCE of any pattern match is a violation (the rule
-     requires the pattern to be present, e.g. a copyright header or a k8s
-     resource limit). Applicability (file-globs, phases) scopes which artifacts
-     a negative rule can flag, so a missing pattern only fires on relevant files.
-
-   Honors `:rule/detection :multiline?`: when true the patterns are matched
-   against the whole content instead of line-by-line, so a pattern that spans
-   lines (`resources:\\n  limits:`) can match. Line-oriented patterns keep the
-   default per-line behavior.
-
-   Returns:
-   - Violation map if detected, nil otherwise"
-  [rule artifact _context]
-  (let [detection (:rule/detection rule)
-        content (:artifact/content artifact)
-        patterns (extract-patterns detection)
-        context-lines (:context-lines detection 2)
-        mode (:mode detection :positive)
-        violation (fn [matches]
-                    {:type :content-scan
-                     :rule-id (:rule/id rule)
-                     :matches (vec matches)
-                     :artifact-path (:artifact/path artifact)
-                     :message (get-in rule [:rule/enforcement :message])})]
-    (when (and content (seq patterns))
-      (let [matches (if (:multiline? detection)
-                      (any-pattern-matches-multiline? patterns content)
-                      (any-pattern-matches? patterns content context-lines))]
-        (if (= :negative mode)
-          (when-not matches (violation nil))
-          (when matches (violation matches)))))))
-
-;; Diff analysis detection
-(defn ^{:stratum 3} detect-diff-analysis
-  "Detect violations by analyzing git diff.
-
-   Looks for pattern matches in:
-   - The artifact's diff field (if present)
-   - The context's diff field
-
-   Useful for detecting removed lines, changed patterns, etc.
-
-   Arguments:
-   - rule - Rule with :rule/detection config
-   - artifact - Artifact with optional :artifact/diff
-   - context - Context with optional :diff
-
-   Returns:
-   - Violation map if detected, nil otherwise"
-  [rule artifact context]
-  (let [detection (:rule/detection rule)
-        ;; Diff can be on artifact or in context
-        diff (or (:artifact/diff artifact)
-                 (:diff context))
-        patterns (extract-patterns detection)
-        context-lines (:context-lines detection 3)]
-    (when (and diff (seq patterns))
-      (when-let [matches (any-pattern-matches? patterns diff context-lines)]
-        {:type :diff-analysis
-         :rule-id (:rule/id rule)
-         :matches matches
-         :artifact-path (:artifact/path artifact)
-         :message (get-in rule [:rule/enforcement :message])}))))
-
-(defn ^{:stratum 3} detect-plan-output
-  "Detect violations by analyzing terraform plan output.
-
-   Parses plan output and checks for:
-   - Resource patterns matching replace/destroy actions
-   - Specific patterns in plan text
-
-   Arguments:
-   - rule - Rule with :rule/detection config
-   - artifact - Artifact (may contain plan output)
-   - context - Context with :terraform-plan
-
-   Returns:
-   - Violation map if detected, nil otherwise"
-  [rule artifact context]
-  (let [detection (:rule/detection rule)
-        plan-output (or (:terraform-plan context)
-                        (:artifact/content artifact))
-        patterns (extract-patterns detection)
-        resource-patterns (get-in rule [:rule/applies-to :resource-patterns])]
-    (when plan-output
-      ;; Two detection modes:
-      ;; 1. Pattern match against raw plan text
-      ;; 2. Parse plan and check resource changes
-      (let [pattern-matches (when (seq patterns)
-                              (any-pattern-matches? patterns plan-output 2))
-            ;; Parse resources and check for concerning actions
-            parsed (parse-plan-resources plan-output)
-            resource-violations
-            (when (and (seq resource-patterns) (seq parsed))
-              (->> parsed
-                   (filter (fn [{:keys [resource action]}]
-                             (and (#{:replace :destroy} action)
-                                  (some (fn [rp]
-                                          (re-find (ensure-pattern rp) resource))
-                                        resource-patterns))))
-                   seq))]
-        (when (or pattern-matches resource-violations)
-          {:type :plan-output
-           :rule-id (:rule/id rule)
-           :matches (or pattern-matches [])
-           :resource-violations (vec resource-violations)
-           :message (get-in rule [:rule/enforcement :message])})))))
-
-(defn ^{:stratum 3} register-custom-fn!
-  "Register `f` as the detector implementation for `custom-fn-sym`.
-
-   Custom policy detectors are an explicit extension point. Callers that own a
-   detector namespace should register the symbol they place in policy-pack EDN
-   before compiling or applying packs."
-  [custom-fn-sym f]
-  (when-not (symbol? custom-fn-sym)
-    (throw (ex-info "Custom detector key must be a symbol"
-                    {:custom-fn custom-fn-sym})))
-  (when-not (detector-predicate? f)
-    (throw (ex-info "Custom detector value must be a two-arity predicate function"
-                    {:custom-fn custom-fn-sym
-                     :value-type (some-> f class .getName)})))
-  (swap! custom-fn-registry assoc custom-fn-sym f)
-  f)
-
-;------------------------------------------------------------------------------ Layer 4
-
 ;; Unified detection dispatcher
-(defn ^{:stratum 4} detect-violation
+(defn ^{:stratum 2} detect-violation
   "Detect violations for a rule against an artifact.
 
    Dispatches to the appropriate detection implementation based on
@@ -741,9 +587,26 @@ depending on ambient namespace loading or raw var resolution."}
       :capability (detect-capability rule artifact context)
       nil)))
 
-;------------------------------------------------------------------------------ Layer 5
+;------------------------------------------------------------------------------ Layer 3
 
-(defn ^{:stratum 5} check-rules
+(defn ^{:stratum 3} register-custom-fn!
+  "Register `f` as the detector implementation for `custom-fn-sym`.
+
+   Custom policy detectors are an explicit extension point. Callers that own a
+   detector namespace should register the symbol they place in policy-pack EDN
+   before compiling or applying packs."
+  [custom-fn-sym f]
+  (when-not (symbol? custom-fn-sym)
+    (throw (ex-info "Custom detector key must be a symbol"
+                    {:custom-fn custom-fn-sym})))
+  (when-not (detector-predicate? f)
+    (throw (ex-info "Custom detector value must be a two-arity predicate function"
+                    {:custom-fn custom-fn-sym
+                     :value-type (some-> f class .getName)})))
+  (swap! custom-fn-registry assoc custom-fn-sym f)
+  f)
+
+(defn ^{:stratum 3} check-rules
   "Check multiple rules against an artifact.
 
    Returns vector of violations found.
@@ -801,13 +664,6 @@ depending on ambient namespace loading or raw var resolution."}
                        :message "Network resource recreation detected"}}
    {}
    {:terraform-plan "# aws_route.main will be replaced\n  -/+ aws_route.main"})
-
-  ;; Parse plan resources
-  (parse-plan-resources
-   "# aws_vpc.main will be created
-    # aws_subnet.private[0] will be destroyed
-    # aws_route.public must be replaced
-      -/+ aws_route.main (tainted)")
 
   ;; Check multiple rules
   (check-rules

--- a/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
@@ -18,23 +18,27 @@
 (ns ai.miniforge.policy-pack.detection
   "Rule violation detection implementations.
 
-   Layer 0: Pattern/plan-resource primitives, state-comparison, semantic and
-     capability detectors, violation-severity filters and formatting —
-     pure or leaf-level, no same-file dependents yet
-   Layer 1: find-matches, any-pattern-matches-multiline?, ast-analysis
-     detection, plan-resource-counts, custom-fn resolution/registration
-     helpers, violation location/message builders (over Layer 0)
-   Layer 2: any-pattern-matches?, detector-predicate?, detect-custom,
-     custom-fn-resolvable?, violation->error (over Layer 1)
-   Layer 3: detect-content-scan/diff-analysis/plan-output, register-custom-fn!
-     (over Layer 2)
-   Layer 4: detect-violation (unified per-type dispatcher, over Layer 3)
-   Layer 5: check-rules (over detect-violation)
+   Layer 0: state-comparison, semantic and capability detectors,
+     ast-analysis/content-scan/diff-analysis/plan-output detection,
+     custom-fn registry/reflection primitives, violation-severity
+     filters and formatting — pure or leaf-level, no same-file
+     dependents yet
+   Layer 1: custom-fn arity-reflection/registry helpers, violation
+     location/message builders (over Layer 0)
+   Layer 2: detector-predicate?, detect-custom, custom-fn-resolvable?,
+     violation->error, detect-violation (unified per-type dispatcher)
+     (over Layer 1)
+   Layer 3: register-custom-fn!, check-rules (over Layer 2)
 
-   Pattern-matching and terraform-plan-parsing primitives moved to the
-   sibling `detection.matching` namespace (rule 210 split, Wave 2); layer
-   count in the docstring above is stale pending the next commit's
-   `stratum-lint --fix` renumbering.
+   4 real strata — over the rule 210 budget of 3; still a genuine
+   namespace split (Wave 2) mid-train. Pattern-matching and
+   terraform-plan-parsing primitives already moved to the sibling
+   `detection.matching` namespace in this same PR; the custom-fn
+   registry/reflection mechanics (`custom-fn-registry`,
+   `declared-method?`, `reflectable-invoke?`, `variadic-accepts-arity?`,
+   `resolve-custom-fn`, `detector-predicate?`) move to
+   `detection.custom-registry` in the next PR of this train, which
+   brings this namespace down to the 3-layer budget.
 
    Supports detection types:
    - :content-scan - Regex against artifact content

--- a/components/policy-pack/src/ai/miniforge/policy_pack/detection/matching.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/detection/matching.clj
@@ -1,0 +1,185 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.detection.matching
+  "Pattern-matching and terraform-plan-parsing primitives shared by the
+   content-scan/diff-analysis/plan-output/ast-analysis detectors. Split
+   out of `ai.miniforge.policy-pack.detection` (rule 210: the combined
+   namespace measured 6 real layers, max 3) — same approach as the
+   mdc-compiler split, miniforge#1729-#1743, and the workflow-runner
+   split, miniforge#1662.
+
+   Layer 0: pattern coercion, pattern/detection-config extraction,
+     terraform plan-output line parsing — pure, no same-file dependents
+   Layer 1: find-matches (line-oriented), any-pattern-matches-multiline?,
+     plan-resource-counts (over Layer 0)
+   Layer 2: any-pattern-matches? (over Layer 1)"
+  (:require
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Pattern matching utilities
+(defn ^{:stratum 0} ensure-pattern
+  "Convert string or regex to compiled pattern."
+  [p]
+  (cond
+    (instance? java.util.regex.Pattern p) p
+    (string? p) (re-pattern p)
+    :else nil))
+
+(defn ^{:stratum 0} extract-patterns
+  "Extract pattern(s) from detection config.
+   Returns vector of patterns."
+  [detection]
+  (let [{:keys [pattern patterns]} detection]
+    (cond
+      (seq patterns) patterns
+      pattern [pattern]
+      :else [])))
+
+;; Plan output detection
+(defn ^{:stratum 0} parse-plan-resources
+  "Parse terraform plan output to extract resource changes.
+   Returns vector of {:action :resource :details}."
+  [plan-output]
+  (when plan-output
+    (let [;; Match lines like:
+          ;; "# aws_route.main will be destroyed"
+          ;; "# aws_subnet.private[0] must be replaced"
+          ;; "# aws_vpc.main will be created"
+          ;; "  -/+ aws_route.main (tainted)"
+          action-patterns
+          [{:pattern #"#\s+(\S+)\s+will be (created|destroyed|updated)"
+            :extractor (fn [[_ resource action]]
+                         {:resource resource
+                          :action (case action
+                                    "created" :create
+                                    "destroyed" :destroy
+                                    "updated" :update
+                                    (keyword action))})}
+           {:pattern #"#\s+(\S+)\s+must be (replaced)"
+            :extractor (fn [[_ resource _action]]
+                         {:resource resource
+                          :action :replace})}
+           {:pattern #"^\s*(-/\+|~|\+|-)\s+(\S+)"
+            :extractor (fn [[_ symbol resource]]
+                         {:resource resource
+                          :action (case symbol
+                                    "-/+" :replace
+                                    "~" :update
+                                    "+" :create
+                                    "-" :destroy
+                                    :unknown)})}]]
+      (->> (str/split-lines plan-output)
+           (mapcat (fn [line]
+                     (keep (fn [{:keys [pattern extractor]}]
+                             (when-let [match (re-find pattern line)]
+                               (assoc (extractor match)
+                                      :line line)))
+                           action-patterns)))
+           (distinct)
+           vec))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} find-matches
+  "Find all matches of a pattern in content.
+   Returns vector of {:match string :line int :column int :context string}."
+  [pattern content context-lines]
+  (when-let [pat (ensure-pattern pattern)]
+    (let [lines (str/split-lines content)
+          context-lines (or context-lines 2)]
+      (->> lines
+           (map-indexed vector)
+           (keep (fn [[idx line]]
+                   (when-let [match (re-find pat line)]
+                     (let [match-str (if (string? match) match (first match))
+                           start (max 0 (- idx context-lines))
+                           end (min (count lines) (+ idx context-lines 1))
+                           context-vec (subvec (vec lines) start end)]
+                       {:match match-str
+                        :line (inc idx)  ; 1-indexed
+                        :column (when-let [idx (str/index-of line match-str)]
+                                  (inc idx))
+                        :context (str/join "\n" context-vec)}))))
+           vec))))
+
+;; Content scan detection
+(defn ^{:stratum 1} any-pattern-matches-multiline?
+  "Like `any-pattern-matches?` but matches each pattern against the WHOLE content
+   rather than line-by-line, for rules whose pattern must span lines (e.g. a k8s
+   `resources:` block followed by `limits:`). Returns a one-element matches vec
+   (with the match's `:line`/`:column` and a bounded `:context` — never the whole
+   file, to avoid payload bloat and leaking unrelated content) on the first hit,
+   or nil."
+  [patterns content]
+  (some (fn [p]
+          (when-let [pat (ensure-pattern p)]
+            (let [matcher (re-matcher pat content)]
+              (when (.find matcher)
+                (let [start     (.start matcher)
+                      match-str (.group matcher)
+                      before    (subs content 0 start)
+                      last-nl   (str/last-index-of before "\n")
+                      match-cap (if (> (count match-str) 200)
+                                  (str (subs match-str 0 200) "…")
+                                  match-str)]
+                  [{:match   match-str
+                    :line    (inc (count (re-seq #"\n" before)))
+                    :column  (inc (- start (if last-nl (inc last-nl) 0)))
+                    :context match-cap}])))))
+        patterns))
+
+(defn ^{:stratum 1} plan-resource-counts
+  "Aggregate resource change counts from terraform plan output.
+   Returns {:creates int :updates int :destroys int}."
+  [plan-output]
+  (let [resources (parse-plan-resources plan-output)]
+    (reduce (fn [acc {:keys [action]}]
+              (case action
+                :create  (update acc :creates inc)
+                :destroy (update acc :destroys inc)
+                :update  (update acc :updates inc)
+                :replace (-> acc (update :creates inc) (update :destroys inc))
+                acc))
+            {:creates 0 :updates 0 :destroys 0}
+            resources)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} any-pattern-matches?
+  "Check if any of the patterns match the content.
+   Returns the first matching pattern's matches, or nil."
+  [patterns content context-lines]
+  (when (seq patterns)
+    (some (fn [p]
+            (let [matches (find-matches p content context-lines)]
+              (when (seq matches)
+                matches)))
+          patterns)))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Parse plan resources
+  (parse-plan-resources
+   "# aws_vpc.main will be created
+    # aws_subnet.private[0] will be destroyed
+    # aws_route.public must be replaced
+      -/+ aws_route.main (tainted)")
+
+  :leave-this-here)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/intent.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/intent.clj
@@ -37,7 +37,7 @@
      :refactor → Creates: 0, Updates: 0, Destroys: 0
      :migrate  → Creates: >0, Destroys: >0"
   (:require
-   [ai.miniforge.policy-pack.detection :as detection]
+   [ai.miniforge.policy-pack.detection.matching :as matching]
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -84,7 +84,7 @@
 ;; Terraform plan parsing
 (defn ^{:stratum 0} parse-terraform-plan-counts
   "Parse terraform plan output and return resource change counts.
-   Delegates to detection/plan-resource-counts (added by PR #457).
+   Delegates to matching/plan-resource-counts (added by PR #457).
 
    Arguments:
    - plan-output — Raw terraform plan output string
@@ -92,7 +92,7 @@
   Returns:
    - {:creates int :updates int :destroys int}"
   [plan-output]
-  (detection/plan-resource-counts plan-output))
+  (matching/plan-resource-counts plan-output))
 
 ;; Kubernetes diff parsing
 (defn ^{:stratum 0} parse-k8s-diff-counts

--- a/components/policy-pack/test/ai/miniforge/policy_pack/ast_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/ast_test.clj
@@ -6,7 +6,8 @@
   (:require
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.policy-pack.ast :as sut]
-   [ai.miniforge.policy-pack.detection :as detection]))
+   [ai.miniforge.policy-pack.detection :as detection]
+   [ai.miniforge.policy-pack.detection.matching :as matching]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -93,8 +94,8 @@
   (testing "counts creates, updates, destroys from plan output"
     (let [plan "# aws_vpc.main will be created\n# aws_route.old will be destroyed\n# aws_subnet.main will be updated"]
       (is (= {:creates 1 :updates 1 :destroys 1}
-             (detection/plan-resource-counts plan)))))
+             (matching/plan-resource-counts plan)))))
 
   (testing "empty plan returns zeros"
     (is (= {:creates 0 :updates 0 :destroys 0}
-           (detection/plan-resource-counts "no resources")))))
+           (matching/plan-resource-counts "no resources")))))

--- a/docs/pull-requests/2026-08-11-refactor-split-policy-pack-detection-1.md
+++ b/docs/pull-requests/2026-08-11-refactor-split-policy-pack-detection-1.md
@@ -1,0 +1,127 @@
+<!--
+  Title: Split policy-pack detection.clj — extract detection.matching (1/N)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(policy-pack): split detection.clj — extract detection.matching (1/N)
+
+## Overview
+
+`components/policy-pack/src/ai/miniforge/policy_pack/detection.clj` trips
+stratum-lint SL003: 6 distinct real layers, max 3 (rule 210,
+`standards/miniforge`). This is slice 1 of a multi-PR split following the
+mdc_compiler.clj train (miniforge#1729-#1743) and the workflow_runner.clj
+train (miniforge#1662-#1667): one cohesive concern per namespace, each new
+file within the 3-layer budget, mechanical moves only.
+
+This slice extracts `ai.miniforge.policy-pack.detection.matching`: pattern
+coercion, detection-config pattern extraction, terraform plan-output
+parsing, and the line/multiline pattern-match helpers — `ensure-pattern`,
+`extract-patterns`, `parse-plan-resources`, `find-matches`,
+`any-pattern-matches-multiline?`, `plan-resource-counts`,
+`any-pattern-matches?`. 3 real layers, stratum-lint clean.
+
+## Motivation
+
+Part of the stratum-lint rule-210 remediation program's Wave 2, policy-pack
+batch 2. `detection.clj` (823 lines) is the largest and most-depended-on
+file in this batch: 13 files repo-wide reference
+`ai.miniforge.policy-pack.detection` (confirmed via
+`grep -rlE "ai\.miniforge\.policy-pack\.detection\b"`, which catches every
+caller regardless of require `:as` alias — a prior PR in this batch was
+broken by a symbol-prefix grep that missed an aliased call site).
+
+## Changes in Detail
+
+- New file `detection/matching.clj`: the 7 pattern/plan-parsing functions
+  named above, unchanged bodies. 3 layers (L0: `ensure-pattern`,
+  `extract-patterns`, `parse-plan-resources`; L1: `find-matches`,
+  `any-pattern-matches-multiline?`, `plan-resource-counts`; L2:
+  `any-pattern-matches?`).
+- `detection.clj`: the 7 functions removed. `detect-ast-analysis`,
+  `detect-content-scan`, `detect-diff-analysis`, and `detect-plan-output`
+  now call `matching/extract-patterns`, `matching/any-pattern-matches?`,
+  `matching/any-pattern-matches-multiline?`, `matching/parse-plan-resources`,
+  and `matching/ensure-pattern` across the namespace boundary instead of
+  same-file calls. Ran `stratum-lint --fix` (folded into the pre-commit
+  hook's `lint:stratum` step) to renumber the remaining defs' `;--- Layer N`
+  headings and `^{:stratum n}` metadata: 6 → 4 real layers. Still over the
+  3-layer budget — the rest of this train brings it down further.
+- Two external callers updated, found via the fully-qualified namespace
+  grep (not a symbol-prefix guess, per the fan-in bug that hit two earlier
+  PRs in this batch):
+  - `intent.clj`'s `parse-terraform-plan-counts` now delegates to
+    `matching/plan-resource-counts` instead of
+    `detection/plan-resource-counts`; the `detection` require is replaced
+    with a `detection.matching` require (it had no other use of
+    `detection/*`).
+  - `ast_test.clj`'s `plan-resource-counts-test` now calls
+    `matching/plan-resource-counts`. The same file's
+    `state-comparison-detection-test` still calls
+    `detection/detect-state-comparison` — that detector hasn't moved — so
+    the file now requires both `detection` and `detection.matching`.
+- No other repo-wide caller referenced the seven moved functions directly
+  (confirmed against all 13 files found by the namespace grep — the other
+  11 use `detection/register-custom-fn!`, `detection/detect-violation`,
+  `detection/check-rules`, `detection/classify-violations`,
+  `detection/violation->error`, `detection/violation->warning`, and
+  similar, none of which moved in this slice).
+
+This is pure code motion — no detection logic changed, def set unchanged
+except location.
+
+## Testing Plan
+
+- `stratum-lint` clean on `detection/matching.clj` (exit 0).
+- `stratum-lint` on `detection.clj`: SL003 4 real layers (down from 6),
+  expected and tracked — not yet compliant, more slices follow.
+- `clj-kondo` clean on all four touched/added files.
+- Directly ran the three affected test namespaces (`bb test`'s
+  change-scope plus `test:precommit`/`test:graalvm` both ran clean via the
+  pre-commit hook; the direct runs below re-confirm the same after the
+  hook's stratum-lint autofix landed):
+  - `ai.miniforge.policy-pack.detection-test`: 18 tests / 91 assertions, 0
+    failures.
+  - `ai.miniforge.policy-pack.ast-test`: 7 tests / 22 assertions, 0
+    failures.
+  - `ai.miniforge.policy-pack.intent-test`: 9 tests / 33 assertions, 0
+    failures.
+- Adversarial self-review: diffed the top-level `defn`/`def` set before and
+  after — exactly 7 relocated, 0 added/removed/altered in behavior; every
+  call site update is a namespace-qualification change only.
+
+PR size: two commits, 143 and 167 reportable lines respectively (the
+second commit's actually-committed diff is larger after the pre-commit
+hook's `lint:stratum` autofix re-stages the renumbered file — expected,
+not a budget violation, since `bb commit-budget` measured the pre-hook
+staged diff). Both under the 600-line PR budget; no override needed.
+`MINIFORGE_STRATUM_BUDGET_MODE=warn` used on the second commit for the
+plain-lint pre-commit gate, given the file is intentionally still over
+budget mid-train — same convention as the mdc_compiler.clj train.
+
+## Deployment Plan
+
+Merges to `main` as part of an ongoing multi-PR train. The next slice
+extracts the custom-fn registry primitives (`custom-fn-registry`,
+`declared-method?`, `reflectable-invoke?`, `variadic-accepts-arity?`,
+`resolve-custom-fn`, `unregister-custom-fn!`, `detector-predicate?`) into
+`detection.custom-registry`. Each subsequent PR rebases onto the updated
+`main` after the prior one merges.
+
+## Related Issues/PRs
+
+- Precedent: [mdc_compiler.clj split, #1729-#1743](https://github.com/miniforge-ai/miniforge/pull/1729)
+- Precedent: [workflow_runner.clj split, #1662-#1667](https://github.com/miniforge-ai/miniforge/pull/1662)
+- Part of the stratum-lint rule-210 remediation program (Wave 2, policy-pack batch 2)
+
+## Checklist
+
+- [x] Fan-in confirmed via fully-qualified-namespace grep before starting
+      (13 files; two required call-site updates, both handled here)
+- [x] Pure code motion — no behavior change, no logic altered
+- [x] `clj-kondo` clean
+- [x] Tests green (detection-test 18/91, ast-test 7/22, intent-test 9/33)
+- [x] PR-diff and commit-diff budgets checked
+- [x] `MINIFORGE_STRATUM_BUDGET_MODE=warn` used + documented for the
+      expected intermediate over-budget state (6 → 4 layers)


### PR DESCRIPTION
<!--
  Title: Split policy-pack detection.clj — extract detection.matching (1/N)
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# refactor(policy-pack): split detection.clj — extract detection.matching (1/N)

## Overview

`components/policy-pack/src/ai/miniforge/policy_pack/detection.clj` trips
stratum-lint SL003: 6 distinct real layers, max 3 (rule 210,
`standards/miniforge`). This is slice 1 of a multi-PR split following the
mdc_compiler.clj train (miniforge#1729-#1743) and the workflow_runner.clj
train (miniforge#1662-#1667): one cohesive concern per namespace, each new
file within the 3-layer budget, mechanical moves only.

This slice extracts `ai.miniforge.policy-pack.detection.matching`: pattern
coercion, detection-config pattern extraction, terraform plan-output
parsing, and the line/multiline pattern-match helpers — `ensure-pattern`,
`extract-patterns`, `parse-plan-resources`, `find-matches`,
`any-pattern-matches-multiline?`, `plan-resource-counts`,
`any-pattern-matches?`. 3 real layers, stratum-lint clean.

## Motivation

Part of the stratum-lint rule-210 remediation program's Wave 2, policy-pack
batch 2. `detection.clj` (823 lines) is the largest and most-depended-on
file in this batch: 13 files repo-wide reference
`ai.miniforge.policy-pack.detection` (confirmed via
`grep -rlE "ai\.miniforge\.policy-pack\.detection\b"`, which catches every
caller regardless of require `:as` alias — a prior PR in this batch was
broken by a symbol-prefix grep that missed an aliased call site).

## Changes in Detail

- New file `detection/matching.clj`: the 7 pattern/plan-parsing functions
  named above, unchanged bodies. 3 layers (L0: `ensure-pattern`,
  `extract-patterns`, `parse-plan-resources`; L1: `find-matches`,
  `any-pattern-matches-multiline?`, `plan-resource-counts`; L2:
  `any-pattern-matches?`).
- `detection.clj`: the 7 functions removed. `detect-ast-analysis`,
  `detect-content-scan`, `detect-diff-analysis`, and `detect-plan-output`
  now call `matching/extract-patterns`, `matching/any-pattern-matches?`,
  `matching/any-pattern-matches-multiline?`, `matching/parse-plan-resources`,
  and `matching/ensure-pattern` across the namespace boundary instead of
  same-file calls. Ran `stratum-lint --fix` (folded into the pre-commit
  hook's `lint:stratum` step) to renumber the remaining defs' `;--- Layer N`
  headings and `^{:stratum n}` metadata: 6 → 4 real layers. Still over the
  3-layer budget — the rest of this train brings it down further.
- Two external callers updated, found via the fully-qualified namespace
  grep (not a symbol-prefix guess, per the fan-in bug that hit two earlier
  PRs in this batch):
  - `intent.clj`'s `parse-terraform-plan-counts` now delegates to
    `matching/plan-resource-counts` instead of
    `detection/plan-resource-counts`; the `detection` require is replaced
    with a `detection.matching` require (it had no other use of
    `detection/*`).
  - `ast_test.clj`'s `plan-resource-counts-test` now calls
    `matching/plan-resource-counts`. The same file's
    `state-comparison-detection-test` still calls
    `detection/detect-state-comparison` — that detector hasn't moved — so
    the file now requires both `detection` and `detection.matching`.
- No other repo-wide caller referenced the seven moved functions directly
  (confirmed against all 13 files found by the namespace grep — the other
  11 use `detection/register-custom-fn!`, `detection/detect-violation`,
  `detection/check-rules`, `detection/classify-violations`,
  `detection/violation->error`, `detection/violation->warning`, and
  similar, none of which moved in this slice).

This is pure code motion — no detection logic changed, def set unchanged
except location.

## Testing Plan

- `stratum-lint` clean on `detection/matching.clj` (exit 0).
- `stratum-lint` on `detection.clj`: SL003 4 real layers (down from 6),
  expected and tracked — not yet compliant, more slices follow.
- `clj-kondo` clean on all four touched/added files.
- Directly ran the three affected test namespaces (`bb test`'s
  change-scope plus `test:precommit`/`test:graalvm` both ran clean via the
  pre-commit hook; the direct runs below re-confirm the same after the
  hook's stratum-lint autofix landed):
  - `ai.miniforge.policy-pack.detection-test`: 18 tests / 91 assertions, 0
    failures.
  - `ai.miniforge.policy-pack.ast-test`: 7 tests / 22 assertions, 0
    failures.
  - `ai.miniforge.policy-pack.intent-test`: 9 tests / 33 assertions, 0
    failures.
- Adversarial self-review: diffed the top-level `defn`/`def` set before and
  after — exactly 7 relocated, 0 added/removed/altered in behavior; every
  call site update is a namespace-qualification change only.

PR size: two commits, 143 and 167 reportable lines respectively (the
second commit's actually-committed diff is larger after the pre-commit
hook's `lint:stratum` autofix re-stages the renumbered file — expected,
not a budget violation, since `bb commit-budget` measured the pre-hook
staged diff). Both under the 600-line PR budget; no override needed.
`MINIFORGE_STRATUM_BUDGET_MODE=warn` used on the second commit for the
plain-lint pre-commit gate, given the file is intentionally still over
budget mid-train — same convention as the mdc_compiler.clj train.

## Deployment Plan

Merges to `main` as part of an ongoing multi-PR train. The next slice
extracts the custom-fn registry primitives (`custom-fn-registry`,
`declared-method?`, `reflectable-invoke?`, `variadic-accepts-arity?`,
`resolve-custom-fn`, `unregister-custom-fn!`, `detector-predicate?`) into
`detection.custom-registry`. Each subsequent PR rebases onto the updated
`main` after the prior one merges.

## Related Issues/PRs

- Precedent: [mdc_compiler.clj split, #1729-#1743](https://github.com/miniforge-ai/miniforge/pull/1729)
- Precedent: [workflow_runner.clj split, #1662-#1667](https://github.com/miniforge-ai/miniforge/pull/1662)
- Part of the stratum-lint rule-210 remediation program (Wave 2, policy-pack batch 2)

## Checklist

- [x] Fan-in confirmed via fully-qualified-namespace grep before starting
      (13 files; two required call-site updates, both handled here)
- [x] Pure code motion — no behavior change, no logic altered
- [x] `clj-kondo` clean
- [x] Tests green (detection-test 18/91, ast-test 7/22, intent-test 9/33)
- [x] PR-diff and commit-diff budgets checked
- [x] `MINIFORGE_STRATUM_BUDGET_MODE=warn` used + documented for the
      expected intermediate over-budget state (6 → 4 layers)