### PR TITLE
refactor(policy-pack): split taxonomy.clj (rule 210)

### DIFF
--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface/taxonomy.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface/taxonomy.clj
@@ -18,7 +18,8 @@
 (ns ai.miniforge.policy-pack.interface.taxonomy
   "Taxonomy loading, validation, and lookup."
   (:require
-   [ai.miniforge.policy-pack.taxonomy :as taxonomy]))
+   [ai.miniforge.policy-pack.taxonomy :as taxonomy]
+   [ai.miniforge.policy-pack.taxonomy.category :as category]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -27,22 +28,22 @@
   "Malli schema (a `[:map ...]` vector) for a taxonomy artifact — an
    independently versioned category tree with id, version, title, categories,
    and optional aliases."
-  taxonomy/Taxonomy)
+  category/Taxonomy)
 
 (def ^{:stratum 0} TaxonomyCategory
   "Malli schema (a `[:map ...]` vector) for a single taxonomy category —
    :category/id, :category/code, :category/title, optional :category/parent, and an integer :category/order."
-  taxonomy/TaxonomyCategory)
+  category/TaxonomyCategory)
 
 (def ^{:stratum 0} TaxonomyAlias
   "Malli schema (a `[:map ...]` vector) for a taxonomy alias — a stable
    :alias/name keyword pointing at an :alias/target category ID."
-  taxonomy/TaxonomyAlias)
+  category/TaxonomyAlias)
 
 (def ^{:stratum 0} TaxonomyRef
   "Malli schema (a `[:map ...]` vector) for a pack's taxonomy reference —
    :taxonomy/id and :taxonomy/min-version."
-  taxonomy/TaxonomyRef)
+  category/TaxonomyRef)
 
 ;; Validation
 (def ^{:stratum 0} valid-taxonomy?
@@ -74,22 +75,22 @@
   "Look up a category by its keyword ID in a loaded taxonomy.
    (category-by-id taxonomy category-id) returns the TaxonomyCategory map, or
    nil if not present."
-  taxonomy/category-by-id)
+  category/category-by-id)
 
 (def ^{:stratum 0} resolve-alias
   "Resolve an alias keyword to its target category ID.
    (resolve-alias taxonomy alias-kw) returns the target keyword, or the input
    keyword unchanged when no alias matches."
-  taxonomy/resolve-alias)
+  category/resolve-alias)
 
 (def ^{:stratum 0} category-title
   "Get the display title for a category ID, resolving aliases first.
    (category-title taxonomy category-id) returns the title string, or nil if
    not found."
-  taxonomy/category-title)
+  category/category-title)
 
 (def ^{:stratum 0} category-order
   "Get the integer sort order for a category ID, resolving aliases first.
    (category-order taxonomy category-id) returns the order int, or
    Integer/MAX_VALUE if not found."
-  taxonomy/category-order)
+  category/category-order)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/taxonomy.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/taxonomy.clj
@@ -22,21 +22,22 @@
    the runtime resolves category IDs to display labels and sort orders
    without any knowledge of Dewey codes or MDC format.
 
-   Layer 0: TaxonomyCategory/TaxonomyAlias/TaxonomyRef schemas, category-by-id,
-     resolve-alias
-   Layer 1: Taxonomy schema (composes TaxonomyCategory/TaxonomyAlias),
-     category-title, category-order (over category-by-id)
-   Layer 2: valid-taxonomy?, validate-taxonomy (over the Taxonomy schema)
-   Layer 3: load-taxonomy, load-taxonomy-from-classpath (over
-     validate-taxonomy)
+   Category schemas (TaxonomyCategory/TaxonomyAlias/TaxonomyRef, the
+   composed Taxonomy schema) and the pure category-by-id/resolve-alias/
+   category-title/category-order lookups live in
+   `ai.miniforge.policy-pack.taxonomy.category` (rule 210: this combined
+   namespace measured 4 real layers, max 3). This namespace keeps malli
+   validation and EDN/classpath loading, which build on that schema.
 
-   4 real strata — over the rule 210 budget of 3; a genuine namespace split
-   (Wave 2), not a labeling problem.
+   Layer 0: valid-taxonomy?, validate-taxonomy (over the Taxonomy schema)
+   Layer 1: load-taxonomy, load-taxonomy-from-classpath (over
+     validate-taxonomy)
 
    Related:
      specs/normative/N4-policy-packs.md §2.1 — Taxonomy artifact spec
      docs/design/policy-pack-taxonomy.md     — Four-artifact model design"
   (:require
+   [ai.miniforge.policy-pack.taxonomy.category :as category]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
    [malli.core :as m]
@@ -44,97 +45,22 @@
 
 ;------------------------------------------------------------------------------ Layer 0
 
-;; Schemas
-(def ^{:stratum 0} TaxonomyCategory
-  "Schema for a single category within a taxonomy.
+;; Validation
+(defn ^{:stratum 0} valid-taxonomy?
+  [value]
+  (m/validate category/Taxonomy value))
 
-   :category/id     — Stable namespaced keyword, immutable after publication
-   :category/code   — Display code (e.g. \"210\"); Dewey numbers, display only
-   :category/title  — Human-readable label for reports
-   :category/parent — Parent category ID (nil for root categories)
-   :category/order  — Integer sort order; drives rule application sequence"
-  [:map
-   [:category/id keyword?]
-   [:category/code string?]
-   [:category/title string?]
-   [:category/parent {:optional true} [:maybe keyword?]]
-   [:category/order int?]])
-
-(def ^{:stratum 0} TaxonomyAlias
-  "Schema for a taxonomy alias — stable logical name to category ID mapping.
-   Allows decoupling rule category references from taxonomy reorganization."
-  [:map
-   [:alias/name keyword?]
-   [:alias/target keyword?]])
-
-(def ^{:stratum 0} TaxonomyRef
-  "Schema for a taxonomy reference within a pack manifest.
-   Packs declare which taxonomy they target and the minimum version required."
-  [:map
-   [:taxonomy/id keyword?]
-   [:taxonomy/min-version string?]])
-
-;; Lookup helpers
-(defn ^{:stratum 0} category-by-id
-  [taxonomy category-id]
-  (some (fn [cat]
-          (when (= category-id (:category/id cat))
-            cat))
-        (:taxonomy/categories taxonomy)))
-
-(defn ^{:stratum 0} resolve-alias
-  [taxonomy alias-kw]
-  (or (some (fn [a]
-              (when (= alias-kw (:alias/name a))
-                (:alias/target a)))
-            (:taxonomy/aliases taxonomy))
-      alias-kw))
+(defn ^{:stratum 0} validate-taxonomy
+  [value]
+  (if (m/validate category/Taxonomy value)
+    {:valid? true :errors nil}
+    {:valid? false
+     :errors (me/humanize (m/explain category/Taxonomy value))}))
 
 ;------------------------------------------------------------------------------ Layer 1
 
-(def ^{:stratum 1} Taxonomy
-  "Schema for a taxonomy artifact.
-
-   Taxonomies are independently versioned category trees. Each pack
-   references a taxonomy via :pack/taxonomy-ref and declares a minimum
-   compatible version."
-  [:map
-   [:taxonomy/id keyword?]
-   [:taxonomy/version string?]
-   [:taxonomy/title string?]
-   [:taxonomy/description {:optional true} string?]
-   [:taxonomy/categories [:vector TaxonomyCategory]]
-   [:taxonomy/aliases {:optional true} [:vector TaxonomyAlias]]])
-
-(defn ^{:stratum 1} category-title
-  [taxonomy category-id]
-  (let [resolved (resolve-alias taxonomy category-id)]
-    (:category/title (category-by-id taxonomy resolved))))
-
-(defn ^{:stratum 1} category-order
-  [taxonomy category-id]
-  (let [resolved (resolve-alias taxonomy category-id)]
-    (or (:category/order (category-by-id taxonomy resolved))
-        Integer/MAX_VALUE)))
-
-;------------------------------------------------------------------------------ Layer 2
-
-;; Validation
-(defn ^{:stratum 2} valid-taxonomy?
-  [value]
-  (m/validate Taxonomy value))
-
-(defn ^{:stratum 2} validate-taxonomy
-  [value]
-  (if (m/validate Taxonomy value)
-    {:valid? true :errors nil}
-    {:valid? false
-     :errors (me/humanize (m/explain Taxonomy value))}))
-
-;------------------------------------------------------------------------------ Layer 3
-
 ;; Loading
-(defn ^{:stratum 3} load-taxonomy
+(defn ^{:stratum 1} load-taxonomy
   "Load a taxonomy artifact from an EDN file.
 
    Arguments:
@@ -156,7 +82,7 @@
     (catch Exception e
       {:success? false :error (.getMessage e)})))
 
-(defn ^{:stratum 3} load-taxonomy-from-classpath
+(defn ^{:stratum 1} load-taxonomy-from-classpath
   "Load a taxonomy from the classpath resources.
 
    Arguments:

--- a/components/policy-pack/src/ai/miniforge/policy_pack/taxonomy/category.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/taxonomy/category.clj
@@ -1,0 +1,111 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.taxonomy.category
+  "Taxonomy category schemas and lookup helpers.
+
+   TaxonomyCategory/TaxonomyAlias/TaxonomyRef and the composed Taxonomy
+   schema, plus the pure lookup functions that resolve a category ID or
+   alias against a loaded taxonomy. Split out of
+   `ai.miniforge.policy-pack.taxonomy` (rule 210: the combined
+   namespace measured 4 real layers, max 3) — schema shape and lookup
+   live here; malli validation and EDN/classpath loading stay in the
+   parent namespace, which requires this one for the `Taxonomy` schema.
+
+   Layer 0: TaxonomyCategory/TaxonomyAlias/TaxonomyRef schemas,
+     category-by-id, resolve-alias
+   Layer 1: Taxonomy schema (composes TaxonomyCategory/TaxonomyAlias),
+     category-title, category-order (over category-by-id/resolve-alias)
+
+   Related:
+     specs/normative/N4-policy-packs.md §2.1 — Taxonomy artifact spec
+     docs/design/policy-pack-taxonomy.md     — Four-artifact model design")
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Schemas
+(def ^{:stratum 0} TaxonomyCategory
+  "Schema for a single category within a taxonomy.
+
+   :category/id     — Stable namespaced keyword, immutable after publication
+   :category/code   — Display code (e.g. \"210\"); Dewey numbers, display only
+   :category/title  — Human-readable label for reports
+   :category/parent — Parent category ID (nil for root categories)
+   :category/order  — Integer sort order; drives rule application sequence"
+  [:map
+   [:category/id keyword?]
+   [:category/code string?]
+   [:category/title string?]
+   [:category/parent {:optional true} [:maybe keyword?]]
+   [:category/order int?]])
+
+(def ^{:stratum 0} TaxonomyAlias
+  "Schema for a taxonomy alias — stable logical name to category ID mapping.
+   Allows decoupling rule category references from taxonomy reorganization."
+  [:map
+   [:alias/name keyword?]
+   [:alias/target keyword?]])
+
+(def ^{:stratum 0} TaxonomyRef
+  "Schema for a taxonomy reference within a pack manifest.
+   Packs declare which taxonomy they target and the minimum version required."
+  [:map
+   [:taxonomy/id keyword?]
+   [:taxonomy/min-version string?]])
+
+;; Lookup helpers
+(defn ^{:stratum 0} category-by-id
+  [taxonomy category-id]
+  (some (fn [cat]
+          (when (= category-id (:category/id cat))
+            cat))
+        (:taxonomy/categories taxonomy)))
+
+(defn ^{:stratum 0} resolve-alias
+  [taxonomy alias-kw]
+  (or (some (fn [a]
+              (when (= alias-kw (:alias/name a))
+                (:alias/target a)))
+            (:taxonomy/aliases taxonomy))
+      alias-kw))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(def ^{:stratum 1} Taxonomy
+  "Schema for a taxonomy artifact.
+
+   Taxonomies are independently versioned category trees. Each pack
+   references a taxonomy via :pack/taxonomy-ref and declares a minimum
+   compatible version."
+  [:map
+   [:taxonomy/id keyword?]
+   [:taxonomy/version string?]
+   [:taxonomy/title string?]
+   [:taxonomy/description {:optional true} string?]
+   [:taxonomy/categories [:vector TaxonomyCategory]]
+   [:taxonomy/aliases {:optional true} [:vector TaxonomyAlias]]])
+
+(defn ^{:stratum 1} category-title
+  [taxonomy category-id]
+  (let [resolved (resolve-alias taxonomy category-id)]
+    (:category/title (category-by-id taxonomy resolved))))
+
+(defn ^{:stratum 1} category-order
+  [taxonomy category-id]
+  (let [resolved (resolve-alias taxonomy category-id)]
+    (or (:category/order (category-by-id taxonomy resolved))
+        Integer/MAX_VALUE)))

--- a/components/policy-pack/test/ai/miniforge/policy_pack/taxonomy_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/taxonomy_test.clj
@@ -27,6 +27,7 @@
    [clojure.test :refer [deftest testing is]]
    [malli.core]
    [ai.miniforge.policy-pack.taxonomy :as sut]
+   [ai.miniforge.policy-pack.taxonomy.category :as category]
    [ai.miniforge.policy-pack.mdc-compiler :as mdc-compiler]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -68,12 +69,12 @@
 
 (deftest ^{:stratum 0} taxonomy-ref-schema-test
   (testing "valid TaxonomyRef"
-    (is (true? (malli.core/validate sut/TaxonomyRef
+    (is (true? (malli.core/validate category/TaxonomyRef
                                     {:taxonomy/id :miniforge/dewey
                                      :taxonomy/min-version "1.0.0"}))))
 
   (testing "TaxonomyRef missing version fails"
-    (is (false? (malli.core/validate sut/TaxonomyRef
+    (is (false? (malli.core/validate category/TaxonomyRef
                                      {:taxonomy/id :miniforge/dewey})))))
 
 ;; ============================================================================
@@ -122,8 +123,8 @@
 
   (testing "aliases resolve correctly"
     (let [taxonomy (mdc-compiler/export-canonical-taxonomy)]
-      (is (= :mf.cat/foundations (sut/resolve-alias taxonomy :foundations)))
-      (is (= :mf.cat/languages (sut/resolve-alias taxonomy :languages)))))
+      (is (= :mf.cat/foundations (category/resolve-alias taxonomy :foundations)))
+      (is (= :mf.cat/languages (category/resolve-alias taxonomy :languages)))))
 
   (testing "exported taxonomy matches bundled resource"
     (let [exported (mdc-compiler/export-canonical-taxonomy)
@@ -170,34 +171,34 @@
 ;; ============================================================================
 (deftest ^{:stratum 1} category-by-id-test
   (testing "finds category by keyword ID"
-    (let [cat (sut/category-by-id minimal-taxonomy :test.cat/alpha)]
+    (let [cat (category/category-by-id minimal-taxonomy :test.cat/alpha)]
       (is (= :test.cat/alpha (:category/id cat)))
       (is (= "Alpha Category" (:category/title cat)))))
 
   (testing "returns nil for unknown category"
-    (is (nil? (sut/category-by-id minimal-taxonomy :test.cat/unknown)))))
+    (is (nil? (category/category-by-id minimal-taxonomy :test.cat/unknown)))))
 
 (deftest ^{:stratum 1} resolve-alias-test
   (testing "resolves known alias to target"
-    (is (= :test.cat/alpha (sut/resolve-alias minimal-taxonomy :alpha))))
+    (is (= :test.cat/alpha (category/resolve-alias minimal-taxonomy :alpha))))
 
   (testing "returns input unchanged for unknown alias"
-    (is (= :test.cat/beta (sut/resolve-alias minimal-taxonomy :test.cat/beta)))))
+    (is (= :test.cat/beta (category/resolve-alias minimal-taxonomy :test.cat/beta)))))
 
 (deftest ^{:stratum 1} category-title-test
   (testing "returns title for direct category ID"
-    (is (= "Alpha Category" (sut/category-title minimal-taxonomy :test.cat/alpha))))
+    (is (= "Alpha Category" (category/category-title minimal-taxonomy :test.cat/alpha))))
 
   (testing "returns title via alias resolution"
-    (is (= "Alpha Category" (sut/category-title minimal-taxonomy :alpha))))
+    (is (= "Alpha Category" (category/category-title minimal-taxonomy :alpha))))
 
   (testing "returns nil for unknown category"
-    (is (nil? (sut/category-title minimal-taxonomy :unknown)))))
+    (is (nil? (category/category-title minimal-taxonomy :unknown)))))
 
 (deftest ^{:stratum 1} category-order-test
   (testing "returns order for known category"
-    (is (= 0 (sut/category-order minimal-taxonomy :test.cat/alpha)))
-    (is (= 100 (sut/category-order minimal-taxonomy :test.cat/beta))))
+    (is (= 0 (category/category-order minimal-taxonomy :test.cat/alpha)))
+    (is (= 100 (category/category-order minimal-taxonomy :test.cat/beta))))
 
   (testing "returns MAX_VALUE for unknown category"
-    (is (= Integer/MAX_VALUE (sut/category-order minimal-taxonomy :unknown)))))
+    (is (= Integer/MAX_VALUE (category/category-order minimal-taxonomy :unknown)))))

--- a/docs/pull-requests/2026-08-11-refactor-split-policy-pack-taxonomy.md
+++ b/docs/pull-requests/2026-08-11-refactor-split-policy-pack-taxonomy.md
@@ -1,0 +1,122 @@
+<!--
+  Title: Split policy-pack/taxonomy.clj (rule 210)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(policy-pack): split taxonomy.clj (rule 210)
+
+## Overview
+
+Splits the taxonomy artifact's category schemas and lookup helpers out
+of `ai.miniforge.policy-pack.taxonomy` into a new sibling namespace,
+`ai.miniforge.policy-pack.taxonomy.category`, resolving a stratum-lint
+SL003 finding (the combined namespace measured 4 real layers, over
+the rule 210 budget of 3).
+
+## Motivation
+
+Part of the stratum-lint rule-210 remediation program's policy-pack
+Wave 2, batch 2. `taxonomy.clj` (199 lines) is one of this batch.
+Unlike most files remaining in this program, this one is not
+zero-fan-in: two files inside the same component reference it
+directly (`interface/taxonomy.clj`, `taxonomy_test.clj`), so this
+split required updating call sites, not just moving code.
+
+## Changes in Detail
+
+- New file `taxonomy/category.clj`: `TaxonomyCategory`, `TaxonomyAlias`,
+  `TaxonomyRef` schemas, the composed `Taxonomy` schema, and the pure
+  lookup functions `category-by-id`, `resolve-alias`, `category-title`,
+  `category-order` — 2 layers. None of this needs malli or EDN/IO, so
+  the new namespace has no `:require` clause at all.
+- `taxonomy.clj`: keeps `valid-taxonomy?`/`validate-taxonomy` (malli
+  validation over `category/Taxonomy`) and `load-taxonomy`/
+  `load-taxonomy-from-classpath` (EDN/classpath loading) — now 2
+  layers (down from 4). Requires `taxonomy.category` for the schema.
+  The rich-comment block at the bottom is unchanged, since both
+  functions it exercises (`valid-taxonomy?`, `load-taxonomy-from-classpath`)
+  stayed in this namespace.
+- `interface/taxonomy.clj`: this Polylith interface file re-exports
+  every taxonomy def via a `def` alias. Updated the 8 defs that moved
+  (`Taxonomy`, `TaxonomyCategory`, `TaxonomyAlias`, `TaxonomyRef`,
+  `category-by-id`, `resolve-alias`, `category-title`,
+  `category-order`) to delegate to `category/*` instead of
+  `taxonomy/*`; the 4 that stayed (`valid-taxonomy?`,
+  `validate-taxonomy`, `load-taxonomy`, `load-taxonomy-from-classpath`)
+  are untouched. The interface's own public API surface — the 12 defs
+  it exposes to the rest of the workspace — is unchanged; nothing
+  outside `policy-pack` needed to change.
+- `taxonomy_test.clj`: added a `category` alias for
+  `ai.miniforge.policy-pack.taxonomy.category` alongside the existing
+  `sut` alias. Updated call sites for the 8 moved symbols
+  (`TaxonomyRef`, `category-by-id`, `resolve-alias`, `category-title`,
+  `category-order`, and their schema/lookup test groups) to
+  `category/*`; left the `sut/valid-taxonomy?`, `sut/validate-taxonomy`,
+  `sut/load-taxonomy-from-classpath` call sites alone since those defs
+  didn't move.
+
+This is pure code motion — no logic changed. The def set is identical
+before and after (12 defs total, same names), and the interface file's
+exposed public API is byte-identical (diffed both def-name lists to
+confirm).
+
+## Testing Plan
+
+- Fan-in check before starting: `grep -rlE
+  "ai\.miniforge\.policy-pack\.taxonomy\b" --include='*.clj' components
+  bases projects` — grepping the namespace symbol (not the underscored
+  file path, the mistake that bit `mdc_compiler.clj`'s split,
+  miniforge#1740) found exactly 3 files: the target itself,
+  `interface/taxonomy.clj`, and `taxonomy_test.clj`. Also checked
+  `mdc_compiler/dewey.clj` (which builds an
+  `export-canonical-taxonomy` map structurally matching the `Taxonomy`
+  schema) — it does not `:require` `ai.miniforge.policy-pack.taxonomy`
+  at all, so it's not a caller here.
+- `projects/miniforge/test/` grepped separately for any taxonomy
+  reference — none found. No project-level caller exists for this
+  file (unlike the `knowledge_safety.clj` split, which had one in
+  `governance/e2e_test.clj`).
+- `stratum-lint` clean (exit 0) on all four touched/new files, before
+  and after `--fix` (no changes from `--fix` — files were already
+  correctly formatted).
+- Direct component-test verification (bypassing the shared machine's
+  contended `bb test` — several other stratum-lint batch tasks were
+  running concurrently, which pushed the full change-scope run past
+  30 minutes): `cd components/policy-pack && clojure -M:test -e
+  "(require 'ai.miniforge.policy-pack.taxonomy-test)
+  (require 'ai.miniforge.policy-pack.mdc-compiler-test)
+  (require 'ai.miniforge.policy-pack.interface-test)
+  (clojure.test/run-tests 'ai.miniforge.policy-pack.taxonomy-test
+  'ai.miniforge.policy-pack.mdc-compiler-test
+  'ai.miniforge.policy-pack.interface-test)"` — 50 tests, 267
+  assertions, 0 failures. `mdc-compiler-test` and `interface-test`
+  were included because they exercise `export-canonical-taxonomy` and
+  the full `interface/taxonomy.clj` re-export surface respectively.
+- `bb commit-budget` / PR-total line count kept under the 200/600
+  ceilings by splitting into two commits: the code split itself
+  (165 reportable lines) and the caller updates (48 reportable lines).
+
+## Deployment Plan
+
+Merges to `main` immediately; no follow-up needed for this file.
+
+## Related Issues/PRs
+
+- Part of the stratum-lint rule-210 remediation program, policy-pack
+  Wave 2 batch 2 (see `knowledge_safety.clj`/`knowledge_safety/detectors.clj`
+  miniforge#1731 and the `mdc_compiler.clj`/`mdc_compiler/dewey.clj`
+  split miniforge#1740 for the established convention and the
+  fan-in-grep methodology this follows).
+
+## Checklist
+
+- [x] stratum-lint clean on all resulting files
+- [x] Component tests green (`taxonomy-test`, `mdc-compiler-test`,
+      `interface-test` — 267 assertions, 0 failures), verified directly
+- [x] Adversarial self-review: def set unchanged (relocated only), no
+      logic changes; interface's public API surface byte-identical
+- [x] All call sites updated: `interface/taxonomy.clj`,
+      `taxonomy_test.clj` — no project-level caller exists
+- [x] Zero-fan-in check done via fully-qualified namespace grep, not a
+      symbol-prefix guess


### PR DESCRIPTION
<!--
  Title: Split policy-pack/taxonomy.clj (rule 210)
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# refactor(policy-pack): split taxonomy.clj (rule 210)

## Overview

Splits the taxonomy artifact's category schemas and lookup helpers out
of `ai.miniforge.policy-pack.taxonomy` into a new sibling namespace,
`ai.miniforge.policy-pack.taxonomy.category`, resolving a stratum-lint
SL003 finding (the combined namespace measured 4 real layers, over
the rule 210 budget of 3).

## Motivation

Part of the stratum-lint rule-210 remediation program's policy-pack
Wave 2, batch 2. `taxonomy.clj` (199 lines) is one of this batch.
Unlike most files remaining in this program, this one is not
zero-fan-in: two files inside the same component reference it
directly (`interface/taxonomy.clj`, `taxonomy_test.clj`), so this
split required updating call sites, not just moving code.

## Changes in Detail

- New file `taxonomy/category.clj`: `TaxonomyCategory`, `TaxonomyAlias`,
  `TaxonomyRef` schemas, the composed `Taxonomy` schema, and the pure
  lookup functions `category-by-id`, `resolve-alias`, `category-title`,
  `category-order` — 2 layers. None of this needs malli or EDN/IO, so
  the new namespace has no `:require` clause at all.
- `taxonomy.clj`: keeps `valid-taxonomy?`/`validate-taxonomy` (malli
  validation over `category/Taxonomy`) and `load-taxonomy`/
  `load-taxonomy-from-classpath` (EDN/classpath loading) — now 2
  layers (down from 4). Requires `taxonomy.category` for the schema.
  The rich-comment block at the bottom is unchanged, since both
  functions it exercises (`valid-taxonomy?`, `load-taxonomy-from-classpath`)
  stayed in this namespace.
- `interface/taxonomy.clj`: this Polylith interface file re-exports
  every taxonomy def via a `def` alias. Updated the 8 defs that moved
  (`Taxonomy`, `TaxonomyCategory`, `TaxonomyAlias`, `TaxonomyRef`,
  `category-by-id`, `resolve-alias`, `category-title`,
  `category-order`) to delegate to `category/*` instead of
  `taxonomy/*`; the 4 that stayed (`valid-taxonomy?`,
  `validate-taxonomy`, `load-taxonomy`, `load-taxonomy-from-classpath`)
  are untouched. The interface's own public API surface — the 12 defs
  it exposes to the rest of the workspace — is unchanged; nothing
  outside `policy-pack` needed to change.
- `taxonomy_test.clj`: added a `category` alias for
  `ai.miniforge.policy-pack.taxonomy.category` alongside the existing
  `sut` alias. Updated call sites for the 8 moved symbols
  (`TaxonomyRef`, `category-by-id`, `resolve-alias`, `category-title`,
  `category-order`, and their schema/lookup test groups) to
  `category/*`; left the `sut/valid-taxonomy?`, `sut/validate-taxonomy`,
  `sut/load-taxonomy-from-classpath` call sites alone since those defs
  didn't move.

This is pure code motion — no logic changed. The def set is identical
before and after (12 defs total, same names), and the interface file's
exposed public API is byte-identical (diffed both def-name lists to
confirm).

## Testing Plan

- Fan-in check before starting: `grep -rlE
  "ai\.miniforge\.policy-pack\.taxonomy\b" --include='*.clj' components
  bases projects` — grepping the namespace symbol (not the underscored
  file path, the mistake that bit `mdc_compiler.clj`'s split,
  miniforge#1740) found exactly 3 files: the target itself,
  `interface/taxonomy.clj`, and `taxonomy_test.clj`. Also checked
  `mdc_compiler/dewey.clj` (which builds an
  `export-canonical-taxonomy` map structurally matching the `Taxonomy`
  schema) — it does not `:require` `ai.miniforge.policy-pack.taxonomy`
  at all, so it's not a caller here.
- `projects/miniforge/test/` grepped separately for any taxonomy
  reference — none found. No project-level caller exists for this
  file (unlike the `knowledge_safety.clj` split, which had one in
  `governance/e2e_test.clj`).
- `stratum-lint` clean (exit 0) on all four touched/new files, before
  and after `--fix` (no changes from `--fix` — files were already
  correctly formatted).
- Direct component-test verification (bypassing the shared machine's
  contended `bb test` — several other stratum-lint batch tasks were
  running concurrently, which pushed the full change-scope run past
  30 minutes): `cd components/policy-pack && clojure -M:test -e
  "(require 'ai.miniforge.policy-pack.taxonomy-test)
  (require 'ai.miniforge.policy-pack.mdc-compiler-test)
  (require 'ai.miniforge.policy-pack.interface-test)
  (clojure.test/run-tests 'ai.miniforge.policy-pack.taxonomy-test
  'ai.miniforge.policy-pack.mdc-compiler-test
  'ai.miniforge.policy-pack.interface-test)"` — 50 tests, 267
  assertions, 0 failures. `mdc-compiler-test` and `interface-test`
  were included because they exercise `export-canonical-taxonomy` and
  the full `interface/taxonomy.clj` re-export surface respectively.
- `bb commit-budget` / PR-total line count kept under the 200/600
  ceilings by splitting into two commits: the code split itself
  (165 reportable lines) and the caller updates (48 reportable lines).

## Deployment Plan

Merges to `main` immediately; no follow-up needed for this file.

## Related Issues/PRs

- Part of the stratum-lint rule-210 remediation program, policy-pack
  Wave 2 batch 2 (see `knowledge_safety.clj`/`knowledge_safety/detectors.clj`
  miniforge#1731 and the `mdc_compiler.clj`/`mdc_compiler/dewey.clj`
  split miniforge#1740 for the established convention and the
  fan-in-grep methodology this follows).

## Checklist

- [x] stratum-lint clean on all resulting files
- [x] Component tests green (`taxonomy-test`, `mdc-compiler-test`,
      `interface-test` — 267 assertions, 0 failures), verified directly
- [x] Adversarial self-review: def set unchanged (relocated only), no
      logic changes; interface's public API surface byte-identical
- [x] All call sites updated: `interface/taxonomy.clj`,
      `taxonomy_test.clj` — no project-level caller exists
- [x] Zero-fan-in check done via fully-qualified namespace grep, not a
      symbol-prefix guess
