### PR TITLE
refactor(policy-pack): split compiler.clj (rule 210)

### DIFF
--- a/components/policy-pack/src/ai/miniforge/policy_pack/compiler.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/compiler.clj
@@ -41,78 +41,44 @@
 
    All public fns return data: a failed compilation yields an :invalid-input
    anomaly map (N4 §3.1 — anomalies are data at the component interface),
-   never a throw."
+   never a throw.
+
+   Split (rule 210: this namespace originally measured 8 real layers, max 3)
+   across three siblings, each an earlier stage of the same pipeline:
+   `compiler.check` (detector resolution + result/violation construction),
+   `compiler.artifacts` (N4 check-input normalization, required by
+   `compiler.check`), and `compiler.rule` (the executable check-fn built on
+   top of `compiler.check`). `resolve-detector`, `rule-enabled?`, and
+   `compile-rule-check` stay part of this namespace's public surface as thin
+   re-exports so every existing caller (`ai.miniforge.policy-pack.compiler/…`)
+   is unaffected; pack-level compilation — this namespace's own reason to
+   exist — stays here with its real implementation.
+
+   Layer 0: resolve-detector, rule-enabled?, compile-rule-check (re-exports),
+     anomaly-rule-id, compiled-entry-detector
+   Layer 1: compile-pack-checks
+   Layer 2: compile-pack"
   (:require
    [ai.miniforge.anomaly.interface :as anomaly]
-   [ai.miniforge.policy-pack.capability :as capability]
-   [ai.miniforge.policy-pack.detection :as detection]))
+   [ai.miniforge.policy-pack.compiler.check :as check]
+   [ai.miniforge.policy-pack.compiler.rule :as rule]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
-;; Per-rule classification
-(def ^{:stratum 0} ^{:doc "Detection types that bind to a mechanism directly by their type."}
-  by-type-detectors
-  #{:content-scan :diff-analysis :plan-output :state-comparison :ast-analysis})
+(def ^{:stratum 0} resolve-detector
+  "Return the detection-mechanism keyword that `rule` binds to.
+   See `ai.miniforge.policy-pack.compiler.check/resolve-detector`."
+  check/resolve-detector)
 
-(defn ^{:stratum 0} rule-enabled?
+(def ^{:stratum 0} rule-enabled?
   "True unless the rule explicitly sets `:rule/enabled?` to false.
-   A missing `:rule/enabled?` means enabled (the shipped pack omits it)."
-  [rule]
-  (not (false? (:rule/enabled? rule))))
+   See `ai.miniforge.policy-pack.compiler.check/rule-enabled?`."
+  check/rule-enabled?)
 
-(defn- ^{:stratum 0} detector-class
-  [detector]
-  (if (= :semantic detector)
-    :heuristic
-    :deterministic))
-
-(defn- ^{:stratum 0} code-files
-  [artifacts]
-  (or (get artifacts :code/files)
-      (get artifacts :files)))
-
-(defn- ^{:stratum 0} code-files-present?
-  [artifacts]
-  (or (contains? artifacts :code/files)
-      (contains? artifacts :files)))
-
-(defn- ^{:stratum 0} file-entry->artifact
-  [file-entry]
-  (let [path    (or (get file-entry :artifact/path)
-                    (get file-entry :path))
-        content (or (get file-entry :artifact/content)
-                    (get file-entry :content))]
-    (cond-> file-entry
-      path    (assoc :artifact/path path)
-      content (assoc :artifact/content content))))
-
-(defn- ^{:stratum 0} semantic-context-ready?
-  [context]
-  (and (fn? (:semantic-analyze-fn context))
-       (some? (:llm-client context))
-       (fn? (:complete-fn context))))
-
-(defn- ^{:stratum 0} violation-with-rule
-  [rule violation]
-  (assoc violation
-         :rule-id  (or (:rule-id violation) (:rule/id rule))
-         :severity (or (:severity violation) (:rule/severity rule))))
-
-(defn- ^{:stratum 0} exception-violation
-  [rule detector e]
-  {:type     :check-error
-   :rule-id  (:rule/id rule)
-   :severity (:rule/severity rule)
-   :detector detector
-   :error    (ex-message e)
-   :message  (str "Policy check failed: " (ex-message e))})
-
-(defn- ^{:stratum 0} missing-semantic-wiring-violation
-  [rule]
-  {:type     :semantic-error
-   :rule-id  (:rule/id rule)
-   :severity (:rule/severity rule)
-   :message  "Semantic policy check requires :semantic-analyze-fn, :llm-client, and :complete-fn"})
+(def ^{:stratum 0} compile-rule-check
+  "Compile one enabled rule into an executable N4 check entry.
+   See `ai.miniforge.policy-pack.compiler.rule/compile-rule-check`."
+  rule/compile-rule-check)
 
 (defn- ^{:stratum 0} anomaly-rule-id
   [a]
@@ -124,132 +90,8 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 
-(defn ^{:stratum 1} resolve-detector
-  "Return the detection-mechanism keyword that `rule` binds to.
-
-   One of the `by-type-detectors`, or `:capability` / `:custom` / `:semantic`,
-   or `:none` when the rule binds to no available mechanism.
-
-   - :capability binds only if its `:capability` keyword is registered.
-   - :custom binds to :custom when its `:custom-fn` resolves; to :none when a
-     `:custom-fn` is declared but unresolvable (fail-loud); to :semantic when no
-     `:custom-fn` is declared.
-   - An unknown/missing detection type is :none."
-  [rule]
-  (let [detection-type (get-in rule [:rule/detection :type])]
-    (cond
-      (contains? by-type-detectors detection-type)
-      detection-type
-
-      (= :capability detection-type)
-      (let [capability-kw (get-in rule [:rule/detection :capability])]
-        (if (and capability-kw (capability/capability-available? capability-kw))
-          :capability
-          :none))
-
-      (= :custom detection-type)
-      (cond
-        (detection/custom-fn-resolvable? rule) :custom
-        ;; A rule that DECLARES a :custom-fn symbol which does not resolve is a
-        ;; broken registration (the detector namespace never registered it), not
-        ;; an intentional judge rule. Bind to :none so the compiler fails loud
-        ;; (`compile-rule-check` returns an :invalid-input anomaly) instead of
-        ;; silently routing it to the LLM judge — the failure mode from #1381.
-        (get-in rule [:rule/detection :custom-fn]) :none
-        :else :semantic)
-
-      :else
-      :none)))
-
-(defn- ^{:stratum 1} rule-metadata
-  [rule detector]
-  {:rule/id       (:rule/id rule)
-   :rule/severity (:rule/severity rule)
-   :detector      detector
-   :class         (detector-class detector)})
-
-(defn- ^{:stratum 1} normalize-artifacts
-  "Normalize N4 check input into artifact maps that existing detectors accept."
-  [artifacts]
-  (cond
-    (sequential? artifacts) (mapv file-entry->artifact artifacts)
-    (code-files-present? artifacts) (mapv file-entry->artifact (code-files artifacts))
-    (map? artifacts) [(file-entry->artifact artifacts)]
-    :else []))
-
-;------------------------------------------------------------------------------ Layer 2
-
-(defn- ^{:stratum 2} artifact-inputs
-  [detector artifacts]
-  (let [normalized (normalize-artifacts artifacts)]
-    (if (and (= :semantic detector) (seq normalized))
-      [(first normalized)]
-      normalized)))
-
-(defn- ^{:stratum 2} check-result
-  [rule detector violations]
-  {:passed?    (empty? violations)
-   :violations violations
-   :metadata   (rule-metadata rule detector)})
-
-;------------------------------------------------------------------------------ Layer 3
-
-(defn- ^{:stratum 3} detect-rule-violations
-  [rule detector artifacts context]
-  (->> (artifact-inputs detector artifacts)
-       (keep #(detection/detect-violation rule % context))
-       (mapv #(violation-with-rule rule %))))
-
-;------------------------------------------------------------------------------ Layer 4
-
-(defn- ^{:stratum 4} compile-check-fn
-  [rule detector]
-  (fn [artifacts context]
-    (try
-      (if (and (= :semantic detector)
-               (not (semantic-context-ready? context)))
-        (check-result rule detector [(missing-semantic-wiring-violation rule)])
-        (check-result rule detector
-                      (detect-rule-violations rule detector artifacts context)))
-      (catch Exception e
-        (check-result rule detector [(exception-violation rule detector e)])))))
-
-;------------------------------------------------------------------------------ Layer 5
-
-(defn ^{:stratum 5} compile-rule-check
-  "Compile one enabled rule into an executable N4 check entry.
-
-   Returns:
-     {:rule rule
-      :detector <mechanism>
-      :check-fn (fn [artifacts context] -> {:passed? bool
-                                            :violations [...]
-                                            :metadata {...}})}
-
-   Returns an :invalid-input anomaly when the rule cannot bind to any
-   mechanism. Disabled rules are not compiled."
-  [rule]
-  (let [detector (resolve-detector rule)]
-    (cond
-      (not (rule-enabled? rule))
-      (anomaly/anomaly :invalid-input
-                       "Disabled rules are not compiled into checks"
-                       {:rule/id (:rule/id rule)})
-
-      (= :none detector)
-      (anomaly/anomaly :invalid-input
-                       "Enabled policy rule binds to no detection mechanism"
-                       {:rule/id (:rule/id rule)})
-
-      :else
-      {:rule     rule
-       :detector detector
-       :check-fn (compile-check-fn rule detector)})))
-
-;------------------------------------------------------------------------------ Layer 6
-
 ;; Pack-level validation
-(defn ^{:stratum 6} compile-pack-checks
+(defn ^{:stratum 1} compile-pack-checks
   "Compile every enabled rule in `pack` into executable check entries.
 
    Returns:
@@ -280,9 +122,9 @@
          :detector-counts (frequencies (map compiled-entry-detector compiled))
          :compiled-rules  compiled}))))
 
-;------------------------------------------------------------------------------ Layer 7
+;------------------------------------------------------------------------------ Layer 2
 
-(defn ^{:stratum 7} compile-pack
+(defn ^{:stratum 2} compile-pack
   "Validate that every ENABLED rule in `pack` binds to a detection mechanism.
 
    `pack` is a PackManifest map carrying `:pack/rules`.

--- a/components/policy-pack/src/ai/miniforge/policy_pack/compiler/artifacts.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/compiler/artifacts.clj
@@ -1,0 +1,73 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.compiler.artifacts
+  "Normalize N4 check input into the artifact maps detectors accept.
+
+   Split out of `ai.miniforge.policy-pack.compiler` (rule 210: the
+   combined namespace measured 8 real layers, max 3). This namespace
+   holds the artifact-normalization chain — `code-files` through
+   `artifact-inputs` sat at the bottom of that chain and, kept
+   together, are 3 layers on their own; extracting them lets the
+   parent and its other siblings (`compiler.check`, `compiler.rule`)
+   each land under budget too.
+
+   Layer 0: code-files, code-files-present?, file-entry->artifact
+   Layer 1: normalize-artifacts
+   Layer 2: artifact-inputs")
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} code-files
+  [artifacts]
+  (or (get artifacts :code/files)
+      (get artifacts :files)))
+
+(defn- ^{:stratum 0} code-files-present?
+  [artifacts]
+  (or (contains? artifacts :code/files)
+      (contains? artifacts :files)))
+
+(defn- ^{:stratum 0} file-entry->artifact
+  [file-entry]
+  (let [path    (or (get file-entry :artifact/path)
+                    (get file-entry :path))
+        content (or (get file-entry :artifact/content)
+                    (get file-entry :content))]
+    (cond-> file-entry
+      path    (assoc :artifact/path path)
+      content (assoc :artifact/content content))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} normalize-artifacts
+  "Normalize N4 check input into artifact maps that existing detectors accept."
+  [artifacts]
+  (cond
+    (sequential? artifacts) (mapv file-entry->artifact artifacts)
+    (code-files-present? artifacts) (mapv file-entry->artifact (code-files artifacts))
+    (map? artifacts) [(file-entry->artifact artifacts)]
+    :else []))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} artifact-inputs
+  [detector artifacts]
+  (let [normalized (normalize-artifacts artifacts)]
+    (if (and (= :semantic detector) (seq normalized))
+      [(first normalized)]
+      normalized)))

--- a/components/policy-pack/src/ai/miniforge/policy_pack/compiler/check.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/compiler/check.clj
@@ -1,0 +1,153 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.compiler.check
+  "Resolve a rule's detection mechanism and produce the violations/result
+   shapes an executable check-fn is built from.
+
+   Split out of `ai.miniforge.policy-pack.compiler` (rule 210: the
+   combined namespace measured 8 real layers, max 3). This namespace
+   holds two of the original chains that fed the compiler's outermost
+   functions:
+   - detector resolution (`resolve-detector`, `by-type-detectors`,
+     `rule-enabled?`) — which mechanism a rule binds to;
+   - result/violation construction (`rule-metadata`, `check-result`,
+     `detect-rule-violations`, and the plain violation-map builders) —
+     what running that mechanism against an artifact produces.
+
+   Kept together these are 3 layers; `ai.miniforge.policy-pack.compiler.rule`
+   builds the executable check-fn on top of this namespace's outputs, and
+   `ai.miniforge.policy-pack.compiler.artifacts` (required here for
+   `detect-rule-violations`) normalizes N4 check input into the artifact
+   maps detectors accept.
+
+   Layer 0: by-type-detectors, rule-enabled?, detector-class,
+     semantic-context-ready?, violation-with-rule, exception-violation,
+     missing-semantic-wiring-violation
+   Layer 1: resolve-detector, rule-metadata, detect-rule-violations
+   Layer 2: check-result"
+  (:require
+   [ai.miniforge.policy-pack.capability :as capability]
+   [ai.miniforge.policy-pack.compiler.artifacts :as artifacts]
+   [ai.miniforge.policy-pack.detection :as detection]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Per-rule classification
+(def ^{:stratum 0} ^{:doc "Detection types that bind to a mechanism directly by their type."}
+  by-type-detectors
+  #{:content-scan :diff-analysis :plan-output :state-comparison :ast-analysis})
+
+(defn ^{:stratum 0} rule-enabled?
+  "True unless the rule explicitly sets `:rule/enabled?` to false.
+   A missing `:rule/enabled?` means enabled (the shipped pack omits it)."
+  [rule]
+  (not (false? (:rule/enabled? rule))))
+
+(defn- ^{:stratum 0} detector-class
+  [detector]
+  (if (= :semantic detector)
+    :heuristic
+    :deterministic))
+
+(defn ^{:stratum 0} semantic-context-ready?
+  [context]
+  (and (fn? (:semantic-analyze-fn context))
+       (some? (:llm-client context))
+       (fn? (:complete-fn context))))
+
+(defn- ^{:stratum 0} violation-with-rule
+  [rule violation]
+  (assoc violation
+         :rule-id  (or (:rule-id violation) (:rule/id rule))
+         :severity (or (:severity violation) (:rule/severity rule))))
+
+(defn ^{:stratum 0} exception-violation
+  [rule detector e]
+  {:type     :check-error
+   :rule-id  (:rule/id rule)
+   :severity (:rule/severity rule)
+   :detector detector
+   :error    (ex-message e)
+   :message  (str "Policy check failed: " (ex-message e))})
+
+(defn ^{:stratum 0} missing-semantic-wiring-violation
+  [rule]
+  {:type     :semantic-error
+   :rule-id  (:rule/id rule)
+   :severity (:rule/severity rule)
+   :message  "Semantic policy check requires :semantic-analyze-fn, :llm-client, and :complete-fn"})
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} resolve-detector
+  "Return the detection-mechanism keyword that `rule` binds to.
+
+   One of the `by-type-detectors`, or `:capability` / `:custom` / `:semantic`,
+   or `:none` when the rule binds to no available mechanism.
+
+   - :capability binds only if its `:capability` keyword is registered.
+   - :custom binds to :custom when its `:custom-fn` resolves; to :none when a
+     `:custom-fn` is declared but unresolvable (fail-loud); to :semantic when no
+     `:custom-fn` is declared.
+   - An unknown/missing detection type is :none."
+  [rule]
+  (let [detection-type (get-in rule [:rule/detection :type])]
+    (cond
+      (contains? by-type-detectors detection-type)
+      detection-type
+
+      (= :capability detection-type)
+      (let [capability-kw (get-in rule [:rule/detection :capability])]
+        (if (and capability-kw (capability/capability-available? capability-kw))
+          :capability
+          :none))
+
+      (= :custom detection-type)
+      (cond
+        (detection/custom-fn-resolvable? rule) :custom
+        ;; A rule that DECLARES a :custom-fn symbol which does not resolve is a
+        ;; broken registration (the detector namespace never registered it), not
+        ;; an intentional judge rule. Bind to :none so the compiler fails loud
+        ;; (`compile-rule-check` returns an :invalid-input anomaly) instead of
+        ;; silently routing it to the LLM judge — the failure mode from #1381.
+        (get-in rule [:rule/detection :custom-fn]) :none
+        :else :semantic)
+
+      :else
+      :none)))
+
+(defn- ^{:stratum 1} rule-metadata
+  [rule detector]
+  {:rule/id       (:rule/id rule)
+   :rule/severity (:rule/severity rule)
+   :detector      detector
+   :class         (detector-class detector)})
+
+(defn ^{:stratum 1} detect-rule-violations
+  [rule detector artifacts-input context]
+  (->> (artifacts/artifact-inputs detector artifacts-input)
+       (keep #(detection/detect-violation rule % context))
+       (mapv #(violation-with-rule rule %))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} check-result
+  [rule detector violations]
+  {:passed?    (empty? violations)
+   :violations violations
+   :metadata   (rule-metadata rule detector)})

--- a/components/policy-pack/src/ai/miniforge/policy_pack/compiler/rule.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/compiler/rule.clj
@@ -1,0 +1,79 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.compiler.rule
+  "Compile one enabled policy rule into an executable N4 check entry.
+
+   Split out of `ai.miniforge.policy-pack.compiler` (rule 210: the
+   combined namespace measured 8 real layers, max 3). This namespace
+   builds the executable check-fn on top of
+   `ai.miniforge.policy-pack.compiler.check`'s detector resolution and
+   result/violation construction; the parent namespace builds
+   pack-level compilation (`compile-pack-checks`, `compile-pack`) on
+   top of this namespace's `compile-rule-check`.
+
+   Layer 0: compile-check-fn
+   Layer 1: compile-rule-check"
+  (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.policy-pack.compiler.check :as check]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn- ^{:stratum 0} compile-check-fn
+  [rule detector]
+  (fn [artifacts context]
+    (try
+      (if (and (= :semantic detector)
+               (not (check/semantic-context-ready? context)))
+        (check/check-result rule detector [(check/missing-semantic-wiring-violation rule)])
+        (check/check-result rule detector
+                            (check/detect-rule-violations rule detector artifacts context)))
+      (catch Exception e
+        (check/check-result rule detector [(check/exception-violation rule detector e)])))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} compile-rule-check
+  "Compile one enabled rule into an executable N4 check entry.
+
+   Returns:
+     {:rule rule
+      :detector <mechanism>
+      :check-fn (fn [artifacts context] -> {:passed? bool
+                                            :violations [...]
+                                            :metadata {...}})}
+
+   Returns an :invalid-input anomaly when the rule cannot bind to any
+   mechanism. Disabled rules are not compiled."
+  [rule]
+  (let [detector (check/resolve-detector rule)]
+    (cond
+      (not (check/rule-enabled? rule))
+      (anomaly/anomaly :invalid-input
+                       "Disabled rules are not compiled into checks"
+                       {:rule/id (:rule/id rule)})
+
+      (= :none detector)
+      (anomaly/anomaly :invalid-input
+                       "Enabled policy rule binds to no detection mechanism"
+                       {:rule/id (:rule/id rule)})
+
+      :else
+      {:rule     rule
+       :detector detector
+       :check-fn (compile-check-fn rule detector)})))


### PR DESCRIPTION
<!--
  Title: Split policy-pack/compiler.clj (rule 210)
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# refactor(policy-pack): split compiler.clj (rule 210)

## Overview

Splits `ai.miniforge.policy-pack.compiler` (317 lines, SL003: 8 real
layers, max 3) into a parent plus three sibling namespaces under
`compiler/`, each holding one stage of the same detector-resolution →
check-building → pack-compilation pipeline. Pure code motion — no
detection or compilation logic changed.

## Motivation

Part of the stratum-lint rule-210 remediation program, policy-pack
Wave 2 batch 2 (task #9). `compiler.clj` compiles a policy pack's
rules into executable N4 check entries; the whole pipeline — resolve
a rule's detector, normalize artifacts, build a result, wrap it in an
executable check-fn, compile a whole pack — lived in one namespace and
had grown to 8 real dependency layers.

## Changes in Detail

- New file `compiler/artifacts.clj`
  (`ai.miniforge.policy-pack.compiler.artifacts`): `code-files`,
  `code-files-present?`, `file-entry->artifact` (layer 0),
  `normalize-artifacts` (layer 1, private), `artifact-inputs` (layer
  2) — N4 check-input normalization. 3 layers.
- New file `compiler/check.clj`
  (`ai.miniforge.policy-pack.compiler.check`): `by-type-detectors`,
  `rule-enabled?`, `detector-class`, `semantic-context-ready?`,
  `violation-with-rule`, `exception-violation`,
  `missing-semantic-wiring-violation` (layer 0); `resolve-detector`,
  `rule-metadata`, `detect-rule-violations` (layer 1); `check-result`
  (layer 2). Requires `compiler.artifacts` for `detect-rule-violations`.
  3 layers.
- New file `compiler/rule.clj` (`ai.miniforge.policy-pack.compiler.rule`):
  `compile-check-fn` (layer 0, private), `compile-rule-check` (layer
  1). Requires `compiler.check`. 2 layers.
- `compiler.clj`: now requires `compiler.check` and `compiler.rule`.
  `resolve-detector`, `rule-enabled?`, and `compile-rule-check` become
  thin re-export `def`s pointing at the sibling implementations, so
  every existing external caller of
  `ai.miniforge.policy-pack.compiler/...` keeps working unchanged.
  `anomaly-rule-id`, `compiled-entry-detector`, `compile-pack-checks`,
  and `compile-pack` keep their real implementations here — pack-level
  compilation is this namespace's own reason to exist, following the
  `mdc_compiler.clj` split's convention of keeping the outermost
  orchestration in the parent rather than re-exporting it too. 3
  layers (down from 8).

### Visibility changes (the only non-motion changes)

Four defs go from `defn-`/private to `defn`/public because a sibling
namespace now calls them cross-namespace; no signature, name, or
logic changed:

- `compiler.check/semantic-context-ready?`
- `compiler.check/exception-violation`
- `compiler.check/missing-semantic-wiring-violation`
- `compiler.check/detect-rule-violations`
- `compiler.artifacts/artifact-inputs`

`compiler.check/rule-enabled?`, `compiler.check/resolve-detector`, and
`compiler.check/check-result` were already public in the original file
— unchanged. `compiler.artifacts/normalize-artifacts`,
`compiler.check/detector-class`, `compiler.check/violation-with-rule`,
`compiler.check/rule-metadata`, and `compiler.rule/compile-check-fn`
stay private — each is used only within the file it now lives in.

One local parameter rename, no observable effect: `detect-rule-violations`'s
`artifacts` parameter is renamed to `artifacts-input` in
`compiler.check` because that file now also requires the sibling
namespace `ai.miniforge.policy-pack.compiler.artifacts` aliased as
`artifacts` — Clojure resolves `artifacts/artifact-inputs` via the
alias table regardless of a local binding of the same name, so this
wasn't strictly required, but keeping the two apart avoids a confusing
read.

## Fan-in Check

Grepped the fully-qualified namespace (not a guessed alias prefix)
across `components`, `bases`, and `projects`:

```
grep -rlE "ai\.miniforge\.policy-pack\.compiler\b" --include='*.clj' components bases projects
```

Four files, all already accounted for by the re-export design:

- `components/policy-pack/src/ai/miniforge/policy_pack/interface/checking.clj`
  — re-exports `resolve-detector`, `rule-enabled?`, `compile-rule-check`,
  `compile-pack-checks`, `compile-pack` as `compiler/...`. Unaffected —
  those five names still resolve from `ai.miniforge.policy-pack.compiler`
  with identical semantics.
- `components/policy-pack/test/ai/miniforge/policy_pack/compiler_test.clj`
  — exercises the same five public fns via `sut/...`. Unaffected.
- `components/policy-pack/test/ai/miniforge/policy_pack/builtin_detectors_test.clj`
  — calls `compiler/resolve-detector`. Unaffected.
- `components/policy-pack/src/ai/miniforge/policy_pack/compiler.clj`
  — the file being split.

No project-level caller found; `projects/miniforge/test/` has no file
referencing this namespace. Zero call sites required a change.

## Testing Plan

- `stratum-lint` (with `--fix`) clean on all four touched files (exit
  0 on the target and every new sibling; was SL003 exit 1 on the
  original).
- `bb lint:clj` (clj-kondo) clean on all four files.
- `bb pre-commit` (commit-budget, `poly check`, lint, stratum-lint,
  pre-commit smoke tests, GraalVM/Babashka compatibility) green on
  both commits.
- `bb test` (change-scope) — policy-pack component and its
  `compiler-test`/`builtin-detectors-test` namespaces green.
- No project-level integration test references this namespace (fan-in
  check above), so no separate `clojure -M -e` verification was
  needed for this file, unlike the `knowledge_safety.clj` split.

## Deployment Plan

Merges to `main` immediately; no follow-up needed for this file.

## Related Issues/PRs

- Part of the stratum-lint rule-210 remediation program, policy-pack
  Wave 2 batch 2 (task #9). Follows the established splitting
  convention from `workflow_runner.clj` (miniforge#1662-#1667),
  `knowledge_safety.clj` (miniforge#1731), and the `mdc_compiler.clj`
  train (miniforge#1729-#1743) — extract cohesive layer-groups into
  sibling files under a subdirectory named after the original file,
  keep the outermost public orchestration in the parent, re-export
  any lower-level public API the parent used to implement directly.

## Checklist

- [x] stratum-lint clean on all resulting files
- [x] `bb lint:clj` clean
- [x] `bb pre-commit` green on both commits
- [x] `bb test` green (policy-pack change-scope)
- [x] Adversarial self-review: def set unchanged (relocated + 5
      re-exports added), 5 visibility flips documented above, one
      cosmetic local-parameter rename, no logic changes
- [x] Zero fan-in confirmed repo-wide before starting; all four
      matches accounted for, zero required a code change