### PR TITLE
refactor(policy-pack): split registry.clj (rule 210)

### DIFF
--- a/components/policy-pack/src/ai/miniforge/policy_pack/applicability.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/applicability.clj
@@ -27,7 +27,7 @@
    Layer 1: filter-applicable-rules (over all three Layer 0 predicates plus
      the rule's :rule/enabled? flag)"
   (:require
-   [ai.miniforge.policy-pack.registry :as registry]))
+   [ai.miniforge.policy-pack.registry.support :as registry-support]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -46,7 +46,7 @@
         path (:artifact/path artifact "")]
     (or (nil? file-globs)
         (empty? file-globs)
-        (some #(registry/glob-matches? % path) file-globs))))
+        (some #(registry-support/glob-matches? % path) file-globs))))
 
 (defn ^{:stratum 0} rule-applies-to-task?
   "Check if a rule applies to a task type.

--- a/components/policy-pack/src/ai/miniforge/policy_pack/external.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/external.clj
@@ -31,7 +31,7 @@
    (Wave 2), not a labeling problem."
   (:require
    [ai.miniforge.policy-pack.core :as core]
-   [ai.miniforge.policy-pack.registry :as registry]
+   [ai.miniforge.policy-pack.registry.support :as registry-support]
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -93,7 +93,7 @@
   "True if any path in `paths` matches any pattern in `globs`."
   [paths globs]
   (some (fn [path]
-          (some #(path-matches-glob? registry/glob-matches? % path) globs))
+          (some #(path-matches-glob? registry-support/glob-matches? % path) globs))
         paths))
 
 ;------------------------------------------------------------------------------ Layer 2

--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface/registry.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface/registry.clj
@@ -18,7 +18,8 @@
 (ns ai.miniforge.policy-pack.interface.registry
   "Registry-facing policy-pack API."
   (:require
-   [ai.miniforge.policy-pack.registry :as registry]))
+   [ai.miniforge.policy-pack.registry :as registry]
+   [ai.miniforge.policy-pack.registry.support :as registry-support]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -76,10 +77,10 @@
   "Predicate. (glob-matches? pattern path) returns true when path matches the
    glob pattern (supports * within a segment and ** across segments); false on
    no match or a bad pattern."
-  registry/glob-matches?)
+  registry-support/glob-matches?)
 
 (def ^{:stratum 0} compare-versions
   "Compare two DateVer (YYYY.MM.DD) version strings. Returns a negative int if
    a < b, 0 if equal, positive if a > b; unparseable versions compare as
    [0 0 0]."
-  registry/compare-versions)
+  registry-support/compare-versions)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/registry.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/registry.clj
@@ -18,21 +18,23 @@
 (ns ai.miniforge.policy-pack.registry
   "Policy pack registry protocol and in-memory implementation.
 
-   Layer 0: PolicyPackRegistry protocol, parse-datever, glob-matches?,
-     dedupe-by-id
-   Layer 1: compare-versions, rule-applies? (over parse-datever/glob-matches?)
-   Layer 2: latest-version (over compare-versions)
-   Layer 3: InMemoryPackRegistry (implements the Layer 0 protocol, uses
-     latest-version/rule-applies?/dedupe-by-id)
-   Layer 4: create-registry (constructs InMemoryPackRegistry)
+   Version comparison, glob matching, rule applicability, dedup, and
+   signature decoding live in `ai.miniforge.policy-pack.registry.support`
+   (rule 210: the combined namespace measured 5 real layers, over the
+   budget of 3 — a genuine namespace split (Wave 2), not a labeling
+   problem).
 
-   5 real strata — over the rule 210 budget of 3; a genuine namespace split
-   (Wave 2), not a labeling problem."
+   Layer 0: t (translator), PolicyPackRegistry protocol
+   Layer 1: InMemoryPackRegistry (implements the Layer 0 protocol, uses
+     support/latest-version, support/rule-applies?, support/dedupe-by-id,
+     support/decode-signature)
+   Layer 2: create-registry (constructs InMemoryPackRegistry)"
   (:require
    [ai.miniforge.anomaly.interface :as anomaly]
    [ai.miniforge.messages.interface :as messages]
    [ai.miniforge.policy-pack.canonical-edn :as canonical-edn]
    [ai.miniforge.policy-pack.crypto :as crypto]
+   [ai.miniforge.policy-pack.registry.support :as support]
    [ai.miniforge.policy-pack.schema :as schema]
    [ai.miniforge.policy-pack.trust-roots :as trust-roots]
    [ai.miniforge.policy-pack.trust-roots-config :as trust-roots-config]
@@ -118,110 +120,11 @@
      - :phase - Current workflow phase
      Returns vector of applicable rules."))
 
-;; Version comparison helpers
-(defn ^{:stratum 0} parse-datever
-  "Parse DateVer string (YYYY.MM.DD) into comparable vector."
-  [version-str]
-  (when version-str
-    (try
-      (mapv parse-long (str/split version-str #"\."))
-      (catch Exception _
-        nil))))
-
-;; Rule applicability checking
-(defn ^{:stratum 0} glob-matches?
-  "Simple glob pattern matching.
-   Supports * (any within segment) and ** (any path segments)."
-  [pattern path]
-  (let [regex-pattern (str "^"
-                          (-> pattern
-                              (str/replace "." "\\.")
-                              (str/replace "**/" "<<<GLOBSTAR_SLASH>>>")
-                              (str/replace "**" "<<<GLOBSTAR>>>")
-                              (str/replace "*" "[^/]*")
-                              (str/replace "<<<GLOBSTAR_SLASH>>>" "(.*/)?")
-                              (str/replace "<<<GLOBSTAR>>>" ".*"))
-                          "$")]
-    (try
-      (boolean (re-matches (re-pattern regex-pattern) path))
-      (catch Exception _
-        false))))
-
-(defn ^{:stratum 0} decode-signature
-  "Base64 pack signature to bytes; nil when the field is not a string or not
-   base64. A pack reaching verification has not necessarily been through
-   schema validation, so the type check belongs here."
-  [sig-str]
-  (when (string? sig-str)
-    (try
-      (.decode (java.util.Base64/getDecoder) ^String sig-str)
-      (catch IllegalArgumentException _
-        nil))))
-
-(defn ^{:stratum 0} dedupe-by-id
-  "Remove duplicate rules, keeping the last occurrence (later pack wins)."
-  [rules]
-  (vals (reduce (fn [acc rule]
-                  (assoc acc (:rule/id rule) rule))
-                {}
-                rules)))
-
 ;------------------------------------------------------------------------------ Layer 1
-
-(defn ^{:stratum 1} compare-versions
-  "Compare two DateVer version strings.
-   Returns negative if a < b, 0 if equal, positive if a > b."
-  [a b]
-  (let [va (or (parse-datever a) [0 0 0])
-        vb (or (parse-datever b) [0 0 0])]
-    (compare va vb)))
-
-(defn ^{:stratum 1} rule-applies?
-  "Check if a rule applies to the given context.
-
-   Context map:
-   - :task - Task with :task/intent containing :intent/type
-   - :artifact - Artifact with :artifact/path, :artifact/type
-   - :repo - Repository with :repo/type
-   - :phase - Current workflow phase keyword"
-  [rule context]
-  (let [{:keys [task-types file-globs repo-types phases]}
-        (:rule/applies-to rule)]
-    (and
-     ;; Task type filter
-     (or (nil? task-types)
-         (empty? task-types)
-         (contains? task-types (get-in context [:task :task/intent :intent/type])))
-
-     ;; File glob filter
-     (or (nil? file-globs)
-         (empty? file-globs)
-         (let [path (get-in context [:artifact :artifact/path] "")]
-           (some #(glob-matches? % path) file-globs)))
-
-     ;; Repo type filter
-     (or (nil? repo-types)
-         (empty? repo-types)
-         (contains? repo-types (get-in context [:repo :repo/type])))
-
-     ;; Phase filter
-     (or (nil? phases)
-         (empty? phases)
-         (contains? phases (:phase context))))))
-
-;------------------------------------------------------------------------------ Layer 2
-
-(defn ^{:stratum 2} latest-version
-  "Get the latest version from a collection of version strings."
-  [versions]
-  (when (seq versions)
-    (first (sort-by identity (comparator #(pos? (compare-versions %1 %2))) versions))))
-
-;------------------------------------------------------------------------------ Layer 3
 
 ;; In-memory registry implementation. `trust-roots` (N4 §8.2.1) sits outside
 ;; `state` because it is fixed configuration, not state a caller mutates.
-(defrecord ^{:stratum 3} InMemoryPackRegistry [state trust-roots]
+(defrecord ^{:stratum 1} InMemoryPackRegistry [state trust-roots]
   PolicyPackRegistry
 
   (register-pack [_this pack]
@@ -240,7 +143,7 @@
   (get-pack [this pack-id]
     (let [versions (get-in @state [:packs pack-id])]
       (when (seq versions)
-        (let [latest (latest-version (keys versions))]
+        (let [latest (support/latest-version (keys versions))]
           (get-pack-version this pack-id latest)))))
 
   (get-pack-version [_this pack-id version]
@@ -333,7 +236,7 @@
 
         :else
         (if-let [pub-bytes (trust-roots/resolve-key trust-roots key-id)]
-          (if-let [sig-bytes (decode-signature sig-str)]
+          (if-let [sig-bytes (support/decode-signature sig-str)]
             (merge claimed
                    (crypto/verify-ed25519 (canonical-edn/pack-signable-bytes pack)
                                           sig-bytes
@@ -365,14 +268,14 @@
     (let [resolved-packs (keep #(resolve-pack this %) pack-ids)
           all-rules (mapcat :pack/rules resolved-packs)]
       (->> all-rules
-           (filter #(rule-applies? % context))
-           (dedupe-by-id)
+           (filter #(support/rule-applies? % context))
+           (support/dedupe-by-id)
            vec))))
 
-;------------------------------------------------------------------------------ Layer 4
+;------------------------------------------------------------------------------ Layer 2
 
 ;; Registry constructors
-(defn ^{:stratum 4} create-registry
+(defn ^{:stratum 2} create-registry
   "Create an in-memory policy pack registry.
 
    Options:
@@ -431,22 +334,5 @@
                          ["test-pack"]
                          {:artifact {:artifact/path "main.tf"}
                           :phase :implement})
-
-  ;; Version comparison
-  (compare-versions "2026.01.22" "2026.01.15")
-  ;; => 7 (positive, first is later)
-
-  (latest-version ["2025.12.01" "2026.01.22" "2026.01.15"])
-  ;; => "2026.01.22"
-
-  ;; Glob matching
-  (glob-matches? "**/*.tf" "modules/vpc/main.tf")
-  ;; => true
-
-  (glob-matches? "*.tf" "main.tf")
-  ;; => true
-
-  (glob-matches? "*.tf" "modules/main.tf")
-  ;; => false
 
   :leave-this-here)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/registry/support.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/registry/support.clj
@@ -1,0 +1,154 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.registry.support
+  "Version comparison, glob matching, rule applicability, dedup, and
+   signature-decoding helpers for `ai.miniforge.policy-pack.registry`.
+
+   Split out of `registry` (rule 210: the combined namespace measured 5
+   real layers, over the budget of 3) — the protocol, the stateful
+   InMemoryPackRegistry, and the registry constructor stay in the
+   parent namespace; the pure functions they compose live here.
+
+   Layer 0: parse-datever, glob-matches?, decode-signature, dedupe-by-id
+   Layer 1: compare-versions (over parse-datever), rule-applies? (over
+     glob-matches?)
+   Layer 2: latest-version (over compare-versions)"
+  (:require
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Version comparison helpers
+(defn ^{:stratum 0} parse-datever
+  "Parse DateVer string (YYYY.MM.DD) into comparable vector."
+  [version-str]
+  (when version-str
+    (try
+      (mapv parse-long (str/split version-str #"\."))
+      (catch Exception _
+        nil))))
+
+;; Rule applicability checking
+(defn ^{:stratum 0} glob-matches?
+  "Simple glob pattern matching.
+   Supports * (any within segment) and ** (any path segments)."
+  [pattern path]
+  (let [regex-pattern (str "^"
+                          (-> pattern
+                              (str/replace "." "\\.")
+                              (str/replace "**/" "<<<GLOBSTAR_SLASH>>>")
+                              (str/replace "**" "<<<GLOBSTAR>>>")
+                              (str/replace "*" "[^/]*")
+                              (str/replace "<<<GLOBSTAR_SLASH>>>" "(.*/)?")
+                              (str/replace "<<<GLOBSTAR>>>" ".*"))
+                          "$")]
+    (try
+      (boolean (re-matches (re-pattern regex-pattern) path))
+      (catch Exception _
+        false))))
+
+(defn ^{:stratum 0} decode-signature
+  "Base64 pack signature to bytes; nil when the field is not a string or not
+   base64. A pack reaching verification has not necessarily been through
+   schema validation, so the type check belongs here."
+  [sig-str]
+  (when (string? sig-str)
+    (try
+      (.decode (java.util.Base64/getDecoder) ^String sig-str)
+      (catch IllegalArgumentException _
+        nil))))
+
+(defn ^{:stratum 0} dedupe-by-id
+  "Remove duplicate rules, keeping the last occurrence (later pack wins)."
+  [rules]
+  (vals (reduce (fn [acc rule]
+                  (assoc acc (:rule/id rule) rule))
+                {}
+                rules)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} compare-versions
+  "Compare two DateVer version strings.
+   Returns negative if a < b, 0 if equal, positive if a > b."
+  [a b]
+  (let [va (or (parse-datever a) [0 0 0])
+        vb (or (parse-datever b) [0 0 0])]
+    (compare va vb)))
+
+(defn ^{:stratum 1} rule-applies?
+  "Check if a rule applies to the given context.
+
+   Context map:
+   - :task - Task with :task/intent containing :intent/type
+   - :artifact - Artifact with :artifact/path, :artifact/type
+   - :repo - Repository with :repo/type
+   - :phase - Current workflow phase keyword"
+  [rule context]
+  (let [{:keys [task-types file-globs repo-types phases]}
+        (:rule/applies-to rule)]
+    (and
+     ;; Task type filter
+     (or (nil? task-types)
+         (empty? task-types)
+         (contains? task-types (get-in context [:task :task/intent :intent/type])))
+
+     ;; File glob filter
+     (or (nil? file-globs)
+         (empty? file-globs)
+         (let [path (get-in context [:artifact :artifact/path] "")]
+           (some #(glob-matches? % path) file-globs)))
+
+     ;; Repo type filter
+     (or (nil? repo-types)
+         (empty? repo-types)
+         (contains? repo-types (get-in context [:repo :repo/type])))
+
+     ;; Phase filter
+     (or (nil? phases)
+         (empty? phases)
+         (contains? phases (:phase context))))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} latest-version
+  "Get the latest version from a collection of version strings."
+  [versions]
+  (when (seq versions)
+    (first (sort-by identity (comparator #(pos? (compare-versions %1 %2))) versions))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Version comparison
+  (compare-versions "2026.01.22" "2026.01.15")
+  ;; => 7 (positive, first is later)
+
+  (latest-version ["2025.12.01" "2026.01.22" "2026.01.15"])
+  ;; => "2026.01.22"
+
+  ;; Glob matching
+  (glob-matches? "**/*.tf" "modules/vpc/main.tf")
+  ;; => true
+
+  (glob-matches? "*.tf" "main.tf")
+  ;; => true
+
+  (glob-matches? "*.tf" "modules/main.tf")
+  ;; => false
+
+  :leave-this-here)

--- a/docs/pull-requests/2026-08-11-refactor-split-policy-pack-registry.md
+++ b/docs/pull-requests/2026-08-11-refactor-split-policy-pack-registry.md
@@ -1,0 +1,135 @@
+<!--
+  Title: Split policy-pack/registry.clj (rule 210)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(policy-pack): split registry.clj (rule 210)
+
+## Overview
+
+Splits `ai.miniforge.policy-pack.registry`'s pure version-comparison,
+glob-matching, rule-applicability, dedup, and signature-decoding
+helpers out into a new sibling namespace,
+`ai.miniforge.policy-pack.registry.support`, resolving a stratum-lint
+SL003 finding (the combined namespace measured 5 real layers, over
+the rule 210 budget of 3).
+
+## Motivation
+
+Part of the stratum-lint rule-210 remediation program's policy-pack
+Wave 2, batch 2. `registry.clj` (452 lines) is the CRUD/composition
+protocol for policy packs plus its in-memory implementation — six
+files repo-wide reference the namespace (not a zero-fan-in file), so
+every caller needed checking, not just the definitions.
+
+## Changes in Detail
+
+- New file `registry/support.clj`: `parse-datever`, `glob-matches?`,
+  `decode-signature`, `dedupe-by-id` (Layer 0), `compare-versions`,
+  `rule-applies?` (Layer 1, over `parse-datever`/`glob-matches?`),
+  `latest-version` (Layer 2, over `compare-versions`) — 3 layers.
+  Committed as a new-file-only commit ahead of the wire-up, same
+  pattern as `knowledge_safety.clj` (#1731 refers to it as
+  `detectors.clj`) and the `workflow_runner.clj` train
+  (miniforge#1662-#1667).
+- `registry.clj`: keeps the `PolicyPackRegistry` protocol and the `t`
+  translator (Layer 0), the `InMemoryPackRegistry` defrecord (Layer 1,
+  now calling `support/latest-version`, `support/rule-applies?`,
+  `support/dedupe-by-id`, `support/decode-signature` via the qualified
+  require instead of same-file symbols), and `create-registry`
+  (Layer 2) — down from 5 real layers to 3.
+- `interface/registry.clj`: the component's Polylith interface
+  re-exports `glob-matches?` and `compare-versions` as public defs;
+  both now point at `registry-support/*` instead of `registry/*`. The
+  umbrella `ai.miniforge.policy-pack.interface` re-exports these
+  transitively through `interface.registry` and needed no direct
+  change.
+- `applicability.clj` and `external.clj`: both called
+  `registry/glob-matches?` directly; both now require
+  `ai.miniforge.policy-pack.registry.support` instead of
+  `ai.miniforge.policy-pack.registry` (that was their only use of the
+  `registry` namespace) and call `registry-support/glob-matches?`.
+- No other caller needed changes. `registry_signature_test.clj` and
+  `anomaly/registry_anomaly_test.clj` only call symbols that stayed in
+  `registry.clj` (`create-registry`, `verify-signature`,
+  `->InMemoryPackRegistry`, `register-pack`, `import-pack`,
+  `export-pack`). `rules/pack_version_constraint_test.clj`'s
+  `#'sut/compare-versions` looked like a possible fourth caller from a
+  symbol-only grep, but `sut` there aliases
+  `pack-dependency-validation`, an unrelated namespace with its own
+  `compare-versions` — confirmed by reading the file's `ns` form, not
+  assumed.
+
+This is pure code motion — no logic changes. The def set is unchanged;
+every moved function's body, docstring, and `:stratum` metadata is
+byte-for-byte identical to what it was in `registry.clj` (the Layer
+0/1/2 grouping in `support.clj` mirrors the original file's own
+Layer 0/1/2, before its Layer 3/4 `InMemoryPackRegistry`/
+`create-registry` collapse to Layer 1/2 in the parent).
+
+`external.clj` carries its own pre-existing, unrelated SL003 finding
+(5 real layers, already documented in its own namespace docstring as
+part of this same sweep's queue) — only its `:require` and one call
+site changed here, not its layer structure, so the wire-up commit used
+`MINIFORGE_STRATUM_BUDGET_MODE=warn` to avoid blocking on a violation
+this PR doesn't touch.
+
+## Testing Plan
+
+- `stratum-lint` clean (exit 0) on `registry.clj`,
+  `registry/support.clj`, `applicability.clj`, and
+  `interface/registry.clj` — the four in-scope files. `external.clj`
+  still reports its pre-existing SL003 (documented above, tracked
+  separately).
+- `clj-kondo` clean (0 errors, 0 warnings) across all five touched/new
+  files.
+- Repo-wide fan-in grep for the fully-qualified namespace
+  (`ai\.miniforge\.policy-pack\.registry\b`) across `components`,
+  `bases`, and `projects` before starting: six callers found, all
+  accounted for above. `projects/miniforge/test/` specifically checked
+  and clean — no project-level integration test references this
+  namespace.
+- Full `policy-pack` component test suite run directly (`clojure -M
+  -e ...`) rather than only through `bb test`, since this session's
+  `bb test` was contending with a large number of concurrent sibling
+  rule-210 split PRs running in parallel worktrees on the same
+  machine: 294 tests, 2689 assertions, 0 failures, 0 errors. The four
+  tests directly touching this change
+  (`registry-signature-test`, `anomaly.registry-anomaly-test`,
+  `interface-test`, `external-test`) also verified in isolation: 33
+  tests, 144 assertions, 0 failures.
+- Both commits' pre-commit hooks (`clojure -M:poly check`, clj-kondo,
+  stratum-lint, and the pre-commit smoke suite: 345 tests / 1301
+  assertions component-smoke + 8 tests / 623 assertions GraalVM
+  compatibility) passed clean.
+
+## Deployment Plan
+
+Merges to `main` immediately; no follow-up needed for this file. This
+was task #15 of the policy-pack Wave 2 batch 2 sweep; the sweep
+continues with other files in the queue (`external.clj`'s own SL003
+finding among them).
+
+## Related Issues/PRs
+
+- Part of the stratum-lint rule-210 Wave 2 continuation — see
+  `knowledge_safety.clj` (miniforge#1731) for the sibling-namespace +
+  new-file-then-wire-up convention this follows, and
+  `workflow_runner.clj` (miniforge#1662-#1667) for the original
+  two-commit-PR pattern.
+
+## Checklist
+
+- [x] stratum-lint clean on all four in-scope resulting files
+- [x] Full policy-pack component test suite green (294 tests / 2689
+      assertions), plus the four directly-affected test namespaces in
+      isolation
+- [x] Adversarial self-review: def set unchanged (relocated only), no
+      logic changes
+- [x] Fan-in confirmed via fully-qualified-namespace grep across
+      components, bases, and projects; every caller updated or
+      confirmed unaffected
+- [x] PR budget: 228 reportable lines total, split 98/130 across two
+      commits (both under the 200-line commit ceiling), well under the
+      600-line PR ceiling


### PR DESCRIPTION
<!--
  Title: Split policy-pack/registry.clj (rule 210)
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# refactor(policy-pack): split registry.clj (rule 210)

## Overview

Splits `ai.miniforge.policy-pack.registry`'s pure version-comparison,
glob-matching, rule-applicability, dedup, and signature-decoding
helpers out into a new sibling namespace,
`ai.miniforge.policy-pack.registry.support`, resolving a stratum-lint
SL003 finding (the combined namespace measured 5 real layers, over
the rule 210 budget of 3).

## Motivation

Part of the stratum-lint rule-210 remediation program's policy-pack
Wave 2, batch 2. `registry.clj` (452 lines) is the CRUD/composition
protocol for policy packs plus its in-memory implementation — six
files repo-wide reference the namespace (not a zero-fan-in file), so
every caller needed checking, not just the definitions.

## Changes in Detail

- New file `registry/support.clj`: `parse-datever`, `glob-matches?`,
  `decode-signature`, `dedupe-by-id` (Layer 0), `compare-versions`,
  `rule-applies?` (Layer 1, over `parse-datever`/`glob-matches?`),
  `latest-version` (Layer 2, over `compare-versions`) — 3 layers.
  Committed as a new-file-only commit ahead of the wire-up, same
  pattern as `knowledge_safety.clj` (#1731 refers to it as
  `detectors.clj`) and the `workflow_runner.clj` train
  (miniforge#1662-#1667).
- `registry.clj`: keeps the `PolicyPackRegistry` protocol and the `t`
  translator (Layer 0), the `InMemoryPackRegistry` defrecord (Layer 1,
  now calling `support/latest-version`, `support/rule-applies?`,
  `support/dedupe-by-id`, `support/decode-signature` via the qualified
  require instead of same-file symbols), and `create-registry`
  (Layer 2) — down from 5 real layers to 3.
- `interface/registry.clj`: the component's Polylith interface
  re-exports `glob-matches?` and `compare-versions` as public defs;
  both now point at `registry-support/*` instead of `registry/*`. The
  umbrella `ai.miniforge.policy-pack.interface` re-exports these
  transitively through `interface.registry` and needed no direct
  change.
- `applicability.clj` and `external.clj`: both called
  `registry/glob-matches?` directly; both now require
  `ai.miniforge.policy-pack.registry.support` instead of
  `ai.miniforge.policy-pack.registry` (that was their only use of the
  `registry` namespace) and call `registry-support/glob-matches?`.
- No other caller needed changes. `registry_signature_test.clj` and
  `anomaly/registry_anomaly_test.clj` only call symbols that stayed in
  `registry.clj` (`create-registry`, `verify-signature`,
  `->InMemoryPackRegistry`, `register-pack`, `import-pack`,
  `export-pack`). `rules/pack_version_constraint_test.clj`'s
  `#'sut/compare-versions` looked like a possible fourth caller from a
  symbol-only grep, but `sut` there aliases
  `pack-dependency-validation`, an unrelated namespace with its own
  `compare-versions` — confirmed by reading the file's `ns` form, not
  assumed.

This is pure code motion — no logic changes. The def set is unchanged;
every moved function's body, docstring, and `:stratum` metadata is
byte-for-byte identical to what it was in `registry.clj` (the Layer
0/1/2 grouping in `support.clj` mirrors the original file's own
Layer 0/1/2, before its Layer 3/4 `InMemoryPackRegistry`/
`create-registry` collapse to Layer 1/2 in the parent).

`external.clj` carries its own pre-existing, unrelated SL003 finding
(5 real layers, already documented in its own namespace docstring as
part of this same sweep's queue) — only its `:require` and one call
site changed here, not its layer structure, so the wire-up commit used
`MINIFORGE_STRATUM_BUDGET_MODE=warn` to avoid blocking on a violation
this PR doesn't touch.

## Testing Plan

- `stratum-lint` clean (exit 0) on `registry.clj`,
  `registry/support.clj`, `applicability.clj`, and
  `interface/registry.clj` — the four in-scope files. `external.clj`
  still reports its pre-existing SL003 (documented above, tracked
  separately).
- `clj-kondo` clean (0 errors, 0 warnings) across all five touched/new
  files.
- Repo-wide fan-in grep for the fully-qualified namespace
  (`ai\.miniforge\.policy-pack\.registry\b`) across `components`,
  `bases`, and `projects` before starting: six callers found, all
  accounted for above. `projects/miniforge/test/` specifically checked
  and clean — no project-level integration test references this
  namespace.
- Full `policy-pack` component test suite run directly (`clojure -M
  -e ...`) rather than only through `bb test`, since this session's
  `bb test` was contending with a large number of concurrent sibling
  rule-210 split PRs running in parallel worktrees on the same
  machine: 294 tests, 2689 assertions, 0 failures, 0 errors. The four
  tests directly touching this change
  (`registry-signature-test`, `anomaly.registry-anomaly-test`,
  `interface-test`, `external-test`) also verified in isolation: 33
  tests, 144 assertions, 0 failures.
- Both commits' pre-commit hooks (`clojure -M:poly check`, clj-kondo,
  stratum-lint, and the pre-commit smoke suite: 345 tests / 1301
  assertions component-smoke + 8 tests / 623 assertions GraalVM
  compatibility) passed clean.

## Deployment Plan

Merges to `main` immediately; no follow-up needed for this file. This
was task #15 of the policy-pack Wave 2 batch 2 sweep; the sweep
continues with other files in the queue (`external.clj`'s own SL003
finding among them).

## Related Issues/PRs

- Part of the stratum-lint rule-210 Wave 2 continuation — see
  `knowledge_safety.clj` (miniforge#1731) for the sibling-namespace +
  new-file-then-wire-up convention this follows, and
  `workflow_runner.clj` (miniforge#1662-#1667) for the original
  two-commit-PR pattern.

## Checklist

- [x] stratum-lint clean on all four in-scope resulting files
- [x] Full policy-pack component test suite green (294 tests / 2689
      assertions), plus the four directly-affected test namespaces in
      isolation
- [x] Adversarial self-review: def set unchanged (relocated only), no
      logic changes
- [x] Fan-in confirmed via fully-qualified-namespace grep across
      components, bases, and projects; every caller updated or
      confirmed unaffected
- [x] PR budget: 228 reportable lines total, split 98/130 across two
      commits (both under the 200-line commit ceiling), well under the
      600-line PR ceiling
