### PR TITLE
refactor(policy-pack): split detection.clj — extract detection.custom-registry (2/2)

### DIFF
--- a/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
@@ -20,25 +20,20 @@
 
    Layer 0: state-comparison, semantic and capability detectors,
      ast-analysis/content-scan/diff-analysis/plan-output detection,
-     custom-fn registry/reflection primitives, violation-severity
-     filters and formatting — pure or leaf-level, no same-file
-     dependents yet
-   Layer 1: custom-fn arity-reflection/registry helpers, violation
-     location/message builders (over Layer 0)
-   Layer 2: detector-predicate?, detect-custom, custom-fn-resolvable?,
-     violation->error, detect-violation (unified per-type dispatcher)
-     (over Layer 1)
-   Layer 3: register-custom-fn!, check-rules (over Layer 2)
+     unregister-custom-fn!, custom-fn-resolvable?, register-custom-fn!,
+     violation-severity filters and formatting — pure or leaf-level, no
+     same-file dependents yet
+   Layer 1: violation location/message builders, detect-custom,
+     detect-violation (unified per-type dispatcher) (over Layer 0)
+   Layer 2: violation->error, check-rules (over Layer 1)
 
-   4 real strata — over the rule 210 budget of 3; still a genuine
-   namespace split (Wave 2) mid-train. Pattern-matching and
-   terraform-plan-parsing primitives already moved to the sibling
-   `detection.matching` namespace in this same PR; the custom-fn
-   registry/reflection mechanics (`custom-fn-registry`,
-   `declared-method?`, `reflectable-invoke?`, `variadic-accepts-arity?`,
-   `resolve-custom-fn`, `detector-predicate?`) move to
-   `detection.custom-registry` in the next PR of this train, which
-   brings this namespace down to the 3-layer budget.
+   3 real strata — at the rule 210 budget. Pattern-matching and
+   terraform-plan-parsing primitives live in the sibling
+   `detection.matching` namespace; the custom-fn registry/reflection
+   mechanics (`custom-fn-registry`, `declared-method?`,
+   `reflectable-invoke?`, `variadic-accepts-arity?`, `resolve-custom-fn`,
+   `detector-predicate?`) live in `detection.custom-registry` (rule 210
+   split, Wave 2, final slice of this file's train).
 
    Supports detection types:
    - :content-scan - Regex against artifact content
@@ -52,6 +47,7 @@
   (:require
    [ai.miniforge.policy-pack.ast :as ast]
    [ai.miniforge.policy-pack.capability :as capability]
+   [ai.miniforge.policy-pack.detection.custom-registry :as custom-registry]
    [ai.miniforge.policy-pack.detection.matching :as matching]
    [ai.miniforge.policy-pack.schema-validation :as schema]
    [ai.miniforge.policy-clause.interface :as clause]
@@ -88,29 +84,6 @@
            :message       (get-in rule [:rule/enforcement :message])})))))
 
 ;; Custom detection
-(defonce ^{:stratum 0} ^{:private true
-           :doc "Explicit extension registry for custom policy detectors.
-
-Keys are the symbols stored under `:rule/detection :custom-fn`; values are
-2-arity detector functions. This keeps pack manifests data-driven without
-depending on ambient namespace loading or raw var resolution."}
-  custom-fn-registry
-  (atom {}))
-
-(defn- ^{:stratum 0} declared-method?
-  [method-name arity f]
-  (some (fn [^java.lang.reflect.Method method]
-          (and (= method-name (.getName method))
-               (= arity (count (.getParameterTypes method)))))
-        (.getDeclaredMethods (class f))))
-
-(defn- ^{:stratum 0} reflectable-invoke?
-  "True when `f`'s class declares any `invoke` method. JVM functions do; SCI
-   functions under babashka do not, so arity reflection is blind there."
-  [f]
-  (boolean (some #(= "invoke" (.getName ^java.lang.reflect.Method %))
-                 (.getDeclaredMethods (class f)))))
-
 (defn- ^{:stratum 0} run-resolved-custom
   "Run an already-resolved custom fn against `artifact`/`context`, adapting
    the result (or a thrown exception) into a violation map, or nil on pass.
@@ -440,27 +413,39 @@ depending on ambient namespace loading or raw var resolution."}
            :resource-violations (vec resource-violations)
            :message (get-in rule [:rule/enforcement :message])})))))
 
-;------------------------------------------------------------------------------ Layer 1
-
-(defn- ^{:stratum 1} variadic-accepts-arity?
-  [arity f]
-  (when (declared-method? "getRequiredArity" 0 f)
-    (try
-      (<= (.getRequiredArity f) arity)
-      (catch Throwable _ false))))
-
-(defn ^{:stratum 1} unregister-custom-fn!
+(defn ^{:stratum 0} unregister-custom-fn!
   "Remove a registered custom detector. Intended for tests and reload hygiene."
   [custom-fn-sym]
-  (swap! custom-fn-registry dissoc custom-fn-sym)
+  (swap! custom-registry/custom-fn-registry dissoc custom-fn-sym)
   nil)
 
-(defn- ^{:stratum 1} resolve-custom-fn
-  "Look up a `:custom` rule's `:custom-fn` symbol in the explicit registry.
-   Missing registrations are the no-op case routed to the judge."
+(defn ^{:stratum 0} custom-fn-resolvable?
+  "True when a `:custom` rule names a registered `:custom-fn` symbol.
+
+   A `:custom` rule with no resolvable `:custom-fn` is the no-op case the
+   compiled standards pack is full of (PR #979): such rules route to the
+   LLM-as-judge semantic detector instead of silently never firing."
   [rule]
-  (when-let [custom-fn-sym (get-in rule [:rule/detection :custom-fn])]
-    (get @custom-fn-registry custom-fn-sym)))
+  (some? (custom-registry/resolve-custom-fn rule)))
+
+(defn ^{:stratum 0} register-custom-fn!
+  "Register `f` as the detector implementation for `custom-fn-sym`.
+
+   Custom policy detectors are an explicit extension point. Callers that own a
+   detector namespace should register the symbol they place in policy-pack EDN
+   before compiling or applying packs."
+  [custom-fn-sym f]
+  (when-not (symbol? custom-fn-sym)
+    (throw (ex-info "Custom detector key must be a symbol"
+                    {:custom-fn custom-fn-sym})))
+  (when-not (custom-registry/detector-predicate? f)
+    (throw (ex-info "Custom detector value must be a two-arity predicate function"
+                    {:custom-fn custom-fn-sym
+                     :value-type (some-> f class .getName)})))
+  (swap! custom-registry/custom-fn-registry assoc custom-fn-sym f)
+  f)
+
+;------------------------------------------------------------------------------ Layer 1
 
 (defn- ^{:stratum 1} violation-location
   "Location for a gate finding, spanning both detector shapes. Content-scan
@@ -504,26 +489,7 @@ depending on ambient namespace loading or raw var resolution."}
                hits)))
     (:message violation)))
 
-;------------------------------------------------------------------------------ Layer 2
-
-(defn- ^{:stratum 2} detector-predicate?
-  "True when `f` is a custom detector fn. On the JVM its 2-arity shape is verified
-   by reflection; under babashka/SCI (whose fn classes expose no reflectable
-   `invoke` methods, or where reflection is unavailable) arity cannot be
-   introspected, so any `fn?` is accepted rather than rejecting a valid detector
-   we cannot check — this lets detector namespaces register at LOAD time on both
-   runtimes, instead of deferring registration to first use."
-  [f]
-  (and (fn? f)
-       (try
-         (or (declared-method? "invoke" 2 f)
-             (variadic-accepts-arity? 2 f)
-             (not (reflectable-invoke? f)))
-         ;; Reflection/introspection failure (e.g. babashka) → accept the fn.
-         ;; Catch Exception, not Throwable, so JVM Errors are not masked.
-         (catch Exception _ true))))
-
-(defn ^{:stratum 2} detect-custom
+(defn ^{:stratum 1} detect-custom
   "Detect violations using a custom function.
 
    The custom function is specified by registered symbol in :custom-fn and must:
@@ -538,28 +504,11 @@ depending on ambient namespace loading or raw var resolution."}
    Returns:
    - Violation map if detected, nil otherwise"
   [rule artifact context]
-  (when-let [f (resolve-custom-fn rule)]
+  (when-let [f (custom-registry/resolve-custom-fn rule)]
     (run-resolved-custom f rule artifact context)))
 
-(defn ^{:stratum 2} custom-fn-resolvable?
-  "True when a `:custom` rule names a registered `:custom-fn` symbol.
-
-   A `:custom` rule with no resolvable `:custom-fn` is the no-op case the
-   compiled standards pack is full of (PR #979): such rules route to the
-   LLM-as-judge semantic detector instead of silently never firing."
-  [rule]
-  (some? (resolve-custom-fn rule)))
-
-(defn ^{:stratum 2} violation->error
-  [{:keys [rule violation]}]
-  {:code (:rule/id rule)
-   :message (violation-message violation)
-   :severity (:rule/severity rule)
-   :location (violation-location violation)
-   :remediation (get-in rule [:rule/enforcement :remediation])})
-
 ;; Unified detection dispatcher
-(defn ^{:stratum 2} detect-violation
+(defn ^{:stratum 1} detect-violation
   "Detect violations for a rule against an artifact.
 
    Dispatches to the appropriate detection implementation based on
@@ -583,7 +532,7 @@ depending on ambient namespace loading or raw var resolution."}
       :content-scan (detect-content-scan rule artifact context)
       :diff-analysis (detect-diff-analysis rule artifact context)
       :plan-output (detect-plan-output rule artifact context)
-      :custom (if-let [f (resolve-custom-fn rule)]
+      :custom (if-let [f (custom-registry/resolve-custom-fn rule)]
                 (run-resolved-custom f rule artifact context)
                 (detect-semantic rule artifact context))
       :state-comparison (detect-state-comparison rule artifact context)
@@ -591,26 +540,17 @@ depending on ambient namespace loading or raw var resolution."}
       :capability (detect-capability rule artifact context)
       nil)))
 
-;------------------------------------------------------------------------------ Layer 3
+;------------------------------------------------------------------------------ Layer 2
 
-(defn ^{:stratum 3} register-custom-fn!
-  "Register `f` as the detector implementation for `custom-fn-sym`.
+(defn ^{:stratum 2} violation->error
+  [{:keys [rule violation]}]
+  {:code (:rule/id rule)
+   :message (violation-message violation)
+   :severity (:rule/severity rule)
+   :location (violation-location violation)
+   :remediation (get-in rule [:rule/enforcement :remediation])})
 
-   Custom policy detectors are an explicit extension point. Callers that own a
-   detector namespace should register the symbol they place in policy-pack EDN
-   before compiling or applying packs."
-  [custom-fn-sym f]
-  (when-not (symbol? custom-fn-sym)
-    (throw (ex-info "Custom detector key must be a symbol"
-                    {:custom-fn custom-fn-sym})))
-  (when-not (detector-predicate? f)
-    (throw (ex-info "Custom detector value must be a two-arity predicate function"
-                    {:custom-fn custom-fn-sym
-                     :value-type (some-> f class .getName)})))
-  (swap! custom-fn-registry assoc custom-fn-sym f)
-  f)
-
-(defn ^{:stratum 3} check-rules
+(defn ^{:stratum 2} check-rules
   "Check multiple rules against an artifact.
 
    Returns vector of violations found.

--- a/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
@@ -30,10 +30,15 @@
    3 real strata — at the rule 210 budget. Pattern-matching and
    terraform-plan-parsing primitives live in the sibling
    `detection.matching` namespace; the custom-fn registry/reflection
-   mechanics (`custom-fn-registry`, `declared-method?`,
+   mechanics (the registry atom, `declared-method?`,
    `reflectable-invoke?`, `variadic-accepts-arity?`, `resolve-custom-fn`,
-   `detector-predicate?`) live in `detection.custom-registry` (rule 210
-   split, Wave 2, final slice of this file's train).
+   `register!`, `unregister!`, `detector-predicate?`) live in
+   `detection.custom-registry` (rule 210 split, Wave 2, final slice of
+   this file's train). The registry atom itself stays private to that
+   namespace — `register-custom-fn!`/`unregister-custom-fn!` here call
+   `custom-registry/register!`/`custom-registry/unregister!` rather than
+   swapping the atom directly, so this namespace can't bypass whatever
+   invariants the registry namespace enforces.
 
    Supports detection types:
    - :content-scan - Regex against artifact content
@@ -416,8 +421,7 @@
 (defn ^{:stratum 0} unregister-custom-fn!
   "Remove a registered custom detector. Intended for tests and reload hygiene."
   [custom-fn-sym]
-  (swap! custom-registry/custom-fn-registry dissoc custom-fn-sym)
-  nil)
+  (custom-registry/unregister! custom-fn-sym))
 
 (defn ^{:stratum 0} custom-fn-resolvable?
   "True when a `:custom` rule names a registered `:custom-fn` symbol.
@@ -442,8 +446,7 @@
     (throw (ex-info "Custom detector value must be a two-arity predicate function"
                     {:custom-fn custom-fn-sym
                      :value-type (some-> f class .getName)})))
-  (swap! custom-registry/custom-fn-registry assoc custom-fn-sym f)
-  f)
+  (custom-registry/register! custom-fn-sym f))
 
 ;------------------------------------------------------------------------------ Layer 1
 

--- a/components/policy-pack/src/ai/miniforge/policy_pack/detection/custom_registry.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/detection/custom_registry.clj
@@ -81,9 +81,15 @@ depending on ambient namespace loading or raw var resolution."}
     (get @custom-fn-registry custom-fn-sym)))
 
 (defn ^{:stratum 1} register!
-  "Associate `custom-fn-sym` with `f` in the registry. Callers validate `f`
-   (see `detector-predicate?`) before calling this — this fn only mutates."
+  "Associate `custom-fn-sym` with `f` in the registry, enforcing the one
+   invariant this namespace owns: registry keys are symbols. Callers
+   additionally validate `f` itself (see `detector-predicate?`) before
+   calling this, since only the caller knows what a valid detector fn
+   looks like for its use case."
   [custom-fn-sym f]
+  (when-not (symbol? custom-fn-sym)
+    (throw (ex-info "Custom detector key must be a symbol"
+                    {:custom-fn custom-fn-sym})))
   (swap! custom-fn-registry assoc custom-fn-sym f)
   f)
 

--- a/components/policy-pack/src/ai/miniforge/policy_pack/detection/custom_registry.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/detection/custom_registry.clj
@@ -1,0 +1,96 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.detection.custom-registry
+  "Explicit extension registry for custom policy detectors, plus the
+   reflection helpers that decide whether a candidate fn is a valid
+   2-arity detector. Split out of `ai.miniforge.policy-pack.detection`
+   (rule 210: the combined namespace measured 6 real layers, max 3) —
+   same approach as the mdc-compiler split, miniforge#1729-#1743, and
+   the workflow-runner split, miniforge#1662.
+
+   `custom-fn-registry`, `resolve-custom-fn`, and `detector-predicate?`
+   are public (not private, despite being internal mechanics) because
+   `ai.miniforge.policy-pack.detection` — the parent namespace, not this
+   one — is the caller that actually resolves/runs/(un)registers custom
+   detectors; this namespace only stores the registry and validates
+   candidate fns.
+
+   Layer 0: the registry atom, method-declaration reflection primitives
+   Layer 1: arity-reflection (over declared-method?), registry lookup
+     (over the registry atom)
+   Layer 2: detector-predicate? (over Layer 0 + Layer 1)")
+
+;------------------------------------------------------------------------------ Layer 0
+
+(defonce ^{:stratum 0}
+  ^{:doc "Explicit extension registry for custom policy detectors.
+
+Keys are the symbols stored under `:rule/detection :custom-fn`; values are
+2-arity detector functions. This keeps pack manifests data-driven without
+depending on ambient namespace loading or raw var resolution."}
+  custom-fn-registry
+  (atom {}))
+
+(defn- ^{:stratum 0} declared-method?
+  [method-name arity f]
+  (some (fn [^java.lang.reflect.Method method]
+          (and (= method-name (.getName method))
+               (= arity (count (.getParameterTypes method)))))
+        (.getDeclaredMethods (class f))))
+
+(defn- ^{:stratum 0} reflectable-invoke?
+  "True when `f`'s class declares any `invoke` method. JVM functions do; SCI
+   functions under babashka do not, so arity reflection is blind there."
+  [f]
+  (boolean (some #(= "invoke" (.getName ^java.lang.reflect.Method %))
+                 (.getDeclaredMethods (class f)))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn- ^{:stratum 1} variadic-accepts-arity?
+  [arity f]
+  (when (declared-method? "getRequiredArity" 0 f)
+    (try
+      (<= (.getRequiredArity f) arity)
+      (catch Throwable _ false))))
+
+(defn ^{:stratum 1} resolve-custom-fn
+  "Look up a `:custom` rule's `:custom-fn` symbol in the explicit registry.
+   Missing registrations are the no-op case routed to the judge."
+  [rule]
+  (when-let [custom-fn-sym (get-in rule [:rule/detection :custom-fn])]
+    (get @custom-fn-registry custom-fn-sym)))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} detector-predicate?
+  "True when `f` is a custom detector fn. On the JVM its 2-arity shape is verified
+   by reflection; under babashka/SCI (whose fn classes expose no reflectable
+   `invoke` methods, or where reflection is unavailable) arity cannot be
+   introspected, so any `fn?` is accepted rather than rejecting a valid detector
+   we cannot check — this lets detector namespaces register at LOAD time on both
+   runtimes, instead of deferring registration to first use."
+  [f]
+  (and (fn? f)
+       (try
+         (or (declared-method? "invoke" 2 f)
+             (variadic-accepts-arity? 2 f)
+             (not (reflectable-invoke? f)))
+         ;; Reflection/introspection failure (e.g. babashka) → accept the fn.
+         ;; Catch Exception, not Throwable, so JVM Errors are not masked.
+         (catch Exception _ true))))

--- a/components/policy-pack/src/ai/miniforge/policy_pack/detection/custom_registry.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/detection/custom_registry.clj
@@ -23,21 +23,25 @@
    same approach as the mdc-compiler split, miniforge#1729-#1743, and
    the workflow-runner split, miniforge#1662.
 
-   `custom-fn-registry`, `resolve-custom-fn`, and `detector-predicate?`
-   are public (not private, despite being internal mechanics) because
+   The registry atom itself is private: `register!`, `unregister!`, and
+   `resolve-custom-fn` are this namespace's mutation/read API, so a
+   registry invariant (e.g. keys must be symbols) can be enforced here
+   in one place rather than trusting every caller that reaches in with
+   `swap!` directly. `resolve-custom-fn` and `detector-predicate?` are
+   public (not private, despite being internal mechanics) because
    `ai.miniforge.policy-pack.detection` — the parent namespace, not this
    one — is the caller that actually resolves/runs/(un)registers custom
    detectors; this namespace only stores the registry and validates
    candidate fns.
 
    Layer 0: the registry atom, method-declaration reflection primitives
-   Layer 1: arity-reflection (over declared-method?), registry lookup
-     (over the registry atom)
+   Layer 1: arity-reflection (over declared-method?), registry
+     lookup/register!/unregister! (over the registry atom)
    Layer 2: detector-predicate? (over Layer 0 + Layer 1)")
 
 ;------------------------------------------------------------------------------ Layer 0
 
-(defonce ^{:stratum 0}
+(defonce ^{:stratum 0} ^:private
   ^{:doc "Explicit extension registry for custom policy detectors.
 
 Keys are the symbols stored under `:rule/detection :custom-fn`; values are
@@ -75,6 +79,20 @@ depending on ambient namespace loading or raw var resolution."}
   [rule]
   (when-let [custom-fn-sym (get-in rule [:rule/detection :custom-fn])]
     (get @custom-fn-registry custom-fn-sym)))
+
+(defn ^{:stratum 1} register!
+  "Associate `custom-fn-sym` with `f` in the registry. Callers validate `f`
+   (see `detector-predicate?`) before calling this — this fn only mutates."
+  [custom-fn-sym f]
+  (swap! custom-fn-registry assoc custom-fn-sym f)
+  f)
+
+(defn ^{:stratum 1} unregister!
+  "Remove `custom-fn-sym` from the registry. Intended for tests and reload
+   hygiene."
+  [custom-fn-sym]
+  (swap! custom-fn-registry dissoc custom-fn-sym)
+  nil)
 
 ;------------------------------------------------------------------------------ Layer 2
 

--- a/docs/pull-requests/2026-08-11-refactor-split-policy-pack-detection-2.md
+++ b/docs/pull-requests/2026-08-11-refactor-split-policy-pack-detection-2.md
@@ -39,31 +39,41 @@ primitives into `detection.matching`, and picked up one review fix
 ## Changes in Detail
 
 - New file `detection/custom_registry.clj`: the six functions named
-  above, unchanged bodies. 3 layers (L0: `custom-fn-registry`,
+  above, unchanged bodies, plus two new ones added in a review-fix
+  commit (see below). 3 layers (L0: `custom-fn-registry`,
   `declared-method?`, `reflectable-invoke?`; L1: `variadic-accepts-arity?`,
-  `resolve-custom-fn`; L2: `detector-predicate?`).
-  - `custom-fn-registry`, `resolve-custom-fn`, and `detector-predicate?`
-    are now public (were `^:private`/`defn-` in the combined namespace)
-    because `detection.clj` is now a cross-namespace caller of all
-    three — the only visibility changes in this split.
-- `detection.clj`: the six functions removed.
+  `resolve-custom-fn`, `register!`, `unregister!`; L2: `detector-predicate?`).
+  - `resolve-custom-fn` and `detector-predicate?` are public (were
+    `^:private`/`defn-` in the combined namespace) because `detection.clj`
+    is now a cross-namespace caller of both.
+  - `custom-fn-registry` stays `^:private` — never public. A first cut
+    of this slice made it public so `detection.clj` could `swap!` it
+    directly; Copilot review correctly flagged that as an encapsulation
+    regression this split introduced (the atom was never reachable
+    outside its own file before), so a follow-up commit added
+    `register!`/`unregister!` here as the mutation API and put the atom
+    back behind it.
+- `detection.clj`: the six original functions removed.
   `detect-custom`/`custom-fn-resolvable?`/`detect-violation` now call
-  `custom-registry/resolve-custom-fn`, and
-  `register-custom-fn!`/`unregister-custom-fn!` now call
-  `custom-registry/custom-fn-registry` and
-  `custom-registry/detector-predicate?` across the namespace boundary.
-  `register-custom-fn!`, `unregister-custom-fn!`, `custom-fn-resolvable?`,
-  and `detect-custom` themselves stay in `detection.clj`, unchanged in
-  name/signature — they're the "use the registry" half of the custom-fn
-  extension point; the "store/validate the registry" half moved.
+  `custom-registry/resolve-custom-fn` across the namespace boundary.
+  `register-custom-fn!` validates (unchanged: `symbol?` and
+  `custom-registry/detector-predicate?` checks, throwing `ex-info`) then
+  calls `custom-registry/register!`; `unregister-custom-fn!` calls
+  `custom-registry/unregister!`. Neither touches the registry atom
+  itself anymore. `register-custom-fn!`, `unregister-custom-fn!`,
+  `custom-fn-resolvable?`, and `detect-custom` themselves stay in
+  `detection.clj`, unchanged in name/signature — they're the "use the
+  registry" half of the custom-fn extension point; the "store/validate
+  the registry" half moved.
   Ran `stratum-lint --fix` (folded into the pre-commit hook's
   `lint:stratum` step, same as PR 1/2) to renumber the remaining defs:
   4 → 3 real layers. The ns docstring was written to the correct final
-  state directly in the code-motion commit, not left stale.
+  state directly in the code-motion commit, not left stale, and updated
+  again in the review-fix commit to describe the encapsulated registry.
 - Fan-in re-checked via the fully-qualified namespace grep
-  (`ai\.miniforge\.policy-pack\.detection\b`). All 6 moved symbols were
-  `defn-`/`^:private` in the combined namespace, so **no external caller
-  referenced them directly** — confirmed with
+  (`ai\.miniforge\.policy-pack\.detection\b`). All 6 originally-moved
+  symbols were `defn-`/`^:private` in the combined namespace, so **no
+  external caller referenced them directly** — confirmed with
   `grep -rnE 'declared-method\?|reflectable-invoke\?|variadic-accepts-arity\?'`
   across `components`/`bases`/`projects`, which found only
   self-references inside the new file (plus this namespace's own
@@ -71,8 +81,13 @@ primitives into `detection.matching`, and picked up one review fix
   `ai.miniforge.policy-pack.detection` needed call-site updates for this
   slice.
 
-This is pure code motion — no detection logic changed, def set unchanged
-except location and the three visibility flips documented above.
+This is pure code motion for the six originally-moved functions — no
+detection logic changed, def set unchanged except location and two
+visibility flips (`resolve-custom-fn`, `detector-predicate?` private →
+public). The two new `register!`/`unregister!` functions and the
+`custom-fn-registry` visibility reversal are a real (small) design
+change, added in response to review, not part of the original
+code-motion claim.
 
 ## Testing Plan
 
@@ -94,17 +109,21 @@ except location and the three visibility flips documented above.
   - The pre-commit hook's own `test:precommit`/`test:graalvm` passed on
     both commits.
 - Adversarial self-review: diffed the top-level `defn`/`def` set before
-  and after — exactly 6 relocated, 0 added/removed/altered in behavior;
-  3 visibility flips (private → public), documented above; every other
+  and after — 6 relocated with 0 altered behavior, 2 new functions
+  (`register!`/`unregister!`, added in the review-fix commit), 2
+  visibility flips (`resolve-custom-fn`/`detector-predicate?` private →
+  public) plus one visibility reversal (`custom-fn-registry` briefly
+  public, put back to private in the review-fix commit); every other
   call site update is a namespace-qualification change only.
 
-PR size: two commits, 62 and 89 reportable lines respectively (plus the
-pre-commit hook's `lint:stratum` autofix re-staging, same pattern as PR
-1/2 — not a budget violation, `bb commit-budget` measured the pre-hook
-staged diff). Both comfortably under the 600-line PR budget.
-`MINIFORGE_STRATUM_BUDGET_MODE=warn` used on the second commit for the
-plain-lint pre-commit gate, given `detection.clj` was still (briefly,
-pre-autofix) over budget mid-commit.
+PR size: four commits (62, 89, and 43 reportable lines for the
+code-motion/review-fix commits respectively, plus a doc-only commit;
+the pre-commit hook's `lint:stratum` autofix re-stages beyond what
+`bb commit-budget` measures on the pre-hook staged diff, same pattern
+as PR 1/2 — not a budget violation). All comfortably under the 600-line
+PR budget. `MINIFORGE_STRATUM_BUDGET_MODE=warn` used on the code-motion
+commit for the plain-lint pre-commit gate, given `detection.clj` was
+still (briefly, pre-autofix) over budget mid-commit.
 
 Note: this PR was originally opened as #1765, stacked on #1761 before
 that PR merged. Rebasing the stacked branch onto the post-squash-merge
@@ -135,7 +154,9 @@ and `detection.custom-registry`. No further slices needed for this file.
 - [x] Fan-in confirmed via fully-qualified-namespace grep before starting;
       zero external call-site updates needed (all moved symbols were
       already private)
-- [x] Pure code motion — no behavior change; 3 documented visibility flips
+- [x] Pure code motion for the six originally-moved functions; the
+      registry-encapsulation follow-up (2 new fns, 1 visibility
+      reversal) is a documented, review-driven exception
 - [x] `clj-kondo` clean
 - [x] Tests green across all 6 affected namespaces (run from repo root)
 - [x] PR-diff and commit-diff budgets checked

--- a/docs/pull-requests/2026-08-11-refactor-split-policy-pack-detection-2.md
+++ b/docs/pull-requests/2026-08-11-refactor-split-policy-pack-detection-2.md
@@ -1,0 +1,145 @@
+<!--
+  Title: Split policy-pack detection.clj — extract detection.custom-registry (2/2)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(policy-pack): split detection.clj — extract detection.custom-registry (2/2)
+
+## Overview
+
+Slice 2 of the `detection.clj` rule-210 split (see PR 1/2, merged as
+`ff92b0b1b6802ab3e52158ac95d6708873e2ad15`, #1761). Extracts
+`ai.miniforge.policy-pack.detection.custom-registry`: the custom-fn
+extension-point registry atom and the reflection helpers that decide
+whether a candidate fn is a valid 2-arity detector —
+`custom-fn-registry`, `declared-method?`, `reflectable-invoke?`,
+`variadic-accepts-arity?`, `resolve-custom-fn`, `detector-predicate?`.
+3 real layers, stratum-lint clean.
+
+This is the **final slice** of this train: with these six functions
+moved, `detection.clj` itself drops from 4 real layers to 3 — at the
+rule 210 budget. Confirmed by hand-computing each remaining def's real
+same-file dependency depth ahead of the move (cross-namespace calls no
+longer count toward a file's own layer depth once the callee moves out),
+then verifying with a scratch `stratum-lint --fix` dry-run before
+committing, and writing the ns docstring's layer summary to match the
+verified post-fix state directly (rather than leaving a "stale pending
+next commit" placeholder — the first PR of this train left one of those
+and Copilot correctly flagged it as misleading, see below).
+
+## Motivation
+
+Part of the stratum-lint rule-210 remediation program's Wave 2,
+policy-pack batch 2. Continues from PR 1/2, which brought `detection.clj`
+from 6 real layers to 4 by extracting the pattern-matching/plan-parsing
+primitives into `detection.matching`, and picked up one review fix
+(correcting that same PR's stale ns docstring) before merging.
+
+## Changes in Detail
+
+- New file `detection/custom_registry.clj`: the six functions named
+  above, unchanged bodies. 3 layers (L0: `custom-fn-registry`,
+  `declared-method?`, `reflectable-invoke?`; L1: `variadic-accepts-arity?`,
+  `resolve-custom-fn`; L2: `detector-predicate?`).
+  - `custom-fn-registry`, `resolve-custom-fn`, and `detector-predicate?`
+    are now public (were `^:private`/`defn-` in the combined namespace)
+    because `detection.clj` is now a cross-namespace caller of all
+    three — the only visibility changes in this split.
+- `detection.clj`: the six functions removed.
+  `detect-custom`/`custom-fn-resolvable?`/`detect-violation` now call
+  `custom-registry/resolve-custom-fn`, and
+  `register-custom-fn!`/`unregister-custom-fn!` now call
+  `custom-registry/custom-fn-registry` and
+  `custom-registry/detector-predicate?` across the namespace boundary.
+  `register-custom-fn!`, `unregister-custom-fn!`, `custom-fn-resolvable?`,
+  and `detect-custom` themselves stay in `detection.clj`, unchanged in
+  name/signature — they're the "use the registry" half of the custom-fn
+  extension point; the "store/validate the registry" half moved.
+  Ran `stratum-lint --fix` (folded into the pre-commit hook's
+  `lint:stratum` step, same as PR 1/2) to renumber the remaining defs:
+  4 → 3 real layers. The ns docstring was written to the correct final
+  state directly in the code-motion commit, not left stale.
+- Fan-in re-checked via the fully-qualified namespace grep
+  (`ai\.miniforge\.policy-pack\.detection\b`). All 6 moved symbols were
+  `defn-`/`^:private` in the combined namespace, so **no external caller
+  referenced them directly** — confirmed with
+  `grep -rnE 'declared-method\?|reflectable-invoke\?|variadic-accepts-arity\?'`
+  across `components`/`bases`/`projects`, which found only
+  self-references inside the new file (plus this namespace's own
+  docstring prose). None of the files that reference
+  `ai.miniforge.policy-pack.detection` needed call-site updates for this
+  slice.
+
+This is pure code motion — no detection logic changed, def set unchanged
+except location and the three visibility flips documented above.
+
+## Testing Plan
+
+- `stratum-lint` clean (exit 0) on all three files:
+  `detection.clj` (now 3 real layers, down from 6 originally — **at
+  budget**), `detection/matching.clj`, `detection/custom_registry.clj`.
+- `clj-kondo` clean on both touched/added files.
+- Ran every policy-pack test namespace that requires
+  `ai.miniforge.policy-pack.detection`, from repo root (
+  `standard-packs-test` reads a repo-root-relative fixture path, a
+  lesson carried over from PR 1/2's testing notes):
+  - `ai.miniforge.policy-pack.detection-test`: 18 tests / 91 assertions
+  - `ai.miniforge.policy-pack.ast-test`: 7 tests / 22 assertions
+  - `ai.miniforge.policy-pack.intent-test`: 9 tests / 33 assertions
+  - `ai.miniforge.policy-pack.builtin-detectors-test`: 1 test / 13 assertions
+  - `ai.miniforge.policy-pack.compiler-test`: 19 tests / 64 assertions
+  - `ai.miniforge.policy-pack.standard-packs-test`: 10 tests / 399 assertions
+  - All 0 failures, 0 errors.
+  - The pre-commit hook's own `test:precommit`/`test:graalvm` passed on
+    both commits.
+- Adversarial self-review: diffed the top-level `defn`/`def` set before
+  and after — exactly 6 relocated, 0 added/removed/altered in behavior;
+  3 visibility flips (private → public), documented above; every other
+  call site update is a namespace-qualification change only.
+
+PR size: two commits, 62 and 89 reportable lines respectively (plus the
+pre-commit hook's `lint:stratum` autofix re-staging, same pattern as PR
+1/2 — not a budget violation, `bb commit-budget` measured the pre-hook
+staged diff). Both comfortably under the 600-line PR budget.
+`MINIFORGE_STRATUM_BUDGET_MODE=warn` used on the second commit for the
+plain-lint pre-commit gate, given `detection.clj` was still (briefly,
+pre-autofix) over budget mid-commit.
+
+Note: this PR was originally opened as #1765, stacked on #1761 before
+that PR merged. Rebasing the stacked branch onto the post-squash-merge
+`main` produced a real conflict (the squash-merged commit's diff didn't
+patch-match the pre-squash commits cleanly), so the branch was rebuilt
+from a fresh worktree off the merged `main` instead of resolving the
+rebase conflict in place — same code, same commits in spirit, clean
+history against the actual merge base.
+
+## Deployment Plan
+
+Merges to `main` as the final PR of this train.
+`ai.miniforge.policy-pack.detection` is now stratum-lint compliant (3
+real layers, budget 3), alongside its two siblings `detection.matching`
+and `detection.custom-registry`. No further slices needed for this file.
+
+## Related Issues/PRs
+
+- Part 1/2 of this train: `refactor(policy-pack): split detection.clj —
+  extract detection.matching (1/N)`, merged as
+  ff92b0b1b6802ab3e52158ac95d6708873e2ad15 (#1761)
+- Precedent: [mdc_compiler.clj split, #1729-#1743](https://github.com/miniforge-ai/miniforge/pull/1729)
+- Precedent: [workflow_runner.clj split, #1662-#1667](https://github.com/miniforge-ai/miniforge/pull/1662)
+- Part of the stratum-lint rule-210 remediation program (Wave 2, policy-pack batch 2)
+
+## Checklist
+
+- [x] Fan-in confirmed via fully-qualified-namespace grep before starting;
+      zero external call-site updates needed (all moved symbols were
+      already private)
+- [x] Pure code motion — no behavior change; 3 documented visibility flips
+- [x] `clj-kondo` clean
+- [x] Tests green across all 6 affected namespaces (run from repo root)
+- [x] PR-diff and commit-diff budgets checked
+- [x] `MINIFORGE_STRATUM_BUDGET_MODE=warn` used + documented for the
+      expected intermediate over-budget state
+- [x] `detection.clj` confirmed at 3 real layers (target reached) via
+      `stratum-lint` post-commit


### PR DESCRIPTION
<!--
  Title: Split policy-pack detection.clj — extract detection.custom-registry (2/2)
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# refactor(policy-pack): split detection.clj — extract detection.custom-registry (2/2)

## Overview

Slice 2 of the `detection.clj` rule-210 split (see PR 1/2, merged as
`ff92b0b1b6802ab3e52158ac95d6708873e2ad15`, #1761). Extracts
`ai.miniforge.policy-pack.detection.custom-registry`: the custom-fn
extension-point registry atom and the reflection helpers that decide
whether a candidate fn is a valid 2-arity detector —
`custom-fn-registry`, `declared-method?`, `reflectable-invoke?`,
`variadic-accepts-arity?`, `resolve-custom-fn`, `detector-predicate?`.
3 real layers, stratum-lint clean.

This is the **final slice** of this train: with these six functions
moved, `detection.clj` itself drops from 4 real layers to 3 — at the
rule 210 budget. Confirmed by hand-computing each remaining def's real
same-file dependency depth ahead of the move (cross-namespace calls no
longer count toward a file's own layer depth once the callee moves out),
then verifying with a scratch `stratum-lint --fix` dry-run before
committing, and writing the ns docstring's layer summary to match the
verified post-fix state directly (rather than leaving a "stale pending
next commit" placeholder — the first PR of this train left one of those
and Copilot correctly flagged it as misleading, see below).

## Motivation

Part of the stratum-lint rule-210 remediation program's Wave 2,
policy-pack batch 2. Continues from PR 1/2, which brought `detection.clj`
from 6 real layers to 4 by extracting the pattern-matching/plan-parsing
primitives into `detection.matching`, and picked up one review fix
(correcting that same PR's stale ns docstring) before merging.

## Changes in Detail

- New file `detection/custom_registry.clj`: the six functions named
  above, unchanged bodies. 3 layers (L0: `custom-fn-registry`,
  `declared-method?`, `reflectable-invoke?`; L1: `variadic-accepts-arity?`,
  `resolve-custom-fn`; L2: `detector-predicate?`).
  - `custom-fn-registry`, `resolve-custom-fn`, and `detector-predicate?`
    are now public (were `^:private`/`defn-` in the combined namespace)
    because `detection.clj` is now a cross-namespace caller of all
    three — the only visibility changes in this split.
- `detection.clj`: the six functions removed.
  `detect-custom`/`custom-fn-resolvable?`/`detect-violation` now call
  `custom-registry/resolve-custom-fn`, and
  `register-custom-fn!`/`unregister-custom-fn!` now call
  `custom-registry/custom-fn-registry` and
  `custom-registry/detector-predicate?` across the namespace boundary.
  `register-custom-fn!`, `unregister-custom-fn!`, `custom-fn-resolvable?`,
  and `detect-custom` themselves stay in `detection.clj`, unchanged in
  name/signature — they're the "use the registry" half of the custom-fn
  extension point; the "store/validate the registry" half moved.
  Ran `stratum-lint --fix` (folded into the pre-commit hook's
  `lint:stratum` step, same as PR 1/2) to renumber the remaining defs:
  4 → 3 real layers. The ns docstring was written to the correct final
  state directly in the code-motion commit, not left stale.
- Fan-in re-checked via the fully-qualified namespace grep
  (`ai\.miniforge\.policy-pack\.detection\b`). All 6 moved symbols were
  `defn-`/`^:private` in the combined namespace, so **no external caller
  referenced them directly** — confirmed with
  `grep -rnE 'declared-method\?|reflectable-invoke\?|variadic-accepts-arity\?'`
  across `components`/`bases`/`projects`, which found only
  self-references inside the new file (plus this namespace's own
  docstring prose). None of the files that reference
  `ai.miniforge.policy-pack.detection` needed call-site updates for this
  slice.

This is pure code motion — no detection logic changed, def set unchanged
except location and the three visibility flips documented above.

## Testing Plan

- `stratum-lint` clean (exit 0) on all three files:
  `detection.clj` (now 3 real layers, down from 6 originally — **at
  budget**), `detection/matching.clj`, `detection/custom_registry.clj`.
- `clj-kondo` clean on both touched/added files.
- Ran every policy-pack test namespace that requires
  `ai.miniforge.policy-pack.detection`, from repo root (
  `standard-packs-test` reads a repo-root-relative fixture path, a
  lesson carried over from PR 1/2's testing notes):
  - `ai.miniforge.policy-pack.detection-test`: 18 tests / 91 assertions
  - `ai.miniforge.policy-pack.ast-test`: 7 tests / 22 assertions
  - `ai.miniforge.policy-pack.intent-test`: 9 tests / 33 assertions
  - `ai.miniforge.policy-pack.builtin-detectors-test`: 1 test / 13 assertions
  - `ai.miniforge.policy-pack.compiler-test`: 19 tests / 64 assertions
  - `ai.miniforge.policy-pack.standard-packs-test`: 10 tests / 399 assertions
  - All 0 failures, 0 errors.
  - The pre-commit hook's own `test:precommit`/`test:graalvm` passed on
    both commits.
- Adversarial self-review: diffed the top-level `defn`/`def` set before
  and after — exactly 6 relocated, 0 added/removed/altered in behavior;
  3 visibility flips (private → public), documented above; every other
  call site update is a namespace-qualification change only.

PR size: two commits, 62 and 89 reportable lines respectively (plus the
pre-commit hook's `lint:stratum` autofix re-staging, same pattern as PR
1/2 — not a budget violation, `bb commit-budget` measured the pre-hook
staged diff). Both comfortably under the 600-line PR budget.
`MINIFORGE_STRATUM_BUDGET_MODE=warn` used on the second commit for the
plain-lint pre-commit gate, given `detection.clj` was still (briefly,
pre-autofix) over budget mid-commit.

Note: this PR was originally opened as #1765, stacked on #1761 before
that PR merged. Rebasing the stacked branch onto the post-squash-merge
`main` produced a real conflict (the squash-merged commit's diff didn't
patch-match the pre-squash commits cleanly), so the branch was rebuilt
from a fresh worktree off the merged `main` instead of resolving the
rebase conflict in place — same code, same commits in spirit, clean
history against the actual merge base.

## Deployment Plan

Merges to `main` as the final PR of this train.
`ai.miniforge.policy-pack.detection` is now stratum-lint compliant (3
real layers, budget 3), alongside its two siblings `detection.matching`
and `detection.custom-registry`. No further slices needed for this file.

## Related Issues/PRs

- Part 1/2 of this train: `refactor(policy-pack): split detection.clj —
  extract detection.matching (1/N)`, merged as
  ff92b0b1b6802ab3e52158ac95d6708873e2ad15 (#1761)
- Precedent: [mdc_compiler.clj split, #1729-#1743](https://github.com/miniforge-ai/miniforge/pull/1729)
- Precedent: [workflow_runner.clj split, #1662-#1667](https://github.com/miniforge-ai/miniforge/pull/1662)
- Part of the stratum-lint rule-210 remediation program (Wave 2, policy-pack batch 2)

## Checklist

- [x] Fan-in confirmed via fully-qualified-namespace grep before starting;
      zero external call-site updates needed (all moved symbols were
      already private)
- [x] Pure code motion — no behavior change; 3 documented visibility flips
- [x] `clj-kondo` clean
- [x] Tests green across all 6 affected namespaces (run from repo root)
- [x] PR-diff and commit-diff budgets checked
- [x] `MINIFORGE_STRATUM_BUDGET_MODE=warn` used + documented for the
      expected intermediate over-budget state
- [x] `detection.clj` confirmed at 3 real layers (target reached) via
      `stratum-lint` post-commit