### PR TITLE
refactor(policy-pack): split mdc_to_pack_mapping_test.clj — extract fields (2/7)

### DIFF
--- a/components/policy-pack/test/ai/miniforge/policy_pack/mdc_to_pack_mapping_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/mdc_to_pack_mapping_test.clj
@@ -30,6 +30,7 @@
    as the authoritative acceptance suite."
   (:require
    [ai.miniforge.policy-pack.mdc-to-pack-mapping-test.dewey :as dewey]
+   [ai.miniforge.policy-pack.mdc-to-pack-mapping-test.fields :as fields]
    [clojure.test :refer [deftest testing is are]]
    [clojure.string :as str]
    [clojure.set :as set]))
@@ -53,76 +54,6 @@
   (->> (str/split slug #"-")
        (map str/capitalize)
        (str/join " ")))
-
-(defn ^{:stratum 0} derive-description
-  "Generate :rule/description from category and title.
-   Format: 'Engineering standard (<category>): <title>'"
-  [category title]
-  (str "Engineering standard (" category "): " title))
-
-(defn ^{:stratum 0} normalize-globs
-  "Wrap string globs in a vector; pass vectors through; nil → nil."
-  [globs]
-  (cond
-    (nil? globs)    nil
-    (string? globs) [globs]
-    (vector? globs) globs
-    (sequential? globs) (vec globs)
-    :else [globs]))
-
-(defn ^{:stratum 0} build-always-inject
-  "Derive :rule/always-inject? map fragment.
-   true → {:rule/always-inject? true}, false/nil → {}"
-  [always-apply]
-  (if (true? always-apply)
-    {:rule/always-inject? true}
-    {}))
-
-(defn ^{:stratum 0} build-enforcement
-  "Build :rule/enforcement from title and alwaysApply flag."
-  [title always-apply]
-  {:action  (if always-apply :warn :audit)
-   :message (str "Standard: " title)})
-
-;; ---------------------------------------------------------------------------
-;; Agent behavior extraction helpers
-;; ---------------------------------------------------------------------------
-(defn ^{:stratum 0} extract-agent-behavior-section
-  "Extract ## Agent behavior section content from body.
-   Returns nil if section not found."
-  [body]
-  (when body
-    (let [lines (str/split-lines body)
-          start-idx (some (fn [[i line]]
-                           (when (re-matches #"(?i)^##\s+Agent\s+behavior.*" line)
-                             i))
-                         (map-indexed vector lines))]
-      (when start-idx
-        (let [rest-lines (drop (inc start-idx) lines)
-              content-lines (take-while
-                             (fn [line]
-                               (not (re-matches #"^##\s+.*" line)))
-                             rest-lines)
-              content (str/trim (str/join "\n" content-lines))]
-          (when (not (str/blank? content))
-            content))))))
-
-(defn ^{:stratum 0} extract-first-paragraph
-  "Extract first non-heading paragraph from body."
-  [body]
-  (when body
-    (let [lines (str/split-lines body)
-          ;; Skip leading headings and blank lines
-          content-lines (drop-while
-                         (fn [line]
-                           (or (str/blank? line)
-                               (str/starts-with? line "#")))
-                         lines)
-          ;; Take until blank line
-          para-lines (take-while (complement str/blank?) content-lines)
-          para (str/trim (str/join " " para-lines))]
-      (when (not (str/blank? para))
-        para))))
 
 ;; ---------------------------------------------------------------------------
 ;; Design spec data (from the .edn)
@@ -191,6 +122,15 @@
                        (set/union frontmatter-in-sources #{"globs"})) ;; globs is in compound source
           "All frontmatter fields must have mappings"))))
 
+(defn ^{:stratum 0} build-applies-to
+  "Build :rule/applies-to from dewey + optional globs."
+  [dewey-str globs]
+  (let [phases (dewey/dewey-to-phases dewey-str)
+        base   {:phases phases}]
+    (if-let [g (fields/normalize-globs globs)]
+      (assoc base :file-globs g)
+      base)))
+
 ;------------------------------------------------------------------------------ Layer 1
 
 (defn ^{:stratum 1} rule-id-from-filepath
@@ -230,101 +170,12 @@
       "stratified-design"       "Stratified Design"
       "git-branch-management"   "Git Branch Management")))
 
-;; ===========================================================================
-;; Section 3: Description Generation Tests
-;; ===========================================================================
-(deftest ^{:stratum 1} description-generation-test
-  (testing "Format: 'Engineering standard (<category>): <title>'"
-    (is (= "Engineering standard (001): Stratified Design — enforce one-way dependencies"
-           (derive-description "001" "Stratified Design — enforce one-way dependencies")))
-    (is (= "Engineering standard (210): Clojure Polylith + per-file stratified design"
-           (derive-description "210" "Clojure Polylith + per-file stratified design")))
-    (is (= "Engineering standard (000): Index"
-           (derive-description "000" "Index")))))
-
-;; ===========================================================================
-;; Section 5: alwaysApply → :rule/always-inject? Mapping Tests
-;; ===========================================================================
-(deftest ^{:stratum 1} always-inject-mapping-test
-  (testing "alwaysApply: true → {:rule/always-inject? true}"
-    (is (= {:rule/always-inject? true} (build-always-inject true))))
-
-  (testing "alwaysApply: false → {} (key omitted)"
-    (is (= {} (build-always-inject false))))
-
-  (testing "alwaysApply: nil (absent) → {} (key omitted)"
-    (is (= {} (build-always-inject nil))))
-
-  (testing "Consumers get nil (falsy) for missing always-inject?"
-    (let [rule-without (merge {} (build-always-inject false))]
-      (is (nil? (:rule/always-inject? rule-without))))))
-
-(deftest ^{:stratum 1} globs-normalization-test
-  (testing "String globs wrapped in vector"
-    (is (= ["*.clj"] (normalize-globs "*.clj"))))
-
-  (testing "Vector globs passed through"
-    (is (= ["*.clj" "*.cljc"] (normalize-globs ["*.clj" "*.cljc"]))))
-
-  (testing "nil globs → nil"
-    (is (nil? (normalize-globs nil)))))
-
-;; ===========================================================================
-;; Section 9: Agent Behavior Extraction Tests
-;; ===========================================================================
-(deftest ^{:stratum 1} agent-behavior-section-extraction-test
-  (testing "Extracts content from ## Agent behavior section"
-    (let [body "# Heading\n\nIntro paragraph.\n\n## Agent behavior\n\n- Do X.\n- Do Y.\n\n## Next section"]
-      (is (= "- Do X.\n- Do Y." (extract-agent-behavior-section body)))))
-
-  (testing "Case-insensitive heading match"
-    (let [body "## agent behavior\n\nDo stuff."]
-      (is (= "Do stuff." (extract-agent-behavior-section body)))))
-
-  (testing "Extracts to end of file when no next heading"
-    (let [body "## Agent behavior\n\n- Be concise.\n- Be clear."]
-      (is (= "- Be concise.\n- Be clear." (extract-agent-behavior-section body)))))
-
-  (testing "Returns nil when section not present"
-    (let [body "# Heading\n\nJust content, no agent behavior section."]
-      (is (nil? (extract-agent-behavior-section body)))))
-
-  (testing "Returns nil for empty section"
-    (let [body "## Agent behavior\n\n## Next heading"]
-      (is (nil? (extract-agent-behavior-section body)))))
-
-  (testing "Returns nil for nil body"
-    (is (nil? (extract-agent-behavior-section nil)))))
-
-(deftest ^{:stratum 1} first-paragraph-extraction-test
-  (testing "Extracts first non-heading paragraph"
-    (let [body "# Code Quality (ALWAYS)\n\nEvery function must read as a pipeline: data enters, transforms, exits.\n\nMore text."]
-      (is (= "Every function must read as a pipeline: data enters, transforms, exits."
-             (extract-first-paragraph body)))))
-
-  (testing "Skips leading headings and blank lines"
-    (let [body "\n# Heading\n## Sub\n\nActual content here."]
-      (is (= "Actual content here." (extract-first-paragraph body)))))
-
-  (testing "Returns nil for heading-only body"
-    (let [body "# Just a heading\n## And subheading"]
-      (is (nil? (extract-first-paragraph body)))))
-
-  (testing "Returns nil for nil body"
-    (is (nil? (extract-first-paragraph nil)))))
-
 (deftest ^{:stratum 1} edge-case-duplicate-slugs-test
   (testing "Duplicate filename slugs must be detectable"
     (let [files ["foundations/foo.mdc" "workflows/foo.mdc"]
           slugs (map slug-from-filename files)]
       (is (not= (count slugs) (count (set slugs)))
           "Duplicate slugs should be detected by ETL"))))
-
-(deftest ^{:stratum 1} edge-case-body-only-headings-test
-  (testing "Body with only headings → knowledge-content present, agent-behavior nil"
-    (let [body "# Just a heading\n## And subheading"]
-      (is (nil? (extract-agent-behavior-section body)))
-      (is (nil? (extract-first-paragraph body))))))
 
 ;; ===========================================================================
 ;; Section 15: Inventory Completeness Tests
@@ -393,14 +244,26 @@
       (is (= inventory-ids category-rules)
           "Pack categories should reference exactly the inventory rule IDs"))))
 
-(defn ^{:stratum 1} build-applies-to
-  "Build :rule/applies-to from dewey + optional globs."
-  [dewey-str globs]
-  (let [phases (dewey/dewey-to-phases dewey-str)
-        base   {:phases phases}]
-    (if-let [g (normalize-globs globs)]
-      (assoc base :file-globs g)
-      base)))
+;; ===========================================================================
+;; Section 6: Applies-To (Phases + Globs) Tests
+;; ===========================================================================
+(deftest ^{:stratum 1} applies-to-test
+  (testing "Dewey-only → phases from dewey, no globs"
+    (is (= {:phases #{:plan :implement :review :verify :release}}
+           (build-applies-to "001" nil))))
+
+  (testing "Dewey + globs → phases + file-globs"
+    (is (= {:phases     #{:implement :review}
+            :file-globs ["components/**/src/**/*.clj"]}
+           (build-applies-to "210" ["components/**/src/**/*.clj"]))))
+
+  (testing "Meta dewey → empty phases"
+    (is (= {:phases #{}} (build-applies-to "900" nil))))
+
+  (testing "Meta dewey + globs → empty phases + globs"
+    (is (= {:phases     #{}
+            :file-globs [".cursor/rules/**/*.mdc"]}
+           (build-applies-to "900" [".cursor/rules/**/*.mdc"])))))
 
 ;------------------------------------------------------------------------------ Layer 2
 
@@ -451,7 +314,7 @@
   [{:keys [filepath frontmatter body]}]
   (let [dewey       (get frontmatter "dewey" "000")
         title       (derive-title frontmatter filepath)
-        description (derive-description dewey title)
+        description (fields/derive-description dewey title)
         always-apply (get frontmatter "alwaysApply")
         globs       (get frontmatter "globs")
         severity    (if always-apply :high :low)
@@ -466,31 +329,10 @@
       :rule/category          dewey
       :rule/applies-to        (build-applies-to dewey globs)
       :rule/detection         {:type :custom}
-      :rule/enforcement       (build-enforcement title always-apply)}
-     (build-always-inject always-apply)
+      :rule/enforcement       (fields/build-enforcement title always-apply)}
+     (fields/build-always-inject always-apply)
      (when knowledge
        {:rule/knowledge-content knowledge}))))
-
-;; ===========================================================================
-;; Section 6: Applies-To (Phases + Globs) Tests
-;; ===========================================================================
-(deftest ^{:stratum 2} applies-to-test
-  (testing "Dewey-only → phases from dewey, no globs"
-    (is (= {:phases #{:plan :implement :review :verify :release}}
-           (build-applies-to "001" nil))))
-
-  (testing "Dewey + globs → phases + file-globs"
-    (is (= {:phases     #{:implement :review}
-            :file-globs ["components/**/src/**/*.clj"]}
-           (build-applies-to "210" ["components/**/src/**/*.clj"]))))
-
-  (testing "Meta dewey → empty phases"
-    (is (= {:phases #{}} (build-applies-to "900" nil))))
-
-  (testing "Meta dewey + globs → empty phases + globs"
-    (is (= {:phases     #{}
-            :file-globs [".cursor/rules/**/*.mdc"]}
-           (build-applies-to "900" [".cursor/rules/**/*.mdc"])))))
 
 ;------------------------------------------------------------------------------ Layer 3
 

--- a/components/policy-pack/test/ai/miniforge/policy_pack/mdc_to_pack_mapping_test/fields.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/mdc_to_pack_mapping_test/fields.clj
@@ -1,0 +1,107 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.mdc-to-pack-mapping-test.fields
+  "Independent field-derivation helpers, part of the reference
+   implementation for the MDC-to-Pack Rule Field Mapping acceptance
+   spec (Sections 3, 5, 6, and 9 of
+   work/designs/mdc-to-pack-field-mapping.edn): description text,
+   :rule/always-inject?, :rule/enforcement, glob normalization, and
+   ## Agent behavior / first-paragraph extraction from the MDC body.
+
+   Split out of `ai.miniforge.policy-pack.mdc-to-pack-mapping-test`
+   (rule 210: slice 2/7 of a stratum-lint SL003 split train — see
+   `mdc-to-pack-mapping-test.dewey` for slice 1 and the full train
+   rationale). Every function here is a single-layer leaf: none of
+   them call each other or anything else in the parent namespace, so
+   this file was always a layer-0 island — moving it out only removes
+   its bulk from the parent file, it doesn't unwind any call chain.
+
+   Layer 0: derive-description, normalize-globs, build-always-inject,
+     build-enforcement, extract-agent-behavior-section,
+     extract-first-paragraph"
+  (:require
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} derive-description
+  "Generate :rule/description from category and title.
+   Format: 'Engineering standard (<category>): <title>'"
+  [category title]
+  (str "Engineering standard (" category "): " title))
+
+(defn ^{:stratum 0} normalize-globs
+  "Wrap string globs in a vector; pass vectors through; nil → nil."
+  [globs]
+  (cond
+    (nil? globs)    nil
+    (string? globs) [globs]
+    (vector? globs) globs
+    (sequential? globs) (vec globs)
+    :else [globs]))
+
+(defn ^{:stratum 0} build-always-inject
+  "Derive :rule/always-inject? map fragment.
+   true → {:rule/always-inject? true}, false/nil → {}"
+  [always-apply]
+  (if (true? always-apply)
+    {:rule/always-inject? true}
+    {}))
+
+(defn ^{:stratum 0} build-enforcement
+  "Build :rule/enforcement from title and alwaysApply flag."
+  [title always-apply]
+  {:action  (if always-apply :warn :audit)
+   :message (str "Standard: " title)})
+
+(defn ^{:stratum 0} extract-agent-behavior-section
+  "Extract ## Agent behavior section content from body.
+   Returns nil if section not found."
+  [body]
+  (when body
+    (let [lines (str/split-lines body)
+          start-idx (some (fn [[i line]]
+                           (when (re-matches #"(?i)^##\s+Agent\s+behavior.*" line)
+                             i))
+                         (map-indexed vector lines))]
+      (when start-idx
+        (let [rest-lines (drop (inc start-idx) lines)
+              content-lines (take-while
+                             (fn [line]
+                               (not (re-matches #"^##\s+.*" line)))
+                             rest-lines)
+              content (str/trim (str/join "\n" content-lines))]
+          (when (not (str/blank? content))
+            content))))))
+
+(defn ^{:stratum 0} extract-first-paragraph
+  "Extract first non-heading paragraph from body."
+  [body]
+  (when body
+    (let [lines (str/split-lines body)
+          ;; Skip leading headings and blank lines
+          content-lines (drop-while
+                         (fn [line]
+                           (or (str/blank? line)
+                               (str/starts-with? line "#")))
+                         lines)
+          ;; Take until blank line
+          para-lines (take-while (complement str/blank?) content-lines)
+          para (str/trim (str/join " " para-lines))]
+      (when (not (str/blank? para))
+        para))))

--- a/components/policy-pack/test/ai/miniforge/policy_pack/mdc_to_pack_mapping_test/fields_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/mdc_to_pack_mapping_test/fields_test.clj
@@ -1,0 +1,119 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.mdc-to-pack-mapping-test.fields-test
+  "Acceptance tests for the independent field-derivation helpers
+   (Sections 3, 5, 6, and 9 of work/designs/mdc-to-pack-field-mapping.edn).
+
+   Split out of `ai.miniforge.policy-pack.mdc-to-pack-mapping-test`
+   (rule 210 split train, slice 2/7). Assertions are unchanged from the
+   parent namespace — only the deftest forms and their dependency on
+   `mdc-to-pack-mapping-test.fields` moved."
+  (:require
+   [ai.miniforge.policy-pack.mdc-to-pack-mapping-test.fields :as fields]
+   [clojure.test :refer [deftest is testing]]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; ===========================================================================
+;; Section 3: Description Generation Tests
+;; ===========================================================================
+(deftest ^{:stratum 0} description-generation-test
+  (testing "Format: 'Engineering standard (<category>): <title>'"
+    (is (= "Engineering standard (001): Stratified Design — enforce one-way dependencies"
+           (fields/derive-description "001" "Stratified Design — enforce one-way dependencies")))
+    (is (= "Engineering standard (210): Clojure Polylith + per-file stratified design"
+           (fields/derive-description "210" "Clojure Polylith + per-file stratified design")))
+    (is (= "Engineering standard (000): Index"
+           (fields/derive-description "000" "Index")))))
+
+;; ===========================================================================
+;; Section 5: alwaysApply → :rule/always-inject? Mapping Tests
+;; ===========================================================================
+(deftest ^{:stratum 0} always-inject-mapping-test
+  (testing "alwaysApply: true → {:rule/always-inject? true}"
+    (is (= {:rule/always-inject? true} (fields/build-always-inject true))))
+
+  (testing "alwaysApply: false → {} (key omitted)"
+    (is (= {} (fields/build-always-inject false))))
+
+  (testing "alwaysApply: nil (absent) → {} (key omitted)"
+    (is (= {} (fields/build-always-inject nil))))
+
+  (testing "Consumers get nil (falsy) for missing always-inject?"
+    (let [rule-without (merge {} (fields/build-always-inject false))]
+      (is (nil? (:rule/always-inject? rule-without))))))
+
+(deftest ^{:stratum 0} globs-normalization-test
+  (testing "String globs wrapped in vector"
+    (is (= ["*.clj"] (fields/normalize-globs "*.clj"))))
+
+  (testing "Vector globs passed through"
+    (is (= ["*.clj" "*.cljc"] (fields/normalize-globs ["*.clj" "*.cljc"]))))
+
+  (testing "nil globs → nil"
+    (is (nil? (fields/normalize-globs nil)))))
+
+;; ===========================================================================
+;; Section 9: Agent Behavior Extraction Tests
+;; ===========================================================================
+(deftest ^{:stratum 0} agent-behavior-section-extraction-test
+  (testing "Extracts content from ## Agent behavior section"
+    (let [body "# Heading\n\nIntro paragraph.\n\n## Agent behavior\n\n- Do X.\n- Do Y.\n\n## Next section"]
+      (is (= "- Do X.\n- Do Y." (fields/extract-agent-behavior-section body)))))
+
+  (testing "Case-insensitive heading match"
+    (let [body "## agent behavior\n\nDo stuff."]
+      (is (= "Do stuff." (fields/extract-agent-behavior-section body)))))
+
+  (testing "Extracts to end of file when no next heading"
+    (let [body "## Agent behavior\n\n- Be concise.\n- Be clear."]
+      (is (= "- Be concise.\n- Be clear." (fields/extract-agent-behavior-section body)))))
+
+  (testing "Returns nil when section not present"
+    (let [body "# Heading\n\nJust content, no agent behavior section."]
+      (is (nil? (fields/extract-agent-behavior-section body)))))
+
+  (testing "Returns nil for empty section"
+    (let [body "## Agent behavior\n\n## Next heading"]
+      (is (nil? (fields/extract-agent-behavior-section body)))))
+
+  (testing "Returns nil for nil body"
+    (is (nil? (fields/extract-agent-behavior-section nil)))))
+
+(deftest ^{:stratum 0} first-paragraph-extraction-test
+  (testing "Extracts first non-heading paragraph"
+    (let [body "# Code Quality (ALWAYS)\n\nEvery function must read as a pipeline: data enters, transforms, exits.\n\nMore text."]
+      (is (= "Every function must read as a pipeline: data enters, transforms, exits."
+             (fields/extract-first-paragraph body)))))
+
+  (testing "Skips leading headings and blank lines"
+    (let [body "\n# Heading\n## Sub\n\nActual content here."]
+      (is (= "Actual content here." (fields/extract-first-paragraph body)))))
+
+  (testing "Returns nil for heading-only body"
+    (let [body "# Just a heading\n## And subheading"]
+      (is (nil? (fields/extract-first-paragraph body)))))
+
+  (testing "Returns nil for nil body"
+    (is (nil? (fields/extract-first-paragraph nil)))))
+
+(deftest ^{:stratum 0} edge-case-body-only-headings-test
+  (testing "Body with only headings → knowledge-content present, agent-behavior nil"
+    (let [body "# Just a heading\n## And subheading"]
+      (is (nil? (fields/extract-agent-behavior-section body)))
+      (is (nil? (fields/extract-first-paragraph body))))))

--- a/docs/pull-requests/2026-08-11-refactor-split-policy-pack-mdc-to-pack-mapping-test-2.md
+++ b/docs/pull-requests/2026-08-11-refactor-split-policy-pack-mdc-to-pack-mapping-test-2.md
@@ -1,0 +1,99 @@
+<!--
+  Title: Split policy-pack mdc_to_pack_mapping_test.clj — extract fields (2/7)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(policy-pack): split mdc_to_pack_mapping_test.clj — extract fields (2/7)
+
+## Overview
+
+Slice 2 of the 7-PR split of
+`components/policy-pack/test/ai/miniforge/policy_pack/mdc_to_pack_mapping_test.clj`
+(stratum-lint SL003, rule 210, `standards/miniforge`). See
+[slice 1, miniforge#1758](https://github.com/miniforge-ai/miniforge/pull/1758)
+for the full train rationale and precedent links.
+
+This slice extracts `ai.miniforge.policy-pack.mdc-to-pack-mapping-test.fields`:
+six independent, dependency-free field-derivation helpers —
+`derive-description`, `normalize-globs`, `build-always-inject`,
+`build-enforcement`, `extract-agent-behavior-section`,
+`extract-first-paragraph`. None of these call each other or anything
+else in the parent namespace, so unlike slice 1's dewey chain this was
+always a layer-0 island — moving it out shrinks the parent file's bulk
+without shortening its deepest same-file call chain.
+
+## Motivation
+
+Zero fan-in confirmed for the parent test namespace before slice 1
+(see miniforge#1758); this slice doesn't change that — no other
+namespace requires `mdc-to-pack-mapping-test` or its `fields` sibling.
+
+## Changes in Detail
+
+- New file `mdc_to_pack_mapping_test/fields.clj`: the six helpers
+  above, all layer 0, moved verbatim (only their `:stratum` tags and
+  the file's own header/docstring are new).
+- New file `mdc_to_pack_mapping_test/fields_test.clj`: the six
+  `deftest` forms that exercise them (`description-generation-test`,
+  `always-inject-mapping-test`, `globs-normalization-test`,
+  `agent-behavior-section-extraction-test`,
+  `first-paragraph-extraction-test`,
+  `edge-case-body-only-headings-test`) — assertions unchanged, call
+  sites now go through the `fields` alias.
+- `mdc_to_pack_mapping_test.clj`: the six functions and six tests
+  removed; `build-applies-to` and `compile-rule` now call
+  `fields/normalize-globs`, `fields/derive-description`,
+  `fields/build-enforcement`, and `fields/build-always-inject` across
+  the namespace boundary. Ran `stratum-lint --fix` to renumber the
+  remaining defs' `;--- Layer N` headings and `^{:stratum n}`
+  metadata — still 4 real layers (unchanged by this slice, as noted
+  above; the deepest chain is now `dewey`/`build-applies-to` →
+  `derive-title`/`compile-rule` → the `compile-rule`-dependent tests,
+  which slices 4 and 6 resolve).
+
+The parent namespace stays over budget (4 real layers) until the
+remaining slices land; the commit removing the `fields` helpers used
+`MINIFORGE_STRATUM_BUDGET_MODE=warn`, same convention as slice 1.
+
+## Testing Plan
+
+1. `clj-kondo` clean on all three touched/new files.
+2. stratum-lint: `fields.clj` and `fields_test.clj` pass SL003
+   outright; `mdc_to_pack_mapping_test.clj` intentionally still over
+   budget (4 layers) — expected and tracked, not a defect.
+3. Test/assertion count verified unchanged before and after, across
+   all three namespaces combined: 39 tests / 1213 assertions, 0
+   failures — identical to the slice-1 baseline.
+4. Full pre-commit suite (`poly:check`, lint, stratum-lint, smoke
+   tests, GraalVM) passed on both commits.
+5. Adversarial self-review: diffed the full top-level `defn`/`deftest`
+   set before and after — exactly 6 functions and 6 deftest forms
+   relocated, 0 added/removed/altered in behavior; the four remaining
+   call sites (`build-applies-to`, `compile-rule`) changed only their
+   qualification (`fields/...`), not their arguments or logic.
+
+PR size: 279 reportable lines (259 raw insertions / 191 raw deletions
+across 3 files, two commits of 149 and 171 reportable lines each),
+under the 600-line budget — no override needed.
+
+## Deployment Plan
+
+Merges to `main` as part of the ongoing 7-PR train. The next slice
+rebases onto the updated `main` after this one merges.
+
+## Related Issues/PRs
+
+- Slice 1: [miniforge#1758](https://github.com/miniforge-ai/miniforge/pull/1758)
+- Precedent: [mdc_compiler.clj split train, miniforge#1729-#1743](https://github.com/miniforge-ai/miniforge/pull/1743)
+- Part of the stratum-lint rule-210 remediation program (Wave 2, policy-pack batch 2)
+
+## Checklist
+
+- [x] Zero fan-in confirmed (unchanged since slice 1)
+- [x] Pure code motion — no behavior change, no assertions altered
+- [x] `clj-kondo` clean
+- [x] Tests green (39/39 tests, 1213/1213 assertions, matches baseline)
+- [x] PR-diff and commit-diff budgets checked (279/600 PR, both commits ≤200)
+- [x] `MINIFORGE_STRATUM_BUDGET_MODE=warn` used + documented for the
+      expected intermediate over-budget state


### PR DESCRIPTION
<!--
  Title: Split policy-pack mdc_to_pack_mapping_test.clj — extract fields (2/7)
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# refactor(policy-pack): split mdc_to_pack_mapping_test.clj — extract fields (2/7)

## Overview

Slice 2 of the 7-PR split of
`components/policy-pack/test/ai/miniforge/policy_pack/mdc_to_pack_mapping_test.clj`
(stratum-lint SL003, rule 210, `standards/miniforge`). See
[slice 1, miniforge#1758](https://github.com/miniforge-ai/miniforge/pull/1758)
for the full train rationale and precedent links.

This slice extracts `ai.miniforge.policy-pack.mdc-to-pack-mapping-test.fields`:
six independent, dependency-free field-derivation helpers —
`derive-description`, `normalize-globs`, `build-always-inject`,
`build-enforcement`, `extract-agent-behavior-section`,
`extract-first-paragraph`. None of these call each other or anything
else in the parent namespace, so unlike slice 1's dewey chain this was
always a layer-0 island — moving it out shrinks the parent file's bulk
without shortening its deepest same-file call chain.

## Motivation

Zero fan-in confirmed for the parent test namespace before slice 1
(see miniforge#1758); this slice doesn't change that — no other
namespace requires `mdc-to-pack-mapping-test` or its `fields` sibling.

## Changes in Detail

- New file `mdc_to_pack_mapping_test/fields.clj`: the six helpers
  above, all layer 0, moved verbatim (only their `:stratum` tags and
  the file's own header/docstring are new).
- New file `mdc_to_pack_mapping_test/fields_test.clj`: the six
  `deftest` forms that exercise them (`description-generation-test`,
  `always-inject-mapping-test`, `globs-normalization-test`,
  `agent-behavior-section-extraction-test`,
  `first-paragraph-extraction-test`,
  `edge-case-body-only-headings-test`) — assertions unchanged, call
  sites now go through the `fields` alias.
- `mdc_to_pack_mapping_test.clj`: the six functions and six tests
  removed; `build-applies-to` and `compile-rule` now call
  `fields/normalize-globs`, `fields/derive-description`,
  `fields/build-enforcement`, and `fields/build-always-inject` across
  the namespace boundary. Ran `stratum-lint --fix` to renumber the
  remaining defs' `;--- Layer N` headings and `^{:stratum n}`
  metadata — still 4 real layers (unchanged by this slice, as noted
  above; the deepest chain is now `dewey`/`build-applies-to` →
  `derive-title`/`compile-rule` → the `compile-rule`-dependent tests,
  which slices 4 and 6 resolve).

The parent namespace stays over budget (4 real layers) until the
remaining slices land; the commit removing the `fields` helpers used
`MINIFORGE_STRATUM_BUDGET_MODE=warn`, same convention as slice 1.

## Testing Plan

1. `clj-kondo` clean on all three touched/new files.
2. stratum-lint: `fields.clj` and `fields_test.clj` pass SL003
   outright; `mdc_to_pack_mapping_test.clj` intentionally still over
   budget (4 layers) — expected and tracked, not a defect.
3. Test/assertion count verified unchanged before and after, across
   all three namespaces combined: 39 tests / 1213 assertions, 0
   failures — identical to the slice-1 baseline.
4. Full pre-commit suite (`poly:check`, lint, stratum-lint, smoke
   tests, GraalVM) passed on both commits.
5. Adversarial self-review: diffed the full top-level `defn`/`deftest`
   set before and after — exactly 6 functions and 6 deftest forms
   relocated, 0 added/removed/altered in behavior; the four remaining
   call sites (`build-applies-to`, `compile-rule`) changed only their
   qualification (`fields/...`), not their arguments or logic.

PR size: 279 reportable lines (259 raw insertions / 191 raw deletions
across 3 files, two commits of 149 and 171 reportable lines each),
under the 600-line budget — no override needed.

## Deployment Plan

Merges to `main` as part of the ongoing 7-PR train. The next slice
rebases onto the updated `main` after this one merges.

## Related Issues/PRs

- Slice 1: [miniforge#1758](https://github.com/miniforge-ai/miniforge/pull/1758)
- Precedent: [mdc_compiler.clj split train, miniforge#1729-#1743](https://github.com/miniforge-ai/miniforge/pull/1743)
- Part of the stratum-lint rule-210 remediation program (Wave 2, policy-pack batch 2)

## Checklist

- [x] Zero fan-in confirmed (unchanged since slice 1)
- [x] Pure code motion — no behavior change, no assertions altered
- [x] `clj-kondo` clean
- [x] Tests green (39/39 tests, 1213/1213 assertions, matches baseline)
- [x] PR-diff and commit-diff budgets checked (279/600 PR, both commits ≤200)
- [x] `MINIFORGE_STRATUM_BUDGET_MODE=warn` used + documented for the
      expected intermediate over-budget state