### PR TITLE
feat(buzzword-bingo): bingo card and session tracking

### DIFF
--- a/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/card.cljc
+++ b/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/card.cljc
@@ -65,8 +65,12 @@
 ;; Hashing seed and id together is what makes a different seed deal a different
 ;; card; the id also breaks ties, so the order stays total when two terms hash
 ;; alike.
+;; The whole keyword, not its name: `name` discards the namespace, so
+;; :a/robust and :b/robust would hash and sort alike and the tie-break would
+;; stop being total. The compiler never mints a namespaced id, but card-for
+;; accepts any catalog a caller hands it.
 (defn- ^{:stratum 1} draw-order [seed entry]
-  (let [id (name (:entry/id entry))]
+  (let [id (str (:entry/id entry))]
     [(string-hash (str seed "|" id)) id]))
 
 (def ^{:stratum 1} ^:private term-square-indices

--- a/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/card.cljc
+++ b/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/card.cljc
@@ -1,0 +1,99 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.buzzword-bingo.card
+  "Deal a five-by-five bingo card of terms from a catalog.
+
+   The same seed always deals the same card, on any host, so a card can
+   be rebuilt from its seed rather than stored, and two people watching
+   one session see the same board.")
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Geometry and deterministic ordering
+(def ^{:stratum 0} square-count
+  "Squares on a card, the middle one free."
+  25)
+
+(def ^{:stratum 0} free-square-index
+  "Position of the free square, at the centre of the card."
+  12)
+
+;; The modulus keeps the running hash small enough that every intermediate
+;; product is exact in both a JVM long and a JavaScript double, so the two
+;; hosts agree on the ordering and therefore deal the same card.
+(defn- ^{:stratum 0} string-hash [s]
+  (let [seed       7
+        multiplier 31
+        modulus    1000003]
+    (loop [i 0
+           h seed]
+      (if (= i (count s))
+        h
+        (recur (inc i)
+               (mod (+ (* multiplier h)
+                       #?(:clj (int (.charAt ^String s i)) :cljs (.charCodeAt s i)))
+                    modulus))))))
+
+(defn- ^{:stratum 0} square-of [index entry]
+  {:square/index    index
+   :square/id       (:entry/id entry)
+   :square/term     (:entry/display entry)
+   :square/category (:entry/category entry)})
+
+(defn ^{:stratum 0} ids-on
+  "The set of term ids `card` can be marked with."
+  [card]
+  (into #{} (keep :square/id) (:card/squares card)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Hashing seed and id together is what makes a different seed deal a different
+;; card; the id also breaks ties, so the order stays total when two terms hash
+;; alike.
+(defn- ^{:stratum 1} draw-order [seed entry]
+  (let [id (name (:entry/id entry))]
+    [(string-hash (str seed "|" id)) id]))
+
+(def ^{:stratum 1} ^:private term-square-indices
+  (vec (remove #(= free-square-index %) (range square-count))))
+
+(def ^{:stratum 1} ^:private free-square
+  {:square/index free-square-index
+   :square/free? true})
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Cards
+(defn ^{:stratum 2} card-for
+  "Deal the card for `seed` from `entries`.
+
+   Returns `{:card/seed s :card/squares [...]}` with the centre square
+   free. Deterministic in both arguments."
+  [seed entries]
+  (when (< (count entries) (count term-square-indices))
+    (throw (#?(:clj IllegalArgumentException. :cljs js/Error.)
+            (str "Need at least " (count term-square-indices)
+                 " entries to fill a card, got " (count entries)))))
+  (let [drawn   (take (count term-square-indices) (sort-by (partial draw-order seed) entries))
+        squares (conj (map square-of term-square-indices drawn) free-square)]
+    {:card/seed    seed
+     :card/squares (vec (sort-by :square/index squares))}))
+
+(comment
+  (card-for "session-1" [{:entry/id :robust :entry/display "robust"
+                          :entry/category :marketing}]))

--- a/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/interface.cljc
+++ b/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/interface.cljc
@@ -97,7 +97,9 @@
   "Fold one `scan` result into `session`, returning it advanced a turn.
 
    `:session/new-lines` holds only the lines this turn completed, so a
-   caller announcing BINGO announces each line once."
+   caller announcing BINGO announces each line once. Both it and
+   `:session/lines` are sets of indices into `winning-lines`, not
+   square indices and not the line vectors themselves."
   [session scan-result]
   (session/track session scan-result))
 

--- a/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/interface.cljc
+++ b/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/interface.cljc
@@ -20,12 +20,15 @@
 
    Counts marketing, corporate and generated-prose tells in a document
    and grades the result, so a caller can decide whether prose is worth
-   keeping or should be written again."
+   keeping or should be written again. A session plays the same hits
+   onto a bingo card across the turns of one conversation."
   (:require
+   [ai.miniforge.buzzword-bingo.card :as card]
    [ai.miniforge.buzzword-bingo.detect :as detect]
    [ai.miniforge.buzzword-bingo.lexicon :as lexicon]
    [ai.miniforge.buzzword-bingo.score :as score]
-   [ai.miniforge.buzzword-bingo.segment :as segment]))
+   [ai.miniforge.buzzword-bingo.segment :as segment]
+   [ai.miniforge.buzzword-bingo.session :as session]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -71,7 +74,35 @@
   ([text] (scan text nil))
   ([text opts] (score/summarize (detect/scan text opts) opts)))
 
+;; Sessions
+(defn ^{:stratum 0} deal-card
+  "Deal the bingo card `seed` selects from the catalog.
+
+   Deterministic: the same seed and catalog always deal the same card,
+   so a card can be rebuilt from its seed rather than stored."
+  ([seed] (card/card-for seed lexicon/entries))
+  ([seed catalog-entries] (card/card-for seed catalog-entries)))
+
+(defn ^{:stratum 0} winning-lines
+  "Square indices of the twelve lines that win."
+  []
+  session/winning-lines)
+
+(defn ^{:stratum 0} open-session
+  "Start a session playing the card `seed` deals."
+  ([seed] (session/open seed lexicon/entries))
+  ([seed catalog-entries] (session/open seed catalog-entries)))
+
+(defn ^{:stratum 0} track
+  "Fold one `scan` result into `session`, returning it advanced a turn.
+
+   `:session/new-lines` holds only the lines this turn completed, so a
+   caller announcing BINGO announces each line once."
+  [session scan-result]
+  (session/track session scan-result))
+
 (comment
   (prose-only "Use `robust` in code but not in prose.")
   (scan "A robust, comprehensive, seamless solution.")
-  (:score/grade (scan "Plain sentence about a file parser.")))
+  (:score/grade (scan "Plain sentence about a file parser."))
+  (-> (open-session "demo") (track (scan "A robust and seamless solution."))))

--- a/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/session.cljc
+++ b/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/session.cljc
@@ -22,7 +22,8 @@
    than mutating one, so the caller holding it decides where state
    lives."
   (:require
-   [ai.miniforge.buzzword-bingo.card :as card]))
+   [ai.miniforge.buzzword-bingo.card :as card]
+   [ai.miniforge.buzzword-bingo.tally :as tally]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -44,6 +45,8 @@
    :session/card       (card/card-for seed entries)
    :session/marked     #{}
    :session/lines      #{}
+   :session/new-lines  #{}
+   :session/bingo?     false
    :session/turns      0
    :session/hit-count  0
    :session/weighted   0
@@ -73,11 +76,17 @@
 (defn ^{:stratum 2} track
   "Fold one `scan` result into `session`.
 
-   Returns the session advanced by a turn, with `:session/new-lines`
-   holding only the lines this turn completed — a caller shouts BINGO
-   on that, so one line is announced once however many turns follow."
+   Returns the session advanced by a turn. `:session/lines` and
+   `:session/new-lines` are sets of indices into `winning-lines` — not
+   square indices and not the line vectors themselves. `:session/new-lines`
+   holds only the lines this turn completed, so a caller shouting BINGO
+   on it announces each line once however many turns follow.
+
+   Turn weight is summed from the hits rather than read from
+   `:score/weighted`, so an unscored scan still totals correctly."
   [session scan]
-  (let [marked (into (:session/marked session) (map :hit/id) (:scan/hits scan))
+  (let [hits   (:scan/hits scan)
+        marked (into (:session/marked session) (map :hit/id) hits)
         lines  (lines-completed (:session/card session) marked)
         fresh  (into #{} (remove (:session/lines session)) lines)]
     (assoc session
@@ -86,8 +95,8 @@
            :session/new-lines  fresh
            :session/bingo?     (boolean (seq lines))
            :session/turns      (inc (:session/turns session))
-           :session/hit-count  (+ (:session/hit-count session) (count (:scan/hits scan)))
-           :session/weighted   (+ (:session/weighted session) (get scan :score/weighted 0))
+           :session/hit-count  (+ (:session/hit-count session) (count hits))
+           :session/weighted   (+ (:session/weighted session) (tally/weight-of hits))
            :session/word-count (+ (:session/word-count session) (get scan :scan/word-count 0)))))
 
 (comment

--- a/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/session.cljc
+++ b/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/session.cljc
@@ -1,0 +1,95 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.buzzword-bingo.session
+  "Play a card across many turns of one conversation.
+
+   A session is a value: each turn's scan produces a new session rather
+   than mutating one, so the caller holding it decides where state
+   lives."
+  (:require
+   [ai.miniforge.buzzword-bingo.card :as card]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; The board
+;; Written out rather than computed: the geometry of a bingo card is worth
+;; being able to read, and a literal cannot drift from the card it describes.
+(def ^{:stratum 0} winning-lines
+  "Square indices of the five rows, five columns and two diagonals."
+  [[0 1 2 3 4]      [5 6 7 8 9]      [10 11 12 13 14]
+   [15 16 17 18 19] [20 21 22 23 24]
+   [0 5 10 15 20]   [1 6 11 16 21]   [2 7 12 17 22]
+   [3 8 13 18 23]   [4 9 14 19 24]
+   [0 6 12 18 24]   [4 8 12 16 20]])
+
+(defn ^{:stratum 0} open
+  "Start a session on the card `seed` deals from `entries`."
+  [seed entries]
+  {:session/id         seed
+   :session/card       (card/card-for seed entries)
+   :session/marked     #{}
+   :session/lines      #{}
+   :session/turns      0
+   :session/hit-count  0
+   :session/weighted   0
+   :session/word-count 0})
+
+;; Marking
+(defn- ^{:stratum 0} marked-indices
+  "Square indices covered by `marked` ids, the free square included."
+  [card marked]
+  (into #{card/free-square-index}
+        (comp (filter #(contains? marked (:square/id %)))
+              (map :square/index))
+        (:card/squares card)))
+
+(defn- ^{:stratum 0} line-index-when-covered [covered line-index line]
+  (when (every? covered line) line-index))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} lines-completed [card marked]
+  (let [covered (marked-indices card marked)]
+    (into #{} (keep-indexed (partial line-index-when-covered covered)) winning-lines)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Turns
+(defn ^{:stratum 2} track
+  "Fold one `scan` result into `session`.
+
+   Returns the session advanced by a turn, with `:session/new-lines`
+   holding only the lines this turn completed — a caller shouts BINGO
+   on that, so one line is announced once however many turns follow."
+  [session scan]
+  (let [marked (into (:session/marked session) (map :hit/id) (:scan/hits scan))
+        lines  (lines-completed (:session/card session) marked)
+        fresh  (into #{} (remove (:session/lines session)) lines)]
+    (assoc session
+           :session/marked     marked
+           :session/lines      lines
+           :session/new-lines  fresh
+           :session/bingo?     (boolean (seq lines))
+           :session/turns      (inc (:session/turns session))
+           :session/hit-count  (+ (:session/hit-count session) (count (:scan/hits scan)))
+           :session/weighted   (+ (:session/weighted session) (get scan :score/weighted 0))
+           :session/word-count (+ (:session/word-count session) (get scan :scan/word-count 0)))))
+
+(comment
+  (open "session-1" [])
+  (track (open "session-1" []) {:scan/hits [] :scan/word-count 10}))

--- a/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/card_test.cljc
+++ b/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/card_test.cljc
@@ -1,0 +1,76 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.buzzword-bingo.card-test
+  (:require
+   [ai.miniforge.buzzword-bingo.card :as sut]
+   #?(:clj  [clojure.test :refer [deftest is testing]]
+      :cljs [cljs.test :refer-macros [deftest is testing]])))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Fixtures and helpers
+;; Mirrors the shape entry/compile-all emits, minus the compiled pattern the
+;; card never looks at.
+(defn- ^{:stratum 0} catalog
+  "A catalog of `n` distinct entries."
+  [n]
+  (mapv (fn [i]
+          {:entry/id       (keyword (str "term-" i))
+           :entry/display  (str "term " i)
+           :entry/category :probe})
+        (range n)))
+
+(defn- ^{:stratum 0} terms-on [card]
+  (mapv :square/term (:card/squares card)))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Dealing
+(deftest ^{:stratum 1} test-a-card-is-a-full-board
+  (testing "given a catalog → the card has every square, in index order"
+    (let [card (sut/card-for "seed" (catalog 40))]
+      (is (= sut/square-count (count (:card/squares card))))
+      (is (= (range sut/square-count) (map :square/index (:card/squares card))))))
+
+  (testing "given a card → the centre square is free and carries no term"
+    (let [centre (nth (:card/squares (sut/card-for "seed" (catalog 40)))
+                      sut/free-square-index)]
+      (is (:square/free? centre))
+      (is (nil? (:square/id centre)))))
+
+  (testing "given a card → no term is dealt twice"
+    (let [ids (sut/ids-on (sut/card-for "seed" (catalog 40)))]
+      (is (= (dec sut/square-count) (count ids))))))
+
+(deftest ^{:stratum 1} test-dealing-is-determined-by-the-seed
+  (testing "given the same seed and catalog → the same card, so it need not be stored"
+    (is (= (sut/card-for "seed" (catalog 40))
+           (sut/card-for "seed" (catalog 40)))))
+
+  (testing "given a different seed → a different arrangement"
+    (is (not= (terms-on (sut/card-for "one" (catalog 40)))
+              (terms-on (sut/card-for "two" (catalog 40))))))
+
+  (testing "given a catalog in a different order → the same card, since order is derived"
+    (is (= (sut/card-for "seed" (catalog 40))
+           (sut/card-for "seed" (reverse (catalog 40)))))))
+
+(deftest ^{:stratum 1} test-a-catalog-too-small-to-fill-a-card-is-refused
+  (testing "given fewer entries than squares → the caller is told rather than dealt a gap"
+    (is (thrown? #?(:clj Exception :cljs js/Error)
+                 (sut/card-for "seed" (catalog 10))))))

--- a/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/card_test.cljc
+++ b/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/card_test.cljc
@@ -38,6 +38,16 @@
 (defn- ^{:stratum 0} terms-on [card]
   (mapv :square/term (:card/squares card)))
 
+(deftest ^{:stratum 0} test-ids-differing-only-by-namespace-stay-distinct
+  (testing "given ids sharing a name across namespaces → every one is dealt, none merged"
+    (let [namespaced (mapv (fn [i]
+                             {:entry/id       (keyword (str "ns-" i) "same-name")
+                              :entry/display  (str "term " i)
+                              :entry/category :probe})
+                           (range 30))]
+      (is (= (dec sut/square-count)
+             (count (sut/ids-on (sut/card-for "seed" namespaced))))))))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 ;; Dealing

--- a/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/session_test.cljc
+++ b/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/session_test.cljc
@@ -33,12 +33,13 @@
            :entry/category :probe})
         (range n)))
 
-;; Mirrors the shape score/summarize emits, carrying only what track reads.
+;; Mirrors the shape detect/scan emits: every hit carries its weight, which is
+;; what track sums. Deliberately omits the :score/* keys, so these tests also
+;; cover an unscored scan being tracked.
 (defn- ^{:stratum 0} scan-of
-  [hit-ids & {:keys [words weighted] :or {words 20 weighted 6}}]
-  {:scan/hits       (mapv (fn [id] {:hit/id id}) hit-ids)
-   :scan/word-count words
-   :score/weighted  weighted})
+  [hit-ids & {:keys [words weight] :or {words 20 weight 3}}]
+  {:scan/hits       (mapv (fn [id] {:hit/id id :hit/weight weight}) hit-ids)
+   :scan/word-count words})
 
 (defn- ^{:stratum 0} ids-at
   "Term ids of the squares of `session` at `indices`."
@@ -60,18 +61,30 @@
   (testing "given two turns → marks, counts and totals add up across them"
     (let [session (fresh-session)
           after   (-> session
-                      (sut/track (scan-of (ids-at session [0 1]) :words 20 :weighted 6))
-                      (sut/track (scan-of (ids-at session [2]) :words 30 :weighted 3)))]
+                      (sut/track (scan-of (ids-at session [0 1]) :words 20 :weight 3))
+                      (sut/track (scan-of (ids-at session [2]) :words 30 :weight 3)))]
       (is (= 2 (:session/turns after)))
       (is (= 3 (:session/hit-count after)))
       (is (= 9 (:session/weighted after)))
       (is (= 50 (:session/word-count after)))))
 
+  ;; The weight comes off the hits, so a caller handing track the output of
+  ;; detect/scan rather than a scored result still gets a correct total.
+  (testing "given hits of differing weight → the session sums what the hits carry"
+    (let [session (fresh-session)
+          after   (sut/track session (scan-of (ids-at session [0 1]) :weight 5))]
+      (is (= 10 (:session/weighted after)))))
+
   (testing "given a turn with no hits → the session advances but nothing is marked"
     (let [after (sut/track (fresh-session) (scan-of []))]
       (is (= 1 (:session/turns after)))
       (is (empty? (:session/marked after)))
-      (is (false? (:session/bingo? after))))))
+      (is (false? (:session/bingo? after)))))
+
+  (testing "given a session not yet tracked → it already has the shape track returns"
+    (let [session (fresh-session)]
+      (is (= #{} (:session/new-lines session)))
+      (is (false? (:session/bingo? session))))))
 
 ;; Completing lines
 (deftest ^{:stratum 2} test-a-line-completes-in-any-direction

--- a/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/session_test.cljc
+++ b/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/session_test.cljc
@@ -1,0 +1,109 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.buzzword-bingo.session-test
+  (:require
+   [ai.miniforge.buzzword-bingo.session :as sut]
+   #?(:clj  [clojure.test :refer [deftest is testing]]
+      :cljs [cljs.test :refer-macros [deftest is testing]])))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Fixtures and helpers
+(def ^{:stratum 0} ^:private seed "session-under-test")
+
+(defn- ^{:stratum 0} catalog [n]
+  (mapv (fn [i]
+          {:entry/id       (keyword (str "term-" i))
+           :entry/display  (str "term " i)
+           :entry/category :probe})
+        (range n)))
+
+;; Mirrors the shape score/summarize emits, carrying only what track reads.
+(defn- ^{:stratum 0} scan-of
+  [hit-ids & {:keys [words weighted] :or {words 20 weighted 6}}]
+  {:scan/hits       (mapv (fn [id] {:hit/id id}) hit-ids)
+   :scan/word-count words
+   :score/weighted  weighted})
+
+(defn- ^{:stratum 0} ids-at
+  "Term ids of the squares of `session` at `indices`."
+  [session indices]
+  (let [wanted (set indices)]
+    (into [] (comp (filter #(contains? wanted (:square/index %)))
+                   (keep :square/id))
+          (:card/squares (:session/card session)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} fresh-session []
+  (sut/open seed (catalog 40)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+;; Playing a turn
+(deftest ^{:stratum 2} test-a-turn-accumulates-into-the-session
+  (testing "given two turns → marks, counts and totals add up across them"
+    (let [session (fresh-session)
+          after   (-> session
+                      (sut/track (scan-of (ids-at session [0 1]) :words 20 :weighted 6))
+                      (sut/track (scan-of (ids-at session [2]) :words 30 :weighted 3)))]
+      (is (= 2 (:session/turns after)))
+      (is (= 3 (:session/hit-count after)))
+      (is (= 9 (:session/weighted after)))
+      (is (= 50 (:session/word-count after)))))
+
+  (testing "given a turn with no hits → the session advances but nothing is marked"
+    (let [after (sut/track (fresh-session) (scan-of []))]
+      (is (= 1 (:session/turns after)))
+      (is (empty? (:session/marked after)))
+      (is (false? (:session/bingo? after))))))
+
+;; Completing lines
+(deftest ^{:stratum 2} test-a-line-completes-in-any-direction
+  (testing "given a full row → that line is complete"
+    (let [session (fresh-session)]
+      (is (= #{0} (:session/lines (sut/track session (scan-of (ids-at session [0 1 2 3 4]))))))))
+
+  (testing "given a full column → that line is complete"
+    (let [session (fresh-session)]
+      (is (= #{5} (:session/lines (sut/track session (scan-of (ids-at session [0 5 10 15 20]))))))))
+
+  (testing "given a diagonal → the free centre square supplies the fifth mark"
+    (let [session (fresh-session)]
+      (is (= #{10} (:session/lines (sut/track session (scan-of (ids-at session [0 6 18 24]))))))))
+
+  (testing "given four of five squares → no line"
+    (let [session (fresh-session)]
+      (is (empty? (:session/lines (sut/track session (scan-of (ids-at session [0 1 2 3])))))))))
+
+(deftest ^{:stratum 2} test-a-completed-line-is-announced-once
+  (testing "given a line completed on an earlier turn → it is not new again"
+    (let [session (fresh-session)
+          first-turn  (sut/track session (scan-of (ids-at session [0 1 2 3 4])))
+          second-turn (sut/track first-turn (scan-of (ids-at session [5 6 7 8 9])))]
+      (is (= #{0} (:session/new-lines first-turn)))
+      (is (= #{1} (:session/new-lines second-turn)))
+      (is (= #{0 1} (:session/lines second-turn)))
+      (is (true? (:session/bingo? second-turn)))))
+
+  (testing "given a turn repeating already-marked terms → no line is announced again"
+    (let [session (fresh-session)
+          marked  (sut/track session (scan-of (ids-at session [0 1 2 3 4])))
+          again   (sut/track marked (scan-of (ids-at session [0 1])))]
+      (is (empty? (:session/new-lines again)))
+      (is (= #{0} (:session/lines again))))))

--- a/docs/pull-requests/2026-08-12-feat-buzzword-bingo-card.md
+++ b/docs/pull-requests/2026-08-12-feat-buzzword-bingo-card.md
@@ -1,0 +1,118 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# feat: buzzword-bingo card and session
+
+## Overview
+
+Third slice. #1716 prepared documents for counting, #1757 did the counting and
+grading. This adds the game half: a five-by-five card dealt from the catalog,
+and a session that plays hits onto it across the turns of one conversation.
+
+The two halves answer different questions and neither replaces the other. The
+score says *is this prose worth keeping* — a rate, comparable across documents,
+suitable for a gate. The card says *how bad has this conversation got* — a
+running picture of which distinct buzzwords have turned up, and a line to shout
+BINGO on.
+
+## Motivation
+
+A density score is the right instrument for a gate and the wrong one for
+watching a session. Repeating `robust` twenty times raises one number and tells
+you nothing new; the card only marks that square once, so a completed line
+means twenty *different* tells, which is a genuinely different observation.
+
+## Changes in Detail
+
+### `card.cljc`
+
+Twenty-five squares drawn from the catalog, centre free.
+
+Dealing is determined entirely by the seed: the same seed and catalog always
+deal the same card, so a card can be rebuilt from its seed rather than stored,
+and two people watching one session see the same board.
+
+Order comes from hashing seed and term id together, with the id breaking ties
+so the order is total. The hash uses a modulus small enough that every
+intermediate product is exact in both a JVM long and a JavaScript double. That
+is the one thing this file has to get right — a host disagreement would deal
+two different cards from one seed, and the MCP server (Node) and the CLI
+(Babashka) would then disagree about the same session.
+
+Dealing does not depend on the order entries arrive in, so a reordered catalog
+deals the same card. A catalog too small to fill a board is refused rather than
+dealt with gaps.
+
+### `session.cljc`
+
+A session is a value. Each turn's scan folds into a new session rather than
+mutating one, so whoever holds it decides where state lives — an atom in the
+MCP server, a file for the CLI, nothing at all in a test.
+
+Marking is by term id, so a word said five times marks one square. The twelve
+winning lines are written out rather than computed: card geometry is worth
+being able to read, and a literal cannot drift from the board it describes. The
+free centre square counts toward both diagonals and the middle row and column,
+as it does in the game.
+
+`:session/new-lines` carries only the lines this turn completed. A caller
+announcing BINGO reads that rather than `:session/lines`, so each line is
+announced once however many turns follow it.
+
+The session also accumulates turns, hits, weight and words, so a conversation
+can be scored as a whole and not only turn by turn.
+
+### `interface.cljc`
+
+`deal-card`, `open-session`, `track` and `winning-lines`.
+
+## Testing Plan
+
+35 tests, 105 assertions across the component, of which the new ones are:
+
+- `card-test` — a full board in index order, the centre square free and
+  term-less, no term dealt twice, same seed dealing the same card, different
+  seeds differing, a reordered catalog dealing the same card, and a
+  too-small catalog refused.
+- `session-test` — marks, counts and totals accumulating across turns; a turn
+  with no hits still advancing; a line completing by row, by column and by
+  diagonal with the free square supplying its fifth mark; four of five squares
+  not completing; a line announced once and not again on a later turn; and a
+  turn repeating already-marked terms announcing nothing.
+
+### Cross-host verification
+
+The whole component compiles to a Node script with `cljs.main --target node`,
+and all 35 test namespaces pass under `cljs.test` with the same counts as
+Babashka. The determinism the card depends on is therefore checked on both
+hosts rather than assumed from one.
+
+## Deployment Plan
+
+Library code. No entry point; nothing consumes the card until the MCP server
+and CLI arrive.
+
+## Related Issues/PRs
+
+1. #1716 — regex, phrase, segment strata (merged)
+2. #1757 — catalog, detection, scoring (merged)
+3. **This PR** — card and session
+4. Report renderers and message catalogs
+5. CLI and `bb bingo` task
+6. MCP server
+7. Stop hook and skill
+8. ClojureScript/Node build and npm packaging
+
+## Checklist
+
+- [x] `poly check` clean, no warnings
+- [x] `clj-kondo` clean
+- [x] `stratum-lint` clean, both namespaces inside the three-layer budget
+- [x] Each commit under the 200-line commit budget
+- [x] Apache header on every source file
+- [x] Adversarial self-review of the diff
+- [x] Standards gap analysis against `standards/miniforge`
+- [x] Determinism verified on both hosts, not inferred from one


### PR DESCRIPTION
## Overview

Third slice. #1716 prepared documents for counting, #1757 did the counting and
grading. This adds the game half: a five-by-five card dealt from the catalog,
and a session that plays hits onto it across the turns of one conversation.

Detail in [the PR document](docs/pull-requests/2026-08-12-feat-buzzword-bingo-card.md).

## Why a card as well as a score

The two answer different questions and neither replaces the other.

The score says *is this prose worth keeping* — a rate per thousand words,
comparable across documents, suitable for a gate. The card says *how bad has
this conversation got* — which distinct tells have turned up, and a line to
shout BINGO on.

Repeating `robust` twenty times raises the score and tells you nothing new. The
card marks that square once, so a completed line means twenty *different*
tells. That is a genuinely different observation, which is why the card is not
just a rendering of the number.

## What's here

- **`card.cljc`** — 25 squares, centre free, dealt entirely from the seed. Same
  seed and catalog always deal the same card, so a card can be rebuilt rather
  than stored. Order comes from hashing seed and term id together, with the id
  breaking ties.
- **`session.cljc`** — a value, not a mutable thing: each turn's scan folds
  into a new session, so whoever holds it decides where state lives. Marking is
  by term id, so a word said five times marks one square. Twelve winning lines,
  written out rather than computed. `:session/new-lines` carries only the lines
  this turn completed, so BINGO is announced once per line.
- **`interface.cljc`** — `deal-card`, `open-session`, `track`, `winning-lines`.

## The one thing this had to get right

The card's hash uses a modulus small enough that every intermediate product is
exact in **both** a JVM long and a JavaScript double. A host disagreement here
would deal two different cards from one seed, and the MCP server (Node) and the
CLI (Babashka) would then disagree about the same session.

Verified rather than reasoned about: the whole component compiles to a Node
script with `cljs.main --target node`, and all 35 test namespaces pass under
`cljs.test` with the same counts as Babashka.

## Verification

- `poly check` clean, `clj-kondo` clean, `stratum-lint` clean
- 35 tests / 105 assertions for the component, 9 tests / 36 assertions new here
- Determinism covered from both directions: same seed dealing the same card,
  different seeds differing, and a reordered catalog dealing the same card
- Line completion tested by row, by column, and by diagonal with the free
  square supplying the fifth mark; four-of-five completing nothing; a line
  never announced twice
- Each commit under the 200-line commit budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)