### PR TITLE
refactor(policy-pack): split loader.clj (rule 210)

### DIFF
--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface/loading.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface/loading.clj
@@ -50,9 +50,10 @@
   loader/resolve-overlay)
 
 (def ^{:stratum 0} discover-packs
-  "Discover packs in a directory: top-level *.pack.edn files and subdirectories
-   containing pack.edn. Returns a vector of {:path string :type :file|:directory}
-   (nil when the directory does not exist)."
+  "Discover packs in a directory: top-level pack files (pack.edn or
+   *.pack.edn) and subdirectories containing pack.edn. Returns a vector of
+   {:path string :type :file|:directory} (nil when the directory does not
+   exist)."
   loader-io/discover-packs)
 
 (def ^{:stratum 0} load-all-packs

--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface/loading.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface/loading.clj
@@ -18,7 +18,8 @@
 (ns ai.miniforge.policy-pack.interface.loading
   "Pack loading and serialization helpers."
   (:require
-   [ai.miniforge.policy-pack.loader :as loader]))
+   [ai.miniforge.policy-pack.loader :as loader]
+   [ai.miniforge.policy-pack.loader.io :as loader-io]))
 
 ;------------------------------------------------------------------------------ Layer 0
 
@@ -52,7 +53,7 @@
   "Discover packs in a directory: top-level *.pack.edn files and subdirectories
    containing pack.edn. Returns a vector of {:path string :type :file|:directory}
    (nil when the directory does not exist)."
-  loader/discover-packs)
+  loader-io/discover-packs)
 
 (def ^{:stratum 0} load-all-packs
   "Load every pack discovered in a directory. Arity [packs-dir] or
@@ -67,4 +68,4 @@
    neither an Instant nor a Date is refused and nothing is written.
    (write-pack-to-file pack file-path) returns {:success? bool :error
    string-or-nil} — nil on success."
-  loader/write-pack-to-file)
+  loader-io/write-pack-to-file)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/loader.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/loader.clj
@@ -18,11 +18,12 @@
 (ns ai.miniforge.policy-pack.loader
   "Load policy packs from EDN files and directory structures.
 
-   Layer 0: File discovery and path utilities
-   Layer 1: EDN parsing and validation
-   Layer 2: Single file and directory loaders
-   Layer 3: Pack loading orchestration
-   Layer 4: Trust validation (N1 §2.10.2)
+   Layer 0: Overlay resolution helpers, dependency-validation wrapper, trust
+            ref, and the single-file/directory loaders
+   Layer 1: Overlay pack composition, trust validation (N1 §2.10.2), and
+            format auto-detection
+   Layer 2: Overlay resolution (N4 §2.5) and the trust-validated /
+            load-all-packs top-level entry points
 
    Supports two formats:
    - Single EDN file: pack.edn or *.pack.edn
@@ -32,121 +33,26 @@
    - Instruction authority is not transitive
    - Trust level inheritance (lowest wins)
    - Cross-trust references are validated
-   - Tainted content is isolated from instruction authority"
+   - Tainted content is isolated from instruction authority
+
+   EDN parsing, timestamp/rule normalization, pack writing, and rule/pack
+   discovery live in sibling `ai.miniforge.policy-pack.loader.*` namespaces.
+   Extracting those (rule 210: the combined namespace measured 5 real
+   layers, max 3) also shortened this namespace's own in-file call chain —
+   the file-IO/normalization hops no longer count toward its local layer
+   depth, so the remaining overlay/dependency/trust/orchestration code now
+   measures 3 real layers on its own, within budget."
   (:require
+   [ai.miniforge.policy-pack.loader.io :as loader-io]
+   [ai.miniforge.policy-pack.loader.normalize :as normalize]
+   [ai.miniforge.knowledge.interface :as knowledge]
+   [ai.miniforge.policy-pack.rules.pack-dependency-validation :as dep-validation]
    [ai.miniforge.policy-pack.schema :as schema]
    [ai.miniforge.policy-pack.schema-validation :as schema-validation]
-   [ai.miniforge.policy-pack.rules.pack-dependency-validation :as dep-validation]
-   [ai.miniforge.knowledge.interface :as knowledge]
    [clojure.java.io :as io]
-   [clojure.edn :as edn]
-   [clojure.pprint :as pprint]
-   [clojure.set]
-   [clojure.string :as str])
-  (:import
-   [java.time Instant]
-   [java.util Date]))
+   [clojure.set]))
 
 ;------------------------------------------------------------------------------ Layer 0
-
-;; File discovery and path utilities
-(defn ^{:stratum 0} find-rule-files
-  "Find all rule .edn files in a rules/ directory, recursive."
-  [rules-dir]
-  (when (.exists (io/file rules-dir))
-    (->> (file-seq (io/file rules-dir))
-         (filter #(.isFile %))
-         (filter #(str/ends-with? (.getName %) ".edn")))))
-
-(defn ^{:stratum 0} pack-file?
-  "Check if a file is a pack file (pack.edn or *.pack.edn)."
-  [file]
-  (let [name (.getName file)]
-    (or (= name "pack.edn")
-        (str/ends-with? name ".pack.edn"))))
-
-;; EDN parsing and validation
-(defn ^{:stratum 0} safe-read-edn
-  "Safely read EDN from a file.
-   Returns {:success? bool :data any :error string}."
-  [file]
-  (try
-    (let [content (slurp file)
-          data (edn/read-string content)]
-      (schema-validation/success :data data {:error nil}))
-    (catch Exception e
-      (schema-validation/failure :data (.getMessage e)))))
-
-;; Timestamp wire form
-(defn ^{:stratum 0} map-instant-keys
-  "Apply `f` to every timestamp key PRESENT in `pack`. Those keys cross
-   the disk boundary as ISO-8601 strings, parsed back on read.
-
-   Presence, not non-nil-ness: an absent `:pack/signed-at` is legitimately
-   optional, but a key explicitly holding nil is a bad timestamp and goes
-   to `f` like any other. A missing required one stays missing so the
-   schema reports it, rather than being invented here."
-  [pack f]
-  (reduce (fn [acc k]
-            (if (contains? acc k)
-              (assoc acc k (f (get acc k)))
-              acc))
-          pack
-          [:pack/created-at :pack/updated-at :pack/signed-at]))
-
-(defn ^{:stratum 0} ->iso
-  "Timestamp -> ISO-8601 string, by actual type rather than by print form.
-
-   `inst?` admits BOTH `java.time.Instant` and `java.util.Date`, and
-   `pprint` renders them differently: a Date prints as `#inst` and reads
-   back, an Instant prints as `#object[...]` and makes the whole file
-   unreadable by `edn/read-string`. `builders/make-pack` stamps an
-   Instant, so the unreadable form is the default one.
-
-   Both are normalized; anything else throws, strings included — one that
-   does not parse would persist fine and fail only on the way back out.
-   Same defect class as effect-transaction's store and zettel frontmatter."
-  ^String [v]
-  (cond
-    (instance? Instant v) (.toString ^Instant v)
-    (instance? Date v) (.toString (.toInstant ^Date v))
-    :else (throw (ex-info "policy pack timestamp is not a supported instant type"
-                          {:value v :type (some-> v class .getName)}))))
-
-(defn ^{:stratum 0} ensure-instant
-  "Wire timestamp -> Instant, or nil when the value is not a readable one.
-
-   Returns nil rather than the old fail-soft `Instant/now`. A pack whose
-   created-at cannot be read is corrupt, and stamping the current time
-   hides that at the moment it should surface — the pack loads clean,
-   dated today, and nothing downstream can tell. nil fails the schema's
-   `inst?` on the next step, so the corruption surfaces through the
-   loader's own `{:success? false :errors [...]}` channel: one entry in
-   `load-all-packs`' `:failed`, not an exception aborting the rest."
-  [value]
-  (cond
-    (instance? Instant value) value
-    (instance? Date value) (.toInstant ^Date value)
-    (string? value) (try
-                      (Instant/parse value)
-                      (catch Exception _ nil))
-    :else nil))
-
-(defn ^{:stratum 0} normalize-rule
-  "Normalize a rule, ensuring required fields and types."
-  [rule]
-  (cond-> rule
-    (not (:rule/applies-to rule))
-    (assoc :rule/applies-to {})
-
-    (get-in rule [:rule/applies-to :task-types])
-    (update-in [:rule/applies-to :task-types] #(if (set? %) % (set %)))
-
-    (get-in rule [:rule/applies-to :repo-types])
-    (update-in [:rule/applies-to :repo-types] #(if (set? %) % (set %)))
-
-    (get-in rule [:rule/applies-to :phases])
-    (update-in [:rule/applies-to :phases] #(if (set? %) % (set %)))))
 
 ;; Overlay pack resolution (N4 §2.5)
 (defn- ^{:stratum 0} validate-no-rule-id-collisions
@@ -243,52 +149,103 @@
    (:pack/authority pack :authority/data)
    :dependencies (mapv :pack-id (:pack/extends pack []))))
 
-;------------------------------------------------------------------------------ Layer 1
+;; Single file loader
+(defn ^{:stratum 0} load-pack-from-file
+  "Load a policy pack from a single EDN file.
 
-(defn ^{:stratum 1} normalize-pack
-  "Normalize a pack, ensuring required fields and types."
-  [pack]
-  (-> pack
-      (update :pack/rules #(mapv normalize-rule (or % [])))
-      (update :pack/categories #(or % []))
-      (map-instant-keys ensure-instant)
-      ;; Default trust metadata
-      (update :pack/trust-level #(or % :untrusted))
-      (update :pack/authority #(or % :authority/data))
-      (update :pack/dependencies #(or % []))))
-
-;; Pack writing
-(defn ^{:stratum 1} write-pack-to-file
-  "Write a pack manifest to a single EDN file.
-
-   Timestamps are normalized to ISO-8601 strings first: written raw, the
-   file cannot be read back at all. An unsupported timestamp is refused —
-   `->iso` throws, nothing is written, and the caller gets
-   `{:success? false}` instead of a file that fails only on load.
+   The file should contain a complete pack manifest with all rules inline.
 
    Arguments:
-   - pack - PackManifest
-   - file-path - Output file path
+   - file-path - Path to the .pack.edn or pack.edn file
 
    Returns:
-   - {:success? bool :error string-or-nil} — :error is nil on success"
-  [pack file-path]
-  (try
-    (let [content (with-out-str
-                    (pprint/pprint (map-instant-keys pack ->iso)))]
-      (spit file-path content)
-      {:success? true :error nil})
-    (catch Exception e
-      (schema-validation/failure nil (.getMessage e)))))
+   - {:success? bool :pack PackManifest :errors [...]}
 
-;; Directory structure loader
-(defn ^{:stratum 1} load-rule-file
-  "Load a single rule from an EDN file."
-  [file]
-  (let [{:keys [success? data error]} (safe-read-edn file)]
-    (if success?
-      (schema-validation/success :rule (normalize-rule data) {:error nil})
-      (schema-validation/failure :rule error))))
+   Example:
+     (load-pack-from-file \"terraform-safety.pack.edn\")"
+  [file-path]
+  (let [file (io/file file-path)]
+    (if (.exists file)
+      (let [{:keys [success? data error]} (loader-io/safe-read-edn file)]
+        (if success?
+          (let [pack (normalize/normalize-pack data)
+                {:keys [valid? errors]} (schema/validate-pack pack)]
+            (if valid?
+              (schema-validation/success :pack pack {:errors nil})
+              (schema-validation/failure-with-errors :pack errors)))
+          (schema-validation/failure-with-errors :pack [{:file file-path :error error}])))
+      (schema-validation/failure-with-errors :pack [{:file file-path :error "File not found"}]))))
+
+(defn ^{:stratum 0} load-pack-from-directory
+  "Load a policy pack from a directory structure.
+
+   Expected structure:
+   ```
+   my-pack/
+   ├── pack.edn           # Pack manifest (rules can be inline or in rules/)
+   ├── rules/             # Optional separate rule files
+   │   ├── 310-import-safety/
+   │   │   ├── 310-import-block-preservation.edn
+   │   │   └── 311-import-no-creates.edn
+   │   └── 320-network-safety/
+   │       └── 320-network-recreation-block.edn
+   └── examples/          # Optional test examples
+       └── ...
+   ```
+
+   Arguments:
+   - dir-path - Path to the pack directory
+
+   Returns:
+   - {:success? bool :pack PackManifest :errors [...]}
+
+   Example:
+     (load-pack-from-directory \"./packs/terraform-safety\")"
+  [dir-path]
+  (let [dir (io/file dir-path)
+        manifest-file (io/file dir "pack.edn")
+        rules-dir (io/file dir "rules")]
+
+    (cond
+      (not (.exists dir))
+      (schema-validation/failure-with-errors :pack [{:dir dir-path :error "Directory not found"}])
+
+      (not (.exists manifest-file))
+      (schema-validation/failure-with-errors :pack [{:file "pack.edn" :error "Manifest not found in directory"}])
+
+      :else
+      (let [{:keys [success? data error]} (loader-io/safe-read-edn manifest-file)]
+        (if-not success?
+          (schema-validation/failure-with-errors :pack [{:file "pack.edn" :error error}])
+
+          ;; Load rules from rules/ directory if it exists
+          (let [rule-files (when (.exists rules-dir)
+                             (loader-io/find-rule-files rules-dir))
+                rule-results (mapv loader-io/load-rule-file rule-files)
+                successful-rules (keep :rule (filter schema-validation/succeeded? rule-results))
+                rule-errors (keep (fn [r]
+                                    (when-not (schema-validation/succeeded? r)
+                                      {:error (:error r)}))
+                                  rule-results)
+
+                ;; Merge rules: inline rules + directory rules
+                ;; Directory rules override inline rules with same ID
+                inline-rules (:pack/rules data [])
+                inline-by-id (zipmap (map :rule/id inline-rules) inline-rules)
+                dir-by-id (zipmap (map :rule/id successful-rules) successful-rules)
+                merged-rules (vals (merge inline-by-id dir-by-id))
+
+                pack (-> data
+                         (assoc :pack/rules (vec merged-rules))
+                         normalize/normalize-pack)
+
+                {:keys [valid? errors]} (schema/validate-pack pack)]
+
+            (if valid?
+              (schema-validation/success :pack pack {:errors (when (seq rule-errors) rule-errors)})
+              (schema-validation/failure-with-errors :pack (concat errors rule-errors)))))))))
+
+;------------------------------------------------------------------------------ Layer 1
 
 (defn- ^{:stratum 1} compose-resolved-pack
   "Merge inherited + overlay rules, apply overrides, inherit taxonomy ref."
@@ -301,37 +258,6 @@
         resolved-pack  (cond-> (assoc overlay-pack :pack/rules final-rules)
                          final-tax-ref (assoc :pack/taxonomy-ref final-tax-ref))]
     (schema-validation/success :pack resolved-pack {})))
-
-(defn ^{:stratum 1} discover-packs
-  "Discover all packs in a directory.
-
-   Looks for:
-   - *.pack.edn files
-   - Subdirectories containing pack.edn
-
-   Arguments:
-   - packs-dir - Directory containing packs
-
-   Returns:
-   - Vector of {:path string :type :file|:directory}"
-  [packs-dir]
-  (let [dir (io/file packs-dir)]
-    (when (.exists dir)
-      (let [;; Find *.pack.edn files
-            pack-files (->> (.listFiles dir)
-                            (filter #(.isFile %))
-                            (filter pack-file?)
-                            (map (fn [f]
-                                   {:path (.getPath f)
-                                    :type :file})))
-            ;; Find subdirectories with pack.edn
-            pack-dirs (->> (.listFiles dir)
-                           (filter #(.isDirectory %))
-                           (filter #(.exists (io/file % "pack.edn")))
-                           (map (fn [d]
-                                  {:path (.getPath d)
-                                   :type :directory})))]
-        (vec (concat pack-files pack-dirs))))))
 
 (defn ^{:stratum 1} validate-pack-trust
   "Validate transitive trust rules for a pack.
@@ -380,103 +306,39 @@
         {:valid? false
          :errors [(str "Trust validation error: " (.getMessage e))]}))))
 
-;------------------------------------------------------------------------------ Layer 2
+;; Auto-detect and load
+(defn ^{:stratum 1} load-pack
+  "Load a policy pack, auto-detecting format.
 
-;; Single file loader
-(defn ^{:stratum 2} load-pack-from-file
-  "Load a policy pack from a single EDN file.
-
-   The file should contain a complete pack manifest with all rules inline.
+   Supports:
+   - Single EDN file (pack.edn or *.pack.edn)
+   - Directory with pack.edn manifest
 
    Arguments:
-   - file-path - Path to the .pack.edn or pack.edn file
+   - path - File or directory path
 
    Returns:
    - {:success? bool :pack PackManifest :errors [...]}
 
    Example:
-     (load-pack-from-file \"terraform-safety.pack.edn\")"
-  [file-path]
-  (let [file (io/file file-path)]
-    (if (.exists file)
-      (let [{:keys [success? data error]} (safe-read-edn file)]
-        (if success?
-          (let [pack (normalize-pack data)
-                {:keys [valid? errors]} (schema/validate-pack pack)]
-            (if valid?
-              (schema-validation/success :pack pack {:errors nil})
-              (schema-validation/failure-with-errors :pack errors)))
-          (schema-validation/failure-with-errors :pack [{:file file-path :error error}])))
-      (schema-validation/failure-with-errors :pack [{:file file-path :error "File not found"}]))))
-
-(defn ^{:stratum 2} load-pack-from-directory
-  "Load a policy pack from a directory structure.
-
-   Expected structure:
-   ```
-   my-pack/
-   ├── pack.edn           # Pack manifest (rules can be inline or in rules/)
-   ├── rules/             # Optional separate rule files
-   │   ├── 310-import-safety/
-   │   │   ├── 310-import-block-preservation.edn
-   │   │   └── 311-import-no-creates.edn
-   │   └── 320-network-safety/
-   │       └── 320-network-recreation-block.edn
-   └── examples/          # Optional test examples
-       └── ...
-   ```
-
-   Arguments:
-   - dir-path - Path to the pack directory
-
-   Returns:
-   - {:success? bool :pack PackManifest :errors [...]}
-
-   Example:
-     (load-pack-from-directory \"./packs/terraform-safety\")"
-  [dir-path]
-  (let [dir (io/file dir-path)
-        manifest-file (io/file dir "pack.edn")
-        rules-dir (io/file dir "rules")]
-
+     (load-pack \"terraform-safety.pack.edn\")
+     (load-pack \"./packs/terraform-safety/\")"
+  [path]
+  (let [file (io/file path)]
     (cond
-      (not (.exists dir))
-      (schema-validation/failure-with-errors :pack [{:dir dir-path :error "Directory not found"}])
+      (not (.exists file))
+      (schema-validation/failure-with-errors :pack [{:path path :error "Path not found"}])
 
-      (not (.exists manifest-file))
-      (schema-validation/failure-with-errors :pack [{:file "pack.edn" :error "Manifest not found in directory"}])
+      (.isFile file)
+      (load-pack-from-file path)
+
+      (.isDirectory file)
+      (load-pack-from-directory path)
 
       :else
-      (let [{:keys [success? data error]} (safe-read-edn manifest-file)]
-        (if-not success?
-          (schema-validation/failure-with-errors :pack [{:file "pack.edn" :error error}])
+      (schema-validation/failure-with-errors :pack [{:path path :error "Unknown path type"}]))))
 
-          ;; Load rules from rules/ directory if it exists
-          (let [rule-files (when (.exists rules-dir)
-                             (find-rule-files rules-dir))
-                rule-results (mapv load-rule-file rule-files)
-                successful-rules (keep :rule (filter schema-validation/succeeded? rule-results))
-                rule-errors (keep (fn [r]
-                                    (when-not (schema-validation/succeeded? r)
-                                      {:error (:error r)}))
-                                  rule-results)
-
-                ;; Merge rules: inline rules + directory rules
-                ;; Directory rules override inline rules with same ID
-                inline-rules (:pack/rules data [])
-                inline-by-id (zipmap (map :rule/id inline-rules) inline-rules)
-                dir-by-id (zipmap (map :rule/id successful-rules) successful-rules)
-                merged-rules (vals (merge inline-by-id dir-by-id))
-
-                pack (-> data
-                         (assoc :pack/rules (vec merged-rules))
-                         normalize-pack)
-
-                {:keys [valid? errors]} (schema/validate-pack pack)]
-
-            (if valid?
-              (schema-validation/success :pack pack {:errors (when (seq rule-errors) rule-errors)})
-              (schema-validation/failure-with-errors :pack (concat errors rule-errors)))))))))
+;------------------------------------------------------------------------------ Layer 2
 
 (defn ^{:stratum 2} resolve-overlay
   "Resolve an overlay pack by merging inherited rules from base packs.
@@ -517,43 +379,7 @@
               (compose-resolved-pack overlay-pack base-packs
                                      inherited-rules overlay-rules))))))))
 
-;------------------------------------------------------------------------------ Layer 3
-
-;; Auto-detect and load
-(defn ^{:stratum 3} load-pack
-  "Load a policy pack, auto-detecting format.
-
-   Supports:
-   - Single EDN file (pack.edn or *.pack.edn)
-   - Directory with pack.edn manifest
-
-   Arguments:
-   - path - File or directory path
-
-   Returns:
-   - {:success? bool :pack PackManifest :errors [...]}
-
-   Example:
-     (load-pack \"terraform-safety.pack.edn\")
-     (load-pack \"./packs/terraform-safety/\")"
-  [path]
-  (let [file (io/file path)]
-    (cond
-      (not (.exists file))
-      (schema-validation/failure-with-errors :pack [{:path path :error "Path not found"}])
-
-      (.isFile file)
-      (load-pack-from-file path)
-
-      (.isDirectory file)
-      (load-pack-from-directory path)
-
-      :else
-      (schema-validation/failure-with-errors :pack [{:path path :error "Unknown path type"}]))))
-
-;------------------------------------------------------------------------------ Layer 4
-
-(defn ^{:stratum 4} load-all-packs
+(defn ^{:stratum 2} load-all-packs
   "Load all packs from a packs directory.
 
    Arguments:
@@ -575,7 +401,7 @@
   ([packs-dir opts]
    (let [validate-deps? (get opts :validate-dependencies? true)
          max-depth (get opts :max-dependency-depth 5)
-         discovered (discover-packs packs-dir)
+         discovered (loader-io/discover-packs packs-dir)
          results (map (fn [{:keys [path]}]
                         (assoc (load-pack path) :path path))
                       discovered)
@@ -595,7 +421,7 @@
        dep-validation-result
        (assoc :dependency-validation dep-validation-result)))))
 
-(defn ^{:stratum 4} load-pack-with-trust-validation
+(defn ^{:stratum 2} load-pack-with-trust-validation
   "Load a pack and validate trust rules.
 
    This is the recommended entry point for loading packs with trust enforcement.
@@ -656,24 +482,9 @@
   (load-pack "./packs/terraform-safety.pack.edn")
   (load-pack "./packs/terraform-safety/")
 
-  ;; Discover all packs
-  (discover-packs ".miniforge/packs")
-  ;; => [{:path ".miniforge/packs/terraform-safety.pack.edn" :type :file}
-  ;;     {:path ".miniforge/packs/kubernetes/" :type :directory}]
-
   ;; Load all packs
   (load-all-packs ".miniforge/packs")
   ;; => {:loaded [...] :failed [...]}
-
-  ;; Test normalization
-  (normalize-rule {:rule/id :test
-                   :rule/title "Test"
-                   :rule/description "Desc"
-                   :rule/severity :high
-                   :rule/category "300"
-                   :rule/applies-to {:task-types [:import]}  ; vector, not set
-                   :rule/detection {:type :content-scan}
-                   :rule/enforcement {:action :warn :message "Warning"}})
 
   ;; Trust validation examples
   (def base-pack

--- a/components/policy-pack/src/ai/miniforge/policy_pack/loader.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/loader.clj
@@ -43,9 +43,9 @@
    depth, so the remaining overlay/dependency/trust/orchestration code now
    measures 3 real layers on its own, within budget."
   (:require
+   [ai.miniforge.knowledge.interface :as knowledge]
    [ai.miniforge.policy-pack.loader.io :as loader-io]
    [ai.miniforge.policy-pack.loader.normalize :as normalize]
-   [ai.miniforge.knowledge.interface :as knowledge]
    [ai.miniforge.policy-pack.rules.pack-dependency-validation :as dep-validation]
    [ai.miniforge.policy-pack.schema :as schema]
    [ai.miniforge.policy-pack.schema-validation :as schema-validation]

--- a/components/policy-pack/src/ai/miniforge/policy_pack/loader/io.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/loader/io.clj
@@ -98,7 +98,7 @@
   "Discover all packs in a directory.
 
    Looks for:
-   - *.pack.edn files
+   - Top-level pack files (pack-file?: pack.edn or *.pack.edn)
    - Subdirectories containing pack.edn
 
    Arguments:
@@ -109,7 +109,7 @@
   [packs-dir]
   (let [dir (io/file packs-dir)]
     (when (.exists dir)
-      (let [;; Find *.pack.edn files
+      (let [;; Find top-level pack files (pack.edn or *.pack.edn)
             pack-files (->> (.listFiles dir)
                             (filter #(.isFile %))
                             (filter pack-file?)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/loader/io.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/loader/io.clj
@@ -1,0 +1,134 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.loader.io
+  "Disk I/O for policy packs: rule-file discovery, EDN parsing, pack
+   writing, single rule-file loading, and pack discovery within a
+   directory. Extracted from `ai.miniforge.policy-pack.loader` (rule 210:
+   the combined namespace measured 5 real layers, max 3)."
+  (:require
+   [ai.miniforge.policy-pack.loader.normalize :as normalize]
+   [ai.miniforge.policy-pack.loader.timestamps :as timestamps]
+   [ai.miniforge.policy-pack.schema-validation :as schema-validation]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [clojure.pprint :as pprint]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; File discovery and path utilities
+(defn ^{:stratum 0} find-rule-files
+  "Find all rule .edn files in a rules/ directory, recursive."
+  [rules-dir]
+  (when (.exists (io/file rules-dir))
+    (->> (file-seq (io/file rules-dir))
+         (filter #(.isFile %))
+         (filter #(str/ends-with? (.getName %) ".edn")))))
+
+(defn ^{:stratum 0} pack-file?
+  "Check if a file is a pack file (pack.edn or *.pack.edn)."
+  [file]
+  (let [name (.getName file)]
+    (or (= name "pack.edn")
+        (str/ends-with? name ".pack.edn"))))
+
+;; EDN parsing and validation
+(defn ^{:stratum 0} safe-read-edn
+  "Safely read EDN from a file.
+   Returns {:success? bool :data any :error string}."
+  [file]
+  (try
+    (let [content (slurp file)
+          data (edn/read-string content)]
+      (schema-validation/success :data data {:error nil}))
+    (catch Exception e
+      (schema-validation/failure :data (.getMessage e)))))
+
+;; Pack writing
+(defn ^{:stratum 0} write-pack-to-file
+  "Write a pack manifest to a single EDN file.
+
+   Timestamps are normalized to ISO-8601 strings first: written raw, the
+   file cannot be read back at all. An unsupported timestamp is refused —
+   `->iso` throws, nothing is written, and the caller gets
+   `{:success? false}` instead of a file that fails only on load.
+
+   Arguments:
+   - pack - PackManifest
+   - file-path - Output file path
+
+   Returns:
+   - {:success? bool :error string-or-nil} — :error is nil on success"
+  [pack file-path]
+  (try
+    (let [content (with-out-str
+                    (pprint/pprint (timestamps/map-instant-keys pack timestamps/->iso)))]
+      (spit file-path content)
+      {:success? true :error nil})
+    (catch Exception e
+      (schema-validation/failure nil (.getMessage e)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Directory structure loader
+(defn ^{:stratum 1} load-rule-file
+  "Load a single rule from an EDN file."
+  [file]
+  (let [{:keys [success? data error]} (safe-read-edn file)]
+    (if success?
+      (schema-validation/success :rule (normalize/normalize-rule data) {:error nil})
+      (schema-validation/failure :rule error))))
+
+(defn ^{:stratum 1} discover-packs
+  "Discover all packs in a directory.
+
+   Looks for:
+   - *.pack.edn files
+   - Subdirectories containing pack.edn
+
+   Arguments:
+   - packs-dir - Directory containing packs
+
+   Returns:
+   - Vector of {:path string :type :file|:directory}"
+  [packs-dir]
+  (let [dir (io/file packs-dir)]
+    (when (.exists dir)
+      (let [;; Find *.pack.edn files
+            pack-files (->> (.listFiles dir)
+                            (filter #(.isFile %))
+                            (filter pack-file?)
+                            (map (fn [f]
+                                   {:path (.getPath f)
+                                    :type :file})))
+            ;; Find subdirectories with pack.edn
+            pack-dirs (->> (.listFiles dir)
+                           (filter #(.isDirectory %))
+                           (filter #(.exists (io/file % "pack.edn")))
+                           (map (fn [d]
+                                  {:path (.getPath d)
+                                   :type :directory})))]
+        (vec (concat pack-files pack-dirs))))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (discover-packs ".miniforge/packs")
+  ;; => [{:path ".miniforge/packs/terraform-safety.pack.edn" :type :file}
+  ;;     {:path ".miniforge/packs/kubernetes/" :type :directory}]
+
+  :leave-this-here)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/loader/normalize.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/loader/normalize.clj
@@ -1,0 +1,68 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.loader.normalize
+  "Rule and pack normalization: fill required-field defaults and coerce
+   collection types. Extracted from `ai.miniforge.policy-pack.loader`
+   (rule 210: the combined namespace measured 5 real layers, max 3)."
+  (:require
+   [ai.miniforge.policy-pack.loader.timestamps :as timestamps]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} normalize-rule
+  "Normalize a rule, ensuring required fields and types."
+  [rule]
+  (cond-> rule
+    (not (:rule/applies-to rule))
+    (assoc :rule/applies-to {})
+
+    (get-in rule [:rule/applies-to :task-types])
+    (update-in [:rule/applies-to :task-types] #(if (set? %) % (set %)))
+
+    (get-in rule [:rule/applies-to :repo-types])
+    (update-in [:rule/applies-to :repo-types] #(if (set? %) % (set %)))
+
+    (get-in rule [:rule/applies-to :phases])
+    (update-in [:rule/applies-to :phases] #(if (set? %) % (set %)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} normalize-pack
+  "Normalize a pack, ensuring required fields and types."
+  [pack]
+  (-> pack
+      (update :pack/rules #(mapv normalize-rule (or % [])))
+      (update :pack/categories #(or % []))
+      (timestamps/map-instant-keys timestamps/ensure-instant)
+      ;; Default trust metadata
+      (update :pack/trust-level #(or % :untrusted))
+      (update :pack/authority #(or % :authority/data))
+      (update :pack/dependencies #(or % []))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (normalize-rule {:rule/id :test
+                   :rule/title "Test"
+                   :rule/description "Desc"
+                   :rule/severity :high
+                   :rule/category "300"
+                   :rule/applies-to {:task-types [:import]}  ; vector, not set
+                   :rule/detection {:type :content-scan}
+                   :rule/enforcement {:action :warn :message "Warning"}})
+
+  :leave-this-here)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/loader/timestamps.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/loader/timestamps.clj
@@ -1,0 +1,91 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.loader.timestamps
+  "Timestamp wire form for policy pack manifests.
+
+   `:pack/created-at`, `:pack/updated-at`, and `:pack/signed-at` cross the
+   disk boundary as ISO-8601 strings and are parsed back to `Instant` on
+   read. Extracted from `ai.miniforge.policy-pack.loader` (rule 210: the
+   combined namespace measured 5 real layers, max 3)."
+  (:import
+   [java.time Instant]
+   [java.util Date]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defn ^{:stratum 0} map-instant-keys
+  "Apply `f` to every timestamp key PRESENT in `pack`. Those keys cross
+   the disk boundary as ISO-8601 strings, parsed back on read.
+
+   Presence, not non-nil-ness: an absent `:pack/signed-at` is legitimately
+   optional, but a key explicitly holding nil is a bad timestamp and goes
+   to `f` like any other. A missing required one stays missing so the
+   schema reports it, rather than being invented here."
+  [pack f]
+  (reduce (fn [acc k]
+            (if (contains? acc k)
+              (assoc acc k (f (get acc k)))
+              acc))
+          pack
+          [:pack/created-at :pack/updated-at :pack/signed-at]))
+
+(defn ^{:stratum 0} ->iso
+  "Timestamp -> ISO-8601 string, by actual type rather than by print form.
+
+   `inst?` admits BOTH `java.time.Instant` and `java.util.Date`, and
+   `pprint` renders them differently: a Date prints as `#inst` and reads
+   back, an Instant prints as `#object[...]` and makes the whole file
+   unreadable by `edn/read-string`. `builders/make-pack` stamps an
+   Instant, so the unreadable form is the default one.
+
+   Both are normalized; anything else throws, strings included — one that
+   does not parse would persist fine and fail only on the way back out.
+   Same defect class as effect-transaction's store and zettel frontmatter."
+  ^String [v]
+  (cond
+    (instance? Instant v) (.toString ^Instant v)
+    (instance? Date v) (.toString (.toInstant ^Date v))
+    :else (throw (ex-info "policy pack timestamp is not a supported instant type"
+                          {:value v :type (some-> v class .getName)}))))
+
+(defn ^{:stratum 0} ensure-instant
+  "Wire timestamp -> Instant, or nil when the value is not a readable one.
+
+   Returns nil rather than the old fail-soft `Instant/now`. A pack whose
+   created-at cannot be read is corrupt, and stamping the current time
+   hides that at the moment it should surface — the pack loads clean,
+   dated today, and nothing downstream can tell. nil fails the schema's
+   `inst?` on the next step, so the corruption surfaces through the
+   loader's own `{:success? false :errors [...]}` channel: one entry in
+   `load-all-packs`' `:failed`, not an exception aborting the rest."
+  [value]
+  (cond
+    (instance? Instant value) value
+    (instance? Date value) (.toInstant ^Date value)
+    (string? value) (try
+                      (Instant/parse value)
+                      (catch Exception _ nil))
+    :else nil))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (->iso (Instant/now))
+  (ensure-instant "2026-08-01T12:34:56.789Z")
+  (map-instant-keys {:pack/created-at (Instant/now)} ->iso)
+
+  :leave-this-here)

--- a/components/policy-pack/test/ai/miniforge/policy_pack/loader_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/loader_test.clj
@@ -20,6 +20,7 @@
   (:require
    [clojure.test :refer [deftest is testing use-fixtures]]
    [ai.miniforge.policy-pack.loader :as loader]
+   [ai.miniforge.policy-pack.loader.io :as loader-io]
    [clojure.java.io :as io]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -265,7 +266,7 @@
                 :pack/description \"\" :pack/author \"\" :pack/categories []
                 :pack/rules [] :pack/created-at #inst \"2026-01-01\" :pack/updated-at #inst \"2026-01-01\"}"))
 
-      (let [discovered (loader/discover-packs (.getPath packs-dir))]
+      (let [discovered (loader-io/discover-packs (.getPath packs-dir))]
         (is (= 2 (count discovered)))
         (is (some #(= :file (:type %)) discovered))
         (is (some #(= :directory (:type %)) discovered))))))

--- a/components/policy-pack/test/ai/miniforge/policy_pack/loader_timestamps_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/loader_timestamps_test.clj
@@ -24,6 +24,8 @@
    `#object[...]` that `edn/read-string` refuses."
   (:require
    [ai.miniforge.policy-pack.loader :as loader]
+   [ai.miniforge.policy-pack.loader.io :as loader-io]
+   [ai.miniforge.policy-pack.loader.timestamps :as timestamps]
    [ai.miniforge.policy-pack.schema :as schema]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
@@ -66,7 +68,7 @@
   "Write `pack` and read the raw EDN back, without normalization."
   [pack]
   (let [f (out-file)]
-    (loader/write-pack-to-file pack (.getPath f))
+    (loader-io/write-pack-to-file pack (.getPath f))
     (select-keys (edn/read-string (slurp f)) [:pack/created-at :pack/updated-at])))
 
 (deftest ^{:stratum 1} both-inst-types-are-schema-valid-test
@@ -83,7 +85,7 @@
   (doseq [[label t] [["Date" (Date/from now)] ["Instant" now]]]
     (testing (str "a pack written from a " label " survives the disk boundary")
       (let [f      (out-file)
-            _      (loader/write-pack-to-file (pack-with t) (.getPath f))
+            _      (loader-io/write-pack-to-file (pack-with t) (.getPath f))
             result (loader/load-pack-from-file (.getPath f))]
         (is (:success? result))
         (is (= now (get-in result [:pack :pack/created-at])))
@@ -98,9 +100,9 @@
                      ["an explicit nil" nil]]]
     (testing (str label " is refused")
       (let [f      (out-file)
-            result (loader/write-pack-to-file (assoc (pack-with now)
-                                                     :pack/created-at t)
-                                              (.getPath f))]
+            result (loader-io/write-pack-to-file (assoc (pack-with now)
+                                                        :pack/created-at t)
+                                                 (.getPath f))]
         (is (false? (:success? result)))
         (is (not (.exists f))
             "nothing is written when a timestamp is refused")))))
@@ -120,9 +122,9 @@
       (spit f (pr-str (dissoc (pack-with now) :pack/created-at)))
       (is (false? (:success? (loader/load-pack-from-file (.getPath f)))))))
   (testing "ensure-instant itself reports unreadable rather than answering now"
-    (is (nil? (loader/ensure-instant "not-a-timestamp")))
-    (is (nil? (loader/ensure-instant 1754051696789)))
-    (is (nil? (loader/ensure-instant nil)))))
+    (is (nil? (timestamps/ensure-instant "not-a-timestamp")))
+    (is (nil? (timestamps/ensure-instant 1754051696789)))
+    (is (nil? (timestamps/ensure-instant nil)))))
 
 ;------------------------------------------------------------------------------ Layer 2
 
@@ -147,5 +149,5 @@
       (is (= {:pack/created-at "2026-08-01T12:34:56.789Z"
               :pack/updated-at "2026-08-01T12:34:56.789Z"}
              (written-timestamps (assoc (pack-with now) :pack/signed-at now))))
-      (loader/write-pack-to-file (pack-with now) (.getPath plain))
+      (loader-io/write-pack-to-file (pack-with now) (.getPath plain))
       (is (not (contains? (edn/read-string (slurp plain)) :pack/signed-at))))))

--- a/docs/pull-requests/2026-08-11-refactor-split-policy-pack-loader.md
+++ b/docs/pull-requests/2026-08-11-refactor-split-policy-pack-loader.md
@@ -1,0 +1,116 @@
+<!--
+  Title: Split policy-pack/loader.clj (rule 210)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(policy-pack): split loader.clj (rule 210)
+
+## Overview
+
+Splits disk-I/O, pack/rule normalization, and timestamp wire-form
+conversion out of `ai.miniforge.policy-pack.loader` into three new
+sibling namespaces, resolving a stratum-lint SL003 finding (the
+combined namespace measured 5 real layers, over the rule 210 budget
+of 3).
+
+## Motivation
+
+Part of the stratum-lint rule-210 remediation program's Wave 2,
+policy-pack batch 2. `loader.clj` was 724 lines and the largest
+outstanding file in the component (confirmed via `stratum-lint`:
+`SL003 file uses 5 distinct layers (max 3)`).
+
+## Changes in Detail
+
+- New file `loader/timestamps.clj`: `map-instant-keys`, `->iso`,
+  `ensure-instant` — the ISO-8601 <-> `Instant`/`Date` wire-form
+  conversions at the disk boundary. 1 real layer.
+- New file `loader/normalize.clj`: `normalize-rule`, `normalize-pack`
+  — required-field defaults and collection-type coercion for rules and
+  packs. 2 real layers.
+- New file `loader/io.clj`: `find-rule-files`, `pack-file?`,
+  `safe-read-edn`, `write-pack-to-file`, `load-rule-file`,
+  `discover-packs` — EDN parsing/writing and directory scanning. 2 real
+  layers.
+- `loader.clj`: the 11 functions above are deleted; `load-pack-from-file`,
+  `load-pack-from-directory`, and `load-all-packs` now call the moved
+  code via `loader-io/*` and `normalize/*`. What's left — overlay
+  resolution (N4 §2.5), the dependency-validation wrapper, trust
+  validation (N1 §2.10.2), and load-path orchestration — was not itself
+  split further: extracting the file-IO/normalization layer also
+  shortened this namespace's own in-file call chain (those hops no
+  longer count toward local layer depth), so the remainder now measures
+  3 real layers on its own (`stratum-lint` exit 0, confirmed directly,
+  not assumed). The ns docstring's layer summary is updated to match.
+  418 lines, down from 724.
+- `interface/loading.clj`: `discover-packs` and `write-pack-to-file` now
+  redirect to `loader.io` (they moved there); `load-pack`,
+  `load-pack-from-file`, `load-pack-from-directory`, `resolve-overlay`,
+  and `load-all-packs` are unchanged, still forwarding to
+  `ai.miniforge.policy-pack.loader` (`resolve-overlay` did not move —
+  it was already within budget and not part of this split).
+- `loader_test.clj`: the `discover-packs` call updated to the
+  `loader-io` alias.
+- `loader_timestamps_test.clj`: `write-pack-to-file` calls updated to
+  the `loader-io` alias; `ensure-instant` calls (a white-box test of the
+  boundary's refusal behavior) updated to the `loader.timestamps` alias.
+- `overlay_test.clj`: untouched — `resolve-overlay` stayed in
+  `loader.clj`.
+
+This is pure code motion aside from the test call-site updates above —
+no detection/validation/normalization logic changed.
+
+## Testing Plan
+
+- Repo-wide grep on the fully-qualified namespace
+  (`ai\.miniforge\.policy-pack\.loader\b`, across
+  `components`/`bases`/`projects`, not a symbol-prefix guess — the
+  methodology two earlier splits in this program got bitten by)
+  confirmed exactly four callers before starting: `loader_test.clj`,
+  `overlay_test.clj`, `loader_timestamps_test.clj`, and
+  `interface/loading.clj`. No caller under `projects/miniforge/test/`.
+- `stratum-lint` clean (exit 0) on all four touched/new source files;
+  `loader.clj` specifically confirmed clean after each of the two
+  commits that changed it, not just at the end.
+- `clj-kondo` clean on every touched/new file (0 errors, 0 warnings).
+- `clojure -M:test`: `ai.miniforge.policy-pack.loader-test`,
+  `overlay-test`, and `loader-timestamps-test` — 22 tests, 74
+  assertions, 0 failures. `ai.miniforge.policy-pack.interface` compiles
+  clean (full component classpath).
+- Pre-commit's smoke suite (`bb pre-commit`, cross-component) ran clean
+  on every commit: 345 tests / 1301 assertions, plus 8 GraalVM
+  compatibility tests / 623 assertions, 0 failures throughout.
+
+## Deployment Plan
+
+Merges to `main` immediately; no follow-up needed for this file.
+
+## Related Issues/PRs
+
+- Precedent: `mdc_compiler.clj` split, miniforge#1729-#1734 (6-PR train
+  — the closest precedent for a large file, including how it handled a
+  fan-in it initially missed mid-train).
+- Precedent: `workflow_runner.clj` split, miniforge#1662-#1667 (the
+  original convention).
+- Precedent: `knowledge_safety.clj` split (2026-08-09, same component)
+  — the fan-in-by-alias miss this PR's grep methodology was written to
+  avoid.
+- Part of the stratum-lint rule-210 remediation program (Wave 2, batch 2).
+
+## Checklist
+
+- [x] Zero unaccounted-for fan-in confirmed via fully-qualified
+      namespace grep before starting
+- [x] Pure code motion — no logic/behavior changes
+- [x] `stratum-lint` clean on every touched/new file
+- [x] `clj-kondo` clean
+- [x] Tests green (22/22, 74 assertions) + full-component compile check
+- [x] Pre-commit smoke suite green on every commit (not just the last)
+- [x] PR-diff and commit-diff budgets checked (432 insertions / 324
+      deletions across 7 files total; each of the 3 commits ≤200
+      reportable lines)
+- [x] Adversarial self-review: diffed `loader.clj` end to end against
+      the original — every relocated def is byte-identical apart from
+      its `:stratum` tag/heading and call-site qualification; no
+      def added, removed, or behaviorally altered


### PR DESCRIPTION

# refactor(policy-pack): split loader.clj (rule 210)

## Overview

Splits disk-I/O, pack/rule normalization, and timestamp wire-form
conversion out of `ai.miniforge.policy-pack.loader` into three new
sibling namespaces, resolving a stratum-lint SL003 finding (the
combined namespace measured 5 real layers, over the rule 210 budget
of 3).

## Motivation

Part of the stratum-lint rule-210 remediation program's Wave 2,
policy-pack batch 2. `loader.clj` was 724 lines and the largest
outstanding file in the component (confirmed via `stratum-lint`:
`SL003 file uses 5 distinct layers (max 3)`).

## Changes in Detail

- New file `loader/timestamps.clj`: `map-instant-keys`, `->iso`,
  `ensure-instant` — the ISO-8601 <-> `Instant`/`Date` wire-form
  conversions at the disk boundary. 1 real layer.
- New file `loader/normalize.clj`: `normalize-rule`, `normalize-pack`
  — required-field defaults and collection-type coercion for rules and
  packs. 2 real layers.
- New file `loader/io.clj`: `find-rule-files`, `pack-file?`,
  `safe-read-edn`, `write-pack-to-file`, `load-rule-file`,
  `discover-packs` — EDN parsing/writing and directory scanning. 2 real
  layers.
- `loader.clj`: the 11 functions above are deleted; `load-pack-from-file`,
  `load-pack-from-directory`, and `load-all-packs` now call the moved
  code via `loader-io/*` and `normalize/*`. What's left — overlay
  resolution (N4 §2.5), the dependency-validation wrapper, trust
  validation (N1 §2.10.2), and load-path orchestration — was not itself
  split further: extracting the file-IO/normalization layer also
  shortened this namespace's own in-file call chain (those hops no
  longer count toward local layer depth), so the remainder now measures
  3 real layers on its own (`stratum-lint` exit 0, confirmed directly,
  not assumed). The ns docstring's layer summary is updated to match.
  418 lines, down from 724.
- `interface/loading.clj`: `discover-packs` and `write-pack-to-file` now
  redirect to `loader.io` (they moved there); `load-pack`,
  `load-pack-from-file`, `load-pack-from-directory`, `resolve-overlay`,
  and `load-all-packs` are unchanged, still forwarding to
  `ai.miniforge.policy-pack.loader` (`resolve-overlay` did not move —
  it was already within budget and not part of this split).
- `loader_test.clj`: the `discover-packs` call updated to the
  `loader-io` alias.
- `loader_timestamps_test.clj`: `write-pack-to-file` calls updated to
  the `loader-io` alias; `ensure-instant` calls (a white-box test of the
  boundary's refusal behavior) updated to the `loader.timestamps` alias.
- `overlay_test.clj`: untouched — `resolve-overlay` stayed in
  `loader.clj`.

This is pure code motion aside from the test call-site updates above —
no detection/validation/normalization logic changed.

## Testing Plan

- Repo-wide grep on the fully-qualified namespace
  (`ai\.miniforge\.policy-pack\.loader\b`, across
  `components`/`bases`/`projects`, not a symbol-prefix guess — the
  methodology two earlier splits in this program got bitten by)
  confirmed exactly four callers before starting: `loader_test.clj`,
  `overlay_test.clj`, `loader_timestamps_test.clj`, and
  `interface/loading.clj`. No caller under `projects/miniforge/test/`.
- `stratum-lint` clean (exit 0) on all four touched/new source files;
  `loader.clj` specifically confirmed clean after each of the two
  commits that changed it, not just at the end.
- `clj-kondo` clean on every touched/new file (0 errors, 0 warnings).
- `clojure -M:test`: `ai.miniforge.policy-pack.loader-test`,
  `overlay-test`, and `loader-timestamps-test` — 22 tests, 74
  assertions, 0 failures. `ai.miniforge.policy-pack.interface` compiles
  clean (full component classpath).
- Pre-commit's smoke suite (`bb pre-commit`, cross-component) ran clean
  on every commit: 345 tests / 1301 assertions, plus 8 GraalVM
  compatibility tests / 623 assertions, 0 failures throughout.

## Deployment Plan

Merges to `main` immediately; no follow-up needed for this file.

## Related Issues/PRs

- Precedent: `mdc_compiler.clj` split, miniforge#1729-#1734 (6-PR train
  — the closest precedent for a large file, including how it handled a
  fan-in it initially missed mid-train).
- Precedent: `workflow_runner.clj` split, miniforge#1662-#1667 (the
  original convention).
- Precedent: `knowledge_safety.clj` split (2026-08-09, same component)
  — the fan-in-by-alias miss this PR's grep methodology was written to
  avoid.
- Part of the stratum-lint rule-210 remediation program (Wave 2, batch 2).

## Checklist

- [x] Zero unaccounted-for fan-in confirmed via fully-qualified
      namespace grep before starting
- [x] Pure code motion — no logic/behavior changes
- [x] `stratum-lint` clean on every touched/new file
- [x] `clj-kondo` clean
- [x] Tests green (22/22, 74 assertions) + full-component compile check
- [x] Pre-commit smoke suite green on every commit (not just the last)
- [x] PR-diff and commit-diff budgets checked (432 insertions / 324
      deletions across 7 files total; each of the 3 commits ≤200
      reportable lines)
- [x] Adversarial self-review: diffed `loader.clj` end to end against
      the original — every relocated def is byte-identical apart from
      its `:stratum` tag/heading and call-site qualification; no
      def added, removed, or behaviorally altered

🤖 Generated with [Claude Code](https://claude.com/claude-code)