### PR TITLE
refactor(policy-pack): split repair.clj (rule 210)

### DIFF
--- a/components/policy-pack/src/ai/miniforge/policy_pack/repair.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/repair.clj
@@ -16,21 +16,18 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns ai.miniforge.policy-pack.repair
-  "Repair function registry for policy-pack violations.
+  "Repair orchestration for policy-pack violations: looks up a registered
+   repair function and applies it, sequentially, across a set of violations.
 
-   Repair functions can automatically fix certain violation types.
-   They are registered by rule-id or violation pattern.
+   Registry storage/lookup and the built-in repair implementations were
+   split out to `ai.miniforge.policy-pack.repair.registry` and
+   `ai.miniforge.policy-pack.repair.builtin` (rule 210: this namespace
+   measured 4 real layers, max 3; a genuine namespace split (Wave 2), not a
+   labeling problem).
 
-   Layer 0: succeeded?, repair-registry atom, built-in repair fns
-     (whitespace-repair, trailing-newline-repair)
-   Layer 1: register-repair!, deregister-repair!, get-repair-fn, list-repairs
-     (over repair-registry)
-   Layer 2: attempt-repair (over get-repair-fn)
-   Layer 3: attempt-repairs (over attempt-repair)
-
-   4 real strata — over the rule 210 budget of 3; a genuine namespace split
-   (Wave 2), not a labeling problem."
-  (:require [clojure.string :as str]))
+   Layer 0: succeeded?, attempt-repair (over repair.registry/get-repair-fn)
+   Layer 1: attempt-repairs (over attempt-repair)"
+  (:require [ai.miniforge.policy-pack.repair.registry :as registry]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -40,76 +37,8 @@
   [result]
   (boolean (:success? result)))
 
-;; Repair registry
-;; Registry of repair functions keyed by rule-id pattern.
-(defonce ^{:stratum 0} repair-registry (atom {}))
-
-;; Built-in repair functions
-(defn ^{:stratum 0} whitespace-repair
-  "Repair function for whitespace violations (trailing whitespace, mixed tabs/spaces)."
-  [_violation artifact _context]
-  (let [content (get artifact :content "")
-        fixed (-> content
-                  (str/replace #"[ \t]+\n" "\n")
-                  (str/replace #"\t" "  "))]
-    (if (= content fixed)
-      {:success? false :artifact artifact :fix-description "No whitespace issues found"}
-      {:success? true
-       :artifact (assoc artifact :content fixed)
-       :fix-description "Removed trailing whitespace and converted tabs to spaces"})))
-
-(defn ^{:stratum 0} trailing-newline-repair
-  "Ensure file ends with exactly one newline."
-  [_violation artifact _context]
-  (let [content (get artifact :content "")
-        fixed (str (clojure.string/trimr content) "\n")]
-    {:success? true
-     :artifact (assoc artifact :content fixed)
-     :fix-description "Ensured file ends with single newline"}))
-
-;------------------------------------------------------------------------------ Layer 1
-
-(defn ^{:stratum 1} register-repair!
-  "Register a repair function for a rule-id or pattern.
-
-   Arguments:
-   - rule-id-or-pattern: String or regex matching rule IDs
-   - repair-fn: (fn [violation artifact context] -> {:success? bool :artifact map :fix-description string})
-
-   Returns: rule-id-or-pattern"
-  [rule-id-or-pattern repair-fn]
-  (swap! repair-registry assoc rule-id-or-pattern repair-fn)
-  rule-id-or-pattern)
-
-(defn ^{:stratum 1} deregister-repair!
-  "Remove a repair function."
-  [rule-id-or-pattern]
-  (swap! repair-registry dissoc rule-id-or-pattern)
-  nil)
-
-(defn ^{:stratum 1} get-repair-fn
-  "Find a repair function for a given rule-id.
-
-   Checks exact match first, then regex patterns.
-
-   Returns: repair-fn or nil"
-  [rule-id]
-  (or (get @repair-registry rule-id)
-      (some (fn [[k v]]
-              (when (and (instance? java.util.regex.Pattern k)
-                         (re-matches k rule-id))
-                v))
-            @repair-registry)))
-
-(defn ^{:stratum 1} list-repairs
-  "List all registered repair function keys."
-  []
-  (keys @repair-registry))
-
-;------------------------------------------------------------------------------ Layer 2
-
 ;; Repair orchestration
-(defn ^{:stratum 2} attempt-repair
+(defn ^{:stratum 0} attempt-repair
   "Attempt to repair a single violation.
 
    Arguments:
@@ -119,7 +48,7 @@
 
    Returns: {:success? bool :artifact map :fix-description string?} or nil if no repair available"
   [violation artifact context]
-  (when-let [repair-fn (get-repair-fn (:violation/rule-id violation))]
+  (when-let [repair-fn (registry/get-repair-fn (:violation/rule-id violation))]
     (try
       (repair-fn violation artifact context)
       (catch Exception e
@@ -127,9 +56,9 @@
          :artifact artifact
          :fix-description (str "Repair failed: " (ex-message e))}))))
 
-;------------------------------------------------------------------------------ Layer 3
+;------------------------------------------------------------------------------ Layer 1
 
-(defn ^{:stratum 3} attempt-repairs
+(defn ^{:stratum 1} attempt-repairs
   "Attempt to repair all violations in sequence.
 
    Applies repair functions in order. Each successful repair updates the artifact

--- a/components/policy-pack/src/ai/miniforge/policy_pack/repair/builtin.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/repair/builtin.clj
@@ -41,7 +41,12 @@
        :fix-description "Removed trailing whitespace and converted tabs to spaces"})))
 
 (defn ^{:stratum 0} trailing-newline-repair
-  "Ensure file ends with exactly one newline."
+  "Ensure file ends with exactly one newline. Uses `trimr`, which strips ALL
+   trailing whitespace (spaces/tabs/newlines), not just newline characters,
+   before appending the single `\\n` — so a file with trailing spaces on its
+   last line loses them too. That overlaps `whitespace-repair` by design:
+   this repair's job is the end-of-file newline invariant, not narrowly
+   scoped to newline characters alone."
   [_violation artifact _context]
   (let [content (get artifact :content "")
         fixed (str (clojure.string/trimr content) "\n")]

--- a/components/policy-pack/src/ai/miniforge/policy_pack/repair/builtin.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/repair/builtin.clj
@@ -1,0 +1,50 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.repair.builtin
+  "Built-in repair functions (whitespace, trailing newline). Split out of
+   `ai.miniforge.policy-pack.repair` (rule 210: the parent namespace measured
+   4 real layers, max 3; these concrete repair implementations are
+   layer-coherent on their own). Not registered at load time — a caller
+   opts in via `ai.miniforge.policy-pack.repair.registry/register-repair!`.
+
+   Layer 0: whitespace-repair, trailing-newline-repair"
+  (:require [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} whitespace-repair
+  "Repair function for whitespace violations (trailing whitespace, mixed tabs/spaces)."
+  [_violation artifact _context]
+  (let [content (get artifact :content "")
+        fixed (-> content
+                  (str/replace #"[ \t]+\n" "\n")
+                  (str/replace #"\t" "  "))]
+    (if (= content fixed)
+      {:success? false :artifact artifact :fix-description "No whitespace issues found"}
+      {:success? true
+       :artifact (assoc artifact :content fixed)
+       :fix-description "Removed trailing whitespace and converted tabs to spaces"})))
+
+(defn ^{:stratum 0} trailing-newline-repair
+  "Ensure file ends with exactly one newline."
+  [_violation artifact _context]
+  (let [content (get artifact :content "")
+        fixed (str (clojure.string/trimr content) "\n")]
+    {:success? true
+     :artifact (assoc artifact :content fixed)
+     :fix-description "Ensured file ends with single newline"}))

--- a/components/policy-pack/src/ai/miniforge/policy_pack/repair/registry.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/repair/registry.clj
@@ -1,0 +1,70 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.repair.registry
+  "Repair function registry: keyed by rule-id or pattern, backed by an atom.
+   Split out of `ai.miniforge.policy-pack.repair` (rule 210: the parent
+   namespace measured 4 real layers, max 3; registry storage and lookup is
+   layer-coherent on its own).
+
+   Layer 0: repair-registry atom
+   Layer 1: register-repair!, deregister-repair!, get-repair-fn, list-repairs
+     (over repair-registry)")
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Registry of repair functions keyed by rule-id pattern.
+(defonce ^{:stratum 0} repair-registry (atom {}))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} register-repair!
+  "Register a repair function for a rule-id or pattern.
+
+   Arguments:
+   - rule-id-or-pattern: String or regex matching rule IDs
+   - repair-fn: (fn [violation artifact context] -> {:success? bool :artifact map :fix-description string})
+
+   Returns: rule-id-or-pattern"
+  [rule-id-or-pattern repair-fn]
+  (swap! repair-registry assoc rule-id-or-pattern repair-fn)
+  rule-id-or-pattern)
+
+(defn ^{:stratum 1} deregister-repair!
+  "Remove a repair function."
+  [rule-id-or-pattern]
+  (swap! repair-registry dissoc rule-id-or-pattern)
+  nil)
+
+(defn ^{:stratum 1} get-repair-fn
+  "Find a repair function for a given rule-id.
+
+   Checks exact match first, then regex patterns.
+
+   Returns: repair-fn or nil"
+  [rule-id]
+  (or (get @repair-registry rule-id)
+      (some (fn [[k v]]
+              (when (and (instance? java.util.regex.Pattern k)
+                         (re-matches k rule-id))
+                v))
+            @repair-registry)))
+
+(defn ^{:stratum 1} list-repairs
+  "List all registered repair function keys."
+  []
+  (keys @repair-registry))

--- a/docs/pull-requests/2026-08-11-refactor-split-policy-pack-repair.md
+++ b/docs/pull-requests/2026-08-11-refactor-split-policy-pack-repair.md
@@ -36,7 +36,11 @@ call-site risk, and no data (`.edn`) references any of its symbols.
   implementations (`whitespace-repair`, `trailing-newline-repair`) —
   1 layer, unchanged behavior. Not registered at load time (unchanged
   from before the split) — a caller opts in via
-  `repair.registry/register-repair!`.
+  `repair.registry/register-repair!`. `trailing-newline-repair`'s
+  docstring was expanded (doc-only, no logic change) to say plainly
+  that `trimr` strips all trailing whitespace, not just newlines,
+  before the single `\n` is appended — flagged by Copilot review as
+  a docstring/behavior mismatch in the moved code.
 - `repair.clj`: now only orchestration — `succeeded?` and
   `attempt-repair` (requiring `repair.registry` for
   `get-repair-fn`), and `attempt-repairs` — 2 layers.
@@ -48,7 +52,11 @@ re-namespaced. The def set is unchanged.
 
 - `stratum-lint` clean on all three files (exit 0, was SL003 exit 1
   on the combined file).
-- `bb test` (change-scope) green on the policy-pack component.
+- `bb test` — the full stable-derived changed-and-affected suite (not
+  scoped to policy-pack alone), run synchronously with the exit code
+  captured to a file rather than piped: exit 0, "Stable-derived test
+  plan passed", 27m35s, zero failures/errors across every namespace
+  exercised.
 - No existing test file for this namespace (confirmed before
   starting); none added, since this is pure restructuring with no
   behavior change — see `workflows/tests-with-code`.

--- a/docs/pull-requests/2026-08-11-refactor-split-policy-pack-repair.md
+++ b/docs/pull-requests/2026-08-11-refactor-split-policy-pack-repair.md
@@ -1,0 +1,73 @@
+<!--
+  Title: Split policy-pack/repair.clj (rule 210)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(policy-pack): split repair.clj (rule 210)
+
+## Overview
+
+Splits `ai.miniforge.policy-pack.repair` (4 real layers, over the rule
+210 budget of 3) into three files: the original `repair.clj` keeps
+only the orchestration (`succeeded?`, `attempt-repair`,
+`attempt-repairs`), and two new sibling namespaces take the registry
+storage/lookup and the built-in repair implementations,
+`ai.miniforge.policy-pack.repair.registry` and
+`ai.miniforge.policy-pack.repair.builtin`.
+
+## Motivation
+
+Part of the stratum-lint rule-210 remediation program's Wave 2, policy
+pack batch 2. `repair.clj` was a stratum-lint SL003 finding (4 real
+strata vs the budget of 3, per the file's own docstring, which already
+called out the split as owed). Zero fan-in repo-wide — nothing else
+requires `ai.miniforge.policy-pack.repair` — so the split carries no
+call-site risk, and no data (`.edn`) references any of its symbols.
+
+## Changes in Detail
+
+- New file `repair/registry.clj`
+  (`ai.miniforge.policy-pack.repair.registry`): the `repair-registry`
+  atom and its CRUD ops (`register-repair!`, `deregister-repair!`,
+  `get-repair-fn`, `list-repairs`) — 2 layers, unchanged behavior.
+- New file `repair/builtin.clj`
+  (`ai.miniforge.policy-pack.repair.builtin`): the concrete repair
+  implementations (`whitespace-repair`, `trailing-newline-repair`) —
+  1 layer, unchanged behavior. Not registered at load time (unchanged
+  from before the split) — a caller opts in via
+  `repair.registry/register-repair!`.
+- `repair.clj`: now only orchestration — `succeeded?` and
+  `attempt-repair` (requiring `repair.registry` for
+  `get-repair-fn`), and `attempt-repairs` — 2 layers.
+
+This is pure code motion: no logic changed, only relocated and
+re-namespaced. The def set is unchanged.
+
+## Testing Plan
+
+- `stratum-lint` clean on all three files (exit 0, was SL003 exit 1
+  on the combined file).
+- `bb test` (change-scope) green on the policy-pack component.
+- No existing test file for this namespace (confirmed before
+  starting); none added, since this is pure restructuring with no
+  behavior change — see `workflows/tests-with-code`.
+
+## Deployment Plan
+
+Merges to `main` immediately; no follow-up needed for this file.
+
+## Related Issues/PRs
+
+- Part of the stratum-lint rule-210 Wave 2 policy-pack batch 2 (see
+  `builtin_detectors.clj` split, and the original `workflow_runner.clj`
+  splits miniforge#1662-#1667, for the established convention this
+  follows).
+
+## Checklist
+
+- [x] stratum-lint clean on all three resulting files
+- [x] `bb test` green (policy-pack change-scope)
+- [x] Adversarial self-review: def set unchanged, only relocated
+- [x] Zero fan-in confirmed repo-wide before starting (re-verified,
+      not assumed from the task brief)

--- a/docs/pull-requests/2026-08-11-refactor-split-policy-pack-repair.md
+++ b/docs/pull-requests/2026-08-11-refactor-split-policy-pack-repair.md
@@ -36,17 +36,27 @@ call-site risk, and no data (`.edn`) references any of its symbols.
   implementations (`whitespace-repair`, `trailing-newline-repair`) —
   1 layer, unchanged behavior. Not registered at load time (unchanged
   from before the split) — a caller opts in via
-  `repair.registry/register-repair!`. `trailing-newline-repair`'s
-  docstring was expanded (doc-only, no logic change) to say plainly
-  that `trimr` strips all trailing whitespace, not just newlines,
-  before the single `\n` is appended — flagged by Copilot review as
-  a docstring/behavior mismatch in the moved code.
+  `ai.miniforge.policy-pack.repair.registry/register-repair!`.
+  `trailing-newline-repair`'s docstring was expanded (doc-only, no
+  logic change) to say plainly that `trimr` strips all trailing
+  whitespace, not just newlines, before the single `\n` is appended —
+  flagged by Copilot review as a docstring/behavior mismatch in the
+  moved code.
 - `repair.clj`: now only orchestration — `succeeded?` and
-  `attempt-repair` (requiring `repair.registry` for
-  `get-repair-fn`), and `attempt-repairs` — 2 layers.
+  `attempt-repair` (requiring
+  `ai.miniforge.policy-pack.repair.registry` for `get-repair-fn`),
+  and `attempt-repairs` — 2 layers.
 
 This is pure code motion: no logic changed, only relocated and
 re-namespaced. The def set is unchanged.
+
+Copilot also flagged (as a suppressed, non-blocking note) that
+`trailing-newline-repair` always returns `:success? true` even when
+`fixed` equals `content` — unlike `whitespace-repair`, which returns
+`:success? false` on a no-op. That inconsistency is unchanged
+pre-existing behavior carried over from `main`; fixing it would be a
+logic change outside this PR's pure-restructuring scope, so it is
+left as-is here and flagged separately for a follow-up.
 
 ## Testing Plan
 
@@ -75,7 +85,7 @@ Merges to `main` immediately; no follow-up needed for this file.
 ## Checklist
 
 - [x] stratum-lint clean on all three resulting files
-- [x] `bb test` green (policy-pack change-scope)
+- [x] `bb test` green (full stable-derived changed-and-affected suite)
 - [x] Adversarial self-review: def set unchanged, only relocated
 - [x] Zero fan-in confirmed repo-wide before starting (re-verified,
       not assumed from the task brief)


### PR DESCRIPTION
## Overview

Splits `ai.miniforge.policy-pack.repair` (4 real layers, over the rule
210 budget of 3) into three files: the original `repair.clj` keeps
only the orchestration (`succeeded?`, `attempt-repair`,
`attempt-repairs`), and two new sibling namespaces take the registry
storage/lookup and the built-in repair implementations,
`ai.miniforge.policy-pack.repair.registry` and
`ai.miniforge.policy-pack.repair.builtin`.

## Motivation

Part of the stratum-lint rule-210 remediation program's Wave 2, policy
pack batch 2. `repair.clj` was a stratum-lint SL003 finding (4 real
strata vs the budget of 3, per the file's own docstring, which already
called out the split as owed). Zero fan-in repo-wide — nothing else
requires `ai.miniforge.policy-pack.repair` — so the split carries no
call-site risk, and no data (`.edn`) references any of its symbols.

## Changes in Detail

- New file `repair/registry.clj` (`ai.miniforge.policy-pack.repair.registry`):
  the `repair-registry` atom and its CRUD ops (`register-repair!`,
  `deregister-repair!`, `get-repair-fn`, `list-repairs`) — 2 layers,
  unchanged behavior.
- New file `repair/builtin.clj` (`ai.miniforge.policy-pack.repair.builtin`):
  the concrete repair implementations (`whitespace-repair`,
  `trailing-newline-repair`) — 1 layer, unchanged behavior.
- `repair.clj`: now only orchestration — `succeeded?` and
  `attempt-repair` (requiring `repair.registry` for `get-repair-fn`),
  and `attempt-repairs` — 2 layers.

Pure code motion: no logic changed, only relocated and re-namespaced.
Def set unchanged.

## Testing Plan

- `stratum-lint` clean on all three files (exit 0, was SL003 exit 1
  on the combined file).
- `bb test` (full stable-derived changed-and-affected suite) green:
  27m35s, exit 0, "Stable-derived test plan passed".
- No existing test file for this namespace (confirmed before
  starting); none added, since this is pure restructuring with no
  behavior change.

## Deployment Plan

Merges to `main` immediately; no follow-up needed for this file.

## Related Issues/PRs

Part of the stratum-lint rule-210 Wave 2 policy-pack batch 2. See
`builtin_detectors.clj` split and the original `workflow_runner.clj`
splits (miniforge#1662-#1667) for the established convention this
follows.

## Checklist

- [x] stratum-lint clean on all three resulting files
- [x] `bb test` green
- [x] Adversarial self-review: def set unchanged, only relocated
- [x] Zero fan-in confirmed repo-wide before starting

🤖 Generated with [Claude Code](https://claude.com/claude-code)