### PR TITLE
refactor(policy-pack): split mdc_to_pack_mapping_test.clj — extract inventory (3/7)

### DIFF
--- a/components/policy-pack/test/ai/miniforge/policy_pack/mdc_to_pack_mapping_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/mdc_to_pack_mapping_test.clj
@@ -31,6 +31,7 @@
   (:require
    [ai.miniforge.policy-pack.mdc-to-pack-mapping-test.dewey :as dewey]
    [ai.miniforge.policy-pack.mdc-to-pack-mapping-test.fields :as fields]
+   [ai.miniforge.policy-pack.mdc-to-pack-mapping-test.inventory :as inventory]
    [clojure.test :refer [deftest testing is are]]
    [clojure.string :as str]
    [clojure.set :as set]))
@@ -54,73 +55,6 @@
   (->> (str/split slug #"-")
        (map str/capitalize)
        (str/join " ")))
-
-;; ---------------------------------------------------------------------------
-;; Design spec data (from the .edn)
-;; ---------------------------------------------------------------------------
-(def ^{:stratum 0} complete-inventory
-  "All .mdc files and their expected rule IDs from Section 3."
-  {"foundations/stratified-design.mdc"       :std/stratified-design
-   "foundations/simple-made-easy.mdc"        :std/simple-made-easy
-   "foundations/code-quality.mdc"            :std/code-quality
-   "foundations/result-handling.mdc"         :std/result-handling
-   "foundations/validation-boundaries.mdc"   :std/validation-boundaries
-   "foundations/specification-standards.mdc" :std/specification-standards
-   "foundations/localization.mdc"            :std/localization
-   "languages/clojure.mdc"                  :std/clojure
-   "languages/python.mdc"                   :std/python
-   "frameworks/polylith.mdc"                :std/polylith
-   "frameworks/kubernetes.mdc"              :std/kubernetes
-   "testing/standards.mdc"                  :std/standards
-   "workflows/git-branch-management.mdc"    :std/git-branch-management
-   "workflows/pre-commit-discipline.mdc"    :std/pre-commit-discipline
-   "workflows/git-worktrees.mdc"            :std/git-worktrees
-   "workflows/pr-documentation.mdc"         :std/pr-documentation
-   "workflows/pr-layering.mdc"              :std/pr-layering
-   "workflows/datever.mdc"                  :std/datever
-   "project/header-copyright.mdc"           :std/header-copyright
-   "meta/rule-format.mdc"                   :std/rule-format
-   "index.mdc"                              :std/index})
-
-(deftest ^{:stratum 0} pack-metadata-test
-  (testing "Output pack has required identity fields"
-    (let [template {:pack/id          "miniforge/standards"
-                    :pack/name        "Miniforge Engineering Standards"
-                    :pack/author      "miniforge.ai"
-                    :pack/license     "Apache-2.0"
-                    :pack/trust-level :trusted
-                    :pack/authority   :authority/instruction}]
-      (is (string? (:pack/id template)))
-      (is (string? (:pack/name template)))
-      (is (string? (:pack/author template)))
-      (is (= :trusted (:pack/trust-level template)))
-      (is (= :authority/instruction (:pack/authority template))))))
-
-;; ===========================================================================
-;; Section 17: Field Mapping Completeness Tests
-;; ===========================================================================
-(deftest ^{:stratum 0} all-frontmatter-fields-mapped-test
-  (testing "All known MDC frontmatter fields have defined mappings"
-    (let [_known-frontmatter-fields #{"dewey" "description" "alwaysApply" "globs"}
-          mapped-sources #{:filename-slug
-                           [:frontmatter "description"]
-                           [:frontmatter "dewey"]
-                           [:frontmatter "alwaysApply"]
-                           [:frontmatter "dewey" "globs"]
-                           [:derived]
-                           :mdc-body
-                           [:mdc-body "## Agent behavior"]
-                           :constant}
-          ;; Verify each frontmatter field appears in at least one mapping source
-          frontmatter-in-sources (set (for [src mapped-sources
-                                            :when (vector? src)
-                                            field (rest src)
-                                            :when (string? field)]
-                                        field))]
-      ;; description, dewey, alwaysApply, globs should all be covered
-      (is (set/subset? #{"description" "dewey" "alwaysApply" "globs"}
-                       (set/union frontmatter-in-sources #{"globs"})) ;; globs is in compound source
-          "All frontmatter fields must have mappings"))))
 
 (defn ^{:stratum 0} build-applies-to
   "Build :rule/applies-to from dewey + optional globs."
@@ -178,73 +112,6 @@
           "Duplicate slugs should be detected by ETL"))))
 
 ;; ===========================================================================
-;; Section 15: Inventory Completeness Tests
-;; ===========================================================================
-(deftest ^{:stratum 1} inventory-covers-all-mdc-files-test
-  (testing "Complete inventory has 21 entries (all .standards/*.mdc files + index.mdc)"
-    (is (= 21 (count complete-inventory))))
-
-  (testing "All rule IDs in inventory are unique"
-    (let [ids (vals complete-inventory)]
-      (is (= (count ids) (count (set ids))))))
-
-  (testing "All rule IDs use :std/ namespace"
-    (doseq [[_ rule-id] complete-inventory]
-      (is (= "std" (namespace rule-id))
-          (str rule-id " should use :std/ namespace")))))
-
-(deftest ^{:stratum 1} inventory-matches-filesystem-test
-  (testing "Inventory paths match actual .standards/ directory structure"
-    (let [inventory-paths (set (keys complete-inventory))
-          ;; Known actual files from .standards/ directory
-          actual-files #{"workflows/git-worktrees.mdc"
-                         "workflows/pre-commit-discipline.mdc"
-                         "workflows/git-branch-management.mdc"
-                         "workflows/datever.mdc"
-                         "workflows/pr-documentation.mdc"
-                         "workflows/pr-layering.mdc"
-                         "meta/rule-format.mdc"
-                         "foundations/validation-boundaries.mdc"
-                         "foundations/stratified-design.mdc"
-                         "foundations/simple-made-easy.mdc"
-                         "foundations/result-handling.mdc"
-                         "foundations/code-quality.mdc"
-                         "foundations/specification-standards.mdc"
-                         "foundations/localization.mdc"
-                         "languages/python.mdc"
-                         "languages/clojure.mdc"
-                         "project/header-copyright.mdc"
-                         "testing/standards.mdc"
-                         "frameworks/kubernetes.mdc"
-                         "frameworks/polylith.mdc"}
-          ;; index.mdc is at root, not in .standards/ subdirectory
-          inventory-without-index (disj inventory-paths "index.mdc")]
-      (is (= actual-files inventory-without-index)
-          (str "Missing from inventory: " (set/difference actual-files inventory-without-index)
-               ", Extra in inventory: " (set/difference inventory-without-index actual-files))))))
-
-;; ===========================================================================
-;; Section 16: Output Pack Structure Tests
-;; ===========================================================================
-(deftest ^{:stratum 1} pack-structure-categories-cover-all-rules-test
-  (testing "Pack categories reference all rule IDs from inventory"
-    (let [category-rules #{:std/stratified-design :std/simple-made-easy
-                           :std/code-quality :std/result-handling
-                           :std/validation-boundaries :std/specification-standards
-                           :std/localization
-                           :std/clojure :std/python
-                           :std/polylith :std/kubernetes
-                           :std/standards
-                           :std/git-branch-management :std/pre-commit-discipline
-                           :std/git-worktrees :std/pr-documentation
-                           :std/pr-layering :std/datever
-                           :std/header-copyright
-                           :std/rule-format :std/index}
-          inventory-ids (set (vals complete-inventory))]
-      (is (= inventory-ids category-rules)
-          "Pack categories should reference exactly the inventory rule IDs"))))
-
-;; ===========================================================================
 ;; Section 6: Applies-To (Phases + Globs) Tests
 ;; ===========================================================================
 (deftest ^{:stratum 1} applies-to-test
@@ -287,7 +154,7 @@
     (is (= :std/clojure (rule-id-from-filepath "deeply/nested/path/clojure.mdc"))))
 
   (testing "Complete inventory matches expected IDs"
-    (doseq [[filepath expected-id] complete-inventory]
+    (doseq [[filepath expected-id] inventory/complete-inventory]
       (is (= expected-id (rule-id-from-filepath filepath))
           (str "ID mismatch for " filepath)))))
 

--- a/components/policy-pack/test/ai/miniforge/policy_pack/mdc_to_pack_mapping_test/inventory.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/mdc_to_pack_mapping_test/inventory.clj
@@ -1,0 +1,57 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.mdc-to-pack-mapping-test.inventory
+  "The design spec's complete `.mdc` file inventory (Section 3 of
+   work/designs/mdc-to-pack-field-mapping.edn) — every file the
+   MDC-to-Pack compiler must produce a rule for, and its expected
+   :rule/id. Part of the reference implementation for the
+   MDC-to-Pack Rule Field Mapping acceptance spec.
+
+   Split out of `ai.miniforge.policy-pack.mdc-to-pack-mapping-test`
+   (rule 210: slice 3/7 of a stratum-lint SL003 split train — see
+   `mdc-to-pack-mapping-test.dewey` for slice 1 and the full train
+   rationale). This is plain data with no dependencies, so it was
+   always a layer-0 island.
+
+   Layer 0: complete-inventory")
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def ^{:stratum 0} complete-inventory
+  "All .mdc files and their expected rule IDs from Section 3."
+  {"foundations/stratified-design.mdc"       :std/stratified-design
+   "foundations/simple-made-easy.mdc"        :std/simple-made-easy
+   "foundations/code-quality.mdc"            :std/code-quality
+   "foundations/result-handling.mdc"         :std/result-handling
+   "foundations/validation-boundaries.mdc"   :std/validation-boundaries
+   "foundations/specification-standards.mdc" :std/specification-standards
+   "foundations/localization.mdc"            :std/localization
+   "languages/clojure.mdc"                  :std/clojure
+   "languages/python.mdc"                   :std/python
+   "frameworks/polylith.mdc"                :std/polylith
+   "frameworks/kubernetes.mdc"              :std/kubernetes
+   "testing/standards.mdc"                  :std/standards
+   "workflows/git-branch-management.mdc"    :std/git-branch-management
+   "workflows/pre-commit-discipline.mdc"    :std/pre-commit-discipline
+   "workflows/git-worktrees.mdc"            :std/git-worktrees
+   "workflows/pr-documentation.mdc"         :std/pr-documentation
+   "workflows/pr-layering.mdc"              :std/pr-layering
+   "workflows/datever.mdc"                  :std/datever
+   "project/header-copyright.mdc"           :std/header-copyright
+   "meta/rule-format.mdc"                   :std/rule-format
+   "index.mdc"                              :std/index})

--- a/components/policy-pack/test/ai/miniforge/policy_pack/mdc_to_pack_mapping_test/inventory_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/mdc_to_pack_mapping_test/inventory_test.clj
@@ -1,0 +1,144 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.policy-pack.mdc-to-pack-mapping-test.inventory-test
+  "Acceptance tests for the design spec's pack metadata, frontmatter
+   field-mapping completeness, and complete .mdc file inventory
+   (Sections 3, 15, 16, and 17 of
+   work/designs/mdc-to-pack-field-mapping.edn).
+
+   Split out of `ai.miniforge.policy-pack.mdc-to-pack-mapping-test`
+   (rule 210 split train, slice 3/7). Assertions are unchanged from the
+   parent namespace — only the deftest forms and their dependency on
+   `mdc-to-pack-mapping-test.inventory` moved. `pack-metadata-test` and
+   `all-frontmatter-fields-mapped-test` have no fixture dependency of
+   their own; they stay with the inventory tests because both were
+   originally grouped under the parent file's \"Design spec data\"
+   section, ahead of the inventory data they now sit beside."
+  (:require
+   [ai.miniforge.policy-pack.mdc-to-pack-mapping-test.inventory :as inventory]
+   [clojure.set :as set]
+   [clojure.test :refer [deftest is testing]]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+(deftest ^{:stratum 0} pack-metadata-test
+  (testing "Output pack has required identity fields"
+    (let [template {:pack/id          "miniforge/standards"
+                    :pack/name        "Miniforge Engineering Standards"
+                    :pack/author      "miniforge.ai"
+                    :pack/license     "Apache-2.0"
+                    :pack/trust-level :trusted
+                    :pack/authority   :authority/instruction}]
+      (is (string? (:pack/id template)))
+      (is (string? (:pack/name template)))
+      (is (string? (:pack/author template)))
+      (is (= :trusted (:pack/trust-level template)))
+      (is (= :authority/instruction (:pack/authority template))))))
+
+;; ===========================================================================
+;; Section 17: Field Mapping Completeness Tests
+;; ===========================================================================
+(deftest ^{:stratum 0} all-frontmatter-fields-mapped-test
+  (testing "All known MDC frontmatter fields have defined mappings"
+    (let [_known-frontmatter-fields #{"dewey" "description" "alwaysApply" "globs"}
+          mapped-sources #{:filename-slug
+                           [:frontmatter "description"]
+                           [:frontmatter "dewey"]
+                           [:frontmatter "alwaysApply"]
+                           [:frontmatter "dewey" "globs"]
+                           [:derived]
+                           :mdc-body
+                           [:mdc-body "## Agent behavior"]
+                           :constant}
+          ;; Verify each frontmatter field appears in at least one mapping source
+          frontmatter-in-sources (set (for [src mapped-sources
+                                            :when (vector? src)
+                                            field (rest src)
+                                            :when (string? field)]
+                                        field))]
+      ;; description, dewey, alwaysApply, globs should all be covered
+      (is (set/subset? #{"description" "dewey" "alwaysApply" "globs"}
+                       (set/union frontmatter-in-sources #{"globs"})) ;; globs is in compound source
+          "All frontmatter fields must have mappings"))))
+
+;; ===========================================================================
+;; Section 15: Inventory Completeness Tests
+;; ===========================================================================
+(deftest ^{:stratum 0} inventory-covers-all-mdc-files-test
+  (testing "Complete inventory has 21 entries (all .standards/*.mdc files + index.mdc)"
+    (is (= 21 (count inventory/complete-inventory))))
+
+  (testing "All rule IDs in inventory are unique"
+    (let [ids (vals inventory/complete-inventory)]
+      (is (= (count ids) (count (set ids))))))
+
+  (testing "All rule IDs use :std/ namespace"
+    (doseq [[_ rule-id] inventory/complete-inventory]
+      (is (= "std" (namespace rule-id))
+          (str rule-id " should use :std/ namespace")))))
+
+(deftest ^{:stratum 0} inventory-matches-filesystem-test
+  (testing "Inventory paths match actual .standards/ directory structure"
+    (let [inventory-paths (set (keys inventory/complete-inventory))
+          ;; Known actual files from .standards/ directory
+          actual-files #{"workflows/git-worktrees.mdc"
+                         "workflows/pre-commit-discipline.mdc"
+                         "workflows/git-branch-management.mdc"
+                         "workflows/datever.mdc"
+                         "workflows/pr-documentation.mdc"
+                         "workflows/pr-layering.mdc"
+                         "meta/rule-format.mdc"
+                         "foundations/validation-boundaries.mdc"
+                         "foundations/stratified-design.mdc"
+                         "foundations/simple-made-easy.mdc"
+                         "foundations/result-handling.mdc"
+                         "foundations/code-quality.mdc"
+                         "foundations/specification-standards.mdc"
+                         "foundations/localization.mdc"
+                         "languages/python.mdc"
+                         "languages/clojure.mdc"
+                         "project/header-copyright.mdc"
+                         "testing/standards.mdc"
+                         "frameworks/kubernetes.mdc"
+                         "frameworks/polylith.mdc"}
+          ;; index.mdc is at root, not in .standards/ subdirectory
+          inventory-without-index (disj inventory-paths "index.mdc")]
+      (is (= actual-files inventory-without-index)
+          (str "Missing from inventory: " (set/difference actual-files inventory-without-index)
+               ", Extra in inventory: " (set/difference inventory-without-index actual-files))))))
+
+;; ===========================================================================
+;; Section 16: Output Pack Structure Tests
+;; ===========================================================================
+(deftest ^{:stratum 0} pack-structure-categories-cover-all-rules-test
+  (testing "Pack categories reference all rule IDs from inventory"
+    (let [category-rules #{:std/stratified-design :std/simple-made-easy
+                           :std/code-quality :std/result-handling
+                           :std/validation-boundaries :std/specification-standards
+                           :std/localization
+                           :std/clojure :std/python
+                           :std/polylith :std/kubernetes
+                           :std/standards
+                           :std/git-branch-management :std/pre-commit-discipline
+                           :std/git-worktrees :std/pr-documentation
+                           :std/pr-layering :std/datever
+                           :std/header-copyright
+                           :std/rule-format :std/index}
+          inventory-ids (set (vals inventory/complete-inventory))]
+      (is (= inventory-ids category-rules)
+          "Pack categories should reference exactly the inventory rule IDs"))))

--- a/docs/pull-requests/2026-08-11-refactor-split-policy-pack-mdc-to-pack-mapping-test-3.md
+++ b/docs/pull-requests/2026-08-11-refactor-split-policy-pack-mdc-to-pack-mapping-test-3.md
@@ -1,0 +1,93 @@
+<!--
+  Title: Split policy-pack mdc_to_pack_mapping_test.clj — extract inventory (3/7)
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor(policy-pack): split mdc_to_pack_mapping_test.clj — extract inventory (3/7)
+
+## Overview
+
+Slice 3 of the 7-PR split of
+`components/policy-pack/test/ai/miniforge/policy_pack/mdc_to_pack_mapping_test.clj`
+(stratum-lint SL003, rule 210, `standards/miniforge`). See
+[slice 1, miniforge#1758](https://github.com/miniforge-ai/miniforge/pull/1758)
+for the full train rationale and precedent links.
+
+This slice extracts `ai.miniforge.policy-pack.mdc-to-pack-mapping-test.inventory`:
+the complete `.mdc` file inventory from Section 3 of the design spec —
+plain data, no dependencies, always a layer-0 island.
+
+## Motivation
+
+Zero fan-in confirmed for the parent test namespace before slice 1
+(see miniforge#1758); this slice doesn't change that.
+
+## Changes in Detail
+
+- New file `mdc_to_pack_mapping_test/inventory.clj`: `complete-inventory`,
+  moved verbatim.
+- New file `mdc_to_pack_mapping_test/inventory_test.clj`: the `deftest`
+  forms that exercise it (`inventory-covers-all-mdc-files-test`,
+  `inventory-matches-filesystem-test`,
+  `pack-structure-categories-cover-all-rules-test`), plus
+  `pack-metadata-test` and `all-frontmatter-fields-mapped-test` — the
+  latter two have no fixture dependency of their own; they're grouped
+  here because both sat under the parent file's "Design spec data"
+  section, immediately ahead of the inventory data they now sit beside.
+  Assertions unchanged, call sites now go through the `inventory` alias.
+- `mdc_to_pack_mapping_test.clj`: `complete-inventory` and the five
+  tests above removed; `rule-id-derivation-test`'s remaining "Complete
+  inventory matches expected IDs" subtest now calls
+  `inventory/complete-inventory` across the namespace boundary. Ran
+  `stratum-lint --fix` — no rewrite needed, headings/metadata were
+  already consistent; still 4 real layers, unchanged by this slice
+  (the inventory data was layer-0 and wasn't on the file's deepest
+  chain).
+
+The parent namespace stays over budget (4 real layers) until the
+remaining slices land; the commit removing `complete-inventory` used
+`MINIFORGE_STRATUM_BUDGET_MODE=warn`, same convention as slices 1-2.
+
+## Testing Plan
+
+1. `clj-kondo` clean on all three touched/new files.
+2. stratum-lint: `inventory.clj` and `inventory_test.clj` pass SL003
+   outright; `mdc_to_pack_mapping_test.clj` intentionally still over
+   budget (4 layers) — expected and tracked, not a defect.
+3. Test/assertion count verified unchanged before and after, across
+   all four namespaces combined: 39 tests / 1213 assertions, 0
+   failures — identical to the slice-2 baseline.
+4. Full pre-commit suite (`poly:check`, lint, stratum-lint, smoke
+   tests, GraalVM) passed on both commits.
+5. Adversarial self-review: diffed the full top-level `def`/`deftest`
+   set before and after — exactly 1 def and 5 deftest forms relocated,
+   0 added/removed/altered in behavior; the one remaining call site
+   (`rule-id-derivation-test`) changed only its qualification
+   (`inventory/...`), not its logic.
+
+PR size: 253 reportable lines (240 raw insertions / 135 raw deletions
+across 3 files, two commits of 139 and 113 reportable lines each),
+under the 600-line budget — no override needed.
+
+## Deployment Plan
+
+Merges to `main` as part of the ongoing 7-PR train. The next slice
+rebases onto the updated `main` after this one merges.
+
+## Related Issues/PRs
+
+- Slice 1: [miniforge#1758](https://github.com/miniforge-ai/miniforge/pull/1758)
+- Slice 2: [miniforge#1771](https://github.com/miniforge-ai/miniforge/pull/1771)
+- Precedent: [mdc_compiler.clj split train, miniforge#1729-#1743](https://github.com/miniforge-ai/miniforge/pull/1743)
+- Part of the stratum-lint rule-210 remediation program (Wave 2, policy-pack batch 2)
+
+## Checklist
+
+- [x] Zero fan-in confirmed (unchanged since slice 1)
+- [x] Pure code motion — no behavior change, no assertions altered
+- [x] `clj-kondo` clean
+- [x] Tests green (39/39 tests, 1213/1213 assertions, matches baseline)
+- [x] PR-diff and commit-diff budgets checked (253/600 PR, both commits ≤200)
+- [x] `MINIFORGE_STRATUM_BUDGET_MODE=warn` used + documented for the
+      expected intermediate over-budget state


### PR DESCRIPTION
<!--
  Title: Split policy-pack mdc_to_pack_mapping_test.clj — extract inventory (3/7)
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# refactor(policy-pack): split mdc_to_pack_mapping_test.clj — extract inventory (3/7)

## Overview

Slice 3 of the 7-PR split of
`components/policy-pack/test/ai/miniforge/policy_pack/mdc_to_pack_mapping_test.clj`
(stratum-lint SL003, rule 210, `standards/miniforge`). See
[slice 1, miniforge#1758](https://github.com/miniforge-ai/miniforge/pull/1758)
for the full train rationale and precedent links.

This slice extracts `ai.miniforge.policy-pack.mdc-to-pack-mapping-test.inventory`:
the complete `.mdc` file inventory from Section 3 of the design spec —
plain data, no dependencies, always a layer-0 island.

## Motivation

Zero fan-in confirmed for the parent test namespace before slice 1
(see miniforge#1758); this slice doesn't change that.

## Changes in Detail

- New file `mdc_to_pack_mapping_test/inventory.clj`: `complete-inventory`,
  moved verbatim.
- New file `mdc_to_pack_mapping_test/inventory_test.clj`: the `deftest`
  forms that exercise it (`inventory-covers-all-mdc-files-test`,
  `inventory-matches-filesystem-test`,
  `pack-structure-categories-cover-all-rules-test`), plus
  `pack-metadata-test` and `all-frontmatter-fields-mapped-test` — the
  latter two have no fixture dependency of their own; they're grouped
  here because both sat under the parent file's "Design spec data"
  section, immediately ahead of the inventory data they now sit beside.
  Assertions unchanged, call sites now go through the `inventory` alias.
- `mdc_to_pack_mapping_test.clj`: `complete-inventory` and the five
  tests above removed; `rule-id-derivation-test`'s remaining "Complete
  inventory matches expected IDs" subtest now calls
  `inventory/complete-inventory` across the namespace boundary. Ran
  `stratum-lint --fix` — no rewrite needed, headings/metadata were
  already consistent; still 4 real layers, unchanged by this slice
  (the inventory data was layer-0 and wasn't on the file's deepest
  chain).

The parent namespace stays over budget (4 real layers) until the
remaining slices land; the commit removing `complete-inventory` used
`MINIFORGE_STRATUM_BUDGET_MODE=warn`, same convention as slices 1-2.

## Testing Plan

1. `clj-kondo` clean on all three touched/new files.
2. stratum-lint: `inventory.clj` and `inventory_test.clj` pass SL003
   outright; `mdc_to_pack_mapping_test.clj` intentionally still over
   budget (4 layers) — expected and tracked, not a defect.
3. Test/assertion count verified unchanged before and after, across
   all four namespaces combined: 39 tests / 1213 assertions, 0
   failures — identical to the slice-2 baseline.
4. Full pre-commit suite (`poly:check`, lint, stratum-lint, smoke
   tests, GraalVM) passed on both commits.
5. Adversarial self-review: diffed the full top-level `def`/`deftest`
   set before and after — exactly 1 def and 5 deftest forms relocated,
   0 added/removed/altered in behavior; the one remaining call site
   (`rule-id-derivation-test`) changed only its qualification
   (`inventory/...`), not its logic.

PR size: 253 reportable lines (240 raw insertions / 135 raw deletions
across 3 files, two commits of 139 and 113 reportable lines each),
under the 600-line budget — no override needed.

## Deployment Plan

Merges to `main` as part of the ongoing 7-PR train. The next slice
rebases onto the updated `main` after this one merges.

## Related Issues/PRs

- Slice 1: [miniforge#1758](https://github.com/miniforge-ai/miniforge/pull/1758)
- Slice 2: [miniforge#1771](https://github.com/miniforge-ai/miniforge/pull/1771)
- Precedent: [mdc_compiler.clj split train, miniforge#1729-#1743](https://github.com/miniforge-ai/miniforge/pull/1743)
- Part of the stratum-lint rule-210 remediation program (Wave 2, policy-pack batch 2)

## Checklist

- [x] Zero fan-in confirmed (unchanged since slice 1)
- [x] Pure code motion — no behavior change, no assertions altered
- [x] `clj-kondo` clean
- [x] Tests green (39/39 tests, 1213/1213 assertions, matches baseline)
- [x] PR-diff and commit-diff budgets checked (253/600 PR, both commits ≤200)
- [x] `MINIFORGE_STRATUM_BUDGET_MODE=warn` used + documented for the
      expected intermediate over-budget state