### PR TITLE
feat(buzzword-bingo): reports and message catalog

### DIFF
--- a/components/buzzword-bingo/resources/config/buzzword-bingo/messages/en-US.edn
+++ b/components/buzzword-bingo/resources/config/buzzword-bingo/messages/en-US.edn
@@ -28,6 +28,13 @@
   :report/position       "line {line}, column {column}"
   :report/and-more       "and {count} more"
 
+  ;; Categories
+  :category/ai-tell      "ai-tell"
+  :category/corporate    "corporate"
+  :category/filler       "filler"
+  :category/hedge        "hedge"
+  :category/marketing    "marketing"
+
   ;; Card
   :card/heading          "BINGO CARD"
   :card/free             "FREE"

--- a/components/buzzword-bingo/resources/config/buzzword-bingo/messages/en-US.edn
+++ b/components/buzzword-bingo/resources/config/buzzword-bingo/messages/en-US.edn
@@ -1,0 +1,44 @@
+;; User-facing strings for buzzword-bingo reports.
+;;
+;; Counts are pluralised by key rather than by rule: `-one` when the
+;; count is exactly one, `-many` otherwise. English needs only the two,
+;; and a locale needing more adds its own keys without touching code.
+
+{:buzzword-bingo/messages
+ {;; Verdict
+  :report/heading        "BUZZWORD BINGO"
+  :grade/clean           "clean"
+  :grade/suspect         "suspect"
+  :grade/slop            "slop"
+  :report/nothing-found  "nothing flagged"
+
+  ;; Figures
+  :report/score-line     "score {value} per 1000 words"
+  :report/threshold-line "suspect from {suspect}, slop from {slop}"
+  :report/tally-one      "{hits} hit in {words} words, weight {weighted}"
+  :report/tally-many     "{hits} hits in {words} words, weight {weighted}"
+  :report/catalog-line   "catalog {version}"
+  :report/catalog-custom "catalog supplied by caller"
+
+  ;; Breakdown
+  :report/by-category    "By category"
+  :report/by-term        "By term"
+  :report/count-one      "{count} time"
+  :report/count-many     "{count} times"
+  :report/position       "line {line}, column {column}"
+  :report/and-more       "and {count} more"
+
+  ;; Card
+  :card/heading          "BINGO CARD"
+  :card/free             "FREE"
+  :card/bingo            "BINGO!"
+  :card/line-one         "{count} line complete"
+  :card/line-many        "{count} lines complete"
+  :card/squares          "{marked} of {total} squares marked"
+  :card/turns-one        "{turns} turn"
+  :card/turns-many       "{turns} turns"
+
+  ;; Advice
+  :advice/clean          "Nothing to change."
+  :advice/suspect        "Worth a second look before this goes out."
+  :advice/slop           "Write it again without these."}}

--- a/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/board.cljc
+++ b/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/board.cljc
@@ -1,0 +1,91 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.buzzword-bingo.board
+  "Render a session's card as a five-by-five grid of text.
+
+   Marked squares are bracketed rather than coloured, so the board
+   survives a pipe, a log file and a terminal without colour."
+  (:require
+   [ai.miniforge.buzzword-bingo.card :as card]
+   [ai.miniforge.buzzword-bingo.format :as fmt]
+   [ai.miniforge.buzzword-bingo.messages :as msg]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Cells
+(def ^{:stratum 0} ^:private cell-width 17)
+
+(def ^{:stratum 0} ^:private row-length 5)
+
+(def ^{:stratum 0} ^:private row-prefix "  ")
+
+;; The board
+;; Counts the marks that landed on this card, not every term the session has
+;; seen: most of the catalog is not on any one board, and reporting the wider
+;; number next to a 24-square total would overstate how full the card is.
+(defn- ^{:stratum 0} squares-marked [session]
+  (let [marked (:session/marked session)]
+    (count (filter marked (card/ids-on (:session/card session))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; The grid
+;; Two characters go around every label, so the label itself gets two fewer
+;; than the cell — which keeps every cell exactly `cell-width` wide whether it
+;; is bracketed or not, and the columns therefore line up.
+(defn- ^{:stratum 1} cell-text [marked square]
+  (let [free?   (:square/free? square)
+        label   (if free?
+                  (msg/t :card/free)
+                  (fmt/truncate (- cell-width 2) (:square/term square)))
+        wrapped (if (or free? (contains? marked (:square/id square)))
+                  (str "[" label "]")
+                  (str " " label " "))]
+    (fmt/pad cell-width wrapped)))
+
+(defn- ^{:stratum 1} progress-lines [session]
+  (let [lines (count (:session/lines session))
+        turns (:session/turns session)]
+    [(str (msg/counted :card/turns-one :card/turns-many turns {:turns turns})
+          ", "
+          (msg/t :card/squares {:marked (squares-marked session)
+                                :total  (dec card/square-count)}))
+     (when (pos? lines)
+       (str (msg/t :card/bingo) " "
+            (msg/counted :card/line-one :card/line-many lines {:count lines})))]))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} board-report
+  "Render `session` as a heading, the card, and where the game stands."
+  [session]
+  (let [marked  (:session/marked session)
+        cells   (map (partial cell-text marked)
+                     (:card/squares (:session/card session)))
+        grid    (map (partial str row-prefix)
+                     (map str/join (partition row-length cells)))
+        heading (str (msg/t :card/heading) " — " (:session/id session))]
+    (str/join "\n" (remove nil? (concat [heading ""]
+                                        grid
+                                        [""]
+                                        (progress-lines session))))))
+
+(comment
+  (board-report {:session/id "demo" :session/marked #{} :session/lines #{}
+                 :session/turns 0 :session/card {:card/squares []}}))

--- a/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/format.cljc
+++ b/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/format.cljc
@@ -1,0 +1,63 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.buzzword-bingo.format
+  "Render numbers and columns the same way on every host.
+
+   `clojure.core/format` does not exist in ClojureScript, and `str` on
+   a double disagrees across hosts — 25.0 prints as \"25.0\" on the JVM
+   and \"25\" in JavaScript. Both would show up as a diff between the
+   Babashka CLI and the Node build reporting the same scan.")
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Numbers and columns
+(def ^{:stratum 0} ^:private hundredths 100)
+
+(defn ^{:stratum 0} pad
+  "Pad `s` with spaces to `width`, leaving it alone when already longer."
+  [width s]
+  (let [text (str s)]
+    (if (>= (count text) width)
+      text
+      (str text (apply str (repeat (- width (count text)) " "))))))
+
+(def ^{:stratum 0} ^:private ellipsis "…")
+
+;------------------------------------------------------------------------------ Layer 1
+
+(defn ^{:stratum 1} decimal
+  "Render non-negative `x` with exactly two decimal places."
+  [x]
+  (let [scaled (long (+ 0.5 (* x hundredths)))
+        whole  (quot scaled hundredths)
+        frac   (rem scaled hundredths)]
+    (str whole "." (when (< frac 10) "0") frac)))
+
+(defn ^{:stratum 1} truncate
+  "Shorten `s` to `width`, ending it with an ellipsis when cut."
+  [width s]
+  (let [text (str s)]
+    (if (<= (count text) width)
+      text
+      (str (subs text 0 (dec width)) ellipsis))))
+
+(comment
+  (decimal 62.015)
+  (decimal 25.0)
+  (pad 10 "robust")
+  (truncate 8 "low-hanging fruit"))

--- a/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/interface.cljc
+++ b/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/interface.cljc
@@ -23,9 +23,11 @@
    keeping or should be written again. A session plays the same hits
    onto a bingo card across the turns of one conversation."
   (:require
+   [ai.miniforge.buzzword-bingo.board :as board]
    [ai.miniforge.buzzword-bingo.card :as card]
    [ai.miniforge.buzzword-bingo.detect :as detect]
    [ai.miniforge.buzzword-bingo.lexicon :as lexicon]
+   [ai.miniforge.buzzword-bingo.report :as report]
    [ai.miniforge.buzzword-bingo.score :as score]
    [ai.miniforge.buzzword-bingo.segment :as segment]
    [ai.miniforge.buzzword-bingo.session :as session]))
@@ -103,8 +105,20 @@
   [session scan-result]
   (session/track session scan-result))
 
+;; Reports
+(defn ^{:stratum 0} scan-report
+  "Render a scan result as text: the verdict first, then the evidence."
+  [scored]
+  (report/scan-report scored))
+
+(defn ^{:stratum 0} board-report
+  "Render a session's card as a grid, with where the game stands."
+  [session]
+  (board/board-report session))
+
 (comment
   (prose-only "Use `robust` in code but not in prose.")
   (scan "A robust, comprehensive, seamless solution.")
   (:score/grade (scan "Plain sentence about a file parser."))
-  (-> (open-session "demo") (track (scan "A robust and seamless solution."))))
+  (println (scan-report (scan "A robust and comprehensive solution.")))
+  (-> (open-session "demo") (track (scan "A robust and seamless solution.")) board-report println))

--- a/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/messages.cljc
+++ b/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/messages.cljc
@@ -46,11 +46,16 @@
 ;; Lookup
 (defn ^{:stratum 1} t
   "Look up the message `k`, substituting `params` into `{placeholder}`
-   tokens. An absent key renders as its own name rather than throwing,
-   so a missing string degrades a report instead of failing it."
+   tokens. An absent key renders as its own qualified name rather than
+   throwing, so a missing string degrades a report instead of failing it.
+
+   The fallback keeps the namespace — `:report/heading` renders as
+   `report/heading`, not `heading` — because the bare name is ambiguous
+   across the catalog's sections and harder to grep for when a missing
+   string shows up in output."
   ([k] (t k nil))
   ([k params]
-   (let [template (get catalog k (name k))]
+   (let [template (get catalog k (str (symbol k)))]
      (if (seq params)
        (substitute template params)
        template))))

--- a/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/messages.cljc
+++ b/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/messages.cljc
@@ -1,0 +1,71 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.buzzword-bingo.messages
+  "Message catalog for this component, on every host.
+
+   Same `{placeholder}` convention and `t` signature as the shared
+   messages component, but the catalog is inlined at compile time
+   rather than read from the classpath, because this component also
+   compiles to a Node script where no classpath exists."
+  (:require
+   [clojure.string :as str]
+   #?(:clj [ai.miniforge.buzzword-bingo.inline :as inline]))
+  #?(:cljs (:require-macros [ai.miniforge.buzzword-bingo.inline :as inline])))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Catalog
+;; The macro needs a literal path, so it cannot come from a named constant.
+(def ^{:stratum 0} ^:private catalog
+  (get (inline/edn-resource "config/buzzword-bingo/messages/en-US.edn")
+       :buzzword-bingo/messages))
+
+(defn- ^{:stratum 0} substitute [template params]
+  (reduce-kv (fn [s placeholder value]
+               (str/replace s (str "{" (name placeholder) "}") (str value)))
+             template
+             params))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Lookup
+(defn ^{:stratum 1} t
+  "Look up the message `k`, substituting `params` into `{placeholder}`
+   tokens. An absent key renders as its own name rather than throwing,
+   so a missing string degrades a report instead of failing it."
+  ([k] (t k nil))
+  ([k params]
+   (let [template (get catalog k (name k))]
+     (if (seq params)
+       (substitute template params)
+       template))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} counted
+  "Look up the singular or plural form of `base` for `n`.
+
+   Takes the two keys rather than deriving them, so a grep for a
+   message key finds its use site."
+  [one-key many-key n params]
+  (t (if (= 1 n) one-key many-key) params))
+
+(comment
+  (t :report/heading)
+  (t :report/score-line {:value 62.02})
+  (counted :report/count-one :report/count-many 1 {:count 1}))

--- a/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/report.cljc
+++ b/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/report.cljc
@@ -35,6 +35,16 @@
 (def ^{:stratum 0} ^:private advice-keys
   {:clean :advice/clean :suspect :advice/suspect :slop :advice/slop})
 
+;; Spelled out rather than derived from the category, so a grep for a
+;; message key finds its use site — same reason `counted` takes both of
+;; its keys instead of building them.
+(def ^{:stratum 0} ^:private category-keys
+  {:ai-tell   :category/ai-tell
+   :corporate :category/corporate
+   :filler    :category/filler
+   :hedge     :category/hedge
+   :marketing :category/marketing})
+
 (def ^{:stratum 0} ^:private term-column-width 22)
 
 (def ^{:stratum 0} ^:private count-column-width 10)
@@ -67,6 +77,17 @@
     (msg/t :report/catalog-line {:version version})
     (msg/t :report/catalog-custom)))
 
+(defn- ^{:stratum 0} category-label
+  "Catalog label for `category`.
+
+   A caller-supplied lexicon can name categories this catalog has no
+   string for, so an unknown one falls back to its own name rather than
+   rendering blank."
+  [category]
+  (if-let [k (get category-keys category)]
+    (msg/t k)
+    (name category)))
+
 (defn- ^{:stratum 0} times [n]
   (msg/counted :report/count-one :report/count-many n {:count n}))
 
@@ -78,7 +99,7 @@
 
 (defn- ^{:stratum 1} category-line [[category tally]]
   (str indent-prefix
-       (fmt/pad term-column-width (name category))
+       (fmt/pad term-column-width (category-label category))
        (fmt/pad count-column-width (times (:tally/count tally)))
        (:tally/weighted tally)))
 
@@ -86,7 +107,7 @@
   (str indent-prefix
        (fmt/pad term-column-width (:tally/term tally))
        (fmt/pad count-column-width (times (:tally/count tally)))
-       (name (:tally/category tally))))
+       (category-label (:tally/category tally))))
 
 ;------------------------------------------------------------------------------ Layer 2
 

--- a/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/report.cljc
+++ b/components/buzzword-bingo/src/ai/miniforge/buzzword_bingo/report.cljc
@@ -1,0 +1,117 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.buzzword-bingo.report
+  "Render a scored scan as text a person reads.
+
+   Ordered so the verdict comes first and the evidence after it: a
+   reader who only wants the answer stops at line one, and a reader who
+   disagrees with it can see every word that produced it."
+  (:require
+   [ai.miniforge.buzzword-bingo.format :as fmt]
+   [ai.miniforge.buzzword-bingo.messages :as msg]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Vocabulary
+(def ^{:stratum 0} ^:private grade-keys
+  {:clean :grade/clean :suspect :grade/suspect :slop :grade/slop})
+
+(def ^{:stratum 0} ^:private advice-keys
+  {:clean :advice/clean :suspect :advice/suspect :slop :advice/slop})
+
+(def ^{:stratum 0} ^:private term-column-width 22)
+
+(def ^{:stratum 0} ^:private count-column-width 10)
+
+(def ^{:stratum 0} ^:private indent-prefix "  ")
+
+(def ^{:stratum 0} ^:private listed-term-limit
+  "Terms listed individually before the tail is summarised. Past this a
+   report stops being read and starts being scrolled."
+  12)
+
+(defn- ^{:stratum 0} score-line [scored]
+  (let [thresholds (:score/thresholds scored)]
+    (str (msg/t :report/score-line {:value (fmt/decimal (:score/value scored))})
+         " ("
+         (msg/t :report/threshold-line
+                {:suspect (fmt/decimal (:threshold/suspect thresholds))
+                 :slop    (fmt/decimal (:threshold/slop thresholds))})
+         ")")))
+
+(defn- ^{:stratum 0} tally-line [scored]
+  (let [hits (:score/hit-count scored)]
+    (msg/counted :report/tally-one :report/tally-many hits
+                 {:hits     hits
+                  :words    (:scan/word-count scored)
+                  :weighted (:score/weighted scored)})))
+
+(defn- ^{:stratum 0} catalog-line [scored]
+  (if-let [version (:scan/lexicon-version scored)]
+    (msg/t :report/catalog-line {:version version})
+    (msg/t :report/catalog-custom)))
+
+(defn- ^{:stratum 0} times [n]
+  (msg/counted :report/count-one :report/count-many n {:count n}))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; Sections
+(defn- ^{:stratum 1} verdict-line [scored]
+  (str (msg/t :report/heading) " — " (msg/t (get grade-keys (:score/grade scored)))))
+
+(defn- ^{:stratum 1} category-line [[category tally]]
+  (str indent-prefix
+       (fmt/pad term-column-width (name category))
+       (fmt/pad count-column-width (times (:tally/count tally)))
+       (:tally/weighted tally)))
+
+(defn- ^{:stratum 1} term-line [tally]
+  (str indent-prefix
+       (fmt/pad term-column-width (:tally/term tally))
+       (fmt/pad count-column-width (times (:tally/count tally)))
+       (name (:tally/category tally))))
+
+;------------------------------------------------------------------------------ Layer 2
+
+(defn ^{:stratum 2} scan-report
+  "Render `scored`, the result of a scan, as plain text."
+  [scored]
+  (let [header     [(verdict-line scored) (score-line scored)
+                    (tally-line scored) (catalog-line scored)]
+        categories (into [(msg/t :report/by-category)]
+                         (map category-line)
+                         (sort-by key (:score/by-category scored)))
+        tallies    (:score/by-term scored)
+        listed     (take listed-term-limit tallies)
+        hidden     (- (count tallies) (count listed))
+        terms      (cond-> (into [(msg/t :report/by-term)] (map term-line) listed)
+                     (pos? hidden)
+                     (conj (str indent-prefix (msg/t :report/and-more {:count hidden}))))
+        body       (if (zero? (:score/hit-count scored))
+                     [(msg/t :report/nothing-found)]
+                     (concat categories [""] terms))
+        advice     (msg/t (get advice-keys (:score/grade scored)))]
+    (str/join "\n" (concat header [""] body ["" advice]))))
+
+(comment
+  (scan-report {:score/grade :slop :score/value 62.02 :score/hit-count 4
+                :score/weighted 8 :scan/word-count 29
+                :score/thresholds {:threshold/suspect 10.0 :threshold/slop 25.0}
+                :score/by-category {} :score/by-term []}))

--- a/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/board_test.cljc
+++ b/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/board_test.cljc
@@ -1,0 +1,85 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.buzzword-bingo.board-test
+  (:require
+   [ai.miniforge.buzzword-bingo.board :as sut]
+   [ai.miniforge.buzzword-bingo.interface :as bingo]
+   [clojure.string :as str]
+   #?(:clj  [clojure.test :refer [deftest is testing]]
+      :cljs [cljs.test :refer-macros [deftest is testing]])))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Fixtures and helpers
+(def ^{:stratum 0} ^:private board-rows 5)
+
+(defn- ^{:stratum 0} session-marking
+  "A session whose card squares at `indices` have been marked."
+  [indices]
+  (let [session (bingo/open-session "board-under-test")
+        wanted  (set indices)
+        ids     (into [] (comp (filter #(contains? wanted (:square/index %)))
+                               (keep :square/id))
+                      (:card/squares (:session/card session)))]
+    (bingo/track session
+                 ;; Weight included because every hit detect/scan emits carries
+                 ;; one, and the session sums it.
+                 {:scan/hits       (mapv (fn [id] {:hit/id id :hit/weight 3}) ids)
+                  :scan/word-count 10})))
+
+(defn- ^{:stratum 0} grid-lines [report]
+  (filterv #(str/starts-with? % "  ") (str/split-lines report)))
+
+;; Counted rather than matched on the term itself: a long term is truncated to
+;; fit its cell, so the full text is not in the output to look for.
+(defn- ^{:stratum 0} bracketed-cells [session]
+  (count (re-seq #"\[[^\]]*\]" (sut/board-report session))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; The grid
+(deftest ^{:stratum 1} test-a-board-is-five-rows-of-five
+  (testing "given a session → the card renders as five rows"
+    (is (= board-rows (count (grid-lines (sut/board-report (session-marking [])))))))
+
+  (testing "given a session → the free centre square is shown as taken"
+    (is (str/includes? (sut/board-report (session-marking [])) "[FREE]"))))
+
+(deftest ^{:stratum 1} test-marks-are-visible-without-colour
+  (testing "given nothing marked → only the free square is bracketed"
+    (is (= 1 (bracketed-cells (session-marking [])))))
+
+  (testing "given three marked squares → each is bracketed alongside the free one"
+    (is (= 4 (bracketed-cells (session-marking [0 1 2]))))))
+
+;; Progress
+(deftest ^{:stratum 1} test-progress-counts-squares-on-this-card
+  (testing "given marks → the count is of squares on the board, not of every term seen"
+    (let [session (session-marking [0 1 2])
+          padded  (assoc session :session/marked
+                         (into (:session/marked session) [:not-on-this-card :nor-this]))]
+      (is (str/includes? (sut/board-report padded) "3 of 24 squares marked")))))
+
+(deftest ^{:stratum 1} test-bingo-is-announced-only-once-a-line-is-complete
+  (testing "given no completed line → no announcement"
+    (is (not (str/includes? (sut/board-report (session-marking [0 1 2 3])) "BINGO!"))))
+
+  (testing "given a completed row → the announcement and the line count"
+    (let [report (sut/board-report (session-marking [0 1 2 3 4]))]
+      (is (str/includes? report "BINGO!"))
+      (is (str/includes? report "1 line complete")))))

--- a/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/format_test.cljc
+++ b/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/format_test.cljc
@@ -1,0 +1,54 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.buzzword-bingo.format-test
+  (:require
+   [ai.miniforge.buzzword-bingo.format :as sut]
+   #?(:clj  [clojure.test :refer [deftest is testing]]
+      :cljs [cljs.test :refer-macros [deftest is testing]])))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Numbers
+;; The whole reason this namespace exists: `(str 25.0)` is "25.0" on the JVM
+;; and "25" in JavaScript, which would show up as a diff between the Babashka
+;; CLI and the Node build reporting the same scan.
+(deftest ^{:stratum 0} test-decimals-render-identically-on-every-host
+  (testing "given a whole number → two decimal places all the same"
+    (is (= "25.00" (sut/decimal 25.0))))
+
+  (testing "given a fraction → rounded to two places, half up"
+    (is (= "62.02" (sut/decimal 62.015)))
+    (is (= "0.00" (sut/decimal 0.0)))
+    (is (= "3.58" (sut/decimal 3.5837))))
+
+  (testing "given a value below a tenth → the leading zero is kept"
+    (is (= "0.05" (sut/decimal 0.05)))))
+
+;; Columns
+(deftest ^{:stratum 0} test-columns-hold-their-width
+  (testing "given text shorter than the column → padded to it"
+    (is (= "robust    " (sut/pad 10 "robust"))))
+
+  (testing "given text longer than the column → left alone rather than cut"
+    (is (= "low-hanging fruit" (sut/pad 10 "low-hanging fruit"))))
+
+  (testing "given text longer than a truncation width → cut with an ellipsis"
+    (is (= 8 (count (sut/truncate 8 "low-hanging fruit")))))
+
+  (testing "given text within the truncation width → returned whole"
+    (is (= "robust" (sut/truncate 8 "robust")))))

--- a/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/messages_test.cljc
+++ b/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/messages_test.cljc
@@ -1,0 +1,56 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.buzzword-bingo.messages-test
+  (:require
+   [ai.miniforge.buzzword-bingo.messages :as sut]
+   [clojure.string :as str]
+   #?(:clj  [clojure.test :refer [deftest is testing]]
+      :cljs [cljs.test :refer-macros [deftest is testing]])))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Lookup
+(deftest ^{:stratum 0} test-catalog-lookup
+  (testing "given a key in the catalog → its string"
+    (is (= "BUZZWORD BINGO" (sut/t :report/heading))))
+
+  (testing "given placeholders → substituted from params"
+    (is (= "score 62.02 per 1000 words"
+           (sut/t :report/score-line {:value "62.02"}))))
+
+  (testing "given several placeholders → all substituted"
+    (let [rendered (sut/t :report/tally-many {:hits 4 :words 29 :weighted 8})]
+      (is (not (str/includes? rendered "{")))
+      (is (str/includes? rendered "4"))
+      (is (str/includes? rendered "29"))))
+
+  ;; A report that loses a line is better than a report that throws, and the
+  ;; key name says which string is missing.
+  (testing "given a key absent from the catalog → its name, not an exception"
+    (is (= "missing-string" (sut/t :nowhere/missing-string)))))
+
+;; Counting
+(deftest ^{:stratum 0} test-plural-forms-are-chosen-by-key
+  (testing "given exactly one → the singular key"
+    (is (= "1 time" (sut/counted :report/count-one :report/count-many 1 {:count 1}))))
+
+  (testing "given more than one → the plural key"
+    (is (= "3 times" (sut/counted :report/count-one :report/count-many 3 {:count 3}))))
+
+  (testing "given none → the plural key, as English does"
+    (is (= "0 times" (sut/counted :report/count-one :report/count-many 0 {:count 0})))))

--- a/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/messages_test.cljc
+++ b/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/messages_test.cljc
@@ -40,9 +40,14 @@
       (is (str/includes? rendered "29"))))
 
   ;; A report that loses a line is better than a report that throws, and the
-  ;; key name says which string is missing.
-  (testing "given a key absent from the catalog → its name, not an exception"
-    (is (= "missing-string" (sut/t :nowhere/missing-string)))))
+  ;; qualified key says which string is missing. The bare name would not:
+  ;; the catalog reuses names across sections, so `heading` alone does not
+  ;; identify `:report/heading` versus `:card/heading`.
+  (testing "given a key absent from the catalog → its qualified name, not an exception"
+    (is (= "nowhere/missing-string" (sut/t :nowhere/missing-string))))
+
+  (testing "given an absent key → the namespace is kept, not dropped"
+    (is (= "report/nowhere" (sut/t :report/nowhere)))))
 
 ;; Counting
 (deftest ^{:stratum 0} test-plural-forms-are-chosen-by-key

--- a/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/report_test.cljc
+++ b/components/buzzword-bingo/test/ai/miniforge/buzzword_bingo/report_test.cljc
@@ -1,0 +1,81 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns ai.miniforge.buzzword-bingo.report-test
+  (:require
+   [ai.miniforge.buzzword-bingo.interface :as bingo]
+   [ai.miniforge.buzzword-bingo.report :as sut]
+   [clojure.string :as str]
+   #?(:clj  [clojure.test :refer [deftest is testing]]
+      :cljs [cljs.test :refer-macros [deftest is testing]])))
+
+;------------------------------------------------------------------------------ Layer 0
+
+;; Fixtures and helpers
+(def ^{:stratum 0} ^:private slop-text
+  (str "Our comprehensive platform delivers a seamless, robust experience. "
+       "Let us delve into the tapestry of synergy and low-hanging fruit."))
+
+(def ^{:stratum 0} ^:private clean-text
+  (str "The loop condition used the wrong comparison, so the last index was "
+       "skipped. The fix changes it and the two failing tests pass."))
+
+(defn- ^{:stratum 0} report-of [text]
+  (sut/scan-report (bingo/scan text)))
+
+(defn- ^{:stratum 0} first-line [text]
+  (first (str/split-lines text)))
+
+(deftest ^{:stratum 0} test-a-caller-supplied-catalog-is-not-attributed-to-the-shipped-one
+  (testing "given a caller's own catalog → the report does not claim a shipped version"
+    (let [report (sut/scan-report (bingo/scan "robust" {:entries []}))]
+      (is (not (str/includes? report (bingo/lexicon-version)))))))
+
+;------------------------------------------------------------------------------ Layer 1
+
+;; What a report says
+(deftest ^{:stratum 1} test-the-verdict-comes-first
+  (testing "given slop → the first line names the grade, before any evidence"
+    (is (str/includes? (first-line (report-of slop-text)) "slop")))
+
+  (testing "given clean prose → the first line says so"
+    (is (str/includes? (first-line (report-of clean-text)) "clean"))))
+
+(deftest ^{:stratum 1} test-a-report-shows-its-working
+  (testing "given hits → the score, the thresholds it was judged against, and the catalog"
+    (let [report (report-of slop-text)]
+      (is (str/includes? report "per 1000 words"))
+      (is (str/includes? report "suspect from"))
+      (is (str/includes? report (bingo/lexicon-version)))))
+
+  (testing "given hits → every flagged term is named, so the verdict can be argued with"
+    (let [report (report-of slop-text)]
+      (is (str/includes? report "comprehensive"))
+      (is (str/includes? report "delve"))
+      (is (str/includes? report "low-hanging fruit"))))
+
+  (testing "given hits → categories are broken out alongside terms"
+    (let [report (report-of slop-text)]
+      (is (str/includes? report "marketing"))
+      (is (str/includes? report "ai-tell")))))
+
+;; Edges
+(deftest ^{:stratum 1} test-a-clean-report-stays-short
+  (testing "given nothing flagged → the report says so rather than printing empty sections"
+    (let [report (report-of clean-text)]
+      (is (str/includes? report "nothing flagged"))
+      (is (not (str/includes? report "By term"))))))

--- a/docs/pull-requests/2026-08-12-feat-buzzword-bingo-reports.md
+++ b/docs/pull-requests/2026-08-12-feat-buzzword-bingo-reports.md
@@ -1,0 +1,117 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# feat: buzzword-bingo reports and message catalog
+
+## Overview
+
+Fourth slice. The scanner produces data; this turns it into something a person
+reads. Two renderers — a scan report and a session board — plus the message
+catalog they draw their strings from and the number formatting they share.
+
+Nothing here changes what is counted. It is the surface the CLI, the MCP server
+and the Stop hook all print.
+
+## Motivation
+
+Every consumer that follows needs the same two pieces of text. Writing them
+once, here, keeps the CLI and the MCP server from drifting into two dialects of
+the same report — and keeps the strings in a catalog, where the localization
+rule requires them, rather than scattered across three entry points.
+
+## Changes in Detail
+
+### `messages.cljc` and the catalog
+
+The localization rule (dewey 050) is hard-halt: every emitted prose string
+flows through a catalog. The shared `messages` component loads catalogs from
+the classpath, which does not exist in a bundled Node script, so this component
+carries its own loader using the same compile-time inlining as the lexicon.
+
+Same `{placeholder}` convention and same `t` signature as the shared component,
+so the two read alike at call sites. An absent key renders as its own name
+rather than throwing: a missing string should degrade a report, not fail it.
+
+Counts are pluralised by key — `-one` and `-many` — rather than by rule.
+English needs only the two, and a locale needing more adds its own keys without
+touching code.
+
+### `format.cljc`
+
+`clojure.core/format` does not exist in ClojureScript, and `str` on a double
+disagrees across hosts: `25.0` prints as `"25.0"` on the JVM and `"25"` in
+JavaScript. Either would show up as a diff between the Babashka CLI and the
+Node build reporting the same scan, which is the property this component has
+been protecting throughout. `decimal` renders two places identically on both;
+`pad` and `truncate` hold the card's columns.
+
+### `report.cljc`
+
+The verdict first, the evidence after it. A reader who only wants the answer
+stops at line one; a reader who disagrees can see every word that produced it,
+along with the thresholds it was judged against and the catalog version that
+produced the hits.
+
+A clean scan says so in one line rather than printing empty sections. A long
+tail of terms is cut at twelve with a count of the remainder — past that a
+report stops being read and starts being scrolled.
+
+### `board.cljc`
+
+The card as a five-by-five grid, marked squares bracketed rather than coloured
+so the board survives a pipe, a log file and a terminal without colour. Long
+terms are truncated to keep every cell the same width, so the columns line up
+whether a square is marked or not.
+
+Progress counts the marks that landed *on this card*, not every term the
+session has seen. Most of the catalog is not on any one board, and reporting
+the wider number next to a 24-square total would overstate how full the card
+is — a bug this PR found and fixed while writing the renderer.
+
+## Testing Plan
+
+21 tests, 78 assertions across these namespaces:
+
+- `format-test` — the cross-host number cases that motivate the namespace,
+  including a whole number rendering with two places on both hosts.
+- `messages-test` — lookup, single and multiple placeholder substitution, the
+  missing-key fallback, and plural selection at zero, one and many.
+- `report-test` — the grade on the first line before any evidence, the score
+  and thresholds and catalog version present, every flagged term named, a clean
+  report staying short, and a caller-supplied catalog not being attributed to
+  the shipped version.
+- `board-test` — five rows, the free square shown as taken, marks visible
+  without colour, progress counting card squares rather than every term seen,
+  and BINGO announced only once a line is complete.
+
+Bracketed cells are counted rather than matched by term, because a long term is
+truncated to fit its cell and the full text is not in the output to look for.
+
+## Deployment Plan
+
+Library code. No entry point; the CLI is the first consumer.
+
+## Related Issues/PRs
+
+1. #1716 — regex, phrase, segment strata (merged)
+2. #1757 — catalog, detection, scoring (merged)
+3. #1767 — card and session
+4. **This PR** — reports and message catalog
+5. CLI and `bb bingo` task
+6. MCP server
+7. Stop hook and skill
+8. ClojureScript/Node build and npm packaging
+
+## Checklist
+
+- [x] `poly check` clean, no warnings
+- [x] `clj-kondo` clean
+- [x] `stratum-lint` clean, every namespace inside the three-layer budget
+- [x] Every emitted prose string routed through the catalog (dewey 050)
+- [x] Each commit under the 200-line commit budget
+- [x] Apache header on every source file
+- [x] Adversarial self-review of the diff
+- [x] Standards gap analysis against `standards/miniforge`


### PR DESCRIPTION
## Overview

Fourth slice. The scanner produces data; this turns it into something a person
reads. Two renderers — a scan report and a session board — plus the message
catalog they draw strings from and the number formatting they share.

Nothing here changes what is counted. It is the surface the CLI, the MCP server
and the Stop hook will all print, written once so they cannot drift into three
dialects of the same report.

Detail in [the PR document](docs/pull-requests/2026-08-12-feat-buzzword-bingo-reports.md).

## What's here

- **`messages.cljc` + `en-US.edn`** — the localization rule (dewey 050) is
  hard-halt, and the shared `messages` component reads catalogs from the
  classpath, which a bundled Node script does not have. Same `{placeholder}`
  convention and `t` signature as the shared component, loaded by the same
  compile-time inlining as the lexicon. A missing key renders as its own name:
  a missing string should degrade a report, not fail it.
- **`format.cljc`** — `clojure.core/format` does not exist in ClojureScript,
  and `str` on a double disagrees across hosts (`25.0` → `"25.0"` on the JVM,
  `"25"` in JavaScript). Either would show up as a diff between the Babashka
  CLI and the Node build reporting the same scan.
- **`report.cljc`** — verdict first, evidence after. Thresholds and catalog
  version included, so the verdict can be argued with rather than just
  received.
- **`board.cljc`** — the card as a grid, marks bracketed rather than coloured
  so it survives a pipe and a colourless terminal.

## A bug this found

Writing the board surfaced one in the session summary: progress counted every
term the session had seen against a 24-square total. Most of the catalog is not
on any one card, so a session that had seen nine tells reported "9 of 24
squares marked" when three squares were actually marked. It now counts the
marks that landed on this card, with a test that pads `:session/marked` with
ids deliberately absent from the board.

## Verification

- `poly check` clean, `clj-kondo` clean, `stratum-lint` clean
- 22 tests / 79 assertions for the component; 12 tests / 39 assertions new here
- Number rendering pinned on the exact cases that differ between hosts
- Bracketed cells counted rather than matched by term, because a long term is
  truncated to fit its cell and the full text is not there to look for
- Each commit under the 200-line commit budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)